### PR TITLE
Metric tagging 

### DIFF
--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -1214,6 +1214,7 @@ export async function putMetric(
     return;
   }
 
+  const existing: MetricInterface = metric.toJSON();
   const fields: (keyof MetricInterface)[] = [
     "name",
     "description",
@@ -1240,6 +1241,12 @@ export async function putMetric(
   });
 
   await metric.save();
+
+  await addTagsDiff(
+    req.organization.id,
+    existing.tags || [],
+    req.body.tags || []
+  );
 
   res.status(200).json({
     status: 200,

--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -1137,6 +1137,7 @@ export async function postMetrics(
     earlyStart,
     cap,
     sql,
+    tags,
     conditions,
     datasource,
     timestampColumn,
@@ -1182,6 +1183,7 @@ export async function postMetrics(
     anonymousIdColumn,
     timestampColumn,
     conditions,
+    tags,
   });
 
   res.status(200).json({
@@ -1221,6 +1223,7 @@ export async function putMetric(
     "ignoreNulls",
     "cap",
     "sql",
+    "tags",
     "conditions",
     "dateUpdated",
     "table",

--- a/packages/back-end/src/models/MetricModel.ts
+++ b/packages/back-end/src/models/MetricModel.ts
@@ -25,6 +25,7 @@ const metricSchema = new mongoose.Schema({
   userIdType: String,
   sql: String,
   timestampColumn: String,
+  tags: [String],
   conditions: [
     {
       _id: false,

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -110,12 +110,18 @@ export function getMetricById(id: string) {
 }
 
 export async function createMetric(data: Partial<MetricInterface>) {
-  return MetricModel.create({
+  const metric = MetricModel.create({
     ...data,
     id: uniqid("met_"),
     dateCreated: new Date(),
     dateUpdated: new Date(),
   });
+
+  if (data.tags) {
+    await addTags(data.organization, data.tags);
+  }
+
+  return metric;
 }
 
 function generateTrackingKey(name: string, n: number): string {

--- a/packages/back-end/src/services/tag.ts
+++ b/packages/back-end/src/services/tag.ts
@@ -33,7 +33,6 @@ export async function addTagsDiff(
   oldTags: string[],
   newTags: string[]
 ) {
-  if (!oldTags.length) return;
   const diff = newTags.filter((x) => !oldTags.includes(x));
   if (diff.length) {
     console.log(diff);

--- a/packages/back-end/types/metric.d.ts
+++ b/packages/back-end/types/metric.d.ts
@@ -35,6 +35,7 @@ export interface MetricInterface {
   inverse: boolean;
   ignoreNulls: boolean;
   cap?: number;
+  tags?: string[];
   dateCreated: Date;
   dateUpdated: Date;
   userIdType?: "anonymous" | "user" | "either";

--- a/packages/front-end/components/Experiment/MetricsSelector.tsx
+++ b/packages/front-end/components/Experiment/MetricsSelector.tsx
@@ -1,6 +1,8 @@
-import { FC } from "react";
+import { FC, Fragment } from "react";
 import { Typeahead } from "react-bootstrap-typeahead";
 import { useDefinitions } from "../../services/DefinitionsContext";
+import { FaQuestionCircle } from "react-icons/fa";
+import Tooltip from "../Tooltip";
 
 const MetricsSelector: FC<{
   datasource?: string;
@@ -20,23 +22,124 @@ const MetricsSelector: FC<{
     };
   };
 
+  const metricTags = new Map();
+  validMetrics.forEach((m) => {
+    if (m.tags) {
+      m.tags.forEach((t) => {
+        if (metricTags.has(t)) {
+          metricTags.set(t, [...metricTags.get(t), m]);
+        } else {
+          metricTags.set(t, [m.id]);
+        }
+      });
+    }
+  });
+
+  // keep track of any tags which have been used.
+  const usedTags = [];
+  metricTags.forEach((mArr, tagName) => {
+    let used = true;
+    mArr.forEach((m) => {
+      if (!selected.includes(m)) {
+        used = false;
+      }
+    });
+    if (used) {
+      usedTags.push(tagName);
+    }
+  });
+
+  const selectMetricFromTag = [];
+  if (metricTags.size < 6) {
+    // use buttons:
+    metricTags.forEach((mArr, tagName) => {
+      selectMetricFromTag.push(
+        <a
+          className={`badge badge-secondary mx-2 cursor-pointer ${
+            usedTags.includes(tagName) ? "badge-used" : ""
+          }`}
+          onClick={(e) => {
+            e.preventDefault();
+            const tmp = [...selected];
+            mArr.forEach((m) => {
+              if (!tmp.includes(m)) {
+                tmp.push(m);
+              }
+            });
+            onChange(tmp);
+          }}
+        >
+          {tagName} <span className="badge badge-light">{mArr.length}</span>
+        </a>
+      );
+    });
+  } else {
+    // use select html:
+    const options = [];
+    options.push(<option value="...">...</option>);
+    metricTags.forEach((mArr, tagName) => {
+      options.push(
+        <option value={tagName}>
+          {tagName} ({mArr.length})
+        </option>
+      );
+    });
+    selectMetricFromTag.push(
+      <select
+        placeholder="..."
+        value="..."
+        className="form-control ml-3"
+        onChange={(e) => {
+          const tmp = [...selected];
+          if (metricTags.has(e.target.value)) {
+            metricTags.get(e.target.value).forEach((m) => {
+              if (!tmp.includes(m)) {
+                tmp.push(m);
+              }
+            });
+          }
+          onChange(tmp);
+        }}
+      >
+        {options.map((o, i) => {
+          return <Fragment key={i}>{o}</Fragment>;
+        })}
+      </select>
+    );
+  }
+
   return (
-    <Typeahead
-      id="experiment-metrics"
-      labelKey="name"
-      multiple={true}
-      options={validMetrics.map((m) => {
-        return {
-          id: m.id,
-          name: m.name,
-        };
-      })}
-      onChange={(selected: { id: string; name: string }[]) => {
-        onChange(selected.map((s) => s.id));
-      }}
-      selected={selected.map(toMetricValue)}
-      placeholder="Select metrics..."
-    />
+    <>
+      <Typeahead
+        id="experiment-metrics"
+        labelKey="name"
+        multiple={true}
+        options={validMetrics.map((m) => {
+          return {
+            id: m.id,
+            name: m.name,
+          };
+        })}
+        onChange={(selected: { id: string; name: string }[]) => {
+          onChange(selected.map((s) => s.id));
+        }}
+        selected={selected.map(toMetricValue)}
+        placeholder="Select metrics..."
+      />
+      {metricTags.size > 0 && (
+        <div className="metric-from-tag text-muted form-inline mt-2">
+          <span style={{ fontSize: "0.82rem" }}>
+            Select metric by tag:{" "}
+            <Tooltip text="Metrics can be tagged for grouping. Select any tag to add those metrics">
+              <FaQuestionCircle />
+            </Tooltip>
+          </span>
+          {selectMetricFromTag.map((s, i) => {
+            return <Fragment key={i}>{s}</Fragment>;
+          })}
+        </div>
+      )}
+    </>
   );
 };
 

--- a/packages/front-end/components/Metrics/MetricForm.tsx
+++ b/packages/front-end/components/Metrics/MetricForm.tsx
@@ -78,7 +78,7 @@ const MetricForm: FC<MetricFormProps> = ({
   source,
   initialStep = 0,
 }) => {
-  const { datasources, getDatasourceById } = useDefinitions();
+  const { datasources, getDatasourceById, refreshTags } = useDefinitions();
   const [step, setStep] = useState(initialStep);
   const [sqlInput, setSqlInput] = useState(
     current?.sql || !current?.table ? true : false
@@ -286,7 +286,10 @@ const MetricForm: FC<MetricFormProps> = ({
           Tags
           <TagsInput
             value={value.tags}
-            onChange={(tags) => manualUpdate({ tags })}
+            onChange={(tags) => {
+              refreshTags(tags);
+              manualUpdate({ tags });
+            }}
           />
         </div>
         <div className="form-group">

--- a/packages/front-end/components/Metrics/MetricForm.tsx
+++ b/packages/front-end/components/Metrics/MetricForm.tsx
@@ -10,6 +10,7 @@ import track from "../../services/track";
 import { useDefinitions } from "../../services/DefinitionsContext";
 import { useEffect } from "react";
 import Code from "../Code";
+import TagsInput from "../TagsInput";
 
 const weekAgo = new Date();
 weekAgo.setDate(weekAgo.getDate() - 7);
@@ -135,6 +136,7 @@ const MetricForm: FC<MetricFormProps> = ({
       anonymousIdColumn: current.anonymousIdColumn || "",
       userIdType: current.userIdType || "either",
       timestampColumn: current.timestampColumn || "",
+      tags: current.tags || [],
     },
     current.id || "new"
   );
@@ -278,6 +280,13 @@ const MetricForm: FC<MetricFormProps> = ({
             required
             className="form-control"
             {...inputs.name}
+          />
+        </div>
+        <div className="form-group">
+          Tags
+          <TagsInput
+            value={value.tags}
+            onChange={(tags) => manualUpdate({ tags })}
           />
         </div>
         <div className="form-group">

--- a/packages/front-end/pages/metric/[mid].tsx
+++ b/packages/front-end/pages/metric/[mid].tsx
@@ -297,11 +297,6 @@ const MetricPage: FC = () => {
                 open={() => setEditModalOpen(0)}
                 canOpen={canEdit}
               >
-                {metric.tags?.length && (
-                  <RightRailSectionGroup type="badge">
-                    {metric.tags}
-                  </RightRailSectionGroup>
-                )}
                 <RightRailSectionGroup title="Type" type="badge">
                   {metric.type}
                 </RightRailSectionGroup>
@@ -394,6 +389,18 @@ const MetricPage: FC = () => {
                     metric.earlyStart ? "start of session" : null,
                   ]}
                 </RightRailSectionGroup>
+              </RightRailSection>
+              <hr />
+              <RightRailSection
+                title="Tags"
+                open={() => setEditModalOpen(0)}
+                canOpen={canEdit}
+              >
+                {metric.tags?.length > 0 && (
+                  <RightRailSectionGroup type="badge">
+                    {metric.tags}
+                  </RightRailSectionGroup>
+                )}
               </RightRailSection>
             </div>
           </div>

--- a/packages/front-end/pages/metric/[mid].tsx
+++ b/packages/front-end/pages/metric/[mid].tsx
@@ -297,6 +297,11 @@ const MetricPage: FC = () => {
                 open={() => setEditModalOpen(0)}
                 canOpen={canEdit}
               >
+                {metric.tags?.length && (
+                  <RightRailSectionGroup type="badge">
+                    {metric.tags}
+                  </RightRailSectionGroup>
+                )}
                 <RightRailSectionGroup title="Type" type="badge">
                   {metric.type}
                 </RightRailSectionGroup>

--- a/packages/front-end/pages/metrics.tsx
+++ b/packages/front-end/pages/metrics.tsx
@@ -121,6 +121,7 @@ const MetricsPage = (): React.ReactElement => {
           <tr>
             <th>Name</th>
             <th>Type</th>
+            <th>Tags</th>
             <th className="d-none d-lg-table-cell">Data Source</th>
             <th className="d-none d-md-table-cell">Last Updated</th>
           </tr>
@@ -141,6 +142,14 @@ const MetricsPage = (): React.ReactElement => {
                 </Link>
               </td>
               <td>{metric.type}</td>
+
+              <td className="nowrap">
+                {Object.values(metric.tags).map((col) => (
+                  <span className="tag badge badge-secondary mr-2" key={col}>
+                    {col}
+                  </span>
+                ))}
+              </td>
               <td className="d-none d-lg-table-cell">
                 {metric.datasource
                   ? getDatasourceById(metric.datasource)?.name || ""

--- a/packages/front-end/styles/global.scss
+++ b/packages/front-end/styles/global.scss
@@ -86,7 +86,9 @@ pre {
   overflow-x: hidden;
   overflow-y: auto;
 }
-
+.badge-used {
+  opacity: 0.5;
+}
 .tiptrigger {
   display: inline-block;
   position: relative;


### PR DESCRIPTION
Adds the ability to add tags to metrics, and use those tags to quickly add sets/groups of metrics to an experiment. 