### PR TITLE
Switch experiments results to use the new async queriy engine

### DIFF
--- a/packages/back-end/src/app.ts
+++ b/packages/back-end/src/app.ts
@@ -346,6 +346,8 @@ app.get(
   experimentsController.getExperimentsFrequencyMonth
 );
 app.get("/experiment/:id", experimentsController.getExperiment);
+app.get("/snapshot/:id/status", experimentsController.getSnapshotStatus);
+app.post("/snapshot/:id/cancel", experimentsController.cancelSnapshot);
 app.get("/experiment/:id/snapshot/:phase", experimentsController.getSnapshot);
 app.get(
   "/experiment/:id/snapshot/:phase/:dimension",

--- a/packages/back-end/src/controllers/admin.ts
+++ b/packages/back-end/src/controllers/admin.ts
@@ -361,7 +361,7 @@ export async function addSampleData(req: AuthRequest, res: Response) {
       }
 
       // Refresh results
-      await createSnapshot(exp, 0, datasource);
+      await createSnapshot(exp, 0, datasource, null, false);
     })
   );
 

--- a/packages/back-end/src/controllers/admin.ts
+++ b/packages/back-end/src/controllers/admin.ts
@@ -361,7 +361,7 @@ export async function addSampleData(req: AuthRequest, res: Response) {
       }
 
       // Refresh results
-      await createSnapshot(exp, 0, datasource, null, false);
+      await createSnapshot(exp, 0, datasource);
     })
   );
 

--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -15,6 +15,7 @@ import {
   getManualSnapshotData,
   ensureWatching,
   processPastExperiments,
+  processSnapshotData,
 } from "../services/experiments";
 import uniqid from "uniqid";
 import {
@@ -56,6 +57,7 @@ import { addGroupsDiff } from "../services/group";
 import { IdeaModel } from "../models/IdeasModel";
 import { IdeaInterface } from "../../types/idea";
 import { queueWebhook } from "../jobs/webhooks";
+import { ExperimentSnapshotModel } from "../models/ExperimentSnapshotModel";
 
 export async function getExperiments(req: AuthRequest, res: Response) {
   const experiments = await getExperimentsByOrganization(req.organization.id);
@@ -164,7 +166,8 @@ async function _getSnapshot(
   organization: string,
   id: string,
   phase: string,
-  dimension?: string
+  dimension?: string,
+  withResults: boolean = true
 ) {
   const experiment = await getExperimentById(id);
 
@@ -176,7 +179,12 @@ async function _getSnapshot(
     throw new Error("You do not have access to view this experiment");
   }
 
-  return await getLatestSnapshot(experiment.id, parseInt(phase), dimension);
+  return await getLatestSnapshot(
+    experiment.id,
+    parseInt(phase),
+    dimension,
+    withResults
+  );
 }
 
 export async function getSnapshotWithDimension(
@@ -195,18 +203,36 @@ export async function getSnapshotWithDimension(
     dimension
   );
 
+  const latest = await _getSnapshot(
+    req.organization.id,
+    id,
+    phase,
+    dimension,
+    false
+  );
+
   res.status(200).json({
     status: 200,
     snapshot,
+    latest,
   });
 }
 export async function getSnapshot(req: AuthRequest, res: Response) {
   const { id, phase }: { id: string; phase: string } = req.params;
   const snapshot = await _getSnapshot(req.organization.id, id, phase);
 
+  const latest = await _getSnapshot(
+    req.organization.id,
+    id,
+    phase,
+    null,
+    false
+  );
+
   res.status(200).json({
     status: 200,
     snapshot,
+    latest,
   });
 }
 
@@ -1302,6 +1328,34 @@ export async function previewManualSnapshot(
   }
 }
 
+export async function getSnapshotStatus(req: AuthRequest, res: Response) {
+  const { id }: { id: string } = req.params;
+  const snapshot = await ExperimentSnapshotModel.findOne({ id });
+  if (!snapshot) throw new Error("Unknown snapshot id");
+
+  if (snapshot.organization !== req.organization?.id)
+    throw new Error("You don't have access to that snapshot");
+
+  const experiment = await ExperimentModel.findOne({
+    id: snapshot.experiment,
+  });
+  if (!experiment) throw new Error("Invalid experiment id");
+
+  const phase = experiment.phases[snapshot.phase];
+
+  const result = await getStatusEndpoint(
+    snapshot,
+    req.organization.id,
+    "results",
+    (queryData) => processSnapshotData(experiment, phase, queryData)
+  );
+  return res.status(200).json(result);
+}
+export async function cancelSnapshot(req: AuthRequest, res: Response) {
+  const { id }: { id: string } = req.params;
+  const snapshot = await ExperimentSnapshotModel.findOne({ id });
+  res.status(200).json(await cancelRun(snapshot, req.organization.id));
+}
 export async function postSnapshot(
   req: AuthRequest<{
     phase: number;

--- a/packages/back-end/src/integrations/GoogleAnalytics.ts
+++ b/packages/back-end/src/integrations/GoogleAnalytics.ts
@@ -10,6 +10,8 @@ import {
   VariationResult,
   MetricValueResultDate,
   PastExperimentResult,
+  ExperimentUsersResult,
+  ExperimentMetricResult,
 } from "../types/Integration";
 import { GoogleAnalyticsParams } from "../../types/integrations/googleanalytics";
 import { decryptDataSourceParams } from "../services/datasource";
@@ -42,6 +44,18 @@ const GoogleAnalytics: SourceIntegrationConstructor = class
     this.params = decryptDataSourceParams<GoogleAnalyticsParams>(
       encryptedParams
     );
+  }
+  getExperimentUsersQuery(): string {
+    throw new Error("Method not implemented.");
+  }
+  getExperimentMetricQuery(): string {
+    throw new Error("Method not implemented.");
+  }
+  runExperimentUsersQuery(): Promise<ExperimentUsersResult> {
+    throw new Error("Method not implemented.");
+  }
+  runExperimentMetricQuery(): Promise<ExperimentMetricResult> {
+    throw new Error("Method not implemented.");
   }
   getPastExperimentQuery(): string {
     throw new Error("Method not implemented.");
@@ -206,6 +220,7 @@ const GoogleAnalytics: SourceIntegrationConstructor = class
       type: "api",
       queryLanguage: "json",
       metricCaps: false,
+      separateExperimentResultQueries: false,
     };
   }
 

--- a/packages/back-end/src/integrations/GoogleAnalytics.ts
+++ b/packages/back-end/src/integrations/GoogleAnalytics.ts
@@ -253,11 +253,11 @@ const GoogleAnalytics: SourceIntegrationConstructor = class
     throw new Error("Not implemented for GA");
   }
 
-  async getExperimentResults(
+  getExperimentResultsQuery(
     experiment: ExperimentInterface,
     phase: ExperimentPhase,
     metrics: MetricInterface[]
-  ): Promise<ExperimentResults> {
+  ): string {
     const metricExpressions = metrics.map((m) => ({
       expression: m.table,
     }));
@@ -283,10 +283,20 @@ const GoogleAnalytics: SourceIntegrationConstructor = class
       ],
     };
 
+    return JSON.stringify(query, null, 2);
+  }
+
+  async getExperimentResults(
+    experiment: ExperimentInterface,
+    phase: ExperimentPhase,
+    metrics: MetricInterface[]
+  ): Promise<ExperimentResults> {
+    const query = this.getExperimentResultsQuery(experiment, phase, metrics);
+
     const result = await google.analyticsreporting("v4").reports.batchGet({
       auth: this.getAuth(),
       requestBody: {
-        reportRequests: [query],
+        reportRequests: [JSON.parse(query)],
       },
     });
 
@@ -326,15 +336,12 @@ const GoogleAnalytics: SourceIntegrationConstructor = class
       });
     });
 
-    return {
-      results: [
-        {
-          dimension: "All",
-          variations: rows,
-        },
-      ],
-      query: JSON.stringify(query, null, 2),
-    };
+    return [
+      {
+        dimension: "All",
+        variations: rows,
+      },
+    ];
   }
 };
 export default GoogleAnalytics;

--- a/packages/back-end/src/integrations/Mixpanel.ts
+++ b/packages/back-end/src/integrations/Mixpanel.ts
@@ -11,7 +11,9 @@ import { decryptDataSourceParams } from "../services/datasource";
 import { formatQuery, runQuery } from "../services/mixpanel";
 import {
   DimensionResult,
+  ExperimentMetricResult,
   ExperimentResults,
+  ExperimentUsersResult,
   ImpactEstimationResult,
   MetricValueParams,
   MetricValueResult,
@@ -58,6 +60,18 @@ export default class Mixpanel implements SourceIntegrationInterface {
         ...settings.events,
       },
     };
+  }
+  getExperimentUsersQuery(): string {
+    throw new Error("Method not implemented.");
+  }
+  getExperimentMetricQuery(): string {
+    throw new Error("Method not implemented.");
+  }
+  runExperimentUsersQuery(): Promise<ExperimentUsersResult> {
+    throw new Error("Method not implemented.");
+  }
+  runExperimentMetricQuery(): Promise<ExperimentMetricResult> {
+    throw new Error("Method not implemented.");
   }
   async getExperimentResults(
     experiment: ExperimentInterface,
@@ -309,6 +323,7 @@ export default class Mixpanel implements SourceIntegrationInterface {
       type: "api",
       queryLanguage: "javascript",
       metricCaps: true,
+      separateExperimentResultQueries: false,
     };
   }
 

--- a/packages/back-end/src/integrations/Mixpanel.ts
+++ b/packages/back-end/src/integrations/Mixpanel.ts
@@ -73,6 +73,195 @@ export default class Mixpanel implements SourceIntegrationInterface {
   runExperimentMetricQuery(): Promise<ExperimentMetricResult> {
     throw new Error("Method not implemented.");
   }
+  getExperimentResultsQuery(
+    experiment: ExperimentInterface,
+    phase: ExperimentPhase,
+    metrics: MetricInterface[],
+    activationMetric: MetricInterface,
+    dimension: DimensionInterface
+  ): string {
+    const hasEarlyStartMetrics = metrics.filter((m) => m.earlyStart).length > 0;
+
+    const onActivate = `
+        ${activationMetric ? "state.activated = true;" : ""}
+        state.start = e.time;
+        ${
+          hasEarlyStartMetrics
+            ? ` // Process queued values
+        state.queuedEvents.forEach((q) => {
+          // Make sure event happened during the same session (within 30 minutes)
+          if(state.start - q.time > ${30 * 60 * 1000}) return;
+          ${metrics
+            .filter((m) => m.earlyStart)
+            .map(
+              (metric, i) => `// Metric - ${metric.name}
+          if(${this.getValidMetricCondition(metric, "q")}) {
+            ${this.getMetricAggregationCode(
+              metric,
+              this.getMetricValueCode(metric, "q"),
+              `state.m${i}`
+            )}
+          }`
+            )
+            .join("\n")}
+        });
+        state.queuedEvents = [];`
+            : ""
+        }`;
+
+    const query = formatQuery(`// Experiment results - ${experiment.name}
+        const metrics = ${JSON.stringify(
+          metrics.map(({ id, name }) => ({ id, name })),
+          null,
+          2
+        )};
+  
+        return ${this.getEvents(
+          phase.dateStarted,
+          phase.dateEnded || new Date()
+        )}
+        .filter(function(e) {
+          if(${this.getValidExperimentCondition(
+            experiment.trackingKey
+          )}) return true;
+          ${
+            activationMetric
+              ? `if(${this.getValidMetricCondition(
+                  activationMetric
+                )}) return true;`
+              : ""
+          }
+          ${metrics
+            .map(
+              (metric) => `// Metric - ${metric.name}
+          if(${this.getValidMetricCondition(metric)}) return true;`
+            )
+            .join("\n")}
+          return false;
+        })
+        // Metric value per user
+        .groupByUser(function(state, events) {
+          state = state || {
+            inExperiment: false,
+            ${dimension ? "dimension: null," : ""}
+            ${activationMetric ? "activated: false," : ""}
+            start: null,
+            variation: null,
+            ${metrics.map((m, i) => `m${i}: null,`).join("\n")} ${
+      hasEarlyStartMetrics ? "queuedEvents: []" : ""
+    }
+          };
+          for(var i=0; i<events.length; i++) {
+            const e = events[i];
+            // User is put into the experiment
+            if(!state.inExperiment && ${this.getValidExperimentCondition(
+              experiment.trackingKey
+            )}) {
+              state.inExperiment = true;
+              state.variation = ${this.getPropertyColumn(
+                this.settings.events.variationIdProperty || "Variant name",
+                "e"
+              )};
+              ${
+                dimension
+                  ? `state.dimension = ${this.getPropertyColumn(
+                      dimension.sql,
+                      "e"
+                    )} || null;`
+                  : ""
+              }
+              ${activationMetric ? "" : onActivate}
+              continue;
+            }
+  
+            // Not in the experiment yet
+            if(!state.inExperiment) {
+              ${hasEarlyStartMetrics ? "state.queuedEvents.push(e);" : ""}
+              continue;
+            }
+            ${
+              activationMetric
+                ? `
+              // Not activated yet
+              if(!state.activated) {
+                // Does this event activate it? (Metric - ${
+                  activationMetric.name
+                })
+                if(${this.getValidMetricCondition(activationMetric)}) {
+                  ${onActivate}
+                }
+                else {
+                  ${hasEarlyStartMetrics ? "state.queuedEvents.push(e);" : ""}
+                  continue;
+                }
+              }
+            `
+                : ""
+            }
+  
+            ${this.getConversionWindowCheck(
+              experiment.conversionWindowDays || 3,
+              "state.start"
+            )}
+            ${metrics
+              .map(
+                (metric, i) => `// Metric - ${metric.name}
+              if(${this.getValidMetricCondition(metric)}) {
+                ${this.getMetricAggregationCode(
+                  metric,
+                  this.getMetricValueCode(metric),
+                  `state.m${i}`
+                )}
+              }
+            `
+              )
+              .join("")}
+          }
+          return state;
+        })
+        // Remove users that are not in the experiment
+        .filter(function(ev) {
+          if(!ev.value.inExperiment) return false;
+          if(ev.value.variation === null || ev.value.variation === undefined) return false;
+          ${activationMetric ? "if(!ev.value.activated) return false;" : ""}
+          return true;
+        })
+        // One group per experiment variation${
+          dimension ? "/dimension" : ""
+        } with summary data
+        .groupBy(["value.variation"${dimension ? ', "value.dimension"' : ""}], [
+          // Total users in the group
+          mixpanel.reducer.count(),
+          ${metrics
+            .map(
+              (metric, i) => `// Metric - ${metric.name}
+          mixpanel.reducer.numeric_summary('value.m${i}'),`
+            )
+            .join("\n")}
+        ])
+        // Convert to an object that's easier to work with
+        .map(row => {
+          const ret = {
+            variation: row.key[0],
+            dimension: ${dimension ? "row.key[1] || ''" : "''"},
+            users: row.value[0],
+            metrics: [],
+          };
+          for(let i=1; i<row.value.length; i++) {
+            ret.metrics.push({
+              id: metrics[i-1].id,
+              name: metrics[i-1].name,
+              count: row.value[i].count,
+              mean: row.value[i].avg,
+              stddev: row.value[i].stddev,
+            });
+          }
+          return ret;
+        });
+      `);
+
+    return query;
+  }
   async getExperimentResults(
     experiment: ExperimentInterface,
     phase: ExperimentPhase,
@@ -80,182 +269,14 @@ export default class Mixpanel implements SourceIntegrationInterface {
     activationMetric: MetricInterface,
     dimension: DimensionInterface
   ): Promise<ExperimentResults> {
-    const hasEarlyStartMetrics = metrics.filter((m) => m.earlyStart).length > 0;
+    const query = this.getExperimentResultsQuery(
+      experiment,
+      phase,
+      metrics,
+      activationMetric,
+      dimension
+    );
 
-    const onActivate = `
-      ${activationMetric ? "state.activated = true;" : ""}
-      state.start = e.time;
-      ${
-        hasEarlyStartMetrics
-          ? ` // Process queued values
-      state.queuedEvents.forEach((q) => {
-        // Make sure event happened during the same session (within 30 minutes)
-        if(state.start - q.time > ${30 * 60 * 1000}) return;
-        ${metrics
-          .filter((m) => m.earlyStart)
-          .map(
-            (metric, i) => `// Metric - ${metric.name}
-        if(${this.getValidMetricCondition(metric, "q")}) {
-          ${this.getMetricAggregationCode(
-            metric,
-            this.getMetricValueCode(metric, "q"),
-            `state.m${i}`
-          )}
-        }`
-          )
-          .join("\n")}
-      });
-      state.queuedEvents = [];`
-          : ""
-      }`;
-
-    const query = formatQuery(`// Experiment results - ${experiment.name}
-      const metrics = ${JSON.stringify(
-        metrics.map(({ id, name }) => ({ id, name })),
-        null,
-        2
-      )};
-
-      return ${this.getEvents(phase.dateStarted, phase.dateEnded || new Date())}
-      .filter(function(e) {
-        if(${this.getValidExperimentCondition(
-          experiment.trackingKey
-        )}) return true;
-        ${
-          activationMetric
-            ? `if(${this.getValidMetricCondition(
-                activationMetric
-              )}) return true;`
-            : ""
-        }
-        ${metrics
-          .map(
-            (metric) => `// Metric - ${metric.name}
-        if(${this.getValidMetricCondition(metric)}) return true;`
-          )
-          .join("\n")}
-        return false;
-      })
-      // Metric value per user
-      .groupByUser(function(state, events) {
-        state = state || {
-          inExperiment: false,
-          ${dimension ? "dimension: null," : ""}
-          ${activationMetric ? "activated: false," : ""}
-          start: null,
-          variation: null,
-          ${metrics.map((m, i) => `m${i}: null,`).join("\n")} ${
-      hasEarlyStartMetrics ? "queuedEvents: []" : ""
-    }
-        };
-        for(var i=0; i<events.length; i++) {
-          const e = events[i];
-          // User is put into the experiment
-          if(!state.inExperiment && ${this.getValidExperimentCondition(
-            experiment.trackingKey
-          )}) {
-            state.inExperiment = true;
-            state.variation = ${this.getPropertyColumn(
-              this.settings.events.variationIdProperty || "Variant name",
-              "e"
-            )};
-            ${
-              dimension
-                ? `state.dimension = ${this.getPropertyColumn(
-                    dimension.sql,
-                    "e"
-                  )} || null;`
-                : ""
-            }
-            ${activationMetric ? "" : onActivate}
-            continue;
-          }
-
-          // Not in the experiment yet
-          if(!state.inExperiment) {
-            ${hasEarlyStartMetrics ? "state.queuedEvents.push(e);" : ""}
-            continue;
-          }
-          ${
-            activationMetric
-              ? `
-            // Not activated yet
-            if(!state.activated) {
-              // Does this event activate it? (Metric - ${
-                activationMetric.name
-              })
-              if(${this.getValidMetricCondition(activationMetric)}) {
-                ${onActivate}
-              }
-              else {
-                ${hasEarlyStartMetrics ? "state.queuedEvents.push(e);" : ""}
-                continue;
-              }
-            }
-          `
-              : ""
-          }
-
-          ${this.getConversionWindowCheck(
-            experiment.conversionWindowDays || 3,
-            "state.start"
-          )}
-          ${metrics
-            .map(
-              (metric, i) => `// Metric - ${metric.name}
-            if(${this.getValidMetricCondition(metric)}) {
-              ${this.getMetricAggregationCode(
-                metric,
-                this.getMetricValueCode(metric),
-                `state.m${i}`
-              )}
-            }
-          `
-            )
-            .join("")}
-        }
-        return state;
-      })
-      // Remove users that are not in the experiment
-      .filter(function(ev) {
-        if(!ev.value.inExperiment) return false;
-        if(ev.value.variation === null || ev.value.variation === undefined) return false;
-        ${activationMetric ? "if(!ev.value.activated) return false;" : ""}
-        return true;
-      })
-      // One group per experiment variation${
-        dimension ? "/dimension" : ""
-      } with summary data
-      .groupBy(["value.variation"${dimension ? ', "value.dimension"' : ""}], [
-        // Total users in the group
-        mixpanel.reducer.count(),
-        ${metrics
-          .map(
-            (metric, i) => `// Metric - ${metric.name}
-        mixpanel.reducer.numeric_summary('value.m${i}'),`
-          )
-          .join("\n")}
-      ])
-      // Convert to an object that's easier to work with
-      .map(row => {
-        const ret = {
-          variation: row.key[0],
-          dimension: ${dimension ? "row.key[1] || ''" : "''"},
-          users: row.value[0],
-          metrics: [],
-        };
-        for(let i=1; i<row.value.length; i++) {
-          ret.metrics.push({
-            id: metrics[i-1].id,
-            name: metrics[i-1].name,
-            count: row.value[i].count,
-            mean: row.value[i].avg,
-            stddev: row.value[i].stddev,
-          });
-        }
-        return ret;
-      });
-    `);
     const result = await runQuery<
       {
         variation: string;
@@ -299,10 +320,7 @@ export default class Mixpanel implements SourceIntegrationInterface {
       });
     });
 
-    return {
-      query,
-      results: Object.values(dimensions),
-    };
+    return Object.values(dimensions);
   }
   async testConnection(): Promise<boolean> {
     const today = new Date().toISOString().substr(0, 10);

--- a/packages/back-end/src/jobs/updateExperimentResults.ts
+++ b/packages/back-end/src/jobs/updateExperimentResults.ts
@@ -113,7 +113,9 @@ async function updateSingleExperiment(job: UpdateSingleExpJob) {
     currentSnapshot = await createSnapshot(
       experiment,
       experiment.phases.length - 1,
-      datasource
+      datasource,
+      null,
+      false
     );
     logger.info("Success");
 

--- a/packages/back-end/src/jobs/updateExperimentResults.ts
+++ b/packages/back-end/src/jobs/updateExperimentResults.ts
@@ -7,11 +7,13 @@ import {
   getExperimentWatchers,
   getLatestSnapshot,
   getMetricById,
+  processSnapshotData,
 } from "../services/experiments";
 import { getConfidenceLevelsForOrg } from "../services/organizations";
 import pino from "pino";
 import { ExperimentSnapshotDocument } from "../models/ExperimentSnapshotModel";
 import { ExperimentInterface } from "../../types/experiment";
+import { getStatusEndpoint } from "../services/queries";
 
 // Time between experiment result updates (6 hours)
 const UPDATE_EVERY = 6 * 60 * 60 * 1000;
@@ -113,10 +115,37 @@ async function updateSingleExperiment(job: UpdateSingleExpJob) {
     currentSnapshot = await createSnapshot(
       experiment,
       experiment.phases.length - 1,
-      datasource,
-      null,
-      false
+      datasource
     );
+
+    await new Promise<void>((resolve, reject) => {
+      const check = async () => {
+        const res = await getStatusEndpoint(
+          currentSnapshot,
+          currentSnapshot.organization,
+          "results",
+          (queryData) =>
+            processSnapshotData(
+              experiment,
+              experiment.phases[experiment.phases.length - 1],
+              queryData
+            )
+        );
+        if (res.queryStatus === "succeeded") {
+          resolve();
+          return;
+        }
+        if (res.queryStatus === "failed") {
+          reject("Queries failed to run");
+          return;
+        }
+        // Check every 10 seconds
+        setTimeout(check, 10000);
+      };
+      // Do the first check after a 2 second delay to quickly handle fast queries
+      setTimeout(check, 2000);
+    });
+
     logger.info("Success");
 
     await sendSignificanceEmail(experiment, lastSnapshot, currentSnapshot);

--- a/packages/back-end/src/models/ExperimentSnapshotModel.ts
+++ b/packages/back-end/src/models/ExperimentSnapshotModel.ts
@@ -1,5 +1,6 @@
 import mongoose from "mongoose";
 import { ExperimentSnapshotInterface } from "../../types/experiment-snapshot";
+import { queriesSchema } from "./QueryModel";
 
 const experimentSnapshotSchema = new mongoose.Schema({
   id: String,
@@ -10,6 +11,7 @@ const experimentSnapshotSchema = new mongoose.Schema({
   manual: Boolean,
   query: String,
   queryLanguage: String,
+  queries: queriesSchema,
   dimension: String,
   results: [
     {

--- a/packages/back-end/src/models/ExperimentSnapshotModel.ts
+++ b/packages/back-end/src/models/ExperimentSnapshotModel.ts
@@ -4,10 +4,12 @@ import { queriesSchema } from "./QueryModel";
 
 const experimentSnapshotSchema = new mongoose.Schema({
   id: String,
+  organization: String,
   experiment: String,
   phase: Number,
   type: { type: String },
   dateCreated: Date,
+  runStarted: Date,
   manual: Boolean,
   query: String,
   queryLanguage: String,

--- a/packages/back-end/src/models/ExperimentSnapshotModel.ts
+++ b/packages/back-end/src/models/ExperimentSnapshotModel.ts
@@ -3,7 +3,10 @@ import { ExperimentSnapshotInterface } from "../../types/experiment-snapshot";
 import { queriesSchema } from "./QueryModel";
 
 const experimentSnapshotSchema = new mongoose.Schema({
-  id: String,
+  id: {
+    type: String,
+    unique: true,
+  },
   organization: String,
   experiment: String,
   phase: Number,
@@ -58,6 +61,10 @@ const experimentSnapshotSchema = new mongoose.Schema({
       ],
     },
   ],
+});
+experimentSnapshotSchema.index({
+  experiment: 1,
+  dateCreated: -1,
 });
 
 export type ExperimentSnapshotDocument = mongoose.Document &

--- a/packages/back-end/src/models/QueryModel.ts
+++ b/packages/back-end/src/models/QueryModel.ts
@@ -11,8 +11,14 @@ export const queriesSchema = [
 ];
 
 const querySchema = new mongoose.Schema({
-  id: String,
-  organization: String,
+  id: {
+    type: String,
+    unique: true,
+  },
+  organization: {
+    type: String,
+    index: true,
+  },
   datasource: String,
   language: String,
   query: String,

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -9,14 +9,30 @@ import { srm, ABTestStats, abtest, getValueCR } from "./stats";
 import { getSourceIntegrationObject } from "./datasource";
 import { addTags } from "./tag";
 import { WatchModel } from "../models/WatchModel";
-import { QueryMap } from "./queries";
-import { PastExperimentResult } from "../types/Integration";
-import { ExperimentSnapshotModel } from "../models/ExperimentSnapshotModel";
+import {
+  getExperimentMetric,
+  getExperimentResults,
+  getExperimentUsers,
+  QueryMap,
+  startRun,
+} from "./queries";
+import {
+  DimensionResult,
+  ExperimentMetricResult,
+  ExperimentUsersResult,
+  PastExperimentResult,
+} from "../types/Integration";
+import {
+  ExperimentSnapshotDocument,
+  ExperimentSnapshotModel,
+} from "../models/ExperimentSnapshotModel";
 import { MetricInterface, MetricStats } from "../../types/metric";
-import { ExperimentInterface } from "../../types/experiment";
+import { ExperimentInterface, ExperimentPhase } from "../../types/experiment";
 import { DimensionInterface } from "../../types/dimension";
 import { DataSourceInterface } from "../../types/datasource";
 import { PastExperiment } from "../../types/past-experiments";
+import { QueryDocument } from "../models/QueryModel";
+import { FilterQuery } from "mongoose";
 
 export function getExperimentsByOrganization(organization: string) {
   return ExperimentModel.find({
@@ -66,9 +82,18 @@ type OldSnapshotModel = ExperimentSnapshotInterface & {
 export async function getLatestSnapshot(
   experiment: string,
   phase: number,
-  dimension?: string
+  dimension?: string,
+  withResults: boolean = true
 ) {
-  const query = { experiment, phase, dimension: dimension || null };
+  const query: FilterQuery<ExperimentSnapshotDocument> = {
+    experiment,
+    phase,
+    dimension: dimension || null,
+  };
+
+  if (withResults) {
+    query.results = { $exists: true, $type: "array", $ne: [] };
+  }
 
   const all = await ExperimentSnapshotModel.find(query, null, {
     sort: { dateCreated: -1 },
@@ -285,8 +310,11 @@ export async function createManualSnapshot(
 
   const data: ExperimentSnapshotInterface = {
     id: uniqid("snp_"),
+    organization: experiment.organization,
     experiment: experiment.id,
     phase: phaseIndex,
+    queries: [],
+    runStarted: new Date(),
     dateCreated: new Date(),
     manual: true,
     results: [
@@ -303,55 +331,77 @@ export async function createManualSnapshot(
   return snapshot;
 }
 
-export async function createSnapshot(
+export async function processSnapshotData(
   experiment: ExperimentInterface,
-  phaseIndex: number,
-  datasource: DataSourceInterface,
-  dimension?: DimensionInterface
-) {
+  phase: ExperimentPhase,
+  queryData: QueryMap
+): Promise<
+  {
+    name: string;
+    srm: number;
+    variations: SnapshotVariation[];
+  }[]
+> {
   const metrics = await getMetricsByOrganization(experiment.organization);
-
   const metricMap = new Map<string, MetricInterface>();
   metrics.forEach((m) => {
     metricMap.set(m.id, m);
   });
 
-  const activationMetric = metricMap.get(experiment.activationMetric) || null;
+  // Combine user and metric data into a single data structure
+  const combined: {
+    [key: string]: {
+      users: number[];
+      metrics: {
+        [key: string]: MetricStats[];
+      };
+    };
+  } = {};
 
-  // Only include metrics tied to this experiment (both goal and guardrail metrics)
-  const selectedMetrics = Array.from(
-    new Set(experiment.metrics.concat(experiment.guardrails || []))
-  )
-    .map((m) => metricMap.get(m))
-    .filter((m) => m);
-  if (!selectedMetrics.length) {
-    throw new Error("Experiment must have at least 1 metric selected.");
+  // Everything done in a single query (Mixpanel, Google Analytics)
+  if (queryData.has("results")) {
+    const data = queryData.get("results").result as DimensionResult[];
+    data.forEach((row) => {
+      combined[row.dimension] = {
+        users: [],
+        metrics: {},
+      };
+      const d = combined[row.dimension];
+      row.variations.forEach((v) => {
+        d.users[v.variation] = v.users;
+        v.metrics.forEach(({ metric, ...stats }) => {
+          if (!d.metrics[metric]) d.metrics[metric] = [];
+          d.metrics[metric][v.variation] = stats;
+        });
+      });
+    });
   }
+  // Spread out over multiple queries (SQL sources)
+  else {
+    // User counts
+    const usersResult: ExperimentUsersResult = queryData.get("users")
+      ?.result as ExperimentUsersResult;
+    if (!usersResult) return [];
+    usersResult.dimensions.forEach((d) => {
+      combined[d.dimension] = { users: [], metrics: {} };
+      d.variations.forEach((v) => {
+        combined[d.dimension].users[v.variation] = v.users;
+      });
+    });
 
-  const phase = experiment.phases[phaseIndex];
-
-  // Update lastSnapshotAttempt
-  experiment.lastSnapshotAttempt = new Date();
-  await ExperimentModel.updateOne(
-    {
-      id: experiment.id,
-    },
-    {
-      $set: {
-        lastSnapshotAttempt: experiment.lastSnapshotAttempt,
-      },
-    }
-  );
-
-  // Generate and run the SQL for test results
-  const integration = getSourceIntegrationObject(datasource);
-  const { results: rows, query } = await integration.getExperimentResults(
-    experiment,
-    phase,
-    selectedMetrics,
-    activationMetric,
-    dimension
-  );
+    // Raw metric numbers
+    queryData.forEach((obj, key) => {
+      if (!metricMap.has(key)) return;
+      const data = obj.result as ExperimentMetricResult;
+      data.dimensions.forEach((d) => {
+        if (!combined[d.dimension]) return;
+        combined[d.dimension].metrics[key] = [];
+        d.variations.forEach((v) => {
+          combined[d.dimension].metrics[key][v.variation] = v.stats;
+        });
+      });
+    });
+  }
 
   const results: {
     name: string;
@@ -360,37 +410,20 @@ export async function createSnapshot(
   }[] = [];
 
   await Promise.all(
-    rows.map(async (d) => {
-      // Default variation values, override from SQL results if available
-      const variations: SnapshotVariation[] = experiment.variations.map(() => ({
-        users: 0,
-        metrics: {},
-      }));
+    Object.keys(combined).map(async (dimension) => {
+      const row = combined[dimension];
+      // One doc per variation
+      const variations: SnapshotVariation[] = experiment.variations.map(
+        (v, i) => ({
+          users: row.users[i] || 0,
+          metrics: {},
+        })
+      );
 
-      const metricData = new Map<
-        string,
-        { count: number; mean: number; stddev: number }[]
-      >();
-      d.variations.forEach((row) => {
-        const variation = row.variation;
-        if (!variations[variation]) {
-          return;
-        }
-        variations[variation].users = row.users || 0;
-
-        row.metrics.forEach((m) => {
-          const doc = metricData.get(m.metric) || [];
-          doc[variation] = {
-            count: m.count,
-            mean: m.mean,
-            stddev: m.stddev,
-          };
-          metricData.set(m.metric, doc);
-        });
-      });
-
+      // Calculate metric stats
       const metricPromises: Promise<void[]>[] = [];
-      metricData.forEach((v, k) => {
+      Object.keys(row.metrics).forEach((k) => {
+        const v = row.metrics[k];
         const baselineSuccess = v[0]?.count * v[0]?.mean || 0;
 
         metricPromises.push(
@@ -401,10 +434,8 @@ export async function createSnapshot(
               const metric = metricMap.get(k);
               const value = success;
 
-              // Don't do stats for the baseline or when breaking down by dimension
-              // We aren't doing a correction for multiple tests, so the numbers would be misleading for the break down
-              // Can enable this later when we have a more robust stats engine
-              if (!i || dimension) {
+              // Don't do stats for the baseline
+              if (!i) {
                 variations[i].metrics[k] = {
                   ...getValueCR(metric, value, data.count, variations[i].users),
                   stats: data,
@@ -441,7 +472,6 @@ export async function createSnapshot(
           )
         );
       });
-
       await Promise.all(metricPromises);
 
       // Check to see if the observed number of samples per variation matches what we expect
@@ -452,20 +482,106 @@ export async function createSnapshot(
       );
 
       results.push({
-        name: d.dimension,
+        name: dimension,
         srm: sampleRatioMismatch,
         variations,
       });
     })
   );
+  return results;
+}
+
+export async function createSnapshot(
+  experiment: ExperimentInterface,
+  phaseIndex: number,
+  datasource: DataSourceInterface,
+  dimension?: DimensionInterface,
+  separateQueries: boolean = true
+) {
+  const metrics = await getMetricsByOrganization(experiment.organization);
+  const metricMap = new Map<string, MetricInterface>();
+  metrics.forEach((m) => {
+    metricMap.set(m.id, m);
+  });
+
+  const activationMetric = metricMap.get(experiment.activationMetric) || null;
+
+  // Only include metrics tied to this experiment (both goal and guardrail metrics)
+  const selectedMetrics = Array.from(
+    new Set(experiment.metrics.concat(experiment.guardrails || []))
+  )
+    .map((m) => metricMap.get(m))
+    .filter((m) => m);
+  if (!selectedMetrics.length) {
+    throw new Error("Experiment must have at least 1 metric selected.");
+  }
+
+  const phase = experiment.phases[phaseIndex];
+
+  // Update lastSnapshotAttempt
+  experiment.lastSnapshotAttempt = new Date();
+  await ExperimentModel.updateOne(
+    {
+      id: experiment.id,
+    },
+    {
+      $set: {
+        lastSnapshotAttempt: experiment.lastSnapshotAttempt,
+      },
+    }
+  );
+
+  const integration = getSourceIntegrationObject(datasource);
+
+  const queryDocs: { [key: string]: Promise<QueryDocument> } = {};
+
+  // Run it as a single synchronous task (non-sql datasources and legacy code)
+  if (
+    !separateQueries ||
+    !integration.getSourceProperties().separateExperimentResultQueries
+  ) {
+    queryDocs["results"] = getExperimentResults(
+      integration,
+      experiment,
+      phase,
+      metrics,
+      activationMetric,
+      dimension
+    );
+  }
+  // Run as multiple async queries (new way for sql datasources)
+  else {
+    queryDocs["users"] = getExperimentUsers(integration, {
+      experiment,
+      dimension,
+      activationMetric,
+      phase,
+    });
+    selectedMetrics.forEach((m) => {
+      queryDocs[m.id] = getExperimentMetric(integration, {
+        metric: m,
+        experiment,
+        dimension,
+        activationMetric,
+        phase,
+      });
+    });
+  }
+
+  const { queries, result: results } = await startRun(
+    queryDocs,
+    async (queryData) => processSnapshotData(experiment, phase, queryData)
+  );
 
   const data: ExperimentSnapshotInterface = {
     id: uniqid("snp_"),
+    organization: experiment.organization,
     experiment: experiment.id,
+    runStarted: new Date(),
     dateCreated: new Date(),
     phase: phaseIndex,
     manual: false,
-    query,
+    queries,
     queryLanguage: integration.getSourceProperties().queryLanguage,
     dimension: dimension?.id || null,
     results,

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -488,6 +488,15 @@ export async function processSnapshotData(
       });
     })
   );
+
+  if (!results.length) {
+    results.push({
+      name: "All",
+      srm: 1,
+      variations: [],
+    });
+  }
+
   return results;
 }
 
@@ -495,8 +504,7 @@ export async function createSnapshot(
   experiment: ExperimentInterface,
   phaseIndex: number,
   datasource: DataSourceInterface,
-  dimension?: DimensionInterface,
-  separateQueries: boolean = true
+  dimension?: DimensionInterface
 ) {
   const metrics = await getMetricsByOrganization(experiment.organization);
   const metricMap = new Map<string, MetricInterface>();
@@ -536,15 +544,12 @@ export async function createSnapshot(
   const queryDocs: { [key: string]: Promise<QueryDocument> } = {};
 
   // Run it as a single synchronous task (non-sql datasources and legacy code)
-  if (
-    !separateQueries ||
-    !integration.getSourceProperties().separateExperimentResultQueries
-  ) {
+  if (!integration.getSourceProperties().separateExperimentResultQueries) {
     queryDocs["results"] = getExperimentResults(
       integration,
       experiment,
       phase,
-      metrics,
+      selectedMetrics,
       activationMetric,
       dimension
     );

--- a/packages/back-end/src/services/postgres.ts
+++ b/packages/back-end/src/services/postgres.ts
@@ -1,14 +1,29 @@
 import { Client } from "pg";
 import { PostgresConnectionParams } from "../../types/integrations/postgres";
 
-export async function runPostgresQuery<T>(
+export function runPostgresQuery<T>(
   conn: PostgresConnectionParams,
   sql: string,
   values: string[] = []
 ): Promise<T[]> {
-  const client = new Client(conn);
-  await client.connect();
-  const res = await client.query(sql, values);
-  await client.end();
-  return res.rows;
+  return new Promise<T[]>((resolve, reject) => {
+    const client = new Client(conn);
+    client
+      .on("error", (err) => {
+        reject(err);
+      })
+      .connect()
+      .then(() => client.query(sql, values))
+      .then(async (res) => {
+        try {
+          await client.end();
+        } catch (e) {
+          console.error(e);
+        }
+        resolve(res.rows);
+      })
+      .catch((e) => {
+        reject(e);
+      });
+  });
 }

--- a/packages/back-end/src/types/Integration.ts
+++ b/packages/back-end/src/types/Integration.ts
@@ -21,10 +21,7 @@ export interface DimensionResult {
   variations: VariationResult[];
 }
 
-export interface ExperimentResults {
-  query: string;
-  results: DimensionResult[];
-}
+export type ExperimentResults = DimensionResult[];
 
 export interface ExperimentUsersResult {
   dimensions: {
@@ -138,6 +135,13 @@ export interface SourceIntegrationInterface {
   organization: string;
   // eslint-disable-next-line
   getNonSensitiveParams(): any;
+  getExperimentResultsQuery(
+    experiment: ExperimentInterface,
+    phase: ExperimentPhase,
+    metrics: MetricInterface[],
+    activationMetric: MetricInterface | null,
+    dimension: DimensionInterface | null
+  ): string;
   getExperimentResults(
     experiment: ExperimentInterface,
     phase: ExperimentPhase,

--- a/packages/back-end/src/types/Integration.ts
+++ b/packages/back-end/src/types/Integration.ts
@@ -26,12 +26,47 @@ export interface ExperimentResults {
   results: DimensionResult[];
 }
 
+export interface ExperimentUsersResult {
+  dimensions: {
+    dimension: string;
+    variations: {
+      variation: number;
+      users: number;
+    }[];
+  }[];
+}
+export interface ExperimentMetricResult {
+  dimensions: {
+    dimension: string;
+    variations: {
+      variation: number;
+      stats: MetricStats;
+    }[];
+  }[];
+}
+
 export interface ImpactEstimationResult {
   query: string;
   metricTotal: number;
   users: number;
   value: number;
 }
+
+export type ExperimentUsersQueryParams = {
+  experiment: ExperimentInterface;
+  phase: ExperimentPhase;
+  activationMetric: MetricInterface | null;
+  dimension: DimensionInterface | null;
+};
+
+export type ExperimentMetricQueryParams = {
+  experiment: ExperimentInterface;
+  phase: ExperimentPhase;
+  metric: MetricInterface;
+  activationMetric: MetricInterface | null;
+  dimension: DimensionInterface | null;
+};
+
 export type UsersQueryParams = {
   name: string;
   userIdType: "anonymous" | "user" | "either";
@@ -119,8 +154,18 @@ export interface SourceIntegrationInterface {
   ): Promise<ImpactEstimationResult>;
   getUsersQuery(params: UsersQueryParams): string;
   getMetricValueQuery(params: MetricValueParams): string;
+  getExperimentUsersQuery(params: ExperimentUsersQueryParams): string;
+  getExperimentMetricQuery(params: ExperimentMetricQueryParams): string;
   runUsersQuery(query: string): Promise<UsersResult>;
   runMetricValueQuery(query: string): Promise<MetricValueResult>;
+  runExperimentUsersQuery(
+    experiment: ExperimentInterface,
+    query: string
+  ): Promise<ExperimentUsersResult>;
+  runExperimentMetricQuery(
+    experiment: ExperimentInterface,
+    query: string
+  ): Promise<ExperimentMetricResult>;
   getPastExperimentQuery(from: Date): string;
   runPastExperimentQuery(query: string): Promise<PastExperimentResult>;
 }

--- a/packages/back-end/types/datasource.d.ts
+++ b/packages/back-end/types/datasource.d.ts
@@ -36,6 +36,7 @@ export interface DataSourceProperties {
   includeInConfig: boolean;
   readonlyFields: string[];
   metricCaps: boolean;
+  separateExperimentResultQueries: boolean;
 }
 
 type WithParams<B, P> = Omit<B, "params"> & { params: P };

--- a/packages/back-end/types/experiment-snapshot.d.ts
+++ b/packages/back-end/types/experiment-snapshot.d.ts
@@ -31,13 +31,15 @@ export interface SnapshotVariation {
 
 export interface ExperimentSnapshotInterface {
   id: string;
+  organization: string;
   experiment: string;
   phase: number;
   dateCreated: Date;
+  runStarted: Date;
   manual: boolean;
   query?: string;
   queryLanguage?: QueryLanguage;
-  queries?: Queries;
+  queries: Queries;
   dimension?: string;
   results?: {
     name: string;

--- a/packages/back-end/types/experiment-snapshot.d.ts
+++ b/packages/back-end/types/experiment-snapshot.d.ts
@@ -1,5 +1,6 @@
 import { QueryLanguage } from "./datasource";
 import { MetricStats } from "./metric";
+import { Queries } from "./query";
 
 export interface SnapshotMetric {
   value: number;
@@ -36,8 +37,9 @@ export interface ExperimentSnapshotInterface {
   manual: boolean;
   query?: string;
   queryLanguage?: QueryLanguage;
+  queries?: Queries;
   dimension?: string;
-  results: {
+  results?: {
     name: string;
     srm: number;
     variations: SnapshotVariation[];

--- a/packages/front-end/components/Experiment/GuardrailResult.tsx
+++ b/packages/front-end/components/Experiment/GuardrailResult.tsx
@@ -1,11 +1,8 @@
 import React, { FC } from "react";
 import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
 import { SnapshotVariation } from "back-end/types/experiment-snapshot";
-import { useState } from "react";
 import clsx from "clsx";
 import {
-  FaAngleDown,
-  FaAngleRight,
   FaCheckCircle,
   FaExclamation,
   FaExclamationTriangle,
@@ -58,110 +55,93 @@ const GuardrailResults: FC<{
     status = "success";
   }
 
-  const hasSomeData =
-    status !== "secondary" ||
-    variations.filter((v) => v.metrics[metric.id]?.value > 0).length > 0;
-
-  const [open, setOpen] = useState(
-    status !== "success" && (status !== "secondary" || !hasSomeData)
-  );
-
   return (
     <div className="d-flex flex-column" key={metric.id}>
       <div
         className={clsx(
-          "cursor-pointer d-flex align-items-center guardrail alert m-0",
+          "d-flex align-items-center guardrail alert m-0",
           `alert-${status}`
         )}
-        onClick={() => setOpen(!open)}
       >
         {status === "success" && <FaCheckCircle className="mr-1" />}
         {status === "warning" && <FaExclamationTriangle className="mr-1" />}
         {status === "danger" && <FaExclamation className="mr-1" />}
         {status === "secondary" && <FaQuestionCircle className="mr-1" />}
         <strong>{metric.name}</strong>
-        {open ? (
-          <FaAngleDown className="ml-auto" />
-        ) : (
-          <FaAngleRight className="ml-auto" />
-        )}
       </div>
-      <div
-        style={{
-          maxHeight: open ? 300 : 0,
-          overflow: "hidden",
-          transition: "max-height 0.3s",
-        }}
-      >
-        {hasSomeData ? (
-          <table
-            className={clsx("rounded table table-bordered experiment-compact")}
-          >
-            <thead>
-              <tr>
-                <th>Variation</th>
-                <th>Value</th>
-                <th>Chance of Being Worse</th>
-              </tr>
-            </thead>
-            <tbody>
-              {experiment.variations.map((v, i) => {
-                const stats = variations[i].metrics[metric.id];
-                if (!stats) return;
-
-                const chance = 1 - (stats.chanceToWin || 1);
+      <div>
+        <table
+          className={clsx("rounded table table-bordered experiment-compact")}
+        >
+          <thead>
+            <tr>
+              <th>Variation</th>
+              <th>Value</th>
+              <th>Chance of Being Worse</th>
+            </tr>
+          </thead>
+          <tbody>
+            {experiment.variations.map((v, i) => {
+              const stats = variations[i]?.metrics?.[metric.id];
+              if (!stats) {
                 return (
                   <tr key={i}>
                     <td>{v.name}</td>
-                    <td>
-                      <div className="result-number">
-                        {formatConversionRate(metric.type, stats.cr)}
-                      </div>
-                      <div>
-                        <small className="text-muted">
-                          <em>
-                            {numberFormatter.format(stats.value)}
-                            &nbsp;/&nbsp;
-                            {numberFormatter.format(
-                              stats.users || variations[i].users
-                            )}
-                          </em>
-                        </small>
-                      </div>
+                    <td colSpan={2}>
+                      <em>no data yet</em>
                     </td>
-                    {!i ? (
-                      <td></td>
-                    ) : hasEnoughData(
-                        stats.value,
-                        variations[0].metrics[metric.id]?.value
-                      ) ? (
-                      <td
-                        className={clsx("chance result-number align-middle", {
-                          won: i > 0 && chance >= 0 && chance < WARNING_CUTOFF,
-                          lost: i > 0 && chance >= DANGER_CUTOFF,
-                          warning:
-                            i > 0 &&
-                            chance >= WARNING_CUTOFF &&
-                            chance < DANGER_CUTOFF,
-                        })}
-                      >
-                        {percentFormatter.format(chance)}
-                      </td>
-                    ) : (
-                      <td>
-                        <em>not enough data</em>
-                      </td>
-                    )}
                   </tr>
                 );
-              })}
-            </tbody>
-          </table>
-        ) : (
-          <div className="border py-2 px-3">
-            <em>No data yet</em>
-          </div>
-        )}
+              }
+
+              const chance = 1 - (stats.chanceToWin || 1);
+              return (
+                <tr key={i}>
+                  <td>{v.name}</td>
+                  <td>
+                    <div className="result-number">
+                      {formatConversionRate(metric.type, stats.cr)}
+                    </div>
+                    <div>
+                      <small className="text-muted">
+                        <em>
+                          {numberFormatter.format(stats.value)}
+                          &nbsp;/&nbsp;
+                          {numberFormatter.format(
+                            stats.users || variations[i].users
+                          )}
+                        </em>
+                      </small>
+                    </div>
+                  </td>
+                  {!i ? (
+                    <td></td>
+                  ) : hasEnoughData(
+                      stats.value,
+                      variations[0].metrics[metric.id]?.value
+                    ) ? (
+                    <td
+                      className={clsx("chance result-number align-middle", {
+                        won: i > 0 && chance >= 0 && chance < WARNING_CUTOFF,
+                        lost: i > 0 && chance >= DANGER_CUTOFF,
+                        warning:
+                          i > 0 &&
+                          chance >= WARNING_CUTOFF &&
+                          chance < DANGER_CUTOFF,
+                      })}
+                    >
+                      {percentFormatter.format(chance)}
+                    </td>
+                  ) : (
+                    <td>
+                      <em>not enough data</em>
+                    </td>
+                  )}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
       </div>
     </div>
   );

--- a/packages/front-end/components/Experiment/RefreshSnapshotButton.tsx
+++ b/packages/front-end/components/Experiment/RefreshSnapshotButton.tsx
@@ -3,7 +3,6 @@ import { useAuth } from "../../services/auth";
 import { BsArrowRepeat } from "react-icons/bs";
 import Button from "../Button";
 import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
-import { ago } from "../../services/dates";
 import ManualSnapshotForm from "./ManualSnapshotForm";
 import { ExperimentSnapshotInterface } from "back-end/types/experiment-snapshot";
 
@@ -56,15 +55,8 @@ const RefreshSnapshotButton: FC<{
           lastSnapshot={lastSnapshot}
         />
       )}
-      {loading && longResult ? (
+      {loading && longResult && (
         <small className="text-muted mr-3">this may take several minutes</small>
-      ) : (
-        !loading &&
-        lastSnapshot && (
-          <small className="text-muted mr-3">
-            last updated {ago(lastSnapshot.dateCreated)}
-          </small>
-        )
       )}
       <Button
         color="outline-primary"

--- a/packages/front-end/components/Experiment/Results.tsx
+++ b/packages/front-end/components/Experiment/Results.tsx
@@ -206,7 +206,6 @@ const Results: FC<{
                   }}
                   icon="refresh"
                   color="outline-primary"
-                  containerClass="d-flex"
                 />
               </form>
             ) : (

--- a/packages/front-end/components/HomePage/Dashboard.tsx
+++ b/packages/front-end/components/HomePage/Dashboard.tsx
@@ -50,13 +50,13 @@ const Dashboard: FC = () => {
         <div className="row">
           <div className="col-lg-4 mb-4">
             <h4>Running Experiments</h4>
-            <div className="list-group activity-box overflow-auto mb-4">
+            <div className="list-group activity-box fixed-height overflow-auto mb-4">
               <ExperimentList num={5} status={"stopped"} />
             </div>
           </div>
           <div className="col-lg-4 mb-4">
             <h4>Recent discussions</h4>
-            <div className="list-group activity-box overflow-auto mb-2">
+            <div className="list-group activity-box fixed-height overflow-auto mb-2">
               <DiscussionFeed num={5} />
             </div>
           </div>
@@ -69,7 +69,7 @@ const Dashboard: FC = () => {
                 </Link>
               </small>
             </h4>
-            <div className="list-group activity-box overflow-auto">
+            <div className="list-group activity-box fixed-height overflow-auto">
               <ActivityList num={3} />
             </div>
             <div className="text-center"></div>

--- a/packages/front-end/components/HomePage/DiscussionFeed.tsx
+++ b/packages/front-end/components/HomePage/DiscussionFeed.tsx
@@ -58,7 +58,10 @@ const DiscussionFeed: FC<{
                     <strong>{name || email}</strong> commented on an{" "}
                     {comment.parentType} on {date(comment.date)}
                   </div>
-                  <div className="card-body pb-0 pt-3">
+                  <div
+                    className="card-body py-3"
+                    style={{ maxHeight: 200, overflowY: "auto" }}
+                  >
                     <Markdown className="card-text">
                       {comment.content || ""}
                     </Markdown>

--- a/packages/front-end/components/Metrics/ViewQueryButton.tsx
+++ b/packages/front-end/components/Metrics/ViewQueryButton.tsx
@@ -2,10 +2,11 @@ import { FC, useState } from "react";
 import { QueryLanguage } from "back-end/types/datasource";
 import QueryModal from "../Experiment/QueryModal";
 
-const ViewQueryButton: FC<{ language: QueryLanguage; queries: string[] }> = ({
-  language,
-  queries,
-}) => {
+const ViewQueryButton: FC<{
+  language: QueryLanguage;
+  queries: string[];
+  display?: string;
+}> = ({ language, queries, display = "View Queries" }) => {
   const [open, setOpen] = useState(false);
 
   return (
@@ -24,7 +25,7 @@ const ViewQueryButton: FC<{ language: QueryLanguage; queries: string[] }> = ({
           setOpen(true);
         }}
       >
-        View Queries ({language})
+        {display} ({language})
       </button>
     </>
   );

--- a/packages/front-end/components/Queries/AsyncQueriesModal.tsx
+++ b/packages/front-end/components/Queries/AsyncQueriesModal.tsx
@@ -3,9 +3,7 @@ import Modal from "../Modal";
 import useApi from "../../hooks/useApi";
 import { QueryInterface } from "back-end/types/query";
 import LoadingOverlay from "../LoadingOverlay";
-import { formatDistanceStrict } from "date-fns";
-import { FaCircle, FaExclamationTriangle, FaCheck } from "react-icons/fa";
-import Code from "../Code";
+import ExpandableQuery from "./ExpandableQuery";
 
 const AsyncQueriesModal: FC<{
   queries: string[];
@@ -20,7 +18,7 @@ const AsyncQueriesModal: FC<{
       close={close}
       header="Queries"
       open={true}
-      size="max"
+      size="lg"
       closeCta="Close"
     >
       {!data && !error && <LoadingOverlay />}
@@ -35,55 +33,12 @@ const AsyncQueriesModal: FC<{
         data.queries
           .filter((q) => q !== null)
           .map((query, i) => (
-            <div key={query.id} className="mb-4">
-              <h4>
-                {query.status === "running" && (
-                  <FaCircle className="text-info mr-2" />
-                )}
-                {query.status === "failed" && (
-                  <FaExclamationTriangle className="text-danger mr-2" />
-                )}
-                {query.status === "succeeded" && (
-                  <FaCheck className="text-success mr-2" />
-                )}
-                Query {i + 1} of {data.queries.length}
-              </h4>
-              <Code language={query.language} code={query.query} />
-              {query.status === "failed" && (
-                <div className="alert alert-danger">
-                  <pre>{query.error}</pre>
-                </div>
-              )}
-              {query.status === "succeeded" && (
-                <div className="alert alert-success">
-                  <pre style={{ maxHeight: 300, overflowY: "auto" }}>
-                    {JSON.stringify(query.result, null, 2)}
-                  </pre>
-                  {query.status === "succeeded" && (
-                    <small>
-                      <em>
-                        Took{" "}
-                        {formatDistanceStrict(
-                          new Date(query.startedAt),
-                          new Date(query.finishedAt)
-                        )}
-                      </em>
-                    </small>
-                  )}
-                </div>
-              )}
-              {query.status === "running" && (
-                <div className="alert alert-info">
-                  <em>
-                    Running for{" "}
-                    {formatDistanceStrict(
-                      new Date(query.startedAt),
-                      new Date()
-                    )}
-                  </em>
-                </div>
-              )}
-            </div>
+            <ExpandableQuery
+              query={query}
+              i={i}
+              total={data.queries.length}
+              key={i}
+            />
           ))}
     </Modal>
   );

--- a/packages/front-end/components/Queries/ExpandableQuery.tsx
+++ b/packages/front-end/components/Queries/ExpandableQuery.tsx
@@ -38,7 +38,15 @@ const ExpandableQuery: FC<{
             background:
               "linear-gradient(to bottom, rgba(45,45,45,0) 0%,rgba(45,45,45,0.8) 60%)",
           }}
-          onClick={() => queryOpen && setQueryOpen(false)}
+          onClick={(e) => {
+            if (!queryOpen) return;
+            setQueryOpen(false);
+
+            const pre = (e.target as HTMLDivElement).previousElementSibling;
+            if (pre) {
+              pre.scrollTo({ top: 0 });
+            }
+          }}
         >
           click to {queryOpen ? "minimize" : "expand"}
         </div>
@@ -62,7 +70,15 @@ const ExpandableQuery: FC<{
               background:
                 "linear-gradient(to bottom, rgba(212,237,218,0) 0%,rgba(212,237,218,0.8) 60%)",
             }}
-            onClick={() => resultsOpen && setResultsOpen(false)}
+            onClick={(e) => {
+              if (!resultsOpen) return;
+              setResultsOpen(false);
+
+              const pre = (e.target as HTMLDivElement).previousElementSibling;
+              if (pre) {
+                pre.scrollTo({ top: 0 });
+              }
+            }}
           >
             click to {resultsOpen ? "minimize" : "expand"}
           </div>

--- a/packages/front-end/components/Queries/ExpandableQuery.tsx
+++ b/packages/front-end/components/Queries/ExpandableQuery.tsx
@@ -1,0 +1,94 @@
+import { FC, useState } from "react";
+import { QueryInterface } from "back-end/types/query";
+import { formatDistanceStrict } from "date-fns";
+import { FaCircle, FaExclamationTriangle, FaCheck } from "react-icons/fa";
+import Code from "../Code";
+import clsx from "clsx";
+
+const ExpandableQuery: FC<{
+  query: QueryInterface;
+  i: number;
+  total: number;
+}> = ({ query, i, total }) => {
+  const [queryOpen, setQueryOpen] = useState(false);
+  const [resultsOpen, setResultsOpen] = useState(false);
+
+  return (
+    <div className="mb-4">
+      <h4>
+        {query.status === "running" && <FaCircle className="text-info mr-2" />}
+        {query.status === "failed" && (
+          <FaExclamationTriangle className="text-danger mr-2" />
+        )}
+        {query.status === "succeeded" && (
+          <FaCheck className="text-success mr-2" />
+        )}
+        Query {i + 1} of {total}
+      </h4>
+      <div
+        className={clsx("expandable-container text-light", {
+          expanded: queryOpen,
+        })}
+        onClick={() => !queryOpen && setQueryOpen(true)}
+      >
+        <Code language={query.language} code={query.query} />
+        <div
+          className="fader"
+          style={{
+            background:
+              "linear-gradient(to bottom, rgba(45,45,45,0) 0%,rgba(45,45,45,0.8) 60%)",
+          }}
+          onClick={() => queryOpen && setQueryOpen(false)}
+        >
+          click to {queryOpen ? "minimize" : "expand"}
+        </div>
+      </div>
+      {query.status === "failed" && (
+        <div className="alert alert-danger">
+          <pre>{query.error}</pre>
+        </div>
+      )}
+      {query.status === "succeeded" && (
+        <div
+          className={clsx("alert alert-success expandable-container mb-1", {
+            expanded: resultsOpen,
+          })}
+          onClick={() => !resultsOpen && setResultsOpen(true)}
+        >
+          <pre>{JSON.stringify(query.result, null, 2)}</pre>
+          <div
+            className="fader"
+            style={{
+              background:
+                "linear-gradient(to bottom, rgba(212,237,218,0) 0%,rgba(212,237,218,0.8) 60%)",
+            }}
+            onClick={() => resultsOpen && setResultsOpen(false)}
+          >
+            click to {resultsOpen ? "minimize" : "expand"}
+          </div>
+        </div>
+      )}
+      {query.status === "succeeded" && (
+        <small>
+          <em>
+            Took{" "}
+            {formatDistanceStrict(
+              new Date(query.startedAt),
+              new Date(query.finishedAt)
+            )}
+          </em>
+        </small>
+      )}
+      {query.status === "running" && (
+        <div className="alert alert-info">
+          <em>
+            Running for{" "}
+            {formatDistanceStrict(new Date(query.startedAt), new Date())}
+          </em>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ExpandableQuery;

--- a/packages/front-end/components/Queries/RunQueriesButton.tsx
+++ b/packages/front-end/components/Queries/RunQueriesButton.tsx
@@ -44,6 +44,7 @@ const RunQueriesButton: FC<{
   icon?: "run" | "refresh";
   onReady: () => void;
   color?: string;
+  containerClass?: string;
 }> = ({
   cta = "Run Queries",
   loadingText = "Running",
@@ -53,6 +54,7 @@ const RunQueriesButton: FC<{
   onReady,
   icon = "run",
   color = "success",
+  containerClass = "",
 }) => {
   const { data, error, mutate } = useApi<{
     queryStatus: QueryStatus;
@@ -127,28 +129,7 @@ const RunQueriesButton: FC<{
   }
 
   return (
-    <div>
-      <button
-        className={clsx("btn", `btn-${color}`, {
-          disabled: status === "running",
-        })}
-        type="submit"
-      >
-        {buttonIcon}{" "}
-        {status === "running"
-          ? `${loadingText} (${getTimeDisplay(counter)})...`
-          : cta}
-      </button>
-      {status === "running" && data?.total > 0 && (
-        <div
-          style={{
-            width:
-              Math.floor((100 * (data?.finished || 0)) / data?.total) + "%",
-            height: 5,
-          }}
-          className="bg-info"
-        ></div>
-      )}
+    <div className={containerClass}>
       {status === "running" && (
         <div>
           <button
@@ -163,6 +144,29 @@ const RunQueriesButton: FC<{
           </button>
         </div>
       )}
+      <div>
+        <button
+          className={clsx("btn", `btn-${color}`, {
+            disabled: status === "running",
+          })}
+          type="submit"
+        >
+          {buttonIcon}{" "}
+          {status === "running"
+            ? `${loadingText} (${getTimeDisplay(counter)})...`
+            : cta}
+        </button>
+        {status === "running" && data?.total > 0 && (
+          <div
+            style={{
+              width:
+                Math.floor((100 * (data?.finished || 0)) / data?.total) + "%",
+              height: 5,
+            }}
+            className="bg-info"
+          ></div>
+        )}
+      </div>
       {error && <div className="text-danger">{error.message}</div>}
     </div>
   );

--- a/packages/front-end/components/Queries/RunQueriesButton.tsx
+++ b/packages/front-end/components/Queries/RunQueriesButton.tsx
@@ -43,6 +43,7 @@ const RunQueriesButton: FC<{
   initialStatus: QueryStatus;
   icon?: "run" | "refresh";
   onReady: () => void;
+  color?: string;
 }> = ({
   cta = "Run Queries",
   loadingText = "Running",
@@ -51,6 +52,7 @@ const RunQueriesButton: FC<{
   initialStatus,
   onReady,
   icon = "run",
+  color = "success",
 }) => {
   const { data, error, mutate } = useApi<{
     queryStatus: QueryStatus;
@@ -127,7 +129,7 @@ const RunQueriesButton: FC<{
   return (
     <div>
       <button
-        className={clsx("btn btn-success", {
+        className={clsx("btn", `btn-${color}`, {
           disabled: status === "running",
         })}
         type="submit"

--- a/packages/front-end/components/Queries/RunQueriesButton.tsx
+++ b/packages/front-end/components/Queries/RunQueriesButton.tsx
@@ -44,7 +44,6 @@ const RunQueriesButton: FC<{
   icon?: "run" | "refresh";
   onReady: () => void;
   color?: string;
-  containerClass?: string;
 }> = ({
   cta = "Run Queries",
   loadingText = "Running",
@@ -54,7 +53,6 @@ const RunQueriesButton: FC<{
   onReady,
   icon = "run",
   color = "success",
-  containerClass = "",
 }) => {
   const { data, error, mutate } = useApi<{
     queryStatus: QueryStatus;
@@ -129,7 +127,7 @@ const RunQueriesButton: FC<{
   }
 
   return (
-    <div className={containerClass}>
+    <div className="d-flex">
       {status === "running" && (
         <div>
           <button

--- a/packages/front-end/components/Queries/ViewAsyncQueriesButton.tsx
+++ b/packages/front-end/components/Queries/ViewAsyncQueriesButton.tsx
@@ -5,7 +5,8 @@ import clsx from "clsx";
 const ViewAsyncQueriesButton: FC<{
   queries: string[];
   display?: string;
-}> = ({ queries, display = "View Queries" }) => {
+  color?: string;
+}> = ({ queries, display = "View Queries", color = "link" }) => {
   const [open, setOpen] = useState(false);
 
   return (
@@ -14,7 +15,7 @@ const ViewAsyncQueriesButton: FC<{
         <AsyncQueriesModal close={() => setOpen(false)} queries={queries} />
       )}
       <button
-        className={clsx("btn btn-link", {
+        className={clsx("btn", `btn-${color}`, {
           disabled: queries.length === 0,
         })}
         onClick={(e) => {

--- a/packages/front-end/components/Queries/ViewAsyncQueriesButton.tsx
+++ b/packages/front-end/components/Queries/ViewAsyncQueriesButton.tsx
@@ -4,7 +4,8 @@ import clsx from "clsx";
 
 const ViewAsyncQueriesButton: FC<{
   queries: string[];
-}> = ({ queries }) => {
+  display?: string;
+}> = ({ queries, display = "View Queries" }) => {
   const [open, setOpen] = useState(false);
 
   return (
@@ -22,7 +23,7 @@ const ViewAsyncQueriesButton: FC<{
           setOpen(true);
         }}
       >
-        View Queries {queries.length > 0 ? `(${queries.length})` : ""}
+        {display} {queries.length > 0 ? `(${queries.length})` : ""}
       </button>
     </>
   );

--- a/packages/front-end/pages/experiment/[eid].tsx
+++ b/packages/front-end/pages/experiment/[eid].tsx
@@ -623,12 +623,28 @@ const ExperimentPage = (): ReactElement => {
                     {getMetricById(experiment.activationMetric)?.name}
                   </RightRailSectionGroup>
                 )}
-                <RightRailSectionGroup title="Goals" type="badge">
-                  {experiment.metrics.map((m) => getMetricById(m)?.name)}
+                <RightRailSectionGroup title="Goals" type="custom">
+                  {experiment.metrics.map((m) => {
+                    return (
+                      <Link href={`/metric/${m}`} key={m}>
+                        <a className="badge badge-secondary mr-2">
+                          {getMetricById(m)?.name}
+                        </a>
+                      </Link>
+                    );
+                  })}
                 </RightRailSectionGroup>
                 {experiment.guardrails?.length > 0 && (
-                  <RightRailSectionGroup title="Guardrails" type="badge">
-                    {experiment.guardrails.map((m) => getMetricById(m)?.name)}
+                  <RightRailSectionGroup title="Guardrails" type="custom">
+                    {experiment.guardrails.map((m) => {
+                      return (
+                        <Link href={`/metric/${m}`} key={m}>
+                          <a className="badge badge-secondary mr-2">
+                            {getMetricById(m)?.name}
+                          </a>
+                        </Link>
+                      );
+                    })}
                   </RightRailSectionGroup>
                 )}
               </RightRailSection>

--- a/packages/front-end/styles/global.scss
+++ b/packages/front-end/styles/global.scss
@@ -599,10 +599,14 @@ li.reports a span img {
 
 .dashboard {
   .activity-box {
-    max-height: 300px;
     background-color: #f8fbff;
     border: 1px solid #dadee3;
     padding: 10px;
+  }
+  @media (min-width: 992px) {
+    .fixed-height {
+      height: 375px;
+    }
   }
 }
 .cursor-pointer {

--- a/packages/front-end/styles/global.scss
+++ b/packages/front-end/styles/global.scss
@@ -100,17 +100,26 @@ pre {
     color: rgba(0, 0, 0, 0);
   }
 
+  pre {
+    max-height: 590px;
+    overflow: hidden !important;
+  }
+
   &:hover .fader {
     color: inherit;
   }
   &.expanded {
     cursor: initial;
-    max-height: 5000px;
+    max-height: 600px;
     .fader {
       display: none;
     }
     &:hover .fader {
       display: block;
+    }
+
+    pre {
+      overflow-y: auto !important;
     }
   }
 }

--- a/packages/front-end/styles/global.scss
+++ b/packages/front-end/styles/global.scss
@@ -82,6 +82,38 @@ pre {
 .flex-1 {
   flex: 1;
 }
+.expandable-container {
+  overflow: hidden;
+  max-height: 120px;
+  cursor: pointer;
+  transition: max-height 0.3s;
+  position: relative;
+
+  .fader {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    padding: 15px 0 5px;
+    text-align: center;
+    cursor: pointer;
+    color: rgba(0, 0, 0, 0);
+  }
+
+  &:hover .fader {
+    color: inherit;
+  }
+  &.expanded {
+    cursor: initial;
+    max-height: 5000px;
+    .fader {
+      display: none;
+    }
+    &:hover .fader {
+      display: block;
+    }
+  }
+}
 .vertical-scroll {
   overflow-x: hidden;
   overflow-y: auto;


### PR DESCRIPTION
Main benefits:
-  Progress indicator and elapsed timer while queries are running
-  Ability to view raw results, errors, and running time for each individual query
-  Progress and errors persist across page refreshes
-  Can still view queries even if they haven't finished yet or have failed
-  Visual indication on the front-end when autosnapshots are happening
-  Will automatically benefit from future improvements to the async query engine

TODO:
-  [x] Add `queries` field to experiment snapshot type
-  [x] Update Integration interface to have `getExperimentUsersQuery`, `runExperimentUsersQuery`, `getExperimentMetricQuery`, and `runExperimentMetricQuery` methods.
-  [x] Support the old all-in-one `getExperimentResults` method for Mixpanel and GoogleAnalytics
-  [x] Implement new methods on SqlIntegration
-  [x] When creating a snapshot, create Query records for each query and create empty snapshot (with no results) immediately and return.
-  [x] When queries finish, update results in the snapshot
-  [x] When getting the latest snapshot, return the latest one with results, plus the `queries` array of the latest one (whether or not it has results).
-  [x] On experiment results, switch to the `ViewAsyncQueriesButton` component
-  [x] On experiment results, use the `RunAsyncQueries` button instead of the custom refresh results button
-  [x] Make sure results are backwards compatible and continue to display correctly for old snapshots.
- [x] Bypass query cache when refreshing results manually
-  [x] Make sure other places that get the latest snapshot only include ones with results
-  [x] When running snapshot is cancelled, delete it from mongo
-  [x] Make sure results cronjob continues working
