### PR TITLE
Clickhouse bugs - fix date function names and refactor non-equi joins

### DIFF
--- a/packages/back-end/src/integrations/ClickHouse.ts
+++ b/packages/back-end/src/integrations/ClickHouse.ts
@@ -43,10 +43,10 @@ export default class ClickHouse extends SqlIntegration {
       .replace("T", " ")}')`;
   }
   addDateInterval(col: string, days: number) {
-    return `date_add(day, ${days}, ${col})`;
+    return `dateAdd(day, ${days}, ${col})`;
   }
   subtractHalfHour(col: string) {
-    return `date_sub(hour, 30, ${col})`;
+    return `dateSub(hour, 30, ${col})`;
   }
   regexMatch(col: string, regex: string) {
     return `match(${col}, '${regex.replace(/\\/g, "\\\\")}')`;
@@ -55,9 +55,9 @@ export default class ClickHouse extends SqlIntegration {
     return `quantile(${percentile})(${col})`;
   }
   dateTrunc(col: string) {
-    return `date_trunc('day', ${col})`;
+    return `dateTrunc('day', ${col})`;
   }
   dateDiff(startCol: string, endCol: string) {
-    return `date_diff('day', ${startCol}, ${endCol})`;
+    return `dateDiff('day', ${startCol}, ${endCol})`;
   }
 }

--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -268,10 +268,11 @@ export default abstract class SqlIntegration
         FROM
           __experimentDates d
           JOIN __userThresholds u ON (
-            d.users > u.threshold
-            AND d.experiment_id = u.experiment_id
+            d.experiment_id = u.experiment_id
             AND d.variation_id = u.variation_id
           )
+        WHERE
+          d.users > u.threshold
         GROUP BY
           d.experiment_id, d.variation_id
       )
@@ -344,7 +345,7 @@ export default abstract class SqlIntegration
             __users u
             ${
               params.segmentQuery
-                ? "JOIN segment s ON (s.user_id = u.user_id AND s.date <= u.actual_start)"
+                ? "JOIN segment s ON (s.user_id = u.user_id) WHERE s.date <= u.actual_start"
                 : ""
             }
           GROUP BY
@@ -358,11 +359,12 @@ export default abstract class SqlIntegration
             __distinctUsers d
             JOIN __metric m ON (
               m.user_id = d.user_id
-              AND m.actual_start >= d.${
+            )
+            WHERE
+              m.actual_start >= d.${
                 params.metric.earlyStart ? "session_start" : "actual_start"
               }
               AND m.actual_start <= d.conversion_end
-            )
           GROUP BY
             d.user_id
         )
@@ -378,11 +380,12 @@ export default abstract class SqlIntegration
               __distinctUsers d
               JOIN __metric m ON (
                 m.user_id = d.user_id
-                AND m.actual_start >= d.${
+              )
+              WHERE
+                m.actual_start >= d.${
                   params.metric.earlyStart ? "session_start" : "actual_start"
                 }
                 AND m.actual_start <= d.conversion_end
-              )
             GROUP BY
               ${this.dateTrunc("d.actual_start")},
               d.user_id
@@ -462,7 +465,7 @@ export default abstract class SqlIntegration
         __users u
         ${
           params.segmentQuery
-            ? "JOIN __segment s ON (s.user_id = u.user_id AND s.date <= u.actual_start)"
+            ? "JOIN __segment s ON (s.user_id = u.user_id) WHERE s.date <= u.actual_start"
             : ""
         }
 
@@ -476,7 +479,7 @@ export default abstract class SqlIntegration
           __users u
           ${
             params.segmentQuery
-              ? "JOIN __segment s ON (s.user_id = u.user_id AND s.date <= u.actual_start)"
+              ? "JOIN __segment s ON (s.user_id = u.user_id) WHERE s.date <= u.actual_start"
               : ""
           }
         GROUP BY
@@ -821,9 +824,9 @@ export default abstract class SqlIntegration
               ? `
           JOIN __activationMetric a ON (
             a.user_id = e.user_id
-            AND a.actual_start >= e.actual_start
-            AND a.actual_start <= e.conversion_end
-          )`
+          ) WHERE
+            a.actual_start >= e.actual_start
+            AND a.actual_start <= e.conversion_end`
               : ""
           }
         GROUP BY
@@ -906,9 +909,9 @@ export default abstract class SqlIntegration
               ? `
           JOIN __activationMetric a ON (
             a.user_id = e.user_id
-            AND a.actual_start >= e.actual_start
-            AND a.actual_start <= e.conversion_end
-          )`
+          ) WHERE
+            a.actual_start >= e.actual_start
+            AND a.actual_start <= e.conversion_end`
               : ""
           }
         GROUP BY
@@ -924,11 +927,12 @@ export default abstract class SqlIntegration
           __distinctUsers d
           JOIN __metric m ON (
             m.user_id = d.user_id
-            AND m.actual_start >= d.${
+          )
+          WHERE
+            m.actual_start >= d.${
               metric.earlyStart ? "session_start" : "actual_start"
             }
             AND m.actual_start <= d.conversion_end
-          )
         GROUP BY
           variation, dimension, d.user_id
       )


### PR DESCRIPTION
Use `dateDiff` etc vs `date_diff`.  Clickhouse docs say they are aliases, but apparently the underscore version throws errors.

Also, refactored all queries to remove non-equi-joins.  We only use inner joins, so this is as simple as moving comparison operators from the ON clause to the WHERE clause.  `JOIN b ON (a.id = b.id AND a.date > b.date)` becomes `JOIN b ON (a.id = b.id) WHERE a.date > b.date`.  Most query planners should optimize these to be identical anyways.  Quick performance testing on Postgres confirmed this.