### PR TITLE
Enable S3 file upload support for self-hosted installations

### DIFF
--- a/packages/back-end/src/app.ts
+++ b/packages/back-end/src/app.ts
@@ -8,7 +8,12 @@ import express, {
 import mongoInit from "./init/mongo";
 import cors from "cors";
 import { AuthRequest } from "./types/AuthRequest";
-import { APP_ORIGIN, CORS_ORIGIN_REGEX, IS_CLOUD } from "./util/secrets";
+import {
+  APP_ORIGIN,
+  CORS_ORIGIN_REGEX,
+  IS_CLOUD,
+  UPLOAD_METHOD,
+} from "./util/secrets";
 import {
   getExperimentConfig,
   getExperimentsScript,
@@ -223,7 +228,7 @@ if (!IS_CLOUD) {
 
 // File uploads don't require auth tokens.
 // Upload urls are signed and image access is public.
-if (!IS_CLOUD) {
+if (UPLOAD_METHOD === "local") {
   // Create 'uploads' directory if it doesn't exist yet
   const uploadDir = getUploadsDir();
   if (!fs.existsSync(uploadDir)) {

--- a/packages/back-end/src/services/files.ts
+++ b/packages/back-end/src/services/files.ts
@@ -4,11 +4,11 @@ import crypto from "crypto";
 import path from "path";
 import fs from "fs";
 import {
-  IS_CLOUD,
   JWT_SECRET,
   S3_BUCKET,
   S3_DOMAIN,
   S3_REGION,
+  UPLOAD_METHOD,
 } from "../util/secrets";
 
 let s3: AWS.S3;
@@ -65,8 +65,7 @@ export async function getFileUploadURL(ext: string, pathPrefix: string) {
   const filename = uniqid("img_");
   const filePath = `${pathPrefix}${filename}.${ext}`;
 
-  // Cloud deployments use S3 to store files
-  if (IS_CLOUD) {
+  if (UPLOAD_METHOD === "s3") {
     const s3Params = {
       Bucket: S3_BUCKET,
       Key: filePath,
@@ -81,7 +80,7 @@ export async function getFileUploadURL(ext: string, pathPrefix: string) {
       fileURL: S3_DOMAIN + "/" + filePath,
     };
   }
-  // Self-hosted deployments use the file system
+  // Otherwise, use the local file system
   else {
     const fileURL = `/upload/${filePath}`;
     const uploadURL = `/upload?path=${filePath}&signature=${getFileSignature(

--- a/packages/back-end/src/util/secrets.ts
+++ b/packages/back-end/src/util/secrets.ts
@@ -10,11 +10,8 @@ if (fs.existsSync(".env.local")) {
 
 export const IS_CLOUD = !!process.env.IS_CLOUD;
 
-export const UPLOAD_METHOD = ["s3", "local"].includes(process.env.UPLOAD_METHOD)
-  ? (process.env.UPLOAD_METHOD as "s3" | "local")
-  : IS_CLOUD
-  ? "s3"
-  : "local";
+export const UPLOAD_METHOD =
+  IS_CLOUD || process.env.UPLOAD_METHOD === "s3" ? "s3" : "local";
 
 export const MONGODB_URI =
   process.env.MONGODB_URI ??

--- a/packages/back-end/src/util/secrets.ts
+++ b/packages/back-end/src/util/secrets.ts
@@ -10,6 +10,12 @@ if (fs.existsSync(".env.local")) {
 
 export const IS_CLOUD = !!process.env.IS_CLOUD;
 
+export const UPLOAD_METHOD = ["s3", "local"].includes(process.env.UPLOAD_METHOD)
+  ? (process.env.UPLOAD_METHOD as "s3" | "local")
+  : IS_CLOUD
+  ? "s3"
+  : "local";
+
 export const MONGODB_URI =
   process.env.MONGODB_URI ??
   (prod ? "" : "mongodb://root:password@localhost:27017/");

--- a/packages/docs/pages/self-host.mdx
+++ b/packages/docs/pages/self-host.mdx
@@ -81,6 +81,13 @@ The Growth Book App is configured via environment variables. Below are all of th
 - Google OAuth Settings (only if using Google Analytics as a data source)
   - **GOOGLE_OAUTH_CLIENT_ID**
   - **GOOGLE_OAUTH_CLIENT_SECRET**
+- S3 File Uploads (optional, will store uploads locally by default)
+  - **UPLOAD_METHOD** (set to "s3")
+  - **S3_BUCKET**
+  - **S3_REGION** (defaults to `us-east-1`)
+  - **S3_DOMAIN** (defaults to `https://${S3_BUCKET}.s3.amazonaws.com/`)
+  - **AWS_ACCESS_KEY_ID** (not required when deployed to AWS with an instance role)
+  - **AWS_SECRET_ACCESS_KEY** (not required when deployed to AWS with an instance role)
 
 ### Changing the Ports
 
@@ -108,7 +115,7 @@ Now your app would be available on [http://localhost:4000](http://localhost:4000
 
 ### Volumes
 
-Images uploaded in the Growth Book app are stored in `/usr/local/src/app/packages/back-end/uploads`. We recommend mounting a volume there so images can be persisted.
+If you are not using S3 for file uploads, they are stored locally in `/usr/local/src/app/packages/back-end/uploads`. We recommend mounting a volume there so images can be persisted.
 
 Also, if you are running MongoDB through Docker, you will need to mount a volume to `/data/db` to persist data between container restarts. In production, we highly suggest just using a hosted solution like [MongoDB Atlas](https://www.mongodb.com/cloud/atlas) instead.
 


### PR DESCRIPTION
Adds new environment variables for self-hosted installations that want to use S3 to store uploaded files instead of storing them locally.  Fixes #37 

  - **UPLOAD_METHOD** (set to "s3")
  - **S3_BUCKET**
  - **S3_REGION** (defaults to `us-east-1`)
  - **S3_DOMAIN** (defaults to `https://${S3_BUCKET}.s3.amazonaws.com/`)
  - **AWS_ACCESS_KEY_ID** (not required when deployed to AWS with an instance role)
  - **AWS_SECRET_ACCESS_KEY** (not required when deployed to AWS with an instance role)
