### PR TITLE
Allow customizing datasource SQL queries during onboarding

### DIFF
--- a/packages/back-end/src/controllers/organizations.ts
+++ b/packages/back-end/src/controllers/organizations.ts
@@ -907,10 +907,17 @@ FROM
       ...settings?.queries,
     };
 
-    await createDataSource(req.organization.id, name, type, params, settings);
+    const datasource = await createDataSource(
+      req.organization.id,
+      name,
+      type,
+      params,
+      settings
+    );
 
     res.status(200).json({
       status: 200,
+      id: datasource.id,
     });
   } catch (e) {
     res.status(400).json({

--- a/packages/front-end/components/HomePage/GetStarted.tsx
+++ b/packages/front-end/components/HomePage/GetStarted.tsx
@@ -19,6 +19,7 @@ import { UserContext } from "../ProtectedPage";
 import track from "../../services/track";
 import { hasFileConfig } from "../../services/env";
 import clsx from "clsx";
+import EditDataSourceSettingsForm from "../Settings/EditDataSourceSettingsForm";
 
 const GetStarted = ({
   experiments,
@@ -38,6 +39,7 @@ const GetStarted = ({
   const [dataSourceOpen, setDataSourceOpen] = useState(false);
   const [metricsOpen, setMetricsOpen] = useState(false);
   const [experimentsOpen, setExperimentsOpen] = useState(false);
+  const [dataSourceQueriesOpen, setDataSourceQueriesOpen] = useState(false);
   const router = useRouter();
 
   const hasSampleExperiment = experiments.filter((m) =>
@@ -60,15 +62,43 @@ const GetStarted = ({
   return (
     <>
       <div className="container-fluid mt-3 pagecontents getstarted">
+        {dataSourceQueriesOpen &&
+          datasources?.[0] &&
+          datasources[0].type !== "google_analytics" && (
+            <EditDataSourceSettingsForm
+              firstTime={true}
+              data={datasources[0]}
+              onCancel={() => setDataSourceQueriesOpen(false)}
+              onSuccess={() => {
+                setDataSourceQueriesOpen(false);
+                mutateDefinitions();
+              }}
+              source="onboarding"
+            />
+          )}
         {dataSourceOpen && (
           <DataSourceForm
-            data={{}}
+            data={{
+              type: "redshift",
+              name: "My Datasource",
+              params: {
+                port: 5439,
+                database: "",
+                host: "",
+                password: "",
+                user: "",
+                defaultSchema: "",
+                ssl: "false",
+              },
+              settings: {},
+            }}
             existing={false}
             source="get-started"
             onCancel={() => setDataSourceOpen(false)}
-            onSuccess={() => {
+            onSuccess={async () => {
               setDataSourceOpen(false);
-              mutateDefinitions();
+              await mutateDefinitions();
+              setDataSourceQueriesOpen(true);
             }}
           />
         )}

--- a/packages/front-end/components/HomePage/GetStarted.tsx
+++ b/packages/front-end/components/HomePage/GetStarted.tsx
@@ -96,8 +96,8 @@ const GetStarted = ({
             source="get-started"
             onCancel={() => setDataSourceOpen(false)}
             onSuccess={async () => {
-              setDataSourceOpen(false);
               await mutateDefinitions();
+              setDataSourceOpen(false);
               setDataSourceQueriesOpen(true);
             }}
           />

--- a/packages/front-end/components/Settings/DataSourceForm.tsx
+++ b/packages/front-end/components/Settings/DataSourceForm.tsx
@@ -194,11 +194,7 @@ const DataSourceForm: FC<{
       }
       // Create
       else {
-        const res = await apiCall<{
-          status: number;
-          message: string;
-          id: string;
-        }>(`/datasources`, {
+        const res = await apiCall<{ id: string }>(`/datasources`, {
           method: "POST",
           body: JSON.stringify(datasource),
         });

--- a/packages/front-end/components/Settings/DataSourceForm.tsx
+++ b/packages/front-end/components/Settings/DataSourceForm.tsx
@@ -140,7 +140,7 @@ const DataSourceForm: FC<{
   existing: boolean;
   source: string;
   onCancel: () => void;
-  onSuccess: () => void;
+  onSuccess: (id: string) => Promise<void>;
 }> = ({ data, onSuccess, onCancel, source, existing }) => {
   const [dirty, setDirty] = useState(false);
   const [datasource, setDatasource] = useState<
@@ -177,6 +177,8 @@ const DataSourceForm: FC<{
         throw new Error("Please select a data source type");
       }
 
+      let id = data.id;
+
       // Update
       if (data.id) {
         const res = await apiCall<{ status: number; message: string }>(
@@ -192,16 +194,15 @@ const DataSourceForm: FC<{
       }
       // Create
       else {
-        const res = await apiCall<{ status: number; message: string }>(
-          `/datasources`,
-          {
-            method: "POST",
-            body: JSON.stringify(datasource),
-          }
-        );
-        if (res.status > 200) {
-          throw new Error(res.message);
-        }
+        const res = await apiCall<{
+          status: number;
+          message: string;
+          id: string;
+        }>(`/datasources`, {
+          method: "POST",
+          body: JSON.stringify(datasource),
+        });
+        id = res.id;
         track("Submit Datasource Form", {
           source,
           type: datasource.type,
@@ -209,7 +210,7 @@ const DataSourceForm: FC<{
       }
 
       setDirty(false);
-      onSuccess();
+      await onSuccess(id);
     } catch (e) {
       setHasError(true);
       throw e;

--- a/packages/front-end/components/Settings/DataSources.tsx
+++ b/packages/front-end/components/Settings/DataSources.tsx
@@ -122,8 +122,9 @@ const DataSources: FC = () => {
               ? "datasource-list"
               : "datasource-detail"
           }
-          onSuccess={() => {
-            mutateDefinitions({});
+          onSuccess={async (id) => {
+            await mutateDefinitions({});
+            await router.push(`/datasources/${id}`);
           }}
           onCancel={() => {
             setEdit(null);

--- a/packages/front-end/components/Settings/EditDataSourceSettingsForm.tsx
+++ b/packages/front-end/components/Settings/EditDataSourceSettingsForm.tsx
@@ -13,10 +13,11 @@ import { DataSourceInterfaceWithParams } from "back-end/types/datasource";
 
 const EditDataSourceSettingsForm: FC<{
   data: Partial<DataSourceInterfaceWithParams>;
+  firstTime?: boolean;
   source: string;
   onCancel: () => void;
   onSuccess: () => void;
-}> = ({ data, onSuccess, onCancel, source }) => {
+}> = ({ data, onSuccess, onCancel, firstTime = false, source }) => {
   const [dirty, setDirty] = useState(false);
   const [datasource, setDatasource] = useState<
     Partial<DataSourceInterfaceWithParams>
@@ -121,12 +122,25 @@ const EditDataSourceSettingsForm: FC<{
       submit={handleSubmit}
       close={onCancel}
       size="lg"
-      header={"Edit Queries"}
+      header={firstTime ? "Query Settings" : "Edit Queries"}
       cta="Save"
     >
+      {firstTime && (
+        <div className="alert alert-success mb-4">
+          <strong>Connection successful!</strong> Customize the queries that
+          Growth Book uses to pull experiment results. Need help?{" "}
+          <a
+            href="https://docs.growthbook.io/app/datasources#configuration-settings"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            View Documentation
+          </a>
+        </div>
+      )}
       {datasource.type === "mixpanel" && (
         <div>
-          <h4>Experiments</h4>
+          <h4 className="font-weight-bold">Experiments</h4>
           <div className="form-group">
             <label>View Experiment Event</label>
             <input
@@ -185,7 +199,7 @@ const EditDataSourceSettingsForm: FC<{
             </select>
           </div>
           <hr />
-          <h4>Page Views</h4>
+          <h4 className="font-weight-bold">Page Views</h4>
           <div className="form-group">
             <label>Page Views Event</label>
             <input

--- a/packages/front-end/pages/datasources/[did].tsx
+++ b/packages/front-end/pages/datasources/[did].tsx
@@ -230,8 +230,8 @@ const DataSourcePage: FC = () => {
           existing={true}
           data={d}
           source={"datasource-detail"}
-          onSuccess={() => {
-            mutateDefinitions({});
+          onSuccess={async () => {
+            await mutateDefinitions({});
           }}
           onCancel={() => {
             setEditConn(false);

--- a/packages/front-end/pages/oauth/google.tsx
+++ b/packages/front-end/pages/oauth/google.tsx
@@ -28,9 +28,9 @@ const Google: FC = () => {
     return <div className="alert alert-danger">{error.message}</div>;
   }
 
-  const redirectToSettings = () => {
-    mutateDefinitions({});
-    router.push("/datasources");
+  const redirectToSettings = async () => {
+    await mutateDefinitions({});
+    await router.push("/datasources");
   };
 
   return (


### PR DESCRIPTION
**Problem:** After connecting to a data source, many users will need to edit the default SQL queries in order to use Growth Book.  First, users don't realize they even need to edit the default queries until they try to run an experiment and see errors.  Second, if they do want to edit the queries up front, it's hard to find out how and it completely removes them from the onboarding flow.

**Solution:** After a user connects to their first data source on the getting started page, automatically open the "edit queries" modal so they can customize the default SQL without leaving the page.  Similarly, after adding a new data source via the settings page, immediately open the details page where users can see the default queries and edit them.  After these changes, it won't be possible to create a data source without knowing about the existing of the default SQL queries and being able to easily edit them.