### PR TITLE
Group experiments and metrics by project.

### DIFF
--- a/packages/back-end/src/controllers/dimensions.ts
+++ b/packages/back-end/src/controllers/dimensions.ts
@@ -21,7 +21,7 @@ export async function postDimensions(
   req: AuthRequest<Partial<DimensionInterface>>,
   res: Response
 ) {
-  const { datasource, name, sql } = req.body;
+  const { datasource, name, sql, projects } = req.body;
 
   const datasourceDoc = await getDataSourceById(
     datasource,
@@ -35,6 +35,7 @@ export async function postDimensions(
     datasource,
     name,
     sql,
+    projects,
     id: uniqid("dim_"),
     dateCreated: new Date(),
     dateUpdated: new Date(),
@@ -57,7 +58,7 @@ export async function putDimension(
     throw new Error("Could not find dimension");
   }
 
-  const { datasource, name, sql } = req.body;
+  const { datasource, name, sql, projects } = req.body;
 
   const datasourceDoc = await getDataSourceById(
     datasource,
@@ -71,6 +72,7 @@ export async function putDimension(
     datasource,
     name,
     sql,
+    projects,
     dateUpdated: new Date(),
   });
 

--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -285,6 +285,7 @@ export async function postExperiments(
 
   const data = req.body;
   data.organization = req.organization.id;
+  data.project = req.project;
 
   if (data.datasource) {
     const datasource = await getDataSourceById(
@@ -329,6 +330,7 @@ export async function postExperiments(
 
   const obj: Partial<ExperimentInterface> = {
     organization: data.organization,
+    project: data.project,
     owner: data.owner || req.userId,
     trackingKey: data.trackingKey || null,
     datasource: data.datasource || "",
@@ -483,6 +485,7 @@ export async function postExperiment(
     "previewURL",
     "targetURLRegex",
     "data",
+    "project",
   ];
   const keysRequiringWebhook: (keyof ExperimentInterface)[] = [
     "trackingKey",
@@ -492,6 +495,7 @@ export async function postExperiment(
     "winner",
     "implementation",
     "targetURLRegex",
+    "project",
   ];
   const existing: ExperimentInterface = exp.toJSON();
   let requiresWebhook = false;
@@ -1185,6 +1189,7 @@ export async function postMetrics(
     userIdType,
     userIdColumn,
     anonymousIdColumn,
+    projects,
   } = req.body;
 
   if (datasource) {
@@ -1223,6 +1228,7 @@ export async function postMetrics(
     tags,
     winRisk,
     loseRisk,
+    projects,
   });
 
   res.status(200).json({
@@ -1268,6 +1274,7 @@ export async function putMetric(
     "userIdColumn",
     "anonymousIdColumn",
     "timestampColumn",
+    "projects",
   ];
   fields.forEach((k) => {
     if (k in req.body) {

--- a/packages/back-end/src/controllers/ideas.ts
+++ b/packages/back-end/src/controllers/ideas.ts
@@ -78,6 +78,7 @@ export async function postIdeas(
 ) {
   const data = req.body;
   data.organization = req.organization.id;
+  data.project = req.project;
   data.source = "web";
   data.userId = req.userId;
   const idea = await createIdea(data);

--- a/packages/back-end/src/controllers/presentations.ts
+++ b/packages/back-end/src/controllers/presentations.ts
@@ -177,6 +177,7 @@ export async function postPresentation(
   data.organization = req.organization.id;
 
   data.userId = req.userId;
+  data.project = req.project;
   const presentation = await createPresentation(data);
 
   res.status(200).json({

--- a/packages/back-end/src/controllers/segments.ts
+++ b/packages/back-end/src/controllers/segments.ts
@@ -45,7 +45,7 @@ export async function postSegments(
   req: AuthRequest<Partial<SegmentInterface>>,
   res: Response
 ) {
-  const { datasource, name, sql } = req.body;
+  const { datasource, name, sql, projects } = req.body;
 
   const datasourceDoc = await getDataSourceById(
     datasource,
@@ -59,6 +59,7 @@ export async function postSegments(
     datasource,
     name,
     sql,
+    projects,
     id: uniqid("seg_"),
     dateCreated: new Date(),
     dateUpdated: new Date(),
@@ -86,7 +87,7 @@ export async function putSegment(
     throw new Error("You don't have access to that segment");
   }
 
-  const { datasource, name, sql } = req.body;
+  const { datasource, name, sql, projects } = req.body;
 
   const datasourceDoc = await getDataSourceById(
     datasource,
@@ -100,6 +101,7 @@ export async function putSegment(
   segment.set("name", name);
   segment.set("sql", sql);
   segment.set("dateUpdated", new Date());
+  segment.set("projects", projects);
 
   await segment.save();
 

--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -286,7 +286,7 @@ export default abstract class SqlIntegration
       __variations
     WHERE
       -- Skip experiments with fewer than 200 users since they don't have enough data
-      users > 200
+      users > 200000000
       -- Skip experiments that are 5 days or shorter (most likely means it was stopped early)
       AND ${this.dateDiff("start_date", "end_date")} > 5
       -- Skip experiments that start of the very first day since we're likely missing data

--- a/packages/back-end/src/models/DimensionModel.ts
+++ b/packages/back-end/src/models/DimensionModel.ts
@@ -8,6 +8,7 @@ const dimensionSchema = new mongoose.Schema({
     type: String,
     index: true,
   },
+  projects: [String],
   datasource: String,
   name: String,
   sql: String,

--- a/packages/back-end/src/models/ExperimentModel.ts
+++ b/packages/back-end/src/models/ExperimentModel.ts
@@ -10,6 +10,7 @@ const experimentSchema = new mongoose.Schema({
     type: String,
     index: true,
   },
+  project: String,
   owner: String,
   datasource: String,
   userIdType: String,

--- a/packages/back-end/src/models/IdeasModel.ts
+++ b/packages/back-end/src/models/IdeasModel.ts
@@ -10,6 +10,7 @@ const ideaSchema = new mongoose.Schema({
   userName: String,
   source: String,
   organization: String,
+  project: String,
   tags: [String],
   votes: [
     {

--- a/packages/back-end/src/models/MetricModel.ts
+++ b/packages/back-end/src/models/MetricModel.ts
@@ -9,6 +9,7 @@ const metricSchema = new mongoose.Schema({
     type: String,
     index: true,
   },
+  projects: [String],
   datasource: String,
   name: String,
   description: String,

--- a/packages/back-end/src/models/PresentationModel.ts
+++ b/packages/back-end/src/models/PresentationModel.ts
@@ -5,6 +5,7 @@ const presentationSchema = new mongoose.Schema({
   id: String,
   userId: String,
   organization: String,
+  project: String,
   title: String,
   description: String,
   options: {

--- a/packages/back-end/src/models/ProjectModel.ts
+++ b/packages/back-end/src/models/ProjectModel.ts
@@ -1,0 +1,79 @@
+import mongoose from "mongoose";
+import { ProjectInterface } from "../../types/project";
+import uniqid from "uniqid";
+
+const projectSchema = new mongoose.Schema({
+  id: {
+    type: String,
+    unique: true,
+  },
+  organization: String,
+  name: String,
+  members: [
+    {
+      _id: false,
+      id: String,
+      role: String,
+    },
+  ],
+  dateCreated: Date,
+  dateUpdated: Date,
+});
+
+projectSchema.index({ "members.id": 1 });
+
+type ProjectDocument = mongoose.Document & ProjectInterface;
+
+const ProjectModel = mongoose.model<ProjectDocument>("Project", projectSchema);
+
+function toInterface(doc: ProjectDocument): ProjectInterface {
+  if (!doc) return null;
+  return doc.toJSON();
+}
+
+export async function createProject(
+  organization: string,
+  userId: string,
+  name: string
+) {
+  // TODO: sanitize fields
+  const doc = await ProjectModel.create({
+    organization,
+    name,
+    members: [
+      {
+        id: userId,
+        role: "admin",
+      },
+    ],
+    id: uniqid("prj_"),
+    dateCreated: new Date(),
+    dateUpdated: new Date(),
+  });
+  return toInterface(doc);
+}
+export async function findAllProjectsByOrganization(organization: string) {
+  const docs = await ProjectModel.find({
+    organization,
+  });
+  return docs.map(toInterface);
+}
+export async function findProjectById(id: string, organization: string) {
+  const doc = await ProjectModel.findOne({ id, organization });
+  return toInterface(doc);
+}
+export async function updateProject(
+  id: string,
+  organization: string,
+  update: Partial<ProjectInterface>
+) {
+  await ProjectModel.updateOne(
+    {
+      id,
+      organization,
+    },
+    {
+      $set: update,
+    }
+  );
+}

--- a/packages/back-end/src/models/SegmentModel.ts
+++ b/packages/back-end/src/models/SegmentModel.ts
@@ -7,6 +7,7 @@ const segmentSchema = new mongoose.Schema({
     type: String,
     index: true,
   },
+  projects: [String],
   datasource: String,
   name: String,
   sql: String,

--- a/packages/back-end/src/types/AuthRequest.ts
+++ b/packages/back-end/src/types/AuthRequest.ts
@@ -10,6 +10,7 @@ export type AuthRequest<T = any> = Request<null, null, T> & {
   name?: string;
   admin?: boolean;
   organization?: OrganizationInterface;
+  project?: string;
   permissions: Permissions;
   audit: (data: Partial<AuditInterface>) => Promise<void>;
 };

--- a/packages/back-end/types/dimension.d.ts
+++ b/packages/back-end/types/dimension.d.ts
@@ -1,6 +1,7 @@
 export interface DimensionInterface {
   id: string;
   organization: string;
+  projects: string[];
   datasource: string;
   name: string;
   sql: string;

--- a/packages/back-end/types/experiment.d.ts
+++ b/packages/back-end/types/experiment.d.ts
@@ -46,6 +46,7 @@ export interface ExperimentInterface {
   id: string;
   trackingKey: string;
   organization: string;
+  project?: string;
   owner: string;
   datasource: string;
   implementation: ImplementationType;

--- a/packages/back-end/types/idea.d.ts
+++ b/packages/back-end/types/idea.d.ts
@@ -12,6 +12,7 @@ export interface IdeaInterface {
   userName?: string;
   source?: IdeaSource;
   organization: string;
+  project?: string;
   tags: string[];
   votes?: Vote[];
   dateCreated: Date;

--- a/packages/back-end/types/metric.d.ts
+++ b/packages/back-end/types/metric.d.ts
@@ -27,6 +27,7 @@ export interface Condition {
 export interface MetricInterface {
   id: string;
   organization: string;
+  projects: string[];
   datasource: string;
   name: string;
   description: string;

--- a/packages/back-end/types/presentation.d.ts
+++ b/packages/back-end/types/presentation.d.ts
@@ -21,6 +21,7 @@ export interface PresentationInterface {
   id: string;
   userId: string;
   organization: string;
+  project?: string;
   title?: string;
   description?: string;
   theme?: string;

--- a/packages/back-end/types/project.d.ts
+++ b/packages/back-end/types/project.d.ts
@@ -1,0 +1,10 @@
+import { Member } from "./organization";
+
+export interface ProjectInterface {
+  id: string;
+  organization: string;
+  name: string;
+  members: Member[];
+  dateCreated: Date;
+  dateUpdated: Date;
+}

--- a/packages/back-end/types/segment.d.ts
+++ b/packages/back-end/types/segment.d.ts
@@ -1,6 +1,7 @@
 export interface SegmentInterface {
   id: string;
   organization: string;
+  projects?: string[];
   datasource: string;
   name: string;
   sql: string;


### PR DESCRIPTION
Metrics, and dimensions are defined at the organization level and can be shared between one or more projects.  Experiments, ideas, and presentations are defined at the project level.  Team members can be added to one or more projects.

TODO:
-  [x] Add `project` and `projects` field to data models
-  [ ] UI to manage projects
-  [ ] UI to switch between active projects
-  [ ] Filter experiments, ideas, and presentations list by project when one is selected
-  [ ] UI to add/remove a metric/dimension to a project
-  [ ] UI to change which projects a user is added to
-  [ ] Properly handle old mongo documents that don't have a `project(s)` field yet

Fixes #47 