### PR TITLE
Fix bug in stddev correction for metrics with non-converted users

### DIFF
--- a/packages/back-end/src/integrations/Postgres.ts
+++ b/packages/back-end/src/integrations/Postgres.ts
@@ -28,4 +28,7 @@ export default class Postgres extends SqlIntegration {
   dateDiff(startCol: string, endCol: string) {
     return `${endCol}::DATE - ${startCol}::DATE`;
   }
+  avg(col: string) {
+    return `AVG(${col}::float)`;
+  }
 }

--- a/packages/back-end/src/integrations/Redshift.ts
+++ b/packages/back-end/src/integrations/Redshift.ts
@@ -25,4 +25,7 @@ export default class Redshift extends SqlIntegration {
   percentile(col: string, percentile: number) {
     return `APPROXIMATE  PERCENTILE_DISC ( ${percentile} ) WITHIN GROUP (ORDER BY ${col})`;
   }
+  avg(col: string) {
+    return `AVG(${col}::float)`;
+  }
 }

--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -198,6 +198,9 @@ export default abstract class SqlIntegration
   stddev(col: string) {
     return `STDDEV(${col})`;
   }
+  avg(col: string) {
+    return `AVG(${col})`;
+  }
 
   getPastExperimentQuery(params: PastExperimentParams) {
     const minLength = params.minLength ?? 6;
@@ -380,7 +383,7 @@ export default abstract class SqlIntegration
       SELECT
         ${params.includeByDate ? "null as date," : ""}
         COUNT(*) as count,
-        AVG(value) as mean,
+        ${this.avg("value")} as mean,
         ${this.stddev("value")} as stddev
         ${
           params.includePercentiles && params.metric.type !== "binomial"
@@ -400,7 +403,7 @@ export default abstract class SqlIntegration
         UNION ALL SELECT
           date,
           COUNT(*) as count,
-          AVG(value) as mean,
+          ${this.avg("value")} as mean,
           ${this.stddev("value")} as stddev
           ${
             params.includePercentiles && params.metric.type !== "binomial"
@@ -987,7 +990,7 @@ export default abstract class SqlIntegration
       variation,
       dimension,
       COUNT(*) as count,
-      AVG(value) as mean,
+      ${this.avg("value")} as mean,
       ${this.stddev("value")} as stddev
     FROM
       __userMetric


### PR DESCRIPTION
For example, a `Revenue per User` metric may only return rows for converted users.  Everyone else is assumed to have 0 revenue.  The database returns mean/stddev for just these converted users and we must correct these to account for the non-converted users.  There was a bug in this correction formula for standard deviation.

The new formula is as follows:

```ts
  // x = mean of converted users
  // varX = variance of converted users
  // c = number of converted users
  // n = all users (converted + non-converted)
  correctedStdDev = Math.sqrt(
    ((c - 1) * varX) / (n - 1) + (c * (n - c) * Math.pow(x, 2)) / (n * (n - 1))
  );
```

This PR also fixes a rounding bug.  If a metric value is an integer, then `AVG(value)` will do integer division instead of float division in Postgres/Redshift.  We're now doing `AVG(value::float)` to force it to use the correct data type.