### PR TITLE
Reduce false positives for data quality checks

### DIFF
--- a/packages/front-end/components/Experiment/CompactResults.tsx
+++ b/packages/front-end/components/Experiment/CompactResults.tsx
@@ -1,12 +1,14 @@
 import React, { FC, Fragment } from "react";
-import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
+import {
+  ExperimentInterfaceStringDates,
+  ExperimentPhaseStringDates,
+} from "back-end/types/experiment";
 import {
   formatConversionRate,
   defaultWinRiskThreshold,
   defaultLoseRiskThreshold,
 } from "../../services/metrics";
 import clsx from "clsx";
-import SRMWarning from "./SRMWarning";
 import { ExperimentSnapshotInterface } from "back-end/types/experiment-snapshot";
 import { useDefinitions } from "../../services/DefinitionsContext";
 import AlignedGraph from "./AlignedGraph";
@@ -16,7 +18,7 @@ import Tooltip from "../Tooltip";
 import useConfidenceLevels from "../../hooks/useConfidenceLevels";
 import { FaQuestionCircle } from "react-icons/fa";
 import { useState } from "react";
-import isEqual from "lodash/isEqual";
+import DataQualityWarning from "./DataQualityWarning";
 
 const numberFormatter = new Intl.NumberFormat();
 const percentFormatter = new Intl.NumberFormat(undefined, {
@@ -33,11 +35,13 @@ const CompactResults: FC<{
   experiment: ExperimentInterfaceStringDates;
   barFillType?: "gradient" | "significant";
   barType?: "pill" | "violin";
+  phase?: ExperimentPhaseStringDates;
 }> = ({
   snapshot,
   experiment,
   barFillType = "gradient",
   barType = "violin",
+  phase,
 }) => {
   const { getMetricById } = useDefinitions();
   const { ciUpper, ciLower } = useConfidenceLevels();
@@ -104,60 +108,13 @@ const CompactResults: FC<{
       (x) => x.risk?.length > 0
     ).length > 0;
 
-  // Variations defined for the experiment
-  const definedVariations: string[] = experiment.variations
-    .map((v, i) => v.key || i + "")
-    .sort();
-  // Variation ids returned from the query
-  const returnedVariations: string[] = variations
-    .map((v, i) => {
-      return {
-        variation: experiment.variations[i]?.key || i + "",
-        hasData: v.users > 0,
-      };
-    })
-    .filter((v) => v.hasData)
-    .map((v) => v.variation)
-    .concat(snapshot?.unknownVariations || [])
-    .sort();
-
-  const unequalVariations = !isEqual(returnedVariations, definedVariations);
-  const variationMismatch =
-    (experiment.datasource && snapshot?.unknownVariations?.length > 0) ||
-    unequalVariations;
-
   return (
     <div className="mb-4 experiment-compact-holder">
-      {variationMismatch && (
-        <div className="alert alert-danger">
-          <h4 className="font-weight-bold">Variation Id Mismatch</h4>
-          {unequalVariations ? (
-            <div>
-              <div className="mb-1">
-                Returned from data source:
-                {returnedVariations.map((v) => (
-                  <code className="mx-2" key={v}>
-                    {v}
-                  </code>
-                ))}
-              </div>
-              <div>
-                Defined in Growth Book:
-                {definedVariations.map((v) => (
-                  <code className="mx-2" key={v}>
-                    {v}
-                  </code>
-                ))}
-              </div>
-            </div>
-          ) : (
-            <div>All problems fixed. Update Data to refresh the results.</div>
-          )}
-        </div>
-      )}
-
-      {!variationMismatch && <SRMWarning srm={results.srm} />}
-
+      <DataQualityWarning
+        experiment={experiment}
+        snapshot={snapshot}
+        phase={phase}
+      />
       <table className={`table experiment-compact aligned-graph`}>
         <thead>
           <tr>

--- a/packages/front-end/components/Experiment/DataQualityWarning.tsx
+++ b/packages/front-end/components/Experiment/DataQualityWarning.tsx
@@ -1,0 +1,151 @@
+import { FC } from "react";
+import {
+  ExperimentInterfaceStringDates,
+  ExperimentPhaseStringDates,
+} from "back-end/types/experiment";
+import { ExperimentSnapshotInterface } from "back-end/types/experiment-snapshot";
+import SRMWarning from "./SRMWarning";
+import isEqual from "lodash/isEqual";
+import { useDefinitions } from "../../services/DefinitionsContext";
+
+const DataQualityWarning: FC<{
+  experiment: ExperimentInterfaceStringDates;
+  snapshot: ExperimentSnapshotInterface;
+  phase?: ExperimentPhaseStringDates;
+}> = ({ experiment, snapshot, phase }) => {
+  const { getDatasourceById } = useDefinitions();
+
+  if (!snapshot || !phase) return null;
+  const results = snapshot.results[0];
+  if (!results) return null;
+  const variations = results?.variations || [];
+
+  // Skip checks if experiment phase has extremely uneven weights
+  // This causes too many false positives with the current data quality checks
+  if (phase.variationWeights.filter((x) => x < 0.02).length > 0) {
+    return;
+  }
+
+  const datasource = getDatasourceById(experiment.datasource);
+  const hasStringKeys = datasource?.settings?.variationIdFormat === "key";
+
+  // Minimum number of users required to do data quality checks
+  let totalUsers = 0;
+  variations.forEach((v) => {
+    totalUsers += v.users;
+  });
+  if (
+    totalUsers < 8 * experiment.variations.length &&
+    !snapshot.unknownVariations?.length
+  ) {
+    return null;
+  }
+
+  // Variations defined for the experiment
+  const definedVariations: string[] = experiment.variations
+    .map((v, i) => v.key || i + "")
+    .sort();
+  // Variation ids returned from the query
+  const returnedVariations: string[] = variations
+    .map((v, i) => {
+      return {
+        variation: experiment.variations[i]?.key || i + "",
+        hasData: v.users > 0,
+      };
+    })
+    .filter((v) => v.hasData)
+    .map((v) => v.variation)
+    .concat(snapshot.unknownVariations || [])
+    .sort();
+
+  // Problem was fixed
+  if (
+    snapshot.unknownVariations?.length > 0 &&
+    isEqual(returnedVariations, definedVariations)
+  ) {
+    return (
+      <div className="alert alert-info">
+        Results are out of date. Update Data to refresh.
+      </div>
+    );
+  }
+
+  // There are unknown variations
+  if (snapshot.unknownVariations?.length > 0) {
+    // Data source is expecting numeric variation ids, but received string ids
+    if (
+      !hasStringKeys &&
+      snapshot.unknownVariations.filter((x) => isNaN(parseInt(x))).length > 0
+    ) {
+      return (
+        <div className="alert alert-danger">
+          <div className="mb-2">
+            Your data source is configured to expect variation ids as numeric
+            indexes (e.g. <code>0</code>, <code>1</code>, etc.), but we received
+            strings instead (
+            {snapshot.unknownVariations.map((v) => (
+              <code key={v} className="mx-2">
+                {v}
+              </code>
+            ))}
+            ).
+          </div>
+          Please check your data source settings.
+        </div>
+      );
+    }
+
+    // Data source returned incorrect set of numeric ids
+    if (!hasStringKeys) {
+      return (
+        <div className="alert alert-warning">
+          <strong>Warning:</strong> Expected {experiment.variations.length}{" "}
+          variation ids (<code>{definedVariations.join(",")}</code>), but
+          database returned{" "}
+          {returnedVariations.length === definedVariations.length
+            ? "a different set"
+            : returnedVariations.length}{" "}
+          (<code>{returnedVariations.join(",")}</code>).
+        </div>
+      );
+    }
+
+    // Data source using string keys and has unexpected variations returned
+    return (
+      <div className="alert alert-danger">
+        <h4 className="font-weight-bold">Unexpected Variation Ids</h4>
+        <div>
+          <div className="mb-1">
+            Ids returned from data source:
+            {returnedVariations.map((v) => (
+              <code className="mx-2" key={v}>
+                {v}
+              </code>
+            ))}
+          </div>
+          <div>
+            Ids defined in GrowthBook:
+            {definedVariations.map((v) => (
+              <code className="mx-2" key={v}>
+                {v}
+              </code>
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Results missing variations
+  if (definedVariations.length > returnedVariations.length) {
+    return (
+      <div className="alert alert-warning">
+        <strong>Warning</strong>: Missing data from one or more variations.
+      </div>
+    );
+  }
+
+  // SRM check
+  return <SRMWarning srm={results.srm} />;
+};
+export default DataQualityWarning;

--- a/packages/front-end/components/Experiment/DataQualityWarning.tsx
+++ b/packages/front-end/components/Experiment/DataQualityWarning.tsx
@@ -11,6 +11,23 @@ import { useContext } from "react";
 import { UserContext } from "../ProtectedPage";
 import Link from "next/link";
 
+const CommaList: FC<{ vals: string[] }> = ({ vals }) => {
+  if (!vals.length) {
+    return <em>empty</em>;
+  }
+
+  return (
+    <>
+      {vals.map((v, i) => (
+        <Fragment key={v}>
+          {i > 0 && ", "}
+          <code>{v}</code>
+        </Fragment>
+      ))}
+    </>
+  );
+};
+
 const DataQualityWarning: FC<{
   experiment: ExperimentInterfaceStringDates;
   snapshot: ExperimentSnapshotInterface;
@@ -28,7 +45,7 @@ const DataQualityWarning: FC<{
   // Skip checks if experiment phase has extremely uneven weights
   // This causes too many false positives with the current data quality checks
   if (phase.variationWeights.filter((x) => x < 0.02).length > 0) {
-    return;
+    return null;
   }
 
   const datasource = getDatasourceById(experiment.datasource);
@@ -87,20 +104,9 @@ const DataQualityWarning: FC<{
       return (
         <div className="alert alert-warning">
           <strong>Warning:</strong> Your data source is configured to expect
-          numeric Variation Ids (
-          {definedVariations.map((v, i) => (
-            <Fragment key={v}>
-              {i > 0 && ", "}
-              <code>{v}</code>
-            </Fragment>
-          ))}
+          numeric Variation Ids (<CommaList vals={definedVariations} />
           ), but it returned strings instead (
-          {returnedVariations.map((v, i) => (
-            <Fragment key={v}>
-              {i > 0 && ", "}
-              <code>{v}</code>
-            </Fragment>
-          ))}
+          <CommaList vals={returnedVariations} />
           ).{" "}
           {permissions.organizationSettings && (
             <Link href={`/datasources/${datasource.id}`}>
@@ -114,12 +120,13 @@ const DataQualityWarning: FC<{
     return (
       <div className="alert alert-warning">
         <strong>Warning:</strong> Expected {experiment.variations.length}{" "}
-        variation ids (<code>{definedVariations.join(",")}</code>), but database
-        returned{" "}
+        variation ids (<CommaList vals={definedVariations} />
+        ), but database returned{" "}
         {returnedVariations.length === definedVariations.length
           ? "a different set"
           : returnedVariations.length}{" "}
-        (<code>{returnedVariations.join(",")}</code>).
+        (<CommaList vals={returnedVariations} />
+        ).
       </div>
     );
   }

--- a/packages/front-end/components/Experiment/Results.tsx
+++ b/packages/front-end/components/Experiment/Results.tsx
@@ -281,7 +281,11 @@ const Results: FC<{
       )}
       {hasData && !snapshot.dimension && (
         <>
-          <CompactResults snapshot={snapshot} experiment={experiment} />
+          <CompactResults
+            snapshot={snapshot}
+            experiment={experiment}
+            phase={experiment.phases?.[phase]}
+          />
           {experiment.guardrails?.length > 0 && (
             <div className="mb-3">
               <hr />


### PR DESCRIPTION
### Thresholds for data quality warnings
-  Unknown variations must account for more than 2% of users in an experiment
-  Must be more than 8*numVariations users total
-  None of the variations can be configured for less than 2% of traffic allocation

### Create separate warning messages for each type of data quality issue

Data source configured for numeric ids, but strings returned:
![image](https://user-images.githubusercontent.com/1087514/132096029-c7a3efbb-0d62-4eb3-81bd-8e0802fed1a0.png)

Extra ids returned from the query:
![image](https://user-images.githubusercontent.com/1087514/132095486-b20f2964-e215-4204-8440-9033211e3656.png)

Fewer ids returned from the query:
![image](https://user-images.githubusercontent.com/1087514/132095704-3b21310c-af39-4a23-aab4-8afb29332b4d.png)

Same number of ids returned, but they don't match:
![image](https://user-images.githubusercontent.com/1087514/132095666-a5849fbb-227a-4692-9041-02d873eee7eb.png)

The user fixed the variation ids in the UI, but hasn't refreshed results yet:
![image](https://user-images.githubusercontent.com/1087514/132098671-4df9da9f-3723-4151-b0b2-1fff26aeb57f.png)

SRM:
![image](https://user-images.githubusercontent.com/1087514/132095962-3ad43450-e990-4fce-bc40-4a167985edb6.png)



Fixes #75 