### PR TITLE
Fixes for importing a running experiment.

### DIFF
--- a/packages/front-end/components/Experiment/NewExperimentForm.tsx
+++ b/packages/front-end/components/Experiment/NewExperimentForm.tsx
@@ -133,6 +133,7 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
       variations:
         initialValue?.variations || getDefaultVariations(initialNumVariations),
       phases: initialPhases,
+      status: initialValue?.status || "running",
       ideaSource: idea || "",
     },
   });
@@ -163,8 +164,12 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
     // TODO: more validation?
 
     const data = { ...value };
-    if (isImport) {
-      data.status = "stopped";
+    if (!isImport) {
+      data.status = "draft";
+    }
+
+    if (data.status === "running") {
+      data.phases[0].dateEnded = "";
     }
 
     const body = JSON.stringify(data);
@@ -271,15 +276,22 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
         {isImport && (
           <>
             <Field
+              label="Status"
+              options={["running", "stopped"]}
+              {...form.register("status")}
+            />
+            <Field
               label="Start Date (UTC)"
               type="datetime-local"
               {...form.register("phases.0.dateStarted")}
             />
-            <Field
-              label="End Date (UTC)"
-              type="datetime-local"
-              {...form.register("phases.0.dateEnded")}
-            />
+            {form.watch("status") === "stopped" && (
+              <Field
+                label="End Date (UTC)"
+                type="datetime-local"
+                {...form.register("phases.0.dateEnded")}
+              />
+            )}
           </>
         )}
       </Page>
@@ -439,7 +451,6 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
           {datasource?.type !== "mixpanel" && (
             <Field
               label="Login State"
-              className="form-control"
               {...form.register("userIdType")}
               options={["user", "anonymous"]}
             />

--- a/packages/front-end/components/Experiment/StopExperimentForm.tsx
+++ b/packages/front-end/components/Experiment/StopExperimentForm.tsx
@@ -90,7 +90,7 @@ const StopExperimentForm: FC<{
       <div className="row">
         <Field
           label="Conclusion"
-          className="col-lg"
+          containerClassName="col-lg"
           {...form.register("results")}
           options={[
             { display: "Did Not Finish", value: "dnf" },
@@ -102,7 +102,7 @@ const StopExperimentForm: FC<{
         {form.watch("results") === "won" && experiment.variations.length > 2 && (
           <Field
             label="Winner"
-            className="col-lg"
+            containerClassName="col-lg"
             {...form.register("winner")}
             options={experiment.variations.map((v, i) => {
               if (!i) return null;

--- a/packages/front-end/pages/experiments/import/[id].tsx
+++ b/packages/front-end/pages/experiments/import/[id].tsx
@@ -183,6 +183,12 @@ const ImportPage: FC = () => {
                                     .substr(0, 10) + "T23:59:59Z",
                               },
                             ],
+                            // Default to stopped if the last data was more than 3 days ago
+                            status:
+                              new Date(e.endDate).getTime() <
+                              Date.now() - 72 * 60 * 60 * 1000
+                                ? "stopped"
+                                : "running",
                           });
                         }}
                       >


### PR DESCRIPTION
- [x] While importing, if there was experiment data within the past 3 days, default to setting the status to "running"
- [x] Allow changing the status within the import modal
- [x] When importing a running experiment, don't ask for an End Date
- [x] Fix broken css on "Stop Experiment" modal