### PR TITLE
If variations ids are left empty, assume they are "0", "1", etc.

### DIFF
--- a/packages/front-end/components/Experiment/CompactResults.tsx
+++ b/packages/front-end/components/Experiment/CompactResults.tsx
@@ -411,7 +411,8 @@ const CompactResults: FC<{
   snapshot: ExperimentSnapshotInterface;
   experiment: ExperimentInterfaceStringDates;
   phase?: ExperimentPhaseStringDates;
-}> = ({ snapshot, experiment, phase }) => {
+  isUpdating?: boolean;
+}> = ({ snapshot, experiment, phase, isUpdating }) => {
   const { getMetricById } = useDefinitions();
 
   const results = snapshot.results[0];
@@ -430,6 +431,7 @@ const CompactResults: FC<{
         experiment={experiment}
         snapshot={snapshot}
         phase={phase}
+        isUpdating={isUpdating}
       />
       <table className={`table experiment-compact aligned-graph`}>
         <thead>

--- a/packages/front-end/components/Experiment/DataQualityWarning.tsx
+++ b/packages/front-end/components/Experiment/DataQualityWarning.tsx
@@ -32,7 +32,8 @@ const DataQualityWarning: FC<{
   experiment: ExperimentInterfaceStringDates;
   snapshot: ExperimentSnapshotInterface;
   phase?: ExperimentPhaseStringDates;
-}> = ({ experiment, snapshot, phase }) => {
+  isUpdating?: boolean;
+}> = ({ experiment, snapshot, phase, isUpdating }) => {
   const { getDatasourceById } = useDefinitions();
 
   const { permissions } = useContext(UserContext);
@@ -86,6 +87,9 @@ const DataQualityWarning: FC<{
     snapshot.unknownVariations?.length > 0 &&
     isEqual(returnedVariations, definedVariations)
   ) {
+    if (isUpdating) {
+      return null;
+    }
     return (
       <div className="alert alert-info">
         Results are out of date. Update Data to refresh.

--- a/packages/front-end/components/Experiment/EditInfoForm.tsx
+++ b/packages/front-end/components/Experiment/EditInfoForm.tsx
@@ -181,7 +181,11 @@ const EditInfoForm: FC<{
                   {...form.register(`variations.${i}.name`)}
                 />
                 {variationKeys && (
-                  <Field label="Id" {...form.register(`variations.${i}.key`)} />
+                  <Field
+                    label="Id"
+                    {...form.register(`variations.${i}.key`)}
+                    placeholder={i + ""}
+                  />
                 )}
                 <Field
                   label="Description"

--- a/packages/front-end/components/Experiment/NewExperimentForm.tsx
+++ b/packages/front-end/components/Experiment/NewExperimentForm.tsx
@@ -329,6 +329,7 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
                     <Field
                       label="Id"
                       {...form.register(`variations.${i}.key`)}
+                      placeholder={i + ""}
                     />
                   )}
                   <Field

--- a/packages/front-end/components/Experiment/Results.tsx
+++ b/packages/front-end/components/Experiment/Results.tsx
@@ -286,6 +286,7 @@ const Results: FC<{
             snapshot={snapshot}
             experiment={experiment}
             phase={experiment.phases?.[phase]}
+            isUpdating={status === "running"}
           />
           {experiment.guardrails?.length > 0 && (
             <div className="mb-3">


### PR DESCRIPTION
Currently shows a very confusing error message that tells you to update results, but that just gives you the same error message back.