### PR TITLE
Simplify handling of variation ids

### DIFF
--- a/config/config.sample.yml
+++ b/config/config.sample.yml
@@ -28,7 +28,6 @@ datasources:
             path as url
           FROM
             pages
-      variationIdFormat: index
       experimentDimensions:
         - country
 metrics:

--- a/packages/back-end/src/controllers/admin.ts
+++ b/packages/back-end/src/controllers/admin.ts
@@ -100,7 +100,6 @@ export async function addSampleData(req: AuthRequest, res: Response) {
   FROM
     pages`,
       },
-      variationIdFormat: "index",
     }
   );
   const integration = getSourceIntegrationObject(datasource);

--- a/packages/back-end/src/integrations/Mixpanel.ts
+++ b/packages/back-end/src/integrations/Mixpanel.ts
@@ -54,7 +54,6 @@ export default class Mixpanel implements SourceIntegrationInterface {
       encryptedParams
     );
     this.settings = {
-      variationIdFormat: settings.variationIdFormat || "index",
       events: {
         experimentEvent: "$experiment_started",
         experimentIdProperty: "Experiment name",

--- a/packages/back-end/src/models/DataSourceModel.ts
+++ b/packages/back-end/src/models/DataSourceModel.ts
@@ -38,7 +38,6 @@ const dataSourceSchema = new mongoose.Schema({
       pageviewEvent: String,
       urlProperty: String,
     },
-    variationIdFormat: String,
     experimentDimensions: [String],
 
     // Deprecated
@@ -54,7 +53,6 @@ const dataSourceSchema = new mongoose.Schema({
       anonymousIdColumn: String,
       experimentIdColumn: String,
       variationColumn: String,
-      variationFormat: String,
     },
     users: {
       table: String,

--- a/packages/back-end/src/services/notebook.ts
+++ b/packages/back-end/src/services/notebook.ts
@@ -83,11 +83,7 @@ export async function generateExperimentNotebook(
 
   const var_id_map: Record<string, number> = {};
   experiment.variations.forEach((v, i) => {
-    if (datasource.settings?.variationIdFormat === "key" && v.key) {
-      var_id_map[v.key] = i;
-    } else {
-      var_id_map[i + ""] = i;
-    }
+    var_id_map[v.key || i + ""] = i;
   });
 
   const data = JSON.stringify({

--- a/packages/back-end/src/services/queries.ts
+++ b/packages/back-end/src/services/queries.ts
@@ -255,7 +255,7 @@ export function processPastExperimentQueryResponse(
 function getVariationMap(experiment: ExperimentInterface) {
   const variationMap = new Map<string, number>();
   experiment.variations.forEach((v, i) => {
-    variationMap.set(v.key && v.key.length > 0 ? v.key : i + "", i);
+    variationMap.set(v.key || i + "", i);
   });
   return variationMap;
 }

--- a/packages/back-end/types/datasource.d.ts
+++ b/packages/back-end/types/datasource.d.ts
@@ -51,7 +51,6 @@ type WithParams<B, P> = Omit<B, "params"> & {
 };
 
 export type DataSourceSettings = {
-  variationIdFormat?: "key" | "index";
   experimentDimensions?: string[];
   notebookRunQuery?: string;
   queries?: {
@@ -77,7 +76,6 @@ export type DataSourceSettings = {
     anonymousIdColumn?: string;
     experimentIdColumn?: string;
     variationColumn?: string;
-    variationFormat?: "index" | "key";
   };
   users?: {
     table?: string;

--- a/packages/front-end/components/Experiment/AnalysisForm.tsx
+++ b/packages/front-end/components/Experiment/AnalysisForm.tsx
@@ -1,5 +1,5 @@
 import { FC } from "react";
-import { useForm } from "react-hook-form";
+import { useFieldArray, useForm } from "react-hook-form";
 import { useAuth } from "../../services/auth";
 import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
 import Modal from "../Modal";
@@ -46,9 +46,15 @@ const AnalysisForm: FC<{
       queryFilter: experiment.queryFilter || "",
       dateStarted: defaultDateStarted.toISOString().substr(0, 16),
       dateEnded: defaultDateEnded.toISOString().substr(0, 16),
+      variations: experiment.variations || [],
     },
   });
   const { apiCall } = useAuth();
+
+  const variations = useFieldArray({
+    control: form.control,
+    name: "variations",
+  });
 
   return (
     <Modal
@@ -94,6 +100,25 @@ const AnalysisForm: FC<{
         {...form.register("trackingKey")}
         helpText="Will match against the experiment_id column in your data source"
       />
+      <div className="form-group">
+        <label className="font-weight-bold">Variation Ids</label>
+        <div className="row align-items-top">
+          {variations.fields.map((v, i) => (
+            <div className="col-auto" key={i}>
+              <Field
+                label={v.name}
+                labelClassName="mb-0"
+                containerClassName="mb-1"
+                {...form.register(`variations.${i}.key`)}
+                placeholder={i + ""}
+              />
+            </div>
+          ))}
+        </div>
+        <small className="form-text text-muted">
+          Will match against the variation_id column in your data source
+        </small>
+      </div>
       {datasource?.properties?.userIds && (
         <Field
           label="User Id Column"

--- a/packages/front-end/components/Experiment/DataQualityWarning.tsx
+++ b/packages/front-end/components/Experiment/DataQualityWarning.tsx
@@ -6,10 +6,6 @@ import {
 import { ExperimentSnapshotInterface } from "back-end/types/experiment-snapshot";
 import SRMWarning from "./SRMWarning";
 import isEqual from "lodash/isEqual";
-import { useDefinitions } from "../../services/DefinitionsContext";
-import { useContext } from "react";
-import { UserContext } from "../ProtectedPage";
-import Link from "next/link";
 
 const CommaList: FC<{ vals: string[] }> = ({ vals }) => {
   if (!vals.length) {
@@ -34,10 +30,6 @@ const DataQualityWarning: FC<{
   phase?: ExperimentPhaseStringDates;
   isUpdating?: boolean;
 }> = ({ experiment, snapshot, phase, isUpdating }) => {
-  const { getDatasourceById } = useDefinitions();
-
-  const { permissions } = useContext(UserContext);
-
   if (!snapshot || !phase) return null;
   const results = snapshot.results[0];
   if (!results) return null;
@@ -48,9 +40,6 @@ const DataQualityWarning: FC<{
   if (phase.variationWeights.filter((x) => x < 0.02).length > 0) {
     return null;
   }
-
-  const datasource = getDatasourceById(experiment.datasource);
-  const hasStringKeys = datasource?.settings?.variationIdFormat === "key";
 
   // Minimum number of users required to do data quality checks
   let totalUsers = 0;
@@ -66,14 +55,13 @@ const DataQualityWarning: FC<{
 
   // Variations defined for the experiment
   const definedVariations: string[] = experiment.variations
-    .map((v, i) => (hasStringKeys ? v.key : null) || i + "")
+    .map((v, i) => v.key || i + "")
     .sort();
   // Variation ids returned from the query
   const returnedVariations: string[] = variations
     .map((v, i) => {
       return {
-        variation:
-          (hasStringKeys ? experiment.variations[i]?.key : null) || i + "",
+        variation: experiment.variations[i]?.key || i + "",
         hasData: v.users > 0,
       };
     })
@@ -99,28 +87,6 @@ const DataQualityWarning: FC<{
 
   // There are unknown variations
   if (snapshot.unknownVariations?.length > 0) {
-    // Data source is expecting numeric variation ids, but received string ids
-    if (
-      datasource &&
-      !hasStringKeys &&
-      snapshot.unknownVariations.filter((x) => isNaN(parseInt(x))).length > 0
-    ) {
-      return (
-        <div className="alert alert-warning">
-          <strong>Warning:</strong> Your data source is configured to expect
-          numeric Variation Ids (<CommaList vals={definedVariations} />
-          ), but it returned strings instead (
-          <CommaList vals={returnedVariations} />
-          ).{" "}
-          {permissions.organizationSettings && (
-            <Link href={`/datasources/${datasource.id}`}>
-              <a>View settings</a>
-            </Link>
-          )}
-        </div>
-      );
-    }
-
     return (
       <div className="alert alert-warning">
         <strong>Warning:</strong> Expected {experiment.variations.length}{" "}
@@ -139,7 +105,12 @@ const DataQualityWarning: FC<{
   if (definedVariations.length > returnedVariations.length) {
     return (
       <div className="alert alert-warning">
-        <strong>Warning</strong>: Missing data from one or more variations.
+        <strong>Warning</strong>: Missing data from the following variation ids:{" "}
+        <CommaList
+          vals={definedVariations.filter(
+            (v) => !returnedVariations.includes(v)
+          )}
+        />
       </div>
     );
   }

--- a/packages/front-end/components/Experiment/EditInfoForm.tsx
+++ b/packages/front-end/components/Experiment/EditInfoForm.tsx
@@ -9,7 +9,6 @@ import {
 import MarkdownInput from "../Markdown/MarkdownInput";
 import Modal from "../Modal";
 import dJSON from "dirty-json";
-import { useDefinitions } from "../../services/DefinitionsContext";
 import { UserContext } from "../ProtectedPage";
 import RadioSelector from "../Forms/RadioSelector";
 import Field from "../Forms/Field";
@@ -23,7 +22,6 @@ const EditInfoForm: FC<{
     settings: { visualEditorEnabled },
   } = useContext(UserContext);
 
-  const { getDatasourceById } = useDefinitions();
   const form = useForm<Partial<ExperimentInterfaceStringDates>>({
     defaultValues: {
       name: experiment.name || "",
@@ -66,11 +64,6 @@ const EditInfoForm: FC<{
   });
 
   const implementation = form.watch("implementation");
-
-  const datasource = getDatasourceById(experiment.datasource);
-  const variationKeys =
-    (datasource?.settings?.variationIdFormat ||
-      datasource?.settings?.experiments?.variationFormat) === "key";
 
   return (
     <Modal
@@ -180,13 +173,11 @@ const EditInfoForm: FC<{
                   label={i === 0 ? "Control Name" : `Variation ${i} Name`}
                   {...form.register(`variations.${i}.name`)}
                 />
-                {variationKeys && (
-                  <Field
-                    label="Id"
-                    {...form.register(`variations.${i}.key`)}
-                    placeholder={i + ""}
-                  />
-                )}
+                <Field
+                  label="Id"
+                  {...form.register(`variations.${i}.key`)}
+                  placeholder={i + ""}
+                />
                 <Field
                   label="Description"
                   textarea

--- a/packages/front-end/components/Experiment/NewExperimentForm.tsx
+++ b/packages/front-end/components/Experiment/NewExperimentForm.tsx
@@ -145,9 +145,6 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
   });
 
   const datasource = getDatasourceById(form.watch("datasource"));
-  const variationKeys =
-    (datasource?.settings?.variationIdFormat ||
-      datasource?.settings?.experiments?.variationFormat) === "key";
 
   const { apiCall } = useAuth();
 
@@ -326,13 +323,11 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
                     label={i === 0 ? "Control Name" : `Variation ${i} Name`}
                     {...form.register(`variations.${i}.name`)}
                   />
-                  {variationKeys && (
-                    <Field
-                      label="Id"
-                      {...form.register(`variations.${i}.key`)}
-                      placeholder={i + ""}
-                    />
-                  )}
+                  <Field
+                    label="Id"
+                    {...form.register(`variations.${i}.key`)}
+                    placeholder={i + ""}
+                  />
                   <Field
                     label="Description"
                     {...form.register(`variations.${i}.description`)}

--- a/packages/front-end/components/Settings/EditDataSourceSettingsForm.tsx
+++ b/packages/front-end/components/Settings/EditDataSourceSettingsForm.tsx
@@ -58,10 +58,6 @@ const EditDataSourceSettingsForm: FC<{
             urlProperty: "",
             ...data?.settings?.events,
           },
-          variationIdFormat:
-            data?.settings?.variationIdFormat ||
-            data?.settings?.experiments?.variationFormat ||
-            "index",
         },
       };
       setDatasource(newValue);
@@ -186,29 +182,6 @@ const EditDataSourceSettingsForm: FC<{
               placeholder="Variant name"
               value={datasource.settings?.events?.variationIdProperty}
             />
-          </div>
-
-          <div className="form-group">
-            <label>Variation Id Format</label>
-            <select
-              className="form-control"
-              name="variationFormat"
-              onChange={(e) => {
-                setDatasource({
-                  ...datasource,
-                  settings: {
-                    ...datasource.settings,
-                    variationIdFormat: e.target.value as "index" | "key",
-                  },
-                });
-                setDirty(true);
-              }}
-              required
-              value={datasource.settings?.variationIdFormat || "index"}
-            >
-              <option value="index">(0=control, 1=1st variation, ...)</option>
-              <option value="key">Unique String Keys</option>
-            </select>
           </div>
           <hr />
           <h4 className="font-weight-bold">Page Views</h4>
@@ -352,45 +325,6 @@ FROM
                 <p>
                   List any columns from the above query here that you want to
                   use as dimensions to drill down into experiment results.
-                </p>
-              </div>
-            </div>
-          </div>
-
-          <div className="row mb-3">
-            <div className="col">
-              <div className="form-group">
-                <label className="font-weight-bold">Variation Id Format</label>
-                <select
-                  className="form-control"
-                  name="variationFormat"
-                  onChange={(e) => {
-                    setDatasource({
-                      ...datasource,
-                      settings: {
-                        ...datasource.settings,
-                        variationIdFormat: e.target.value as "index" | "key",
-                      },
-                    });
-                    setDirty(true);
-                  }}
-                  required
-                  value={datasource.settings?.variationIdFormat || "index"}
-                >
-                  <option value="index">Array Index</option>
-                  <option value="key">String Keys</option>
-                </select>
-              </div>
-            </div>
-            <div className="col-md-5 col-lg-4">
-              <div className="pt-md-3">
-                <p>
-                  <strong>Array Index</strong> (<code>0</code>, <code>1</code>,{" "}
-                  <code>2</code>, etc.)
-                </p>
-                <p>
-                  <strong>String Keys</strong> (<code>blue-buttons</code>,{" "}
-                  <code>control</code>, etc.)
                 </p>
               </div>
             </div>

--- a/packages/front-end/pages/datasources/[did].tsx
+++ b/packages/front-end/pages/datasources/[did].tsx
@@ -163,19 +163,8 @@ const DataSourcePage: FC = () => {
                     (d.params as PostgresConnectionParams)?.defaultSchema
                   )}
                 />
-                <div className="mt-2">
-                  <div>
-                    <strong>Variation Id Format:</strong>{" "}
-                    {d.settings?.variationIdFormat === "key" ? (
-                      "String Keys"
-                    ) : (
-                      <>
-                        Array Index (<code>0</code> = control, <code>1</code> =
-                        1st variation, etc.)
-                      </>
-                    )}
-                  </div>
-                  {d.settings?.experimentDimensions?.length > 0 && (
+                {d.settings?.experimentDimensions?.length > 0 && (
+                  <div className="mt-2">
                     <div>
                       <strong>Dimension Columns:</strong>{" "}
                       {d.settings.experimentDimensions.map((d) => (
@@ -184,8 +173,8 @@ const DataSourcePage: FC = () => {
                         </code>
                       ))}
                     </div>
-                  )}
-                </div>
+                  </div>
+                )}
               </div>
               <div className="mb-4">
                 <h3>Pageviews Query</h3>

--- a/packages/front-end/pages/dimensions/index.tsx
+++ b/packages/front-end/pages/dimensions/index.tsx
@@ -193,7 +193,7 @@ const DimensionsPage: FC = () => {
         </p>
 
         {permissions.organizationSettings && (
-          <Link href="/settings/datasources">
+          <Link href="/datasources">
             <a className="btn btn-outline-primary">View Data Sources</a>
           </Link>
         )}

--- a/packages/front-end/pages/experiment/[eid].tsx
+++ b/packages/front-end/pages/experiment/[eid].tsx
@@ -528,12 +528,7 @@ const ExperimentPage = (): ReactElement => {
                         <strong>{v.name}</strong>{" "}
                       </div>
                       <div className="mb-1">
-                        <small className="text-muted">
-                          id:{" "}
-                          {(datasource?.settings?.variationIdFormat === "key" &&
-                            v.key) ||
-                            i}
-                        </small>
+                        <small className="text-muted">id: {v.key || i}</small>
                       </div>
                       {v.description && <p>{v.description}</p>}
                       {v.value && experiment.implementation !== "visual" && (

--- a/packages/front-end/services/config.ts
+++ b/packages/front-end/services/config.ts
@@ -43,9 +43,7 @@ export function useConfigJson({
         type: d.type,
         name: d.name,
         params: d.params,
-        settings: {
-          variationIdFormat: d.settings.variationIdFormat ?? "index",
-        },
+        settings: {},
       } as Partial<DataSourceInterfaceWithParams>;
 
       if (d.type === "google_analytics") return;


### PR DESCRIPTION
Fixes #108 

Changes
-  [x] Remove variationIdFormat setting from data sources
-  [x] Assume string keys (with array index fallback) throughout code base
-  [x] Allow changing variation ids within "Configure Analysis" modal
-  [x] List specific missing variation ids instead of just saying "one or more are missing"
-  [x] Throw error when trying to save an experiment with duplicate variation ids