### PR TITLE
New built-in dimension for Activation Metric Status

### DIFF
--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -1756,9 +1756,10 @@ export async function postSnapshot(
         type: "experiment",
         id: dimension.substr(4),
       };
-    } else if (dimension === "pre:date") {
+    } else if (dimension.substr(0, 4) === "pre:") {
       dimensionArg = {
-        type: "date",
+        // eslint-disable-next-line
+        type: dimension.substr(4) as any,
       };
     } else {
       const obj = await findDimensionById(dimension, org.id);

--- a/packages/back-end/src/integrations/ClickHouse.ts
+++ b/packages/back-end/src/integrations/ClickHouse.ts
@@ -76,4 +76,7 @@ export default class ClickHouse extends SqlIntegration {
   formatDate(col: string): string {
     return `formatDateTime(${col}, '%F')`;
   }
+  ifElse(condition: string, ifTrue: string, ifFalse: string) {
+    return `if(${condition}, ${ifTrue}, ${ifFalse})`;
+  }
 }

--- a/packages/back-end/src/types/Integration.ts
+++ b/packages/back-end/src/types/Integration.ts
@@ -70,7 +70,14 @@ export type ExperimentDimension = {
 export type DateDimension = {
   type: "date";
 };
-export type Dimension = UserDimension | ExperimentDimension | DateDimension;
+export type ActivationDimension = {
+  type: "activation";
+};
+export type Dimension =
+  | UserDimension
+  | ExperimentDimension
+  | DateDimension
+  | ActivationDimension;
 
 export type ExperimentUsersQueryParams = {
   experiment: ExperimentInterface;

--- a/packages/back-end/types/datasource.d.ts
+++ b/packages/back-end/types/datasource.d.ts
@@ -40,6 +40,7 @@ export interface DataSourceProperties {
   experimentSegments?: boolean;
   dimensions?: boolean;
   hasSettings?: boolean;
+  activationDimension?: boolean;
   events?: boolean;
   userIds?: boolean;
   separateExperimentResultQueries?: boolean;

--- a/packages/front-end/components/Experiment/AnalysisSettingsBar.tsx
+++ b/packages/front-end/components/Experiment/AnalysisSettingsBar.tsx
@@ -130,6 +130,10 @@ export default function AnalysisSettingsBar({
               {supportsSql && (
                 <optgroup label="Built-in">
                   <option value="pre:date">Date</option>
+                  {datasource?.properties?.activationDimension &&
+                    experiment.activationMetric && (
+                      <option value="pre:activation">Activation Status</option>
+                    )}
                 </optgroup>
               )}
               {filteredDimensions.length > 0 && (

--- a/packages/front-end/components/Experiment/AnalysisSettingsBar.tsx
+++ b/packages/front-end/components/Experiment/AnalysisSettingsBar.tsx
@@ -67,11 +67,7 @@ export default function AnalysisSettingsBar({
 
   // If an experiment doesn't have an activation metric, don't allow selecting it
   useEffect(() => {
-    if (
-      dimension &&
-      dimension === "pre:activation" &&
-      !experiment.activationMetric
-    ) {
+    if (dimension === "pre:activation" && !experiment.activationMetric) {
       setDimension("");
     }
   }, [dimension, experiment.activationMetric]);

--- a/packages/front-end/components/Experiment/AnalysisSettingsBar.tsx
+++ b/packages/front-end/components/Experiment/AnalysisSettingsBar.tsx
@@ -1,7 +1,7 @@
 import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
 import { ExperimentSnapshotInterface } from "back-end/types/experiment-snapshot";
 import clsx from "clsx";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useContext } from "react";
 import { FaCog } from "react-icons/fa";
 import { useAuth } from "../../services/auth";
@@ -64,6 +64,17 @@ export default function AnalysisSettingsBar({
   const supportsSql = datasource?.properties?.queryLanguage === "sql";
   const outdated = isOutdated(experiment, snapshot);
   const [modalOpen, setModalOpen] = useState(false);
+
+  // If an experiment doesn't have an activation metric, don't allow selecting it
+  useEffect(() => {
+    if (
+      dimension &&
+      dimension === "pre:activation" &&
+      !experiment.activationMetric
+    ) {
+      setDimension("");
+    }
+  }, [dimension, experiment.activationMetric]);
 
   const { permissions } = useContext(UserContext);
 

--- a/packages/front-end/components/Experiment/BreakDownResults.tsx
+++ b/packages/front-end/components/Experiment/BreakDownResults.tsx
@@ -88,17 +88,14 @@ const BreakDownResults: FC<{
   return (
     <div className="mb-3">
       <div className="mb-4 px-3">
-        {snapshot.dimension === "pre:activation" &&
-          experiment.activationMetric && (
-            <div className="alert alert-info mt-1">
-              Your experiment has an Activation Metric (
-              <strong>
-                {getMetricById(experiment.activationMetric)?.name}
-              </strong>
-              ). This report lets you compare activated users with those who
-              entered into the experiment, but were not activated.
-            </div>
-          )}
+        {snapshot.dimension === "pre:activation" && snapshot.activationMetric && (
+          <div className="alert alert-info mt-1">
+            Your experiment has an Activation Metric (
+            <strong>{getMetricById(snapshot.activationMetric)?.name}</strong>
+            ). This report lets you compare activated users with those who
+            entered into the experiment, but were not activated.
+          </div>
+        )}
         <h2>Users</h2>
         <table className="table w-auto table-bordered mb-5">
           <thead>

--- a/packages/front-end/components/Experiment/BreakDownResults.tsx
+++ b/packages/front-end/components/Experiment/BreakDownResults.tsx
@@ -1,7 +1,7 @@
 import { FC, useMemo, useState } from "react";
 import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
 import { ExperimentSnapshotInterface } from "back-end/types/experiment-snapshot";
-import { FaExclamationTriangle } from "react-icons/fa";
+import { FaExclamationTriangle, FaQuestionCircle } from "react-icons/fa";
 import { useDefinitions } from "../../services/DefinitionsContext";
 import {
   ExperimentTableRow,
@@ -10,6 +10,7 @@ import {
 import ResultsTable from "./ResultsTable";
 import { MetricInterface } from "../../../back-end/types/metric";
 import Toggle from "../Forms/Toggle";
+import Tooltip from "../Tooltip";
 
 const FULL_STATS_LIMIT = 5;
 
@@ -45,7 +46,6 @@ const BreakDownResults: FC<{
   snapshot: ExperimentSnapshotInterface;
   experiment: ExperimentInterfaceStringDates;
 }> = ({ snapshot, experiment }) => {
-  const srmFailures = snapshot.results.filter((r) => r.srm <= 0.001);
   const { getDimensionById, getMetricById } = useDefinitions();
 
   const dimension = useMemo(() => {
@@ -87,61 +87,71 @@ const BreakDownResults: FC<{
 
   return (
     <div className="mb-3">
-      {srmFailures.length > 0 && (
-        <div className="mb-4">
-          <div className="px-3">
-            <h2>Users</h2>
-            <div className="alert alert-danger">
-              The following dimension values failed the Sample Ratio Mismatch
-              (SRM) check. This means the traffic split between the variations
-              was not what we expected. This is likely a bug.
+      <div className="mb-4 px-3">
+        {snapshot.dimension === "pre:activation" &&
+          experiment.activationMetric && (
+            <div className="alert alert-info mt-1">
+              Your experiment has an Activation Metric (
+              <strong>
+                {getMetricById(experiment.activationMetric)?.name}
+              </strong>
+              ). This report lets you compare activated users with those who
+              entered into the experiment, but were not activated.
             </div>
-          </div>
-          <table className="table w-auto table-bordered">
-            <thead>
-              <tr>
-                <th>{dimension}</th>
+          )}
+        <h2>Users</h2>
+        <table className="table w-auto table-bordered mb-5">
+          <thead>
+            <tr>
+              <th>{dimension}</th>
+              {experiment.variations.map((v, i) => (
+                <th key={i}>{v.name}</th>
+              ))}
+              <th>Expected</th>
+              <th>Actual</th>
+              <th>
+                SRM P-Value{" "}
+                <Tooltip text="Sample Ratio Mismatch (SRM) occurs when the actual traffic split is not what we expect. A small value (<0.001) indicates a likely bug.">
+                  <FaQuestionCircle />
+                </Tooltip>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {snapshot.results?.map((r, i) => (
+              <tr key={i}>
+                <td>{r.name || <em>unknown</em>}</td>
                 {experiment.variations.map((v, i) => (
-                  <th key={i}>{v.name}</th>
+                  <td key={i}>
+                    {numberFormatter.format(r.variations[i]?.users || 0)}
+                  </td>
                 ))}
-                <th>Expected</th>
-                <th>Actual</th>
-                <th>SRM P-Value</th>
-              </tr>
-            </thead>
-            <tbody>
-              {srmFailures.map((r, i) => (
-                <tr key={i}>
-                  <td>{r.name || <em>unknown</em>}</td>
-                  {experiment.variations.map((v, i) => (
-                    <td key={i}>
-                      {numberFormatter.format(r.variations[i]?.users || 0)}
-                    </td>
-                  ))}
-                  <td>
-                    {getAllocationText(
-                      experiment.phases[snapshot.phase]?.variationWeights || []
-                    )}
-                  </td>
-                  <td>
-                    {getAllocationText(
-                      experiment.variations.map(
-                        (v, i) => r.variations[i]?.users || 0
-                      )
-                    )}
-                  </td>
+                <td>
+                  {getAllocationText(
+                    experiment.phases[snapshot.phase]?.variationWeights || []
+                  )}
+                </td>
+                <td>
+                  {getAllocationText(
+                    experiment.variations.map(
+                      (v, i) => r.variations[i]?.users || 0
+                    )
+                  )}
+                </td>
+                {r.srm < 0.001 ? (
                   <td className="bg-danger text-light">
                     <FaExclamationTriangle className="mr-1" />
                     {(r.srm || 0).toFixed(6)}
                   </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-          <hr />
-          <h2>Metrics</h2>
-        </div>
-      )}
+                ) : (
+                  <td>{(r.srm || 0).toFixed(6)}</td>
+                )}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <h2>Metrics</h2>
+      </div>
 
       {tooManyDimensions && (
         <div className="row align-items-center mb-3 px-3">


### PR DESCRIPTION
TODO:
- [x] Add "Activation Status" to dimension dropdown when appropriate
- [x] Modify SQL when dimension is selected
- [x] Explanation message on front-end
- [x] When activation metric is removed from an experiment, switch dimension dropdown to "none"
- [x] Show activation metric name from the snapshot instead of the experiment (in case results are out of date)

Fixes #85