### PR TITLE
Protect against invalid Date objects

### DIFF
--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -65,6 +65,7 @@ import { getDataSourceById } from "../models/DataSourceModel";
 import { generateExperimentNotebook } from "../services/notebook";
 import { SegmentModel } from "../models/SegmentModel";
 import { getAdjustedStats } from "../services/stats";
+import { getValidDate } from "../util/dates";
 
 export async function getExperiments(req: AuthRequest, res: Response) {
   const { org } = getOrgFromReq(req);
@@ -128,7 +129,7 @@ export async function getExperimentsFrequencyMonth(
         }
       });
     }
-    const monthYear = format(new Date(dateStarted || new Date()), "MMM yyy");
+    const monthYear = format(getValidDate(dateStarted), "MMM yyy");
 
     allData.forEach((md, i) => {
       if (md.name === monthYear) {
@@ -572,10 +573,10 @@ export async function postExperiment(
     phases[Math.floor(currentPhase * 1)] = phaseClone;
 
     if (phaseStartDate) {
-      phaseClone.dateStarted = new Date(phaseStartDate + ":00Z");
+      phaseClone.dateStarted = getValidDate(phaseStartDate + ":00Z");
     }
     if (exp.status === "stopped" && phaseEndDate) {
-      phaseClone.dateEnded = new Date(phaseEndDate + ":00Z");
+      phaseClone.dateEnded = getValidDate(phaseEndDate + ":00Z");
     }
     exp.set("phases", phases);
   }
@@ -735,7 +736,7 @@ export async function postExperimentStop(
   if (phases.length) {
     phases[phases.length - 1] = {
       ...phases[phases.length - 1],
-      dateEnded: dateEnded ? new Date(dateEnded + ":00Z") : new Date(),
+      dateEnded: dateEnded ? getValidDate(dateEnded + ":00Z") : new Date(),
       reason,
     };
     exp.set("phases", phases);
@@ -903,7 +904,7 @@ export async function postExperimentPhase(
     return;
   }
 
-  const date = dateStarted ? new Date(dateStarted + ":00Z") : new Date();
+  const date = dateStarted ? getValidDate(dateStarted + ":00Z") : new Date();
 
   const phases = [...exp.toJSON().phases];
   // Already has phases
@@ -1162,7 +1163,7 @@ async function getMetricAnalysis(
       total += dateTotal;
       count += d.count || 0;
       dates.push({
-        d: new Date(d.date),
+        d: getValidDate(d.date),
         v: mean,
         u: averageBase,
         s: stddev,

--- a/packages/back-end/src/integrations/BigQuery.ts
+++ b/packages/back-end/src/integrations/BigQuery.ts
@@ -2,6 +2,7 @@ import { decryptDataSourceParams } from "../services/datasource";
 import * as bq from "@google-cloud/bigquery";
 import SqlIntegration from "./SqlIntegration";
 import { BigQueryConnectionParams } from "../../types/integrations/bigquery";
+import { getValidDate } from "../util/dates";
 
 export default class BigQuery extends SqlIntegration {
   params: BigQueryConnectionParams;
@@ -47,7 +48,7 @@ export default class BigQuery extends SqlIntegration {
     )})]`;
   }
   convertDate(fromDB: bq.BigQueryDatetime) {
-    return new Date(fromDB.value + "Z");
+    return getValidDate(fromDB.value + "Z");
   }
   dateTrunc(col: string) {
     return `date_trunc(${col}, DAY)`;

--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -28,6 +28,7 @@ import {
   processMetricValueQueryResponse,
   processUsersQueryResponse,
 } from "../services/queries";
+import { getValidDate } from "../util/dates";
 
 const percentileNumbers = [
   0.01,
@@ -171,7 +172,7 @@ export default abstract class SqlIntegration
   }
   // eslint-disable-next-line
   convertDate(fromDB: any): Date {
-    return new Date(fromDB);
+    return getValidDate(fromDB);
   }
   stddev(col: string) {
     return `STDDEV(${col})`;

--- a/packages/back-end/src/services/queries.ts
+++ b/packages/back-end/src/services/queries.ts
@@ -28,6 +28,7 @@ import {
 import { ExperimentInterface, ExperimentPhase } from "../../types/experiment";
 import { MetricInterface, MetricStats } from "../../types/metric";
 import { DimensionInterface } from "../../types/dimension";
+import { getValidDate } from "../util/dates";
 export type QueryMap = Map<string, QueryInterface>;
 
 export type InterfaceWithQueries = {
@@ -245,8 +246,8 @@ export function processPastExperimentQueryResponse(
         users: row.users,
         experiment_id: row.experiment_id,
         variation_id: row.variation_id,
-        end_date: new Date(row.end_date),
-        start_date: new Date(row.start_date),
+        end_date: getValidDate(row.end_date),
+        start_date: getValidDate(row.start_date),
       };
     }),
   };

--- a/packages/back-end/src/util/dates.ts
+++ b/packages/back-end/src/util/dates.ts
@@ -1,0 +1,11 @@
+export function getValidDate(dateStr: string | Date | null, fallback?: Date) {
+  fallback = fallback || new Date();
+
+  if (!dateStr) return fallback;
+
+  const d = new Date(dateStr);
+  if (isNaN(d.getTime())) {
+    return fallback;
+  }
+  return d;
+}

--- a/packages/front-end/components/Experiment/AnalysisForm.tsx
+++ b/packages/front-end/components/Experiment/AnalysisForm.tsx
@@ -5,6 +5,7 @@ import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
 import Modal from "../Modal";
 import { useDefinitions } from "../../services/DefinitionsContext";
 import Field from "../Forms/Field";
+import { getValidDate } from "../../services/dates";
 
 const AnalysisForm: FC<{
   experiment: ExperimentInterfaceStringDates;
@@ -26,17 +27,6 @@ const AnalysisForm: FC<{
 
   const phaseObj = experiment.phases[phase];
 
-  let defaultDateStarted = new Date(phaseObj?.dateStarted || Date.now());
-  // check for a valid date:
-  if (!+defaultDateStarted) {
-    defaultDateStarted = new Date();
-  }
-  let defaultDateEnded = new Date(phaseObj?.dateEnded || Date.now());
-  // check for a valid date:
-  if (!+defaultDateEnded) {
-    defaultDateEnded = new Date();
-  }
-
   const form = useForm({
     defaultValues: {
       userIdType: experiment.userIdType || "anonymous",
@@ -44,8 +34,10 @@ const AnalysisForm: FC<{
       activationMetric: experiment.activationMetric || "",
       segment: experiment.segment || "",
       queryFilter: experiment.queryFilter || "",
-      dateStarted: defaultDateStarted.toISOString().substr(0, 16),
-      dateEnded: defaultDateEnded.toISOString().substr(0, 16),
+      dateStarted: getValidDate(phaseObj?.dateStarted)
+        .toISOString()
+        .substr(0, 16),
+      dateEnded: getValidDate(phaseObj?.dateEnded).toISOString().substr(0, 16),
       variations: experiment.variations || [],
     },
   });

--- a/packages/front-end/components/Experiment/DateResults.tsx
+++ b/packages/front-end/components/Experiment/DateResults.tsx
@@ -9,6 +9,7 @@ import ExperimentDateGraph, {
 import { formatConversionRate } from "../../services/metrics";
 import { useState } from "react";
 import Toggle from "../Forms/Toggle";
+import { getValidDate } from "../../services/dates";
 
 const percentFormatter = new Intl.NumberFormat(undefined, {
   style: "percent",
@@ -37,12 +38,12 @@ const DateResults: FC<{
     const total: number[] = [];
     const sortedResults = [...snapshot.results];
     sortedResults.sort((a, b) => {
-      return new Date(a.name).getTime() - new Date(b.name).getTime();
+      return getValidDate(a.name).getTime() - getValidDate(b.name).getTime();
     });
 
     return sortedResults.map((d) => {
       return {
-        d: new Date(d.name),
+        d: getValidDate(d.name),
         variations: experiment.variations.map((v, i) => {
           const users = d.variations[i]?.users || 0;
           total[i] = total[i] || 0;
@@ -61,7 +62,7 @@ const DateResults: FC<{
   const metrics = useMemo<Metric[]>(() => {
     const sortedResults = [...snapshot.results];
     sortedResults.sort((a, b) => {
-      return new Date(a.name).getTime() - new Date(b.name).getTime();
+      return getValidDate(a.name).getTime() - getValidDate(b.name).getTime();
     });
 
     // Merge goal and guardrail metrics
@@ -77,7 +78,7 @@ const DateResults: FC<{
 
           const datapoints = sortedResults.map((d) => {
             return {
-              d: new Date(d.name),
+              d: getValidDate(d.name),
               variations: experiment.variations.map((v, i) => {
                 const stats = d.variations[i]?.metrics?.[metricId];
                 const uplift = stats?.uplift;

--- a/packages/front-end/components/Experiment/ExperimentGraph.tsx
+++ b/packages/front-end/components/Experiment/ExperimentGraph.tsx
@@ -9,6 +9,7 @@ import { scaleLinear, scaleTime } from "@visx/scale";
 import { GridRows } from "@visx/grid";
 import format from "date-fns/format";
 import { useDefinitions } from "../../services/DefinitionsContext";
+import { getValidDate } from "../../services/dates";
 
 export default function ExperimentGraph({
   resolution = "month",
@@ -49,8 +50,8 @@ export default function ExperimentGraph({
     return <div>no data to show</div>;
   }
 
-  const firstMonth = new Date(graphData[0].name);
-  const lastMonth = new Date(graphData[graphData.length - 1].name);
+  const firstMonth = getValidDate(graphData[0].name);
+  const lastMonth = getValidDate(graphData[graphData.length - 1].name);
 
   return (
     <ParentSizeModern>
@@ -83,7 +84,7 @@ export default function ExperimentGraph({
                 width={xMax + barWidth / 2}
               />
               {graphData.map((d, i) => {
-                const barX = xScale(new Date(d.name)) - barWidth / 2;
+                const barX = xScale(getValidDate(d.name)) - barWidth / 2;
                 const barHeight = yMax - (yScale(d.numExp) ?? 0);
                 const barY = yMax - barHeight;
                 return (

--- a/packages/front-end/components/Experiment/NewExperimentForm.tsx
+++ b/packages/front-end/components/Experiment/NewExperimentForm.tsx
@@ -21,6 +21,7 @@ import { useContext } from "react";
 import { UserContext } from "../ProtectedPage";
 import RadioSelector from "../Forms/RadioSelector";
 import Field from "../Forms/Field";
+import { getValidDate } from "../../services/dates";
 
 const weekAgo = new Date();
 weekAgo.setDate(weekAgo.getDate() - 7);
@@ -90,12 +91,10 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
     ? [
         {
           coverage: 1,
-          dateStarted: new Date(
-            initialValue.phases?.[0]?.dateStarted || Date.now()
-          )
+          dateStarted: getValidDate(initialValue.phases?.[0]?.dateStarted)
             .toISOString()
             .substr(0, 16),
-          dateEnded: new Date(initialValue.phases?.[0]?.dateEnded || Date.now())
+          dateEnded: getValidDate(initialValue.phases?.[0]?.dateEnded)
             .toISOString()
             .substr(0, 16),
           phase: "main",

--- a/packages/front-end/components/Experiment/NotEnoughData.tsx
+++ b/packages/front-end/components/Experiment/NotEnoughData.tsx
@@ -1,4 +1,5 @@
 import { formatDistance } from "date-fns";
+import { getValidDate } from "../../services/dates";
 
 export default function NotEnoughData({
   phaseStart,
@@ -21,11 +22,11 @@ export default function NotEnoughData({
     Math.max(variationValue, baselineValue) / minSampleSize
   );
 
-  const snapshotCreatedTime = new Date(snapshotCreated).getTime();
+  const snapshotCreatedTime = getValidDate(snapshotCreated).getTime();
 
   const msRemaining =
     percentComplete > 0.1
-      ? ((snapshotCreatedTime - new Date(phaseStart).getTime()) *
+      ? ((snapshotCreatedTime - getValidDate(phaseStart).getTime()) *
           (1 - percentComplete)) /
           percentComplete -
         (Date.now() - snapshotCreatedTime)

--- a/packages/front-end/components/Experiment/Results.tsx
+++ b/packages/front-end/components/Experiment/Results.tsx
@@ -14,7 +14,7 @@ import GuardrailResults from "./GuardrailResult";
 import ViewAsyncQueriesButton from "../Queries/ViewAsyncQueriesButton";
 import { getQueryStatus } from "../Queries/RunQueriesButton";
 import { useAuth } from "../../services/auth";
-import { ago } from "../../services/dates";
+import { ago, getValidDate } from "../../services/dates";
 import Button from "../Button";
 import { useEffect } from "react";
 import DateResults from "./DateResults";
@@ -85,7 +85,7 @@ const Results: FC<{
 
   const phaseAgeMinutes =
     (Date.now() -
-      new Date(experiment.phases?.[phase]?.dateStarted || 0).getTime()) /
+      getValidDate(experiment.phases?.[phase]?.dateStarted).getTime()) /
     (1000 * 60);
 
   return (

--- a/packages/front-end/components/Metrics/DateGraph.tsx
+++ b/packages/front-end/components/Metrics/DateGraph.tsx
@@ -2,7 +2,7 @@ import styles from "./DateGraph.module.scss";
 import { MetricType } from "back-end/types/metric";
 import { FC, useMemo } from "react";
 import { formatConversionRate } from "../../services/metrics";
-import { date } from "../../services/dates";
+import { date, getValidDate } from "../../services/dates";
 import { ParentSizeModern } from "@visx/responsive";
 import { Group } from "@visx/group";
 import { GridColumns, GridRows } from "@visx/grid";
@@ -76,8 +76,8 @@ const DateGraph: FC<{
             { d, v, u, s }
           ) => {
             const key = (groupby === "day"
-              ? new Date(d)
-              : setDay(new Date(d), 0)
+              ? getValidDate(d)
+              : setDay(getValidDate(d), 0)
             ).getTime();
 
             const users = u || 1;

--- a/packages/front-end/components/Queries/ExpandableQuery.tsx
+++ b/packages/front-end/components/Queries/ExpandableQuery.tsx
@@ -4,6 +4,7 @@ import { formatDistanceStrict } from "date-fns";
 import { FaCircle, FaExclamationTriangle, FaCheck } from "react-icons/fa";
 import Code from "../Code";
 import clsx from "clsx";
+import { getValidDate } from "../../services/dates";
 
 const ExpandableQuery: FC<{
   query: QueryInterface;
@@ -103,8 +104,8 @@ const ExpandableQuery: FC<{
           <em>
             Took{" "}
             {formatDistanceStrict(
-              new Date(query.startedAt),
-              new Date(query.finishedAt)
+              getValidDate(query.startedAt),
+              getValidDate(query.finishedAt)
             )}
           </em>
         </small>
@@ -113,7 +114,7 @@ const ExpandableQuery: FC<{
         <div className="alert alert-info">
           <em>
             Running for{" "}
-            {formatDistanceStrict(new Date(query.startedAt), new Date())}
+            {formatDistanceStrict(getValidDate(query.startedAt), new Date())}
           </em>
         </div>
       )}

--- a/packages/front-end/components/Share/ShareModal.tsx
+++ b/packages/front-end/components/Share/ShareModal.tsx
@@ -9,7 +9,7 @@ import { useAuth } from "../../services/auth";
 import Tabs from "../Tabs/Tabs";
 import Tab from "../Tabs/Tab";
 import Preview from "./Preview";
-import { ago, datetime } from "../../services/dates";
+import { ago, datetime, getValidDate } from "../../services/dates";
 import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
 import {
   PresentationInterface,
@@ -382,10 +382,12 @@ const ShareModal = ({
               {byStatus[status]
                 .sort(
                   (a, b) =>
-                    new Date(
+                    getValidDate(
                       b.phases[b.phases.length - 1]?.dateEnded
                     ).getTime() -
-                    new Date(a.phases[a.phases.length - 1]?.dateEnded).getTime()
+                    getValidDate(
+                      a.phases[a.phases.length - 1]?.dateEnded
+                    ).getTime()
                 )
                 .map((e: ExperimentInterfaceStringDates) => {
                   const phase = e.phases[e.phases.length - 1];

--- a/packages/front-end/pages/experiments/import/[id].tsx
+++ b/packages/front-end/pages/experiments/import/[id].tsx
@@ -10,7 +10,7 @@ import RunQueriesButton, {
 import ViewAsyncQueriesButton from "../../../components/Queries/ViewAsyncQueriesButton";
 import useApi from "../../../hooks/useApi";
 import { useAuth } from "../../../services/auth";
-import { date } from "../../../services/dates";
+import { date, getValidDate } from "../../../services/dates";
 import { PastExperimentsInterface } from "back-end/types/past-experiments";
 import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
 import { useDefinitions } from "../../../services/DefinitionsContext";
@@ -193,18 +193,18 @@ const ImportPage: FC = () => {
                                 reason: "",
                                 variationWeights: e.weights,
                                 dateStarted:
-                                  new Date(e.startDate)
+                                  getValidDate(e.startDate)
                                     .toISOString()
                                     .substr(0, 10) + "T00:00:00Z",
                                 dateEnded:
-                                  new Date(e.endDate)
+                                  getValidDate(e.endDate)
                                     .toISOString()
                                     .substr(0, 10) + "T23:59:59Z",
                               },
                             ],
                             // Default to stopped if the last data was more than 3 days ago
                             status:
-                              new Date(e.endDate).getTime() <
+                              getValidDate(e.endDate).getTime() <
                               Date.now() - 72 * 60 * 60 * 1000
                                 ? "stopped"
                                 : "running",

--- a/packages/front-end/pages/experiments/index.tsx
+++ b/packages/front-end/pages/experiments/index.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import LoadingOverlay from "../../components/LoadingOverlay";
 import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
 import { phaseSummary } from "../../services/utils";
-import { datetime, ago } from "../../services/dates";
+import { datetime, ago, getValidDate } from "../../services/dates";
 import ResultsIndicator from "../../components/Experiment/ResultsIndicator";
 import { UserContext } from "../../components/ProtectedPage";
 import { useRouter } from "next/router";
@@ -168,8 +168,8 @@ const ExperimentsPage = (): React.ReactElement => {
                 {byStatus.myDrafts
                   .sort(
                     (a, b) =>
-                      new Date(b.dateCreated).getTime() -
-                      new Date(a.dateCreated).getTime()
+                      getValidDate(b.dateCreated).getTime() -
+                      getValidDate(a.dateCreated).getTime()
                   )
                   .slice(0, draftsExpanded ? 20 : 3)
                   .map((e) => {
@@ -273,10 +273,10 @@ const ExperimentsPage = (): React.ReactElement => {
                     {byStatus.running
                       .sort(
                         (a, b) =>
-                          new Date(
+                          getValidDate(
                             b.phases[b.phases.length - 1]?.dateStarted
                           ).getTime() -
-                          new Date(
+                          getValidDate(
                             a.phases[a.phases.length - 1]?.dateStarted
                           ).getTime()
                       )
@@ -354,8 +354,8 @@ const ExperimentsPage = (): React.ReactElement => {
                     {byStatus.draft
                       .sort(
                         (a, b) =>
-                          new Date(b.dateCreated).getTime() -
-                          new Date(a.dateCreated).getTime()
+                          getValidDate(b.dateCreated).getTime() -
+                          getValidDate(a.dateCreated).getTime()
                       )
                       .map((e) => {
                         return (
@@ -432,10 +432,10 @@ const ExperimentsPage = (): React.ReactElement => {
                     {byStatus.stopped
                       .sort(
                         (a, b) =>
-                          new Date(
+                          getValidDate(
                             b.phases[b.phases.length - 1]?.dateEnded
                           ).getTime() -
-                          new Date(
+                          getValidDate(
                             a.phases[a.phases.length - 1]?.dateEnded
                           ).getTime()
                       )

--- a/packages/front-end/services/dates.ts
+++ b/packages/front-end/services/dates.ts
@@ -5,22 +5,37 @@ import { addMonths } from "date-fns";
 
 export function date(date: string | Date): string {
   if (!date) return "";
-  return format(new Date(date), "PP");
+  return format(getValidDate(date), "PP");
 }
 export function datetime(date: string | Date): string {
   if (!date) return "";
-  return format(new Date(date), "PPp");
+  return format(getValidDate(date), "PPp");
 }
 export function ago(date: string | Date): string {
   if (!date) return "";
-  return formatDistance(new Date(date), new Date()) + " ago";
+  return formatDistance(getValidDate(date), new Date()) + " ago";
 }
 export function daysLeft(date: string | Date): number {
-  return differenceInDays(new Date(date), new Date());
+  return differenceInDays(getValidDate(date), new Date());
 }
 export function subtractMonths(date: string | Date, num: number): Date {
-  return addMonths(new Date(date), -1 * num);
+  return addMonths(getValidDate(date), -1 * num);
 }
 export function monthYear(date: string | Date): string {
-  return format(new Date(date), "MMM yyy");
+  return format(getValidDate(date), "MMM yyy");
+}
+
+export function getValidDate(
+  dateStr: string | Date | null | number,
+  fallback?: Date
+) {
+  fallback = fallback || new Date();
+
+  if (!dateStr) return fallback;
+
+  const d = new Date(dateStr);
+  if (isNaN(d.getTime())) {
+    return fallback;
+  }
+  return d;
 }


### PR DESCRIPTION
Fixes #141

Example bug:

```ts
const d = new Date("blah")

// Throws an error
d.toISOString();
```