### PR TITLE
Ad-hoc Experiment Analysis

### DIFF
--- a/packages/back-end/src/app.ts
+++ b/packages/back-end/src/app.ts
@@ -411,12 +411,12 @@ app.post(
   "/experiments/notebook/:id",
   experimentsController.postSnapshotNotebook
 );
-
-// Reports
 app.post(
-  "/reports/snapshot/:snapshot",
+  "/experiments/report/:snapshot",
   reportsController.postReportFromSnapshot
 );
+
+// Reports
 app.get("/report/:id", reportsController.getReport);
 app.put("/report/:id", reportsController.putReport);
 app.get("/report/:id/status", reportsController.getReportStatus);

--- a/packages/back-end/src/app.ts
+++ b/packages/back-end/src/app.ts
@@ -30,6 +30,7 @@ import fs from "fs";
 import * as authController from "./controllers/auth";
 import * as organizationsController from "./controllers/organizations";
 import * as experimentsController from "./controllers/experiments";
+import * as reportsController from "./controllers/reports";
 import * as ideasController from "./controllers/ideas";
 import * as presentationController from "./controllers/presentations";
 import * as discussionsController from "./controllers/discussions";
@@ -64,6 +65,7 @@ wrapController(segmentsController);
 wrapController(dimensionsController);
 wrapController(projectsController);
 wrapController(slackController);
+wrapController(reportsController);
 
 const app = express();
 
@@ -409,6 +411,14 @@ app.post(
   "/experiments/notebook/:id",
   experimentsController.postSnapshotNotebook
 );
+
+// Reports
+app.post(
+  "/reports/snapshot/:snapshot",
+  reportsController.postReportFromSnapshot
+);
+app.get("/report/:id", reportsController.getReport);
+app.put("/report/:id", reportsController.putReport);
 
 // Segments
 app.get("/segments", segmentsController.getAllSegments);

--- a/packages/back-end/src/app.ts
+++ b/packages/back-end/src/app.ts
@@ -419,6 +419,9 @@ app.post(
 );
 app.get("/report/:id", reportsController.getReport);
 app.put("/report/:id", reportsController.putReport);
+app.get("/report/:id/status", reportsController.getReportStatus);
+app.post("/report/:id/refresh", reportsController.refreshReport);
+app.post("/report/:id/cancel", reportsController.cancelReport);
 
 // Segments
 app.get("/segments", segmentsController.getAllSegments);

--- a/packages/back-end/src/app.ts
+++ b/packages/back-end/src/app.ts
@@ -422,6 +422,7 @@ app.put("/report/:id", reportsController.putReport);
 app.get("/report/:id/status", reportsController.getReportStatus);
 app.post("/report/:id/refresh", reportsController.refreshReport);
 app.post("/report/:id/cancel", reportsController.cancelReport);
+app.post("/report/:id/notebook", reportsController.postNotebook);
 
 // Segments
 app.get("/segments", segmentsController.getAllSegments);

--- a/packages/back-end/src/controllers/admin.ts
+++ b/packages/back-end/src/controllers/admin.ts
@@ -365,7 +365,7 @@ export async function addSampleData(req: AuthRequest, res: Response) {
       }
 
       // Refresh results
-      await createSnapshot(exp, 0, datasource, null);
+      await createSnapshot(exp, 0, null);
     })
   );
 

--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -63,6 +63,7 @@ import {
   analyzeExperimentResults,
 } from "../services/stats";
 import { getValidDate } from "../util/dates";
+import { getReportVariations } from "../services/reports";
 
 export async function getExperiments(req: AuthRequest, res: Response) {
   const { org } = getOrgFromReq(req);
@@ -1659,13 +1660,7 @@ export async function getSnapshotStatus(
     (queryData) =>
       analyzeExperimentResults(
         org.id,
-        experiment.variations.map((v, i) => {
-          return {
-            id: v.key || i + "",
-            name: v.name,
-            weight: phase.variationWeights[i] || 0,
-          };
-        }),
+        getReportVariations(experiment, phase),
         snapshot.dimension || undefined,
         queryData
       ),

--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -57,9 +57,11 @@ import { ExperimentSnapshotModel } from "../models/ExperimentSnapshotModel";
 import { getDataSourceById } from "../models/DataSourceModel";
 import { generateExperimentNotebook } from "../services/notebook";
 import { SegmentModel } from "../models/SegmentModel";
-import { addNonconvertingUsersToStats } from "../services/stats";
+import {
+  addNonconvertingUsersToStats,
+  analyzeExperimentResults,
+} from "../services/stats";
 import { getValidDate } from "../util/dates";
-import { analyzeExperimentResults } from "../services/reports";
 
 export async function getExperiments(req: AuthRequest, res: Response) {
   const { org } = getOrgFromReq(req);

--- a/packages/back-end/src/controllers/reports.ts
+++ b/packages/back-end/src/controllers/reports.ts
@@ -12,6 +12,7 @@ import { getOrgFromReq } from "../services/organizations";
 import { cancelRun, getStatusEndpoint } from "../services/queries";
 import { analyzeExperimentResults, runReport } from "../services/reports";
 import { AuthRequest } from "../types/AuthRequest";
+import { getValidDate } from "../util/dates";
 
 export async function postReportFromSnapshot(
   req: AuthRequest<null, { snapshot: string }>,
@@ -152,6 +153,9 @@ export async function putReport(
       ...report.args,
       ...req.body.args,
     };
+
+    updates.args.startDate = getValidDate(updates.args.startDate);
+    updates.args.endDate = getValidDate(updates.args.endDate || new Date());
     needsRun = true;
   }
   if ("title" in req.body) updates.title = req.body.title;

--- a/packages/back-end/src/controllers/reports.ts
+++ b/packages/back-end/src/controllers/reports.ts
@@ -2,7 +2,6 @@ import { Response } from "express";
 import { ReportInterface } from "../../types/report";
 import { ExperimentModel } from "../models/ExperimentModel";
 import { ExperimentSnapshotModel } from "../models/ExperimentSnapshotModel";
-import { getMetricById, updateMetric } from "../models/MetricModel";
 import {
   createReport,
   getReportById,
@@ -108,7 +107,6 @@ export async function refreshReport(
     throw new Error("Unknown report id");
   }
 
-  // TODO: start refreshing results
   await runReport(report);
 
   return res.status(200).json({
@@ -198,20 +196,16 @@ export async function cancelReport(
 ) {
   const { org } = getOrgFromReq(req);
   const { id } = req.params;
-  const metric = await getMetricById(id, org.id, true);
-  if (!metric) {
+  const report = await getReportById(org.id, id);
+  if (!report) {
     throw new Error("Could not cancel query");
   }
   res.status(200).json(
-    await cancelRun(metric, org.id, async () => {
-      await updateMetric(
-        id,
-        {
-          queries: [],
-          runStarted: null,
-        },
-        org.id
-      );
+    await cancelRun(report, org.id, async () => {
+      await updateReport(org.id, id, {
+        queries: [],
+        runStarted: null,
+      });
     })
   );
 }

--- a/packages/back-end/src/controllers/reports.ts
+++ b/packages/back-end/src/controllers/reports.ts
@@ -85,6 +85,17 @@ export async function postReportFromSnapshot(
     error: snapshot.error,
   });
 
+  await req.audit({
+    event: "experiment.analysis",
+    entity: {
+      object: "experiment",
+      id: snapshot.experiment,
+    },
+    details: JSON.stringify({
+      report: doc.id,
+    }),
+  });
+
   res.status(200).json({
     status: 200,
     report: doc,

--- a/packages/back-end/src/controllers/reports.ts
+++ b/packages/back-end/src/controllers/reports.ts
@@ -10,7 +10,8 @@ import {
 } from "../models/ReportModel";
 import { getOrgFromReq } from "../services/organizations";
 import { cancelRun, getStatusEndpoint } from "../services/queries";
-import { analyzeExperimentResults, runReport } from "../services/reports";
+import { runReport } from "../services/reports";
+import { analyzeExperimentResults } from "../services/stats";
 import { AuthRequest } from "../types/AuthRequest";
 import { getValidDate } from "../util/dates";
 

--- a/packages/back-end/src/controllers/reports.ts
+++ b/packages/back-end/src/controllers/reports.ts
@@ -2,12 +2,15 @@ import { Response } from "express";
 import { ReportInterface } from "../../types/report";
 import { ExperimentModel } from "../models/ExperimentModel";
 import { ExperimentSnapshotModel } from "../models/ExperimentSnapshotModel";
+import { getMetricById, updateMetric } from "../models/MetricModel";
 import {
   createReport,
   getReportById,
   updateReport,
 } from "../models/ReportModel";
 import { getOrgFromReq } from "../services/organizations";
+import { cancelRun, getStatusEndpoint } from "../services/queries";
+import { analyzeExperimentResults, runReport } from "../services/reports";
 import { AuthRequest } from "../types/AuthRequest";
 
 export async function postReportFromSnapshot(
@@ -71,7 +74,12 @@ export async function postReportFromSnapshot(
       queryFilter: snapshot.queryFilter,
       skipPartialData: snapshot.skipPartialData,
     },
-    results: snapshot.results,
+    results: snapshot.results
+      ? {
+          dimensions: snapshot.results,
+          unknownVariations: snapshot.unknownVariations || [],
+        }
+      : undefined,
     queries: snapshot.queries,
     runStarted: snapshot.runStarted,
     error: snapshot.error,
@@ -101,6 +109,26 @@ export async function getReport(
   });
 }
 
+export async function refreshReport(
+  req: AuthRequest<null, { id: string }>,
+  res: Response
+) {
+  const { org } = getOrgFromReq(req);
+
+  const report = await getReportById(org.id, req.params.id);
+
+  if (!report) {
+    throw new Error("Unknown report id");
+  }
+
+  // TODO: start refreshing results
+  await runReport(report);
+
+  return res.status(200).json({
+    status: 200,
+  });
+}
+
 export async function putReport(
   req: AuthRequest<Partial<ReportInterface>, { id: string }>,
   res: Response
@@ -113,11 +141,87 @@ export async function putReport(
     throw new Error("Unknown report id");
   }
 
-  await updateReport(org.id, req.params.id, req.body);
+  const updates: Partial<ReportInterface> = {};
+  let needsRun = false;
+  if ("args" in req.body) {
+    updates.args = {
+      ...report.args,
+      ...req.body.args,
+    };
+    needsRun = true;
+  }
+  if ("title" in req.body) updates.title = req.body.title;
+  if ("description" in req.body) updates.description = req.body.description;
+  await updateReport(org.id, req.params.id, updates);
 
-  // TODO: start refreshing results
+  if (needsRun) {
+    await runReport({
+      ...report,
+      ...updates,
+    });
+  }
 
   return res.status(200).json({
     status: 200,
   });
+}
+
+export async function getReportStatus(
+  req: AuthRequest<null, { id: string }>,
+  res: Response
+) {
+  const { org } = getOrgFromReq(req);
+  const { id } = req.params;
+  const report = await getReportById(org.id, id);
+  if (!report) {
+    throw new Error("Could not get query status");
+  }
+  const result = await getStatusEndpoint(
+    report,
+    org.id,
+    (queryData) => {
+      if (report.type === "experiment") {
+        return analyzeExperimentResults(
+          org.id,
+          report.args.variations,
+          report.args.dimension || "",
+          queryData
+        );
+      }
+      throw new Error("Unsupported report type");
+    },
+    async (updates, results, error) => {
+      await updateReport(org.id, id, {
+        ...updates,
+        results: results || report.results,
+        error,
+      });
+    },
+    report.error
+  );
+  return res.status(200).json(result);
+}
+
+export async function cancelReport(
+  req: AuthRequest<null, { id: string }>,
+  res: Response
+) {
+  const { org } = getOrgFromReq(req);
+  const { id } = req.params;
+  const metric = await getMetricById(id, org.id, true);
+  if (!metric) {
+    throw new Error("Could not cancel query");
+  }
+  res.status(200).json(
+    await cancelRun(metric, org.id, async () => {
+      await updateMetric(
+        id,
+        {
+          queries: [],
+          runStarted: null,
+        },
+        org.id
+      );
+    })
+  );
 }

--- a/packages/back-end/src/controllers/reports.ts
+++ b/packages/back-end/src/controllers/reports.ts
@@ -1,0 +1,123 @@
+import { Response } from "express";
+import { ReportInterface } from "../../types/report";
+import { ExperimentModel } from "../models/ExperimentModel";
+import { ExperimentSnapshotModel } from "../models/ExperimentSnapshotModel";
+import {
+  createReport,
+  getReportById,
+  updateReport,
+} from "../models/ReportModel";
+import { getOrgFromReq } from "../services/organizations";
+import { AuthRequest } from "../types/AuthRequest";
+
+export async function postReportFromSnapshot(
+  req: AuthRequest<null, { snapshot: string }>,
+  res: Response
+) {
+  const { org } = getOrgFromReq(req);
+
+  const snapshot = await ExperimentSnapshotModel.findOne({
+    id: req.params.snapshot,
+    organization: org.id,
+  });
+
+  if (!snapshot) {
+    throw new Error("Invalid snapshot id");
+  }
+
+  const experiment = await ExperimentModel.findOne({
+    organization: org.id,
+    id: snapshot.experiment,
+  });
+
+  if (!experiment) {
+    throw new Error("Could not find experiment");
+  }
+
+  const phase = experiment.phases[snapshot.phase];
+  if (!phase) {
+    throw new Error("Unknown experiment phase");
+  }
+
+  const doc = await createReport(org.id, {
+    title: `New Report - ${experiment.name}`,
+    description: "",
+    links: [
+      {
+        href: `/experiment/${snapshot.experiment}#results`,
+        display: "Back to experiment results",
+        external: false,
+      },
+    ],
+    type: "experiment",
+    args: {
+      trackingKey: experiment.trackingKey,
+      datasource: experiment.datasource,
+      userIdType: experiment.userIdType,
+      startDate: phase.dateStarted,
+      endDate: phase.dateEnded || undefined,
+      dimension: snapshot.dimension || undefined,
+      variations: experiment.variations.map((v, i) => {
+        return {
+          id: v.key || i + "",
+          name: v.name,
+          weight: phase.variationWeights[i] || 0,
+        };
+      }),
+      segment: snapshot.segment,
+      metrics: experiment.metrics,
+      guardrails: experiment.guardrails,
+      activationMetric: snapshot.activationMetric,
+      queryFilter: snapshot.queryFilter,
+      skipPartialData: snapshot.skipPartialData,
+    },
+    results: snapshot.results,
+    queries: snapshot.queries,
+    runStarted: snapshot.runStarted,
+    error: snapshot.error,
+  });
+
+  res.status(200).json({
+    status: 200,
+    report: doc,
+  });
+}
+
+export async function getReport(
+  req: AuthRequest<null, { id: string }>,
+  res: Response
+) {
+  const { org } = getOrgFromReq(req);
+
+  const report = await getReportById(org.id, req.params.id);
+
+  if (!report) {
+    throw new Error("Unknown report id");
+  }
+
+  res.status(200).json({
+    status: 200,
+    report,
+  });
+}
+
+export async function putReport(
+  req: AuthRequest<Partial<ReportInterface>, { id: string }>,
+  res: Response
+) {
+  const { org } = getOrgFromReq(req);
+
+  const report = await getReportById(org.id, req.params.id);
+
+  if (!report) {
+    throw new Error("Unknown report id");
+  }
+
+  await updateReport(org.id, req.params.id, req.body);
+
+  // TODO: start refreshing results
+
+  return res.status(200).json({
+    status: 200,
+  });
+}

--- a/packages/back-end/src/controllers/reports.ts
+++ b/packages/back-end/src/controllers/reports.ts
@@ -44,14 +44,7 @@ export async function postReportFromSnapshot(
 
   const doc = await createReport(org.id, {
     title: `New Report - ${experiment.name}`,
-    description: "",
-    links: [
-      {
-        href: `/experiment/${snapshot.experiment}#results`,
-        display: "Back to experiment results",
-        external: false,
-      },
-    ],
+    description: `[Back to experiment results](/experiment/${snapshot.experiment}#results)`,
     type: "experiment",
     args: {
       trackingKey: experiment.trackingKey,

--- a/packages/back-end/src/jobs/updateExperimentResults.ts
+++ b/packages/back-end/src/jobs/updateExperimentResults.ts
@@ -132,6 +132,10 @@ async function updateSingleExperiment(job: UpdateSingleExpJob) {
     await new Promise<void>((resolve, reject) => {
       const check = async () => {
         const phase = experiment.phases[experiment.phases.length - 1];
+        if (!phase) {
+          reject("Invalid phase");
+          return;
+        }
         const res = await getStatusEndpoint(
           currentSnapshot,
           currentSnapshot.organization,

--- a/packages/back-end/src/jobs/updateExperimentResults.ts
+++ b/packages/back-end/src/jobs/updateExperimentResults.ts
@@ -17,7 +17,7 @@ import { ExperimentInterface } from "../../types/experiment";
 import { getStatusEndpoint } from "../services/queries";
 import { getMetricById } from "../models/MetricModel";
 import { EXPERIMENT_REFRESH_FREQUENCY } from "../util/secrets";
-import { analyzeExperimentResults } from "../services/reports";
+import { analyzeExperimentResults } from "../services/stats";
 
 // Time between experiment result updates (default 6 hours)
 const UPDATE_EVERY = EXPERIMENT_REFRESH_FREQUENCY * 60 * 60 * 1000;

--- a/packages/back-end/src/jobs/updateExperimentResults.ts
+++ b/packages/back-end/src/jobs/updateExperimentResults.ts
@@ -18,6 +18,7 @@ import { getStatusEndpoint } from "../services/queries";
 import { getMetricById } from "../models/MetricModel";
 import { EXPERIMENT_REFRESH_FREQUENCY } from "../util/secrets";
 import { analyzeExperimentResults } from "../services/stats";
+import { getReportVariations } from "../services/reports";
 
 // Time between experiment result updates (default 6 hours)
 const UPDATE_EVERY = EXPERIMENT_REFRESH_FREQUENCY * 60 * 60 * 1000;
@@ -137,13 +138,7 @@ async function updateSingleExperiment(job: UpdateSingleExpJob) {
           (queryData) => {
             return analyzeExperimentResults(
               experiment.organization,
-              experiment.variations.map((v, i) => {
-                return {
-                  id: v.key || i + "",
-                  name: v.name,
-                  weight: phase.variationWeights[i] || 0,
-                };
-              }),
+              getReportVariations(experiment, phase),
               undefined,
               queryData
             );

--- a/packages/back-end/src/models/ReportModel.ts
+++ b/packages/back-end/src/models/ReportModel.ts
@@ -1,0 +1,77 @@
+import mongoose from "mongoose";
+import { ReportInterface } from "../../types/report";
+import uniqid from "uniqid";
+import { queriesSchema } from "./QueryModel";
+
+const reportSchema = new mongoose.Schema({
+  id: String,
+  dateCreated: Date,
+  dateUpdated: Date,
+  organization: String,
+  links: [
+    {
+      _id: false,
+      href: String,
+      display: String,
+      external: Boolean,
+    },
+  ],
+  title: String,
+  description: String,
+  runStarted: Date,
+  error: String,
+  queries: queriesSchema,
+  type: String,
+  args: {},
+  results: {},
+});
+
+type ReportDocument = mongoose.Document & ReportInterface;
+
+const ReportModel = mongoose.model<ReportDocument>("Report", reportSchema);
+
+export async function createReport(
+  organization: string,
+  initialValue: Partial<ReportInterface>
+): Promise<ReportInterface> {
+  const report = await ReportModel.create({
+    ...initialValue,
+    organization,
+    id: uniqid("rep_"),
+    dateCreated: new Date(),
+    dateUpdated: new Date(),
+  });
+
+  return report.toJSON();
+}
+
+export async function getReportById(
+  organization: string,
+  id: string
+): Promise<ReportInterface | null> {
+  const report = await ReportModel.findOne({
+    organization,
+    id,
+  });
+
+  return report ? report.toJSON() : null;
+}
+
+export async function updateReport(
+  organization: string,
+  id: string,
+  updates: Partial<ReportInterface>
+) {
+  await ReportModel.updateOne(
+    {
+      organization,
+      id,
+    },
+    {
+      $set: {
+        ...updates,
+        dateUpdated: new Date(),
+      },
+    }
+  );
+}

--- a/packages/back-end/src/models/ReportModel.ts
+++ b/packages/back-end/src/models/ReportModel.ts
@@ -8,14 +8,6 @@ const reportSchema = new mongoose.Schema({
   dateCreated: Date,
   dateUpdated: Date,
   organization: String,
-  links: [
-    {
-      _id: false,
-      href: String,
-      display: String,
-      external: Boolean,
-    },
-  ],
   title: String,
   description: String,
   runStarted: Date,

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -6,17 +6,10 @@ import {
 import { getMetricsByOrganization, insertMetric } from "../models/MetricModel";
 import uniqid from "uniqid";
 import { analyzeExperimentMetric } from "./stats";
-import { getSourceIntegrationObject } from "./datasource";
 import { addTags } from "./tag";
 import { WatchModel } from "../models/WatchModel";
+import { QueryMap } from "./queries";
 import {
-  getExperimentMetric,
-  getExperimentResults,
-  QueryMap,
-  startRun,
-} from "./queries";
-import {
-  ExperimentResults,
   PastExperimentResult,
   Dimension,
   ExperimentMetricQueryResponse,
@@ -27,15 +20,12 @@ import {
 } from "../models/ExperimentSnapshotModel";
 import { MetricInterface, MetricStats } from "../../types/metric";
 import { ExperimentInterface, ExperimentPhase } from "../../types/experiment";
-import { DataSourceInterface } from "../../types/datasource";
 import { PastExperiment } from "../../types/past-experiments";
-import { QueryDocument } from "../models/QueryModel";
 import { FilterQuery } from "mongoose";
 import { promiseAllChunks } from "../util/promise";
-import { SegmentModel } from "../models/SegmentModel";
-import { SegmentInterface } from "../../types/segment";
-
-const MAX_DIMENSIONS = 20;
+import { findDimensionById } from "../models/DimensionModel";
+import { ExperimentReportArgs } from "../../types/report";
+import { startExperimentAnalysis } from "./reports";
 
 export function getExperimentsByOrganization(
   organization: string,
@@ -228,9 +218,15 @@ export async function getManualSnapshotData(
             variation: experiment.variations[i].key || i + "",
           };
         });
+
         const res = await analyzeExperimentMetric(
-          experiment,
-          phase,
+          experiment.variations.map((v, i) => {
+            return {
+              id: v.key || i + "",
+              weight: phase.variationWeights[i] || 0,
+              name: v.name,
+            };
+          }),
           metric,
           rows,
           20
@@ -291,228 +287,88 @@ export async function createManualSnapshot(
   return snapshot;
 }
 
-type ProcessedSnapshotDimension = {
-  name: string;
-  srm: number;
-  variations: SnapshotVariation[];
-};
-type ProcessedSnapshotData = {
-  dimensions: ProcessedSnapshotDimension[];
-  unknownVariations: string[];
-};
-
-export async function processSnapshotData(
+export function getExperimentReportArgs(
   experiment: ExperimentInterface,
   phase: ExperimentPhase,
-  queryData: QueryMap,
-  dimension: string | null = null
-): Promise<ProcessedSnapshotData> {
-  const metrics = await getMetricsByOrganization(experiment.organization);
-  const metricMap = new Map<string, MetricInterface>();
-  metrics.forEach((m) => {
-    metricMap.set(m.id, m);
-  });
-
-  const metricRows: {
-    metric: string;
-    rows: ExperimentMetricQueryResponse;
-  }[] = [];
-
-  let unknownVariations: string[] = [];
-
-  // Everything done in a single query (Mixpanel, Google Analytics)
-  // Need to convert to the same format as SQL rows
-  if (queryData.has("results")) {
-    const results = queryData.get("results");
-    if (!results) throw new Error("Empty experiment results");
-    const data = results.result as ExperimentResults;
-
-    unknownVariations = data.unknownVariations;
-
-    const byMetric: { [key: string]: ExperimentMetricQueryResponse } = {};
-    data.dimensions.forEach((row) => {
-      row.variations.forEach((v) => {
-        Object.keys(v.metrics).forEach((metric) => {
-          const stats = v.metrics[metric];
-          byMetric[metric] = byMetric[metric] || [];
-          byMetric[metric].push({
-            ...stats,
-            dimension: row.dimension,
-            variation:
-              experiment.variations[v.variation].key || v.variation + "",
-          });
-        });
-      });
-    });
-
-    Object.keys(byMetric).forEach((metric) => {
-      metricRows.push({
-        metric,
-        rows: byMetric[metric],
-      });
-    });
-  }
-  // One query for each metric, can just use the rows directly from the query
-  else {
-    queryData.forEach((query, key) => {
-      const metric = metricMap.get(key);
-      if (!metric) return;
-
-      metricRows.push({
-        metric: key,
-        rows: query.result as ExperimentMetricQueryResponse,
-      });
-    });
-  }
-
-  const dimensionMap: Map<string, ProcessedSnapshotDimension> = new Map();
-  await promiseAllChunks(
-    metricRows.map((data) => {
-      const metric = metricMap.get(data.metric);
-      return async () => {
-        if (!metric) return;
-        const result = await analyzeExperimentMetric(
-          experiment,
-          phase,
-          metric,
-          data.rows,
-          dimension === "pre:date" ? 100 : MAX_DIMENSIONS
-        );
-        unknownVariations = unknownVariations.concat(result.unknownVariations);
-
-        result.dimensions.forEach((row) => {
-          const dim = dimensionMap.get(row.dimension) || {
-            name: row.dimension,
-            srm: row.srm,
-            variations: [],
-          };
-
-          row.variations.forEach((v, i) => {
-            const data = dim.variations[i] || {
-              users: v.users,
-              metrics: {},
-            };
-            data.metrics[metric.id] = {
-              ...v,
-              buckets: [],
-            };
-            dim.variations[i] = data;
-          });
-
-          dimensionMap.set(row.dimension, dim);
-        });
-      };
-    }),
-    3
-  );
-
-  const dimensions = Array.from(dimensionMap.values());
-  if (!dimensions.length) {
-    dimensions.push({
-      name: "All",
-      srm: 1,
-      variations: [],
-    });
-  }
+  dimension: string | null
+): ExperimentReportArgs {
+  const {
+    trackingKey,
+    metrics,
+    guardrails,
+    queryFilter,
+    segment,
+    activationMetric,
+    datasource,
+    userIdType,
+    skipPartialData,
+  } = experiment;
+  const { dateStarted, dateEnded, variationWeights } = phase;
 
   return {
-    unknownVariations: Array.from(new Set(unknownVariations)),
-    dimensions,
+    trackingKey,
+    userIdType,
+    metrics,
+    skipPartialData,
+    guardrails,
+    queryFilter,
+    segment,
+    activationMetric,
+    datasource,
+    dimension: dimension || undefined,
+    endDate: dateEnded,
+    startDate: dateStarted,
+    variations: experiment.variations.map((v, i) => {
+      return {
+        id: v.key || i + "",
+        name: v.name,
+        weight: variationWeights[i] || 0,
+      };
+    }),
   };
+}
+
+export async function parseDimensionId(
+  dimension: string | undefined,
+  organization: string
+): Promise<Dimension | null> {
+  if (dimension) {
+    if (dimension.match(/^exp:/)) {
+      return {
+        type: "experiment",
+        id: dimension.substr(4),
+      };
+    } else if (dimension.substr(0, 4) === "pre:") {
+      return {
+        // eslint-disable-next-line
+        type: dimension.substr(4) as any,
+      };
+    } else {
+      const obj = await findDimensionById(dimension, organization);
+      if (obj) {
+        return {
+          type: "user",
+          dimension: obj,
+        };
+      }
+    }
+  }
+  return null;
 }
 
 export async function createSnapshot(
   experiment: ExperimentInterface,
   phaseIndex: number,
-  datasource: DataSourceInterface,
-  dimension: Dimension | null
+  dimensionId: string | null
 ) {
-  const metrics = await getMetricsByOrganization(experiment.organization);
-  const metricMap = new Map<string, MetricInterface>();
-  metrics.forEach((m) => {
-    metricMap.set(m.id, m);
-  });
-
-  const activationMetric =
-    metricMap.get(experiment.activationMetric || "") || null;
-
-  // Only include metrics tied to this experiment (both goal and guardrail metrics)
-  const selectedMetrics = Array.from(
-    new Set(experiment.metrics.concat(experiment.guardrails || []))
-  )
-    .map((m) => metricMap.get(m))
-    .filter((m) => m) as MetricInterface[];
-  if (!selectedMetrics.length) {
-    throw new Error("Experiment must have at least 1 metric selected.");
-  }
-
-  const phase = experiment.phases[phaseIndex];
-
-  let segment: SegmentInterface | null = null;
-  if (experiment.segment) {
-    segment =
-      (await SegmentModel.findOne({
-        id: experiment.segment,
-        organization: experiment.organization,
-      })) || null;
-  }
-
-  // Update lastSnapshotAttempt
-  experiment.lastSnapshotAttempt = new Date();
-  await ExperimentModel.updateOne(
-    {
-      id: experiment.id,
-    },
-    {
-      $set: {
-        lastSnapshotAttempt: experiment.lastSnapshotAttempt,
-      },
-    }
-  );
-
-  const integration = getSourceIntegrationObject(datasource);
-
-  const queryDocs: { [key: string]: Promise<QueryDocument> } = {};
-
-  // Run it as a single synchronous task (non-sql datasources and legacy code)
-  if (!integration.getSourceProperties().separateExperimentResultQueries) {
-    queryDocs["results"] = getExperimentResults(
-      integration,
+  const { queries, results } = await startExperimentAnalysis({
+    organization: experiment.organization,
+    ...getExperimentReportArgs(
       experiment,
-      phase,
-      selectedMetrics,
-      activationMetric,
-      dimension?.type === "user" ? dimension.dimension : null
-    );
-  }
-  // Run as multiple async queries (new way for sql datasources)
-  else {
-    selectedMetrics.forEach((m) => {
-      queryDocs[m.id] = getExperimentMetric(integration, {
-        metric: m,
-        experiment,
-        dimension,
-        activationMetric,
-        phase,
-        segment,
-      });
-    });
-  }
-
-  const dimensionId =
-    (!dimension
-      ? null
-      : dimension.type === "user"
-      ? dimension.dimension.id
-      : dimension.type === "experiment"
-      ? "exp:" + dimension.id
-      : "pre:" + dimension.type) || null;
-
-  const { queries, result: results } = await startRun(
-    queryDocs,
-    async (queryData) =>
-      processSnapshotData(experiment, phase, queryData, dimensionId)
-  );
+      experiment.phases[phaseIndex],
+      dimensionId
+    ),
+  });
 
   const data: ExperimentSnapshotInterface = {
     id: uniqid("snp_"),
@@ -525,8 +381,8 @@ export async function createSnapshot(
     manual: false,
     queries,
     hasRawQueries: true,
-    queryLanguage: integration.getSourceProperties().queryLanguage,
-    dimension: dimensionId || null,
+    queryLanguage: "sql",
+    dimension: dimensionId,
     results: results?.dimensions,
     unknownVariations: results?.unknownVariations || [],
     activationMetric: experiment.activationMetric || "",

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -330,7 +330,9 @@ export async function createSnapshot(
     userIdType,
     skipPartialData,
   } = experiment;
-  const { dateStarted, dateEnded, variationWeights } = phase;
+  const { dateStarted, dateEnded, variationWeights } = experiment.phases[
+    phaseIndex
+  ];
 
   const { queries, results } = await startExperimentAnalysis({
     organization: experiment.organization,
@@ -343,7 +345,7 @@ export async function createSnapshot(
     segment,
     activationMetric,
     datasource,
-    dimension: dimension || undefined,
+    dimension: dimensionId || undefined,
     endDate: dateEnded,
     startDate: dateStarted,
     variations: experiment.variations.map((v, i) => {

--- a/packages/back-end/src/services/notebook.ts
+++ b/packages/back-end/src/services/notebook.ts
@@ -7,8 +7,34 @@ import { MetricInterface } from "../../types/metric";
 import { getQueryData } from "./queries";
 import { promisify } from "util";
 import { PythonShell } from "python-shell";
+import { ExperimentReportArgs } from "../../types/report";
+import { getReportById } from "../models/ReportModel";
+import { Queries } from "../../types/query";
+import { reportArgsFromSnapshot } from "./reports";
 
-async function getNotebookObjects(snapshotId: string, organization: string) {
+export async function generateReportNotebook(
+  reportId: string,
+  organization: string
+): Promise<string> {
+  const report = await getReportById(organization, reportId);
+  if (!report) {
+    throw new Error("Could not find report");
+  }
+
+  return generateNotebook(
+    organization,
+    report.queries,
+    report.args,
+    `/report/${report.id}`,
+    report.title,
+    ""
+  );
+}
+
+export async function generateExperimentNotebook(
+  snapshotId: string,
+  organization: string
+): Promise<string> {
   // Get snapshot
   const snapshot = await ExperimentSnapshotModel.findOne({
     id: snapshotId,
@@ -36,13 +62,28 @@ async function getNotebookObjects(snapshotId: string, organization: string) {
     throw new Error("Experiment must use a datasource");
   }
 
-  // Get datasource
-  const datasource = await getDataSourceById(
-    experiment.datasource,
-    organization
+  return generateNotebook(
+    organization,
+    snapshot.queries,
+    reportArgsFromSnapshot(experiment, snapshot),
+    `/experiment/${experiment.id}`,
+    experiment.name,
+    experiment.hypothesis || ""
   );
+}
+
+export async function generateNotebook(
+  organization: string,
+  queryPointers: Queries,
+  args: ExperimentReportArgs,
+  url: string,
+  name: string,
+  description: string
+) {
+  // Get datasource
+  const datasource = await getDataSourceById(args.datasource, organization);
   if (!datasource) {
-    throw new Error("Cannot find snapshot");
+    throw new Error("Cannot find datasource");
   }
   if (!datasource.settings?.notebookRunQuery) {
     throw new Error(
@@ -58,39 +99,18 @@ async function getNotebookObjects(snapshotId: string, organization: string) {
   });
 
   // Get queries
-  const queries = await getQueryData(snapshot.queries, organization);
-
-  return {
-    experiment,
-    snapshot,
-    datasource,
-    metrics: metricMap,
-    queries,
-  };
-}
-
-export async function generateExperimentNotebook(
-  snapshotId: string,
-  organization: string
-): Promise<string> {
-  const {
-    experiment,
-    snapshot,
-    datasource,
-    metrics,
-    queries,
-  } = await getNotebookObjects(snapshotId, organization);
+  const queries = await getQueryData(queryPointers, organization);
 
   const var_id_map: Record<string, number> = {};
-  experiment.variations.forEach((v, i) => {
-    var_id_map[v.key || i + ""] = i;
+  args.variations.forEach((v, i) => {
+    var_id_map[v.id] = i;
   });
 
   const data = JSON.stringify({
-    metrics: experiment.metrics
+    metrics: args.metrics
       .map((m) => {
         const q = queries.get(m);
-        const metric = metrics.get(m);
+        const metric = metricMap.get(m);
         if (!q || !metric) return null;
         return {
           rows: q.rawResult,
@@ -102,12 +122,12 @@ export async function generateExperimentNotebook(
         };
       })
       .filter(Boolean),
-    url: `${APP_ORIGIN}/experiment/${experiment.id}`,
-    hypothesis: experiment.hypothesis,
-    name: experiment.name,
+    url: `${APP_ORIGIN}${url}`,
+    hypothesis: description,
+    name,
     var_id_map,
-    var_names: experiment.variations.map((v) => v.name),
-    weights: experiment.phases[snapshot.phase].variationWeights,
+    var_names: args.variations.map((v) => v.name),
+    weights: args.variations.map((v) => v.weight),
     run_query: datasource.settings.notebookRunQuery,
   }).replace(/\\/g, "\\\\");
 

--- a/packages/back-end/src/services/reports.ts
+++ b/packages/back-end/src/services/reports.ts
@@ -25,7 +25,7 @@ export function getReportVariations(
     return {
       id: v.key || i + "",
       name: v.name,
-      weight: phase.variationWeights[i] || 0,
+      weight: phase?.variationWeights?.[i] || 0,
     };
   });
 }

--- a/packages/back-end/src/services/reports.ts
+++ b/packages/back-end/src/services/reports.ts
@@ -40,6 +40,8 @@ export async function startExperimentAnalysis({
   dimension,
   trackingKey,
   queryFilter,
+  userIdType,
+  skipPartialData,
 }: {
   organization: string;
   datasource: string;
@@ -53,6 +55,8 @@ export async function startExperimentAnalysis({
   dimension?: string;
   trackingKey: string;
   queryFilter?: string;
+  skipPartialData?: boolean;
+  userIdType?: "user" | "anonymous";
 }) {
   const metricObjs = await getMetricsByOrganization(organization);
   const metricMap = new Map<string, MetricInterface>();
@@ -97,13 +101,22 @@ export async function startExperimentAnalysis({
     variationWeights: variations.map((v) => v.weight),
   };
   const experimentObj: ExperimentInterface = {
+    userIdType,
+    organization,
+    skipPartialData,
+    trackingKey,
+    datasource,
+    segment,
+    queryFilter,
+    activationMetric,
+    metrics,
+    guardrails,
     id: "",
     name: "",
     dateCreated: new Date(),
     dateUpdated: new Date(),
     tags: [],
     autoAssign: false,
-    organization: organization,
     owner: "",
     implementation: "code",
     previewURL: "",
@@ -119,13 +132,6 @@ export async function startExperimentAnalysis({
         screenshots: [],
       };
     }),
-    trackingKey: trackingKey,
-    datasource: datasource,
-    segment: segment,
-    queryFilter: queryFilter,
-    activationMetric: activationMetric,
-    metrics: metrics,
-    guardrails: guardrails,
   };
   const dimensionObj = await parseDimensionId(dimension, organization);
 

--- a/packages/back-end/src/services/reports.ts
+++ b/packages/back-end/src/services/reports.ts
@@ -1,0 +1,299 @@
+import { MetricInterface } from "../../types/metric";
+import {
+  ExperimentReportResults,
+  ExperimentReportResultDimension,
+  ExperimentReportVariation,
+  ReportInterface,
+} from "../../types/report";
+import { getMetricsByOrganization } from "../models/MetricModel";
+import {
+  ExperimentMetricQueryResponse,
+  ExperimentResults,
+} from "../types/Integration";
+import { analyzeExperimentMetric, MAX_DIMENSIONS } from "./stats";
+import { getSourceIntegrationObject } from "./datasource";
+import {
+  getExperimentMetric,
+  getExperimentResults,
+  QueryMap,
+  startRun,
+} from "./queries";
+import { QueryDocument } from "../models/QueryModel";
+import { promiseAllChunks } from "../util/promise";
+import { SegmentModel } from "../models/SegmentModel";
+import { SegmentInterface } from "../../types/segment";
+import { getDataSourceById } from "../models/DataSourceModel";
+import { ExperimentInterface, ExperimentPhase } from "../../types/experiment";
+import { parseDimensionId } from "./experiments";
+import { updateReport } from "../models/ReportModel";
+
+export async function startExperimentAnalysis({
+  organization,
+  datasource,
+  activationMetric,
+  metrics,
+  guardrails,
+  segment,
+  startDate,
+  endDate,
+  variations,
+  dimension,
+  trackingKey,
+  queryFilter,
+}: {
+  organization: string;
+  datasource: string;
+  activationMetric?: string;
+  metrics: string[];
+  guardrails?: string[];
+  segment?: string;
+  startDate: Date;
+  endDate?: Date;
+  variations: ExperimentReportVariation[];
+  dimension?: string;
+  trackingKey: string;
+  queryFilter?: string;
+}) {
+  const metricObjs = await getMetricsByOrganization(organization);
+  const metricMap = new Map<string, MetricInterface>();
+  metricObjs.forEach((m) => {
+    metricMap.set(m.id, m);
+  });
+
+  const datasourceObj = await getDataSourceById(datasource, organization);
+  if (!datasourceObj) {
+    throw new Error("Missing datasource for report");
+  }
+
+  const activationMetricObj = metricMap.get(activationMetric || "") || null;
+
+  // Only include metrics tied to this experiment (both goal and guardrail metrics)
+  const selectedMetrics = Array.from(new Set(metrics.concat(guardrails || [])))
+    .map((m) => metricMap.get(m))
+    .filter((m) => m) as MetricInterface[];
+  if (!selectedMetrics.length) {
+    throw new Error("Experiment must have at least 1 metric selected.");
+  }
+
+  let segmentObj: SegmentInterface | null = null;
+  if (segment) {
+    segmentObj =
+      (await SegmentModel.findOne({
+        id: segment,
+        organization,
+      })) || null;
+  }
+
+  const integration = getSourceIntegrationObject(datasourceObj);
+
+  const queryDocs: { [key: string]: Promise<QueryDocument> } = {};
+
+  const experimentPhaseObj: ExperimentPhase = {
+    dateStarted: startDate,
+    dateEnded: endDate,
+    phase: "main",
+    coverage: 1,
+    reason: "",
+    variationWeights: variations.map((v) => v.weight),
+  };
+  const experimentObj: ExperimentInterface = {
+    id: "",
+    name: "",
+    dateCreated: new Date(),
+    dateUpdated: new Date(),
+    tags: [],
+    autoAssign: false,
+    organization: organization,
+    owner: "",
+    implementation: "code",
+    previewURL: "",
+    status: "stopped",
+    phases: [experimentPhaseObj],
+    autoSnapshots: false,
+    targetURLRegex: "",
+    archived: false,
+    variations: variations.map((v) => {
+      return {
+        name: v.name,
+        key: v.id,
+        screenshots: [],
+      };
+    }),
+    trackingKey: trackingKey,
+    datasource: datasource,
+    segment: segment,
+    queryFilter: queryFilter,
+    activationMetric: activationMetric,
+    metrics: metrics,
+    guardrails: guardrails,
+  };
+  const dimensionObj = await parseDimensionId(dimension, organization);
+
+  // Run it as a single synchronous task (non-sql datasources and legacy code)
+  if (!integration.getSourceProperties().separateExperimentResultQueries) {
+    queryDocs["results"] = getExperimentResults(
+      integration,
+      experimentObj,
+      experimentPhaseObj,
+      selectedMetrics,
+      activationMetricObj,
+      dimensionObj?.type === "user" ? dimensionObj.dimension : null
+    );
+  }
+  // Run as multiple async queries (new way for sql datasources)
+  else {
+    selectedMetrics.forEach((m) => {
+      queryDocs[m.id] = getExperimentMetric(integration, {
+        metric: m,
+        experiment: experimentObj,
+        dimension: dimensionObj,
+        activationMetric: activationMetricObj,
+        phase: experimentPhaseObj,
+        segment: segmentObj,
+      });
+    });
+  }
+
+  const { queries, result: results } = await startRun(
+    queryDocs,
+    async (queryData) =>
+      analyzeExperimentResults(organization, variations, dimension, queryData)
+  );
+  return { queries, results };
+}
+
+export async function runReport(report: ReportInterface) {
+  const updates: Partial<ReportInterface> = {};
+
+  if (report.type === "experiment") {
+    const { queries, results } = await startExperimentAnalysis({
+      organization: report.organization,
+      ...report.args,
+    });
+    updates.queries = queries;
+    updates.results = results;
+    updates.runStarted = new Date();
+  } else {
+    throw new Error("Unsupported report type");
+  }
+
+  await updateReport(report.organization, report.id, updates);
+}
+
+export async function analyzeExperimentResults(
+  organization: string,
+  variations: ExperimentReportVariation[],
+  dimension: string | undefined,
+  queryData: QueryMap
+): Promise<ExperimentReportResults> {
+  const metrics = await getMetricsByOrganization(organization);
+  const metricMap = new Map<string, MetricInterface>();
+  metrics.forEach((m) => {
+    metricMap.set(m.id, m);
+  });
+
+  const metricRows: {
+    metric: string;
+    rows: ExperimentMetricQueryResponse;
+  }[] = [];
+
+  let unknownVariations: string[] = [];
+
+  // Everything done in a single query (Mixpanel, Google Analytics)
+  // Need to convert to the same format as SQL rows
+  if (queryData.has("results")) {
+    const results = queryData.get("results");
+    if (!results) throw new Error("Empty experiment results");
+    const data = results.result as ExperimentResults;
+
+    unknownVariations = data.unknownVariations;
+
+    const byMetric: { [key: string]: ExperimentMetricQueryResponse } = {};
+    data.dimensions.forEach((row) => {
+      row.variations.forEach((v) => {
+        Object.keys(v.metrics).forEach((metric) => {
+          const stats = v.metrics[metric];
+          byMetric[metric] = byMetric[metric] || [];
+          byMetric[metric].push({
+            ...stats,
+            dimension: row.dimension,
+            variation: variations[v.variation].id,
+          });
+        });
+      });
+    });
+
+    Object.keys(byMetric).forEach((metric) => {
+      metricRows.push({
+        metric,
+        rows: byMetric[metric],
+      });
+    });
+  }
+  // One query for each metric, can just use the rows directly from the query
+  else {
+    queryData.forEach((query, key) => {
+      const metric = metricMap.get(key);
+      if (!metric) return;
+
+      metricRows.push({
+        metric: key,
+        rows: query.result as ExperimentMetricQueryResponse,
+      });
+    });
+  }
+
+  const dimensionMap: Map<string, ExperimentReportResultDimension> = new Map();
+  await promiseAllChunks(
+    metricRows.map((data) => {
+      const metric = metricMap.get(data.metric);
+      return async () => {
+        if (!metric) return;
+        const result = await analyzeExperimentMetric(
+          variations,
+          metric,
+          data.rows,
+          dimension === "pre:date" ? 100 : MAX_DIMENSIONS
+        );
+        unknownVariations = unknownVariations.concat(result.unknownVariations);
+
+        result.dimensions.forEach((row) => {
+          const dim = dimensionMap.get(row.dimension) || {
+            name: row.dimension,
+            srm: row.srm,
+            variations: [],
+          };
+
+          row.variations.forEach((v, i) => {
+            const data = dim.variations[i] || {
+              users: v.users,
+              metrics: {},
+            };
+            data.metrics[metric.id] = {
+              ...v,
+              buckets: [],
+            };
+            dim.variations[i] = data;
+          });
+
+          dimensionMap.set(row.dimension, dim);
+        });
+      };
+    }),
+    3
+  );
+
+  const dimensions = Array.from(dimensionMap.values());
+  if (!dimensions.length) {
+    dimensions.push({
+      name: "All",
+      srm: 1,
+      variations: [],
+    });
+  }
+
+  return {
+    unknownVariations: Array.from(new Set(unknownVariations)),
+    dimensions,
+  };
+}

--- a/packages/back-end/src/services/reports.ts
+++ b/packages/back-end/src/services/reports.ts
@@ -1,31 +1,16 @@
 import { MetricInterface } from "../../types/metric";
-import {
-  ExperimentReportResults,
-  ExperimentReportResultDimension,
-  ExperimentReportVariation,
-  ReportInterface,
-} from "../../types/report";
+import { ExperimentReportVariation, ReportInterface } from "../../types/report";
 import { getMetricsByOrganization } from "../models/MetricModel";
-import {
-  ExperimentMetricQueryResponse,
-  ExperimentResults,
-} from "../types/Integration";
-import { analyzeExperimentMetric, MAX_DIMENSIONS } from "./stats";
 import { getSourceIntegrationObject } from "./datasource";
-import {
-  getExperimentMetric,
-  getExperimentResults,
-  QueryMap,
-  startRun,
-} from "./queries";
+import { getExperimentMetric, getExperimentResults, startRun } from "./queries";
 import { QueryDocument } from "../models/QueryModel";
-import { promiseAllChunks } from "../util/promise";
 import { SegmentModel } from "../models/SegmentModel";
 import { SegmentInterface } from "../../types/segment";
 import { getDataSourceById } from "../models/DataSourceModel";
 import { ExperimentInterface, ExperimentPhase } from "../../types/experiment";
 import { parseDimensionId } from "./experiments";
 import { updateReport } from "../models/ReportModel";
+import { analyzeExperimentResults } from "./stats";
 
 export async function startExperimentAnalysis({
   organization,
@@ -185,122 +170,4 @@ export async function runReport(report: ReportInterface) {
   }
 
   await updateReport(report.organization, report.id, updates);
-}
-
-export async function analyzeExperimentResults(
-  organization: string,
-  variations: ExperimentReportVariation[],
-  dimension: string | undefined,
-  queryData: QueryMap
-): Promise<ExperimentReportResults> {
-  const metrics = await getMetricsByOrganization(organization);
-  const metricMap = new Map<string, MetricInterface>();
-  metrics.forEach((m) => {
-    metricMap.set(m.id, m);
-  });
-
-  const metricRows: {
-    metric: string;
-    rows: ExperimentMetricQueryResponse;
-  }[] = [];
-
-  let unknownVariations: string[] = [];
-
-  // Everything done in a single query (Mixpanel, Google Analytics)
-  // Need to convert to the same format as SQL rows
-  if (queryData.has("results")) {
-    const results = queryData.get("results");
-    if (!results) throw new Error("Empty experiment results");
-    const data = results.result as ExperimentResults;
-
-    unknownVariations = data.unknownVariations;
-
-    const byMetric: { [key: string]: ExperimentMetricQueryResponse } = {};
-    data.dimensions.forEach((row) => {
-      row.variations.forEach((v) => {
-        Object.keys(v.metrics).forEach((metric) => {
-          const stats = v.metrics[metric];
-          byMetric[metric] = byMetric[metric] || [];
-          byMetric[metric].push({
-            ...stats,
-            dimension: row.dimension,
-            variation: variations[v.variation].id,
-          });
-        });
-      });
-    });
-
-    Object.keys(byMetric).forEach((metric) => {
-      metricRows.push({
-        metric,
-        rows: byMetric[metric],
-      });
-    });
-  }
-  // One query for each metric, can just use the rows directly from the query
-  else {
-    queryData.forEach((query, key) => {
-      const metric = metricMap.get(key);
-      if (!metric) return;
-
-      metricRows.push({
-        metric: key,
-        rows: query.result as ExperimentMetricQueryResponse,
-      });
-    });
-  }
-
-  const dimensionMap: Map<string, ExperimentReportResultDimension> = new Map();
-  await promiseAllChunks(
-    metricRows.map((data) => {
-      const metric = metricMap.get(data.metric);
-      return async () => {
-        if (!metric) return;
-        const result = await analyzeExperimentMetric(
-          variations,
-          metric,
-          data.rows,
-          dimension === "pre:date" ? 100 : MAX_DIMENSIONS
-        );
-        unknownVariations = unknownVariations.concat(result.unknownVariations);
-
-        result.dimensions.forEach((row) => {
-          const dim = dimensionMap.get(row.dimension) || {
-            name: row.dimension,
-            srm: row.srm,
-            variations: [],
-          };
-
-          row.variations.forEach((v, i) => {
-            const data = dim.variations[i] || {
-              users: v.users,
-              metrics: {},
-            };
-            data.metrics[metric.id] = {
-              ...v,
-              buckets: [],
-            };
-            dim.variations[i] = data;
-          });
-
-          dimensionMap.set(row.dimension, dim);
-        });
-      };
-    }),
-    3
-  );
-
-  const dimensions = Array.from(dimensionMap.values());
-  if (!dimensions.length) {
-    dimensions.push({
-      name: "All",
-      srm: 1,
-      variations: [],
-    });
-  }
-
-  return {
-    unknownVariations: Array.from(new Set(unknownVariations)),
-    dimensions,
-  };
 }

--- a/packages/back-end/src/services/reports.ts
+++ b/packages/back-end/src/services/reports.ts
@@ -177,8 +177,9 @@ export async function runReport(report: ReportInterface) {
       ...report.args,
     });
     updates.queries = queries;
-    updates.results = results;
+    updates.results = results || report.results;
     updates.runStarted = new Date();
+    updates.error = "";
   } else {
     throw new Error("Unsupported report type");
   }

--- a/packages/back-end/src/services/stats.ts
+++ b/packages/back-end/src/services/stats.ts
@@ -1,8 +1,18 @@
 import { MetricInterface, MetricStats } from "../../types/metric";
 import { PythonShell } from "python-shell";
 import { promisify } from "util";
-import { ExperimentMetricQueryResponse } from "../types/Integration";
-import { ExperimentReportVariation } from "../../types/report";
+import {
+  ExperimentMetricQueryResponse,
+  ExperimentResults,
+} from "../types/Integration";
+import {
+  ExperimentReportResultDimension,
+  ExperimentReportResults,
+  ExperimentReportVariation,
+} from "../../types/report";
+import { QueryMap } from "./queries";
+import { getMetricsByOrganization } from "../models/MetricModel";
+import { promiseAllChunks } from "../util/promise";
 
 export const MAX_DIMENSIONS = 20;
 
@@ -123,6 +133,124 @@ print(json.dumps({
   }
 
   return parsed;
+}
+
+export async function analyzeExperimentResults(
+  organization: string,
+  variations: ExperimentReportVariation[],
+  dimension: string | undefined,
+  queryData: QueryMap
+): Promise<ExperimentReportResults> {
+  const metrics = await getMetricsByOrganization(organization);
+  const metricMap = new Map<string, MetricInterface>();
+  metrics.forEach((m) => {
+    metricMap.set(m.id, m);
+  });
+
+  const metricRows: {
+    metric: string;
+    rows: ExperimentMetricQueryResponse;
+  }[] = [];
+
+  let unknownVariations: string[] = [];
+
+  // Everything done in a single query (Mixpanel, Google Analytics)
+  // Need to convert to the same format as SQL rows
+  if (queryData.has("results")) {
+    const results = queryData.get("results");
+    if (!results) throw new Error("Empty experiment results");
+    const data = results.result as ExperimentResults;
+
+    unknownVariations = data.unknownVariations;
+
+    const byMetric: { [key: string]: ExperimentMetricQueryResponse } = {};
+    data.dimensions.forEach((row) => {
+      row.variations.forEach((v) => {
+        Object.keys(v.metrics).forEach((metric) => {
+          const stats = v.metrics[metric];
+          byMetric[metric] = byMetric[metric] || [];
+          byMetric[metric].push({
+            ...stats,
+            dimension: row.dimension,
+            variation: variations[v.variation].id,
+          });
+        });
+      });
+    });
+
+    Object.keys(byMetric).forEach((metric) => {
+      metricRows.push({
+        metric,
+        rows: byMetric[metric],
+      });
+    });
+  }
+  // One query for each metric, can just use the rows directly from the query
+  else {
+    queryData.forEach((query, key) => {
+      const metric = metricMap.get(key);
+      if (!metric) return;
+
+      metricRows.push({
+        metric: key,
+        rows: query.result as ExperimentMetricQueryResponse,
+      });
+    });
+  }
+
+  const dimensionMap: Map<string, ExperimentReportResultDimension> = new Map();
+  await promiseAllChunks(
+    metricRows.map((data) => {
+      const metric = metricMap.get(data.metric);
+      return async () => {
+        if (!metric) return;
+        const result = await analyzeExperimentMetric(
+          variations,
+          metric,
+          data.rows,
+          dimension === "pre:date" ? 100 : MAX_DIMENSIONS
+        );
+        unknownVariations = unknownVariations.concat(result.unknownVariations);
+
+        result.dimensions.forEach((row) => {
+          const dim = dimensionMap.get(row.dimension) || {
+            name: row.dimension,
+            srm: row.srm,
+            variations: [],
+          };
+
+          row.variations.forEach((v, i) => {
+            const data = dim.variations[i] || {
+              users: v.users,
+              metrics: {},
+            };
+            data.metrics[metric.id] = {
+              ...v,
+              buckets: [],
+            };
+            dim.variations[i] = data;
+          });
+
+          dimensionMap.set(row.dimension, dim);
+        });
+      };
+    }),
+    3
+  );
+
+  const dimensions = Array.from(dimensionMap.values());
+  if (!dimensions.length) {
+    dimensions.push({
+      name: "All",
+      srm: 1,
+      variations: [],
+    });
+  }
+
+  return {
+    unknownVariations: Array.from(new Set(unknownVariations)),
+    dimensions,
+  };
 }
 
 /**

--- a/packages/back-end/types/api.d.ts
+++ b/packages/back-end/types/api.d.ts
@@ -1,6 +1,8 @@
+import { ExperimentStatus } from "./experiment";
+
 export interface ExperimentOverride {
   weights?: number[];
-  status?: "draft" | "running" | "stopped";
+  status?: ExperimentStatus;
   force?: number;
   coverage?: number;
   groups?: string[];

--- a/packages/back-end/types/audit.d.ts
+++ b/packages/back-end/types/audit.d.ts
@@ -18,6 +18,7 @@ export type EventType =
   | "experiment.unarchive"
   | "experiment.delete"
   | "experiment.results"
+  | "experiment.analysis"
   | "experiment.screenshot.create"
   | "experiment.screenshot.delete"
   | "metric.create"

--- a/packages/back-end/types/experiment.d.ts
+++ b/packages/back-end/types/experiment.d.ts
@@ -42,6 +42,8 @@ export type ExperimentPhaseStringDates = Omit<
   dateEnded?: string;
 };
 
+export type ExperimentStatus = "draft" | "running" | "stopped";
+
 export interface ExperimentInterface {
   id: string;
   trackingKey: string;
@@ -72,7 +74,7 @@ export interface ExperimentInterface {
   targetURLRegex: string;
   variations: Variation[];
   archived: boolean;
-  status: "draft" | "running" | "stopped";
+  status: ExperimentStatus;
   phases: ExperimentPhase[];
   results?: "dnf" | "won" | "lost" | "inconclusive";
   winner?: number;

--- a/packages/back-end/types/report.d.ts
+++ b/packages/back-end/types/report.d.ts
@@ -6,11 +6,6 @@ export interface ReportInterfaceBase {
   dateCreated: Date;
   dateUpdated: Date;
   organization: string;
-  links: {
-    href: string;
-    display: string;
-    external: boolean;
-  }[];
   title: string;
   description: string;
   runStarted: Date | null;

--- a/packages/back-end/types/report.d.ts
+++ b/packages/back-end/types/report.d.ts
@@ -18,32 +18,39 @@ export interface ReportInterfaceBase {
   queries: Queries;
 }
 
+export interface ExperimentReportVariation {
+  id: string;
+  name: string;
+  weight: number;
+}
+export interface ExperimentReportArgs {
+  trackingKey: string;
+  datasource: string;
+  userIdType?: "anonymous" | "user";
+  startDate: Date;
+  endDate?: Date;
+  dimension?: string;
+  variations: ExperimentReportVariation[];
+  segment?: string;
+  metrics: string[];
+  guardrails?: string[];
+  activationMetric?: string;
+  queryFilter?: string;
+  skipPartialData?: boolean;
+}
+export interface ExperimentReportResultDimension {
+  name: string;
+  srm: number;
+  variations: SnapshotVariation[];
+}
+export interface ExperimentReportResults {
+  unknownVariations: string[];
+  dimensions: ExperimentReportResultDimension[];
+}
 export interface ExperimentReportInterface extends ReportInterfaceBase {
   type: "experiment";
-  args: {
-    trackingKey: string;
-    datasource: string;
-    userIdType?: "anonymous" | "user";
-    startDate: Date;
-    endDate?: Date;
-    dimension?: string;
-    variations: {
-      id: string;
-      name: string;
-      weight: number;
-    }[];
-    segment?: string;
-    metrics: string[];
-    guardrails?: string[];
-    activationMetric?: string;
-    queryFilter?: string;
-    skipPartialData?: boolean;
-  };
-  results?: {
-    name: string;
-    srm: number;
-    variations: SnapshotVariation[];
-  }[];
+  args: ExperimentReportArgs;
+  results?: ExperimentReportResults;
 }
 
 export type ReportInterface = ExperimentReportInterface;

--- a/packages/back-end/types/report.d.ts
+++ b/packages/back-end/types/report.d.ts
@@ -1,0 +1,49 @@
+import { SnapshotVariation } from "./experiment-snapshot";
+import { Queries } from "./query";
+
+export interface ReportInterfaceBase {
+  id: string;
+  dateCreated: Date;
+  dateUpdated: Date;
+  organization: string;
+  links: {
+    href: string;
+    display: string;
+    external: boolean;
+  }[];
+  title: string;
+  description: string;
+  runStarted: Date | null;
+  error?: string;
+  queries: Queries;
+}
+
+export interface ExperimentReportInterface extends ReportInterfaceBase {
+  type: "experiment";
+  args: {
+    trackingKey: string;
+    datasource: string;
+    userIdType?: "anonymous" | "user";
+    startDate: Date;
+    endDate?: Date;
+    dimension?: string;
+    variations: {
+      id: string;
+      name: string;
+      weight: number;
+    }[];
+    segment?: string;
+    metrics: string[];
+    guardrails?: string[];
+    activationMetric?: string;
+    queryFilter?: string;
+    skipPartialData?: boolean;
+  };
+  results?: {
+    name: string;
+    srm: number;
+    variations: SnapshotVariation[];
+  }[];
+}
+
+export type ReportInterface = ExperimentReportInterface;

--- a/packages/front-end/components/Experiment/AnalysisSettingsBar.tsx
+++ b/packages/front-end/components/Experiment/AnalysisSettingsBar.tsx
@@ -3,7 +3,6 @@ import { ExperimentSnapshotInterface } from "back-end/types/experiment-snapshot"
 import clsx from "clsx";
 import { useEffect, useState } from "react";
 import { useContext } from "react";
-import { FaCog } from "react-icons/fa";
 import { useAuth } from "../../services/auth";
 import { ago, datetime } from "../../services/dates";
 import { useDefinitions } from "../../services/DefinitionsContext";
@@ -14,6 +13,7 @@ import RunQueriesButton, { getQueryStatus } from "../Queries/RunQueriesButton";
 import ViewAsyncQueriesButton from "../Queries/ViewAsyncQueriesButton";
 import AnalysisForm from "./AnalysisForm";
 import RefreshSnapshotButton from "./RefreshSnapshotButton";
+import ResultMoreMenu from "./ResultMoreMenu";
 
 function isDifferent(val1?: string | boolean, val2?: string | boolean) {
   if (!val1 && !val2) return false;
@@ -54,6 +54,7 @@ export default function AnalysisSettingsBar({
   setPhase,
   mutate,
   mutateExperiment,
+  editMetrics,
 }: {
   experiment: ExperimentInterfaceStringDates;
   snapshot?: ExperimentSnapshotInterface;
@@ -64,6 +65,7 @@ export default function AnalysisSettingsBar({
   setDimension: (dimension: string) => void;
   mutate: () => void;
   mutateExperiment: () => void;
+  editMetrics: () => void;
 }) {
   const { getDatasourceById, dimensions } = useDefinitions();
   const datasource = getDatasourceById(experiment.datasource);
@@ -101,6 +103,8 @@ export default function AnalysisSettingsBar({
   }
 
   const status = getQueryStatus(latest?.queries || [], latest?.error);
+
+  const hasData = snapshot?.results?.[0]?.variations?.length > 0;
 
   return (
     <div>
@@ -225,6 +229,21 @@ export default function AnalysisSettingsBar({
             )}
           </div>
         )}
+        <div className="col-auto">
+          <ResultMoreMenu
+            id={snapshot?.id || ""}
+            configure={() => setModalOpen(true)}
+            editMetrics={editMetrics}
+            notebookUrl={`/experiments/notebook/${snapshot.id}`}
+            notebookFilename={experiment.trackingKey}
+            generateReport={true}
+            queries={snapshot?.queries}
+            queryError={snapshot?.error}
+            hasUserQuery={!("skipPartialData" in snapshot)}
+            supportsNotebooks={!!datasource?.settings?.notebookRunQuery}
+            hasData={hasData}
+          />
+        </div>
       </div>
       {permissions.runExperiments && datasource && (
         <div className="px-3">
@@ -249,18 +268,6 @@ export default function AnalysisSettingsBar({
                 />
               </div>
             )}
-            <div style={{ flex: 1 }} />
-            <div className="col-auto">
-              <a
-                href="#"
-                onClick={(e) => {
-                  e.preventDefault();
-                  setModalOpen(true);
-                }}
-              >
-                <FaCog /> Configure Analysis
-              </a>
-            </div>
           </div>
         </div>
       )}

--- a/packages/front-end/components/Experiment/BreakDownResults.tsx
+++ b/packages/front-end/components/Experiment/BreakDownResults.tsx
@@ -13,6 +13,7 @@ import {
   ExperimentReportResultDimension,
   ExperimentReportVariation,
 } from "back-end/types/report";
+import { ExperimentStatus } from "back-end/types/experiment";
 
 const FULL_STATS_LIMIT = 5;
 
@@ -54,7 +55,7 @@ const BreakDownResults: FC<{
   startDate: string;
   reportDate: Date;
   activationMetric?: string;
-  status: "running" | "draft" | "stopped";
+  status: ExperimentStatus;
 }> = ({
   dimensionId,
   results,

--- a/packages/front-end/components/Experiment/BreakDownResults.tsx
+++ b/packages/front-end/components/Experiment/BreakDownResults.tsx
@@ -8,7 +8,7 @@ import {
   useRiskVariation,
 } from "../../services/experiments";
 import ResultsTable from "./ResultsTable";
-import { MetricInterface } from "../../../back-end/types/metric";
+import { MetricInterface } from "back-end/types/metric";
 import Toggle from "../Forms/Toggle";
 import Tooltip from "../Tooltip";
 
@@ -81,9 +81,11 @@ const BreakDownResults: FC<{
   }, [snapshot]);
 
   const risk = useRiskVariation(
-    experiment,
+    experiment.variations.length,
     [].concat(...tables.map((t) => t.rows))
   );
+
+  const phase = experiment.phases[snapshot.phase];
 
   return (
     <div className="mb-3">
@@ -187,10 +189,18 @@ const BreakDownResults: FC<{
           <div className="experiment-compact-holder">
             <ResultsTable
               dateCreated={snapshot.dateCreated}
-              experiment={experiment}
+              isLatestPhase={snapshot.phase === experiment.phases.length - 1}
+              startDate={phase.dateStarted}
+              status={experiment.status}
+              variations={experiment.variations.map((v, i) => {
+                return {
+                  id: v.key || i + "",
+                  name: v.name,
+                  weight: phase.variationWeights[i] || 0,
+                };
+              })}
               id={table.metric.id}
               labelHeader={dimension}
-              phase={snapshot.phase}
               renderLabelColumn={(label) => label || <em>unknown</em>}
               rows={table.rows}
               fullStats={fullStats}

--- a/packages/front-end/components/Experiment/BreakDownResults.tsx
+++ b/packages/front-end/components/Experiment/BreakDownResults.tsx
@@ -1,6 +1,4 @@
 import { FC, useMemo, useState } from "react";
-import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
-import { ExperimentSnapshotInterface } from "back-end/types/experiment-snapshot";
 import { FaExclamationTriangle, FaQuestionCircle } from "react-icons/fa";
 import { useDefinitions } from "../../services/DefinitionsContext";
 import {
@@ -11,6 +9,10 @@ import ResultsTable from "./ResultsTable";
 import { MetricInterface } from "back-end/types/metric";
 import Toggle from "../Forms/Toggle";
 import Tooltip from "../Tooltip";
+import {
+  ExperimentReportResultDimension,
+  ExperimentReportVariation,
+} from "../../../back-end/types/report";
 
 const FULL_STATS_LIMIT = 5;
 
@@ -43,30 +45,47 @@ function getAllocationText(weights: number[]) {
 }
 
 const BreakDownResults: FC<{
-  snapshot: ExperimentSnapshotInterface;
-  experiment: ExperimentInterfaceStringDates;
-}> = ({ snapshot, experiment }) => {
+  results: ExperimentReportResultDimension[];
+  variations: ExperimentReportVariation[];
+  metrics: string[];
+  guardrails?: string[];
+  dimensionId: string;
+  isLatestPhase: boolean;
+  startDate: string;
+  reportDate: Date;
+  activationMetric?: string;
+  status: "running" | "draft" | "stopped";
+}> = ({
+  dimensionId,
+  results,
+  variations,
+  metrics,
+  guardrails,
+  isLatestPhase,
+  startDate,
+  activationMetric,
+  status,
+  reportDate,
+}) => {
   const { getDimensionById, getMetricById } = useDefinitions();
 
   const dimension = useMemo(() => {
-    return getDimensionById(snapshot.dimension)?.name || "Dimension";
-  }, [getDimensionById, snapshot.dimension]);
+    return getDimensionById(dimensionId)?.name || "Dimension";
+  }, [getDimensionById, dimensionId]);
 
-  const tooManyDimensions = snapshot.results?.length > FULL_STATS_LIMIT;
+  const tooManyDimensions = results.length > FULL_STATS_LIMIT;
 
   const [fullStatsToggle, setFullStats] = useState(false);
   const fullStats = !tooManyDimensions || fullStatsToggle;
 
   const tables = useMemo<TableDef[]>(() => {
-    return Array.from(
-      new Set(experiment.metrics.concat(experiment.guardrails || []))
-    )
+    return Array.from(new Set(metrics.concat(guardrails || [])))
       .map((metricId) => {
         const metric = getMetricById(metricId);
         return {
           metric,
-          isGuardrail: !experiment.metrics.includes(metricId),
-          rows: snapshot.results.map((d) => {
+          isGuardrail: !metrics.includes(metricId),
+          rows: results.map((d) => {
             return {
               label: d.name,
               metric,
@@ -78,22 +97,20 @@ const BreakDownResults: FC<{
         };
       })
       .filter((table) => table.metric);
-  }, [snapshot]);
+  }, [results, metrics, guardrails]);
 
   const risk = useRiskVariation(
-    experiment.variations.length,
+    variations.length,
     [].concat(...tables.map((t) => t.rows))
   );
-
-  const phase = experiment.phases[snapshot.phase];
 
   return (
     <div className="mb-3">
       <div className="mb-4 px-3">
-        {snapshot.dimension === "pre:activation" && snapshot.activationMetric && (
+        {dimensionId === "pre:activation" && activationMetric && (
           <div className="alert alert-info mt-1">
             Your experiment has an Activation Metric (
-            <strong>{getMetricById(snapshot.activationMetric)?.name}</strong>
+            <strong>{getMetricById(activationMetric)?.name}</strong>
             ). This report lets you compare activated users with those who
             entered into the experiment, but were not activated.
           </div>
@@ -103,7 +120,7 @@ const BreakDownResults: FC<{
           <thead>
             <tr>
               <th>{dimension}</th>
-              {experiment.variations.map((v, i) => (
+              {variations.map((v, i) => (
                 <th key={i}>{v.name}</th>
               ))}
               <th>Expected</th>
@@ -117,24 +134,18 @@ const BreakDownResults: FC<{
             </tr>
           </thead>
           <tbody>
-            {snapshot.results?.map((r, i) => (
+            {results?.map((r, i) => (
               <tr key={i}>
                 <td>{r.name || <em>unknown</em>}</td>
-                {experiment.variations.map((v, i) => (
+                {variations.map((v, i) => (
                   <td key={i}>
                     {numberFormatter.format(r.variations[i]?.users || 0)}
                   </td>
                 ))}
+                <td>{getAllocationText(variations.map((v) => v.weight))}</td>
                 <td>
                   {getAllocationText(
-                    experiment.phases[snapshot.phase]?.variationWeights || []
-                  )}
-                </td>
-                <td>
-                  {getAllocationText(
-                    experiment.variations.map(
-                      (v, i) => r.variations[i]?.users || 0
-                    )
+                    variations.map((v, i) => r.variations[i]?.users || 0)
                   )}
                 </td>
                 {r.srm < 0.001 ? (
@@ -188,17 +199,11 @@ const BreakDownResults: FC<{
 
           <div className="experiment-compact-holder">
             <ResultsTable
-              dateCreated={snapshot.dateCreated}
-              isLatestPhase={snapshot.phase === experiment.phases.length - 1}
-              startDate={phase.dateStarted}
-              status={experiment.status}
-              variations={experiment.variations.map((v, i) => {
-                return {
-                  id: v.key || i + "",
-                  name: v.name,
-                  weight: phase.variationWeights[i] || 0,
-                };
-              })}
+              dateCreated={reportDate}
+              isLatestPhase={isLatestPhase}
+              startDate={startDate}
+              status={status}
+              variations={variations}
               id={table.metric.id}
               labelHeader={dimension}
               renderLabelColumn={(label) => label || <em>unknown</em>}

--- a/packages/front-end/components/Experiment/BreakDownResults.tsx
+++ b/packages/front-end/components/Experiment/BreakDownResults.tsx
@@ -12,7 +12,7 @@ import Tooltip from "../Tooltip";
 import {
   ExperimentReportResultDimension,
   ExperimentReportVariation,
-} from "../../../back-end/types/report";
+} from "back-end/types/report";
 
 const FULL_STATS_LIMIT = 5;
 

--- a/packages/front-end/components/Experiment/BreakDownResults.tsx
+++ b/packages/front-end/components/Experiment/BreakDownResults.tsx
@@ -67,7 +67,7 @@ const BreakDownResults: FC<{
   status,
   reportDate,
 }) => {
-  const { getDimensionById, getMetricById } = useDefinitions();
+  const { getDimensionById, getMetricById, ready } = useDefinitions();
 
   const dimension = useMemo(() => {
     return getDimensionById(dimensionId)?.name || "Dimension";
@@ -79,6 +79,7 @@ const BreakDownResults: FC<{
   const fullStats = !tooManyDimensions || fullStatsToggle;
 
   const tables = useMemo<TableDef[]>(() => {
+    if (!ready) return [];
     return Array.from(new Set(metrics.concat(guardrails || [])))
       .map((metricId) => {
         const metric = getMetricById(metricId);
@@ -97,7 +98,7 @@ const BreakDownResults: FC<{
         };
       })
       .filter((table) => table.metric);
-  }, [results, metrics, guardrails]);
+  }, [results, metrics, guardrails, ready]);
 
   const risk = useRiskVariation(
     variations.length,

--- a/packages/front-end/components/Experiment/ChanceToWinColumn.tsx
+++ b/packages/front-end/components/Experiment/ChanceToWinColumn.tsx
@@ -1,5 +1,4 @@
 import clsx from "clsx";
-import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
 import { SnapshotMetric } from "back-end/types/experiment-snapshot";
 import { MetricInterface } from "back-end/types/metric";
 import useConfidenceLevels from "../../hooks/useConfidenceLevels";
@@ -18,15 +17,17 @@ const percentFormatter = new Intl.NumberFormat(undefined, {
 
 export default function ChanceToWinColumn({
   metric,
-  experiment,
-  phase,
+  status,
+  isLatestPhase,
+  startDate,
   snapshotDate,
   baseline,
   stats,
 }: {
   metric: MetricInterface;
-  experiment: ExperimentInterfaceStringDates;
-  phase: number;
+  status: "draft" | "running" | "stopped";
+  isLatestPhase: boolean;
+  startDate: string;
   snapshotDate: Date;
   baseline: SnapshotMetric;
   stats: SnapshotMetric;
@@ -60,13 +61,13 @@ export default function ChanceToWinColumn({
         <em>no data</em>
       ) : !enoughData ? (
         <NotEnoughData
-          experimentStatus={experiment.status}
-          isLatestPhase={phase === experiment.phases.length - 1}
+          experimentStatus={status}
+          isLatestPhase={isLatestPhase}
           baselineValue={baseline?.value}
           variationValue={stats?.value}
           minSampleSize={minSampleSize}
           snapshotCreated={snapshotDate}
-          phaseStart={experiment.phases[phase]?.dateStarted}
+          phaseStart={startDate}
         />
       ) : suspiciousChange ? (
         <div>

--- a/packages/front-end/components/Experiment/ChanceToWinColumn.tsx
+++ b/packages/front-end/components/Experiment/ChanceToWinColumn.tsx
@@ -9,6 +9,7 @@ import {
 } from "../../services/experiments";
 import { defaultMinSampleSize } from "../../services/metrics";
 import NotEnoughData from "./NotEnoughData";
+import { ExperimentStatus } from "back-end/types/experiment";
 
 const percentFormatter = new Intl.NumberFormat(undefined, {
   style: "percent",
@@ -25,7 +26,7 @@ export default function ChanceToWinColumn({
   stats,
 }: {
   metric: MetricInterface;
-  status: "draft" | "running" | "stopped";
+  status: ExperimentStatus;
   isLatestPhase: boolean;
   startDate: string;
   snapshotDate: Date;

--- a/packages/front-end/components/Experiment/CompactResults.tsx
+++ b/packages/front-end/components/Experiment/CompactResults.tsx
@@ -1,9 +1,4 @@
 import React, { FC } from "react";
-import {
-  ExperimentInterfaceStringDates,
-  ExperimentPhaseStringDates,
-} from "back-end/types/experiment";
-import { ExperimentSnapshotInterface } from "back-end/types/experiment-snapshot";
 import { useDefinitions } from "../../services/DefinitionsContext";
 import { MdSwapCalls } from "react-icons/md";
 import Tooltip from "../Tooltip";
@@ -14,20 +9,41 @@ import {
 } from "../../services/experiments";
 import { useMemo } from "react";
 import ResultsTable from "./ResultsTable";
+import {
+  ExperimentReportResultDimension,
+  ExperimentReportVariation,
+} from "back-end/types/report";
 
 const CompactResults: FC<{
-  snapshot: ExperimentSnapshotInterface;
-  experiment: ExperimentInterfaceStringDates;
-  phase?: ExperimentPhaseStringDates;
   isUpdating?: boolean;
   editMetrics?: () => void;
-}> = ({ snapshot, experiment, phase, isUpdating, editMetrics }) => {
+  variations: ExperimentReportVariation[];
+  unknownVariations: string[];
+  results: ExperimentReportResultDimension;
+  reportDate: Date;
+  startDate: string;
+  isLatestPhase: boolean;
+  status: "running" | "draft" | "stopped";
+  metrics: string[];
+  id: string;
+}> = ({
+  results,
+  variations,
+  isUpdating,
+  unknownVariations,
+  editMetrics,
+  reportDate,
+  startDate,
+  status,
+  isLatestPhase,
+  metrics,
+  id,
+}) => {
   const { getMetricById } = useDefinitions();
 
   const rows = useMemo<ExperimentTableRow[]>(() => {
-    const results = snapshot.results[0];
     if (!results || !results.variations) return [];
-    return experiment.metrics
+    return metrics
       .map((m) => {
         const metric = getMetricById(m);
         return {
@@ -40,22 +56,22 @@ const CompactResults: FC<{
         };
       })
       .filter((row) => row.metric);
-  }, [snapshot]);
+  }, [results]);
 
   const users = useMemo(() => {
-    const vars = snapshot.results?.[0]?.variations;
-    return experiment.variations.map((v, i) => vars?.[i]?.users || 0);
-  }, [snapshot]);
+    const vars = results?.variations;
+    return variations.map((v, i) => vars?.[i]?.users || 0);
+  }, [results]);
 
-  const risk = useRiskVariation(experiment, rows);
+  const risk = useRiskVariation(variations.length, rows);
 
   return (
     <>
       <div className="px-3">
         <DataQualityWarning
-          experiment={experiment}
-          snapshot={snapshot}
-          phase={phase}
+          results={results}
+          unknownVariations={unknownVariations}
+          variations={variations}
           isUpdating={isUpdating}
         />
         <h3 className="mb-3">
@@ -77,12 +93,14 @@ const CompactResults: FC<{
       </div>
       <div className="mb-3 experiment-compact-holder">
         <ResultsTable
-          dateCreated={snapshot.dateCreated}
-          experiment={experiment}
-          id={experiment.id}
+          dateCreated={reportDate}
+          isLatestPhase={isLatestPhase}
+          startDate={startDate}
+          status={status}
+          variations={variations}
+          id={id}
           {...risk}
           labelHeader="Metric"
-          phase={snapshot.phase}
           users={users}
           renderLabelColumn={(label, metric) => {
             if (!metric.inverse) return label;

--- a/packages/front-end/components/Experiment/CompactResults.tsx
+++ b/packages/front-end/components/Experiment/CompactResults.tsx
@@ -39,10 +39,10 @@ const CompactResults: FC<{
   metrics,
   id,
 }) => {
-  const { getMetricById } = useDefinitions();
+  const { getMetricById, ready } = useDefinitions();
 
   const rows = useMemo<ExperimentTableRow[]>(() => {
-    if (!results || !results.variations) return [];
+    if (!results || !results.variations || !ready) return [];
     return metrics
       .map((m) => {
         const metric = getMetricById(m);
@@ -56,7 +56,7 @@ const CompactResults: FC<{
         };
       })
       .filter((row) => row.metric);
-  }, [results]);
+  }, [results, ready]);
 
   const users = useMemo(() => {
     const vars = results?.variations;

--- a/packages/front-end/components/Experiment/CompactResults.tsx
+++ b/packages/front-end/components/Experiment/CompactResults.tsx
@@ -13,6 +13,7 @@ import {
   ExperimentReportResultDimension,
   ExperimentReportVariation,
 } from "back-end/types/report";
+import { ExperimentStatus } from "back-end/types/experiment";
 
 const CompactResults: FC<{
   isUpdating?: boolean;
@@ -23,7 +24,7 @@ const CompactResults: FC<{
   reportDate: Date;
   startDate: string;
   isLatestPhase: boolean;
-  status: "running" | "draft" | "stopped";
+  status: ExperimentStatus;
   metrics: string[];
   id: string;
 }> = ({

--- a/packages/front-end/components/Experiment/DateResults.tsx
+++ b/packages/front-end/components/Experiment/DateResults.tsx
@@ -32,7 +32,7 @@ const DateResults: FC<{
   metrics: string[];
   guardrails?: string[];
 }> = ({ results, variations, metrics, guardrails }) => {
-  const { getMetricById } = useDefinitions();
+  const { getMetricById, ready } = useDefinitions();
 
   const [cumulative, setCumulative] = useState(false);
 
@@ -64,6 +64,8 @@ const DateResults: FC<{
 
   // Data for the metric graphs
   const metricSections = useMemo<Metric[]>(() => {
+    if (!ready) return [];
+
     const sortedResults = [...results];
     sortedResults.sort((a, b) => {
       return getValidDate(a.name).getTime() - getValidDate(b.name).getTime();
@@ -141,7 +143,7 @@ const DateResults: FC<{
         // Filter out any edge cases when the metric is undefined
         .filter((table) => table.metric)
     );
-  }, [results, cumulative]);
+  }, [results, cumulative, ready]);
 
   return (
     <div className="mb-4 mx-3 pb-4">

--- a/packages/front-end/components/Experiment/DateResults.tsx
+++ b/packages/front-end/components/Experiment/DateResults.tsx
@@ -11,7 +11,7 @@ import { getValidDate } from "../../services/dates";
 import {
   ExperimentReportResultDimension,
   ExperimentReportVariation,
-} from "../../../back-end/types/report";
+} from "back-end/types/report";
 
 const percentFormatter = new Intl.NumberFormat(undefined, {
   style: "percent",

--- a/packages/front-end/components/Experiment/ExperimentGraph.tsx
+++ b/packages/front-end/components/Experiment/ExperimentGraph.tsx
@@ -10,6 +10,7 @@ import { GridRows } from "@visx/grid";
 import format from "date-fns/format";
 import { useDefinitions } from "../../services/DefinitionsContext";
 import { getValidDate } from "../../services/dates";
+import { ExperimentStatus } from "back-end/types/experiment";
 
 export default function ExperimentGraph({
   resolution = "month",
@@ -19,7 +20,7 @@ export default function ExperimentGraph({
 }: {
   resolution?: "month" | "day" | "year";
   num?: number;
-  status: "all" | "draft" | "running" | "stopped";
+  status: "all" | ExperimentStatus;
   height?: number;
 }): React.ReactElement {
   const { project } = useDefinitions();

--- a/packages/front-end/components/Experiment/ExperimentList.tsx
+++ b/packages/front-end/components/Experiment/ExperimentList.tsx
@@ -2,7 +2,10 @@ import Link from "next/link";
 import React from "react";
 import useApi from "../../hooks/useApi";
 import { ago, datetime } from "../../services/dates";
-import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
+import {
+  ExperimentInterfaceStringDates,
+  ExperimentStatus,
+} from "back-end/types/experiment";
 import LoadingOverlay from "../LoadingOverlay";
 import { useDefinitions } from "../../services/DefinitionsContext";
 import { phaseSummary } from "../../services/utils";
@@ -12,7 +15,7 @@ export default function ExperimentList({
   status,
 }: {
   num: number;
-  status: "draft" | "running" | "stopped";
+  status: ExperimentStatus;
 }): React.ReactElement {
   const { project } = useDefinitions();
   const { data, error } = useApi<{

--- a/packages/front-end/components/Experiment/GuardrailResult.tsx
+++ b/packages/front-end/components/Experiment/GuardrailResult.tsx
@@ -9,7 +9,7 @@ import {
 } from "react-icons/fa";
 import { MetricInterface } from "back-end/types/metric";
 import MetricValueColumn from "./MetricValueColumn";
-import { ExperimentReportVariation } from "../../../back-end/types/report";
+import { ExperimentReportVariation } from "back-end/types/report";
 
 const WARNING_CUTOFF = 0.65;
 const DANGER_CUTOFF = 0.9;

--- a/packages/front-end/components/Experiment/GuardrailResult.tsx
+++ b/packages/front-end/components/Experiment/GuardrailResult.tsx
@@ -1,5 +1,4 @@
 import React, { FC } from "react";
-import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
 import { SnapshotVariation } from "back-end/types/experiment-snapshot";
 import clsx from "clsx";
 import {
@@ -10,6 +9,7 @@ import {
 } from "react-icons/fa";
 import { MetricInterface } from "back-end/types/metric";
 import MetricValueColumn from "./MetricValueColumn";
+import { ExperimentReportVariation } from "../../../back-end/types/report";
 
 const WARNING_CUTOFF = 0.65;
 const DANGER_CUTOFF = 0.9;
@@ -24,18 +24,18 @@ function hasEnoughData(value1: number, value2: number): boolean {
 }
 
 const GuardrailResults: FC<{
-  variations: SnapshotVariation[];
-  experiment: ExperimentInterfaceStringDates;
+  data: SnapshotVariation[];
+  variations: ExperimentReportVariation[];
   metric: MetricInterface;
-}> = ({ variations, experiment, metric }) => {
+}> = ({ data, variations, metric }) => {
   let status: "danger" | "success" | "warning" | "secondary" = "secondary";
 
   const maxChance = Math.max(
-    ...variations.slice(1).map((v) => {
+    ...data.slice(1).map((v) => {
       if (
         !hasEnoughData(
           v.metrics[metric.id]?.value,
-          variations[0].metrics[metric.id]?.value
+          data[0].metrics[metric.id]?.value
         )
       ) {
         return -1;
@@ -80,8 +80,8 @@ const GuardrailResults: FC<{
             </tr>
           </thead>
           <tbody>
-            {experiment.variations.map((v, i) => {
-              const stats = variations[i]?.metrics?.[metric.id];
+            {variations.map((v, i) => {
+              const stats = data[i]?.metrics?.[metric.id];
               if (!stats) {
                 return (
                   <tr key={i}>
@@ -100,13 +100,13 @@ const GuardrailResults: FC<{
                   <MetricValueColumn
                     metric={metric}
                     stats={stats}
-                    users={variations[i].users}
+                    users={data[i].users}
                   />
                   {!i ? (
                     <td></td>
                   ) : hasEnoughData(
                       stats.value,
-                      variations[0].metrics[metric.id]?.value
+                      data[0].metrics[metric.id]?.value
                     ) ? (
                     <td
                       className={clsx("chance result-number align-middle", {

--- a/packages/front-end/components/Experiment/NotEnoughData.tsx
+++ b/packages/front-end/components/Experiment/NotEnoughData.tsx
@@ -1,4 +1,5 @@
 import { formatDistance } from "date-fns";
+import { ExperimentStatus } from "back-end/types/experiment";
 import { getValidDate } from "../../services/dates";
 
 export default function NotEnoughData({
@@ -12,7 +13,7 @@ export default function NotEnoughData({
 }: {
   snapshotCreated: Date;
   phaseStart: string;
-  experimentStatus: "draft" | "running" | "stopped";
+  experimentStatus: ExperimentStatus;
   isLatestPhase: boolean;
   minSampleSize: number;
   variationValue: number;

--- a/packages/front-end/components/Experiment/ResultMoreMenu.tsx
+++ b/packages/front-end/components/Experiment/ResultMoreMenu.tsx
@@ -1,0 +1,130 @@
+import { useRouter } from "next/router";
+import { useContext } from "react";
+import { FaCog, FaFileDownload, FaPencilAlt } from "react-icons/fa";
+import { GrTableAdd } from "react-icons/gr";
+import { Queries } from "back-end/types/query";
+import { ReportInterface } from "back-end/types/report";
+import { useAuth } from "../../services/auth";
+import Button from "../Button";
+import MoreMenu from "../Dropdown/MoreMenu";
+import { UserContext } from "../ProtectedPage";
+import ViewAsyncQueriesButton from "../Queries/ViewAsyncQueriesButton";
+
+export default function ResultMoreMenu({
+  editMetrics,
+  configure,
+  queries,
+  queryError,
+  hasData,
+  supportsNotebooks,
+  id,
+  generateReport,
+  notebookUrl,
+  notebookFilename,
+  hasUserQuery,
+}: {
+  editMetrics?: () => void;
+  configure?: () => void;
+  queries?: Queries;
+  queryError?: string;
+  hasData?: boolean;
+  supportsNotebooks?: boolean;
+  id: string;
+  generateReport?: boolean;
+  notebookUrl?: string;
+  notebookFilename?: string;
+  hasUserQuery?: boolean;
+}) {
+  const { apiCall } = useAuth();
+  const router = useRouter();
+  const { permissions } = useContext(UserContext);
+
+  return (
+    <MoreMenu id="exp-result-actions">
+      <button
+        className="btn dropdown-item py-2"
+        onClick={(e) => {
+          e.preventDefault();
+          configure();
+        }}
+      >
+        <FaCog className="mr-2" /> Configure Analysis
+      </button>
+      {queries?.length > 0 && (
+        <ViewAsyncQueriesButton
+          queries={queries.map((q) => q.query)}
+          error={queryError}
+          className="dropdown-item py-2"
+        />
+      )}
+      {hasData && queries && !hasUserQuery && generateReport && (
+        <Button
+          className="dropdown-item py-2"
+          color="outline-info"
+          onClick={async () => {
+            const res = await apiCall<{ report: ReportInterface }>(
+              `/experiments/report/${id}`,
+              {
+                method: "POST",
+              }
+            );
+
+            if (!res.report) {
+              throw new Error("Failed to create report");
+            }
+
+            await router.push(`/report/${res.report.id}`);
+          }}
+        >
+          <GrTableAdd className="mr-2" style={{ fontSize: "1.2rem" }} /> Ad-hoc
+          Report
+        </Button>
+      )}
+
+      {hasData && !hasUserQuery && supportsNotebooks && (
+        <Button
+          color="outline-info"
+          className="dropdown-item py-2"
+          onClick={async () => {
+            const res = await apiCall<{ notebook: string }>(notebookUrl, {
+              method: "POST",
+            });
+
+            const url = URL.createObjectURL(
+              new Blob([res.notebook], {
+                type: "application/json",
+              })
+            );
+
+            const name = notebookFilename
+              .replace(/[^a-zA-Z0-9_-]+/g, "")
+              .replace(/[-]+/g, "_")
+              .replace(/[_]{2,}/g, "_");
+
+            const d = new Date().toISOString().slice(0, 10).replace(/-/g, "_");
+
+            const el = document.createElement("a");
+            el.href = url;
+            el.download = `${name}_${d}.ipynb`;
+            el.click();
+          }}
+        >
+          <FaFileDownload className="mr-2" style={{ fontSize: "1.2rem" }} />{" "}
+          Download Notebook
+        </Button>
+      )}
+
+      {permissions.runExperiments && editMetrics && (
+        <button
+          type="button"
+          className="dropdown-item py-2"
+          onClick={() => {
+            editMetrics();
+          }}
+        >
+          <FaPencilAlt className="mr-2" /> Add/Remove Metrics
+        </button>
+      )}
+    </MoreMenu>
+  );
+}

--- a/packages/front-end/components/Experiment/ResultMoreMenu.tsx
+++ b/packages/front-end/components/Experiment/ResultMoreMenu.tsx
@@ -24,7 +24,7 @@ export default function ResultMoreMenu({
   hasUserQuery,
 }: {
   editMetrics?: () => void;
-  configure?: () => void;
+  configure: () => void;
   queries?: Queries;
   queryError?: string;
   hasData?: boolean;
@@ -81,38 +81,45 @@ export default function ResultMoreMenu({
         </Button>
       )}
 
-      {hasData && !hasUserQuery && supportsNotebooks && (
-        <Button
-          color="outline-info"
-          className="dropdown-item py-2"
-          onClick={async () => {
-            const res = await apiCall<{ notebook: string }>(notebookUrl, {
-              method: "POST",
-            });
+      {hasData &&
+        !hasUserQuery &&
+        supportsNotebooks &&
+        notebookUrl &&
+        notebookFilename && (
+          <Button
+            color="outline-info"
+            className="dropdown-item py-2"
+            onClick={async () => {
+              const res = await apiCall<{ notebook: string }>(notebookUrl, {
+                method: "POST",
+              });
 
-            const url = URL.createObjectURL(
-              new Blob([res.notebook], {
-                type: "application/json",
-              })
-            );
+              const url = URL.createObjectURL(
+                new Blob([res.notebook], {
+                  type: "application/json",
+                })
+              );
 
-            const name = notebookFilename
-              .replace(/[^a-zA-Z0-9_-]+/g, "")
-              .replace(/[-]+/g, "_")
-              .replace(/[_]{2,}/g, "_");
+              const name = notebookFilename
+                .replace(/[^a-zA-Z0-9_-]+/g, "")
+                .replace(/[-]+/g, "_")
+                .replace(/[_]{2,}/g, "_");
 
-            const d = new Date().toISOString().slice(0, 10).replace(/-/g, "_");
+              const d = new Date()
+                .toISOString()
+                .slice(0, 10)
+                .replace(/-/g, "_");
 
-            const el = document.createElement("a");
-            el.href = url;
-            el.download = `${name}_${d}.ipynb`;
-            el.click();
-          }}
-        >
-          <FaFileDownload className="mr-2" style={{ fontSize: "1.2rem" }} />{" "}
-          Download Notebook
-        </Button>
-      )}
+              const el = document.createElement("a");
+              el.href = url;
+              el.download = `${name}_${d}.ipynb`;
+              el.click();
+            }}
+          >
+            <FaFileDownload className="mr-2" style={{ fontSize: "1.2rem" }} />{" "}
+            Download Notebook
+          </Button>
+        )}
 
       {permissions.runExperiments && editMetrics && (
         <button

--- a/packages/front-end/components/Experiment/Results.tsx
+++ b/packages/front-end/components/Experiment/Results.tsx
@@ -3,25 +3,18 @@ import { FC, useState, useContext } from "react";
 import useApi from "../../hooks/useApi";
 import LoadingOverlay from "../LoadingOverlay";
 import clsx from "clsx";
-import { ReportInterface } from "back-end/types/report";
 import { UserContext } from "../ProtectedPage";
-import ViewQueryButton from "../Metrics/ViewQueryButton";
-import { FaFileDownload, FaPencilAlt } from "react-icons/fa";
+import { FaPencilAlt } from "react-icons/fa";
 import dynamic from "next/dynamic";
 import Markdown from "../Markdown/Markdown";
 import { ExperimentSnapshotInterface } from "back-end/types/experiment-snapshot";
 import { useDefinitions } from "../../services/DefinitionsContext";
 import GuardrailResults from "./GuardrailResult";
-import ViewAsyncQueriesButton from "../Queries/ViewAsyncQueriesButton";
 import { getQueryStatus } from "../Queries/RunQueriesButton";
-import { useAuth } from "../../services/auth";
 import { ago, getValidDate } from "../../services/dates";
-import Button from "../Button";
 import { useEffect } from "react";
 import DateResults from "./DateResults";
 import AnalysisSettingsBar from "./AnalysisSettingsBar";
-import { MdExplore } from "react-icons/md";
-import { useRouter } from "next/router";
 
 const BreakDownResults = dynamic(() => import("./BreakDownResults"));
 const CompactResults = dynamic(() => import("./CompactResults"));
@@ -34,12 +27,8 @@ const Results: FC<{
 }> = ({ experiment, editMetrics, editResult, mutateExperiment }) => {
   const { dimensions, getMetricById, getDatasourceById } = useDefinitions();
 
-  const { apiCall } = useAuth();
-
   const [phase, setPhase] = useState(experiment.phases.length - 1);
   const [dimension, setDimension] = useState("");
-
-  const router = useRouter();
 
   useEffect(() => {
     setPhase(experiment.phases.length - 1);
@@ -158,6 +147,7 @@ const Results: FC<{
         setDimension={setDimension}
         setPhase={setPhase}
         latest={latest}
+        editMetrics={editMetrics}
       />
       {experiment.metrics.length === 0 && (
         <div className="alert alert-info m-3">
@@ -260,109 +250,11 @@ const Results: FC<{
           )}
         </>
       )}
-      <div className="px-3">
-        <div className="row mb-3">
-          {permissions.runExperiments && editMetrics && (
-            <div className="col-auto">
-              <button
-                type="button"
-                className="btn btn-outline-secondary"
-                onClick={() => {
-                  editMetrics();
-                }}
-              >
-                Add{experiment.metrics?.length > 0 ? "/Remove" : ""} Metrics
-              </button>
-            </div>
-          )}
-          {snapshot &&
-            hasData &&
-            snapshot.hasRawQueries &&
-            "skipPartialData" in snapshot &&
-            datasource?.settings?.notebookRunQuery && (
-              <div className="col-auto">
-                <Button
-                  color="outline-info"
-                  onClick={async () => {
-                    const res = await apiCall<{ notebook: string }>(
-                      `/experiments/notebook/${snapshot.id}`,
-                      {
-                        method: "POST",
-                      }
-                    );
-
-                    const url = URL.createObjectURL(
-                      new Blob([res.notebook], {
-                        type: "application/json",
-                      })
-                    );
-
-                    const name = experiment.trackingKey
-                      .replace(/[^a-zA-Z0-9_-]+/g, "")
-                      .replace(/[-]+/g, "_")
-                      .replace(/[_]{2,}/g, "_");
-
-                    const d = new Date()
-                      .toISOString()
-                      .slice(0, 10)
-                      .replace(/-/g, "_");
-
-                    const el = document.createElement("a");
-                    el.href = url;
-                    el.download = `${name}_${d}.ipynb`;
-                    el.click();
-                  }}
-                >
-                  <FaFileDownload /> Download Notebook
-                </Button>
-              </div>
-            )}
-          {snapshot &&
-            hasData &&
-            snapshot.hasRawQueries &&
-            "skipPartialData" in snapshot && (
-              <div className="col-auto">
-                <Button
-                  color="outline-info"
-                  onClick={async () => {
-                    const res = await apiCall<{ report: ReportInterface }>(
-                      `/experiments/report/${snapshot.id}`,
-                      {
-                        method: "POST",
-                      }
-                    );
-
-                    if (!res.report) {
-                      throw new Error("Failed to create report");
-                    }
-
-                    await router.push(`/report/${res.report.id}`);
-                  }}
-                >
-                  <MdExplore /> Explore Results
-                </Button>
-              </div>
-            )}
-
-          {snapshot && (
-            <div className="col-auto">
-              {snapshot.queries?.length > 0 ? (
-                <ViewAsyncQueriesButton
-                  queries={snapshot.queries.map((q) => q.query)}
-                  error={snapshot.error}
-                />
-              ) : (
-                // From old query engine
-                snapshot.query && (
-                  <ViewQueryButton
-                    queries={[snapshot.query]}
-                    language={snapshot.queryLanguage}
-                  />
-                )
-              )}
-            </div>
-          )}
-        </div>
+      <div className="px-3 mb-3">
+        <span className="text-muted">
+          Click the 3 dots next to the Update button above to configure this
+          report, download as a Jupyter notebook, and more.
+        </span>
       </div>
     </>
   );

--- a/packages/front-end/components/Experiment/Results.tsx
+++ b/packages/front-end/components/Experiment/Results.tsx
@@ -184,7 +184,7 @@ const Results: FC<{
             isLatestPhase={phase === experiment.phases.length - 1}
             metrics={experiment.metrics}
             reportDate={snapshot.dateCreated}
-            results={snapshot.results}
+            results={snapshot.results || []}
             status={experiment.status}
             startDate={phaseObj?.dateStarted}
             dimensionId={snapshot.dimension}

--- a/packages/front-end/components/Experiment/Results.tsx
+++ b/packages/front-end/components/Experiment/Results.tsx
@@ -93,6 +93,14 @@ const Results: FC<{
   const phaseAgeMinutes =
     (Date.now() - getValidDate(phaseObj?.dateStarted).getTime()) / (1000 * 60);
 
+  const variations = experiment.variations.map((v, i) => {
+    return {
+      id: v.key || i + "",
+      name: v.name,
+      weight: phaseObj?.variationWeights?.[i] || 0,
+    };
+  });
+
   return (
     <>
       {experiment.status === "stopped" && (
@@ -175,11 +183,24 @@ const Results: FC<{
       {hasData &&
         snapshot.dimension &&
         (snapshot.dimension === "pre:date" ? (
-          <DateResults snapshot={snapshot} experiment={experiment} />
+          <DateResults
+            metrics={experiment.metrics}
+            guardrails={experiment.guardrails}
+            results={snapshot.results}
+            variations={variations}
+          />
         ) : (
           <BreakDownResults
-            snapshot={snapshot}
-            experiment={experiment}
+            isLatestPhase={phase === experiment.phases.length - 1}
+            metrics={experiment.metrics}
+            reportDate={snapshot.dateCreated}
+            results={snapshot.results}
+            status={experiment.status}
+            startDate={phaseObj?.dateStarted}
+            dimensionId={snapshot.dimension}
+            activationMetric={experiment.activationMetric}
+            guardrails={experiment.guardrails}
+            variations={variations}
             key={snapshot.dimension}
           />
         ))}
@@ -194,13 +215,7 @@ const Results: FC<{
             status={experiment.status}
             startDate={phaseObj?.dateStarted}
             unknownVariations={snapshot.unknownVariations || []}
-            variations={experiment.variations.map((v, i) => {
-              return {
-                id: v.key || i + "",
-                name: v.name,
-                weight: phaseObj?.variationWeights?.[i] || 0,
-              };
-            })}
+            variations={variations}
             isUpdating={status === "running"}
             editMetrics={editMetrics}
           />
@@ -227,13 +242,13 @@ const Results: FC<{
                   const metric = getMetricById(g);
                   if (!metric) return "";
 
-                  const variations = snapshot.results[0]?.variations;
-                  if (!variations) return "";
+                  const data = snapshot.results[0]?.variations;
+                  if (!data) return "";
 
                   return (
                     <div className="col-12 col-xl-4 col-lg-6 mb-3" key={g}>
                       <GuardrailResults
-                        experiment={experiment}
+                        data={data}
                         variations={variations}
                         metric={metric}
                       />

--- a/packages/front-end/components/Experiment/ResultsTable.tsx
+++ b/packages/front-end/components/Experiment/ResultsTable.tsx
@@ -10,11 +10,12 @@ import ChanceToWinColumn from "./ChanceToWinColumn";
 import MetricValueColumn from "./MetricValueColumn";
 import PercentGraphColumn from "./PercentGraphColumn";
 import RiskColumn from "./RiskColumn";
+import { ExperimentStatus } from "back-end/types/experiment";
 
 export type ResultsTableProps = {
   id: string;
   variations: ExperimentReportVariation[];
-  status: "running" | "draft" | "stopped";
+  status: ExperimentStatus;
   isLatestPhase: boolean;
   startDate: string;
   rows: ExperimentTableRow[];

--- a/packages/front-end/components/Experiment/StatusIndicator.tsx
+++ b/packages/front-end/components/Experiment/StatusIndicator.tsx
@@ -1,8 +1,9 @@
 import { FC } from "react";
 import styles from "./StatusIndicator.module.scss";
 import clsx from "clsx";
+import { ExperimentStatus } from "back-end/types/experiment";
 
-const getColor = (status: "draft" | "running" | "stopped") => {
+const getColor = (status: ExperimentStatus) => {
   switch (status) {
     case "draft":
       return "warning";
@@ -14,7 +15,7 @@ const getColor = (status: "draft" | "running" | "stopped") => {
 };
 
 const StatusIndicator: FC<{
-  status: "draft" | "running" | "stopped";
+  status: ExperimentStatus;
   archived: boolean;
   showBubble?: boolean;
   className?: string;

--- a/packages/front-end/components/Forms/Field.tsx
+++ b/packages/front-end/components/Forms/Field.tsx
@@ -6,9 +6,10 @@ export type SelectOptions =
   | (
       | string
       | number
+      | boolean
       | null
       | {
-          value: string | number;
+          value: string | number | boolean;
           display: string;
         }
     )[]
@@ -95,13 +96,13 @@ const Field = forwardRef(
                 if (o === null || o === undefined) return null;
                 if (typeof o === "object") {
                   return (
-                    <option key={o.value} value={o.value}>
+                    <option key={o.value + ""} value={o.value + ""}>
                       {o.display}
                     </option>
                   );
                 } else {
                   return (
-                    <option key={o} value={o}>
+                    <option key={o + ""} value={o + ""}>
                       {o}
                     </option>
                   );

--- a/packages/front-end/components/Forms/Field.tsx
+++ b/packages/front-end/components/Forms/Field.tsx
@@ -24,6 +24,7 @@ export type BaseFieldProps = {
   // eslint-disable-next-line
   render?: (id: string, ref: any) => ReactElement;
   options?: SelectOptions;
+  optionGroups?: { [key: string]: SelectOptions };
   initialOption?: string;
   minRows?: number;
   maxRows?: number;
@@ -37,6 +38,44 @@ export type FieldProps = BaseFieldProps &
     React.InputHTMLAttributes<HTMLInputElement>,
     HTMLInputElement
   >;
+
+function Options({ options }: { options: SelectOptions }) {
+  if (Array.isArray(options)) {
+    return (
+      <>
+        {options.map((o) => {
+          if (o === null || o === undefined) return null;
+          if (typeof o === "object") {
+            return (
+              <option key={o.value + ""} value={o.value + ""}>
+                {o.display}
+              </option>
+            );
+          } else {
+            return (
+              <option key={o + ""} value={o + ""}>
+                {o}
+              </option>
+            );
+          }
+        })}
+      </>
+    );
+  }
+
+  return (
+    <>
+      {" "}
+      {Object.keys(options).map((k) => {
+        return (
+          <option key={k} value={k}>
+            {options[k]}
+          </option>
+        );
+      })}
+    </>
+  );
+}
 
 const Field = forwardRef(
   (
@@ -55,6 +94,7 @@ const Field = forwardRef(
       minRows,
       maxRows,
       options,
+      optionGroups,
       type = "text",
       initialOption,
       ...otherProps
@@ -82,7 +122,7 @@ const Field = forwardRef(
           maxRows={maxRows || 6}
         />
       );
-    } else if (options) {
+    } else if (options || optionGroups) {
       component = (
         <select
           {...(otherProps as unknown)}
@@ -91,30 +131,15 @@ const Field = forwardRef(
           className={cn}
         >
           {initialOption && <option value="">{initialOption}</option>}
-          {Array.isArray(options)
-            ? options.map((o) => {
-                if (o === null || o === undefined) return null;
-                if (typeof o === "object") {
-                  return (
-                    <option key={o.value + ""} value={o.value + ""}>
-                      {o.display}
-                    </option>
-                  );
-                } else {
-                  return (
-                    <option key={o + ""} value={o + ""}>
-                      {o}
-                    </option>
-                  );
-                }
-              })
-            : Object.keys(options).map((k) => {
-                return (
-                  <option key={k} value={k}>
-                    {options[k]}
-                  </option>
-                );
-              })}
+          {options && <Options options={options} />}
+          {optionGroups &&
+            Object.keys(optionGroups).map((k) => {
+              return (
+                <optgroup label={k} key={k}>
+                  <Options options={optionGroups[k]} />
+                </optgroup>
+              );
+            })}
         </select>
       );
     } else {

--- a/packages/front-end/components/Forms/Field.tsx
+++ b/packages/front-end/components/Forms/Field.tsx
@@ -6,10 +6,9 @@ export type SelectOptions =
   | (
       | string
       | number
-      | boolean
       | null
       | {
-          value: string | number | boolean;
+          value: string | number;
           display: string;
         }
     )[]
@@ -65,7 +64,6 @@ function Options({ options }: { options: SelectOptions }) {
 
   return (
     <>
-      {" "}
       {Object.keys(options).map((k) => {
         return (
           <option key={k} value={k}>

--- a/packages/front-end/components/HistoryTable.tsx
+++ b/packages/front-end/components/HistoryTable.tsx
@@ -5,13 +5,47 @@ import { AuditInterface } from "back-end/types/audit";
 import Modal from "./Modal";
 import { ago, datetime } from "../services/dates";
 import Code from "./Code";
+import Link from "next/link";
+
+function EventDetails({
+  event,
+  setModal,
+}: {
+  event: AuditInterface;
+  setModal: (contents: string) => void;
+}) {
+  if (event.event === "experiment.analysis" && event.details) {
+    const details = JSON.parse(event.details);
+    if (details && details.report) {
+      return (
+        <Link href={`/report/${details.report}`}>
+          <a>View Report</a>
+        </Link>
+      );
+    }
+  }
+  // TODO: More special actions depending on event type
+  if (event.details) {
+    return (
+      <button
+        className="btn btn-link btn-sm"
+        onClick={(e) => {
+          e.preventDefault();
+          setModal(event.details);
+        }}
+      >
+        View Details
+      </button>
+    );
+  }
+
+  return null;
+}
 
 const HistoryTable: FC<{ type: "experiment" | "metric"; id: string }> = ({
   id,
   type,
 }) => {
-  // TODO: Special actions for some event types (e.g. delete manual snapshot)
-
   const [modal, setModal] = useState(null);
 
   const { data, error } = useApi<{ events: AuditInterface[] }>(
@@ -54,19 +88,7 @@ const HistoryTable: FC<{ type: "experiment" | "metric"; id: string }> = ({
               <td>{event.user.name || event.user.email}</td>
               <td>{event.event}</td>
               <td>
-                {event.details ? (
-                  <button
-                    className="btn btn-link btn-sm"
-                    onClick={(e) => {
-                      e.preventDefault();
-                      setModal(event.details);
-                    }}
-                  >
-                    View Details
-                  </button>
-                ) : (
-                  ""
-                )}
+                <EventDetails event={event} setModal={setModal} />
               </td>
             </tr>
           ))}

--- a/packages/front-end/components/Modal.tsx
+++ b/packages/front-end/components/Modal.tsx
@@ -12,7 +12,7 @@ type ModalProps = {
   closeCta?: string;
   ctaEnabled?: boolean;
   error?: string;
-  size?: "md" | "lg" | "max";
+  size?: "md" | "lg" | "max" | "fill";
   inline?: boolean;
   autoFocusSelector?: string;
   autoCloseOnSubmit?: boolean;
@@ -64,7 +64,10 @@ const Modal: FC<ModalProps> = ({
   }, [open, autoFocusSelector]);
 
   const contents = (
-    <div className={`modal-content ${className}`} style={{ maxHeight: "93vh" }}>
+    <div
+      className={`modal-content ${className}`}
+      style={{ maxHeight: size === "fill" ? "" : "93vh" }}
+    >
       {loading && <LoadingOverlay />}
       {header ? (
         <div className="modal-header">
@@ -160,61 +163,69 @@ const Modal: FC<ModalProps> = ({
       }
     : null;
 
-  return (
-    <Portal>
-      {!inline && (
-        <div
-          className={clsx("modal-backdrop fade", {
-            show: open,
-            "d-none": !open,
-            "bg-dark": solidOverlay,
-          })}
-          style={overlayStyle}
-        />
-      )}
+  const modalHtml = (
+    <div
+      className={clsx("modal", { show: open })}
+      style={{
+        display: open ? "block" : "none",
+        position: inline ? "relative" : undefined,
+        zIndex: inline ? 1 : undefined,
+      }}
+    >
       <div
-        className={clsx("modal", { show: open })}
-        style={{
-          display: open ? "block" : "none",
-          position: inline ? "relative" : undefined,
-          zIndex: inline ? 1 : undefined,
-        }}
+        className={`modal-dialog modal-${size}`}
+        style={
+          size === "max"
+            ? { width: "95vw", maxWidth: 1400, margin: "2vh auto" }
+            : size === "fill"
+            ? { width: "100%", maxWidth: "100%" }
+            : null
+        }
       >
-        <div
-          className={`modal-dialog modal-${size}`}
-          style={
-            size === "max"
-              ? { width: "95vw", maxWidth: 1400, margin: "2vh auto" }
-              : null
-          }
-        >
-          {submit ? (
-            <form
-              onSubmit={async (e) => {
-                e.preventDefault();
-                if (loading) return;
-                setError(null);
-                setLoading(true);
-                try {
-                  await submit();
-                  if (close && autoCloseOnSubmit) {
-                    close();
-                  } else {
-                    setLoading(false);
-                  }
-                } catch (e) {
-                  setError(e.message);
+        {submit ? (
+          <form
+            onSubmit={async (e) => {
+              e.preventDefault();
+              if (loading) return;
+              setError(null);
+              setLoading(true);
+              try {
+                await submit();
+                if (close && autoCloseOnSubmit) {
+                  close();
+                } else {
                   setLoading(false);
                 }
-              }}
-            >
-              {contents}
-            </form>
-          ) : (
-            contents
-          )}
-        </div>
+              } catch (e) {
+                setError(e.message);
+                setLoading(false);
+              }
+            }}
+          >
+            {contents}
+          </form>
+        ) : (
+          contents
+        )}
       </div>
+    </div>
+  );
+
+  if (inline) {
+    return modalHtml;
+  }
+
+  return (
+    <Portal>
+      <div
+        className={clsx("modal-backdrop fade", {
+          show: open,
+          "d-none": !open,
+          "bg-dark": solidOverlay,
+        })}
+        style={overlayStyle}
+      />
+      {modalHtml}
     </Portal>
   );
 };

--- a/packages/front-end/components/Queries/ViewAsyncQueriesButton.tsx
+++ b/packages/front-end/components/Queries/ViewAsyncQueriesButton.tsx
@@ -8,8 +8,17 @@ const ViewAsyncQueriesButton: FC<{
   error?: string;
   display?: string;
   color?: string;
-}> = ({ queries, display = "View Queries", color = "link", error }) => {
+  className?: string;
+}> = ({
+  queries,
+  display = "View Queries",
+  color = "link",
+  error,
+  className = "",
+}) => {
   const [open, setOpen] = useState(false);
+
+  if (!className) className = `btn btn-${color}`;
 
   return (
     <>
@@ -21,7 +30,7 @@ const ViewAsyncQueriesButton: FC<{
         />
       )}
       <button
-        className={clsx("btn", `btn-${color}`, {
+        className={clsx(className, {
           disabled: queries.length === 0,
         })}
         onClick={(e) => {

--- a/packages/front-end/components/Report/ConfigureReport.tsx
+++ b/packages/front-end/components/Report/ConfigureReport.tsx
@@ -1,0 +1,312 @@
+import { useFieldArray, useForm } from "react-hook-form";
+import {
+  ExperimentReportArgs,
+  ReportInterface,
+} from "../../../back-end/types/report";
+import { useAuth } from "../../services/auth";
+import { useDefinitions } from "../../services/DefinitionsContext";
+import MetricsSelector from "../Experiment/MetricsSelector";
+import Field from "../Forms/Field";
+import Modal from "../Modal";
+
+export default function ConfigureReport({
+  report,
+  mutate,
+  viewResults,
+}: {
+  report: ReportInterface;
+  mutate: () => void;
+  viewResults: () => void;
+}) {
+  const { apiCall } = useAuth();
+  const form = useForm({
+    defaultValues: report.args,
+  });
+
+  const { metrics, segments, dimensions, getDatasourceById } = useDefinitions();
+
+  const filteredMetrics = metrics.filter(
+    (m) => m.datasource === report.args.datasource
+  );
+  const filteredSegments = segments.filter(
+    (s) => s.datasource === report.args.datasource
+  );
+  const filteredDimensions = dimensions
+    .filter((d) => d.datasource === report.args.datasource)
+    .map((d) => {
+      return {
+        display: d.name,
+        value: d.id,
+      };
+    });
+
+  const datasource = getDatasourceById(report.args.datasource);
+  const datasourceProperties = datasource?.properties;
+  const supportsSql = datasource?.properties?.queryLanguage === "sql";
+
+  const variations = useFieldArray({
+    control: form.control,
+    name: "variations",
+  });
+
+  return (
+    <Modal
+      inline={true}
+      header=""
+      size="fill"
+      open={true}
+      submit={form.handleSubmit(async (value) => {
+        const args: ExperimentReportArgs = {
+          ...value,
+          skipPartialData: !!value.skipPartialData,
+        };
+
+        await apiCall(`/report/${report.id}`, {
+          method: "PUT",
+          body: JSON.stringify({
+            args,
+          }),
+        });
+        mutate();
+        viewResults();
+      })}
+      cta="Save and Run"
+    >
+      <Field
+        label="Experiment Id"
+        labelClassName="font-weight-bold"
+        {...form.register("trackingKey")}
+        helpText="Will match against the experiment_id column in your data source"
+      />
+      <div className="form-group">
+        <label className="font-weight-bold">Variation Ids</label>
+        <div className="row align-items-top">
+          {variations.fields.map((v, i) => (
+            <div
+              className={`col-${Math.max(
+                Math.round(12 / variations.fields.length),
+                3
+              )} mb-2`}
+              key={i}
+            >
+              <Field
+                label={v.name}
+                labelClassName="mb-0"
+                containerClassName="mb-1"
+                {...form.register(`variations.${i}.id`)}
+                placeholder={i + ""}
+              />
+            </div>
+          ))}
+        </div>
+        <small className="form-text text-muted">
+          Will match against the variation_id column in your data source
+        </small>
+      </div>
+      <div className="form-group">
+        <label className="font-weight-bold">Variation Weights</label>
+        <div className="row align-items-top">
+          {variations.fields.map((v, i) => (
+            <div
+              className={`col-${Math.max(
+                Math.round(12 / variations.fields.length),
+                3
+              )} mb-2`}
+              key={i}
+            >
+              <Field
+                label={v.name}
+                labelClassName="mb-0"
+                containerClassName="mb-1"
+                {...form.register(`variations.${i}.weight`, {
+                  valueAsNumber: true,
+                })}
+              />
+            </div>
+          ))}
+        </div>
+        <small className="form-text text-muted">
+          Will use this to check for a Sample Ratio Mismatch (SRM) in the
+          results
+        </small>
+      </div>
+      {datasource?.properties?.userIds && (
+        <Field
+          label="User Id Column"
+          labelClassName="font-weight-bold"
+          {...form.register("userIdType")}
+          options={[
+            {
+              display: "user_id",
+              value: "user",
+            },
+            {
+              display: "anonymous_id",
+              value: "anonymous",
+            },
+          ]}
+          helpText="Determines how we define a single 'user' in the analysis"
+        />
+      )}
+
+      <div className="row">
+        <div className="col">
+          <Field
+            label="Start Date (UTC)"
+            labelClassName="font-weight-bold"
+            type="datetime-local"
+            {...form.register("startDate")}
+            helpText="Only include users who entered the experiment on or after this date"
+          />
+        </div>
+        <div className="col">
+          <Field
+            label="End Date (UTC)"
+            labelClassName="font-weight-bold"
+            type="datetime-local"
+            {...form.register("endDate")}
+            helpText="Only include users who entered the experiment on or before this date"
+          />
+        </div>
+      </div>
+
+      <div className="form-group">
+        <label className="font-weight-bold mb-1">Goal Metrics</label>
+        <div className="mb-1 font-italic">
+          Metrics you are trying to improve with this experiment.
+        </div>
+        <MetricsSelector
+          selected={form.watch("metrics")}
+          onChange={(metrics) => form.setValue("metrics", metrics)}
+          datasource={report.args.datasource}
+        />
+      </div>
+      <div className="form-group">
+        <label className="font-weight-bold mb-1">Guardrail Metrics</label>
+        <div className="mb-1 font-italic">
+          Metrics you want to monitor, but are NOT specifically trying to
+          improve.
+        </div>
+        <MetricsSelector
+          selected={form.watch("guardrails")}
+          onChange={(metrics) => form.setValue("guardrails", metrics)}
+          datasource={report.args.datasource}
+        />
+      </div>
+      {(filteredDimensions.length > 0 || supportsSql) && (
+        <div className="col-auto form-inline">
+          <label className="mr-2">Dimension</label>{" "}
+          <select
+            className="form-control"
+            value={form.watch("dimension")}
+            onChange={(e) => {
+              form.setValue("dimension", e.target.value);
+            }}
+          >
+            <option value="">None</option>
+            {supportsSql && (
+              <optgroup label="Built-in">
+                <option value="pre:date">Date</option>
+                {datasource?.properties?.activationDimension &&
+                  report.args.activationMetric && (
+                    <option value="pre:activation">Activation Status</option>
+                  )}
+              </optgroup>
+            )}
+            {filteredDimensions.length > 0 && (
+              <optgroup label="Custom">
+                {filteredDimensions.map((d) => (
+                  <option key={d.value} value={d.value}>
+                    {d.display}
+                  </option>
+                ))}
+              </optgroup>
+            )}
+          </select>
+          <small className="form-text text-muted">
+            Break down results for each metric by a dimension
+          </small>
+        </div>
+      )}
+
+      <Field
+        label="Activation Metric"
+        labelClassName="font-weight-bold"
+        {...form.register("activationMetric")}
+        options={filteredMetrics.map((m) => {
+          return {
+            display: m.name,
+            value: m.id,
+          };
+        })}
+        initialOption="None"
+        helpText="Users must convert on this metric before being included"
+      />
+      {datasourceProperties?.experimentSegments && (
+        <Field
+          label="Segment"
+          labelClassName="font-weight-bold"
+          {...form.register("segment")}
+          initialOption="None (All Users)"
+          options={filteredSegments.map((s) => {
+            return {
+              display: s.name,
+              value: s.id,
+            };
+          })}
+          helpText="Only users in this segment will be included"
+        />
+      )}
+      {datasourceProperties?.separateExperimentResultQueries && (
+        <Field
+          label="Metric Conversion Windows"
+          labelClassName="font-weight-bold"
+          {...form.register("skipPartialData")}
+          options={[
+            {
+              display: "Include In-Progress Conversions",
+              value: false,
+            },
+            {
+              display: "Exclude In-Progress Conversions",
+              value: true,
+            },
+          ]}
+          helpText="How to treat users who have not had the full time to convert yet"
+        />
+      )}
+      {datasourceProperties?.queryLanguage === "sql" && (
+        <div className="row">
+          <div className="col">
+            <Field
+              label="Custom SQL Filter"
+              labelClassName="font-weight-bold"
+              {...form.register("queryFilter")}
+              textarea
+              placeholder="e.g. user_id NOT IN ('123', '456')"
+              helpText="WHERE clause to add to the default experiment query"
+            />
+          </div>
+          <div className="pt-2 border-left col-sm-4 col-lg-6">
+            Available columns:
+            <div className="mb-2 d-flex flex-wrap">
+              {["user_id", "anonymous_id", "timestamp", "variation_id"]
+                .concat(datasource?.settings?.experimentDimensions || [])
+                .map((d) => {
+                  return (
+                    <div className="mr-2 mb-2 border px-1" key={d}>
+                      <code>{d}</code>
+                    </div>
+                  );
+                })}
+            </div>
+            <div>
+              <strong>Tip:</strong> Use a subquery inside an <code>IN</code> or{" "}
+              <code>NOT IN</code> clause for more advanced filtering.
+            </div>
+          </div>
+        </div>
+      )}
+    </Modal>
+  );
+}

--- a/packages/front-end/components/Report/ConfigureReport.tsx
+++ b/packages/front-end/components/Report/ConfigureReport.tsx
@@ -1,8 +1,5 @@
 import { useFieldArray, useForm } from "react-hook-form";
-import {
-  ExperimentReportArgs,
-  ReportInterface,
-} from "../../../back-end/types/report";
+import { ExperimentReportArgs, ReportInterface } from "back-end/types/report";
 import { useAuth } from "../../services/auth";
 import { useDefinitions } from "../../services/DefinitionsContext";
 import MetricsSelector from "../Experiment/MetricsSelector";

--- a/packages/front-end/components/Report/ConfigureReport.tsx
+++ b/packages/front-end/components/Report/ConfigureReport.tsx
@@ -53,6 +53,15 @@ export default function ConfigureReport({
     name: "variations",
   });
 
+  if (datasource?.settings?.experimentDimensions?.length > 0) {
+    datasource.settings.experimentDimensions.forEach((d) => {
+      filteredDimensions.push({
+        display: d,
+        value: "exp:" + d,
+      });
+    });
+  }
+
   const builtInDimensions = [
     {
       display: "Date",

--- a/packages/front-end/components/Report/EditTitleDescription.tsx
+++ b/packages/front-end/components/Report/EditTitleDescription.tsx
@@ -1,5 +1,5 @@
 import { useForm } from "react-hook-form";
-import { ReportInterface } from "../../../back-end/types/report";
+import { ReportInterface } from "back-end/types/report";
 import { useAuth } from "../../services/auth";
 import Field from "../Forms/Field";
 import MarkdownInput from "../Markdown/MarkdownInput";

--- a/packages/front-end/components/Report/EditTitleDescription.tsx
+++ b/packages/front-end/components/Report/EditTitleDescription.tsx
@@ -1,0 +1,50 @@
+import { useForm } from "react-hook-form";
+import { ReportInterface } from "../../../back-end/types/report";
+import { useAuth } from "../../services/auth";
+import Field from "../Forms/Field";
+import MarkdownInput from "../Markdown/MarkdownInput";
+import Modal from "../Modal";
+
+export default function EditTitleDescription({
+  cancel,
+  report,
+  mutate,
+}: {
+  cancel: () => void;
+  report: ReportInterface;
+  mutate: () => void;
+}) {
+  const { apiCall } = useAuth();
+  const form = useForm({
+    defaultValues: {
+      title: report.title,
+      description: report.description,
+    },
+  });
+
+  return (
+    <Modal
+      open={true}
+      submit={form.handleSubmit(async (value) => {
+        await apiCall(`/report/${report.id}`, {
+          method: "PUT",
+          body: JSON.stringify(value),
+        });
+        mutate();
+      })}
+      close={cancel}
+      header="Edit Report"
+    >
+      <Field label="Title" {...form.register("title")} />
+      <div className="form-group">
+        <label>Description</label>
+        <MarkdownInput
+          setValue={(value) => {
+            form.setValue("description", value);
+          }}
+          value={form.watch("description")}
+        />
+      </div>
+    </Modal>
+  );
+}

--- a/packages/front-end/components/Share/Presentation.tsx
+++ b/packages/front-end/components/Share/Presentation.tsx
@@ -178,7 +178,11 @@ const Presentation = ({
       // const numMetrics = e.experiment.metrics.length;
       const result = e.experiment.results;
 
-      if (result)
+      if (result) {
+        const experiment = e.experiment;
+        const snapshot = e.snapshot;
+        const phase = experiment.phases[snapshot.phase];
+
         expSlides.push(
           <Slide key={`s-${expSlides.length}`}>
             <Heading className="m-0 p-0">Results</Heading>
@@ -211,10 +215,27 @@ const Presentation = ({
                 fontSize: "95%",
               }}
             >
-              <CompactResults snapshot={e.snapshot} experiment={e.experiment} />
+              <CompactResults
+                id={experiment.id}
+                isLatestPhase={phase === experiment.phases.length - 1}
+                metrics={experiment.metrics}
+                reportDate={snapshot.dateCreated}
+                results={snapshot.results?.[0]}
+                status={experiment.status}
+                startDate={phase?.dateStarted}
+                unknownVariations={snapshot.unknownVariations || []}
+                variations={experiment.variations.map((v, i) => {
+                  return {
+                    id: v.key || i + "",
+                    name: v.name,
+                    weight: phase?.variationWeights?.[i] || 0,
+                  };
+                })}
+              />
             </div>
           </Slide>
         );
+      }
     }
   });
 

--- a/packages/front-end/components/Tabs/ControlledTabs.tsx
+++ b/packages/front-end/components/Tabs/ControlledTabs.tsx
@@ -1,0 +1,202 @@
+import {
+  FC,
+  Children,
+  useState,
+  isValidElement,
+  ReactNode,
+  ReactElement,
+  useEffect,
+} from "react";
+import clsx from "clsx";
+
+const ControlledTabs: FC<{
+  orientation?: "vertical" | "horizontal";
+  className?: string;
+  navClassName?: string;
+  tabContentsClassName?: string;
+  defaultTab?: string;
+  newStyle?: boolean;
+  navExtra?: ReactElement;
+  active?: string | null;
+  setActive: (tab: string | null) => void;
+}> = ({
+  active,
+  setActive,
+  children,
+  orientation,
+  className,
+  tabContentsClassName,
+  navClassName,
+  defaultTab,
+  newStyle = false,
+  navExtra,
+}) => {
+  const [loaded, setLoaded] = useState({});
+
+  const tabs: ReactElement[] = [];
+
+  const contents: ReactNode[] = [];
+
+  useEffect(() => {
+    if (!active && defaultTab) {
+      setActive(defaultTab);
+    }
+  }, [defaultTab, active]);
+
+  const anchorMap = new Map<string, string>();
+  let activeChosen = null;
+  let backupActive = null;
+  Children.forEach(children, (child) => {
+    if (!isValidElement(child)) return;
+    const { display, anchor, visible } = child.props;
+    if (anchor) {
+      anchorMap.set(anchor, display);
+    }
+
+    if (!activeChosen && visible !== false && active === display) {
+      activeChosen = display;
+    } else if (!activeChosen && visible !== false && !backupActive) {
+      backupActive = display;
+    }
+  });
+  if (!activeChosen) {
+    activeChosen = backupActive;
+  }
+
+  const hash = window.location.hash.replace(/^#/, "");
+  const display = anchorMap.get(hash);
+  if (display && display !== active) {
+    setActive(display);
+  }
+
+  let contentsPadding = true;
+  const numTabs = Children.toArray(children).filter((c) => {
+    return !!c;
+  }).length;
+
+  Children.forEach(children, (child, i) => {
+    if (!isValidElement(child)) return;
+    const {
+      display,
+      count,
+      anchor,
+      lazy,
+      visible,
+      action,
+      className,
+      padding,
+    } = child.props;
+    if (visible === false) return;
+
+    const isActive = display === activeChosen;
+
+    if (isActive && padding === false) {
+      contentsPadding = false;
+    }
+    tabs.push(
+      <a
+        className={clsx("nav-item nav-link", {
+          active: isActive,
+          last: i === numTabs - 1,
+          "nav-button-item": newStyle,
+        })}
+        key={i}
+        role="tab"
+        href={anchor ? `#${anchor}` : "#"}
+        aria-selected={isActive ? "true" : "false"}
+        onClick={(e) => {
+          if (!anchor) {
+            e.preventDefault();
+          }
+          setActive(display);
+        }}
+      >
+        {display}
+        {!isActive && (count === 0 || count > 0) ? (
+          <span className={`badge badge-gray ml-2`}>{count}</span>
+        ) : (
+          ""
+        )}
+        {(isActive && action) || ""}
+      </a>
+    );
+
+    if (lazy && !isActive && !loaded[display]) {
+      contents.push(null);
+    } else {
+      contents.push(
+        <div
+          className={clsx("tab-pane", className, { active: isActive })}
+          role="tabpanel"
+          key={i}
+        >
+          {child}
+        </div>
+      );
+    }
+  });
+
+  useEffect(() => {
+    if (!loaded[active]) {
+      setLoaded({
+        ...loaded,
+        [active]: true,
+      });
+    }
+  }, [active]);
+
+  useEffect(() => {
+    const handler = () => {
+      const hash = window.location.hash.replace(/^#/, "");
+      const display = anchorMap.get(hash);
+      if (display) {
+        setActive(display);
+      }
+    };
+    handler();
+    window.addEventListener("hashchange", handler, false);
+    return () => window.removeEventListener("hashchange", handler, false);
+  }, []);
+
+  return (
+    <div
+      className={clsx(className, {
+        row: orientation === "vertical",
+        buttontabs: newStyle,
+      })}
+    >
+      <nav
+        className={clsx(navClassName, {
+          "col-md-3": orientation === "vertical",
+        })}
+      >
+        <div
+          className={clsx(
+            `${
+              orientation === "vertical"
+                ? "nav nav-pills flex-column"
+                : "nav nav-tabs"
+            }`,
+            { "nav-button-tabs": newStyle }
+          )}
+          role="tablist"
+        >
+          {tabs}
+          {navExtra && navExtra}
+        </div>
+      </nav>
+      <div
+        className={clsx("tab-content", tabContentsClassName, {
+          "col-md-9": orientation === "vertical",
+          "p-3": contentsPadding,
+          "p-0": !contentsPadding,
+          "border-top-0": !newStyle,
+        })}
+      >
+        {contents}
+      </div>
+    </div>
+  );
+};
+
+export default ControlledTabs;

--- a/packages/front-end/components/Tabs/ControlledTabs.tsx
+++ b/packages/front-end/components/Tabs/ControlledTabs.tsx
@@ -63,12 +63,6 @@ const ControlledTabs: FC<{
     activeChosen = backupActive;
   }
 
-  const hash = window.location.hash.replace(/^#/, "");
-  const display = anchorMap.get(hash);
-  if (display && display !== active) {
-    setActive(display);
-  }
-
   let contentsPadding = true;
   const numTabs = Children.toArray(children).filter((c) => {
     return !!c;

--- a/packages/front-end/components/Tabs/Tabs.tsx
+++ b/packages/front-end/components/Tabs/Tabs.tsx
@@ -1,13 +1,5 @@
-import {
-  FC,
-  Children,
-  useState,
-  isValidElement,
-  ReactNode,
-  ReactElement,
-  useEffect,
-} from "react";
-import clsx from "clsx";
+import { FC, useState, ReactElement } from "react";
+import ControlledTabs from "./ControlledTabs";
 
 const Tabs: FC<{
   orientation?: "vertical" | "horizontal";
@@ -17,183 +9,18 @@ const Tabs: FC<{
   defaultTab?: string;
   newStyle?: boolean;
   navExtra?: ReactElement;
-}> = ({
-  children,
-  orientation,
-  className,
-  tabContentsClassName,
-  navClassName,
-  defaultTab,
-  newStyle = false,
-  navExtra,
-}) => {
+}> = ({ children, defaultTab, ...props }) => {
   const [active, setActive] = useState<string | null>(defaultTab || null);
 
-  const [loaded, setLoaded] = useState({});
-
-  const tabs: ReactElement[] = [];
-
-  const contents: ReactNode[] = [];
-
-  useEffect(() => {
-    if (!active && defaultTab) {
-      setActive(defaultTab);
-    }
-  }, [defaultTab, active]);
-
-  const anchorMap = new Map<string, string>();
-  let activeChosen = null;
-  let backupActive = null;
-  Children.forEach(children, (child) => {
-    if (!isValidElement(child)) return;
-    const { display, anchor, visible } = child.props;
-    if (anchor) {
-      anchorMap.set(anchor, display);
-    }
-
-    if (!activeChosen && visible !== false && active === display) {
-      activeChosen = display;
-    } else if (!activeChosen && visible !== false && !backupActive) {
-      backupActive = display;
-    }
-  });
-  if (!activeChosen) {
-    activeChosen = backupActive;
-  }
-
-  const hash = window.location.hash.replace(/^#/, "");
-  const display = anchorMap.get(hash);
-  if (display && display !== active) {
-    setActive(display);
-  }
-
-  let contentsPadding = true;
-  const numTabs = Children.toArray(children).filter((c) => {
-    return !!c;
-  }).length;
-
-  Children.forEach(children, (child, i) => {
-    if (!isValidElement(child)) return;
-    const {
-      display,
-      count,
-      anchor,
-      lazy,
-      visible,
-      action,
-      className,
-      padding,
-    } = child.props;
-    if (visible === false) return;
-
-    const isActive = display === activeChosen;
-
-    if (isActive && padding === false) {
-      contentsPadding = false;
-    }
-    tabs.push(
-      <a
-        className={clsx("nav-item nav-link", {
-          active: isActive,
-          last: i === numTabs - 1,
-          "nav-button-item": newStyle,
-        })}
-        key={i}
-        role="tab"
-        href={anchor ? `#${anchor}` : "#"}
-        aria-selected={isActive ? "true" : "false"}
-        onClick={(e) => {
-          if (!anchor) {
-            e.preventDefault();
-          }
-          setActive(display);
-        }}
-      >
-        {display}
-        {!isActive && (count === 0 || count > 0) ? (
-          <span className={`badge badge-gray ml-2`}>{count}</span>
-        ) : (
-          ""
-        )}
-        {(isActive && action) || ""}
-      </a>
-    );
-
-    if (lazy && !isActive && !loaded[display]) {
-      contents.push(null);
-    } else {
-      contents.push(
-        <div
-          className={clsx("tab-pane", className, { active: isActive })}
-          role="tabpanel"
-          key={i}
-        >
-          {child}
-        </div>
-      );
-    }
-  });
-
-  useEffect(() => {
-    if (!loaded[active]) {
-      setLoaded({
-        ...loaded,
-        [active]: true,
-      });
-    }
-  }, [active]);
-
-  useEffect(() => {
-    const handler = () => {
-      const hash = window.location.hash.replace(/^#/, "");
-      const display = anchorMap.get(hash);
-      if (display) {
-        setActive(display);
-      }
-    };
-    handler();
-    window.addEventListener("hashchange", handler, false);
-    return () => window.removeEventListener("hashchange", handler, false);
-  }, []);
-
   return (
-    <div
-      className={clsx(className, {
-        row: orientation === "vertical",
-        buttontabs: newStyle,
-      })}
+    <ControlledTabs
+      {...props}
+      defaultTab={defaultTab}
+      active={active}
+      setActive={setActive}
     >
-      <nav
-        className={clsx(navClassName, {
-          "col-md-3": orientation === "vertical",
-        })}
-      >
-        <div
-          className={clsx(
-            `${
-              orientation === "vertical"
-                ? "nav nav-pills flex-column"
-                : "nav nav-tabs"
-            }`,
-            { "nav-button-tabs": newStyle }
-          )}
-          role="tablist"
-        >
-          {tabs}
-          {navExtra && navExtra}
-        </div>
-      </nav>
-      <div
-        className={clsx("tab-content", tabContentsClassName, {
-          "col-md-9": orientation === "vertical",
-          "p-3": contentsPadding,
-          "p-0": !contentsPadding,
-          "border-top-0": !newStyle,
-        })}
-      >
-        {contents}
-      </div>
-    </div>
+      {children}
+    </ControlledTabs>
   );
 };
 

--- a/packages/front-end/pages/report/[rid].tsx
+++ b/packages/front-end/pages/report/[rid].tsx
@@ -200,7 +200,7 @@ export default function ReportPage() {
                 isLatestPhase={true}
                 metrics={report.args.metrics}
                 reportDate={report.dateCreated}
-                results={report.results?.dimensions}
+                results={report.results?.dimensions || []}
                 status={"stopped"}
                 startDate={getValidDate(report.args.startDate).toISOString()}
                 dimensionId={report.args.dimension}

--- a/packages/front-end/pages/report/[rid].tsx
+++ b/packages/front-end/pages/report/[rid].tsx
@@ -1,0 +1,32 @@
+import { useRouter } from "next/router";
+import { ReportInterface } from "back-end/types/report";
+import LoadingOverlay from "../../components/LoadingOverlay";
+import Markdown from "../../components/Markdown/Markdown";
+import useApi from "../../hooks/useApi";
+
+export default function ReportPage() {
+  const router = useRouter();
+  const { rid } = router.query;
+
+  const { data, error } = useApi<{ report: ReportInterface }>(`/report/${rid}`);
+
+  if (error) {
+    return <div className="alert alert-danger">{error.message}</div>;
+  }
+  if (!data) {
+    return <LoadingOverlay />;
+  }
+
+  const report = data.report;
+
+  return (
+    <div className="container-fluid pagecontents">
+      <h1>{report.title}</h1>
+      {report.description && (
+        <div className="mb-3">
+          <Markdown>{report.description}</Markdown>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/front-end/pages/report/[rid].tsx
+++ b/packages/front-end/pages/report/[rid].tsx
@@ -20,10 +20,14 @@ import { FaFileDownload } from "react-icons/fa";
 import ViewAsyncQueriesButton from "../../components/Queries/ViewAsyncQueriesButton";
 import ControlledTabs from "../../components/Tabs/ControlledTabs";
 import Tab from "../../components/Tabs/Tab";
+import { GBEdit } from "../../components/Icons";
+import EditTitleDescription from "../../components/Report/EditTitleDescription";
 
 export default function ReportPage() {
   const router = useRouter();
   const { rid } = router.query;
+
+  const [editModalOpen, setEditModalOpen] = useState(false);
 
   const { dimensions, getMetricById, getDatasourceById } = useDefinitions();
   const { data, error, mutate } = useApi<{ report: ReportInterface }>(
@@ -68,8 +72,23 @@ export default function ReportPage() {
 
   return (
     <div className="container-fluid pagecontents experiment-details">
+      {editModalOpen && (
+        <EditTitleDescription
+          report={report}
+          cancel={() => setEditModalOpen(false)}
+          mutate={mutate}
+        />
+      )}
       <div className="mb-3">
-        <h1>{report.title}</h1>
+        <h1>
+          {report.title}{" "}
+          <a
+            className="ml-2 cursor-pointer"
+            onClick={() => setEditModalOpen(true)}
+          >
+            <GBEdit />
+          </a>
+        </h1>
         {report.description && (
           <div className="mb-3">
             <Markdown>{report.description}</Markdown>

--- a/packages/front-end/pages/report/[rid].tsx
+++ b/packages/front-end/pages/report/[rid].tsx
@@ -35,7 +35,7 @@ export default function ReportPage() {
     `/report/${rid}`
   );
   const { permissions } = useContext(UserContext);
-  const [active, setActive] = useState<string | null>("results");
+  const [active, setActive] = useState<string | null>("Results");
 
   const { apiCall } = useAuth();
 
@@ -83,12 +83,14 @@ export default function ReportPage() {
       <div className="mb-3">
         <h1>
           {report.title}{" "}
-          <a
-            className="ml-2 cursor-pointer"
-            onClick={() => setEditModalOpen(true)}
-          >
-            <GBEdit />
-          </a>
+          {permissions.runExperiments && (
+            <a
+              className="ml-2 cursor-pointer"
+              onClick={() => setEditModalOpen(true)}
+            >
+              <GBEdit />
+            </a>
+          )}
         </h1>
         {report.description && (
           <div className="mb-3">
@@ -97,38 +99,18 @@ export default function ReportPage() {
         )}
       </div>
 
-      <ControlledTabs active={active} setActive={setActive} newStyle={true}>
+      <ControlledTabs
+        active={active}
+        setActive={setActive}
+        newStyle={true}
+        navClassName={permissions.runExperiments ? "" : "d-none"}
+      >
         <Tab key="results" anchor="results" display="Results" padding={false}>
           <div className="p-3">
-            <h2>Results</h2>
             <div className="row">
-              {report.args.metrics.length === 0 && (
-                <div className="col">
-                  <div className="alert alert-info">
-                    Add at least 1 metric to view results.
-                  </div>
-                </div>
-              )}
-              {!hasData &&
-                status !== "running" &&
-                report.args.metrics.length > 0 && (
-                  <div className="col">
-                    <div className="alert alert-info">
-                      No data yet.{" "}
-                      {report.results &&
-                        phaseAgeMinutes >= 120 &&
-                        "Make sure your experiment is tracking properly."}
-                      {report.results &&
-                        phaseAgeMinutes < 120 &&
-                        "It was just started " +
-                          ago(report.args.startDate) +
-                          ". Give it a little longer and click the 'Refresh' button to check again."}
-                      {!report.results &&
-                        permissions.runExperiments &&
-                        `Click the "Refresh" button.`}
-                    </div>
-                  </div>
-                )}
+              <div className="col">
+                <h2>Results</h2>
+              </div>
               <div className="col-auto ml-auto">
                 <form
                   onSubmit={async (e) => {
@@ -157,6 +139,27 @@ export default function ReportPage() {
                 </form>
               </div>
             </div>
+            {report.args.metrics.length === 0 && (
+              <div className="alert alert-info">
+                Add at least 1 metric to view results.
+              </div>
+            )}
+            {!hasData &&
+              status !== "running" &&
+              report.args.metrics.length > 0 && (
+                <div className="alert alert-info">
+                  No data yet.{" "}
+                  {report.results &&
+                    phaseAgeMinutes >= 120 &&
+                    "Make sure your experiment is tracking properly."}
+                  {report.results &&
+                    phaseAgeMinutes < 120 &&
+                    "It was just started " +
+                      ago(report.args.startDate) +
+                      ". Give it a little longer and click the 'Refresh' button to check again."}
+                  {!report.results && `Click the "Refresh" button.`}
+                </div>
+              )}
           </div>
           {hasData &&
             report.args.dimension &&
@@ -274,12 +277,17 @@ export default function ReportPage() {
             </div>
           </div>
         </Tab>
-        <Tab key="configuration" anchor="configuration" display="Configuration">
-          <h2></h2>
+        <Tab
+          key="configuration"
+          anchor="configuration"
+          display="Configuration"
+          visible={permissions.runExperiments}
+        >
+          <h2>Configuration</h2>
           <ConfigureReport
             mutate={mutate}
             report={report}
-            viewResults={() => setActive("results")}
+            viewResults={() => setActive("Results")}
           />
         </Tab>
       </ControlledTabs>

--- a/packages/front-end/pages/report/[rid].tsx
+++ b/packages/front-end/pages/report/[rid].tsx
@@ -22,6 +22,7 @@ import ControlledTabs from "../../components/Tabs/ControlledTabs";
 import Tab from "../../components/Tabs/Tab";
 import { GBEdit } from "../../components/Icons";
 import EditTitleDescription from "../../components/Report/EditTitleDescription";
+import ConfigureReport from "../../components/Report/ConfigureReport";
 
 export default function ReportPage() {
   const router = useRouter();
@@ -99,6 +100,7 @@ export default function ReportPage() {
       <ControlledTabs active={active} setActive={setActive} newStyle={true}>
         <Tab key="results" anchor="results" display="Results" padding={false}>
           <div className="p-3">
+            <h2>Results</h2>
             <div className="row">
               {report.args.metrics.length === 0 && (
                 <div className="col">
@@ -272,11 +274,14 @@ export default function ReportPage() {
             </div>
           </div>
         </Tab>
-        <Tab
-          key="configuration"
-          anchor="configuration"
-          display="Configuration"
-        ></Tab>
+        <Tab key="configuration" anchor="configuration" display="Configuration">
+          <h2></h2>
+          <ConfigureReport
+            mutate={mutate}
+            report={report}
+            viewResults={() => setActive("results")}
+          />
+        </Tab>
       </ControlledTabs>
     </div>
   );

--- a/packages/front-end/pages/report/[rid].tsx
+++ b/packages/front-end/pages/report/[rid].tsx
@@ -28,7 +28,7 @@ export default function ReportPage() {
 
   const [editModalOpen, setEditModalOpen] = useState(false);
 
-  const { dimensions, getMetricById, getDatasourceById } = useDefinitions();
+  const { getMetricById, getDatasourceById } = useDefinitions();
   const { data, error, mutate } = useApi<{ report: ReportInterface }>(
     `/report/${rid}`
   );
@@ -48,19 +48,7 @@ export default function ReportPage() {
 
   const variations = report.args.variations;
 
-  const filteredDimensions: { id: string; name: string }[] = dimensions.filter(
-    (d) => d.datasource === report.args.datasource
-  );
-
   const datasource = getDatasourceById(report.args.datasource);
-  if (datasource?.settings?.experimentDimensions?.length > 0) {
-    datasource.settings.experimentDimensions.forEach((d) => {
-      filteredDimensions.push({
-        id: "exp:" + d,
-        name: d,
-      });
-    });
-  }
 
   const status = getQueryStatus(report.queries || [], report.error);
 

--- a/packages/front-end/pages/report/[rid].tsx
+++ b/packages/front-end/pages/report/[rid].tsx
@@ -8,7 +8,7 @@ import { useContext, useState } from "react";
 import RunQueriesButton, {
   getQueryStatus,
 } from "../../components/Queries/RunQueriesButton";
-import { ago, getValidDate } from "../../services/dates";
+import { ago, datetime, getValidDate } from "../../services/dates";
 import { UserContext } from "../../components/ProtectedPage";
 import DateResults from "../../components/Experiment/DateResults";
 import BreakDownResults from "../../components/Experiment/BreakDownResults";
@@ -107,11 +107,23 @@ export default function ReportPage() {
       >
         <Tab key="results" anchor="results" display="Results" padding={false}>
           <div className="p-3">
-            <div className="row">
+            <div className="row align-items-center">
               <div className="col">
                 <h2>Results</h2>
               </div>
               <div className="col-auto ml-auto">
+                {report.runStarted && status !== "running" ? (
+                  <small
+                    className="text-muted"
+                    title={datetime(report.runStarted)}
+                  >
+                    updated {ago(report.runStarted)}
+                  </small>
+                ) : (
+                  ""
+                )}
+              </div>
+              <div className="col-auto">
                 <form
                   onSubmit={async (e) => {
                     e.preventDefault();

--- a/packages/front-end/pages/report/[rid].tsx
+++ b/packages/front-end/pages/report/[rid].tsx
@@ -14,15 +14,13 @@ import DateResults from "../../components/Experiment/DateResults";
 import BreakDownResults from "../../components/Experiment/BreakDownResults";
 import CompactResults from "../../components/Experiment/CompactResults";
 import GuardrailResults from "../../components/Experiment/GuardrailResult";
-import Button from "../../components/Button";
 import { useAuth } from "../../services/auth";
-import { FaFileDownload } from "react-icons/fa";
-import ViewAsyncQueriesButton from "../../components/Queries/ViewAsyncQueriesButton";
 import ControlledTabs from "../../components/Tabs/ControlledTabs";
 import Tab from "../../components/Tabs/Tab";
 import { GBEdit } from "../../components/Icons";
 import EditTitleDescription from "../../components/Report/EditTitleDescription";
 import ConfigureReport from "../../components/Report/ConfigureReport";
+import ResultMoreMenu from "../../components/Experiment/ResultMoreMenu";
 
 export default function ReportPage() {
   const router = useRouter();
@@ -150,6 +148,21 @@ export default function ReportPage() {
                   />
                 </form>
               </div>
+              <div className="col-auto">
+                <ResultMoreMenu
+                  id={report.id}
+                  hasData={hasData}
+                  supportsNotebooks={!!datasource?.settings?.notebookRunQuery}
+                  configure={() => setActive("Configuration")}
+                  editMetrics={() => setActive("Configuration")}
+                  generateReport={false}
+                  hasUserQuery={false}
+                  notebookUrl={`/report/${report.id}/notebook`}
+                  notebookFilename={report.title}
+                  queries={report.queries}
+                  queryError={report.error}
+                />
+              </div>
             </div>
             {report.args.metrics.length === 0 && (
               <div className="alert alert-info">
@@ -237,57 +250,6 @@ export default function ReportPage() {
               )}
             </>
           )}
-          <div className="px-3">
-            <div className="row mb-3">
-              {hasData && datasource?.settings?.notebookRunQuery && (
-                <div className="col-auto">
-                  <Button
-                    color="outline-info"
-                    onClick={async () => {
-                      const res = await apiCall<{ notebook: string }>(
-                        `/report/${report.id}/notebook`,
-                        {
-                          method: "POST",
-                        }
-                      );
-
-                      const url = URL.createObjectURL(
-                        new Blob([res.notebook], {
-                          type: "application/json",
-                        })
-                      );
-
-                      const name = report.title
-                        .replace(/[^a-zA-Z0-9_-]+/g, "")
-                        .replace(/[-]+/g, "_")
-                        .replace(/[_]{2,}/g, "_");
-
-                      const d = new Date()
-                        .toISOString()
-                        .slice(0, 10)
-                        .replace(/-/g, "_");
-
-                      const el = document.createElement("a");
-                      el.href = url;
-                      el.download = `${name}_${d}.ipynb`;
-                      el.click();
-                    }}
-                  >
-                    <FaFileDownload /> Download Notebook
-                  </Button>
-                </div>
-              )}
-
-              {report.queries?.length > 0 && (
-                <div className="col-auto">
-                  <ViewAsyncQueriesButton
-                    queries={report.queries.map((q) => q.query)}
-                    error={report.error}
-                  />
-                </div>
-              )}
-            </div>
-          </div>
         </Tab>
         <Tab
           key="configuration"

--- a/packages/front-end/services/experiments.ts
+++ b/packages/front-end/services/experiments.ts
@@ -1,12 +1,12 @@
 import { SnapshotMetric } from "back-end/types/experiment-snapshot";
 import { MetricInterface } from "back-end/types/metric";
 import { useState } from "react";
-import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
 import {
   defaultMaxPercentChange,
   defaultMinPercentChange,
   defaultMinSampleSize,
 } from "./metrics";
+import { ExperimentReportVariation } from "back-end/types/report";
 
 export type ExperimentTableRow = {
   label: string;
@@ -98,12 +98,12 @@ export function getRisk(riskVariation: number, row: ExperimentTableRow) {
 }
 
 export function useRiskVariation(
-  experiment: ExperimentInterfaceStringDates,
+  numVariations: number,
   rows: ExperimentTableRow[]
 ) {
   const [riskVariation, setRiskVariation] = useState(() => {
     // Calculate the total risk for each variation across all metrics
-    const sums: number[] = Array(experiment.variations.length).fill(0);
+    const sums: number[] = Array(numVariations).fill(0);
     rows.forEach((row) => {
       const baseline = row.variations[0];
       if (!baseline || !baseline.cr) return;
@@ -141,14 +141,14 @@ export function useRiskVariation(
   return { hasRisk, riskVariation, setRiskVariation };
 }
 export function useDomain(
-  experiment: ExperimentInterfaceStringDates,
+  variations: ExperimentReportVariation[],
   rows: ExperimentTableRow[]
 ): [number, number] {
   let lowerBound: number, upperBound: number;
   rows.forEach((row) => {
     const baseline = row.variations[0];
     if (!baseline) return;
-    experiment.variations?.forEach((v, i) => {
+    variations?.forEach((v, i) => {
       // Skip for baseline
       if (!i) return;
 

--- a/packages/front-end/styles/global.scss
+++ b/packages/front-end/styles/global.scss
@@ -148,6 +148,9 @@ pre {
     font-weight: 600;
   }
 }
+.modal-dialog.modal-fill {
+  margin: 0 auto;
+}
 .gbtable {
   color: $main-black;
   margin-bottom: 0;


### PR DESCRIPTION
Fixes #163

TODO:
- [x] Types, Models, and API endpoints for reports
- [x] Back-end logic to run a report and process the results
- [x] Create audit entry for experiment when a report is created and add link to history tab
- [x] CTA on experiment results to create an ad-hoc analysis
- [x] Front-end page to display an experiment report
- [x] Modal to edit a report title/description
- [x] More flexible analysis configuration form for the report page (edit metrics, guardrails, end date, variation weights, variation names)
- [x] Export report as Jupyter notebook
