### PR TITLE
specify media type for body-parser

### DIFF
--- a/packages/docs/pages/app/webhooks.mdx
+++ b/packages/docs/pages/app/webhooks.mdx
@@ -68,7 +68,7 @@ const GROWTHBOOK_WEBHOOK_SECRET = "abc123";
 
 const app = express();
 
-app.post("/webhook", bodyParser.raw(), (req, res) => {
+app.post("/webhook", bodyParser.raw({ type: "application/json" }), (req, res) => {
   const payload = req.body;
   const sig = req.get("X-GrowthBook-Signature");
 


### PR DESCRIPTION
The `raw()` middleware by default only parses requests with `content-type: application/octet-stream`, per the [body-parser docs](https://expressjs.com/en/resources/middleware/body-parser.html#bodyparserrawoptions). As written, the code example leaves `req.body` undefined and computing the payload always fails as the crypto module is expecting a buffer-like.

This PR fixes this unintended behavior by specifying that the `raw()` middleware should parse the json payload sent by growthbook webhooks.