### PR TITLE
Support SQL template variables `{{startDate}}` and `{{endDate}}`

### DIFF
--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -39,6 +39,23 @@ const percentileNumbers = [
   0.99,
 ];
 
+// Replace `{{startDate}}` and `{{endDate}}` in SQL queries
+function replaceDateVars(sql: string, startDate: Date, endDate?: Date) {
+  return sql
+    .replace(
+      /\{\{\s*startDate\s*\}\}/g,
+      startDate.toISOString().substr(0, 19).replace("T", " ")
+    )
+    .replace(
+      /\{\{\s*endDate\s*\}\}/g,
+      // Give an extra day buffer to account for any timezones, etc.
+      (endDate || new Date(Date.now() + 1000 * 60 * 60 * 24))
+        .toISOString()
+        .substr(0, 19)
+        .replace("T", " ")
+    );
+}
+
 export function getExperimentQuery(
   settings: DataSourceSettings,
   schema?: string
@@ -187,7 +204,10 @@ export default abstract class SqlIntegration
       `-- Past Experiments
     WITH
       __experiments as (
-        ${getExperimentQuery(this.settings, this.getSchema())}
+        ${replaceDateVars(
+          getExperimentQuery(this.settings, this.getSchema()),
+          params.from
+        )}
       ),
       __experimentDates as (
         SELECT
@@ -288,7 +308,11 @@ export default abstract class SqlIntegration
           segment: !!params.segmentQuery,
           metrics: [params.metric],
         })}
-        __pageviews as (${getPageviewsQuery(this.settings, this.getSchema())}),
+        __pageviews as (${replaceDateVars(
+          getPageviewsQuery(this.settings, this.getSchema()),
+          params.from,
+          params.to
+        )}),
         __users as (${this.getPageUsersCTE(
           params,
           userId,
@@ -673,9 +697,10 @@ export default abstract class SqlIntegration
         dimension: dimension?.type === "user",
         metrics: [metric, activationMetric],
       })}
-      __rawExperiment as (${getExperimentQuery(
-        this.settings,
-        this.getSchema()
+      __rawExperiment as (${replaceDateVars(
+        getExperimentQuery(this.settings, this.getSchema()),
+        phase.dateStarted,
+        phase.dateEnded
       )}),
       __experiment as (${this.getExperimentCTE({
         experiment,
@@ -852,8 +877,8 @@ export default abstract class SqlIntegration
     metric: MetricInterface;
     conversionWindowHours?: number;
     userId?: boolean;
-    startDate?: Date;
-    endDate?: Date | null;
+    startDate: Date;
+    endDate: Date | null;
   }) {
     let userIdCol: string;
     let join = "";
@@ -912,7 +937,11 @@ export default abstract class SqlIntegration
       FROM
         ${
           metric.sql
-            ? `(${metric.sql})`
+            ? `(${replaceDateVars(
+                metric.sql,
+                startDate,
+                endDate || undefined
+              )})`
             : (schema && !metric.table?.match(/\./) ? schema + "." : "") +
               (metric.table || "")
         } m

--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -603,7 +603,11 @@ export default abstract class SqlIntegration
         user_id,
         anonymous_id
       FROM
-        (${getPageviewsQuery(this.settings, this.getSchema())}) i
+        (${replaceDateVars(
+          getPageviewsQuery(this.settings, this.getSchema()),
+          from,
+          to
+        )}) i
       WHERE
         i.timestamp >= ${this.toTimestamp(from)}
         ${to ? `AND i.timestamp <= ${this.toTimestamp(to)}` : ""}
@@ -695,6 +699,7 @@ export default abstract class SqlIntegration
         from: phase.dateStarted,
         to: phase.dateEnded,
         dimension: dimension?.type === "user",
+        segment: !!segment,
         metrics: [metric, activationMetric],
       })}
       __rawExperiment as (${replaceDateVars(

--- a/packages/docs/pages/app/datasources.mdx
+++ b/packages/docs/pages/app/datasources.mdx
@@ -86,6 +86,24 @@ FROM
 
 Similar to the experiment query, don’t worry about duplicate rows or ordering. Just make sure the column names you select exactly match the above.
 
+#### SQL Template Variables
+
+Within your experiment and page view queries, you can use the variables `{{ startDate }}` and `{{ endDate }}`, which will be replaced with strings before being run. This can be useful for giving hints to SQL optimization engines to improve query performance.
+
+For example:
+
+```sql
+SELECT
+  user_id,
+  anonymous_id,
+  received_at as timestamp,
+  path as url
+FROM
+  pages
+WHERE
+  received_at BETWEEN '{{ startDate }}' AND '{{ endDate }}'
+```
+
 #### 3. Jupyter Notebook Query Runner
 
 This setting is only required if you want to export experiment results as a Jupyter Notebook.

--- a/packages/docs/pages/app/metrics.mdx
+++ b/packages/docs/pages/app/metrics.mdx
@@ -56,6 +56,22 @@ FROM
   registrations
 ```
 
+#### SQL Template Variables
+
+You can use the variables `{{ startDate }}` and `{{ endDate }}` in your query, which will be replaced with strings before being run. This can be useful for giving hints to SQL optimization engines to improve query performance.
+
+For example:
+
+```sql
+SELECT
+  user_id as user_id,
+  received_at as timestamp
+FROM
+  registrations
+WHERE
+  received_at BETWEEN '{{ startDate }}' AND '{{ endDate }}'
+```
+
 ### 2. Query Builder (legacy)
 
 The query builder prompts you for things such as table/column names and constructs a query behind the scenes.


### PR DESCRIPTION
The text `{{startDate}}` and `{{endDate}}` in SQL queries you set in GrowthBook will now be replaced by a date string. This helps in cases where the SQL optimization engine isn't picking up indexes properly.

Fixes #147 