### PR TITLE
Use database connection pools when possible to improve performance

### DIFF
--- a/packages/back-end/src/integrations/Mysql.ts
+++ b/packages/back-end/src/integrations/Mysql.ts
@@ -14,13 +14,17 @@ export default class Mysql extends SqlIntegration {
     return ["password"];
   }
   async runQuery(sql: string) {
-    const conn = await mysql.createConnection({
-      host: this.params.host,
-      port: this.params.port,
-      user: this.params.user,
-      password: this.params.password,
-      database: this.params.database,
-    });
+    const conn = await this.createPooledConnection(
+      () =>
+        mysql.createConnection({
+          host: this.params.host,
+          port: this.params.port,
+          user: this.params.user,
+          password: this.params.password,
+          database: this.params.database,
+        }),
+      15
+    );
 
     const [rows] = await conn.query(sql);
     return rows as RowDataPacket[];

--- a/packages/back-end/src/integrations/Postgres.ts
+++ b/packages/back-end/src/integrations/Postgres.ts
@@ -1,6 +1,6 @@
 import { PostgresConnectionParams } from "../../types/integrations/postgres";
 import { decryptDataSourceParams } from "../services/datasource";
-import { runPostgresQuery } from "../services/postgres";
+import { getPostgresClient, runPostgresQuery } from "../services/postgres";
 import SqlIntegration from "./SqlIntegration";
 
 export default class Postgres extends SqlIntegration {
@@ -13,8 +13,13 @@ export default class Postgres extends SqlIntegration {
   getSensitiveParamKeys(): string[] {
     return ["password"];
   }
-  runQuery(sql: string) {
-    return runPostgresQuery(this.params, sql);
+  async runQuery(sql: string) {
+    const { client } = await this.createPooledConnection(
+      () => getPostgresClient(this.params),
+      15,
+      ({ destroy }) => destroy()
+    );
+    return runPostgresQuery(client, sql);
   }
   getSchema(): string {
     return this.params.defaultSchema || "";

--- a/packages/back-end/src/integrations/Snowflake.ts
+++ b/packages/back-end/src/integrations/Snowflake.ts
@@ -1,6 +1,6 @@
 import { SnowflakeConnectionParams } from "../../types/integrations/snowflake";
 import { decryptDataSourceParams } from "../services/datasource";
-import { runSnowflakeQuery } from "../services/snowflake";
+import { getSnowflakeClient, runSnowflakeQuery } from "../services/snowflake";
 import SqlIntegration from "./SqlIntegration";
 
 export default class Snowflake extends SqlIntegration {
@@ -13,8 +13,12 @@ export default class Snowflake extends SqlIntegration {
   getSensitiveParamKeys(): string[] {
     return ["password"];
   }
-  runQuery(sql: string) {
-    return runSnowflakeQuery(this.params, sql);
+  async runQuery(sql: string) {
+    const snowflake = await this.createPooledConnection(
+      () => getSnowflakeClient(this.params),
+      15
+    );
+    return runSnowflakeQuery(snowflake, sql);
   }
   percentile(col: string, percentile: number) {
     return `APPROX_PERCENTILE(${col}, ${percentile})`;

--- a/packages/back-end/src/services/snowflake.ts
+++ b/packages/back-end/src/services/snowflake.ts
@@ -1,11 +1,7 @@
 import { Snowflake } from "snowflake-promise";
 import { SnowflakeConnectionParams } from "../../types/integrations/snowflake";
 
-export async function runSnowflakeQuery<T>(
-  conn: SnowflakeConnectionParams,
-  sql: string,
-  values: string[] = []
-): Promise<T[]> {
+export async function getSnowflakeClient(conn: SnowflakeConnectionParams) {
   const snowflake = new Snowflake({
     account: conn.account,
     username: conn.username,
@@ -17,6 +13,15 @@ export async function runSnowflakeQuery<T>(
   });
 
   await snowflake.connect();
+
+  return snowflake;
+}
+
+export async function runSnowflakeQuery<T>(
+  snowflake: Snowflake,
+  sql: string,
+  values: string[] = []
+): Promise<T[]> {
   const res = await snowflake.execute(sql, values);
 
   // Annoyingly, Snowflake turns all column names into all caps


### PR DESCRIPTION
Fixes #178
- [x] Postgres, Redshift
- [x] MySQL
- [x] Snowflake
- [ ] Test expiration and garbage collection
- [ ] Test changing connection params
- [ ] Choose proper TTLs for connection objects