### PR TITLE
Allow custom SSL certs for postgres data sources

### DIFF
--- a/packages/back-end/src/services/postgres.ts
+++ b/packages/back-end/src/services/postgres.ts
@@ -7,14 +7,26 @@ export function runPostgresQuery<T>(
   values: string[] = []
 ): Promise<T[]> {
   return new Promise<T[]>((resolve, reject) => {
+    let ssl: false | Record<string, unknown> = false;
+    if (conn.ssl === true || conn.ssl === "true") {
+      ssl = {
+        rejectUnauthorized: false,
+      };
+
+      if (conn.caCert) {
+        ssl.ca = conn.caCert;
+      }
+      if (conn.clientCert) {
+        ssl.cert = conn.clientCert;
+      }
+      if (conn.clientKey) {
+        ssl.key = conn.clientKey;
+      }
+    }
+
     const settings: ClientConfig = {
       ...conn,
-      ssl:
-        conn.ssl === true || conn.ssl === "true"
-          ? {
-              rejectUnauthorized: false,
-            }
-          : false,
+      ssl,
     };
 
     const client = new Client(settings);

--- a/packages/back-end/src/services/postgres.ts
+++ b/packages/back-end/src/services/postgres.ts
@@ -7,7 +7,7 @@ export function runPostgresQuery<T>(
   values: string[] = []
 ): Promise<T[]> {
   return new Promise<T[]>((resolve, reject) => {
-    let ssl: false | Record<string, unknown> = false;
+    let ssl: false | ClientConfig["ssl"] = false;
     if (conn.ssl === true || conn.ssl === "true") {
       ssl = {
         rejectUnauthorized: false,

--- a/packages/back-end/types/integrations/postgres.d.ts
+++ b/packages/back-end/types/integrations/postgres.d.ts
@@ -6,4 +6,7 @@ export interface PostgresConnectionParams {
   port: number;
   ssl: string | boolean;
   defaultSchema: string;
+  caCert?: string;
+  clientCert?: string;
+  clientKey?: string;
 }

--- a/packages/docs/pages/self-host/config.mdx
+++ b/packages/docs/pages/self-host/config.mdx
@@ -152,7 +152,19 @@ params:
   user: root
   password: password
   database: growthbook
-  ssl: false # ssl setting only works for postgres and redshift currently
+```
+
+Redshift and Postgres also support optional params to force an SSL connection:
+
+```yml
+type: postgres
+params:
+  ...
+  ssl: true
+  # Omit the below fields to use the default trusted CA from Mozilla
+  caCert: "-----BEGIN CERTIFICATE-----\n..."
+  clientCert: "-----BEGIN CERTIFICATE-----\n..."
+  clientKey: "-----BEGIN CERTIFICATE-----\n..."
 ```
 
 #### Snowflake

--- a/packages/front-end/components/Settings/DataSourceForm.tsx
+++ b/packages/front-end/components/Settings/DataSourceForm.tsx
@@ -258,6 +258,7 @@ const DataSourceForm: FC<{
       <PostgresForm
         existing={existing}
         onParamChange={onParamChange}
+        setParams={setParams}
         params={datasource.params}
       />
     );
@@ -266,6 +267,7 @@ const DataSourceForm: FC<{
       <PostgresForm
         existing={existing}
         onParamChange={onParamChange}
+        setParams={setParams}
         params={datasource.params}
       />
     );

--- a/packages/front-end/components/Settings/PostgresForm.tsx
+++ b/packages/front-end/components/Settings/PostgresForm.tsx
@@ -1,12 +1,18 @@
-import { FC, ChangeEventHandler } from "react";
+import { FC, ChangeEventHandler, useState } from "react";
 import { PostgresConnectionParams } from "back-end/types/integrations/postgres";
 import { isCloud } from "../../services/env";
+import Toggle from "../Forms/Toggle";
+import Field from "../Forms/Field";
+import { FaCaretDown, FaCaretRight } from "react-icons/fa";
 
 const PostgresForm: FC<{
   params: Partial<PostgresConnectionParams>;
   existing: boolean;
   onParamChange: ChangeEventHandler<HTMLInputElement | HTMLSelectElement>;
-}> = ({ params, existing, onParamChange }) => {
+  setParams: (params: { [key: string]: string }) => void;
+}> = ({ params, existing, onParamChange, setParams }) => {
+  const [certs, setCerts] = useState(false);
+
   return (
     <>
       {isCloud() ? (
@@ -77,20 +83,6 @@ const PostgresForm: FC<{
           />
         </div>
         <div className="form-group col-md-12">
-          <label>Require SSL</label>
-          <select
-            className="form-control"
-            name="ssl"
-            value={
-              params.ssl === true || params.ssl === "true" ? "true" : "false"
-            }
-            onChange={onParamChange}
-          >
-            <option value="false">Off</option>
-            <option value="true">On</option>
-          </select>
-        </div>
-        <div className="form-group col-md-12">
           <label>Default Schema</label>
           <input
             type="text"
@@ -101,6 +93,68 @@ const PostgresForm: FC<{
             placeholder="(optional)"
           />
         </div>
+        <div className="col-md-12">
+          <div className="form-group">
+            <label htmlFor="require-ssl" className="mr-2">
+              Require SSL
+            </label>
+            <Toggle
+              id="require-ssl"
+              label="Require SSL"
+              value={params.ssl === true || params.ssl === "true"}
+              setValue={(value) => {
+                setParams({
+                  ssl: value ? "true" : "",
+                });
+              }}
+            />
+            {params.ssl && (
+              <a
+                href="#"
+                onClick={(e) => {
+                  e.preventDefault();
+                  setCerts(!certs);
+                }}
+              >
+                Advanced SSL Settings{" "}
+                {certs ? <FaCaretDown /> : <FaCaretRight />}
+              </a>
+            )}
+          </div>
+        </div>
+        {params.ssl && certs && (
+          <div className="col-md-12 mb-3">
+            <div className="p-2 bg-light border">
+              <Field
+                label="CA Cert (optional)"
+                textarea
+                placeholder={`-----BEGIN CERTIFICATE-----\nMIIE...`}
+                minRows={2}
+                value={params.caCert || ""}
+                name="caCert"
+                onChange={onParamChange}
+              />
+              <Field
+                label="Client Cert"
+                textarea
+                placeholder={`-----BEGIN CERTIFICATE-----\nMIIE...`}
+                minRows={2}
+                value={params.clientCert || ""}
+                name="clientCert"
+                onChange={onParamChange}
+              />
+              <Field
+                label="Client Key"
+                textarea
+                placeholder={`-----BEGIN CERTIFICATE-----\nMIIE...`}
+                minRows={2}
+                value={params.clientKey || ""}
+                name="clientKey"
+                onChange={onParamChange}
+              />
+            </div>
+          </div>
+        )}
       </div>
     </>
   );


### PR DESCRIPTION
Fixes #215 

TODO:
- [x] Update postgres connection types to support CA cert, client cert, and key
- [x] UI in the datasource form to set the CA cert, client cert, and key
- [x] Documentation for self-host config.yml