### PR TITLE
Focus the experiment page on analysis, not implementation

### DIFF
--- a/packages/front-end/components/Experiment/EditInfoForm.tsx
+++ b/packages/front-end/components/Experiment/EditInfoForm.tsx
@@ -7,7 +7,6 @@ import {
 } from "back-end/types/experiment";
 import MarkdownInput from "../Markdown/MarkdownInput";
 import Modal from "../Modal";
-import dJSON from "dirty-json";
 import { UserContext } from "../ProtectedPage";
 import RadioSelector from "../Forms/RadioSelector";
 import Field from "../Forms/Field";
@@ -64,8 +63,6 @@ const EditInfoForm: FC<{
     name: "variations",
   });
 
-  const implementation = form.watch("implementation");
-
   return (
     <Modal
       header={"Edit Info"}
@@ -75,21 +72,6 @@ const EditInfoForm: FC<{
       submit={form.handleSubmit(async (value) => {
         const data = { ...value };
         data.variations = [...data.variations];
-
-        value.variations.forEach((v, i) => {
-          if (v.value) {
-            try {
-              data.variations[i] = {
-                ...data.variations[i],
-                value: JSON.stringify(dJSON.parse(v.value), null, 2),
-              };
-            } catch (e) {
-              throw new Error(
-                `JSON parse error for variation "${v.name}": ${e.message}`
-              );
-            }
-          }
-        });
 
         await apiCall(`/experiment/${experiment.id}`, {
           method: "POST",
@@ -168,17 +150,6 @@ const EditInfoForm: FC<{
                   textarea
                   {...form.register(`variations.${i}.description`)}
                 />
-                {implementation !== "visual" && (
-                  <Field
-                    label="JSON Value"
-                    textarea
-                    minRows={1}
-                    maxRows={10}
-                    placeholder='e.g. {"color": "red"}'
-                    {...form.register(`variations.${i}.value`)}
-                    helpText="Optional, use to parameterize experiment data."
-                  />
-                )}
                 <div className="text-right">
                   {experiment.status === "draft" &&
                   variations.fields.length > 2 ? (

--- a/packages/front-end/components/Experiment/NewExperimentForm.tsx
+++ b/packages/front-end/components/Experiment/NewExperimentForm.tsx
@@ -7,7 +7,6 @@ import TagsInput from "../TagsInput";
 import {
   ExperimentInterfaceStringDates,
   ExperimentPhaseStringDates,
-  ImplementationType,
   Variation,
 } from "back-end/types/experiment";
 import { MdDeleteForever } from "react-icons/md";
@@ -19,7 +18,6 @@ import track from "../../services/track";
 import { useDefinitions } from "../../services/DefinitionsContext";
 import { useContext } from "react";
 import { UserContext } from "../ProtectedPage";
-import RadioSelector from "../Forms/RadioSelector";
 import Field from "../Forms/Field";
 import { getValidDate } from "../../services/dates";
 import { GBAddCircle } from "../Icons";
@@ -149,6 +147,8 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
 
   const datasource = getDatasourceById(form.watch("datasource"));
 
+  const implementation = form.watch("implementation");
+
   const { apiCall } = useAuth();
 
   const {
@@ -213,29 +213,14 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
       <Page display="Basic Info">
         <Field label="Name" required minLength={2} {...form.register("name")} />
         {visualEditorEnabled && !isImport && (
-          <div className="form-group">
-            <label className="mb-0">Type</label>
-            <RadioSelector
-              name="implementation"
-              value={form.watch("implementation")}
-              setValue={(val: ImplementationType) =>
-                form.setValue("implementation", val)
-              }
-              options={[
-                {
-                  key: "code",
-                  display: "Code",
-                  description:
-                    "Using one of our Client Libraries (Javascript, React, PHP, Ruby, or Python)",
-                },
-                {
-                  key: "visual",
-                  display: "Visual",
-                  description: "Using our point & click Visual Editor",
-                },
-              ]}
-            />
-          </div>
+          <Field
+            label="Use Visual Editor"
+            options={[
+              { display: "no", value: "code" },
+              { display: "yes", value: "visual" },
+            ]}
+            {...form.register("implementation")}
+          />
         )}
         <div className="form-group">
           <label>Tags</label>
@@ -411,7 +396,7 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
           </div>
         )}
       </Page>
-      <Page display="Metrics and Targeting">
+      <Page display="Goals">
         <div style={{ minHeight: 350 }}>
           <div className="form-group">
             <label className="font-weight-bold mb-1">Goal Metrics</label>
@@ -436,14 +421,14 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
               datasource={datasource?.id}
             />
           </div>
-          {datasource?.properties?.userIds && (
+          {datasource?.properties?.userIds && implementation === "visual" && (
             <Field
               label="Login State"
               {...form.register("userIdType")}
               options={["user", "anonymous"]}
             />
           )}
-          {!isImport && (
+          {!isImport && implementation === "visual" && (
             <Field
               label="URL Targeting"
               {...form.register("targetURLRegex")}

--- a/packages/front-end/components/Experiment/NewPhaseForm.tsx
+++ b/packages/front-end/components/Experiment/NewPhaseForm.tsx
@@ -11,6 +11,7 @@ import { getEvenSplit } from "../../services/utils";
 import GroupsInput from "../GroupsInput";
 import { useDefinitions } from "../../services/DefinitionsContext";
 import Field from "../Forms/Field";
+import { useFeature } from "@growthbook/growthbook-react";
 
 const NewPhaseForm: FC<{
   experiment: ExperimentInterfaceStringDates;
@@ -42,6 +43,8 @@ const NewPhaseForm: FC<{
   const { apiCall } = useAuth();
 
   const variationWeights = form.watch("variationWeights");
+
+  const showGroups = useFeature("show-experiment-groups").on;
 
   // Make sure variation weights add up to 1 (allow for a little bit of rounding error)
   const totalWeights = variationWeights.reduce(
@@ -170,21 +173,24 @@ const NewPhaseForm: FC<{
           )}
         </div>
       </div>
-      <div className="row">
-        <div className="col">
-          <label>User Groups (optional)</label>
-          <GroupsInput
-            value={form.watch("groups")}
-            onChange={(groups) => {
-              form.setValue("groups", groups);
-            }}
-          />
-          <small className="form-text text-muted">
-            Use this to limit your experiment to specific groups of users (e.g.
-            &quot;internal&quot;, &quot;beta-testers&quot;, &quot;qa&quot;).
-          </small>
+      {(experiment.implementation === "visual" || showGroups) && (
+        <div className="row">
+          <div className="col">
+            <label>User Groups (optional)</label>
+            <GroupsInput
+              value={form.watch("groups")}
+              onChange={(groups) => {
+                form.setValue("groups", groups);
+              }}
+            />
+            <small className="form-text text-muted">
+              Use this to limit your experiment to specific groups of users
+              (e.g. &quot;internal&quot;, &quot;beta-testers&quot;,
+              &quot;qa&quot;).
+            </small>
+          </div>
         </div>
-      </div>
+      )}
       <div style={{ height: 150 }} />
     </Modal>
   );

--- a/packages/front-end/pages/experiment/[eid].tsx
+++ b/packages/front-end/pages/experiment/[eid].tsx
@@ -48,12 +48,12 @@ import MoreMenu from "../../components/Dropdown/MoreMenu";
 import InstructionsModal from "../../components/Experiment/InstructionsModal";
 import { useDefinitions } from "../../services/DefinitionsContext";
 import VisualCode from "../../components/Experiment/VisualCode";
-import Code from "../../components/Code";
 import { IdeaInterface } from "back-end/types/idea";
 import EditProjectForm from "../../components/Experiment/EditProjectForm";
 import DeleteButton from "../../components/DeleteButton";
 import { GBCircleArrowLeft, GBEdit } from "../../components/Icons";
 import Button from "../../components/Button";
+import { IfFeatureEnabled, useFeature } from "@growthbook/growthbook-react";
 
 const ExperimentPage = (): ReactElement => {
   const router = useRouter();
@@ -69,6 +69,8 @@ const ExperimentPage = (): ReactElement => {
   const [metricsModalOpen, setMetricsModalOpen] = useState(false);
   const [targetingModalOpen, setTargetingModalOpen] = useState(false);
   const [instructionsModalOpen, setInstructionsModalOpen] = useState(false);
+
+  const showTargeting = useFeature("show-experiment-targeting").on;
 
   const { apiCall } = useAuth();
 
@@ -545,9 +547,6 @@ const ExperimentPage = (): ReactElement => {
                           <small className="text-muted">id: {v.key || i}</small>
                         </div>
                         {v.description && <p>{v.description}</p>}
-                        {v.value && experiment.implementation !== "visual" && (
-                          <Code language="json" code={v.value} />
-                        )}
                         {experiment.implementation === "visual" && (
                           <VisualCode
                             dom={v.dom || []}
@@ -631,7 +630,7 @@ const ExperimentPage = (): ReactElement => {
               {!experiment.archived &&
                 experiment.status !== "stopped" &&
                 experiment.implementation !== "visual" && (
-                  <>
+                  <IfFeatureEnabled feature="experiment-implementation">
                     <RightRailSection title="Implementation">
                       <div className="my-1">
                         <a
@@ -647,7 +646,7 @@ const ExperimentPage = (): ReactElement => {
                       </div>
                     </RightRailSection>
                     <hr />
-                  </>
+                  </IfFeatureEnabled>
                 )}
               <RightRailSection
                 title="Tags"
@@ -707,26 +706,39 @@ const ExperimentPage = (): ReactElement => {
                   </RightRailSectionGroup>
                 )}
               </RightRailSection>
-              <hr />
-              <RightRailSection
-                title="Targeting"
-                open={() => setTargetingModalOpen(true)}
-                canOpen={canEdit && !experiment.archived}
-              >
-                {datasource?.properties?.userIds && (
-                  <RightRailSectionGroup title="Login State" type="commaList">
-                    {experiment.userIdType === "user" ? "User" : "Anonymous"}
-                  </RightRailSectionGroup>
-                )}
-                <RightRailSectionGroup title="URL" type="code" empty="Any">
-                  {experiment.targetURLRegex}
-                </RightRailSectionGroup>
-                {currentPhase?.groups?.length > 0 && (
-                  <RightRailSectionGroup title="User Groups" type="commaList">
-                    {currentPhase?.groups}
-                  </RightRailSectionGroup>
-                )}
-              </RightRailSection>
+
+              {(experiment.implementation === "visual" || showTargeting) && (
+                <>
+                  <hr />
+                  <RightRailSection
+                    title="Targeting"
+                    open={() => setTargetingModalOpen(true)}
+                    canOpen={canEdit && !experiment.archived}
+                  >
+                    {datasource?.properties?.userIds && (
+                      <RightRailSectionGroup
+                        title="Login State"
+                        type="commaList"
+                      >
+                        {experiment.userIdType === "user"
+                          ? "User"
+                          : "Anonymous"}
+                      </RightRailSectionGroup>
+                    )}
+                    <RightRailSectionGroup title="URL" type="code" empty="Any">
+                      {experiment.targetURLRegex}
+                    </RightRailSectionGroup>
+                    {currentPhase?.groups?.length > 0 && (
+                      <RightRailSectionGroup
+                        title="User Groups"
+                        type="commaList"
+                      >
+                        {currentPhase?.groups}
+                      </RightRailSectionGroup>
+                    )}
+                  </RightRailSection>
+                </>
+              )}
               {data.idea && <hr />}
               {data.idea && (
                 <RightRailSection title="Linked Idea" canOpen={false}>


### PR DESCRIPTION
TODO:
- [x] Remove implementation instructions on experiment info tab
- [x] Remove "groups" input from new phase form
- [x] Remove targeting (URL, Login State) from new experiment form and experiment info tab
- [x] Remove variation JSON from edit experiment form and experiment info tab
- [x] Simplify UI for deciding between code and visual experiments
- [ ] New UI for start/stop button
- [ ] Add webhooks for features
- [ ] Remove docs on config API endpoint and experiment overrides in webhook calls
- [ ] Remove docs on experiment overrides from the SDKs (keep the functionality for BC, but make it undocumented and deprecated)
- [ ] Update Experiment docs to focus only on documentation and analysis