### PR TITLE
Auto-fix mismatched variation ids.

### DIFF
--- a/packages/front-end/components/Experiment/CompactResults.tsx
+++ b/packages/front-end/components/Experiment/CompactResults.tsx
@@ -29,6 +29,7 @@ const CompactResults: FC<{
   status: ExperimentStatus;
   metrics: string[];
   id: string;
+  setVariationIds?: (ids: string[]) => Promise<void>;
 }> = ({
   results,
   variations,
@@ -42,6 +43,7 @@ const CompactResults: FC<{
   isLatestPhase,
   metrics,
   id,
+  setVariationIds,
 }) => {
   const { getMetricById, ready } = useDefinitions();
 
@@ -76,6 +78,7 @@ const CompactResults: FC<{
           unknownVariations={unknownVariations}
           variations={variations}
           isUpdating={isUpdating}
+          setVariationIds={setVariationIds}
         />
         <MultipleExposureWarning
           users={users}

--- a/packages/front-end/components/Experiment/DataQualityWarning.tsx
+++ b/packages/front-end/components/Experiment/DataQualityWarning.tsx
@@ -5,6 +5,7 @@ import {
   ExperimentReportResultDimension,
   ExperimentReportVariation,
 } from "back-end/types/report";
+import Button from "../Button";
 
 const CommaList: FC<{ vals: string[] }> = ({ vals }) => {
   if (!vals.length) {
@@ -28,7 +29,14 @@ const DataQualityWarning: FC<{
   isUpdating?: boolean;
   variations: ExperimentReportVariation[];
   unknownVariations: string[];
-}> = ({ isUpdating, results, variations, unknownVariations }) => {
+  setVariationIds?: (ids: string[]) => Promise<void>;
+}> = ({
+  isUpdating,
+  results,
+  variations,
+  unknownVariations,
+  setVariationIds,
+}) => {
   if (!results) return null;
   const variationResults = results?.variations || [];
 
@@ -88,7 +96,19 @@ const DataQualityWarning: FC<{
           ? "a different set"
           : returnedVariations.length}{" "}
         (<CommaList vals={returnedVariations} />
-        ).
+        ).{" "}
+        {setVariationIds &&
+          returnedVariations.length === definedVariations.length && (
+            <Button
+              color="info"
+              className="btn-sm ml-3"
+              onClick={async () => {
+                await setVariationIds(returnedVariations);
+              }}
+            >
+              Use these instead
+            </Button>
+          )}
       </div>
     );
   }

--- a/packages/front-end/components/Experiment/DataQualityWarning.tsx
+++ b/packages/front-end/components/Experiment/DataQualityWarning.tsx
@@ -119,7 +119,7 @@ const DataQualityWarning: FC<{
                 setIdModal(true);
               }}
             >
-              Fix Ids
+              Update Ids
             </button>
           )}
         </div>

--- a/packages/front-end/components/Experiment/DataQualityWarning.tsx
+++ b/packages/front-end/components/Experiment/DataQualityWarning.tsx
@@ -5,7 +5,8 @@ import {
   ExperimentReportResultDimension,
   ExperimentReportVariation,
 } from "back-end/types/report";
-import Button from "../Button";
+import { useState } from "react";
+import FixVariationIds from "./FixVariationIds";
 
 const CommaList: FC<{ vals: string[] }> = ({ vals }) => {
   if (!vals.length) {
@@ -37,6 +38,8 @@ const DataQualityWarning: FC<{
   unknownVariations,
   setVariationIds,
 }) => {
+  const [idModal, setIdModal] = useState(false);
+
   if (!results) return null;
   const variationResults = results?.variations || [];
 
@@ -88,28 +91,39 @@ const DataQualityWarning: FC<{
   // There are unknown variations
   if (unknownVariations?.length > 0) {
     return (
-      <div className="alert alert-warning">
-        <strong>Warning:</strong> Expected {variations.length} variation ids (
-        <CommaList vals={definedVariations} />
-        ), but database returned{" "}
-        {returnedVariations.length === definedVariations.length
-          ? "a different set"
-          : returnedVariations.length}{" "}
-        (<CommaList vals={returnedVariations} />
-        ).{" "}
-        {setVariationIds &&
-          returnedVariations.length === definedVariations.length && (
-            <Button
-              color="info"
-              className="btn-sm ml-3"
-              onClick={async () => {
-                await setVariationIds(returnedVariations);
+      <>
+        {idModal && (
+          <FixVariationIds
+            close={() => setIdModal(false)}
+            expected={definedVariations}
+            actual={returnedVariations}
+            names={variations.map((v) => v.name)}
+            setVariationIds={setVariationIds}
+          />
+        )}
+        <div className="alert alert-warning">
+          <strong>Warning:</strong> Expected {variations.length} variation ids (
+          <CommaList vals={definedVariations} />
+          ), but database returned{" "}
+          {returnedVariations.length === definedVariations.length
+            ? "a different set"
+            : returnedVariations.length}{" "}
+          (<CommaList vals={returnedVariations} />
+          ).{" "}
+          {setVariationIds && (
+            <button
+              className="btn btn-info btn-sm ml-3"
+              type="button"
+              onClick={(e) => {
+                e.preventDefault();
+                setIdModal(true);
               }}
             >
-              Use these instead
-            </Button>
+              Fix Ids
+            </button>
           )}
-      </div>
+        </div>
+      </>
     );
   }
 

--- a/packages/front-end/components/Experiment/FixVariationIds.tsx
+++ b/packages/front-end/components/Experiment/FixVariationIds.tsx
@@ -1,0 +1,55 @@
+import { useForm } from "react-hook-form";
+import Modal from "../Modal";
+import uniq from "lodash/uniq";
+import Field from "../Forms/Field";
+
+export interface Props {
+  setVariationIds: (ids: string[]) => Promise<void>;
+  names: string[];
+  expected: string[];
+  actual: string[];
+  close: () => void;
+}
+
+export default function FixVariationIds({
+  names,
+  expected,
+  actual,
+  setVariationIds,
+  close,
+}: Props) {
+  const form = useForm({
+    defaultValues: {
+      ids: new Array(expected.length).fill(""),
+    },
+  });
+
+  return (
+    <Modal
+      open={true}
+      submit={form.handleSubmit(async (value) => {
+        const ids = value.ids.map((id, i) => (id ? id : expected[i]));
+
+        if (uniq(ids).length !== ids.length) {
+          throw new Error("Variation Ids must all be unique");
+        }
+
+        await setVariationIds(ids);
+      })}
+      cta="Save"
+      close={close}
+      header="Fix Variation Ids"
+    >
+      <h3>Variation Ids</h3>
+      {names.map((name, i) => (
+        <Field
+          key={i}
+          label={name}
+          options={actual}
+          placeholder={expected[i]}
+          {...form.register(`ids.${i}`)}
+        />
+      ))}
+    </Modal>
+  );
+}

--- a/packages/front-end/components/Experiment/NewExperimentForm.tsx
+++ b/packages/front-end/components/Experiment/NewExperimentForm.tsx
@@ -77,7 +77,7 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
 }) => {
   const router = useRouter();
   const [step, setStep] = useState(initialStep || 0);
-  const [showVariationIds] = useState(false);
+  const [showVariationIds] = useState(isImport);
 
   const {
     datasources,
@@ -289,23 +289,23 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
                 style={{ minWidth: 200 }}
               >
                 <div className="graybox">
-                  <div className="row">
-                    <div className={showVariationIds ? "col-8" : "col-12"}>
-                      <Field
-                        label={i === 0 ? "Control Name" : `Variation ${i} Name`}
-                        {...form.register(`variations.${i}.name`)}
-                      />
-                    </div>
-                    <div
-                      className={`col-4 ${showVariationIds ? "" : "d-none"}`}
-                    >
-                      <Field
-                        label="Id"
-                        {...form.register(`variations.${i}.key`)}
-                        placeholder={i + ""}
-                      />
-                    </div>
-                  </div>
+                  <Field
+                    label={i === 0 ? "Control Name" : `Variation ${i} Name`}
+                    {...form.register(`variations.${i}.name`)}
+                  />
+                  {showVariationIds && (
+                    <Field
+                      label="Id"
+                      {...form.register(`variations.${i}.key`)}
+                      placeholder={i + ""}
+                      helpText={
+                        <span>
+                          Must match the <code>variation_id</code> field in your
+                          data source
+                        </span>
+                      }
+                    />
+                  )}
                   <Field
                     label="Description"
                     {...form.register(`variations.${i}.description`)}

--- a/packages/front-end/components/Experiment/NewExperimentForm.tsx
+++ b/packages/front-end/components/Experiment/NewExperimentForm.tsx
@@ -9,7 +9,6 @@ import {
   ExperimentPhaseStringDates,
   Variation,
 } from "back-end/types/experiment";
-import { MdDeleteForever } from "react-icons/md";
 import MetricsSelector from "./MetricsSelector";
 import { useWatching } from "../../services/WatchProvider";
 import MarkdownInput from "../Markdown/MarkdownInput";
@@ -21,6 +20,7 @@ import Field from "../Forms/Field";
 import { getValidDate } from "../../services/dates";
 import { GBAddCircle } from "../Icons";
 import SelectField from "../Forms/SelectField";
+import MoreMenu from "../Dropdown/MoreMenu";
 
 const weekAgo = new Date();
 weekAgo.setDate(weekAgo.getDate() - 7);
@@ -288,11 +288,54 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
                 key={i}
                 style={{ minWidth: 200 }}
               >
-                <div className="graybox">
+                <div className="graybox position-relative">
                   <Field
                     label={i === 0 ? "Control Name" : `Variation ${i} Name`}
                     {...form.register(`variations.${i}.name`)}
                   />
+                  <div
+                    style={{
+                      position: "absolute",
+                      top: 5,
+                      right: 5,
+                    }}
+                  >
+                    <MoreMenu id={`variation${i}`}>
+                      {i > 0 && (
+                        <a
+                          className="dropdown-item"
+                          onClick={(e) => {
+                            e.preventDefault();
+                            variations.swap(i, i - 1);
+                          }}
+                        >
+                          Swap left
+                        </a>
+                      )}
+                      {i < variations.fields.length - 1 && (
+                        <a
+                          className="dropdown-item"
+                          onClick={(e) => {
+                            e.preventDefault();
+                            variations.swap(i, i + 1);
+                          }}
+                        >
+                          Swap right
+                        </a>
+                      )}
+                      {!isImport && variations.fields.length > 2 && (
+                        <a
+                          className=" dropdown-item text-danger"
+                          onClick={(e) => {
+                            e.preventDefault();
+                            variations.remove(i);
+                          }}
+                        >
+                          Delete
+                        </a>
+                      )}
+                    </MoreMenu>
+                  </div>
                   {showVariationIds && (
                     <Field
                       label="Id"
@@ -310,21 +353,6 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
                     label="Description"
                     {...form.register(`variations.${i}.description`)}
                   />
-                  <div className="text-right">
-                    {!isImport && variations.fields.length > 2 ? (
-                      <a
-                        className="text-danger cursor-pointer"
-                        onClick={(e) => {
-                          e.preventDefault();
-                          variations.remove(i);
-                        }}
-                      >
-                        <MdDeleteForever /> Delete
-                      </a>
-                    ) : (
-                      ""
-                    )}
-                  </div>
                 </div>
               </div>
             ))}

--- a/packages/front-end/components/Experiment/Results.tsx
+++ b/packages/front-end/components/Experiment/Results.tsx
@@ -16,6 +16,7 @@ import DateResults from "./DateResults";
 import AnalysisSettingsBar from "./AnalysisSettingsBar";
 import ExperimentReportsList from "./ExperimentReportsList";
 import usePermissions from "../../hooks/usePermissions";
+import { useAuth } from "../../services/auth";
 
 const BreakDownResults = dynamic(() => import("./BreakDownResults"));
 const CompactResults = dynamic(() => import("./CompactResults"));
@@ -27,6 +28,8 @@ const Results: FC<{
   mutateExperiment: () => void;
 }> = ({ experiment, editMetrics, editResult, mutateExperiment }) => {
   const { dimensions, getMetricById, getDatasourceById } = useDefinitions();
+
+  const { apiCall } = useAuth();
 
   const [phase, setPhase] = useState(experiment.phases.length - 1);
   const [dimension, setDimension] = useState("");
@@ -215,6 +218,37 @@ const Results: FC<{
             variations={variations}
             isUpdating={status === "running"}
             editMetrics={editMetrics}
+            setVariationIds={async (ids) => {
+              // Don't do anything if the query is currently running
+              if (status === "running") {
+                throw new Error("Cancel running query first");
+              }
+
+              // Update variation ids
+              await apiCall(`/experiment/${experiment.id}`, {
+                method: "POST",
+                body: JSON.stringify({
+                  variations: experiment.variations.map((v, i) => {
+                    return {
+                      ...v,
+                      key: ids[i] ?? v.key,
+                    };
+                  }),
+                }),
+              });
+
+              // Fetch results again
+              await apiCall(`/experiment/${experiment.id}/snapshot`, {
+                method: "POST",
+                body: JSON.stringify({
+                  phase,
+                  dimension,
+                }),
+              });
+
+              mutateExperiment();
+              mutate();
+            }}
           />
           {experiment.guardrails?.length > 0 && (
             <div className="mb-3 p-3">

--- a/packages/front-end/components/Tabs/ControlledTabs.tsx
+++ b/packages/front-end/components/Tabs/ControlledTabs.tsx
@@ -80,6 +80,7 @@ const ControlledTabs: FC<{
       action,
       className,
       padding,
+      forceRenderOnFocus,
     } = child.props;
     if (visible === false) return;
     const id = child.props?.id ?? display;
@@ -118,6 +119,8 @@ const ControlledTabs: FC<{
     );
 
     if (lazy && !isActive && !loaded[id]) {
+      contents.push(null);
+    } else if (!isActive && forceRenderOnFocus) {
       contents.push(null);
     } else {
       contents.push(

--- a/packages/front-end/components/Tabs/Tab.tsx
+++ b/packages/front-end/components/Tabs/Tab.tsx
@@ -10,6 +10,7 @@ const Tab: FC<{
   action?: ReactElement;
   className?: string;
   padding?: boolean;
+  forceRenderOnFocus?: boolean;
 }> = ({ children }) => {
   return <>{children}</>;
 };

--- a/packages/front-end/pages/report/[rid].tsx
+++ b/packages/front-end/pages/report/[rid].tsx
@@ -1,5 +1,5 @@
 import { useRouter } from "next/router";
-import { ReportInterface } from "back-end/types/report";
+import { ExperimentReportArgs, ReportInterface } from "back-end/types/report";
 import LoadingOverlay from "../../components/LoadingOverlay";
 import Markdown from "../../components/Markdown/Markdown";
 import useApi from "../../hooks/useApi";
@@ -302,6 +302,25 @@ export default function ReportPage() {
                 multipleExposures={report.results?.multipleExposures || 0}
                 variations={variations}
                 isUpdating={status === "running"}
+                setVariationIds={async (ids) => {
+                  const args: ExperimentReportArgs = {
+                    ...report.args,
+                    variations: report.args.variations.map((v, i) => {
+                      return {
+                        ...v,
+                        id: ids[i] ?? v.id,
+                      };
+                    }),
+                  };
+
+                  await apiCall(`/report/${report.id}`, {
+                    method: "PUT",
+                    body: JSON.stringify({
+                      args,
+                    }),
+                  });
+                  mutate();
+                }}
               />
               {report.args.guardrails?.length > 0 && (
                 <div className="mb-3 p-3">
@@ -335,6 +354,7 @@ export default function ReportPage() {
           anchor="configuration"
           display="Configuration"
           visible={permissions.runExperiments}
+          forceRenderOnFocus={true}
         >
           <h2>Configuration</h2>
           <ConfigureReport


### PR DESCRIPTION
When we run an experiment query, we have an expected array of variation keys and an actual array of variation keys.  When there's a mismatch, we currently show a warning message, but there's no CTA to fix it.

TODO:
- [x] When there are unknown variation ids in experiment/report results, add  CTA to fix it which opens a simple modal form.
- [x] Allow re-ordering variations for an experiment
- [x] When importing an experiment, show the variation ids and allow changing them