### PR TITLE
Fix typo in getBucketRanges docs

### DIFF
--- a/packages/docs/pages/lib/build-your-own.mdx
+++ b/packages/docs/pages/lib/build-your-own.mdx
@@ -270,7 +270,7 @@ This converts and experiment's coverage and variation weights into an array of b
    for (w in weights) {
      start = cumulative;
      cumulative += w;
-     ranges.push(start, start + cumulative * w);
+     ranges.push(start, start + coverage * w);
    }
 
    return ranges;


### PR DESCRIPTION
This fixes a issue in the docs, where instead of `coverage`, `cumulative` was used.
