### PR TITLE
When creating feature, option to add initial override rule.

### DIFF
--- a/packages/front-end/components/Features/ConditionInput.tsx
+++ b/packages/front-end/components/Features/ConditionInput.tsx
@@ -218,7 +218,6 @@ export default function ConditionInput(props: Props) {
                       type="button"
                       onClick={(e) => {
                         e.preventDefault();
-                        console.log("Click delete");
                         const newConds = [...conds];
                         newConds.splice(i, 1);
                         setConds(newConds);

--- a/packages/front-end/components/Features/FeatureModal.tsx
+++ b/packages/front-end/components/Features/FeatureModal.tsx
@@ -108,6 +108,7 @@ export default function FeatureModal({ close, existing, onSuccess }: Props) {
           track("Feature Created", {
             valueType: values.valueType,
             hasDescription: values.description.length > 0,
+            initialRule: values.rules?.[0]?.type ?? "none",
           });
           if (values.rules?.length > 0) {
             track("Save Feature Rule", {

--- a/packages/front-end/components/Features/FeatureModal.tsx
+++ b/packages/front-end/components/Features/FeatureModal.tsx
@@ -9,12 +9,20 @@ import { useDefinitions } from "../../services/DefinitionsContext";
 import track from "../../services/track";
 import Toggle from "../Forms/Toggle";
 import uniq from "lodash/uniq";
+import RadioSelector from "../Forms/RadioSelector";
+import ConditionInput from "./ConditionInput";
+import useOrgSettings from "../../hooks/useOrgSettings";
 
 export type Props = {
   close: () => void;
   onSuccess: (feature: FeatureInterface) => Promise<void>;
   existing?: FeatureInterface;
 };
+
+const percentFormatter = new Intl.NumberFormat(undefined, {
+  style: "percent",
+  maximumFractionDigits: 2,
+});
 
 function parseDefaultValue(
   defaultValue: string,
@@ -46,12 +54,20 @@ export default function FeatureModal({ close, existing, onSuccess }: Props) {
       id: existing?.id || "",
       project: existing?.project ?? project,
       environments: ["dev"],
+      rules: [],
     },
   });
   const { apiCall } = useAuth();
+  const settings = useOrgSettings();
+  const firstAttr = settings?.attributeSchema?.[0];
+  const hasHashAttributes =
+    settings?.attributeSchema?.filter((x) => x.hashAttribute)?.length > 0;
 
   const valueType = form.watch("valueType");
   const environments = form.watch("environments");
+
+  const rules = form.watch("rules");
+  const rule = rules?.[0];
 
   return (
     <Modal
@@ -109,24 +125,10 @@ export default function FeatureModal({ close, existing, onSuccess }: Props) {
         />
       )}
 
-      <Field
-        label="Value Type"
-        {...form.register("valueType")}
-        options={[
-          {
-            display: "boolean (on/off)",
-            value: "boolean",
-          },
-          "number",
-          "string",
-          "json",
-        ]}
-      />
-
       <label>Enabled Environments</label>
       <div className="row">
         <div className="col-auto">
-          <div className="form-group">
+          <div className="form-group mb-0">
             <label htmlFor={"dev_toggle_create"} className="mr-2 ml-3">
               Dev:
             </label>
@@ -144,7 +146,7 @@ export default function FeatureModal({ close, existing, onSuccess }: Props) {
           </div>
         </div>
         <div className="col-auto">
-          <div className="form-group">
+          <div className="form-group mb-0">
             <label htmlFor={"production_toggle_create"} className="mr-2">
               Production:
             </label>
@@ -163,17 +165,292 @@ export default function FeatureModal({ close, existing, onSuccess }: Props) {
         </div>
       </div>
 
-      <FeatureValueField
-        label="Value When Enabled"
-        form={form}
-        field="defaultValue"
-        valueType={valueType}
-        helpText={
-          existing
-            ? ""
-            : "After creating the feature, you will be able to add rules to override this default"
-        }
+      <hr />
+      <h5>When Enabled</h5>
+
+      <Field
+        label="Value Type"
+        {...form.register("valueType")}
+        options={[
+          {
+            display: "boolean (on/off)",
+            value: "boolean",
+          },
+          "number",
+          "string",
+          "json",
+        ]}
       />
+
+      <div className="form-group">
+        <label>
+          Behavior <small className="text-muted">(can change later)</small>
+        </label>
+        <RadioSelector
+          name="ruleType"
+          value={rules?.[0]?.type || ""}
+          labelWidth={145}
+          options={[
+            {
+              key: "",
+              display: "Simple",
+              description: "All users get the same value",
+            },
+            {
+              key: "force",
+              display: "Targeted",
+              description:
+                "Most users get one value, a targeted segment gets another",
+            },
+            {
+              key: "rollout",
+              display: "Percentage Rollout",
+              description:
+                "Gradually release a value to users while everyone else gets a fallback",
+            },
+            {
+              key: "experiment",
+              display: "A/B Experiment",
+              description: "Run an A/B test between multiple values.",
+            },
+          ]}
+          setValue={(value) => {
+            if (!value) {
+              form.setValue("rules", []);
+              form.setValue(
+                "defaultValue",
+                valueType === "boolean" ? "true" : ""
+              );
+            } else if (value === "force") {
+              form.setValue("rules", [
+                {
+                  id: "",
+                  type: "force",
+                  description: "",
+                  value: valueType === "boolean" ? "true" : "",
+                  condition: firstAttr
+                    ? JSON.stringify({
+                        [firstAttr.property]:
+                          firstAttr.datatype === "boolean" ? "true" : "",
+                      })
+                    : "",
+                },
+              ]);
+              form.setValue(
+                "defaultValue",
+                valueType === "boolean" ? "false" : ""
+              );
+            } else if (value === "rollout") {
+              form.setValue("rules", [
+                {
+                  id: "",
+                  type: "rollout",
+                  description: "",
+                  value: valueType === "boolean" ? "true" : "",
+                  coverage: 0.5,
+                  hashAttribute: "id",
+                  condition: "",
+                },
+              ]);
+              form.setValue(
+                "defaultValue",
+                valueType === "boolean" ? "false" : ""
+              );
+            } else if (value === "experiment") {
+              form.setValue("rules", [
+                {
+                  id: "",
+                  type: "experiment",
+                  description: "",
+                  hashAttribute: "id",
+                  trackingKey: "",
+                  values: [
+                    {
+                      value: valueType === "boolean" ? "false" : "",
+                      weight: 0.5,
+                    },
+                    {
+                      value: valueType === "boolean" ? "true" : "",
+                      weight: 0.5,
+                    },
+                  ],
+                  condition: "",
+                },
+              ]);
+            }
+          }}
+        />
+      </div>
+
+      {!rule ? (
+        <FeatureValueField
+          label={"Value"}
+          form={form}
+          field="defaultValue"
+          valueType={valueType}
+        />
+      ) : rule?.type === "rollout" ? (
+        <>
+          <Field
+            label="Sample users based on attribute"
+            {...form.register("rules.0.hashAttribute")}
+            options={settings.attributeSchema
+              .filter((s) => !hasHashAttributes || s.hashAttribute)
+              .map((s) => s.property)}
+            helpText="Will be hashed together with the feature key to determine if user is part of the rollout"
+          />
+          <div className="form-group">
+            <label>Percent of users to include</label>
+            <div className="row align-items-center">
+              <div className="col">
+                <input
+                  {...form.register(`rules.0.coverage`, {
+                    valueAsNumber: true,
+                  })}
+                  min="0"
+                  max="1"
+                  step="0.01"
+                  type="range"
+                  className="w-100"
+                />
+              </div>
+              <div
+                className="col-auto"
+                style={{ fontSize: "1.3em", width: "4em" }}
+              >
+                {percentFormatter.format(rule?.coverage)}
+              </div>
+            </div>
+          </div>
+          <FeatureValueField
+            label={"Value when included"}
+            form={form}
+            field="rules.0.value"
+            valueType={valueType}
+          />
+          <FeatureValueField
+            label={"Fallback value"}
+            form={form}
+            field="defaultValue"
+            valueType={valueType}
+          />
+        </>
+      ) : rule?.type === "force" ? (
+        <>
+          <ConditionInput
+            defaultValue={rule?.condition}
+            onChange={(cond) => {
+              form.setValue("rules.0.condition", cond);
+            }}
+          />
+          <FeatureValueField
+            label={"Value When Targeted"}
+            form={form}
+            field="rules.0.value"
+            valueType={valueType}
+          />
+          <FeatureValueField
+            label={"Fallback Value"}
+            form={form}
+            field="defaultValue"
+            valueType={valueType}
+          />
+        </>
+      ) : (
+        <>
+          <Field
+            label="Tracking Key"
+            {...form.register(`rules.0.trackingKey`)}
+            placeholder={form.watch("id")}
+            helpText="Unique identifier for this experiment, used to track impressions and analyze results"
+          />
+          <Field
+            label="Assign variation based on attribute"
+            {...form.register("rules.0.hashAttribute")}
+            options={settings.attributeSchema
+              .filter((s) => !hasHashAttributes || s.hashAttribute)
+              .map((s) => s.property)}
+            helpText="Will be hashed together with the Tracking Key to pick a value"
+          />
+          <div className="form-group">
+            <label>Variations and Weights</label>
+            <table className="table table-bordered">
+              <thead>
+                <tr>
+                  <th>Variation</th>
+                  <th>Percent of Users</th>
+                  {rule.values.length > 2 && <th></th>}
+                </tr>
+              </thead>
+              <tbody>
+                {rule.values.map((val, i) => {
+                  return (
+                    <tr key={i}>
+                      <td>
+                        <FeatureValueField
+                          label=""
+                          form={form}
+                          field={`rules.0.values.${i}.value`}
+                          valueType={valueType}
+                        />
+                      </td>
+                      <td>
+                        <Field
+                          {...form.register(`rules.0.values.${i}.weight`, {
+                            valueAsNumber: true,
+                          })}
+                          type="number"
+                          min={0}
+                          max={1}
+                          step="0.01"
+                        />
+                      </td>
+                      {rule.values.length > 2 && (
+                        <td style={{ width: 100 }}>
+                          <button
+                            className="btn btn-link text-danger"
+                            onClick={(e) => {
+                              e.preventDefault();
+                              form.setValue(
+                                `rules.0.values`,
+                                rule.values.filter((_, j) => j !== i)
+                              );
+                            }}
+                            type="button"
+                          >
+                            remove
+                          </button>
+                        </td>
+                      )}
+                    </tr>
+                  );
+                })}
+                {valueType !== "boolean" && (
+                  <tr>
+                    <td colSpan={3}>
+                      <a
+                        href="#"
+                        onClick={(e) => {
+                          e.preventDefault();
+                          form.setValue(`rules.0.values`, [
+                            ...rule.values,
+                            {
+                              value: "",
+                              weight: 0,
+                            },
+                          ]);
+                        }}
+                      >
+                        add another variation
+                      </a>
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
     </Modal>
   );
 }

--- a/packages/front-end/components/Features/FeatureModal.tsx
+++ b/packages/front-end/components/Features/FeatureModal.tsx
@@ -131,6 +131,7 @@ export default function FeatureModal({ close, existing, onSuccess }: Props) {
           pattern="^[a-zA-Z0-9_.:|-]+$"
           required
           disabled={!!existing}
+          readOnly={!!existing}
           title="Only letters, numbers, and the characters '_-.:|' allowed. No spaces."
           helpText={
             <>

--- a/packages/front-end/components/Features/RolloutPercentInput.tsx
+++ b/packages/front-end/components/Features/RolloutPercentInput.tsx
@@ -1,0 +1,40 @@
+export interface Props {
+  value: number;
+  setValue: (value: number) => void;
+  label?: string;
+}
+
+const percentFormatter = new Intl.NumberFormat(undefined, {
+  style: "percent",
+  maximumFractionDigits: 2,
+});
+
+export default function RolloutPercentInput({
+  value,
+  setValue,
+  label = "Percent of Users",
+}: Props) {
+  return (
+    <div className="form-group">
+      <label>{label}</label>
+      <div className="row align-items-center">
+        <div className="col">
+          <input
+            value={value}
+            onChange={(e) => {
+              setValue(parseFloat(e.target.value));
+            }}
+            min="0"
+            max="1"
+            step="0.01"
+            type="range"
+            className="w-100"
+          />
+        </div>
+        <div className="col-auto" style={{ fontSize: "1.3em", width: "4em" }}>
+          {percentFormatter.format(value)}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/front-end/components/Features/RuleModal.tsx
+++ b/packages/front-end/components/Features/RuleModal.tsx
@@ -97,6 +97,7 @@ export default function RuleModal({
       <Field
         label="Type of Rule"
         readOnly={!!feature.rules?.[i]}
+        disabled={!!feature.rules?.[i]}
         value={type}
         onChange={(e) => {
           const existingCondition = form.watch("condition");

--- a/packages/front-end/components/Features/VariationsInput.tsx
+++ b/packages/front-end/components/Features/VariationsInput.tsx
@@ -1,0 +1,138 @@
+import { FeatureValueType } from "back-end/types/feature";
+import { useFieldArray, UseFormReturn } from "react-hook-form";
+import { getDefaultVariationValue } from "../../services/features";
+import Field from "../Forms/Field";
+import FeatureValueField from "./FeatureValueField";
+
+export interface Props {
+  valueType: FeatureValueType;
+  defaultValue: string;
+  // eslint-disable-next-line
+  form: UseFormReturn<any>;
+  formPrefix?: string;
+}
+
+// Returns n "equal" decimals rounded to 2 places that add up to 1
+// The sum always adds to 1. In some cases the values are not equal.
+// For example, getEqualWeights(3) returns [0.34, 0.33, 0.33]
+function getEqualWeights(n: number): number[] {
+  const w = Math.round(100 / n) / 100;
+  const diff = w * n - 1;
+  const nDiffs = Math.round(Math.abs(diff) * 100);
+  return Array(n)
+    .fill(0)
+    .map((v, i) => {
+      const j = n - i - 1;
+      let d = 0;
+      if (diff < 0 && i < nDiffs) d = 0.01;
+      else if (diff > 0 && j < nDiffs) d = -0.01;
+      return +(w + d).toFixed(2);
+    });
+}
+
+export default function VariationsInput({
+  form,
+  formPrefix = "",
+  valueType,
+  defaultValue,
+}: Props) {
+  const values = useFieldArray({
+    control: form.control,
+    name: `${formPrefix}values`,
+  });
+
+  return (
+    <div className="form-group">
+      <label>Variations and Weights</label>
+      <table className="table table-bordered">
+        <thead>
+          <tr>
+            <th>Variation</th>
+            <th>Percent of Users</th>
+            {values.fields.length > 2 && <th></th>}
+          </tr>
+        </thead>
+        <tbody>
+          {values.fields.map((val, i) => {
+            return (
+              <tr key={i}>
+                <td>
+                  <FeatureValueField
+                    label=""
+                    form={form}
+                    field={`${formPrefix}values.${i}.value`}
+                    valueType={valueType}
+                  />
+                </td>
+                <td>
+                  <Field
+                    {...form.register(`${formPrefix}values.${i}.weight`, {
+                      valueAsNumber: true,
+                    })}
+                    type="number"
+                    min={0}
+                    max={1}
+                    step="0.01"
+                  />
+                </td>
+                {values.fields.length > 2 && (
+                  <td style={{ width: 100 }}>
+                    <button
+                      className="btn btn-link text-danger"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        values.remove(i);
+                      }}
+                      type="button"
+                    >
+                      remove
+                    </button>
+                  </td>
+                )}
+              </tr>
+            );
+          })}
+          {valueType !== "boolean" && (
+            <tr>
+              <td colSpan={3}>
+                <div className="row">
+                  <div className="col">
+                    <a
+                      href="#"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        values.append({
+                          value: getDefaultVariationValue(defaultValue),
+                          weight: 0,
+                        });
+                      }}
+                    >
+                      add another variation
+                    </a>
+                  </div>
+                  <div className="col-auto">
+                    <a
+                      href="#"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        const weights = getEqualWeights(values.fields.length);
+                        values.fields.forEach((v, i) => {
+                          form.setValue(
+                            `${formPrefix}values.${i}.weight`,
+                            weights[i]
+                          );
+                        });
+                      }}
+                    >
+                      set equal weights
+                    </a>
+                  </div>
+                </div>
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/packages/front-end/pages/features/[fid].tsx
+++ b/packages/front-end/pages/features/[fid].tsx
@@ -128,7 +128,7 @@ console.log(growthbook.feature(${JSON.stringify(feature.id)}).value);`;
         </div>
       </div>
 
-      <h3>Environments</h3>
+      <h3>Enabled Environments</h3>
       <div className="appbox mb-4 p-3">
         <div className="row mb-2">
           <div className="col-auto">
@@ -164,7 +164,7 @@ console.log(growthbook.feature(${JSON.stringify(feature.id)}).value);`;
       </div>
 
       <h3>
-        Value When Enabled
+        When Enabled
         <a className="ml-2 cursor-pointer" onClick={() => setEdit(true)}>
           <GBEdit />
         </a>

--- a/packages/front-end/services/features.ts
+++ b/packages/front-end/services/features.ts
@@ -1,8 +1,12 @@
 import { useMemo } from "react";
-import { SDKAttributeType } from "back-end/types/organization";
-import { FeatureValueType } from "back-end/types/feature";
+import {
+  SDKAttributeSchema,
+  SDKAttributeType,
+} from "back-end/types/organization";
+import { FeatureRule, FeatureValueType } from "back-end/types/feature";
 import stringify from "json-stringify-pretty-compact";
 import useOrgSettings from "../hooks/useOrgSettings";
+import uniq from "lodash/uniq";
 
 export interface Condition {
   field: string;
@@ -16,6 +20,146 @@ export interface AttributeData {
   array: boolean;
   identifier: boolean;
   enum: string[];
+}
+
+export function validateFeatureRule(
+  rule: FeatureRule,
+  valueType: FeatureValueType
+) {
+  if (rule.condition) {
+    try {
+      const res = JSON.parse(rule.condition);
+      if (!res || typeof res !== "object") {
+        throw new Error("Condition is invalid");
+      }
+    } catch (e) {
+      throw new Error("Condition is invalid: " + e.message);
+    }
+  }
+  if (rule.type === "force") {
+    isValidValue(valueType, rule.value, "Forced value");
+  } else if (rule.type === "experiment") {
+    const ruleValues = rule.values;
+    if (!ruleValues || !ruleValues.length) {
+      throw new Error("Must set at least one value");
+    }
+    let totalWeight = 0;
+    ruleValues.forEach((val, i) => {
+      if (val.weight < 0) throw new Error("Percents cannot be negative");
+      totalWeight += val.weight;
+      isValidValue(valueType, val.value, "Value #" + (i + 1));
+    });
+    if (totalWeight > 1) {
+      throw new Error(
+        `Sum of weights cannot be greater than 1 (currently equals ${totalWeight})`
+      );
+    }
+    if (uniq(ruleValues.map((v) => v.value)).length !== ruleValues.length) {
+      throw new Error(`All variations must be unique`);
+    }
+  } else {
+    isValidValue(valueType, rule.value, "Rollout value");
+
+    if (rule.type === "rollout" && (rule.coverage < 0 || rule.coverage > 1)) {
+      throw new Error("Rollout percent must be between 0 and 1");
+    }
+  }
+}
+
+export function getDefaultValue(valueType: FeatureValueType): string {
+  if (valueType === "boolean") {
+    return "true";
+  }
+  if (valueType === "number") {
+    return "1";
+  }
+  if (valueType === "string") {
+    return "foo";
+  }
+  if (valueType === "json") {
+    return "{}";
+  }
+  return "";
+}
+export function getDefaultVariationValue(defaultValue: string) {
+  const map: Record<string, string> = {
+    true: "false",
+    false: "true",
+    "1": "0",
+    "0": "1",
+    foo: "bar",
+    bar: "foo",
+  };
+  return defaultValue in map ? map[defaultValue] : defaultValue;
+}
+
+export function getDefaultRuleValue({
+  defaultValue,
+  attributeSchema,
+  ruleType,
+}: {
+  defaultValue: string;
+  attributeSchema?: SDKAttributeSchema;
+  ruleType: string;
+}): FeatureRule {
+  const hashAttributes = attributeSchema
+    .filter((a) => a.hashAttribute)
+    .map((a) => a.property);
+  const hashAttribute = hashAttributes.includes("id")
+    ? "id"
+    : hashAttributes[0] || "id";
+
+  const value = getDefaultVariationValue(defaultValue);
+
+  if (ruleType === "rollout") {
+    return {
+      type: "rollout",
+      description: "",
+      id: "",
+      value,
+      coverage: 0.5,
+      condition: "",
+      enabled: true,
+      hashAttribute,
+    };
+  }
+  if (ruleType === "experiment") {
+    return {
+      type: "experiment",
+      description: "",
+      id: "",
+      condition: "",
+      enabled: true,
+      hashAttribute,
+      trackingKey: "",
+      values: [
+        {
+          value: defaultValue,
+          weight: 0.5,
+        },
+        {
+          value: value,
+          weight: 0.5,
+        },
+      ],
+    };
+  }
+
+  const firstAttr = attributeSchema?.[0];
+  const condition = firstAttr
+    ? JSON.stringify({
+        [firstAttr.property]: firstAttr.datatype === "boolean" ? "true" : "",
+      })
+    : "";
+
+  return {
+    type: "force",
+    description: "",
+    id: "",
+    value,
+    enabled: true,
+    condition,
+  };
 }
 
 export function isValidValue(


### PR DESCRIPTION
It's common to create a feature and then immediately create an override rule.  We can streamline this process by letting users do this in one step instead of two.  Also, specifying an override rule at the same time you set the default value can be much more intuitive for new users.

TODO:
- [x] Re-order "Create Feature" modal fields
- [x] Add radio selector for initial override rule to add
- [x] Override rule fields in modal
- [x] Default value for experiments (separate from control)
- [x] Abstract out common code between RuleModal an FeatureModal
- [x] Validation of initial rule
- [x] Better default values based on value type
- [ ] Targeting rules for rollouts and experiments?
- [x] Testing
- [x] Tracking