### PR TITLE
Import sample data from datasource modal.

### DIFF
--- a/packages/front-end/components/Experiment/NewFeatureExperiments.tsx
+++ b/packages/front-end/components/Experiment/NewFeatureExperiments.tsx
@@ -20,7 +20,7 @@ export default function NewFeatureExperiments() {
     }[];
   }>(`/experiments/newfeatures/?project=${project || ""}`);
 
-  if (!data || error || data?.features?.length === 0) {
+  if (!data || error || data?.features?.length === 0 || !datasources.length) {
     return null;
   }
 

--- a/packages/front-end/components/HomePage/ExperimentsGetStarted.tsx
+++ b/packages/front-end/components/HomePage/ExperimentsGetStarted.tsx
@@ -72,6 +72,18 @@ const ExperimentsGetStarted = ({
     : 1;
   const allowImport = !(hasMetrics || hasExperiments) && !hasFileConfig();
 
+  const importSampleData = async () => {
+    const res = await apiCall<{
+      experiment: string;
+    }>(`/organization/sample-data`, {
+      method: "POST",
+    });
+    await mutateDefinitions();
+    await mutate();
+    track("Add Sample Data");
+    await router.push("/experiment/" + res.experiment);
+  };
+
   return (
     <>
       <div>
@@ -103,6 +115,12 @@ const ExperimentsGetStarted = ({
               setDataSourceOpen(false);
               setDataSourceQueriesOpen(true);
             }}
+            importSampleData={
+              !hasDataSource &&
+              allowImport &&
+              !hasSampleExperiment &&
+              importSampleData
+            }
           />
         )}
         {metricsOpen && (
@@ -159,17 +177,7 @@ const ExperimentsGetStarted = ({
                         <Button
                           color="info"
                           className="btn-sm ml-3 mr-2"
-                          onClick={async () => {
-                            const res = await apiCall<{
-                              experiment: string;
-                            }>(`/organization/sample-data`, {
-                              method: "POST",
-                            });
-                            await mutateDefinitions();
-                            await mutate();
-                            track("Add Sample Data");
-                            await router.push("/experiment/" + res.experiment);
-                          }}
+                          onClick={importSampleData}
                         >
                           <FaDatabase /> Import Sample Data
                         </Button>

--- a/packages/front-end/components/Settings/DataSourceForm.tsx
+++ b/packages/front-end/components/Settings/DataSourceForm.tsx
@@ -23,6 +23,7 @@ import Modal from "../Modal";
 import PrestoForm from "./PrestoForm";
 import MysqlForm from "./MysqlForm";
 import SelectField from "../Forms/SelectField";
+import Button from "../Button";
 
 const typeOptions: {
   type: DataSourceType;
@@ -142,7 +143,8 @@ const DataSourceForm: FC<{
   source: string;
   onCancel: () => void;
   onSuccess: (id: string) => Promise<void>;
-}> = ({ data, onSuccess, onCancel, source, existing }) => {
+  importSampleData?: () => Promise<void>;
+}> = ({ data, onSuccess, onCancel, source, existing, importSampleData }) => {
   const [dirty, setDirty] = useState(false);
   const [datasource, setDatasource] = useState<
     Partial<DataSourceInterfaceWithParams>
@@ -335,6 +337,29 @@ const DataSourceForm: FC<{
       header={existing ? "Edit Data Source" : "Add Data Source"}
       cta="Save"
     >
+      {importSampleData && !datasource.type && (
+        <div className="alert alert-info">
+          <div className="row align-items-center">
+            <div className="col">
+              <div>
+                <strong>Not ready to connect to your data source?</strong>
+              </div>{" "}
+              Try out GrowthBook first with a sample dataset.
+            </div>
+            <div className="col-auto">
+              <Button
+                color="info"
+                className="btn-sm"
+                onClick={async () => {
+                  await importSampleData();
+                }}
+              >
+                Use Sample Data
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
       <SelectField
         label="Data Source Type"
         value={datasource.type}

--- a/packages/front-end/components/Settings/MixpanelForm.tsx
+++ b/packages/front-end/components/Settings/MixpanelForm.tsx
@@ -15,7 +15,7 @@ const MixpanelForm: FC<{
           target="_blank"
           rel="noreferrer noopener"
         >
-          Project Settings
+          Mixpanel Project Settings
         </a>
         .
       </div>


### PR DESCRIPTION
New users might not be ready to connect to their data source right away.  This gives them an option to explore GrowthBook with a sample dataset first.