### PR TITLE
Fix variation id warning for Mixpanel data sources

### DIFF
--- a/packages/front-end/components/Experiment/CompactResults.tsx
+++ b/packages/front-end/components/Experiment/CompactResults.tsx
@@ -17,10 +17,8 @@ import { ExperimentStatus } from "back-end/types/experiment";
 import MultipleExposureWarning from "./MultipleExposureWarning";
 
 const CompactResults: FC<{
-  isUpdating?: boolean;
   editMetrics?: () => void;
   variations: ExperimentReportVariation[];
-  unknownVariations: string[];
   multipleExposures?: number;
   results: ExperimentReportResultDimension;
   reportDate: Date;
@@ -29,12 +27,9 @@ const CompactResults: FC<{
   status: ExperimentStatus;
   metrics: string[];
   id: string;
-  setVariationIds?: (ids: string[]) => Promise<void>;
 }> = ({
   results,
   variations,
-  isUpdating,
-  unknownVariations,
   multipleExposures,
   editMetrics,
   reportDate,
@@ -43,7 +38,6 @@ const CompactResults: FC<{
   isLatestPhase,
   metrics,
   id,
-  setVariationIds,
 }) => {
   const { getMetricById, ready } = useDefinitions();
 
@@ -73,13 +67,7 @@ const CompactResults: FC<{
   return (
     <>
       <div className="px-3">
-        <DataQualityWarning
-          results={results}
-          unknownVariations={unknownVariations}
-          variations={variations}
-          isUpdating={isUpdating}
-          setVariationIds={setVariationIds}
-        />
+        <DataQualityWarning results={results} variations={variations} />
         <MultipleExposureWarning
           users={users}
           multipleExposures={multipleExposures}

--- a/packages/front-end/components/Experiment/DataQualityWarning.tsx
+++ b/packages/front-end/components/Experiment/DataQualityWarning.tsx
@@ -1,45 +1,14 @@
-import { FC, Fragment } from "react";
+import { FC } from "react";
 import SRMWarning from "./SRMWarning";
-import isEqual from "lodash/isEqual";
 import {
   ExperimentReportResultDimension,
   ExperimentReportVariation,
 } from "back-end/types/report";
-import { useState } from "react";
-import FixVariationIds from "./FixVariationIds";
-
-const CommaList: FC<{ vals: string[] }> = ({ vals }) => {
-  if (!vals.length) {
-    return <em>empty</em>;
-  }
-
-  return (
-    <>
-      {vals.map((v, i) => (
-        <Fragment key={v}>
-          {i > 0 && ", "}
-          <code>{v}</code>
-        </Fragment>
-      ))}
-    </>
-  );
-};
 
 const DataQualityWarning: FC<{
   results: ExperimentReportResultDimension;
-  isUpdating?: boolean;
   variations: ExperimentReportVariation[];
-  unknownVariations: string[];
-  setVariationIds?: (ids: string[]) => Promise<void>;
-}> = ({
-  isUpdating,
-  results,
-  variations,
-  unknownVariations,
-  setVariationIds,
-}) => {
-  const [idModal, setIdModal] = useState(false);
-
+}> = ({ results, variations }) => {
   if (!results) return null;
   const variationResults = results?.variations || [];
 
@@ -54,91 +23,8 @@ const DataQualityWarning: FC<{
   variationResults.forEach((v) => {
     totalUsers += v.users;
   });
-  if (totalUsers < 8 * variations.length && !unknownVariations?.length) {
+  if (totalUsers < 8 * variations.length) {
     return null;
-  }
-
-  // Variations defined for the experiment
-  const definedVariations: string[] = variations.map((v) => v.id).sort();
-  // Variation ids returned from the query
-  const returnedVariations: string[] = variationResults
-    .map((v, i) => {
-      return {
-        variation: variations[i]?.id || i + "",
-        hasData: v.users > 0,
-      };
-    })
-    .filter((v) => v.hasData)
-    .map((v) => v.variation)
-    .concat(unknownVariations)
-    .sort();
-
-  // Problem was fixed
-  if (
-    unknownVariations?.length > 0 &&
-    isEqual(returnedVariations, definedVariations)
-  ) {
-    if (isUpdating) {
-      return null;
-    }
-    return (
-      <div className="alert alert-info">
-        Results are out of date. Update Data to refresh.
-      </div>
-    );
-  }
-
-  // There are unknown variations
-  if (unknownVariations?.length > 0) {
-    return (
-      <>
-        {idModal && (
-          <FixVariationIds
-            close={() => setIdModal(false)}
-            expected={definedVariations}
-            actual={returnedVariations}
-            names={variations.map((v) => v.name)}
-            setVariationIds={setVariationIds}
-          />
-        )}
-        <div className="alert alert-warning">
-          <strong>Warning:</strong> Expected {variations.length} variation ids (
-          <CommaList vals={definedVariations} />
-          ), but database returned{" "}
-          {returnedVariations.length === definedVariations.length
-            ? "a different set"
-            : returnedVariations.length}{" "}
-          (<CommaList vals={returnedVariations} />
-          ).{" "}
-          {setVariationIds && (
-            <button
-              className="btn btn-info btn-sm ml-3"
-              type="button"
-              onClick={(e) => {
-                e.preventDefault();
-                setIdModal(true);
-              }}
-            >
-              Update Ids
-            </button>
-          )}
-        </div>
-      </>
-    );
-  }
-
-  // Results missing variations
-  if (definedVariations.length > returnedVariations.length) {
-    return (
-      <div className="alert alert-warning">
-        <strong>Warning</strong>: Missing data from the following variation ids:{" "}
-        <CommaList
-          vals={definedVariations.filter(
-            (v) => !returnedVariations.includes(v)
-          )}
-        />
-      </div>
-    );
   }
 
   // SRM check

--- a/packages/front-end/components/Experiment/VariationIdWarning.tsx
+++ b/packages/front-end/components/Experiment/VariationIdWarning.tsx
@@ -1,0 +1,150 @@
+import { FC, Fragment } from "react";
+import isEqual from "lodash/isEqual";
+import {
+  ExperimentReportResultDimension,
+  ExperimentReportVariation,
+} from "back-end/types/report";
+import { useState } from "react";
+import FixVariationIds from "./FixVariationIds";
+
+const CommaList: FC<{ vals: string[] }> = ({ vals }) => {
+  if (!vals.length) {
+    return <em>empty</em>;
+  }
+
+  return (
+    <>
+      {vals.map((v, i) => (
+        <Fragment key={v}>
+          {i > 0 && ", "}
+          <code>{v}</code>
+        </Fragment>
+      ))}
+    </>
+  );
+};
+
+const VariationIdWarning: FC<{
+  results: ExperimentReportResultDimension;
+  isUpdating?: boolean;
+  variations: ExperimentReportVariation[];
+  unknownVariations: string[];
+  setVariationIds?: (ids: string[]) => Promise<void>;
+}> = ({
+  isUpdating,
+  results,
+  variations,
+  unknownVariations,
+  setVariationIds,
+}) => {
+  const [idModal, setIdModal] = useState(false);
+
+  if (!results) return null;
+  const variationResults = results?.variations || [];
+
+  // Skip checks if experiment phase has extremely uneven weights
+  // This causes too many false positives with the current data quality checks
+  if (variations.filter((x) => x.weight < 0.02).length > 0) {
+    return null;
+  }
+
+  // Minimum number of users required to do data quality checks
+  let totalUsers = 0;
+  variationResults.forEach((v) => {
+    totalUsers += v.users;
+  });
+  if (totalUsers < 8 * variations.length && !unknownVariations?.length) {
+    return null;
+  }
+
+  // Variations defined for the experiment
+  const definedVariations: string[] = variations.map((v) => v.id).sort();
+  // Variation ids returned from the query
+  const returnedVariations: string[] = variationResults
+    .map((v, i) => {
+      return {
+        variation: variations[i]?.id || i + "",
+        hasData: v.users > 0,
+      };
+    })
+    .filter((v) => v.hasData)
+    .map((v) => v.variation)
+    .concat(unknownVariations)
+    .sort();
+
+  // Problem was fixed
+  if (
+    unknownVariations?.length > 0 &&
+    isEqual(returnedVariations, definedVariations)
+  ) {
+    if (isUpdating) {
+      return null;
+    }
+    return (
+      <div className="px-3">
+        <div className="alert alert-info">
+          Results are out of date. Update Data to refresh.
+        </div>
+      </div>
+    );
+  }
+
+  // There are unknown variations
+  if (unknownVariations?.length > 0) {
+    return (
+      <div className="px-3">
+        {idModal && (
+          <FixVariationIds
+            close={() => setIdModal(false)}
+            expected={definedVariations}
+            actual={returnedVariations}
+            names={variations.map((v) => v.name)}
+            setVariationIds={setVariationIds}
+          />
+        )}
+        <div className="alert alert-warning">
+          <strong>Warning:</strong> Expected {variations.length} variation ids (
+          <CommaList vals={definedVariations} />
+          ), but database returned{" "}
+          {returnedVariations.length === definedVariations.length
+            ? "a different set"
+            : returnedVariations.length}{" "}
+          (<CommaList vals={returnedVariations} />
+          ).{" "}
+          {setVariationIds && (
+            <button
+              className="btn btn-info btn-sm ml-3"
+              type="button"
+              onClick={(e) => {
+                e.preventDefault();
+                setIdModal(true);
+              }}
+            >
+              Update Ids
+            </button>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // Results missing variations
+  if (definedVariations.length > returnedVariations.length) {
+    return (
+      <div className="px-3">
+        <div className="alert alert-warning">
+          <strong>Warning</strong>: Missing data from the following variation
+          ids:{" "}
+          <CommaList
+            vals={definedVariations.filter(
+              (v) => !returnedVariations.includes(v)
+            )}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  return null;
+};
+export default VariationIdWarning;

--- a/packages/front-end/components/Share/Presentation.tsx
+++ b/packages/front-end/components/Share/Presentation.tsx
@@ -223,7 +223,6 @@ const Presentation = ({
                 results={snapshot.results?.[0]}
                 status={experiment.status}
                 startDate={phase?.dateStarted}
-                unknownVariations={snapshot.unknownVariations || []}
                 multipleExposures={snapshot.multipleExposures || 0}
                 variations={experiment.variations.map((v, i) => {
                   return {


### PR DESCRIPTION
During A/B test analysis, when we detect a mismatch between the configured variation ids and the ones returned by the data source, we show a warning with instructions for how to fix the issue.  There is a bug that hides this warning in some cases when a Mixpanel data source is used.