### PR TITLE
BigQuery - support both TIMESTAMP and DATETIME data types

### DIFF
--- a/packages/back-end/src/integrations/BigQuery.ts
+++ b/packages/back-end/src/integrations/BigQuery.ts
@@ -58,4 +58,7 @@ export default class BigQuery extends SqlIntegration {
   castToString(col: string): string {
     return `cast(${col} as string)`;
   }
+  castUserDateCol(column: string): string {
+    return `CAST(${column} as DATETIME)`;
+  }
 }


### PR DESCRIPTION
Currently, in BigQuery we only support `DATETIME` data types in user-supplied SQL.  As a result, people have to do things like `CAST(timestamp as DATETIME)` all throughout their SQL which is annoying and easy to forget.

This change applies the CAST automatically, so both data types are now supported. This change is backwards compatible with the previous workaround since BigQuery supports nested casts: `CAST(CAST(timestamp as DATETIME) as DATETIME)`


TESTS:
- [x] Experiment results - non-bigquery
- [x] Experiment results - bigquery
- [x] Metric value - non-bigquery
- [x] Metric value - bigquery
- [x] Past experiments - non-bigquery
- [x] Past experiments - bigquery