### PR TITLE
Environment-specific feature rules

### DIFF
--- a/packages/back-end/types/feature.d.ts
+++ b/packages/back-end/types/feature.d.ts
@@ -13,6 +13,13 @@ export interface FeatureInterface {
   environments: string[];
   defaultValue: string;
   rules?: FeatureRule[];
+  environmentRules?: Record<
+    string,
+    {
+      defaultValue?: string;
+      rules: FeatureRule[];
+    }
+  >;
 }
 
 export interface BaseRule {


### PR DESCRIPTION
Currently, features have a single default value and list of rules that is shared between all environments.  This makes it difficult to, for example, test an experiment rule in dev and then promote it to production.  It's also difficult to have a separate value in dev vs production (e.g. a config value).

With this change, each environment will have its own default value and list of rules.  It will be easy to copy rules between environments as needed, but the default behavior will be to keep them separate.  This PR will also set the stage for allowing custom environments beyond the default `dev` and `production`, although that will be implemented in a follow-up project.

TODO:
- [x] Add `environmentRules` to feature model
- [x] Make model backwards compatible with existing db schema
- [ ] On the feature list page, add tabs to switch between the selected environment.  Only show the selected environment's toggle in the list.
- [ ] Update feature API and webhook payload to pull rules from the right place depending on environment
- [ ] New webhooks must select a single environment only.  Figure out how to support old webhooks and API keys without a single environment scope (merge rule arrays together? always default to production?)
- [ ] Add tabs to feature detail page to switch between environments for default value and override rules
- [ ] Figure out what to do in initial feature modal when adding a rule (clone the rule to all toggled environments?)
- [ ] Update docs