### PR TITLE
Rule condition fixes

### DIFF
--- a/packages/front-end/components/Features/ConditionDisplay.tsx
+++ b/packages/front-end/components/Features/ConditionDisplay.tsx
@@ -11,6 +11,10 @@ function operatorToText(operator: string): string {
       return `includes`;
     case "$notIncludes":
       return `does not include`;
+    case "$empty":
+      return `is empty`;
+    case "$notEmpty":
+      return `is not empty`;
     case "$lt":
       return `is less than`;
     case "$lte":
@@ -40,7 +44,7 @@ function operatorToText(operator: string): string {
 }
 
 function needsValue(operator: string) {
-  return !["$exists", "$notExists"].includes(operator);
+  return !["$exists", "$notExists", "$empty", "$notEmpty"].includes(operator);
 }
 function getValue(operator: string, value: string): string {
   if (operator === "$true") return "TRUE";

--- a/packages/front-end/components/Features/ConditionDisplay.tsx
+++ b/packages/front-end/components/Features/ConditionDisplay.tsx
@@ -1,18 +1,16 @@
-import {
-  AttributeData,
-  jsonToConds,
-  useAttributeMap,
-} from "../../services/features";
+import { jsonToConds, useAttributeMap } from "../../services/features";
 import Code from "../Code";
 
-function operatorToText(operator: string, attribute?: AttributeData): string {
+function operatorToText(operator: string): string {
   switch (operator) {
     case "$eq":
-      if (attribute?.array) return `contains`;
       return `is equal to`;
     case "$ne":
-      if (attribute?.array) return `does not contain`;
       return `is not equal to`;
+    case "$includes":
+      return `includes`;
+    case "$notIncludes":
+      return `does not include`;
     case "$lt":
       return `is less than`;
     case "$lte":
@@ -73,9 +71,7 @@ export default function ConditionDisplay({ condition }: { condition: string }) {
         <div key={i} className="col-auto d-flex flex-wrap">
           {i > 0 && <span className="mr-1">AND</span>}
           <span className="mr-1 border px-2 bg-light rounded">{field}</span>
-          <span className="mr-1">
-            {operatorToText(operator, attributes[field])}
-          </span>
+          <span className="mr-1">{operatorToText(operator)}</span>
           {needsValue(operator) ? (
             <span className="mr-1 border px-2 bg-light rounded">
               {getValue(operator, value)}

--- a/packages/front-end/components/Features/ConditionInput.tsx
+++ b/packages/front-end/components/Features/ConditionInput.tsx
@@ -170,8 +170,8 @@ export default function ConditionInput(props: Props) {
                         </>
                       ) : attribute.array ? (
                         <>
-                          <option value="$eq">contains</option>
-                          <option value="$ne">does not contain</option>
+                          <option value="$includes">includes</option>
+                          <option value="$notIncludes">does not include</option>
                           <option value="$exists">exists</option>
                           <option value="$notExists">does not exist</option>
                         </>
@@ -189,6 +189,9 @@ export default function ConditionInput(props: Props) {
                           <option value="$eq">is equal to</option>
                           <option value="$ne">is not equal to</option>
                           <option value="$regex">matches regex</option>
+                          <option value="$notRegex">
+                            does not match regex
+                          </option>
                           <option value="$gt">is greater than</option>
                           <option value="$gte">
                             is greater than or equal to
@@ -197,6 +200,8 @@ export default function ConditionInput(props: Props) {
                           <option value="$lte">is less than or equal to</option>
                           <option value="$in">is in the list</option>
                           <option value="$nin">is not in the list</option>
+                          <option value="$exists">exists</option>
+                          <option value="$notExists">does not exist</option>
                         </>
                       ) : attribute.datatype === "number" ? (
                         <>
@@ -210,6 +215,8 @@ export default function ConditionInput(props: Props) {
                           <option value="$lte">is less than or equal to</option>
                           <option value="$in">is in the list</option>
                           <option value="$nin">is not in the list</option>
+                          <option value="$exists">exists</option>
+                          <option value="$notExists">does not exist</option>
                         </>
                       ) : (
                         ""

--- a/packages/front-end/components/Features/ConditionInput.tsx
+++ b/packages/front-end/components/Features/ConditionInput.tsx
@@ -172,6 +172,8 @@ export default function ConditionInput(props: Props) {
                         <>
                           <option value="$includes">includes</option>
                           <option value="$notIncludes">does not include</option>
+                          <option value="$empty">is empty</option>
+                          <option value="$notEmpty">is not empty</option>
                           <option value="$exists">exists</option>
                           <option value="$notExists">does not exist</option>
                         </>
@@ -223,9 +225,14 @@ export default function ConditionInput(props: Props) {
                       )}
                     </select>
                   </div>
-                  {["$exists", "$notExists", "$true", "$false"].includes(
-                    operator
-                  ) ? (
+                  {[
+                    "$exists",
+                    "$notExists",
+                    "$true",
+                    "$false",
+                    "$empty",
+                    "$notEmpty",
+                  ].includes(operator) ? (
                     ""
                   ) : ["$in", "$nin"].includes(operator) ? (
                     <Field

--- a/packages/sdk-js/test/cases.json
+++ b/packages/sdk-js/test/cases.json
@@ -903,6 +903,66 @@
       false
     ],
     [
+      "$elemMatch contains - pass",
+      {
+        "tags": {
+          "$elemMatch": {
+            "$eq": "bar"
+          }
+        }
+      },
+      {
+        "tags": ["foo", "bar", "baz"]
+      },
+      true
+    ],
+    [
+      "$elemMatch contains - false",
+      {
+        "tags": {
+          "$elemMatch": {
+            "$eq": "bar"
+          }
+        }
+      },
+      {
+        "tags": ["foo", "baz"]
+      },
+      false
+    ],
+    [
+      "$elemMatch not contains - pass",
+      {
+        "tags": {
+          "$not": {
+            "$elemMatch": {
+              "$eq": "bar"
+            }
+          }
+        }
+      },
+      {
+        "tags": ["foo", "baz"]
+      },
+      true
+    ],
+    [
+      "$elemMatch not contains - fail",
+      {
+        "tags": {
+          "$not": {
+            "$elemMatch": {
+              "$eq": "bar"
+            }
+          }
+        }
+      },
+      {
+        "tags": ["foo", "bar", "baz"]
+      },
+      false
+    ],
+    [
       "$elemMatch nested - pass",
       {
         "hobbies": {

--- a/packages/sdk-js/test/cases.json
+++ b/packages/sdk-js/test/cases.json
@@ -813,6 +813,26 @@
       false
     ],
     [
+      "$size empty - pass",
+      {
+        "tags": { "$size": 0 }
+      },
+      {
+        "tags": []
+      },
+      true
+    ],
+    [
+      "$size empty - fail",
+      {
+        "tags": { "$size": 0 }
+      },
+      {
+        "tags": [10]
+      },
+      false
+    ],
+    [
       "$size number - pass",
       {
         "tags": {


### PR DESCRIPTION
Fixes:
- [x] `$exists`/`$notExists` operator not available for string attribute
- [x] `$exists` operator setting value to empty string instead of `true`
- [x] New `$includes`, `$notIncludes` operators for arrays
- [x] New `$empty`, `$notEmpty` operators for arrays