### PR TITLE
Support for claimed email domains in GrowthBook Cloud

### DIFF
--- a/packages/back-end/src/controllers/organizations.ts
+++ b/packages/back-end/src/controllers/organizations.ts
@@ -894,8 +894,7 @@ export async function signup(req: AuthRequest<SignupBody>, res: Response) {
     try {
       await sendNewOrgEmail(company, req.email);
     } catch (e) {
-      console.error("New org email sending failure:");
-      console.error(e.message);
+      console.error("New org email sending failure:", e.message);
     }
 
     res.status(200).json({

--- a/packages/back-end/src/controllers/organizations.ts
+++ b/packages/back-end/src/controllers/organizations.ts
@@ -97,7 +97,7 @@ import { ExperimentRule, NamespaceValue } from "../../types/feature";
 export async function getUser(req: AuthRequest, res: Response) {
   // Ensure user exists in database
   if (!req.userId && IS_CLOUD) {
-    const user = await createUser(req.name || "", req.email);
+    const user = await createUser(req.name || "", req.email, "", req.verified);
     req.userId = user.id;
   }
 

--- a/packages/back-end/src/controllers/organizations.ts
+++ b/packages/back-end/src/controllers/organizations.ts
@@ -9,6 +9,7 @@ import {
   getRole,
   importConfig,
   getOrgFromReq,
+  addMemberToOrg,
 } from "../services/organizations";
 import {
   DataSourceParams,
@@ -78,6 +79,7 @@ import { WebhookModel } from "../models/WebhookModel";
 import { createWebhook } from "../services/webhooks";
 import {
   createOrganization,
+  findOrganizationByClaimedDomain,
   findOrganizationsByMemberId,
   hasOrganization,
   updateOrganization,
@@ -93,6 +95,13 @@ export async function getUser(req: AuthRequest, res: Response) {
   if (!req.userId && IS_CLOUD) {
     const user = await createUser(req.name || "", req.email);
     req.userId = user.id;
+
+    const emailDomain = req.email.split("@").pop()?.toLowerCase() || "";
+
+    const autoOrg = await findOrganizationByClaimedDomain(emailDomain);
+    if (autoOrg) {
+      await addMemberToOrg(autoOrg, user.id);
+    }
   }
 
   if (!req.userId) {

--- a/packages/back-end/src/controllers/organizations.ts
+++ b/packages/back-end/src/controllers/organizations.ts
@@ -100,6 +100,14 @@ export async function getUser(req: AuthRequest, res: Response) {
 
     const autoOrg = await findOrganizationByClaimedDomain(emailDomain);
     if (autoOrg) {
+      // Only allow verified email addresses to auto-join an organization
+      if (!req.verified) {
+        return res.status(406).json({
+          status: 406,
+          message:
+            "You must first verify your email address before using GrowthBook",
+        });
+      }
       await addMemberToOrg(autoOrg, user.id);
     }
   }

--- a/packages/back-end/src/controllers/organizations.ts
+++ b/packages/back-end/src/controllers/organizations.ts
@@ -56,7 +56,11 @@ import {
   findDimensionsByOrganization,
 } from "../models/DimensionModel";
 import { IS_CLOUD } from "../util/secrets";
-import { sendInviteEmail, sendNewOrgEmail } from "../services/email";
+import {
+  sendInviteEmail,
+  sendNewMemberEmail,
+  sendNewOrgEmail,
+} from "../services/email";
 import {
   createDataSource,
   getDataSourcesByOrganization,
@@ -109,6 +113,16 @@ export async function getUser(req: AuthRequest, res: Response) {
         });
       }
       await addMemberToOrg(autoOrg, user.id);
+      try {
+        await sendNewMemberEmail(
+          req.name || "",
+          req.email || "",
+          autoOrg.name,
+          autoOrg.ownerEmail
+        );
+      } catch (e) {
+        console.error("Failed to send new member email", e.message);
+      }
     }
   }
 

--- a/packages/back-end/src/models/ForgotPasswordModel.ts
+++ b/packages/back-end/src/models/ForgotPasswordModel.ts
@@ -2,7 +2,7 @@ import mongoose from "mongoose";
 import crypto from "crypto";
 import { getUserByEmail } from "../services/users";
 import { APP_ORIGIN } from "../util/secrets";
-import { sendResetPasswordEmail } from "../services/email";
+import { isEmailEnabled, sendResetPasswordEmail } from "../services/email";
 
 export interface ForgotPasswordInterface {
   token: string;
@@ -48,14 +48,15 @@ export async function createForgotPasswordToken(email: string): Promise<void> {
   const resetUrl = `${APP_ORIGIN}/reset-password?token=${token}`;
 
   try {
+    if (!isEmailEnabled()) {
+      throw new Error(
+        "Email server not configured. Check server logs for reset link."
+      );
+    }
+
     await sendResetPasswordEmail(email, resetUrl);
   } catch (e) {
-    console.error(
-      "Failed to send reset password email. The reset password link for " +
-        email +
-        " is: " +
-        resetUrl
-    );
+    console.error("The reset password link for " + email + " is: " + resetUrl);
     throw e;
   }
 }

--- a/packages/back-end/src/models/OrganizationModel.ts
+++ b/packages/back-end/src/models/OrganizationModel.ts
@@ -11,7 +11,10 @@ const organizationSchema = new mongoose.Schema({
   url: String,
   name: String,
   ownerEmail: String,
-  claimedDomain: String,
+  claimedDomain: {
+    type: String,
+    index: true,
+  },
   members: [
     {
       _id: false,

--- a/packages/back-end/src/models/OrganizationModel.ts
+++ b/packages/back-end/src/models/OrganizationModel.ts
@@ -11,6 +11,7 @@ const organizationSchema = new mongoose.Schema({
   url: String,
   name: String,
   ownerEmail: String,
+  claimedDomain: String,
   members: [
     {
       _id: false,
@@ -181,4 +182,11 @@ export async function getOrganizationsWithNorthStars() {
     },
   });
   return withNorthStars.map(toInterface);
+}
+
+export async function findOrganizationByClaimedDomain(domain: string) {
+  const doc = await OrganizationModel.findOne({
+    claimedDomain: domain,
+  });
+  return doc ? toInterface(doc) : null;
 }

--- a/packages/back-end/src/models/OrganizationModel.ts
+++ b/packages/back-end/src/models/OrganizationModel.ts
@@ -188,6 +188,7 @@ export async function getOrganizationsWithNorthStars() {
 }
 
 export async function findOrganizationByClaimedDomain(domain: string) {
+  if (!domain) return null;
   const doc = await OrganizationModel.findOne({
     claimedDomain: domain,
   });

--- a/packages/back-end/src/models/UserModel.ts
+++ b/packages/back-end/src/models/UserModel.ts
@@ -13,8 +13,20 @@ const userSchema = new mongoose.Schema({
   },
   passwordHash: String,
   admin: Boolean,
+  verified: Boolean,
 });
 
 export type UserDocument = mongoose.Document & UserInterface;
 
 export const UserModel = mongoose.model<UserDocument>("User", userSchema);
+
+export async function markUserAsVerified(id: string) {
+  await UserModel.updateOne(
+    { id },
+    {
+      $set: {
+        verified: true,
+      },
+    }
+  );
+}

--- a/packages/back-end/src/services/email.ts
+++ b/packages/back-end/src/services/email.ts
@@ -150,3 +150,23 @@ export async function sendNewOrgEmail(company: string, email: string) {
     text: `Company Name: ${company}\nOwner Email: ${email}`,
   });
 }
+
+export async function sendNewMemberEmail(
+  name: string,
+  email: string,
+  organization: string,
+  ownerEmail: string
+) {
+  const html = nunjucks.render("new-member.jinja", {
+    name,
+    email,
+    organization,
+  });
+
+  await sendMail({
+    html,
+    subject: `A new user joined your GrowthBook account: ${name} (${email})`,
+    to: ownerEmail,
+    text: `Organization: ${organization}\nName: ${name}\nEmail: ${email}`,
+  });
+}

--- a/packages/back-end/src/services/email.ts
+++ b/packages/back-end/src/services/email.ts
@@ -52,23 +52,16 @@ async function sendMail({
   text: string;
 }) {
   if (!isEmailEnabled() || !transporter) {
-    throw new Error(
-      "Email server not configured. Check server logs for reset link."
-    );
+    throw new Error("Email server not configured.");
   }
 
-  try {
-    await transporter.sendMail({
-      from: `"GrowthBook" <${EMAIL_FROM}>`,
-      to,
-      subject,
-      text,
-      html,
-    });
-  } catch (e) {
-    console.error(e);
-    throw e;
-  }
+  await transporter.sendMail({
+    from: `"GrowthBook" <${EMAIL_FROM}>`,
+    to,
+    subject,
+    text,
+    html,
+  });
 }
 export async function sendInviteEmail(
   organization: OrganizationInterface,

--- a/packages/back-end/src/services/organizations.ts
+++ b/packages/back-end/src/services/organizations.ts
@@ -163,6 +163,27 @@ export function getInviteUrl(key: string) {
   return `${APP_ORIGIN}/invitation?key=${key}`;
 }
 
+export async function addMemberToOrg(
+  org: OrganizationInterface,
+  userId: string,
+  role: MemberRole = "collaborator"
+) {
+  // If memebr is already in the org, skip
+  if (org.members.find((m) => m.id === userId)) {
+    return;
+  }
+
+  const members = [
+    ...org.members,
+    {
+      id: userId,
+      role,
+    },
+  ];
+
+  await updateOrganization(org.id, { members });
+}
+
 export async function acceptInvite(key: string, userId: string) {
   const organization = await findOrganizationByInviteKey(key);
   if (!organization) {

--- a/packages/back-end/src/services/users.ts
+++ b/packages/back-end/src/services/users.ts
@@ -72,7 +72,8 @@ export async function updatePassword(userId: string, password: string) {
 export async function createUser(
   name: string,
   email: string,
-  password?: string
+  password?: string,
+  verified: boolean = false
 ) {
   let passwordHash = "";
 
@@ -86,5 +87,6 @@ export async function createUser(
     email,
     passwordHash,
     id: uniqid("u_"),
+    verified,
   });
 }

--- a/packages/back-end/src/templates/email/new-member.jinja
+++ b/packages/back-end/src/templates/email/new-member.jinja
@@ -1,0 +1,20 @@
+{% extends "base.jinja" %}
+
+{% block preview %}
+  {{ name }} ({{ email }})
+{% endblock %}
+
+{% block title %}
+  New User Joined {{ organization }} on GrowthBook
+{% endblock %}
+
+{% block top %}
+  <p>
+    Name: <strong>{{ name }}</strong><br/>
+    Email: <strong>{{ email }}</strong><br/>
+  </p>
+{% endblock %}
+
+{% block lower %}
+  <p>You are receiving this email because you are the owner for the {{ organization }} organization in GrowthBook.</p>
+{% endblock %}

--- a/packages/back-end/src/types/AuthRequest.ts
+++ b/packages/back-end/src/types/AuthRequest.ts
@@ -6,6 +6,7 @@ import { Permissions } from "../../types/organization";
 // eslint-disable-next-line
 export type AuthRequest<B = any, P = any, Q = any> = Request<P, null, B, Q> & {
   email: string;
+  verified?: boolean;
   userId?: string;
   name?: string;
   admin?: boolean;

--- a/packages/back-end/types/organization.d.ts
+++ b/packages/back-end/types/organization.d.ts
@@ -88,6 +88,7 @@ export interface OrganizationSettings {
 export interface OrganizationInterface {
   id: string;
   url: string;
+  claimedDomain?: string;
   name: string;
   ownerEmail: string;
   stripeCustomerId?: string;

--- a/packages/back-end/types/user.d.ts
+++ b/packages/back-end/types/user.d.ts
@@ -2,6 +2,7 @@ export interface UserInterface {
   id: string;
   name: string;
   email: string;
+  verified: boolean;
   passwordHash?: string;
   admin: boolean;
 }

--- a/packages/front-end/components/ProtectedPage.tsx
+++ b/packages/front-end/components/ProtectedPage.tsx
@@ -14,6 +14,7 @@ import { useGrowthBook } from "@growthbook/growthbook-react";
 import { useRouter } from "next/router";
 import { isCloud } from "../services/env";
 import InAppHelp from "./Auth/InAppHelp";
+import Modal from "./Modal";
 
 type User = { id: string; email: string; name: string };
 
@@ -90,6 +91,7 @@ const ProtectedPage: React.FC<{
     loading,
     isAuthenticated,
     login,
+    logout,
     apiCall,
     orgId,
     organizations,
@@ -97,16 +99,21 @@ const ProtectedPage: React.FC<{
   } = useAuth();
 
   const [data, setData] = useState<UserResponse>(null);
+  const [error, setError] = useState("");
   const [users, setUsers] = useState<Map<string, User>>(new Map());
   const router = useRouter();
 
   const update = async () => {
-    const res = await apiCall<UserResponse>("/user", {
-      method: "GET",
-    });
-    setData(res);
-    if (res.organizations) {
-      setOrganizations(res.organizations);
+    try {
+      const res = await apiCall<UserResponse>("/user", {
+        method: "GET",
+      });
+      setData(res);
+      if (res.organizations) {
+        setOrganizations(res.organizations);
+      }
+    } catch (e) {
+      setError(e.message);
     }
   };
 
@@ -174,6 +181,28 @@ const ProtectedPage: React.FC<{
   // This page is before the user is authenticated (e.g. reset password)
   if (preAuth) {
     return <>{children}</>;
+  }
+
+  if (error) {
+    return (
+      <Modal
+        inline={true}
+        open={true}
+        cta="Log Out"
+        submit={async () => {
+          await logout();
+        }}
+        submitColor="danger"
+        closeCta="Reload"
+        close={() => {
+          setError("");
+          update();
+        }}
+      >
+        <h3>Error signing in</h3>
+        <div className="alert alert-danger">{error}</div>
+      </Modal>
+    );
   }
 
   // Waiting for initial authentication

--- a/packages/front-end/components/ProtectedPage.tsx
+++ b/packages/front-end/components/ProtectedPage.tsx
@@ -198,6 +198,7 @@ const ProtectedPage: React.FC<{
           setError("");
           update();
         }}
+        autoCloseOnSubmit={false}
       >
         <h3>Error signing in</h3>
         <div className="alert alert-danger">{error}</div>

--- a/packages/front-end/components/ProtectedPage.tsx
+++ b/packages/front-end/components/ProtectedPage.tsx
@@ -195,8 +195,7 @@ const ProtectedPage: React.FC<{
         submitColor="danger"
         closeCta="Reload"
         close={() => {
-          setError("");
-          update();
+          window.location.reload();
         }}
         autoCloseOnSubmit={false}
       >


### PR DESCRIPTION
In order to support SAML connections in GrowthBook Cloud, organizations must be able to "claim" an email domain.  Any user who registers through the IdP with an email address from a claimed domain will be auto-added to the matching organization.

TODO:
- [x] Add users with matching domain automatically
- [x] Make sure email address is verified first (i.e. coming from IdP or an SSO login)
- [x] Once a user logs in with a verified email from SSO or SAML, disable future unverified logins (email/password).
- [x] Send an email to the account owner when someone auto joins
- [x] Testing