### PR TITLE
Added a way to sort the order of metrics in an experiment

### DIFF
--- a/packages/front-end/components/Experiment/CompactResults.tsx
+++ b/packages/front-end/components/Experiment/CompactResults.tsx
@@ -76,19 +76,17 @@ const CompactResults: FC<{
         <h3 className="mb-3">
           Metrics
           {editMetrics && (
-            <>
-              <a
-                href="#"
-                onClick={(e) => {
-                  e.preventDefault();
-                  editMetrics();
-                }}
-                className="ml-2"
-                style={{ fontSize: "0.8rem" }}
-              >
-                Adjust Metrics
-              </a>
-            </>
+            <a
+              href="#"
+              onClick={(e) => {
+                e.preventDefault();
+                editMetrics();
+              }}
+              className="ml-2"
+              style={{ fontSize: "0.8rem" }}
+            >
+              Adjust Metrics
+            </a>
           )}
         </h3>
       </div>

--- a/packages/front-end/components/Experiment/CompactResults.tsx
+++ b/packages/front-end/components/Experiment/CompactResults.tsx
@@ -75,17 +75,19 @@ const CompactResults: FC<{
         <h3 className="mb-3">
           Metrics
           {editMetrics && (
-            <a
-              href="#"
-              onClick={(e) => {
-                e.preventDefault();
-                editMetrics();
-              }}
-              className="ml-2"
-              style={{ fontSize: "0.8rem" }}
-            >
-              Add/Remove Metrics
-            </a>
+            <>
+              <a
+                href="#"
+                onClick={(e) => {
+                  e.preventDefault();
+                  editMetrics();
+                }}
+                className="ml-2"
+                style={{ fontSize: "0.8rem" }}
+              >
+                Adjust Metrics
+              </a>
+            </>
           )}
         </h3>
       </div>

--- a/packages/front-end/components/Experiment/EditMetricsForm.tsx
+++ b/packages/front-end/components/Experiment/EditMetricsForm.tsx
@@ -1,9 +1,25 @@
-import { FC } from "react";
+import React, { FC, useState } from "react";
 import { useForm } from "react-hook-form";
 import { useAuth } from "../../services/auth";
 import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
 import Modal from "../Modal";
 import MetricsSelector from "./MetricsSelector";
+import {
+  closestCenter,
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 
 const EditMetricsForm: FC<{
   experiment: ExperimentInterfaceStringDates;
@@ -18,6 +34,19 @@ const EditMetricsForm: FC<{
     },
   });
   const { apiCall } = useAuth();
+  const [adjustOrder, setAdjustOrder] = useState(false);
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
+  function getMetricIndex(metric: string) {
+    for (let i = 0; i < form.watch("metrics").length; i++) {
+      if (form.watch("metrics")[i] === metric) return i;
+    }
+    return -1;
+  }
 
   return (
     <Modal
@@ -34,32 +63,116 @@ const EditMetricsForm: FC<{
       })}
       cta="Save"
     >
-      <div className="form-group">
-        <label className="font-weight-bold mb-1">Goal Metrics</label>
-        <div className="mb-1 font-italic">
-          Metrics you are trying to improve with this experiment.
-        </div>
-        <MetricsSelector
-          selected={form.watch("metrics")}
-          onChange={(metrics) => form.setValue("metrics", metrics)}
-          datasource={experiment.datasource}
-        />
-      </div>
-      <div className="form-group">
-        <label className="font-weight-bold mb-1">Guardrail Metrics</label>
-        <div className="mb-1 font-italic">
-          Metrics you want to monitor, but are NOT specifically trying to
-          improve.
-        </div>
-        <MetricsSelector
-          selected={form.watch("guardrails")}
-          onChange={(metrics) => form.setValue("guardrails", metrics)}
-          datasource={experiment.datasource}
-        />
-      </div>
-      <div style={{ height: 100 }} />
+      {adjustOrder && form.watch("metrics").length > 0 ? (
+        <>
+          <div className="mb-3">
+            <a
+              href="#"
+              className="float-right"
+              onClick={(e) => {
+                e.preventDefault();
+                setAdjustOrder(false);
+              }}
+            >
+              Adjust metrics
+            </a>
+            <h5>Drag the metrics to adjust the order</h5>
+          </div>
+          <div>
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              onDragEnd={async ({ active, over }) => {
+                if (active.id !== over.id) {
+                  const oldIndex = getMetricIndex(active.id);
+                  const newIndex = getMetricIndex(over.id);
+                  if (oldIndex === -1 || newIndex === -1) return;
+
+                  const newMetrics = arrayMove(
+                    form.watch("metrics"),
+                    oldIndex,
+                    newIndex
+                  );
+                  form.setValue("metrics", newMetrics);
+                }
+              }}
+            >
+              <SortableContext
+                items={form.watch("metrics")}
+                strategy={verticalListSortingStrategy}
+              >
+                {form.watch("metrics").map((met, i) => (
+                  <SortableMetric key={met} metric={met} i={i} />
+                ))}
+              </SortableContext>
+            </DndContext>
+          </div>
+        </>
+      ) : (
+        <>
+          <div className="form-group">
+            <label className="font-weight-bold mb-1">Goal Metrics</label>
+            <a
+              href="#"
+              className="float-right"
+              onClick={(e) => {
+                e.preventDefault();
+                setAdjustOrder(true);
+              }}
+            >
+              Adjust metric order
+            </a>
+            <div className="mb-1 font-italic">
+              Metrics you are trying to improve with this experiment.
+            </div>
+            <MetricsSelector
+              selected={form.watch("metrics")}
+              onChange={(metrics) => form.setValue("metrics", metrics)}
+              datasource={experiment.datasource}
+            />
+          </div>
+          <div className="form-group">
+            <label className="font-weight-bold mb-1">Guardrail Metrics</label>
+            <div className="mb-1 font-italic">
+              Metrics you want to monitor, but are NOT specifically trying to
+              improve.
+            </div>
+            <MetricsSelector
+              selected={form.watch("guardrails")}
+              onChange={(metrics) => form.setValue("guardrails", metrics)}
+              datasource={experiment.datasource}
+            />
+          </div>
+          <div style={{ height: 100 }} />
+        </>
+      )}
     </Modal>
   );
 };
+
+export function SortableMetric(props: { i: number; metric: string }) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    active,
+  } = useSortable({ id: props.metric });
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: active?.id === props.metric ? 0.5 : 1,
+    cursor: "grab",
+  };
+
+  return (
+    <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
+      <div className="p-2 my-1 border">
+        {props.i + 1}. {props.metric}
+      </div>
+    </div>
+  );
+}
 
 export default EditMetricsForm;

--- a/packages/front-end/components/Experiment/EditMetricsForm.tsx
+++ b/packages/front-end/components/Experiment/EditMetricsForm.tsx
@@ -1,25 +1,9 @@
-import React, { FC, useState } from "react";
+import { FC } from "react";
 import { useForm } from "react-hook-form";
 import { useAuth } from "../../services/auth";
 import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
 import Modal from "../Modal";
 import MetricsSelector from "./MetricsSelector";
-import {
-  closestCenter,
-  DndContext,
-  KeyboardSensor,
-  PointerSensor,
-  useSensor,
-  useSensors,
-} from "@dnd-kit/core";
-import {
-  arrayMove,
-  SortableContext,
-  sortableKeyboardCoordinates,
-  useSortable,
-  verticalListSortingStrategy,
-} from "@dnd-kit/sortable";
-import { CSS } from "@dnd-kit/utilities";
 
 const EditMetricsForm: FC<{
   experiment: ExperimentInterfaceStringDates;
@@ -34,19 +18,6 @@ const EditMetricsForm: FC<{
     },
   });
   const { apiCall } = useAuth();
-  const [adjustOrder, setAdjustOrder] = useState(false);
-  const sensors = useSensors(
-    useSensor(PointerSensor),
-    useSensor(KeyboardSensor, {
-      coordinateGetter: sortableKeyboardCoordinates,
-    })
-  );
-  function getMetricIndex(metric: string) {
-    for (let i = 0; i < form.watch("metrics").length; i++) {
-      if (form.watch("metrics")[i] === metric) return i;
-    }
-    return -1;
-  }
 
   return (
     <Modal
@@ -63,116 +34,32 @@ const EditMetricsForm: FC<{
       })}
       cta="Save"
     >
-      {adjustOrder && form.watch("metrics").length > 0 ? (
-        <>
-          <div className="mb-3">
-            <a
-              href="#"
-              className="float-right"
-              onClick={(e) => {
-                e.preventDefault();
-                setAdjustOrder(false);
-              }}
-            >
-              Adjust metrics
-            </a>
-            <h5>Drag the metrics to adjust the order</h5>
-          </div>
-          <div>
-            <DndContext
-              sensors={sensors}
-              collisionDetection={closestCenter}
-              onDragEnd={async ({ active, over }) => {
-                if (active.id !== over.id) {
-                  const oldIndex = getMetricIndex(active.id);
-                  const newIndex = getMetricIndex(over.id);
-                  if (oldIndex === -1 || newIndex === -1) return;
-
-                  const newMetrics = arrayMove(
-                    form.watch("metrics"),
-                    oldIndex,
-                    newIndex
-                  );
-                  form.setValue("metrics", newMetrics);
-                }
-              }}
-            >
-              <SortableContext
-                items={form.watch("metrics")}
-                strategy={verticalListSortingStrategy}
-              >
-                {form.watch("metrics").map((met, i) => (
-                  <SortableMetric key={met} metric={met} i={i} />
-                ))}
-              </SortableContext>
-            </DndContext>
-          </div>
-        </>
-      ) : (
-        <>
-          <div className="form-group">
-            <label className="font-weight-bold mb-1">Goal Metrics</label>
-            <a
-              href="#"
-              className="float-right"
-              onClick={(e) => {
-                e.preventDefault();
-                setAdjustOrder(true);
-              }}
-            >
-              Adjust metric order
-            </a>
-            <div className="mb-1 font-italic">
-              Metrics you are trying to improve with this experiment.
-            </div>
-            <MetricsSelector
-              selected={form.watch("metrics")}
-              onChange={(metrics) => form.setValue("metrics", metrics)}
-              datasource={experiment.datasource}
-            />
-          </div>
-          <div className="form-group">
-            <label className="font-weight-bold mb-1">Guardrail Metrics</label>
-            <div className="mb-1 font-italic">
-              Metrics you want to monitor, but are NOT specifically trying to
-              improve.
-            </div>
-            <MetricsSelector
-              selected={form.watch("guardrails")}
-              onChange={(metrics) => form.setValue("guardrails", metrics)}
-              datasource={experiment.datasource}
-            />
-          </div>
-          <div style={{ height: 100 }} />
-        </>
-      )}
+      <div className="form-group">
+        <label className="font-weight-bold mb-1">Goal Metrics</label>
+        <div className="mb-1 font-italic">
+          Metrics you are trying to improve with this experiment.
+        </div>
+        <MetricsSelector
+          selected={form.watch("metrics")}
+          onChange={(metrics) => form.setValue("metrics", metrics)}
+          datasource={experiment.datasource}
+        />
+      </div>
+      <div className="form-group">
+        <label className="font-weight-bold mb-1">Guardrail Metrics</label>
+        <div className="mb-1 font-italic">
+          Metrics you want to monitor, but are NOT specifically trying to
+          improve.
+        </div>
+        <MetricsSelector
+          selected={form.watch("guardrails")}
+          onChange={(metrics) => form.setValue("guardrails", metrics)}
+          datasource={experiment.datasource}
+        />
+      </div>
+      <div style={{ height: 100 }} />
     </Modal>
   );
 };
-
-export function SortableMetric(props: { i: number; metric: string }) {
-  const {
-    attributes,
-    listeners,
-    setNodeRef,
-    transform,
-    transition,
-    active,
-  } = useSortable({ id: props.metric });
-  const style = {
-    transform: CSS.Transform.toString(transform),
-    transition,
-    opacity: active?.id === props.metric ? 0.5 : 1,
-    cursor: "grab",
-  };
-
-  return (
-    <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
-      <div className="p-2 my-1 border">
-        {props.i + 1}. {props.metric}
-      </div>
-    </div>
-  );
-}
 
 export default EditMetricsForm;

--- a/packages/front-end/components/Experiment/EditMetricsForm.tsx
+++ b/packages/front-end/components/Experiment/EditMetricsForm.tsx
@@ -43,6 +43,7 @@ const EditMetricsForm: FC<{
           selected={form.watch("metrics")}
           onChange={(metrics) => form.setValue("metrics", metrics)}
           datasource={experiment.datasource}
+          autoFocus={true}
         />
       </div>
       <div className="form-group">

--- a/packages/front-end/components/Experiment/MetricsSelector.tsx
+++ b/packages/front-end/components/Experiment/MetricsSelector.tsx
@@ -8,7 +8,8 @@ const MetricsSelector: FC<{
   datasource?: string;
   selected: string[];
   onChange: (metrics: string[]) => void;
-}> = ({ datasource, selected, onChange }) => {
+  autoFocus?: boolean;
+}> = ({ datasource, selected, onChange, autoFocus }) => {
   const { metrics } = useDefinitions();
 
   const validMetrics = metrics.filter(
@@ -37,6 +38,7 @@ const MetricsSelector: FC<{
           };
         })}
         placeholder="Select metrics..."
+        autoFocus={autoFocus}
       />
       {Object.keys(tagCounts).length > 0 && (
         <div className="metric-from-tag text-muted form-inline mt-2">

--- a/packages/front-end/components/Experiment/Results.tsx
+++ b/packages/front-end/components/Experiment/Results.tsx
@@ -292,7 +292,7 @@ const Results: FC<{
                     className="ml-2"
                     style={{ fontSize: "0.8rem" }}
                   >
-                    Add/Remove Guardrails
+                    Adjust Guardrails
                   </a>
                 )}
               </h3>

--- a/packages/front-end/components/Forms/MultiSelectField.tsx
+++ b/packages/front-end/components/Forms/MultiSelectField.tsx
@@ -73,7 +73,6 @@ const MultiSelectField: FC<
   sort = true,
   disabled,
   autoFocus,
-  required,
   ...otherProps
 }) => {
   const [map, sorted] = useMemo(() => {
@@ -125,75 +124,34 @@ const MultiSelectField: FC<
       {...fieldProps}
       render={(id, ref) => {
         return (
-          <>
-            <div className="d-md-none">
-              <select
-                multiple={true}
-                value={selected.map((v) => v.value)}
-                onChange={(e) => {
-                  const values = Array.from(e.target.options)
-                    .filter((o) => o.selected)
-                    .map((o) => o.value);
-                  onChange(values);
-                }}
-                className="form-control"
-                disabled={disabled}
-                id={id}
-                ref={ref}
-                required={required}
-                placeholder={initialOption ?? placeholder}
-              >
-                {sorted.map((s) => {
-                  if ("options" in s) {
-                    return (
-                      <optgroup key={s.label} label={s.label}>
-                        {s.options.map((o) => (
-                          <option key={o.value} value={o.value}>
-                            {o.label}
-                          </option>
-                        ))}
-                      </optgroup>
-                    );
-                  } else {
-                    return (
-                      <option key={s.value} value={s.value}>
-                        {s.label}
-                      </option>
-                    );
-                  }
-                })}
-              </select>
-            </div>
-            <div className="d-none d-md-block">
-              <SortableSelect
-                useDragHandle
-                helperClass="multi-select-container"
-                axis="xy"
-                onSortEnd={onSortEnd}
-                distance={4}
-                getHelperDimensions={({ node }) => node.getBoundingClientRect()}
-                id={id}
-                ref={ref}
-                isDisabled={disabled || false}
-                options={sorted}
-                isMulti={true}
-                onChange={(selected) => {
-                  onChange(selected?.map((s) => s.value) ?? []);
-                }}
-                components={{
-                  // eslint-disable-next-line
+          <SortableSelect
+            useDragHandle
+            helperClass="multi-select-container"
+            axis="xy"
+            onSortEnd={onSortEnd}
+            distance={4}
+            getHelperDimensions={({ node }) => node.getBoundingClientRect()}
+            id={id}
+            ref={ref}
+            isDisabled={disabled || false}
+            options={sorted}
+            isMulti={true}
+            onChange={(selected) => {
+              onChange(selected?.map((s) => s.value) ?? []);
+            }}
+            components={{
+              // eslint-disable-next-line
                   // @ts-ignore We're failing to provide a required index prop to SortableElement
-                  MultiValue: SortableMultiValue,
-                  MultiValueLabel: SortableMultiValueLabel,
-                }}
-                closeMenuOnSelect={false}
-                autoFocus={autoFocus}
-                value={selected}
-                placeholder={initialOption ?? placeholder}
-                isSearchable
-              />
-            </div>
-          </>
+              MultiValue: SortableMultiValue,
+              MultiValueLabel: SortableMultiValueLabel,
+            }}
+            closeMenuOnSelect={false}
+            autoFocus={autoFocus}
+            value={selected}
+            placeholder={initialOption ?? placeholder}
+            isSearchable
+            menuPosition="fixed"
+          />
         );
       }}
     />

--- a/packages/front-end/components/Forms/MultiSelectField.tsx
+++ b/packages/front-end/components/Forms/MultiSelectField.tsx
@@ -1,0 +1,203 @@
+import { FC, MouseEventHandler, useMemo } from "react";
+import Field, { FieldProps } from "./Field";
+import ReactSelect, {
+  components,
+  MultiValueGenericProps,
+  MultiValueProps,
+  Props,
+} from "react-select";
+import cloneDeep from "lodash/cloneDeep";
+
+import {
+  SortableContainer,
+  SortableContainerProps,
+  SortableElement,
+  SortEndHandler,
+  SortableHandle,
+} from "react-sortable-hoc";
+
+type SingleValue = { label: string; value: string };
+type GroupedValue = { label: string; options: SingleValue[] };
+
+function arrayMove<T>(array: readonly T[], from: number, to: number) {
+  const slicedArray = array.slice();
+  slicedArray.splice(
+    to < 0 ? array.length + to : to,
+    0,
+    slicedArray.splice(from, 1)[0]
+  );
+  return slicedArray;
+}
+
+const SortableMultiValue = SortableElement(
+  (props: MultiValueProps<SingleValue>) => {
+    // this prevents the menu from being opened/closed when the user clicks
+    // on a value to begin dragging it. ideally, detecting a click (instead of
+    // a drag) would still focus the control and toggle the menu, but that
+    // requires some magic with refs that are out of scope for this example
+    const onMouseDown: MouseEventHandler<HTMLDivElement> = (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+    };
+    const innerProps = { ...props.innerProps, onMouseDown };
+    return <components.MultiValue {...props} innerProps={innerProps} />;
+  }
+);
+
+const SortableMultiValueLabel = SortableHandle(
+  (props: MultiValueGenericProps) => <components.MultiValueLabel {...props} />
+);
+
+const SortableSelect = SortableContainer(ReactSelect) as React.ComponentClass<
+  Props<SingleValue, true> & SortableContainerProps
+>;
+
+const MultiSelectField: FC<
+  Omit<
+    FieldProps,
+    "value" | "onChange" | "options" | "multi" | "initialOption" | "placeholder"
+  > & {
+    value: string[];
+    placeholder?: string;
+    options: (SingleValue | GroupedValue)[];
+    initialOption?: string;
+    onChange: (value: string[]) => void;
+    sort?: boolean;
+  }
+> = ({
+  value,
+  options,
+  onChange,
+  initialOption,
+  placeholder = "Select...",
+  sort = true,
+  disabled,
+  autoFocus,
+  required,
+  ...otherProps
+}) => {
+  const [map, sorted] = useMemo(() => {
+    const m = new Map<string, SingleValue>();
+    const clone = cloneDeep(options);
+    if (sort) {
+      clone.sort((a, b) => {
+        return a.label.localeCompare(b.label);
+      });
+    }
+    clone.forEach((o) => {
+      if ("options" in o) {
+        const suboptions = o.options;
+        if (sort) {
+          suboptions.sort((a, b) => {
+            return a.label.localeCompare(b.label);
+          });
+        }
+        suboptions.forEach((option) => {
+          m.set(option.value, option);
+        });
+      } else {
+        m.set(o.value, o);
+      }
+    });
+
+    if (initialOption) {
+      clone.unshift({ label: initialOption, value: "" });
+    }
+
+    return [m, clone];
+  }, [options, initialOption]);
+  const selected = value.map((v) => map.get(v)).filter(Boolean);
+
+  // eslint-disable-next-line
+  const fieldProps = otherProps as any;
+
+  const onSortEnd: SortEndHandler = ({ oldIndex, newIndex }) => {
+    const newValue = arrayMove(
+      selected.map((v) => v.value),
+      oldIndex,
+      newIndex
+    );
+    onChange(newValue);
+  };
+
+  return (
+    <Field
+      {...fieldProps}
+      render={(id, ref) => {
+        return (
+          <>
+            <div className="d-md-none">
+              <select
+                multiple={true}
+                value={selected.map((v) => v.value)}
+                onChange={(e) => {
+                  const values = Array.from(e.target.options)
+                    .filter((o) => o.selected)
+                    .map((o) => o.value);
+                  onChange(values);
+                }}
+                className="form-control"
+                disabled={disabled}
+                id={id}
+                ref={ref}
+                required={required}
+                placeholder={initialOption ?? placeholder}
+              >
+                {sorted.map((s) => {
+                  if ("options" in s) {
+                    return (
+                      <optgroup key={s.label} label={s.label}>
+                        {s.options.map((o) => (
+                          <option key={o.value} value={o.value}>
+                            {o.label}
+                          </option>
+                        ))}
+                      </optgroup>
+                    );
+                  } else {
+                    return (
+                      <option key={s.value} value={s.value}>
+                        {s.label}
+                      </option>
+                    );
+                  }
+                })}
+              </select>
+            </div>
+            <div className="d-none d-md-block">
+              <SortableSelect
+                useDragHandle
+                helperClass="multi-select-container"
+                axis="xy"
+                onSortEnd={onSortEnd}
+                distance={4}
+                getHelperDimensions={({ node }) => node.getBoundingClientRect()}
+                id={id}
+                ref={ref}
+                isDisabled={disabled || false}
+                options={sorted}
+                isMulti={true}
+                onChange={(selected) => {
+                  onChange(selected?.map((s) => s.value) ?? []);
+                }}
+                components={{
+                  // eslint-disable-next-line
+                  // @ts-ignore We're failing to provide a required index prop to SortableElement
+                  MultiValue: SortableMultiValue,
+                  MultiValueLabel: SortableMultiValueLabel,
+                }}
+                closeMenuOnSelect={false}
+                autoFocus={autoFocus}
+                value={selected}
+                placeholder={initialOption ?? placeholder}
+                isSearchable
+              />
+            </div>
+          </>
+        );
+      }}
+    />
+  );
+};
+
+export default MultiSelectField;

--- a/packages/front-end/components/Forms/SelectField.tsx
+++ b/packages/front-end/components/Forms/SelectField.tsx
@@ -3,34 +3,15 @@ import Field, { FieldProps } from "./Field";
 import ReactSelect from "react-select";
 import cloneDeep from "lodash/cloneDeep";
 
-type SingleValue = { label: string; value: string };
-type GroupedValue = { label: string; options: SingleValue[] };
+export type SingleValue = { label: string; value: string };
+export type GroupedValue = { label: string; options: SingleValue[] };
 
-const SelectField: FC<
-  Omit<
-    FieldProps,
-    "value" | "onChange" | "options" | "multi" | "initialOption" | "placeholder"
-  > & {
-    value: string;
-    placeholder?: string;
-    options: (SingleValue | GroupedValue)[];
-    initialOption?: string;
-    onChange: (value: string) => void;
-    sort?: boolean;
-  }
-> = ({
-  value,
-  options,
-  onChange,
-  initialOption,
-  placeholder = "Select...",
-  sort = true,
-  disabled,
-  autoFocus,
-  required,
-  ...otherProps
-}) => {
-  const [map, sorted] = useMemo(() => {
+export function useSelectOptions(
+  options: (SingleValue | GroupedValue)[],
+  initialOption?: string,
+  sort?: boolean
+) {
+  return useMemo(() => {
     const m = new Map<string, SingleValue>();
     const clone = cloneDeep(options);
     if (sort) {
@@ -58,8 +39,62 @@ const SelectField: FC<
       clone.unshift({ label: initialOption, value: "" });
     }
 
-    return [m, clone];
+    return [m, clone] as const;
   }, [options, initialOption]);
+}
+
+export const ReactSelectProps = {
+  styles: {
+    menu: (base) => ({
+      ...base,
+      width: "max-content",
+      minWidth: "100%",
+    }),
+    menuPortal: (base) => ({ ...base, zIndex: 9999 }),
+    groupHeading: (base) => ({
+      ...base,
+      margin: "3px 0 0 -2px",
+      fontSize: "70%",
+    }),
+    group: (base) => ({
+      ...base,
+      paddingTop: 0,
+      paddingBottom: 0,
+    }),
+    option: (base) => ({
+      ...base,
+      padding: "6px 17px",
+    }),
+  },
+  menuPosition: "fixed" as const,
+  isSearchable: true,
+};
+
+const SelectField: FC<
+  Omit<
+    FieldProps,
+    "value" | "onChange" | "options" | "multi" | "initialOption" | "placeholder"
+  > & {
+    value: string;
+    placeholder?: string;
+    options: (SingleValue | GroupedValue)[];
+    initialOption?: string;
+    onChange: (value: string) => void;
+    sort?: boolean;
+  }
+> = ({
+  value,
+  options,
+  onChange,
+  initialOption,
+  placeholder = "Select...",
+  sort = true,
+  disabled,
+  autoFocus,
+  required,
+  ...otherProps
+}) => {
+  const [map, sorted] = useSelectOptions(options, initialOption, sort);
   const selected = map.get(value);
 
   // eslint-disable-next-line
@@ -105,6 +140,7 @@ const SelectField: FC<
             </div>
             <div className="d-none d-lg-block">
               <ReactSelect
+                {...ReactSelectProps}
                 id={id}
                 ref={ref}
                 isDisabled={disabled || false}
@@ -112,33 +148,9 @@ const SelectField: FC<
                 onChange={(selected) => {
                   onChange(selected?.value || "");
                 }}
-                styles={{
-                  menu: (base) => ({
-                    ...base,
-                    width: "max-content",
-                    minWidth: "100%",
-                  }),
-                  menuPortal: (base) => ({ ...base, zIndex: 9999 }),
-                  groupHeading: (base) => ({
-                    ...base,
-                    margin: "3px 0 0 -2px",
-                    fontSize: "70%",
-                  }),
-                  group: (base) => ({
-                    ...base,
-                    paddingTop: 0,
-                    paddingBottom: 0,
-                  }),
-                  option: (base) => ({
-                    ...base,
-                    padding: "6px 17px",
-                  }),
-                }}
                 autoFocus={autoFocus}
                 value={selected}
                 placeholder={initialOption ?? placeholder}
-                menuPosition="fixed"
-                isSearchable
               />
             </div>
           </>

--- a/packages/front-end/components/Forms/SelectField.tsx
+++ b/packages/front-end/components/Forms/SelectField.tsx
@@ -65,6 +65,24 @@ export const ReactSelectProps = {
       ...base,
       padding: "6px 17px",
     }),
+    multiValue: (styles) => {
+      return {
+        ...styles,
+        backgroundColor: "#F2ECFD",
+      };
+    },
+    multiValueLabel: (styles) => ({
+      ...styles,
+      color: "#7c45ea",
+      fontWeight: 600,
+    }),
+    multiValueRemove: (styles) => ({
+      ...styles,
+      color: "#7c45ea",
+      ":hover": {
+        backgroundColor: "#d3bbff",
+      },
+    }),
   },
   menuPosition: "fixed" as const,
   isSearchable: true,

--- a/packages/front-end/package.json
+++ b/packages/front-end/package.json
@@ -52,6 +52,7 @@
     "react-icons": "^4.3.1",
     "react-paginate": "^8.0.0",
     "react-select": "^5.2.1",
+    "react-sortable-hoc": "^2.0.0",
     "react-syntax-highlighter": "^15.4.3",
     "react-textarea-autosize": "^8.3.2",
     "rich-markdown-editor": "^11.17.2",

--- a/packages/front-end/pages/experiment/[eid].tsx
+++ b/packages/front-end/pages/experiment/[eid].tsx
@@ -690,11 +690,14 @@ const ExperimentPage = (): ReactElement => {
                 <RightRailSectionGroup title="Goals" type="custom">
                   {experiment.metrics.map((m) => {
                     return (
-                      <Link href={`/metric/${m}`} key={m}>
-                        <a className="mr-2 font-weight-bold">
-                          {getMetricById(m)?.name}
-                        </a>
-                      </Link>
+                      <div key={m} className="ml-2">
+                        <span className="mr-1">-</span>
+                        <Link href={`/metric/${m}`}>
+                          <a className="mr-2 font-weight-bold">
+                            {getMetricById(m)?.name}
+                          </a>
+                        </Link>
+                      </div>
                     );
                   })}
                 </RightRailSectionGroup>
@@ -702,11 +705,14 @@ const ExperimentPage = (): ReactElement => {
                   <RightRailSectionGroup title="Guardrails" type="custom">
                     {experiment.guardrails.map((m) => {
                       return (
-                        <Link href={`/metric/${m}`} key={m}>
-                          <a className="mr-2 font-weight-bold">
-                            {getMetricById(m)?.name}
-                          </a>
-                        </Link>
+                        <div key={m} className="ml-2">
+                          <span className="mr-1">-</span>
+                          <Link href={`/metric/${m}`}>
+                            <a className="mr-2 font-weight-bold">
+                              {getMetricById(m)?.name}
+                            </a>
+                          </Link>
+                        </div>
                       );
                     })}
                   </RightRailSectionGroup>

--- a/packages/front-end/styles/global.scss
+++ b/packages/front-end/styles/global.scss
@@ -123,6 +123,9 @@ pre {
   @include badge-variant(#f6f7f9);
   border: 1px solid $gray4;
 }
+.multi-select-container {
+  z-index: 99999999;
+}
 .graybox {
   background-color: $gray6;
   padding: 15px 20px 20px;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1265,6 +1265,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.2.0":
+  version "7.17.8"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.8.tgz#3e56e4aff81befa55ac3ac6a0967349fd1c5bca2"
+  integrity sha512-dQpEpK0O9o6lj6oPu0gRDbbnk+4LeHlNcBpspf6Olzt3GIX4P1lWF1gS+pHLDFlaJvbR6q7jCfQ08zA4QJBnmA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.9.2":
   version "7.14.6"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.6.tgz#535203bc0892efc7dec60bdc27b2ecf6e409062d"
@@ -10408,6 +10415,15 @@ prop-types@15.7.2, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8, 
     object-assign "^4.1.1"
     react-is "^16.8.1"
 
+prop-types@^15.5.7:
+  version "15.8.1"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
+  integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.13.1"
+
 property-information@^5.0.0, property-information@^5.3.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/property-information/-/property-information-5.6.0.tgz#61675545fb23002f245c6540ec46077d4da3ed69"
@@ -10897,6 +10913,15 @@ react-select@^5.2.1:
     memoize-one "^5.0.0"
     prop-types "^15.6.0"
     react-transition-group "^4.3.0"
+
+react-sortable-hoc@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/react-sortable-hoc/-/react-sortable-hoc-2.0.0.tgz#f6780d8aa4b922a21f3e754af542f032677078b7"
+  integrity sha512-JZUw7hBsAHXK7PTyErJyI7SopSBFRcFHDjWW5SWjcugY0i6iH7f+eJkY8cJmGMlZ1C9xz1J3Vjz0plFpavVeRg==
+  dependencies:
+    "@babel/runtime" "^7.2.0"
+    invariant "^2.2.4"
+    prop-types "^15.5.7"
 
 react-spring@^8.0.25:
   version "8.0.27"


### PR DESCRIPTION
- Drag and drop to sort goal and guardrail metrics in an experiment
- Improve display of metrics on experiment info tab
- Simplify "add metrics by tag" UI