### PR TITLE
fix: frontend activity page crash

### DIFF
--- a/packages/front-end/services/utils.tsx
+++ b/packages/front-end/services/utils.tsx
@@ -25,7 +25,7 @@ export function phaseSummary(
       </span>{" "}
       traffic,{" "}
       <span className="split">
-        {formatTrafficSplit(phase.variationWeights)}
+        {formatTrafficSplit(phase.variationWeights || [])}
       </span>{" "}
       split
     </>


### PR DESCRIPTION
# Context

We did few actions about delete experiment phase, and not sure why it caused the `phase.variationWeights` to be `undefined`

So this fix is made on the frontend to just not cause page to crash and give it an default empty array.

<img width="1281" alt="image" src="https://user-images.githubusercontent.com/8667086/162664397-3a57e97f-cd89-48fc-9263-db7a7b4d09ed.png">

<img width="1790" alt="image" src="https://user-images.githubusercontent.com/8667086/162664376-60290d94-b28f-427d-9fad-a9603cb4c3b9.png">

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/8667086/162664358-f099b89b-4cd2-4aa1-b38f-bcf9eeccade0.png">

# After Fix

<img width="1208" alt="image" src="https://user-images.githubusercontent.com/8667086/162664768-5793b0b4-7dfa-41c4-89c7-a4b409bd31d9.png">

