### PR TITLE
Fixed type for the variable in documentation

### DIFF
--- a/packages/docs/pages/lib/build-your-own.mdx
+++ b/packages/docs/pages/lib/build-your-own.mdx
@@ -94,7 +94,7 @@ The only required properties are `key` and `variations`. Everything else is opti
 The result of running an **Experiment** given a specific **Context**
 
 - **inExperiment** (`boolean`) - Whether or not the user is part of the experiment
-- **variationId** (`string`) - The array index of the assigned variation
+- **variationId** (`int`) - The array index of the assigned variation
 - **value** (`any`) - The array value of the assigned variation
 - **hashAttribute** (`string`) - The user attribute used to assign a variation
 - **hashValue** (`string)` - The value of that attribute


### PR DESCRIPTION
The type for 'variationId' inside 'ExperimentResult' should be an int but in the documentation it is an string. I have fixed it in the documentation as well as verified the type in the kotlin client SDK repos as well.