### PR TITLE
Support javascript expressions in Mixpanel dimensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,15 +45,5 @@
       "flake8"
     ]
   },
-  "prettier": {
-    "overrides": [
-      {
-        "files": "*dimensions.mdx",
-        "options": {
-          "semi": false
-        }
-      }
-    ]
-  },
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -45,5 +45,15 @@
       "flake8"
     ]
   },
+  "prettier": {
+    "overrides": [
+      {
+        "files": "*dimensions.mdx",
+        "options": {
+          "semi": false
+        }
+      }
+    ]
+  },
   "license": "MIT"
 }

--- a/packages/back-end/src/util/sql.ts
+++ b/packages/back-end/src/util/sql.ts
@@ -68,10 +68,12 @@ export function replaceDateVars(sql: string, startDate: Date, endDate?: Date) {
   }
 
   const replacements: Record<string, string> = {
+    startDateUnix: "" + Math.floor(startDate.getTime() / 1000),
     startDate: startDate.toISOString().substr(0, 19).replace("T", " "),
     startYear: startDate.toISOString().substr(0, 4),
     startMonth: startDate.toISOString().substr(5, 2),
     startDay: startDate.toISOString().substr(8, 2),
+    endDateUnix: "" + Math.floor(endDate.getTime() / 1000),
     endDate: endDate.toISOString().substr(0, 19).replace("T", " "),
     endYear: endDate.toISOString().substr(0, 4),
     endMonth: endDate.toISOString().substr(5, 2),

--- a/packages/back-end/test/sql.test.ts
+++ b/packages/back-end/test/sql.test.ts
@@ -28,6 +28,14 @@ describe("backend", () => {
     ).toEqual(
       "SELECT '2022-02-09 11:30:12' as full, '2022' as year, '02' as month, '09' as day"
     );
+
+    expect(
+      replaceDateVars(
+        `time > {{startDateUnix}} && time < {{ endDateUnix }}`,
+        start,
+        end
+      )
+    ).toEqual(`time > 1609842015 && time < 1644406212`);
   });
 
   it("determines identifier joins correctly", () => {

--- a/packages/docs/pages/app/datasources.mdx
+++ b/packages/docs/pages/app/datasources.mdx
@@ -102,10 +102,12 @@ The variables are:
 - **startYear** - Just the `YYYY` of the startDate
 - **startMonth** - Just the `MM` of the startDate
 - **startDay** - Just the `DD` of the startDate
+- **startDateUnix** - Unix timestamp of the startDate (seconds since Jan 1, 1970)
 - **endDate** - `YYYY-MM-DD HH:mm:ss` of the latest data that needs to be included
 - **endYear** - Just the `YYYY` of the endDate
 - **endMonth** - Just the `MM` of the endDate
 - **endDay** - Just the `DD` of the endDate
+- **endDateUnix** - Unix timestamp of the endDate (seconds since Jan 1, 1970)
 
 For example:
 

--- a/packages/docs/pages/app/dimensions.mdx
+++ b/packages/docs/pages/app/dimensions.mdx
@@ -10,9 +10,13 @@ countries in your dataset will be signficantly different just by random chance.
 It's best to treat dimensions as an exploratory tool and not something to directly draw conclusions from.
 The two best use cases are identfying bugs (the `browser` example) and getting ideas for dedicated follow-up experiments.
 
-There are two types of dimensions: User Dimensions and Experiment Dimensions. Currently, these are only supported for SQL data sources.
+Dimensions are supported for both Mixpanel and SQL data sources.
 
-## User Dimensions
+## SQL
+
+There are two types of dimensions for SQL data sources: User Dimensions and Experiment Dimensions.
+
+### User Dimensions
 
 These are attributes of your users that are relatively stable over time. For example, `subscription plan`, `age group`, `cohort`.
 
@@ -43,7 +47,7 @@ FROM
   users
 ```
 
-## Experiment Dimensions
+### Experiment Dimensions
 
 These are attributes that are specific to the point-in-time that a user was put into an experiment. For example, `browser` or `referrer`.
 
@@ -63,3 +67,34 @@ FROM
 ```
 
 The first 4 columns are standard, but `browser` is a custom one that can be used as an Experiment Dimension.
+
+## Mixpanel
+
+For mixpanel, there is just a single type of dimension that is based on event properties (at this time Mixpanel user properties are not supported).
+
+For simple dimensions, you can just put the event property name directly. For example: `$browser`.
+
+We also support complex javascript expressions. For example:
+
+```js
+event.properties.$browser.match(/chrome/i) ? "Chrome" : "Other";
+```
+
+You can also reference the experiment start/end date in your javascript expression. For example, if you add a super event called `userRegistrationDate` that stores a unix timestamp, you could make a `New vs Existing` dimension like this:
+
+```js
+event.properties.userRegistrationDate < {{ startDateUnix }} ? "new" : "existing"
+```
+
+The variables you can reference are:
+
+- **startDate** - `YYYY-MM-DD HH:mm:ss` of the earliest data that needs to be included
+- **startYear** - Just the `YYYY` of the startDate
+- **startMonth** - Just the `MM` of the startDate
+- **startDay** - Just the `DD` of the startDate
+- **startDateUnix** - Unix timestamp of the startDate (seconds since Jan 1, 1970)
+- **endDate** - `YYYY-MM-DD HH:mm:ss` of the latest data that needs to be included
+- **endYear** - Just the `YYYY` of the endDate
+- **endMonth** - Just the `MM` of the endDate
+- **endDay** - Just the `DD` of the endDate
+- **endDateUnix** - Unix timestamp of the endDate (seconds since Jan 1, 1970)

--- a/packages/docs/pages/app/dimensions.mdx
+++ b/packages/docs/pages/app/dimensions.mdx
@@ -77,16 +77,16 @@ For simple dimensions, you can just put the event property name directly. For ex
 We also support complex javascript expressions. For example:
 
 ```js
-event.properties.$browser.match(/chrome/i) ? "Chrome" : "Other";
+event.properties.$browser.match(/chrome/i) ? "Chrome" : "Other"
 ```
 
 For more complex expressions, you can wrap your code in an anonymous function:
 
 ```js
-(() => {
+;(() => {
   // ...some complex logic
-  return dimensionValue;
-})();
+  return dimensionValue
+})()
 ```
 
 You can also reference the experiment start/end date in your javascript expression. For example, if you add a super event called `userRegistrationDate` that stores a unix timestamp, you could make a `New vs Existing` dimension like this:

--- a/packages/docs/pages/app/dimensions.mdx
+++ b/packages/docs/pages/app/dimensions.mdx
@@ -76,14 +76,14 @@ For simple dimensions, you can just put the event property name directly. For ex
 
 We also support complex javascript expressions. For example:
 
-```js
+```
 event.properties.$browser.match(/chrome/i) ? "Chrome" : "Other"
 ```
 
 For more complex expressions, you can wrap your code in an anonymous function:
 
-```js
-;(() => {
+```
+(() => {
   // ...some complex logic
   return dimensionValue
 })()
@@ -91,7 +91,7 @@ For more complex expressions, you can wrap your code in an anonymous function:
 
 You can also reference the experiment start/end date in your javascript expression. For example, if you add a super event called `userRegistrationDate` that stores a unix timestamp, you could make a `New vs Existing` dimension like this:
 
-```js
+```
 event.properties.userRegistrationDate >= {{ startDateUnix }} ? "new" : "existing"
 ```
 

--- a/packages/docs/pages/app/dimensions.mdx
+++ b/packages/docs/pages/app/dimensions.mdx
@@ -80,6 +80,15 @@ We also support complex javascript expressions. For example:
 event.properties.$browser.match(/chrome/i) ? "Chrome" : "Other";
 ```
 
+For more complex expressions, you can wrap your code in an anonymous function:
+
+```js
+(() => {
+  // ...some complex logic
+  return dimensionValue;
+})();
+```
+
 You can also reference the experiment start/end date in your javascript expression. For example, if you add a super event called `userRegistrationDate` that stores a unix timestamp, you could make a `New vs Existing` dimension like this:
 
 ```js

--- a/packages/docs/pages/app/dimensions.mdx
+++ b/packages/docs/pages/app/dimensions.mdx
@@ -83,7 +83,7 @@ event.properties.$browser.match(/chrome/i) ? "Chrome" : "Other";
 You can also reference the experiment start/end date in your javascript expression. For example, if you add a super event called `userRegistrationDate` that stores a unix timestamp, you could make a `New vs Existing` dimension like this:
 
 ```js
-event.properties.userRegistrationDate < {{ startDateUnix }} ? "new" : "existing"
+event.properties.userRegistrationDate >= {{ startDateUnix }} ? "new" : "existing"
 ```
 
 The variables you can reference are:


### PR DESCRIPTION
Currently, only simple event property names are allowed for dimensions (e.g. `$browser`).  This PR adds support for full javascript expressions.  So you can now do:

```js
event.properties.$browser.match(/chrome/i) ? "chrome" : "other"
```

For more complex logic, you can wrap your code in an anonymous function:

```js
(() => {
  // ...some complex logic
  return dimensionValue;
})()
```

This PR also adds support for the same placeholder variables available to SQL queries.  If you have a super event property named `userRegistration` that stores a unix timestamp, you can now create a dimension called "New vs Existing":

```js
event.properties.userRegistrationDate >= {{ startDateUnix }} ? "new" : "existing"
```