### PR TITLE
Options to bypass draft/publish steps for feature changes in dev

### DIFF
--- a/packages/back-end/src/app.ts
+++ b/packages/back-end/src/app.ts
@@ -526,6 +526,7 @@ app.delete("/datasource/:id", organizationsController.deleteDataSource);
 app.get("/keys", organizationsController.getApiKeys);
 app.post("/keys", organizationsController.postApiKey);
 app.delete("/key/:key", organizationsController.deleteApiKey);
+app.put("/key/:key", organizationsController.putApiKey);
 
 // Webhooks
 app.get("/webhooks", organizationsController.getWebhooks);

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -52,7 +52,11 @@ export async function getFeaturesPublic(req: Request, res: Response) {
   }
 
   try {
-    const { organization, environment } = await lookupOrganizationByApiKey(key);
+    const {
+      organization,
+      environment,
+      includeDrafts,
+    } = await lookupOrganizationByApiKey(key);
     if (!organization) {
       return res.status(400).json({
         status: 400,
@@ -63,7 +67,8 @@ export async function getFeaturesPublic(req: Request, res: Response) {
     const features = await getFeatureDefinitions(
       organization,
       environment,
-      project
+      project,
+      includeDrafts
     );
 
     // Cache for 30 seconds, serve stale up to 1 hour (10 hours if origin is down)

--- a/packages/back-end/src/models/ApiKeyModel.ts
+++ b/packages/back-end/src/models/ApiKeyModel.ts
@@ -10,6 +10,7 @@ const apiKeySchema = new mongoose.Schema({
   description: String,
   organization: String,
   dateCreated: Date,
+  includeDrafts: Boolean,
 });
 
 export type ApiKeyDocument = mongoose.Document & ApiKeyInterface;

--- a/packages/back-end/src/services/apiKey.ts
+++ b/packages/back-end/src/services/apiKey.ts
@@ -5,7 +5,8 @@ import md5 from "md5";
 export async function createApiKey(
   organization: string,
   environment: string,
-  description?: string
+  description?: string,
+  includeDrafts?: boolean
 ): Promise<string> {
   const key =
     "key_" + environment.substr(0, 4) + "_" + md5(uniqid()).substr(0, 16);
@@ -15,10 +16,31 @@ export async function createApiKey(
     key,
     description,
     environment,
+    includeDrafts,
     dateCreated: new Date(),
   });
 
   return key;
+}
+
+export async function updateApiKey(
+  organization: string,
+  key: string,
+  description?: string,
+  includeDrafts?: boolean
+) {
+  await ApiKeyModel.updateOne(
+    {
+      organization,
+      key,
+    },
+    {
+      $set: {
+        description,
+        includeDrafts,
+      },
+    }
+  );
 }
 
 export async function deleteByOrganizationAndApiKey(
@@ -34,14 +56,18 @@ export async function deleteByOrganizationAndApiKey(
 
 export async function lookupOrganizationByApiKey(
   key: string
-): Promise<{ organization?: string; environment?: string }> {
+): Promise<{
+  organization?: string;
+  environment?: string;
+  includeDrafts?: boolean;
+}> {
   const doc = await ApiKeyModel.findOne({
     key,
   });
 
   if (!doc || !doc.organization) return {};
-  const { organization, environment } = doc;
-  return { organization, environment };
+  const { organization, environment, includeDrafts } = doc;
+  return { organization, environment, includeDrafts };
 }
 
 export async function getAllApiKeysByOrganization(organization: string) {

--- a/packages/back-end/types/apikey.d.ts
+++ b/packages/back-end/types/apikey.d.ts
@@ -3,5 +3,6 @@ export interface ApiKeyInterface {
   environment?: string;
   description?: string;
   organization: string;
+  includeDrafts?: boolean;
   dateCreated: Date;
 }

--- a/packages/docs/pages/app/api.mdx
+++ b/packages/docs/pages/app/api.mdx
@@ -12,6 +12,8 @@ When you first start setting up features in GrowthBook, we create a "production"
 
 You can add new environments by going to **Settings -> Environments**.
 
+You can add new API keys for your existing environments by going to **Settings -> API Keys**.
+
 ## Feature Definitions Endpoint
 
 The primary API endpoint is for fetching feature definitions.
@@ -47,6 +49,12 @@ Here is an example API response:
 The `status` field mirrors the HTTP status. The `features` field has feature definitions indexed by the feature key.
 
 Each feature definition has a default value and optional rules that override the value based on targeting conditions. Rules can also be experiments or rollouts where values are randomly assigned to users.
+
+_Note_: If a feature is toggled `off` for an environment, it will not be included in the API response.
+
+### Draft Feature Changes
+
+By default, the features endpoint does not include unpublished changes. You can change this behavior on a per-key basis. This is especially useful for dev or QA environments so you can verify changes before publishing them to production.
 
 ### Project-scoping
 


### PR DESCRIPTION
Currently, all feature changes create a draft that must be published in a separate step.  This is great for production, but can be annoying in dev environments.

This PR fixes this by adding two new settings.
- [x] Per-api key setting to include draft changes in the features API endpoint
- [ ] Per-environment setting to auto-publish changes as new revisions
- [ ] Documentation

The first change makes it possible to just use a single `production` environment and still be able to preview changes locally before making them live.

The second change lets you keep environments separate, but speed up the development process