### PR TITLE
Fix past experiments query bug in Postgres/Redshift

### DIFF
--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -166,7 +166,7 @@ export default abstract class SqlIntegration
           return `
         __exposures${i} as (
           SELECT 
-            '${q.id}' as exposure_query, 
+            ${this.castToString(`'${q.id}'`)} as exposure_query, 
             experiment_id,
             variation_id,
             ${this.dateTrunc(this.castUserDateCol("timestamp"))} as date,


### PR DESCRIPTION
Postgres 9 bug inferring data types in UNIONs - https://stackoverflow.com/questions/18073901/failed-to-find-conversion-function-from-unknown-to-text

To fix, explicitly cast the exposure query id to a varchar type.