### PR TITLE
In SDK feature evaluation, don't skip experiment rules that are forced

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-prettier": "^3.1.3",
     "eslint-plugin-react": "^7.20.0",
+    "husky": "^7.0.0",
     "lint-staged": "^10.2.7",
     "prettier": "^2.2.1",
-    "typescript": "4.3.5",
-    "husky": "^7.0.0"
+    "typescript": "4.3.5"
   },
   "lint-staged": {
     "./**/*.{json,css,scss,md,mdx}": [

--- a/packages/docs/pages/lib/build-your-own.mdx
+++ b/packages/docs/pages/lib/build-your-own.mdx
@@ -96,10 +96,13 @@ The result of running an **Experiment** given a specific **Context**
 - **inExperiment** (`boolean`) - Whether or not the user is part of the experiment
 - **variationId** (`int`) - The array index of the assigned variation
 - **value** (`any`) - The array value of the assigned variation
+- **hashUsed** (`boolean`) - If a hash was used to assign a variation
 - **hashAttribute** (`string`) - The user attribute used to assign a variation
 - **hashValue** (`string)` - The value of that attribute
 
 The `variationId` and `value` should always be set, even when `inExperiment` is false.
+
+The `hashAttribute` and `hashValue` should always be set, even when `hashUsed` is false.
 
 ### Feature
 

--- a/packages/docs/pages/lib/build-your-own.mdx
+++ b/packages/docs/pages/lib/build-your-own.mdx
@@ -511,20 +511,23 @@ Everything else is considered "truthy", including empty arrays and objects.
 
 If value is "truthy", then `on` should be true and `off` should be false. If the value is "falsy", then they should take opposite values.
 
-### private getExperimentResult(experiment, variationIndex, inExperiment): ExperimentResult
+### private getExperimentResult(experiment, variationIndex, hashUsed): ExperimentResult
 
 This is a helper method to create an `ExperimentResult` object. The arguments are:
 
 - Experiment object (required)
-- The assigned variation index (optional, default to `0`)
+- The assigned variation index (optional, default to `-1`)
+- Whether or not the hash was used to assign a variation (optional, default to `false`)
 - Whether or not the user is in the experiment (optional, default to `false`)
 
 The method is pretty simple:
 
-1. Make sure the variationIndex is valid for the experiment
+1. Determine if user is in the experiment and clamp the variationIndex as needed
    ```ts
-   if (variationIndex < 0 || variationIdex >= experiment.variations.length) {
+   let inExperiment = true;
+   if (variationIndex < 0 || variationIndex >= experiment.variations.length) {
      variationIndex = 0;
+     inExperiment = false;
    }
    ```
 2. Get the hashAttribute and hashValue
@@ -536,6 +539,7 @@ The method is pretty simple:
    ```ts
    return {
      inExperiment: inExperiment,
+     hashUsed: hashUsed,
      variationId: variationIndex,
      value: experiment.variations[variationIndex],
      hashAttribute: hashAttribute,
@@ -783,6 +787,7 @@ The cases.json file is an object. The keys are the function being tested, and th
   - experiment object
   - expected value
   - inExperiment (boolean)
+  - hashUsed (boolean)
 
 In addition to the above, you should write custom test cases for things like event subscriptions, tracking callbacks, getters/setters, etc. that are more language-specific.
 

--- a/packages/docs/pages/lib/build-your-own.mdx
+++ b/packages/docs/pages/lib/build-your-own.mdx
@@ -518,16 +518,17 @@ If value is "truthy", then `on` should be true and `off` should be false. If the
 
 This is a helper method to create an `ExperimentResult` object. The arguments are:
 
-- Experiment object (required)
-- The assigned variation index (optional, default to `-1`)
-- Whether or not the hash was used to assign a variation (optional, default to `false`)
-- Whether or not the user is in the experiment (optional, default to `false`)
+- `experiment` - Experiment object (required)
+- `variationIndex` - The assigned variation index (optional, default to `-1`)
+- `hashUsed` - Whether or not the hash was used to assign a variation (optional, default to `false`)
 
 The method is pretty simple:
 
-1. Determine if user is in the experiment and clamp the variationIndex as needed
+1. Handle case when user is not in the experiment (e.g. variationIndex = -1)
    ```ts
+   // By default, assume everyone is in the experiment
    let inExperiment = true;
+   // If the variation is invalid, use the baseline and set the inExperiment flag to false
    if (variationIndex < 0 || variationIndex >= experiment.variations.length) {
      variationIndex = 0;
      inExperiment = false;

--- a/packages/docs/pages/lib/js.mdx
+++ b/packages/docs/pages/lib/js.mdx
@@ -465,6 +465,7 @@ A call to `growthbook.run(experiment)` returns an object with a few useful prope
 ```ts
 const {
   inExperiment,
+  hashUsed,
   variationId,
   value,
   hashAttribute,
@@ -474,7 +475,7 @@ const {
   variations: ["A", "B"],
 });
 
-// If user is part of the experiment
+// If user is included in the experiment
 console.log(inExperiment); // true or false
 
 // The index of the assigned variation
@@ -483,14 +484,19 @@ console.log(variationId); // 0 or 1
 // The value of the assigned variation
 console.log(value); // "A" or "B"
 
-// The user attribute used to assign a variation
+// If the variation was randomly assigned by hashing
+console.log(hashUsed);
+
+// The user attribute that was hashed
 console.log(hashAttribute); // "id"
 
 // The value of that attribute
 console.log(hashValue); // e.g. "123"
 ```
 
-The `inExperiment` flag is only set to true if the user was randomly assigned a variation. If the user failed any targeting rules or was forced into a specific variation, this flag will be false.
+The `inExperiment` flag will be false if the user was excluded from being part of the experiment for any reason (e.g. failed targeting conditions).
+
+The `hashUsed` flag will only be true if the user was randomly assigned a variation. If the user was forced into a specific variation instead, this flag will be false.
 
 ## Typescript
 

--- a/packages/front-end/package.json
+++ b/packages/front-end/package.json
@@ -12,7 +12,7 @@
     "@auth0/auth0-spa-js": "^1.9.0",
     "@dnd-kit/core": "^4.0.3",
     "@dnd-kit/sortable": "^5.1.0",
-    "@growthbook/growthbook-react": "^0.8.0",
+    "@growthbook/growthbook-react": "^0.9.0",
     "@jitsu/sdk-js": "^2.2.0",
     "@jukben/emoji-search": "^2.0.1",
     "@sentry/react": "^6.17.9",

--- a/packages/sdk-js/README.md
+++ b/packages/sdk-js/README.md
@@ -480,6 +480,7 @@ A call to `growthbook.run(experiment)` returns an object with a few useful prope
 ```ts
 const {
   inExperiment,
+  hashUsed,
   variationId,
   value,
   hashAttribute,
@@ -489,7 +490,7 @@ const {
   variations: ["A", "B"],
 });
 
-// If user is part of the experiment
+// If user is included in the experiment
 console.log(inExperiment); // true or false
 
 // The index of the assigned variation
@@ -498,14 +499,19 @@ console.log(variationId); // 0 or 1
 // The value of the assigned variation
 console.log(value); // "A" or "B"
 
-// The user attribute used to assign a variation
+// If the variation was randomly assigned by hashing
+console.log(hashUsed);
+
+// The user attribute that was hashed
 console.log(hashAttribute); // "id"
 
 // The value of that attribute
 console.log(hashValue); // e.g. "123"
 ```
 
-The `inExperiment` flag is only set to true if the user was randomly assigned a variation. If the user failed any targeting rules or was forced into a specific variation, this flag will be false.
+The `inExperiment` flag will be false if the user was excluded from being part of the experiment for any reason (e.g. failed targeting conditions).
+
+The `hashUsed` flag will only be true if the user was randomly assigned a variation. If the user was forced into a specific variation instead, this flag will be false.
 
 ## Typescript
 

--- a/packages/sdk-js/package.json
+++ b/packages/sdk-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@growthbook/growthbook",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/sdk-js/package.json
+++ b/packages/sdk-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@growthbook/growthbook",
-  "version": "0.17.2",
+  "version": "0.18.0",
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/sdk-js/src/GrowthBook.ts
+++ b/packages/sdk-js/src/GrowthBook.ts
@@ -614,11 +614,14 @@ export class GrowthBook {
 
   private getResult<T>(
     experiment: Experiment<T>,
-    variationIndex: number = 0,
-    inExperiment: boolean = false
+    variationIndex: number = -1,
+    hashUsed: boolean = false
   ): Result<T> {
+    let inExperiment = true;
+    // If assigned variation is not valid, use the baseline and mark the user as not in the experiment
     if (variationIndex < 0 || variationIndex >= experiment.variations.length) {
       variationIndex = 0;
+      inExperiment = false;
     }
 
     const { hashAttribute, hashValue } = this.getHashAttribute(
@@ -627,6 +630,7 @@ export class GrowthBook {
 
     return {
       inExperiment,
+      hashUsed,
       variationId: variationIndex,
       value: experiment.variations[variationIndex],
       hashAttribute,

--- a/packages/sdk-js/src/types/growthbook.ts
+++ b/packages/sdk-js/src/types/growthbook.ts
@@ -80,6 +80,7 @@ export interface Result<T> {
   value: T;
   variationId: number;
   inExperiment: boolean;
+  hashUsed?: boolean;
   hashAttribute: string;
   hashValue: string;
 }

--- a/packages/sdk-js/test/cases.json
+++ b/packages/sdk-js/test/cases.json
@@ -1707,6 +1707,7 @@
           "value": "c",
           "variationId": 2,
           "inExperiment": true,
+          "hashUsed": true,
           "hashAttribute": "id",
           "hashValue": "123"
         },
@@ -1742,6 +1743,7 @@
           "value": "a",
           "variationId": 0,
           "inExperiment": true,
+          "hashUsed": true,
           "hashAttribute": "id",
           "hashValue": "456"
         },
@@ -1777,6 +1779,7 @@
           "value": "b",
           "variationId": 1,
           "inExperiment": true,
+          "hashUsed": true,
           "hashAttribute": "id",
           "hashValue": "fds"
         },
@@ -1824,6 +1827,7 @@
           "value": false,
           "variationId": 1,
           "inExperiment": true,
+          "hashUsed": true,
           "hashAttribute": "anonId",
           "hashValue": "123"
         }
@@ -2011,6 +2015,47 @@
         "off": false,
         "source": "force"
       }
+    ],
+    [
+      "include experiments when forced",
+      {
+        "attributes": { "id": "123" },
+        "forcedVariations": {
+          "feature": 1
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "variations": [0, 1, 2, 3]
+              },
+              {
+                "force": 3
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 1,
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "experiment": {
+          "key": "feature",
+          "variations": [0, 1, 2, 3]
+        },
+        "experimentResult": {
+          "value": 1,
+          "variationId": 1,
+          "inExperiment": true,
+          "hashUsed": false,
+          "hashAttribute": "id",
+          "hashValue": "123"
+        }
+      }
     ]
   ],
   "run": [
@@ -2019,6 +2064,7 @@
       { "attributes": { "id": "1" } },
       { "key": "my-test", "variations": [0, 1] },
       1,
+      true,
       true
     ],
     [
@@ -2026,6 +2072,7 @@
       { "attributes": { "id": "2" } },
       { "key": "my-test", "variations": [0, 1] },
       0,
+      true,
       true
     ],
     [
@@ -2033,6 +2080,7 @@
       { "attributes": { "id": "3" } },
       { "key": "my-test", "variations": [0, 1] },
       0,
+      true,
       true
     ],
     [
@@ -2040,6 +2088,7 @@
       { "attributes": { "id": "4" } },
       { "key": "my-test", "variations": [0, 1] },
       1,
+      true,
       true
     ],
     [
@@ -2047,6 +2096,7 @@
       { "attributes": { "id": "5" } },
       { "key": "my-test", "variations": [0, 1] },
       1,
+      true,
       true
     ],
     [
@@ -2054,6 +2104,7 @@
       { "attributes": { "id": "6" } },
       { "key": "my-test", "variations": [0, 1] },
       1,
+      true,
       true
     ],
     [
@@ -2061,6 +2112,7 @@
       { "attributes": { "id": "7" } },
       { "key": "my-test", "variations": [0, 1] },
       0,
+      true,
       true
     ],
     [
@@ -2068,6 +2120,7 @@
       { "attributes": { "id": "8" } },
       { "key": "my-test", "variations": [0, 1] },
       1,
+      true,
       true
     ],
     [
@@ -2075,6 +2128,7 @@
       { "attributes": { "id": "9" } },
       { "key": "my-test", "variations": [0, 1] },
       0,
+      true,
       true
     ],
     [
@@ -2082,6 +2136,7 @@
       { "attributes": { "id": "1" } },
       { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
       1,
+      true,
       true
     ],
     [
@@ -2089,6 +2144,7 @@
       { "attributes": { "id": "2" } },
       { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
       1,
+      true,
       true
     ],
     [
@@ -2096,6 +2152,7 @@
       { "attributes": { "id": "3" } },
       { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
       0,
+      true,
       true
     ],
     [
@@ -2103,6 +2160,7 @@
       { "attributes": { "id": "4" } },
       { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
       1,
+      true,
       true
     ],
     [
@@ -2110,6 +2168,7 @@
       { "attributes": { "id": "5" } },
       { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
       1,
+      true,
       true
     ],
     [
@@ -2117,6 +2176,7 @@
       { "attributes": { "id": "6" } },
       { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
       1,
+      true,
       true
     ],
     [
@@ -2124,6 +2184,7 @@
       { "attributes": { "id": "7" } },
       { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
       0,
+      true,
       true
     ],
     [
@@ -2131,6 +2192,7 @@
       { "attributes": { "id": "8" } },
       { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
       1,
+      true,
       true
     ],
     [
@@ -2138,6 +2200,7 @@
       { "attributes": { "id": "9" } },
       { "key": "my-test", "variations": [0, 1], "weights": [0.1, 0.9] },
       1,
+      true,
       true
     ],
     [
@@ -2145,6 +2208,7 @@
       { "attributes": { "id": "1" } },
       { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
       0,
+      false,
       false
     ],
     [
@@ -2152,6 +2216,7 @@
       { "attributes": { "id": "2" } },
       { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
       0,
+      true,
       true
     ],
     [
@@ -2159,6 +2224,7 @@
       { "attributes": { "id": "3" } },
       { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
       0,
+      true,
       true
     ],
     [
@@ -2166,6 +2232,7 @@
       { "attributes": { "id": "4" } },
       { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
       0,
+      false,
       false
     ],
     [
@@ -2173,6 +2240,7 @@
       { "attributes": { "id": "5" } },
       { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
       1,
+      true,
       true
     ],
     [
@@ -2180,6 +2248,7 @@
       { "attributes": { "id": "6" } },
       { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
       0,
+      false,
       false
     ],
     [
@@ -2187,6 +2256,7 @@
       { "attributes": { "id": "7" } },
       { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
       0,
+      true,
       true
     ],
     [
@@ -2194,6 +2264,7 @@
       { "attributes": { "id": "8" } },
       { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
       1,
+      true,
       true
     ],
     [
@@ -2201,6 +2272,7 @@
       { "attributes": { "id": "9" } },
       { "key": "my-test", "variations": [0, 1], "coverage": 0.4 },
       0,
+      false,
       false
     ],
     [
@@ -2208,6 +2280,7 @@
       { "attributes": { "id": "1" } },
       { "key": "my-test", "variations": [0, 1, 2] },
       2,
+      true,
       true
     ],
     [
@@ -2215,6 +2288,7 @@
       { "attributes": { "id": "2" } },
       { "key": "my-test", "variations": [0, 1, 2] },
       0,
+      true,
       true
     ],
     [
@@ -2222,6 +2296,7 @@
       { "attributes": { "id": "3" } },
       { "key": "my-test", "variations": [0, 1, 2] },
       0,
+      true,
       true
     ],
     [
@@ -2229,6 +2304,7 @@
       { "attributes": { "id": "4" } },
       { "key": "my-test", "variations": [0, 1, 2] },
       2,
+      true,
       true
     ],
     [
@@ -2236,6 +2312,7 @@
       { "attributes": { "id": "5" } },
       { "key": "my-test", "variations": [0, 1, 2] },
       1,
+      true,
       true
     ],
     [
@@ -2243,6 +2320,7 @@
       { "attributes": { "id": "6" } },
       { "key": "my-test", "variations": [0, 1, 2] },
       2,
+      true,
       true
     ],
     [
@@ -2250,6 +2328,7 @@
       { "attributes": { "id": "7" } },
       { "key": "my-test", "variations": [0, 1, 2] },
       0,
+      true,
       true
     ],
     [
@@ -2257,6 +2336,7 @@
       { "attributes": { "id": "8" } },
       { "key": "my-test", "variations": [0, 1, 2] },
       1,
+      true,
       true
     ],
     [
@@ -2264,6 +2344,7 @@
       { "attributes": { "id": "9" } },
       { "key": "my-test", "variations": [0, 1, 2] },
       0,
+      true,
       true
     ],
     [
@@ -2271,6 +2352,7 @@
       { "attributes": { "id": "1" } },
       { "key": "my-test", "variations": [0, 1] },
       1,
+      true,
       true
     ],
     [
@@ -2278,6 +2360,7 @@
       { "attributes": { "id": "1" } },
       { "key": "my-test-3", "variations": [0, 1] },
       0,
+      true,
       true
     ],
     [
@@ -2285,6 +2368,7 @@
       { "attributes": { "id": "" } },
       { "key": "my-test", "variations": [0, 1] },
       0,
+      false,
       false
     ],
     [
@@ -2292,6 +2376,7 @@
       { "attributes": {} },
       { "key": "my-test", "variations": [0, 1] },
       0,
+      false,
       false
     ],
     [
@@ -2299,6 +2384,7 @@
       {},
       { "key": "my-test", "variations": [0, 1] },
       0,
+      false,
       false
     ],
     [
@@ -2306,6 +2392,7 @@
       { "attributes": { "id": "1" } },
       { "key": "my-test", "variations": [0] },
       0,
+      false,
       false
     ],
     [
@@ -2313,6 +2400,7 @@
       { "attributes": { "id": "1" } },
       { "key": "my-test", "variations": [0, 1], "force": -8 },
       0,
+      false,
       false
     ],
     [
@@ -2320,6 +2408,7 @@
       { "attributes": { "id": "1" } },
       { "key": "my-test", "variations": [0, 1], "force": 25 },
       0,
+      false,
       false
     ],
     [
@@ -2338,6 +2427,7 @@
         }
       },
       1,
+      true,
       true
     ],
     [
@@ -2356,6 +2446,7 @@
         }
       },
       0,
+      false,
       false
     ],
     [
@@ -2372,6 +2463,7 @@
         "hashAttribute": "companyId"
       },
       1,
+      true,
       true
     ],
     [
@@ -2387,6 +2479,7 @@
         "variations": [0, 1]
       },
       0,
+      false,
       false
     ],
     [
@@ -2402,6 +2495,7 @@
         "variations": [0, 1]
       },
       1,
+      true,
       false
     ],
     [
@@ -2417,6 +2511,7 @@
         "variations": [0, 1]
       },
       1,
+      true,
       true
     ],
     [
@@ -2432,6 +2527,7 @@
         "variations": [0, 1]
       },
       0,
+      false,
       false
     ],
     [
@@ -2448,6 +2544,7 @@
         "variations": [0, 1]
       },
       1,
+      true,
       false
     ],
     [
@@ -2464,6 +2561,7 @@
         "variations": [0, 1]
       },
       0,
+      false,
       false
     ],
     [
@@ -2490,6 +2588,7 @@
         "color": "green",
         "size": "large"
       },
+      true,
       true
     ],
     [
@@ -2503,6 +2602,7 @@
         "variations": [0, 1]
       },
       0,
+      true,
       false
     ],
     [
@@ -2516,6 +2616,7 @@
         "variations": [0, 1]
       },
       0,
+      false,
       false
     ],
     [
@@ -2530,6 +2631,7 @@
         "variations": [0, 1]
       },
       1,
+      true,
       false
     ],
     [
@@ -2544,6 +2646,7 @@
         "force": 1
       },
       1,
+      true,
       false
     ],
     [
@@ -2559,6 +2662,7 @@
         "namespace": ["namespace", 0.1, 1]
       },
       1,
+      true,
       true
     ],
     [
@@ -2574,6 +2678,7 @@
         "namespace": ["namespace", 0, 0.1]
       },
       0,
+      false,
       false
     ]
   ],

--- a/packages/sdk-js/test/experiments.test.ts
+++ b/packages/sdk-js/test/experiments.test.ts
@@ -154,7 +154,8 @@ describe("experiments", () => {
     });
 
     expect(res.variationId).toEqual(1);
-    expect(res.inExperiment).toEqual(false);
+    expect(res.inExperiment).toEqual(true);
+    expect(res.hashUsed).toEqual(false);
 
     growthbook.destroy();
   });
@@ -406,8 +407,10 @@ describe("experiments", () => {
     const res2 = growthbook.run(exp);
 
     expect(res1.inExperiment).toEqual(false);
+    expect(res1.hashUsed).toEqual(false);
     expect(res1.value).toEqual(0);
-    expect(res2.inExperiment).toEqual(false);
+    expect(res2.inExperiment).toEqual(true);
+    expect(res2.hashUsed).toEqual(false);
     expect(res2.value).toEqual(1);
 
     growthbook.destroy();
@@ -433,8 +436,10 @@ describe("experiments", () => {
 
     expect(res1.value).toEqual(0);
     expect(res1.inExperiment).toEqual(false);
+    expect(res1.hashUsed).toEqual(false);
     expect(res2.value).toEqual(2);
-    expect(res2.inExperiment).toEqual(false);
+    expect(res2.inExperiment).toEqual(true);
+    expect(res2.hashUsed).toEqual(false);
 
     growthbook.destroy();
   });
@@ -533,6 +538,7 @@ describe("experiments", () => {
     };
     const res1 = growthbook.run(exp);
     expect(res1.inExperiment).toEqual(true);
+    expect(res1.hashUsed).toEqual(true);
     expect(res1.value).toEqual(1);
 
     growthbook.setForcedVariations({
@@ -540,12 +546,14 @@ describe("experiments", () => {
     });
 
     const res2 = growthbook.run(exp);
-    expect(res2.inExperiment).toEqual(false);
+    expect(res2.inExperiment).toEqual(true);
+    expect(res2.hashUsed).toEqual(false);
     expect(res2.value).toEqual(0);
 
     growthbook.setForcedVariations({});
     const res3 = growthbook.run(exp);
     expect(res3.inExperiment).toEqual(true);
+    expect(res3.hashUsed).toEqual(true);
     expect(res3.value).toEqual(1);
 
     growthbook.destroy();
@@ -561,12 +569,14 @@ describe("experiments", () => {
 
     const res1 = growthbook.run(exp);
     expect(res1.inExperiment).toEqual(false);
+    expect(res1.hashUsed).toEqual(false);
     expect(res1.value).toEqual(0);
 
     // Still works if explicitly forced
     context.forcedVariations = { "my-test": 1 };
     const res2 = growthbook.run(exp);
-    expect(res2.inExperiment).toEqual(false);
+    expect(res2.inExperiment).toEqual(true);
+    expect(res2.hashUsed).toEqual(false);
     expect(res2.value).toEqual(1);
 
     // Works if the experiment itself is forced
@@ -575,7 +585,8 @@ describe("experiments", () => {
       variations: [0, 1],
       force: 1,
     });
-    expect(res3.inExperiment).toEqual(false);
+    expect(res3.inExperiment).toEqual(true);
+    expect(res3.hashUsed).toEqual(false);
     expect(res3.value).toEqual(1);
 
     growthbook.destroy();
@@ -687,6 +698,17 @@ describe("experiments", () => {
     growthbook.destroy();
 
     expect(window._growthbook).toBeUndefined();
+  });
+
+  it("does not store growthbook in window when disabled", () => {
+    const context: Context = {
+      disableDevTools: true,
+    };
+    const growthbook = new GrowthBook(context);
+
+    expect(window._growthbook).toBeUndefined();
+
+    growthbook.destroy();
   });
 
   it("does not have bias when using namespaces", () => {

--- a/packages/sdk-js/test/json.test.ts
+++ b/packages/sdk-js/test/json.test.ts
@@ -17,7 +17,7 @@ type Cases = {
   // value, hash
   hash: [string, number][];
   // name, context, experiment, value, inExperiment
-  run: [string, Context, Experiment<any>, any, boolean][];
+  run: [string, Context, Experiment<any>, any, boolean, boolean][];
   // name, context, feature key, result
   feature: [string, Context, string, Omit<FeatureResult, "ruleId">][];
   // name, condition, attribute, result
@@ -117,11 +117,12 @@ describe("json test suite", () => {
 
   it.each((cases as Cases).run)(
     "run[%#] %s",
-    (name, ctx, exp, value, inExperiment) => {
+    (name, ctx, exp, value, inExperiment, hashUsed) => {
       const growthbook = new GrowthBook(ctx);
       const res = growthbook.run(exp);
       expect(res.value).toEqual(value);
       expect(res.inExperiment).toEqual(inExperiment);
+      expect(res.hashUsed).toEqual(hashUsed);
       growthbook.destroy();
     }
   );

--- a/packages/sdk-react/package.json
+++ b/packages/sdk-react/package.json
@@ -36,7 +36,7 @@
     "react": "^16.8.0-0 || ^17.0.0-0"
   },
   "dependencies": {
-    "@growthbook/growthbook": "^0.17.0"
+    "@growthbook/growthbook": "^0.17.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.15.4",

--- a/packages/sdk-react/package.json
+++ b/packages/sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@growthbook/growthbook-react",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -33,10 +33,10 @@
   },
   "author": "Jeremy Dorn",
   "peerDependencies": {
-    "react": "^16.8.0-0 || ^17.0.0-0"
+    "react": "^16.8.0-0 || ^17.0.0-0 || ^18.0.0-0"
   },
   "dependencies": {
-    "@growthbook/growthbook": "^0.17.2"
+    "@growthbook/growthbook": "^0.18.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.15.4",

--- a/packages/sdk-react/src/GrowthBookReact.tsx
+++ b/packages/sdk-react/src/GrowthBookReact.tsx
@@ -25,6 +25,7 @@ function run<T>(exp: Experiment<T>, growthbook?: GrowthBook): Result<T> {
       value: exp.variations[0],
       variationId: 0,
       inExperiment: false,
+      hashUsed: false,
       hashAttribute: exp.hashAttribute || "id",
       hashValue: "",
     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4338,9 +4338,9 @@ camelize@^1.0.0:
   integrity sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=
 
 caniuse-lite@^1.0.30001173, caniuse-lite@^1.0.30001179, caniuse-lite@^1.0.30001202, caniuse-lite@^1.0.30001219, caniuse-lite@^1.0.30001230, caniuse-lite@^1.0.30001254:
-  version "1.0.30001283"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001283.tgz"
-  integrity sha512-9RoKo841j1GQFSJz/nCXOj0sD7tHBtlowjYlrqIUS812x9/emfBLBt6IyMz1zIaYc/eRL8Cs6HPUVi2Hzq4sIg==
+  version "1.0.30001342"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001342.tgz"
+  integrity sha512-bn6sOCu7L7jcbBbyNhLg0qzXdJ/PMbybZTH/BA6Roet9wxYRm6Tr9D0s0uhLkOZ6MSG+QU6txUgdpr3MXIVqjA==
 
 caseless@~0.12.0:
   version "0.12.0"


### PR DESCRIPTION
Currently, in the SDKs, experiment results have a boolean `inExperiment` property that is only true when a variation is randomly assigned.  When evaluating a feature, we skip experiment rules when this is false.

This behavior makes sense when an experiment is excluded because of coverage or a namespace.  But, it is unexpected behavior when you force an experiment via a querystring or devtools and then all of a sudden the rule is skipped.

This PR changes the behavior of `inExperiment` to return true even when a value is forced, as long as the user is not excluded by targeting conditions, coverage, namespace, etc..  There is a new boolean property `hashUsed` on results that indicate if the variation was randomly assigned.