### PR TITLE
fix bug for BigQuery intergration

### DIFF
--- a/packages/back-end/src/integrations/BigQuery.ts
+++ b/packages/back-end/src/integrations/BigQuery.ts
@@ -42,7 +42,7 @@ export default class BigQuery extends SqlIntegration {
     return rows;
   }
   toTimestamp(date: Date) {
-    return `DATETIME "${date.toISOString().substr(0, 19).replace("T", " ")}"`;
+    return `DATETIME("${date.toISOString().substr(0, 19).replace("T", " ")}")`;
   }
   addTime(
     col: string,


### PR DESCRIPTION
Experiment builds impracticable BigQuery query for metrics calculation. 
There is a problem with converting string to datetime.
It could be easily fixed with adding brackets.

<img width="799" alt="Screenshot 2022-05-25 at 18 02 00" src="https://user-images.githubusercontent.com/9803147/170306721-2d87ae3e-5d2f-4a93-8bb0-193749533f02.png">
