### PR TITLE
Make old developer roles backwards compatible.

### DIFF
--- a/packages/back-end/src/controllers/organizations.ts
+++ b/packages/back-end/src/controllers/organizations.ts
@@ -12,6 +12,7 @@ import {
   addMemberToOrg,
   validateLogin,
   getPermissionsByRole,
+  updateRole,
 } from "../services/organizations";
 import {
   getSourceIntegrationObject,
@@ -129,7 +130,7 @@ export async function getUser(req: AuthRequest, res: Response) {
     email: req.email,
     admin: !!req.admin,
     organizations: validOrgs.map((org) => {
-      const role = getRole(org, userId) || "readonly";
+      const role = getRole(org, userId);
       return {
         id: org.id,
         name: org.name,
@@ -406,7 +407,7 @@ export async function getOrganization(req: AuthRequest, res: Response) {
 
   const roleMapping: Map<string, MemberRole> = new Map();
   members.forEach((m) => {
-    roleMapping.set(m.id, m.role);
+    roleMapping.set(m.id, updateRole(m.role));
   });
 
   const users = await getUsersByIds(members.map((m) => m.id));

--- a/packages/back-end/src/services/auth.ts
+++ b/packages/back-end/src/services/auth.ts
@@ -169,7 +169,7 @@ export async function processJWT(
 
         const role: MemberRole = req.admin
           ? "admin"
-          : getRole(req.organization, user.id) || "collaborator";
+          : getRole(req.organization, user.id);
         req.permissions = getPermissionsByRole(role);
       } else {
         return res.status(404).json({

--- a/packages/back-end/src/services/organizations.ts
+++ b/packages/back-end/src/services/organizations.ts
@@ -90,12 +90,24 @@ export async function getConfidenceLevelsForOrg(id: string) {
   };
 }
 
+// Handle old roles in a backwards-compatible way
+export function updateRole(role: MemberRole): MemberRole {
+  if (role === "designer") {
+    return "collaborator";
+  }
+  if (role === "developer") {
+    return "experimenter";
+  }
+  return role;
+}
+
 export function getRole(
   org: OrganizationInterface,
   userId: string
-): MemberRole | null {
-  return (
-    org.members.filter((m) => m.id === userId).map((m) => m.role)[0] || null
+): MemberRole {
+  return updateRole(
+    org.members.filter((m) => m.id === userId).map((m) => m.role)[0] ||
+      "readonly"
   );
 }
 
@@ -120,10 +132,7 @@ export function getDefaultPermissions(): Permissions {
 }
 
 export function getPermissionsByRole(role: MemberRole): Permissions {
-  // Handle old, deprecated "designer" role
-  if (role === "designer") {
-    role = "collaborator";
-  }
+  role = updateRole(role);
 
   // Start with no permissions
   const permissions = getDefaultPermissions();
@@ -136,7 +145,7 @@ export function getPermissionsByRole(role: MemberRole): Permissions {
   }
 
   // Feature flag permissions
-  if (role === "developer" || role === "experimenter" || role === "admin") {
+  if (role === "engineer" || role === "experimenter" || role === "admin") {
     permissions.publishFeatures = true;
     permissions.createFeatures = true;
     permissions.createFeatureDrafts = true;

--- a/packages/back-end/types/organization.d.ts
+++ b/packages/back-end/types/organization.d.ts
@@ -24,6 +24,7 @@ export type MemberRole =
   | "designer"
   | "analyst"
   | "developer"
+  | "engineer"
   | "experimenter"
   | "admin";
 

--- a/packages/front-end/components/Settings/RoleSelector.tsx
+++ b/packages/front-end/components/Settings/RoleSelector.tsx
@@ -5,7 +5,7 @@ import { MemberRole } from "back-end/types/organization";
 const roles: [MemberRole, string][] = [
   ["readonly", "View all features and experiment results"],
   ["collaborator", "Add comments and contribute ideas"],
-  ["developer", "Manage features"],
+  ["engineer", "Manage features"],
   ["analyst", "Analyze experiments"],
   ["experimenter", "Manage features AND analyze experiments"],
   [
@@ -18,10 +18,6 @@ const RoleSelector: FC<{
   role: MemberRole;
   setRole: (role: MemberRole) => void;
 }> = ({ role, setRole }) => {
-  if (role === "designer") {
-    role = "collaborator";
-  }
-
   return (
     <div>
       {roles.map(([name, description]) => (


### PR DESCRIPTION
Old 'developer' role had access to metrics/experiments. Create a new 'engineer' role that only has access to feature flags so the 'developer' role can remain backwards compatible.