### PR TITLE
Remove `await` key from fetch promise

### DIFF
--- a/packages/docs/pages/lib/js.mdx
+++ b/packages/docs/pages/lib/js.mdx
@@ -32,7 +32,7 @@ import { GrowthBook } from "@growthbook/growthbook";
 const growthbook = new GrowthBook();
 
 // Load feature definitions (from API, database, etc.)
-await fetch("https://cdn.growthbook.io/api/features/<your api key>")
+fetch("https://cdn.growthbook.io/api/features/<your api key>")
   .then((res) => res.json())
   .then((parsed) => {
     growthbook.setFeatures(parsed.features);


### PR DESCRIPTION
Hi,
I think this is the write way to use fetch (without await key)

```js
fetch('http://example.com/movies.json')
  .then(response => response.json())
  .then(data => console.log(data));
```

https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch