### PR TITLE
Added functionality for archived features

### DIFF
--- a/packages/back-end/src/app.ts
+++ b/packages/back-end/src/app.ts
@@ -507,6 +507,7 @@ app.post(
 );
 app.post("/feature/:id/discard", featuresController.postFeatureDiscard);
 app.post("/feature/:id/publish", featuresController.postFeaturePublish);
+app.put("/feature/:id/archive", featuresController.archiveFeatureById);
 app.post("/feature/:id/toggle", featuresController.postFeatureToggle);
 app.post("/feature/:id/draft", featuresController.postFeatureDraft);
 app.post("/feature/:id/rule", featuresController.postFeatureRule);

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -14,6 +14,7 @@ import { saveRevision } from "./FeatureRevisionModel";
 
 const featureSchema = new mongoose.Schema({
   id: String,
+  archived: Boolean,
   description: String,
   organization: String,
   project: String,
@@ -100,6 +101,14 @@ export async function updateFeature(
       $set: updates,
     }
   );
+}
+
+export async function archiveFeature(
+  organization: string,
+  id: string,
+  isArchived: boolean
+) {
+  await updateFeature(organization, id, { archived: isArchived });
 }
 
 function setEnvironmentSettings(

--- a/packages/back-end/types/feature.d.ts
+++ b/packages/back-end/types/feature.d.ts
@@ -27,6 +27,7 @@ export interface FeatureDraftChanges {
 
 export interface FeatureInterface {
   id: string;
+  archived: boolean;
   description?: string;
   organization: string;
   project?: string;

--- a/packages/front-end/pages/features/[fid].tsx
+++ b/packages/front-end/pages/features/[fid].tsx
@@ -33,6 +33,7 @@ import SortedTags from "../../components/Tags/SortedTags";
 import Modal from "../../components/Modal";
 import HistoryTable from "../../components/HistoryTable";
 import DraftModal from "../../components/Features/DraftModal";
+import ConfirmButton from "../../components/Modal/ConfirmButton";
 import { FaExclamationTriangle } from "react-icons/fa";
 import RevisionDropdown from "../../components/Features/RevisionDropdown";
 
@@ -81,6 +82,7 @@ export default function FeaturePage() {
   const type = data.feature.valueType;
 
   const isDraft = !!data.feature.draft?.active;
+  const isArchived = data.feature.archived;
 
   return (
     <div className="contents container-fluid pagecontents">
@@ -213,11 +215,67 @@ export default function FeaturePage() {
               className="dropdown-item"
               text="Delete feature"
             />
+            {isArchived ? (
+              <ConfirmButton
+                onClick={async () => {
+                  await apiCall(`/feature/${data.feature.id}/archive`, {
+                    method: "PUT",
+                  });
+                  router.push("/features");
+                }}
+                modalHeader="Unarchive Feature"
+                confirmationText={
+                  <>
+                    <p>
+                      Are you sure you want to continue? This will make the
+                      current feature active again.
+                    </p>
+                  </>
+                }
+                cta="Unarchive"
+                ctaColor="danger"
+              >
+                <button className="dropdown-item">Unarchive Feature</button>
+              </ConfirmButton>
+            ) : (
+              <ConfirmButton
+                onClick={async () => {
+                  await apiCall(`/feature/${data.feature.id}/archive`, {
+                    method: "PUT",
+                  });
+                  router.push("/features");
+                }}
+                modalHeader="Archive Feature"
+                confirmationText={
+                  <>
+                    <p>
+                      Are you sure you want to continue? This will make the
+                      current feature unactive.
+                    </p>
+                  </>
+                }
+                cta="Archive"
+                ctaColor="danger"
+              >
+                <button className="dropdown-item">Archive Feature</button>
+              </ConfirmButton>
+            )}
           </MoreMenu>
         </div>
       </div>
 
-      <h1>{fid}</h1>
+      <div className="row align-items-center mb-0">
+        <h1>{fid}</h1>
+        {isArchived && (
+          <div
+            className="badge badge-secondary mx-3 h4 mb-1"
+            style={{ fontSize: "1.1em" }}
+          >
+            {" "}
+            Archived
+          </div>
+        )}
+      </div>
 
       <div className="mb-2 row" style={{ fontSize: "0.8em" }}>
         {projects.length > 0 && (

--- a/packages/front-end/pages/features/index.tsx
+++ b/packages/front-end/pages/features/index.tsx
@@ -29,6 +29,7 @@ import TagsFilter, {
 import { useEnvironments } from "../../services/features";
 import SortedTags from "../../components/Tags/SortedTags";
 import { FaExclamationTriangle } from "react-icons/fa";
+import Toggle from "../../components/Forms/Toggle";
 
 const NUM_PER_PAGE = 20;
 
@@ -41,6 +42,13 @@ export default function FeaturesPage() {
   const end = start + NUM_PER_PAGE;
 
   const { features, loading, error, mutate } = useFeaturesList();
+  let showToggle = false;
+  for (let i = start; i < end; i++) {
+    if (features[i] && features[i].archived) {
+      showToggle = true;
+      break;
+    }
+  }
 
   const showGraphs = useFeature("feature-list-realtime-graphs").on;
   const { usage, usageDomain } = useRealtimeData(
@@ -67,6 +75,7 @@ export default function FeaturesPage() {
   const filtered = filterByTags(list, tagsFilter);
 
   const { sorted, SortableTH } = useSort(filtered, "id", 1);
+  const [showArchived, setShowArchived] = useState(false);
 
   // Reset to page 1 when a filter is applied
   useEffect(() => {
@@ -175,7 +184,18 @@ export default function FeaturesPage() {
             <div className="col">
               <TagsFilter filter={tagsFilter} items={sorted} />
             </div>
+            {showToggle && (
+              <div className="col">
+                <Toggle
+                  value={showArchived}
+                  id="archived"
+                  setValue={setShowArchived}
+                ></Toggle>
+                Show Archived
+              </div>
+            )}
           </div>
+
           <table className="table gbtable table-hover">
             <thead>
               <tr>
@@ -217,12 +237,18 @@ export default function FeaturesPage() {
                 let version = feature.revision?.version || 1;
                 if (isDraft) version++;
 
-                return (
+                return !(!feature.archived || showArchived) ? null : (
                   <tr key={feature.id}>
                     <td>
-                      <Link href={`/features/${feature.id}`}>
-                        <a>{feature.id}</a>
-                      </Link>
+                      {feature.archived ? (
+                        <Link href={`/features/${feature.id}`}>
+                          <a style={{ color: "red" }}>{feature.id}</a>
+                        </Link>
+                      ) : (
+                        <Link href={`/features/${feature.id}`}>
+                          <a>{feature.id}</a>
+                        </Link>
+                      )}
                     </td>
                     <td>
                       <SortedTags tags={feature?.tags || []} />


### PR DESCRIPTION
- Added an archived property to the feature type and database model
- Added a new database model method for setting this property
- Added a new API route that calls this db model method
- Created getUnarchivedFeatureDefinitions function to filter out archived features (There may also be a web hooks issue as it probably should show archive features and it may not)
- Added an action to the feature dropdown on the front end to archive/unarchived a feature
- Added a banner to features that are currently archived
- Wrote archived features in a different color in the features dashboard
- Added a confirmation modal for when archiving/unarchiving features
- Added a toggle on the feature list to include archived features (default off)
