### PR TITLE
Don't use aliases in group by (fixes Presto/Trino/Athena bug)

### DIFF
--- a/packages/back-end/src/integrations/Athena.ts
+++ b/packages/back-end/src/integrations/Athena.ts
@@ -33,4 +33,7 @@ export default class Athena extends SqlIntegration {
   dateDiff(startCol: string, endCol: string) {
     return `date_diff('day', ${startCol}, ${endCol})`;
   }
+  useAliasInGroupBy(): boolean {
+    return false;
+  }
 }

--- a/packages/back-end/src/integrations/Presto.ts
+++ b/packages/back-end/src/integrations/Presto.ts
@@ -81,4 +81,7 @@ export default class Presto extends SqlIntegration {
   dateDiff(startCol: string, endCol: string) {
     return `date_diff('day', ${startCol}, ${endCol})`;
   }
+  useAliasInGroupBy(): boolean {
+    return false;
+  }
 }

--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -127,6 +127,9 @@ export default abstract class SqlIntegration
   castUserDateCol(column: string): string {
     return column;
   }
+  useAliasInGroupBy(): boolean {
+    return true;
+  }
 
   private getExposureQuery(
     exposureQueryId: string,
@@ -551,6 +554,9 @@ export default abstract class SqlIntegration
     const aggregate = this.getAggregateMetricColumn(metric, "m");
 
     const dimensionCol = this.getDimensionColumn(baseIdType, dimension);
+    const dimensionGroupBy = this.useAliasInGroupBy()
+      ? "dimension"
+      : dimensionCol;
 
     return format(
       `-- ${metric.name} (${metric.type})
@@ -666,7 +672,7 @@ export default abstract class SqlIntegration
           }
         ${segment ? `WHERE s.date <= e.conversion_start` : ""}
         GROUP BY
-        ${dimension ? dimensionCol + ", " : ""}e.${baseIdType}${
+        ${dimension ? dimensionGroupBy + ", " : ""}e.${baseIdType}${
         removeMultipleExposures ? "" : ", e.variation"
       }
       )


### PR DESCRIPTION
Use the actual selected expression and not the alias when doing GROUP BYs.

For example, replace this:
```sql
SELECT a.col as value
FROM a
GROUP BY value
```

With this:
```sql
SELECT a.col as value
FROM a
GROUP BY a.col
```

This works around a bug in PrestoDB, TrinoDB, and Athena: https://github.com/prestodb/presto/pull/5581