### PR TITLE
Changed how variation weights are defined and shown in features

### DIFF
--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -13,21 +13,6 @@ import isEqual from "lodash/isEqual";
 function roundVariationWeight(num: number): number {
   return Math.round(num * 1000) / 1000;
 }
-function getTotalVariationWeight(weights: number[]): number {
-  return roundVariationWeight(weights.reduce((sum, w) => sum + w, 0));
-}
-// Adjusts an array of weights so it always sums to exactly 1
-function adjustWeights(weights: number[]): number[] {
-  const diff = getTotalVariationWeight(weights) - 1;
-  const nDiffs = Math.round(Math.abs(diff) * 1000);
-  return weights.map((v, i) => {
-    const j = weights.length - i - 1;
-    let d = 0;
-    if (diff < 0 && i < nDiffs) d = 0.001;
-    else if (diff > 0 && j < nDiffs) d = -0.001;
-    return +(v + d).toFixed(3);
-  });
-}
 
 // eslint-disable-next-line
 function getJSONValue(type: FeatureValueType, value: string): any {
@@ -81,21 +66,12 @@ export async function getFeatureDefinitions(
                 getJSONValue(feature.valueType, v.value)
               );
 
-              const weights = r.values
+              rule.coverage = r.coverage;
+
+              rule.weights = r.values
                 .map((v) => v.weight)
                 .map((w) => (w < 0 ? 0 : w > 1 ? 1 : w))
                 .map((w) => roundVariationWeight(w));
-              const totalWeight = getTotalVariationWeight(weights);
-              if (totalWeight <= 0) {
-                rule.coverage = 0;
-              } else if (totalWeight < 0.999) {
-                rule.coverage = totalWeight;
-              }
-
-              const multiplier = totalWeight > 0 ? 1 / totalWeight : 0;
-              rule.weights = adjustWeights(
-                weights.map((w) => roundVariationWeight(w * multiplier))
-              );
 
               if (r.trackingKey) {
                 rule.key = r.trackingKey;

--- a/packages/back-end/src/util/migrations.ts
+++ b/packages/back-end/src/util/migrations.ts
@@ -14,6 +14,26 @@ import {
 } from "../../types/feature";
 import isEqual from "lodash/isEqual";
 
+function roundVariationWeight(num: number): number {
+  return Math.round(num * 1000) / 1000;
+}
+function getTotalVariationWeight(weights: number[]): number {
+  return roundVariationWeight(weights.reduce((sum, w) => sum + w, 0));
+}
+
+// Adjusts an array of weights so it always sums to exactly 1
+function adjustWeights(weights: number[]): number[] {
+  const diff = getTotalVariationWeight(weights) - 1;
+  const nDiffs = Math.round(Math.abs(diff) * 1000);
+  return weights.map((v, i) => {
+    const j = weights.length - i - 1;
+    let d = 0;
+    if (diff < 0 && i < nDiffs) d = 0.001;
+    else if (diff > 0 && j < nDiffs) d = -0.001;
+    return +(v + d).toFixed(3);
+  });
+}
+
 export function upgradeMetricDoc(doc: MetricInterface): MetricInterface {
   const newDoc = { ...doc };
 
@@ -201,6 +221,46 @@ export function upgradeFeatureInterface(
     "production",
     newFeature
   );
+
+  // Add weights/coverage translation here:
+  for (const env in newFeature.environmentSettings) {
+    if (
+      newFeature.environmentSettings[env] &&
+      newFeature.environmentSettings[env]?.rules
+    ) {
+      newFeature.environmentSettings[
+        env
+      ].rules = newFeature.environmentSettings[env].rules.map((r) => {
+        if (r.type === "experiment") {
+          if (r.coverage !== 0 || !r.coverage) {
+            // old style without coverage, so recreate:
+            const rule = { coverage: 1, ...r };
+            const weights = r.values
+              .map((v) => v.weight)
+              .map((w) => (w < 0 ? 0 : w > 1 ? 1 : w))
+              .map((w) => roundVariationWeight(w));
+            const totalWeight = getTotalVariationWeight(weights);
+            if (totalWeight <= 0) {
+              rule.coverage = 0;
+            } else if (totalWeight < 0.999) {
+              rule.coverage = totalWeight;
+            }
+
+            const multiplier = totalWeight > 0 ? 1 / totalWeight : 0;
+            const adjustedWeights = adjustWeights(
+              weights.map((w) => roundVariationWeight(w * multiplier))
+            );
+
+            rule.values = rule.values.map((v, j) => {
+              return { ...v, weight: adjustedWeights[j] };
+            });
+            return rule;
+          }
+        }
+        return r;
+      });
+    }
+  }
 
   // Ignore drafts if nothing has changed
   if (newFeature.draft?.active && !draftHasChanges(newFeature)) {

--- a/packages/back-end/types/feature.d.ts
+++ b/packages/back-end/types/feature.d.ts
@@ -67,6 +67,7 @@ export interface RolloutRule extends BaseRule {
 type ExperimentValue = {
   value: string;
   weight: number;
+  name?: string;
 };
 
 type NamespaceValue = {
@@ -80,6 +81,7 @@ export interface ExperimentRule extends BaseRule {
   trackingKey: string;
   hashAttribute: string;
   namespace?: NamespaceValue;
+  coverage?: number;
   values: ExperimentValue[];
 }
 

--- a/packages/front-end/components/Features/EnvironmentToggle.tsx
+++ b/packages/front-end/components/Features/EnvironmentToggle.tsx
@@ -56,6 +56,7 @@ export default function EnvironmentToggle({
         setToggling(false);
         mutate();
       }}
+      type="environment"
     />
   );
 }

--- a/packages/front-end/components/Features/ExperimentSplitVisual.module.scss
+++ b/packages/front-end/components/Features/ExperimentSplitVisual.module.scss
@@ -1,0 +1,34 @@
+@import "../../styles/colors.scss";
+
+.legend {
+  font-size: 0.8em;
+  color: $gray1;
+}
+
+.legend_box {
+  width: 14px;
+  height: 14px;
+  display: inline-block;
+  vertical-align: middle;
+  border: 1px solid $gray3;
+}
+
+.previewBar {
+  position: relative;
+  font-size: 0.8em;
+}
+
+.percentMarker {
+  position: absolute;
+  bottom: -8px;
+  height: 8px;
+  width: 100%;
+  text-align: center;
+  border-radius: 0 0 6px 6px;
+  border: 2px solid $gray2;
+  border-top: 0;
+  span {
+    position: relative;
+    bottom: -10px;
+  }
+}

--- a/packages/front-end/components/Features/ExperimentSplitVisual.tsx
+++ b/packages/front-end/components/Features/ExperimentSplitVisual.tsx
@@ -148,7 +148,7 @@ export default function VariationsInput({
                 }}
               >
                 <Tooltip
-                  text={`Unallocated: ${parseFloat(
+                  text={`Not included: ${parseFloat(
                     ((1 - coverage) * 100).toPrecision(5)
                   )}% - users will skip this rule`}
                   style={{ width: "100%", height: "100%" }}

--- a/packages/front-end/components/Features/ExperimentSplitVisual.tsx
+++ b/packages/front-end/components/Features/ExperimentSplitVisual.tsx
@@ -1,0 +1,163 @@
+import clsx from "clsx";
+import styles from "./ExperimentSplitVisual.module.scss";
+import React, { CSSProperties } from "react";
+import { ExperimentValue, FeatureValueType } from "back-end/types/feature";
+import Tooltip from "../Tooltip";
+
+export interface Props {
+  label?: string;
+  unallocated?: string;
+  coverage: number;
+  values: ExperimentValue[];
+  showValues?: boolean;
+  type: FeatureValueType;
+  stackLeft?: boolean;
+  showPercentages?: boolean;
+}
+export default function VariationsInput({
+  label = "Traffic Split Preview",
+  unallocated = "Unallocated",
+  coverage,
+  values,
+  showValues = false,
+  type,
+  stackLeft = false,
+  showPercentages = true,
+}: Props) {
+  let previewLeft = 0;
+
+  return (
+    <>
+      <div className="row">
+        <div className="col">
+          <label>{label}</label>
+        </div>
+        <div className={clsx("col-auto", styles.legend)} />
+        <div className={clsx("col-auto", styles.legend)}>
+          <div
+            className={clsx(
+              styles.legend_box,
+              styles.used,
+              "progress-bar-striped"
+            )}
+            style={{ backgroundColor: "#e0e0e0" }}
+          />{" "}
+          {unallocated}{" "}
+          <strong>
+            ({parseFloat(((1 - coverage) * 100).toPrecision(5)) + "%"})
+          </strong>
+        </div>
+      </div>
+      <div
+        className="position-relative progress-bar-striped mb-5"
+        style={{
+          width: "100%",
+          textAlign: "right",
+          height: 30,
+          backgroundColor: "#e0e0e0",
+        }}
+      >
+        <div className="d-flex flex-row">
+          <div className="w-100 d-flex flex-row">
+            {values.map((val, i) => {
+              const thisLeft = previewLeft;
+              previewLeft += 100 * val.weight;
+              const additionalStyles: CSSProperties = {
+                width: val.weight * coverage * 100 + "%",
+                height: 30,
+              };
+              if (!stackLeft) {
+                additionalStyles.position = "absolute";
+                additionalStyles.left = thisLeft + "%";
+              }
+
+              const variationLabel =
+                (val?.name
+                  ? val.name
+                  : type === "boolean"
+                  ? val.value === "true"
+                    ? "on"
+                    : "off"
+                  : val.value) +
+                " (" +
+                parseFloat((val.weight * coverage * 100).toPrecision(5)) +
+                "%)";
+              return (
+                <div
+                  key={i}
+                  className={`${styles.previewBar} ${
+                    "variationColor" + (i % 9)
+                  }`}
+                  style={additionalStyles}
+                >
+                  <Tooltip
+                    text={variationLabel}
+                    style={{ width: "100%", height: "100%" }}
+                  >
+                    <></>
+                  </Tooltip>
+                  {showPercentages && (
+                    <div className={`${styles.percentMarker}`}>
+                      <span>
+                        {parseFloat(
+                          (val.weight * coverage * 100).toPrecision(5)
+                        ) + "%"}
+                        {showValues && (
+                          <>
+                            {" "}
+                            -{" "}
+                            <strong>
+                              {val?.name
+                                ? val.name
+                                : type === "boolean"
+                                ? val.value === "true"
+                                  ? "on"
+                                  : "off"
+                                : val.value}
+                            </strong>
+                          </>
+                        )}
+                      </span>
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+            {stackLeft && coverage < 1 && (
+              <div
+                className={`${styles.previewBar} unallocated`}
+                style={{
+                  position: "relative",
+                  width: (1 - coverage) * 100 + "%",
+                  height: 30,
+                }}
+              >
+                <Tooltip
+                  text={`Unallocated: ${parseFloat(
+                    ((1 - coverage) * 100).toPrecision(5)
+                  )}% - users will skip this rule`}
+                  style={{ width: "100%", height: "100%" }}
+                >
+                  <></>
+                </Tooltip>
+                {showPercentages && (
+                  <div className={`${styles.percentMarker}`}>
+                    <span>
+                      {parseFloat(((1 - coverage) * 100).toPrecision(5)) + "%"}
+                      {showValues && (
+                        <>
+                          {" "}
+                          - <strong>unallocated</strong>
+                        </>
+                      )}
+                    </span>
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/packages/front-end/components/Features/ExperimentSplitVisual.tsx
+++ b/packages/front-end/components/Features/ExperimentSplitVisual.tsx
@@ -17,7 +17,7 @@ export interface Props {
 }
 export default function VariationsInput({
   label = "Traffic Split Preview",
-  unallocated = "Unallocated",
+  unallocated = "Not included",
   coverage,
   values,
   showValues = false,
@@ -27,7 +27,7 @@ export default function VariationsInput({
 }: Props) {
   let previewLeft = 0;
   const totalWeights = parseFloat(
-    values.reduce((partialSum, v) => partialSum + v.weight, 0).toFixed(2)
+    values.reduce((partialSum, v) => partialSum + v.weight, 0).toFixed(3)
   );
 
   return (
@@ -73,7 +73,7 @@ export default function VariationsInput({
               const thisLeft = previewLeft;
               previewLeft += 100 * val.weight;
               const additionalStyles: CSSProperties = {
-                width: val.weight * coverage * 100 + "%",
+                width: (val.weight ? val.weight * coverage * 100 : 0) + "%",
                 height: 30,
               };
               if (!stackLeft) {
@@ -90,7 +90,9 @@ export default function VariationsInput({
                     : "off"
                   : val.value) +
                 " (" +
-                parseFloat((val.weight * coverage * 100).toPrecision(5)) +
+                parseFloat(
+                  (val.weight ? val.weight * coverage * 100 : 0).toPrecision(5)
+                ) +
                 "%)";
               return (
                 <div
@@ -110,7 +112,10 @@ export default function VariationsInput({
                     <div className={`${styles.percentMarker}`}>
                       <span>
                         {parseFloat(
-                          (val.weight * coverage * 100).toPrecision(5)
+                          (val.weight
+                            ? val.weight * coverage * 100
+                            : 0
+                          ).toPrecision(4)
                         ) + "%"}
                         {showValues && (
                           <>

--- a/packages/front-end/components/Features/ExperimentSplitVisual.tsx
+++ b/packages/front-end/components/Features/ExperimentSplitVisual.tsx
@@ -34,6 +34,8 @@ export default function ExperimentSplitVisual({
     values.reduce((partialSum, v) => partialSum + v.weight, 0).toFixed(3)
   );
 
+  const coverageVal = coverage ? coverage : 0;
+
   return (
     <div className={`${totalWeights > 1 ? "overflow-hidden" : ""}`}>
       <div className="row">
@@ -76,9 +78,11 @@ export default function ExperimentSplitVisual({
           <div className="w-100 d-flex flex-row">
             {values.map((val, i) => {
               const thisLeft = previewLeft;
+              const percentVal =
+                val.weight && coverage ? val.weight * coverage * 100 : 0;
               previewLeft += 100 * val.weight;
               const additionalStyles: CSSProperties = {
-                width: (val.weight ? val.weight * coverage * 100 : 0) + "%",
+                width: percentVal + "%",
                 height: 30,
                 backgroundColor: getVariationColor(i),
               };
@@ -90,7 +94,7 @@ export default function ExperimentSplitVisual({
               const valueDisplay = getVariationDefaultName(val, type);
 
               const variationLabel = `${valueDisplay} (${parseFloat(
-                (val.weight ? val.weight * coverage * 100 : 0).toPrecision(5)
+                percentVal.toPrecision(5)
               )}%)`;
 
               return (
@@ -108,12 +112,7 @@ export default function ExperimentSplitVisual({
                   {showPercentages && (
                     <div className={`${styles.percentMarker}`}>
                       <span>
-                        {parseFloat(
-                          (val.weight
-                            ? val.weight * coverage * 100
-                            : 0
-                          ).toPrecision(4)
-                        ) + "%"}
+                        {parseFloat(percentVal.toPrecision(4)) + "%"}
                         {showValues && (
                           <>
                             {" "}
@@ -126,18 +125,18 @@ export default function ExperimentSplitVisual({
                 </div>
               );
             })}
-            {stackLeft && coverage < 1 && (
+            {stackLeft && coverageVal < 1 && (
               <div
                 className={`${styles.previewBar} unallocated`}
                 style={{
                   position: "relative",
-                  width: (1 - coverage) * 100 + "%",
+                  width: (1 - coverageVal) * 100 + "%",
                   height: 30,
                 }}
               >
                 <Tooltip
                   text={`Not included: ${parseFloat(
-                    ((1 - coverage) * 100).toPrecision(5)
+                    ((1 - coverageVal) * 100).toPrecision(5)
                   )}% - users will skip this rule`}
                   style={{ width: "100%", height: "100%" }}
                 >
@@ -146,7 +145,8 @@ export default function ExperimentSplitVisual({
                 {showPercentages && (
                   <div className={`${styles.percentMarker}`}>
                     <span>
-                      {parseFloat(((1 - coverage) * 100).toPrecision(5)) + "%"}
+                      {parseFloat(((1 - coverageVal) * 100).toPrecision(5)) +
+                        "%"}
                       {showValues && (
                         <>
                           {" "}

--- a/packages/front-end/components/Features/ExperimentSplitVisual.tsx
+++ b/packages/front-end/components/Features/ExperimentSplitVisual.tsx
@@ -44,7 +44,7 @@ export default function ExperimentSplitVisual({
           {totalWeights !== 1 && (
             <span className="ml-2 text-danger">
               <FaExclamationTriangle className="text-danger mr-2" />
-              <span className="">Please adjust weights to sum to 100.</span>
+              <span className="">Please adjust weights to sum to 100%.</span>
             </span>
           )}
         </div>

--- a/packages/front-end/components/Features/ExperimentSplitVisual.tsx
+++ b/packages/front-end/components/Features/ExperimentSplitVisual.tsx
@@ -3,6 +3,7 @@ import styles from "./ExperimentSplitVisual.module.scss";
 import React, { CSSProperties } from "react";
 import { ExperimentValue, FeatureValueType } from "back-end/types/feature";
 import Tooltip from "../Tooltip";
+import { FaExclamationTriangle } from "react-icons/fa";
 
 export interface Props {
   label?: string;
@@ -25,12 +26,21 @@ export default function VariationsInput({
   showPercentages = true,
 }: Props) {
   let previewLeft = 0;
+  const totalWeights = parseFloat(
+    values.reduce((partialSum, v) => partialSum + v.weight, 0).toFixed(2)
+  );
 
   return (
-    <>
+    <div className={`${totalWeights > 1 ? "overflow-hidden" : ""}`}>
       <div className="row">
         <div className="col">
           <label>{label}</label>
+          {totalWeights !== 1 && (
+            <span className="ml-2 text-danger">
+              <FaExclamationTriangle className="text-danger mr-2" />
+              <span className="">Please adjust weights to sum to 100.</span>
+            </span>
+          )}
         </div>
         <div className={clsx("col-auto", styles.legend)} />
         <div className={clsx("col-auto", styles.legend)}>
@@ -158,6 +168,6 @@ export default function VariationsInput({
           </div>
         </div>
       </div>
-    </>
+    </div>
   );
 }

--- a/packages/front-end/components/Features/ExperimentSplitVisual.tsx
+++ b/packages/front-end/components/Features/ExperimentSplitVisual.tsx
@@ -4,6 +4,10 @@ import React, { CSSProperties } from "react";
 import { ExperimentValue, FeatureValueType } from "back-end/types/feature";
 import Tooltip from "../Tooltip";
 import { FaExclamationTriangle } from "react-icons/fa";
+import {
+  getVariationColor,
+  getVariationDefaultName,
+} from "../../services/features";
 
 export interface Props {
   label?: string;
@@ -15,7 +19,7 @@ export interface Props {
   stackLeft?: boolean;
   showPercentages?: boolean;
 }
-export default function VariationsInput({
+export default function ExperimentSplitVisual({
   label = "Traffic Split Preview",
   unallocated = "Not included",
   coverage,
@@ -42,21 +46,22 @@ export default function VariationsInput({
             </span>
           )}
         </div>
-        <div className={clsx("col-auto", styles.legend)} />
-        <div className={clsx("col-auto", styles.legend)}>
-          <div
-            className={clsx(
-              styles.legend_box,
-              styles.used,
-              "progress-bar-striped"
-            )}
-            style={{ backgroundColor: "#e0e0e0" }}
-          />{" "}
-          {unallocated}{" "}
-          <strong>
-            ({parseFloat(((1 - coverage) * 100).toPrecision(5)) + "%"})
-          </strong>
-        </div>
+        {coverage < 1 && (
+          <div className={clsx("col-auto", styles.legend)}>
+            <div
+              className={clsx(
+                styles.legend_box,
+                styles.used,
+                "progress-bar-striped"
+              )}
+              style={{ backgroundColor: "#e0e0e0" }}
+            />{" "}
+            {unallocated}{" "}
+            <strong>
+              ({parseFloat(((1 - coverage) * 100).toPrecision(5)) + "%"})
+            </strong>
+          </div>
+        )}
       </div>
       <div
         className="position-relative progress-bar-striped mb-5"
@@ -75,31 +80,23 @@ export default function VariationsInput({
               const additionalStyles: CSSProperties = {
                 width: (val.weight ? val.weight * coverage * 100 : 0) + "%",
                 height: 30,
+                backgroundColor: getVariationColor(i),
               };
               if (!stackLeft) {
                 additionalStyles.position = "absolute";
                 additionalStyles.left = thisLeft + "%";
               }
 
-              const variationLabel =
-                (val?.name
-                  ? val.name
-                  : type === "boolean"
-                  ? val.value === "true"
-                    ? "on"
-                    : "off"
-                  : val.value) +
-                " (" +
-                parseFloat(
-                  (val.weight ? val.weight * coverage * 100 : 0).toPrecision(5)
-                ) +
-                "%)";
+              const valueDisplay = getVariationDefaultName(val, type);
+
+              const variationLabel = `${valueDisplay} (${parseFloat(
+                (val.weight ? val.weight * coverage * 100 : 0).toPrecision(5)
+              )}%)`;
+
               return (
                 <div
                   key={i}
-                  className={`${styles.previewBar} ${
-                    "variationColor" + (i % 9)
-                  }`}
+                  className={`${styles.previewBar}`}
                   style={additionalStyles}
                 >
                   <Tooltip
@@ -120,16 +117,7 @@ export default function VariationsInput({
                         {showValues && (
                           <>
                             {" "}
-                            -{" "}
-                            <strong>
-                              {val?.name
-                                ? val.name
-                                : type === "boolean"
-                                ? val.value === "true"
-                                  ? "on"
-                                  : "off"
-                                : val.value}
-                            </strong>
+                            - <strong>{valueDisplay}</strong>
                           </>
                         )}
                       </span>

--- a/packages/front-end/components/Features/ExperimentSummary.tsx
+++ b/packages/front-end/components/Features/ExperimentSummary.tsx
@@ -10,7 +10,10 @@ import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
 import { useDefinitions } from "../../services/DefinitionsContext";
 import React, { useState } from "react";
 import NewExperimentForm from "../Experiment/NewExperimentForm";
-import { getExperimentDefinitionFromFeature } from "../../services/features";
+import {
+  getExperimentDefinitionFromFeature,
+  getVariationColor,
+} from "../../services/features";
 import Modal from "../Modal";
 import ExperimentSplitVisual from "./ExperimentSplitVisual";
 
@@ -38,8 +41,6 @@ export default function ExperimentSummary({
   experiment?: ExperimentInterfaceStringDates;
   expRule: ExperimentRule;
 }) {
-  // const totalPercent =
-  //   coverage ?? getTotalVariationWeight(values.map((v) => v.weight));
   const { datasources, metrics } = useDefinitions();
   const [newExpModal, setNewExpModal] = useState(false);
   const [experimentInstructions, setExperimentInstructions] = useState(false);
@@ -142,13 +143,13 @@ export default function ExperimentSummary({
                 style={{ fontSize: "0.9em", width: 25 }}
               >
                 <div
-                  className={`${"variationColor" + (j % 9)}`}
                   style={{
                     width: "6px",
                     position: "absolute",
                     top: 0,
                     bottom: 0,
                     left: 0,
+                    backgroundColor: getVariationColor(j),
                   }}
                 />
                 {j}.

--- a/packages/front-end/components/Features/ExperimentSummary.tsx
+++ b/packages/front-end/components/Features/ExperimentSummary.tsx
@@ -178,7 +178,7 @@ export default function ExperimentSummary({
                 values={values}
                 coverage={coverage}
                 label="Traffic split"
-                unallocated="Unallocated (skips this rule)"
+                unallocated="Not included (skips this rule)"
                 type={type}
                 showValues={false}
                 stackLeft={true}

--- a/packages/front-end/components/Features/ExperimentSummary.tsx
+++ b/packages/front-end/components/Features/ExperimentSummary.tsx
@@ -1,9 +1,4 @@
-import {
-  ExperimentRule,
-  ExperimentValue,
-  FeatureInterface,
-  FeatureValueType,
-} from "back-end/types/feature";
+import { ExperimentRule, FeatureInterface } from "back-end/types/feature";
 import ValueDisplay from "./ValueDisplay";
 import Link from "next/link";
 import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
@@ -23,33 +18,27 @@ const percentFormatter = new Intl.NumberFormat(undefined, {
 });
 
 export default function ExperimentSummary({
-  values,
-  coverage,
-  type,
-  hashAttribute,
-  trackingKey,
+  rule,
   experiment,
   feature,
-  expRule,
 }: {
-  values: ExperimentValue[];
-  coverage: number;
-  type: FeatureValueType;
-  hashAttribute: string;
-  trackingKey: string;
   feature: FeatureInterface;
   experiment?: ExperimentInterfaceStringDates;
-  expRule: ExperimentRule;
+  rule: ExperimentRule;
 }) {
+  const { namespace, coverage, values, hashAttribute, trackingKey } = rule;
+  const type = feature.valueType;
+
   const { datasources, metrics } = useDefinitions();
   const [newExpModal, setNewExpModal] = useState(false);
   const [experimentInstructions, setExperimentInstructions] = useState(false);
 
-  const expDefinition = getExperimentDefinitionFromFeature(feature, expRule);
-  const namespaceRange =
-    expRule?.namespace && expRule?.namespace?.enabled
-      ? expRule.namespace.range[1] - expRule.namespace.range[0]
-      : 1;
+  const expDefinition = getExperimentDefinitionFromFeature(feature, rule);
+
+  const hasNamespace = namespace && namespace.enabled;
+  const namespaceRange = hasNamespace
+    ? namespace.range[1] - namespace.range[0]
+    : 1;
   const effectiveCoverage = namespaceRange * coverage;
 
   return (
@@ -107,14 +96,14 @@ export default function ExperimentSummary({
           {" "}
           users by{" "}
           <span className="mr-1 border px-2 py-1 bg-light rounded">
-            {hashAttribute}
+            {hashAttribute || ""}
           </span>
-          {expRule?.namespace && expRule?.namespace?.enabled && (
+          {hasNamespace && (
             <>
               {" "}
               <span>in the namespace </span>
               <span className="mr-1 border px-2 py-1 bg-light rounded">
-                {expRule.namespace.name}
+                {namespace.name}
               </span>
             </>
           )}
@@ -129,13 +118,11 @@ export default function ExperimentSummary({
             {percentFormatter.format(effectiveCoverage)}
           </span>{" "}
           of users in the experiment
-          {expRule?.namespace && expRule?.namespace?.enabled && (
+          {hasNamespace && (
             <>
-              <span>( </span>
+              <span> (</span>
               <span className="border px-2 py-1 bg-light rounded">
-                {percentFormatter.format(
-                  expRule.namespace.range[1] - expRule.namespace.range[0]
-                )}
+                {percentFormatter.format(namespaceRange)}
               </span>{" "}
               of the namespace and{" "}
               <span className="border px-2 py-1 bg-light rounded">
@@ -209,9 +196,9 @@ export default function ExperimentSummary({
         </div>
         <div className="col">
           {" "}
-          the split with the key{" "}
+          the result using the key{" "}
           <span className="mr-1 border px-2 py-1 bg-light rounded">
-            {trackingKey}
+            {trackingKey || feature.id}
           </span>{" "}
         </div>
         <div className="col-auto">

--- a/packages/front-end/components/Features/ExperimentSummary.tsx
+++ b/packages/front-end/components/Features/ExperimentSummary.tsx
@@ -46,6 +46,10 @@ export default function ExperimentSummary({
   const [experimentInstructions, setExperimentInstructions] = useState(false);
 
   const expDefinition = getExperimentDefinitionFromFeature(feature, expRule);
+  const namespaceRange = expRule?.namespace
+    ? expRule.namespace.range[1] - expRule.namespace.range[0]
+    : 1;
+  const effectiveCoverage = namespaceRange * coverage;
 
   return (
     <div>
@@ -107,13 +111,7 @@ export default function ExperimentSummary({
           {expRule?.namespace && expRule?.namespace?.enabled && (
             <>
               {" "}
-              <span>and include </span>
-              <span className="mr-1 border px-2 py-1 bg-light rounded">
-                {percentFormatter.format(
-                  expRule.namespace.range[1] - expRule.namespace.range[0]
-                )}
-              </span>{" "}
-              <span>of the namespace </span>
+              <span>in the namespace </span>
               <span className="mr-1 border px-2 py-1 bg-light rounded">
                 {expRule.namespace.name}
               </span>
@@ -127,9 +125,24 @@ export default function ExperimentSummary({
         </div>
         <div className="col-auto">
           <span className="mr-1 border px-2 py-1 bg-light rounded">
-            {percentFormatter.format(coverage)}
+            {percentFormatter.format(effectiveCoverage)}
           </span>{" "}
-          of users
+          of users in the experiment
+          {expRule?.namespace && expRule?.namespace?.enabled && (
+            <>
+              <span>( </span>
+              <span className="border px-2 py-1 bg-light rounded">
+                {percentFormatter.format(
+                  expRule.namespace.range[1] - expRule.namespace.range[0]
+                )}
+              </span>{" "}
+              of the namespace and{" "}
+              <span className="border px-2 py-1 bg-light rounded">
+                {percentFormatter.format(coverage)}
+              </span>
+              <span> exposure)</span>
+            </>
+          )}
         </div>
       </div>
       <strong>SERVE</strong>
@@ -177,7 +190,7 @@ export default function ExperimentSummary({
             <td colSpan={4}>
               <ExperimentSplitVisual
                 values={values}
-                coverage={coverage}
+                coverage={effectiveCoverage}
                 label="Traffic split"
                 unallocated="Not included (skips this rule)"
                 type={type}

--- a/packages/front-end/components/Features/ExperimentSummary.tsx
+++ b/packages/front-end/components/Features/ExperimentSummary.tsx
@@ -46,9 +46,10 @@ export default function ExperimentSummary({
   const [experimentInstructions, setExperimentInstructions] = useState(false);
 
   const expDefinition = getExperimentDefinitionFromFeature(feature, expRule);
-  const namespaceRange = expRule?.namespace
-    ? expRule.namespace.range[1] - expRule.namespace.range[0]
-    : 1;
+  const namespaceRange =
+    expRule?.namespace && expRule?.namespace?.enabled
+      ? expRule.namespace.range[1] - expRule.namespace.range[0]
+      : 1;
   const effectiveCoverage = namespaceRange * coverage;
 
   return (

--- a/packages/front-end/components/Features/FeatureModal.tsx
+++ b/packages/front-end/components/Features/FeatureModal.tsx
@@ -215,7 +215,7 @@ export default function FeatureModal({ close, onSuccess }: Props) {
           } else if (rule.type === "experiment") {
             const otherVal = getDefaultVariationValue(defaultValue);
             form.setValue("defaultValue", otherVal);
-
+            form.setValue("rule.coverage", 1);
             if (val === "boolean") {
               form.setValue("rule.values", [
                 {

--- a/packages/front-end/components/Features/FeatureModal.tsx
+++ b/packages/front-end/components/Features/FeatureModal.tsx
@@ -184,6 +184,7 @@ export default function FeatureModal({ close, onSuccess }: Props) {
                   environmentSettings[env.id].enabled = on;
                   form.setValue("environmentSettings", environmentSettings);
                 }}
+                type="environment"
               />
             </div>
           </div>
@@ -309,7 +310,6 @@ export default function FeatureModal({ close, onSuccess }: Props) {
           form={form}
           field="defaultValue"
           valueType={valueType}
-          type="secondary"
         />
       ) : rule?.type === "rollout" ? (
         <>
@@ -333,14 +333,12 @@ export default function FeatureModal({ close, onSuccess }: Props) {
             form={form}
             field="rule.value"
             valueType={valueType}
-            type="secondary"
           />
           <FeatureValueField
             label={"Fallback value"}
             form={form}
             field="defaultValue"
             valueType={valueType}
-            type="secondary"
           />
         </>
       ) : rule?.type === "force" ? (
@@ -362,7 +360,6 @@ export default function FeatureModal({ close, onSuccess }: Props) {
             form={form}
             field="defaultValue"
             valueType={valueType}
-            type="secondary"
           />
         </>
       ) : (
@@ -401,7 +398,6 @@ export default function FeatureModal({ close, onSuccess }: Props) {
             form={form}
             field="defaultValue"
             valueType={valueType}
-            type="secondary"
           />
         </>
       )}

--- a/packages/front-end/components/Features/FeatureModal.tsx
+++ b/packages/front-end/components/Features/FeatureModal.tsx
@@ -309,6 +309,7 @@ export default function FeatureModal({ close, onSuccess }: Props) {
           form={form}
           field="defaultValue"
           valueType={valueType}
+          type="secondary"
         />
       ) : rule?.type === "rollout" ? (
         <>
@@ -332,12 +333,14 @@ export default function FeatureModal({ close, onSuccess }: Props) {
             form={form}
             field="rule.value"
             valueType={valueType}
+            type="secondary"
           />
           <FeatureValueField
             label={"Fallback value"}
             form={form}
             field="defaultValue"
             valueType={valueType}
+            type="secondary"
           />
         </>
       ) : rule?.type === "force" ? (
@@ -359,6 +362,7 @@ export default function FeatureModal({ close, onSuccess }: Props) {
             form={form}
             field="defaultValue"
             valueType={valueType}
+            type="secondary"
           />
         </>
       ) : (
@@ -397,6 +401,7 @@ export default function FeatureModal({ close, onSuccess }: Props) {
             form={form}
             field="defaultValue"
             valueType={valueType}
+            type="secondary"
           />
         </>
       )}

--- a/packages/front-end/components/Features/FeatureModal.tsx
+++ b/packages/front-end/components/Features/FeatureModal.tsx
@@ -222,7 +222,7 @@ export default function FeatureModal({ close, onSuccess }: Props) {
                 {
                   value: otherVal,
                   weight: 0.5,
-                  name: "Control",
+                  name: "",
                 },
                 {
                   value: defaultValue,

--- a/packages/front-end/components/Features/FeatureModal.tsx
+++ b/packages/front-end/components/Features/FeatureModal.tsx
@@ -221,10 +221,12 @@ export default function FeatureModal({ close, onSuccess }: Props) {
                 {
                   value: otherVal,
                   weight: 0.5,
+                  name: "Control",
                 },
                 {
                   value: defaultValue,
                   weight: 0.5,
+                  name: "",
                 },
               ]);
             } else {

--- a/packages/front-end/components/Features/FeatureValueField.tsx
+++ b/packages/front-end/components/Features/FeatureValueField.tsx
@@ -1,6 +1,7 @@
 import { UseFormReturn } from "react-hook-form";
 import { FeatureValueType } from "back-end/types/feature";
 import Field from "../Forms/Field";
+import Toggle from "../Forms/Toggle";
 
 export interface Props {
   valueType: FeatureValueType;
@@ -23,30 +24,16 @@ export default function FeatureValueField({
       <div className="form-group">
         <label>{label}</label>
         <div>
-          <div className="form-check form-check-inline">
-            <input
-              className="form-check-input"
-              type="radio"
-              {...form.register(field)}
-              id={field + "__off"}
-              value="false"
-            />
-            <label className="form-check-label" htmlFor={field + "__off"}>
-              OFF
-            </label>
-          </div>
-          <div className="form-check form-check-inline">
-            <input
-              className="form-check-input"
-              type="radio"
-              {...form.register(field)}
-              id={field + "__on"}
-              value="true"
-            />
-            <label className="form-check-label" htmlFor={field + "__on"}>
-              ON
-            </label>
-          </div>
+          <Toggle
+            id={field + "__toggle"}
+            value={form.watch(field) === "true"}
+            setValue={(v) => {
+              form.setValue(field, v ? "true" : "false");
+            }}
+          />
+          <span className="text-muted pl-2">
+            <strong>{form.watch(field) === "true" ? "on" : "off"}</strong>
+          </span>
         </div>
       </div>
     );

--- a/packages/front-end/components/Features/FeatureValueField.tsx
+++ b/packages/front-end/components/Features/FeatureValueField.tsx
@@ -19,7 +19,6 @@ export default function FeatureValueField({
   form,
   field,
   helpText,
-  type = "primary",
 }: Props) {
   if (valueType === "boolean") {
     return (
@@ -32,7 +31,7 @@ export default function FeatureValueField({
             setValue={(v) => {
               form.setValue(field, v ? "true" : "false");
             }}
-            type={type}
+            type="featureValue"
           />
           <span className="text-muted pl-2">
             <strong>{form.watch(field) === "true" ? "on" : "off"}</strong>

--- a/packages/front-end/components/Features/FeatureValueField.tsx
+++ b/packages/front-end/components/Features/FeatureValueField.tsx
@@ -10,6 +10,7 @@ export interface Props {
   form: UseFormReturn<any>;
   field: string;
   helpText?: string;
+  type?: string;
 }
 
 export default function FeatureValueField({
@@ -18,6 +19,7 @@ export default function FeatureValueField({
   form,
   field,
   helpText,
+  type = "primary",
 }: Props) {
   if (valueType === "boolean") {
     return (
@@ -30,6 +32,7 @@ export default function FeatureValueField({
             setValue={(v) => {
               form.setValue(field, v ? "true" : "false");
             }}
+            type={type}
           />
           <span className="text-muted pl-2">
             <strong>{form.watch(field) === "true" ? "on" : "off"}</strong>

--- a/packages/front-end/components/Features/Rule.tsx
+++ b/packages/front-end/components/Features/Rule.tsx
@@ -52,9 +52,7 @@ export const Rule = forwardRef<HTMLDivElement, RuleProps>(
     const title =
       rule.description ||
       rule.type[0].toUpperCase() + rule.type.slice(1) + " Rule";
-
     const rules = getRules(feature, environment);
-
     const environments = useEnvironments();
 
     return (
@@ -238,6 +236,7 @@ export const Rule = forwardRef<HTMLDivElement, RuleProps>(
             {rule.type === "experiment" && (
               <ExperimentSummary
                 values={rule.values}
+                coverage={rule.coverage}
                 type={type}
                 feature={feature}
                 experiment={experiments[rule.trackingKey || feature.id]}

--- a/packages/front-end/components/Features/Rule.tsx
+++ b/packages/front-end/components/Features/Rule.tsx
@@ -235,14 +235,9 @@ export const Rule = forwardRef<HTMLDivElement, RuleProps>(
             )}
             {rule.type === "experiment" && (
               <ExperimentSummary
-                values={rule.values}
-                coverage={rule.coverage}
-                type={type}
                 feature={feature}
                 experiment={experiments[rule.trackingKey || feature.id]}
-                hashAttribute={rule.hashAttribute || ""}
-                trackingKey={rule.trackingKey || feature.id}
-                expRule={rule}
+                rule={rule}
               />
             )}
           </div>

--- a/packages/front-end/components/Features/RuleModal.tsx
+++ b/packages/front-end/components/Features/RuleModal.tsx
@@ -156,7 +156,6 @@ export default function RuleModal({
           form={form}
           field="value"
           valueType={feature.valueType}
-          type="secondary"
         />
       )}
       {type === "rollout" && (
@@ -166,7 +165,6 @@ export default function RuleModal({
             form={form}
             field="value"
             valueType={feature.valueType}
-            type="secondary"
           />
           <RolloutPercentInput
             value={form.watch("coverage")}

--- a/packages/front-end/components/Features/RuleModal.tsx
+++ b/packages/front-end/components/Features/RuleModal.tsx
@@ -156,6 +156,7 @@ export default function RuleModal({
           form={form}
           field="value"
           valueType={feature.valueType}
+          type="secondary"
         />
       )}
       {type === "rollout" && (
@@ -165,6 +166,7 @@ export default function RuleModal({
             form={form}
             field="value"
             valueType={feature.valueType}
+            type="secondary"
           />
           <RolloutPercentInput
             value={form.watch("coverage")}

--- a/packages/front-end/components/Features/RuleModal.tsx
+++ b/packages/front-end/components/Features/RuleModal.tsx
@@ -52,7 +52,6 @@ export default function RuleModal({
   const form = useForm({
     defaultValues,
   });
-
   const { apiCall } = useAuth();
 
   const type = form.watch("type");

--- a/packages/front-end/components/Features/VariationsInput.module.scss
+++ b/packages/front-end/components/Features/VariationsInput.module.scss
@@ -1,0 +1,27 @@
+@import "../../styles/colors.scss";
+
+.variationSplitHeader {
+  th {
+    background-color: #f3f3f3;
+  }
+}
+.colorMarker {
+  width: 6px;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+}
+
+.percentInput {
+  width: 5.5em;
+}
+.percentInputWrap {
+  span {
+    position: absolute;
+    right: 25px;
+    top: 7px;
+    z-index: 10000;
+    color: $gray-600;
+  }
+}

--- a/packages/front-end/components/Features/VariationsInput.module.scss
+++ b/packages/front-end/components/Features/VariationsInput.module.scss
@@ -19,7 +19,7 @@
 .percentInputWrap {
   span {
     position: absolute;
-    right: 25px;
+    right: 26px;
     top: 7px;
     z-index: 10000;
     color: $gray-600;

--- a/packages/front-end/components/Features/VariationsInput.module.scss
+++ b/packages/front-end/components/Features/VariationsInput.module.scss
@@ -14,7 +14,7 @@
 }
 
 .percentInput {
-  width: 5.5em;
+  width: 6em;
 }
 .percentInputWrap {
   span {

--- a/packages/front-end/components/Features/VariationsInput.tsx
+++ b/packages/front-end/components/Features/VariationsInput.tsx
@@ -235,6 +235,7 @@ export default function VariationsInput({
                 <tr key={i}>
                   <td style={{ width: 45 }} className="position-relative pl-3">
                     <div
+                      className={styles.colorMarker}
                       style={{
                         backgroundColor: getVariationColor(i),
                       }}

--- a/packages/front-end/components/Features/VariationsInput.tsx
+++ b/packages/front-end/components/Features/VariationsInput.tsx
@@ -31,18 +31,18 @@ function getEqualWeights(n: number): number[] {
       let d = 0;
       if (diff < 0 && i < nDiffs) d = 0.001;
       else if (diff > 0 && j < nDiffs) d = -0.001;
-      return +(w + d).toFixed(2);
+      return +(w + d).toFixed(3);
     });
 }
 
 function percentToDecimal(val: string): number {
-  return parseFloat((parseFloat(val) / 100).toFixed(2));
+  return parseFloat((parseFloat(val) / 100).toFixed(3));
 }
 function decimalToPercent(val: string): number {
-  return Math.round(parseFloat(val) * 100);
+  return parseFloat((parseFloat(val) * 100).toFixed(1));
 }
 function floatRound(val: number): number {
-  return parseFloat(val.toFixed(2));
+  return parseFloat(val.toFixed(3));
 }
 
 function getWeightExcept(variationValues: ExperimentValue[], i): number {
@@ -86,7 +86,6 @@ export default function VariationsInput({
   const rebalance = (i: number) => {
     const newValue = form.watch(`${formPrefix}values.${i}.weight`);
     const currentTotal = getWeightExcept(variationValues, i) + newValue;
-
     const nextValue = floatRound(
       parseFloat(
         form.watch(
@@ -227,6 +226,7 @@ export default function VariationsInput({
                       form={form}
                       field={`${formPrefix}values.${i}.value`}
                       valueType={valueType}
+                      type="secondary"
                     />
                   </td>
                   <td>
@@ -240,10 +240,9 @@ export default function VariationsInput({
                       {customSplit ? (
                         <div className="col d-flex flex-row">
                           <input
-                            value={(
-                              form.watch(`${formPrefix}values.${i}.weight`) *
-                              100
-                            ).toFixed(0)}
+                            value={decimalToPercent(
+                              form.watch(`${formPrefix}values.${i}.weight`)
+                            )}
                             onChange={(e) => {
                               form.setValue(
                                 `${formPrefix}values.${i}.weight`,
@@ -278,7 +277,7 @@ export default function VariationsInput({
                               type="number"
                               min={0}
                               max={100}
-                              step="1"
+                              step="0.1"
                               className={styles.percentInput}
                             />
                             <span>%</span>
@@ -286,9 +285,9 @@ export default function VariationsInput({
                         </div>
                       ) : (
                         <div className="col d-flex flex-row">
-                          {parseFloat(
+                          {decimalToPercent(
                             form.watch(`${formPrefix}values.${i}.weight`)
-                          ) * 100}
+                          )}
                           %
                         </div>
                       )}

--- a/packages/front-end/components/Features/VariationsInput.tsx
+++ b/packages/front-end/components/Features/VariationsInput.tsx
@@ -310,31 +310,34 @@ export default function VariationsInput({
                 </tr>
               );
             })}
-            {valueType !== "boolean" && (
+            {(valueType !== "boolean" || !isEqualWeights) && (
               <tr>
                 <td colSpan={4}>
                   <div className="row">
                     <div className="col">
-                      <a
-                        className="btn btn-outline-primary"
-                        href="#"
-                        onClick={(e) => {
-                          e.preventDefault();
-                          values.append({
-                            value: getDefaultVariationValue(defaultValue),
-                            weight: 0,
-                          });
-                        }}
-                      >
-                        <span
-                          className={`h4 pr-2 m-0 d-inline-block align-top`}
+                      {valueType !== "boolean" && (
+                        <a
+                          className="btn btn-outline-primary"
+                          href="#"
+                          onClick={(e) => {
+                            e.preventDefault();
+                            values.append({
+                              value: getDefaultVariationValue(defaultValue),
+                              weight: 0,
+                            });
+                          }}
                         >
-                          <GBAddCircle />
-                        </span>
-                        add another variation
-                      </a>
+                          <span
+                            className={`h4 pr-2 m-0 d-inline-block align-top`}
+                          >
+                            <GBAddCircle />
+                          </span>
+                          add another variation
+                        </a>
+                      )}
                     </div>
-                    <div className="col-auto">
+
+                    <div className="col-auto text-right">
                       <a
                         href="#"
                         onClick={(e) => {

--- a/packages/front-end/components/Forms/Toggle.tsx
+++ b/packages/front-end/components/Forms/Toggle.tsx
@@ -6,14 +6,14 @@ export default function Toggle({
   label = "",
   id,
   disabled = false,
-  type = "primary",
+  type = "toggle",
 }: {
   id: string;
   value: boolean;
   label?: string | ReactElement;
   setValue: (value: boolean) => void;
   disabled?: boolean;
-  type?: string;
+  type?: "featureValue" | "environment" | "toggle";
 }) {
   return (
     <div

--- a/packages/front-end/components/Forms/Toggle.tsx
+++ b/packages/front-end/components/Forms/Toggle.tsx
@@ -6,15 +6,19 @@ export default function Toggle({
   label = "",
   id,
   disabled = false,
+  type = "primary",
 }: {
   id: string;
   value: boolean;
   label?: string | ReactElement;
   setValue: (value: boolean) => void;
   disabled?: boolean;
+  type?: string;
 }) {
   return (
-    <div className={`toggle-switch ${disabled ? "disabled" : ""}`}>
+    <div
+      className={`toggle-switch ${disabled ? "disabled" : ""} toggle-${type}`}
+    >
       <input
         type="checkbox"
         id={id}

--- a/packages/front-end/services/features.ts
+++ b/packages/front-end/services/features.ts
@@ -283,12 +283,15 @@ export function getDefaultRuleValue({
         {
           value: defaultValue,
           weight: 0.5,
+          name: "Control",
         },
         {
           value: value,
           weight: 0.5,
+          name: "",
         },
       ],
+      coverage: 1,
       namespace: {
         enabled: false,
         name: "",
@@ -601,7 +604,9 @@ export function getExperimentDefinitionFromFeature(
     description: `Experiment analysis for the feature [**${feature.id}**](/features/${feature.id})`,
     variations: expRule.values.map((v, i) => {
       let name = i ? `Variation ${i}` : "Control";
-      if (feature.valueType === "boolean") {
+      if (v?.name) {
+        name = v.name;
+      } else if (feature.valueType === "boolean") {
         name = v.value === "true" ? "On" : "Off";
       }
       return {

--- a/packages/front-end/services/features.ts
+++ b/packages/front-end/services/features.ts
@@ -90,15 +90,19 @@ export function getVariationDefaultName(
   val: ExperimentValue,
   type: FeatureValueType
 ) {
-  return val.name
-    ? val.name
-    : type === "boolean"
-    ? val.value === "true"
-      ? "on"
-      : "off"
-    : type === "json"
-    ? val.name
-    : val.value;
+  if (val.name) {
+    return val.name;
+  }
+
+  if (type === "boolean") {
+    return val.value === "true" ? "On" : "Off";
+  }
+
+  if (type === "json") {
+    return "";
+  }
+
+  return val.value;
 }
 
 type NamespaceGaps = { start: number; end: number }[];
@@ -626,8 +630,6 @@ export function getExperimentDefinitionFromFeature(
     return null;
   }
 
-  const totalPercent = expRule.values.reduce((sum, w) => sum + w.weight, 0);
-
   const expDefinition: Partial<ExperimentInterfaceStringDates> = {
     trackingKey: trackingKey,
     name: trackingKey + " experiment",
@@ -648,10 +650,8 @@ export function getExperimentDefinitionFromFeature(
     }),
     phases: [
       {
-        coverage: totalPercent,
-        variationWeights: expRule.values.map((v) =>
-          totalPercent > 0 ? v.weight / totalPercent : 1 / expRule.values.length
-        ),
+        coverage: expRule.coverage || 1,
+        variationWeights: expRule.values.map((v) => v.weight),
         phase: "main",
         reason: "",
         dateStarted: new Date().toISOString(),

--- a/packages/front-end/services/features.ts
+++ b/packages/front-end/services/features.ts
@@ -6,6 +6,7 @@ import {
 } from "back-end/types/organization";
 import {
   ExperimentRule,
+  ExperimentValue,
   FeatureInterface,
   FeatureRule,
   FeatureValueType,
@@ -85,6 +86,19 @@ export function getTotalVariationWeight(weights: number[]): number {
   return roundVariationWeight(weights.reduce((sum, w) => sum + w, 0));
 }
 
+export function getVariationDefaultName(
+  val: ExperimentValue,
+  type: FeatureValueType
+) {
+  return val.name
+    ? val.name
+    : type === "boolean"
+    ? val.value === "true"
+      ? "on"
+      : "off"
+    : val.value;
+}
+
 type NamespaceGaps = { start: number; end: number }[];
 export function findGaps(
   namespaces: NamespaceUsage,
@@ -135,6 +149,21 @@ export function useFeaturesList(withProject = true) {
     error,
     mutate,
   };
+}
+
+export function getVariationColor(i: number) {
+  const colors = [
+    "#8f66dc",
+    "#e5a6f3",
+    "#38aecc",
+    "#f5dd90",
+    "#3383ec",
+    "#80c17b",
+    "#79c4e0",
+    "#f87a7a",
+    "#6cc160",
+  ];
+  return colors[i % colors.length];
 }
 
 export function useAttributeSchema() {
@@ -283,7 +312,7 @@ export function getDefaultRuleValue({
         {
           value: defaultValue,
           weight: 0.5,
-          name: "Control",
+          name: "",
         },
         {
           value: value,

--- a/packages/front-end/services/features.ts
+++ b/packages/front-end/services/features.ts
@@ -96,6 +96,8 @@ export function getVariationDefaultName(
     ? val.value === "true"
       ? "on"
       : "off"
+    : type === "json"
+    ? val.name
     : val.value;
 }
 

--- a/packages/front-end/styles/global.scss
+++ b/packages/front-end/styles/global.scss
@@ -794,6 +794,9 @@ pre {
   input:checked + label {
     background: $purple;
   }
+  &.toggle-secondary input:checked + label {
+    background: $blue;
+  }
 
   label:active:after {
     width: 30px;

--- a/packages/front-end/styles/global.scss
+++ b/packages/front-end/styles/global.scss
@@ -431,34 +431,6 @@ pre {
   }
 }
 
-.variationColor0 {
-  background-color: #8f66dc;
-}
-.variationColor1 {
-  background-color: #e5a6f3;
-}
-.variationColor2 {
-  background-color: #38aecc;
-}
-.variationColor3 {
-  background-color: #f5dd90;
-}
-.variationColor4 {
-  background-color: #3383ec;
-}
-.variationColor5 {
-  background-color: #80c17b;
-}
-.variationColor6 {
-  background-color: #79c4e0;
-}
-.variationColor7 {
-  background-color: #f87a7a;
-}
-.variationColor8 {
-  background-color: #6cc160;
-}
-
 .app-sidebar-header {
   .selected {
     background-color: $purple;
@@ -794,7 +766,7 @@ pre {
   input:checked + label {
     background: $purple;
   }
-  &.toggle-secondary input:checked + label {
+  &.toggle-featureValue input:checked + label {
     background: $blue;
   }
 

--- a/packages/front-end/styles/global.scss
+++ b/packages/front-end/styles/global.scss
@@ -431,6 +431,34 @@ pre {
   }
 }
 
+.variationColor0 {
+  background-color: #8f66dc;
+}
+.variationColor1 {
+  background-color: #e5a6f3;
+}
+.variationColor2 {
+  background-color: #38aecc;
+}
+.variationColor3 {
+  background-color: #f5dd90;
+}
+.variationColor4 {
+  background-color: #3383ec;
+}
+.variationColor5 {
+  background-color: #80c17b;
+}
+.variationColor6 {
+  background-color: #79c4e0;
+}
+.variationColor7 {
+  background-color: #f87a7a;
+}
+.variationColor8 {
+  background-color: #6cc160;
+}
+
 .app-sidebar-header {
   .selected {
     background-color: $purple;


### PR DESCRIPTION
* Added an overall exposure slider to the A/B test modal
* Changed from decimal to percent
* Added visualization of the traffic split
* Added name to variations

TODO:
- [x] Add test cases for new feature migration code
- [x] Error when deleting the input value for coverage
- [x] Error when deleting the input value for variation weight
- [x] When deleting a variation, the other weights don't rebalance so the sum doesn't add to 1
- [x] When unchecking "Customize Split" do we want to reset weights to equal?