### PR TITLE
Fixes #246

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ coverage.xml
 .coverage
 .tox
 .ipynb_checkpoints
+
+# Python virtual environment
+venv/

--- a/packages/stats/gbstats/bayesian/constants.py
+++ b/packages/stats/gbstats/bayesian/constants.py
@@ -1,0 +1,3 @@
+BETA_PRIOR = 1, 1
+NORM_PRIOR = 0, 1, 0
+EPSILON = 1e-04

--- a/packages/stats/gbstats/bayesian/dists.py
+++ b/packages/stats/gbstats/bayesian/dists.py
@@ -4,8 +4,7 @@ import numpy as np
 from scipy.stats import beta, norm, rv_continuous
 from scipy.special import digamma, polygamma, roots_hermitenorm
 from .orthogonal import roots_sh_jacobi
-
-EPSILON = 1e-04
+from gbstats.bayesian.constants import EPSILON
 
 
 class BayesABDist(ABC):

--- a/packages/stats/gbstats/bayesian/main.py
+++ b/packages/stats/gbstats/bayesian/main.py
@@ -1,6 +1,8 @@
 import numpy as np
 from scipy.stats import norm
+from typing import Tuple, Dict, Union, List
 from .dists import Beta, Norm
+from gbstats.bayesian.constants import BETA_PRIOR, NORM_PRIOR, EPSILON
 
 
 """
@@ -10,10 +12,6 @@ Medium article inspiration:
 Original code:
     https://github.com/itamarfaran/public-sandbox/tree/master/bayesian_blog
 """
-
-
-BETA_PRIOR = 1, 1
-NORM_PRIOR = 0, 1, 0
 
 
 def binomial_ab_test(x_a, n_a, x_b, n_b, ccr=0.05):
@@ -44,17 +42,14 @@ def binomial_ab_test(x_a, n_a, x_b, n_b, ccr=0.05):
 
 def gaussian_ab_test(m_a, s_a, n_a, m_b, s_b, n_b, ccr=0.05):
     # Hacky fix to avoid divide by zero errors
-    if np.amin(s_a) <= 0 or np.amin(s_b) <= 0:
-        return {
-            "chance_to_win": 0.5,
-            "expected": 0,
-            "ci": [0, 0],
-            "uplift": {"dist": "lognormal", "mean": 0, "stddev": 0},
-            "risk": [0, 0],
-        }
+    if not _is_std_dev_positive((s_a, s_b)):
+        return _default_output()
 
     mu_a, sd_a = Norm.posterior(NORM_PRIOR, [m_a, s_a, n_a])
     mu_b, sd_b = Norm.posterior(NORM_PRIOR, [m_b, s_b, n_b])
+
+    if _is_log_approximation_inexact(((mu_a, sd_a), (mu_b, sd_b))):
+        return _default_output()
 
     mean_a, var_a = Norm.moments(mu_a, sd_a, log=True)
     mean_b, var_b = Norm.moments(mu_b, sd_b, log=True)
@@ -76,3 +71,36 @@ def gaussian_ab_test(m_a, s_a, n_a, m_b, s_b, n_b, ccr=0.05):
     }
 
     return output
+
+
+def _is_std_dev_positive(std_devs: Tuple[float, float]) -> bool:
+    """Check if all standard deviations are positive
+
+    :param Tuple[float, float] std_devs: A tuple of standard deviations (s_a, s_b)
+    """
+    return all([std_dev > 0 for std_dev in std_devs])
+
+
+def _is_log_approximation_inexact(
+    mean_std_dev_pairs: Tuple[Tuple[float, float], Tuple[float, float]]
+) -> bool:
+    """Check if any mean-standard deviation pair yields an inexact approximation
+    due to a high probability of being negative.
+
+    :param Tuple[Tuple[float, float], Tuple[float, float]] mean_std_dev_pairs:
+        A tuple of (mean, standard deviation) tuples.
+    """
+    return any([norm.cdf(0, pair[0], pair[1]) > EPSILON for pair in mean_std_dev_pairs])
+
+
+def _default_output() -> Dict[str, Union[float, List, Dict]]:
+    """Return uninformative output when AB test analysis can't be performed
+    adequately
+    """
+    return {
+        "chance_to_win": 0.5,
+        "expected": 0,
+        "ci": [0, 0],
+        "uplift": {"dist": "lognormal", "mean": 0, "stddev": 0},
+        "risk": [0, 0],
+    }

--- a/packages/stats/tests/test_main.py
+++ b/packages/stats/tests/test_main.py
@@ -60,6 +60,25 @@ class TestNorm(TestCase):
         self.assertEqual(result["chance_to_win"], 0.5)
         self.assertEqual(result["expected"], 0)
 
+    def test_inexact_log_approximation(self):
+        expected = {
+            "chance_to_win": 0.5,
+            "expected": 0,
+            "ci": [0, 0],
+            "uplift": {"dist": "lognormal", "mean": 0, "stddev": 0},
+            "risk": [0, 0],
+        }
+
+        result = gaussian_ab_test(
+            m_a=0.26, s_a=5.12, n_a=381, m_b=0.84, s_b=12.26, n_b=24145
+        )
+
+        for key in expected.keys():
+            ex = expected[key]
+            res = result[key]
+
+            self.assertEqual(res, ex)
+
 
 if __name__ == "__main__":
     unittest_main()


### PR DESCRIPTION
- Adds logic to check for inexact log approximation in the gaussian_ab_test function.
- Moves constant priors and epsilon to a new constants.py file
- Adds tests for the inexact log approximation behavior

I considered the different options described in #246. However, I decided the best one was option 2 (detect the probability of being negative at the top of the `gaussian_ab_test` function and return immediately with zeros for uplift, risk, etc.).

I considered Monte Carlo simulations as an alternative to the log approximation (option 3). Nevertheless, they resulted in unusual behavior (e.g., infinite confidence intervals). Thus, I discarded this option.