### PR TITLE
Adds negative means analysis capabilities

### DIFF
--- a/packages/stats/gbstats/bayesian/main.py
+++ b/packages/stats/gbstats/bayesian/main.py
@@ -1,7 +1,11 @@
-import numpy as np
-from scipy.stats import norm
 from typing import Tuple, Dict, Union, List
-from .dists import Beta, Norm
+
+import numpy as np
+from numpy.random import normal
+from scipy.stats import norm
+
+# from .dists import Beta, Norm
+from gbstats.bayesian.dists import Beta, Norm
 from gbstats.bayesian.constants import BETA_PRIOR, NORM_PRIOR, EPSILON
 
 
@@ -45,32 +49,144 @@ def gaussian_ab_test(m_a, s_a, n_a, m_b, s_b, n_b, ccr=0.05):
     if not _is_std_dev_positive((s_a, s_b)):
         return _default_output()
 
-    mu_a, sd_a = Norm.posterior(NORM_PRIOR, [m_a, s_a, n_a])
-    mu_b, sd_b = Norm.posterior(NORM_PRIOR, [m_b, s_b, n_b])
+    a_distribution = Norm(mean=m_a, std_dev=s_a, num_observations=n_a)
+    b_distribution = Norm(mean=m_b, std_dev=s_b, num_observations=n_b)
 
-    if _is_log_approximation_inexact(((mu_a, sd_a), (mu_b, sd_b))):
-        return _default_output()
+    posterior_mean_a, posterior_std_dev_a = a_distribution.get_posterior(NORM_PRIOR)
+    posterior_mean_b, posterior_std_dev_b = b_distribution.get_posterior(NORM_PRIOR)
 
-    mean_a, var_a = Norm.moments(mu_a, sd_a, log=True)
-    mean_b, var_b = Norm.moments(mu_b, sd_b, log=True)
-
-    mean_diff = mean_b - mean_a
-    std_diff = np.sqrt(var_a + var_b)
-
-    chance_to_win = norm.sf(0, mean_diff, std_diff)
-    expected = np.exp(mean_diff) - 1
-    ci = np.exp(norm.ppf([ccr / 2, 1 - ccr / 2], mean_diff, std_diff)) - 1
-    risk_norm = Norm.risk(mu_a, sd_a, mu_b, sd_b)
-
-    output = {
-        "chance_to_win": chance_to_win,
-        "expected": expected,
-        "ci": ci.tolist(),
-        "uplift": {"dist": "lognormal", "mean": mean_diff, "stddev": std_diff},
-        "risk": risk_norm.tolist(),
-    }
+    output = _calculate_output_kpis(
+        posterior_mean_a,
+        posterior_std_dev_a,
+        posterior_mean_b,
+        posterior_std_dev_b,
+        ccr=ccr,
+    )
 
     return output
+
+
+def _calculate_output_kpis(
+    posterior_mean_a: float,
+    posterior_std_dev_a: float,
+    posterior_mean_b: float,
+    posterior_std_dev_b: float,
+    ccr: float,
+) -> dict:
+    """Calculates the output KPIs either through log-approximation or MCMC simulation"""
+    # We can't do log approximation with negative values so we do MCMC
+    if posterior_mean_a <= 0 or posterior_mean_b <= 0:
+        output = _get_mcmc_output(
+            posterior_mean_a,
+            posterior_std_dev_a,
+            posterior_mean_b,
+            posterior_std_dev_b,
+            ccr,
+        )
+        return output
+
+    # The posterior mean is positive, but we can't assure an appropriate
+    # log approximation given how close it is to being negative
+    if _is_log_approximation_inexact(
+        (
+            (posterior_mean_a, posterior_std_dev_a),
+            (posterior_mean_b, posterior_std_dev_b),
+        )
+    ):
+        return _default_output()
+
+    # We have a positive mean that can be correctly log-approximated so we
+    # do so as doing MCMC is computationally demanding
+    output = _get_log_approximation_output(
+        posterior_mean_a,
+        posterior_std_dev_a,
+        posterior_mean_b,
+        posterior_std_dev_b,
+        ccr,
+    )
+    return output
+
+
+def _get_mcmc_output(
+    posterior_mean_a: float,
+    posterior_std_dev_a: float,
+    posterior_mean_b: float,
+    posterior_std_dev_b: float,
+    ccr: float,
+    num_draws: int = 20000,
+) -> Dict[str, Union[float, List, Dict]]:
+    """Calculate the output experiment KPIs through MCMC simulations"""
+    simulation_a = normal(
+        loc=posterior_mean_a, scale=posterior_std_dev_a, size=num_draws
+    )
+    simulation_b = normal(
+        loc=posterior_mean_b, scale=posterior_std_dev_b, size=num_draws
+    )
+
+    relative_difference = (simulation_b - simulation_a) / np.abs(simulation_a)
+
+    mean_diff = np.mean(relative_difference)
+    std_diff = np.std(relative_difference)
+
+    output = dict(
+        chance_to_win=np.mean(simulation_b > simulation_a),
+        expected=mean_diff.copy(),
+        ci=np.exp(norm.ppf([ccr / 2, 1 - ccr / 2], mean_diff, std_diff)) - 1,
+        uplift={"dist": "lognormal", "mean": mean_diff, "stddev": std_diff},
+        risk=list(
+            Norm.risk(
+                posterior_mean_a,
+                posterior_std_dev_a,
+                posterior_mean_b,
+                posterior_std_dev_b,
+            )
+        ),
+    )
+
+    return output
+
+
+def _get_log_approximation_output(
+    posterior_mean_a: float,
+    posterior_std_dev_a: float,
+    posterior_mean_b: float,
+    posterior_std_dev_b: float,
+    ccr: float,
+) -> Dict[str, Union[float, List, Dict]]:
+    mean_a, variance_a = _get_log_approximated_moments(
+        posterior_mean_a, posterior_std_dev_a
+    )
+    mean_b, variance_b = _get_log_approximated_moments(
+        posterior_mean_b, posterior_std_dev_b
+    )
+
+    mean_diff = mean_b - mean_a
+    std_diff = np.sqrt(variance_a + variance_b)
+
+    output = dict(
+        chance_to_win=norm.sf(0, mean_diff, std_diff),
+        expected=np.exp(mean_diff) - 1,
+        ci=np.exp(norm.ppf([ccr / 2, 1 - ccr / 2], mean_diff, std_diff)) - 1,
+        uplift={"dist": "lognormal", "mean": mean_diff, "stddev": std_diff},
+        risk=list(
+            Norm.risk(
+                posterior_mean_a,
+                posterior_std_dev_a,
+                posterior_mean_b,
+                posterior_std_dev_b,
+            )
+        ),
+    )
+
+    return output
+
+
+def _get_log_approximated_moments(mean: float, std_dev: float) -> Tuple[float, float]:
+    """Get posterior moments through log approximation"""
+    log_approx_mean = np.log(mean)
+    log_approx_variance = np.power(std_dev / mean, 2)
+
+    return log_approx_mean, log_approx_variance
 
 
 def _is_std_dev_positive(std_devs: Tuple[float, float]) -> bool:

--- a/packages/stats/tests/test_dists.py
+++ b/packages/stats/tests/test_dists.py
@@ -52,7 +52,7 @@ class TestBeta(TestCase):
         pars = 12, 745
         result = Beta.moments(*pars, log=True)
         mean = beta.expect(np.log, pars)
-        var = beta.expect(lambda x: np.log(x) ** 2, pars) - mean ** 2
+        var = beta.expect(lambda x: np.log(x) ** 2, pars) - mean**2
         expected = mean, var
         for res, out in zip(result, expected):
             self.assertEqual(round_(res), round_(out))
@@ -72,7 +72,7 @@ class TestBeta(TestCase):
         for a, b in test_cases:
             x, w = Beta.gq(24, a, b)
             for p in range(8):
-                self.assertEqual(roundsum(x ** p * w), roundsum(beta.moment(p, a, b)))
+                self.assertEqual(roundsum(x**p * w), roundsum(beta.moment(p, a, b)))
             self.assertEqual(
                 roundsum(np.log(x) * w), roundsum(digamma(a) - digamma(a + b))
             )
@@ -82,7 +82,8 @@ class TestNorm(TestCase):
     def test_posterior(self):
         prior = 0, 1, 10
         data = 12, 1, 10
-        result = Norm.posterior(prior, data)
+        normal = Norm(12, 1, 10)
+        result = normal.get_posterior(prior)
         outcome = (6, np.sqrt(1 / 20))
 
         for res, out in zip(result, outcome):
@@ -90,7 +91,8 @@ class TestNorm(TestCase):
 
         prior = 0, 1, 10
         data = pd.Series([12, 100]), pd.Series([1, np.sqrt(2)]), pd.Series([10, 20])
-        result = Norm.posterior(prior, data)
+        normal = Norm(data[0], data[1], data[2])
+        result = normal.get_posterior(prior)
         outcome = pd.Series([6.0, 50.0]), pd.Series([np.sqrt(1 / 20), np.sqrt(1 / 20)])
 
         for res, out in zip(result, outcome):
@@ -98,35 +100,12 @@ class TestNorm(TestCase):
 
         prior = pd.Series([0, 100]), pd.Series([1, np.sqrt(2)]), pd.Series([10, 20])
         data = pd.Series([12, 100]), pd.Series([1, np.sqrt(2)]), pd.Series([10, 20])
-        result = Norm.posterior(prior, data)
+        normal = Norm(data[0], data[1], data[2])
+        result = normal.get_posterior(prior)
         outcome = pd.Series([6.0, 100.0]), pd.Series([np.sqrt(1 / 20), np.sqrt(1 / 20)])
 
         for res, out in zip(result, outcome):
             pd.testing.assert_series_equal(res, out)
-
-    def test_moments(self):
-        pars = 10, 100
-        result = Norm.moments(*pars)
-        expected = norm.mean(*pars), norm.var(*pars)
-        for res, out in zip(result, expected):
-            self.assertEqual(round_(res), round_(out))
-
-        pars = 100, 10
-        result = Norm.moments(*pars, log=True)
-        expected = np.log(100), (10 / 100) ** 2
-        for res, out in zip(result, expected):
-            self.assertEqual(round_(res), round_(out))
-
-        pars = np.array([10, 100]), np.array([100, 10])
-        result = Norm.moments(*pars)
-        expected = norm.mean(*pars), norm.var(*pars)
-        for res, out in zip(result, expected):
-            np.testing.assert_array_almost_equal(res, out)
-
-        self.assertWarns(RuntimeWarning, Norm.moments, 0.1, 1, log=True)
-        self.assertRaises(RuntimeError, Norm.moments, 0, 1, log=True)
-        self.assertRaises(RuntimeError, Norm.moments, -1, 1, log=True)
-        self.assertRaises(RuntimeError, Norm.moments, 1, -1)
 
     def test_gq(self):
         test_cases = zip([0, -2, 2, 10], [0.01, 1, 4, 0.0001])
@@ -134,7 +113,7 @@ class TestNorm(TestCase):
             x, w = Norm.gq(24, loc, scale)
             for p in range(8):
                 self.assertEqual(
-                    roundsum(x ** p * w), roundsum(norm.moment(p, loc, scale))
+                    roundsum(x**p * w), roundsum(norm.moment(p, loc, scale))
                 )
 
         self.assertRaises(RuntimeError, Norm.gq, 24, 0, 0)


### PR DESCRIPTION
- Implements logic to handle gaussian_ab_tests with negative means. #401 
- Implements tests to test the new functionality

Notes: 
- Please review the [definition of relative difference](https://github.com/santiago-rico/growthbook/blob/c873b99273467f7bdea493ff6f097a159bf6bf9a/packages/stats/gbstats/bayesian/main.py#L126) when working with negative means as it's not standardized 
- I think the main.py code is starting to look a little dirty. I want to work next on refactoring the Beta distribution works so that we have a joint "analysis" class where we can put all of that together. 