### PR TITLE
Show invited users register modal instead of login modal by default

### DIFF
--- a/packages/front-end/components/Auth/Welcome.tsx
+++ b/packages/front-end/components/Auth/Welcome.tsx
@@ -1,9 +1,10 @@
-import { ReactElement, useState } from "react";
+import { ReactElement, useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import track from "../../services/track";
 import { getApiHost } from "../../services/env";
 import WelcomeFrame from "./WelcomeFrame";
 import Field from "../Forms/Field";
+import { useRouter } from "next/router";
 
 export default function Welcome({
   onSuccess,
@@ -26,6 +27,13 @@ export default function Welcome({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [welcomeMsgIndex] = useState(Math.floor(Math.random() * 4));
+  const { pathname } = useRouter();
+
+  useEffect(() => {
+    if (pathname === "/invitation") {
+      setState("register");
+    }
+  }, []);
 
   const welcomeMsg = [
     <>Welcome to GrowthBook!</>,

--- a/packages/front-end/components/Auth/Welcome.tsx
+++ b/packages/front-end/components/Auth/Welcome.tsx
@@ -33,7 +33,7 @@ export default function Welcome({
     if (pathname === "/invitation") {
       setState("register");
     }
-  }, []);
+  }, [pathname]);
 
   const welcomeMsg = [
     <>Welcome to GrowthBook!</>,


### PR DESCRIPTION
### Overview
Currently, when an invited user clicks on their invite link, they're routed to the app to register, but we actually show the login content, instead of the registration content. Users must then click the "Register" link. 

This PR checks the pathname inside of `<Welcome />` and if it's `/pathname` sets the state to `register`, resulting in one less click by the user in order to register.