### PR TITLE
Bug: Sorting by tag breaks when you remove a tag and that tag is no longer connected to any feature.

### DIFF
--- a/packages/front-end/components/Tags/TagsFilter.tsx
+++ b/packages/front-end/components/Tags/TagsFilter.tsx
@@ -43,8 +43,6 @@ export default function TagsFilter({
   filter: { tags, setTags },
   items,
 }: Props) {
-  const { tags: currentTags } = useDefinitions();
-
   const counts: Record<string, number> = {};
   const availableTags: string[] = [];
   const { getTagById } = useDefinitions();
@@ -63,7 +61,7 @@ export default function TagsFilter({
     return (counts[b] || 0) - (counts[a] || 0);
   });
 
-  if (!tags.length && !currentTags.length) return null;
+  if (!tags.length && !availableTags.length) return null;
 
   return (
     <div style={{ minWidth: 207 }}>
@@ -75,9 +73,8 @@ export default function TagsFilter({
         prompt={"Filter by tags..."}
         closeMenuOnSelect={true}
         tagOptions={
-          availableTags.length
-            ? availableTags.map((t) => getTagById(t)).filter(Boolean)
-            : null
+          availableTags.length &&
+          availableTags.map((t) => getTagById(t)).filter(Boolean)
         }
         creatable={false}
       />

--- a/packages/front-end/components/Tags/TagsFilter.tsx
+++ b/packages/front-end/components/Tags/TagsFilter.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useLocalStorage } from "../../hooks/useLocalStorage";
 import { useDefinitions } from "../../services/DefinitionsContext";
 import TagsInput from "./TagsInput";
@@ -43,6 +44,7 @@ export default function TagsFilter({
   filter: { tags, setTags },
   items,
 }: Props) {
+  const [open, setOpen] = useState(false);
   const counts: Record<string, number> = {};
   const availableTags: string[] = [];
   const { getTagById } = useDefinitions();
@@ -57,11 +59,32 @@ export default function TagsFilter({
       });
     }
   });
+
+  tags.forEach((tag) => {
+    if (!availableTags.includes(tag)) {
+      availableTags.push(tag);
+    }
+  });
+
   availableTags.sort((a, b) => {
     return (counts[b] || 0) - (counts[a] || 0);
   });
 
   if (!tags.length && !availableTags.length) return null;
+
+  if (!open && !tags.length) {
+    return (
+      <a
+        href="#"
+        onClick={(e) => {
+          e.preventDefault();
+          setOpen(true);
+        }}
+      >
+        Filter by tags...
+      </a>
+    );
+  }
 
   return (
     <div style={{ minWidth: 207 }}>
@@ -71,11 +94,9 @@ export default function TagsFilter({
           setTags(value);
         }}
         prompt={"Filter by tags..."}
+        autoFocus={open}
         closeMenuOnSelect={true}
-        tagOptions={
-          availableTags.length &&
-          availableTags.map((t) => getTagById(t)).filter(Boolean)
-        }
+        tagOptions={availableTags.map((t) => getTagById(t)).filter(Boolean)}
         creatable={false}
       />
     </div>

--- a/packages/front-end/components/Tags/TagsFilter.tsx
+++ b/packages/front-end/components/Tags/TagsFilter.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { useLocalStorage } from "../../hooks/useLocalStorage";
 import { useDefinitions } from "../../services/DefinitionsContext";
 import TagsInput from "./TagsInput";
@@ -44,7 +43,7 @@ export default function TagsFilter({
   filter: { tags, setTags },
   items,
 }: Props) {
-  const [open, setOpen] = useState(false);
+  const { tags: currentTags } = useDefinitions();
 
   const counts: Record<string, number> = {};
   const availableTags: string[] = [];
@@ -64,23 +63,7 @@ export default function TagsFilter({
     return (counts[b] || 0) - (counts[a] || 0);
   });
 
-  if (!tags.length && !availableTags.length) {
-    return null;
-  }
-
-  if (!open && !tags.length) {
-    return (
-      <a
-        href="#"
-        onClick={(e) => {
-          e.preventDefault();
-          setOpen(true);
-        }}
-      >
-        Filter by tags...
-      </a>
-    );
-  }
+  if (!tags.length && !currentTags.length) return null;
 
   return (
     <div style={{ minWidth: 207 }}>
@@ -90,9 +73,12 @@ export default function TagsFilter({
           setTags(value);
         }}
         prompt={"Filter by tags..."}
-        autoFocus={open}
         closeMenuOnSelect={true}
-        tagOptions={availableTags.map((t) => getTagById(t)).filter(Boolean)}
+        tagOptions={
+          availableTags.length
+            ? availableTags.map((t) => getTagById(t)).filter(Boolean)
+            : null
+        }
         creatable={false}
       />
     </div>

--- a/packages/front-end/components/Tags/TagsFilter.tsx
+++ b/packages/front-end/components/Tags/TagsFilter.tsx
@@ -60,12 +60,6 @@ export default function TagsFilter({
     }
   });
 
-  tags.forEach((tag) => {
-    if (!availableTags.includes(tag)) {
-      availableTags.push(tag);
-    }
-  });
-
   availableTags.sort((a, b) => {
     return (counts[b] || 0) - (counts[a] || 0);
   });

--- a/packages/front-end/components/Tags/TagsInput.tsx
+++ b/packages/front-end/components/Tags/TagsInput.tsx
@@ -31,7 +31,7 @@ const TagsInput: FC<{
   prompt = "Tags...",
   creatable = true,
 }) => {
-  const { tags } = useDefinitions();
+  const { tags, getTagById } = useDefinitions();
   if (!tagOptions) tagOptions = tags;
 
   const tagSet = new Set(tagOptions.map((t) => t.id));
@@ -41,7 +41,7 @@ const TagsInput: FC<{
       tagOptions.push({
         id: value,
         description: "",
-        color: "#029dd1",
+        color: getTagById(value)?.color || "#029dd1",
       });
     }
   });

--- a/packages/front-end/components/Tags/TagsInput.tsx
+++ b/packages/front-end/components/Tags/TagsInput.tsx
@@ -34,20 +34,17 @@ const TagsInput: FC<{
   const { tags } = useDefinitions();
   if (!tagOptions) tagOptions = tags;
 
-  // Add newly created values to the list of options
-  if (creatable) {
-    const tagSet = new Set(tagOptions.map((t) => t.id));
-    tagOptions = [...tagOptions];
-    value.forEach((value) => {
-      if (!tagSet.has(value)) {
-        tagOptions.push({
-          id: value,
-          description: "",
-          color: "#029dd1",
-        });
-      }
-    });
-  }
+  const tagSet = new Set(tagOptions.map((t) => t.id));
+  tagOptions = [...tagOptions];
+  value.forEach((value) => {
+    if (!tagSet.has(value)) {
+      tagOptions.push({
+        id: value,
+        description: "",
+        color: "#029dd1",
+      });
+    }
+  });
 
   const tagStyles: StylesConfig<ColorOption, true> = {
     option: (styles, { data, isDisabled, isFocused, isSelected }) => {


### PR DESCRIPTION
### Overview

From a GB User:

> hey found a bug on the features list, I filtered by a tag which only had 1 feature, I then went into that feature and removed the tag from that feature, and went back to the features list and was unable to turn off the tag for the filters and the list had no items. Had to create a new feature, give it that tag, then turn off the filter, etc to fix

The fix overall is pretty small - In TagsInput, we were always passing the tagOptions array, even if it was an empty array. All I did was make it so we're only passing the tagOptions array when it's not empty. This allows the check on line 35 of `TagsInput` to run (which sets tagOptions to all tags. Which allows `MultiSelectField` to filter through the array of all tags (instead of an empty array).