### PR TITLE
Make projects sorted alphabetically

### DIFF
--- a/packages/front-end/components/Layout/ProjectSelector.tsx
+++ b/packages/front-end/components/Layout/ProjectSelector.tsx
@@ -82,7 +82,7 @@ export default function ProjectSelector() {
             bold={!project}
           />
         </DropdownLink>
-        {projects.sort((a, b) => a.name > b.name ? 1 : -1).map((p) => {
+        {projects.slice().sort((a, b) => a.name > b.name ? 1 : -1).map((p) => {
           return (
             <DropdownLink
               className="p-0"

--- a/packages/front-end/components/Layout/ProjectSelector.tsx
+++ b/packages/front-end/components/Layout/ProjectSelector.tsx
@@ -82,7 +82,7 @@ export default function ProjectSelector() {
             bold={!project}
           />
         </DropdownLink>
-        {projects.map((p) => {
+        {projects.sort((a, b) => a.name > b.name ? 1 : -1).map((p) => {
           return (
             <DropdownLink
               className="p-0"


### PR DESCRIPTION
Fixes https://github.com/growthbook/growthbook/issues/425

The projects are now sorted alphabetically instead of by creation date.

The change means that they are also sorted alphabetically on the **Projects** page (found under **Settings** on the sidebar). I didn't know if this was desirable or not and I was also a little bit confused about how that works because that seems to be rendered here https://github.com/growthbook/growthbook/blob/ca0716b114c7cc80183b250352e43b0568b2e319/packages/front-end/pages/projects.tsx using a separate map, so I thought that I would submit the change and see what you think.

It would also be interesting on the **Projects** page to allow sorting by different categories based on clicking on them.