### PR TITLE
Fix bug causing custom attributes to be reset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ config.yml
 .vscode
 packages/stats/notebooks
 buildinfo/
+*.tsbuildinfo
 
 # Python compiled files
 __pycache__/

--- a/packages/back-end/src/controllers/organizations.ts
+++ b/packages/back-end/src/controllers/organizations.ts
@@ -36,6 +36,7 @@ import {
   getWatchedAudits,
   findByEntity,
   findByEntityParent,
+  auditDetailsUpdate,
 } from "../services/audit";
 import { WatchModel } from "../models/WatchModel";
 import { ExperimentModel } from "../models/ExperimentModel";
@@ -735,17 +736,30 @@ export async function putOrganization(
   try {
     const updates: Partial<OrganizationInterface> = {};
 
+    const orig: Partial<OrganizationInterface> = {};
+
     if (name) {
       updates.name = name;
+      orig.name = org.name;
     }
     if (settings) {
       updates.settings = {
         ...org.settings,
         ...settings,
       };
+      orig.settings = org.settings;
     }
 
     await updateOrganization(org.id, updates);
+
+    await req.audit({
+      event: "organization.update",
+      entity: {
+        object: "organization",
+        id: org.id,
+      },
+      details: auditDetailsUpdate(orig, updates),
+    });
 
     res.status(200).json({
       status: 200,

--- a/packages/back-end/src/models/OrganizationModel.ts
+++ b/packages/back-end/src/models/OrganizationModel.ts
@@ -74,6 +74,20 @@ function toInterface(doc: OrganizationDocument): OrganizationInterface {
   const configSettings = getConfigOrganizationSettings();
   json.settings = Object.assign({}, json.settings || {}, configSettings);
 
+  // Default attribute schema
+  if (!json.settings.attributeSchema) {
+    json.settings.attributeSchema = [
+      { property: "id", datatype: "string", hashAttribute: true },
+      { property: "deviceId", datatype: "string", hashAttribute: true },
+      { property: "company", datatype: "string", hashAttribute: true },
+      { property: "loggedIn", datatype: "boolean" },
+      { property: "employee", datatype: "boolean" },
+      { property: "country", datatype: "string" },
+      { property: "browser", datatype: "string" },
+      { property: "url", datatype: "string" },
+    ];
+  }
+
   return json;
 }
 

--- a/packages/front-end/components/Features/EditAttributesModal.tsx
+++ b/packages/front-end/components/Features/EditAttributesModal.tsx
@@ -8,17 +8,7 @@ import Field from "../Forms/Field";
 import Tooltip from "../Tooltip";
 import { FaQuestionCircle } from "react-icons/fa";
 import track from "../../services/track";
-
-const INITIAL_ATTRS: SDKAttributeSchema = [
-  { property: "id", datatype: "string", hashAttribute: true },
-  { property: "deviceId", datatype: "string", hashAttribute: true },
-  { property: "company", datatype: "string", hashAttribute: true },
-  { property: "loggedIn", datatype: "boolean" },
-  { property: "employee", datatype: "boolean" },
-  { property: "country", datatype: "string" },
-  { property: "browser", datatype: "string" },
-  { property: "url", datatype: "string" },
-];
+import { useAttributeSchema } from "../../services/features";
 
 export default function EditAttributesModal({ close }: { close: () => void }) {
   const { settings, update } = useUser();
@@ -26,9 +16,7 @@ export default function EditAttributesModal({ close }: { close: () => void }) {
 
   const form = useForm<{ attributeSchema: SDKAttributeSchema }>({
     defaultValues: {
-      attributeSchema: settings?.attributeSchema?.length
-        ? settings?.attributeSchema
-        : INITIAL_ATTRS,
+      attributeSchema: useAttributeSchema(),
     },
   });
 
@@ -48,9 +36,6 @@ export default function EditAttributesModal({ close }: { close: () => void }) {
         if (!settings?.attributeSchema) {
           track("Save Targeting Attributes", {
             source: "onboarding",
-            customized:
-              JSON.stringify(value.attributeSchema) !==
-              JSON.stringify(INITIAL_ATTRS),
             hashAttributes: value.attributeSchema
               .filter((s) => s.hashAttribute)
               .map((s) => s.property),

--- a/packages/front-end/services/features.ts
+++ b/packages/front-end/services/features.ts
@@ -14,7 +14,6 @@ import {
 import stringify from "json-stringify-pretty-compact";
 import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
 import useUser from "../hooks/useUser";
-import { useAuth } from "./auth";
 import useApi from "../hooks/useApi";
 import { FeatureUsageRecords } from "back-end/types/realtime";
 import { useDefinitions } from "./DefinitionsContext";
@@ -173,33 +172,7 @@ export function getVariationColor(i: number) {
 }
 
 export function useAttributeSchema() {
-  const { settings, update } = useUser();
-  const { apiCall } = useAuth();
-
-  useEffect(() => {
-    if (!settings?.attributeSchema) {
-      apiCall(`/organization`, {
-        method: "PUT",
-        body: JSON.stringify({
-          settings: {
-            attributeSchema: [
-              { property: "id", datatype: "string", hashAttribute: true },
-              { property: "deviceId", datatype: "string", hashAttribute: true },
-              { property: "company", datatype: "string", hashAttribute: true },
-              { property: "loggedIn", datatype: "boolean" },
-              { property: "employee", datatype: "boolean" },
-              { property: "country", datatype: "string" },
-              { property: "browser", datatype: "string" },
-              { property: "url", datatype: "string" },
-            ],
-          },
-        }),
-      }).then(() => {
-        update();
-      });
-    }
-  }, [settings?.attributeSchema]);
-
+  const { settings } = useUser();
   return settings?.attributeSchema || [];
 }
 


### PR DESCRIPTION
In rare circumstances, the list of attributes for an organization can be reset to the default list and there's no way to recover except by using database backups.  This was caused by random network failures and race conditions during app initialization.  This PR fixes this issue on two fronts:

1.  Make the attribute schema code much more robust against unintentional changes
2.  Record audit log entries when any organization settings are changed so it's easier to recover if any similar bugs happen in the future