### PR TITLE
Update how we display suspicious results

### DIFF
--- a/packages/front-end/components/Experiment/ChanceToWinColumn.tsx
+++ b/packages/front-end/components/Experiment/ChanceToWinColumn.tsx
@@ -11,6 +11,7 @@ import { defaultMinSampleSize } from "../../services/metrics";
 import NotEnoughData from "./NotEnoughData";
 import { ExperimentStatus } from "back-end/types/experiment";
 import Tooltip from "../Tooltip";
+import { FaQuestionCircle } from "react-icons/fa";
 
 const percentFormatter = new Intl.NumberFormat(undefined, {
   style: "percent",
@@ -76,6 +77,22 @@ export default function ChanceToWinColumn({
         className
       )}
     >
+      {suspiciousChange && (
+        <div>
+          <div className="mb-1 d-flex">
+            <span className="badge badge-pill badge-warning">
+              Suspicious Result
+            </span>
+            <Tooltip
+              body={`A suspicious result occurs when the percent change is equal to or greater than your maximum percent change (${
+                metric.maxPercentChange * 100
+              }%).`}
+            >
+              <FaQuestionCircle />
+            </Tooltip>
+          </div>
+        </div>
+      )}
       <Tooltip
         body={sigText}
         className="d-block"
@@ -94,15 +111,6 @@ export default function ChanceToWinColumn({
             snapshotCreated={snapshotDate}
             phaseStart={startDate}
           />
-        ) : suspiciousChange ? (
-          <div>
-            <div className="mb-1">
-              <span className="badge badge-pill badge-warning">
-                suspicious result
-              </span>
-            </div>
-            <small className="text-muted">value changed too much</small>
-          </div>
         ) : (
           <>{percentFormatter.format(chanceToWin)}</>
         )}

--- a/packages/front-end/components/Experiment/ChanceToWinColumn.tsx
+++ b/packages/front-end/components/Experiment/ChanceToWinColumn.tsx
@@ -11,7 +11,6 @@ import { defaultMinSampleSize } from "../../services/metrics";
 import NotEnoughData from "./NotEnoughData";
 import { ExperimentStatus } from "back-end/types/experiment";
 import Tooltip from "../Tooltip";
-import { FaQuestionCircle } from "react-icons/fa";
 
 const percentFormatter = new Intl.NumberFormat(undefined, {
   style: "percent",
@@ -77,18 +76,17 @@ export default function ChanceToWinColumn({
         className
       )}
     >
-      {suspiciousChange && (
+      {enoughData && suspiciousChange && (
         <div>
-          <div className="mb-1 d-flex">
-            <span className="badge badge-pill badge-warning">
-              Suspicious Result
-            </span>
+          <div className="mb-1 d-flex flex-row">
             <Tooltip
               body={`A suspicious result occurs when the percent change is equal to or greater than your maximum percent change (${
                 metric.maxPercentChange * 100
               }%).`}
             >
-              <FaQuestionCircle />
+              <span className="badge badge-pill badge-warning">
+                Suspicious Result
+              </span>
             </Tooltip>
           </div>
         </div>

--- a/packages/front-end/components/Experiment/PercentGraphColumn.tsx
+++ b/packages/front-end/components/Experiment/PercentGraphColumn.tsx
@@ -1,7 +1,7 @@
 import { SnapshotMetric } from "back-end/types/experiment-snapshot";
 import { MetricInterface } from "back-end/types/metric";
 import useConfidenceLevels from "../../hooks/useConfidenceLevels";
-import { hasEnoughData, isSuspiciousUplift } from "../../services/experiments";
+import { hasEnoughData } from "../../services/experiments";
 import AlignedGraph from "./AlignedGraph";
 
 export default function PercentGraphColumn({
@@ -18,11 +18,10 @@ export default function PercentGraphColumn({
   id: string;
 }) {
   const enoughData = hasEnoughData(baseline, stats, metric);
-  const suspiciousChange = isSuspiciousUplift(baseline, stats, metric);
   const { ciUpper, ciLower } = useConfidenceLevels();
   const barType = stats.uplift?.dist ? "violin" : "pill";
 
-  const showGraph = metric && enoughData && !suspiciousChange;
+  const showGraph = metric && enoughData;
   return (
     <td className="compact-graph pb-0 align-middle">
       <AlignedGraph


### PR DESCRIPTION
## Overview ##
Currently, when a metric changes too much in an experiment we hide all the data and just show a "Suspicious Result" badge instead.

This isn't very helpful since people can't dig into the data to figure out WHY it's suspicious. We should find a way to label the data as suspicious without hiding it.

## Updates ##
- With this update, we will show the percent change graph even when the result is suspicious.
- We'll also show the "Chance to Win" amount, but it will be below a "Suspicious Result" pill with an accompanying tooltip.
- This tooltip will the use `maximumPercentChange` for the metric in question.

## Screenshots ## 
<img width="1277" alt="Screen Shot 2022-08-26 at 12 56 34 PM" src="https://user-images.githubusercontent.com/75274610/186955337-b5545e05-a826-4ce4-9004-9fa8cb4b32c6.png">

<img width="516" alt="Screen Shot 2022-08-26 at 12 56 45 PM" src="https://user-images.githubusercontent.com/75274610/186955350-18b0f991-f7b8-450a-a34a-cd0374127569.png">

