### PR TITLE
Secure file uploads when NODE_ENV=dev

### DIFF
--- a/packages/back-end/src/controllers/auth.ts
+++ b/packages/back-end/src/controllers/auth.ts
@@ -183,6 +183,14 @@ export async function postFirstTimeRegister(
   >,
   res: Response
 ) {
+  // Only allow this API endpoint when it's a brand-new installation with no users yet
+  const newInstallation = await isNewInstallation();
+  if (!newInstallation) {
+    throw new Error(
+      "An organization is already configured. Please refresh the page and try again."
+    );
+  }
+
   const { email, name, password, companyname } = req.body;
 
   validatePasswordFormat(password);

--- a/packages/back-end/src/util/secrets.ts
+++ b/packages/back-end/src/util/secrets.ts
@@ -29,6 +29,7 @@ if (!MONGODB_URI) {
 }
 
 export const APP_ORIGIN = process.env.APP_ORIGIN || "http://localhost:3000";
+const isLocalhost = APP_ORIGIN.includes("localhost");
 
 const corsOriginRegex = process.env.CORS_ORIGIN_REGEX;
 export const CORS_ORIGIN_REGEX = corsOriginRegex
@@ -56,7 +57,7 @@ export const GCS_DOMAIN =
   `https://storage.googleapis.com/${GCS_BUCKET_NAME}/`;
 
 export const JWT_SECRET = process.env.JWT_SECRET || "dev";
-if (prod && !IS_CLOUD && JWT_SECRET === "dev") {
+if ((prod || !isLocalhost) && !IS_CLOUD && JWT_SECRET === "dev") {
   throw new Error(
     "Cannot use JWT_SECRET=dev in production. Please set to a long random string."
   );


### PR DESCRIPTION
If a user fails to set NODE_ENV=production, our built-in security checks are disabled and it's possible to misconfigure GrowthBook and leave the file upload API endpoint open to attack.

To be affected, ALL of the following must be true
1. Self-hosted (GrowthBook Cloud is unaffected)
2. GrowthBook API exposed to the internet
3. Using local file uploads (as opposed to S3 or Google Cloud Storage)
4. NODE_ENV set to a non-production value
5. JWT_SECRET set to the default "dev" string

To solve these security vulnerabilities, this PR makes 3 changes:
1. Add more protection around the fileUpload API endpoint (protect against directory traversal, etc.)
2. Only disable built-in security checks if the domain is still `localhost` (in case someone forgets to update NODE_ENV)
3. Add an extra sanity check to the first-time register API endpoint

What should you do if you are potentially affected:
- **Update to the latest GrowthBook version**
- Make sure `NODE_ENV` is set to "production"
- Set the `JWT_SECRET` environment variable to a long random string