### PR TITLE
Show user counts in experiment when there are no metric conversions yet

### DIFF
--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -825,16 +825,16 @@ export default abstract class SqlIntegration
           dimension
       )
     SELECT
-      s.variation,
-      s.dimension,
+      u.variation,
+      u.dimension,
       s.count,
       s.mean,
       s.stddev,
       u.users
     FROM
-      __stats s
-      JOIN __overallUsers u ON (
-        s.variation = u.variation 
+      __overallUsers u
+      LEFT JOIN __stats s ON (
+        s.variation = u.variation
         AND s.dimension = u.dimension
       )
     `


### PR DESCRIPTION
Now using a LEFT join so user counts are returned no matter what. Especially useful for debugging early on in a test.

Fixes #435