### PR TITLE
Remove pip from pyproject.toml, add docs for pytest in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,7 @@ To start the docs site, run `yarn workspace docs dev`. You can view the site at 
 
 To work on the SDKs, `cd` into the desired directory and the following commands are available:
 
-- `yarn test` - Run just
+- `yarn test` - Run Jest
 - `yarn build` - Run the rollup build process
 - `yarn size` - Get the gzip size of the bundle (must run `yarn build` first)
 
@@ -116,7 +116,7 @@ To work on the SDKs, `cd` into the desired directory and the following commands 
 
 To work on the Python stats engine, `cd` into the `packages/stats` directory and the following commands are available:
 
-- `yarn test` - Run pytest
+- `. $(cd packages/stats && poetry env info --path)/bin/activate && yarn test` - Run pytest
 - `yarn lint` - Run flake8 and black
 - `poetry build` - Run the build process
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "lint": "eslint './**/*.{ts,tsx,js,jsx}' --fix --max-warnings 0",
     "pretty": "prettier --write ./**/*.{json,css,scss,md,mdx}",
     "type-check": "wsrun -m type-check",
-    "test": ". $(cd packages/stats && poetry env info --path)/bin/activate && wsrun -m test",
+    "test": "wsrun -m test",
     "dev": ". $(cd packages/stats && poetry env info --path)/bin/activate && wsrun -p '*-end' -m dev",
     "build": "wsrun -p '*-end' -m build",
     "start": "wsrun -p '*-end' -m start",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "lint": "eslint './**/*.{ts,tsx,js,jsx}' --fix --max-warnings 0",
     "pretty": "prettier --write ./**/*.{json,css,scss,md,mdx}",
     "type-check": "wsrun -m type-check",
-    "test": "wsrun -m test",
+    "test": ". $(cd packages/stats && poetry env info --path)/bin/activate && wsrun -m test",
     "dev": ". $(cd packages/stats && poetry env info --path)/bin/activate && wsrun -p '*-end' -m dev",
     "build": "wsrun -p '*-end' -m build",
     "start": "wsrun -p '*-end' -m start",

--- a/packages/stats/pyproject.toml
+++ b/packages/stats/pyproject.toml
@@ -31,7 +31,6 @@ scipy = "^1.5.4"
 [tool.poetry.dev-dependencies]
 tox = "^3.20.1"
 virtualenv = "^20.2.2"
-pip = "^20.3.1"
 twine = "^3.3.0"
 toml = "^0.10.2"
 black = "20.8b1"


### PR DESCRIPTION
## Remove `pip` from pyproject.toml

Removes the version requirement for pip. This helps in cases where a machine has multiple versions of Python and pip and poetry does not use the right version. This can cause `yarn setup` to fail at the gbstats setup stage.

## Add docs for pytest in CONTRIBUTING

Adding a note to activate the poetry env before attempting to run `yarn test` from the root. Unless the user has pytest installed globally, the execution of `yarn test` would fail.

Initially I had added it to the npm `test` script but this caused CI to fail due to poetry not being installed. 