### PR TITLE
Add targeting conditions to the FeatureModal component

### DIFF
--- a/packages/front-end/components/Features/FeatureModal.tsx
+++ b/packages/front-end/components/Features/FeatureModal.tsx
@@ -349,6 +349,12 @@ export default function FeatureModal({
             }}
             label="Percent of users to include"
           />
+          <ConditionInput
+            defaultValue={rule?.condition}
+            onChange={(cond) => {
+              form.setValue("rule.condition", cond);
+            }}
+          />
           <FeatureValueField
             label={"Value when included"}
             id="ruleValue"
@@ -402,6 +408,12 @@ export default function FeatureModal({
               .filter((s) => !hasHashAttributes || s.hashAttribute)
               .map((s) => s.property)}
             helpText="Will be hashed together with the Tracking Key to pick a value"
+          />
+          <ConditionInput
+            defaultValue={rule?.condition}
+            onChange={(cond) => {
+              form.setValue("rule.condition", cond);
+            }}
           />
           <VariationsInput
             coverage={form.watch("rule.coverage")}


### PR DESCRIPTION
The following changes add the targeting conditions functionality to the following parts of the create feature modal:

- Percentage rollout
- A/B Experiment

It already exists in Targeted, and when I asked yesterday if it needs to go in Simple, the answer was no. Let me know if that has changed and if we need to add it there too.


## Percentage Rollout

Initial state:

<img width="1106" alt="Screen Shot 2022-09-13 at 10 39 01 AM" src="https://user-images.githubusercontent.com/113377031/189987490-3acd46b0-ed76-4a7b-891c-c4b3bbb969bd.png">

After clicking "Add targeting condition":

<img width="958" alt="image" src="https://user-images.githubusercontent.com/113377031/189987633-286d7cc2-c18e-4af2-91e4-69cd8c6bab4d.png">

Percentage Rollout Feature created with the targeting condition present:

<img width="1232" alt="Screen Shot 2022-09-13 at 10 41 25 AM" src="https://user-images.githubusercontent.com/113377031/189987753-78fcf831-5094-4b17-8e47-3c67234fdc3b.png">


## A/B Experiment

Example targeting condition being entered for A/B Experiment:

<img width="1043" alt="Screen Shot 2022-09-13 at 10 44 05 AM" src="https://user-images.githubusercontent.com/113377031/189987851-a67f6917-0961-45a8-9a02-9793fd8ff487.png">

A/B Experiment Feature created with the targeting condition present:

<img width="1229" alt="Screen Shot 2022-09-13 at 10 44 32 AM" src="https://user-images.githubusercontent.com/113377031/189988085-a31d8166-fd08-4b8e-bfe3-403f4ae96126.png">
