### PR TITLE
Support for Snowflake authenticated proxies when self-hosting

### DIFF
--- a/packages/back-end/src/services/snowflake.ts
+++ b/packages/back-end/src/services/snowflake.ts
@@ -1,6 +1,27 @@
 import { Snowflake } from "snowflake-promise";
 import { SnowflakeConnectionParams } from "../../types/integrations/snowflake";
 
+type ProxyOptions = {
+  proxyHost?: string;
+  proxyPassword?: string;
+  proxyUser?: string;
+  proxyPort?: number;
+  proxyProtocol?: string;
+};
+function getProxySettings(): ProxyOptions {
+  const uri = process.env.SNOWFLAKE_PROXY;
+  if (!uri) return {};
+
+  const parsed = new URL(uri);
+  return {
+    proxyProtocol: parsed.protocol,
+    proxyHost: parsed.host,
+    proxyPort: (parsed.port ? parseInt(parsed.port) : 0) || undefined,
+    proxyUser: parsed.username || undefined,
+    proxyPassword: parsed.password || undefined,
+  };
+}
+
 export async function runSnowflakeQuery<T>(
   conn: SnowflakeConnectionParams,
   sql: string,
@@ -14,6 +35,7 @@ export async function runSnowflakeQuery<T>(
     schema: conn.schema,
     warehouse: conn.warehouse,
     role: conn.role,
+    ...getProxySettings(),
   });
 
   await snowflake.connect();

--- a/packages/docs/pages/app/datasources.mdx
+++ b/packages/docs/pages/app/datasources.mdx
@@ -233,6 +233,18 @@ There are two ways to provide credentials to GrowthBook:
 1. Auto-discovery from environment variables or GCP metadata (only available when self-hosting)
 2. Upload a JSON key file for the service account
 
+### Snowflake
+
+We support multiple [account identifier](https://docs.snowflake.com/en/user-guide/admin-account-identifier.html) formats when connecting to Snowflake. An example account identifier is `xy12345.us-east-2.aws`.
+
+If you are self-hosting GrowthBook, you can send queries to Snowflake through an Authenticated Proxy.
+
+To enable this, set a `SNOWFLAKE_PROXY` environment variable in your GrowthBook container. Here is an example:
+
+```
+SNOWFLAKE_PROXY=http://username:password@proxyserver.company.com:80
+```
+
 ### Mixpanel
 
 You must first create a Service Account in Mixpanel under your [Project Settings](https://mixpanel.com/settings/project#serviceaccounts).

--- a/yarn.lock
+++ b/yarn.lock
@@ -11767,9 +11767,9 @@ snowflake-promise@^4.5.0:
     snowflake-sdk "^1.6.0"
 
 snowflake-sdk@^1.6.0:
-  version "1.6.12"
-  resolved "https://registry.yarnpkg.com/snowflake-sdk/-/snowflake-sdk-1.6.12.tgz#6434c3c26ecf9ec6b96dd157f9047ccde868e65b"
-  integrity sha512-nkwtsWsZr4KrloLgpMpLgCnJIxfcuWlD4sqR53kn8BQRmhOi6cSBgnvZmoYcFvW2arVvfHh/Dc3vOQ/4OuRSLg==
+  version "1.6.13"
+  resolved "https://registry.yarnpkg.com/snowflake-sdk/-/snowflake-sdk-1.6.13.tgz#75e6521f83cecb24a2d2276575d753b14496fef2"
+  integrity sha512-X/eiT4v/yw6+aLdEJK85te4lvkB45lkTzad2CtJdofzxWqtfi1CB2hafTJTfXoDKKJTxLTyYVo+zIYhvhcEarA==
   dependencies:
     "@azure/storage-blob" "^12.5.0"
     "@techteamer/ocsp" "1.0.0"
@@ -13399,9 +13399,9 @@ vfile@^4.0.0:
     vfile-message "^2.0.0"
 
 vm2@^3.9.8:
-  version "3.9.10"
-  resolved "https://registry.yarnpkg.com/vm2/-/vm2-3.9.10.tgz#c66543096b5c44c8861a6465805c23c7cc996a44"
-  integrity sha512-AuECTSvwu2OHLAZYhG716YzwodKCIJxB6u1zG7PgSQwIgAlEaoXH52bxdcvT8GkGjnYK7r7yWDW0m0sOsPuBjQ==
+  version "3.9.11"
+  resolved "https://registry.yarnpkg.com/vm2/-/vm2-3.9.11.tgz#a880f510a606481719ec3f9803b940c5805a06fe"
+  integrity sha512-PFG8iJRSjvvBdisowQ7iVF580DXb1uCIiGaXgm7tynMR1uTBlv7UJlB1zdv5KJ+Tmq1f0Upnj3fayoEOPpCBKg==
   dependencies:
     acorn "^8.7.0"
     acorn-walk "^8.2.0"


### PR DESCRIPTION
Some companies use an [authenticated proxy](https://docs.snowflake.com/en/user-guide/nodejs-driver-use.html#connecting-through-an-authenticated-proxy) when connecting to Snowflake.

Our Snowflake data sources do not support this connection setting currently.  This PR adds support to detect the proxy settings automatically from an environment variable `SNOWFLAKE_PROXY`.  This is only available when self-hosting GrowthBook.