### PR TITLE
API keys lengths

### DIFF
--- a/packages/back-end/src/services/apiKey.ts
+++ b/packages/back-end/src/services/apiKey.ts
@@ -6,14 +6,16 @@ export async function createApiKey(
   environment: string,
   description?: string
 ): Promise<string> {
-  const key =
-    "key_" +
-    environment.substring(0, 4) +
-    "_" +
-    crypto
-      .randomBytes(32)
+  const keyBase = `key_${environment.substring(0, 4)}_`;
+  let keySecret = "";
+  while (keySecret.length < 32) {
+    keySecret = crypto
+      .randomBytes(128)
       .toString("base64")
-      .replace(/[=+/]/g, crypto.randomBytes(1).toString("hex"));
+      .replace(/[=+/]/g, "")
+      .substring(0, 32);
+  }
+  const key = keyBase + keySecret;
 
   await ApiKeyModel.create({
     organization,

--- a/packages/back-end/src/services/apiKey.ts
+++ b/packages/back-end/src/services/apiKey.ts
@@ -1,6 +1,5 @@
-import uniqid from "uniqid";
 import { ApiKeyModel } from "../models/ApiKeyModel";
-import md5 from "md5";
+import crypto from "crypto";
 
 export async function createApiKey(
   organization: string,
@@ -8,7 +7,13 @@ export async function createApiKey(
   description?: string
 ): Promise<string> {
   const key =
-    "key_" + environment.substr(0, 4) + "_" + md5(uniqid()).substr(0, 16);
+    "key_" +
+    environment.substring(0, 4) +
+    "_" +
+    crypto
+      .randomBytes(32)
+      .toString("base64")
+      .replace(/[=+/]/g, crypto.randomBytes(1).toString("hex"));
 
   await ApiKeyModel.create({
     organization,


### PR DESCRIPTION
increased API key length to 32 and encoded as base64 replacing non-url safe chars / + = with a random hex character