### PR TITLE
express app refactor

### DIFF
--- a/packages/back-end/src/routers/admin.ts
+++ b/packages/back-end/src/routers/admin.ts
@@ -1,0 +1,9 @@
+import express from "express";
+import { getOrganizations, addSampleData } from "../controllers/admin";
+
+const router = express.Router();
+
+router.get("/admin/organizations", getOrganizations);
+router.post("/admin/organization/:id/populate", addSampleData);
+
+export { router as adminRouter };

--- a/packages/back-end/src/routers/datasources.ts
+++ b/packages/back-end/src/routers/datasources.ts
@@ -1,0 +1,15 @@
+import express from "express";
+import * as datasourcesController from "../controllers/datasources";
+import { wrapController } from "../services/routers";
+
+wrapController(datasourcesController);
+
+const router = express.Router();
+
+router.get("/datasources", datasourcesController.getDataSources);
+router.get("/datasource/:id", datasourcesController.getDataSource);
+router.post("/datasources", datasourcesController.postDataSources);
+router.put("/datasource/:id", datasourcesController.putDataSource);
+router.delete("/datasource/:id", datasourcesController.deleteDataSource);
+
+export { router as datasourcesRouter };

--- a/packages/back-end/src/routers/dimensions.ts
+++ b/packages/back-end/src/routers/dimensions.ts
@@ -1,0 +1,14 @@
+import express from "express";
+import * as dimensionsController from "../controllers/dimensions";
+import { wrapController } from "../services/routers";
+
+wrapController(dimensionsController);
+
+const router = express.Router();
+
+router.get("/dimensions", dimensionsController.getAllDimensions);
+router.post("/dimensions", dimensionsController.postDimensions);
+router.put("/dimensions/:id", dimensionsController.putDimension);
+router.delete("/dimensions/:id", dimensionsController.deleteDimension);
+
+export { router as dimensionsRouter };

--- a/packages/back-end/src/routers/discussions.ts
+++ b/packages/back-end/src/routers/discussions.ts
@@ -1,0 +1,20 @@
+import express from "express";
+import {
+  deleteComment,
+  getDiscussion,
+  getRecentDiscussions,
+  postDiscussions,
+  postImageUploadUrl,
+  putComment,
+} from "../controllers/discussions";
+
+const router = express.Router();
+
+router.get("/discussion/:parentType/:parentId", getDiscussion);
+router.post("/discussion/:parentType/:parentId", postDiscussions);
+router.put("/discussion/:parentType/:parentId/:index", putComment);
+router.delete("/discussion/:parentType/:parentId/:index", deleteComment);
+router.get("/discussions/recent/:num", getRecentDiscussions);
+router.post("/file/upload/:filetype", postImageUploadUrl);
+
+export { router as discussionsRouter };

--- a/packages/back-end/src/routers/experiments.ts
+++ b/packages/back-end/src/routers/experiments.ts
@@ -1,0 +1,91 @@
+import express from "express";
+import * as experimentsController from "../controllers/experiments";
+import * as reportsController from "../controllers/reports";
+import { wrapController } from "../services/routers";
+
+wrapController(experimentsController);
+wrapController(reportsController);
+
+const router = express.Router();
+
+router.get("/experiments", experimentsController.getExperiments);
+router.post("/experiments", experimentsController.postExperiments);
+router.get(
+  "/experiments/frequency/month/:num",
+  experimentsController.getExperimentsFrequencyMonth
+);
+router.get("/experiments/newfeatures/", experimentsController.getNewFeatures);
+router.get("/experiments/snapshots/", experimentsController.getSnapshots);
+router.get("/experiment/:id", experimentsController.getExperiment);
+router.get("/experiment/:id/reports", reportsController.getReportsOnExperiment);
+router.get("/snapshot/:id/status", experimentsController.getSnapshotStatus);
+router.post("/snapshot/:id/cancel", experimentsController.cancelSnapshot);
+router.get(
+  "/experiment/:id/snapshot/:phase",
+  experimentsController.getSnapshot
+);
+router.get(
+  "/experiment/:id/snapshot/:phase/:dimension",
+  experimentsController.getSnapshotWithDimension
+);
+router.post("/experiment/:id/snapshot", experimentsController.postSnapshot);
+router.post(
+  "/experiment/:id/snapshot/:phase/preview",
+  experimentsController.previewManualSnapshot
+);
+router.post("/experiment/:id", experimentsController.postExperiment);
+router.delete("/experiment/:id", experimentsController.deleteExperiment);
+router.get("/experiment/:id/watchers", experimentsController.getWatchingUsers);
+router.post("/experiment/:id/phase", experimentsController.postExperimentPhase);
+router.post(
+  "/experiment/:id/status",
+  experimentsController.postExperimentStatus
+);
+router.put(
+  "/experiment/:id/phase/:phase",
+  experimentsController.putExperimentPhase
+);
+router.delete(
+  "/experiment/:id/phase/:phase",
+  experimentsController.deleteExperimentPhase
+);
+router.post("/experiment/:id/stop", experimentsController.postExperimentStop);
+router.put(
+  "/experiment/:id/variation/:variation/screenshot",
+  experimentsController.addScreenshot
+);
+router.delete(
+  "/experiment/:id/variation/:variation/screenshot",
+  experimentsController.deleteScreenshot
+);
+router.post(
+  "/experiment/:id/archive",
+  experimentsController.postExperimentArchive
+);
+router.post(
+  "/experiment/:id/unarchive",
+  experimentsController.postExperimentUnarchive
+);
+router.post("/experiments/import", experimentsController.postPastExperiments);
+router.get(
+  "/experiments/import/:id",
+  experimentsController.getPastExperimentsList
+);
+router.get(
+  "/experiments/import/:id/status",
+  experimentsController.getPastExperimentStatus
+);
+router.post(
+  "/experiments/import/:id/cancel",
+  experimentsController.cancelPastExperiments
+);
+router.post(
+  "/experiments/notebook/:id",
+  experimentsController.postSnapshotNotebook
+);
+router.post(
+  "/experiments/report/:snapshot",
+  reportsController.postReportFromSnapshot
+);
+
+export { router as experimentsRouter };

--- a/packages/back-end/src/routers/features.ts
+++ b/packages/back-end/src/routers/features.ts
@@ -1,0 +1,29 @@
+import express from "express";
+import * as featuresController from "../controllers/features";
+import { wrapController } from "../services/routers";
+
+wrapController(featuresController);
+
+const router = express.Router();
+
+router.get("/feature", featuresController.getFeatures);
+router.get("/feature/:id", featuresController.getFeatureById);
+router.post("/feature", featuresController.postFeatures);
+router.put("/feature/:id", featuresController.putFeature);
+router.delete("/feature/:id", featuresController.deleteFeatureById);
+router.post(
+  "/feature/:id/defaultvalue",
+  featuresController.postFeatureDefaultValue
+);
+router.post("/feature/:id/discard", featuresController.postFeatureDiscard);
+router.post("/feature/:id/publish", featuresController.postFeaturePublish);
+router.post("/feature/:id/archive", featuresController.postFeatureArchive);
+router.post("/feature/:id/toggle", featuresController.postFeatureToggle);
+router.post("/feature/:id/draft", featuresController.postFeatureDraft);
+router.post("/feature/:id/rule", featuresController.postFeatureRule);
+router.put("/feature/:id/rule", featuresController.putFeatureRule);
+router.delete("/feature/:id/rule", featuresController.deleteFeatureRule);
+router.post("/feature/:id/reorder", featuresController.postFeatureMoveRule);
+router.get("/usage/features", featuresController.getRealtimeUsage);
+
+export { router as featuresRouter };

--- a/packages/back-end/src/routers/ideas.ts
+++ b/packages/back-end/src/routers/ideas.ts
@@ -1,0 +1,22 @@
+import express from "express";
+import * as ideasController from "../controllers/ideas";
+import { wrapController } from "../services/routers";
+
+wrapController(ideasController);
+
+const router = express.Router();
+
+router.get("/ideas", ideasController.getIdeas);
+router.post("/ideas", ideasController.postIdeas);
+router.get("/idea/:id", ideasController.getIdea);
+router.post("/idea/:id", ideasController.postIdea);
+router.delete("/idea/:id", ideasController.deleteIdea);
+router.post("/idea/:id/vote", ideasController.postVote);
+router.post("/ideas/impact", ideasController.getEstimatedImpact);
+router.post(
+  "/ideas/estimate/manual",
+  ideasController.postEstimatedImpactManual
+);
+router.get("/ideas/recent/:num", ideasController.getRecentIdeas);
+
+export { router as ideasRouter };

--- a/packages/back-end/src/routers/keys.ts
+++ b/packages/back-end/src/routers/keys.ts
@@ -1,0 +1,14 @@
+import express from "express";
+import {
+  getApiKeys,
+  postApiKey,
+  deleteApiKey,
+} from "../controllers/organizations";
+
+const router = express.Router();
+
+router.get("/keys", getApiKeys);
+router.post("/keys", postApiKey);
+router.delete("/key/:key", deleteApiKey);
+
+export { router as keysRouter };

--- a/packages/back-end/src/routers/metrics.ts
+++ b/packages/back-end/src/routers/metrics.ts
@@ -1,0 +1,25 @@
+import express from "express";
+import * as metricsController from "../controllers/metrics";
+import { wrapController } from "../services/routers";
+
+wrapController(metricsController);
+
+const router = express.Router();
+
+router.get("/metrics", metricsController.getMetrics);
+router.post("/metrics", metricsController.postMetrics);
+router.get("/metric/:id", metricsController.getMetric);
+router.put("/metric/:id", metricsController.putMetric);
+router.delete("/metric/:id", metricsController.deleteMetric);
+router.get("/metric/:id/usage", metricsController.getMetricUsage);
+router.post("/metric/:id/analysis", metricsController.postMetricAnalysis);
+router.get(
+  "/metric/:id/analysis/status",
+  metricsController.getMetricAnalysisStatus
+);
+router.post(
+  "/metric/:id/analysis/cancel",
+  metricsController.cancelMetricAnalysis
+);
+
+export { router as metricsRouter };

--- a/packages/back-end/src/routers/organization.ts
+++ b/packages/back-end/src/routers/organization.ts
@@ -1,0 +1,58 @@
+import express from "express";
+import * as organizationsController from "../controllers/organizations";
+import * as datasourcesController from "../controllers/datasources";
+import * as stripeController from "../controllers/stripe";
+import { wrapController } from "../services/routers";
+
+wrapController(organizationsController);
+wrapController(datasourcesController);
+wrapController(stripeController);
+
+const router = express.Router();
+
+// Organization and Settings
+router.put("/user/name", organizationsController.putUserName);
+router.get("/user/watching", organizationsController.getWatchedItems);
+router.post("/user/watch/:type/:id", organizationsController.postWatchItem);
+router.post("/user/unwatch/:type/:id", organizationsController.postUnwatchItem);
+router.get("/organization/definitions", organizationsController.getDefinitions);
+router.get("/activity", organizationsController.getActivityFeed);
+router.get("/history/:type/:id", organizationsController.getHistory);
+router.get("/organization", organizationsController.getOrganization);
+router.post("/organization", organizationsController.signup);
+router.put("/organization", organizationsController.putOrganization);
+router.post(
+  "/organization/config/import",
+  organizationsController.postImportConfig
+);
+router.get("/organization/namespaces", organizationsController.getNamespaces);
+router.post("/organization/namespaces", organizationsController.postNamespaces);
+router.put(
+  "/organization/namespaces/:name",
+  organizationsController.putNamespaces
+);
+router.delete(
+  "/organization/namespaces/:name",
+  organizationsController.deleteNamespace
+);
+router.post("/invite/accept", organizationsController.postInviteAccept);
+router.post("/invite", organizationsController.postInvite);
+router.post("/invite/resend", organizationsController.postInviteResend);
+router.put("/invite/:key/role", organizationsController.putInviteRole);
+router.delete("/invite", organizationsController.deleteInvite);
+router.get("/members", organizationsController.getUsers);
+router.delete("/member/:id", organizationsController.deleteMember);
+router.put("/member/:id/role", organizationsController.putMemberRole);
+router.post("/oauth/google", datasourcesController.postGoogleOauthRedirect);
+router.post("/subscription/checkout", stripeController.postNewSubscription);
+router.get("/subscription/quote", stripeController.getSubscriptionQuote);
+router.post("/subscription/manage", stripeController.postCreateBillingSession);
+router.post("/subscription/success", stripeController.postSubscriptionSuccess);
+router.get("/queries/:ids", datasourcesController.getQueries);
+router.post("/organization/sample-data", datasourcesController.postSampleData);
+router.put(
+  "/member/:id/admin-password-reset",
+  organizationsController.putAdminResetUserPassword
+);
+
+export { router as organizationsRouter };

--- a/packages/back-end/src/routers/preAuth.ts
+++ b/packages/back-end/src/routers/preAuth.ts
@@ -1,0 +1,24 @@
+import express from "express";
+import * as authController from "../controllers/auth";
+import { wrapController } from "../services/routers";
+import { IS_CLOUD } from "../util/secrets";
+
+wrapController(authController);
+
+const router = express.Router();
+
+// Pre-auth requests
+// Managed cloud deployment uses Auth0 instead
+if (!IS_CLOUD) {
+  router.post("/refresh", authController.postRefresh);
+  router.post("/login", authController.postLogin);
+  router.post("/logout", authController.postLogout);
+  router.post("/register", authController.postRegister);
+  router.post("/firsttime", authController.postFirstTimeRegister);
+  router.post("/forgot", authController.postForgotPassword);
+  router.get("/reset/:token", authController.getResetPassword);
+  router.post("/reset/:token", authController.postResetPassword);
+}
+router.get("/hasorgs", authController.getHasOrganizations);
+
+export { router as preAuthRouter };

--- a/packages/back-end/src/routers/presentations.ts
+++ b/packages/back-end/src/routers/presentations.ts
@@ -1,0 +1,20 @@
+import express from "express";
+import {
+  deletePresentation,
+  getPresentation,
+  getPresentationPreview,
+  getPresentations,
+  postPresentation,
+  updatePresentation,
+} from "../controllers/presentations";
+
+const router = express.Router();
+
+router.get("/presentations", getPresentations);
+router.post("/presentation", postPresentation);
+router.get("/presentation/preview", getPresentationPreview);
+router.get("/presentation/:id", getPresentation);
+router.post("/presentation/:id", updatePresentation);
+router.delete("/presentation/:id", deletePresentation);
+
+export { router as presentationsRouter };

--- a/packages/back-end/src/routers/projects.ts
+++ b/packages/back-end/src/routers/projects.ts
@@ -1,0 +1,13 @@
+import express from "express";
+import * as projectsController from "../controllers/projects";
+import { wrapController } from "../services/routers";
+
+wrapController(projectsController);
+
+const router = express.Router();
+
+router.post("", projectsController.postProjects);
+router.put("/:id", projectsController.putProject);
+router.delete("/:id", projectsController.deleteProject);
+
+export { router as projectsRouter };

--- a/packages/back-end/src/routers/reports.ts
+++ b/packages/back-end/src/routers/reports.ts
@@ -1,0 +1,18 @@
+import express from "express";
+import * as reportsController from "../controllers/reports";
+import { wrapController } from "../services/routers";
+
+wrapController(reportsController);
+
+const router = express.Router();
+
+router.get("/report/:id", reportsController.getReport);
+router.put("/report/:id", reportsController.putReport);
+router.delete("/report/:id", reportsController.deleteReport);
+router.get("/report/:id/status", reportsController.getReportStatus);
+router.post("/report/:id/refresh", reportsController.refreshReport);
+router.post("/report/:id/cancel", reportsController.cancelReport);
+router.post("/report/:id/notebook", reportsController.postNotebook);
+router.get("/reports", reportsController.getReports);
+
+export { router as reportsRouter };

--- a/packages/back-end/src/routers/segments.ts
+++ b/packages/back-end/src/routers/segments.ts
@@ -1,0 +1,15 @@
+import express from "express";
+import * as segmentsController from "../controllers/segments";
+import { wrapController } from "../services/routers";
+
+wrapController(segmentsController);
+
+const router = express.Router();
+
+router.get("", segmentsController.getAllSegments);
+router.post("", segmentsController.postSegments);
+router.put("/:id", segmentsController.putSegment);
+router.delete("/:id", segmentsController.deleteSegment);
+router.get("/:id/usage", segmentsController.getSegmentUsage);
+
+export { router as segmentsRouter };

--- a/packages/back-end/src/routers/tags.ts
+++ b/packages/back-end/src/routers/tags.ts
@@ -1,0 +1,12 @@
+import express from "express";
+import * as tagsController from "../controllers/tags";
+import { wrapController } from "../services/routers";
+
+wrapController(tagsController);
+
+const router = express.Router();
+
+router.post("", tagsController.postTag);
+router.delete("/:id", tagsController.deleteTag);
+
+export { router as tagsRouter };

--- a/packages/back-end/src/routers/webhooks.ts
+++ b/packages/back-end/src/routers/webhooks.ts
@@ -1,0 +1,16 @@
+import express from "express";
+import {
+  getWebhooks,
+  postWebhook,
+  putWebhook,
+  deleteWebhook,
+} from "../controllers/organizations";
+
+const router = express.Router();
+
+router.get("/webhooks", getWebhooks);
+router.post("/webhooks", postWebhook);
+router.put("/webhook/:id", putWebhook);
+router.delete("/webhook/:id", deleteWebhook);
+
+export { router as webhooksRouter };

--- a/packages/back-end/src/services/routers.ts
+++ b/packages/back-end/src/services/routers.ts
@@ -1,0 +1,12 @@
+import asyncHandler from "express-async-handler";
+import { RequestHandler } from "express";
+
+// Wrap every controller function in asyncHandler to catch errors properly
+// eslint-disable-next-line
+export function wrapController(controller: Record<string, RequestHandler<any>>): void {
+  Object.keys(controller).forEach((key) => {
+    if (typeof controller[key] === "function") {
+      controller[key] = asyncHandler(controller[key]);
+    }
+  });
+}


### PR DESCRIPTION
The back-end/src/app.ts file was become quite massive and hard to work with because of `app.use()` calls that determine how certain endpoints are allowed to be used. By moving endpoints to routers we can add more granular permissions to endpoints in the future without breaking other endpoints by leveraging `express.Router()` capabilities.