### PR TITLE
Full ratio metric support using the Delta method

### DIFF
--- a/packages/back-end/package.json
+++ b/packages/back-end/package.json
@@ -11,8 +11,7 @@
     "start": "node dist/server.js",
     "test": "jest --forceExit --verbose --detectOpenHandles",
     "type-check": "tsc --pretty --noEmit",
-    "generate-dummy-data": "node --stack-size=8192 ./test/data-generator/data-generator.js",
-    "import-dummy-data": "node --stack-size=8192 ./test/data-generator/import.js"
+    "generate-dummy-data": "ts-node ./test/data-generator/new-generator.ts"
   },
   "dependencies": {
     "@google-cloud/bigquery": "5",

--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -1311,6 +1311,7 @@ export async function getSnapshotStatus(
         {
           $set: {
             ...updates,
+            hasCorrectedStats: true,
             unknownVariations:
               results?.unknownVariations || snapshot.unknownVariations || [],
             multipleExposures:

--- a/packages/back-end/src/integrations/Athena.ts
+++ b/packages/back-end/src/integrations/Athena.ts
@@ -36,4 +36,7 @@ export default class Athena extends SqlIntegration {
   useAliasInGroupBy(): boolean {
     return false;
   }
+  ensureFloat(col: string): string {
+    return `1.0*${col}`;
+  }
 }

--- a/packages/back-end/src/integrations/ClickHouse.ts
+++ b/packages/back-end/src/integrations/ClickHouse.ts
@@ -69,6 +69,12 @@ export default class ClickHouse extends SqlIntegration {
   stddev(col: string) {
     return `stddevSamp(${col})`;
   }
+  variance(col: string) {
+    return `varSamp(${col})`;
+  }
+  covariance(y: string, x: string): string {
+    return `covarSamp(${y}, ${x})`;
+  }
   formatDate(col: string): string {
     return `formatDateTime(${col}, '%F')`;
   }

--- a/packages/back-end/src/integrations/GoogleAnalytics.ts
+++ b/packages/back-end/src/integrations/GoogleAnalytics.ts
@@ -278,17 +278,20 @@ const GoogleAnalytics: SourceIntegrationConstructor = class
             value = users * value;
           }
 
-          const mean =
-            metric.type === "binomial" ? 1 : Math.round(value) / users;
-          const count = metric.type === "binomial" ? value : users;
+          const mean = Math.round(value) / users;
+          const count = users;
 
+          // GA doesn't expose standard deviations, so we have to guess
           // If the metric is duration, we can assume an exponential distribution where the stddev equals the mean
           // If the metric is count, we can assume a poisson distribution where the variance equals the mean
+          // For binomial metrics, we can use the Normal approximation for a bernouli random variable
           const stddev =
             metric.type === "duration"
               ? mean
               : metric.type === "count"
               ? Math.sqrt(mean)
+              : metric.type === "binomial"
+              ? Math.sqrt(mean * (1 - mean))
               : 0;
 
           return {

--- a/packages/back-end/src/integrations/Mixpanel.ts
+++ b/packages/back-end/src/integrations/Mixpanel.ts
@@ -61,11 +61,11 @@ export default class Mixpanel implements SourceIntegrationInterface {
   private aggregateMetricValues(metric: MetricInterface, destVar: string) {
     if (metric.type === "binomial") {
       return `// Metric - ${metric.name}
-      ${destVar} = ${destVar}.length ? 1 : null;`;
+      ${destVar} = ${destVar}.length ? 1 : 0;`;
     }
 
     return `// Metric - ${metric.name}
-    ${destVar} = !${destVar}.length ? null : (
+    ${destVar} = !${destVar}.length ? 0 : (
       (values => ${this.getMetricAggregationExpression(metric)})(${destVar})
     );${
       metric.cap && metric.cap > 0

--- a/packages/back-end/src/integrations/Mysql.ts
+++ b/packages/back-end/src/integrations/Mysql.ts
@@ -31,6 +31,9 @@ export default class Mysql extends SqlIntegration {
   covariance(y: string, x: string): string {
     return `(SUM(${x}*${y})-SUM(${x})*SUM(${y})/COUNT(*))/(COUNT(*)-1)`;
   }
+  stddev(col: string) {
+    return `STDDEV_SAMP(${col})`;
+  }
   addTime(
     col: string,
     unit: "hour" | "minute",

--- a/packages/back-end/src/integrations/Mysql.ts
+++ b/packages/back-end/src/integrations/Mysql.ts
@@ -28,6 +28,9 @@ export default class Mysql extends SqlIntegration {
   dateDiff(startCol: string, endCol: string) {
     return `DATEDIFF(${endCol}, ${startCol})`;
   }
+  covariance(y: string, x: string): string {
+    return `(SUM(${x}*${y})-SUM(${x})*SUM(${y})/COUNT(*))/(COUNT(*)-1)`;
+  }
   addTime(
     col: string,
     unit: "hour" | "minute",

--- a/packages/back-end/src/integrations/Postgres.ts
+++ b/packages/back-end/src/integrations/Postgres.ts
@@ -22,7 +22,7 @@ export default class Postgres extends SqlIntegration {
   dateDiff(startCol: string, endCol: string) {
     return `${endCol}::DATE - ${startCol}::DATE`;
   }
-  castIntToFloat(col: string): string {
+  ensureFloat(col: string): string {
     return `${col}::float`;
   }
   avg(col: string) {

--- a/packages/back-end/src/integrations/Postgres.ts
+++ b/packages/back-end/src/integrations/Postgres.ts
@@ -22,6 +22,9 @@ export default class Postgres extends SqlIntegration {
   dateDiff(startCol: string, endCol: string) {
     return `${endCol}::DATE - ${startCol}::DATE`;
   }
+  castIntToFloat(col: string): string {
+    return `${col}::float`;
+  }
   avg(col: string) {
     return `AVG(${col}::float)`;
   }

--- a/packages/back-end/src/integrations/Presto.ts
+++ b/packages/back-end/src/integrations/Presto.ts
@@ -84,4 +84,7 @@ export default class Presto extends SqlIntegration {
   useAliasInGroupBy(): boolean {
     return false;
   }
+  ensureFloat(col: string): string {
+    return `1.0*${col}`;
+  }
 }

--- a/packages/back-end/src/integrations/Redshift.ts
+++ b/packages/back-end/src/integrations/Redshift.ts
@@ -28,7 +28,7 @@ export default class Redshift extends SqlIntegration {
   formatDate(col: string) {
     return `to_char(${col}, 'YYYY-MM-DD')`;
   }
-  castIntToFloat(col: string): string {
+  ensureFloat(col: string): string {
     return `${col}::float`;
   }
 }

--- a/packages/back-end/src/integrations/Redshift.ts
+++ b/packages/back-end/src/integrations/Redshift.ts
@@ -22,6 +22,9 @@ export default class Redshift extends SqlIntegration {
   avg(col: string) {
     return `AVG(${col}::float)`;
   }
+  covariance(y: string, x: string): string {
+    return `(SUM(${x}*${y})-SUM(${x})*SUM(${y})/COUNT(*))/(COUNT(*)-1)`;
+  }
   formatDate(col: string) {
     return `to_char(${col}, 'YYYY-MM-DD')`;
   }

--- a/packages/back-end/src/integrations/Redshift.ts
+++ b/packages/back-end/src/integrations/Redshift.ts
@@ -28,4 +28,7 @@ export default class Redshift extends SqlIntegration {
   formatDate(col: string) {
     return `to_char(${col}, 'YYYY-MM-DD')`;
   }
+  castIntToFloat(col: string): string {
+    return `${col}::float`;
+  }
 }

--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -130,7 +130,7 @@ export default abstract class SqlIntegration
   castToString(col: string): string {
     return `cast(${col} as varchar)`;
   }
-  castIntToFloat(col: string): string {
+  ensureFloat(col: string): string {
     return col;
   }
   castUserDateCol(column: string): string {
@@ -929,17 +929,17 @@ export default abstract class SqlIntegration
         SELECT
           ${isRatio ? `d` : `m`}.variation,
           ${isRatio ? `d` : `m`}.dimension,
-          ${this.castIntToFloat("COUNT(*)")} as count,
+          ${this.ensureFloat("COUNT(*)")} as count,
           ${this.avg("m.value")} as m_mean,
           ${this.variance("m.value")} as m_var,
-          ${this.castIntToFloat("sum(m.value)")} as m_sum,
+          ${this.ensureFloat("sum(m.value)")} as m_sum,
           ${this.stddev("m.value")} as m_sd
           ${
             isRatio
               ? `,
             ${this.avg("d.value")} as d_mean,
             ${this.variance("d.value")} as d_var,
-            ${this.castIntToFloat("sum(d.value)")} as d_sum,
+            ${this.ensureFloat("sum(d.value)")} as d_sum,
             ${this.covariance("d.value", "m.value")} as covar
           `
               : ""

--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -951,7 +951,7 @@ export default abstract class SqlIntegration
       ${this.getVariationDenominator(isRatio, metric)} as count,
       ${this.getVariationMean(isRatio, metric)} as mean,
       ${this.getVariationStddev(isRatio, metric)} as stddev,
-      u.users
+      ${this.getVariationUsers(metric)} as users
     FROM
       __overallUsers u
       LEFT JOIN __stats s ON (
@@ -972,6 +972,12 @@ export default abstract class SqlIntegration
     return metric.queryFormat || (metric.sql ? "sql" : "builder");
   }
 
+  private getVariationUsers(metric: MetricInterface) {
+    if (metric.ignoreNulls) {
+      return `coalesce(s.count,0)`;
+    }
+    return `u.users`;
+  }
   private getVariationDenominator(isRatio: boolean, metric: MetricInterface) {
     // Ratio metrics use the sum of the denominator metric
     if (isRatio) {

--- a/packages/back-end/src/models/ExperimentSnapshotModel.ts
+++ b/packages/back-end/src/models/ExperimentSnapshotModel.ts
@@ -21,6 +21,7 @@ const experimentSnapshotSchema = new mongoose.Schema({
   dimension: String,
   unknownVariations: [String],
   multipleExposures: Number,
+  hasCorrectedStats: Boolean,
   results: [
     {
       _id: false,

--- a/packages/back-end/src/models/ExperimentSnapshotModel.ts
+++ b/packages/back-end/src/models/ExperimentSnapshotModel.ts
@@ -37,6 +37,7 @@ const experimentSnapshotSchema = new mongoose.Schema({
               value: Number,
               cr: Number,
               users: Number,
+              denominator: Number,
               ci: [Number],
               uplift: {
                 dist: String,

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -661,6 +661,7 @@ export async function createSnapshot(
   data.results = results?.dimensions;
   data.unknownVariations = results?.unknownVariations || [];
   data.multipleExposures = results?.multipleExposures || 0;
+  data.hasCorrectedStats = true;
 
   const snapshot = await ExperimentSnapshotModel.create(data);
 

--- a/packages/back-end/src/services/notebook.ts
+++ b/packages/back-end/src/services/notebook.ts
@@ -117,7 +117,6 @@ export async function generateNotebook(
           name: metric.name,
           sql: q.query,
           inverse: !!metric.inverse,
-          ignore_nulls: !!metric.ignoreNulls,
           type: metric.type,
         };
       })
@@ -146,7 +145,6 @@ for metric in data['metrics']:
         'name': metric['name'],
         'sql': metric['sql'],
         'inverse': metric['inverse'],
-        'ignore_nulls': metric['ignore_nulls'],
         'type': metric['type']
     })
 

--- a/packages/back-end/src/services/reports.ts
+++ b/packages/back-end/src/services/reports.ts
@@ -216,6 +216,11 @@ export async function runReport(
       report.args,
       useCache
     );
+
+    if (results) {
+      results.hasCorrectedStats = true;
+    }
+
     updates.queries = queries;
     updates.results = results || report.results;
     updates.runStarted = new Date();

--- a/packages/back-end/src/services/stats.ts
+++ b/packages/back-end/src/services/stats.ts
@@ -24,6 +24,7 @@ export interface StatsEngineDimensionResponse {
     cr: number;
     value: number;
     users: number;
+    denominator?: number;
     stats: MetricStats;
     expected?: number;
     chanceToWin?: number;

--- a/packages/back-end/src/services/stats.ts
+++ b/packages/back-end/src/services/stats.ts
@@ -79,7 +79,6 @@ data = json.loads("""${JSON.stringify({
       var_names: variations.map((v) => v.name),
       weights: variations.map((v) => v.weight),
       type: metric.type,
-      ignore_nulls: !!metric.ignoreNulls,
       inverse: !!metric.inverse,
       max_dimensions: maxDimensions,
       rows,
@@ -87,7 +86,6 @@ data = json.loads("""${JSON.stringify({
 
 var_id_map = data['var_id_map']
 var_names = data['var_names']
-ignore_nulls = data['ignore_nulls']
 inverse = data['inverse']
 type = data['type']
 weights = data['weights']
@@ -104,8 +102,6 @@ df = get_metric_df(
   rows=rows,
   var_id_map=var_id_map,
   var_names=var_names,
-  ignore_nulls=ignore_nulls,
-  type=type,
 )
 
 reduced = reduce_dimensionality(

--- a/packages/back-end/src/services/stats.ts
+++ b/packages/back-end/src/services/stats.ts
@@ -80,6 +80,7 @@ data = json.loads("""${JSON.stringify({
       var_names: variations.map((v) => v.name),
       weights: variations.map((v) => v.weight),
       type: metric.type,
+      ignore_nulls: !!metric.ignoreNulls,
       inverse: !!metric.inverse,
       max_dimensions: maxDimensions,
       rows,
@@ -87,6 +88,7 @@ data = json.loads("""${JSON.stringify({
 
 var_id_map = data['var_id_map']
 var_names = data['var_names']
+ignore_nulls = data['ignore_nulls']
 inverse = data['inverse']
 type = data['type']
 weights = data['weights']
@@ -103,6 +105,9 @@ df = get_metric_df(
   rows=rows,
   var_id_map=var_id_map,
   var_names=var_names,
+  ignore_nulls=ignore_nulls,
+  type=type,
+  needs_correction=False
 )
 
 reduced = reduce_dimensionality(

--- a/packages/back-end/test/data-generator/create.sql
+++ b/packages/back-end/test/data-generator/create.sql
@@ -5,8 +5,8 @@ CREATE TABLE pages (
   sessionId VARCHAR(64), 
   browser VARCHAR(20), 
   country VARCHAR(2), 
-  path VARCHAR(32), 
-  timestamp TIMESTAMP
+  timestamp TIMESTAMP, 
+  path VARCHAR(32)
 );
 
 DROP TABLE IF EXISTS experiment_viewed;
@@ -15,10 +15,10 @@ CREATE TABLE experiment_viewed (
   anonymousId VARCHAR(64), 
   sessionId VARCHAR(64), 
   browser VARCHAR(20), 
-  country VARCHAR(2), 
+  country VARCHAR(2),
+  timestamp TIMESTAMP, 
   experimentId VARCHAR(32),
-  variationId VARCHAR(32),
-  timestamp TIMESTAMP
+  variationId VARCHAR(32)
 );
 
 DROP TABLE IF EXISTS orders;
@@ -27,10 +27,10 @@ CREATE TABLE orders (
   anonymousId VARCHAR(64), 
   sessionId VARCHAR(64), 
   browser VARCHAR(20), 
-  country VARCHAR(2), 
+  country VARCHAR(2),
+  timestamp TIMESTAMP, 
   qty INTEGER,
-  amount INTEGER,
-  timestamp TIMESTAMP
+  amount INTEGER
 );
 
 DROP TABLE IF EXISTS events;
@@ -41,8 +41,8 @@ CREATE TABLE events (
   sessionId VARCHAR(64), 
   browser VARCHAR(20), 
   country VARCHAR(2), 
-  event VARCHAR(32), 
-  timestamp TIMESTAMP
+  timestamp TIMESTAMP, 
+  event VARCHAR(32)
 );
 
 DROP TABLE IF EXISTS sessions;
@@ -51,8 +51,8 @@ CREATE TABLE sessions (
   anonymousId VARCHAR(64), 
   sessionId VARCHAR(64), 
   browser VARCHAR(20), 
-  sessionStart TIMESTAMP, 
   country VARCHAR(2), 
+  sessionStart TIMESTAMP, 
   pages INTEGER,
   duration INTEGER
 );

--- a/packages/back-end/test/data-generator/create.sql
+++ b/packages/back-end/test/data-generator/create.sql
@@ -1,0 +1,66 @@
+DROP TABLE IF EXISTS pages;
+CREATE TABLE pages (
+  userId VARCHAR(8), 
+  anonymousId VARCHAR(64), 
+  sessionId VARCHAR(64), 
+  browser VARCHAR(20), 
+  country VARCHAR(2), 
+  path VARCHAR(32), 
+  timestamp TIMESTAMP
+);
+
+DROP TABLE IF EXISTS experiment_viewed;
+CREATE TABLE experiment_viewed (
+  userId VARCHAR(8), 
+  anonymousId VARCHAR(64), 
+  sessionId VARCHAR(64), 
+  browser VARCHAR(20), 
+  country VARCHAR(2), 
+  experimentId VARCHAR(32),
+  variationId VARCHAR(32),
+  timestamp TIMESTAMP
+);
+
+DROP TABLE IF EXISTS orders;
+CREATE TABLE orders (
+  userId VARCHAR(8), 
+  anonymousId VARCHAR(64), 
+  sessionId VARCHAR(64), 
+  browser VARCHAR(20), 
+  country VARCHAR(2), 
+  qty INTEGER,
+  amount INTEGER,
+  timestamp TIMESTAMP
+);
+
+DROP TABLE IF EXISTS events;
+CREATE TABLE events (
+  value INTEGER,
+  userId VARCHAR(8), 
+  anonymousId VARCHAR(64), 
+  sessionId VARCHAR(64), 
+  browser VARCHAR(20), 
+  country VARCHAR(2), 
+  event VARCHAR(32), 
+  timestamp TIMESTAMP
+);
+
+DROP TABLE IF EXISTS sessions;
+CREATE TABLE sessions (
+  userId VARCHAR(8), 
+  anonymousId VARCHAR(64), 
+  sessionId VARCHAR(64), 
+  browser VARCHAR(20), 
+  sessionStart TIMESTAMP, 
+  country VARCHAR(2), 
+  pages INTEGER,
+  duration INTEGER
+);
+
+
+
+\copy orders from '/tmp/csv/purchases.csv' WITH DELIMITER ',' CSV HEADER;
+\copy sessions from '/tmp/csv/sessions.csv' WITH DELIMITER ',' CSV HEADER;
+\copy events from '/tmp/csv/events.csv' WITH DELIMITER ',' CSV HEADER;
+\copy experiment_viewed from '/tmp/csv/experimentViews.csv' WITH DELIMITER ',' CSV HEADER;
+\copy pages from '/tmp/csv/pageViews.csv' WITH DELIMITER ',' CSV HEADER;

--- a/packages/back-end/test/data-generator/new-generator.js
+++ b/packages/back-end/test/data-generator/new-generator.js
@@ -1,0 +1,424 @@
+const growthbook = require("@growthbook/growthbook");
+const jstat = require("jstat");
+const fs = require("fs");
+const ObjectToCsv = require("objects-to-csv");
+
+const NUM_USERS = 10000;
+
+const userRetention = {};
+
+const startDate = new Date();
+startDate.setDate(startDate.getDate() - 90);
+function getDateRangeCondition(start, end) {
+  const s = new Date(startDate);
+  const e = new Date(startDate);
+  s.setDate(s.getDate() + start);
+  e.setDate(e.getDate() + end);
+
+  return {
+    date: {
+      $gte: s.toISOString().substring(0, 10),
+      $lte: e.toISOString().substring(0, 10),
+    },
+  };
+}
+
+const currentDate = new Date(startDate);
+
+function setRandomTime() {
+  currentDate.setHours(Math.floor(Math.random() * 12));
+  currentDate.setMinutes(Math.floor(Math.random() * 50));
+  currentDate.setSeconds(0);
+}
+
+function advanceTime(max = 61) {
+  const seconds = normalInt(1, max);
+  currentDate.setSeconds(currentDate.getSeconds() + seconds);
+}
+
+const experimentViews = [];
+function trackExperiment({ sessionStart, ...data }, result, experimentId) {
+  if (!result.inExperiment) return;
+  experimentViews.push({
+    ...data,
+    experimentId,
+    variationId: result.variationId,
+    timestamp: getTimestamp(),
+  });
+}
+
+const events = [];
+function trackEvent({ sessionStart, ...data }, event) {
+  events.push({
+    value: 0,
+    ...data,
+    event,
+    timestamp: getTimestamp(),
+  });
+}
+
+const purchases = [];
+function trackPurchase({ sessionStart, ...data }) {
+  purchases.push({
+    ...data,
+    timestamp: getTimestamp(),
+  });
+}
+
+const pageViews = [];
+function trackPageView({ sessionStart, ...data }) {
+  pageViews.push({
+    ...data,
+    timestamp: getTimestamp(),
+  });
+}
+
+function getBrowser() {
+  const r = Math.random();
+  if (r < 0.68) {
+    return "Chrome";
+  }
+  if (r < 0.87) {
+    return "Safari";
+  }
+  if (r < 0.91) {
+    return "Edge";
+  }
+  if (r < 0.95) {
+    return "Firefox";
+  }
+  if (r < 0.98) {
+    return "Samsung Internet";
+  }
+  return "Opera";
+}
+
+function normalInt(min, max) {
+  const mean = (max - min) / 2 + min;
+  const stddev = (max - min) / 3;
+
+  const x = Math.round(jstat.normal.sample(mean, stddev));
+  if (x < min) return min;
+  if (x > max) return max;
+  return x;
+}
+
+function getCountry(userId) {
+  const i = userId % 10;
+  if (i < 6) return "US";
+  if (i < 8) return "UK";
+  if (i < 9) return "CA";
+  return "AU";
+}
+
+function viewHomepage(data, gb) {
+  // Land on home page
+  trackPageView({
+    ...data,
+    path: "/",
+  });
+  // Homepage CTA experiment (no change to behavior)
+  trackExperiment(
+    data,
+    gb.run({
+      key: "homepage-nav-ios",
+      variations: [0, 1, 2],
+      weights: [0.5, 0.25, 0.25],
+      condition: {
+        browser: "Safari",
+      },
+    }),
+    "homepage-nav-ios"
+  );
+
+  advanceTime(30);
+
+  // Only some users open the navigation
+  if (Math.random() < 0.5) {
+    trackEvent(data, "Open Nav");
+  }
+
+  // And some perform a search
+  const searched = Math.random() < 0.8;
+  if (searched) {
+    trackEvent(data, "Search");
+  }
+
+  advanceTime(30);
+
+  return !searched;
+}
+
+function viewSearchResults(data, gb) {
+  trackPageView({
+    ...data,
+    path: "/search",
+  });
+  // A/B test on the search order (mixed, less people sorting manually, but more bounces)
+  const res = gb.run({
+    key: "results-order",
+    // Bounce rate
+    variations: [0.15, 0.12],
+    condition: getDateRangeCondition(5, 35),
+  });
+  trackExperiment(data, res, "results-order");
+  advanceTime(20);
+
+  // Some people sort manually (depends on experiment variation)
+  if (Math.random() < Math.pow(res.value, 2) * 5) {
+    trackEvent(data, "Sort Results");
+  }
+
+  // Bounce rate also depends on variation
+  return Math.random() < 0.3 - res.value;
+}
+
+function viewItemPage(data, gb) {
+  // Id corresponds to price
+  const itemId = Math.floor(Math.random() * 10 + 1);
+  trackPageView({
+    ...data,
+    path: `/item/${itemId}`,
+  });
+  // A/B test price display (loser, fewer qty purchased)
+  let res = gb.run({
+    key: "price-display",
+    // Max qty purchased
+    variations: [7, 5],
+    condition: getDateRangeCondition(30, 60),
+  });
+  trackExperiment(data, res, "price-display");
+  const qty = normalInt(1, res.value);
+  const amount = qty * itemId;
+
+  // A/B test the add-to-cart CTA (winner)
+  res = gb.run({
+    key: "add-to-cart-cta",
+    variations: [0.3, 0.36],
+    condition: getDateRangeCondition(45, 75),
+  });
+
+  advanceTime(20);
+  if (Math.random() < res.value) {
+    trackEvent(
+      {
+        ...data,
+        value: amount,
+      },
+      "Add to Cart"
+    );
+    return {
+      itemId,
+      addToCart: true,
+      qty,
+      amount,
+    };
+  }
+
+  return {
+    itemId,
+    addToCart: false,
+    qty: 0,
+    amount: 0,
+  };
+}
+
+function viewCheckout(data, gb) {
+  trackPageView({
+    ...data,
+    path: `/checkout`,
+  });
+  // A/B test checkout layout (variation 1 is worse, 2 is better)
+  const res = gb.run({
+    key: "checkout-layout",
+    // Bounce rate
+    variations: [0.3, 0.4, 0.25],
+    condition: getDateRangeCondition(50, 100),
+  });
+  trackExperiment(data, res, "checkout-layout");
+  advanceTime(30);
+  return Math.random() < res.value;
+}
+
+function purchase(data, gb, qty, price) {
+  trackPageView({
+    ...data,
+    path: `/success`,
+  });
+  trackPurchase({
+    ...data,
+    qty: qty,
+    amount: price,
+  });
+  advanceTime(30);
+
+  // A/B test confirmation email (winner, improved retention)
+  const res = gb.run({
+    key: "confirmation-email",
+    // How much retention is gained (out of 100)
+    variations: [5, 10],
+    condition: getDateRangeCondition(70, 90),
+  });
+  trackExperiment(data, res, "confirmation-email");
+  userRetention[parseInt(data.userId)] += normalInt(
+    res.value - 10,
+    res.value + 10
+  );
+}
+
+function getTimestamp() {
+  return currentDate.toISOString().substring(0, 19).replace("T", " ");
+}
+
+const sessions = [];
+async function simulateSession(userId, anonymousId) {
+  setRandomTime();
+  const browser = getBrowser();
+  const commonEventData = {
+    userId: userId + "",
+    anonymousId: browser + anonymousId,
+    sessionId: Math.random() + "",
+    browser,
+    sessionStart: getTimestamp(),
+    country: getCountry(userId),
+  };
+
+  const gb = new growthbook.GrowthBook({
+    attributes: {
+      id: userId,
+      anonId: commonEventData.anonymousId,
+      date: currentDate.toISOString().substring(0, 10),
+      browser: commonEventData.browser,
+      country: commonEventData.country,
+    },
+  });
+
+  let bounce = viewHomepage(commonEventData, gb);
+  if (bounce) return commonEventData;
+
+  bounce = viewSearchResults(commonEventData, gb);
+  if (bounce) return commonEventData;
+
+  // Views a couple items
+  let qty = 0;
+  let price = 0;
+  // A/B test that shows recommended items (increases number viewed)
+  let res = gb.run({
+    key: "recommended-items",
+    variations: [4, 4.2, 4.4],
+    condition: getDateRangeCondition(20, 50),
+  });
+  const itemsViewed = normalInt(1, res.value);
+  for (let i = 0; i < itemsViewed; i++) {
+    const item = viewItemPage(commonEventData, gb);
+    qty += item.qty;
+    price += item.amount;
+  }
+  if (!qty) return commonEventData;
+
+  bounce = viewCheckout(commonEventData, gb);
+  if (bounce) return commonEventData;
+
+  purchase(commonEventData, gb, qty, price);
+
+  return commonEventData;
+}
+
+const anonymousIds = {};
+async function simulate() {
+  for (let i = 0; i < 90; i++) {
+    for (let j = 0; j < NUM_USERS; j++) {
+      // Space out people's starting days
+      const firstDay = (j / NUM_USERS) * 60;
+      if (i < firstDay) continue;
+
+      // If user is retained
+      const r = Math.random() * 800;
+      if (!(j in userRetention)) {
+        userRetention[j] = 100;
+      }
+      if (r >= userRetention[j]) continue;
+
+      // Small chance of clearing cookies
+      if (!anonymousIds[j] || Math.random() < 0.05) {
+        anonymousIds[j] = j + "__" + Math.random() + "";
+      }
+
+      const startingPageviews = pageViews.length;
+      const data = await simulateSession(j, anonymousIds[j]);
+      const duration = Math.round(
+        (currentDate.getTime() - new Date(data.sessionStart + "Z").getTime()) /
+          1000
+      );
+      sessions.push({
+        ...data,
+        pages: pageViews.length - startingPageviews,
+        duration,
+      });
+
+      userRetention[j] -= normalInt(20, 40);
+    }
+    currentDate.setDate(currentDate.getDate() + 1);
+  }
+}
+simulate().then(async () => {
+  console.log("Done!");
+
+  const sortDate = (a, b) => a.timestamp.localeCompare(b.timestamp);
+
+  sessions.sort((a, b) => a.sessionStart.localeCompare(b.sessionStart));
+  pageViews.sort(sortDate);
+  experimentViews.sort(sortDate);
+  purchases.sort(sortDate);
+  events.sort(sortDate);
+
+  console.log({
+    users: NUM_USERS,
+    sessions: sessions.length,
+    pageViews: pageViews.length,
+    experiments: experimentViews.length,
+    purchases: purchases.length,
+    events: events.length,
+  });
+
+  //fs.mkdirSync("csv");
+  fs.mkdirSync("/tmp/csv", { recursive: true });
+  await new ObjectToCsv(sessions).toDisk("/tmp/csv/sessions.csv");
+  await new ObjectToCsv(pageViews).toDisk("/tmp/csv/pageViews.csv");
+  await new ObjectToCsv(experimentViews).toDisk("/tmp/csv/experimentViews.csv");
+  await new ObjectToCsv(purchases).toDisk("/tmp/csv/purchases.csv");
+  await new ObjectToCsv(events).toDisk("/tmp/csv/events.csv");
+});
+
+function getSample(userId) {
+  return {
+    userId,
+    sessions: sessions
+      .filter((x) => x.userId === userId)
+      .map((s) => {
+        const filter = (x) =>
+          x.userId === userId && x.sessionId === s.sessionId;
+        const combined = events
+          .filter(filter)
+          .concat(
+            pageViews.filter(filter).map((p) => ({ ...p, event: "Page View" }))
+          )
+          .concat(
+            experimentViews
+              .filter(filter)
+              .map((e) => ({ ...e, event: "Experiment Viewed" }))
+          )
+          .map(({ userId, sessionStart, sessionId, anonymousId, ...other }) => {
+            return other;
+          });
+        combined.sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+
+        return {
+          ...s,
+          events: combined,
+        };
+      }),
+  };
+}
+
+// console.log(JSON.stringify(getSample("100"), null, 2));

--- a/packages/back-end/types/experiment-snapshot.d.ts
+++ b/packages/back-end/types/experiment-snapshot.d.ts
@@ -45,6 +45,7 @@ export interface ExperimentSnapshotInterface {
   dimension: string | null;
   unknownVariations?: string[];
   multipleExposures?: number;
+  hasCorrectedStats?: boolean;
   results?: {
     name: string;
     srm: number;

--- a/packages/back-end/types/experiment-snapshot.d.ts
+++ b/packages/back-end/types/experiment-snapshot.d.ts
@@ -6,6 +6,7 @@ export interface SnapshotMetric {
   value: number;
   cr: number;
   users: number;
+  denominator?: number;
   ci?: [number, number];
   expected?: number;
   risk?: [number, number];

--- a/packages/back-end/types/report.d.ts
+++ b/packages/back-end/types/report.d.ts
@@ -51,6 +51,7 @@ export interface ExperimentReportResultDimension {
 export interface ExperimentReportResults {
   unknownVariations: string[];
   multipleExposures: number;
+  hasCorrectedStats?: boolean;
   dimensions: ExperimentReportResultDimension[];
 }
 export interface ExperimentReportInterface extends ReportInterfaceBase {

--- a/packages/back-end/typings/jstat/index.d.ts
+++ b/packages/back-end/typings/jstat/index.d.ts
@@ -3,6 +3,7 @@ declare module "jstat" {
     namespace normal {
       export function inv(n: number, mean: number, stddev: number): number;
       export function pdf(x: number, mean: number, stddev: number): number;
+      export function sample(mean: number, stddev: number): number;
     }
     namespace chisquare {
       export function cdf(x: number, l: number): number;

--- a/packages/docs/pages/app/metrics.mdx
+++ b/packages/docs/pages/app/metrics.mdx
@@ -80,14 +80,28 @@ WHERE
 
 By default, metrics are evaluated against all users in an experiment: `(# users who converted) / (# users in experiment)`
 
-You can instead choose another metric to use as the denominator. This acts just like an "activation metric" in an experiment to filter the list of users who are included in the analysis to those who first convert on the denominator metric.
+You can instead choose another metric to use as the denominator.
 
-For example, it's common to have multiple metrics related to revenue, all selecting the exact same data but with different denominators:
+##### Funnel Metrics
 
-- **Revenue per User** - default denominator of "All Users in Experiment"
-- **Average Order Value** - denominator set to a metric which only includes paying customers.
+When the denominator is a simple binomial (conversion) metric, then it acts just like an "activation metric" in an experiment. It filters the users who are included in the analysis to those who first convert on this denominator metric.
 
-Another common example is a funnel conversion metric like `Add To Cart -> Start Checkout` or `Signup Completion Rate`.
+For example, if you want to look at what percent of users checkout after viewing a cart, it can be described as `% checkout / % viewed cart`. This requires creating two metrics:
+
+1. `Viewed Cart` - selects all users who viewed a cart
+2. `Viewed Cart -> Checkout` - selects all users who checked out and picks `Viewed Cart` as the denominator.
+
+##### Ratio Metrics
+
+When the denominator is a count metric, then things are a little different. Instead of acting like a filter, we calculate both metrics and treat the value as a ratio.
+
+- The mean is `sum(metric) / sum(denominator)`
+- The standard deviation is calculated using the **Delta method**
+
+For example, if you want to look at the Average Order Value (AOV), what you're really looking for is `total revenue / number of orders`. This also requires creating two metrics:
+
+1. `Orders per User` - selects the count of orders for each user
+2. `AOV` - selects total revenue per user and picks `Orders per User` as the denominator.
 
 ### 2. Javascript (Mixpanel only)
 

--- a/packages/front-end/components/Experiment/ManualSnapshotForm.tsx
+++ b/packages/front-end/components/Experiment/ManualSnapshotForm.tsx
@@ -86,11 +86,12 @@ const ManualSnapshotForm: FC<{
       const m = getMetricById(key);
       ret[key] = values.metrics[key].map((v, i) => {
         if (m.type === "binomial") {
+          const p = v.count / values.users[i];
           return {
             users: values.users[i],
-            count: v.count,
-            mean: 1,
-            stddev: 1,
+            count: values.users[i],
+            mean: p,
+            stddev: Math.sqrt(p * (1 - p)),
           };
         } else if (m.type === "count") {
           return {
@@ -102,7 +103,7 @@ const ManualSnapshotForm: FC<{
         } else if (m.type === "revenue") {
           return {
             users: values.users[i],
-            count: v.count,
+            count: values.users[i],
             mean: v.mean,
             stddev: v.stddev,
           };

--- a/packages/front-end/components/Experiment/MetricValueColumn.tsx
+++ b/packages/front-end/components/Experiment/MetricValueColumn.tsx
@@ -43,7 +43,7 @@ export default function MetricValueColumn({
                 </span>{" "}
                 /&nbsp;
                 {numberFormatter.format(
-                  stats.stats?.count || stats.users || users
+                  stats.denominator || stats.users || users
                 )}
               </em>
             </small>

--- a/packages/front-end/components/Experiment/MetricValueColumn.tsx
+++ b/packages/front-end/components/Experiment/MetricValueColumn.tsx
@@ -42,7 +42,9 @@ export default function MetricValueColumn({
                   )}
                 </span>{" "}
                 /&nbsp;
-                {numberFormatter.format(stats.users || users)}
+                {numberFormatter.format(
+                  stats.stats?.count || stats.users || users
+                )}
               </em>
             </small>
           </div>

--- a/packages/front-end/components/Metrics/MetricForm.tsx
+++ b/packages/front-end/components/Metrics/MetricForm.tsx
@@ -251,14 +251,23 @@ const MetricForm: FC<MetricFormProps> = ({
     return metrics
       .filter((m) => m.id !== current?.id)
       .filter((m) => m.datasource === value.datasource)
-      .filter((m) => m.type === "binomial")
+      .filter((m) => {
+        // Binomial metrics can always be a denominator
+        // That just makes it act like a funnel (or activation) metric
+        if (m.type === "binomial") return true;
+
+        // If the numerator has a value (not binomial),
+        // then count metrics can be used as the denominator as well.
+        // This makes it act like a true ratio metric
+        return value.type !== "binomial" && m.type === "count";
+      })
       .map((m) => {
         return {
           value: m.id,
           label: m.name,
         };
       });
-  }, [metrics, value.datasource]);
+  }, [metrics, value.type, value.datasource]);
 
   const currentDataSource = getDatasourceById(value.datasource);
 

--- a/packages/front-end/components/Metrics/MetricForm.tsx
+++ b/packages/front-end/components/Metrics/MetricForm.tsx
@@ -257,9 +257,11 @@ const MetricForm: FC<MetricFormProps> = ({
         if (m.type === "binomial") return true;
 
         // If the numerator has a value (not binomial),
-        // then count metrics can be used as the denominator as well.
+        // then count metrics can be used as the denominator as well (as long as they don't have their own denominator)
         // This makes it act like a true ratio metric
-        return value.type !== "binomial" && m.type === "count";
+        return (
+          value.type !== "binomial" && m.type === "count" && !m.denominator
+        );
       })
       .map((m) => {
         return {

--- a/packages/stats/gbstats/gbstats.py
+++ b/packages/stats/gbstats/gbstats.py
@@ -73,7 +73,7 @@ def get_metric_df(rows, var_id_map, var_names, ignore_nulls=None, type="binomial
             }
 
             # Legacy usage of this library required mean/stddev correction
-            if ignore_nulls != None:
+            if ignore_nulls is not None:
                 # Mean/stddev in SQL results are only based on converting users
                 # If we need to add in unconverting users, we need to correct the values
                 stats = get_adjusted_stats(
@@ -180,7 +180,7 @@ def analyze_metric_df(df, weights, type="binomial", inverse=False):
 
             # Run the A/B test analysis of baseline vs variation
             if type == "binomial":
-                res = binomial_ab_test(m_a * x_a, x_a, m_b*x_b, x_b)
+                res = binomial_ab_test(m_a * x_a, x_a, m_b * x_b, x_b)
             else:
                 res = gaussian_ab_test(m_a, s_a, n_a, m_b, s_b, n_b)
 
@@ -259,8 +259,14 @@ def format_results(df):
 def get_adjusted_stats(x, sx, c, n, ignore_nulls=False, type="binomial"):
     # Binomial metrics always have mean=1 and stddev=0, no need to correct
     if type == "binomial":
-        p = c/n if n > 0 else 0
-        return {"users": n, "count": n, "mean": p, "stddev": math.sqrt(p*(1-p)), "total": c}
+        p = c / n if n > 0 else 0
+        return {
+            "users": n,
+            "count": n,
+            "mean": p,
+            "stddev": math.sqrt(p * (1 - p)),
+            "total": c,
+        }
     # Ignore unconverted users
     elif ignore_nulls:
         return {"users": c, "count": c, "mean": x, "stddev": sx, "total": c * x}

--- a/packages/stats/gbstats/gbstats.py
+++ b/packages/stats/gbstats/gbstats.py
@@ -213,6 +213,7 @@ def format_results(df):
                         "cr": row[f"{prefix}_cr"],
                         "value": row[f"{prefix}_total"],
                         "users": row[f"{prefix}_users"],
+                        "denominator": row[f"{prefix}_count"],
                         "stats": stats,
                     }
                 )
@@ -222,6 +223,7 @@ def format_results(df):
                         "cr": row[f"{prefix}_cr"],
                         "value": row[f"{prefix}_total"],
                         "users": row[f"{prefix}_users"],
+                        "denominator": row[f"{prefix}_count"],
                         "expected": row[f"{prefix}_expected"],
                         "chanceToWin": row[f"{prefix}_prob_beat_baseline"],
                         "uplift": row[f"{prefix}_uplift"],

--- a/packages/stats/gbstats/gbstats.py
+++ b/packages/stats/gbstats/gbstats.py
@@ -32,7 +32,14 @@ def detect_unknown_variations(rows, var_id_map, ignore_ids={"__multiple__"}):
 
 
 # Transform raw SQL result for metrics into a dataframe of dimensions
-def get_metric_df(rows, var_id_map, var_names, ignore_nulls=None, type="binomial"):
+def get_metric_df(
+    rows,
+    var_id_map,
+    var_names,
+    ignore_nulls=False,
+    type="binomial",
+    needs_correction=True,
+):
     dimensions = {}
     # Each row in the raw SQL result is a dimension/variation combo
     # We want to end up with one row per dimension
@@ -73,7 +80,7 @@ def get_metric_df(rows, var_id_map, var_names, ignore_nulls=None, type="binomial
             }
 
             # Legacy usage of this library required mean/stddev correction
-            if ignore_nulls is not None:
+            if needs_correction:
                 # Mean/stddev in SQL results are only based on converting users
                 # If we need to add in unconverting users, we need to correct the values
                 stats = get_adjusted_stats(

--- a/packages/stats/gbstats/gbstats.py
+++ b/packages/stats/gbstats/gbstats.py
@@ -136,9 +136,7 @@ def analyze_metric_df(df, weights, type="binomial", inverse=False):
         m_a = s["baseline_mean"]
         x_a = s["baseline_count"]
         s_a = s["baseline_stddev"]
-        cr_a = s["baseline_total"] / x_a if x_a > 0 else 0
-
-        s["baseline_cr"] = cr_a
+        s["baseline_cr"] = m_a
 
         # List of users in each variation (used for SRM check)
         users = [0] * num_variations
@@ -152,10 +150,9 @@ def analyze_metric_df(df, weights, type="binomial", inverse=False):
             m_b = s[f"v{i}_mean"]
             x_b = s[f"v{i}_count"]
             s_b = s[f"v{i}_stddev"]
-            cr_b = s[f"v{i}_total"] / x_b if x_b > 0 else 0
 
-            s[f"v{i}_cr"] = cr_b
-            s[f"v{i}_expected"] = (cr_b / cr_a) - 1 if cr_a > 0 else 0
+            s[f"v{i}_cr"] = m_b
+            s[f"v{i}_expected"] = (m_b / m_a) - 1 if m_a > 0 else 0
 
             users[i] = n_b
 
@@ -171,8 +168,8 @@ def analyze_metric_df(df, weights, type="binomial", inverse=False):
             ctw = res["chance_to_win"] if not inverse else 1 - res["chance_to_win"]
 
             # Turn risk into relative risk
-            risk0 = risk0 / cr_b if cr_b > 0 else 0
-            risk1 = risk1 / cr_b if cr_b > 0 else 0
+            risk0 = risk0 / m_b if m_b > 0 else 0
+            risk1 = risk1 / m_b if m_b > 0 else 0
 
             # The baseline risk is the max risk of any of the variation A/B tests
             if risk0 > baseline_risk:

--- a/packages/stats/gbstats/gbstats.py
+++ b/packages/stats/gbstats/gbstats.py
@@ -32,7 +32,7 @@ def detect_unknown_variations(rows, var_id_map, ignore_ids={"__multiple__"}):
 
 
 # Transform raw SQL result for metrics into a dataframe of dimensions
-def get_metric_df(rows, var_id_map, var_names, ignore_nulls=False, type="binomial"):
+def get_metric_df(rows, var_id_map, var_names):
     dimensions = {}
     # Each row in the raw SQL result is a dimension/variation combo
     # We want to end up with one row per dimension
@@ -63,23 +63,13 @@ def get_metric_df(rows, var_id_map, var_names, ignore_nulls=False, type="binomia
         key = str(row.variation)
         if key in var_id_map:
             i = var_id_map[key]
-            # Mean/stddev in SQL results are only based on converting users
-            # If we need to add in unconverting users, we need to correct the values
-            stats = get_adjusted_stats(
-                x=row.mean,
-                sx=row.stddev,
-                c=row.count,
-                n=row.users,
-                ignore_nulls=ignore_nulls,
-                type=type,
-            )
-            dimensions[dim]["total_users"] += stats["users"]
+            dimensions[dim]["total_users"] += row.users
             prefix = f"v{i}" if i > 0 else "baseline"
-            dimensions[dim][f"{prefix}_users"] = stats["users"]
-            dimensions[dim][f"{prefix}_count"] = stats["count"]
-            dimensions[dim][f"{prefix}_mean"] = stats["mean"]
-            dimensions[dim][f"{prefix}_stddev"] = stats["stddev"]
-            dimensions[dim][f"{prefix}_total"] = stats["total"]
+            dimensions[dim][f"{prefix}_users"] = row.users
+            dimensions[dim][f"{prefix}_count"] = row.count
+            dimensions[dim][f"{prefix}_mean"] = row.mean
+            dimensions[dim][f"{prefix}_stddev"] = row.stddev
+            dimensions[dim][f"{prefix}_total"] = row.mean * row.count
 
     return pd.DataFrame(dimensions.values())
 
@@ -146,7 +136,7 @@ def analyze_metric_df(df, weights, type="binomial", inverse=False):
         m_a = s["baseline_mean"]
         x_a = s["baseline_count"]
         s_a = s["baseline_stddev"]
-        cr_a = s["baseline_total"] / n_a if n_a > 0 else 0
+        cr_a = s["baseline_total"] / x_a if x_a > 0 else 0
 
         s["baseline_cr"] = cr_a
 
@@ -162,7 +152,7 @@ def analyze_metric_df(df, weights, type="binomial", inverse=False):
             m_b = s[f"v{i}_mean"]
             x_b = s[f"v{i}_count"]
             s_b = s[f"v{i}_stddev"]
-            cr_b = s[f"v{i}_total"] / n_b if n_b > 0 else 0
+            cr_b = s[f"v{i}_total"] / x_b if x_b > 0 else 0
 
             s[f"v{i}_cr"] = cr_b
             s[f"v{i}_expected"] = (cr_b / cr_a) - 1 if cr_a > 0 else 0
@@ -171,7 +161,7 @@ def analyze_metric_df(df, weights, type="binomial", inverse=False):
 
             # Run the A/B test analysis of baseline vs variation
             if type == "binomial":
-                res = binomial_ab_test(x_a, n_a, x_b, n_b)
+                res = binomial_ab_test(m_a*x_a, x_a, m_b*x_b, x_b)
             else:
                 res = gaussian_ab_test(m_a, s_a, n_a, m_b, s_b, n_b)
 
@@ -242,150 +232,6 @@ def format_results(df):
                 )
         results.append(dim)
     return results
-
-
-# Adjust metric stats to account for unconverted users
-def get_adjusted_stats(x, sx, c, n, ignore_nulls=False, type="binomial"):
-    # Binomial metrics always have mean=1 and stddev=0, no need to correct
-    if type == "binomial":
-        return {"users": n, "count": c, "mean": 1, "stddev": 0, "total": c}
-    # Ignore unconverted users
-    elif ignore_nulls:
-        return {"users": c, "count": c, "mean": x, "stddev": sx, "total": c * x}
-    # Add in unconverted users and correct the mean/stddev
-    else:
-        m = n - c
-        return {
-            "users": n,
-            "count": c,
-            "mean": correctMean(c, x, m, 0),
-            "stddev": correctStddev(c, x, sx, m, 0, 0),
-            "total": c * x,
-        }
-
-
-# @deprecated
-# Transform raw SQL result for metrics into a list of stats per variation
-def process_metric_rows(rows, var_id_map, users, ignore_nulls=False, type="binomial"):
-    stats = [{"users": 0, "count": 0, "mean": 0, "stddev": 0, "total": 0}] * len(
-        var_id_map.keys()
-    )
-    for row in rows.itertuples(index=False):
-        id = str(row.variation)
-        if id in var_id_map:
-            variation = var_id_map[id]
-            stats[variation] = get_adjusted_stats(
-                x=row.mean,
-                sx=row.stddev,
-                c=row.count,
-                n=users[variation],
-                ignore_nulls=ignore_nulls,
-                type=type,
-            )
-    return pd.DataFrame(stats)
-
-
-# @deprecated
-# Transform raw SQL result for users into a list of num_users per variation
-def process_user_rows(rows, var_id_map):
-    users = [0] * len(var_id_map.keys())
-    unknown_var_ids = []
-    for row in rows.itertuples(index=False):
-        id = str(row.variation)
-        if id in var_id_map:
-            variation = var_id_map[id]
-            users[variation] = row.users
-        else:
-            unknown_var_ids.append(id)
-    return users, unknown_var_ids
-
-
-# @deprecated
-# Run A/B test analysis for a metric
-def run_analysis(metric, var_names, type="binomial", inverse=False):
-    vars = iter(metric.itertuples(index=False))
-    baseline = next(vars)
-
-    # baseline users, mean, count, stddev, and value
-    n_a = baseline.users
-    m_a = baseline.mean
-    x_a = baseline.count
-    s_a = baseline.stddev
-    v_a = baseline.total
-
-    cr_a = v_a / n_a
-
-    ret = pd.DataFrame(
-        [
-            {
-                "variation": var_names[0],
-                "users": n_a,
-                "total": v_a,
-                "per_user": cr_a,
-                "chance_to_beat_control": None,
-                "risk_of_choosing": None,
-                "percent_change": None,
-                "uplift_dist": None,
-                "uplift_mean": None,
-                "uplift_stddev": None,
-            }
-        ]
-    )
-
-    baseline_risk = 0
-    for i, row in enumerate(vars):
-        # variation users, mean, count, stddev, and value
-        n_b = row.users
-        m_b = row.mean
-        x_b = row.count
-        s_b = row.stddev
-        v_b = row.total
-        cr_b = v_b / n_b
-
-        if type == "binomial":
-            res = binomial_ab_test(x_a, n_a, x_b, n_b)
-        else:
-            res = gaussian_ab_test(m_a, s_a, n_a, m_b, s_b, n_b)
-
-        # Flip risk and chance to win for inverse metrics
-        risk0 = res["risk"][0] if not inverse else res["risk"][1]
-        risk1 = res["risk"][1] if not inverse else res["risk"][0]
-        ctw = res["chance_to_win"] if not inverse else 1 - res["chance_to_win"]
-
-        # Turn risk into relative risk
-        risk0 = risk0 / cr_b
-        risk1 = risk1 / cr_b
-
-        if risk0 > baseline_risk:
-            baseline_risk = risk0
-
-        s = pd.Series(
-            {
-                "variation": var_names[i + 1],
-                "users": n_b,
-                "total": v_b,
-                "per_user": cr_b,
-                "chance_to_beat_control": ctw,
-                "risk_of_choosing": risk1,
-                "percent_change": res["expected"],
-                "uplift_dist": res["uplift"]["dist"],
-                "uplift_mean": res["uplift"]["mean"],
-                "uplift_stddev": res["uplift"]["stddev"],
-            }
-        )
-
-        ret = ret.append(s, ignore_index=True)
-
-    ret.at[0, "risk_of_choosing"] = baseline_risk
-
-    # Rename columns for binomial metrics
-    if type == "binomial":
-        ret.rename(
-            columns={"total": "conversions", "per_user": "conversion_rate"},
-            inplace=True,
-        )
-
-    return ret
 
 
 # Run a chi-squared test to make sure the observed traffic split matches the expected one

--- a/packages/stats/gbstats/gen_notebook.py
+++ b/packages/stats/gbstats/gen_notebook.py
@@ -1,4 +1,4 @@
-from .gbstats import (
+from packages.stats.gbstats.gbstats import (
     detect_unknown_variations,
     analyze_metric_df,
     get_metric_df,
@@ -102,7 +102,6 @@ def create_notebook(
         cells.append(nbf.new_markdown_cell("### Data Quality Checks / Preparation"))
 
         type = metric["type"]
-        ignore_nulls = metric["ignore_nulls"]
         inverse = metric["inverse"]
 
         unknown_var_ids = detect_unknown_variations(metric["rows"], var_id_map)
@@ -124,8 +123,6 @@ def create_notebook(
             rows=metric["rows"],
             var_id_map=var_id_map,
             var_names=var_names,
-            ignore_nulls=ignore_nulls,
-            type=type,
         )
         cells.append(
             code_cell_df(
@@ -136,8 +133,6 @@ def create_notebook(
                     f"    rows=m{i}_rows,\n"
                     f"    var_id_map=var_id_map,\n"
                     f"    var_names=var_names,\n"
-                    f"    ignore_nulls={ignore_nulls},\n"
-                    f'    type="{type}"\n'
                     f")\n"
                     f"display(m{i})"
                 ),

--- a/packages/stats/gbstats/gen_notebook.py
+++ b/packages/stats/gbstats/gen_notebook.py
@@ -39,6 +39,7 @@ def create_notebook(
     weights=[],
     run_query="",
     metrics=[],
+    needs_correction=False,
 ):
     summary_cols = [
         "dimension",
@@ -102,6 +103,7 @@ def create_notebook(
         cells.append(nbf.new_markdown_cell("### Data Quality Checks / Preparation"))
 
         type = metric["type"]
+        ignore_nulls = metric["ignore_nulls"]
         inverse = metric["inverse"]
 
         unknown_var_ids = detect_unknown_variations(metric["rows"], var_id_map)
@@ -123,6 +125,9 @@ def create_notebook(
             rows=metric["rows"],
             var_id_map=var_id_map,
             var_names=var_names,
+            ignore_nulls=ignore_nulls,
+            type=type,
+            needs_correction=needs_correction,
         )
         cells.append(
             code_cell_df(
@@ -133,6 +138,9 @@ def create_notebook(
                     f"    rows=m{i}_rows,\n"
                     f"    var_id_map=var_id_map,\n"
                     f"    var_names=var_names,\n"
+                    f"    ignore_nulls={ignore_nulls},\n"
+                    f'    type="{type}",\n'
+                    f'    needs_correction="{needs_correction}"\n'
                     f")\n"
                     f"display(m{i})"
                 ),

--- a/packages/stats/gbstats/gen_notebook.py
+++ b/packages/stats/gbstats/gen_notebook.py
@@ -1,4 +1,4 @@
-from packages.stats.gbstats.gbstats import (
+from .gbstats import (
     detect_unknown_variations,
     analyze_metric_df,
     get_metric_df,

--- a/packages/stats/tests/test_gbstats.py
+++ b/packages/stats/tests/test_gbstats.py
@@ -213,7 +213,9 @@ def test_get_metric_df_new():
             },
         ]
     )
-    df = get_metric_df(rows, {"zero": 0, "one": 1}, ["zero", "one"])
+    df = get_metric_df(
+        rows, {"zero": 0, "one": 1}, ["zero", "one"], False, "revenue", False
+    )
     result = analyze_metric_df(df, [0.5, 0.5], "revenue", False)
 
     assert len(result.index) == 2

--- a/packages/stats/tests/test_gbstats.py
+++ b/packages/stats/tests/test_gbstats.py
@@ -1,8 +1,12 @@
-import pytest
 import numpy as np
 import pandas as pd
+import math
 from gbstats.gbstats import (
     check_srm,
+    get_adjusted_stats,
+    process_user_rows,
+    process_metric_rows,
+    run_analysis,
     correctMean,
     correctStddev,
     detect_unknown_variations,
@@ -102,7 +106,7 @@ def test_reduce_dimensionality():
             {
                 "dimension": "one",
                 "variation": "one",
-                "count": 1000,
+                "count": 120,
                 "mean": 2.5,
                 "stddev": 1,
                 "users": 1000,
@@ -110,7 +114,7 @@ def test_reduce_dimensionality():
             {
                 "dimension": "one",
                 "variation": "zero",
-                "count": 1100,
+                "count": 100,
                 "mean": 2.7,
                 "stddev": 1.1,
                 "users": 1100,
@@ -118,7 +122,7 @@ def test_reduce_dimensionality():
             {
                 "dimension": "two",
                 "variation": "one",
-                "count": 2000,
+                "count": 220,
                 "mean": 3.5,
                 "stddev": 2,
                 "users": 2000,
@@ -126,7 +130,7 @@ def test_reduce_dimensionality():
             {
                 "dimension": "two",
                 "variation": "zero",
-                "count": 2100,
+                "count": 200,
                 "mean": 3.7,
                 "stddev": 2.1,
                 "users": 2100,
@@ -134,7 +138,7 @@ def test_reduce_dimensionality():
             {
                 "dimension": "three",
                 "variation": "one",
-                "count": 3000,
+                "count": 320,
                 "mean": 4.5,
                 "stddev": 3,
                 "users": 3000,
@@ -142,36 +146,37 @@ def test_reduce_dimensionality():
             {
                 "dimension": "three",
                 "variation": "zero",
-                "count": 3100,
+                "count": 300,
                 "mean": 4.7,
                 "stddev": 3.1,
                 "users": 3100,
             },
         ]
     )
-    df = get_metric_df(rows, {"zero": 0, "one": 1}, ["zero", "one"])
+    df = get_metric_df(rows, {"zero": 0, "one": 1}, ["zero", "one"], True, "revenue")
     reduced = reduce_dimensionality(df, 3)
     print(reduced)
     assert len(reduced.index) == 3
     assert reduced.at[0, "dimension"] == "three"
     assert reduced.at[0, "v1_mean"] == 4.5
     assert reduced.at[0, "v1_stddev"] == 3.0
-    assert reduced.at[0, "v1_users"] == 3000
+    assert reduced.at[0, "v1_total"] == 1440.0
 
     reduced = reduce_dimensionality(df, 2)
     print(reduced)
     assert len(reduced.index) == 2
     assert reduced.at[1, "dimension"] == "(other)"
-    assert round_(reduced.at[1, "v1_mean"]) == 3.166666667
-    assert round_(reduced.at[1, "v1_stddev"]) == 1.794889811
-    assert reduced.at[1, "total_users"] == 6200
-    assert reduced.at[1, "v1_users"] == 3000
-    assert reduced.at[1, "v1_total"] == 9500
-    assert reduced.at[1, "baseline_users"] == 3200
-    assert reduced.at[1, "baseline_total"] == 10740
+    assert round_(reduced.at[1, "v1_mean"]) == 3.147058824
+    assert round_(reduced.at[1, "v1_stddev"]) == 1.778805952
+    assert reduced.at[1, "total_users"] == 640
+    assert reduced.at[1, "v1_users"] == 340
+    assert reduced.at[1, "v1_total"] == 1070
+    assert reduced.at[1, "baseline_users"] == 300
+    assert reduced.at[1, "baseline_total"] == 1010
 
 
-def test_analyze_metric_normal_df():
+# New usage (no mean/stddev correction)
+def test_get_metric_df_new():
     rows = pd.DataFrame(
         [
             {
@@ -211,8 +216,6 @@ def test_analyze_metric_normal_df():
     df = get_metric_df(rows, {"zero": 0, "one": 1}, ["zero", "one"])
     result = analyze_metric_df(df, [0.5, 0.5], "revenue", False)
 
-    print(result)
-
     assert len(result.index) == 2
     assert result.at[0, "dimension"] == "one"
     assert round_(result.at[0, "baseline_cr"]) == 2.7
@@ -221,3 +224,204 @@ def test_analyze_metric_normal_df():
     assert round_(result.at[0, "v1_risk"]) == 0.0821006
     assert round_(result.at[0, "v1_expected"]) == -0.074074074
     assert round_(result.at[0, "v1_prob_beat_baseline"]) == 0.079755378
+
+
+# Legacy usage needed mean/stddev to be corrected
+def test_analyze_metric_df_legacy():
+    rows = pd.DataFrame(
+        [
+            {
+                "dimension": "one",
+                "variation": "one",
+                "count": 120,
+                "mean": 2.5,
+                "stddev": 1,
+                "users": 1000,
+            },
+            {
+                "dimension": "one",
+                "variation": "zero",
+                "count": 100,
+                "mean": 2.7,
+                "stddev": 1.1,
+                "users": 1100,
+            },
+            {
+                "dimension": "two",
+                "variation": "one",
+                "count": 220,
+                "mean": 3.5,
+                "stddev": 2,
+                "users": 2000,
+            },
+            {
+                "dimension": "two",
+                "variation": "zero",
+                "count": 200,
+                "mean": 3.7,
+                "stddev": 2.1,
+                "users": 2100,
+            },
+        ]
+    )
+    df = get_metric_df(rows, {"zero": 0, "one": 1}, ["zero", "one"], False, "revenue")
+    result = analyze_metric_df(df, [0.5, 0.5], "revenue", False)
+
+    assert len(result.index) == 2
+    assert result.at[0, "dimension"] == "one"
+    assert round_(result.at[0, "baseline_cr"]) == 0.245454545
+    assert round_(result.at[0, "baseline_risk"]) == 0.186006962
+    assert round_(result.at[0, "v1_cr"]) == 0.3
+    assert round_(result.at[0, "v1_risk"]) == 0.00418878
+    assert round_(result.at[0, "v1_expected"]) == 0.222222222
+    assert round_(result.at[0, "v1_prob_beat_baseline"]) == 0.925127213
+
+
+def test_adjusted_stats():
+    adjusted = get_adjusted_stats(5, 3, 1000, 2000, False, "revenue")
+    print(adjusted)
+    assert adjusted["users"] == 2000
+    assert adjusted["mean"] == 2.5
+    assert round_(adjusted["stddev"]) == 3.278852762
+    assert adjusted["total"] == 5000
+
+
+def test_adjusted_stats_binomial():
+    adjusted = get_adjusted_stats(1, 0, 1000, 2000, False, "binomial")
+    print(adjusted)
+    assert adjusted["users"] == 2000
+    assert adjusted["mean"] == 0.5
+    assert round_(adjusted["stddev"]) == math.sqrt(.25)
+    assert adjusted["total"] == 1000
+
+
+def test_adjusted_stats_ignore_nulls():
+    adjusted = get_adjusted_stats(5, 3, 1000, 2000, True, "revenue")
+    assert adjusted["users"] == 1000
+    assert adjusted["mean"] == 5
+    assert adjusted["stddev"] == 3
+    assert adjusted["total"] == 5000
+
+
+def test_process_users():
+    vars = {"zero": 0, "one": 1}
+    rows = pd.DataFrame(
+        [{"variation": "one", "users": 120}, {"variation": "zero", "users": 100}]
+    )
+    users, unknown_variations = process_user_rows(rows, vars)
+
+    assert users == [100, 120]
+    assert unknown_variations == []
+
+
+def test_process_users_unknown_vars():
+    var_id_map = {"zero": 0, "one": 1}
+    rows = pd.DataFrame(
+        [{"variation": "one", "users": 120}, {"variation": "zeros", "users": 100}]
+    )
+    users, unknown_variations = process_user_rows(rows, var_id_map)
+
+    assert users == [0, 120]
+    assert unknown_variations == ["zeros"]
+
+
+def test_process_metrics():
+    rows = pd.DataFrame(
+        [
+            {"variation": "one", "count": 120, "mean": 2.5, "stddev": 1},
+            {"variation": "zero", "count": 100, "mean": 2.7, "stddev": 1.1},
+        ]
+    )
+    var_id_map = {"zero": 0, "one": 1}
+    users = [1000, 1010]
+
+    res = process_metric_rows(rows, var_id_map, users, False, "revenue")
+    assert res.loc[0].at["users"] == 1000
+    assert res.loc[0].at["count"] == 1000
+    assert res.loc[0].at["mean"] == 0.27
+    assert round_(res.loc[0].at["stddev"]) == 0.881286938
+
+
+def test_process_metrics_ignore_nulls():
+    rows = pd.DataFrame(
+        [
+            {"variation": "one", "count": 120, "mean": 2.5, "stddev": 1},
+            {"variation": "zero", "count": 100, "mean": 2.7, "stddev": 1.1},
+        ]
+    )
+    var_id_map = {"zero": 0, "one": 1}
+    users = [1000, 1010]
+
+    res = process_metric_rows(rows, var_id_map, users, True, "revenue")
+    assert res.loc[0].at["users"] == 100
+    assert res.loc[0].at["count"] == 100
+    assert res.loc[0].at["mean"] == 2.7
+    assert round_(res.loc[0].at["stddev"]) == 1.1
+
+
+def test_binomial_analysis():
+    metric = pd.DataFrame(
+        [
+            {"users": 1000, "count": 120, "mean": 1, "stddev": 0, "total": 120},
+            {"users": 1024, "count": 128, "mean": 1, "stddev": 0, "total": 128},
+            {"users": 1000, "count": 102, "mean": 1, "stddev": 0, "total": 102},
+        ]
+    )
+    var_names = ["Control", "Variation 1", "Variation 2"]
+    res = run_analysis(metric, var_names, "binomial", False)
+
+    baseline = res.loc[0]
+    var1 = res.loc[1]
+    var2 = res.loc[2]
+
+    assert baseline.at["variation"] == "Control"
+    assert baseline.at["conversion_rate"] == 0.12
+    assert baseline.at["chance_to_beat_control"] == None
+    assert round_(baseline.at["risk_of_choosing"]) == 0.069118343
+    assert baseline.at["percent_change"] == None
+
+    assert var1.at["variation"] == "Variation 1"
+    assert var1.at["conversion_rate"] == 0.125
+    assert round_(var1.at["chance_to_beat_control"]) == 0.633751254
+    assert round_(var1.at["risk_of_choosing"]) == 0.029338254
+    assert round_(var1.at["percent_change"]) == 0.041432724
+
+    assert var2.at["variation"] == "Variation 2"
+    assert var2.at["conversion_rate"] == 0.102
+    assert round_(var2.at["chance_to_beat_control"]) == 0.100849049
+    assert round_(var2.at["risk_of_choosing"]) == 0.182688464
+    assert round_(var2.at["percent_change"]) == -0.149376661
+
+
+def test_gaussian_analysis():
+    metric = pd.DataFrame(
+        [
+            {"users": 1000, "count": 120, "mean": 1.3, "stddev": 1, "total": 156},
+            {"users": 1024, "count": 128, "mean": 1.29, "stddev": 0.9, "total": 165.12},
+            {"users": 1000, "count": 102, "mean": 1.4, "stddev": 1.1, "total": 142.8},
+        ]
+    )
+    var_names = ["Control", "Variation 1", "Variation 2"]
+    res = run_analysis(metric, var_names, "duration", True)
+
+    baseline = res.loc[0]
+    var1 = res.loc[1]
+    var2 = res.loc[2]
+
+    assert baseline.at["variation"] == "Control"
+    assert baseline.at["per_user"] == 0.156
+    assert baseline.at["chance_to_beat_control"] == None
+    assert round_(baseline.at["risk_of_choosing"]) == 0.138620458
+    assert baseline.at["percent_change"] == None
+
+    assert var1.at["variation"] == "Variation 1"
+    assert var1.at["per_user"] == 0.16125
+    assert round_(var1.at["chance_to_beat_control"]) == 0.593436958
+    assert round_(var1.at["risk_of_choosing"]) == 0.076604954
+    assert round_(var1.at["percent_change"]) == -0.007692308
+
+    assert var2.at["variation"] == "Variation 2"
+    assert round_(var2.at["per_user"]) == 0.1428
+    assert round_(var2.at["chance_to_beat_control"]) == 0.016533047
+    assert round_(var2.at["risk_of_choosing"]) == 0.702254931
+    assert round_(var2.at["percent_change"]) == 0.076923077

--- a/packages/stats/tests/test_gbstats.py
+++ b/packages/stats/tests/test_gbstats.py
@@ -1,12 +1,7 @@
-import pytest
 import numpy as np
 import pandas as pd
 from gbstats.gbstats import (
     check_srm,
-    get_adjusted_stats,
-    process_user_rows,
-    process_metric_rows,
-    run_analysis,
     correctMean,
     correctStddev,
     detect_unknown_variations,
@@ -106,7 +101,7 @@ def test_reduce_dimensionality():
             {
                 "dimension": "one",
                 "variation": "one",
-                "count": 120,
+                "count": 1000,
                 "mean": 2.5,
                 "stddev": 1,
                 "users": 1000,
@@ -114,7 +109,7 @@ def test_reduce_dimensionality():
             {
                 "dimension": "one",
                 "variation": "zero",
-                "count": 100,
+                "count": 1100,
                 "mean": 2.7,
                 "stddev": 1.1,
                 "users": 1100,
@@ -122,7 +117,7 @@ def test_reduce_dimensionality():
             {
                 "dimension": "two",
                 "variation": "one",
-                "count": 220,
+                "count": 2000,
                 "mean": 3.5,
                 "stddev": 2,
                 "users": 2000,
@@ -130,7 +125,7 @@ def test_reduce_dimensionality():
             {
                 "dimension": "two",
                 "variation": "zero",
-                "count": 200,
+                "count": 2100,
                 "mean": 3.7,
                 "stddev": 2.1,
                 "users": 2100,
@@ -138,7 +133,7 @@ def test_reduce_dimensionality():
             {
                 "dimension": "three",
                 "variation": "one",
-                "count": 320,
+                "count": 3000,
                 "mean": 4.5,
                 "stddev": 3,
                 "users": 3000,
@@ -146,36 +141,36 @@ def test_reduce_dimensionality():
             {
                 "dimension": "three",
                 "variation": "zero",
-                "count": 300,
+                "count": 3100,
                 "mean": 4.7,
                 "stddev": 3.1,
                 "users": 3100,
             },
         ]
     )
-    df = get_metric_df(rows, {"zero": 0, "one": 1}, ["zero", "one"], True, "revenue")
+    df = get_metric_df(rows, {"zero": 0, "one": 1}, ["zero", "one"])
     reduced = reduce_dimensionality(df, 3)
     print(reduced)
     assert len(reduced.index) == 3
     assert reduced.at[0, "dimension"] == "three"
     assert reduced.at[0, "v1_mean"] == 4.5
     assert reduced.at[0, "v1_stddev"] == 3.0
-    assert reduced.at[0, "v1_total"] == 1440.0
+    assert reduced.at[0, "v1_users"] == 3000
 
     reduced = reduce_dimensionality(df, 2)
     print(reduced)
     assert len(reduced.index) == 2
     assert reduced.at[1, "dimension"] == "(other)"
-    assert round_(reduced.at[1, "v1_mean"]) == 3.147058824
-    assert round_(reduced.at[1, "v1_stddev"]) == 1.778805952
-    assert reduced.at[1, "total_users"] == 640
-    assert reduced.at[1, "v1_users"] == 340
-    assert reduced.at[1, "v1_total"] == 1070
-    assert reduced.at[1, "baseline_users"] == 300
-    assert reduced.at[1, "baseline_total"] == 1010
+    assert round_(reduced.at[1, "v1_mean"]) == 3.166666667
+    assert round_(reduced.at[1, "v1_stddev"]) == 1.794889811
+    assert reduced.at[1, "total_users"] == 6200
+    assert reduced.at[1, "v1_users"] == 3000
+    assert reduced.at[1, "v1_total"] == 9500
+    assert reduced.at[1, "baseline_users"] == 3200
+    assert reduced.at[1, "baseline_total"] == 10740
 
 
-def test_analyze_metric_df():
+def test_analyze_metric_normal_df():
     rows = pd.DataFrame(
         [
             {
@@ -184,7 +179,7 @@ def test_analyze_metric_df():
                 "count": 120,
                 "mean": 2.5,
                 "stddev": 1,
-                "users": 1000,
+                "users": 120,
             },
             {
                 "dimension": "one",
@@ -192,7 +187,7 @@ def test_analyze_metric_df():
                 "count": 100,
                 "mean": 2.7,
                 "stddev": 1.1,
-                "users": 1100,
+                "users": 100,
             },
             {
                 "dimension": "two",
@@ -200,7 +195,7 @@ def test_analyze_metric_df():
                 "count": 220,
                 "mean": 3.5,
                 "stddev": 2,
-                "users": 2000,
+                "users": 220,
             },
             {
                 "dimension": "two",
@@ -208,168 +203,20 @@ def test_analyze_metric_df():
                 "count": 200,
                 "mean": 3.7,
                 "stddev": 2.1,
-                "users": 2100,
+                "users": 200,
             },
         ]
     )
-    df = get_metric_df(rows, {"zero": 0, "one": 1}, ["zero", "one"], False, "revenue")
+    df = get_metric_df(rows, {"zero": 0, "one": 1}, ["zero", "one"])
     result = analyze_metric_df(df, [0.5, 0.5], "revenue", False)
+
+    print(result)
 
     assert len(result.index) == 2
     assert result.at[0, "dimension"] == "one"
-    assert round_(result.at[0, "baseline_cr"]) == 0.245454545
-    assert round_(result.at[0, "baseline_risk"]) == 0.186006962
-    assert round_(result.at[0, "v1_cr"]) == 0.3
-    assert round_(result.at[0, "v1_risk"]) == 0.00418878
-    assert round_(result.at[0, "v1_expected"]) == 0.222222222
-    assert round_(result.at[0, "v1_prob_beat_baseline"]) == 0.925127213
-
-
-def test_adjusted_stats():
-    adjusted = get_adjusted_stats(5, 3, 1000, 2000, False, "revenue")
-    print(adjusted)
-    assert adjusted["users"] == 2000
-    assert adjusted["mean"] == 2.5
-    assert round_(adjusted["stddev"]) == 3.278852762
-    assert adjusted["total"] == 5000
-
-
-def test_adjusted_stats_binomial():
-    adjusted = get_adjusted_stats(1, 0, 1000, 2000, False, "binomial")
-    print(adjusted)
-    assert adjusted["users"] == 2000
-    assert adjusted["mean"] == 1
-    assert round_(adjusted["stddev"]) == 0
-    assert adjusted["total"] == 1000
-
-
-def test_adjusted_stats_ignore_nulls():
-    adjusted = get_adjusted_stats(5, 3, 1000, 2000, True, "revenue")
-    assert adjusted["users"] == 1000
-    assert adjusted["mean"] == 5
-    assert adjusted["stddev"] == 3
-    assert adjusted["total"] == 5000
-
-
-def test_process_users():
-    vars = {"zero": 0, "one": 1}
-    rows = pd.DataFrame(
-        [{"variation": "one", "users": 120}, {"variation": "zero", "users": 100}]
-    )
-    users, unknown_variations = process_user_rows(rows, vars)
-
-    assert users == [100, 120]
-    assert unknown_variations == []
-
-
-def test_process_users_unknown_vars():
-    var_id_map = {"zero": 0, "one": 1}
-    rows = pd.DataFrame(
-        [{"variation": "one", "users": 120}, {"variation": "zeros", "users": 100}]
-    )
-    users, unknown_variations = process_user_rows(rows, var_id_map)
-
-    assert users == [0, 120]
-    assert unknown_variations == ["zeros"]
-
-
-def test_process_metrics():
-    rows = pd.DataFrame(
-        [
-            {"variation": "one", "count": 120, "mean": 2.5, "stddev": 1},
-            {"variation": "zero", "count": 100, "mean": 2.7, "stddev": 1.1},
-        ]
-    )
-    var_id_map = {"zero": 0, "one": 1}
-    users = [1000, 1010]
-
-    res = process_metric_rows(rows, var_id_map, users, False, "revenue")
-    assert res.loc[0].at["users"] == 1000
-    assert res.loc[0].at["count"] == 100
-    assert res.loc[0].at["mean"] == 0.27
-    assert round_(res.loc[0].at["stddev"]) == 0.881286938
-
-
-def test_process_metrics_ignore_nulls():
-    rows = pd.DataFrame(
-        [
-            {"variation": "one", "count": 120, "mean": 2.5, "stddev": 1},
-            {"variation": "zero", "count": 100, "mean": 2.7, "stddev": 1.1},
-        ]
-    )
-    var_id_map = {"zero": 0, "one": 1}
-    users = [1000, 1010]
-
-    res = process_metric_rows(rows, var_id_map, users, True, "revenue")
-    assert res.loc[0].at["users"] == 100
-    assert res.loc[0].at["count"] == 100
-    assert res.loc[0].at["mean"] == 2.7
-    assert round_(res.loc[0].at["stddev"]) == 1.1
-
-
-def test_binomial_analysis():
-    metric = pd.DataFrame(
-        [
-            {"users": 1000, "count": 120, "mean": 1, "stddev": 0, "total": 120},
-            {"users": 1024, "count": 128, "mean": 1, "stddev": 0, "total": 128},
-            {"users": 1000, "count": 102, "mean": 1, "stddev": 0, "total": 102},
-        ]
-    )
-    var_names = ["Control", "Variation 1", "Variation 2"]
-    res = run_analysis(metric, var_names, "binomial", False)
-
-    baseline = res.loc[0]
-    var1 = res.loc[1]
-    var2 = res.loc[2]
-
-    assert baseline.at["variation"] == "Control"
-    assert baseline.at["conversion_rate"] == 0.12
-    assert baseline.at["chance_to_beat_control"] == None
-    assert round_(baseline.at["risk_of_choosing"]) == 0.069118343
-    assert baseline.at["percent_change"] == None
-
-    assert var1.at["variation"] == "Variation 1"
-    assert var1.at["conversion_rate"] == 0.125
-    assert round_(var1.at["chance_to_beat_control"]) == 0.633751254
-    assert round_(var1.at["risk_of_choosing"]) == 0.029338254
-    assert round_(var1.at["percent_change"]) == 0.041432724
-
-    assert var2.at["variation"] == "Variation 2"
-    assert var2.at["conversion_rate"] == 0.102
-    assert round_(var2.at["chance_to_beat_control"]) == 0.100849049
-    assert round_(var2.at["risk_of_choosing"]) == 0.182688464
-    assert round_(var2.at["percent_change"]) == -0.149376661
-
-
-def test_gaussian_analysis():
-    metric = pd.DataFrame(
-        [
-            {"users": 1000, "count": 120, "mean": 1.3, "stddev": 1, "total": 156},
-            {"users": 1024, "count": 128, "mean": 1.29, "stddev": 0.9, "total": 165.12},
-            {"users": 1000, "count": 102, "mean": 1.4, "stddev": 1.1, "total": 142.8},
-        ]
-    )
-    var_names = ["Control", "Variation 1", "Variation 2"]
-    res = run_analysis(metric, var_names, "duration", True)
-
-    baseline = res.loc[0]
-    var1 = res.loc[1]
-    var2 = res.loc[2]
-
-    assert baseline.at["variation"] == "Control"
-    assert baseline.at["per_user"] == 0.156
-    assert baseline.at["chance_to_beat_control"] == None
-    assert round_(baseline.at["risk_of_choosing"]) == 0.138620458
-    assert baseline.at["percent_change"] == None
-
-    assert var1.at["variation"] == "Variation 1"
-    assert var1.at["per_user"] == 0.16125
-    assert round_(var1.at["chance_to_beat_control"]) == 0.593436958
-    assert round_(var1.at["risk_of_choosing"]) == 0.076604954
-    assert round_(var1.at["percent_change"]) == -0.007692308
-
-    assert var2.at["variation"] == "Variation 2"
-    assert round_(var2.at["per_user"]) == 0.1428
-    assert round_(var2.at["chance_to_beat_control"]) == 0.016533047
-    assert round_(var2.at["risk_of_choosing"]) == 0.702254931
-    assert round_(var2.at["percent_change"]) == 0.076923077
+    assert round_(result.at[0, "baseline_cr"]) == 2.7
+    assert round_(result.at[0, "baseline_risk"]) == 0.0021006
+    assert round_(result.at[0, "v1_cr"]) == 2.5
+    assert round_(result.at[0, "v1_risk"]) == 0.0821006
+    assert round_(result.at[0, "v1_expected"]) == -0.074074074
+    assert round_(result.at[0, "v1_prob_beat_baseline"]) == 0.079755378

--- a/packages/stats/tests/test_gbstats.py
+++ b/packages/stats/tests/test_gbstats.py
@@ -1,3 +1,4 @@
+import pytest
 import numpy as np
 import pandas as pd
 from gbstats.gbstats import (

--- a/packages/stats/tests/test_gbstats.py
+++ b/packages/stats/tests/test_gbstats.py
@@ -291,7 +291,7 @@ def test_adjusted_stats_binomial():
     print(adjusted)
     assert adjusted["users"] == 2000
     assert adjusted["mean"] == 0.5
-    assert round_(adjusted["stddev"]) == math.sqrt(.25)
+    assert round_(adjusted["stddev"]) == math.sqrt(0.25)
     assert adjusted["total"] == 1000
 
 


### PR DESCRIPTION
Fixes #495

### Overview

Currently, we only support ratio metrics where the denominator is `binomial`.  This basically limits their use to simple funnel conversion metrics like `Viewed Checkout -> Purchase`.

If we allow the denominator to also be a `count` metric, it would enable a wide range of popular metrics such as:
- **Average Order Value (AOV)** (# orders is the denominator)
- **Pages per Session** (# sessions is the denominator)
- **Average Visit Duration** (# visits is the denominator)
- **Click Through Rate (CTR)** (# impressions is the denominator)

### Changes
- Move all variance/mean correction code from Python to SQL. This simplifies the stats engine and makes it easier to implement new correction techniques.
- Allow selecting `count` metrics as the denominator and implement the **Delta Method** for variance correction.  This is required since the analysis unit (e.g. session) is smaller than the randomization unit (user).
- New realistic sample data generator script. This allows us to test complex interactions between metrics.


### Stats

We're performing the Delta method directly in SQL.  Given a ratio `x/y`, we're first calculating some aggregate stats:

```sql
WITH variations as (
  SELECT
    variation,
    -- Overall stats for the variation
    count(*)         as count,
    covar_samp(y, x) as covar
    -- Stats for x
    avg(x)           as x_mean,
    var_samp(x)      as x_var,
    sum(x)           as x_sum,
    -- Stats for y
    avg(y)           as y_mean,
    var_samp(y)      as y_var,
    sum(y)           as y_sum,
  FROM
    y LEFT JOIN x ON (x.user_id = y.user_id)
  GROUP BY
    variation
)
```

Then we calculate the ratio mean and the stddev using the delta method:

```sql
SELECT
  variation,
  count,
  x_sum/y_sum as mean,
  sqrt(
    x_var/power(y_mean,2)
    - 2*x_mean*covar/power(y_mean,3)
    + power(x_mean,2)*y_var/power(y_mean,4)
  ) as stddev
FROM
  variation
```

### Testing Plan

- [x] Test the implementation of the Delta method
- [x] Test Snowflake
- [x] Test Postgres/Redshift
- [x] Test Presto/Athena
- [x] Test BigQuery
- [x] Test ClickHouse
- [x] Test MySQL
- [x] Test Mixpanel
- [ ] Test GA
- [x] Test gbstats changes
- [x] Make sure existing ratio (funnel) metrics continue to work
- [x] Test new ratio metrics
- [x] Test when combined with activation metrics
- [x] Test when using "All Exposures" attribution model
- [x] Test docker build
- [x] Test Jupyter notebook export