### PR TITLE
Bug fix: Duplicate ports added to Snowflake proxy URL

### DIFF
--- a/packages/back-end/src/services/snowflake.ts
+++ b/packages/back-end/src/services/snowflake.ts
@@ -15,7 +15,7 @@ function getProxySettings(): ProxyOptions {
   const parsed = new URL(uri);
   return {
     proxyProtocol: parsed.protocol,
-    proxyHost: parsed.host,
+    proxyHost: parsed.hostname,
     proxyPort: (parsed.port ? parseInt(parsed.port) : 0) || undefined,
     proxyUser: parsed.username || undefined,
     proxyPassword: parsed.password || undefined,


### PR DESCRIPTION
Accidentally using `url.host` instead of `url.hostname` when constructing the Snowflake proxy URL