### PR TITLE
390 (1 of 4) - Data Source editing UI/UX -> Jupyter

### DIFF
--- a/packages/front-end/components/Settings/EditDataSource/EditJupyterNotebookQueryRunner.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/EditJupyterNotebookQueryRunner.tsx
@@ -36,7 +36,7 @@ export const EditJupyterNotebookQueryRunner: FC<EditJupyterNotebookQueryRunnerPr
       submit={handleSubmit}
       close={onCancel}
       size="max"
-      header="Edit upyter Notebook Query Runner"
+      header="Edit Jupyter Notebook Query Runner"
       cta="Save"
     >
       <h4>Jupyter Notebook Query Runner (optional)</h4>

--- a/packages/front-end/components/Settings/EditDataSource/EditJupyterNotebookQueryRunner.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/EditJupyterNotebookQueryRunner.tsx
@@ -1,0 +1,92 @@
+import { FC } from "react";
+import { useForm } from "react-hook-form";
+import CodeTextArea from "../../Forms/CodeTextArea";
+import cloneDeep from "lodash/cloneDeep";
+import Code from "../../Code";
+import Modal from "../../Modal";
+import { DataSourceQueryEditingModalBaseProps } from "./types";
+import { DataSourceInterfaceWithParams } from "back-end/types/datasource";
+
+type EditJupyterNotebookQueryRunnerProps = DataSourceQueryEditingModalBaseProps;
+
+export const EditJupyterNotebookQueryRunner: FC<EditJupyterNotebookQueryRunnerProps> = ({
+  dataSource,
+  onSave,
+  onCancel,
+}) => {
+  if (!dataSource) {
+    throw new Error("ImplementationError: dataSource cannot be null");
+  }
+
+  const form = useForm({
+    defaultValues: {
+      query: dataSource.settings.notebookRunQuery || "",
+    },
+  });
+
+  const handleSubmit = form.handleSubmit(async (value) => {
+    const copy = cloneDeep<DataSourceInterfaceWithParams>(dataSource);
+    copy.settings.notebookRunQuery = value.query;
+    onSave(copy);
+  });
+
+  return (
+    <Modal
+      open={true}
+      submit={handleSubmit}
+      close={onCancel}
+      size="max"
+      header="Edit upyter Notebook Query Runner"
+      cta="Save"
+    >
+      <h4>Jupyter Notebook Query Runner (optional)</h4>
+      <div className="bg-light border my-2 p-3 ml-3">
+        <div className="row mb-3">
+          <div className="col">
+            <CodeTextArea
+              label="Python runQuery definition"
+              language="python"
+              placeholder="def runQuery(sql):"
+              value={form.watch("query")}
+              setValue={(python) => form.setValue("query", python)}
+              helpText="Used when exporting experiment results to a Jupyter notebook"
+            />
+          </div>
+          <div className="col-md-5 col-lg-4">
+            <div className="pt-md-4">
+              Function definition:
+              <ul>
+                <li>
+                  Function name: <code>runQuery</code>
+                </li>
+                <li>
+                  Arguments: <code>sql</code> (string)
+                </li>
+                <li>
+                  Return: <code>df</code> (pandas data frame)
+                </li>
+              </ul>
+              <p>Example for postgres/redshift:</p>
+              <Code
+                language="python"
+                theme="light"
+                code={`import os
+import psycopg2
+import pandas as pd
+from sqlalchemy import create_engine, text
+
+# Use env variables or similar for passwords!
+password = os.getenv('POSTGRES_PW')
+connStr = f'postgresql+psycopg2://user:{password}@localhost'
+dbConnection = create_engine(connStr).connect();
+
+def runQuery(sql):
+  return pd.read_sql(text(sql), dbConnection)`}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+};

--- a/packages/front-end/components/Settings/EditDataSource/types.d.ts
+++ b/packages/front-end/components/Settings/EditDataSource/types.d.ts
@@ -1,0 +1,19 @@
+import { DataSourceInterfaceWithParams } from "back-end/types/datasource";
+
+export type DataSourceUIMode = "edit" | "view" | "add";
+
+export type DataSourceEditingResourceType =
+  // id: dataSource.settings.queries[x].userIdTypes[y].userIdType
+  | "identifier_types"
+  // id: dataSource.settings.queries[x].exposure[y].id
+  | "experiment_assignment"
+  // id: dataSource.settings.queries[x].identityJoins[y].ids
+  | "identifier_join"
+  // id: dataSource.settings.notebookRunQuery
+  | "jupyter_notebook";
+
+export type DataSourceQueryEditingModalBaseProps = {
+  dataSource: DataSourceInterfaceWithParams;
+  onSave: (dataSource: DataSourceInterfaceWithParams) => void;
+  onCancel: () => void;
+};

--- a/packages/front-end/components/Settings/EditDataSourceSettingsForm.tsx
+++ b/packages/front-end/components/Settings/EditDataSourceSettingsForm.tsx
@@ -5,7 +5,6 @@ import track from "../../services/track";
 import Modal from "../Modal";
 import { DataSourceInterfaceWithParams } from "back-end/types/datasource";
 import Field from "../Forms/Field";
-import Code from "../Code";
 import DataSourceSchemaChooser from "./DataSourceSchemaChooser";
 import { useFieldArray, useForm } from "react-hook-form";
 import StringArrayField from "../Forms/StringArrayField";
@@ -499,57 +498,6 @@ const EditDataSourceSettingsForm: FC<{
                   </button>
                 </div>
               )}
-
-              <h4>Jupyter Notebook Query Runner (optional)</h4>
-              <div className="bg-light border my-2 p-3 ml-3">
-                <div className="row mb-3">
-                  <div className="col">
-                    <CodeTextArea
-                      label="Python runQuery definition"
-                      language="python"
-                      placeholder="def runQuery(sql):"
-                      value={form.watch(`settings.notebookRunQuery`)}
-                      setValue={(python) =>
-                        form.setValue(`settings.notebookRunQuery`, python)
-                      }
-                      helpText="Used when exporting experiment results to a Jupyter notebook"
-                    />
-                  </div>
-                  <div className="col-md-5 col-lg-4">
-                    <div className="pt-md-4">
-                      Function definition:
-                      <ul>
-                        <li>
-                          Function name: <code>runQuery</code>
-                        </li>
-                        <li>
-                          Arguments: <code>sql</code> (string)
-                        </li>
-                        <li>
-                          Return: <code>df</code> (pandas data frame)
-                        </li>
-                      </ul>
-                      <p>Example for postgres/redshift:</p>
-                      <Code
-                        language="python"
-                        theme="light"
-                        code={`import os
-import psycopg2
-import pandas as pd
-from sqlalchemy import create_engine, text
-
-# Use env variables or similar for passwords!
-password = os.getenv('POSTGRES_PW')
-connStr = f'postgresql+psycopg2://user:{password}@localhost'
-dbConnection = create_engine(connStr).connect();
-
-def runQuery(sql):
-  return pd.read_sql(text(sql), dbConnection)`}
-                      />
-                    </div>
-                  </div>
-                </div>
-              </div>
             </>
           )}
         </div>

--- a/packages/front-end/pages/datasources/[did].tsx
+++ b/packages/front-end/pages/datasources/[did].tsx
@@ -1,15 +1,8 @@
 import Link from "next/link";
 import { useRouter } from "next/router";
 import React, { FC, useState } from "react";
-import {
-  FaAngleLeft,
-  FaCloudDownloadAlt,
-  FaCode,
-  FaExternalLinkAlt,
-  FaKey,
-} from "react-icons/fa";
+import { FaAngleLeft, FaCode, FaExternalLinkAlt, FaKey } from "react-icons/fa";
 import DeleteButton from "../../components/DeleteButton";
-import Button from "../../components/Button";
 import { useAuth } from "../../services/auth";
 import { useDefinitions } from "../../services/DefinitionsContext";
 import DataSourceForm from "../../components/Settings/DataSourceForm";
@@ -64,7 +57,6 @@ const DataSourcePage: FC = () => {
 
   const supportsSQL = d.properties?.queryLanguage === "sql";
   const supportsEvents = d.properties?.events || false;
-  const supportsImports = d.properties?.pastExperiments;
 
   const joinTables = (d.settings?.queries?.identityJoins || []).filter(
     (j) => j.query.length > 1
@@ -106,7 +98,7 @@ const DataSourcePage: FC = () => {
       </div>
 
       <div className="row">
-        <div className="col-md-9">
+        <div className="col-md-12">
           <div className="row mb-3">
             {canEdit && permissions.createDatasources && (
               <div className="col-auto">
@@ -317,40 +309,6 @@ mixpanel.init('YOUR PROJECT TOKEN', {
               </div>
             </>
           )}
-        </div>
-        <div className="col-md-3">
-          {supportsImports &&
-            permissions.runQueries &&
-            permissions.createAnalyses && (
-              <div className="card">
-                <div className="card-body">
-                  <h2>Import Past Experiments</h2>
-                  <p>
-                    If you have past experiments already in your data source,
-                    you can import them to GrowthBook.
-                  </p>
-                  <Button
-                    color="outline-primary"
-                    onClick={async () => {
-                      const res = await apiCall<{ id: string }>(
-                        "/experiments/import",
-                        {
-                          method: "POST",
-                          body: JSON.stringify({
-                            datasource: d.id,
-                          }),
-                        }
-                      );
-                      if (res.id) {
-                        await router.push(`/experiments/import/${res.id}`);
-                      }
-                    }}
-                  >
-                    <FaCloudDownloadAlt /> Import
-                  </Button>
-                </div>
-              </div>
-            )}
         </div>
       </div>
 


### PR DESCRIPTION
### Features and Changes

Migrates the Jupyter query section to its own editing modal.

It removes the existing Jupyter section from the unified form and adds it to its own separate section.

The provided types are meant to be used for all data source query editing modals.

- Relates to: https://github.com/growthbook/growthbook/issues/390

### Dependencies

None

### Testing

1. Scroll to the bottom of the screen
2. Click the Edit button beside the Jupyter title
3. Saving path
    1. Edit the query
    2. Press Save
4. Cancel path
    1. Press Cancel

### Screenshots

<img width="1233" alt="image" src="https://user-images.githubusercontent.com/113377031/191382028-8cce8ff2-da7b-4948-88c4-fd2e0fb6a54d.png">

<img width="1303" alt="image" src="https://user-images.githubusercontent.com/113377031/191383356-97e57917-0566-4296-88f4-eb24a851620e.png">


