### PR TITLE
Fix formatting bug for Presto/Athena lambda syntax ('->')

### DIFF
--- a/packages/back-end/src/util/sql.ts
+++ b/packages/back-end/src/util/sql.ts
@@ -96,6 +96,8 @@ export function format(sql: string) {
     })
       // Fix Snowflate syntax for flatten function
       .replace(/ = > /g, " => ")
+      // Similar fix for PrestoDB/Athena lambda functions
+      .replace(/ - > /g, " -> ")
   );
 }
 

--- a/packages/back-end/test/sql.test.ts
+++ b/packages/back-end/test/sql.test.ts
@@ -4,6 +4,7 @@ import {
   conditionToJavascript,
   getMixpanelPropertyColumn,
   expandDenominatorMetrics,
+  format,
 } from "../src/util/sql";
 
 describe("backend", () => {
@@ -177,5 +178,30 @@ describe("backend", () => {
     expect(expandDenominatorMetrics("f", metricMap)).toEqual(["f"]);
     expect(expandDenominatorMetrics("g", metricMap)).toEqual(["g"]);
     expect(expandDenominatorMetrics("h", metricMap)).toEqual([]);
+  });
+
+  it("formats SQL correctly", () => {
+    let inputSQL = `SELECT * FROM mytable`;
+    expect(format(inputSQL)).toEqual(`SELECT\n  *\nFROM\n  mytable`);
+
+    // Snowflake flatten function (=>)
+    inputSQL = `select * from table(flatten(input => parse_json('{"a":1, "b":[77,88]}'), outer => true)) f`;
+    expect(format(inputSQL)).toEqual(
+      `select
+  *
+from
+  table(
+    flatten(
+      input => parse_json('{"a":1, "b":[77,88]}'),
+      outer => true
+    )
+  ) f`
+    );
+
+    // Athena lambda syntax (->)
+    inputSQL = `SELECT transform(numbers, n -> n * n) as sq`;
+    expect(format(inputSQL)).toEqual(
+      `SELECT\n  transform(numbers, n -> n * n) as sq`
+    );
   });
 });


### PR DESCRIPTION
### Features and Changes

Presto/Athena use the `->` syntax in queries for lambda expressions.  Our SQL formatter adds a space (`- >`), which breaks the syntax.  This PR fixes this edge case in our formatter.

Example query:
```sql
SELECT transform(numbers, n -> n * n) as sq
```

Current behavior (broken):
```sql
SELECT
  transform(numbers, n - > n * n) as sq
```

New behavior (fixed):
```sql
SELECT
  transform(numbers, n -> n * n) as sq
```

Note: this is a quick hacky fix and not a long term solution to broken formatting.  #379 contains a more permanent fix for issues like this.

### Testing

Added unit tests.