### PR TITLE
390 (3) - Data Source editing UI/UX -> Identifier Join queries

### DIFF
--- a/packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentifierTypes/DataSourceInlineEditIdentifierTypes.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentifierTypes/DataSourceInlineEditIdentifierTypes.tsx
@@ -82,7 +82,10 @@ export const DataSourceInlineEditIdentifierTypes: FC<DataSourceInlineEditIdentif
         </div>
 
         <div className="">
-          <button className="btn btn-outline-secondary" onClick={handleAdd}>
+          <button
+            className="btn btn-outline-primary font-weight-bold"
+            onClick={handleAdd}
+          >
             <FaPlus className="mr-1" /> Add
           </button>
         </div>
@@ -140,7 +143,10 @@ export const DataSourceInlineEditIdentifierTypes: FC<DataSourceInlineEditIdentif
         <EmptyStateCard>
           <div className="mb-3">No user identifier types.</div>
 
-          <button onClick={handleAdd} className="btn btn-outline-primary">
+          <button
+            onClick={handleAdd}
+            className="btn btn-outline-primary font-weight-bold"
+          >
             <FaPlus className="mr-1" /> Add
           </button>
         </EmptyStateCard>

--- a/packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentifierTypes/EditIdentifierType.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentifierTypes/EditIdentifierType.tsx
@@ -65,39 +65,37 @@ export const EditIdentifierType: FC<EditIdentifierTypeProps> = ({
       open={true}
       submit={handleSubmit}
       close={onCancel}
-      size="max"
+      size="lg"
       header={`${mode === "edit" ? "Edit" : "Add"} Identifier Type`}
       cta="Save"
       ctaEnabled={saveEnabled}
       autoFocusSelector="#id-modal-identifier-type"
     >
-      <div className="row">
-        <div className="col-md-7 col-lg-8">
-          <h4 id="id-modal-identifier-type">Identifier Type</h4>
-          <div>
-            Define all the different units you use to split traffic in an
-            experiment. Some examples: user_id, device_id, ip_address.
-          </div>
-
-          <Field
-            label="Identifier Type"
-            {...form.register("userIdType")}
-            pattern="^[a-z_]+$"
-            title="Only lowercase letters and underscores allowed"
-            readOnly={mode === "edit"}
-            required
-            error={fieldError}
-            helpText="Only lowercase letters and underscores allowed. For example, 'user_id' or 'device_cookie'."
-          />
-          <Field
-            label="Description (optional)"
-            {...form.register("description")}
-            minRows={1}
-            maxRows={5}
-            textarea
-          />
+      <>
+        <h4 id="id-modal-identifier-type">Identifier Type</h4>
+        <div>
+          Define all the different units you use to split traffic in an
+          experiment. Some examples: user_id, device_id, ip_address.
         </div>
-      </div>
+
+        <Field
+          label="Identifier Type"
+          {...form.register("userIdType")}
+          pattern="^[a-z_]+$"
+          title="Only lowercase letters and underscores allowed"
+          readOnly={mode === "edit"}
+          required
+          error={fieldError}
+          helpText="Only lowercase letters and underscores allowed. For example, 'user_id' or 'device_cookie'."
+        />
+        <Field
+          label="Description (optional)"
+          {...form.register("description")}
+          minRows={1}
+          maxRows={5}
+          textarea
+        />
+      </>
     </Modal>
   );
 };

--- a/packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentityJoins/AddEditIdentityJoinModal.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentityJoins/AddEditIdentityJoinModal.tsx
@@ -1,0 +1,135 @@
+import React, { FC, useCallback, useMemo } from "react";
+import {
+  DataSourceInterfaceWithParams,
+  IdentityJoinQuery,
+} from "back-end/types/datasource";
+import isEqual from "lodash/isEqual";
+import intersectionBy from "lodash/intersectionBy";
+
+import { useForm } from "react-hook-form";
+import Modal from "../../../Modal";
+import MultiSelectField from "../../../Forms/MultiSelectField";
+import CodeTextArea from "../../../Forms/CodeTextArea";
+
+type AddEditIdentityJoinModalProps = {
+  identityJoin: IdentityJoinQuery | null;
+  dataSource: DataSourceInterfaceWithParams;
+  mode: "add" | "edit";
+  onSave: (identityJoin: IdentityJoinQuery) => void;
+  onCancel: () => void;
+  // TODO: other props
+};
+
+export const AddEditIdentityJoinModal: FC<AddEditIdentityJoinModalProps> = ({
+  identityJoin,
+  mode,
+  dataSource,
+  onCancel,
+  onSave,
+}) => {
+  const identityTypes = dataSource.settings.userIdTypes || [];
+  const existingIdentityJoins = dataSource.settings.queries.identityJoins || [];
+
+  const defaultQuery = useMemo(() => {
+    return (
+      "SELECT \n" +
+      identityTypes
+        .map(({ userIdType }) => `  ${userIdType} as ${userIdType}`)
+        .join(", \n") +
+      "\nFROM my_table"
+    );
+  }, [identityTypes]);
+
+  const form = useForm<IdentityJoinQuery>({
+    defaultValues: {
+      ids: identityJoin?.ids || [],
+      query: mode === "add" ? defaultQuery : identityJoin?.query || "",
+    },
+  });
+
+  const handleSubmit = form.handleSubmit(async (value) => {
+    onSave(value);
+
+    form.reset({
+      ids: [],
+      query: "",
+    });
+  });
+
+  // TODO: Validate
+  const saveEnabled = true;
+
+  // const isDuplicate = useMemo(() => {
+  //   intersectionBy(existingIdentityJoins, )
+  //   // return mode === "add" && existingIdentityJoins.filter(identityJoin => isEqual());
+  // }, [existingIdentityJoins, mode]);
+
+  const modalTitle = useMemo(() => {
+    if (mode === "add") {
+      return "Add Identifier Join";
+    }
+
+    return `Edit Identifier Join: ${identityJoin.ids.join(" ↔ ")}`;
+  }, [mode, identityJoin]);
+
+  if (!identityJoin && mode === "edit") {
+    console.error(
+      "ImplementationError: identityJoin is required for Edit mode"
+    );
+    return null;
+  }
+
+  return (
+    <Modal
+      open={true}
+      submit={handleSubmit}
+      close={onCancel}
+      size="max"
+      header={modalTitle}
+      cta="Save"
+      ctaEnabled={saveEnabled}
+      autoFocusSelector="#id-modal-identify-joins-heading"
+    >
+      <h4 id="id-modal-identify-joins-heading">Identifier Join</h4>
+      <p>Queries that return a mapping between different identifier types</p>
+
+      <div className="row">
+        <div className="col-xs-12 col-md-6">
+          <MultiSelectField
+            label="Identifier Types"
+            value={form.watch("ids")}
+            onChange={(value) => {
+              form.setValue("ids", value);
+            }}
+            options={identityTypes.map((idType) => ({
+              value: idType.userIdType,
+              label: idType.userIdType,
+            }))}
+          />
+
+          <div>
+            <div className="pt-md-4">
+              <strong>Required columns</strong>
+            </div>
+            <ul>
+              {form.watch("ids").map((id) => (
+                <li key={id}>
+                  <code>{id}</code>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+
+        <div className="col-xs-12 col-md-6">
+          <CodeTextArea
+            label="SQL Query"
+            language="sql"
+            value={form.watch("query")}
+            setValue={(sql) => form.setValue("query", sql)}
+          />
+        </div>
+      </div>
+    </Modal>
+  );
+};

--- a/packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentityJoins/DataSourceInlineEditIdentityJoins.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentityJoins/DataSourceInlineEditIdentityJoins.tsx
@@ -6,8 +6,12 @@ import Code from "../../../Code";
 import MoreMenu from "../../../Dropdown/MoreMenu";
 import DeleteButton from "../../../DeleteButton";
 import cloneDeep from "lodash/cloneDeep";
-import { DataSourceInterfaceWithParams } from "back-end/types/datasource";
+import {
+  DataSourceInterfaceWithParams,
+  IdentityJoinQuery,
+} from "back-end/types/datasource";
 import Tooltip from "../../../Tooltip";
+import { AddEditIdentityJoinModal } from "./AddEditIdentityJoinModal";
 
 type DataSourceInlineEditIdentityJoinsProps = DataSourceQueryEditingModalBaseProps;
 
@@ -69,6 +73,15 @@ export const DataSourceInlineEditIdentityJoins: FC<DataSourceInlineEditIdentityJ
       onSave(copy);
     },
     [identityJoins, onSave, dataSource]
+  );
+
+  const handleSave = useCallback(
+    (idx: number) => (identityJoin: IdentityJoinQuery) => {
+      const copy = cloneDeep<DataSourceInterfaceWithParams>(dataSource);
+      copy.settings.queries.identityJoins[idx] = identityJoin;
+      onSave(copy);
+    },
+    [dataSource, onSave, uiMode]
   );
 
   if (!dataSource) {
@@ -202,7 +215,15 @@ export const DataSourceInlineEditIdentityJoins: FC<DataSourceInlineEditIdentityJ
       {/* endregion Identity Joins empty state */}
 
       {/* region Add/Edit modal */}
-      {uiMode === "edit" || uiMode === "add" ? <>TODO: Add/Edit</> : null}
+      {uiMode === "edit" || uiMode === "add" ? (
+        <AddEditIdentityJoinModal
+          dataSource={dataSource}
+          mode={uiMode}
+          onSave={handleSave(editingIndex)}
+          onCancel={handleCancel}
+          identityJoin={identityJoins[editingIndex]}
+        />
+      ) : null}
       {/* endregion Add/Edit modal */}
     </div>
   );

--- a/packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentityJoins/DataSourceInlineEditIdentityJoins.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentityJoins/DataSourceInlineEditIdentityJoins.tsx
@@ -10,7 +10,6 @@ import {
   DataSourceInterfaceWithParams,
   IdentityJoinQuery,
 } from "back-end/types/datasource";
-import Tooltip from "../../../Tooltip";
 import { AddEditIdentityJoinModal } from "./AddEditIdentityJoinModal";
 
 type DataSourceInlineEditIdentityJoinsProps = DataSourceQueryEditingModalBaseProps;
@@ -42,12 +41,7 @@ export const DataSourceInlineEditIdentityJoins: FC<DataSourceInlineEditIdentityJ
     [openIndexes]
   );
 
-  // const indexOpenMapRef = useRef<Map<number, boolean>>(new Map());
-
   const addIsDisabled = (dataSource.settings?.userIdTypes || []).length < 2;
-  const addButtonTooltip = addIsDisabled
-    ? "You will be able to create identifier join tables when you have identified at least 2 user identifiers."
-    : "";
 
   const identityJoins = dataSource?.settings?.queries?.identityJoins || [];
 
@@ -107,16 +101,14 @@ export const DataSourceInlineEditIdentityJoins: FC<DataSourceInlineEditIdentityJ
           )}
         </div>
 
-        <div className="">
-          <Tooltip body={addButtonTooltip}>
-            <button
-              disabled={addIsDisabled}
-              className="btn btn-outline-primary font-weight-bold"
-              onClick={handleAdd}
-            >
-              <FaPlus className="mr-1" /> Add
-            </button>
-          </Tooltip>
+        <div>
+          <button
+            disabled={addIsDisabled}
+            className="btn btn-outline-primary font-weight-bold"
+            onClick={handleAdd}
+          >
+            <FaPlus className="mr-1" /> Add
+          </button>
         </div>
       </div>
       {/* endregion Heading */}
@@ -192,24 +184,26 @@ export const DataSourceInlineEditIdentityJoins: FC<DataSourceInlineEditIdentityJ
       {identityJoins.length === 0 ? (
         <EmptyStateCard>
           <div className="mb-3">
-            <p>No identity joins.</p>
-            {addIsDisabled && (
+            <h4>No identity joins.</h4>
+            {addIsDisabled ? (
               <p>
                 You will be able to create identifier join tables when you have
                 identified at least 2 user identifiers.
               </p>
+            ) : (
+              <p>
+                You can create identifier join tables with 2 or more identifiers
+              </p>
             )}
           </div>
 
-          <Tooltip body={addButtonTooltip}>
-            <button
-              disabled={addIsDisabled}
-              onClick={handleAdd}
-              className="btn btn-outline-primary font-weight-bold"
-            >
-              <FaPlus className="mr-1" /> Add
-            </button>
-          </Tooltip>
+          <button
+            disabled={addIsDisabled}
+            onClick={handleAdd}
+            className="btn btn-outline-primary font-weight-bold"
+          >
+            <FaPlus className="mr-1" /> Add
+          </button>
         </EmptyStateCard>
       ) : null}
       {/* endregion Identity Joins empty state */}

--- a/packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentityJoins/DataSourceInlineEditIdentityJoins.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentityJoins/DataSourceInlineEditIdentityJoins.tsx
@@ -1,0 +1,139 @@
+import React, { FC, useCallback, useState } from "react";
+import { DataSourceQueryEditingModalBaseProps } from "../types";
+import { EmptyStateCard } from "../EmptyStateCard";
+import { FaChevronRight, FaPlus } from "react-icons/fa";
+import Code from "../../../Code";
+
+type DataSourceInlineEditIdentityJoinsProps = DataSourceQueryEditingModalBaseProps;
+
+export const DataSourceInlineEditIdentityJoins: FC<DataSourceInlineEditIdentityJoinsProps> = ({
+  dataSource,
+  onSave,
+  onCancel,
+}) => {
+  const [uiMode, setUiMode] = useState<"view" | "edit" | "add">("view");
+  const [editingIndex, setEditingIndex] = useState<number>(-1);
+
+  const [openIndexes, setOpenIndexes] = useState<boolean[]>([]);
+
+  const handleExpandCollapseForIndex = useCallback(
+    (index) => () => {
+      const currentValue = openIndexes[index] || false;
+      const updatedOpenIndexes = [...openIndexes];
+      updatedOpenIndexes[index] = !currentValue;
+
+      setOpenIndexes(updatedOpenIndexes);
+    },
+    [openIndexes]
+  );
+
+  // const indexOpenMapRef = useRef<Map<number, boolean>>(new Map());
+
+  const addIsDisabled = (dataSource.settings?.userIdTypes || []).length < 2;
+
+  const identityJoins = dataSource?.settings?.queries?.identityJoins || [];
+
+  const handleAdd = useCallback(() => {
+    setUiMode("add");
+    setEditingIndex(identityJoins.length);
+  }, [identityJoins]);
+
+  if (!dataSource) {
+    console.error("ImplementationError: dataSource cannot be null");
+    return null;
+  }
+
+  return (
+    <div className="my-5">
+      {/* region Heading */}
+      <div className="d-flex justify-content-between align-items-center">
+        <div className="">
+          <h3>Identifier Join Tables</h3>
+          <p>
+            Joins different identifier types together when needed during
+            experiment analysis.
+          </p>
+          {addIsDisabled && (
+            <p>
+              You will be able to create identifier join tables when you have
+              identified at least 2 user identifiers.
+            </p>
+          )}
+        </div>
+
+        <div className="">
+          <button
+            disabled={addIsDisabled}
+            className="btn btn-outline-primary font-weight-bold"
+            onClick={handleAdd}
+          >
+            <FaPlus className="mr-1" /> Add
+          </button>
+        </div>
+      </div>
+      {/* endregion Heading */}
+
+      {/* region Identity Joins list */}
+      <div className="mb-4">
+        {identityJoins.map((identityJoin, idx) => {
+          const isOpen = openIndexes[idx] || false;
+          return (
+            <div className="bg-white border mb-3" key={`identity-join-${idx}`}>
+              <div className="d-flex justify-content-between">
+                <h4 className="py-3 px-3 my-0">
+                  {identityJoin.ids.join(" ↔ ")}
+                </h4>
+                <button
+                  className="btn"
+                  onClick={handleExpandCollapseForIndex(idx)}
+                >
+                  <FaChevronRight
+                    style={{
+                      transform: `rotate(${isOpen ? "90deg" : "0deg"})`,
+                    }}
+                  />
+                </button>
+              </div>
+              <div>
+                {isOpen && (
+                  <Code
+                    language="sql"
+                    theme="light"
+                    code={identityJoin.query}
+                    containerClassName="mb-0"
+                    expandable={true}
+                  />
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+      {/* endregion Identity Joins list */}
+
+      {/* region Identity Joins empty state */}
+      {identityJoins.length === 0 ? (
+        <EmptyStateCard>
+          <div className="mb-3">
+            <p>No identity joins.</p>
+            {addIsDisabled && (
+              <p>
+                You will be able to create identifier join tables when you have
+                identified at least 2 user identifiers.
+              </p>
+            )}
+          </div>
+
+          <button
+            disabled={addIsDisabled}
+            onClick={handleAdd}
+            className="btn btn-outline-primary font-weight-bold"
+          >
+            <FaPlus className="mr-1" /> Add
+          </button>
+        </EmptyStateCard>
+      ) : null}
+      {/* endregion Identity Joins empty state */}
+    </div>
+  );
+};

--- a/packages/front-end/pages/datasources/[did].tsx
+++ b/packages/front-end/pages/datasources/[did].tsx
@@ -25,6 +25,7 @@ import {
 import { EditJupyterNotebookQueryRunner } from "../../components/Settings/EditDataSource/EditJupyterNotebookQueryRunner";
 import { DataSourceInterfaceWithParams } from "back-end/types/datasource";
 import { DataSourceInlineEditIdentifierTypes } from "../../components/Settings/EditDataSource/DataSourceInlineEditIdentifierTypes/DataSourceInlineEditIdentifierTypes";
+import { DataSourceInlineEditIdentityJoins } from "../../components/Settings/EditDataSource/DataSourceInlineEditIdentityJoins/DataSourceInlineEditIdentityJoins";
 
 function quotePropertyName(name: string) {
   if (name.match(/^[a-zA-Z_][a-zA-Z0-9_]*$/)) {
@@ -304,6 +305,7 @@ mixpanel.init('YOUR PROJECT TOKEN', {
                   </div>
                 ))}
               </div>
+
               {joinTables.length > 0 && d.settings?.userIdTypes?.length > 1 && (
                 <div className="mb-4">
                   <h3>Identifier Join Tables</h3>
@@ -325,6 +327,12 @@ mixpanel.init('YOUR PROJECT TOKEN', {
                   ))}
                 </div>
               )}
+
+              <DataSourceInlineEditIdentityJoins
+                dataSource={d}
+                onSave={updateDataSource}
+                onCancel={cancelUpdateDataSource}
+              />
 
               {/* region Jupyter Notebook */}
               <div className="mb-4">

--- a/packages/front-end/pages/datasources/[did].tsx
+++ b/packages/front-end/pages/datasources/[did].tsx
@@ -306,28 +306,6 @@ mixpanel.init('YOUR PROJECT TOKEN', {
                 ))}
               </div>
 
-              {joinTables.length > 0 && d.settings?.userIdTypes?.length > 1 && (
-                <div className="mb-4">
-                  <h3>Identifier Join Tables</h3>
-                  <p>
-                    Joins different identifier types together when needed during
-                    experiment analysis.
-                  </p>
-                  {joinTables.map((t, i) => (
-                    <div className="bg-white border mb-3" key={i}>
-                      <h4 className="pt-3 px-3">{t.ids.join(", ")}</h4>
-                      <Code
-                        language="sql"
-                        theme="light"
-                        code={t.query}
-                        containerClassName="mb-0"
-                        expandable={true}
-                      />
-                    </div>
-                  ))}
-                </div>
-              )}
-
               <DataSourceInlineEditIdentityJoins
                 dataSource={d}
                 onSave={updateDataSource}

--- a/packages/front-end/pages/datasources/[did].tsx
+++ b/packages/front-end/pages/datasources/[did].tsx
@@ -127,6 +127,7 @@ const DataSourcePage: FC = () => {
           <div className="col-auto">
             <DeleteButton
               displayName={d.name}
+              className="font-weight-bold"
               text="Delete"
               onClick={async () => {
                 await apiCall(`/datasource/${d.id}`, {
@@ -261,6 +262,7 @@ mixpanel.init('YOUR PROJECT TOKEN', {
                 onCancel={cancelUpdateDataSource}
                 dataSource={d}
               />
+              {/* endregion Identifier Types */}
 
               <div className="mb-4">
                 <h3>Experiment Assignment Queries</h3>
@@ -333,7 +335,7 @@ mixpanel.init('YOUR PROJECT TOKEN', {
 
                   <div className="">
                     <button
-                      className="btn btn-outline-secondary"
+                      className="btn btn-outline-primary font-weight-bold"
                       onClick={() => {
                         setUiMode("edit");
                         setEditingResource("jupyter_notebook");


### PR DESCRIPTION
### Features and Changes

Adds the ability to add and edit Identifier Join queries by query on the datasource page.


- Relates to #390 

### Dependencies

None

### Testing

1. Test adding when you have no identifiers – this should be disabled
2. Test adding when you have 2 or more identifiers – this should be enabled
3. Test Editing an existing query
4. Test deleting an existing query
5. Test toggling an existing query to get access to the SQL


### Screenshots

Empty state when you have identifiers and can add identifier joins.

<img width="1009" alt="image" src="https://user-images.githubusercontent.com/113377031/191873704-ae03e70e-ff38-402f-92b9-4e40e521860d.png">


Empty state when you do not have enough identifiers to create an identity join table.

<img width="1008" alt="image" src="https://user-images.githubusercontent.com/113377031/191873678-c33b2c88-a935-49aa-9d2e-6a528f51d77a.png">

Create modal when creating an identity join table. All available ID's are prepopulated in the SQL. Previously there was a bug that resulted in `undefined` being printed and it looked quite broken. That didn't look like the intention, so I changed that here.

<img width="1232" alt="image" src="https://user-images.githubusercontent.com/113377031/191873742-394da852-c8a9-47f7-a59a-c2e788a00c07.png">
<img width="1225" alt="image" src="https://user-images.githubusercontent.com/113377031/191873818-d19bc480-fb7a-4e2e-8989-264709d4f6fc.png">

When selecting from the multiple select, the **Required Columns** list populates with the identifier types.

<img width="1216" alt="image" src="https://user-images.githubusercontent.com/113377031/191873894-e9ef3549-0723-4365-8659-3458fe9890af.png">

Identifier Join tables list with 2 items where the first one is expanded by clicking the chevron. 

<img width="1010" alt="image" src="https://user-images.githubusercontent.com/113377031/191873951-53fe30bf-89c7-4119-8cce-35affb3bf5a1.png">

More menu showing Edit and Delete buttons.

<img width="1006" alt="image" src="https://user-images.githubusercontent.com/113377031/191873986-37e83bb4-bf90-4c8d-8b98-5631ab806ab6.png">

Delete confirmation.

<img width="588" alt="image" src="https://user-images.githubusercontent.com/113377031/191874004-932484c4-5648-47e9-97a7-c93dbaa8bc3a.png">

When editing an existing Identifier Join query, the existing data prepopulates and the modal title is the same as the item printed in the list.

<img width="1223" alt="image" src="https://user-images.githubusercontent.com/113377031/191874060-7340b8e5-c7f4-4e24-bbff-c5546ffa99bf.png">


Editing and deleting.

https://user-images.githubusercontent.com/113377031/191874879-b999a58e-fc61-4f1a-8500-f5cf3f896ac9.mov


