### PR TITLE
Fixed bug with the Add Data Source Modal when component re-renders. 

### DIFF
--- a/packages/front-end/components/Settings/EventSourceList.tsx
+++ b/packages/front-end/components/Settings/EventSourceList.tsx
@@ -62,15 +62,14 @@ export default function EventSourceList({ onSelect, selected }: Props) {
         )}
       </div>
       {!expand && (
-        <div className="text-center mb-3">
-          <a
-            href="#"
-            className="display-block"
-            onClick={(e) => {
-              e.preventDefault();
-              setExpand(true);
-            }}
-          >
+        <div
+          className="text-center mb-3 cursor-pointer"
+          onClick={(e) => {
+            e.preventDefault();
+            setExpand(true);
+          }}
+        >
+          <a href="#" className="display-block">
             Show All <MdKeyboardArrowDown />
           </a>
         </div>

--- a/packages/front-end/components/Settings/NewDataSourceForm.tsx
+++ b/packages/front-end/components/Settings/NewDataSourceForm.tsx
@@ -43,13 +43,16 @@ const NewDataSourceForm: FC<{
 }) => {
   const [step, setStep] = useState(0);
   const [schema, setSchema] = useState("");
+  const [dataSourceId, setDataSourceId] = useState<string | null>(
+    data?.id || null
+  );
   const [possibleTypes, setPossibleTypes] = useState(
     dataSourceConnections.map((d) => d.type)
   );
 
   const [datasource, setDatasource] = useState<
     Partial<DataSourceInterfaceWithParams>
-  >(null);
+  >(data);
   const [lastError, setLastError] = useState("");
   const DEFAULT_DATA_SOURCE: Partial<DataSourceInterfaceWithParams> = {
     name: "My Datasource",
@@ -80,14 +83,6 @@ const NewDataSourceForm: FC<{
   }, [source]);
 
   const { apiCall } = useAuth();
-  useEffect(() => {
-    if (data) {
-      const newValue: Partial<DataSourceInterfaceWithParams> = {
-        ...data,
-      };
-      setDatasource(newValue);
-    }
-  }, [data]);
 
   if (!datasource) {
     return null;
@@ -102,9 +97,9 @@ const NewDataSourceForm: FC<{
       }
 
       // Update
-      if (data.id) {
+      if (dataSourceId) {
         const res = await apiCall<{ status: number; message: string }>(
-          `/datasource/${data.id}`,
+          `/datasource/${dataSourceId}`,
           {
             method: "PUT",
             body: JSON.stringify(datasource),
@@ -136,7 +131,7 @@ const NewDataSourceForm: FC<{
             },
           }),
         });
-        data.id = res.id;
+        setDataSourceId(res.id);
         track("Submit Datasource Form", {
           source,
           type: datasource.type,
@@ -162,7 +157,7 @@ const NewDataSourceForm: FC<{
       datasource.params,
       form.watch("settings.schemaOptions")
     );
-    if (!data.id) {
+    if (!dataSourceId) {
       throw new Error("Could not find existing data source id");
     }
     const newVal = {
@@ -171,7 +166,7 @@ const NewDataSourceForm: FC<{
     };
     setDatasource(newVal as Partial<DataSourceInterfaceWithParams>);
     await apiCall<{ status: number; message: string }>(
-      `/datasource/${data.id}`,
+      `/datasource/${dataSourceId}`,
       {
         method: "PUT",
         body: JSON.stringify(newVal),
@@ -234,7 +229,7 @@ const NewDataSourceForm: FC<{
           }
           if (isFinalStep) {
             await updateSettings();
-            await onSuccess(data.id);
+            await onSuccess(dataSourceId);
             onCancel && onCancel();
           } else {
             setStep(step + 1);
@@ -325,7 +320,10 @@ const NewDataSourceForm: FC<{
               setStep(0);
             }}
           >
-            <GBCircleArrowLeft /> Back
+            <span style={{ position: "relative", top: "-1px" }}>
+              <GBCircleArrowLeft />
+            </span>{" "}
+            Back
           </a>
         </div>
         <h3>{selectedSchema.label}</h3>
@@ -399,7 +397,10 @@ const NewDataSourceForm: FC<{
               setStep(1);
             }}
           >
-            <GBCircleArrowLeft /> Back
+            <span style={{ position: "relative", top: "-1px" }}>
+              <GBCircleArrowLeft />
+            </span>{" "}
+            Back
           </a>
         </div>
         <div className="alert alert-success mb-3">

--- a/packages/front-end/services/utils.tsx
+++ b/packages/front-end/services/utils.tsx
@@ -15,10 +15,13 @@ export function phaseSummaryText(phase: ExperimentPhaseStringDates): string {
 export function phaseSummary(
   phase: ExperimentPhaseStringDates
 ): React.ReactElement {
+  if (!phase?.phase) {
+    return null;
+  }
   return (
     <>
       <span className="phase">
-        {phase?.phase === "main" || !phase?.phase ? "" : phase.phase + ", "}
+        {phase.phase === "main" ? "" : phase.phase + ", "}
       </span>
       <span className="percent-traffic">
         {Math.floor(phase.coverage * 100)}%

--- a/packages/front-end/services/utils.tsx
+++ b/packages/front-end/services/utils.tsx
@@ -18,7 +18,7 @@ export function phaseSummary(
   return (
     <>
       <span className="phase">
-        {phase.phase === "main" ? "" : phase.phase + ", "}
+        {phase?.phase === "main" || !phase?.phase ? "" : phase.phase + ", "}
       </span>
       <span className="percent-traffic">
         {Math.floor(phase.coverage * 100)}%


### PR DESCRIPTION
### Features and Changes

- Switching away from the Add Data Source Modal, causes the component to re-render and lose the form state of what datasource the user is editing or updating. Removed useEffect entirely to prevent this. 
- Made the whole div clickable when expanding the 'Show All' when selecting event trackers
- Fixed edge case error state when phase is not defined

Fixes #535
