### PR TITLE
Add note to docs about using different domains when self-hosting.

### DIFF
--- a/packages/docs/pages/self-host/env.mdx
+++ b/packages/docs/pages/self-host/env.mdx
@@ -20,7 +20,24 @@ growthbook:
     - API_HOST=http://<my ip>:3100
 ```
 
-**Important**: In order for authentication cookies to work correctly, the 2 domains must be considered the "same site". They can be on different subdomains or ports, but the top level domain must be the same. So `growthbook.example.com` and `growthbook-api.example.com` will work, but `growthbook.com` and `growthbook-api.com` will not.
+<div className="bg-blue-50 py-3 mb-5 px-4 text-gray-600 border-l-8 border-blue-200 dark:bg-blue-800 dark:text-gray-50">
+  <p>
+    <strong>Important</strong>: In order for authentication cookies to work
+    correctly, both the app and api domains must be considered the &quot;same
+    site&quot;. They can be on different subdomains or ports, but the root
+    domain must be the same.
+  </p>
+  <ul>
+    <li>
+      <strong>Works:</strong> <code>gb.example.com</code> and{" "}
+      <code>gb-api.example.com</code>
+    </li>
+    <li>
+      <strong>Breaks:</strong> <code>gb-example.com</code> and{" "}
+      <code>gb-api-example.com</code>
+    </li>
+  </ul>
+</div>
 
 If you need to change the ports on your local dev environment (e.g. if `3000` is already being used),
 you need to update the above variables AND change the port mapping in `docker-compose.yml`:

--- a/packages/docs/pages/self-host/env.mdx
+++ b/packages/docs/pages/self-host/env.mdx
@@ -20,6 +20,8 @@ growthbook:
     - API_HOST=http://<my ip>:3100
 ```
 
+**Important**: In order for authentication cookies to work correctly, the 2 domains must be considered the "same site". They can be on different subdomains or ports, but the top level domain must be the same. So `growthbook.example.com` and `growthbook-api.example.com` will work, but `growthbook.com` and `growthbook-api.com` will not.
+
 If you need to change the ports on your local dev environment (e.g. if `3000` is already being used),
 you need to update the above variables AND change the port mapping in `docker-compose.yml`:
 


### PR DESCRIPTION
### Features and Changes

Hosting the front-end and back-end on different top-level domains will prevent auth cookies from setting.  You will still be able to log in and use the app, but you will need to re-authenticate every time you refresh the page.

Works: http://growthbook.example.com and http://growthbook-api.example.com Breaks: http://growthbook-example.com and http://growthbook-api-example.com

This is because of the `SameSite=Lax` setting for our auth cookies.  We could change it to `None`, but that opens up the possibility of CSRF attacks. We have other CSRF protections in place, but multiple layers of protection are always better.

Fixes #554

![image](https://user-images.githubusercontent.com/1087514/192878527-ae71f71c-b4e6-4ac6-8497-12af3c346743.png)

