### PR TITLE
547  Prevent password manager prompt when filling datasource forms

### DIFF
--- a/packages/front-end/components/Settings/AthenaForm.tsx
+++ b/packages/front-end/components/Settings/AthenaForm.tsx
@@ -1,11 +1,16 @@
 import { FC, ChangeEventHandler } from "react";
 import { AthenaConnectionParams } from "back-end/types/integrations/athena";
+import { useNoAutoFillPasswordProps } from "../../hooks/useNoAutoFillPasswordProps";
 
 const AthenaForm: FC<{
   params: Partial<AthenaConnectionParams>;
   existing: boolean;
   onParamChange: ChangeEventHandler<HTMLInputElement>;
 }> = ({ params, existing, onParamChange }) => {
+  const usernameFieldProps = useNoAutoFillPasswordProps();
+  const databaseFieldProps = useNoAutoFillPasswordProps();
+  const passwordFieldProps = useNoAutoFillPasswordProps();
+
   return (
     <div className="row">
       <div className="form-group col-md-12">
@@ -33,6 +38,7 @@ const AthenaForm: FC<{
       <div className="form-group col-md-12">
         <label>AWS Access Key</label>
         <input
+          {...usernameFieldProps}
           type="text"
           className="form-control"
           name="accessKeyId"
@@ -45,6 +51,7 @@ const AthenaForm: FC<{
       <div className="form-group col-md-12">
         <label>Access Secret</label>
         <input
+          {...passwordFieldProps}
           type="password"
           className="form-control"
           name="secretAccessKey"
@@ -57,6 +64,7 @@ const AthenaForm: FC<{
       <div className="form-group col-md-12">
         <label>Database Name</label>
         <input
+          {...databaseFieldProps}
           type="text"
           className="form-control"
           name="database"

--- a/packages/front-end/components/Settings/ClickHouseForm.tsx
+++ b/packages/front-end/components/Settings/ClickHouseForm.tsx
@@ -1,6 +1,7 @@
 import { FC, ChangeEventHandler } from "react";
 import { ClickHouseConnectionParams } from "back-end/types/integrations/clickhouse";
 import HostWarning from "./HostWarning";
+import { useNoAutoFillPasswordProps } from "../../hooks/useNoAutoFillPasswordProps";
 
 const ClickHouseForm: FC<{
   params: Partial<ClickHouseConnectionParams>;
@@ -8,6 +9,10 @@ const ClickHouseForm: FC<{
   onParamChange: ChangeEventHandler<HTMLInputElement>;
   setParams: (params: { [key: string]: string }) => void;
 }> = ({ params, existing, onParamChange, setParams }) => {
+  const usernameFieldProps = useNoAutoFillPasswordProps();
+  const databaseFieldProps = useNoAutoFillPasswordProps();
+  const passwordFieldProps = useNoAutoFillPasswordProps();
+
   return (
     <>
       <HostWarning
@@ -44,6 +49,7 @@ const ClickHouseForm: FC<{
         <div className="form-group col-md-12">
           <label>Database</label>
           <input
+            {...databaseFieldProps}
             type="text"
             className="form-control"
             name="database"
@@ -54,6 +60,7 @@ const ClickHouseForm: FC<{
         <div className="form-group col-md-12">
           <label>Username</label>
           <input
+            {...usernameFieldProps}
             type="text"
             className="form-control"
             name="username"
@@ -64,6 +71,7 @@ const ClickHouseForm: FC<{
         <div className="form-group col-md-12">
           <label>Password</label>
           <input
+            {...passwordFieldProps}
             type="password"
             className="form-control"
             name="password"

--- a/packages/front-end/components/Settings/MixpanelForm.tsx
+++ b/packages/front-end/components/Settings/MixpanelForm.tsx
@@ -1,11 +1,15 @@
-import { FC, ChangeEventHandler } from "react";
+import { ChangeEventHandler, FC } from "react";
 import { MixpanelConnectionParams } from "back-end/types/integrations/mixpanel";
+import { useNoAutoFillPasswordProps } from "../../hooks/useNoAutoFillPasswordProps";
 
 const MixpanelForm: FC<{
   params: Partial<MixpanelConnectionParams>;
   existing: boolean;
   onParamChange: ChangeEventHandler<HTMLInputElement | HTMLSelectElement>;
 }> = ({ params, existing, onParamChange }) => {
+  const usernameFieldProps = useNoAutoFillPasswordProps();
+  const secretFieldProps = useNoAutoFillPasswordProps();
+
   return (
     <>
       <div className="alert alert-info">
@@ -23,6 +27,7 @@ const MixpanelForm: FC<{
         <div className="form-group col-md-12">
           <label>Username</label>
           <input
+            {...usernameFieldProps}
             type="text"
             className="form-control"
             name="username"
@@ -34,9 +39,9 @@ const MixpanelForm: FC<{
         <div className="form-group col-md-12">
           <label>Secret</label>
           <input
+            {...secretFieldProps}
             type="password"
             className="form-control"
-            name="secret"
             required={!existing}
             value={params.secret || ""}
             onChange={onParamChange}

--- a/packages/front-end/components/Settings/MysqlForm.tsx
+++ b/packages/front-end/components/Settings/MysqlForm.tsx
@@ -1,6 +1,7 @@
 import { FC, ChangeEventHandler } from "react";
 import { MysqlConnectionParams } from "back-end/types/integrations/mysql";
 import HostWarning from "./HostWarning";
+import { useNoAutoFillPasswordProps } from "../../hooks/useNoAutoFillPasswordProps";
 
 const MysqlForm: FC<{
   params: Partial<MysqlConnectionParams>;
@@ -8,6 +9,10 @@ const MysqlForm: FC<{
   onParamChange: ChangeEventHandler<HTMLInputElement>;
   setParams: (params: { [key: string]: string }) => void;
 }> = ({ params, existing, onParamChange, setParams }) => {
+  const databaseFieldProps = useNoAutoFillPasswordProps();
+  const usernameFieldProps = useNoAutoFillPasswordProps();
+  const passwordFieldProps = useNoAutoFillPasswordProps();
+
   return (
     <>
       <HostWarning
@@ -44,6 +49,7 @@ const MysqlForm: FC<{
         <div className="form-group col-md-12">
           <label>Database</label>
           <input
+            {...databaseFieldProps}
             type="text"
             className="form-control"
             name="database"
@@ -55,6 +61,7 @@ const MysqlForm: FC<{
         <div className="form-group col-md-12">
           <label>User</label>
           <input
+            {...usernameFieldProps}
             type="text"
             className="form-control"
             name="user"
@@ -66,6 +73,7 @@ const MysqlForm: FC<{
         <div className="form-group col-md-12">
           <label>Password</label>
           <input
+            {...passwordFieldProps}
             type="password"
             className="form-control"
             name="password"

--- a/packages/front-end/components/Settings/PostgresForm.tsx
+++ b/packages/front-end/components/Settings/PostgresForm.tsx
@@ -4,6 +4,7 @@ import Toggle from "../Forms/Toggle";
 import Field from "../Forms/Field";
 import { FaCaretDown, FaCaretRight } from "react-icons/fa";
 import HostWarning from "./HostWarning";
+import { useNoAutoFillPasswordProps } from "../../hooks/useNoAutoFillPasswordProps";
 
 const PostgresForm: FC<{
   params: Partial<PostgresConnectionParams>;
@@ -12,6 +13,9 @@ const PostgresForm: FC<{
   setParams: (params: { [key: string]: string }) => void;
 }> = ({ params, existing, onParamChange, setParams }) => {
   const [certs, setCerts] = useState(false);
+  const databaseFieldProps = useNoAutoFillPasswordProps();
+  const usernameFieldProps = useNoAutoFillPasswordProps();
+  const passwordFieldProps = useNoAutoFillPasswordProps();
 
   return (
     <>
@@ -49,6 +53,7 @@ const PostgresForm: FC<{
         <div className="form-group col-md-12">
           <label>Database</label>
           <input
+            {...databaseFieldProps}
             type="text"
             className="form-control"
             name="database"
@@ -60,6 +65,7 @@ const PostgresForm: FC<{
         <div className="form-group col-md-12">
           <label>User</label>
           <input
+            {...usernameFieldProps}
             type="text"
             className="form-control"
             name="user"
@@ -71,6 +77,7 @@ const PostgresForm: FC<{
         <div className="form-group col-md-12">
           <label>Password</label>
           <input
+            {...passwordFieldProps}
             type="password"
             className="form-control"
             name="password"

--- a/packages/front-end/components/Settings/SnowflakeForm.tsx
+++ b/packages/front-end/components/Settings/SnowflakeForm.tsx
@@ -1,11 +1,15 @@
 import { FC, ChangeEventHandler } from "react";
 import { SnowflakeConnectionParams } from "back-end/types/integrations/snowflake";
+import { useNoAutoFillPasswordProps } from "../../hooks/useNoAutoFillPasswordProps";
 
 const SnowflakeForm: FC<{
   params: Partial<SnowflakeConnectionParams>;
   existing: boolean;
   onParamChange: ChangeEventHandler<HTMLInputElement>;
 }> = ({ params, existing, onParamChange }) => {
+  const usernameFieldProps = useNoAutoFillPasswordProps();
+  const passwordFieldProps = useNoAutoFillPasswordProps();
+
   return (
     <div className="row">
       <div className="form-group col-md-12">
@@ -23,6 +27,7 @@ const SnowflakeForm: FC<{
       <div className="form-group col-md-12">
         <label>Username</label>
         <input
+          {...usernameFieldProps}
           type="text"
           className="form-control"
           name="username"
@@ -34,6 +39,7 @@ const SnowflakeForm: FC<{
       <div className="form-group col-md-12">
         <label>Password</label>
         <input
+          {...passwordFieldProps}
           type="password"
           className="form-control"
           name="password"

--- a/packages/front-end/hooks/useNoAutoFillPasswordProps.ts
+++ b/packages/front-end/hooks/useNoAutoFillPasswordProps.ts
@@ -1,0 +1,44 @@
+import { CSSProperties, useCallback, useState } from "react";
+import uniqId from "uniqid";
+
+type NoAutoFillPasswordProps = {
+  name: string;
+  readOnly: boolean;
+  onFocus: () => void;
+  onBlur: () => void;
+  autoComplete: string;
+  style: CSSProperties;
+};
+
+/**
+ * This is a hack to remove Chrome's autofill password prompt.
+ * This will need to be used on both username and password fields, in separate implementations.
+ * Learn why here: https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion#the_autocomplete_attribute_and_login_fields
+ * Appropriate usages:
+ *    - data source forms to prevent sending GrowthBook credentials to third-parties
+ *      - Fields: username, password, database
+ * Inappropriate usages (do not use for):
+ *    - GrowthBook login forms
+ */
+export const useNoAutoFillPasswordProps = (): NoAutoFillPasswordProps => {
+  const [readOnly, setReadOnly] = useState(true);
+
+  const onFocus = useCallback(() => {
+    setTimeout(() => {
+      setReadOnly(false);
+    }, 300);
+  }, []);
+
+  const onBlur = useCallback(() => {
+    setReadOnly(true);
+  }, []);
+
+  return {
+    autoComplete: "new-password",
+    style: { backgroundColor: "white" },
+    readOnly,
+    name: uniqId(),
+    onBlur,
+    onFocus,
+  };
+};

--- a/packages/front-end/hooks/useNoAutoFillPasswordProps.ts
+++ b/packages/front-end/hooks/useNoAutoFillPasswordProps.ts
@@ -11,12 +11,14 @@ type NoAutoFillPasswordProps = {
 };
 
 /**
- * This is a hack to remove Chrome's autofill password prompt.
- * This will need to be used on both username and password fields, in separate implementations.
+ * This is a hack to remove the browser autofill password prompts.
+ * This has been tested on macOS in Chrome, Brave, Firefox and Safari.
+ * A separate hook invocation will need to be used for each field that may trigger password auto-fill.
+ * This includes but is not limited to username, password, and (sometimes) database.
  * Learn why here: https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion#the_autocomplete_attribute_and_login_fields
  * Appropriate usages:
  *    - data source forms to prevent sending GrowthBook credentials to third-parties
- *      - Fields: username, password, database
+ *      - Fields: username, password, database (and possibly more)
  * Inappropriate usages (do not use for):
  *    - GrowthBook login forms
  */


### PR DESCRIPTION
### Features and Changes

Prevents the password auto-fill prompt from showing up for data source forms. Users are currently prompted to autofill their GrowthBook credentials in a third-party form but this is not the desired behaviour. 

This was tested to be working in the following browsers on macOS 12.5:

- Brave with built-in password manager
- Chrome with 1Password
- Firefox Developer Edition with built-in password manager
- Safari with built-in password manager

It's important to note that the fix (hack) causes the cursor to not blink in affected fields in Safari. They still work, there just isn't the user feedback they'd normally expect. Also in Safari, if the user clicks the field twice, they will see the prompt.


Issues:

- Closes #547 

### Dependencies

None

### Testing

- ensure you have a stored password
- go to the new data source form


### Screenshots

#### Before

Safari:

<img width="1551" alt="Screen Shot 2022-09-28 at 11 01 48 AM" src="https://user-images.githubusercontent.com/113377031/192860356-19b37f0c-1f2a-47f0-a56f-19402076bdd6.png">

Firefox:
<img width="995" alt="Screen Shot 2022-09-28 at 11 02 06 AM" src="https://user-images.githubusercontent.com/113377031/192860405-99a82d98-2777-4fb0-b36f-c03757b327da.png">

Brave:
<img width="1021" alt="Screen Shot 2022-09-28 at 11 02 55 AM" src="https://user-images.githubusercontent.com/113377031/192860443-00230d0e-2ed9-4f54-99ee-0d51bb1365e7.png">

#### After

Fix in Safari:

https://user-images.githubusercontent.com/113377031/192860524-1d8affaa-018e-4242-873c-f7091457913a.mov

Fix in Firefox:

https://user-images.githubusercontent.com/113377031/192860744-fff079f8-65f5-4555-9997-4ec2961c55a8.mov

Fix in Chromium (Brave):

https://user-images.githubusercontent.com/113377031/192860800-ff8484c6-b86c-4ef8-80b5-c3139a5f3080.mov






