### PR TITLE
Allow OR in mixpanel metric event names to match against multiple events

### DIFF
--- a/packages/docs/pages/app/metrics.mdx
+++ b/packages/docs/pages/app/metrics.mdx
@@ -107,7 +107,7 @@ For example, if you want to look at the Average Order Value (AOV), what you're r
 
 We query Mixpanel data sources using their proprietary JQL language based on Javascript. This allows for extreme flexibility when defining metrics.
 
-All metrics at minimum need to specify an **Event Name** which must exactly match what is used in Mixpanel.
+All metrics at minimum need to specify an **Event Name** which must exactly match what is used in Mixpanel. You can use `OR` to match against multiple events. For example `viewed_cart OR purchased`
 
 You can optionally add **Conditions** which filters the events further based on properties. For example, if Event Name is `Page view`, you can add a condition `path = "/blog"`.
 
@@ -142,7 +142,7 @@ If the aggregation is left blank, we do a sum by default (last example above).
 
 The query builder prompts you for things such as table/column names and constructs a SQL query behind the scenes.
 
-We only recommend this for extremely simple metrics. Inputting raw SQL is more more flexible.
+We only recommend this for extremely simple metrics. Inputting raw SQL is far more flexible.
 
 ## Behavior
 


### PR DESCRIPTION
Now, you can match metrics against multiple event names using ` OR ` as a delimiter.  The reason `" OR "` was used as a delimiter instead of a comma or `||` is to match Mixpanel's built-in syntax for custom events.  This allows copy/pasting between Mixpanel and GrowthBook.

Here's what a custom event looks like in Mixpanel:
![image](https://user-images.githubusercontent.com/1087514/192886406-ac840216-1a47-4060-b71a-d33d19e538a4.png)

And here's what it looks like when defined in GrowthBook:
![image](https://user-images.githubusercontent.com/1087514/192886570-91cefac9-3e4a-4ad1-a703-d6da0df2e592.png)

And here's the JQL code we generate for this:
```ts
["Hello","Goodbye"].includes(event.name)
```

Fixes #432