### PR TITLE
Adds rules to all feature environments even if they are not enabled

### DIFF
--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -2,7 +2,6 @@ import { AuthRequest } from "../types/AuthRequest";
 import { Request, Response } from "express";
 import {
   FeatureDraftChanges,
-  FeatureEnvironment,
   FeatureInterface,
   FeatureRule,
 } from "../../types/feature";
@@ -97,8 +96,8 @@ export async function postFeatures(
 ) {
   req.checkPermissions("createFeatures");
 
-  const { id, ...otherProps } = req.body;
-  const { org, environments, userId, email, userName } = getOrgFromReq(req);
+  const { id, environmentSettings, ...otherProps } = req.body;
+  const { org, userId, email, userName } = getOrgFromReq(req);
 
   if (!id) {
     throw new Error("Must specify feature key");
@@ -109,14 +108,6 @@ export async function postFeatures(
       "Feature keys can only include letters, numbers, hyphens, and underscores."
     );
   }
-
-  const environmentSettings: Record<string, FeatureEnvironment> = {};
-  environments.forEach((env) => {
-    environmentSettings[env.id] = {
-      enabled: true,
-      rules: [],
-    };
-  });
 
   const feature: FeatureInterface = {
     defaultValue: "",

--- a/packages/front-end/components/Features/FeatureModal.tsx
+++ b/packages/front-end/components/Features/FeatureModal.tsx
@@ -119,20 +119,12 @@ export default function FeatureModal({
         const { rule, defaultValue, ...feature } = values;
         const valueType = feature.valueType as FeatureValueType;
 
-        // Validate rule and add to all enabled environments (or just dev if none are enabled)
         if (rule) {
           feature.environmentSettings = cloneDeep(feature.environmentSettings);
           validateFeatureRule(rule, valueType);
-          let envEnabled = false;
           Object.keys(feature.environmentSettings).forEach((env) => {
-            if (feature.environmentSettings[env].enabled) {
-              envEnabled = true;
-              feature.environmentSettings[env].rules.push(rule);
-            }
+            feature.environmentSettings[env].rules.push(rule);
           });
-          if (!envEnabled) {
-            feature.environmentSettings.dev.rules.push(rule);
-          }
         }
 
         const body = {


### PR DESCRIPTION
### Features and Changes

Previously when users created a feature with rules the rules would only be added to the enabled environments for that feature. This change makes it so that the rules are applied to all environments even if they are not enabled.

- Closes https://github.com/growthbook/growthbook/issues/418

### Testing

Create a feature with at least one rule with all environments disabled. When you create the feature you should see that the rule(s) are added to all environments

### Screenshots

![image](https://user-images.githubusercontent.com/36757028/192892247-9e2154ae-43db-4c34-833b-714704893f66.png)
