### PR TITLE
fix tooltip not disappearing on disabled buttons

### DIFF
--- a/packages/front-end/components/Tooltip.tsx
+++ b/packages/front-end/components/Tooltip.tsx
@@ -47,6 +47,7 @@ const Tooltip: FC<Props> = ({
         ref={setTrigger}
         onMouseEnter={() => setOpen(true)}
         onMouseLeave={() => setOpen(false)}
+        onPointerLeave={() => setOpen(false)}
         className={`${className}`}
         {...otherProps}
       >


### PR DESCRIPTION
### Features and Changes

Previously we thought that the Tooltip component was unable to have button elements as child comps however as it turns out that was not the case. The actual issue was only for buttons that were `disabled`. The `onMouseLeave` event was not firing. The fix is 1 line and pretty simple, add `onPointerLeave` event to the Tooltip comp and everything works as intended.

- Closes https://github.com/growthbook/growthbook/issues/538

### Testing

Create a button that is disabled and wrap it with the Tooltip component and make sure that the tooltip is being displayed properly when mouse is over the button and outside of the button.
