### PR TITLE
Add support for ==tag== syntax in markdown fields

### DIFF
--- a/packages/front-end/components/Markdown/Markdown.module.scss
+++ b/packages/front-end/components/Markdown/Markdown.module.scss
@@ -1,3 +1,5 @@
+@import "../../styles/colors.scss";
+
 .markdown {
   pre {
     padding: 12px;
@@ -38,6 +40,12 @@
       background: #ddd;
       content: "";
     }
+  }
+  mark {
+    background: $blue;
+    color: #fff;
+    padding: 3px 8px;
+    border-radius: 5px;
   }
   code[class*="language-"] {
     color: #333;

--- a/packages/front-end/components/Markdown/Markdown.tsx
+++ b/packages/front-end/components/Markdown/Markdown.tsx
@@ -1,10 +1,11 @@
 import { DetailedHTMLProps, FC, HTMLAttributes } from "react";
 import markdown from "markdown-it";
 import sanitizer from "markdown-it-sanitizer";
+import mark from "markdown-it-mark";
 import styles from "./Markdown.module.scss";
 import clsx from "clsx";
 
-const md = markdown({ html: true, linkify: true }).use(sanitizer);
+const md = markdown({ html: true, linkify: true }).use(sanitizer).use(mark);
 
 const Markdown: FC<
   DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement>

--- a/packages/front-end/package.json
+++ b/packages/front-end/package.json
@@ -41,6 +41,7 @@
     "jstat": "^1.9.3",
     "lodash": "^4.17.21",
     "markdown-it": "^11.0.0",
+    "markdown-it-mark": "^3.0.1",
     "markdown-it-sanitizer": "^0.4.3",
     "md5": "^2.3.0",
     "next": "12.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8804,6 +8804,11 @@ markdown-escapes@^1.0.0:
   resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.4.tgz#c95415ef451499d7602b91095f3c8e8975f78535"
   integrity sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==
 
+markdown-it-mark@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/markdown-it-mark/-/markdown-it-mark-3.0.1.tgz#51257db58787d78aaf46dc13418d99a9f3f0ebd3"
+  integrity sha512-HyxjAu6BRsdt6Xcv6TKVQnkz/E70TdGXEFHRYBGLncRE9lBFwDNLVtFojKxjJWgJ+5XxUwLaHXy+2sGBbDn+4A==
+
 markdown-it-sanitizer@^0.4.3:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/markdown-it-sanitizer/-/markdown-it-sanitizer-0.4.3.tgz#2ba34e9fe16e6372ce7192fb50b37d9dfbff0102"


### PR DESCRIPTION
### Features and Changes

Input markdown:
```
Hello ==world==
```

Output:
![image](https://user-images.githubusercontent.com/1087514/192899838-86bbfc97-c2eb-4c81-8f77-859c29a8ebd6.png)

Fixes #558 

