### PR TITLE
[feature/547]  Datasource secrets input field presentation

### DIFF
--- a/packages/front-end/components/Settings/AthenaForm.tsx
+++ b/packages/front-end/components/Settings/AthenaForm.tsx
@@ -45,8 +45,9 @@ const AthenaForm: FC<{
       <div className="form-group col-md-12">
         <label>Access Secret</label>
         <input
-          type="password"
-          className="form-control"
+          type="text"
+          className="form-control password-presentation"
+          autoComplete="off"
           name="secretAccessKey"
           required={!existing}
           value={params.secretAccessKey || ""}

--- a/packages/front-end/components/Settings/ClickHouseForm.tsx
+++ b/packages/front-end/components/Settings/ClickHouseForm.tsx
@@ -64,8 +64,9 @@ const ClickHouseForm: FC<{
         <div className="form-group col-md-12">
           <label>Password</label>
           <input
-            type="password"
-            className="form-control"
+            type="text"
+            className="form-control password-presentation"
+            autoComplete="off"
             name="password"
             value={params.password || ""}
             onChange={onParamChange}

--- a/packages/front-end/components/Settings/MixpanelForm.tsx
+++ b/packages/front-end/components/Settings/MixpanelForm.tsx
@@ -34,8 +34,9 @@ const MixpanelForm: FC<{
         <div className="form-group col-md-12">
           <label>Secret</label>
           <input
-            type="password"
-            className="form-control"
+            type="text"
+            className="form-control password-presentation"
+            autoComplete="off"
             name="secret"
             required={!existing}
             value={params.secret || ""}

--- a/packages/front-end/components/Settings/MysqlForm.tsx
+++ b/packages/front-end/components/Settings/MysqlForm.tsx
@@ -66,8 +66,9 @@ const MysqlForm: FC<{
         <div className="form-group col-md-12">
           <label>Password</label>
           <input
-            type="password"
-            className="form-control"
+            type="text"
+            className="form-control password-presentation"
+            autoComplete="off"
             name="password"
             required={!existing}
             value={params.password || ""}

--- a/packages/front-end/components/Settings/PostgresForm.tsx
+++ b/packages/front-end/components/Settings/PostgresForm.tsx
@@ -71,8 +71,9 @@ const PostgresForm: FC<{
         <div className="form-group col-md-12">
           <label>Password</label>
           <input
-            type="password"
-            className="form-control"
+            type="text"
+            className="form-control password-presentation"
+            autoComplete="off"
             name="password"
             required={!existing}
             value={params.password || ""}

--- a/packages/front-end/components/Settings/SnowflakeForm.tsx
+++ b/packages/front-end/components/Settings/SnowflakeForm.tsx
@@ -34,8 +34,9 @@ const SnowflakeForm: FC<{
       <div className="form-group col-md-12">
         <label>Password</label>
         <input
-          type="password"
-          className="form-control"
+          type="text"
+          className="form-control password-presentation"
+          autoComplete="off"
           name="password"
           required={!existing}
           value={params.password || ""}

--- a/packages/front-end/styles/global.scss
+++ b/packages/front-end/styles/global.scss
@@ -793,6 +793,11 @@ pre {
   }
 }
 
+// To make non-password fields look like password fields.
+.password-presentation {
+  -webkit-text-security: disc;
+}
+
 .experiment-compact {
   border-spacing: 0;
   border: 1px solid #ddd;


### PR DESCRIPTION
These changes add a class `.password-presentation` to help non-password fields look like passwords by obscuring the input. 

**Note**: This class is not a web standard and will not work in Firefox but supposedly works in MS Edge and Opera (untested) [More info](https://caniuse.com/?search=text-security). It does not work in Safari—Safari still shows the password manager prompts.

Fields for secrets in the data sources screens have been changed to use this approach in order to avoid the following:

- users accidentally overriding their GrowthBook credentials with their datasource credentials
- users accidentally sending GrowthBook credentials to third-parties

Browsers:

- Chromium: Works as desired: conceals text, does not result in password manager prompts
- Edge: untested
- Opera: untested
- Firefox: does not work. Results in regular text fields, so sensitive content can be exposed
- Safari: behaves like a password field. Conceals text but also results in password manager prompts, so is essentially equivalent to using `type="password"`.

Issues:

- Relates to #547 


### Dependencies

n/a

### Testing

Add or edit a data source that requires a secret.


### Screenshots

Chrome:

<img width="533" alt="image" src="https://user-images.githubusercontent.com/113377031/192915150-348040dc-bbf8-42a8-bdb7-8cc2bf04f4ff.png">


Brave:

<img width="487" alt="image" src="https://user-images.githubusercontent.com/113377031/192915185-def4070b-5586-439b-80c3-a6873a53c110.png">

Firefox:

<img width="510" alt="image" src="https://user-images.githubusercontent.com/113377031/192915235-ae3c5f73-4eb9-4aa7-8759-550748cb08ca.png">


Safari:

<img width="446" alt="image" src="https://user-images.githubusercontent.com/113377031/192915267-8bf7c7ea-7b93-49ee-b106-4aafaabc3606.png">
