### PR TITLE
Fix "View results" link when an experiment uses the default tracking key

### DIFF
--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -600,8 +600,8 @@ export async function getFeatureById(
   if (feature.environmentSettings) {
     Object.values(feature.environmentSettings).forEach((env) => {
       env.rules?.forEach((r) => {
-        if (r.type === "experiment" && r.trackingKey) {
-          expIds.add(r.trackingKey);
+        if (r.type === "experiment") {
+          expIds.add(r.trackingKey || feature.id);
         }
       });
     });


### PR DESCRIPTION
### Features and Changes

For feature experiment rules, if you don't specify a tracking key, we use the feature id by default.

The logic of the `View results` button does not take this into account.  If the tracking key is empty, it just assumes an experiment doesn't exist and prompts the user to create a new one.  This results in a "duplicate tracking key" error.

This PR fixes the behavior by adding the same "fallback to feature id" logic to the `View results` button.

### Testing

1. Create an experiment rule and leave the tracking key empty
2. Click on "View results"
3. You should see the "Add Experiment" modal
4. Save the experiment
5. Go back to the feature and click on "View results" again
6. You should get taken directly to the experiment