### PR TITLE
Cache ESLint to speed up local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ coverage.xml
 
 # Python virtual environment
 venv/
+.eslintcache

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "repository": "https://github.com/growthbook/growthbook-app.git",
   "private": true,
   "scripts": {
-    "lint": "eslint './**/*.{ts,tsx,js,jsx}' --fix --max-warnings 0",
+    "lint": "eslint './**/*.{ts,tsx,js,jsx}' --fix --max-warnings 0 --cache",
     "pretty": "prettier --write ./**/*.{json,css,scss,md,mdx}",
     "type-check": "wsrun -m type-check",
     "test": "wsrun -m test",


### PR DESCRIPTION
### Features and Changes

Caches ESLint files:

> Store the info about processed files in order to only operate on the changed ones. The cache is stored in .eslintcache by default. Enabling this option can dramatically improve ESLint’s running time by ensuring that only changed files are linted.

Learn more here: https://eslint.org/docs/latest/user-guide/command-line-interface#--cache

- Closes #583 


### Testing

1. Run`yarn lint` once. You should see the `.eslintcache` directory show up
2. Run it again, it should be instant since no files have changed.
3. Change a file. A suggested change to avoid your editor auto-fixing is to remove a required dependency from a dependency array (for a file that isn't ignored in ESLint, e.g. one of the `DataSourceInlineEdit` files)
4. Run ESLint again—you should see it be much faster but still catch the lint error on the newly changed file.