### PR TITLE
Add `experimentId` as a SQL template variable

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,11 +22,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      # Ensures `yarn install` only runs when dependencies change (saves ~2 minutes)
-      - name: Cache Docker Layers
-        uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:

--- a/packages/back-end/src/integrations/Mixpanel.ts
+++ b/packages/back-end/src/integrations/Mixpanel.ts
@@ -20,7 +20,7 @@ import {
 import { DEFAULT_CONVERSION_WINDOW_HOURS } from "../util/secrets";
 import {
   conditionToJavascript,
-  replaceDateVars,
+  replaceSQLVars,
   getMixpanelPropertyColumn,
 } from "../util/sql";
 
@@ -177,7 +177,8 @@ export default class Mixpanel implements SourceIntegrationInterface {
                   ? `state.dimension = (${this.getDimensionColumn(
                       dimension.sql,
                       phase.dateStarted,
-                      phase.dateEnded
+                      phase.dateEnded,
+                      experiment.trackingKey
                     )}) || null;`
                   : ""
               }
@@ -534,8 +535,17 @@ export default class Mixpanel implements SourceIntegrationInterface {
 
     return `Events(${JSON.stringify(filter, null, 2)})`;
   }
-  private getDimensionColumn(col: string, startDate: Date, endDate?: Date) {
-    return replaceDateVars(getMixpanelPropertyColumn(col), startDate, endDate);
+  private getDimensionColumn(
+    col: string,
+    startDate: Date,
+    endDate?: Date,
+    experimentId?: string
+  ) {
+    return replaceSQLVars(getMixpanelPropertyColumn(col), {
+      startDate,
+      endDate,
+      experimentId,
+    });
   }
 
   private getValidMetricCondition(

--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -21,7 +21,7 @@ import { DimensionInterface } from "../../types/dimension";
 import { DEFAULT_CONVERSION_WINDOW_HOURS } from "../util/secrets";
 import { getValidDate } from "../util/dates";
 import { SegmentInterface } from "../../types/segment";
-import { getBaseIdTypeAndJoins, replaceDateVars, format } from "../util/sql";
+import { getBaseIdTypeAndJoins, replaceSQLVars, format } from "../util/sql";
 
 export default abstract class SqlIntegration
   implements SourceIntegrationInterface {
@@ -191,7 +191,7 @@ export default abstract class SqlIntegration
             count(distinct ${q.userIdType}) as users
           FROM
             (
-              ${replaceDateVars(q.query, params.from)}
+              ${replaceSQLVars(q.query, { startDate: params.from })}
             ) e${i}
           WHERE
             ${this.castUserDateCol("timestamp")} > ${this.toTimestamp(
@@ -425,7 +425,8 @@ export default abstract class SqlIntegration
     objects: string[][],
     from: Date,
     to?: Date,
-    forcedBaseIdType?: string
+    forcedBaseIdType?: string,
+    experimentId?: string
   ) {
     const { baseIdType, joinsRequired } = getBaseIdTypeAndJoins(
       objects,
@@ -442,7 +443,14 @@ export default abstract class SqlIntegration
       idJoinMap[idType] = table;
       joins.push(
         `${table} as (
-        ${this.getIdentitiesQuery(this.settings, baseIdType, idType, from, to)}
+        ${this.getIdentitiesQuery(
+          this.settings,
+          baseIdType,
+          idType,
+          from,
+          to,
+          experimentId
+        )}
       ),`
       );
     });
@@ -608,7 +616,8 @@ export default abstract class SqlIntegration
       ],
       phase.dateStarted,
       phase.dateEnded,
-      exposureQuery.userIdType
+      exposureQuery.userIdType,
+      experiment.trackingKey
     );
 
     const removeMultipleExposures = !!experiment.removeMultipleExposures;
@@ -640,11 +649,11 @@ export default abstract class SqlIntegration
     WITH
       ${idJoinSQL}
       __rawExperiment as (
-        ${replaceDateVars(
-          exposureQuery.query,
-          phase.dateStarted,
-          phase.dateEnded
-        )}
+        ${replaceSQLVars(exposureQuery.query, {
+          startDate: phase.dateStarted,
+          endDate: phase.dateEnded,
+          experimentId: experiment.trackingKey,
+        })}
       ),
       __experiment as (${this.getExperimentCTE({
         experiment,
@@ -661,6 +670,7 @@ export default abstract class SqlIntegration
         idJoinMap,
         startDate: metricStart,
         endDate: metricEnd,
+        experimentId: experiment.trackingKey,
       })})
       ${
         segment
@@ -694,6 +704,7 @@ export default abstract class SqlIntegration
             idJoinMap,
             startDate: metricStart,
             endDate: metricEnd,
+            experimentId: experiment.trackingKey,
           })})`;
         })
         .join("\n")}
@@ -718,6 +729,7 @@ export default abstract class SqlIntegration
             idJoinMap,
             startDate: metricStart,
             endDate: metricEnd,
+            experimentId: experiment.trackingKey,
           })})`;
         })
         .join("\n")}
@@ -1037,6 +1049,7 @@ export default abstract class SqlIntegration
     idJoinMap,
     startDate,
     endDate,
+    experimentId,
   }: {
     metric: MetricInterface;
     conversionWindowHours?: number;
@@ -1045,6 +1058,7 @@ export default abstract class SqlIntegration
     idJoinMap: Record<string, string>;
     startDate: Date;
     endDate: Date | null;
+    experimentId?: string;
   }) {
     const queryFormat = this.getMetricQueryFormat(metric);
 
@@ -1103,11 +1117,11 @@ export default abstract class SqlIntegration
         ${
           queryFormat === "sql"
             ? `(
-              ${replaceDateVars(
-                metric.sql || "",
+              ${replaceSQLVars(metric.sql || "", {
                 startDate,
-                endDate || undefined
-              )}
+                endDate: endDate || undefined,
+                experimentId,
+              })}
               )`
             : (schema && !metric.table?.match(/\./) ? schema + "." : "") +
               (metric.table || "")
@@ -1339,7 +1353,8 @@ export default abstract class SqlIntegration
     id1: string,
     id2: string,
     from: Date,
-    to: Date | undefined
+    to: Date | undefined,
+    experimentId?: string
   ) {
     if (settings?.queries?.identityJoins) {
       for (let i = 0; i < settings.queries.identityJoins.length; i++) {
@@ -1355,7 +1370,11 @@ export default abstract class SqlIntegration
             ${id2}
           FROM
             (
-              ${replaceDateVars(join.query, from, to)}
+              ${replaceSQLVars(join.query, {
+                startDate: from,
+                endDate: to,
+                experimentId,
+              })}
             ) i
           GROUP BY
             ${id1}, ${id2}
@@ -1376,7 +1395,11 @@ export default abstract class SqlIntegration
           user_id,
           anonymous_id
         FROM
-          (${replaceDateVars(settings.queries.pageviewsQuery, from, to)}) i
+          (${replaceSQLVars(settings.queries.pageviewsQuery, {
+            startDate: from,
+            endDate: to,
+            experimentId,
+          })}) i
         WHERE
           ${timestampColumn} >= ${this.toTimestamp(from)}
           ${to ? `AND ${timestampColumn} <= ${this.toTimestamp(to)}` : ""}

--- a/packages/docs/pages/app/datasources.mdx
+++ b/packages/docs/pages/app/datasources.mdx
@@ -116,7 +116,7 @@ SELECT user_id, device_id FROM logins
 
 ##### SQL Template Variables
 
-Within your queries, there are several placeholder variables you can use. These will be replaced with strings before being run based on your experiment. This are completely optional, but can be useful for giving hints to SQL optimization engines to improve query performance.
+Within your queries, there are several placeholder variables you can use. These will be replaced with strings before being run based on your experiment. This can be useful for giving hints to SQL optimization engines to improve query performance.
 
 The variables are:
 

--- a/packages/docs/pages/app/datasources.mdx
+++ b/packages/docs/pages/app/datasources.mdx
@@ -116,7 +116,7 @@ SELECT user_id, device_id FROM logins
 
 ##### SQL Template Variables
 
-Within your queries, there are several placeholder variables you can use. These will be replaced with strings before being run based on your experiment. This can be useful for giving hints to SQL optimization engines to improve query performance.
+Within your queries, there are several placeholder variables you can use. These will be replaced with strings before being run based on your experiment. This are completely optional, but can be useful for giving hints to SQL optimization engines to improve query performance.
 
 The variables are:
 
@@ -130,6 +130,7 @@ The variables are:
 - **endMonth** - Just the `MM` of the endDate
 - **endDay** - Just the `DD` of the endDate
 - **endDateUnix** - Unix timestamp of the endDate (seconds since Jan 1, 1970)
+- **experimentId** - Either a specific experiment id OR `%` if you should include all experiments
 
 For example:
 
@@ -144,6 +145,7 @@ FROM
   experiment_viewed
 WHERE
   received_at BETWEEN '{{ startDate }}' AND '{{ endDate }}'
+  AND experiment_id LIKE '{{ experimentId }}'
 ```
 
 **Note:** The inserted values do not have surrounding quotes, so you must add those yourself (e.g. use `'{{ startDate }}'` instead of just `{{ startDate }}`)

--- a/packages/docs/pages/app/dimensions.mdx
+++ b/packages/docs/pages/app/dimensions.mdx
@@ -107,3 +107,4 @@ The variables you can reference are:
 - **endMonth** - Just the `MM` of the endDate
 - **endDay** - Just the `DD` of the endDate
 - **endDateUnix** - Unix timestamp of the endDate (seconds since Jan 1, 1970)
+- **experimentId** - Either a specific experiment id OR `%` if you should include all experiments

--- a/packages/docs/pages/app/metrics.mdx
+++ b/packages/docs/pages/app/metrics.mdx
@@ -57,10 +57,13 @@ The variables are:
 - **startYear** - Just the `YYYY` of the startDate
 - **startMonth** - Just the `MM` of the startDate
 - **startDay** - Just the `DD` of the startDate
+- **startDateUnix** - Unix timestamp of the startDate (seconds since Jan 1, 1970)
 - **endDate** - `YYYY-MM-DD HH:mm:ss` of the latest data that needs to be included
 - **endYear** - Just the `YYYY` of the endDate
 - **endMonth** - Just the `MM` of the endDate
 - **endDay** - Just the `DD` of the endDate
+- **endDateUnix** - Unix timestamp of the endDate (seconds since Jan 1, 1970)
+- **experimentId** - Either a specific experiment id OR `%` if you should include all experiments
 
 For example:
 

--- a/packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentityJoins/DataSourceInlineEditIdentityJoins.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentityJoins/DataSourceInlineEditIdentityJoins.tsx
@@ -159,7 +159,7 @@ export const DataSourceInlineEditIdentityJoins: FC<DataSourceInlineEditIdentityJ
                     </MoreMenu>
 
                     <button
-                      className="btn ml-3"
+                      className="btn ml-3 text-dark"
                       onClick={handleExpandCollapseForIndex(idx)}
                     >
                       <FaChevronRight

--- a/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/AddEditExperimentAssignmentQueryModal.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/AddEditExperimentAssignmentQueryModal.tsx
@@ -88,8 +88,7 @@ export const AddEditExperimentAssignmentQueryModal: FC<EditExperimentAssignmentQ
 
   const identityTypes = dataSource.settings.userIdTypes || [];
 
-  const saveEnabled =
-    userEnteredUserIdType && userEnteredQuery && userEnteredHasNameCol;
+  const saveEnabled = userEnteredUserIdType && userEnteredQuery;
 
   if (!exposureQuery && mode === "edit") {
     console.error(

--- a/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/AddEditExperimentAssignmentQueryModal.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/AddEditExperimentAssignmentQueryModal.tsx
@@ -88,7 +88,7 @@ export const AddEditExperimentAssignmentQueryModal: FC<EditExperimentAssignmentQ
 
   const identityTypes = dataSource.settings.userIdTypes || [];
 
-  const saveEnabled = userEnteredUserIdType && userEnteredQuery;
+  const saveEnabled = !!userEnteredUserIdType && !!userEnteredQuery;
 
   if (!exposureQuery && mode === "edit") {
     console.error(

--- a/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/ExperimentAssignmentQueries.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/ExperimentAssignmentQueries.tsx
@@ -175,7 +175,7 @@ export const ExperimentAssignmentQueries: FC<ExperimentAssignmentQueriesProps> =
                 </MoreMenu>
 
                 <button
-                  className="btn ml-3"
+                  className="btn ml-3 text-dark"
                   onClick={handleExpandCollapseForIndex(idx)}
                 >
                   <FaChevronRight


### PR DESCRIPTION
### Features and Changes

You can now use `{{ experimentId }}` in SQL queries to provide better hints to optimization engines.

There are a few instances where we need to include all experiments and not just a single id.  In those cases, the variable is set to `%`, which allows using the LIKE syntax.

An example experiment assignment query:

```sql
SELECT
  user_id,
  experiment_id,
  variation_id,
  received_at as timestamp
FROM
  experiment_viewed
WHERE
  received_at BETWEEN '{{ startDate }}' AND '{{ endDate }}'
  AND experiment_id LIKE '{{ experimentId }}'
```

Fixes #600 