### PR TITLE
Support for trial enterprise licence keys

### DIFF
--- a/packages/back-end/src/controllers/organizations.ts
+++ b/packages/back-end/src/controllers/organizations.ts
@@ -119,6 +119,7 @@ export async function getUser(req: AuthRequest, res: Response) {
         name: org.name,
         role,
         permissions: getPermissionsByRole(role),
+        enterprise: org.enterprise || false,
         settings: org.settings || {},
         freeSeats: org.freeSeats || 3,
         discountCode: org.discountCode || "",
@@ -508,6 +509,7 @@ export async function getOrganization(req: AuthRequest, res: Response) {
     connections,
     settings,
     disableSelfServeBilling,
+    enterprise,
   } = org;
 
   const roleMapping: Map<string, MemberRole> = new Map();
@@ -534,6 +536,7 @@ export async function getOrganization(req: AuthRequest, res: Response) {
       url,
       subscription,
       freeSeats,
+      enterprise,
       disableSelfServeBilling,
       slackTeam: connections?.slack?.team,
       members: users.map(({ id, email, name }) => {

--- a/packages/back-end/src/models/OrganizationModel.ts
+++ b/packages/back-end/src/models/OrganizationModel.ts
@@ -13,6 +13,7 @@ const organizationSchema = new mongoose.Schema({
   name: String,
   ownerEmail: String,
   restrictLoginMethod: String,
+  restrictAuthSubPrefix: String,
   members: [
     {
       _id: false,
@@ -34,6 +35,7 @@ const organizationSchema = new mongoose.Schema({
   priceId: String,
   freeSeats: Number,
   disableSelfServeBilling: Boolean,
+  enterprise: Boolean,
   subscription: {
     id: String,
     qty: Number,

--- a/packages/back-end/src/services/auth/index.ts
+++ b/packages/back-end/src/services/auth/index.ts
@@ -60,7 +60,7 @@ function getInitialDataFromJWT(user: IdToken): JWTInfo {
 
 export async function processJWT(
   // eslint-disable-next-line
-  req: AuthRequest & { user: any },
+  req: AuthRequest & { user: IdToken },
   res: Response,
   next: NextFunction
 ) {
@@ -126,6 +126,20 @@ export async function processJWT(
             return res.status(403).json({
               status: 403,
               message: "Must login with Enterprise SSO.",
+            });
+          }
+        }
+
+        // If the org requires a specific subject in the IdToken
+        // This is mostly used with GrowthBook Cloud to restrict people to "Login with Google"
+        // For that, we set `restrictAuthSubPrefix` to "google"
+        if (req.organization.restrictAuthSubPrefix) {
+          if (
+            !req.user.sub?.startsWith(req.organization.restrictAuthSubPrefix)
+          ) {
+            throw res.status(403).json({
+              status: 403,
+              message: `Must login with ${req.organization.restrictAuthSubPrefix}`,
             });
           }
         }

--- a/packages/back-end/src/services/organizations.ts
+++ b/packages/back-end/src/services/organizations.ts
@@ -48,6 +48,34 @@ export async function getOrganizationById(id: string) {
   return findOrganizationById(id);
 }
 
+export function validateLoginMethod(
+  org: OrganizationInterface,
+  req: AuthRequest
+) {
+  if (
+    org.restrictLoginMethod &&
+    req.loginMethod?.id !== org.restrictLoginMethod
+  ) {
+    throw new Error(
+      "Your organization requires you to login with Enterprise SSO"
+    );
+  }
+
+  // If the org requires a specific subject in the IdToken
+  // This is mostly used with GrowthBook Cloud to restrict people to "Login with Google"
+  // For that, we set `restrictAuthSubPrefix` to "google"
+  if (
+    org.restrictAuthSubPrefix &&
+    !req.authSubject?.startsWith(org.restrictAuthSubPrefix)
+  ) {
+    throw new Error(
+      `Your organization requires you to login with ${org.restrictAuthSubPrefix}`
+    );
+  }
+
+  return true;
+}
+
 export function getOrgFromReq(req: AuthRequest) {
   if (!req.organization) {
     throw new Error("Must be part of an organization to make that request");

--- a/packages/back-end/src/types/AuthRequest.ts
+++ b/packages/back-end/src/types/AuthRequest.ts
@@ -9,6 +9,7 @@ export type AuthRequest<B = any, P = any, Q = any> = Request<P, null, B, Q> & {
   verified?: boolean;
   userId?: string;
   loginMethod?: SSOConnectionInterface;
+  authSubject?: string;
   name?: string;
   admin?: boolean;
   organization?: OrganizationInterface;

--- a/packages/back-end/types/organization.d.ts
+++ b/packages/back-end/types/organization.d.ts
@@ -150,10 +150,12 @@ export interface OrganizationInterface {
   ownerEmail: string;
   stripeCustomerId?: string;
   restrictLoginMethod?: string;
+  restrictAuthSubPrefix?: string;
   freeSeats?: number;
   discountCode?: string;
   priceId?: string;
   disableSelfServeBilling?: boolean;
+  enterprise?: boolean;
   subscription?: {
     id: string;
     qty: number;

--- a/packages/back-end/types/organization.d.ts
+++ b/packages/back-end/types/organization.d.ts
@@ -185,9 +185,16 @@ export type NamespaceUsage = Record<
 >;
 
 export type LicenceData = {
+  // Unique id for the licence key
   ref: string;
+  // Name of organization on the licence
   sub: string;
+  // Max number of seats
   qty: number;
+  // Date issued
   iat: string;
+  // Expiration date
   eat: string;
+  // If it's a trial or not
+  trial?: boolean;
 };

--- a/packages/front-end/components/Layout/TopNav.tsx
+++ b/packages/front-end/components/Layout/TopNav.tsx
@@ -52,7 +52,15 @@ const TopNav: FC<{
     hasActiveSubscription,
   } = useStripeSubscription();
 
-  const { name, email, update, permissions, role, licence } = useUser();
+  const {
+    name,
+    email,
+    update,
+    permissions,
+    role,
+    licence,
+    enterprise,
+  } = useUser();
 
   const { datasources } = useDefinitions();
 
@@ -251,7 +259,7 @@ const TopNav: FC<{
               </div>
             )}
 
-            {licence && (
+            {(licence || enterprise) && (
               <div className="ml-2">
                 <span className="badge badge-pill badge-dark mr-1">
                   ENTERPRISE

--- a/packages/front-end/components/Layout/TopNav.tsx
+++ b/packages/front-end/components/Layout/TopNav.tsx
@@ -64,6 +64,8 @@ const TopNav: FC<{
 
   const trialRemaining = trialEnd ? daysLeft(trialEnd) : -1;
 
+  const licenceTrialRemaining = licence?.trial ? daysLeft(licence.eat) : -1;
+
   const onSubmitEditName = form.handleSubmit(async (value) => {
     await apiCall(`/user/name`, {
       method: "PUT",
@@ -189,7 +191,24 @@ const TopNav: FC<{
                   <FaExclamationTriangle /> free tier exceded
                 </button>
               )}
-
+            {licenceTrialRemaining >= 0 && (
+              <Tooltip
+                body={
+                  <>
+                    Contact sales@growthbook.io if you need more time or would
+                    like to upgrade
+                  </>
+                }
+              >
+                <div className="alert alert-warning py-1 px-2 mb-0 d-none d-md-block mr-1">
+                  <span className="badge badge-warning">
+                    {licenceTrialRemaining}
+                  </span>{" "}
+                  day
+                  {licenceTrialRemaining === 1 ? "" : "s"} left in trial
+                </div>
+              </Tooltip>
+            )}
             {licence &&
               permissions.organizationSettings &&
               licence.eat < new Date().toISOString().substring(0, 10) && (

--- a/packages/front-end/components/ProtectedPage.tsx
+++ b/packages/front-end/components/ProtectedPage.tsx
@@ -53,6 +53,7 @@ export type UserContextValue = {
   admin?: boolean;
   role?: string;
   licence?: LicenceData;
+  enterprise?: boolean;
   users?: Map<string, User>;
   getUserDisplay?: (id: string, fallback?: boolean) => string;
   update?: () => Promise<void>;
@@ -155,6 +156,7 @@ const ProtectedPage: React.FC<{
       userAgent: window.navigator.userAgent,
       url: router?.pathname || "",
       cloud: isCloud(),
+      enterprise: currentOrg?.enterprise || false,
       hasLicenceKey: !!data?.licence,
       freeSeats: currentOrg?.freeSeats || 3,
       discountCode: currentOrg?.discountCode || "",
@@ -215,6 +217,7 @@ const ProtectedPage: React.FC<{
     role,
     permissions,
     settings: currentOrg?.settings || {},
+    enterprise: currentOrg?.enterprise || false,
     licence: data?.licence,
   };
 

--- a/packages/front-end/components/ProtectedPage.tsx
+++ b/packages/front-end/components/ProtectedPage.tsx
@@ -19,7 +19,8 @@ import { useGrowthBook } from "@growthbook/growthbook-react";
 import { useRouter } from "next/router";
 import { isCloud } from "../services/env";
 import InAppHelp from "./Auth/InAppHelp";
-import Modal from "./Modal";
+import Button from "./Button";
+import { ThemeToggler } from "./Layout/ThemeToggler";
 
 type User = { id: string; email: string; name: string };
 
@@ -166,23 +167,57 @@ const ProtectedPage: React.FC<{
 
   if (error) {
     return (
-      <Modal
-        inline={true}
-        open={true}
-        cta="Log Out"
-        submit={async () => {
-          await safeLogout();
-        }}
-        submitColor="danger"
-        closeCta="Reload"
-        close={() => {
-          window.location.reload();
-        }}
-        autoCloseOnSubmit={false}
-      >
-        <h3>Error signing in</h3>
-        <div className="alert alert-danger">{error}</div>
-      </Modal>
+      <div>
+        <div className="navbar bg-white border-bottom">
+          <div>
+            <img
+              alt="GrowthBook"
+              src="/logo/growthbook-logo.png"
+              style={{ height: 36 }}
+            />
+          </div>
+          <div className="ml-auto">
+            <ThemeToggler />
+          </div>
+          <div>
+            <Button
+              className="ml-auto"
+              onClick={async () => {
+                await safeLogout();
+              }}
+              color="danger"
+            >
+              Log Out
+            </Button>
+          </div>
+        </div>
+        <div className="container mt-5">
+          <div className="appbox p-4" style={{ maxWidth: 500, margin: "auto" }}>
+            <h3 className="mb-3">Error Signing In</h3>
+            <div className="alert alert-danger">{error}</div>
+            <div className="d-flex">
+              <Button
+                className="ml-auto"
+                onClick={async () => {
+                  await safeLogout();
+                }}
+                color="danger"
+              >
+                Log Out
+              </Button>
+              <button
+                className="btn btn-link"
+                onClick={(e) => {
+                  e.preventDefault();
+                  window.location.reload();
+                }}
+              >
+                Reload
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
     );
   }
 

--- a/packages/front-end/services/auth.tsx
+++ b/packages/front-end/services/auth.tsx
@@ -26,6 +26,7 @@ export type OrganizationMember = {
   name: string;
   role: MemberRole;
   permissions?: Permissions;
+  enterprise: boolean;
   settings?: OrganizationSettings;
   freeSeats?: number;
   discountCode?: string;
@@ -242,6 +243,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
       id: specialOrg.id,
       name: specialOrg.name,
       role: "admin",
+      enterprise: specialOrg.enterprise,
     });
   }
 

--- a/packages/front-end/styles/global.scss
+++ b/packages/front-end/styles/global.scss
@@ -197,6 +197,7 @@ pre {
   margin: 0 auto;
 }
 .gbtable {
+  background-color: var(--surface-background-color);
   margin-bottom: 0;
 
   thead {


### PR DESCRIPTION
### Features and Changes

- If an enterprise licence key is expired and it's a trial, throw an error during back-end startup
- If an enterprise licence key is in a trial, show a countdown in the top nav
- Add an `Enterprise` badge in the top nav for enterprise accounts on GrowthBook Cloud
- Support for restricting an organization on Cloud to "Login with Google"
- Fix background color for tables

### Screenshots

Top nav while a trial licence key is active:
![image](https://user-images.githubusercontent.com/1087514/194105305-88c0bc0d-d8f3-4b02-8b0a-f86d94196797.png)

With tooltip:
![image](https://user-images.githubusercontent.com/1087514/194105550-35ece716-206d-4566-94b1-f817d055d8fc.png)

If login is restricted to Google and user logs in with email/password:
![image](https://user-images.githubusercontent.com/1087514/194172007-c66dd074-63b0-4be8-8e73-3f667b13ca2e.png)

### Testing

- [x] Self-hosted local auth
- [x] Self-hosted enterprise auth
- [x] Trial licence key (expired)
- [x] Trial licence key (active)
- [x] Real licence key (expired)
- [x] Real licence key (active)
- [x] Cloud default auth
- [x] Cloud enterprise badge
- [x] Cloud enterprise SSO
- [x] Cloud "Login with Google" required
- [x] Table bg colors