### PR TITLE
Update poetry install instructions

### DIFF
--- a/.devcontainer/dockerBuild.sh
+++ b/.devcontainer/dockerBuild.sh
@@ -3,7 +3,7 @@ echo "export PATH=\"$PATH:$HOME/.poetry/bin\"" >> ~/.bashrc
 echo "printf 'Welcome to GrowthBook, to get started run:\n"yarn dev"\n'" >> ~/.bashrc
 
 #poetry installation
-curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 -
+curl -sSL https://install.python-poetry.org | python3 -
 
 #needed for 'poetry install' during 'yarn setup'
 export PATH="$PATH:$HOME/.poetry/bin"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,9 +45,9 @@ Now you have the basic Linux system set up, and can follow along with all the ot
 3. Run `cd growthbook`
 4. Run `yarn` to install dependencies
 5. Install [poetry](https://python-poetry.org/docs/)
-   - Run `curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 -`
+   - Run `curl -sSL https://install.python-poetry.org | python3 -`
    - Close and reopen your terminal
-   - Run `poetry --v` to confirm a successful install
+   - Run `poetry --version` to confirm a successful install
    - If unsuccessful add the Poetry path (ex. `$HOME/.poetry/bin`) to your global path (ex. `/etc/profile`, `/etc/environment`, `~/.bashrc`, `~/.zshrc`)
 6. Run `yarn setup` to do the initial build
 7. If you have Docker installed, start MongoDB in Docker:


### PR DESCRIPTION
The command to install poetry has changed.

Reference the Poetry [installation](https://python-poetry.org/docs/#installation) docs.

## New command

```bash
curl -sSL https://install.python-poetry.org | python3 -
```

## Old command

```bash
curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 -
```

```
Retrieving Poetry metadata

This installer is deprecated, and scheduled for removal from the Poetry repository on or after January 1, 2023.
See https://github.com/python-poetry/poetry/issues/6377 for details.

You should migrate to https://install.python-poetry.org instead, which supports all versions of Poetry, and allows for `self update` of versions 1.1.7 or newer.
Instructions are available at https://python-poetry.org/docs/#installation.

Without an explicit version, this installer will attempt to install the latest version of Poetry.
This installer cannot install Poetry 1.2.0a1 or newer (and installs will be unable to `self update` to 1.2.0a1 or newer).

To continue to use this deprecated installer, you must specify an explicit version with --version <version> or POETRY_VERSION=<version>.
Alternatively, if you wish to force this deprecated installer to use the latest installable release, set GET_POETRY_IGNORE_DEPRECATION=1.

Version 1.2.1 is not supported by this installer! Please specify a version prior to 1.2.0a1 to continue!
```