### PR TITLE
Let users enter the experiment_id when creating a draft experiment

### DIFF
--- a/packages/front-end/components/Experiment/NewExperimentForm.tsx
+++ b/packages/front-end/components/Experiment/NewExperimentForm.tsx
@@ -155,6 +155,7 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
   });
 
   const datasource = getDatasourceById(form.watch("datasource"));
+  const supportsSQL = datasource?.properties?.queryLanguage === "sql";
 
   const implementation = form.watch("implementation");
 
@@ -227,6 +228,22 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
       <Page display="Basic Info">
         {msg && <div className="alert alert-info">{msg}</div>}
         <Field label="Name" required minLength={2} {...form.register("name")} />
+        {!isImport && !fromFeature && datasource && (
+          <Field
+            label="Experiment Id"
+            {...form.register("trackingKey")}
+            helpText={
+              supportsSQL ? (
+                <>
+                  Must match the <code>experiment_id</code> field in your
+                  datasource
+                </>
+              ) : (
+                "Must match the experiment id in your tracking callback"
+              )
+            }
+          />
+        )}
         {visualEditorEnabled && !isImport && (
           <Field
             label="Use Visual Editor"

--- a/packages/front-end/components/Experiment/NewExperimentForm.tsx
+++ b/packages/front-end/components/Experiment/NewExperimentForm.tsx
@@ -236,7 +236,7 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
               supportsSQL ? (
                 <>
                   Must match the <code>experiment_id</code> field in your
-                  datasource
+                  database table
                 </>
               ) : (
                 "Must match the experiment id in your tracking callback"


### PR DESCRIPTION
### Features and Changes

We currently only let users enter the experiment name. We then guess the experiment id based on the name. This behavior is unintuitive and often produces an incorrect id that is hard to debug.

This PR lets the user explicitly enter the experiment id when creating an experiment. If left empty, it will fall back to the guessing behavior that exists now.

The experiment id field is hidden when importing an experiment from a data source or feature rule, since we already know the real id.

![image](https://user-images.githubusercontent.com/1087514/195100357-3bf35d62-aff1-4cef-a6e7-a6ef8e6e36b8.png)

