### PR TITLE
Helper script to migrate data sources when ENCRYPTION_KEY changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "start": "wsrun -p '*-end' -m start",
     "setup": "wsrun -p '@growthbook/growthbook' -c build && wsrun -p '@growthbook/growthbook-react' -c build && wsrun -p 'stats' -c setup",
     "prepare": "husky install",
+    "migrate-encryption-key": "yarn workspace back-end migrate-encryption-key",
     "ci": "yarn lint && yarn run type-check && yarn run test"
   },
   "workspaces": [

--- a/packages/back-end/package.json
+++ b/packages/back-end/package.json
@@ -13,7 +13,8 @@
     "type-check": "tsc --pretty --noEmit",
     "generate-dummy-data": "ts-node --swc ./test/data-generator/new-generator.ts",
     "watch-compile": "swc src -w --out-dir dist",
-    "watch-dev": "sleep 1 && nodemon --watch \"dist/**/*\" -e js ./dist/server.js"
+    "watch-dev": "sleep 1 && nodemon --watch \"dist/**/*\" -e js ./dist/server.js",
+    "migrate-encryption-key": "node dist/scripts/migrate-encryption-key.js"
   },
   "dependencies": {
     "@google-cloud/bigquery": "5",

--- a/packages/back-end/src/app.ts
+++ b/packages/back-end/src/app.ts
@@ -5,8 +5,6 @@ import express, {
   ErrorRequestHandler,
   Response,
 } from "express";
-import mongoInit from "./init/mongo";
-import licenseInit from "./init/license";
 import { usingFileConfig } from "./init/config";
 import cors from "cors";
 import { AuthRequest } from "./types/AuthRequest";
@@ -95,8 +93,8 @@ const savedGroupsController = wrapController(savedGroupsControllerRaw);
 // End Controllers
 
 import { getUploadsDir } from "./services/files";
-import { queueInit } from "./init/queue";
 import { isEmailEnabled } from "./services/email";
+import { init } from "./init";
 
 // eslint-disable-next-line
 type Handler = RequestHandler<any>;
@@ -125,23 +123,6 @@ if (SENTRY_DSN) {
       user: ["email", "sub"],
     })
   );
-}
-
-let initPromise: Promise<void>;
-async function init() {
-  if (!initPromise) {
-    initPromise = (async () => {
-      await mongoInit();
-      await queueInit();
-      await licenseInit();
-    })();
-  }
-  try {
-    await initPromise;
-  } catch (err) {
-    console.error(err);
-    process.exit(1);
-  }
 }
 
 if (!process.env.NO_INIT) {

--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -1745,6 +1745,11 @@ export async function postPastExperiments(
   }
 
   const integration = getSourceIntegrationObject(datasourceObj);
+  if (integration.decryptionError) {
+    throw new Error(
+      "Could not decrypt data source credentials. View the data source settings for more info."
+    );
+  }
   const start = new Date();
   start.setDate(start.getDate() - IMPORT_LIMIT_DAYS);
   const now = new Date();

--- a/packages/back-end/src/controllers/organizations.ts
+++ b/packages/back-end/src/controllers/organizations.ts
@@ -178,6 +178,7 @@ export async function getDefinitions(req: AuthRequest, res: Response) {
         settings: d.settings,
         params: getNonSensitiveParams(integration),
         properties: integration.getSourceProperties(),
+        decryptionError: integration.decryptionError || false,
       };
     }),
     dimensions,

--- a/packages/back-end/src/init/index.ts
+++ b/packages/back-end/src/init/index.ts
@@ -1,0 +1,20 @@
+import mongoInit from "./mongo";
+import licenseInit from "./license";
+import { queueInit } from "./queue";
+
+let initPromise: Promise<void>;
+export async function init() {
+  if (!initPromise) {
+    initPromise = (async () => {
+      await mongoInit();
+      await queueInit();
+      await licenseInit();
+    })();
+  }
+  try {
+    await initPromise;
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+}

--- a/packages/back-end/src/integrations/GoogleAnalytics.ts
+++ b/packages/back-end/src/integrations/GoogleAnalytics.ts
@@ -52,11 +52,17 @@ const GoogleAnalytics: SourceIntegrationConstructor = class
   datasource: string;
   organization: string;
   settings: DataSourceSettings;
+  decryptionError: boolean;
 
   constructor(encryptedParams: string) {
-    this.params = decryptDataSourceParams<GoogleAnalyticsParams>(
-      encryptedParams
-    );
+    try {
+      this.params = decryptDataSourceParams<GoogleAnalyticsParams>(
+        encryptedParams
+      );
+    } catch (e) {
+      this.params = { customDimension: "", refreshToken: "", viewId: "" };
+      this.decryptionError = true;
+    }
     this.settings = {};
   }
   getExperimentMetricQuery(): string {

--- a/packages/back-end/src/integrations/Mixpanel.ts
+++ b/packages/back-end/src/integrations/Mixpanel.ts
@@ -30,10 +30,16 @@ export default class Mixpanel implements SourceIntegrationInterface {
   params: MixpanelConnectionParams;
   organization: string;
   settings: DataSourceSettings;
+  decryptionError: boolean;
   constructor(encryptedParams: string, settings: DataSourceSettings) {
-    this.params = decryptDataSourceParams<MixpanelConnectionParams>(
-      encryptedParams
-    );
+    try {
+      this.params = decryptDataSourceParams<MixpanelConnectionParams>(
+        encryptedParams
+      );
+    } catch (e) {
+      this.params = { projectId: "", secret: "", username: "" };
+      this.decryptionError = true;
+    }
     this.settings = {
       events: {
         experimentEvent: "$experiment_started",

--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -28,6 +28,7 @@ export default abstract class SqlIntegration
   settings: DataSourceSettings;
   datasource: string;
   organization: string;
+  decryptionError: boolean;
   // eslint-disable-next-line
   params: any;
   abstract setParams(encryptedParams: string): void;
@@ -36,7 +37,12 @@ export default abstract class SqlIntegration
   abstract getSensitiveParamKeys(): string[];
 
   constructor(encryptedParams: string, settings: DataSourceSettings) {
-    this.setParams(encryptedParams);
+    try {
+      this.setParams(encryptedParams);
+    } catch (e) {
+      this.params = {};
+      this.decryptionError = true;
+    }
     this.settings = {
       ...settings,
     };

--- a/packages/back-end/src/models/DataSourceModel.ts
+++ b/packages/back-end/src/models/DataSourceModel.ts
@@ -161,3 +161,10 @@ export async function updateDataSource(
     }
   );
 }
+
+export async function _dangerousGetAllDatasources(): Promise<
+  DataSourceInterface[]
+> {
+  const all = await DataSourceModel.find();
+  return all.map(toInterface);
+}

--- a/packages/back-end/src/models/DataSourceModel.ts
+++ b/packages/back-end/src/models/DataSourceModel.ts
@@ -162,6 +162,8 @@ export async function updateDataSource(
   );
 }
 
+// WARNING: This does not restrict by organization
+// Only use for deployment-wide actions like migration scripts or superadmin tools
 export async function _dangerousGetAllDatasources(): Promise<
   DataSourceInterface[]
 > {

--- a/packages/back-end/src/models/ImpactEstimateModel.ts
+++ b/packages/back-end/src/models/ImpactEstimateModel.ts
@@ -74,6 +74,11 @@ export async function getImpactEstimate(
   }
 
   const integration = getSourceIntegrationObject(datasource);
+  if (integration.decryptionError) {
+    throw new Error(
+      "Could not decrypt data source credentials. View the data source settings for more info."
+    );
+  }
 
   const conversionWindowHours =
     metricObj.conversionWindowHours || DEFAULT_CONVERSION_WINDOW_HOURS;

--- a/packages/back-end/src/scripts/migrate-encryption-key.ts
+++ b/packages/back-end/src/scripts/migrate-encryption-key.ts
@@ -26,7 +26,7 @@ async function run() {
   await init();
   if (usingFileConfig()) {
     console.error(
-      "============\n== ERROR: == Cannot migration encryption keys when using config.yml\n============\n"
+      "============\n== ERROR: == Cannot migrate encryption keys when using config.yml\n============\n"
     );
     process.exit(1);
   }

--- a/packages/back-end/src/scripts/migrate-encryption-key.ts
+++ b/packages/back-end/src/scripts/migrate-encryption-key.ts
@@ -1,0 +1,67 @@
+import {
+  updateDataSource,
+  _dangerousGetAllDatasources,
+} from "../models/DataSourceModel";
+import { AES, enc } from "crypto-js";
+import { usingFileConfig } from "../init/config";
+import { ENCRYPTION_KEY, IS_CLOUD } from "../util/secrets";
+import { init } from "../init";
+import { encryptParams } from "../services/datasource";
+
+const [oldEncryptionKey] = process.argv.slice(2);
+if (IS_CLOUD) {
+  console.error("Cannot migrate encryption keys on Cloud");
+  process.exit(1);
+}
+
+if (oldEncryptionKey === ENCRYPTION_KEY) {
+  console.error(
+    "============\n== ERROR: == Please specify the previous encryption key, not the current one\n============\n"
+  );
+  process.exit(1);
+}
+
+async function run() {
+  // Initialize the mongo connection, etc.
+  await init();
+  if (usingFileConfig()) {
+    console.error(
+      "============\n== ERROR: == Cannot migration encryption keys when using config.yml\n============\n"
+    );
+    process.exit(1);
+  }
+
+  // Loop through all data sources in Mongo
+  const allDatasources = await _dangerousGetAllDatasources();
+  for (let i = 0; i < allDatasources.length; i++) {
+    const ds = allDatasources[i];
+    const params = ds.params;
+    if (!params) continue;
+
+    // Try to decrypt and parse using the old key
+    try {
+      const parsed = JSON.parse(
+        AES.decrypt(params, oldEncryptionKey || "dev").toString(enc.Utf8)
+      );
+      console.log(
+        `- Decrypted '${ds.name}' (${ds.id}), re-encrypting with new key and saving...`
+      );
+      // Update the data source
+      await updateDataSource(ds.id, ds.organization, {
+        params: encryptParams(parsed),
+      });
+    } catch (e) {
+      console.log(`- Could not decrypt '${ds.name}' (${ds.id}), skipping`);
+    }
+  }
+}
+run()
+  .then(() => {
+    console.log("Done!");
+  })
+  .catch((e) => {
+    console.error(e);
+  })
+  .finally(() => {
+    process.exit(0);
+  });

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -293,6 +293,11 @@ export async function refreshMetric(
       throw new Error("Could not load metric datasource");
     }
     const integration = getSourceIntegrationObject(datasource);
+    if (integration.decryptionError) {
+      throw new Error(
+        "Could not decrypt data source credentials. View the data source settings for more info."
+      );
+    }
 
     let segment: SegmentInterface | undefined = undefined;
     if (metric.segment) {

--- a/packages/back-end/src/services/reports.ts
+++ b/packages/back-end/src/services/reports.ts
@@ -104,6 +104,11 @@ export async function startExperimentAnalysis(
   }
 
   const integration = getSourceIntegrationObject(datasourceObj);
+  if (integration.decryptionError) {
+    throw new Error(
+      "Could not decrypt data source credentials. View the data source settings for more info."
+    );
+  }
 
   const queryDocs: { [key: string]: Promise<QueryDocument> } = {};
 

--- a/packages/back-end/src/types/Integration.ts
+++ b/packages/back-end/src/types/Integration.ts
@@ -140,6 +140,7 @@ export interface SourceIntegrationInterface {
   datasource: string;
   organization: string;
   settings: DataSourceSettings;
+  decryptionError: boolean;
   // eslint-disable-next-line
   params: any;
   getSensitiveParamKeys(): string[];

--- a/packages/back-end/types/datasource.d.ts
+++ b/packages/back-end/types/datasource.d.ts
@@ -96,6 +96,7 @@ export interface DataSourceProperties {
 type WithParams<B, P> = Omit<B, "params"> & {
   params: P;
   properties?: DataSourceProperties;
+  decryptionError: boolean;
 };
 
 export type IdentityJoinQuery = {

--- a/packages/docs/pages/self-host/env.mdx
+++ b/packages/docs/pages/self-host/env.mdx
@@ -60,6 +60,13 @@ growthbook:
 - **JWT_SECRET** - Auth signing key (use a long random string)
 - **ENCRYPTION_KEY** - Data source credential encryption key (use a long random string)
 
+If you change the `ENCRYPTION_KEY`, you will need to migrate any existing data sources using the following script:
+
+```sh
+# If you didn't have an ENCRYPTION_KEY before, leave OLD_KEY blank below
+docker-compose run growthbook yarn migrate-encryption-key OLD_KEY
+```
+
 <div className="bg-blue-50 py-3 mb-5 px-4 text-gray-600 border-l-8 border-blue-200 dark:bg-blue-800 dark:text-gray-50">
   When using GrowthBook in production, it is important to change the{" "}
   <code>NODE_ENV</code> to to "production" and change the{" "}

--- a/packages/docs/pages/self-host/env.mdx
+++ b/packages/docs/pages/self-host/env.mdx
@@ -62,7 +62,7 @@ growthbook:
 
 If you change the `ENCRYPTION_KEY`, you will need to migrate any existing data sources using the following script:
 
-```sh
+```bash
 # If you didn't have an ENCRYPTION_KEY before, leave OLD_KEY blank below
 docker-compose run growthbook yarn migrate-encryption-key OLD_KEY
 ```

--- a/packages/front-end/components/DocLink.tsx
+++ b/packages/front-end/components/DocLink.tsx
@@ -31,6 +31,7 @@ const docSections = {
   config_yml: "/self-host/config",
   config_domains_and_ports: "/self-host/env#domains-and-ports",
   config_organization_settings: "/self-host/config#organization-settings",
+  env_prod: "/self-host/env#production-settings",
   visual_editor: "/app/visual",
 };
 

--- a/packages/front-end/components/Settings/DataSources.tsx
+++ b/packages/front-end/components/Settings/DataSources.tsx
@@ -9,6 +9,8 @@ import { GBAddCircle } from "../Icons";
 import usePermissions from "../../hooks/usePermissions";
 import { DocLink } from "../DocLink";
 import NewDataSourceForm from "./NewDataSourceForm";
+import Tooltip from "../Tooltip";
+import { FaExclamationTriangle } from "react-icons/fa";
 
 const DataSources: FC = () => {
   const [newModalOpen, setNewModalOpen] = useState(false);
@@ -48,7 +50,20 @@ const DataSources: FC = () => {
                 }}
               >
                 <td>
-                  <Link href={`/datasources/${d.id}`}>{d.name}</Link>
+                  <Link href={`/datasources/${d.id}`}>{d.name}</Link>{" "}
+                  {d.decryptionError && (
+                    <Tooltip
+                      body={
+                        <>
+                          Could not decrypt the connection settings for this
+                          data source. Click on the data source name for more
+                          info.
+                        </>
+                      }
+                    >
+                      <FaExclamationTriangle className="text-danger" />
+                    </Tooltip>
+                  )}
                 </td>
                 <td>{d.type}</td>
                 {!hasFileConfig() && <td>{datetime(d.dateCreated)}</td>}

--- a/packages/front-end/components/Settings/HostWarning.tsx
+++ b/packages/front-end/components/Settings/HostWarning.tsx
@@ -8,7 +8,10 @@ export default function HostWarning({
   setHost: (host: string) => void;
 }) {
   // Trying to connect to localhost
-  if (host.match(/^([a-z0-9+-_]+:\/\/)?(localhost|127.0.0.1)($|[/?:])/)) {
+  if (
+    host &&
+    host.match(/^([a-z0-9+-_]+:\/\/)?(localhost|127.0.0.1)($|[/?:])/)
+  ) {
     if (isCloud()) {
       return (
         <div className="alert alert-danger">

--- a/packages/front-end/pages/datasources/[did].tsx
+++ b/packages/front-end/pages/datasources/[did].tsx
@@ -90,6 +90,14 @@ const DataSourcePage: FC = () => {
           </a>
         </Link>
       </div>
+      {d.decryptionError && (
+        <div className="alert alert-danger mb-2 d-flex justify-content-between align-items-center">
+          <strong>Error Decrypting Data Source Credentials.</strong>{" "}
+          <DocLink docSection="env_prod" className="btn btn-primary">
+            View instructions for fixing
+          </DocLink>
+        </div>
+      )}
       <div className="row mb-3 align-items-center">
         <div className="col-auto">
           <h1 className="mb-0">{d.name}</h1>


### PR DESCRIPTION
### Features and Changes

If you change the `ENCRYPTION_KEY` environment variable, all of your existing data source connections break because we can no longer decrypt the connection params.

This PR adds a new script to migrate data soruces to a new encryption key.

First, I made the app fail gracefully if decryption fails (before the whole app would fail to load):

![errors-running-queries](https://user-images.githubusercontent.com/1087514/195199583-2bf872b3-357c-4e6c-82b3-2fff26fc2bf6.png)

![decryption-warning-list](https://user-images.githubusercontent.com/1087514/195199585-bbca25b6-c5b5-4d96-9675-86543471b5b0.png)

![decryption-warning-did](https://user-images.githubusercontent.com/1087514/195199587-a498ee9f-3042-4b4e-b3cd-3171253c9d5d.png)

Then, I added instructions to the docs on how to use the helper script:

![image](https://user-images.githubusercontent.com/1087514/195200027-b87fbf2f-1910-4368-9a2f-48662871d7f9.png)

Fixes #622
