### PR TITLE
Fix Ad-hoc Reports icon for dark mode

### DIFF
--- a/packages/front-end/components/Experiment/ResultMoreMenu.tsx
+++ b/packages/front-end/components/Experiment/ResultMoreMenu.tsx
@@ -1,6 +1,6 @@
 import { useRouter } from "next/router";
 import { FaCog, FaFileDownload, FaPencilAlt } from "react-icons/fa";
-import { GrTableAdd } from "react-icons/gr";
+import { BiTable } from "react-icons/bi";
 import { Queries } from "back-end/types/query";
 import {
   ExperimentReportResultDimension,
@@ -110,8 +110,8 @@ export default function ResultMoreMenu({
               await router.push(`/report/${res.report.id}`);
             }}
           >
-            <GrTableAdd className="mr-2" style={{ fontSize: "1.2rem" }} />{" "}
-            Ad-hoc Report
+            <BiTable className="mr-2" style={{ fontSize: "1.2rem" }} /> Ad-hoc
+            Report
           </Button>
         )}
 


### PR DESCRIPTION
### Features and Changes

Quick dark mode fix for a user-reported icon colour.

It looks like the icon library we're using has a bug and incorrectly hardcodes the stroke colour. It should be using `currentColor`. I found a different icon that uses `currentColor` throughout all its child elements.

![image](https://user-images.githubusercontent.com/113377031/196252923-07963115-dc5f-47fb-90eb-29a2c44aab44.png)

I just picked the first table icon I could find in a known icon set. If you have a preference for a specific icon in a specific set, let me know, but the `gr` one we had before won't work on dark mode.

### Dependencies

n/a

### Testing

Go to the experiment results, click the context menu on the right under "Mark as finished" and see "Ad-hoc Report."

### Screenshots

#### Before

![image](https://user-images.githubusercontent.com/113377031/196252687-70579486-cc71-4505-9efb-871e7390aff2.png)


#### After

<img width="375" alt="image" src="https://user-images.githubusercontent.com/113377031/196252633-2aca2c19-ad82-4f5c-b47e-546f19face10.png">

