### PR TITLE
Correctly handle Athena queries in QUEUED and CANCELLED states

### DIFF
--- a/packages/back-end/src/services/athena.ts
+++ b/packages/back-end/src/services/athena.ts
@@ -56,10 +56,12 @@ export async function runAthenaQuery<T>(
             const StateChangeReason =
               resp.QueryExecution?.Status?.StateChangeReason;
 
-            if (State === "RUNNING") {
+            if (State === "RUNNING" || State === "QUEUED") {
               resolve(false);
             } else if (State === "FAILED") {
               reject(new Error(StateChangeReason || "Query failed"));
+            } else if (State === "CANCELLED") {
+              reject(new Error("Query was cancelled"));
             } else {
               athena
                 .getQueryResults({ QueryExecutionId })


### PR DESCRIPTION
### Features and Changes

Currently, if an Athena query has state `RUNNING`, we keep waiting.  If the state is `FAILED`, we record the error.  And if the state is `SUCCEEDED`, we fetch the results.

There are 2 additional states which the code does not properly handle - `QUEUED` (should be treated the same as `Running`), and `CANCELLED` (should be treated the same as `FAILED`).

As a result, if Athena takes a long time to start executing a query, the first time we check for results, it might be in a `QUEUED` state and we would treat that as an error instead of continuing to wait.

This PR adds support for those 2 additional states.