### PR TITLE
SQL dialect-specific formatting rules

### DIFF
--- a/packages/back-end/package.json
+++ b/packages/back-end/package.json
@@ -63,7 +63,7 @@
     "python-shell": "^3.0.0",
     "saslprep": "^1.0.0",
     "snowflake-promise": "^4.5.0",
-    "sql-formatter": "^4.0.2",
+    "sql-formatter": "^11.0.2",
     "string-env-interpolation": "^1.0.1",
     "stripe": "^9.14.0",
     "uniqid": "^5.3.0",

--- a/packages/back-end/src/integrations/Athena.ts
+++ b/packages/back-end/src/integrations/Athena.ts
@@ -2,6 +2,7 @@ import { decryptDataSourceParams } from "../services/datasource";
 import { runAthenaQuery } from "../services/athena";
 import SqlIntegration from "./SqlIntegration";
 import { AthenaConnectionParams } from "../../types/integrations/athena";
+import { FormatDialect } from "../util/sql";
 
 export default class Athena extends SqlIntegration {
   params: AthenaConnectionParams;
@@ -9,6 +10,9 @@ export default class Athena extends SqlIntegration {
     this.params = decryptDataSourceParams<AthenaConnectionParams>(
       encryptedParams
     );
+  }
+  getFormatDialect(): FormatDialect {
+    return "trino";
   }
   getSensitiveParamKeys(): string[] {
     return ["accessKeyId", "secretAccessKey"];

--- a/packages/back-end/src/integrations/BigQuery.ts
+++ b/packages/back-end/src/integrations/BigQuery.ts
@@ -4,6 +4,7 @@ import SqlIntegration from "./SqlIntegration";
 import { BigQueryConnectionParams } from "../../types/integrations/bigquery";
 import { getValidDate } from "../util/dates";
 import { IS_CLOUD } from "../util/secrets";
+import { FormatDialect } from "../util/sql";
 
 export default class BigQuery extends SqlIntegration {
   params: BigQueryConnectionParams;
@@ -11,6 +12,9 @@ export default class BigQuery extends SqlIntegration {
     this.params = decryptDataSourceParams<BigQueryConnectionParams>(
       encryptedParams
     );
+  }
+  getFormatDialect(): FormatDialect {
+    return "bigquery";
   }
   getSensitiveParamKeys(): string[] {
     return ["privateKey"];

--- a/packages/back-end/src/integrations/Mssql.ts
+++ b/packages/back-end/src/integrations/Mssql.ts
@@ -2,6 +2,7 @@ import { MssqlConnectionParams } from "../../types/integrations/mssql";
 import { decryptDataSourceParams } from "../services/datasource";
 import SqlIntegration from "./SqlIntegration";
 import mssql from "mssql";
+import { FormatDialect } from "../util/sql";
 
 export default class Mssql extends SqlIntegration {
   params: MssqlConnectionParams;
@@ -9,6 +10,9 @@ export default class Mssql extends SqlIntegration {
     this.params = decryptDataSourceParams<MssqlConnectionParams>(
       encryptedParams
     );
+  }
+  getFormatDialect(): FormatDialect {
+    return "tsql";
   }
   getSensitiveParamKeys(): string[] {
     return ["password"];

--- a/packages/back-end/src/integrations/Mysql.ts
+++ b/packages/back-end/src/integrations/Mysql.ts
@@ -3,6 +3,7 @@ import { decryptDataSourceParams } from "../services/datasource";
 import SqlIntegration from "./SqlIntegration";
 import mysql, { RowDataPacket } from "mysql2/promise";
 import { ConnectionOptions } from "mysql2";
+import { FormatDialect } from "../util/sql";
 
 export default class Mysql extends SqlIntegration {
   params: MysqlConnectionParams;
@@ -10,6 +11,9 @@ export default class Mysql extends SqlIntegration {
     this.params = decryptDataSourceParams<MysqlConnectionParams>(
       encryptedParams
     );
+  }
+  getFormatDialect(): FormatDialect {
+    return "mysql";
   }
   getSensitiveParamKeys(): string[] {
     return ["password"];

--- a/packages/back-end/src/integrations/Postgres.ts
+++ b/packages/back-end/src/integrations/Postgres.ts
@@ -1,6 +1,7 @@
 import { PostgresConnectionParams } from "../../types/integrations/postgres";
 import { decryptDataSourceParams } from "../services/datasource";
 import { runPostgresQuery } from "../services/postgres";
+import { FormatDialect } from "../util/sql";
 import SqlIntegration from "./SqlIntegration";
 
 export default class Postgres extends SqlIntegration {
@@ -9,6 +10,9 @@ export default class Postgres extends SqlIntegration {
     this.params = decryptDataSourceParams<PostgresConnectionParams>(
       encryptedParams
     );
+  }
+  getFormatDialect(): FormatDialect {
+    return "postgresql";
   }
   getSensitiveParamKeys(): string[] {
     return ["password", "caCert", "clientCert", "clientKey"];

--- a/packages/back-end/src/integrations/Presto.ts
+++ b/packages/back-end/src/integrations/Presto.ts
@@ -3,6 +3,7 @@ import { decryptDataSourceParams } from "../services/datasource";
 import SqlIntegration from "./SqlIntegration";
 import { PrestoConnectionParams } from "../../types/integrations/presto";
 import { Client, IPrestoClientOptions } from "presto-client";
+import { FormatDialect } from "../util/sql";
 
 // eslint-disable-next-line
 type Row = any;
@@ -13,6 +14,9 @@ export default class Presto extends SqlIntegration {
     this.params = decryptDataSourceParams<PrestoConnectionParams>(
       encryptedParams
     );
+  }
+  getFormatDialect(): FormatDialect {
+    return "trino";
   }
   getSensitiveParamKeys(): string[] {
     return ["password"];

--- a/packages/back-end/src/integrations/Redshift.ts
+++ b/packages/back-end/src/integrations/Redshift.ts
@@ -1,6 +1,7 @@
 import { PostgresConnectionParams } from "../../types/integrations/postgres";
 import { decryptDataSourceParams } from "../services/datasource";
 import { runPostgresQuery } from "../services/postgres";
+import { FormatDialect } from "../util/sql";
 import SqlIntegration from "./SqlIntegration";
 
 export default class Redshift extends SqlIntegration {
@@ -9,6 +10,9 @@ export default class Redshift extends SqlIntegration {
     this.params = decryptDataSourceParams<PostgresConnectionParams>(
       encryptedParams
     );
+  }
+  getFormatDialect(): FormatDialect {
+    return "redshift";
   }
   getSensitiveParamKeys(): string[] {
     return ["password", "caCert", "clientCert", "clientKey"];

--- a/packages/back-end/src/integrations/Snowflake.ts
+++ b/packages/back-end/src/integrations/Snowflake.ts
@@ -1,6 +1,7 @@
 import { SnowflakeConnectionParams } from "../../types/integrations/snowflake";
 import { decryptDataSourceParams } from "../services/datasource";
 import { runSnowflakeQuery } from "../services/snowflake";
+import { FormatDialect } from "../util/sql";
 import SqlIntegration from "./SqlIntegration";
 
 export default class Snowflake extends SqlIntegration {
@@ -9,6 +10,9 @@ export default class Snowflake extends SqlIntegration {
     this.params = decryptDataSourceParams<SnowflakeConnectionParams>(
       encryptedParams
     );
+  }
+  getFormatDialect(): FormatDialect {
+    return "snowflake";
   }
   getSensitiveParamKeys(): string[] {
     return ["password"];

--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -21,7 +21,12 @@ import { DimensionInterface } from "../../types/dimension";
 import { DEFAULT_CONVERSION_WINDOW_HOURS } from "../util/secrets";
 import { getValidDate } from "../util/dates";
 import { SegmentInterface } from "../../types/segment";
-import { getBaseIdTypeAndJoins, replaceSQLVars, format } from "../util/sql";
+import {
+  getBaseIdTypeAndJoins,
+  replaceSQLVars,
+  format,
+  FormatDialect,
+} from "../util/sql";
 
 export default abstract class SqlIntegration
   implements SourceIntegrationInterface {
@@ -69,6 +74,9 @@ export default abstract class SqlIntegration
   }
 
   getSchema(): string {
+    return "";
+  }
+  getFormatDialect(): FormatDialect {
     return "";
   }
   toTimestamp(date: Date) {
@@ -263,7 +271,8 @@ export default abstract class SqlIntegration
       -- Skip experiments at start of date range since it's likely missing data
       ${this.dateDiff(this.toTimestamp(params.from), "start_date")} > 2
     ORDER BY
-      experiment_id ASC, variation_id ASC`
+      experiment_id ASC, variation_id ASC`,
+      this.getFormatDialect()
     );
   }
   async runPastExperimentQuery(query: string): Promise<PastExperimentResponse> {
@@ -390,7 +399,8 @@ export default abstract class SqlIntegration
       `
           : ""
       }
-      `
+      `,
+      this.getFormatDialect()
     );
   }
 
@@ -974,7 +984,8 @@ export default abstract class SqlIntegration
       ${this.ifElse(`variance > 0`, `sqrt(variance)`, `0`)} as stddev,
       users
     FROM __overall
-    `
+    `,
+      this.getFormatDialect()
     );
   }
   getExperimentResultsQuery(): string {

--- a/packages/back-end/src/util/sql.ts
+++ b/packages/back-end/src/util/sql.ts
@@ -1,4 +1,4 @@
-import { format as sqlFormat } from "sql-formatter";
+import { format as sqlFormat, FormatOptions } from "sql-formatter";
 
 function getBaseIdType(objects: string[][], forcedBaseIdType?: string) {
   // If a specific id type is already chosen as the base, return it
@@ -103,16 +103,17 @@ export function replaceSQLVars(
   return sql;
 }
 
-export function format(sql: string) {
-  return (
-    sqlFormat(sql, {
-      language: "redshift",
-    })
-      // Fix Snowflate syntax for flatten function
-      .replace(/ = > /g, " => ")
-      // Similar fix for PrestoDB/Athena lambda functions
-      .replace(/ - > /g, " -> ")
-  );
+export type FormatDialect = FormatOptions["language"] | "";
+export function format(sql: string, dialect?: FormatDialect) {
+  if (!dialect) return sql;
+
+  try {
+    return sqlFormat(sql, {
+      language: dialect,
+    });
+  } catch (e) {
+    return sql;
+  }
 }
 
 // Recursively create list of metric denominators in order

--- a/yarn.lock
+++ b/yarn.lock
@@ -5464,6 +5464,11 @@ dirty-json@^0.9.2:
     unescape-js "^1.1.4"
     utf8 "^3.0.0"
 
+discontinuous-range@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
+  integrity sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==
+
 dlv@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/dlv/-/dlv-1.1.3.tgz#5c198a8a11453596e751494d49874bc7732f2e79"
@@ -9684,6 +9689,11 @@ mongoose@^5.13.13:
     sift "13.5.2"
     sliced "1.0.1"
 
+moo@^0.5.0:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/moo/-/moo-0.5.2.tgz#f9fe82473bc7c184b0d32e2215d3f6e67278733c"
+  integrity sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==
+
 mousetrap@^1.6.5:
   version "1.6.5"
   resolved "https://registry.yarnpkg.com/mousetrap/-/mousetrap-1.6.5.tgz#8a766d8c272b08393d5f56074e0b5ec183485bf9"
@@ -9854,6 +9864,16 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
+
+nearley@^2.20.1:
+  version "2.20.1"
+  resolved "https://registry.yarnpkg.com/nearley/-/nearley-2.20.1.tgz#246cd33eff0d012faf197ff6774d7ac78acdd474"
+  integrity sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==
+  dependencies:
+    commander "^2.19.0"
+    moo "^0.5.0"
+    railroad-diagrams "^1.0.0"
+    randexp "0.4.6"
 
 negotiator@0.6.3:
   version "0.6.3"
@@ -11095,6 +11115,19 @@ raf-schd@^4.0.2:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/raf-schd/-/raf-schd-4.0.3.tgz#5d6c34ef46f8b2a0e880a8fcdb743efc5bfdbc1a"
   integrity sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==
+
+railroad-diagrams@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz#eb7e6267548ddedfb899c1b90e57374559cddb7e"
+  integrity sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==
+
+randexp@0.4.6:
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/randexp/-/randexp-0.4.6.tgz#e986ad5e5e31dae13ddd6f7b3019aa7c87f60ca3"
+  integrity sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==
+  dependencies:
+    discontinuous-range "1.0.0"
+    ret "~0.1.10"
 
 randombytes@^2.1.0:
   version "2.1.0"
@@ -12530,12 +12563,13 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
 
-sql-formatter@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/sql-formatter/-/sql-formatter-4.0.2.tgz#2b359e5a4c611498d327b9659da7329d71724607"
-  integrity sha512-R6u9GJRiXZLr/lDo8p56L+OyyN2QFJPCDnsyEOsbdIpsnDKL8gubYFo7lNR7Zx7hfdWT80SfkoVS0CMaF/DE2w==
+sql-formatter@^11.0.2:
+  version "11.0.2"
+  resolved "https://registry.yarnpkg.com/sql-formatter/-/sql-formatter-11.0.2.tgz#2fde373c8c1845f8ee9f201d2eccb1fb365cd893"
+  integrity sha512-6QumAdGHEnI5dXEq1d0aBRP876AyA9Wp/UE7wopKNA2Mp9sKGRKVqGgoWHk4dr0J0nceesC85Y0p36qmGoNqhw==
   dependencies:
     argparse "^2.0.1"
+    nearley "^2.20.1"
 
 sqlstring@^2.3.2:
   version "2.3.3"


### PR DESCRIPTION
### Features and Changes

1. Update the sql-formatter library to the latest version
2. Pass the SQL dialect into the formatter for language-specific formatting rules
3. Disable formatting for ClickHouse (not well supported)
4. On parsing failure, fail gracefully and return the original unformatted SQL
5. Add more test cases for SQL formatting

Fixes #198
Fixes #379