### PR TITLE
Bug: Editing saved groups without changing the values results in an error.

### DIFF
--- a/packages/front-end/components/SavedGroupForm.tsx
+++ b/packages/front-end/components/SavedGroupForm.tsx
@@ -25,7 +25,7 @@ const SavedGroupForm: FC<{
       groupName: current.groupName || "",
       owner: current.owner || "",
       attributeKey: current.attributeKey || "",
-      groupList: String(current.values) || "",
+      groupList: String(current.values || ""),
       id: current.id || "",
     },
   });

--- a/packages/front-end/components/SavedGroupForm.tsx
+++ b/packages/front-end/components/SavedGroupForm.tsx
@@ -25,7 +25,7 @@ const SavedGroupForm: FC<{
       groupName: current.groupName || "",
       owner: current.owner || "",
       attributeKey: current.attributeKey || "",
-      groupList: String(current.values || ""),
+      groupList: current.values?.join(", ") || "",
       id: current.id || "",
     },
   });

--- a/packages/front-end/components/SavedGroupForm.tsx
+++ b/packages/front-end/components/SavedGroupForm.tsx
@@ -25,7 +25,7 @@ const SavedGroupForm: FC<{
       groupName: current.groupName || "",
       owner: current.owner || "",
       attributeKey: current.attributeKey || "",
-      groupList: current.values || "",
+      groupList: String(current.values) || "",
       id: current.id || "",
     },
   });

--- a/packages/front-end/pages/saved-groups.tsx
+++ b/packages/front-end/pages/saved-groups.tsx
@@ -87,13 +87,7 @@ export default function SavedGroupsPage() {
                         className="d-none d-md-table-cell text-truncate"
                         style={{ maxWidth: "100px" }}
                       >
-                        {s.values.map((attribute, index) => {
-                          if (index === s.values.length - 1) {
-                            return attribute;
-                          } else {
-                            return `${attribute}, `;
-                          }
-                        })}
+                        {String(s.values)}
                       </td>
                       <td>{ago(s.dateUpdated)}</td>
                       {permissions.manageSavedGroups && (

--- a/packages/front-end/pages/saved-groups.tsx
+++ b/packages/front-end/pages/saved-groups.tsx
@@ -87,7 +87,7 @@ export default function SavedGroupsPage() {
                         className="d-none d-md-table-cell text-truncate"
                         style={{ maxWidth: "100px" }}
                       >
-                        {String(s.values)}
+                        {s.values.join(", ")}
                       </td>
                       <td>{ago(s.dateUpdated)}</td>
                       {permissions.manageSavedGroups && (


### PR DESCRIPTION
### Features and Changes

Just found a bug on the SavedGroups form.  When editing a group, we're setting the default values with:

  const form = useForm({
    defaultValues: {
      groupName: current.groupName || "",
      owner: current.owner || "",
      attributeKey: current.attributeKey || "",
      groupList: current.values || "",
      id: current.id || "",
    },
  });
current.values is an array of strings, but we should be setting groupList to a comma-separated string instead.
If you open the modal and then immediately try to save, you get an error.  But if you focus and blur the values textbox, useForm will update the value and then submit will work.

### Solution
I'm using the `String()` constructor, and calling it as a function, which, when an array is passed in as a param, converts the array to a comma-separated string.

This looks to have great browser compatibility.

MDN Docs - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/String

### Testing

- [x] Open an existing saved group to edit it, and click "Save" without making any changes and confirm that you no longer get an error.
- [x] Create a new saved group and save it without any errors and confirm the array that is built and saved to the DB is in the right shape.
- [x] Edit this newly saved group and confirm that even with wonky inputs (e.g. extra spaces, multiple commas) it formats nicely before saved as an array on the DB.
