### PR TITLE
Fix bug: Could not find API key to delete

### DIFF
--- a/packages/back-end/src/models/ApiKeyModel.ts
+++ b/packages/back-end/src/models/ApiKeyModel.ts
@@ -110,11 +110,11 @@ export async function getApiKeyByIdOrKey(
   id: string | undefined,
   key: string | undefined
 ): Promise<ApiKeyInterface | null> {
-  const doc = await ApiKeyModel.findOne({
-    organization,
-    id,
-    key,
-  });
+  if (!id && !key) return null;
+
+  const doc = await ApiKeyModel.findOne(
+    id ? { organization, id } : { organization, key }
+  );
   return doc ? doc.toJSON() : null;
 }
 


### PR DESCRIPTION
### Features and Changes

Fix bug when trying to delete a secret API key: `Could not find API key to delete`.