### PR TITLE
Fix invitation bug - prompted to create new organization instead of accepting invite

### DIFF
--- a/packages/front-end/components/ProtectedPage.tsx
+++ b/packages/front-end/components/ProtectedPage.tsx
@@ -102,7 +102,9 @@ const ProtectedPage: React.FC<{
     <UserContextProvider key={orgId}>
       <LoggedInPageGuard organizationRequired={organizationRequired}>
         <InAppHelp />
-        {orgId ? (
+        {!organizationRequired ? (
+          <>{children}</>
+        ) : orgId ? (
           <WatchProvider>{children}</WatchProvider>
         ) : (
           <CreateOrganization />

--- a/packages/front-end/hooks/useStripeSubscription.ts
+++ b/packages/front-end/hooks/useStripeSubscription.ts
@@ -83,6 +83,7 @@ export default function useStripeSubscription() {
     canSubscribe:
       isCloud() &&
       !disableSelfServeBilling &&
+      !organization?.enterprise &&
       selfServePricingEnabled &&
       !hasActiveSubscription,
   };


### PR DESCRIPTION
### Features and Changes

When clicking a GrowthBook invitation link, we were prompting users to create a new organization instead of accepting the invitation.