### PR TITLE
Added Markdown support for the experiment metrics tooltip and also up…

### DIFF
--- a/packages/front-end/components/Markdown/Markdown.tsx
+++ b/packages/front-end/components/Markdown/Markdown.tsx
@@ -17,7 +17,12 @@ const Markdown: FC<
     );
   }
 
-  const text = typeof children === "string" ? children : "";
+  const text =
+    typeof children === "string"
+      ? children
+      : typeof children === "number"
+      ? children.toString()
+      : "";
 
   return (
     <div

--- a/packages/front-end/components/Markdown/Markdown.tsx
+++ b/packages/front-end/components/Markdown/Markdown.tsx
@@ -17,12 +17,7 @@ const Markdown: FC<
     );
   }
 
-  const text =
-    typeof children === "string"
-      ? children
-      : typeof children === "number"
-      ? children.toString()
-      : "";
+  const text = typeof children === "string" ? children : "";
 
   return (
     <div

--- a/packages/front-end/components/Metrics/MetricToolTipBody.module.scss
+++ b/packages/front-end/components/Metrics/MetricToolTipBody.module.scss
@@ -1,0 +1,16 @@
+.description {
+  position: relative;
+  height: 100px;
+  overflow: hidden;
+}
+
+.description:after {
+  position: absolute;
+  content: "";
+  bottom: 0;
+  right: 0;
+  width: 100%;
+  height: 60px;
+  padding-top: 40px;
+  background-image: linear-gradient(to bottom, transparent, white);
+}

--- a/packages/front-end/components/Metrics/MetricToolTipBody.module.scss
+++ b/packages/front-end/components/Metrics/MetricToolTipBody.module.scss
@@ -1,19 +1,17 @@
 @import "../../styles/colors.scss";
 
-.description {
+.markdown {
   position: relative;
-  height: 100px;
+  max-height: 100px;
   overflow: hidden;
 }
 
-.description:after {
+.markdown:after {
   position: absolute;
   content: "";
   bottom: 0;
-  right: 0;
+  top: 40px;
   width: 100%;
-  height: 60px;
-  padding-top: 40px;
   background-image: linear-gradient(
     to bottom,
     transparent,

--- a/packages/front-end/components/Metrics/MetricToolTipBody.module.scss
+++ b/packages/front-end/components/Metrics/MetricToolTipBody.module.scss
@@ -1,3 +1,5 @@
+@import "../../styles/colors.scss";
+
 .description {
   position: relative;
   height: 100px;
@@ -12,5 +14,9 @@
   width: 100%;
   height: 60px;
   padding-top: 40px;
-  background-image: linear-gradient(to bottom, transparent, white);
+  background-image: linear-gradient(
+    to bottom,
+    transparent,
+    var(--surface-background-color)
+  );
 }

--- a/packages/front-end/components/Metrics/MetricTooltipBody.tsx
+++ b/packages/front-end/components/Metrics/MetricTooltipBody.tsx
@@ -1,5 +1,6 @@
 import { MetricInterface } from "back-end/types/metric";
 import { isNullUndefinedOrEmpty } from "../../services/utils";
+import Markdown from "../Markdown/Markdown";
 import SortedTags from "../Tags/SortedTags";
 
 interface MetricToolTipCompProps {
@@ -69,7 +70,7 @@ const MetricTooltipBody = ({
         .map(({ label, body }, index) => (
           <div key={`metricInfo${index}`}>
             <strong>{`${label}: `}</strong>
-            <span className="font-weight-normal">{body}</span>
+            <Markdown className="font-weight-normal">{body}</Markdown>
           </div>
         ))}
     </div>

--- a/packages/front-end/components/Metrics/MetricTooltipBody.tsx
+++ b/packages/front-end/components/Metrics/MetricTooltipBody.tsx
@@ -11,6 +11,7 @@ interface MetricInfo {
   show: boolean;
   label: string;
   body: string | number | JSX.Element;
+  markdown?: boolean;
 }
 
 const MetricTooltipBody = ({
@@ -33,6 +34,7 @@ const MetricTooltipBody = ({
       show: validMetricDescription(metric.description),
       label: "Description",
       body: truncateMetricDescription(metric.description),
+      markdown: true,
     },
     {
       show: true,
@@ -67,10 +69,10 @@ const MetricTooltipBody = ({
     <div className="text-left">
       {metricInfo
         .filter((i) => i.show)
-        .map(({ label, body }, index) => (
+        .map(({ label, body, markdown }, index) => (
           <div key={`metricInfo${index}`}>
             <strong>{`${label}: `}</strong>
-            {label === "Description" ? (
+            {markdown ? (
               <Markdown className="font-weight-normal">{body}</Markdown>
             ) : (
               <span className="font-weight-normal">{body}</span>

--- a/packages/front-end/components/Metrics/MetricTooltipBody.tsx
+++ b/packages/front-end/components/Metrics/MetricTooltipBody.tsx
@@ -1,7 +1,9 @@
 import { MetricInterface } from "back-end/types/metric";
+import clsx from "clsx";
 import { isNullUndefinedOrEmpty } from "../../services/utils";
 import Markdown from "../Markdown/Markdown";
 import SortedTags from "../Tags/SortedTags";
+import styles from "./MetricToolTipBody.module.scss";
 
 interface MetricToolTipCompProps {
   metric: MetricInterface;
@@ -31,12 +33,6 @@ const MetricTooltipBody = ({
 
   const metricInfo: MetricInfo[] = [
     {
-      show: validMetricDescription(metric.description),
-      label: "Description",
-      body: truncateMetricDescription(metric.description),
-      markdown: true,
-    },
-    {
       show: true,
       label: "Type",
       body: metric.type,
@@ -63,6 +59,12 @@ const MetricTooltipBody = ({
       label: "Conversion Window Hours",
       body: metric.conversionWindowHours,
     },
+    {
+      show: validMetricDescription(metric.description),
+      label: "Description",
+      body: truncateMetricDescription(metric.description),
+      markdown: true,
+    },
   ];
 
   return (
@@ -73,7 +75,9 @@ const MetricTooltipBody = ({
           <div key={`metricInfo${index}`}>
             <strong>{`${label}: `}</strong>
             {markdown ? (
-              <Markdown className="font-weight-normal">{body}</Markdown>
+              <div className={clsx("border rounded p-2", styles.description)}>
+                <Markdown className="font-weight-normal">{body}</Markdown>
+              </div>
             ) : (
               <span className="font-weight-normal">{body}</span>
             )}

--- a/packages/front-end/components/Metrics/MetricTooltipBody.tsx
+++ b/packages/front-end/components/Metrics/MetricTooltipBody.tsx
@@ -19,12 +19,6 @@ interface MetricInfo {
 const MetricTooltipBody = ({
   metric,
 }: MetricToolTipCompProps): React.ReactElement => {
-  function truncateMetricDescription(metricDescription: string) {
-    if (!metricDescription) return;
-    if (metricDescription.length < 300) return metricDescription;
-    return `${metricDescription.substring(0, 300)}...`;
-  }
-
   function validMetricDescription(description: string): boolean {
     if (!description) return false;
     const regExp = new RegExp(/[A-Za-z0-9]/);
@@ -62,7 +56,7 @@ const MetricTooltipBody = ({
     {
       show: validMetricDescription(metric.description),
       label: "Description",
-      body: truncateMetricDescription(metric.description),
+      body: metric.description,
       markdown: true,
     },
   ];
@@ -75,8 +69,8 @@ const MetricTooltipBody = ({
           <div key={`metricInfo${index}`}>
             <strong>{`${label}: `}</strong>
             {markdown ? (
-              <div className={clsx("border rounded p-2", styles.description)}>
-                <Markdown className="font-weight-normal">{body}</Markdown>
+              <div className={clsx("border rounded p-2", styles.markdown)}>
+                <Markdown>{body}</Markdown>
               </div>
             ) : (
               <span className="font-weight-normal">{body}</span>

--- a/packages/front-end/components/Metrics/MetricTooltipBody.tsx
+++ b/packages/front-end/components/Metrics/MetricTooltipBody.tsx
@@ -70,7 +70,11 @@ const MetricTooltipBody = ({
         .map(({ label, body }, index) => (
           <div key={`metricInfo${index}`}>
             <strong>{`${label}: `}</strong>
-            <Markdown className="font-weight-normal">{body}</Markdown>
+            {label === "Description" ? (
+              <Markdown className="font-weight-normal">{body}</Markdown>
+            ) : (
+              <span className="font-weight-normal">{body}</span>
+            )}
           </div>
         ))}
     </div>


### PR DESCRIPTION
### Features and Changes

In the experiment results table, we show a tooltip when hovering over metric names. The tooltip gives a summary view of the metric, but it doesn't render markdown properly in the description.

This PR adds support for markdown in the description.

- Closes **(https://github.com/growthbook/growthbook/issues/631)**

### Testing

- [x] Add markdown to a metric and confirm that it displays correctly within the tooltip.
- [x] Ensure that it works with both long and short descriptions
- [x] Ensure that it works with dark and light modes

### Screenshots

<img width="325" alt="Screen Shot 2022-11-03 at 9 01 38 AM" src="https://user-images.githubusercontent.com/75274610/199728543-c397b635-45cc-4d6f-8ec0-bc7ede23941c.png">

<img width="348" alt="Screen Shot 2022-11-03 at 9 01 21 AM" src="https://user-images.githubusercontent.com/75274610/199728563-184ae074-4101-42dd-8886-55398e5598bd.png">

<img width="410" alt="Screen Shot 2022-11-03 at 9 02 34 AM" src="https://user-images.githubusercontent.com/75274610/199728581-70c30c5d-51ae-4bec-bd40-bca93bdfb3b3.png">

<img width="410" alt="Screen Shot 2022-11-03 at 9 02 44 AM" src="https://user-images.githubusercontent.com/75274610/199728611-3fac7bbd-f54f-47e1-b901-9d220b049c8c.png">
