### PR TITLE
Increase browser support for javascript SDK - iOS 12.2+

### DIFF
--- a/packages/sdk-js/.babelrc.js
+++ b/packages/sdk-js/.babelrc.js
@@ -4,7 +4,6 @@ const esm = {
       "@babel/preset-env",
       {
         modules: false,
-        targets: "defaults, not IE 11, maintained node versions",
       },
     ],
     ["@babel/preset-typescript"],

--- a/packages/sdk-js/README.md
+++ b/packages/sdk-js/README.md
@@ -4,7 +4,7 @@
 
 This is the Javascript client library that lets you evaluate feature flags and run experiments (A/B tests) within a Javascript application.
 
-![Build Status](https://github.com/growthbook/growthbook/workflows/CI/badge.svg) ![GZIP Size](https://img.shields.io/badge/gzip%20size-3.19KB-informational) ![NPM Version](https://img.shields.io/npm/v/@growthbook/growthbook)
+![Build Status](https://github.com/growthbook/growthbook/workflows/CI/badge.svg) ![GZIP Size](https://img.shields.io/badge/gzip%20size-3.34KB-informational) ![NPM Version](https://img.shields.io/npm/v/@growthbook/growthbook)
 
 - **No external dependencies**
 - **Lightweight and fast**

--- a/packages/sdk-js/package.json
+++ b/packages/sdk-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@growthbook/growthbook",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -54,6 +54,7 @@
   },
   "browserslist": [
     "defaults",
+    ">0.35%",
     "not IE 11",
     "maintained node versions"
   ]

--- a/packages/sdk-react/package.json
+++ b/packages/sdk-react/package.json
@@ -59,6 +59,7 @@
   },
   "browserslist": [
     "defaults",
+    ">0.35%",
     "not IE 11",
     "maintained node versions"
   ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -4096,9 +4096,9 @@ camelize@^1.0.0:
   integrity sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=
 
 caniuse-lite@^1.0.30001370, caniuse-lite@^1.0.30001406:
-  version "1.0.30001414"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001414.tgz#5f1715e506e71860b4b07c50060ea6462217611e"
-  integrity sha512-t55jfSaWjCdocnFdKQoO+d2ct9C59UZg4dY3OnUlSZ447r8pUtIKdp0hpAzrGFultmTC+Us+KpKi4GZl/LXlFg==
+  version "1.0.30001429"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001429.tgz"
+  integrity sha512-511ThLu1hF+5RRRt0zYCf2U2yRr9GPF6m5y90SBCWsvSoYoW7yAGlv/elyPaNfvGCkp6kj/KFZWU0BMA69Prsg==
 
 caseless@~0.12.0:
   version "0.12.0"


### PR DESCRIPTION
### Features and Changes

Change `browserslist` setting to include iOS 12.2+.

TODO:
- [x] Test
- [x] Bump version and release javascript SDK on npm
- [ ] Merge PR