### PR TITLE
Mixpanel - Optional extra property when grouping by user

### DIFF
--- a/docs/docs/app/datasources.mdx
+++ b/docs/docs/app/datasources.mdx
@@ -195,9 +195,7 @@ We query Mixpanel using JQL. We have sensible defaults for the event and propert
   - **View Experiments Event** - The name of the event you are firing when a user is put into a variation
   - **Experiment Id Property** - The property name that stores the experiment tracking key
   - **Variation Id Property** - The property name that stores the variation the user was assigned
-  - **Variation Id Format** - What format the variation id is stored in.
-    1.  Numeric (0 = control, 1 = variation 1, etc.)
-    2.  Unique String Keys (e.g. "blue", "random-uuid", etc.)
+  - **Extra UserId Property** - _(optional)_ An additional event property to add to the groupBy (`distinct_id` is always included)
 
 Below is an example of what your Mixpanel tracking call would look like in Javascript using our default settings:
 

--- a/packages/back-end/src/integrations/Mixpanel.ts
+++ b/packages/back-end/src/integrations/Mixpanel.ts
@@ -163,7 +163,7 @@ export default class Mixpanel implements SourceIntegrationInterface {
           return false;
         })
         // Array of metric values for each user
-        .groupByUser(function(state, events) {
+        .groupByUser(${this.getGroupByUserFields()}function(state, events) {
           state = state || {
             inExperiment: false,
             ${dimension ? "dimension: null," : ""}
@@ -392,7 +392,7 @@ export default class Mixpanel implements SourceIntegrationInterface {
           return false;
         })
         // Metric value per user
-        .groupByUser(function(state, events) {
+        .groupByUser(${this.getGroupByUserFields()}function(state, events) {
           state = state || {date: null, metricValue: []};
           for(var i=0; i<events.length; i++) {
             state.date = state.date || events[i].time;
@@ -547,6 +547,13 @@ function is${name}(event) {
       .split(/ OR /g)
       .map((e) => e.trim())
       .filter(Boolean);
+  }
+
+  private getGroupByUserFields() {
+    if (this.settings?.events?.extraUserIdProperty) {
+      return JSON.stringify([this.settings?.events?.extraUserIdProperty]) + ",";
+    }
+    return "";
   }
 
   private getEvents(from: Date, to: Date, events: (string | undefined)[]) {

--- a/packages/back-end/types/datasource.d.ts
+++ b/packages/back-end/types/datasource.d.ts
@@ -123,6 +123,7 @@ export type DataSourceEvents = {
   experimentEvent?: string;
   experimentIdProperty?: string;
   variationIdProperty?: string;
+  extraUserIdProperty?: string;
 };
 
 export type DataSourceSettings = {

--- a/packages/front-end/components/Settings/EditDataSource/DataSourceExperimentProperties/DataSourceEditExperimentEventPropertiesModal.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/DataSourceExperimentProperties/DataSourceEditExperimentEventPropertiesModal.tsx
@@ -25,6 +25,8 @@ export const DataSourceEditExperimentEventPropertiesModal: FC<DataSourceEditExpe
         dataSource.settings?.events?.experimentIdProperty || "",
       variationIdProperty:
         dataSource.settings?.events?.variationIdProperty || "",
+      extraUserIdProperty:
+        dataSource.settings?.events?.extraUserIdProperty || "",
     },
   });
 
@@ -35,6 +37,7 @@ export const DataSourceEditExperimentEventPropertiesModal: FC<DataSourceEditExpe
       experimentEvent: "",
       experimentIdProperty: "",
       variationIdProperty: "",
+      extraUserIdProperty: "",
     });
   });
 
@@ -74,6 +77,17 @@ export const DataSourceEditExperimentEventPropertiesModal: FC<DataSourceEditExpe
                 label="Variation Id Property"
                 placeholder="Variant name"
                 {...form.register("variationIdProperty")}
+              />
+              <Field
+                label="Extra UserId Property (optional)"
+                placeholder=""
+                {...form.register("extraUserIdProperty")}
+                helpText={
+                  <>
+                    Will be added to the groupBy along with{" "}
+                    <code>distinct_id</code>.
+                  </>
+                }
               />
             </div>
           </div>

--- a/packages/front-end/components/Settings/EditDataSource/DataSourceExperimentProperties/DataSourceViewEditExperimentProperties.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/DataSourceExperimentProperties/DataSourceViewEditExperimentProperties.tsx
@@ -79,6 +79,21 @@ export const DataSourceViewEditExperimentProperties: FC<DataSourceViewEditExperi
               </code>
             </td>
           </tr>
+          <tr>
+            <th>UserId Property</th>
+            <td>
+              <code>distinct_id</code>
+              {dataSource.settings?.events?.extraUserIdProperty && (
+                <>
+                  {" "}
+                  +{" "}
+                  <code>
+                    {dataSource.settings?.events?.extraUserIdProperty || ""}
+                  </code>
+                </>
+              )}
+            </td>
+          </tr>
         </tbody>
       </table>
 


### PR DESCRIPTION
### Features and Changes

Allow specifying an additional event property to use when grouping by user.  `distinct_id` is always used, this just adds a 2nd property to the group by.

Fixes #692

![image](https://user-images.githubusercontent.com/1087514/199552563-f15704b5-b890-43c9-8830-83b9a44fb968.png)

![image](https://user-images.githubusercontent.com/1087514/199552821-a346c7b8-a8c1-40e6-8262-24c49211dbb3.png)
