### PR TITLE
Move docs CI to a separate workflow

### DIFF
--- a/.github/workflows/ci-nochanges.yml
+++ b/.github/workflows/ci-nochanges.yml
@@ -1,0 +1,18 @@
+name: CI
+on:
+  pull_request:
+    paths-ignore:
+      - "packages/**"
+      - "yarn.lock"
+      - ".eslintrc"
+      - ".eslintignore"
+      - ".prettierignore"
+
+# If nothing of importance changed, the normal CI workflow is skipped
+# Skipped steps do not count as successful, which will block the PR from being merged
+# This is a dummy workflow for those cases so it gets marked as successful in GitHub
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No changes, skipping"'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,12 @@
 name: CI
-on: [pull_request]
+on:
+  pull_request:
+    paths:
+      - "packages/**"
+      - "yarn.lock"
+      - ".eslintrc"
+      - ".eslintignore"
+      - ".prettierignore"
 
 jobs:
   # Linting, type-checking, and tests
@@ -37,22 +44,7 @@ jobs:
           # Stats engine
           pip install numpy scipy pandas pytest black flake8 nbformat gbstats
 
-          # Docs
-          cd docs
-          yarn
-          cd ..
-
-      - name: App/SDK - get changed files
-        id: app-changed-files
-        uses: tj-actions/changed-files@v34
-        with:
-          files: |
-            packages/**
-            yarn.lock
-            .github/workflows/ci.yml
-
-      - name: App/SDK - build, lint, type-check, and test 
-        if: steps.app-changed-files.outputs.any_changed == 'true'
+      - name: Build, lint, type-check, and test 
         run: |
           # Build SDK packages (required for linting/type checks to work)
           yarn workspace @growthbook/growthbook build
@@ -69,19 +61,3 @@ jobs:
           yarn test
         env:
           CI: true
-
-
-      - name: Docs - get changed files
-        id: docs-changed-files
-        uses: tj-actions/changed-files@v34
-        with:
-          files: |
-            docs/**
-            .github/workflows/ci.yml
-
-      - name: Docs - type-check
-        if: steps.docs-changed-files.outputs.any_changed == 'true'
-        run: |
-          cd docs
-          yarn typecheck
-          cd ..

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,13 +3,11 @@ on:
   pull_request:
     paths:
       - "docs/**"
-      - ".github/workflows/docs.yml"
   push:
     branches:
       - "main"
     paths:
       - "docs/**"
-      - ".github/workflows/docs.yml"
 jobs:
   vercel:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-name: Deploy Docs
+name: Docs
 on:
   pull_request:
     paths:
@@ -37,3 +37,22 @@ jobs:
           vercel-org-id: ${{ secrets.VERCEL_DOCS_ORG_ID}}
           vercel-project-id: ${{ secrets.VERCEL_DOCS_PROJECT_ID}} 
           working-directory: ./
+
+  # Linting, type-checking, and tests
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+          cache: 'yarn'
+      
+      - name: Install dependencies and type-check
+        run: |
+          cd docs
+          yarn
+          yarn typecheck

--- a/packages/back-end/README.md
+++ b/packages/back-end/README.md
@@ -120,3 +120,7 @@ To make it available from the front-end, you'll need to import your controller a
 We use Jest to write tests on the back-end.
 
 To avoid pulling in Mongo dependencies, all tested code should be in small standalone util files that do not import db models.
+
+## REST API endpoints
+
+_Coming soon_


### PR DESCRIPTION
### Features and Changes

-  Only run the CI workflow if important files were changed (e.g. `packages/**` or `yarn.lock`)
-  Don't include docs CI steps in the main CI workflow.  Instead, move them to a separate workflow
-  Add a dummy CI workflow so that "required checks" in GitHub will still work correctly