### PR TITLE
Add support for json syntax highlighting and also added support for m…

### DIFF
--- a/packages/front-end/components/Features/ConditionInput.tsx
+++ b/packages/front-end/components/Features/ConditionInput.tsx
@@ -55,6 +55,7 @@ export default function ConditionInput(props: Props) {
   ];
 
   if (advanced || !attributes.size || !simpleAllowed) {
+    console.log("simpleAllowed", simpleAllowed);
     return (
       <div className="mb-3">
         <CodeTextArea

--- a/packages/front-end/components/Features/ConditionInput.tsx
+++ b/packages/front-end/components/Features/ConditionInput.tsx
@@ -10,6 +10,7 @@ import styles from "./ConditionInput.module.scss";
 import { GBAddCircle } from "../Icons";
 import SelectField from "../Forms/SelectField";
 import { useDefinitions } from "../../services/DefinitionsContext";
+import CodeTextArea from "../Forms/CodeTextArea";
 
 interface Props {
   defaultValue: string;
@@ -56,14 +57,11 @@ export default function ConditionInput(props: Props) {
   if (advanced || !attributes.size || !simpleAllowed) {
     return (
       <div className="mb-3">
-        <Field
+        <CodeTextArea
           label="Targeting Conditions"
-          containerClassName="mb-0"
-          textarea
-          minRows={1}
-          maxRows={12}
+          language="json"
           value={value}
-          onChange={(e) => setValue(e.target.value)}
+          setValue={setValue}
           helpText="JSON format using MongoDB query syntax"
         />
         {simpleAllowed && attributes.size && (

--- a/packages/front-end/components/Features/ConditionInput.tsx
+++ b/packages/front-end/components/Features/ConditionInput.tsx
@@ -62,23 +62,29 @@ export default function ConditionInput(props: Props) {
           language="json"
           value={value}
           setValue={setValue}
-          helpText="JSON format using MongoDB query syntax"
+          helpText={
+            <div className="d-flex">
+              <div>JSON format using MongoDB query syntax.</div>
+              {simpleAllowed && attributes.size && (
+                <div className="ml-auto">
+                  <a
+                    href="#"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      const newConds = jsonToConds(value, attributes);
+                      // TODO: show error
+                      if (newConds === null) return;
+                      setConds(newConds);
+                      setAdvanced(false);
+                    }}
+                  >
+                    switch to simple mode
+                  </a>
+                </div>
+              )}
+            </div>
+          }
         />
-        {simpleAllowed && attributes.size && (
-          <a
-            href="#"
-            onClick={(e) => {
-              e.preventDefault();
-              const newConds = jsonToConds(value, attributes);
-              // TODO: show error
-              if (newConds === null) return;
-              setConds(newConds);
-              setAdvanced(false);
-            }}
-          >
-            switch to simple mode
-          </a>
-        )}
       </div>
     );
   }

--- a/packages/front-end/components/Forms/CodeTextArea.tsx
+++ b/packages/front-end/components/Forms/CodeTextArea.tsx
@@ -30,8 +30,9 @@ export type Props = Omit<
 > & {
   language: Language;
   value: string;
-  height?: number;
   setValue: (value: string) => void;
+  minLines?: number;
+  maxLines?: number;
 };
 
 const LIGHT_THEME = "textmate";
@@ -42,7 +43,8 @@ export default function CodeTextArea({
   value,
   setValue,
   placeholder,
-  height = 260,
+  minLines = 3,
+  maxLines = 50,
   ...otherProps
 }: Props) {
   // eslint-disable-next-line
@@ -69,10 +71,11 @@ export default function CodeTextArea({
                 mode={language}
                 theme={theme === "light" ? LIGHT_THEME : DARK_THEME}
                 width="inherit"
-                height={`${height}px`}
                 value={value}
                 onChange={(newValue) => setValue(newValue)}
                 placeholder={placeholder}
+                minLines={minLines}
+                maxLines={maxLines}
               />
             </div>
           </>


### PR DESCRIPTION
### Features and Changes

When a user is creating/editing a feature's targeting, we offer an advanced mode, and this PR adds support for JSON syntax highlighting in that text area.

- Closes **(https://github.com/growthbook/growthbook/issues/650)**


### Testing

- [x] Write valid MongoDB json syntax (EX: `{"id": {"$inGroup": "grp_exl5j15bzl9isco8z"}}`) and ensure the highlighting works as expected and the targeting works as expected. Ex: The plain-text feature rule should read as "id is in the saved group test".
- [x] Ensure that invalid JSON returns an applicable error

### Screenshots

<img width="520" alt="Screen Shot 2022-11-03 at 8 53 31 AM" src="https://user-images.githubusercontent.com/75274610/199725709-1e395fa8-8390-4466-bf1c-7b104cb373db.png">

<img width="1012" alt="Screen Shot 2022-11-02 at 2 19 48 PM" src="https://user-images.githubusercontent.com/75274610/199570775-9ceac303-a845-4824-be9f-c02b2b79cc9b.png">

<img width="492" alt="Screen Shot 2022-11-02 at 2 20 25 PM" src="https://user-images.githubusercontent.com/75274610/199570891-476d9067-d0fc-4ed7-bd12-adff77f53282.png">

