### PR TITLE
Fix mismatched syntax highlighting in Code related to dark/light appearance modes

### DIFF
--- a/packages/front-end/components/SyntaxHighlighting/Code.tsx
+++ b/packages/front-end/components/SyntaxHighlighting/Code.tsx
@@ -70,14 +70,16 @@ export default function Code({
 
   const enoughLines = code.split("\n").length > 8;
 
-  const style = cloneDeep(theme === "light" ? light : dark);
+  const style = cloneDeep(theme === "dark" ? dark : light);
   style['code[class*="language-"]'].fontSize = "0.85rem";
   style['code[class*="language-"]'].lineHeight = 1.5;
   style['code[class*="language-"]'].fontWeight = 600;
-  delete style['pre[class*="language-"]'].background;
-  delete style['pre[class*="language-"]'].backgroundColor;
-  style['pre[class*="language-"]'].background =
-    "var(--surface-background-color-alt)";
+
+  const codeBackgrounds = {
+    dark: "#212529",
+    light: "#fff",
+  };
+  style['pre[class*="language-"]'].backgroundColor = codeBackgrounds[theme];
   style['pre[class*="language-"]'].border = "1px solid var(--border-color-200)";
 
   const display =


### PR DESCRIPTION
### Features and Changes

The bug can be reproduced if you're on the Getting Started screen's 2nd step in light mode and you switch to dark mode.

I've made 2 fixes that should help with 2 concerns:

1. falling into the wrong code editor syntax highlighting theme
2. adding a background in the event that the above fails

The first change, I've made the change to default to check the presence of dark rather than the presence of light, so this should help with the issue where you fall into the wrong syntax highlighting theme due to condition where the OS setting was `system`. 

For the second fix, in the event that we do somehow still fall into that condition, I'm hardcoding the background colour to the hardcoded value of what the CSS variables return. This is to retain the same desired colour (the surface background colour) rather than the theme default. This means if we do change the CSS variable value, we will need to change the code theme too.

I think the first change should be enough to fix it, but I've added the 2nd one just in case.

Closes https://github.com/growthbook/growthbook/issues/663

### Dependencies

n/a


### Screenshots

If we do somehow fall into this case (we shouldn't anymore due to the boolean logic change):

<img width="967" alt="Screen Shot 2022-11-02 at 11 09 16 AM" src="https://user-images.githubusercontent.com/113377031/199570242-f43c4391-2742-4e0b-9ac8-806fa3128b4e.png">
