### PR TITLE
Allow duplicate experiment tracking keys

### DIFF
--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -402,18 +402,7 @@ export async function createExperiment(
     throw new Error("Experiment and Organization must match");
   }
 
-  if (data.trackingKey) {
-    // Make sure id is unique
-    const existing = await getExperimentByTrackingKey(
-      data.organization,
-      data.trackingKey
-    );
-    if (existing) {
-      throw new Error(
-        "Error: Duplicate experiment id. Please choose something else"
-      );
-    }
-  } else {
+  if (!data.trackingKey) {
     // Try to generate a unique tracking key based on the experiment name
     let n = 1;
     let found = null;

--- a/packages/front-end/components/Experiment/NewExperimentForm.tsx
+++ b/packages/front-end/components/Experiment/NewExperimentForm.tsx
@@ -203,7 +203,7 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
     if ("duplicateTrackingKey" in res) {
       setAllowDuplicateTrackingKey(true);
       throw new Error(
-        "An experiment with that id already exists. To create a new one, click 'Save' again."
+        "Warning: An experiment with that id already exists. To continue anyway, click 'Save' again."
       );
     }
 

--- a/packages/front-end/components/Experiment/NewExperimentForm.tsx
+++ b/packages/front-end/components/Experiment/NewExperimentForm.tsx
@@ -81,6 +81,9 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
 }) => {
   const router = useRouter();
   const [step, setStep] = useState(initialStep || 0);
+  const [allowDuplicateTrackingKey, setAllowDuplicateTrackingKey] = useState(
+    false
+  );
 
   const {
     datasources,
@@ -184,13 +187,26 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
 
     const body = JSON.stringify(data);
 
-    const res = await apiCall<{ experiment: ExperimentInterfaceStringDates }>(
-      `/experiments`,
+    const res = await apiCall<
+      | { experiment: ExperimentInterfaceStringDates }
+      | { duplicateTrackingKey: true; existingId: string }
+    >(
+      `/experiments${
+        allowDuplicateTrackingKey ? "?allowDuplicateTrackingKey=true" : ""
+      }`,
       {
         method: "POST",
         body,
       }
     );
+
+    if ("duplicateTrackingKey" in res) {
+      setAllowDuplicateTrackingKey(true);
+      throw new Error(
+        "An experiment with that id already exists. To create a new one, click 'Save' again."
+      );
+    }
+
     track("Create Experiment", {
       source,
       implementation: data.implementation || "code",


### PR DESCRIPTION
### Features and Changes

Fixes #686

If attempting to add an experiment with the same tracking key as an existing one, show a warning instead of making it a fatal error.  Submitting again will create the experiment.

![image](https://user-images.githubusercontent.com/1087514/199612797-293bb2ed-0050-407b-90ed-d58f015c2055.png)

