### PR TITLE
Force count to be a float in SQL to avoid integer division errors

### DIFF
--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -922,7 +922,7 @@ export default abstract class SqlIntegration
         SELECT
           variation,
           dimension,
-          COUNT(*) as users
+          ${this.ensureFloat("COUNT(*)")} as users
         FROM
           __distinctUsers
         GROUP BY


### PR DESCRIPTION
Added the 'ensureFloat' to the count(*) as users to make sure the count comes back as a float. 