### PR TITLE
Change the "Create Issue" link in the Java SDK docs to the Java SDK repo

### DIFF
--- a/docs/docs/lib/java.mdx
+++ b/docs/docs/lib/java.mdx
@@ -21,7 +21,7 @@ This supports Java applications using Java version 1.8 and higher.
 
 :::success New
 
-The GrowthBook Java SDK is a brand new feature. If you experience any issues, let us know either on [Slack](https://slack.growthbook.io/) or [create an issue](https://github.com/growthbook/growthbook/issues/new/choose).
+The GrowthBook Java SDK is a brand new feature. If you experience any issues, let us know either on [Slack](https://slack.growthbook.io/) or [create an issue](https://github.com/growthbook/growthbook-sdk-java/issues).
 
 :::
 


### PR DESCRIPTION
Changes the link for creating an issue to the Java SDK repo instead of the main monorepo.