### PR TITLE
Add link to React Native example in the React docs

### DIFF
--- a/docs/docs/lib/react.mdx
+++ b/docs/docs/lib/react.mdx
@@ -5,6 +5,8 @@ sidebar_label: React
 slug: react
 ---
 
+import ExternalLink from '@site/src/components/ExternalLink'
+
 # ReactJS
 
 This is a thin wrapper on top of the [Javascript Library](/lib/js), so you might want to view those docs first to familiarize yourself with the basic classes and methods.
@@ -312,3 +314,7 @@ class OtherComponent extends React.Component {
 // Wrap your component in `withRunExperiment`
 export default withRunExperiment(OtherComponent);
 ```
+
+## Examples
+
+- [React Native <ExternalLink />](https://github.com/growthbook/examples/tree/main/react-native-cli)


### PR DESCRIPTION
Adds a link to React Native example in the React docs.

<img width="912" alt="image" src="https://user-images.githubusercontent.com/113377031/202023868-2c74d066-42b5-40bd-b4fe-008b99bf10a4.png">
