### PR TITLE
improve styling for metric graph axis

### DIFF
--- a/packages/front-end/components/Metrics/DateGraph.tsx
+++ b/packages/front-end/components/Metrics/DateGraph.tsx
@@ -484,10 +484,14 @@ const DateGraph: FC<{
                   tickLabelProps={() => ({
                     fill: "var(--text-color-table)",
                     fontSize: 11,
-                    textAnchor: "middle",
+                    textAnchor: "start",
+                    dx: -15,
                   })}
                   tickFormat={(d) => {
-                    return date(d as Date);
+                    return (d as Date).toLocaleDateString("en-us", {
+                      month: "short",
+                      day: "numeric",
+                    });
                   }}
                 />
                 <AxisLeft
@@ -497,6 +501,8 @@ const DateGraph: FC<{
                     fill: "var(--text-color-table)",
                     fontSize: 11,
                     textAnchor: "end",
+                    dx: -2,
+                    dy: 2,
                   })}
                   tickFormat={(v) =>
                     type === "binomial"

--- a/packages/front-end/pages/metric/[mid].tsx
+++ b/packages/front-end/pages/metric/[mid].tsx
@@ -550,7 +550,7 @@ const MetricPage: FC = () => {
                         <div className="mb-4">
                           <div className="row mb-3">
                             <div className="col-auto">
-                              <h5>
+                              <h5 className="mb-1 mt-1">
                                 {metric.type === "binomial"
                                   ? "Conversions"
                                   : "Metric Value"}{" "}


### PR DESCRIPTION
Makes the X axis more legible; also removes the year (not needed IMO). Also fixes some alignment style issues:
<img width="842" alt="image" src="https://user-images.githubusercontent.com/7927873/202767819-a4b24cbf-a3bf-400f-9914-29f0c91bd2dd.png">
