### PR TITLE
Expand supported fields in config.yml import/export

### DIFF
--- a/packages/front-end/services/config.ts
+++ b/packages/front-end/services/config.ts
@@ -27,22 +27,33 @@ export function useConfigJson({
       dimensions?: Record<string, Partial<DimensionInterface>>;
     } = {};
 
+    const orgSettingsFields: (keyof OrganizationSettings)[] = [
+      "environments",
+      "attributeSchema",
+      "namespaces",
+      "metricAnalysisDays",
+      "northStar",
+      "updateSchedule",
+      "multipleExposureMinPercent",
+      "videoInstructionsViewed",
+      "sdkInstructionsViewed",
+      "defaultRole",
+      "metricDefaults",
+    ];
+
+    const orgSettings = {
+      pastExperimentsMinLength: settings.pastExperimentsMinLength ?? 6,
+      visualEditorEnabled: !!settings.visualEditorEnabled,
+    };
+
+    orgSettingsFields.forEach((field) => {
+      if (settings[field]) {
+        orgSettings[field] = settings[field];
+      }
+    });
+
     config.organization = {
-      settings: {
-        pastExperimentsMinLength: settings.pastExperimentsMinLength ?? 6,
-        visualEditorEnabled: !!settings.visualEditorEnabled,
-        environments: settings.environments,
-        attributeSchema: settings.attributeSchema,
-        namespaces: settings.namespaces,
-        metricAnalysisDays: settings.metricAnalysisDays,
-        northStar: settings.northStar,
-        updateSchedule: settings.updateSchedule,
-        multipleExposureMinPercent: settings.multipleExposureMinPercent,
-        videoInstructionsViewed: settings.videoInstructionsViewed,
-        sdkInstructionsViewed: settings.sdkInstructionsViewed,
-        defaultRole: settings.defaultRole,
-        metricDefaults: settings.metricDefaults,
-      },
+      settings: orgSettings,
     };
 
     const datasourceIds: string[] = [];

--- a/packages/front-end/services/config.ts
+++ b/packages/front-end/services/config.ts
@@ -31,6 +31,17 @@ export function useConfigJson({
       settings: {
         pastExperimentsMinLength: settings.pastExperimentsMinLength ?? 6,
         visualEditorEnabled: !!settings.visualEditorEnabled,
+        environments: settings.environments,
+        attributeSchema: settings.attributeSchema,
+        namespaces: settings.namespaces,
+        metricAnalysisDays: settings.metricAnalysisDays,
+        northStar: settings.northStar,
+        updateSchedule: settings.updateSchedule,
+        multipleExposureMinPercent: settings.multipleExposureMinPercent,
+        videoInstructionsViewed: settings.videoInstructionsViewed,
+        sdkInstructionsViewed: settings.sdkInstructionsViewed,
+        defaultRole: settings.defaultRole,
+        metricDefaults: settings.metricDefaults,
       },
     };
 
@@ -49,12 +60,31 @@ export function useConfigJson({
       if (d.type === "google_analytics") return;
 
       if (d.type === "mixpanel") {
+        if (d.settings?.schemaFormat) {
+          config.datasources[d.id].settings.schemaFormat =
+            d.settings?.schemaFormat;
+        }
+      } else {
         if (d.settings?.events?.experimentIdProperty) {
           config.datasources[d.id].settings.events = d.settings.events;
         }
-      } else {
-        if (d.settings?.queries?.experimentsQuery) {
+        if (
+          d.settings?.queries?.experimentsQuery ||
+          d.settings?.queries?.exposure ||
+          d.settings?.queries?.identityJoins
+        ) {
           config.datasources[d.id].settings.queries = d.settings.queries;
+        }
+        if (d.settings?.userIdTypes) {
+          config.datasources[d.id].settings.userIdTypes =
+            d.settings?.userIdTypes;
+        }
+        if (d.settings?.notebookRunQuery) {
+          config.datasources[d.id].settings.notebookRunQuery =
+            d.settings?.notebookRunQuery;
+        }
+        if (d.settings?.events?.experimentIdProperty) {
+          config.datasources[d.id].settings.events = d.settings.events;
         }
       }
     });
@@ -84,6 +114,8 @@ export function useConfigJson({
         "userIdTypes",
         "tags",
         "denominator",
+        "type",
+        "conditions",
       ];
 
       if (m.sql) {

--- a/packages/front-end/services/config.ts
+++ b/packages/front-end/services/config.ts
@@ -83,6 +83,7 @@ export function useConfigJson({
         "userIdType",
         "userIdTypes",
         "tags",
+        "denominator",
       ];
 
       if (m.sql) {

--- a/packages/front-end/services/config.ts
+++ b/packages/front-end/services/config.ts
@@ -11,6 +11,18 @@ type Props = {
   settings: OrganizationSettings;
 };
 
+type OrgSettingsFields = Omit<
+  OrganizationSettings,
+  | "confidenceLevel"
+  | "customized"
+  | "logoPath"
+  | "primaryColor"
+  | "secondaryColor"
+  | "datasources"
+  | "techsources"
+  | "implementationTypes"
+>;
+
 export function useConfigJson({
   metrics,
   dimensions,
@@ -20,7 +32,7 @@ export function useConfigJson({
   return useMemo(() => {
     const config: {
       organization?: {
-        settings?: OrganizationSettings;
+        settings?: OrgSettingsFields;
       };
       datasources?: Record<string, Partial<DataSourceInterfaceWithParams>>;
       metrics?: Record<string, Partial<MetricInterface>>;
@@ -39,12 +51,11 @@ export function useConfigJson({
       "sdkInstructionsViewed",
       "defaultRole",
       "metricDefaults",
+      "pastExperimentsMinLength",
+      "visualEditorEnabled",
     ];
 
-    const orgSettings = {
-      pastExperimentsMinLength: settings.pastExperimentsMinLength ?? 6,
-      visualEditorEnabled: !!settings.visualEditorEnabled,
-    };
+    const orgSettings: OrgSettingsFields = {};
 
     orgSettingsFields.forEach((field) => {
       if (settings[field]) {
@@ -71,9 +82,8 @@ export function useConfigJson({
       if (d.type === "google_analytics") return;
 
       if (d.type === "mixpanel") {
-        if (d.settings?.schemaFormat) {
-          config.datasources[d.id].settings.schemaFormat =
-            d.settings?.schemaFormat;
+        if (d.settings?.events?.experimentIdProperty) {
+          config.datasources[d.id].settings.events = d.settings.events;
         }
       } else {
         if (d.settings?.events?.experimentIdProperty) {
@@ -94,8 +104,9 @@ export function useConfigJson({
           config.datasources[d.id].settings.notebookRunQuery =
             d.settings?.notebookRunQuery;
         }
-        if (d.settings?.events?.experimentIdProperty) {
-          config.datasources[d.id].settings.events = d.settings.events;
+        if (d.settings?.schemaFormat) {
+          config.datasources[d.id].settings.schemaFormat =
+            d.settings?.schemaFormat;
         }
       }
     });
@@ -125,21 +136,16 @@ export function useConfigJson({
         "userIdTypes",
         "tags",
         "denominator",
-        "type",
         "conditions",
+        "sql",
+        "queryFormat",
+        "anonymousIdColumn",
+        "timestampColumn",
+        "userIdColumn",
+        "userIdColumns",
+        "table",
+        "column",
       ];
-
-      if (m.sql) {
-        fields.push("sql");
-      } else {
-        fields.push("anonymousIdColumn");
-        fields.push("timestampColumn");
-        fields.push("userIdColumn");
-        fields.push("userIdColumns");
-        fields.push("table");
-        fields.push("column");
-        fields.push("conditions");
-      }
 
       fields.forEach((f) => {
         const v = m[f];

--- a/packages/front-end/services/config.ts
+++ b/packages/front-end/services/config.ts
@@ -11,18 +11,6 @@ type Props = {
   settings: OrganizationSettings;
 };
 
-type OrgSettingsFields = Omit<
-  OrganizationSettings,
-  | "confidenceLevel"
-  | "customized"
-  | "logoPath"
-  | "primaryColor"
-  | "secondaryColor"
-  | "datasources"
-  | "techsources"
-  | "implementationTypes"
->;
-
 export function useConfigJson({
   metrics,
   dimensions,
@@ -32,83 +20,28 @@ export function useConfigJson({
   return useMemo(() => {
     const config: {
       organization?: {
-        settings?: OrgSettingsFields;
+        settings?: OrganizationSettings;
       };
       datasources?: Record<string, Partial<DataSourceInterfaceWithParams>>;
       metrics?: Record<string, Partial<MetricInterface>>;
       dimensions?: Record<string, Partial<DimensionInterface>>;
     } = {};
 
-    const orgSettingsFields: (keyof OrganizationSettings)[] = [
-      "environments",
-      "attributeSchema",
-      "namespaces",
-      "metricAnalysisDays",
-      "northStar",
-      "updateSchedule",
-      "multipleExposureMinPercent",
-      "videoInstructionsViewed",
-      "sdkInstructionsViewed",
-      "defaultRole",
-      "metricDefaults",
-      "pastExperimentsMinLength",
-      "visualEditorEnabled",
-    ];
-
-    const orgSettings: OrgSettingsFields = {};
-
-    orgSettingsFields.forEach((field) => {
-      if (settings[field]) {
-        orgSettings[field] = settings[field];
-      }
-    });
-
     config.organization = {
-      settings: orgSettings,
+      settings,
     };
 
     const datasourceIds: string[] = [];
-
     if (datasources.length) config.datasources = {};
+
     datasources.forEach((d) => {
       datasourceIds.push(d.id);
       config.datasources[d.id] = {
         type: d.type,
         name: d.name,
         params: d.params,
-        settings: {},
+        settings: d.settings,
       } as Partial<DataSourceInterfaceWithParams>;
-
-      if (d.type === "google_analytics") return;
-
-      if (d.type === "mixpanel") {
-        if (d.settings?.events?.experimentIdProperty) {
-          config.datasources[d.id].settings.events = d.settings.events;
-        }
-      } else {
-        if (d.settings?.events?.experimentIdProperty) {
-          config.datasources[d.id].settings.events = d.settings.events;
-        }
-        if (
-          d.settings?.queries?.experimentsQuery ||
-          d.settings?.queries?.exposure ||
-          d.settings?.queries?.identityJoins
-        ) {
-          config.datasources[d.id].settings.queries = d.settings.queries;
-        }
-        if (d.settings?.userIdTypes) {
-          config.datasources[d.id].settings.userIdTypes =
-            d.settings?.userIdTypes;
-        }
-        if (d.settings?.notebookRunQuery) {
-          config.datasources[d.id].settings.notebookRunQuery =
-            d.settings?.notebookRunQuery;
-        }
-        if (d.settings?.schemaFormat) {
-          config.datasources[d.id].settings.schemaFormat =
-            d.settings?.schemaFormat;
-        }
-      }
     });
 
     if (metrics.length) config.metrics = {};


### PR DESCRIPTION
### Features and Changes

This PR adds support for the following fields when generating a config.yml document and importing it.

### Metrics
- type
- conditions

### Datasources
- settings.userIdTypes
- settings.queries (exposure & identityJoins)
- settings.notebookRunQuery
- settings.schemaFormat

### Organization Settings
- environments
- attributeSchema
- namespaces
- metricAnalysisDays
- northStar
- updateSchedule
- multipleExposureMinPercent
- videoInstructionsViewed
- sdkInstructionsViewed
- defaultRole
- metricDefaults

<!--
  Indicate which issue this will close, if applicable
  For multiple issues, add a new `- Closes` or `- Fixes` line
-->

- Closes https://github.com/growthbook/growthbook/issues/736

### Testing

- [x] Generate a new config.yml report and ensure that all of the properties above are included and appear in the correct spot/format.
- [x] Import said config.yml to a new organization and ensure that its able to be imported, and adds the correct datasource(s), metrics, dimensions, and org settings.
- [x] Confirm that if a metric has a custom denominator, that is reflected in the metric that was set via the config.yml file.

