### PR TITLE
Docs: Add link to webhooks example

### DIFF
--- a/docs/docs/app/webhooks.mdx
+++ b/docs/docs/app/webhooks.mdx
@@ -5,6 +5,8 @@ sidebar_label: Webhooks
 slug: webhooks
 ---
 
+import ExternalLink from '@site/src/components/ExternalLink'
+
 # Webhooks
 
 Webhooks are one way to keep cached feature definitions up-to-date on your servers.
@@ -109,4 +111,8 @@ If your endpoint returns any HTTP status besides `200`, the webhook will be cons
 
 Failed webhooks are tried a total of 3 times using an exponential back-off between attempts.
 
-You can view the status of your webhooks in the GrowthBook app under **Settings -> Webhooks**.
+You can view the status of your webhooks in the GrowthBook app under **Settings &rarr; Webhooks**.
+
+## Examples
+
+- [Web hooks implementation example <ExternalLink />](https://github.com/growthbook/examples/tree/main/webhooks-impl)


### PR DESCRIPTION
Adds a link to the example implementation of the SDK Endpoint web hooks. That repo is set up for when I do event-based web hooks, I'll also add the example there. Right now there's placeholder code that's commented out.

### Screenshots

<img width="894" alt="image" src="https://user-images.githubusercontent.com/113377031/203436455-3508a280-fe4a-4216-816b-546e35156217.png">
