### PR TITLE
Tools to deal with orphaned users while self-hosting

### DIFF
--- a/packages/back-end/src/models/UserModel.ts
+++ b/packages/back-end/src/models/UserModel.ts
@@ -30,3 +30,17 @@ export async function markUserAsVerified(id: string) {
     }
   );
 }
+
+export async function getAllUsers(): Promise<UserInterface[]> {
+  const users = await UserModel.find();
+  return users.map((u) => u.toJSON());
+}
+
+export async function findUserById(id: string): Promise<UserInterface | null> {
+  const user = await UserModel.findOne({ id });
+  return user ? user.toJSON() : null;
+}
+
+export async function deleteUser(id: string): Promise<void> {
+  await UserModel.deleteOne({ id });
+}

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -2,6 +2,7 @@ import { Response } from "express";
 import { AuthRequest } from "../../types/AuthRequest";
 import {
   acceptInvite,
+  addMemberToOrg,
   getInviteUrl,
   getOrgFromReq,
   importConfig,
@@ -44,6 +45,8 @@ import { WebhookModel } from "../../models/WebhookModel";
 import { createWebhook } from "../../services/webhooks";
 import {
   createOrganization,
+  findAllOrganizations,
+  findOrganizationsByMemberId,
   hasOrganization,
   updateOrganization,
 } from "../../models/OrganizationModel";
@@ -68,6 +71,7 @@ import {
   getAccountPlan,
   getRoles,
 } from "../../util/organization.util";
+import { deleteUser, findUserById, getAllUsers } from "../../models/UserModel";
 
 export async function getDefinitions(req: AuthRequest, res: Response) {
   const { org } = getOrgFromReq(req);
@@ -1070,6 +1074,121 @@ export async function postImportConfig(
   });
 }
 
+export async function getOrphanedUsers(req: AuthRequest, res: Response) {
+  req.checkPermissions("organizationSettings");
+
+  if (IS_CLOUD) {
+    throw new Error("Unable to get orphaned users on GrowthBook Cloud");
+  }
+
+  const allUsers = await getAllUsers();
+  const allOrgs = await findAllOrganizations();
+
+  const membersInOrgs = new Set<string>();
+  allOrgs.forEach((org) => {
+    org.members.forEach((m) => {
+      membersInOrgs.add(m.id);
+    });
+  });
+
+  const orphanedUsers = allUsers
+    .filter((u) => !membersInOrgs.has(u.id))
+    .map(({ id, name, email }) => ({
+      id,
+      name,
+      email,
+    }));
+
+  return res.status(200).json({
+    status: 200,
+    orphanedUsers,
+  });
+}
+
+export async function addOrphanedUser(
+  req: AuthRequest<MemberRoleWithProjects, { id: string }>,
+  res: Response
+) {
+  req.checkPermissions("organizationSettings");
+
+  const { org } = getOrgFromReq(req);
+
+  const { id } = req.params;
+  const {
+    role,
+    environments,
+    limitAccessByEnvironment,
+    projectRoles,
+  } = req.body;
+
+  // Make sure user exists
+  const user = await findUserById(id);
+  if (!user) {
+    return res.status(400).json({
+      status: 400,
+      message: "Cannot find user with that id",
+    });
+  }
+
+  // Make sure user is actually orphaned
+  const orgs = await findOrganizationsByMemberId(id);
+  if (orgs.length) {
+    return res.status(400).json({
+      status: 400,
+      message: "Cannot add users who are already part of an organization",
+    });
+  }
+
+  await addMemberToOrg({
+    organization: org,
+    userId: id,
+    role,
+    environments,
+    limitAccessByEnvironment,
+    projectRoles,
+  });
+
+  return res.status(200).json({
+    status: 200,
+  });
+}
+
+export async function deleteOrphanedUser(
+  req: AuthRequest<unknown, { id: string }>,
+  res: Response
+) {
+  req.checkPermissions("organizationSettings");
+
+  if (IS_CLOUD) {
+    throw new Error("Unable to delete orphaned users on GrowthBook Cloud");
+  }
+
+  const { id } = req.params;
+
+  // Make sure user exists
+  const user = await findUserById(id);
+  if (!user) {
+    return res.status(400).json({
+      status: 400,
+      message: "Cannot find user with that id",
+    });
+  }
+
+  // Make sure user is orphaned
+  const orgs = await findOrganizationsByMemberId(id);
+  if (orgs.length) {
+    return res.status(400).json({
+      status: 400,
+      message: "Cannot delete users who are part of an organization",
+    });
+  }
+
+  await deleteUser(id);
+  return res.status(200).json({
+    status: 200,
+  });
+}
+
 export async function putAdminResetUserPassword(
   req: AuthRequest<
     {
@@ -1087,6 +1206,7 @@ export async function putAdminResetUserPassword(
   const { updatedPassword } = req.body;
   const userToUpdateId = req.params.id;
 
+  // Only enable for self-hosted deployments that are not using SSO
   if (usingOpenId()) {
     throw new Error("This functionality is not available when using SSO");
   }
@@ -1097,10 +1217,14 @@ export async function putAdminResetUserPassword(
   );
 
   // Only update the password if the member we're updating is in the same org as the requester
+  // Exception: allow updating the password if the user is not part of any organization
   if (!isUserToUpdateInSameOrg) {
-    throw new Error(
-      "Cannot change password of users outside your organization."
-    );
+    const orgs = await findOrganizationsByMemberId(userToUpdateId);
+    if (orgs.length > 0) {
+      throw new Error(
+        "Cannot change password of users outside your organization."
+      );
+    }
   }
 
   await updatePassword(userToUpdateId, updatedPassword);

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -1111,6 +1111,10 @@ export async function addOrphanedUser(
 ) {
   req.checkPermissions("organizationSettings");
 
+  if (IS_CLOUD) {
+    throw new Error("This action is not permitted on GrowthBook Cloud");
+  }
+
   const { org } = getOrgFromReq(req);
 
   const { id } = req.params;

--- a/packages/back-end/src/routers/organizations/organizations.router.ts
+++ b/packages/back-end/src/routers/organizations/organizations.router.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import * as organizationsControllerRaw from "./organizations.controller";
 import { wrapController } from "../wrapController";
+import { IS_CLOUD } from "../../util/secrets";
 
 const router = express.Router();
 
@@ -49,5 +50,19 @@ router.get("/webhooks", organizationsController.getWebhooks);
 router.post("/webhooks", organizationsController.postWebhook);
 router.put("/webhook/:id", organizationsController.putWebhook);
 router.delete("/webhook/:id", organizationsController.deleteWebhook);
+
+// Orphaned users (users not part of an organization)
+// Only available when self-hosting
+if (!IS_CLOUD) {
+  router.get("/orphaned-users", organizationsController.getOrphanedUsers);
+  router.post(
+    "/orphaned-users/:id/delete",
+    organizationsController.deleteOrphanedUser
+  );
+  router.post(
+    "/orphaned-users/:id/add",
+    organizationsController.addOrphanedUser
+  );
+}
 
 export { router as organizationsRouter };

--- a/packages/back-end/src/services/organizations.ts
+++ b/packages/back-end/src/services/organizations.ts
@@ -17,6 +17,7 @@ import {
   MemberRoleInfo,
   MemberRoleWithProjects,
   OrganizationInterface,
+  ProjectMemberRole,
 } from "../../types/organization";
 import { createMetric, getExperimentsByOrganization } from "./experiments";
 import { ExperimentOverride } from "../../types/api";
@@ -221,12 +222,14 @@ export async function addMemberToOrg({
   role,
   environments,
   limitAccessByEnvironment,
+  projectRoles,
 }: {
   organization: OrganizationInterface;
   userId: string;
   role: MemberRole;
   limitAccessByEnvironment: boolean;
   environments: string[];
+  projectRoles?: ProjectMemberRole[];
 }) {
   // If member is already in the org, skip
   if (organization.members.find((m) => m.id === userId)) {
@@ -240,6 +243,7 @@ export async function addMemberToOrg({
       role,
       limitAccessByEnvironment,
       environments,
+      projectRoles,
       dateCreated: new Date(),
     },
   ];

--- a/packages/front-end/components/Settings/Team/AddOrphanedUserModal.tsx
+++ b/packages/front-end/components/Settings/Team/AddOrphanedUserModal.tsx
@@ -1,0 +1,72 @@
+import { FC, useState } from "react";
+import { useAuth } from "../../../services/auth";
+import Modal from "../../Modal";
+import RoleSelector from "./RoleSelector";
+import { MemberRoleWithProjects } from "back-end/types/organization";
+import UpgradeModal from "../UpgradeModal";
+import useOrgSettings from "../../../hooks/useOrgSettings";
+
+const AddOrphanedUserModal: FC<{
+  mutate: () => void;
+  close: () => void;
+  name: string;
+  email: string;
+  id: string;
+}> = ({ mutate, close, name, email, id }) => {
+  const { defaultRole } = useOrgSettings();
+
+  const [showUpgradeModal, setShowUpgradeModal] = useState(false);
+
+  const [value, setValue] = useState<MemberRoleWithProjects>({
+    role: "admin",
+    limitAccessByEnvironment: false,
+    environments: [],
+    projectRoles: [],
+    ...defaultRole,
+  });
+
+  const { apiCall } = useAuth();
+
+  if (showUpgradeModal) {
+    return (
+      <UpgradeModal
+        close={close}
+        source="add orphaned user"
+        reason={"To enable advanced permissioning,"}
+      />
+    );
+  }
+
+  return (
+    <Modal
+      close={close}
+      header="Add User"
+      open={true}
+      cta="Add"
+      closeCta={"Cancel"}
+      submit={async () => {
+        await apiCall<{
+          emailSent: boolean;
+          inviteUrl: string;
+          status: number;
+          message?: string;
+        }>(`/orphaned-users/${id}/add`, {
+          method: "POST",
+          body: JSON.stringify(value),
+        });
+        mutate();
+      }}
+    >
+      <div className="mb-3">
+        <strong>{name}</strong> ({email})
+      </div>
+      <RoleSelector
+        value={value}
+        setValue={setValue}
+        showUpgradeModal={() => setShowUpgradeModal(true)}
+      />
+    </Modal>
+  );
+};
+
+export default AddOrphanedUserModal;

--- a/packages/front-end/components/Settings/Team/MemberList.tsx
+++ b/packages/front-end/components/Settings/Team/MemberList.tsx
@@ -128,7 +128,7 @@ const MemberList: FC<{
                         )}
                         <DeleteButton
                           link={true}
-                          text="Delete User"
+                          text="Remove User"
                           useIcon={false}
                           className="dropdown-item"
                           displayName={member.email}

--- a/packages/front-end/components/Settings/Team/OrphanedUsersList.tsx
+++ b/packages/front-end/components/Settings/Team/OrphanedUsersList.tsx
@@ -1,0 +1,105 @@
+import React, { FC, useEffect, useState } from "react";
+import DeleteButton from "../../DeleteButton/DeleteButton";
+import MoreMenu from "../../Dropdown/MoreMenu";
+import useApi from "../../../hooks/useApi";
+import LoadingOverlay from "../../LoadingOverlay";
+import { useAuth } from "../../../services/auth";
+import AddOrphanedUserModal from "./AddOrphanedUserModal";
+import { isCloud } from "../../../services/env";
+
+const OrphanedUsersList: FC<{
+  mutateUsers: () => void;
+  numUsersInAccount: number;
+}> = ({ mutateUsers, numUsersInAccount }) => {
+  const { apiCall } = useAuth();
+  const [addModal, setAddModal] = useState<string>("");
+
+  const { data, mutate, error } = useApi<{
+    orphanedUsers: { email: string; name: string; id: string }[];
+  }>(`/orphaned-users`);
+
+  // Update the list of orphaned users if the number of org members changes
+  useEffect(() => {
+    mutate();
+  }, [numUsersInAccount, mutate]);
+
+  // Only available when self-hosting since Cloud is a multi-tenant environment
+  if (isCloud()) return null;
+
+  if (error) {
+    return <div className="alert alert-danger">{error.message}</div>;
+  }
+
+  if (!data) {
+    return <LoadingOverlay />;
+  }
+
+  const users = data.orphanedUsers;
+
+  if (!users.length) return null;
+
+  const addModalData = addModal && users.find((u) => u.id === addModal);
+
+  return (
+    <div className="my-4">
+      {addModalData && (
+        <AddOrphanedUserModal
+          close={() => setAddModal("")}
+          mutate={() => {
+            mutate();
+            mutateUsers();
+          }}
+          {...addModalData}
+        />
+      )}
+      <h5>Removed Members{` (${users.length})`}</h5>
+      <table className="table appbox gbtable">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Email</th>
+            <th />
+          </tr>
+        </thead>
+        <tbody>
+          {Array.from(users).map(({ id, email, name }) => {
+            return (
+              <tr key={id}>
+                <td>{name}</td>
+                <td>{email}</td>
+                <td style={{ width: 30 }}>
+                  <MoreMenu id={`orphaned-user-actions-${id}`}>
+                    <button
+                      className="dropdown-item"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        setAddModal(id);
+                      }}
+                    >
+                      Add back to account
+                    </button>
+                    <DeleteButton
+                      link={true}
+                      text="Permanently delete"
+                      useIcon={false}
+                      className="dropdown-item"
+                      displayName={email}
+                      onClick={async () => {
+                        await apiCall(`/orphaned-users/${id}/delete`, {
+                          method: "POST",
+                        });
+                        mutate();
+                      }}
+                    />
+                  </MoreMenu>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default OrphanedUsersList;

--- a/packages/front-end/pages/settings/team.tsx
+++ b/packages/front-end/pages/settings/team.tsx
@@ -10,6 +10,7 @@ import { useUser } from "../../services/UserContext";
 import usePermissions from "../../hooks/usePermissions";
 import { useDefinitions } from "../../services/DefinitionsContext";
 import SelectField from "../../components/Forms/SelectField";
+import OrphanedUsersList from "../../components/Settings/Team/OrphanedUsersList";
 
 const TeamPage: FC = () => {
   const { refreshOrganization, enterpriseSSO, organization } = useUser();
@@ -104,6 +105,11 @@ const TeamPage: FC = () => {
       ) : (
         ""
       )}
+
+      <OrphanedUsersList
+        mutateUsers={refreshOrganization}
+        numUsersInAccount={organization.members?.length || 0}
+      />
     </div>
   );
 };


### PR DESCRIPTION
### Features and Changes

When self-hosting, users who are removed from your organization still exist in the database.

This PR lets you see these orphaned users and decide what to do with them
-  permanently delete
-  re-add to the organization

Fixes #665

List on Team settings page:

![image](https://user-images.githubusercontent.com/1087514/205994661-0fb63e73-5d9d-4b8b-bc46-93d7fb4d3171.png)

When adding a user back to your account:

![image](https://user-images.githubusercontent.com/1087514/205994535-cb3eaa9f-ee68-43d4-aefc-dffe784d92e0.png)