### PR TITLE
Experiments - Show hint to users converting UTC to local timezone

### DIFF
--- a/packages/front-end/components/Experiment/AnalysisForm.tsx
+++ b/packages/front-end/components/Experiment/AnalysisForm.tsx
@@ -210,6 +210,7 @@ const AnalysisForm: FC<{
               labelClassName="font-weight-bold"
               type="datetime-local"
               {...form.register("dateStarted")}
+              // TODO How to include UTC hint
               helpText="Only include users who entered the experiment on or after this date"
             />
           </div>
@@ -220,6 +221,7 @@ const AnalysisForm: FC<{
                 labelClassName="font-weight-bold"
                 type="datetime-local"
                 {...form.register("dateEnded")}
+                // TODO How to include UTC hint
                 helpText="Only include users who entered the experiment on or before this date"
               />
             </div>

--- a/packages/front-end/components/Experiment/EditPhaseModal.tsx
+++ b/packages/front-end/components/Experiment/EditPhaseModal.tsx
@@ -6,6 +6,7 @@ import {
 import Field from "../Forms/Field";
 import Modal from "../Modal";
 import { useAuth } from "../../services/auth";
+import { renderDateTimeInLocalTimeZone } from "../../services/dates";
 import VariationsInput from "../Features/VariationsInput";
 
 export interface Props {
@@ -59,11 +60,13 @@ export default function EditPhaseModal({
         label="Start Time (UTC)"
         type="datetime-local"
         {...form.register("dateStarted")}
+        helpText={renderDateTimeInLocalTimeZone(form.watch("dateStarted"))}
       />
       <Field
         label="End Time (UTC)"
         type="datetime-local"
         {...form.register("dateEnded")}
+        // TODO How to include UTC hint
         helpText={
           <>
             Leave blank if still running.{" "}

--- a/packages/front-end/components/Experiment/EditStatusModal.tsx
+++ b/packages/front-end/components/Experiment/EditStatusModal.tsx
@@ -2,6 +2,7 @@ import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
 import { useForm } from "react-hook-form";
 import Modal from "../Modal";
 import { useAuth } from "../../services/auth";
+import { renderDateTimeInLocalTimeZone } from "../../services/dates";
 import Field from "../Forms/Field";
 
 export interface Props {
@@ -50,6 +51,7 @@ export default function EditStatusModal({ experiment, close, mutate }: Props) {
             label="Stop Time (UTC)"
             type="datetime-local"
             {...form.register("dateEnded")}
+            helpText={renderDateTimeInLocalTimeZone(form.watch("dateEnded"))}
           />
         </>
       )}

--- a/packages/front-end/components/Experiment/NewExperimentForm.tsx
+++ b/packages/front-end/components/Experiment/NewExperimentForm.tsx
@@ -1,4 +1,5 @@
 import { FC, useEffect, useState } from "react";
+import { toDate, utcToZonedTime } from "date-fns-tz";
 import { useAuth } from "../../services/auth";
 import { useForm } from "react-hook-form";
 import PagedModal from "../Modal/PagedModal";
@@ -15,7 +16,7 @@ import { useRouter } from "next/router";
 import track from "../../services/track";
 import { useDefinitions } from "../../services/DefinitionsContext";
 import Field from "../Forms/Field";
-import { getValidDate } from "../../services/dates";
+import { datetime, getValidDate } from "../../services/dates";
 import SelectField from "../Forms/SelectField";
 import { getExposureQuery } from "../../services/datasources";
 import VariationsInput from "../Features/VariationsInput";
@@ -65,6 +66,14 @@ function getDefaultVariations(num: number) {
   }
   return variations;
 }
+
+const renderDateTimeInLocalTimeZone = (
+  date: string,
+  timezone = Intl.DateTimeFormat().resolvedOptions().timeZone
+): string =>
+  `${datetime(date)} UTC is ${datetime(
+    utcToZonedTime(toDate(date, { timeZone: "Universal" }), timezone)
+  )} in ${timezone.replace("_", " ")}`;
 
 const NewExperimentForm: FC<NewExperimentFormProps> = ({
   initialStep = 0,
@@ -329,6 +338,9 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
             label="Start Date (UTC)"
             type="datetime-local"
             {...form.register("phases.0.dateStarted")}
+            helpText={renderDateTimeInLocalTimeZone(
+              form.watch("phases.0.dateStarted")
+            )}
           />
         )}
         {status === "stopped" && (
@@ -336,6 +348,9 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
             label="End Date (UTC)"
             type="datetime-local"
             {...form.register("phases.0.dateEnded")}
+            helpText={renderDateTimeInLocalTimeZone(
+              form.watch("phases.0.dateEnded")
+            )}
           />
         )}
       </Page>

--- a/packages/front-end/components/Experiment/NewExperimentForm.tsx
+++ b/packages/front-end/components/Experiment/NewExperimentForm.tsx
@@ -1,5 +1,4 @@
 import { FC, useEffect, useState } from "react";
-import { toDate, utcToZonedTime } from "date-fns-tz";
 import { useAuth } from "../../services/auth";
 import { useForm } from "react-hook-form";
 import PagedModal from "../Modal/PagedModal";
@@ -16,7 +15,10 @@ import { useRouter } from "next/router";
 import track from "../../services/track";
 import { useDefinitions } from "../../services/DefinitionsContext";
 import Field from "../Forms/Field";
-import { datetime, getValidDate } from "../../services/dates";
+import {
+  getValidDate,
+  renderDateTimeInLocalTimeZone,
+} from "../../services/dates";
 import SelectField from "../Forms/SelectField";
 import { getExposureQuery } from "../../services/datasources";
 import VariationsInput from "../Features/VariationsInput";
@@ -66,14 +68,6 @@ function getDefaultVariations(num: number) {
   }
   return variations;
 }
-
-const renderDateTimeInLocalTimeZone = (
-  date: string,
-  timezone = Intl.DateTimeFormat().resolvedOptions().timeZone
-): string =>
-  `${datetime(date)} UTC is ${datetime(
-    utcToZonedTime(toDate(date, { timeZone: "Universal" }), timezone)
-  )} in ${timezone.replace("_", " ")}`;
 
 const NewExperimentForm: FC<NewExperimentFormProps> = ({
   initialStep = 0,

--- a/packages/front-end/components/Experiment/NewPhaseForm.tsx
+++ b/packages/front-end/components/Experiment/NewPhaseForm.tsx
@@ -8,6 +8,7 @@ import Modal from "../Modal";
 import { useAuth } from "../../services/auth";
 import { useWatching } from "../../services/WatchProvider";
 import { getEvenSplit } from "../../services/utils";
+import { renderDateTimeInLocalTimeZone } from "../../services/dates";
 import GroupsInput from "../GroupsInput";
 import { useDefinitions } from "../../services/DefinitionsContext";
 import Field from "../Forms/Field";
@@ -98,6 +99,7 @@ const NewPhaseForm: FC<{
           label="Start Time (UTC)"
           type="datetime-local"
           {...form.register("dateStarted")}
+          helpText={renderDateTimeInLocalTimeZone(form.watch("dateStarted"))}
         />
       </div>
       <div className="row">

--- a/packages/front-end/components/Experiment/StopExperimentForm.tsx
+++ b/packages/front-end/components/Experiment/StopExperimentForm.tsx
@@ -3,6 +3,7 @@ import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
 import { useForm } from "react-hook-form";
 import Modal from "../Modal";
 import { useAuth } from "../../services/auth";
+import { renderDateTimeInLocalTimeZone } from "../../services/dates";
 import MarkdownInput from "../Markdown/MarkdownInput";
 import track from "../../services/track";
 import Field from "../Forms/Field";
@@ -84,6 +85,7 @@ const StopExperimentForm: FC<{
             label="Stop Time (UTC)"
             type="datetime-local"
             {...form.register("dateEnded")}
+            helpText={renderDateTimeInLocalTimeZone(form.watch("dateEnded"))}
           />
         </>
       )}

--- a/packages/front-end/components/Report/ConfigureReport.tsx
+++ b/packages/front-end/components/Report/ConfigureReport.tsx
@@ -164,6 +164,7 @@ export default function ConfigureReport({
             labelClassName="font-weight-bold"
             type="datetime-local"
             {...form.register("startDate")}
+            // TODO How to include UTC hint
             helpText="Only include users who entered the experiment on or after this date"
           />
         </div>
@@ -173,6 +174,7 @@ export default function ConfigureReport({
             labelClassName="font-weight-bold"
             type="datetime-local"
             {...form.register("endDate")}
+            // TODO How to include UTC hint
             helpText="Only include users who entered the experiment on or before this date"
           />
         </div>

--- a/packages/front-end/package.json
+++ b/packages/front-end/package.json
@@ -35,6 +35,7 @@
     "clsx": "^1.1.1",
     "cronstrue": "^1.122.0",
     "date-fns": "^2.15.0",
+    "date-fns-tz": "^1.3.7",
     "diff": "^5.0.0",
     "diff2html": "^3.4.11",
     "dirty-json": "^0.9.2",

--- a/packages/front-end/services/dates.ts
+++ b/packages/front-end/services/dates.ts
@@ -2,6 +2,7 @@ import format from "date-fns/format";
 import formatDistance from "date-fns/formatDistance";
 import differenceInDays from "date-fns/differenceInDays";
 import { addMonths } from "date-fns";
+import { toDate, utcToZonedTime } from "date-fns-tz";
 
 export function date(date: string | Date): string {
   if (!date) return "";
@@ -26,6 +27,14 @@ export function monthYear(date: string | Date): string {
 }
 export function daysBetween(start: string | Date, end: string | Date): number {
   return differenceInDays(getValidDate(end), getValidDate(start));
+}
+export function renderDateTimeInLocalTimeZone(
+  date: string,
+  timezone = Intl.DateTimeFormat().resolvedOptions().timeZone
+) {
+  return `${datetime(date)} UTC is ${datetime(
+    utcToZonedTime(toDate(date, { timeZone: "Universal" }), timezone)
+  )} in ${timezone.replace("_", " ")}`;
 }
 
 export function getValidDate(

--- a/yarn.lock
+++ b/yarn.lock
@@ -8264,6 +8264,11 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
+date-fns-tz@^1.3.7:
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/date-fns-tz/-/date-fns-tz-1.3.7.tgz#e8e9d2aaceba5f1cc0e677631563081fdcb0e69a"
+  integrity sha512-1t1b8zyJo+UI8aR+g3iqr5fkUHWpd58VBx8J/ZSQ+w7YrGlw80Ag4sA86qkfCXRBLmMc4I2US+aPMd4uKvwj5g==
+
 date-fns@^2.15.0, date-fns@^2.29.1:
   version "2.29.3"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.3.tgz#27402d2fc67eb442b511b70bbdf98e6411cd68a8"
@@ -18778,8 +18783,10 @@ watchpack@^1.7.4:
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.5.tgz#1267e6c55e0b9b5be44c2023aed5437a2c26c453"
   integrity sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==
   dependencies:
+    chokidar "^3.4.1"
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
+    watchpack-chokidar2 "^2.0.1"
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"


### PR DESCRIPTION
Fixes #733 

This will naively convert UTC time to the web browser's local timezone. In the case that it's not a relevant timezone, it will at least give the user some idea relative to the timezone they wish to see

Changes:
- Adds `date-fns-tz` package to frontend in order to do timezone conversion between UTC and local

Screenshots:

<img width="826" alt="Screen Shot 2022-12-06 at 4 14 05 PM" src="https://user-images.githubusercontent.com/2374625/206024716-7017e547-1742-4a31-9a62-9b03cd8572f3.png">


<img width="834" alt="Screen Shot 2022-12-06 at 4 15 24 PM" src="https://user-images.githubusercontent.com/2374625/206024712-3de9d932-40d3-46e0-b744-329fc3b1c428.png">

