### PR TITLE
Add link to Ruby on Rails example

### DIFF
--- a/docs/docs/lib/ruby.mdx
+++ b/docs/docs/lib/ruby.mdx
@@ -5,6 +5,8 @@ sidebar_label: Ruby
 slug: ruby
 ---
 
+import ExternalLink from '@site/src/components/ExternalLink'
+
 # Ruby
 
 View the full source code at [https://github.com/growthbook/growthbook-ruby](https://github.com/growthbook/growthbook-ruby).
@@ -148,3 +150,7 @@ gb.run(Growthbook::InlineExperiment.new(
   namespace: ["pricing-page", 0, 0.25]
 ))
 ```
+
+## Code Examples
+
+- [Ruby on Rails example <ExternalLink />](https://github.com/growthbook/examples/tree/main/acme_donuts_rails)


### PR DESCRIPTION
Adds a link to the Ruby on Rails example.

<img width="1303" alt="image" src="https://user-images.githubusercontent.com/113377031/206067647-8598b788-762c-42b0-a231-51ee10524087.png">

<img width="1303" alt="image" src="https://user-images.githubusercontent.com/113377031/206067663-d9fa0bda-b629-4334-84de-386cf257b663.png">
