### PR TITLE
Tag metrics and datasources to projects

### DIFF
--- a/packages/back-end/src/models/DataSourceModel.ts
+++ b/packages/back-end/src/models/DataSourceModel.ts
@@ -67,6 +67,21 @@ export async function getDataSourceById(id: string, organization: string) {
 
   return doc ? toInterface(doc) : null;
 }
+export async function getDataSourcesByIds(ids: string[], organization: string) {
+  // If using config.yml, immediately return the list from there
+  if (usingFileConfig()) {
+    return (
+      getConfigDatasources(organization).filter((d) => ids.includes(d.id)) || []
+    );
+  }
+
+  return (
+    await DataSourceModel.find({
+      id: { $in: ids },
+      organization,
+    })
+  ).map(toInterface);
+}
 
 export async function getOrganizationsWithDatasources(): Promise<string[]> {
   if (usingFileConfig()) {

--- a/packages/back-end/src/models/MetricModel.ts
+++ b/packages/back-end/src/models/MetricModel.ts
@@ -182,6 +182,21 @@ export async function getMetricById(
   return res ? toInterface(res) : null;
 }
 
+export async function getMetricsByIds(ids: string[], organization: string) {
+  // If using config.yml, immediately return the list from there
+  if (usingFileConfig()) {
+    return getConfigMetrics(organization).filter(
+      (m) => ids.includes(m.datasource) || []
+    );
+  }
+
+  const docs = await MetricModel.find({
+    id: { $in: ids },
+    organization,
+  });
+  return docs.map(toInterface);
+}
+
 export async function getMetricsUsingSegment(
   segment: string,
   organization: string

--- a/packages/back-end/src/models/ProjectModel.ts
+++ b/packages/back-end/src/models/ProjectModel.ts
@@ -14,6 +14,8 @@ const projectSchema = new mongoose.Schema({
   name: String,
   dateCreated: Date,
   dateUpdated: Date,
+  datasources: [String],
+  metrics: [String],
 });
 
 type ProjectDocument = mongoose.Document & ProjectInterface;

--- a/packages/back-end/src/routers/project/project.controller.ts
+++ b/packages/back-end/src/routers/project/project.controller.ts
@@ -37,30 +37,28 @@ export const postProject = async (
 ) => {
   req.checkPermissions("manageProjects");
 
-  const { name, datasources, metrics } = req.body;
+  const datasources: string[] = req.body.datasources || [];
+  const metrics: string[] = req.body.metrics || [];
+  const { name } = req.body;
   const { org } = getOrgFromReq(req);
 
-  if (datasources?.length) {
-    for (let i = 0; i < datasources.length; i++) {
-      const datasource = await getDataSourceById(datasources[i], org.id);
-      if (!datasource) {
-        res.status(403).json({
-          message: "Invalid datasource: " + datasources[i],
-        });
-        return;
-      }
+  for (let i = 0; i < datasources.length; i++) {
+    const datasource = await getDataSourceById(datasources[i], org.id);
+    if (!datasource) {
+      res.status(403).json({
+        message: "Invalid datasource: " + datasources[i],
+      });
+      return;
     }
   }
 
-  if (metrics?.length) {
-    for (let i = 0; i < metrics.length; i++) {
-      const metric = await getMetricById(metrics[i], org.id);
-      if (!metric) {
-        res.status(403).json({
-          message: "Invalid metric: " + metrics[i],
-        });
-        return;
-      }
+  for (let i = 0; i < metrics.length; i++) {
+    const metric = await getMetricById(metrics[i], org.id);
+    if (!metric) {
+      res.status(403).json({
+        message: "Invalid metric: " + metrics[i],
+      });
+      return;
     }
   }
 
@@ -117,29 +115,27 @@ export const putProject = async (
     return;
   }
 
-  const { name, datasources, metrics } = req.body;
+  const datasources: string[] = req.body.datasources || [];
+  const metrics: string[] = req.body.metrics || [];
+  const { name } = req.body;
 
-  if (datasources?.length) {
-    for (let i = 0; i < datasources.length; i++) {
-      const datasource = await getDataSourceById(datasources[i], org.id);
-      if (!datasource) {
-        res.status(403).json({
-          message: "Invalid datasource: " + datasources[i],
-        });
-        return;
-      }
+  for (let i = 0; i < datasources.length; i++) {
+    const datasource = await getDataSourceById(datasources[i], org.id);
+    if (!datasource) {
+      res.status(403).json({
+        message: "Invalid datasource: " + datasources[i],
+      });
+      return;
     }
   }
 
-  if (metrics?.length) {
-    for (let i = 0; i < metrics.length; i++) {
-      const metric = await getMetricById(metrics[i], org.id);
-      if (!metric) {
-        res.status(403).json({
-          message: "Invalid metric: " + metrics[i],
-        });
-        return;
-      }
+  for (let i = 0; i < metrics.length; i++) {
+    const metric = await getMetricById(metrics[i], org.id);
+    if (!metric) {
+      res.status(403).json({
+        message: "Invalid metric: " + metrics[i],
+      });
+      return;
     }
   }
 

--- a/packages/back-end/src/routers/project/project.controller.ts
+++ b/packages/back-end/src/routers/project/project.controller.ts
@@ -9,8 +9,8 @@ import {
   findProjectById,
   updateProject,
 } from "../../models/ProjectModel";
-import { getDataSourceById } from "../../models/DataSourceModel";
-import { getMetricById } from "../../models/MetricModel";
+import { getDataSourcesByIds } from "../../models/DataSourceModel";
+import { getMetricsByIds } from "../../models/MetricModel";
 
 // region POST /projects
 
@@ -42,8 +42,9 @@ export const postProject = async (
   const { name } = req.body;
   const { org } = getOrgFromReq(req);
 
+  const datasourceDocs = await getDataSourcesByIds(datasources, org.id);
   for (let i = 0; i < datasources.length; i++) {
-    const datasource = await getDataSourceById(datasources[i], org.id);
+    const datasource = datasourceDocs.find((dsd) => dsd.id === datasources[i]);
     if (!datasource) {
       res.status(403).json({
         message: "Invalid datasource: " + datasources[i],
@@ -52,8 +53,9 @@ export const postProject = async (
     }
   }
 
+  const metricDocs = await getMetricsByIds(metrics, org.id);
   for (let i = 0; i < metrics.length; i++) {
-    const metric = await getMetricById(metrics[i], org.id);
+    const metric = metricDocs.find((md) => md.id === metrics[i]);
     if (!metric) {
       res.status(403).json({
         message: "Invalid metric: " + metrics[i],
@@ -119,8 +121,9 @@ export const putProject = async (
   const metrics: string[] = req.body.metrics || [];
   const { name } = req.body;
 
+  const datasourceDocs = await getDataSourcesByIds(datasources, org.id);
   for (let i = 0; i < datasources.length; i++) {
-    const datasource = await getDataSourceById(datasources[i], org.id);
+    const datasource = datasourceDocs.find((dsd) => dsd.id === datasources[i]);
     if (!datasource) {
       res.status(403).json({
         message: "Invalid datasource: " + datasources[i],
@@ -129,8 +132,9 @@ export const putProject = async (
     }
   }
 
+  const metricDocs = await getMetricsByIds(metrics, org.id);
   for (let i = 0; i < metrics.length; i++) {
-    const metric = await getMetricById(metrics[i], org.id);
+    const metric = metricDocs.find((md) => md.id === metrics[i]);
     if (!metric) {
       res.status(403).json({
         message: "Invalid metric: " + metrics[i],

--- a/packages/back-end/src/routers/project/project.router.ts
+++ b/packages/back-end/src/routers/project/project.router.ts
@@ -14,6 +14,8 @@ router.post(
     body: z
       .object({
         name: z.string(),
+        datasources: z.optional(z.array(z.string())),
+        metrics: z.optional(z.array(z.string())),
       })
       .strict(),
   }),
@@ -31,6 +33,8 @@ router.put(
     body: z
       .object({
         name: z.string(),
+        datasources: z.optional(z.array(z.string())),
+        metrics: z.optional(z.array(z.string())),
       })
       .strict(),
   }),

--- a/packages/back-end/types/project.d.ts
+++ b/packages/back-end/types/project.d.ts
@@ -4,4 +4,6 @@ export interface ProjectInterface {
   name: string;
   dateCreated: Date;
   dateUpdated: Date;
+  datasources?: string[];
+  metrics?: string[];
 }

--- a/packages/front-end/components/Auth/InitialOrgSettings.tsx
+++ b/packages/front-end/components/Auth/InitialOrgSettings.tsx
@@ -68,7 +68,7 @@ export default function InitialOrgSettings(): ReactElement {
       method: "PUT",
       body: JSON.stringify({
         types: value.types,
-        dataSouce: datas,
+        dataSource: datas,
         techStack: techs,
       }),
     });

--- a/packages/front-end/components/Dimensions/DimensionForm.tsx
+++ b/packages/front-end/components/Dimensions/DimensionForm.tsx
@@ -20,12 +20,23 @@ const DimensionForm: FC<{
     getDatasourceById,
     datasources,
     mutateDefinitions,
+    project,
+    getProjectById,
   } = useDefinitions();
+  const projectDefinition = getProjectById(project);
+  let filteredDatasources = datasources;
+  if (projectDefinition?.datasources?.length) {
+    const projectDatasources = projectDefinition.datasources;
+    filteredDatasources = datasources.filter((ds) =>
+      projectDatasources.includes(ds.id)
+    );
+  }
   const form = useForm({
     defaultValues: {
       name: current.name || "",
       sql: current.sql || "",
-      datasource: (current.id ? current.datasource : datasources[0]?.id) || "",
+      datasource:
+        (current.id ? current.datasource : filteredDatasources[0]?.id) || "",
       userIdType: current.userIdType || "user_id",
       owner: current.owner || "",
     },
@@ -42,7 +53,7 @@ const DimensionForm: FC<{
     <Modal
       close={close}
       open={true}
-      header={current ? "Edit Dimension" : "New Dimension"}
+      header={current.id ? "Edit Dimension" : "New Dimension"}
       submit={form.handleSubmit(async (value) => {
         if (sql) {
           validateSQL(value.sql, [value.userIdType, "value"]);
@@ -71,7 +82,7 @@ const DimensionForm: FC<{
         value={form.watch("datasource")}
         onChange={(v) => form.setValue("datasource", v)}
         placeholder="Choose one..."
-        options={datasources.map((d) => ({
+        options={filteredDatasources.map((d) => ({
           value: d.id,
           label: d.name,
         }))}

--- a/packages/front-end/components/Experiment/EditMetricsForm.tsx
+++ b/packages/front-end/components/Experiment/EditMetricsForm.tsx
@@ -31,11 +31,23 @@ const EditMetricsForm: FC<{
   const { hasCommercialFeature } = useUser();
   const hasOverrideMetricsFeature = hasCommercialFeature("override-metrics");
 
-  const { metrics: metricDefinitions, getDatasourceById } = useDefinitions();
+  const {
+    metrics: metricDefinitions,
+    getDatasourceById,
+    getProjectById,
+  } = useDefinitions();
   const datasource = getDatasourceById(experiment.datasource);
-  const filteredMetrics = metricDefinitions.filter(
+  const project = getProjectById(experiment.project || "");
+  let filteredMetrics = metricDefinitions.filter(
     (m) => m.datasource === datasource?.id
   );
+  if (project) {
+    if (project?.metrics?.length) {
+      filteredMetrics = filteredMetrics.filter((m) =>
+        project.metrics.includes(m.id)
+      );
+    }
+  }
   const form = useForm<EditMetricsFormInterface>({
     defaultValues: {
       metrics: experiment.metrics || [],
@@ -80,6 +92,7 @@ const EditMetricsForm: FC<{
             onChange={(metrics) => form.setValue("metrics", metrics)}
             datasource={experiment.datasource}
             autoFocus={true}
+            project={project}
           />
         </div>
 
@@ -93,6 +106,7 @@ const EditMetricsForm: FC<{
             selected={form.watch("guardrails")}
             onChange={(metrics) => form.setValue("guardrails", metrics)}
             datasource={experiment.datasource}
+            project={project}
           />
         </div>
 

--- a/packages/front-end/components/Experiment/EditMetricsForm.tsx
+++ b/packages/front-end/components/Experiment/EditMetricsForm.tsx
@@ -41,12 +41,10 @@ const EditMetricsForm: FC<{
   let filteredMetrics = metricDefinitions.filter(
     (m) => m.datasource === datasource?.id
   );
-  if (project) {
-    if (project?.metrics?.length) {
-      filteredMetrics = filteredMetrics.filter((m) =>
-        project.metrics.includes(m.id)
-      );
-    }
+  if (project?.metrics?.length) {
+    filteredMetrics = filteredMetrics.filter((m) =>
+      project.metrics.includes(m.id)
+    );
   }
   const form = useForm<EditMetricsFormInterface>({
     defaultValues: {

--- a/packages/front-end/components/Experiment/MetricsSelector.tsx
+++ b/packages/front-end/components/Experiment/MetricsSelector.tsx
@@ -3,18 +3,25 @@ import { useDefinitions } from "../../services/DefinitionsContext";
 import { FaQuestionCircle } from "react-icons/fa";
 import Tooltip from "../Tooltip/Tooltip";
 import MultiSelectField from "../Forms/MultiSelectField";
+import { ProjectInterface } from "back-end/types/project";
 
 const MetricsSelector: FC<{
   datasource?: string;
   selected: string[];
   onChange: (metrics: string[]) => void;
   autoFocus?: boolean;
-}> = ({ datasource, selected, onChange, autoFocus }) => {
+  project?: ProjectInterface;
+}> = ({ datasource, selected, onChange, autoFocus, project }) => {
   const { metrics } = useDefinitions();
 
-  const validMetrics = metrics.filter(
+  let validMetrics = metrics.filter(
     (m) => !datasource || m.datasource === datasource
   );
+  if (project) {
+    if (project?.metrics?.length) {
+      validMetrics = validMetrics.filter((m) => project.metrics.includes(m.id));
+    }
+  }
 
   const tagCounts: Record<string, number> = {};
   validMetrics.forEach((m) => {

--- a/packages/front-end/components/Experiment/MetricsSelector.tsx
+++ b/packages/front-end/components/Experiment/MetricsSelector.tsx
@@ -17,10 +17,8 @@ const MetricsSelector: FC<{
   let validMetrics = metrics.filter(
     (m) => !datasource || m.datasource === datasource
   );
-  if (project) {
-    if (project?.metrics?.length) {
-      validMetrics = validMetrics.filter((m) => project.metrics.includes(m.id));
-    }
+  if (project?.metrics?.length) {
+    validMetrics = validMetrics.filter((m) => project.metrics.includes(m.id));
   }
 
   const tagCounts: Record<string, number> = {};

--- a/packages/front-end/components/Experiment/NewExperimentForm.tsx
+++ b/packages/front-end/components/Experiment/NewExperimentForm.tsx
@@ -90,8 +90,17 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
     getDatasourceById,
     refreshTags,
     project,
+    getProjectById,
   } = useDefinitions();
   const { refreshWatching } = useWatching();
+  const projectDefinition = getProjectById(project);
+  let filteredDatasources = datasources;
+  if (projectDefinition?.datasources?.length) {
+    const projectDatasources = projectDefinition.datasources;
+    filteredDatasources = datasources.filter((ds) =>
+      projectDatasources.includes(ds.id)
+    );
+  }
 
   useEffect(() => {
     track("New Experiment Form", {
@@ -104,7 +113,8 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
       project: initialValue?.project || project || "",
       implementation: initialValue?.implementation || "code",
       trackingKey: initialValue?.trackingKey || "",
-      datasource: initialValue?.datasource || datasources?.[0]?.id || "",
+      datasource:
+        initialValue?.datasource || filteredDatasources?.[0]?.id || "",
       exposureQueryId:
         getExposureQuery(
           getDatasourceById(initialValue?.datasource)?.settings,
@@ -298,7 +308,7 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
             value={form.watch("datasource")}
             onChange={(v) => form.setValue("datasource", v)}
             initialOption="Manual"
-            options={datasources.map((d) => ({
+            options={filteredDatasources.map((d) => ({
               value: d.id,
               label: d.name,
             }))}
@@ -400,6 +410,7 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
               selected={form.watch("metrics")}
               onChange={(metrics) => form.setValue("metrics", metrics)}
               datasource={datasource?.id}
+              project={projectDefinition}
             />
           </div>
           <div className="form-group">
@@ -412,6 +423,7 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
               selected={form.watch("guardrails")}
               onChange={(metrics) => form.setValue("guardrails", metrics)}
               datasource={datasource?.id}
+              project={projectDefinition}
             />
           </div>
           {!isImport && implementation === "visual" && (

--- a/packages/front-end/components/Metrics/MetricForm.tsx
+++ b/packages/front-end/components/Metrics/MetricForm.tsx
@@ -131,10 +131,24 @@ const MetricForm: FC<MetricFormProps> = ({
   onSuccess,
   secondaryCTA,
 }) => {
-  const { datasources, getDatasourceById, metrics } = useDefinitions();
+  const {
+    datasources,
+    getDatasourceById,
+    metrics,
+    project,
+    getProjectById,
+  } = useDefinitions();
   const [step, setStep] = useState(initialStep);
   const [showAdvanced, setShowAdvanced] = useState(advanced);
   const [hideTags, setHideTags] = useState(true);
+  const projectDefinition = getProjectById(project);
+  let filteredDatasources = datasources;
+  if (projectDefinition?.datasources?.length) {
+    const projectDatasources = projectDefinition.datasources;
+    filteredDatasources = datasources.filter((ds) =>
+      projectDatasources.includes(ds.id)
+    );
+  }
 
   const {
     getMinSampleSizeForMetric,
@@ -179,8 +193,9 @@ const MetricForm: FC<MetricFormProps> = ({
   const form = useForm({
     defaultValues: {
       datasource:
-        ("datasource" in current ? current.datasource : datasources[0]?.id) ||
-        "",
+        ("datasource" in current
+          ? current.datasource
+          : filteredDatasources[0]?.id) || "",
       name: current.name || "",
       description: current.description || "",
       type: current.type || "binomial",
@@ -403,7 +418,7 @@ const MetricForm: FC<MetricFormProps> = ({
           label="Data Source"
           value={value.datasource || ""}
           onChange={(v) => form.setValue("datasource", v)}
-          options={(datasources || []).map((d) => ({
+          options={(filteredDatasources || []).map((d) => ({
             value: d.id,
             label: d.name,
           }))}

--- a/packages/front-end/components/Projects/ProjectModal.tsx
+++ b/packages/front-end/components/Projects/ProjectModal.tsx
@@ -3,6 +3,8 @@ import { useForm } from "react-hook-form";
 import { useAuth } from "../../services/auth";
 import Modal from "../Modal";
 import Field from "../Forms/Field";
+import MultiSelectField from "../Forms/MultiSelectField";
+import { useDefinitions } from "../../services/DefinitionsContext";
 
 export default function ProjectModal({
   existing,
@@ -13,9 +15,13 @@ export default function ProjectModal({
   close: () => void;
   onSuccess: () => Promise<void>;
 }) {
+  const { datasources, metrics } = useDefinitions();
+
   const form = useForm<Partial<ProjectInterface>>({
     defaultValues: {
       name: existing.name || "",
+      datasources: existing.datasources || [],
+      metrics: existing.metrics || [],
     },
   });
   const { apiCall } = useAuth();
@@ -33,7 +39,27 @@ export default function ProjectModal({
         await onSuccess();
       })}
     >
-      <Field name="Name" maxLength={30} required {...form.register("name")} />
+      <Field label="Name" maxLength={30} required {...form.register("name")} />
+
+      { datasources.length && (
+        <MultiSelectField
+          label="Data Sources (optional)"
+          value={form.watch("datasources")}
+          onChange={(v) => form.setValue("datasources", v)}
+          options={datasources.map(ds => ({label: ds.name, value: ds.id}))}
+          helpText="Limit this project to specific data sources"
+        />
+      )}
+
+      { metrics.length && (
+        <MultiSelectField
+          label="Metrics (optional)"
+          value={form.watch("metrics")}
+          onChange={(v) => form.setValue("metrics", v)}
+          options={metrics.map(m => ({label: m.name, value: m.id}))}
+          helpText="Limit this project to specific metrics"
+        />
+      )}
     </Modal>
   );
 }

--- a/packages/front-end/components/Segments/SegmentForm.tsx
+++ b/packages/front-end/components/Segments/SegmentForm.tsx
@@ -20,17 +20,27 @@ const SegmentForm: FC<{
     datasources,
     getDatasourceById,
     mutateDefinitions,
+    project,
+    getProjectById,
   } = useDefinitions();
+  const projectDefinition = getProjectById(project);
+  let filteredDatasources = datasources.filter((d) => d.properties?.segments);
+  if (projectDefinition?.datasources?.length) {
+    const projectDatasources = projectDefinition.datasources;
+    filteredDatasources = datasources.filter((ds) =>
+      projectDatasources.includes(ds.id)
+    );
+  }
   const form = useForm({
     defaultValues: {
       name: current.name || "",
       sql: current.sql || "",
-      datasource: (current.id ? current.datasource : datasources[0]?.id) || "",
+      datasource:
+        (current.id ? current.datasource : filteredDatasources[0]?.id) || "",
       userIdType: current.userIdType || "user_id",
       owner: current.owner || "",
     },
   });
-  const filteredDatasources = datasources.filter((d) => d.properties?.segments);
 
   const userIdType = form.watch("userIdType");
 
@@ -42,7 +52,7 @@ const SegmentForm: FC<{
     <Modal
       close={close}
       open={true}
-      header={current ? "Edit Segment" : "New Segment"}
+      header={current.id ? "Edit Segment" : "New Segment"}
       submit={form.handleSubmit(async (value) => {
         if (sql) {
           validateSQL(value.sql, [value.userIdType, "date"]);

--- a/packages/front-end/components/Settings/DataSources.tsx
+++ b/packages/front-end/components/Settings/DataSources.tsx
@@ -17,7 +17,22 @@ const DataSources: FC = () => {
 
   const router = useRouter();
 
-  const { datasources, error, mutateDefinitions, ready } = useDefinitions();
+  const {
+    datasources,
+    error,
+    mutateDefinitions,
+    ready,
+    project,
+    getProjectById,
+  } = useDefinitions();
+  const projectDefinition = getProjectById(project);
+  let filteredDatasources = datasources.filter((d) => d.properties?.segments);
+  if (projectDefinition?.datasources?.length) {
+    const projectDatasources = projectDefinition.datasources;
+    filteredDatasources = datasources.filter((ds) =>
+      projectDatasources.includes(ds.id)
+    );
+  }
 
   const permissions = usePermissions();
 
@@ -30,7 +45,7 @@ const DataSources: FC = () => {
 
   return (
     <div>
-      {datasources.length > 0 ? (
+      {filteredDatasources.length > 0 ? (
         <table className="table appbox gbtable table-hover">
           <thead>
             <tr>
@@ -40,7 +55,7 @@ const DataSources: FC = () => {
             </tr>
           </thead>
           <tbody>
-            {datasources.map((d, i) => (
+            {filteredDatasources.map((d, i) => (
               <tr
                 className="nav-item"
                 key={i}

--- a/packages/front-end/pages/projects.tsx
+++ b/packages/front-end/pages/projects.tsx
@@ -11,7 +11,12 @@ import usePermissions from "../hooks/usePermissions";
 const ProjectsPage: FC = () => {
   const permissions = usePermissions();
 
-  const { projects, mutateDefinitions } = useDefinitions();
+  const {
+    projects,
+    mutateDefinitions,
+    datasources,
+    metrics,
+  } = useDefinitions();
 
   const { apiCall } = useAuth();
   const [modalOpen, setModalOpen] = useState<Partial<ProjectInterface> | null>(
@@ -46,20 +51,42 @@ const ProjectsPage: FC = () => {
         <table className="table appbox gbtable table-hover">
           <thead>
             <tr>
-              <th>Project Id</th>
               <th>Project Name</th>
+              <th>Project Id</th>
               <th>Date Created</th>
               <th>Date Updated</th>
+              <th>Data Sources</th>
+              <th>Metrics</th>
               <th></th>
             </tr>
           </thead>
           <tbody>
             {projects.map((p) => (
               <tr key={p.id}>
-                <td>{p.id}</td>
                 <td>{p.name}</td>
+                <td>{p.id}</td>
                 <td>{date(p.dateCreated)}</td>
                 <td>{date(p.dateUpdated)}</td>
+                <td className="col-2">
+                  {p.datasources.map((ds) => (
+                    <span
+                      key={`datasource_tag_${ds}`}
+                      className="tag mr-2 badge badge-primary"
+                    >
+                      {datasources.find((d) => d.id === ds)?.name}
+                    </span>
+                  ))}
+                </td>
+                <td className="col-2">
+                  {p.metrics.map((m) => (
+                    <span
+                      key={`metric_tag_${m}`}
+                      className="tag mr-2 badge badge-primary"
+                    >
+                      {metrics.find((mm) => mm.id === m)?.name}
+                    </span>
+                  ))}
+                </td>
                 <td>
                   <button
                     className="btn btn-outline-primary"


### PR DESCRIPTION
Closes #741 

- Adds datasource and metric tagging to projects.
- If project's datasources or metrics whitelists are set, we prevent using those datasources and metrics in many different contexts.

<img width="1343" alt="image" src="https://user-images.githubusercontent.com/7927873/206110306-06687fd7-5e18-493d-9757-6081da9de22d.png">
