### PR TITLE
Added a project drop down to the add feature modal.

### DIFF
--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -138,6 +138,12 @@ export async function postFeatures(
       "Feature keys can only include letters, numbers, hyphens, and underscores."
     );
   }
+  const existing = await getFeature(org.id, id);
+  if (existing) {
+    throw new Error(
+      "This feature key already exists. Feature keys must be unique."
+    );
+  }
 
   const feature: FeatureInterface = {
     defaultValue: "",

--- a/packages/front-end/components/Features/FeatureModal.tsx
+++ b/packages/front-end/components/Features/FeatureModal.tsx
@@ -32,6 +32,7 @@ import useOrgSettings from "../../hooks/useOrgSettings";
 import { useWatching } from "../../services/WatchProvider";
 import { ReactElement } from "react";
 import usePermissions from "../../hooks/usePermissions";
+import SelectField, { GroupedValue, SingleValue } from "../Forms/SelectField";
 
 export type Props = {
   close?: () => void;
@@ -68,7 +69,7 @@ export default function FeatureModal({
   cta = "Create",
   secondaryCTA,
 }: Props) {
-  const { project, refreshTags } = useDefinitions();
+  const { project, refreshTags, projects } = useDefinitions();
   const environments = useEnvironments();
   const permissions = usePermissions();
 
@@ -97,7 +98,22 @@ export default function FeatureModal({
       rule: null,
     },
   });
+
+  const availableProjects: (SingleValue | GroupedValue)[] = projects
+    .slice()
+    .sort((a, b) => (a.name > b.name ? 1 : -1))
+    .filter(
+      (p) =>
+        permissions.check("manageFeatures", p.id) &&
+        permissions.check("createFeatureDrafts", p.id)
+    )
+    .map((p) => ({ value: p.id, label: p.name }));
+
   const { apiCall } = useAuth();
+
+  const allowAllProjects =
+    permissions.check("manageFeatures", "") &&
+    permissions.check("createFeatureDrafts", "");
 
   const attributeSchema = useAttributeSchema();
 
@@ -197,6 +213,17 @@ export default function FeatureModal({
           </>
         }
       />
+
+      <div className="form-group">
+        <label>Project</label>
+        <SelectField
+          value={form.watch("project")}
+          onChange={(p) => form.setValue("project", p)}
+          name="project"
+          initialOption={allowAllProjects ? "All Projects" : undefined}
+          options={availableProjects}
+        />
+      </div>
 
       <div className="form-group">
         <label>Tags</label>


### PR DESCRIPTION
Now when you create a feature, you can select a project that the feature will be created in (and continues to default to the current project). It also checks permissions to make sure you are allowed to create a project there. 

Also improved the error message when a feature key is a duplicate.

Fixes #793
<img width="811" alt="Screen Shot 2022-12-07 at 12 11 48 AM" src="https://user-images.githubusercontent.com/46107/206124073-9def3c86-acc3-40d9-b17e-8b5166a747b8.png">

