### PR TITLE
Fixed GB dev container setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,5 +4,16 @@ ARG MONGO_TOOLS_VERSION=5.0
 RUN curl -sSL "https://www.mongodb.org/static/pgp/server-${MONGO_TOOLS_VERSION}.asc" | gpg --dearmor > /usr/share/keyrings/mongodb-archive-keyring.gpg \
         && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/mongodb-archive-keyring.gpg] http://repo.mongodb.org/apt/debian $(lsb_release -cs)/mongodb-org/${MONGO_TOOLS_VERSION} main" | tee /etc/apt/sources.list.d/mongodb-org-${MONGO_TOOLS_VERSION}.list \
         && apt-get update && export DEBIAN_FRONTEND=noninteractive \
-        && apt-get install -y mongodb-database-tools mongodb-mongosh \
-        && apt-get clean -y && rm -rf /var/lib/apt/lists/*;
+        && apt-get install -y mongodb-database-tools mongodb-mongosh
+
+RUN export DEBIAN_FRONTEND=noninteractive && apt-get install -y make build-essential libssl-dev zlib1g-dev \
+        libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
+        libncurses5-dev libncursesw5-dev xz-utils tk-dev
+
+RUN wget https://www.python.org/ftp/python/3.8.4/Python-3.8.4.tgz && \
+        tar xvf Python-3.8.4.tgz && \
+        cd Python-3.8.4 && \
+        ./configure --enable-optimizations --with-ensurepip=install && \
+        make -j 8 && \
+        make altinstall && \
+        apt-get clean -y && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/dockerBuild.sh
+++ b/.devcontainer/dockerBuild.sh
@@ -3,7 +3,7 @@ echo "export PATH=\"$PATH:$HOME/.poetry/bin\"" >> ~/.bashrc
 echo "printf 'Welcome to GrowthBook, to get started run:\n"yarn dev"\n'" >> ~/.bashrc
 
 #poetry installation
-curl -sSL https://install.python-poetry.org | python3 -
+curl -sSL https://install.python-poetry.org | python3.8 -
 
 #needed for 'poetry install' during 'yarn setup'
 export PATH="$PATH:$HOME/.poetry/bin"


### PR DESCRIPTION
### Features and Changes

 Added additional steps to building a dev container to fulfill GBStats package by installing from source python 3.8. In addition changed the post script to point python 3.8
 
 Please note this might not be the most performant way to do this using multiple RUN commands.

- Closes **https://github.com/growthbook/growthbook/issues/818**

### Dependencies

None

### Testing

Spin up the container using Visual Studio Code and there should be no errors.

### Screenshots
