### PR TITLE
Fix for session expiration error

### DIFF
--- a/packages/front-end/services/auth.tsx
+++ b/packages/front-end/services/auth.tsx
@@ -284,7 +284,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
               // ignore
             }
             // Don't need to confirm, just redirect immediately
-            window.location.href = resp.redirectURI;
+            await redirectWithTimeout(resp.redirectURI);
           }
           setSessionError(true);
           throw new Error(

--- a/packages/front-end/services/auth.tsx
+++ b/packages/front-end/services/auth.tsx
@@ -272,6 +272,19 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
               throw new Error(responseData.message || "There was an error");
             }
             return responseData;
+          } else if ("redirectURI" in resp) {
+            try {
+              const redirectAddress =
+                window.location.pathname + (window.location.search || "");
+              window.sessionStorage.setItem(
+                "postAuthRedirectPath",
+                redirectAddress
+              );
+            } catch (e) {
+              // ignore
+            }
+            // Don't need to confirm, just redirect immediately
+            window.location.href = resp.redirectURI;
           }
           setSessionError(true);
           throw new Error(


### PR DESCRIPTION
Currently when you leave a GrowthBook Cloud page up for a while, the JWT will expire, and give you a response to fetch a new JWT. This is handled correctly on `init()`, but when the expiration happens on an `apiCall`, the redirectURI is ignored, and instead it shows a message saying you're logged out. 

<img width="535" alt="Screen Shot 2022-12-08 at 10 22 26 PM" src="https://user-images.githubusercontent.com/46107/206638193-813ee876-050f-4a50-ac07-b9f78f07d2be.png">

This code adds a refresh when the JWT expires and returns a redirectURI. It might briefly flash the above message, so it could be improved.