### PR TITLE
Generate dummy data - Fix data generation bug (NULL variationid)

### DIFF
--- a/packages/back-end/test/data-generator/new-generator.ts
+++ b/packages/back-end/test/data-generator/new-generator.ts
@@ -416,7 +416,7 @@ function writeCSV(objs: Record<string, unknown>[], filename: string) {
   for (let i = 0; i < objs.length; i++) {
     const row: string[] = [];
     for (let j = 0; j < headers.length; j++) {
-      row.push(String(objs[i][headers[j]] || ""));
+      row.push(String(objs[i][headers[j]] ?? ""));
     }
     rows.push(row);
   }


### PR DESCRIPTION
While testing the dummy data, I noticed that not all experiments from the `experiments_viewed` table were being represented in Growthbook. There are five total, however the app would only pick up two of them. After some digging, I discovered we were storing variation IDs of `0` as `NULL` in postgres. This PR fixes the code to respect `0` when converting to a CSV.

### Before
<img width="1624" alt="Screen Shot 2022-12-15 at 4 26 51 PM" src="https://user-images.githubusercontent.com/2374625/207979928-252af912-4a3d-4fc5-8cd3-83491d8bf216.png">

<img width="1624" alt="Screen Shot 2022-12-15 at 5 03 33 PM" src="https://user-images.githubusercontent.com/2374625/207980170-a721e6f0-b813-44a4-a409-336f05e925dd.png">

### After
<img width="1624" alt="Screen Shot 2022-12-15 at 5 18 16 PM" src="https://user-images.githubusercontent.com/2374625/207980641-ffed1112-fcf9-4d78-aff8-7976b405d97c.png">

<img width="1624" alt="Screen Shot 2022-12-15 at 5 18 10 PM" src="https://user-images.githubusercontent.com/2374625/207980663-c523325c-4243-49cf-b5d7-21d15b99b7e4.png">
