### PR TITLE
Frequentist - UX Changes to experiment results

### DIFF
--- a/packages/back-end/src/controllers/datasources.ts
+++ b/packages/back-end/src/controllers/datasources.ts
@@ -44,6 +44,7 @@ export async function postSampleData(req: AuthRequest, res: Response) {
 
   const { org, userId } = getOrgFromReq(req);
   const orgId = org.id;
+  const statsEngine = org.settings?.statsEngine;
 
   const existingMetrics = await getSampleMetrics(orgId);
 
@@ -157,36 +158,42 @@ Revenue did not reach 95% significance, but the risk is so low it doesn't seem w
     };
     await ExperimentModel.create(experiment);
 
-    await createManualSnapshot(experiment, 0, [15500, 15400], {
-      [metric1.id]: [
-        {
-          users: 15500,
-          count: 950,
-          mean: 1,
-          stddev: 1,
-        },
-        {
-          users: 15400,
-          count: 1025,
-          mean: 1,
-          stddev: 1,
-        },
-      ],
-      [metric2.id]: [
-        {
-          users: 15500,
-          count: 950,
-          mean: 26.54,
-          stddev: 16.75,
-        },
-        {
-          users: 15400,
-          count: 1025,
-          mean: 25.13,
-          stddev: 16.87,
-        },
-      ],
-    });
+    await createManualSnapshot(
+      experiment,
+      0,
+      [15500, 15400],
+      {
+        [metric1.id]: [
+          {
+            users: 15500,
+            count: 950,
+            mean: 1,
+            stddev: 1,
+          },
+          {
+            users: 15400,
+            count: 1025,
+            mean: 1,
+            stddev: 1,
+          },
+        ],
+        [metric2.id]: [
+          {
+            users: 15500,
+            count: 950,
+            mean: 26.54,
+            stddev: 16.75,
+          },
+          {
+            users: 15400,
+            count: 1025,
+            mean: 25.13,
+            stddev: 16.87,
+          },
+        ],
+      },
+      statsEngine
+    );
   }
 
   res.status(200).json({

--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -1513,7 +1513,6 @@ export async function postSnapshot(
       useCache,
       org.settings?.statsEngine
     );
-
     await req.audit({
       event: "experiment.refresh",
       entity: {

--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -1513,6 +1513,7 @@ export async function postSnapshot(
       useCache,
       org.settings?.statsEngine
     );
+
     await req.audit({
       event: "experiment.refresh",
       entity: {

--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -1431,6 +1431,7 @@ export async function postSnapshot(
   req.checkPermissions("runQueries", "");
 
   const { org } = getOrgFromReq(req);
+  const statsEngine = org.settings?.statsEngine;
 
   const useCache = !req.query["force"];
 
@@ -1466,7 +1467,13 @@ export async function postSnapshot(
     }
 
     try {
-      const snapshot = await createManualSnapshot(exp, phase, users, metrics);
+      const snapshot = await createManualSnapshot(
+        exp,
+        phase,
+        users,
+        metrics,
+        statsEngine
+      );
       res.status(200).json({
         status: 200,
         snapshot,

--- a/packages/back-end/src/models/ExperimentSnapshotModel.ts
+++ b/packages/back-end/src/models/ExperimentSnapshotModel.ts
@@ -73,6 +73,7 @@ const experimentSnapshotSchema = new mongoose.Schema({
   segment: String,
   activationMetric: String,
   skipPartialData: Boolean,
+  statsEngine: String,
 });
 experimentSnapshotSchema.index({
   experiment: 1,

--- a/packages/back-end/src/models/ExperimentSnapshotModel.ts
+++ b/packages/back-end/src/models/ExperimentSnapshotModel.ts
@@ -61,6 +61,7 @@ const experimentSnapshotSchema = new mongoose.Schema({
                 },
               ],
               chanceToWin: Number,
+              pValue: Number,
             },
           },
         },

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -640,6 +640,7 @@ export async function createSnapshot(
     segment: experiment.segment || "",
     queryFilter: experiment.queryFilter || "",
     skipPartialData: experiment.skipPartialData || false,
+    statsEngine,
   };
 
   const nextUpdate = determineNextDate(

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -518,7 +518,8 @@ export async function createManualSnapshot(
   users: number[],
   metrics: {
     [key: string]: MetricStats[];
-  }
+  },
+  statsEngine?: OrganizationSettings["statsEngine"]
 ) {
   const { srm, variations } = await getManualSnapshotData(
     experiment,
@@ -544,6 +545,7 @@ export async function createManualSnapshot(
         variations,
       },
     ],
+    statsEngine,
   };
 
   const snapshot = await ExperimentSnapshotModel.create(data);

--- a/packages/back-end/types/experiment-snapshot.d.ts
+++ b/packages/back-end/types/experiment-snapshot.d.ts
@@ -11,6 +11,7 @@ export interface SnapshotMetric {
   expected?: number;
   risk?: [number, number];
   stats?: MetricStats;
+  pValue?: number;
   uplift?: {
     dist: string;
     mean?: number;

--- a/packages/back-end/types/experiment-snapshot.d.ts
+++ b/packages/back-end/types/experiment-snapshot.d.ts
@@ -1,5 +1,6 @@
 import { QueryLanguage } from "./datasource";
 import { MetricStats } from "./metric";
+import { OrganizationSettings } from "./organization";
 import { Queries } from "./query";
 
 export interface SnapshotMetric {
@@ -57,4 +58,5 @@ export interface ExperimentSnapshotInterface {
   segment?: string;
   activationMetric?: string;
   skipPartialData?: boolean;
+  statsEngine: OrganizationSettings["statsEngine"];
 }

--- a/packages/back-end/types/organization.d.ts
+++ b/packages/back-end/types/organization.d.ts
@@ -143,9 +143,10 @@ export interface OrganizationSettings {
   videoInstructionsViewed?: boolean;
   multipleExposureMinPercent?: number;
   defaultRole?: MemberRoleInfo;
+  statsEngine?: "bayesian" | "frequentist";
+  pValueThreshold?: number;
   /** @deprecated */
   implementationTypes?: ImplementationType[];
-  statsEngine?: "bayesian" | "frequentist";
 }
 
 export interface SubscriptionQuote {

--- a/packages/front-end/components/Experiment/ChanceToWinColumn.tsx
+++ b/packages/front-end/components/Experiment/ChanceToWinColumn.tsx
@@ -7,6 +7,7 @@ import {
   hasEnoughData,
   isBelowMinChange,
   isSuspiciousUplift,
+  shouldHighlight as _shouldHighlight,
 } from "@/services/experiments";
 import { useOrganizationMetricDefaults } from "@/hooks/useOrganizationMetricDefaults";
 import Tooltip from "../Tooltip/Tooltip";
@@ -55,13 +56,14 @@ export default function ChanceToWinColumn({
   );
   const { ciUpper, ciLower } = useConfidenceLevels();
 
-  const shouldHighlight =
-    metric &&
-    baseline?.value &&
-    stats?.value &&
-    enoughData &&
-    !suspiciousChange &&
-    !belowMinChange;
+  const shouldHighlight = _shouldHighlight({
+    metric,
+    baseline,
+    stats,
+    hasEnoughData: enoughData,
+    suspiciousChange,
+    belowMinChange,
+  });
 
   const chanceToWin = stats?.chanceToWin ?? 0;
 

--- a/packages/front-end/components/Experiment/GuardrailResult.tsx
+++ b/packages/front-end/components/Experiment/GuardrailResult.tsx
@@ -22,7 +22,8 @@ const percentFormatter = new Intl.NumberFormat(undefined, {
   maximumFractionDigits: 2,
 });
 
-function hasEnoughData(value1: number, value2: number): boolean {
+// TODO Needs to be modified for pvalue
+export function hasEnoughData(value1: number, value2: number): boolean {
   return Math.max(value1, value2) >= 80 && Math.min(value1, value2) >= 20;
 }
 
@@ -78,6 +79,7 @@ const GuardrailResults: FC<{
           </Link>
         </Tooltip>
       </div>
+
       <div>
         <table
           className={clsx("rounded table table-bordered experiment-compact")}
@@ -86,7 +88,6 @@ const GuardrailResults: FC<{
             <tr>
               <th>Variation</th>
               <th>Value</th>
-              {/** TODO Change title to 'P-value' for frequentist **/}
               <th className="text-center">Chance of Being Worse</th>
             </tr>
           </thead>

--- a/packages/front-end/components/Experiment/GuardrailResult.tsx
+++ b/packages/front-end/components/Experiment/GuardrailResult.tsx
@@ -22,7 +22,7 @@ const percentFormatter = new Intl.NumberFormat(undefined, {
   maximumFractionDigits: 2,
 });
 
-function hasEnoughData(value1: number, value2: number): boolean {
+export function hasEnoughData(value1: number, value2: number): boolean {
   return Math.max(value1, value2) >= 80 && Math.min(value1, value2) >= 20;
 }
 

--- a/packages/front-end/components/Experiment/GuardrailResult.tsx
+++ b/packages/front-end/components/Experiment/GuardrailResult.tsx
@@ -22,8 +22,7 @@ const percentFormatter = new Intl.NumberFormat(undefined, {
   maximumFractionDigits: 2,
 });
 
-// TODO Needs to be modified for pvalue
-export function hasEnoughData(value1: number, value2: number): boolean {
+function hasEnoughData(value1: number, value2: number): boolean {
   return Math.max(value1, value2) >= 80 && Math.min(value1, value2) >= 20;
 }
 
@@ -79,7 +78,6 @@ const GuardrailResults: FC<{
           </Link>
         </Tooltip>
       </div>
-
       <div>
         <table
           className={clsx("rounded table table-bordered experiment-compact")}

--- a/packages/front-end/components/Experiment/PValueColumn.tsx
+++ b/packages/front-end/components/Experiment/PValueColumn.tsx
@@ -13,14 +13,6 @@ import usePValueThreshold from "@/hooks/usePValueThreshold";
 import Tooltip from "../Tooltip/Tooltip";
 import NotEnoughData from "./NotEnoughData";
 
-// TODO replace with util w/ following heuristics
-// - round to 3 digits, if < 0.001 write “<0.001”
-// - “0.000” replaced by “<0.001”
-const pValueFormatter = new Intl.NumberFormat(undefined, {
-  style: "percent",
-  maximumFractionDigits: 3,
-});
-
 const PValueColumn: FC<{
   metric: MetricInterface;
   status: ExperimentStatus;
@@ -125,7 +117,7 @@ const PValueColumn: FC<{
             phaseStart={startDate}
           />
         ) : (
-          <>{pValueFormatter.format(stats.pValue)}</>
+          <>{stats.pValue.toFixed(3)}</>
         )}
       </Tooltip>
     </td>

--- a/packages/front-end/components/Experiment/PValueColumn.tsx
+++ b/packages/front-end/components/Experiment/PValueColumn.tsx
@@ -8,6 +8,7 @@ import {
   isBelowMinChange,
   isSuspiciousUplift,
   shouldHighlight as _shouldHighlight,
+  pValueFormatter,
 } from "@/services/experiments";
 import { useOrganizationMetricDefaults } from "@/hooks/useOrganizationMetricDefaults";
 import usePValueThreshold from "@/hooks/usePValueThreshold";
@@ -63,14 +64,19 @@ const PValueColumn: FC<{
     : stats.expected > 0;
   const statSig = stats.pValue < pValueThreshold;
 
-  let sigText = "";
+  let sigText: string | JSX.Element = "";
   let className = "";
 
   if (shouldHighlight && statSig && expectedDirection) {
     sigText = `Significant win as the p-value is below ${pValueThreshold} and the change is in the desired direction.`;
     className = "won";
   } else if (shouldHighlight && statSig && !expectedDirection) {
-    sigText = `Significant loss as the p-value is below ${pValueThreshold} and the change is in the opposite direction.`;
+    sigText = (
+      <>
+        Significant loss as the p-value is below {pValueThreshold} and the
+        change is <em>not</em> in the desired direction.
+      </>
+    );
     className = "lost";
   } else if (belowMinChange && statSig) {
     sigText =
@@ -119,7 +125,7 @@ const PValueColumn: FC<{
             phaseStart={startDate}
           />
         ) : (
-          <>{stats.pValue?.toFixed(3)}</>
+          <>{pValueFormatter(stats.pValue)}</>
         )}
       </Tooltip>
     </td>

--- a/packages/front-end/components/Experiment/PValueColumn.tsx
+++ b/packages/front-end/components/Experiment/PValueColumn.tsx
@@ -1,0 +1,135 @@
+import clsx from "clsx";
+import { FC } from "react";
+import { SnapshotMetric } from "back-end/types/experiment-snapshot";
+import { MetricInterface } from "back-end/types/metric";
+import { ExperimentStatus } from "back-end/types/experiment";
+import {
+  hasEnoughData,
+  isBelowMinChange,
+  isSuspiciousUplift,
+} from "@/services/experiments";
+import { useOrganizationMetricDefaults } from "@/hooks/useOrganizationMetricDefaults";
+import usePValueThreshold from "@/hooks/usePValueThreshold";
+import Tooltip from "../Tooltip/Tooltip";
+import NotEnoughData from "./NotEnoughData";
+
+// TODO replace with util w/ following heuristics
+// - round to 3 digits, if < 0.001 write “<0.001”
+// - “0.000” replaced by “<0.001”
+const pValueFormatter = new Intl.NumberFormat(undefined, {
+  style: "percent",
+  maximumFractionDigits: 3,
+});
+
+const PValueColumn: FC<{
+  metric: MetricInterface;
+  status: ExperimentStatus;
+  isLatestPhase: boolean;
+  startDate: string;
+  snapshotDate: Date;
+  baseline: SnapshotMetric;
+  stats: SnapshotMetric;
+}> = ({
+  metric,
+  status,
+  isLatestPhase,
+  startDate,
+  snapshotDate,
+  baseline,
+  stats,
+}) => {
+  const {
+    getMinSampleSizeForMetric,
+    metricDefaults,
+  } = useOrganizationMetricDefaults();
+  const pValueThreshold = usePValueThreshold();
+  const minSampleSize = getMinSampleSizeForMetric(metric);
+  const suspiciousChange = isSuspiciousUplift(
+    baseline,
+    stats,
+    metric,
+    metricDefaults
+  );
+  const belowMinChange = isBelowMinChange(
+    baseline,
+    stats,
+    metric,
+    metricDefaults
+  );
+  const enoughData = hasEnoughData(baseline, stats, metric, metricDefaults);
+  const shouldHighlight =
+    metric &&
+    baseline?.value &&
+    stats?.value &&
+    enoughData &&
+    !suspiciousChange &&
+    !belowMinChange;
+  const expectedDirection = metric.inverse
+    ? stats.expected < 0
+    : stats.expected > 0;
+  const statSig = stats.pValue < pValueThreshold;
+
+  let sigText = "";
+  let className = "";
+
+  if (shouldHighlight && statSig && expectedDirection) {
+    sigText = `Significant win as the p-value is below ${pValueThreshold} and the change is in the desired direction.`;
+    className = "won";
+  } else if (shouldHighlight && statSig && !expectedDirection) {
+    sigText = `Significant loss as the p-value is below ${pValueThreshold} and the change is in the opposite direction.`;
+    className = "lost";
+  } else if (belowMinChange && statSig) {
+    sigText =
+      "The change is significant, but too small to matter (below the min detectable change threshold). Consider this a draw.";
+    className += " draw";
+  }
+
+  return (
+    <td
+      className={clsx(
+        "variation chance result-number align-middle d-table-cell",
+        className
+      )}
+    >
+      {enoughData && suspiciousChange && (
+        <div>
+          <div className="mb-1 d-flex flex-row">
+            <Tooltip
+              body={`A suspicious result occurs when the percent change is equal to or greater than your maximum percent change (${
+                metric.maxPercentChange * 100
+              }%).`}
+            >
+              <span className="badge badge-pill badge-warning">
+                Suspicious Result
+              </span>
+            </Tooltip>
+          </div>
+        </div>
+      )}
+      <Tooltip
+        body={sigText}
+        className="d-block"
+        tipPosition={"top"}
+        shouldDisplay={sigText !== ""}
+      >
+        {!baseline?.value || !stats?.value ? (
+          <em>no data</em>
+        ) : !enoughData ? (
+          <NotEnoughData
+            experimentStatus={status}
+            isLatestPhase={isLatestPhase}
+            baselineValue={baseline?.value}
+            variationValue={stats?.value}
+            minSampleSize={minSampleSize}
+            snapshotCreated={snapshotDate}
+            phaseStart={startDate}
+          />
+        ) : (
+          <>{pValueFormatter.format(stats.pValue)}</>
+        )}
+      </Tooltip>
+    </td>
+  );
+};
+
+export default PValueColumn;

--- a/packages/front-end/components/Experiment/PValueColumn.tsx
+++ b/packages/front-end/components/Experiment/PValueColumn.tsx
@@ -117,7 +117,7 @@ const PValueColumn: FC<{
             phaseStart={startDate}
           />
         ) : (
-          <>{stats.pValue.toFixed(3)}</>
+          <>{stats.pValue?.toFixed(3)}</>
         )}
       </Tooltip>
     </td>

--- a/packages/front-end/components/Experiment/PValueColumn.tsx
+++ b/packages/front-end/components/Experiment/PValueColumn.tsx
@@ -7,6 +7,7 @@ import {
   hasEnoughData,
   isBelowMinChange,
   isSuspiciousUplift,
+  shouldHighlight as _shouldHighlight,
 } from "@/services/experiments";
 import { useOrganizationMetricDefaults } from "@/hooks/useOrganizationMetricDefaults";
 import usePValueThreshold from "@/hooks/usePValueThreshold";
@@ -49,13 +50,14 @@ const PValueColumn: FC<{
     metricDefaults
   );
   const enoughData = hasEnoughData(baseline, stats, metric, metricDefaults);
-  const shouldHighlight =
-    metric &&
-    baseline?.value &&
-    stats?.value &&
-    enoughData &&
-    !suspiciousChange &&
-    !belowMinChange;
+  const shouldHighlight = _shouldHighlight({
+    metric,
+    baseline,
+    stats,
+    hasEnoughData: enoughData,
+    suspiciousChange,
+    belowMinChange,
+  });
   const expectedDirection = metric.inverse
     ? stats.expected < 0
     : stats.expected > 0;

--- a/packages/front-end/components/Experiment/PValueGuardrailResults.tsx
+++ b/packages/front-end/components/Experiment/PValueGuardrailResults.tsx
@@ -17,6 +17,7 @@ import usePValueThreshold from "@/hooks/usePValueThreshold";
 import Tooltip from "../Tooltip/Tooltip";
 import MetricTooltipBody from "../Metrics/MetricTooltipBody";
 import MetricValueColumn from "./MetricValueColumn";
+import { hasEnoughData } from "./GuardrailResult";
 
 type PValueGuardrailResult = {
   stats: SnapshotMetric;
@@ -26,11 +27,6 @@ type PValueGuardrailResult = {
   name: string;
   hasEnoughData: boolean;
 };
-
-function hasEnoughData(value1: number, value2: number): boolean {
-  // TODO Is this right for pvalue?
-  return Math.max(value1, value2) >= 80 && Math.min(value1, value2) >= 0.0001;
-}
 
 const HeaderResult: FC<{
   metric: MetricInterface;
@@ -100,7 +96,7 @@ const PValueGuardrailResults: FC<{
         users,
         name,
         hasEnoughData: hasEnoughData(
-          stats.pValue,
+          stats.value,
           data[0].metrics[metric.id]?.value
         ),
       };

--- a/packages/front-end/components/Experiment/PValueGuardrailResults.tsx
+++ b/packages/front-end/components/Experiment/PValueGuardrailResults.tsx
@@ -1,0 +1,169 @@
+import clsx from "clsx";
+import { FC } from "react";
+import {
+  FaCheckCircle,
+  FaExclamation,
+  FaExclamationTriangle,
+  FaQuestionCircle,
+} from "react-icons/fa";
+import Link from "next/link";
+import {
+  SnapshotMetric,
+  SnapshotVariation,
+} from "back-end/types/experiment-snapshot";
+import { MetricInterface } from "back-end/types/metric";
+import { ExperimentReportVariation } from "back-end/types/report";
+import usePValueThreshold from "@/hooks/usePValueThreshold";
+import Tooltip from "../Tooltip/Tooltip";
+import MetricTooltipBody from "../Metrics/MetricTooltipBody";
+import MetricValueColumn from "./MetricValueColumn";
+import { hasEnoughData } from "./GuardrailResult";
+
+type PValueGuardrailResult = {
+  stats: SnapshotMetric;
+  expectedDirection: boolean;
+  statSig: boolean;
+  users: number;
+  name: string;
+  hasEnoughData: boolean;
+};
+
+const HeaderResult: FC<{
+  metric: MetricInterface;
+  results: PValueGuardrailResult[];
+}> = ({ metric, results }) => {
+  const anyInsufficientData = results.some((r) => !r.hasEnoughData);
+  const significantNegativeDirection = results.some(
+    (r) => !r.expectedDirection && r.statSig
+  );
+  const anyNegativeDirection = results.some((r) => !r.expectedDirection);
+  const allSignificantPositiveDirection = results.every(
+    (r) => r.expectedDirection && r.statSig
+  );
+
+  let status = "secondary";
+
+  if (anyInsufficientData) {
+    status = "secondary";
+  } else if (significantNegativeDirection) {
+    status = "danger";
+  } else if (anyNegativeDirection) {
+    status = "warning";
+  } else if (allSignificantPositiveDirection) {
+    status = "success";
+  }
+
+  return (
+    <div
+      className={clsx(
+        "d-flex align-items-center guardrail alert m-0",
+        `alert-${status}`
+      )}
+    >
+      {status === "success" && <FaCheckCircle className="mr-1" />}
+      {status === "warning" && <FaExclamationTriangle className="mr-1" />}
+      {status === "danger" && <FaExclamation className="mr-1" />}
+      {status === "secondary" && <FaQuestionCircle className="mr-1" />}
+      <Tooltip body={<MetricTooltipBody metric={metric} />} tipPosition="right">
+        <Link href={`/metric/${metric.id}`}>
+          <a className="text-dark font-weight-bold">{metric.name}</a>
+        </Link>
+      </Tooltip>
+    </div>
+  );
+};
+
+const PValueGuardrailResults: FC<{
+  data: SnapshotVariation[];
+  variations: ExperimentReportVariation[];
+  metric: MetricInterface;
+}> = ({ data, variations, metric }) => {
+  const pValueThreshold = usePValueThreshold();
+
+  const results: PValueGuardrailResult[] = variations.map((v, i) => {
+    const stats = data[i]?.metrics?.[metric.id];
+    const expectedDirection = metric.inverse
+      ? stats.expected < 0
+      : stats.expected > 0;
+    const statSig = stats.pValue < pValueThreshold;
+    const users = data[i].users;
+    const name = v.name;
+    return {
+      stats,
+      expectedDirection,
+      statSig,
+      users,
+      name,
+      hasEnoughData: hasEnoughData(
+        stats.pValue,
+        data[0].metrics[metric.id]?.value
+      ),
+    };
+  });
+
+  return (
+    <div className="d-flex flex-column" key={metric.id}>
+      <HeaderResult metric={metric} results={results} />
+
+      <div>
+        <table
+          className={clsx("rounded table table-bordered experiment-compact")}
+        >
+          <thead>
+            <tr>
+              <th>Variation</th>
+              <th>Value</th>
+              <th className="text-center">P-value</th>
+            </tr>
+          </thead>
+          <tbody>
+            {results.map((r, i) => {
+              if (!r.stats) {
+                return (
+                  <tr key={i}>
+                    <td>{r.name}</td>
+                    <td colSpan={2}>
+                      <em>no data yet</em>
+                    </td>
+                  </tr>
+                );
+              }
+
+              return (
+                <tr key={i}>
+                  <td>{r.name}</td>
+
+                  <MetricValueColumn
+                    metric={metric}
+                    stats={r.stats}
+                    users={r.users}
+                  />
+
+                  {!i ? (
+                    <td></td>
+                  ) : r.hasEnoughData ? (
+                    <td
+                      className={clsx("chance result-number align-middle", {
+                        won: r.expectedDirection && r.statSig,
+                        lost: !r.expectedDirection && r.statSig,
+                        warning: !r.expectedDirection,
+                      })}
+                    >
+                      {pValueFormatter.format(r.stats.pValue)}
+                    </td>
+                  ) : (
+                    <td>
+                      <em>not enough data</em>
+                    </td>
+                  )}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+export default PValueGuardrailResults;

--- a/packages/front-end/components/Experiment/PValueGuardrailResults.tsx
+++ b/packages/front-end/components/Experiment/PValueGuardrailResults.tsx
@@ -13,6 +13,7 @@ import {
 } from "back-end/types/experiment-snapshot";
 import { MetricInterface } from "back-end/types/metric";
 import { ExperimentReportVariation } from "back-end/types/report";
+import { pValueFormatter } from "@/services/experiments";
 import usePValueThreshold from "@/hooks/usePValueThreshold";
 import Tooltip from "../Tooltip/Tooltip";
 import MetricTooltipBody from "../Metrics/MetricTooltipBody";
@@ -152,7 +153,8 @@ const PValueGuardrailResults: FC<{
                         warning: !r.expectedDirection,
                       })}
                     >
-                      {r.stats.pValue?.toFixed(3)}
+                      {r.expectedDirection ? "Better" : "Worse"}{" "}
+                      {`(${pValueFormatter(r.stats.pValue)})`}
                     </td>
                   ) : (
                     <td>

--- a/packages/front-end/components/Experiment/PValueGuardrailResults.tsx
+++ b/packages/front-end/components/Experiment/PValueGuardrailResults.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { FC } from "react";
+import { FC, useMemo } from "react";
 import {
   FaCheckCircle,
   FaExclamation,
@@ -84,26 +84,29 @@ const PValueGuardrailResults: FC<{
 }> = ({ data, variations, metric }) => {
   const pValueThreshold = usePValueThreshold();
 
-  const results: PValueGuardrailResult[] = variations.map((v, i) => {
-    const stats = data[i]?.metrics?.[metric.id];
-    const expectedDirection = metric.inverse
-      ? stats.expected < 0
-      : stats.expected > 0;
-    const statSig = stats.pValue < pValueThreshold;
-    const users = data[i].users;
-    const name = v.name;
-    return {
-      stats,
-      expectedDirection,
-      statSig,
-      users,
-      name,
-      hasEnoughData: hasEnoughData(
-        stats.pValue,
-        data[0].metrics[metric.id]?.value
-      ),
-    };
-  });
+  const results: PValueGuardrailResult[] = useMemo(() => {
+    return variations.map((v, i) => {
+      const stats = data[i]?.metrics?.[metric.id];
+      const expectedDirection = metric.inverse
+        ? stats.expected < 0
+        : stats.expected > 0;
+      const statSig = stats.pValue < pValueThreshold;
+      const users = data[i].users;
+      const name = v.name;
+      return {
+        stats,
+        expectedDirection,
+        statSig,
+        users,
+        name,
+        hasEnoughData: hasEnoughData(
+          stats.pValue,
+          data[0].metrics[metric.id]?.value
+        ),
+      };
+    });
+    // eslint-disable-next-line
+  }, [variations]);
 
   return (
     <div className="d-flex flex-column" key={metric.id}>

--- a/packages/front-end/components/Experiment/PValueGuardrailResults.tsx
+++ b/packages/front-end/components/Experiment/PValueGuardrailResults.tsx
@@ -156,7 +156,7 @@ const PValueGuardrailResults: FC<{
                         warning: !r.expectedDirection,
                       })}
                     >
-                      {r.stats.pValue.toFixed(3)}
+                      {r.stats.pValue?.toFixed(3)}
                     </td>
                   ) : (
                     <td>

--- a/packages/front-end/components/Experiment/PValueGuardrailResults.tsx
+++ b/packages/front-end/components/Experiment/PValueGuardrailResults.tsx
@@ -150,7 +150,7 @@ const PValueGuardrailResults: FC<{
                       className={clsx("chance result-number align-middle", {
                         won: r.expectedDirection && r.statSig,
                         lost: !r.expectedDirection && r.statSig,
-                        warning: !r.expectedDirection,
+                        warning: !r.expectedDirection && !r.statSig,
                       })}
                     >
                       {r.expectedDirection ? "Better" : "Worse"}{" "}

--- a/packages/front-end/components/Experiment/PValueGuardrailResults.tsx
+++ b/packages/front-end/components/Experiment/PValueGuardrailResults.tsx
@@ -17,7 +17,6 @@ import usePValueThreshold from "@/hooks/usePValueThreshold";
 import Tooltip from "../Tooltip/Tooltip";
 import MetricTooltipBody from "../Metrics/MetricTooltipBody";
 import MetricValueColumn from "./MetricValueColumn";
-import { hasEnoughData } from "./GuardrailResult";
 
 type PValueGuardrailResult = {
   stats: SnapshotMetric;
@@ -27,6 +26,11 @@ type PValueGuardrailResult = {
   name: string;
   hasEnoughData: boolean;
 };
+
+function hasEnoughData(value1: number, value2: number): boolean {
+  // TODO Is this right for pvalue?
+  return Math.max(value1, value2) >= 80 && Math.min(value1, value2) >= 0.0001;
+}
 
 const HeaderResult: FC<{
   metric: MetricInterface;
@@ -149,7 +153,7 @@ const PValueGuardrailResults: FC<{
                         warning: !r.expectedDirection,
                       })}
                     >
-                      {pValueFormatter.format(r.stats.pValue)}
+                      {r.stats.pValue.toFixed(3)}
                     </td>
                   ) : (
                     <td>

--- a/packages/front-end/components/Experiment/PercentGraphColumn.tsx
+++ b/packages/front-end/components/Experiment/PercentGraphColumn.tsx
@@ -11,17 +11,19 @@ export default function PercentGraphColumn({
   stats,
   domain,
   id,
+  barType: _barType,
 }: {
   metric: MetricInterface;
   baseline: SnapshotMetric;
   stats: SnapshotMetric;
   domain: [number, number];
   id: string;
+  barType?: "pill" | "violin";
 }) {
   const { metricDefaults } = useOrganizationMetricDefaults();
   const enoughData = hasEnoughData(baseline, stats, metric, metricDefaults);
   const { ciUpper, ciLower } = useConfidenceLevels();
-  const barType = stats.uplift?.dist ? "violin" : "pill";
+  const barType = _barType ? _barType : stats.uplift?.dist ? "violin" : "pill";
 
   const showGraph = metric && enoughData;
   return (

--- a/packages/front-end/components/Experiment/Results.tsx
+++ b/packages/front-end/components/Experiment/Results.tsx
@@ -67,7 +67,9 @@ const Results: FC<{
 
   const status = getQueryStatus(latest?.queries || [], latest?.error);
 
-  const hasData = snapshot?.results?.[0]?.variations?.length > 0;
+  const hasData =
+    snapshot?.results?.[0]?.variations?.length > 0 &&
+    snapshot.statsEngine === settings.statsEngine;
 
   const phaseObj = experiment.phases?.[phase];
 

--- a/packages/front-end/components/Experiment/Results.tsx
+++ b/packages/front-end/components/Experiment/Results.tsx
@@ -4,6 +4,7 @@ import dynamic from "next/dynamic";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import { ago, getValidDate } from "@/services/dates";
 import usePermissions from "@/hooks/usePermissions";
+import useOrgSettings from "@/hooks/useOrgSettings";
 import { useAuth } from "@/services/auth";
 import { getQueryStatus } from "@/components/Queries/RunQueriesButton";
 import { useSnapshot } from "@/components/Experiment/SnapshotProvider";
@@ -13,6 +14,7 @@ import VariationIdWarning from "@/components/Experiment/VariationIdWarning";
 import AnalysisSettingsBar from "@/components/Experiment/AnalysisSettingsBar";
 import GuardrailResults from "@/components/Experiment/GuardrailResult";
 import StatusBanner from "@/components/Experiment/StatusBanner";
+import PValueGuardrailResults from "./PValueGuardrailResults";
 
 const BreakDownResults = dynamic(
   () => import("@/components/Experiment/BreakDownResults")
@@ -39,6 +41,7 @@ const Results: FC<{
   reportDetailsLink = true,
 }) => {
   const { getMetricById } = useDefinitions();
+  const settings = useOrgSettings();
 
   const { apiCall } = useAuth();
 
@@ -249,11 +252,19 @@ const Results: FC<{
                       className={`col-12 col-xl-${xlargeCols} col-lg-6 mb-3`}
                       key={g}
                     >
-                      <GuardrailResults
-                        data={data}
-                        variations={variations}
-                        metric={metric}
-                      />
+                      {settings.statsEngine === "frequentist" ? (
+                        <PValueGuardrailResults
+                          data={data}
+                          variations={variations}
+                          metric={metric}
+                        />
+                      ) : (
+                        <GuardrailResults
+                          data={data}
+                          variations={variations}
+                          metric={metric}
+                        />
+                      )}
                     </div>
                   );
                 })}

--- a/packages/front-end/components/Experiment/ResultsTable.tsx
+++ b/packages/front-end/components/Experiment/ResultsTable.tsx
@@ -5,6 +5,7 @@ import { MetricInterface } from "back-end/types/metric";
 import { ExperimentReportVariation } from "back-end/types/report";
 import { ExperimentStatus } from "back-end/types/experiment";
 import { ExperimentTableRow, useDomain } from "@/services/experiments";
+import useOrgSettings from "@/hooks/useOrgSettings";
 import Tooltip from "../Tooltip/Tooltip";
 import SelectField from "../Forms/SelectField";
 import AlignedGraph from "./AlignedGraph";
@@ -12,6 +13,7 @@ import ChanceToWinColumn from "./ChanceToWinColumn";
 import MetricValueColumn from "./MetricValueColumn";
 import PercentGraphColumn from "./PercentGraphColumn";
 import RiskColumn from "./RiskColumn";
+import PValueColumn from "./PValueColumn";
 
 export type ResultsTableProps = {
   id: string;
@@ -56,6 +58,7 @@ export default function ResultsTable({
   setRiskVariation,
 }: ResultsTableProps) {
   const domain = useDomain(variations, rows);
+  const settings = useOrgSettings();
 
   return (
     <table
@@ -114,8 +117,9 @@ export default function ResultsTable({
                   className={`variation${i} text-center`}
                   style={{ minWidth: 110 }}
                 >
-                  {/** TODO Change to 'P-Value' for frequentist **/}
-                  Chance to Beat Control
+                  {settings.statsEngine === "frequentist"
+                    ? "P-value"
+                    : "Chance to Beat Control"}
                 </th>
               )}
               {i > 0 && (
@@ -202,35 +206,43 @@ export default function ResultsTable({
                       users={stats?.users || 0}
                       className="value variation"
                     />
-                    {/** TODO Switch to p-value for frequentist **/}
-                    {i > 0 && fullStats && (
-                      <ChanceToWinColumn
-                        baseline={baseline}
-                        stats={stats}
-                        status={status}
-                        isLatestPhase={isLatestPhase}
-                        startDate={startDate}
-                        metric={row.metric}
-                        snapshotDate={dateCreated}
-                      />
-                    )}
-                    {i > 0 && (
-                      <>
-                        {fullStats ? (
-                          <PercentGraphColumn
-                            baseline={baseline}
-                            domain={domain}
-                            metric={row.metric}
-                            stats={stats}
-                            id={`${id}_violin_row${ind}_var${i}`}
-                          />
-                        ) : (
-                          <td className="align-middle">
-                            {percentFormatter.format(stats?.expected || 0)}
-                          </td>
-                        )}
-                      </>
-                    )}
+                    {i > 0 &&
+                      fullStats &&
+                      (settings.statsEngine === "frequentist" ? (
+                        <PValueColumn
+                          baseline={baseline}
+                          stats={stats}
+                          status={status}
+                          isLatestPhase={isLatestPhase}
+                          startDate={startDate}
+                          metric={row.metric}
+                          snapshotDate={dateCreated}
+                        />
+                      ) : (
+                        <ChanceToWinColumn
+                          baseline={baseline}
+                          stats={stats}
+                          status={status}
+                          isLatestPhase={isLatestPhase}
+                          startDate={startDate}
+                          metric={row.metric}
+                          snapshotDate={dateCreated}
+                        />
+                      ))}
+                    {i > 0 &&
+                      (fullStats ? (
+                        <PercentGraphColumn
+                          baseline={baseline}
+                          domain={domain}
+                          metric={row.metric}
+                          stats={stats}
+                          id={`${id}_violin_row${ind}_var${i}`}
+                        />
+                      ) : (
+                        <td className="align-middle">
+                          {percentFormatter.format(stats?.expected || 0)}
+                        </td>
+                      ))}
                   </React.Fragment>
                 );
               })}

--- a/packages/front-end/components/Experiment/ResultsTable.tsx
+++ b/packages/front-end/components/Experiment/ResultsTable.tsx
@@ -232,6 +232,11 @@ export default function ResultsTable({
                     {i > 0 &&
                       (fullStats ? (
                         <PercentGraphColumn
+                          barType={
+                            settings.statsEngine === "frequentist"
+                              ? "pill"
+                              : null
+                          }
                           baseline={baseline}
                           domain={domain}
                           metric={row.metric}

--- a/packages/front-end/components/Metrics/MetricForm/index.tsx
+++ b/packages/front-end/components/Metrics/MetricForm/index.tsx
@@ -7,6 +7,7 @@ import {
 } from "back-end/types/metric";
 import { useFieldArray, useForm } from "react-hook-form";
 import { useOrganizationMetricDefaults } from "@/hooks/useOrganizationMetricDefaults";
+import useOrgSettings from "@/hooks/useOrgSettings";
 import { getInitialMetricQuery, validateSQL } from "@/services/datasources";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import track from "@/services/track";
@@ -148,6 +149,7 @@ const MetricForm: FC<MetricFormProps> = ({
   const [step, setStep] = useState(initialStep);
   const [showAdvanced, setShowAdvanced] = useState(advanced);
   const [hideTags, setHideTags] = useState(!current?.tags?.length);
+  const settings = useOrgSettings();
 
   const {
     getMinSampleSizeForMetric,
@@ -926,13 +928,15 @@ const MetricForm: FC<MetricFormProps> = ({
                 </small>
               </div>
             )}
-            <RiskThresholds
-              winRisk={value.winRisk}
-              loseRisk={value.loseRisk}
-              winRiskRegisterField={form.register("winRisk")}
-              loseRiskRegisterField={form.register("loseRisk")}
-              riskError={riskError}
-            />
+            {settings.statsEngine !== "frequentist" && (
+              <RiskThresholds
+                winRisk={value.winRisk}
+                loseRisk={value.loseRisk}
+                winRiskRegisterField={form.register("winRisk")}
+                loseRiskRegisterField={form.register("loseRisk")}
+                riskError={riskError}
+              />
+            )}
             <div className="form-group">
               <label>Minimum Sample Size</label>
               <input

--- a/packages/front-end/components/Settings/DataSources.tsx
+++ b/packages/front-end/components/Settings/DataSources.tsx
@@ -148,7 +148,7 @@ const DataSources: FC = () => {
           data={{
             name: "My Datasource",
             settings: {},
-            projects: project ? [project] : []
+            projects: project ? [project] : [],
           }}
           source="datasource-list"
           onSuccess={async (id) => {

--- a/packages/front-end/components/Settings/NewDataSourceForm.tsx
+++ b/packages/front-end/components/Settings/NewDataSourceForm.tsx
@@ -15,14 +15,14 @@ import {
   dataSourceConnections,
   eventSchema,
 } from "@/services/eventSchema";
+import MultiSelectField from "@/components/Forms/MultiSelectField";
+import { useDefinitions } from "@/services/DefinitionsContext";
 import SelectField from "../Forms/SelectField";
 import Field from "../Forms/Field";
 import Modal from "../Modal";
 import { GBCircleArrowLeft } from "../Icons";
 import EventSourceList from "./EventSourceList";
 import ConnectionSettings from "./ConnectionSettings";
-import MultiSelectField from "@/components/Forms/MultiSelectField";
-import { useDefinitions } from "@/services/DefinitionsContext";
 
 const NewDataSourceForm: FC<{
   data: Partial<DataSourceInterfaceWithParams>;

--- a/packages/front-end/hooks/usePValueThreshold.ts
+++ b/packages/front-end/hooks/usePValueThreshold.ts
@@ -1,0 +1,6 @@
+import useOrgSettings from "./useOrgSettings";
+
+export default function usePValueThreshold() {
+  const settings = useOrgSettings();
+  return settings.pValueThreshold || 0.05;
+}

--- a/packages/front-end/pages/metric/[mid].tsx
+++ b/packages/front-end/pages/metric/[mid].tsx
@@ -9,6 +9,7 @@ import { BsGear } from "react-icons/bs";
 import clsx from "clsx";
 import { IdeaInterface } from "back-end/types/idea";
 import useApi from "@/hooks/useApi";
+import useOrgSettings from "@/hooks/useOrgSettings";
 import DiscussionThread from "@/components/DiscussionThread";
 import useSwitchOrg from "@/services/useSwitchOrg";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
@@ -63,6 +64,7 @@ const MetricPage: FC = () => {
     getMetricById,
     segments,
   } = useDefinitions();
+  const settings = useOrgSettings();
   const [editModalOpen, setEditModalOpen] = useState<boolean | number>(false);
   const [editing, setEditing] = useState(false);
   const [editTags, setEditTags] = useState(false);
@@ -920,22 +922,31 @@ const MetricPage: FC = () => {
 
               <RightRailSectionGroup type="custom" empty="">
                 <ul className="right-rail-subsection list-unstyled">
-                  <li className="mb-2">
-                    <span className="uppercase-title">Thresholds</span>
-                  </li>
-                  <li className="mb-2">
-                    <span className="text-gray">Acceptable risk &lt;</span>{" "}
-                    <span className="font-weight-bold">
-                      {metric?.winRisk * 100 || defaultWinRiskThreshold * 100}%
-                    </span>
-                  </li>
-                  <li className="mb-2">
-                    <span className="text-gray">Unacceptable risk &gt;</span>{" "}
-                    <span className="font-weight-bold">
-                      {metric?.loseRisk * 100 || defaultLoseRiskThreshold * 100}
-                      %
-                    </span>
-                  </li>
+                  {settings.statsEngine !== "frequentist" && (
+                    <>
+                      <li className="mb-2">
+                        <span className="uppercase-title">Thresholds</span>
+                      </li>
+                      <li className="mb-2">
+                        <span className="text-gray">Acceptable risk &lt;</span>{" "}
+                        <span className="font-weight-bold">
+                          {metric?.winRisk * 100 ||
+                            defaultWinRiskThreshold * 100}
+                          %
+                        </span>
+                      </li>
+                      <li className="mb-2">
+                        <span className="text-gray">
+                          Unacceptable risk &gt;
+                        </span>{" "}
+                        <span className="font-weight-bold">
+                          {metric?.loseRisk * 100 ||
+                            defaultLoseRiskThreshold * 100}
+                          %
+                        </span>
+                      </li>
+                    </>
+                  )}
                   <li className="mb-2">
                     <span className="text-gray">Minimum sample size:</span>{" "}
                     <span className="font-weight-bold">

--- a/packages/front-end/pages/report/[rid].tsx
+++ b/packages/front-end/pages/report/[rid].tsx
@@ -6,6 +6,7 @@ import { useForm } from "react-hook-form";
 import LoadingOverlay from "@/components/LoadingOverlay";
 import Markdown from "@/components/Markdown/Markdown";
 import useApi from "@/hooks/useApi";
+import useOrgSettings from "@/hooks/useOrgSettings";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import RunQueriesButton, {
   getQueryStatus,
@@ -29,6 +30,7 @@ import Tooltip from "@/components/Tooltip/Tooltip";
 import { useUser } from "@/services/UserContext";
 import VariationIdWarning from "@/components/Experiment/VariationIdWarning";
 import DeleteButton from "@/components/DeleteButton/DeleteButton";
+import PValueGuardrailResults from "@/components/Experiment/PValueGuardrailResults";
 
 export default function ReportPage() {
   const router = useRouter();
@@ -53,6 +55,8 @@ export default function ReportPage() {
       status: data?.report?.status ? data.report.status : "private",
     },
   });
+
+  const settings = useOrgSettings();
 
   useEffect(() => {
     if (data?.report) {
@@ -135,7 +139,7 @@ export default function ReportPage() {
         {report?.experimentId && (
           <Link href={`/experiment/${report.experimentId}#results`}>
             <a>
-              <GBCircleArrowLeft /> go to experiment results
+              <GBCircleArrowLeft /> Go to experiment results
             </a>
           </Link>
         )}
@@ -387,11 +391,19 @@ export default function ReportPage() {
 
                       return (
                         <div className="col-12 col-xl-4 col-lg-6 mb-3" key={g}>
-                          <GuardrailResults
-                            data={data}
-                            variations={variations}
-                            metric={metric}
-                          />
+                          {settings.statsEngine === "frequentist" ? (
+                            <PValueGuardrailResults
+                              data={data}
+                              variations={variations}
+                              metric={metric}
+                            />
+                          ) : (
+                            <GuardrailResults
+                              data={data}
+                              variations={variations}
+                              metric={metric}
+                            />
+                          )}
                         </div>
                       );
                     })}

--- a/packages/front-end/services/experiments.ts
+++ b/packages/front-end/services/experiments.ts
@@ -244,3 +244,7 @@ export function applyMetricOverrides(
   }
   return { newMetric, overrideFields };
 }
+
+export function pValueFormatter(pValue: number) {
+  return pValue < 0.001 ? "<0.001" : pValue.toFixed(3);
+}

--- a/packages/front-end/services/experiments.ts
+++ b/packages/front-end/services/experiments.ts
@@ -56,6 +56,31 @@ export function isBelowMinChange(
   return Math.abs(baseline.cr - stats.cr) / baseline.cr < minPercentChange;
 }
 
+export function shouldHighlight({
+  metric,
+  baseline,
+  stats,
+  hasEnoughData,
+  suspiciousChange,
+  belowMinChange,
+}: {
+  metric: MetricInterface;
+  baseline: SnapshotMetric;
+  stats: SnapshotMetric;
+  hasEnoughData: boolean;
+  suspiciousChange: boolean;
+  belowMinChange: boolean;
+}): boolean {
+  return (
+    metric &&
+    baseline?.value &&
+    stats?.value &&
+    hasEnoughData &&
+    !suspiciousChange &&
+    !belowMinChange
+  );
+}
+
 export function getRisk(
   riskVariation: number,
   row: ExperimentTableRow,

--- a/yarn.lock
+++ b/yarn.lock
@@ -19336,8 +19336,10 @@ watchpack@^1.7.4:
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.5.tgz#1267e6c55e0b9b5be44c2023aed5437a2c26c453"
   integrity sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==
   dependencies:
+    chokidar "^3.4.1"
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
+    watchpack-chokidar2 "^2.0.1"
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"


### PR DESCRIPTION
This PR updates experiment results, experiment reports, and the edit metric modal to represent stats and settings relating to the frequentist stats engine. These changes are necessary since frequentist does not deal with concepts of 'risk' values or 'winning'.

Notion doc: https://www.notion.so/growthbook/Front-End-Changes-for-Frequentist-Engine-2299651ecd5541378fcfc25e25438a62

Changes:
- Update ResultsTable
  - Create new `PValueColumn` component
  - Update PercentGraph to represent bar diagrams in pill form
- Create new `PValueGuardrailResults` component
- Create `usePValueThreshold` hook to provide org setting pvalue threshold
- Update metric page and edit metric modal to hide UI relating to risk thresholds
- Update ExperimentSnapshotModel to accommodate `pValue` field

Screenshots

Metrics page no longer showing risk thresholds when frequentist is enabled
<img width="1624" alt="Screen Shot 2022-12-21 at 11 36 23 AM" src="https://user-images.githubusercontent.com/2374625/208959607-3fa26138-0792-43ce-b0a5-4f15bb8fd949.png">

Risk thresholds viewable when stats engine is bayesian
<img width="1624" alt="Screen Shot 2022-12-21 at 11 33 20 AM" src="https://user-images.githubusercontent.com/2374625/208959614-ac9d601e-5880-4e85-b136-adac2c508293.png">

Risk thresholds hidden when stats engine is frequentist
<img width="1624" alt="Screen Shot 2022-12-21 at 11 33 00 AM" src="https://user-images.githubusercontent.com/2374625/208959617-d3b9d606-14cf-436f-a0b3-59ac874f930c.png">

Experiment report with frequentist results
<img width="1624" alt="Screen Shot 2022-12-21 at 11 32 46 AM" src="https://user-images.githubusercontent.com/2374625/208959620-177f0683-1ebe-4e3e-84b8-c34423087969.png">
<img width="1624" alt="Screen Shot 2022-12-23 at 11 04 09 AM" src="https://user-images.githubusercontent.com/2374625/209373757-7f17db60-9c52-4709-bd88-75d27352bb07.png">


Experiment results with bayesian enabled
<img width="1624" alt="Screen Shot 2022-12-21 at 11 31 35 AM" src="https://user-images.githubusercontent.com/2374625/208959626-c899220f-37e6-43b9-8fa2-f192939d0e91.png">