### PR TITLE
update "to" variable to include the current day's worth of data

### DIFF
--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -321,6 +321,7 @@ export async function refreshMetric(
     const from = new Date();
     from.setDate(from.getDate() - days);
     const to = new Date();
+    to.setDate(to.getDate() + 1);
 
     const baseParams: Omit<MetricValueParams, "metric"> = {
       from,


### PR DESCRIPTION
Issue: https://github.com/growthbook/growthbook/issues/171

Added an extra day to the `to` variable in order to include the current day's worth of data when showing data for a metric,  so that users getting set up can get their events from today in order to test out if their query is working, all as is also outlined in the issue above.

`yarn test` and `yarn type-check` both passed