### PR TITLE
HOTFIX: Fix error when feature flag contains no schedule rules.

### DIFF
--- a/packages/front-end/components/Features/RuleModal.tsx
+++ b/packages/front-end/components/Features/RuleModal.tsx
@@ -76,21 +76,23 @@ export default function RuleModal({
         const ruleAction = i === rules.length ? "add" : "edit";
 
         // Loop through each scheduleRule and convert the timestamp to an ISOString()
-        values.scheduleRules?.forEach((scheduleRule: ScheduleRule) => {
-          if (scheduleRule.timestamp === null) {
-            return;
-          }
-          scheduleRule.timestamp = new Date(
-            scheduleRule.timestamp
-          ).toISOString();
-        });
+        if (values.scheduleRules?.length) {
+          values.scheduleRules?.forEach((scheduleRule: ScheduleRule) => {
+            if (scheduleRule.timestamp === null) {
+              return;
+            }
+            scheduleRule.timestamp = new Date(
+              scheduleRule.timestamp
+            ).toISOString();
+          });
 
-        // We currently only support a start date and end date, and if both are null, set schedule to empty array
-        if (
-          values.scheduleRules[0].timestamp === null &&
-          values.scheduleRules[1].timestamp === null
-        ) {
-          values.scheduleRules = [];
+          // We currently only support a start date and end date, and if both are null, set schedule to empty array
+          if (
+            values.scheduleRules[0].timestamp === null &&
+            values.scheduleRules[1].timestamp === null
+          ) {
+            values.scheduleRules = [];
+          }
         }
 
         const rule = values as FeatureRule;


### PR DESCRIPTION
### Features and Changes

This change adds a check to only loop through schedule rules if the scheduleRules array isn't empty.

### Testing

- [ ] Create a new feature flag and add a force rule without any schedule rules and ensure you can save the rule without any errors.
