### PR TITLE
Persist SDK Endpoint payloads in Mongo

### DIFF
--- a/packages/back-end/src/api/features/toggleFeature.ts
+++ b/packages/back-end/src/api/features/toggleFeature.ts
@@ -54,27 +54,27 @@ export const toggleFeature = createApiRequestHandler({
       toggles[env] = state;
     });
 
-    const newFeature = await toggleMultipleEnvironments(
+    const updatedFeature = await toggleMultipleEnvironments(
       req.organization,
       feature,
       toggles
     );
 
-    if (newFeature !== feature) {
+    if (updatedFeature !== feature) {
       await req.audit({
         event: "feature.toggle",
         entity: {
           object: "feature",
           id: feature.id,
         },
-        details: auditDetailsUpdate(feature, newFeature),
+        details: auditDetailsUpdate(feature, updatedFeature),
         reason: req.body.reason,
       });
     }
 
     const groupMap = await getSavedGroupMap(req.organization);
     return {
-      feature: getApiFeatureObj(newFeature, req.organization, groupMap),
+      feature: getApiFeatureObj(updatedFeature, req.organization, groupMap),
     };
   }
 );

--- a/packages/back-end/src/api/features/toggleFeature.ts
+++ b/packages/back-end/src/api/features/toggleFeature.ts
@@ -54,7 +54,11 @@ export const toggleFeature = createApiRequestHandler({
       toggles[env] = state;
     });
 
-    const newFeature = await toggleMultipleEnvironments(feature, toggles);
+    const newFeature = await toggleMultipleEnvironments(
+      req.organization,
+      feature,
+      toggles
+    );
 
     if (newFeature !== feature) {
       await req.audit({

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -29,7 +29,6 @@ import {
   addIdsToRules,
   arrayMove,
   encrypt,
-  getAffectedEnvs,
   getEnabledEnvironments,
   getFeatureDefinitions,
   verifyDraftsAreEqual,
@@ -46,6 +45,7 @@ import {
   auditDetailsDelete,
 } from "../services/audit";
 import { getRevisions } from "../models/FeatureRevisionModel";
+import { getAffectedEnvs } from "../util/features";
 
 export async function getFeaturesPublic(req: Request, res: Response) {
   const { key } = req.params;
@@ -133,6 +133,10 @@ export async function postFeatures(
 
   if (!id) {
     throw new Error("Must specify feature key");
+  }
+
+  if (!environmentSettings) {
+    throw new Error("Feature missing initial environment toggle settings");
   }
 
   if (!id.match(/^[a-zA-Z0-9_.:|-]+$/)) {

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -600,6 +600,7 @@ export async function putFeature(
     featureUpdated(
       org,
       newFeature,
+      // Previous environments/projects in case they changed
       getEnabledEnvironments(feature),
       feature.project || ""
     );

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -196,7 +196,7 @@ export async function postFeatures(
     details: auditDetailsCreate(feature),
   });
 
-  featureUpdated(feature);
+  featureUpdated(org, feature);
   res.status(200).json({
     status: 200,
     feature,
@@ -248,6 +248,7 @@ export async function postFeaturePublish(
   verifyDraftsAreEqual(feature.draft, draft);
 
   const newFeature = await publishDraft(
+    org,
     feature,
     {
       id: userId,
@@ -433,7 +434,7 @@ export async function postFeatureToggle(
   const previousFeatureState = _.cloneDeep(feature);
   const newFeatureState: FeatureInterface = _.cloneDeep(previousFeatureState);
 
-  await toggleFeatureEnvironment(feature, environment, state);
+  await toggleFeatureEnvironment(org, feature, environment, state);
 
   await req.audit({
     event: "feature.toggle",
@@ -597,6 +598,7 @@ export async function putFeature(
 
   if (requiresWebhook) {
     featureUpdated(
+      org,
       newFeature,
       getEnabledEnvironments(feature),
       feature.project || ""
@@ -638,7 +640,7 @@ export async function deleteFeatureById(
       },
       details: auditDetailsDelete(feature),
     });
-    featureUpdated(feature);
+    featureUpdated(org, feature);
   }
 
   res.status(200).json({
@@ -676,7 +678,7 @@ export async function postFeatureArchive(
       { archived: !feature.archived } // New state
     ),
   });
-  featureUpdated(feature);
+  featureUpdated(org, feature);
 
   res.status(200).json({
     status: 200,

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -29,7 +29,6 @@ import {
   addIdsToRules,
   arrayMove,
   encrypt,
-  getEnabledEnvironments,
   getFeatureDefinitions,
   verifyDraftsAreEqual,
 } from "../services/features";
@@ -45,7 +44,7 @@ import {
   auditDetailsDelete,
 } from "../services/audit";
 import { getRevisions } from "../models/FeatureRevisionModel";
-import { getAffectedEnvs } from "../util/features";
+import { getEnabledEnvironments } from "../util/features";
 
 export async function getFeaturesPublic(req: Request, res: Response) {
   const { key } = req.params;
@@ -235,10 +234,11 @@ export async function postFeaturePublish(
   }
   // Otherwise, only the environments with rule changes are affected
   else {
+    const draftRules = draft.rules || {};
     req.checkPermissions(
       "publishFeatures",
       feature.project,
-      getAffectedEnvs(feature, Object.keys(draft.rules || {}))
+      [...getEnabledEnvironments(feature)].filter((e) => e in draftRules)
     );
   }
 

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -578,10 +578,7 @@ export async function putFeature(
     requiresWebhook = true;
   }
 
-  await updateFeature(feature.organization, id, {
-    ...updates,
-    dateUpdated: new Date(),
-  });
+  await updateFeature(feature.organization, id, updates);
 
   const newFeature = { ...feature, ...updates };
 

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -196,7 +196,7 @@ export async function postFeatures(
     details: auditDetailsCreate(feature),
   });
 
-  featureUpdated(org, feature);
+  featureUpdated(org, feature, feature);
   res.status(200).json({
     status: 200,
     feature,
@@ -585,20 +585,11 @@ export async function putFeature(
   await logFeatureUpdatedEvent(org, feature, newFeature);
 
   if (requiresWebhook) {
-    featureUpdated(
-      org,
-      newFeature,
-      // Previous environments/projects in case they changed
-      getEnabledEnvironments(feature),
-      feature.project || ""
-    );
+    featureUpdated(org, feature, newFeature);
   }
 
   res.status(200).json({
-    feature: {
-      ...newFeature,
-      dateUpdated: new Date(),
-    },
+    feature: newFeature,
     status: 200,
   });
 }
@@ -629,7 +620,7 @@ export async function deleteFeatureById(
       },
       details: auditDetailsDelete(feature),
     });
-    featureUpdated(org, feature);
+    featureUpdated(org, feature, feature);
   }
 
   res.status(200).json({
@@ -667,7 +658,7 @@ export async function postFeatureArchive(
       { archived: newFeature.archived } // New state
     ),
   });
-  featureUpdated(org, newFeature);
+  featureUpdated(org, feature, newFeature);
 
   res.status(200).json({
     status: 200,

--- a/packages/back-end/src/events/handlers/webhooks/event-webhooks-utils.ts
+++ b/packages/back-end/src/events/handlers/webhooks/event-webhooks-utils.ts
@@ -1,7 +1,7 @@
 import { createHmac } from "crypto";
 import fetch, { RequestInfo, RequestInit, Response } from "node-fetch";
 import { OrganizationInterface } from "../../../../types/organization";
-import { getApiFeatureObj, GroupMap } from "../../../services/features";
+import { getApiFeatureObj } from "../../../services/features";
 import {
   FeatureCreatedNotificationEvent,
   FeatureDeletedNotificationEvent,
@@ -15,6 +15,7 @@ import {
 } from "../../base-types";
 import { ApiFeatureInterface } from "../../../../types/api";
 import { logger } from "../../../util/logger";
+import { GroupMap } from "../../../../types/saved-group";
 
 export type EventWebHookSuccessResult = {
   result: "success";

--- a/packages/back-end/src/jobs/updateScheduledFeatures.ts
+++ b/packages/back-end/src/jobs/updateScheduledFeatures.ts
@@ -4,7 +4,7 @@ import {
   getScheduledFeaturesToUpdate,
   updateFeature,
 } from "../models/FeatureModel";
-import { featureUpdated, getNextScheduledUpdate } from "../services/features";
+import { getNextScheduledUpdate } from "../services/features";
 import { getOrganizationById } from "../services/organizations";
 import { logger } from "../util/logger";
 
@@ -84,12 +84,9 @@ async function updateSingleFeature(job: UpdateSingleFeatureJob) {
     );
 
     // Update the feature in Mongo
-    const newFeature = await updateFeature(feature, {
+    await updateFeature(org, feature, {
       nextScheduledUpdate: nextScheduledUpdate,
     });
-
-    // Fire the webhook
-    featureUpdated(org, feature, newFeature);
   } catch (e) {
     log.error("Failure - " + e.message);
   }

--- a/packages/back-end/src/jobs/updateScheduledFeatures.ts
+++ b/packages/back-end/src/jobs/updateScheduledFeatures.ts
@@ -9,6 +9,7 @@ import {
   getEnabledEnvironments,
   getNextScheduledUpdate,
 } from "../services/features";
+import { getOrganizationById } from "../services/organizations";
 import { logger } from "../util/logger";
 
 type UpdateSingleFeatureJob = Job<{
@@ -74,13 +75,16 @@ async function updateSingleFeature(job: UpdateSingleFeatureJob) {
     featureId,
   });
 
-  const feature = await getFeature(organization, featureId);
+  const org = await getOrganizationById(organization);
+  if (!org) return;
 
+  const feature = await getFeature(organization, featureId);
   if (!feature) return;
 
   try {
     // Fire the webhook
     featureUpdated(
+      org,
       feature,
       getEnabledEnvironments(feature),
       feature.project || ""

--- a/packages/back-end/src/jobs/updateScheduledFeatures.ts
+++ b/packages/back-end/src/jobs/updateScheduledFeatures.ts
@@ -89,7 +89,7 @@ async function updateSingleFeature(job: UpdateSingleFeatureJob) {
     });
 
     // Fire the webhook
-    featureUpdated(org, newFeature);
+    featureUpdated(org, feature, newFeature);
   } catch (e) {
     log.error("Failure - " + e.message);
   }

--- a/packages/back-end/src/jobs/updateScheduledFeatures.ts
+++ b/packages/back-end/src/jobs/updateScheduledFeatures.ts
@@ -84,12 +84,12 @@ async function updateSingleFeature(job: UpdateSingleFeatureJob) {
     );
 
     // Update the feature in Mongo
-    await updateFeature(organization, featureId, {
+    const newFeature = await updateFeature(feature, {
       nextScheduledUpdate: nextScheduledUpdate,
     });
 
     // Fire the webhook
-    featureUpdated(org, feature);
+    featureUpdated(org, newFeature);
   } catch (e) {
     log.error("Failure - " + e.message);
   }

--- a/packages/back-end/src/jobs/updateScheduledFeatures.ts
+++ b/packages/back-end/src/jobs/updateScheduledFeatures.ts
@@ -4,11 +4,7 @@ import {
   getScheduledFeaturesToUpdate,
   updateFeature,
 } from "../models/FeatureModel";
-import {
-  featureUpdated,
-  getEnabledEnvironments,
-  getNextScheduledUpdate,
-} from "../services/features";
+import { featureUpdated, getNextScheduledUpdate } from "../services/features";
 import { getOrganizationById } from "../services/organizations";
 import { logger } from "../util/logger";
 
@@ -83,12 +79,7 @@ async function updateSingleFeature(job: UpdateSingleFeatureJob) {
 
   try {
     // Fire the webhook
-    featureUpdated(
-      org,
-      feature,
-      getEnabledEnvironments(feature),
-      feature.project || ""
-    );
+    featureUpdated(org, feature);
 
     // Then, we'll need to recalculate the feature's new nextScheduledUpdate
     const nextScheduledUpdate = getNextScheduledUpdate(

--- a/packages/back-end/src/jobs/updateScheduledFeatures.ts
+++ b/packages/back-end/src/jobs/updateScheduledFeatures.ts
@@ -78,18 +78,18 @@ async function updateSingleFeature(job: UpdateSingleFeatureJob) {
   if (!feature) return;
 
   try {
-    // Fire the webhook
-    featureUpdated(org, feature);
-
-    // Then, we'll need to recalculate the feature's new nextScheduledUpdate
+    // Recalculate the feature's new nextScheduledUpdate
     const nextScheduledUpdate = getNextScheduledUpdate(
       feature.environmentSettings || {}
     );
 
-    // And finally, we'll need to update the feature with the new nextScheduledUpdate
+    // Update the feature in Mongo
     await updateFeature(organization, featureId, {
       nextScheduledUpdate: nextScheduledUpdate,
     });
+
+    // Fire the webhook
+    featureUpdated(org, feature);
   } catch (e) {
     log.error("Failure - " + e.message);
   }

--- a/packages/back-end/src/jobs/webhooks.ts
+++ b/packages/back-end/src/jobs/webhooks.ts
@@ -124,6 +124,7 @@ export async function queueWebhook(
   isFeature?: boolean
 ) {
   if (!CRON_ENABLED) return;
+  if (!environments.length) return;
 
   const webhooks = await WebhookModel.find({
     organization: orgId,

--- a/packages/back-end/src/jobs/webhooks.ts
+++ b/packages/back-end/src/jobs/webhooks.ts
@@ -6,6 +6,7 @@ import { getExperimentOverrides } from "../services/organizations";
 import { getFeatureDefinitions } from "../services/features";
 import { WebhookInterface } from "../../types/webhook";
 import { CRON_ENABLED } from "../util/secrets";
+import { SDKPayloadKey } from "../../types/sdk-payload";
 
 const WEBHOOK_JOB_NAME = "fireWebhook";
 type WebhookJob = Job<{
@@ -119,12 +120,11 @@ export default function (ag: Agenda) {
 
 export async function queueWebhook(
   orgId: string,
-  environments: string[],
-  projects: string[],
+  payloadKeys: SDKPayloadKey[],
   isFeature?: boolean
 ) {
   if (!CRON_ENABLED) return;
-  if (!environments.length) return;
+  if (!payloadKeys.length) return;
 
   const webhooks = await WebhookModel.find({
     organization: orgId,
@@ -135,21 +135,17 @@ export async function queueWebhook(
   for (let i = 0; i < webhooks.length; i++) {
     const webhook: WebhookInterface = webhooks[i];
 
-    // Skip if this webhook is for another project
-    if (webhook.project && !projects.includes(webhook.project)) {
-      continue;
-    }
-    // Legacy webhook without an environment, default to "production" only
+    // Skip if this webhook isn't affected by the changes
     if (
-      webhook.environment === undefined &&
-      !environments.includes("production")
+      !payloadKeys.some(
+        (key) =>
+          key.project === (webhook.project || "") &&
+          key.environment === (webhook.environment || "production")
+      )
     ) {
       continue;
     }
-    // Skip if this webhook is for another environment
-    if (webhook.environment && !environments.includes(webhook.environment)) {
-      continue;
-    }
+
     // Skip if this webhook is only for features and this isn't a feature event
     if (!isFeature && webhook.featuresOnly) {
       continue;

--- a/packages/back-end/src/models/EventModel.ts
+++ b/packages/back-end/src/models/EventModel.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import z from "zod";
-import _ from "lodash";
+import omit from "lodash/omit";
 import mongoose from "mongoose";
 import {
   notificationEventNames,
@@ -71,7 +71,7 @@ type EventDocument<T> = mongoose.Document & EventInterface<T>;
  * @returns
  */
 const toInterface = <T>(doc: EventDocument<T>): EventInterface<T> =>
-  _.omit(doc.toJSON(), ["__v", "_id"]) as EventInterface<T>;
+  omit(doc.toJSON(), ["__v", "_id"]) as EventInterface<T>;
 
 const EventModel = mongoose.model<EventDocument<unknown>>("Event", eventSchema);
 

--- a/packages/back-end/src/models/EventWebHookLogModel.ts
+++ b/packages/back-end/src/models/EventWebHookLogModel.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "crypto";
-import _ from "lodash";
+import omit from "lodash/omit";
 import mongoose from "mongoose";
 import { EventWebHookLogInterface } from "../../types/event-webhook-log";
 
@@ -45,7 +45,7 @@ eventWebHookLogSchema.index({ eventWebHookId: 1 });
 type EventWebHookLogDocument = mongoose.Document & EventWebHookLogInterface;
 
 const toInterface = (doc: EventWebHookLogDocument): EventWebHookLogDocument =>
-  _.omit(doc.toJSON(), ["__v", "_id"]) as EventWebHookLogDocument;
+  omit(doc.toJSON(), ["__v", "_id"]) as EventWebHookLogDocument;
 
 const EventWebHookLogModel = mongoose.model<EventWebHookLogDocument>(
   "EventWebHookLog",

--- a/packages/back-end/src/models/EventWebhookModel.ts
+++ b/packages/back-end/src/models/EventWebhookModel.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "crypto";
 import z from "zod";
-import _ from "lodash";
+import omit from "lodash/omit";
 import md5 from "md5";
 import mongoose from "mongoose";
 import {
@@ -88,7 +88,7 @@ type EventWebHookDocument = mongoose.Document & EventWebHookInterface;
  * @returns
  */
 const toInterface = (doc: EventWebHookDocument): EventWebHookInterface =>
-  _.omit(doc.toJSON(), ["__v", "_id"]) as EventWebHookInterface;
+  omit(doc.toJSON(), ["__v", "_id"]) as EventWebHookInterface;
 
 const EventWebHookModel = mongoose.model<EventWebHookDocument>(
   "EventWebHook",

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -178,23 +178,19 @@ export async function toggleMultipleEnvironments(
 ) {
   const changes: Record<string, boolean> = {};
   let newFeature = cloneDeep(feature);
-  const previousEnvs: string[] = [];
   Object.keys(toggles).forEach((env) => {
     const state = toggles[env];
     const currentState = feature.environmentSettings?.[env]?.enabled ?? false;
     if (currentState !== state) {
       changes[`environmentSettings.${env}.enabled`] = state;
       newFeature = setEnvironmentSettings(newFeature, env, { enabled: state });
-      if (currentState) {
-        previousEnvs.push(env);
-      }
     }
   });
 
   // If there are changes we need to apply
   if (Object.keys(changes).length > 0) {
     const { dateUpdated } = await updateFeature(feature, changes);
-    featureUpdated(organization, { ...newFeature, dateUpdated }, previousEnvs);
+    featureUpdated(organization, feature, { ...newFeature, dateUpdated });
   }
 
   return newFeature;
@@ -365,7 +361,7 @@ export async function publishDraft(
   };
   const newFeature = await updateFeature(feature, changes);
 
-  featureUpdated(organization, newFeature);
+  featureUpdated(organization, feature, newFeature);
   await saveRevision(newFeature);
   return newFeature;
 }

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -15,6 +15,7 @@ import {
   getNextScheduledUpdate,
 } from "../services/features";
 import { upgradeFeatureInterface } from "../util/migrations";
+import { OrganizationInterface } from "../../types/organization";
 import { saveRevision } from "./FeatureRevisionModel";
 
 const featureSchema = new mongoose.Schema({
@@ -162,6 +163,7 @@ function setEnvironmentSettings(
 }
 
 export async function toggleMultipleEnvironments(
+  organization: OrganizationInterface,
   feature: FeatureInterface,
   toggles: Record<string, boolean>
 ) {
@@ -195,18 +197,19 @@ export async function toggleMultipleEnvironments(
       }
     );
 
-    featureUpdated(newFeature, previousEnvs);
+    featureUpdated(organization, newFeature, previousEnvs);
   }
 
   return newFeature;
 }
 
 export async function toggleFeatureEnvironment(
+  organization: OrganizationInterface,
   feature: FeatureInterface,
   environment: string,
   state: boolean
 ) {
-  await toggleMultipleEnvironments(feature, {
+  await toggleMultipleEnvironments(organization, feature, {
     [environment]: state,
   });
 }
@@ -343,6 +346,7 @@ export async function discardDraft(feature: FeatureInterface) {
 }
 
 export async function publishDraft(
+  organization: OrganizationInterface,
   feature: FeatureInterface,
   user: {
     id: string;
@@ -404,7 +408,7 @@ export async function publishDraft(
     ...changes,
   };
 
-  featureUpdated(newFeature);
+  featureUpdated(organization, newFeature);
   await saveRevision(newFeature);
   return newFeature;
 }

--- a/packages/back-end/src/models/SdkPayloadModel.ts
+++ b/packages/back-end/src/models/SdkPayloadModel.ts
@@ -75,10 +75,8 @@ export async function updateSDKPayload({
   project: string;
   environment: string;
   featureDefinitions: Record<string, FeatureDefinition>;
-  dateUpdated?: Date | null;
+  dateUpdated: Date;
 }) {
-  dateUpdated = dateUpdated || new Date();
-
   const contents: SDKPayloadContents = {
     features: featureDefinitions,
   };

--- a/packages/back-end/src/models/SdkPayloadModel.ts
+++ b/packages/back-end/src/models/SdkPayloadModel.ts
@@ -69,13 +69,11 @@ export async function updateSDKPayload({
   project,
   environment,
   featureDefinitions,
-  dateUpdated,
 }: {
   organization: string;
   project: string;
   environment: string;
   featureDefinitions: Record<string, FeatureDefinition>;
-  dateUpdated: Date;
 }) {
   const contents: SDKPayloadContents = {
     features: featureDefinitions,
@@ -89,7 +87,7 @@ export async function updateSDKPayload({
     },
     {
       $set: {
-        dateUpdated,
+        dateUpdated: new Date(),
         deployed: false,
         schemaVersion: LATEST_SDK_PAYLOAD_SCHEMA_VERSION,
         // Contents need to be serialized since they may contain invalid Mongo field keys

--- a/packages/back-end/src/models/SdkPayloadModel.ts
+++ b/packages/back-end/src/models/SdkPayloadModel.ts
@@ -1,0 +1,95 @@
+import mongoose from "mongoose";
+import { FeatureDefinition } from "../../types/api";
+import { SDKPayloadInterface } from "../../types/sdk-payload";
+
+const sdkPayloadSchema = new mongoose.Schema({
+  organization: String,
+  project: String,
+  environment: String,
+  dateUpdated: Date,
+  deployed: Boolean,
+  schemaVersion: Number,
+  payload: String,
+});
+sdkPayloadSchema.index(
+  { organization: 1, project: 1, environment: 1 },
+  { unique: true }
+);
+type SDKPayloadDocument = mongoose.Document & SDKPayloadInterface;
+
+const SDKPayloadModel = mongoose.model<SDKPayloadDocument>(
+  "SdkPayload",
+  sdkPayloadSchema
+);
+
+function toInterface(doc: SDKPayloadDocument): SDKPayloadInterface {
+  return doc.toJSON();
+}
+
+export async function getSDKPayload({
+  organization,
+  project,
+  environment,
+}: {
+  organization: string;
+  project: string;
+  environment: string;
+}) {
+  const doc = await SDKPayloadModel.findOne({
+    organization,
+    project,
+    environment,
+  });
+  return doc ? toInterface(doc) : null;
+}
+
+export async function deleteSDKPayload({
+  organization,
+  project,
+  environment,
+}: {
+  organization: string;
+  project: string;
+  environment: string;
+}) {
+  await SDKPayloadModel.deleteOne({
+    organization,
+    project,
+    environment,
+  });
+}
+
+export async function updateSDKPayload({
+  organization,
+  project,
+  environment,
+  features,
+}: {
+  organization: string;
+  project: string;
+  environment: string;
+  features: Record<string, FeatureDefinition>;
+}) {
+  const now = new Date();
+  await SDKPayloadModel.updateOne(
+    {
+      organization,
+      project,
+      environment,
+    },
+    {
+      $set: {
+        dateUpdated: now,
+        deployed: false,
+        schemaVersion: 1,
+        payload: JSON.stringify({
+          features,
+          dateUpdated: now,
+        }),
+      },
+    },
+    {
+      upsert: true,
+    }
+  );
+}

--- a/packages/back-end/src/models/SdkPayloadModel.ts
+++ b/packages/back-end/src/models/SdkPayloadModel.ts
@@ -26,6 +26,8 @@ function toInterface(doc: SDKPayloadDocument): SDKPayloadInterface {
   return doc.toJSON();
 }
 
+export const SDK_PAYLOAD_SCHEMA_VERSION = 1;
+
 export async function getSDKPayload({
   organization,
   project,
@@ -39,6 +41,7 @@ export async function getSDKPayload({
     organization,
     project,
     environment,
+    schemaVersion: SDK_PAYLOAD_SCHEMA_VERSION,
   });
   return doc ? toInterface(doc) : null;
 }
@@ -63,14 +66,16 @@ export async function updateSDKPayload({
   organization,
   project,
   environment,
-  features,
+  featureDefinitions,
+  dateUpdated,
 }: {
   organization: string;
   project: string;
   environment: string;
-  features: Record<string, FeatureDefinition>;
+  featureDefinitions: Record<string, FeatureDefinition>;
+  dateUpdated?: Date | null;
 }) {
-  const now = new Date();
+  dateUpdated = dateUpdated || new Date();
   await SDKPayloadModel.updateOne(
     {
       organization,
@@ -79,12 +84,11 @@ export async function updateSDKPayload({
     },
     {
       $set: {
-        dateUpdated: now,
+        dateUpdated,
         deployed: false,
-        schemaVersion: 1,
+        schemaVersion: SDK_PAYLOAD_SCHEMA_VERSION,
         payload: JSON.stringify({
-          features,
-          dateUpdated: now,
+          featureDefinitions,
         }),
       },
     },

--- a/packages/back-end/src/routers/saved-group/saved-group.controller.ts
+++ b/packages/back-end/src/routers/saved-group/saved-group.controller.ts
@@ -138,7 +138,7 @@ export const putSavedGroup = async (
 
   // If the values change, we need to invalidate cached feature rules
   if (savedGroup.values !== values) {
-    savedGroupUpdated(org);
+    savedGroupUpdated(org, savedGroup.id);
   }
 
   return res.status(200).json({

--- a/packages/back-end/src/services/auth/index.ts
+++ b/packages/back-end/src/services/auth/index.ts
@@ -113,9 +113,9 @@ export async function processJWT(
   req.checkPermissions = (
     permission: Permission,
     project?: string,
-    envs?: string[]
+    envs?: string[] | Set<string>
   ) => {
-    if (!hasPermission(permission, project, envs)) {
+    if (!hasPermission(permission, project, envs ? [...envs] : undefined)) {
       throw new Error("You do not have permission to complete that action.");
     }
   };

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -48,6 +48,7 @@ import {
   OrganizationSettings,
 } from "../../types/organization";
 import { logger } from "../util/logger";
+import { getSDKPayloadKeys } from "../util/features";
 import {
   getReportVariations,
   reportArgsFromSnapshot,
@@ -799,17 +800,13 @@ export async function experimentUpdated(
   experiment: ExperimentInterface,
   previousProject: string = ""
 ) {
-  const projects: string[] = [];
-  if (previousProject) projects.push(previousProject);
-  if (experiment.project) projects.push(experiment.project);
+  const payloadKeys = getSDKPayloadKeys(
+    new Set(["dev", "production"]),
+    new Set(["", previousProject || "", experiment.project || ""])
+  );
 
   // fire the webhook:
-  await queueWebhook(
-    experiment.organization,
-    ["dev", "production"],
-    projects,
-    false
-  );
+  await queueWebhook(experiment.organization, payloadKeys, false);
 
   // invalidate the CDN
   await queueCDNInvalidate(experiment.organization, (key) => {

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -799,11 +799,15 @@ export async function experimentUpdated(
   experiment: ExperimentInterface,
   previousProject: string = ""
 ) {
+  const projects: string[] = [];
+  if (previousProject) projects.push(previousProject);
+  if (experiment.project) projects.push(experiment.project);
+
   // fire the webhook:
   await queueWebhook(
     experiment.organization,
     ["dev", "production"],
-    [previousProject || "", experiment.project || ""],
+    projects,
     false
   );
 

--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -310,15 +310,11 @@ export async function getFeatureDefinitions(
       project: project || "",
     });
     if (cached) {
-      const { features } = JSON.parse(cached.payload) as {
-        features: Record<string, FeatureDefinition>;
+      const { features } = cached.contents;
+      return {
+        features,
+        dateUpdated: cached.dateUpdated,
       };
-      if (features) {
-        return {
-          features,
-          dateUpdated: cached.dateUpdated,
-        };
-      }
     }
   } catch (e) {
     logger.error(e, "Failed to fetch SDK payload from cache");

--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -21,9 +21,9 @@ import { getSDKPayload, updateSDKPayload } from "../models/SdkPayloadModel";
 import { logger } from "../util/logger";
 import { promiseAllChunks } from "../util/promise";
 import { queueWebhook } from "../jobs/webhooks";
+import { GroupMap } from "../../types/saved-group";
 import { getEnvironments, getOrganizationById } from "./organizations";
 
-export type GroupMap = Map<string, string[] | number[]>;
 export type AttributeMap = Map<string, string>;
 
 function generatePayload(

--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -398,8 +398,11 @@ export function hasMatchingFeatureRule(
   return false;
 }
 
-// eslint-disable-next-line
-export function arrayMove(array: Array<any>, from: number, to: number) {
+export function arrayMove<T>(
+  array: Array<T>,
+  from: number,
+  to: number
+): Array<T> {
   const newArray = array.slice();
   newArray.splice(
     to < 0 ? newArray.length + to : to,

--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -371,20 +371,21 @@ export function getAffectedEnvs(
 export async function featureUpdated(
   organization: OrganizationInterface,
   feature: FeatureInterface,
-  previousEnvironments: string[] = [],
-  previousProject: string = ""
+  newFeature: FeatureInterface
 ) {
-  const currentEnvironments = getEnabledEnvironments(feature);
-
-  const projects: Set<string> = new Set([
-    "",
-    previousProject || "",
-    feature.project || "",
-  ]);
+  // Skip archived features
+  if (feature.archived && newFeature.archived) return;
 
   const environments = new Set([
-    ...currentEnvironments,
-    ...previousEnvironments,
+    ...getEnabledEnvironments(feature),
+    ...getEnabledEnvironments(newFeature),
+  ]);
+
+  const projects = new Set([
+    // Empty string is added since that represents the "All Projects" view, which every feature is part of
+    "",
+    feature.project || "",
+    newFeature.project || "",
   ]);
 
   await refreshSDKPayloadCache(organization, environments, projects);

--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -13,7 +13,7 @@ import {
   FeatureRule,
 } from "../../types/feature";
 import { getAllFeatures } from "../models/FeatureModel";
-import { generatePayload, getFeatureDefinition } from "../util/features";
+import { getFeatureDefinition } from "../util/features";
 import { getAllSavedGroups } from "../models/SavedGroupModel";
 import { OrganizationInterface } from "../../types/organization";
 import { getCurrentEnabledState } from "../util/scheduleRules";
@@ -25,6 +25,26 @@ import { getEnvironments, getOrganizationById } from "./organizations";
 
 export type GroupMap = Map<string, string[] | number[]>;
 export type AttributeMap = Map<string, string>;
+
+function generatePayload(
+  features: FeatureInterface[],
+  environment: string,
+  groupMap: GroupMap
+): Record<string, FeatureDefinition> {
+  const defs: Record<string, FeatureDefinition> = {};
+  features.forEach((feature) => {
+    const def = getFeatureDefinition({
+      feature,
+      environment,
+      groupMap,
+    });
+    if (def) {
+      defs[feature.id] = def;
+    }
+  });
+
+  return defs;
+}
 
 export async function getSavedGroupMap(
   organization: OrganizationInterface

--- a/packages/back-end/src/services/savedGroups.ts
+++ b/packages/back-end/src/services/savedGroups.ts
@@ -1,31 +1,18 @@
 import { OrganizationInterface } from "../../types/organization";
 import { getAllFeatures } from "../models/FeatureModel";
-import { getAffectedEnvironmentsAndProjects } from "../util/features";
-import { getEnvironments } from "./organizations";
-import { hasMatchingFeatureRule, refreshSDKPayloadCache } from "./features";
+import { getAffectedSDKPayloadKeys } from "../util/features";
+import { refreshSDKPayloadCache } from "./features";
 
 export async function savedGroupUpdated(
   org: OrganizationInterface,
   id: string
 ) {
   const allFeatures = await getAllFeatures(org.id);
-  // Only features that reference this saved group id in a condition are affected
-  const changedFeatures = allFeatures
-    .filter((feature) => !feature.archived)
-    .filter((feature) =>
-      hasMatchingFeatureRule(
-        feature,
-        // Do a simple string lookup in the serialized condition
-        // Might have occasional false positives, but it's much faster than full parsing
-        // False positives aren't too bad, they'll just cause the cache to be invalidated more frequently
-        (rule) => rule.condition && rule.condition.includes(id)
-      )
-    );
 
-  const { environments, projects } = getAffectedEnvironmentsAndProjects(
-    changedFeatures,
-    getEnvironments(org).map((e) => e.id)
+  const payloadKeys = getAffectedSDKPayloadKeys(
+    allFeatures,
+    (rule) => rule.condition && rule.condition.includes(id)
   );
 
-  await refreshSDKPayloadCache(org, environments, projects, allFeatures);
+  await refreshSDKPayloadCache(org, payloadKeys, allFeatures);
 }

--- a/packages/back-end/src/services/savedGroups.ts
+++ b/packages/back-end/src/services/savedGroups.ts
@@ -13,15 +13,17 @@ export async function savedGroupUpdated(
 ) {
   const allFeatures = await getAllFeatures(org.id);
   // Only features that reference this saved group id in a condition are affected
-  const changedFeatures = allFeatures.filter((feature) =>
-    hasMatchingFeatureRule(
-      feature,
-      // Do a simple string lookup in the serialized condition
-      // Might have occasional false positives, but it's much faster than full parsing
-      // False positives aren't too bad, they'll just cause the cache to be invalidated more frequently
-      (rule) => rule.condition && rule.condition.includes(id)
-    )
-  );
+  const changedFeatures = allFeatures
+    .filter((feature) => !feature.archived)
+    .filter((feature) =>
+      hasMatchingFeatureRule(
+        feature,
+        // Do a simple string lookup in the serialized condition
+        // Might have occasional false positives, but it's much faster than full parsing
+        // False positives aren't too bad, they'll just cause the cache to be invalidated more frequently
+        (rule) => rule.condition && rule.condition.includes(id)
+      )
+    );
 
   const { environments, projects } = await getAffectedEnvironmentsAndProjects(
     org,

--- a/packages/back-end/src/services/savedGroups.ts
+++ b/packages/back-end/src/services/savedGroups.ts
@@ -1,5 +1,4 @@
 import { OrganizationInterface } from "../../types/organization";
-import { queueWebhook } from "../jobs/webhooks";
 import { getAllFeatures } from "../models/FeatureModel";
 import {
   getAffectedEnvironmentsAndProjects,
@@ -31,5 +30,4 @@ export async function savedGroupUpdated(
   );
 
   await refreshSDKPayloadCache(org, environments, projects, allFeatures);
-  await queueWebhook(org.id, [...environments], [...projects], true);
 }

--- a/packages/back-end/src/services/savedGroups.ts
+++ b/packages/back-end/src/services/savedGroups.ts
@@ -1,33 +1,24 @@
 import { OrganizationInterface } from "../../types/organization";
-import { ProjectInterface } from "../../types/project";
 import { queueWebhook } from "../jobs/webhooks";
-import { findAllProjectsByOrganization } from "../models/ProjectModel";
-import { hasMatchingFeatureRule, refreshSDKPayloadCache } from "./features";
-import { getEnvironments } from "./organizations";
+import { getAllFeatures } from "../models/FeatureModel";
+import {
+  getChangedEnvironmentsAndProjects,
+  refreshSDKPayloadCache,
+} from "./features";
 
 export async function savedGroupUpdated(
   org: OrganizationInterface,
   id: string
 ) {
-  const environments: string[] = await getEnvironments(org).map((env) => {
-    return env.id;
-  });
+  const allFeatures = await getAllFeatures(org.id);
 
-  const projects: string[] = (await findAllProjectsByOrganization(org.id)).map(
-    (project: ProjectInterface) => {
-      return project.id;
-    }
+  // Only features that reference this saved group id in a condition are affected
+  const { environments, projects } = await getChangedEnvironmentsAndProjects(
+    org,
+    allFeatures,
+    (rule) => rule.condition && rule.condition.includes(id)
   );
 
-  await refreshSDKPayloadCache(org, {
-    // Only features that reference this saved group id in a condition are affected
-    filter: (f) =>
-      hasMatchingFeatureRule(
-        f,
-        (r) => !!(r.condition && r.condition.includes(id))
-      ),
-  });
-
-  // Call the webhook to update every feature for every environment and every project.
-  await queueWebhook(org.id, environments, projects, true);
+  await refreshSDKPayloadCache(org, environments, projects, allFeatures);
+  await queueWebhook(org.id, [...environments], [...projects], true);
 }

--- a/packages/back-end/src/services/savedGroups.ts
+++ b/packages/back-end/src/services/savedGroups.ts
@@ -1,10 +1,8 @@
 import { OrganizationInterface } from "../../types/organization";
 import { getAllFeatures } from "../models/FeatureModel";
-import {
-  getAffectedEnvironmentsAndProjects,
-  hasMatchingFeatureRule,
-  refreshSDKPayloadCache,
-} from "./features";
+import { getAffectedEnvironmentsAndProjects } from "../util/features";
+import { getEnvironments } from "./organizations";
+import { hasMatchingFeatureRule, refreshSDKPayloadCache } from "./features";
 
 export async function savedGroupUpdated(
   org: OrganizationInterface,
@@ -24,9 +22,9 @@ export async function savedGroupUpdated(
       )
     );
 
-  const { environments, projects } = await getAffectedEnvironmentsAndProjects(
-    org,
-    changedFeatures
+  const { environments, projects } = getAffectedEnvironmentsAndProjects(
+    changedFeatures,
+    getEnvironments(org).map((e) => e.id)
   );
 
   await refreshSDKPayloadCache(org, environments, projects, allFeatures);

--- a/packages/back-end/src/services/savedGroups.ts
+++ b/packages/back-end/src/services/savedGroups.ts
@@ -2,9 +2,13 @@ import { OrganizationInterface } from "../../types/organization";
 import { ProjectInterface } from "../../types/project";
 import { queueWebhook } from "../jobs/webhooks";
 import { findAllProjectsByOrganization } from "../models/ProjectModel";
+import { hasMatchingFeatureRule, refreshSDKPayloadCache } from "./features";
 import { getEnvironments } from "./organizations";
 
-export async function savedGroupUpdated(org: OrganizationInterface) {
+export async function savedGroupUpdated(
+  org: OrganizationInterface,
+  id: string
+) {
   const environments: string[] = await getEnvironments(org).map((env) => {
     return env.id;
   });
@@ -14,6 +18,15 @@ export async function savedGroupUpdated(org: OrganizationInterface) {
       return project.id;
     }
   );
+
+  await refreshSDKPayloadCache(org, {
+    // Only features that reference this saved group id in a condition are affected
+    filter: (f) =>
+      hasMatchingFeatureRule(
+        f,
+        (r) => !!(r.condition && r.condition.includes(id))
+      ),
+  });
 
   // Call the webhook to update every feature for every environment and every project.
   await queueWebhook(org.id, environments, projects, true);

--- a/packages/back-end/src/types/AuthRequest.ts
+++ b/packages/back-end/src/types/AuthRequest.ts
@@ -17,7 +17,7 @@ interface PermissionFunctions {
   checkPermissions(
     permission: EnvScopedPermission,
     project: string | undefined,
-    envs: string[]
+    envs: string[] | Set<string>
   ): void;
 }
 

--- a/packages/back-end/src/util/features.ts
+++ b/packages/back-end/src/util/features.ts
@@ -206,23 +206,3 @@ export function getFeatureDefinition({
 
   return def;
 }
-
-export function generatePayload(
-  features: FeatureInterface[],
-  environment: string,
-  groupMap: GroupMap
-): Record<string, FeatureDefinition> {
-  const defs: Record<string, FeatureDefinition> = {};
-  features.forEach((feature) => {
-    const def = getFeatureDefinition({
-      feature,
-      environment,
-      groupMap,
-    });
-    if (def) {
-      defs[feature.id] = def;
-    }
-  });
-
-  return defs;
-}

--- a/packages/back-end/src/util/features.ts
+++ b/packages/back-end/src/util/features.ts
@@ -1,8 +1,8 @@
 import omit from "lodash/omit";
 import isEqual from "lodash/isEqual";
 import { FeatureInterface, FeatureValueType } from "../../types/feature";
-import { GroupMap } from "../services/features";
 import { FeatureDefinition, FeatureDefinitionRule } from "../../types/api";
+import { GroupMap } from "../../types/saved-group";
 import { getCurrentEnabledState } from "./scheduleRules";
 
 export function replaceSavedGroupsInCondition(

--- a/packages/back-end/src/util/features.ts
+++ b/packages/back-end/src/util/features.ts
@@ -1,4 +1,9 @@
+import omit from "lodash/omit";
+import isEqual from "lodash/isEqual";
+import { FeatureInterface, FeatureValueType } from "../../types/feature";
 import { GroupMap } from "../services/features";
+import { FeatureDefinition, FeatureDefinitionRule } from "../../types/api";
+import { getCurrentEnabledState } from "./scheduleRules";
 
 export function replaceSavedGroupsInCondition(
   condition: string,
@@ -15,4 +20,209 @@ export function replaceSavedGroupsInCondition(
   );
 
   return newString;
+}
+
+// If changes to a feature are going to affect it's value in at least one environment
+export function changesAffectFeatureValue(
+  feature: FeatureInterface,
+  updatedFeature: FeatureInterface
+) {
+  // If the feature was and still is archived, then the changes don't matter
+  if (feature.archived && updatedFeature.archived) return false;
+
+  const ignoredFields: (keyof FeatureInterface)[] = [
+    "description",
+    "owner",
+    "dateUpdated",
+    "tags",
+    "revision",
+    "draft",
+  ];
+
+  return !isEqual(
+    omit(feature, ignoredFields),
+    omit(updatedFeature, ignoredFields)
+  );
+}
+
+export function getAffectedEnvs(
+  feature: FeatureInterface,
+  changedEnvs?: string[]
+): string[] {
+  const settings = feature.environmentSettings;
+  if (!settings) return [];
+
+  if (!changedEnvs) {
+    changedEnvs = Object.keys(settings);
+  }
+
+  return changedEnvs.filter((e) => settings[e]?.enabled);
+}
+
+// When features change, determine which environments/projects are affected
+// e.g. If a feature is disabled in all environments, then it's project won't be affected
+export function getAffectedEnvironmentsAndProjects(
+  changedFeatures: FeatureInterface[],
+  allowedEnvs?: string[]
+): {
+  projects: Set<string>;
+  environments: Set<string>;
+} {
+  // An empty string for projects means "All Projects", so that one is always affected
+  const projects: Set<string> = new Set([""]);
+  const environments: Set<string> = new Set();
+
+  // Determine which specific environments/projects are affected by the changed features
+  changedFeatures.forEach((feature) => {
+    const affectedEnvs = getAffectedEnvs(feature, allowedEnvs);
+    if (affectedEnvs.length > 0) {
+      if (feature.project) projects.add(feature.project);
+      affectedEnvs.forEach((env) => {
+        environments.add(env);
+      });
+    }
+  });
+
+  return {
+    projects,
+    environments,
+  };
+}
+
+// eslint-disable-next-line
+export function getJSONValue(type: FeatureValueType, value: string): any {
+  if (type === "json") {
+    try {
+      return JSON.parse(value);
+    } catch (e) {
+      return null;
+    }
+  }
+  if (type === "number") return parseFloat(value) || 0;
+  if (type === "string") return value;
+  if (type === "boolean") return value === "false" ? false : true;
+  return null;
+}
+
+export function roundVariationWeight(num: number): number {
+  return Math.round(num * 10000) / 10000;
+}
+
+export function getFeatureDefinition({
+  feature,
+  environment,
+  groupMap,
+  useDraft = false,
+}: {
+  feature: FeatureInterface;
+  environment: string;
+  groupMap: GroupMap;
+  useDraft?: boolean;
+}): FeatureDefinition | null {
+  const settings = feature.environmentSettings?.[environment];
+
+  // Don't include features which are disabled for this environment
+  if (!settings || !settings.enabled || feature.archived) {
+    return null;
+  }
+
+  const draft = feature.draft;
+  if (!draft?.active) {
+    useDraft = false;
+  }
+
+  const defaultValue = useDraft
+    ? draft?.defaultValue ?? feature.defaultValue
+    : feature.defaultValue;
+
+  const rules = useDraft
+    ? draft?.rules?.[environment] ?? settings.rules
+    : settings.rules;
+
+  const def: FeatureDefinition = {
+    defaultValue: getJSONValue(feature.valueType, defaultValue),
+    rules:
+      rules
+        ?.filter((r) => r.enabled)
+        ?.filter((r) => {
+          return getCurrentEnabledState(r.scheduleRules || [], new Date());
+        })
+        ?.map((r) => {
+          const rule: FeatureDefinitionRule = {};
+          if (r.condition && r.condition !== "{}") {
+            try {
+              rule.condition = JSON.parse(
+                replaceSavedGroupsInCondition(r.condition, groupMap)
+              );
+            } catch (e) {
+              // ignore condition parse errors here
+            }
+          }
+
+          if (r.type === "force") {
+            rule.force = getJSONValue(feature.valueType, r.value);
+          } else if (r.type === "experiment") {
+            rule.variations = r.values.map((v) =>
+              getJSONValue(feature.valueType, v.value)
+            );
+
+            rule.coverage = r.coverage;
+
+            rule.weights = r.values
+              .map((v) => v.weight)
+              .map((w) => (w < 0 ? 0 : w > 1 ? 1 : w))
+              .map((w) => roundVariationWeight(w));
+
+            if (r.trackingKey) {
+              rule.key = r.trackingKey;
+            }
+            if (r.hashAttribute) {
+              rule.hashAttribute = r.hashAttribute;
+            }
+            if (r?.namespace && r.namespace.enabled && r.namespace.name) {
+              rule.namespace = [
+                r.namespace.name,
+                // eslint-disable-next-line
+                parseFloat(r.namespace.range[0] as any) || 0,
+                // eslint-disable-next-line
+                parseFloat(r.namespace.range[1] as any) || 0,
+              ];
+            }
+          } else if (r.type === "rollout") {
+            rule.force = getJSONValue(feature.valueType, r.value);
+            rule.coverage =
+              r.coverage > 1 ? 1 : r.coverage < 0 ? 0 : r.coverage;
+
+            if (r.hashAttribute) {
+              rule.hashAttribute = r.hashAttribute;
+            }
+          }
+          return rule;
+        }) ?? [],
+  };
+  if (def.rules && !def.rules.length) {
+    delete def.rules;
+  }
+
+  return def;
+}
+
+export function generatePayload(
+  features: FeatureInterface[],
+  environment: string,
+  groupMap: GroupMap
+): Record<string, FeatureDefinition> {
+  const defs: Record<string, FeatureDefinition> = {};
+  features.forEach((feature) => {
+    const def = getFeatureDefinition({
+      feature,
+      environment,
+      groupMap,
+    });
+    if (def) {
+      defs[feature.id] = def;
+    }
+  });
+
+  return defs;
 }

--- a/packages/back-end/test/features.test.ts
+++ b/packages/back-end/test/features.test.ts
@@ -548,21 +548,40 @@ describe("Detecting Feature Changes", () => {
         environment: "dev",
       },
     ]);
-
-    // If an environment was disabled before and after the change, then it won't be included
-    feature.environmentSettings.dev.enabled = false;
-    expect(
-      getSDKPayloadKeysByDiff(feature, {
-        ...updatedFeature,
-        defaultValue: "false",
-      })
-    ).toEqual([
-      {
-        project: "",
-        environment: "production",
-      },
-    ]);
   });
+});
+
+describe("Changes are ignored when archived or disabled", () => {
+  const feature = cloneDeep(baseFeature);
+  const updatedFeature = cloneDeep(baseFeature);
+
+  // Ignore changes when archived before and after
+  expect(
+    getSDKPayloadKeysByDiff(
+      {
+        ...feature,
+        archived: true,
+      },
+      {
+        ...updatedFeature,
+        archived: true,
+        project: "43280943fjdskalfja",
+      }
+    )
+  ).toEqual([]);
+
+  // Ignore environment changes if it's disabled before and after
+  feature.environmentSettings.dev.enabled = false;
+  updatedFeature.environmentSettings.dev.enabled = false;
+  updatedFeature.environmentSettings.dev.rules = [
+    {
+      type: "force",
+      description: "",
+      id: "",
+      value: "true",
+    },
+  ];
+  expect(getSDKPayloadKeysByDiff(feature, updatedFeature)).toEqual([]);
 });
 
 describe("SDK Payloads", () => {

--- a/packages/back-end/types/feature.d.ts
+++ b/packages/back-end/types/feature.d.ts
@@ -38,7 +38,7 @@ export interface FeatureInterface {
   valueType: FeatureValueType;
   defaultValue: string;
   tags?: string[];
-  environmentSettings?: Record<string, FeatureEnvironment>;
+  environmentSettings: Record<string, FeatureEnvironment>;
   draft?: FeatureDraftChanges;
   revision?: {
     version: number;

--- a/packages/back-end/types/saved-group.d.ts
+++ b/packages/back-end/types/saved-group.d.ts
@@ -8,3 +8,5 @@ export interface SavedGroupInterface {
   dateUpdated: Date;
   dateCreated: Date;
 }
+
+export type GroupMap = Map<string, string[] | number[]>;

--- a/packages/back-end/types/sdk-payload.ts
+++ b/packages/back-end/types/sdk-payload.ts
@@ -21,3 +21,8 @@ export type SDKStringifiedPayloadInterface = Omit<
 > & {
   contents: string;
 };
+
+export type SDKPayloadKey = {
+  environment: string;
+  project: string;
+};

--- a/packages/back-end/types/sdk-payload.ts
+++ b/packages/back-end/types/sdk-payload.ts
@@ -1,9 +1,23 @@
+import { FeatureDefinition } from "./api";
+
+// If this changes, also increment the LATEST_SDK_PAYLOAD_SCHEMA_VERSION constant
+export type SDKPayloadContents = {
+  features: Record<string, FeatureDefinition>;
+};
+
 export interface SDKPayloadInterface {
   organization: string;
   project: string;
   environment: string;
   dateUpdated: Date;
   deployed: boolean;
-  schemaVersion: 1;
-  payload: string;
+  schemaVersion: number;
+  contents: SDKPayloadContents;
 }
+
+export type SDKStringifiedPayloadInterface = Omit<
+  SDKPayloadInterface,
+  "contents"
+> & {
+  contents: string;
+};

--- a/packages/back-end/types/sdk-payload.ts
+++ b/packages/back-end/types/sdk-payload.ts
@@ -1,0 +1,9 @@
+export interface SDKPayloadInterface {
+  organization: string;
+  project: string;
+  environment: string;
+  dateUpdated: Date;
+  deployed: boolean;
+  schemaVersion: 1;
+  payload: string;
+}

--- a/packages/front-end/pages/saved-groups.tsx
+++ b/packages/front-end/pages/saved-groups.tsx
@@ -73,7 +73,7 @@ export default function SavedGroupsPage() {
         if (feature.environmentSettings[env]?.rules) {
           feature.environmentSettings[env].rules.forEach((rule) => {
             savedGroups.forEach((group) => {
-              if (rule.condition.includes(group.id)) {
+              if (rule.condition?.includes(group.id)) {
                 map[group.id] = map[group.id] || new Set();
                 map[group.id].add(feature.id);
               }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8383,6 +8383,11 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
+date-fns-tz@^1.3.7:
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/date-fns-tz/-/date-fns-tz-1.3.7.tgz#e8e9d2aaceba5f1cc0e677631563081fdcb0e69a"
+  integrity sha512-1t1b8zyJo+UI8aR+g3iqr5fkUHWpd58VBx8J/ZSQ+w7YrGlw80Ag4sA86qkfCXRBLmMc4I2US+aPMd4uKvwj5g==
+
 date-fns@^2.15.0, date-fns@^2.29.1:
   version "2.29.3"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.3.tgz#27402d2fc67eb442b511b70bbdf98e6411cd68a8"


### PR DESCRIPTION
### Overview

SDK Endpoint payloads are regenerated from scratch on every request to `/api/features/...`.  This is expensive and slow (averaging ~200ms in production).  GrowthBook Cloud has a CDN in front, which helps, but the cache hit ratio is <95%, so there are still a significant number of requests serving directly from the API.  Plus, self-hosted deployments do not have a CDN by default and thus suffer from slow performance unless custom caching is implemented.

This PR persists generated SDK endpoint payloads in Mongo.  Every time a feature is updated, the cache entries are immediately updated to match.  The SDK endpoints (as well as webhooks) will prefer the cached copy in Mongo and fallback to the existing method.

This also sets the stage for future performance enhancements such as S3 caching and a Proxy Server

### Changes
- New SDKPayloads collection in Mongo to store cached feature definition payloads for each project/environment combo
- Add cache layer to SDK endpoints and webhooks to use this new Mongo collection when possible
- Consolidate all `onFeatureUpdate` logic into a single function call and moved it to the FeatureModel methods so we don't forget them in the future.  Also added `onFeatureCreate` and `onFeatureDelete` placeholder methods.
- Add smarter logic to determine exactly which environment/project pairs are affected by a change
- When updating a savedGroup, check which rules are actually referencing it instead of just marking every feature and every environment as updated
- Add unit tests for the SDK payload generation logic and helper methods

### Benchmarks

When hitting an SDK endpoint locally:
- Old: **80ms**
- New: **16ms**

Production:
- Old: **200ms**
- New: ??? (expected: 40ms)

### Manual Testing
- [x] SDK payload cache is populated when hitting the SDK endpoint
- [x] Changing a feature updates the SDK payload cache, fires webhooks, and logs the event in Mongo
  - [x] Creating a feature
  - [x] Toggling a feature in an evironment
  - [x] Deleting a feature
  - [x] Archiving a feature
  - [x] Updating a saved group
  - [x] Adding a rule
  - [x] Editing a rule
  - [x] Re-ordering rules
  - [x] Deleting a rule
  - [x] Publishing
  - [x] Discarding a draft
  - [x] Toggling via the REST api
  - [x] Scheduled rule cronjob
- [x] SDK payload cache not updated while feature is archived
- [x] SDK payload cache not updated for an environment when the feature i s toggled off
- [x] SDK payload cache updated when a feature is in a project