### PR TITLE
Add rootDir to tsconfig

### DIFF
--- a/packages/back-end/tsconfig.json
+++ b/packages/back-end/tsconfig.json
@@ -12,7 +12,8 @@
     "strictNullChecks": true,
     "strictBindCallApply": true,
     "strictPropertyInitialization": true,
-    "incremental": true
+    "incremental": true,
+    "rootDir": "src"
   },
   "include": ["src/**/*", "types/**/*.d.ts", "typings/**/*.d.ts"]
 }


### PR DESCRIPTION
Addresses an issue that was [raised in Slack](https://growthbookapp.slack.com/archives/C03M46VMGTB/p1672604214080609):

> I accidentally added a file to packages/back-end/types with a .ts  extension instead of .d.ts.  That caused the Typescript compiler to add another level of directory nesting to dist .

This PR adds a `rootDir` setting to the `back-end` tsconfig.json, which will enforce the longest path possible for any input files when compiling - by default this is simply the longest filepath it encounters while crawling through the codebase. However setting `rootDir` will enforce that it stays under the specified directory (though does not interrupt operations dictated by `includes`, `excludes`, or `files` settings in the tsconfig.json).

Tested against the offending commit (a36243bf527213ab075eec7b91f2ca4a45eebf2d) which broke the build


<img width="1711" alt=" " src="https://user-images.githubusercontent.com/2374625/210374822-cef35a6a-bbe3-44bf-b5a4-b837522fa49f.png">

