### PR TITLE
Add support for feature.created and feature.deleted for events and event webhooks

### DIFF
--- a/packages/back-end/src/events/base-events.ts
+++ b/packages/back-end/src/events/base-events.ts
@@ -4,7 +4,9 @@ import { NotificationEventPayload } from "./base-types";
 export type FeatureCreatedNotificationEvent = NotificationEventPayload<
   "feature.created",
   "feature",
-  FeatureInterface
+  {
+    current: FeatureInterface;
+  }
 >;
 
 export type FeatureUpdatedNotificationEvent = NotificationEventPayload<

--- a/packages/back-end/src/events/handlers/webhooks/event-webhooks-utils.ts
+++ b/packages/back-end/src/events/handlers/webhooks/event-webhooks-utils.ts
@@ -108,7 +108,7 @@ const getPayloadForFeatureCreated = ({
   ...event,
   data: {
     ...event.data,
-    feature: getApiFeatureObj(event.data, organization, savedGroupMap),
+    feature: getApiFeatureObj(event.data.current, organization, savedGroupMap),
   },
 });
 

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -169,7 +169,9 @@ async function logFeatureCreatedEvent(
   const payload: FeatureCreatedNotificationEvent = {
     object: "feature",
     event: "feature.created",
-    data: feature,
+    data: {
+      current: feature,
+    },
   };
 
   const emittedEvent = await createEvent(organization.id, payload);

--- a/packages/front-end/components/EventsPage/utils.ts
+++ b/packages/front-end/components/EventsPage/utils.ts
@@ -20,13 +20,13 @@ export const getEventText = (
   switch (event.data.event) {
     case "feature.created":
       return `The feature ${
-        ((event.data as unknown) as FeatureCreatedNotificationEvent).data.id ||
-        "(unknown)"
+        ((event.data as unknown) as FeatureCreatedNotificationEvent).data
+          ?.current?.id || "(unknown)"
       } was created`;
     case "feature.updated":
       return `The feature ${
         ((event.data as unknown) as FeatureUpdatedNotificationEvent).data
-          ?.current?.id
+          ?.current?.id || "(unknown)"
       } was updated`;
     case "feature.deleted":
       return `The feature ${


### PR DESCRIPTION
### Features and Changes

Logs feature created and deleted events in the event logs. This automatically works with event webhooks too.

### Dependencies

n/a

### Testing

Enable the code on the webhooks page [here](https://github.com/growthbook/growthbook/blob/main/packages/front-end/pages/settings/webhooks/index.tsx#L33-L35) so you can see the event webhooks section.

Create an event webhook that watches `feature.created` and another that watches `feature.deleted`. You can point to any URL like `http://localhost:3100/` and you will still see the failed runs.

Perform the following actions to generate events and web hook runs:

1. Create a feature
2. Delete that feature

Verify that events were created at http://localhost:3000/events

![image](https://user-images.githubusercontent.com/113377031/210449766-9b0d5448-a03c-4827-859e-9374f2ff3a74.png)

Verify that the web hook runs occurred at http://localhost:3000/settings/webhooks

![image](https://user-images.githubusercontent.com/113377031/210449848-9b7ad6af-ec37-4f32-9074-713996eef258.png)

In the above screenshot you'll see separate web hooks I created for each event type.

Clicking on each will show the attempted runs, which should fail unless you specified valid webhook endpoints.

![image](https://user-images.githubusercontent.com/113377031/210449982-f67cf185-29f6-48c8-8ea0-63a9a9682ff9.png)

![image](https://user-images.githubusercontent.com/113377031/210450025-05ebcf6e-0c90-4173-acd1-de2c09112241.png)

All events for a single web hook:

![image](https://user-images.githubusercontent.com/113377031/210451656-ff518095-5baf-48d7-b289-14f91fb22dd4.png)
