### PR TITLE
Fixes an issue that allows a user to edit an existing feature rule wi…

### DIFF
--- a/packages/front-end/components/Features/ScheduleInputs.tsx
+++ b/packages/front-end/components/Features/ScheduleInputs.tsx
@@ -56,6 +56,19 @@ export default function ScheduleInputs(props: Props) {
           value={props.scheduleToggleEnabled}
           setValue={(v) => {
             props.setScheduleToggleEnabled(v);
+
+            if (!rules.length) {
+              setRules([
+                {
+                  enabled: true,
+                  timestamp: null,
+                },
+                {
+                  enabled: false,
+                  timestamp: null,
+                },
+              ]);
+            }
           }}
           disabled={!canScheduleFeatureFlags}
           type="featureValue"


### PR DESCRIPTION
### Features and Changes

This PR ensures that users can edit existing feature flags that do not currently have any schedule rules.

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

- [x] Open an existing feature flag, and ensure that if you have the ability to create schedule rules, you can create a new schedule rule set from scratch.
- [x] Double check no new regressions were introduced with this change, including, making sure that a user can still edit an existing schedule rule set, and disabling the schedule rule toggle overrides any schedule rules.
- [x] Ensure that you can create a feature from scratch with feature rules.
