### PR TITLE
"Free while in beta" messaging for event webhooks

### DIFF
--- a/packages/front-end/components/EventWebHooks/EventWebHookList/EventWebHookList.tsx
+++ b/packages/front-end/components/EventWebHooks/EventWebHookList/EventWebHookList.tsx
@@ -39,11 +39,21 @@ export const EventWebHookList: FC<EventWebHookListProps> = ({
       ) : null}
 
       <div className="mb-4">
-        <h1>Event Webhooks</h1>
+        <div className="d-flex justify-space-between align-items-center">
+          <span className="badge badge-purple text-uppercase mr-2">Beta</span>
+          <h1>Event Webhooks</h1>
+        </div>
         <p>
           Event Webhooks are event-based, and allow you to monitor specific
           events.
         </p>
+        <div className="alert alert-premium">
+          <h4>Free while in Beta</h4>
+          <p className="mb-0">
+            This feature will be free while we build it out and work out the
+            bugs.
+          </p>
+        </div>
       </div>
 
       {/* Feedback messages */}

--- a/packages/front-end/styles/global.scss
+++ b/packages/front-end/styles/global.scss
@@ -2063,7 +2063,6 @@ td.disabled {
     var(--alert-premium-background-gradient-1),
     var(--alert-premium-background-gradient-2)
   );
-  border-color: var(--border-color-100);
 
   .alert-link {
     color: var(--text-color-main);


### PR DESCRIPTION
### Features and Changes

Adds premium-related styling (badge, alert) for the event webhooks. 

I also removed the grey border around the `alert-premium` as that seems to look better.


### Dependencies

n/a

### Testing

Visit the Webhooks tab.

### Screenshots

![CleanShot 2023-01-10 at 13 21 01@2x](https://user-images.githubusercontent.com/113377031/211665068-c8833e30-a330-4a73-8769-d78cd8f5d406.png)

![CleanShot 2023-01-10 at 13 21 53@2x](https://user-images.githubusercontent.com/113377031/211665186-5345625f-ae46-49e7-94df-26071435e46e.png)
