### PR TITLE
Upgrade button showing for enterprise/pro plans

### DIFF
--- a/packages/front-end/components/Marketing/UpgradeLabel.tsx
+++ b/packages/front-end/components/Marketing/UpgradeLabel.tsx
@@ -21,9 +21,7 @@ export default function UpgradeLabel({
 
   const { hasCommercialFeature } = useUser();
 
-  const showUpgradeCTA =
-    !hasCommercialFeature(commercialFeature) ||
-    !process.env.HIDE_GROWTHBOOK_UPGRADE_CTAS;
+  const showUpgradeCTA = !hasCommercialFeature(commercialFeature);
 
   const headerMessage = isCloud()
     ? `Please upgrade your plan to ${upgradeMessage}.`

--- a/packages/front-end/components/Marketing/UpgradeLabel.tsx
+++ b/packages/front-end/components/Marketing/UpgradeLabel.tsx
@@ -21,7 +21,10 @@ export default function UpgradeLabel({
 
   const { hasCommercialFeature } = useUser();
 
-  const showUpgradeCTA = !hasCommercialFeature(commercialFeature);
+  // Only show if they don't have the feature and they don't have the env variable to hide it
+  const showUpgradeCTA =
+    !hasCommercialFeature(commercialFeature) &&
+    !process.env.HIDE_GROWTHBOOK_UPGRADE_CTAS;
 
   const headerMessage = isCloud()
     ? `Please upgrade your plan to ${upgradeMessage}.`


### PR DESCRIPTION
### Features and Changes

This PR fixes a logical bug where enterprise/premium accounts were seeing the upgrade button when they shouldn't have.

### Testing

- [x] Within an enterprise account, go to build a schedule rule and confirm the upgrade button is not displayed.
- [x] Within a premium account, go to build a schedule rule and confirm the upgrade button is not displayed.
- [x] Confirm no new regressions were introduced - specifically check that both account types above can create schedule rules without issue.
- [x] Confirm that non enterprise & premium accounts DO see the upgrade button and tooltip and can not create schedule rules.
