### PR TITLE
Visual editor - JS endpoint - Fix regex

### DIFF
--- a/packages/back-end/src/controllers/config.ts
+++ b/packages/back-end/src/controllers/config.ts
@@ -84,7 +84,7 @@ type CompressedExperimentOptions = {
 const baseScript = fs
   .readFileSync(path.join(__dirname, "..", "templates", "javascript.js"))
   .toString("utf-8")
-  .replace(/.*eslint-.*\n/g, "")
+  .replace(/\/\*\s*eslint-.*\*\//, "")
   .replace(/\n\/\/.*/g, "");
 
 export async function getExperimentsScript(


### PR DESCRIPTION
The endpoint that generates a JS script for the visual editor has logic to strip out `/* eslint-disable */` comments out from the template script, however `swc` will compile the script and move things around in such a way that the regex deletes extraneous code and makes the JS syntax invalid

This PR updates the regex used in the replace call to strip out eslint comments so that it does not disturb the syntax

Template script before being compiled (note: newline between eslint comment and initial JS syntax):
<img width="558" alt="image" src="https://user-images.githubusercontent.com/2374625/211913224-561dff97-212a-4d29-a248-41fa2b425eb5.png">

Template script after being compiled (aforementioned newline is gone; this makes it susceptible to being replaced by old regex pattern):
<img width="483" alt="image" src="https://user-images.githubusercontent.com/2374625/211913317-c2f96abc-9598-4afd-8bfa-effe98924620.png">

The script generated in development is broken (notice there is no arrow function declaration before the code starts)

<img width="842" alt="image" src="https://user-images.githubusercontent.com/2374625/212137528-9ed07aac-661b-4165-b778-db8e79f8637b.png">

In prod this does not happen because we use `tsc` to compile rather than `swc`