### PR TITLE
Frequentist - Configure stats engine at project and experiment level

### DIFF
--- a/packages/back-end/src/controllers/admin.ts
+++ b/packages/back-end/src/controllers/admin.ts
@@ -369,7 +369,7 @@ export async function addSampleData(
       }
 
       // Refresh results
-      await createSnapshot(exp, 0, org, null, false, org.settings?.statsEngine);
+      await createSnapshot(exp, 0, org, null, false);
     })
   );
 

--- a/packages/back-end/src/controllers/datasources.ts
+++ b/packages/back-end/src/controllers/datasources.ts
@@ -192,6 +192,7 @@ Revenue did not reach 95% significance, but the risk is so low it doesn't seem w
           },
         ],
       },
+      // TODO determine stats engine: experiment > project > org
       statsEngine
     );
   }

--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -1431,7 +1431,6 @@ export async function postSnapshot(
   req.checkPermissions("runQueries", "");
 
   const { org } = getOrgFromReq(req);
-  const statsEngine = org.settings?.statsEngine;
 
   const useCache = !req.query["force"];
 
@@ -1450,6 +1449,10 @@ export async function postSnapshot(
     });
     return;
   }
+
+  // TODO
+  // const statsEngine = exp.statsEngine ?? org.settings?.statsEngine;
+  const statsEngine = org.settings?.statsEngine;
 
   if (!exp.phases[phase]) {
     res.status(404).json({

--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -1313,6 +1313,7 @@ export async function previewManualSnapshot(
   }
 
   try {
+    // TODO determine stats engine: experiment > project > org
     const data = await getManualSnapshotData(
       exp,
       phaseIndex,
@@ -1364,6 +1365,7 @@ export async function getSnapshotStatus(
         getReportVariations(experiment, phase),
         snapshot.dimension || undefined,
         queryData,
+        // TODO determine stats engine: experiment > project > org
         org.settings?.statsEngine
       ),
     async (updates, results, error) => {
@@ -1450,8 +1452,7 @@ export async function postSnapshot(
     return;
   }
 
-  // TODO
-  // const statsEngine = exp.statsEngine ?? org.settings?.statsEngine;
+  // TODO determine stats engine: experiment > project > org
   const statsEngine = org.settings?.statsEngine;
 
   if (!exp.phases[phase]) {
@@ -1475,6 +1476,7 @@ export async function postSnapshot(
         phase,
         users,
         metrics,
+        // TODO determine stats engine: experiment > project > org
         statsEngine
       );
       res.status(200).json({
@@ -1520,8 +1522,7 @@ export async function postSnapshot(
       phase,
       org,
       dimension || null,
-      useCache,
-      org.settings?.statsEngine
+      useCache
     );
     await req.audit({
       event: "experiment.refresh",

--- a/packages/back-end/src/controllers/reports.ts
+++ b/packages/back-end/src/controllers/reports.ts
@@ -197,6 +197,8 @@ export async function refreshReport(
 
   const useCache = !req.query["force"];
 
+  // TODO determine stats engine: experiment > project > org
+  // TODO pass org????????
   await runReport(report, useCache, org.settings?.statsEngine);
 
   return res.status(200).json({
@@ -238,6 +240,7 @@ export async function putReport(
   await updateReport(org.id, req.params.id, updates);
 
   if (needsRun) {
+    // TODO pass org????????????
     await runReport(
       {
         ...report,
@@ -273,6 +276,7 @@ export async function getReportStatus(
           report.args.variations,
           report.args.dimension || "",
           queryData,
+          // TODO determine stats engine: experiment > project > org
           org.settings?.statsEngine
         );
       }

--- a/packages/back-end/src/jobs/updateExperimentResults.ts
+++ b/packages/back-end/src/jobs/updateExperimentResults.ts
@@ -175,8 +175,7 @@ async function updateSingleExperiment(job: UpdateSingleExpJob) {
       experiment.phases.length - 1,
       organization,
       null,
-      false,
-      organization.settings?.statsEngine
+      false
     );
 
     await new Promise<void>((resolve, reject) => {
@@ -195,6 +194,7 @@ async function updateSingleExperiment(job: UpdateSingleExpJob) {
               getReportVariations(experiment, phase),
               undefined,
               queryData,
+              // TODO determine stats engine: experiment > project > org
               organization.settings?.statsEngine
             );
           },

--- a/packages/back-end/src/models/ExperimentModel.ts
+++ b/packages/back-end/src/models/ExperimentModel.ts
@@ -96,6 +96,7 @@ const experimentSchema = new mongoose.Schema({
   nextSnapshotAttempt: Date,
   autoSnapshots: Boolean,
   ideaSource: String,
+  statsEngine: String,
 });
 
 export const ExperimentModel = mongoose.model<ExperimentDocument>(

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -45,8 +45,8 @@ import { EXPERIMENT_REFRESH_FREQUENCY } from "../util/secrets";
 import {
   ExperimentUpdateSchedule,
   OrganizationInterface,
-  OrganizationSettings,
 } from "../../types/organization";
+import { StatsEngine } from "../../types/stats";
 import { logger } from "../util/logger";
 import { getSDKPayloadKeys } from "../util/features";
 import {
@@ -519,7 +519,7 @@ export async function createManualSnapshot(
   metrics: {
     [key: string]: MetricStats[];
   },
-  statsEngine?: OrganizationSettings["statsEngine"]
+  statsEngine?: StatsEngine
 ) {
   const { srm, variations } = await getManualSnapshotData(
     experiment,
@@ -615,7 +615,7 @@ export async function createSnapshot(
   organization: OrganizationInterface,
   dimensionId: string | null,
   useCache: boolean = false,
-  statsEngine: OrganizationSettings["statsEngine"]
+  statsEngine: StatsEngine | undefined
 ) {
   const phase = experiment.phases[phaseIndex];
   if (!phase) {

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -614,8 +614,7 @@ export async function createSnapshot(
   phaseIndex: number,
   organization: OrganizationInterface,
   dimensionId: string | null,
-  useCache: boolean = false,
-  statsEngine: StatsEngine | undefined
+  useCache: boolean = false
 ) {
   const phase = experiment.phases[phaseIndex];
   if (!phase) {
@@ -642,7 +641,7 @@ export async function createSnapshot(
     segment: experiment.segment || "",
     queryFilter: experiment.queryFilter || "",
     skipPartialData: experiment.skipPartialData || false,
-    statsEngine,
+    statsEngine: experiment.statsEngine,
   };
 
   const nextUpdate = determineNextDate(
@@ -667,6 +666,7 @@ export async function createSnapshot(
     experiment.organization,
     reportArgsFromSnapshot(experiment, data),
     useCache,
+    // TODO determine stats engine: experiment > project > org
     statsEngine
   );
 

--- a/packages/back-end/src/services/reports.ts
+++ b/packages/back-end/src/services/reports.ts
@@ -10,7 +10,7 @@ import { SegmentModel } from "../models/SegmentModel";
 import { SegmentInterface } from "../../types/segment";
 import { getDataSourceById } from "../models/DataSourceModel";
 import { ExperimentInterface, ExperimentPhase } from "../../types/experiment";
-import { OrganizationSettings } from "../../types/organization";
+import { StatsEngine } from "../../types/stats";
 import { updateReport } from "../models/ReportModel";
 import { ExperimentSnapshotInterface } from "../../types/experiment-snapshot";
 import { expandDenominatorMetrics } from "../util/sql";
@@ -65,7 +65,7 @@ export async function startExperimentAnalysis(
   organization: string,
   args: ExperimentReportArgs,
   useCache: boolean,
-  statsEngine: OrganizationSettings["statsEngine"]
+  statsEngine: StatsEngine | undefined
 ) {
   const metricObjs = await getMetricsByOrganization(organization);
   const metricMap = new Map<string, MetricInterface>();
@@ -217,7 +217,7 @@ export async function startExperimentAnalysis(
 export async function runReport(
   report: ReportInterface,
   useCache: boolean = true,
-  statsEngine: OrganizationSettings["statsEngine"]
+  statsEngine: StatsEngine | undefined
 ) {
   const updates: Partial<ReportInterface> = {};
 

--- a/packages/back-end/src/services/stats.ts
+++ b/packages/back-end/src/services/stats.ts
@@ -1,7 +1,7 @@
 import { promisify } from "util";
 import { PythonShell } from "python-shell";
 import { MetricInterface } from "../../types/metric";
-import { ExperimentMetricAnalysis } from "../../types/stats";
+import { ExperimentMetricAnalysis, StatsEngine } from "../../types/stats";
 import {
   ExperimentMetricQueryResponse,
   ExperimentResults,
@@ -15,7 +15,6 @@ import { getMetricsByOrganization } from "../models/MetricModel";
 import { promiseAllChunks } from "../util/promise";
 import { checkSrm } from "../util/stats";
 import { logger } from "../util/logger";
-import { OrganizationSettings } from "../../types/organization";
 import { QueryMap } from "./queries";
 
 export const MAX_DIMENSIONS = 20;
@@ -25,7 +24,7 @@ export async function analyzeExperimentMetric(
   metric: MetricInterface,
   rows: ExperimentMetricQueryResponse,
   maxDimensions: number,
-  statsEngine: OrganizationSettings["statsEngine"] = "bayesian"
+  statsEngine: StatsEngine = "bayesian"
 ): Promise<ExperimentMetricAnalysis> {
   if (!rows || !rows.length) {
     return {
@@ -132,7 +131,7 @@ export async function analyzeExperimentResults(
   variations: ExperimentReportVariation[],
   dimension: string | undefined,
   queryData: QueryMap,
-  statsEngine: OrganizationSettings["statsEngine"] = "bayesian"
+  statsEngine: StatsEngine = "bayesian"
 ): Promise<ExperimentReportResults> {
   const metrics = await getMetricsByOrganization(organization);
   const metricMap = new Map<string, MetricInterface>();

--- a/packages/back-end/types/experiment-snapshot.d.ts
+++ b/packages/back-end/types/experiment-snapshot.d.ts
@@ -1,6 +1,6 @@
 import { QueryLanguage } from "./datasource";
 import { MetricStats } from "./metric";
-import { OrganizationSettings } from "./organization";
+import { StatsEngine } from "./stats";
 import { Queries } from "./query";
 
 export interface SnapshotMetric {
@@ -58,5 +58,5 @@ export interface ExperimentSnapshotInterface {
   segment?: string;
   activationMetric?: string;
   skipPartialData?: boolean;
-  statsEngine: OrganizationSettings["statsEngine"];
+  statsEngine?: StatsEngine;
 }

--- a/packages/back-end/types/experiment.d.ts
+++ b/packages/back-end/types/experiment.d.ts
@@ -1,3 +1,5 @@
+import { StatsEngine } from "./stats";
+
 export type ImplementationType = "visual" | "code" | "configuration" | "custom";
 
 export type ExperimentPhaseType = "ramp" | "main" | "holdout";
@@ -105,6 +107,7 @@ export interface ExperimentInterface {
   nextSnapshotAttempt?: Date;
   autoSnapshots: boolean;
   ideaSource?: string;
+  statsEngine?: StatsEngine;
 }
 
 export type ExperimentInterfaceStringDates = Omit<

--- a/packages/back-end/types/organization.d.ts
+++ b/packages/back-end/types/organization.d.ts
@@ -5,6 +5,7 @@ import {
   PROJECT_SCOPED_PERMISSIONS,
 } from "../src/util/organization.util";
 import { ImplementationType } from "./experiment";
+import type { StatsEngine } from "./stats";
 
 export type EnvScopedPermission = typeof ENV_SCOPED_PERMISSIONS[number];
 export type ProjectScopedPermission = typeof PROJECT_SCOPED_PERMISSIONS[number];
@@ -143,7 +144,7 @@ export interface OrganizationSettings {
   videoInstructionsViewed?: boolean;
   multipleExposureMinPercent?: number;
   defaultRole?: MemberRoleInfo;
-  statsEngine?: "bayesian" | "frequentist";
+  statsEngine?: StatsEngine;
   pValueThreshold?: number;
   /** @deprecated */
   implementationTypes?: ImplementationType[];

--- a/packages/back-end/types/stats.d.ts
+++ b/packages/back-end/types/stats.d.ts
@@ -1,5 +1,7 @@
 import type { MetricStats } from "./metric";
 
+export type StatsEngine = "bayesian" | "frequentist";
+
 interface BaseVariationResponse {
   cr: number;
   value: number;

--- a/packages/front-end/components/Experiment/AnalysisForm.tsx
+++ b/packages/front-end/components/Experiment/AnalysisForm.tsx
@@ -4,6 +4,7 @@ import {
   AttributionModel,
   ExperimentInterfaceStringDates,
 } from "back-end/types/experiment";
+import { StatsEngine } from "back-end/types/stats";
 import { FaQuestionCircle } from "react-icons/fa";
 import { useAuth } from "@/services/auth";
 import { useDefinitions } from "@/services/DefinitionsContext";
@@ -61,6 +62,7 @@ const AnalysisForm: FC<{
         .substr(0, 16),
       dateEnded: getValidDate(phaseObj?.dateEnded).toISOString().substr(0, 16),
       variations: experiment.variations || [],
+      statsEngine: experiment.statsEngine || undefined,
     },
   });
   const { apiCall } = useAuth();
@@ -322,6 +324,30 @@ const AnalysisForm: FC<{
           ]}
         />
       )}
+
+      <SelectField
+        label="Stats Engine"
+        value={form.watch("statsEngine")}
+        onChange={(value: StatsEngine | undefined) =>
+          form.setValue("statsEngine", value)
+        }
+        options={[
+          {
+            label: "Default for organization",
+            value: undefined,
+          },
+          {
+            label: "Bayesian",
+            value: "bayesian",
+          },
+          {
+            label: "Frequentist",
+            value: "frequentist",
+          },
+        ]}
+        sort={false}
+      />
+
       {datasourceProperties?.queryLanguage === "sql" && (
         <div className="row">
           <div className="col">

--- a/packages/front-end/components/Experiment/SinglePage.tsx
+++ b/packages/front-end/components/Experiment/SinglePage.tsx
@@ -8,10 +8,12 @@ import {
   FaLink,
   FaQuestionCircle,
 } from "react-icons/fa";
+import { capitalize } from "lodash";
 import { IdeaInterface } from "back-end/types/idea";
 import { MetricInterface } from "back-end/types/metric";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import usePermissions from "@/hooks/usePermissions";
+import useOrgSettings from "@/hooks/useOrgSettings";
 import { useAuth } from "@/services/auth";
 import useApi from "@/hooks/useApi";
 import { useUser } from "@/services/UserContext";
@@ -142,6 +144,7 @@ export default function SinglePage({
   } = useDefinitions();
 
   const router = useRouter();
+  const orgSettings = useOrgSettings();
 
   const { phase: phaseIndex } = useSnapshot();
 
@@ -570,6 +573,14 @@ export default function SinglePage({
                   </strong>{" "}
                   <FaQuestionCircle />
                 </AttributionModelTooltip>
+              </RightRailSectionGroup>
+
+              <RightRailSectionGroup title="Stats Engine" type="custom">
+                {capitalize(
+                  experiment.statsEngine ||
+                    orgSettings.statsEngine ||
+                    "bayesian"
+                )}
               </RightRailSectionGroup>
             </div>
           </RightRailSection>


### PR DESCRIPTION
Work in progress; current plan is to make both project and experiment scoping of stats engine as **premium features**

This is NON-blocking for Frequentist release (org-wide stats engine setting), here: #906 

## TODO
- [ ] Introduce 'global context' obj pattern 
- [ ] Consolidate statsEngine override logic in backend
- [ ] Allow configuring of stats engine per experiment (premium feature)
- [ ] Allow configuring of stats engine per project (premium feature)