### PR TITLE
Add ensureFloat method to MySQL

### DIFF
--- a/packages/back-end/src/integrations/Mysql.ts
+++ b/packages/back-end/src/integrations/Mysql.ts
@@ -68,4 +68,7 @@ export default class Mysql extends SqlIntegration {
   castToString(col: string): string {
     return `cast(${col} as char)`;
   }
+  ensureFloat(col: string): string {
+    return `CAST(${col} AS FLOAT)`;
+  }
 }


### PR DESCRIPTION
### Features and Changes

This adds an `ensureFloat` method to the MySQL integration. This is needed to deal with some minor rounding errors for the `AVG()` method in MySQL, which returns a DECIMAL object when the input is an integer (see docs here: https://dev.mysql.com/doc/refman/8.0/en/aggregate-functions.html).

Note, this issue would also be resolved (at least for the experiment metric queries) with the integration refactor to use sums rather than averages, but adding `ensureFloat` to the MySQL integration is the right move anyways.

### Testing

I used the new way to run integration queries (https://github.com/growthbook/growthbook/pull/910) to test this PR out. I also have an accompanying notebook which then compares the output that can be found here: https://colab.research.google.com/drive/1o9H3kcp1Z_M8GVXZ0OZIz1iw45SLd76r?usp=sharing. (the NB won't run, but you can see and comment on the NB)

The main takeaway can be found in this screenshot (no differences in user, count, and all differences for mean and stddev are < 0.0001):
<img width="614" alt="Screen Shot 2023-01-20 at 10 19 09 AM" src="https://user-images.githubusercontent.com/5298599/213776837-0187b2e0-ed18-49bc-ad93-ba5eb8e339df.png">
