### PR TITLE
Fix ratio metric numerator/denominator join to use all unique keys

### DIFF
--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -1041,6 +1041,8 @@ export default abstract class SqlIntegration
               ? `__userDenominator d
           LEFT JOIN __userMetric m ON (
             d.${baseIdType} = m.${baseIdType}
+            AND d.dimension = m.dimension
+            AND d.variation = m.variation
           )`
               : `__userMetric m`
           }


### PR DESCRIPTION
### Features and Changes

Our LEFT JOIN in the `__stats` sub-query for ratio metrics was duplicating rows when there were multiple rows per user in the denominator or numerator metric sub-tables. This would occur either when ratio metrics were analyzed for experiments where (a) a dimensional slice was selected and there was more than one dimension for at least one user, or (b) analysis with users in multiple variations was allowed and there was at least one user with one than one variation exposure.

In short this sort of join was problematic:
```
    FROM
      __userDenominator d
      LEFT JOIN __userMetric m ON (d.user_id = m.user_id)
```
because `__userDenominator` and `__userMetric` are keyed on user_id, dimension *and* variation, which matters when you are analyzing by dimension or allowing users to have multiple variations. In those cases, this left join would duplicate rows for this user as it cross joins all of their (e.g.) user-dimension rows across the two tables.

To fix this, we can just join on dimension and variation as well, since those will always be present in the two sub-tables referenced in this join and will have the appropriate values.

### Testing

You can see the before and after comparisons of SQL output for BigQuery, MySQL, and Postgres here: https://colab.research.google.com/drive/1FyS9Xp4UTBT308Q9zkGcQgPwkEczsC1A?usp=sharing

The main takeaway is that (a) this query change only affects the combination of: ratio metrics AND experiment analyses that allow multiple variations or multiple dimensions per user, and (b) in these cases the "count" column is always bigger in the main results rather than this branches results, indicative of the "over-counting" due to the cross join in the aforementioned join.