### PR TITLE
Add/fix ensureFloat to presto and snowflake

### DIFF
--- a/packages/back-end/src/integrations/Presto.ts
+++ b/packages/back-end/src/integrations/Presto.ts
@@ -100,6 +100,6 @@ export default class Presto extends SqlIntegration {
     return false;
   }
   ensureFloat(col: string): string {
-    return `1.0*${col}`;
+    return `CAST(${col} AS DOUBLE)`;
   }
 }

--- a/packages/back-end/src/integrations/Snowflake.ts
+++ b/packages/back-end/src/integrations/Snowflake.ts
@@ -28,4 +28,7 @@ export default class Snowflake extends SqlIntegration {
   castToString(col: string): string {
     return `TO_VARCHAR(${col})`;
   }
+  ensureFloat(col: string): string {
+    return `CAST(${col} AS DOUBLE)`;
+  }
 }


### PR DESCRIPTION
### Features and Changes

Additional testing revealed that the way we implemented `ensureFloat` in Presto, and the fact that we did not implement it in Snowflake, was causing some rounding errors, beginning with the `AVG()` method in the `__stats` CTE.

### Testing

Tested using the integration query runner and a notebook: https://colab.research.google.com/drive/1DryiQrkqFqKQtjiTxF9b6K4l1ZFx_w9q?usp=sharing

Shows that differences are indeed due to rounding at the levels we'd expect (and contained to the presto and snowflake engines).