### PR TITLE
Force risk to be non-negative

### DIFF
--- a/packages/stats/gbstats/bayesian/dists.py
+++ b/packages/stats/gbstats/bayesian/dists.py
@@ -61,7 +61,7 @@ class BayesABDist(ABC):
         )
         out = gq - cls.dist.mean((a_par1, b_par1), (a_par2, b_par2))
 
-        return out
+        return np.maximum(out, 0)
 
 
 class Beta(BayesABDist):

--- a/packages/stats/tests/bayesian/test_dists.py
+++ b/packages/stats/tests/bayesian/test_dists.py
@@ -84,7 +84,6 @@ class TestBeta(TestCase):
             self.assertGreaterEqual(r, 0)
 
 
-
 class TestNorm(TestCase):
     def test_posterior(self):
         prior = 0, 1, 10

--- a/packages/stats/tests/bayesian/test_dists.py
+++ b/packages/stats/tests/bayesian/test_dists.py
@@ -77,6 +77,13 @@ class TestBeta(TestCase):
                 roundsum(np.log(x) * w), roundsum(digamma(a) - digamma(a + b))
             )
 
+    def test_risk_nonnegative(self):
+        # Test used to fail before solution to GH issue
+        risk = Beta.risk(5563, 1281, 4605, 2888).tolist()
+        for r in risk:
+            self.assertGreaterEqual(r, 0)
+
+
 
 class TestNorm(TestCase):
     def test_posterior(self):


### PR DESCRIPTION
### Features and Changes

Forces risk to be non-negative. This would happen in some edge cases where we would calculate risk as numerically 0 (-6e14), but risk is a strictly non-negative concept. This would cascade to cause front-end issues of displaying negative risk or blanking out the risk box when it should be 0.

Closes #938 

### Testing

The unit test I added used to fail in the case shown in the linked issue screenshot.
```
    def test_risk_nonnegative(self):
        # Test used to fail before solution to GH issue
        risk = Beta.risk(5563, 1281, 4605, 2888).tolist()
        for r in risk:
>           self.assertGreaterEqual(r, 0)
E           AssertionError: -6.750155989720952e-14 not greater than or equal to 0
```

After the update to `dists.py` this test passes.