### PR TITLE
Bug: Fix bug where adding tag to feature didn't persist it at the org level

### DIFF
--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -49,6 +49,7 @@ import {
   markSDKConnectionUsed,
 } from "../models/SdkConnectionModel";
 import { logger } from "../util/logger";
+import { addTagsDiff } from "../models/TagModel";
 
 class ApiKeyError extends Error {
   constructor(message: string) {
@@ -613,6 +614,9 @@ export async function putFeature(
   }
 
   const updatedFeature = await updateFeature(org, feature, updates);
+
+  // If there are new tags to add
+  await addTagsDiff(org.id, feature.tags || [], updates.tags || []);
 
   await req.audit({
     event: "feature.update",


### PR DESCRIPTION
### Features and Changes

This PR updates the `putFeature` method within the features controller to consume the `addTagsDiff` method - this method will look at the current tags for a particular feature and compare that array of tags with an organization's tags, and add any new tags at the org level.

This way, if a user creates a new tag from the `EditTagModal` within `/features/[fid].tsx` - the tag will not only be added to the feature itself, but will also be added to the organization's tags.

- Closes **https://github.com/growthbook/growthbook/issues/945**

### Testing

- [x]  From an existing feature, create "edit tag" and add a new tag. Then, navigate to `/settings/tags` and ensure the newly created tag is visible. Then, do a hard refresh and confirm the new tag still exists.
- [x] Ensure that when you do the above, an organizations tags array within the 'tags' table, reflects the new tag.

https://user-images.githubusercontent.com/75274610/214947862-01daf5a0-5774-4be6-b17f-9fe5b0ed42ff.mov



