### PR TITLE
Populate experiment events in the events table

### DIFF
--- a/packages/back-end/types/event.d.ts
+++ b/packages/back-end/types/event.d.ts
@@ -4,6 +4,9 @@ import {
   NotificationEventResource,
 } from "../src/events/base-types";
 import {
+  ExperimentCreatedNotificationEvent,
+  ExperimentDeletedNotificationEvent,
+  ExperimentUpdatedNotificationEvent,
   FeatureCreatedNotificationEvent,
   FeatureDeletedNotificationEvent,
   FeatureUpdatedNotificationEvent,
@@ -24,4 +27,7 @@ export {
   FeatureCreatedNotificationEvent,
   FeatureDeletedNotificationEvent,
   FeatureUpdatedNotificationEvent,
+  ExperimentCreatedNotificationEvent,
+  ExperimentUpdatedNotificationEvent,
+  ExperimentDeletedNotificationEvent,
 };

--- a/packages/front-end/components/EventWebHooks/utils.tsx
+++ b/packages/front-end/components/EventWebHooks/utils.tsx
@@ -9,9 +9,14 @@ export type EventWebHookEditParams = {
 };
 
 export const notificationEventNames = [
+  // Features
   "feature.created",
   "feature.updated",
   "feature.deleted",
+  // Experiments
+  "experiment.created",
+  "experiment.updated",
+  "experiment.deleted",
 ] as const;
 
 export const eventWebHookEventOptions: {

--- a/packages/front-end/components/Events/EventsPage/utils.ts
+++ b/packages/front-end/components/Events/EventsPage/utils.ts
@@ -3,6 +3,9 @@ import {
   FeatureCreatedNotificationEvent,
   FeatureDeletedNotificationEvent,
   FeatureUpdatedNotificationEvent,
+  ExperimentCreatedNotificationEvent,
+  ExperimentUpdatedNotificationEvent,
+  ExperimentDeletedNotificationEvent,
   NotificationEventName,
   NotificationEventPayload,
   NotificationEventResource,
@@ -18,20 +21,84 @@ export const getEventText = (
   >
 ): string => {
   switch (event.data.event) {
+    case "experiment.created":
+      return getTitleForExperimentCreated(
+        (event.data as unknown) as ExperimentCreatedNotificationEvent
+      );
+
+    case "experiment.updated":
+      return getTitleForExperimentUpdated(
+        (event.data as unknown) as ExperimentUpdatedNotificationEvent
+      );
+
+    case "experiment.deleted":
+      return getTitleForExperimentDeleted(
+        (event.data as unknown) as ExperimentDeletedNotificationEvent
+      );
+
     case "feature.created":
-      return `The feature ${
-        ((event.data as unknown) as FeatureCreatedNotificationEvent).data
-          ?.current?.id || "(unknown)"
-      } was created`;
+      return getTitleForFeatureCreated(
+        (event.data as unknown) as FeatureCreatedNotificationEvent
+      );
+
     case "feature.updated":
-      return `The feature ${
-        ((event.data as unknown) as FeatureUpdatedNotificationEvent).data
-          ?.current?.id || "(unknown)"
-      } was updated`;
+      return getTitleForFeatureUpdated(
+        (event.data as unknown) as FeatureUpdatedNotificationEvent
+      );
+
     case "feature.deleted":
-      return `The feature ${
-        ((event.data as unknown) as FeatureDeletedNotificationEvent).data
-          ?.previous?.id || "(unknown)"
-      } was deleted`;
+      return getTitleForFeatureDeleted(
+        (event.data as unknown) as FeatureDeletedNotificationEvent
+      );
   }
 };
+
+// region Feature
+
+const getTitleForFeatureCreated = ({
+  data,
+}: FeatureCreatedNotificationEvent): string => {
+  return `The feature ${data?.current?.id || "(unknown)"} was created`;
+};
+
+const getTitleForFeatureUpdated = ({
+  data,
+}: FeatureUpdatedNotificationEvent): string => {
+  return `The feature ${data?.current?.id || "(unknown)"} was updated`;
+};
+
+const getTitleForFeatureDeleted = ({
+  data,
+}: FeatureDeletedNotificationEvent): string => {
+  return `The feature ${data?.previous?.id || "(unknown)"} was deleted`;
+};
+
+// endregion Feature
+
+// region Experiment
+
+const getTitleForExperimentCreated = ({
+  data,
+}: ExperimentCreatedNotificationEvent): string => {
+  return `The experiment ${
+    data?.current?.name || data?.current?.id || "(unknown)"
+  } was created`;
+};
+
+const getTitleForExperimentUpdated = ({
+  data,
+}: ExperimentUpdatedNotificationEvent): string => {
+  return `The experiment ${
+    data?.previous?.name || data?.previous?.id || "(unknown)"
+  } was updated`;
+};
+
+const getTitleForExperimentDeleted = ({
+  data,
+}: ExperimentDeletedNotificationEvent): string => {
+  return `The experiment ${
+    data?.previous?.name || data?.previous?.id || "(unknown)"
+  } was deleted`;
+};
+
+// endregion Experiment


### PR DESCRIPTION
This fixes the bug where events for experiments wouldn't have titles in the events table.

Before changes:

![CleanShot 2023-01-26 at 13 52 50@2x](https://user-images.githubusercontent.com/113377031/214959044-6d1d3faf-1f4d-4990-a83c-aee2feeec4d9.png)

After changes:

<img width="1234" alt="image" src="https://user-images.githubusercontent.com/113377031/214958892-7cf49453-7b91-417b-97cc-1b4170931f1b.png">
