### PR TITLE
Add stddev, pvalue, and CI to experiment Export CSV option

### DIFF
--- a/packages/front-end/components/Experiment/ResultsDownloadButton.tsx
+++ b/packages/front-end/components/Experiment/ResultsDownloadButton.tsx
@@ -18,8 +18,12 @@ type CsvRow = {
   users?: number;
   totalValue?: number;
   perUserValue?: number;
+  perUserValueStdDev?: number | null;
   chanceToBeatControl?: number | null;
   percentChange?: number | null;
+  percentChangePValue?: number | null;
+  percentChangeCILower?: number | null;
+  percentChangeCIUpper?: number | null;
 };
 
 export default function ResultsDownloadButton({
@@ -79,8 +83,12 @@ export default function ResultsDownloadButton({
             users: stats.users,
             totalValue: stats.value,
             perUserValue: stats.cr,
+            perUserValueStdDev: stats.stats.stddev || null,
             chanceToBeatControl: stats.chanceToWin || null,
             percentChange: stats.expected || null,
+            percentChangePValue: stats.pValue || null,
+            percentChangeCILower: stats.ci[0] || null,
+            percentChangeCIUpper: stats.ci[1] || null,
           });
         });
       });


### PR DESCRIPTION
### Features and Changes

This PR adds three columns to the `Export CSV` option in the Experiment Analysis view---the standard error of the variation mean along with our percent uplift confidence/credible intervals.
<img width="161" alt="Screen Shot 2023-01-26 at 2 24 24 PM" src="https://user-images.githubusercontent.com/5298599/214964457-af6092c2-f660-4bf4-b5cf-4eaed4841841.png">

This has two goals.

1) it's a very cheap workaround for people who want all of the pertinent values from the table in a spreadsheet that they can export, do whatever with (e.g. people who want exact CI values). We should definitely handle this with a mouse-over or something, but this is a cheap solution until then.
2) It adds the standard deviations because the integration refactor will *remove* these from the SQL queries that people get from the experiment analysis. If folks complain, at least for now we can say that we do return them in the experiment results CSV.

### Testing

**Bayesian engine**

<img width="1234" alt="Screen Shot 2023-01-26 at 2 23 45 PM" src="https://user-images.githubusercontent.com/5298599/214964341-9600d76f-05b8-4870-a4e7-70a61dca2ddf.png">
link: https://docs.google.com/spreadsheets/d/1sQi8VMQB-m6JZJG7MeYQnKGE8Z-1rRZ5UqPW1sdSmUA/edit#gid=2138748879

**Frequentist engine**
<img width="1227" alt="Screen Shot 2023-01-26 at 2 21 26 PM" src="https://user-images.githubusercontent.com/5298599/214963969-444b2ef6-c1c2-4c83-8e4a-ca8a896b352f.png">
link: https://docs.google.com/spreadsheets/d/1Wp3Rx5K83ChaXcWVIfKM8rcIp4nT7VUaQfguyG3dWPI/edit?usp=sharing