### PR TITLE
MySQL ensureFloat should use `DOUBLE`

### DIFF
--- a/packages/back-end/src/integrations/Mysql.ts
+++ b/packages/back-end/src/integrations/Mysql.ts
@@ -69,6 +69,6 @@ export default class Mysql extends SqlIntegration {
     return `cast(${col} as char)`;
   }
   ensureFloat(col: string): string {
-    return `CAST(${col} AS FLOAT)`;
+    return `CAST(${col} AS DOUBLE)`;
   }
 }


### PR DESCRIPTION
Updates ensureFloat to use DOUBLE to limit possible inaccuracies with casting large ints. Only should affect MySQL and effect is minimal since I just landed this earlier this week.