### PR TITLE
Reports-level scoping of stats engine

### DIFF
--- a/packages/back-end/src/controllers/reports.ts
+++ b/packages/back-end/src/controllers/reports.ts
@@ -197,8 +197,7 @@ export async function refreshReport(
 
   const useCache = !req.query["force"];
 
-  // TODO pass up organization instead
-  await runReport(report, useCache, org.settings?.statsEngine);
+  await runReport(report, useCache, org);
 
   return res.status(200).json({
     status: 200,
@@ -239,14 +238,13 @@ export async function putReport(
   await updateReport(org.id, req.params.id, updates);
 
   if (needsRun) {
-    // TODO pass up organization instead
     await runReport(
       {
         ...report,
         ...updates,
       },
       true,
-      org.settings?.statsEngine
+      org
     );
   }
 
@@ -265,6 +263,7 @@ export async function getReportStatus(
   if (!report) {
     throw new Error("Could not get query status");
   }
+  const statsEngine = report.args.statsEngine || org.settings?.statsEngine;
   const result = await getStatusEndpoint(
     report,
     org.id,
@@ -275,8 +274,7 @@ export async function getReportStatus(
           report.args.variations,
           report.args.dimension || "",
           queryData,
-          // TODO override org setting with report setting
-          org.settings?.statsEngine
+          statsEngine
         );
       }
       throw new Error("Unsupported report type");

--- a/packages/back-end/src/controllers/reports.ts
+++ b/packages/back-end/src/controllers/reports.ts
@@ -197,6 +197,7 @@ export async function refreshReport(
 
   const useCache = !req.query["force"];
 
+  // TODO pass up organization instead
   await runReport(report, useCache, org.settings?.statsEngine);
 
   return res.status(200).json({
@@ -238,6 +239,7 @@ export async function putReport(
   await updateReport(org.id, req.params.id, updates);
 
   if (needsRun) {
+    // TODO pass up organization instead
     await runReport(
       {
         ...report,
@@ -273,6 +275,7 @@ export async function getReportStatus(
           report.args.variations,
           report.args.dimension || "",
           queryData,
+          // TODO override org setting with report setting
           org.settings?.statsEngine
         );
       }

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -54,8 +54,8 @@ import { EXPERIMENT_REFRESH_FREQUENCY } from "../util/secrets";
 import {
   ExperimentUpdateSchedule,
   OrganizationInterface,
-  OrganizationSettings,
 } from "../../types/organization";
+import { StatsEngine } from "../../types/stats";
 import { logger } from "../util/logger";
 import { getSDKPayloadKeys } from "../util/features";
 import {
@@ -605,7 +605,7 @@ export async function createManualSnapshot(
   metrics: {
     [key: string]: MetricStats[];
   },
-  statsEngine?: OrganizationSettings["statsEngine"]
+  statsEngine?: StatsEngine
 ) {
   const { srm, variations } = await getManualSnapshotData(
     experiment,
@@ -701,7 +701,7 @@ export async function createSnapshot(
   organization: OrganizationInterface,
   dimensionId: string | null,
   useCache: boolean = false,
-  statsEngine: OrganizationSettings["statsEngine"]
+  statsEngine: StatsEngine | undefined
 ) {
   const previousExperiment = cloneDeep(experiment);
 

--- a/packages/back-end/src/services/reports.ts
+++ b/packages/back-end/src/services/reports.ts
@@ -226,6 +226,7 @@ export async function runReport(
       report.organization,
       report.args,
       useCache,
+      // TODO override org setting with report setting
       statsEngine
     );
 

--- a/packages/back-end/src/services/reports.ts
+++ b/packages/back-end/src/services/reports.ts
@@ -10,7 +10,7 @@ import { SegmentModel } from "../models/SegmentModel";
 import { SegmentInterface } from "../../types/segment";
 import { getDataSourceById } from "../models/DataSourceModel";
 import { ExperimentInterface, ExperimentPhase } from "../../types/experiment";
-import { OrganizationSettings } from "../../types/organization";
+import { StatsEngine } from "../../types/stats";
 import { updateReport } from "../models/ReportModel";
 import { ExperimentSnapshotInterface } from "../../types/experiment-snapshot";
 import { expandDenominatorMetrics } from "../util/sql";
@@ -65,7 +65,7 @@ export async function startExperimentAnalysis(
   organization: string,
   args: ExperimentReportArgs,
   useCache: boolean,
-  statsEngine: OrganizationSettings["statsEngine"]
+  statsEngine: StatsEngine | undefined
 ) {
   const metricObjs = await getMetricsByOrganization(organization);
   const metricMap = new Map<string, MetricInterface>();
@@ -217,7 +217,7 @@ export async function startExperimentAnalysis(
 export async function runReport(
   report: ReportInterface,
   useCache: boolean = true,
-  statsEngine: OrganizationSettings["statsEngine"]
+  statsEngine: StatsEngine | undefined
 ) {
   const updates: Partial<ReportInterface> = {};
 

--- a/packages/back-end/src/services/reports.ts
+++ b/packages/back-end/src/services/reports.ts
@@ -11,6 +11,7 @@ import { SegmentInterface } from "../../types/segment";
 import { getDataSourceById } from "../models/DataSourceModel";
 import { ExperimentInterface, ExperimentPhase } from "../../types/experiment";
 import { StatsEngine } from "../../types/stats";
+import { OrganizationInterface } from "../../types/organization";
 import { updateReport } from "../models/ReportModel";
 import { ExperimentSnapshotInterface } from "../../types/experiment-snapshot";
 import { expandDenominatorMetrics } from "../util/sql";
@@ -217,16 +218,17 @@ export async function startExperimentAnalysis(
 export async function runReport(
   report: ReportInterface,
   useCache: boolean = true,
-  statsEngine: StatsEngine | undefined
+  organization: OrganizationInterface
 ) {
   const updates: Partial<ReportInterface> = {};
+  const statsEngine =
+    report.args.statsEngine || organization.settings?.statsEngine;
 
   if (report.type === "experiment") {
     const { queries, results } = await startExperimentAnalysis(
       report.organization,
       report.args,
       useCache,
-      // TODO override org setting with report setting
       statsEngine
     );
 

--- a/packages/back-end/src/services/stats.ts
+++ b/packages/back-end/src/services/stats.ts
@@ -1,7 +1,7 @@
 import { promisify } from "util";
 import { PythonShell } from "python-shell";
 import { MetricInterface } from "../../types/metric";
-import { ExperimentMetricAnalysis } from "../../types/stats";
+import { ExperimentMetricAnalysis, StatsEngine } from "../../types/stats";
 import {
   ExperimentMetricQueryResponse,
   ExperimentResults,
@@ -15,7 +15,6 @@ import { getMetricsByOrganization } from "../models/MetricModel";
 import { promiseAllChunks } from "../util/promise";
 import { checkSrm } from "../util/stats";
 import { logger } from "../util/logger";
-import { OrganizationSettings } from "../../types/organization";
 import { QueryMap } from "./queries";
 
 export const MAX_DIMENSIONS = 20;
@@ -25,7 +24,7 @@ export async function analyzeExperimentMetric(
   metric: MetricInterface,
   rows: ExperimentMetricQueryResponse,
   maxDimensions: number,
-  statsEngine: OrganizationSettings["statsEngine"] = "bayesian"
+  statsEngine: StatsEngine = "bayesian"
 ): Promise<ExperimentMetricAnalysis> {
   if (!rows || !rows.length) {
     return {
@@ -132,7 +131,7 @@ export async function analyzeExperimentResults(
   variations: ExperimentReportVariation[],
   dimension: string | undefined,
   queryData: QueryMap,
-  statsEngine: OrganizationSettings["statsEngine"] = "bayesian"
+  statsEngine: StatsEngine = "bayesian"
 ): Promise<ExperimentReportResults> {
   const metrics = await getMetricsByOrganization(organization);
   const metricMap = new Map<string, MetricInterface>();

--- a/packages/back-end/types/experiment-snapshot.d.ts
+++ b/packages/back-end/types/experiment-snapshot.d.ts
@@ -1,6 +1,6 @@
 import { QueryLanguage } from "./datasource";
 import { MetricStats } from "./metric";
-import { OrganizationSettings } from "./organization";
+import { StatsEngine } from "./stats";
 import { Queries } from "./query";
 
 export interface SnapshotMetric {
@@ -58,5 +58,5 @@ export interface ExperimentSnapshotInterface {
   segment?: string;
   activationMetric?: string;
   skipPartialData?: boolean;
-  statsEngine: OrganizationSettings["statsEngine"];
+  statsEngine?: StatsEngine;
 }

--- a/packages/back-end/types/organization.d.ts
+++ b/packages/back-end/types/organization.d.ts
@@ -5,6 +5,7 @@ import {
   PROJECT_SCOPED_PERMISSIONS,
 } from "../src/util/organization.util";
 import { ImplementationType } from "./experiment";
+import type { StatsEngine } from "./stats";
 
 export type EnvScopedPermission = typeof ENV_SCOPED_PERMISSIONS[number];
 export type ProjectScopedPermission = typeof PROJECT_SCOPED_PERMISSIONS[number];
@@ -143,7 +144,7 @@ export interface OrganizationSettings {
   videoInstructionsViewed?: boolean;
   multipleExposureMinPercent?: number;
   defaultRole?: MemberRoleInfo;
-  statsEngine?: "bayesian" | "frequentist";
+  statsEngine?: StatsEngine;
   pValueThreshold?: number;
   /** @deprecated */
   implementationTypes?: ImplementationType[];

--- a/packages/back-end/types/report.d.ts
+++ b/packages/back-end/types/report.d.ts
@@ -1,6 +1,7 @@
 import { AttributionModel, MetricOverride } from "./experiment";
 import { SnapshotVariation } from "./experiment-snapshot";
 import { Queries } from "./query";
+import { StatsEngine } from "./stats";
 
 export interface ReportInterfaceBase {
   id: string;
@@ -43,6 +44,7 @@ export interface ExperimentReportArgs {
   skipPartialData?: boolean;
   removeMultipleExposures?: boolean;
   attributionModel?: AttributionModel;
+  statsEngine?: StatsEngine;
 }
 export interface ExperimentReportResultDimension {
   name: string;

--- a/packages/back-end/types/stats.d.ts
+++ b/packages/back-end/types/stats.d.ts
@@ -1,5 +1,7 @@
 import type { MetricStats } from "./metric";
 
+export type StatsEngine = "bayesian" | "frequentist";
+
 interface BaseVariationResponse {
   cr: number;
   value: number;

--- a/packages/front-end/components/Experiment/BreakDownResults.tsx
+++ b/packages/front-end/components/Experiment/BreakDownResults.tsx
@@ -5,6 +5,7 @@ import {
   ExperimentReportVariation,
 } from "back-end/types/report";
 import { ExperimentStatus, MetricOverride } from "back-end/types/experiment";
+import { StatsEngine } from "back-end/types/stats";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import {
   applyMetricOverrides,
@@ -35,6 +36,7 @@ const BreakDownResults: FC<{
   reportDate: Date;
   activationMetric?: string;
   status: ExperimentStatus;
+  statsEngine?: StatsEngine;
 }> = ({
   dimensionId,
   results,
@@ -47,6 +49,7 @@ const BreakDownResults: FC<{
   activationMetric,
   status,
   reportDate,
+  statsEngine,
 }) => {
   const { getDimensionById, getMetricById, ready } = useDefinitions();
 
@@ -151,6 +154,7 @@ const BreakDownResults: FC<{
               renderLabelColumn={(label) => label || <em>unknown</em>}
               rows={table.rows}
               fullStats={fullStats}
+              statsEngine={statsEngine}
               {...risk}
             />
           </div>

--- a/packages/front-end/components/Experiment/CompactResults.tsx
+++ b/packages/front-end/components/Experiment/CompactResults.tsx
@@ -5,6 +5,7 @@ import {
   ExperimentReportVariation,
 } from "back-end/types/report";
 import { ExperimentStatus, MetricOverride } from "back-end/types/experiment";
+import { StatsEngine } from "back-end/types/stats";
 import Link from "next/link";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import {
@@ -30,6 +31,7 @@ const CompactResults: FC<{
   metrics: string[];
   metricOverrides: MetricOverride[];
   id: string;
+  statsEngine?: StatsEngine;
 }> = ({
   results,
   variations,
@@ -42,6 +44,7 @@ const CompactResults: FC<{
   metrics,
   metricOverrides,
   id,
+  statsEngine,
 }) => {
   const { getMetricById, ready } = useDefinitions();
 
@@ -105,6 +108,7 @@ const CompactResults: FC<{
           {...risk}
           labelHeader="Metric"
           users={users}
+          statsEngine={statsEngine}
           renderLabelColumn={(label, metric) => {
             const metricLink = (
               <Tooltip

--- a/packages/front-end/components/Experiment/ResultsDownloadButton.tsx
+++ b/packages/front-end/components/Experiment/ResultsDownloadButton.tsx
@@ -87,8 +87,8 @@ export default function ResultsDownloadButton({
             chanceToBeatControl: stats.chanceToWin || null,
             percentChange: stats.expected || null,
             percentChangePValue: stats.pValue || null,
-            percentChangeCILower: stats.ci[0] || null,
-            percentChangeCIUpper: stats.ci[1] || null,
+            percentChangeCILower: stats.ci?.[0] || null,
+            percentChangeCIUpper: stats.ci?.[1] || null,
           });
         });
       });

--- a/packages/front-end/components/Experiment/ResultsTable.tsx
+++ b/packages/front-end/components/Experiment/ResultsTable.tsx
@@ -4,6 +4,7 @@ import { FaQuestionCircle } from "react-icons/fa";
 import { MetricInterface } from "back-end/types/metric";
 import { ExperimentReportVariation } from "back-end/types/report";
 import { ExperimentStatus } from "back-end/types/experiment";
+import { StatsEngine } from "back-end/types/stats";
 import { ExperimentTableRow, useDomain } from "@/services/experiments";
 import useOrgSettings from "@/hooks/useOrgSettings";
 import Tooltip from "../Tooltip/Tooltip";
@@ -33,6 +34,7 @@ export type ResultsTableProps = {
   fullStats?: boolean;
   riskVariation: number;
   setRiskVariation: (riskVariation: number) => void;
+  statsEngine?: StatsEngine;
 };
 
 const numberFormatter = new Intl.NumberFormat();
@@ -56,9 +58,11 @@ export default function ResultsTable({
   hasRisk,
   riskVariation,
   setRiskVariation,
+  statsEngine: _statsEngine,
 }: ResultsTableProps) {
   const domain = useDomain(variations, rows);
-  const settings = useOrgSettings();
+  const orgSettings = useOrgSettings();
+  const statsEngine = _statsEngine ? _statsEngine : orgSettings.statsEngine;
 
   return (
     <table
@@ -117,7 +121,7 @@ export default function ResultsTable({
                   className={`variation${i} text-center`}
                   style={{ minWidth: 110 }}
                 >
-                  {settings.statsEngine === "frequentist"
+                  {statsEngine === "frequentist"
                     ? "P-value"
                     : "Chance to Beat Control"}
                 </th>
@@ -208,7 +212,7 @@ export default function ResultsTable({
                     />
                     {i > 0 &&
                       fullStats &&
-                      (settings.statsEngine === "frequentist" ? (
+                      (statsEngine === "frequentist" ? (
                         <PValueColumn
                           baseline={baseline}
                           stats={stats}
@@ -233,9 +237,7 @@ export default function ResultsTable({
                       (fullStats ? (
                         <PercentGraphColumn
                           barType={
-                            settings.statsEngine === "frequentist"
-                              ? "pill"
-                              : null
+                            statsEngine === "frequentist" ? "pill" : null
                           }
                           baseline={baseline}
                           domain={domain}

--- a/packages/front-end/components/Report/ConfigureReport.tsx
+++ b/packages/front-end/components/Report/ConfigureReport.tsx
@@ -6,6 +6,7 @@ import { useAuth } from "@/services/auth";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import { getValidDate } from "@/services/dates";
 import { getExposureQuery } from "@/services/datasources";
+import useOrgSettings from "@/hooks/useOrgSettings";
 import MetricsSelector from "../Experiment/MetricsSelector";
 import Field from "../Forms/Field";
 import Modal from "../Modal";
@@ -22,6 +23,7 @@ export default function ConfigureReport({
   mutate: () => void;
   viewResults: () => void;
 }) {
+  const settings = useOrgSettings();
   const { apiCall } = useAuth();
   const { metrics, segments, getDatasourceById } = useDefinitions();
   const datasource = getDatasourceById(report.args.datasource);
@@ -41,6 +43,7 @@ export default function ConfigureReport({
         .toISOString()
         .substr(0, 16),
       endDate: getValidDate(report.args.endDate).toISOString().substr(0, 16),
+      statsEngine: report.args.statsEngine || settings.statsEngine,
     },
   });
 
@@ -308,6 +311,28 @@ export default function ConfigureReport({
           ]}
         />
       )}
+
+      <SelectField
+        label={<strong>Stats Engine</strong>}
+        value={form.watch("statsEngine")}
+        onChange={(value) =>
+          form.setValue(
+            "statsEngine",
+            value === "frequentist" ? "frequentist" : "bayesian"
+          )
+        }
+        options={[
+          {
+            label: "Bayesian",
+            value: "bayesian",
+          },
+          {
+            label: "Frequentist",
+            value: "frequentist",
+          },
+        ]}
+      />
+
       {datasourceProperties?.queryLanguage === "sql" && (
         <div className="row">
           <div className="col">

--- a/packages/front-end/components/Report/ConfigureReport.tsx
+++ b/packages/front-end/components/Report/ConfigureReport.tsx
@@ -1,3 +1,4 @@
+import { useCallback, useState } from "react";
 import { useFieldArray, useForm } from "react-hook-form";
 import { ReportInterface } from "back-end/types/report";
 import { FaQuestionCircle } from "react-icons/fa";
@@ -27,6 +28,7 @@ export default function ConfigureReport({
   const { apiCall } = useAuth();
   const { metrics, segments, getDatasourceById } = useDefinitions();
   const datasource = getDatasourceById(report.args.datasource);
+  const [usingStatsEngineDefault, setUsingStatsEngineDefault] = useState(false);
 
   const form = useForm({
     defaultValues: {
@@ -64,6 +66,16 @@ export default function ConfigureReport({
   const exposureQueries = datasource?.settings?.queries?.exposure || [];
   const exposureQueryId = form.watch("exposureQueryId");
   const exposureQuery = exposureQueries.find((e) => e.id === exposureQueryId);
+
+  const setStatsEngineToDefault = useCallback(
+    (enable: boolean) => {
+      if (enable) {
+        form.setValue("statsEngine", settings.statsEngine);
+      }
+      setUsingStatsEngineDefault(enable);
+    },
+    [form, setUsingStatsEngineDefault, settings.statsEngine]
+  );
 
   return (
     <Modal
@@ -312,26 +324,40 @@ export default function ConfigureReport({
         />
       )}
 
-      <SelectField
-        label={<strong>Stats Engine</strong>}
-        value={form.watch("statsEngine")}
-        onChange={(value) =>
-          form.setValue(
-            "statsEngine",
-            value === "frequentist" ? "frequentist" : "bayesian"
-          )
-        }
-        options={[
-          {
-            label: "Bayesian",
-            value: "bayesian",
-          },
-          {
-            label: "Frequentist",
-            value: "frequentist",
-          },
-        ]}
-      />
+      <div className="d-flex flex-row no-gutters align-items-center">
+        <div className="col-2">
+          <SelectField
+            disabled={usingStatsEngineDefault}
+            label={<strong>Stats Engine</strong>}
+            value={form.watch("statsEngine")}
+            onChange={(value) =>
+              form.setValue(
+                "statsEngine",
+                value === "frequentist" ? "frequentist" : "bayesian"
+              )
+            }
+            options={[
+              {
+                label: "Bayesian",
+                value: "bayesian",
+              },
+              {
+                label: "Frequentist",
+                value: "frequentist",
+              },
+            ]}
+          />
+        </div>
+        <label className="ml-5 mt-3">
+          <input
+            type="checkbox"
+            className="form-check-input"
+            checked={usingStatsEngineDefault}
+            onChange={(e) => setStatsEngineToDefault(e.target.checked)}
+          />
+          Use Organization Default
+        </label>
+      </div>
 
       {datasourceProperties?.queryLanguage === "sql" && (
         <div className="row">

--- a/packages/front-end/pages/report/[rid].tsx
+++ b/packages/front-end/pages/report/[rid].tsx
@@ -335,6 +335,7 @@ export default function ReportPage() {
                 guardrails={report.args.guardrails}
                 variations={variations}
                 key={report.args.dimension}
+                statsEngine={report.args.statsEngine}
               />
             ))}
           {report.results && !report.args.dimension && (
@@ -377,6 +378,7 @@ export default function ReportPage() {
                 startDate={getValidDate(report.args.startDate).toISOString()}
                 multipleExposures={report.results?.multipleExposures || 0}
                 variations={variations}
+                statsEngine={report.args.statsEngine}
               />
               {report.args.guardrails?.length > 0 && (
                 <div className="mb-3 p-3">


### PR DESCRIPTION
This PR includes changes to allow users to set the **stats engine** for **experiment reports**

Background: We recently introduced the ability to configure a stats engine across an entire organization. However some users still need a way to pilot a different stats engine without changing it org-wide. This PR introduces an alternative to the org-wide setting - via an experiment report. This unlocks the ability to set stats engine in a contained context without changing it for all experiments in an org.

Changes
- Isolate `StatsEngine` enum type definition
- UI: Adds "Stats Engine" dropdown to Reports configuration page 
- Update `ReportInterface` to accept optional `statsEngine` property under `args` object
- Fix small bug that occurs in frequentist reports (packages/front-end/components/Experiment/ResultsDownloadButton.tsx)

Screenshots
<img width="2122" alt="image" src="https://user-images.githubusercontent.com/2374625/215829526-b541cf1e-7823-4082-a007-79d45ec83f6b.png">
<img width="2122" alt="image" src="https://user-images.githubusercontent.com/2374625/215829594-474437c4-d5c3-4e48-841f-6002df31b286.png">