### PR TITLE
Docs for decryption with the Java SDK

### DIFF
--- a/docs/docs/lib/java.mdx
+++ b/docs/docs/lib/java.mdx
@@ -9,6 +9,7 @@ toc_max_heading_level: 5
 import ExternalLink from '@site/src/components/ExternalLink'
 import CodeTabsAddDependencyPartial from '@site/src/partials/java/_code-tabs-add-dependency.mdx'
 import CodeTabsGBContextBuilderPartial from '@site/src/partials/java/_code-tabs-gbcontext-builder.mdx'
+import CodeTabsGBContextBuilderEncryptedPartial from '@site/src/partials/java/_code-tabs-gbcontext-builder-encrypted.mdx'
 import CodeTabsGBContextConstructorPartial from '@site/src/partials/java/_code-tabs-gbcontext-constructor.mdx'
 import CodeTabsUserAttributesPartial from '@site/src/partials/java/_code-tabs-user-attributes.mdx'
 import CodeTabsUsingFeaturesPartial from '@site/src/partials/java/_code-tabs-using-features.mdx'
@@ -219,6 +220,14 @@ You can subscribe with as many callbacks as you like:
 <CodeTabsExperimentResultSubscribeMultipleCallbackPartial />
 
 **The experiment run callback is called for every experiment run, regardless of experiment result**. If you would like to subscribe only to evaluations where the user falls into an experiment, see [TrackingCallback](#tracking-callback).
+
+## Working with Encrypted features
+
+As of version 0.3.0, the Java SDK supports decrypting encrypted features. You can learn more about [SDK Connection Endpoint Encryption](/app/api#encryption).
+
+The main difference is you create a `GBContext` by passing an encryption key (`.encryptionKey()` when using the builder) and using the encrypted payload as the features JSON (`.featuresJson()` for the builder).
+
+<CodeTabsGBContextBuilderEncryptedPartial />
 
 ## Code Examples
 

--- a/docs/src/partials/java/_code-tabs-gbcontext-builder-encrypted.mdx
+++ b/docs/src/partials/java/_code-tabs-gbcontext-builder-encrypted.mdx
@@ -1,0 +1,77 @@
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+
+```mdx-code-block
+<Tabs>
+  <TabItem value="java" label="Java">
+```
+
+```java
+// Fetch feature definitions from the GrowthBook API
+// We recommend adding a caching layer in production
+// Get your endpoint in the Environments tab -> SDK Endpoints: https://app.growthbook.io/environments
+URI featuresEndpoint = new URI("https://cdn.growthbook.io/api/features/<environment_key>");
+HttpRequest request = HttpRequest.newBuilder().uri(featuresEndpoint).GET().build();
+HttpResponse<String> response = HttpClient.newBuilder().build()
+    .send(request, HttpResponse.BodyHandlers.ofString());
+String encryptedFeaturesJson = new JSONObject(response.body()).get("encryptedFeatures").toString();
+
+// JSON serializable user attributes
+String userAttributesJson = user.toJson();
+
+// You can store your encryption key as an environment variable rather than hardcoding in plain text in your codebase
+String encryptionKey = "<key-for-decrypting>";
+
+// Initialize the GrowthBook SDK with the GBContext
+GBContext context = GBContext
+    .builder()
+    .featuresJson(encryptedFeaturesJson)
+    .encryptionKey(encryptionKey)
+    .attributesJson(userAttributesJson)
+    .build();
+
+GrowthBook growthBook = new GrowthBook(context);
+```
+
+```mdx-code-block
+</TabItem>
+
+<TabItem value="kotlin" label="Kotlin">
+```
+
+```kotlin
+// Fetch feature definitions from the GrowthBook API
+// We recommend adding a caching layer in production
+// Get your endpoint in the Environments tab -> SDK Endpoints: https://app.growthbook.io/environments
+val featuresEndpoint = URI.create("https://cdn.growthbook.io/api/features/<environment_key>")
+val request = HttpRequest.newBuilder().uri(featuresEndpoint).GET().build();
+val response = HttpClient.newBuilder().build()
+    .send(request, HttpResponse.BodyHandlers.ofString());
+val encryptedFeaturesJson = JSONObject(response.body()).get("encryptedFeatures").toString()
+
+// JSON serializable user attributes
+val userAttributes = """
+    {
+        "id": "user-abc123",
+        "country": "canada"
+    }
+""".trimIndent()
+
+// You can store your encryption key as an environment variable rather than hardcoding in plain text in your codebase
+val encryptionKey = "<key-for-decrypting>";
+
+// Initialize the GrowthBook SDK with the GBContext
+val context = GBContext
+    .builder()
+    .featuresJson(encryptedFeaturesJson)
+    .encryptionKey(encryptionKey)
+    .attributesJson(userAttributes)
+    .build()
+
+val growthBook = GrowthBook(context)
+```
+
+```mdx-code-block
+</TabItem>
+</Tabs>
+```

--- a/docs/src/partials/java/_code-tabs-gbcontext-builder-encrypted.mdx
+++ b/docs/src/partials/java/_code-tabs-gbcontext-builder-encrypted.mdx
@@ -22,7 +22,7 @@ String userAttributesJson = user.toJson();
 // You can store your encryption key as an environment variable rather than hardcoding in plain text in your codebase
 String encryptionKey = "<key-for-decrypting>";
 
-// Initialize the GrowthBook SDK with the GBContext
+// Initialize the GrowthBook SDK with the GBContext and the encryption key
 GBContext context = GBContext
     .builder()
     .featuresJson(encryptedFeaturesJson)
@@ -60,7 +60,7 @@ val userAttributes = """
 // You can store your encryption key as an environment variable rather than hardcoding in plain text in your codebase
 val encryptionKey = "<key-for-decrypting>";
 
-// Initialize the GrowthBook SDK with the GBContext
+// Initialize the GrowthBook SDK with the GBContext and the encryption key
 val context = GBContext
     .builder()
     .featuresJson(encryptedFeaturesJson)

--- a/packages/front-end/components/Features/CodeSnippetModal.tsx
+++ b/packages/front-end/components/Features/CodeSnippetModal.tsx
@@ -87,7 +87,7 @@ export default function CodeSnippetModal({
   const [installationOpen, setInstallationOpen] = useState(true);
   const [setupOpen, setSetupOpen] = useState(true);
   const [usageOpen, setUsageOpen] = useState(true);
-  const [attributesOpen, setAttributesOpen] = useState(false);
+  const [attributesOpen, setAttributesOpen] = useState(true);
 
   const { apiCall } = useAuth();
 

--- a/packages/front-end/components/Features/SDKConnections/SDKLanguageLogo.tsx
+++ b/packages/front-end/components/Features/SDKConnections/SDKLanguageLogo.tsx
@@ -91,7 +91,7 @@ export const languageMapping: Record<
     color: "#f89820",
     label: "Java",
     docs: "java",
-    supportsEncryption: false,
+    supportsEncryption: true,
     usesEntireEndpoint: true,
   },
   javascript: {

--- a/packages/front-end/components/SyntaxHighlighting/Snippets/GrowthBookSetupCodeSnippet.tsx
+++ b/packages/front-end/components/SyntaxHighlighting/Snippets/GrowthBookSetupCodeSnippet.tsx
@@ -441,13 +441,26 @@ TrackingCallback trackingCallback = new TrackingCallback() {
         Create a GrowthBook instance
         <Code
           language="java"
-          code={`
+          code={
+            encryptionKey
+              ? `
 GBContext context = GBContext.builder()
     .featuresJson(featuresJson)
+    .attributesJson(userAttributesObj.toString()) // Optional
+    .encryptionKey("${encryptionKey}") // You may want to store this in an environment variable
     .trackingCallback(trackingCallback)
     .build();
 GrowthBook growthBook = new GrowthBook(context);
-            `.trim()}
+            `.trim()
+              : `
+GBContext context = GBContext.builder()
+    .featuresJson(featuresJson)
+    .attributesJson(userAttributesObj.toString()) // Optional
+    .trackingCallback(trackingCallback)
+    .build();
+GrowthBook growthBook = new GrowthBook(context);
+            `.trim()
+          }
         />
       </>
     );

--- a/packages/front-end/components/SyntaxHighlighting/Snippets/InstallationCodeSnippet.tsx
+++ b/packages/front-end/components/SyntaxHighlighting/Snippets/InstallationCodeSnippet.tsx
@@ -125,7 +125,7 @@ dependencies: [
 <dependency>
   <groupId>com.github.growthbook</groupId>
   <artifactId>growthbook-sdk-java</artifactId>
-  <version>0.2.2</version>
+  <version>0.3.0</version>
 </dependency>
 `.trim()}
           />
@@ -142,7 +142,7 @@ allprojects {
     }
 }
 dependencies {
-    implementation 'com.github.growthbook:growthbook-sdk-java:0.2.2'
+    implementation 'com.github.growthbook:growthbook-sdk-java:0.3.0'
 }`.trim()}
           />
         </div>


### PR DESCRIPTION
### Features and Changes

Adds changes to the product and the documentation to support decrypting encrypted features with the Java SDK.


### Dependencies

n/a

### Testing

1. Have an account with encryption enabled.
2. Toggle encryption on for a new SDK Endpoint configured with Java


## Screenshots

### In the GrowthBook dashboard

![CleanShot 2023-01-31 at 12 21 03@2x](https://user-images.githubusercontent.com/113377031/215873831-52e1e376-49f0-4beb-bb3c-7abb5d461a3d.png)

![CleanShot 2023-01-31 at 12 21 55@2x](https://user-images.githubusercontent.com/113377031/215874008-89a39557-c92d-4925-a7e0-460262bdc497.png)

Not sure if this one is a controversial change but I've made the Targeting Attributes section toggle open by default. At a quick scan, I didn't see it and thought it was missing.

![CleanShot 2023-01-31 at 12 23 16@2x](https://user-images.githubusercontent.com/113377031/215874252-5c2e826b-3934-46ec-8754-b7900ba369e6.png)

### In the Docs

In the screenshot below:

1. Menu item for encryption support
3. Link to https://docs.growthbook.io/app/api#encryption
4. Where we add the encryption key in the builder config

![CleanShot 2023-01-31 at 12 25 01@2x](https://user-images.githubusercontent.com/113377031/215874818-5d024c41-6fbe-471d-8ea7-7e1e58aa03f0.png)
