### PR TITLE
fix MetricsSelector when datasource is empty

### DIFF
--- a/packages/front-end/components/Experiment/MetricsSelector.tsx
+++ b/packages/front-end/components/Experiment/MetricsSelector.tsx
@@ -14,7 +14,7 @@ const MetricsSelector: FC<{
 }> = ({ datasource, project, selected, onChange, autoFocus }) => {
   const { metrics } = useDefinitions();
   const filteredMetrics = metrics
-    .filter((m) => m.datasource === datasource)
+    .filter((m) => (datasource ? m.datasource === datasource : true))
     .filter((m) => {
       if (!project) return true;
       if (!m?.projects?.length) return true;


### PR DESCRIPTION
northstar metrics selector was not populating metrics due to an often-undefined datasource.