### PR TITLE
961 Enforce organization privileges for encrypted features

### DIFF
--- a/packages/back-end/src/routers/sdk-connection/sdk-connection.controller.ts
+++ b/packages/back-end/src/routers/sdk-connection/sdk-connection.controller.ts
@@ -15,6 +15,7 @@ import {
   findSDKConnectionsByOrganization,
   testProxyConnection,
 } from "../../models/SdkConnectionModel";
+import { orgHasPremiumFeature } from "../../util/organization.util";
 
 export const getSDKConnections = async (
   req: AuthRequest,
@@ -45,7 +46,16 @@ export const postSDKConnection = async (
     params.environment,
   ]);
 
-  const doc = await createSDKConnection({ ...params, organization: org.id });
+  let encryptPayload = false;
+  if (orgHasPremiumFeature(org, "encrypt-features-endpoint")) {
+    encryptPayload = params.encryptPayload;
+  }
+
+  const doc = await createSDKConnection({
+    ...params,
+    encryptPayload,
+    organization: org.id,
+  });
 
   res.status(200).json({
     status: 200,

--- a/packages/back-end/src/routers/sdk-connection/sdk-connection.controller.ts
+++ b/packages/back-end/src/routers/sdk-connection/sdk-connection.controller.ts
@@ -81,7 +81,21 @@ export const putSDKConnection = async (
     [connection.environment]
   );
 
-  await editSDKConnection(connection, req.body);
+  let encryptPayload = req.body.encryptPayload || false;
+  const encryptionPermitted = orgHasPremiumFeature(
+    org,
+    "encrypt-features-endpoint"
+  );
+  const changingFromUnencryptedToEncrypted =
+    !connection.encryptPayload && encryptPayload;
+  if (changingFromUnencryptedToEncrypted && !encryptionPermitted) {
+    encryptPayload = false;
+  }
+
+  await editSDKConnection(connection, {
+    ...req.body,
+    encryptPayload,
+  });
 
   res.status(200).json({
     status: 200,


### PR DESCRIPTION
Adds a check on the backend to make sure the org has permissions to create an encrypted endpoint.

- Closes #961 
