### PR TITLE
Fix safari datestring parsing

### DIFF
--- a/packages/front-end/services/dates.ts
+++ b/packages/front-end/services/dates.ts
@@ -36,7 +36,12 @@ export function getValidDate(
 
   if (!dateStr) return fallback;
 
-  const d = new Date(dateStr);
+  // Fix date parsing for Safari
+  let reformattedDateStr = (dateStr + "").replace(/[/\s]/g, "-");
+  if (reformattedDateStr.match(/-/)?.length === 1) {
+    reformattedDateStr = reformattedDateStr.replace("-", "-1-");
+  }
+  const d = new Date(reformattedDateStr);
   if (isNaN(d.getTime())) {
     return fallback;
   }

--- a/packages/front-end/services/dates.ts
+++ b/packages/front-end/services/dates.ts
@@ -36,12 +36,18 @@ export function getValidDate(
 
   if (!dateStr) return fallback;
 
-  // Fix date parsing for Safari
-  let reformattedDateStr = (dateStr + "").replace(/[/\s]/g, "-");
-  if (reformattedDateStr.match(/-/)?.length === 1) {
-    reformattedDateStr = reformattedDateStr.replace("-", "-1-");
+  let d: Date;
+
+  if (typeof dateStr === "string") {
+    // Fix date parsing for Safari
+    let reformattedDateStr = (dateStr + "").replace(/[/\s]/g, "-");
+    if (reformattedDateStr.match(/-/g)?.length === 1) {
+      reformattedDateStr = reformattedDateStr.replace("-", "-1-");
+    }
+    d = new Date(reformattedDateStr);
+  } else {
+    d = new Date(dateStr);
   }
-  const d = new Date(reformattedDateStr);
   if (isNaN(d.getTime())) {
     return fallback;
   }


### PR DESCRIPTION
Current bug is causing many of the bugs in Safari to render incorrectly.

before:
<img width="826" alt="image" src="https://user-images.githubusercontent.com/7927873/215910582-2a3b6cbc-922a-442f-a9a7-db6d61844ec9.png">

after:
<img width="823" alt="image" src="https://user-images.githubusercontent.com/7927873/215910617-f5a2ed3f-53e6-483a-921d-24df7084e347.png">
