### PR TITLE
Fix experiment graph date format

### DIFF
--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -104,7 +104,7 @@ export async function getExperimentsFrequencyMonth(
     d.setDate(1); // necessary because altering the month may result in an invalid date (ex: Feb 31)
     d.setMonth(d.getMonth() - i);
     const ob = {
-      date: format(d, "MM/dd/yyyy"),
+      date: format(d, "yyyy/MM/dd"),
       numExp: 0,
     };
     allData.push(ob);

--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -96,14 +96,15 @@ export async function getExperimentsFrequencyMonth(
   const { num } = req.params;
   const experiments = await getExperimentsByOrganization(org.id, project);
 
-  const allData: { name: string; numExp: number }[] = [];
+  const allData: { date: string; numExp: number }[] = [];
 
   // make the data array with all the months needed and 0 experiments.
   for (let i = parseInt(num) - 1; i >= 0; i--) {
     const d = new Date();
+    d.setDate(1); // necessary because altering the month may result in an invalid date (ex: Feb 31)
     d.setMonth(d.getMonth() - i);
     const ob = {
-      name: format(d, "MMM yyy"),
+      date: format(d, "MM/dd/yyyy"),
       numExp: 0,
     };
     allData.push(ob);
@@ -133,7 +134,8 @@ export async function getExperimentsFrequencyMonth(
     const monthYear = format(getValidDate(dateStarted), "MMM yyy");
 
     allData.forEach((md, i) => {
-      if (md.name === monthYear) {
+      const name = format(getValidDate(md.date), "MMM yyy");
+      if (name === monthYear) {
         md.numExp++;
         // I can do this because the indexes will represent the same month
         dataByStatus[e.status][i].numExp++;

--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -104,7 +104,7 @@ export async function getExperimentsFrequencyMonth(
     d.setDate(1); // necessary because altering the month may result in an invalid date (ex: Feb 31)
     d.setMonth(d.getMonth() - i);
     const ob = {
-      date: format(d, "yyyy/MM/dd"),
+      date: d.toISOString(),
       numExp: 0,
     };
     allData.push(ob);

--- a/packages/front-end/components/Experiment/ExperimentGraph.tsx
+++ b/packages/front-end/components/Experiment/ExperimentGraph.tsx
@@ -39,10 +39,10 @@ export default function ExperimentGraph({
 
   const { data, error } = useApi<{
     data: {
-      all: { name: string; numExp: number }[];
-      draft: { name: string; numExp: number }[];
-      running: { name: string; numExp: number }[];
-      stopped: { name: string; numExp: number }[];
+      all: { name: string; date: string; numExp: number }[];
+      draft: { name: string; date: string; numExp: number }[];
+      running: { name: string; date: string; numExp: number }[];
+      stopped: { name: string; date: string; numExp: number }[];
     };
   }>(`/experiments/frequency/${resolution}/${num}?project=${project}`);
 
@@ -63,8 +63,8 @@ export default function ExperimentGraph({
     return <div>no data to show</div>;
   }
 
-  const firstMonth = getValidDate(graphData[0].name);
-  const lastMonth = getValidDate(graphData[graphData.length - 1].name);
+  const firstMonth = getValidDate(graphData[0].date);
+  const lastMonth = getValidDate(graphData[graphData.length - 1].date);
 
   return (
     <ParentSizeModern>
@@ -95,7 +95,7 @@ export default function ExperimentGraph({
           const xCoord = coords.x - barWidth;
 
           const barData = graphData.map((d) => {
-            return { xcord: xScale(getValidDate(d.name)), numExp: d.numExp };
+            return { xcord: xScale(getValidDate(d.date)), numExp: d.numExp };
           });
 
           const closestBar = barData.reduce((prev, curr) =>
@@ -140,16 +140,18 @@ export default function ExperimentGraph({
                   scale={yScale}
                   numTicks={Math.min(maxYValue, 5)}
                   width={xMax + barWidth / 2}
+                  stroke="var(--border-color-200)"
                 />
                 {graphData.map((d, i) => {
-                  const barX = xScale(getValidDate(d.name)) - barWidth / 2;
+                  const barX = xScale(getValidDate(d.date)) - barWidth / 2;
                   let barHeight = yMax - (yScale(d.numExp) ?? 0);
                   // if there are no experiments this month, show a little nub for design reasons.
                   if (barHeight === 0) barHeight = 6;
                   const barY = yMax - barHeight;
+                  const name = format(getValidDate(d.date), "MMM yyy");
                   return (
                     <BarRounded
-                      key={d.name + i}
+                      key={name + i}
                       x={barX + 5}
                       y={barY}
                       width={Math.max(10, barWidth - 10)}
@@ -166,12 +168,18 @@ export default function ExperimentGraph({
                   top={yMax}
                   scale={xScale}
                   numTicks={
-                    width > 567
+                    width > 670
                       ? graphData.length
                       : Math.ceil(graphData.length / 2)
                   }
+                  tickLabelProps={() => ({
+                    fill: "var(--text-color-table)",
+                    fontSize: 11,
+                    textAnchor: "start",
+                    dx: -25,
+                  })}
                   hideAxisLine={false}
-                  stroke={"#C2C5D6"}
+                  stroke={"var(--text-color-table)"}
                   hideTicks={true}
                   rangePadding={barWidth / 2}
                   tickFormat={(v) => {
@@ -181,7 +189,14 @@ export default function ExperimentGraph({
                 <AxisLeft
                   scale={yScale}
                   numTicks={Math.min(maxYValue, 5)}
-                  stroke={"#C2C5D6"}
+                  tickLabelProps={() => ({
+                    fill: "var(--text-color-table)",
+                    fontSize: 11,
+                    textAnchor: "end",
+                    dx: -2,
+                    dy: 2,
+                  })}
+                  stroke={"var(--text-color-table)"}
                   hideTicks={true}
                   tickFormat={(v) => {
                     return Math.round(v as number) + "";

--- a/packages/front-end/components/Experiment/ExperimentGraph.tsx
+++ b/packages/front-end/components/Experiment/ExperimentGraph.tsx
@@ -39,10 +39,10 @@ export default function ExperimentGraph({
 
   const { data, error } = useApi<{
     data: {
-      all: { name: string; date: string; numExp: number }[];
-      draft: { name: string; date: string; numExp: number }[];
-      running: { name: string; date: string; numExp: number }[];
-      stopped: { name: string; date: string; numExp: number }[];
+      all: { date: string; numExp: number }[];
+      draft: { date: string; numExp: number }[];
+      running: { date: string; numExp: number }[];
+      stopped: { date: string; numExp: number }[];
     };
   }>(`/experiments/frequency/${resolution}/${num}?project=${project}`);
 

--- a/packages/front-end/components/Layout/TopNav.module.scss
+++ b/packages/front-end/components/Layout/TopNav.module.scss
@@ -36,13 +36,13 @@ $sidebarwidth: 240px;
 }
 .leftSection {
   display: flex;
-  justify-content: start;
+  justify-content: flex-start;
   align-items: center;
   max-width: 30%;
 }
 .rightSection {
   display: flex;
-  justify-content: end;
+  justify-content: flex-end;
   align-items: center;
 }
 @media (max-width: 1180px) {

--- a/packages/front-end/components/Metrics/DateGraph.tsx
+++ b/packages/front-end/components/Metrics/DateGraph.tsx
@@ -480,6 +480,7 @@ const DateGraph: FC<{
                 <AxisBottom
                   top={graphHeight}
                   scale={xScale}
+                  stroke={"var(--text-color-table)"}
                   numTicks={numXTicks}
                   tickLabelProps={() => ({
                     fill: "var(--text-color-table)",
@@ -496,6 +497,7 @@ const DateGraph: FC<{
                 />
                 <AxisLeft
                   scale={yScale}
+                  stroke={"var(--text-color-table)"}
                   numTicks={numYTicks}
                   tickLabelProps={() => ({
                     fill: "var(--text-color-table)",


### PR DESCRIPTION
Current date format issues are causing Safari to render ExperimentGraph incorrectly. Also fixed some layout issues.

before:
<img width="826" alt="image" src="https://user-images.githubusercontent.com/7927873/215910582-2a3b6cbc-922a-442f-a9a7-db6d61844ec9.png">

after:
<img width="826" alt="image" src="https://user-images.githubusercontent.com/7927873/215979202-f5f74bf1-ed51-4fd2-bee5-d8da24b6c6bb.png">

