### PR TITLE
GBKOSS-15 - [Bug] Cannot edit Dimension

### DIFF
--- a/packages/front-end/components/Dimensions/DimensionForm.tsx
+++ b/packages/front-end/components/Dimensions/DimensionForm.tsx
@@ -82,7 +82,7 @@ const DimensionForm: FC<{
         }))}
         className="portal-overflow-ellipsis"
       />
-      {dsProps.userIds && (
+      {dsProps?.userIds && (
         <SelectField
           label="Identifier Type"
           required


### PR DESCRIPTION
Features and changes
This PR fixes https://github.com/growthbook/growthbook/issues/588
Before the bug fix

`DimensionForm.tsx?552d:87 Uncaught TypeError: Cannot read properties of undefined (reading 'userIds')
    at DimensionForm (DimensionForm.tsx?552d:87:16)`
Clicking the edit icon on the dimensions page crashes.

After bug fix

Clicking the edit icon opens the edit modal

![Screenshot from 2023-02-21 09-20-53](https://user-images.githubusercontent.com/63657008/220263587-b1fc7415-cd82-4bbf-8329-50557bc9f623.png)

