### PR TITLE
Bump gbstats to 0.3.1

### DIFF
--- a/packages/stats/LICENSE
+++ b/packages/stats/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021, GrowthBook, Inc.
+Copyright (c) 2023, GrowthBook, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/stats/gbstats/__init__.py
+++ b/packages/stats/gbstats/__init__.py
@@ -1,3 +1,3 @@
 """Top-level package for GrowthBook Stats."""
 
-__version__ = "0.2.0"
+__version__ = "0.3.1"

--- a/packages/stats/gbstats/gen_notebook.py
+++ b/packages/stats/gbstats/gen_notebook.py
@@ -65,7 +65,7 @@ def create_notebook(
         ),
         nbf.new_markdown_cell("## Notebook Setup"),
         nbf.new_code_cell(
-            "# Requires gbstats version 0.2.1 or higher\n"
+            "# Requires gbstats version 0.3.1 or higher\n"
             "from gbstats.gbstats import (\n"
             "  detect_unknown_variations,\n"
             "  analyze_metric_df,\n"

--- a/packages/stats/pyproject.toml
+++ b/packages/stats/pyproject.toml
@@ -1,7 +1,7 @@
 [tool]
 [tool.poetry]
 name = "gbstats"
-version = "0.3.0"
+version = "0.3.1"
 homepage = "https://github.com/growthbook/growthbook/tree/main/packages/stats"
 description = "Stats engine for GrowthBook, the open source feature flagging and A/B testing platform."
 authors = ["Jeremy Dorn <jeremy@growthbook.io>"]


### PR DESCRIPTION
### Features and Changes

Bumps gbstats to 0.3.1 so we can release it before bumping it to 0.4.0 as part of the Integration refactor (#841 ).

Should help with backwards compatibility.
