### PR TITLE
Add support for non-lognormal dist in experiment date result CIs

### DIFF
--- a/packages/front-end/components/Experiment/DateResults.tsx
+++ b/packages/front-end/components/Experiment/DateResults.tsx
@@ -110,7 +110,7 @@ const DateResults: FC<{
                     value = Math.exp(x) - 1;
                   } else {
                     error = [x - 2 * sx, x + 2 * sx];
-                    value = Math.exp(x) - 1;
+                    value = x;
                   }
                 }
                 // For non-baseline variations and cumulative turned ON, calculate uplift from cumulative data

--- a/packages/front-end/components/Experiment/DateResults.tsx
+++ b/packages/front-end/components/Experiment/DateResults.tsx
@@ -99,10 +99,19 @@ const DateResults: FC<{
                 if (i && !cumulative) {
                   const x = uplift?.mean || 0;
                   const sx = uplift?.stddev || 0;
-                  // Uplift distribution is lognormal, so need to correct this
-                  // Add 2 standard deviations (~95% CI) for an error bar
-                  error = [Math.exp(x - 2 * sx) - 1, Math.exp(x + 2 * sx) - 1];
-                  value = Math.exp(x) - 1;
+                  const dist = uplift?.dist || "";
+                  if (dist === "lognormal") {
+                    // Uplift distribution is lognormal, so need to correct this
+                    // Add 2 standard deviations (~95% CI) for an error bar
+                    error = [
+                      Math.exp(x - 2 * sx) - 1,
+                      Math.exp(x + 2 * sx) - 1,
+                    ];
+                    value = Math.exp(x) - 1;
+                  } else {
+                    error = [x - 2 * sx, x + 2 * sx];
+                    value = Math.exp(x) - 1;
+                  }
                 }
                 // For non-baseline variations and cumulative turned ON, calculate uplift from cumulative data
                 else if (i) {


### PR DESCRIPTION
### Features and Changes

Ensure that if `uplift.dist` is not lognormal that we don't transform the CIs for the date experiment view (only a problem for frequentist results ATM).

In other words, ensures the CIs in these kind of date plots are correct for the Frequentist engine:

![image](https://user-images.githubusercontent.com/5298599/216664179-86c28d6e-89d3-434b-bb11-c55f8d0265c2.png)


### Screenshots
Gut check that CIs are changing only for frequentist engine. Also checked offline that these values are closer to the `ci` values we return with our results.

*Frequentist - before*
<img width="476" alt="Screen Shot 2023-02-03 at 8 58 00 AM" src="https://user-images.githubusercontent.com/5298599/216662485-e0cfa34c-376d-435c-b475-72ec8ad91064.png">

*Frequentist - after*
These are the correct, non-rescaled values
<img width="491" alt="Screen Shot 2023-02-03 at 8 57 10 AM" src="https://user-images.githubusercontent.com/5298599/216662549-9a424bc9-88b3-405e-810f-3900a4b8f47d.png">

*Bayesian - before*
<img width="474" alt="Screen Shot 2023-02-03 at 8 58 38 AM" src="https://user-images.githubusercontent.com/5298599/216662607-e45b0018-2fc5-433a-8bcc-398832f2fb22.png">

*Bayesian - after*
Should be unchanged.
<img width="463" alt="Screen Shot 2023-02-03 at 8 59 11 AM" src="https://user-images.githubusercontent.com/5298599/216662643-b9784c42-2cd0-4756-8390-6f4b8370b94b.png">
