### PR TITLE
add basic refresh capability for northstar metric displays

### DIFF
--- a/packages/front-end/components/HomePage/NorthStarMetricDisplay.tsx
+++ b/packages/front-end/components/HomePage/NorthStarMetricDisplay.tsx
@@ -69,7 +69,7 @@ const NorthStarMetricDisplay = ({
           </div>
         ) : (
           <div className="mb-4">
-            <h5 className="mb-3">{metric.name}</h5>
+            <h5 className="my-3">{metric.name}</h5>
             {permissions.check("runQueries", "") && (
               <form
                 onSubmit={async (e) => {
@@ -94,6 +94,7 @@ const NorthStarMetricDisplay = ({
                   statusEndpoint={`/metric/${metric.id}/analysis/status`}
                   cancelEndpoint={`/metric/${metric.id}/analysis/cancel`}
                   color="outline-primary"
+                  position="left"
                   onReady={() => {
                     mutate();
                   }}
@@ -110,10 +111,10 @@ const NorthStarMetricDisplay = ({
                 Your analysis is currently running.
               </div>
             )}
-            <div>
+            <div className="mt-2">
               <em>
-                No data for this metric yet. Click the Run Analysis button
-                above.
+                No data for this metric yet. Click the{" "}
+                {analysis ? "Refresh Data" : "Run Analysis"} button above.
               </em>
             </div>
           </div>

--- a/packages/front-end/components/HomePage/NorthStarMetricDisplay.tsx
+++ b/packages/front-end/components/HomePage/NorthStarMetricDisplay.tsx
@@ -4,6 +4,11 @@ import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
 import useApi from "@/hooks/useApi";
 import LoadingOverlay from "@/components/LoadingOverlay";
 import { useDefinitions } from "@/services/DefinitionsContext";
+import RunQueriesButton, {
+  getQueryStatus,
+} from "@/components/Queries/RunQueriesButton";
+import usePermissions from "@/hooks/usePermissions";
+import { useAuth } from "@/services/auth";
 import DateGraph from "../Metrics/DateGraph";
 
 const NorthStarMetricDisplay = ({
@@ -17,7 +22,10 @@ const NorthStarMetricDisplay = ({
   resolution?: string;
 }): React.ReactElement => {
   const { project } = useDefinitions();
-  const { data, error } = useApi<{
+  const permissions = usePermissions();
+  const { apiCall } = useAuth();
+
+  const { data, error, mutate } = useApi<{
     metric: MetricInterface;
     experiments: Partial<ExperimentInterfaceStringDates>[];
   }>(`/metric/${metricId}`);
@@ -41,11 +49,13 @@ const NorthStarMetricDisplay = ({
   if (!analysis || !("average" in analysis)) {
     analysis = null;
   }
+  const status = getQueryStatus(metric.queries || [], metric.analysisError);
+  const hasQueries = metric.queries?.length > 0;
 
   return (
     <>
       <div>
-        {analysis && analysis?.dates && analysis.dates.length > 0 && (
+        {analysis && analysis?.dates && analysis.dates.length > 0 ? (
           <div className="mb-4">
             <h5 className="mb-3">{metric.name}</h5>
             <DateGraph
@@ -56,6 +66,56 @@ const NorthStarMetricDisplay = ({
               groupby={resolution === "week" ? "week" : "day"}
               height={300}
             />
+          </div>
+        ) : (
+          <div className="mb-4">
+            <h5 className="mb-3">{metric.name}</h5>
+            {permissions.check("runQueries", "") && (
+              <form
+                onSubmit={async (e) => {
+                  e.preventDefault();
+                  try {
+                    await apiCall(`/metric/${metric.id}/analysis`, {
+                      method: "POST",
+                    });
+                    mutate();
+                  } catch (e) {
+                    console.error(e);
+                  }
+                }}
+              >
+                <RunQueriesButton
+                  icon="refresh"
+                  cta={analysis ? "Refresh Data" : "Run Analysis"}
+                  initialStatus={getQueryStatus(
+                    metric.queries || [],
+                    metric.analysisError
+                  )}
+                  statusEndpoint={`/metric/${metric.id}/analysis/status`}
+                  cancelEndpoint={`/metric/${metric.id}/analysis/cancel`}
+                  color="outline-primary"
+                  onReady={() => {
+                    mutate();
+                  }}
+                />
+              </form>
+            )}
+            {hasQueries && status === "failed" && (
+              <div className="alert alert-danger my-3">
+                Error running the analysis.
+              </div>
+            )}
+            {hasQueries && status === "running" && (
+              <div className="alert alert-info my-3">
+                Your analysis is currently running.
+              </div>
+            )}
+            <div>
+              <em>
+                No data for this metric yet. Click the Run Analysis button
+                above.
+              </em>
+            </div>
           </div>
         )}
       </div>

--- a/packages/front-end/components/Queries/RunQueriesButton.tsx
+++ b/packages/front-end/components/Queries/RunQueriesButton.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useState } from "react";
+import { FC, ReactElement, useEffect, useState } from "react";
 import { QueryStatus, Queries } from "back-end/types/query";
 import clsx from "clsx";
 import { FaPlay } from "react-icons/fa";
@@ -46,6 +46,7 @@ const RunQueriesButton: FC<{
   icon?: "run" | "refresh";
   onReady: () => void;
   color?: string;
+  position?: "left" | "right";
 }> = ({
   cta = "Run Queries",
   loadingText = "Running",
@@ -55,6 +56,7 @@ const RunQueriesButton: FC<{
   onReady,
   icon = "run",
   color = "primary",
+  position = "right",
 }) => {
   const { data, error, mutate } = useApi<{
     queryStatus: QueryStatus;
@@ -119,7 +121,7 @@ const RunQueriesButton: FC<{
     setCounter(data?.elapsed || 0);
   }, [data?.elapsed]);
 
-  let buttonIcon: React.ReactElement;
+  let buttonIcon: ReactElement;
   if (status === "running") {
     buttonIcon = <LoadingSpinner />;
   } else if (icon === "refresh") {
@@ -130,7 +132,11 @@ const RunQueriesButton: FC<{
 
   return (
     <>
-      <div className="d-flex justify-content-end">
+      <div
+        className={`d-flex ${
+          position === "right" ? "justify-content-end" : "justify-content-start"
+        }`}
+      >
         {status === "running" && (
           <div>
             <button


### PR DESCRIPTION
If a metric used as a northstar had no valid analysis, the dashboard would display nothing (making it seem as though there was a bug with northstar metric selection). Instead, we add a refresh button to indicate that the analysis is actually missing or stale.
![image](https://user-images.githubusercontent.com/7927873/217060525-a98988f7-5d01-457e-820d-3341b14900c6.png)
