### PR TITLE
GBK-920 - Standardize on MultiSelect (vs TypeAhead) 

### DIFF
--- a/packages/front-end/components/GroupsInput.tsx
+++ b/packages/front-end/components/GroupsInput.tsx
@@ -1,6 +1,6 @@
 import { FC } from "react";
-import { Typeahead } from "react-bootstrap-typeahead";
 import { useDefinitions } from "../services/DefinitionsContext";
+import MultiSelectField from "./Forms/MultiSelectField";
 
 const GroupsInput: FC<{
   onChange: (groups: string[]) => void;
@@ -9,26 +9,23 @@ const GroupsInput: FC<{
   const { groups } = useDefinitions();
 
   return (
-    <Typeahead
+    <MultiSelectField
       id="groups-input"
-      newSelectionPrefix="New Group: "
-      labelKey="name"
-      multiple={true}
-      allowNew={true}
+      placeholder="Groups..."
+      value={value}
       options={groups.map((group) => {
         return {
-          id: group,
-          name: group,
+          label: group,
+          value: group,
         };
       })}
-      onChange={(selected: { id: string; name: string }[]) => {
-        onChange(selected.map((s) => s.name).filter((t) => t.length > 0));
+      onChange={(value: string[]) => {
+        value.map((t) => groups.push(t));
+        onChange(value.filter((t) => t.length > 0));
       }}
-      selected={value.map((v) => {
-        return { id: v, name: v };
-      })}
-      placeholder="Groups..."
-      positionFixed={true}
+      closeMenuOnSelect={true}
+      autoFocus={true}
+      creatable={true}
     />
   );
 };


### PR DESCRIPTION
**Features and Changes**

We currently have at least 2 components we use for type-ahead/multiple select form fields.

TypeAhead
MultiSelect
We are trying to standardize to MultiSelect so let's do that.

There is also a bug (needs more information) with the TypeAhead component when there is only one option.

This PR fixes issue https://github.com/growthbook/growthbook/issues/920 

**After implementation**
Successfully replaced the TypeAhead with the MultiSelect while retaining functionality as soon in the video below:

https://www.loom.com/share/9ae12902511f475fa24f69cf90ceb14c 

