### PR TITLE
[Bug] Cannot edit segment

### DIFF
--- a/packages/front-end/components/Segments/SegmentForm.tsx
+++ b/packages/front-end/components/Segments/SegmentForm.tsx
@@ -79,7 +79,7 @@ const SegmentForm: FC<{
         }))}
         className="portal-overflow-ellipsis"
       />
-      {datasource.properties.userIds && (
+      {datasource?.properties.userIds && (
         <SelectField
           label="Identifier Type"
           required


### PR DESCRIPTION
Features and Changes

This PR fixes issue https://github.com/growthbook/growthbook/issues/587

Before the bug
```
Uncaught TypeError: Cannot read properties of null (reading 'properties')
    at SegmentForm (SegmentForm.tsx?a785:84:19)
```
Clicking the Edit icon crashes

After the bug Fix

https://www.loom.com/share/d479ffe7dd0247f384515545d9b422d6
