### PR TITLE
 [Feature] Return creator email in the 'GET /api/v1/features' API

### DIFF
--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -213,6 +213,7 @@ export async function postFeatures(
     defaultValue: "",
     valueType: "boolean",
     owner: userName,
+    ownerEmail: email,
     description: "",
     project: "",
     environmentSettings,

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -36,6 +36,7 @@ const featureSchema = new mongoose.Schema({
   organization: String,
   nextScheduledUpdate: Date,
   owner: String,
+  ownerEmail: String,
   project: String,
   dateCreated: Date,
   dateUpdated: Date,

--- a/packages/back-end/types/feature.d.ts
+++ b/packages/back-end/types/feature.d.ts
@@ -32,6 +32,7 @@ export interface FeatureInterface {
   organization: string;
   nextScheduledUpdate?: Date | null;
   owner: string;
+  ownerEmail?: string;
   project?: string;
   dateCreated: Date;
   dateUpdated: Date;


### PR DESCRIPTION
Fixes Issue  https://github.com/growthbook/growthbook/issues/967

### Feature Description

We have a use case where we need to tag the owner/creator of long-running feature flags on slack or an issue on our project tracker.

I was looking at the GET /api/v1/features API and found that the owner information is available but it is a free text field and revision.publishedBy contains the email address of the person who did the last change. We are unable to co-related the free text owner field with the email address as multiple people can have the same name.

Having the creator's email address along with each of the features would help us tag the correct user.

If you could expose the /history/feature/<feature-id> externally, that should also work. We can pick up the oldest revision from it to get the user.

### Screenshot Fixes
<img width="1266" alt="Screenshot 2023-02-27 at 18 15 51" src="https://user-images.githubusercontent.com/122984233/221564530-79fd6d3e-b33e-49be-9a27-abbb445870e3.png">
<img width="864" alt="Screenshot 2023-02-27 at 18 15 05" src="https://user-images.githubusercontent.com/122984233/221564633-b67c100d-87c4-40c2-a1db-5477696ca1a5.png">

### Demo video
https://www.loom.com/share/204de5f92f414de098334cabfcdf6bd1
