### PR TITLE
[Bug] Broken vertical guides in CI plot when metric names are long

### DIFF
--- a/packages/front-end/components/Experiment/PercentGraphColumn.tsx
+++ b/packages/front-end/components/Experiment/PercentGraphColumn.tsx
@@ -4,6 +4,7 @@ import useConfidenceLevels from "@/hooks/useConfidenceLevels";
 import { hasEnoughData } from "@/services/experiments";
 import { useOrganizationMetricDefaults } from "@/hooks/useOrganizationMetricDefaults";
 import AlignedGraph from "./AlignedGraph";
+import { useState, useRef, useEffect } from "react";
 
 export default function PercentGraphColumn({
   metric,
@@ -26,8 +27,15 @@ export default function PercentGraphColumn({
   const barType = _barType ? _barType : stats.uplift?.dist ? "violin" : "pill";
 
   const showGraph = metric && enoughData;
+  const [height, setHeight] = useState(0);
+  const ref = useRef(null);
+
+  useEffect(() => {
+    setHeight(ref.current.clientHeight);
+  });
+
   return (
-    <td className="compact-graph pb-0 align-middle">
+    <td className="compact-graph pb-0 align-middle" ref={ref}>
       <AlignedGraph
         ci={showGraph ? stats.ci || [] : [0, 0]}
         id={id}
@@ -43,7 +51,7 @@ export default function PercentGraphColumn({
             ? stats.chanceToWin > ciUpper || stats.chanceToWin < ciLower
             : false
         }
-        height={75}
+        height={height}
         inverse={!!metric?.inverse}
       />
     </td>


### PR DESCRIPTION
Fixes Issue https://github.com/growthbook/growthbook/issues/884 
When metric names are long, the vertical guides in the CI plot are broken.

Before implementation:
![image](https://user-images.githubusercontent.com/68685849/220129826-b481f219-a801-464e-af4b-b026519e751f.png)

After implementation:
![chart-after](https://user-images.githubusercontent.com/68685849/220130004-1ffbee5a-07d8-45ea-a057-777c5f3c8385.png)

