### PR TITLE
    [Feature] Include Last Date Access column in Teams page

### DIFF
--- a/packages/back-end/src/models/OrganizationModel.ts
+++ b/packages/back-end/src/models/OrganizationModel.ts
@@ -42,6 +42,20 @@ const organizationSchema = new mongoose.Schema({
     {
       ...baseMemberFields,
       id: String,
+      role: String,
+      dateCreated: Date,
+      lastAccessDate: Date,
+      limitAccessByEnvironment: Boolean,
+      environments: [String],
+      projectRoles: [
+        {
+          _id: false,
+          project: String,
+          role: String,
+          limitAccessByEnvironment: Boolean,
+          environments: [String],
+        },
+      ],
     },
   ],
   invites: [

--- a/packages/back-end/src/services/organizations.ts
+++ b/packages/back-end/src/services/organizations.ts
@@ -5,6 +5,7 @@ import {
   findAllOrganizations,
   findOrganizationById,
   findOrganizationByInviteKey,
+  findOrganizationsByMemberId,
   findOrganizationsByDomain,
   updateOrganization,
 } from "../models/OrganizationModel";
@@ -205,6 +206,22 @@ export async function removeMember(
   });
 
   return organization;
+}
+
+export async function updateOrganizationMemberLastAccessDate(userId: string) {
+  const memberOrganization = await findOrganizationsByMemberId(userId);
+  const promise = memberOrganization.map((mo) => {
+    const members: Array<Member> = mo.members.map((u) => {
+      if (u.id == userId) {
+        return { ...u, lastAccessDate: new Date() };
+      }
+      return u;
+    });
+    return updateOrganization(mo.id, {
+      members,
+    });
+  });
+  return Promise.all(promise);
 }
 
 export async function revokeInvite(

--- a/packages/back-end/types/organization.d.ts
+++ b/packages/back-end/types/organization.d.ts
@@ -71,6 +71,7 @@ export interface PendingMember extends MemberRoleWithProjects {
 export interface Member extends MemberRoleWithProjects {
   id: string;
   dateCreated?: Date;
+  lastAccessDate?: Date;
 }
 
 export interface ExpandedMember extends Member {

--- a/packages/front-end/components/Settings/Team/MemberList.tsx
+++ b/packages/front-end/components/Settings/Team/MemberList.tsx
@@ -71,6 +71,7 @@ const MemberList: FC<{
           <tr>
             <th>Name</th>
             <th>Email</th>
+            <th>Last Date Access</th>
             <th>Date Joined</th>
             <th>{project ? "Project Role" : "Global Role"}</th>
             {!project && <th>Project Roles</th>}
@@ -90,6 +91,9 @@ const MemberList: FC<{
               <tr key={id}>
                 <td>{member.name}</td>
                 <td>{member.email}</td>
+                <td>
+                  {member.lastAccessDate && datetime(member.lastAccessDate)}
+                </td>
                 <td>{member.dateCreated && datetime(member.dateCreated)}</td>
                 <td>{roleInfo.role}</td>
                 {!project && (


### PR DESCRIPTION
fixes issue[834](  https://github.com/growthbook/growthbook/issues/834)

### Feature Description

Include timestamp of last access to GrowthBook left to the Date Joined column in the Teams page.

### Screenshot and Fixes
<img width="1280" alt="Screenshot 2023-02-27 at 21 47 04" src="https://user-images.githubusercontent.com/122984233/221615097-642c7b69-f1dd-49c0-b519-11f8da779afe.png">

