### PR TITLE
Fix Localstorage bug in Javascript SDK

### DIFF
--- a/packages/sdk-js/package.json
+++ b/packages/sdk-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@growthbook/growthbook",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/sdk-js/src/types/growthbook.ts
+++ b/packages/sdk-js/src/types/growthbook.ts
@@ -163,7 +163,7 @@ export type Polyfills = {
   SubtleCrypto: any;
   // eslint-disable-next-line
   EventSource: any;
-  localStorage: LocalStorageCompat;
+  localStorage?: LocalStorageCompat;
 };
 
 export interface LocalStorageCompat {

--- a/packages/sdk-react/package.json
+++ b/packages/sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@growthbook/growthbook-react",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -36,7 +36,7 @@
     "react": "^16.8.0-0 || ^17.0.0-0 || ^18.0.0-0"
   },
   "dependencies": {
-    "@growthbook/growthbook": "^0.21.1"
+    "@growthbook/growthbook": "^0.21.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.19.3",


### PR DESCRIPTION
### Features and Changes

Our Javascript SDK does `globalThis.localStorage` without wrapping in a try/catch.  In Incognito windows with strict security settings, this can throw an uncaught exception.

This PR wraps the code in a try/catch to prevent that error.