### PR TITLE
Remove control result from determining guardrail header in Frequentist engine

### DIFF
--- a/packages/front-end/components/Experiment/PValueGuardrailResults.tsx
+++ b/packages/front-end/components/Experiment/PValueGuardrailResults.tsx
@@ -33,6 +33,8 @@ const HeaderResult: FC<{
   metric: MetricInterface;
   results: PValueGuardrailResult[];
 }> = ({ metric, results }) => {
+  // remove control for determining header
+  results.shift();
   const anyInsufficientData = results.some((r) => !r.hasEnoughData);
   const significantNegativeDirection = results.some(
     (r) => !r.expectedDirection && r.statSig


### PR DESCRIPTION
### Current buggy behavior

The problem is limited to the Frequentist engine. We shouldn't show the yellow `Danger` exclamation header for guardrail metrics when all variations are `Better` with a p-value > 0.05 (in otherwords, seems fine, but not enough evidence).

<img width="292" alt="Screen Shot 2023-02-10 at 5 13 52 PM" src="https://user-images.githubusercontent.com/5298599/218221060-dd960984-b1ff-419b-a34f-659646360bc0.png">

This is caused by our checks in `HeaderResult` looping over the control bucket, which always had `expectedDirection: False` since it had a `stats.expected` value == to 0 (I think). 

### Fixed behavior

Just remove the control (or whatever is the first indexed bucket, which for now we always assume is the control) when deciding the header color). I use `shift()`. Please advise if there is another preferred approach.

We could `null` out `statSig` and `expectedDirection` for the control to be a bit more honest with what `PValueGuardrailResult` should be, but this quickfix works and seems reasonable.

<img width="275" alt="Screen Shot 2023-02-10 at 5 14 24 PM" src="https://user-images.githubusercontent.com/5298599/218221738-0027e547-d2f9-4d3d-8c13-5e2c961a8aee.png">