### PR TITLE
GBK[457] - 457 Support case-sensitive (upper-case) feature names

### DIFF
--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -220,7 +220,7 @@ export async function postFeatures(
     dateCreated: new Date(),
     dateUpdated: new Date(),
     organization: org.id,
-    id: id.toLowerCase(),
+    id: id,
     archived: false,
     revision: {
       version: 1,


### PR DESCRIPTION
Fixes issue [https://github.com/growthbook/growthbook/issues/457](https://github.com/growthbook/growthbook/issues/457)

Bug:
I added a feature named "showSecretUI" and after saving it, the name turned into "showsecretui" -- not good. There is nothing indicating that lower-casing would happen:

<img width="803" alt="181344566-8c5e46bc-e6e6-4629-8f0e-c673951a2ac2" src="https://user-images.githubusercontent.com/68685849/220178448-b6869b58-3a59-44f9-8650-6a5663a18a8c.png">

Before applying fix:
![beforeUpper](https://user-images.githubusercontent.com/68685849/220178331-c3a53835-286a-4c9d-ba59-6bcc17ca2de2.png)

After applying fix:
![image](https://user-images.githubusercontent.com/68685849/220178385-9414ba70-46f3-4100-b186-d84acb3a0fdb.png)

Testing:
-Create a new Feature and name it with lower and Upper casing, then checkout feature name after it is created 