### PR TITLE
GBKOSS-24 - [Bug] Experiments with 6, 7, and 10 variations can't be saved

### DIFF
--- a/packages/front-end/services/features.ts
+++ b/packages/front-end/services/features.ts
@@ -250,7 +250,6 @@ export function validateFeatureRule(
     ruleValues.forEach((val, i) => {
       if (val.weight < 0)
         throw new Error("Variation weights cannot be negative");
-      val.weight = roundVariationWeight(val.weight);
       totalWeight += val.weight;
       const newValue = validateFeatureValue(
         valueType,


### PR DESCRIPTION
Fixes issue [https://github.com/growthbook/growthbook/issues/880](https://github.com/growthbook/growthbook/issues/880)
Summary
When creating an experiment, if you have 6,7, or 10 variations (and likely others) you're unable to save. The weight of the variations add up to above 1, and there is no way to adjust a single variation down in order to save it, as adjusting 1 variation down, adjusts another variation up on a 1:1 scale.

Before Implementation:
![Before-567](https://user-images.githubusercontent.com/68685849/220175349-4dd5955b-5593-473d-9888-eb5f689d836b.png)


After Implementation fix:
![image](https://user-images.githubusercontent.com/68685849/220175297-a8be0df9-2e55-4938-aadb-d053e3616cc6.png)

