### PR TITLE
Automatically add verifiedDomain when possible to new Cloud orgs

### DIFF
--- a/packages/back-end/src/controllers/auth.ts
+++ b/packages/back-end/src/controllers/auth.ts
@@ -251,7 +251,11 @@ export async function postFirstTimeRegister(
   }
 
   const user = await createUser(name, email, password);
-  await createOrganization(email, user.id, companyname, "");
+  await createOrganization({
+    email,
+    userId: user.id,
+    name: companyname,
+  });
   markInstalled();
 
   sendLocalSuccessResponse(req, res, user);

--- a/packages/back-end/src/models/OrganizationModel.ts
+++ b/packages/back-end/src/models/OrganizationModel.ts
@@ -105,13 +105,19 @@ function toInterface(doc: OrganizationDocument): OrganizationInterface {
   return upgradeOrganizationDoc(doc.toJSON());
 }
 
-export async function createOrganization(
-  email: string,
-  userId: string,
-  name: string,
-  url: string,
-  verifiedDomain: string = ""
-) {
+export async function createOrganization({
+  email,
+  userId,
+  name,
+  url = "",
+  verifiedDomain = "",
+}: {
+  email: string;
+  userId: string;
+  name: string;
+  url?: string;
+  verifiedDomain?: string;
+}) {
   // TODO: sanitize fields
   const doc = await OrganizationModel.create({
     ownerEmail: email,

--- a/packages/back-end/src/models/OrganizationModel.ts
+++ b/packages/back-end/src/models/OrganizationModel.ts
@@ -109,13 +109,15 @@ export async function createOrganization(
   email: string,
   userId: string,
   name: string,
-  url: string
+  url: string,
+  verifiedDomain: string = ""
 ) {
   // TODO: sanitize fields
   const doc = await OrganizationModel.create({
     ownerEmail: email,
     name,
     url,
+    verifiedDomain,
     invites: [],
     members: [
       {

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -1034,13 +1034,12 @@ export async function signup(req: AuthRequest<SignupBody>, res: Response) {
     if (!req.userId) {
       throw Error("Must be logged in");
     }
-    const org = await createOrganization(
-      req.email,
-      req.userId,
-      company,
-      "",
-      verifiedDomain
-    );
+    const org = await createOrganization({
+      email: req.email,
+      userId: req.userId,
+      name: company,
+      verifiedDomain,
+    });
 
     // Alert the site manager about new organizations that are created
     try {

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -22,11 +22,7 @@ import {
   getNonSensitiveParams,
   getSourceIntegrationObject,
 } from "../../services/datasource";
-import {
-  getUserById,
-  getUsersByIds,
-  updatePassword,
-} from "../../services/users";
+import { getUsersByIds, updatePassword } from "../../services/users";
 import { getAllTags } from "../../models/TagModel";
 import {
   ExpandedMember,
@@ -330,9 +326,7 @@ export async function putMember(
   if (!orgId) {
     throw new Error("Must provide orgId");
   }
-
-  const user = await getUserById(req.userId);
-  if (!user?.verified) {
+  if (!req.verified) {
     throw new Error("User is not verified");
   }
 
@@ -1007,14 +1001,11 @@ export async function signup(req: AuthRequest<SignupBody>, res: Response) {
   let verifiedDomain = "";
   if (IS_CLOUD) {
     // if the owner is verified, try to infer a verified domain
-    if (req.userId) {
-      const user = await findUserById(req.userId);
-      if (user?.verified) {
-        const domain = user.email.toLowerCase().split("@")[1] || "";
-        const isFreeDomain = freeEmailDomains.includes(domain);
-        if (!isFreeDomain) {
-          verifiedDomain = domain;
-        }
+    if (req.email && req.verified) {
+      const domain = req.email.toLowerCase().split("@")[1] || "";
+      const isFreeDomain = freeEmailDomains.includes(domain);
+      if (!isFreeDomain) {
+        verifiedDomain = domain;
       }
     }
   }

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -1020,7 +1020,7 @@ export async function signup(req: AuthRequest<SignupBody>, res: Response) {
       if (user?.verified) {
         const domain = user.email.toLowerCase().split("@")[1] || "";
         const isFreeDomain = freeEmailDomains.includes(domain);
-        if (isFreeDomain) {
+        if (!isFreeDomain) {
           verifiedDomain = domain;
         }
       }

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -1,5 +1,6 @@
 import { Response } from "express";
 import { cloneDeep } from "lodash";
+import { freeEmailDomains } from "free-email-domains-typescript";
 import {
   AuthRequest,
   ResponseWithStatusAndError,
@@ -21,7 +22,11 @@ import {
   getNonSensitiveParams,
   getSourceIntegrationObject,
 } from "../../services/datasource";
-import { getUsersByIds, updatePassword } from "../../services/users";
+import {
+  getUserById,
+  getUsersByIds,
+  updatePassword,
+} from "../../services/users";
 import { getAllTags } from "../../models/TagModel";
 import {
   ExpandedMember,
@@ -332,6 +337,11 @@ export async function putMember(
   const { orgId } = req.body;
   if (!orgId) {
     throw new Error("Must provide orgId");
+  }
+
+  const user = await getUserById(req.userId);
+  if (!user?.verified) {
+    throw new Error("User is not verified");
   }
 
   // ensure org matches calculated verified org
@@ -1002,6 +1012,21 @@ export async function signup(req: AuthRequest<SignupBody>, res: Response) {
     }
   }
 
+  let verifiedDomain = "";
+  if (IS_CLOUD) {
+    // if the owner is verified, try to infer a verified domain
+    if (req.userId) {
+      const user = await findUserById(req.userId);
+      if (user?.verified) {
+        const domain = user.email.toLowerCase().split("@")[1] || "";
+        const isFreeDomain = freeEmailDomains.includes(domain);
+        if (isFreeDomain) {
+          verifiedDomain = domain;
+        }
+      }
+    }
+  }
+
   try {
     if (company.length < 3) {
       throw Error("Company length must be at least 3 characters");
@@ -1009,7 +1034,13 @@ export async function signup(req: AuthRequest<SignupBody>, res: Response) {
     if (!req.userId) {
       throw Error("Must be logged in");
     }
-    const org = await createOrganization(req.email, req.userId, company, "");
+    const org = await createOrganization(
+      req.email,
+      req.userId,
+      company,
+      "",
+      verifiedDomain
+    );
 
     // Alert the site manager about new organizations that are created
     try {

--- a/packages/back-end/src/services/organizations.ts
+++ b/packages/back-end/src/services/organizations.ts
@@ -761,12 +761,11 @@ export async function addMemberFromSSOConnection(
     }
     // If this is a brand-new installation, create an organization first
     else if (!orgs.length) {
-      organization = await createOrganization(
-        req.email,
-        req.userId,
-        "My Organization",
-        ""
-      );
+      organization = await createOrganization({
+        email: req.email,
+        userId: req.userId,
+        name: "My Organization",
+      });
       markInstalled();
       return organization;
     }

--- a/packages/back-end/src/templates/email/pending-member-approval.jinja
+++ b/packages/back-end/src/templates/email/pending-member-approval.jinja
@@ -1,4 +1,5 @@
 {% extends "base.jinja" %}
+{% import "utils.jinja" as utils %}
 
 {% block preview %}
   {{ name }} ({{ email }})

--- a/packages/back-end/src/templates/email/pending-member.jinja
+++ b/packages/back-end/src/templates/email/pending-member.jinja
@@ -1,4 +1,5 @@
 {% extends "base.jinja" %}
+{% import "utils.jinja" as utils %}
 
 {% block preview %}
   {{ name }} ({{ email }})

--- a/packages/front-end/components/Auth/CreateOrganization.tsx
+++ b/packages/front-end/components/Auth/CreateOrganization.tsx
@@ -126,11 +126,13 @@ export default function CreateOrganization(): ReactElement {
                       </div>
                     </div>
                     <div className={style.recommendedOrgInfo}>
-                      <div className={style.recommendedOrgName}>{org.name}</div>
+                      <div className={style.recommendedOrgName}>
+                        {org?.name}
+                      </div>
                       <div className={style.recommendedOrgMembers}>
-                        {org.members === 1
-                          ? `${org.members} member`
-                          : `${org.members} members`}
+                        {org?.members === 1
+                          ? `${org?.members} member`
+                          : `${org?.members} members`}
                       </div>
                     </div>
                     <Field type="hidden" {...joinOrgForm.register("orgId")} />
@@ -145,8 +147,13 @@ export default function CreateOrganization(): ReactElement {
                 </form>
                 {currentUserIsPending && (
                   <div className="alert alert-success">
-                    <div className="mb-2"><FaCheck /> Your membership is pending.</div>
-                    <div>Please contact your organization&apos;s admin to approve your membership.</div>
+                    <div className="mb-2">
+                      <FaCheck /> Your membership is pending.
+                    </div>
+                    <div>
+                      Please contact your organization&apos;s admin to approve
+                      your membership.
+                    </div>
                   </div>
                 )}
                 <div

--- a/packages/front-end/components/Auth/CreateOrganization.tsx
+++ b/packages/front-end/components/Auth/CreateOrganization.tsx
@@ -90,7 +90,7 @@ export default function CreateOrganization(): ReactElement {
         </a>
         {isCloud() || !data.hasOrganizations ? (
           <>
-            {mode === "join" ? (
+            {mode === "join" && org ? (
               <>
                 <form
                   onSubmit={joinOrgForm.handleSubmit(async (value) => {
@@ -124,17 +124,15 @@ export default function CreateOrganization(): ReactElement {
                   <div className={`${style.recommendedOrgBox} mt-5 mb-3`}>
                     <div className={style.recommendedOrgLogo}>
                       <div className={style.recommendedOrgLogoText}>
-                        {org?.name?.slice(0, 1)?.toUpperCase()}
+                        {org.name?.slice(0, 1)?.toUpperCase()}
                       </div>
                     </div>
                     <div className={style.recommendedOrgInfo}>
-                      <div className={style.recommendedOrgName}>
-                        {org?.name}
-                      </div>
+                      <div className={style.recommendedOrgName}>{org.name}</div>
                       <div className={style.recommendedOrgMembers}>
-                        {org?.members === 1
-                          ? `${org?.members} member`
-                          : `${org?.members} members`}
+                        {org.members === 1
+                          ? `${org.members} member`
+                          : `${org.members} members`}
                       </div>
                     </div>
                     <Field type="hidden" {...joinOrgForm.register("orgId")} />

--- a/packages/front-end/components/Auth/CreateOrganization.tsx
+++ b/packages/front-end/components/Auth/CreateOrganization.tsx
@@ -124,7 +124,7 @@ export default function CreateOrganization(): ReactElement {
                   <div className={`${style.recommendedOrgBox} mt-5 mb-3`}>
                     <div className={style.recommendedOrgLogo}>
                       <div className={style.recommendedOrgLogoText}>
-                        {org.name?.slice(0, 1)?.toUpperCase()}
+                        {org.name.slice(0, 1)?.toUpperCase()}
                       </div>
                     </div>
                     <div className={style.recommendedOrgInfo}>

--- a/packages/front-end/components/Auth/CreateOrganization.tsx
+++ b/packages/front-end/components/Auth/CreateOrganization.tsx
@@ -50,6 +50,8 @@ export default function CreateOrganization(): ReactElement {
       if (org.currentUserIsPending) {
         setCurrentUserIsPending(true);
       }
+    } else {
+      setMode("create");
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [org]);


### PR DESCRIPTION
This is a fast-follow to a previous PR which allows new Cloud SSO users to join existing verified orgs:
https://github.com/growthbook/growthbook/pull/979

This change does a few things:
- Add some additional auth on putMember()
- Auto-set the verified domain for a new Cloud organization when the owner/user has a verified non-free email domain.
- Minor refactors