### PR TITLE
🚧 example PR with changes to Response models 🚧 

### DIFF
--- a/packages/back-end/types/experiment-snapshot.d.ts
+++ b/packages/back-end/types/experiment-snapshot.d.ts
@@ -1,28 +1,12 @@
 import { QueryLanguage } from "./datasource";
-import { MetricStats } from "./metric";
-import { StatsEngine } from "./stats";
+import { StatsEngine, VariationResponse } from "./stats";
 import { Queries } from "./query";
 
-export interface SnapshotMetric {
-  value: number;
-  cr: number;
-  users: number;
-  denominator?: number;
-  ci?: [number, number];
-  expected?: number;
-  risk?: [number, number];
-  stats?: MetricStats;
-  pValue?: number;
-  uplift?: {
-    dist: string;
-    mean?: number;
-    stddev?: number;
-  };
+export interface SnapshotMetric extends VariationResponse {
   buckets?: {
     x: number;
     y: number;
   }[];
-  chanceToWin?: number;
 }
 
 export interface SnapshotVariation {

--- a/packages/back-end/types/stats.d.ts
+++ b/packages/back-end/types/stats.d.ts
@@ -2,46 +2,54 @@ import type { MetricStats } from "./metric";
 
 export type StatsEngine = "bayesian" | "frequentist";
 
-interface BaseVariationResponse {
+interface BaseDiffStats {
+  dist: string;
+  mean: number;
+  stddev: number;
+  expected: number;
+  ci: [number, number];
+}
+
+interface RelativeDiffStats extends BaseDiffStats {
+  DiffType: "relative";
+}
+
+interface AbsoluteDiffStats extends BaseDiffStats {
+  DiffType: "absolute";
+}
+
+interface BayesianDiffStats {
+  chanceToWin: number;
+  risk: [number, number];
+}
+
+interface FrequentistDiffStats {
+  pValue: number;
+}
+
+type BayesianRelativeDiffStats = RelativeDiffStats & BayesianDiffStats;
+
+type FrequentistRelativeDiffStats = RelativeDiffStats & FrequentistDiffStats;
+
+type BayesianAbsoluteDiffStats = AbsoluteDiffStats & BayesianDiffStats;
+
+type FrequentistAbsoluteDiffStats = AbsoluteDiffStats & FrequentistDiffStats;
+
+export interface VariationResponse {
   cr: number;
   value: number;
   users: number;
   denominator?: number;
   stats: MetricStats;
-  expected?: number;
-  uplift?: {
-    dist: string;
-    mean?: number;
-    stddev?: number;
-  };
-  ci?: [number, number];
+  relativeDiffStats: BayesianRelativeDiffStats | FrequentistRelativeDiffStats;
+  absoluteDiffStats: BayesianAbsoluteDiffStats | FrequentistAbsoluteDiffStats;
 }
 
-interface BayesianVariationResponse extends BaseVariationResponse {
-  chanceToWin?: number;
-  risk?: [number, number];
-}
-
-interface FrequentistVariationResponse extends BaseVariationResponse {
-  pValue?: number;
-}
-
-interface BaseDimensionResponse {
+interface StatsEngineDimensionResponse {
   dimension: string;
   srm: number;
+  variations: VariationResponse[];
 }
-
-interface BayesianDimensionResponse extends BaseDimensionResponse {
-  variations: BayesianVariationResponse[];
-}
-
-interface FrequentistVariationResponse extends BaseDimensionResponse {
-  variations: FrequentistVariationResponse[];
-}
-
-type StatsEngineDimensionResponse =
-  | BayesianDimensionResponse
-  | FrequentistVariationResponse;
 
 export interface ExperimentMetricAnalysis {
   unknownVariations: string[];


### PR DESCRIPTION
Hypothetical changes to Response models to allow for additional difference types and different analysis types to live side-by-side and be easily switched between on the user end.