### PR TITLE
1014 - Metric defaults bug (2 decimal places)

### DIFF
--- a/packages/front-end/pages/settings/index.tsx
+++ b/packages/front-end/pages/settings/index.tsx
@@ -136,11 +136,12 @@ const GeneralSettingsPage = (): React.ReactElement => {
     if (settings) {
       const newVal = { ...form.getValues() };
       Object.keys(newVal).forEach((k) => {
+        const hasExistingMetrics = typeof settings?.[k] !== "undefined";
         newVal[k] = settings?.[k] || newVal[k];
 
         // Existing values are stored as a multiplier, e.g. 50% on the UI is stored as 0.5
         // Transform these values from the UI format
-        if (k === "metricDefaults") {
+        if (k === "metricDefaults" && hasExistingMetrics) {
           newVal.metricDefaults = {
             ...newVal.metricDefaults,
             maxPercentageChange:


### PR DESCRIPTION
### Features and Changes

Fixes the bug that occurs in the case where the user does not have any metric defaults set and the preloaded form causes it to be too big by 2 decimal points. The user could then save any other fields on that page, without having touched metric defaults, and this would cause 0.5% to be 50% and 50% to be 5000%.

- Closes #1014 

### Dependencies

n/a

### Testing

Test the following scenarios:

1. Delete the `metricDefaults` property from the organization in MongoDB and save the organization settings form for an unrelated field, e.g. the "Amount of historical data to include when analyzing metrics" dropdown. Previously this would cause the form to have loaded the wrong values and these would've been saved. Now, the adjusted values are loaded and should be saved. Create a metric and ensure the right percentages are present.
2. Delete the `metricDefaults` property from the organization in MongoDB. Do not adjust the organization settings form. Go directly to metrics and create a metric. This flow was previously unaffected and should continue to provide the correct defaults (max 50%, min 0.5%).
3. Save any previously-saved metric defaults. Ensure the correct values are saved. This flow was previously unaffected.

