### PR TITLE
SegmentModel Refactor

### DIFF
--- a/packages/back-end/src/controllers/admin.ts
+++ b/packages/back-end/src/controllers/admin.ts
@@ -8,7 +8,6 @@ import {
 } from "../models/OrganizationModel";
 import { PostgresConnectionParams } from "../../types/integrations/postgres";
 import { createMetric, createSnapshot } from "../services/experiments";
-import { SegmentModel } from "../models/SegmentModel";
 import { createDimension } from "../models/DimensionModel";
 import { getSourceIntegrationObject } from "../services/datasource";
 import { ExperimentInterface } from "../../types/experiment";
@@ -19,6 +18,7 @@ import {
 import { POSTGRES_TEST_CONN } from "../util/secrets";
 import { processPastExperimentQueryResponse } from "../services/queries";
 import { createExperiment } from "../models/ExperimentModel";
+import { createSegment } from "../models/SegmentModel";
 
 export async function getOrganizations(req: AuthRequest, res: Response) {
   if (!req.admin) {
@@ -179,7 +179,7 @@ export async function addSampleData(
   });
 
   // Example segment
-  await SegmentModel.create({
+  await createSegment({
     datasource: datasource.id,
     name: "Male",
     sql:

--- a/packages/back-end/src/controllers/datasources.ts
+++ b/packages/back-end/src/controllers/datasources.ts
@@ -22,8 +22,8 @@ import {
   getSampleExperiment,
 } from "../models/ExperimentModel";
 import { QueryModel } from "../models/QueryModel";
+import { findSegmentsByDataSource } from "../models/SegmentModel";
 import { createManualSnapshot } from "../services/experiments";
-import { SegmentModel } from "../models/SegmentModel";
 import { findDimensionsByDataSource } from "../models/DimensionModel";
 import {
   createDataSource,
@@ -233,9 +233,10 @@ export async function deleteDataSource(
   }
 
   // Make sure there are no segments
-  const segments = await SegmentModel.find({
-    datasource: datasource.id,
-  });
+  const segments = await findSegmentsByDataSource(
+    datasource.id,
+    datasource.organization
+  );
   if (segments.length > 0) {
     throw new Error(
       "Error: Please delete all segments tied to this datasource first."

--- a/packages/back-end/src/models/ImpactEstimateModel.ts
+++ b/packages/back-end/src/models/ImpactEstimateModel.ts
@@ -6,7 +6,7 @@ import { getSourceIntegrationObject } from "../services/datasource";
 import { SegmentInterface } from "../../types/segment";
 import { processMetricValueQueryResponse } from "../services/queries";
 import { DEFAULT_CONVERSION_WINDOW_HOURS } from "../util/secrets";
-import { SegmentModel } from "./SegmentModel";
+import { findSegmentById } from "./SegmentModel";
 import { getDataSourceById } from "./DataSourceModel";
 
 const impactEstimateSchema = new mongoose.Schema({
@@ -66,11 +66,7 @@ export async function getImpactEstimate(
 
   let segmentObj: SegmentInterface | null = null;
   if (segment) {
-    segmentObj = await SegmentModel.findOne({
-      id: segment,
-      organization,
-      datasource: datasource.id,
-    });
+    segmentObj = await findSegmentById(segment, organization);
   }
 
   const integration = getSourceIntegrationObject(datasource);

--- a/packages/back-end/src/models/ImpactEstimateModel.ts
+++ b/packages/back-end/src/models/ImpactEstimateModel.ts
@@ -69,6 +69,10 @@ export async function getImpactEstimate(
     segmentObj = await findSegmentById(segment, organization);
   }
 
+  if (segmentObj?.datasource !== metricObj.datasource) {
+    segmentObj = null;
+  }
+
   const integration = getSourceIntegrationObject(datasource);
   if (integration.decryptionError) {
     throw new Error(

--- a/packages/back-end/src/models/SegmentModel.ts
+++ b/packages/back-end/src/models/SegmentModel.ts
@@ -15,9 +15,46 @@ const segmentSchema = new mongoose.Schema({
   dateCreated: Date,
   dateUpdated: Date,
 });
-export type SegmentDocument = mongoose.Document & SegmentInterface;
 
-export const SegmentModel = mongoose.model<SegmentDocument>(
-  "Segment",
-  segmentSchema
-);
+type SegmentDocument = mongoose.Document & SegmentInterface;
+
+const SegmentModel = mongoose.model<SegmentDocument>("Segment", segmentSchema);
+
+function toInterface(doc: SegmentDocument): SegmentInterface {
+  return doc.toJSON();
+}
+
+export async function createSegment(segment: Partial<SegmentInterface>) {
+  return toInterface(await SegmentModel.create(segment));
+}
+
+export async function findSegmentById(id: string, organization: string) {
+  const doc = await SegmentModel.findOne({ id, organization });
+
+  return doc ? toInterface(doc) : null;
+}
+
+export async function findSegmentsByOrganization(organization: string) {
+  return (await SegmentModel.find({ organization })).map(toInterface);
+}
+
+export async function findSegmentsByDataSource(
+  datasource: string,
+  organization: string
+) {
+  return (await SegmentModel.find({ datasource, organization })).map(
+    toInterface
+  );
+}
+
+export async function deleteSegmentById(id: string, organization: string) {
+  await SegmentModel.deleteOne({ id, organization });
+}
+
+export async function updateSegment(
+  id: string,
+  organization: string,
+  updates: Partial<SegmentInterface>
+) {
+  await SegmentModel.updateOne({ id, organization }, { $set: updates });
+}

--- a/packages/back-end/src/models/SegmentModel.ts
+++ b/packages/back-end/src/models/SegmentModel.ts
@@ -1,3 +1,4 @@
+import omit from "lodash/omit";
 import mongoose from "mongoose";
 import { SegmentInterface } from "../../types/segment";
 
@@ -20,9 +21,8 @@ type SegmentDocument = mongoose.Document & SegmentInterface;
 
 const SegmentModel = mongoose.model<SegmentDocument>("Segment", segmentSchema);
 
-function toInterface(doc: SegmentDocument): SegmentInterface {
-  return doc.toJSON();
-}
+const toInterface = (doc: SegmentDocument): SegmentInterface =>
+  omit(doc.toJSON(), ["__v", "_id"]);
 
 export async function createSegment(segment: Partial<SegmentInterface>) {
   return toInterface(await SegmentModel.create(segment));

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -42,8 +42,8 @@ import {
   getWatchedAudits,
 } from "../../services/audit";
 import { getAllFeatures } from "../../models/FeatureModel";
-import { SegmentModel } from "../../models/SegmentModel";
 import { findDimensionsByOrganization } from "../../models/DimensionModel";
+import { findSegmentsByOrganization } from "../../models/SegmentModel";
 import { APP_ORIGIN, IS_CLOUD } from "../../util/secrets";
 import {
   sendInviteEmail,
@@ -112,9 +112,7 @@ export async function getDefinitions(req: AuthRequest, res: Response) {
     getMetricsByOrganization(orgId),
     getDataSourcesByOrganization(orgId),
     findDimensionsByOrganization(orgId),
-    SegmentModel.find({
-      organization: orgId,
-    }),
+    findSegmentsByOrganization(orgId),
     getAllTags(orgId),
     getAllGroups(orgId),
     getAllSavedGroups(orgId),

--- a/packages/back-end/src/routers/segment/segment.controller.ts
+++ b/packages/back-end/src/routers/segment/segment.controller.ts
@@ -5,7 +5,13 @@ import { FilterQuery } from "mongoose";
 import { AuthRequest } from "../../types/AuthRequest";
 import { ApiErrorResponse } from "../../../types/api";
 import { getOrgFromReq } from "../../services/organizations";
-import { SegmentDocument, SegmentModel } from "../../models/SegmentModel";
+import {
+  createSegment,
+  deleteSegmentById,
+  findSegmentById,
+  findSegmentsByOrganization,
+  updateSegment,
+} from "../../models/SegmentModel";
 import { getDataSourceById } from "../../models/DataSourceModel";
 import { getIdeasByQuery } from "../../services/ideas";
 import { IdeaDocument, IdeaModel } from "../../models/IdeasModel";
@@ -19,6 +25,7 @@ import {
   logExperimentUpdated,
 } from "../../models/ExperimentModel";
 import { MetricInterface } from "../../../types/metric";
+import { SegmentInterface } from "../../../types/segment";
 import { ExperimentInterface } from "../../../types/experiment";
 
 // region GET /segments
@@ -27,7 +34,7 @@ type GetSegmentsRequest = AuthRequest;
 
 type GetSegmentsResponse = {
   status: 200;
-  segments: SegmentDocument[];
+  segments: SegmentInterface[];
 };
 
 /**
@@ -41,9 +48,7 @@ export const getSegments = async (
   res: Response<GetSegmentsResponse>
 ) => {
   const { org } = getOrgFromReq(req);
-  const segments = await SegmentModel.find({
-    organization: org.id,
-  });
+  const segments = await findSegmentsByOrganization(org.id);
   res.status(200).json({
     status: 200,
     segments,
@@ -81,10 +86,7 @@ export const getSegmentUsage = async (
   const { id } = req.params;
   const { org } = getOrgFromReq(req);
 
-  const segment = await SegmentModel.findOne({
-    id,
-    organization: org.id,
-  });
+  const segment = await findSegmentById(id, org.id);
 
   if (!segment) {
     throw new Error("Could not find segment");
@@ -126,7 +128,7 @@ type CreateSegmentRequest = AuthRequest<{
 
 type CreateSegmentResponse = {
   status: 200;
-  segment: SegmentDocument;
+  segment: SegmentInterface;
 };
 
 /**
@@ -150,7 +152,7 @@ export const postSegment = async (
     throw new Error("Invalid data source");
   }
 
-  const doc = await SegmentModel.create({
+  const doc = await createSegment({
     owner: userName,
     datasource,
     userIdType,
@@ -185,7 +187,6 @@ type PutSegmentRequest = AuthRequest<
 
 type PutSegmentResponse = {
   status: 200;
-  segment: SegmentDocument;
 };
 
 /**
@@ -201,11 +202,9 @@ export const putSegment = async (
   req.checkPermissions("createSegments");
 
   const { id } = req.params;
-  const segment = await SegmentModel.findOne({
-    id,
-  });
-
   const { org } = getOrgFromReq(req);
+
+  const segment = await findSegmentById(id, org.id);
 
   if (!segment) {
     throw new Error("Could not find segment");
@@ -221,18 +220,17 @@ export const putSegment = async (
     throw new Error("Invalid data source");
   }
 
-  segment.set("datasource", datasource);
-  segment.set("userIdType", userIdType);
-  segment.set("name", name);
-  segment.set("owner", owner);
-  segment.set("sql", sql);
-  segment.set("dateUpdated", new Date());
-
-  await segment.save();
+  await updateSegment(id, org.id, {
+    datasource,
+    userIdType,
+    name,
+    owner,
+    sql,
+    dateUpdated: new Date(),
+  });
 
   res.status(200).json({
     status: 200,
-    segment,
   });
 };
 
@@ -260,19 +258,13 @@ export const deleteSegment = async (
 
   const { id } = req.params;
   const { org } = getOrgFromReq(req);
-  const segment = await SegmentModel.findOne({
-    id,
-    organization: org.id,
-  });
+  const segment = await findSegmentById(id, org.id);
 
   if (!segment) {
     throw new Error("Could not find segment");
   }
 
-  await SegmentModel.deleteOne({
-    id,
-    organization: org.id,
-  });
+  await deleteSegmentById(id, org.id);
 
   // delete references:
   // ideas:

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -44,7 +44,7 @@ import { promiseAllChunks } from "../util/promise";
 import { findDimensionById } from "../models/DimensionModel";
 import { getValidDate } from "../util/dates";
 import { getDataSourceById } from "../models/DataSourceModel";
-import { SegmentModel } from "../models/SegmentModel";
+import { findSegmentById } from "../models/SegmentModel";
 import { EXPERIMENT_REFRESH_FREQUENCY } from "../util/secrets";
 import {
   ExperimentUpdateSchedule,
@@ -172,12 +172,8 @@ export async function refreshMetric(
 
     let segment: SegmentInterface | undefined = undefined;
     if (metric.segment) {
-      segment =
-        (await SegmentModel.findOne({
-          id: metric.segment,
-          datasource: metric.datasource,
-        })) || undefined;
-      if (!segment) {
+      segment = (await findSegmentById(metric.segment, orgId)) || undefined;
+      if (!segment || segment.datasource !== metric.datasource) {
         throw new Error("Invalid user segment chosen");
       }
     }

--- a/packages/back-end/src/services/reports.ts
+++ b/packages/back-end/src/services/reports.ts
@@ -6,7 +6,7 @@ import {
 } from "../../types/report";
 import { getMetricsByOrganization } from "../models/MetricModel";
 import { QueryDocument } from "../models/QueryModel";
-import { SegmentModel } from "../models/SegmentModel";
+import { findSegmentById } from "../models/SegmentModel";
 import { SegmentInterface } from "../../types/segment";
 import { getDataSourceById } from "../models/DataSourceModel";
 import { ExperimentInterface, ExperimentPhase } from "../../types/experiment";
@@ -100,11 +100,7 @@ export async function startExperimentAnalysis(
 
   let segmentObj: SegmentInterface | null = null;
   if (args.segment) {
-    segmentObj =
-      (await SegmentModel.findOne({
-        id: args.segment,
-        organization,
-      })) || null;
+    segmentObj = await findSegmentById(args.segment, organization);
   }
 
   const integration = getSourceIntegrationObject(datasourceObj);

--- a/packages/back-end/types/segment.d.ts
+++ b/packages/back-end/types/segment.d.ts
@@ -6,6 +6,6 @@ export interface SegmentInterface {
   userIdType: string;
   name: string;
   sql: string;
-  dateCreated: Date;
-  dateUpdated: Date;
+  dateCreated: Date | null;
+  dateUpdated: Date | null;
 }

--- a/packages/back-end/types/segment.d.ts
+++ b/packages/back-end/types/segment.d.ts
@@ -6,6 +6,6 @@ export interface SegmentInterface {
   userIdType: string;
   name: string;
   sql: string;
-  dateCreated: Date | null;
-  dateUpdated: Date | null;
+  dateCreated: Date;
+  dateUpdated: Date;
 }


### PR DESCRIPTION
### Features and Changes

This PR introduces a refactor of the SegmentModel and is related to (and blocks) the work done to add segment support to the config.yml workflow.

When I was adding segment support to the config.yml, it was clear that the SegmentModel needed a refactor as the model was leaking outside of the model file. This PR updates the SegmentModel pattern to match that of our more modern model files, e.g. ExperimentModel and SegmentModel.

Once this PR is pushed, I can then push the PR that [adds segment support to the config.yml file](https://github.com/growthbook/growthbook/pull/1018).

### Blocks

PR to add Segment support to config.yml file - https://github.com/growthbook/growthbook/pull/1018

### Testing

- [x] Ensure that the `createSegment` method correctly creates a new segment within Mongo when called.
- [x] Ensure that the `deleteSegmentById` correctly deletes the correct segment within Mongo when called.
- [x] Ensure the `findSegmentById` method returns the correct segment when called. (Tested by calling "Estimate Impact" and confirming the correct segment was returned.
- [x] Ensure the `findSegmentsByOrganization` method returns all of the segments for a particular organization. (Tested by calling `getDefinitions` within segments/index.tsx and ensuring that all of an organizations segments were returned.)
- [x] Ensure the `findSegmentsByDataSource` method correctly returns all segments with a specific datasource. (Tested by calling "Delete Datasource" and ensuring that there is an error message telling the user to delete the segments connected to a datasource before they can delete, and logging the segments and confirming the call returned all segments connected to that datasource.)
- [x] Ensure that `updateSegment` accurately updates a specific segment with the correct information. (Tested by updating the name of a segment, updating the owner, updating the query, and updating the identifier type.

