### PR TITLE
Mitigate undefined errors in PValueColumn

### DIFF
--- a/packages/front-end/components/Experiment/PValueColumn.tsx
+++ b/packages/front-end/components/Experiment/PValueColumn.tsx
@@ -59,10 +59,13 @@ const PValueColumn: FC<{
     suspiciousChange,
     belowMinChange,
   });
+
+  const expected: number = stats.expected ?? 0;
   const expectedDirection = metric.inverse
-    ? stats.expected < 0
-    : stats.expected > 0;
-  const statSig = stats.pValue < pValueThreshold;
+    ? expected < 0
+    : expected > 0;
+  const pValue: number = stats.pValue ?? 1;
+  const statSig = pValue < pValueThreshold;
 
   let sigText: string | JSX.Element = "";
   let className = "";


### PR DESCRIPTION
### Features and Changes

When building the `ResultsTable` we may pass some default stats if a row is missing for a variation for some reason. We do:
```
  {variations.map((v, i) => {
    const stats = row.variations[i] || {
      value: 0,
      cr: 0,
      users: 0,
    };
    .BUILD SOME THINGS.
    }
```

Because we don't populate `expected` or `pValue`, if this code were to execute for some edge case, then the PValueColumn code which expects `defined` values for those fields will throw an error.

This PR fixes that by letting them be undefined and setting them to some default values if needed. The values themselves shouldn't matter since users should be 0 and therefore there should not be enough data to generate anything other than an empty `<td>`.

I think this is causing a customer reported error and I think that this patch will at least fix the immediate issue.

We may prefer to figure out why this edge case is being created at all and more directly solve the issue, but this may be sufficient to prevent the front-end from throwing errors that lock the user out of the experiment page altogether.