### PR TITLE
Update eslintignore to definitely ignore docs/build

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@
 dist
 coverage
 ./docs
+docs/build/

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -284,7 +284,11 @@ export async function getManualSnapshotData(
             statistic_type: "mean", // ratio not supported for now
             main_metric_type: metric.type,
             main_sum: s.mean * s.count,
-            main_sum_squares: sumSquaresFromStats(s.mean * s.count, Math.pow(s.stddev, 2), s.count),
+            main_sum_squares: sumSquaresFromStats(
+              s.mean * s.count,
+              Math.pow(s.stddev, 2),
+              s.count
+            ),
           };
         });
 

--- a/packages/front-end/components/Experiment/PValueColumn.tsx
+++ b/packages/front-end/components/Experiment/PValueColumn.tsx
@@ -61,9 +61,7 @@ const PValueColumn: FC<{
   });
 
   const expected: number = stats.expected ?? 0;
-  const expectedDirection = metric.inverse
-    ? expected < 0
-    : expected > 0;
+  const expectedDirection = metric.inverse ? expected < 0 : expected > 0;
   const pValue: number = stats.pValue ?? 1;
   const statSig = pValue < pValueThreshold;
 


### PR DESCRIPTION
Problem: my linter was hanging and the problem was `docs/build` were not being ignored. I'm not sure why given the contents of `.eslintignore`.

Solution: Explicitly ignore any `docs/build/` directories and run the linter.

This PR also picks up some linting my recent PRs missed due to my linter not functioning well.