### PR TITLE
carve out webhook job for cloud proxy users

### DIFF
--- a/packages/back-end/src/jobs/proxyUpdate.ts
+++ b/packages/back-end/src/jobs/proxyUpdate.ts
@@ -1,7 +1,7 @@
 import { createHmac } from "crypto";
 import Agenda, { Job } from "agenda";
 import { getFeatureDefinitions } from "../services/features";
-import { CRON_ENABLED } from "../util/secrets";
+import { CRON_ENABLED, IS_CLOUD } from "../util/secrets";
 import { SDKPayloadKey } from "../../types/sdk-payload";
 import {
   findSDKConnectionById,
@@ -28,8 +28,10 @@ export default function addProxyUpdateJob(ag: Agenda) {
 
     const connection = await findSDKConnectionById(connectionId);
     if (!connection) return;
-    if (!connection.proxy.enabled) return;
-    if (!connection.proxy.host) return;
+    if (!IS_CLOUD && (!connection.proxy.enabled || !connection.proxy.host))
+      return;
+    // note: sseEnabled indicates that we are using Cloud Proxy behind the scenes.
+    if (IS_CLOUD && !connection.sseEnabled) return;
 
     const defs = await getFeatureDefinitions(
       connection.organization,
@@ -40,12 +42,17 @@ export default function addProxyUpdateJob(ag: Agenda) {
 
     const payload = JSON.stringify(defs);
 
+    // note: Cloud Proxy users will have proxy.enabled === false, but will still have a valid proxy.signingKey
     const signature = createHmac("sha256", connection.proxy.signingKey)
       .update(payload)
       .digest("hex");
 
+    const url = IS_CLOUD
+      ? `https://proxy.growthbook.io/proxy/features`
+      : `${connection.proxy.host}/proxy/features`;
+
     const { responseWithoutBody: res } = await cancellableFetch(
-      `${connection.proxy.host}/proxy/features`,
+      url,
       {
         headers: {
           "Content-Type": "application/json",
@@ -96,7 +103,11 @@ export default function addProxyUpdateJob(ag: Agenda) {
 export async function queueSingleProxyUpdate(
   connection: SDKConnectionInterface
 ) {
-  if (!connection.proxy.enabled || !connection.proxy.host) return;
+  if (!IS_CLOUD && (!connection.proxy.enabled || !connection.proxy.host))
+    return;
+  // note: sseEnabled indicates that we are using Cloud Proxy behind the scenes.
+  if (IS_CLOUD && !connection.sseEnabled) return;
+
   const job = agenda.create(PROXY_UPDATE_JOB_NAME, {
     connectionId: connection.id,
     retryCount: 0,


### PR DESCRIPTION
This is a small change needed in order to push feature updates to Cloud Proxy users. Currently the proxy webhooks only work for self hosted proxy servers.

There is some double-dipping of variables to make this work (`sseEnabled` indicating that cloud proxy is enabled), but this is temporary until we can roll out Cloud Proxy for all Cloud users.