### PR TITLE
Updated spelling error in docs

### DIFF
--- a/docs/docs/self-host/proxy.mdx
+++ b/docs/docs/self-host/proxy.mdx
@@ -66,7 +66,7 @@ SECRET_API_KEY=something_secret
 
 ## Using with the SDKs
 
-The GrowtBook Proxy has the same public feature endpoints as GrowthBook, so all you need to do is change the API host your SDK clients connect to:
+The GrowthBook Proxy has the same public feature endpoints as GrowthBook, so all you need to do is change the API host your SDK clients connect to:
 
 ```ts
 // Before


### PR DESCRIPTION
### Features and Changes

Fixes spelling mistake on https://docs.growthbook.io/self-host/proxy page.

### Dependencies

N/A

### Testing

N/A

### Screenshots

N/A
