### PR TITLE
Fix GET /organizations 401 on initial load

### DIFF
--- a/packages/front-end/services/auth.tsx
+++ b/packages/front-end/services/auth.tsx
@@ -235,6 +235,8 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
 
   const _makeApiCall = useCallback(
     async (url: string, token: string, options: RequestInit = {}) => {
+      if (!token) return;
+
       const init = { ...options };
       init.headers = init.headers || {};
       init.headers["Authorization"] = `Bearer ${token}`;


### PR DESCRIPTION
### Features and Changes

Fixes this bug by not making a call if we don't have a bearer token:

> This 401 Unauthorized that always gets returned on a hard refresh of the page is misleading when other errors occur, causing users to falsely report the cause of the error they're experiencing to this call.


- Closes https://github.com/growthbook/growthbook/issues/1038

### Testing

Flows to test:

- Login (local)
- Sign up (local)
- Being on any page and refreshing and seeing no red

