### PR TITLE
Add positive and negative conversion delays to query tester config

### DIFF
--- a/packages/back-end/test/integrations/experiments.json
+++ b/packages/back-end/test/integrations/experiments.json
@@ -23,7 +23,7 @@
       {
         "id": "OVERRWITTENINSCRIPT",
         "conversionWindowHours": 48,
-        "conversionDelayHour": -24
+        "conversionDelayHours": -24
       }
     ],
     "attributionModel": "firstExposure"
@@ -34,7 +34,7 @@
       {
         "id": "OVERRWITTENINSCRIPT",
         "conversionWindowHours": 48,
-        "conversionDelayHour": -24
+        "conversionDelayHours": -24
       }
     ],
     "attributionModel": "allExposures"
@@ -45,7 +45,7 @@
       {
         "id": "OVERRWITTENINSCRIPT",
         "conversionWindowHours": 48,
-        "conversionDelayHour": -24
+        "conversionDelayHours": -24
       }
     ],
     "activationMetric": "cart_loaded",
@@ -57,7 +57,7 @@
       {
         "id": "OVERRWITTENINSCRIPT",
         "conversionWindowHours": 48,
-        "conversionDelayHour": -24
+        "conversionDelayHours": -24
       }
     ],
     "activationMetric": "cart_loaded",
@@ -69,7 +69,7 @@
       {
         "id": "OVERRWITTENINSCRIPT",
         "conversionWindowHours": 48,
-        "conversionDelayHour": 24
+        "conversionDelayHours": 24
       }
     ],
     "attributionModel": "firstExposure"
@@ -80,7 +80,7 @@
       {
         "id": "OVERRWITTENINSCRIPT",
         "conversionWindowHours": 48,
-        "conversionDelayHour": 24
+        "conversionDelayHours": 24
       }
     ],
     "attributionModel": "allExposures"
@@ -91,7 +91,7 @@
       {
         "id": "OVERRWITTENINSCRIPT",
         "conversionWindowHours": 48,
-        "conversionDelayHour": 24
+        "conversionDelayHours": 24
       }
     ],
     "activationMetric": "cart_loaded",
@@ -103,7 +103,7 @@
       {
         "id": "OVERRWITTENINSCRIPT",
         "conversionWindowHours": 48,
-        "conversionDelayHour": 24
+        "conversionDelayHours": 24
       }
     ],
     "activationMetric": "cart_loaded",

--- a/packages/back-end/test/integrations/experiments.json
+++ b/packages/back-end/test/integrations/experiments.json
@@ -64,6 +64,52 @@
     "attributionModel": "allExposures"
   },
   {
+    "id": "positiveconversion",
+    "metricOverrides": [
+      {
+        "id": "OVERRWITTENINSCRIPT",
+        "conversionWindowHours": 48,
+        "conversionDelayHour": 24
+      }
+    ],
+    "attributionModel": "firstExposure"
+  },
+  {
+    "id": "base_allExposures_positiveconversion",
+    "metricOverrides": [
+      {
+        "id": "OVERRWITTENINSCRIPT",
+        "conversionWindowHours": 48,
+        "conversionDelayHour": 24
+      }
+    ],
+    "attributionModel": "allExposures"
+  },
+  {
+    "id": "activation_positiveconversion",
+    "metricOverrides": [
+      {
+        "id": "OVERRWITTENINSCRIPT",
+        "conversionWindowHours": 48,
+        "conversionDelayHour": 24
+      }
+    ],
+    "activationMetric": "cart_loaded",
+    "attributionModel": "firstExposure"
+  },
+  {
+    "id": "activation_allExposures_positiveconversion",
+    "metricOverrides": [
+      {
+        "id": "OVERRWITTENINSCRIPT",
+        "conversionWindowHours": 48,
+        "conversionDelayHour": 24
+      }
+    ],
+    "activationMetric": "cart_loaded",
+    "attributionModel": "allExposures"
+  },
+  {
     "id": "dimension_date",
     "dimensionType": "date",
     "attributionModel": "firstExposure"


### PR DESCRIPTION
### Problem

The integration query tester was not applying the appropriate negative metric conversion delay before and we didn't test any positive metric conversion delay.

### Solution

* fix name of override field from `conversionDelayHour` to `conversionDelayHours` for negative conversion experiment configs
* Add new experiment overrides with positive `conversionDelayHours` to additionally test these cases (will help with testing regression adjustment)

### Testing

Just sanity checking that `main_sum` coming out of these three configs (no delay, negative delay, positive delay) is in line with expectations and differs across experiment configs.

Also, you can see some snippets of the generate BigQuery for a particular metric use the right ranges on `conversion_start` and `conversion_end` for no delay, positive delay, and negative delays, as well as the right date filters on the `__metric` CTE.

engine: bigquery, experiment: no delay, metric: nonbinom__purchased_items
```
...
  __experiment as ( -- Viewed Experiment
    SELECT
      e.user_id as user_id,
      cast(e.variation_id as string) as variation,
      CAST(e.timestamp as DATETIME) as timestamp,
      CAST(e.timestamp as DATETIME) as conversion_start,
      DATETIME_ADD(CAST(e.timestamp as DATETIME), INTERVAL 72 HOUR) as conversion_end
    FROM
      __rawExperiment e
    WHERE
      e.experiment_id = 'checkout-layout'
      AND CAST(e.timestamp as DATETIME) >= DATETIME("2021-11-03 07:00:00")
      AND CAST(e.timestamp as DATETIME) <= DATETIME("2022-02-01 08:00:00")
  ),
  __metric as ( -- Metric ()
    SELECT
      user_id as user_id,
      m.value as value,
      CAST(m.timestamp as DATETIME) as timestamp,
      CAST(m.timestamp as DATETIME) as conversion_start,
      CAST(m.timestamp as DATETIME) as conversion_end
    FROM
      (
        SELECT
          userId as user_id,
          timestamp as timestamp,
          qty as value
        FROM
          sample.orders
      ) m
    WHERE
      CAST(m.timestamp as DATETIME) >= DATETIME("2021-11-03 07:00:00")
      AND CAST(m.timestamp as DATETIME) <= DATETIME("2022-02-04 08:00:00")
 ...
 ```
engine: bigquery, experiment: negativeconversion, metric: nonbinom__purchased_items
```
...
  __experiment as ( -- Viewed Experiment
    SELECT
      e.user_id as user_id,
      cast(e.variation_id as string) as variation,
      CAST(e.timestamp as DATETIME) as timestamp,
      DATETIME_SUB(CAST(e.timestamp as DATETIME), INTERVAL 24 HOUR) as conversion_start,
      DATETIME_ADD(CAST(e.timestamp as DATETIME), INTERVAL 24 HOUR) as conversion_end
    FROM
      __rawExperiment e
    WHERE
      e.experiment_id = 'checkout-layout'
      AND CAST(e.timestamp as DATETIME) >= DATETIME("2021-11-03 07:00:00")
      AND CAST(e.timestamp as DATETIME) <= DATETIME("2022-02-01 08:00:00")
  ),
  __metric as ( -- Metric ()
    SELECT
      user_id as user_id,
      m.value as value,
      CAST(m.timestamp as DATETIME) as timestamp,
      CAST(m.timestamp as DATETIME) as conversion_start,
      CAST(m.timestamp as DATETIME) as conversion_end
    FROM
      (
        SELECT
          userId as user_id,
          timestamp as timestamp,
          qty as value
        FROM
          sample.orders
      ) m
    WHERE
      CAST(m.timestamp as DATETIME) >= DATETIME("2021-11-02 07:00:00")
      AND CAST(m.timestamp as DATETIME) <= DATETIME("2022-02-02 08:00:00")
  ),
  ...
```

engine: bigquery, experiment: positiveconversion, metric: nonbinom__purchased_items
```
...
  __experiment as ( -- Viewed Experiment
    SELECT
      e.user_id as user_id,
      cast(e.variation_id as string) as variation,
      CAST(e.timestamp as DATETIME) as timestamp,
      DATETIME_ADD(CAST(e.timestamp as DATETIME), INTERVAL 24 HOUR) as conversion_start,
      DATETIME_ADD(CAST(e.timestamp as DATETIME), INTERVAL 72 HOUR) as conversion_end
    FROM
      __rawExperiment e
    WHERE
      e.experiment_id = 'checkout-layout'
      AND CAST(e.timestamp as DATETIME) >= DATETIME("2021-11-03 07:00:00")
      AND CAST(e.timestamp as DATETIME) <= DATETIME("2022-02-01 08:00:00")
  ),
  __metric as ( -- Metric ()
    SELECT
      user_id as user_id,
      m.value as value,
      CAST(m.timestamp as DATETIME) as timestamp,
      CAST(m.timestamp as DATETIME) as conversion_start,
      CAST(m.timestamp as DATETIME) as conversion_end
    FROM
      (
        SELECT
          userId as user_id,
          timestamp as timestamp,
          qty as value
        FROM
          sample.orders
      ) m
    WHERE
      CAST(m.timestamp as DATETIME) >= DATETIME("2021-11-03 07:00:00")
      AND CAST(m.timestamp as DATETIME) <= DATETIME("2022-02-04 08:00:00")
  ),
  ...
  ```