### PR TITLE
Add VisualChangeset model and API endpoints

### DIFF
--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -604,6 +604,59 @@ paths:
                 properties:
                   result:
                     $ref: '#/components/schemas/ExperimentResults'
+  /visual-changesets:
+    get:
+      summary: Get all visual changeset
+      tags:
+        - visual-changesets
+      parameters:
+        - $ref: '#/components/parameters/limit'
+        - $ref: '#/components/parameters/offset'
+      operationId: listVisualChangesets
+      x-codeSamples:
+        - lang: cURL
+          source: |
+            curl https://api.growthbook.io/api/v1/visual-changesets \
+              -u secret_abc123DEF456:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - type: object
+                    required:
+                      - visualChangesets
+                    properties:
+                      visualChangesets:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/VisualChangeset'
+                  - $ref: '#/components/schemas/PaginationFields'
+  '/visual-changesets/{id}':
+    parameters:
+      - $ref: '#/components/parameters/id'
+    get:
+      tags:
+        - visual-changesets
+      summary: Get a single visual changeset
+      operationId: getVisualChangeset
+      x-codeSamples:
+        - lang: cURL
+          source: |
+            curl https://api.growthbook.io/api/v1/visual-changesets/ds_123abc \
+              -u secret_abc123DEF456:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - visualChangeset
+                properties:
+                  visualChangeset:
+                    $ref: '#/components/schemas/VisualChangeset'
 components:
   parameters:
     id:
@@ -1650,6 +1703,57 @@ components:
               type: string
             extraUserIdProperty:
               type: string
+    VisualChangeset:
+      type: object
+      required:
+        - urlPattern
+        - editorUrl
+        - experiment
+        - visualChanges
+      properties:
+        id:
+          type: string
+        urlPattern:
+          type: string
+        editorUrl:
+          type: string
+        experiment:
+          type: string
+        visualChanges:
+          type: array
+          items:
+            type: object
+            required:
+              - variation
+              - domMutations
+            properties:
+              description:
+                type: string
+              css:
+                type: string
+              variation:
+                type: string
+              domMutations:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - selector
+                    - action
+                    - attribute
+                  properties:
+                    selector:
+                      type: string
+                    action:
+                      type: string
+                      enum:
+                        - append
+                        - set
+                        - remove
+                    attribute:
+                      type: string
+                    value:
+                      type: string
   securitySchemes:
     bearerAuth:
       type: http

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -78,6 +78,9 @@ tags:
   - name: sdk-connections
     x-displayName: SDK Connections
     description: Client keys and settings for connecting SDKs to a GrowthBook instance
+  - name: visual-changesets
+    x-displayName: Visual Changesets
+    description: Groups of visual changes made by the visual editor to a single page
 paths:
   /features:
     get:
@@ -604,19 +607,24 @@ paths:
                 properties:
                   result:
                     $ref: '#/components/schemas/ExperimentResults'
-  /visual-changesets:
+  '/experiments/{id}/visual-changesets':
     get:
-      summary: Get all visual changeset
+      summary: Get all visual changesets
       tags:
         - visual-changesets
       parameters:
-        - $ref: '#/components/parameters/limit'
-        - $ref: '#/components/parameters/offset'
+        - id: null
+          name: id
+          in: path
+          required: true
+          description: The experiment id the visual changesets belong to
+          schema:
+            type: string
       operationId: listVisualChangesets
       x-codeSamples:
         - lang: cURL
           source: |
-            curl https://api.growthbook.io/api/v1/visual-changesets \
+            curl https://api.growthbook.io/api/v1/experiments/exp_123abc/visual-changesets \
               -u secret_abc123DEF456:
       responses:
         '200':
@@ -632,7 +640,6 @@ paths:
                         type: array
                         items:
                           $ref: '#/components/schemas/VisualChangeset'
-                  - $ref: '#/components/schemas/PaginationFields'
   '/visual-changesets/{id}':
     parameters:
       - $ref: '#/components/parameters/id'

--- a/packages/back-end/repl.ts
+++ b/packages/back-end/repl.ts
@@ -4,6 +4,7 @@ import * as Event from "./src/models/EventModel";
 import * as EventWebHook from "./src/models/EventWebhookModel";
 import * as EventWebHookLog from "./src/models/EventWebHookLogModel";
 import * as SlackIntegration from "./src/models/SlackIntegrationModel";
+import * as VisualChangeset from "./src/models/VisualChangesetModel";
 import mongoInit from "./src/init/mongo";
 
 (async () => {
@@ -19,4 +20,5 @@ import mongoInit from "./src/init/mongo";
   replServer.context.EventWebHook = EventWebHook;
   replServer.context.EventWebHookLog = EventWebHookLog;
   replServer.context.SlackIntegration = SlackIntegration;
+  replServer.context.VisualChangeset = VisualChangeset;
 })();

--- a/packages/back-end/src/api/experiments/experiments.router.ts
+++ b/packages/back-end/src/api/experiments/experiments.router.ts
@@ -1,4 +1,5 @@
 import { Router } from "express";
+import { listVisualChangesets } from "../visual-changesets/listVisualChangesets";
 import { getExperimentResults } from "./getExperimentResults";
 import { getExperiment } from "./getExperiment";
 import { listExperiments } from "./listExperiments";
@@ -10,5 +11,8 @@ const router = Router();
 router.get("/", listExperiments);
 router.get("/:id", getExperiment);
 router.get("/:id/results", getExperimentResults);
+
+// VisualChangeset Endpoints
+router.get("/:id/visual_changesets", listVisualChangesets);
 
 export default router;

--- a/packages/back-end/src/api/openapi/openapi.yaml
+++ b/packages/back-end/src/api/openapi/openapi.yaml
@@ -116,6 +116,10 @@ paths:
   /experiments/{id}/results:
     $ref: "./paths/getExperimentResults.yaml"
 # PLOP_INSERT_PATHS_HERE
+  /visual-changesets:
+    $ref: "./paths/listVisualChangesets.yaml"
+  /visual-changesets/{id}:
+    $ref: "./paths/getVisualChangeset.yaml"
 components:
   parameters:
     $ref: "./parameters.yaml"

--- a/packages/back-end/src/api/openapi/openapi.yaml
+++ b/packages/back-end/src/api/openapi/openapi.yaml
@@ -78,6 +78,9 @@ tags:
   - name: sdk-connections
     x-displayName: SDK Connections
     description: Client keys and settings for connecting SDKs to a GrowthBook instance
+  - name: visual-changesets
+    x-displayName: Visual Changesets
+    description: Groups of visual changes made by the visual editor to a single page
 paths:
   /features:
     $ref: "./paths/listFeatures.yaml"
@@ -115,8 +118,8 @@ paths:
     $ref: "./paths/getExperiment.yaml"
   /experiments/{id}/results:
     $ref: "./paths/getExperimentResults.yaml"
-# PLOP_INSERT_PATHS_HERE
-  /visual-changesets:
+  # PLOP_INSERT_PATHS_HERE
+  /experiments/{id}/visual-changesets:
     $ref: "./paths/listVisualChangesets.yaml"
   /visual-changesets/{id}:
     $ref: "./paths/getVisualChangeset.yaml"

--- a/packages/back-end/src/api/openapi/paths/getVisualChangeset.yaml
+++ b/packages/back-end/src/api/openapi/paths/getVisualChangeset.yaml
@@ -1,0 +1,23 @@
+parameters:
+  - $ref: "../parameters.yaml#/id"
+get:
+  tags:
+    - visual-changesets
+  summary: Get a single visual changeset
+  operationId: getVisualChangeset
+  x-codeSamples:
+    - lang: 'cURL'
+      source: |
+        curl https://api.growthbook.io/api/v1/visual-changesets/ds_123abc \
+          -u secret_abc123DEF456:
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - visualChangeset
+            properties:
+              visualChangeset:
+                $ref: "../schemas/VisualChangeset.yaml"

--- a/packages/back-end/src/api/openapi/paths/listVisualChangesets.yaml
+++ b/packages/back-end/src/api/openapi/paths/listVisualChangesets.yaml
@@ -1,15 +1,20 @@
 get:
-  summary: Get all visual changeset
+  summary: Get all visual changesets
   tags:
     - visual-changesets
   parameters:
-  - $ref: "../parameters.yaml#/limit"
-  - $ref: "../parameters.yaml#/offset"
+    - id:
+      name: id
+      in: path
+      required: true
+      description: The experiment id the visual changesets belong to
+      schema:
+        type: string
   operationId: listVisualChangesets
   x-codeSamples:
-    - lang: 'cURL'
+    - lang: "cURL"
       source: |
-        curl https://api.growthbook.io/api/v1/visual-changesets \
+        curl https://api.growthbook.io/api/v1/experiments/exp_123abc/visual-changesets \
           -u secret_abc123DEF456:
   responses:
     "200":
@@ -25,4 +30,3 @@ get:
                     type: array
                     items:
                       $ref: "../schemas/VisualChangeset.yaml"
-              - $ref: "../schemas/PaginationFields.yaml"

--- a/packages/back-end/src/api/openapi/paths/listVisualChangesets.yaml
+++ b/packages/back-end/src/api/openapi/paths/listVisualChangesets.yaml
@@ -1,0 +1,28 @@
+get:
+  summary: Get all visual changeset
+  tags:
+    - visual-changesets
+  parameters:
+  - $ref: "../parameters.yaml#/limit"
+  - $ref: "../parameters.yaml#/offset"
+  operationId: listVisualChangesets
+  x-codeSamples:
+    - lang: 'cURL'
+      source: |
+        curl https://api.growthbook.io/api/v1/visual-changesets \
+          -u secret_abc123DEF456:
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            allOf:
+              - type: object
+                required:
+                  - visualChangesets
+                properties:
+                  visualChangesets:
+                    type: array
+                    items:
+                      $ref: "../schemas/VisualChangeset.yaml"
+              - $ref: "../schemas/PaginationFields.yaml"

--- a/packages/back-end/src/api/openapi/schemas/VisualChangeset.yaml
+++ b/packages/back-end/src/api/openapi/schemas/VisualChangeset.yaml
@@ -1,0 +1,47 @@
+type: object
+required:
+  - urlPattern
+  - editorUrl
+  - experiment
+  - visualChanges
+properties:
+  id:
+    type: string
+  urlPattern:
+    type: string
+  editorUrl:
+    type: string
+  experiment:
+    type: string
+  visualChanges:
+    type: array
+    items:
+      type: object
+      required:
+        - variation
+        - domMutations
+      properties:
+        description:
+          type: string
+        css:
+          type: string
+        variation:
+          type: string
+        domMutations:
+          type: array
+          items:
+            type: object
+            required:
+              - selector
+              - action
+              - attribute
+            properties:
+              selector:
+                type: string
+              action:
+                type: string
+                enum: [append, set, remove]
+              attribute:
+                type: string
+              value:
+                type: string

--- a/packages/back-end/src/api/openapi/schemas/_index.yaml
+++ b/packages/back-end/src/api/openapi/schemas/_index.yaml
@@ -34,3 +34,5 @@ ExperimentResults:
   $ref: './ExperimentResults.yaml'
 DataSource:
   $ref: './DataSource.yaml'
+VisualChangeset:
+  $ref: './VisualChangeset.yaml'

--- a/packages/back-end/src/api/visual-changesets/getVisualChangeset.ts
+++ b/packages/back-end/src/api/visual-changesets/getVisualChangeset.ts
@@ -1,0 +1,25 @@
+import { GetVisualChangesetResponse } from "../../../types/openapi";
+import {
+  findVisualChangesetById,
+  toVisualChangesetApiInterface,
+} from "../../models/VisualChangesetModel";
+import { createApiRequestHandler } from "../../util/handler";
+import { getVisualChangesetValidator } from "../../validators/openapi";
+
+export const getVisualChangeset = createApiRequestHandler(
+  getVisualChangesetValidator
+)(
+  async (req): Promise<GetVisualChangesetResponse> => {
+    const visualChangeset = await findVisualChangesetById(
+      req.params.id,
+      req.organization.id
+    );
+    if (!visualChangeset) {
+      throw new Error("Could not find visualChangeset with that id");
+    }
+
+    return {
+      visualChangeset: toVisualChangesetApiInterface(visualChangeset),
+    };
+  }
+);

--- a/packages/back-end/src/api/visual-changesets/listVisualChangesets.ts
+++ b/packages/back-end/src/api/visual-changesets/listVisualChangesets.ts
@@ -1,30 +1,24 @@
 import { ListVisualChangesetsResponse } from "../../../types/openapi";
 import {
-  findVisualChangesetsByOrganization,
+  findVisualChangesetsByExperiment,
   toVisualChangesetApiInterface,
 } from "../../models/VisualChangesetModel";
-import { applyPagination, createApiRequestHandler } from "../../util/handler";
+import { createApiRequestHandler } from "../../util/handler";
 import { listVisualChangesetsValidator } from "../../validators/openapi";
 
 export const listVisualChangesets = createApiRequestHandler(
   listVisualChangesetsValidator
 )(
   async (req): Promise<ListVisualChangesetsResponse> => {
-    const visualChangesets = await findVisualChangesetsByOrganization(
+    const visualChangesets = await findVisualChangesetsByExperiment(
+      req.params.id,
       req.organization.id
     );
 
-    // TODO: Move sorting/limiting to the database query for better performance
-    const { filtered, returnFields } = applyPagination(
-      visualChangesets.sort((a, b) => a.id.localeCompare(b.id)),
-      req.query
-    );
-
     return {
-      visualChangesets: filtered.map((visualChangeset) =>
+      visualChangesets: visualChangesets.map((visualChangeset) =>
         toVisualChangesetApiInterface(visualChangeset)
       ),
-      ...returnFields,
     };
   }
 );

--- a/packages/back-end/src/api/visual-changesets/listVisualChangesets.ts
+++ b/packages/back-end/src/api/visual-changesets/listVisualChangesets.ts
@@ -1,0 +1,30 @@
+import { ListVisualChangesetsResponse } from "../../../types/openapi";
+import {
+  findVisualChangesetsByOrganization,
+  toVisualChangesetApiInterface,
+} from "../../models/VisualChangesetModel";
+import { applyPagination, createApiRequestHandler } from "../../util/handler";
+import { listVisualChangesetsValidator } from "../../validators/openapi";
+
+export const listVisualChangesets = createApiRequestHandler(
+  listVisualChangesetsValidator
+)(
+  async (req): Promise<ListVisualChangesetsResponse> => {
+    const visualChangesets = await findVisualChangesetsByOrganization(
+      req.organization.id
+    );
+
+    // TODO: Move sorting/limiting to the database query for better performance
+    const { filtered, returnFields } = applyPagination(
+      visualChangesets.sort((a, b) => a.id.localeCompare(b.id)),
+      req.query
+    );
+
+    return {
+      visualChangesets: filtered.map((visualChangeset) =>
+        toVisualChangesetApiInterface(visualChangeset)
+      ),
+      ...returnFields,
+    };
+  }
+);

--- a/packages/back-end/src/api/visual-changesets/visual-changesets.router.ts
+++ b/packages/back-end/src/api/visual-changesets/visual-changesets.router.ts
@@ -1,0 +1,12 @@
+import { Router } from "express";
+import { getVisualChangeset } from "./getVisualChangeset";
+import { listVisualChangesets } from "./listVisualChangesets";
+
+const router = Router();
+
+// VisualChangeset Endpoints
+// Mounted at /api/v1/visual-changesets
+router.get("/", listVisualChangesets);
+router.get("/:id", getVisualChangeset);
+
+export default router;

--- a/packages/back-end/src/api/visual-changesets/visual-changesets.router.ts
+++ b/packages/back-end/src/api/visual-changesets/visual-changesets.router.ts
@@ -1,12 +1,12 @@
 import { Router } from "express";
 import { getVisualChangeset } from "./getVisualChangeset";
-import { listVisualChangesets } from "./listVisualChangesets";
 
 const router = Router();
 
 // VisualChangeset Endpoints
 // Mounted at /api/v1/visual-changesets
-router.get("/", listVisualChangesets);
 router.get("/:id", getVisualChangeset);
+
+// See experiment router for 'get all' endpoint
 
 export default router;

--- a/packages/back-end/src/models/VisualChangeset.ts
+++ b/packages/back-end/src/models/VisualChangeset.ts
@@ -1,0 +1,52 @@
+import mongoose from "mongoose";
+import { VisualChangesetInterface } from "../../types/visual-changeset";
+
+/**
+ * VisualChangeset is a collection of visual changes that are grouped together
+ * by a single url target. They are many-to-one with Experiments.
+ */
+const visualChangesetSchema = new mongoose.Schema({
+  id: {
+    type: String,
+    unique: true,
+  },
+  organization: {
+    type: String,
+    index: true,
+  },
+  urlPattern: String,
+  editorUrl: String,
+  experiment: {
+    type: String,
+    index: true,
+  },
+  // VisualChanges are associated with one of the variations of the experiment
+  // associated with the VisualChangeset
+  visualChanges: [
+    {
+      id: String,
+      description: String,
+      css: String,
+      variation: {
+        type: String,
+        index: true,
+      },
+      domMutations: [
+        {
+          selector: String,
+          action: ["append", "set", "remove"],
+          attribute: String,
+          value: String,
+        },
+      ],
+    },
+  ],
+});
+
+export type VisualChangesetDocument = mongoose.Document &
+  VisualChangesetInterface;
+
+export const VisualChangesetModel = mongoose.model<VisualChangesetDocument>(
+  "VisualChangeset",
+  visualChangesetSchema
+);

--- a/packages/back-end/src/models/VisualChangesetModel.ts
+++ b/packages/back-end/src/models/VisualChangesetModel.ts
@@ -11,38 +11,58 @@ const visualChangesetSchema = new mongoose.Schema({
   id: {
     type: String,
     unique: true,
+    required: true,
   },
   organization: {
     type: String,
     index: true,
+    required: true,
   },
-  urlPattern: String,
-  editorUrl: String,
+  urlPattern: {
+    type: String,
+    required: true,
+  },
+  editorUrl: {
+    type: String,
+    required: true,
+  },
   experiment: {
     type: String,
     index: true,
+    required: true,
   },
   // VisualChanges are associated with one of the variations of the experiment
   // associated with the VisualChangeset
-  visualChanges: [
-    {
-      id: String,
-      description: String,
-      css: String,
-      variation: {
-        type: String,
-        index: true,
-      },
-      domMutations: [
-        {
-          selector: String,
-          action: ["append", "set", "remove"],
-          attribute: String,
-          value: String,
+  visualChanges: {
+    type: [
+      {
+        id: {
+          type: String,
+          required: true,
         },
-      ],
-    },
-  ],
+        description: String,
+        css: String,
+        variation: {
+          type: String,
+          index: true,
+          required: true,
+        },
+        domMutations: [
+          {
+            selector: { type: String, required: true },
+            action: {
+              type: String,
+              enum: ["append", "set", "remove"],
+              required: true,
+            },
+            attribute: { type: String, required: true },
+            value: String,
+          },
+        ],
+      },
+    ],
+    required: true,
+  },
 });
 
 export type VisualChangesetDocument = mongoose.Document &
@@ -77,7 +97,7 @@ export function toVisualChangesetApiInterface(
 export async function findVisualChangesetById(
   id: string,
   organization: string
-) {
+): Promise<VisualChangesetInterface | null> {
   const visualChangeset = await VisualChangesetModel.findOne({
     organization,
     id,
@@ -85,7 +105,9 @@ export async function findVisualChangesetById(
   return visualChangeset ? toInterface(visualChangeset) : null;
 }
 
-export async function findVisualChangesetsByOrganization(organization: string) {
+export async function findVisualChangesetsByOrganization(
+  organization: string
+): Promise<VisualChangesetInterface[]> {
   const visualChangesets = await VisualChangesetModel.find({
     organization,
   });

--- a/packages/back-end/src/models/VisualChangesetModel.ts
+++ b/packages/back-end/src/models/VisualChangesetModel.ts
@@ -105,10 +105,12 @@ export async function findVisualChangesetById(
   return visualChangeset ? toInterface(visualChangeset) : null;
 }
 
-export async function findVisualChangesetsByOrganization(
+export async function findVisualChangesetsByExperiment(
+  experiment: string,
   organization: string
 ): Promise<VisualChangesetInterface[]> {
   const visualChangesets = await VisualChangesetModel.find({
+    experiment,
     organization,
   });
   return visualChangesets.map(toInterface);

--- a/packages/back-end/src/validators/openapi.ts
+++ b/packages/back-end/src/validators/openapi.ts
@@ -116,8 +116,8 @@ export const getExperimentResultsValidator = {
 
 export const listVisualChangesetsValidator = {
   bodySchema: z.never(),
-  querySchema: z.object({"limit":z.coerce.number().int().default(10),"offset":z.coerce.number().int().optional()}).strict(),
-  paramsSchema: z.never(),
+  querySchema: z.never(),
+  paramsSchema: z.object({"id":z.string()}).strict(),
 };
 
 export const getVisualChangesetValidator = {

--- a/packages/back-end/src/validators/openapi.ts
+++ b/packages/back-end/src/validators/openapi.ts
@@ -113,3 +113,15 @@ export const getExperimentResultsValidator = {
   querySchema: z.object({"phase":z.string().optional(),"dimension":z.string().optional()}).strict(),
   paramsSchema: z.object({"id":z.string()}).strict(),
 };
+
+export const listVisualChangesetsValidator = {
+  bodySchema: z.never(),
+  querySchema: z.object({"limit":z.coerce.number().int().default(10),"offset":z.coerce.number().int().optional()}).strict(),
+  paramsSchema: z.never(),
+};
+
+export const getVisualChangesetValidator = {
+  bodySchema: z.never(),
+  querySchema: z.never(),
+  paramsSchema: z.object({"id":z.string()}).strict(),
+};

--- a/packages/back-end/types/openapi.d.ts
+++ b/packages/back-end/types/openapi.d.ts
@@ -143,8 +143,8 @@ export interface paths {
       };
     };
   };
-  "/visual-changesets": {
-    /** Get all visual changeset */
+  "/experiments/{id}/visual-changesets": {
+    /** Get all visual changesets */
     get: operations["listVisualChangesets"];
   };
   "/visual-changesets/{id}": {
@@ -2186,19 +2186,17 @@ export interface operations {
     };
   };
   listVisualChangesets: {
-    /** Get all visual changeset */
+    /** Get all visual changesets */
     parameters: {
-        /** @description The number of items to return */
-        /** @description How many items to skip (use in conjunction with limit for pagination) */
-      query: {
-        limit?: number;
-        offset?: number;
+        /** @description The experiment id the visual changesets belong to */
+      path: {
+        id: string;
       };
     };
     responses: {
       200: {
         content: {
-          "application/json": ({
+          "application/json": {
             visualChangesets: ({
                 id?: string;
                 urlPattern: string;
@@ -2217,13 +2215,6 @@ export interface operations {
                       })[];
                   })[];
               })[];
-          }) & {
-            limit: number;
-            offset: number;
-            count: number;
-            total: number;
-            hasMore: boolean;
-            nextOffset: OneOf<[number, null]>;
           };
         };
       };

--- a/packages/back-end/types/openapi.d.ts
+++ b/packages/back-end/types/openapi.d.ts
@@ -143,6 +143,20 @@ export interface paths {
       };
     };
   };
+  "/visual-changesets": {
+    /** Get all visual changeset */
+    get: operations["listVisualChangesets"];
+  };
+  "/visual-changesets/{id}": {
+    /** Get a single visual changeset */
+    get: operations["getVisualChangeset"];
+    parameters: {
+        /** @description The id of the requested resource */
+      path: {
+        id: string;
+      };
+    };
+  };
 }
 
 export type webhooks = Record<string, never>;
@@ -844,6 +858,24 @@ export interface components {
         variationIdProperty: string;
         extraUserIdProperty: string;
       };
+    };
+    VisualChangeset: {
+      id?: string;
+      urlPattern: string;
+      editorUrl: string;
+      experiment: string;
+      visualChanges: ({
+          description?: string;
+          css?: string;
+          variation: string;
+          domMutations: ({
+              selector: string;
+              /** @enum {string} */
+              action: "append" | "set" | "remove";
+              attribute: string;
+              value?: string;
+            })[];
+        })[];
     };
   };
   responses: {
@@ -2153,6 +2185,79 @@ export interface operations {
       };
     };
   };
+  listVisualChangesets: {
+    /** Get all visual changeset */
+    parameters: {
+        /** @description The number of items to return */
+        /** @description How many items to skip (use in conjunction with limit for pagination) */
+      query: {
+        limit?: number;
+        offset?: number;
+      };
+    };
+    responses: {
+      200: {
+        content: {
+          "application/json": ({
+            visualChangesets: ({
+                id?: string;
+                urlPattern: string;
+                editorUrl: string;
+                experiment: string;
+                visualChanges: ({
+                    description?: string;
+                    css?: string;
+                    variation: string;
+                    domMutations: ({
+                        selector: string;
+                        /** @enum {string} */
+                        action: "append" | "set" | "remove";
+                        attribute: string;
+                        value?: string;
+                      })[];
+                  })[];
+              })[];
+          }) & {
+            limit: number;
+            offset: number;
+            count: number;
+            total: number;
+            hasMore: boolean;
+            nextOffset: OneOf<[number, null]>;
+          };
+        };
+      };
+    };
+  };
+  getVisualChangeset: {
+    /** Get a single visual changeset */
+    responses: {
+      200: {
+        content: {
+          "application/json": {
+            visualChangeset: {
+              id?: string;
+              urlPattern: string;
+              editorUrl: string;
+              experiment: string;
+              visualChanges: ({
+                  description?: string;
+                  css?: string;
+                  variation: string;
+                  domMutations: ({
+                      selector: string;
+                      /** @enum {string} */
+                      action: "append" | "set" | "remove";
+                      attribute: string;
+                      value?: string;
+                    })[];
+                })[];
+            };
+          };
+        };
+      };
+    };
+  };
 }
 
 // Schemas
@@ -2174,6 +2279,7 @@ export type ApiExperimentMetric = components["schemas"]["ExperimentMetric"];
 export type ApiExperimentAnalysisSettings = components["schemas"]["ExperimentAnalysisSettings"];
 export type ApiExperimentResults = components["schemas"]["ExperimentResults"];
 export type ApiDataSource = components["schemas"]["DataSource"];
+export type ApiVisualChangeset = components["schemas"]["VisualChangeset"];
 
 // Operations
 export type ListFeaturesResponse = operations["listFeatures"]["responses"]["200"]["content"]["application/json"];
@@ -2194,3 +2300,5 @@ export type GetDataSourceResponse = operations["getDataSource"]["responses"]["20
 export type ListExperimentsResponse = operations["listExperiments"]["responses"]["200"]["content"]["application/json"];
 export type GetExperimentResponse = operations["getExperiment"]["responses"]["200"]["content"]["application/json"];
 export type GetExperimentResultsResponse = operations["getExperimentResults"]["responses"]["200"]["content"]["application/json"];
+export type ListVisualChangesetsResponse = operations["listVisualChangesets"]["responses"]["200"]["content"]["application/json"];
+export type GetVisualChangesetResponse = operations["getVisualChangeset"]["responses"]["200"]["content"]["application/json"];

--- a/packages/back-end/types/visual-changeset.d.ts
+++ b/packages/back-end/types/visual-changeset.d.ts
@@ -15,6 +15,7 @@ interface VisualChange {
 
 export interface VisualChangesetInterface {
   id: string;
+  organization: string;
   urlPattern: string;
   editorUrl: string;
   experiment: string;

--- a/packages/back-end/types/visual-changeset.d.ts
+++ b/packages/back-end/types/visual-changeset.d.ts
@@ -1,0 +1,22 @@
+interface DOMMutation {
+  selector: string;
+  action: "append" | "set" | "remove";
+  attribute: string;
+  value: string;
+}
+
+interface VisualChange {
+  id: string;
+  description: string;
+  css: string;
+  variation: string;
+  domMutations: DOMMutation[];
+}
+
+export interface VisualChangesetInterface {
+  id: string;
+  urlPattern: string;
+  editorUrl: string;
+  experiment: string;
+  visualChanges: VisualChange[];
+}


### PR DESCRIPTION
This PR adds the `VisualChangeset` model and dependent models to our backend and REST API. It's a simple PR with just the addition of the model, interface types, and read-only REST API endpoints. Would like to get a review on just these early changes to make sure I'm building things the right way and not missing anything...

Diagram of proposed data model

![image](https://user-images.githubusercontent.com/2374625/222534093-b811ca95-0102-49a8-90ce-c7064616f9ef.png)

Documentation
- [VisualChangeset model doc](https://www.notion.so/growthbook/Visual-Changesets-Data-model-1cabf5276654493e9c048ee27fb5e3c7)
- [Jeremy's experiment model refactor doc](https://www.notion.so/growthbook/Experiment-Model-Changes-3396eafb6d894a2ca190c6b72c402e8d)