### PR TITLE
fix: incorrect stats check in MetricValueColumn

### DIFF
--- a/packages/front-end/components/Experiment/MetricValueColumn.tsx
+++ b/packages/front-end/components/Experiment/MetricValueColumn.tsx
@@ -17,7 +17,7 @@ export default function MetricValueColumn({
 }) {
   return (
     <td className={className}>
-      {metric && stats.value ? (
+      {metric && stats.users ? (
         <>
           <div className="result-number">
             {formatConversionRate(metric?.type, stats.cr)}


### PR DESCRIPTION
### Features and Changes

I'm currently running an experiment on a `count` metric, and breaking it down by my selected dimension (before screenshot). Upon spot checking the data that Growthbook outputted, I noticed that `fourth` variant in Growthbook reported no data, but in my dataset had three entries, it just happens to be that all their values were **zero**, falling in to one of the classic JavaScript traps. :D

This PR updates the `MetricValueColumn` component to render if there were entries for a given metric (`users`) rather than if the metric value was greater than 0, not a falsey.

### Dependencies

None.

### Testing

Directly on the UI.

### Screenshots

__Before__

![Screenshot 2023-03-02 at 5 08 21 PM](https://user-images.githubusercontent.com/5246169/222584245-de3eec1a-79fd-4bf4-8f2b-75a15975fcf4.png)

__After__

![Screenshot 2023-03-02 at 5 08 35 PM](https://user-images.githubusercontent.com/5246169/222584319-6b3d540e-980c-4635-b64c-6755f1a14d28.png)
