### PR TITLE
use ApiExperiment instead of ExperimentInterface for event logs

### DIFF
--- a/packages/back-end/src/events/base-events.ts
+++ b/packages/back-end/src/events/base-events.ts
@@ -1,5 +1,5 @@
 import { FeatureInterface } from "../../types/feature";
-import { ExperimentInterface } from "../../types/experiment";
+import { ApiExperiment } from "../../types/openapi";
 import { NotificationEventPayload } from "./base-types";
 
 // region Feature
@@ -37,7 +37,7 @@ export type ExperimentCreatedNotificationEvent = NotificationEventPayload<
   "experiment.created",
   "experiment",
   {
-    current: ExperimentInterface;
+    current: ApiExperiment;
   }
 >;
 
@@ -45,8 +45,8 @@ export type ExperimentUpdatedNotificationEvent = NotificationEventPayload<
   "experiment.updated",
   "experiment",
   {
-    current: ExperimentInterface;
-    previous: ExperimentInterface;
+    current: ApiExperiment;
+    previous: ApiExperiment;
   }
 >;
 
@@ -54,7 +54,7 @@ export type ExperimentDeletedNotificationEvent = NotificationEventPayload<
   "experiment.deleted",
   "experiment",
   {
-    previous: ExperimentInterface;
+    previous: ApiExperiment;
   }
 >;
 

--- a/packages/back-end/src/models/ExperimentModel.ts
+++ b/packages/back-end/src/models/ExperimentModel.ts
@@ -10,6 +10,7 @@ import {
   determineNextDate,
   experimentUpdated,
   generateTrackingKey,
+  toExperimentApiInterface,
 } from "../services/experiments";
 import {
   ExperimentCreatedNotificationEvent,
@@ -566,7 +567,7 @@ export const logExperimentCreated = async (
     object: "experiment",
     event: "experiment.created",
     data: {
-      current: experiment,
+      current: toExperimentApiInterface(organization, experiment),
     },
   };
 
@@ -594,8 +595,8 @@ export const logExperimentUpdated = async ({
     object: "experiment",
     event: "experiment.updated",
     data: {
-      previous,
-      current,
+      previous: toExperimentApiInterface(organization, previous),
+      current: toExperimentApiInterface(organization, current),
     },
   };
 
@@ -779,7 +780,7 @@ export const logExperimentDeleted = async (
     object: "experiment",
     event: "experiment.deleted",
     data: {
-      previous: experiment,
+      previous: toExperimentApiInterface(organization, experiment),
     },
   };
 


### PR DESCRIPTION
### Features and Changes

Uses the new `ApiExperiment` instead of the `ExperimentInterface` for the event logs.

- Closes https://linear.app/growthbook/issue/GB-64/[be]-use-new-apiexperiment-shape-for-event-logging

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

<!--
  Please describe how to test these changes.
 -->

<details>
<summary><b>Example payload</b></summary>

```json
{
  "object": "experiment",
  "event": "experiment.updated",
  "data": {
    "previous": {
      "id": "exp_sktwi6h9lak499tp",
      "name": "Experiment Analysis (1)",
      "project": "prj_sktwi76klbcpsjzu",
      "hypothesis": "",
      "description": "",
      "tags": [
        "checkout"
      ],
      "owner": "u_sktwi1id9l7z9xkis",
      "dateCreated": "2022-11-16T20:49:03.997Z",
      "dateUpdated": "2023-02-14T22:24:56.597Z",
      "archived": false,
      "status": "running",
      "autoRefresh": false,
      "variations": [
        {
          "variationId": "0",
          "key": "1",
          "name": "Variation 1",
          "description": "",
          "screenshots": []
        },
        {
          "variationId": "1",
          "key": "2",
          "name": "Variation 2",
          "description": "",
          "screenshots": []
        }
      ],
      "phases": [
        {
          "name": "main",
          "dateStarted": "2022-07-07T07:00:00.000Z",
          "dateEnded": "",
          "reasonForStopping": "",
          "seed": "homepage-nav-ios",
          "coverage": 0.51,
          "trafficSplit": [
            {
              "variationId": "0",
              "weight": 0.5
            },
            {
              "variationId": "1",
              "weight": 0.5
            }
          ],
          "targetingCondition": ""
        }
      ],
      "settings": {
        "datasourceId": "ds_sktwi15odl8t77li0",
        "assignmentQueryId": "tbl_l8t7gkdy",
        "experimentId": "homepage-nav-ios",
        "segmentId": "",
        "queryFilter": "",
        "inProgressConversions": "include",
        "multipleVariations": "exclude",
        "attributionModel": "firstExposure",
        "statsEngine": "bayesian",
        "goals": [],
        "guardrails": []
      }
    },
    "current": {
      "id": "exp_sktwi6h9lak499tp",
      "name": "Experiment Analysis (1)",
      "project": "prj_sktwi76klbcpsjzu",
      "hypothesis": "",
      "description": "",
      "tags": [
        "checkout"
      ],
      "owner": "u_sktwi1id9l7z9xkis",
      "dateCreated": "2022-11-16T20:49:03.997Z",
      "dateUpdated": "2023-02-14T22:24:56.597Z",
      "archived": false,
      "status": "running",
      "autoRefresh": false,
      "variations": [
        {
          "variationId": "0",
          "key": "1",
          "name": "Variation 1",
          "description": "",
          "screenshots": []
        },
        {
          "variationId": "1",
          "key": "2",
          "name": "Variation 2",
          "description": "",
          "screenshots": []
        }
      ],
      "phases": [
        {
          "name": "main",
          "dateStarted": "2022-07-07T07:00:00.000Z",
          "dateEnded": "",
          "reasonForStopping": "",
          "seed": "homepage-nav-ios",
          "coverage": 0.51,
          "trafficSplit": [
            {
              "variationId": "0",
              "weight": 0.5
            },
            {
              "variationId": "1",
              "weight": 0.5
            }
          ],
          "targetingCondition": ""
        }
      ],
      "settings": {
        "datasourceId": "ds_sktwi15odl8t77li0",
        "assignmentQueryId": "tbl_l8t7gkdy",
        "experimentId": "homepage-nav-ios",
        "segmentId": "",
        "queryFilter": "",
        "inProgressConversions": "include",
        "multipleVariations": "exclude",
        "attributionModel": "firstExposure",
        "statsEngine": "bayesian",
        "goals": [],
        "guardrails": []
      }
    }
  }
}

```

</details>

