### PR TITLE
Fix incorrect denominator being shown in results table

### DIFF
--- a/packages/stats/gbstats/gbstats.py
+++ b/packages/stats/gbstats/gbstats.py
@@ -238,7 +238,7 @@ def format_results(df):
                         "cr": row[f"{prefix}_cr"],
                         "value": row[f"{prefix}_main_sum"],
                         "users": row[f"{prefix}_users"],
-                        "denominator": row[f"{prefix}_count"],
+                        "denominator": row[f"{prefix}_denominator_sum"],
                         "stats": stats,
                     }
                 )
@@ -248,7 +248,7 @@ def format_results(df):
                         "cr": row[f"{prefix}_cr"],
                         "value": row[f"{prefix}_main_sum"],
                         "users": row[f"{prefix}_users"],
-                        "denominator": row[f"{prefix}_count"],
+                        "denominator": row[f"{prefix}_denominator_sum"],
                         "expected": row[f"{prefix}_expected"],
                         "chanceToWin": row[f"{prefix}_prob_beat_baseline"],
                         "pValue": row[f"{prefix}_p_value"],

--- a/packages/stats/tests/frequentist/test_tests.py
+++ b/packages/stats/tests/frequentist/test_tests.py
@@ -37,7 +37,7 @@ class TestTwoSidedTTest(TestCase):
             result_dict[k] = v
 
         self.assertDictEqual(result_dict, expected_rounded_dict)
-    
+
     def test_two_sided_ttest_missing_variance(self):
         stat_a = SampleMeanStatistic(sum=1396.87, sum_squares=52377.9767, n=2)
         stat_b = SampleMeanStatistic(sum=2422.7, sum_squares=134698.29, n=3461)

--- a/packages/stats/tests/test_shared_models.py
+++ b/packages/stats/tests/test_shared_models.py
@@ -27,7 +27,6 @@ class TestSampleMeanStatistic(TestCase):
         expected_var = np.var(METRIC_1, ddof=1)
         self.assertEqual(stat.mean, expected_mean)
         self.assertEqual(stat.variance, expected_var)
-    
 
     def test_sample_mean_statistic_low_n(self):
         stat = SampleMeanStatistic(


### PR DESCRIPTION
Fixes #1057 

### Features and Changes

Following the stats refactor, the value returned as `denominator` to the app and therefore the front-end needed to change to `denominator_sum`  rather than `count`. The only place I see this is used in the front-end after a cursory look is in the MetricValueColumn, so the bug should be constrained just to the denominator in that visual element. All other statistics (mean values, inferential statistics, etc) should be unaffected since this is just one auxiliary field used for display purposes.



### Screenshots

Before:
<img width="436" alt="Screen Shot 2023-03-08 at 7 06 38 AM" src="https://user-images.githubusercontent.com/5298599/223750061-a8bdd97e-72d2-476f-9cb7-8689904d7d76.png">

note that 1553/63=24.65 not 24.27, so we need to fix Average Order Value

After the results are fixed, and the denominator for the user based metrics are unchaged:
<img width="446" alt="Screen Shot 2023-03-08 at 7 06 25 AM" src="https://user-images.githubusercontent.com/5298599/223750035-ea61ac84-ea51-4517-8a13-dbe35acc6eed.png">
