### PR TITLE
Add sum graph to metrics page, alter smoothing function and UI

### DIFF
--- a/packages/front-end/components/HomePage/NorthStarMetricDisplay.tsx
+++ b/packages/front-end/components/HomePage/NorthStarMetricDisplay.tsx
@@ -54,10 +54,11 @@ const NorthStarMetricDisplay = ({
 
   return (
     <>
-      <div>
+      <div className="mt-2">
         {analysis && analysis?.dates && analysis.dates.length > 0 ? (
           <div className="mb-4">
-            <h5 className="mb-3">{metric.name}</h5>
+            <h4 className="mb-3">{metric.name}</h4>
+            <strong className="ml-4 align-bottom">Daily Average</strong>
             <DateGraph
               type={metric.type}
               dates={analysis.dates}
@@ -69,7 +70,7 @@ const NorthStarMetricDisplay = ({
           </div>
         ) : (
           <div className="mb-4">
-            <h5 className="my-3">{metric.name}</h5>
+            <h4 className="my-3">{metric.name}</h4>
             {permissions.check("runQueries", "") && (
               <form
                 onSubmit={async (e) => {

--- a/packages/front-end/components/HomePage/NorthStarMetricDisplay.tsx
+++ b/packages/front-end/components/HomePage/NorthStarMetricDisplay.tsx
@@ -58,14 +58,17 @@ const NorthStarMetricDisplay = ({
         {analysis && analysis?.dates && analysis.dates.length > 0 ? (
           <div className="mb-4">
             <h4 className="mb-3">{metric.name}</h4>
-            <strong className="ml-4 align-bottom">Daily Average</strong>
+            <strong className="ml-4 align-bottom">
+              Daily {metric.type !== "binomial" ? "Average" : "Count"}
+            </strong>
             <DateGraph
               type={metric.type}
               dates={analysis.dates}
               experiments={experiments}
               showStdDev={false}
-              groupby={resolution === "week" ? "week" : "day"}
+              smoothBy={resolution === "week" ? "week" : "day"}
               height={300}
+              method={metric.type !== "binomial" ? "avg" : "sum"}
             />
           </div>
         ) : (

--- a/packages/front-end/components/Metrics/DateGraph.tsx
+++ b/packages/front-end/components/Metrics/DateGraph.tsx
@@ -176,8 +176,9 @@ const DateGraph: FC<{
   } = useTooltip<TooltipData>();
 
   const margin = [15, 15, 30, 80];
-  const min = Math.min(...data.map((d) => d.d));
-  const max = Math.max(...data.map((d) => d.d));
+  const dateNums = data.map((d) => getValidDate(d.d).getTime());
+  const min = Math.min(...dateNums);
+  const max = Math.max(...dateNums);
 
   const [toolTipTimer, setToolTipTimer] = useState<null | ReturnType<
     typeof setTimeout

--- a/packages/front-end/components/Metrics/DateGraph.tsx
+++ b/packages/front-end/components/Metrics/DateGraph.tsx
@@ -61,7 +61,7 @@ type ExperimentDisplayData = {
 
 const DateGraph: FC<{
   type: MetricType;
-  groupby?: "day" | "week";
+  smoothBy?: "day" | "week";
   method?: "avg" | "sum";
   dates: Datapoint[];
   showStdDev?: boolean;
@@ -69,7 +69,7 @@ const DateGraph: FC<{
   height?: number;
 }> = ({
   type,
-  groupby = "day",
+  smoothBy = "day",
   method = "avg",
   dates,
   showStdDev = true,
@@ -84,7 +84,7 @@ const DateGraph: FC<{
         let stddev = method === "avg" ? row.s : 0;
         const count = row.c || 1;
 
-        if (groupby === "week") {
+        if (smoothBy === "week") {
           // get 7 day average (or < 7 days if at beginning of data)
           const windowedDates = dates.slice(Math.max(i - 6, 0), i + 1);
           const days = windowedDates.length;
@@ -104,13 +104,13 @@ const DateGraph: FC<{
           s: stddev,
           c: count,
         };
-        if (groupby === "week" && i < 6) {
+        if (smoothBy === "week" && i < 6) {
           ret.oor = true;
         }
         return ret;
       }),
 
-    [dates, groupby, method]
+    [dates, smoothBy, method]
   );
 
   const getTooltipData = (mx: number, width: number, yScale): TooltipData => {
@@ -122,7 +122,7 @@ const DateGraph: FC<{
     );
     const d = data[index];
     const x = (data.length > 0 ? index / data.length : 0) * innerWidth;
-    const y = yScale(type === "binomial" ? d.c : d.v) ?? 0;
+    const y = yScale(d.v) ?? 0;
     return { x, y, d };
   };
 
@@ -137,14 +137,14 @@ const DateGraph: FC<{
             <div className={styles.val}>
               {method === "sum" ? `Σ` : `μ`}:{" "}
               {formatConversionRate(type, d.v as number)}
-              {groupby === "week" && (
+              {smoothBy === "week" && (
                 <sub style={{ fontWeight: "normal", fontSize: 8 }}>smooth</sub>
               )}
             </div>
             {"s" in d && method === "avg" && (
               <div className={styles.secondary}>
                 {`σ`}: {formatConversionRate(type, d.s)}
-                {groupby === "week" && (
+                {smoothBy === "week" && (
                   <sub style={{ fontWeight: "normal", fontSize: 8 }}>
                     smooth
                   </sub>
@@ -447,7 +447,7 @@ const DateGraph: FC<{
                       curve={curveMonotoneX}
                     />
 
-                    {groupby === "week" && (
+                    {smoothBy === "week" && (
                       <>
                         <AreaClosed
                           yScale={yScale}
@@ -479,17 +479,17 @@ const DateGraph: FC<{
                 <LinePath
                   data={data}
                   x={(d) => xScale(d.d) ?? 0}
-                  y={(d) => yScale(type === "binomial" ? d.c : d.v) ?? 0}
+                  y={(d) => yScale(d.v) ?? 0}
                   stroke={"#8884d8"}
                   strokeWidth={2}
                   curve={curveMonotoneX}
                   defined={(d) => !d?.oor}
                 />
-                {groupby === "week" && (
+                {smoothBy === "week" && (
                   <LinePath
                     data={data}
                     x={(d) => xScale(d.d) ?? 0}
-                    y={(d) => yScale(type === "binomial" ? d.c : d.v) ?? 0}
+                    y={(d) => yScale(d.v) ?? 0}
                     stroke={"#8884d8"}
                     opacity={0.5}
                     strokeDasharray={"2,5"}

--- a/packages/front-end/pages/metric/[mid].tsx
+++ b/packages/front-end/pages/metric/[mid].tsx
@@ -72,13 +72,13 @@ const MetricPage: FC = () => {
   const [editProjects, setEditProjects] = useState(false);
   const [editOwnerModal, setEditOwnerModal] = useState(false);
   const [segmentOpen, setSegmentOpen] = useState(false);
-  const storageKeyAvg = `metric_groupby`; // to make metric-specific, include `${mid}`
-  const storageKeySum = `metric_groupby_sum`; // to make metric-specific, include `${mid}`
-  const [groupbyAvg, setGroupbyAvg] = useLocalStorage<"day" | "week">(
+  const storageKeyAvg = `metric_smoothBy_avg`; // to make metric-specific, include `${mid}`
+  const storageKeySum = `metric_smoothBy_sum`;
+  const [smoothByAvg, setSmoothByAvg] = useLocalStorage<"day" | "week">(
     storageKeyAvg,
     "day"
   );
-  const [groupbySum, setGroupbySum] = useLocalStorage<"day" | "week">(
+  const [smoothBySum, setSmoothBySum] = useLocalStorage<"day" | "week">(
     storageKeySum,
     "day"
   );
@@ -625,86 +625,111 @@ const MetricPage: FC = () => {
                             </div>
                           </div>
 
-                          <div className="row mt-4 mb-1">
-                            <div className="col">
-                              <Tooltip
-                                body={
-                                  <>
-                                    <p>
-                                      This figure shows the average metric value
-                                      on a day divided by number of unique units
-                                      (e.g. users) in the metric source on that
-                                      day.
-                                    </p>
-                                    {metric.type !== "binomial" && (
-                                      <p>
-                                        The standard deviation shows the spread
-                                        of the daily user metric values.
-                                      </p>
-                                    )}
-                                    <p>
-                                      When smoothing is turned on, we simply
-                                      average values and standard deviations
-                                      over the 7 trailing days (including the
-                                      selected day).
-                                    </p>
-                                  </>
-                                }
-                              >
-                                <strong className="ml-4 align-bottom">
-                                  Daily Average <FaQuestionCircle />
-                                </strong>
-                              </Tooltip>
-                            </div>
-                            <div className="col">
-                              <div className="float-right mr-2">
-                                <label
-                                  className="small my-0 mr-2 text-right align-middle"
-                                  htmlFor="toggle-group-by-avg"
-                                >
-                                  Smoothing
-                                  <br />
-                                  (7 day trailing)
-                                </label>
-                                <Toggle
-                                  value={groupbyAvg === "week"}
-                                  setValue={() =>
-                                    setGroupbyAvg(
-                                      groupbyAvg === "week" ? "day" : "week"
-                                    )
-                                  }
-                                  id="toggle-group-by-avg"
-                                  className="align-middle"
-                                />
+                          {metric.type !== "binomial" && (
+                            <>
+                              <div className="row mt-4 mb-1">
+                                <div className="col">
+                                  <Tooltip
+                                    body={
+                                      <>
+                                        <p>
+                                          This figure shows the average metric
+                                          value on a day divided by number of
+                                          unique units (e.g. users) in the
+                                          metric source on that day.
+                                        </p>
+                                        <p>
+                                          The standard deviation shows the
+                                          spread of the daily user metric
+                                          values.
+                                        </p>
+                                        <p>
+                                          When smoothing is turned on, we simply
+                                          average values and standard deviations
+                                          over the 7 trailing days (including
+                                          the selected day).
+                                        </p>
+                                      </>
+                                    }
+                                  >
+                                    <strong className="ml-4 align-bottom">
+                                      Daily Average <FaQuestionCircle />
+                                    </strong>
+                                  </Tooltip>
+                                </div>
+                                <div className="col">
+                                  <div className="float-right mr-2">
+                                    <label
+                                      className="small my-0 mr-2 text-right align-middle"
+                                      htmlFor="toggle-group-by-avg"
+                                    >
+                                      Smoothing
+                                      <br />
+                                      (7 day trailing)
+                                    </label>
+                                    <Toggle
+                                      value={smoothByAvg === "week"}
+                                      setValue={() =>
+                                        setSmoothByAvg(
+                                          smoothByAvg === "week"
+                                            ? "day"
+                                            : "week"
+                                        )
+                                      }
+                                      id="toggle-group-by-avg"
+                                      className="align-middle"
+                                    />
+                                  </div>
+                                </div>
                               </div>
-                            </div>
-                          </div>
-                          <DateGraph
-                            type={metric.type}
-                            method="avg"
-                            dates={analysis.dates}
-                            groupby={groupbyAvg}
-                          />
+                              <DateGraph
+                                type={metric.type}
+                                method="avg"
+                                dates={analysis.dates}
+                                smoothBy={smoothByAvg}
+                              />
+                            </>
+                          )}
 
                           <div className="row mt-4 mb-1">
                             <div className="col">
                               <Tooltip
                                 body={
                                   <>
-                                    <p>
-                                      This figure shows the daily sum of values
-                                      in the metric source on that day.
-                                    </p>
-                                    <p>
-                                      When smoothing is turned on, we simply
-                                      average values over the 7 trailing days
-                                      (including the selected day).
-                                    </p>
+                                    {metric.type !== "binomial" ? (
+                                      <>
+                                        <p>
+                                          This figure shows the daily sum of
+                                          values in the metric source on that
+                                          day.
+                                        </p>
+                                        <p>
+                                          When smoothing is turned on, we simply
+                                          average values over the 7 trailing
+                                          days (including the selected day).
+                                        </p>
+                                      </>
+                                    ) : (
+                                      <>
+                                        <p>
+                                          This figure shows the total count of
+                                          units (e.g. users) in the metric
+                                          source on that day.
+                                        </p>
+                                        <p>
+                                          When smoothing is turned on, we simply
+                                          average counts over the 7 trailing
+                                          days (including the selected day).
+                                        </p>
+                                      </>
+                                    )}
                                   </>
                                 }
                               >
                                 <strong className="ml-4 align-bottom">
-                                  Daily Sum <FaQuestionCircle />
+                                  Daily{" "}
+                                  {metric.type !== "binomial" ? "Sum" : "Count"}{" "}
+                                  <FaQuestionCircle />
                                 </strong>
                               </Tooltip>
                             </div>
@@ -719,10 +744,10 @@ const MetricPage: FC = () => {
                                   (7 day trailing)
                                 </label>
                                 <Toggle
-                                  value={groupbySum === "week"}
+                                  value={smoothBySum === "week"}
                                   setValue={() =>
-                                    setGroupbySum(
-                                      groupbySum === "week" ? "day" : "week"
+                                    setSmoothBySum(
+                                      smoothBySum === "week" ? "day" : "week"
                                     )
                                   }
                                   id="toggle-group-by-sum"
@@ -735,7 +760,7 @@ const MetricPage: FC = () => {
                             type={metric.type}
                             method="sum"
                             dates={analysis.dates}
-                            groupby={groupbySum}
+                            smoothBy={smoothBySum}
                           />
                         </div>
                       )}

--- a/packages/front-end/pages/metric/[mid].tsx
+++ b/packages/front-end/pages/metric/[mid].tsx
@@ -2,7 +2,7 @@ import { useRouter } from "next/router";
 import React, { FC, useState, useEffect, Fragment } from "react";
 import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
 import Link from "next/link";
-import { FaAngleLeft, FaChevronRight } from "react-icons/fa";
+import { FaAngleLeft, FaChevronRight, FaQuestionCircle } from "react-icons/fa";
 import { MetricInterface } from "back-end/types/metric";
 import { useForm } from "react-hook-form";
 import { BsGear } from "react-icons/bs";
@@ -51,6 +51,7 @@ import ProjectBadges from "@/components/ProjectBadges";
 import EditProjectsForm from "@/components/Projects/EditProjectsForm";
 import { GBEdit } from "@/components/Icons";
 import Toggle from "@/components/Forms/Toggle";
+import Tooltip from "@/components/Tooltip/Tooltip";
 
 const MetricPage: FC = () => {
   const router = useRouter();
@@ -626,9 +627,34 @@ const MetricPage: FC = () => {
 
                           <div className="row mt-4 mb-1">
                             <div className="col">
-                              <strong className="ml-4 align-bottom">
-                                Daily Average
-                              </strong>
+                              <Tooltip
+                                body={
+                                  <>
+                                    <p>
+                                      This figure shows the average metric value
+                                      on a day divided by number of unique units
+                                      (e.g. users) in the metric source on that
+                                      day.
+                                    </p>
+                                    {metric.type !== "binomial" && (
+                                      <p>
+                                        The standard deviation shows the spread
+                                        of the daily user metric values.
+                                      </p>
+                                    )}
+                                    <p>
+                                      When smoothing is turned on, we simply
+                                      average values and standard deviations
+                                      over the 7 trailing days (including the
+                                      selected day).
+                                    </p>
+                                  </>
+                                }
+                              >
+                                <strong className="ml-4 align-bottom">
+                                  Daily Average <FaQuestionCircle />
+                                </strong>
+                              </Tooltip>
                             </div>
                             <div className="col">
                               <div className="float-right mr-2">
@@ -662,9 +688,25 @@ const MetricPage: FC = () => {
 
                           <div className="row mt-4 mb-1">
                             <div className="col">
-                              <strong className="ml-4 align-bottom">
-                                Daily Sum
-                              </strong>
+                              <Tooltip
+                                body={
+                                  <>
+                                    <p>
+                                      This figure shows the daily sum of values
+                                      in the metric source on that day.
+                                    </p>
+                                    <p>
+                                      When smoothing is turned on, we simply
+                                      average values over the 7 trailing days
+                                      (including the selected day).
+                                    </p>
+                                  </>
+                                }
+                              >
+                                <strong className="ml-4 align-bottom">
+                                  Daily Sum <FaQuestionCircle />
+                                </strong>
+                              </Tooltip>
                             </div>
                             <div className="col">
                               <div className="float-right mr-2">

--- a/packages/front-end/pages/metric/[mid].tsx
+++ b/packages/front-end/pages/metric/[mid].tsx
@@ -6,7 +6,6 @@ import { FaAngleLeft, FaChevronRight } from "react-icons/fa";
 import { MetricInterface } from "back-end/types/metric";
 import { useForm } from "react-hook-form";
 import { BsGear } from "react-icons/bs";
-import clsx from "clsx";
 import { IdeaInterface } from "back-end/types/idea";
 import useApi from "@/hooks/useApi";
 import useOrgSettings from "@/hooks/useOrgSettings";
@@ -51,6 +50,7 @@ import { useOrganizationMetricDefaults } from "@/hooks/useOrganizationMetricDefa
 import ProjectBadges from "@/components/ProjectBadges";
 import EditProjectsForm from "@/components/Projects/EditProjectsForm";
 import { GBEdit } from "@/components/Icons";
+import Toggle from "@/components/Forms/Toggle";
 
 const MetricPage: FC = () => {
   const router = useRouter();
@@ -71,9 +71,14 @@ const MetricPage: FC = () => {
   const [editProjects, setEditProjects] = useState(false);
   const [editOwnerModal, setEditOwnerModal] = useState(false);
   const [segmentOpen, setSegmentOpen] = useState(false);
-  const storageKey = `metric_groupby`; // to make metric-specific, include `${mid}`
-  const [groupby, setGroupby] = useLocalStorage<"day" | "week">(
-    storageKey,
+  const storageKeyAvg = `metric_groupby`; // to make metric-specific, include `${mid}`
+  const storageKeySum = `metric_groupby_sum`; // to make metric-specific, include `${mid}`
+  const [groupbyAvg, setGroupbyAvg] = useLocalStorage<"day" | "week">(
+    storageKeyAvg,
+    "day"
+  );
+  const [groupbySum, setGroupbySum] = useLocalStorage<"day" | "week">(
+    storageKeySum,
     "day"
   );
 
@@ -608,7 +613,7 @@ const MetricPage: FC = () => {
                       )}
                       {analysis?.dates && analysis.dates.length > 0 && (
                         <div className="mb-4">
-                          <div className="row mb-3">
+                          <div className="row mt-3">
                             <div className="col-auto">
                               <h5 className="mb-1 mt-1">
                                 {metric.type === "binomial"
@@ -617,40 +622,78 @@ const MetricPage: FC = () => {
                                 Over Time
                               </h5>
                             </div>
-                            <div className="col-auto">
-                              <a
-                                className={clsx("badge badge-pill mr-2", {
-                                  "badge-light": groupby === "week",
-                                  "badge-primary": groupby === "day",
-                                })}
-                                href="#"
-                                onClick={(e) => {
-                                  e.preventDefault();
-                                  setGroupby("day");
-                                }}
-                              >
-                                day
-                              </a>
-                              <a
-                                className={clsx("badge badge-pill", {
-                                  "badge-light": groupby === "day",
-                                  "badge-primary": groupby === "week",
-                                })}
-                                href="#"
-                                onClick={(e) => {
-                                  e.preventDefault();
-                                  setGroupby("week");
-                                }}
-                              >
-                                week
-                              </a>
-                            </div>
                           </div>
 
+                          <div className="row mt-4 mb-1">
+                            <div className="col">
+                              <strong className="ml-4 align-bottom">
+                                Daily Average
+                              </strong>
+                            </div>
+                            <div className="col">
+                              <div className="float-right mr-2">
+                                <label
+                                  className="small my-0 mr-2 text-right align-middle"
+                                  htmlFor="toggle-group-by-avg"
+                                >
+                                  Smoothing
+                                  <br />
+                                  (7 day trailing)
+                                </label>
+                                <Toggle
+                                  value={groupbyAvg === "week"}
+                                  setValue={() =>
+                                    setGroupbyAvg(
+                                      groupbyAvg === "week" ? "day" : "week"
+                                    )
+                                  }
+                                  id="toggle-group-by-avg"
+                                  className="align-middle"
+                                />
+                              </div>
+                            </div>
+                          </div>
                           <DateGraph
                             type={metric.type}
+                            method="avg"
                             dates={analysis.dates}
-                            groupby={groupby}
+                            groupby={groupbyAvg}
+                          />
+
+                          <div className="row mt-4 mb-1">
+                            <div className="col">
+                              <strong className="ml-4 align-bottom">
+                                Daily Sum
+                              </strong>
+                            </div>
+                            <div className="col">
+                              <div className="float-right mr-2">
+                                <label
+                                  className="small my-0 mr-2 text-right align-middle"
+                                  htmlFor="toggle-group-by-sum"
+                                >
+                                  Smoothing
+                                  <br />
+                                  (7 day trailing)
+                                </label>
+                                <Toggle
+                                  value={groupbySum === "week"}
+                                  setValue={() =>
+                                    setGroupbySum(
+                                      groupbySum === "week" ? "day" : "week"
+                                    )
+                                  }
+                                  id="toggle-group-by-sum"
+                                  className="align-middle"
+                                />
+                              </div>
+                            </div>
+                          </div>
+                          <DateGraph
+                            type={metric.type}
+                            method="sum"
+                            dates={analysis.dates}
+                            groupby={groupbySum}
                           />
                         </div>
                       )}


### PR DESCRIPTION
### Features and Changes

At the request of some customers, we are adding a graph of metric sums (instead of only averages). After some discussion, we also felt that the "day"/"week" toggle is misleading, as "week" effectively smooths the same data over a 7-day window rather than provides a meaningful aggregation. We decided to allow for 7-day smoothing to still have a daily plot. We also needed to adjust standard deviation somewhat.

Note that standard deviation is a tiny bit suspect in both the "average" and "sum" graphs, since it's the daily std dev rather than the "std dev of the sum" or "std dev of the average". It's still useful though in providing a visual sense of variability of the metric. We may refine this further later.

### Screenshots

**Latest update:**
<img width="852" alt="image" src="https://user-images.githubusercontent.com/7927873/224188223-165a0c1e-4955-4e85-a31c-3523c2fd7964.png">


**Prior:**

New Sums graph with updated UI. Note that the day/week picker has been reworded to indicate a smoothing function rather than an aggregation.
<img width="842" alt="image" src="https://user-images.githubusercontent.com/7927873/223930055-1f429d8f-11b4-417f-a54f-9291af3bf0d1.png">

Toggling the "week" smoothing on both graphs:
<img width="848" alt="image" src="https://user-images.githubusercontent.com/7927873/223930218-56fb544e-a1cd-42a3-9457-6946d682b183.png">

