### PR TITLE
Fix: Add whitespace to clear the chat button on the settings page

### DIFF
--- a/packages/front-end/pages/settings/index.tsx
+++ b/packages/front-end/pages/settings/index.tsx
@@ -209,7 +209,7 @@ const GeneralSettingsPage = (): React.ReactElement => {
         />
       )}
 
-      <div className="container-fluid pagecontents">
+      <div className="container-fluid pagecontents pb-5">
         {saveMsg && (
           <TempMessage
             close={() => {
@@ -234,7 +234,7 @@ const GeneralSettingsPage = (): React.ReactElement => {
         )}
         <h1>General Settings</h1>
 
-        <div className="mb-1">
+        <div className="mb-5">
           <div className=" bg-white p-3 border">
             <div className="row mb-0">
               <div className="col-sm-3">


### PR DESCRIPTION
### Features and Changes

Add whitespace to clear the Papercups chat button on the settings page. This is a quick fix for now but a more long-term solution would be to split up this page into sections like we did for the data sources page.

### Dependencies

n/a

### Testing

Visit /settings and clicking the save button should be more obvious to click.


### Screenshots

<img width="1234" alt="image" src="https://user-images.githubusercontent.com/113377031/224130313-779b4b6e-5519-4b77-bdc5-e823a17ca5b5.png">
