### PR TITLE
Revert "GB-18 Support experiment CRUD events in event webhooks (#1064)"

### DIFF
--- a/packages/back-end/src/events/base-events.ts
+++ b/packages/back-end/src/events/base-events.ts
@@ -1,4 +1,5 @@
-import { ApiExperiment, ApiFeature } from "../../types/openapi";
+import { FeatureInterface } from "../../types/feature";
+import { ApiExperiment } from "../../types/openapi";
 import { NotificationEventPayload } from "./base-types";
 
 // region Feature
@@ -7,7 +8,7 @@ export type FeatureCreatedNotificationEvent = NotificationEventPayload<
   "feature.created",
   "feature",
   {
-    current: ApiFeature;
+    current: FeatureInterface;
   }
 >;
 
@@ -15,8 +16,8 @@ export type FeatureUpdatedNotificationEvent = NotificationEventPayload<
   "feature.updated",
   "feature",
   {
-    current: ApiFeature;
-    previous: ApiFeature;
+    current: FeatureInterface;
+    previous: FeatureInterface;
   }
 >;
 
@@ -24,7 +25,7 @@ export type FeatureDeletedNotificationEvent = NotificationEventPayload<
   "feature.deleted",
   "feature",
   {
-    previous: ApiFeature;
+    previous: FeatureInterface;
   }
 >;
 

--- a/packages/back-end/src/events/handlers/slack/slack-event-handler-utils.ts
+++ b/packages/back-end/src/events/handlers/slack/slack-event-handler-utils.ts
@@ -14,8 +14,8 @@ import {
   NotificationEvent,
 } from "../../base-events";
 import { SlackIntegrationInterface } from "../../../../types/slack-integration";
+import { FeatureInterface } from "../../../../types/feature";
 import { APP_ORIGIN } from "../../../util/secrets";
-import { ApiFeature } from "../../../../types/openapi";
 
 // region Filtering
 
@@ -180,11 +180,12 @@ const filterFeatureUpdateEventForRelevance = (
   const changedEnvironments = new Set<string>();
 
   // Some of the feature keys that change affect all enabled environments
-  const relevantKeysForAllEnvs: (keyof ApiFeature)[] = [
+  const relevantKeysForAllEnvs: (keyof FeatureInterface)[] = [
     "archived",
     "defaultValue",
     "project",
     "valueType",
+    "nextScheduledUpdate",
   ];
   if (relevantKeysForAllEnvs.some((k) => !isEqual(previous[k], current[k]))) {
     // Some of the relevant keys for all environments has changed.
@@ -192,14 +193,14 @@ const filterFeatureUpdateEventForRelevance = (
   }
 
   const allEnvs = new Set([
-    ...Object.keys(previous.environments),
-    ...Object.keys(current.environments),
+    ...Object.keys(previous.environmentSettings),
+    ...Object.keys(current.environmentSettings),
   ]);
 
   // Add in environments if their specific settings changed
   allEnvs.forEach((env) => {
-    const previousEnvSettings = previous.environments[env];
-    const currentEnvSettings = current.environments[env];
+    const previousEnvSettings = previous.environmentSettings[env];
+    const currentEnvSettings = current.environmentSettings[env];
 
     // If the environment is disabled both before and after the change, ignore changes
     if (!previousEnvSettings?.enabled && !currentEnvSettings?.enabled) {

--- a/packages/back-end/src/events/handlers/webhooks/EventWebHookNotifier.ts
+++ b/packages/back-end/src/events/handlers/webhooks/EventWebHookNotifier.ts
@@ -6,6 +6,7 @@ import {
   updateEventWebHookStatus,
 } from "../../../models/EventWebhookModel";
 import { EventWebHookInterface } from "../../../../types/event-webhook";
+import { getSavedGroupMap } from "../../../services/features";
 import { findOrganizationById } from "../../../models/OrganizationModel";
 import { createEventWebHookLog } from "../../../models/EventWebHookLogModel";
 import { logger } from "../../../util/logger";
@@ -15,6 +16,7 @@ import {
   EventWebHookResult,
   EventWebHookSuccessResult,
   getEventWebHookSignatureForPayload,
+  getPayloadForNotificationEvent,
 } from "./event-webhooks-utils";
 
 let jobDefined = false;
@@ -99,7 +101,12 @@ export class EventWebHookNotifier implements Notifier {
       );
     }
 
-    const payload = event.data;
+    const savedGroupMap = await getSavedGroupMap(organization);
+    const payload = getPayloadForNotificationEvent({
+      event: event.data,
+      organization,
+      savedGroupMap,
+    });
 
     if (!payload) {
       // Unsupported events return a null payload

--- a/packages/back-end/src/events/handlers/webhooks/event-webhooks-utils.ts
+++ b/packages/back-end/src/events/handlers/webhooks/event-webhooks-utils.ts
@@ -1,4 +1,19 @@
 import { createHmac } from "crypto";
+import { OrganizationInterface } from "../../../../types/organization";
+import { getApiFeatureObj } from "../../../services/features";
+import {
+  FeatureCreatedNotificationEvent,
+  FeatureDeletedNotificationEvent,
+  FeatureUpdatedNotificationEvent,
+  NotificationEvent,
+} from "../../base-events";
+import {
+  NotificationEventName,
+  NotificationEventPayload,
+  NotificationEventResource,
+} from "../../base-types";
+import { GroupMap } from "../../../../types/saved-group";
+import { ApiFeature } from "../../../../types/openapi";
 
 export type EventWebHookSuccessResult = {
   result: "success";
@@ -36,3 +51,114 @@ export const getEventWebHookSignatureForPayload = <T>({
 };
 
 // endregion Web hook signing
+
+// region Web hook Payload creation
+
+type BasePayloadCreatorOptions = {
+  organization: OrganizationInterface;
+  savedGroupMap: GroupMap;
+};
+
+export const getPayloadForNotificationEvent = ({
+  event,
+  organization,
+  savedGroupMap,
+}: BasePayloadCreatorOptions & {
+  event: NotificationEvent;
+}): NotificationEventPayload<
+  NotificationEventName,
+  NotificationEventResource,
+  unknown
+> | null => {
+  switch (event.event) {
+    case "experiment.created":
+    case "experiment.updated":
+    case "experiment.deleted":
+      // TODO: https://linear.app/growthbook/issue/GB-18
+      return null;
+
+    case "feature.created":
+      return getPayloadForFeatureCreated({
+        event,
+        organization,
+        savedGroupMap,
+      });
+    case "feature.updated":
+      return getPayloadForFeatureUpdated({
+        event,
+        organization,
+        savedGroupMap,
+      });
+    case "feature.deleted":
+      return getPayloadForFeatureDeleted({
+        event,
+        organization,
+        savedGroupMap,
+      });
+  }
+};
+
+const getPayloadForFeatureCreated = ({
+  event,
+  organization,
+  savedGroupMap,
+}: BasePayloadCreatorOptions & {
+  event: FeatureCreatedNotificationEvent;
+}): NotificationEventPayload<
+  "feature.created",
+  "feature",
+  { feature: ApiFeature }
+> => ({
+  ...event,
+  data: {
+    ...event.data,
+    feature: getApiFeatureObj(event.data.current, organization, savedGroupMap),
+  },
+});
+
+const getPayloadForFeatureUpdated = ({
+  event,
+  organization,
+  savedGroupMap,
+}: BasePayloadCreatorOptions & {
+  event: FeatureUpdatedNotificationEvent;
+}): NotificationEventPayload<
+  "feature.updated",
+  "feature",
+  { current: ApiFeature; previous: ApiFeature }
+> => ({
+  ...event,
+  data: {
+    ...event.data,
+    current: getApiFeatureObj(event.data.current, organization, savedGroupMap),
+    previous: getApiFeatureObj(
+      event.data.previous,
+      organization,
+      savedGroupMap
+    ),
+  },
+});
+
+const getPayloadForFeatureDeleted = ({
+  event,
+  organization,
+  savedGroupMap,
+}: BasePayloadCreatorOptions & {
+  event: FeatureDeletedNotificationEvent;
+}): NotificationEventPayload<
+  "feature.deleted",
+  "feature",
+  { previous: ApiFeature }
+> => ({
+  ...event,
+  data: {
+    ...event.data,
+    previous: getApiFeatureObj(
+      event.data.previous,
+      organization,
+      savedGroupMap
+    ),
+  },
+});
+
+// endregion Web hook Payload creation

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -11,9 +11,7 @@ import {
 } from "../../types/feature";
 import {
   generateRuleId,
-  getApiFeatureObj,
   getNextScheduledUpdate,
-  getSavedGroupMap,
   refreshSDKPayloadCache,
 } from "../services/features";
 import { upgradeFeatureInterface } from "../util/migrations";
@@ -144,14 +142,12 @@ async function logFeatureUpdatedEvent(
   previous: FeatureInterface,
   current: FeatureInterface
 ): Promise<string> {
-  const savedGroupMap = await getSavedGroupMap(organization);
-
   const payload: FeatureUpdatedNotificationEvent = {
     object: "feature",
     event: "feature.updated",
     data: {
-      current: getApiFeatureObj(current, organization, savedGroupMap),
-      previous: getApiFeatureObj(previous, organization, savedGroupMap),
+      current,
+      previous,
     },
   };
 
@@ -170,13 +166,11 @@ async function logFeatureCreatedEvent(
   organization: OrganizationInterface,
   feature: FeatureInterface
 ): Promise<string> {
-  const savedGroupMap = await getSavedGroupMap(organization);
-
   const payload: FeatureCreatedNotificationEvent = {
     object: "feature",
     event: "feature.created",
     data: {
-      current: getApiFeatureObj(feature, organization, savedGroupMap),
+      current: feature,
     },
   };
 
@@ -188,19 +182,18 @@ async function logFeatureCreatedEvent(
 
 /**
  * @param organization
- * @param previousFeature
+ * @param feature
+ * @returns event.id
  */
 async function logFeatureDeletedEvent(
   organization: OrganizationInterface,
   previousFeature: FeatureInterface
 ): Promise<string> {
-  const savedGroupMap = await getSavedGroupMap(organization);
-
   const payload: FeatureDeletedNotificationEvent = {
     object: "feature",
     event: "feature.deleted",
     data: {
-      previous: getApiFeatureObj(previousFeature, organization, savedGroupMap),
+      previous: previousFeature,
     },
   };
 

--- a/packages/front-end/components/EventWebHooks/utils.tsx
+++ b/packages/front-end/components/EventWebHooks/utils.tsx
@@ -23,7 +23,6 @@ export const eventWebHookEventOptions: {
   id: NotificationEventName;
   name: NotificationEventName;
 }[] = [
-  // Features
   {
     id: "feature.updated",
     name: "feature.updated",
@@ -35,19 +34,6 @@ export const eventWebHookEventOptions: {
   {
     id: "feature.deleted",
     name: "feature.deleted",
-  },
-  // Experiments
-  {
-    id: "experiment.created",
-    name: "experiment.created",
-  },
-  {
-    id: "experiment.updated",
-    name: "experiment.updated",
-  },
-  {
-    id: "experiment.deleted",
-    name: "experiment.deleted",
   },
 ];
 


### PR DESCRIPTION
This reverts commit b263ed6973f129c167c9022fc90fe2f65a6c1e50.

The changes of logging the ApiFeature instead of FeatureInterface are crashing because the conditions contain keys that we cannot store that start with `$`.