### PR TITLE
add archiving to metrics page, alter UIs

### DIFF
--- a/packages/front-end/pages/metric/[mid].tsx
+++ b/packages/front-end/pages/metric/[mid].tsx
@@ -2,7 +2,12 @@ import { useRouter } from "next/router";
 import React, { FC, useState, useEffect, Fragment } from "react";
 import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
 import Link from "next/link";
-import { FaAngleLeft, FaChevronRight, FaQuestionCircle } from "react-icons/fa";
+import {
+  FaAngleLeft,
+  FaArchive,
+  FaChevronRight,
+  FaQuestionCircle,
+} from "react-icons/fa";
 import { MetricInterface } from "back-end/types/metric";
 import { useForm } from "react-hook-form";
 import { BsGear } from "react-icons/bs";
@@ -349,7 +354,7 @@ const MetricPage: FC = () => {
           <div className="col-auto">
             <MoreMenu>
               <DeleteButton
-                className="dropdown-item"
+                className="btn dropdown-item py-2"
                 text="Delete"
                 title="Delete this metric"
                 getConfirmationContent={getMetricUsage(metric)}
@@ -360,11 +365,11 @@ const MetricPage: FC = () => {
                   mutateDefinitions({});
                   router.push("/metrics");
                 }}
-                useIcon={false}
+                useIcon={true}
                 displayName={"Metric '" + metric.name + "'"}
               />
               <Button
-                className="dropdown-item"
+                className="btn dropdown-item py-2"
                 color=""
                 onClick={async () => {
                   const newStatus =
@@ -379,6 +384,7 @@ const MetricPage: FC = () => {
                   mutate();
                 }}
               >
+                <FaArchive />{" "}
                 {metric.status === "archived" ? "Unarchive" : "Archive"}
               </Button>
             </MoreMenu>

--- a/packages/front-end/pages/metrics.tsx
+++ b/packages/front-end/pages/metrics.tsx
@@ -49,7 +49,9 @@ const MetricsPage = (): React.ReactElement => {
   const tagsFilter = useTagsFilter("metrics");
 
   const [showArchived, setShowArchived] = useState(false);
-  const [recentlyArchived, setRecentlyArchived] = useState<string[]>([]);
+  const [recentlyArchived, setRecentlyArchived] = useState<Set<string>>(
+    new Set()
+  );
 
   const metrics = useAddComputedFields(
     data?.metrics,
@@ -75,7 +77,7 @@ const MetricsPage = (): React.ReactElement => {
     (items: typeof filteredMetrics) => {
       if (!showArchived) {
         items = items.filter((m) => {
-          return m.status !== "archived" || recentlyArchived.includes(m.id);
+          return m.status !== "archived" || recentlyArchived.has(m.id);
         });
       }
       items = filterByTags(items, tagsFilter.tags);
@@ -390,10 +392,13 @@ const MetricsPage = (): React.ReactElement => {
                           }),
                         });
                         if (newStatus === "archived") {
-                          setRecentlyArchived((arr) => [...arr, metric.id]);
+                          setRecentlyArchived(
+                            (set) => new Set([...set, metric.id])
+                          );
                         } else {
-                          setRecentlyArchived((arr) =>
-                            arr.filter((id) => id !== metric.id)
+                          setRecentlyArchived(
+                            (set) =>
+                              new Set([...set].filter((id) => id !== metric.id))
                           );
                         }
                         mutateDefinitions({});

--- a/packages/front-end/pages/metrics.tsx
+++ b/packages/front-end/pages/metrics.tsx
@@ -345,7 +345,7 @@ const MetricsPage = (): React.ReactElement => {
                     innerClassName="p-2"
                     tipMinWidth="auto"
                   >
-                    <FaArchive alt={"Archived"} />
+                    <FaArchive />
                   </Tooltip>
                 )}
               </td>

--- a/packages/front-end/pages/metrics.tsx
+++ b/packages/front-end/pages/metrics.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from "react";
-import { FaPlus, FaRegCopy } from "react-icons/fa";
+import { FaArchive, FaPlus, FaRegCopy } from "react-icons/fa";
 import { MetricInterface } from "back-end/types/metric";
 import { useRouter } from "next/router";
 import Link from "next/link";
@@ -24,6 +24,8 @@ import { useUser } from "@/services/UserContext";
 import { hasFileConfig } from "@/services/env";
 import Tooltip from "@/components/Tooltip/Tooltip";
 import { checkMetricProjectPermissions } from "@/services/metrics";
+import MoreMenu from "@/components/Dropdown/MoreMenu";
+import { useAuth } from "@/services/auth";
 
 const MetricsPage = (): React.ReactElement => {
   const [modalData, setModalData] = useState<{
@@ -42,10 +44,12 @@ const MetricsPage = (): React.ReactElement => {
   const { getUserDisplay } = useUser();
 
   const permissions = usePermissions();
+  const { apiCall } = useAuth();
 
   const tagsFilter = useTagsFilter("metrics");
 
   const [showArchived, setShowArchived] = useState(false);
+  const [recentlyArchived, setRecentlyArchived] = useState<string[]>([]);
 
   const metrics = useAddComputedFields(
     data?.metrics,
@@ -70,12 +74,14 @@ const MetricsPage = (): React.ReactElement => {
   const filterResults = useCallback(
     (items: typeof filteredMetrics) => {
       if (!showArchived) {
-        items = items.filter((m) => m.status !== "archived");
+        items = items.filter((m) => {
+          return m.status !== "archived" || recentlyArchived.includes(m.id);
+        });
       }
       items = filterByTags(items, tagsFilter.tags);
       return items;
     },
-    [showArchived, tagsFilter.tags]
+    [showArchived, recentlyArchived, tagsFilter.tags]
   );
   const editMetricsPermissions: { [id: string]: boolean } = {};
   filteredMetrics.forEach((m) => {
@@ -271,8 +277,8 @@ const MetricsPage = (): React.ReactElement => {
                 Last Updated
               </SortableTH>
             )}
-            {showArchived && <th>status</th>}
-            {!hasFileConfig() && <th></th>}
+            <th></th>
+            <th></th>
           </tr>
         </thead>
         <tbody>
@@ -332,16 +338,28 @@ const MetricsPage = (): React.ReactElement => {
                   {ago(metric.dateUpdated)}
                 </td>
               )}
-              {showArchived && (
-                <td className="text-muted">
-                  {metric.status === "archived" ? "archived" : "active"}
-                </td>
-              )}
-              {!hasFileConfig() && (
-                <td>
-                  {editMetricsPermissions[metric.id] && (
+              <td className="text-muted">
+                {metric.status === "archived" && (
+                  <Tooltip
+                    body={"Archived"}
+                    innerClassName="p-2"
+                    tipMinWidth="auto"
+                  >
+                    <FaArchive alt={"Archived"} />
+                  </Tooltip>
+                )}
+              </td>
+              <td
+                style={{ cursor: "initial" }}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  e.preventDefault();
+                }}
+              >
+                <MoreMenu>
+                  {!hasFileConfig() && editMetricsPermissions[metric.id] && (
                     <button
-                      className="tr-hover btn btn-secondary btn-sm float-right"
+                      className="btn dropdown-item py-2"
                       onClick={(e) => {
                         e.stopPropagation();
                         e.preventDefault();
@@ -358,8 +376,36 @@ const MetricsPage = (): React.ReactElement => {
                       <FaRegCopy /> Duplicate
                     </button>
                   )}
-                </td>
-              )}
+                  {!hasFileConfig() && editMetricsPermissions[metric.id] && (
+                    <button
+                      className="btn dropdown-item py-2"
+                      color=""
+                      onClick={async () => {
+                        const newStatus =
+                          metric.status === "archived" ? "active" : "archived";
+                        await apiCall(`/metric/${metric.id}`, {
+                          method: "PUT",
+                          body: JSON.stringify({
+                            status: newStatus,
+                          }),
+                        });
+                        if (newStatus === "archived") {
+                          setRecentlyArchived((arr) => [...arr, metric.id]);
+                        } else {
+                          setRecentlyArchived((arr) =>
+                            arr.filter((id) => id !== metric.id)
+                          );
+                        }
+                        mutateDefinitions({});
+                        mutate();
+                      }}
+                    >
+                      <FaArchive />{" "}
+                      {metric.status === "archived" ? "Unarchive" : "Archive"}
+                    </button>
+                  )}
+                </MoreMenu>
+              </td>
             </tr>
           ))}
 


### PR DESCRIPTION
### Features and Changes

Add archiving to the metrics page. Put archive/unarchive and duplicate into <MoreMenu>. Alter UI a bit to make things cleaner looking and consistent with [mid].tsx.

When archiving from the metrics listing page, items will not immediately disappear from the listing page (recently archived items temporarily override the "show archived" filter).

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

<!--
  Please describe how to test these changes.
 -->

### Screenshots

<img width="1346" alt="image" src="https://user-images.githubusercontent.com/7927873/224835105-8bed04f9-c0e5-4432-bebe-075a46260889.png">
