### PR TITLE
Allow 0 value pValue in CSV return

### DIFF
--- a/packages/front-end/components/Experiment/ResultsDownloadButton.tsx
+++ b/packages/front-end/components/Experiment/ResultsDownloadButton.tsx
@@ -84,7 +84,7 @@ export default function ResultsDownloadButton({
             totalValue: stats.value,
             perUserValue: stats.cr,
             perUserValueStdDev: stats.stats.stddev || null,
-            chanceToBeatControl: stats.chanceToWin || null,
+            chanceToBeatControl: stats.chanceToWin ?? null,
             percentChange: stats.expected || null,
             percentChangePValue: stats.pValue ?? null,
             percentChangeCILower: stats.ci?.[0] || null,

--- a/packages/front-end/components/Experiment/ResultsDownloadButton.tsx
+++ b/packages/front-end/components/Experiment/ResultsDownloadButton.tsx
@@ -86,7 +86,7 @@ export default function ResultsDownloadButton({
             perUserValueStdDev: stats.stats.stddev || null,
             chanceToBeatControl: stats.chanceToWin || null,
             percentChange: stats.expected || null,
-            percentChangePValue: stats.pValue || null,
+            percentChangePValue: stats.pValue ?? null,
             percentChangeCILower: stats.ci?.[0] || null,
             percentChangeCIUpper: stats.ci?.[1] || null,
           });


### PR DESCRIPTION
### Features and Changes

A user reported unexpectedly missing p-values from the output CSV (see thread here: https://growthbookusers.slack.com/archives/C01T6PKD9C3/p1678744805716989)

It turns out, these pValues were missing because of we use the logical or `||` rather than `??` for coalescing pvalues to their value or `null` in the output. We tend to prefer `||` because 0 is sometimes used for default results that are missing (an anti-pattern we could fix). However, for pValues, that default value is 1, so we can safely use `??` and at least return 0 in these cases, which is more accurate than an empty cell.

I'm still uncertain as to why the value is 0 in any case, but somewhere in the passing of data between gbstats, mongo, and the front-end, a very small number (e.g. 1e-60) is getting set to 0.