### PR TITLE
Add custom aggregation metrics to query tester

### DIFF
--- a/packages/back-end/test/integrations/integration-query-runner.py
+++ b/packages/back-end/test/integrations/integration-query-runner.py
@@ -303,7 +303,13 @@ def main():
 
         key = engine + "::" + test_case["sql"]
         if key in cache:
-            results.append(cache[key])
+            update_fields = ['engine', 'name']
+            results.append({
+                # prevent drawing wrong test case from cache when different
+                # configs produce the exact same SQL
+                **{k: v for k, v in cache[key].items() if k not in update_fields},
+                **{k: v for k, v in test_case.items() if k in update_fields}
+            })
         else:
             if engine not in nonlinted_engines:
                 validate(test_case)

--- a/packages/back-end/test/integrations/metrics.json
+++ b/packages/back-end/test/integrations/metrics.json
@@ -6,6 +6,13 @@
     "sql": "SELECT\nuserId as user_id,\ntimestamp as timestamp,\nqty as value\nFROM orders"
   },
   {
+    "id": "nonbinomcustom__purchased_items",
+    "type": "count",
+    "ignoreNulls": false,
+    "sql": "SELECT\nuserId as user_id,\ntimestamp as timestamp,\nqty as value\nFROM orders",
+    "aggregation": "COUNT(*)"
+  },
+  {
     "id": "nonbinom_null__purchased_value",
     "type": "count",
     "ignoreNulls": false,
@@ -37,5 +44,13 @@
     "ignoreNulls": false,
     "sql": "SELECT\nuserId as user_id,\ntimestamp as timestamp,\namount as value\nFROM orders",
     "denominator": "nonbinom__purchased_items"
+  },
+  {
+    "id": "ratio_nonbinomcustom_nonbinomcustom__purchased_value_over_purchased_items",
+    "type": "count",
+    "ignoreNulls": false,
+    "sql": "SELECT\nuserId as user_id,\ntimestamp as timestamp,\namount as value\nFROM orders",
+    "denominator": "nonbinomcustom__purchased_items",
+    "aggregation": "COUNT(*)"
   }
 ]


### PR DESCRIPTION
Simply adds aggregation metrics to query tester config to easily test #1066.

Also ensures that if two tests have the same sql they can use the cache but return the right value to the results json object (overriding the name of the config but using the shared, cached results).