### PR TITLE
Visual Editor - Experiment Model Triggers

### DIFF
--- a/packages/back-end/src/controllers/admin.ts
+++ b/packages/back-end/src/controllers/admin.ts
@@ -371,7 +371,10 @@ export async function addSampleData(
       if (!data.name) return;
 
       // Create experiment document
-      const exp = await createExperiment(data, org);
+      const exp = await createExperiment({
+        data,
+        organization: org,
+      });
 
       // Add a few experiments to evidence
       if (

--- a/packages/back-end/src/controllers/admin.ts
+++ b/packages/back-end/src/controllers/admin.ts
@@ -374,6 +374,7 @@ export async function addSampleData(
       const exp = await createExperiment({
         data,
         organization: org,
+        bypassWebhooks: true,
       });
 
       // Add a few experiments to evidence

--- a/packages/back-end/src/controllers/datasources.ts
+++ b/packages/back-end/src/controllers/datasources.ts
@@ -17,7 +17,6 @@ import {
 } from "../services/datasource";
 import { getOauth2Client } from "../integrations/GoogleAnalytics";
 import {
-  logExperimentCreated,
   createExperiment,
   getSampleExperiment,
 } from "../models/ExperimentModel";
@@ -167,8 +166,7 @@ Revenue did not reach 95% significance, but the risk is so low it doesn't seem w
       ],
     };
 
-    const createdExperiment = await createExperiment(experiment, org);
-    await logExperimentCreated(org, createdExperiment);
+    await createExperiment(experiment, org);
 
     await createManualSnapshot(
       experiment,

--- a/packages/back-end/src/controllers/datasources.ts
+++ b/packages/back-end/src/controllers/datasources.ts
@@ -169,6 +169,7 @@ Revenue did not reach 95% significance, but the risk is so low it doesn't seem w
     await createExperiment({
       data: experiment,
       organization: org,
+      bypassWebhooks: true,
     });
 
     await createManualSnapshot(

--- a/packages/back-end/src/controllers/datasources.ts
+++ b/packages/back-end/src/controllers/datasources.ts
@@ -166,7 +166,10 @@ Revenue did not reach 95% significance, but the risk is so low it doesn't seem w
       ],
     };
 
-    await createExperiment(experiment, org);
+    await createExperiment({
+      data: experiment,
+      organization: org,
+    });
 
     await createManualSnapshot(
       experiment,

--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -553,7 +553,6 @@ export async function postExperiments(
     const experiment = await createExperiment({
       data: obj,
       organization: org,
-      fireWebhooks: true,
     });
 
     await req.audit({
@@ -740,7 +739,7 @@ export async function postExperiment(
     changes.phases = phases;
   }
 
-  const updated = await updateExperimentById(org.id, experiment, changes);
+  const updated = await updateExperimentById(org, experiment, changes);
 
   await req.audit({
     event: "experiment.update",
@@ -794,7 +793,7 @@ export async function postExperimentArchive(
   changes.archived = true;
 
   try {
-    await updateExperimentById(org.id, experiment, changes);
+    await updateExperimentById(org, experiment, changes);
 
     // TODO: audit
     res.status(200).json({
@@ -847,7 +846,7 @@ export async function postExperimentUnarchive(
   changes.archived = false;
 
   try {
-    await updateExperimentById(org.id, experiment, changes);
+    await updateExperimentById(org, experiment, changes);
 
     // TODO: audit
     res.status(200).json({
@@ -912,7 +911,7 @@ export async function postExperimentStatus(
 
   changes.status = status;
 
-  const updated = await updateExperimentById(org.id, experiment, changes);
+  const updated = await updateExperimentById(org, experiment, changes);
 
   await req.audit({
     event: "experiment.status",
@@ -991,7 +990,7 @@ export async function postExperimentStop(
   changes.releasedVariationId = releasedVariationId;
 
   try {
-    const updated = await updateExperimentById(org.id, experiment, changes);
+    const updated = await updateExperimentById(org, experiment, changes);
 
     await req.audit({
       event: isEnding ? "experiment.stop" : "experiment.results",
@@ -1052,7 +1051,7 @@ export async function deleteExperimentPhase(
   if (!changes.phases.length) {
     changes.status = "draft";
   }
-  const updated = await updateExperimentById(org.id, experiment, changes);
+  const updated = await updateExperimentById(org, experiment, changes);
 
   await updateSnapshotsOnPhaseDelete(org.id, id, phaseIndex);
 
@@ -1110,7 +1109,7 @@ export async function putExperimentPhase(
     ...phase,
   };
   changes.phases = phases;
-  const updated = await updateExperimentById(org.id, experiment, changes);
+  const updated = await updateExperimentById(org, experiment, changes);
 
   await req.audit({
     event: "experiment.phase",
@@ -1183,7 +1182,7 @@ export async function postExperimentPhase(
   // TODO: validation
   try {
     changes.phases = phases;
-    const updated = await updateExperimentById(org.id, experiment, changes);
+    const updated = await updateExperimentById(org, experiment, changes);
 
     await req.audit({
       event: isStarting ? "experiment.start" : "experiment.phase",
@@ -1564,7 +1563,7 @@ export async function deleteScreenshot(
   changes.variations[variation].screenshots = changes.variations[
     variation
   ].screenshots.filter((s) => s.path !== url);
-  const updated = await updateExperimentById(org.id, experiment, changes);
+  const updated = await updateExperimentById(org, experiment, changes);
 
   await req.audit({
     event: "experiment.screenshot.delete",
@@ -1634,7 +1633,7 @@ export async function addScreenshot(
     description: description,
   });
 
-  await updateExperimentById(org.id, experiment, changes);
+  await updateExperimentById(org, experiment, changes);
 
   await req.audit({
     event: "experiment.screenshot.create",

--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -7,7 +7,6 @@ import {
   createManualSnapshot,
   createSnapshot,
   ensureWatching,
-  experimentUpdated,
   getExperimentWatchers,
   getManualSnapshotData,
   processPastExperiments,
@@ -21,6 +20,7 @@ import {
   getExperimentByTrackingKey,
   getPastExperimentsByDatasource,
   logExperimentUpdated,
+  onExperimentUpdate,
   updateExperimentById,
 } from "../models/ExperimentModel";
 import {
@@ -566,7 +566,7 @@ export async function postExperiments(
 
     await ensureWatching(userId, org.id, experiment.id, "experiments");
 
-    await experimentUpdated(experiment);
+    await onExperimentUpdate({ organization: org, newExperiment: experiment });
 
     res.status(200).json({
       status: 200,
@@ -1276,7 +1276,10 @@ export async function deleteExperiment(
     details: auditDetailsDelete(experiment),
   });
 
-  await experimentUpdated(experiment);
+  await onExperimentUpdate({
+    organization: org,
+    newExperiment: experiment,
+  });
 
   res.status(200).json({
     status: 200,

--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -550,7 +550,11 @@ export async function postExperiments(
       }
     }
 
-    const experiment = await createExperiment(obj, org);
+    const experiment = await createExperiment({
+      data: obj,
+      organization: org,
+      fireWebhooks: true,
+    });
 
     await req.audit({
       event: "experiment.create",

--- a/packages/back-end/src/jobs/proxyUpdate.ts
+++ b/packages/back-end/src/jobs/proxyUpdate.ts
@@ -30,11 +30,14 @@ export default function addProxyUpdateJob(ag: Agenda) {
     if (!connection) return;
     if (!connectionSupportsProxyUpdate(connection)) return;
 
+    // TODO This probably needs to renamed
     const defs = await getFeatureDefinitions(
       connection.organization,
       connection.environment,
       connection.project,
       connection.encryptPayload ? connection.encryptionKey : undefined
+      // TODO visual experiment filter
+      // TODO draft experiment filter
     );
 
     const payload = JSON.stringify(defs);

--- a/packages/back-end/src/models/ExperimentModel.ts
+++ b/packages/back-end/src/models/ExperimentModel.ts
@@ -912,7 +912,7 @@ const _hasVisualChanges = async (
   return visualChanges.some((vc) => !!vc.css || !!vc.domMutations.length);
 };
 
-const _fireWebhoks = async (
+const _fireWebooks = async (
   experiment: ExperimentInterface,
   previousProject: string = ""
 ) => {
@@ -945,7 +945,7 @@ const _onExperimentCreate = async ({
   await _logExperimentCreated(organization, experiment);
 
   if (fireWebhooks) {
-    _fireWebhoks(experiment);
+    _fireWebooks(experiment);
   }
 
   // if no visual changes, return early
@@ -968,7 +968,7 @@ const _onExperimentUpdate = async ({
   bypassWebhooks?: boolean;
 }) => {
   if (!bypassWebhooks) {
-    _fireWebhoks(newExperiment, oldExperiment?.project);
+    _fireWebooks(newExperiment, oldExperiment?.project);
   }
 
   await _logExperimentUpdated({
@@ -999,7 +999,7 @@ const _onExperimentDelete = async (
   experiment: ExperimentInterface
 ) => {
   // fire webhooks
-  _fireWebhoks(experiment);
+  _fireWebooks(experiment);
 
   await _logExperimentDeleted(organization, experiment);
 

--- a/packages/back-end/src/models/ExperimentModel.ts
+++ b/packages/back-end/src/models/ExperimentModel.ts
@@ -27,7 +27,10 @@ import { getOrganizationById } from "../services/organizations";
 import { IdeaDocument } from "./IdeasModel";
 import { addTags } from "./TagModel";
 import { createEvent } from "./EventModel";
-import { findVisualChangesetsByExperiment } from "./VisualChangesetModel";
+import {
+  findVisualChangesets,
+  findVisualChangesetsByExperiment,
+} from "./VisualChangesetModel";
 
 type FindOrganizationOptions = {
   experimentId: string;
@@ -828,14 +831,13 @@ export const getAllVisualExperiments = async (
 
   if (!visualChangesets.length) return [];
 
-  const visualChangesByExperimentId = visualChangesets.reduce(
-    (acc: Record<string, Array<VisualChange>>, c) => {
-      if (!acc[c.experiment]) acc[c.experiment] = [];
-      acc[c.experiment] = acc[c.experiment].concat(c.visualChanges);
-      return acc;
-    },
-    {}
-  );
+  const visualChangesByExperimentId = visualChangesets.reduce<
+    Record<string, Array<VisualChange>>
+  >((acc, c) => {
+    if (!acc[c.experiment]) acc[c.experiment] = [];
+    acc[c.experiment] = acc[c.experiment].concat(c.visualChanges);
+    return acc;
+  }, {});
 
   const experiments = (
     await findExperiments({

--- a/packages/back-end/src/models/ExperimentModel.ts
+++ b/packages/back-end/src/models/ExperimentModel.ts
@@ -834,6 +834,13 @@ const _isValidVisualExperiment = (
 export const getAllVisualExperiments = async (
   organization: string
 ): Promise<Array<VisualExperiment>> => {
+  // TODO encryption
+  // if (!encryptionKey) {
+  //   return {
+  //     features,
+  //     dateUpdated,
+  //   };
+  // }
   const visualChangesets = await findVisualChangesets(organization);
 
   if (!visualChangesets.length) return [];
@@ -944,9 +951,10 @@ const _onExperimentCreate = async ({
 }) => {
   await _logExperimentCreated(organization, experiment);
 
-  if (fireWebhooks) {
-    _fireWebooks(experiment);
-  }
+  if (!fireWebhooks) return;
+
+  // legacy
+  _fireWebooks(experiment);
 
   // if no visual changes, return early
   if (!(await _hasVisualChanges(organization, experiment))) return;
@@ -967,15 +975,16 @@ const _onExperimentUpdate = async ({
   newExperiment: ExperimentInterface;
   bypassWebhooks?: boolean;
 }) => {
-  if (!bypassWebhooks) {
-    _fireWebooks(newExperiment, oldExperiment?.project);
-  }
-
   await _logExperimentUpdated({
     organization,
     current: newExperiment,
     previous: oldExperiment,
   });
+
+  if (bypassWebhooks) return;
+
+  // legacy
+  _fireWebooks(newExperiment, oldExperiment?.project);
 
   // if no delta in visual changes, return early
   const oldChanges = oldExperiment

--- a/packages/back-end/src/models/VisualChangesetModel.ts
+++ b/packages/back-end/src/models/VisualChangesetModel.ts
@@ -125,3 +125,8 @@ export async function findVisualChangesets(
     })
   ).map(toInterface);
 }
+
+// TODO
+// const onVisualChangeCreate = () => {};
+// const onVisualChangeUpdate = () => {};
+// const onVisualChangeDelete = () => {};

--- a/packages/back-end/src/routers/segment/segment.controller.ts
+++ b/packages/back-end/src/routers/segment/segment.controller.ts
@@ -1,6 +1,5 @@
 import type { Response } from "express";
 import uniqid from "uniqid";
-import cloneDeep from "lodash/cloneDeep";
 import { FilterQuery } from "mongoose";
 import { AuthRequest } from "../../types/AuthRequest";
 import { ApiErrorResponse } from "../../../types/api";
@@ -22,7 +21,6 @@ import {
 import {
   deleteExperimentSegment,
   getExperimentsUsingSegment,
-  logExperimentUpdated,
 } from "../../models/ExperimentModel";
 import { MetricInterface } from "../../../types/metric";
 import { SegmentInterface } from "../../../types/segment";
@@ -292,21 +290,7 @@ export const deleteSegment = async (
     );
   }
 
-  const exps = await getExperimentsUsingSegment(id, org.id);
-  if (exps.length > 0) {
-    await deleteExperimentSegment(org.id, id);
-
-    exps.forEach((previous) => {
-      const current = cloneDeep(previous);
-      current.segment = "";
-
-      logExperimentUpdated({
-        organization: org,
-        previous,
-        current,
-      });
-    });
-  }
+  await deleteExperimentSegment(org, id);
 
   res.status(200).json({
     status: 200,

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -427,7 +427,7 @@ export async function createSnapshot(
     determineNextDate(organization.settings?.updateSchedule || null) ||
     undefined;
 
-  await updateExperimentById(organization.id, experiment, {
+  await updateExperimentById(organization, experiment, {
     lastSnapshotAttempt: new Date(),
     nextSnapshotAttempt: nextUpdate,
     autoSnapshots: nextUpdate !== null,

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -29,8 +29,6 @@ import {
 import { SegmentInterface } from "../../types/segment";
 import { ExperimentInterface } from "../../types/experiment";
 import { PastExperiment } from "../../types/past-experiments";
-import { queueWebhook } from "../jobs/webhooks";
-import { queueCDNInvalidate } from "../jobs/cacheInvalidate";
 import { promiseAllChunks } from "../util/promise";
 import { findDimensionById } from "../models/DimensionModel";
 import { getValidDate } from "../util/dates";
@@ -46,7 +44,6 @@ import {
 } from "../../types/organization";
 import { StatsEngine } from "../../types/stats";
 import { logger } from "../util/logger";
-import { getSDKPayloadKeys } from "../util/features";
 import { DataSourceInterface } from "../../types/datasource";
 import {
   ApiExperiment,
@@ -583,27 +580,6 @@ export async function processPastExperiments(
   return Array.from(experimentMap.values()).filter(
     (e) => e.numVariations > 1 && e.numVariations < 10
   );
-}
-
-export async function experimentUpdated(
-  experiment: ExperimentInterface,
-  previousProject: string = ""
-) {
-  const payloadKeys = getSDKPayloadKeys(
-    new Set(["dev", "production"]),
-    new Set(["", previousProject || "", experiment.project || ""])
-  );
-
-  // fire the webhook:
-  await queueWebhook(experiment.organization, payloadKeys, false);
-
-  // invalidate the CDN
-  await queueCDNInvalidate(experiment.organization, (key) => {
-    // Which url to invalidate depends on the type of experiment
-    return experiment.implementation === "visual"
-      ? `/js/${key}.js`
-      : `/config/${key}`;
-  });
 }
 
 function getExperimentMetric(

--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -143,6 +143,7 @@ export async function getSavedGroupMap(
   return groupMap;
 }
 
+// TODO consider renaming this
 export async function refreshSDKPayloadCache(
   organization: OrganizationInterface,
   payloadKeys: SDKPayloadKey[],
@@ -216,6 +217,7 @@ async function getFeatureDefinitionsResponse(
   dateUpdated: Date | null,
   encryptionKey?: string
 ) {
+  // TODO replicate in visual changeset flow
   if (!encryptionKey) {
     return {
       features,


### PR DESCRIPTION
This PR adds three hooks for use with our Experiment model:
- `onExperimentCreated`
- `onExperimentUpdated`
- `onExperimentDeleted`

Two things refactored with these changes:
- Existing log events
  - Now all log events are contained within each hook (and each hook is called for all Experiment CRUD operations)
- `experimentUpdated` legacy hook
  - This hook was only  called _sometimes_ when we update experiments. It effectively fired webhooks and refreshed the CDN cache. We preserve this behavior while making sure we call the new hook (`onExperimentUpdated`) _every time_ an experiment is updated

## TODO
- Triggers 
    - Clean up ExperimentModel
        - New functions `onExperimentUpdated`, `onExperimentCreated`, and `onExperimentDeleted`
            - [x] These should get the list of affected SDK payload keys for the event
            - [x] If the experiment has any visual changes AND important fields are updated (i.e. things that will affect the SDK payload contents), call `refreshSDKPayloadCache`
            - [x] Call the `logExperimentUpdated` / `logExperimentCreated` / `logExperimentDeleted` methods
        - [x] Remove the old `experimentUpdated` function (replaced by `onExperimentUpdated`)
    -  ~Add triggers to the visual changeset model~ Will be done in separate PR