### PR TITLE
Better word wrapping in code blocks

### DIFF
--- a/packages/front-end/components/SyntaxHighlighting/Code.tsx
+++ b/packages/front-end/components/SyntaxHighlighting/Code.tsx
@@ -80,6 +80,8 @@ export default function Code({
   style['code[class*="language-"]'].fontSize = "0.85rem";
   style['code[class*="language-"]'].lineHeight = 1.5;
   style['code[class*="language-"]'].fontWeight = 600;
+  style['code[class*="language-"]'].whiteSpace = "pre-wrap";
+  style['code[class*="language-"]'].wordBreak = "normal";
 
   const codeBackgrounds = {
     dark: "#212529",
@@ -157,6 +159,8 @@ export default function Code({
         <Prism
           language={language}
           style={style}
+          wrapLines
+          wrapLongLines
           className={clsx("rounded-bottom", className)}
           showLineNumbers={true}
         >


### PR DESCRIPTION
### Features and Changes

These changes prevent horizontal scrolling from occurring by using `pre-wrap` and normal word break behaviour.


### Testing

- Edit some features, especially ones with targeting conditions
- Visit http://localhost:3000/events


### Screenshots

Before, causing horizontal scrolling for large strings (e.g. serialized feature definitions):

<details>
<summary><b>Before</b></summary>

<img width="1018" alt="Screen Shot 2023-03-20 at 2 54 59 PM" src="https://user-images.githubusercontent.com/113377031/226474574-f7cc421f-9011-4daa-af6b-1b042b2231cc.png">

</details>


### After

Normal word wrapping for large strings.

<img width="1018" alt="Screen Shot 2023-03-20 at 2 55 08 PM" src="https://user-images.githubusercontent.com/113377031/226474688-2dfd1176-b06a-4cb6-89b1-f9520e408821.png">



