### PR TITLE
Visual editor - VisualChangeset model hooks

### DIFF
--- a/packages/back-end/src/api/visual-changesets/putVisualChangeset.ts
+++ b/packages/back-end/src/api/visual-changesets/putVisualChangeset.ts
@@ -9,7 +9,7 @@ export const putVisualChangeset = createApiRequestHandler(
   async (req): Promise<PutVisualChangesetResponse> => {
     const res = await updateVisualChangeset({
       changesetId: req.params.id,
-      organization: req.organization.id,
+      organization: req.organization,
       updates: req.body,
     });
 

--- a/packages/back-end/src/app.ts
+++ b/packages/back-end/src/app.ts
@@ -422,6 +422,10 @@ app.post(
 
 // Visual Changesets
 app.put("/visual-changesets/:id", experimentsController.putVisualChangeset);
+app.delete(
+  "/visual-changesets/:id",
+  experimentsController.deleteVisualChangeset
+);
 
 // Reports
 app.get("/report/:id", reportsController.getReport);

--- a/packages/back-end/src/models/ExperimentModel.ts
+++ b/packages/back-end/src/models/ExperimentModel.ts
@@ -878,7 +878,7 @@ export const getAllVisualExperiments = async (
   return visualExperiments.filter(_isValidVisualExperiment);
 };
 
-const _getPayloadKeys = (
+export const getPayloadKeys = (
   organization: OrganizationInterface,
   experiment: ExperimentInterface
 ): SDKPayloadKey[] => {
@@ -929,7 +929,7 @@ const _onExperimentCreate = async ({
   // if no visual changes, return early
   if (!(await _hasVisualChanges(organization, experiment))) return;
 
-  const payloadKeys = _getPayloadKeys(organization, experiment);
+  const payloadKeys = getPayloadKeys(organization, experiment);
 
   refreshSDKPayloadCache(organization, payloadKeys);
 };
@@ -962,9 +962,9 @@ const _onExperimentUpdate = async ({
   if (isEqual(oldChanges, newChanges)) return;
 
   const oldPayloadKeys = oldExperiment
-    ? _getPayloadKeys(organization, oldExperiment)
+    ? getPayloadKeys(organization, oldExperiment)
     : [];
-  const newPayloadKeys = _getPayloadKeys(organization, newExperiment);
+  const newPayloadKeys = getPayloadKeys(organization, newExperiment);
   const payloadKeys = uniqWith([...oldPayloadKeys, ...newPayloadKeys], isEqual);
 
   refreshSDKPayloadCache(organization, payloadKeys);
@@ -979,7 +979,7 @@ const _onExperimentDelete = async (
   // if no visual changes, return early
   if (!(await _hasVisualChanges(organization, experiment))) return;
 
-  const payloadKeys = _getPayloadKeys(organization, experiment);
+  const payloadKeys = getPayloadKeys(organization, experiment);
 
   refreshSDKPayloadCache(organization, payloadKeys);
 };

--- a/packages/back-end/src/models/VisualChangesetModel.ts
+++ b/packages/back-end/src/models/VisualChangesetModel.ts
@@ -1,13 +1,17 @@
+import { isEqual, keyBy } from "lodash";
 import omit from "lodash/omit";
 import mongoose from "mongoose";
 import uniqid from "uniqid";
-import { ExperimentInterface } from "../../types/experiment";
+import { ExperimentInterface, Variation } from "../../types/experiment";
 import { ApiVisualChangeset } from "../../types/openapi";
+import { OrganizationInterface } from "../../types/organization";
 import {
   VisualChange,
   VisualChangesetInterface,
   VisualChangesetURLPattern,
 } from "../../types/visual-changeset";
+import { refreshSDKPayloadCache } from "../services/features";
+import { getExperimentById, getPayloadKeys } from "./ExperimentModel";
 
 /**
  * VisualChangeset is a collection of visual changes that are grouped together
@@ -145,11 +149,6 @@ export async function findVisualChangesets(
   ).map(toInterface);
 }
 
-// TODO
-// const onVisualChangeCreate = () => {};
-// const onVisualChangeUpdate = () => {};
-// const onVisualChangeDelete = () => {};
-
 export async function createVisualChange(
   id: string,
   organization: string,
@@ -190,10 +189,10 @@ export async function updateVisualChange({
   organization: string;
   payload: Partial<VisualChange>;
 }): Promise<{ nModified: number }> {
-  const visualChangeset = await VisualChangesetModel.findOne({
-    id: changesetId,
-    organization,
-  });
+  const visualChangeset = await findVisualChangesetById(
+    changesetId,
+    organization
+  );
 
   if (!visualChangeset) {
     throw new Error("Visual Changeset not found");
@@ -222,7 +221,14 @@ export async function updateVisualChange({
   return { nModified: res.nModified };
 }
 
-// TODO On creating a variation, we need to create a visual change for each
+const _genNewVisualChange = (variation: Variation): VisualChange => ({
+  id: uniqid("vc_"),
+  variation: variation.id,
+  description: "",
+  css: "",
+  domMutations: [],
+});
+
 export const createVisualChangeset = async ({
   experiment,
   organization,
@@ -230,26 +236,35 @@ export const createVisualChangeset = async ({
   editorUrl,
 }: {
   experiment: ExperimentInterface;
-  organization: string;
+  organization: OrganizationInterface;
   urlPatterns: VisualChangesetURLPattern[];
   editorUrl: VisualChangesetInterface["editorUrl"];
 }): Promise<VisualChangesetInterface> => {
-  const visualChangeset = await VisualChangesetModel.create({
-    id: uniqid("vcs_"),
-    experiment: experiment.id,
+  const visualChangeset = toInterface(
+    await VisualChangesetModel.create({
+      id: uniqid("vcs_"),
+      experiment: experiment.id,
+      organization: organization.id,
+      urlPatterns,
+      editorUrl,
+      visualChanges: experiment.variations.map(_genNewVisualChange),
+    })
+  );
+  await _onVisualChangesetCreate({
     organization,
-    urlPatterns,
-    editorUrl,
-    visualChanges: experiment.variations.map((variation) => ({
-      id: uniqid("vc_"),
-      variation: variation.id,
-      description: "",
-      css: "",
-      domMutations: [],
-    })),
+    visualChangeset,
+    experiment,
   });
-  return toInterface(visualChangeset);
+  return visualChangeset;
 };
+
+// type guard
+const _isUpdatingVisualChanges = (
+  updates: Partial<VisualChangesetInterface>
+): updates is {
+  visualChanges: VisualChange[];
+} & Partial<VisualChangesetInterface> =>
+  updates.visualChanges !== undefined && updates.visualChanges.length > 0;
 
 export const updateVisualChangeset = async ({
   changesetId,
@@ -257,28 +272,177 @@ export const updateVisualChangeset = async ({
   updates,
 }: {
   changesetId: string;
-  organization: string;
+  organization: OrganizationInterface;
   updates: Partial<VisualChangesetInterface>;
 }) => {
+  const visualChangeset = await findVisualChangesetById(
+    changesetId,
+    organization.id
+  );
+
+  if (!visualChangeset) {
+    throw new Error("Visual Changeset not found");
+  }
+
+  const isUpdatingVisualChanges = _isUpdatingVisualChanges(updates);
+
   // ensure new visual changes have ids assigned
-  const visualChanges =
-    updates.visualChanges?.map((vc) => ({
-      ...vc,
-      id: vc.id || uniqid("vc_"),
-    })) ?? [];
+  const visualChanges = isUpdatingVisualChanges
+    ? updates.visualChanges.map((vc) => ({
+        ...vc,
+        id: vc.id || uniqid("vc_"),
+      }))
+    : [];
 
   const res = await VisualChangesetModel.updateOne(
     {
       id: changesetId,
-      organization,
+      organization: organization.id,
     },
     {
       $set: {
         ...updates,
-        visualChanges,
+        ...(isUpdatingVisualChanges ? { visualChanges } : {}),
       },
     }
   );
 
+  await _onVisualChangesetUpdate({
+    oldVisualChangeset: visualChangeset,
+    newVisualChangeset: {
+      ...visualChangeset,
+      ...updates,
+      ...(isUpdatingVisualChanges ? { visualChanges } : {}),
+    },
+    organization,
+  });
+
   return { nModified: res.nModified, visualChanges };
+};
+
+const _hasVisualChanges = ({ visualChanges }: VisualChangesetInterface) =>
+  visualChanges.some((vc) => !!vc.css || !!vc.domMutations.length);
+
+const _onVisualChangesetCreate = async ({
+  organization,
+  visualChangeset,
+  experiment,
+}: {
+  organization: OrganizationInterface;
+  visualChangeset: VisualChangesetInterface;
+  experiment: ExperimentInterface;
+}) => {
+  if (!_hasVisualChanges(visualChangeset)) return;
+
+  const payloadKeys = getPayloadKeys(organization, experiment);
+
+  await refreshSDKPayloadCache(organization, payloadKeys);
+};
+
+const _onVisualChangesetUpdate = async ({
+  organization,
+  oldVisualChangeset,
+  newVisualChangeset,
+}: {
+  organization: OrganizationInterface;
+  oldVisualChangeset: VisualChangesetInterface;
+  newVisualChangeset: VisualChangesetInterface;
+}) => {
+  // if no effective delta between old and new, return early
+  const oldVisualChanges = oldVisualChangeset.visualChanges.map(
+    ({ css, domMutations }) => ({ css, domMutations })
+  );
+  const newVisualChanges = newVisualChangeset.visualChanges.map(
+    ({ css, domMutations }) => ({ css, domMutations })
+  );
+
+  if (isEqual(oldVisualChanges, newVisualChanges)) return;
+
+  const experiment = await getExperimentById(
+    organization.id,
+    newVisualChangeset.experiment
+  );
+
+  if (!experiment) return;
+
+  const payloadKeys = getPayloadKeys(organization, experiment);
+
+  await refreshSDKPayloadCache(organization, payloadKeys);
+};
+
+const _onVisualChangesetDelete = async ({
+  organization,
+  visualChangeset,
+}: {
+  organization: OrganizationInterface;
+  visualChangeset: VisualChangesetInterface;
+}) => {
+  // if there were no visual changes before deleting, return early
+  if (!_hasVisualChanges(visualChangeset)) return;
+
+  // get payload keys
+  const experiment = await getExperimentById(
+    organization.id,
+    visualChangeset.experiment
+  );
+
+  if (!experiment) return;
+
+  const payloadKeys = getPayloadKeys(organization, experiment);
+
+  await refreshSDKPayloadCache(organization, payloadKeys);
+};
+
+// when an experiment adds/removes variations, we need to update the analogous
+// visual changes to be in sync
+export const syncVisualChangesWithVariations = async ({
+  experiment,
+  organization,
+  visualChangeset,
+}: {
+  experiment: ExperimentInterface;
+  organization: OrganizationInterface;
+  visualChangeset: VisualChangesetInterface;
+}) => {
+  const { variations } = experiment;
+  const { visualChanges } = visualChangeset;
+  const visualChangesByVariationId = keyBy(visualChanges, "variation");
+  const newVisualChanges = variations.map((variation) => {
+    const visualChange = visualChangesByVariationId[variation.id];
+    return visualChange ? visualChange : _genNewVisualChange(variation);
+  });
+
+  await updateVisualChangeset({
+    organization,
+    changesetId: visualChangeset.id,
+    updates: { visualChanges: newVisualChanges },
+  });
+};
+
+// TODO implement in UI
+export const deleteVisualChangesetById = async ({
+  changesetId,
+  organization,
+}: {
+  changesetId: string;
+  organization: OrganizationInterface;
+}) => {
+  const visualChangeset = await findVisualChangesetById(
+    changesetId,
+    organization.id
+  );
+
+  if (!visualChangeset) {
+    throw new Error("Visual Changeset not found");
+  }
+
+  await VisualChangesetModel.deleteOne({
+    id: changesetId,
+    organization: organization.id,
+  });
+
+  await _onVisualChangesetDelete({
+    organization,
+    visualChangeset,
+  });
 };

--- a/packages/back-end/src/models/VisualChangesetModel.ts
+++ b/packages/back-end/src/models/VisualChangesetModel.ts
@@ -221,7 +221,7 @@ export async function updateVisualChange({
   return { nModified: res.nModified };
 }
 
-const _genNewVisualChange = (variation: Variation): VisualChange => ({
+const genNewVisualChange = (variation: Variation): VisualChange => ({
   id: uniqid("vc_"),
   variation: variation.id,
   description: "",
@@ -247,10 +247,10 @@ export const createVisualChangeset = async ({
       organization: organization.id,
       urlPatterns,
       editorUrl,
-      visualChanges: experiment.variations.map(_genNewVisualChange),
+      visualChanges: experiment.variations.map(genNewVisualChange),
     })
   );
-  await _onVisualChangesetCreate({
+  await onVisualChangesetCreate({
     organization,
     visualChangeset,
     experiment,
@@ -307,7 +307,7 @@ export const updateVisualChangeset = async ({
     }
   );
 
-  await _onVisualChangesetUpdate({
+  await onVisualChangesetUpdate({
     oldVisualChangeset: visualChangeset,
     newVisualChangeset: {
       ...visualChangeset,
@@ -320,10 +320,10 @@ export const updateVisualChangeset = async ({
   return { nModified: res.nModified, visualChanges };
 };
 
-const _hasVisualChanges = ({ visualChanges }: VisualChangesetInterface) =>
+const hasVisualChanges = ({ visualChanges }: VisualChangesetInterface) =>
   visualChanges.some((vc) => !!vc.css || !!vc.domMutations.length);
 
-const _onVisualChangesetCreate = async ({
+const onVisualChangesetCreate = async ({
   organization,
   visualChangeset,
   experiment,
@@ -332,14 +332,14 @@ const _onVisualChangesetCreate = async ({
   visualChangeset: VisualChangesetInterface;
   experiment: ExperimentInterface;
 }) => {
-  if (!_hasVisualChanges(visualChangeset)) return;
+  if (!hasVisualChanges(visualChangeset)) return;
 
   const payloadKeys = getPayloadKeys(organization, experiment);
 
   await refreshSDKPayloadCache(organization, payloadKeys);
 };
 
-const _onVisualChangesetUpdate = async ({
+const onVisualChangesetUpdate = async ({
   organization,
   oldVisualChangeset,
   newVisualChangeset,
@@ -370,7 +370,7 @@ const _onVisualChangesetUpdate = async ({
   await refreshSDKPayloadCache(organization, payloadKeys);
 };
 
-const _onVisualChangesetDelete = async ({
+const onVisualChangesetDelete = async ({
   organization,
   visualChangeset,
 }: {
@@ -378,7 +378,7 @@ const _onVisualChangesetDelete = async ({
   visualChangeset: VisualChangesetInterface;
 }) => {
   // if there were no visual changes before deleting, return early
-  if (!_hasVisualChanges(visualChangeset)) return;
+  if (!hasVisualChanges(visualChangeset)) return;
 
   // get payload keys
   const experiment = await getExperimentById(
@@ -409,7 +409,7 @@ export const syncVisualChangesWithVariations = async ({
   const visualChangesByVariationId = keyBy(visualChanges, "variation");
   const newVisualChanges = variations.map((variation) => {
     const visualChange = visualChangesByVariationId[variation.id];
-    return visualChange ? visualChange : _genNewVisualChange(variation);
+    return visualChange ? visualChange : genNewVisualChange(variation);
   });
 
   await updateVisualChangeset({
@@ -441,7 +441,7 @@ export const deleteVisualChangesetById = async ({
     organization: organization.id,
   });
 
-  await _onVisualChangesetDelete({
+  await onVisualChangesetDelete({
     organization,
     visualChangeset,
   });

--- a/packages/front-end/components/Experiment/VariationsTable.tsx
+++ b/packages/front-end/components/Experiment/VariationsTable.tsx
@@ -6,7 +6,7 @@ import {
   VisualChangesetInterface,
   VisualChangesetURLPattern,
 } from "back-end/types/visual-changeset";
-import { FC, useState } from "react";
+import { FC, useEffect, useState } from "react";
 import { useAuth } from "@/services/auth";
 import Carousel from "../Carousel";
 import ScreenshotUpload from "../EditExperiment/ScreenshotUpload";
@@ -78,6 +78,10 @@ const VariationsTable: FC<Props> = ({
   const [isEditingVisualChangeset, setIsEditingVisualChangeset] = useState(
     false
   );
+
+  useEffect(() => {
+    setVisualChangesets(_visualChangesets ?? []);
+  }, [_visualChangesets]);
 
   const createVisualChangeset = async ({
     editorUrl,


### PR DESCRIPTION
Changes
- Add hooks to VisualChangesetModel
  - `onVisualChangesetCreate`, `onVisualChangesetUpdate`, `onVisualChangesetDelete`
- Add sync step to `postExperiment` to ensure parity between variations <> visual changes 
  - Fix bug in frontend to update `VariationsTable` when experiment.visualChangesets is updated
- Add delete visual changeset endpoint

Related
- [Visual Editor TODO Notion doc](https://www.notion.so/Visual-editor-todo-3-20-dfa0dd2a605346c8b20475a1ee53833a#36f3030212d44d5096552a50325d768a)