### PR TITLE
Manage null as a conditional

### DIFF
--- a/packages/sdk-js/src/mongrule.ts
+++ b/packages/sdk-js/src/mongrule.ts
@@ -72,7 +72,7 @@ function evalConditionValue(condition: ConditionValue, value: any) {
     return !!value === condition;
   }
 
-  if(condition === null) {
+  if (condition === null) {
     return value === null || value === undefined;
   }
 

--- a/packages/sdk-js/src/mongrule.ts
+++ b/packages/sdk-js/src/mongrule.ts
@@ -71,6 +71,11 @@ function evalConditionValue(condition: ConditionValue, value: any) {
   if (typeof condition === "boolean") {
     return !!value === condition;
   }
+
+  if(condition === null) {
+    return value === null || value === undefined;
+  }
+
   if (Array.isArray(condition) || !isOperatorObject(condition)) {
     return JSON.stringify(value) === JSON.stringify(condition);
   }

--- a/packages/sdk-js/src/types/mongrule.ts
+++ b/packages/sdk-js/src/types/mongrule.ts
@@ -60,7 +60,8 @@ export type ConditionValue =
   // eslint-disable-next-line
   | Array<any>
   // eslint-disable-next-line
-  | Record<string, any>;
+  | Record<string, any>
+  | null;
 
 export type OperatorCondition = {
   [key: string]: ConditionValue;

--- a/packages/sdk-js/test/mongrule.test.ts
+++ b/packages/sdk-js/test/mongrule.test.ts
@@ -1,0 +1,73 @@
+import { evalCondition } from "../src/mongrule";
+
+describe("Mongrule", () => {
+  describe("Null", () => {
+    it("Returns true when the value is null or not present", () => {
+      expect(
+        evalCondition(
+          { userId: null },
+          {
+            userId: null,
+          }
+        )
+      ).toBe(true);
+
+      expect(
+        evalCondition(
+          {},
+          {
+            userId: null,
+          }
+        )
+      ).toBe(true);
+    });
+
+    it("Returns true when the value is undefined", () => {
+      expect(
+        evalCondition(
+          { userId: undefined },
+          {
+            userId: null,
+          }
+        )
+      ).toBe(true);
+    });
+
+    it("Returns false when the value is present", () => {
+      expect(
+        evalCondition(
+          {
+            userId: "123",
+          },
+          {
+            userId: null,
+          }
+        )
+      ).toBe(false);
+    });
+
+    it("Returns false when the value is present but falsy", () => {
+      expect(
+        evalCondition(
+          {
+            userId: 0,
+          },
+          {
+            userId: null,
+          }
+        )
+      ).toBe(false);
+
+      expect(
+        evalCondition(
+          {
+            userId: "",
+          },
+          {
+            userId: null,
+          }
+        )
+      ).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
### Features and Changes

This PR manages a condition with null as value.

Based on [the MongoDB Documentation](https://www.mongodb.com/docs/manual/tutorial/query-for-null-fields/#equality-filter), using null will return values that are null or do not exist (in the MongoDB shell and node.js sdk)

This is mainly because despite it being a valid MongoDB query, it will currently throw an error when trying to call `isOperatorObject` with null as the object.

### Testing

This PR also includes a new test file for mongrule.

---
Note: Undefined, despite being falsy, is considered by this rule. I would like your opinion on if this should be the case or not.