### PR TITLE
Fix SQL ClickHouse to not rely on non-equality join conditions

### DIFF
--- a/packages/back-end/src/integrations/ClickHouse.ts
+++ b/packages/back-end/src/integrations/ClickHouse.ts
@@ -1,7 +1,6 @@
 import { ClickHouse as ClickHouseClient } from "clickhouse";
 import { decryptDataSourceParams } from "../services/datasource";
 import { ClickHouseConnectionParams } from "../../types/integrations/clickhouse";
-import { MetricAggregationType } from "../types/Integration";
 import SqlIntegration from "./SqlIntegration";
 
 export default class ClickHouse extends SqlIntegration {
@@ -81,25 +80,6 @@ export default class ClickHouse extends SqlIntegration {
   castToString(col: string): string {
     return `toString(${col})`;
   }
-  addPrePostTimeFilter(col: string, timePeriod: MetricAggregationType): string {
-    const mcol = `m.timestamp`;
-    if (timePeriod === "pre") {
-      return `${this.ifElse(
-        `${mcol} < d.preexposure_end AND ${mcol} > d.preexposure_start`,
-        `${col}`,
-        `NULL`
-      )}`;
-    }
-    if (timePeriod === "post") {
-      return `${this.ifElse(
-        `${mcol} BETWEEN d.conversion_start AND d.conversion_end`,
-        `${col}`,
-        `NULL`
-      )}`;
-    }
-    return `${col}`;
-  }
-
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   userMetricJoin(ignoreConversionEnd: boolean): string {
     // Clickhouse does not support anything other than equality in join condition

--- a/packages/back-end/src/integrations/ClickHouse.ts
+++ b/packages/back-end/src/integrations/ClickHouse.ts
@@ -1,8 +1,8 @@
 import { ClickHouse as ClickHouseClient } from "clickhouse";
 import { decryptDataSourceParams } from "../services/datasource";
 import { ClickHouseConnectionParams } from "../../types/integrations/clickhouse";
-import SqlIntegration from "./SqlIntegration";
 import { MetricAggregationType } from "../types/Integration";
+import SqlIntegration from "./SqlIntegration";
 
 export default class ClickHouse extends SqlIntegration {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -81,13 +81,14 @@ export default class ClickHouse extends SqlIntegration {
   castToString(col: string): string {
     return `toString(${col})`;
   }
-  addPrePostTimeFilter(
-    col: string,
-    timePeriod: MetricAggregationType
-  ): string {
+  addPrePostTimeFilter(col: string, timePeriod: MetricAggregationType): string {
     const mcol = `m.timestamp`;
     if (timePeriod === "pre") {
-      return `${this.ifElse(`${mcol} < d.preexposure_end AND ${mcol} > d.preexposure_start`, `${col}`, `NULL`)}`;
+      return `${this.ifElse(
+        `${mcol} < d.preexposure_end AND ${mcol} > d.preexposure_start`,
+        `${col}`,
+        `NULL`
+      )}`;
     }
     if (timePeriod === "post") {
       return `${this.ifElse(
@@ -98,10 +99,12 @@ export default class ClickHouse extends SqlIntegration {
     }
     return `${col}`;
   }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   userMetricJoin(ignoreConversionEnd: boolean): string {
     // Clickhouse does not support anything other than equality in join condition
     // so we do not join on date and instead use the custom time filter above in
     // addPrePostTimeFilter
-    return '';
+    return "";
   }
 }

--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -745,7 +745,7 @@ export default abstract class SqlIntegration
 
     const ignoreConversionEnd =
       experiment.attributionModel === "experimentDuration";
-    const postAggregationType: MetricAggregationType = ignoreConversionEnd
+    const postAggregationType: MetricWindowType = ignoreConversionEnd
       ? "postDuration"
       : "postConversion";
     // Get rough date filter for metrics to improve performance

--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -34,7 +34,6 @@ import {
   FormatDialect,
   replaceCountStar,
 } from "../util/sql";
-import { MetricWindow } from "aws-sdk/clients/iotsitewise";
 
 export default abstract class SqlIntegration
   implements SourceIntegrationInterface {
@@ -746,7 +745,9 @@ export default abstract class SqlIntegration
 
     const ignoreConversionEnd =
       experiment.attributionModel === "experimentDuration";
-    const postAggregationType: MetricAggregationType = ignoreConversionEnd ? "postDuration" : "postConversion"
+    const postAggregationType: MetricAggregationType = ignoreConversionEnd
+      ? "postDuration"
+      : "postConversion";
     // Get rough date filter for metrics to improve performance
     const orderedMetrics = activationMetrics
       .concat(denominatorMetrics)
@@ -776,7 +777,10 @@ export default abstract class SqlIntegration
       experiment.trackingKey
     );
 
-    const aggregate = this.getAggregateMetricColumn(metric, postAggregationType);
+    const aggregate = this.getAggregateMetricColumn(
+      metric,
+      postAggregationType
+    );
 
     const dimensionCol = this.getDimensionColumn(baseIdType, dimension);
 
@@ -987,7 +991,10 @@ export default abstract class SqlIntegration
               -- Add in the aggregate denominator value for each user
               SELECT
                 d.${baseIdType},
-                ${this.getAggregateMetricColumn(denominator, postAggregationType)} as value
+                ${this.getAggregateMetricColumn(
+                  denominator,
+                  postAggregationType
+                )} as value
               FROM
                 __distinctUsers d
                 JOIN __denominator${denominatorMetrics.length - 1} m ON (

--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -971,11 +971,10 @@ export default abstract class SqlIntegration
           ${aggregate} as value
         FROM
           __distinctUsers d
-          LEFT JOIN __metric m ON (
-            m.${baseIdType} = d.${baseIdType}
-            AND m.timestamp >= d.conversion_start
-            ${ignoreConversionEnd ? "" : "AND m.timestamp <= d.conversion_end"}
-          )
+        LEFT JOIN __metric m ON (
+          m.${baseIdType} = d.${baseIdType}
+          ${this.userMetricJoin(ignoreConversionEnd)}
+        )    
         GROUP BY
           d.variation,
           d.dimension,
@@ -1308,7 +1307,7 @@ export default abstract class SqlIntegration
     return `LEAST(${cap}, ${value})`;
   }
 
-  private addPrePostTimeFilter(
+  addPrePostTimeFilter(
     col: string,
     timePeriod: MetricAggregationType
   ): string {
@@ -1324,6 +1323,12 @@ export default abstract class SqlIntegration
       )}`;
     }
     return `${col}`;
+  }
+
+  userMetricJoin(ignoreConversionEnd: boolean): string {
+    return `AND m.timestamp >= d.conversion_start
+      ${ignoreConversionEnd ? "" : "AND m.timestamp <= d.conversion_end"}
+      `;
   }
 
   private getAggregateMetricColumn(

--- a/packages/back-end/src/types/Integration.ts
+++ b/packages/back-end/src/types/Integration.ts
@@ -20,7 +20,7 @@ export class DataSourceNotSupportedError extends Error {
     this.name = "DataSourceNotSupportedError";
   }
 }
-export type MetricAggregationType = "pre" | "post" | "noWindow";
+export type MetricWindowType = "pre" | "postConversion" | "postDuration" | "noWindow";
 
 export interface ExperimentMetricStats {
   metric_type: MetricType;

--- a/packages/back-end/test/sqlintegration.test.ts
+++ b/packages/back-end/test/sqlintegration.test.ts
@@ -55,9 +55,17 @@ describe("bigquery integration", () => {
       bqIntegration["getAggregateMetricColumn"](binomialMetric, "noWindow")
     ).toEqual("MAX(1)");
     expect(
-      bqIntegration["getAggregateMetricColumn"](binomialMetric, "post")
+      bqIntegration["getAggregateMetricColumn"](binomialMetric, "postDuration")
     ).toEqual(
       "MAX((CASE WHEN m.timestamp >= d.conversion_start THEN 1 ELSE NULL END))"
+    );
+    expect(
+      bqIntegration["getAggregateMetricColumn"](
+        binomialMetric,
+        "postConversion"
+      )
+    ).toEqual(
+      "MAX((CASE WHEN m.timestamp >= d.conversion_start AND m.timestamp <= d.conversion_end THEN 1 ELSE NULL END))"
     );
     expect(
       bqIntegration["getAggregateMetricColumn"](binomialMetric, "pre")
@@ -71,9 +79,20 @@ describe("bigquery integration", () => {
       )
     ).toEqual("MAX(33)");
     expect(
-      bqIntegration["getAggregateMetricColumn"](customNumberAggMetric, "post")
+      bqIntegration["getAggregateMetricColumn"](
+        customNumberAggMetric,
+        "postDuration"
+      )
     ).toEqual(
       "MAX((CASE WHEN m.timestamp >= d.conversion_start THEN 33 ELSE NULL END))"
+    );
+    expect(
+      bqIntegration["getAggregateMetricColumn"](
+        customNumberAggMetric,
+        "postConversion"
+      )
+    ).toEqual(
+      "MAX((CASE WHEN m.timestamp >= d.conversion_start AND m.timestamp <= d.conversion_end THEN 33 ELSE NULL END))"
     );
     expect(
       bqIntegration["getAggregateMetricColumn"](customNumberAggMetric, "pre")
@@ -84,7 +103,13 @@ describe("bigquery integration", () => {
       bqIntegration["getAggregateMetricColumn"](customCountAgg, "noWindow")
     ).toEqual("COUNT(m.timestamp) / (5 + COUNT(m.timestamp))");
     expect(
-      bqIntegration["getAggregateMetricColumn"](customCountAgg, "post")
+      bqIntegration["getAggregateMetricColumn"](customCountAgg, "postDuration")
+    ).toEqual("COUNT(m.timestamp) / (5 + COUNT(m.timestamp))");
+    expect(
+      bqIntegration["getAggregateMetricColumn"](
+        customCountAgg,
+        "postConversion"
+      )
     ).toEqual("COUNT(m.timestamp) / (5 + COUNT(m.timestamp))");
     expect(
       bqIntegration["getAggregateMetricColumn"](customCountAgg, "pre")
@@ -93,9 +118,17 @@ describe("bigquery integration", () => {
       bqIntegration["getAggregateMetricColumn"](normalSqlMetric, "noWindow")
     ).toEqual("SUM(m.value)");
     expect(
-      bqIntegration["getAggregateMetricColumn"](normalSqlMetric, "post")
+      bqIntegration["getAggregateMetricColumn"](normalSqlMetric, "postDuration")
     ).toEqual(
       "SUM((CASE WHEN m.timestamp >= d.conversion_start THEN m.value ELSE NULL END))"
+    );
+    expect(
+      bqIntegration["getAggregateMetricColumn"](
+        normalSqlMetric,
+        "postConversion"
+      )
+    ).toEqual(
+      "SUM((CASE WHEN m.timestamp >= d.conversion_start AND m.timestamp <= d.conversion_end THEN m.value ELSE NULL END))"
     );
     expect(
       bqIntegration["getAggregateMetricColumn"](normalSqlMetric, "pre")


### PR DESCRIPTION
### Features and Changes

A user reported the following error:
> 500: Code: 403. DB::Exception: Unsupported JOIN ON conditions. Unexpected 'timestamp >= conversion_start': While processing timestamp >= conversion_start. (INVALID_JOIN_ON_EXPRESSION) (version 22.3.19.6 (official build))

Our SQL refactor (#1066) relies on a join that compares timestamps using greater than/less than operators.

ClickHouse does not support operators other than `=` in JOIN conditions (https://clickhouse.com/docs/en/sql-reference/statements/select/join#on-section-conditions).

This patches this by building separate logic for ClickHouse, where we do all the filtering for metric values in the CASE WHEN statement and join only on ID. Unfortunately this adds an additional statement to First Exposure CASE WHEN statements in all languages (shouldn't really hurt performance much), but it keeps the code forking to a minimum.

### Dependencies

n/a

### Testing

We don't have automated testing for clickhouse.

- [x] Ensure tested engines show no change
- [ ] Ensure clickhouse queries themselves produce the same values when run through another engine
- [ ] Manually inspect the ON clauses for all ClickHouse test queries

### Screenshots

n/a