### PR TITLE
Fixing FeaturesReady to account for when timeout is not provided

### DIFF
--- a/packages/sdk-react/src/GrowthBookReact.tsx
+++ b/packages/sdk-react/src/GrowthBookReact.tsx
@@ -131,7 +131,7 @@ export function useGrowthBook<
 
 export function FeaturesReady({
   children,
-  timeout,
+  timeout = 0,
   fallback,
 }: {
   children: React.ReactNode;
@@ -139,17 +139,22 @@ export function FeaturesReady({
   fallback?: React.ReactNode;
 }) {
   const gb = useGrowthBook();
-  const [ready, setReady] = React.useState(gb ? gb.ready : false);
-  React.useEffect(() => {
-    if (timeout && !ready) {
-      const timer = setTimeout(() => {
-        setReady(true);
-      }, timeout);
-      return () => clearTimeout(timer);
-    }
-  }, [timeout, ready]);
+  const [display, setDisplay] = React.useState(gb?.ready ?? false);
 
-  return ready ? children : fallback || null;
+  React.useEffect(() => {
+    setDisplay(gb?.ready ?? false);
+    const timer = setTimeout(() => {
+      setDisplay(true);
+    }, timeout);
+    return () => clearTimeout(timer);
+  }, [timeout, gb?.ready]);
+
+  return (
+    <>
+      {display && children}
+      {!display && fallback}
+    </>
+  );
 }
 
 export function IfFeatureEnabled({


### PR DESCRIPTION
### Features and Changes

There is an issue with `<FeaturesReady>` as if we provide no value for `timeout` prop (max time to wait for) it will never display the child components. A similar implementation is something that we use internally but would be nice to include it in the upstream repository.
