### PR TITLE
Restore <Code /> block changes and link to event instead

### DIFF
--- a/packages/front-end/components/Events/EventsPage/EventsTableRow.tsx
+++ b/packages/front-end/components/Events/EventsPage/EventsTableRow.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from "react";
+import React, { FC } from "react";
 import {
   EventInterface,
   NotificationEventName,
@@ -6,7 +6,6 @@ import {
   NotificationEventResource,
 } from "back-end/types/event";
 import { datetime } from "@/services/dates";
-import Code from "../../SyntaxHighlighting/Code";
 import { getEventText } from "./utils";
 
 type EventsTableRowProps = {
@@ -20,22 +19,8 @@ type EventsTableRowProps = {
 };
 
 export const EventsTableRow: FC<EventsTableRowProps> = ({ event }) => {
-  const [isOpen, setIsOpen] = useState(false);
-
   return (
-    <tr
-      style={{ cursor: "pointer" }}
-      className={isOpen ? "highlight" : "hover-highlight"}
-      onClick={(e) => {
-        // Don't toggle the row's open state if a button in the code block was clicked, e.g. Copy, Expand
-        const target = e.target as HTMLElement;
-        if (target && target.closest("[role='button']")) {
-          return;
-        }
-
-        setIsOpen(!isOpen);
-      }}
-    >
+    <tr>
       <td>
         <span className="py-2 d-block nowrap">
           {datetime(event.dateCreated)}
@@ -44,16 +29,9 @@ export const EventsTableRow: FC<EventsTableRowProps> = ({ event }) => {
       <td>
         <p className="py-2 mb-0">{getEventText(event)}</p>
 
-        {isOpen && (
-          <div className="mt-2">
-            <Code
-              language="json"
-              filename={event.data.event}
-              code={JSON.stringify(event.data, null, 2)}
-              expandable={true}
-            />
-          </div>
-        )}
+        <p className="my-0 py-1">
+          <a href={`/events/${event.id}`}>View Event</a>
+        </p>
       </td>
     </tr>
   );

--- a/packages/front-end/components/SyntaxHighlighting/Code.tsx
+++ b/packages/front-end/components/SyntaxHighlighting/Code.tsx
@@ -80,8 +80,6 @@ export default function Code({
   style['code[class*="language-"]'].fontSize = "0.85rem";
   style['code[class*="language-"]'].lineHeight = 1.5;
   style['code[class*="language-"]'].fontWeight = 600;
-  style['code[class*="language-"]'].whiteSpace = "pre-wrap";
-  style['code[class*="language-"]'].wordBreak = "normal";
 
   const codeBackgrounds = {
     dark: "#212529",
@@ -159,8 +157,6 @@ export default function Code({
         <Prism
           language={language}
           style={style}
-          wrapLines
-          wrapLongLines
           className={clsx("rounded-bottom", className)}
           showLineNumbers={true}
         >


### PR DESCRIPTION
### Features and Changes

Reverts the changes made to #1093 for some code blocks that should intentionally allow horizontal scrolling.

The table had a lot going on anyhow, and we weren't linking to the original event, so I decided to remove the complexity with the code block in the table and link to the event page. This is a better solution anyway because it allows people to share the direct link if they want to. 


### Testing

- View the events page
- View other code blocks

### Screenshots
<img width="1445" alt="Screen Shot 2023-03-27 at 10 29 20 AM" src="https://user-images.githubusercontent.com/113377031/228020531-ec7db7cd-4134-4fbb-8c70-5ce5bf6d6609.png">

<img width="1442" alt="Screen Shot 2023-03-27 at 10 29 31 AM" src="https://user-images.githubusercontent.com/113377031/228020549-f4fedc65-a26e-4f5b-be49-805bc0b092de.png">

