### PR TITLE
Fix bugs when organization statsEngine is undefined

### DIFF
--- a/packages/back-end/src/util/migrations.ts
+++ b/packages/back-end/src/util/migrations.ts
@@ -285,8 +285,11 @@ export function upgradeOrganizationDoc(
 ): OrganizationInterface {
   const org = cloneDeep(doc);
 
+  // Add settings from config.json
+  const configSettings = getConfigOrganizationSettings();
+  org.settings = Object.assign({}, org.settings || {}, configSettings);
+
   // Add dev/prod environments if there are none yet
-  org.settings = org.settings || {};
   if (!org.settings?.environments?.length) {
     org.settings.environments = [
       {
@@ -321,10 +324,6 @@ export function upgradeOrganizationDoc(
     };
   }
 
-  // Add settings from config.json
-  const configSettings = getConfigOrganizationSettings();
-  org.settings = Object.assign({}, org.settings || {}, configSettings);
-
   // Default attribute schema
   if (!org.settings.attributeSchema) {
     org.settings.attributeSchema = [
@@ -337,6 +336,11 @@ export function upgradeOrganizationDoc(
       { property: "browser", datatype: "string" },
       { property: "url", datatype: "string" },
     ];
+  }
+
+  // Add statsEngine setting if not defined
+  if (!org.settings.statsEngine) {
+    org.settings.statsEngine = "bayesian";
   }
 
   // Rename legacy roles

--- a/packages/back-end/test/migrations.test.ts
+++ b/packages/back-end/test/migrations.test.ts
@@ -8,6 +8,7 @@ import {
   upgradeFeatureInterface,
   upgradeFeatureRule,
   upgradeMetricDoc,
+  upgradeOrganizationDoc,
 } from "../src/util/migrations";
 import { DataSourceInterface, DataSourceSettings } from "../types/datasource";
 import { encryptParams } from "../src/services/datasource";
@@ -19,6 +20,7 @@ import {
   FeatureRule,
   LegacyFeatureInterface,
 } from "../types/feature";
+import { OrganizationInterface } from "../types/organization";
 
 describe("backend", () => {
   it("updates old metric objects - earlyStart", () => {
@@ -918,6 +920,56 @@ describe("backend", () => {
     ).toEqual({
       ...upgraded,
       attributionModel: "firstExposure",
+    });
+  });
+
+  it("Upgrades old Organization objects", () => {
+    const org: OrganizationInterface = {
+      dateCreated: new Date(),
+      id: "",
+      invites: [],
+      members: [],
+      name: "",
+      ownerEmail: "",
+      url: "",
+    };
+
+    expect(
+      upgradeOrganizationDoc({
+        ...org,
+      })
+    ).toEqual({
+      ...org,
+      settings: {
+        attributeSchema: [
+          { property: "id", datatype: "string", hashAttribute: true },
+          { property: "deviceId", datatype: "string", hashAttribute: true },
+          { property: "company", datatype: "string", hashAttribute: true },
+          { property: "loggedIn", datatype: "boolean" },
+          { property: "employee", datatype: "boolean" },
+          { property: "country", datatype: "string" },
+          { property: "browser", datatype: "string" },
+          { property: "url", datatype: "string" },
+        ],
+        defaultRole: {
+          role: "collaborator",
+          environments: [],
+          limitAccessByEnvironment: false,
+        },
+        statsEngine: "bayesian",
+        environments: [
+          {
+            id: "dev",
+            description: "",
+            toggleOnList: true,
+          },
+          {
+            id: "production",
+            description: "",
+            toggleOnList: true,
+          },
+        ],
+      },
     });
   });
 });

--- a/packages/front-end/components/Experiment/AnalysisSettingsBar.tsx
+++ b/packages/front-end/components/Experiment/AnalysisSettingsBar.tsx
@@ -53,7 +53,7 @@ function isOutdated(
     return true;
   }
   const experimentRegressionAdjustmentEnabled =
-    statsEngine === "bayesian" || !hasRegressionAdjustmentFeature
+    statsEngine !== "frequentist" || !hasRegressionAdjustmentFeature
       ? false
       : !!experiment.regressionAdjustmentEnabled;
   if (

--- a/packages/front-end/components/Experiment/Results.tsx
+++ b/packages/front-end/components/Experiment/Results.tsx
@@ -82,7 +82,8 @@ const Results: FC<{
 
   const hasData =
     snapshot?.results?.[0]?.variations?.length > 0 &&
-    snapshot.statsEngine === settings.statsEngine;
+    (snapshot.statsEngine || "bayesian") ===
+      (settings.statsEngine || "bayesian");
 
   const phaseObj = experiment.phases?.[phase];
 


### PR DESCRIPTION
### Features and Changes

When the organization statsEngine setting is undefined, it can cause experiment results to be hidden.  This PR forces the organization stats setting to always be defined and also makes the checks throughout the code more robust to missing statsEngine settings.