### PR TITLE
Add stats engine selection to generated notebooks

### DIFF
--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -490,7 +490,7 @@ export default abstract class SqlIntegration
         variation: row.variation ?? "",
         dimension: row.dimension || "",
         users: parseInt(row.users) || 0,
-        count: parseInt(row.users) || 0,
+        count: parseInt(row.count) || 0,
         statistic_type: row.statistic_type ?? "",
         main_metric_type: row.main_metric_type ?? "",
         main_sum: parseFloat(row.main_sum) || 0,
@@ -1182,6 +1182,7 @@ export default abstract class SqlIntegration
         u.variation,
         u.dimension,
         ${metric.ignoreNulls ? "COALESCE(s.count, 0)" : "u.users"} AS users,
+        ${metric.ignoreNulls ? "COALESCE(s.count, 0)" : "u.users"} AS count,
         '${this.getStatisticType(
           isRatio,
           isRegressionAdjusted

--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -490,7 +490,7 @@ export default abstract class SqlIntegration
         variation: row.variation ?? "",
         dimension: row.dimension || "",
         users: parseInt(row.users) || 0,
-        count: parseInt(row.count) || 0,
+        count: parseInt(row.users) || 0,
         statistic_type: row.statistic_type ?? "",
         main_metric_type: row.main_metric_type ?? "",
         main_sum: parseFloat(row.main_sum) || 0,
@@ -1182,7 +1182,6 @@ export default abstract class SqlIntegration
         u.variation,
         u.dimension,
         ${metric.ignoreNulls ? "COALESCE(s.count, 0)" : "u.users"} AS users,
-        ${metric.ignoreNulls ? "COALESCE(s.count, 0)" : "u.users"} AS count,
         '${this.getStatisticType(
           isRatio,
           isRegressionAdjusted

--- a/packages/back-end/src/services/notebook.ts
+++ b/packages/back-end/src/services/notebook.ts
@@ -133,6 +133,7 @@ export async function generateNotebook(
   const result = await promisify(PythonShell.runString)(
     `
 from gbstats.gen_notebook import create_notebook
+from gbstats.shared.constants import StatsEngine
 import pandas as pd
 import json
 
@@ -158,7 +159,12 @@ print(create_notebook(
     var_names=data['var_names'],
     weights=data['weights'],
     run_query=data['run_query'],
-    needs_correction=data['needs_correction']
+    needs_correction=data['needs_correction'],
+    stats_engine=${
+      (args.statsEngine ?? "bayesian") === "frequentist"
+        ? "StatsEngine.FREQUENTIST"
+        : "StatsEngine.BAYESIAN"
+    }
 ))`,
     {}
   );

--- a/packages/back-end/src/services/notebook.ts
+++ b/packages/back-end/src/services/notebook.ts
@@ -75,8 +75,7 @@ export async function generateNotebook(
   args: ExperimentReportArgs,
   url: string,
   name: string,
-  description: string,
-  needsCorrection: boolean
+  description: string
 ) {
   // Get datasource
   const datasource = await getDataSourceById(args.datasource, organization);
@@ -127,7 +126,6 @@ export async function generateNotebook(
     var_names: args.variations.map((v) => v.name),
     weights: args.variations.map((v) => v.weight),
     run_query: datasource.settings.notebookRunQuery,
-    needs_correction: needsCorrection,
   }).replace(/\\/g, "\\\\");
 
   const result = await promisify(PythonShell.runString)(
@@ -159,7 +157,6 @@ print(create_notebook(
     var_names=data['var_names'],
     weights=data['weights'],
     run_query=data['run_query'],
-    needs_correction=data['needs_correction'],
     stats_engine=${
       (args.statsEngine ?? "bayesian") === "frequentist"
         ? "StatsEngine.FREQUENTIST"

--- a/packages/back-end/src/services/notebook.ts
+++ b/packages/back-end/src/services/notebook.ts
@@ -27,8 +27,7 @@ export async function generateReportNotebook(
     report.args,
     `/report/${report.id}`,
     report.title,
-    "",
-    !report.results?.hasCorrectedStats
+    ""
   );
 }
 
@@ -64,8 +63,7 @@ export async function generateExperimentNotebook(
     reportArgsFromSnapshot(experiment, snapshot),
     `/experiment/${experiment.id}`,
     experiment.name,
-    experiment.hypothesis || "",
-    !snapshot.hasCorrectedStats
+    experiment.hypothesis || ""
   );
 }
 

--- a/packages/stats/gbstats/gbstats.py
+++ b/packages/stats/gbstats/gbstats.py
@@ -87,6 +87,9 @@ def get_metric_df(
             prefix = f"v{i}" if i > 0 else "baseline"
             for col in SUM_COLS:
                 dimensions[dim][f"{prefix}_{col}"] = getattr(row, col, 0)
+            # Special handling for count, if missing returnes a method, so override with user value
+            if callable(getattr(row, "count")):
+                dimensions[dim][f"{prefix}_count"] = getattr(row, "users", 0)
 
     return pd.DataFrame(dimensions.values())
 

--- a/packages/stats/gbstats/gen_notebook.py
+++ b/packages/stats/gbstats/gen_notebook.py
@@ -84,7 +84,7 @@ def create_notebook(
             f"var_names = {str(var_names)}\n\n"
             "# Expected traffic split between variations\n"
             f"weights = {str(weights)}\n"
-            "# Statistics engine to user\n"
+            "# Statistics engine to use\n"
             f"stats_engine = {str(stats_engine)}\n"
             f"# Columns to show in the result summary\n"
             f"summary_cols = {str(summary_cols)}"

--- a/packages/stats/gbstats/gen_notebook.py
+++ b/packages/stats/gbstats/gen_notebook.py
@@ -53,10 +53,14 @@ def create_notebook(
         summary_cols.append(f"v{i}_name")
         summary_cols.append(f"v{i}_users")
         summary_cols.append(f"v{i}_cr")
-        summary_cols.append(f"v{i}_risk")
         summary_cols.append(f"v{i}_expected")
         summary_cols.append(f"v{i}_ci")
-        summary_cols.append(f"v{i}_prob_beat_baseline")
+        if stats_engine == StatsEngine.BAYESIAN:
+            summary_cols.append(f"v{i}_risk")
+            summary_cols.append(f"v{i}_prob_beat_baseline")
+        elif stats_engine == StatsEngine.FREQUENTIST:
+
+            summary_cols.append(f"v{i}_p_value")
 
     cells = [
         nbf.new_markdown_cell(
@@ -80,6 +84,8 @@ def create_notebook(
             f"var_names = {str(var_names)}\n\n"
             "# Expected traffic split between variations\n"
             f"weights = {str(weights)}\n"
+            "# Statistics engine to user\n"
+            f"stats_engine = {str(stats_engine)}\n"
             f"# Columns to show in the result summary\n"
             f"summary_cols = {str(summary_cols)}"
         ),
@@ -167,7 +173,7 @@ def create_notebook(
                     f"    df=m{i}_reduced,\n"
                     f"    weights=weights,\n"
                     f"    inverse={inverse},\n"
-                    f"    engine={stats_engine}\n"
+                    f"    engine=stats_engine\n"
                     f")\n"
                     f"display(m{i}_result[summary_cols].T)"
                 ),

--- a/packages/stats/gbstats/gen_notebook.py
+++ b/packages/stats/gbstats/gen_notebook.py
@@ -4,6 +4,7 @@ from .gbstats import (
     get_metric_df,
     reduce_dimensionality,
 )
+from gbstats.shared.constants import StatsEngine
 import nbformat
 from nbformat import v4 as nbf
 from nbformat.v4.nbjson import from_dict
@@ -39,7 +40,7 @@ def create_notebook(
     weights=[],
     run_query="",
     metrics=[],
-    needs_correction=False,
+    stats_engine=StatsEngine.BAYESIAN,
 ):
     summary_cols = [
         "dimension",
@@ -71,7 +72,8 @@ def create_notebook(
             "  analyze_metric_df,\n"
             "  get_metric_df,\n"
             "  reduce_dimensionality\n"
-            ")\n\n"
+            ")\n"
+            "from gbstats.shared.constants import StatsEngine\n\n"
             "# Mapping of variation id to index\n"
             f"var_id_map = {str(var_id_map)}\n\n"
             "# Display names of variations\n"
@@ -144,7 +146,7 @@ def create_notebook(
             code_cell_df(
                 df=df,
                 source=(
-                    "# If there are too many dimensions, marge the smaller ones together\n"
+                    "# If there are too many dimensions, merge the smaller ones together\n"
                     f"m{i}_reduced = reduce_dimensionality(m{i}, max=20)\n"
                     f"display(m{i}_reduced)"
                 ),
@@ -154,9 +156,7 @@ def create_notebook(
         cells.append(nbf.new_markdown_cell("### Result"))
 
         result = analyze_metric_df(
-            df=df,
-            weights=weights,
-            inverse=inverse,
+            df=df, weights=weights, inverse=inverse, engine=stats_engine
         )
         cells.append(
             code_cell_df(
@@ -166,7 +166,8 @@ def create_notebook(
                     f"m{i}_result = analyze_metric_df(\n"
                     f"    df=m{i}_reduced,\n"
                     f"    weights=weights,\n"
-                    f"    inverse={inverse}\n"
+                    f"    inverse={inverse},\n"
+                    f"    engine={stats_engine}\n"
                     f")\n"
                     f"display(m{i}_result[summary_cols].T)"
                 ),

--- a/packages/stats/tests/test_gbstats.py
+++ b/packages/stats/tests/test_gbstats.py
@@ -15,7 +15,11 @@ from gbstats.gbstats import (
 )
 from gbstats.messages import RA_NOT_COMPATIBLE_WITH_BAYESIAN_ERROR
 from gbstats.shared.constants import StatsEngine
-from gbstats.shared.models import RegressionAdjustedStatistic, SampleMeanStatistic, ProportionStatistic
+from gbstats.shared.models import (
+    RegressionAdjustedStatistic,
+    SampleMeanStatistic,
+    ProportionStatistic,
+)
 
 DECIMALS = 9
 round_ = partial(np.round, decimals=DECIMALS)
@@ -189,6 +193,19 @@ RA_STATISTICS_DF = pd.DataFrame(
 ).assign(
     statistic_type="mean_ra", main_metric_type="count", covariate_metric_type="count"
 )
+
+
+class TestGetMetricDf(TestCase):
+    def test_get_metric_df_missing_count(self):
+        rows = MULTI_DIMENSION_STATISTICS_DF.drop("count", axis=1)
+        df = get_metric_df(
+            rows,
+            {"zero": 0, "one": 1},
+            ["zero", "one"],
+        )
+        for i, row in df.iterrows():
+            self.assertEqual(row["baseline_count"], row["baseline_users"])
+            self.assertEqual(row["v1_count"], row["v1_users"])
 
 
 class TestBaseStatisticBuilder(TestCase):
@@ -546,10 +563,10 @@ class TestAnalyzeMetricDfRegressionAdjustment(TestCase):
     def test_analyze_metric_df_ra_proportion(self):
         rows = RA_STATISTICS_DF
         # override default DF
-        rows['main_metric_type'] = 'binomial'
-        rows['covariate_metric_type'] = 'binomial'
-        rows['main_sum_squares'] = None
-        rows['covariate_sum_squares'] = None
+        rows["main_metric_type"] = "binomial"
+        rows["covariate_metric_type"] = "binomial"
+        rows["main_sum_squares"] = None
+        rows["covariate_sum_squares"] = None
         df = get_metric_df(rows, {"zero": 0, "one": 1}, ["zero", "one"])
         result = analyze_metric_df(
             df=df, weights=[0.5, 0.5], inverse=False, engine=StatsEngine.FREQUENTIST


### PR DESCRIPTION
### Features and Changes

* Notebooks did not seem to be aware of stats engine settings. This fixes that for notebooks from snapshots or reports.
* Also, after SQL refactor where we removed redundant count, the notebook export function would break notebooks once you ran them due to missing count field. I hacked together a solution to this to just always use "users" if "count" is missing in the dataframe.
* Also removes `needs_correction` from the notebook gbstats integration since we no longer use it after Stats Refactor (#841)

### Dependencies

n/a

### Testing

- [x] Experiment Report Bayesian as expected (results and engine)
- [x] Experiment Report Frequentist as expected (results and engine)
- [x] Snapshot Bayesian as expected (results and engine)
- [x] Snapshot Frequentist as expected (results and engine)

### Screenshots

n/a