### PR TITLE
Bug fix when user's name is undefined

### DIFF
--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -596,7 +596,7 @@ export async function getOrganization(req: AuthRequest, res: Response) {
     expandedMembers.push({
       email,
       verified,
-      name,
+      name: name || "",
       ...memberInfo,
       dateCreated: memberInfo.dateCreated || _id.getTimestamp(),
     });

--- a/packages/back-end/src/services/auth/index.ts
+++ b/packages/back-end/src/services/auth/index.ts
@@ -193,7 +193,7 @@ export async function processJWT(
       type: "dashboard",
       id: user.id,
       email: user.email,
-      name: user.name,
+      name: user.name || "",
     };
     res.locals.eventAudit = eventAudit;
 
@@ -203,7 +203,7 @@ export async function processJWT(
         user: {
           id: user.id,
           email: user.email,
-          name: user.name,
+          name: user.name || "",
         },
         organization: req.organization?.id,
         dateCreated: new Date(),

--- a/packages/back-end/types/user.d.ts
+++ b/packages/back-end/types/user.d.ts
@@ -1,6 +1,6 @@
 export interface UserInterface {
   id: string;
-  name: string;
+  name?: string;
   email: string;
   verified: boolean;
   passwordHash?: string;


### PR DESCRIPTION
This was breaking our EventModel validation.

This is a quick bug fix to unblock affected users. For a proper fix, we should apply a migration to the UserModel and ensure name is always defined. This requires refactoring the UserModel to only export methods and use a toInferface method, so it's a little bit bigger scope.