### PR TITLE
fix undefined experiments while getting SDK payload

### DIFF
--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -230,7 +230,7 @@ async function getFeatureDefinitionsResponse(
   includeDraftExperiments?: boolean
 ) {
   if (!includeDraftExperiments) {
-    experiments = experiments.filter((e) => e.status !== "draft");
+    experiments = experiments?.filter((e) => e.status !== "draft") || [];
   }
 
   if (!encryptionKey) {
@@ -246,7 +246,7 @@ async function getFeatureDefinitionsResponse(
     encryptionKey
   );
   const encryptedExperiments = includeVisualExperiments
-    ? await encrypt(JSON.stringify(experiments), encryptionKey)
+    ? await encrypt(JSON.stringify(experiments || []), encryptionKey)
     : undefined;
 
   return {
@@ -283,7 +283,7 @@ export async function getFeatureDefinitions(
       const { features, experiments } = cached.contents;
       return await getFeatureDefinitionsResponse(
         features,
-        experiments,
+        experiments || [],
         cached.dateUpdated,
         encryptionKey,
         includeVisualExperiments,

--- a/packages/front-end/pages/features/[fid].tsx
+++ b/packages/front-end/pages/features/[fid].tsx
@@ -489,7 +489,7 @@ export default function FeaturePage() {
               count={rules.length}
               padding={false}
             >
-              <div className="appbox mb-4 border-top-0">
+              <div className="border mb-4 border-top-0">
                 {rules.length > 0 ? (
                   <RuleList
                     environment={e.id}


### PR DESCRIPTION
Experiments may be undefined when pulling from old cache that doesn't match the model. Avoid filtering on undefined, and generally fix them.

https://growthbook.sentry.io/issues/4059384870/?alert_rule_id=12426543&alert_timestamp=1680550019684&alert_type=email&environment=production&project=4503942935216128&ref_fallback=ga&referrer=alert_email