### PR TITLE
Use Depot for Docker builds

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           push: true
           context: .
-          project: TODO
+          project: vmp2ssvj9r
           tags: |
             growthbook/growthbook:latest
             growthbook/growthbook:git-${{ steps.metadata.outputs.sha }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,9 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'growthbook/growthbook' }}
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -28,16 +31,27 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
-      - name: Build, tag, and push image to Docker Hub
+      - name: Install Depot CLI
+        uses: depot/setup-action@v1
+
+      - name: Prepare build metadata
+        id: metadata
         run: |
           # Store current git hash and date in files
           mkdir -p buildinfo
           echo "${GITHUB_SHA}" > buildinfo/SHA
           printf '%(%Y-%m-%dT%H:%M:%SZ)T' > buildinfo/DATE
+          echo "sha=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
 
-          # Build and push the docker image
-          docker build -t growthbook/growthbook:latest -t growthbook/growthbook:git-${GITHUB_SHA::7} .
-          docker push -a growthbook/growthbook
+      - name: Build, tag, and push image to Docker Hub
+        uses: depot/build-push-action@v1
+        with:
+          push: true
+          context: .
+          project: TODO
+          tags: |
+            growthbook/growthbook:latest
+            growthbook/growthbook:git-${{ steps.metadata.outputs.sha }}
 
   # Deploy the back-end for GrowthBook Cloud
   prod:
@@ -51,7 +65,7 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
-      
+
       - name: Deploy docker image to ECS for GrowthBook Cloud API
         run:
           aws ecs update-service --cluster prod-api --service prod-api --force-new-deployment --region us-east-1


### PR DESCRIPTION
cc @jdorn 

### Features and Changes

This PR switches the `deploy.yml` workflow to use [Depot](https://depot.dev) to build the Docker image on main. Depot provides a hosted container build service based on BuildKit with fully managed SSD cache. 

The goal with this PR is to greatly reduce build/deploy time from [the current 8-10 minutes](https://github.com/growthbook/growthbook/actions/workflows/deploy.yml).

### Dependencies

You will need to create a Depot project, and we'll need to add that project ID in place of the current `TODO`.

Depot uses OIDC for authentication, meaning that it will use a short-lived token that Actions generates to authenticate builds. The workflow `permissions.id-token` option enables this on GitHub's side, but you will also need to add a trust relationship to your Depot project. When you create the project, there should be an option to add the trust relationship directly:

<img width="624" alt="image" src="https://user-images.githubusercontent.com/130874/229764775-c2b2ece6-4980-4749-b7a0-2a8fabedb955.png">

You can also add it later in your project settings.

