### PR TITLE
Add SchemaBrowser support for MySQL

### DIFF
--- a/packages/back-end/src/integrations/Mysql.ts
+++ b/packages/back-end/src/integrations/Mysql.ts
@@ -3,6 +3,9 @@ import { ConnectionOptions } from "mysql2";
 import { MysqlConnectionParams } from "../../types/integrations/mysql";
 import { decryptDataSourceParams } from "../services/datasource";
 import { FormatDialect } from "../util/sql";
+import { DataSourceProperties } from "../../types/datasource";
+import { formatInformationSchema } from "../util/informationSchemas";
+import { InformationSchema, RawInformationSchema } from "../types/Integration";
 import SqlIntegration from "./SqlIntegration";
 
 export default class Mysql extends SqlIntegration {
@@ -13,6 +16,12 @@ export default class Mysql extends SqlIntegration {
     this.params = decryptDataSourceParams<MysqlConnectionParams>(
       encryptedParams
     );
+  }
+  getSourceProperties(): DataSourceProperties {
+    return {
+      ...super.getSourceProperties(),
+      supportsInformationSchema: true,
+    };
   }
   getFormatDialect(): FormatDialect {
     return "mysql";
@@ -67,5 +76,52 @@ export default class Mysql extends SqlIntegration {
   }
   ensureFloat(col: string): string {
     return `CAST(${col} AS DOUBLE)`;
+  }
+  async getInformationSchema(): Promise<InformationSchema[]> {
+    const databaseName = this.params.database;
+    const sql = `SELECT
+        table_name as table_name,
+        table_catalog as table_catalog,
+        table_schema as table_schema,
+        count(column_name) as column_count
+      FROM
+        information_schema.columns
+      WHERE table_schema in ('${databaseName}')
+      GROUP BY table_name, table_schema, table_catalog`;
+
+    const results = await this.runQuery(sql);
+
+    if (!results.length) {
+      throw new Error(`No tables found.`);
+    }
+
+    return formatInformationSchema(results as RawInformationSchema[], "mysql");
+  }
+
+  async getTableData(
+    databaseName: string,
+    tableSchema: string,
+    tableName: string
+  ): Promise<{ tableData: null | unknown[]; refreshMS: number }> {
+    const sql = `SELECT
+        data_type as data_type,
+        column_name as column_name
+      FROM
+        information_schema.columns
+      WHERE
+        table_catalog
+      IN ('${databaseName}')
+      AND
+        table_schema
+      IN ('${tableSchema}')
+      AND
+        table_name
+      IN ('${tableName}')`;
+
+    const queryStartTime = Date.now();
+    const tableData = await this.runQuery(sql);
+    const queryEndTime = Date.now();
+
+    return { tableData, refreshMS: queryEndTime - queryStartTime };
   }
 }


### PR DESCRIPTION
### Features and Changes
This PR adds `SchemaBrowser` support for MySQL Data Sources within GrowthBook. This is accomplished by doing 3 things - the first is setting the datasource property `supportsInformationSchema` to `true`. This enables the front-end to show the `SchemaBrowser`.

Then, we have to add two queries/methods - a `getInformationSchema` method and a `getTableData` method.

### Testing

- [x] Create a new MySQL Data Source within GrowthBook
- [x] Confirm that when this Data Source is created, we're automatically generating an `informationSchema` object, and when we view the `SchemaBrowser` the data is correct
- [x] When viewing the `SchemaBrowser` ensure that you can click on a table and we'll fetch the table's metadata (columns, column type, etc).

### Screenshots
<img width="512" alt="Screen Shot 2023-04-05 at 6 44 42 AM" src="https://user-images.githubusercontent.com/75274610/230058523-a3489dc7-d081-4edc-a8d4-b353eae4f06a.png">

