### PR TITLE
Add option to include experiment/variation names in SDK Payload

### DIFF
--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -1623,6 +1623,8 @@ components:
           type: boolean
         includeDraftExperiments:
           type: boolean
+        includeExperimentNames:
+          type: boolean
         key:
           type: string
         proxyEnabled:

--- a/packages/back-end/src/api/openapi/schemas/SdkConnection.yaml
+++ b/packages/back-end/src/api/openapi/schemas/SdkConnection.yaml
@@ -40,6 +40,8 @@ properties:
     type: boolean
   includeDraftExperiments:
     type: boolean
+  includeExperimentNames:
+    type: boolean
   key:
     type: string
   proxyEnabled:

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -70,6 +70,7 @@ async function getPayloadParamsFromApiKey(
   sseEnabled?: boolean;
   includeVisualExperiments?: boolean;
   includeDraftExperiments?: boolean;
+  includeExperimentNames?: boolean;
 }> {
   // SDK Connection key
   if (key.match(/^sdk-/)) {
@@ -96,6 +97,7 @@ async function getPayloadParamsFromApiKey(
       sseEnabled: connection.sseEnabled,
       includeVisualExperiments: connection.includeVisualExperiments,
       includeDraftExperiments: connection.includeDraftExperiments,
+      includeExperimentNames: connection.includeExperimentNames,
     };
   }
   // Old, legacy API Key
@@ -153,16 +155,18 @@ export async function getFeaturesPublic(req: Request, res: Response) {
       sseEnabled,
       includeVisualExperiments,
       includeDraftExperiments,
+      includeExperimentNames,
     } = await getPayloadParamsFromApiKey(key, req);
 
-    const defs = await getFeatureDefinitions(
+    const defs = await getFeatureDefinitions({
       organization,
       environment,
       project,
-      encrypted ? encryptionKey : "",
+      encryptionKey: encrypted ? encryptionKey : "",
       includeVisualExperiments,
-      includeDraftExperiments
-    );
+      includeDraftExperiments,
+      includeExperimentNames,
+    });
 
     // Cache for 30 seconds, serve stale up to 1 hour (10 hours if origin is down)
     res.set(

--- a/packages/back-end/src/jobs/proxyUpdate.ts
+++ b/packages/back-end/src/jobs/proxyUpdate.ts
@@ -31,14 +31,17 @@ export default function addProxyUpdateJob(ag: Agenda) {
     if (!connectionSupportsProxyUpdate(connection)) return;
 
     // TODO This probably needs to renamed
-    const defs = await getFeatureDefinitions(
-      connection.organization,
-      connection.environment,
-      connection.project,
-      connection.encryptPayload ? connection.encryptionKey : undefined,
-      connection.includeVisualExperiments,
-      connection.includeDraftExperiments
-    );
+    const defs = await getFeatureDefinitions({
+      organization: connection.organization,
+      environment: connection.environment,
+      project: connection.project,
+      encryptionKey: connection.encryptPayload
+        ? connection.encryptionKey
+        : undefined,
+      includeVisualExperiments: connection.includeVisualExperiments,
+      includeDraftExperiments: connection.includeDraftExperiments,
+      includeExperimentNames: connection.includeExperimentNames,
+    });
 
     const payload = JSON.stringify(defs);
 

--- a/packages/back-end/src/jobs/webhooks.ts
+++ b/packages/back-end/src/jobs/webhooks.ts
@@ -29,11 +29,12 @@ export default function (ag: Agenda) {
 
     if (!webhook) return;
 
-    const { features, dateUpdated } = await getFeatureDefinitions(
-      webhook.organization,
-      webhook.environment === undefined ? "production" : webhook.environment,
-      webhook.project || ""
-    );
+    const { features, dateUpdated } = await getFeatureDefinitions({
+      organization: webhook.organization,
+      environment:
+        webhook.environment === undefined ? "production" : webhook.environment,
+      project: webhook.project || "",
+    });
 
     // eslint-disable-next-line
     const body: any = {

--- a/packages/back-end/src/models/SdkConnectionModel.ts
+++ b/packages/back-end/src/models/SdkConnectionModel.ts
@@ -40,6 +40,7 @@ const sdkConnectionSchema = new mongoose.Schema({
   encryptionKey: String,
   includeVisualExperiments: Boolean,
   includeDraftExperiments: Boolean,
+  includeExperimentNames: Boolean,
   connected: Boolean,
   sseEnabled: Boolean,
   key: {
@@ -111,6 +112,7 @@ export const createSDKConnectionValidator = z
     encryptPayload: z.boolean(),
     includeVisualExperiments: z.boolean().optional(),
     includeDraftExperiments: z.boolean().optional(),
+    includeExperimentNames: z.boolean().optional(),
     proxyEnabled: z.boolean().optional(),
     proxyHost: z.string().optional(),
   })
@@ -175,6 +177,7 @@ export const editSDKConnectionValidator = z
     encryptPayload: z.boolean(),
     includeVisualExperiments: z.boolean().optional(),
     includeDraftExperiments: z.boolean().optional(),
+    includeExperimentNames: z.boolean().optional(),
   })
   .strict();
 
@@ -388,6 +391,7 @@ export function toApiSDKConnectionInterface(
     encryptionKey: connection.encryptionKey,
     includeVisualExperiments: connection.includeVisualExperiments,
     includeDraftExperiments: connection.includeDraftExperiments,
+    includeExperimentNames: connection.includeExperimentNames,
     key: connection.key,
     proxyEnabled: connection.proxy.enabled,
     proxyHost: connection.proxy.host,

--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -221,16 +221,40 @@ export async function refreshSDKPayloadCache(
   await queueProxyUpdate(organization.id, payloadKeys);
 }
 
-async function getFeatureDefinitionsResponse(
-  features: Record<string, FeatureDefinition>,
-  experiments: SDKExperiment[],
-  dateUpdated: Date | null,
-  encryptionKey?: string,
-  includeVisualExperiments?: boolean,
-  includeDraftExperiments?: boolean
-) {
+export type FeatureDefinitionsResponseArgs = {
+  features: Record<string, FeatureDefinition>;
+  experiments: SDKExperiment[];
+  dateUpdated: Date | null;
+  encryptionKey?: string;
+  includeVisualExperiments?: boolean;
+  includeDraftExperiments?: boolean;
+  includeExperimentNames?: boolean;
+};
+
+async function getFeatureDefinitionsResponse({
+  features,
+  experiments,
+  dateUpdated,
+  encryptionKey,
+  includeVisualExperiments,
+  includeDraftExperiments,
+  includeExperimentNames,
+}: FeatureDefinitionsResponseArgs) {
   if (!includeDraftExperiments) {
     experiments = experiments?.filter((e) => e.status !== "draft") || [];
+  }
+
+  if (!includeExperimentNames) {
+    // Remove meta info from every visual experiment
+    experiments.forEach((exp) => {
+      // TODO: We are mutating the experiments argument, should we clone it first?
+      if (exp.meta) {
+        exp.meta.forEach((meta) => {
+          delete meta.name;
+        });
+      }
+      delete exp.name;
+    });
   }
 
   if (!encryptionKey) {
@@ -258,14 +282,25 @@ async function getFeatureDefinitionsResponse(
   };
 }
 
-export async function getFeatureDefinitions(
-  organization: string,
-  environment: string = "production",
-  project?: string,
-  encryptionKey?: string,
-  includeVisualExperiments?: boolean,
-  includeDraftExperiments?: boolean
-): Promise<{
+export type FeatureDefinitionArgs = {
+  organization: string;
+  environment?: string;
+  project?: string;
+  encryptionKey?: string;
+  includeVisualExperiments?: boolean;
+  includeDraftExperiments?: boolean;
+  includeExperimentNames?: boolean;
+};
+
+export async function getFeatureDefinitions({
+  organization,
+  environment = "production",
+  project,
+  encryptionKey,
+  includeVisualExperiments,
+  includeDraftExperiments,
+  includeExperimentNames,
+}: FeatureDefinitionArgs): Promise<{
   features: Record<string, FeatureDefinition>;
   experiments?: SDKExperiment[];
   dateUpdated: Date | null;
@@ -281,14 +316,15 @@ export async function getFeatureDefinitions(
     });
     if (cached) {
       const { features, experiments } = cached.contents;
-      return await getFeatureDefinitionsResponse(
+      return await getFeatureDefinitionsResponse({
         features,
-        experiments || [],
-        cached.dateUpdated,
+        experiments: experiments || [],
+        dateUpdated: cached.dateUpdated,
         encryptionKey,
         includeVisualExperiments,
-        includeDraftExperiments
-      );
+        includeDraftExperiments,
+        includeExperimentNames,
+      });
     }
   } catch (e) {
     logger.error(e, "Failed to fetch SDK payload from cache");
@@ -296,14 +332,15 @@ export async function getFeatureDefinitions(
 
   const org = await getOrganizationById(organization);
   if (!org) {
-    return await getFeatureDefinitionsResponse(
-      {},
-      [],
-      null,
+    return await getFeatureDefinitionsResponse({
+      features: {},
+      experiments: [],
+      dateUpdated: null,
       encryptionKey,
       includeVisualExperiments,
-      includeDraftExperiments
-    );
+      includeDraftExperiments,
+      includeExperimentNames,
+    });
   }
 
   // Generate the feature definitions
@@ -332,14 +369,15 @@ export async function getFeatureDefinitions(
     experimentsDefinitions,
   });
 
-  return await getFeatureDefinitionsResponse(
-    featureDefinitions,
-    experimentsDefinitions,
-    new Date(),
+  return await getFeatureDefinitionsResponse({
+    features: featureDefinitions,
+    experiments: experimentsDefinitions,
+    dateUpdated: new Date(),
     encryptionKey,
     includeVisualExperiments,
-    includeDraftExperiments
-  );
+    includeDraftExperiments,
+    includeExperimentNames,
+  });
 }
 
 export function generateRuleId() {

--- a/packages/back-end/types/openapi.d.ts
+++ b/packages/back-end/types/openapi.d.ts
@@ -564,6 +564,7 @@ export interface components {
       encryptionKey: string;
       includeVisualExperiments?: boolean;
       includeDraftExperiments?: boolean;
+      includeExperimentNames?: boolean;
       key: string;
       proxyEnabled: boolean;
       proxyHost: string;
@@ -1468,6 +1469,7 @@ export interface operations {
                 encryptionKey: string;
                 includeVisualExperiments?: boolean;
                 includeDraftExperiments?: boolean;
+                includeExperimentNames?: boolean;
                 key: string;
                 proxyEnabled: boolean;
                 proxyHost: string;
@@ -1505,6 +1507,7 @@ export interface operations {
               encryptionKey: string;
               includeVisualExperiments?: boolean;
               includeDraftExperiments?: boolean;
+              includeExperimentNames?: boolean;
               key: string;
               proxyEnabled: boolean;
               proxyHost: string;

--- a/packages/back-end/types/sdk-connection.d.ts
+++ b/packages/back-end/types/sdk-connection.d.ts
@@ -20,6 +20,7 @@ export type EditSDKConnectionParams = {
   encryptPayload?: boolean;
   includeVisualExperiments?: boolean;
   includeDraftExperiments?: boolean;
+  includeExperimentNames?: boolean;
 };
 export type CreateSDKConnectionParams = {
   organization: string;
@@ -32,6 +33,7 @@ export type CreateSDKConnectionParams = {
   encryptPayload: boolean;
   includeVisualExperiments: boolean;
   includeDraftExperiments: boolean;
+  includeExperimentNames: boolean;
 };
 
 export type SDKLanguage =
@@ -66,6 +68,7 @@ export interface SDKConnectionInterface {
   encryptionKey: string;
   includeVisualExperiments?: boolean;
   includeDraftExperiments?: boolean;
+  includeExperimentNames?: boolean;
 
   // URL slug for fetching features from the API
   key: string;

--- a/packages/front-end/components/Features/SDKConnections/InitialSDKConnectionForm.tsx
+++ b/packages/front-end/components/Features/SDKConnections/InitialSDKConnectionForm.tsx
@@ -101,6 +101,7 @@ export default function InitialSDKConnectionForm({
           encryptPayload: false,
           includeVisualExperiments: false,
           includeDraftExperiments: false,
+          includeExperimentNames: false,
           environment: environments[0]?.id || "production",
           project: "",
           proxyEnabled: false,

--- a/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
+++ b/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
@@ -56,6 +56,7 @@ export default function SDKConnectionForm({
       encryptPayload: initialValue.encryptPayload || false,
       includeVisualExperiments: initialValue.includeVisualExperiments || false,
       includeDraftExperiments: initialValue.includeDraftExperiments || false,
+      includeExperimentNames: initialValue.includeExperimentNames || false,
       proxyEnabled: initialValue.proxy?.enabled || false,
       proxyHost: initialValue.proxy?.host || "",
     },
@@ -190,39 +191,71 @@ export default function SDKConnectionForm({
               </div>
             </div>
             {form.watch("includeVisualExperiments") && (
-              <div className="mt-3">
-                <Tooltip
-                  body={
-                    <>
-                      <p>
-                        In-development visual experiments will be sent to the
-                        SDK. We recommend only enabling this for non-production
-                        environments.
-                      </p>
-                      <p className="mb-0">
-                        To force into a variation, use a URL query string such
-                        as{" "}
-                        <div className="text-monospace">
-                          ?my-experiment-id=2
-                        </div>
-                      </p>
-                    </>
-                  }
-                >
-                  <label htmlFor="sdk-connection-include-draft-experiments-toggle">
-                    Include draft experiments <FaInfoCircle />
-                  </label>
-                </Tooltip>
-                <div>
-                  <Toggle
-                    id="sdk-connection-include-draft-experiments-toggle"
-                    value={form.watch("includeDraftExperiments")}
-                    setValue={(val) =>
-                      form.setValue("includeDraftExperiments", val)
+              <>
+                <div className="mt-3">
+                  <Tooltip
+                    body={
+                      <>
+                        <p>
+                          In-development visual experiments will be sent to the
+                          SDK. We recommend only enabling this for
+                          non-production environments.
+                        </p>
+                        <p className="mb-0">
+                          To force into a variation, use a URL query string such
+                          as{" "}
+                          <div className="text-monospace">
+                            ?my-experiment-id=2
+                          </div>
+                        </p>
+                      </>
                     }
-                  />
+                  >
+                    <label htmlFor="sdk-connection-include-draft-experiments-toggle">
+                      Include draft experiments <FaInfoCircle />
+                    </label>
+                  </Tooltip>
+                  <div>
+                    <Toggle
+                      id="sdk-connection-include-draft-experiments-toggle"
+                      value={form.watch("includeDraftExperiments")}
+                      setValue={(val) =>
+                        form.setValue("includeDraftExperiments", val)
+                      }
+                    />
+                  </div>
                 </div>
-              </div>
+                <div className="mt-3">
+                  <Tooltip
+                    body={
+                      <>
+                        <p>
+                          This can help add context when debugging or tracking
+                          events.
+                        </p>
+                        <p>
+                          However, if used in a client-side or mobile app, be
+                          careful of exposing potentially sensitive information
+                          to your users.
+                        </p>
+                      </>
+                    }
+                  >
+                    <label htmlFor="sdk-connection-include-experiment-meta">
+                      Include experiment/variation names? <FaInfoCircle />
+                    </label>
+                  </Tooltip>
+                  <div>
+                    <Toggle
+                      id="sdk-connection-include-experiment-meta"
+                      value={form.watch("includeExperimentNames")}
+                      setValue={(val) =>
+                        form.setValue("includeExperimentNames", val)
+                      }
+                    />
+                  </div>
+                </div>
+              </>
             )}
           </div>
         </>


### PR DESCRIPTION
### Features and Changes

New option for SDK Connections to include names for experiments and variations in the SDK Payload.  This setting only applies to Visual Editor experiments currently.

This PR is a prerequisite for #1139 .  When we refactor feature flag experiments, this setting will also take effect there.