### PR TITLE
i18n [pt-BR] docs

### DIFF
--- a/docs/docs/integrations/slack.mdx
+++ b/docs/docs/integrations/slack.mdx
@@ -22,17 +22,26 @@ The first step to setting up the GrowthBook Slack integration is to create a new
 
 Navigate to your workspace’s apps and choose to create a new app. You can get to that page directly [here](https://api.slack.com/apps?new_app=1).
 
-![](../../static/images/integrations/slack/slack-create-app.png)
+<img
+  src="/images/integrations/slack/slack-create-app.png"
+  alt="Create an app from scratch"
+/>
 
 Name the app and choose the workspace. In this case we are created the app named GrowthBook Alerts and are picking the GrowthBook Dev workspace.
 
-![](../../static/images/integrations/slack/slack-name-app-choose-workspace.png)
+<img
+  src="/images/integrations/slack/slack-name-app-choose-workspace.png"
+  alt="Name your app and choose Growthbook Dev workspace"
+/>
 
 ### Create an Incoming Webhook
 
 We will be alerting via Slack's incoming webhooks functionality. Under the **Basic Information** tab of your app, click on **Incoming Webhooks**.
 
-![](../../static/images/integrations/slack/slack-incoming-webhooks.png)
+<img
+  src="/images/integrations/slack/slack-incoming-webhooks.png"
+  alt="Select Incoming Webhooks"
+/>
 
 ### Subscribe a channel to alerts
 
@@ -40,11 +49,17 @@ Click on the button at the bottom of the **Incoming Webhooks** page that says **
 
 You will be asked to install the app into your workspace. Choose the desired channel you'd like to receive notifications in.
 
-![](../../static/images/integrations/slack/slack-install-flow.png)
+<img
+  src="/images/integrations/slack/slack-install-flow.png"
+  alt="Choose and allow a channel"
+/>
 
 Once you've completed this flow, you will see a URL available for you to copy. Save this value for later.
 
-![](../../static/images/integrations/slack/slack-copy-webhook-url.png)
+<img
+  src="/images/integrations/slack/slack-copy-webhook-url.png"
+  alt="Activate and copy webhook url"
+/>
 
 ## Add the Slack integration to GrowthBook
 
@@ -52,7 +67,10 @@ Next step is to login to the GrowthBook app and visit the **Slack** tab under **
 
 Click the **Create a Slack integration** button. You should see a modal pop up with some fields for configuring the Slack integration.
 
-![](../../static/images/integrations/slack/slack-gb-new-integration.png)
+<img
+  src="/images/integrations/slack/slack-gb-new-integration.png"
+  alt="Add Slack integration information"
+/>
 
 ### Copy the Slack app credentials
 
@@ -77,7 +95,10 @@ After configuring all the fields, press **Create** to save your new Slack integr
 
 You can also edit these fields at any point if you make a mistake.
 
-![](../../static/images/integrations/slack/slack-gb-config.png)
+<img
+  src="/images/integrations/slack/slack-gb-config.png"
+  alt="Edit Slack integration if you need it"
+/>
 
 ### Adding more alerts
 

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -21,7 +21,7 @@ const config = {
   // to replace "en" with "zh-Hans".
   i18n: {
     defaultLocale: "en",
-    locales: ["en"],
+    locales: ["en", "pt-BR"],
   },
 
   presets: [
@@ -76,6 +76,10 @@ const config = {
           srcDark: "img/growthbook-docslogo-dark.png",
         },
         items: [
+          {
+            type: 'localeDropdown',
+            position: 'left',
+          },
           {
             to: "/",
             label: "Docs",

--- a/docs/i18n/pt-BR/code.json
+++ b/docs/i18n/pt-BR/code.json
@@ -1,0 +1,388 @@
+{
+  "theme.ErrorPageContent.title": {
+    "message": "This page crashed.",
+    "description": "The title of the fallback page when the page crashed"
+  },
+  "theme.ErrorPageContent.tryAgain": {
+    "message": "Try again",
+    "description": "The label of the button to try again when the page crashed"
+  },
+  "theme.NotFound.title": {
+    "message": "Página não encontrada",
+    "description": "The title of the 404 page"
+  },
+  "theme.NotFound.p1": {
+    "message": "Não foi possível encontrar o que você está procurando.",
+    "description": "The first paragraph of the 404 page"
+  },
+  "theme.NotFound.p2": {
+    "message": "Entre em contato com o proprietário do site que lhe trouxe para cá e lhe informe que o link está quebrado.",
+    "description": "The 2nd paragraph of the 404 page"
+  },
+  "theme.admonition.note": {
+    "message": "note",
+    "description": "The default label used for the Note admonition (:::note)"
+  },
+  "theme.admonition.tip": {
+    "message": "tip",
+    "description": "The default label used for the Tip admonition (:::tip)"
+  },
+  "theme.admonition.danger": {
+    "message": "danger",
+    "description": "The default label used for the Danger admonition (:::danger)"
+  },
+  "theme.admonition.info": {
+    "message": "info",
+    "description": "The default label used for the Info admonition (:::info)"
+  },
+  "theme.admonition.caution": {
+    "message": "caution",
+    "description": "The default label used for the Caution admonition (:::caution)"
+  },
+  "theme.BackToTopButton.buttonAriaLabel": {
+    "message": "Volte para o topo",
+    "description": "The ARIA label for the back to top button"
+  },
+  "theme.blog.archive.title": {
+    "message": "Arquivo",
+    "description": "The page & hero title of the blog archive page"
+  },
+  "theme.blog.archive.description": {
+    "message": "Arquivo",
+    "description": "The page & hero description of the blog archive page"
+  },
+  "theme.blog.paginator.navAriaLabel": {
+    "message": "Navegação da página de listagem do blog",
+    "description": "The ARIA label for the blog pagination"
+  },
+  "theme.blog.paginator.newerEntries": {
+    "message": "Conteúdo mais novo",
+    "description": "The label used to navigate to the newer blog posts page (previous page)"
+  },
+  "theme.blog.paginator.olderEntries": {
+    "message": "Conteúdo mais antigo",
+    "description": "The label used to navigate to the older blog posts page (next page)"
+  },
+  "theme.blog.post.paginator.navAriaLabel": {
+    "message": "Navegação da página de postagem do blog",
+    "description": "The ARIA label for the blog posts pagination"
+  },
+  "theme.blog.post.paginator.newerPost": {
+    "message": "Postagem mais nova",
+    "description": "The blog post button label to navigate to the newer/previous post"
+  },
+  "theme.blog.post.paginator.olderPost": {
+    "message": "Postagem mais antiga",
+    "description": "The blog post button label to navigate to the older/next post"
+  },
+  "theme.blog.post.plurals": {
+    "message": "Uma postagem|{count} postagens",
+    "description": "Pluralized label for \"{count} posts\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.blog.tagTitle": {
+    "message": "{nPosts} marcadas com \"{tagName}\"",
+    "description": "The title of the page for a blog tag"
+  },
+  "theme.tags.tagsPageLink": {
+    "message": "Ver todas os Marcadores",
+    "description": "The label of the link targeting the tag list page"
+  },
+  "theme.colorToggle.ariaLabel": {
+    "message": "Switch between dark and light mode (currently {mode})",
+    "description": "The ARIA label for the navbar color mode toggle"
+  },
+  "theme.colorToggle.ariaLabel.mode.dark": {
+    "message": "dark mode",
+    "description": "The name for the dark color mode"
+  },
+  "theme.colorToggle.ariaLabel.mode.light": {
+    "message": "light mode",
+    "description": "The name for the light color mode"
+  },
+  "theme.docs.breadcrumbs.home": {
+    "message": "Home page",
+    "description": "The ARIA label for the home page in the breadcrumbs"
+  },
+  "theme.docs.breadcrumbs.navAriaLabel": {
+    "message": "Breadcrumbs",
+    "description": "The ARIA label for the breadcrumbs"
+  },
+  "theme.docs.DocCard.categoryDescription": {
+    "message": "{count} items",
+    "description": "The default description for a category card in the generated index about how many items this category includes"
+  },
+  "theme.docs.paginator.navAriaLabel": {
+    "message": "Navigação das páginas de documentação",
+    "description": "The ARIA label for the docs pagination"
+  },
+  "theme.docs.paginator.previous": {
+    "message": "Anterior",
+    "description": "The label used to navigate to the previous doc"
+  },
+  "theme.docs.paginator.next": {
+    "message": "Próxima",
+    "description": "The label used to navigate to the next doc"
+  },
+  "theme.docs.tagDocListPageTitle.nDocsTagged": {
+    "message": "Um documento selecionado|{count} documentos selecionados",
+    "description": "Pluralized label for \"{count} docs tagged\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.docs.tagDocListPageTitle": {
+    "message": "{nDocsTagged} com \"{tagName}\"",
+    "description": "The title of the page for a docs tag"
+  },
+  "theme.docs.versionBadge.label": {
+    "message": "Version: {versionLabel}"
+  },
+  "theme.docs.versions.unreleasedVersionLabel": {
+    "message": "Esta é uma documentação não lançada para {siteTitle} {versionLabel}.",
+    "description": "The label used to tell the user that he's browsing an unreleased doc version"
+  },
+  "theme.docs.versions.unmaintainedVersionLabel": {
+    "message": "Esta é a documentação para {siteTitle} {versionLabel}, que não é mais mantida ativamente.",
+    "description": "The label used to tell the user that he's browsing an unmaintained doc version"
+  },
+  "theme.docs.versions.latestVersionSuggestionLabel": {
+    "message": "Para a documentação atualizada, veja: {latestVersionLink} ({versionLabel}).",
+    "description": "The label used to tell the user to check the latest version"
+  },
+  "theme.docs.versions.latestVersionLinkLabel": {
+    "message": "última versão",
+    "description": "The label used for the latest version suggestion link label"
+  },
+  "theme.common.editThisPage": {
+    "message": "Editar essa página",
+    "description": "The link label to edit the current page"
+  },
+  "theme.common.headingLinkTitle": {
+    "message": "Link direto para o título",
+    "description": "Title for link to heading"
+  },
+  "theme.lastUpdated.atDate": {
+    "message": " em {date}",
+    "description": "The words used to describe on which date a page has been last updated"
+  },
+  "theme.lastUpdated.byUser": {
+    "message": " por {user}",
+    "description": "The words used to describe by who the page has been last updated"
+  },
+  "theme.lastUpdated.lastUpdatedAtBy": {
+    "message": "Última atualização {atDate}{byUser}",
+    "description": "The sentence used to display when a page has been last updated, and by who"
+  },
+  "theme.navbar.mobileVersionsDropdown.label": {
+    "message": "Versions",
+    "description": "The label for the navbar versions dropdown on mobile view"
+  },
+  "theme.common.skipToMainContent": {
+    "message": "Pular para o conteúdo principal",
+    "description": "The skip to content label used for accessibility, allowing to rapidly navigate to main content with keyboard tab/enter navigation"
+  },
+  "theme.tags.tagsListLabel": {
+    "message": "Marcadores:",
+    "description": "The label alongside a tag list"
+  },
+  "theme.AnnouncementBar.closeButtonAriaLabel": {
+    "message": "Fechar",
+    "description": "The ARIA label for close button of announcement bar"
+  },
+  "theme.blog.sidebar.navAriaLabel": {
+    "message": "Blog recent posts navigation",
+    "description": "The ARIA label for recent posts in the blog sidebar"
+  },
+  "theme.CodeBlock.copied": {
+    "message": "Copiado",
+    "description": "The copied button label on code blocks"
+  },
+  "theme.CodeBlock.copyButtonAriaLabel": {
+    "message": "Copiar código para a área de transferência",
+    "description": "The ARIA label for copy code blocks button"
+  },
+  "theme.CodeBlock.copy": {
+    "message": "Copiar",
+    "description": "The copy button label on code blocks"
+  },
+  "theme.CodeBlock.wordWrapToggle": {
+    "message": "Toggle word wrap",
+    "description": "The title attribute for toggle word wrapping button of code block lines"
+  },
+  "theme.DocSidebarItem.toggleCollapsedCategoryAriaLabel": {
+    "message": "Toggle the collapsible sidebar category '{label}'",
+    "description": "The ARIA label to toggle the collapsible sidebar category"
+  },
+  "theme.navbar.mobileLanguageDropdown.label": {
+    "message": "Languages",
+    "description": "The label for the mobile language switcher dropdown"
+  },
+  "theme.TOCCollapsible.toggleButtonLabel": {
+    "message": "Nessa página",
+    "description": "The label used by the button on the collapsible TOC component"
+  },
+  "theme.blog.post.readMore": {
+    "message": "Leia Mais",
+    "description": "The label used in blog post item excerpts to link to full blog posts"
+  },
+  "theme.blog.post.readMoreLabel": {
+    "message": "Read more about {title}",
+    "description": "The ARIA label for the link to full blog posts from excerpts"
+  },
+  "theme.blog.post.readingTime.plurals": {
+    "message": "Leitura de um minuto|Leitura de {readingTime} minutos",
+    "description": "Pluralized label for \"{readingTime} min read\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.docs.sidebar.collapseButtonTitle": {
+    "message": "Fechar painel lateral",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.docs.sidebar.collapseButtonAriaLabel": {
+    "message": "Fechar painel lateral",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.navbar.mobileSidebarSecondaryMenu.backButtonLabel": {
+    "message": "← Voltar para o menu principal",
+    "description": "The label of the back button to return to main menu, inside the mobile navbar sidebar secondary menu (notably used to display the docs sidebar)"
+  },
+  "theme.docs.sidebar.expandButtonTitle": {
+    "message": "Expandir painel lateral",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.docs.sidebar.expandButtonAriaLabel": {
+    "message": "Expandir painel lateral",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.SearchBar.seeAll": {
+    "message": "See all {count} results"
+  },
+  "theme.SearchPage.documentsFound.plurals": {
+    "message": "Um documento encontrado|{count} documentos encontrados",
+    "description": "Pluralized label for \"{count} documents found\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.SearchPage.existingResultsTitle": {
+    "message": "Resultado da busca por \"{query}\"",
+    "description": "The search page title for non-empty query"
+  },
+  "theme.SearchPage.emptyResultsTitle": {
+    "message": "Busca da documentação",
+    "description": "The search page title for empty query"
+  },
+  "theme.SearchPage.inputPlaceholder": {
+    "message": "Digite sua busca aqui",
+    "description": "The placeholder for search page input"
+  },
+  "theme.SearchPage.inputLabel": {
+    "message": "Buscar",
+    "description": "The ARIA label for search page input"
+  },
+  "theme.SearchPage.algoliaLabel": {
+    "message": "Busca feita por Algolia",
+    "description": "The ARIA label for Algolia mention"
+  },
+  "theme.SearchPage.noResultsText": {
+    "message": "Nenhum resultado foi encontrado",
+    "description": "The paragraph for empty search result"
+  },
+  "theme.SearchPage.fetchingNewResults": {
+    "message": "Trazendo novos resultados...",
+    "description": "The paragraph for fetching new search results"
+  },
+  "theme.SearchBar.label": {
+    "message": "Buscar",
+    "description": "The ARIA label and placeholder for search button"
+  },
+  "theme.SearchModal.searchBox.resetButtonTitle": {
+    "message": "Clear the query",
+    "description": "The label and ARIA label for search box reset button"
+  },
+  "theme.SearchModal.searchBox.cancelButtonText": {
+    "message": "Cancel",
+    "description": "The label and ARIA label for search box cancel button"
+  },
+  "theme.SearchModal.startScreen.recentSearchesTitle": {
+    "message": "Recent",
+    "description": "The title for recent searches"
+  },
+  "theme.SearchModal.startScreen.noRecentSearchesText": {
+    "message": "No recent searches",
+    "description": "The text when no recent searches"
+  },
+  "theme.SearchModal.startScreen.saveRecentSearchButtonTitle": {
+    "message": "Save this search",
+    "description": "The label for save recent search button"
+  },
+  "theme.SearchModal.startScreen.removeRecentSearchButtonTitle": {
+    "message": "Remove this search from history",
+    "description": "The label for remove recent search button"
+  },
+  "theme.SearchModal.startScreen.favoriteSearchesTitle": {
+    "message": "Favorite",
+    "description": "The title for favorite searches"
+  },
+  "theme.SearchModal.startScreen.removeFavoriteSearchButtonTitle": {
+    "message": "Remove this search from favorites",
+    "description": "The label for remove favorite search button"
+  },
+  "theme.SearchModal.errorScreen.titleText": {
+    "message": "Unable to fetch results",
+    "description": "The title for error screen of search modal"
+  },
+  "theme.SearchModal.errorScreen.helpText": {
+    "message": "You might want to check your network connection.",
+    "description": "The help text for error screen of search modal"
+  },
+  "theme.SearchModal.footer.selectText": {
+    "message": "to select",
+    "description": "The explanatory text of the action for the enter key"
+  },
+  "theme.SearchModal.footer.selectKeyAriaLabel": {
+    "message": "Enter key",
+    "description": "The ARIA label for the Enter key button that makes the selection"
+  },
+  "theme.SearchModal.footer.navigateText": {
+    "message": "to navigate",
+    "description": "The explanatory text of the action for the Arrow up and Arrow down key"
+  },
+  "theme.SearchModal.footer.navigateUpKeyAriaLabel": {
+    "message": "Arrow up",
+    "description": "The ARIA label for the Arrow up key button that makes the navigation"
+  },
+  "theme.SearchModal.footer.navigateDownKeyAriaLabel": {
+    "message": "Arrow down",
+    "description": "The ARIA label for the Arrow down key button that makes the navigation"
+  },
+  "theme.SearchModal.footer.closeText": {
+    "message": "to close",
+    "description": "The explanatory text of the action for Escape key"
+  },
+  "theme.SearchModal.footer.closeKeyAriaLabel": {
+    "message": "Escape key",
+    "description": "The ARIA label for the Escape key button that close the modal"
+  },
+  "theme.SearchModal.footer.searchByText": {
+    "message": "Search by",
+    "description": "The text explain that the search is making by Algolia"
+  },
+  "theme.SearchModal.noResultsScreen.noResultsText": {
+    "message": "No results for",
+    "description": "The text explains that there are no results for the following search"
+  },
+  "theme.SearchModal.noResultsScreen.suggestedQueryText": {
+    "message": "Try searching for",
+    "description": "The text for the suggested query when no results are found for the following search"
+  },
+  "theme.SearchModal.noResultsScreen.reportMissingResultsText": {
+    "message": "Believe this query should return results?",
+    "description": "The text for the question where the user thinks there are missing results"
+  },
+  "theme.SearchModal.noResultsScreen.reportMissingResultsLinkText": {
+    "message": "Let us know.",
+    "description": "The text for the link to report missing results"
+  },
+  "theme.SearchModal.placeholder": {
+    "message": "Search docs",
+    "description": "The placeholder of the input of the DocSearch pop-up modal"
+  },
+  "theme.tags.tagsPageTitle": {
+    "message": "Marcadores",
+    "description": "The title of the tag list page"
+  }
+}

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current.json
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current.json
@@ -1,0 +1,198 @@
+{
+  "version.label": {
+    "message": "Próxima",
+    "description": "Rótulo para a versão atual"
+  },
+  "sidebar.docs.category.Self-Hosting Guide": {
+    "message": "Guia de Hospedagem Própria",
+    "description": "O rótulo para a categoria Guia de Hospedagem Própria na barra de documentação lateral"
+  },
+  "sidebar.docs.category.Platform": {
+    "message": "Plataforma",
+    "description": "O rótulo para a categoria Platform na barra de documentação lateral"
+  },
+  "sidebar.docs.category.How to Guides": {
+    "message": "Guias Detalhados",
+    "description": "O rótulo para a categoria How to Guides na barra de documentação lateral"
+  },
+  "sidebar.docs.category.SDKs": {
+    "message": "SDKs",
+    "description": "O rótulo para a categoria SDKs na barra de documentação lateral"
+  },
+  "sidebar.docs.category.Tools": {
+    "message": "Ferramentas",
+    "description": "O rótulo para a categoria Tools na barra de documentação lateral"
+  },
+  "sidebar.docs.category.Statistics": {
+    "message": "Estatísticas",
+    "description": "O rótulo para a categoria Statistics na barra de documentação lateral"
+  },
+  "sidebar.docs.category.Integrations": {
+    "message": "Integrações",
+    "description": "O rótulo para a categoria Integrations na barra de documentação lateral"
+  },
+  "sidebar.docs.link.Guide to A/B Testing": {
+    "message": "Guia de Teste A/B",
+    "description": "The label for link Guide to A/B Testing na barra de documentação lateral, direcionando para https://docs.growthbook.io/open-guide-to-ab-testing.v1.0.pdf"
+  },
+  "sidebar.docs.doc.What is GrowthBook?": {
+    "message": "O que é o GrowthBook?",
+    "description": "O rótulo para o item What is GrowthBook? na barra de documentação lateral, direcionando para overview"
+  },
+  "sidebar.docs.doc.Data Sources": {
+    "message": "Fontes de Dados",
+    "description": "O rótulo para o item Data Sources na barra de documentação lateral, direcionando para app/data-sources"
+  },
+  "sidebar.docs.doc.Metrics": {
+    "message": "Métricas",
+    "description": "O rótulo para o item Metrics na barra de documentação lateral, direcionando para app/metrics"
+  },
+  "sidebar.docs.doc.Features": {
+    "message": "Feature Flags",
+    "description": "O rótulo para o item Features na barra de documentação lateral, direcionando para app/features"
+  },
+  "sidebar.docs.doc.Experiments": {
+    "message": "Experimentos",
+    "description": "O rótulo para o item Experiments na barra de documentação lateral, direcionando para app/experiments"
+  },
+  "sidebar.docs.doc.Dimensions": {
+    "message": "Dimensões",
+    "description": "O rótulo para o item Dimensions na barra de documentação lateral, direcionando para app/dimensions"
+  },
+  "sidebar.docs.doc.Visual Editor": {
+    "message": "Editor Visual",
+    "description": "O rótulo para o item Visual Editor na barra de documentação lateral, direcionando para app/visual-editor"
+  },
+  "sidebar.docs.doc.API": {
+    "message": "API",
+    "description": "O rótulo para o item API na barra de documentação lateral, direcionando para app/api"
+  },
+  "sidebar.docs.doc.Webhooks": {
+    "message": "Webhooks",
+    "description": "O rótulo para o item Webhooks na barra de documentação lateral, direcionando para app/webhooks"
+  },
+  "sidebar.docs.doc.Next.js": {
+    "message": "Next.js",
+    "description": "O rótulo para o item Next.js na barra de documentação lateral, direcionando para guide/nextjs-and-growthbook"
+  },
+  "sidebar.docs.doc.Create React App": {
+    "message": "Create React App",
+    "description": "O rótulo para o item Create React App na barra de documentação lateral, direcionando para guide/create-react-app-and-growthbook"
+  },
+  "sidebar.docs.doc.Google Analytics (GA4)": {
+    "message": "Google Analytics (GA4)",
+    "description": "O rótulo para o item Google Analytics (GA4) na barra de documentação lateral, direcionando para guide/GA4-google-analytics"
+  },
+  "sidebar.docs.doc.Google Analytics (UA)": {
+    "message": "Google Analytics (UA)",
+    "description": "O rótulo para o item Google Analytics (UA) na barra de documentação lateral, direcionando para guide/GA-universal-analytics"
+  },
+  "sidebar.docs.doc.Google Tag Manager (GTM)": {
+    "message": "Google Tag Manager (GTM)",
+    "description": "O rótulo para o item Google Tag Manager (GTM) na barra de documentação lateral, direcionando para guide/google-tag-manager-and-growthbook"
+  },
+  "sidebar.docs.doc.Mixpanel": {
+    "message": "Mixpanel",
+    "description": "O rótulo para o item Mixpanel na barra de documentação lateral, direcionando para guide/mixpanel"
+  },
+  "sidebar.docs.doc.Matomo": {
+    "message": "Matomo",
+    "description": "O rótulo para o item Matomo na barra de documentação lateral, direcionando para guide/matomo"
+  },
+  "sidebar.docs.doc.BigQuery": {
+    "message": "BigQuery",
+    "description": "O rótulo para o item BigQuery na barra de documentação lateral, direcionando para guide/bigquery"
+  },
+  "sidebar.docs.doc.Rudderstack": {
+    "message": "Rudderstack",
+    "description": "O rótulo para o item Rudderstack na barra de documentação lateral, direcionando para guide/rudderstack"
+  },
+  "sidebar.docs.doc.Rudderstack + Next.js": {
+    "message": "Rudderstack + Next.js",
+    "description": "O rótulo para o item Rudderstack + Next.js na barra de documentação lateral, direcionando para guide/rudderstack-and-nextjs-with-growthbook"
+  },
+  "sidebar.docs.doc.Javascript": {
+    "message": "Javascript",
+    "description": "O rótulo para o item Javascript na barra de documentação lateral, direcionando para lib/js"
+  },
+  "sidebar.docs.doc.React": {
+    "message": "React",
+    "description": "O rótulo para o item React na barra de documentação lateral, direcionando para lib/react"
+  },
+  "sidebar.docs.doc.Vue.js": {
+    "message": "Vue.js",
+    "description": "O rótulo para o item Vue.js na barra de documentação lateral, direcionando para lib/vue"
+  },
+  "sidebar.docs.doc.PHP)": {
+    "message": "PHP",
+    "description": "O rótulo para o item PHP) na barra de documentação lateral, direcionando para lib/php"
+  },
+  "sidebar.docs.doc.Ruby": {
+    "message": "Ruby",
+    "description": "O rótulo para o item Ruby na barra de documentação lateral, direcionando para lib/ruby"
+  },
+  "sidebar.docs.doc.Python": {
+    "message": "Python",
+    "description": "O rótulo para o item Python na barra de documentação lateral, direcionando para lib/python"
+  },
+  "sidebar.docs.doc.Java": {
+    "message": "Java",
+    "description": "O rótulo para o item Java na barra de documentação lateral, direcionando para lib/java"
+  },
+  "sidebar.docs.doc.C#": {
+    "message": "C#",
+    "description": "O rótulo para o item C# na barra de documentação lateral, direcionando para lib/csharp"
+  },
+  "sidebar.docs.doc.Go": {
+    "message": "Go",
+    "description": "O rótulo para o item Go na barra de documentação lateral, direcionando para lib/go"
+  },
+  "sidebar.docs.doc.Kotlin (Android)": {
+    "message": "Kotlin (Android)",
+    "description": "O rótulo para o item Kotlin (Android) na barra de documentação lateral, direcionando para lib/kotlin"
+  },
+  "sidebar.docs.doc.Flutter": {
+    "message": "Flutter",
+    "description": "O rótulo para o item Flutter na barra de documentação lateral, direcionando para lib/flutter"
+  },
+  "sidebar.docs.doc.Swift (iOS)": {
+    "message": "Swift (iOS)",
+    "description": "O rótulo para o item Swift (iOS) na barra de documentação lateral, direcionando para lib/swift"
+  },
+  "sidebar.docs.doc.Build Your Own": {
+    "message": "Crie o seu próprio",
+    "description": "O rótulo para o item Build Your Own na barra de documentação lateral, direcionando para lib/build-your-own"
+  },
+  "sidebar.docs.doc.Chrome Extension": {
+    "message": "Extensão para Chrome ",
+    "description": "O rótulo para o item Chrome Extension na barra de documentação lateral, direcionando para tools/chrome-extension"
+  },
+  "sidebar.docs.doc.Visual Studio Code Extension": {
+    "message": "Extensão para Visual Studio Code",
+    "description": "O rótulo para o item Visual Studio Code Extension na barra de documentação lateral, direcionando para tools/vscode-extension"
+  },
+  "sidebar.docs.doc.Command Line Interface (CLI)": {
+    "message": "Command Line Interface (CLI)",
+    "description": "O rótulo para o item Command Line Interface (CLI) na barra de documentação lateral, direcionando para tools/cli"
+  },
+  "sidebar.docs.doc.Statistics Overview": {
+    "message": "Visão Geral da Análise Estatística",
+    "description": "O rótulo para o item Statistics Overview na barra de documentação lateral, direcionando para statistics/overview"
+  },
+  "sidebar.docs.doc.Aggregate Data": {
+    "message": "Agregação de Dados",
+    "description": "O rótulo para o item Aggregate Data na barra de documentação lateral, direcionando para statistics/aggregation"
+  },
+  "sidebar.docs.doc.Regression Adjustment (CUPED)": {
+    "message": "Ajuste de Regressão (CUPED)",
+    "description": "O rótulo para o item Regression Adjustment (CUPED) na barra de documentação lateral, direcionando para statistics/cuped"
+  },
+  "sidebar.docs.doc.Slack alerts": {
+    "message": "Alertas no Slack",
+    "description": "O rótulo para o item Slack alerts na barra de documentação lateral, direcionando para integrations/slack"
+  },
+  "sidebar.docs.doc.FAQ": {
+    "message": "FAQ",
+    "description": "O rótulo para o item FAQ na barra de documentação lateral, direcionando para faq"
+  }
+}

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/app/api.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/app/api.mdx
@@ -9,22 +9,22 @@ import Pill from '@site/src/components/Pill';
 
 # API <Pill>beta</Pill>
 
-GrowthBook offers a full REST API for interacting with the GrowthBook application. This is currently in **beta** as we add more authenticated API routes and features.
+GrowthBook oferece uma API REST completa. Atualmente se encontra em **beta** enquanto novas rotas e funcionalidades são adicionadas.
 
-[View REST API Docs](/api/)
+[Visualizar documentação da API REST](/api/)
 
-## SDK Connection Endpoints
+## Endpoints de Conexão com o SDK
 
-In addition to the REST API above, there is one additional readonly endpoint - the SDK Connection Endpoint.
+Complementando a API REST acima, existem endpoints adicionais em um modo somente leitura - Os Endpoints de Conexão com o SDK.
 
-The SDK Connection Endpoint provides readonly access to a subset of your feature flag data, just enough for the [GrowthBook SDKs](/lib) to assign values to users. They are meant to be public and do not require authentication to view.
+Os Endpoints de Conexão com o SDK disponibilizam um acesso somente leitura à um subconjunto de dados das suas feature flags, apenas o necessário para que os [SDKs do Growthbook](/lib) estabeleçam valores para as pessoas usuárias. Eles são públicos e não necessitam de autenticação para visualizar.
 
-In **GrowthBook Cloud**, the SDK Connection Endpoints are served from our global CDN: `https://cdn.growthbook.io/api/features/...`. If you are self-hosting, you can run the [GrowthBook Proxy server](/self-host/proxy), which provides built-in caching and performance optimizations.
+No **GrowthBook Cloud**, os Endpoints de Conexão com o SDK são servidos em nossa CDN global: `https://cdn.growthbook.io/api/features/...`. Se você estiver usando uma hospedagem própria, você pode executar o [servidor Proxy do GrowthBook](/self-host/proxy), que fornece cache e otimizações de performance.
 
-SDK Connection Endpoints are scoped to a single Environment (e.g. `dev` or `production`) and can also be scoped to a single Project. Manage all of your SDK Connections on the **Features -> SDKs** page.
+Os Endpoints de Conexão com o SDK estão restritos a um único Ambiente (Ex: `dev` ou `produção`) e também restritos um único Projeto. Você pode gerenciar todas as suas Conexões de SDK na página **Features -> SDKs**.
 
 <details className="mb-3">
-<summary className="cursor-pointer">Typescript Type Definition</summary>
+<summary className="cursor-pointer">Definição de Tipos no Typescript</summary>
 
 ```ts
 interface SDKEndpointResponse {
@@ -54,7 +54,7 @@ interface FeatureDefinitionRule {
 </details>
 
 <details className="mb-3">
-<summary className="cursor-pointer">Example JSON object</summary>
+<summary className="cursor-pointer">Exemplo objeto JSON</summary>
 
 ```json
 {
@@ -80,12 +80,12 @@ interface FeatureDefinitionRule {
 
 </details>
 
-### Encryption
+### Criptografia
 
-If you've enabled encryption for your SDK endpoint, the response format changes:
+Se você habilitar a criptografia no endpoint do SDK, o formato de resposta será alterado:
 
 <details className="mb-3">
-<summary className="cursor-pointer">Typescript Type Definition</summary>
+<summary className="cursor-pointer">Definição de Tipos no Typescript</summary>
 
 ```ts
 interface SDKEncryptedEndpointResponse {
@@ -97,7 +97,7 @@ interface SDKEncryptedEndpointResponse {
 </details>
 
 <details className="mb-3">
-<summary className="cursor-pointer">Example JSON object</summary>
+<summary className="cursor-pointer">Exemplo objeto JSON</summary>
 
 ```json
 {
@@ -108,4 +108,4 @@ interface SDKEncryptedEndpointResponse {
 
 </details>
 
-You will need to decrypt the features first before passing into the SDK. Our front-end SDKs (Javascript and React) handle this for you automatically and we're in the process of adding built-in support to our other SDKs.
+Você precisará descriptografar as features antes de passar para o SDK. Os SDKs de front-end (Javascript e React) gerenciam isso automaticamente e estamos no processo de adicionar o mesmo para nossos outros SDKs.

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/app/api.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/app/api.mdx
@@ -1,0 +1,111 @@
+---
+title: API
+description: API
+sidebar_label: API
+slug: api
+---
+
+import Pill from '@site/src/components/Pill';
+
+# API <Pill>beta</Pill>
+
+GrowthBook offers a full REST API for interacting with the GrowthBook application. This is currently in **beta** as we add more authenticated API routes and features.
+
+[View REST API Docs](/api/)
+
+## SDK Connection Endpoints
+
+In addition to the REST API above, there is one additional readonly endpoint - the SDK Connection Endpoint.
+
+The SDK Connection Endpoint provides readonly access to a subset of your feature flag data, just enough for the [GrowthBook SDKs](/lib) to assign values to users. They are meant to be public and do not require authentication to view.
+
+In **GrowthBook Cloud**, the SDK Connection Endpoints are served from our global CDN: `https://cdn.growthbook.io/api/features/...`. If you are self-hosting, you can run the [GrowthBook Proxy server](/self-host/proxy), which provides built-in caching and performance optimizations.
+
+SDK Connection Endpoints are scoped to a single Environment (e.g. `dev` or `production`) and can also be scoped to a single Project. Manage all of your SDK Connections on the **Features -> SDKs** page.
+
+<details className="mb-3">
+<summary className="cursor-pointer">Typescript Type Definition</summary>
+
+```ts
+interface SDKEndpointResponse {
+  status: 200;
+  features: {
+    [key: string]: FeatureDefinition
+  }
+}
+
+interface FeatureDefinition {
+  defaultValue: any;
+  rules?: FeatureDefinitionRule[];
+}
+
+interface FeatureDefinitionRule {
+  force?: any;
+  weights?: number[];
+  variations?: any[];
+  hashAttribute?: string;
+  namespace?: [string, number, number];
+  key?: string;
+  coverage?: number;
+  condition?: any;
+}
+```
+
+</details>
+
+<details className="mb-3">
+<summary className="cursor-pointer">Example JSON object</summary>
+
+```json
+{
+  "status": 200,
+  "features": {
+    "feature-key": {
+      "defaultValue": true
+    },
+    "another-feature": {
+      "defaultValue": "blue",
+      "rules": [
+        {
+          "condition": {
+            "browser": "firefox"
+          },
+          "force": "green"
+        }
+      ]
+    }
+  }
+}
+```
+
+</details>
+
+### Encryption
+
+If you've enabled encryption for your SDK endpoint, the response format changes:
+
+<details className="mb-3">
+<summary className="cursor-pointer">Typescript Type Definition</summary>
+
+```ts
+interface SDKEncryptedEndpointResponse {
+  status: 200;
+  encryptedFeatures: string;
+}
+```
+
+</details>
+
+<details className="mb-3">
+<summary className="cursor-pointer">Example JSON object</summary>
+
+```json
+{
+  "status": 200,
+  "encryptedFeatures": "abcdef123456GHIJKL0987654321..."
+}
+```
+
+</details>
+
+You will need to decrypt the features first before passing into the SDK. Our front-end SDKs (Javascript and React) handle this for you automatically and we're in the process of adding built-in support to our other SDKs.

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/app/datasources.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/app/datasources.mdx
@@ -1,7 +1,7 @@
 ---
 title: Data Sources
 description: Learn about data sources supported by GrowthBook
-sidebar_label: Data Sources
+sidebar_label: Data Sources 🚧
 id: data-sources
 slug: datasources
 ---

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/app/datasources.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/app/datasources.mdx
@@ -1,0 +1,296 @@
+---
+title: Data Sources
+description: Learn about data sources supported by GrowthBook
+sidebar_label: Data Sources
+id: data-sources
+slug: datasources
+---
+
+# Data Sources
+
+Data Sources are how GrowthBook connects to your analytics tool or data warehouse to automatically pull metrics and experiment results.
+
+You can use GrowthBook without a Data Source, but the user experience is not as smooth since you must enter all data manually.
+
+Below are the currently supported Data Sources (links are to our detail guides):
+
+- Redshift
+- Snowflake
+- [BigQuery](/guide/bigquery)
+- ClickHouse
+- AWS Athena
+- Postgres
+- MySQL/MariaDB
+- MsSQL/SQL Server
+- PrestoDB (and Trino)
+- Databricks
+- [Mixpanel](/guide/mixpanel)
+- Google Analytics
+
+## Configuration Settings
+
+To effectively use GrowthBook, you'll need to tell us a little about the shape of your data.
+
+### SQL Sources
+
+GrowthBook can work with your existing SQL data, no matter what shape or format it is in, whether you have a strongly normalized schema, a single “events” table with JSON fields, or something in between.
+
+#### Predefined Schemas
+
+GrowthBook supports a few popular database schemas out-of-the-box:
+
+- Segment
+- Snowplow
+- [RudderStack](/guide/rudderstack)
+- [Matomo](/guide/matomo)
+- Amplitude (Snowflake only)
+- Google Analytics 4 (BigQuery only)
+- Jitsu
+- Firebase
+- Heap Analytics
+- Freshpaint
+
+After connecting to your data source, you will be prompted to choose one of the above. If your data is in a different format, you can also decide to define a custom schema.
+
+#### Custom Schemas
+
+GrowthBook just needs you to write a couple SQL queries in order to query your data. Writing this SQL is a (mostly) one-time setup task. After building out this library of queries, they can easily be reused across many experiments.
+
+Don’t worry about the potentially huge number of rows returned by these raw queries. They are never run directly as-is and are instead combined, filtered, and aggregated as part of larger queries. Most of the final queries run by GrowthBook result in fewer than 10 rows returned.
+
+In the spirit of transparency, any time a query is run, you should see a `View Queries` link in the app to view the raw SQL sent to the data warehouse. This can help with debugging or let you move a query into a tool like Mode Analytics for more advanced analysis.
+
+##### Identifier Types
+
+These are all of the types of identifiers you use to split traffic in an experiment and track metric conversions. Common examples are `user_id`, `anonymous_id`, `device_id`, and `ip_address`.
+
+##### Experiment Assignment Queries
+
+An experiment assignment query returns which users were part of which experiment, what variation they saw, and when they saw it. Each assignment query is tied to a single identifier type (defined above). You can also have multiple assignment queries if you store that data in different tables, for example one from your email system and one from your back-end.
+
+The end result of the query should return data like this:
+
+| user_id | timestamp           | experiment_id  | variation_id |
+| ------- | ------------------- | -------------- | ------------ |
+| 123     | 2021-08-23-10:53:04 | my-button-test | 0            |
+| 456     | 2021-08-23 10:53:06 | my-button-test | 1            |
+
+The above assumes the identifier type you are using is `user_id`. If you are using a different identifier, you would use a different column name.
+
+Here's an example query you might use:
+
+```sql
+SELECT
+  user_id,
+  received_at as timestamp,
+  experiment_id,
+  variation_id
+FROM
+  events
+WHERE
+  event_type = 'viewed experiment'
+```
+
+Make sure to return the exact column names that GrowthBook is expecting. If your table’s columns use a different name, add an alias in the SELECT list (e.g. `SELECT original_column as new_column`).
+
+##### Duplicate Rows
+
+If a user sees an experiment multiple times, you should return multiple rows in your assignment query, one for each time the user was exposed to the experiment.
+
+This helps us detect when users were exposed to more than one variation, and eventually may be useful in helping build interesting time series.
+
+##### Experiment Dimensions
+
+In addition to the standard 4 columns above, you can also select additional dimension columns. For example, `browser` or `referrer`. These extra columns can be used to drill down into experiment results.
+
+##### Identifier Join Tables
+
+If you have multiple identifier types and want to be able to auto-merge them together during analysis, you also need to define identifier join tables. For example, if your experiment is assigned based on `device_id`, but the conversion metric only has a `user_id` column.
+
+These queries are very simple and just need to return columns for each of the identifier types being joined. For example:
+
+```sql
+SELECT user_id, device_id FROM logins
+```
+
+##### SQL Template Variables
+
+Within your queries, there are several placeholder variables you can use. These will be replaced with strings before being run based on your experiment. This can be useful for giving hints to SQL optimization engines to improve query performance.
+
+The variables are:
+
+- **startDate** - `YYYY-MM-DD HH:mm:ss` of the earliest data that needs to be included
+- **startYear** - Just the `YYYY` of the startDate
+- **startMonth** - Just the `MM` of the startDate
+- **startDay** - Just the `DD` of the startDate
+- **startDateUnix** - Unix timestamp of the startDate (seconds since Jan 1, 1970)
+- **endDate** - `YYYY-MM-DD HH:mm:ss` of the latest data that needs to be included
+- **endYear** - Just the `YYYY` of the endDate
+- **endMonth** - Just the `MM` of the endDate
+- **endDay** - Just the `DD` of the endDate
+- **endDateUnix** - Unix timestamp of the endDate (seconds since Jan 1, 1970)
+- **experimentId** - Either a specific experiment id OR `%` if you should include all experiments
+
+For example:
+
+```sql
+SELECT
+  user_id,
+  anonymous_id,
+  received_at as timestamp,
+  experiment_id,
+  variation_id
+FROM
+  experiment_viewed
+WHERE
+  received_at BETWEEN '{{ startDate }}' AND '{{ endDate }}'
+  AND experiment_id LIKE '{{ experimentId }}'
+```
+
+**Note:** The inserted values do not have surrounding quotes, so you must add those yourself (e.g. use `'{{ startDate }}'` instead of just `{{ startDate }}`)
+
+#### Jupyter Notebook Query Runner
+
+This setting is only required if you want to export experiment results as a Jupyter Notebook.
+
+There is no one standard way to store credentials or run SQL queries from Jupyter notebooks, so GrowthBook lets you define your own Python function.
+
+It needs to be called `runQuery`, accept a single string argument named `sql`, and return a pandas data frame.
+
+Here's an example for a Postgres (or Redshift) data source:
+
+```python
+import os
+import psycopg2
+import pandas as pd
+from sqlalchemy import create_engine, text
+
+# Use environment variables or similar for passwords!
+password = os.getenv('POSTGRES_PW')
+connStr = f'postgresql+psycopg2://user:{password}@localhost'
+dbConnection = create_engine(connStr).connect();
+
+def runQuery(sql):
+  return pd.read_sql(text(sql), dbConnection)
+```
+
+**Note:** This python source is stored as plain text in the database. Do not hard-code passwords or sensitive info. Use environment variables (shown above) or another credential store instead.
+
+### Mixpanel
+
+We have a detailed guide on how to set up [Mixpanel with GrowthBook](/guide/mixpanel).
+
+We query Mixpanel using JQL. We have sensible defaults for the event and property names, but you can change them if you need to.
+
+- Experiments
+  - **View Experiments Event** - The name of the event you are firing when a user is put into a variation
+  - **Experiment Id Property** - The property name that stores the experiment tracking key
+  - **Variation Id Property** - The property name that stores the variation the user was assigned
+  - **Extra UserId Property** - _(optional)_ An additional event property to add to the groupBy (`distinct_id` is always included)
+
+Below is an example of what your Mixpanel tracking call would look like in Javascript using our default settings:
+
+```js
+// Tracking Callback for GrowthBook SDK
+const growthbook = new GrowthBook({
+  ...,
+  trackingCallback: function(experiment, result) {
+    mixpanel.track("$experiment_started", {
+      "Experiment name": experiment.key,
+      "Variant name":  result.variationId,
+      "$source": "growthbook",
+    })
+  }
+})
+```
+
+When we query Mixpanel, we group users by `distinct_id`. We recommend passing this into the GrowthBook SDK as the user attribute `id`. This varies by platform, but below is a javascript example:
+
+```js
+// Can only get the distinct_id after Mixpanel fully loads
+mixpanel.init("YOUR PROJECT TOKEN", {
+  loaded: function (mixpanel) {
+    growthbook.setAttributes({
+      ...growthbook.getAttributes(),
+      id: mixpanel.get_distinct_id(),
+    });
+  },
+});
+```
+
+## Connection Info
+
+Connection info is encrypted twice - once within the app and again by the database when persisting to disk.
+
+GrowthBook only runs `SELECT` queries (or the equivalent for non-SQL data sources). We still always recommend creating read-only users with as few permissions as possible.
+
+If you are using GrowthBook Cloud (https://app.growthbook.io), make sure to whitelist the ip address `52.70.79.40` if applicable.
+
+Most data sources have straight forward connection parameters like host, port, username, password. A few of the data sources, documented below, require some extra work to connect.
+
+### AWS Athena
+
+Unlike other database engines with their own user management system, Athena uses IAM for authentication.
+
+We recommend creating a new role with readonly permissions for GrowthBook. The managed [Quick Sight Policy](https://docs.aws.amazon.com/athena/latest/ug/awsquicksightathenaaccess-managed-policy.html) is a good starting point.
+
+For the S3 results url, we recommend naming your bucket with the prefix `aws-athena-query-results-`
+
+There are two ways to provide AWS credentials to GrowthBook:
+
+1. Auto-discovery from environment variables or instance metadata (only available when self-hosting)
+2. Enter the accessKeyId and secretAccessKey in the GrowthBook UI when connecting to the data source
+
+### BigQuery
+
+We have a detailed page on how to set up [BiqQuery with GrowthBook](/guide/bigquery).
+
+The quick guide:
+
+You must first create a Service Account in Google with the following roles:
+
+- Data Viewer
+- Metadata Viewer
+- Job User
+
+There are two ways to provide credentials to GrowthBook:
+
+1. Auto-discovery from environment variables or GCP metadata (only available when self-hosting)
+2. Upload a JSON key file for the service account
+
+### Snowflake
+
+We support multiple [account identifier](https://docs.snowflake.com/en/user-guide/admin-account-identifier.html) formats when connecting to Snowflake. An example account identifier is `xy12345.us-east-2.aws`.
+
+If you are self-hosting GrowthBook, you can send queries to Snowflake through an Authenticated Proxy.
+
+To enable this, set a `SNOWFLAKE_PROXY` environment variable in your GrowthBook container. Here is an example:
+
+```
+SNOWFLAKE_PROXY=http://username:password@proxyserver.company.com:80
+```
+
+### Mixpanel
+
+You must first create a Service Account in Mixpanel under your [Project Settings](https://mixpanel.com/settings/project#serviceaccounts).
+
+To add the datasource in GrowthBook, you will need:
+
+1.  The service account username
+2.  The service account secret
+3.  Your project id (found on the Project Settings Overview page)
+
+### Universal Google Analytics
+
+**Note:** The Google Analytics data source only supports older Universal Analytics properties. If you are using Google Analytics v4 property, you need to [setup a BigQuery export](https://support.google.com/analytics/answer/9823238) and use that as the data source instead.
+
+Because of Universal Analytics tracking limitations, a user can only be in a single experiment at a time. We highly recommend using a more full-featured data source for serious A/B testing.
+
+We require 4 things to query the Universal Analytics API:
+
+1.  OAuth Authorization
+2.  View ID (found in Admin -> View Settings)
+3.  Custom Dimension Index
+4.  Custom Dimension Delimiter (defaults to `:`)
+
+When tracking experiment views, the custom dimension value must be formatted as `{experiment-key}{delimiter}{variation-index}`. For example: `my-test:0` for the control and `my-test:1` for the 1st variation.

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/app/dimensions.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/app/dimensions.mdx
@@ -1,7 +1,7 @@
 ---
 title: Dimensions
 description: Drill down into experiment results
-sidebar_label: Dimensions
+sidebar_label: Dimensions 🚧
 slug: dimensions
 ---
 

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/app/dimensions.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/app/dimensions.mdx
@@ -1,0 +1,125 @@
+---
+title: Dimensions
+description: Drill down into experiment results
+sidebar_label: Dimensions
+slug: dimensions
+---
+
+# Dimensions
+
+Dimensions let you drill down into experiment results. For example, if you define a `browser` dimension, you can
+see how Safari users behaved vs Chrome.
+
+Be careful, the more dimensions and metrics you look at for an experiment, the more likely you are to see false positives -
+something that looks significant when it really isn't. For example, if you break out results by country, it's pretty likely that at least one of the 100+
+countries in your dataset will be signficantly different just by random chance.
+
+It's best to treat dimensions as an exploratory tool and not something to directly draw conclusions from.
+The two best use cases are identfying bugs (the `browser` example) and getting ideas for dedicated follow-up experiments.
+
+Dimensions are supported for both Mixpanel and SQL data sources.
+
+## SQL
+
+There are two types of dimensions for SQL data sources: Experiment Dimensions and User Dimensions. Experiment dimensions are more reliable for producing unbiased experiment analyses because we can always know the dimension that is associated with the first experiment exposure for a unit. Using dimension data that could be affected by the experiment (e.g. that is collected _after_ the first experiment exposure) could bias dimension drill-downs. Therefore, use user dimensions with caution, and we suggest using immutable dimensions as your user dimensions (e.g. the first client the user ever used, or the first country the user ever logged in from).
+
+For all experiment analyses, we only ever choose one dimension per user, to avoid the aforementioned issues with potential bias. For Experiment Dimensions, we select the dimension associated with the user's first exposure event for the experiment. For User Dimensions, we strongly suggest only having one dimension value per user, as we cannot discern what dimension a user had before the experiment. Instead, we simply choose the `MAX(value)` for the user dimension.
+
+### Experiment Dimensions
+
+These are attributes that are specific to the point-in-time that a user was put into an experiment. For example, `browser` or `referrer`.
+
+Instead of a standalone SQL query, experiment dimensions are simply extra columns you return from the Experiment assignment query defined for your data source.
+
+As an example, if you set the following as your experiment assignment query:
+
+```sql
+SELECT
+  user_id,
+  received_at as timestamp,
+  experiment_id,
+  variation_id,
+  browser
+FROM
+  experiment_viewed
+```
+
+The first 4 columns are standard, but `browser` is a custom one that can be used as an Experiment Dimension.
+
+### User Dimensions
+
+These are attributes of your users that are relatively stable over time, and ideally, do not change over the course of an experiment. For example, `cohort`, `initial age group`, or `first client used`.
+
+A user dimension is defined by a simple SQL query that returns two columns: an identifier and `value`. The name of the identifier column depends on which identifier type the dimension is using. Remember, when using these for analysis, we will pick the `MAX(value)` for each user, and therefore it is best to only have one value per user.
+
+Here's an example SQL:
+
+```sql
+-- Assumes identifier type is "user_id"
+SELECT
+  user_id,
+  plan_type as value
+FROM
+  subscriptions
+```
+
+It's best to keep the number of unique values for a dimension small if possible to avoid the False Positive issues discussed above. We automatically cap the number at 20, but you can do it youself if you want more control. Here's an example for a "country" dimension:
+
+```sql
+SELECT
+  user_id,
+  (
+    CASE WHEN country = 'us' THEN 'US'
+    WHEN country = 'uk' THEN 'UK'
+    ELSE 'Other' END
+  ) as value
+FROM
+  users
+```
+
+:::tip
+
+You can use SQL template variables in dimension queries just like you can with metrics. See the [SQL Template Variables](/app/metrics#sql-template-variables) page for more details.
+
+:::
+
+## Mixpanel
+
+For mixpanel, there is just a single type of dimension that is based on event properties (at this time Mixpanel user properties are not supported).
+
+For simple dimensions, you can just put the event property name directly. For example: `$browser`.
+
+We also support complex javascript expressions. For example:
+
+```
+event.properties.$browser.match(/chrome/i) ? "Chrome" : "Other"
+```
+
+For more complex expressions, you can wrap your code in an anonymous function:
+
+```
+(() => {
+  // ...some complex logic
+  return dimensionValue
+})()
+```
+
+You can also reference the experiment start/end date in your javascript expression. For example, if you add a super event called `userRegistrationDate` that stores a unix timestamp, you could make a `New vs Existing` dimension like this:
+
+```
+event.properties.userRegistrationDate >= {{ startDateUnix }} ? "new" : "existing"
+```
+
+The variables you can reference are:
+
+- **startDate** - `YYYY-MM-DD HH:mm:ss` of the earliest data that needs to be included
+- **startYear** - Just the `YYYY` of the startDate
+- **startMonth** - Just the `MM` of the startDate
+- **startDay** - Just the `DD` of the startDate
+- **startDateUnix** - Unix timestamp of the startDate (seconds since Jan 1, 1970)
+- **endDate** - `YYYY-MM-DD HH:mm:ss` of the latest data that needs to be included
+- **endYear** - Just the `YYYY` of the endDate
+- **endMonth** - Just the `MM` of the endDate
+- **endDay** - Just the `DD` of the endDate
+- **endDateUnix** - Unix timestamp of the endDate (seconds since Jan 1, 1970)
+- **experimentId** - Either a specific experiment id OR `%` if you should include all experiments

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/app/experiments.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/app/experiments.mdx
@@ -1,0 +1,170 @@
+---
+title: Experiments
+description: Analyze your experiment results from your data source.
+sidebar_label: Experiments
+slug: experiments
+---
+
+# Experiment Configuration and Analysis
+
+The Experiments section in GrowthBook is all about analyzing raw experiment results in a data source.
+
+Before analyzing results, you need to actually run the experiment. This can be done in several ways:
+
+- [Feature Flags](/app/features) (most common)
+- Running an inline experiment directly with our [SDKs](/lib)
+- Our [Visual Editor](/app/visual) (beta)
+- Your own custom variation assignment / bucketing system
+
+When you go to add an experiment in GrowthBook, it will first look in your [data source](/app/datasources) for any new experiment ids and prompt you to import them. If none are found, you can enter the experiment settings yourself.
+
+## Adding an Experiment
+
+You can add an experiment analysis to GrowthBook in a few ways.
+
+**Starting an Experiment Analysis from a Feature**
+
+This is the easiest way to start a new analysis if you have a Feature set up.
+Navigate to the Feature of interest and click "View results" in the Experiment Rule of the Feature.
+
+**Importing an Experiment Analysis from your Data Source**
+
+You can also import an analysis directly from your Data Source using your configured Experiment Assignment Source.
+If you navigate to the Experiment page in the left toolbar and click Add Experiment, you'll see the following panel.
+
+<img
+  src="/images/import-experiment-modal.png"
+  alt="Experiment Import Modal"
+  style={{ width: 600, margin: "0 auto" }}
+/>
+
+On this modal you can either create an experiment using some metadata that we infer from your metric source using the Import buttons on the right hand side.
+You can also manually create an experiment from scratch.
+
+## Experiment Configuration
+
+There are several different ways to configure your experiment analysis.
+
+### Experiment Metadata
+
+The top left of the experiment page shows the experiment name, tags description, hypothesis, and variation metadata. You can edit these fields as you see fit to help describe and categorize your experiment.
+
+### Experiment Settings
+
+Here is where much of your experiment analysis is configured. Many of the fields here have some text explaining how they affect your analysis. Here are a few of them in more detail:
+
+**Experiment Id** - This is the key that will be used when filtering your experiment assignment source to query experiment exposure data.
+
+**Activation Metric** - A binomial metric that will filter the users in your analysis to only those who have converted on this binomial metric. This should only be used if activation is expected to be independent of experiment assignment. If an experiment affects the activation metric directly, then there is the potential for bias in your analysis.
+
+**Metric Conversion Windows** - Each user has a conversion window defined by when they were exposed to the experiment. If a user was recently exposed to the experiment, or was exposed near the end of the experiment, they may not have had the full window to convert before the analysis window closes. You may exclude these users with "In-Progress Conversions" if you want your experiment averages to only include those who have had the full window to convert.
+
+**Attribution Model**
+
+Attribution models deal with how we attribute metric values (conversions, counts, any arbitrary value to be aggregated at the unit level) to individual units (e.g. users). They rely on the concept of "conversion windows" which is discussed more in depth on the [Metric documentation page](metrics).
+
+There are 2 **Attribution Models** that experiments can use:
+
+- **First Exposure** uses a single conversion window based on the first time the user sees a particular experiment. The conversion window runs from the exposure timestamp + the conversion delay hours and for however many hours the conversion window is set to. For example, if the delay is 12 hours, and the window is 24 hours, then we will aggregate the metric values for each user from 12-36 hours after their first experiment exposure.
+- **Experiment Duration** uses a single conversion window that extends from their first exposure + conversion delay until the end of the experiment or phase. For example, if the delay is 12 hours, then the conversion window will extend from 12 hours after each user is bucketed until the present time or the end of the experiment/phase, if specified.
+
+This table summarizes the two models:
+
+| Attribution Model   | Conversion Window Start                | Conversion Window End                              |
+| ------------------- | -------------------------------------- | -------------------------------------------------- |
+| First Exposure      | First Exposure Date + Conversion Delay | Conversion Window Start + Conversion Window Length |
+| Experiment Duration | First Exposure Date + Conversion Delay | End of Experiment                                  |
+
+Currently, all analyses will use the "First Exposure" model by default. The _Experiment Duration_ model replaced the _All Exposures_ model in early 2023.
+
+### Experiment Metrics
+
+You can add metrics as goal metrics, guardrail metrics, or both. You also can add "Metric Overrides" which provide experiment-specific controls for metrics, allowing you to override the metric's defaults for, for example, conversion windows and risk thresholds.
+
+### Experiment Phases
+
+Experiment Phases can help you filter the dates used in the experiment analysis. Be very careful using phases. If you move the start date of the phase to past the start date of the experiment (and users were not re-randomized across phases), then your analysis could suffer from carryover bias. It is best to always look at the full history of an experiment if possible.
+
+## Experiment Results Table (Bayesian Engine)
+
+Once imported or added, go to the Results tab to view and update the results:
+
+![Results Table](/images/results-table.png)
+
+Each row of this table is a different metric.
+
+**Risk** tells you how much you are predicted to lose if you choose the selected variation as the winner and you are wrong. Anything below 0.25% is highlighted green indicating the risk is very low and it's safe to call the experiment. You can use the dropdown to see the risk of choosing a different winner.
+
+**Value** is the conversion rate or average value per user. In small print you can see the raw numbers used to calculate this.
+
+**Chance to Beat Control** tells you the probability that the variation is better. Anything above 95% is highlighted green indicating a very clear winner. Anything below 5% is highlighted red, indicating a very clear loser. Anything in between is grayed out indicating it's inconclusive. If that's the case, there's either no measurable difference or you haven't gathered enough data yet.
+
+**Percent Change** shows how much better/worse the variation is compared to the control. It is a probability density graph and the thicker the area, the more likely the true percent change will be there.
+As you collect more data, the tails of the graphs will shorten, indicating more certainty around the estimates.
+
+## Experiment Results Table (Frequentist Engine)
+
+You can also choose to analyze results using a Frequentist engine that conducts simple t-tests for differences in means and displays the commensurate p-values and confidence intervals. You can switch to the frequentist engine under **General -> Settings -> Experiment Settings -> Statistics Engine**.
+
+![Frequentist Setting](/images/engine-setting.png)
+
+If you select the "Frequentist" engine, when you navigate to the results tab to view and update the results, you will see the following results table:
+
+![Results Table (Frequentist)](/images/results-table-frequentist.png)
+
+Everything is the same as above except for three key changes:
+
+1. There is no longer a risk column, as the concept is not easily replicated in frequentist statistics.
+2. The **Chance to Beat Control** column has been replaced with the **P-value** column.
+   The p-value is the probability that the percent change for a variant would have been observed if the true percent change
+   were zero. When the p-value is less than 0.05 and the percent change is in the preferred direction, we highlight the cell green, indicating it is a clear winner. When the p-value is less than 0.05 and the percent change is _opposite_ the preferred diection, we highlight the cell red, indicating the variant is a clear loser on this metric.
+3. We now present a 95% confidence interval rather than a posterior probability density plot.
+
+## Sample Ratio Mismatch (SRM)
+
+Every experiment automatically checks for a Sample Ratio Mismatch and will warn you if found. This happens when you expect a certain traffic split (e.g. 50/50) but you see something significantly different (e.g. 46/54). We only show this warning if the p-value is less than `0.001`, which means it's extremely unlikely to occur by chance.
+
+![SRM Warning](/images/srm.png)
+
+Like the warning says, you shouldn't trust the results since they are likely misleading. Instead, find and fix the source of the bug and restart the experiment.
+
+## Guardrails
+
+Guardrail metrics are ones that you want to keep an eye on, but aren't trying to specifically improve with your experiment.
+For example, if you are trying to improve page load times, you may add revenue as a guardrail since you don't want
+to inadvertantly harm it.
+
+Guardrail results show up beneath the main table of metrics and you can click on one to expand it and show more info. They are colored based on "Chance of Being Worse", which is just the complement of "Chance to Beat Control". If there are more than 2 variations, the max value is used to determine the overall color.
+A "Chance of Being Worse" less than 65% is green and of no concern. Between 65% and 90% is yellow and should be watched as more data comes in. Above 90% is red and you may consider stopping the experiment. If we don't have enough data to accurately predict the "Chance of Being Worse", we will color the metric grey.
+
+![Guardrails](/images/guardrails.png)
+
+If you select the frequentist engine, we instead use yellow to represent a metric moving in the wrong direction at all (regardless of statistical significance), red to represent a metric moving in the wrong direction with a two-sided t-test p-value below 0.05, and green to represent a metric moving in the right direction with a p-value below 0.05. Otherwise the cell is unshaded if the metric is moving in the right direction but not statistically significant at the 0.05 level.
+
+## Dimensions
+
+### User or Experiment
+
+If you have defined dimensions for your data source, you can use the **Dimension** dropdown to drill down into your results. For SQL integrations (e.g. non-MixPanel) GrowthBook enforces one dimension per user to prevent statistical bias and to simplify analyses. For more on how GrowthBook picks a dimension when more than one are present for a user, see the [Dimensions documentation](/app/dimensions).
+This is very useful for debugging (e.g. if Safari is down, but the other browsers are fine, you may have an implementation bug) or for better understanding your experiment effects.
+
+Be careful. The more metrics and dimensions you look at, the more likely you are to see a false positive. If you find something that looks
+surprising, it's often worth a dedicated follow-up experiment to verify that it's real.
+
+### Date
+
+The date dimension shows a time series of the count of users _first_ exposed to an experiment, as well as effects when comparing users _first_ bucketed on each day.
+
+Take the following results, for example.
+
+<img
+  src="/images/experiment-date-results.png"
+  alt="Experiment Date Results"
+  style={{ width: 400, margin: "0 auto" }}
+/>
+
+In the first graph, we see the number of users who were first exposed to the experiment on that day.
+
+In the second graph, we see the uplift for the two variations relative to the control _for all users first bucketed on that day_. That means that the values on October 7 show that users first exposed to the experiment on October 7 had X% uplift relative to control, when pooling all of the data in their relevant conversion window. It does not mean show the difference in conversions across variations on October 7 for all previously bucketed users.
+
+That analysis, and other time series analyses, are on GrowthBook's roadmap.

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/app/experiments.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/app/experiments.mdx
@@ -1,7 +1,7 @@
 ---
 title: Experiments
 description: Analyze your experiment results from your data source.
-sidebar_label: Experiments
+sidebar_label: Experiments 🚧
 slug: experiments
 ---
 

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/app/features.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/app/features.mdx
@@ -1,7 +1,7 @@
 ---
 title: Features
 description: Learn about feature flags and how to use them in your application.
-sidebar_label: Features
+sidebar_label: Features 🚧
 slug: features
 ---
 

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/app/features.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/app/features.mdx
@@ -1,0 +1,211 @@
+---
+title: Features
+description: Learn about feature flags and how to use them in your application.
+sidebar_label: Features
+slug: features
+---
+
+# Features
+
+Feature Flags enable you to change your application's behavior from within the
+GrowthBook UI. For example, turn on/off a sales banner or change the
+title of your pricing page.
+
+You can set a global value for everyone, use advanced targeting to
+assign values to users, and run experiments to see which value is
+better.
+
+Feature flags aren't limited to front-end changes. Use them on your back-end
+to gradually release a new ML model or enable new fields in an API response.
+
+## Environments
+
+GrowthBook comes with one environment by default (**production**), but you can add as many as you need.
+
+Feature flags can be enabled and disabled on a per-environment basis.
+
+When a feature is disabled in an environment, it will always evaluate to `null` and ignore any other targeting or override rules.
+
+:::note
+
+It's possible for a feature to be enabled for an environment and still be considered "off". This happens when its value is set to `false`, `null`, `0`, or an empty string.
+
+:::
+
+## Feature Keys
+
+Every feature is defined by a unique **key**. This is what the engineering team will reference in their code when they check the value of a feature. Feature keys cannot be changed after they are created, so take care when choosing one.
+
+Feature keys must be all lowercase and include only letters, numbers, hyphens, and underscores.
+
+Some examples of good feature keys:
+
+- `onboarding-checklist` - ON/OFF flag for a feature
+- `checkout_button_color` - The color of the checkout button
+- `results-per-page` - Number of search results to show per page
+
+## Feature Types
+
+Features can be a simple ON/OFF flag or a more complex data type (strings, numbers or JSON).
+
+ON/OFF flags can support any of the following use cases:
+
+- Decouple code deploys and releases
+- Kill switch for production
+- Gradual rollout of features
+- Complex targeting and segmentation of features
+- Validating feature releases with A/B tests
+
+More complex data types enable you to have more than 2 possible states. For example, if you have a checkout button that is currently blue, you could use an ON/OFF flag called `new-button-color` that sets it to red when ON, but this is pretty limiting since you can't easily try other colors in the future. Instead, if you use a flag `button-color` and make it a string data type, you can easily set the value to 'blue', 'red', 'green', or any other color without changing your code.
+
+## Targeting Attributes
+
+Feature values can be targeted to specific users or groups of users. In order for this to work, you must pass targeting attributes into the GrowthBook SDK and also list them in the GrowthBook App.
+
+This is an example of specifying the targeting attributes in the SDK:
+
+```ts
+growthbook.setAttributes({
+  id: user.id,
+  email: user.email,
+  country: user.country,
+  url: window.location.href,
+  userAgent: navigator.userAgent,
+  admin: user.isAdmin,
+  age: user.age,
+});
+```
+
+You can update the attributes in the GrowthBook App under **Settings** > **Attributes**:
+
+![List of targeting attributes](/images/edit-targeting-attributes.png)
+
+:::note
+
+The actual values of the targeting attributes (e.g. the user ids, emails, etc.) are never sent to GrowthBook. They are only stored in memory locally within the SDK. This architecture
+eliminates huge potential security holes and keeps your user's PII safe and secure.
+
+:::
+
+Each attribute has 3 parts:
+
+- The **attribute name** itself. This is how the attribute will be referenced in the SDK.
+- The **data type** of the attribute
+  - String - freeform text
+  - Number - Floats or integers
+  - Boolean - true or false
+  - Array of strings - useful for things like "tags"
+  - Array of numbers - useful anytime you have multiple numeric values
+  - Enum - When there are only a small list of pre-defined values it could take
+- Whether or not it's an **identifier**. Identifiers are attributes which uniquely identify something - typically either a person, account, company, or device.
+
+## Override Rules
+
+Every feature has a default value that is served to all users. The real power comes when you define **override rules** that let you run experiments and/or change the value based on targeting attributes.
+
+Override rules are defined separately for each environment (e.g. dev and production). This way you can, for example, test an experiment rule in dev first before deploying it to production.
+
+The first matching rule for a user will be applied, so order matters. If there are no matching rules, the default value will be used.
+
+### Conditions
+
+Rules can specify conditions to limit which users the rule applies to. These conditions are evaluated against the targeting attributes in the SDK.
+
+There is an easy-to-use UI for simple conditions:
+
+![Rule conditions UI](/images/rule-conditions.png)
+
+In advanced mode, you can specify conditions using the MongoDB query syntax. This enables you to have nested logic, advanced array operators and more. Here's an example:
+
+```js
+// Either the user's name starts with "john"
+// OR they are over 65 and have a kid who's a doctor
+{
+  "$or": [
+    {
+      "name": { "$regex": "^john" }
+    },
+    {
+      "age": { "$gt": 65 },
+      "kids": {
+        "$elemMatch": {
+          "profession": "doctor"
+        }
+      }
+    }
+  ]
+}
+```
+
+**Note**: We use the MongoDB query syntax because it is easy to read and write and is well documented. The conditions are never actually executed against a database. Instead, our SDKs include a light-weight interpreter for this syntax that runs entirely locally.
+
+### Forced Value
+
+The simplest type of override rule is a "Forced Value" rule. This forces everyone who matches the targeting condition to get a specific value. For example, you could have a feature default to OFF and use force rules to turn it ON for a specific list of countries.
+
+### Percentage Rollout
+
+Percentage Rollout rules let you gradually release a feature value to a random sample of your users.
+
+Rollouts are most useful when you want to make sure a new feature doesn't break your app or site. You start by releasing to maybe 10% of users. Then after a while if your metrics look ok, you increase to 30% and so on.
+
+For rollout rules, you choose a user attribute to use for the random sample. Users with the same attribute value will be treated the same (either included or not included in the rollout). For example, if you choose a "company" attribute, then multiple employees in the same company will get the same experience.
+
+### Experiments
+
+The last type of rule is an Experiment. This randomly splits users into buckets, assigns them different values, and tracks that assignment in your data warehouse or analytics tool.
+
+Experiments are most useful when you aren't sure which value to assign yet.
+
+Here's what an Experiment rule looks like in the GrowthBook UI:
+
+![Experiment rule](/images/experiment-rule.png)
+
+In the vast majority of cases, you want to split traffic based on either a logged-in user id or some sort of anonymous identifier like a device id or session cookie. As long as the user has the same value for this attribute, they will always get assigned the same variation. In rare cases, you may want to use an attribute such as company or account instead, which ensures all users in a company will see the same thing.
+
+If the total variation percents add up to less than 100%, the remaining users will skip the rule and fall through to the next matching one (or the default value) instead.
+
+You can analyze the result of an Experiment the same way you would any experiment in GrowthBook.
+
+#### Namespaces
+
+If you have multiple experiments that may conflict with each other (e.g. background color and text color), you can use **namespaces** to make the conflicting experiments mutually exclusive.
+
+Users are randomly assigned a value from 0 to 1 for each namespace. Each experiment in a namespace has a range of values that it includes. Users are only part of an experiment if their value falls within the experiment's range. So as long as two experiment ranges do not overlap, users will only ever be in at most one of them.
+
+![Namespaces](/images/namespaces.png)
+
+Before you can use namespaces, you must configure them under Settings > Namespaces.
+
+## Publishing Changes
+
+When you make changes to a feature's definition (default value or override rules), a new draft version of the feature is created automatically. This draft version is unpublished and is only visible within the GrowthBook UI, not to your users.
+
+You can continue adding changes to this draft and when you are ready, publish them all at once with an optional commit message.
+
+![Draft Modal](/images/draft-modal.png)
+
+## Revision History
+
+You can view a revision history for your feature and revert to a past version by clicking the blue revert icons. This will create a new draft based on the past version you select, so you can safely review it (or add additional changes) before deciding to publish.
+
+![Feature Revisions](/images/feature-revisions.png)
+
+## SDK Connections
+
+In order to use feature flags in your application, you need to create an **SDK Connection** in GrowthBook.
+
+At a high level, the SDK Connection generates a unique clientKey which grants read-only access to feature flags in a specific environment. The SDKs use this to fetch feature flag states and override rules from the GrowthBook API.
+
+On GrowthBook Cloud, we have a global CDN in front of the API (https://cdn.growthbook.io) to ensure low latency responses from anywhere in the world. The CDN has a 30-second TTL, so changes to a feature may take a little time to be reflected.
+
+### GrowthBook Proxy
+
+We also offer a pre-built proxy server you can deploy on your own infrastructure.
+This can be put in front of either GrowthBook Cloud or a self-hosted GrowthBook instance.
+
+The GrowthBook Proxy offers the following benefits:
+
+- Fast - Requests served from an in-memory cache close to your app servers
+- Scalable - A single Proxy server can handle over 10,000 reqs/second. Horizontally scale for more
+- Responsive - Changes in GrowthBook are rolled out to users in under a second

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/app/index.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/app/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: User Guide to the Platform
-sidebar_label: Platform
+sidebar_label: Platform 🚧
 slug: /app
 ---
 

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/app/index.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/app/index.mdx
@@ -1,0 +1,16 @@
+---
+title: User Guide to the Platform
+sidebar_label: Platform
+slug: /app
+---
+
+# User Guide
+
+The following sections will walk you through the various parts of the GrowthBook app.
+
+- Create [Features](/app/features), integrate with our [SDKs](/lib), and use them to run experiments or control the behavior of your app.
+- Connect to your [Data Sources](/app/datasources) so we can pull experiment results automatically.
+- Define your [Metrics](/app/metrics) that you can use as goals and guardrails for experiments.
+- Create an [Experiment Analysis](/app/experiments) and view results.
+- Enable our [Visual Editor](/app/visual) (beta) so non-technical teammates can launch experiments without writing code.
+- Integrate with our [API](/app/api) or [Webhooks](/app/webhooks) for a more seamless experience.

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/app/metrics.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/app/metrics.mdx
@@ -1,0 +1,296 @@
+---
+title: Metrics
+description: Learn about defining the metrics you will use in your A/B test results
+sidebar_label: Metrics
+slug: metrics
+---
+
+# Metrics
+
+Metrics are what your experiments are trying to improve (or at least not hurt). GrowthBook has a very flexible and powerful way to define metrics.
+
+## Conversion Types
+
+Metrics can have different units and statistical distributions. Below are the ones GrowthBook supports:
+
+| Conversion Type | Description                     | Example          | Default aggregation (SQL) |
+| --------------- | ------------------------------- | ---------------- | ------------------------- |
+| binomial        | A simple yes/no conversion      | Created Account  | 1/0 per unit              |
+| count           | Sums conversion values per user | Pages per Visit  | `SUM(value)` per unit     |
+| duration        | How much time something takes   | Time on Site     | `SUM(value)` per unit     |
+| revenue         | The revenue gained/lost         | Revenue per User | `SUM(value)` per unit     |
+
+For experiment analysis, each of these metric types uses some aggregation (often defaulting to `SUM`) per user and then takes an average with respect to the total number of users. In the case of SQL metrics, the only meaningful difference between count, duration, and revenue is how we render the units in the metric and experiment results pages.
+
+## Query settings
+
+For metrics to work, you need to tell GrowthBook how to query the data from your data source. There are a few ways to do this depending on your data source.
+
+### 1. SQL (recommended)
+
+If your data source supports SQL, this is the preferred way to define metrics. You can use joins, subselects, or anything else supported by your SQL dialect.
+
+Your SELECT statement should return one row per "conversion event". This may be a page view, a purchase, a session, or something else. The end result should look like this:
+
+| user_id | timestamp           | value |
+| ------- | ------------------- | ----- |
+| 123     | 2021-08-23 12:45:14 | 10    |
+| 456     | 2021-08-23 12:45:15 | 5.25  |
+
+Metrics can support one or more types of identifiers. The above example assumes the metric only supports a single id type called `user_id`, but you would add additional columns if you need to support other ones.
+
+#### Non-binomial metrics
+
+For count, revenue, and duration metrics metric types, the value represents the count, duration, or revenue from that single conversion event. In the case of multiple rows for a single user, the values will be summed together or we will use a custom aggregation that you can specify.
+
+Therefore a `count` metric can really be any arbitrary metric whose `value` you want to sum at the user level before taking an average per variation.
+
+If you use Segment to populate your data warehouse, the SQL for a `Revenue per User` metric might look like this:
+
+```sql
+SELECT
+  -- Assuming you support 2 identifier types - 'user_id' and 'anonymous_id'
+  user_id as user_id,
+  anon_id as anonymous_id,
+  received_at as timestamp,
+  grand_total as value
+FROM
+  purchases
+```
+
+If you wanted to count the number of conversion rows per user, you can simply set `1 as value` in your SQL query and then the default SUM aggregation will count the number of rows per user.
+
+#### Binomial metrics
+
+Binomial metrics don't need a `value` column (the existence of a row means the user converted). You would only need to return the following columns, representing users and when they "converted" on this binomial metric:
+
+| user_id | timestamp           |
+| ------- | ------------------- |
+| 789     | 2022-08-23 12:45:14 |
+| 111     | 2022-08-23 12:45:15 |
+
+When we go to conduct experiment analysis, any `user_id` that has a conversion in the appropriate time window will be counted as a `1`, while all other users will be counted as a `0`. Then we can compute the proportion of users in an experiment variation who converted.
+
+#### SQL Template Variables
+
+Within your queries, there are several placeholder variables you can use. These will be replaced with strings before being run. This can be useful for giving hints to SQL optimization engines to improve query performance.
+
+The variables are:
+
+- **startDate** - `YYYY-MM-DD HH:mm:ss` of the earliest data that needs to be included
+- **startYear** - Just the `YYYY` of the startDate
+- **startMonth** - Just the `MM` of the startDate
+- **startDay** - Just the `DD` of the startDate
+- **startDateUnix** - Unix timestamp of the startDate (seconds since Jan 1, 1970)
+- **endDate** - `YYYY-MM-DD HH:mm:ss` of the latest data that needs to be included
+- **endYear** - Just the `YYYY` of the endDate
+- **endMonth** - Just the `MM` of the endDate
+- **endDay** - Just the `DD` of the endDate
+- **endDateUnix** - Unix timestamp of the endDate (seconds since Jan 1, 1970)
+- **experimentId** - Either a specific experiment id OR `%` if you should include all experiments
+
+For example:
+
+```sql
+SELECT
+  user_id as user_id,
+  received_at as timestamp
+FROM
+  registrations
+WHERE
+  received_at BETWEEN '{{ startDate }}' AND '{{ endDate }}'
+```
+
+:::note
+
+The inserted values do not have surrounding quotes, so you must add those yourself (e.g. use `'{{ startDate }}'` instead of just `{{ startDate }}`)
+
+:::
+
+#### Denominator (Ratio / Funnel Metrics)
+
+By default, metrics are evaluated against all users in an experiment: `(# users who converted) / (# users in experiment)`
+
+You can instead choose another metric to use as the denominator.
+
+##### Funnel Metrics
+
+When the denominator is a simple binomial (conversion) metric, then it acts just like an "activation metric" in an experiment. It filters the users who are included in the analysis to those who first convert on this denominator metric.
+
+For example, if you want to look at what percent of users checkout after viewing a cart, it can be described as `% checkout / % viewed cart`. This requires creating two metrics:
+
+1. `Viewed Cart` - selects all users who viewed a cart
+2. `Viewed Cart -> Checkout` - selects all users who checked out and picks `Viewed Cart` as the denominator.
+
+##### Ratio Metrics
+
+When the denominator is a count metric, then things are a little different. Instead of acting like a filter, we calculate both metrics and treat the value as a ratio.
+
+- The mean is `sum(metric) / sum(denominator)`
+- The standard deviation is calculated using the **Delta method**
+
+For example, if you want to look at the Average Order Value (AOV), what you're really looking for is `total revenue / number of orders`. This also requires creating two metrics:
+
+1. `Orders per User` - selects the count of orders for each user
+2. `AOV` - selects total revenue per user and picks `Orders per User` as the denominator.
+
+### 2. Javascript (Mixpanel only)
+
+We query Mixpanel data sources using their proprietary JQL language based on Javascript. This allows for extreme flexibility when defining metrics.
+
+All metrics at minimum need to specify an **Event Name** which must exactly match what is used in Mixpanel. You can use `OR` to match against multiple events. For example `viewed_cart OR purchased`
+
+You can optionally add **Conditions** which filters the events further based on properties. For example, if Event Name is `Page view`, you can add a condition `path = "/blog"`.
+
+Count, duration, and revenue metrics have two additional steps. We first extract all event values for a user into an array and then reduce that array down to a single number, which is the final metric value for the user.
+
+#### Conditions
+
+Conditions in Mixpanel are very powerful. They consist of a **Property**, an **Operator**, and a **Value**. Multiple conditions are joined with an AND.
+
+The **Property** can either be the name of an event property or a javascript expression. Some examples:
+
+- `amount`, equivalent to `event.properties.amount`
+- `event.time`
+- `event.properties.city + ", " + event.properties.country`
+
+The **Operator** is one of the following:
+
+- equals
+- does not equal
+- is greater than
+- is greater than or equal to
+- is less than
+- is less than or equal to
+- matches the regex
+- does not match the regex
+- custom javascript
+
+The `custom javascript` operator is special. The **Value** is a javascript expression that evaluates to either `true` or `false` (access the property value with the `value` variable). It lets you do arbitrarily complex filtering. For example:
+
+```js
+value < 5 || value > 10;
+```
+
+For all other operators, the condition should read like an English sentence. For example:
+
+```js
+// property operator value
+country equals US
+
+// Will render as
+event.properties.country == "US"
+```
+
+#### Event Value
+
+For count, revenue, and duration metrics, we need to know what the "value" of the event is.
+
+The **Event Value** is a Javascript expression to extract a value from a raw Mixpanel event. If you are just extracting a single property as-is, you can just enter the property name as a shortcut. Otherwise, you can reference the `event` variable in your expression.
+
+Here are some example Event Value expressions:
+
+- `grand_total`, equivalent to `event.properties.grand_total`
+- `1` (hard-code the value to a specific number)
+- `(event.properties.endTime - event.properties.startTime) / (60 * 60)` (difference in hours between two unix timestamps)
+- `new Date(event.time).toISOString().substr(0, 10)` (event timestamp in YYYY-MM-DD format)
+
+For count metrics, you can leave Event Value blank and it will default to hard-coding the value to `1`, which is perfect for when you just want to count the number of events and don't care about specific properties.
+
+#### User Value Aggregation
+
+For count, revenue, and duration metrics, we need to know how to aggregate the event values together, in case a single user has multiple matching events.
+
+The **User Value Aggregation** is another Javascript expression that reduces an array of Event Values to a single number (or null if the user did not convert). Reference the variable `values` in your expression. There are a few built-in helper functions:
+
+- `count(values)`
+- `countDistinct(values)`
+- `sum(values)`
+- `min(values)`
+- `max(values)`
+- `avg(values)`
+- `median(values)`
+- `percentile(values, p)` (p is a number between `0` and `100`)
+
+You can use your own custom expression too if you want. For example, this is the equivalent of `sum(values)`:
+
+```js
+values.reduce((sum, n) => sum + n, 0);
+```
+
+If the aggregation is left blank, we do `sum(values)` by default.
+
+### 3. SQL Query Builder (legacy)
+
+The query builder prompts you for things such as table/column names and constructs a SQL query behind the scenes.
+
+We only recommend this for extremely simple metrics. Inputting raw SQL is far more flexible.
+
+## Behavior
+
+The behavior tab lets you tweak how the metric is used in experiments. Depending on the metric type and datasource you chose, some or all of the following will be available:
+
+### What is the Goal?
+
+For the vast majority of metrics, the goal is to increase the value. But for some metrics like "Bounce Rate" and "Page Load Time", lower is actually better.
+
+Setting this to "decrease" basically inverts the "Chance to Beat Control" value in experiment results so that "beating" the control means decreasing the value. This will also reverse the red and green coloring on graphs.
+
+### Capped Value
+
+Large outliers can have an outsized effect on experiment results. For example, if your normal order size is $10 and someone happens to make a $5000 order, whatever variation that person is in will automatically "win" any experiment even if it had no effect on their behavior.
+
+If set above zero, all values will be capped at this value. So in the above example, if you set the cap to $100, the $5000 purchase will still be counted, but only as $100 and will have a much smaller effect on the results. It will still give a boost to whatever variation the person is in, but it won't completely dominate all of the other orders and is unlikely to make a winner just on its own.
+
+### Conversion Delay
+
+Conversions within the first X hours of being put into an experiment are ignored (default = `0`). This is useful for metrics like "day 2 retention". In that case, if your underlying table reports whether a user is retained on any given day, you could set a conversion delay to `24` hours.
+
+#### Negative conversion delays
+
+The conversion delay can also be negative to include some conversions **before** a user is put into an experiment. For example, a value of `-2` would mean conversions up to 2 hours before will be included. You might be wondering when this would ever be useful.
+
+Imagine the average person stays on your site for 60 seconds and your experiment can trigger at any time.
+
+If you just look at the average time spent after the experiment, the numbers will lose a lot of meaning. A value of `20 seconds` might be horrible if it happened to someone after only 5 seconds on your site since they are staying a lot less time than average. But, that same `20 seconds` might be great if it happened to someone after 55 seconds since their visit is a lot longer than usual.
+Over time, these things will average out and you can eventually see patterns, but you need an enormous amount of data to get to that point.
+
+If you set the conversion delay to something negative, say `-0.5` (30 minutes), you can reduce the amount of data you need to see patterns. For example, you may see your average go from 60 seconds to 65 seconds.
+
+Keep in mind, these two things are answering slightly different questions.
+`How much longer do people stay after viewing the experiment?` vs `How much longer is an average session that includes the experiment?`.
+The first question is more direct and often a more strict test of your hypothesis, but it may not be worth the extra running time.
+
+### Conversion Window
+
+The number of hours the user has to convert after the conversion delay (default = `72`). Any conversions that happens after this time will be ignored. As always there's a tradeoff here.
+
+The lower you set this, the more you can be sure that your experiment directly contributed to the metric conversion. For example, a user who views your new checkout page and then completes the purchase right away is a much stronger signal than someone viewing your checkout page and then finally completing the purchase 7 days later.
+
+However, setting this too low can exclude valid conversions. In the above example, maybe your new checkout page is more memorable and makes people more likely to return later. With a short conversion window you wouldn't be able to capture this data.
+
+If you are using the "First Exposure" attribution model, then we build this conversion window from the first exposure each user has to an experiment. Because it is possible that each user has multiple rows (one for each exposure) in the experiment assignment source, we use the earliest row (measured by `timestamp` in the experiment assignment source) as the basis from which to build the first conversion window.
+
+If you use the "Experiment Duration" attribution model, we effectively ignore the conversion window setting. In this case, we still respect the conversion _delay_ from a user's first experiment exposure timestamp, but we aggregate all metric values/conversions after the conversion delay.
+
+## Examples
+
+Let's walk through some examples of creating binomial, count, and retention metrics with GrowthBook. For all of the metrics below, let's pretend we have some table called `purchases`, which has one row per purchase that a user makes. For each row we have the following columns:
+
+- `user_id` - the id of the user
+- `timestamp` - the time the purchase was made
+- `items` - the number of items they purchased
+- `cost` - the total value of the items they purchased
+
+From this table, we can build many different metrics:
+
+| Name                | Metric Type     | SQL                                                      | Aggregation   | Denominator         | Conversion Delay |
+| ------------------- | --------------- | -------------------------------------------------------- | ------------- | ------------------- | ---------------- |
+| Any Purchase        | Binomial        | SELECT user_id, timestamp FROM purchases                 | n/a           |                     | 0                |
+| Items Purchased     | Count           | SELECT user_id, timestamp, items as value FROM purchases | default (SUM) |                     | 0                |
+| Number of Purchases | Count           | SELECT user_id, timestamp, 1 as value FROM purchases     | default (SUM) |                     | 0                |
+| Order Value         | Revenue         | SELECT user_id, timestamp, cost as value FROM purchases  | default (SUM) |                     | 0                |
+| Average Order Value | Revenue (ratio) | SELECT user_id, timestamp, cost as value FROM purchases  | default (SUM) | Number of Purchases | 0                |
+| 7-Day Retention     | Binomial        | SELECT user_id, timestamp FROM purchases                 | n/a           |                     | 24\*7=144 hours  |
+
+If you wanted to only count purchases and purchase values made in the 72 hours after a user's first exposure to an experiment, then you could set the conversion window to 72 hours. If you wanted to just count any user who made a purchase any time after experiment exposure and before the end of the experiment, you don't need to increase the conversion window. Instead, you can simply change the Attribution Model to "Experiment Duration" in the experiment settings.

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/app/metrics.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/app/metrics.mdx
@@ -1,7 +1,7 @@
 ---
 title: Metrics
 description: Learn about defining the metrics you will use in your A/B test results
-sidebar_label: Metrics
+sidebar_label: Metrics 🚧
 slug: metrics
 ---
 

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/app/visual.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/app/visual.mdx
@@ -1,0 +1,168 @@
+---
+title: Visual Editor
+description: Learn about our visual editor currently in beta
+sidebar_label: Visual Editor
+id: visual-editor
+slug: visual
+---
+
+import Pill from '@site/src/components/Pill';
+
+# Visual Editor 2.0 <Pill>beta</Pill>
+
+The Visual Editor enables non-technical users to design A/B tests on their site directly in their browser, run them in production, and analyze results, all without writing a single line of code.
+
+In March, 2023 we released version 2.0 of our Visual Editor with many improvements.
+
+## Requirements
+
+To use our Visual Editor, you need to install the [GrowthBook Chrome Extension](https://chrome.google.com/webstore/detail/growthbook-devtools/opemhndcehfgipokneipaafbglcecjia).
+
+You will also need a Secret API Key so the Chrome Extension can connect to your GrowthBook instance and save changes. You can create a key on the **Settings -> API Keys** page in GrowthBook (you will need admin permissions to access this). You will be prompted to enter this API key the first time you use the Visual Editor.
+
+The application you want to experiment on must also be a front-end web application viewed in a browser. Our Visual Editor does not work for mobile apps (Native or ReactNative) or desktop apps (e.g. Electron). For these unsupported apps, you can use [Feature Flags](/app/features) instead and implement your changes in code.
+
+:::note
+
+There are additional steps required before you deploy your A/B test to production. See below for more info.
+
+:::
+
+## Creating a Visual Experiment
+
+To use the visual editor, first add a new Experiment. This can be done under **Analysis -> Experiments**
+
+![Design a new experiment](/images/add-experiment-modal.png)
+
+Select the option to design a new experiment. Then, you'll have a series of fields to fill out (hypothesis, variation names, goal metrics, etc.). Don't worry, these can all be changed later.
+
+Once you created an experiment, you should be prompted to open the Visual Editor.
+
+### URL Targeting
+
+GrowthBook needs to know what page(s) of your site the experiment should run on.
+
+If your experiment is going to be on a single static page, enter the full URL and submit (e.g. `https://www.example.com/pricing`).
+
+If your experiment is going to be on a page with a dynamic URL (e.g. all pages that start with `/post/`), click on the "Advanced Mode" link.
+
+You'll need to enter 2 different URLs.
+
+1. A single representative URL you want to load in the Visual Editor (e.g. `https://www.example.com/post/my-first-post`)
+2. A URL targeting pattern to match all of your dynamic URLs
+
+The targeting pattern supports wildcards (`*`), so for this example, you could enter `/post/*`.
+
+:::tip
+
+We recommend sticking with "Simple" URL targeting rules (don't be fooled by the name, it's actually really powerful). The other option (Regex) can be useful for really advanced use cases, but it is much harder to write and more error prone.
+
+:::
+
+#### Simple Targeting
+
+Our "simple" URL targeting option supports the vast majority of use cases and is easy to use. It supports the following features:
+
+- Match based on full URLs (e.g. `https://www.example.com/pricing`)
+- Match based on path (e.g. `/pricing`)
+- Match based on query strings (e.g. `/pricing?utm_source=email`)
+- Match based on hashes/anchors (e.g. `/pricing#more-info`)
+- Wildcards (e.g. `/posts/*` will match `/posts/123` AND `/posts/2023/03/30/my-post`)
+- Ignores leading and trailing slashes (e.g. `pricing`, `/pricing`, and `/pricing/` are identical)
+- Ignores the protocol (e.g. `https://...` will also match `http://...`)
+- Ignores extra query string parameters (e.g. `/pricing/?plan=pro` will match `/pricing/?utm_source=email&plan=pro&logged-in=true`)
+
+#### Regex Targeting
+
+Our "regex" URL targeting option supports full regular expressions. Writing regular expressions for URLs is very error prone, so be careful and make sure you escape all special characters you don't want to be interpreted. Here's a full example:
+
+```js
+https?:\/\/(www\.)?example\.com\/pricing\/?
+```
+
+You can also match on just the path:
+
+```js
+^\/pricing\/(pro|enterprise)
+```
+
+### The Visual Editor
+
+There are a number of different tools in the Visual Editor.
+
+![The Visual Editor UI](/images/visual-editor-ui.png)
+
+At the top is a dropdown where you can select which variation you are currently editing.
+
+Below that is your toolbar. It has the following tools in order from left to right:
+
+1. **Interactive Mode** - Click around your site normally
+2. **Element Selector** - Point and click to select an element on your site to edit. This is the most common way to make changes.
+3. **Global CSS** - Inject global CSS styles into the page. Use this to control things like page background color or font size.
+4. **Custom DOM Changes** - A low level way to specify changes to elements
+5. **Change List** - See a summary of all of the changes you've made to the page so far
+
+When you're using the Element Selector, after you pick an element to edit, you'll be able to modify the Inner HTML (i.e. the copy), any attributes (e.g. a link HREF), and the list of CSS classes.
+
+When you're finished making changes, click the **Done Editing** button to be taken back to GrowthBook.
+
+## Production
+
+Before publishing an A/B test to production you will need to integrate either our [JavaScript](/lib/js) or [ReactJS](/lib/js) SDK to your application (requires a developer).
+
+:::note
+
+The Visual Editor requires the latest versions of our SDKs. If you've already been using GrowthBook for feature flags, you may need to update your installed version.
+
+:::
+
+### SDK Connection
+
+You will need a **client key** to pass into the SDK. You can get this by creating a new SDK Connection (under **Features** in the left navigation).
+
+**Important**: Make sure to enable the "Include Visual Experiments" toggle. If you forget this step, Visual Editor experiments will not be sent to your application.
+
+![Enable the Visual Editor in your SDK Connection](/images/sdk-connection-visual-editor.png)
+
+You can also optionally include Draft Experiments. These are not run automatically like Production experiments. Instead, they can be triggered via special URLs (see below for more info). Drafts are useful for QA testing before releasing to your actual users.
+
+### SPA Support
+
+If you have a Single Page Application (SPA) that does client-side routing, you'll need to update the URL within the GrowthBook SDK every time it changes.
+
+For example, with Next.js you can do the following:
+
+```js
+function updateGrowthBookURL() {
+  gb.setURL(window.location.href);
+}
+
+export default function MyApp() {
+  // Subscribe to route change events and update GrowthBook
+  const router = useRouter();
+  useEffect(() => {
+    router.events.on("routeChangeComplete", updateGrowthBookURL);
+    return () => router.events.off("routeChangeComplete", updateGrowthBookURL);
+  }, []);
+
+  // ...
+}
+```
+
+## Drafts and QA
+
+While the experiment is still a draft, you can preview variations by adding a querystring to your URL.
+
+:::note
+
+This requires turning on the "Include Drafts" toggle for your SDK Connection in GrowthBook.
+
+:::
+
+To build the QA preview URL, you'll need the **Experiment Id** (viewable on the right side of the experiment page under Settings). You'll also need the variation number you want to preview. `0` is the control, `1` is the 1st variation, etc..
+
+Now, just join these together with an equals sign (e.g. `my-experiment-id=1`). This needs to go in the Querystring part of the URL (after a question mark). Here's a full example:
+
+`https://www.example.com/pricing?my-experiment-id=1`
+
+Until an experiment is moved out of the "draft" phase and started, this is the only way to view it on your site.

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/app/visual.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/app/visual.mdx
@@ -1,7 +1,7 @@
 ---
 title: Visual Editor
 description: Learn about our visual editor currently in beta
-sidebar_label: Visual Editor
+sidebar_label: Visual Editor 🚧
 id: visual-editor
 slug: visual
 ---

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/app/webhooks.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/app/webhooks.mdx
@@ -1,0 +1,128 @@
+---
+title: Webhooks
+description: Webhooks to help you update your cache or take other actions when the state changes on GrowthBook
+sidebar_label: Webhooks
+slug: webhooks
+---
+
+import ExternalLink from '@site/src/components/ExternalLink'
+import Pill from '@site/src/components/Pill';
+
+# Webhooks <Pill>beta</Pill>
+
+GrowthBook has event-based webhooks that trigger a script on your server whenever something changes within GrowthBook. It is currently in beta as we add support for more event types and create better documentation and examples.
+
+## Adding a Webhook
+
+When logged into GrowthBook as an admin, navigate to **Settings -> Webhooks**.
+
+There you can add a webhook endpoint and select which events you want to be notified about.
+
+This page is also where you can view the shared secret used to verify requests (see below) and see the status of your webhook and any errors.
+
+### VPCs and Firewalls
+
+If your webhook endpoint is behind a firewall and you are using GrowthBook Cloud, make sure to whitelist the ip address `52.70.79.40`.
+
+## Verify Signatures
+
+Webhook payloads are signed with a shared secret so you can verify they actually came from GrowthBook. The signature is passed in a `X-GrowthBook-Signature` header.
+
+Here is example code in NodeJS for verifying the signature. Other languages should be similar:
+
+```js
+const crypto = require("crypto");
+const express = require("express");
+const bodyParser = require("body-parser");
+
+// Retrieve from GrowthBook settings
+const GROWTHBOOK_WEBHOOK_SECRET = "abc123";
+
+const port = 1337;
+const app = express();
+
+app.post(
+  "/webhook",
+  bodyParser.raw({ type: "application/json" }),
+  (req, res) => {
+    const payload = req.body;
+    const sig = req.get("X-GrowthBook-Signature");
+
+    const computed = crypto
+      .createHmac("sha256", GROWTHBOOK_WEBHOOK_SECRET)
+      .update(req.body)
+      .digest("hex");
+
+    if (!crypto.timingSafeEqual(Buffer.from(computed), Buffer.from(sig))) {
+      throw new Error("Signatures do not match!");
+    }
+
+    const data = JSON.parse(payload);
+    // TODO: Do something with the webhook data
+
+    // Make sure to respond with a 200 status code
+    res.status(200).send("");
+  }
+);
+
+app.listen(port, () => {
+  console.log(`Webhook endpoint listening on port ${port}`);
+});
+```
+
+## Errors and Retries
+
+If your endpoint returns any HTTP status besides `200`, the webhook will be considered failed.
+
+Failed webhooks are tried a total of 3 times using an exponential back-off between attempts.
+
+You can view the status of your webhooks in the GrowthBook app under **Settings &rarr; Webhooks**.
+
+## Supported Event Types
+
+We currently support the following event types:
+
+- **feature.created**
+- **feature.updated**
+- **feature.deleted**
+- **experiment.created**
+- **experiment.updated**
+- **experiment.deleted**
+
+The new webhooks are still in beta and we are always updating the list of supported events.
+
+## Examples
+
+- [Web hooks implementation example <ExternalLink />](https://github.com/growthbook/examples/tree/main/webhooks-impl)
+
+## SDK Webhooks (deprecated)
+
+GrowthBook has another type of webhook, meant specifically to keep SDKs up-to-date with the latest feature flag states. These have been deprecated in favor of SDK Connections and the GrowthBook Proxy Server. The payload for these legacy webhooks are described below for reference.
+
+### Payload
+
+SDK Webhooks will do a `POST` to the endpoint you provide. The body is a JSON object containing feature definitions in the same format that SDKs are expecting.
+
+Here's an example payload:
+
+```json
+{
+  "timestamp": 1625098156,
+  "features": {
+    "feature1": {
+      "defaultValue": true
+    }
+  }
+}
+```
+
+The `features` field has one entry per feature definition. Features can have the following properties:
+
+- **defaultValue**
+- **rules[]** - Array of feature rules
+  - **condition** - A JSON condition using MongoDB query syntax
+  - **force** - Force a specific value, takes precedence over all other rules besides `condition`
+  - **variations[]** - Run an experiment and randomly assign one of the specified variations
+  - **key** - When running an experiment, this is the experiment key that will be passed to the tracking callback function
+  - **weights[]** - Determines how traffic is split between variations in an experiment
+  - **coverage** - Specifies what sampling rate (0 to 1) to use for including users in an experiment. A rate of `1` means everyone is included. A rate of `0` means no one is.

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/app/webhooks.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/app/webhooks.mdx
@@ -1,7 +1,7 @@
 ---
 title: Webhooks
 description: Webhooks to help you update your cache or take other actions when the state changes on GrowthBook
-sidebar_label: Webhooks
+sidebar_label: Webhooks 🚧
 slug: webhooks
 ---
 

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/faq.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ
 description: Frequently asked questions about GrowthBook.
-sidebar_label: FAQ
+sidebar_label: FAQ 🚧
 slug: faq
 ---
 

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/faq.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/faq.mdx
@@ -1,0 +1,143 @@
+---
+title: FAQ
+description: Frequently asked questions about GrowthBook.
+sidebar_label: FAQ
+slug: faq
+---
+
+# FAQ
+
+Below are some frequently asked questions about GrowthBook.
+
+## Do users always get assigned the same experiment variation?
+
+GrowthBook SDKs use deterministic hashing to ensure the same user always gets assigned the same variation in an experiment.
+
+In a nutshell, GrowthBook hashes together the user id and the experiment `trackingKey` which produces a decimal between 0 and 1. Each variation is assigned a range of values (e.g. `0 to 0.5` and `0.5 to 1.0`) and the user is assigned to whichever one their hash falls into.
+
+This does mean, if you change the experiment configuration, some users may switch their assigned variation. For example, if someone has the hash `0.49` and you adjust the weights to a 40/60 experiment, the variation ranges become `0 to 0.4` and `0.4 to 1.0`. In this case, the user was previously in the control group, but will now be in the variation.
+
+GrowthBook will detect issues like this and will remove users who see both variations from the analysis automatically. However, to keep things simple and safe, we recommend not relying on this and treating experiments as immutable once they are running.
+
+It's important to note that the above only applies when changing the traffic split between variations. If you keep the split the same, but increase the percent of traffic included, users will not switch variations. For example, if you are running a 50/50 experiment on 20% of traffic, the variation ranges will be `0 to 0.1` and `0.5 to 0.6`. Users outside those ranges will be excluded from the experiment. If you increase the percent of traffic to 40%, but keep the 50/50 split, the ranges will become: `0 to 0.2` and `0.5 to 0.7`. As you can see, no users switch variations. Instead, some users who were previously excluded are now part of the experiment.
+
+## What do I use for an "id" attribute in the SDK if my users aren't logged in?
+
+If your application has both logged-in and anonymous users, we recommend using two identifier attributes:
+
+- `id` which is the database identifier of logged-in users (or empty string for anonymous)
+- `deviceId` (or `sessionId`, etc.) which is a random anonymous hash, persisted in a cookie or local storage. This should always be set for both anonymous and logged-in users.
+
+If your application only has anonymous users (e.g. a static marketing site), then we recommend a single `id` attribute which, similar to `deviceId` or `sessionId` above, is a random hash persisted in a cookie or local storage.
+
+## Why is the trackingCallback not firing in the SDK?
+
+The `trackingCallback` only fires when a user is included in an experiment. If you're expecting to be included and you're still not seeing the callback fire, it's likely for one of the following reasons:
+
+- You are missing the `hashAttribute` for the experiment. For example, when you are splitting users by "company", but the company attribute is empty.
+- The feature is disabled for the environment you are in (dev/prod)
+- The experiment has reduced coverage. For example, if it's only running for 10% of users and you are in the 90% that are excluded.
+- There is another feature rule that is taking precedence over the experiment.
+
+If you are using the Javascript or React SDK in a browser environment, you can install the [GrowthBook DevTools Chrome Extension](https://chrome.google.com/webstore/detail/growthbook-devtools/opemhndcehfgipokneipaafbglcecjia) to help you debug.
+
+**Note**: To use the plugin, you will need to pass `enableDevMode: true` when creating your GrowthBook instance.
+
+```ts
+const growthbook = new GrowthBook({
+  enableDevMode: true,
+},
+```
+
+## How do I run an A/B test in GrowthBook?
+
+The recommended way to run an A/B test is by using Feature Flags and our SDKs.
+
+1. Create a feature in GrowthBook (e.g. `new-signup-form`) with an A/B Experiment rule
+2. Use our SDKs to serve the different variations
+   ```ts
+   if (growthbook.feature("new-signup-form").on) {
+     // Variation
+   } else {
+     // Control
+   }
+   ```
+
+## How much traffic do I need to run A/B tests?
+
+What matters most for A/B testing is not traffic, but conversions. The general rule of thumb is to have at least 100-200 conversions per variation before you might start reaching significance.
+
+So that means if you do 50 orders per week and that's the metric you are trying to optimize, you'll need to run a simple 2-way A/B test for at least 4-8 weeks. If you run a 3-way test, it will take 6-12 weeks.
+
+## Can I run multiple A/B tests at a time?
+
+Yes! In fact, we recommend running many experiments in parallel in your application. Most A/B tests fail, so the more shots-on-goal you take, the more likely you are to get a winner. Running tests in parallel is a great way to increase your velocity.
+
+Now it's possible your experiments might have interaction effects, but these are actually pretty rare in practice. One example is if one test is changing the text color on a page and another test is changing the background color. Some users might see end up seeing black text on a black background, which is obviously not ideal. For these rare cases, you can use [Namespaces](/app/features#namespaces) to run mutually exclusive experiments.
+
+As long as you apply a little common sense to avoid situations like the above, running multiple experiments has low risk and really high reward.
+
+## What is the difference between a Dimension and a Segment?
+
+A dimension is a user attribute that can have multiple values. Some examples are `country`, `account_type`, and `browser`.
+
+A segment is a specific group of users. Some examples are `visitors in the US`, `premium users`, and `chrome users`.
+
+Dimensions are used to explore experiment results. For example, you can use a `country` dimension to see which countries had the highest conversion rates. Or an `account_type` dimension to see if there was a significant difference in how free vs paid users behaved. Or a `browser` dimension to detect any browser-specific bugs in your implementation.
+
+Segments can apply a filter to results, usually to compensate for bad data. For example, if your experiment was only visible to premium users, but your database inaccurately shows that free users were also included, you could apply a `premium users` segment to only include those who were actually exposed to the test. Ideally, you could just fix the underlying data, but that's often not feasible so segments provide a quick and dirty alternative.
+
+## Which docker image tag should I use when self-hosting?
+
+We recommend using the `latest` tag for both dev and production self-hosted deployments. This tag represents the latest stable build of GrowthBook and is what the Cloud app uses.
+
+Specific version tags (e.g. `v1.1.0`) are only released periodically (about once a month) and you will miss out on the many bug fixes and features added between major releases.
+
+We also recommend updating the image regularly. You can do that by downloading the latest image (`docker pull growthbook/growthbook:latest`) and restarting the container.
+
+## What are the hardware requirements for self-hosting GrowthBook?
+
+The GrowthBook application is very lightweight and efficient. For most usecases, 2GB of memory is sufficient even for large production deployments.
+
+GrowthBook only deals with aggregate data and the bulk of the processing is offloaded to your data source. Because of this, you can easily analyze terrabytes of data from your laptop or a small container in the cloud.
+
+If you are using feature flags, we recommend adding a caching layer between the GrowthBook API and your application in production. We offer a pre-built [GrowthBook Proxy server](/self-host/proxy) you can run that handles caching and invalidation automatically. You can also setup your own custom system using a CDN or distributed cache like Redis.
+
+## I can't upload to S3/getting 400 error when uploading to S3?
+
+- Make sure you've correctly set the `S3_BUCKET` and `S3_REGION` environment variables
+- Enable bucket ACL and set ownership to Bucket owner preferred: [read more here](https://stackoverflow.com/questions/70333681/for-an-amazon-s3-bucket-deplolyent-from-guithub-how-do-i-fix-the-error-accesscon).
+- Make sure the S3 bucket is publically accessible
+- Make sure CORS settings are correct. Add your URLs to the AllowedOrigins array or set to "\*"
+
+## How do I use the Chrome DevTools Extension?
+
+- Make sure you are using the React or Javascript SDK
+- Install the [Chrome DevTools Extension](https://chrome.google.com/webstore/detail/growthbook-devtools/opemhndcehfgipokneipaafbglcecjia)
+- Pass the `enableDevMode: true` option into the GrowthBook constructor
+
+```ts
+const growthbook = new GrowthBook({
+  enableDevMode: true,
+},
+```
+
+## My old exported notebook stopped working. How can I fix it?
+
+There's a good chance that the SQL we are exporting and your version of our Python stats library, `gbstats`, are out of sync.
+In February of 2023 we updated our SQL engines and `gbstats` library to only use sums and sums of squares, rather than averages and standard deviations.
+
+If the queries in your notebook return averages and standard deviations (using `AVG` and `VAR` SQL operators as part of the `__stats` CTE), then you need to run that notebook with `gbstats` version 0.3.1.
+You can download this from PyPI [here](https://pypi.org/project/gbstats/0.3.1/) using `pip install gbstats==0.3.1` and ensure that your kernel uses that version of `gbstats`.
+Ideally in this case you can redownload the notebook and use the new `gbstats` library (0.4.0 or newer). You can download a new notebook by navigating to your experiment in GrowthBook and clicking `Download Notebook` again. This should now use the updated SQL and `gbstats` syntax. Then, if you install `gbstats` 0.4.0 or later, everything should work as expected.
+
+If the queries in your notebook return sums and sums of squares as part of the `__stats` CTE but your notebook is still erroring, then you probably have an old `gbstats` version installed and need to update to 0.4.0 or later.
+You can download this from PyPI [here](https://pypi.org/project/gbstats) using `pip install gbstats` and ensure that your kernel uses that version of `gbstats`.
+
+## Can't find your question?
+
+If you can't find an answer to your question above, please let us know so we can help you out and improve the docs for future users!
+
+You can join our [Slack channel](https://slack.growthbook.io?ref=docs-faq) for the fastest response times.
+
+Or send an email to hello@growthbook.io if Slack isn't your thing.

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/guide/GA-universal-analytics.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/guide/GA-universal-analytics.mdx
@@ -1,7 +1,7 @@
 ---
 title: GrowthBook and Google Analytics UA
 description: This guide walks you through using GrowthBook with Google Analytics Universal Analytics (UA) to track your experiments and measure their impact on your business.
-sidebar_label: Google Analytics (UA)
+sidebar_label: Google Analytics (UA) 🚧
 slug: GA-universal-analytics
 ---
 

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/guide/GA-universal-analytics.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/guide/GA-universal-analytics.mdx
@@ -1,0 +1,107 @@
+---
+title: GrowthBook and Google Analytics UA
+description: This guide walks you through using GrowthBook with Google Analytics Universal Analytics (UA) to track your experiments and measure their impact on your business.
+sidebar_label: Google Analytics (UA)
+slug: GA-universal-analytics
+---
+
+# Configuring GrowthBook to work with Google Analytics - Universal Analytics (UA)
+
+:::info
+GrowthBook supports using your existing Google Analytics UA as a data source
+for your experiment analysis. Keep in mind, however, that there are some
+limitations with using GA as data source, namely it only supports running one
+experiment at a time. Using GA4 (or any other supported event tracking) as a
+data source provides more flexibility and has no limits.
+
+  <br />
+  <br />
+Also please be aware that GA UA is being deprecated, and will not collect new data after <strong>July 1, 2023</strong>.
+:::
+
+## 1. Connect GrowthBook to GA
+
+GrowthBook uses one of the custom dimensions that you define in GA to pass in with your gtag call. The value
+you pass for this dimension is in the format of `[experiment key][delimiter][variation id]`. In this example
+we’ll use dimension `1`, and a colon as a delimiter.
+
+You set the custom dimension you’re going to use as
+well as the divider string when you connect GrowthBook to your GA data source:
+
+<img
+  src="/images/guides/GA-datasource.png"
+  alt="GA Data Source"
+  style={{ width: 500, margin: "0 auto 10px auto" }}
+/>
+
+:::note
+
+The `delimiter` mentioned above is needed for GA as both the experiment name and the variation id need to be passed into a single text value. You can think of the delimiter as just a diver or seperator between those two fields.
+
+:::
+
+## 2. Implement the the GrowthBook code
+
+Add the gtag to the GrowthBook tracking callback. The exact implementation will depend on the SDK you're using,
+but should look similar to the javascript example shown here:
+
+```ts
+// Create a GrowthBook instance
+const growthbook = new GrowthBook({
+  trackingCallback: (experiment, result) => {
+    if ("gtag" in window) {
+      window.gtag("event", "experiment_viewed", {
+        event_category: "experiment",
+        event_label: result.variationId,
+        event_action: experiment.key,
+        dimension1: experiment.key + ":" + result.variationId,
+      });
+    } else {
+      console.log("no gtag");
+    }
+  },
+});
+```
+
+You can also map the dimension name passed in google, by defining it in gtag config:
+
+```ts
+gtag("config", "UA-1234...", {
+  custom_map: { dimension1: "experiment" },
+});
+```
+
+When you define a custom map, the last line in the tracking callback will be mapped from dimension1 to the name
+you chose, in this case ‘experiment.’ Therefore, if you do this, the last line of your gtag call would become:
+
+```ts
+ 'experiment':  experiment.key+":"+result.variationId
+```
+
+## 3. Add Dimension in Google Analytics
+
+Within GA you need to map the custom dimension:
+
+<img
+  src="/images/guides/GA-admin-add-dimension.png"
+  alt="GA add custom dimension"
+  style={{ margin: "0 auto 2em" }}
+/>
+
+<img
+  src="/images/guides/GA-edit-custom-dimension.png"
+  alt="GA edit dimension"
+  style={{ width: 300, margin: "0 auto" }}
+/>
+
+The name here is for your internal use, and it can be whatever you like. At the end, you should see a dimension like this:
+
+<img
+  src="/images/guides/GA-dimension-result.png"
+  alt="GA edit dimension"
+  style={{ margin: "0 auto" }}
+/>
+
+With this done, you can add metrics within GrowthBook, and start implementing an experiment.
+
+Keep in mind that it takes a day for event data to show up in GA and therefore will take a day to show up in GrowthBook as well.

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/guide/GA4-google-analytics.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/guide/GA4-google-analytics.mdx
@@ -1,0 +1,258 @@
+---
+title: GrowthBook and Google Analytics GA4
+description: This guide walks you through using GrowthBook with Google Analytics 4 (GA4) to track your experiments and measure their impact on your business.
+sidebar_label: Google Analytics (GA4)
+slug: GA4-google-analytics
+---
+
+# A/B Testing with Google Analytics 4 (GA4) and GrowthBook
+
+This guide walks you through using GrowthBook with Google Analytics 4 (GA4) for A/B testing. There are a few parts to
+this, connecting GA4 to BigQuery, connecting GrowthBook to BigQuery, and then configuring GrowthBook to track correctly
+with GA4.
+
+## Configuring GrowthBook to use Google Analytics GA4 as a data source
+
+GrowthBook connects to Google Analytics (GA4) via BigQuery. This process is straight forward, and outlined below.
+You can also find Google's documentation on how to create this link [here](https://support.google.com/analytics/answer/9823238).
+
+### 1. Create a BigQuery Project (if you don't have one)
+
+If you don't have a BigQuery project, you'll need to create one. Go to your [Google Cloud Console](https://console.cloud.google.com/) and create a new project:
+
+<img
+  src="/images/guides/GA4-1-project-list.png"
+  alt="GA4 - BigQuery create project"
+  style={{ width: 800, margin: "0 auto 10px auto" }}
+/>
+
+Click on **_Create new project_** from the right and give your project a name.
+
+<img
+  src="/images/guides/GA4-2-create-project.png"
+  alt="GA4 - BigQuery create project"
+  style={{ width: 500, margin: "0 auto 10px auto" }}
+/>
+
+Once created, you'll be redirected to the BigQuery dashboard.
+
+<img
+  src="/images/guides/GA4-3-new-project.png"
+  alt="GA4 BigQuery new project dashboard"
+  style={{ width: 800, margin: "0 auto 10px auto" }}
+/>
+
+If you created a new project, the BigQuery API is automatically enabled. Otherwise, you'll need to enable it manually [here](https://console.cloud.google.com/flows/enableapi?apiid=bigquery)
+
+:::note
+
+If you are just testing GrowthBook with GA4 out, you can use the sandbox project that Google provides for free. When you create a new cloud project the sandbox should be automatically enabled. You can find more information about the sandbox [here](https://cloud.google.com/bigquery/docs/sandbox).
+
+:::
+
+### 2. Connect Google Analytics to BigQuery
+
+Log into your Google Analytics account and navigate to the Admin section. From there, make sure you have selected the right property, and scroll down to **_Product Links_** section. Click on the menu named **_BigQuery Links_**
+
+<img
+  src="/images/guides/GA4-4-link-to-bigquery-1.png"
+  alt="GA4 BigQuery new project dashboard"
+  style={{ width: 700, margin: "0 auto 10px auto" }}
+/>
+
+Click on the **_Link_** button. This will open a menu that allows you select the project. Select on the **_Choose a BigQuery Project_** link.
+
+<img
+  src="/images/guides/GA4-5-link-to-bigquery-2.png"
+  alt="GA4 BigQuery new project dashboard"
+  style={{ width: 700, margin: "0 auto 10px auto" }}
+/>
+
+Select the project you wish to send your GA4 data to:
+
+<img
+  src="/images/guides/GA4-5-link-to-bigquery-3.png"
+  alt="GA4 BigQuery connect to project"
+  style={{ width: 900, margin: "0 auto 10px auto" }}
+/>
+
+Then click **_next_**
+
+<img
+  src="/images/guides/GA4-5-link-to-bigquery-4.png"
+  alt="GA4 BigQuery connected to project"
+  style={{ width: 900, margin: "0 auto 10px auto" }}
+/>
+
+On the next step you'll be presented with some options about the connection.
+
+<img
+  src="/images/guides/GA4-5-link-to-bigquery-5.png"
+  alt="GA4 BigQuery link options"
+  style={{ width: 900, margin: "0 auto 10px auto" }}
+/>
+
+Here you can choose the frequency of data updates, either daily or streaming. To use Streaming, you'll need a BigQuery account with billing info added. Depending on your use case, daily updates may be sufficient.
+
+On the final step you'll be asked to confirm your choices. When finished, you should see something like this, verifying that the connection was successful.
+
+<img
+  src="/images/guides/GA4-5-link-to-bigquery-6.png"
+  alt="GA4 BigQuery successfully connected"
+  style={{ width: 900, margin: "0 auto 10px auto" }}
+/>
+
+And then your BigQuery link will show up on the listing page:
+
+<img
+  src="/images/guides/GA4-5-link-to-bigquery-7.png"
+  alt="GA4 BigQuery successfully connected"
+  style={{ width: 900, margin: "0 auto 10px auto" }}
+/>
+
+### 3. Configure BigQuery for GrowthBook
+
+You'll need to give GrowthBook some permissions to your BigQuery project so that we can access the data. We have created a guide just for this, which you can find [here](https://docs.growthbook.io/guide/bigquery)
+
+### 4. Connect GrowthBook to BigQuery
+
+Within GrowthBook, navigate to the **_Analysis_** section, and then click on the **_Data Sources_** page. Add a new data source, and select **_Google Analytics (GA4)_**.
+
+<img
+  src="/images/guides/GA4-6-add-GA4-datasource.png"
+  alt="GrowthBook connect to GA4"
+  style={{ width: 500, margin: "0 auto 10px auto" }}
+/>
+
+<img
+  src="/images/guides/GA4-6-add-GA4-datasource2.png"
+  alt="GrowthBook connect to GA4"
+  style={{ width: 500, margin: "0 auto 10px auto" }}
+/>
+
+Then add your BigQuery connection info. GrowthBook will pre-populate the SQL queries required to use your GA4 data. You
+can also add a custom SQL query if you want to use a different table or filter the data in some way as you like.
+
+:::note
+
+While GrowthBook will pre-populate the SQL queries for you, you may need to adjust the experiment query to match your
+data depending on the way you are tracking your experiments (see the **_trackingCallback_** below).
+
+:::
+
+Once connected, you'll be able to add any additional metrics or dimensions, and then you can use your GA4 data for your
+experiments. You can use all your existing events and tracking- GrowthBook only requires one additional tracking call
+when a user is exposed to an experiment.
+
+## Running experiments with GrowthBook and GA4
+
+With the data source connected, you can use the GrowthBook SDK run A/B tests. The SDK lets you run experiments where the
+variations are defined in code, and controlled from UI. Once implemented, the SDK will do the random assignments and send
+the experiment exposure event to GA4 based on the settings in the GrowthBook UI.
+
+:::info
+
+We do have a visual editor for creating experiments, but it is meant for simple experiments. Experiments that are more
+complex are best created with a change in the code.
+
+:::
+
+### SDK integration for GA4
+
+You can follow the guides on SDK integration for any of our supported languages [here](http://localhost:3200/lib/). The
+only special case for GA4 is getting the **user Id** and/or **Client ID** attribute, and adjusting the `trackingCallback` to
+send the experiment exposure event to GA4.
+
+#### Using GA's Client ID
+
+GA generates a **Client ID** (sometimes called a device Id) for each visitor, and then stores this unique ID in a cookie
+(\_ga). There are a few ways to grab this Id from your code. Here are a few ways with Javascript:
+
+```js
+gtag('get', 'G-[your google property id]', 'client_id', (clientId) => {
+  console.log(clientId)
+});
+```
+
+or
+
+```js
+const clientId = document.cookie.match(/_ga=(.+?);/)[1].split('.').slice(-2).join(".")
+```
+
+You can read more about getting this ID [here](https://stackoverflow.com/questions/20053949/how-to-get-the-google-analytics-client-id)
+
+#### Using a User ID
+
+If you have a custom **User Id** already, you can use this with GA4 instead (or as well) as the **Client Id**.
+You can read Google's official instructions on how to pass a custom **User Id** [here](https://developers.google.com/analytics/devguides/collection/ga4/user-id?client_type=gtag).
+
+:::info
+
+A **User Id** in this case would be something you pass to GA4, not something GA4 generates for you. You can use this ID throughout your GA4 reports.
+
+:::
+
+#### Passing Attributes to the SDK
+
+Once you have your **Client ID** and/or **User Id**, you can pass it to the GrowthBook SDK when you initialize it. For example:
+
+```js
+const gb = new GrowthBook({
+  apiHost: "https://cdn.growthbook.io",
+  clientKey: "sdk-abc123",
+  // Enable easier debugging during development
+  enableDevMode: true,
+  // Targeting attributes
+  attributes: {
+    clientId: clientId,
+    userId: userId,
+    country: "US",
+    ...
+  }
+});
+```
+
+And then these id's can be used from the GrowthBook UI to target your experiments. You can add the attributes to the UI from the **_Features -> Attributes_** page.
+
+#### Tracking experiment exposure
+
+The only additional event required is when a user is exposed to an experiment. This is done by adding a GA4 custom event from inside the `trackingCallback` method. For example:
+
+```js
+const gb = new GrowthBook({
+  apiHost: "https://cdn.growthbook.io",
+  clientKey: "sdk-abc123",
+  // Targeting attributes
+  attributes: {
+    clientId: gaUserId,
+    userId: userId,
+    country: country,
+    ...
+  },
+  trackingCallback: (experiment, result) => {
+    // track using GA4
+    if ("gtag" in window) {
+      window.gtag("event", "experiment_viewed", {
+        event_category: "experiment",
+        experiment_id: experiment.key,
+        variation_id: result.variationId,
+        ...
+      });
+    } else {
+      console.log("no gtag");
+    }
+  },
+});
+```
+
+:::note
+
+If your experiment is not firing the `trackingCallback` you can use our
+[Chrome developer tool](https://chrome.google.com/webstore/detail/growthbook-devtools/opemhndcehfgipokneipaafbglcecjia)
+to help you debug and make sure the user attributes are being set correctly.
+
+:::
+
+Implementing the experiment variations can be done with code with inline experiments, using the feature flags, or by
+using our visual editor.

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/guide/GA4-google-analytics.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/guide/GA4-google-analytics.mdx
@@ -1,7 +1,7 @@
 ---
 title: GrowthBook and Google Analytics GA4
 description: This guide walks you through using GrowthBook with Google Analytics 4 (GA4) to track your experiments and measure their impact on your business.
-sidebar_label: Google Analytics (GA4)
+sidebar_label: Google Analytics (GA4) 🚧
 slug: GA4-google-analytics
 ---
 

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/guide/bigquery.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/guide/bigquery.mdx
@@ -1,0 +1,110 @@
+---
+title: GrowthBook and BigQuery
+description: This document outlines the steps needed to add your BigQuery database to GrowthBook.
+sidebar_label: BigQuery
+slug: bigquery
+---
+
+# Configuring GrowthBook to work with BigQuery
+
+This document outlines the steps needed to add your BigQuery database to GrowthBook.
+
+## 1. Create a service account for GrowthBook
+
+Within your [Google Cloud console account](https://console.cloud.google.com/iam-admin/serviceaccounts), create a service account for GrowthBook to use
+
+<img
+  src="/images/guides/bigquery-1-addserviceaccount-for-gb-highlited.png"
+  alt="Create a new service account in BigQuery"
+/>
+
+<img
+  src="/images/guides/bigquery-2-addserviceaccount-for-gb3.png"
+  alt="Create a new service account in BigQuery"
+  style={{ width: 500, margin: "0 auto" }}
+/>
+
+Create a service account name and account ID. On the next page you need to add 3 specific roles:
+
+<img
+  src="/images/guides/bigquery-3-addserviceaccount-for-gb4-roles.png"
+  alt="Create a new service account in BigQuery"
+  style={{ width: 500, margin: "0 auto" }}
+/>
+
+On the Grant page, add two (read only) permissions roles:
+
+- BigQuery Data Viewer
+- BigQuery Job User
+
+<img
+  src="/images/guides/bigquery-4-addserviceaccount-for-gb5-roles.png"
+  alt="Create a new service account in BigQuery"
+  style={{ width: 500, margin: "0 auto" }}
+/>
+
+On the final page when creating a service account, you can skip the optional fields.
+
+You should see the new service account listed, without a `Key ID`. We need to add an access key to this account so the
+credentials can be added to GrowthBook. Click on actions, and select `Manage Keys`.
+
+<img
+  src="/images/guides/bigquery-5-getjson-key.png"
+  alt="Create a new service account in BigQuery"
+/>
+
+There are two ways to provide credentials to GrowthBook:
+
+- Auto-discovery from environment variables or GCP metadata (only available when self-hosting)
+- Upload a JSON key file for the service account
+
+We're going to show how to do the JSON key file method. On the keys page, add a new key, and select JSON.
+
+<img
+  src="/images/guides/bigquery-6-getjson-key2.png"
+  alt="Get json key for service account"
+  style={{ width: 900, margin: "0 auto 15px" }}
+/>
+
+<img
+  src="/images/guides/bigquery-6-getjson-key3.png"
+  alt="Get json key for service account"
+  style={{ width: 500, margin: "0 auto" }}
+/>
+
+This will cause the JSON key to be downloaded to your computer.
+
+## 2. Connect GrowthBook to BigQuery
+
+From the Analysis -> Data Source page, click on add new data source and select the event tracker you're using. If your event tracker is not listed, or you're using something custom, click on the "Custom" button at the bottom.
+
+Selecting an event tracker here will pre-populate the experiment exposure query which is need to determine which user saw which experiment
+variation. Depending on your needs, you may still need to adjust these queries to match your specific schema.
+
+<img
+  src="/images/guides/bigquery-7-add-datasource1.png"
+  alt="Add BigQuery to GrowthBook"
+  style={{ width: 500, margin: "0 auto" }}
+/>
+
+Select BigQuery as the data source type.
+
+<img
+  src="/images/guides/bigquery-7-add-datasource2.png"
+  alt="Add BigQuery to GrowthBook"
+  style={{ width: 500, margin: "0 auto" }}
+/>
+
+Add the names you'd like to use, and select the JSON key file that was downloaded earlier.
+
+Although the `Default Project Name` and `Default Dataset` is not required, it is helpful to set this to the correct
+values for your database. You can get the name of these fields from the [Google Cloud explorer](https://console.cloud.google.com/bigquery). You will see the top level
+project name, and when expanded, find the dataset which has your experiment exposure table (which will be `experiment_viewed` if you use Segment or Rudderstack).
+
+<img
+  src="/images/guides/bigquery-8-getdefault-names.png"
+  alt="Get default project name and default dataset"
+  style={{ width: 300, margin: "0 auto 10px" }}
+/>
+
+When you click save, GrowthBook will test the connection to make sure the credentials are correct. If the connection is successful, you should see a success message on the next page.

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/guide/bigquery.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/guide/bigquery.mdx
@@ -1,7 +1,7 @@
 ---
 title: GrowthBook and BigQuery
 description: This document outlines the steps needed to add your BigQuery database to GrowthBook.
-sidebar_label: BigQuery
+sidebar_label: BigQuery 🚧
 slug: bigquery
 ---
 

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/guide/create-react-app-and-growthbook.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/guide/create-react-app-and-growthbook.mdx
@@ -1,0 +1,170 @@
+---
+title: GrowthBook and BigQuery
+description: This guide walks you through installing GrowthBook SDK into your Create React App
+sidebar_label: Create React App
+slug: create-react-app-and-growthbook
+---
+
+# GrowthBook and Create React App
+
+## 1. Set up Create React App
+
+Create React App is simple to get a new project started. This guide does the standard process with one extra command
+to install the GrowthBook SDK and the nanoid library:
+
+```bash
+npx create-react-app my-app
+cd my-app
+npm install --save @growthbook/growthbook-react nanoid
+npm start
+```
+
+Then open `http://localhost:3000/` and make sure the app is working
+
+## 2. Set up GrowthBook
+
+In this tutorial assume you are using the cloud-hosted version of GrowthBook, which is free for small teams, but you can
+also use the open source version and host it yourself if you prefer.
+
+:::note
+GrowthBook uses the concept of Feature Flagging to run A/B tests. Basically,
+you wrap the code you want to test in a conditional check
+
+<pre>if (feature.on) ...</pre>and then you run an A/B test within GrowthBook to turn the feature on for 50% of users and off for the other 50% (or whatever
+
+percentage you like).
+:::
+
+To start, go to https://app.growthbook.io and register a new account. Then there are a couple steps required before you
+can run an experiment.
+
+## 3. Install and configure the SDK
+
+Next, click on Step 1: Install our SDK and you should see API keys for dev/production as well as sample code.
+
+Since you already ran the npm i command at the start, you can skip that part. I'll walk through the different parts below:
+
+First, in `src/index.js`, import the GrowthBook SDK and nanoid library:
+
+```ts
+// ... after existing imports
+import { GrowthBook, GrowthBookProvider } from "@growthbook/growthbook-react";
+import { nanoid } from "nanoid";
+```
+
+Then you will need to generate an anonymous visitor id, which is used to assign an A/B test variation to a user. In this example we'll
+persist this id in localStorage so if the user refreshes our app they will get assigned the same variation as before.
+
+```ts
+let visitor_id = localStorage.getItem("visitor_id");
+if (!visitor_id) {
+  visitor_id = nanoid();
+  localStorage.setItem("visitor_id", visitor_id);
+}
+```
+
+Then, you create a GrowthBook instance with our visitor id and a tracking callback when a user is put into an experiment.
+
+```ts
+const growthbook = new GrowthBook({
+  attributes: {
+    id: visitor_id,
+  },
+  trackingCallback: (experiment, result) => {
+    console.log({
+      experimentId: experiment.key,
+      variationId: result.variationId,
+    });
+  },
+});
+```
+
+After that, you can fetch the list of features from the GrowthBook API and pass them into the SDK:
+
+```ts
+const FEATURES_ENDPOINT = "https://cdn.growthbook.io/api/features/...";
+
+fetch(FEATURES_ENDPOINT)
+  .then((res) => res.json())
+  .then((json) => {
+    growthbook.setFeatures(json.features);
+  });
+```
+
+Make sure to swap out the `FEATURES_ENDPOINT` constant above with your own dev API key you see in the GrowthBook application.
+
+Lastly, you'll need to wrap the app in a GrowthBookProvider component which will let us run A/B tests from anywhere in the app.
+
+```html
+ReactDOM.render(
+<React.StrictMode>
+  <GrowthBookProvider growthbook={growthbook}>
+    <App />
+  </GrowthBookProvider>
+</React.StrictMode>, document.getElementById('root')
+);
+```
+
+## 4. Create and use a feature
+
+Now that the SDK is installed and fully integrated in our application, you can finally create the `show-logo` feature.
+
+Back in GrowthBook, Click on Step 2 of the quick start instruction or click on add new feature. Fill in the following info:
+
+- Feature key: `show-logo`
+- Dev: toggle on
+- Prod: toggle off
+- Value Type: boolean (on/off)
+- Behavior: A/B Experiment
+- Tracking Key: `show-logo`
+- Sample Users based on attribute: `id`
+- Variations and Weights: leave default (OFF/ON, 50/50 split)
+- Fallback Value: `OFF`
+
+There's a lot of fields there, but hopefully it's pretty straight forward what's happening. We setup a new boolean feature called show-logo, that's only enabled in dev and running an A/B test where 50% get ON and 50% get OFF
+
+Now you can switch back to our React app and reference this feature in our code.
+
+In src/App.js, we currently have the following code:
+
+```html
+<img src={logo} className="App-logo" alt="logo" />
+```
+
+Let's add an import at the top of the file:
+
+```js
+import { IfFeatureEnabled } from "@growthbook/growthbook-react";
+```
+
+And wrap the img element in an IfFeatureEnabled component:
+
+```html
+<IfFeatureEnabled feature="show-logo">
+  <img src={logo} className="App-logo" alt="logo" />
+</IfFeatureEnabled>
+```
+
+Now, if you refresh your app, the A/B test should be running! If you're part of the lucky 50% that are in the B variation (no logo), it should be pretty obvious. If you happen to be in the A variations, you can verify you're in the test by looking in DevTools for our trackingCallback console.log.
+
+You can test out different variations by deleting the visitor_id from localStorage and refreshing your app. Repeat a few times and you should see each version of the page about half of the time. If you want an easier and faster way to QA the variations, you can download the GrowthBook Chrome DevTools Extension.
+
+## 5. Analyze Results
+
+Before you can analyze the results, you will need to connect GrowthBook to the event tracking and a data source. In the
+trackingCallback in `src/index.js`, instead of doing a `console.log`, you could use [Mixpanel](/guide/mixpanel), Rudderstack, Jitsu,
+Segment or another event tracking system.
+
+Then, throughout your app, you can similarly track events when users do something you care about, like sign up, convert, or buy something.
+
+Once you do that, GrowthBook can connect to your event tracking system, query the raw data, run it through a stats engine,
+and show you the results. Follow the directions for the data source you're using.
+
+## Next Steps
+
+There's so much more you can do with GrowthBook beyond a simple on/off A/B test...
+
+- Add complex targeting and override rules for your features
+- Read the full [React SDK Docs](/lib/react) for more details and ways to use feature flags
+- Install the [Chrome DevTools Extension](https://chrome.google.com/webstore/detail/growthbook-devtools/opemhndcehfgipokneipaafbglcecjia) to test different variations and scenarios
+- Read about the [powerful statistics engine](/statistics/overview) that is used to analyze experiment results.

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/guide/create-react-app-and-growthbook.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/guide/create-react-app-and-growthbook.mdx
@@ -1,7 +1,7 @@
 ---
 title: GrowthBook and BigQuery
 description: This guide walks you through installing GrowthBook SDK into your Create React App
-sidebar_label: Create React App
+sidebar_label: Create React App 🚧
 slug: create-react-app-and-growthbook
 ---
 

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/guide/google-tag-manager-and-growthbook.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/guide/google-tag-manager-and-growthbook.mdx
@@ -1,7 +1,7 @@
 ---
 title: GrowthBook and Google Tag Manager
 description: This guide walks you through using GrowthBook with Google Tag Manager (GTM) to track your experiments and measure their impact on your business.
-sidebar_label: Google Tag Manager (GTM)
+sidebar_label: Google Tag Manager (GTM) 🚧
 slug: google-tag-manager-and-growthbook
 ---
 

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/guide/google-tag-manager-and-growthbook.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/guide/google-tag-manager-and-growthbook.mdx
@@ -1,0 +1,365 @@
+---
+title: GrowthBook and Google Tag Manager
+description: This guide walks you through using GrowthBook with Google Tag Manager (GTM) to track your experiments and measure their impact on your business.
+sidebar_label: Google Tag Manager (GTM)
+slug: google-tag-manager-and-growthbook
+---
+
+# Using GrowthBook with Google Tag Manager (GTM)
+
+Now customers who are familiar with feature management using Google Tag Manager (GTM), yet may lack the engineering resources or capability to implement changes in their codebase, may easily use GrowthBook with GTM to power their AB tests. This setup is commonly used by marketing teams and CRO agencies.
+
+:::note
+GrowthBook also offers a [visual editor](https://docs.growthbook.io/app/visual) for lightweight, no-code UI changes.
+:::
+
+In this guide, we will assume familiarity with the GTM platform. We also assume the ability to apply a unique user ID via Google Analytics (`client_id`), cookies, etc; as well as the ability to track events (GA or otherwise).
+
+## Choosing a strategy: performance vs flexibility
+
+There are two strategies that we can use to implement AB tests with GrowthBook via GTM.
+
+The first strategy is the most performant but requires us to hard-code all of our experiments and their rulesets instead of referencing feature flags. While this can lead to some inflexibility in controlling targeting post-launch, the upside is that we avoid an extra network call to GrowthBook to fetch feature flags. This leads to less noticeable flicker between our initial page render and the DOM changes we apply after the GrowthBook SDK loads. In this strategy, each time you need to change your experiments or targeting rules, you'll need to modify the code snippet and publish a new GTM version.
+
+The second strategy gives us the flexibility of using feature flags, but comes with a page render speed tax. Using this method, we implement a single code snippet that needs to be updated whenever we need to instrument new on-page variations for experiements, which are associated with feature flags. Our code snippet will query GrowthBook for all feature flags, which would typically reference AB test experiments and their rulesets, and will automatically evaluate these feature flags for us. However, we need to make a network request to the GrowthBook app to fetch these features, and this happens client-side while the page is loading. By the time we receive a server response and can apply DOM changes, there may be a noticeable flicker while re-rendering.
+
+:::note
+If neither of these strategies seem ideal, we'd encourage you to pursue a traditional GrowthBook implementation without GTM, preferably with back-end or hybrid feature flag evaluation. See our [SDK documentation](https://docs.growthbook.io/lib/) for more information.
+:::
+
+## Basic setup
+
+Regardless of which of the above strategies you've chosen, in order to implement GrowthBook AB Tests you'll first need to inject the GrowthBook Javascript SDK using a GTM Tag. You'll also need to pass some basic information along to the SDK in order to use it.
+
+### Creating a GTM tag for the GrowthBook SDK
+
+First, create a new tag in your desired workspace. We will choose "Custom HTML" as the tag type. We can give it the name "GrowthBook SDK" or similar. Also, be sure to set the firing triggers to target the specific pages where we need to instrument our feature changes and experiments (or just choose "All Pages").
+
+Next, paste in the script below to load the GrowthBook JavaScript SDK; then save the tag:
+
+```js
+<script id="growthbook-sdk" src="https://cdn.jsdelivr.net/npm/@growthbook/growthbook/dist/bundles/index.min.js" defer></script>
+```
+
+To publish the SDK tag, submit our workspace changes (the blue "Submit" button on the top of the GTM application), Then ensure "Publish and Create version" is selected and click the blue "Publish" button – or use whichever GTM release strategy you are already using.
+
+## Initializing the SDK
+
+To actually use the GrowthBook SDK on our pages to control on-page features with AB tests, we'll need to create another code snippet and load it through GTM. While you can certainly add the snippet to your existing tag (the GrowthBook SDK tag we created above), you may find it cleaner to add another Custom HTML tag and give it a name such as "GrowthBook Implementation" Be sure to set the firing triggers in the same way as you did above.
+
+In the subsequent sections, we will learn how to fill in the SDK parameters such as our own `apiHost`, `clientKey`, `attributes`, and `trackingCallback`. For now, insert the following code into your tag:
+
+```html
+<script>
+  (function() {
+    // Wait for the SDK to load before starting GrowthBook
+    if (window.growthbook) {
+      startGrowthbook();
+    } else {
+      document.querySelector("#growthbook-sdk").addEventListener("load", startGrowthbook);
+    }
+
+    function startGrowthbook() {
+      if (!window.growthbook) return;
+      var gb = new growthbook.GrowthBook({
+        apiHost: "https://cdn.growthbook.io",
+        clientKey: "sdk-abcd1234",
+        // TODO: Add decryptionKey if using encryption
+        attributes: {
+          id: "u1234" // TODO: Read user/device id from a cookie/datalayer
+        },
+        trackingCallback: function(experiment, result) {
+          // TODO: track experiment impression
+        }
+      });
+
+      // TODO: Instrument DOM with AB test logic
+    }
+  })();
+</script>
+```
+
+Let's have a look at the SDK constructor code above, specifically the parameters defined within this block:
+
+```js
+var gb = new growthbook.GrowthBook({
+  apiHost: "https://cdn.growthbook.io",
+  // etc...
+});
+```
+
+Here, we will need to add pass in SDK connection parameters, user attributes, and any tracking callback functions. We will talk through each of these.
+
+### Connection parameters
+
+Let's first pass in our SDK connection parameters. To find them, you will need to find your SDK in the GrowthBook app (in **Features > SDKs**), and select "Javascript" for implementation instructions. Here you will see values for `apiHost`, `clientKey`, and in some cases `decryptionKey`. (Note: if you've decided to use Strategy 2 - page speed, you won't actually need to include these connection parameters.)
+
+### User attributes
+
+We also need to define any relevant user attributes, most importantly the `id`. If you have any other user attributes available that affect your experiment targeting, also add them to the `attributes` object here.
+
+Let's talk about the user ID specifically, since it's crucial for running AB tests wherein individuals are deterministically bucketed into experiment variations. Skip ahead if you already have a good way to retrieve a unique user ID.
+
+#### User id from your website
+
+Chances are your website has an internal userId associated with the user's session. If you are able to obtain this ID in JavaScript, use this value for your GrowthBook user attributes. For example, the userId may be assigned to all rendered pages via something like this (PHP template, although your site may use an entirely different server configuration):
+
+```html
+<script>
+  var myWebsiteUserId = "<?= $_SESSION['userId']; ?>";
+</script>
+```
+
+You could then assign this value to your GrowthBook user attributes:
+
+```js
+attributes: {
+  id: myWebsiteUserId
+}
+```
+
+Alternatively, you could potentially pull the userId out of your site's session cookie, if available. A sample PHP-based session system might have a JavaScript lookup like this:
+
+```html
+<script>
+  var sessionCookie = document.cookie.match(/PHPSESSID=([^;]+)/);
+  var myWebsiteUserId = sessionCookie
+    ? decodeURIComponent(sessionCookie[1]).match(/userId=([^&]+)/)[1]
+    : null;
+</script>
+```
+
+#### User id from Google Analytics
+
+For organizations using GTM, Google Analytics is also commonly used (which GrowthBook plays nicely with via a BigQuery integration), although there is certainly no requirement that you also use GA with GrowthBook. With this configuration, it's often common to see a client_id or user_id associated with GA.
+
+#### GA4
+
+You may be interested in getting the client_id (a unique identifier for users and their device) to represent a single user. This is available out of the box with GA4. The "proper" way to retrieve it in JavaScript would look like this (where `G-XXXXXX` is your GA4 property ID):
+
+```js
+var clientId = "";
+gtag('get', 'G-XXXXXX', 'client_id', function(cid) {
+  clientId = cid;
+});
+```
+
+However since this is an asynchronous lookup, we need to make sure that clientId is available before we create the GrowthBook SDK instance. The simplest way to do this is to nest the SDK instantiation inside your gtag callback function. For example:
+
+```js
+gtag('get', 'G-XXXXXX', 'client_id', function(cid) {
+  var gb = new growthbook.GrowthBook({
+    apiHost: "https://cdn.growthbook.io",
+    clientKey: "sdk-abcd1234",
+    attributes: {
+      id: cid
+    },
+    // etc...
+  });
+
+  // TODO: Instrument DOM with AB test logic
+});
+```
+
+...or you could use async/await or promises to prevent additional nesting.
+
+:::tip
+In some cases where `gtag()` is not yet defined at the time in which we invoke it, we may need to force our GrowthBook snippet to load after GA has successfully loaded. You may be able to use `window.onload()` to ensure GA has loaded before the SDK is instantiated (although GA loaded through GTM can sometimes complicate this). Alternatively, you can use a GTM trigger such as "Window Loaded" to ensure that the GrowthBook SDK is loaded after GA has loaded.
+
+All of these delays, however, can cause render flickering and should be avoided if possible. You might consider loading GA outside of GTM. You could even load GA and GrowthBook in parallel, wrap each load inside its own promise, and use `Promise.all()` to ensure both are loaded before the SDK is instantiated. Specifics will vary depending on your site's configuration, but hopefully this provides some ideas.
+
+In some situations, `gtag()` may never become defined. You can use your browser's developer tools / JavaScript console to confirm this by typing `window.tag`. If undefined, you may need to manually define it — either on your page or in a GTM custom HTML tag — using JavaScript. For example:
+
+```js
+window.gtag = window.gtag || function() { dataLayer.push(arguments); };
+```
+
+:::
+
+You may have a custom user ID (website-generated perhaps) that you'd like to propagate through GA4. In this case, you'll want to ensure that this user ID has been pushed to the dataLayer (GA4's local data store). For example:
+
+```js
+dataLayer.push({
+  'user_id': myWebsiteUserId
+});
+```
+
+Then, to get the user id from GA4 into our GrowthBook user attributes, we can modify our SDK code snippet:
+
+```js
+gtag('get', 'G-XXXXXX', 'user_id', function(uid) {
+  var gb = new growthbook.GrowthBook({
+    apiHost: "https://cdn.growthbook.io",
+    clientKey: "sdk-abcd1234",
+    attributes: {
+      id: uid
+    },
+    // etc...
+  });
+
+  // TODO: Instrument DOM with AB test logic
+});
+```
+
+#### GA (Universal Analytics)
+
+Prior to GA4, the mechanism to fetch our client_id is slightly different. A few different ways to deal with this are via a lookup using the GA API:
+
+```js
+attributes: {
+  id: ga.getAll()[0].get('clientId')
+}
+```
+
+...or by extracting the ID from the cookie:
+
+```js
+attributes: {
+  id: document.cookie.match(/_ga=(.+?);/)[1].split('.').slice(-2).join('.')
+}
+```
+
+### Tracking callback
+
+We may be interested in defining an analytics tracking event in order to track AB test impressions. This is not required for GrowthBook to function correctly, but is often of interest for 3rd party analytics purposes.
+
+If you already have tracking events set up, insert them into our code snippet. Here's a contrived example:
+
+```js
+trackingCallback: function(experiment, result) {
+  TrackingAgent.track("experiment_viewed", {
+    experiment_id: experiment.key,
+    variation_id: result.variationId,
+    userId: myWebsiteUserId, // or perhaps client_id from gtag('get', 'client_id', ...)
+  });
+}
+```
+
+Or if you are using Google Analytics (GA4) for event tracking, it may look something like this:
+
+```js
+trackingCallback: function(experiment, result) {
+  gtag("event", "experiment_viewed", {
+    event_category: "experiment",
+    experiment_id: experiment.key,
+    variation_id: result.variationId,
+  });
+}
+```
+
+Note the omission of `client_id`, as this is typically included by default in GA events.
+
+We're now ready to start implementing our AB test rendering logic. Let's return to the two aforementioned implementation strategies...
+
+## Strategy 1: Page speed optimized, inline experiments
+
+Recall that in this strategy, we define our experiments and their rulesets inline. This avoids an extra network request via `gb.loadFeatures()`, which introduces an additional delay. Avoiding this lookup ensures any render flickering is minimized.
+
+Let's get started with our test instrumentation. We'll consider a hypothetical landing page where there are 2 features that need to be changed on the DOM based on feature flag settings: a large button (#button1) which we can optionally turn green, and a sticky banner (#banner1) which we can alter with custom text.
+
+Find the section of our snippet above beginning with `// TODO: Instrument DOM with AB test logic`. We will replace this comment with a snippet that will fetch the feature flag definitions and then apply test-specific DOM changes. Our earlier code snippet now becomes:
+
+```html
+<script>
+  (function() {
+    // Wait for the SDK to load before starting GrowthBook
+    if (window.growthbook) {
+      startGrowthbook();
+    } else {
+      document.querySelector("#growthbook-sdk").addEventListener("load", startGrowthbook);
+    }
+
+    function startGrowthbook() {
+      if (!window.growthbook) return;
+      var gb = new growthbook.GrowthBook({
+        attributes: {
+          id: "u1234" // TODO: Read user/device id from a cookie/datalayer
+        },
+        trackingCallback: function(experiment, result) {
+          // TODO: track experiment impression
+        }
+      });
+
+      // 2-way inline test
+      var result1 = gb.run({
+        key: "button-experiment",
+        variations: ["control", "green-button"],
+        weights: [0.5, 0.5], // Traffic split between the variations
+        coverage: 1.0  // What percent of overall traffic to include (0.0 to 1.0)
+      });
+      if (result1.value === "green-button") {
+        document.querySelector("#button-1").classList.add("green");
+      }
+
+      // 3-way inline test
+      var result2 = gb.run({
+        key: "banner-experiment",
+        variations: ["A", "B", "C"],
+        weights: [0.5, 0.25, 0.25],
+        coverage: 1.0
+      });
+      if (result2.value === "B") {
+        document.querySelector("banner1").innerHTML = "Click here in the next 24 hours";
+      } else if (result2.value === "C") {
+        document.querySelector("banner1").innerHTML = "Click here before this offer expires";
+      }
+    }
+  })();
+</script>
+```
+
+Note that we have needed to define the properties of both our `button-experiment` and `banner-experiment` inline. Although less flexible than using feature flags defined in GrowthBook, this approach is performant and relatively easy to implement. The `gb.run()` call, which evaluates a feature flag to determine which AB test variant a user belongs to, is evaluated on the client side and does not make a network call.
+
+## Strategy 2: Flexible feature flags, less performant
+
+Recall that our second strategy allows us the flexibility of referencing feature flags and their targeting rules, which we may modify in the GrowthBook app without pushing an update to our GTM tag, even after the test has launched. Also recall that this strategy comes with additional page flickering while we await feature flag definitions from the GrowthBook app before rendering our variations.
+
+In this scenario, our updated code snippet would look something like this:
+
+```html
+<script>
+  (function() {
+    // Wait for the SDK to load before starting GrowthBook
+    if (window.growthbook) {
+      startGrowthbook();
+    } else {
+      document.querySelector("#growthbook-sdk").addEventListener("load", startGrowthbook);
+    }
+
+    function startGrowthbook() {
+      if (!window.growthbook) return;
+      var gb = new growthbook.GrowthBook({
+        apiHost: "https://cdn.growthbook.io",
+        clientKey: "sdk-abcd1234",
+        // TODO: Add decryptionKey if using encryption
+        attributes: {
+          id: "u1234" // TODO: Read user/device id from a cookie/datalayer
+        },
+        trackingCallback: function(experiment, result) {
+          // TODO: track experiment impression
+        }
+      });
+
+      gb.loadFeatures().then(function() {
+
+        // 2-way test using a boolean feature flag
+        if (gb.isOn("green-button")) {
+          document.querySelector("#button-1").classList.add("green");
+        }
+
+        // Multiple variations using a string feature flag
+        var value = gb.getFeatureValue("my-string-feature");
+        if (value === "B") {
+          document.querySelector("banner1").innerHTML = "Click here in the next 24 hours";
+        } else if (value === "C") {
+          document.querySelector("banner1").innerHTML = "Click here before this offer expires";
+        }
+      });
+    }
+  })();
+</script>
+```
+
+Here, we are instrumenting two different tests. First is our button (`button-1`) which is modified by a 2-way AB test (control and one variant). It uses a boolean flag (`green-button`) to toggle a CSS class. Second is our sticky banner (`banner-1`) which is modified by a 3-way test. It uses a string flag (`my-string-feature`), with values representing different test variations, to alter the text of our banner.
+
+Notice that we need to call `gb.loadFeatures()` and wait for the return from the GrowthBook app before actually implementing our AB test's render logic. This delay is responsible for some render flickering while switching from a control to a variant for our tests.

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/guide/index.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/guide/index.mdx
@@ -1,0 +1,39 @@
+---
+title: How to Guides for installing the platform
+sidebar_label: How to
+slug: /guide
+---
+
+# GrowthBook Detailed Guides.
+
+The following sections contain detailed walk through on how to set up GrowthBook with various technologies.
+
+## A/B testing guide
+
+- [The Open Guide to Successful A/B Testing (pdf)](/open-guide-to-ab-testing.v1.0.pdf)
+
+## Database connection guides
+
+- [BigQuery](/guide/bigquery)
+
+## Implementation guides
+
+- [GrowthBook with Next.js](/guide/nextjs-and-growthbook)
+- [GrowthBook with Create React App](/guide/create-react-app-and-growthbook)
+- [GrowthBook with Next.js and Rudderstack](/guide/rudderstack-and-nextjs-with-growthbook)
+- [GrowthBook with Google Tag Manager](/guide/google-tag-manager-and-growthbook)
+
+## Tracking and analytics setup for common event trackers:
+
+- [Google Analytics - GA4](/guide/GA4-google-analytics)
+- [Google Analytics - UA](/guide/GA-universal-analytics)
+- [Mixpanel](/guide/mixpanel)
+- [Rudderstack](/guide/rudderstack)
+- [Matomo](/guide/matomo)
+
+## Coming soon:
+
+- Jitsu
+- Snowplow
+- Amplitude
+- Segment

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/guide/index.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/guide/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: How to Guides for installing the platform
-sidebar_label: How to
+sidebar_label: How to 🚧
 slug: /guide
 ---
 

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/guide/matomo.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/guide/matomo.mdx
@@ -1,0 +1,159 @@
+---
+title: GrowthBook and Matomo
+description: Configure GrowthBook to do A/B testing using Matomo Analytics
+sidebar_label: Matomo
+slug: matomo
+---
+
+# Configuring GrowthBook to work with Matomo
+
+GrowthBook makes it easy to do A/B testing using Matomo as an event source. This guide shows you how to set up GrowthBook to work with self-hosted Matomo and the MySQL/MariaDB that it runs on.
+
+## 1. Integrate GrowthBook's SDK with Matomo within your application
+
+You can follow the SDK integration guides depending on your language. We need to add the `TrackingCallback` call
+specifically for Matomo. For this guide, we'll use Javascript (Next.js).
+
+Matomo lets you track custom events, and you can adjust the `Event Category`, `Event Action`, `Event Name`, and
+`Event Value`. You can read more about the custom tracking call at [Matomo's documentation site](https://matomo.org/faq/reports/implement-event-tracking-with-matomo/).
+
+:::note
+There are a few caveats with Matomo's event schema that it is important to be aware of.
+
+  <ul>
+    <li>
+      <strong>Event Category</strong> cannot contain any spaces.
+    </li>
+    <li>
+      {" "}
+      If <strong>Event Name</strong> is 0 or "0" it will record null.
+    </li>
+    <li>
+      <strong>Event Value</strong> must be an integer.
+    </li>
+  </ul>
+:::
+
+To work with the default data schema in GrowthBook, we will encode the following:
+
+- `Event Category`: will have the value `ExperimentViewed` to isolate the exposure events.
+- `Event Action`: will store the experiment key.
+- `Event Name`: will store the variation id (with a prefix of `v` or some other string)
+
+```ts
+// Create a GrowthBook instance
+const growthbook = new GrowthBook({
+  trackingCallback: (experiment, result) => {
+    window["_paq"] = window._paq || [];
+    window._paq.push([
+      "trackEvent",
+      "ExperimentViewed",
+      experiment.key,
+      "v" + result.variationId,
+    ]);
+  },
+});
+```
+
+:::note
+We use the string prefix on the Event Name so that it is saved correctly, as `0`
+saves as `null`, but `v0` works correctly. This prefix is stripped with the SQL
+exposure query in step two.
+:::
+
+With that set, we need to load the user id into the GrowthBook user attributes. The following code shows how to do this with the Matomo anonymous `visitor ID`
+
+```ts
+// add the Matomo anonId when loaded
+let visitor_id;
+if ("_paq" in window) {
+  _paq.push([
+    function () {
+      visitor_id = this.getVisitorId();
+      growthbook.setAttributes({
+        ...growthbook.getAttributes(),
+        id: visitor_id,
+      });
+    },
+  ]);
+}
+```
+
+For Next.js, we would need to do this in the useEffect and also detect the window in case of a server side render:
+
+```tsx
+// Create a GrowthBook instance
+const growthbook = new GrowthBook({
+    trackingCallback: (experiment, result) => {
+        if (window) {
+            window["_paq"] = window._paq || [];
+            window._paq.push(['trackEvent', 'ExperimentViewed', experiment.key, "v"+result.variationId]);
+        }
+    }
+});
+
+export default function MyApp({ Component, pageProps }) {
+    useEffect(() => {
+        // Load feature definitions from API
+        fetch(process.env.NEXT_PUBLIC_GROWTHBOOK_FEATURES_URL)
+            .then((res) => res.json())
+            .then((json) => {
+                growthbook.setFeatures(json.features);
+            });
+
+        // TODO: replace with real targeting attributes
+        growthbook.setAttributes({
+            "company": "foo",
+            "browser": "foo",
+            "url": "foo"
+        });
+
+        // add the Matomo anonId when loaded
+        let visitor_id;
+        if("_paq" in window) {
+            _paq.push([function () {
+                visitor_id = this.getVisitorId();
+                growthbook.setAttributes({ ...growthbook.getAttributes(), id: visitor_id });
+            }]);
+        }
+    }, []);
+    ...
+```
+
+## 2. Add the Data Source for Matomo
+
+From within the GrowthBook application, navigate to the `Data Sources` page from within the `Analysis` section. Click on `add data source` and select `Matomo` from the list of event sources.
+
+<img
+  src="/images/new-data-sources-modal.png"
+  alt="Add Matomo data source"
+  style={{ width: 500, margin: "0 auto" }}
+/>
+
+After you select Matomo, you will be prompted to connect to your MySQL/Maria database.
+
+<img
+    src="/images/guides/matomo-2-connect-to-db.png"
+    alt="Add MySQL/MariaDB data source"
+    style={{ width: 500, margin: "0 auto" }}
+/>
+
+Once you've completed the connection GrowthBook will and then you can adjust some settings specific to your instance and how you implemented the Matomo tracking code.
+
+<img
+  src="/images/guides/matomo-3-matomo-options.png"
+  alt="Setting Matomo options"
+  style={{ width: 500, margin: "0 auto" }}
+/>
+
+When you save, you'll have the experiment exposure queries for anonymous and user_id set for you.
+
+<img
+  src="/images/guides/matomo-4-matomo-anon.png"
+  alt="Default Matomo experiment exposure query"
+  style={{ width: 800, margin: "0 auto" }}
+/>
+
+You can test running this query directly against your database. It should return a list of experiments exposure events.
+
+You will still need to define the metrics you want to test against from the metrics settings.

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/guide/matomo.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/guide/matomo.mdx
@@ -1,7 +1,7 @@
 ---
 title: GrowthBook and Matomo
 description: Configure GrowthBook to do A/B testing using Matomo Analytics
-sidebar_label: Matomo
+sidebar_label: Matomo 🚧
 slug: matomo
 ---
 

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/guide/mixpanel.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/guide/mixpanel.mdx
@@ -1,7 +1,7 @@
 ---
 title: Using GrowthBook with Mixpanel
 description: GrowthBook supports Mixpanel as a data source for your A/B test reports.
-sidebar_label: Mixpanel
+sidebar_label: Mixpanel 🚧
 slug: mixpanel
 ---
 

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/guide/mixpanel.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/guide/mixpanel.mdx
@@ -1,0 +1,138 @@
+---
+title: Using GrowthBook with Mixpanel
+description: GrowthBook supports Mixpanel as a data source for your A/B test reports.
+sidebar_label: Mixpanel
+slug: mixpanel
+---
+
+# Configuring GrowthBook to work with Mixpanel
+
+GrowthBook supports Mixpanel as a data source for your A/B test reports.
+
+## 1. Create a Service Account in Mixpanel
+
+To add Mixpanel to GrowthBook you need to create a service account within Mixpanel.
+
+<img
+  src="/images/guides/mixpanel-2-add-service-account.png"
+  alt="Add Mixpanel service account"
+/>
+
+Click on the add service account. This account needs at least analysis permissions.
+
+<img
+  src="/images/guides/mixpanel-3-add-service-account-details.png"
+  alt="Add Mixpanel service account specifics"
+  style={{ width: 500, margin: "0 auto" }}
+/>
+
+Once you crete the account, you'll get the username and secret. This is the only time you'll see this information, so
+it's best to leave this page up while you do the next step to add that connection information to GrowthBook.
+
+<img
+  src="/images/guides/mixpanel-4-service-account-results.png"
+  alt="Service account details"
+  style={{ width: 500, margin: "0 auto" }}
+/>
+
+## 2. Connect GrowthBook to Mixpanel
+
+From the Analysis -> Data source section of the GrowthBook Platform, you can add a data source, and then choose
+Mixpanel from the avaliable options.
+
+<img
+  src="/images/new-data-sources-modal.png"
+  alt="GrowthBook add Mixpanel data source form"
+  style={{ width: 500, margin: "0 auto" }}
+/>
+
+Then you'll be asked to enter your Mixpanel connection information:
+
+<img
+  src="/images/guides/mixpanel-1-add-data-source.png"
+  alt="GrowthBook add Mixpanel data source form"
+  style={{ width: 500, margin: "0 auto" }}
+/>
+
+Add the mixpanel information from the previous step here. The other information you'll need is the `project ID` from
+Mixpanel. You can find this in the the project settings overview from mixpanel
+
+<img
+  src="/images/guides/mixpanel-5-get-project-id.png"
+  alt="Get the Mixpanel project ID"
+  style={{ width: 1000, margin: "0 auto" }}
+/>
+
+## 3. Experiment Tracking Information
+
+After you successfully connect to mixpanel from GrowthBook you'll be asked to enter the experiment event information.
+These values need to match the names you choose when sending the experiment exposure information to Mixpanel (see
+step 4), but can be any values you choose. We suggest you use `$experiment started`, `Experiment name` and
+`Variant name` as in the example below.
+
+<img
+  src="/images/guides/mixpanel-6-add-exp-event-names2.png"
+  alt="Experiment event naming for GrowthBook"
+  style={{ width: 500, margin: "0 auto" }}
+/>
+
+The naming here has to match the event names you pass with the SDK implementation (see step 4).
+
+When you've successfully connected GrowthBook to your Mixpanel account, you'll see the experiment tracking information
+as well as sample code.
+
+<img
+  src="/images/guides/mixpanel-8-successful-connection2.png"
+  alt="Successful connection to Mixpanel"
+/>
+
+## 4. Implement GrowthBook SDK with Mixpanel
+
+When implementing the GrowthBook SDK there are two things that are needed that are specific to Mixpanel: tracking to
+Mixpanel when a user is placed into an experiment, and adding the Mixpanel user ID to the list of user attributes.
+You can find the implementation of the GrowthBook SDKs in many languages, the implementation is similar for each.
+Shown below is the typescript version:
+
+```ts
+import mixpanel from "mixpanel-browser";
+
+// Create a GrowthBook instance
+const growthbook = new GrowthBook({
+  trackingCallback: (experiment, result) => {
+    mixpanel.track("$experiment_started", {
+      "Experiment name": experiment.key,
+      "Variant name": result.variationId,
+      $source: "growthbook",
+    });
+  },
+});
+
+// Add the mixpanel user id to the GrowthBook attributes when it loads:
+mixpanel.init("[YOUR PROJECT TOKEN]", {
+  debug: true,
+  loaded: function (mx) {
+    growthbook.setAttributes({
+      ...growthbook.getAttributes(),
+      id: mx.get_distinct_id(),
+    });
+  },
+});
+```
+
+The project token can be found in the Mixpanel Project Settings.
+
+<img
+  src="/images/guides/mixpanel-9-project-token.png"
+  alt="Project Tokens from Mixpanel"
+/>
+
+You will still need to implement the feature flagging side of GrowthBook, where the feature JSON is fetched and other user
+attributes defined. This implementation instructions can be found for each specific language.
+
+:::note
+
+By default, Mixpanel stores all events as UTC time, but can be changed per
+project. If the timezones between GrowthBook and your Mixpanel don't match, it
+can cause results to not show data for the correct time period.
+
+:::

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/guide/nextjs-and-growthbook.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/guide/nextjs-and-growthbook.mdx
@@ -1,0 +1,346 @@
+---
+title: GrowthBook and Next.js
+description: This guide walks you through using GrowthBook with Next.js.
+sidebar_label: Next.js
+slug: nextjs-and-growthbook
+---
+
+# GrowthBook and Next.js
+
+This document is a guide on how to add GrowthBook feature flags to your Next.js application. It assumes you are starting from scratch, so if you already have a Next.js application, you can skip to step 2.
+
+Here is a video version similar to the steps below:
+
+<iframe
+  width="480"
+  height="360"
+  src="https://www.youtube.com/embed/J8tyS4j3DtA"
+  title="Feature flagging and A/B testing with Next.js and GrowthBook"
+  frameborder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowfullscreen
+></iframe>
+
+## 1. Create your Next.js App
+
+Let's start by getting a basic Next.js app running:
+
+```bash
+yarn create next-app
+```
+
+Then cd into the newly create directory and run:
+
+```bash
+cd my-app
+yarn dev -p 4000
+```
+
+Note: Both GrowthBook and Next.js run on port 3000 by default, so we're making our Next.js app use 4000 instead to avoid conflicts.
+
+Visit `http://localhost:4000` and you should see the application running!
+
+## 2. GrowthBook Account
+
+You will need a GrowthBook account. You can either run GrowthBook locally or using the cloud hosted GrowthBook at [https://app.growthbook.io](https://app.growthbook.io). If you are using the GrowthBook cloud, you can skip to step 3. If you are installing it locally, here is the quick start instructions - or you can follow the [self hosting](/self-host) instructions.
+
+```bash
+git clone https://github.com/growthbook/growthbook.git
+cd growthbook
+docker-compose up -d
+```
+
+After that, visit `http://localhost:3000` and create your first user account.
+
+<img
+  src="/images/guides/nextjs-1-growthbook-signup-screen.jpeg"
+  alt="GrowthBook Signup Screen"
+  style={{ width: 500, margin: "0 auto" }}
+/>
+
+## 3. Integrate the GrowthBook React SDK into our Next.js app
+
+GrowthBook will generate some integration code for you, including a unique SDK Endpoint to load your features from.
+
+<img
+  src="/images/guides/nextjs-2-feature-flag-key.png"
+  alt="GrowthBook Integration Code"
+  style={{ width: 500, margin: "0 auto" }}
+/>
+
+We first need to install the GrowthBook React SDK in our Next.js app:
+
+```bash
+yarn add @growthbook/growthbook-react
+```
+
+Then we can modify the generated React code to work with the Next.js framework. Modify the file `pages/_app.js` with the following contents:
+
+```ts
+import "../styles/globals.css";
+import { GrowthBook, GrowthBookProvider } from "@growthbook/growthbook-react";
+import { useEffect } from "react";
+
+const FEATURES_ENDPOINT = "http://localhost:3100/api/features/key_abc123";
+
+// Create a GrowthBook instance
+const growthbook = new GrowthBook({
+  trackingCallback: (experiment, result) => {
+    console.log("Viewed Experiment", experiment, result);
+  },
+});
+
+export default function MyApp({ Component, pageProps, router }) {
+  // Refresh features and targeting attributes on navigation
+  useEffect(() => {
+    fetch(FEATURES_ENDPOINT)
+      .then((res) => res.json())
+      .then((json) => {
+        growthbook.setFeatures(json.features);
+      });
+
+    growthbook.setAttributes({
+      id: "123",
+      loggedIn: true,
+      deviceId: "abcdef123456",
+      employee: true,
+      company: "acme",
+      country: "US",
+      browser: navigator.userAgent,
+      url: router.pathname,
+    });
+  }, [router.pathname]);
+
+  return (
+    <GrowthBookProvider growthbook={growthbook}>
+      <Component {...pageProps} />
+    </GrowthBookProvider>
+  );
+}
+```
+
+Replace the `FEATURES_ENDPOINT` constant with the one you see in your instructions modal in GrowthBook.
+
+In a real application, you would pull some of the targeting attributes from your authentication system or an API, but let's just leave them hard-coded for now.
+
+## 4. Create a Feature in GrowthBook
+
+Back in the GrowthBook application, we can create a new feature. For this tutorial, we'll make a simple on/off feature flag that determines whether or not we show a welcome banner on our site.
+
+<img
+  src="/images/guides/nextjs-3-create-feature.png"
+  alt="GrowthBook Create Feature"
+  style={{ width: 500, margin: "0 auto" }}
+/>
+
+The key we chose (welcome-message) is what we will reference when using the GrowthBook SDK.
+
+We can now edit `pages/index.js` and conditionally render a welcome message based on the state of the feature:
+
+Add an import statement:
+
+```ts
+import { IfFeatureEnabled } from "@growthbook/growthbook-react";
+```
+
+And then put your welcome message somewhere on the page:
+
+```ts
+<IfFeatureEnabled feature="welcome-message">
+  <p>I hope you enjoy this site and have a great day!</p>
+</IfFeatureEnabled>
+```
+
+If you refresh your Next.js app, you'll notice the welcome message is not rendered. This is because when creating the feature, we set the default value to off. At this point, we could safely deploy our change to production and not worry about breaking anything.
+
+## 5. Turn on the feature for your team
+
+Now we can add rules to the feature to turn it on for specific groups of users.
+
+In the hard-coded targeting attributes we set in pages/\_app.js, we designated ourselves as an internal employee. Let's use this attribute to turn on the feature for the whole internal team:
+
+<img
+  src="/images/guides/nextjs-4-employee-rule.png"
+  alt="GrowthBook Targeting Rule"
+  style={{ width: 500, margin: "0 auto" }}
+/>
+
+Refresh your Next.js app and you should now see the welcome message appearing! (Note: it might take up to 30 seconds for the API cache to refresh).
+
+<img
+  src="/images/guides/nextjs-5-nextjs-title.png"
+  alt="Next.js app with feature"
+  style={{ width: 500, margin: "0 auto" }}
+/>
+
+If you change employee to false in pages/\_app.js, you should see the welcome message disappear.
+
+The best part about targeting attributes in GrowthBook is that they are evaluated entirely locally. Sensitive user data is never sent over the network and there is no performance penalty. Some other libraries require an HTTP request to evaluate a feature for a user and this is often a deal breaker.
+
+## 6. Gradually roll out to your users
+
+After you test the new feature within your team, you probably want to start rolling it out to real users.
+
+We can do that with another rule in GrowthBook:
+
+<img
+  src="/images/guides/nextjs-6-rollout-rule.png"
+  alt="GrowthBook Rollout Rule"
+  style={{ width: 500, margin: "0 auto" }}
+/>
+
+In the targeting attributes in pages/\_app.js, make sure employee is set to false. That will ensure you skip the first rule we made and fall into the second rollout rule.
+
+:::note
+The GrowthBook SDK uses deterministic hashing to figure out whether or not
+someone is included in a rollout (or A/B test). The SDKs hash together the
+selected targeting attribute (id) and the feature key (welcome-message) and
+coverts it to a float between 0 and 1. If that float is less than or equal to
+the rollout percent, the user is included. This ensures a consistent UX and
+prevents one user from constantly switching between ON and OFF as they
+navigate your app.
+:::
+
+Try changing the user id in the targeting attributes in `pages/_app.js` to a few different random strings and see what happens. You should notice about half of the time the welcome message shows up and half of the time it doesn't.
+
+## Conclusion and Next Steps
+
+We showed here how to do a targeted rule, and how to do a rollout rule. It's also just as easy to make an A/B test in the same manner. You will need to set up an event tracking and connect GrowthBook to your data source.
+
+You can look at the [GrowthBook React SDK](/lib/react) docs for more ways to use feature flags in your code besides the `<IfFeatureEnabled>` component. Once you do the initial integration work, it only takes a few seconds to wrap your code in feature flags. Once you realize how easy and stress-free deploys and experimentation can be, there's no going back.
+
+## GrowthBook on Next.js 13 (Beta)
+
+Next.js 13 introduces a new paradigm in Next.js apps that delineate between **server-side** and **client-side** components. Among these changes include a new folder layout for the default Next.js app.
+
+The following examples illustrate how to use Growthbook using their new app folder layout:
+
+`app/GrowthBookProvider.tsx`
+
+```ts
+"use client";
+
+import { useEffect } from "react";
+import { usePathname } from "next/navigation";
+import {
+  GrowthBook,
+  GrowthBookProvider as Provider,
+  useFeature,
+} from "@growthbook/growthbook-react";
+import path from "path";
+
+const FEATURES_ENDPOINT = "http://localhost:3100/api/features/key_abc123";
+
+const growthbook = new GrowthBook({
+  trackingCallback: (experiment, result) => {
+    console.log("Viewed Experiment", experiment, result);
+  },
+});
+
+export default function GrowthBookProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const pathname = usePathname();
+
+  // Refresh features and targeting attributes on navigation
+  useEffect(() => {
+    fetch(FEATURES_ENDPOINT)
+      .then((res) => res.json())
+      .then((json) => {
+        growthbook.setFeatures(json.features);
+      });
+
+    growthbook.setAttributes({
+      id: "123",
+      loggedIn: true,
+      deviceId: "abcdef123456",
+      employee: true,
+      company: "acme",
+      country: "US",
+      browser: navigator.userAgent,
+      url: pathname,
+    });
+  }, [pathname]);
+
+  return <Provider growthbook={growthbook}>{children}</Provider>;
+}
+```
+
+Changes to `app/layout.tsx`
+
+```ts
+import GrowthBookProvider from "./GrowthBookProvider";
+import "./globals.css";
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      {/*
+        <head /> will contain the components returned by the nearest parent
+        head.tsx. Find out more at https://beta.nextjs.org/docs/api-reference/file-conventions/head
+      */}
+      <head />
+      <body>
+        <GrowthBookProvider>{children}</GrowthBookProvider>
+      </body>
+    </html>
+  );
+}
+```
+
+`app/WelcomeBanner.tsx`
+
+```ts
+"use client";
+
+import { useFeature, IfFeatureEnabled } from "@growthbook/growthbook-react";
+
+export default function WelcomeBanner() {
+  return (
+    <IfFeatureEnabled feature="welcome-message">
+      <h1>Welcome to the Growthbook demo!</h1>
+    </IfFeatureEnabled>
+  );
+}
+```
+
+Changes to `app/page.tsx`:
+
+```ts
+import WelcomeBanner from "./WelcomeBanner";
+```
+
+Insert into the JSX (above the Next.js Logo):
+
+```ts
++     <WelcomeBanner />
++
+      <div className={styles.center}>
+        <Image
+          className={styles.logo}
+          src="/next.svg"
+          alt="Next.js Logo"
+          width={180}
+          height={37}
+          priority
+        />
+        <div className={styles.thirteen}>
+          <Image src="/thirteen.svg" alt="13" width={40} height={31} priority />
+        </div>
+      </div>
+```
+
+Following the same steps as outlined earlier in the article, you should be able to toggle the WelcomeBanner component on and see the following:
+
+<img
+  src="/images/guides/next-13-title.png"
+  alt="Next.js app with feature"
+  style={{ width: 500, margin: "0 auto" }}
+/>
+
+Good luck!

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/guide/nextjs-and-growthbook.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/guide/nextjs-and-growthbook.mdx
@@ -1,7 +1,7 @@
 ---
 title: GrowthBook and Next.js
 description: This guide walks you through using GrowthBook with Next.js.
-sidebar_label: Next.js
+sidebar_label: Next.js 🚧
 slug: nextjs-and-growthbook
 ---
 

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/guide/rudderstack-and-nextjs-with-growthbook.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/guide/rudderstack-and-nextjs-with-growthbook.mdx
@@ -1,7 +1,7 @@
 ---
 title: GrowthBook, Rudderstack, and Next.js
 description: Learn how to use GrowthBook with Rudderstack to easily add A/B testing to your application running on Next.js
-sidebar_label: Rudderstack + Next.js
+sidebar_label: Rudderstack + Next.js 🚧
 slug: rudderstack-and-nextjs-with-growthbook
 ---
 

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/guide/rudderstack-and-nextjs-with-growthbook.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/guide/rudderstack-and-nextjs-with-growthbook.mdx
@@ -1,0 +1,259 @@
+---
+title: GrowthBook, Rudderstack, and Next.js
+description: Learn how to use GrowthBook with Rudderstack to easily add A/B testing to your application running on Next.js
+sidebar_label: Rudderstack + Next.js
+slug: rudderstack-and-nextjs-with-growthbook
+---
+
+# A/B Testing with Rudderstack and Next.js
+
+This document is a guide on how to add GrowthBook feature flags and A/B testing to your existing Next.js application using Rudderstack for event tracking.
+
+## 1. Create a GrowthBook Account
+
+You will need a GrowthBook account. You can either run GrowthBook locally or using the cloud hosted GrowthBook at
+[https://app.growthbook.io](https://app.growthbook.io). If you are installing it locally, you can follow the
+self-hosting quick start instructions here: [self hosting instructions](/self-host).
+
+## 2. Create a JS source in Rudderstack
+
+From within your Rudderstack account, create a new JS source.
+
+<img
+  src="/images/guides/rudderstack-7-create-source.png"
+  alt="Add Rudderstack JS source"
+  style={{ width: 600, margin: "0 auto" }}
+/>
+
+Name the source whatever you like, in this example I'm using `GrowthBook JS`. When the source is created, connect it to
+your BigQuery data warehouse (or whatever destination you're using for GrowthBook experiment data). You can read more
+about how to connect to your data destination [here](/guide/rudderstack).
+
+<img
+  src="/images/guides/rudderstack-8-source-w-destination.png"
+  alt="Add BigQuery destination"
+  style={{ width: 600, margin: "0 auto" }}
+/>
+
+Once you have it connected, copy the write key, as we'll need it for the next step.
+
+Under connections, you should now see the JS source connected to the BigQuery destination. You will also need the
+`Data plane URL` which appears near the top of the page.
+
+<img
+  src="/images/guides/rudderstack-9-connected-js.png"
+  alt="Add BigQuery destination"
+  style={{ width: 600, margin: "0 auto" }}
+/>
+
+## 3. Integrate Rudderstack into your Next.js application
+
+While there is plenty of documentation on how to add Rudderstack to your Next.js application out there, none of those
+implementations are very Next.js like, and limit the ability of Rudderstack to integrate more deeply into your code-
+including using GrowthBook. Below is the integration code that we came up with to address these concerns.
+
+### install the Rudderstack Analytics package
+
+Install the javascript SDK for Rudderstack with yarn,
+
+```bash
+yarn add rudder-sdk-js
+```
+
+or npm:
+
+```bash
+npm install --save rudder-sdk-js
+```
+
+### Create Rudderstack loader
+
+Create a `rudder.js` file in your Next.js project. This file will load Rudderstack's SDK in a reusable and asynchronous way.
+
+```javascript
+let rudder;
+async function getInstance() {
+  if (!rudder) {
+    rudder = await import("rudder-sdk-js");
+    rudder.load(
+      process.env.NEXT_PUBLIC_RUDDERSTACK_KEY,
+      process.env.NEXT_PUBLIC_RUDDERSTACK_HOST,
+      { integrations: { All: true } }
+    );
+    await new Promise((resolve) => rudder.ready(resolve));
+  }
+
+  return rudder;
+}
+
+const rudderObj = {
+  init: getInstance,
+  track: (...args) => getInstance().then((r) => r.track(...args)),
+  getAnonymousId: async () => getInstance().then((r) => r.getAnonymousId()),
+};
+
+export default rudderObj;
+```
+
+If you want to add other methods, like `identify`, you can extend the rudderObj.
+
+You'll also have to add the Rudderstack Key and Host to your environment variables, or add to your `.env.local` file:
+
+```javascript
+NEXT_PUBLIC_RUDDERSTACK_KEY=<your key>
+NEXT_PUBLIC_RUDDERSTACK_HOST=https://<rudderstack host>
+```
+
+The key is the `write key` from the JS source we made in step 2, and the HOST is the `data plane URL`.
+
+### Integrate Rudderstack into your Next.js application
+
+In your `_app.js`, add the Rudderstack integration we just created
+
+```javascript
+import rudder from "./rudder";
+```
+
+This will allow you add `rudder.track()` in your app anywhere you import rudder.js while sharing the same Rudderstack object.
+
+## 4. Integrate the GrowthBook React SDK into our Next.js app
+
+We first need to install the GrowthBook React SDK in our Next.js app:
+
+```bash
+yarn add @growthbook/growthbook-react
+```
+
+Get the API key from GrowthBook (under settings -> API or from the top of the implementation instructions) and add to your environment variables (.env.local)
+
+```js
+NEXT_PUBLIC_GROWTHBOOK_FEATURES_URL=<GrowthBook API url>
+```
+
+Then we can modify the code to work with GrowthBook. Modify the file `pages/_app.js` to add GrowthBook and Rudderstack. Import GrowthBook (and Rudderstack, if you haven't):
+
+```ts
+import {
+  GrowthBook,
+  GrowthBookProvider,
+  useFeature,
+} from "@growthbook/growthbook-react";
+import rudder from "./rudder";
+```
+
+then create your GrowthBook instance:
+
+```ts
+// Create a GrowthBook instance
+const growthbook = new GrowthBook({
+  trackingCallback: (experiment, result) => {
+    rudder.track("Experiment Viewed", {
+      experimentId: experiment.key,
+      variationId: result.variationId,
+    });
+  },
+});
+```
+
+:::note
+
+The names `experiment Viewed`, `experimentId` and `variationId` will be
+mapped to `experiment_id` and `variation_id` columns in the
+`experiment_viewed` table within BigQuery
+
+:::
+
+Then add a `useEffect` hook to update Rudderstack and GrowthBook when the page changes.
+
+```ts
+export default function MyApp({ Component, pageProps }) {
+  useEffect(() => {
+    // Load feature definitions from API
+    fetch(process.env.NEXT_PUBLIC_GROWTHBOOK_FEATURES_URL)
+      .then((res) => res.json())
+      .then((json) => {
+        growthbook.setFeatures(json.features);
+      });
+
+    // TODO: replace with real targeting attributes
+    growthbook.setAttributes({
+      company: "foo",
+      browser: "foo",
+      url: "foo",
+    });
+
+    // Add in Rudderstack anonId when loaded
+    rudder.getAnonymousId().then((id) => {
+      growthbook.setAttributes({ ...growthbook.getAttributes(), id });
+    });
+  }, []);
+
+  //...
+}
+```
+
+This code adds the `id` with in GrowthBook to the Rudderstack anonymous_id. If you want to load user_id as well as anonymous_id you'll have to add this id to the setAttribute, and also call the `rudder.identify()` with the user_id info.
+
+Finally, wrap your Next.js project in the GrowthBookProvider component, so we can use the GrowthBook methods throughout the codebase without doing addition instantiation.
+
+```ts
+return (
+  <GrowthBookProvider growthbook={growthbook}>
+    <Component {...pageProps} />
+  </GrowthBookProvider>
+);
+```
+
+All together, your `_app.js` should look something like this:
+
+```ts
+import "../styles/globals.css";
+import {
+  GrowthBook,
+  GrowthBookProvider,
+  useFeature,
+} from "@growthbook/growthbook-react";
+import { useEffect } from "react";
+import rudder from "./rudder";
+
+// Create a GrowthBook instance
+const growthbook = new GrowthBook({
+  trackingCallback: (experiment, result) => {
+    rudder.track("Experiment Viewed", {
+      experimentId: experiment.key,
+      variationId: result.variationId,
+    });
+  },
+});
+
+export default function MyApp({ Component, pageProps }) {
+  useEffect(() => {
+    // Load feature definitions from API
+    fetch(process.env.NEXT_PUBLIC_GROWTHBOOK_FEATURES_URL)
+      .then((res) => res.json())
+      .then((json) => {
+        growthbook.setFeatures(json.features);
+      });
+
+    // TODO: replace with real targeting attributes
+    growthbook.setAttributes({
+      company: "foo",
+      browser: "foo",
+      url: "foo",
+    });
+
+    // Add in Rudderstack anonId when loaded
+    rudder.getAnonymousId().then((id) => {
+      growthbook.setAttributes({ ...growthbook.getAttributes(), id });
+    });
+  }, []);
+
+  return (
+    <GrowthBookProvider growthbook={growthbook}>
+      <Component {...pageProps} />
+    </GrowthBookProvider>
+  );
+}
+```
+
+Once you have data flowing into Rudderstack, you can set it up to work with GrowthBook by following the [Rudderstack guide](/guide/rudderstack)

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/guide/rudderstack.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/guide/rudderstack.mdx
@@ -1,7 +1,7 @@
 ---
 title: GrowthBook and Rudderstack
 description: Learn how to use GrowthBook with Rudderstack to easily add A/B testing to your application
-sidebar_label: Rudderstack
+sidebar_label: Rudderstack 🚧
 slug: rudderstack
 ---
 

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/guide/rudderstack.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/guide/rudderstack.mdx
@@ -1,0 +1,110 @@
+---
+title: GrowthBook and Rudderstack
+description: Learn how to use GrowthBook with Rudderstack to easily add A/B testing to your application
+sidebar_label: Rudderstack
+slug: rudderstack
+---
+
+# Configuring GrowthBook to work with Rudderstack
+
+GrowthBook supports Rudderstack as an event source for easily adding A/B testing to your application. This document is a
+how-to guide for setting up Rudderstack with your application, connecting Rudderstack to BigQuery and then connecting
+GrowthBook to this data.
+
+## 1. Setup Rudderstack
+
+If you have already set up Rudderstack, you can skip this step. Rudderstack allows you to send events from your application to any data destination, including BigQuery, which is what we're going to use it for here.
+
+Once you have a Rudderstack account, you need to create a BigQuery bucket for the event data to be stored. You can follow the [directions from Rudderstack](https://www.rudderstack.com/docs/destinations/storage-platforms/google-cloud-storage/), but the short version is:
+
+- From the Google Cloud console for BigQuery, create a new bucket (or you can also use an already existing bucket).
+- Create a new service account under [IAM & Admin -> Service Accounts](https://console.cloud.google.com/iam-admin/serviceaccounts) for Rudderstack to connect to this bucket.
+- Give Storage `Object Admin` role access to the newly created service account.
+- Under the `actions` menu on the service account you just created, click on manage keys to create a new key. Choose key
+  type as JSON. This will cause a JSON key file to be downloaded to your computer.
+
+With the bucket created, we can create a Rudderstack warehouse destination.
+
+<img
+  src="/images/guides/rudderstack-1-addwarehouse.png"
+  alt="Add a data warehouse destination for Rudderstack"
+  style={{ width: 500, margin: "0 auto 20px" }}
+/>
+
+<img
+  src="/images/guides/rudderstack-2-adddestination.png"
+  alt="Select BigQuery from the list"
+  style={{ width: 500, margin: "0 auto 20px" }}
+/>
+
+<img
+  src="/images/guides/rudderstack-3-addbucket.png"
+  alt="Add the BigQuery account information"
+  style={{ width: 500, margin: "0 auto" }}
+/>
+
+The `Project` and `bucket name` needs to match the values you set up when creating the Google cloud project and bucket.
+
+Once you've created the destination, you should see it successfully connect
+
+<img
+  src="/images/guides/rudderstack-4-connection-completed.png"
+  alt="Successfully added the BigQuery account information"
+  style={{ width: 500, margin: "0 auto" }}
+/>
+
+And it will show up as a connected destination on your Rudderstack Connect dashboard.
+
+<img
+  src="/images/guides/rudderstack-4.5-bigQueryDestination.png"
+  alt="BigQuery connection in rudderstack"
+/>
+
+## 2. Connect GrowthBook
+
+Now that we have data flowing into BigQuery, we need to have GrowthBook connect to it. It
+is best practice to create another service account for GrowthBook to connect to BigQuery.
+(We have a complete guide on how to do this here: [Setting up BigQuery as a data source](/guide/bigquery))
+
+Navigate to Analysis -> Data Sources from within GrowthBook and click on 'Add Data Source'
+Button. From the window that pops up, select Rudderstack:
+
+<img
+  src="/images/new-data-sources-modal.png"
+  alt="Choose Rudderstack data schema"
+  style={{ width: 500, margin: "0 auto" }}
+/>
+
+After choosing RudderStack you'll be presented with a connection window to connect to BigQuery.
+
+<img
+  src="/images/guides/rudderstack-add-bigquery.png"
+  alt="Connect to your database"
+  style={{ width: 500, margin: "0 auto" }}
+/>
+
+When successfully connected, you'll be redirected to the data source page. You'll see all the connection
+options for BigQuery as well as the queries used. By choosing Rudderstack as you added the data source, GrowthBook
+will pre-populate the experiment exposure query which is need to determine which user saw which experiment variation.
+Depending on your needs, you may still need to adjust these queries - for instance if you're tracking both
+`anonymous_id` and `user_id`, you'll need to add the `user_id` query.
+
+## 3. Add Metrics
+
+GrowthBook needs to know what metrics you want to use in your experiments, and how to query this data from BigQuery.
+This step depends on your needs as an organization. Keep in mind that metric queries will be generic, returning all
+users who do an event, but will be joined to the experiment exposure information when determining the impact of
+experiment results.
+
+Metrics are added from the Analysis -> Metrics menu.
+
+<img
+  src="/images/guides/metrics-addmetric.png"
+  alt="Choose Rudderstack data schema"
+  style={{ width: 500, margin: "0 auto 20px" }}
+/>
+
+<img
+  src="/images/guides/metrics-metricoverview.png"
+  alt="Choose Rudderstack data schema"
+/>

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/index.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: GrowthBook Documentation
-sidebar_label: Overview
+title: Documentação do GrowthBook
+sidebar_label: Visão Geral
 id: introduction
 slug: /
 hide_table_of_contents: true
@@ -8,25 +8,25 @@ hide_table_of_contents: true
 
 import ButtonCard from '@site/src/components/ButtonCard'
 
-# Introduction
+# Introdução
 
-GrowthBook is an open-source platform for feature flagging and A/B testing built for data teams, engineers, and product managers.
-It's great whether you're looking to just analyze experiment results or looking to make it easier to deploy code.
+GrowthBook é uma plataforma de código aberto para feature flags e testes A/B, desenvolvido especialmente para times de dados, engenheiros e gerentes de produto.
+É ótimo se você deseja apenas analisar os resultados de um experimento ou facilitar a implementação de código.
 
-:::tip Got questions?
+:::tip Dúvidas?
 
-We would love to help you get started with GrowthBook. You can [meet with us](https://calendly.com/growthbook), or [join our Slack](https://slack.growthbook.io?ref=docs-home)
+Nós adoraríamos lhe ajudar a começar com o GrowthBook. Você pode agendar uma [conversa conosco](https://calendly.com/growthbook) ou [se juntar ao nosso Slack](https://slack.growthbook.io?ref=docs-home)
 
 :::
 
-### Quick Links
+### Links Rápidos
 
 <div className="row is-multiline">
     <div className="col col--4">
         <ButtonCard
             to={'/overview'}
-            title="How it works"
-            description="Learn about what GrowthBook does and how it works"
+            title="Como funciona"
+            description="Aprenda o que é o GrowthBook e como ele funciona"
             style={{ height: '100%' }}
             color="default"
         ></ButtonCard>
@@ -34,16 +34,16 @@ We would love to help you get started with GrowthBook. You can [meet with us](ht
         <div className="col col--4">
             <ButtonCard
                 to={'/self-host'}
-                title="Self-Host"
-                description="Learn about running GrowthBook on your own infrastructure"
+                title="Hospedagem Própria"
+                description="Aprenda utilizar o GrowthBook em sua própria infraestrutura"
                 style={{ height: '100%' }}
             ></ButtonCard>
         </div>
     <div className="col col--4">
         <ButtonCard
             to={'/lib'}
-            title="SDK Docs"
-            description="Learn about the GrowthBook SDKs"
+            title="Documentação do SDK"
+            description="Aprenda sobre os SDKs do GrowthBook"
             style={{ height: '100%' }}
             color="default"
         ></ButtonCard>
@@ -52,33 +52,33 @@ We would love to help you get started with GrowthBook. You can [meet with us](ht
     <ButtonCard
       aLink={true}
       to={'/open-guide-to-ab-testing.v1.0.pdf'}
-      title="Get our open source guide to successful A/B testing"
-      description="This guide outlines everything you need to know as you scale up experimentation at your company. It covers everything from foundational knowledge (“what is an A/B test?”) to advanced topics and common mistakes."
+      title="Obtenha nosso guia gratuito de como obter sucesso com testes A/B"
+      description="Este guia descreve tudo o que você precisa saber para escalar a experimentação em sua empresa. Abrange desde conhecimento básico (“o que é um teste A/B?”) até tópicos avançados e erros comuns"
       style={{ height: '100%' }}
       color="default"
     ></ButtonCard>
   </div>
 </div>
 
-## Our Goals
+## Nossos Objetivos
 
-Companies spend thousands of hours building internal tools for feature flagging and experimentation (A/B testing).
-They do this in part because they want to run these systems on their own infrastructure, using their own data, and have them deeply integrated into their code.
+As empresas gastam milhares de horas criando ferramentas internas de feature flag e criação de experimentos (testes A/B).
+Um dos motivos é porque desejam ter esses sistemas em sua própria infraestrutura, usando seus próprios dados integrados profundamente em seu código.
 
-GrowthBook gives data, engineering, and product teams the power of a customizable platform without needing to build it yourself.
+O GrowthBook oferece às equipes de dados, engenharia e produtos o poder de uma plataforma personalizável sem a necessidade de construí-la você mesmo.
 
-We believe that **feature flagging** is the best way to deploy features and easily adopt an experimentation culture.
+Acreditamos que o uso de **feature flags** é a melhor maneira de implementar funcionalidades e adotar facilmente uma cultura de experimentação.
 
-We believe A/B testing should sit on top of your **existing data and metrics**, wherever they live and however they are defined.
+Acreditamos que os testes A/B devem se basear em seus **dados e métricas** existentes, onde quer que estejam e tenham sido definidos.
 
-We believe in **data transparency**. You can export results as a Jupyter notebook and our Bayesian stats engine is developed out in the open on [GitHub](https://github.com/growthbook/growthbook/tree/main/packages/stats).
+Acreditamos na **transparência de dados**. Você pode exportar os resultados como um notebook Jupyter e nosso motor de estatística Bayesiano é desenvolvido de forma aberta no [GitHub](https://github.com/growthbook/growthbook/tree/main/packages/stats).
 
-We are fanatical about **performance**. Our [SDKs](/lib) are crazy fast and light-weight and evaluate everything locally with no network requests.
+Somos fanáticos por **desempenho**. Nossos [SDKs](/lib) são incrivelmente rápidos e leves e avaliam tudo localmente sem solicitações de rede.
 
-We believe good ideas come from everywhere. GrowthBook gives you feature flags so its easy to **test everything** and make experimentation part of your process.
+Acreditamos que boas ideias vêm de todos os lugares. O GrowthBook fornece feature flags para que seja fácil **testar tudo** e tornar a experimentação parte do seu processo.
 
-## Documentation
+## Documentação
 
-Use the menu or the Previous/Next links at the bottom to navigate these docs.
+Use o menu ou os botões de Anterior/Próxima para navegar entre as páginas dessa documentação.
 
-[Join us on Slack](https://slack.growthbook.io?ref=docs-home) if you need help, want to chat, or are thinking of a new feature. We're here to help - and to make GrowthBook even better.
+[Junte-se a nós no Slack](https://slack.growthbook.io?ref=docs-home) se você precisar de alguma ajuda, quiser conversar ou discutir alguma ideia de uma nova funcionalidade. Nós estamos aqui para ajudar - e tornar o GrowthBook cada vez melhor.

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/index.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/index.mdx
@@ -1,0 +1,84 @@
+---
+title: GrowthBook Documentation
+sidebar_label: Overview
+id: introduction
+slug: /
+hide_table_of_contents: true
+---
+
+import ButtonCard from '@site/src/components/ButtonCard'
+
+# Introduction
+
+GrowthBook is an open-source platform for feature flagging and A/B testing built for data teams, engineers, and product managers.
+It's great whether you're looking to just analyze experiment results or looking to make it easier to deploy code.
+
+:::tip Got questions?
+
+We would love to help you get started with GrowthBook. You can [meet with us](https://calendly.com/growthbook), or [join our Slack](https://slack.growthbook.io?ref=docs-home)
+
+:::
+
+### Quick Links
+
+<div className="row is-multiline">
+    <div className="col col--4">
+        <ButtonCard
+            to={'/overview'}
+            title="How it works"
+            description="Learn about what GrowthBook does and how it works"
+            style={{ height: '100%' }}
+            color="default"
+        ></ButtonCard>
+    </div>
+        <div className="col col--4">
+            <ButtonCard
+                to={'/self-host'}
+                title="Self-Host"
+                description="Learn about running GrowthBook on your own infrastructure"
+                style={{ height: '100%' }}
+            ></ButtonCard>
+        </div>
+    <div className="col col--4">
+        <ButtonCard
+            to={'/lib'}
+            title="SDK Docs"
+            description="Learn about the GrowthBook SDKs"
+            style={{ height: '100%' }}
+            color="default"
+        ></ButtonCard>
+    </div>
+  <div className="col margin-top--md">
+    <ButtonCard
+      aLink={true}
+      to={'/open-guide-to-ab-testing.v1.0.pdf'}
+      title="Get our open source guide to successful A/B testing"
+      description="This guide outlines everything you need to know as you scale up experimentation at your company. It covers everything from foundational knowledge (“what is an A/B test?”) to advanced topics and common mistakes."
+      style={{ height: '100%' }}
+      color="default"
+    ></ButtonCard>
+  </div>
+</div>
+
+## Our Goals
+
+Companies spend thousands of hours building internal tools for feature flagging and experimentation (A/B testing).
+They do this in part because they want to run these systems on their own infrastructure, using their own data, and have them deeply integrated into their code.
+
+GrowthBook gives data, engineering, and product teams the power of a customizable platform without needing to build it yourself.
+
+We believe that **feature flagging** is the best way to deploy features and easily adopt an experimentation culture.
+
+We believe A/B testing should sit on top of your **existing data and metrics**, wherever they live and however they are defined.
+
+We believe in **data transparency**. You can export results as a Jupyter notebook and our Bayesian stats engine is developed out in the open on [GitHub](https://github.com/growthbook/growthbook/tree/main/packages/stats).
+
+We are fanatical about **performance**. Our [SDKs](/lib) are crazy fast and light-weight and evaluate everything locally with no network requests.
+
+We believe good ideas come from everywhere. GrowthBook gives you feature flags so its easy to **test everything** and make experimentation part of your process.
+
+## Documentation
+
+Use the menu or the Previous/Next links at the bottom to navigate these docs.
+
+[Join us on Slack](https://slack.growthbook.io?ref=docs-home) if you need help, want to chat, or are thinking of a new feature. We're here to help - and to make GrowthBook even better.

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/integrations/index.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/integrations/index.mdx
@@ -1,0 +1,10 @@
+# GrowthBook integrations
+
+GrowthBook plans on supporting more integrations in the near future. If you have a suggestion for an integration,
+please let us know in our [Community Slack](https://slack.growthbook.io?ref=docs-integrations)
+or via email at support@growthbook.io.
+
+## Integrations list
+
+- [Vercel](/integrations/vercel)
+- [Slack](/integrations/slack)

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/integrations/slack.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/integrations/slack.mdx
@@ -1,0 +1,111 @@
+---
+toc_max_heading_level: 5
+---
+
+import ExternalLink from '@site/src/components/ExternalLink'
+
+# Slack integration
+
+The GrowthBook Slack integration allows you to receive alerts for the events that you care about in a Slack channel of your choosing.
+
+:::success New
+
+The GrowthBook Slack integration is a brand new feature. If you experience any issues, let us know either on [Slack](https://slack.growthbook.io/) or [create an issue](https://github.com/growthbook/growthbook-sdk-java/issues).
+
+:::
+
+## Creating and configuring an app in Slack
+
+### Create a Slack app
+
+The first step to setting up the GrowthBook Slack integration is to create a new app under your workspace's owned apps. You will need administrative privileges for your workspace in order to be able to manage apps.
+
+Navigate to your workspace’s apps and choose to create a new app. You can get to that page directly [here](https://api.slack.com/apps?new_app=1).
+
+<img
+  src="/images/integrations/slack/slack-create-app.png"
+  alt="Create an app from scratch"
+/>
+
+Name the app and choose the workspace. In this case we are created the app named GrowthBook Alerts and are picking the GrowthBook Dev workspace.
+
+<img
+  src="/images/integrations/slack/slack-name-app-choose-workspace.png"
+  alt="Name your app and choose Growthbook Dev workspace"
+/>
+
+### Create an Incoming Webhook
+
+We will be alerting via Slack's incoming webhooks functionality. Under the **Basic Information** tab of your app, click on **Incoming Webhooks**.
+
+<img
+  src="/images/integrations/slack/slack-incoming-webhooks.png"
+  alt="Select Incoming Webhooks"
+/>
+
+### Subscribe a channel to alerts
+
+Click on the button at the bottom of the **Incoming Webhooks** page that says **Add New Webhook to Workspace**.
+
+You will be asked to install the app into your workspace. Choose the desired channel you'd like to receive notifications in.
+
+<img
+  src="/images/integrations/slack/slack-install-flow.png"
+  alt="Choose and allow a channel"
+/>
+
+Once you've completed this flow, you will see a URL available for you to copy. Save this value for later.
+
+<img
+  src="/images/integrations/slack/slack-copy-webhook-url.png"
+  alt="Activate and copy webhook url"
+/>
+
+## Add the Slack integration to GrowthBook
+
+Next step is to login to the GrowthBook app and visit the **Slack** tab under **Integrations**, also available [here](https://app.growthbook.io/integrations/slack). You will need privileges to manage integrations in order for this menu item to be available.
+
+Click the **Create a Slack integration** button. You should see a modal pop up with some fields for configuring the Slack integration.
+
+<img
+  src="/images/integrations/slack/slack-gb-new-integration.png"
+  alt="Add Slack integration information"
+/>
+
+### Copy the Slack app credentials
+
+Go to the **App Credentials** section on the **Basic Information** page.
+
+From here, you will need to copy the following details from Slack:
+
+- **Slack App ID**: Copy the Slack app ID from the Basic Information page
+- **Slack Signing Secret**: Copy the signing secret from the Basic Information page
+- **Webhook URL**: Copy the webhook URL from the Incoming Webhooks page
+
+Then, configure the following:
+
+- **Name**: The name of the integration. In case you have multiple integrations, this can help you tell them apart. This will also show in the contextual text alongside the alerts.
+- **Description**: Optionally add a description for you and your team
+- **Event filters**: You can optionally filter by events you care about. For example, if you only care about when features are deleted, you can choose `feature.deleted` from the list. If you care about all events, leave this blank.
+- **Environment filters**: You can optionally choose to filter by environment. For example, if you only want to hear about events that are for the production environment, you can choose `production` from the list. For all environments, leave this blank.
+- **Project filters**: You can optionally choose to filter by project. For example, if you have a project named "Onboarding V2" and you only want to alert for that project, you can choose that project from the projects list. For all projects, leave this blank.
+- **Tag filters**: You can optionally choose to filter by tag. For all events regardless of tag, leave this blank.
+
+After configuring all the fields, press **Create** to save your new Slack integration configuration.
+
+You can also edit these fields at any point if you make a mistake.
+
+<img
+  src="/images/integrations/slack/slack-gb-config.png"
+  alt="Edit Slack integration if you need it"
+/>
+
+### Adding more alerts
+
+If you'd like to be alerted in another Slack channel, you can add another Incoming Webhook in Slack.
+
+Then, you can create new integrations in the GrowthBook dashboard, specifying all of the same information except adding your new webhook URL.
+
+## Testing your alerts
+
+You are now ready to test your alerts. Perform one of the actions you're watching if you've added Event filters. If you haven't added any event filters, the quickest way to test it's working is to either create a new test feature (then delete it if it's not needed), or toggle an environment on or off for an existing feature.

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/integrations/vercel.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/integrations/vercel.mdx
@@ -1,0 +1,80 @@
+# Configuring GrowthBook with Vercel
+
+_This guide assumes that you already have a Vercel account and have at least one Vercel project_
+
+This integration creates GrowthBook API keys and creates matching keys as Environment Variables in Vercel (for use with any of [our SDKs](/lib)).
+
+## Keys created
+
+`GROWTHBOOK_KEY`: This key will be used with the SDK of your choice.
+
+## 1. Navigate to the GrowthBook Vercel integration
+
+<a href="https://vercel.com/integrations/growthbook" target="_blank">
+  https://vercel.com/integrations/growthbook
+</a>
+
+## 2. Click on the "Add Integration" button
+
+Located in the upper right corner of the page, click on the "Add Integration" button.
+
+<img
+  src="/images/integrations/vercel-add-integration.png"
+  alt="Add Mixpanel service account specifics"
+  style={{ width: 700, margin: "0 auto" }}
+/>
+
+## 3. Choose which account you want to use for the integration
+
+The account selected will determine which projects are shown in the next step.
+
+<img
+  src="/images/integrations/vercel-choose-account.png"
+  alt="Add Mixpanel service account specifics"
+  style={{ width: 400, margin: "0 auto" }}
+/>
+
+## 4. Choose which projects you want GrowthBook to be enabled for
+
+<img
+  src="/images/integrations/vercel-choose-project.png"
+  alt="Add Mixpanel service account specifics"
+  style={{ width: 400, margin: "0 auto" }}
+/>
+
+## 5. Setup your environments
+
+`GROWTHBOOK_KEY` will be added as an environment variable to your project.
+Configure each Vercel environment to map to its correct GrowthBook environment. For example, if you are
+using "production" for your Vercel environment you will most likely want to set your GrowthBook Environment to
+"production".
+
+_Note: If you leave a GrowthBook environment as None, neither GrowthBook nor Vercel keys will be created for that environment._
+
+<img
+  src="/images/integrations/vercel-environments.png"
+  alt="Add Mixpanel service account specifics"
+  style={{ width: 400, margin: "0 auto" }}
+/>
+
+By clicking "Submit" both sets of keys will be created for all of your environments.
+
+## 6. Integration configuration
+
+You will then be taken to the integration page. From here you can click on "Configure" in the top right corner to
+view the created keys.
+
+<img
+  src="/images/integrations/vercel-configure.png"
+  alt="Add Mixpanel service account specifics"
+  style={{ width: 400, margin: "0 auto" }}
+/>
+
+You can also look at your keys from GrowthBook & Vercel:
+
+GrowthBook Keys are located <a href="https://app.growthbook.io/settings/keys" target="_blank">here</a><br/>
+Vercel Keys are located in the "Environment Variables" section of your project settings.
+
+## 7. Next steps
+
+Configure an SDK with your project using the keys you just created. [Click here to view our SDKs](/lib).

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/build-your-own.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/build-your-own.mdx
@@ -1,5 +1,5 @@
 ---
-title: Build Your Own
+title: Build Your Own 🚧
 description: This guide is meant for library authors looking to build a GrowthBook SDK in a currently unsupported language.
 sidebar_label: Build Your Own
 slug: build-your-own

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/build-your-own.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/build-your-own.mdx
@@ -1,0 +1,1045 @@
+---
+title: Build Your Own
+description: This guide is meant for library authors looking to build a GrowthBook SDK in a currently unsupported language.
+sidebar_label: Build Your Own
+slug: build-your-own
+---
+
+# Build Your Own SDK
+
+**Latest spec version: 0.4.0 [View Changelog](#changelog)**
+
+This guide is meant for library authors looking to build a GrowthBook SDK in a currently unsupported language.
+
+GrowthBook SDKs are very simple and do not interact with the filesystem or network. Because of this, they can often be kept to **under 1000 lines of code**.
+
+All libraries should follow this specification as closely as the language permits to maintain consistency.
+
+## Data structures
+
+Here are a number of important data structures in GrowthBook SDKs, listed alphabetically.
+
+### Attributes
+
+**Attributes** are an arbitrary JSON object containing user and request attributes. Here's an example:
+
+```json
+{
+  "id": "123",
+  "anonId": "abcdef",
+  "company": "growthbook",
+  "url": "/pricing",
+  "country": "US",
+  "browser": "firefox",
+  "age": 25,
+  "beta": true,
+  "account": {
+    "plan": "team",
+    "seats": 10
+  }
+}
+```
+
+### BucketRange
+
+A tuple that describes a range of the numberline between `0` and `1`.
+
+The tuple has 2 parts, both floats - the start of the range and the end. For example:
+
+```ts
+[0.3, 0.7];
+```
+
+### Condition
+
+A **Condition** is evaluated against **Attributes** and used to target features/experiments to specific users.
+
+The syntax is inspired by MongoDB queries. Here is an example:
+
+```ts
+{
+  "country": "US",
+  "browser": {
+    "$in": ["firefox", "chrome"]
+  },
+  "email": {
+    "$not": {
+      "$regex": "@gmail.com$"
+    }
+  }
+}
+```
+
+### Context
+
+**Context** object passed into the GrowthBook constructor. Has a number of optional properties:
+
+- **enabled** (`boolean`) - Switch to globally disable all experiments. Default true.
+- **apiHost** (`string`) - The GrowthBook API Host. Optional
+- **clientKey** (`string`) - The key used to fetch features from the GrowthBook API. Optional
+- **decryptionKey** (`string`) - The key used to decrypt encrypted features from the API. Optional
+- **attributes** (`Attributes`) - Map of user attributes that are used to assign variations
+- **url** (`string`) - The URL of the current page
+- **features** (`FeatureMap`) - Feature definitions (usually pulled from an API or cache)
+- **forcedVariations** (`ForcedVariationsMap`) - Force specific experiments to always assign a specific variation (used for QA)
+- **qaMode** (`boolean`) - If true, random assignment is disabled and only explicitly forced variations are used.
+- **trackingCallback** (`TrackingCallback`) - A function that takes `experiment` and `result` as arguments.
+
+### Experiment
+
+Defines a single **Experiment**. Has a number of properties:
+
+- **key** (`string`) - The globally unique identifier for the experiment
+- **variations** (`any[]`) - The different variations to choose between
+- **weights** (`float[]`) - How to weight traffic between variations. Must add to 1.
+- **active** (`boolean`) - If set to false, always return the control (first variation)
+- **coverage** (`float`) - What percent of users should be included in the experiment (between 0 and 1, inclusive)
+- **ranges** (`BucketRange[]`) - Array of ranges, one per variation
+- **condition** (`Condition`) - Optional targeting condition
+- **namespace** (`Namespace`) - Adds the experiment to a namespace
+- **force** (`integer`) - All users included in the experiment will be forced into the specific variation index
+- **hashAttribute** (`string`) - What user attribute should be used to assign variations (defaults to `id`)
+- **hashVersion** (`integer`) - The hash version to use (default to `1`)
+- **meta** (`VariationMeta[]`) - Meta info about the variations
+- **filters** (`Filter[]`) - Array of filters to apply
+- **seed** (`string`) - The hash seed to use
+- **name** (`string`) - Human-readable name for the experiment
+- **phase** (`string`) - Id of the current experiment phase
+
+The only required properties are `key` and `variations`. Everything else is optional.
+
+### ExperimentResult
+
+The result of running an **Experiment** given a specific **Context**
+
+- **inExperiment** (`boolean`) - Whether or not the user is part of the experiment
+- **variationId** (`int`) - The array index of the assigned variation
+- **value** (`any`) - The array value of the assigned variation
+- **hashUsed** (`boolean`) - If a hash was used to assign a variation
+- **hashAttribute** (`string`) - The user attribute used to assign a variation
+- **hashValue** (`string`) - The value of that attribute
+- **featureId** (`string` or `null`) - The id of the feature (if any) that the experiment came from
+- **key** (`string`) - The unique key for the assigned variation
+- **bucket** (`float`) - The hash value used to assign a variation (float from `0` to `1`)
+- **name** (`string` or `null`) - The human-readable name of the assigned variation
+- **passthrough** (`boolean`) - Used for holdout groups
+
+The `variationId` and `value` should always be set, even when `inExperiment` is false.
+
+The `hashAttribute` and `hashValue` should always be set, even when `hashUsed` is false.
+
+The `key` should always be set, even if `experiment.meta` is not defined or incomplete. In that case, convert the variation's array index to a string (e.g. `0` -> `"0"`) and use that as the `key` instead.
+
+### Feature
+
+A **Feature** object consists of a default value plus rules that can override the default.
+
+- **defaultValue** (`any`) - The default value (should use `null` if not specified)
+- **rules** (`FeatureRule[]`) - Array of **FeatureRule** objects that determine when and how the defaultValue gets overridden
+
+### FeatureMap
+
+A hash or map of **Feature** objects. Keys are string ids for the features. Values are **Feature** objects. For example:
+
+```js
+{
+  "feature-1": {
+    "defaultValue": false
+  },
+  "my_other_feature": {
+    "defaultValue": 1,
+    "rules": [
+      {
+        "force": 2
+      }
+    ]
+  }
+}
+```
+
+### FeatureResult
+
+The result of evaluating a **Feature**. Has a number of properties:
+
+- **value** (`any`) - The assigned value of the feature
+- **on** (`boolean`) - The assigned value cast to a boolean
+- **off** (`boolean`) - The assigned value cast to a boolean and then negated
+- **source** (`enum`) - One of "unknownFeature", "defaultValue", "force", or "experiment"
+- **experiment** (`Experiment` or `null`) - When source is "experiment", this will be an Experiment object
+- **experimentResult** (`ExperimentResult` or `null`) - When source is "experiment", this will be an ExperimentResult object
+
+### FeatureRule
+
+Overrides the defaultValue of a **Feature**. Has a number of optional properties
+
+- **condition** (`Condition`) - Optional targeting condition
+- **coverage** (`float`) - What percent of users should be included in the experiment (between 0 and 1, inclusive)
+- **force** (`any`) - Immediately force a specific value (ignore every other option besides condition and coverage)
+- **variations** (`any[]`) - Run an experiment (A/B test) and randomly choose between these variations
+- **key** (`string`) - The globally unique tracking key for the experiment (default to the feature key)
+- **weights** (`float[]`) - How to weight traffic between variations. Must add to 1.
+- **namespace** (`Namespace`) - Adds the experiment to a namespace
+- **hashAttribute** (`string`) - What user attribute should be used to assign variations (defaults to `id`)
+- **hashVersion** (`integer`) - The hash version to use (default to `1`)
+- **range** (`BucketRange`) - A more precise version of `coverage`
+- **ranges** (`BucketRange[]`) - Ranges for experiment variations
+- **meta** (`VariationMeta[]`) - Meta info about the experiment variations
+- **filters** (`Filter[]`) - Array of filters to apply to the rule
+- **seed** (`string`) - Seed to use for hashing
+- **name** (`string`) - Human-readable name for the experiment
+- **phase** (`string`) - The phase id of the experiment
+- **tracks** (`TrackData[]`) - Array of tracking calls to fire
+
+### Filter
+
+Object used for mutual exclusion and filtering users out of experiments based on random hashes. Has the following properties:
+
+- **seed** (`string`) - The seed used in the hash
+- **ranges** (`BucketRange[]`) - Array of ranges that are included
+- **hashVersion** (`integer`) - The hash version to use (default to `2`)
+- **attribute** (`string`, optional) - The attribute to use (default to `"id"`)
+
+### ForcedVariationsMap
+
+A hash or map that forces an **Experiment** to always assign a specific variation. Useful for QA.
+
+Keys are the experiment key, values are the array index of the variation. For example:
+
+```json
+{
+  "my-test": 0,
+  "other-test": 1
+}
+```
+
+### Namespace
+
+A tuple that specifies what part of a namespace an experiment includes. If two experiments are in the same namespace and their ranges don't overlap, they wil be mutually exclusive.
+
+The tuple has 3 parts:
+
+1. The namespace id (`string`)
+2. The beginning of the range (`float`, between `0` and `1`)
+3. The end of the range (`float`, between `0` and `1`)
+
+For example:
+
+```ts
+["namespace1", 0, 0.5];
+```
+
+### TrackingCallback
+
+A callback function that is executed every time a user is included in an **Experiment**. Here's an example:
+
+```js
+function track(experiment, result) {
+  analytics.track("Experiment Viewed", {
+    experimentId: experiment.key,
+    variationId: result.variationId,
+  });
+}
+```
+
+### TrackData
+
+Used for remote feature evaluation to trigger the `TrackingCallback`. An object with 2 properties:
+
+- **experiment** - `Experiment`
+- **result** - `ExperimentResult`
+
+### VariationMeta
+
+Meta info about an experiment variation. Has the following properties:
+
+- **key** (`string`, optional) - A unique key for this variation
+- **name** (`string`, optional) - A human-readable name for this variation
+- **passthrough** (`boolean`, optional) - Used to implement holdout groups
+
+## Helper Functions
+
+There are some helper functions which are used a few times throughout the SDK.
+
+### hash(seed: string, value: string, version: integer): float
+
+Hashes a string to a float between 0 and 1.
+
+Uses the simple [Fowler–Noll–Vo](https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function) algorithm, specifically fnv32a. An implementation of this is available in most languages already, and if not it's only a few lines of code to implement yourself. Fnv32a returns an integer, so we convert that to a float using a modulus.
+
+The original hash version (1) had a flaw that caused bias when running experiments in parallel.
+
+```ts
+// New hashing algorithm
+if (version === 2) {
+  n = fnv32a(fnv32a(seed + value) + "");
+  return (n % 10000) / 10000;
+}
+// Original hashing algorithm (with a bias flaw)
+else if (version === 1) {
+  n = fnv32a(value + seed);
+  return (n % 1000) / 1000;
+}
+
+return -1;
+```
+
+**Note**: It's important to use the exact hashing algorithms outlined here so all SDKs behave identically.
+
+### inRange(n: float, range: BucketRange): boolean
+
+Determines if a number `n` is within the provided range.
+
+```js
+return n >= range[0] && n < range[1]>;
+```
+
+### inNamespace(userId: string, namespace: Namespace): boolean
+
+This checks if a userId is within an experiment namespace or not.
+
+The `namespace` argument is a tuple with 3 parts: id (string), start (float), and end (float).
+
+1. Hash the userId and namespace name with two underscores as a delimiter
+   ```ts
+   n = hash("__" + namespace[0], userId, 1);
+   ```
+2. Return if hash is greater than (inclusive) the namespace start and less than (exclusive) the namespace end:
+   ```ts
+   return n >= namespace[1] && n < namespace[2];
+   ```
+
+### getEqualWeights(numVariations: integer): float[]
+
+Returns an array of floats with `numVariations` items that are all equal and sum to 1. For example, `getEqualWeights(2)` would return `[0.5, 0.5]`.
+
+It's ok if the sum is slightly off due to rounding. So a sum of `0.9999999` is fine for example.
+
+1. If numVariations is less than 1, return empty array
+2. Create array with a length of `numVariations`
+3. Fill the array with `1.0/numVariations` and return
+
+### getBucketRanges(numVariations: integer, coverage: float, weights: float[]): BucketRange[]
+
+This converts and experiment's coverage and variation weights into an array of bucket ranges.
+
+`numVariations` is an integer, `coverage` is a float, and `weights` is an array of floats.
+
+1. Clamp the value of `coverage` to between 0 and 1 inclusive.
+   ```ts
+   if (coverage < 0) coverage = 0;
+   if (coverage > 1) coverage = 1;
+   ```
+2. Default to equal weights if the weights don't match the number of variations.
+   ```ts
+   if (weights.length != numVariations) {
+     weights = getEqualWeights(numVariations);
+   }
+   ```
+3. Default to equal weights if the sum is not equal `1` (or close enough when rounding errors are factored in):
+   ```ts
+   if (sum(weights) < 0.99 || sum(weights) > 1.01) {
+     weights = getEqualWeights(numVariations);
+   }
+   ```
+4. Convert weights to ranges and return
+
+   ```ts
+   cumulative = 0;
+   ranges = [];
+
+   for (w in weights) {
+     start = cumulative;
+     cumulative += w;
+     ranges.push([start, start + coverage * w]);
+   }
+
+   return ranges;
+   ```
+
+Some examples:
+
+- `getBucketRanges(2, 1, [0.5, 0.5])` -> `[[0, 0.5], [0.5, 1]]`
+- `getBucketRanges(2, 0.5, [0.4, 0.6])` -> `[[0, 0.2], [0.4, 0.7]]`
+
+### chooseVariation(n: float, ranges: BucketRange[]): integer
+
+Given a hash and bucket ranges, assign one of the bucket ranges.
+
+1. Loop through ranges
+   1. If n is within the range, return the range index
+      ```ts
+      if (inRange(n, ranges[i])) {
+        return i;
+      }
+      ```
+2. Return `-1` if it makes it through the whole ranges array without returning
+
+If multiple ranges match, return the first matching one.
+
+### getQueryStringOverride(id: string, url: string, numVariations: integer): null|integer
+
+This checks if an experiment variation is being forced via a URL query string. This may not be applicable for all SDKs (e.g. mobile).
+
+As an example, if the id is `my-test` and url is `http://localhost/?my-test=1`, you would return `1`.
+
+If possible, you should use a proper URL parsing library vs relying on simple regexes.
+
+Return `null` if any of these are true:
+
+- There is no querystring
+- The id is not a key in the querystring
+- The variation is not an integer
+- The variation is less than 0 or greater than or equal to numVariations
+
+## Evaluating Conditions
+
+In addition to the helper functions above, there are a number of methods related to evaluating targeting conditions.
+
+There is only one public method `evalCondition` and everything else is a private helper function.
+
+### public evalCondition(attributes: Attributes, condition: Condition): boolean
+
+This is the main function used to evaluate a condition.
+
+1. If condition has a key `$or`, return `evalOr(attributes, condition["$or"])`
+2. If condition has a key `$nor`, return `!evalOr(attributes, condition["$nor"])`
+3. If condition has a key `$and`, return `evalAnd(attributes, condition["$and"])`
+4. If condition has a key `$not`, return `!evalCondition(attributes, condition["$not"])`
+5. Loop through the condition key/value pairs
+   1. If `evalConditionValue(value, getPath(attributes, key))` is false, break out of loop and return false
+6. Return true
+
+### private evalOr(attributes: Attributes, conditions: Condition[]): boolean
+
+`conditions` is an array of Condition objects
+
+1. If conditions is empty, return true
+2. Loop through conditions
+   1. If `evalCondition(attributes, conditions[i])` is true, break out of the loop and return true
+3. Return false
+
+### private evalAnd(attributes: Attributes, conditions: Condition[]): boolean
+
+`conditions` is an array of Condition objects
+
+1. Loop through conditions
+   1. If `evalCondition(attributes, conditions[i])` is false, break out of the loop and return false
+2. Return true
+
+### private isOperatorObject(obj): boolean
+
+This accepts a parsed JSON object as input and returns `true` if every key in the object starts with `$`.
+
+- `{"$gt": 1}` -> `true`
+- `{"$gt": 1, "$lt": 10}` -> `true`
+- `{"foo": "bar"}` -> `false`
+- `{"$gt": 1, "foo": "bar"}` -> `false`
+
+If the object is empty and has no keys, this should also return true.
+
+### private getType(attributeValue): string
+
+This returns the data type of the passed in argument.
+
+The valid types to return are:
+
+- `string`
+- `number`
+- `boolean`
+- `array`
+- `object`
+- `null`
+- `undefined`
+- `unknown`
+
+The difference between `null` and `undefined` can be illustrated as follows:
+
+```ts
+obj = JSON.parse('{"foo": null}');
+
+getType(obj["foo"]); // null
+
+getType(obj["bar"]); // undefined
+```
+
+The value `unknown` is there just in case you can't figure out the data type for whatever reason. It will never be used in most implementations.
+
+### private getPath(attributes: Attributes, path: string): any
+
+Given attributes and a dot-separated path string, return the value at that path (or `null`/`undefined` if the path doesn't exist)
+
+Given the input:
+
+```json
+{
+  "name": "john",
+  "job": {
+    "title": "developer"
+  }
+}
+```
+
+It should return:
+
+- `getPath(input, "name")` -> `"john"`
+- `getPath(input, "job.title")` -> `"developer"`
+- `getPath(input, "job.company")` -> `null` or `undefined`
+
+### private evalConditionValue(conditionValue, attributeValue): boolean
+
+1. If `conditionValue` is an object and `isOperatorObject(conditionValue)` is true
+   1. Loop over each key/value pair
+      1. If `evalOperatorCondition(key, attributeValue, value)` is false, return false
+   2. Return true
+2. Else, do a deep comparison between `attributeValue` and `conditionValue`. Return true if equal, false if not.
+
+### private elemMatch(condition, attributeValue): boolean
+
+This checks if `attributeValue` is an array, and if so at least one of the array items must match the condition
+
+1. If `attributeValue` is not an array, return false
+2. Loop through items in `attributeValue`
+   1. If `isOperatorObject(condition)`
+      1. If `evalConditionValue(condition, item)`, break out of loop and return true
+   2. Else if `evalCondition(item, condition)`, break out of loop and return true
+3. Return false
+
+### private evalOperatorCondition(operator, attributeValue, conditionValue)
+
+This function is just a case statement that handles all the possible operators
+
+There are basic comparison operators in the form `attributeValue {op} conditionValue`:
+
+- `$eq` ==
+- `$ne` != (not equals)
+- `$lt` &lt;
+- `$lte` &lt;=
+- `$gt` &gt;
+- `$gte` &gt;=
+- `$regex` ~ (regex match)
+
+There are 2 operators where conditionValue is an array:
+
+- `$in`
+  1. Return true if attributeValue in the conditionValue array, false otherwise
+- `$nin`
+  1. Return false if attributeValue in the conditionValue array, true otherwise
+
+There are 2 operators where attributeValue is an array:
+
+- `$elemMatch`
+  1. Return `elemMatch(conditionValue, attributeValue)`
+- `$size`
+  1.  If attributeValue is not an array, return false
+  2.  Return `evalConditionValue(conditionValue, attributeValue.length)`
+
+There is 1 operator where both attributeValue and conditionValue are arrays:
+
+- `$all`
+  1. If attributeValue is not an array, return false
+  2. Loop through conditionValue array
+     1. If none of the elements in the attributeValue array pass `evalConditionValue(conditionValue[i], attributeValue[j])`, return false
+  3. Return true
+
+There are 3 other operators:
+
+- `$exists`
+  1. If conditionValue is false, return true if attributeValue is null or undefined
+  2. Else, return true if attributeValue is NOT null or undefined
+  3. Return false by default
+- `$type`
+  1. Return `getType(attributeValue) == conditionValue`
+- `$not`
+  1. Return `!evalConditionValue(conditionValue, attributeValue)`
+
+If operator doesn't match any of these, return false and potentially log the error for debug purposes.
+
+## GrowthBook Class
+
+The GrowthBook class is the main export of the SDK.
+
+### constructor
+
+The constructor takes a Context object and stores the properties for later. Nothing else needs to be done during initialization.
+
+This class has a few helper methods as well as 2 main public methods - `evalFeature` and `run`.
+
+### Getters and Setters
+
+There should be simple getters and setters for a few of the context properties:
+
+- `attributes`
+- `features`
+- `forcedVariations`
+- `url`
+- `enabled`
+
+### private getFeatureResult(value, source, experiment, experimentResult): FeatureResult
+
+This is a helper method to create a `FeatureResult` object. The first two arguments, `value`, and `source` are required. The last two, `experiment` and `experimentResult` are optional and should default to `null`.
+
+Besides the passed-in arguments, there are two derived values - `on` and `off`, which are just the value cast to booleans.
+
+value can be any JSON type. Only the following values are considered to be "falsy":
+
+- `null`
+- `false`
+- `""`
+- `0`
+
+Everything else is considered "truthy", including empty arrays and objects.
+
+If value is "truthy", then `on` should be true and `off` should be false. If the value is "falsy", then they should take opposite values.
+
+### private isFilteredOut(filters: Filters[]): boolean
+
+This is a helper method to evaluate `filters` for both feature flags and experiments.
+
+1. Loop through filters array
+   1. Get the hashAttribute and hashValue
+   ```ts
+   hashAttribute = filter.attribute || "id";
+   hashValue = context.attributes[hashAttribute] || "";
+   ```
+   2. If hashValue is empty, return `true`
+   3. Determine the bucket for the user
+      ```ts
+      n = hash(filter.seed, hashValue, filter.hashVersion || 2);
+      ```
+   4. If `inRange(n, range)` is false for every range in `filter.ranges`, return `true`
+2. If you made it through the entire array without returning early, return `false` now
+
+### private isIncludedInRollout(seed: string, hashAttribute: string | null, range: BucketRange | null, coverage: float | null, hashVersion: integer | null): boolean
+
+Determines if the user is part of a gradual feature rollout.
+
+1. Either `coverage` or `range` are required. If both are `null`, return `true` immediately
+2. Get the hashAttribute and hashValue
+   ```ts
+   hashAttribute = hashAttribute || "id";
+   hashValue = context.attributes[hashAttribute] || "";
+   ```
+3. If `hashValue` is empty, return `false` immediately
+4. Determine the bucket for the user
+   ```ts
+   n = hash(seed, hashValue, hashVersion || 1)
+   ```
+5. Check if user is included
+
+   ```js
+   if (range) {
+    return inRange(n, range)
+   }
+   else if (coverage !== null) {
+    return n <= coverage
+   }
+
+   return true
+   ```
+
+### private getExperimentResult(experiment, variationIndex, hashUsed, featureId, bucket): ExperimentResult
+
+This is a helper method to create an `ExperimentResult` object. The arguments are:
+
+- `experiment` - Experiment object (required)
+- `variationIndex` - The assigned variation index (optional, default to `-1`)
+- `hashUsed` - Whether or not the hash was used to assign a variation (optional, default to `false`)
+- `featureId` - The id of the feature (if any) that the experiment came from (optional, default to `null`)
+- `bucket` - The hash bucket value for the user. Float from `0` to `1` (optional, default to `null`)
+
+The method is pretty simple:
+
+1. Handle case when user is not in the experiment (e.g. variationIndex = -1)
+   ```ts
+   // By default, assume everyone is in the experiment
+   let inExperiment = true;
+   // If the variation is invalid, use the baseline and set the inExperiment flag to false
+   if (variationIndex < 0 || variationIndex >= experiment.variations.length) {
+     variationIndex = 0;
+     inExperiment = false;
+   }
+   ```
+2. Get the hashAttribute and hashValue
+   ```ts
+   hashAttribute = experiment.hashAttribute || "id";
+   hashValue = context.attributes[hashAttribute] || "";
+   ```
+3. Get meta info for the assigned variation (if any)
+   ```ts
+   meta = experiment.meta ? experiment.meta[variationIndex] : null
+   ```
+4. Build return object
+   ```ts
+   res = {
+     key: (meta && meta.key) ? meta.key : ("" + variationIndex),
+     featureId: featureId,
+     inExperiment: inExperiment,
+     hashUsed: hashUsed,
+     variationId: variationIndex,
+     value: experiment.variations[variationIndex],
+     hashAttribute: hashAttribute,
+     hashvalue: hashValue,
+   };
+   ```
+5. Add optional properties and return
+
+   ```ts
+   if (meta && meta.name) res.name = meta.name;
+   if (meta && meta.passthrough) res.passthrough = true;
+   if (bucket !== null) res.bucket = bucket;
+
+   return res;
+   ```
+
+### public evalFeature(key: string): FeatureResult
+
+The `evalFeature` method takes a single string argument, which is the unique identifier for the feature and returns a `FeatureResult` object.
+
+```js
+growthbook = new GrowthBook(context);
+myFeature = growthbook.evalFeature("my-feature");
+```
+
+There are a few ordered steps to evaluate a feature
+
+1. If the key doesn't exist in `context.features`
+   1. Return `getFeatureResult(null, "unknownFeature")`
+2. Loop through the feature rules (if any)
+   1. If the rule has a `condition`
+      1. If `evalCondition(context.attributes, rule.condition)` is false, skip this rule and continue to the next one
+   2. If the rule has `filters` defined
+      1. if `isFilteredOut(rule.filters)`, skip this rule and continue to the next one
+   3. If `rule.force` is set
+      1. If not `isIncludedInRollout`, skip this rule and continue to the next one
+         ```ts
+         if (!isIncludedInRollout(
+           rule.seed || featureKey,
+           rule.hashAttribute,
+           rule.range,
+           rule.coverage,
+           rule.hashVersion
+         )) {
+          continue;
+         }
+         ```
+      2. If `rule.tracks` is set, fire the `TrackingCallback` for each element in the `rule.tracks` array.
+      3. Return `getFeatureResult(rule.force, "force")`
+   4. Otherwise, convert the rule to an Experiment object
+      ```ts
+      const exp = {
+        variations: rule.variations,
+        key: rule.key || featureKey,
+      };
+      ```
+   5. Copy over additional settings from the rule to `exp` if defined:
+      - `coverage`
+      - `weights`
+      - `hashAttribute`
+      - `namespace`
+      - `meta`
+      - `ranges`
+      - `name`
+      - `phase`
+      - `seed`
+      - `filters`
+   6. Run the experiment
+      ```ts
+      result = run(exp);
+      ```
+   7. If `result.inExperiment` is false OR `result.passthrough` is true, skip this rule and continue to the next one
+   8. Otherwise, return
+      ```ts
+      return getFeatureResult(result.value, "experiment", exp, result);
+      ```
+3. Return `getFeatureResult(feature.defaultValue || null, "defaultValue")`
+
+### public run(experiment: Experiment): ExperimentResult
+
+The `run` method takes an Experiment object and returns an `ExperimentResult`.
+
+There are a bunch of ordered steps to run an experiment:
+
+1.  If `experiment.variations` has fewer than 2 variations, return `getExperimentResult(experiment)`
+2.  If `context.enabled` is false, return `getExperimentResult(experiment)`
+3.  If `context.url` exists
+    ```ts
+    qsOverride = getQueryStringOverride(experiment.key, context.url);
+    if (qsOverride != null) {
+      return getExperimentResult(experiment, qsOverride);
+    }
+    ```
+4.  Return if forced via context
+    ```ts
+    if (experiment.key in context.forcedVariations) {
+      return getExperimentResult(
+        experiment,
+        context.forcedVariations[experiment.key]
+      );
+    }
+    ```
+5.  If `experiment.active` is set to false, return `getExperimentResult(experiment)`
+6.  Get the user hash value and return if empty
+    ```ts
+    hashAttribute = experiment.hashAttribute || "id";
+    hashValue = context.attributes[hashAttribute] || "";
+    if (hashValue == "") {
+      return getExperimentResult(experiment);
+    }
+    ```
+7.  Apply filters and namespace
+    1.  If `experiment.filters` is set
+        ```js
+        if (isFilteredOut(experiment.filters)) {
+         return getExperimentResult(experiment)
+        }
+        ```
+    2.  Else if `experiment.namespace` is set, return if not in range
+        ```ts
+        if (!inNamespace(hashValue, experiment.namespace)) {
+         return getExperimentResult(experiment);
+        }
+        ```
+8.  If `experiment.condition` is set return if it evaluates to false
+    ```ts
+    if (!evalCondition(context.attributes, experiment.condition)) {
+      return getExperimentResult(experiment);
+    }
+    ```
+9.  Calculate bucket ranges for the variations and choose one
+    ```ts
+    ranges = experiment.ranges || getBucketRanges(
+      experiment.variations.length,
+      experiment.converage ?? 1,
+      experiment.weights ?? []
+    );
+    n = hash(
+      experiment.seed || experiment.key,
+      hashValue,
+      experiment.hashVersion || 1
+    );
+    assigned = chooseVariation(n, ranges);
+    ```
+10. If assigned == `-1`, return `getExperimentResult(experiment)`
+11. If experiment has a forced variation, return
+    ```ts
+    if ("force" in experiment) {
+      return getExperimentResult(experiment, experiment.force);
+    }
+    ```
+12. If `context.qaMode`, return `getExperimentResult(experiment)`
+13. Build the result object
+    ```ts
+    result = getExperimentResult(experiment, assigned, true, n);
+    ```
+14. Fire `context.trackingCallback` if set and the combination of hashAttribute, hashValue, experiment.key, and variationId has not been tracked before
+15. Return `result`
+
+### Feature helper methods
+
+There are 3 tiny helper methods that wrap `evalFeature` for a better developer experience:
+
+```js
+public isOn(key) {
+  return this.evalFeature(key).on
+}
+
+public isOff(key) {
+  return this.evalFeature(key).off
+}
+
+public getFeatureValue(key, fallback) {
+  value = this.evalFeature(key).value
+  return value === null ? fallback : value
+}
+```
+
+For strongly typed languages, you can use generics (if supported) for `getFeatureValue` and coerce the return value to always match the data type of fallback. If generics are not supported, you can use type-specific versions of the function such as `getFeatureValueAsString`.
+
+## Fetching and Caching Features
+
+When the Context contains a `clientKey`, the SDK should fetch and cache features automatically.
+
+If `apiHost` is not specified, default to `https://cdn.growthbook.io`. Make sure to strip and trailing slashes on user-entered hosts (e.g. `http://example.com/` becomes `http://example.com`).
+
+Features should be fetched from `{apiHost}/api/features/{clientKey}` and all errors should be handled gracefully. A network error while fetching features should never be a fatal error that stops execution.
+
+The API responses should be parsed and cached so future GrowthBook instances with the same clientKey can avoid a duplicate network request. The standard cache TTL to use is 60 seconds.
+
+For best performance, a stale-while-revalidate pattern should be used. If a cache entry is older than the TTL, return the cached value immediately and start a background process to update the cache from the API.
+
+The initial download should be intiated by a `growthbook.loadFeatures()` method call. This method may take optional parameters, such as `timeout` or `skipCache`, if it makes sense.
+
+There should be an easy way for the user to wait until features finish loading. Depending on the language, this might be an event emitter, a Promise, a callback, or something similar. Use whatever method is standard for the language.
+
+### Server Sent Events
+
+The API response (`/api/features/{clientKey}`) may contain a response header:
+
+> x-sse-support: enabled
+
+If set to "enabled", you are able to subscribe to the API for realtime changes to feature definitions. This will let you update the cache immediately when a feature changes instead of waiting for the 60s TTL to expire.
+
+The URL for subscribing to changes is `{apiHost}/sub/{clientKey}`. An example implementation in Javascript is below:
+
+```js
+const channel = new EventSource(`${apiHost}/sub/${clientKey}`);
+channel.addEventListener("features", (event) => {
+  const data = JSON.parse(event.data);
+  cache.set(clientKey, data.features);
+})
+```
+
+### Encrypted Features
+
+The `/api/features/{clientKey}` endpoint can have encryption enabled (128-bit AES-CBC). When this is the case, the API response will look like this:
+
+```js
+{
+  "features": {},
+  "encryptedFeatures": "abcdef123456.ghijklmnop789jksdkfaksfadfasdfkahsfa"
+}
+```
+
+Before you can use this response, you will need to decrypt it. This requires the user to set `Context.decryptionKey` when creating the GrowthBook instance.
+
+Look at the Javascript SDK for an example decryption implementation.
+
+## Type Hinting
+
+Most languages have some sort of strong typing support, whether in the language itself or via annotations. This helps to reduce errors and is highly encouraged for SDKs.
+
+If possible, use generics to type the return value. For example, if `experiment.variations` is type `T[]`, then `result.value` should be type `T`. Or, if the fallback of `getFeatureValue` is type `string`, the return type should also be type `string`.
+
+## Handling Errors
+
+The general rule is to be strict in development and lenient in production.
+
+You can throw exceptions in development, but someone's production app should never crash because of a call to `growthbook.evalFeature` or `growthbook.run`.
+
+For the below edge cases in production, just act as if the problematic property didn't exist and ignore errors:
+
+- `experiment.weights` is a different length from `experiment.variations`
+- `experiment.weights` adds up to something other than 1
+- `experiment.coverage` or `feature.coverage` is greater than 1 or less than 0
+- `context.trackingCallback` throws an error
+- URL querystring specifies an invalid variation index
+
+For the below edge cases in production, the experiment should be disabled (everyone gets assigned variation `0`):
+
+- `experiment.coverage` is less than 0
+- `experiment.force` specifies an invalid variation index
+- `context.forcedVariations` specifies an invalid variation index
+- `experiment.hashAttribute` is an empty string
+
+## Subscriptions
+
+Sometimes it's useful to be able to "subscribe" to a GrowthBook instance and be alerted every time `growthbook.run` is called. This is different from the tracking callback since it also fires when a user is _not_ included in an experiment.
+
+```js
+growthbook.subscribe(function (experiment, result) {
+  // do something
+});
+```
+
+It's best to only re-fire the callbacks for an experiment if the result has changed. That means either the `inExperiment` flag has changed or the `variationId` has changed.
+
+If it makes sense for your language, this function should return an "unsubscriber". A simple callback that removes the subscription.
+
+```js
+unsubscriber = growthbook.subscribe(...)
+unsubscriber()
+```
+
+In addition to subscriptions you may also want to expose a `growthbook.getAllResults` method that returns a map of the latest results indexed by experiment key.
+
+## Memory Management
+
+Subscriptions and tracking calls require storing references to many objects and functions. If it makes sense for your language, libraries should provide a `growthbook.destroy` method to remove all of these references and release their memory.
+
+## Tests
+
+We strive to have 100% test coverage for all of our SDKs.
+
+There is a language-agnostic test suite stored as a JSON file `packages/sdk-js/test/cases.json` with more than 200 unit tests. This extensively tests all of the public methods mentioned above.
+
+The cases.json file is an object. The keys are the function being tested, and the values are arrays of test cases. The test case arrays structure is different for each function and listed below:
+
+- **hash**
+  - seed (string)
+  - value to hash (string)
+  - hash version to use (integer)
+  - expected result (float)
+- **getBucketRange**
+  - Name of the test case (string)
+  - Arguments array ([numVariations, coverage, weights or null])
+  - expected result
+- **chooseVariation**
+  - name of the test case (string)
+  - n (hash)
+  - bucket ranges
+  - expected result
+- **getQueryStringOverride**
+  - name of the test case (string)
+  - experiment key
+  - url
+  - numVariations
+  - expected result
+- **inNamespace**
+  - name of the test case (string)
+  - id
+  - namespace
+  - expected result
+- **getEqualWeights**
+  - numVariations
+  - expected result (weights rounded to 8 decimal places)
+- **evalCondition**
+  - name of the test case (string)
+  - condition
+  - attributes
+  - expected return value (boolean)
+- **feature** (evalFeature)
+  - name of the test case (string)
+  - context passed into GrowthBook constructor
+  - name of the feature (string)
+  - expected result
+- **run**
+  - name of the test case (string)
+  - context passed into GrowthBook constructor
+  - experiment object
+  - expected value
+  - inExperiment (boolean)
+  - hashUsed (boolean)
+
+In addition to the above, you should write custom test cases for things like event subscriptions, tracking callbacks, getters/setters, etc. that are more language-specific.
+
+## Getting Help
+
+Join our [Slack community](https://slack.growthbook.io?ref=docs-buildyourown) if you need help or want to chat. We're also happy to hop on a call and do some pair programming.
+
+## Attribution
+
+Open a [GitHub issue](https://github.com/growthbook/growthbook/issues) with a link to your project and we'll make sure we add it to our docs and give you proper credit for your hard work.
+
+## Changelog
+
+- **v0.1** 2022-05-23
+  - Don't skip experiment rules that are forced
+- **v0.2** 2022-07-19
+  - Add `featureId` to ExperimentResult object
+- **v0.2.1** 2022-08-01
+  - Add test case for when an experiment's hashAttribute is `null`
+- **v0.2.2** 2022-09-08
+  - Add test case for when an experiment's hashAttribute is an integer
+- **v0.2.3** 2022-12-06
+  - Add test case for when an experiment's coverage is set to 0
+- **v0.3.0** 2023-01-18
+  - New `apiHost`, `clientKey`, and `decryptionKey` Context properties
+  - Built-in fetching and caching
+  - Server Sent Events (SSE) support for realtime feature updates
+- **v0.4.0** 2023-02-24
+  - Changed signature of `hash` method and added multiple hashing versions
+  - New `inRange`, `isIncludedInRollout`, and `isFilteredOut` helper methods
+  - New `hashVersion`, `range`, `ranges`, `meta`, `filters`, `seed`, `name`, `tracks`, and `phase` properties of FeatureRules
+  - New `hashVersion`, `ranges`, `meta`, `filters`, `seed`, `name`, and `phase` properties of Experiments
+  - New `key`, `name`, `bucket`, and `passthrough` fields in Experiment Results
+  - New `Filter`, `VariationMeta`, and `TrackData` data structures

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/csharp.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/csharp.mdx
@@ -1,0 +1,124 @@
+---
+title: C# SDK
+description: GrowthBook SDK for C#
+sidebar_label: C#
+slug: csharp
+---
+
+# C#
+
+View the full documentation on [GitHub](https://github.com/growthbook/growthbook-c-sharp).
+
+[![nuget badge for growthbook](https://img.shields.io/nuget/v/growthbook-c-sharp?style=flat-square)](https://www.nuget.org/packages/growthbook-c-sharp)
+
+## Installation
+
+```csharp
+    dotnet add package growthbook-c-sharp
+```
+
+## Quick Usage
+
+This library is based on the [GrowthBook SDK specs](https://docs.growthbook.io/lib/build-your-own) and should be compatible with the usage examples in the [GrowthBook docs](https://docs.growthbook.io/).
+
+Down below you'll find two basic examples on how the package works.
+
+### Basic
+
+1. Declare features
+
+   ```csharp
+
+   var staticFeatures = new Dictionary<string, Feature>
+   {
+       {"firstFeature", new Feature{ DefaultValue = true}},
+       {"secondFeature", new Feature{ DefaultValue = false}}
+   };
+   ```
+
+2. Create a context and add the features
+
+   ```csharp
+   var context = new Context
+   {
+       Enabled = true,
+       Url = "",
+       Features = staticFeatures
+   };
+   ```
+
+3. Create the `GrowthBook` object with the context
+
+   ```csharp
+   using GrowthBook;
+   //...
+
+   var GrowthBook = new GrowthBook.GrowthBook(context);
+   ```
+
+4. Check whether a feature is enabled
+
+   ```csharp
+   GrowthBook.IsOn("firstFeature") // true
+   GrowthBook.IsOn("secondFeature") // false
+   ```
+
+### Loading feature definitions from an API
+
+Because feature definitions are typically loaded from API calls or cache, [Json.NET](https://www.nuget.org/packages/Newtonsoft.Json/13.0.2-beta1)
+objects are used to represent arbitrary document types such as Attributes, Conditions, and Feature values.
+
+To load your features from the GrowthBook API use the following example:
+
+1. Create a result model for the API response
+
+   ```csharp
+   public class FeaturesResult
+   {
+       public HttpStatusCode Status { get; set; }
+       public IDictionary<string, Feature>? Features { get; set; }
+       public DateTimeOffset? DateUpdated { get; set; }
+   }
+   ```
+
+2. call the endpoint and deserialize result
+
+   ```csharp
+   var url = "YOUR_GROWTHBOOK_URL/api/features/YOUR_API_KEY";
+   var response = await client.GetAsync(url);
+
+   if (response.IsSuccessStatusCode)
+   {
+       var content = await response.Content.ReadAsStringAsync();
+       var featuresResult = JsonConvert.DeserializeObject<FeaturesResult>(content);
+   }
+   ```
+
+3. Construct a context and initialize GrowthBook
+
+   ```csharp
+   var GrowthBook = new GrowthBook.GrowthBook(
+       new Context {
+           Enabled = true,
+           Url = "",
+           Features = featuresResult.Features,
+       }
+   );
+   ```
+
+#### Generic getters
+
+To make it easier to deal with Feature values, generic getter functions are provided for the following:
+
+- Experiment:
+  - `GetVariations<T>()`
+- ExperimentResult:
+  - `GetValue<T>()`
+- Feature:
+  - `GetDefaultValue<T>()`
+- FeatureResult:
+  - `GetValue<T>()`
+- Feature Rule:
+  - `GetVariations<T>()`
+- GrowthBook:
+  - `GetFeatureValue<T>(string key, T fallback)`

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/csharp.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/csharp.mdx
@@ -1,5 +1,5 @@
 ---
-title: C# SDK
+title: C# SDK 🚧
 description: GrowthBook SDK for C#
 sidebar_label: C#
 slug: csharp

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/flutter.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/flutter.mdx
@@ -1,5 +1,5 @@
 ---
-title: Flutter SDK
+title: Flutter SDK 🚧
 description: Flutter SDK for GrowthBook
 sidebar_label: Flutter
 slug: flutter

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/flutter.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/flutter.mdx
@@ -1,0 +1,122 @@
+---
+title: Flutter SDK
+description: Flutter SDK for GrowthBook
+sidebar_label: Flutter
+slug: flutter
+---
+
+# Flutter
+
+This SDK supports the following versions:
+
+- **Android version 21 & above**
+- **iOS version 12 & Above**
+- **Apple TvOS version 13 & Above**
+- **Apple WatchOS version 7 & Above**
+
+## Installation
+
+Add this to your `pubspec.yaml` file
+
+```
+growthbook_sdk_flutter: ^1.0.0
+```
+
+## Quick Usage
+
+To create a GrowthBook SDK instance, use `GBSDKBuilderApp`. Then, you can evaluate feature flags or run experiments.
+
+```dart
+// User attributes for targeting and assigning users to experiment variations
+val attrs = HashMap<String, Any>()
+attrs.put("id", "123")
+attrs.put("env", "dev")
+attrs.put("betaUser", true)
+
+final GrowthBookSDK sdkInstance = GBSDKBuilderApp(
+  apiKey: "<API_KEY>",
+  attributes: {
+    attrs
+  },
+  growthBookTrackingCallBack: (gbExperiment, gbExperimentResult) {},
+  hostURL: '<GrowthBook_URL>',
+).initialize();
+
+if (gb.feature("my-feature").on) {
+  // Feature is enabled!
+}
+```
+
+## Using Features
+
+The `feature` method takes a String feature name and returns a `GBFeatureResult` object with a few useful properties:
+
+- **value** (`dynamic`) - The assigned value of the feature
+- **on** (`bool`) - The value cast to a boolean
+- **off** (`bool`) - The value cast to a boolean and then negated
+- **source** (`String`) - Why the value was assigned to the user. One of "unknownFeature", "defaultValue", "force", or "experiment"
+
+When the source is "experiment", there are 2 additional properties that tell you which experiment was used and more details about the result of the experiment:
+
+- **experiment** (`GBExperiment`)
+- **experimentResult** (`GBExperimentResult`)
+
+Here are some examples:
+
+```dart
+GBFeatureResult feature = gb.feature("my-feature")
+
+// Do something if feature is truthy
+if (feature.on) { }
+
+// Do something if feature is falsy
+if (feature.off) { }
+
+// Print the actual value of the feature
+// (depending on the feature, might be a string, number, boolean, etc.)
+Println(feature.value)
+
+// Print the experiment id used to assign the feature value
+if (feature.source == "experiment") {
+  Println(feature.experiment.key)
+}
+```
+
+## Running Inline Experiments
+
+Instead of just using features defined in the GrowthBook API, you can also just run an experiment directly. This is done with the `run` method which takes a `GBExperiment` object as an argument and returns a `GBExperimentResult` object:
+
+```dart
+var exp = GBExperiment()
+exp.key = "my-experiment"
+exp.variations = List.of("control", "variation")
+
+var result = gb.run(exp)
+
+// Either "control" or "variation"
+Println(result.value)
+```
+
+The `GBExperiment` class has two required properties - `key` and `variations`. There are also a number of optional properties:
+
+- **key** (`String`) - The unique identifier for this experiment
+- **variations** (`dynamic[]`) - Array of variations to decide between
+- **weights** (`double[]`) - How to weight traffic between variations. Must add to 1.
+- **active** (`bool`) - If set to false, always return the control (first variation)
+- **coverage** (`double`) - What percent of users should be included in the experiment (between 0 and 1, inclusive)
+- **condition** (`GBCondition`) - Optional targeting condition
+- **namespace** (`[String, int, int]`) - Adds the experiment to a namespace
+- **force** (`int`) - All users included in the experiment will be forced into the specific variation index
+- **hashAttribute** (`String`) - What user attribute should be used to assign variations (defaults to `id`)
+
+The `GBExperimentResult` object returns the following properties:
+
+- **inExperiment** (`bool`)
+- **variationId** (`int`) - The array index of the assigned variation
+- **value** (`dynamic`) - The value of the assigned variation
+- **hashAttribute** (`String`) - The user attribute used to assign a variation
+- **hashValue** (`String`) - The value of the attribute used to assign a variation
+
+## More Documentation
+
+The GitHub repo for this SDK has more detailed class and method documentation - https://github.com/alippo-com/GrowthBook-SDK-Flutter

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/go.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/go.mdx
@@ -1,0 +1,490 @@
+---
+title: Go SDK
+description: GrowthBook SDK for Golang
+sidebar_label: Go
+slug: go
+toc_max_heading_level: 5
+---
+
+import ExternalLink from '@site/src/components/ExternalLink'
+
+# GrowthBook Go SDK
+
+## Installation
+
+```
+go get github.com/growthbook/growthbook-golang
+```
+
+## Quick Usage
+
+The main public API for the SDK is provided through the `Context` and
+`GrowthBook` types. The `Context` type provides a means to pass
+settings to the main `GrowthBook` type, while the `GrowthBook` type
+provides a `Feature` method for accessing feature values, and a `Run`
+method for running inline experiments.
+
+```go
+// GBFeaturesResponse
+// GrowthBook features response
+type GBFeaturesResponse struct {
+	Status            int             `json:"status"`
+	Features          json.RawMessage `json:"features"`
+	EncryptedFeatures string          `json:"encryptedFeatures,omitempty"` // Not yet supported in the Go SDK
+	DateUpdated       time.Time       `json:"dateUpdated"`
+}
+
+// Get JSON from GrowthBook and deserialize it into GBFeaturesResponse struct
+res, err := http.Get("https://cdn.growthbook.io/api/features/<environment_key>")
+if err != nil {
+	fmt.Printf("Error fetching features from GrowthBook: %s \n", err)
+	os.Exit(1)
+}
+
+var featuresResponse GBFeaturesResponse
+err = json.NewDecoder(res.Body).Decode(&featuresResponse)
+if err != nil {
+	fmt.Printf("Error decoding JSON: %s \n", err)
+	os.Exit(1)
+}
+
+features := growthbook.ParseFeatureMap(featuresResponse.Features)
+
+// Optional tracking callback
+// This will get called when the font_colour experiment below is evaluated
+// See "Tracking and subscriptions" section below
+trackingCallback := func(experiment *growthbook.Experiment, result *growthbook.ExperimentResult) {
+	fmt.Printf("Experiment Viewed: %s - Variation index: %d - Value: %s \n", experiment.Key, result.VariationID, result.Value)
+}
+
+// Set up user attributes - See Attributes below for more info
+userAttributes := growthbook.Attributes{
+	"id": "user-abc123",
+	"country": "canada",
+}
+
+// Create a growthbook.Context instance with the features and attributes
+context := growthbook.NewContext().
+	WithFeatures(features).
+	WithAttributes(userAttributes).
+	WithTrackingCallback(trackingCallback)
+
+// Create a growthbook.GrowthBook instance
+gb := growthbook.New(context)
+
+// Get a string value
+bannerText := gb.Feature("banner_text").GetValueWithDefault("(unknown banner text)")
+
+// Perform feature test.
+if gb.Feature("dark_mode").On {
+	// ...
+}
+
+// Evaluate an inline experiment and cast the result to a string (or the known type)
+experiment := growthbook.
+	NewExperiment("font_colour").
+	WithVariations("red", "orange", "yellow", "green", "blue", "purple")
+result := gb.Run(experiment)
+var fontColour = result.Value.(string)
+
+fmt.Println(fontColour)
+
+experiment2 :=
+  growthbook.NewExperiment("complex-experiment").
+    WithVariations(
+      map[string]string{"color": "blue", "size": "small"},
+      map[string]string{"color": "green", "size": "large"},
+    ).
+    WithWeights(0.8, 0.2).
+    WithCoverage(0.5)
+
+result2 := gb.Run(experiment2)
+fmt.Println(result2.Value.(map[string]string)["color"],
+  result2.Value.(map[string]string)["size"])
+```
+
+## The GrowthBook Context
+
+A new `Context` is created using the `NewContext` function and its
+fields can be set using the `WithEnabled`, `WithAttributes`,
+`WithURL`, `WithFeatures`, `WithForcedVariations`, `WithQAMode` and
+`WithTrackingCallback` methods. These `With...` methods return a
+`Context` pointer to enable call chaining. Context details can
+alternatively be parsed from JSON data (see [JSON data
+representations](#json-data-representations)). The fields in a
+`Context` include information about the user for whom feature results
+will be evaluated (the `Attributes`), the features that are defined,
+plus some additional values to control forcing of feature results
+under some circumstances.
+
+Given a `Context` value, a new `GrowthBook` value can be created using
+the `New` function. The `GrowthBook` type has some getter and setter
+methods (setters are methods with names of the form `With...`) for
+fields of the associated `Context`. As well as providing access to the
+underlying Context and exposing the main `Feature` and `Run` methods,
+the `GrowthBook` type also keeps track of the results of experiments
+that are performed, in order to implement tracking and experiment
+subscription callbacks.
+
+For example, assuming that the `growthbook` package is imported with
+name "`growthbook`", the following code will create a `Context` and
+`GrowthBook` value using features parsed from JSON data and some fixed
+attributes:
+
+```go
+// Parse feature map from JSON.
+features := growthbook.ParseFeatureMap(featureJSON)
+
+// Create context and main GrowthBook object.
+context := growthbook.NewContext().
+  WithFeatures(features).
+  WithAttributes(growthbook.Attributes{
+    "country": "US",
+    "browser": "firefox",
+  })
+gb := growthbook.New(context)
+```
+
+### Features
+
+The `WithFeatures` method of `Context` takes a `FeatureMap` value,
+which is defined as `map[string]*Feature`, and which can be created
+from JSON data using the `ParseFeatureMap` function (see [JSON data
+representations](#json-data-representations)). You can pass a feature
+map generated this way to the `WithFeatures` method of `Context` or
+`GrowthBook`:
+
+```go
+featureMap := ParseFeatureMap([]byte(
+  `{ "feature-1": {...},
+     "feature-2": {...},
+     "another-feature": {...}
+   }`))
+
+gb := NewContext().WithFeatures(featureMap)
+```
+
+If you need to load feature definitions from a remote source like an
+API or database, you can update the context at any time with
+`WithFeatures`.
+
+If you use the GrowthBook App to manage your features, you don't need
+to build this JSON file yourself -- it will auto-generate one for you
+and make it available via an API endpoint.
+
+If you prefer to build this file by hand or you want to know how it
+works under the hood, check out the detailed [Feature
+Definitions](#feature-definitions) section below.
+
+### Attributes
+
+You can specify attributes about the current user and request. These
+are used for two things:
+
+- Feature targeting (e.g. paid users get one value, free users get
+  another);
+- Assigning persistent variations in A/B tests (e.g. user id "123"
+  always gets variation B).
+
+Attributes can be any JSON data type -- boolean, integer, string,
+array, or object and are represented by the `Attributes` type, which
+is an alias for the generic `map[string]interface{}` type that Go uses
+for JSON objects. If you know them up front, you can pass them into
+`Context` or `GrowthBook` using `WithAttributes`:
+
+```go
+gb := growthbook.New(context).
+  WithAttributes(Attributes{
+    "id":       "123",
+    "loggedIn": true,
+    "deviceId": "abc123def456",
+    "company":  "acme",
+    "paid":     false,
+    "url":      "/pricing",
+    "browser":  "chrome",
+    "mobile":   false,
+    "country":  "US",
+  })
+```
+
+You can also set or update attributes asynchronously at any time with
+the `WithAttributes` method. This will completely overwrite the
+attributes object with whatever you pass in. If you want to merge
+attributes instead, you can get the existing ones with `Attributes`:
+
+```go
+attrs := gb.Attributes()
+attrs["url"] = "/checkout"
+gb.WithAttributes(attrs)
+```
+
+Be aware that changing attributes may change the assigned feature
+values. This can be disorienting to users if not handled carefully. A
+common approach is to only refresh attributes on navigation, when the
+window is focused, and/or after a user performs a major action like
+logging in.
+
+### Tracking Callback
+
+Any time an experiment is run to determine the value of a feature, we
+can run a callback function so you can record the assigned value in
+your event tracking or analytics system of choice.
+
+```go
+context.WithTrackingCallback(func(experiment *growthbook.Experiment,
+  result *growthbook.ExperimentResult) {
+    // Example using Segment.io
+    client.Enqueue(analytics.Track{
+      UserId: context.Attributes()["id"],
+      Event: "Experiment Viewed",
+      Properties: analytics.NewProperties().
+        Set("experimentId", experiment.Key).
+        Set("variationId", result.VariationID)
+    })
+  }
+)
+```
+
+## Error handling
+
+The GrowthBook public API does not return errors under any normal
+circumstances. The intention is for developers to be able to use the
+SDK in both development and production smoothly. To this end, error
+reporting is provided by a configurable logging interface.
+
+For development use, the `DevLogger` type provides a suitable
+implementation of the logging interface: it prints all logged messages
+to standard output, and exits on errors.
+
+For production use, a logger that directs log messages to a suitable
+centralised logging facility and ignores all errors would be suitable.
+The logger can of course also signal error and warning conditions to
+other parts of the program in which it is used.
+
+To be specific about this:
+
+- None of the functions that create or update `Context`, `GrowthBook`
+  or `Experiment` values return errors.
+
+- The main `GrowthBook.Feature` and `GrowthBook.Run` methods never
+  return errors.
+
+- None of the functions that create values from JSON data return
+  errors.
+
+For most common use cases, this means that the GrowthBook SDK can be
+used transparently, without needing to care about error handling. Your
+server code will never crash because of problems in the GrowthBook
+SDK. The only effect of error conditions in the inputs to the SDK may
+be that feature values and results of experiments are not what you
+expect.
+
+## Using Features
+
+The main method, `GrowthBook.Feature(key)`, takes a feature key and
+uses the stored feature definitions and attributes to evaluate the
+feature value. It returns a `FeatureResult` value with the following
+fields:
+
+- `Value`: the JSON value of the feature (or null if not defined), as
+  a `FeatureValue` value (which is just an alias for `interface{}`,
+  using Go's default behavior for handling JSON values);
+- `On` and `Off`: the JSON value cast to booleans (to make your code
+  easier to read);
+- `Source`: a value of type `FeatureResultSource`, telling why the
+  value was assigned to the user. One of
+  `UnknownFeatureResultSource`, `DefaultValueResultSource`,
+  `ForceResultSource`, or `ExperimentResultSource`.
+- `Experiment`: information about the experiment (if any) which was
+  used to assign the value to the user.
+- `ExperimentResult`: the result of the experiment (if any) which was
+  used to assign the value to the user.
+
+Here's an example that uses all of them:
+
+```go
+result := gb.Feature("my-feature")
+
+// The JSON value (might be null, string, boolean, number, array, or
+// object).
+fmt.Println(result.Value)
+
+if result.On {
+  // Feature value is truthy (in a Javascript sense)
+}
+if result.Off {
+  // Feature value is falsy
+}
+
+// If the feature value was assigned as part of an experiment
+if result.Source == growthbook.ExperimentResultSource {
+  // Get all the possible variations that could have been assigned
+  fmt.Println(result.Experiment.Variations)
+}
+```
+
+Defaulting of the values of feature results is assisted by the
+`GetValueWithDefault` method on the `FeatureResult` type. For example,
+this code evaluates the result of a feature and returns the feature
+value, defaulting to "blue" if the feature has no value:
+
+```go
+color := gb.Feature("signup-button-color").GetValueWithDefault("blue")
+```
+
+## Feature Definitions
+
+For details of the JSON format used for feature definitions, consult
+the documentation for the [GrowthBook Javascript
+SDK](https://docs.growthbook.io/lib/js). The Go SDK uses exactly the
+same logic for processing features, and can ingest the same JSON
+feature definitions as are used by the Javascript SDK (see [JSON data
+representations](#json-data-representations)).
+
+It is possible to create `Feature` values in the Go SDK by hand,
+simply by creating Go values of the appropriate types (`Feature`,
+`FeatureValue`, `FeatureRule`), but the most common use case is
+likely to be ingesting feature definitions from JSON data using the
+`ParseFeatureMap` function.
+
+## Inline Experiments
+
+Experiments can be defined and run using the `Experiment` type and the
+`Run` method of the `GrowthBook` type. Experiment definitions can be
+created directly as values of the `Experiment` type, or parsed from
+JSON definitions using the `ParseExperiment` function. Passing an
+`Experiment` value to the `Run` method of the `GrowthBook` type will
+run the experiment, returing an `ExperimentResult` value that contains
+the resulting feature value. This allows users to run arbitrary
+experiments without providing feature definitions up-front.
+
+```go
+experiment :=
+  growthbook.NewExperiment("my-experiment").
+    WithVariations("red", "blue", "green")
+
+result := gb.Run(experiment)
+```
+
+All other experiment settings (weights, hash attribute, coverage,
+namespace, condition) are supported when using inline experiments: the
+`Experiment` type has `With...` methods that allow these fields to be
+set easily (i.e. `WithWeights`, `WithHashAttribute`, `WithCoverage`,
+`WithNamespace`, `WithCondition`).
+
+In addition, there are a few other settings that only really make
+sense for inline experiments:
+
+- `Force` can be set to one of the variation array indexes. Everyone
+  will be immediately assigned the specified value.
+- `Active` can be set to `false` to disable the experiment and return
+  the control for everyone.
+
+### Inline Experiment Return Value
+
+A call to `GrowthBook.Run(experiment)` returns a value of type
+`*ExperimentResult`:
+
+```go
+experiment := growthbook.NewExperiment("my-experiment").
+  WithVariations("A", "B")
+result := gb.Run(experiment)
+
+// If user is part of the experiment
+fmt.Println(result.InExperiment) // true or false
+
+// The index of the assigned variation
+fmt.Println(result.VariationID) // 0 or 1
+
+// The value of the assigned variation
+fmt.Println(result.Value) // "A" or "B"
+
+// The user attribute used to assign a variation
+fmt.Println(result.HashAttribute) // "id"
+
+// The value of that attribute
+fmt.Println(result.HashValue) // e.g. "123"
+```
+
+The `InExperiment` flag is only set to true if the user was randomly
+assigned a variation. If the user failed any targeting rules or was
+forced into a specific variation, this flag will be false.
+
+## JSON data representations
+
+For interoperability of the GrowthBook Go SDK with versions of the SDK
+in other languages, the core "input" values of the SDK (in particular,
+`Context` and `Experiment` values and maps of feature definitions) can
+be created by parsing JSON data.
+
+A common use case is to download the feature definition from the GrowthBook SDK endpoints, and parse them into a feature map that can be passed into the GrowthBook `Context`.
+
+The shape of the GrowthBook response can use the following struct:
+
+```go
+// GBFeaturesResponse
+// GrowthBook features response
+type GBFeaturesResponse struct {
+	Status            int             `json:"status"`
+	Features          json.RawMessage `json:"features"`
+	EncryptedFeatures string          `json:"encryptedFeatures,omitempty"` // Not yet supported in the Go SDK
+	DateUpdated       time.Time       `json:"dateUpdated"`
+}
+```
+
+Next, get JSON from GrowthBook and deserialize it into GBFeaturesResponse struct.
+
+```go
+res, err := http.Get("https://cdn.growthbook.io/api/features/<environment_key>")
+if err != nil {
+	fmt.Printf("Error fetching features from GrowthBook: %s \n", err)
+	os.Exit(1)
+}
+
+var featuresResponse GBFeaturesResponse
+err = json.NewDecoder(res.Body).Decode(&featuresResponse)
+if err != nil {
+	fmt.Printf("Error decoding JSON: %s \n", err)
+	os.Exit(1)
+}
+
+features := growthbook.ParseFeatureMap(featuresResponse.Features)
+
+// Create a growthbook.Context instance with the features and attributes
+context := growthbook.NewContext().
+	WithFeatures(features).
+	WithAttributes(userAttributes)
+
+// Create a growthbook.GrowthBook instance
+gb := growthbook.New(context)
+```
+
+The functions that implement this JSON processing functionality have
+names like `ParseContext`, `BuildContext`, and so on. Each `Parse...`
+function process raw JSON data (as a `[]byte` value), while the
+`Build...` functions process JSON objects unmarshalled to Go values of
+type `map[string]interface{}`. This provides flexibility in ingestion
+of JSON data.
+
+## Tracking and subscriptions
+
+The `Context` value supports a "tracking callback", which is a
+function that is called any time an experiment is run to determine the
+value of a feature, so that users can record the assigned value in an
+external event tracking or analytics system.
+
+In addition to the tracking callback, the `GrowthBook` type also
+supports more general "subscriptions", which are callback functions
+that are called any time `Run` is called, irrespective of whether or
+not a user is included in an experiment. The subscription system
+ensures that subscription callbacks are only called when the result of
+an experiment changes, or a new experiment is run.
+
+## Code Examples
+
+- [Go server example that fetches from the GrowthBook API <ExternalLink/>](https://github.com/growthbook/examples/tree/main/go-example)
+- [Go CLI app that ingests features from file <ExternalLink/>](https://github.com/ian-ross/growthbook-golang-example)
+
+## Further Reading
+
+- [godoc <ExternalLink/>](https://growthbook.github.io/growthbook-golang)

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/go.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/go.mdx
@@ -1,5 +1,5 @@
 ---
-title: Go SDK
+title: Go SDK 🚧
 description: GrowthBook SDK for Golang
 sidebar_label: Go
 slug: go

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/index.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/index.mdx
@@ -1,0 +1,29 @@
+---
+title: GrowthBook SDKs
+description: Learn about GrowthBook's supported SDKs
+sidebar_label: SDKs
+---
+
+# SDKs
+
+We offer official SDKs in a few popular languages:
+
+- [Javascript/Typescript](/lib/js)
+- [React](/lib/react)
+- [PHP](/lib/php)
+- [Ruby](/lib/ruby)
+- [Python](/lib/python)
+- [Go](/lib/go)
+- [Java](/lib/java)
+- [C#](/lib/csharp)
+- [Kotlin (Android)](/lib/kotlin)
+- [Swift](/lib/swift)
+- [Flutter](/lib/flutter)
+
+We also have community created SDKs:
+
+- [C#](https://github.com/growthbook/growthbook-c-sharp)
+
+There is also a guide if you want to [build your own](/lib/build-your-own).
+
+It's not required to use any of these libraries. The only requirement is that you track in your datasource when users are put into an experiment and which variation they received.

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/index.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: GrowthBook SDKs
+title: GrowthBook SDKs 🚧
 description: Learn about GrowthBook's supported SDKs
 sidebar_label: SDKs
 ---

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/java.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/java.mdx
@@ -1,5 +1,5 @@
 ---
-title: Java SDK
+title: Java SDK 🚧
 description: GrowthBook SDK for Java
 sidebar_label: Java
 slug: java

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/java.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/java.mdx
@@ -1,0 +1,333 @@
+---
+title: Java SDK
+description: GrowthBook SDK for Java
+sidebar_label: Java
+slug: java
+toc_max_heading_level: 5
+---
+
+import ExternalLink from '@site/src/components/ExternalLink'
+import CodeTabsAddDependencyPartial from '@site/src/partials/java/_code-tabs-add-dependency.mdx'
+import CodeTabsGBContextBuilderPartial from '@site/src/partials/java/_code-tabs-gbcontext-builder.mdx'
+import CodeTabsGBContextBuilderEncryptedPartial from '@site/src/partials/java/_code-tabs-gbcontext-builder-encrypted.mdx'
+import CodeTabsGBContextConstructorPartial from '@site/src/partials/java/_code-tabs-gbcontext-constructor.mdx'
+import CodeTabsUserAttributesPartial from '@site/src/partials/java/_code-tabs-user-attributes.mdx'
+import CodeTabsUsingFeaturesPartial from '@site/src/partials/java/_code-tabs-using-features.mdx'
+import CodeTabsTrackingCallbackPartial from '@site/src/partials/java/_code-tabs-tracking-callback.mdx'
+import CodeTabsRunExperimentPartial from '@site/src/partials/java/_code-tabs-run-experiment.mdx'
+import CodeTabsExperimentResultCallbackPartial from '@site/src/partials/java/_code-tabs-subscribe-experiment-run.mdx'
+import CodeTabsExperimentResultSubscribeMultipleCallbackPartial from '@site/src/partials/java/_code-tabs-subscribe-multiple.mdx'
+import CodeTabsFeaturesRepository from '@site/src/partials/java/_code-tabs-gbfeatures-repository.mdx'
+
+This supports Java applications using Java version 1.8 and higher.
+
+:::success New
+
+The GrowthBook Java SDK is a brand new feature. If you experience any issues, let us know either on [Slack](https://slack.growthbook.io/) or [create an issue](https://github.com/growthbook/growthbook-sdk-java/issues).
+
+:::
+
+## Installation
+
+[![](https://jitpack.io/v/growthbook/growthbook-sdk-java.svg)](https://jitpack.io/#growthbook/growthbook-sdk-java)
+
+### Gradle
+
+To install in a Gradle project, add Jitpack to your repositories, and then add the dependency with the latest version to your project's dependencies.
+
+<CodeTabsAddDependencyPartial />
+
+### Maven
+
+To install in a Maven project, add Jitpack to your repositories:
+
+```xml
+<repositories>
+    <repository>
+        <id>jitpack.io</id>
+        <url>https://jitpack.io</url>
+    </repository>
+</repositories>
+```
+
+Next, add the dependency with the latest version to your project's dependencies:
+
+```xml
+<dependency>
+    <groupId>com.github.growthbook</groupId>
+    <artifactId>growthbook-sdk-java</artifactId>
+    <version>0.5.0</version>
+</dependency>
+```
+
+## Usage
+
+There are 2 steps to initializing the GrowthBook SDK:
+
+1. Create a GrowthBook context `GBContext` with the features JSON and the user attributes
+2. Create the `GrowthBook` SDK class with the context
+
+### GrowthBook context
+
+The GrowthBook context `GBContext` can be created either by implementing the builder class, available at `GBContext.builder()`, or by using the `GBContext` constructor.
+
+| Field name            | Type                   | Description                                                                                                                                                                                                                                                                                                                                                    |
+| --------------------- | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `attributesJson`      | `String`               | The user attributes JSON. See [Attributes](#attributes).                                                                                                                                                                                                                                                                                                       |
+| `featuresJson`        | `String`               | The features JSON served by the GrowthBook API (or equivalent). See [Features](#features).                                                                                                                                                                                                                                                                     |
+| `enabled`             | `Boolean`              | Whether to enable the functionality of the SDK (default: `true`)                                                                                                                                                                                                                                                                                               |
+| `isQaMode`            | `Boolean`              | Whether the SDK is in QA mode. Not for production use. If true, random assignment is disabled and only explicitly forced variations are used (default: `false`)                                                                                                                                                                                                |
+| `url`                 | `String`               | The URL of the current page. Useful when evaluating features and experiments based on the page URL.                                                                                                                                                                                                                                                            |
+| `forcedVariationsMap` | `Map<String, Integer>` | Force specific experiments to always assign a specific variation (used for QA)                                                                                                                                                                                                                                                                                 |
+| `trackingCallback`    | `TrackingCallback`     | A callback that will be invoked with every experiment evaluation where the user **is** included in the experiment. See [TrackingCallback](#tracking-callback). To subscribe to all evaluated events regardless of whether the user is in the experiment, see [Subscribing to experiment runs](#subscribing-to-experiment-runs-with-the-experimentruncallback). |
+
+#### Using the GBContext builder
+
+The builder is the easiest to use way to construct a `GBContext`, allowing you to provide as many or few arguments as you'd like. All fields mentioned above are available via the builder.
+
+<CodeTabsGBContextBuilderPartial />
+
+:::info Note
+The above example uses `java.net.http.HttpClient` which, depending on your web framework, may not be the best option, in which case it is recommended to use a networking library more suitable for your implementation.
+:::
+
+#### Using the GBContext constructor
+
+You can also use `GBContext` constructor if you prefer, which will require you to pass all arguments explicitly.
+
+<CodeTabsGBContextConstructorPartial />
+
+For complete examples, see the [Examples](#code-examples) section below.
+
+#### Features
+
+The features JSON is equivalent to the `features` property that is returned from the SDK Endpoint for the specified environment. You can find your endpoint on the [Environments &rarr; SDK Endpoints page <ExternalLink/>](https://app.growthbook.io/environments).
+
+- You can read more [about features here](/app/features)
+- You can see an [example features JSON here](/app/api#the-sdk-endpoint)
+
+#### Attributes
+
+Attributes are a JSON string. You can specify attributes about the current user and request. Here's an example:
+
+<CodeTabsUserAttributesPartial />
+
+If you need to set or update attributes asynchronously, you can do so with `Context#attributesJson` or `GrowthBook#setAttributes`. This will completely overwrite the attributes object with whatever you pass in. Also, be aware that changing attributes may change the assigned feature values. This can be disorienting to users if not handled carefully.
+
+#### Tracking Callback
+
+Any time an experiment is run to determine the value of a feature, we may call this callback so you can record the assigned value in your event tracking or analytics system of choice.
+
+**The tracking callback is only called when the user is in the experiment**. If they are not in the experiment, this will not be called. If you'd like to subscribe to all evaluations, regardless of experiment result, see [Subscribing to experiment runs](#subscribing-to-experiment-runs-with-the-experimentruncallback).
+
+<CodeTabsTrackingCallbackPartial />
+
+### Using Features
+
+Every feature has a "value" which is assigned to a user. This value can be any JSON data type. If a feature doesn't exist, the value will be `null`.
+
+There are 4 main methods for evaluating features.
+
+| Method                        | Return type            | Description                                                                                                               |
+| ----------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| **`isOn(String)`**            | `Boolean`              | Returns true if the value is a truthy value                                                                               |
+| **`isOff(String)`**           | `Boolean`              | Returns true if the value is a falsy value                                                                                |
+| **`getFeatureValue(String)`** | generic `T` (nullable) | Returns the value cast to the generic type. Type is inferred based on the `defaultValue` argument provided.               |
+| **`evalFeature(String)`**     | `FeatureResult<T>`     | Returns a feature result with a value of generic type `T`. The value type needs to be specified in the generic parameter. |
+
+<CodeTabsUsingFeaturesPartial />
+
+#### isOn() / isOff()
+
+These methods return a boolean for truthy and falsy values.
+
+Only the following values are considered to be "falsy":
+
+- `null`
+- `false`
+- `""`
+- `0`
+
+Everything else is considered "truthy", including empty arrays and objects.
+
+If the value is "truthy", then `isOn()` will return true and `isOff()` will return false. If the value is "falsy", then the opposite values will be returned.
+
+#### getFeatureValue(featureKey, defaultValue)
+
+This method has a variety of overloads to help with casting values to primitive and complex types.
+
+In short, the type of the `defaultValue` argument will determine the return type of the function.
+
+| Return type             | Method                                                                                                     | Additional Info                                                                                                                                                                   |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Boolean`               | **`getFeatureValue(String featureKey, Boolean defaultValue)`**                                             |                                                                                                                                                                                   |
+| `Double`                | **`getFeatureValue(String featureKey, Double defaultValue)`**                                              |                                                                                                                                                                                   |
+| `Float`                 | **`getFeatureValue(String featureKey, Float defaultValue)`**                                               |                                                                                                                                                                                   |
+| `Integer`               | **`getFeatureValue(String featureKey, Integer defaultValue)`**                                             |                                                                                                                                                                                   |
+| `String`                | **`getFeatureValue(String featureKey, String defaultValue)`**                                              |                                                                                                                                                                                   |
+| `<ValueType> ValueType` | **`getFeatureValue(String featureKey, ValueType defaultValue, Class<ValueType> gsonDeserializableClass)`** | Internally, the SDK uses Gson. You can pass any class that does not require a custom deserializer.                                                                                |
+| `Object`                | **`getFeatureValue(String featureKey, Object defaultValue)`**                                              | Use this method if you need to cast a complex object that uses a custom deserializer, or if you use a different JSON serialization library than Gson, and cast the type yourself. |
+
+[See the Java Docs](https://growthbook.github.io/growthbook-sdk-java/growthbook/sdk/java/GrowthBook.html) for more information.
+
+[See the unit tests <ExternalLink />](https://github.com/growthbook/growthbook-sdk-java/blob/main/lib/src/test/java/growthbook/sdk/java/GrowthBookTest.java#L220) for example implementations including type casting for all above-mentioned methods.
+
+#### evalFeature(String)
+
+The `evalFeature` method returns a `FeatureResult<T>` object with more info about why the feature was assigned to the user. The `T` type corresponds to the value type of the feature. In the above example, `T` is `Float`.
+
+`FeatureResult<T>` It has the following getters.
+
+| Method                      | Return type                           | Description                                                                                  |
+| --------------------------- | ------------------------------------- | -------------------------------------------------------------------------------------------- |
+| **`getValue()`**            | generic `T` (nullable)                | The evaluated value of the feature                                                           |
+| **`getSource()`**           | `enum FeatureResultSource` (nullable) | The reason/source for the evaluated feature value.                                           |
+| **`getRuleId()`**           | `String` (nullable)                   | ID of the rule that was used to assign the value to the user.                                |
+| **`getExperiment()`**       | `Experiment<T>` (nullable)            | The experiment details, available only if the feature evaluates due to an experiment.        |
+| **`getExperimentResult()`** | `ExperimentResult<T>` (nullable)      | The experiment result details, available only if the feature evaluates due to an experiment. |
+
+As expected in Kotlin, you can access these getters using property accessors.
+
+### Inline Experiments
+
+Instead of declaring all features up-front in the context and referencing them by IDs in your code, you can also just run an experiment directly. This is done with the `growthbook.run(Experiment<T>)` method.
+
+<CodeTabsRunExperimentPartial />
+
+#### Inline experiment return value ExperimentResult
+
+An `ExperimentResult<T>` is returned where `T` is the generic value type for the experiment.
+
+There's also a number of methods available.
+
+| Method                   | Return type            | Description                                                                                                                                                                                                  |
+| ------------------------ | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **`getValue()`**         | generic `T` (nullable) | The evaluated value of the feature                                                                                                                                                                           |
+| **`getVariationId()`**   | `Integer` (nullable)   | Index of the variation used, if applicable                                                                                                                                                                   |
+| **`getInExperiment()`**  | `Boolean`              | If the user was in the experiment. This will be false if the user was excluded from being part of the experiment for any reason (e.g. failed targeting conditions).                                          |
+| **`getHashAttribute()`** | `String`               | User attribute used for hashing, defaulting to `id` if not set.                                                                                                                                              |
+| **`getHashValue()`**     | `String` (nullable)    | The hash value used for evaluating the experiment, if applicable.                                                                                                                                            |
+| **`getFeatureId()`**     | `String`               | The feature key/ID                                                                                                                                                                                           |
+| **`getHashUsed()`**      | `Boolean`              | If a hash was used to evaluate the experiment. This flag will only be true if the user was randomly assigned a variation. If the user was forced into a specific variation instead, this flag will be false. |
+
+As expected in Kotlin, you can access these getters using property accessors.
+
+### Subscribing to experiment runs with the ExperimentRunCallback
+
+You can subscribe to experiment run evaluations using the `ExperimentRunCallback`.
+
+<CodeTabsExperimentResultCallbackPartial />
+
+Every time an experiment is evaluated when calling `growthBook.run(Experiment)`, the callbacks will be called.
+
+You can subscribe with as many callbacks as you like:
+
+<CodeTabsExperimentResultSubscribeMultipleCallbackPartial />
+
+**The experiment run callback is called for every experiment run, regardless of experiment result**. If you would like to subscribe only to evaluations where the user falls into an experiment, see [TrackingCallback](#tracking-callback).
+
+### Working with Encrypted features
+
+As of version 0.3.0, the Java SDK supports decrypting encrypted features. You can learn more about [SDK Connection Endpoint Encryption](/app/api#encryption).
+
+The main difference is you create a `GBContext` by passing an encryption key (`.encryptionKey()` when using the builder) and using the encrypted payload as the features JSON (`.featuresJson()` for the builder).
+
+<CodeTabsGBContextBuilderEncryptedPartial />
+
+### Fetching, Cacheing, and Refreshing features with GBFeaturesRepository
+
+As of version 0.4.0, the Java SDK provides an optional `GBFeaturesRepository` class which will manage networking for you in the following ways:
+
+- Fetching features from the SDK endpoint when `initialize()` is called
+- Decrypting encrypted features when provided with the client key, e.g. `.builder().encryptionKey(clientKey)`
+- Cacheing features (in-memory)
+- Refreshing features
+
+If you wish to manage fetching, refreshing, and cacheing features on your own, you can choose to not implement this class.
+
+:::info Recommendation
+This class should be implemented as a singleton class as it includes caching and refreshing functionality.
+:::
+
+If you have more than one SDK endpoint you'd like to implement, you can extend the `GBFeaturesRepository` class with your own class to make it easier to work with dependency injection frameworks. Each of these instances should be singletons.
+
+#### Fetching the features
+
+You will need to create a singleton instance of the `GBFeaturesRepository` class either by implementing its `.builder()` or by using its constructor.
+
+Then, you would call `myGbFeaturesRepositoryInstance.initialize()` in order to make the initial (blocking) request to fetch the features. Then, you would call `myGbFeaturesRepositoryInstance.getFeaturesJson()` and provided that to the `GBContext` initialization.
+
+<CodeTabsFeaturesRepository />
+
+For more references, see the [Examples](#code-examples) below.
+
+#### Cacheing and refreshing behaviour
+
+The `GBFeaturesRepository` will automatically refresh the features when the features become stale. Features are considered stale every 60 seconds. This amount is configurable with the `ttlSeconds` option.
+
+When you fetch features and they are considered stale, the stale features are returned from the `getFeaturesJson()` method and a network call to refresh the features is enqueued asynchronously. When that request succeeds, the features are updated with the newest features, and the next call to `getFeaturesJson()` will return the refreshed features.
+
+## Overriding Feature Values
+
+The Java SDK allows you to override feature values and experiments using the URL.
+
+### Force Experiment Variations
+
+You can force an experiment variation by passing the experiment key and variation index as query parameters in the URL you set on the `GBContext`. For example, if you add `?my-experiment-id=2` to the URL, users will be forced into the variation at index 2 in the variations list when evaluating the experiment with key `my-experiment-id`.
+
+### Force Feature Values via the URL
+
+You can force a value for a feature by passing the key, prefixed by `gb~`, and the URI-encoded value in the URL's query parameters. You must also set `allowUrlOverrides` to true when building your `GBContext` in order to enable this feature as it is not enabled by default.
+
+```java
+GBContext context = GBContext
+    .builder()
+    .url("http://localhost:8080/url-feature-force?gb~dark_mode=true&gb~donut_price=3.33&gb~banner_text=Hello%2C%20everyone!%20I%20hope%20you%20are%20all%20doing%20well!")
+    .allowUrlOverrides(true)
+    .build();
+```
+
+The above code sample sets the following:
+
+- `dark_mode`: `true`
+- `banner_text`: `"Hello, everyone! I hope you are all doing well!"`
+- `donut_price`: `3.33`
+
+#### Supported types
+
+| Type                          | Value                                                                                                                                          |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `String`                      | A URI-encoded string value                                                                                                                     |
+| `Float`                       | A float value, e.g. `3.33`                                                                                                                     |
+| `Double`                      | A double value, e.g. `3.33`                                                                                                                    |
+| `Integer`                     | An integer value, e.g. `1337`                                                                                                                  |
+| `Boolean`                     | A boolean value, e.g. `true` or `false`. You can also represent boolean values with on/off state as `on` or `off` or binary values `1` or `0`. |
+| JSON as `Gson`-deserializable | A class that can be deserialized using Gson and that does not have any dependencies on custom type adapters.                                   |
+| JSON as `String`              | A URI-encoded string value that should be a valid JSON string that you can deserialize with your own JSON deserialization implementation.      |
+
+The value passed in the URL is cast at runtime based on the generic type argument passed in when evaluating the feature. This means that when you call `<ValueType>getFeatureValue()`, what you pass into the URL must successfully cast as `ValueType` otherwise the value in the URL will be ignored.
+
+All keys must be prefixed with `gb~`.
+
+## Using with Proguard and R8
+
+Many Android projects use code-shrinking and obfuscation tools like Proguard and R8 in production.
+
+If you are experiencing unexpected feature evaluation results with your release Android builds that do not occur in your debug builds, it's most likely related to this.
+
+You will need to add the following to your `proguard-rules.pro` file to ensure that all of the GrowthBook SDK classes are kept so that your features are evaluated properly in projects that use Proguard and R8:
+
+```
+# Growthbook Java SDK classes
+-keep class growthbook.sdk.java.** { *; }
+```
+
+## Code Examples
+
+- [JVM with Spring Web example <ExternalLink/>](https://github.com/growthbook/examples/tree/main/jvm-spring-web)
+- [JVM example in Kotlin with Ktor <ExternalLink/>](https://github.com/growthbook/examples/tree/main/jvm-kotlin-ktor-example)
+- [Android Java example <ExternalLink/>](https://github.com/growthbook/examples/tree/main/android-example)
+
+## Further Reading
+
+- [JavaDoc class documentation <ExternalLink/>](https://growthbook.github.io/growthbook-sdk-java/)

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/js.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/js.mdx
@@ -1,5 +1,5 @@
 ---
-title: Javascript SDK
+title: Javascript SDK 🚧
 description: GrowthBook SDK for Javascript
 sidebar_label: Javascript
 slug: js

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/js.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/js.mdx
@@ -1,0 +1,909 @@
+---
+title: Javascript SDK
+description: GrowthBook SDK for Javascript
+sidebar_label: Javascript
+slug: js
+toc_max_heading_level: 5
+---
+
+import ExternalLink from '@site/src/components/ExternalLink'
+
+# Javascript
+
+Supports both browser and NodeJS environments.
+
+## Installation
+
+Install with a package manager
+
+```bash npm2yarn
+npm install --save @growthbook/growthbook
+```
+
+or use directly in your HTML without installing first:
+
+```html
+<!-- Creates `window.growthbook` with all of the exported classes -->
+<script src="https://cdn.jsdelivr.net/npm/@growthbook/growthbook/dist/bundles/index.js"></script>
+```
+
+## Quick Usage
+
+### Step 1: Configure your app
+
+```js
+import { GrowthBook } from "@growthbook/growthbook";
+
+// Create a GrowthBook instance
+const gb = new GrowthBook({
+  apiHost: "https://cdn.growthbook.io",
+  clientKey: "sdk-abc123",
+  // Enable easier debugging during development
+  enableDevMode: true,
+  // Targeting attributes
+  attributes: {
+    id: "123",
+    country: "US"
+  },
+  // Only required for A/B testing
+  // Called every time a user is put into an experiment
+  trackingCallback: (experiment, result) => {
+    console.log("Experiment Viewed", {
+      experimentId: experiment.key,
+      variationId: result.key,
+    });
+  },
+});
+
+// Wait for features to be available
+await gb.loadFeatures({ autoRefresh: true });
+```
+
+### Step 2: Start Feature Flagging!
+
+There are 2 main methods for evaluating features: `isOn` and `getFeatureValue`:
+
+```js
+// Simple boolean (on/off) feature flag
+if (gb.isOn("my-feature")) {
+  console.log("Feature enabled!");
+}
+
+// Get the value of a string/JSON/number feature with a fallback
+const color = gb.getFeatureValue("button-color", "blue");
+```
+
+## Node.js
+
+If using this SDK in a server-side environment, you may need to configure some polyfills for missing browser APIs.
+
+```js
+const { setPolyfills } = require("@growthbook/growthbook");
+
+setPolyfills({
+  // Required when using built-in feature loading and Node 17 or lower
+  fetch: require("cross-fetch"),
+  // Required when using encrypted feature flags and Node 18 or lower
+  SubtleCrypto: require("node:crypto").webcrypto.subtle,
+  // Optional, can make feature rollouts faster
+  EventSource: require("eventsource"),
+  // Optional, can reduce startup times by persisting cached feature flags
+  localStorage: {
+    // Example using Redis
+    getItem: (key) => redisClient.get(key),
+    setItem: (key, value) => redisClient.set(key, value),
+  }
+})
+```
+
+Create a separate GrowthBook instance for every incoming request. This is easiest if you use a middleware:
+
+```js
+// Example using Express
+app.use(function(req, res, next) {
+  // Create a GrowthBook instance and store in the request
+  req.growthbook = new GrowthBook({
+    apiHost: "https://cdn.growthbook.io",
+    clientKey: "sdk-abc123",
+    enableDevMode: true,
+  });
+
+  // Clean up at the end of the request
+  res.on('close', () => req.growthbook.destroy());
+
+  // Wait for features to load (will be cached in-memory for future requests)
+  req.growthbook.loadFeatures()
+    .then(() => next())
+    .catch((e) => {
+      console.error("Failed to load features from GrowthBook", e);
+      next();
+    })
+})
+```
+
+Then, you can access the GrowthBook instance from any route:
+
+```js
+app.get("/", (req, res) => {
+  const gb = req.growthbook;
+  // ...
+})
+```
+
+## Loading Features
+
+In order for the GrowthBook SDK to work, it needs to have feature definitions from the GrowthBook API. There are 2 ways to get this data into the SDK.
+
+### Built-in Fetching and Caching
+
+If you pass an `apiHost` and `clientKey` into the GrowthBook constructor, it will handle the network requests, caching, retry logic, etc. for you automatically. If your feature payload is encrypted, you can also pass in a `decryptionKey`.
+
+```ts
+const gb = new GrowthBook({
+  apiHost: "https://cdn.growthbook.io",
+  clientKey: "sdk-abc123",
+  decryptionKey: "key_abc123", // Only if you have feature encryption turned on
+});
+
+// Wait for features to be downloaded
+await gb.loadFeatures({
+  // When features change, update the GrowthBook instance automatically
+  // Default: `false`
+  autoRefresh: true,
+  // If the network request takes longer than this (in milliseconds), continue
+  // Default: `0` (no timeout)
+  timeout: 2000,
+});
+```
+
+Until features are loaded, all features will evaluate to `null`. If you're ok with a potential flicker in your application (features going from `null` to their real value), you can call `loadFeatures` without awaiting the result.
+
+If you want to refresh the features at any time (e.g. when a navigation event occurs), you can call `gb.refreshFeatures()`.
+
+### Custom Integration
+
+If you prefer to handle the network and caching logic yourself, you can instead pass in a features JSON object directly. For example, you might store features in Postgres and send it down to your front-end as part of your app's initial bootstrap API call.
+
+```ts
+const gb = new GrowthBook({
+  features: {
+    "feature-1": {...},
+    "feature-2": {...},
+    "another-feature": {...},
+  }
+})
+```
+
+Note that you don't have to call `gb.loadFeatures()`. There's nothing to load - everything required is already passed in.
+
+You can update features at any time by calling `gb.setFeatures()` with a new JSON object.
+
+### Re-rendering When Features Change
+
+When features change (e.g. by calling `gb.refreshFeatures()`), you need to re-render your app so that all of your feature flag checks can be re-evaluated. You can specify your own custom rendering function for this purpose:
+
+```js
+// Callback to re-render your app when feature flag values change
+gb.setRenderer(() => {
+  // TODO: re-render your app
+});
+```
+
+## Experimentation (A/B Testing)
+
+In order to run A/B tests, you need to set up a tracking callback function. This is called every time a user is put into an experiment and can be used to track the exposure event in your analytics system (Segment, Mixpanel, GA, etc.).
+
+```js
+const gb = new GrowthBook({
+  apiHost: "https://cdn.growthbook.io",
+  clientKey: "sdk-abc123",
+  trackingCallback: (experiment, result) => {
+    // Example using Segment
+    analytics.track("Experiment Viewed", {
+      experimentId: experiment.key,
+      variationId: result.key,
+    });
+  },
+});
+```
+
+This same tracking callback is used for both feature flag experiments and Visual Editor experiments.
+
+### Feature Flag Experiments
+
+There is nothing special you have to do for feature flag experiments. Just evaluate the feature flag like you would normally do. If the user is put into an experiment as part of the feature flag, it will call the `trackingCallback` automatically in the background.
+
+```js
+// If this has an active experiment and the user is included,
+// it will call trackingCallback automatically
+const newLogin = gb.isOn("new-signup-form");
+```
+
+If the experiment came from a feature rule, `result.featureId` in the trackingCallback will contain the feature id, which may be useful for tracking/logging purposes.
+
+### Visual Editor Experiments
+
+Experiments created through the GrowthBook Visual Editor will run automatically as soon as their targeting conditions are met.
+
+**Note**: Visual Editor experiments are only supported in a web browser environment. They will not run in Node.js, Mobile apps, or Desktop apps.
+
+If you are using this SDK in a Single Page App (SPA), you will need to let the GrowthBook instance know when the URL changes so the active experiments can update accordingly.
+
+```js
+// Call this every time a navigation event happens in your SPA
+function onRouteChange() {
+  gb.setURL(window.location.href);
+}
+```
+
+## TypeScript
+
+When used in a TypeScript project, GrowthBook includes basic type inference out of the box:
+
+```ts
+// Type will be `string` based on the fallback provided ("blue")
+const color = gb.getFeatureValue("button-color", "blue");
+
+// You can manually specify types as well
+// feature.value will be type `number`
+const feature = gb.evalFeature<number>("font-size");
+console.log(feature.value);
+
+// Experiments will use the variations to infer the return value
+// result.value will be type "string"
+const result = gb.run({
+  key: "my-test",
+  variations: ["blue", "green"],
+});
+```
+
+### Strict Typing
+
+If you want to enforce stricter types in your application, you can do that when creating the GrowthBook instance:
+
+```ts
+// Define all your feature flags and types here
+interface AppFeatures {
+  "button-color": string;
+  "font-size": number;
+  "newForm": boolean;
+}
+
+// Pass into the GrowthBook instance
+const gb = new GrowthBook<AppFeatures>({
+  ...
+});
+```
+
+Now, all feature flag methods will be strictly typed.
+
+```ts
+// feature.value will by type `number`
+const feature = gb.evalFeature("font-size");
+console.log(feature.value);
+
+// Typos will cause compile-time errors
+gb.isOn("buton-color"); // "buton" instead of "button"
+```
+
+Instead of defining the `AppFeatures` interface manually like above, you can auto-generate it from your GrowthBook account using the [GrowthBook CLI](/tools/cli).
+
+## GrowthBook Instance (reference)
+
+### Attributes
+
+You can specify attributes about the current user and request. These are used for two things:
+
+1.  Feature targeting (e.g. paid users get one value, free users get another)
+2.  Assigning persistent variations in A/B tests (e.g. user id "123" always gets variation B)
+
+The following are some comonly used attributes, but use whatever makes sense for your application.
+
+```ts
+new GrowthBook({
+  attributes: {
+    id: "123",
+    loggedIn: true,
+    deviceId: "abc123def456",
+    company: "acme",
+    paid: false,
+    url: "/pricing",
+    browser: "chrome",
+    mobile: false,
+    country: "US",
+  },
+});
+```
+
+If you need to set or update attributes asynchronously, you can do so with `setAttributes()`. This will completely overwrite the attributes object with whatever you pass in. Also, be aware that changing attributes may change the assigned feature values. This can be disorienting to users if not handled carefully.
+
+### Feature Usage Callback
+
+GrowthBook can fire a callback whenever a feature is evaluated for a user. This can be useful to update 3rd party tools like NewRelic or DataDog.
+
+```ts
+new GrowthBook({
+  onFeatureUsage: (featureKey, result) => {
+    console.log("feature", featureKey, "has value", result.value);
+  },
+});
+```
+
+The `result` argument is the same thing returned from `gb.evalFeature`.
+
+Note: If you evaluate the same feature multiple times (and the value doesn't change), the callback will only be fired the first time.
+
+### Dev Mode
+
+There is a [GrowthBook Chrome DevTools Extension](https://chrome.google.com/webstore/detail/growthbook-devtools/opemhndcehfgipokneipaafbglcecjia) that can help you debug and test your feature flags in development.
+
+In order for this to work, you must explicitly enable dev mode when creating your GrowthBook instance:
+
+```js
+const gb = new GrowthBook({
+  enableDevMode: true,
+});
+```
+
+To avoid exposing all of your internal feature flags and experiments to users, we recommend setting this to `false` in production in most cases.
+
+### evalFeature
+
+In addition to the `isOn` and `getFeatureValue` helper methods, there is the `evalFeature` method that gives you more detailed information about why the value was assigned to the user.
+
+```ts
+// Get detailed information about the feature evaluation
+const result = gb.evalFeature("my-feature");
+
+// The value of the feature (or `null` if not defined)
+console.log(result.value);
+
+// Why the value was assigned to the user
+// One of: `override`, `unknownFeature`, `defaultValue`, `force`, or `experiment`
+console.log(result.source);
+
+// The string id of the rule (if any) which was used
+console.log(result.ruleId);
+
+// Information about the experiment (if any) which was used
+console.log(result.experiment);
+
+// The result of the experiment (or `undefined`)
+console.log(result.experimentResult);
+```
+
+### Inline Experiments
+
+Instead of declaring all features up-front in the context and referencing them by ids in your code, you can also just run an experiment directly. This is done with the `gb.run` method:
+
+```js
+// These are the only required options
+const { value } = gb.run({
+  key: "my-experiment",
+  variations: ["red", "blue", "green"],
+});
+```
+
+#### Customizing the Traffic Split
+
+By default, this will include all traffic and do an even split between all variations. There are 2 ways to customize this behavior:
+
+```js
+// Option 1: Using weights and coverage
+gb.run({
+  key: "my-experiment",
+  variations: ["red", "blue", "green"],
+  // Only include 10% of traffic
+  coverage: 0.1,
+  // Split the included traffic 50/25/25 instead of the default 33/33/33
+  weights: [0.5, 0.25, 0.25],
+});
+
+// Option 2: Specifying ranges
+gb.run({
+  key: "my-experiment",
+  variations: ["red", "blue", "green"],
+  // Identical to the above
+  // 5% of traffic in A, 2.5% each in B and C
+  ranges: [
+    [0, 0.05],
+    [0.5, 0.525],
+    [0.75, 0.775],
+  ],
+});
+```
+
+#### Hashing
+
+We use deterministic hashing to assign a variation to a user. We hash together the user's id and experiment key, which produces a number between `0` and `1`. Each variation is assigned a range of numbers, and whichever one the user's hash value falls into will be assigned.
+
+You can customize this hashing behavior:
+
+```js
+gb.run({
+  key: "my-experiment",
+  variations: ["A", "B"],
+
+  // Which hashing algorithm to use
+  // Version 2 is the latest and the one we recommend
+  hashVersion: 2,
+
+  // Use a different seed instead of the experiment key
+  seed: "abcdef123456",
+
+  // Use a different user attribute (default is `id`)
+  hashAttribute: "device_id",
+});
+```
+
+**Note**: For backwards compatibility, if no `hashVersion` is specified, it will fall back to using version `1`, which is deprecated. In the future, version `2` will become the default. We recommend specifying version `2` now for all new experiments to avoid migration issues down the line.
+
+#### Meta Info
+
+You can also define meta info for the experiment and/or variations. These do not affect the behavior, but they are passed through to the `trackingCallback`, so they can be used to annotate events.
+
+```js
+gb.run({
+  key: "results-per-page",
+  variations: [10, 20],
+
+  // Experiment meta info
+  name: "Results per Page",
+  phase: "full-traffic"
+
+  // Variation meta info
+  meta: [
+    {
+      key: "control",
+      name: "10 Results per Page",
+    },
+    {
+      key: "variation",
+      name: "20 Results per Page",
+    },
+  ]
+})
+```
+
+#### Mutual Exclusion
+
+Sometimes you want to run multiple conflicting experiments at the same time. You can use the `filters` setting to run mutually exclusive experiments.
+
+We do this using deterministic hashing to assign users a value between 0 and 1 for each filter.
+
+```js
+// Will include 60% of users - ones with a hash between 0 and 0.6
+gb.run({
+  key: "experiment-1",
+  variation: [0, 1],
+  filters: [
+    {
+      seed: "pricing",
+      attribute: "id",
+      ranges: [[0, 0.6]]
+    }
+  ]
+});
+
+
+// Will include the other 40% of users - ones with a hash between 0.6 and 1
+gb.run({
+  key: "experiment-2",
+  variation: [0, 1],
+  filters: [
+    {
+      seed: "pricing",
+      attribute: "id",
+      ranges: [[0.6, 1.0]]
+    }
+  ]
+});
+```
+
+**Note** - If a user is excluded from an experiment due to a filter, the rule will be skipped and the next matching rule will be used instead.
+
+#### Holdout Groups
+
+To use global holdout groups, use a nested experiment design:
+
+```js
+// The value will be `true` if in the holdout group, otherwise `false`
+const holdout = gb.run({
+  key: "holdout",
+  variations: [true, false],
+  // 10% of users in the holdout group
+  weights: [0.1, 0.9]
+});
+
+// Only run your main experiment if the user is NOT in the holdout
+if (!holdout.value) {
+  const res = gb.run({
+    key: "my-experiment",
+    variations: ["A", "B"]
+  })
+}
+```
+
+#### Targeting Conditions
+
+You can also define targeting conditions that limit which users are included in the experiment. These conditions are evaluated against the `attributes` passed into the GrowthBook context. The syntax for conditions is based on the MongoDB query syntax and is straightforward to read and write.
+
+For example, if the attributes are:
+
+```json
+{
+  "id": "123",
+  "browser": {
+    "vendor": "firefox",
+    "version": 94
+  },
+  "country": "CA"
+}
+```
+
+The following condition would evaluate to `true` and the user would be included in the experiment:
+
+```js
+gb.run({
+  key: "my-experiment",
+  variation: [0, 1],
+  condition: {
+    "browser.vendor": "firefox",
+    "country": {
+      "$in": ["US", "CA", "IN"]
+    }
+  }
+})
+```
+
+#### Inline Experiment Return Value
+
+A call to `gb.run(experiment)` returns an object with a few useful properties:
+
+```ts
+const {
+  value,
+  key,
+  name,
+  variationId,
+  inExperiment,
+  hashUsed,
+  hashAttribute,
+  hashValue,
+} = gb.run({
+  key: "my-experiment",
+  variations: ["A", "B"],
+});
+
+// If user is included in the experiment
+console.log(inExperiment); // true or false
+
+// The index of the assigned variation
+console.log(variationId); // 0 or 1
+
+// The value of the assigned variation
+console.log(value); // "A" or "B"
+
+// The key and name of the assigned variation (if specified in `meta`)
+console.log(key); // "0" or "1"
+console.log(name); // ""
+
+// If the variation was randomly assigned by hashing
+console.log(hashUsed);
+
+// The user attribute that was hashed
+console.log(hashAttribute); // "id"
+
+// The value of that attribute
+console.log(hashValue); // e.g. "123"
+```
+
+The `inExperiment` flag will be false if the user was excluded from being part of the experiment for any reason (e.g. failed targeting conditions).
+
+The `hashUsed` flag will only be true if the user was randomly assigned a variation. If the user was forced into a specific variation instead, this flag will be false.
+
+## Feature Definitions (reference)
+
+The feature definition JSON file contains information about all of the features in your application.
+
+Each feature consists of a unique key, a list of possible values, and rules for how to assign those values to users.
+
+```ts
+{
+  "feature-1": {...},
+  "feature-2": {...},
+  "another-feature": {...},
+}
+```
+
+### Basic Feature
+
+An empty feature always has the value `null`:
+
+```js
+{
+  "my-feature": {}
+}
+```
+
+#### Default Values
+
+You can change the default assigned value with the `defaultValue` property:
+
+```js
+{
+  "my-feature": {
+    defaultValue: "green"
+  }
+}
+```
+
+### Override Rules
+
+You can override the default value with **rules**.
+
+Rules give you fine-grained control over how feature values are assigned to users. There are 2 types of feature rules: `force` and `experiment`. Force rules give the same value to everyone. Experiment rules assign values to users randomly.
+
+#### Rule Ids
+
+Rules can specify a unique identifier with the `id` property. This can help with debugging and QA by letting you see exactly why a specific value was assigned to a user.
+
+#### Rule Conditions
+
+Rules can optionally define targeting conditions that limit which users the rule applies to. These conditions are evaluated against the `attributes` passed into the GrowthBook context. The syntax for conditions is based on the MongoDB query syntax and is straightforward to read and write.
+
+For example, if the attributes are:
+
+```json
+{
+  "id": "123",
+  "browser": {
+    "vendor": "firefox",
+    "version": 94
+  },
+  "country": "CA"
+}
+```
+
+The following condition would evaluate to `true`:
+
+```json
+{
+  "browser.vendor": "firefox",
+  "country": {
+    "$in": ["US", "CA", "IN"]
+  }
+}
+```
+
+If a condition evaluates to `false`, the rule will be skipped. This means you can chain rules together with different conditions to support even the most complex use cases.
+
+#### Force Rules
+
+Force rules do what you'd expect - force a specific value for the feature
+
+```js
+// Firefox users in the US or Canada get "green"
+// Everyone else gets the default "blue"
+{
+  "button-color": {
+    defaultValue: "blue",
+    rules: [
+      {
+        id: "rule-123",
+        condition: {
+          browser: "firefox",
+          country: {
+            $in: ["US", "CA"]
+          }
+        },
+        force: "green"
+      }
+    ],
+  }
+}
+```
+
+##### Gradual Rollouts
+
+You can specify a `range` for your rule, which determines what percent of users will get the rule applied to them. Users who do not get the rule applied will fall through to the next matching rule (or default value). You can also specify a `seed` that will be used for hashing.
+
+In order to figure out if a user is included or not, we use deterministic hashing. By default, we use the user attribute `id` for this, but you can override this by specifying `hashAttribute` for the rule:
+
+This is useful for gradually rolling out features to users (start with a small range and slowly increase).
+
+```js
+{
+  "new-feature": {
+    defaultValue: false,
+    rules: [
+      {
+        force: true,
+        hashAttribute: "device-id",
+        seed: 'new-feature-rollout-abcdef123',
+        // 20% of users
+        range: [0, 0.2]
+        // Increase to 40%:
+        // range: [0, 0.4]
+      }
+    ]
+  }
+}
+```
+
+#### Experiment Rules
+
+Experiment rules let you adjust the percent of users who get randomly assigned to each variation. This can either be used for hypothesis-driven A/B tests or to simply mitigate risk by gradually rolling out new features to your users.
+
+```js
+// Each variation gets assigned to a random 1/3rd of users
+{
+  "image-size": {
+    rules: [
+      {
+        variations: ["small", "medium", "large"]
+      }
+    ]
+  }
+}
+```
+
+##### Customizing the Traffic Split
+
+By default, an experiment rule will include all traffic and do an even split between all variations. There are 2 ways to customize this behavior:
+
+```js
+// Option 1: Using weights and coverage
+{
+  variations: ["red", "blue", "green"],
+  // Only include 10% of traffic
+  coverage: 0.1,
+  // Split the included traffic 50/25/25 instead of the default 33/33/33
+  weights: [0.5, 0.25, 0.25]
+}
+
+// Option 2: Specifying ranges
+{
+  variations: ["red", "blue", "green"],
+  // Identical to the above
+  // 5% of traffic in A, 2.5% each in B and C
+  ranges: [
+    [0, 0.05],
+    [0.5, 0.525],
+    [0.75, 0.775]
+  ]
+}
+```
+
+A user is assigned a number from 0 to 1 and whichever variation's range includes their number will be assigned to them.
+
+##### Variation Meta Info
+
+You can use the `meta` setting to provide additional info about the variations such as name.
+
+```js
+{
+  "image-size": {
+    rules: [
+      {
+        variations: ["sm", "md", "lg"],
+        ranges: [
+          [0, 0.5],
+          [0.5, 0.75],
+          [0.75, 1.0]
+        ],
+        meta: [
+          {
+            key: "control",
+            name: "Small",
+          },
+          {
+            key: "v1",
+            name: "Medium",
+          },
+          {
+            key: "v2",
+            name: "Large",
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+##### Tracking Key and Name
+
+When a user is assigned a variation, we call the `trackingCallback` function so you can record the exposure with your analytics event tracking system. By default, we use the feature id to identify the experiment, but this can be overridden if needed with the `key` setting. You can also optionally provide a human-readable name.
+
+```js
+{
+  "feature-1": {
+    rules: [
+      {
+        // Use "my-experiment" as the key instead of "feature-1"
+        key: "my-experiment",
+        name: "My Experiment",
+        variations: ["A", "B"]
+      }
+    ]
+  },
+}
+```
+
+##### Hash Attribute
+
+We use deterministic hashing to make sure the same user always gets assigned the same value. By default, we use the attribute `id`, but this can be overridden with the `hashAttribute` setting:
+
+```js
+const gb = new GrowthBook({
+  attributes: {
+    id: "123",
+    company: "acme",
+  },
+  features: {
+    "my-feature": {
+      rules: [
+        // All users with the same "company" value
+        // will be assigned the same variation
+        {
+          variations: ["A", "B"],
+          hashAttribute: "company",
+        },
+        // If "company" is empty for the user (e.g. if they are logged out)
+        // The experiment will be skipped and fall through to this next rule
+        {
+          force: "A",
+        },
+      ],
+    },
+  },
+});
+```
+
+##### Filters
+
+Sometimes you want to run multiple conflicting experiments at the same time. You can use the `filters` setting to run mutually exclusive experiments.
+
+We do this using deterministic hashing to assign users a value between 0 and 1 for each filter.
+
+```js
+{
+  "feature1": {
+    rules: [
+      // Will include 60% of users - ones with a hash between 0 and 0.6
+      {
+        variations: [false, true],
+        filters: [
+          {
+            seed: "pricing",
+            attribute: "id",
+            ranges: [[0, 0.6]]
+          }
+        ]
+      }
+    ]
+  },
+  "feature2": {
+    rules: [
+      // Will include the other 40% of users - ones with a hash between 0.6 and 1
+      {
+        variations: [false, true],
+        filters: [
+          {
+            seed: "pricing",
+            attribute: "id",
+            ranges: [[0.6, 1.0]]
+          }
+        ]
+      },
+    ]
+  }
+}
+```
+
+**Note** - If a user is excluded from an experiment due to a filter, the rule will be skipped and the next matching rule will be used instead.
+
+## Examples
+
+- [Typescript example app with strict typing <ExternalLink />](https://github.com/growthbook/examples/tree/main/vanilla-typescript).

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/kotlin.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/kotlin.mdx
@@ -1,0 +1,125 @@
+---
+title: Kotlin SDK
+description: GrowthBook SDK for Kotlin - Android
+sidebar_label: Kotlin (Android)
+slug: kotlin
+---
+
+# Kotlin (Android)
+
+This SDK supports both Java and Kotlin Android apps using Android SDK 21 and above.
+
+## Installation
+
+```
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'io.growthbook.sdk:GrowthBook:1.0.3'
+}
+```
+
+## Quick Usage
+
+To create a GrowthBook SDK instance, use `GBSDKBuilder`. Then, you can evaluate feature flags or run experiments.
+
+```kotlin
+// User attributes for targeting and assigning users to experiment variations
+val attrs = HashMap<String, Any>()
+attrs.put("id", "123")
+attrs.put("env", "dev")
+attrs.put("betaUser", true)
+
+val gb = GBSDKBuilder(
+  // Fetch and cache feature definitions from GrowthBook API
+  // If self-hosting, we recommend using a CDN in production
+  apiKey = "key_123abc",
+  hostURL = "https://cdn.growthbook.io/",
+  attributes = attrs,
+  trackingCallback = { gbExperiment, gbExperimentResult ->
+    // TODO: track in your analytics system
+  }
+).initialize()
+
+if (gb.feature("my-feature").on) {
+  // Feature is enabled!
+}
+```
+
+If you need to set or update attributes asynchronously, you can do so with `setAttributes()`. This will completely overwrite the attributes object with whatever you pass in. Also, be aware that changing attributes may change the assigned feature values. This can be disorienting to users if not handled carefully.
+
+## Using Features
+
+The `feature` method takes a String feature name and returns a `FeatureResult` object with a few useful properties:
+
+- **value** (`Any`) - The assigned value of the feature
+- **on** (`Boolean`) - The value cast to a boolean
+- **off** (`Boolean`) - The value cast to a boolean and then negated
+- **source** (`String`) - Why the value was assigned to the user. One of "unknownFeature", "defaultValue", "force", or "experiment"
+
+When the source is "experiment", there are 2 additional properties that tell you which experiment was used and more details about the result of the experiment:
+
+- **experiment** (`GBExperiment`)
+- **experimentResult** (`GBExperimentResult`)
+
+Here are some examples:
+
+```kotlin
+val feature = gb.feature("my-feature")
+
+// Do something if feature is truthy
+if (feature.on) { }
+
+// Do something if feature is falsy
+if (feature.off) { }
+
+// Print the actual value of the feature
+// (depending on the feature, might be a string, number, boolean, etc.)
+println(feature.value)
+
+// Print the experiment id used to assign the feature value
+if (feature.source == "experiment") {
+  println(feature.experiment.key)
+}
+```
+
+## Running Inline Experiments
+
+Instead of just using features defined in the GrowthBook API, you can also just run an experiment directly. This is done with the `run` method which takes a `GBExperiment` object as an argument and returns a `GBExperimentResult` object:
+
+```kotlin
+cal exp = GBExperiment()
+exp.key = "my-experiment"
+exp.variations = arrayOf("control", "variation")
+
+val result = gb.run(exp)
+
+// Either "control" or "variation"
+println(result.value)
+```
+
+The `GBExperiment` class has two required properties - `key` and `variations`. There are also a number of optional properties:
+
+- **key** (`String`) - The unique identifier for this experiment
+- **variations** (`Any[]`) - Array of variations to decide between
+- **weights** (`Float[]`) - How to weight traffic between variations. Must add to 1.
+- **active** (`Boolean`) - If set to false, always return the control (first variation)
+- **coverage** (`Float`) - What percent of users should be included in the experiment (between 0 and 1, inclusive)
+- **condition** (`GBCondition`) - Optional targeting condition
+- **namespace** (`[String, Int, Int]`) - Adds the experiment to a namespace
+- **force** (`Int`) - All users included in the experiment will be forced into the specific variation index
+- **hashAttribute** (`String`) - What user attribute should be used to assign variations (defaults to `id`)
+
+The `GBExperimentResult` object returns the following properties:
+
+- **inExperiment** (`Boolean`)
+- **variationId** (`Int`) - The array index of the assigned variation
+- **value** (`Any`) - The value of the assigned variation
+- **hashAttribute** (`String`) - The user attribute used to assign a variation
+- **hashValue** (`String`) - The value of the attribute used to assign a variation
+
+## More Documentation
+
+The GitHub repo for this SDK has more detailed class and method documentation - https://github.com/growthbook/growthbook-kotlin

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/kotlin.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/kotlin.mdx
@@ -1,5 +1,5 @@
 ---
-title: Kotlin SDK
+title: Kotlin SDK 🚧
 description: GrowthBook SDK for Kotlin - Android
 sidebar_label: Kotlin (Android)
 slug: kotlin

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/php.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/php.mdx
@@ -1,0 +1,322 @@
+---
+title: PHP SDK
+description: GrowthBook SDK for PHP
+sidebar_label: PHP
+slug: php
+---
+
+# PHP
+
+The GrowthBook PHP SDK requires PHP version 7.1 or greater.
+
+## Installation
+
+GrowthBook is available on Composer:
+
+`composer require growthbook/growthbook`
+
+## Quick Usage
+
+```php
+// Get current feature flags from GrowthBook API
+// TODO: persist the JSON in a database or cache in production
+const FEATURES_ENDPOINT = 'https://cdn.growthbook.io/api/features/key_prod_abc123';
+$apiResponse = json_decode(file_get_contents(FEATURES_ENDPOINT), true);
+$features = $apiResponse["features"];
+
+// Create a GrowthBook instance
+$growthbook = Growthbook\Growthbook::create()
+  ->withFeatures($features)
+  ->withAttributes([
+    'id' => $userId,
+    'someCustomAttribute' => true
+  ]);
+
+// Feature gating
+if ($growthbook->isOn("my-feature")) {
+  echo "It's on!";
+} else {
+  echo "It's off :(";
+}
+
+// Remote configuration with fallback
+$color = $growthbook->getValue("button-color", "blue");
+
+echo "<button style='color:${color}'>Click Me!</button>";
+```
+
+Some of the feature flags you evaluate might be running an A/B test behind the scenes which you'll want to track in your analytics system.
+
+At the end of the request, you can loop through all experiments and track them however you want to:
+
+```php
+$impressions = $growthbook->getViewedExperiments();
+foreach($impressions as $impression) {
+  // Whatever you use for event tracking
+  Segment::track([
+    "userId" => $userId,
+    "event" => "Experiment Viewed",
+    "properties" => [
+      "experimentId" => $impression->experiment->key,
+      "variationId" => $impression->result->variationId
+    ]
+  ]);
+}
+```
+
+## The Growthbook Class
+
+The `Growthbook` class has a number of properties. These can be set using a Fluent interface or can be passed into a constructor using an associative array. Every property also has a getter method if needed. Here's an example:
+
+```php
+// Using the fluent interface
+$growthbook = Growthbook\Growthbook::create()
+  ->withFeatures($features)
+  ->withAttributes($attributes);
+
+// Using the constructor
+$growthbook = new Growthbook\Growthbook([
+  'features' => $features,
+  'attributes' => $attributes
+]);
+
+// Getter methods
+print_r($growthbook->getFeatures());
+print_r($growthbook->getAttributes());
+```
+
+Note: you can also use the fluent methods (e.g. `withFeatures`) at any point to update properties.
+
+### Features
+
+Defines all of the available features plus rules for how to assign values to users. Features are usually fetched from the GrowthBook API and persisted in cache or a database in production.
+
+Feature definitions are defined in a JSON format. You can fetch them directly from the GrowthBook API:
+
+```php
+const FEATURES_ENDPOINT = 'https://cdn.growthbook.io/api/features/key_prod_abc123';
+$apiResponse = json_decode(file_get_contents(FEATURES_ENDPOINT), true);
+$features = $apiResponse["features"];
+```
+
+Or, you can use a copy stored in your database or cache server instead:
+
+```php
+// From database/cache
+$jsonString = '{"feature-1": {...}, "feature-2": {...}}';
+$features = json_decode($jsonString, true);
+```
+
+We recomend the cache approach for production.
+
+### Attributes
+
+You can specify attributes about the current user and request. These are used for two things:
+
+1.  Feature targeting (e.g. paid users get one value, free users get another)
+2.  Assigning persistent variations in A/B tests (e.g. user id "123" always gets variation B)
+
+Attributes can be any JSON data type - boolean, integer, float, string, or array.
+
+```php
+$attributes = [
+  'id' => "123",
+  'loggedIn' => true,
+  'deviceId' => "abc123def456",
+  'age' => 21,
+  'tags' => ["tag1", "tag2"],
+  'account' => [
+    'age' => 90
+  ]
+];
+```
+
+If you want to update attributes later, please note that the `withAttributes` method completely overwrites the attributes object. You can use `array_merge` if you only want to update a subset of fields:
+
+```ts
+// Only update the url attribute
+$growthbook->withAttributes(array_merge(
+  $growthbook->getAttributes(),
+  [
+    'url' => '/checkout'
+  ]
+));
+```
+
+### Tracking Experiments
+
+Any time an experiment is run to determine the value of a feature, you want to track that event in your analytics system.
+
+You can either do this via a callback function:
+
+```php
+$trackingCallback = function (
+  Growthbook\InlineExperiment $experiment,
+  Growthbook\ExperimentResult $result
+) {
+  // Segment.io example
+  Segment::track([
+    "userId" => $userId,
+    "event" => "Experiment Viewed",
+    "properties" => [
+      "experimentId" => $experiment->key,
+      "variationId" => $result->variationId
+    ]
+  ]);
+};
+
+// Fluent interface
+$growthbook = Growthbook\Growthbook::create()
+  ->withTrackingCallback($callback);
+
+// Using the construtor
+$growthbook = new Growthbook([
+  'trackingCallback' => $trackingCallback
+]);
+
+// Getter method
+$trackingCallback = $growthbook->getTrackingCallback();
+```
+
+Or track all events at the end of the request by looping through an array:
+
+```php
+$impressions = $growthbook->getViewedExperiments();
+foreach($impressions as $impression) {
+  // Segment.io example
+  Segment::track([
+    "userId" => $userId,
+    "event" => "Experiment Viewed",
+    "properties" => [
+      "experimentId" => $impression->experiment->key,
+      "variationId" => $impression->result->variationId
+    ]
+  ]);
+}
+```
+
+Or, you can pass the impressions onto your front-end and fire analytics events from there. To do this, simply add a block to your template (shown here in plain PHP, but similar idea for Twig, Blade, etc.).
+
+```php
+<script>
+<?php foreach($growthbook->getViewedExperiments() as $impression): ?>
+  // tracking code goes here
+<?php endforeach; ?>
+</script>
+```
+
+Below are examples for a few popular front-end tracking libraries:
+
+#### Google Analytics
+
+```php
+ga('send', 'event', 'experiment',
+  "<?= $impression->experiment->key ?>",
+  "<?= $impression->result->variationId ?>",
+  {
+    // Custom dimension for easier analysis
+    'dimension1': "<?=
+      $impression->experiment->key.':'.$impression->result->variationId
+    ?>"
+  }
+);
+```
+
+#### Segment
+
+```php
+analytics.track("Experiment Viewed", <?=json_encode([
+  "experimentId" => $impression->experiment->key,
+  "variationId" => $impression->result->variationId
+])?>);
+```
+
+#### Mixpanel
+
+```php
+mixpanel.track('$experiment_started', <?=json_encode([
+  'Experiment name' => $impression->experiment->key,
+  'Variant name' => $impression->result->variationId,
+  '$source' => 'growthbook'
+])?>);
+```
+
+## Using Features
+
+There are 3 main methods for interacting with features.
+
+- `$growthbook->isOn("feature-key")` returns true if the feature is on
+- `$growthbook->isOff("feature-key")` returns false if the feature is on
+- `$growthbook->getValue("feature-key", "default")` returns the value of the feature with a fallback
+
+In addition, you can use `$growthbook->getFeature("feature-key")` to get back a `FeatureResult` object with the following properties:
+
+- **value** - The JSON-decoded value of the feature (or `null` if not defined)
+- **on** and **off** - The JSON-decoded value cast to booleans
+- **source** - Why the value was assigned to the user. One of `unknownFeature`, `defaultValue`, `force`, or `experiment`
+- **experiment** - Information about the experiment (if any) which was used to assign the value to the user
+- **experimentResult** - The result of the experiment (if any) which was used to assign the value to the user
+
+## Inline Experiments
+
+Instead of declaring all features up-front and referencing them by ids in your code, you can also just run an experiment directly. This is done with the `$growthbook->runInlineExperiment` method:
+
+```js
+$exp = Growthbook\InlineExperiment::create(
+  "my-experiment",
+  ["red", "blue", "green"]
+);
+
+// Either "red", "blue", or "green"
+echo $growthbook->runInlineExperiment($exp)->value;
+```
+
+As you can see, there are 2 required parameters for experiments, a string key, and an array of variations. Variations can be any data type, not just strings.
+
+There are a number of additional settings to control the experiment behavior. The methods are all chainable. Here's an example that shows all of the possible settings:
+
+```php
+$exp = Growthbook\InlineExperiment::create("my-experiment", ["red","blue"])
+  // Run a 40/60 experiment instead of the default even split (50/50)
+  ->withWeights([0.4, 0.6])
+  // Only include 20% of users in the experiment
+  ->withCoverage(0.2)
+  // Targeting conditions using a MongoDB-like syntax
+  ->withCondition([
+    'country' => 'US',
+    'browser' => [
+      '$in' => ['chrome', 'firefox']
+    ]
+  ])
+  // Use an alternate attribute for assigning variations (default is 'id')
+  ->withHashAttribute("sessionId")
+  // Namespaces are used to run mutually exclusive experiments
+  // Another experiment in the "pricing" namespace with a non-overlapping range
+  //   will be mutually exclusive (e.g. [0.5, 1])
+  ->withNamespace("pricing", 0, 0.5);
+```
+
+### Inline Experiment Return Value
+
+A call to `runInlineExperiment` returns an `ExperimentResult` object with a few useful properties:
+
+```php
+$result = $growthbook->runInlineExperiment($exp);
+
+// If user is part of the experiment
+echo($result->inExperiment); // true or false
+
+// The index of the assigned variation
+echo($result->variationId); // e.g. 0 or 1
+
+// The value of the assigned variation
+echo($result->value); // e.g. "A" or "B"
+
+// The user attribute used to assign a variation
+echo($result->hashAttribute); // "id"
+
+// The value of that attribute
+echo($result->hashValue); // e.g. "123"
+```
+
+The `inExperiment` flag is only set to true if the user was randomly assigned a variation. If the user failed any targeting rules or was forced into a specific variation, this flag will be false.

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/php.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/php.mdx
@@ -1,5 +1,5 @@
 ---
-title: PHP SDK
+title: PHP SDK 🚧
 description: GrowthBook SDK for PHP
 sidebar_label: PHP
 slug: php

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/python.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/python.mdx
@@ -1,5 +1,5 @@
 ---
-title: Python SDK
+title: Python SDK 🚧
 description: GrowthBook SDK for Python
 sidebar_label: Python
 slug: python

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/python.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/python.mdx
@@ -1,0 +1,329 @@
+---
+title: Python SDK
+description: GrowthBook SDK for Python
+sidebar_label: Python
+slug: python
+---
+
+# Python
+
+View the full documentation on [GitHub](https://github.com/growthbook/growthbook-python).
+
+## Installation
+
+`pip install growthbook` (recommended) or copy `growthbook.py` into your project
+
+## Quick Usage
+
+```python
+import requests
+from growthbook import GrowthBook
+
+
+# We recommend using a db or cache layer in production
+apiResp = requests.get("https://cdn.growthbook.io/api/features/MY_API_KEY")
+features = apiResp.json()["features"]
+
+# User attributes for targeting and experimentation
+attributes = {
+  "id": "123",
+  "customUserAttribute": "foo"
+}
+
+def on_experiment_viewed(experiment, result):
+  # Use whatever event tracking system you want
+  analytics.track(attributes["id"], "Experiment Viewed", {
+    'experimentId': experiment.key,
+    'variationId': result.variationId
+  })
+
+# Create a GrowthBook instance
+gb = GrowthBook(
+  attributes = attributes,
+  features = features,
+  trackingCallback = on_experiment_viewed
+)
+
+# Simple on/off feature gating
+if gb.isOn("my-feature"):
+  print("My feature is on!")
+
+# Get the value of a feature with a fallback
+color = gb.getFeatureValue("button-color-feature", "blue")
+```
+
+## GrowthBook class
+
+The GrowthBook constructor has the following parameters:
+
+- **enabled** (`bool`) - Flag to globally disable all experiments. Default true.
+- **attributes** (`dict`) - Dictionary of user attributes that are used for targeting and to assign variations
+- **url** (`str`) - The URL of the current request (if applicable)
+- **features** (`dict`) - Feature definitions from the GrowthBook API
+- **forcedVariations** (`dict`) - Dictionary of forced experiment variations (used for QA)
+- **qaMode** (`boolean`) - If true, random assignment is disabled and only explicitly forced variations are used.
+- **trackingCallback** (`callable`) - A function that takes `experiment` and `result` as arguments.
+
+There are also getter and setter methods for features and attributes if you need to update them later in the request:
+
+```python
+gb.setFeatures(gb.getFeatures())
+gb.setAttributes(gb.getAttributes())
+```
+
+### Features
+
+Defines all of the available features plus rules for how to assign values to users. Features are usually fetched from the GrowthBook API and persisted in cache or a database in production.
+
+Feature definitions are defined in a JSON format. You can fetch them directly from the GrowthBook API:
+
+```python
+import requests
+
+apiResp = requests.get("https://cdn.growthbook.io/api/features/MY_API_KEY")
+features = apiResp.json()["features"]
+```
+
+Or, you can use a copy stored in your database or cache server instead:
+
+```python
+import json
+
+json_string = '{"feature-1":{...},"feature-2":{...},...}'
+features = json.loads(json_string)
+```
+
+We recommend using the db/cache approach for production.
+
+### Attributes
+
+You can specify attributes about the current user and request. These are used for two things:
+
+1.  Feature targeting (e.g. paid users get one value, free users get another)
+2.  Assigning persistent variations in A/B tests (e.g. user id "123" always gets variation B)
+
+Attributes can be any JSON data type - boolean, integer, float, string, list, or dict.
+
+```python
+attributes = {
+  'id': "123",
+  'loggedIn': True,
+  'age': 21.5,
+  'tags': ["tag1", "tag2"],
+  'account': {
+    'age': 90
+  ]
+}
+```
+
+### Tracking Experiments
+
+Any time an experiment is run to determine the value of a feature, you want to track that event in your analytics system.
+
+You can use the `trackingCallback` option to do this:
+
+```python
+from growthbook import GrowthBook, Experiment, Result
+
+def on_experiment_viewed(experiment: Experiment, result: Result):
+  # Use whatever event tracking system you want
+  analytics.track(attributes["id"], "Experiment Viewed", {
+    'experimentId': experiment.key,
+    'variationId': result.variationId
+  })
+
+gb = GrowthBook(
+  trackingCallback = on_experiment_viewed
+)
+```
+
+## Using Features
+
+There are 3 main methods for interacting with features.
+
+- `gb.isOn("feature-key")` returns true if the feature is on
+- `gb.isOff("feature-key")` returns false if the feature is on
+- `gb.getFeatureValue("feature-key", "default")` returns the value of the feature with a fallback
+
+In addition, you can use `gb.evalFeature("feature-key")` to get back a `FeatureResult` object with the following properties:
+
+- **value** - The JSON-decoded value of the feature (or `null` if not defined)
+- **on** and **off** - The JSON-decoded value cast to booleans
+- **source** - Why the value was assigned to the user. One of `unknownFeature`, `defaultValue`, `force`, or `experiment`
+- **experiment** - Information about the experiment (if any) which was used to assign the value to the user
+- **experimentResult** - The result of the experiment (if any) which was used to assign the value to the user
+
+## Inline Experiments
+
+Instead of declaring all features up-front and referencing them by ids in your code, you can also just run an experiment directly. This is done with the `gb->run` method:
+
+```python
+from growthbook import Experiment
+
+exp = Experiment(
+  key = "my-experiment",
+  variations = ["red", "blue", "green"]
+)
+
+# Either "red", "blue", or "green"
+print(gb.run(exp).value)
+```
+
+As you can see, there are 2 required parameters for experiments, a string key, and an array of variations. Variations can be any data type, not just strings.
+
+There are a number of additional settings to control the experiment behavior:
+
+- **key** (`str`) - The globally unique tracking key for the experiment
+- **variations** (`any[]`) - The different variations to choose between
+- **weights** (`float[]`) - How to weight traffic between variations. Must add to 1.
+- **coverage** (`float`) - What percent of users should be included in the experiment (between 0 and 1, inclusive)
+- **condition** (`dict`) - Targeting conditions
+- **force** (`int`) - All users included in the experiment will be forced into the specified variation index
+- **hashAttribute** (`string`) - What user attribute should be used to assign variations (defaults to "id")
+- **namespace** (`tuple[str,float,float]`) - Used to run mutually exclusive experiments.
+
+Here's an example that uses all of them:
+
+```python
+exp = Experiment(
+  key="my-test",
+  # Variations can be a list of any data type
+  variations=[0, 1],
+  # Run a 40/60 experiment instead of the default even split (50/50)
+  weights=[0.4, 0.6],
+  # Only include 20% of users in the experiment
+  coverage=0.2,
+  # Targeting condition using a MongoDB-like syntax
+  condition={
+    'country': 'US',
+    'browser': {
+      '$in': ['chrome', 'firefox']
+    }
+  },
+  # Use an alternate attribute for assigning variations (default is 'id')
+  hashAttribute="sessionId",
+  # Includes the first 50% of users in the "pricing" namespace
+  # Another experiment with a non-overlapping range will be mutually exclusive (e.g. [0.5, 1])
+  namespace=("pricing", 0, 0.5),
+)
+```
+
+### Inline Experiment Return Value
+
+A call to `run` returns a `Result` object with a few useful properties:
+
+```python
+result = gb.run(exp)
+
+# If user is part of the experiment
+print(result.inExperiment) # True or False
+
+# The index of the assigned variation
+print(result.variationId) # e.g. 0 or 1
+
+# The value of the assigned variation
+print(result.value) # e.g. "A" or "B"
+
+# The user attribute used to assign a variation
+print(result.hashAttribute) # "id"
+
+# The value of that attribute
+print(result.hashValue) # e.g. "123"
+```
+
+The `inExperiment` flag is only set to True if the user was randomly assigned a variation. If the user failed any targeting rules or was forced into a specific variation, this flag will be false.
+
+### Example Experiments
+
+3-way experiment with uneven variation weights:
+
+```python
+gb.run(Experiment(
+  key = "3-way-uneven",
+  variations = ["A","B","C"],
+  weights = [0.5, 0.25, 0.25]
+))
+```
+
+Slow rollout (10% of users who match the targeting condition):
+
+```python
+# User is marked as being in "qa" and "beta"
+gb = GrowthBook(
+  attributes = {
+    "id": "123",
+    "beta": True,
+    "qa": True,
+  },
+)
+
+gb.run(Experiment(
+  key = "slow-rollout",
+  variations = ["A", "B"],
+  coverage = 0.1,
+  condition = {
+    'beta': True
+  }
+))
+```
+
+Complex variations
+
+```python
+result = gb.run(Experiment(
+  key = "complex-variations",
+  variations = [
+    ("blue", "large"),
+    ("green", "small")
+  ],
+))
+
+# Either "blue,large" OR "green,small"
+print(result.value[0] + "," + result.value[1])
+```
+
+Assign variations based on something other than user id
+
+```python
+gb = GrowthBook(
+  attributes = {
+    "id": "123",
+    "company": "growthbook"
+  }
+)
+
+# Users in the same company will always get the same variation
+gb.run(Experiment(
+  key = "by-company-id",
+  variations = ["A", "B"],
+  hashAttribute = "company"
+))
+```
+
+### Django
+
+For Django (and other web frameworks), we recommend adding a simple middleware where you instantiate the GrowthBook object
+
+```python
+from growthbook import GrowthBook
+
+def growthbook_middleware(get_response):
+    def middleware(request):
+        request.gb = GrowthBook(
+          # ...
+        )
+        response = get_response(request)
+
+        request.gb.destroy() # Cleanup
+
+        return response
+    return middleware
+```
+
+Then, you can easily evaluate a feature (or run an inline experiment) in any of your views:
+
+```python
+def index(request):
+    featureEnabled = request.gb.isOn("my-feature")
+    # ...
+```

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/react.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/react.mdx
@@ -1,0 +1,606 @@
+---
+title: React SDK
+description: GrowthBook SDK for React
+sidebar_label: React
+slug: react
+toc_max_heading_level: 5
+---
+
+import ExternalLink from '@site/src/components/ExternalLink'
+
+# ReactJS
+
+This is a thin wrapper on top of the [Javascript Library](/lib/js), so you might want to view those docs first to familiarize yourself with the basic classes and methods.
+
+This SDK supports both ReactJS and ReactNative environments.
+
+## Installation
+
+Install with a package manager
+
+```bash npm2yarn
+npm install --save @growthbook/growthbook-react
+```
+
+## Quick Usage
+
+### Step 1: Configure your app
+
+```tsx
+import { useEffect } from "react";
+import { GrowthBook, GrowthBookProvider } from "@growthbook/growthbook-react";
+
+// Create a GrowthBook instance
+const gb = new GrowthBook({
+  apiHost: "https://cdn.growthbook.io",
+  clientKey: "sdk-abc123",
+  // Enable easier debugging during development
+  enableDevMode: true,
+  // Only required for A/B testing
+  // Called every time a user is put into an experiment
+  trackingCallback: (experiment, result) => {
+    console.log("Experiment Viewed", {
+      experimentId: experiment.key,
+      variationId: result.key,
+    });
+  },
+});
+
+export default function App() {
+  useEffect(() => {
+    // Load features from the GrowthBook API
+    gb.loadFeatures({ autoRefresh: true })
+  }, []);
+
+  useEffect(() => {
+    // Set user attributes for targeting (from cookie, auth system, etc.)
+    gb.setAttributes({
+      id: user.id,
+      company: user.company,
+    });
+  }, [user])
+
+  return (
+    <GrowthBookProvider growthbook={gb}>
+      <OtherComponent />
+    </GrowthBookProvider>
+  );
+}
+```
+
+### Step 2: Start feature flagging!
+
+There are a few ways to use feature flags in GrowthBook:
+
+#### Feature Hooks
+
+```tsx
+import { useFeatureValue, useFeatureIsOn } from "@growthbook/growthbook-react";
+
+export default function OtherComponent() {
+  // Boolean on/off features
+  const newLogin = useFeatureIsOn("new-login-form");
+
+  // String/Number/JSON features with a fallback value
+  const buttonColor = useFeatureValue("login-button-color", "blue");
+
+  if (newLogin) {
+    return <NewLogin color={buttonColor} />;
+  } else {
+    return <Login color={buttonColor} />;
+  }
+}
+```
+
+#### Feature Wrapper Components
+
+```tsx
+import { IfFeatureEnabled, FeatureString } from "@growthbook/growthbook-react";
+
+export default function OtherComponent() {
+  return (
+    <div>
+      <h1>
+        <FeatureString feature="site-h1" default="My Site"/>
+      </h1>
+      <IfFeatureEnabled feature="welcome-message">
+        <p>Welcome to our site!</p>
+      </IfFeatureEnabled>
+    </div>
+  );
+}
+```
+
+#### useGrowthBook hook
+
+If you need low-level access to the GrowthBook instance for any reason, you can use the `useGrowthBook` hook.
+
+One example is updating targeting attributes when a user logs in:
+
+```jsx
+import { useGrowthBook } from "@growthbook/growthbook-react";
+
+export default function Auth() {
+  const growthbook = useGrowthBook();
+
+  const user = useUser();
+  useEffect(() => {
+    if (!user || !growthbook) return;
+    growthbook.setAttributes({
+      loggedIn: true,
+      id: user.id,
+      company: user.company,
+      isPro: user.plan === "pro"
+    })
+  }, [user, growthbook])
+
+  ...
+}
+```
+
+## Loading Features
+
+In order for the GrowthBook SDK to work, it needs to have feature definitions from the GrowthBook API. There are 2 ways to get this data into the SDK.
+
+### Built-in Fetching and Caching
+
+If you pass an `apiHost` and `clientKey` into the GrowthBook constructor, it will handle the network requests, caching, retry logic, etc. for you automatically. If your feature payload is encrypted, you can also pass in a `decryptionKey`.
+
+```ts
+const gb = new GrowthBook({
+  apiHost: "https://cdn.growthbook.io",
+  clientKey: "sdk-abc123",
+  decryptionKey: "key_abc123" // Only if you have feature encryption turned on
+});
+
+// Wait for features to be downloaded
+await gb.loadFeatures({
+  // When features change, update the GrowthBook instance automatically
+  // Default: `false`
+  autoRefresh: true,
+  // If the network request takes longer than this (in milliseconds), continue
+  // Default: `0` (no timeout)
+  timeout: 2000
+});
+```
+
+Until features are loaded, all features will evaluate to `null`. If you're ok with a potential flicker in your application (features going from `null` to their real value), you can call `loadFeatures` without awaiting the result.
+
+If you want to refresh the features at any time (e.g. when a navigation event occurs), you can call `gb.refreshFeatures()`.
+
+### Custom Integration
+
+If you prefer to handle the network and caching logic yourself, you can instead pass in a features JSON object directly. For example, you might store features in Postgres and send it down to your front-end as part of your app's initial bootstrap API call.
+
+```ts
+const gb = new GrowthBook({
+  features: {
+    "feature-1": {...},
+    "feature-2": {...},
+    "another-feature": {...},
+  }
+})
+```
+
+Note that you don't have to call `gb.loadFeatures()`. There's nothing to load - everything required is already passed in.
+
+You can update features at any time by calling `gb.setFeatures()` with a new JSON object.
+
+### Waiting for Features to Load
+
+There is a helper component `<FeaturesReady>` that lets you render a fallback component until features are done loading. This works for both built-in fetching and custom integrations.
+
+```jsx
+<FeaturesReady timeout={500} fallback={<LoadingSpinner/>}>
+  <ComponentThatUsesFeatures/>
+</FeaturesReady>
+```
+
+- `timeout` is the max time you want to wait for features to load (in ms). The default is `0` (no timeout).
+- `fallback` is the component you want to display before features are loaded. The default is `null`.
+
+If you want more control, you can use the `useGrowthBook()` hook and the `ready` flag:
+
+```ts
+const gb = useGrowthBook();
+
+if (gb.ready) {
+  // Do something
+}
+```
+
+## Experimentation (A/B Testing)
+
+In order to run A/B tests, you need to set up a tracking callback function. This is called every time a user is put into an experiment and can be used to track the exposure event in your analytics system (Segment, Mixpanel, GA, etc.).
+
+```js
+const gb = new GrowthBook({
+  apiHost: "https://cdn.growthbook.io",
+  clientKey: "sdk-abc123",
+  trackingCallback: (experiment, result) => {
+    // Example using Segment
+    analytics.track("Experiment Viewed", {
+      experimentId: experiment.key,
+      variationId: result.key,
+    });
+  },
+});
+```
+
+This same tracking callback is used for both feature flag experiments and Visual Editor experiments.
+
+### Feature Flag Experiments
+
+There is nothing special you have to do for feature flag experiments. Just evaluate the feature flag like you would normally do. If the user is put into an experiment as part of the feature flag, it will call the `trackingCallback` automatically in the background.
+
+```js
+// If this has an active experiment and the user is included,
+// it will call trackingCallback automatically
+useFeatureIsOn("new-signup-form")
+```
+
+If the experiment came from a feature rule, `result.featureId` in the trackingCallback will contain the feature id, which may be useful for tracking/logging purposes.
+
+### Visual Editor Experiments
+
+Experiments created through the GrowthBook Visual Editor will run automatically as soon as their targeting conditions are met.
+
+**Note**: Visual Editor experiments are only supported in a web browser environment. They will not run in React Native or during Server Side Rendering (SSR).
+
+If you are using this SDK in a Single Page App (SPA), you will need to let the GrowthBook instance know when the URL changes so the active experiments can update accordingly.
+
+For example, in Next.js, you could do this:
+
+```js
+function updateGrowthBookURL() {
+  gb.setURL(window.location.href);
+}
+
+export default function MyApp() {
+  // Subscribe to route change events and update GrowthBook
+  const router = useRouter();
+  useEffect(() => {
+    router.events.on("routeChangeComplete", updateGrowthBookURL);
+    return () => router.events.off("routeChangeComplete", updateGrowthBookURL);
+  }, []);
+
+  // ...
+}
+```
+
+## Server Side Rendering (SSR)
+
+This SDK fully supports server side rendering. The below examples use Next.js, but other frameworks should be similar.
+
+First, create a helper function:
+
+```js
+import { setPolyfills } from "@growthbook/growthbook-react";
+
+export function getServerSideGrowthBookContext(req) {
+  // Set GrowthBook polyfills for server environments
+  setPolyfills({
+    fetch: globalThis.fetch || require("cross-fetch"),
+    EventSource: globalThis.EventSource || require("eventsource"),
+    SubtleCrypto: globalThis.crypto?.subtle || require("node:crypto")?.webcrypto?.subtle
+  });
+
+  return {
+    apiHost: process.env.NEXT_PUBLIC_GROWTHBOOK_API_HOST,
+    clientKey: process.env.NEXT_PUBLIC_GROWTHBOOK_CLIENT_KEY,
+    decryptionKey: process.env.NEXT_PUBLIC_GROWTHBOOK_DECRYPTION_KEY,
+    attributes: {
+      // TODO: get more targeting attributes from request context
+      id: (req && req.cookies.DEVICE_ID) ?? null,
+    },
+  }
+}
+```
+
+There are 2 ways to use GrowthBook for SSR.
+
+### Pure SSR
+
+With this approach, feature flags are evaluated once when the page is rendered. If a feature flag changes, the user would need to refresh the page to see it.
+
+```js
+export const getServerSideProps = async (context) => {
+  // Create a GrowthBook instance and load features from the API
+  const gbContext = getServerSideGrowthBookContext(context);
+  const gb = new GrowthBook(gbContext);
+  await gb.loadFeatures({ timeout: 1000 });
+
+  return {
+    props: {
+      title: gb.getFeatureValue("site-title", "fallback"),
+      showBanner: gb.isOn("sale-banner")
+    }
+  }
+}
+
+export default function MyPage({ title, showBanner }) {
+  return (
+    <div>
+      <h1>{title}</h1>
+      {showBanner && (
+        <div className="sale">There's a Sale!</div>
+      )}
+    </div>
+  )
+}
+```
+
+### Hybrid (SSR + Client-side)
+
+With this approach, you use the client-side hooks and components (e.g. `useFeatureValue`) and simply use SSR to make sure the initial load already has the latest features from the API.
+
+You get the benefits of client-side rendering (interactivity, realtime feature flag updates) plus the benefits of SSR (no flickering, improved SEO).
+
+First, follow the normal setup steps for client-side rendering:
+
+```jsx
+// pages/_app.jsx
+import { useEffect } from "react";
+import { GrowthBook, GrowthBookProvider } from "@growthbook/growthbook-react";
+
+// Create a client-side GrowthBook instance
+const gb = new GrowthBook({
+  apiHost: process.env.NEXT_PUBLIC_GROWTHBOOK_API_HOST,
+  clientKey: process.env.NEXT_PUBLIC_GROWTHBOOK_CLIENT_KEY,
+  decryptionKey: process.env.NEXT_PUBLIC_GROWTHBOOK_DECRYPTION_KEY,
+  enableDevMode: true,
+});
+
+export default function App() {
+  useEffect(() => {
+    // Load features from the GrowthBook API and keep them up-to-date
+    gb.loadFeatures({ autoRefresh: true })
+  }, []);
+
+  useEffect(() => {
+    // Set user attributes for targeting (use the same values as SSR when possible)
+    gb.setAttributes({
+      id: user.id,
+    });
+  }, [user])
+
+  // Wrap your app in a GrowthBookProvider
+  return (
+    <GrowthBookProvider growthbook={gb}>
+      <OtherComponent />
+    </GrowthBookProvider>
+  );
+}
+```
+
+Then, use the `useGrowthBookSSR` hook to enable server side rendering:
+
+```jsx
+// pages/server.jsx
+import MyComponent from "../components/MyComponent";
+import { generateGrowthBookSSRProps } from "../util/gb-server";
+import { useGrowthBookSSR } from "@growthbook/growthbook-react";
+
+
+export const getServerSideProps = async (context) => {
+  const gbContext = getServerSideGrowthBookContext(context);
+  const gbData = await getGrowthBookSSRData(gbContext);
+
+  return {
+    props: {
+      gbData,
+    },
+  };
+};
+
+export default function ServerPage({ gbData }) {
+  // This is required once at the top of the SSR page
+  useGrowthBookSSR(gbData);
+
+  return <MyComponent />;
+}
+```
+
+Lastly, in the rest of your app, use the client-side hooks and components just as you would if you weren't using SSR.
+
+```jsx
+// components/MyComponent.jsx
+export default function MyComponent() {
+  // Boolean on/off features
+  const newLogin = useFeatureIsOn("new-login-form");
+
+  // String/Number/JSON features with a fallback value
+  const buttonColor = useFeatureValue("login-button-color", "blue");
+
+  if (newLogin) {
+    return <NewLogin color={buttonColor} />;
+  } else {
+    return <Login color={buttonColor} />;
+  }
+}
+```
+
+These exact same approaches work for static pages as well!
+
+## API Reference
+
+There are a number of configuration options and settings that control how GrowthBook behaves.
+
+### Attributes
+
+You can specify attributes about the current user and request. These are used for two things:
+
+1.  Feature targeting (e.g. paid users get one value, free users get another)
+2.  Assigning persistent variations in A/B tests (e.g. user id "123" always gets variation B)
+
+The following are some comonly used attributes, but use whatever makes sense for your application.
+
+```ts
+new GrowthBook({
+  attributes: {
+    id: "123",
+    loggedIn: true,
+    deviceId: "abc123def456",
+    company: "acme",
+    paid: false,
+    url: "/pricing",
+    browser: "chrome",
+    mobile: false,
+    country: "US",
+  },
+});
+```
+
+#### Updating Attributes
+
+If attributes change, you can call `setAttributes()` to update. This will completely overwrite any existing attributes. To do a partial update, use the following pattern:
+
+```js
+gb.setAttributes({
+  // Only update the `url` attribute, keep the rest the same
+  ...gb.getAttributes(),
+  url: "/new-page"
+})
+```
+
+### Feature Usage Callback
+
+GrowthBook can fire a callback whenever a feature is evaluated for a user. This can be useful to update 3rd party tools like NewRelic or DataDog.
+
+```ts
+new GrowthBook({
+  onFeatureUsage: (featureKey, result) => {
+    console.log("feature", featureKey, "has value", result.value);
+  },
+});
+```
+
+Note: If you evaluate the same feature multiple times (and the value doesn't change), the callback will only be fired the first time.
+
+### Dev Mode
+
+There is a [GrowthBook Chrome DevTools Extension](https://chrome.google.com/webstore/detail/growthbook-devtools/opemhndcehfgipokneipaafbglcecjia) that can help you debug and test your feature flags in development.
+
+In order for this to work, you must explicitly enable dev mode when creating your GrowthBook instance:
+
+```js
+const gb = new GrowthBook({
+  enableDevMode: true,
+});
+```
+
+To avoid exposing all of your internal feature flags and experiments to users, we recommend setting this to `false` in production in most cases.
+
+### Inline Experiments
+
+Depending on how you configure feature flags, they may run A/B tests behind the scenes to determine which value gets assigned to the user.
+
+Sometimes though, you want to run an inline experiment without going through a feature flag first. For this, you can use either the `useExperiment` hook or the Higher Order Component `withRunExperiment`:
+
+View the [Javascript SDK Docs](/lib/js) for all of the options available for inline experiments
+
+#### useExperiment hook
+
+```tsx
+import { useExperiment } from "@growthbook/growthbook-react";
+
+export default function OtherComponent() {
+  const { value } = useExperiment({
+    key: "new-headline",
+    variations: ["Hello", "Hi", "Good Day"]
+  });
+
+  return <h1>{value}</h1>;
+}
+```
+
+#### withRunExperiment (class components)
+
+**Note:** This library uses hooks internally, so still requires React 16.8 or above.
+
+```tsx
+import { withRunExperiment } from "@growthbook/growthbook-react";
+
+class OtherComponent extends React.Component {
+  render() {
+    // The `runExperiment` prop is identical to the `useExperiment` hook
+    const { value } = this.props.runExperiment({
+      key: "headline-test",
+      variations: ["Hello World", "Hola Mundo"]
+    });
+    return <h1>{value}</h1>;
+  }
+}
+// Wrap your component in `withRunExperiment`
+export default withRunExperiment(OtherComponent);
+```
+
+## TypeScript support
+
+Some hooks are available in type-safe versions. These require you to pass in your generated types as the generic argument.
+
+See the [GrowthBook CLI](/tools/cli) documentation for more information on generating type definitions and [JavaScript &rarr; TypeScript &rarr; Scrict Typing](/lib/js#strict-typing) for how to use them.
+
+### useGrowthBook&lt;T&gt;()
+
+A type-safe version of the `useGrowthBook()` hook is available. Everywhere you use `useGrowthBook()`, pass the generated features as the generic argument:
+
+```ts
+const growthbook = useGrowthBook<AppFeatures>()
+```
+
+In that case, the hook will return `GrowthBook<AppFeatures> | undefined`.
+
+You can reduce this boilerplate by creating your own hook, e.g.:
+
+```ts
+// ./src/utils/growthbook.ts
+import { useGrowthBook as _useGrowthBook } from "@growthbook/growthbook-react";
+
+export const useGrowthBook = (): GrowthBook<AppFeatures> | undefined =>
+  _useGrowthBook<AppFeatures>();
+```
+
+You can now reference the hook you created instead of the one from the official package:
+
+```ts
+import { useGrowthBook } from "@/src/utils/growthbook"
+
+const growthbook = useGrowthBook();
+
+growthbook?.getFeatureValue(knownKey, defaultValueOfValidType)
+```
+
+### useFeatureIsOn&lt;T&gt;()
+
+The React SDK also provides access to a type-safe `useFeatureIsOn<AppFeatures>()` hook.
+
+```ts
+const isDarkModeOn = useFeatureIsOn<AppFeatures>("dark_mode");
+```
+
+This will only allow you to pass known keys to the hook.
+
+You can reduce the boilerplate for this hook by creating your own and using that instead:
+
+```ts
+// ./src/utils/growthbook.ts
+import { useFeatureIsOn as _useFeatureIsOn } from "@growthbook/growthbook-react";
+
+export const useFeatureIsOn = (id: keyof AppFeatures & string): boolean =>
+  _useFeatureIsOn<AppFeatures>(id);
+```
+
+And then reference the hook you created instead of the one from the official package:
+
+```ts
+import { useFeatureIsOn } from "@/src/utils/growthbook"
+
+const isDarkModeOn = useFeatureIsOn("dark_mode");
+```
+
+## Examples
+
+- [Next.js <ExternalLink />](https://github.com/growthbook/examples/tree/main/next-js)
+- [React Native <ExternalLink />](https://github.com/growthbook/examples/tree/main/react-native-cli)
+- [Typescript example app with strict typing <ExternalLink />](https://github.com/growthbook/examples/tree/main/vanilla-typescript).

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/react.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/react.mdx
@@ -1,5 +1,5 @@
 ---
-title: React SDK
+title: React SDK 🚧
 description: GrowthBook SDK for React
 sidebar_label: React
 slug: react

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/ruby.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/ruby.mdx
@@ -1,0 +1,156 @@
+---
+title: Ruby SDK
+description: GrowthBook SDK for Ruby
+sidebar_label: Ruby
+slug: ruby
+---
+
+import ExternalLink from '@site/src/components/ExternalLink'
+
+# Ruby
+
+View the full source code at [https://github.com/growthbook/growthbook-ruby](https://github.com/growthbook/growthbook-ruby).
+
+## Installation
+
+Install the gem
+
+`gem install growthbook`
+
+## Quick start
+
+```ruby
+require 'growthbook'
+require 'uri'
+require 'net/http'
+require 'json'
+
+# Fetch features from GrowthBook API (or a Redis cache, etc.)
+uri = URI('https://cdn.growthbook.io/api/features/MY_API_KEY')
+res = Net::HTTP.get_response(uri)
+features = res.is_a?(Net::HTTPSuccess) ? JSON.parse(res.body)['features'] : nil
+
+# Create a context for the current user/request
+gb = Growthbook::Context.new(
+  features: features,
+  # User attributes for targeting / variation assignment
+  attributes: {
+    id: '123',
+    country: 'US'
+  }
+)
+
+# Use a boolean feature flag
+if gb.on? :my_feature_key
+  puts 'My feature is on!'
+end
+
+# Get the value of a multivariate feature with a fallback
+btn_color = gb.feature_value(:signup_btn_color, 'pink')
+```
+
+## Track experiment impressions
+
+When a feature's value is determined by an experiment (A/B test), you typically want to track that assignment event for later analysis.
+
+There are two ways to do this. First is by accessing all impressions at the end of a request:
+
+```ruby
+gb.impressions.each do |key, result|
+  puts "Assigned variation #{result.variation_id} in experiment #{key}"
+end
+```
+
+Second is by using a listener to get alerted in realtime as users are put into experiments:
+
+```ruby
+class MyImpressionListener
+  def on_experiment_viewed(experiment, result)
+    puts "Assigned variation #{result.variation_id} in experiment #{experiment.key}"
+  end
+end
+
+gb.listener = MyImpressionListener.new
+```
+
+## Using with Rails
+
+The recommended way to use GrowthBook with a Rails app is as follows:
+
+1. Fetch the features from the GrowthBook API (or a cache) once at server startup
+2. At the start of each request, create a new Context object
+3. Use the Context object to evaluate features and run experiments during the request
+4. At the end of a request, track experiment impressions (if any) and destroy the Context instance
+5. (optional) Periodically refresh the list of features from the GrowthBook API in the background
+
+## Dev and QA helpers
+
+For dev/QA it's often useful to force specific feature values.
+
+```ruby
+# These take precedence over everything else when determining a feature's value
+gb.forced_features = {
+  my_feature: true,
+  other_feature: "new value"
+}
+
+# Will always be true
+gb.is_on?(:my_feature)
+
+# Will always be "new value"
+gb.feature_value(:other_feature)
+```
+
+For more predictability during QA, you can also globally disable all random assignment in experiments from running:
+
+```ruby
+gb.enabled = false
+```
+
+## Inline experiments
+
+It's also possible to directly run an experiment directly in code without going through a feature flag.
+
+```ruby
+# Simple 50/50 experiment
+result = gb.run(Growthbook::InlineExperiment.new(
+  key: "my-experiment-key",
+  variations: ["red", "green"]
+))
+
+# Whether or not the user was included in the experiment (either true or false)
+puts(result.in_experiment ? 'included' : 'excluded')
+
+# The value of the assigned variation (either "red" or "green")
+puts(result.value)
+
+# The variation index (either 0 or 1)
+puts(result.variation_id)
+```
+
+There are lots of additional options when running inline experiments:
+
+```ruby
+gb.run(Growthbook::InlineExperiment.new(
+  key: "my-experiment-key",
+  variations: ["red", "green"],
+  # Filter by context attributes
+  condition: {
+    country: {
+      "$in": ["US", "CA"]
+    }
+  },
+  # Adjust variation weights from the default 50/50 split
+  weights: [0.8, 0.2],
+  # Run for a subset of traffic (0 to 1, default = 1)
+  coverage: 0.5,
+  # Use a different context attribute for assigning a variation (default = "id")
+  hash_attribute: "device_id",
+  # Use a namespace to run mutually exclusive experiments
+  namespace: ["pricing-page", 0, 0.25]
+))
+```
+
+## Code Examples
+
+- [Ruby on Rails example <ExternalLink />](https://github.com/growthbook/examples/tree/main/acme_donuts_rails)

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/ruby.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/ruby.mdx
@@ -1,5 +1,5 @@
 ---
-title: Ruby SDK
+title: Ruby SDK 🚧
 description: GrowthBook SDK for Ruby
 sidebar_label: Ruby
 slug: ruby

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/swift.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/swift.mdx
@@ -1,0 +1,128 @@
+---
+title: Swift SDK
+description: GrowthBook SDK for Swift - iOS
+sidebar_label: Swift (iOS)
+slug: swift
+---
+
+# Swift (iOS)
+
+This SDK supports the following platforms and versions:
+
+- iOS 12 and above
+- Apple TvOS 12 and above
+- Apple WatchOS 5.0 and above
+
+## Installation
+
+### CocoaPods
+
+Add the following to your podfile:
+
+```ruby
+source 'https://github.com/CocoaPods/Specs.git'
+
+target 'MyApp' do
+  pod 'GrowthBook-IOS'
+end
+```
+
+Then, install:
+
+```bash
+pod install
+```
+
+### Swift Package Manager (SPM)
+
+Add GrowthBook to your `Package.swift` file:
+
+```swift
+dependencies: [
+  .package(url: "https://github.com/growthbook/growthbook-swift.git")
+]
+```
+
+## Quick Usage
+
+```swift
+// First, create a GrowthBook instance using your unique features endpoint
+var gb: GrowthBookSDK = GrowthBookBuilder(
+  // Your GrowthBook feature flag endpoint
+  url: "https://cdn.growthbook.io/api/features/sdk-abc123"
+).initializer()
+
+// Then, add targeting attributes so you can control the release of your features
+// TODO: Replace with your real targeting attributes
+var attrs = [
+  "id": "12345",
+  "deviceId": "abc123",
+  "loggedIn": true,
+  "country": "US"
+]
+gb.setAttributes(attrs)
+
+// Finally, start feature flagging!
+
+// Boolean (On/Off) Feature Flag
+if (gb.isOn("feature-usage-code")) {
+  // Feature is enabled!
+}
+
+// String/Number/JSON Feature Flag with a fallback
+var value = gb.getFeatureValue("button-color", "blue")
+print(value)
+```
+
+## Loading Features
+
+In order for the GrowthBook SDK to work, it needs to have feature definitions from the GrowthBook API. There are 2 ways to get this data into the SDK.
+
+### Built-in Fetching and Caching
+
+If you pass a `url` into GrowthBookBuilder, it will handle the network requests, caching, retry logic, etc. for you automatically. If your feature payload is encrypted, you can also pass in an `encryptionKey` and it will decrypt feature flags automatically.
+
+```swift
+var gb: GrowthBookSDK = GrowthBookBuilder(
+  // Your feature flag endpoint
+  url: "https://cdn.growthbook.io/api/features/sdk-abc123",
+  // View your encryption key on the Features -> SDKs page
+  encryptionKey: "abcdef98765"
+).initializer()
+```
+
+If you want to refresh the features at any time (e.g. when a navigation event occurs), you can call `gb.refreshCache()`.
+
+### Custom Integration
+
+If you prefer to handle the network and caching logic yourself, you can instead pass in a features JSON object directly. For example, you might store features in Postgres on your back-end and send it down to your app as part of an initial bootstrap API call.
+
+```swift
+var gb: GrowthBookSDK = GrowthBookBuilder(
+  features: [
+    "feature1": Feature(defaultValue: true)
+  ]
+).initializer()
+```
+
+## Experimentation (A/B Testing)
+
+In order to run A/B tests on your feature flags, you need to set up a tracking callback function. This is called every time a user is put into an experiment and can be used to track the exposure event in your analytics system (Segment, Mixpanel, GA, etc.).
+
+```swift
+var gb: GrowthBookSDK = GrowthBookBuilder(
+  // Your feature flag endpoint
+  url: "https://cdn.growthbook.io/api/features/sdk-abc123",
+  // Called whenever someone is put into an experiment
+  trackingCallback: { experiment, experimentResult in
+    // TODO: Track in your real analytics system
+    print("Viewed Experiment")
+    print("Experiment Id: ", experiment.key)
+    print("Variation Id: ", experimentResult.variationId)
+  }
+).initializer()
+```
+
+## Reference
+
+View detailed docs on the [GitHub Repo](https://github.com/growthbook/growthbook-swift)

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/swift.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/swift.mdx
@@ -1,5 +1,5 @@
 ---
-title: Swift SDK
+title: Swift SDK 🚧
 description: GrowthBook SDK for Swift - iOS
 sidebar_label: Swift (iOS)
 slug: swift

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/vue.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/vue.mdx
@@ -1,5 +1,5 @@
 ---
-title: Vue.js
+title: Vue.js 🚧
 description: GrowthBook SDK for Vue.js
 sidebar_label: Vue.js
 slug: vue

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/vue.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/lib/vue.mdx
@@ -1,0 +1,299 @@
+---
+title: Vue.js
+description: GrowthBook SDK for Vue.js
+sidebar_label: Vue.js
+slug: vue
+toc_max_heading_level: 5
+---
+
+import ExternalLink from '@site/src/components/ExternalLink'
+
+This page includes example implementations for Vue 3 (composition API) and Vue 2 (options API).
+
+The Vue.js implementations are a light wrapper around the [JavaScript library](/lib/js), so you may want to view those docs first to familiarize yourself with the basic classes and methods.
+
+## Installation
+
+Add the `@growthbook/growthbook` package to your project.
+
+With Yarn:
+
+```sh
+yarn add @growthbook/growthbook
+```
+
+With NPM:
+
+```sh
+npm i --save @growthbook/growthbook
+```
+
+With unpkg:
+
+```html
+<script type="module">
+  import { GrowthBook } from "https://unpkg.com/@growthbook/growthbook/dist/bundles/esm.min.js";
+  //...
+</script>
+```
+
+## Vue 3 &rarr; Composition API
+
+### Create a provider
+
+First, we're going to create a provider that can be injected in your app.
+
+Create a file `./src/utils/growthbook/growthbook.ts` and add the following code:
+
+```ts title="./src/utils/growthbook/growthbook.ts"
+import type { App, InjectionKey } from "vue";
+import { GrowthBook } from "@growthbook/growthbook";
+
+/**
+ * Configuration for the options passed to the app.use() call
+ */
+export type GrowthBookVuePluginConfig = {
+  /**
+   * The endpoint that your features are hosted on. Get this from the Environments -> SDK Endpoints section
+   */
+  featuresEndpoint: string;
+
+  /**
+   * Allows you to use the Chrome DevTools Extension to test/debug.
+   * Learn more: https://docs.growthbook.io/tools/chrome-extension
+   */
+  enableDevMode: boolean;
+};
+
+/**
+ * The provided GrowthBook would be null in the event that the API call to the features endpoint fails.
+ */
+type GrowthBookProvider = {
+  init: () => Promise<GrowthBook | null>;
+};
+
+export const growthBookKey = Symbol() as InjectionKey<GrowthBookProvider>;
+
+const getFeaturesJson = async (
+  featuresEndpoint: string
+): Promise<Record<string, any>> => {
+  const response = await fetch(featuresEndpoint);
+  return await response.json();
+};
+
+export const growthBookPlugin = {
+  install(
+    app: App,
+    { featuresEndpoint, enableDevMode = false }: GrowthBookVuePluginConfig
+  ) {
+    let growthBook: GrowthBook | null = null;
+
+    const init = async (): Promise<GrowthBook | null> => {
+      if (growthBook) {
+        return growthBook;
+      }
+
+      try {
+        const json = await getFeaturesJson(featuresEndpoint);
+
+        growthBook = new GrowthBook({
+          enableDevMode,
+        });
+
+        growthBook.setFeatures(json.features);
+
+        return growthBook;
+      } catch (e) {
+        console.error("GrowthBook Vue plugin error", e);
+        return null;
+      }
+    };
+
+    app.provide<GrowthBookProvider>(growthBookKey, {
+      init,
+    });
+  },
+};
+```
+
+### Add the provider to your app
+
+Next, in the `./src/main.ts` file of your app, use this new plugin we just created:
+
+```ts title="./src/main.ts"
+import { growthBookPlugin } from "@/utils/growthbook/growthbook";
+
+const app = createApp(App);
+
+app.use(router);
+
+// Use the new GrowthBook plugin like other plugins
+app.use(growthBookPlugin, {
+  featuresEndpoint: "https://cdn.growthbook.io/api/features/:env_key",
+  enableDevMode: true,
+});
+
+app.mount("#app");
+```
+
+You can find your features endpoint on the [Environments &rarr; SDK Endpoints page <ExternalLink/>](https://app.growthbook.io/environments).
+
+### Use GrowthBook in your components
+
+Next, to use the GrowthBook SDK in our components, we will need to inject it, initialize the SDK with user attributes, and then check features.
+
+```ts title="<script setup lang='ts'>"
+import { inject, onMounted, ref } from "vue";
+import { growthBookKey } from "@/utils/growthbook/growthbook";
+
+const growthBookInjectable = inject(growthBookKey);
+
+const bannerText = ref<string>("");
+
+onMounted(() => {
+  growthBookInjectable?.init().then((growthBook) => {
+    if (!growthBook) {
+      console.error("GrowthBook failed to initialize");
+      return;
+    }
+
+    growthBook.setAttributes({
+      loggedIn: true,
+      country: "canada",
+      employee: true,
+      id: "user-employee-123456789",
+    });
+
+    const evaluatedBannerText = growthBook.getFeatureValue("banner_text", "");
+    if (typeof evaluatedBannerText !== "undefined") {
+      bannerText.value = evaluatedBannerText;
+    }
+  });
+});
+```
+
+The above code will allow you to use the dynamic `{{bannerText}}` value in your template.
+
+## Vue 2 &rarr; Options API
+
+### Create a provider
+
+First, we're going to create a provider that can be injected in your app.
+
+Create a file `./src/utils/growthbook/growthbook.js` and add the following code:
+
+```js title="./src/utils/growthbook/growthbook.ts"
+import { GrowthBook } from "@growthbook/growthbook";
+
+const getFeaturesJson = (featuresEndpoint) => {
+  return fetch(featuresEndpoint)
+    .then((response) => {
+      return response.json()
+    })
+}
+
+export const GrowthBookVuePlugin = {
+  install: function (Vue, { featuresEndpoint, enableDevMode = false }) {
+    let growthBook = null;
+
+    Vue.prototype.initGrowthBook = function initGrowthBook() {
+      if (growthBook) {
+        return Promise.resolve(growthBook);
+      }
+
+      return getFeaturesJson(featuresEndpoint)
+        .then((json) => {
+          growthBook = new GrowthBook({
+            enableDevMode,
+          });
+
+          growthBook.setFeatures(json.features);
+
+          return growthBook;
+        })
+        .catch((error) => {
+          console.error("GrowthBook Vue plugin initialization error", error);
+          return null;
+        })
+    }
+  }
+}
+```
+
+### Add the provider to your app
+
+Next, in the `./src/main.js` file of your app, use this new plugin we just created:
+
+```js title="./src/main.js"
+import Vue from 'vue'
+import App from './App.vue'
+import { GrowthBookVuePlugin } from './utils/growthbook/growthbook'
+
+Vue.config.productionTip = false
+
+Vue.use(GrowthBookVuePlugin, {
+  featuresEndpoint: "https://cdn.growthbook.io/api/features/:feature_key",
+  enableDevMode: true,
+})
+
+new Vue({
+  render: h => h(App),
+}).$mount('#app')
+
+```
+
+You can find your features endpoint on the [Environments &rarr; SDK Endpoints page <ExternalLink/>](https://app.growthbook.io/environments).
+
+### Use GrowthBook in your components
+
+Next, to use the GrowthBook SDK in our components, we will need to inject it, initialize the SDK with user attributes, and then check features.
+
+```js title="<script>"
+export default {
+  name: 'PublicPage',
+
+  props: {},
+
+  mounted() {
+    this
+      .initGrowthBook()
+      .then((growthBook) => {
+        if (!growthBook) {
+          console.warn('GrowthBook failed to initialize. Feature flags and experiments not active.')
+          return
+        }
+
+        growthBook.setAttributes({
+          loggedIn: true,
+          country: "france",
+          employee: false,
+          id: "user-abc123",
+        });
+
+        const evaluatedBannerText = growthBook.getFeatureValue("banner_text", "");
+        if (typeof evaluatedBannerText !== "undefined") {
+          this.bannerText = evaluatedBannerText;
+        }
+      })
+      .catch((error) => {
+        console.error('Unknown Error', error)
+      })
+      .finally(() => {
+        this.loading = false
+      })
+  },
+
+  data() {
+    return {
+      bannerText: '',
+    }
+  }
+}
+```
+
+The above code will allow you to use the dynamic `{{bannerText}}` value in your template.
+
+## Examples
+
+- [Vue 3 composition API example <ExternalLink />](https://github.com/growthbook/examples/tree/main/javascript-vue-composition)
+- [Vue 2 options API example <ExternalLink />](https://github.com/growthbook/examples/tree/main/javascript-vue-options)

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/overview.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/overview.mdx
@@ -1,120 +1,120 @@
 ---
-title: An overview of the GrowthBook Platform
-description: What is GrowthBook and how does it work? Learn about the GrowthBook platform and how it can help you grow your business.
-sidebar_label: How it works
+title: Uma visão geral da Plataforma GrowthBook
+description: O que é o GrowthBook e como funciona? Aprenda mais sobre a plataforma e como ela pode ajudar seu negócio a crescer.
+sidebar_label: Como funciona
 slug: overview
 ---
 
 import ButtonCard from '@site/src/components/ButtonCard'
 
-# What is GrowthBook?
+# O que é o GrowthBook?
 
-GrowthBook is a modular platform. You can use it for either Feature Flags, Experiment Analysis, or both.
+GrowthBook é uma plataforma modular. Você pode utilizá-la para Feature Flags ou Análises de Experimentos.
 
-[**Feature Flags**](/app/features) you create in the GrowthBook UI are published to our API as a JSON file. Pass this JSON into our SDKs and use the feature flags throughout your code. If a feature is running as part of an A/B test, we'll fire a tracking callback in the SDK so you can record that event in your data warehouse or analytics platform for later analysis.
+[**Feature Flags**](/app/features) são utilizadas para mudar o comportamento das funcionalidades. Você as cria no app GrowthBook e elas são publicadas para a nossa API como um arquivo JSON. Com esse JSON sendo passado para um de nossos SDKs você pode usar feature flags pelo seu código. Se uma funcionalidade está sendo utilizada como parte de um teste A/B, nós disparamos um callback para o SDK com intuito de você guardar este evento em seu Data Warehouse ou Plataforma de Análise para uso posterior.
 
-[**Experiment Analysis**](/app/experiments) queries your data warehouse for raw experiment data and runs it through our stats engine to produce a report. No raw user-level events or PII are ever sent to GrowthBook. We only get back aggregate info instead (sums, sums of squares, etc.).
+[**Análises de Experimentos**](/app/experiments) consiste na realização de consultas ao seu data warehouse por dados brutos de experimentos e os utiliza em nosso motor de análise para produzir um relatório. Nenhum evento bruto a nível de pessoa usuária ou informação pessoal é enviado para o GrowthBook. Nós só utilizamos informações agregadas (somas, somas dos quadrados, etc.).
 
 <div style={{textAlign: 'center'}}>
 
-![GrowthBook: How it Works Diagram](/images/feature-flagging-experimentation-diagram-766.png)
+![GrowthBook: Diagrama de funcionamento](/images/feature-flagging-experimentation-diagram-766.png)
 
 </div>
 
 ## Feature Flags
 
-[Feature flags](/app/features) are a very powerful developer tool. They give you deep control over how and when new functionality is released to your users.
+[Feature flags](/app/features) são uma ferramenta poderosa de desenvolvimento. Elas te dão um profundo controle sobre como e quando uma nova funcionalidade será lançada para sua base de pessoas usuárias.
 
-GrowthBook supports 4 types of features:
+GrowthBook suporta quatro tipo de feature flags:
 
-- **Boolean (on/off)**
-- **Number**
-- **String**
+- **Boleano (Boolean - on/off)**
+- **Número (Number)**
+- **Texto (String)**
 - **JSON**
 
-Using features in your code is easy. Here's an example from our Javascript SDK:
+O seu uso no código é bem simples. Observe um exemplo usando o SDK Javascript:
 
 ```js
-// For boolean features
-if (growthbook.isOn("my-feature")) {
-  // ... Do something
+// Para funcionalidades boleanas
+if (growthbook.isOn("minha-funcionalidade")) {
+  // ... Faça alguma coisa
 }
 
-// For number, string, and JSON features
-const value = growthbook.getFeatureValue("other-feature", "fallback");
+// Para funcionalidades no formato de número, texto, JSON
+const value = growthbook.getFeatureValue("outra-funcionalidade", "exceção");
 ```
 
-GrowthBook also supports multiple environments, so you can, for example, have a feature enabled in **dev** but not **production**.
+GrowthBook também suporta múltiplos ambientes: você pode, por exemplo, ter uma funcionalidade habilitada em **desenvolvimento** mas não em **produção**.
 
-You can also change the value of a feature with **Override Rules**. The following types of rules are supported:
+Você também pode alterar o valor da feature flag com a **Sobreposição de Regras (Override Rules)**. Os seguintes tipos são suportados:
 
-- **Forced Value** - Choose a subset of users based on targeting attributes and assign them all the same value
-- **Percentage Rollout** - Use random sampling to roll out a new feature value to a percent of users
-- **A/B Experiment** - Run a controlled A/B test between 2 or more feature values
+- **Forçar Valor (Forced Value)** - Escolha um subconjunto de pessoas usuárias baseado em atributos direcionados e coloque-os com o mesmo valor
+- **Lançamento em Porcentagem (Percentage Rollout)** - Use uma amostragem aleatória para lançar uma nova funcionalidade para um percentual de pessoas usuárias
+- **Experimento A/B (A/B Experiment)** - Execute testes A/B controlados entre duas ou mais funcionalidades
 
-All features for an environment are packaged together into a single JSON file. All you need to do is pass this into our [SDKs](/lib) along with [user targeting attributes](/app/features#targeting-attributes).
+Todas as feature flags de um ambiente ficam presentes em um único arquivo JSON. Tudo que você precisa é que isto seja passado para um de nossos [SDKs](/lib) com [os atributos direcionados das pessoas](/app/features#targeting-attributes).
 
-Read more about [features here](/app/features).
+Leia mais sobre a parte de [feature flags aqui](/app/features).
 
-## Experiment Analysis
+## Análise de Experimentos
 
-GrowthBook needs to connect to your [Data Source](/app/datasources) in order to query experiment results. We support all of the popular SQL data warehouses in addition to Mixpanel and Google Analytics. GrowthBook is extremely flexible and can support almost any schema structure with a little bit of configuration.
+O GrowthBook precisa se conectar a sua [Fonte de Dados](/app/datasources) para consultar os resultados dos experimentos. Nós suportamos todos os data warehouses SQL populares além do Mixpanel e Google Analytics. O GrowthBook é extremamente flexível e pode suportar praticamente qualquer estrutura com algumas poucas configurações.
 
-![Data warehouses supported by GrowthBook](/images/GrowthBook-supported-DB-766.png)
+![Data warehouses suportados pelo GrowthBook](/images/GrowthBook-supported-DB-766.png)
 
-Once connected to a data source, you need to build a re-usable library of [Metrics](/app/metrics). Metrics are what your experiments are trying to improve. Metrics are defined via SQL (if your data source supports it) or a simple query builder. The following types are supported:
+Uma vez conectado a uma fonte de dados, você precisa construir uma biblioteca re-utilizável de [Métricas](/app/metrics). Métricas são o que os seus experimentos estão tentando melhorar. Elas são definidas via SQL (caso sua fonte suporte) ou uma simples consulta. Os seguintes tipos são suportados:
 
-- **binomial** - simple yes/no conversion metrics (e.g. `started trial`, `bounce rate`, `purchased`)
-- **count** - when the number or magnitude of conversions matters (e.g. `downloads per user`, `points earned`)
-- **revenue** - the amount of revenue earned (e.g. `revenue per user`, `average order value`)
-- **duration** - the time it takes to do something (e.g. `page load time`, `time on site`)
+- **Binomial (binomial)** - métricas simples de conversão sim/não (ex. `número de pessoas que iniciarem o período de avaliação`, `taxa de bounce`, `compras`)
+- **Contagem (count)** - quando o número ou a magnitide das conversões é importante (ex. `downloads por pessoa`, `pontos conquistados`)
+- **Receita (revenue)** - número de receita adquirido (ex. `receita por pessoa`, `média de valor por pedido`)
+- **Duração (duration)** - o tempo que leva para alguma coisa acontecer (ex. `tempo de carregamento da página`, `tempo utilizando o app`)
 
-Once these are metrics are set up, you can import experiments and start analyzing the results. GrowthBook uses a [Bayesian statistics engine](/statistics/overview) to determine the probability that a variation is better than the control, as well as how much better it is and how risky it is to stop the experiment now.
+Uma vez que essas métricas são configuradas, você pode importar experimentos e começar analisar os resultados. GrowthBook usa um [motor de estatística Bayesiano](/statistics/overview) para determinar a probabilidade de que uma variante seja melhor que o grupo controle, assim como o quão melhor foi o resultado e o risco de parar o experimento em um dado momento.
 
-![Results Table](/images/results-table.png)
+![Tabela de Resultados](/images/results-table.png)
 
-Your data team can drill down into results by custom [dimensions](/app/dimensions), view the raw SQL that GrowthBook is running on your data warehouse, and export results to a Jupyter notebook for even deeper analysis.
+Seu time de dados pode se aprofundar nos resultados utilizando [dimensões](/app/adimensions) personalizadas, observando o SQL bruto que o GrowthBook está utilizando para consultar seu data warehouse e exportando os resultados pra um Jupyter notebook para uma análise ainda mais aprofundada.
 
-Read more about [experiments here](/app/experiments).
+Leia mais sobre a parte de [experimentos aqui](/app/experiments).
 
-## Use Cases
+## Casos de uso
 
-There are typically three reasons that teams use GrowthBook.
+Há geralmente três motivos para os times utilizarem o GrowthBook.
 
-### 1. Full Experimentation Platform
+### 1. Plataforma Completa de Experimentos
 
-In this use case, companies use Feature Flags and our SDKs to run experiments in their applications. Then they use our Experiment Analysis to look at the results and decide on a winner.
+Neste caso, as empresas usam Feature Flags e os nossos SDKs para experimentos em suas aplicações. Então utilizam nossa Análise de Experimentos para olhar os resultados e decidir a versão vencedora.
 
-This is best for companies that are either just starting with experimentation or want to completely switch away from their current way of doing things.
+Esse caso é o melhor para empresas que estão iniciando no mundo da experimentação ou querem mudar drásticamente a sua forma de fazerem as coisas.
 
-### 2. Feature Flags Only
+### 2. Apenas Feature Flags
 
-In this use case, companies don't run experiments at all and just use GrowthBook feature flags within their engineering team.
+Neste caso, as empresas não realizam experimentos e só utilizam as feature flags do GrowthBook dentro de seu time de engenharia.
 
-This is best for companies that don't have enough traffic to run full experiments, but still want all of the benefits that feature flags provide. It's also good for companies that know they will want to run experiments in the future and want to start instrumenting their applications today to get ready.
+Esse caso é o melhor para empresas que não tem um volume de pessoas usuárias adequado para rodar experimentos completos, porém querem todos os benefícios proporcionados pelas feature flags. É bom também para empresas que pretendem rodar experimentos no futuro e querem começar a "preparar o terreno" em suas aplicações desde já.
 
-### 3. Experiment Analysis Only
+### 3. Apenas Análise de Experimentos
 
-In this use case, companies are already running experiments and analyzing results usually with either a home-built reporting system or by manually creating Jupyter notebooks. They use GrowthBook to automate and improve the analysis process to save time and make better decisions.
+Neste caso, as empresas já estão realizando experimentos e analisandos resultados geralmente com um sistema próprio de análise ou de forma manual usando notebooks Jupyter. O uso do Growthbook consiste em automatizar e aprimorar o processo de análise com intuito de reduzir o tempo e ter melhores decisões.
 
-This is best for companies that already have a robust process for running experiments and just need a little help analyzing results at scale.
+Esse caso é o melhor para empresas that already have a robust process for running experiments and just need a little help analyzing results at scale.
 
-## Next Steps
+## Próximos passos
 
 <div className="row is-multiline">
     <div className="col col--4">
         <ButtonCard
             to={'/self-host'}
-            title="Self-Host"
-            description="Learn about running GrowthBook on your own infrastructure"
+            title="Hospedagem Própria"
+            description="Aprenda utilizar o GrowthBook em sua própria infraestrutura"
             style={{ height: '100%' }}
         ></ButtonCard>
     </div>
     <div className="col col--4">
         <ButtonCard
             to={'/lib'}
-            title="SDK Docs"
-            description="Learn about the GrowthBook SDKs"
+            title="Documentação do SDK"
+            description="Aprenda sobre os SDKs do GrowthBook"
             style={{ height: '100%' }}
             color="default"
         ></ButtonCard>
@@ -123,7 +123,7 @@ This is best for companies that already have a robust process for running experi
         <ButtonCard
             to={'/faq'}
             title="FAQ"
-            description="Frequently asked questions"
+            description="Perguntas frequentes"
             style={{ height: '100%' }}
             color="default"
         ></ButtonCard>

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/overview.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/overview.mdx
@@ -1,0 +1,131 @@
+---
+title: An overview of the GrowthBook Platform
+description: What is GrowthBook and how does it work? Learn about the GrowthBook platform and how it can help you grow your business.
+sidebar_label: How it works
+slug: overview
+---
+
+import ButtonCard from '@site/src/components/ButtonCard'
+
+# What is GrowthBook?
+
+GrowthBook is a modular platform. You can use it for either Feature Flags, Experiment Analysis, or both.
+
+[**Feature Flags**](/app/features) you create in the GrowthBook UI are published to our API as a JSON file. Pass this JSON into our SDKs and use the feature flags throughout your code. If a feature is running as part of an A/B test, we'll fire a tracking callback in the SDK so you can record that event in your data warehouse or analytics platform for later analysis.
+
+[**Experiment Analysis**](/app/experiments) queries your data warehouse for raw experiment data and runs it through our stats engine to produce a report. No raw user-level events or PII are ever sent to GrowthBook. We only get back aggregate info instead (sums, sums of squares, etc.).
+
+<div style={{textAlign: 'center'}}>
+
+![GrowthBook: How it Works Diagram](/images/feature-flagging-experimentation-diagram-766.png)
+
+</div>
+
+## Feature Flags
+
+[Feature flags](/app/features) are a very powerful developer tool. They give you deep control over how and when new functionality is released to your users.
+
+GrowthBook supports 4 types of features:
+
+- **Boolean (on/off)**
+- **Number**
+- **String**
+- **JSON**
+
+Using features in your code is easy. Here's an example from our Javascript SDK:
+
+```js
+// For boolean features
+if (growthbook.isOn("my-feature")) {
+  // ... Do something
+}
+
+// For number, string, and JSON features
+const value = growthbook.getFeatureValue("other-feature", "fallback");
+```
+
+GrowthBook also supports multiple environments, so you can, for example, have a feature enabled in **dev** but not **production**.
+
+You can also change the value of a feature with **Override Rules**. The following types of rules are supported:
+
+- **Forced Value** - Choose a subset of users based on targeting attributes and assign them all the same value
+- **Percentage Rollout** - Use random sampling to roll out a new feature value to a percent of users
+- **A/B Experiment** - Run a controlled A/B test between 2 or more feature values
+
+All features for an environment are packaged together into a single JSON file. All you need to do is pass this into our [SDKs](/lib) along with [user targeting attributes](/app/features#targeting-attributes).
+
+Read more about [features here](/app/features).
+
+## Experiment Analysis
+
+GrowthBook needs to connect to your [Data Source](/app/datasources) in order to query experiment results. We support all of the popular SQL data warehouses in addition to Mixpanel and Google Analytics. GrowthBook is extremely flexible and can support almost any schema structure with a little bit of configuration.
+
+![Data warehouses supported by GrowthBook](/images/GrowthBook-supported-DB-766.png)
+
+Once connected to a data source, you need to build a re-usable library of [Metrics](/app/metrics). Metrics are what your experiments are trying to improve. Metrics are defined via SQL (if your data source supports it) or a simple query builder. The following types are supported:
+
+- **binomial** - simple yes/no conversion metrics (e.g. `started trial`, `bounce rate`, `purchased`)
+- **count** - when the number or magnitude of conversions matters (e.g. `downloads per user`, `points earned`)
+- **revenue** - the amount of revenue earned (e.g. `revenue per user`, `average order value`)
+- **duration** - the time it takes to do something (e.g. `page load time`, `time on site`)
+
+Once these are metrics are set up, you can import experiments and start analyzing the results. GrowthBook uses a [Bayesian statistics engine](/statistics/overview) to determine the probability that a variation is better than the control, as well as how much better it is and how risky it is to stop the experiment now.
+
+![Results Table](/images/results-table.png)
+
+Your data team can drill down into results by custom [dimensions](/app/dimensions), view the raw SQL that GrowthBook is running on your data warehouse, and export results to a Jupyter notebook for even deeper analysis.
+
+Read more about [experiments here](/app/experiments).
+
+## Use Cases
+
+There are typically three reasons that teams use GrowthBook.
+
+### 1. Full Experimentation Platform
+
+In this use case, companies use Feature Flags and our SDKs to run experiments in their applications. Then they use our Experiment Analysis to look at the results and decide on a winner.
+
+This is best for companies that are either just starting with experimentation or want to completely switch away from their current way of doing things.
+
+### 2. Feature Flags Only
+
+In this use case, companies don't run experiments at all and just use GrowthBook feature flags within their engineering team.
+
+This is best for companies that don't have enough traffic to run full experiments, but still want all of the benefits that feature flags provide. It's also good for companies that know they will want to run experiments in the future and want to start instrumenting their applications today to get ready.
+
+### 3. Experiment Analysis Only
+
+In this use case, companies are already running experiments and analyzing results usually with either a home-built reporting system or by manually creating Jupyter notebooks. They use GrowthBook to automate and improve the analysis process to save time and make better decisions.
+
+This is best for companies that already have a robust process for running experiments and just need a little help analyzing results at scale.
+
+## Next Steps
+
+<div className="row is-multiline">
+    <div className="col col--4">
+        <ButtonCard
+            to={'/self-host'}
+            title="Self-Host"
+            description="Learn about running GrowthBook on your own infrastructure"
+            style={{ height: '100%' }}
+        ></ButtonCard>
+    </div>
+    <div className="col col--4">
+        <ButtonCard
+            to={'/lib'}
+            title="SDK Docs"
+            description="Learn about the GrowthBook SDKs"
+            style={{ height: '100%' }}
+            color="default"
+        ></ButtonCard>
+    </div>
+    <div className="col col--4">
+        <ButtonCard
+            to={'/faq'}
+            title="FAQ"
+            description="Frequently asked questions"
+            style={{ height: '100%' }}
+            color="default"
+        ></ButtonCard>
+    </div>
+</div>

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/self-host/config.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/self-host/config.mdx
@@ -1,5 +1,5 @@
 ---
-title: Config.yml
+title: Config.yml 🚧
 description: Adjust the configuration of the GrowthBook platform through Config.yml
 id: config-yml
 slug: config

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/self-host/config.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/self-host/config.mdx
@@ -1,0 +1,529 @@
+---
+title: Config.yml
+description: Adjust the configuration of the GrowthBook platform through Config.yml
+id: config-yml
+slug: config
+---
+
+# Config.yml
+
+In order to use GrowthBook, you need to connect to a data source and define metrics (and optionally dimensions and segments). There are two ways to do this.
+
+The default way to define these is by filling out forms in the GrowthBook UI, which persists them to MongoDB.
+
+The other option is to create a `config.yml` file. In the Docker container, this file must be placed at `/usr/local/src/app/config/config.yml`. Below is an example file:
+
+```yml
+datasources:
+  warehouse:
+    type: postgres
+    name: Main Warehouse
+    # Connection params (different for each type of data source)
+    params:
+      host: localhost
+      port: 5432
+      user: root
+      password: ${POSTGRES_PW} # use env for secrets
+      database: growthbook
+    # How to query the data (same for all SQL sources)
+    settings:
+      userIdTypes:
+        - userIdType: user_id
+          description: Logged-in user id
+        - userIdType: anonymous_id
+          description: Anonymous visitor id
+      queries:
+        exposure:
+          - id: user_id
+            name: Logged-in user experiments
+            userIdType: user_id
+            query: >
+              SELECT
+                user_id,
+                received_at as timestamp,
+                experiment_id,
+                variation_id,
+                context_location_country as country
+              FROM
+                experiment_viewed
+            dimensions:
+              - country
+        identityJoins:
+          - ids: ["user_id", "anonymous_id"]
+            query: SELECT user_id, anonymous_id FROM identifies
+metrics:
+  signups:
+    type: binomial
+    name: Sign Ups
+    userIdType: user_id
+    datasource: warehouse
+    sql: SELECT user_id, anonymous_id, received_at as timestamp FROM signups
+dimensions:
+  country:
+    name: Country
+    userIdType: user_id
+    datasource: warehouse
+    sql: SELECT user_id, country as value from users
+segments:
+  visitors:
+    name: Visitors in the US
+    datasource: warehouse
+    sql: |-
+      SELECT userid as user_id, timestamp as date
+      FROM users
+      WHERE country='US'
+    userIdType: user_id
+```
+
+### Data Source Connection Params
+
+The contents of the `params` field for a data source depends on the type.
+
+As seen in the example above, you can use environment variable interpolation for secrets (e.g. `${POSTGRES_PW}`).
+
+#### Redshift, ClickHouse, Postgres, and Mysql (or MariaDB)
+
+```yml
+type: postgres # or "redshift" or "mysql" or "clickhouse"
+params:
+  host: localhost
+  port: 5432
+  user: root
+  password: password
+  database: growthbook
+```
+
+Redshift and Postgres also support optional params to force an SSL connection:
+
+```yml
+type: postgres
+params:
+  ...
+  ssl: true
+  # Omit the below fields to use the default trusted CA from Mozilla
+  caCert: "-----BEGIN CERTIFICATE-----\n..."
+  clientCert: "-----BEGIN CERTIFICATE-----\n..."
+  clientKey: "-----BEGIN CERTIFICATE-----\n..."
+```
+
+#### Snowflake
+
+```yml
+type: snowflake
+params:
+  account: abc123.us-east-1
+  username: user
+  password: password
+  database: GROWTHBOOK
+  schema: PUBLIC
+  role: SYSADMIN
+  warehouse: COMPUTE_WH
+```
+
+#### BigQuery
+
+You must first create a Service Account in Google with the following roles:
+
+- Data Viewer
+- Metadata Viewer
+- Job User
+
+If you want GrowthBook to auto-discover credentials from environment variables or GCP metadata, use the following:
+
+```yml
+type: bigquery
+params:
+  authType: auto
+```
+
+If you prefer to pass in credentials directly, you can use this format instead:
+
+```yml
+type: bigquery
+params:
+  projectId: my-project
+  clientEmail: growthbook@my-project.iam.gserviceaccount.com
+  privateKey: -----BEGIN PRIVATE KEY-----\nABC123\n-----END PRIVATE KEY-----\n
+```
+
+#### Presto and TrinoDB
+
+```yml
+type: presto
+params:
+  engine: presto # or "trino"
+  host: localhost
+  port: 8080
+  username: user
+  password: password
+  catalog: growthbook
+  schema: growthbook
+```
+
+#### Databricks
+
+```yml
+type: databricks
+params:
+  host: dbc-123-abc.cloud.databricks.com
+  port: 443
+  path: /sql/1.0/warehouses/abc123
+  token: dapi123abc
+```
+
+#### AWS Athena
+
+If you want GrowthBook to auto-discover credentials from environment variables or instance metadata, use the following format:
+
+```yml
+type: athena
+params:
+  authType: auto
+  region: us-east-1
+  database: growthbook
+  bucketUri: aws-athena-query-results-growthbook
+  workGroup: primary
+```
+
+If you prefer to specify access key and secret directly instead, use the following format:
+
+```yml
+type: athena
+params:
+  accessKeyId: AKIA123
+  secretAccessKey: AB+cdef123
+  region: us-east-1
+  database: growthbook
+  bucketUri: aws-athena-query-results-growthbook
+  workGroup: primary
+```
+
+#### Mixpanel
+
+Mixpanel access requires a service account.
+
+```yml
+type: mixpanel
+params:
+  username: growthbook
+  secret: abc123
+  projectId: my-project
+```
+
+#### Google Analytics
+
+Unfortunately at this time there is no way to connect to Google Analytics in `config.yml`. You must connect via the GrowthBook UI, where we use OAuth and a browser redirect.
+
+### Data Source Settings
+
+The settings tell GrowthBook how to query your data.
+
+#### SQL Data Sources
+
+For data sources that support SQL, there are a couple queries you need to define plus an optional Python script to run queries from inside a Jupyter notebook:
+
+```yml
+type: postgres
+params: ...
+settings:
+  # The different types of supported identifiers
+  userIdTypes:
+    - userIdType: user_id
+      description: Logged-in user id
+    - userIdType: anonymous_id
+      description: Anonymous visitor id
+  queries:
+    # These queries returns experiment variation assignment info
+    # One row every time a user was put into an experiment
+    exposure:
+      - id: user_id
+        name: Logged-in user experiments
+        userIdType: user_id
+        query: >
+          SELECT
+            user_id,
+            received_at as timestamp,
+            experiment_id,
+            variation_id,
+            context_location_country as country
+          FROM
+            experiment_viewed
+        # List additional columns you selected in your experimentsQuery
+        # Can use these to drill down into experiment results
+        dimensions:
+          - country
+    # These optional queries map between different types of identifiers
+    identityJoins:
+      - ids: ["user_id", "anonymous_id"]
+        query: SELECT user_id, anonymous_id FROM identifies
+  # Used when exporting experiment results to a Jupyter notebook
+  # Define a `runQuery(sql)` function that returns a pandas data frame
+  notebookRunQuery: >
+    import os
+    import psycopg2
+    import pandas as pd
+    from sqlalchemy import create_engine, text
+
+    # Use environment variables or similar for passwords!
+    password = os.getenv('POSTGRES_PW')
+    connStr = f'postgresql+psycopg2://user:{password}@localhost'
+    dbConnection = create_engine(connStr).connect();
+
+    def runQuery(sql):
+      return pd.read_sql(text(sql), dbConnection)
+```
+
+#### Mixpanel
+
+Mixpanel does not support SQL, so we query the data using JQL instead. In order to do this, we just need to know a few event names and properties:
+
+```yml
+type: mixpanel
+params: ...
+settings:
+  events:
+    experimentEvent: Viewed Experiment
+    experimentIdProperty: experiment_id
+    variationIdProperty: variation_id
+```
+
+### Metrics
+
+Metrics are what your experiments are trying to improve (or at least not hurt).
+
+Below is an example of all the possible settings with comments:
+
+```yml
+name: Revenue per User
+# Required. The data distribution and unit
+type: revenue # or "binomial" or "count" or "duration"
+# Required. Must match one of the datasources defined in config.yml
+datasource: warehouse
+# Description supports full markdown
+description: This metric is **super** important
+# For inverse metrics, the goal is to DECREASE the value (e.g. "page load time")
+inverse: false
+# When ignoring nulls, only users who convert are included in the denominator
+# Setting to true here would change from "Revenue per User" to "Average Order Value"
+ignoreNulls: false
+# Which identifier types are supported for this metric
+userIdTypes:
+  - user
+# Any user with a higher metric amount will be capped at this value
+# In this case, if someone bought a $10,000 order, it would only be counted as $100
+cap: 100
+# Ignore all conversions within the first X hours of being put into an experiment.
+conversionDelayHours: 0
+# After the conversion delay (if any), wait this many hours for a conversion event.
+conversionWindowHours: 72
+# The risk thresholds for the metric.
+# If risk < $winRisk, it is highlighted green.
+# If risk > $loseRisk, it is highlighted red.
+# Otherwise, it's highlighted yellow.
+winRisk: 0.0025
+loseRisk: 0.0125
+# Min number of conversions for an experiment variation before we reveal results
+minSampleSize: 150
+# The "suspicious" threshold. If the percent change for a variation is above this,
+#   we hide the result and label it as suspicious.
+# Default 0.5 = 50% change
+maxPercentChange: 0.50
+# The minimum change required for a result to considered a win or loss. If the percent
+# change for a variation is below this threshold, we will consider an otherwise conclusive
+# test a draw.
+# Default 0.005 = 0.5% change
+minPercentChange: 0.005
+# Arbitrary tags used to group related metrics
+tags:
+  - revenue
+  - core
+```
+
+In addition to all of those settings, you also need to tell GrowthBook how to query the metric.
+
+#### SQL Data Sources
+
+For SQL data sources, you just need to specify a single query. Depending on the other settings, the columns you need to select may differ slightly:
+
+- `timestamp` - always required
+- `value` - required unless type is set to "binomial"
+
+Plus, you need to select a column for each identifier type the metric supports.
+
+A full example:
+
+```yml
+type: duration
+userIdTypes:
+  - user_id
+  - anonymous_id
+sql: >
+  SELECT
+    created_at as timestamp,
+    user_id,
+    anonymous_id,
+    duration as value
+  FROM
+    requests
+```
+
+And a simple binomial metric that only supports logged-in users:
+
+```yml
+type: binomial
+userIdTypes:
+  - user
+sql: SELECT user_id, timestamp FROM orders
+```
+
+By default, if a user has more than 1 non-binomial metric row during an experiment, we sum the values together. You can override this behavior with the `aggregation` setting:
+
+```yml
+type: duration
+userIdTypes:
+  - user_id
+sql: >
+  SELECT
+    created_at as timestamp,
+    user_id,
+    duration as value
+  FROM
+    requests
+aggregation: MAX(value) # use MAX instead of the default SUM
+```
+
+#### Mixpanel
+
+For Mixpanel, instead of SQL we just need some info about what events and properties to use.
+
+Here's a simple binomial metric:
+
+```yml
+type: binomial
+# The event name
+table: Purchased
+```
+
+Any metric can have optional conditions as well:
+
+```yml
+type: binomial
+# The event name
+table: Purchased
+# Only include events which pass these conditions
+conditions:
+  - column: category # property
+    operator: "=" # "=", "!=", ">", "<", "<=", ">=", "~", "!~"
+    value: clothing
+```
+
+For count, duration, and revenue metrics, it will count the number of events per user by default:
+
+```yml
+type: count
+# Event name to count
+table: Page views
+```
+
+You can instead specify a javascript expression for the value of the event. By default, it will sum these values for each user:
+
+```yml
+# A "Revenue per user" metric
+type: revenue
+# The event name
+table: Purchases
+# The metric value that will be summed
+column: event.properties.grand_total
+```
+
+If you don't want to sum, you can also provide a custom aggregation method that reduces an array of `values` into a single number (or null). For example, here's a metric that counts the number of unique files downloaded per user
+
+```yml
+type: count
+# The event name
+table: PDF Downloads
+# The "value" of the metric (the file name)
+column: event.properties.filename
+# The aggregation operation (number of unique values)
+aggregation: new Set(values).size
+```
+
+### Dimensions
+
+Dimensions let you drill down into your experiment results. They are currently only supported for SQL data sources.
+
+Dimensions only have 4 properties: name, datasource, userIdType, and SQL. The SQL query must return two columns: the identifier type and `value`.
+
+Example:
+
+```yml
+name: Country
+# Must match one of the datasources defined in config.yml
+datasource: warehouse
+userIdType: user_id
+sql: SELECT user_id, country as value FROM users
+```
+
+### Segments
+
+Segments define important groups of users - for example, "annual subscribers" or "left-handed people from France." They are currently only supported for SQL data sources.
+
+Segments only have 4 properties: name, datasource, userIdType, and SQL. The SQL query must return two columns: the identifier type and `date`.
+
+Example:
+
+```yml
+name: US Page Visitors
+# Must match one of the datasources defined in config.yml
+datasource: warehouse
+userIdType: user_id
+sql: SELECT user_id, timestamp as date FROM pages WHERE country='US'
+```
+
+Segment support for the config.yml was added in February 2023. If you are using the config.yml file and have previously created segments stored in MongoDB, in order to access,
+you will need to add the environment variable `STORE_SEGMENTS_IN_MONGO` or update your config.yml file to include these segments.
+
+### Organization Settings
+
+In addition to the above, you can also control some organization settings from `config.yml`.
+
+Below are all of the currently supported settings:
+
+```yml
+organization:
+  settings:
+    # Enable creating experiments using the Visual Editor (beta).  Default `false`
+    visualEditorEnabled: true
+    # Minimum experiment length (in days) when importing past experiments. Default `6`
+    pastExperimentsMinLength: 3
+    # Number of days of historical data to use when analyzing metrics
+    # (must be between 1 and 400, default `90`)
+    metricAnalysisDays: 90
+    # The min percent of users exposed to multiple variations in an
+    # experiment before we start warning you (between 0 and 1, defaults to `0.01`)
+    multipleExposureMinPercent: 0.01
+    # When we should auto-update experiment results
+    updateSchedule:
+      type: stale
+      hours: 6
+```
+
+The `updateSchedule` setting has 3 types of values:
+
+- Never update automatically
+  ```yml
+  updateSchedule:
+    type: never
+  ```
+- Update if data is X hours stale
+  ```yml
+  updateSchedule:
+    type: stale
+    hours: 6
+  ```
+- Update on a fixed Cron schedule
+  ```yml
+  updateSchedule:
+    type: cron
+    cron: "0 */6 * * *"
+  ```

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/self-host/env.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/self-host/env.mdx
@@ -1,5 +1,5 @@
 ---
-title: Environment Variables
+title: Environment Variables 🚧
 description: Learn how to set environment variables for your self hosted version of GrowthBook
 id: environment-variables
 slug: env

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/self-host/env.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/self-host/env.mdx
@@ -1,0 +1,367 @@
+---
+title: Environment Variables
+description: Learn how to set environment variables for your self hosted version of GrowthBook
+id: environment-variables
+slug: env
+---
+
+# Environment Variables
+
+The default configuration in GrowthBook is optimized for trying things out quickly on a local dev machine. Beyond that, you can customize behavior with Environment Variables.
+
+## Domains and Ports
+
+This is used to generate links to GrowthBook and enable CORS access to the API.
+
+- **APP_ORIGIN** - default http://localhost:3000
+- **API_HOST** - default http://localhost:3100
+
+If you want to run GrowthBook on a different host than localhost, you need to add the above environment
+variables to your `docker-compose.yml` file.
+
+```yml
+growthbook:
+  ...
+  environment:
+    - APP_ORIGIN=http://<my ip>:3000
+    - API_HOST=http://<my ip>:3100
+```
+
+:::info Important
+In order for authentication cookies to work correctly, both the app and api domains must be considered the &quot;same
+site&quot;. They can be on different subdomains or ports, but the root domain must be the same.
+
+  <ul>
+    <li>
+      <strong>Works:</strong> <code>gb.example.com</code> and{" "}
+      <code>gb-api.example.com</code>
+    </li>
+    <li>
+      <strong>Breaks:</strong> <code>gb-example.com</code> and{" "}
+      <code>gb-api-example.com</code>
+    </li>
+  </ul>
+:::
+
+If you need to change the ports on your local dev environment (e.g. if `3000` is already being used),
+you need to update the above variables AND change the port mapping in `docker-compose.yml`:
+
+```yml
+growthbook:
+  ports:
+    - "4000:3000" # example: use 4000 instead of 3000 for the app
+    - "4100:3100" # example: use 4100 instead of 3100 for the api
+  ...
+  environment:
+    - APP_ORIGIN=http://<my ip or url>:4000
+    - API_HOST=http://<my ip or url>:4100
+```
+
+### Production Settings
+
+- **NODE_ENV** - Set to "production" to turn on additional optimizations and API request logging
+- **MONGODB_URI** - The MongoDB connection string
+- **JWT_SECRET** - Auth signing key (use a long random string)
+- **ENCRYPTION_KEY** - Data source credential encryption key (use a long random string)
+
+If you change the `ENCRYPTION_KEY`, you will need to migrate any existing data sources using the following script:
+
+```bash
+# If you didn't have an ENCRYPTION_KEY before, leave OLD_KEY blank below
+docker-compose run growthbook yarn migrate-encryption-key OLD_KEY
+```
+
+:::info Important
+When using GrowthBook in production, it is important to change the
+
+  <code>NODE_ENV</code> to to "production" and change the
+  <code>JWT_SECRET</code> to a random string. Using the <code>production</code>
+  node environment and the default <code>JWT_SECRET</code> will throw an error.
+:::
+
+## Email SMTP Settings
+
+This is required in order to send experiment alerts, team member invites, and reset password emails.
+
+- **EMAIL_ENABLED** ("true" or "false")
+- **EMAIL_HOST**
+- **EMAIL_PORT**
+- **EMAIL_HOST_USER**
+- **EMAIL_HOST_PASSWORD**
+- **EMAIL_FROM**
+
+## Google OAuth Settings
+
+Only required if using Google Analytics as a data source
+
+- **GOOGLE_OAUTH_CLIENT_ID**
+- **GOOGLE_OAUTH_CLIENT_SECRET**
+
+## File Uploads
+
+The **UPLOAD_METHOD** environment variable controls where to store uploaded files
+and screenshots. The supported values are `local`, `s3`, and `google-cloud`.
+
+### local
+
+This is the default value. Uploads are stored in the GrowthBook docker container at
+`/usr/local/src/app/packages/back-end/uploads`. In production, you should mount a volume here to persist uploads across container restarts.
+
+### s3
+
+Store uploads in an AWS S3 bucket.
+
+- **S3_BUCKET**
+- **S3_REGION** (defaults to `us-east-1`)
+- **S3_DOMAIN** (defaults to `https://${S3_BUCKET}.s3.amazonaws.com/`)
+- **AWS_ACCESS_KEY_ID** (not required when deployed to AWS with an instance role)
+- **AWS_SECRET_ACCESS_KEY** (not required when deployed to AWS with an instance role)
+
+### google-cloud
+
+Store uploads in a Google Cloud Storage bucket.
+
+- **GCS_BUCKET_NAME**
+- **GCS_DOMAIN** (defaults to `https://storage.googleapis.com/${GCS_BUCKET_NAME}/`)
+- **GOOGLE_APPLICATION_CREDENTIALS** (not required when deployed to GCP with an instance service account)
+
+## Enterprise Settings
+
+Some features in self-hosted GrowthBook are only available with a commercial license key. You can get a trial
+Enterprise key from your self-hosted version of GrowthBook, or reach out to [sales@growthbook.io](mailto:sales@growthbook.io) to learn more.
+
+### License Keys
+
+If you have a license key, you can activate it in GrowthBook two different ways:
+
+1. Navigate to **Settings** > **General** and look for the License section of the page. There you can input or edit your license key string. (Recommended)
+2. Alternately, set the environment variable `LICENSE_KEY` to your license key string. If using Docker, go to _docker-compose.yml_ and add the variable to the _growthbook_ > _environment_ section.
+
+### Enterprise SSO
+
+To enable SSO on your self hosted GrowthBook instance, you will need an active license key (see above section), and then you may add
+the SSO settings for your provider. If your provider is not listed below, you can use the generic Open ID Connect below. The JSON
+object with the settings will need to be JSON encoded and then set to the environment variable `SSO_CONFIG`.
+
+#### Generic Open ID Connect
+
+- **LICENSE_KEY** - Your signed license key provided by the GrowthBook team
+- **SSO_CONFIG** - A JSON-encoded string that configures SSO (using OpenID Connect). It should be an object with the following keys:
+  - `clientId` (string)
+  - `clientSecret` (string)
+  - `emailDomain` (string, optional) - Allow auto-joining from a specified email domain
+  - `metadata` (object)
+    - `issuer` (string)
+    - `authorization_endpoint` (string)
+    - `jwks_uri` (string)
+    - `id_token_signing_alg_values_supported` (array of strings)
+    - `token_endpoint` (string)
+    - `code_challenge_methods_supported` (array of strings)
+    - `logout_endpoint` (string, optional)
+  - `extraQueryParams` (object, optional) - Dictionary of extra query params to be passed along with the `/authorize` OAuth call
+  - `additionalScope` (string, optional) - Additional scopes to include, along with the default value: `openid profile email`
+
+For SSO, make sure the following callback URL is whitelisted:
+
+- `{APP_ORIGIN}/oauth/callback`
+
+For the best SSO user experience, enable offline access and refresh tokens in your Identity Provder.
+
+:::info Note
+
+With all the SSO providers listed below, replace the all caps values with values from the provider, JSON encode the object, and set to the `SSO_CONFIG` environment variable for GrowthBook.
+
+:::
+
+#### Okta
+
+```json
+{
+    "clientId": "CLIENT_ID",
+    "clientSecret": "CLIENT_SECRET",
+    "emailDomain": "EMAIL_DOMAIN",
+    "additionalScope": "offline_access",
+    "metadata": {
+        "issuer": "BASE_URL",
+        "authorization_endpoint": "BASE_URL/oauth2/v1/authorize",
+        "id_token_signing_alg_values_supported": [
+            "RS256"
+        ],
+        "jwks_uri": "BASE_URL/oauth2/v1/keys",
+        "token_endpoint": "BASE_URL/oauth2/v1/token",
+        "code_challenge_methods_supported": [
+            "S256"
+        ]
+    }
+}
+```
+
+<details>
+    <summary>See complete Okta instructions</summary>
+    <div>
+    <ol>
+    <li>
+<strong>Create an OIDC Web application:</strong>
+<img src="/images/guides/SSO-Okta-1.png" />
+</li>
+
+<li>
+<strong>Allow refresh tokens and specify callback URLs. If you are using the cloud, you can use the following values:</strong>
+<ul>
+    <li><strong>Sign-in redirect URIs</strong> - <code>https://app.growthbook.io/oauth/callback</code></li>
+    <li><strong>Sign-out redirect URIs</strong> (optional) - <code>https://app.growthbook.io</code></li>
+</ul>
+<p>If you are self-hosting, replace with <code>https://app.growthbook.io</code> with the value from your <code>API_HOST</code></p>
+<img src="/images/guides/SSO-Okta-2.png" />
+</li>
+
+<li>
+<strong>Require PKCE as additional verification</strong>(optional)<br/>
+<img src="/images/guides/SSO-Okta-3.png" /><br/>
+<div>
+You will need the following in order to configure SSO in GrowthBook:
+<ul>
+<li><code>CLIENT_ID</code></li>
+<li><code>CLIENT_SECRET</code></li>
+<li><code>BASE_URL</code></li>
+<li><code>EMAIL_DOMAIN</code></li>
+</ul>
+<p>
+If using GrowthBook Cloud, first sign up for an account at <a href="https://app.growthbook.io" target="_blank">https://app.growthbook.io</a>, then send us the above and we will enable SSO on your account.
+</p>
+<p>
+If self-hosting, add the environment settings at the beginning of this section to enable SSO on your instance.
+</p>
+</div>
+</li>
+</ol>
+</div>
+</details>
+
+#### Google
+
+```json
+{
+    "clientId": "CLIENT_ID",
+    "clientSecret": "CLIENT_SECRET",
+    "emailDomain": "EMAIL_DOMAIN",
+    "metadata": {
+        "issuer": "https://accounts.google.com",
+        "authorization_endpoint": "https://accounts.google.com/o/oauth2/v2/auth",
+        "token_endpoint": "https://oauth2.googleapis.com/token",
+        "jwks_uri": "https://www.googleapis.com/oauth2/v3/certs",
+        "id_token_signing_alg_values_supported": [
+            "RS256"
+        ],
+        "code_challenge_methods_supported": [
+            "S256"
+        ]
+    },
+    "extraQueryParams": {
+        "access_type": "offline",
+        "prompt": "consent"
+    }
+}
+```
+
+#### Auth0
+
+```json
+{
+    "clientId": "CLIENT_ID",
+    "clientSecret": "CLIENT_SECRET",
+    "emailDomain": "EMAIL_DOMAIN",
+    "additionalScope": "offline_access",
+    "metadata": {
+        "issuer": "https://TENANT.auth0.com/",
+        "authorization_endpoint": "https://TENANT.auth0.com/authorize",
+        "logout_endpoint": "https://TENANT.auth0.com/v2/logout?client_id=CLIENT_ID",
+        "id_token_signing_alg_values_supported": [
+            "HS256",
+            "RS256"
+        ],
+        "jwks_uri": "https://TENANT.auth0.com/.well-known/jwks.json",
+        "token_endpoint": "https://TENANT.auth0.com/oauth/token",
+        "code_challenge_methods_supported": [
+            "S256",
+            "plain"
+        ],
+        "audience": "AUDIENCE"
+    }
+}
+```
+
+:::note
+When setting up Auth0, please ensure that you've enabled offline access, and check the `OIDC Compliant` checkbox.
+:::
+
+#### Azure AD
+
+```json
+{
+  "clientId": "CLIENT_ID",
+  "clientSecret": "CLIENT_SECRET",
+  "emailDomain": "EMAIL_DOMAIN",
+  "additionalScope": "offline_access",
+  "metadata": {
+    "token_endpoint": "https://login.microsoftonline.com/TENANT_ID/oauth2/v2.0/token",
+    "jwks_uri": "https://login.microsoftonline.com/TENANT_ID/discovery/v2.0/keys",
+    "id_token_signing_alg_values_supported": ["RS256"],
+    "code_challenge_methods_supported": ["S256"],
+    "issuer": "https://login.microsoftonline.com/TENANT_ID/v2.0",
+    "authorization_endpoint": "https://login.microsoftonline.com/TENANT_ID/oauth2/v2.0/authorize",
+    "logout_endpoint": "https://login.microsoftonline.com/TENANT_ID/oauth2/v2.0/logout",
+  }
+}
+```
+
+:::note
+
+In Azure, register an Application, instead of Enterprise, as we use OpenID Connect, not SAML.
+
+:::
+
+<details>
+    <summary>See complete Azure instructions</summary>
+    <div>
+    <ol>
+    <li>
+Register an Application (we use OpenID Connect, so choose regular app, not Enterprise)
+<img src="/images/guides/SSO-Azure-1.png" />
+</li>
+
+<li>
+Enter the redirect URL as APP_HOST/oauth/callback
+<img src="/images/guides/SSO-Azure-2.png" />
+</li>
+
+<li>
+Take note of your Application Id (CLIENT_ID) and Directory Id (TENANT_ID). You will need it later
+<img src="/images/guides/SSO-Azure-3.png" />
+</li>
+<li>
+Generate a new Client Secret<br/>
+<img src="/images/guides/SSO-Azure-4.png" />
+</li>
+<li>
+Take note of the Secret Value (CLIENT_SECRET). You will need it in the next step
+</li>
+<li>
+Construct the JSON configuration for GrowthBook. Replace CLIENT_ID, CLIENT_SECRET, EMAIL_DOMAIN, and TENANT_ID, as into the JSON object above.
+</li>
+<li>
+Pass the JSON string into the environment variable SSO_CONFIG of your GrowthBook container
+</li>
+</ol>
+    </div>
+</details>
+
+## Other Settings
+
+- **EXPERIMENT_REFRESH_FREQUENCY** - Default update schedule for experiment results. Update when stale for X hours (default `6`).
+- **QUERY_CACHE_TTL_MINS** - How long (in minutes) to cache and re-use SQL query results (default `60`)
+- **DEFAULT_CONVERSION_WINDOW_HOURS** - How many hours after being put into an experiment does a user have to convert. Can be overridden on a per-metric basis. (default `72`)
+- **DISABLE_TELEMETRY** - We collect anonymous telemetry data to help us improve GrowthBook. Set to "true" to disable.
+- **STORE_SEGMENTS_IN_MONGO** - If using the config.yml file, set to `true` if you want to store segments in Mongo. This is also useful if you have existing segments stored in Mongo that you need to access. When set, GrowthBook will ignore segments in the config.yml file and only use Segments stored in Mongo.
+- **CDN_HOST** - When set, this will update the implementation instructions within GrowthBook to override the `API_HOST` in cases where a CDN is used.
+- **EXPRESS_TRUST_PROXY_OPTS** - Express' [trust proxy](https://expressjs.com/en/5x/api.html#trust.proxy.options.table) setting value. Supports boolean (true/false), string values, and integer values for trusting the _n_<sup>th</sup> hop from the front-facing proxy server as the client. Leavy empty or specify `false` to use Express' default behavior. If you are running GrowthBook behind a proxy or load balancer, this is required to track the correct user IP for audit log events.

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/self-host/index.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/self-host/index.mdx
@@ -1,24 +1,24 @@
 ---
-title: Self-Hosting GrowthBook
-description: Learn how to set a self-hosted version of GrowthBook
+title: GrowthBook em Hospedagem Própria
+description: Aprenda como configurar o GrowthBook em sua infraestrutura própria
 id: index
 slug: /self-host
 ---
 
-# Self Hosting GrowthBook
+# GrowthBook em Hospedagem Própria
 
-GrowthBook consists of a NextJS front-end, an ExpressJS API, and a Python stats engine. Everything is bundled together in a single [Docker Image](https://hub.docker.com/r/growthbook/growthbook).
+O GrowthBook é composto por um front-end em NextJS, uma API ExpressJS e um motor de análise em Python. Tudo está junto em uma única [Imagem Docker](https://hub.docker.com/r/growthbook/growthbook).
 
-In addition to the app itself, you will also need a MongoDB instance to store login credentials, cached experiment results, and metadata.
+Além do próprio app, você vai precisar configurar uma instância do MongoDB para guardar credenciais de acesso, cache de resultados de experimentos e metadados.
 
 :::tip
-Don't want to install or host the app yourself? <a href="https://app.growthbook.io">GrowthBook Cloud</a> is a fully managed
-version that's free to get started.
+Não quer instalar ou hospedar o app por conta própria? <a href="https://app.growthbook.io">GrowthBook Cloud</a> é uma versão 
+completamente gerenciada em que você pode começar de forma gratuita.
 :::
 
-## Installation
+## Instalação
 
-You can use **docker-compose** to get started quickly:
+Você pode usar o **docker-compose** para começar:
 
 ```yml
 # docker-compose.yml
@@ -44,19 +44,19 @@ volumes:
   uploads:
 ```
 
-Then, just run `docker-compose up -d` to start everything and view the app at [http://localhost:3000](http://localhost:3000)
+Depois é só executar o comando `docker-compose up -d` para inicializar e abrir o app em [http://localhost:3000](http://localhost:3000)
 
-## Docker Tags
+## Tags Docker
 
-Builds are published automatically from the [GitHub repo](https://github.com/growthbook/growthbook) main branch. The most recent commit is tagged with `latest`.
+As versões são publicadas automaticamente a partir da branch main do [repositório GitHub](https://github.com/growthbook/growthbook). Os commits mais recentes possuem a tag `latest`.
 
-GitHub Releases are also tagged using SemVer (e.g. `0.2.1`).
+O Versionamento no Github também utiliza o formato SemVer (ex. `0.2.1`).
 
-If you need to reference the image for a specific git commit for any reason, you can use the git shorthash tag (e.g. `git-41278e9`).
+Se você precisar de uma imagem de referência de algum commit por algum motivo, você pode usar a tag do hash encurtado do git (ex. `git-41278e9`).
 
-## Updating to Latest
+## Atualizando para a última versão
 
-If you are using docker-compose, and assuming you specify the growthbook container with `:latest`, you can update with:
+Se você está usando docker-compose e assumindo que você especificou a tag `:latest` no seu container do GrowthBook, você pode atualizar utilizando os seguintes comandos:
 
 ```bash
 docker-compose pull growthbook

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/self-host/index.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/self-host/index.mdx
@@ -1,0 +1,65 @@
+---
+title: Self-Hosting GrowthBook
+description: Learn how to set a self-hosted version of GrowthBook
+id: index
+slug: /self-host
+---
+
+# Self Hosting GrowthBook
+
+GrowthBook consists of a NextJS front-end, an ExpressJS API, and a Python stats engine. Everything is bundled together in a single [Docker Image](https://hub.docker.com/r/growthbook/growthbook).
+
+In addition to the app itself, you will also need a MongoDB instance to store login credentials, cached experiment results, and metadata.
+
+:::tip
+Don't want to install or host the app yourself? <a href="https://app.growthbook.io">GrowthBook Cloud</a> is a fully managed
+version that's free to get started.
+:::
+
+## Installation
+
+You can use **docker-compose** to get started quickly:
+
+```yml
+# docker-compose.yml
+version: "3"
+services:
+  mongo:
+    image: "mongo:latest"
+    environment:
+      - MONGO_INITDB_ROOT_USERNAME=root
+      - MONGO_INITDB_ROOT_PASSWORD=password
+  growthbook:
+    image: "growthbook/growthbook:latest"
+    ports:
+      - "3000:3000"
+      - "3100:3100"
+    depends_on:
+      - mongo
+    environment:
+      - MONGODB_URI=mongodb://root:password@mongo:27017/
+    volumes:
+      - uploads:/usr/local/src/app/packages/back-end/uploads
+volumes:
+  uploads:
+```
+
+Then, just run `docker-compose up -d` to start everything and view the app at [http://localhost:3000](http://localhost:3000)
+
+## Docker Tags
+
+Builds are published automatically from the [GitHub repo](https://github.com/growthbook/growthbook) main branch. The most recent commit is tagged with `latest`.
+
+GitHub Releases are also tagged using SemVer (e.g. `0.2.1`).
+
+If you need to reference the image for a specific git commit for any reason, you can use the git shorthash tag (e.g. `git-41278e9`).
+
+## Updating to Latest
+
+If you are using docker-compose, and assuming you specify the growthbook container with `:latest`, you can update with:
+
+```bash
+docker-compose pull growthbook
+docker-compose stop growthbook
+docker-compose up -d growthbook
+```

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/self-host/proxy.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/self-host/proxy.mdx
@@ -1,5 +1,5 @@
 ---
-title: GrowthBook Proxy
+title: GrowthBook Proxy 🚧
 description: Turbocharge your GrowthBook deployment with the GrowthBook Proxy server
 sidebar_label: GrowthBook Proxy
 slug: proxy

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/self-host/proxy.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/self-host/proxy.mdx
@@ -1,0 +1,111 @@
+---
+title: GrowthBook Proxy
+description: Turbocharge your GrowthBook deployment with the GrowthBook Proxy server
+sidebar_label: GrowthBook Proxy
+slug: proxy
+---
+
+# GrowthBook Proxy
+
+The GrowthBook Proxy server sits between your application and GrowthBook. It turbocharges your GrowthBook implementation by providing **speed**, **scalability**, **security**, and **real-time** feature rollouts.
+
+## Features
+
+- **Caching** - Significantly faster feature lookups!
+  - In-memory cache plus an optional distributed layer (Redis or MongoDB)
+  - Automatic cache invalidation when features change in GrowthBook (using WebHooks)
+- **Streaming** - Updates your application in real-time as features are changed or toggled in GrowthBook (Javascript and React only)
+- **Security** - Private-key authentication between GrowthBook and GrowthBook Proxy
+- **Scalability** - Horizontally scale to support millions of concurrent users
+
+## Installation
+
+### Using docker-compose
+
+If you are already using `docker-compose` to run GrowthBook, we have a pre-configured setup that includes a GrowthBook Proxy instance.
+
+Just run
+
+```bash
+docker-compose -f docker-compose.proxy.yml up -d
+```
+
+This will start the proxy server on port 3300. Check out the health check endpoint to ensure it's working correctly - http://localhost:3300/healthcheck
+
+### Standalone
+
+You can also run the GrowthBook Proxy as a standalone Docker container.
+
+First, pull the latest image
+
+```bash
+docker pull growthbook/proxy:latest
+```
+
+Then, run a GrowthBook Proxy instance on port 3300
+
+```bash
+docker run -d -p 3300:3300 \
+  -e "GROWTHBOOK_API_HOST=https://growthbook-api.example.com" \
+  -e "SECRET_API_KEY=something_secret" \
+  --name gbproxy growthbook/proxy
+```
+
+Check http://localhost:3300/healthcheck to ensure it's running correctly.
+
+Lastly, on your main GrowthBook instance, add environment variables to enable the proxy:
+
+```yml
+PROXY_ENABLED=1
+# The public URL of your proxy server
+PROXY_HOST_PUBLIC=https://growthbook-proxy.example.com
+# Must match the SECRET_API_KEY used above
+# You can either define the secret key here or create one in the GrowthBook UI
+SECRET_API_KEY=something_secret
+```
+
+## Using with the SDKs
+
+The GrowthBook Proxy has the same public feature endpoints as GrowthBook, so all you need to do is change the API host your SDK clients connect to:
+
+```ts
+// Before
+const gb = new GrowthBook({
+  apiHost: "https://growthbook-api.example.com",
+  clientKey: "sdk-abc123"
+});
+
+// After (clientKey remains the same)
+const gb = new GrowthBook({
+  apiHost: "https://growthbook-proxy.example.com",
+  clientKey: "sdk-abc123"
+});
+```
+
+## Configuration
+
+The GrowthBook Proxy supports a number of configuration options available via environment variables:
+
+- `GROWTHBOOK_API_HOST` - Set this to the host and port of your GrowthBook API instance
+- `SECRET_API_KEY` - Create a secret API key in GrowthBook by going to **Settings -> API Keys**
+- `NODE_ENV` - Set to "production" to hide debug and informational log messages
+- `CACHE_ENGINE` - One of - `memory`, `redis`, or `mongo`
+- `CACHE_CONNECTION_URL` - The URL of your redis or mongo cluster (if using)
+- `CACHE_STALE_TTL` - Number of seconds until a cache entry is considered stale
+- `CACHE_EXPIRES_TTL` - Number of seconds until a cache entry is expired
+
+You can also configure the GrowthBook Proxy to handle SSL termination. It supports HTTP/2 by default, which is required for high performance streaming.
+
+- `USE_HTTP2` - Set to "true" or "1" to enable
+- `HTTPS_CERT` - The SSL certificate
+- `HTTPS_KEY` - The SSL key
+
+## Best Practices
+
+In high-traffic production scenarios, there are a few best practices to follow
+
+- Auto-scale GrowthBook Proxy instances based on number of active connections or memory
+- Run the instances in the same region as your application servers for the lowest latency
+- Add a load balancer in-front that supports HTTP/2 and streaming responses (AWS ALB, HAProxy, etc.)
+- Use Redis (or MongoDB) as the cache engine for more consistent feature releases
+- Use the `/healthcheck` endpoint to determine if the instances are running correctly

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/statistics/aggregation.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/statistics/aggregation.mdx
@@ -1,0 +1,41 @@
+---
+title: Aggregate Data 
+description: Aggregate Data
+sidebar_label: Aggregate Data
+slug: aggregation
+---
+
+# Aggregate Data and the Statistics Engine
+
+GrowthBook never collects user-level events or PII. To power our statistics engine, contained within the `gbstats` Python library, GrowthBook works solely with aggregate level data that is sufficient to conduct analyses of interest.
+
+## Working with sums
+
+Specifically, GrowthBook mostly relies on queries that run on your data warehouse and return data aggregated across users. We aggregate data at the level of the experiment variation (or dimension-variation, if you have dimensions specified).
+We rely on sums, sums of squares, and sums of cross products to power our statistics engine. These simple quantities allow us to easily re-aggregate over different dimensions while still containing sufficient information to compute experiment statistics.
+
+Note that these are the aggregations at the experiment variation level---they are computed across users. These often follow an aggregation at the user level, which defaults to SUM for non-binomial metrics, or a 1 for binomial metrics. You may have overriden the user-level aggregation in your metric definition with some other function. However, when we then go to aggregate at the variation level, we sum across those user-level aggregations.
+
+### Aggregate fields
+
+You can view the aggregate data we use for any metric in your experiment by selecting the three dots in the top right of the experiment table and clicking "View Queries". There, you can see the actual queries we build and the aggregate results they contain. The following image is an example of those aggregate values.
+
+![View Query - SQL and aggregate statistics](/images/view-query-aggregate.png)
+
+The potential fields the queries will return are as follows, with all sums aggregating at the variation-dimension level:
+
+- `variation` - the name of the experiment variation
+- `dimension` - the name of the dimension we aggregate to; defaults to "All" if there is no dimensional analysis specified
+- `users` - the number of users in the variation-dimension that are part of the denominator for that metric; normally this is all users in the variation-dimension, but for ratio metrics or activation metrics it will only include users that are in the ratio denomitor or in the set of activated users.
+- `count` - deprecated; duplicate of users
+- `statistic_type` - one of "mean" or "ratio"; this indicates to the statistics engine how to process the data as the formulae for the variance is different across these statistic types
+- `main_metric_type` - the metric type of the main metric (e.g. the metric itself or the numerator for ratio metrics)
+- `main_sum` - the summed value of the user-level main metric
+- `main_sum_squares` - the sum of the squared values of the user-level main metric
+
+If the metric is a ratio metric, you will additionally see the following fields:
+
+- `denominator_metric_type` - the metric type of the denominator metric
+- `denominator_sum` - the summed value of the user-level denominator metric
+- `denominator_sum_squares` - the sum of the squared values of the user-level denominator metric
+- `main_denominator_sum_product` - the sum of the product of the user-level main and denominator metric

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/statistics/aggregation.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/statistics/aggregation.mdx
@@ -1,5 +1,5 @@
 ---
-title: Aggregate Data 
+title: Aggregate Data 🚧
 description: Aggregate Data
 sidebar_label: Aggregate Data
 slug: aggregation

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/statistics/cuped.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/statistics/cuped.mdx
@@ -1,0 +1,135 @@
+---
+title: Regression Adjustment (CUPED)
+description: Regression Adjustment (CUPED)
+sidebar_label: Regression Adjustment (CUPED)
+slug: cuped
+---
+
+# Regression Adjustment (CUPED)
+
+:::note
+
+Regression Adjustment (CUPED) is only implemented for the Frequentist statistics engine, and is a premium feature.
+
+:::
+
+GrowthBook aims to unlock high-velocity, enterprise-scale experimentation. Regression adjustment (also known as CUPED, short for Controlled-experiment Using Pre-Experiment Data) is one way to increase the velocity of experimentation by reducing the uncertainty in estimates of experiment uplift.
+
+### Why use CUPED?
+
+CUPED decreases the variance of experiment uplift, increasing the accuracy of your experimental results and therefore the speed at which you can see the effects of an experiment. In the right conditions, CUPED can equate to getting 20% or more traffic during your experiment!
+
+- In 2016, Netflix reported that CUPED reduced variance by rougly ~40% for some key engagment metrics ([source](https://www.kdd.org/kdd2016/papers/files/adp0945-xieA.pdf)).
+- In 2022, Microsoft reported that, for one product team, CUPED was akin to adding 20% more traffic to analysis of a majority of metrics ([source](https://www.microsoft.com/en-us/research/group/experimentation-platform-exp/articles/deep-dive-into-variance-reduction/)).
+
+### How does it work?
+
+Regression adjustment (RA) in general uses data correlated with a metric to reduce our uncertainty about that metric and the statistics we compute. Any data correlated with the metric of interest, but uncorrelated with variation assignment can be used. GrowthBook (and many others) use pre-experiment data, as metrics collected before an experiment will not be affected by said experiment. In fact, the very name CUPED embeds this concept of using pre-experiment data. Using this pre-experiment data, we can fit a simple model to predict our outcome metric and use those predictions to adjust our metric. The adjusted metric then tends to have lower variance.
+
+The more correlated the pre-experiment data is with your metric of interest, the more variance reduction you can achieve. For example, the following plot demonstrates the difference in the distribution of a metric before adjustment ("Normal") and after adjustment ("Adjusted"). In both panels, the green, adjusted metric is distributed less widely (e.g. it is more tightly spaced out around the mean). However, the adjusted distribution is even tighter in the right plot, showing that variance reduction will be greater the more correlated your pre-experiment data is with your post-experiment data.
+
+<img
+  src="/images/statistics/cuped-corr.png"
+  alt="Variance Reduction by Correlation"
+  style={{ width: 600, margin: "0 auto" }}
+/>
+
+In simpler terms, if we know a particular user tends to buy a lot of products on your website before you launch an experiment, we can use that information to understand whether purchase behavior after an experiment is driven by that customer's innate tendency to buy a lot of products or whether it was due to the experiment.
+
+The concept of regression adjustment has been around for a long time, but you should feel free to read more in the original CUPED paper ([Deng et al. 2013](https://exp-platform.com/Documents/2013-02-CUPED-ImprovingSensitivityOfControlledExperiments.pdf)), a more general purpose paper on the underpinnings of regression adjustment from a sampling perspective ([Lin 2013](https://projecteuclid.org/journals/annals-of-applied-statistics/volume-7/issue-1/Agnostic-notes-on-regression-adjustments-to-experimental-data--Reexamining/10.1214/12-AOAS583.full)), and any of the many blog posts on the topic (e.g. [Booking.com](https://booking.ai/how-booking-com-increases-the-power-of-online-experiments-with-cuped-995d186fff1d), [Microsoft](https://www.microsoft.com/en-us/research/group/experimentation-platform-exp/articles/deep-dive-into-variance-reduction/)).
+
+## GrowthBook's implementation
+
+GrowthBook takes a transparent, simple approach to CUPED.
+
+For each metric you analyze, we use the metric itself from the pre-exposure period as the correlated data. This tends to be very powerful for metrics that are frequently produced by users (e.g. engagement measures), but can be less powerful if your metric is rare, or if you are measuring behavior for new users. In general, CUPED is more powerful the more you know about your units of interest and the longer they have been able to generate the metric that you are analyzing as a part of your experiment.
+
+We then use the standard CUPED estimator for each variation mean,
+
+$$
+\bar{Y}_{adjusted} = \bar{Y}_{post} - \theta * \bar{Y}_{pre}
+$$
+
+where $\bar{Y}_{post}$ is the post-exposure metric average, $\bar{Y}_{pre}$ is the pre-exposure metric average, and $\theta$ is essentially a regression coefficient from a regression of the post-experiment data on the pre-experiment data (pooled across both the control and treatment variation of interest), $\theta = \text{Cov}(Y_{pre}, Y_{post}) / \text{Var}(Y_{pre})$.
+
+As discussed above, we could use any correlated data instead of $Y_{pre}$. For example, we could use some model that includes all pre-exposure metrics added to your experiment, or auxiliary dimension information you have configured per user. However, one downside of these approaches is that your results for metric A will depend on whether or not you add a metric B to your experiment and our analysis pipeline would lose its modularity, where each metric can be processed in parallel. Nonetheless, we anticipate continuing to build methods that leverage additional data to improve variance reduction from CUPED.
+
+### Lookback window
+
+GrowthBook defaults to using 14 days of pre-exposure data, but this is customizable at the organization, metric, and metric-experiment level.
+
+Why use a longer lookback window?
+
+- A longer window can be better if your metric is low frequency and a longer window is needed to capture meaningful user behavior that will be correlated across the pre- and post-exposure time periods
+
+Why use a shorter lookback window?
+
+- Shorter lookback windows will yield more performant queries (fewer days to scan from your metric source)
+- Behavior in the days just before a user enters an experiment is likely to be more highly correlated with behavior during an experiment, as users change over time. Of course, this is mostly true for metrics that are observed at a higher frequency (e.g. simple engagement metrics).
+
+### Availability
+
+CUPED works for all metrics that are analyzed using the Frequentist engine, except for:
+
+- Ratio metrics where the denominator is a count metric
+- Metrics with custom user value aggregations
+- Metrics from MixPanel and Google Analytics data sources
+
+## Configuring CUPED
+
+### Organization-level settings
+
+You can turn CUPED on for all Frequentist analyses under Settings -> General. On that page, you can set the default behavior for metrics analyzed with the Frequentist engine. CUPED can be turned on or off by default for all analyses and you can set the default number of days to use for a lookback window. This setting will set the default for all of your metrics, which will then flow through to all analyses that use those metrics.
+
+<img
+  src="/images/statistics/cuped-org.png"
+  alt="Organization-level CUPED Setting"
+  style={{ width: 800, margin: "0 auto" }}
+/>
+
+### Metric-level settings
+
+You can also override these organization-level defaults at the Metric level. When creating or editing a Metric, go to the "Behavior" panel, click "Show advanced options" and scroll to the bottom. From there, you will see the following settings. These settings will allow you to disable CUPED for a metric, even if it is set at the organization or experiment level.
+
+<img
+  src="/images/statistics/cuped-metric.png"
+  alt="Metric-level CUPED Setting"
+  style={{ width: 700, margin: "0 auto" }}
+/>
+
+You might want to disable CUPED for a particular metric if that metric never collects values for a user before they enter an experiment. You might want to adjust metric-specific lookback windows for any of the reasons listed in the section above.
+
+Finally, you could also, if you wanted, override these metric-level settings for a particular experiment using metric overrides on the experiment page.
+
+### Experiment settings and results
+
+By default, each experiment analyzed using the Frequentist engine will use your organization-level defaults, unless they are overriden by a metric. However, you can always toggle CUPED on or off for a Frequentist analysis using the new toggle added to the top of the results table. You may need to re-run your analysis if you change this setting.
+
+- If the toggle is Off, then CUPED will not be applied to any metrics.
+- If the toggle is On, then it will be applied for all metrics that:
+  - (a) it can be applied to
+  - (b) do not have a metric setting or metric override turning it off
+
+The following screenshot shows the results with CUPED on. However, you can see that there is an icon showing that CUPED is disabled for Average Order Value (because it is a ratio metric). So even if CUPED is toggled on, we will always show you any metrics for which GrowthBook did not use CUPED using that small CUPED icon with a red x.
+
+<img
+  src="/images/statistics/cuped-results.png"
+  alt="Experiment Results with CUPED toggle"
+  style={{ width: 800, margin: "0 auto" }}
+/>
+
+Furthermore, if you mouse over the icon showing CUPED wasn't applied, you will get an explanation why.
+
+<img
+  src="/images/statistics/cuped-icon.png"
+  alt="Metric Icon showing CUPED Disabled Reason"
+  style={{ width: 300, margin: "0 auto" }}
+/>
+
+If you mouse over the metric name itself, you get the final CUPED status for each metric (on/off, number of lookback days).
+
+<img
+  src="/images/statistics/cuped-tooltip.png"
+  alt="Metric Tooltip with CUPED status"
+  style={{ width: 300, margin: "0 auto" }}
+/>

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/statistics/cuped.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/statistics/cuped.mdx
@@ -1,5 +1,5 @@
 ---
-title: Regression Adjustment (CUPED)
+title: Regression Adjustment (CUPED) 🚧
 description: Regression Adjustment (CUPED)
 sidebar_label: Regression Adjustment (CUPED)
 slug: cuped

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/statistics/overview.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/statistics/overview.mdx
@@ -1,0 +1,123 @@
+---
+title: GrowthBook Statistics
+description: GrowthBook Statistics
+sidebar_label: Statistics Overview
+slug: overview
+---
+
+# GrowthBook's Statistics
+
+This page is a summary verison of the statistical methods used by GrowthBook. GrowthBook primarily relies
+on Bayesian statistics to power experimental analysis, but also provides an option to perform frequentist tests.
+If you want to read more detail on the Bayesian approach, see our [white paper](/GrowthBookStatsEngine.pdf).
+
+## Bayesian Statistics
+
+Bayesian methods offer some distinct advantages over the frequentist approach. In order for
+frequentist methods to be valid, you must decide on
+the sample size in advance before running an experiment---a fixed horizon.
+Under the frequentist framework, if you peek at experimental results and make a decision
+before it has finished running, or even decide to run an experiment for longer, your false positive
+rates will no longer be controlled at the level you expect. This issue--commonly referred to as "peeking"---
+will inflate your false positive rates (Type I errors) and decision making is likely to suffer.
+In addition to being prone to the peeking problem, frequentist methods also provide p-values
+and confidence intervals, both of which can be difficult to interpret and explain to others.
+
+Bayesian methods help with both of these issues. There are no fixed horizons, and peeking problems are
+less of a concern, although not completely resolved. You can generally stop an experiment whenever you want
+without a huge increase in Type I errors. In addition, the results are very easy to explain and interpret. Everything
+has some probability of being true and you adjust the probabilities as you gather data
+and learn more about the world. This matches up with how most people think about
+experiments - _"there’s a 95% chance this new button is better and a 5% chance it’s
+worse."_
+
+### Priors and Posteriors
+
+At GrowthBook, we use an Uninformative Prior. This simply means that before an
+experiment runs, we assume both variations have an equal chance of
+being higher/lower than the other one. As the experiment runs and you gather data, the
+Prior is updated to create a Posterior distribution. For Binomial metrics (simple yes/no conversion events) we
+use a Beta-Binomial Prior. For count, duration, and revenue metrics, we use a Gaussian
+(or Normal) Prior.
+
+### Inferential Statistics
+
+GrowthBook uses fast estimation techniques to quickly generate inferential statistics at scale for every metric in an experiment -
+Chance to Beat Control, Relative Uplift, and Risk (or expected loss).
+
+**Chance to Beat Control** is straight forward. It is simply the probability that a variation is better.
+You typically want to wait until this reaches 95% (or 5% if it's worse).
+
+**Relative Uplift** is similar to a frequentist Confidence Interval. Instead of showing a fixed 95% interval, we show the full
+probability distribution using a violin plot:
+
+![Violin plot of a metrics change](/images/violin-plot.png)
+
+We have found this tends to lead to more accurate interpretations. For example, instead of
+just reading the above as _"it’s 17% better"_, people tend to factor in the error bars (_"it’s
+about 17% better, but there’s a lot of uncertainty still"_).
+
+**Risk** (or expected loss) can be interpreted as _“If I stop the test now and choose X and it’s actually worse, how
+much am I expected to lose?”_. This is shown as a relative percent change - so if your baseline metric value is $5/user,
+a 10% risk equates to losing $0.50. You can specify your risk tolerance thresholds on a per-metric basis within GrowthBook.
+
+GrowthBook gives the human decision maker everything they need to weigh the results against
+external factors to determine when to stop an experiment and which variation to declare the winner.
+
+## Frequentist Statistics
+
+While frequentist statistics have the aforementioned issues, they also are familiar to many practitioners and have
+certain advantages. Their widespread adoption has spurred important developments in variance reduction, heterogeneous treatment
+effect detection, and indeed corrections to peeking issues (e.g. sequential testing) that make frequentist statistics
+less problematic and, at times, more valuable.
+
+GrowthBook has begun also investing in developing a frequentist statistics engine, and users can now select which approach
+fits their use case best under their organization settings. The current frequentist engine computes two-sample t-tests for
+relative percent change and has variance reduction (via [CUPED](/statistics/cuped)) enabled. Future extensions to implement sequential testing, one-sided tests
+for guardrails, and more are possible.
+
+Because our default results and confidence intervals display relative percent change, we use a delta
+method corrected variance for our p-values and confidence intervals that correctly incorporates uncertainty from the control variation mean.
+
+## Data Quality Checks
+
+In addition, GrowthBook performs automatic data quality
+checks to ensure the statistical inferences are valid and ready for interpretation.
+We currently run a number of checks and plan to add even more in the future.
+
+1.  **Sample Ratio Mismatch** (SRM) detects when the traffic split doesn't match what you are expecting (e.g. a 48/52 split when you expect it to be 50/50)
+2.  **Multiple Exposures** which alerts you if too many users were exposed to multiple variations of a single experiment (e.g. someone saw both A and B)
+3.  **Guardrail Metrics** help ensure an experiment isn't inadvertently hurting core metrics like error rate or page load time
+4.  **Minimum Data Thresholds** so you aren't drawing conclusions too early (e.g. when it's 5 vs 2 conversions)
+5.  **Variation Id Mismatch** which can detect missing or improperly-tagged rows in your data warehouse
+6.  **Suspicious Uplift Detection** which alerts you when a metric changes by too much in a single experiment, indicating a likely bug
+
+Many of these checks are customizeable at a per-metric level.
+So you can, for example, have stricter quality checks for revenue than you have for less important metrics.
+
+## Dimensional Analysis
+
+There is often a desire to drill down into results to see how segments or dimensions
+of your users were affected by an A/B test variation. This is especially useful for finding bugs
+(e.g. if Safari is down, but the other browsers are up) and for identifying ideas for follow-up experiments (e.g.
+"European countries seem to be responding really well to this test, let's try a dedicated variation for them").
+
+However, too much slicing and dicing of data can lead to
+what is known as the Multiple Testing Problem. If you look at the data in enough ways, one of them
+will look significant just by random chance.
+
+GrowthBook does not run any statistical corrections (e.g. Bonferroni). Instead, we change how much we show depending on the cardinality of the dimension. For example, if your dimension has only a few distinct values (e.g. "free" or "paid") we show the full statistical analysis since the impact to the false positive rate is low. However, if your dimension has many distinct values (e.g. `country`) we only show the raw conversion numbers without any statistical inferences at all.
+
+In addition, we apply automatic grouping to very high-cardinality dimensions. In the country example, only the top 20 countries will be shown individually. The rest will be lumped together into an `(other)` category.
+
+We have found this to be a good trade-off between false positives and false negatives.
+
+## Conclusion
+
+GrowthBook utilizes a combination of Bayesian statistics, fast estimation techniques,
+and data quality checks to robustly analyze A/B tests at scale and provide intuitive
+results to decision makers. GrowthBook also provides a frequentist statistics engine
+for customers who prefer operating in that paradigm.
+The implementation is fully open source under an MIT license
+and available on GitHub. You can also read more about the statistics and equations used
+in the [white paper PDF](/GrowthBookStatsEngine.pdf).

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/statistics/overview.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/statistics/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: GrowthBook Statistics
+title: GrowthBook Statistics 🚧
 description: GrowthBook Statistics
 sidebar_label: Statistics Overview
 slug: overview

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/tools/chrome-extension.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/tools/chrome-extension.mdx
@@ -1,0 +1,14 @@
+---
+title: Chrome Extension
+description: GrowthBook's Chrome Extension
+sidebar_label: Chrome Extension
+slug: chrome-extension
+---
+
+import ExternalLink from '@site/src/components/ExternalLink'
+
+GrowthBook has a Chrome Extension that integrates with the JavaScript SDK's.
+
+QA and debug feature flags and experiments from GrowthBook's JavaScript SDK's.
+
+You can [download it from the Chrome Web Store <ExternalLink />](https://chrome.google.com/webstore/detail/growthbook-devtools/opemhndcehfgipokneipaafbglcecjia).

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/tools/chrome-extension.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/tools/chrome-extension.mdx
@@ -1,5 +1,5 @@
 ---
-title: Chrome Extension
+title: Chrome Extension 🚧
 description: GrowthBook's Chrome Extension
 sidebar_label: Chrome Extension
 slug: chrome-extension

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/tools/cli.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/tools/cli.mdx
@@ -1,5 +1,5 @@
 ---
-title: GrowthBook Command Line Interface (CLI)
+title: GrowthBook Command Line Interface (CLI) 🚧
 description: The GrowthBook command-line interface (CLI) for working with the GrowthBook A/B testing, feature flagging, and experimentation platform
 slug: cli
 toc_max_heading_level: 5

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/tools/cli.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/tools/cli.mdx
@@ -1,0 +1,82 @@
+---
+title: GrowthBook Command Line Interface (CLI)
+description: The GrowthBook command-line interface (CLI) for working with the GrowthBook A/B testing, feature flagging, and experimentation platform
+slug: cli
+toc_max_heading_level: 5
+---
+
+import ExternalLink from '@site/src/components/ExternalLink'
+
+The GrowthBook command-line interface (CLI) is a tool for working with the GrowthBook A/B testing, feature flagging, and experimentation platform.
+
+:::success New
+
+The GrowthBook CLI is a brand new tool. If you experience any issues, let us know either on [Slack](https://slack.growthbook.io/) or [create an issue](https://github.com/growthbook/growthbook-cli/issues).
+
+:::
+
+## CLI Features
+
+### Generating Types
+
+The GrowthBook CLI enables you to generate TypeScript types for working with the SDK.
+
+Run `growthbook features generate-types --help` for more info.
+
+See the [JavaScript SDK documentation &rarr; Strongly-typed feature definitions](/lib/js#strongly-typed-feature-definitions) for more information on working with typed features.
+
+### Profile management
+
+If you have multiple GrowthBook organizations or accounts, you can easily switch between profiles when running individual commands.
+
+Run `growthbook auth --help` for more info.
+
+## Usage
+
+### Installing the CLI
+
+You can install the CLI to your project with the following command:
+
+    npm install growthbook --save
+
+Or if you use `yarn` you can do:
+
+    yarn add growthbook
+
+You can also install it globally so you can use it with multiple projects and outside of projects:
+
+    npm install -g growthbook
+
+The `growthbook` executable should now be available in your project. You should now be able to run commands, e.g.:
+
+    growthbook --help
+
+### Adding your API secret
+
+Before using the GrowthBook CLI you will need to authenticate yourself. You will need to get an API key, which you can do [here <ExternalLink />](https://app.growthbook.io/settings/keys).
+
+Next, use the `growthbook auth login --apiKey XXX` command to set your token for the default profile.
+
+Run `growthbook auth login --help` for more info and options.
+
+### Generating Types
+
+You can also add it to your `package.json` file of the project that will use the types, e.g.:
+
+```json
+{
+  "scripts": {
+    "type-gen": "growthbook features generate-types --output ./types"
+  }
+}
+```
+
+It should now be available for use when you run `npm run type-gen` or `yarn type-gen`.
+
+### Detailed Command Usage
+
+See the generated [GrowthBook CLI command documentation on Github <ExternalLink />](https://github.com/growthbook/growthbook-cli#commands).
+
+### Examples
+
+- [Example implementation of a TypeScript project that uses the GrowthBook CLI <ExternalLink />](https://github.com/growthbook/examples/tree/main/vanilla-typescript)

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/tools/vscode-extension.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/tools/vscode-extension.mdx
@@ -1,0 +1,14 @@
+---
+title: Visual Studio Code Extension
+description: GrowthBook's Visual Studio Code Extension
+sidebar_label: Visual Studio Code Extension
+slug: vscode-extension
+---
+
+import ExternalLink from '@site/src/components/ExternalLink'
+
+The GrowthBook Visual Studio Code extension allows you to see your available feature definitions right in VS Code.
+
+It can be configured to work with your project in under a minute and makes it easier for developers who use VS Code to work with the GrowthBook SDK by making features browsable and conveniently surfacing common actions.
+
+You [download it from the Visual Studio Marketplace <ExternalLink />](https://marketplace.visualstudio.com/items?itemName=GrowthBook.growthbook).

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/tools/vscode-extension.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/tools/vscode-extension.mdx
@@ -1,5 +1,5 @@
 ---
-title: Visual Studio Code Extension
+title: Visual Studio Code Extension 🚧
 description: GrowthBook's Visual Studio Code Extension
 sidebar_label: Visual Studio Code Extension
 slug: vscode-extension

--- a/docs/i18n/pt-BR/docusaurus-theme-classic/navbar.json
+++ b/docs/i18n/pt-BR/docusaurus-theme-classic/navbar.json
@@ -1,0 +1,34 @@
+{
+  "item.label.Docs": {
+    "message": "Docs",
+    "description": "Item da navbar com rótulo Docs"
+  },
+  "item.label.API": {
+    "message": "API",
+    "description": "Item da navbar com rótulo API"
+  },
+  "item.label.Home": {
+    "message": "Início",
+    "description": "Item da navbar com rótulo Início"
+  },
+  "item.label.Log in / sign up": {
+    "message": "Login / Cadastrar",
+    "description": "Item da navbar com rótulo Login / Cadastrar"
+  },
+  "item.label.GitHub": {
+    "message": "GitHub",
+    "description": "Item da navbar com rótulo GitHub"
+  },
+  "item.label.Support": {
+    "message": "Suporte",
+    "description": "Item da navbar com rótulo Suporte"
+  },
+  "item.label.Join our Slack": {
+    "message": "Junte-se ao nosso Slack",
+    "description": "Item da navbar com rótulo Junte-se ao nosso Slack"
+  },
+  "item.label.Open an issue": {
+    "message": "Reporte um problema",
+    "description": "Item da navbar com rótulo Reporte um problema"
+  }
+}


### PR DESCRIPTION
### Overview

Hey everyone! This PR enables i18n translations, starting with pt-BR (Brazilian Portuguese).

I'm going to work for next few weeks to finish entire pt-BR translation.

### Features and Changes

- Changed some hard-coded path images to dynamic willing to enable i18n translations.
- Translated sidebar 
- Translated navbar
- Translated index page
- Translated api page
- Translated self-host/index page
- Translated overview page
- Translated extra labels inside docs, like docusaurus main structure
- Created all folder structures of i18n pt-BR translation
- Put 'Construction Sign' (🚧) emoji on pages with translation working in progress

### Screenshots

![image](https://user-images.githubusercontent.com/14371178/230739398-60cfe0e9-368a-4d29-add1-0c151e7890eb.png)
