### PR TITLE
Free trials for cloud accounts

### DIFF
--- a/packages/back-end/package.json
+++ b/packages/back-end/package.json
@@ -73,7 +73,7 @@
     "snowflake-promise": "^4.5.0",
     "sql-formatter": "^11.0.2",
     "string-env-interpolation": "^1.0.1",
-    "stripe": "^9.14.0",
+    "stripe": "^12.0.0",
     "uniqid": "^5.3.0",
     "zod": "^3.20.6"
   },

--- a/packages/back-end/src/app.ts
+++ b/packages/back-end/src/app.ts
@@ -303,6 +303,10 @@ app.use(organizationsRouter);
 app.post("/oauth/google", datasourcesController.postGoogleOauthRedirect);
 app.post("/subscription/checkout", stripeController.postNewSubscription);
 app.get("/subscription/quote", stripeController.getSubscriptionQuote);
+app.get(
+  "/subscription/valid-payment-method",
+  stripeController.getHasValidPaymentMethod
+);
 app.post("/subscription/manage", stripeController.postCreateBillingSession);
 app.post("/subscription/success", stripeController.postSubscriptionSuccess);
 app.get("/queries/:ids", datasourcesController.getQueries);

--- a/packages/back-end/src/app.ts
+++ b/packages/back-end/src/app.ts
@@ -303,10 +303,6 @@ app.use(organizationsRouter);
 app.post("/oauth/google", datasourcesController.postGoogleOauthRedirect);
 app.post("/subscription/checkout", stripeController.postNewSubscription);
 app.get("/subscription/quote", stripeController.getSubscriptionQuote);
-app.get(
-  "/subscription/valid-payment-method",
-  stripeController.getHasValidPaymentMethod
-);
 app.post("/subscription/manage", stripeController.postCreateBillingSession);
 app.post("/subscription/success", stripeController.postSubscriptionSuccess);
 app.get("/queries/:ids", datasourcesController.getQueries);

--- a/packages/back-end/src/controllers/stripe.ts
+++ b/packages/back-end/src/controllers/stripe.ts
@@ -78,6 +78,9 @@ export async function postNewSubscription(
         quantity: qty,
       },
     ],
+    subscription_data: {
+      trial_period_days: 14,
+    },
     success_url: `${APP_ORIGIN}/settings/team?org=${org.id}&subscription-success-session={CHECKOUT_SESSION_ID}`,
     cancel_url: `${APP_ORIGIN}${returnUrl}?org=${org.id}`,
   });

--- a/packages/back-end/src/models/OrganizationModel.ts
+++ b/packages/back-end/src/models/OrganizationModel.ts
@@ -77,6 +77,7 @@ const organizationSchema = new mongoose.Schema({
     cancel_at_period_end: Boolean,
     planNickname: String,
     priceId: String,
+    hasPaymentMethod: Boolean,
   },
   licenseKey: String,
   connections: {

--- a/packages/back-end/src/models/OrganizationModel.ts
+++ b/packages/back-end/src/models/OrganizationModel.ts
@@ -64,6 +64,7 @@ const organizationSchema = new mongoose.Schema({
   priceId: String,
   freeSeats: Number,
   disableSelfServeBilling: Boolean,
+  freeTrialDate: Date,
   enterprise: Boolean,
   subscription: {
     id: String,

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -93,7 +93,6 @@ import {
   getExperimentsForActivityFeed,
 } from "../../models/ExperimentModel";
 import { removeEnvironmentFromSlackIntegration } from "../../models/SlackIntegrationModel";
-import { startFreeTrial } from "../../services/stripe";
 
 export async function getDefinitions(req: AuthRequest, res: Response) {
   const { org } = getOrgFromReq(req);
@@ -623,6 +622,7 @@ export async function getOrganization(req: AuthRequest, res: Response) {
       licenseKey,
       freeSeats,
       disableSelfServeBilling,
+      freeTrialDate: org.freeTrialDate,
       discountCode: org.discountCode || "",
       slackTeam: connections?.slack?.team,
       settings,
@@ -1052,15 +1052,6 @@ export async function signup(req: AuthRequest<SignupBody>, res: Response) {
       await sendNewOrgEmail(company, req.email);
     } catch (e) {
       req.log.error(e, "New org email sending failure");
-    }
-
-    // Start a free trial for the organization
-    if (IS_CLOUD) {
-      try {
-        await startFreeTrial(org, { cancelAtPeriodEnd: true });
-      } catch (e) {
-        req.log.error(e, "Error starting free trial");
-      }
     }
 
     res.status(200).json({

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -93,6 +93,7 @@ import {
   getExperimentsForActivityFeed,
 } from "../../models/ExperimentModel";
 import { removeEnvironmentFromSlackIntegration } from "../../models/SlackIntegrationModel";
+import { startFreeTrial } from "../../services/stripe";
 
 export async function getDefinitions(req: AuthRequest, res: Response) {
   const { org } = getOrgFromReq(req);
@@ -1051,6 +1052,15 @@ export async function signup(req: AuthRequest<SignupBody>, res: Response) {
       await sendNewOrgEmail(company, req.email);
     } catch (e) {
       req.log.error(e, "New org email sending failure");
+    }
+
+    // Start a free trial for the organization
+    if (IS_CLOUD) {
+      try {
+        await startFreeTrial(org, { cancelAtPeriodEnd: true });
+      } catch (e) {
+        req.log.error(e, "Error starting free trial");
+      }
     }
 
     res.status(200).json({

--- a/packages/back-end/src/services/stripe.ts
+++ b/packages/back-end/src/services/stripe.ts
@@ -1,5 +1,5 @@
 import { Stripe } from "stripe";
-import { STRIPE_PRICE, STRIPE_SECRET } from "../util/secrets";
+import { STRIPE_SECRET } from "../util/secrets";
 import {
   updateOrganization,
   updateOrganizationByStripeId,
@@ -9,7 +9,7 @@ import { logger } from "../util/logger";
 import { isActiveSubscriptionStatus } from "../util/organization.util";
 
 export const stripe = new Stripe(STRIPE_SECRET || "", {
-  apiVersion: "2020-08-27",
+  apiVersion: "2022-11-15",
 });
 
 /**
@@ -121,26 +121,4 @@ export async function getStripeCustomerId(org: OrganizationInterface) {
   });
 
   return id;
-}
-
-export async function startFreeTrial(
-  org: OrganizationInterface,
-  options?: {
-    cancelAtPeriodEnd?: boolean;
-  }
-) {
-  const customerId = await getStripeCustomerId(org);
-
-  const subscription = await stripe.subscriptions.create({
-    customer: customerId,
-    items: [
-      {
-        price: org.priceId || STRIPE_PRICE,
-      },
-    ],
-    trial_period_days: 14,
-    cancel_at_period_end: !!options.cancelAtPeriodEnd,
-  });
-
-  await updateSubscriptionInDb(subscription);
 }

--- a/packages/back-end/src/services/stripe.ts
+++ b/packages/back-end/src/services/stripe.ts
@@ -1,5 +1,5 @@
 import { Stripe } from "stripe";
-import { STRIPE_SECRET } from "../util/secrets";
+import { STRIPE_PRICE, STRIPE_SECRET } from "../util/secrets";
 import {
   updateOrganization,
   updateOrganizationByStripeId,
@@ -121,4 +121,26 @@ export async function getStripeCustomerId(org: OrganizationInterface) {
   });
 
   return id;
+}
+
+export async function startFreeTrial(
+  org: OrganizationInterface,
+  options?: {
+    cancelAtPeriodEnd?: boolean;
+  }
+) {
+  const customerId = await getStripeCustomerId(org);
+
+  const subscription = await stripe.subscriptions.create({
+    customer: customerId,
+    items: [
+      {
+        price: org.priceId || STRIPE_PRICE,
+      },
+    ],
+    trial_period_days: 14,
+    cancel_at_period_end: !!options.cancelAtPeriodEnd,
+  });
+
+  await updateSubscriptionInDb(subscription);
 }

--- a/packages/back-end/types/organization.d.ts
+++ b/packages/back-end/types/organization.d.ts
@@ -217,6 +217,7 @@ export interface OrganizationInterface {
     cancel_at_period_end: boolean;
     planNickname: string | null;
     priceId?: string;
+    hasPaymentMethod?: boolean;
   };
   licenseKey?: string;
   autoApproveMembers?: boolean;

--- a/packages/back-end/types/organization.d.ts
+++ b/packages/back-end/types/organization.d.ts
@@ -204,6 +204,7 @@ export interface OrganizationInterface {
   discountCode?: string;
   priceId?: string;
   disableSelfServeBilling?: boolean;
+  freeTrialDate?: Date;
   enterprise?: boolean;
   subscription?: {
     id: string;

--- a/packages/front-end/components/Layout/Layout.tsx
+++ b/packages/front-end/components/Layout/Layout.tsx
@@ -420,7 +420,7 @@ const Layout = (): React.ReactElement => {
                 </>
               ) : (
                 <>
-                  Upgrade to Pro <GBPremiumBadge />
+                  Try Pro <GBPremiumBadge />
                 </>
               )}
             </button>

--- a/packages/front-end/components/Settings/SubscriptionInfo.tsx
+++ b/packages/front-end/components/Settings/SubscriptionInfo.tsx
@@ -20,7 +20,7 @@ export default function SubscriptionInfo() {
     dateToBeCanceled,
     cancelationDate,
     subscriptionStatus,
-    hasValidPaymentMethod,
+    hasPaymentMethod,
     pendingCancelation,
     quote,
     loading,
@@ -69,7 +69,7 @@ export default function SubscriptionInfo() {
             <strong>Next Bill Date: </strong>
             {nextBillDate}
           </div>
-          {hasValidPaymentMethod === true ? (
+          {hasPaymentMethod === true ? (
             <div
               className="mt-3 px-3 py-2 alert alert-success row"
               style={{ maxWidth: 650 }}
@@ -82,7 +82,7 @@ export default function SubscriptionInfo() {
                 automatically on this date.
               </div>
             </div>
-          ) : hasValidPaymentMethod === false ? (
+          ) : hasPaymentMethod === false ? (
             <div
               className="mt-3 px-3 py-2 alert alert-warning row"
               style={{ maxWidth: 550 }}

--- a/packages/front-end/components/Settings/SubscriptionInfo.tsx
+++ b/packages/front-end/components/Settings/SubscriptionInfo.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { FaCheckCircle, FaExclamationTriangle } from "react-icons/fa";
 import { redirectWithTimeout, useAuth } from "@/services/auth";
 import useStripeSubscription from "@/hooks/useStripeSubscription";
 import LoadingOverlay from "../LoadingOverlay";
@@ -19,6 +20,7 @@ export default function SubscriptionInfo() {
     dateToBeCanceled,
     cancelationDate,
     subscriptionStatus,
+    hasValidPaymentMethod,
     pendingCancelation,
     quote,
     loading,
@@ -41,6 +43,12 @@ export default function SubscriptionInfo() {
       )}
       <div className="col-auto mb-3">
         <strong>Current Plan:</strong> {planName}
+        {subscriptionStatus === "trialing" && (
+          <>
+            {" "}
+            <em>(trial)</em>
+          </>
+        )}
       </div>
       <div className="col-md-12 mb-3">
         <strong>Number Of Seats:</strong> {quote?.activeAndInvitedUsers || 0}
@@ -57,8 +65,44 @@ export default function SubscriptionInfo() {
       )}
       {subscriptionStatus !== "canceled" && !pendingCancelation && (
         <div className="col-md-12 mb-3">
-          <strong>Next Bill Date: </strong>
-          {nextBillDate}
+          <div>
+            <strong>Next Bill Date: </strong>
+            {nextBillDate}
+          </div>
+          {hasValidPaymentMethod === true ? (
+            <div
+              className="mt-3 px-3 py-2 alert alert-success row"
+              style={{ maxWidth: 650 }}
+            >
+              <div className="col-auto px-1">
+                <FaCheckCircle />
+              </div>
+              <div className="col">
+                You have a valid payment method on file. You will be billed
+                automatically on this date.
+              </div>
+            </div>
+          ) : hasValidPaymentMethod === false ? (
+            <div
+              className="mt-3 px-3 py-2 alert alert-warning row"
+              style={{ maxWidth: 550 }}
+            >
+              <div className="col-auto px-1">
+                <FaExclamationTriangle />
+              </div>
+              <div className="col">
+                <p>
+                  You do not have a valid payment method on file. Your
+                  subscription will be cancelled on this date unless you add a
+                  valid payment method.
+                </p>
+                <p className="mb-0">
+                  Click <strong>Manage Subscription</strong> below to add a
+                  payment method.
+                </p>
+              </div>
+            </div>
+          ) : null}
         </div>
       )}
       {pendingCancelation && dateToBeCanceled && (
@@ -73,7 +117,7 @@ export default function SubscriptionInfo() {
           Your plan was canceled on {` ${cancelationDate}.`}
         </div>
       )}
-      <div className="col-md-12 mb-3 d-flex flex-row">
+      <div className="col-md-12 mt-4 mb-3 d-flex flex-row px-0">
         <div className="col-auto">
           <Button
             color="primary"

--- a/packages/front-end/components/Settings/UpgradeModal/CloudUpgradeForm.tsx
+++ b/packages/front-end/components/Settings/UpgradeModal/CloudUpgradeForm.tsx
@@ -15,17 +15,17 @@ const currencyFormatter = new Intl.NumberFormat(undefined, {
 export default function CloudUpgradeForm({
   accountPlan,
   source,
-  reason,
 }: {
   accountPlan: AccountPlan;
   source: string;
-  reason: string;
   setCloseCta: (string) => void;
   close: () => void;
 }) {
-  const { quote, loading } = useStripeSubscription();
+  const { quote, loading, subscriptionStatus } = useStripeSubscription();
   const { apiCall } = useAuth();
   const [error, setError] = useState(null);
+
+  const freeTrialAvailable = !subscriptionStatus;
 
   useEffect(() => {
     track("View Upgrade Modal", {
@@ -78,16 +78,37 @@ export default function CloudUpgradeForm({
   return (
     <>
       {loading && <LoadingOverlay />}
-      <p className="text-center mb-4" style={{ fontSize: "1.5em" }}>
-        {reason} Upgrade to a <strong>Pro Plan</strong>
-      </p>
-      <p className="text-center mb-4">
-        After upgrading, you will be able to add additional users for{" "}
-        <strong>
-          {currencyFormatter.format(quote?.additionalSeatPrice || 0)}
-        </strong>
-        /month.
-      </p>
+      {freeTrialAvailable ? (
+        <>
+          <p className="text-center mb-3" style={{ fontSize: "1.5em" }}>
+            Try GrowthBook Pro for free
+          </p>
+          <p className="text-center mb-2">
+            Try our <strong>Pro</strong> plan for Cloud accounts for{" "}
+            <em>14 days free</em>!
+          </p>
+          <p className="text-center mb-4">
+            After upgrading, you will be able to add additional users for{" "}
+            <strong>
+              {currencyFormatter.format(quote?.additionalSeatPrice || 0)}
+            </strong>
+            /month.
+          </p>
+        </>
+      ) : (
+        <>
+          <p className="text-center mb-4" style={{ fontSize: "1.5em" }}>
+            Upgrade to a <strong>Pro Plan</strong>
+          </p>
+          <p className="text-center mb-4">
+            After upgrading, you will be able to add additional users for{" "}
+            <strong>
+              {currencyFormatter.format(quote?.additionalSeatPrice || 0)}
+            </strong>
+            /month.
+          </p>
+        </>
+      )}
       <div className="row align-items-center justify-content-center">
         <div className="col-auto mb-4 mr-lg-5 pr-lg-5">
           <h3>Pro Plan includes:</h3>
@@ -103,6 +124,14 @@ export default function CloudUpgradeForm({
                     Or make them read-only in Project A and an admin for Project
                     B.
                   </>
+                }
+              />
+            </li>
+            <li>
+              Visual A/B test editor{" "}
+              <Tooltip
+                body={
+                  "Make UI changes using our Visual Editor browser plugin without writing code."
                 }
               />
             </li>
@@ -130,10 +159,15 @@ export default function CloudUpgradeForm({
                 }
               />
             </li>
+            <li>
+              Advanced experimentation features
+              <br />
+              (CUPED, Sequential Testing, etc)
+            </li>
             <li>Early access to new features</li>
           </ul>
         </div>
-        <div className="col-auto mb-4">
+        <div className="col-lg-5 mb-4">
           <div className="bg-light border rounded p-3 p-lg-4">
             <div className="d-flex">
               <div>Current team size</div>
@@ -161,28 +195,59 @@ export default function CloudUpgradeForm({
                 </div>
               </div>
             )}
-            <div className="d-flex py-2 mb-3" style={{ fontSize: "1.3em" }}>
-              <div>Total</div>
-              <div className="ml-auto">
-                <strong>{currencyFormatter.format(quote?.total || 0)}</strong>
-                <small className="text-muted"> / month</small>
+            {freeTrialAvailable ? (
+              <>
+                <div className="d-flex pt-2 mb-2" style={{ fontSize: "1.3em" }}>
+                  <div>Pay Today</div>
+                  <div className="ml-auto">
+                    <strong>{currencyFormatter.format(0)}</strong>
+                  </div>
+                </div>
+                <div className="d-flex pb-2 mb-3">
+                  <div>
+                    After 14 day trial <sup>&#10019;</sup>
+                  </div>
+                  <div className="ml-auto">
+                    {currencyFormatter.format(quote?.total | 0)}
+                    <small className="text-muted"> / month</small>
+                  </div>
+                </div>
+              </>
+            ) : (
+              <div className="d-flex py-2 mb-3" style={{ fontSize: "1.3em" }}>
+                <div>Total</div>
+                <div className="ml-auto">
+                  <strong>{currencyFormatter.format(quote?.total || 0)}</strong>
+                  <small className="text-muted"> / month</small>
+                </div>
               </div>
-            </div>
+            )}
             <div className="text-center px-4 mb-2">
               <Button
                 color="primary"
                 className="btn-block btn-lg"
                 onClick={startStripeSubscription}
               >
-                Upgrade to Pro
+                {freeTrialAvailable ? "Start Free Trial" : "Upgrade to Pro"}
               </Button>
             </div>
             <div
               className="text-center text-muted"
-              style={{ fontSize: "0.8em" }}
+              style={{ fontSize: "0.7em" }}
             >
-              Cancel or modify your subscription anytime.
+              Cancel or modify your subscription at any time.
             </div>
+            {freeTrialAvailable && (
+              <div
+                className="mt-2 text-center text-muted"
+                style={{ fontSize: "0.7em", lineHeight: 1.2 }}
+              >
+                &#10019; After the 14 day trial period ends, your credit card
+                will automatically be charged at the rate of{" "}
+                {currencyFormatter.format(quote?.total || 0)} / month unless you
+                cancel beforehand.
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/packages/front-end/components/Settings/UpgradeModal/CloudUpgradeForm.tsx
+++ b/packages/front-end/components/Settings/UpgradeModal/CloudUpgradeForm.tsx
@@ -67,6 +67,7 @@ export default function CloudUpgradeForm({
           discountMessage: quote?.discountMessage || "",
           subtotal: quote?.subtotal,
           total: quote?.total,
+          isFreeTrial: freeTrialAvailable,
         });
         await redirectWithTimeout(resp.session.url);
       } else {

--- a/packages/front-end/components/Settings/UpgradeModal/CloudUpgradeForm.tsx
+++ b/packages/front-end/components/Settings/UpgradeModal/CloudUpgradeForm.tsx
@@ -83,12 +83,9 @@ export default function CloudUpgradeForm({
       {freeTrialAvailable ? (
         <>
           <p className="text-center mb-4" style={{ fontSize: "1.5em" }}>
-            Try GrowthBook Pro for free
+            Try <strong>GrowthBook Pro</strong> free for 14 days
           </p>
-          <p className="text-center mb-4">
-            Try our <strong>Pro</strong> plan for Cloud accounts for{" "}
-            <em>14 days free</em>!
-          </p>
+          <p className="text-center mb-4">No credit card required</p>
         </>
       ) : (
         <>
@@ -126,7 +123,7 @@ export default function CloudUpgradeForm({
               Visual A/B test editor{" "}
               <Tooltip
                 body={
-                  "Make UI changes using our Visual Editor browser plugin without writing code."
+                  "A/B test UI changes using our Visual Editor browser plugin without writing code."
                 }
               />
             </li>
@@ -256,8 +253,7 @@ export default function CloudUpgradeForm({
                 <strong>
                   {currencyFormatter.format(quote?.total || 0)} / month
                 </strong>{" "}
-                by providing payment information to your subscription from the
-                Billing page.
+                by adding a credit card to your account.
               </div>
             )}
           </div>

--- a/packages/front-end/components/Settings/UpgradeModal/index.tsx
+++ b/packages/front-end/components/Settings/UpgradeModal/index.tsx
@@ -11,7 +11,7 @@ export interface Props {
   reason: string;
 }
 
-export default function UpgradeModal({ close, source, reason }: Props) {
+export default function UpgradeModal({ close, source }: Props) {
   const [closeCta, setCloseCta] = useState("Cancel");
   const { accountPlan, permissions } = useUser();
 
@@ -36,7 +36,6 @@ export default function UpgradeModal({ close, source, reason }: Props) {
         <CloudUpgradeForm
           accountPlan={accountPlan}
           source={source}
-          reason={reason}
           setCloseCta={(s) => setCloseCta(s)}
           close={close}
         />

--- a/packages/front-end/hooks/useStripeSubscription.ts
+++ b/packages/front-end/hooks/useStripeSubscription.ts
@@ -18,9 +18,13 @@ export default function useStripeSubscription() {
   const freeSeats = organization?.freeSeats || 3;
 
   const [quote, setQuote] = useState<SubscriptionQuote | null>(null);
+  const [hasValidPaymentMethod, setHasValidPaymentMethod] = useState<
+    boolean | null
+  >(null);
 
   const { apiCall } = useAuth();
   const permissions = usePermissions();
+
   useEffect(() => {
     if (!permissions.manageBilling) return;
     if (!isCloud()) return;
@@ -31,6 +35,19 @@ export default function useStripeSubscription() {
       })
       .catch((e) => console.error(e));
   }, [freeSeats, isCloud(), permissions.manageBilling]);
+
+  useEffect(() => {
+    if (!permissions.manageBilling) return;
+    if (!isCloud()) return;
+
+    apiCall<{ hasValidPaymentMethod: boolean | null }>(
+      "/subscription/valid-payment-method"
+    )
+      .then((data) => {
+        setHasValidPaymentMethod(data.hasValidPaymentMethod);
+      })
+      .catch((e) => console.error(e));
+  }, [isCloud(), permissions.manageBilling]);
 
   const activeAndInvitedUsers = quote?.activeAndInvitedUsers || 0;
 
@@ -74,6 +91,7 @@ export default function useStripeSubscription() {
     dateToBeCanceled,
     cancelationDate,
     subscriptionStatus,
+    hasValidPaymentMethod,
     pendingCancelation,
     activeAndInvitedUsers,
     hasActiveSubscription,

--- a/packages/front-end/hooks/useStripeSubscription.ts
+++ b/packages/front-end/hooks/useStripeSubscription.ts
@@ -62,7 +62,7 @@ export default function useStripeSubscription() {
 
   // eslint-disable-next-line
   let trialEnd = (organization?.subscription?.trialEnd || null) as any;
-  if (trialEnd) {
+  if (typeof trialEnd === "number") {
     trialEnd = getValidDate(trialEnd * 1000);
   }
 

--- a/packages/front-end/hooks/useStripeSubscription.ts
+++ b/packages/front-end/hooks/useStripeSubscription.ts
@@ -18,9 +18,6 @@ export default function useStripeSubscription() {
   const freeSeats = organization?.freeSeats || 3;
 
   const [quote, setQuote] = useState<SubscriptionQuote | null>(null);
-  const [hasValidPaymentMethod, setHasValidPaymentMethod] = useState<
-    boolean | null
-  >(null);
 
   const { apiCall } = useAuth();
   const permissions = usePermissions();
@@ -36,22 +33,11 @@ export default function useStripeSubscription() {
       .catch((e) => console.error(e));
   }, [freeSeats, isCloud(), permissions.manageBilling]);
 
-  useEffect(() => {
-    if (!permissions.manageBilling) return;
-    if (!isCloud()) return;
-
-    apiCall<{ hasValidPaymentMethod: boolean | null }>(
-      "/subscription/valid-payment-method"
-    )
-      .then((data) => {
-        setHasValidPaymentMethod(data.hasValidPaymentMethod);
-      })
-      .catch((e) => console.error(e));
-  }, [isCloud(), permissions.manageBilling]);
-
   const activeAndInvitedUsers = quote?.activeAndInvitedUsers || 0;
 
   const subscriptionStatus = organization?.subscription?.status;
+
+  const hasPaymentMethod = organization?.subscription?.hasPaymentMethod;
 
   // We will treat past_due as active so as to not interrupt users
   const hasActiveSubscription = ["active", "trialing", "past_due"].includes(
@@ -91,7 +77,7 @@ export default function useStripeSubscription() {
     dateToBeCanceled,
     cancelationDate,
     subscriptionStatus,
-    hasValidPaymentMethod,
+    hasPaymentMethod,
     pendingCancelation,
     activeAndInvitedUsers,
     hasActiveSubscription,

--- a/packages/front-end/pages/settings/index.tsx
+++ b/packages/front-end/pages/settings/index.tsx
@@ -363,7 +363,7 @@ const GeneralSettingsPage = (): React.ReactElement => {
                           </>
                         ) : (
                           <>
-                            Upgrade to Pro <GBPremiumBadge />
+                            Try Pro <GBPremiumBadge />
                           </>
                         )}
                       </button>

--- a/yarn.lock
+++ b/yarn.lock
@@ -16154,10 +16154,17 @@ qs@6.10.3:
   dependencies:
     side-channel "^1.0.4"
 
-qs@^6.10.0, qs@^6.10.3, qs@^6.4.0, qs@^6.7.0:
+qs@^6.10.0, qs@^6.4.0, qs@^6.7.0:
   version "6.11.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.0.tgz#fd0d963446f7a65e1367e01abd85429453f0c37a"
   integrity sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==
+  dependencies:
+    side-channel "^1.0.4"
+
+qs@^6.11.0:
+  version "6.11.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.1.tgz#6c29dff97f0c0060765911ba65cbc9764186109f"
+  integrity sha512-0wsrzgTz/kAVIeuxSjnpGC56rzYtr6JT/2BwEvMaPhFIoYa1aGO8LbzuU1R0uUYQkLpWBTOj0l/CLAJB64J6nQ==
   dependencies:
     side-channel "^1.0.4"
 
@@ -18346,13 +18353,13 @@ strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
-stripe@^9.14.0:
-  version "9.14.0"
-  resolved "https://registry.yarnpkg.com/stripe/-/stripe-9.14.0.tgz#4f78d7adb932ba2ea1b696cc2dea8a5ba9efbb33"
-  integrity sha512-nonEpYI7kPxZI8BGqlichBont9oHTBKFdKQV4LW6SvMAfYyQ95pL3vw1kqnW38oAui/c1sJqDOE2t8AoosOC9w==
+stripe@^12.0.0:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/stripe/-/stripe-12.0.0.tgz#7261f2dcc2179256f3f57856012fc65b512cecb1"
+  integrity sha512-9zdcWApF4Yg2WG4GVv1qnvAv+h5KD103gKwbTsTyk5G3lf9h4vN0FXGQ5d5eWKP9itAjt0D5gZtWG7cLPzyLxw==
   dependencies:
     "@types/node" ">=8.1.0"
-    qs "^6.10.3"
+    qs "^6.11.0"
 
 strnum@^1.0.5:
   version "1.0.5"
@@ -19802,10 +19809,8 @@ watchpack@^1.7.4:
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.5.tgz#1267e6c55e0b9b5be44c2023aed5437a2c26c453"
   integrity sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==
   dependencies:
-    chokidar "^3.4.1"
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
-    watchpack-chokidar2 "^2.0.1"
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"


### PR DESCRIPTION
### Features and Changes

Adds the ability to enroll into a free trial (14 days) for Cloud users.
- Free trials can only be redeemed once, subsequent subscriptions will use the paid subscription flow.
- Free trials will not auto-bill unless the user opts in by providing payment information (Settings > Billing)
- No billing information is collected during the trial signup
- Additional feedback for having valid payment methods (only for users with `manageBilling` permissions)


### Screenshots

<img width="868" alt="image" src="https://user-images.githubusercontent.com/7927873/231071406-fcc0a6c3-8c01-4f15-bcc0-79f9870cef10.png">
<img width="910" alt="image" src="https://user-images.githubusercontent.com/7927873/231070017-099a3ab2-378f-46e6-b7d5-d8a7fd2cef65.png">
<img width="288" alt="image" src="https://user-images.githubusercontent.com/7927873/231071481-78e910f2-301f-4288-9b1b-c37b8b0cb89d.png">

