### PR TITLE
Surface Events in UI and Paywall audit logging behind commercial feature "audit-logging"

### DIFF
--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -31,9 +31,9 @@ import {
 import {
   deleteSnapshotById,
   findSnapshotById,
+  getLatestSnapshot,
   updateSnapshot,
   updateSnapshotsOnPhaseDelete,
-  getLatestSnapshot,
 } from "../models/ExperimentSnapshotModel";
 import { getSourceIntegrationObject } from "../services/datasource";
 import { addTagsDiff } from "../models/TagModel";
@@ -74,7 +74,7 @@ import { ExperimentSnapshotInterface } from "../../types/experiment-snapshot";
 import { StatsEngine } from "../../types/stats";
 import { MetricRegressionAdjustmentStatus } from "../../types/report";
 import { VisualChangesetInterface } from "../../types/visual-changeset";
-import { ApiErrorResponse } from "../../types/api";
+import { PrivateApiErrorResponse } from "../../types/api";
 import { EventAuditUserForResponseLocals } from "../events/event-types";
 
 export async function getExperiments(
@@ -467,7 +467,7 @@ export async function postExperiments(
   res: Response<
     | { status: 200; experiment: ExperimentInterface }
     | { status: 200; duplicateTrackingKey: boolean; existingId: string }
-    | ({ status: number } & ApiErrorResponse),
+    | PrivateApiErrorResponse,
     EventAuditUserForResponseLocals
   >
 ) {
@@ -617,7 +617,7 @@ export async function postExperiment(
   >,
   res: Response<
     | { status: number; experiment?: ExperimentInterface | null }
-    | ApiErrorResponse,
+    | PrivateApiErrorResponse,
     EventAuditUserForResponseLocals
   >
 ) {
@@ -1312,7 +1312,7 @@ export async function getWatchingUsers(
 export async function deleteExperiment(
   req: AuthRequest<ExperimentInterface, { id: string }>,
   res: Response<
-    { status: 200 } | ({ status: number } & ApiErrorResponse),
+    { status: 200 } | PrivateApiErrorResponse,
     EventAuditUserForResponseLocals
   >
 ) {

--- a/packages/back-end/src/routers/data-export/data-export.controller.ts
+++ b/packages/back-end/src/routers/data-export/data-export.controller.ts
@@ -1,11 +1,11 @@
 import type { Response } from "express";
 import { AuthRequest } from "../../types/AuthRequest";
-import { ApiErrorResponse } from "../../../types/api";
 import { getOrgFromReq } from "../../services/organizations";
 import { EventAuditUserForResponseLocals } from "../../events/event-types";
 import { getLatestEventsForOrganization } from "../../models/EventModel";
 import { DataExportFileResponse } from "../../../types/data-exports";
 import { orgHasPremiumFeature } from "../../util/organization.util";
+import { PrivateApiErrorResponse } from "../../../types/api";
 
 /**
  * GET /data-export/events
@@ -16,7 +16,7 @@ import { orgHasPremiumFeature } from "../../util/organization.util";
 export const getDataExportForEvents = async (
   req: AuthRequest,
   res: Response<
-    DataExportFileResponse | ApiErrorResponse,
+    DataExportFileResponse | PrivateApiErrorResponse,
     EventAuditUserForResponseLocals
   >
 ) => {
@@ -26,6 +26,7 @@ export const getDataExportForEvents = async (
 
   if (!orgHasPremiumFeature(org, "audit-logging")) {
     return res.status(403).json({
+      status: 403,
       message: "Organization does not have premium feature: audit-logging",
     });
   }

--- a/packages/back-end/src/routers/data-export/data-export.controller.ts
+++ b/packages/back-end/src/routers/data-export/data-export.controller.ts
@@ -5,6 +5,7 @@ import { getOrgFromReq } from "../../services/organizations";
 import { EventAuditUserForResponseLocals } from "../../events/event-types";
 import { getLatestEventsForOrganization } from "../../models/EventModel";
 import { DataExportFileResponse } from "../../../types/data-exports";
+import { orgHasPremiumFeature } from "../../util/organization.util";
 
 /**
  * GET /data-export/events
@@ -22,6 +23,12 @@ export const getDataExportForEvents = async (
   req.checkPermissions("viewEvents");
 
   const { org } = getOrgFromReq(req);
+
+  if (!orgHasPremiumFeature(org, "audit-logging")) {
+    return res.status(403).json({
+      message: "Organization does not have premium feature: audit-logging",
+    });
+  }
 
   const events = await getLatestEventsForOrganization(org.id, 0);
 

--- a/packages/back-end/src/routers/dimension/dimension.controller.ts
+++ b/packages/back-end/src/routers/dimension/dimension.controller.ts
@@ -1,7 +1,7 @@
 import type { Response } from "express";
 import uniqid from "uniqid";
 import { AuthRequest } from "../../types/AuthRequest";
-import { ApiErrorResponse } from "../../../types/api";
+import { PrivateApiErrorResponse } from "../../../types/api";
 import { getOrgFromReq } from "../../services/organizations";
 import { DimensionInterface } from "../../../types/dimension";
 import {
@@ -30,7 +30,7 @@ type GetDimensionsResponse = {
  */
 export const getDimensions = async (
   req: GetDimensionsRequest,
-  res: Response<GetDimensionsResponse | ApiErrorResponse>
+  res: Response<GetDimensionsResponse | PrivateApiErrorResponse>
 ) => {
   const { org } = getOrgFromReq(req);
   const dimensions = await findDimensionsByOrganization(org.id);
@@ -64,7 +64,7 @@ type CreateDimensionResponse = {
  */
 export const postDimension = async (
   req: CreateDimensionRequest,
-  res: Response<CreateDimensionResponse | ApiErrorResponse>
+  res: Response<CreateDimensionResponse | PrivateApiErrorResponse>
 ) => {
   req.checkPermissions("createDimensions");
 
@@ -173,7 +173,7 @@ type DeleteDimensionResponse = {
  */
 export const deleteDimension = async (
   req: DeleteDimensionRequest,
-  res: Response<DeleteDimensionResponse | ApiErrorResponse>
+  res: Response<DeleteDimensionResponse | PrivateApiErrorResponse>
 ) => {
   req.checkPermissions("createDimensions");
 

--- a/packages/back-end/src/routers/event-webhooks/event-webhooks.controller.ts
+++ b/packages/back-end/src/routers/event-webhooks/event-webhooks.controller.ts
@@ -1,18 +1,18 @@
 import type { Response } from "express";
-import { ApiErrorResponse } from "../../../types/api";
+import { PrivateApiErrorResponse } from "../../../types/api";
 import { EventWebHookInterface } from "../../../types/event-webhook";
 import * as EventWebHook from "../../models/EventWebhookModel";
+import {
+  deleteEventWebHookById,
+  getEventWebHookById,
+  updateEventWebHook,
+} from "../../models/EventWebhookModel";
 import * as EventWebHookLog from "../../models/EventWebHookLogModel";
 
 import { AuthRequest } from "../../types/AuthRequest";
 import { getOrgFromReq } from "../../services/organizations";
 import { EventWebHookLogInterface } from "../../../types/event-webhook-log";
 import { NotificationEventName } from "../../events/base-types";
-import {
-  deleteEventWebHookById,
-  getEventWebHookById,
-  updateEventWebHook,
-} from "../../models/EventWebhookModel";
 
 // region GET /event-webhooks
 
@@ -47,7 +47,7 @@ type GetEventWebHookByIdResponse = {
 
 export const getEventWebHook = async (
   req: GetEventWebHookByIdRequest,
-  res: Response<GetEventWebHookByIdResponse | ApiErrorResponse>
+  res: Response<GetEventWebHookByIdResponse | PrivateApiErrorResponse>
 ) => {
   req.checkPermissions("manageWebhooks");
 
@@ -56,7 +56,7 @@ export const getEventWebHook = async (
 
   const eventWebHook = await getEventWebHookById(eventWebHookId, org.id);
   if (!eventWebHook) {
-    return res.status(404).json({ message: "Not found" });
+    return res.status(404).json({ status: 404, message: "Not found" });
   }
 
   return res.json({
@@ -83,7 +83,7 @@ type PostEventWebHooksResponse = {
 
 export const createEventWebHook = async (
   req: PostEventWebHooksRequest,
-  res: Response<PostEventWebHooksResponse | ApiErrorResponse>
+  res: Response<PostEventWebHooksResponse | PrivateApiErrorResponse>
 ) => {
   req.checkPermissions("manageWebhooks");
 
@@ -116,7 +116,7 @@ type GetEventWebHookLogsResponse = {
 
 export const getEventWebHookLogs = async (
   req: GetEventWebHookLogsRequest,
-  res: Response<GetEventWebHookLogsResponse | ApiErrorResponse>
+  res: Response<GetEventWebHookLogsResponse | PrivateApiErrorResponse>
 ) => {
   req.checkPermissions("manageWebhooks");
 
@@ -143,7 +143,7 @@ type DeleteEventWebhookResponse = {
 
 export const deleteEventWebHook = async (
   req: DeleteEventWebhookRequest,
-  res: Response<DeleteEventWebhookResponse | ApiErrorResponse>
+  res: Response<DeleteEventWebhookResponse | PrivateApiErrorResponse>
 ) => {
   req.checkPermissions("manageWebhooks");
 

--- a/packages/back-end/src/util/organization.util.ts
+++ b/packages/back-end/src/util/organization.util.ts
@@ -40,6 +40,7 @@ export const accountFeatures: CommercialFeaturesMap = {
   enterprise: new Set<CommercialFeature>([
     "sso",
     "advanced-permissions",
+    "audit-logging",
     "encrypt-features-endpoint",
     "schedule-feature-flag",
     "override-metrics",

--- a/packages/back-end/types/api.d.ts
+++ b/packages/back-end/types/api.d.ts
@@ -53,3 +53,11 @@ export interface ApiRequestLocals {
 export interface ApiErrorResponse {
   message: string;
 }
+
+/**
+ * In the private API, there is a convention to add `status: number` to all response types.
+ */
+export interface PrivateApiErrorResponse {
+  status: number;
+  message: string;
+}

--- a/packages/back-end/types/organization.d.ts
+++ b/packages/back-end/types/organization.d.ts
@@ -40,6 +40,7 @@ export type CommercialFeature =
   | "schedule-feature-flag"
   | "override-metrics"
   | "regression-adjustment"
+  | "audit-logging"
   | "visual-editor";
 export type CommercialFeaturesMap = Record<AccountPlan, Set<CommercialFeature>>;
 

--- a/packages/front-end/components/Events/EventsPage/EventsPage.tsx
+++ b/packages/front-end/components/Events/EventsPage/EventsPage.tsx
@@ -8,9 +8,9 @@ import {
 import { FaDownload } from "react-icons/fa";
 import useApi from "@/hooks/useApi";
 import { useDownloadDataExport } from "@/hooks/useDownloadDataExport";
+import { useUser } from "@/services/UserContext";
 import LoadingSpinner from "../../LoadingSpinner";
 import { EventsTableRow } from "./EventsTableRow";
-import { useUser } from "@/services/UserContext";
 
 type EventsPageProps = {
   isLoading: boolean;
@@ -61,12 +61,12 @@ export const EventsPage: FC<EventsPageProps> = ({
       </div>
 
       {hasLoadError && (
-        <div className="alert alert-danger">
+        <div className="alert alert-danger mt-2">
           There was an error loading the events.
         </div>
       )}
       {hasExportError && (
-        <div className="alert alert-danger">
+        <div className="alert alert-danger mt-2">
           There was an error exporting the events.
         </div>
       )}

--- a/packages/front-end/components/Events/EventsPage/EventsPage.tsx
+++ b/packages/front-end/components/Events/EventsPage/EventsPage.tsx
@@ -9,6 +9,7 @@ import { FaDownload } from "react-icons/fa";
 import useApi from "@/hooks/useApi";
 import { useDownloadDataExport } from "@/hooks/useDownloadDataExport";
 import { useUser } from "@/services/UserContext";
+import PremiumTooltip from "@/components/Marketing/PremiumTooltip";
 import LoadingSpinner from "../../LoadingSpinner";
 import { EventsTableRow } from "./EventsTableRow";
 
@@ -44,19 +45,23 @@ export const EventsPage: FC<EventsPageProps> = ({
           <h1>Events</h1>
         </div>
 
-        <div className="col-6 text-right ">
-          {shouldShowExportButton && (
-            <button
-              onClick={performDownload}
-              disabled={isDownloading}
-              className="btn btn-primary"
-            >
-              <span className="mr-1">
-                <FaDownload />
-              </span>{" "}
-              Export
-            </button>
-          )}
+        <div className="col-6 text-right">
+          <PremiumTooltip commercialFeature="audit-logging">
+            {shouldShowExportButton
+              ? ""
+              : "Exporting events is available to Enterprise customers"}
+          </PremiumTooltip>
+
+          <button
+            onClick={performDownload}
+            disabled={isDownloading || !shouldShowExportButton}
+            className="btn btn-primary ml-3"
+          >
+            <span className="mr-1">
+              <FaDownload />
+            </span>{" "}
+            Export
+          </button>
         </div>
       </div>
 

--- a/packages/front-end/components/Layout/Layout.tsx
+++ b/packages/front-end/components/Layout/Layout.tsx
@@ -191,6 +191,12 @@ const navlinks: SidebarLinkProps[] = [
         permissions: ["manageWebhooks"],
       },
       {
+        name: "Logs",
+        href: "/events",
+        path: /^events/,
+        permissions: ["viewEvents"],
+      },
+      {
         name: "Billing",
         href: "/settings/billing",
         path: /^settings\/billing/,

--- a/packages/front-end/hooks/useDownloadDataExport.ts
+++ b/packages/front-end/hooks/useDownloadDataExport.ts
@@ -1,5 +1,6 @@
 import { useCallback, useState } from "react";
 import { DataExportFileResponse } from "back-end/types/data-exports";
+import { ApiErrorResponse } from "back-end/types/api";
 import { useAuth } from "@/services/auth";
 import { saveAs } from "@/services/files";
 
@@ -46,10 +47,21 @@ export const useDownloadDataExport = ({
     setIsDownloading(true);
 
     apiCall(url)
-      .then((response: DataExportFileResponse) => {
-        saveAs({ textContent: response.data, fileName: response.fileName });
+      .then((response: DataExportFileResponse | ApiErrorResponse) => {
+        if (Object.prototype.hasOwnProperty.call(response, "data")) {
+          const successResponse = response as DataExportFileResponse;
+          saveAs({
+            textContent: successResponse.data,
+            fileName: successResponse.fileName,
+          });
 
-        setHasError(false);
+          setHasError(false);
+        } else {
+          const failedResponse = response as ApiErrorResponse;
+
+          setHasError(true);
+          console.error(failedResponse.message);
+        }
 
         setTimeout(() => {
           // Re-enable after some time to avoid spam

--- a/packages/front-end/hooks/useDownloadDataExport.ts
+++ b/packages/front-end/hooks/useDownloadDataExport.ts
@@ -1,6 +1,5 @@
 import { useCallback, useState } from "react";
 import { DataExportFileResponse } from "back-end/types/data-exports";
-import { ApiErrorResponse } from "back-end/types/api";
 import { useAuth } from "@/services/auth";
 import { saveAs } from "@/services/files";
 
@@ -47,21 +46,11 @@ export const useDownloadDataExport = ({
     setIsDownloading(true);
 
     apiCall(url)
-      .then((response: DataExportFileResponse | ApiErrorResponse) => {
-        if (Object.prototype.hasOwnProperty.call(response, "data")) {
-          const successResponse = response as DataExportFileResponse;
-          saveAs({
-            textContent: successResponse.data,
-            fileName: successResponse.fileName,
-          });
-
-          setHasError(false);
-        } else {
-          const failedResponse = response as ApiErrorResponse;
-
-          setHasError(true);
-          console.error(failedResponse.message);
-        }
+      .then((response: DataExportFileResponse) => {
+        saveAs({
+          textContent: response.data,
+          fileName: response.fileName,
+        });
 
         setTimeout(() => {
           // Re-enable after some time to avoid spam

--- a/plop-templates/back-end/controller.hbs
+++ b/plop-templates/back-end/controller.hbs
@@ -1,6 +1,6 @@
 import type { Response } from "express";
 import { AuthRequest } from "../../types/AuthRequest";
-import { ApiErrorResponse } from "../../../types/api";
+import { PrivateApiErrorResponse } from "../../../types/api";
 import { getOrgFromReq } from "../../services/organizations";
 import { EventAuditUserForResponseLocals } from '../../events/event-types';
 
@@ -25,7 +25,7 @@ type Get{{pascalCase resource}}sResponse = {
 export const get{{pascalCase resource}}s = async (
   req: Get{{pascalCase resource}}sRequest,
   res: Response<
-    Get{{pascalCase resource}}sResponse | ApiErrorResponse,
+    Get{{pascalCase resource}}sResponse | PrivateApiErrorResponse,
     EventAuditUserForResponseLocals
   >
 ) => {
@@ -59,7 +59,7 @@ type Get{{pascalCase resource}}Response = {
 export const get{{pascalCase resource}} = async (
   req: Get{{pascalCase resource}}Request,
   res: Response<
-    Get{{pascalCase resource}}Response | ApiErrorResponse,
+    Get{{pascalCase resource}}Response | PrivateApiErrorResponse,
     EventAuditUserForResponseLocals
   >
 ) => {
@@ -93,7 +93,7 @@ type Create{{pascalCase resource}}Response = {
 export const post{{pascalCase resource}} = async (
   req: Create{{pascalCase resource}}Request,
   res: Response<
-    Create{{pascalCase resource}}Response | ApiErrorResponse,
+    Create{{pascalCase resource}}Response | PrivateApiErrorResponse,
     EventAuditUserForResponseLocals
   >
 ) => {
@@ -128,7 +128,7 @@ type Put{{pascalCase resource}}Response = {
 export const put{{pascalCase resource}} = async (
   req: Put{{pascalCase resource}}Request,
   res: Response<
-    Put{{pascalCase resource}}Response | ApiErrorResponse,
+    Put{{pascalCase resource}}Response | PrivateApiErrorResponse,
     EventAuditUserForResponseLocals
   >
 ) => {
@@ -161,7 +161,7 @@ type Delete{{pascalCase resource}}Response = Record<string, never>;
 export const delete{{pascalCase resource}} = async (
   req: Delete{{pascalCase resource}}Request,
   res: Response<
-    Delete{{pascalCase resource}}Response | ApiErrorResponse,
+    Delete{{pascalCase resource}}Response | PrivateApiErrorResponse,
     EventAuditUserForResponseLocals
   >
 ) => {


### PR DESCRIPTION
## Features and Changes

### Surface in menu UI

It gets surfaced in the UI as a menu item under Settings for anyone with the `viewEvents` permission. This essentially "launches" the Events page but it's always been accessible in the UI just hidden.


### Paywalling

Requires that the user has commercial feature `audit-logging` in order to download exports, which has been added to the enterprise feature list.

Checks on the back-end and front-end.

Returns 403 Unauthorized on the backend for those without this commercial feature.

If the download fails for any reason, we show them an error message. 

The button will not be enabled for customers who do not have access, and will show the premium tooltip.


### Dependencies

n/a


### Testing

- Try it as a licensed enterprise user
- Try it as a regular user


## Screenshots

### Surface in UI

For anyone with the `viewEvents` permission.

<img width="261" alt="image" src="https://user-images.githubusercontent.com/113377031/231268828-2a0e6251-2e47-4918-b62c-4c4322bbe38b.png">



### Paywall

What users that are not enterprise customers will see:

<img width="552" alt="image" src="https://user-images.githubusercontent.com/113377031/231269540-c4e6213f-8121-44b0-97c8-f8621d8c608c.png">


<img width="1237" alt="image" src="https://user-images.githubusercontent.com/113377031/231268692-25745577-e963-42b7-a478-5ebbb05b1c18.png">


What enterprise customers will see:

<img width="1238" alt="Screen Shot 2023-04-11 at 11 29 22 AM" src="https://user-images.githubusercontent.com/113377031/231257544-6ada1022-f2d8-4069-9d01-197325041cb8.png">

Failed download error message.

<img width="1185" alt="image" src="https://user-images.githubusercontent.com/113377031/231258117-3a5aa5f0-d350-4729-a5dd-a85f1157033b.png">
