### PR TITLE
Add fix to redshift dimension

### DIFF
--- a/packages/back-end/src/integrations/Athena.ts
+++ b/packages/back-end/src/integrations/Athena.ts
@@ -36,6 +36,9 @@ export default class Athena extends SqlIntegration {
   formatDate(col: string): string {
     return `substr(to_iso8601(${col}),1,10)`;
   }
+  formatDateTimeString(col: string): string {
+    return `to_iso8601(${col})`;
+  }
   dateDiff(startCol: string, endCol: string) {
     return `date_diff('day', ${startCol}, ${endCol})`;
   }

--- a/packages/back-end/src/integrations/BigQuery.ts
+++ b/packages/back-end/src/integrations/BigQuery.ts
@@ -84,6 +84,9 @@ export default class BigQuery extends SqlIntegration {
   formatDate(col: string): string {
     return `format_date("%F", ${col})`;
   }
+  formatDateTimeString(col: string): string {
+    return `format_datetime("%F %T", ${col})`;
+  }
   castToString(col: string): string {
     return `cast(${col} as string)`;
   }

--- a/packages/back-end/src/integrations/ClickHouse.ts
+++ b/packages/back-end/src/integrations/ClickHouse.ts
@@ -83,6 +83,9 @@ export default class ClickHouse extends SqlIntegration {
   formatDate(col: string): string {
     return `formatDateTime(${col}, '%F')`;
   }
+  formatDateTimeString(col: string): string {
+    return `formatDateTime(${col}, '%Y-%m-%d %H:%i:%S.%f')`;
+  }
   ifElse(condition: string, ifTrue: string, ifFalse: string) {
     return `if(${condition}, ${ifTrue}, ${ifFalse})`;
   }

--- a/packages/back-end/src/integrations/Databricks.ts
+++ b/packages/back-end/src/integrations/Databricks.ts
@@ -36,6 +36,9 @@ export default class Databricks extends SqlIntegration {
   formatDate(col: string) {
     return `date_format(${col}, 'y-MM-dd')`;
   }
+  formatDateTimeString(col: string) {
+    return `date_format(${col}, 'y-MM-dd H:m:s.S')`;
+  }
   castToString(col: string): string {
     return `cast(${col} as string)`;
   }

--- a/packages/back-end/src/integrations/Mssql.ts
+++ b/packages/back-end/src/integrations/Mssql.ts
@@ -57,10 +57,7 @@ export default class Mssql extends SqlIntegration {
   castToString(col: string): string {
     return `cast(${col} as varchar(256))`;
   }
-  castDateToStandardString(col: string): string {
+  formatDateTimeString(col: string): string {
     return `CONVERT(VARCHAR(25), ${col}, 121)`;
-  }
-  replaceDateDimensionString(minDateDimString: string): string {
-    return `SUBSTRING(${minDateDimString}, 29, 99999)`;
   }
 }

--- a/packages/back-end/src/integrations/Mysql.ts
+++ b/packages/back-end/src/integrations/Mysql.ts
@@ -71,6 +71,9 @@ export default class Mysql extends SqlIntegration {
   formatDate(col: string): string {
     return `DATE_FORMAT(${col}, "%Y-%m-%d")`;
   }
+  formatDateTimeString(col: string): string {
+    return `DATE_FORMAT(${col}, "%Y-%m-%d %H:%i:%S")`;
+  }
   castToString(col: string): string {
     return `cast(${col} as char)`;
   }

--- a/packages/back-end/src/integrations/Postgres.ts
+++ b/packages/back-end/src/integrations/Postgres.ts
@@ -41,6 +41,9 @@ export default class Postgres extends SqlIntegration {
   formatDate(col: string) {
     return `to_char(${col}, 'YYYY-MM-DD')`;
   }
+  formatDateTimeString(col: string): string {
+    return `to_char(${col}, 'YYYY-MM-DD HH24:MI:SS.MS')`;
+  }
 
   async getInformationSchema(): Promise<InformationSchema[]> {
     const sql = `SELECT

--- a/packages/back-end/src/integrations/Presto.ts
+++ b/packages/back-end/src/integrations/Presto.ts
@@ -106,6 +106,9 @@ export default class Presto extends SqlIntegration {
   formatDate(col: string): string {
     return `substr(to_iso8601(${col}),1,10)`;
   }
+  formatDateTimeString(col: string): string {
+    return `to_iso8601(${col})`;
+  }
   dateDiff(startCol: string, endCol: string) {
     return `date_diff('day', ${startCol}, ${endCol})`;
   }

--- a/packages/back-end/src/integrations/Redshift.ts
+++ b/packages/back-end/src/integrations/Redshift.ts
@@ -28,6 +28,9 @@ export default class Redshift extends SqlIntegration {
   formatDate(col: string) {
     return `to_char(${col}, 'YYYY-MM-DD')`;
   }
+  formatDateTimeString(col: string) {
+    return `to_char(${col}, 'YYYY-MM-DD HH24:MI:SS.MS')`;
+  }
   ensureFloat(col: string): string {
     return `${col}::float`;
   }

--- a/packages/back-end/src/integrations/Snowflake.ts
+++ b/packages/back-end/src/integrations/Snowflake.ts
@@ -34,6 +34,9 @@ export default class Snowflake extends SqlIntegration {
   formatDate(col: string): string {
     return `TO_VARCHAR(${col}, 'YYYY-MM-DD')`;
   }
+  formatDateTimeString(col: string): string {
+    return `TO_VARCHAR(${col}, 'YYYY-MM-DD HH24:MI:SS.MS')`;
+  }
   castToString(col: string): string {
     return `TO_VARCHAR(${col})`;
   }

--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -166,8 +166,8 @@ export default abstract class SqlIntegration
   }
   replaceDateDimensionString(minDateDimString: string): string {
     return `REGEXP_REPLACE(${minDateDimString}, ${this.castToString(
-      ".*____"
-    )}, ${this.castToString("")})`;
+      "'.*____'"
+    )}, ${this.castToString("''")})`;
   }
 
   applyMetricOverrides(
@@ -670,9 +670,11 @@ export default abstract class SqlIntegration
         `MIN(
           CONCAT(
             CONCAT(${this.castDateToStandardString("e.timestamp")}, 
-            ${this.castToString("____")}
+            ${this.castToString("'____'")}
             ), 
-            coalesce(${this.castToString("e.dimension")},'${missingDimString}')
+            coalesce(${this.castToString("e.dimension")}, ${this.castToString(
+          `'${missingDimString}'`
+        )})
           )
         )`
       );

--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -161,13 +161,8 @@ export default abstract class SqlIntegration
   useAliasInGroupBy(): boolean {
     return true;
   }
-  castDateToStandardString(col: string): string {
+  formatDateTimeString(col: string): string {
     return this.castToString(col);
-  }
-  replaceDateDimensionString(minDateDimString: string): string {
-    return `REGEXP_REPLACE(${minDateDimString}, ${this.castToString(
-      "'.*____'"
-    )}, ${this.castToString("''")})`;
   }
 
   applyMetricOverrides(
@@ -666,18 +661,17 @@ export default abstract class SqlIntegration
     } else if (dimension.type === "date") {
       return `MIN(${this.formatDate(this.dateTrunc("e.timestamp"))})`;
     } else if (dimension.type === "experiment") {
-      return this.replaceDateDimensionString(
-        `MIN(
-          CONCAT(
-            CONCAT(${this.castDateToStandardString("e.timestamp")}, 
-            ${this.castToString("'____'")}
-            ), 
+      return `SUBSTRING(
+        MIN(
+          CONCAT(SUBSTRING(${this.formatDateTimeString("e.timestamp")}, 1, 19), 
             coalesce(${this.castToString("e.dimension")}, ${this.castToString(
-          `'${missingDimString}'`
-        )})
+        `'${missingDimString}'`
+      )})
           )
-        )`
-      );
+        ),
+        20, 
+        99999
+      )`;
     }
 
     throw new Error("Unknown dimension type: " + (dimension as Dimension).type);

--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -165,7 +165,9 @@ export default abstract class SqlIntegration
     return this.castToString(col);
   }
   replaceDateDimensionString(minDateDimString: string): string {
-    return `REGEXP_REPLACE(${minDateDimString}, '.*____', '')`;
+    return `REGEXP_REPLACE(${minDateDimString}, ${this.castToString(
+      ".*____"
+    )}, ${this.castToString("")})`;
   }
 
   applyMetricOverrides(
@@ -665,11 +667,14 @@ export default abstract class SqlIntegration
       return `MIN(${this.formatDate(this.dateTrunc("e.timestamp"))})`;
     } else if (dimension.type === "experiment") {
       return this.replaceDateDimensionString(
-        `MIN(CONCAT(${this.castDateToStandardString(
-          "e.timestamp"
-        )}, '____', coalesce(${this.castToString(
-          "e.dimension"
-        )},'${missingDimString}')))`
+        `MIN(
+          CONCAT(
+            CONCAT(${this.castDateToStandardString("e.timestamp")}, 
+            ${this.castToString("____")}
+            ), 
+            coalesce(${this.castToString("e.dimension")},'${missingDimString}')
+          )
+        )`
       );
     }
 


### PR DESCRIPTION
### Features and Changes

* Fixes issue with literal strings in one dimension handling method for Redshift
* Does so by moving all engines to substr approach. I first cast the timestamp to string, trying to keep milliseconds (but not always keeping them) and then *forcibly* truncating to just the first 19 characters, which should give us down to the second on all engines, and then uses that to sort.

### Dependencies

n/a

### Testing

- [x] Test other queries unchanged
- [x] Test redshift query in sandbox
- [x] Test mssql query in sandbox

### Screenshots

n/a