### PR TITLE
Fix bug - experiment results not refreshing when dimension selected

### DIFF
--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -1637,6 +1637,7 @@ export async function postSnapshot(
       user: res.locals.eventAudit,
       phaseIndex: phase,
       useCache,
+      dimension,
       experimentSnapshotSettings,
     });
 


### PR DESCRIPTION
### Features and Changes

When a dimension is selected on experiment results, the "Update Data" button continues to refresh the overall "no-dimension" view instead of the selected dimension.

Bug introduced in #1155 when refactoring the code for snapshot updates.