### PR TITLE
Removed "date" field requirement from Dimension sql validator method

### DIFF
--- a/packages/front-end/components/Dimensions/DimensionForm.tsx
+++ b/packages/front-end/components/Dimensions/DimensionForm.tsx
@@ -68,7 +68,7 @@ const DimensionForm: FC<{
         header={current.id ? "Edit Dimension" : "New Dimension"}
         submit={form.handleSubmit(async (value) => {
           if (supportsSQL) {
-            validateSQL(value.sql, [value.userIdType, "date"]);
+            validateSQL(value.sql, [value.userIdType, "value"]);
           }
 
           await apiCall(


### PR DESCRIPTION
### Features and Changes

Per the original ticket (Linked Below):

"When editing or creating a dimension from the dimensions page, the SQL editor will tell you date is required when saving, but not tell you it's required before that point."

![](https://user-images.githubusercontent.com/46107/231434293-d2fa82a4-9166-49d5-89dd-aa4e41f682c8.png)
![](https://user-images.githubusercontent.com/46107/231434304-fc56f9fb-1f1d-4e5d-8d59-6e8ab3d3a0ba.png)

When reviewing this further, it appears that we were adding `"date"` to the `validateSql` call when the `DimensionForm` was being submitted, but this appears to have been added in error. This was added in [this PR](https://github.com/growthbook/growthbook/pull/1095/files#diff-53eb633551abb289d7a226190aa868c144cf2fd4a57d887b1abb6a161515157f) and was likely a result of a copy/paste from an existing implementation.

I have reverted the `validateSql` props back to what they were before, and tested that you're able to build a dimension without including a date field.

- Closes **(https://github.com/growthbook/growthbook/issues/1171)**

### Testing

- [x] Build a new dimension without a date field, only a `user_id` field and a `value` field, and ensure you are able to save it as expected, without getting the error.
