### PR TITLE
React SDK - Bump @growthbook/growthbook version

### DIFF
--- a/packages/sdk-react/package.json
+++ b/packages/sdk-react/package.json
@@ -36,7 +36,7 @@
     "react": "^16.8.0-0 || ^17.0.0-0 || ^18.0.0-0"
   },
   "dependencies": {
-    "@growthbook/growthbook": "^0.25.0"
+    "@growthbook/growthbook": "^0.26.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.19.3",


### PR DESCRIPTION
Bump `@growthbook/growthbook` version to `^0.26.0`

[GB-165](https://linear.app/growthbook/issue/GB-165/update-react-and-js-sdks-for-new-dom-mutator-version)