### PR TITLE
Add minimum Node version requirement for the CLI

### DIFF
--- a/docs/docs/tools/cli.mdx
+++ b/docs/docs/tools/cli.mdx
@@ -9,6 +9,8 @@ import ExternalLink from '@site/src/components/ExternalLink'
 
 The GrowthBook command-line interface (CLI) is a tool for working with the GrowthBook A/B testing, feature flagging, and experimentation platform.
 
+Requires Node.js version 16+.
+
 :::success New
 
 The GrowthBook CLI is a brand new tool. If you experience any issues, let us know either on [Slack](https://slack.growthbook.io/) or [create an issue](https://github.com/growthbook/growthbook-cli/issues).


### PR DESCRIPTION
Updates the docs to reflect the minimum Node version dependency based on [this report](https://github.com/growthbook/growthbook-cli/issues/28). 