### PR TITLE
Remove use of Pino child loggers (fixes experiment refresh bug)

### DIFF
--- a/packages/back-end/src/jobs/updateScheduledFeatures.ts
+++ b/packages/back-end/src/jobs/updateScheduledFeatures.ts
@@ -6,7 +6,7 @@ import {
 } from "../models/FeatureModel";
 import { getNextScheduledUpdate } from "../services/features";
 import { getOrganizationById } from "../services/organizations";
-import { childLogger } from "../util/logger";
+import { logger } from "../util/logger";
 
 type UpdateSingleFeatureJob = Job<{
   featureId: string;
@@ -66,11 +66,6 @@ async function updateSingleFeature(job: UpdateSingleFeatureJob) {
   const organization = job.attrs.data?.organization;
   if (!featureId) return;
 
-  const log = childLogger({
-    cron: "updateSingleFeature",
-    featureId,
-  });
-
   const org = await getOrganizationById(organization);
   if (!org) return;
 
@@ -88,6 +83,6 @@ async function updateSingleFeature(job: UpdateSingleFeatureJob) {
       nextScheduledUpdate: nextScheduledUpdate,
     });
   } catch (e) {
-    log.error("Failure - " + e.message);
+    logger.error(e, "Failed updating feature " + featureId);
   }
 }

--- a/packages/back-end/src/util/logger.ts
+++ b/packages/back-end/src/util/logger.ts
@@ -85,8 +85,3 @@ export const logger: BaseLogger = {
     httpLogger.logger.warn(...args);
   },
 };
-
-/**
- * pino's logger.child function
- */
-export const childLogger = httpLogger.logger.child;


### PR DESCRIPTION
### Features and Changes

Using Pino child loggers was causing experiment refreshes to fail for the past 2 weeks.  This switches to using the normal logging method instead.