### PR TITLE
Updates the plop rest api generator to deprecate the put endpoint and…

### DIFF
--- a/plop-templates/back-end/api/delete.hbs
+++ b/plop-templates/back-end/api/delete.hbs
@@ -1,0 +1,24 @@
+import { Delete{{pascalCase object}}Response } from "../../../types/openapi";
+import {
+  delete{{pascalCase object}},
+  to{{pascalCase object}}ApiInterface
+} from "../../models/{{pascalCase object}}Model";
+import { createApiRequestHandler } from "../../util/handler";
+import { delete{{pascalCase object}}Validator } from "../../validators/openapi";
+
+export const delete{{pascalCase object}} = createApiRequestHandler(delete{{pascalCase object}}Validator)(
+  async (req): Promise<Delete{{pascalCase object}}Response> => {
+    const {{camelCase object}} = await find{{pascalCase object}}ById(
+      req.params.id,
+      req.organization.id
+    );
+    if (!{{camelCase object}}) {
+      throw new Error("Unable to delete - Could not find {{camelCase object}} with that id");
+    }
+    const {{camelCase object}} = await delete{{pascalCase object}}(/* */);
+
+    return {
+      deletedId: req.params.id,
+    };
+  }
+);

--- a/plop-templates/back-end/api/openapi_delete.hbs
+++ b/plop-templates/back-end/api/openapi_delete.hbs
@@ -1,0 +1,24 @@
+parameters:
+  - $ref: "../parameters.yaml#/id"
+tags:
+  - {{kebabCase object}}s
+summary: Deletes a single {{object}}
+operationId: get{{pascalCase object}}
+x-codeSamples:
+  - lang: 'cURL'
+    source: |
+      curl -X DELETE https://api.growthbook.io/api/v1/{{kebabCase object}}s/ds_123abc \
+        -u secret_abc123DEF456:
+responses:
+  "200":
+    content:
+      application/json:
+        schema:
+          type: object
+          required:
+            - {{camelCase object}}
+          properties:
+            deletedId:
+              type: string
+              description: The ID of the deleted {{object}}
+              example: ds_123abc

--- a/plop-templates/back-end/api/openapi_update.hbs
+++ b/plop-templates/back-end/api/openapi_update.hbs
@@ -7,7 +7,7 @@ operationId: post{{pascalCase object}}
 x-codeSamples:
   - lang: 'cURL'
     source: |
-      curl -X PUT https://api.growthbook.io/api/v1/{{kebabCase object}}s \
+      curl -X POST https://api.growthbook.io/api/v1/{{kebabCase object}}s \
         -d '{}' # TODO: Example JSON
         -u secret_abc123DEF456:
 requestBody:

--- a/plop-templates/back-end/api/router.hbs
+++ b/plop-templates/back-end/api/router.hbs
@@ -2,7 +2,7 @@ import { Router } from "express";
 import { get{{pascalCase object}} } from "./get{{pascalCase object}}";
 import { list{{pascalCase object}}s } from "./list{{pascalCase object}}s";
 import { post{{pascalCase object}} } from "./post{{pascalCase object}}";
-import { put{{pascalCase object}} } from "./put{{pascalCase object}}";
+import { update{{pascalCase object}} } from "./update{{pascalCase object}}";
 
 const router = Router();
 
@@ -10,7 +10,7 @@ const router = Router();
 // Mounted at /api/v1/{{kebabCase object}}s
 router.get("/", list{{pascalCase object}}s);
 router.get("/:id", get{{pascalCase object}});
-router.put("/:id", put{{pascalCase object}});
+router.post("/:id", update{{pascalCase object}});
 router.post("/", post{{pascalCase object}});
 
 export default router;

--- a/plop-templates/back-end/api/router.hbs
+++ b/plop-templates/back-end/api/router.hbs
@@ -3,14 +3,16 @@ import { get{{pascalCase object}} } from "./get{{pascalCase object}}";
 import { list{{pascalCase object}}s } from "./list{{pascalCase object}}s";
 import { post{{pascalCase object}} } from "./post{{pascalCase object}}";
 import { update{{pascalCase object}} } from "./update{{pascalCase object}}";
+import { delete{{pascalCase object}} } from "./delete{{pascalCase object}}";
 
 const router = Router();
 
 // {{pascalCase object}} Endpoints
 // Mounted at /api/v1/{{kebabCase object}}s
 router.get("/", list{{pascalCase object}}s);
+router.post("/", post{{pascalCase object}});
 router.get("/:id", get{{pascalCase object}});
 router.post("/:id", update{{pascalCase object}});
-router.post("/", post{{pascalCase object}});
+router.delete("/:id", delete{{pascalCase object}});
 
 export default router;

--- a/plop-templates/back-end/api/update.hbs
+++ b/plop-templates/back-end/api/update.hbs
@@ -1,14 +1,14 @@
 import { Put{{pascalCase object}}Response } from "../../../types/openapi";
 import {
-  put{{pascalCase object}},
+  update{{pascalCase object}},
   to{{pascalCase object}}ApiInterface
 } from "../../models/{{pascalCase object}}Model";
 import { createApiRequestHandler } from "../../util/handler";
-import { put{{pascalCase object}}Validator } from "../../validators/openapi";
+import { update{{pascalCase object}}Validator } from "../../validators/openapi";
 
-export const put{{pascalCase object}} = createApiRequestHandler(put{{pascalCase object}}Validator)(
+export const update{{pascalCase object}} = createApiRequestHandler(update{{pascalCase object}}Validator)(
   async (req): Promise<Put{{pascalCase object}}Response> => {
-    const {{camelCase object}} = await put{{pascalCase object}}(/* */);
+    const {{camelCase object}} = await update{{pascalCase object}}(/* */);
 
     return {
       {{camelCase object}}: to{{pascalCase object}}ApiInterface({{camelCase object}}),

--- a/plopfile.js
+++ b/plopfile.js
@@ -103,8 +103,8 @@ module.exports = function (plop) {
         type: "add",
         skipIfExists: true,
         path:
-          "./packages/back-end/src/api/{{kebabCase object}}s/put{{pascalCase object}}.ts",
-        templateFile: "./plop-templates/back-end/api/put.hbs",
+          "./packages/back-end/src/api/{{kebabCase object}}s/update{{pascalCase object}}.ts",
+        templateFile: "./plop-templates/back-end/api/update.hbs",
       },
       {
         type: "add",
@@ -131,8 +131,8 @@ module.exports = function (plop) {
         type: "add",
         skipIfExists: true,
         path:
-          "./packages/back-end/src/api/openapi/paths/put{{pascalCase object}}.yaml",
-        templateFile: "./plop-templates/back-end/api/openapi_put.hbs",
+          "./packages/back-end/src/api/openapi/paths/update{{pascalCase object}}.yaml",
+        templateFile: "./plop-templates/back-end/api/openapi_update.hbs",
       },
       {
         type: "add",
@@ -161,8 +161,8 @@ module.exports = function (plop) {
   /{{kebabCase object}}s/{id}:
     get:
       $ref: "./paths/get{{pascalCase object}}.yaml"
-    put:
-      $ref: "./paths/put{{pascalCase object}}.yaml"`,
+    post:
+      $ref: "./paths/update{{pascalCase object}}.yaml"`,
       },
     ],
   });

--- a/plopfile.js
+++ b/plopfile.js
@@ -110,6 +110,13 @@ module.exports = function (plop) {
         type: "add",
         skipIfExists: true,
         path:
+          "./packages/back-end/src/api/{{kebabCase object}}s/delete{{pascalCase object}}.ts",
+        templateFile: "./plop-templates/back-end/api/delete.hbs",
+      },
+      {
+        type: "add",
+        skipIfExists: true,
+        path:
           "./packages/back-end/src/api/openapi/schemas/{{pascalCase object}}.yaml",
         templateFile: "./plop-templates/back-end/api/openapi_model.hbs",
       },
@@ -142,6 +149,13 @@ module.exports = function (plop) {
         templateFile: "./plop-templates/back-end/api/openapi_get.hbs",
       },
       {
+        type: "add",
+        skipIfExists: true,
+        path:
+          "./packages/back-end/src/api/openapi/paths/delete{{pascalCase object}}.yaml",
+        templateFile: "./plop-templates/back-end/api/openapi_delete.hbs",
+      },
+      {
         type: "append",
         path: "./packages/back-end/src/api/openapi/schemas/_index.yaml",
         template: `
@@ -162,7 +176,9 @@ module.exports = function (plop) {
     get:
       $ref: "./paths/get{{pascalCase object}}.yaml"
     post:
-      $ref: "./paths/update{{pascalCase object}}.yaml"`,
+      $ref: "./paths/update{{pascalCase object}}.yaml"
+    delete:
+      $ref: "./paths/delete{{pascalCase object}}.yaml"`,
       },
     ],
   });


### PR DESCRIPTION
### Features and Changes

Based on the recent conversation, we are going to update the plop Rest API templates and deprecate the `put` request type in leu of a `post` request to handle partial updates. This pattern exists and is used by Twillio and Stripe, both of which have very popular REST API's.

Additionally, this PR adds support for a `delete` endpoint for every new resource. 

### Testing

<!--
  Please describe how to test these changes.
 -->

