### PR TITLE
Docs: Ruby SDK – Decryption

### DIFF
--- a/docs/docs/lib/ruby.mdx
+++ b/docs/docs/lib/ruby.mdx
@@ -157,6 +157,41 @@ gb.run(Growthbook::InlineExperiment.new(
 ))
 ```
 
+## Working with Encrypted features
+
+You can learn more about [SDK Connection Endpoint Encryption](/app/api#encryption).
+
+Create a `GrowthBook::Context` with an encrypted payload and an encryption key:
+
+```rb
+# TODO: Replace these values with your own:
+Growthbook::Context.new(
+  encrypted_features: 'm5ylFM6ndyOJA2OPadubkw==.Uu7ViqgKEt/dWvCyhI46q088PkAEJbnXKf3KPZjf9IEQQ+A8fojNoxw4wIbPX3aj',
+  encryption_key: 'Zvwv/+uhpFDznZ6SX28Yjg==',
+  attributes: {
+    id: '456',
+    country: 'CA'
+  }
+)
+```
+
+When fetching features from the GrowthBook SDK endpoint, the encrypted features are available on a property `encryptedFeatures` instead of plain text on the property `features`. Here's an example with networking:
+
+```rb
+uri = URI('https://cdn.growthbook.io/api/features/MY_API_KEY')
+res = Net::HTTP.get_response(uri)
+encrypted_features = res.is_a?(Net::HTTPSuccess) ? JSON.parse(res.body)['encryptedFeatures'] : nil
+
+Growthbook::Context.new(
+  encrypted_features: encrypted_features,
+  encryption_key: '<key-for-decrypting>',
+  attributes: {
+    id: '456',
+    country: 'CA'
+  }
+)
+```
+
 ## Code Examples
 
 - [Ruby on Rails example <ExternalLink />](https://github.com/growthbook/examples/tree/main/acme_donuts_rails)

--- a/docs/docs/lib/ruby.mdx
+++ b/docs/docs/lib/ruby.mdx
@@ -161,13 +161,13 @@ gb.run(Growthbook::InlineExperiment.new(
 
 You can learn more about [SDK Connection Endpoint Encryption](/app/api#encryption).
 
-Create a `GrowthBook::Context` with an encrypted payload and an encryption key:
+Create a `GrowthBook::Context` with an encrypted payload and a decryption key:
 
 ```rb
 # TODO: Replace these values with your own:
 Growthbook::Context.new(
   encrypted_features: 'm5ylFM6ndyOJA2OPadubkw==.Uu7ViqgKEt/dWvCyhI46q088PkAEJbnXKf3KPZjf9IEQQ+A8fojNoxw4wIbPX3aj',
-  encryption_key: 'Zvwv/+uhpFDznZ6SX28Yjg==',
+  decryption_key: 'Zvwv/+uhpFDznZ6SX28Yjg==',
   attributes: {
     id: '456',
     country: 'CA'
@@ -184,7 +184,7 @@ encrypted_features = res.is_a?(Net::HTTPSuccess) ? JSON.parse(res.body)['encrypt
 
 Growthbook::Context.new(
   encrypted_features: encrypted_features,
-  encryption_key: '<key-for-decrypting>',
+  decryption_key: '<key-for-decrypting>',
   attributes: {
     id: '456',
     country: 'CA'


### PR DESCRIPTION
Adds documentation for encrypted features support in the Ruby SDK docs.

## Dependencies

### Hard dependencies

These must be done before merging this PR:

- [x] Merge https://github.com/growthbook/growthbook-ruby/pull/16
- [ ] Deploy a new version of the SDK


### Soft dependencies

Ideally these are done to validate in a real example that these changes work:

- [ ] Add decryption example to the Rails example