### PR TITLE
Fix organization message list layout on larger resolution

### DIFF
--- a/packages/front-end/components/OrganizationMessages/OrganizationMessages.tsx
+++ b/packages/front-end/components/OrganizationMessages/OrganizationMessages.tsx
@@ -26,7 +26,7 @@ export const OrganizationMessages: FC<OrganizationMessagesProps> = ({
   }
 
   return (
-    <div className="contents pagecontents mb-3">
+    <div className="contents pagecontents container mb-3">
       {renderedMessages.map((orgMessage) => (
         <div
           key={md5(orgMessage.message)}


### PR DESCRIPTION
Fixes the centring of the organization messages.

<img width="2495" alt="image" src="https://user-images.githubusercontent.com/113377031/234993383-ca0f0117-50cd-4559-9f0f-7a10d75e1fd3.png">
