### PR TITLE
Only deploy PR preview environments when code changes

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,8 +1,15 @@
-# file: .github/workflows/preview.yaml
+name: PR Preview Environment
+
 on:
   pull_request:
     branches:
       - main
+    paths:
+      - "packages/**"
+      - "!**.md"
+      - "yarn.lock"
+      - "Dockerfile"
+      - ".dockerignore"
 
 jobs:
   preview:


### PR DESCRIPTION
### Features and Changes

Skip deploying a PR preview environment on Okteto if code doesn't change - for example a documentation-only PR.

Uses the same file filter as the production deploy workflow.

Fixes #1207 
