### PR TITLE
Frontend TS - Enabled `strictNullChecks`; Add @ts-expect-errors everywhere

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -83,12 +83,13 @@
     "react/prop-types": "off",
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",
-   "import/order": [
-     "error",
-     {
-       "groups": ["builtin", "external", "internal", "parent", "sibling", "index", "unknown"]
-     }
-   ]
+    "import/order": [
+      "error",
+      {
+        "groups": ["builtin", "external", "internal", "parent", "sibling", "index", "unknown"]
+      }
+    ],
+    "@typescript-eslint/prefer-ts-expect-error": "error"
   },
   "overrides": [
     {

--- a/packages/back-end/src/integrations/Athena.ts
+++ b/packages/back-end/src/integrations/Athena.ts
@@ -13,7 +13,7 @@ import SqlIntegration from "./SqlIntegration";
 
 export default class Athena extends SqlIntegration {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
+  // @ts-expect-error
   params: AthenaConnectionParams;
   setParams(encryptedParams: string) {
     this.params = decryptDataSourceParams<AthenaConnectionParams>(

--- a/packages/back-end/src/integrations/BigQuery.ts
+++ b/packages/back-end/src/integrations/BigQuery.ts
@@ -14,7 +14,7 @@ import SqlIntegration from "./SqlIntegration";
 
 export default class BigQuery extends SqlIntegration {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
+  // @ts-expect-error
   params: BigQueryConnectionParams;
   setParams(encryptedParams: string) {
     this.params = decryptDataSourceParams<BigQueryConnectionParams>(

--- a/packages/back-end/src/integrations/ClickHouse.ts
+++ b/packages/back-end/src/integrations/ClickHouse.ts
@@ -8,7 +8,7 @@ import SqlIntegration from "./SqlIntegration";
 
 export default class ClickHouse extends SqlIntegration {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
+  // @ts-expect-error
   params: ClickHouseConnectionParams;
   setParams(encryptedParams: string) {
     this.params = decryptDataSourceParams<ClickHouseConnectionParams>(

--- a/packages/back-end/src/integrations/GoogleAnalytics.ts
+++ b/packages/back-end/src/integrations/GoogleAnalytics.ts
@@ -51,14 +51,14 @@ const GoogleAnalytics: SourceIntegrationConstructor = class
   implements SourceIntegrationInterface {
   params: GoogleAnalyticsParams;
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
+  // @ts-expect-error
   datasource: string;
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
+  // @ts-expect-error
   organization: string;
   settings: DataSourceSettings;
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
+  // @ts-expect-error
   decryptionError: boolean;
 
   constructor(encryptedParams: string) {

--- a/packages/back-end/src/integrations/Mixpanel.ts
+++ b/packages/back-end/src/integrations/Mixpanel.ts
@@ -27,15 +27,15 @@ import { replaceSQLVars } from "../util/sql";
 
 export default class Mixpanel implements SourceIntegrationInterface {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
+  // @ts-expect-error
   datasource: string;
   params: MixpanelConnectionParams;
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
+  // @ts-expect-error
   organization: string;
   settings: DataSourceSettings;
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
+  // @ts-expect-error
   decryptionError: boolean;
   constructor(encryptedParams: string, settings: DataSourceSettings) {
     try {

--- a/packages/back-end/src/integrations/Mssql.ts
+++ b/packages/back-end/src/integrations/Mssql.ts
@@ -12,7 +12,7 @@ import SqlIntegration from "./SqlIntegration";
 
 export default class Mssql extends SqlIntegration {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
+  // @ts-expect-error
   params: MssqlConnectionParams;
   setParams(encryptedParams: string) {
     this.params = decryptDataSourceParams<MssqlConnectionParams>(

--- a/packages/back-end/src/integrations/Mysql.ts
+++ b/packages/back-end/src/integrations/Mysql.ts
@@ -10,7 +10,7 @@ import SqlIntegration from "./SqlIntegration";
 
 export default class Mysql extends SqlIntegration {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
+  // @ts-expect-error
   params: MysqlConnectionParams;
   setParams(encryptedParams: string) {
     this.params = decryptDataSourceParams<MysqlConnectionParams>(

--- a/packages/back-end/src/integrations/Presto.ts
+++ b/packages/back-end/src/integrations/Presto.ts
@@ -17,7 +17,7 @@ type Row = any;
 
 export default class Presto extends SqlIntegration {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
+  // @ts-expect-error
   params: PrestoConnectionParams;
   setParams(encryptedParams: string) {
     this.params = decryptDataSourceParams<PrestoConnectionParams>(

--- a/packages/back-end/src/integrations/Redshift.ts
+++ b/packages/back-end/src/integrations/Redshift.ts
@@ -9,7 +9,7 @@ import SqlIntegration from "./SqlIntegration";
 
 export default class Redshift extends SqlIntegration {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
+  // @ts-expect-error
   params: PostgresConnectionParams;
   setParams(encryptedParams: string) {
     this.params = decryptDataSourceParams<PostgresConnectionParams>(

--- a/packages/back-end/src/integrations/Snowflake.ts
+++ b/packages/back-end/src/integrations/Snowflake.ts
@@ -9,7 +9,7 @@ import SqlIntegration from "./SqlIntegration";
 
 export default class Snowflake extends SqlIntegration {
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
+  // @ts-expect-error
   params: SnowflakeConnectionParams;
   setParams(encryptedParams: string) {
     this.params = decryptDataSourceParams<SnowflakeConnectionParams>(

--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -39,13 +39,13 @@ export default abstract class SqlIntegration
   implements SourceIntegrationInterface {
   settings: DataSourceSettings;
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
+  // @ts-expect-error
   datasource: string;
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
+  // @ts-expect-error
   organization: string;
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
+  // @ts-expect-error
   decryptionError: boolean;
   // eslint-disable-next-line
   params: any;

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -664,13 +664,11 @@ export async function toExperimentApiInterface(
   if (experiment.project) {
     project = await findProjectById(experiment.project, organization.id);
   }
-  const { settings: scopedSettings } = getScopedSettings(
-    {
-      organization,
-      project: project ?? undefined,
-      // todo: experiment settings
-    }
-  );
+  const { settings: scopedSettings } = getScopedSettings({
+    organization,
+    project: project ?? undefined,
+    // todo: experiment settings
+  });
 
   const activationMetric = experiment.activationMetric;
   return {

--- a/packages/back-end/src/services/queueing.ts
+++ b/packages/back-end/src/services/queueing.ts
@@ -7,7 +7,7 @@ export const getAgendaInstance = (): Agenda => {
   if (!agendaInstance) {
     const config: AgendaConfig = {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore - For some reason the Mongoose MongoDB instance does not match (missing 5 properties)
+      // @ts-expect-error - For some reason the Mongoose MongoDB instance does not match (missing 5 properties)
       mongo: mongoose.connection.db,
       defaultLockLimit: 5,
     };

--- a/packages/front-end/components/Auth/InitialOrgSettings.tsx
+++ b/packages/front-end/components/Auth/InitialOrgSettings.tsx
@@ -59,9 +59,11 @@ export default function InitialOrgSettings(): ReactElement {
     const datas = [...value.datasource];
     const techs = [...value.techstack];
     if (value.dataother) {
+      // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string' is not assignable to par... Remove this comment to see the full error message
       datas.push(value.dataother.trim());
     }
     if (value.techother) {
+      // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string' is not assignable to par... Remove this comment to see the full error message
       techs.push(value.techother.trim());
     }
 

--- a/packages/front-end/components/Auth/Welcome.tsx
+++ b/packages/front-end/components/Auth/Welcome.tsx
@@ -127,6 +127,7 @@ export default function Welcome({
             setError(null);
             setLoading(true);
             try {
+              // @ts-expect-error TS(2722) If you come across this, please fix it!: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
               await submit();
               setLoading(false);
             } catch (e) {

--- a/packages/front-end/components/Button.tsx
+++ b/packages/front-end/components/Button.tsx
@@ -48,6 +48,7 @@ const Button: FC<Props> = ({
           e.preventDefault();
           if (loading) return;
           setLoading(true);
+          // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'null' is not assignable to param... Remove this comment to see the full error message
           setError(null);
 
           try {

--- a/packages/front-end/components/Carousel.tsx
+++ b/packages/front-end/components/Carousel.tsx
@@ -25,6 +25,7 @@ const Carousel: FC<{
   if (modalOpen) {
     const orig = Children.toArray(children)[current];
     if (orig && isValidElement(orig)) {
+      // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'ReactElement<any, string | JSXElementConstru... Remove this comment to see the full error message
       currentChild = cloneElement(orig, {
         style: { ...orig.props.style, height: "100%" },
       });

--- a/packages/front-end/components/CommentForm.tsx
+++ b/packages/front-end/components/CommentForm.tsx
@@ -60,6 +60,7 @@ const CommentForm: FC<{
         autofocus={autofocus}
         cta={cta}
         onCancel={onCancel}
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'null' is not assignable to type 'string | un... Remove this comment to see the full error message
         error={formError}
       />
     </form>

--- a/packages/front-end/components/CopyToClipboard.tsx
+++ b/packages/front-end/components/CopyToClipboard.tsx
@@ -65,6 +65,7 @@ const CopyToClipboard: FC<{
             <button
               className="btn btn-secondary"
               onClick={(e) => {
+                // @ts-expect-error TS(2531) If you come across this, please fix it!: Object is possibly 'null'.
                 ref.current.select();
                 document.execCommand("copy");
                 (e.target as HTMLButtonElement).focus();

--- a/packages/front-end/components/Dimensions/DimensionChooser.tsx
+++ b/packages/front-end/components/Dimensions/DimensionChooser.tsx
@@ -25,6 +25,7 @@ export default function DimensionChooser({
   showHelp,
 }: Props) {
   const { dimensions, getDatasourceById } = useDefinitions();
+  // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
   const datasource = getDatasourceById(datasourceId);
 
   // If activation metric is not selected, don't allow using that dimension
@@ -66,7 +67,9 @@ export default function DimensionChooser({
     }
   }
   // Legacy data sources - add experiment dimensions
+  // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
   else if (datasource.settings?.experimentDimensions?.length > 0) {
+    // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
     datasource.settings.experimentDimensions.forEach((d) => {
       filteredDimensions.push({
         label: d,

--- a/packages/front-end/components/Dimensions/DimensionForm.tsx
+++ b/packages/front-end/components/Dimensions/DimensionForm.tsx
@@ -106,6 +106,7 @@ const DimensionForm: FC<{
             required
             value={userIdType}
             onChange={(v) => form.setValue("userIdType", v)}
+            // @ts-expect-error TS(2531) If you come across this, please fix it!: Object is possibly 'null'.
             options={(dsObj.settings.userIdTypes || []).map((t) => {
               return {
                 label: t.userIdType,

--- a/packages/front-end/components/DiscussionThread.tsx
+++ b/packages/front-end/components/DiscussionThread.tsx
@@ -95,6 +95,7 @@ const DiscussionThread: FC<{
                               href="#"
                               onClick={(e) => {
                                 e.preventDefault();
+                                // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'number' is not assignable to par... Remove this comment to see the full error message
                                 setEdit(i);
                               }}
                             >

--- a/packages/front-end/components/Dropdown/Dropdown.tsx
+++ b/packages/front-end/components/Dropdown/Dropdown.tsx
@@ -42,6 +42,7 @@ const Dropdown: FC<{
     setOpen = _setOpen;
   }
 
+  // @ts-expect-error TS(2722) If you come across this, please fix it!: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
   useGlobalMenu(`.${uuid}`, () => setOpen(false));
 
   const content = Children.map(children, (child) => {
@@ -51,6 +52,7 @@ const Dropdown: FC<{
       return cloneElement(child, {
         onClick: () => {
           child.props.onClick();
+          // @ts-expect-error TS(2722) If you come across this, please fix it!: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
           setOpen(false);
         },
       });
@@ -69,6 +71,7 @@ const Dropdown: FC<{
         className={clsx({ "dropdown-toggle": caret })}
         onClick={(e) => {
           e.preventDefault();
+          // @ts-expect-error TS(2722) If you come across this, please fix it!: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
           setOpen(!open);
         }}
         style={{ cursor: "pointer" }}

--- a/packages/front-end/components/EventWebHooks/EventWebHookAddEditModal/EventWebHookAddEditModal.tsx
+++ b/packages/front-end/components/EventWebHooks/EventWebHookAddEditModal/EventWebHookAddEditModal.tsx
@@ -71,6 +71,7 @@ export const EventWebHookAddEditModal: FC<EventWebHookAddEditModalProps> = ({
       close={onClose}
       open={isOpen}
       submit={handleSubmit}
+      // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | null' is not assignable to type 'st... Remove this comment to see the full error message
       error={error}
       ctaEnabled={ctaEnabled}
     >

--- a/packages/front-end/components/EventWebHooks/EventWebHookDetail/EventWebHookDetail.stories.tsx
+++ b/packages/front-end/components/EventWebHooks/EventWebHookDetail/EventWebHookDetail.stories.tsx
@@ -117,17 +117,17 @@ export const LotsOfEvents = () => {
     "feature.created",
     "feature.updated",
     "feature.deleted",
-    // @ts-ignore
+    // @ts-expect-error
     "experiment.created",
-    // @ts-ignore
+    // @ts-expect-error
     "experiment.updated",
-    // @ts-ignore
+    // @ts-expect-error
     "experiment.deleted",
-    // @ts-ignore
+    // @ts-expect-error
     "another_resource.created",
-    // @ts-ignore
+    // @ts-expect-error
     "another_resource.updated",
-    // @ts-ignore
+    // @ts-expect-error
     "another_resource.deleted",
   ];
 

--- a/packages/front-end/components/EventWebHooks/EventWebHookDetail/EventWebHookDetail.stories.tsx
+++ b/packages/front-end/components/EventWebHooks/EventWebHookDetail/EventWebHookDetail.stories.tsx
@@ -117,11 +117,8 @@ export const LotsOfEvents = () => {
     "feature.created",
     "feature.updated",
     "feature.deleted",
-    // @ts-expect-error
     "experiment.created",
-    // @ts-expect-error
     "experiment.updated",
-    // @ts-expect-error
     "experiment.deleted",
     // @ts-expect-error
     "another_resource.created",

--- a/packages/front-end/components/EventWebHooks/EventWebHookDetail/EventWebHookDetail.stories.tsx
+++ b/packages/front-end/components/EventWebHooks/EventWebHookDetail/EventWebHookDetail.stories.tsx
@@ -51,6 +51,7 @@ const eventWebHookNoState: EventWebHookInterface = {
   enabled: false,
   url: "http://192.168.0.15:1115/events/webhooks?v=4",
   signingKey: "ewhk_6220c5592f03244c43a929850816d644",
+  // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'null' is not assignable to type 'Date'.
   lastRunAt: null,
   lastState: "none",
   lastResponseBody: null,

--- a/packages/front-end/components/EventWebHooks/EventWebHookList/EventWebHookList.stories.tsx
+++ b/packages/front-end/components/EventWebHooks/EventWebHookList/EventWebHookList.stories.tsx
@@ -47,6 +47,7 @@ export const Default = () => {
       enabled: false,
       url: "http://192.168.0.15:1115/events/webhooks?v=4",
       signingKey: "ewhk_6220c5592f03244c43a929850816d644",
+      // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'null' is not assignable to type 'Date'.
       lastRunAt: null,
       lastState: "none",
       lastResponseBody: null,
@@ -109,6 +110,7 @@ export const WithLongUrl = () => {
       url:
         "http://www.foo.bar.baz.growthbook.com/api/v100/vendors/webhooks/features/feature-deleted/webhooks?token=8ca47365b8b2499ca7a863d5b5c36b5d",
       signingKey: "ewhk_6220c5592f03244c43a929850816d644",
+      // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'null' is not assignable to type 'Date'.
       lastRunAt: null,
       lastState: "none",
       lastResponseBody: null,

--- a/packages/front-end/components/EventWebHooks/EventWebHookList/EventWebHookListItem/EventWebHookListItem.stories.tsx
+++ b/packages/front-end/components/EventWebHooks/EventWebHookList/EventWebHookListItem/EventWebHookListItem.stories.tsx
@@ -70,6 +70,7 @@ export const NoRuns = () => {
     enabled: false,
     url: "http://192.168.0.15:1115/events/webhooks?v=4",
     signingKey: "ewhk_6220c5592f03244c43a929850816d644",
+    // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'null' is not assignable to type 'Date'.
     lastRunAt: null,
     lastState: "none",
     lastResponseBody: null,

--- a/packages/front-end/components/Experiment/AddExperimentModal.tsx
+++ b/packages/front-end/components/Experiment/AddExperimentModal.tsx
@@ -64,6 +64,7 @@ const AddExperimentModal: FC<{
       return (
         <NewExperimentForm
           onClose={onClose}
+          // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
           source={source}
           isNewExperiment={true}
         />

--- a/packages/front-end/components/Experiment/AlignedGraph.tsx
+++ b/packages/front-end/components/Experiment/AlignedGraph.tsx
@@ -92,10 +92,14 @@ const AlignedGraph: FC<Props> = ({
   const gradient: { color: string; percent: number }[] = [];
   const gradientId = "gr_" + id;
   if (ci && barFillType === "gradient") {
+    // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
     if (ci[0] < 0) {
       gradient.push({ color: sigBarColorNeg, percent: 0 });
+      // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
       if (ci[1] > 0) {
+        // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
         const w = ci[1] - ci[0];
+        // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
         const wNeg = (100 * (-1 * ci[0])) / w;
         gradient.push({ color: sigBarColorNeg, percent: wNeg });
         gradient.push({ color: sigBarColorPos, percent: wNeg + 0.001 });
@@ -113,7 +117,8 @@ const AlignedGraph: FC<Props> = ({
     barFillType === "gradient"
       ? `url(#${gradientId})`
       : significant
-      ? expected > 0
+      ? // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
+        expected > 0
         ? sigBarColorPos
         : sigBarColorNeg
       : barColor;
@@ -197,6 +202,7 @@ const AlignedGraph: FC<Props> = ({
                           <ViolinPlot
                             top={barHeight}
                             width={barThickness}
+                            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
                             left={xScale(ci[0])}
                             data={[
                               0.025,
@@ -215,15 +221,20 @@ const AlignedGraph: FC<Props> = ({
                             ].map((n) => {
                               let x = jStat.normal.inv(
                                 n,
+                                // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
                                 uplift.mean,
+                                // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
                                 uplift.stddev
                               );
                               const y = jStat.normal.pdf(
                                 x,
+                                // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
                                 uplift.mean,
+                                // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
                                 uplift.stddev
                               );
 
+                              // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
                               if (uplift.dist === "lognormal") {
                                 x = Math.exp(x) - 1;
                               }
@@ -243,8 +254,10 @@ const AlignedGraph: FC<Props> = ({
                         )}
                         {barType === "pill" && (
                           <rect
+                            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
                             x={xScale(ci[0])}
                             y={barHeight}
+                            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
                             width={xScale(ci[1]) - xScale(ci[0])}
                             height={barThickness}
                             fill={barFill}
@@ -255,8 +268,10 @@ const AlignedGraph: FC<Props> = ({
                           fill="#000000"
                           strokeWidth={3}
                           stroke={"#666"}
+                          // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'number | undefined' is not assig... Remove this comment to see the full error message
                           from={{ x: xScale(expected), y: barHeight }}
                           to={{
+                            // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'number | undefined' is not assig... Remove this comment to see the full error message
                             x: xScale(expected),
                             y: barHeight + barThickness,
                           }}
@@ -273,9 +288,11 @@ const AlignedGraph: FC<Props> = ({
           <>
             <div className="expectedwrap text-right">
               <span className="expectedArrows">
+                {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
                 {expected > 0 ? <FaArrowUp /> : <FaArrowDown />}
               </span>{" "}
               <span className="expected bold">
+                {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
                 {parseFloat((expected * 100).toFixed(1)) + "%"}{" "}
               </span>
             </div>

--- a/packages/front-end/components/Experiment/AnalysisForm.tsx
+++ b/packages/front-end/components/Experiment/AnalysisForm.tsx
@@ -52,6 +52,7 @@ const AnalysisForm: FC<{
   const orgSettings = useOrgSettings();
 
   const pid = experiment?.project;
+  // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
   const project = getProjectById(pid);
 
   const { settings: scopedSettings } = getScopedSettings({
@@ -89,9 +90,11 @@ const AnalysisForm: FC<{
         experiment.attributionModel ||
         orgSettings.attributionModel ||
         "firstExposure",
+      // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
       dateStarted: getValidDate(phaseObj?.dateStarted)
         .toISOString()
         .substr(0, 16),
+      // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
       dateEnded: getValidDate(phaseObj?.dateEnded).toISOString().substr(0, 16),
       variations: experiment.variations || [],
       sequentialTestingEnabled:
@@ -450,6 +453,7 @@ const AnalysisForm: FC<{
               {...form.register("sequentialTestingTuningParameter", {
                 valueAsNumber: true,
                 validate: (v) => {
+                  // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
                   return !(v <= 0);
                 },
               })}

--- a/packages/front-end/components/Experiment/AnalysisSettingsBar.tsx
+++ b/packages/front-end/components/Experiment/AnalysisSettingsBar.tsx
@@ -147,6 +147,7 @@ export default function AnalysisSettingsBar({
 
   const { getDatasourceById } = useDefinitions();
   const orgSettings = useOrgSettings();
+  // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
   const datasource = getDatasourceById(experiment.datasource);
 
   const { hasCommercialFeature } = useUser();
@@ -156,6 +157,7 @@ export default function AnalysisSettingsBar({
   const hasSequentialFeature = hasCommercialFeature("sequential-testing");
 
   const { outdated, reason } = isOutdated(
+    // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'ExperimentInterfaceStringDates |... Remove this comment to see the full error message
     experiment,
     snapshot,
     orgSettings,
@@ -171,6 +173,7 @@ export default function AnalysisSettingsBar({
 
   const status = getQueryStatus(latest?.queries || [], latest?.error);
 
+  // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
   const hasData = snapshot?.results?.[0]?.variations?.length > 0;
 
   const [refreshError, setRefreshError] = useState("");
@@ -180,13 +183,16 @@ export default function AnalysisSettingsBar({
       {modalOpen && (
         <AnalysisForm
           cancel={() => setModalOpen(false)}
+          // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'ExperimentInterfaceStringDates | undefined' ... Remove this comment to see the full error message
           experiment={experiment}
           mutate={mutateExperiment}
           phase={phase}
         />
       )}
       <div className="row align-items-center p-3">
+        {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
         {experiment.phases &&
+          // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
           (alwaysShowPhaseSelector || experiment.phases.length > 1) && (
             <div className="col-auto form-inline">
               <PhaseSelector
@@ -199,9 +205,13 @@ export default function AnalysisSettingsBar({
           <DimensionChooser
             value={dimension}
             setValue={setDimension}
+            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
             activationMetric={!!experiment.activationMetric}
+            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
             datasourceId={experiment.datasource}
+            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
             exposureQueryId={experiment.exposureQueryId}
+            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
             userIdType={experiment.userIdType}
             labelClassName="mr-2"
           />
@@ -227,6 +237,7 @@ export default function AnalysisSettingsBar({
                 <span className="mx-1 font-weight-bold">CUPED</span>
                 <Toggle
                   id="toggle-experiment-regression-adjustment"
+                  // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'boolean | undefined' is not assignable to ty... Remove this comment to see the full error message
                   value={regressionAdjustmentEnabled}
                   setValue={(value) => {
                     if (
@@ -283,23 +294,28 @@ export default function AnalysisSettingsBar({
               <div
                 className="text-muted text-right"
                 style={{ width: 100, fontSize: "0.8em" }}
+                // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
                 title={datetime(snapshot.dateCreated)}
               >
                 <div className="font-weight-bold" style={{ lineHeight: 1.2 }}>
                   last updated
                 </div>
                 <div className="d-inline-block" style={{ lineHeight: 1 }}>
+                  {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
                   {ago(snapshot.dateCreated)}
                 </div>
               </div>
             ))}
         </div>
+        {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
         {permissions.check("runQueries", "") && experiment.metrics.length > 0 && (
           <div className="col-auto">
+            {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
             {experiment.datasource && latest && latest.queries?.length > 0 ? (
               <form
                 onSubmit={(e) => {
                   e.preventDefault();
+                  // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
                   apiCall(`/experiment/${experiment.id}/snapshot`, {
                     method: "POST",
                     body: JSON.stringify({
@@ -335,6 +351,7 @@ export default function AnalysisSettingsBar({
               <RefreshSnapshotButton
                 mutate={mutate}
                 phase={phase}
+                // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'ExperimentInterfaceStringDates | undefined' ... Remove this comment to see the full error message
                 experiment={experiment}
                 lastSnapshot={snapshot}
                 dimension={dimension}
@@ -352,7 +369,10 @@ export default function AnalysisSettingsBar({
             id={snapshot?.id || ""}
             forceRefresh={async () => {
               await apiCall(
-                `/experiment/${experiment.id}/snapshot?force=true`,
+                `/experiment/${
+                  // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
+                  experiment.id
+                }/snapshot?force=true`,
                 {
                   method: "POST",
                   body: JSON.stringify({
@@ -374,6 +394,7 @@ export default function AnalysisSettingsBar({
             configure={() => setModalOpen(true)}
             editMetrics={editMetrics}
             notebookUrl={`/experiments/notebook/${snapshot?.id}`}
+            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
             notebookFilename={experiment.trackingKey}
             generateReport={true}
             queries={snapshot?.queries}
@@ -381,11 +402,14 @@ export default function AnalysisSettingsBar({
             hasUserQuery={snapshot && !("skipPartialData" in snapshot)}
             supportsNotebooks={!!datasource?.settings?.notebookRunQuery}
             hasData={hasData}
+            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
             metrics={experiment.metrics}
             results={snapshot?.results}
             variations={variations}
+            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
             trackingKey={experiment.trackingKey}
             dimension={dimension}
+            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
             project={experiment.project}
           />
         </div>

--- a/packages/front-end/components/Experiment/BreakDownResults.tsx
+++ b/packages/front-end/components/Experiment/BreakDownResults.tsx
@@ -80,6 +80,7 @@ const BreakDownResults: FC<{
     return Array.from(new Set(metrics.concat(guardrails || [])))
       .map((metricId) => {
         const metric = getMetricById(metricId);
+        // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'MetricInterface | null' is not a... Remove this comment to see the full error message
         const { newMetric } = applyMetricOverrides(metric, metricOverrides);
         let regressionAdjustmentStatus:
           | MetricRegressionAdjustmentStatus
@@ -119,6 +120,7 @@ const BreakDownResults: FC<{
 
   const risk = useRiskVariation(
     variations.length,
+    // @ts-expect-error TS(2769) If you come across this, please fix it!: No overload matches this call.
     [].concat(...tables.map((t) => t.rows))
   );
 

--- a/packages/front-end/components/Experiment/ChanceToWinColumn.tsx
+++ b/packages/front-end/components/Experiment/ChanceToWinColumn.tsx
@@ -102,6 +102,7 @@ export default function ChanceToWinColumn({
           <div className="mb-1 d-flex flex-row">
             <Tooltip
               body={`A suspicious result occurs when the percent change is equal to or greater than your maximum percent change (${
+                // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
                 metric.maxPercentChange * 100
               }%).`}
             >

--- a/packages/front-end/components/Experiment/CompactResults.tsx
+++ b/packages/front-end/components/Experiment/CompactResults.tsx
@@ -68,6 +68,7 @@ const CompactResults: FC<{
     return metrics
       .map((metricId) => {
         const metric = getMetricById(metricId);
+        // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'MetricInterface | null' is not a... Remove this comment to see the full error message
         const { newMetric } = applyMetricOverrides(metric, metricOverrides);
         let regressionAdjustmentStatus:
           | MetricRegressionAdjustmentStatus
@@ -111,6 +112,7 @@ const CompactResults: FC<{
         <DataQualityWarning results={results} variations={variations} />
         <MultipleExposureWarning
           users={users}
+          // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'number | undefined' is not assignable to typ... Remove this comment to see the full error message
           multipleExposures={multipleExposures}
         />
         <h3 className="mb-3">

--- a/packages/front-end/components/Experiment/DateResults.tsx
+++ b/packages/front-end/components/Experiment/DateResults.tsx
@@ -62,6 +62,7 @@ const DateResults: FC<{
   }, [results, cumulative]);
 
   // Data for the metric graphs
+  // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type '() => { metric: MetricInterface ... Remove this comment to see the full error message
   const metricSections = useMemo<Metric[]>(() => {
     if (!ready) return [];
 
@@ -129,6 +130,7 @@ const DateResults: FC<{
                 const label = i
                   ? (value > 0 ? "+" : "") + percentFormatter.format(value)
                   : formatConversionRate(
+                      // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'MetricType | undefined' is not a... Remove this comment to see the full error message
                       metric?.type,
                       cumulative
                         ? totalUsers[i]

--- a/packages/front-end/components/Experiment/EditPhaseModal.tsx
+++ b/packages/front-end/components/Experiment/EditPhaseModal.tsx
@@ -26,9 +26,11 @@ export default function EditPhaseModal({
   const form = useForm<ExperimentPhaseStringDates>({
     defaultValues: {
       ...experiment.phases[i],
+      // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
       dateStarted: experiment.phases[i].dateStarted.substr(0, 16),
       dateEnded: experiment.phases[i].dateEnded
-        ? experiment.phases[i].dateEnded.substr(0, 16)
+        ? // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
+          experiment.phases[i].dateEnded.substr(0, 16)
         : "",
     },
   });

--- a/packages/front-end/components/Experiment/EditPhasesModal.tsx
+++ b/packages/front-end/components/Experiment/EditPhasesModal.tsx
@@ -71,10 +71,13 @@ export default function EditPhasesModal({
               <td>{i + 1}</td>
               <td>{phase.name}</td>
               <td>
+                {/* @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message */}
                 <strong title={datetime(phase.dateStarted)}>
+                  {/* @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message */}
                   {date(phase.dateStarted)}
                 </strong>{" "}
                 to{" "}
+                {/* @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message */}
                 <strong title={datetime(phase.dateEnded)}>
                   {phase.dateEnded ? date(phase.dateEnded) : "now"}
                 </strong>

--- a/packages/front-end/components/Experiment/ExpandablePhaseSummary.tsx
+++ b/packages/front-end/components/Experiment/ExpandablePhaseSummary.tsx
@@ -39,6 +39,7 @@ export default function ExpandablePhaseSummary({ i, phase, editPhase }: Props) {
         <div className="small">
           <div style={{ fontSize: "1.2em" }}>{phase.name}</div>
           <div>
+            {/* @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message */}
             <strong>{date(phase.dateStarted)}</strong> to{" "}
             <strong>{phase.dateEnded ? date(phase.dateEnded) : "now"}</strong>
           </div>

--- a/packages/front-end/components/Experiment/ExperimentDateGraph.tsx
+++ b/packages/front-end/components/Experiment/ExperimentDateGraph.tsx
@@ -217,6 +217,7 @@ const ExperimentDateGraph: FC<ExperimentDateGraphProps> = ({
                         key={i}
                         className={styles.positionIndicator}
                         style={{
+                          // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
                           transform: `translate(${tooltipLeft}px, ${tooltipData.y[i]}px)`,
                           background: COLORS[i % COLORS.length],
                         }}
@@ -233,6 +234,7 @@ const ExperimentDateGraph: FC<ExperimentDateGraphProps> = ({
                     className={styles.tooltip}
                     unstyled={true}
                   >
+                    {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
                     {getTooltipContents(tooltipData.d, variationNames)}
                   </TooltipWithBounds>
                 </>
@@ -263,7 +265,9 @@ const ExperimentDateGraph: FC<ExperimentDateGraphProps> = ({
                       yScale={yScale}
                       data={datapoints}
                       x={(d) => xScale(d.d) ?? 0}
+                      // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'number | undefined' is not assig... Remove this comment to see the full error message
                       y0={(d) => yScale(d.variations[i]?.error?.[0]) ?? 0}
+                      // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'number | undefined' is not assig... Remove this comment to see the full error message
                       y1={(d) => yScale(d.variations[i]?.error?.[1]) ?? 0}
                       fill={COLORS[i % COLORS.length]}
                       opacity={0.12}

--- a/packages/front-end/components/Experiment/ExperimentGraph.tsx
+++ b/packages/front-end/components/Experiment/ExperimentGraph.tsx
@@ -90,6 +90,7 @@ export default function ExperimentGraph({
 
         const handlePointer = (event: React.MouseEvent<SVGElement>) => {
           const coords = localPoint(event);
+          // @ts-expect-error TS(2531) If you come across this, please fix it!: Object is possibly 'null'.
           const xCoord = coords.x - barWidth;
 
           const barData = graphData.map((d) => {
@@ -97,6 +98,7 @@ export default function ExperimentGraph({
           });
 
           const closestBar = barData.reduce((prev, curr) =>
+            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
             Math.abs(curr.xcord - xCoord) < Math.abs(prev.xcord - xCoord)
               ? curr
               : prev
@@ -141,6 +143,7 @@ export default function ExperimentGraph({
                   stroke="var(--border-color-200)"
                 />
                 {graphData.map((d, i) => {
+                  // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
                   const barX = xScale(getValidDate(d.date)) - barWidth / 2;
                   let barHeight = yMax - (yScale(d.numExp) ?? 0);
                   // if there are no experiments this month, show a little nub for design reasons.

--- a/packages/front-end/components/Experiment/ExperimentList.tsx
+++ b/packages/front-end/components/Experiment/ExperimentList.tsx
@@ -32,9 +32,12 @@ export default function ExperimentList({
           endDate;
 
         test.phases.forEach((p) => {
+          // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
           if (!startDate || p.dateStarted < startDate) {
+            // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
             startDate = p.dateStarted;
           }
+          // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
           if (!endDate || p.dateEnded > endDate) endDate = p.dateEnded;
         });
         const currentPhase = test.phases[test.phases.length - 1];

--- a/packages/front-end/components/Experiment/ExperimentReportsList.tsx
+++ b/packages/front-end/components/Experiment/ExperimentReportsList.tsx
@@ -28,21 +28,26 @@ export default function ExperimentReportsList({
     reports: ReportInterface[];
   }>(`/experiment/${experiment.id}/reports`);
 
+  // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'null' is not assignable to type 'ReactElemen... Remove this comment to see the full error message
   if (!experiment.datasource) return null;
 
   if (error) {
+    // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'null' is not assignable to type 'ReactElemen... Remove this comment to see the full error message
     return null;
   }
   if (!data) {
+    // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'null' is not assignable to type 'ReactElemen... Remove this comment to see the full error message
     return null;
   }
 
   const { reports } = data;
 
   if (!reports.length) {
+    // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'null' is not assignable to type 'ReactElemen... Remove this comment to see the full error message
     return null;
   }
 
+  // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
   const hasData = snapshot?.results?.[0]?.variations?.length > 0;
   const hasUserQuery = snapshot && !("skipPartialData" in snapshot);
   const canCreateReports =
@@ -97,6 +102,7 @@ export default function ExperimentReportsList({
         </thead>
         <tbody>
           {reports.map((report) => {
+            // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
             const user = users.get(report.userId);
             const name = user ? user.name : "";
             return (

--- a/packages/front-end/components/Experiment/ExperimentVariationsInput.tsx
+++ b/packages/front-end/components/Experiment/ExperimentVariationsInput.tsx
@@ -21,6 +21,7 @@ export default function ExperimentVariationsInput({
       <div className="row">
         <SortableVariationsList
           variations={variations}
+          // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '((variations: Variation[]) => void) | undefi... Remove this comment to see the full error message
           setVariations={setVariations}
           sortingStrategy="rect"
         >
@@ -57,6 +58,7 @@ export default function ExperimentVariationsInput({
                   screenshots: [],
                   id: generateVariationId(),
                 });
+                // @ts-expect-error TS(2722) If you come across this, please fix it!: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
                 setVariations(newVariations);
               }}
             >

--- a/packages/front-end/components/Experiment/FilterSummary.tsx
+++ b/packages/front-end/components/Experiment/FilterSummary.tsx
@@ -77,6 +77,7 @@ const FilterSummary: FC<{
                 <strong className="text-gray">Date range:</strong>
               </div>
               <div className="col">
+                {/* @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message */}
                 <strong>{datetime(phase.dateStarted)}</strong> to
                 <br />
                 <strong>

--- a/packages/front-end/components/Experiment/GuardrailResult.tsx
+++ b/packages/front-end/components/Experiment/GuardrailResult.tsx
@@ -44,6 +44,7 @@ const GuardrailResults: FC<{
         return -1;
       }
 
+      // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
       return 1 - v.metrics[metric.id]?.chanceToWin;
     })
   );

--- a/packages/front-end/components/Experiment/ImportExperimentList.tsx
+++ b/packages/front-end/components/Experiment/ImportExperimentList.tsx
@@ -37,6 +37,7 @@ const ImportExperimentList: FC<{
     experiments: PastExperimentsInterface;
     existing: Record<string, string>;
   }>(`/experiments/import/${importId}`);
+  // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
   const datasource = getDatasourceById(data?.experiments?.datasource);
 
   const status = getQueryStatus(
@@ -119,6 +120,7 @@ const ImportExperimentList: FC<{
   }
 
   const supportedDatasources = datasources.filter(
+    // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
     (d) => d.properties.pastExperiments
   );
 
@@ -159,8 +161,10 @@ const ImportExperimentList: FC<{
           <div
             className="text-muted"
             style={{ fontSize: "0.8em" }}
+            // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'Date | null' is not assignable t... Remove this comment to see the full error message
             title={datetime(data.experiments.runStarted)}
           >
+            {/* @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'Date | null' is not assignable t... Remove this comment to see the full error message */}
             last updated {ago(data.experiments.runStarted)}
           </div>
         </div>
@@ -199,10 +203,12 @@ const ImportExperimentList: FC<{
         <>
           <div className="alert alert-danger my-3">
             <p>Error importing experiments.</p>
+            {/* @ts-expect-error TS(2531) If you come across this, please fix it!: Object is possibly 'null'. */}
             {datasource.id && (
               <p>
                 Your datasource&apos;s <em>Experiment Assignment Queries</em>{" "}
                 may be misconfigured.{" "}
+                {/* @ts-expect-error TS(2531) If you come across this, please fix it!: Object is possibly 'null'. */}
                 <Link href={`/datasources/${datasource.id}?openAll=1`}>
                   Edit the datasource
                 </Link>
@@ -402,6 +408,7 @@ const ImportExperimentList: FC<{
                               datasource: data?.experiments?.datasource,
                               exposureQueryId: e.exposureQueryId || "",
                               variations: e.variationKeys.map((vKey, i) => {
+                                // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
                                 let vName = e.variationNames[i] || vKey;
                                 // If the name is an integer, rename 0 to "Control" and anything else to "Variation {name}"
                                 if (vName.match(/^[0-9]{1,2}$/)) {

--- a/packages/front-end/components/Experiment/ImportExperimentModal.tsx
+++ b/packages/front-end/components/Experiment/ImportExperimentModal.tsx
@@ -23,11 +23,13 @@ const ImportExperimentModal: FC<{
   const [
     selected,
     setSelected,
+    // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'Partial<ExperimentInterfaceStrin... Remove this comment to see the full error message
   ] = useState<null | Partial<ExperimentInterfaceStringDates>>(initialValue);
   const [importModal, setImportModal] = useState<boolean>(importMode);
   const [datasourceId, setDatasourceId] = useState(() => {
     if (!datasources) return null;
     return (
+      // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
       datasources.filter((d) => d.properties.pastExperiments)[0]?.id ?? null
     );
   });
@@ -45,6 +47,7 @@ const ImportExperimentModal: FC<{
           }),
         });
         if (res?.id) {
+          // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string' is not assignable to par... Remove this comment to see the full error message
           setImportId(res.id);
         }
       } catch (e) {
@@ -59,8 +62,10 @@ const ImportExperimentModal: FC<{
   if (selected || !importModal || !datasourceId) {
     return (
       <NewExperimentForm
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'Partial<ExperimentInterfaceStringDates> | nu... Remove this comment to see the full error message
         initialValue={selected}
         onClose={() => onClose()}
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
         source={source}
         isImport={!!selected}
         fromFeature={fromFeature}

--- a/packages/front-end/components/Experiment/ManualSnapshotForm.tsx
+++ b/packages/front-end/components/Experiment/ManualSnapshotForm.tsx
@@ -95,6 +95,7 @@ const ManualSnapshotForm: FC<{
   const form = useForm({
     defaultValues: initialValue,
   });
+  // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'null' is not assignable to param... Remove this comment to see the full error message
   const [preview, setPreview] = useState<SnapshotPreview>(null);
 
   const values = {
@@ -107,6 +108,7 @@ const ManualSnapshotForm: FC<{
     Object.keys(values.metrics).forEach((key) => {
       const m = getMetricById(key);
       ret[key] = values.metrics[key].map((v, i) => {
+        // @ts-expect-error TS(2531) If you come across this, please fix it!: Object is possibly 'null'.
         if (m.type === "binomial") {
           // Use the normal approximation for a bernouli variable to calculate stddev
           const p = v.count / values.users[i];
@@ -116,6 +118,7 @@ const ManualSnapshotForm: FC<{
             mean: p,
             stddev: Math.sqrt(p * (1 - p)),
           };
+          // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'MetricInterface | null' is not a... Remove this comment to see the full error message
         } else if (isRatio(m)) {
           // For ratio metrics, the count (denominator) may be different from the number of users
           return {
@@ -124,6 +127,7 @@ const ManualSnapshotForm: FC<{
             mean: v.mean,
             stddev: v.stddev,
           };
+          // @ts-expect-error TS(2531) If you come across this, please fix it!: Object is possibly 'null'.
         } else if (m.ignoreNulls || m.denominator) {
           // When ignoring nulls (or using a funnel metric)
           // Limit the users to only ones who converted
@@ -152,6 +156,7 @@ const ManualSnapshotForm: FC<{
 
     // Only preview when all variations have number of users set
     if (values.users.filter((n) => n <= 0).length > 0) {
+      // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'null' is not assignable to param... Remove this comment to see the full error message
       setPreview(null);
       return;
     }
@@ -163,6 +168,7 @@ const ManualSnapshotForm: FC<{
         stats[key].filter((n) => Math.min(n.count, n.mean, n.stddev) <= 0)
           .length > 0
       ) {
+        // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'null' is not assignable to param... Remove this comment to see the full error message
         setPreview(null);
         return;
       }
@@ -228,6 +234,7 @@ const ManualSnapshotForm: FC<{
         style={{ overflowY: "auto", overflowX: "hidden" }}
         onBlur={(e) => {
           if (e.target.tagName !== "INPUT") return;
+          // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string' is not assignable to par... Remove this comment to see the full error message
           setHash(JSON.stringify(form.getValues()));
         }}
       >
@@ -337,6 +344,7 @@ const ManualSnapshotForm: FC<{
                           preview &&
                           preview.variations[i].metrics[m.id] &&
                           parseFloat(
+                            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
                             (
                               preview.variations[i].metrics[m.id].chanceToWin *
                               100

--- a/packages/front-end/components/Experiment/ManualSnapshotForm.tsx
+++ b/packages/front-end/components/Experiment/ManualSnapshotForm.tsx
@@ -344,11 +344,9 @@ const ManualSnapshotForm: FC<{
                           preview &&
                           preview.variations[i].metrics[m.id] &&
                           parseFloat(
+                            // prettier-ignore
                             // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
-                            (
-                              preview.variations[i].metrics[m.id].chanceToWin *
-                              100
-                            ).toFixed(2)
+                            (preview.variations[i].metrics[m.id].chanceToWin * 100).toFixed(2)
                           ) + "%"}
                       </td>
                     </tr>

--- a/packages/front-end/components/Experiment/MetricsOverridesSelector.tsx
+++ b/packages/front-end/components/Experiment/MetricsOverridesSelector.tsx
@@ -52,12 +52,19 @@ export default function MetricsOverridesSelector({
         const metricDefinition = metricDefinitions.find(
           (md) => md.id === mo.id
         );
+        // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'number | undefined' is not assig... Remove this comment to see the full error message
         const loseRisk = isNaN(mo.loseRisk)
-          ? metricDefinition.loseRisk
-          : mo.loseRisk / 100;
+          ? // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
+            metricDefinition.loseRisk
+          : // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
+            mo.loseRisk / 100;
+        // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'number | undefined' is not assig... Remove this comment to see the full error message
         const winRisk = isNaN(mo.winRisk)
-          ? metricDefinition.winRisk
-          : mo.winRisk / 100;
+          ? // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
+            metricDefinition.winRisk
+          : // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
+            mo.winRisk / 100;
+        // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
         if (loseRisk < winRisk) {
           hasRiskError = true;
         }
@@ -85,8 +92,10 @@ export default function MetricsOverridesSelector({
           );
           let regressionAdjustmentAvailableForMetric = true;
           let regressionAdjustmentAvailableForMetricReason = <></>;
+          // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
           if (metricDefinition.denominator) {
             const denominator = metricDefinitions.find(
+              // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
               (m) => m.id === metricDefinition.denominator
             );
             if (denominator?.type === "count") {
@@ -99,6 +108,7 @@ export default function MetricsOverridesSelector({
               );
             }
           }
+          // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
           if (metricDefinition.aggregation) {
             regressionAdjustmentAvailableForMetric = false;
             regressionAdjustmentAvailableForMetricReason = (
@@ -106,25 +116,35 @@ export default function MetricsOverridesSelector({
             );
           }
 
+          // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'number | undefined' is not assig... Remove this comment to see the full error message
           const loseRisk = isNaN(mo.loseRisk)
-            ? metricDefinition.loseRisk
-            : mo.loseRisk / 100;
+            ? // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
+              metricDefinition.loseRisk
+            : // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
+              mo.loseRisk / 100;
+          // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'number | undefined' is not assig... Remove this comment to see the full error message
           const winRisk = isNaN(mo.winRisk)
-            ? metricDefinition.winRisk
-            : mo.winRisk / 100;
+            ? // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
+              metricDefinition.winRisk
+            : // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
+              mo.winRisk / 100;
           const riskError =
+            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
             loseRisk < winRisk
               ? "The acceptable risk percentage cannot be higher than the too risky percentage"
               : "";
 
           const regressionAdjustmentDaysHighlightColor =
+            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
             mo.regressionAdjustmentDays > 28 || mo.regressionAdjustmentDays < 7
               ? "#e27202"
               : "";
           const regressionAdjustmentDaysWarningMsg =
+            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
             mo.regressionAdjustmentDays > 28
               ? "Longer lookback periods can sometimes be useful, but also will reduce query performance and may incorporate less useful data"
-              : mo.regressionAdjustmentDays < 7
+              : // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
+              mo.regressionAdjustmentDays < 7
               ? "Lookback periods under 7 days tend not to capture enough metric data to reduce variance and may be subject to weekly seasonality"
               : "";
 
@@ -146,6 +166,7 @@ export default function MetricsOverridesSelector({
               <div>
                 <label className="mb-1">
                   <strong className="text-purple">
+                    {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
                     {metricDefinition.name}
                   </strong>
                 </label>
@@ -168,6 +189,7 @@ export default function MetricsOverridesSelector({
                           placeholder="default"
                           helpText={
                             <div className="text-right">
+                              {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
                               default: {metricDefinition.conversionDelayHours}
                             </div>
                           }
@@ -187,6 +209,7 @@ export default function MetricsOverridesSelector({
                           placeholder="default"
                           helpText={
                             <div className="text-right">
+                              {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
                               default: {metricDefinition.conversionWindowHours}{" "}
                             </div>
                           }
@@ -211,6 +234,7 @@ export default function MetricsOverridesSelector({
                           placeholder="default"
                           helpText={
                             <div className="text-right">
+                              {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
                               default: {(metricDefinition.winRisk || 0) * 100}%
                             </div>
                           }
@@ -231,6 +255,7 @@ export default function MetricsOverridesSelector({
                           placeholder="default"
                           helpText={
                             <div className="text-right">
+                              {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
                               default: {(metricDefinition.loseRisk || 0) * 100}%
                             </div>
                           }
@@ -320,9 +345,11 @@ export default function MetricsOverridesSelector({
                             />
                             <div className="small">
                               <small className="form-text text-muted">
+                                {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
                                 {metricDefinition.regressionAdjustmentOverride ? (
                                   <>
                                     (metric default:{" "}
+                                    {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
                                     {metricDefinition.regressionAdjustmentEnabled
                                       ? "On"
                                       : "Off"}
@@ -370,10 +397,12 @@ export default function MetricsOverridesSelector({
                               helpText={
                                 <>
                                   <span className="ml-2">
+                                    {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
                                     {metricDefinition.regressionAdjustmentOverride ? (
                                       <>
                                         (metric default:{" "}
                                         {
+                                          // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
                                           metricDefinition.regressionAdjustmentDays
                                         }
                                         )
@@ -394,6 +423,7 @@ export default function MetricsOverridesSelector({
                                 {
                                   valueAsNumber: true,
                                   validate: (v) => {
+                                    // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
                                     return !(v <= 0 || v > 100);
                                   },
                                 }
@@ -436,7 +466,9 @@ export default function MetricsOverridesSelector({
               options={unusedMetrics.map((m) => {
                 const metric = metricDefinitions.find((md) => md.id === m);
                 return {
+                  // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
                   label: metric.name,
+                  // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
                   value: metric.id,
                 };
               })}

--- a/packages/front-end/components/Experiment/NamespaceModal.tsx
+++ b/packages/front-end/components/Experiment/NamespaceModal.tsx
@@ -34,6 +34,7 @@ export default function NamespaceModal({
       header={existing ? "Edit Namespace" : "Create Namespace"}
       submit={form.handleSubmit(async (value) => {
         if (existing) {
+          // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
           await apiCall(`/organization/namespaces/${existingNamespace.name}`, {
             method: "PUT",
             body: JSON.stringify(value),
@@ -48,6 +49,7 @@ export default function NamespaceModal({
       })}
     >
       <Field
+        // @ts-expect-error TS(2783) If you come across this, please fix it!: 'name' is specified more than once, so this usage ... Remove this comment to see the full error message
         name="Name"
         label="Name"
         maxLength={60}
@@ -56,6 +58,7 @@ export default function NamespaceModal({
         {...form.register("name")}
       />
       <Field
+        // @ts-expect-error TS(2783) If you come across this, please fix it!: 'name' is specified more than once, so this usage ... Remove this comment to see the full error message
         name="Description"
         label="Description"
         textarea

--- a/packages/front-end/components/Experiment/NewExperimentForm.tsx
+++ b/packages/front-end/components/Experiment/NewExperimentForm.tsx
@@ -111,6 +111,7 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
       datasource: initialValue?.datasource || datasources?.[0]?.id || "",
       exposureQueryId:
         getExposureQuery(
+          // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
           getDatasourceById(initialValue?.datasource)?.settings,
           initialValue?.exposureQueryId,
           initialValue?.userIdType
@@ -134,9 +135,11 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
         initialValue
           ? {
               coverage: initialValue.phases?.[0].coverage || 1,
+              // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
               dateStarted: getValidDate(initialValue.phases?.[0]?.dateStarted)
                 .toISOString()
                 .substr(0, 16),
+              // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
               dateEnded: getValidDate(initialValue.phases?.[0]?.dateEnded)
                 .toISOString()
                 .substr(0, 16),
@@ -162,6 +165,7 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
     },
   });
 
+  // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
   const datasource = getDatasourceById(form.watch("datasource"));
   const supportsSQL = datasource?.properties?.queryLanguage === "sql";
 
@@ -169,6 +173,7 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
 
   const onSubmit = form.handleSubmit(async (value) => {
     // Make sure there's an experiment name
+    // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
     if (value.name.length < 1) {
       setStep(0);
       throw new Error("Experiment Name must not be empty");
@@ -179,6 +184,7 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
     const data = { ...value };
 
     if (data.status !== "stopped") {
+      // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
       data.phases[0].dateEnded = "";
     }
 
@@ -206,12 +212,16 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
 
     track("Create Experiment", {
       source,
+      // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
       numTags: data.tags.length,
+      // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
       numMetrics: data.metrics.length,
+      // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
       numVariations: data.variations.length,
     });
     refreshWatching();
 
+    // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string[] | undefined' is not ass... Remove this comment to see the full error message
     refreshTags(data.tags);
     if (onCreate) {
       onCreate(res.experiment.id);
@@ -259,6 +269,7 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
         <div className="form-group">
           <label>Tags</label>
           <TagsInput
+            // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string[] | undefined' is not assignable to t... Remove this comment to see the full error message
             value={form.watch("tags")}
             onChange={(tags) => form.setValue("tags", tags)}
           />
@@ -275,6 +286,7 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
           <div className="form-group">
             <label>Description</label>
             <MarkdownInput
+              // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
               value={form.watch("description")}
               setValue={(val) => form.setValue("description", val)}
             />
@@ -292,6 +304,7 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
               const status = v as ExperimentStatus;
               form.setValue("status", status);
             }}
+            // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
             value={form.watch("status")}
           />
         )}
@@ -323,6 +336,7 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
             options={attributeSchema
               .filter((s) => !hasHashAttributes || s.hashAttribute)
               .map((s) => ({ label: s.property, value: s.property }))}
+            // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
             value={form.watch("hashAttribute")}
             onChange={(v) => {
               form.setValue("hashAttribute", v);
@@ -349,6 +363,7 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
                 return {
                   // default values
                   name: "",
+                  // @ts-expect-error TS(2783) If you come across this, please fix it!: 'value' is specified more than once, so this usage... Remove this comment to see the full error message
                   value: i,
                   screenshots: [],
                   // overwrite defaults
@@ -363,6 +378,7 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
               v.map((v) => v.weight)
             );
           }}
+          // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
           variations={form.watch("variations").map((v, i) => {
             return {
               value: v.key || "",
@@ -406,6 +422,7 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
             <SelectField
               label="Data Source"
               labelClassName="font-weight-bold"
+              // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
               value={form.watch("datasource")}
               onChange={(v) => form.setValue("datasource", v)}
               initialOption="Manual"
@@ -420,6 +437,7 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
             <SelectField
               label="Experiment Assignment Table"
               labelClassName="font-weight-bold"
+              // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
               value={form.watch("exposureQueryId")}
               onChange={(v) => form.setValue("exposureQueryId", v)}
               initialOption="Choose..."
@@ -438,6 +456,7 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
               Metrics you are trying to improve with this experiment.
             </div>
             <MetricsSelector
+              // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string[] | undefined' is not assignable to t... Remove this comment to see the full error message
               selected={form.watch("metrics")}
               onChange={(metrics) => form.setValue("metrics", metrics)}
               datasource={datasource?.id}
@@ -450,6 +469,7 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
               improve.
             </div>
             <MetricsSelector
+              // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string[] | undefined' is not assignable to t... Remove this comment to see the full error message
               selected={form.watch("guardrails")}
               onChange={(metrics) => form.setValue("guardrails", metrics)}
               datasource={datasource?.id}

--- a/packages/front-end/components/Experiment/NewFeatureExperiments.tsx
+++ b/packages/front-end/components/Experiment/NewFeatureExperiments.tsx
@@ -61,6 +61,7 @@ export default function NewFeatureExperiments() {
           source="feature-rule"
           isImport={true}
           msg="We've prefilled the form with values from the the feature."
+          // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'Partial<ExperimentInterfaceStringDates> | nu... Remove this comment to see the full error message
           initialValue={expDef}
           fromFeature={true}
         />

--- a/packages/front-end/components/Experiment/PValueColumn.tsx
+++ b/packages/front-end/components/Experiment/PValueColumn.tsx
@@ -91,6 +91,7 @@ const PValueColumn: FC<{
     className += " draw";
   }
 
+  // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'number | undefined' is not assig... Remove this comment to see the full error message
   let pValText = <>{pValueFormatter(stats?.pValue)}</>;
   if (stats?.pValueAdjusted !== undefined && pValueCorrection) {
     pValText = (
@@ -113,6 +114,7 @@ const PValueColumn: FC<{
           <div className="mb-1 d-flex flex-row">
             <Tooltip
               body={`A suspicious result occurs when the percent change is equal to or greater than your maximum percent change (${
+                // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
                 metric.maxPercentChange * 100
               }%).`}
             >

--- a/packages/front-end/components/Experiment/PValueGuardrailResults.tsx
+++ b/packages/front-end/components/Experiment/PValueGuardrailResults.tsx
@@ -161,6 +161,7 @@ const PValueGuardrailResults: FC<{
                     >
                       {r.expectedDirection ? "Better" : "Worse"}{" "}
                       {`(${
+                        // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'number | undefined' is not assig... Remove this comment to see the full error message
                         pValueFormatter(r.stats?.pValue) || "P-value missing"
                       })`}
                     </td>

--- a/packages/front-end/components/Experiment/PercentGraphColumn.tsx
+++ b/packages/front-end/components/Experiment/PercentGraphColumn.tsx
@@ -32,7 +32,9 @@ export default function PercentGraphColumn({
         ci={showGraph ? stats.ci || [] : [0, 0]}
         id={id}
         domain={domain}
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '{ dist: string; mean?: number | undefined; s... Remove this comment to see the full error message
         uplift={showGraph ? stats.uplift : null}
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'number | null | undefined' is not assignable... Remove this comment to see the full error message
         expected={showGraph ? stats.expected : null}
         barType={barType}
         barFillType="gradient"
@@ -40,7 +42,8 @@ export default function PercentGraphColumn({
         showAxis={false}
         significant={
           showGraph
-            ? stats.chanceToWin > ciUpper || stats.chanceToWin < ciLower
+            ? // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
+              stats.chanceToWin > ciUpper || stats.chanceToWin < ciLower
             : false
         }
         height={75}

--- a/packages/front-end/components/Experiment/PhaseSelector.tsx
+++ b/packages/front-end/components/Experiment/PhaseSelector.tsx
@@ -11,6 +11,7 @@ export interface Props {
 export default function PhaseSelector({ mutateExperiment, editPhases }: Props) {
   const { phase, setPhase, experiment } = useSnapshot();
 
+  // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
   const phaseOptions = experiment.phases.map((phase, i) => ({
     label: i + "",
     value: i + "",
@@ -57,6 +58,7 @@ export default function PhaseSelector({ mutateExperiment, editPhases }: Props) {
         }
 
         const phaseIndex = parseInt(value) || 0;
+        // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
         const phase = experiment.phases[phaseIndex];
         if (!phase) return value;
 
@@ -68,6 +70,7 @@ export default function PhaseSelector({ mutateExperiment, editPhases }: Props) {
                 {phase.name === "Main" ? phaseSummary(phase) : phase.name}
               </div>
               <div>
+                {/* @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message */}
                 <strong>{date(phase.dateStarted)}</strong> to{" "}
                 <strong>
                   {phase.dateEnded ? date(phase.dateEnded) : "now"}

--- a/packages/front-end/components/Experiment/ResultMoreMenu.tsx
+++ b/packages/front-end/components/Experiment/ResultMoreMenu.tsx
@@ -81,8 +81,10 @@ export default function ResultMoreMenu({
           <FaCog className="mr-2" /> Configure Analysis
         </button>
       )}
+      {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
       {queries?.length > 0 && (
         <ViewAsyncQueriesButton
+          // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
           queries={queries.map((q) => q.query)}
           error={queryError}
           className="dropdown-item py-2"
@@ -131,6 +133,7 @@ export default function ResultMoreMenu({
           className="dropdown-item py-2"
           disabled={!canDownloadJupyterNotebook}
           onClick={async () => {
+            // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
             const res = await apiCall<{ notebook: string }>(notebookUrl, {
               method: "POST",
             });
@@ -141,6 +144,7 @@ export default function ResultMoreMenu({
               })
             );
 
+            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
             const name = notebookFilename
               .replace(/[^a-zA-Z0-9_-]+/g, "")
               .replace(/[-]+/g, "_")
@@ -172,9 +176,13 @@ export default function ResultMoreMenu({
       {results && (
         <ResultsDownloadButton
           results={results}
+          // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string[] | undefined' is not assignable to t... Remove this comment to see the full error message
           metrics={metrics}
+          // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'ExperimentReportVariation[] | undefined' is ... Remove this comment to see the full error message
           variations={variations}
+          // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
           trackingKey={trackingKey}
+          // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
           dimension={dimension}
         />
       )}

--- a/packages/front-end/components/Experiment/Results.tsx
+++ b/packages/front-end/components/Experiment/Results.tsx
@@ -86,12 +86,15 @@ const Results: FC<{
   const status = getQueryStatus(latest?.queries || [], latest?.error);
 
   const hasData =
+    // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
     snapshot?.results?.[0]?.variations?.length > 0 &&
+    // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
     (snapshot.statsEngine || DEFAULT_STATS_ENGINE) === statsEngine;
 
   const phaseObj = experiment.phases?.[phase];
 
   const phaseAgeMinutes =
+    // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
     (Date.now() - getValidDate(phaseObj?.dateStarted).getTime()) / (1000 * 60);
 
   const variations = experiment.variations.map((v, i) => {
@@ -104,8 +107,10 @@ const Results: FC<{
 
   return (
     <>
+      {/* @ts-expect-error TS(2786) If you come across this, please fix it!: 'StatusBanner' cannot be used as a JSX component. */}
       <StatusBanner
         mutateExperiment={mutateExperiment}
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '(() => void) | undefined' is not assignable ... Remove this comment to see the full error message
         editResult={editResult}
       />
       <AnalysisSettingsBar
@@ -152,6 +157,7 @@ const Results: FC<{
             {snapshot &&
               phaseAgeMinutes < 120 &&
               "It was just started " +
+                // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
                 ago(experiment.phases[phase]?.dateStarted) +
                 ". Give it a little longer and click the 'Update' button above to check again."}
             {!snapshot &&
@@ -163,6 +169,7 @@ const Results: FC<{
         <VariationIdWarning
           unknownVariations={snapshot.unknownVariations || []}
           isUpdating={status === "running"}
+          // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'ExperimentReportResultDimension | undefined'... Remove this comment to see the full error message
           results={snapshot.results?.[0]}
           variations={variations}
           setVariationIds={async (ids) => {
@@ -200,37 +207,51 @@ const Results: FC<{
         />
       )}
       {hasData &&
+        // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
         snapshot.dimension &&
+        // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
         (snapshot.dimension === "pre:date" ? (
           <DateResults
             metrics={experiment.metrics}
             guardrails={experiment.guardrails}
+            // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'ExperimentReportResultDimension[] | undefine... Remove this comment to see the full error message
             results={snapshot.results}
             variations={variations}
           />
         ) : (
           <BreakDownResults
+            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
             key={snapshot.dimension}
+            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
             results={snapshot.results || []}
             variations={variations}
             metrics={experiment.metrics}
+            // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'MetricOverride[] | undefined' is not assigna... Remove this comment to see the full error message
             metricOverrides={experiment.metricOverrides}
             guardrails={experiment.guardrails}
+            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
             dimensionId={snapshot.dimension}
             isLatestPhase={phase === experiment.phases.length - 1}
+            // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
             startDate={phaseObj?.dateStarted}
+            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
             reportDate={snapshot.dateCreated}
             activationMetric={experiment.activationMetric}
             status={experiment.status}
+            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
             statsEngine={snapshot.statsEngine}
             pValueCorrection={pValueCorrection}
+            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
             regressionAdjustmentEnabled={snapshot.regressionAdjustmentEnabled}
             metricRegressionAdjustmentStatuses={
+              // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
               snapshot.metricRegressionAdjustmentStatuses
             }
+            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
             sequentialTestingEnabled={snapshot.sequentialTestingEnabled}
           />
         ))}
+      {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
       {hasData && !snapshot.dimension && (
         <>
           {reportDetailsLink && (
@@ -238,6 +259,7 @@ const Results: FC<{
               <FilterSummary
                 experiment={experiment}
                 phase={phaseObj}
+                // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'ExperimentSnapshotInterface | undefined' is ... Remove this comment to see the full error message
                 snapshot={snapshot}
               />
             </div>
@@ -245,40 +267,54 @@ const Results: FC<{
           <CompactResults
             editMetrics={editMetrics}
             variations={variations}
+            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
             multipleExposures={snapshot.multipleExposures || 0}
+            // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'ExperimentReportResultDimension | undefined'... Remove this comment to see the full error message
             results={snapshot.results?.[0]}
+            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
             reportDate={snapshot.dateCreated}
+            // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
             startDate={phaseObj?.dateStarted}
             isLatestPhase={phase === experiment.phases.length - 1}
             status={experiment.status}
             metrics={experiment.metrics}
+            // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'MetricOverride[] | undefined' is not assigna... Remove this comment to see the full error message
             metricOverrides={experiment.metricOverrides}
             id={experiment.id}
+            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
             statsEngine={snapshot.statsEngine}
             pValueCorrection={pValueCorrection}
+            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
             regressionAdjustmentEnabled={snapshot.regressionAdjustmentEnabled}
             metricRegressionAdjustmentStatuses={
+              // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
               snapshot.metricRegressionAdjustmentStatuses
             }
+            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
             sequentialTestingEnabled={snapshot.sequentialTestingEnabled}
           />
+          {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
           {experiment.guardrails?.length > 0 && (
             <div className="mt-1 px-3">
               <h3 className="mb-3">Guardrails</h3>
               <div className="row">
+                {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
                 {experiment.guardrails.map((g) => {
                   const metric = getMetricById(g);
                   if (!metric) return "";
 
+                  // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
                   const data = snapshot.results[0]?.variations;
                   if (!data) return "";
 
+                  // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
                   const xlargeCols = experiment.guardrails.length === 2 ? 6 : 4;
                   return (
                     <div
                       className={`col-12 col-xl-${xlargeCols} col-lg-6`}
                       key={g}
                     >
+                      {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
                       {snapshot.statsEngine === "frequentist" ? (
                         <PValueGuardrailResults
                           data={data}
@@ -341,6 +377,7 @@ const Results: FC<{
             <div>
               <span className="text-muted">Run date:</span>{" "}
               <span>
+                {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
                 {getValidDate(snapshot.dateCreated).toLocaleString([], {
                   year: "numeric",
                   month: "numeric",

--- a/packages/front-end/components/Experiment/ResultsDownloadButton.tsx
+++ b/packages/front-end/components/Experiment/ResultsDownloadButton.tsx
@@ -65,7 +65,9 @@ export default function ResultsDownloadButton({
         result.variations.forEach((variation, index) => {
           const metric = getMetricById(m);
           const row: ExperimentTableRow = {
+            // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
             label: metric?.name,
+            // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'MetricInterface | null' is not assignable to... Remove this comment to see the full error message
             metric: metric,
             rowClass: metric?.inverse ? "inverse" : "",
             variations: result.variations.map((v) => {
@@ -83,6 +85,7 @@ export default function ResultsDownloadButton({
             users: stats.users,
             totalValue: stats.value,
             perUserValue: stats.cr,
+            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
             perUserValueStdDev: stats.stats.stddev || null,
             chanceToBeatControl: stats.chanceToWin ?? null,
             percentChange: stats.expected || null,

--- a/packages/front-end/components/Experiment/ResultsTable.tsx
+++ b/packages/front-end/components/Experiment/ResultsTable.tsx
@@ -338,6 +338,7 @@ export default function ResultsTable({
                           startDate={startDate}
                           metric={row.metric}
                           snapshotDate={dateCreated}
+                          // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'PValueCorrection | undefined' is not assigna... Remove this comment to see the full error message
                           pValueCorrection={pValueCorrection}
                         />
                       ) : (
@@ -354,6 +355,7 @@ export default function ResultsTable({
                     {i > 0 &&
                       (fullStats ? (
                         <PercentGraphColumn
+                          // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '"pill" | null' is not assignable to type '"p... Remove this comment to see the full error message
                           barType={
                             statsEngine === "frequentist" ? "pill" : null
                           }

--- a/packages/front-end/components/Experiment/SinglePage.tsx
+++ b/packages/front-end/components/Experiment/SinglePage.tsx
@@ -231,6 +231,7 @@ export default function SinglePage({
   const denominatorMetricIds = uniq(
     allExperimentMetrics.map((m) => m?.denominator).filter((m) => m)
   );
+  // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
   const denominatorMetrics = denominatorMetricIds.map((m) => getMetricById(m));
 
   const [
@@ -249,6 +250,7 @@ export default function SinglePage({
         metricRegressionAdjustmentStatus,
       } = getRegressionAdjustmentsForMetric({
         metric: metric,
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '(MetricInterface | null)[]' is not assignabl... Remove this comment to see the full error message
         denominatorMetrics: denominatorMetrics,
         experimentRegressionAdjustmentEnabled:
           experiment.regressionAdjustmentEnabled ??
@@ -321,6 +323,7 @@ export default function SinglePage({
   const usersWatching = (watcherIds?.data?.userIds || [])
     .map((id) => users.get(id))
     .filter(Boolean)
+    // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
     .map((u) => u.name || u.email);
 
   const hasSDKWithVisualExperimentsEnabled = sdkConnectionsData?.connections.some(
@@ -643,6 +646,7 @@ export default function SinglePage({
           <div className="appbox h-100">
             <div className="p-3">
               <MarkdownInlineEdit
+                // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
                 value={experiment.description}
                 save={async (description) => {
                   await apiCall(`/experiment/${experiment.id}`, {
@@ -657,6 +661,7 @@ export default function SinglePage({
                 header="Description"
               />
               <MarkdownInlineEdit
+                // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
                 value={experiment.hypothesis}
                 save={async (hypothesis) => {
                   await apiCall(`/experiment/${experiment.id}`, {
@@ -749,6 +754,7 @@ export default function SinglePage({
               {experiment.queryFilter && (
                 <RightRailSectionGroup title="Custom Filter" type="custom">
                   <Code
+                    // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'QueryLanguage | undefined' is not assignable... Remove this comment to see the full error message
                     language={datasource?.properties?.queryLanguage}
                     code={experiment.queryFilter}
                     expandable={true}
@@ -823,11 +829,13 @@ export default function SinglePage({
                   const metric = getMetricById(m);
                   return drawMetricRow(
                     m,
+                    // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'MetricInterface | null' is not a... Remove this comment to see the full error message
                     metric,
                     experiment,
                     ignoreConversionEnd
                   );
                 })}
+                {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
                 {experiment.guardrails?.length > 0 && (
                   <>
                     <div className="row mb-1 mt-3 text-muted">
@@ -837,10 +845,12 @@ export default function SinglePage({
                       </div>
                       <div className="col-sm-2">Behavior</div>
                     </div>
+                    {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
                     {experiment.guardrails.map((m) => {
                       const metric = getMetricById(m);
                       return drawMetricRow(
                         m,
+                        // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'MetricInterface | null' is not a... Remove this comment to see the full error message
                         metric,
                         experiment,
                         ignoreConversionEnd
@@ -859,6 +869,7 @@ export default function SinglePage({
                     </div>
                     {drawMetricRow(
                       experiment.activationMetric,
+                      // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'MetricInterface | null' is not a... Remove this comment to see the full error message
                       getMetricById(experiment.activationMetric),
                       experiment,
                       ignoreConversionEnd
@@ -906,6 +917,7 @@ export default function SinglePage({
         </div>
       </div>
 
+      {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
       {growthbook.isOn("visual-editor-ui") &&
       experiment.status === "draft" &&
       experiment.phases.length > 0 ? (
@@ -943,6 +955,7 @@ export default function SinglePage({
                     className="ml-2"
                     color="link"
                     onClick={async () => {
+                      // @ts-expect-error TS(2722) If you come across this, please fix it!: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
                       editPhase(experiment.phases.length - 1);
                       track("Edit phase", { source: "visual-editor-ui" });
                     }}

--- a/packages/front-end/components/Experiment/StatusBanner.tsx
+++ b/packages/front-end/components/Experiment/StatusBanner.tsx
@@ -14,17 +14,22 @@ export default function StatusBanner({ mutateExperiment, editResult }: Props) {
   const { experiment } = useSnapshot();
   const { apiCall } = useAuth();
 
+  // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
   if (experiment.status === "stopped") {
+    // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
     const result = experiment.results;
 
     const winningVariation =
       (result === "lost"
-        ? experiment.variations[0]?.name
+        ? // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
+          experiment.variations[0]?.name
         : result === "won"
-        ? experiment.variations[experiment.winner || 1]?.name
+        ? // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
+          experiment.variations[experiment.winner || 1]?.name
         : "") || "";
 
     const releasedVariation =
+      // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
       experiment.variations.find((v) => v.id === experiment.releasedVariationId)
         ?.name || "";
 
@@ -84,9 +89,11 @@ export default function StatusBanner({ mutateExperiment, editResult }: Props) {
             </div>
           )}
         </div>
+        {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
         {experiment.analysis && (
           <div className="card text-dark mt-2">
             <div className="card-body">
+              {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
               <Markdown className="card-text">{experiment.analysis}</Markdown>
             </div>
           </div>
@@ -95,6 +102,7 @@ export default function StatusBanner({ mutateExperiment, editResult }: Props) {
     );
   }
 
+  // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
   if (experiment.status === "running") {
     return (
       <div className={clsx("alert mb-0 alert-info")}>
@@ -115,15 +123,18 @@ export default function StatusBanner({ mutateExperiment, editResult }: Props) {
     );
   }
 
+  // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
   if (experiment.status === "draft") {
     return (
       <div className={clsx("alert mb-0 alert-warning")}>
+        {/* @ts-expect-error TS(2774) If you come across this, please fix it!: This condition will always return true since this ... Remove this comment to see the full error message */}
         {editResult && (
           <Button
             color="link"
             className="alert-link float-right ml-2 p-0"
             onClick={async () => {
               // Already has a phase, just update the status
+              // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
               await apiCall(`/experiment/${experiment.id}/status`, {
                 method: "POST",
                 body: JSON.stringify({

--- a/packages/front-end/components/Experiment/VariationIdWarning.tsx
+++ b/packages/front-end/components/Experiment/VariationIdWarning.tsx
@@ -103,6 +103,7 @@ const VariationIdWarning: FC<{
             expected={definedVariations}
             actual={returnedVariations}
             names={variations.map((v) => v.name)}
+            // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '((ids: string[]) => Promise<void>) | undefin... Remove this comment to see the full error message
             setVariationIds={setVariationIds}
           />
         )}

--- a/packages/front-end/components/Experiment/VariationsTable.tsx
+++ b/packages/front-end/components/Experiment/VariationsTable.tsx
@@ -43,6 +43,7 @@ const ScreenshotCarousel: FC<{
 
   return (
     <Carousel
+      // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '((j: number) => Promise<void>) | null' is no... Remove this comment to see the full error message
       deleteImage={
         !canEdit
           ? null
@@ -85,6 +86,7 @@ const ScreenshotCarousel: FC<{
 };
 
 const isLegacyVariation = (v: Partial<LegacyVariation>): v is LegacyVariation =>
+  // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
   !!v.css || v.dom?.length > 0;
 
 const drawUrlPattern = (
@@ -147,6 +149,7 @@ const VariationsTable: FC<Props> = ({
                       : "pb-2"
                   }`}
                   style={{
+                    // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'number | null' is not assignable to type 'Bo... Remove this comment to see the full error message
                     borderBottom: hasDescriptions || hasUniqueIDs ? 0 : null,
                   }}
                 >
@@ -182,6 +185,7 @@ const VariationsTable: FC<Props> = ({
                   style={{
                     minWidth: "17.5rem",
                     height: "inherit",
+                    // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'number | null' is not assignable to type 'Bo... Remove this comment to see the full error message
                     borderBottom: canEdit ? 0 : null,
                   }}
                 >

--- a/packages/front-end/components/Experiment/VisualChangesetModal.tsx
+++ b/packages/front-end/components/Experiment/VisualChangesetModal.tsx
@@ -24,6 +24,7 @@ const VisualChangesetModal: FC<{
 
   // todo: bug bash this
   let forceAdvancedMode = false;
+  // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
   if (visualChangeset?.urlPatterns?.length > 0) {
     forceAdvancedMode = true;
   }
@@ -69,6 +70,7 @@ const VisualChangesetModal: FC<{
         body: JSON.stringify(payload),
       });
     } else {
+      // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
       await apiCall(`/visual-changesets/${visualChangeset.id}`, {
         method: "PUT",
         body: JSON.stringify(payload),

--- a/packages/front-end/components/Features/CodeSnippetModal.tsx
+++ b/packages/front-end/components/Features/CodeSnippetModal.tsx
@@ -146,6 +146,7 @@ export default function CodeSnippetModal({
           }}
           connection={currentConnection}
           mutate={mutateConnections}
+          // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '(() => void) | undefined' is not assignable ... Remove this comment to see the full error message
           goToNextStep={submit}
         />
       )}
@@ -158,6 +159,7 @@ export default function CodeSnippetModal({
         size={"max"}
         header="Implementation Instructions"
         autoCloseOnSubmit={false}
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '(() => Promise<void>) | null' is not assigna... Remove this comment to see the full error message
         submit={
           includeCheck
             ? async () => {
@@ -321,6 +323,7 @@ export default function CodeSnippetModal({
                     language={language}
                     apiHost={apiHost}
                     apiKey={clientKey}
+                    // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | false' is not assignable to type 's... Remove this comment to see the full error message
                     encryptionKey={encryptionKey}
                   />
                 </div>

--- a/packages/front-end/components/Features/ConditionInput.tsx
+++ b/packages/front-end/components/Features/ConditionInput.tsx
@@ -37,6 +37,7 @@ export default function ConditionInput(props: Props) {
 
   useEffect(() => {
     if (advanced) return;
+    // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'Condition[] | null' is not assig... Remove this comment to see the full error message
     setValue(condToJson(conds, attributes));
   }, [advanced, conds]);
 
@@ -92,6 +93,7 @@ export default function ConditionInput(props: Props) {
     );
   }
 
+  // @ts-expect-error TS(2531) If you come across this, please fix it!: Object is possibly 'null'.
   if (!conds.length) {
     return (
       <div className="form-group">
@@ -126,6 +128,7 @@ export default function ConditionInput(props: Props) {
       <label className={props.labelClassName || ""}>Targeting Conditions</label>
       <div className={`mb-3 bg-light px-3 pb-3 ${styles.conditionbox}`}>
         <ul className={styles.conditionslist}>
+          {/* @ts-expect-error TS(2531) If you come across this, please fix it!: Object is possibly 'null'. */}
           {conds.map(({ field, operator, value }, i) => {
             const attribute = attributes.get(field);
 
@@ -141,6 +144,7 @@ export default function ConditionInput(props: Props) {
               const name = e.target.name;
               const value: string | number = e.target.value;
 
+              // @ts-expect-error TS(2488) If you come across this, please fix it!: Type 'Condition[] | null' must have a '[Symbol.ite... Remove this comment to see the full error message
               const newConds = [...conds];
               newConds[i] = { ...newConds[i] };
               newConds[i][name] = value;
@@ -155,6 +159,7 @@ export default function ConditionInput(props: Props) {
             };
 
             const operatorOptions =
+              // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
               attribute.datatype === "boolean"
                 ? [
                     { label: "is true", value: "$true" },
@@ -162,7 +167,8 @@ export default function ConditionInput(props: Props) {
                     { label: "exists", value: "$exists" },
                     { label: "does not exist", value: "$notExists" },
                   ]
-                : attribute.array
+                : // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
+                attribute.array
                 ? [
                     { label: "includes", value: "$includes" },
                     { label: "does not include", value: "$notIncludes" },
@@ -171,7 +177,8 @@ export default function ConditionInput(props: Props) {
                     { label: "exists", value: "$exists" },
                     { label: "does not exist", value: "$notExists" },
                   ]
-                : attribute.enum?.length > 0
+                : // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
+                attribute.enum?.length > 0
                 ? [
                     { label: "is equal to", value: "$eq" },
                     { label: "is not equal to", value: "$ne" },
@@ -180,7 +187,8 @@ export default function ConditionInput(props: Props) {
                     { label: "exists", value: "$exists" },
                     { label: "does not exist", value: "$notExists" },
                   ]
-                : attribute.datatype === "string"
+                : // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
+                attribute.datatype === "string"
                 ? [
                     { label: "is equal to", value: "$eq" },
                     { label: "is not equal to", value: "$ne" },
@@ -198,7 +206,8 @@ export default function ConditionInput(props: Props) {
                       ? savedGroupOperators
                       : []),
                   ]
-                : attribute.datatype === "number"
+                : // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
+                attribute.datatype === "number"
                 ? [
                     { label: "is equal to", value: "$eq" },
                     { label: "is not equal to", value: "$ne" },
@@ -240,10 +249,13 @@ export default function ConditionInput(props: Props) {
 
                         const newAttribute = attributes.get(value);
                         const hasAttrChanged =
+                          // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
                           newAttribute.datatype !== attribute.datatype ||
+                          // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
                           newAttribute.array !== attribute.array;
                         if (hasAttrChanged) {
                           newConds[i]["operator"] = getDefaultOperator(
+                            // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'AttributeData | undefined' is no... Remove this comment to see the full error message
                             newAttribute
                           );
                           newConds[i]["value"] = newConds[i]["value"] || "";
@@ -296,8 +308,10 @@ export default function ConditionInput(props: Props) {
                       helpText="separate values by comma"
                       required
                     />
-                  ) : attribute.enum.length ? (
+                  ) : // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
+                  attribute.enum.length ? (
                     <SelectField
+                      // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
                       options={attribute.enum.map((v) => ({
                         label: v,
                         value: v,
@@ -311,7 +325,8 @@ export default function ConditionInput(props: Props) {
                       containerClassName="col-sm-12 col-md mb-2"
                       required
                     />
-                  ) : attribute.datatype === "number" ? (
+                  ) : // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
+                  attribute.datatype === "number" ? (
                     <Field
                       type="number"
                       step="any"
@@ -322,7 +337,8 @@ export default function ConditionInput(props: Props) {
                       containerClassName="col-sm-12 col-md mb-2"
                       required
                     />
-                  ) : attribute.datatype === "string" ? (
+                  ) : // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
+                  attribute.datatype === "string" ? (
                     <Field
                       value={value}
                       onChange={onChange}

--- a/packages/front-end/components/Features/DraftModal.tsx
+++ b/packages/front-end/components/Features/DraftModal.tsx
@@ -79,15 +79,19 @@ export default function DraftModal({
   const diffs = useMemo(() => {
     const diffs: { a: string; b: string; title: string }[] = [];
 
+    // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
     if ("defaultValue" in feature.draft) {
       diffs.push({
         title: "Default Value",
         a: feature.defaultValue,
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
         b: feature.draft.defaultValue,
       });
     }
+    // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
     if ("rules" in feature.draft) {
       environments.forEach((env) => {
+        // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
         if (env.id in feature.draft.rules) {
           diffs.push({
             title: `Rules - ${env.id}`,
@@ -96,6 +100,7 @@ export default function DraftModal({
               null,
               2
             ),
+            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
             b: JSON.stringify(feature.draft.rules[env.id] || [], null, 2),
           });
         }
@@ -108,6 +113,7 @@ export default function DraftModal({
   const hasPermission = permissions.check(
     "publishFeatures",
     feature.project,
+    // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
     "defaultValue" in feature.draft
       ? getEnabledEnvironments(feature)
       : getAffectedEnvs(feature, Object.keys(feature.draft?.rules || {}))
@@ -117,6 +123,7 @@ export default function DraftModal({
     <Modal
       open={true}
       header={"Review Draft Changes"}
+      // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '(() => Promise<void>) | null' is not assigna... Remove this comment to see the full error message
       submit={
         hasPermission
           ? async () => {
@@ -141,6 +148,7 @@ export default function DraftModal({
       close={close}
       closeCta="close"
       size="max"
+      // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'Element | null' is not assignable to type 'R... Remove this comment to see the full error message
       secondaryCTA={
         permissions.check("createFeatureDrafts", feature.project) ? (
           <Button

--- a/packages/front-end/components/Features/EditDefaultValueModal.tsx
+++ b/packages/front-end/components/Features/EditDefaultValueModal.tsx
@@ -32,6 +32,7 @@ export default function EditDefaultValueModal({
       submit={form.handleSubmit(async (value) => {
         const newDefaultValue = validateFeatureValue(
           feature.valueType,
+          // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
           value.defaultValue,
           ""
         );
@@ -58,6 +59,7 @@ export default function EditDefaultValueModal({
       <FeatureValueField
         label="Value When Enabled"
         id="defaultValue"
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
         value={form.watch("defaultValue")}
         setValue={(v) => form.setValue("defaultValue", v)}
         valueType={feature.valueType}

--- a/packages/front-end/components/Features/ExperimentSummary.tsx
+++ b/packages/front-end/components/Features/ExperimentSummary.tsx
@@ -39,6 +39,7 @@ export default function ExperimentSummary({
   const namespaceRange = hasNamespace
     ? namespace.range[1] - namespace.range[0]
     : 1;
+  // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
   const effectiveCoverage = namespaceRange * coverage;
 
   return (
@@ -50,6 +51,7 @@ export default function ExperimentSummary({
           isImport={true}
           fromFeature={true}
           msg="We couldn't find an analysis yet for that feature. Create a new one now."
+          // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'Partial<ExperimentInterfaceStringDates> | nu... Remove this comment to see the full error message
           initialValue={expDefinition}
         />
       )}
@@ -126,6 +128,7 @@ export default function ExperimentSummary({
               </span>{" "}
               of the namespace and{" "}
               <span className="border px-2 py-1 bg-light rounded">
+                {/* @ts-expect-error TS(2769) If you come across this, please fix it!: No overload matches this call. */}
                 {percentFormatter.format(coverage)}
               </span>
               <span> exposure)</span>

--- a/packages/front-end/components/Features/FeatureModal/ExperimentRuleDefaultValuesField.tsx
+++ b/packages/front-end/components/Features/FeatureModal/ExperimentRuleDefaultValuesField.tsx
@@ -80,6 +80,7 @@ const ExperimentRuleDefaultValuesField: FC<{
         defaultValue={variationsDefaultValue}
         valueType={valueType}
       />
+      {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
       {namespaces?.length > 0 && (
         <NamespaceSelector
           form={form}

--- a/packages/front-end/components/Features/FeatureModal/index.tsx
+++ b/packages/front-end/components/Features/FeatureModal/index.tsx
@@ -141,12 +141,15 @@ export default function FeatureModal({
     project,
   });
 
+  // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '{ valueType: FeatureValueType; defaultValue:... Remove this comment to see the full error message
   const form = useForm({ defaultValues });
 
   const [showTags, setShowTags] = useState(
+    // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
     featureToDuplicate?.tags?.length > 0
   );
   const [showDescription, setShowDescription] = useState(
+    // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
     featureToDuplicate?.description?.length > 0
   );
 
@@ -164,6 +167,7 @@ export default function FeatureModal({
 
   if (!permissions.check("createFeatureDrafts", project)) {
     ctaEnabled = false;
+    // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '"You don't have permission to create feature... Remove this comment to see the full error message
     disabledMessage =
       "You don't have permission to create feature flag drafts.";
   }
@@ -177,6 +181,7 @@ export default function FeatureModal({
       cta={cta}
       close={close}
       ctaEnabled={ctaEnabled}
+      // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'null' is not assignable to type 'string | un... Remove this comment to see the full error message
       disabledMessage={disabledMessage}
       secondaryCTA={secondaryCTA}
       submit={form.handleSubmit(async (values) => {
@@ -212,9 +217,11 @@ export default function FeatureModal({
 
         track("Feature Created", {
           valueType: values.valueType,
+          // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
           hasDescription: values.description.length > 0,
           initialRule: "none",
         });
+        // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string[] | undefined' is not ass... Remove this comment to see the full error message
         refreshTags(values.tags);
         refreshWatching();
 
@@ -225,6 +232,7 @@ export default function FeatureModal({
 
       {showTags ? (
         <TagsField
+          // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string[] | undefined' is not assignable to t... Remove this comment to see the full error message
           value={form.watch("tags")}
           onChange={(tags) => form.setValue("tags", tags)}
         />
@@ -245,6 +253,7 @@ export default function FeatureModal({
         <div className="form-group">
           <label>Description</label>
           <MarkdownInput
+            // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
             value={form.watch("description")}
             setValue={(value) => form.setValue("description", value)}
             autofocus={!featureToDuplicate?.description?.length}

--- a/packages/front-end/components/Features/FeatureVariationsInput.tsx
+++ b/packages/front-end/components/Features/FeatureVariationsInput.tsx
@@ -145,6 +145,7 @@ export default function FeatureVariationsInput({
           <tbody>
             <SortableVariationsList
               variations={variations}
+              // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '((variations: SortableVariation[]) => void) ... Remove this comment to see the full error message
               setVariations={setVariations}
             >
               {variations.map((variation, i) => (
@@ -153,6 +154,7 @@ export default function FeatureVariationsInput({
                   key={variation.id}
                   variation={variation}
                   variations={variations}
+                  // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '((variations: SortableVariation[]) => void) ... Remove this comment to see the full error message
                   setVariations={setVariations}
                   setWeight={setWeight}
                   customSplit={customSplit}

--- a/packages/front-end/components/Features/RevisionDropdown.tsx
+++ b/packages/front-end/components/Features/RevisionDropdown.tsx
@@ -54,6 +54,7 @@ export default function RevisionDropdown({
         version: liveVersion,
         comment: "New feature",
         date: feature.dateCreated,
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'null' is not assignable to type 'FeatureRevi... Remove this comment to see the full error message
         data: null,
         draft: false,
         live: true,
@@ -67,7 +68,9 @@ export default function RevisionDropdown({
         // Increment the live version for the draft
         version: liveVersion + 1,
         comment: feature.draft?.comment || "",
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'null' is not assignable to type 'Date'.
         date: null,
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'null' is not assignable to type 'FeatureRevi... Remove this comment to see the full error message
         data: null,
         draft: true,
         live: false,

--- a/packages/front-end/components/Features/Rule.tsx
+++ b/packages/front-end/components/Features/Rule.tsx
@@ -127,6 +127,7 @@ export const Rule = forwardRef<HTMLDivElement, RuleProps>(
           <RuleStatusPill
             rule={rule}
             upcomingScheduleRule={upcomingScheduleRule}
+            // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'number | boolean | undefined' is not assigna... Remove this comment to see the full error message
             scheduleCompletedAndDisabled={scheduleCompletedAndDisabled}
           />
           {rules.length > 1 && canEdit && (

--- a/packages/front-end/components/Features/RuleList.tsx
+++ b/packages/front-end/components/Features/RuleList.tsx
@@ -35,6 +35,7 @@ export default function RuleList({
   setRuleModal: ({ environment: string, i: number }) => void;
 }) {
   const { apiCall } = useAuth();
+  // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'null' is not assignable to param... Remove this comment to see the full error message
   const [activeId, setActiveId] = useState<string>(null);
   const [items, setItems] = useState(getRules(feature, environment));
   const permissions = usePermissions();
@@ -72,6 +73,7 @@ export default function RuleList({
 
     // if this rule covers 100% of traffic, no additional rules are reachable.
     if (isRuleFullyCovered(item)) {
+      // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'number' is not assignable to type 'null'.
       unreachableIndex = i + 1;
     }
   });
@@ -88,12 +90,15 @@ export default function RuleList({
       collisionDetection={closestCenter}
       onDragEnd={async ({ active, over }) => {
         if (!canEdit) {
+          // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'null' is not assignable to param... Remove this comment to see the full error message
           setActiveId(null);
           return;
         }
 
+        // @ts-expect-error TS(2531) If you come across this, please fix it!: Object is possibly 'null'.
         if (active.id !== over.id) {
           const oldIndex = getRuleIndex(active.id);
+          // @ts-expect-error TS(2531) If you come across this, please fix it!: Object is possibly 'null'.
           const newIndex = getRuleIndex(over.id);
 
           if (oldIndex === -1 || newIndex === -1) return;
@@ -111,6 +116,7 @@ export default function RuleList({
           });
           mutate();
         }
+        // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'null' is not assignable to param... Remove this comment to see the full error message
         setActiveId(null);
       }}
       onDragStart={({ active }) => {
@@ -131,6 +137,7 @@ export default function RuleList({
             mutate={mutate}
             experiments={experiments}
             setRuleModal={setRuleModal}
+            // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'null' is not assignable to type 'boolean | u... Remove this comment to see the full error message
             unreachable={unreachableIndex && i >= unreachableIndex}
           />
         ))}

--- a/packages/front-end/components/Features/RuleModal.tsx
+++ b/packages/front-end/components/Features/RuleModal.tsx
@@ -54,6 +54,7 @@ export default function RuleModal({
   const rule = rules[i];
 
   const defaultRuleValues = getDefaultRuleValue({
+    // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
     defaultValue: getFeatureDefaultValue(feature),
     ruleType: defaultType,
     attributeSchema,
@@ -65,12 +66,14 @@ export default function RuleModal({
   };
 
   const [scheduleToggleEnabled, setScheduleToggleEnabled] = useState(
+    // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
     defaultValues.scheduleRules.some(
       (scheduleRule) => scheduleRule.timestamp !== null
     )
   );
 
   const form = useForm({
+    // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '{ type: "force"; value: string; description:... Remove this comment to see the full error message
     defaultValues,
   });
   const { apiCall } = useAuth();
@@ -130,6 +133,7 @@ export default function RuleModal({
         try {
           const newRule = validateFeatureRule(rule, feature.valueType);
           if (newRule) {
+            // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'FeatureRule' is not assignable t... Remove this comment to see the full error message
             form.reset(newRule);
             throw new Error(
               "We fixed some errors in the rule. If it looks correct, submit again."
@@ -141,6 +145,7 @@ export default function RuleModal({
             ruleIndex: i,
             environment,
             type: values.type,
+            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
             hasCondition: rule.condition.length > 2,
             hasDescription: rule.description.length > 0,
           });
@@ -160,6 +165,7 @@ export default function RuleModal({
             ruleIndex: i,
             environment,
             type: rule.type,
+            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
             hasCondition: rule.condition.length > 2,
             hasDescription: rule.description.length > 0,
             error: e.message,
@@ -184,6 +190,7 @@ export default function RuleModal({
           const existingCondition = form.watch("condition");
           const newVal = {
             ...getDefaultRuleValue({
+              // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
               defaultValue: getFeatureDefaultValue(feature),
               ruleType: v,
               attributeSchema,
@@ -193,6 +200,7 @@ export default function RuleModal({
           if (existingCondition && existingCondition !== "{}") {
             newVal.condition = existingCondition;
           }
+          // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type '{ description: string; type: "fo... Remove this comment to see the full error message
           form.reset(newVal);
         }}
         options={[
@@ -221,6 +229,7 @@ export default function RuleModal({
           valueType={feature.valueType}
         />
       )}
+      {/* @ts-expect-error TS(2367) If you come across this, please fix it!: This condition will always return 'false' since th... Remove this comment to see the full error message */}
       {type === "rollout" && (
         <div>
           <FeatureValueField
@@ -231,8 +240,10 @@ export default function RuleModal({
             valueType={feature.valueType}
           />
           <RolloutPercentInput
+            // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'readonly (string | boolean | ScheduleRule | ... Remove this comment to see the full error message
             value={form.watch("coverage")}
             setValue={(coverage) => {
+              // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type '"coverage"' is not assignable to... Remove this comment to see the full error message
               form.setValue("coverage", coverage);
             }}
           />
@@ -241,8 +252,10 @@ export default function RuleModal({
             options={attributeSchema
               .filter((s) => !hasHashAttributes || s.hashAttribute)
               .map((s) => ({ label: s.property, value: s.property }))}
+            // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'readonly (string | boolean | ScheduleRule | ... Remove this comment to see the full error message
             value={form.watch("hashAttribute")}
             onChange={(v) => {
+              // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type '"hashAttribute"' is not assignab... Remove this comment to see the full error message
               form.setValue("hashAttribute", v);
             }}
             helpText={
@@ -251,10 +264,12 @@ export default function RuleModal({
           />
         </div>
       )}
+      {/* @ts-expect-error TS(2367) If you come across this, please fix it!: This condition will always return 'false' since th... Remove this comment to see the full error message */}
       {type === "experiment" && (
         <div>
           <Field
             label="Tracking Key"
+            // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type '"trackingKey"' is not assignable... Remove this comment to see the full error message
             {...form.register(`trackingKey`)}
             placeholder={feature.id}
             helpText="Unique identifier for this experiment, used to track impressions and analyze results"
@@ -264,8 +279,10 @@ export default function RuleModal({
             options={attributeSchema
               .filter((s) => !hasHashAttributes || s.hashAttribute)
               .map((s) => ({ label: s.property, value: s.property }))}
+            // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'readonly (string | boolean | ScheduleRule | ... Remove this comment to see the full error message
             value={form.watch("hashAttribute")}
             onChange={(v) => {
+              // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type '"hashAttribute"' is not assignab... Remove this comment to see the full error message
               form.setValue("hashAttribute", v);
             }}
             helpText={
@@ -275,14 +292,19 @@ export default function RuleModal({
           <FeatureVariationsInput
             defaultValue={getFeatureDefaultValue(feature)}
             valueType={feature.valueType}
+            // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'readonly (string | boolean | ScheduleRule | ... Remove this comment to see the full error message
             coverage={form.watch("coverage")}
+            // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type '"coverage"' is not assignable to... Remove this comment to see the full error message
             setCoverage={(coverage) => form.setValue("coverage", coverage)}
             setWeight={(i, weight) =>
+              // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type '`values.${number}.weight`' is no... Remove this comment to see the full error message
               form.setValue(`values.${i}.weight`, weight)
             }
             variations={
               form
+                // @ts-expect-error TS(2769) If you come across this, please fix it!: No overload matches this call.
                 .watch("values")
+                // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type '(v: ExperimentValue & {    id?: ... Remove this comment to see the full error message
                 .map((v: ExperimentValue & { id?: string }) => {
                   return {
                     value: v.value || "",
@@ -292,11 +314,14 @@ export default function RuleModal({
                   };
                 }) || []
             }
+            // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type '"values"' is not assignable to p... Remove this comment to see the full error message
             setVariations={(variations) => form.setValue("values", variations)}
           />
+          {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
           {namespaces?.length > 0 && (
             <NamespaceSelector
               form={form}
+              // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'readonly (string | boolean | ScheduleRule | ... Remove this comment to see the full error message
               trackingKey={form.watch("trackingKey") || feature.id}
               featureId={feature.id}
               formPrefix=""
@@ -305,6 +330,7 @@ export default function RuleModal({
         </div>
       )}
       <ScheduleInputs
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'ScheduleRule[] | undefined' is not assignabl... Remove this comment to see the full error message
         defaultValue={defaultValues.scheduleRules}
         onChange={(value) => form.setValue("scheduleRules", value)}
         scheduleToggleEnabled={scheduleToggleEnabled}

--- a/packages/front-end/components/Features/RuleStatusPill.tsx
+++ b/packages/front-end/components/Features/RuleStatusPill.tsx
@@ -28,9 +28,11 @@ export default function RuleStatusPill({
       <div className="mr-3">
         <div className="bg-info text-light border px-2 rounded">
           {`Rule was disabled by schedule rule on ${new Date(
+            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
             rule.scheduleRules[rule.scheduleRules.length - 1].timestamp
           ).toLocaleDateString()} at ${formatTimeZone(
             new Date(
+              // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
               rule.scheduleRules[rule.scheduleRules.length - 1].timestamp
             ),
             "h:mm a z"
@@ -47,8 +49,10 @@ export default function RuleStatusPill({
           {`Rule will be ${
             upcomingScheduleRule.enabled ? "enabled" : "disabled"
           } on ${new Date(
+            // @ts-expect-error TS(2769) If you come across this, please fix it!: No overload matches this call.
             upcomingScheduleRule.timestamp
           ).toLocaleDateString()} at ${formatTimeZone(
+            // @ts-expect-error TS(2769) If you come across this, please fix it!: No overload matches this call.
             new Date(upcomingScheduleRule.timestamp),
             "h:mm a z"
           )}`}

--- a/packages/front-end/components/Features/SDKConnections/InitialSDKConnectionForm.tsx
+++ b/packages/front-end/components/Features/SDKConnections/InitialSDKConnectionForm.tsx
@@ -38,6 +38,7 @@ export default function InitialSDKConnectionForm({
   const [currentConnection, setCurrentConnection] = useState(null);
 
   useEffect(() => {
+    // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type '() => SDKConnectionInterface | n... Remove this comment to see the full error message
     setCurrentConnection(() => {
       if (connections && connections[0]) {
         return connections[0];

--- a/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
+++ b/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
@@ -102,6 +102,7 @@ export default function SDKConnectionForm({
     value: p.id,
   }));
   const projectId = initialValue.project;
+  // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
   const projectName = getProjectById(projectId)?.name || null;
   const projectIsOprhaned = projectId && !projectName;
   if (projectIsOprhaned) {
@@ -133,6 +134,7 @@ export default function SDKConnectionForm({
           value.includeDraftExperiments = false;
         }
 
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '{ name: string; languages: SDKLanguage[]; en... Remove this comment to see the full error message
         const body: Omit<CreateSDKConnectionParams, "organization"> = {
           ...value,
         };
@@ -184,6 +186,7 @@ export default function SDKConnectionForm({
         <SelectField
           label="Project"
           initialOption="All Projects"
+          // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
           value={form.watch("project")}
           onChange={(project) => form.setValue("project", project)}
           options={projectsOptions}
@@ -311,6 +314,7 @@ export default function SDKConnectionForm({
 
       {(!hasNoSDKsWithSSESupport || initialValue.sseEnabled) &&
         isCloud() &&
+        // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
         gb.isOn("proxy-cloud-sse") && (
           <div className="mt-3 mb-3">
             <label htmlFor="sdk-connection-sseEnabled-toggle">
@@ -390,6 +394,7 @@ export default function SDKConnectionForm({
         )}
 
       {/*todo: deprecate this in favor of sseEnabled switch?*/}
+      {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
       {isCloud() && gb.isOn("proxy-cloud") && (
         <>
           <div className="mb-3">

--- a/packages/front-end/components/Features/SDKEndpointSelector.tsx
+++ b/packages/front-end/components/Features/SDKEndpointSelector.tsx
@@ -64,6 +64,7 @@ export default function SDKEndpointSelector({ apiKey, setApiKey }: Props) {
 
   const envsWithEndpoints = new Set<string>();
   keys.forEach((k) => {
+    // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
     envsWithEndpoints.add(k.environment);
   });
   async function createMissingEndpoints() {
@@ -120,6 +121,7 @@ export default function SDKEndpointSelector({ apiKey, setApiKey }: Props) {
               const env = key?.environment || "production";
               return (
                 <div>
+                  {/* @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message */}
                   {getProjectById(key?.project)?.name || "All Projects"}{" "}
                   <FaAngleRight /> {env}
                   {key?.description && key.description !== env && (

--- a/packages/front-end/components/Features/SDKEndpoints.tsx
+++ b/packages/front-end/components/Features/SDKEndpoints.tsx
@@ -78,6 +78,7 @@ const SDKEndpoints: FC<{
                 <tr key={key.key}>
                   {projects.length > 0 && (
                     <td>
+                      {/* @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message */}
                       {getProjectById(key.project)?.name || (
                         <em>All Projects</em>
                       )}

--- a/packages/front-end/components/Features/ScheduleInputs.tsx
+++ b/packages/front-end/components/Features/ScheduleInputs.tsx
@@ -102,6 +102,7 @@ export default function ScheduleInputs(props: Props) {
                           0
                         );
                       } else {
+                        // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'null' is not assignable to param... Remove this comment to see the full error message
                         onChange(null, "timestamp", 0);
                       }
                     }}
@@ -154,6 +155,7 @@ export default function ScheduleInputs(props: Props) {
                           1
                         );
                       } else {
+                        // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'null' is not assignable to param... Remove this comment to see the full error message
                         onChange(null, "timestamp", 1);
                       }
                     }}
@@ -176,6 +178,7 @@ export default function ScheduleInputs(props: Props) {
                           setDateErrors("");
                           if (
                             new Date(e.target.value) <
+                            // @ts-expect-error TS(2769) If you come across this, please fix it!: No overload matches this call.
                             new Date(rules[0].timestamp)
                           ) {
                             setDateErrors(

--- a/packages/front-end/components/Features/SortableFeatureVariationRow.tsx
+++ b/packages/front-end/components/Features/SortableFeatureVariationRow.tsx
@@ -171,6 +171,7 @@ export const VariationRow = forwardRef<HTMLTableRowElement, VariationProps>(
                 {decimalToPercent(weights[i])}%
               </div>
             )}
+            {/* @ts-expect-error TS(2774) If you come across this, please fix it!: This condition will always return true since this ... Remove this comment to see the full error message */}
             {variations.length > 1 && setVariations && (
               <div {...handle} title="Drag and drop to re-order rules">
                 <FaArrowsAlt />

--- a/packages/front-end/components/Features/SortableVariationsList.tsx
+++ b/packages/front-end/components/Features/SortableVariationsList.tsx
@@ -47,8 +47,10 @@ const SortableVariationsList: FC<{
       sensors={sensors}
       collisionDetection={closestCenter}
       onDragEnd={({ active, over }) => {
+        // @ts-expect-error TS(2531) If you come across this, please fix it!: Object is possibly 'null'.
         if (active.id !== over.id) {
           const oldIndex = getVariationIndex(active.id);
+          // @ts-expect-error TS(2531) If you come across this, please fix it!: Object is possibly 'null'.
           const newIndex = getVariationIndex(over.id);
 
           if (oldIndex === -1 || newIndex === -1) return;

--- a/packages/front-end/components/Forms/InlineForm.tsx
+++ b/packages/front-end/components/Forms/InlineForm.tsx
@@ -25,6 +25,7 @@ export default function InlineForm({
   canEdit?: boolean;
 }): ReactElement {
   const [saving, setSaving] = useState(false);
+  // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'null' is not assignable to param... Remove this comment to see the full error message
   const [error, setError] = useState<string>(null);
 
   const startEditing = () => {
@@ -36,6 +37,7 @@ export default function InlineForm({
 
   const save = async () => {
     if (saving) return;
+    // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'null' is not assignable to param... Remove this comment to see the full error message
     setError(null);
     setSaving(true);
     try {

--- a/packages/front-end/components/Forms/MultiSelectField.tsx
+++ b/packages/front-end/components/Forms/MultiSelectField.tsx
@@ -32,6 +32,7 @@ const SortableMultiValue = SortableElement(
       e.stopPropagation();
     };
     const innerProps = { ...props.innerProps, onMouseDown };
+    // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '{ innerProps: { onMouseDown: MouseEventHandl... Remove this comment to see the full error message
     return <components.MultiValue {...props} innerProps={innerProps} />;
   }
 );
@@ -48,6 +49,7 @@ const SortableMultiValueLabel = SortableHandle<any>(
 );
 
 const OptionWithTitle = (props: OptionProps<SingleValue>) => {
+  // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '{ children: ReactNode; innerRef: (instance: ... Remove this comment to see the full error message
   const option = <components.Option {...props} />;
   if (props.data?.tooltip) {
     return <div title={props.data.tooltip}>{option}</div>;
@@ -105,6 +107,7 @@ const MultiSelectField: FC<
   const onSortEnd: SortEndHandler = ({ oldIndex, newIndex }) => {
     onChange(
       arrayMove(
+        // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
         selected.map((v) => v.value),
         oldIndex,
         newIndex
@@ -143,6 +146,7 @@ const MultiSelectField: FC<
             }}
             closeMenuOnSelect={closeMenuOnSelect}
             autoFocus={autoFocus}
+            // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '(SingleValue | undefined)[]' is not assignab... Remove this comment to see the full error message
             value={selected}
             placeholder={initialOption ?? placeholder}
             {...{ ...ReactSelectProps, ...mergeStyles }}

--- a/packages/front-end/components/Forms/SelectField.tsx
+++ b/packages/front-end/components/Forms/SelectField.tsx
@@ -161,6 +161,7 @@ const SelectField: FC<
                   setInputValue("");
                 }}
                 onFocus={() => {
+                  // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
                   if (!map.has(selected?.value)) {
                     // If this was a custom option, reset the input value so it's editable
                     setInputValue(selected?.value || "");

--- a/packages/front-end/components/Forms/Toggle.tsx
+++ b/packages/front-end/components/Forms/Toggle.tsx
@@ -24,6 +24,7 @@ export default function Toggle({
 }) {
   const TooltipWrapper = ({ children }) =>
     disabledMessage ? (
+      // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | false' is not assignable to type 's... Remove this comment to see the full error message
       <Tooltip body={disabled && disabledMessage}>{children}</Tooltip>
     ) : (
       children

--- a/packages/front-end/components/GuidedGetStarted/GuidedGetStarted.tsx
+++ b/packages/front-end/components/GuidedGetStarted/GuidedGetStarted.tsx
@@ -204,6 +204,7 @@ export default function GuidedGetStarted({
       learnMoreLink: "Learn more about our SDKs.",
       docSection: "sdks",
       completed:
+        // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
         SDKData?.connections.length > 0 || skippedSteps["install-sdk"] || false,
       render: (
         <InitialSDKConnectionForm
@@ -266,6 +267,7 @@ export default function GuidedGetStarted({
                   Skip Step
                 </button>
               }
+              // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'boolean' is not assignable to type '(source:... Remove this comment to see the full error message
               importSampleData={
                 !hasDataSource &&
                 allowImport &&
@@ -409,6 +411,7 @@ export default function GuidedGetStarted({
               {steps[currentStep].learnMoreLink &&
                 steps[currentStep].docSection && (
                   <span>
+                    {/* @ts-expect-error TS(2322) If you come across this, please fix it!: Type '"ruby" | "home" | "features" | "experiments"... Remove this comment to see the full error message */}
                     <DocLink docSection={steps[currentStep].docSection}>
                       {steps[currentStep].learnMoreLink}
                     </DocLink>

--- a/packages/front-end/components/HomePage/ExperimentsGetStarted.tsx
+++ b/packages/front-end/components/HomePage/ExperimentsGetStarted.tsx
@@ -44,6 +44,7 @@ const ExperimentsGetStarted = ({
       const initialExperiment: Partial<ExperimentInterfaceStringDates> = JSON.parse(
         router?.query?.featureExperiment as string
       );
+      // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'null' is not assignable to param... Remove this comment to see the full error message
       window.history.replaceState(null, null, window.location.pathname);
       return initialExperiment;
     } catch (e) {
@@ -100,6 +101,7 @@ const ExperimentsGetStarted = ({
               await mutateDefinitions();
               setDataSourceOpen(false);
             }}
+            // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'boolean' is not assignable to type '(source:... Remove this comment to see the full error message
             importSampleData={
               !hasDataSource &&
               allowImport &&

--- a/packages/front-end/components/HomePage/FeaturesGetStarted.tsx
+++ b/packages/front-end/components/HomePage/FeaturesGetStarted.tsx
@@ -62,6 +62,7 @@ export default function FeaturesGetStarted({ features }: Props) {
           <div className={`card gsbox`} style={{ overflow: "hidden" }}>
             <GetStartedStep
               current={step === 1}
+              // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'boolean | undefined' is not assignable to ty... Remove this comment to see the full error message
               finished={settings?.sdkInstructionsViewed}
               className="border-top"
               image="/images/coding-icon.svg"

--- a/packages/front-end/components/HomePage/IdeasFeed.tsx
+++ b/packages/front-end/components/HomePage/IdeasFeed.tsx
@@ -33,6 +33,7 @@ const IdeasFeed: FC<{
       <ul className="list-unstyled simple-divider pl-0 mb-0">
         {data.ideas.map((idea, i) => {
           const linkUrl = "/idea/" + idea.id;
+          // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | null' is not assignable... Remove this comment to see the full error message
           const user = users.get(idea.userId);
           const email = user ? user.email : "";
           const name = user ? user.name : idea.userName;

--- a/packages/front-end/components/HomePage/NorthStarMetricDisplay.tsx
+++ b/packages/front-end/components/HomePage/NorthStarMetricDisplay.tsx
@@ -51,6 +51,7 @@ const NorthStarMetricDisplay = ({
     : data.experiments;
   let analysis = data.metric.analysis;
   if (!analysis || !("average" in analysis)) {
+    // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'null' is not assignable to type 'MetricAnaly... Remove this comment to see the full error message
     analysis = null;
   }
   const status = getQueryStatus(metric.queries || [], metric.analysisError);

--- a/packages/front-end/components/Icons.tsx
+++ b/packages/front-end/components/Icons.tsx
@@ -435,6 +435,7 @@ export function GBPremiumBadge({
   prependsText = false,
   size = "large",
 }): GBPremiumBadge {
+  // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'null' is not assignable to type 'GBPremiumBa... Remove this comment to see the full error message
   if (!shouldDisplay) return null;
   return (
     <svg

--- a/packages/front-end/components/Ideas/ImpactModal.tsx
+++ b/packages/front-end/components/Ideas/ImpactModal.tsx
@@ -23,8 +23,11 @@ const ImpactModal: FC<{
     defaultValues: {
       metric: estimate?.metric || metrics[0]?.id || "",
       segment: estimate?.segment || "",
+      // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
       userAdjustment: idea.estimateParams?.userAdjustment || 100,
+      // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
       numVariations: idea.estimateParams?.numVariations || 2,
+      // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
       improvement: idea.estimateParams?.improvement || 10,
     },
   });
@@ -96,6 +99,7 @@ const ImpactModal: FC<{
           },
         };
 
+        // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
         await apiCall(`/idea/${idea.id}`, {
           method: "POST",
           body: JSON.stringify(data),

--- a/packages/front-end/components/Ideas/ImpactProjections.tsx
+++ b/packages/front-end/components/Ideas/ImpactProjections.tsx
@@ -62,6 +62,7 @@ const ImpactProjections: FC<{
           <em>Conversions:</em>
         </small>
         <div className="pt-1">
+          {/* @ts-expect-error TS(2454) If you come across this, please fix it!: Variable 'conversions' is used before being assign... Remove this comment to see the full error message */}
           <strong className="border p-1 mr-1">{conversions}</strong>
           <small className="text-muted">/ variation / day</small>
         </div>

--- a/packages/front-end/components/Layout/Layout.tsx
+++ b/packages/front-end/components/Layout/Layout.tsx
@@ -246,6 +246,7 @@ const otherPageTitles = [
 
 const backgroundShade = (color: string) => {
   // convert to RGB
+  // @ts-expect-error TS(2769) If you come across this, please fix it!: No overload matches this call.
   const c = +("0x" + color.slice(1).replace(color.length < 5 && /./g, "$&$&"));
   const r = c >> 16;
   const g = (c >> 8) & 255;
@@ -265,6 +266,7 @@ const Layout = (): React.ReactElement => {
   const { accountPlan } = useUser();
 
   const [upgradeModal, setUpgradeModal] = useState(false);
+  // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
   const showUpgradeButton = ["oss", "starter"].includes(accountPlan);
 
   // hacky:
@@ -272,6 +274,7 @@ const Layout = (): React.ReactElement => {
   const path = router.route.substr(1);
   // don't show the nav for presentations
   if (path.match(/^present\//)) {
+    // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'null' is not assignable to type 'ReactElemen... Remove this comment to see the full error message
     return null;
   }
 
@@ -297,6 +300,7 @@ const Layout = (): React.ReactElement => {
   let customStyles = ``;
   if (settings?.customized) {
     const textColor =
+      // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
       backgroundShade(settings?.primaryColor) === "dark" ? "#fff" : "#444";
 
     // we could support saving this CSS in the settings so it can be customized
@@ -459,6 +463,7 @@ const Layout = (): React.ReactElement => {
       </div>
 
       <TopNav
+        // @ts-expect-error TS(2454) If you come across this, please fix it!: Variable 'pageTitle' is used before being assigned... Remove this comment to see the full error message
         pageTitle={pageTitle}
         showNotices={true}
         toggleLeftMenu={() => setOpen(!open)}

--- a/packages/front-end/components/Layout/RightRailSectionGroup.tsx
+++ b/packages/front-end/components/Layout/RightRailSectionGroup.tsx
@@ -43,6 +43,7 @@ const RightRailSectionGroup: FC<{
         <>
           {type === "tags" && (
             <SortedTags
+              // @ts-expect-error TS(2533) If you come across this, please fix it!: Object is possibly 'null' or 'undefined'.
               tags={Children.map(children, (child) => child + "").filter(
                 Boolean
               )}

--- a/packages/front-end/components/Layout/SidebarLink.tsx
+++ b/packages/front-end/components/Layout/SidebarLink.tsx
@@ -50,6 +50,7 @@ const SidebarLink: FC<SidebarLinkProps> = (props) => {
     }
   }, [selected]);
 
+  // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
   if (props.feature && !growthbook.isOn(props.feature)) {
     return null;
   }
@@ -130,6 +131,7 @@ const SidebarLink: FC<SidebarLinkProps> = (props) => {
         >
           {props.subLinks
             .filter(
+              // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
               (subLink) => !subLink.feature || growthbook.isOn(subLink.feature)
             )
             .map((l) => {
@@ -148,6 +150,7 @@ const SidebarLink: FC<SidebarLinkProps> = (props) => {
               if (l.selfHostedOnly && isCloud()) {
                 return null;
               }
+              // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'AccountPlan | undefined' is not ... Remove this comment to see the full error message
               if (l.accountPlans && !l.accountPlans.includes(accountPlan)) {
                 return null;
               }

--- a/packages/front-end/components/Layout/TopNav.tsx
+++ b/packages/front-end/components/Layout/TopNav.tsx
@@ -166,6 +166,7 @@ const TopNav: FC<{
                     href="#"
                     onClick={(e) => {
                       e.preventDefault();
+                      // @ts-expect-error TS(2722) If you come across this, please fix it!: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
                       setOrgId(o.id);
                       setOrgDropdownOpen(false);
                     }}
@@ -187,6 +188,7 @@ const TopNav: FC<{
               }}
               style={{ cursor: "pointer" }}
             >
+              {/* @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message */}
               <Avatar email={email} size={26} />{" "}
               <span className="d-none d-lg-inline">{email}</span>
             </div>

--- a/packages/front-end/components/Markdown/MarkdownInlineEdit.tsx
+++ b/packages/front-end/components/Markdown/MarkdownInlineEdit.tsx
@@ -24,6 +24,7 @@ const MarkdownInlineEdit: FC<{
 }) => {
   const [edit, setEdit] = useState(false);
   const [val, setVal] = useState("");
+  // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'null' is not assignable to param... Remove this comment to see the full error message
   const [error, setError] = useState<string>(null);
   const [loading, setLoading] = useState(false);
 
@@ -34,6 +35,7 @@ const MarkdownInlineEdit: FC<{
         onSubmit={async (e) => {
           e.preventDefault();
           if (loading) return;
+          // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'null' is not assignable to param... Remove this comment to see the full error message
           setError(null);
           setLoading(true);
           try {
@@ -63,6 +65,7 @@ const MarkdownInlineEdit: FC<{
     <div className={className}>
       {header && (
         <HeaderWithEdit
+          // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'false | "" | (() => void)' is not assignable... Remove this comment to see the full error message
           edit={
             value &&
             canEdit &&

--- a/packages/front-end/components/Marketing/PremiumTooltip.tsx
+++ b/packages/front-end/components/Marketing/PremiumTooltip.tsx
@@ -8,6 +8,7 @@ import { GBPremiumBadge } from "../Icons";
 export default function PremiumTooltip({
   commercialFeature,
   children,
+  // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'null' is not assignable to type 'string | El... Remove this comment to see the full error message
   body = null,
   tipPosition = "top",
   className = "",

--- a/packages/front-end/components/Metrics/DateGraph.tsx
+++ b/packages/front-end/components/Metrics/DateGraph.tsx
@@ -102,6 +102,7 @@ function getTooltipContents(
           </div>
           {"s" in d && method === "avg" && (
             <div className={styles.secondary}>
+              {/* @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'number | undefined' is not assig... Remove this comment to see the full error message */}
               {`σ`}: {formatConversionRate(type, d.s)}
               {smoothBy === "week" && (
                 <sub style={{ fontWeight: "normal", fontSize: 8 }}> smooth</sub>
@@ -109,6 +110,7 @@ function getTooltipContents(
             </div>
           )}
           <div className={styles.secondary}>
+            {/* @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'number | undefined' is not assig... Remove this comment to see the full error message */}
             <em>n</em>: {Math.round(d.c)}
           </div>
         </>
@@ -179,6 +181,7 @@ const DateGraph: FC<DateGraphProps> = ({
     () =>
       dates.map((row, i) => {
         const key = getValidDate(row.d).getTime();
+        // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
         let value = method === "avg" ? row.v : row.v * row.c;
         let stddev = method === "avg" ? row.s : 0;
         const count = row.c || 1;
@@ -188,9 +191,11 @@ const DateGraph: FC<DateGraphProps> = ({
           const windowedDates = dates.slice(Math.max(i - 6, 0), i + 1);
           const days = windowedDates.length;
           const sumValue = windowedDates.reduce((acc, cur) => {
+            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
             return acc + (method === "avg" ? cur.v : cur.v * cur.c);
           }, 0);
           const sumStddev = windowedDates.reduce((acc, cur) => {
+            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
             return acc + (method === "avg" ? cur.s : 0);
           }, 0);
           value = days ? sumValue / days : 0;
@@ -222,7 +227,9 @@ const DateGraph: FC<DateGraphProps> = ({
     experiments.forEach((e) => {
       if (e.status !== "draft") {
         const expLines: ExperimentDisplayData = {
+          // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
           name: e.name,
+          // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
           id: e.id,
           color: "rgb(136, 132, 216)",
           band: 0,
@@ -244,10 +251,12 @@ const DateGraph: FC<DateGraphProps> = ({
         if (e?.phases) {
           e?.phases.forEach((p) => {
             if (!expLines.dateStarted) expLines.dateStarted = p.dateStarted;
+            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
             else if (p.dateStarted < expLines.dateStarted) {
               expLines.dateStarted = p.dateStarted;
             }
             if (!expLines.dateEnded) expLines.dateEnded = p.dateEnded;
+            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
             else if (p.dateEnded > expLines.dateEnded) {
               expLines.dateEnded = p.dateEnded;
             }
@@ -265,6 +274,7 @@ const DateGraph: FC<DateGraphProps> = ({
     });
     // get all the experiments in order of start date.
     experimentDates.sort((a, b) => {
+      // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
       return a.dateStarted > b.dateStarted ? 1 : -1;
     });
 
@@ -281,6 +291,7 @@ const DateGraph: FC<DateGraphProps> = ({
         } else {
           let fits = true;
           for (let i = 0; i < curBands.length; i++) {
+            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
             if (ed.dateStarted < curBands[i].dateEnded) {
               // it will not fit, there is an overlapping test.
               fits = false;
@@ -466,6 +477,7 @@ const DateGraph: FC<DateGraphProps> = ({
                     className={styles.tooltip}
                     unstyled={true}
                   >
+                    {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
                     {getTooltipContents(tooltipData.d, type, method, smoothBy)}
                   </TooltipWithBounds>
                 </>
@@ -493,18 +505,23 @@ const DateGraph: FC<DateGraphProps> = ({
                           <rect
                             key={e.id}
                             fill={e.color}
+                            // @ts-expect-error TS(2769) If you come across this, please fix it!: No overload matches this call.
                             x={xScale(new Date(e.dateStarted).getTime())}
                             y={0}
                             width={
+                              // @ts-expect-error TS(2769) If you come across this, please fix it!: No overload matches this call.
                               xScale(new Date(e.dateEnded).getTime()) -
+                              // @ts-expect-error TS(2769) If you come across this, please fix it!: No overload matches this call.
                               xScale(new Date(e.dateStarted).getTime())
                             }
                             style={{ opacity: 0.15 }}
                             height={graphHeight}
                             onMouseOver={() => {
+                              // @ts-expect-error TS(2769) If you come across this, please fix it!: No overload matches this call.
                               clearTimeout(toolTipTimer);
                             }}
                             onMouseLeave={() => {
+                              // @ts-expect-error TS(2769) If you come across this, please fix it!: No overload matches this call.
                               clearTimeout(toolTipTimer);
                               setToolTipTimer(
                                 setTimeout(setHighlightExp, toolTipDelay, null)
@@ -564,6 +581,7 @@ const DateGraph: FC<DateGraphProps> = ({
                           y1={(d) => yScale(addStddev(d.v, d.s, 2, true))}
                           fill={"url(#stripe-pattern)"}
                           opacity={0.3}
+                          // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '(d: Datapoint, i: number) => boolean | undef... Remove this comment to see the full error message
                           defined={(d, i) => d?.oor || data?.[i - 1]?.oor}
                           curve={curveMonotoneX}
                         />
@@ -575,6 +593,7 @@ const DateGraph: FC<DateGraphProps> = ({
                           y1={(d) => yScale(addStddev(d.v, d.s, 1, true))}
                           fill={"url(#stripe-pattern)"}
                           opacity={0.3}
+                          // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '(d: Datapoint, i: number) => boolean | undef... Remove this comment to see the full error message
                           defined={(d, i) => d?.oor || data?.[i - 1]?.oor}
                           curve={curveMonotoneX}
                         />
@@ -602,6 +621,7 @@ const DateGraph: FC<DateGraphProps> = ({
                     strokeDasharray={"2,5"}
                     strokeWidth={2}
                     curve={curveMonotoneX}
+                    // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '(d: Datapoint, i: number) => boolean | undef... Remove this comment to see the full error message
                     defined={(d, i) => d?.oor || data?.[i - 1]?.oor}
                   />
                 )}
@@ -649,11 +669,14 @@ const DateGraph: FC<DateGraphProps> = ({
                 >
                   {experimentDates.map((e, i) => {
                     const rectWidth =
+                      // @ts-expect-error TS(2769) If you come across this, please fix it!: No overload matches this call.
                       xScale(new Date(e.dateEnded).getTime()) -
+                      // @ts-expect-error TS(2769) If you come across this, please fix it!: No overload matches this call.
                       xScale(new Date(e.dateStarted).getTime());
                     e.tipPosition = {
                       top: height,
                       left:
+                        // @ts-expect-error TS(2769) If you come across this, please fix it!: No overload matches this call.
                         xScale(new Date(e.dateStarted).getTime()) +
                         Math.min(150, rectWidth / 2),
                     };
@@ -664,17 +687,21 @@ const DateGraph: FC<DateGraphProps> = ({
                       <rect
                         key={i}
                         fill={e.color}
+                        // @ts-expect-error TS(2769) If you come across this, please fix it!: No overload matches this call.
                         x={xScale(new Date(e.dateStarted).getTime())}
+                        // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
                         y={e.band * (expBarHeight + expBarMargin)}
                         width={rectWidth}
                         style={{ opacity: e.opacity }}
                         rx={4}
                         height={expBarHeight}
                         onMouseOver={() => {
+                          // @ts-expect-error TS(2769) If you come across this, please fix it!: No overload matches this call.
                           clearTimeout(toolTipTimer);
                           setHighlightExp(e);
                         }}
                         onMouseLeave={() => {
+                          // @ts-expect-error TS(2769) If you come across this, please fix it!: No overload matches this call.
                           clearTimeout(toolTipTimer);
                           setToolTipTimer(
                             setTimeout(setHighlightExp, toolTipDelay, null)
@@ -688,7 +715,9 @@ const DateGraph: FC<DateGraphProps> = ({
             </svg>
             {highlightExp && (
               <Tooltip
+                // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
                 top={highlightExp.tipPosition.top}
+                // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
                 left={highlightExp.tipPosition.left}
                 className={styles.tooltip}
                 style={{
@@ -697,9 +726,11 @@ const DateGraph: FC<DateGraphProps> = ({
                   zIndex: 9000,
                 }}
                 onMouseOver={() => {
+                  // @ts-expect-error TS(2769) If you come across this, please fix it!: No overload matches this call.
                   clearTimeout(toolTipTimer);
                 }}
                 onMouseLeave={() => {
+                  // @ts-expect-error TS(2769) If you come across this, please fix it!: No overload matches this call.
                   clearTimeout(toolTipTimer);
                   setToolTipTimer(
                     setTimeout(setHighlightExp, toolTipDelay, null)
@@ -717,10 +748,12 @@ const DateGraph: FC<DateGraphProps> = ({
                     </Link>
                   </p>
                   <p className="mb-1">
+                    {/* @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message */}
                     {date(highlightExp.dateStarted)} -{" "}
                     {highlightExp.status === "running"
                       ? ""
-                      : date(highlightExp.dateEnded)}
+                      : // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
+                        date(highlightExp.dateEnded)}
                   </p>
                   <p className="mb-1">
                     {highlightExp.status === "running" ? (

--- a/packages/front-end/components/Metrics/MetricForm/index.tsx
+++ b/packages/front-end/components/Metrics/MetricForm/index.tsx
@@ -107,10 +107,14 @@ function getRawSQLPreview({
   conditions,
 }: Partial<MetricInterface>) {
   const cols: string[] = [];
+  // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
   userIdTypes.forEach((type) => {
+    // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
     if (userIdColumns[type] !== type) {
+      // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
       cols.push(userIdColumns[type] + " as " + type);
     } else {
+      // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
       cols.push(userIdColumns[type]);
     }
   });
@@ -125,9 +129,11 @@ function getRawSQLPreview({
   }
 
   let where = "";
+  // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
   if (conditions.length) {
     where =
       "\nWHERE\n  " +
+      // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
       conditions
         .map((c: Condition) => {
           return (c.column || "_") + " " + c.operator + " '" + c.value + "'";
@@ -442,6 +448,7 @@ const MetricForm: FC<MetricFormProps> = ({
   }, [type, form]);
 
   const { setTableId, tableOptions, columnOptions } = useSchemaFormOptions(
+    // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'DataSourceInterfaceWithParams | ... Remove this comment to see the full error message
     selectedDataSource
   );
 
@@ -450,9 +457,11 @@ const MetricForm: FC<MetricFormProps> = ({
 
   if (riskError) {
     ctaEnabled = false;
+    // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '"The acceptable risk percentage cannot be hi... Remove this comment to see the full error message
     disabledMessage = riskError;
   } else if (!permissions.check("createMetrics", project)) {
     ctaEnabled = false;
+    // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '"You don't have permission to create metrics... Remove this comment to see the full error message
     disabledMessage = "You don't have permission to create metrics.";
   }
 
@@ -474,10 +483,12 @@ const MetricForm: FC<MetricFormProps> = ({
         inline={inline}
         header={edit ? "Edit Metric" : "New Metric"}
         close={onClose}
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'null' is not assignable to type 'string | un... Remove this comment to see the full error message
         disabledMessage={disabledMessage}
         ctaEnabled={ctaEnabled}
         submit={onSubmit}
         cta={cta}
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'false | "Cancel"' is not assignable to type ... Remove this comment to see the full error message
         closeCta={!inline && "Cancel"}
         size="lg"
         docSection="metrics"
@@ -1050,6 +1061,7 @@ const MetricForm: FC<MetricFormProps> = ({
                     ? metricDefaults.minimumSampleSize
                     : formatConversionRate(
                         value.type,
+                        // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'number | undefined' is not assig... Remove this comment to see the full error message
                         metricDefaults.minimumSampleSize
                       )}
                   )
@@ -1063,6 +1075,7 @@ const MetricForm: FC<MetricFormProps> = ({
                 {...form.register("maxPercentChange", { valueAsNumber: true })}
                 helpText={`An experiment that changes the metric by more than this percent will
             be flagged as suspicious (default ${
+              // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
               metricDefaults.maxPercentageChange * 100
             })`}
               />
@@ -1074,6 +1087,7 @@ const MetricForm: FC<MetricFormProps> = ({
                 {...form.register("minPercentChange", { valueAsNumber: true })}
                 helpText={`An experiment that changes the metric by less than this percent will be
             considered a draw (default ${
+              // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
               metricDefaults.minPercentageChange * 100
             })`}
               />

--- a/packages/front-end/components/Metrics/MetricTooltipBody.tsx
+++ b/packages/front-end/components/Metrics/MetricTooltipBody.tsx
@@ -37,6 +37,7 @@ const MetricTooltipBody = ({
       body: metric.type,
     },
     {
+      // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
       show: metric.tags?.length > 0,
       label: "Tags",
       body: <SortedTags tags={metric.tags} />,
@@ -44,6 +45,7 @@ const MetricTooltipBody = ({
     {
       show: !isNullUndefinedOrEmpty(metric.cap) && metric.cap !== 0,
       label: "Cap",
+      // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'number | undefined' is not assignable to typ... Remove this comment to see the full error message
       body: metric.cap,
     },
     {
@@ -51,11 +53,13 @@ const MetricTooltipBody = ({
         !isNullUndefinedOrEmpty(metric.conversionDelayHours) &&
         metric.conversionDelayHours !== 0,
       label: "Conversion Delay Hours",
+      // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'number | undefined' is not assignable to typ... Remove this comment to see the full error message
       body: metric.conversionDelayHours,
     },
     {
       show: !isNullUndefinedOrEmpty(metric.conversionWindowHours),
       label: "Conversion Window Hours",
+      // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'number | undefined' is not assignable to typ... Remove this comment to see the full error message
       body: metric.conversionWindowHours,
     },
   ];

--- a/packages/front-end/components/Modal.tsx
+++ b/packages/front-end/components/Modal.tsx
@@ -71,6 +71,7 @@ const Modal: FC<ModalProps> = ({
   }
 
   useEffect(() => {
+    // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
     setError(externalError);
   }, [externalError]);
 
@@ -96,7 +97,9 @@ const Modal: FC<ModalProps> = ({
     <div
       className={`modal-content ${className}`}
       style={{
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | null' is not assignable to type 'He... Remove this comment to see the full error message
         height: sizeY === "max" ? "93vh" : null,
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | null' is not assignable to type 'Ma... Remove this comment to see the full error message
         maxHeight: sizeY ? null : size === "fill" ? "" : "93vh",
       }}
     >
@@ -152,6 +155,7 @@ const Modal: FC<ModalProps> = ({
       )}
       <div
         className={`modal-body ${bodyClassName}`}
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'MutableRefObject<HTMLDivElement | undefined>... Remove this comment to see the full error message
         ref={bodyRef}
         style={overflowAuto ? { overflowY: "auto" } : {}}
       >
@@ -176,6 +180,7 @@ const Modal: FC<ModalProps> = ({
           {secondaryCTA}
           {submit && !isSuccess ? (
             <Tooltip
+              // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
               body={disabledMessage}
               shouldDisplay={!ctaEnabled && !!disabledMessage}
               tipPosition="top"
@@ -226,6 +231,7 @@ const Modal: FC<ModalProps> = ({
     >
       <div
         className={`modal-dialog modal-${size}`}
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '{ width: string; maxWidth: number; margin: s... Remove this comment to see the full error message
         style={
           size === "max"
             ? { width: "95vw", maxWidth: 1400, margin: "2vh auto" }
@@ -277,6 +283,7 @@ const Modal: FC<ModalProps> = ({
           "d-none": !open,
           "bg-dark": solidOverlay,
         })}
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '{ opacity: number; } | null' is not assignab... Remove this comment to see the full error message
         style={overlayStyle}
       />
       {modalHtml}

--- a/packages/front-end/components/Modal/PagedModal.tsx
+++ b/packages/front-end/components/Modal/PagedModal.tsx
@@ -58,7 +58,9 @@ const PagedModal: FC<Props> = (props) => {
     validate?: () => Promise<void>;
   }[] = [];
   let content: ReactNode;
+  // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'null' is not assignable to type 'number'.
   let nextStep: number = null;
+  // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'null' is not assignable to type 'number'.
   let prevStep: number = null;
   Children.forEach(children, (child) => {
     if (!isValidElement(child)) return;
@@ -73,6 +75,7 @@ const PagedModal: FC<Props> = (props) => {
   });
 
   prevStep = step - 1;
+  // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'null' is not assignable to type 'number'.
   if (prevStep < 0) prevStep = null;
 
   async function validateSteps(before?: number) {
@@ -81,6 +84,7 @@ const PagedModal: FC<Props> = (props) => {
       if (steps[i].enabled === false) continue;
       if (!steps[i].validate) continue;
       try {
+        // @ts-expect-error TS(2722) If you come across this, please fix it!: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
         await steps[i].validate();
       } catch (e) {
         setStep(i);
@@ -112,6 +116,7 @@ const PagedModal: FC<Props> = (props) => {
           setStep(nextStep);
         }
       }}
+      // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'Element | null' is not assignable to type 'R... Remove this comment to see the full error message
       secondaryCTA={
         secondaryCTA ? (
           secondaryCTA

--- a/packages/front-end/components/ProjectBadges.tsx
+++ b/packages/front-end/components/ProjectBadges.tsx
@@ -34,6 +34,7 @@ export default function ProjectBadges({
   if (sort) {
     filteredProjects = filteredProjects.sort(
       (a, b) =>
+        // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
         new Date(a.dateCreated).getTime() - new Date(b.dateCreated).getTime()
     );
   }

--- a/packages/front-end/components/ProtectedPage.tsx
+++ b/packages/front-end/components/ProtectedPage.tsx
@@ -63,6 +63,7 @@ const LoggedInPageGuard = ({
   }
 
   // Still waiting to fetch current user/org details
+  // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
   if (organizations?.length > 0 && !organization) {
     return <LoadingOverlay />;
   }

--- a/packages/front-end/components/Queries/ExpandableQuery.tsx
+++ b/packages/front-end/components/Queries/ExpandableQuery.tsx
@@ -64,6 +64,7 @@ const ExpandableQuery: FC<{
                     return (
                       <tr key={i}>
                         <th>{i}</th>
+                        {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
                         {Object.keys(query.rawResult[0]).map((k) => {
                           return (
                             <td key={k}>
@@ -92,6 +93,7 @@ const ExpandableQuery: FC<{
             Took{" "}
             {formatDistanceStrict(
               getValidDate(query.startedAt),
+              // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'Date | undefined' is not assigna... Remove this comment to see the full error message
               getValidDate(query.finishedAt)
             )}
           </em>

--- a/packages/front-end/components/Queries/RunQueriesButton.tsx
+++ b/packages/front-end/components/Queries/RunQueriesButton.tsx
@@ -165,10 +165,12 @@ const RunQueriesButton: FC<{
               ? `${loadingText} (${getTimeDisplay(counter)})...`
               : cta}
           </button>
+          {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
           {status === "running" && data?.total > 0 && (
             <div
               style={{
                 width:
+                  // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
                   Math.floor((100 * (data?.finished || 0)) / data?.total) + "%",
                 height: 5,
               }}

--- a/packages/front-end/components/Report/ConfigureReport.tsx
+++ b/packages/front-end/components/Report/ConfigureReport.tsx
@@ -61,6 +61,7 @@ export default function ConfigureReport({
   }>(`/experiment/${eid}`);
   const experiment = experimentData?.experiment;
   const pid = experiment?.project;
+  // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
   const project = getProjectById(pid);
 
   const { settings: parentSettings } = getScopedSettings({
@@ -85,6 +86,7 @@ export default function ConfigureReport({
   const denominatorMetricIds = uniq(
     allExperimentMetrics.map((m) => m?.denominator).filter((m) => m)
   );
+  // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
   const denominatorMetrics = denominatorMetricIds.map((m) => getMetricById(m));
 
   // todo: type this form
@@ -130,6 +132,7 @@ export default function ConfigureReport({
         metricRegressionAdjustmentStatus,
       } = getRegressionAdjustmentsForMetric({
         metric: metric,
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '(MetricInterface | null)[]' is not assignabl... Remove this comment to see the full error message
         denominatorMetrics: denominatorMetrics,
         experimentRegressionAdjustmentEnabled: !!form.watch(
           `regressionAdjustmentEnabled`
@@ -305,12 +308,14 @@ export default function ConfigureReport({
           improve.
         </div>
         <MetricsSelector
+          // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string[] | undefined' is not assignable to t... Remove this comment to see the full error message
           selected={form.watch("guardrails")}
           onChange={(metrics) => form.setValue("guardrails", metrics)}
           datasource={report.args.datasource}
         />
       </div>
       <DimensionChooser
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | null | undefined' is not assignable... Remove this comment to see the full error message
         value={form.watch("dimension")}
         setValue={(value) => form.setValue("dimension", value || "")}
         activationMetric={!!form.watch("activationMetric")}
@@ -330,6 +335,7 @@ export default function ConfigureReport({
           };
         })}
         initialOption="None"
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
         value={form.watch("activationMetric")}
         onChange={(value) => form.setValue("activationMetric", value || "")}
         helpText="Users must convert on this metric before being included"
@@ -338,6 +344,7 @@ export default function ConfigureReport({
         <SelectField
           label="Segment"
           labelClassName="font-weight-bold"
+          // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
           value={form.watch("segment")}
           onChange={(value) => form.setValue("segment", value || "")}
           initialOption="None (All Users)"
@@ -488,6 +495,7 @@ export default function ConfigureReport({
                 {...form.register("sequentialTestingTuningParameter", {
                   valueAsNumber: true,
                   validate: (v) => {
+                    // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
                     return !(v <= 0);
                   },
                 })}

--- a/packages/front-end/components/SQLInputField.tsx
+++ b/packages/front-end/components/SQLInputField.tsx
@@ -66,6 +66,7 @@ export default function SQLInputField({
       const suggestions: ReactElement[] = [];
 
       const namedCols = ["experiment_name", "variation_name"];
+      // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
       const userIdTypes = identityTypes.map((type) => type.userIdType || []);
 
       const returnedColumns = new Set<string>(Object.keys(result));
@@ -224,8 +225,10 @@ export default function SQLInputField({
             <DisplayTestQueryResults
               duration={parseInt(testQueryResults.duration || "0")}
               requiredColumns={[...requiredColumns]}
+              // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'TestQueryRow[] | undefined' is not assignabl... Remove this comment to see the full error message
               results={testQueryResults.results}
               error={testQueryResults.error}
+              // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
               sql={testQueryResults.sql}
               suggestions={suggestions}
             />

--- a/packages/front-end/components/SavedGroupForm.tsx
+++ b/packages/front-end/components/SavedGroupForm.tsx
@@ -58,7 +58,9 @@ const SavedGroupForm: FC<{
         onChange={(v) => form.setValue("owner", v)}
         placeholder="Optional"
         options={memberUsernameOptions.map((m) => ({
+          // @ts-expect-error TS(2339) If you come across this, please fix it!: Property 'display' does not exist on type 'never'.
           value: m.display,
+          // @ts-expect-error TS(2339) If you come across this, please fix it!: Property 'display' does not exist on type 'never'.
           label: m.display,
         }))}
       />

--- a/packages/front-end/components/SchemaBrowser/DatasourceTableData.tsx
+++ b/packages/front-end/components/SchemaBrowser/DatasourceTableData.tsx
@@ -32,6 +32,7 @@ export default function DatasourceSchema({
       if (
         retryCount > 1 &&
         retryCount < 8 &&
+        // @ts-expect-error TS(2531) If you come across this, please fix it!: Object is possibly 'null'.
         dateLastUpdated < table?.dateUpdated
       ) {
         setFetching(false);

--- a/packages/front-end/components/SchemaBrowser/EditSqlModal.tsx
+++ b/packages/front-end/components/SchemaBrowser/EditSqlModal.tsx
@@ -78,6 +78,7 @@ export default function EditSqlModal({
   }, [form, apiCall, datasourceId]);
 
   const datasource = getDatasourceById(datasourceId);
+  // @ts-expect-error TS(2531) If you come across this, please fix it!: Object is possibly 'null'.
   const supportsSchemaBrowser = datasource.properties.supportsInformationSchema;
 
   return (
@@ -148,8 +149,10 @@ export default function EditSqlModal({
                 <DisplayTestQueryResults
                   duration={parseInt(testQueryResults.duration || "0")}
                   requiredColumns={[...requiredColumns]}
+                  // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'TestQueryRow[] | undefined' is not assignabl... Remove this comment to see the full error message
                   results={testQueryResults.results}
                   error={testQueryResults.error}
+                  // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
                   sql={testQueryResults.sql}
                   suggestions={[]}
                 />
@@ -163,7 +166,9 @@ export default function EditSqlModal({
               updateSqlInput={(sql: string) => {
                 form.setValue("sql", sql);
               }}
+              // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'DataSourceInterfaceWithParams | null' is not... Remove this comment to see the full error message
               datasource={datasource}
+              // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'CursorData | null' is not assignable to type... Remove this comment to see the full error message
               cursorData={cursorData}
             />
           </div>

--- a/packages/front-end/components/SchemaBrowser/RetryInformationSchemaCard.tsx
+++ b/packages/front-end/components/SchemaBrowser/RetryInformationSchemaCard.tsx
@@ -36,6 +36,7 @@ export default function RetryInformationSchemaCard({
     <div>
       <div className="alert alert-warning d-flex align-items-center">
         <div>
+          {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
           <span>{error ? error : informationSchema.error.message}</span>
         </div>
         <button

--- a/packages/front-end/components/SchemaBrowser/SchemaBrowser.tsx
+++ b/packages/front-end/components/SchemaBrowser/SchemaBrowser.tsx
@@ -113,6 +113,7 @@ export default function SchemaBrowser({
       <SchemaBrowserWrapper
         datasourceName={datasource.name}
         datasourceId={datasource.id}
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'InformationSchemaInterface | undefined' is n... Remove this comment to see the full error message
         informationSchema={informationSchema}
         setFetching={setFetching}
         fetching={fetching}

--- a/packages/front-end/components/SchemaBrowser/SchemaBrowserWrapper.tsx
+++ b/packages/front-end/components/SchemaBrowser/SchemaBrowserWrapper.tsx
@@ -43,6 +43,7 @@ export default function SchemaBrowserWrapper({
                 disabled={informationSchema.status === "PENDING"}
                 onClick={async (e) => {
                   e.preventDefault();
+                  // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'null' is not assignable to param... Remove this comment to see the full error message
                   setError(null);
                   try {
                     await apiCall<{

--- a/packages/front-end/components/Segments/SegmentForm.tsx
+++ b/packages/front-end/components/Segments/SegmentForm.tsx
@@ -103,6 +103,7 @@ const SegmentForm: FC<{
           }))}
           className="portal-overflow-ellipsis"
         />
+        {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
         {datasource?.properties.userIds && (
           <SelectField
             label="Identifier Type"

--- a/packages/front-end/components/Settings/BigQueryForm.tsx
+++ b/packages/front-end/components/Settings/BigQueryForm.tsx
@@ -44,6 +44,7 @@ const BigQueryForm: FC<{
                 id="bigQueryFileInput"
                 accept="application/json"
                 onChange={(e) => {
+                  // @ts-expect-error TS(2531) If you come across this, please fix it!: Object is possibly 'null'.
                   const file = e.target.files[0];
                   if (!file) {
                     return;
@@ -52,6 +53,7 @@ const BigQueryForm: FC<{
                   const reader = new FileReader();
                   reader.onload = function (e) {
                     try {
+                      // @ts-expect-error TS(2531) If you come across this, please fix it!: Object is possibly 'null'.
                       const str = e.target.result;
                       if (typeof str !== "string") {
                         return;

--- a/packages/front-end/components/Settings/ClickHouseForm.tsx
+++ b/packages/front-end/components/Settings/ClickHouseForm.tsx
@@ -11,6 +11,7 @@ const ClickHouseForm: FC<{
   return (
     <>
       <HostWarning
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
         host={params.url}
         setHost={(url) => {
           setParams({

--- a/packages/front-end/components/Settings/ConnectionSettings.tsx
+++ b/packages/front-end/components/Settings/ConnectionSettings.tsx
@@ -51,6 +51,7 @@ export default function ConnectionSettings({
       <AthenaForm
         existing={existing}
         onParamChange={onParamChange}
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'AthenaConnectionParams | undefined' is not a... Remove this comment to see the full error message
         params={datasource.params}
         setParams={setParams}
       />
@@ -62,6 +63,7 @@ export default function ConnectionSettings({
         onParamChange={onParamChange}
         onManualParamChange={onManualParamChange}
         setParams={setParams}
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'PrestoConnectionParams | undefined' is not a... Remove this comment to see the full error message
         params={datasource.params}
       />
     );
@@ -71,6 +73,7 @@ export default function ConnectionSettings({
         existing={existing}
         onParamChange={onParamChange}
         setParams={setParams}
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'DatabricksConnectionParams | undefined' is n... Remove this comment to see the full error message
         params={datasource.params}
       />
     );
@@ -80,6 +83,7 @@ export default function ConnectionSettings({
         existing={existing}
         onParamChange={onParamChange}
         setParams={setParams}
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'PostgresConnectionParams | undefined' is not... Remove this comment to see the full error message
         params={datasource.params}
       />
     );
@@ -89,6 +93,7 @@ export default function ConnectionSettings({
         existing={existing}
         onParamChange={onParamChange}
         setParams={setParams}
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'PostgresConnectionParams | undefined' is not... Remove this comment to see the full error message
         params={datasource.params}
       />
     );
@@ -98,6 +103,7 @@ export default function ConnectionSettings({
         existing={existing}
         onParamChange={onParamChange}
         setParams={setParams}
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'MysqlConnectionParams | undefined' is not as... Remove this comment to see the full error message
         params={datasource.params}
       />
     );
@@ -107,6 +113,7 @@ export default function ConnectionSettings({
         existing={existing}
         onParamChange={onParamChange}
         setParams={setParams}
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'MssqlConnectionParams | undefined' is not as... Remove this comment to see the full error message
         params={datasource.params}
       />
     );
@@ -116,6 +123,7 @@ export default function ConnectionSettings({
         existing={existing}
         onParamChange={onParamChange}
         setParams={setParams}
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'GoogleAnalyticsParams | undefined' is not as... Remove this comment to see the full error message
         params={datasource.params}
         error={hasError}
       />
@@ -125,6 +133,7 @@ export default function ConnectionSettings({
       <SnowflakeForm
         existing={existing}
         onParamChange={onParamChange}
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'SnowflakeConnectionParams | undefined' is no... Remove this comment to see the full error message
         params={datasource.params}
       />
     );
@@ -134,6 +143,7 @@ export default function ConnectionSettings({
         existing={existing}
         onParamChange={onParamChange}
         setParams={setParams}
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'ClickHouseConnectionParams | undefined' is n... Remove this comment to see the full error message
         params={datasource.params}
       />
     );
@@ -141,6 +151,7 @@ export default function ConnectionSettings({
     return (
       <BigQueryForm
         setParams={setParams}
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'BigQueryConnectionParams | undefined' is not... Remove this comment to see the full error message
         params={datasource.params}
         onParamChange={onParamChange}
       />
@@ -151,6 +162,7 @@ export default function ConnectionSettings({
         existing={existing}
         onParamChange={onParamChange}
         onManualParamChange={onManualParamChange}
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'MixpanelConnectionParams | undefined' is not... Remove this comment to see the full error message
         params={datasource.params}
       />
     );

--- a/packages/front-end/components/Settings/DataSourceForm.tsx
+++ b/packages/front-end/components/Settings/DataSourceForm.tsx
@@ -45,6 +45,7 @@ const DataSourceForm: FC<{
   const [dirty, setDirty] = useState(false);
   const [datasource, setDatasource] = useState<
     Partial<DataSourceInterfaceWithParams>
+    // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'null' is not assignable to param... Remove this comment to see the full error message
   >(null);
   const [hasError, setHasError] = useState(false);
 
@@ -99,6 +100,7 @@ const DataSourceForm: FC<{
           body: JSON.stringify({
             ...datasource,
             settings: {
+              // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'PostgresConnectionParams | Athen... Remove this comment to see the full error message
               ...getInitialSettings("custom", datasource.params),
               ...(datasource.settings || {}),
             },
@@ -112,6 +114,7 @@ const DataSourceForm: FC<{
       }
 
       setDirty(false);
+      // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
       await onSuccess(id);
     } catch (e) {
       track("Data Source Form Error", {
@@ -177,6 +180,7 @@ const DataSourceForm: FC<{
       )}
       <SelectField
         label="Data Source Type"
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
         value={datasource.type}
         onChange={(value) => {
           const option = typeOptions.filter((o) => o.type === value)[0];
@@ -245,6 +249,7 @@ const DataSourceForm: FC<{
           />
         </div>
       )}
+      {/* @ts-expect-error TS(2786) If you come across this, please fix it!: 'ConnectionSettings' cannot be used as a JSX compo... Remove this comment to see the full error message */}
       <ConnectionSettings
         datasource={datasource}
         existing={existing}

--- a/packages/front-end/components/Settings/DataSourceSchemaChooser.tsx
+++ b/packages/front-end/components/Settings/DataSourceSchemaChooser.tsx
@@ -32,6 +32,7 @@ export default function DataSourceSchemaChooser({
       <div className="d-flex flex-wrap mb-3 align-items-stretch align-middle">
         {eventSchemas
           // Some schemas only work with specific data sources
+          // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'DataSourceType | undefined' is n... Remove this comment to see the full error message
           .filter((o) => !o.types || o.types.includes(datasource))
           .map(({ value, label, options, logo }, i) => (
             <div
@@ -46,12 +47,15 @@ export default function DataSourceSchemaChooser({
                 title={label}
                 onClick={(e) => {
                   e.preventDefault();
+                  // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'SchemaOption[] | null' is not as... Remove this comment to see the full error message
                   setSelectedOptions(options ?? null);
                   if (options) {
                     options.map((o) => {
+                      // @ts-expect-error TS(2722) If you come across this, please fix it!: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
                       setOptionalValues(o.name, o.defaultValue);
                     });
                   } else {
+                    // @ts-expect-error TS(2722) If you come across this, please fix it!: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
                     setOptionalValues(null, null);
                   }
                   setValue(value);
@@ -78,6 +82,7 @@ export default function DataSourceSchemaChooser({
             href="#"
             onClick={(e) => {
               e.preventDefault();
+              // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'true' is not assignable to param... Remove this comment to see the full error message
               setShowAdvancedOptions(!showAdvancedOptions);
             }}
           >
@@ -92,6 +97,7 @@ export default function DataSourceSchemaChooser({
           </a>
           {showAdvancedOptions && (
             <>
+              {/* @ts-expect-error TS(2339) If you come across this, please fix it!: Property 'map' does not exist on type 'never'. */}
               {selectedOptions.map(
                 ({ name, label, defaultValue, type, helpText }) => (
                   <div key={name} className="form-group">
@@ -101,6 +107,7 @@ export default function DataSourceSchemaChooser({
                       defaultValue={defaultValue}
                       type={type}
                       onChange={(e) => {
+                        // @ts-expect-error TS(2722) If you come across this, please fix it!: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
                         setOptionalValues(name, e.target.value);
                       }}
                       helpText={helpText}

--- a/packages/front-end/components/Settings/DataSources.tsx
+++ b/packages/front-end/components/Settings/DataSources.tsx
@@ -84,6 +84,7 @@ const DataSources: FC = () => {
                 </td>
                 <td>{d.type}</td>
                 <td>
+                  {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
                   {d?.projects?.length > 0 ? (
                     <ProjectBadges
                       projectIds={d.projects}
@@ -93,6 +94,7 @@ const DataSources: FC = () => {
                     <ProjectBadges className="badge-ellipsis short align-middle" />
                   )}
                 </td>
+                {/* @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'Date | null' is not assignable t... Remove this comment to see the full error message */}
                 {!hasFileConfig() && <td>{ago(d.dateUpdated)}</td>}
               </tr>
             ))}

--- a/packages/front-end/components/Settings/DatabricksForm.tsx
+++ b/packages/front-end/components/Settings/DatabricksForm.tsx
@@ -12,6 +12,7 @@ const DatabricksForm: FC<{
     <div className="row">
       <div className="col-md-12">
         <HostWarning
+          // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
           host={params.host}
           setHost={(host) => {
             setParams({

--- a/packages/front-end/components/Settings/DisplayTestQueryResults.tsx
+++ b/packages/front-end/components/Settings/DisplayTestQueryResults.tsx
@@ -97,6 +97,7 @@ export default function DisplayTestQueryResults({
           ))}
         </div>
       )}
+      {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
       {suggestions?.length > 0 && (
         <div className="mb-2">
           <strong>Suggestions:</strong>

--- a/packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentifierTypes/DataSourceInlineEditIdentifierTypes.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentifierTypes/DataSourceInlineEditIdentifierTypes.tsx
@@ -58,6 +58,7 @@ export const DataSourceInlineEditIdentifierTypes: FC<DataSourceInlineEditIdentif
   const handleActionDeleteClicked = useCallback(
     (idx: number) => async () => {
       const copy = cloneDeep<DataSourceInterfaceWithParams>(dataSource);
+      // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
       copy.settings.userIdTypes.splice(idx, 1);
 
       await onSave(copy);
@@ -68,6 +69,7 @@ export const DataSourceInlineEditIdentifierTypes: FC<DataSourceInlineEditIdentif
   const handleSave = useCallback(
     (idx: number) => async (userIdType: string, description: string) => {
       const copy = cloneDeep<DataSourceInterfaceWithParams>(dataSource);
+      // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
       copy.settings.userIdTypes[idx] = {
         userIdType,
         description,
@@ -168,7 +170,9 @@ export const DataSourceInlineEditIdentifierTypes: FC<DataSourceInlineEditIdentif
         <EditIdentifierType
           mode={uiMode}
           onCancel={handleCancel}
+          // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
           userIdType={recordEditing?.userIdType}
+          // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
           description={recordEditing?.description}
           onSave={handleSave(editingIndex)}
           dataSource={dataSource}

--- a/packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentityJoins/AddEditIdentityJoinModal.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentityJoins/AddEditIdentityJoinModal.tsx
@@ -30,7 +30,9 @@ export const AddEditIdentityJoinModal: FC<AddEditIdentityJoinModalProps> = ({
     dataSource.settings.userIdTypes,
   ]);
   const existingIdentityJoins = useMemo(
+    // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
     () => dataSource.settings.queries.identityJoins || [],
+    // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
     [dataSource.settings.queries.identityJoins]
   );
 
@@ -88,6 +90,7 @@ export const AddEditIdentityJoinModal: FC<AddEditIdentityJoinModalProps> = ({
       return "Add Identifier Join";
     }
 
+    // @ts-expect-error TS(2531) If you come across this, please fix it!: Object is possibly 'null'.
     return `Edit Identifier Join: ${identityJoin.ids.join(" ↔ ")}`;
   }, [mode, identityJoin]);
 
@@ -106,6 +109,7 @@ export const AddEditIdentityJoinModal: FC<AddEditIdentityJoinModalProps> = ({
       size="max"
       header={modalTitle}
       cta="Save"
+      // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'boolean | ""' is not assignable to type 'boo... Remove this comment to see the full error message
       ctaEnabled={saveEnabled}
       autoFocusSelector="#id-modal-identify-joins-heading"
     >

--- a/packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentityJoins/DataSourceInlineEditIdentityJoins.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentityJoins/DataSourceInlineEditIdentityJoins.tsx
@@ -79,6 +79,7 @@ export const DataSourceInlineEditIdentityJoins: FC<DataSourceInlineEditIdentityJ
     (idx: number) => async () => {
       const copy = cloneDeep<DataSourceInterfaceWithParams>(dataSource);
 
+      // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
       copy.settings.queries.identityJoins.splice(idx, 1);
 
       await onSave(copy);
@@ -89,6 +90,7 @@ export const DataSourceInlineEditIdentityJoins: FC<DataSourceInlineEditIdentityJ
   const handleSave = useCallback(
     (idx: number) => async (identityJoin: IdentityJoinQuery) => {
       const copy = cloneDeep<DataSourceInterfaceWithParams>(dataSource);
+      // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
       copy.settings.queries.identityJoins[idx] = identityJoin;
       await onSave(copy);
     },

--- a/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/AddEditExperimentAssignmentQueryModal.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/AddEditExperimentAssignmentQueryModal.tsx
@@ -29,8 +29,10 @@ export const AddEditExperimentAssignmentQueryModal: FC<EditExperimentAssignmentQ
   const modalTitle =
     mode === "add"
       ? "Add an Experiment Assignment query"
-      : `Edit ${exposureQuery.name}`;
+      : // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
+        `Edit ${exposureQuery.name}`;
 
+  // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
   const userIdTypeOptions = dataSource.settings.userIdTypes.map(
     ({ userIdType }) => ({
       display: userIdType,
@@ -42,7 +44,8 @@ export const AddEditExperimentAssignmentQueryModal: FC<EditExperimentAssignmentQ
   const form = useForm<ExposureQuery>({
     defaultValues:
       mode === "edit"
-        ? cloneDeep<ExposureQuery>(exposureQuery)
+        ? // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'ExposureQuery | undefined' is no... Remove this comment to see the full error message
+          cloneDeep<ExposureQuery>(exposureQuery)
         : {
             description: "",
             id: uniqId("tbl_"),
@@ -63,12 +66,14 @@ export const AddEditExperimentAssignmentQueryModal: FC<EditExperimentAssignmentQ
     await onSave(value);
 
     form.reset({
+      // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'null' is not assignable to type 'string | un... Remove this comment to see the full error message
       id: null,
       query: "",
       name: "",
       dimensions: [],
       description: "",
       hasNameCol: false,
+      // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'null' is not assignable to type 'string | un... Remove this comment to see the full error message
       userIdType: null,
     });
   });

--- a/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/ExperimentAssignmentQueries.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/ExperimentAssignmentQueries.tsx
@@ -63,7 +63,9 @@ export const ExperimentAssignmentQueries: FC<ExperimentAssignmentQueriesProps> =
   }, [onCancel]);
 
   const experimentExposureQueries = useMemo(
+    // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
     () => dataSource.settings?.queries.exposure || [],
+    // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
     [dataSource.settings?.queries.exposure]
   );
 
@@ -84,6 +86,7 @@ export const ExperimentAssignmentQueries: FC<ExperimentAssignmentQueriesProps> =
     (idx: number) => async () => {
       const copy = cloneDeep<DataSourceInterfaceWithParams>(dataSource);
 
+      // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
       copy.settings.queries.exposure.splice(idx, 1);
 
       await onSave(copy);
@@ -94,6 +97,7 @@ export const ExperimentAssignmentQueries: FC<ExperimentAssignmentQueriesProps> =
   const handleSave = useCallback(
     (idx: number) => async (exposureQuery: ExposureQuery) => {
       const copy = cloneDeep<DataSourceInterfaceWithParams>(dataSource);
+      // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
       copy.settings.queries.exposure[idx] = exposureQuery;
       await onSave(copy);
     },

--- a/packages/front-end/components/Settings/EditOrganizationModal.tsx
+++ b/packages/front-end/components/Settings/EditOrganizationModal.tsx
@@ -28,6 +28,7 @@ const EditOrganizationModal: FC<{
           body: JSON.stringify(value),
         });
         // Update org name in global context (e.g. top nav)
+        // @ts-expect-error TS(2722) If you come across this, please fix it!: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
         setOrgName(value.name);
         // Update org name on settings page
         await mutate();

--- a/packages/front-end/components/Settings/EnvironmentModal.tsx
+++ b/packages/front-end/components/Settings/EnvironmentModal.tsx
@@ -47,6 +47,7 @@ export default function EnvironmentModal({
           env.toggleOnList = value.toggleOnList;
           env.defaultState = value.defaultState;
         } else {
+          // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
           if (!value.id.match(/^[A-Za-z][A-Za-z0-9_-]*$/)) {
             throw new Error(
               "Environment id is invalid. Must start with a letter and can only contain letters, numbers, hyphens, and underscores."
@@ -56,6 +57,7 @@ export default function EnvironmentModal({
             throw new Error("Environment id is already in use");
           }
           newEnvs.push({
+            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
             id: value.id.toLowerCase(),
             description: value.description,
             toggleOnList: value.toggleOnList,
@@ -90,6 +92,7 @@ export default function EnvironmentModal({
     >
       {!existing.id && (
         <Field
+          // @ts-expect-error TS(2783) If you come across this, please fix it!: 'name' is specified more than once, so this usage ... Remove this comment to see the full error message
           name="Environment"
           maxLength={30}
           required

--- a/packages/front-end/components/Settings/MssqlForm.tsx
+++ b/packages/front-end/components/Settings/MssqlForm.tsx
@@ -15,6 +15,7 @@ const MssqlForm: FC<{
   return (
     <>
       <HostWarning
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
         host={params.server}
         setHost={(host) => {
           setParams({
@@ -90,6 +91,7 @@ const MssqlForm: FC<{
             <Toggle
               id="trust-server-cert"
               label="Trust server certificate"
+              // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
               value={params.options.trustServerCertificate === true}
               setValue={(value) => {
                 const opt = {
@@ -109,6 +111,7 @@ const MssqlForm: FC<{
             <Toggle
               id="encryption"
               label="Enable encryption"
+              // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
               value={params.options.encrypt === true}
               setValue={(value) => {
                 const opt = { ...params.options, encrypt: value };

--- a/packages/front-end/components/Settings/MysqlForm.tsx
+++ b/packages/front-end/components/Settings/MysqlForm.tsx
@@ -12,6 +12,7 @@ const MysqlForm: FC<{
   return (
     <>
       <HostWarning
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
         host={params.host}
         setHost={(host) => {
           setParams({
@@ -81,6 +82,7 @@ const MysqlForm: FC<{
           onParamChange={onParamChange}
           setSSL={(ssl) => setParams({ ssl })}
           value={{
+            // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'boolean | undefined' is not assignable to ty... Remove this comment to see the full error message
             ssl: params.ssl,
             caCert: params.caCert,
             clientCert: params.clientCert,

--- a/packages/front-end/components/Settings/NamespaceTableRow.tsx
+++ b/packages/front-end/components/Settings/NamespaceTableRow.tsx
@@ -124,6 +124,7 @@ export default function NamespaceTableRow({
             namespace={namespace.name}
             usage={usage}
             title={"Namespace Usage"}
+            // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '[number, number] | null' is not assignable t... Remove this comment to see the full error message
             range={range}
           />
           {experiments.length > 0 ? (

--- a/packages/front-end/components/Settings/NewDataSourceForm.tsx
+++ b/packages/front-end/components/Settings/NewDataSourceForm.tsx
@@ -99,6 +99,7 @@ const NewDataSourceForm: FC<{
 
   if (!permissions.check("createDatasources", project)) {
     ctaEnabled = false;
+    // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '"You don't have permission to create data so... Remove this comment to see the full error message
     disabledMessage = "You don't have permission to create data sources.";
   }
 
@@ -138,6 +139,7 @@ const NewDataSourceForm: FC<{
             settings: {
               ...getInitialSettings(
                 selectedSchema.value,
+                // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'PostgresConnectionParams | Athen... Remove this comment to see the full error message
                 datasource.params,
                 form.watch("settings.schemaOptions")
               ),
@@ -169,6 +171,7 @@ const NewDataSourceForm: FC<{
   const updateSettings = async () => {
     const settings = getInitialSettings(
       selectedSchema.value,
+      // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'PostgresConnectionParams | Athen... Remove this comment to see the full error message
       datasource.params,
       form.watch("settings.schemaOptions")
     );
@@ -218,10 +221,13 @@ const NewDataSourceForm: FC<{
       source,
       newDatasourceForm: true,
     });
+    // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
     if (s.types.length === 1) {
+      // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
       const data = dataSourcesMap.get(s.types[0]);
       setDatasource({
         ...datasource,
+        // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
         type: s.types[0],
         name: `${s.label}`,
         params: data.default,
@@ -233,6 +239,7 @@ const NewDataSourceForm: FC<{
         projects: project ? [project] : [],
       });
     }
+    // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'DataSourceType[] | undefined' is... Remove this comment to see the full error message
     setPossibleTypes(s.types);
     if (s.options) {
       s.options.map((o) => {
@@ -253,12 +260,14 @@ const NewDataSourceForm: FC<{
       : async () => {
           let newDataId = dataSourceId;
           if (step === 1) {
+            // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
             newDataId = await saveDataConnection();
           }
           if (updateSettingsRequired) {
             await updateSettings();
           }
           if (isFinalStep) {
+            // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | null' is not assignable... Remove this comment to see the full error message
             await onSuccess(newDataId);
             onCancel && onCancel();
           } else {
@@ -363,6 +372,7 @@ const NewDataSourceForm: FC<{
         )}
         <SelectField
           label="Data Source Type"
+          // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
           value={datasource.type}
           onChange={(value) => {
             const option = dataSourceConnections.filter(
@@ -431,6 +441,7 @@ const NewDataSourceForm: FC<{
             />
           </div>
         )}
+        {/* @ts-expect-error TS(2786) If you come across this, please fix it!: 'ConnectionSettings' cannot be used as a JSX compo... Remove this comment to see the full error message */}
         <ConnectionSettings
           datasource={datasource}
           existing={existing}
@@ -499,8 +510,10 @@ const NewDataSourceForm: FC<{
       open={true}
       header={existing ? "Edit Data Source" : "Add Data Source"}
       close={onCancel}
+      // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'null' is not assignable to type 'string | un... Remove this comment to see the full error message
       disabledMessage={disabledMessage}
       ctaEnabled={ctaEnabled}
+      // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '(() => Promise<void>) | null' is not assigna... Remove this comment to see the full error message
       submit={submit}
       autoCloseOnSubmit={false}
       cta={isFinalStep ? (step === 2 ? "Finish" : "Save") : "Next"}

--- a/packages/front-end/components/Settings/PostgresForm.tsx
+++ b/packages/front-end/components/Settings/PostgresForm.tsx
@@ -12,6 +12,7 @@ const PostgresForm: FC<{
   return (
     <>
       <HostWarning
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
         host={params.host}
         setHost={(host) => {
           setParams({

--- a/packages/front-end/components/Settings/PrestoForm.tsx
+++ b/packages/front-end/components/Settings/PrestoForm.tsx
@@ -30,6 +30,7 @@ const PrestoForm: FC<{
       </div>
       <div className="col-md-12">
         <HostWarning
+          // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
           host={params.host}
           setHost={(host) => {
             setParams({
@@ -106,6 +107,7 @@ const PrestoForm: FC<{
         onParamChange={onParamChange}
         setSSL={(ssl) => setParams({ ssl })}
         value={{
+          // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'boolean | undefined' is not assignable to ty... Remove this comment to see the full error message
           ssl: params.ssl,
           caCert: params.caCert,
           clientCert: params.clientCert,

--- a/packages/front-end/components/Settings/RestoreConfigYamlButton.tsx
+++ b/packages/front-end/components/Settings/RestoreConfigYamlButton.tsx
@@ -80,8 +80,10 @@ export default function RestoreConfigYamlButton({
       if (origConfig.datasources) {
         Object.keys(origConfig.datasources).forEach((k) => {
           if (!newConfig?.datasources?.[k]) {
+            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
             delete origConfig.datasources[k];
           } else {
+            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
             const o = origConfig.datasources[k];
             const n = newConfig.datasources[k];
 
@@ -103,8 +105,10 @@ export default function RestoreConfigYamlButton({
       if (origConfig.metrics) {
         Object.keys(origConfig.metrics).forEach((k) => {
           if (!newConfig?.metrics?.[k]) {
+            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
             delete origConfig.metrics[k];
           } else {
+            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
             const o = origConfig.metrics[k];
             const n = newConfig.metrics[k];
 
@@ -118,8 +122,10 @@ export default function RestoreConfigYamlButton({
       if (origConfig.dimensions) {
         Object.keys(origConfig.dimensions).forEach((k) => {
           if (!newConfig?.dimensions?.[k]) {
+            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
             delete origConfig.dimensions[k];
           } else {
+            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
             const o = origConfig.dimensions[k];
             const n = newConfig.dimensions[k];
 
@@ -134,8 +140,10 @@ export default function RestoreConfigYamlButton({
       if (origConfig.segments) {
         Object.keys(origConfig.segments).forEach((k) => {
           if (!newConfig?.segments?.[k]) {
+            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
             delete origConfig.segments[k];
           } else {
+            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
             const o = origConfig.segments[k];
             const n = newConfig.segments[k];
 
@@ -151,6 +159,7 @@ export default function RestoreConfigYamlButton({
       if (origConfig.datasources) {
         Object.keys(origConfig.datasources).forEach((k) => {
           sanitizeSecrets(
+            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
             origConfig.datasources[k] as DataSourceInterfaceWithParams
           );
         });
@@ -212,6 +221,7 @@ export default function RestoreConfigYamlButton({
                 throw new Error("Could not parsed yaml file into JSON object");
               }
 
+              // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'object' is not assignable to par... Remove this comment to see the full error message
               setParsed(json);
               parseConfig(json);
             }}

--- a/packages/front-end/components/Settings/SSOSettings.tsx
+++ b/packages/front-end/components/Settings/SSOSettings.tsx
@@ -18,17 +18,22 @@ export default function SSOSettings({ ssoConnection }: Props) {
       <div className="d-flex">
         <div>
           <h3>Enterprise SSO Enabled</h3>
+          {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
           {ssoConnection?.emailDomains?.length > 0 && (
             <div>
               Users can auto-join your account when signing in through your
               Identity Provider with an email matching{" "}
+              {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
               <strong>*@{ssoConnection.emailDomains[0]}</strong>
+              {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
               {ssoConnection.emailDomains.length > 1 && (
                 <div className="small mt-1">
                   or any of the following email domains:{" "}
+                  {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
                   {ssoConnection.emailDomains.slice(1).map((d, i) => (
                     <>
                       <strong key={i}>{d}</strong>
+                      {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
                       {i < ssoConnection.emailDomains.length - 2 && ", "}
                     </>
                   ))}

--- a/packages/front-end/components/Settings/SubscriptionInfo.tsx
+++ b/packages/front-end/components/Settings/SubscriptionInfo.tsx
@@ -154,13 +154,16 @@ export default function SubscriptionInfo() {
           </div>
         )}
       </div>
+      {/* @ts-expect-error TS(2531) If you come across this, please fix it!: Object is possibly 'null'. */}
       {quote.currentSeatsPaidFor !== activeAndInvitedUsers && (
         <div className="col-md-12 mb-3 alert alert-warning">
           {`You have recently ${
+            // @ts-expect-error TS(2531) If you come across this, please fix it!: Object is possibly 'null'.
             activeAndInvitedUsers - quote.currentSeatsPaidFor > 0
               ? "added"
               : "removed"
           } ${Math.abs(
+            // @ts-expect-error TS(2531) If you come across this, please fix it!: Object is possibly 'null'.
             activeAndInvitedUsers - quote.currentSeatsPaidFor
           )} seats. `}
           These changes will be applied to your subscription soon.

--- a/packages/front-end/components/Settings/Team/AutoApproveMembersToggle.tsx
+++ b/packages/front-end/components/Settings/Team/AutoApproveMembersToggle.tsx
@@ -24,6 +24,7 @@ export default function AutoApproveMembersToggle({
     let owner = null;
     const ownerEmail = organization?.ownerEmail;
     if (ownerEmail) {
+      // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'ExpandedMember | undefined' is not assignabl... Remove this comment to see the full error message
       owner = [...users.values()].find((user) => user.email === ownerEmail);
     }
     setOwner(owner);
@@ -33,7 +34,9 @@ export default function AutoApproveMembersToggle({
     <div className="mt-3">
       <Toggle
         id="autoApproveMembers"
+        // @ts-expect-error TS(2339) If you come across this, please fix it!: Property 'verified' does not exist on type 'never'... Remove this comment to see the full error message
         value={!owner?.verified ? false : !!organization?.autoApproveMembers}
+        // @ts-expect-error TS(2339) If you come across this, please fix it!: Property 'verified' does not exist on type 'never'... Remove this comment to see the full error message
         disabled={!permissions.manageTeam || !owner?.verified}
         setValue={async (on) => {
           if (togglingAutoApprove) return;
@@ -66,6 +69,7 @@ export default function AutoApproveMembersToggle({
           Automatically approve new verified users <FaQuestionCircle />
         </Tooltip>
       </div>
+      {/* @ts-expect-error TS(2339) If you come across this, please fix it!: Property 'verified' does not exist on type 'never'... Remove this comment to see the full error message */}
       {!owner?.verified && (
         <div className="mt-3">
           <Tooltip

--- a/packages/front-end/components/Settings/Team/InviteList.tsx
+++ b/packages/front-end/components/Settings/Team/InviteList.tsx
@@ -25,6 +25,7 @@ const InviteList: FC<{
     email: string;
   } | null>(null);
   const { apiCall } = useAuth();
+  // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'null' is not assignable to param... Remove this comment to see the full error message
   const [roleModal, setRoleModal] = useState<ChangeRoleInfo>(null);
   const [resending, setResending] = useState(false);
   const [resendMessage, setResendMessage] = useState<ReactElement | null>(null);
@@ -104,6 +105,7 @@ const InviteList: FC<{
         <ChangeRoleModal
           displayInfo={roleModal.displayInfo}
           roleInfo={roleModal.roleInfo}
+          // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'null' is not assignable to param... Remove this comment to see the full error message
           close={() => setRoleModal(null)}
           onConfirm={async (value) => {
             await apiCall(`/invite/${roleModal.key}/role`, {
@@ -122,6 +124,7 @@ const InviteList: FC<{
         modalState={deleteInvite !== null}
         setModalState={() => setDeleteInvite(null)}
         onConfirm={async () => {
+          // @ts-expect-error TS(2339) If you come across this, please fix it!: Property 'key' does not exist on type '{ key: stri... Remove this comment to see the full error message
           const { key } = deleteInvite;
           setDeleteInvite(null);
           await apiCall(`/invite`, {

--- a/packages/front-end/components/Settings/Team/InviteModal.tsx
+++ b/packages/front-end/components/Settings/Team/InviteModal.tsx
@@ -122,6 +122,7 @@ const InviteModal: FC<{ mutate: () => void; close: () => void }> = ({
           : "Cancel"
       }
       autoCloseOnSubmit={false}
+      // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '((e?: BaseSyntheticEvent<object, any, any> |... Remove this comment to see the full error message
       submit={
         successfulInvites.length > 0 || failedInvites.length > 0
           ? null

--- a/packages/front-end/components/Settings/Team/MemberList.tsx
+++ b/packages/front-end/components/Settings/Team/MemberList.tsx
@@ -35,6 +35,7 @@ const MemberList: FC<{
   const { userId, users } = useUser();
   const [roleModal, setRoleModal] = useState<string>("");
   const [passwordResetModal, setPasswordResetModal] = useState<ExpandedMember>(
+    // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'null' is not assignable to param... Remove this comment to see the full error message
     null
   );
   const { projects } = useDefinitions();
@@ -61,6 +62,7 @@ const MemberList: FC<{
             role: roleModalUser.role,
             projectRoles: roleModalUser.projectRoles,
           }}
+          // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'null' is not assignable to param... Remove this comment to see the full error message
           close={() => setRoleModal(null)}
           onConfirm={async (value) => {
             await apiCall(`/member/${roleModal}/role`, {
@@ -73,10 +75,12 @@ const MemberList: FC<{
       )}
       {canEditRoles && passwordResetModal && (
         <AdminSetPasswordModal
+          // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'null' is not assignable to param... Remove this comment to see the full error message
           close={() => setPasswordResetModal(null)}
           member={passwordResetModal}
         />
       )}
+      {/* @ts-expect-error TS(2322) If you come across this, please fix it!: Type '{ maxHeight: number; overflowY: "auto"; } | ... Remove this comment to see the full error message */}
       <div style={maxHeight ? { maxHeight, overflowY: "auto" } : null}>
         <table className="table appbox gbtable">
           <thead>
@@ -106,6 +110,7 @@ const MemberList: FC<{
                   <td>{roleInfo.role}</td>
                   {!project && (
                     <td className="col-3">
+                      {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
                       {member.projectRoles.map((pr) => {
                         const p = projects.find((p) => p.id === pr.project);
                         if (p?.name) {

--- a/packages/front-end/components/Settings/Team/PendingMemberList.tsx
+++ b/packages/front-end/components/Settings/Team/PendingMemberList.tsx
@@ -73,6 +73,7 @@ const PendingMemberList: FC<{
                 <td>{roleInfo.role}</td>
                 {!project && (
                   <td className="col-3">
+                    {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
                     {member.projectRoles.map((pr) => {
                       const p = projects.find((p) => p.id === pr.project);
                       if (p?.name) {

--- a/packages/front-end/components/Settings/Team/ProjectRolesSelector.tsx
+++ b/packages/front-end/components/Settings/Team/ProjectRolesSelector.tsx
@@ -94,7 +94,9 @@ export default function ProjectRolesSelector({
                 e.preventDefault();
                 if (!newProject) return;
                 setProjectRoles([
+                  // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'ProjectMemberRole | { role?: MemberRole | un... Remove this comment to see the full error message
                   ...projectRoles,
+                  // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '{ role?: MemberRole | undefined; limitAccess... Remove this comment to see the full error message
                   cloneDeep({
                     project: newProject,
                     ...settings.defaultRole,

--- a/packages/front-end/components/Settings/Team/SingleRoleSelector.tsx
+++ b/packages/front-end/components/Settings/Team/SingleRoleSelector.tsx
@@ -51,8 +51,10 @@ export default function SingleRoleSelector({
           const r = roles.find((r) => r.id === value.label);
           return (
             <div className="d-flex align-items-center">
+              {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
               <strong style={{ width: 110 }}>{r.id}</strong>
               <small className="ml-2">
+                {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
                 <em>{r.description}</em>
               </small>
             </div>

--- a/packages/front-end/components/Settings/UpgradeModal/CloudUpgradeForm.tsx
+++ b/packages/front-end/components/Settings/UpgradeModal/CloudUpgradeForm.tsx
@@ -71,6 +71,7 @@ export default function CloudUpgradeForm({
         });
         await redirectWithTimeout(resp.session.url);
       } else {
+        // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type '"Failed to start checkout"' is n... Remove this comment to see the full error message
         setError("Failed to start checkout");
       }
     } catch (e) {
@@ -196,6 +197,7 @@ export default function CloudUpgradeForm({
                 </div>
               </div>
             )}
+            {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
             {quote?.discountAmount < 0 && quote?.discountMessage && (
               <div className="d-flex border-bottom py-2 mb-2">
                 <div>{quote.discountMessage}</div>

--- a/packages/front-end/components/Settings/UpgradeModal/SelfHostedUpgradeForm.tsx
+++ b/packages/front-end/components/Settings/UpgradeModal/SelfHostedUpgradeForm.tsx
@@ -81,17 +81,20 @@ export default function SelfHostedUpgradeForm({
         switch (txt) {
           case "active license exists":
             setError(
+              // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type '"You already have an active lice... Remove this comment to see the full error message
               "You already have an active license key. Please check your email, or click below to resend the key to your email address. Contact us at sales@growthbook.io for more information."
             );
             setUseResendForm(true);
             break;
           case "expired license exists":
             setError(
+              // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type '"Your license key has already ex... Remove this comment to see the full error message
               "Your license key has already expired. Please contact us at sales@growthbook.io for more information."
             );
             break;
           default:
             setError(
+              // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'Element' is not assignable to pa... Remove this comment to see the full error message
               <>
                 <p className="mb-2">
                   There was a server error. Please try again later, or contact
@@ -235,6 +238,7 @@ export default function SelfHostedUpgradeForm({
                 } else {
                   setLoading(false);
                   const txt = await resp.text();
+                  // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string' is not assignable to par... Remove this comment to see the full error message
                   setError(txt);
                   setSubmitState("resend failed");
                 }

--- a/packages/front-end/components/Settings/UpgradeModal/index.tsx
+++ b/packages/front-end/components/Settings/UpgradeModal/index.tsx
@@ -16,12 +16,14 @@ export default function UpgradeModal({ close, source }: Props) {
   const { accountPlan, permissions } = useUser();
 
   useEffect(() => {
+    // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
     if (["pro", "pro_sso", "enterprise"].includes(accountPlan)) {
       close();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [accountPlan]);
 
+  // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
   if (["pro", "pro_sso", "enterprise"].includes(accountPlan)) {
     return null;
   }
@@ -34,6 +36,7 @@ export default function UpgradeModal({ close, source }: Props) {
         </div>
       ) : isCloud() ? (
         <CloudUpgradeForm
+          // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'AccountPlan | undefined' is not assignable t... Remove this comment to see the full error message
           accountPlan={accountPlan}
           source={source}
           setCloseCta={(s) => setCloseCta(s)}

--- a/packages/front-end/components/Settings/VisualEditorInstructions.tsx
+++ b/packages/front-end/components/Settings/VisualEditorInstructions.tsx
@@ -82,6 +82,7 @@ export default function VisualEditorInstructions({
             href="#"
             onClick={(e) => {
               e.preventDefault();
+              // @ts-expect-error TS(2722) If you come across this, please fix it!: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
               changeUrl();
             }}
           >

--- a/packages/front-end/components/Settings/forms/StatsEngineSelect.tsx
+++ b/packages/front-end/components/Settings/forms/StatsEngineSelect.tsx
@@ -38,6 +38,7 @@ export default function StatsEngineSelect({
       label: parentScopeId
         ? capitalizeFirstLetter(parentScopeId) + " default"
         : "Default",
+      // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'null' is not assignable to type 'string'.
       value: null,
     });
   }

--- a/packages/front-end/components/Share/Presentation.tsx
+++ b/packages/front-end/components/Share/Presentation.tsx
@@ -78,22 +78,30 @@ const Presentation = ({
     const variationExtra = [];
     let sideExtra = <></>;
     const variationsPlural =
+      // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
       e.experiment.variations.length > 2 ? "variations" : "variation";
 
+    // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
     e.experiment.variations.forEach((v, i) => {
+      // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'Element' is not assignable to type 'never'.
       variationExtra[i] = <Fragment key={`f-${i}`}></Fragment>;
     });
     let resultsText = "";
     if (
+      // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
       e.experiment?.status === "running" ||
+      // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
       e.experiment?.status === "draft"
     ) {
       resultsText = "This experiment is still in progress";
     } else {
       // stopped:
+      // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
       if (e.experiment?.results) {
+        // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
         if (e.experiment.results === "won") {
           // if this is a two sided test, mark the winner:
+          // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
           variationExtra[e.experiment.winner] = (
             <Appear>
               <Text className="result variation-result result-winner text-center p-2 m-0">
@@ -102,12 +110,16 @@ const Presentation = ({
             </Appear>
           );
           resultsText =
+            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
             e.experiment.variations[e.experiment.winner]?.name +
             " beat the control and won";
+          // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
         } else if (e.experiment.results === "lost") {
           resultsText = `The ${variationsPlural} did not improve over the control`;
 
+          // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
           if (e.experiment.variations.length === 2) {
+            // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'Element' is not assignable to type 'never'.
             variationExtra[1] = (
               <Appear>
                 <Text className="result variation-result result-lost text-center p-2 m-0">
@@ -116,6 +128,7 @@ const Presentation = ({
               </Appear>
             );
           } else {
+            // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'Element' is not assignable to type 'never'.
             variationExtra[0] = (
               <Appear>
                 <Text className="result variation-result result-winner text-center p-2 m-0">
@@ -124,6 +137,7 @@ const Presentation = ({
               </Appear>
             );
           }
+          // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
         } else if (e.experiment.results === "dnf") {
           sideExtra = (
             <div className="result result-dnf text-center">
@@ -131,6 +145,7 @@ const Presentation = ({
             </div>
           );
           resultsText = `The experiment did not finish`;
+          // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
         } else if (e.experiment.results === "inconclusive") {
           sideExtra = (
             <Appear>
@@ -145,17 +160,22 @@ const Presentation = ({
     }
 
     expSlides.push(
+      // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'Element' is not assignable to pa... Remove this comment to see the full error message
       <Slide key={expSlides.length}>
         <div className="container-fluid">
+          {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
           <Heading className="m-0 pb-0">{e.experiment.name}</Heading>
           <Text className="text-center m-0 mb-4 p-2" fontSize={21}>
+            {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
             {e.experiment.hypothesis}
           </Text>
           <div className="row variations">
+            {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
             {e.experiment.variations.map((v: Variation, j: number) => (
               <Text
                 fontSize={20}
                 className={`col m-0 p-0 col-${
+                  // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
                   12 / e.experiment.variations.length
                 } presentationcol text-center`}
                 key={`v-${j}`}
@@ -173,16 +193,21 @@ const Presentation = ({
         </div>
       </Slide>
     );
+    // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
     if (e.snapshot) {
       // const variationNames = e.experiment.variations.map((v) => v.name);
       // const numMetrics = e.experiment.metrics.length;
+      // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
       const result = e.experiment.results;
 
+      // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
       const experiment = e.experiment;
+      // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
       const snapshot = e.snapshot;
       const phase = experiment.phases[snapshot.phase];
 
       expSlides.push(
+        // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'Element' is not assignable to pa... Remove this comment to see the full error message
         <Slide key={`s-${expSlides.length}`}>
           <Heading className="m-0 p-0">Results</Heading>
           {result && (
@@ -195,10 +220,12 @@ const Presentation = ({
               })}
             >
               <strong>{resultsText}</strong>
+              {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
               {e.experiment.analysis && (
                 <div className="card text-dark mt-2">
                   <div className="card-body">
                     <Markdown className="card-text">
+                      {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
                       {e.experiment.analysis}
                     </Markdown>
                   </div>
@@ -221,10 +248,13 @@ const Presentation = ({
               id={experiment.id}
               isLatestPhase={snapshot.phase === experiment.phases.length - 1}
               metrics={experiment.metrics}
+              // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'MetricOverride[] | undefined' is not assigna... Remove this comment to see the full error message
               metricOverrides={experiment.metricOverrides}
               reportDate={snapshot.dateCreated}
+              // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'ExperimentReportResultDimension | undefined'... Remove this comment to see the full error message
               results={snapshot.results?.[0]}
               status={experiment.status}
+              // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
               startDate={phase?.dateStarted}
               multipleExposures={snapshot.multipleExposures || 0}
               variations={experiment.variations.map((v, i) => {

--- a/packages/front-end/components/Share/Preview.tsx
+++ b/packages/front-end/components/Share/Preview.tsx
@@ -43,6 +43,7 @@ const Preview: FC<{
     }[];
   }>(`/presentation/preview/?expIds=${expIds}`);
 
+  // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
   useSwitchOrg(pdata?.presentation?.organization);
 
   if (error) {

--- a/packages/front-end/components/Share/ShareModal.tsx
+++ b/packages/front-end/components/Share/ShareModal.tsx
@@ -263,6 +263,7 @@ const ShareModal = ({
       }
       if (onSuccess && typeof onSuccess === "function") onSuccess();
       setLoading(false);
+      // @ts-expect-error TS(2722) If you come across this, please fix it!: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
       refreshList();
     } catch (e) {
       console.error(e);
@@ -313,6 +314,7 @@ const ShareModal = ({
     title: form.watch("title"),
     description: form.watch("description"),
   };
+  // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
   value.slides.forEach((obj: PresentationSlide) => {
     selectedExperiments.set(obj.id, byId.get(obj.id));
   });
@@ -326,6 +328,7 @@ const ShareModal = ({
     const exps = [];
     // once we add options, we'll have to make this merge in previous options per exp
     Array.from(selectedExperiments.keys()).forEach((e) => {
+      // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'any' is not assignable to type 'never'.
       exps.push({ id: e, type: "experiment" });
     });
     form.setValue("slides", exps);
@@ -366,6 +369,7 @@ const ShareModal = ({
 
   Object.entries(byStatus).forEach(([status]) => {
     tabContents.push(
+      // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'Element' is not assignable to pa... Remove this comment to see the full error message
       <Tab
         key={status}
         display={
@@ -445,10 +449,13 @@ const ShareModal = ({
                       <td className="nowrap">
                         {getUserDisplay(e.owner, false)}
                       </td>
+                      {/* @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message */}
                       <td className="nowrap" title={datetime(phase.dateEnded)}>
+                        {/* @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message */}
                         {ago(phase.dateEnded)}
                       </td>
                       <td className="nowrap">
+                        {/* @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'ExperimentResultsType | undefined' is not as... Remove this comment to see the full error message */}
                         <ResultsIndicator results={e.results} />
                       </td>
                     </tr>
@@ -474,6 +481,7 @@ const ShareModal = ({
 
   selectedExperiments.forEach((exp: ExperimentInterfaceStringDates, id) => {
     selectedList.push(
+      // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'Element' is not assignable to pa... Remove this comment to see the full error message
       <Draggable key={id} draggableId={id} index={counter++}>
         {(provided, snapshot) => (
           <div
@@ -554,13 +562,16 @@ const ShareModal = ({
   for (const [key, value] of Object.entries(presentationThemes)) {
     if (value.show) {
       presThemes.push({
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string' is not assignable to type 'never'.
         value: key,
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string' is not assignable to type 'never'.
         label: value.title,
       });
     }
   }
 
   if (!modalState) {
+    // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'null' is not assignable to type 'ReactElemen... Remove this comment to see the full error message
     return null;
   }
 
@@ -632,6 +643,7 @@ const ShareModal = ({
                 </div>
               </div>
               <Tabs
+                // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | null' is not assignable to type 'st... Remove this comment to see the full error message
                 defaultTab={
                   byStatus.stopped.length > 0
                     ? "Stopped"
@@ -736,6 +748,7 @@ const ShareModal = ({
               </label>
               <div className="col-sm-8">
                 <SelectField
+                  // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
                   value={form.watch("theme")}
                   onChange={(v) => form.setValue("theme", v)}
                   options={presThemes}
@@ -808,6 +821,7 @@ const ShareModal = ({
                 (use the arrow keys to change pages)
               </small>
             </h4>
+            {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
             {value.slides.length > 0 ? (
               <>
                 <div style={{ position: "absolute", left: "49%", top: "52%" }}>
@@ -822,20 +836,28 @@ const ShareModal = ({
                   }}
                 >
                   <Preview
+                    // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
                     expIds={value.slides
                       .map((o) => {
                         return o.id;
                       })
                       .join(",")}
+                    // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
                     title={value.title}
+                    // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
                     desc={value.description}
+                    // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
                     theme={value.theme}
+                    // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
                     backgroundColor={value.customTheme.backgroundColor.replace(
                       "#",
                       ""
                     )}
+                    // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
                     textColor={value.customTheme.textColor.replace("#", "")}
+                    // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
                     headingFont={value.customTheme.headingFont}
+                    // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
                     bodyFont={value.customTheme.bodyFont}
                   />
                 </div>

--- a/packages/front-end/components/SlackIntegrations/SlackIntegrationAddEditModal/SlackIntegrationAddEditModal.tsx
+++ b/packages/front-end/components/SlackIntegrations/SlackIntegrationAddEditModal/SlackIntegrationAddEditModal.tsx
@@ -106,6 +106,7 @@ export const SlackIntegrationAddEditModal: FC<SlackIntegrationAddEditModalProps>
       open={isOpen}
       autoCloseOnSubmit={false}
       submit={handleSubmit}
+      // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | null' is not assignable to type 'st... Remove this comment to see the full error message
       error={error}
       ctaEnabled={ctaEnabled}
     >

--- a/packages/front-end/components/SlackIntegrations/SlackIntegrationsListView/SlackIntegrationsListView.tsx
+++ b/packages/front-end/components/SlackIntegrations/SlackIntegrationsListView/SlackIntegrationsListView.tsx
@@ -280,6 +280,7 @@ export const SlackIntegrationsListViewContainer = () => {
   return (
     <SlackIntegrationsListView
       slackIntegrations={slackIntegrations}
+      // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'SlackIntegrationModalMode | null | undefined... Remove this comment to see the full error message
       modalMode={modalMode}
       onDelete={handleDelete}
       modalError={addEditError}

--- a/packages/front-end/components/SyntaxHighlighting/Snippets/TargetingAttributeCodeSnippet.tsx
+++ b/packages/front-end/components/SyntaxHighlighting/Snippets/TargetingAttributeCodeSnippet.tsx
@@ -47,9 +47,11 @@ function getExampleAttributes(attributeSchema?: SDKAttributeSchema) {
     } else if (datatype === "string[]") {
       value = ["foo", "bar"];
     } else if (datatype === "enum") {
+      // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
       value = enumList.split(",").map((v) => v.trim())[0] ?? null;
     }
 
+    // @ts-expect-error TS(2538) If you come across this, please fix it!: Type 'undefined' cannot be used as an index type.
     current[last] = value;
   });
 

--- a/packages/front-end/components/Tabs/ControlledTabs.tsx
+++ b/packages/front-end/components/Tabs/ControlledTabs.tsx
@@ -152,9 +152,11 @@ const ControlledTabs: FC<{
   });
 
   useEffect(() => {
+    // @ts-expect-error TS(2538) If you come across this, please fix it!: Type 'null' cannot be used as an index type.
     if (!loaded[active]) {
       setLoaded({
         ...loaded,
+        // @ts-expect-error TS(2464) If you come across this, please fix it!: A computed property name must be of type 'string',... Remove this comment to see the full error message
         [active]: true,
       });
     }

--- a/packages/front-end/components/Tabs/TabButton.tsx
+++ b/packages/front-end/components/Tabs/TabButton.tsx
@@ -44,6 +44,7 @@ export default function TabButton({
       }}
     >
       {display}
+      {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
       {(showActiveCount || !active) && (count === 0 || count > 0) ? (
         <span className={`badge badge-gray ml-2`}>{count}</span>
       ) : (

--- a/packages/front-end/components/Tags/TagsFilter.tsx
+++ b/packages/front-end/components/Tags/TagsFilter.tsx
@@ -101,6 +101,7 @@ export default function TagsFilter({
         prompt={"Filter by tags..."}
         autoFocus={open && autofocus}
         closeMenuOnSelect={true}
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '(TagInterface | null)[]' is not assignable t... Remove this comment to see the full error message
         tagOptions={availableTags.map((t) => getTagById(t)).filter(Boolean)}
         creatable={false}
       />

--- a/packages/front-end/components/Tags/TagsInput.tsx
+++ b/packages/front-end/components/Tags/TagsInput.tsx
@@ -44,6 +44,7 @@ const TagsInput: FC<{
   tagOptions = [...tagOptions];
   value.forEach((value) => {
     if (!tagSet.has(value)) {
+      // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
       tagOptions.push({
         id: value,
         description: "",
@@ -123,6 +124,7 @@ const TagsInput: FC<{
       }}
       closeMenuOnSelect={closeMenuOnSelect}
       autoFocus={autoFocus}
+      // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'StylesConfig<ColorOption, true, GroupBase<Co... Remove this comment to see the full error message
       customStyles={tagStyles}
       placeholder={prompt}
       creatable={creatable}

--- a/packages/front-end/components/Tags/TagsModal.tsx
+++ b/packages/front-end/components/Tags/TagsModal.tsx
@@ -54,6 +54,7 @@ export default function TagsModal({
       <div className="colorpicker tagmodal">
         {!existing?.id && (
           <Field
+            // @ts-expect-error TS(2783) If you come across this, please fix it!: 'name' is specified more than once, so this usage ... Remove this comment to see the full error message
             name="Name"
             label="Name"
             minLength={2}
@@ -88,6 +89,7 @@ export default function TagsModal({
           </div>
         </div>
         <Field
+          // @ts-expect-error TS(2783) If you come across this, please fix it!: 'name' is specified more than once, so this usage ... Remove this comment to see the full error message
           name="Name"
           label="Description"
           textarea

--- a/packages/front-end/components/Tooltip/Tooltip.tsx
+++ b/packages/front-end/components/Tooltip/Tooltip.tsx
@@ -46,6 +46,7 @@ const Tooltip: FC<Props> = ({
   return (
     <>
       <span
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'Dispatch<SetStateAction<null>>' is not assig... Remove this comment to see the full error message
         ref={setTrigger}
         onMouseEnter={() => setOpen(true)}
         onMouseLeave={() => setOpen(false)}
@@ -57,6 +58,7 @@ const Tooltip: FC<Props> = ({
       </span>
       {open && body && shouldDisplay && (
         <div
+          // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'Dispatch<SetStateAction<null>>' is not assig... Remove this comment to see the full error message
           ref={setTooltip}
           style={{
             ...styles.popper,
@@ -69,6 +71,7 @@ const Tooltip: FC<Props> = ({
           role="tooltip"
         >
           <div className={`body ${innerClassName}`}>{body}</div>
+          {/* @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'Dispatch<SetStateAction<null>>' is not assig... Remove this comment to see the full error message */}
           <div ref={setArrow} style={styles.arrow} className="arrow" />
         </div>
       )}

--- a/packages/front-end/hooks/useApi.ts
+++ b/packages/front-end/hooks/useApi.ts
@@ -10,6 +10,7 @@ export default function useApi<Response = any>(path: string | null) {
   const key = path === null ? null : orgId + "::" + path;
 
   return useSWR<Response, Error>(key, async () =>
+    // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | null' is not assignable... Remove this comment to see the full error message
     apiCall<Response>(path, {
       method: "GET",
     })

--- a/packages/front-end/hooks/useMembers.ts
+++ b/packages/front-end/hooks/useMembers.ts
@@ -8,7 +8,9 @@ export default function useMembers() {
     const memberUsernameOptions = [];
     users.forEach((user) => {
       memberUsernameOptions.push({
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string' is not assignable to type 'never'.
         display: user.name ? user.name : user.email,
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string' is not assignable to type 'never'.
         value: user.name ? user.name : user.email,
       });
     });

--- a/packages/front-end/hooks/useSchemaFormOptions.ts
+++ b/packages/front-end/hooks/useSchemaFormOptions.ts
@@ -38,6 +38,7 @@ export default function useSchemaFormOptions(
         }
 
         schema?.tables?.forEach((table) => {
+          // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
           group.options.push({
             label: table.tableName,
             value: table.path,

--- a/packages/front-end/pages/activity.tsx
+++ b/packages/front-end/pages/activity.tsx
@@ -51,6 +51,7 @@ const Activity: FC = () => {
                 }}
                 showName={true}
                 showType={true}
+                // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | false | undefined' is not assignabl... Remove this comment to see the full error message
                 itemName={
                   nameMap.has(event.entity.id) && nameMap.get(event.entity.id)
                 }

--- a/packages/front-end/pages/admin.tsx
+++ b/packages/front-end/pages/admin.tsx
@@ -67,7 +67,9 @@ const Admin: FC = () => {
                   href="#"
                   onClick={(e) => {
                     e.preventDefault();
+                    // @ts-expect-error TS(2722) If you come across this, please fix it!: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
                     setOrgId(o.id);
+                    // @ts-expect-error TS(2722) If you come across this, please fix it!: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
                     setSpecialOrg(o);
                   }}
                 >

--- a/packages/front-end/pages/api/init.ts
+++ b/packages/front-end/pages/api/init.ts
@@ -62,6 +62,7 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
     config: hasConfigFile ? "file" : "db",
     build,
     defaultConversionWindowHours:
+      // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
       parseInt(DEFAULT_CONVERSION_WINDOW_HOURS) || 72,
     telemetry:
       DISABLE_TELEMETRY === "debug"

--- a/packages/front-end/pages/datasources/[did].tsx
+++ b/packages/front-end/pages/datasources/[did].tsx
@@ -48,6 +48,7 @@ const DataSourcePage: FC = () => {
   const { apiCall } = useAuth();
 
   const canEdit =
+    // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'DataSourceInterfaceWithParams | ... Remove this comment to see the full error message
     checkDatasourceProjectPermissions(d, permissions, "createDatasources") &&
     !hasFileConfig();
 
@@ -65,6 +66,7 @@ const DataSourcePage: FC = () => {
         body: JSON.stringify(updates),
       });
       const queriesUpdated =
+        // @ts-expect-error TS(2531) If you come across this, please fix it!: Object is possibly 'null'.
         JSON.stringify(d.settings?.queries) !==
         JSON.stringify(dataSource.settings?.queries);
       if (queriesUpdated) {
@@ -138,6 +140,7 @@ const DataSourcePage: FC = () => {
       <div className="row mb-3 align-items-center">
         <div className="col">
           Projects:{" "}
+          {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
           {d?.projects?.length > 0 ? (
             <ProjectBadges
               projectIds={d.projects}
@@ -172,6 +175,7 @@ const DataSourcePage: FC = () => {
                   >
                     <FaExternalLinkAlt /> View Documentation
                   </DocLink>
+                  {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
                   {d.properties.supportsInformationSchema && (
                     <button
                       className="btn btn-outline-info mr-2 mt-1 font-weight-bold"

--- a/packages/front-end/pages/dimensions/index.tsx
+++ b/packages/front-end/pages/dimensions/index.tsx
@@ -177,6 +177,7 @@ const DimensionsPage: FC = () => {
                           expandable={true}
                         />
                       </td>
+                      {/* @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'Date | null' is not assignable t... Remove this comment to see the full error message */}
                       {!hasFileConfig() && <td>{ago(s.dateUpdated)}</td>}
                       {!hasFileConfig() && permissions.createDimensions && (
                         <td>

--- a/packages/front-end/pages/experiment/[eid].tsx
+++ b/packages/front-end/pages/experiment/[eid].tsx
@@ -41,6 +41,7 @@ const ExperimentPage = (): ReactElement => {
     visualChangesets: VisualChangesetInterface[];
   }>(`/experiment/${eid}`);
 
+  // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
   useSwitchOrg(data?.experiment?.organization);
 
   const { apiCall } = useAuth();
@@ -155,14 +156,23 @@ const ExperimentPage = (): ReactElement => {
             idea={idea}
             visualChangesets={visualChangesets}
             mutate={mutate}
+            // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '(() => void) | null' is not assignable to ty... Remove this comment to see the full error message
             editMetrics={editMetrics}
+            // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '(() => void) | null' is not assignable to ty... Remove this comment to see the full error message
             editResult={editResult}
+            // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '(() => void) | null' is not assignable to ty... Remove this comment to see the full error message
             editVariations={editVariations}
+            // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '(() => void) | null' is not assignable to ty... Remove this comment to see the full error message
             duplicate={duplicate}
+            // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '(() => void) | null' is not assignable to ty... Remove this comment to see the full error message
             editProject={editProject}
+            // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '(() => void) | null' is not assignable to ty... Remove this comment to see the full error message
             editTags={editTags}
+            // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '(() => void) | null' is not assignable to ty... Remove this comment to see the full error message
             newPhase={newPhase}
+            // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '(() => void) | null' is not assignable to ty... Remove this comment to see the full error message
             editPhases={editPhases}
+            // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '((i: number | null) => void) | null' is not ... Remove this comment to see the full error message
             editPhase={editPhase}
           />
         </SnapshotProvider>

--- a/packages/front-end/pages/experiments/designer/[id].tsx
+++ b/packages/front-end/pages/experiments/designer/[id].tsx
@@ -56,6 +56,7 @@ const EditorPage: FC = () => {
     experiment: ExperimentInterfaceStringDates;
   }>(`/experiment/${id}`);
 
+  // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
   useSwitchOrg(data?.experiment?.organization);
 
   const [variation, setVariation] = useState(1);
@@ -115,6 +116,7 @@ const EditorPage: FC = () => {
     displaySurface: "browser" | "monitor" | "window" | "application";
     width: number;
     height: number;
+    // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'null' is not assignable to param... Remove this comment to see the full error message
   }>(null);
 
   const varData = variationData.variations[variation];
@@ -142,6 +144,7 @@ const EditorPage: FC = () => {
   useEffect(() => {
     if (mode !== "screenshot" && stream) {
       stream.stream.getTracks().forEach((track) => track.stop());
+      // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'null' is not assignable to param... Remove this comment to see the full error message
       setStream(null);
     }
   }, [mode]);
@@ -160,6 +163,7 @@ const EditorPage: FC = () => {
     if (!loaded || !iframe.current) return;
     if (!iframeReady && command.command !== "isReady") return;
     try {
+      // @ts-expect-error TS(2531) If you come across this, please fix it!: Object is possibly 'null'.
       iframe.current.contentWindow.postMessage(command, "*");
     } catch (e) {
       console.error(e);
@@ -437,8 +441,11 @@ const EditorPage: FC = () => {
               e.preventDefault();
               setStream({
                 ...stream,
+                // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'null' is not assignable to type 'string'.
                 screenshot: null,
+                // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'null' is not assignable to type '[number, nu... Remove this comment to see the full error message
                 point1: null,
+                // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'null' is not assignable to type '[number, nu... Remove this comment to see the full error message
                 point2: null,
               });
             }}
@@ -486,7 +493,9 @@ const EditorPage: FC = () => {
               if (w < 20 || h < 20) {
                 setStream({
                   ...stream,
+                  // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'undefined' is not assignable to type '[numbe... Remove this comment to see the full error message
                   point1: undefined,
+                  // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'undefined' is not assignable to type '[numbe... Remove this comment to see the full error message
                   point2: undefined,
                 });
               } else {
@@ -508,6 +517,7 @@ const EditorPage: FC = () => {
                   canvas.width = adjustedW;
                   canvas.height = adjustedH;
                   const ctx = canvas.getContext("2d");
+                  // @ts-expect-error TS(2531) If you come across this, please fix it!: Object is possibly 'null'.
                   ctx.drawImage(
                     video,
                     adjustedX,
@@ -552,12 +562,14 @@ const EditorPage: FC = () => {
               : "What URL do you want to load in the editor?"
           }
           open={true}
+          // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '(() => void) | null' is not assignable to ty... Remove this comment to see the full error message
           close={url ? () => setUrlModalOpen(false) : null}
           submit={async () => {
             if (variationData.url === url) {
               setIframeReady(false);
               setIframeLoaded(false);
               setIframeError(false);
+              // @ts-expect-error TS(2531) If you come across this, please fix it!: Object is possibly 'null'.
               iframe.current.src = iframe.current.src + "";
             } else {
               setDirty(true);
@@ -641,6 +653,7 @@ const EditorPage: FC = () => {
                         setIframeReady(false);
                         setIframeLoaded(false);
                         setIframeError(false);
+                        // @ts-expect-error TS(2531) If you come across this, please fix it!: Object is possibly 'null'.
                         iframe.current.src = iframe.current.src + "";
                       }}
                     />
@@ -1241,6 +1254,7 @@ const EditorPage: FC = () => {
                       className="btn btn-primary mt-1"
                       onClick={(e) => {
                         e.preventDefault();
+                        // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
                         if (!currentEl.classes.includes(value.value)) {
                           addDomMod({
                             selector: currentEl.selector,
@@ -1250,6 +1264,7 @@ const EditorPage: FC = () => {
                           });
                           setCurrentEl({
                             ...currentEl,
+                            // @ts-expect-error TS(2488) If you come across this, please fix it!: Type 'string[] | undefined' must have a '[Symbol.i... Remove this comment to see the full error message
                             classes: [...currentEl.classes, value.value],
                           });
                         }
@@ -1270,8 +1285,10 @@ const EditorPage: FC = () => {
                   </div>
                 )}
                 {(!value.editing || value.field !== "class") &&
+                  // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
                   (currentEl.classes.length > 0 ? (
                     <ul className="list-group mt-1">
+                      {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
                       {currentEl.classes.map((c, j) => (
                         <li
                           className="list-group-item py-1 text-dark bg-light d-flex justify-content-between align-items-center"
@@ -1357,6 +1374,7 @@ const EditorPage: FC = () => {
                         setCurrentEl({
                           ...currentEl,
                           attributes: [
+                            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
                             ...currentEl.attributes.filter(
                               (attr) => attr.name !== value.name
                             ),
@@ -1383,8 +1401,10 @@ const EditorPage: FC = () => {
                   </div>
                 )}
                 {(!value.editing || value.field !== "attribute") &&
+                  // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
                   (currentEl.attributes.length > 0 ? (
                     <ul className="list-group mt-1">
+                      {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
                       {currentEl.attributes.map((attr, j) => (
                         <li
                           className="list-group-item py-1 text-dark bg-light d-flex justify-content-between align-items-center"
@@ -1418,6 +1438,7 @@ const EditorPage: FC = () => {
                                   attribute: value.name,
                                   value: "",
                                 });
+                                // @ts-expect-error TS(2488) If you come across this, please fix it!: Type 'ElementAttribute[] | undefined' must have a ... Remove this comment to see the full error message
                                 const clone = [...currentEl.attributes];
                                 clone.splice(j, 1);
                                 setCurrentEl({

--- a/packages/front-end/pages/experiments/import/[id].tsx
+++ b/packages/front-end/pages/experiments/import/[id].tsx
@@ -27,6 +27,7 @@ const ImportPage: FC = () => {
         />
       )}
       <h2>Import Experiments</h2>
+      {/* @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message */}
       <ImportExperimentList onImport={setCreate} importId={importId} />
     </div>
   );

--- a/packages/front-end/pages/experiments/index.tsx
+++ b/packages/front-end/pages/experiments/index.tsx
@@ -54,6 +54,7 @@ const ExperimentsPage = (): React.ReactElement => {
     allExperiments,
     (exp) => {
       const projectId = exp.project;
+      // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
       const projectName = getProjectById(projectId)?.name || "";
       const projectIsOprhaned = projectId && !projectName;
 
@@ -363,6 +364,7 @@ const ExperimentsPage = (): React.ReactElement => {
                     </td>
                     {tab === "stopped" && (
                       <td className="nowrap" data-title="Results:">
+                        {/* @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'ExperimentResultsType | undefined' is not as... Remove this comment to see the full error message */}
                         <ResultsIndicator results={e.results} />
                       </td>
                     )}
@@ -385,6 +387,7 @@ const ExperimentsPage = (): React.ReactElement => {
         </div>
       </div>
       {openNewExperimentModal &&
+        // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
         (growthbook.isOn("new-experiment-modal") ? (
           <AddExperimentModal
             onClose={() => setOpenNewExperimentModal(false)}

--- a/packages/front-end/pages/features/[fid].tsx
+++ b/packages/front-end/pages/features/[fid].tsx
@@ -124,6 +124,7 @@ export default function FeaturePage() {
     permissions.check(
       "publishFeatures",
       projectId,
+      // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
       "defaultValue" in data.feature.draft
         ? getEnabledEnvironments(data.feature)
         : getAffectedEnvs(
@@ -251,6 +252,7 @@ export default function FeaturePage() {
       )}
       {editTagsModal && (
         <EditTagsForm
+          // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string[] | undefined' is not assignable to t... Remove this comment to see the full error message
           tags={data.feature?.tags}
           save={async (tags) => {
             await apiCall(`/feature/${data.feature.id}`, {
@@ -515,6 +517,7 @@ export default function FeaturePage() {
       <div className="mb-3">
         <div className={data.feature.description ? "appbox mb-4 p-3" : ""}>
           <MarkdownInlineEdit
+            // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
             value={data.feature.description}
             canEdit={permissions.check("manageFeatures", projectId)}
             canCreate={permissions.check("manageFeatures", projectId)}
@@ -573,6 +576,7 @@ export default function FeaturePage() {
       <div className="appbox mb-4 p-3">
         <ForceSummary
           type={type}
+          // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
           value={getFeatureDefaultValue(data.feature)}
         />
       </div>
@@ -584,6 +588,7 @@ export default function FeaturePage() {
       </p>
 
       <ControlledTabs
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'Dispatch<SetStateAction<string>>' is not ass... Remove this comment to see the full error message
         setActive={setEnv}
         active={env}
         showActiveCount={true}

--- a/packages/front-end/pages/features/index.tsx
+++ b/packages/front-end/pages/features/index.tsx
@@ -142,6 +142,7 @@ export default function FeaturesPage() {
               features: [...features, feature],
             });
           }}
+          // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'FeatureInterface | null' is not assignable t... Remove this comment to see the full error message
           featureToDuplicate={featureToDuplicate}
         />
       )}
@@ -263,13 +264,17 @@ export default function FeaturesPage() {
               {items.slice(start, end).map((feature) => {
                 let rules = [];
                 environments.forEach(
+                  // @ts-expect-error TS(2769) If you come across this, please fix it!: No overload matches this call.
                   (e) => (rules = rules.concat(getRules(feature, e.id)))
                 );
 
                 // When showing a summary of rules, prefer experiments to rollouts to force rules
                 const orderedRules = [
+                  // @ts-expect-error TS(2339) If you come across this, please fix it!: Property 'type' does not exist on type 'never'.
                   ...rules.filter((r) => r.type === "experiment"),
+                  // @ts-expect-error TS(2339) If you come across this, please fix it!: Property 'type' does not exist on type 'never'.
                   ...rules.filter((r) => r.type === "rollout"),
+                  // @ts-expect-error TS(2339) If you come across this, please fix it!: Property 'type' does not exist on type 'never'.
                   ...rules.filter((r) => r.type === "force"),
                 ];
 
@@ -281,6 +286,7 @@ export default function FeaturesPage() {
                 if (isDraft) version++;
 
                 const projectId = feature.project;
+                // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
                 const projectName = getProjectById(projectId)?.name || null;
                 const projectIsOprhaned = projectId && !projectName;
 
@@ -298,6 +304,7 @@ export default function FeaturesPage() {
                     </td>
                     <td>
                       <Link href={`/features/${feature.id}`}>
+                        {/* @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | null' is not assignable to type 'st... Remove this comment to see the full error message */}
                         <a className={feature.archived ? "text-muted" : null}>
                           {feature.id}
                         </a>
@@ -334,6 +341,7 @@ export default function FeaturesPage() {
                     ))}
                     <td>
                       <ValueDisplay
+                        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
                         value={getFeatureDefaultValue(feature)}
                         type={feature.valueType}
                         full={false}
@@ -341,6 +349,7 @@ export default function FeaturesPage() {
                     </td>
                     <td>
                       {firstRule && (
+                        // @ts-expect-error TS(2339) If you come across this, please fix it!: Property 'type' does not exist on type 'never'.
                         <span className="text-dark">{firstRule.type}</span>
                       )}
                       {totalRules > 1 && (

--- a/packages/front-end/pages/idea/[iid].tsx
+++ b/packages/front-end/pages/idea/[iid].tsx
@@ -66,6 +66,7 @@ const IdeaPage = (): ReactElement => {
     experiment?: Partial<ExperimentInterfaceStringDates>;
   }>(`/idea/${iid}`);
 
+  // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
   useSwitchOrg(data?.idea?.organization);
 
   const form = useForm<{
@@ -221,7 +222,9 @@ const IdeaPage = (): ReactElement => {
               </a>
             </Link>
             <StatusIndicator
+              // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'ExperimentStatus | undefined' is not assigna... Remove this comment to see the full error message
               status={data.experiment.status}
+              // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'boolean | undefined' is not assignable to ty... Remove this comment to see the full error message
               archived={data.experiment.archived}
             />
           </div>
@@ -316,6 +319,7 @@ const IdeaPage = (): ReactElement => {
                         <small>
                           Submitted by{" "}
                           <strong className="mr-1">
+                            {/* @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | null' is not assignable... Remove this comment to see the full error message */}
                             {getUserDisplay(idea.userId) || idea.userName}
                           </strong>
                           {idea.source && idea.source !== "web" && (
@@ -334,6 +338,7 @@ const IdeaPage = (): ReactElement => {
                         <small>
                           Project:{" "}
                           <span className="badge badge-secondary">
+                            {/* @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message */}
                             {getProjectById(idea.project)?.name || "None"}
                           </span>
                         </small>
@@ -357,6 +362,7 @@ const IdeaPage = (): ReactElement => {
                   },
                 });
               }}
+              // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
               value={idea.details}
               canCreate={canEdit}
               canEdit={canEdit}
@@ -440,6 +446,7 @@ const IdeaPage = (): ReactElement => {
                       {idea?.estimateParams?.numVariations || 2}
                     </RightRailSectionGroup>
                     <RightRailSectionGroup title="User Segment" type="badge">
+                      {/* @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message */}
                       {getSegmentById(estimate?.segment)?.name || "Everyone"}
                     </RightRailSectionGroup>
                     <RightRailSectionGroup
@@ -452,11 +459,14 @@ const IdeaPage = (): ReactElement => {
                 </div>
               )}
 
+              {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
               {estimate?.query?.length > 0 && (
                 <div>
                   <hr />
                   <ViewQueryButton
+                    // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
                     queries={[estimate.query]}
+                    // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
                     language={estimate.queryLanguage}
                   />
                 </div>

--- a/packages/front-end/pages/ideas.tsx
+++ b/packages/front-end/pages/ideas.tsx
@@ -22,6 +22,7 @@ const IdeasPage = (): React.ReactElement => {
     ideas: IdeaInterface[];
   }>(`/ideas?project=${project || ""}`);
 
+  // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'null' is not assignable to param... Remove this comment to see the full error message
   const [current, setCurrent] = useState<Partial<IdeaInterface>>(null);
 
   const { getUserDisplay, permissions } = useUser();
@@ -69,6 +70,7 @@ const IdeasPage = (): React.ReactElement => {
         {current && (
           <IdeaForm
             mutate={mutate}
+            // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'null' is not assignable to param... Remove this comment to see the full error message
             close={() => setCurrent(null)}
             idea={current}
           />
@@ -85,6 +87,7 @@ const IdeasPage = (): React.ReactElement => {
       {current && (
         <IdeaForm
           mutate={mutate}
+          // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'null' is not assignable to param... Remove this comment to see the full error message
           close={() => setCurrent(null)}
           idea={current}
         />
@@ -171,6 +174,7 @@ const IdeasPage = (): React.ReactElement => {
                           <div className="date mb-1">
                             By{" "}
                             <strong className="mr-1">
+                              {/* @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | null' is not assignable... Remove this comment to see the full error message */}
                               {getUserDisplay(idea.userId) || idea.userName}
                             </strong>
                             on <strong>{date(idea.dateCreated)}</strong>

--- a/packages/front-end/pages/integrations/vercel/index.tsx
+++ b/packages/front-end/pages/integrations/vercel/index.tsx
@@ -115,6 +115,7 @@ export default function VercelIntegrationPage() {
                           value: env.id,
                         }))}
                         initialOption="None"
+                        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | null' is not assignable to type 'st... Remove this comment to see the full error message
                         value={elem.gb}
                         onChange={(selected) => {
                           const newMap = [...gbVercelEnvMap];

--- a/packages/front-end/pages/invitation.tsx
+++ b/packages/front-end/pages/invitation.tsx
@@ -10,6 +10,7 @@ const InvitationPage = (): React.ReactElement => {
 
   // Extract the invitation key from the querystring
   const key = useMemo(
+    // @ts-expect-error TS(2531) If you come across this, please fix it!: Object is possibly 'null'.
     () => window?.location.search.match(/(^|&|\?)key=([a-zA-Z0-9]+)/)[2],
     []
   );

--- a/packages/front-end/pages/metric/[mid].tsx
+++ b/packages/front-end/pages/metric/[mid].tsx
@@ -100,6 +100,7 @@ const MetricPage: FC = () => {
     experiments: Partial<ExperimentInterfaceStringDates>[];
   }>(`/metric/${mid}`);
 
+  // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
   useSwitchOrg(data?.metric?.organization);
 
   const {
@@ -136,9 +137,11 @@ const MetricPage: FC = () => {
 
   let analysis = data.metric.analysis;
   if (!analysis || !("average" in analysis)) {
+    // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'null' is not assignable to type 'MetricAnaly... Remove this comment to see the full error message
     analysis = null;
   }
 
+  // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
   const segment = getSegmentById(metric.segment);
 
   const supportsSQL = datasource?.properties?.queryLanguage === "sql";
@@ -182,29 +185,39 @@ const MetricPage: FC = () => {
         const experimentLinks = [];
         const ideaLinks = [];
         let subtitleText = "This metric is not referenced anywhere else.";
+        // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
         if (res.ideas?.length > 0 || res.experiments?.length > 0) {
           subtitleText = "This metric is referenced in ";
           const refs = [];
+          // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
           if (res.experiments.length) {
             refs.push(
+              // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
               res.experiments.length === 1
                 ? "1 experiment"
-                : res.experiments.length + " experiments"
+                : // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
+                  res.experiments.length + " experiments"
             );
+            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
             res.experiments.forEach((e) => {
               experimentLinks.push(
+                // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'Element' is not assignable to pa... Remove this comment to see the full error message
                 <Link href={`/experiment/${e.id}`}>
                   <a>{e.name}</a>
                 </Link>
               );
             });
           }
+          // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
           if (res.ideas.length) {
             refs.push(
+              // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
               res.ideas.length === 1 ? "1 idea" : res.ideas.length + " ideas"
             );
+            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
             res.ideas.forEach((i) => {
               ideaLinks.push(
+                // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'Element' is not assignable to pa... Remove this comment to see the full error message
                 <Link href={`/idea/${i.id}`}>
                   <a>{i.text}</a>
                 </Link>
@@ -297,6 +310,7 @@ const MetricPage: FC = () => {
         <EditTagsForm
           cancel={() => setEditTags(false)}
           mutate={mutate}
+          // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string[] | undefined' is not assignable to t... Remove this comment to see the full error message
           tags={metric.tags}
           save={async (tags) => {
             await apiCall(`/metric/${metric.id}`, {
@@ -312,6 +326,7 @@ const MetricPage: FC = () => {
         <EditProjectsForm
           cancel={() => setEditProjects(false)}
           mutate={mutate}
+          // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string[] | undefined' is not assignable to t... Remove this comment to see the full error message
           projects={metric.projects}
           save={async (projects) => {
             await apiCall(`/metric/${metric.id}`, {
@@ -384,6 +399,7 @@ const MetricPage: FC = () => {
                 className="btn dropdown-item py-2"
                 text="Delete"
                 title="Delete this metric"
+                // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '() => Promise<JSX.Element | undefined>' is n... Remove this comment to see the full error message
                 getConfirmationContent={getMetricUsage(metric)}
                 onClick={async () => {
                   await apiCall(`/metric/${metric.id}`, {
@@ -421,6 +437,7 @@ const MetricPage: FC = () => {
       <div className="row mb-3 align-items-center">
         <div className="col">
           Projects:{" "}
+          {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
           {metric?.projects?.length > 0 ? (
             <ProjectBadges
               projectIds={metric.projects}
@@ -837,6 +854,7 @@ const MetricPage: FC = () => {
                       <div className="d-flex">
                         <strong className="mr-3">{e.name}</strong>
                         <div style={{ flex: 1 }} />
+                        {/* @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'ExperimentStatus | undefined' is not assigna... Remove this comment to see the full error message */}
                         <StatusIndicator archived={false} status={e.status} />
                         <FaChevronRight
                           className="ml-3"
@@ -921,6 +939,7 @@ const MetricPage: FC = () => {
               canOpen={canEditProjects}
             >
               <RightRailSectionGroup>
+                {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
                 {metric?.projects?.length > 0 ? (
                   <ProjectBadges
                     projectIds={metric.projects}
@@ -984,8 +1003,10 @@ const MetricPage: FC = () => {
                       >
                         {metric.table}
                       </RightRailSectionGroup>
+                      {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
                       {metric.conditions?.length > 0 && (
                         <RightRailSectionGroup title="Conditions" type="list">
+                          {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
                           {metric.conditions.map(
                             (c) => `${c.column} ${c.operator} "${c.value}"`
                           )}
@@ -1064,6 +1085,7 @@ const MetricPage: FC = () => {
                       <span className="font-weight-bold">Inverse</span>
                     </li>
                   )}
+                  {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
                   {metric.cap > 0 && (
                     <li className="mb-2">
                       <span className="text-gray">Capped value:</span>{" "}
@@ -1139,12 +1161,14 @@ const MetricPage: FC = () => {
                   <li className="mb-2">
                     <span className="text-gray">Acceptable risk &lt;</span>{" "}
                     <span className="font-weight-bold">
+                      {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
                       {metric?.winRisk * 100 || defaultWinRiskThreshold * 100}%
                     </span>
                   </li>
                   <li className="mb-2">
                     <span className="text-gray">Unacceptable risk &gt;</span>{" "}
                     <span className="font-weight-bold">
+                      {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
                       {metric?.loseRisk * 100 || defaultLoseRiskThreshold * 100}
                       %
                     </span>

--- a/packages/front-end/pages/metrics.tsx
+++ b/packages/front-end/pages/metrics.tsx
@@ -308,9 +308,11 @@ const MetricsPage = (): React.ReactElement => {
               <td>{metric.type}</td>
 
               <td className="nowrap">
+                {/* @ts-expect-error TS(2769) If you come across this, please fix it!: No overload matches this call. */}
                 <SortedTags tags={Object.values(metric.tags)} />
               </td>
               <td className="col-2">
+                {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
                 {metric?.projects?.length > 0 ? (
                   <ProjectBadges
                     projectIds={metric.projects}
@@ -334,9 +336,11 @@ const MetricsPage = (): React.ReactElement => {
               </td>
               {!hasFileConfig() && (
                 <td
+                  // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'Date | null' is not assignable t... Remove this comment to see the full error message
                   title={datetime(metric.dateUpdated)}
                   className="d-none d-md-table-cell"
                 >
+                  {/* @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'Date | null' is not assignable t... Remove this comment to see the full error message */}
                   {ago(metric.dateUpdated)}
                 </td>
               )}

--- a/packages/front-end/pages/namespaces.tsx
+++ b/packages/front-end/pages/namespaces.tsx
@@ -46,6 +46,7 @@ const NamespacesPage: FC = () => {
     <div className="container-fluid pagecontents">
       {modalOpen && (
         <NamespaceModal
+          // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '{ namespace: Namespaces; experiments: number... Remove this comment to see the full error message
           existing={editNamespace}
           close={() => {
             setModalOpen(false);
@@ -60,9 +61,11 @@ const NamespacesPage: FC = () => {
       <h1>Experiment Namespaces</h1>
       <p>
         Namespaces allow you to run mutually exclusive experiments.{" "}
+        {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
         {namespaces?.length > 0 &&
           "Click a namespace below to see more details about it's current usage."}
       </p>
+      {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
       {namespaces?.length > 0 && (
         <table className="table appbox gbtable table-hover">
           <thead>
@@ -75,6 +78,7 @@ const NamespacesPage: FC = () => {
             </tr>
           </thead>
           <tbody>
+            {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
             {namespaces.map((ns, i) => {
               const experiments = data?.namespaces[ns.name] ?? [];
               return (

--- a/packages/front-end/pages/oauth/google.tsx
+++ b/packages/front-end/pages/oauth/google.tsx
@@ -14,6 +14,7 @@ const Google: FC = () => {
     if (!c) {
       setError(new Error("Authentication failed"));
     } else {
+      // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string' is not assignable to par... Remove this comment to see the full error message
       setCode(c);
     }
   }, []);

--- a/packages/front-end/pages/present/[pid].tsx
+++ b/packages/front-end/pages/present/[pid].tsx
@@ -27,6 +27,7 @@ const PresentPage = (): React.ReactElement => {
     }[];
   }>(`/presentation/${pid}`);
 
+  // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
   useSwitchOrg(pdata?.presentation?.organization);
 
   if (error) {

--- a/packages/front-end/pages/presentations.tsx
+++ b/packages/front-end/pages/presentations.tsx
@@ -264,6 +264,7 @@ const PresentationPage = (): React.ReactElement => {
         title="Edit Presentation"
         modalState={openEditPresentationModal}
         setModalState={setOpenEditPresentationModal}
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'PresentationInterface | null' is not assigna... Remove this comment to see the full error message
         existing={specificPresentation}
         refreshList={mutate}
       />

--- a/packages/front-end/pages/projects/index.tsx
+++ b/packages/front-end/pages/projects/index.tsx
@@ -88,6 +88,7 @@ const ProjectsPage: FC = () => {
               return (
                 <tr
                   key={p.id}
+                  // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '((e: MouseEvent<HTMLTableRowElement, MouseEv... Remove this comment to see the full error message
                   onClick={
                     canManage
                       ? (e) => {
@@ -96,6 +97,7 @@ const ProjectsPage: FC = () => {
                         }
                       : null
                   }
+                  // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '{ cursor: "pointer"; } | null' is not assign... Remove this comment to see the full error message
                   style={canManage ? { cursor: "pointer" } : null}
                 >
                   <td>
@@ -142,6 +144,7 @@ const ProjectsPage: FC = () => {
                             });
                             mutateDefinitions();
                           }}
+                          // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'Element | null' is not assignable to type 's... Remove this comment to see the full error message
                           additionalMessage={
                             sdkConnectionsData?.connections?.find(
                               (c) => c.project === p.id

--- a/packages/front-end/pages/report/[rid].tsx
+++ b/packages/front-end/pages/report/[rid].tsx
@@ -113,6 +113,7 @@ export default function ReportPage() {
 
   const status = getQueryStatus(report.queries || [], report.error);
 
+  // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
   const hasData = report.results?.dimensions?.[0]?.variations?.length > 0;
 
   const phaseAgeMinutes =
@@ -307,11 +308,13 @@ export default function ReportPage() {
                     }
                   }}
                   supportsNotebooks={!!datasource?.settings?.notebookRunQuery}
+                  // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '(() => void) | null' is not assignable to ty... Remove this comment to see the full error message
                   configure={
                     permissions.check("createAnalyses", "")
                       ? () => setActive("Configuration")
                       : null
                   }
+                  // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '(() => void) | null' is not assignable to ty... Remove this comment to see the full error message
                   editMetrics={
                     permissions.check("createAnalyses", "")
                       ? () => setActive("Configuration")
@@ -323,6 +326,7 @@ export default function ReportPage() {
                   notebookFilename={report.title}
                   queries={report.queries}
                   queryError={report.error}
+                  // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
                   results={report.results.dimensions}
                   variations={variations}
                   metrics={report.args.metrics}
@@ -341,6 +345,7 @@ export default function ReportPage() {
               </div>
             )}
             {!hasData &&
+              // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
               !report.results.unknownVariations?.length &&
               status !== "running" &&
               report.args.metrics.length > 0 && (
@@ -366,6 +371,7 @@ export default function ReportPage() {
               <DateResults
                 metrics={report.args.metrics}
                 guardrails={report.args.guardrails}
+                // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
                 results={report.results.dimensions}
                 variations={variations}
               />
@@ -373,6 +379,7 @@ export default function ReportPage() {
               <BreakDownResults
                 isLatestPhase={true}
                 metrics={report.args.metrics}
+                // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'MetricOverride[] | undefined' is not assigna... Remove this comment to see the full error message
                 metricOverrides={report.args.metricOverrides}
                 reportDate={report.dateCreated}
                 results={report.results?.dimensions || []}
@@ -425,8 +432,10 @@ export default function ReportPage() {
                 id={report.id}
                 isLatestPhase={true}
                 metrics={report.args.metrics}
+                // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'MetricOverride[] | undefined' is not assigna... Remove this comment to see the full error message
                 metricOverrides={report.args.metricOverrides}
                 reportDate={report.dateCreated}
+                // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'ExperimentReportResultDimension | undefined'... Remove this comment to see the full error message
                 results={report.results?.dimensions?.[0]}
                 status={"stopped"}
                 startDate={getValidDate(report.args.startDate).toISOString()}
@@ -440,10 +449,12 @@ export default function ReportPage() {
                 }
                 sequentialTestingEnabled={sequentialTestingEnabled}
               />
+              {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
               {report.args.guardrails?.length > 0 && (
                 <div className="mt-1 px-3">
                   <h3 className="mb-3">Guardrails</h3>
                   <div className="row">
+                    {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
                     {report.args.guardrails.map((g) => {
                       const metric = getMetricById(g);
                       if (!metric) return "";

--- a/packages/front-end/pages/reports.tsx
+++ b/packages/front-end/pages/reports.tsx
@@ -35,7 +35,9 @@ const ReportsPage = (): React.ReactElement => {
   const reports = useAddComputedFields(
     data?.reports,
     (r) => ({
+      // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
       userName: getUserDisplay(r.userId) || "",
+      // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
       experimentName: experimentNames.get(r.experimentId) || "",
       status: r.status === "private" ? "private" : "published",
     }),

--- a/packages/front-end/pages/saved-groups.tsx
+++ b/packages/front-end/pages/saved-groups.tsx
@@ -22,12 +22,14 @@ const getSavedGroupMessage = (
   featuresUsingSavedGroups: Set<string> | undefined
 ) => {
   return async () => {
+    // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
     if (featuresUsingSavedGroups?.size > 0) {
       return (
         <div>
           <p className="alert alert-danger">
             <strong>Whoops!</strong> Before you can delete this saved group, you
             will need to update the feature
+            {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
             {featuresUsingSavedGroups.size > 1 && "s"} listed below by removing
             any targeting conditions that rely on this saved group.
           </p>
@@ -35,6 +37,7 @@ const getSavedGroupMessage = (
             className="border rounded bg-light pt-3 pb-3 overflow-auto"
             style={{ maxHeight: "200px" }}
           >
+            {/* @ts-expect-error TS(2488) If you come across this, please fix it!: Type 'Set<string> | undefined' must have a '[Symbo... Remove this comment to see the full error message */}
             {[...featuresUsingSavedGroups].map((feature) => {
               return (
                 <li key={feature}>
@@ -218,9 +221,11 @@ export default function SavedGroupsPage() {
                                   });
                                   mutateDefinitions({});
                                 }}
+                                // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '() => Promise<JSX.Element | undefined>' is n... Remove this comment to see the full error message
                                 getConfirmationContent={getSavedGroupMessage(
                                   savedGroupFeatureIds[s.id]
                                 )}
+                                // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'boolean | 0' is not assignable to type 'bool... Remove this comment to see the full error message
                                 canDelete={
                                   savedGroupFeatureIds[s.id]?.size &&
                                   savedGroupFeatureIds[s.id]?.size === 0

--- a/packages/front-end/pages/sdks/index.tsx
+++ b/packages/front-end/pages/sdks/index.tsx
@@ -41,6 +41,7 @@ export default function SDKsPage() {
             These legacy tools will continue to work just as before if you are
             unable to migrate at this time.
           </div>
+          {/* @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'ApiKeyInterface[] | undefined' is not assign... Remove this comment to see the full error message */}
           <SDKEndpoints keys={data?.keys} mutate={mutate} />
           <div className="mt-5">
             <h1>SDK Webhooks</h1>

--- a/packages/front-end/pages/segments/index.tsx
+++ b/packages/front-end/pages/segments/index.tsx
@@ -72,40 +72,54 @@ const SegmentPage: FC = () => {
         if (res.total) {
           subtitleText = "This segment is referenced in ";
           const refs = [];
+          // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
           if (res.metrics.length) {
             refs.push(
+              // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
               res.metrics.length === 1
                 ? "1 metric"
-                : res.metrics.length + " metrics"
+                : // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
+                  res.metrics.length + " metrics"
             );
+            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
             res.metrics.forEach((m) => {
               metricLinks.push(
+                // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'Element' is not assignable to pa... Remove this comment to see the full error message
                 <Link href={`/metric/${m.id}`}>
                   <a className="">{m.name}</a>
                 </Link>
               );
             });
           }
+          // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
           if (res.ideas.length) {
             refs.push(
+              // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
               res.ideas.length === 1 ? "1 idea" : res.ideas.length + " ideas"
             );
+            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
             res.ideas.forEach((i) => {
               ideaLinks.push(
+                // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'Element' is not assignable to pa... Remove this comment to see the full error message
                 <Link href={`/idea/${i.id}`}>
                   <a>{i.text}</a>
                 </Link>
               );
             });
           }
+          // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
           if (res.experiments.length) {
             refs.push(
+              // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
               res.experiments.length === 1
                 ? "1 experiment"
-                : res.experiments.length + " Experiments"
+                : // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
+                  res.experiments.length + " Experiments"
             );
+            // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
             res.experiments.forEach((e) => {
               expLinks.push(
+                // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'Element' is not assignable to pa... Remove this comment to see the full error message
                 <Link href={`/experiment/${e.id}`}>
                   <a>{e.name}</a>
                 </Link>
@@ -305,6 +319,7 @@ const SegmentPage: FC = () => {
                         />
                       </td>
                       {canAddEditRemoveSegments() && (
+                        // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'Date | null' is not assignable t... Remove this comment to see the full error message
                         <td>{ago(s.dateUpdated)}</td>
                       )}
                       {canAddEditRemoveSegments() && (
@@ -325,6 +340,7 @@ const SegmentPage: FC = () => {
                             className={"tr-hover text-primary"}
                             displayName={s.name}
                             title="Delete this segment"
+                            // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '() => Promise<JSX.Element | undefined>' is n... Remove this comment to see the full error message
                             getConfirmationContent={getSegmentUsage(s)}
                             onClick={async () => {
                               await apiCall<{

--- a/packages/front-end/pages/settings/index.tsx
+++ b/packages/front-end/pages/settings/index.tsx
@@ -77,6 +77,7 @@ const GeneralSettingsPage = (): React.ReactElement => {
   const { metricDefaults } = useOrganizationMetricDefaults();
 
   const [upgradeModal, setUpgradeModal] = useState(false);
+  // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
   const showUpgradeButton = ["oss", "starter"].includes(accountPlan);
   const licensePlanText =
     (accountPlan === "enterprise"
@@ -108,7 +109,9 @@ const GeneralSettingsPage = (): React.ReactElement => {
       },
       metricDefaults: {
         minimumSampleSize: metricDefaults.minimumSampleSize,
+        // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
         maxPercentageChange: metricDefaults.maxPercentageChange * 100,
+        // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
         minPercentageChange: metricDefaults.minPercentageChange * 100,
       },
       updateSchedule: {
@@ -189,12 +192,16 @@ const GeneralSettingsPage = (): React.ReactElement => {
           newVal.metricDefaults = {
             ...newVal.metricDefaults,
             maxPercentageChange:
+              // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
               newVal.metricDefaults.maxPercentageChange * 100,
             minPercentageChange:
+              // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
               newVal.metricDefaults.minPercentageChange * 100,
           };
         }
+        // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
         if (k === "confidenceLevel" && newVal?.confidenceLevel <= 1) {
+          // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
           newVal.confidenceLevel = newVal.confidenceLevel * 100;
         }
       });
@@ -211,9 +218,12 @@ const GeneralSettingsPage = (): React.ReactElement => {
       ...value,
       metricDefaults: {
         ...value.metricDefaults,
+        // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
         maxPercentageChange: value.metricDefaults.maxPercentageChange / 100,
+        // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
         minPercentageChange: value.metricDefaults.minPercentageChange / 100,
       },
+      // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
       confidenceLevel: value.confidenceLevel / 100,
     };
 
@@ -230,24 +240,31 @@ const GeneralSettingsPage = (): React.ReactElement => {
   });
 
   const highlightColor =
+    // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
     value.confidenceLevel < 70
       ? "#c73333"
-      : value.confidenceLevel < 80
+      : // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
+      value.confidenceLevel < 80
       ? "#e27202"
-      : value.confidenceLevel < 90
+      : // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
+      value.confidenceLevel < 90
       ? "#B39F01"
       : "";
 
   const pHighlightColor =
+    // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
     value.pValueThreshold > 0.3
       ? "#c73333"
-      : value.pValueThreshold > 0.2
+      : // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
+      value.pValueThreshold > 0.2
       ? "#e27202"
-      : value.pValueThreshold > 0.1
+      : // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
+      value.pValueThreshold > 0.1
       ? "#B39F01"
       : "";
 
   const regressionAdjustmentDaysHighlightColor =
+    // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
     value.regressionAdjustmentDays > 28 || value.regressionAdjustmentDays < 7
       ? "#e27202"
       : "";
@@ -255,33 +272,43 @@ const GeneralSettingsPage = (): React.ReactElement => {
   const warningMsg =
     value.confidenceLevel === 70
       ? "This is as low as it goes"
-      : value.confidenceLevel < 75
+      : // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
+      value.confidenceLevel < 75
       ? "Confidence thresholds this low are not recommended"
-      : value.confidenceLevel < 80
+      : // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
+      value.confidenceLevel < 80
       ? "Confidence thresholds this low are not recommended"
-      : value.confidenceLevel < 90
+      : // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
+      value.confidenceLevel < 90
       ? "Use caution with values below 90%"
-      : value.confidenceLevel >= 99
+      : // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
+      value.confidenceLevel >= 99
       ? "Confidence levels 99% and higher can take lots of data to achieve"
       : "";
 
   const pWarningMsg =
     value.pValueThreshold === 0.5
       ? "This is as high as it goes"
-      : value.pValueThreshold > 0.25
+      : // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
+      value.pValueThreshold > 0.25
       ? "P-value thresholds this high are not recommended"
-      : value.pValueThreshold > 0.2
+      : // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
+      value.pValueThreshold > 0.2
       ? "P-value thresholds this high are not recommended"
-      : value.pValueThreshold > 0.1
+      : // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
+      value.pValueThreshold > 0.1
       ? "Use caution with values above 0.1"
-      : value.pValueThreshold <= 0.01
+      : // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
+      value.pValueThreshold <= 0.01
       ? "Threshold values of 0.01 and lower can take lots of data to achieve"
       : "";
 
   const regressionAdjustmentDaysWarningMsg =
+    // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
     value.regressionAdjustmentDays > 28
       ? "Longer lookback periods can sometimes be useful, but also will reduce query performance and may incorporate less useful data"
-      : value.regressionAdjustmentDays < 7
+      : // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
+      value.regressionAdjustmentDays < 7
       ? "Lookback periods under 7 days tend not to capture enough metric data to reduce variance and may be subject to weekly seasonality"
       : "";
 
@@ -308,6 +335,7 @@ const GeneralSettingsPage = (): React.ReactElement => {
       <div className="container-fluid pagecontents">
         {editOpen && (
           <EditOrganizationModal
+            // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
             name={organization.name}
             close={() => setEditOpen(false)}
             mutate={refreshOrganization}
@@ -566,6 +594,7 @@ const GeneralSettingsPage = (): React.ReactElement => {
                         </AttributionModelTooltip>
                       }
                       className="ml-2"
+                      // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
                       value={form.watch("attributionModel")}
                       onChange={(value) => {
                         form.setValue(
@@ -661,6 +690,7 @@ const GeneralSettingsPage = (): React.ReactElement => {
                   className="mt-3"
                   buttonsClassName="px-5"
                   tabContentsClassName="border"
+                  // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'Dispatch<SetStateAction<string>>' is not ass... Remove this comment to see the full error message
                   setActive={setStatsEngineTab}
                   active={statsEngineTab}
                 >
@@ -749,6 +779,7 @@ const GeneralSettingsPage = (): React.ReactElement => {
                       <SelectField
                         label={"Multiple comparisons correction to use: "}
                         className="ml-2"
+                        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | null' is not assignable to type 'st... Remove this comment to see the full error message
                         value={form.watch("pValueCorrection") ?? null}
                         onChange={(value) =>
                           form.setValue(
@@ -760,6 +791,7 @@ const GeneralSettingsPage = (): React.ReactElement => {
                         options={[
                           {
                             label: "None",
+                            // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'null' is not assignable to type 'string'.
                             value: null,
                           },
                           {
@@ -849,6 +881,7 @@ const GeneralSettingsPage = (): React.ReactElement => {
                           {...form.register("regressionAdjustmentDays", {
                             valueAsNumber: true,
                             validate: (v) => {
+                              // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
                               return !(v <= 0 || v > 100);
                             },
                           })}
@@ -932,6 +965,7 @@ const GeneralSettingsPage = (): React.ReactElement => {
                             {
                               valueAsNumber: true,
                               validate: (v) => {
+                                // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
                                 return !(v <= 0);
                               },
                             }

--- a/packages/front-end/pages/settings/team.tsx
+++ b/packages/front-end/pages/settings/team.tsx
@@ -80,6 +80,7 @@ const TeamPage: FC = () => {
           <div>You can now invite more team members to your account.</div>
         </div>
       )}
+      {/* @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'SSOConnectionInterface | undefined' is not a... Remove this comment to see the full error message */}
       <SSOSettings ssoConnection={ssoConnection} />
       <h1>Team Members</h1>
       {projects.length > 0 && (
@@ -106,15 +107,19 @@ const TeamPage: FC = () => {
         canDeleteMembers={true}
         canInviteMembers={true}
       />
+      {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
       {organization?.pendingMembers?.length > 0 && (
         <PendingMemberList
+          // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'PendingMember[] | undefined' is not assignab... Remove this comment to see the full error message
           pendingMembers={organization.pendingMembers}
           mutate={refreshOrganization}
           project={currentProject}
         />
       )}
+      {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
       {organization.invites.length > 0 && (
         <InviteList
+          // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'Invite[] | undefined' is not assignable to t... Remove this comment to see the full error message
           invites={organization.invites}
           mutate={refreshOrganization}
           project={currentProject}

--- a/packages/front-end/services/DefinitionsContext.tsx
+++ b/packages/front-end/services/DefinitionsContext.tsx
@@ -166,6 +166,7 @@ export const DefinitionsProvider: FC<{ children: ReactNode }> = ({
         }
       },
       mutateDefinitions: async (changes) => {
+        // @ts-expect-error TS(2783) If you come across this, please fix it!: 'status' is specified more than once, so this usag... Remove this comment to see the full error message
         await mutate(Object.assign({ status: 200, ...data }, changes), true);
       },
     };

--- a/packages/front-end/services/UserContext.tsx
+++ b/packages/front-end/services/UserContext.tsx
@@ -169,6 +169,7 @@ export function UserContextProvider({ children }: { children: ReactNode }) {
       });
       setData(res);
       if (res.organizations) {
+        // @ts-expect-error TS(2722) If you come across this, please fix it!: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
         setOrganizations(res.organizations);
       }
     } catch (e) {
@@ -186,6 +187,7 @@ export function UserContextProvider({ children }: { children: ReactNode }) {
     return userMap;
   }, [currentOrg?.members]);
 
+  // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
   let user = users.get(data?.userId);
   if (!user && data) {
     user = {
@@ -207,6 +209,7 @@ export function UserContextProvider({ children }: { children: ReactNode }) {
   const permissionsObj: Record<GlobalPermission, boolean> = {
     ...DEFAULT_PERMISSIONS,
   };
+  // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'MemberRole | undefined' is not a... Remove this comment to see the full error message
   getPermissionsByRole(role, currentOrg?.roles || []).forEach((p) => {
     permissionsObj[p] = true;
   });
@@ -216,6 +219,7 @@ export function UserContextProvider({ children }: { children: ReactNode }) {
     currentUser = {
       org: orgId || "",
       id: data?.userId || "",
+      // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'MemberRole | undefined' is not assignable to... Remove this comment to see the full error message
       role: role,
     };
   }, [orgId, data?.userId, role]);
@@ -255,6 +259,7 @@ export function UserContextProvider({ children }: { children: ReactNode }) {
   // Update growthbook tarageting attributes
   const growthbook = useGrowthBook<AppFeatures>();
   useEffect(() => {
+    // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
     growthbook.setAttributes({
       id: data?.userId || "",
       name: data?.userName || "",
@@ -339,6 +344,7 @@ export function UserContextProvider({ children }: { children: ReactNode }) {
         updateUser,
         user,
         users,
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '(id: string, fallback?: boolean | undefined)... Remove this comment to see the full error message
         getUserDisplay: (id, fallback = true) => {
           const u = users.get(id);
           if (!u && fallback) return id;
@@ -354,10 +360,12 @@ export function UserContextProvider({ children }: { children: ReactNode }) {
         },
         settings: currentOrg?.organization?.settings || {},
         license: data?.license,
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'SSOConnectionInterface | null | undefined' i... Remove this comment to see the full error message
         enterpriseSSO: currentOrg?.enterpriseSSO,
         accountPlan: currentOrg?.accountPlan,
         commercialFeatures: currentOrg?.commercialFeatures || [],
         apiKeys: currentOrg?.apiKeys || [],
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'OrganizationInterface | undefined' is not as... Remove this comment to see the full error message
         organization: currentOrg?.organization,
         error,
         hasCommercialFeature: (feature) => commercialFeatures.has(feature),

--- a/packages/front-end/services/auth.tsx
+++ b/packages/front-end/services/auth.tsx
@@ -150,6 +150,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
 }) => {
   const [loading, setLoading] = useState(true);
   const [token, setToken] = useState("");
+  // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'null' is not assignable to param... Remove this comment to see the full error message
   const [orgId, setOrgId] = useState<string>(null);
   const [organizations, setOrganizations] = useState<UserOrganizations>([]);
   const [
@@ -226,9 +227,12 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
   }, []);
 
   const orgList = [...organizations];
+  // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
   if (specialOrg && !orgList.map((o) => o.id).includes(specialOrg.id)) {
     orgList.push({
+      // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
       id: specialOrg.id,
+      // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
       name: specialOrg.name,
     });
   }
@@ -374,6 +378,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
             method: "POST",
             credentials: "include",
           });
+          // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'null' is not assignable to param... Remove this comment to see the full error message
           setOrgId(null);
           setOrganizations([]);
           setSpecialOrg(null);

--- a/packages/front-end/services/codegen.ts
+++ b/packages/front-end/services/codegen.ts
@@ -88,6 +88,7 @@ export function generateJavascriptSnippet(
   let cw = 0;
   for (let i = 0; i < adjustedWeights.length; i++) {
     cw += adjustedWeights[i];
+    // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'number' is not assignable to par... Remove this comment to see the full error message
     cumulativeWeights.push(cw);
   }
 

--- a/packages/front-end/services/config.ts
+++ b/packages/front-end/services/config.ts
@@ -40,6 +40,7 @@ export function useConfigJson({
 
     datasources.forEach((d) => {
       datasourceIds.push(d.id);
+      // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
       config.datasources[d.id] = {
         type: d.type,
         name: d.name,
@@ -50,6 +51,7 @@ export function useConfigJson({
 
     if (segments?.length) config.segments = {};
     segments?.forEach((s) => {
+      // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
       config.segments[s.id] = {
         name: s.name,
         datasource: s.datasource,
@@ -103,12 +105,14 @@ export function useConfigJson({
         (met[f] as any) = v;
       });
 
+      // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
       config.metrics[m.id] = met;
     });
 
     if (dimensions.length) config.dimensions = {};
     dimensions.forEach((d) => {
       if (d.datasource && !datasourceIds.includes(d.datasource)) return;
+      // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
       config.dimensions[d.id] = {
         name: d.name,
         datasource: d.datasource,

--- a/packages/front-end/services/datasources.ts
+++ b/packages/front-end/services/datasources.ts
@@ -104,6 +104,7 @@ const SnowplowSchema: SchemaInterface = {
     "os",
   ],
   getExperimentSQL: (tablePrefix, userId, options) => {
+    // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
     const actionName = options.actionName || "Experiment Viewed";
     const userCol = userId === "user_id" ? "user_id" : "domain_userid";
 
@@ -182,6 +183,7 @@ const AmplitudeSchema: SchemaInterface = {
   experimentDimensions: ["country", "device", "os", "paying"],
   getExperimentSQL: (tablePrefix, userId, options) => {
     const userCol = userId === "user_id" ? "user_id" : "$amplitude_id";
+    // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
     const eventType = options.eventType || "Experiment Viewed";
 
     return `SELECT

--- a/packages/front-end/services/experiments.ts
+++ b/packages/front-end/services/experiments.ts
@@ -35,6 +35,7 @@ export function hasEnoughData(
   const minSampleSize =
     metric.minSampleSize || metricDefaults.minimumSampleSize;
 
+  // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
   return Math.max(baseline.value, stats.value) >= minSampleSize;
 }
 
@@ -49,6 +50,7 @@ export function isSuspiciousUplift(
   const maxPercentChange =
     metric.maxPercentChange || metricDefaults?.maxPercentageChange;
 
+  // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
   return Math.abs(baseline.cr - stats.cr) / baseline.cr >= maxPercentChange;
 }
 
@@ -63,6 +65,7 @@ export function isBelowMinChange(
   const minPercentChange =
     metric.minPercentChange || metricDefaults.minPercentageChange;
 
+  // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
   return Math.abs(baseline.cr - stats.cr) / baseline.cr < minPercentChange;
 }
 
@@ -81,6 +84,7 @@ export function shouldHighlight({
   suspiciousChange: boolean;
   belowMinChange: boolean;
 }): boolean {
+  // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'number | boolean' is not assignable to type ... Remove this comment to see the full error message
   return (
     metric &&
     baseline?.value &&
@@ -104,6 +108,7 @@ export function getRisk(
 
   if (riskVariation > 0) {
     const stats = row.variations[riskVariation];
+    // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'number | undefined' is not assignable to typ... Remove this comment to see the full error message
     risk = stats?.risk?.[row.metric.inverse ? 0 : 1];
     riskCR = stats?.cr;
     showRisk =
@@ -123,19 +128,24 @@ export function getRisk(
       }
 
       const vRisk = stats.risk?.[row.metric.inverse ? 1 : 0];
+      // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
       if (vRisk > risk) {
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'number | undefined' is not assignable to typ... Remove this comment to see the full error message
         risk = vRisk;
         riskCR = stats.cr;
       }
     });
+    // @ts-expect-error TS(2454) If you come across this, please fix it!: Variable 'riskCR' is used before being assigned.
     showRisk = risk >= 0 && riskCR > 0;
   }
   if (showRisk) {
+    // @ts-expect-error TS(2454) If you come across this, please fix it!: Variable 'riskCR' is used before being assigned.
     relativeRisk = risk / riskCR;
   }
 
   return {
     risk,
+    // @ts-expect-error TS(2454) If you come across this, please fix it!: Variable 'relativeRisk' is used before being assig... Remove this comment to see the full error message
     relativeRisk,
     showRisk,
   };
@@ -211,10 +221,13 @@ export function useDomain(
       }
 
       const ci = stats.ci || [];
+      // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
       if (!lowerBound || ci[0] < lowerBound) lowerBound = ci[0];
+      // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
       if (!upperBound || ci[1] > upperBound) upperBound = ci[1];
     });
   });
+  // @ts-expect-error TS(2454) If you come across this, please fix it!: Variable 'lowerBound' is used before being assigne... Remove this comment to see the full error message
   return [lowerBound || 0, upperBound || 0];
 }
 
@@ -452,6 +465,7 @@ export function setAdjustedPValuesOnResults(
       nonGuardrailMetrics.forEach((m) => {
         if (v.metrics[m]?.pValue !== undefined) {
           indexedPValues.push({
+            // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'number | undefined' is not assignable to typ... Remove this comment to see the full error message
             pValue: v.metrics[m].pValue,
             index: [i, j, m],
           });

--- a/packages/front-end/services/features.ts
+++ b/packages/front-end/services/features.ts
@@ -346,6 +346,7 @@ export function getDefaultRuleValue({
   attributeSchema?: SDKAttributeSchema;
   ruleType: string;
 }): FeatureRule {
+  // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
   const hashAttributes = attributeSchema
     .filter((a) => a.hashAttribute)
     .map((a) => a.property);
@@ -724,7 +725,8 @@ export function useAttributeMap(): Map<string, AttributeData> {
         array: !!schema.datatype.match(/\[\]$/),
         enum:
           schema.datatype === "enum"
-            ? schema.enum.split(",").map((x) => x.trim())
+            ? // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
+              schema.enum.split(",").map((x) => x.trim())
             : [],
         identifier: !!schema.hashAttribute,
         archived: !!schema.archived,
@@ -771,7 +773,9 @@ export function getExperimentDefinitionFromFeature(
         name: "Main",
         reason: "",
         dateStarted: new Date().toISOString(),
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
         condition: expRule.condition,
+        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'NamespaceValue | undefined' is not assignabl... Remove this comment to see the full error message
         namespace: expRule.namespace,
         seed: trackingKey,
       },
@@ -853,6 +857,7 @@ export function genDuplicatedKey({ id }: FeatureInterface) {
     // Store 'feature_a' from 'feature_a_4'
     const keyRoot = numSuffix ? id.substr(0, id.length - numSuffix.length) : id;
     // Parse the 4 (number) out of '_4' (string)
+    // @ts-expect-error TS(2531) If you come across this, please fix it!: Object is possibly 'null'.
     const num = (numSuffix ? parseInt(numSuffix.match(/[\d]+/)[0]) : 0) + 1;
 
     return `${keyRoot}_${num}`;

--- a/packages/front-end/services/organizations.tsx
+++ b/packages/front-end/services/organizations.tsx
@@ -3,7 +3,9 @@ import { OrganizationInterface } from "back-end/types/organization";
 export function getNumberOfUniqueMembersAndInvites(
   organization: Partial<OrganizationInterface>
 ) {
+  // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
   const numMembers = new Set(organization.members.map((m) => m.id)).size;
+  // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
   const numInvites = new Set(organization.invites.map((i) => i.email)).size;
 
   return numMembers + numInvites;

--- a/packages/front-end/services/search.tsx
+++ b/packages/front-end/services/search.tsx
@@ -114,6 +114,7 @@ export function useSearch<T>({
       const comp1 = a[sort.field];
       const comp2 = b[sort.field];
       if (typeof comp1 === "string" && typeof comp2 === "string") {
+        // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
         return comp1.localeCompare(comp2) * sort.dir;
       }
       if (Array.isArray(comp1) && Array.isArray(comp2)) {
@@ -121,16 +122,20 @@ export function useSearch<T>({
         // We'll just sort length of the array, then by the first element alphabetically
         // This is typically for tags
         if (comp1.length !== comp2.length) {
+          // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
           return (comp2.length - comp1.length) * sort.dir;
         }
         const temp1 = comp1[0] ?? "";
         const temp2 = comp2[0] ?? "";
         if (typeof temp1 === "string" && typeof temp2 === "string") {
+          // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
           return temp1.localeCompare(temp2) * sort.dir;
         }
+        // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
         return (temp1 - temp2) * sort.dir;
       }
       if (typeof comp1 === "number" && typeof comp2 === "number") {
+        // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
         return (comp1 - comp2) * sort.dir;
       }
       return 0;
@@ -153,6 +158,7 @@ export function useSearch<T>({
               e.preventDefault();
               setSort({
                 field,
+                // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
                 dir: sort.field === field ? sort.dir * -1 : 1,
               });
             }}
@@ -163,6 +169,7 @@ export function useSearch<T>({
               className={sort.field === field ? "activesort" : "inactivesort"}
             >
               {sort.field === field ? (
+                // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
                 sort.dir < 0 ? (
                   <FaSortDown />
                 ) : (
@@ -220,6 +227,7 @@ export function filterFeaturesByEnvironment(
   }
   if (environmentFilter.has("all")) {
     environments.forEach((env) => {
+      // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'boolean | undefined' is not assi... Remove this comment to see the full error message
       environmentFilter.set(env, environmentFilter.get("all"));
     });
   }

--- a/packages/front-end/services/useSwitchOrg.ts
+++ b/packages/front-end/services/useSwitchOrg.ts
@@ -6,7 +6,9 @@ export default function useSwitchOrg(newOrg: null | string): void {
 
   useEffect(() => {
     if (orgId && newOrg && orgId !== newOrg) {
+      // @ts-expect-error TS(2722) If you come across this, please fix it!: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
       setOrgId(newOrg);
+      // @ts-expect-error TS(2722) If you come across this, please fix it!: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
       setSpecialOrg({
         id: newOrg,
         name: "**ADMIN ACCESS**",

--- a/packages/front-end/services/utils.tsx
+++ b/packages/front-end/services/utils.tsx
@@ -11,6 +11,7 @@ export function phaseSummary(
   phase: ExperimentPhaseStringDates
 ): React.ReactElement {
   if (!phase) {
+    // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'null' is not assignable to type 'ReactElemen... Remove this comment to see the full error message
     return null;
   }
   return (

--- a/packages/front-end/tsconfig.json
+++ b/packages/front-end/tsconfig.json
@@ -5,6 +5,7 @@
     "allowJs": true,
     "skipLibCheck": true,
     "strict": false,
+    "strictNullChecks": true,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "esModuleInterop": true,

--- a/packages/shared/src/settings/index.ts
+++ b/packages/shared/src/settings/index.ts
@@ -93,7 +93,7 @@ const scopeSettings = (
   const settings = Object.entries(resolvers).reduce(
     (acc, [fieldName, resolver]) => {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore - todo: we need to figure out how to resolve the type
+      // @ts-expect-error - todo: we need to figure out how to resolve the type
       acc[fieldName as keyof Settings] = resolver(ctx);
       return acc;
     },
@@ -117,16 +117,16 @@ const normalizeInputSettings = (
   for (const key in baseSettings) {
     scopedSettings[key as keyof Settings] = {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore - todo: we need to figure out how to resolve the type
+      // @ts-expect-error - todo: we need to figure out how to resolve the type
       value:
         inputSettings[key as keyof Settings] ??
         baseSettings[key as keyof Settings],
       meta: {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
+        // @ts-expect-error
         reason: "org-level setting applied",
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
+        // @ts-expect-error
         scopeApplied: "organization",
       },
     };


### PR DESCRIPTION
Closes #1114 

Changes:
- Turn on `strictNullChecks` in `tsconfig.json`
- Use `@airbnb/ts-migrate` to insert `// @ts-expect-error` for all lines of code now breaking null-checking rule
- Add eslint rule to enforce using `ts-expect-error` over `ts-ignore` ([Reasons here](https://typescript-eslint.io/rules/prefer-ts-expect-error/))