### PR TITLE
Fix function name typo in authenticateApiRequestMiddleware

### DIFF
--- a/packages/back-end/src/api/api.router.ts
+++ b/packages/back-end/src/api/api.router.ts
@@ -3,7 +3,7 @@ import path from "path";
 import { Router, Request } from "express";
 import rateLimit from "express-rate-limit";
 import bodyParser from "body-parser";
-import authencateApiRequestMiddleware from "../middleware/authenticateApiRequestMiddleware";
+import authenticateApiRequestMiddleware from "../middleware/authenticateApiRequestMiddleware";
 import { getBuild } from "../util/handler";
 import { ApiRequestLocals } from "../../types/api";
 import featuresRouter from "./features/features.router";
@@ -41,7 +41,7 @@ router.get("/openapi.yaml", (req, res) => {
 router.use(bodyParser.json({ limit: "1mb" }));
 router.use(bodyParser.urlencoded({ limit: "1mb", extended: true }));
 
-router.use(authencateApiRequestMiddleware);
+router.use(authenticateApiRequestMiddleware);
 
 // Rate limit API keys to 60 requests per minute
 router.use(

--- a/packages/back-end/src/middleware/authenticateApiRequestMiddleware.ts
+++ b/packages/back-end/src/middleware/authenticateApiRequestMiddleware.ts
@@ -6,7 +6,7 @@ import { getOrganizationById } from "../services/organizations";
 import { getCustomLogProps } from "../util/logger";
 import { EventAuditUserApiKey } from "../events/event-types";
 
-export default function authencateApiRequestMiddleware(
+export default function authenticateApiRequestMiddleware(
   req: Request & ApiRequestLocals,
   res: Response & { log: Request["log"] },
   next: NextFunction


### PR DESCRIPTION


### Testing

`git grep 'authencateApiRequestMiddleware'`.  See no response.
