### PR TITLE
Add launch.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,8 @@ uploads
 packages/back-end/globalConfig.json
 packages/back-end/dummy
 config.yml
-.vscode
+.vscode/*
+!.vscode/launch.json
 packages/stats/notebooks
 buildinfo/
 *.tsbuildinfo

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,45 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug Back-end",
+      "type": "node",
+      "request": "launch",
+      "runtimeArgs": [
+        "nodemon",
+        "-e",
+        "ts",
+        "--exec",
+        "node",
+        "-r",
+        "ts-node/register"
+      ],
+      "args": ["${workspaceFolder}/packages/back-end/src/server.ts"],
+      "cwd": "${workspaceFolder}/packages/back-end",
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "skipFiles": ["<node_internals>/**"],
+      "sourceMaps": true,
+      "runtimeExecutable": "yarn",
+      "restart": true
+    },
+    {
+      "name": "Debug Front-end",
+      "type": "node-terminal",
+      "request": "launch",
+      "command": "yarn dev",
+      "cwd": "${workspaceFolder}/packages/front-end",
+      "serverReadyAction": {
+        "pattern": "started server on .+, url: (https?://.+)",
+        "uriFormat": "%s",
+        "action": "debugWithChrome"
+      }
+    }
+  ],
+  "compounds": [
+    {
+      "name": "Debug Fullstack",
+      "configurations": ["Debug Back-end", "Debug Front-end"]
+    }
+  ]
+}


### PR DESCRIPTION
### Features and Changes

Allow for debugging with VS code.  The backend debugger will restart on changes.

There is also a front-end debugger, but it seems less than useful as it is, as a breakpoint has to be added within google chrome.  When it is hit a read-only version of the file is opened in VS-code.  This doesn't seem to get us much more than just debugging straight in chrome.  I tried briefly getting the front-end to create source maps, but it didn't seem to work.  Still adding it for completeness and it does at least allow both the front-end and back-end to start with one click.

### Testing

In VS code click on Run and Debug or ( Shift - Apple - D)
From the drop down menu select Debug Fullstack.
Click start.
Set a breakpoint in both the front end and back end.
Hit a url that will trigger the breakpoint.  
See it stop.
Edit a file in a backend.
See the backend restart.
Hit a url that will trigger the breakpoint.
See that the backend will stop at the correct line numbers given the edits, because it had successfully restarted.
