### PR TITLE
Remove information_schema for deleted data sources.

### DIFF
--- a/packages/back-end/src/controllers/datasources.ts
+++ b/packages/back-end/src/controllers/datasources.ts
@@ -42,6 +42,8 @@ import {
   getSampleMetrics,
 } from "../models/MetricModel";
 import { EventAuditUserForResponseLocals } from "../events/event-types";
+import { deleteInformationSchemaById } from "../models/InformationSchemaModel";
+import { deleteInformationSchemaTablesByInformationSchemaId } from "../models/InformationSchemaTablesModel";
 
 export async function postSampleData(
   req: AuthRequest,
@@ -283,6 +285,17 @@ export async function deleteDataSource(
   }
 
   await deleteDatasourceById(datasource.id, org.id);
+
+  if (datasource.settings?.informationSchemaId) {
+    const informationSchemaId = datasource.settings.informationSchemaId;
+
+    await deleteInformationSchemaById(org.id, informationSchemaId);
+
+    await deleteInformationSchemaTablesByInformationSchemaId(
+      org.id,
+      informationSchemaId
+    );
+  }
 
   res.status(200).json({
     status: 200,

--- a/packages/back-end/src/models/InformationSchemaModel.ts
+++ b/packages/back-end/src/models/InformationSchemaModel.ts
@@ -169,3 +169,13 @@ export async function getInformationSchemaById(
 
   return result ? toInterface(result) : null;
 }
+
+export async function deleteInformationSchemaById(
+  organization: string,
+  informationSchemaId: string
+): Promise<void> {
+  await InformationSchemaModel.deleteOne({
+    organization,
+    id: informationSchemaId,
+  });
+}

--- a/packages/back-end/src/models/InformationSchemaTablesModel.ts
+++ b/packages/back-end/src/models/InformationSchemaTablesModel.ts
@@ -129,3 +129,13 @@ export async function removeDeletedInformationSchemaTables(
     id: { $in: tableIds },
   });
 }
+
+export async function deleteInformationSchemaTablesByInformationSchemaId(
+  organization: string,
+  informationSchemaId: string
+): Promise<void> {
+  await InformationSchemaTablesModel.deleteMany({
+    organization,
+    informationSchemaId,
+  });
+}


### PR DESCRIPTION
### Features and Changes

This is a simple PR that adds logic to the `deleteDataSource` controller method so that when a data source that contains an `information_schema` is deleted, we also remove any related `information_schema` records, along with any `information_schema_table` records.

Otherwise, that data would persist within Mongo in perpetuity.

Closes GB-83

### Testing

- [x] Delete a data source that has an `information_schema` and ensure that the data source is deleted, the `information_schema` record is deleted, and any `information_schema_table` records that reference the parent `informationSchemaId` are deleted.
- [x] Delete a data source that does not have an `information_schema` and ensure the data source is deleted and no errors or exceptions are raised.

