### PR TITLE
Allow metric lookback window to be any number

### DIFF
--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -172,7 +172,7 @@ export async function refreshMetric(
     }
 
     let days = metricAnalysisDays;
-    if (days < 1 || days > 400) {
+    if (days < 1) {
       days = DEFAULT_METRIC_ANALYSIS_DAYS;
     }
 

--- a/packages/front-end/pages/settings/index.tsx
+++ b/packages/front-end/pages/settings/index.tsx
@@ -92,7 +92,7 @@ const GeneralSettingsPage = (): React.ReactElement => {
     defaultValues: {
       visualEditorEnabled: false,
       pastExperimentsMinLength: 6,
-      metricAnalysisDays: 90,
+      metricAnalysisDays: 90, // should we use DEFAULT_METRIC_ANALYSIS_DAYS here?
       // customization:
       customized: false,
       logoPath: "",
@@ -310,6 +310,11 @@ const GeneralSettingsPage = (): React.ReactElement => {
       : // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
       value.regressionAdjustmentDays < 7
       ? "Lookback periods under 7 days tend not to capture enough metric data to reduce variance and may be subject to weekly seasonality"
+      : "";
+
+  const metricAnalysisDaysWarningMsg =
+    value.metricAnalysisDays && value.metricAnalysisDays > 365
+      ? "Using more historical data will slow down metric analysis queries"
       : "";
 
   if (!permissions.organizationSettings) {
@@ -987,21 +992,30 @@ const GeneralSettingsPage = (): React.ReactElement => {
               <div className="col-sm-9">
                 <div className="form-inline">
                   <Field
-                    label="Amount of historical data to include when analyzing metrics"
+                    label="Amount of historical data to use on metric analysis page"
+                    type="number"
                     append="days"
                     className="ml-2"
-                    containerClassName="mb-3"
+                    containerClassName="mb-0"
                     disabled={hasFileConfig()}
-                    options={[7, 14, 30, 90, 180, 365]}
                     {...form.register("metricAnalysisDays", {
                       valueAsNumber: true,
                     })}
                   />
+                  {metricAnalysisDaysWarningMsg && (
+                    <small
+                      style={{
+                        color: "#e27202",
+                      }}
+                    >
+                      {metricAnalysisDaysWarningMsg}
+                    </small>
+                  )}
                 </div>
 
                 {/* region Metrics Behavior Defaults */}
                 <>
-                  <h5 className="mt-3">Metrics Behavior Defaults</h5>
+                  <h5 className="mt-4">Metrics Behavior Defaults</h5>
                   <p>
                     These are the pre-configured default values that will be
                     used when configuring metrics. You can always change these


### PR DESCRIPTION
### Features and Changes

* Changes the settings page to allow `metricAnalysisDays` to be any number, and removes hard cap at 400 from the code that executes the query
* Adds a warning message if a user puts in more than 365 days

### Dependencies

n/a

### Testing/Screenshots

Before ([loom](https://www.loom.com/share/9f901cac64484fd5ba2839c3cc40d880)):
<img width="1004" alt="Screen Shot 2023-05-12 at 10 48 54 AM" src="https://github.com/growthbook/growthbook/assets/5298599/49ff83d5-d8b0-4d2b-8ae5-752b3a766401">

After ([loom](https://www.loom.com/share/a3ea83334e4b4c2789eba036fdbd3156)):
<img width="1152" alt="Screen Shot 2023-05-12 at 10 50 35 AM" src="https://github.com/growthbook/growthbook/assets/5298599/96a93c02-dda5-44e7-9409-e0b98ec7a167">

warning with value > 365:
<img width="1138" alt="Screen Shot 2023-05-12 at 10 50 40 AM" src="https://github.com/growthbook/growthbook/assets/5298599/9ce3773e-b67a-4ab5-a7a9-d8f2f95870db">
