### PR TITLE
JS SDK bug - localStorage cache not getting new TTL when updating features

### DIFF
--- a/packages/sdk-js/src/feature-repository.ts
+++ b/packages/sdk-js/src/feature-repository.ts
@@ -199,6 +199,7 @@ function onNewFeatureData(key: RepositoryKey, data: FeatureApiResponse): void {
   const existing = cache.get(key);
   if (existing && version && existing.version === version) {
     existing.staleAt = staleAt;
+    updatePersistentCache();
     return;
   }
 

--- a/packages/sdk-js/test/feature-repo.test.ts
+++ b/packages/sdk-js/test/feature-repo.test.ts
@@ -261,17 +261,35 @@ describe("feature-repo", () => {
     expect(f.mock.calls.length).toEqual(0);
 
     // Wait for localStorage entry to expire and refresh features
-    await sleep(100);
+    await sleep(120);
     await growthbook.refreshFeatures();
     expect(f.mock.calls.length).toEqual(1);
     expect(growthbook.evalFeature("foo").value).toEqual("api");
+    const staleAt = new Date(
+      JSON.parse(
+        localStorage.getItem(localStorageCacheKey) || "[]"
+      )[0][1].staleAt
+    ).getTime();
+
+    // Wait for localStorage entry to expire again
+    // Since the payload didn't change, make sure it updates localStorage staleAt flag
+    await sleep(120);
+    await growthbook.refreshFeatures();
+    expect(f.mock.calls.length).toEqual(2);
+    expect(growthbook.evalFeature("foo").value).toEqual("api");
+    const newStaleAt = new Date(
+      JSON.parse(
+        localStorage.getItem(localStorageCacheKey) || "[]"
+      )[0][1].staleAt
+    ).getTime();
+    expect(newStaleAt).toBeGreaterThan(staleAt);
 
     // If api has a new version, refreshFeatures should pick it up
     data.features.foo.defaultValue = "new";
     data.dateUpdated = "2020-02-01T00:00:00Z";
-    await sleep(150);
+    await sleep(120);
     await growthbook.refreshFeatures();
-    expect(f.mock.calls.length).toEqual(2);
+    expect(f.mock.calls.length).toEqual(3);
     expect(growthbook.evalFeature("foo").value).toEqual("new");
 
     const lsValue = JSON.parse(


### PR DESCRIPTION
### Features and Changes

In the JS SDK, when features are fetched, they are cached in memory and localStorage.  After the TTL (60 seconds by default), features may be refreshed from the GrowthBook API.  If the features haven't changed, we update the `staleAt` time in our memory cache to point another 60 seconds in the future.  However, we aren't also updating our localStorage cache `staleAt` value.

This means page refreshes always cause a new network request, even if the copy stored in localStorage is within the TTL time.

The fix is a one-line change.  Also included is a reproducible unit test that is now fixed.