### PR TITLE
[bugfix] Allow 0 value p-values through to UI

### DIFF
--- a/packages/front-end/components/Experiment/PValueColumn.tsx
+++ b/packages/front-end/components/Experiment/PValueColumn.tsx
@@ -98,7 +98,9 @@ const PValueColumn: FC<{
     pValText = (
       <>
         <div>
-          {stats?.pValueAdjusted ? pValueFormatter(stats.pValueAdjusted) : ""}
+          {stats?.pValueAdjusted !== undefined
+            ? pValueFormatter(stats.pValueAdjusted)
+            : ""}
         </div>
         <div className="small text-muted">(unadj.: {pValText})</div>
       </>

--- a/packages/front-end/components/Experiment/PValueColumn.tsx
+++ b/packages/front-end/components/Experiment/PValueColumn.tsx
@@ -91,7 +91,9 @@ const PValueColumn: FC<{
     className += " draw";
   }
 
-  let pValText = <>{stats?.pValue ? pValueFormatter(stats.pValue) : ""}</>;
+  let pValText = (
+    <>{stats?.pValue !== undefined ? pValueFormatter(stats.pValue) : ""}</>
+  );
   if (stats?.pValueAdjusted !== undefined && pValueCorrection) {
     pValText = (
       <>


### PR DESCRIPTION
### Features and Changes

Recent bugfixes to prevent UI crashes also stopped p-values rounded to 0 to display in the experiment results. This fixes that bug.

Tested by setting a p-value to 0 in a snapshot record.

Before:
<img width="618" alt="Screen Shot 2023-05-22 at 4 32 49 PM" src="https://github.com/growthbook/growthbook/assets/5298599/60389025-ad40-4bb9-b7a8-ffb306d2b911">

After:
<img width="619" alt="Screen Shot 2023-05-22 at 4 33 14 PM" src="https://github.com/growthbook/growthbook/assets/5298599/aa311871-de45-460e-b1af-76d709fcbda2">
