### PR TITLE
Add support for multiple MsSql Database Connections

### DIFF
--- a/packages/back-end/src/integrations/Mssql.ts
+++ b/packages/back-end/src/integrations/Mssql.ts
@@ -2,7 +2,7 @@ import { MssqlConnectionParams } from "../../types/integrations/mssql";
 import { decryptDataSourceParams } from "../services/datasource";
 import { FormatDialect } from "../util/sql";
 import { MissingDatasourceParamsError } from "../types/Integration";
-import { get } from "../util/mssqlPoolManager";
+import { findOrCreateConnection } from "../util/mssqlPoolManager";
 import SqlIntegration from "./SqlIntegration";
 
 export default class Mssql extends SqlIntegration {
@@ -21,7 +21,7 @@ export default class Mssql extends SqlIntegration {
     return ["password"];
   }
   async runQuery(sqlStr: string) {
-    const conn = await get(this.params.database, {
+    const conn = await findOrCreateConnection(this.datasource, {
       server: this.params.server,
       port: parseInt(this.params.port + "", 10),
       user: this.params.user,

--- a/packages/back-end/src/integrations/Mssql.ts
+++ b/packages/back-end/src/integrations/Mssql.ts
@@ -1,8 +1,8 @@
-import mssql from "mssql";
 import { MssqlConnectionParams } from "../../types/integrations/mssql";
 import { decryptDataSourceParams } from "../services/datasource";
 import { FormatDialect } from "../util/sql";
 import { MissingDatasourceParamsError } from "../types/Integration";
+import { get } from "../util/mssqlPoolManager";
 import SqlIntegration from "./SqlIntegration";
 
 export default class Mssql extends SqlIntegration {
@@ -21,7 +21,7 @@ export default class Mssql extends SqlIntegration {
     return ["password"];
   }
   async runQuery(sqlStr: string) {
-    const conn = await mssql.connect({
+    const conn = await get(this.params.database, {
       server: this.params.server,
       port: parseInt(this.params.port + "", 10),
       user: this.params.user,

--- a/packages/back-end/src/util/mssqlPoolManager.ts
+++ b/packages/back-end/src/util/mssqlPoolManager.ts
@@ -1,0 +1,14 @@
+import mssql from "mssql";
+import { MssqlConnectionParams } from "../../types/integrations/mssql";
+const pools = new Map();
+
+export function get(name: string, config: MssqlConnectionParams) {
+  if (!pools.has(name)) {
+    if (!config) {
+      throw new Error("Pool does not exist");
+    }
+    const pool: mssql.ConnectionPool = new mssql.ConnectionPool(config);
+    pools.set(name, pool.connect());
+  }
+  return pools.get(name);
+}

--- a/packages/back-end/src/util/mssqlPoolManager.ts
+++ b/packages/back-end/src/util/mssqlPoolManager.ts
@@ -8,6 +8,12 @@ export function findOrCreateConnection(
 ) {
   if (!pools.has(name)) {
     const pool: mssql.ConnectionPool = new mssql.ConnectionPool(config);
+    // automatically remove the pool from the cache if `pool.close()` is called
+    const close = pool.close.bind(pool);
+    pool.close = () => {
+      pools.delete(name);
+      return close();
+    };
     pools.set(name, pool.connect());
   }
   return pools.get(name);

--- a/packages/back-end/src/util/mssqlPoolManager.ts
+++ b/packages/back-end/src/util/mssqlPoolManager.ts
@@ -2,11 +2,11 @@ import mssql from "mssql";
 import { MssqlConnectionParams } from "../../types/integrations/mssql";
 const pools = new Map();
 
-export function get(name: string, config: MssqlConnectionParams) {
+export function findOrCreateConnection(
+  name: string,
+  config: MssqlConnectionParams
+) {
   if (!pools.has(name)) {
-    if (!config) {
-      throw new Error("Pool does not exist");
-    }
     const pool: mssql.ConnectionPool = new mssql.ConnectionPool(config);
     pools.set(name, pool.connect());
   }


### PR DESCRIPTION
### Features and Changes

A GrowthBook user identified a bug with the MsSql Integration.

#### Current Experience:
If you connect to an MsSql database with valid parameters, and then, go to create a second MsSql database connection to a different database, instead of failing to connect, it would connect, but it would use the credentials for the previous (valid) MsSql database.

Likewise, if you then tried to build an experiment assignment query (or any query) it would connect to the original, valid database, instead of using the credentials associated with the invalid datasource.

Upon investigating the issue, I found that this was a result of how the connection pool was being handled by the `node-mssql` package.

In the documentation it states:
_There can only be one global connection pool connected at a time. Providing a different connection config to the connect() function will not create a new connection if it is already connected._

As a result, when we were trying to test the connection of the second, invalid datasource, calling `mssql.connect()` with the new config params was being ignored since there was already a valid connection.

There are two ways to address this.

1. The super easy way, which would be to call `conn.close()` immediately after running each MsSql query to close the connection pool. This works, however, according to the documentation, you really only want to call `close()` if you're certain the application is finished. Calling close will add additional overhead to running subsequent queries.

2. The other way (and the way I've currently addressed this) is by implementing our own connection pool management. Again, according to the docs, this is the preferred way to handle the pool if you want to support connections to multiple databases.

In doing so, we are creating a `Map` of pool connections, and when we go to run the query, we're calling `await get(name, config)` where the name correlates to a connection. And, if it doesn't exist, we add it to the `Map`.

The documentation does have guidance on how to build a `closeAll()` method that will close all connections within the map. It doesn't look like we're doing anything around closing the connection today (with the singular connection pool), so it's not clear if we need to implement that - I suppose that's handled organically via the server and won't cause a memory leak.

#### Link to Package & GitHub
- https://www.npmjs.com/package/mssql#connection-pools
- https://github.com/tediousjs/node-mssql

### Testing

- [x] Create a valid MsSql Datasource connection and confirm that you can build queries against it successfully.
- [x] Then, go to create an invalid MsSql datasource connection, passing in bogus params (screenshot below with example) and confirm that you are not able to create the datasource. 
<img width="516" alt="Screen Shot 2023-05-24 at 9 52 36 AM" src="https://github.com/growthbook/growthbook/assets/75274610/de3df9d9-ae65-4ee4-86fe-09fe47c6a2c3">

