### PR TITLE
invite users, max seats reached: add generic failure modal

### DIFF
--- a/packages/front-end/components/Settings/Team/InviteModal.tsx
+++ b/packages/front-end/components/Settings/Team/InviteModal.tsx
@@ -58,7 +58,7 @@ const InviteModal: FC<{ mutate: () => void; close: () => void }> = ({
 
   // Hit their free limit and needs to upgrade to invite more team members
   if (showUpgradeModal) {
-    // The upgrade modal won't actually show for these plans, so show a generic failure / upgrade message
+    // The <UpgradeModal> won't actually render for these plans, so show a generic modal instead
     if (["pro", "pro_sso", "enterprise"].includes(accountPlan ?? "")) {
       return (
         <Modal open={true} close={close} size="md">

--- a/packages/front-end/components/Settings/Team/InviteModal.tsx
+++ b/packages/front-end/components/Settings/Team/InviteModal.tsx
@@ -1,12 +1,14 @@
 import { FC, useState } from "react";
 import { useForm } from "react-hook-form";
 import { MemberRoleWithProjects } from "back-end/types/organization";
+import Link from "next/link";
 import track from "@/services/track";
 import Field from "@/components/Forms/Field";
 import Modal from "@/components/Modal";
 import { useAuth } from "@/services/auth";
 import useStripeSubscription from "@/hooks/useStripeSubscription";
 import useOrgSettings from "@/hooks/useOrgSettings";
+import { useUser } from "@/services/UserContext";
 import UpgradeModal from "../UpgradeModal";
 import RoleSelector from "./RoleSelector";
 import InviteModalSubscriptionInfo from "./InviteModalSubscriptionInfo";
@@ -21,6 +23,7 @@ const InviteModal: FC<{ mutate: () => void; close: () => void }> = ({
   close,
 }) => {
   const { defaultRole } = useOrgSettings();
+  const { accountPlan } = useUser();
 
   const form = useForm<{
     email: string;
@@ -55,6 +58,20 @@ const InviteModal: FC<{ mutate: () => void; close: () => void }> = ({
 
   // Hit their free limit and needs to upgrade to invite more team members
   if (showUpgradeModal) {
+    // The upgrade modal won't actually show for these plans, so show a generic failure / upgrade message
+    if (["pro", "pro_sso", "enterprise"].includes(accountPlan ?? "")) {
+      return (
+        <Modal open={true} close={close} size="md">
+          <div className="text-center my-3">
+            <div className="strong">{showUpgradeModal}</div>
+            <div className="mt-3">
+              To upgrade, please visit the{" "}
+              <Link href="/settings/billing">billing</Link> page.
+            </div>
+          </div>
+        </Modal>
+      );
+    }
     return (
       <UpgradeModal
         close={close}
@@ -67,7 +84,7 @@ const InviteModal: FC<{ mutate: () => void; close: () => void }> = ({
   const onSubmit = form.handleSubmit(async (value) => {
     const inviteArr = value.email.split(",");
 
-    if (canSubscribe && activeAndInvitedUsers + inviteArr.length > freeSeats) {
+    if (canSubscribe && activeAndInvitedUsers + inviteArr.length >= freeSeats) {
       setShowUpgradeModal("Whoops! You reached your free seat limit.");
       return;
     }


### PR DESCRIPTION
In some cases there is no feedback for invite users failed when max seats are reached. This adds a new generic modal for this case.

### Features and Changes

<!--
  Include a description of your changes.
  If there are any new tools, API's, etc. that devs can leverage, it may be helpful to include usage info.
-->

<!--
  Indicate which issue this will close, if applicable
  For multiple issues, add a new `- Closes` or `- Fixes` line
-->

- Closes **(add link to issue here)**

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

<!--
  Please describe how to test these changes.
 -->

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
