### PR TITLE
🚧 WIP [stats] Add support for daily and cumulative time series to integrations and gbstats

### DIFF
--- a/packages/back-end/src/integrations/Athena.ts
+++ b/packages/back-end/src/integrations/Athena.ts
@@ -28,8 +28,8 @@ export default class Athena extends SqlIntegration {
   }
   addTime(
     col: string,
-    unit: "day" | "day" | "day" | "day" | "day" | "day" | "hour" | "minute",
-    sign: "+" | "-",
+    unit: "day" | "hour" | "minute",
+    sign: "+" | "-" | "",
     amount: number
   ): string {
     return `${col} ${sign} INTERVAL '${amount}' ${unit}`;

--- a/packages/back-end/src/integrations/Athena.ts
+++ b/packages/back-end/src/integrations/Athena.ts
@@ -28,7 +28,7 @@ export default class Athena extends SqlIntegration {
   }
   addTime(
     col: string,
-    unit: "hour" | "minute",
+    unit: "day" | "day" | "day" | "day" | "day" | "day" | "hour" | "minute",
     sign: "+" | "-",
     amount: number
   ): string {

--- a/packages/back-end/src/integrations/BigQuery.ts
+++ b/packages/back-end/src/integrations/BigQuery.ts
@@ -53,7 +53,7 @@ export default class BigQuery extends SqlIntegration {
   }
   addTime(
     col: string,
-    unit: "hour" | "minute",
+    unit: "day" | "hour" | "minute",
     sign: "+" | "-",
     amount: number
   ): string {
@@ -81,6 +81,15 @@ export default class BigQuery extends SqlIntegration {
   }
   castUserDateCol(column: string): string {
     return `CAST(${column} as DATETIME)`;
+  }
+  getDateTable(startDate: Date, endDate: Date | null) {
+    return `
+    SELECT day
+    FROM UNNEST(
+        GENERATE_DATE_ARRAY(DATE(${this.toTimestamp(startDate)}), ${
+      endDate ? `DATE(${this.toTimestamp(endDate)})` : `CURRENT_DATE()`
+    }, INTERVAL 1 DAY)
+    ) AS day`;
   }
   getInformationSchemaFromClause(): string {
     if (!this.params.projectId)

--- a/packages/back-end/src/integrations/ClickHouse.ts
+++ b/packages/back-end/src/integrations/ClickHouse.ts
@@ -99,7 +99,7 @@ export default class ClickHouse extends SqlIntegration {
   `;
   }
   getUserStatSelectAndJoinStatement(
-    metricDateDimensionCumulative: boolean,
+    cumulativeDate: boolean,
     selectStatement: string
   ): string {
     return `
@@ -110,7 +110,7 @@ export default class ClickHouse extends SqlIntegration {
         AND u.dimension = s.dimension
       )
     ${
-      metricDateDimensionCumulative
+      cumulativeDate
         ? `UNION ALL
       ${selectStatement}
       RIGHT JOIN

--- a/packages/back-end/src/integrations/ClickHouse.ts
+++ b/packages/back-end/src/integrations/ClickHouse.ts
@@ -56,7 +56,7 @@ export default class ClickHouse extends SqlIntegration {
   }
   addTime(
     col: string,
-    unit: "hour" | "minute",
+    unit: "day" | "hour" | "minute",
     sign: "+" | "-",
     amount: number
   ): string {

--- a/packages/back-end/src/integrations/Databricks.ts
+++ b/packages/back-end/src/integrations/Databricks.ts
@@ -27,7 +27,7 @@ export default class Databricks extends SqlIntegration {
   }
   addTime(
     col: string,
-    unit: "hour" | "minute",
+    unit: "day" | "hour" | "minute",
     sign: "+" | "-",
     amount: number
   ): string {

--- a/packages/back-end/src/integrations/Databricks.ts
+++ b/packages/back-end/src/integrations/Databricks.ts
@@ -28,7 +28,7 @@ export default class Databricks extends SqlIntegration {
   addTime(
     col: string,
     unit: "day" | "hour" | "minute",
-    sign: "+" | "-",
+    sign: "+" | "-" | "",
     amount: number
   ): string {
     return `timestampadd(${unit},${sign === "-" ? "-" : ""}${amount},${col})`;

--- a/packages/back-end/src/integrations/Mssql.ts
+++ b/packages/back-end/src/integrations/Mssql.ts
@@ -59,7 +59,7 @@ export default class Mssql extends SqlIntegration {
     return `CAST(${col} as FLOAT)`;
   }
   formatDate(col: string): string {
-    return `FORMAT(${col}, "yyyy-MM-dd")`;
+    return `FORMAT(${col}, 'yyyy-MM-dd')`;
   }
   castToString(col: string): string {
     return `cast(${col} as varchar(256))`;
@@ -69,6 +69,22 @@ export default class Mssql extends SqlIntegration {
   }
   currentDate(): string {
     return this.castToDate("GETDATE()");
+  }
+  getDateTable(startDate: Date, endDate: Date | null): string {
+    const startDateStr = this.castToDate(this.toTimestamp(startDate));
+    return `
+      SELECT day
+      FROM (
+        SELECT DATEADD(DAY, a.i + b.i * 10 + c.i * 100 + d.i * 1000, ${startDateStr}) AS day
+        FROM (SELECT 0 AS i UNION ALL SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 UNION ALL SELECT 4 UNION ALL SELECT 5 UNION ALL SELECT 6 UNION ALL SELECT 7 UNION ALL SELECT 8 UNION ALL SELECT 9) AS a
+        CROSS JOIN (SELECT 0 AS i UNION ALL SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 UNION ALL SELECT 4 UNION ALL SELECT 5 UNION ALL SELECT 6 UNION ALL SELECT 7 UNION ALL SELECT 8 UNION ALL SELECT 9) AS b
+        CROSS JOIN (SELECT 0 AS i UNION ALL SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 UNION ALL SELECT 4 UNION ALL SELECT 5 UNION ALL SELECT 6 UNION ALL SELECT 7 UNION ALL SELECT 8 UNION ALL SELECT 9) AS c
+        CROSS JOIN (SELECT 0 AS i UNION ALL SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 UNION ALL SELECT 4 UNION ALL SELECT 5 UNION ALL SELECT 6 UNION ALL SELECT 7 UNION ALL SELECT 8 UNION ALL SELECT 9) AS d
+      ) AS n
+      WHERE day BETWEEN ${startDateStr} AND ${
+      endDate ? this.castToDate(this.toTimestamp(endDate)) : this.currentDate()
+    }
+  `;
   }
   getInformationSchemaFromClause(): string {
     if (!this.params.database)

--- a/packages/back-end/src/integrations/Mssql.ts
+++ b/packages/back-end/src/integrations/Mssql.ts
@@ -43,7 +43,7 @@ export default class Mssql extends SqlIntegration {
   addTime(
     col: string,
     unit: "day" | "hour" | "minute",
-    sign: "+" | "-",
+    sign: "+" | "-" | "",
     amount: number
   ): string {
     return `DATEADD(${unit}, ${sign === "-" ? "-" : ""}${amount}, ${col})`;

--- a/packages/back-end/src/integrations/Mssql.ts
+++ b/packages/back-end/src/integrations/Mssql.ts
@@ -42,7 +42,7 @@ export default class Mssql extends SqlIntegration {
 
   addTime(
     col: string,
-    unit: "hour" | "minute",
+    unit: "day" | "hour" | "minute",
     sign: "+" | "-",
     amount: number
   ): string {
@@ -66,6 +66,9 @@ export default class Mssql extends SqlIntegration {
   }
   formatDateTimeString(col: string): string {
     return `CONVERT(VARCHAR(25), ${col}, 121)`;
+  }
+  currentDate(): string {
+    return this.castToDate("GETDATE()");
   }
   getInformationSchemaFromClause(): string {
     if (!this.params.database)

--- a/packages/back-end/src/integrations/Mysql.ts
+++ b/packages/back-end/src/integrations/Mysql.ts
@@ -49,7 +49,7 @@ export default class Mysql extends SqlIntegration {
   addTime(
     col: string,
     unit: "day" | "hour" | "minute",
-    sign: "+" | "-",
+    sign: "+" | "-" | "",
     amount: number
   ): string {
     return `DATE_${

--- a/packages/back-end/src/integrations/Mysql.ts
+++ b/packages/back-end/src/integrations/Mysql.ts
@@ -88,7 +88,7 @@ export default class Mysql extends SqlIntegration {
   `;
   }
   getUserStatSelectAndJoinStatement(
-    metricDateDimensionCumulative: boolean,
+    cumulativeDate: boolean,
     selectStatement: string
   ): string {
     return `
@@ -99,7 +99,7 @@ export default class Mysql extends SqlIntegration {
         AND u.dimension = s.dimension
       )
     ${
-      metricDateDimensionCumulative
+      cumulativeDate
         ? `UNION
       ${selectStatement}
       RIGHT JOIN

--- a/packages/back-end/src/integrations/Mysql.ts
+++ b/packages/back-end/src/integrations/Mysql.ts
@@ -48,7 +48,7 @@ export default class Mysql extends SqlIntegration {
   }
   addTime(
     col: string,
-    unit: "hour" | "minute",
+    unit: "day" | "hour" | "minute",
     sign: "+" | "-",
     amount: number
   ): string {

--- a/packages/back-end/src/integrations/Presto.ts
+++ b/packages/back-end/src/integrations/Presto.ts
@@ -85,8 +85,8 @@ export default class Presto extends SqlIntegration {
   }
   addTime(
     col: string,
-    unit: "hour" | "minute",
-    sign: "+" | "-",
+    unit: "day" | "hour" | "minute",
+    sign: "+" | "-" | "",
     amount: number
   ): string {
     return `${col} ${sign} INTERVAL '${amount}' ${unit}`;
@@ -105,6 +105,23 @@ export default class Presto extends SqlIntegration {
   }
   ensureFloat(col: string): string {
     return `CAST(${col} AS DOUBLE)`;
+  }
+  getDateTable(startDate: Date, endDate: Date | null): string {
+    return `
+      SELECT ${this.castToDate("t.day")} AS day
+      FROM
+        UNNEST(
+          SEQUENCE(
+            ${this.castToDate(this.toTimestamp(startDate))},
+            ${
+              endDate
+                ? this.castToDate(this.toTimestamp(endDate))
+                : this.currentDate()
+            },
+            ${this.addTime("", "day", "", 1)}
+          )
+        ) AS t(day)
+     `;
   }
   getInformationSchemaFromClause(): string {
     if (!this.params.catalog)

--- a/packages/back-end/src/integrations/Snowflake.ts
+++ b/packages/back-end/src/integrations/Snowflake.ts
@@ -34,6 +34,21 @@ export default class Snowflake extends SqlIntegration {
   ensureFloat(col: string): string {
     return `CAST(${col} AS DOUBLE)`;
   }
+  getDateTable(startDate: Date, endDate: Date | null): string {
+    const startDateTrunc: string = this.castToDate(this.toTimestamp(startDate));
+    return `
+      SELECT ${this.castToDate(startDateTrunc)} + VALUE::INT AS day
+      FROM TABLE(FLATTEN(ARRAY_GENERATE_RANGE(
+        0, 
+        ${this.dateDiff(
+          startDateTrunc,
+          this.castToDate(
+            endDate ? this.toTimestamp(endDate) : "CURRENT_DATE()"
+          )
+        )} +1
+      )))
+    `;
+  }
   getInformationSchemaFromClause(): string {
     if (!this.params.database)
       throw new Error(

--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -1099,7 +1099,7 @@ export default abstract class SqlIntegration
         SELECT
           d.variation AS variation,
           ${userMetricDimensionCol} AS dimension,
-          d.${baseIdType},
+          d.${baseIdType} AS ${baseIdType},
           ${this.getAggregateMetricColumn(
             metric,
             isRegressionAdjusted ? "post" : "noWindow"
@@ -1134,9 +1134,9 @@ export default abstract class SqlIntegration
           ? `, __userDenominator as (
               -- Add in the aggregate denominator value for each user
               SELECT
-                d.variation,
+                d.variation AS variation,
                 ${userMetricDimensionCol} AS dimension,
-                d.${baseIdType},
+                d.${baseIdType} AS ${baseIdType},
                 ${this.getAggregateMetricColumn(
                   denominator,
                   "noWindow"

--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -1097,7 +1097,7 @@ export default abstract class SqlIntegration
       , __userMetric as (
         -- Add in the aggregate metric value for each user
         SELECT
-          d.variation,
+          d.variation AS variation,
           ${userMetricDimensionCol} AS dimension,
           d.${baseIdType},
           ${this.getAggregateMetricColumn(

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -288,8 +288,7 @@ export async function getManualSnapshotData(
         const res = await analyzeExperimentMetric(
           getReportVariations(experiment, phase),
           metric,
-          rows,
-          20
+          rows
         );
         const data = res.dimensions[0];
         if (!data) return;

--- a/packages/back-end/src/services/stats.ts
+++ b/packages/back-end/src/services/stats.ts
@@ -27,7 +27,7 @@ export async function analyzeExperimentMetric(
   variations: ExperimentReportVariation[],
   metric: MetricInterface,
   rows: ExperimentMetricQueryResponse,
-  maxDimensions: number,
+  dimension: string | null = null,
   statsEngine: StatsEngine = DEFAULT_STATS_ENGINE,
   sequentialTestingEnabled: boolean = false,
   sequentialTestingTuningParameter: number = DEFAULT_SEQUENTIAL_TESTING_TUNING_PARAMETER
@@ -48,13 +48,14 @@ export async function analyzeExperimentMetric(
   const result = await promisify(PythonShell.runString)(
     `
 from gbstats.gbstats import (
+  accumulate_time_series_df,
   detect_unknown_variations,
   analyze_metric_df,
   get_metric_df,
   reduce_dimensionality,
   format_results
 )
-from gbstats.shared.constants import StatsEngine
+from gbstats.shared.constants import *
 import pandas as pd
 import json
 
@@ -64,7 +65,7 @@ data = json.loads("""${JSON.stringify({
       weights: variations.map((v) => v.weight),
       ignore_nulls: !!metric.ignoreNulls,
       inverse: !!metric.inverse,
-      max_dimensions: maxDimensions,
+      max_dimensions: dimension === "pre:date" ? 9999 : MAX_DIMENSIONS,
       rows,
     }).replace(/\\/g, "\\\\")}""", strict=False)
 
@@ -82,8 +83,15 @@ unknown_var_ids = detect_unknown_variations(
   var_id_map=var_id_map
 )
 
+accumulated = accumulate_time_series_df(
+  df=rows,
+  time_series=${
+    dimension === "pre:date" ? "TimeSeries.DAILY" : "TimeSeries.NONE"
+  },
+)
+
 df = get_metric_df(
-  rows=rows,
+  rows=accumulated,
   var_id_map=var_id_map,
   var_names=var_names,
 )
@@ -220,7 +228,7 @@ export async function analyzeExperimentResults({
           variations,
           metric,
           data.rows,
-          dimension === "pre:date" ? 100 : MAX_DIMENSIONS,
+          dimension,
           statsEngine,
           sequentialTestingEnabled,
           sequentialTestingTuningParameter

--- a/packages/back-end/test/integrations/integration-query-runner.py
+++ b/packages/back-end/test/integrations/integration-query-runner.py
@@ -16,7 +16,6 @@ import psycopg2
 import psycopg2.extras
 import sqlfluff
 import snowflake.connector
-#import pymssql
 import pandas as pd
 
 CACHE_FILE = "/tmp/json/cache.json"
@@ -195,21 +194,6 @@ class clickhouseRunner(sqlRunner):
                 dfs.append(df)
         return QueryResult(rows=pd.concat(dfs).to_dict('records'))
 
-
-# class mssqlRunner(sqlRunner):
-#     def open_connection(self):
-#         self.connection = pymssql.connect(
-#             server=config["DATABRICKS_TEST_HOST"],
-#             user=config["DATABRICKS_TEST_PATH"],
-#             access_token=config["DATABRICKS_TEST_TOKEN"],
-#         )
-
-#     def run_query(self, sql: str) -> QueryResult:
-#         cursor = self.connection.cursor(as_dict=True)
-#         cursor.execute(sql)
-#         return QueryResult(rows=[row for row in cursor])
-
-
 class dummyRunner(sqlRunner):
     def __init__(self, error_message: str):
         super().__init__()
@@ -271,8 +255,6 @@ def get_sql_runner(engine) -> sqlRunner:
             return snowflakeRunner()
         elif engine == "presto":
             return prestoRunner()
-        #elif engine == "mssql":
-        #    return mssqlRunner()
         #elif engine == "databricks":
         #    return databricksRunner()
         elif engine == "clickhouse":
@@ -350,17 +332,9 @@ def main():
     for test_case in test_cases:
         engine = test_case["engine"]
 
-        if engine not in ["clickhouse"] or 'dimension_date > nonbinom__purchased_items_regressionadjusted' not in test_case['name']:
-            continue
-        # if (
-        #     'dimension_date > nonbinom__purchased_items_regressionadjusted' in test_case['name'] 
-        #     #or 'base > nonbinom__purchased_items_regressionadjusted' in test_case['name']
-        # ):
-        #     print_sql(test_case['sql'])
-        #     raise ValueError()
         if engine not in runners:
             runners[engine] = get_sql_runner(engine)
-        print_sql(test_case['sql'])
+
         key = engine + "::" + test_case["sql"]
         if key in cache:
             update_fields = ['engine', 'name']
@@ -371,8 +345,8 @@ def main():
                 **{k: v for k, v in test_case.items() if k in update_fields}
             })
         else:
-            #if engine not in nonlinted_engines:
-            #    validate(test_case)
+            if engine not in nonlinted_engines:
+                validate(test_case)
             result = execute_query(test_case["sql"], runners[engine])
             result.update(test_case)
             cache[key] = result

--- a/packages/stats/gbstats/frequentist/tests.py
+++ b/packages/stats/gbstats/frequentist/tests.py
@@ -108,6 +108,8 @@ class TTest(BaseABTest):
         """
         if self.stat_a.mean == 0:
             return self._default_output()
+        if self.stat_a.unadjusted_mean == 0:
+            return self._default_output()
         if self._has_zero_variance():
             return self._default_output()
         return FrequentistTestResult(

--- a/packages/stats/gbstats/gbstats.py
+++ b/packages/stats/gbstats/gbstats.py
@@ -60,11 +60,25 @@ def accumulate_time_series_df(
     if time_series == TimeSeries.NONE:
         return df
     dfc = df.copy()
-    if time_series == TimeSeries.CUMULATIVE:
-        cols_to_accum = ["users", "count"]
-        dfc.sort_values("dimension", inplace=True)
-        dfc[cols_to_accum] = dfc.groupby(["variation"])[cols_to_accum].cumsum()
-        return dfc.loc[(dfc["users"] != 0) | (dfc["count"] != 0)].copy()
+    cols_to_accum = ["users", "count"]
+    dfc.sort_values("dimension", inplace=True)
+    dfc[cols_to_accum] = dfc.groupby(["variation"])[cols_to_accum].cumsum()
+    if time_series == TimeSeries.DAILY:
+        diff_cols = [
+            x
+            for x in [
+                "main_sum",
+                "main_sum_squares",
+                "denominator_sum",
+                "denominator_sum_squares",
+                "main_denominator_sum_product",
+                "covariate_sum",
+                "covariate_sum_squares",
+                "main_covariate_sum_product",
+            ]
+            if x in dfc.columns
+        ]
+        dfc[diff_cols] = dfc.groupby(["variation"])[diff_cols].diff().fillna(0)
     return dfc
 
 

--- a/packages/stats/gbstats/shared/constants.py
+++ b/packages/stats/gbstats/shared/constants.py
@@ -4,3 +4,9 @@ from enum import Enum
 class StatsEngine(Enum):
     BAYESIAN = "bayesian"
     FREQUENTIST = "frequentist"
+
+
+class TimeSeries(Enum):
+    NONE = "none"
+    DAILY = "daily"
+    CUMULATIVE = "cumulative"


### PR DESCRIPTION
WIP

## Features

Adds ability to create cumulative and daily time series. 

Our current time series just are dimension results by user's first date bucketed. So that means on day X, we see experimental effects for all users bucketed on day X, regardless of whether those conversions happened on day X or day X+1 and so on. Furthermore, on day X, we don't have any users that were bucketed on days X-1 and backwards influencing the metric, so it doesn't tell you what happened *on day X* but rather what happened to users *bucketed on day X*.

There's ample demand for Cumulative Time Series, which show you *the total effects for all users and all metrics through day X*. In other words, what is the experiment result as if I had run my results at the end of day X?

We also might care about Daily Time Series, which show you *for all users bucketed through day X, what is the effect on metrics ONLY on day X*. This probably only matters for those using the `Experiment Duration` attribution model or long conversion windows, but can let you know what is happening on given days in your experimental population as the experiment goes on.

This PR adds the necessary components to `gbstats` and our SQL integrations to compute these last two series: Cumulative and Daily Time Series.

## Changes

How?
* Uses`getDateTable` to build a time series of dates and then cross joining user metric results to that before aggregating.
  * I think this is necessary because we need to aggregate across all user metrics as of day X, allowing for custom aggregations that might change as of day X+1 in a way that isn't just a SUM. You can also think of future features like binomial conversions with thresholds. If we want to say `IF(count > 3, 1, 0)`, then we need to keep track of `count` itself across days, which requires a unit-level cross join with dates.
  * It also allows us to keep the same Regression Adjustment logic without adding a unit-level join, because each user-day will have the full history of that users metrics to that point, we can always just aggregate the pre and post experiment periods up until that day. Now we could potentially get performance gains from computing this RA value elsewhere, but only once we work with temp tables/writing.
* Does a full outer join between `__stats` and `__overallUsers` because there may be days in the time series (and therefore in `__stats` that had no new users bucketed (and therefore missing from `__overallUsers`).

TODO:
- [ ] Build front-end logic to control setting `cumulativeDate`
- [ ] Build UI to handle multiple kinds of time series
- [ ] Clean up some potentially unnecessary casting and somewhat inconsistent SQL across engines

- Closes GB-251

### Dependencies

n/a

### Testing

All integration test queries execute:
- [X] bigquery  
- [X] clickhouse
- [X] mysql
- [X] postgres
- [X] presto
- [X] snowflake
- [X] mssql (manual testing a couple queries)
- [ ] athena (no testing set up)
- [ ] redshift (no testing set up)
- [ ] databricks (no testing set up)

Cumulative time series on latest day is the same as the full results without any time series:
- [X] bigquery  
- [ ] clickhouse (currently not matching, will debug)
- [X] mysql
- [X] postgres
- [X] presto
- [X] snowflake
- [ ] mssql (will manually test a couple queries)
- [ ] athena (no testing set up)
- [ ] redshift (no testing set up)
- [ ] databricks (no testing set up)

Cumulative time series on day X is the same as if we had run full results at midnight at the end of day X:
- [X] postgres
- [ ] Will not test others, but will just check equivalence of time series results to postgres results on same data

TODO:
- [ ] Test that daily time series (built solely using `diff()`) produces reasonable results

### Screenshots

TODO
