### PR TITLE
GB-215 Delete metric endpoint in the public REST API

### DIFF
--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -865,6 +865,30 @@ paths:
                 properties:
                   metric:
                     $ref: '#/components/schemas/Metric'
+    delete:
+      parameters:
+        - $ref: '#/components/parameters/id'
+      tags:
+        - metrics
+      summary: Deletes a single metric
+      operationId: deleteMetric
+      x-codeSamples:
+        - lang: cURL
+          source: |
+            curl -X DELETE https://api.growthbook.io/api/v1/metrics/met_abc123 \
+              -u secret_abc123DEF456:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                required: []
+                properties:
+                  deletedId:
+                    type: string
+                    description: The ID of the deleted metric
+                    example: met_abc123
   '/experiments/{id}/visual-changesets':
     get:
       summary: Get all visual changesets

--- a/packages/back-end/src/api/metrics/deleteMetric.ts
+++ b/packages/back-end/src/api/metrics/deleteMetric.ts
@@ -9,11 +9,13 @@ export const deleteMetric = createApiRequestHandler(deleteMetricValidator)(
       id: req.params.id,
       organization: req.organization,
       eventAudit: req.eventAudit,
+      // TODO: Add permission check after merging https://github.com/growthbook/growthbook/pull/1265
+      checkPermissions: () => undefined, // checkPermissions: req.checkPermissions
     });
-    const deletedId = await metricDeleter.perform();
+    const deletedMetric = await metricDeleter.perform();
 
     return {
-      deletedId,
+      deletedId: deletedMetric.id,
     };
   }
 );

--- a/packages/back-end/src/api/metrics/deleteMetric.ts
+++ b/packages/back-end/src/api/metrics/deleteMetric.ts
@@ -1,0 +1,19 @@
+import { DeleteMetricResponse } from "../../../types/openapi";
+import { createApiRequestHandler } from "../../util/handler";
+import { deleteMetricValidator } from "../../validators/openapi";
+import { MetricDeleter } from "../../services/metrics";
+
+export const deleteMetric = createApiRequestHandler(deleteMetricValidator)(
+  async (req): Promise<DeleteMetricResponse> => {
+    const metricDeleter = new MetricDeleter({
+      id: req.params.id,
+      organization: req.organization,
+      eventAudit: req.eventAudit,
+    });
+    const deletedId = await metricDeleter.perform();
+
+    return {
+      deletedId,
+    };
+  }
+);

--- a/packages/back-end/src/api/metrics/metrics.router.ts
+++ b/packages/back-end/src/api/metrics/metrics.router.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import { getMetric } from "./getMetric";
 import { listMetrics } from "./listMetrics";
 import { postMetric } from "./postMetric";
+import { deleteMetric } from "./deleteMetric";
 
 const router = Router();
 
@@ -9,6 +10,7 @@ const router = Router();
 // Mounted at /api/v1/metrics
 router.get("/", listMetrics);
 router.get("/:id", getMetric);
+router.delete("/:id", deleteMetric);
 router.post("/", postMetric);
 
 export default router;

--- a/packages/back-end/src/api/openapi/openapi.yaml
+++ b/packages/back-end/src/api/openapi/openapi.yaml
@@ -125,6 +125,8 @@ paths:
   /metrics/{id}:
     get:
       $ref: "./paths/getMetric.yaml"
+    delete:
+      $ref: "./paths/deleteMetric.yaml"
   /experiments/{id}/visual-changesets:
     $ref: "./paths/listVisualChangesets.yaml"
   /visual-changesets/{id}:

--- a/packages/back-end/src/api/openapi/paths/deleteMetric.yaml
+++ b/packages/back-end/src/api/openapi/paths/deleteMetric.yaml
@@ -1,0 +1,23 @@
+parameters:
+  - $ref: "../parameters.yaml#/id"
+tags:
+  - metrics
+summary: Deletes a single metric
+operationId: deleteMetric
+x-codeSamples:
+  - lang: 'cURL'
+    source: |
+      curl -X DELETE https://api.growthbook.io/api/v1/metrics/met_abc123 \
+        -u secret_abc123DEF456:
+responses:
+  "200":
+    content:
+      application/json:
+        schema:
+          type: object
+          required: []
+          properties:
+            deletedId:
+              type: string
+              description: The ID of the deleted metric
+              example: met_abc123

--- a/packages/back-end/src/controllers/metrics.ts
+++ b/packages/back-end/src/controllers/metrics.ts
@@ -36,6 +36,7 @@ export async function deleteMetric(
   req: AuthRequest<null, { id: string }>,
   res: Response<unknown, EventAuditUserForResponseLocals>
 ) {
+  // TODO: use MetricDeleter service after merging https://github.com/growthbook/growthbook/pull/1265
   req.checkPermissions("createAnalyses", "");
 
   const { org } = getOrgFromReq(req);

--- a/packages/back-end/src/services/metrics.ts
+++ b/packages/back-end/src/services/metrics.ts
@@ -1,0 +1,54 @@
+import { OrganizationInterface } from "../../types/organization";
+import { deleteMetricById, getMetricById } from "../models/MetricModel";
+import { ImpactEstimateModel } from "../models/ImpactEstimateModel";
+import { removeMetricFromExperiments } from "../models/ExperimentModel";
+import { EventAuditUser } from "../events/event-types";
+
+// TODO: Enable after merging https://github.com/growthbook/growthbook/pull/1265
+// export type MetricDeleteOptions = PermissionFunctions & {
+export type MetricDeleteOptions = {
+  id: string;
+  organization: OrganizationInterface;
+  eventAudit: EventAuditUser;
+};
+
+export class MetricDeleter {
+  private readonly options: MetricDeleteOptions;
+
+  constructor(options: MetricDeleteOptions) {
+    this.options = options;
+  }
+
+  public async perform(): Promise<string> {
+    const { id, organization, eventAudit } = this.options;
+
+    // TODO: Enable after merging https://github.com/growthbook/growthbook/pull/1265
+    //  checkPermissions("createAnalyses", "");
+
+    const metric = await getMetricById(id, organization.id);
+    // TODO: Enable after merging https://github.com/growthbook/growthbook/pull/1265
+    // checkPermissions(
+    //   "createMetrics",
+    //   metric?.projects?.length ? metric.projects : ""
+    // );
+    if (!metric) {
+      throw new Error("Unable to delete - Could not find metric with that id");
+    }
+    // delete references:
+    // ideas (impact estimate)
+    ImpactEstimateModel.updateMany(
+      {
+        metric: metric.id,
+        organization: organization.id,
+      },
+      { metric: "" }
+    );
+
+    // Experiments
+    await removeMetricFromExperiments(metric.id, organization, eventAudit);
+
+    await deleteMetricById(metric.id, organization.id);
+
+    return metric.id;
+  }
+}

--- a/packages/back-end/src/types/AuthRequest.ts
+++ b/packages/back-end/src/types/AuthRequest.ts
@@ -8,7 +8,7 @@ import {
 import { AuditInterface } from "../../types/audit";
 import { SSOConnectionInterface } from "../../types/sso-connection";
 
-interface PermissionFunctions {
+export type PermissionFunctions = {
   checkPermissions(permission: GlobalPermission): void;
   checkPermissions(
     permission: ProjectScopedPermission,
@@ -19,7 +19,7 @@ interface PermissionFunctions {
     project: string | (string | undefined)[] | undefined,
     envs: string[] | Set<string>
   ): void;
-}
+};
 
 // eslint-disable-next-line
 export type AuthRequest<

--- a/packages/back-end/src/validators/openapi.ts
+++ b/packages/back-end/src/validators/openapi.ts
@@ -120,6 +120,12 @@ export const getMetricValidator = {
   paramsSchema: z.object({"id":z.string()}).strict(),
 };
 
+export const deleteMetricValidator = {
+  bodySchema: z.never(),
+  querySchema: z.never(),
+  paramsSchema: z.object({"id":z.string()}).strict(),
+};
+
 export const listVisualChangesetsValidator = {
   bodySchema: z.never(),
   querySchema: z.never(),

--- a/packages/back-end/types/openapi.d.ts
+++ b/packages/back-end/types/openapi.d.ts
@@ -138,6 +138,8 @@ export interface paths {
   "/metrics/{id}": {
     /** Get a single metric */
     get: operations["getMetric"];
+    /** Deletes a single metric */
+    delete: operations["deleteMetric"];
   };
   "/experiments/{id}/visual-changesets": {
     /** Get all visual changesets */
@@ -2291,6 +2293,28 @@ export interface operations {
       };
     };
   };
+  deleteMetric: {
+    /** Deletes a single metric */
+    parameters: {
+        /** @description The id of the requested resource */
+      path: {
+        id: string;
+      };
+    };
+    responses: {
+      200: {
+        content: {
+          "application/json": {
+            /**
+             * @description The ID of the deleted metric 
+             * @example met_abc123
+             */
+            deletedId?: string;
+          };
+        };
+      };
+    };
+  };
   listVisualChangesets: {
     /** Get all visual changesets */
     parameters: {
@@ -2714,6 +2738,7 @@ export type GetExperimentResultsResponse = operations["getExperimentResults"]["r
 export type ListMetricsResponse = operations["listMetrics"]["responses"]["200"]["content"]["application/json"];
 export type PostMetricResponse = operations["postMetric"]["responses"]["200"]["content"]["application/json"];
 export type GetMetricResponse = operations["getMetric"]["responses"]["200"]["content"]["application/json"];
+export type DeleteMetricResponse = operations["deleteMetric"]["responses"]["200"]["content"]["application/json"];
 export type ListVisualChangesetsResponse = operations["listVisualChangesets"]["responses"]["200"]["content"]["application/json"];
 export type GetVisualChangesetResponse = operations["getVisualChangeset"]["responses"]["200"]["content"]["application/json"];
 export type PutVisualChangesetResponse = operations["putVisualChangeset"]["responses"]["200"]["content"]["application/json"];

--- a/plop-templates/back-end/api/delete.hbs
+++ b/plop-templates/back-end/api/delete.hbs
@@ -1,6 +1,7 @@
 import { Delete{{pascalCase object}}Response } from "../../../types/openapi";
 import {
-  delete{{pascalCase object}},
+  find{{pascalCase object}}ById,
+  delete{{pascalCase object}}ById,
   to{{pascalCase object}}ApiInterface
 } from "../../models/{{pascalCase object}}Model";
 import { createApiRequestHandler } from "../../util/handler";
@@ -15,7 +16,7 @@ export const delete{{pascalCase object}} = createApiRequestHandler(delete{{pasca
     if (!{{camelCase object}}) {
       throw new Error("Unable to delete - Could not find {{camelCase object}} with that id");
     }
-    const {{camelCase object}} = await delete{{pascalCase object}}(/* */);
+    await delete{{pascalCase object}}ById(/* */);
 
     return {
       deletedId: req.params.id,


### PR DESCRIPTION
### Features and Changes

Add an API endpoint to delete a metric. Moves the existing functionality to a `MetricDeleter` class. 

Some permissions stuff is commented out until we merge #1265 

- Closes https://linear.app/growthbook/issue/GB-215/[be]-rest-api-endpoint-delete-metric


### Dependencies

- [ ] #1265 


### Testing

For testing the existing delete metric functionality, go to a metric detail page from the metrics page (http://localhost:3000/metrics) and delete a metric. 

For testing the public API, make a network request to delete an existing metric:

```sh
curl --request DELETE \
  --url 'http://localhost:3100/api/v1/metrics/met_*****' \
  --header 'Authorization: Bearer secret_**********'
```
