### PR TITLE
(Bug) - Unable to reset error message due to Mongoose update

### DIFF
--- a/packages/back-end/src/services/informationSchema.ts
+++ b/packages/back-end/src/services/informationSchema.ts
@@ -249,7 +249,7 @@ export async function updateDatasourceInformationSchema(
   // Reset the informationSchema to remove any errors and change status to "PENDING"
   await updateInformationSchemaById(organization, informationSchema.id, {
     status: "PENDING",
-    error: undefined,
+    error: null,
   });
 
   const {
@@ -280,7 +280,7 @@ export async function updateDatasourceInformationSchema(
     ...informationSchema,
     databases: mergedInformationSchema,
     status: "COMPLETE",
-    error: undefined,
+    error: null,
     refreshMS,
     dateUpdated: new Date(),
   });

--- a/packages/back-end/src/types/Integration.ts
+++ b/packages/back-end/src/types/Integration.ts
@@ -231,7 +231,7 @@ export interface InformationSchemaInterface {
   organization: string;
   status: "PENDING" | "COMPLETE";
   refreshMS: number;
-  error?: InformationSchemaError;
+  error?: InformationSchemaError | null;
   dateCreated: Date;
   dateUpdated: Date;
 }


### PR DESCRIPTION
### Current Behavior

If you have a datasource with an information schema, and the information schema record has an error, the recent Mongoose update introduce a change to where we can no longer pass in `undefined` when calling the `$set` method.

As a result, the error message was never being cleared, despite the update job running successfully.

### Expected Behavior

When you click retry, we are setting the information schema record's status to `PENDING` and the `error` property to null. This way, if the job runs without throwing an error, the error doesn't persist on the front end.

### Testing

- [x] Create/edit a BigQuery datasource and do not add a default dataset, then, try to view the schema via the SchemaBrowser and ensure you get an error message.
- [x] Then, go back and edit the datasource connection settings to include a default datasource, and then, go back to view the SchemaBrowser, and when you see the error message, click the retry, and ensure that the error message is removed correctly.
