### PR TITLE
Revert default MongoDB db name to "test" unless explicitly set

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
     network_mode: service:mongo
     environment:
-      - MONGODB_URI=mongodb://root:password@mongo:27017/
+      - MONGODB_URI=mongodb://root:password@mongo:27017/growthbook?authSource=admin
   mongo:
     image: mongo:latest
     restart: unless-stopped

--- a/.docker-compose-okteto.yml
+++ b/.docker-compose-okteto.yml
@@ -13,7 +13,7 @@ services:
     depends_on:
       - mongo
     environment:
-      - MONGODB_URI=mongodb://root:password@mongo:27017/
+      - MONGODB_URI=mongodb://root:password@mongo:27017/growthbook?authSource=admin
       - APP_ORIGIN=https://growthbook-3000-${OKTETO_NAMESPACE}.growthbook.okteto.dev
       - API_HOST=https://growthbook-3100-${OKTETO_NAMESPACE}.growthbook.okteto.dev
       - JWT_SECRET=${JWT_SECRET}

--- a/docker-compose.proxy.yml
+++ b/docker-compose.proxy.yml
@@ -14,7 +14,7 @@ services:
     depends_on:
       - mongo
     environment:
-      - MONGODB_URI=mongodb://root:password@mongo:27017/
+      - MONGODB_URI=mongodb://root:password@mongo:27017/growthbook?authSource=admin
       # Proxy settings
       - PROXY_ENABLED=1
       - PROXY_HOST_INTERNAL=http://proxy:3300

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     depends_on:
       - mongo
     environment:
-      - MONGODB_URI=mongodb://root:password@mongo:27017/
+      - MONGODB_URI=mongodb://root:password@mongo:27017/growthbook?authSource=admin
     volumes:
       - uploads:/usr/local/src/app/packages/back-end/uploads
 volumes:

--- a/docs/docs/self-host/index.mdx
+++ b/docs/docs/self-host/index.mdx
@@ -37,7 +37,7 @@ services:
     depends_on:
       - mongo
     environment:
-      - MONGODB_URI=mongodb://root:password@mongo:27017/
+      - MONGODB_URI=mongodb://root:password@mongo:27017/growthbook?authSource=admin
     volumes:
       - uploads:/usr/local/src/app/packages/back-end/uploads
 volumes:
@@ -66,7 +66,7 @@ services:
     depends_on:
       - mongo
     environment:
-      - MONGODB_URI=mongodb://root:password@mongo:27017/
+      - MONGODB_URI=mongodb://root:password@mongo:27017/growthbook?authSource=admin
     volumes:
       - uploads:/usr/local/src/app/packages/back-end/uploads
     platform: linux/amd64

--- a/packages/back-end/.env.example
+++ b/packages/back-end/.env.example
@@ -8,7 +8,7 @@ ENCRYPTION_KEY=dev
 APP_ORIGIN=http://localhost:3000
 
 # MongoDB
-MONGODB_URI=mongodb://root:password@localhost:27017/
+MONGODB_URI=mongodb://root:password@localhost:27017/growthbook?authSource=admin
 
 # Required to send emails from the app
 EMAIL_ENABLED=true

--- a/packages/back-end/src/util/secrets.ts
+++ b/packages/back-end/src/util/secrets.ts
@@ -1,6 +1,7 @@
 import fs from "fs";
 import dotenv from "dotenv";
 import { IssuerMetadata } from "openid-client";
+import trimEnd from "lodash/trimEnd";
 import { SSOConnectionInterface } from "../../types/sso-connection";
 
 export const ENVIRONMENT = process.env.NODE_ENV;
@@ -23,11 +24,17 @@ export const UPLOAD_METHOD = (() => {
   return "local";
 })();
 
-export const MONGODB_URI =
+export let MONGODB_URI =
   process.env.MONGODB_URI ??
-  (prod ? "" : "mongodb://root:password@localhost:27017/");
+  (prod ? "" : "mongodb://root:password@localhost:27017/test?authSource=admin");
 if (!MONGODB_URI) {
   throw new Error("Missing MONGODB_URI environment variable");
+}
+
+// For backwards compatibility, if no dbname is explicitly set, use "test" and add the authSource db.
+// This matches the default behavior of the MongoDB driver 3.X, which changed when we updated to 4.X
+if (MONGODB_URI.match(/:27017(\/)?$/)) {
+  MONGODB_URI = trimEnd(MONGODB_URI, "/") + "/test?authSource=admin";
 }
 
 export const APP_ORIGIN = process.env.APP_ORIGIN || "http://localhost:3000";


### PR DESCRIPTION
### Features and Changes

Before updating to the Node.js MongoDB driver v4.X, the default db name was `test`.  Now it is `admin`.  This change was undocumented and was not caught in our initial dependency update PR #1299 

This PR attempts to revert the default behavior to match the old version. It also tries to encourage new users to explicitly set a db name going forward.

1. Updates documentation and starter templates to explicitly set the db name as `growthbook` for new users
2. If dbname is missing from the connection string, make it default to the old `test` value to maintain backwards compatibility.