### PR TITLE
MongoDB migration recovery helper for v3 to v4 migration

### DIFF
--- a/packages/back-end/src/init/mongo.ts
+++ b/packages/back-end/src/init/mongo.ts
@@ -33,13 +33,22 @@ export default async (): Promise<void> => {
         url: modifiedUri,
         success,
         remapped,
+        unsupported,
       } = getConnectionStringWithDeprecatedKeysMigratedForV3to4(uri);
       if (!success) {
         throw new Error("mongodb connection string invalid");
       }
 
       await mongoose.connect(modifiedUri, mongooseOpts);
-      logger.warn(`mongodb deprecated fields remapped: ${remapped.join(", ")}`);
+      if (remapped.length) {
+        logger.warn(
+          `mongodb deprecated fields remapped: ${remapped.join(", ")}`
+        );
+      }
+
+      if (unsupported.length) {
+        logger.error(`mongodb unsupported fields: ${unsupported.join(", ")}`);
+      }
     } catch (e) {
       logger.error(
         e,

--- a/packages/back-end/src/init/mongo.ts
+++ b/packages/back-end/src/init/mongo.ts
@@ -39,21 +39,19 @@ export default async (): Promise<void> => {
         throw new Error("mongodb connection string invalid");
       }
 
-      await mongoose.connect(modifiedUri, mongooseOpts);
+      // Log problematic fields before attempting to reconnect
+      if (unsupported.length) {
+        logger.error(`mongodb unsupported fields: ${unsupported.join(", ")}`);
+      }
       if (remapped.length) {
         logger.warn(
           `mongodb deprecated fields remapped: ${remapped.join(", ")}`
         );
       }
 
-      if (unsupported.length) {
-        logger.error(`mongodb unsupported fields: ${unsupported.join(", ")}`);
-      }
+      await mongoose.connect(modifiedUri, mongooseOpts);
     } catch (e) {
-      logger.error(
-        e,
-        "Failed to connect to MongoDB. Retrying with field remapping for mongodb v3 to v4"
-      );
+      logger.error(e, "Failed to connect to MongoDB after retrying");
       throw new Error("MongoDB connection error.");
     }
   }

--- a/packages/back-end/src/util/mongo.util.ts
+++ b/packages/back-end/src/util/mongo.util.ts
@@ -59,30 +59,38 @@ export const getConnectionStringWithDeprecatedKeysMigratedForV3to4 = (
 
   try {
     const remapped: string[] = [];
-    const parsedUrl = new URL(uri);
+    const [originalUrl, queryString] = uri.split("?");
+
+    const searchParams = new URLSearchParams(queryString);
 
     // Replacements
     const entries = Object.entries(v3to4Mappings);
     entries.forEach(([oldKey, newKey]) => {
-      const value = parsedUrl.searchParams.get(oldKey);
+      const value = searchParams.get(oldKey);
       if (value) {
         remapped.push(oldKey);
-        parsedUrl.searchParams.set(newKey, value);
-        parsedUrl.searchParams.delete(oldKey);
+        searchParams.set(newKey, value);
+        searchParams.delete(oldKey);
       }
     });
 
     // Validation
     const unsupported: string[] = [];
     unsupportedV3FieldsInV4.forEach((oldKey) => {
-      const value = parsedUrl.searchParams.get(oldKey);
+      const value = searchParams.get(oldKey);
       if (value) {
         unsupported.push(oldKey);
       }
     });
 
+    const modifiedParams = searchParams.toString();
+    let modifiedUrl = originalUrl;
+    if (modifiedParams) {
+      modifiedUrl += "?" + modifiedParams;
+    }
+
     return {
-      url: parsedUrl.toString(),
+      url: modifiedUrl,
       success: true,
       remapped,
       unsupported,

--- a/packages/back-end/src/util/mongo.util.ts
+++ b/packages/back-end/src/util/mongo.util.ts
@@ -1,0 +1,69 @@
+/**
+ * Assists in migrating any field options that MongoDB has changed between major versions 3 and 4.
+ * Replaces the query with an equivalent where keys that can be mapped 1-to-1 are replaced with their new values.
+ *
+ * Fields that are concerning and do not have 1-to-1 mappings:
+ *  - autoReconnect: is no longer documented
+ *  - reconnectTries: is no longer documented
+ *  - reconnectInterval: is no longer documented
+ *  - ha: is no longer documented
+ *  - haInterval: is no longer documented
+ *  - secondaryAcceptableLatencyMS: is no longer documented. Possibly related: maxStalenessSeconds
+ *  - acceptableLatencyMS: is no longer documented. Possibly related: maxStalenessSeconds
+ *  - connectWithNoPrimary: is no longer documented
+ *  - w: still exists but is marked as deprecated -> writeConcern (incompatible types)
+ *  - j: is no longer documented (journal write concern). -> writeConcern (incompatible types)
+ *  - domainsEnabled: is no longer documented
+ *  - bufferMaxEntries: is no longer documented
+ *  - promiseLibrary: still exists but is marked as deprecated.
+ *  - loggerLevel: still exists but is marked as deprecated.
+ *  - logger: still exists but is marked as deprecated.
+ */
+export const getConnectionStringWithDeprecatedKeysMigratedForV3to4 = (
+  uri: string
+): ResultDeprecatedKeysMigrationV3to4 => {
+  const v3to4Mappings: Record<string, string> = {
+    poolSize: "maxPoolSize",
+    tlsinsecure: "tlsInsecure",
+
+    /**
+     * @deprecated
+     */
+    wtimeout: "wtimeoutMS",
+
+    appname: "appName",
+  };
+
+  try {
+    const remapped: string[] = [];
+    const parsedUrl = new URL(uri);
+
+    const entries = Object.entries(v3to4Mappings);
+    entries.forEach(([oldKey, newKey]) => {
+      const value = parsedUrl.searchParams.get(oldKey);
+      if (value) {
+        remapped.push(oldKey);
+        parsedUrl.searchParams.set(newKey, value);
+        parsedUrl.searchParams.delete(oldKey);
+      }
+    });
+
+    return {
+      url: parsedUrl.toString(),
+      success: true,
+      remapped,
+    };
+  } catch (e) {
+    return {
+      url: uri,
+      success: false,
+      remapped: [],
+    };
+  }
+};
+
+type ResultDeprecatedKeysMigrationV3to4 = {
+  success: boolean;
+  url: string;
+  remapped: string[];
+};

--- a/packages/back-end/src/util/mongo.util.ts
+++ b/packages/back-end/src/util/mongo.util.ts
@@ -1,9 +1,18 @@
 /**
  * Assists in migrating any field options that MongoDB has changed between major versions 3 and 4.
  * Replaces the query with an equivalent where keys that can be mapped 1-to-1 are replaced with their new values.
+ *
+ * Docs referenced:
+ *  - v3 fields: https://mongodb.github.io/node-mongodb-native/3.7/reference/connecting/connection-settings/
+ *  - v4 fields: https://mongodb.github.io/node-mongodb-native/4.16/interfaces/MongoClientOptions.html
+ *
  * @return ResultDeprecatedKeysMigrationV3to4
  *
- * Fields that are concerning and do not have 1-to-1 mappings:
+ * Unsupported deprecated fields that do not have 1-to-1 mappings.
+ * Some fields no longer exist, while others are marked as deprecated in v4, which means they *could* be removed in the future.
+ *
+ * Note: Some v3 options were marked as deprecated but were included in v4 and not marked as deprecated. These have been ignored.
+ *
  *  - autoReconnect: is no longer documented
  *  - reconnectTries: is no longer documented
  *  - reconnectInterval: is no longer documented

--- a/packages/back-end/src/util/mongo.util.ts
+++ b/packages/back-end/src/util/mongo.util.ts
@@ -1,6 +1,7 @@
 /**
  * Assists in migrating any field options that MongoDB has changed between major versions 3 and 4.
  * Replaces the query with an equivalent where keys that can be mapped 1-to-1 are replaced with their new values.
+ * @return ResultDeprecatedKeysMigrationV3to4
  *
  * Fields that are concerning and do not have 1-to-1 mappings:
  *  - autoReconnect: is no longer documented
@@ -62,8 +63,23 @@ export const getConnectionStringWithDeprecatedKeysMigratedForV3to4 = (
   }
 };
 
+/**
+ * Result object for a MongoDB URI connection string migration attempt from v3 to v4.
+ * Includes the modified URI, the deprecated old keys list, and whether the connection string modification was successful.
+ */
 type ResultDeprecatedKeysMigrationV3to4 = {
+  /**
+   * false when the URL fails to parse
+   */
   success: boolean;
+
+  /**
+   * Modified URL
+   */
   url: string;
+
+  /**
+   * Old keys that have been remapped
+   */
   remapped: string[];
 };

--- a/packages/back-end/test/util/mongo.util.test.ts
+++ b/packages/back-end/test/util/mongo.util.test.ts
@@ -12,11 +12,13 @@ describe("mongo utils", () => {
         url,
         success,
         remapped,
+        unsupported,
       } = getConnectionStringWithDeprecatedKeysMigratedForV3to4(input);
 
       expect(url).toEqual(expected);
       expect(success).toBe(true);
       expect(remapped).toEqual([]);
+      expect(unsupported).toEqual([]);
     });
 
     it("returns a modified URI when one of the properties needs to be migrated", () => {
@@ -29,11 +31,13 @@ describe("mongo utils", () => {
         url,
         success,
         remapped,
+        unsupported,
       } = getConnectionStringWithDeprecatedKeysMigratedForV3to4(input);
 
       expect(url).toEqual(expected);
       expect(success).toBe(true);
       expect(remapped).toEqual(["poolSize"]);
+      expect(unsupported).toEqual([]);
     });
 
     it("returns a modified URI when several properties need to be migrated", () => {
@@ -46,6 +50,7 @@ describe("mongo utils", () => {
         url,
         success,
         remapped,
+        unsupported,
       } = getConnectionStringWithDeprecatedKeysMigratedForV3to4(input);
 
       expect(url).toEqual(expected);
@@ -55,6 +60,43 @@ describe("mongo utils", () => {
         "tlsinsecure",
         "wtimeout",
         "appname",
+      ]);
+      expect(unsupported).toEqual([]);
+    });
+
+    it("reports unsupported keys when known v3 options without adequate v4 mappings are provided, leaving invalid keys in the connection string", () => {
+      const input =
+        "mongodb://root:password@localhost:27017/growthbook?authSource=admin&poolSize=50&wtimeout=123456&appname=foobar&tlsinsecure=true&autoReconnect=true&reconnectRetries=3&reconnectInterval=300&ha=true&haInterval=300&secondaryAcceptableLatencyMS=1000&acceptableLatencyMS=1000&j=true&connectWithNoPrimary=true&domainsEnabled=false&bufferMaxEntries=10&foo=1&bar=2&baz=3";
+      // includes original deprecated keys
+      const expected =
+        "mongodb://root:password@localhost:27017/growthbook?authSource=admin&autoReconnect=true&reconnectRetries=3&reconnectInterval=300&ha=true&haInterval=300&secondaryAcceptableLatencyMS=1000&acceptableLatencyMS=1000&j=true&connectWithNoPrimary=true&domainsEnabled=false&bufferMaxEntries=10&foo=1&bar=2&baz=3&maxPoolSize=50&tlsInsecure=true&wtimeoutMS=123456&appName=foobar";
+
+      const {
+        url,
+        success,
+        remapped,
+        unsupported,
+      } = getConnectionStringWithDeprecatedKeysMigratedForV3to4(input);
+
+      expect(url).toEqual(expected);
+      expect(success).toBe(true);
+      expect(remapped).toEqual([
+        "poolSize",
+        "tlsinsecure",
+        "wtimeout",
+        "appname",
+      ]);
+      expect(unsupported).toEqual([
+        "autoReconnect",
+        "reconnectInterval",
+        "ha",
+        "haInterval",
+        "secondaryAcceptableLatencyMS",
+        "acceptableLatencyMS",
+        "connectWithNoPrimary",
+        "j",
+        "domainsEnabled",
+        "bufferMaxEntries",
       ]);
     });
   });

--- a/packages/back-end/test/util/mongo.util.test.ts
+++ b/packages/back-end/test/util/mongo.util.test.ts
@@ -1,0 +1,61 @@
+import { getConnectionStringWithDeprecatedKeysMigratedForV3to4 } from "../../src/util/mongo.util";
+
+describe("mongo utils", () => {
+  describe("getConnectionStringWithDeprecatedKeysMigratedForV3to4", () => {
+    it("returns the original string when no replacements are required", () => {
+      const input =
+        "mongodb://root:password@localhost:27017/growthbook?authSource=admin";
+      const expected =
+        "mongodb://root:password@localhost:27017/growthbook?authSource=admin";
+
+      const {
+        url,
+        success,
+        remapped,
+      } = getConnectionStringWithDeprecatedKeysMigratedForV3to4(input);
+
+      expect(url).toEqual(expected);
+      expect(success).toBe(true);
+      expect(remapped).toEqual([]);
+    });
+
+    it("returns a modified URI when one of the properties needs to be migrated", () => {
+      const input =
+        "mongodb://root:password@localhost:27017/growthbook?poolSize=50";
+      const expected =
+        "mongodb://root:password@localhost:27017/growthbook?maxPoolSize=50";
+
+      const {
+        url,
+        success,
+        remapped,
+      } = getConnectionStringWithDeprecatedKeysMigratedForV3to4(input);
+
+      expect(url).toEqual(expected);
+      expect(success).toBe(true);
+      expect(remapped).toEqual(["poolSize"]);
+    });
+
+    it("returns a modified URI when several properties need to be migrated", () => {
+      const input =
+        "mongodb://root:password@localhost:27017/growthbook?authSource=admin&poolSize=50&wtimeout=123456&appname=foobar&tlsinsecure=true";
+      const expected =
+        "mongodb://root:password@localhost:27017/growthbook?authSource=admin&maxPoolSize=50&tlsInsecure=true&wtimeoutMS=123456&appName=foobar";
+
+      const {
+        url,
+        success,
+        remapped,
+      } = getConnectionStringWithDeprecatedKeysMigratedForV3to4(input);
+
+      expect(url).toEqual(expected);
+      expect(success).toBe(true);
+      expect(remapped).toEqual([
+        "poolSize",
+        "tlsinsecure",
+        "wtimeout",
+        "appname",
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
### Features and Changes

Adds a util that remaps fields changed from v3 to v4 in a MongoDB connection string.

Adds some logging and docs around deprecated fields that we are unable to migrate.


### Dependencies

n/a


## Testing

Change the `MONGODB_URI` to a value with deprecated fields. 

### Recoverable

In the following case, `poolSize` is deprecated. This can be automatically remapped to `maxPoolSize` and the application can recover:

```
MONGODB_URI=mongodb://user:password@localhost:27017/growthbook?authSource=admin&poolSize=4
```

### Not recoverable

In the following case, some fields can successfully be remapped, while other fields are no longer supported in v4. The application cannot recover because there isn't a suitable alternative. This information is logged by us (with any fields that could be remapped removed) and Mongo, which continues to provide it's MongoParseError.

`MONGODB_URI=mongodb://user:password@localhost:27017/growthbook?authSource=admin&autoReconnect=true&reconnectRetries=3&reconnectInterval=300&ha=true&haInterval=300&secondaryAcceptableLatencyMS=1000&acceptableLatencyMS=1000&j=true&connectWithNoPrimary=true&domainsEnabled=false&bufferMaxEntries=10&foo=1&bar=2&baz=3&poolSize=50&tlsinsecure=true&wtimeout=123456&appname=foobar`

We add the following logging:

```
 | [1] [17:28:15.180] WARN (65739): Failed to connect to MongoDB. Retrying with field remapping for mongodb v3 to v4
 | [1] [17:28:15.183] ERROR (65739): mongodb unsupported fields: autoReconnect, reconnectInterval, ha, haInterval, secondaryAcceptableLatencyMS, acceptableLatencyMS, connectWithNoPrimary, j, domainsEnabled, bufferMaxEntries
 | [1] [17:28:15.184] WARN (65739): mongodb deprecated fields remapped: poolSize, tlsinsecure, wtimeout, appname
 | [1] [17:28:15.191] ERROR (65739): Failed to connect to MongoDB after retrying
```

<img width="1052" alt="image" src="https://github.com/growthbook/growthbook/assets/113377031/7bf01de8-d5cc-4e7e-bfba-cb50df50947a">

<img width="1226" alt="image" src="https://github.com/growthbook/growthbook/assets/113377031/dbf535f7-8549-4786-ab79-8ba6bd6b527b">


Below is the MongoDB original stack trace which will continue to be logged by mongo:

<details>
<summary><b>default mongodb stack trace</b></summary>

```
 | [1]     err: {
 | [1]       "type": "MongoParseError",
 | [1]       "message": "options autoreconnect, reconnectretries, reconnectinterval, ha, hainterval, secondaryacceptablelatencyms, acceptablelatencyms, connectwithnoprimary, domainsenabled, buffermaxentries, foo, bar, baz are not supported",
 | [1]       "stack":
 | [1]           MongoParseError: options autoreconnect, reconnectretries, reconnectinterval, ha, hainterval, secondaryacceptablelatencyms, acceptablelatencyms, connectwithnoprimary, domainsenabled, buffermaxentries, foo, bar, baz are not supported
 | [1]               at parseOptions (/path/to/growthbook/node_modules/mongodb/lib/connection_string.js:270:15)
 | [1]               at new MongoClient (/path/to/growthbook/node_modules/mongodb/lib/mongo_client.js:46:63)
 | [1]               at /path/to/growthbook/node_modules/mongoose/lib/connection.js:802:16
 | [1]               at Promise._execute (/path/to/growthbook/node_modules/bluebird/js/release/debuggability.js:384:9)
 | [1]               at Promise._resolveFromExecutor (/path/to/growthbook/node_modules/bluebird/js/release/promise.js:518:18)
 | [1]               at new Promise (/path/to/growthbook/node_modules/bluebird/js/release/promise.js:103:10)
 | [1]               at NativeConnection.Connection.openUri (/path/to/growthbook/node_modules/mongoose/lib/connection.js:799:19)
 | [1]               at /path/to/growthbook/node_modules/mongoose/lib/index.js:414:10
 | [1]               at /path/to/growthbook/node_modules/mongoose/lib/helpers/promiseOrCallback.js:41:5
 | [1]               at Promise._execute (/path/to/growthbook/node_modules/bluebird/js/release/debuggability.js:384:9)
 | [1]               at Promise._resolveFromExecutor (/path/to/growthbook/node_modules/bluebird/js/release/promise.js:518:18)
 | [1]               at new Promise (/path/to/growthbook/node_modules/bluebird/js/release/promise.js:103:10)
 | [1]               at promiseOrCallback (/path/to/growthbook/node_modules/mongoose/lib/helpers/promiseOrCallback.js:40:10)
 | [1]               at Mongoose._promiseOrCallback (/path/to/growthbook/node_modules/mongoose/lib/index.js:1288:10)
 | [1]               at Mongoose.connect (/path/to/growthbook/node_modules/mongoose/lib/index.js:413:20)
 | [1]               at _default (/path/to/growthbook/packages/back-end/dist/init/mongo.js:48:37)
```

</details>

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
