### PR TITLE
Various front-end and query builder bugfixes

### DIFF
--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -1285,14 +1285,22 @@ export default abstract class SqlIntegration
     // Determine the identifier column to select from
     let userIdCol = cols.userIds[baseIdType] || "user_id";
     let join = "";
+
+    // query builder does not use a sub-query to get a the userId column to
+    // equal the userIdType, so when using the query builder, continue to
+    // use the actual input column name rather than the id type
     if (metric.userIdTypes?.includes(baseIdType)) {
-      userIdCol = baseIdType;
+      userIdCol = queryFormat === "builder" ? userIdCol : baseIdType;
     } else if (metric.userIdTypes) {
       for (let i = 0; i < metric.userIdTypes.length; i++) {
         const userIdType: string = metric.userIdTypes[i];
         if (userIdType in idJoinMap) {
+          const metricUserIdCol =
+            queryFormat === "builder"
+              ? cols.userIds[userIdType]
+              : `m.${userIdType}`;
+          join = `JOIN ${idJoinMap[userIdType]} i ON (i.${userIdType} = ${metricUserIdCol})`;
           userIdCol = `i.${baseIdType}`;
-          join = `JOIN ${idJoinMap[userIdType]} i ON (i.${userIdType} = m.${userIdType})`;
           break;
         }
       }

--- a/packages/front-end/components/Experiment/GuardrailResult.tsx
+++ b/packages/front-end/components/Experiment/GuardrailResult.tsx
@@ -74,7 +74,7 @@ const GuardrailResults: FC<{
           tipPosition="right"
         >
           <Link href={`/metric/${metric.id}`}>
-            <a className="text-dark font-weight-bold">{metric.name}</a>
+            <a className="text-black-50 font-weight-bold">{metric.name}</a>
           </Link>
         </Tooltip>
       </div>

--- a/packages/front-end/components/Experiment/PValueGuardrailResults.tsx
+++ b/packages/front-end/components/Experiment/PValueGuardrailResults.tsx
@@ -73,7 +73,7 @@ const HeaderResult: FC<{
       {status === "secondary" && <FaQuestionCircle className="mr-1" />}
       <Tooltip body={<MetricTooltipBody metric={metric} />} tipPosition="right">
         <Link href={`/metric/${metric.id}`}>
-          <a className="text-dark font-weight-bold">{metric.name}</a>
+          <a className="text-black-50 font-weight-bold">{metric.name}</a>
         </Link>
       </Tooltip>
     </div>

--- a/packages/front-end/components/Experiment/SRMWarning.tsx
+++ b/packages/front-end/components/Experiment/SRMWarning.tsx
@@ -1,5 +1,5 @@
 import { FC, useState } from "react";
-import { formatTrafficSplit } from "@/services/utils";
+import { formatTrafficSplit, getSRMNeededPrecisionP1 } from "@/services/utils";
 import Modal from "../Modal";
 
 export const SRM_THRESHOLD = 0.001;
@@ -98,8 +98,15 @@ const SRMWarning: FC<{
       <div className="alert alert-danger">
         <strong>Warning: Sample Ratio Mismatch (SRM) detected</strong>. We
         expected a <code>{formatTrafficSplit(expected, 1)}</code> split, but
-        observed a <code>{formatTrafficSplit(observed, 1)}</code> split (p-value
-        = <code>{srm}</code>). There is likely a bug in the implementation.{" "}
+        observed a{" "}
+        <code>
+          {formatTrafficSplit(
+            observed,
+            getSRMNeededPrecisionP1(observed, expected)
+          )}
+        </code>{" "}
+        split (p-value = <code>{srm}</code>). There is likely a bug in the
+        implementation.{" "}
         <a
           href="#"
           onClick={(e) => {

--- a/packages/front-end/services/utils.tsx
+++ b/packages/front-end/services/utils.tsx
@@ -2,9 +2,29 @@ import { ExperimentPhaseStringDates } from "back-end/types/experiment";
 import React, { ReactNode } from "react";
 import qs from "query-string";
 
-export function formatTrafficSplit(weights: number[], decimals = 0): string {
+function trafficSplitPercentages(weights: number[]): number[] {
   const sum = weights.reduce((sum, n) => sum + n, 0);
-  return weights.map((w) => +((w / sum) * 100).toFixed(decimals)).join("/");
+  return weights.map((w) => +((w / sum) * 100));
+}
+
+export function formatTrafficSplit(weights: number[], decimals = 0): string {
+  return trafficSplitPercentages(weights)
+    .map((w) => w.toFixed(decimals))
+    .join("/");
+}
+
+// Get the number of decimals +1 needed to differentiate between
+// observed and expected weights
+export function getSRMNeededPrecisionP1(
+  observed: number[],
+  expected: number[]
+): number {
+  const observedpct = trafficSplitPercentages(observed);
+  const expectedpct = trafficSplitPercentages(expected);
+  const maxDiff = Math.max(
+    ...observedpct.map((o, i) => Math.abs(o - expectedpct[i] || 0))
+  );
+  return (maxDiff ? -1 * Math.floor(Math.log10(maxDiff)) : 0) + 1;
 }
 
 export function phaseSummary(phase: ExperimentPhaseStringDates): ReactNode {


### PR DESCRIPTION
### Features and Changes

Front-end bugfixes:
* Picks a smart number of decimals to round to for SRM errors, this closes #1305 
* Better color choice for guardrail metric header to deal with dark mode, this closes #1344 

Back-end bugfixes:
* Use correct column names for id types when using the query builder, this closes #1317 

### Dependencies

n/a

### Testing

Quick testing on local + shots below

### Screenshots

#### SRM decimals

before: 
![image](https://github.com/growthbook/growthbook/assets/5298599/ad46e54c-c267-4743-8e85-b07582392187)

After: 
![image](https://github.com/growthbook/growthbook/assets/5298599/5a6666c5-702c-4aea-a67e-d20c09230aae)


#### Header colors

Both after:
<img width="219" alt="Screenshot 2023-06-07 at 8 46 19 PM" src="https://github.com/growthbook/growthbook/assets/5298599/092ef8c1-7704-4127-8ee3-8807471ef8cb">

<img width="170" alt="Screenshot 2023-06-07 at 8 46 23 PM" src="https://github.com/growthbook/growthbook/assets/5298599/926cfbab-7a02-4cfa-b19f-ad295ad0b561">


#### SQL builder

I could replicate initial bug in #1317 in the Metric analysis query and experiment queries.

*After* (showing that metrics that require userID joins, are builder vs. regular sql, etc all work as expected):
![image](https://github.com/growthbook/growthbook/assets/5298599/fd4149e2-6a70-48eb-84fd-936f4e5df965)



