### PR TITLE
Fix SECRET_API_KEY permissions (used for Proxy Server)

### DIFF
--- a/packages/back-end/src/models/ApiKeyModel.ts
+++ b/packages/back-end/src/models/ApiKeyModel.ts
@@ -8,7 +8,7 @@ import {
   PublishableApiKey,
   SecretApiKey,
 } from "../../types/apikey";
-import { IS_CLOUD, SECRET_API_KEY } from "../util/secrets";
+import { IS_CLOUD, SECRET_API_KEY, SECRET_API_KEY_ROLE } from "../util/secrets";
 import { roleForApiKey } from "../util/api-key.util";
 import { findAllOrganizations } from "./OrganizationModel";
 
@@ -274,6 +274,7 @@ export async function lookupOrganizationByApiKey(
         key: SECRET_API_KEY,
         secret: true,
         organization: orgs[0].id,
+        role: SECRET_API_KEY_ROLE,
       };
     }
   }

--- a/packages/back-end/src/util/secrets.ts
+++ b/packages/back-end/src/util/secrets.ts
@@ -177,8 +177,7 @@ if ((prod || !isLocalhost) && secretAPIKey === "dev") {
   );
 }
 export const SECRET_API_KEY = secretAPIKey;
-// The SECRET_API_KEY option is typically only used for the Proxy Server and requires readonly access
-// This is technically a breaking change, but this env variable is undocumented so it should be ok
+// This is typically used for the Proxy Server, which only requires readonly access
 export const SECRET_API_KEY_ROLE =
   process.env.SECRET_API_KEY_ROLE || "readonly";
 export const PROXY_ENABLED = !!process.env.PROXY_ENABLED;

--- a/packages/back-end/src/util/secrets.ts
+++ b/packages/back-end/src/util/secrets.ts
@@ -177,6 +177,10 @@ if ((prod || !isLocalhost) && secretAPIKey === "dev") {
   );
 }
 export const SECRET_API_KEY = secretAPIKey;
+// The SECRET_API_KEY option is typically only used for the Proxy Server and requires readonly access
+// This is technically a breaking change, but this env variable is undocumented so it should be ok
+export const SECRET_API_KEY_ROLE =
+  process.env.SECRET_API_KEY_ROLE || "readonly";
 export const PROXY_ENABLED = !!process.env.PROXY_ENABLED;
 export const PROXY_HOST_INTERNAL = process.env.PROXY_HOST_INTERNAL || "";
 export const PROXY_HOST_PUBLIC = process.env.PROXY_HOST_PUBLIC || "";


### PR DESCRIPTION
### Features and Changes

There is an undocumented environment variable `SECRET_API_KEY` used by the GrowthBook Proxy.  It allows defining a secret API key without using the GrowthBook UI.

When we added roles to API Keys in #1265 , we migrated old API keys in the database that were missing a role, but the environment variable bypasses that migration step and therefore did not have a role defined.  This caused `401 Unauthorized` errors when trying to use the SECRET_API_KEY.

Since this key is undocumented and only used in the GrowthBook Proxy, I added a default role of `readonly` (the minimum permissions required by the proxy).  This is technically a breaking change since the key used to act like an "admin" key.  But since it was undocumented, this seems like the safer option to default to.  There is a new `SECRET_API_KEY_ROLE` environment variable if someone wants to grant it more access for whatever reason.