### PR TITLE
remove prefix for yarn start command, outputs pure json log entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build:deps": "wsrun -p '@growthbook/growthbook' -p '@growthbook/growthbook-react' -p 'shared' -t -c build",
     "build:app": "wsrun -p 'back-end' -p 'front-end' -c build",
     "build": "yarn build:deps && yarn build:app",
-    "start": "wsrun -p 'back-end' -p 'front-end' -c start",
+    "start": "wsrun -p 'back-end' -p 'front-end' --no-prefix -c start",
     "setup": "yarn build:deps && wsrun -p 'stats' -c setup",
     "prepare": "husky install",
     "plop": "plop",


### PR DESCRIPTION
### Features and Changes

closes https://github.com/growthbook/growthbook/issues/1312

Logging in production inserts an extra ` | ` character which messes up JSON parsing for log entries. For `yarn start`, we add the `--no-prefix` flag to `wsrun` to avoid this.

Before:
```
back-end
 | {"level":30,"time":1686289445673,"pid":68807,"hostname":"Bryces-MacBook-Pro.local","msg":"No config.yml file. Using MongoDB instead to store data sources, metrics, and dimensions."}
 | {"level":30,"time":1686289446330,"pid":68807,"hostname":"Bryces-MacBook-Pro.local","msg":"Back-end is running at http://localhost:3100 in development mode. Press CTRL-C to stop"}
```

After:
```
{"level":30,"time":1686289413982,"pid":68750,"hostname":"Bryces-MacBook-Pro.local","msg":"No config.yml file. Using MongoDB instead to store data sources, metrics, and dimensions."}
{"level":30,"time":1686289414959,"pid":68750,"hostname":"Bryces-MacBook-Pro.local","msg":"Back-end is running at http://localhost:3100 in development mode. Press CTRL-C to stop"}
```

- Closes **(add link to issue here)**

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

<!--
  Please describe how to test these changes.
 -->

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
