### PR TITLE
Bug fix: Datasource settings get wiped on update call

### DIFF
--- a/packages/front-end/components/Settings/NewDataSourceForm.tsx
+++ b/packages/front-end/components/Settings/NewDataSourceForm.tsx
@@ -132,20 +132,21 @@ const NewDataSourceForm: FC<{
       }
       // Create
       else {
+        const updatedDatasource = {
+          ...datasource,
+          settings: {
+            ...getInitialSettings(
+              selectedSchema.value,
+              // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'PostgresConnectionParams | Athen... Remove this comment to see the full error message
+              datasource.params,
+              form.watch("settings.schemaOptions")
+            ),
+            ...(datasource.settings || {}),
+          },
+        };
         const res = await apiCall<{ id: string }>(`/datasources`, {
           method: "POST",
-          body: JSON.stringify({
-            ...datasource,
-            settings: {
-              ...getInitialSettings(
-                selectedSchema.value,
-                // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'PostgresConnectionParams | Athen... Remove this comment to see the full error message
-                datasource.params,
-                form.watch("settings.schemaOptions")
-              ),
-              ...(datasource.settings || {}),
-            },
-          }),
+          body: JSON.stringify(updatedDatasource),
         });
         track("Submit Datasource Form", {
           source,
@@ -154,6 +155,9 @@ const NewDataSourceForm: FC<{
           newDatasourceForm: true,
         });
         setDataSourceId(res.id);
+        setDatasource(
+          updatedDatasource as Partial<DataSourceInterfaceWithParams>
+        );
         return res.id;
       }
     } catch (e) {


### PR DESCRIPTION
### Features and Changes

When testing the auto metrics PR, Jeremy and I came across a bug where if you are building a datasource where the `NewDataSourceForm` has more than a single page (ex: A Segment datasource) - if you complete the first page, and then click the "Back" button, whenever you click "Next" again, we are resetting a datasource's `settings` back to an empty object.

When looking at the code, this is happening because when we make the `POST` call, we're only building out a datasource's `settings` when building the body of the request, and the endpoint returns only the id of the newly created datasource.

So, the `datasource` state object and the actual datasource are not tightly coupled. Then, if the user does the above and we make the `PUT` call, we're passing in the `datasource` state object, where `datasource.settings = {}`.

Within the `putDatasource` method, we're checking if `settings` exists, and an empty object evaluates to true in Javascript, so we're then overriding the existing datasource's settings object with the empty object.

### The Fix
Now, rather than only building the datasource's settings object when doing the POST call, we're doing it right beforehand, and passing the `newValue` as the body of the request, and also updating the `datasource` state object, so now, the two are equal.


### Potential other fixes
Rather than the solution above, we could do a few things.

1. We can update the POST request to return the entire datasource object, not just the ID, and upon a successful call, we can set the `datasource` state object to the returned datasource, tightly coupling the two.
2. On the PUT request, we can do shallow or deep comparison and only update the datasource settings object if something has actually changed. I don't recommend this as the object contains nested objects and arrays which would get really gnarly, really quickly.

### Testing

- [ ] Create a new Segment datasource and go to the second page, before clicking the "back" button. Confirm in Mongo that the datasource.settings object is not an empty object.
- [ ] Then, click the "next" button in the UI and again, go to Mongo and ensure the datasource.settings object is not an empty object.
- [ ] Create other datasources of different types and ensure no regressions are introduced

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
