### PR TITLE
allow unarchiving experiment (and deleting archived exp)

### DIFF
--- a/packages/front-end/components/Experiment/SinglePage.tsx
+++ b/packages/front-end/components/Experiment/SinglePage.tsx
@@ -317,9 +317,8 @@ export default function SinglePage({
     mutate();
   };
 
-  const canEditExperiment =
-    !experiment.archived &&
-    permissions.check("createAnalyses", experiment.project);
+  const canCreateAnalyses = permissions.check("createAnalyses", project);
+  const canEditExperiment = !experiment.archived && canCreateAnalyses;
 
   const hasVisualEditorFeature = hasCommercialFeature("visual-editor");
   const hasVisualEditorPermission =
@@ -508,7 +507,7 @@ export default function SinglePage({
                 Archive
               </button>
             )}
-            {canRunExperiment && (
+            {canCreateAnalyses && experiment.archived && (
               <button
                 className="dropdown-item"
                 onClick={async (e) => {
@@ -526,7 +525,7 @@ export default function SinglePage({
                 Unarchive
               </button>
             )}
-            {canRunExperiment && (
+            {canCreateAnalyses && (
               <DeleteButton
                 className="dropdown-item text-danger"
                 useIcon={false}


### PR DESCRIPTION
### Features and Changes

Unarchiving (and deleting) was not showing on the "more" dropdown on archived experiment pages.


### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

<!--
  Please describe how to test these changes.
 -->

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
