### PR TITLE
More Mongo mappings

### DIFF
--- a/packages/back-end/src/util/mongo.util.ts
+++ b/packages/back-end/src/util/mongo.util.ts
@@ -41,7 +41,6 @@ export const getConnectionStringWithDeprecatedKeysMigratedForV3to4 = (
     "secondaryAcceptableLatencyMS",
     "acceptableLatencyMS",
     "connectWithNoPrimary",
-    "j",
     "domainsEnabled",
     "bufferMaxEntries",
   ];
@@ -50,9 +49,14 @@ export const getConnectionStringWithDeprecatedKeysMigratedForV3to4 = (
     tlsinsecure: "tlsInsecure",
 
     /**
-     * @deprecated
+     * @deprecated use WriteConcern
      */
     wtimeout: "wtimeoutMS",
+
+    /**
+     * @deprecated use WriteConcern
+     */
+    j: "journal",
 
     appname: "appName",
   };

--- a/packages/back-end/src/util/mongo.util.ts
+++ b/packages/back-end/src/util/mongo.util.ts
@@ -45,6 +45,7 @@ export const getConnectionStringWithDeprecatedKeysMigratedForV3to4 = (
     "bufferMaxEntries",
   ];
   const v3to4Mappings: Record<string, string> = {
+    minSize: "minPoolSize",
     poolSize: "maxPoolSize",
     tlsinsecure: "tlsInsecure",
 

--- a/packages/back-end/src/util/mongo.util.ts
+++ b/packages/back-end/src/util/mongo.util.ts
@@ -22,7 +22,6 @@
  *  - acceptableLatencyMS: is no longer documented. Possibly related: maxStalenessSeconds
  *  - connectWithNoPrimary: is no longer documented
  *  - w: still exists but is marked as deprecated -> writeConcern (incompatible types)
- *  - j: is no longer documented (journal write concern). -> writeConcern (incompatible types)
  *  - domainsEnabled: is no longer documented
  *  - bufferMaxEntries: is no longer documented
  *  - promiseLibrary: still exists but is marked as deprecated.


### PR DESCRIPTION
Adds some more mappings:

- `j` to deprecated `journal` though `WriteConcern` is the recommended migration path
- undocumented `minSize` to `minPoolSize`