### PR TITLE
add env var for API rate limit max

### DIFF
--- a/packages/back-end/src/api/api.router.ts
+++ b/packages/back-end/src/api/api.router.ts
@@ -43,15 +43,18 @@ router.use(bodyParser.urlencoded({ limit: "1mb", extended: true }));
 
 router.use(authenticateApiRequestMiddleware);
 
+const API_RATE_LIMIT_MAX = Number(process.env.API_RATE_LIMIT_MAX) || 60;
 // Rate limit API keys to 60 requests per minute
 router.use(
   rateLimit({
     windowMs: 60 * 1000,
-    max: 60,
+    max: API_RATE_LIMIT_MAX,
     standardHeaders: true,
     legacyHeaders: false,
     keyGenerator: (req: Request & ApiRequestLocals) => req.apiKey,
-    message: { message: "Too many requests, limit to 60 per minute" },
+    message: {
+      message: `Too many requests, limit to ${API_RATE_LIMIT_MAX} per minute`,
+    },
   })
 );
 


### PR DESCRIPTION
### Features and Changes

Adds an environment variable to allow configuring API rate limit max

### Dependencies

N/A

### Testing

1. Run locally w/ `yarn:dev`
2. Login & create API key
3. run something like `time while true do; curl ...; done` in a loop on any API endpoint to see rate limiting occuring after some time
4. set API_RATE_LIMIT_MAX env var and restart backend app
5. repeat step 3 and see that it takes... longer :)

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
