### PR TITLE
[stats] Fix idtype join for RA metrics

### DIFF
--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -1235,7 +1235,7 @@ export default abstract class SqlIntegration
         isRegressionAdjusted
           ? `
           LEFT JOIN __userCovariateMetric c
-          ON (c.user_id = m.user_id)
+          ON (c.${baseIdType} = m.${baseIdType})
           `
           : ""
       }


### PR DESCRIPTION
### Features and Changes

Mistakenly hardcoded `user_id` instead of `baseIdType` for the RA join.

### Testing

Test integration queries don't change at all (as all use user_id, should fix later)