### PR TITLE
[stats] Re-enable non-numeric `value` columns; enable RA for custom agg

### DIFF
--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -830,8 +830,7 @@ export default abstract class SqlIntegration
       settings.regressionAdjustmentEnabled &&
       (metric.regressionAdjustmentDays ?? 0) > 0 &&
       !!metric.regressionAdjustmentEnabled &&
-      !isRatio &&
-      !metric.aggregation;
+      !isRatio;
 
     const regressionAdjustmentHours = isRegressionAdjusted
       ? (metric.regressionAdjustmentDays ?? 0) * 24
@@ -1851,9 +1850,7 @@ export default abstract class SqlIntegration
           cumulativeDate ? `AND ${this.dateTrunc("m.timestamp")} <= dr.day` : ""
         }
       `,
-      // The coalesce treats conversions that exist but have a NULL `value` as 0,
-      // reserving NULL for users with no matching metric rows in conversion window
-      `COALESCE(${col}, 0)`,
+      `${col}`,
       `NULL`
     )}`;
   }
@@ -1868,13 +1865,12 @@ export default abstract class SqlIntegration
     if (this.getMetricQueryFormat(metric) === "sql") {
       // Custom aggregation that's a hardcoded number (e.g. "1")
       if (metric.aggregation && Number(metric.aggregation)) {
-        // If value is NULL than user reliably has no conversion rows in the window
+        // Note that if user has conversion row but value IS NULL, this will
+        // return 0 for that user rather than `metric.aggregation`
         return this.ifElse("value IS NOT NULL", metric.aggregation, "0");
       }
       // Other custom aggregation
       else if (metric.aggregation) {
-        // prePostTimeFilter (and regression adjustment) not implemented for
-        // custom aggregate metrics
         return this.capValue(
           metric.cap,
           replaceCountStar(metric.aggregation, `value`)

--- a/packages/back-end/test/integrations/metrics.json
+++ b/packages/back-end/test/integrations/metrics.json
@@ -28,6 +28,13 @@
     "sql": "SELECT\nuserId as user_id,\ntimestamp as timestamp,\namount as value\nFROM orders"
   },
   {
+    "id": "nonbinom__count_distinct_date",
+    "type": "count",
+    "ignoreNulls": false,
+    "aggregation": "COUNT(DISTINCT value)",
+    "sql": "SELECT\nuserId as user_id,\ntimestamp as timestamp,\nCAST(timestamp AS DATE) as value\nFROM orders"
+  },
+  {
     "id": "binomial__any_item_in_cart",
     "type": "binomial",
     "ignoreNulls": false,

--- a/packages/back-end/test/sqlintegration.test.ts
+++ b/packages/back-end/test/sqlintegration.test.ts
@@ -56,7 +56,7 @@ describe("bigquery integration", () => {
         " "
       )
     ).toEqual(
-      "(CASE WHEN m.timestamp >= d.conversion_start AND m.timestamp <= d.conversion_end THEN COALESCE(val, 0) ELSE NULL END)"
+      "(CASE WHEN m.timestamp >= d.conversion_start AND m.timestamp <= d.conversion_end THEN val ELSE NULL END)"
     );
 
     expect(
@@ -65,7 +65,7 @@ describe("bigquery integration", () => {
         " "
       )
     ).toEqual(
-      "(CASE WHEN m.timestamp >= d.conversion_start THEN COALESCE(val, 0) ELSE NULL END)"
+      "(CASE WHEN m.timestamp >= d.conversion_start THEN val ELSE NULL END)"
     );
 
     expect(
@@ -74,7 +74,7 @@ describe("bigquery integration", () => {
         " "
       )
     ).toEqual(
-      "(CASE WHEN m.timestamp >= d.conversion_start AND date_trunc(m.timestamp, DAY) <= dr.day THEN COALESCE(val, 0) ELSE NULL END)"
+      "(CASE WHEN m.timestamp >= d.conversion_start AND date_trunc(m.timestamp, DAY) <= dr.day THEN val ELSE NULL END)"
     );
 
     expect(

--- a/packages/front-end/components/Metrics/MetricForm/index.tsx
+++ b/packages/front-end/components/Metrics/MetricForm/index.tsx
@@ -283,6 +283,7 @@ const MetricForm: FC<MetricFormProps> = ({
     userIdColumns: form.watch("userIdColumns"),
     userIdTypes: form.watch("userIdTypes"),
     denominator: form.watch("denominator"),
+    aggregation: form.watch("aggregation"),
     column: form.watch("column"),
     table: form.watch("table"),
     type,
@@ -358,12 +359,6 @@ const MetricForm: FC<MetricFormProps> = ({
       );
     }
   }
-  if (form.watch("aggregation")) {
-    regressionAdjustmentAvailableForMetric = false;
-    regressionAdjustmentAvailableForMetricReason = (
-      <>Not available for metrics with custom aggregations.</>
-    );
-  }
 
   let table = "Table";
   let column = "Column";
@@ -435,6 +430,10 @@ const MetricForm: FC<MetricFormProps> = ({
       : value.regressionAdjustmentDays < 7
       ? "Lookback periods under 7 days tend not to capture enough metric data to reduce variance and may be subject to weekly seasonality"
       : "";
+
+  const customAggregationWarningMsg = value.aggregation
+    ? "When using a custom aggregation, it is safest to COALESCE values in your SQL so that the `value` column has no NULL values."
+    : "";
 
   const requiredColumns = useMemo(() => {
     const set = new Set(["timestamp", ...value.userIdTypes]);
@@ -676,14 +675,21 @@ const MetricForm: FC<MetricFormProps> = ({
                     </div>
                   </div>
                   {value.type !== "binomial" && (
-                    <Field
-                      label="User Value Aggregation"
-                      placeholder="SUM(value)"
-                      textarea
-                      minRows={1}
-                      {...form.register("aggregation")}
-                      helpText="When there are multiple metric rows for a user"
-                    />
+                    <div className="mb-2">
+                      <Field
+                        label="User Value Aggregation"
+                        placeholder="SUM(value)"
+                        textarea
+                        minRows={1}
+                        className="mb-2"
+                        containerClassName="mb-0"
+                        {...form.register("aggregation")}
+                        helpText="When there are multiple metric rows for a user"
+                      />
+                      {customAggregationWarningMsg && (
+                        <small>{customAggregationWarningMsg}</small>
+                      )}
+                    </div>
                   )}
                   <SelectField
                     label="Denominator"

--- a/packages/front-end/components/Metrics/MetricForm/index.tsx
+++ b/packages/front-end/components/Metrics/MetricForm/index.tsx
@@ -681,7 +681,6 @@ const MetricForm: FC<MetricFormProps> = ({
                         placeholder="SUM(value)"
                         textarea
                         minRows={1}
-                        className="mb-2"
                         containerClassName="mb-0"
                         {...form.register("aggregation")}
                         helpText="When there are multiple metric rows for a user"


### PR DESCRIPTION
### Features and Changes

* Removes coalesce introduced by #1334 to allow for non-numeric `value` columns.
* This does change how `NULL` values in the `value` column are treated by aggregation, so add some warning text to the Metric Form encouraging people to not pass `NULL` values.
* Also, #1334 allows custom aggregations to work with regression adjustment, so this turns RA on for those metrics.

Now if there is `NULL` in the `value` column, these rows will be treated the same as a user who had no conversions in the conversion window.

### Dependencies

n/a

### Testing

Re-ran integration query tester:
* non-value queries now execute
* the `nonbinom_custom*_regressionadjusted` test metric now has `covariate_sum*` columns with appropriate values
* the new `nonbinom__count_distinct_date` test metric uses `date` as the value column, the query executes, and it produces reasonable values

### Screenshots

Metric form updates look reasonable: https://www.loom.com/share/1d25bce4107c458197b201e7a503b880