### PR TITLE
Only show join table div if datasource has more than 1 identifier types

### DIFF
--- a/packages/front-end/pages/datasources/[did].tsx
+++ b/packages/front-end/pages/datasources/[did].tsx
@@ -291,14 +291,16 @@ mixpanel.init('YOUR PROJECT TOKEN', {
                 />
               </div>
 
-              <div className="my-3 p-3 rounded border bg-white">
-                <DataSourceInlineEditIdentityJoins
-                  dataSource={d}
-                  onSave={updateDataSourceSettings}
-                  onCancel={() => undefined}
-                  canEdit={canEdit}
-                />
-              </div>
+              {d.settings?.userIdTypes && d.settings.userIdTypes.length > 1 ? (
+                <div className="my-3 p-3 rounded border bg-white">
+                  <DataSourceInlineEditIdentityJoins
+                    dataSource={d}
+                    onSave={updateDataSourceSettings}
+                    onCancel={() => undefined}
+                    canEdit={canEdit}
+                  />
+                </div>
+              ) : null}
 
               <div className="my-3 p-3 rounded border bg-white">
                 <ExperimentAssignmentQueries


### PR DESCRIPTION
### Features and Changes

This PR introduces a quick fix to hide the `Identifier Joins` wrapper when a datasource has a single identifier type. I didn't realize until after pushing this [PR](https://github.com/growthbook/growthbook/pull/1412) that MySql datasource's were only pre-populated with a singular identifier type, resulting in an empty div.

### Testing

- [ x ] create an MySQL datasource and ensure that with the updated code, so long as there is a single identifier type, we don't show the identifier type join div.
- [ x ] ensure that datasources that have more than a singular identifier type have the identity joins div, regardless of how many identity join queries they have

### Screenshots

Before
<img width="1045" alt="Screen Shot 2023-07-10 at 10 10 18 AM" src="https://github.com/growthbook/growthbook/assets/75274610/c33f87e6-7793-4dc7-afef-307dec04b2f8">

After
<img width="1045" alt="Screen Shot 2023-07-10 at 10 11 22 AM" src="https://github.com/growthbook/growthbook/assets/75274610/85ad4aa5-ba10-46a0-9639-11c7234f2e3d">

### Other potential resolutions
- We can instead always render the section, but include a note that in order to build a join, you need multiple identifier types. I don't prefer that method as it takes up valuable real estate forever in the event an org never wants to add a second identifier type. The current implementation also matches the UX previous to the commit above being merged in - we didn't display anything about identity joins until there were multiple identifier types.

