### PR TITLE
yarn clean - minor fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lint:ci": "eslint './**/*.{ts,tsx,js,jsx}' --max-warnings 0 --cache --cache-strategy content",
     "pretty": "prettier --write ./**/*.{json,css,scss,md,mdx}",
     "type-check": "wsrun -m type-check",
-    "clean": "rm -rf node_modules && rm -rf packages/front-end/node_modules && rm packages/front-end/tsconfig.tsbuildinfo && rm -rf packages/back-end/node_modules && rm -rf packages/sdk-js/node_modules && rm -rf packages/sdk-react/node_modules && rm -rf packages/shared/node_modules && yarn cache clean",
+    "clean": "rm -rf node_modules && rm -rf packages/front-end/node_modules && rm -f packages/front-end/tsconfig.tsbuildinfo && rm -rf packages/back-end/node_modules && rm -rf packages/sdk-js/node_modules && rm -rf packages/sdk-react/node_modules && rm -rf packages/shared/node_modules && yarn cache clean",
     "unused-export-check": "wsrun -m unused-export-check",
     "test": "wsrun -m test",
     "dev:apps": "wsrun -p 'back-end' -p 'front-end' -p 'shared' -c dev",


### PR DESCRIPTION
Minor fix to our `yarn clean` command

If a developer tried to run `yarn clean` without a `.tsbuildinfo` file in their front-end directory (which can happen on a fresh copy of the codebase that hasn't been compiled yet), the command fails.

This appends the force flag (`-f`) to `rm` so that it does ignores if the file is missing