### PR TITLE
Add GrowthBook label to BigQuery query jobs

### DIFF
--- a/docs/docs/warehouses/bigquery.mdx
+++ b/docs/docs/warehouses/bigquery.mdx
@@ -108,3 +108,9 @@ project name, and when expanded, find the dataset which has your experiment expo
 />
 
 When you click save, GrowthBook will test the connection to make sure the credentials are correct. If the connection is successful, you should see a success message on the next page.
+
+## Monitoring GrowthBook query cost
+
+Whenever we query your BigQuery database we add `{ integration: "growthbook" }` as a label to the query job to make it easy for you to monitor cost or filter GrowthBook query jobs by label for other use cases.
+
+Read more about how to [group by label value for a specific key here.](https://cloud.google.com/billing/docs/how-to/bq-examples#group_by_label_value_for_a_specific_key)

--- a/packages/back-end/src/integrations/BigQuery.ts
+++ b/packages/back-end/src/integrations/BigQuery.ts
@@ -42,6 +42,7 @@ export default class BigQuery extends SqlIntegration {
     const client = this.getClient();
 
     const [job] = await client.createQueryJob({
+      labels: { integration: "growthbook" },
       query: sql,
       useLegacySql: false,
     });


### PR DESCRIPTION
### Features and Changes

- Adds a  `{ integration: "growthbook" }` label to BigQuery query jobs to make it easy for users to monitor the cost of GrowthBook queries.

- Updates docs to include details about the label and how to use it.

- Closes #1399 

### Testing

Connect GrowthBook to the BigQuery sample database and validate that the label is being added as expected to GrowthBook query jobs.

Tested using two queries:

1. Added BQ as a custom data source triggering a query
2. Imported sample data triggering another query

Verified the I could see the executed queries with their labels via BQ console using:
```
SELECT
  query,
  labels
FROM
  `region-us`.INFORMATION_SCHEMA.JOBS
CROSS JOIN UNNEST(labels) as labels
WHERE labels.key = 'integration';
```

![Query results](https://github.com/growthbook/growthbook/assets/14947905/9bd8b916-743d-4368-b84e-9c5248d4cdb2)

### Screenshots

![Capture-2023-07-11-160537](https://github.com/growthbook/growthbook/assets/14947905/0d068540-f299-4a9d-a71e-ea2d07f1ce13)