### PR TITLE
[Feat] Sticky column headers for features list (#1454)

### DIFF
--- a/packages/front-end/pages/features/index.tsx
+++ b/packages/front-end/pages/features/index.tsx
@@ -237,7 +237,7 @@ export default function FeaturesPage() {
           </div>
 
           <table className="table gbtable table-hover appbox">
-            <thead>
+            <thead className = "sticky-top bg-white shadow-sm z-index-100"style={{ top: "56px"}}>
               <tr>
                 <th></th>
                 <SortableTH field="id">Feature Key</SortableTH>


### PR DESCRIPTION
### Features and Changes

- Made the position of column headers in the features list sticky.
- When more than 7 features are added, the column names are scrollable and can now be seen even when overlapped by the navbar.
- Applied CSS changes to packages/front-end/pages/features/index.tsx to make the column headers sticky just before the navbar.

Fixes #1454

- Closes **https://github.com/growthbook/growthbook/issues/1454**

### Dependencies
None 

### Testing

To test these changes, follow these steps:
1. Go to the homepage.
2. Add a project.
3. Navigate to the "Features" section from the left-hand side.
4. Add 8 or more features.
5. Scroll down and observe that the column headers remain sticky.
6. Screenshots have been included to provide visual documentation for this pull request.

### Screenshots


when adding more features :
![Screenshot 2023-07-18 052415](https://github.com/growthbook/growthbook/assets/126576749/d3c8e328-19e3-4802-9a15-1e1136f31a17)
after scrolling : 
![Screenshot 2023-07-18 052448](https://github.com/growthbook/growthbook/assets/126576749/5a181c83-dd89-41d0-9fbd-ca5d89cf82b1)


