### PR TITLE
Make bigQueryFileInput a required field

### DIFF
--- a/packages/front-end/components/Settings/BigQueryForm.tsx
+++ b/packages/front-end/components/Settings/BigQueryForm.tsx
@@ -40,6 +40,7 @@ const BigQueryForm: FC<{
             <div className="custom-file">
               <input
                 type="file"
+                required
                 className="custom-file-input"
                 id="bigQueryFileInput"
                 accept="application/json"


### PR DESCRIPTION
### Features and Changes

Very simple PR that makes the `bigQueryFileInput` input field within `BigQueryForm` a required field so if a user attempts to submit the form without adding a service account json key, rather than giving them a weird error message, it just blocks the form submission and calls out that the field is required.

- Closes **([1451](https://github.com/growthbook/growthbook/issues/1451))**

### Testing
- [x] Attempt to add a BigQuery datasource via the JSON key file method, but don't actually attach a json key, and ensure the form doesn't submit and calls out that the json key file is required.
- [x] Do the same, but this time, add a json key file and ensure it saves and connects as normal
- [x] Now, go create another BigQuery datasource, but this time use the auto discover method, and ensure that you can submit the form without the JSON key file and no error is thrown related to not having the JSON key file.

### Screenshots
<img width="818" alt="Screen Shot 2023-07-20 at 2 05 17 PM" src="https://github.com/growthbook/growthbook/assets/75274610/4a268d8d-a232-4d13-8bae-74d2f42bfed5">

OLD EXPERIENCE
<img width="811" alt="Screen Shot 2023-07-20 at 2 05 45 PM" src="https://github.com/growthbook/growthbook/assets/75274610/e07dbeae-e82b-42d5-8735-925d6443a566">

