### PR TITLE
Add better warning message

### DIFF
--- a/packages/front-end/components/Features/AttributeModal.tsx
+++ b/packages/front-end/components/Features/AttributeModal.tsx
@@ -186,7 +186,9 @@ export default function AttributeModal({ close, attribute }: Props) {
             <div className="alert alert-warning">
               <strong>Warning:</strong> Version string attributes are only
               supported in the latest Javascript and React SDK versions. Other
-              language support is coming soon.
+              language support is coming soon. Do not use this format if you are
+              using an older SDK version or a different language as it will
+              break any filtering based on the attribute.
             </div>
           )}
         </>


### PR DESCRIPTION
### Features and Changes

Add a better warning message for using the version string format.
This was inspired by James Billingham: https://growthbookusers.slack.com/archives/C01T6Q0TEG3/p1690329200317749

### Testing
Create a string attribute with a version string format.  See the new error message

### Screenshots
<img width="504" alt="Screenshot 2023-07-26 at 11 49 26 AM" src="https://github.com/growthbook/growthbook/assets/950231/9dcaab6b-f031-449a-a8d3-5b418f3b64f5">
