### PR TITLE
Add defaultDataSource to org settings

### DIFF
--- a/packages/back-end/src/controllers/datasources.ts
+++ b/packages/back-end/src/controllers/datasources.ts
@@ -290,7 +290,7 @@ export async function deleteDataSource(
 
   if (org.settings?.defaultDataSource === datasource.id) {
     throw new Error(
-      "Error: This is the default data source for your organization. You must select a new default data source before deleting this one."
+      "Error: This is the default data source for your organization. You must select a new default data source in your Organization Settings before deleting this one."
     );
   }
 

--- a/packages/back-end/src/controllers/datasources.ts
+++ b/packages/back-end/src/controllers/datasources.ts
@@ -255,6 +255,13 @@ export async function deleteDataSource(
     datasource?.projects?.length ? datasource.projects : ""
   );
 
+  // Make sure this data source isn't the organizations default
+  if (org.settings?.defaultDataSource === datasource.id) {
+    throw new Error(
+      "Error: This is the default data source for your organization. You must select a new default data source in your Organization Settings before deleting this one."
+    );
+  }
+
   // Make sure there are no metrics
   const metrics = await getMetricsByDatasource(
     datasource.id,
@@ -285,12 +292,6 @@ export async function deleteDataSource(
   if (dimensions.length > 0) {
     throw new Error(
       "Error: Please delete all dimensions tied to this datasource first."
-    );
-  }
-
-  if (org.settings?.defaultDataSource === datasource.id) {
-    throw new Error(
-      "Error: This is the default data source for your organization. You must select a new default data source in your Organization Settings before deleting this one."
     );
   }
 

--- a/packages/back-end/src/controllers/datasources.ts
+++ b/packages/back-end/src/controllers/datasources.ts
@@ -288,6 +288,12 @@ export async function deleteDataSource(
     );
   }
 
+  if (org.settings?.defaultDataSource === datasource.id) {
+    throw new Error(
+      "Error: This is the default data source for your organization. You must select a new default data source before deleting this one."
+    );
+  }
+
   await deleteDatasourceById(datasource.id, org.id);
 
   if (datasource.settings?.informationSchemaId) {

--- a/packages/back-end/types/organization.d.ts
+++ b/packages/back-end/types/organization.d.ts
@@ -162,6 +162,7 @@ export interface OrganizationSettings {
   displayCurrency?: string;
   secureAttributeSalt?: string;
   killswitchConfirmation?: boolean;
+  defaultDataSource?: string;
 }
 
 export interface SubscriptionQuote {

--- a/packages/front-end/components/Experiment/ImportExperimentList.tsx
+++ b/packages/front-end/components/Experiment/ImportExperimentList.tsx
@@ -54,7 +54,7 @@ const ImportExperimentList: FC<{
     }),
     [datasource]
   );
-  const { pastExperimentsMinLength } = useOrgSettings();
+  const { pastExperimentsMinLength, defaultDataSource } = useOrgSettings();
 
   const [minUsersFilter, setMinUsersFilter] = useState("100");
   const [minLengthFilter, setMinLengthFilter] = useState(
@@ -139,10 +139,15 @@ const ImportExperimentList: FC<{
           {changeDatasource && supportedDatasources.length > 1 ? (
             <SelectField
               value={data.experiments.datasource}
-              options={supportedDatasources.map((d) => ({
-                value: d.id,
-                label: `${d.name}${d.description ? ` — ${d.description}` : ""}`,
-              }))}
+              options={supportedDatasources.map((d) => {
+                const isDefaultDataSource = d.id === defaultDataSource;
+                return {
+                  value: d.id,
+                  label: `${d.name}${
+                    d.description ? ` — ${d.description}` : ""
+                  } ${isDefaultDataSource ? " (default)" : ""}`,
+                };
+              })}
               className="portal-overflow-ellipsis"
               onChange={changeDatasource}
             />

--- a/packages/front-end/components/Experiment/ImportExperimentModal.tsx
+++ b/packages/front-end/components/Experiment/ImportExperimentModal.tsx
@@ -2,6 +2,7 @@ import { FC, useEffect, useState } from "react";
 import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import { useAuth } from "@/services/auth";
+import useOrgSettings from "@/hooks/useOrgSettings";
 import Modal from "../Modal";
 import ImportExperimentList from "./ImportExperimentList";
 import NewExperimentForm from "./NewExperimentForm";
@@ -19,6 +20,7 @@ const ImportExperimentModal: FC<{
   source,
   fromFeature = false,
 }) => {
+  const settings = useOrgSettings();
   const { datasources } = useDefinitions();
   const [
     selected,
@@ -29,6 +31,13 @@ const ImportExperimentModal: FC<{
   const [importModal, setImportModal] = useState<boolean>(importMode);
   const [datasourceId, setDatasourceId] = useState(() => {
     if (!datasources) return null;
+    if (
+      settings?.defaultDataSource &&
+      datasources.find((d) => d.id === settings.defaultDataSource)?.properties
+        ?.pastExperiments
+    ) {
+      return settings.defaultDataSource;
+    }
     return (
       datasources.filter((d) => d?.properties?.pastExperiments)?.[0]?.id ?? null
     );

--- a/packages/front-end/components/Experiment/NewExperimentForm.tsx
+++ b/packages/front-end/components/Experiment/NewExperimentForm.tsx
@@ -108,7 +108,10 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
     defaultValues: {
       project: initialValue?.project || project || "",
       trackingKey: initialValue?.trackingKey || "",
-      datasource: initialValue?.datasource || datasources?.[0]?.id || "",
+      datasource:
+        initialValue?.datasource || settings.defaultDataSource
+          ? settings.defaultDataSource
+          : datasources?.[0]?.id || "",
       exposureQueryId:
         getExposureQuery(
           initialValue?.datasource
@@ -416,10 +419,15 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
               value={form.watch("datasource") ?? ""}
               onChange={(v) => form.setValue("datasource", v)}
               initialOption="Manual"
-              options={datasources.map((d) => ({
-                value: d.id,
-                label: `${d.name}${d.description ? ` — ${d.description}` : ""}`,
-              }))}
+              options={datasources.map((d) => {
+                const isDefaultDataSource = d.id === settings.defaultDataSource;
+                return {
+                  value: d.id,
+                  label: `${d.name}${
+                    d.description ? ` — ${d.description}` : ""
+                  }${isDefaultDataSource ? " (default)" : ""}`,
+                };
+              })}
               className="portal-overflow-ellipsis"
             />
           )}

--- a/packages/front-end/components/Forms/SelectField.tsx
+++ b/packages/front-end/components/Forms/SelectField.tsx
@@ -81,6 +81,7 @@ const SelectField: FC<
     createable?: boolean;
     formatOptionLabel?: (value: SingleValue) => ReactNode;
     isSearchable?: boolean;
+    isClearable?: boolean;
   }
 > = ({
   value,
@@ -97,6 +98,7 @@ const SelectField: FC<
   createable = false,
   formatOptionLabel,
   isSearchable = true,
+  isClearable = false,
   ...otherProps
 }) => {
   const [map, sorted] = useSelectOptions(options, initialOption, sort);
@@ -200,6 +202,7 @@ const SelectField: FC<
                 {...ReactSelectProps}
                 id={id}
                 ref={ref}
+                isClearable={isClearable}
                 classNamePrefix="gb-select"
                 isDisabled={disabled || false}
                 options={sorted}

--- a/packages/front-end/components/Metrics/MetricForm/index.tsx
+++ b/packages/front-end/components/Metrics/MetricForm/index.tsx
@@ -234,8 +234,11 @@ const MetricForm: FC<MetricFormProps> = ({
   const form = useForm({
     defaultValues: {
       datasource:
-        ("datasource" in current ? current.datasource : datasources[0]?.id) ||
-        "",
+        ("datasource" in current
+          ? current.datasource
+          : settings.defaultDataSource
+          ? settings.defaultDataSource
+          : datasources[0]?.id) || "",
       name: current.name || "",
       description: current.description || "",
       type: current.type || "binomial",
@@ -595,10 +598,15 @@ const MetricForm: FC<MetricFormProps> = ({
             label="Data Source"
             value={value.datasource || ""}
             onChange={(v) => form.setValue("datasource", v)}
-            options={(datasources || []).map((d) => ({
-              value: d.id,
-              label: `${d.name}${d.description ? ` — ${d.description}` : ""}`,
-            }))}
+            options={(datasources || []).map((d) => {
+              const defaultDatasource = d.id === settings.defaultDataSource;
+              return {
+                value: d.id,
+                label: `${d.name}${
+                  d.description ? ` — ${d.description}` : ""
+                } ${defaultDatasource ? " (default)" : ""}`,
+              };
+            })}
             className="portal-overflow-ellipsis"
             name="datasource"
             initialOption="Manual"

--- a/packages/front-end/pages/settings/index.tsx
+++ b/packages/front-end/pages/settings/index.tsx
@@ -1414,6 +1414,7 @@ const GeneralSettingsPage = (): React.ReactElement => {
                     onChange={(v: string) =>
                       form.setValue("defaultDataSource", v)
                     }
+                    isClearable={true}
                     placeholder="Select a data source..."
                     helpText="The default data source is the default data source selected when creating metrics and experiments."
                   />

--- a/packages/front-end/pages/settings/index.tsx
+++ b/packages/front-end/pages/settings/index.tsx
@@ -48,6 +48,7 @@ import ControlledTabs from "@/components/Tabs/ControlledTabs";
 import StatsEngineSelect from "@/components/Settings/forms/StatsEngineSelect";
 import { useCurrency } from "@/hooks/useCurrency";
 import { AppFeatures } from "@/types/app-features";
+import { useDefinitions } from "@/services/DefinitionsContext";
 
 export const supportedCurrencies = {
   AED: "UAE Dirham (AED)",
@@ -248,6 +249,7 @@ const GeneralSettingsPage = (): React.ReactElement => {
   );
   const displayCurrency = useCurrency();
   const growthbook = useGrowthBook<AppFeatures>();
+  const { datasources } = useDefinitions();
 
   const currencyOptions = Object.entries(
     supportedCurrencies
@@ -319,6 +321,7 @@ const GeneralSettingsPage = (): React.ReactElement => {
       displayCurrency,
       secureAttributeSalt: "",
       killswitchConfirmation: false,
+      defaultDataSource: settings.defaultDataSource || "",
     },
   });
   const { apiCall } = useAuth();
@@ -354,6 +357,7 @@ const GeneralSettingsPage = (): React.ReactElement => {
     displayCurrency: form.watch("displayCurrency"),
     secureAttributeSalt: form.watch("secureAttributeSalt"),
     killswitchConfirmation: form.watch("killswitchConfirmation"),
+    defaultDataSource: form.watch("defaultDataSource"),
   };
 
   const [cronString, setCronString] = useState("");
@@ -1391,6 +1395,29 @@ const GeneralSettingsPage = (): React.ReactElement => {
                     }}
                   />
                 </div>
+              </div>
+            </div>
+            <div className="divider border-bottom mb-3 mt-3" />
+            <div className="row">
+              <div className="col-sm-3">
+                <h4>Data Source Settings</h4>
+              </div>
+              <div className="col-sm-9">
+                <>
+                  <SelectField
+                    label="Default Data Source (Optional)"
+                    value={form.watch("defaultDataSource") || ""}
+                    options={datasources.map((d) => ({
+                      label: d.name,
+                      value: d.id,
+                    }))}
+                    onChange={(v: string) =>
+                      form.setValue("defaultDataSource", v)
+                    }
+                    placeholder="Select a data source..."
+                    helpText="The default data source is the default data source selected when creating metrics and experiments."
+                  />
+                </>
               </div>
             </div>
           </div>


### PR DESCRIPTION
### Features and Changes

An organization reached out to us and asked if we would build logic around a `defaultDataSource`. Currently, when a user goes to create a new metric or experiment, the respective form pre-selects the first data source an organization created, and a lot of users are skipping over this field since it's pre-selected, but then there is confusion when their not able to create the metric they set out to create because they're connected to a different data source.

The solution proposed was to add a `defaultDataSource` that, if set, would be the default data source when creating metrics and experiments. We also explored simply not setting a data source on the metric and experiment modals, but that would require an extra click.

We landed on this lightweight approach.

A user can set the optional defaultDataSource via the general settings page, underneath the Metric Settings. This is currently just an org level - we're going to keep our ear to the ground if it makes sense to add a project level. Adding it now feels a bit premature.

This PR also adds a `(default)` tag next to the data source's name when displayed in the Metric and Experiment form drop-downs. The idea being a GrowthBook user can see an admin has selected this as the default.

### Dependencies


### Testing

- [x] Go to an org that doesn't have a default data source, and confirm you can set one by going to `/settings`
- [x] Ensure that when saved, the default data source persists
- [x] Ensure that if a default data source is selected, and you open the Metric Form from `/metrics` we default to the new default data source
- [x] Ensure that if not default data source is set, and you open the Metric Form from `/metrics`, the behavior stays consistent with what is currently happening - e.g. we show the first data source that comes back from the data base.
- [x] Ensure that you can clear the default data source from the `/settings` page
- [x] Ensure that if you try to delete a data source that is an orgs default, you get a warning error

### Screenshots

New section on /settings
<img width="1266" alt="Screen Shot 2023-07-27 at 10 49 12 AM" src="https://github.com/growthbook/growthbook/assets/75274610/97de1d55-0576-41f1-b8ef-3ba6ae65e113">

This input is clearable, should an org want to remove their default without selecting a new default
<img width="1264" alt="Screen Shot 2023-07-27 at 10 49 20 AM" src="https://github.com/growthbook/growthbook/assets/75274610/58294e65-77de-473a-a115-1b32cdacff14">

When creating a new metric, if no data source is provided (i.e. we're opening the form from `/metrics`) we show the default data source first, and add a `(Default)` tag to it.
<img width="815" alt="Screen Shot 2023-07-27 at 10 52 42 AM" src="https://github.com/growthbook/growthbook/assets/75274610/9f4a4e24-d1b7-4298-802e-a9989ae27ee1">

Likewise, the experience is the same when creating an experiment
<img width="1419" alt="Screen Shot 2023-07-27 at 10 52 55 AM" src="https://github.com/growthbook/growthbook/assets/75274610/59d93514-6c1f-4633-8cc4-79bef7ee6f1f">

<img width="818" alt="Screen Shot 2023-07-27 at 10 53 11 AM" src="https://github.com/growthbook/growthbook/assets/75274610/fa2a7fc6-d8ca-4e7d-b1a1-6140b61d3d7e">







