### PR TITLE
CI - Preview environments - Bump timeout

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -28,4 +28,4 @@ jobs:
        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         name: pr-${{ github.event.number }}-bttf
-        timeout: 15m
+        timeout: 30m


### PR DESCRIPTION
Our preview environments seem to consistently go over their 15m timeout.

Frequently, we will 'restart the job' but I think what happens is that it finds the pre-existing job which has finally finished, some time after 15 minutes.

We have the timeout defined in the workflow file ... This PR bumps it to 30 minutes.

This is a low risk PR - the preview env CI job is non-blocking and has no effect on our ability to deploy to prod.