### PR TITLE
SSE doc updates (build your own, Java)

### DIFF
--- a/docs/docs/lib/build-your-own.mdx
+++ b/docs/docs/lib/build-your-own.mdx
@@ -958,7 +958,7 @@ If set to "enabled", you are able to subscribe to the API for realtime changes t
 
 The URL for subscribing to changes is `{apiHost}/sub/{clientKey}`.
 
-SDK's should not attempt to subscribe to the `/sub/` endpoint unless the header `x-sse-support: enabled` is present on the `/api/features` endpoint response.
+SDKs should not attempt to subscribe to the `/sub/` endpoint unless the header `x-sse-support: enabled` is present on the `/api/features` endpoint response.
 
 An example implementation in JavaScript is below:
 
@@ -972,8 +972,8 @@ channel.addEventListener("features", (event) => {
 
 Some important things to note:
 
-- The connection will close after 60 seconds. It is expected that the SDK implements reconnect logic.
-- The response will be the same as when fetching from the `/api/features/{clientKey}` endpoint except that the `dateUpdated` property will not be present—`features` and optionally `encryptedFeatures` will be present.
+- The SDK should implement reconnect logic to support both client and server dropping the connection.
+- The response will be the same as when fetching from the `/api/features/{clientKey}` endpoint
 
 ### Encrypted Features
 

--- a/docs/docs/lib/build-your-own.mdx
+++ b/docs/docs/lib/build-your-own.mdx
@@ -956,7 +956,11 @@ The API response (`/api/features/{clientKey}`) may contain a response header:
 
 If set to "enabled", you are able to subscribe to the API for realtime changes to feature definitions by using the [GrowthBook Proxy](/self-host/proxy). This will let you update the cache immediately when a feature changes instead of waiting for the 60s TTL to expire.
 
-The URL for subscribing to changes is `{apiHost}/sub/{clientKey}`. An example implementation in Javascript is below:
+The URL for subscribing to changes is `{apiHost}/sub/{clientKey}`.
+
+SDK's should not attempt to subscribe to the `/sub/` endpoint unless the header `x-sse-support: enabled` is present on the `/api/features` endpoint response.
+
+An example implementation in JavaScript is below:
 
 ```js
 const channel = new EventSource(`${apiHost}/sub/${clientKey}`);
@@ -965,6 +969,11 @@ channel.addEventListener("features", (event) => {
   cache.set(clientKey, data.features);
 })
 ```
+
+Some important things to note:
+
+- The connection will close after 60 seconds. It is expected that the SDK implements reconnect logic.
+- The response will be the same as when fetching from the `/api/features/{clientKey}` endpoint except that the `dateUpdated` property will not be present—`features` and optionally `encryptedFeatures` will be present.
 
 ### Encrypted Features
 

--- a/docs/docs/lib/java.mdx
+++ b/docs/docs/lib/java.mdx
@@ -279,9 +279,21 @@ For more references, see the [Examples](#code-examples) below.
 
 #### Cacheing and refreshing behaviour
 
+As of version 0.9.0, there are 2 refresh strategies available.
+
+##### Stale While Revalidate
+
+This is the default strategy but can be explicitly stated by passing `FeatureRefreshStrategy.STALE_WHILE_REVALIDATE` as the refresh strategy option to the `GBFeaturesRepository` builder or constructor.
+
 The `GBFeaturesRepository` will automatically refresh the features when the features become stale. Features are considered stale every 60 seconds. This amount is configurable with the `ttlSeconds` option.
 
 When you fetch features and they are considered stale, the stale features are returned from the `getFeaturesJson()` method and a network call to refresh the features is enqueued asynchronously. When that request succeeds, the features are updated with the newest features, and the next call to `getFeaturesJson()` will return the refreshed features.
+
+##### Server-Sent Events
+
+This is a new strategy that can be enabled by passing `FeatureRefreshStrategy.SERVER_SENT_EVENTS` as the refresh strategy option to the `GBFeaturesRepository` builder or constructor.
+
+If you're using [GrowthBook Cloud <ExternalLink/>](https://app.growthbook.io), this is ready for you to use. If you are self-hosting, you will need to set up the [GrowthBook Proxy](/self-host/proxy) to enable it.
 
 ## Overriding Feature Values
 

--- a/docs/src/partials/java/_code-tabs-gbfeatures-repository.mdx
+++ b/docs/src/partials/java/_code-tabs-gbfeatures-repository.mdx
@@ -9,8 +9,10 @@ import TabItem from '@theme/TabItem'
 ```java
 GBFeaturesRepository featuresRepository = GBFeaturesRepository
     .builder()
-    .endpoint("https://cdn.growthbook.io/api/features/<environment_key>")
+    .apiHost("https://cdn.growthbook.io")
+    .clientKey("<environment_key>") // replace with your client key
     .encryptionKey("<client-key-for-decrypting>") // optional, nullable
+    .refreshStrategy(FeatureRefreshStrategy.SERVER_SENT_EVENTS) // optional; options: STALE_WHILE_REVALIDATE, SERVER_SENT_EVENTS (default: STALE_WHILE_REVALIDATE)
     .build();
 
 // Optional callback for getting updates when features are refreshed
@@ -47,7 +49,8 @@ GrowthBook growthBook = new GrowthBook(context);
 
 ```kotlin
 val featuresRepository = GBFeaturesRepository(
-    "https://cdn.growthbook.io/api/features/<environment_key>",
+    "https://cdn.growthbook.io",
+    "<environment_key>",
     "<client-key-for-decrypting>", // optional, nullable
     30,
 ).apply {


### PR DESCRIPTION
Updates SSE build-your-own docs to include info about `dateUpdated` & 1 minute disconnect.

Adds SSE configuration instructions to Java docs.
