### PR TITLE
GTM Docs - Add missing loadFeatures call

### DIFF
--- a/docs/docs/guide/google-tag-manager-and-growthbook.mdx
+++ b/docs/docs/guide/google-tag-manager-and-growthbook.mdx
@@ -73,6 +73,8 @@ In the subsequent sections, we will learn how to fill in the SDK parameters such
         }
       });
 
+      gb.loadFeatures({ autoRefresh: true });
+
       // TODO: Instrument DOM with AB test logic
     }
   })();


### PR DESCRIPTION
A user had trouble getting their SDK to run due to not having called `loadFeatures` - it was missing from the docs