### PR TITLE
Make growthbook image multi-platform

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,6 +50,7 @@ jobs:
           tags: |
             growthbook/growthbook:latest
             growthbook/growthbook:git-${{ steps.metadata.outputs.sha }}
+          platforms: linux/amd64,linux/arm64
 
   # Deploy the back-end for GrowthBook Cloud
   prod:
@@ -65,5 +66,4 @@ jobs:
           aws-region: us-east-1
 
       - name: Deploy docker image to ECS for GrowthBook Cloud API
-        run:
-          aws ecs update-service --cluster prod-api --service prod-api --force-new-deployment --region us-east-1
+        run: aws ecs update-service --cluster prod-api --service prod-api --force-new-deployment --region us-east-1


### PR DESCRIPTION
### Features and Changes

According to https://github.com/depot/build-push-action `platforms` takes a csv list of platforms to build for.  And according to https://depot.dev/docs/guides/arm-containers#what-about-multi-platformmulti-architecture-containers depot can create a multi-platform image with zero emulation.  This should hopefully then allow our same docker compose file to work whether it is on Apple Silicon or not.

### Testing

As this only gets triggered during the deploy process we will just have to watch the deploy and try out `docker-compose up -d` on Apple Silicon as soon as it is done and be ready to revert if it doesn't work.
