### PR TITLE
Remove mongoose model exports for AuditModel and WatchModel and refactor

### DIFF
--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -11,8 +11,6 @@ import { AuthRequest, ResponseWithStatusAndError } from "../types/AuthRequest";
 import {
   createManualSnapshot,
   createSnapshot,
-  ensureWatching,
-  getExperimentWatchers,
   getManualSnapshotData,
 } from "../services/experiments";
 import { MetricStats } from "../../types/metric";
@@ -85,6 +83,7 @@ import { EventAuditUserForResponseLocals } from "../events/event-types";
 import { findProjectById } from "../models/ProjectModel";
 import { ExperimentResultsQueryRunner } from "../queryRunners/ExperimentResultsQueryRunner";
 import { PastExperimentsQueryRunner } from "../queryRunners/PastExperimentsQueryRunner";
+import { getExperimentWatchers, upsertWatch } from "../models/WatchModel";
 
 export async function getExperiments(
   req: AuthRequest<
@@ -605,7 +604,7 @@ export async function postExperiments(
       details: auditDetailsCreate(experiment),
     });
 
-    await ensureWatching(userId, org.id, experiment.id, "experiments");
+    await upsertWatch(userId, org.id, experiment.id, "experiments");
 
     res.status(200).json({
       status: 200,
@@ -853,7 +852,7 @@ export async function postExperiment(
   // If there are new tags to add
   await addTagsDiff(org.id, experiment.tags || [], data.tags || []);
 
-  await ensureWatching(userId, org.id, experiment.id, "experiments");
+  await upsertWatch(userId, org.id, experiment.id, "experiments");
 
   res.status(200).json({
     status: 200,
@@ -1369,7 +1368,7 @@ export async function postExperimentPhase(
       details: auditDetailsUpdate(experiment, updated),
     });
 
-    await ensureWatching(userId, org.id, experiment.id, "experiments");
+    await upsertWatch(userId, org.id, experiment.id, "experiments");
 
     res.status(200).json({
       status: 200,
@@ -1860,7 +1859,7 @@ export async function addScreenshot(
     }),
   });
 
-  await ensureWatching(userId, org.id, experiment.id, "experiments");
+  await upsertWatch(userId, org.id, experiment.id, "experiments");
 
   res.status(200).json({
     status: 200,

--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -604,7 +604,12 @@ export async function postExperiments(
       details: auditDetailsCreate(experiment),
     });
 
-    await upsertWatch(userId, org.id, experiment.id, "experiments");
+    await upsertWatch({
+      userId,
+      organization: org.id,
+      item: experiment.id,
+      type: "experiments",
+    });
 
     res.status(200).json({
       status: 200,
@@ -852,7 +857,12 @@ export async function postExperiment(
   // If there are new tags to add
   await addTagsDiff(org.id, experiment.tags || [], data.tags || []);
 
-  await upsertWatch(userId, org.id, experiment.id, "experiments");
+  await upsertWatch({
+    userId,
+    organization: org.id,
+    item: experiment.id,
+    type: "experiments",
+  });
 
   res.status(200).json({
     status: 200,
@@ -1368,7 +1378,12 @@ export async function postExperimentPhase(
       details: auditDetailsUpdate(experiment, updated),
     });
 
-    await upsertWatch(userId, org.id, experiment.id, "experiments");
+    await upsertWatch({
+      userId,
+      organization: org.id,
+      item: experiment.id,
+      type: "experiments",
+    });
 
     res.status(200).json({
       status: 200,
@@ -1859,7 +1874,12 @@ export async function addScreenshot(
     }),
   });
 
-  await upsertWatch(userId, org.id, experiment.id, "experiments");
+  await upsertWatch({
+    userId,
+    organization: org.id,
+    item: experiment.id,
+    type: "experiments",
+  });
 
   res.status(200).json({
     status: 200,

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -33,7 +33,6 @@ import {
   getSurrogateKey,
   verifyDraftsAreEqual,
 } from "../services/features";
-import { ensureWatching } from "../services/experiments";
 import { getExperimentByTrackingKey } from "../models/ExperimentModel";
 import { FeatureUsageRecords } from "../../types/realtime";
 import {
@@ -52,6 +51,7 @@ import { logger } from "../util/logger";
 import { addTagsDiff } from "../models/TagModel";
 import { FASTLY_SERVICE_ID } from "../util/secrets";
 import { EventAuditUserForResponseLocals } from "../events/event-types";
+import { upsertWatch } from "../models/WatchModel";
 
 class UnrecoverableApiError extends Error {
   constructor(message: string) {
@@ -284,7 +284,7 @@ export async function postFeatures(
   addIdsToRules(feature.environmentSettings, feature.id);
 
   await createFeature(org, res.locals.eventAudit, feature);
-  await ensureWatching(userId, org.id, feature.id, "features");
+  await upsertWatch(userId, org.id, feature.id, "features");
 
   await req.audit({
     event: "feature.create",

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -284,7 +284,12 @@ export async function postFeatures(
   addIdsToRules(feature.environmentSettings, feature.id);
 
   await createFeature(org, res.locals.eventAudit, feature);
-  await upsertWatch(userId, org.id, feature.id, "features");
+  await upsertWatch({
+    userId,
+    organization: org.id,
+    item: feature.id,
+    type: "features",
+  });
 
   await req.audit({
     event: "feature.create",

--- a/packages/back-end/src/jobs/updateExperimentResults.ts
+++ b/packages/back-end/src/jobs/updateExperimentResults.ts
@@ -13,7 +13,6 @@ import { getDataSourceById } from "../models/DataSourceModel";
 import { isEmailEnabled, sendExperimentChangesEmail } from "../services/email";
 import {
   createSnapshot,
-  getExperimentWatchers,
   getRegressionAdjustmentInfo,
 } from "../services/experiments";
 import { getConfidenceLevelsForOrg } from "../services/organizations";
@@ -28,6 +27,7 @@ import {
   ExperimentSnapshotInterface,
 } from "../../types/experiment-snapshot";
 import { findProjectById } from "../models/ProjectModel";
+import { getExperimentWatchers } from "../models/WatchModel";
 
 // Time between experiment result updates (default 6 hours)
 const UPDATE_EVERY = EXPERIMENT_REFRESH_FREQUENCY * 60 * 60 * 1000;

--- a/packages/back-end/src/middleware/authenticateApiRequestMiddleware.ts
+++ b/packages/back-end/src/middleware/authenticateApiRequestMiddleware.ts
@@ -1,7 +1,6 @@
 import { Request, Response, NextFunction } from "express";
 import { ApiRequestLocals } from "../../types/api";
 import { lookupOrganizationByApiKey } from "../models/ApiKeyModel";
-import { insertAudit } from "../services/audit";
 import { getOrganizationById, getRole } from "../services/organizations";
 import { getCustomLogProps } from "../util/logger";
 import { EventAuditUserApiKey } from "../events/event-types";
@@ -13,6 +12,7 @@ import {
 } from "../../types/organization";
 import { getPermissionsByRole } from "../util/organization.util";
 import { ApiKeyInterface } from "../../types/apikey";
+import { insertAudit } from "../models/AuditModel";
 
 export default function authenticateApiRequestMiddleware(
   req: Request & ApiRequestLocals,

--- a/packages/back-end/src/models/AuditModel.ts
+++ b/packages/back-end/src/models/AuditModel.ts
@@ -49,7 +49,9 @@ const toInterface = (doc: AuditDocument): AuditInterface => {
   return omit(doc.toJSON<AuditDocument>(), ["__v", "_id"]);
 };
 
-export async function insertAudit(data: Partial<AuditInterface>) {
+export async function insertAudit(
+  data: Partial<AuditInterface>
+): Promise<AuditInterface> {
   const auditDoc = await AuditModel.create({
     ...data,
     id: uniqid("aud_"),
@@ -57,7 +59,7 @@ export async function insertAudit(data: Partial<AuditInterface>) {
   return toInterface(auditDoc);
 }
 
-export async function findByOrganization(
+export async function findAuditByOrganization(
   organization: string,
   options?: QueryOptions
 ): Promise<AuditInterface[]> {
@@ -70,12 +72,12 @@ export async function findByOrganization(
   return auditDocs.map((doc) => toInterface(doc));
 }
 
-export async function findByEntity(
+export async function findAuditByEntity(
   organization: string,
   type: EntityType,
   id: string,
   options?: QueryOptions
-) {
+): Promise<AuditInterface[]> {
   const auditDocs = await AuditModel.find(
     {
       organization,
@@ -87,13 +89,13 @@ export async function findByEntity(
   return auditDocs.map((doc) => toInterface(doc));
 }
 
-export async function findByEntityList(
+export async function findAuditByEntityList(
   organization: string,
   type: EntityType,
   ids: string[],
   customFilter?: FilterQuery<AuditDocument>,
   options?: QueryOptions
-) {
+): Promise<AuditInterface[]> {
   const auditDocs = await AuditModel.find(
     {
       organization,
@@ -108,12 +110,12 @@ export async function findByEntityList(
   return auditDocs.map((doc) => toInterface(doc));
 }
 
-export async function findByEntityParent(
+export async function findAuditByEntityParent(
   organization: string,
   type: EntityType,
   id: string,
   options?: QueryOptions
-) {
+): Promise<AuditInterface[]> {
   const auditDocs = await AuditModel.find(
     {
       organization,
@@ -125,11 +127,11 @@ export async function findByEntityParent(
   return auditDocs.map((doc) => toInterface(doc));
 }
 
-export async function findAllByEntityType(
+export async function findAllAuditsByEntityType(
   organization: string,
   type: EntityType,
   options?: QueryOptions
-) {
+): Promise<AuditInterface[]> {
   const auditDocs = await AuditModel.find(
     {
       organization,
@@ -140,11 +142,11 @@ export async function findAllByEntityType(
   return auditDocs.map((doc) => toInterface(doc));
 }
 
-export async function findAllByEntityTypeParent(
+export async function findAllAuditsByEntityTypeParent(
   organization: string,
   type: EntityType,
   options?: QueryOptions
-) {
+): Promise<AuditInterface[]> {
   const auditDocs = await AuditModel.find(
     {
       organization,

--- a/packages/back-end/src/models/AuditModel.ts
+++ b/packages/back-end/src/models/AuditModel.ts
@@ -1,4 +1,4 @@
-import mongoose, { QueryOptions } from "mongoose";
+import mongoose, { FilterQuery, QueryOptions } from "mongoose";
 import { omit } from "lodash";
 import uniqid from "uniqid";
 import { AuditInterface } from "../../types/audit";
@@ -39,7 +39,7 @@ const auditSchema = new mongoose.Schema({
 
 type AuditDocument = mongoose.Document & AuditInterface;
 
-export const AuditModel = mongoose.model<AuditInterface>("Audit", auditSchema);
+const AuditModel = mongoose.model<AuditInterface>("Audit", auditSchema);
 
 /**
  * Convert the Mongo document to an AuditInterface, omitting Mongo default fields __v, _id
@@ -81,6 +81,27 @@ export async function findByEntity(
       organization,
       "entity.object": type,
       "entity.id": id,
+    },
+    options
+  );
+  return auditDocs.map((doc) => toInterface(doc));
+}
+
+export async function findByEntityList(
+  organization: string,
+  type: EntityType,
+  ids: string[],
+  customFilter?: FilterQuery<AuditDocument>,
+  options?: QueryOptions
+) {
+  const auditDocs = await AuditModel.find(
+    {
+      organization,
+      "entity.object": type,
+      "entity.id": {
+        $in: ids,
+      },
+      ...customFilter,
     },
     options
   );

--- a/packages/back-end/src/models/WatchModel.ts
+++ b/packages/back-end/src/models/WatchModel.ts
@@ -1,4 +1,5 @@
 import mongoose from "mongoose";
+import { omit } from "lodash";
 import { WatchInterface } from "../../types/watch";
 
 const watchSchema = new mongoose.Schema({
@@ -12,3 +13,22 @@ watchSchema.index({ userId: 1, organization: 1 }, { unique: true });
 export type WatchDocument = mongoose.Document & WatchInterface;
 
 export const WatchModel = mongoose.model<WatchInterface>("Watch", watchSchema);
+
+/**
+ * Convert the Mongo document to a WatchInterface, omitting Mongo default fields __v, _id
+ * @param doc
+ */
+const toInterface = (doc: WatchDocument): WatchInterface => {
+  return omit(doc.toJSON<WatchDocument>(), ["__v", "_id"]);
+};
+
+export async function getWatchesByUser(
+  organization: string,
+  userId: string
+): Promise<WatchInterface | null> {
+  const watchDoc = await WatchModel.findOne({
+    userId,
+    organization,
+  });
+  return watchDoc ? toInterface(watchDoc) : null;
+}

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -42,11 +42,8 @@ import {
 } from "../../../types/organization";
 import {
   auditDetailsUpdate,
-  findAllByEntityType,
-  findAllByEntityTypeParent,
-  findByEntity,
-  findByEntityParent,
   getWatchedAudits,
+  isValidEntityType,
 } from "../../services/audit";
 import { getAllFeatures } from "../../models/FeatureModel";
 import { findDimensionsByOrganization } from "../../models/DimensionModel";
@@ -96,6 +93,13 @@ import {
   getExperimentsForActivityFeed,
 } from "../../models/ExperimentModel";
 import { removeEnvironmentFromSlackIntegration } from "../../models/SlackIntegrationModel";
+import {
+  findAllByEntityType,
+  findAllByEntityTypeParent,
+  findByEntity,
+  findByEntityParent,
+} from "../../models/AuditModel";
+import { EntityType } from "../../types/Audit";
 
 export async function getDefinitions(req: AuthRequest, res: Response) {
   const { org } = getOrgFromReq(req);
@@ -189,6 +193,13 @@ export async function getAllHistory(
   const { org } = getOrgFromReq(req);
   const { type } = req.params;
 
+  if (!isValidEntityType(type)) {
+    return res.status(400).json({
+      status: 400,
+      message: `${type} is not a valid entity type. Possible entity types are: ${EntityType}`,
+    });
+  }
+
   const events = await Promise.all([
     findAllByEntityType(org.id, type),
     findAllByEntityTypeParent(org.id, type),
@@ -221,6 +232,13 @@ export async function getHistory(
 ) {
   const { org } = getOrgFromReq(req);
   const { type, id } = req.params;
+
+  if (!isValidEntityType(type)) {
+    return res.status(400).json({
+      status: 400,
+      message: `${type} is not a valid entity type. Possible entity types are: ${EntityType}`,
+    });
+  }
 
   const events = await Promise.all([
     findByEntity(org.id, type, id),

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -43,7 +43,7 @@ import {
 import {
   auditDetailsUpdate,
   getRecentWatchedAudits,
-  isValidEntityType,
+  isValidAuditEntityType,
 } from "../../services/audit";
 import { getAllFeatures } from "../../models/FeatureModel";
 import { findDimensionsByOrganization } from "../../models/DimensionModel";
@@ -94,10 +94,10 @@ import {
 } from "../../models/ExperimentModel";
 import { removeEnvironmentFromSlackIntegration } from "../../models/SlackIntegrationModel";
 import {
-  findAllByEntityType,
-  findAllByEntityTypeParent,
-  findByEntity,
-  findByEntityParent,
+  findAllAuditsByEntityType,
+  findAllAuditsByEntityTypeParent,
+  findAuditByEntity,
+  findAuditByEntityParent,
 } from "../../models/AuditModel";
 import { EntityType } from "../../types/Audit";
 
@@ -193,7 +193,7 @@ export async function getAllHistory(
   const { org } = getOrgFromReq(req);
   const { type } = req.params;
 
-  if (!isValidEntityType(type)) {
+  if (!isValidAuditEntityType(type)) {
     return res.status(400).json({
       status: 400,
       message: `${type} is not a valid entity type. Possible entity types are: ${EntityType}`,
@@ -201,8 +201,8 @@ export async function getAllHistory(
   }
 
   const events = await Promise.all([
-    findAllByEntityType(org.id, type),
-    findAllByEntityTypeParent(org.id, type),
+    findAllAuditsByEntityType(org.id, type),
+    findAllAuditsByEntityTypeParent(org.id, type),
   ]);
 
   const merged = [...events[0], ...events[1]];
@@ -233,7 +233,7 @@ export async function getHistory(
   const { org } = getOrgFromReq(req);
   const { type, id } = req.params;
 
-  if (!isValidEntityType(type)) {
+  if (!isValidAuditEntityType(type)) {
     return res.status(400).json({
       status: 400,
       message: `${type} is not a valid entity type. Possible entity types are: ${EntityType}`,
@@ -241,8 +241,8 @@ export async function getHistory(
   }
 
   const events = await Promise.all([
-    findByEntity(org.id, type, id),
-    findByEntityParent(org.id, type, id),
+    findAuditByEntity(org.id, type, id),
+    findAuditByEntityParent(org.id, type, id),
   ]);
 
   const merged = [...events[0], ...events[1]];

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -42,7 +42,7 @@ import {
 } from "../../../types/organization";
 import {
   auditDetailsUpdate,
-  getWatchedAudits,
+  getRecentWatchedAudits,
   isValidEntityType,
 } from "../../services/audit";
 import { getAllFeatures } from "../../models/FeatureModel";
@@ -156,7 +156,7 @@ export async function getDefinitions(req: AuthRequest, res: Response) {
 export async function getActivityFeed(req: AuthRequest, res: Response) {
   const { org, userId } = getOrgFromReq(req);
   try {
-    const docs = await getWatchedAudits(userId, org.id);
+    const docs = await getRecentWatchedAudits(userId, org.id);
 
     if (!docs.length) {
       return res.status(200).json({

--- a/packages/back-end/src/services/audit.ts
+++ b/packages/back-end/src/services/audit.ts
@@ -1,8 +1,8 @@
-import { findByEntityList } from "../models/AuditModel";
+import { findAuditByEntityList } from "../models/AuditModel";
 import { getWatchedByUser } from "../models/WatchModel";
 import { EntityType } from "../types/Audit";
 
-export function isValidEntityType(type: string): type is EntityType {
+export function isValidAuditEntityType(type: string): type is EntityType {
   return EntityType.includes(type as EntityType);
 }
 
@@ -47,14 +47,14 @@ export async function getRecentWatchedAudits(
     },
   };
 
-  const experiments = await findByEntityList(
+  const experiments = await findAuditByEntityList(
     organization,
     "experiment",
     userWatches.experiments,
     experimentsFilter
   );
 
-  const features = await findByEntityList(
+  const features = await findAuditByEntityList(
     organization,
     "feature",
     userWatches.features,

--- a/packages/back-end/src/services/auth/index.ts
+++ b/packages/back-end/src/services/auth/index.ts
@@ -11,7 +11,6 @@ import {
 import { Permission } from "../../../types/organization";
 import { UserInterface } from "../../../types/user";
 import { AuditInterface } from "../../../types/audit";
-import { insertAudit } from "../audit";
 import { getUserByEmail } from "../users";
 import { hasOrganization } from "../../models/OrganizationModel";
 import {
@@ -25,6 +24,7 @@ import {
   EventAuditUserForResponseLocals,
   EventAuditUserLoggedIn,
 } from "../../events/event-types";
+import { insertAudit } from "../../models/AuditModel";
 import { AuthConnection } from "./AuthConnection";
 import { OpenIdAuthConnection } from "./OpenIdAuthConnection";
 import { LocalAuthConnection } from "./LocalAuthConnection";

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -23,7 +23,6 @@ import {
 import { getMetricsByIds, insertMetric } from "../models/MetricModel";
 import { checkSrm, sumSquaresFromStats } from "../util/stats";
 import { addTags } from "../models/TagModel";
-import { WatchModel } from "../models/WatchModel";
 import { Dimension, ExperimentMetricQueryResponse } from "../types/Integration";
 import { createExperimentSnapshotModel } from "../models/ExperimentSnapshotModel";
 import {
@@ -481,39 +480,6 @@ export async function createSnapshot({
   });
 
   return queryRunner;
-}
-
-export async function ensureWatching(
-  userId: string,
-  orgId: string,
-  item: string,
-  type: "experiments" | "features"
-) {
-  await WatchModel.updateOne(
-    {
-      userId,
-      organization: orgId,
-    },
-    {
-      $addToSet: {
-        [type]: item,
-      },
-    },
-    {
-      upsert: true,
-    }
-  );
-}
-
-export async function getExperimentWatchers(
-  experimentId: string,
-  orgId: string
-) {
-  const watchers = await WatchModel.find({
-    experiments: experimentId,
-    organization: orgId,
-  });
-  return watchers;
 }
 
 function getExperimentMetric(

--- a/packages/back-end/src/types/Audit.ts
+++ b/packages/back-end/src/types/Audit.ts
@@ -1,0 +1,12 @@
+export const EntityType = [
+  "experiment",
+  "feature",
+  "metric",
+  "datasource",
+  "comment",
+  "user",
+  "organization",
+  "savedGroup",
+] as const;
+
+export type EntityType = typeof EntityType[number];

--- a/packages/back-end/types/audit.d.ts
+++ b/packages/back-end/types/audit.d.ts
@@ -1,12 +1,4 @@
-export type EntityType =
-  | "experiment"
-  | "feature"
-  | "metric"
-  | "datasource"
-  | "comment"
-  | "user"
-  | "organization"
-  | "savedGroup";
+import { EntityType } from "../src/types/Audit";
 
 export type EventType =
   | "experiment.create"


### PR DESCRIPTION
### Features and Changes
This PR moves us closer to having no mongoose model exports to prevent developers from interacting with our models directly. In this PR I specifically worked on the following models:
- AuditModel
- WatchModel

<!--
  Indicate which issue this will close, if applicable
  For multiple issues, add a new `- Closes` or `- Fixes` line
-->

- Makes progress on #1300 

### Testing
PR should be no-op aside from some new error handling added for `getAllHistory` and `getHistory` within the organizations controller which map to `/history/:type` and `/history/:type/:id` respectively. A type that is not within `EntityType` should now return an HTTP 400 response with an explanation of what the valid types are.
