### PR TITLE
Speed up segments [10-40x] by Fix Segment bug not respecting lower bound

### DIFF
--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -1103,7 +1103,7 @@ export default abstract class SqlIntegration
               ? `JOIN __denominatorUsers du ON (du.${baseIdType} = e.${baseIdType})`
               : ""
           }
-        ${segment ? `WHERE s.date <= e.timestamp` : ""}
+        ${segment ? `WHERE s.date <= e.timestamp and s.date >= ${this.toTimestamp(startDate)}` : ""}
         GROUP BY
           e.${baseIdType}
       )

--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -1103,7 +1103,14 @@ export default abstract class SqlIntegration
               ? `JOIN __denominatorUsers du ON (du.${baseIdType} = e.${baseIdType})`
               : ""
           }
-        ${segment ? `WHERE s.date <= e.timestamp and s.date >= ${this.toTimestamp(startDate)}` : ""}
+        ${segment ? `WHERE s.date <= e.timestamp 
+          AND s.date >= ${this.toTimestamp(startDate)}
+          ${
+            endDate // This will provide a hint to the Query Planner for a speed improvement.
+              ? `AND s.date <= ${this.toTimestamp(endDate)}`
+              : ""
+          }` 
+          : ""}
         GROUP BY
           e.${baseIdType}
       )


### PR DESCRIPTION
### The Issue
Currently segments do not respect the lower bounds of the Experiment Date Range.

This will also cause false positives and negatives, since users may be part of segments such as "Active or Paid User segment" prior to the experiment date range; but not after and such should've been filtered out. Which would cause incorrect results.

### Features and Changes

A side effect of fixing this bug is that when you have a very large historical database of segments. 
You will see exponential speed up in your query speed ! 

We see a 10-40x increase in Segment query speed after this change took effect. Since our tables are billions of rows that go back years; your speed up may vary.


### Testing
All Testing was done in Databricks, appreciate if anyone has other platforms they want to test it on.

1. Create an Experiment for analysis
2. Create a segment for that experiment
3. Run the query for a date range and see the effect 👍 

I have tested two variations of the query

1. One with Lower & Upper Bound
2. One with just the Lower Bound Fixed

### Example Query Change
   JOIN __segment s ON (s.customer = e.customer)
  WHERE
    s.date <= e.timestamp -- Originally this was the only Segment filter

    AND s.date >= TIMESTAMP '2023-06-22T00:00:00.000Z' -- Added the lower bound
    AND s.date <= TIMESTAMP '2023-07-17T23:59:00.000Z' ' -- Added the upper bound as well for Query planner speed
 
    