### PR TITLE
Add athena table prefix

### DIFF
--- a/packages/front-end/services/datasources.ts
+++ b/packages/front-end/services/datasources.ts
@@ -561,7 +561,10 @@ function getTablePrefix(params: DataSourceParams) {
       params.schema || "public"
     }.`;
   }
-
+  // Athena
+  else if ("catalog" in params && "database" in params) {
+    return `${params.catalog}.${params.database}.`;
+  }
   return "";
 }
 


### PR DESCRIPTION
### Features and Changes

Add the table prefix for athena.

### Testing

Add a new metric.
Choose an athena table and enter a metric name.
Click next.
Look at the sql and see the tablename prefix such as "awsdatacatalog.rudderstack."

