### PR TITLE
Option to auto-start new experiment rules when adding to a feature

### DIFF
--- a/packages/front-end/components/Experiment/EditPhaseModal.tsx
+++ b/packages/front-end/components/Experiment/EditPhaseModal.tsx
@@ -37,6 +37,9 @@ export default function EditPhaseModal({
   const isDraft = experiment.status === "draft";
   const isMultiPhase = experiment.phases.length > 1;
 
+  const hasLinkedChanges =
+    !!experiment.linkedFeatures?.length || experiment.hasVisualChangesets;
+
   return (
     <Modal
       open={true}
@@ -51,6 +54,12 @@ export default function EditPhaseModal({
       })}
       size="lg"
     >
+      {!isDraft && hasLinkedChanges && (
+        <div className="alert alert-danger">
+          <strong>Warning:</strong> Changes you make to phases will immediately
+          affect all linked Feature Flags and Visual Changes.
+        </div>
+      )}
       <Field label="Phase Name" {...form.register("name")} required />
       <Field
         label="Start Time (UTC)"

--- a/packages/front-end/components/Experiment/EditPhasesModal.tsx
+++ b/packages/front-end/components/Experiment/EditPhasesModal.tsx
@@ -23,6 +23,8 @@ export default function EditPhasesModal({
   const isDraft = experiment.status === "draft";
   const isMultiPhase = experiment.phases.length > 1;
   const hasStoppedPhases = experiment.phases.some((p) => p.dateEnded);
+  const hasLinkedChanges =
+    !!experiment.linkedFeatures?.length || experiment.hasVisualChangesets;
 
   const [editPhase, setEditPhase] = useState<number | null>(
     isDraft && !isMultiPhase ? 0 : null
@@ -70,6 +72,12 @@ export default function EditPhasesModal({
       size="lg"
       closeCta="Close"
     >
+      {!isDraft && hasLinkedChanges && (
+        <div className="alert alert-danger">
+          <strong>Warning:</strong> Editing phases will immediately affect all
+          linked Feature Flags and Visual Changes.
+        </div>
+      )}
       <table className="table gbtable mb-2">
         <thead>
           <tr>

--- a/packages/front-end/components/Experiment/NewPhaseForm.tsx
+++ b/packages/front-end/components/Experiment/NewPhaseForm.tsx
@@ -72,6 +72,9 @@ const NewPhaseForm: FC<{
     refreshWatching();
   });
 
+  const hasLinkedChanges =
+    !!experiment.linkedFeatures?.length || experiment.hasVisualChangesets;
+
   return (
     <Modal
       header={firstPhase ? "Start Experiment" : "New Experiment Phase"}
@@ -82,6 +85,12 @@ const NewPhaseForm: FC<{
       closeCta="Cancel"
       size="lg"
     >
+      {hasLinkedChanges && (
+        <div className="alert alert-danger">
+          <strong>Warning:</strong> Starting a new phase will immediately affect
+          all linked Feature Flags and Visual Changes.
+        </div>
+      )}
       <div className="row">
         <Field
           label="Name"

--- a/packages/front-end/components/Experiment/SinglePage.tsx
+++ b/packages/front-end/components/Experiment/SinglePage.tsx
@@ -470,7 +470,10 @@ export default function SinglePage({
   const numLinkedChanges = visualChangesets.length + linkedFeatures.length;
 
   const hasActualLinkedChanges =
-    visualChangesets.length > 0 || !!experiment.linkedFeatures?.length;
+    visualChangesets.length > 0 ||
+    linkedFeatures.some(({ rules }) =>
+      rules.some((r) => !r.draft && r.rule.type === "experiment-ref")
+    );
 
   // Get name or email of all active users watching this experiment
   const usersWatching = (watcherIds?.data?.userIds || [])
@@ -1026,6 +1029,10 @@ export default function SinglePage({
             <HeaderWithEdit
               edit={safeToEdit && editTargeting ? editTargeting : undefined}
               containerClassName="mb-2"
+              disabledMessage={
+                !safeToEdit &&
+                "Cannot edit targeting settings while the experiment is running."
+              }
             >
               Targeting
             </HeaderWithEdit>
@@ -1105,8 +1112,11 @@ export default function SinglePage({
 
           <HeaderWithEdit
             edit={editVariations && safeToEdit ? editVariations : undefined}
-            className="h3 mb-2"
-            containerClassName="mx-4 mb-1"
+            containerClassName="mx-4 mb-2"
+            disabledMessage={
+              !safeToEdit &&
+              "Cannot edit variations while the experiment is running."
+            }
           >
             Variations
           </HeaderWithEdit>

--- a/packages/front-end/components/Layout/HeaderWithEdit.tsx
+++ b/packages/front-end/components/Layout/HeaderWithEdit.tsx
@@ -1,6 +1,7 @@
 import clsx from "clsx";
 import { ReactElement } from "react";
 import { GBEdit } from "../Icons";
+import Tooltip from "../Tooltip/Tooltip";
 
 export interface Props {
   className?: string;
@@ -10,6 +11,7 @@ export interface Props {
   editClassName?: string;
   additionalActions?: ReactElement;
   stopPropagation?: boolean;
+  disabledMessage?: false | null | undefined | string | ReactElement;
 }
 
 export default function HeaderWithEdit({
@@ -20,11 +22,12 @@ export default function HeaderWithEdit({
   className = "h3",
   containerClassName = "mb-2",
   stopPropagation = false,
+  disabledMessage = null,
 }: Props) {
   return (
     <div className={clsx("d-flex align-items-center", containerClassName)}>
       <div className={clsx(className, "mb-0")}>{children}</div>
-      {edit && (
+      {edit ? (
         <div className="ml-1">
           <a
             className={editClassName}
@@ -38,7 +41,13 @@ export default function HeaderWithEdit({
             <GBEdit />
           </a>
         </div>
-      )}
+      ) : disabledMessage ? (
+        <div className="ml-1 text-muted">
+          <Tooltip body={disabledMessage}>
+            <GBEdit />
+          </Tooltip>
+        </div>
+      ) : null}
       {additionalActions && <div className="ml-1">{additionalActions}</div>}
     </div>
   );

--- a/packages/front-end/services/features.ts
+++ b/packages/front-end/services/features.ts
@@ -49,6 +49,7 @@ export interface AttributeData {
 export type NewExperimentRefRule = {
   type: "experiment-ref-new";
   name: string;
+  autoStart: boolean;
 } & Omit<ExperimentRule, "type">;
 
 export function validateFeatureValue(
@@ -542,6 +543,7 @@ export function getDefaultRuleValue({
       type: "experiment-ref-new",
       description: "",
       name: "",
+      autoStart: true,
       id: "",
       condition: "",
       enabled: true,


### PR DESCRIPTION
### Features and Changes

When adding a new experiment rule to a feature, add a new toggle to auto-start the experiment upon publishing.  This restores the previous default behavior while still allowing you to start with a draft experiment if desired.

![image](https://github.com/growthbook/growthbook/assets/1087514/41b198ff-6116-4177-b215-e43f23b1cd51)

This PR also fixes a few other minor UX issues with #1139 
