### PR TITLE
Show experiment results if some metric queries fail

### DIFF
--- a/packages/back-end/src/queryRunners/QueryRunner.ts
+++ b/packages/back-end/src/queryRunners/QueryRunner.ts
@@ -212,17 +212,20 @@ export abstract class QueryRunner<
     let result: Result | undefined = undefined;
 
     if (oldStatus === "running" && newStatus === "failed") {
-      error = "Failed to run one or more database queries";
+      error = "Failed to run a majority of the database queries";
       logger.debug("Query failed, transitioning to error state");
     }
-    if (oldStatus === "running" && newStatus === "succeeded") {
+    if (
+      oldStatus === "running" &&
+      (newStatus === "succeeded" || newStatus === "partially-succeeded")
+    ) {
       try {
         result = await this.runAnalysis(queryMap);
-        logger.debug("Queries succeeded, ran analysis successfully");
+        logger.debug(`Queries ${newStatus}, ran analysis successfully`);
       } catch (e) {
         error = "Error running analysis: " + e.message;
         logger.debug(
-          "Queries succeeded, failed running analysis: " + e.message
+          `Queries ${newStatus}, failed running analysis: ` + e.message
         );
       }
     }
@@ -256,7 +259,8 @@ export abstract class QueryRunner<
 
   public async startQuery<
     Rows extends Record<string, string | boolean | number>[],
-    ProcessedRows
+    // eslint-disable-next-line
+    ProcessedRows extends Record<string, any>
   >(
     name: string,
     query: string,
@@ -371,17 +375,22 @@ export abstract class QueryRunner<
   }
 
   private getOverallQueryStatus(): QueryStatus {
-    const hasFailedQueries = this.model.queries.some(
+    const failedQueries = this.model.queries.filter(
       (q) => q.status === "failed"
     );
-    const hasRunningQueries = this.model.queries.some(
+    const runningQueries = this.model.queries.filter(
       (q) => q.status === "running"
     );
-    return hasFailedQueries
-      ? "failed"
-      : hasRunningQueries
-      ? "running"
-      : "succeeded";
+
+    const totalQueries = this.model.queries.length;
+
+    if (failedQueries.length >= totalQueries / 2) return "failed";
+
+    if (runningQueries.length > 0) return "running";
+
+    if (failedQueries.length > 0) return "partially-succeeded";
+
+    return "succeeded";
   }
 
   private async updateQueryPointers(): Promise<{

--- a/packages/back-end/types/query.d.ts
+++ b/packages/back-end/types/query.d.ts
@@ -1,6 +1,10 @@
 import { QueryLanguage } from "./datasource";
 
-export type QueryStatus = "running" | "failed" | "succeeded";
+export type QueryStatus =
+  | "running"
+  | "failed"
+  | "partially-succeeded"
+  | "succeeded";
 
 export type QueryPointer = {
   query: string;

--- a/packages/front-end/components/Experiment/AnalysisSettingsBar.tsx
+++ b/packages/front-end/components/Experiment/AnalysisSettingsBar.tsx
@@ -7,7 +7,11 @@ import {
   MetricRegressionAdjustmentStatus,
 } from "back-end/types/report";
 import { StatsEngine } from "back-end/types/stats";
-import { FaExclamationCircle, FaInfoCircle } from "react-icons/fa";
+import {
+  FaExclamationCircle,
+  FaExclamationTriangle,
+  FaInfoCircle,
+} from "react-icons/fa";
 import { OrganizationSettings } from "back-end/types/organization";
 import { ago, datetime } from "shared/dates";
 import { DEFAULT_SEQUENTIAL_TESTING_TUNING_PARAMETER } from "shared/constants";
@@ -292,16 +296,31 @@ export default function AnalysisSettingsBar({
                 </Tooltip>
               ) : (
                 <div
-                  className="text-muted text-right"
+                  className="text-muted"
                   style={{ width: 100, fontSize: "0.8em" }}
-                  title={datetime(snapshot?.dateCreated ?? "")}
                 >
                   <div className="font-weight-bold" style={{ lineHeight: 1.2 }}>
                     last updated
                   </div>
-                  <div className="d-inline-block" style={{ lineHeight: 1 }}>
+                  <div
+                    className="d-inline-block"
+                    style={{ lineHeight: 1 }}
+                    title={datetime(snapshot?.dateCreated ?? "")}
+                  >
                     {ago(snapshot?.dateCreated ?? "")}
                   </div>
+                  {status === "partially-succeeded" && (
+                    <Tooltip
+                      body={
+                        <div className="text-left">
+                          Some of the queries had an error. The partial results
+                          are displayed below
+                        </div>
+                      }
+                    >
+                      <FaExclamationTriangle className="text-danger ml-1" />
+                    </Tooltip>
+                  )}
                 </div>
               ))}
           </div>
@@ -425,7 +444,7 @@ export default function AnalysisSettingsBar({
               </div>
             )}
             <div className="row">
-              {latest && status !== "succeeded" && (
+              {latest && (status === "running" || status === "failed") && (
                 <div className="col-auto pb-3">
                   <ViewAsyncQueriesButton
                     queries={latest.queries.map((q) => q.query)}

--- a/packages/front-end/components/Experiment/ImportExperimentList.tsx
+++ b/packages/front-end/components/Experiment/ImportExperimentList.tsx
@@ -171,7 +171,7 @@ const ImportExperimentList: FC<{
             last updated {ago(data.experiments.runStarted ?? "")}
           </div>
         </div>
-        {!permissions.check("runQueries", project || "") && (
+        {permissions.check("runQueries", project || "") && (
           <div className="col-auto">
             <form
               onSubmit={async (e) => {

--- a/packages/front-end/components/Experiment/NewExperimentForm.tsx
+++ b/packages/front-end/components/Experiment/NewExperimentForm.tsx
@@ -104,18 +104,22 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
   const hasHashAttributes =
     attributeSchema.filter((x) => x.hashAttribute).length > 0;
 
+  const initialDatasource =
+    initialValue?.datasource ||
+    (settings.defaultDataSource
+      ? settings.defaultDataSource
+      : datasources?.[0]?.id) ||
+    "";
+
   const form = useForm<Partial<ExperimentInterfaceStringDates>>({
     defaultValues: {
       project: initialValue?.project || project || "",
       trackingKey: initialValue?.trackingKey || "",
-      datasource:
-        initialValue?.datasource || settings.defaultDataSource
-          ? settings.defaultDataSource
-          : datasources?.[0]?.id || "",
+      datasource: initialDatasource,
       exposureQueryId:
         getExposureQuery(
-          initialValue?.datasource
-            ? getDatasourceById(initialValue.datasource)?.settings
+          initialDatasource
+            ? getDatasourceById(initialDatasource)?.settings
             : undefined,
           initialValue?.exposureQueryId,
           initialValue?.userIdType

--- a/packages/front-end/components/Experiment/SinglePage.tsx
+++ b/packages/front-end/components/Experiment/SinglePage.tsx
@@ -1130,7 +1130,7 @@ export default function SinglePage({
 
           <div className="mx-4 pb-3">
             {numLinkedChanges === 0 && experiment.status !== "draft" ? (
-              <div className="alert alert-info">
+              <div className="alert bg-light border">
                 This experiment has no feature flag or visual editor changes
                 which are managed within the GrowthBook app. Changes are likely
                 implemented manually.

--- a/packages/front-end/components/Queries/RunQueriesButton.tsx
+++ b/packages/front-end/components/Queries/RunQueriesButton.tsx
@@ -30,11 +30,16 @@ export function getQueryStatus(queries: Queries, error?: string): QueryStatus {
   if (error) return "failed";
 
   let running = false;
+  let numFailed = 0;
   for (let i = 0; i < queries.length; i++) {
-    if (queries[i].status === "failed") return "failed";
+    if (queries[i].status === "failed") numFailed++;
     if (queries[i].status === "running") running = true;
   }
-  return running ? "running" : "succeeded";
+
+  if (numFailed >= queries.length / 2) return "failed";
+  if (running) return "running";
+  if (numFailed > 0) return "partially-succeeded";
+  return "succeeded";
 }
 
 const RunQueriesButton: FC<{


### PR DESCRIPTION
### Features and Changes

As long as at least half of the metrics succeed, show the new partial results instead of hiding them.

![image](https://github.com/growthbook/growthbook/assets/1087514/89d31f39-5554-4486-bdc0-1ec99626b1bf)
