### PR TITLE
[bugfix] Pass project name to MetricsSelector in for new experiments and reports

### DIFF
--- a/packages/front-end/components/Experiment/NewExperimentForm.tsx
+++ b/packages/front-end/components/Experiment/NewExperimentForm.tsx
@@ -453,6 +453,7 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
                 selected={form.watch("metrics") ?? []}
                 onChange={(metrics) => form.setValue("metrics", metrics)}
                 datasource={datasource?.id}
+                project={project}
               />
             </div>
             <div className="form-group">
@@ -465,6 +466,7 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
                 selected={form.watch("guardrails") ?? []}
                 onChange={(metrics) => form.setValue("guardrails", metrics)}
                 datasource={datasource?.id}
+                project={project}
               />
             </div>
           </div>

--- a/packages/front-end/components/Report/ConfigureReport.tsx
+++ b/packages/front-end/components/Report/ConfigureReport.tsx
@@ -320,6 +320,7 @@ export default function ConfigureReport({
           selected={form.watch("metrics")}
           onChange={(metrics) => form.setValue("metrics", metrics)}
           datasource={report.args.datasource}
+          project={project?.id}
         />
       </div>
       <div className="form-group">
@@ -333,6 +334,7 @@ export default function ConfigureReport({
           selected={form.watch("guardrails")}
           onChange={(metrics) => form.setValue("guardrails", metrics)}
           datasource={report.args.datasource}
+          project={project?.id}
         />
       </div>
       <DimensionChooser


### PR DESCRIPTION
### Features and Changes

* Add project information when selecting metrics for reports and for new experiments in order to filter metrics from other projects

- Closes #1561 

### Testing

Compare loom in issue to below:

https://www.loom.com/share/5b4caeb70bfd40e6a9199a97400a79b4

Now metrics that are tied to a project don't appear in the new metric form in another metric.