### PR TITLE
Fix Databricks date_format for dimensions

### DIFF
--- a/packages/back-end/src/integrations/Databricks.ts
+++ b/packages/back-end/src/integrations/Databricks.ts
@@ -39,7 +39,7 @@ export default class Databricks extends SqlIntegration {
     return `date_format(${col}, 'y-MM-dd')`;
   }
   formatDateTimeString(col: string) {
-    return `date_format(${col}, 'y-MM-dd H:m:s.S')`;
+    return `date_format(${col}, 'y-MM-dd HH:mm:ss.SSS')`;
   }
   castToString(col: string): string {
     return `cast(${col} as string)`;


### PR DESCRIPTION
### Features and Changes

* Our ability to pick the first dimension without additional computation cost relies on dates and the date formatting for databricks was incorrect and caused inappropriate truncation of dimension names in some cases
* This fixes that by ensuring our date strings are always long enough by asking databricks to prepend 0s for hours, minutes and seconds

### Dependencies

### Testing

Tested it with a sample databricks integration.

Did not run it through the query integration tester.

### Screenshots

Before:
![Screenshot 2023-08-10 at 2 55 44 PM](https://github.com/growthbook/growthbook/assets/5298599/6124f725-fb8a-488c-ba9a-71e4eeabad04)

After (note the user counts change because this dimension is `RAND() > 0.5`):
![Screenshot 2023-08-10 at 2 55 52 PM](https://github.com/growthbook/growthbook/assets/5298599/547706dc-96fc-4231-83bc-19a38dbe0d91)

