### PR TITLE
feat: Option for comments in descending date order(#1572)

### DIFF
--- a/packages/back-end/src/controllers/discussions.ts
+++ b/packages/back-end/src/controllers/discussions.ts
@@ -8,6 +8,7 @@ import {
 } from "../services/discussions";
 import { getFileUploadURL } from "../services/files";
 import { getOrgFromReq } from "../services/organizations";
+import { sortCommentsByOrder } from "../util/discussions";
 
 export async function postDiscussions(
   req: AuthRequest<
@@ -149,12 +150,16 @@ export async function putComment(
 export async function getDiscussion(
   req: AuthRequest<
     null,
-    { parentId: string; parentType: DiscussionParentType }
+    { parentId: string; parentType: DiscussionParentType },
+    {
+      order: "asc" | "desc";
+    }
   >,
   res: Response
 ) {
   const { org } = getOrgFromReq(req);
   const { parentId, parentType } = req.params;
+  const { order } = req.query;
 
   try {
     const discussion = await getDiscussionByParent(
@@ -162,6 +167,8 @@ export async function getDiscussion(
       parentType,
       parentId
     );
+
+    if (discussion) sortCommentsByOrder(discussion.comments, order);
     res.status(200).json({
       status: 200,
       discussion,

--- a/packages/back-end/src/util/discussions.ts
+++ b/packages/back-end/src/util/discussions.ts
@@ -1,0 +1,15 @@
+import { Comment } from "../../types/discussion";
+
+export function sortCommentsByOrder(
+  comments: Comment[],
+  order: "asc" | "desc"
+) {
+  const compareDates = (commentA: Comment, commentB: Comment) => {
+    const dateA = new Date(commentA.date).getTime();
+    const dateB = new Date(commentB.date).getTime();
+
+    return order === "asc" ? dateA - dateB : dateB - dateA;
+  };
+
+  return comments.sort(compareDates);
+}

--- a/packages/front-end/components/DiscussionThread.tsx
+++ b/packages/front-end/components/DiscussionThread.tsx
@@ -22,6 +22,7 @@ const DiscussionThread: FC<{
   allowNewComments?: boolean;
   showTitle?: boolean;
   title?: string;
+  order?: "asc" | "desc";
   project?: string;
 }> = ({
   type,
@@ -30,6 +31,7 @@ const DiscussionThread: FC<{
   showTitle = false,
   title = "Add comment",
   project,
+  order = "asc",
 }) => {
   const { apiCall } = useAuth();
   const { userId, users } = useUser();
@@ -42,7 +44,7 @@ const DiscussionThread: FC<{
   }
 
   const { data, error, mutate } = useApi<{ discussion: DiscussionInterface }>(
-    `/discussion/${type}/${id}`
+    `/discussion/${type}/${id}?order=${order}`
   );
 
   if (error) {

--- a/packages/front-end/pages/features/[fid].tsx
+++ b/packages/front-end/pages/features/[fid].tsx
@@ -50,12 +50,14 @@ import EditSchemaModal from "@/components/Features/EditSchemaModal";
 import Code from "@/components/SyntaxHighlighting/Code";
 import PremiumTooltip from "@/components/Marketing/PremiumTooltip";
 import { useUser } from "@/services/UserContext";
+import SelectField from "@/components/Forms/SelectField";
 
 export default function FeaturePage() {
   const router = useRouter();
   const { fid } = router.query;
 
   const [edit, setEdit] = useState(false);
+  const [commentsOrder, setCommentsOrder] = useState<"asc" | "desc">("desc");
   const [editValidator, setEditValidator] = useState(false);
   const [showSchema, setShowSchema] = useState(false);
   const [auditModal, setAuditModal] = useState(false);
@@ -775,8 +777,24 @@ export default function FeaturePage() {
 
       <div className="mb-4">
         <h3>Comments</h3>
+        <div className="mb-4">
+          <SelectField
+            label="Order by"
+            className="default w-25 "
+            value={commentsOrder}
+            onChange={(v: "asc" | "desc") => {
+              setCommentsOrder(v);
+            }}
+            options={[
+              { label: "Newest First", value: "desc" },
+              { label: "Oldest First", value: "asc" },
+            ]}
+          />
+        </div>
+
         <DiscussionThread
           type="feature"
+          order={commentsOrder}
           id={data.feature.id}
           project={data.feature.project}
         />


### PR DESCRIPTION
### Features and Changes

Enhanced Feature Page: The feature page has been enhanced to now accept an ordering option. This enables users to specify whether the results should be ordered in ascending ('asc') or descending ('desc') order.

Refined Discussion Controller: The discussion controller has undergone refinements to accommodate the ordering enhancements. It now incorporates the ordering option and order-by field provided by the feature page. The controller utilizes these parameters to fetch discussions, ensuring that the comments within each discussion are sorted according to the selected criteria.


- Closes **https://github.com/growthbook/growthbook/issues/1572**

### Testing

- Open feature flag view
- Create comments
- Select various options from the "Order By" dropdown menu.

### Screenshots

![image](https://github.com/growthbook/growthbook/assets/36000474/ea6261a0-ebd1-43b2-9e22-6bfb1819914f)

![image](https://github.com/growthbook/growthbook/assets/36000474/c9675f69-e403-474a-8925-277b636645f0)
