### PR TITLE
fix: made the password field for postgres optional

### DIFF
--- a/packages/front-end/components/Settings/PostgresForm.tsx
+++ b/packages/front-end/components/Settings/PostgresForm.tsx
@@ -5,10 +5,9 @@ import SSLConnectionFields from "./SSLConnectionFields";
 
 const PostgresForm: FC<{
   params: Partial<PostgresConnectionParams>;
-  existing: boolean;
   onParamChange: ChangeEventHandler<HTMLInputElement | HTMLSelectElement>;
   setParams: (params: { [key: string]: string }) => void;
-}> = ({ params, existing, onParamChange, setParams }) => {
+}> = ({ params, onParamChange, setParams }) => {
   return (
     <>
       <HostWarning
@@ -72,10 +71,9 @@ const PostgresForm: FC<{
             className="form-control password-presentation"
             autoComplete="off"
             name="password"
-            required={!existing}
             value={params.password || ""}
             onChange={onParamChange}
-            placeholder={existing ? "(Keep existing)" : ""}
+            placeholder="(optional)"
           />
         </div>
         <div className="form-group col-md-12">


### PR DESCRIPTION
### Features and Changes

This is a fix that makes postgreSQL password field optional.  

- Closes ** https://github.com/growthbook/growthbook/issues/1512 **

### Screenshots

<img width="818" alt="Screenshot 2023-08-15 at 5 33 45 PM" src="https://github.com/growthbook/growthbook/assets/29030948/cfe910cc-ec6e-4751-803d-efde1fd61b43">

