### PR TITLE
Add BE support for team management

### DIFF
--- a/packages/back-end/src/app.ts
+++ b/packages/back-end/src/app.ts
@@ -96,6 +96,7 @@ import { slackIntegrationRouter } from "./routers/slack-integration/slack-integr
 import { dataExportRouter } from "./routers/data-export/data-export.router";
 import { demoDatasourceProjectRouter } from "./routers/demo-datasource-project/demo-datasource-project.router";
 import { environmentRouter } from "./routers/environment/environment.router";
+import { teamRouter } from "./routers/teams/teams.router";
 
 const app = express();
 
@@ -556,6 +557,9 @@ app.delete(
 );
 app.get("/discussions/recent/:num", discussionsController.getRecentDiscussions);
 app.post("/file/upload/:filetype", discussionsController.postImageUploadUrl);
+
+// Teams
+app.use("/teams", teamRouter);
 
 // Admin
 app.get("/admin/organizations", adminController.getOrganizations);

--- a/packages/back-end/src/models/OrganizationModel.ts
+++ b/packages/back-end/src/models/OrganizationModel.ts
@@ -24,7 +24,7 @@ const baseMemberFields = {
       environments: [String],
     },
   ],
-  teams: [],
+  teams: [String],
 };
 
 const organizationSchema = new mongoose.Schema({

--- a/packages/back-end/src/models/OrganizationModel.ts
+++ b/packages/back-end/src/models/OrganizationModel.ts
@@ -24,6 +24,7 @@ const baseMemberFields = {
       environments: [String],
     },
   ],
+  teams: [],
 };
 
 const organizationSchema = new mongoose.Schema({

--- a/packages/back-end/src/models/TeamModel.ts
+++ b/packages/back-end/src/models/TeamModel.ts
@@ -52,9 +52,19 @@ export async function createTeam(
   return toInterface(teamDoc);
 }
 
-export async function findTeamById(id: string): Promise<TeamInterface | null> {
-  const teamDoc = await TeamModel.findById(id);
+export async function findTeamById(
+  id: string,
+  orgId: string
+): Promise<TeamInterface | null> {
+  const teamDoc = await TeamModel.findOne({ id, organization: orgId });
   return teamDoc ? toInterface(teamDoc) : null;
 }
 
-// export async function getMembersForTeam(id: string) {}
+export async function getTeamsForOrganization(
+  orgId: string
+): Promise<TeamInterface[]> {
+  const teamDocs = await TeamModel.find({
+    organization: orgId,
+  });
+  return teamDocs.map((team) => toInterface(team));
+}

--- a/packages/back-end/src/models/TeamModel.ts
+++ b/packages/back-end/src/models/TeamModel.ts
@@ -68,3 +68,17 @@ export async function getTeamsForOrganization(
   });
   return teamDocs.map((team) => toInterface(team));
 }
+
+export async function updateTeamMetadata(
+  id: string,
+  update: Partial<TeamInterface>
+) {
+  await TeamModel.updateOne(
+    {
+      id,
+    },
+    {
+      $set: omit(update, "members"),
+    }
+  );
+}

--- a/packages/back-end/src/models/TeamModel.ts
+++ b/packages/back-end/src/models/TeamModel.ts
@@ -1,0 +1,60 @@
+import mongoose from "mongoose";
+import { omit } from "lodash";
+import uniqid from "uniqid";
+import { TeamInterface } from "../../types/team";
+
+const teamSchema = new mongoose.Schema({
+  id: {
+    type: String,
+    unique: true,
+  },
+  name: String,
+  organization: String,
+  dateCreated: Date,
+  dateUpdated: Date,
+  createdBy: String,
+  description: String,
+  role: String,
+  limitAccessByEnvironment: Boolean,
+  environments: [String],
+  projectRoles: [
+    {
+      _id: false,
+      project: String,
+      role: String,
+      limitAccessByEnvironment: Boolean,
+      environments: [String],
+    },
+  ],
+});
+
+type TeamDocument = mongoose.Document & TeamInterface;
+
+const TeamModel = mongoose.model<TeamInterface>("Team", teamSchema);
+
+/**
+ * Convert the Mongo document to a TeamInterface, omitting Mongo default fields __v, _id
+ * @param doc
+ */
+const toInterface = (doc: TeamDocument): TeamInterface => {
+  return omit(doc.toJSON<TeamDocument>(), ["__v", "_id"]);
+};
+
+export async function createTeam(
+  data: Partial<TeamInterface>
+): Promise<TeamInterface> {
+  const teamDoc = await TeamModel.create({
+    ...data,
+    id: uniqid("team_"),
+    dateCreated: new Date(),
+    dateUpdated: new Date(),
+  });
+  return toInterface(teamDoc);
+}
+
+export async function findTeamById(id: string): Promise<TeamInterface | null> {
+  const teamDoc = await TeamModel.findById(id);
+  return teamDoc ? toInterface(teamDoc) : null;
+}
+
+// export async function getMembersForTeam(id: string) {}

--- a/packages/back-end/src/models/TeamModel.ts
+++ b/packages/back-end/src/models/TeamModel.ts
@@ -72,7 +72,7 @@ export async function getTeamsForOrganization(
 export async function updateTeamMetadata(
   id: string,
   update: Partial<TeamInterface>
-) {
+): Promise<void> {
   await TeamModel.updateOne(
     {
       id,
@@ -81,4 +81,11 @@ export async function updateTeamMetadata(
       $set: omit(update, "members"),
     }
   );
+}
+
+export async function deleteTeam(id: string, orgId: string): Promise<void> {
+  await TeamModel.deleteOne({
+    id,
+    organization: orgId,
+  });
 }

--- a/packages/back-end/src/models/TeamModel.ts
+++ b/packages/back-end/src/models/TeamModel.ts
@@ -32,6 +32,11 @@ type TeamDocument = mongoose.Document & TeamInterface;
 
 const TeamModel = mongoose.model<TeamInterface>("Team", teamSchema);
 
+type CreateTeamProps = Omit<
+  TeamInterface,
+  "dateCreated" | "dateUpdated" | "id"
+>;
+
 type UpdateTeamProps = Omit<
   TeamInterface,
   "dateCreated" | "dateUpdated" | "id" | "organization" | "createdBy"
@@ -46,7 +51,7 @@ const toInterface = (doc: TeamDocument): TeamInterface => {
 };
 
 export async function createTeam(
-  data: Partial<TeamInterface>
+  data: CreateTeamProps
 ): Promise<TeamInterface> {
   const teamDoc = await TeamModel.create({
     ...data,
@@ -80,7 +85,7 @@ export async function updateTeamMetadata(
   update: UpdateTeamProps
 ): Promise<UpdateTeamProps> {
   const changes = {
-    ...omit(update, "members"),
+    ...update,
     dateUpdated: new Date(),
   };
 

--- a/packages/back-end/src/models/TeamModel.ts
+++ b/packages/back-end/src/models/TeamModel.ts
@@ -32,6 +32,11 @@ type TeamDocument = mongoose.Document & TeamInterface;
 
 const TeamModel = mongoose.model<TeamInterface>("Team", teamSchema);
 
+type UpdateTeamProps = Omit<
+  TeamInterface,
+  "dateCreated" | "dateUpdated" | "id" | "organization" | "createdBy"
+>;
+
 /**
  * Convert the Mongo document to a TeamInterface, omitting Mongo default fields __v, _id
  * @param doc
@@ -71,16 +76,25 @@ export async function getTeamsForOrganization(
 
 export async function updateTeamMetadata(
   id: string,
-  update: Partial<TeamInterface>
-): Promise<void> {
+  orgId: string,
+  update: UpdateTeamProps
+): Promise<UpdateTeamProps> {
+  const changes = {
+    ...omit(update, "members"),
+    dateUpdated: new Date(),
+  };
+
   await TeamModel.updateOne(
     {
       id,
+      organization: orgId,
     },
     {
-      $set: omit(update, "members"),
+      $set: changes,
     }
   );
+
+  return changes;
 }
 
 export async function deleteTeam(id: string, orgId: string): Promise<void> {

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -16,6 +16,7 @@ import {
   acceptInvite,
   addMemberToOrg,
   addPendingMemberToOrg,
+  expandOrgMembers,
   findVerifiedOrgForNewUser,
   getInviteUrl,
   getOrgFromReq,
@@ -29,10 +30,9 @@ import {
   getNonSensitiveParams,
   getSourceIntegrationObject,
 } from "../../services/datasource";
-import { getUsersByIds, updatePassword } from "../../services/users";
+import { updatePassword } from "../../services/users";
 import { getAllTags } from "../../models/TagModel";
 import {
-  ExpandedMember,
   Invite,
   MemberRole,
   MemberRoleWithProjects,
@@ -609,20 +609,7 @@ export async function getOrganization(req: AuthRequest, res: Response) {
     ? getSSOConnectionSummary(req.loginMethod)
     : null;
 
-  // Add email/name to the organization members array
-  const userInfo = await getUsersByIds(members.map((m) => m.id));
-  const expandedMembers: ExpandedMember[] = [];
-  userInfo.forEach(({ id, email, verified, name, _id }) => {
-    const memberInfo = members.find((m) => m.id === id);
-    if (!memberInfo) return;
-    expandedMembers.push({
-      email,
-      verified,
-      name: name || "",
-      ...memberInfo,
-      dateCreated: memberInfo.dateCreated || _id.getTimestamp(),
-    });
-  });
+  const expandedMembers = await expandOrgMembers(members);
 
   return res.status(200).json({
     status: 200,

--- a/packages/back-end/src/routers/teams/teams.controller.ts
+++ b/packages/back-end/src/routers/teams/teams.controller.ts
@@ -13,18 +13,18 @@ import {
   auditDetailsUpdate,
 } from "../../services/audit";
 import {
+  addMemberToTeam,
   expandOrgMembers,
   getOrgFromReq,
   removeMemberFromTeam,
 } from "../../services/organizations";
 import { AuthRequest } from "../../types/AuthRequest";
-import { MemberRoleWithProjects } from "../../../types/organization";
+import { Member, MemberRoleWithProjects } from "../../../types/organization";
 
 // region POST /teams
 
 type CreateTeamRequest = AuthRequest<{
   name: string;
-  createdBy: string;
   description: string;
   permissions: MemberRoleWithProjects;
 }>;
@@ -156,9 +156,9 @@ export const getTeamById = async (
 type PutTeamRequest = AuthRequest<
   {
     name: string;
-    createdBy: string;
     description: string;
     permissions: MemberRoleWithProjects;
+    members?: string[];
   },
   { id: string }
 >;
@@ -178,7 +178,7 @@ export const updateTeam = async (
   res: Response<PutTeamResponse>
 ) => {
   const { org } = getOrgFromReq(req);
-  const { name, description, permissions } = req.body;
+  const { name, description, permissions, members } = req.body;
   const { id } = req.params;
 
   req.checkPermissions("manageTeam");
@@ -191,6 +191,31 @@ export const updateTeam = async (
     projectRoles: [],
     ...permissions,
   });
+
+  // If making changes to members remove members and add new requested members
+  if (members) {
+    const prevMembers: Member[] = org.members.filter((member) =>
+      member.teams?.includes(id)
+    );
+    await Promise.all(
+      prevMembers.map((member) => {
+        return removeMemberFromTeam({
+          organization: org,
+          userId: member.id,
+          teamId: id,
+        });
+      })
+    );
+    await Promise.all(
+      members.map((member) => {
+        return addMemberToTeam({
+          organization: org,
+          userId: member,
+          teamId: id,
+        });
+      })
+    );
+  }
 
   await req.audit({
     event: "team.update",
@@ -211,6 +236,10 @@ export const updateTeam = async (
 
 // region DELETE /teams/:id
 
+type DeleteTeamResponse = {
+  status: 200 | 400;
+  message?: string;
+};
 /**
  * DELETE /teams/:id
  * Delete team document for given id and remove team id from teams array for any
@@ -220,7 +249,7 @@ export const updateTeam = async (
  */
 export const deleteTeamById = async (
   req: AuthRequest<null, { id: string }>,
-  res: Response<{ status: 200 }>
+  res: Response<DeleteTeamResponse>
 ) => {
   const { org } = getOrgFromReq(req);
   const { id } = req.params;
@@ -231,16 +260,26 @@ export const deleteTeamById = async (
 
   const members = org.members.filter((member) => member.teams?.includes(id));
 
-  // Remove members from team to be deleted
-  await Promise.all(
-    members.map((member) => {
-      return removeMemberFromTeam({
-        organization: org,
-        userId: member.id,
-        teamId: id,
-      });
-    })
-  );
+  if (members) {
+    return res.status(400).json({
+      status: 400,
+      message:
+        "Cannot delete a team that has members. Please delete members before retrying.",
+    });
+  }
+
+  // TODO: Replace error above with code below once we add a double confirm delete dialog for team deletion in the UI
+
+  // // Remove members from team to be deleted
+  // await Promise.all(
+  //   members.map((member) => {
+  //     return removeMemberFromTeam({
+  //       organization: org,
+  //       userId: member.id,
+  //       teamId: id,
+  //     });
+  //   })
+  // );
 
   // Delete the team
   await deleteTeam(id, org.id);

--- a/packages/back-end/src/routers/teams/teams.controller.ts
+++ b/packages/back-end/src/routers/teams/teams.controller.ts
@@ -6,7 +6,7 @@ import {
   getTeamsForOrganization,
 } from "../../models/TeamModel";
 import { auditDetailsCreate } from "../../services/audit";
-import { getOrgFromReq } from "../../services/organizations";
+import { expandOrgMembers, getOrgFromReq } from "../../services/organizations";
 import { AuthRequest } from "../../types/AuthRequest";
 import { MemberRoleWithProjects } from "../../../types/organization";
 
@@ -112,6 +112,8 @@ export const getTeamById = async (
   req.checkPermissions("manageTeam");
 
   const team = await findTeamById(id, org.id);
+  const members = org.members.filter((member) => member.teams?.includes(id));
+  const expandedMembers = await expandOrgMembers(members);
 
   if (!team) {
     return res.status(404).json({
@@ -122,8 +124,13 @@ export const getTeamById = async (
 
   return res.status(200).json({
     status: 200,
-    team,
+    team: {
+      ...team,
+      members: expandedMembers,
+    },
   });
 };
 
 // endregion GET /teams/:id
+
+// region PUT /teams/:id

--- a/packages/back-end/src/routers/teams/teams.controller.ts
+++ b/packages/back-end/src/routers/teams/teams.controller.ts
@@ -199,7 +199,7 @@ export const updateTeam = async (
       id: id,
       name: name,
     },
-    details: auditDetailsUpdate(team, changes),
+    details: auditDetailsUpdate(team, { ...team, ...changes }),
   });
 
   return res.status(200).json({

--- a/packages/back-end/src/routers/teams/teams.controller.ts
+++ b/packages/back-end/src/routers/teams/teams.controller.ts
@@ -1,6 +1,10 @@
 import type { Response } from "express";
 import { TeamInterface } from "../../../types/team";
-import { createTeam } from "../../models/TeamModel";
+import {
+  createTeam,
+  findTeamById,
+  getTeamsForOrganization,
+} from "../../models/TeamModel";
 import { auditDetailsCreate } from "../../services/audit";
 import { getOrgFromReq } from "../../services/organizations";
 import { AuthRequest } from "../../types/AuthRequest";
@@ -60,3 +64,66 @@ export const postTeam = async (
 };
 
 // endregion POST /teams
+
+// region GET /teams
+
+type GetTeamsResponse = {
+  status: 200;
+  teams: TeamInterface[];
+};
+
+export const getTeams = async (
+  req: AuthRequest,
+  res: Response<GetTeamsResponse>
+) => {
+  const { org } = getOrgFromReq(req);
+
+  req.checkPermissions("manageTeam");
+
+  const teams = await getTeamsForOrganization(org.id);
+
+  return res.status(200).json({
+    status: 200,
+    teams,
+  });
+};
+
+// endregion GET /teams
+
+// region GET /teams/:id
+
+type GetTeamRequest = AuthRequest<{
+  id: string;
+}>;
+
+type GetTeamResponse = {
+  status: 200 | 404;
+  team?: TeamInterface;
+  message?: string;
+};
+
+export const getTeamById = async (
+  req: GetTeamRequest,
+  res: Response<GetTeamResponse>
+) => {
+  const { org } = getOrgFromReq(req);
+  const { id } = req.body;
+
+  req.checkPermissions("manageTeam");
+
+  const team = await findTeamById(id, org.id);
+
+  if (!team) {
+    return res.status(404).json({
+      status: 404,
+      message: "Cannot find team",
+    });
+  }
+
+  return res.status(200).json({
+    status: 200,
+    team,
+  });
+};
+
+// endregion GET /teams/:id

--- a/packages/back-end/src/routers/teams/teams.controller.ts
+++ b/packages/back-end/src/routers/teams/teams.controller.ts
@@ -1,0 +1,62 @@
+import type { Response } from "express";
+import { TeamInterface } from "../../../types/team";
+import { createTeam } from "../../models/TeamModel";
+import { auditDetailsCreate } from "../../services/audit";
+import { getOrgFromReq } from "../../services/organizations";
+import { AuthRequest } from "../../types/AuthRequest";
+import { MemberRoleWithProjects } from "../../../types/organization";
+
+// region POST /teams
+
+type CreateTeamRequest = AuthRequest<{
+  name: string;
+  createdBy: string;
+  description: string;
+  permissions: MemberRoleWithProjects;
+}>;
+
+type CreateTeamResponse = {
+  status: 200;
+  team: TeamInterface;
+};
+
+/**
+ * POST /teams
+ * Create a team resource
+ * @param req
+ * @param res
+ */
+export const postTeam = async (
+  req: CreateTeamRequest,
+  res: Response<CreateTeamResponse>
+) => {
+  const { org } = getOrgFromReq(req);
+  const { name, createdBy, description, permissions } = req.body;
+
+  req.checkPermissions("manageTeam");
+
+  const team = await createTeam({
+    name,
+    createdBy,
+    description,
+    organization: org.id,
+    ...permissions,
+  });
+
+  await req.audit({
+    event: "team.create",
+    entity: {
+      object: "team",
+      id: team.id,
+      name: name,
+    },
+    details: auditDetailsCreate(team),
+  });
+
+  return res.status(200).json({
+    status: 200,
+    team,
+  });
+};
+
+// endregion POST /teams

--- a/packages/back-end/src/routers/teams/teams.controller.ts
+++ b/packages/back-end/src/routers/teams/teams.controller.ts
@@ -164,7 +164,8 @@ type PutTeamRequest = AuthRequest<
 >;
 
 type PutTeamResponse = {
-  status: 200;
+  status: 200 | 404;
+  message?: string;
 };
 
 /**
@@ -184,6 +185,13 @@ export const updateTeam = async (
   req.checkPermissions("manageTeam");
 
   const team = await findTeamById(id, org.id);
+
+  if (!team) {
+    return res.status(404).json({
+      status: 404,
+      message: "Cannot find team",
+    });
+  }
 
   const changes = await updateTeamMetadata(id, org.id, {
     name,

--- a/packages/back-end/src/routers/teams/teams.router.ts
+++ b/packages/back-end/src/routers/teams/teams.router.ts
@@ -20,17 +20,26 @@ router.post(
     body: z
       .object({
         name: z.string(),
-        createdBy: z.string(),
         description: z.string(),
         permissions: PermissionZodObject.extend({
           projectRoles: PermissionZodObject.extend({
             project: z.string(),
-          }),
+          }).array(),
         }),
       })
       .strict(),
   }),
   teamController.postTeam
 );
+
+// TODO: add zod validation for these routes
+
+router.get("/:id", teamController.getTeamById);
+
+router.delete("/:id", teamController.deleteTeamById);
+
+router.get("/", teamController.getTeams);
+
+router.put("/:id", teamController.updateTeam);
 
 export { router as teamRouter };

--- a/packages/back-end/src/routers/teams/teams.router.ts
+++ b/packages/back-end/src/routers/teams/teams.router.ts
@@ -1,0 +1,36 @@
+import express from "express";
+import z from "zod";
+import { wrapController } from "../wrapController";
+import { validateRequestMiddleware } from "../utils/validateRequestMiddleware";
+import * as rawTeamController from "./teams.controller";
+
+const router = express.Router();
+
+const teamController = wrapController(rawTeamController);
+
+const PermissionZodObject = z.object({
+  role: z.string(),
+  limitAccessByEnvironment: z.boolean(),
+  environments: z.string().array(),
+});
+
+router.post(
+  "/",
+  validateRequestMiddleware({
+    body: z
+      .object({
+        name: z.string(),
+        createdBy: z.string(),
+        description: z.string(),
+        permissions: PermissionZodObject.extend({
+          projectRoles: PermissionZodObject.extend({
+            project: z.string(),
+          }),
+        }),
+      })
+      .strict(),
+  }),
+  teamController.postTeam
+);
+
+export { router as teamRouter };

--- a/packages/back-end/src/routers/teams/teams.router.ts
+++ b/packages/back-end/src/routers/teams/teams.router.ts
@@ -14,6 +14,10 @@ const PermissionZodObject = z.object({
   environments: z.string().array(),
 });
 
+router.get("/:id", teamController.getTeamById);
+
+router.get("/", teamController.getTeams);
+
 router.post(
   "/",
   validateRequestMiddleware({
@@ -32,14 +36,25 @@ router.post(
   teamController.postTeam
 );
 
-// TODO: add zod validation for these routes
-
-router.get("/:id", teamController.getTeamById);
+router.put(
+  "/:id",
+  validateRequestMiddleware({
+    body: z
+      .object({
+        name: z.string(),
+        description: z.string(),
+        permissions: PermissionZodObject.extend({
+          projectRoles: PermissionZodObject.extend({
+            project: z.string(),
+          }).array(),
+        }),
+        members: z.string().array().optional(),
+      })
+      .strict(),
+  }),
+  teamController.updateTeam
+);
 
 router.delete("/:id", teamController.deleteTeamById);
-
-router.get("/", teamController.getTeams);
-
-router.put("/:id", teamController.updateTeam);
 
 export { router as teamRouter };

--- a/packages/back-end/src/services/organizations.ts
+++ b/packages/back-end/src/services/organizations.ts
@@ -283,7 +283,7 @@ export async function addMemberToTeam({
   organization: OrganizationInterface;
   userId: string;
   teamId: string;
-}) {
+}): Promise<void> {
   // If member is a pending member, skip
   if (organization?.pendingMembers?.find((m) => m.id === userId)) {
     return;
@@ -301,6 +301,29 @@ export async function addMemberToTeam({
     member.teams = [];
   }
   member.teams.push(teamId);
+
+  await updateOrganization(organization.id, { members: organization.members });
+}
+
+export async function removeMemberFromTeam({
+  organization,
+  userId,
+  teamId,
+}: {
+  organization: OrganizationInterface;
+  userId: string;
+  teamId: string;
+}): Promise<void> {
+  const member = organization.members.find((m) => m.id === userId);
+
+  // If member doesn't exist in the org or isn't in the team, skip
+  if (!member || !member.teams?.includes(teamId)) {
+    return;
+  }
+
+  const indexToDelete = member.teams.indexOf(teamId);
+
+  member.teams.splice(indexToDelete, indexToDelete);
 
   await updateOrganization(organization.id, { members: organization.members });
 }

--- a/packages/back-end/src/services/organizations.ts
+++ b/packages/back-end/src/services/organizations.ts
@@ -323,7 +323,7 @@ export async function removeMemberFromTeam({
 
   const indexToDelete = member.teams.indexOf(teamId);
 
-  member.teams.splice(indexToDelete, indexToDelete);
+  member.teams.splice(indexToDelete, 1);
 
   await updateOrganization(organization.id, { members: organization.members });
 }

--- a/packages/back-end/src/services/organizations.ts
+++ b/packages/back-end/src/services/organizations.ts
@@ -12,6 +12,7 @@ import { APP_ORIGIN, IS_CLOUD } from "../util/secrets";
 import { AuthRequest } from "../types/AuthRequest";
 import { UserModel } from "../models/UserModel";
 import {
+  ExpandedMember,
   Invite,
   Member,
   MemberRole,
@@ -61,6 +62,7 @@ import {
 } from "./datasource";
 import { createMetric } from "./experiments";
 import { isEmailEnabled, sendInviteEmail, sendNewMemberEmail } from "./email";
+import { getUsersByIds } from "./users";
 
 export async function getOrganizationById(id: string) {
   return findOrganizationById(id);
@@ -271,6 +273,36 @@ export async function addMemberToOrg({
     members,
     pendingMembers,
   });
+}
+
+export async function addMemberToTeam({
+  organization,
+  userId,
+  teamId,
+}: {
+  organization: OrganizationInterface;
+  userId: string;
+  teamId: string;
+}) {
+  // If member is a pending member, skip
+  if (organization?.pendingMembers?.find((m) => m.id === userId)) {
+    return;
+  }
+
+  const member = organization.members.find((m) => m.id === userId);
+
+  // If member doesn't exist in the org or is already in the team, skip
+  if (!member || member.teams?.includes(teamId)) {
+    return;
+  }
+
+  // Create teams array for member if it does not exist
+  if (!member.teams) {
+    member.teams = [];
+  }
+  member.teams.push(teamId);
+
+  await updateOrganization(organization.id, { members: organization.members });
 }
 
 export async function addPendingMemberToOrg({
@@ -858,4 +890,24 @@ export async function findVerifiedOrgForNewUser(email: string) {
   return organizations.reduce((prev, current) => {
     return prev.members.length > current.members.length ? prev : current;
   });
+}
+
+export async function expandOrgMembers(
+  members: Member[]
+): Promise<ExpandedMember[]> {
+  // Add email/name to the organization members array
+  const userInfo = await getUsersByIds(members.map((m) => m.id));
+  const expandedMembers: ExpandedMember[] = [];
+  userInfo.forEach(({ id, email, verified, name, _id }) => {
+    const memberInfo = members.find((m) => m.id === id);
+    if (!memberInfo) return;
+    expandedMembers.push({
+      email,
+      verified,
+      name: name || "",
+      ...memberInfo,
+      dateCreated: memberInfo.dateCreated || _id.getTimestamp(),
+    });
+  });
+  return expandedMembers;
 }

--- a/packages/back-end/src/types/Audit.ts
+++ b/packages/back-end/src/types/Audit.ts
@@ -7,6 +7,7 @@ export const EntityType = [
   "user",
   "organization",
   "savedGroup",
+  "team",
 ] as const;
 
 export type EntityType = typeof EntityType[number];

--- a/packages/back-end/types/audit.d.ts
+++ b/packages/back-end/types/audit.d.ts
@@ -42,7 +42,10 @@ export type EventType =
   | "organization.delete"
   | "savedGroup.created"
   | "savedGroup.deleted"
-  | "savedGroup.updated";
+  | "savedGroup.updated"
+  | "team.create"
+  | "team.delete"
+  | "team.update";
 
 export interface AuditUserLoggedIn {
   id: string;

--- a/packages/back-end/types/organization.d.ts
+++ b/packages/back-end/types/organization.d.ts
@@ -36,6 +36,7 @@ export interface MemberRoleInfo {
   role: MemberRole;
   limitAccessByEnvironment: boolean;
   environments: string[];
+  teams?: string[];
 }
 
 export interface ProjectMemberRole extends MemberRoleInfo {

--- a/packages/back-end/types/team.d.ts
+++ b/packages/back-end/types/team.d.ts
@@ -11,6 +11,6 @@ export interface TeamInterface {
   role: string;
   limitAccessByEnvironment: boolean;
   environments: string[];
-  projectRoles: ProjectMemberRole[];
+  projectRoles?: ProjectMemberRole[];
   members?: ExpandedMember[];
 }

--- a/packages/back-end/types/team.d.ts
+++ b/packages/back-end/types/team.d.ts
@@ -1,0 +1,15 @@
+import { ProjectMemberRole } from "./organization";
+
+export interface TeamInterface {
+  id: string;
+  name: string;
+  organization: string;
+  dateCreated: Date;
+  dateUpdated: Date;
+  createdBy: string;
+  description: string;
+  globalRole: string;
+  limitAccessByEnvironment: boolean;
+  environments: string[];
+  projectRoles: ProjectMemberRole[];
+}

--- a/packages/back-end/types/team.d.ts
+++ b/packages/back-end/types/team.d.ts
@@ -1,4 +1,4 @@
-import { ProjectMemberRole } from "./organization";
+import { ExpandedMember, ProjectMemberRole } from "./organization";
 
 export interface TeamInterface {
   id: string;
@@ -12,4 +12,5 @@ export interface TeamInterface {
   limitAccessByEnvironment: boolean;
   environments: string[];
   projectRoles: ProjectMemberRole[];
+  members?: ExpandedMember[];
 }

--- a/packages/back-end/types/team.d.ts
+++ b/packages/back-end/types/team.d.ts
@@ -8,7 +8,7 @@ export interface TeamInterface {
   dateUpdated: Date;
   createdBy: string;
   description: string;
-  globalRole: string;
+  role: string;
   limitAccessByEnvironment: boolean;
   environments: string[];
   projectRoles: ProjectMemberRole[];


### PR DESCRIPTION
### Features and Changes

<!--
  Include a description of your changes.
  If there are any new tools, API's, etc. that devs can leverage, it may be helpful to include usage info.
-->
Creates a new team model, controller, and router to support future team management via the UI. I've also added an array of team ids to members within the organization collection.

New routes:

- `GET /teams`
- `GET /teams/:id`
- `POST /teams`
- `PUT /teams/:id`
- `DELETE /teams/:id`

- [x] Team mongoose model
- [x] Team creation endpoint
- [x] Team read endpoints
- [x] Team update endpoint
- [x] Team deletion endpoint
- [ ] Integrate teams into getUserPermissions (Blocked by #1543)

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

Tested each of these new routes via Insomnia. 
