### PR TITLE
fix: access optional _maintainer safely in import from LD feature

### DIFF
--- a/packages/front-end/services/importing.ts
+++ b/packages/front-end/services/importing.ts
@@ -62,7 +62,7 @@ export type LDListFeatureFlagsResponse = {
       _id: string;
       value: unknown; // maps to `kind`
     }[];
-    _maintainer: {
+    _maintainer?: {
       email: string;
       firstName: string;
       lastName: string;
@@ -99,7 +99,7 @@ export const transformLDFeatureFlagToGBFeature = (
 >[] => {
   return data.items.map(
     ({
-      _maintainer: { email, firstName, lastName },
+      _maintainer,
       environments,
       key,
       kind,
@@ -121,6 +121,10 @@ export const transformLDFeatureFlagToGBFeature = (
         };
       });
 
+      const owner = _maintainer
+        ? `${_maintainer.firstName} ${_maintainer.lastName} (${_maintainer.email})`
+        : "(unknown - imported from LaunchDarkly)";
+
       return {
         environmentSettings: gbEnvironments,
         defaultValue:
@@ -130,7 +134,7 @@ export const transformLDFeatureFlagToGBFeature = (
         project,
         id: key,
         description: description || name,
-        owner: `${firstName} ${lastName} (${email})`,
+        owner,
         tags,
         // todo: get valueType a bit better
         valueType: kind === "boolean" ? "boolean" : "string",


### PR DESCRIPTION
While I cannot reproduce the following error, it's likely this is a fix for it:

<img width="1404" alt="image" src="https://github.com/growthbook/growthbook/assets/113377031/3480701d-3b34-4b10-a066-2c585e3ca7d1">

