### PR TITLE
Approval flows → Add minApprovals to organization settings

### DIFF
--- a/packages/back-end/types/organization.d.ts
+++ b/packages/back-end/types/organization.d.ts
@@ -163,6 +163,7 @@ export interface OrganizationSettings {
   secureAttributeSalt?: string;
   killswitchConfirmation?: boolean;
   defaultDataSource?: string;
+  minApprovals?: number;
 }
 
 export interface SubscriptionQuote {

--- a/packages/front-end/pages/settings/index.tsx
+++ b/packages/front-end/pages/settings/index.tsx
@@ -308,6 +308,7 @@ const GeneralSettingsPage = (): React.ReactElement => {
         hours: 6,
         cron: "0 */6 * * *",
       },
+      minApprovals: undefined,
       multipleExposureMinPercent: 0.01,
       confidenceLevel: 0.95,
       pValueThreshold: 0.05,
@@ -1395,6 +1396,28 @@ const GeneralSettingsPage = (): React.ReactElement => {
                     }}
                   />
                 </div>
+
+                {growthbook?.isOn("ff-approval-flow") ? (
+                  <div>
+                    <div className="form-inline">
+                      <Field
+                        label="Minimum Approvals Required"
+                        type="number"
+                        className="ml-2"
+                        containerClassName="mt-2"
+                        {...form.register("minApprovals", {
+                          valueAsNumber: true,
+                        })}
+                      />
+                    </div>
+                    <p>
+                      <small className="text-muted mb-3">
+                        Minimum number of reviewers required when approving
+                        feature flag changes
+                      </small>
+                    </p>
+                  </div>
+                ) : null}
               </div>
             </div>
             <div className="divider border-bottom mb-3 mt-3" />

--- a/packages/front-end/types/app-features.ts
+++ b/packages/front-end/types/app-features.ts
@@ -31,4 +31,8 @@ export type AppFeatures = {
   "remote-evaluation": boolean;
   "import-from-x": boolean;
   "demo-datasource": boolean;
+  "new-experiment-rule": boolean;
+  "visual-editor-ai-enabled": boolean;
+  "team-permissions-enabled": boolean;
+  "ff-approval-flow": boolean;
 };


### PR DESCRIPTION
### Features and Changes

Adds `minApprovals` to the existing organization settings.

Currently gated behind the feature flag `ff-approval-flow`.


### Testing

- Run in development 
- Check the organization settings page and see the new field
- Update it and check the organization settings in Mongo and see the reflected value

### Screenshots

<img width="802" alt="Screen Shot 2023-08-18 at 12 32 48 PM" src="https://github.com/growthbook/growthbook/assets/113377031/24341149-8e8b-42e1-9c90-8e9828229ef3">
