### PR TITLE
set min conversion window hours to 0 (ex: allow for 0.25)

### DIFF
--- a/packages/front-end/components/Experiment/MetricsOverridesSelector.tsx
+++ b/packages/front-end/components/Experiment/MetricsOverridesSelector.tsx
@@ -212,7 +212,7 @@ export default function MetricsOverridesSelector({
                           labelClassName="small mb-1"
                           type="number"
                           containerClassName="mb-0 metric-override"
-                          min={0}
+                          min={0.125}
                           step="any"
                           {...form.register(
                             `metricOverrides.${i}.conversionWindowHours`,

--- a/packages/front-end/components/Metrics/MetricForm/index.tsx
+++ b/packages/front-end/components/Metrics/MetricForm/index.tsx
@@ -1049,7 +1049,7 @@ const MetricForm: FC<MetricFormProps> = ({
                   <input
                     type="number"
                     step="any"
-                    min={0}
+                    min={0.125}
                     className="form-control"
                     placeholder={getDefaultConversionWindowHours() + ""}
                     {...form.register("conversionWindowHours", {

--- a/packages/front-end/components/Metrics/MetricForm/index.tsx
+++ b/packages/front-end/components/Metrics/MetricForm/index.tsx
@@ -1049,7 +1049,7 @@ const MetricForm: FC<MetricFormProps> = ({
                   <input
                     type="number"
                     step="any"
-                    min="1"
+                    min={0}
                     className="form-control"
                     placeholder={getDefaultConversionWindowHours() + ""}
                     {...form.register("conversionWindowHours", {


### PR DESCRIPTION
### Features and Changes

Change the min from `1` to `0.125` (7.5 mins) on the input field

- Closes **(add link to issue here)**

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

<!--
  Please describe how to test these changes.
 -->

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
