### PR TITLE
Results table fast follows: split shading toggle, allow multiple feedback submissions

### DIFF
--- a/packages/front-end/components/Experiment/AlignedGraph.tsx
+++ b/packages/front-end/components/Experiment/AlignedGraph.tsx
@@ -105,7 +105,7 @@ const AlignedGraph: FC<Props> = ({
       barColor = "#aaa";
     }
   }
-  if(splitShading) {
+  if (splitShading) {
     barFillType = "gradient";
   }
 

--- a/packages/front-end/components/Experiment/AlignedGraph.tsx
+++ b/packages/front-end/components/Experiment/AlignedGraph.tsx
@@ -37,6 +37,7 @@ interface Props
   barColorDanger?: string;
   expectedColor?: string;
   newUi?: boolean;
+  splitShading?: boolean;
   rowStatus?: string;
   isHovered?: boolean;
   onPointerMove?: (e: React.PointerEvent<SVGPathElement>) => void;
@@ -80,6 +81,7 @@ const AlignedGraph: FC<Props> = ({
   barColorWarning = "#d99132cc",
   barColorDanger = "#d94032cc",
   newUi = false,
+  splitShading = false,
   rowStatus,
   isHovered = false,
   onPointerMove,
@@ -88,20 +90,23 @@ const AlignedGraph: FC<Props> = ({
 }) => {
   if (newUi) {
     sigBarColorPos = "#52be5b";
-    sigBarColorNeg = "#d35a5a";
+    sigBarColorNeg = "#b34b4b";
     // barColorDraw = "#9C89BE";
     barColorOk = "#55ab95";
     barColorWarning = "#d99132";
     barColorDanger = "#d94032";
     if (isHovered) {
-      sigBarColorPos = "#39cb45";
-      sigBarColorNeg = "#e34040";
+      sigBarColorPos = "#39cc45";
+      sigBarColorNeg = "#b53333";
       // barColorDraw = "#957dc2";
       barColorOk = "#4ec2a5";
       barColorWarning = "#ea9526";
       barColorDanger = "#e83223";
       barColor = "#aaa";
     }
+  }
+  if(splitShading) {
+    barFillType = "gradient";
   }
 
   if (barType == "violin" && !uplift) {
@@ -136,7 +141,7 @@ const AlignedGraph: FC<Props> = ({
 
   const barHeight = Math.floor(height / 2) - barThickness / 2;
 
-  if (inverse && !rowStatus) {
+  if (inverse && (!rowStatus || splitShading)) {
     [sigBarColorNeg, sigBarColorPos] = [sigBarColorPos, sigBarColorNeg];
   }
   // rough number of columns:
@@ -177,19 +182,21 @@ const AlignedGraph: FC<Props> = ({
       : barColor;
 
   // forced color state (nothing needed for non-significant):
-  if (rowStatus === "won") {
-    barFill = sigBarColorPos;
-  } else if (rowStatus === "lost") {
-    barFill = sigBarColorNeg;
-  } else if (rowStatus === "draw") {
-    // barFill = barColorDraw;
-    barFill = barColor;
-  } else if (rowStatus === "ok") {
-    barFill = barColorOk;
-  } else if (rowStatus === "warning") {
-    barFill = barColorWarning;
-  } else if (rowStatus === "danger") {
-    barFill = barColorDanger;
+  if (!splitShading) {
+    if (rowStatus === "won") {
+      barFill = sigBarColorPos;
+    } else if (rowStatus === "lost") {
+      barFill = sigBarColorNeg;
+    } else if (rowStatus === "draw") {
+      // barFill = barColorDraw;
+      barFill = barColor;
+    } else if (rowStatus === "ok") {
+      barFill = barColorOk;
+    } else if (rowStatus === "warning") {
+      barFill = barColorWarning;
+    } else if (rowStatus === "danger") {
+      barFill = barColorDanger;
+    }
   }
 
   return (

--- a/packages/front-end/components/Experiment/CompactResults.tsx
+++ b/packages/front-end/components/Experiment/CompactResults.tsx
@@ -19,11 +19,16 @@ import {
 } from "@/services/experiments";
 import { GBCuped } from "@/components/Icons";
 import { QueryStatusData } from "@/components/Queries/RunQueriesButton";
+import { useLocalStorage } from "@/hooks/useLocalStorage";
 import Tooltip from "../Tooltip/Tooltip";
 import MetricTooltipBody from "../Metrics/MetricTooltipBody";
 import DataQualityWarning from "./DataQualityWarning";
 import ResultsTable from "./ResultsTable";
 import MultipleExposureWarning from "./MultipleExposureWarning";
+
+export type TableDisplaySettings = {
+  splitShading: boolean;
+};
 
 const CompactResults: FC<{
   editMetrics?: () => void;
@@ -67,6 +72,23 @@ const CompactResults: FC<{
   isTabActive,
 }) => {
   const { getMetricById, ready } = useDefinitions();
+
+  // user settings for table display:
+  const [
+    tableDisplaySettings,
+    setTableDisplaySettings,
+  ] = useLocalStorage<TableDisplaySettings>("results-table-display-settings", {
+    splitShading: false,
+  });
+  const updateTableDisplaySettings = (
+    key: keyof TableDisplaySettings,
+    value: boolean
+  ) => {
+    setTableDisplaySettings({
+      ...tableDisplaySettings,
+      [key]: value,
+    });
+  };
 
   const rows = useMemo<ExperimentTableRow[]>(() => {
     function getRow(metricId: string, isGuardrail: boolean) {
@@ -153,6 +175,8 @@ const CompactResults: FC<{
         pValueCorrection={pValueCorrection}
         renderLabelColumn={getRenderLabelColumn(regressionAdjustmentEnabled)}
         isTabActive={isTabActive}
+        tableDisplaySettings={tableDisplaySettings}
+        updateTableDisplaySettings={updateTableDisplaySettings}
       />
 
       {guardrails.length ? (
@@ -178,6 +202,8 @@ const CompactResults: FC<{
               regressionAdjustmentEnabled
             )}
             isTabActive={isTabActive}
+            tableDisplaySettings={tableDisplaySettings}
+            updateTableDisplaySettings={updateTableDisplaySettings}
           />
         </div>
       ) : (

--- a/packages/front-end/components/Experiment/PercentGraph.tsx
+++ b/packages/front-end/components/Experiment/PercentGraph.tsx
@@ -18,6 +18,7 @@ interface Props
   graphWidth?: number;
   height?: number;
   newUi?: boolean;
+  splitShading?: boolean;
   isHovered?: boolean;
   onPointerMove?: (e: React.PointerEvent<SVGPathElement>) => void;
   onPointerLeave?: (e: React.PointerEvent<SVGPathElement>) => void;
@@ -35,6 +36,7 @@ export default function PercentGraph({
   graphWidth,
   height,
   newUi = false,
+  splitShading = false,
   isHovered = false,
   onPointerMove,
   onPointerLeave,
@@ -76,6 +78,7 @@ export default function PercentGraph({
       height={height}
       inverse={!!metric?.inverse}
       newUi={newUi}
+      splitShading={splitShading}
       isHovered={isHovered}
       onPointerMove={onPointerMove}
       onPointerLeave={onPointerLeave}

--- a/packages/front-end/components/Experiment/ResultsTable.tsx
+++ b/packages/front-end/components/Experiment/ResultsTable.tsx
@@ -25,7 +25,7 @@ import {
   useDomain,
 } from "@/services/experiments";
 import useOrgSettings from "@/hooks/useOrgSettings";
-import { GBEdit } from "@/components/Icons";
+import { GBEdit, GBSplitShading } from "@/components/Icons";
 import useConfidenceLevels from "@/hooks/useConfidenceLevels";
 import usePValueThreshold from "@/hooks/usePValueThreshold";
 import { useOrganizationMetricDefaults } from "@/hooks/useOrganizationMetricDefaults";
@@ -42,6 +42,7 @@ import ResultsTableTooltip, {
   YAlign,
 } from "@/components/Experiment/ResultsTableTooltip";
 import { QueryStatusData } from "@/components/Queries/RunQueriesButton";
+import { TableDisplaySettings } from "@/components/Experiment/CompactResults";
 import Tooltip from "../Tooltip/Tooltip";
 import AlignedGraph from "./AlignedGraph";
 import ChanceToWinColumn from "./ChanceToWinColumn";
@@ -71,6 +72,11 @@ export type ResultsTableProps = {
   pValueCorrection?: PValueCorrection;
   sequentialTestingEnabled?: boolean;
   isTabActive: boolean;
+  tableDisplaySettings?: TableDisplaySettings;
+  updateTableDisplaySettings?: (
+    key: keyof TableDisplaySettings,
+    value: boolean
+  ) => void;
 };
 
 const ROW_HEIGHT = 42;
@@ -96,6 +102,8 @@ export default function ResultsTable({
   pValueCorrection,
   sequentialTestingEnabled = false,
   isTabActive,
+  tableDisplaySettings,
+  updateTableDisplaySettings,
 }: ResultsTableProps) {
   const {
     metricDefaults,
@@ -349,7 +357,10 @@ export default function ResultsTable({
   }, [hoverTimeout]);
 
   return (
-    <div className="position-relative" ref={containerRef}>
+    <div
+      className="experiment-results-wrapper position-relative"
+      ref={containerRef}
+    >
       <CSSTransition
         key={`${hoveredMetricRow}-${hoveredVariationRow}`}
         in={
@@ -375,7 +386,10 @@ export default function ResultsTable({
         />
       </CSSTransition>
 
-      <div ref={tableContainerRef} className="experiment-results-wrapper">
+      <div
+        ref={tableContainerRef}
+        className="experiment-results-scroll-wrapper"
+      >
         <div className="w-100" style={{ minWidth: 700 }}>
           <table
             id="main-results"
@@ -748,10 +762,15 @@ export default function ResultsTable({
                               domain={domain}
                               metric={row.metric}
                               stats={stats}
-                              id={`${id}_violin_row${i}_var${j}`}
+                              id={`${id}_violin_row${i}_var${j}_${
+                                metricsAsGuardrails ? "g" : "m"
+                              }`}
                               graphWidth={graphCellWidth}
                               height={ROW_HEIGHT}
                               newUi={true}
+                              splitShading={
+                                !!tableDisplaySettings?.splitShading
+                              }
                               isHovered={isHovered}
                               onPointerMove={(e) =>
                                 onPointerMove(e, {
@@ -836,6 +855,33 @@ export default function ResultsTable({
           ) : null}
         </div>
       </div>
+
+      {tableDisplaySettings && updateTableDisplaySettings ? (
+        <div className="display-settings w-100 d-flex justify-content-end">
+          <div className="inner">
+            <Tooltip
+              body={
+                <>
+                  Split shading (
+                  {tableDisplaySettings?.splitShading ? "ON" : "OFF"})
+                </>
+              }
+            >
+              <button
+                className="btn btn-outline-primary btn-sm"
+                onClick={() => {
+                  updateTableDisplaySettings(
+                    "splitShading",
+                    !tableDisplaySettings?.splitShading
+                  );
+                }}
+              >
+                <GBSplitShading state={tableDisplaySettings?.splitShading} />
+              </button>
+            </Tooltip>
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/packages/front-end/components/Icons.tsx
+++ b/packages/front-end/components/Icons.tsx
@@ -674,9 +674,17 @@ export function GBSplitShading({
       className={className}
       {...otherProps}
     >
-      <path fill={state ? "#B34B4B" : "#52BE5B"} className="st0" d="M186,107.2H98.3c-50.3,0-91.4,38.4-91.4,85.3v0c0,46.9,41.1,85.3,91.4,85.3H186"/>
-      <path fill="#52BE5B" className="st1" d="M251,277.8h162.7c50.3,0,91.4-38.4,91.4-85.3v0c0-46.9-41.1-85.3-91.4-85.3H251"/>
-      <rect x="186" y="42.5" width="65" height="295"/>
+      <path
+        fill={state ? "#B34B4B" : "#52BE5B"}
+        className="st0"
+        d="M186,107.2H98.3c-50.3,0-91.4,38.4-91.4,85.3v0c0,46.9,41.1,85.3,91.4,85.3H186"
+      />
+      <path
+        fill="#52BE5B"
+        className="st1"
+        d="M251,277.8h162.7c50.3,0,91.4-38.4,91.4-85.3v0c0-46.9-41.1-85.3-91.4-85.3H251"
+      />
+      <rect x="201" y="42.5" width="30" height="295" />
     </svg>
   );
 }

--- a/packages/front-end/components/Icons.tsx
+++ b/packages/front-end/components/Icons.tsx
@@ -657,3 +657,26 @@ export function GBSuspicious({
     </svg>
   );
 }
+
+export function GBSplitShading({
+  className = "",
+  size = 18,
+  state = false,
+  ...otherProps
+}): React.ReactElement {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 512 384"
+      fill="#000"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      {...otherProps}
+    >
+      <path fill={state ? "#B34B4B" : "#52BE5B"} className="st0" d="M186,107.2H98.3c-50.3,0-91.4,38.4-91.4,85.3v0c0,46.9,41.1,85.3,91.4,85.3H186"/>
+      <path fill="#52BE5B" className="st1" d="M251,277.8h162.7c50.3,0,91.4-38.4,91.4-85.3v0c0-46.9-41.1-85.3-91.4-85.3H251"/>
+      <rect x="186" y="42.5" width="65" height="295"/>
+    </svg>
+  );
+}

--- a/packages/front-end/pages/experiment/[eid].tsx
+++ b/packages/front-end/pages/experiment/[eid].tsx
@@ -60,10 +60,6 @@ const ExperimentPage = (): ReactElement => {
     "experiment-results-new-ui-v2",
     true
   );
-  const [showFeedbackBanner, setShowFeedbackBanner] = useLocalStorage<boolean>(
-    "experiment-results-new-ui-v2-feedback-banner",
-    true
-  );
   const [showFeedbackModal, setShowFeedbackModal] = useState<boolean>(false);
 
   const { features } = useFeaturesList(false);
@@ -244,20 +240,18 @@ const ExperimentPage = (): ReactElement => {
                 {newUi ? <FaUndo /> : <FaMagic />}
               </a>
             </div>
-            {showFeedbackBanner ? (
-              <div className="border-left pl-3 ml-3 give-feedback">
-                <a
-                  className="a"
-                  role="button"
-                  onClick={() => {
-                    setShowFeedbackModal(true);
-                  }}
-                >
-                  tell us your thoughts
-                  <BsChatSquareQuote size="18" className="ml-1" />
-                </a>
-              </div>
-            ) : null}
+            <div className="border-left pl-3 ml-3 give-feedback">
+              <a
+                className="a"
+                role="button"
+                onClick={() => {
+                  setShowFeedbackModal(true);
+                }}
+              >
+                tell us your thoughts
+                <BsChatSquareQuote size="18" className="ml-1" />
+              </a>
+            </div>
           </div>
         </div>
         <SnapshotProvider experiment={experiment}>
@@ -300,7 +294,6 @@ const ExperimentPage = (): ReactElement => {
         <FeedbackModal
           open={showFeedbackModal}
           close={() => setShowFeedbackModal(false)}
-          submitCallback={() => setShowFeedbackBanner(false)}
           header={
             <>
               <BsChatSquareQuote size="20" className="mr-2" />

--- a/packages/front-end/styles/global.scss
+++ b/packages/front-end/styles/global.scss
@@ -474,9 +474,41 @@ pre {
 }
 
 .experiment-results-wrapper {
-  padding-bottom: 1px; // to allow for bottom border
-  @media (max-width: 900px) {
-    overflow-x: auto;
+  .experiment-results-scroll-wrapper {
+    padding-bottom: 1px; // to allow for bottom border
+    @media (max-width: 900px) {
+      overflow-x: auto;
+    }
+  }
+  .display-settings {
+    opacity: 0;
+    transition: 150ms all;
+    margin-bottom: -20px;
+    .inner {
+      padding: 4px;
+      border: 1px solid #6662;
+      border-top: 0 none;
+      border-radius: 0 0 5px 5px;
+    }
+    button {
+      opacity: 0.5;
+      transition: 150ms all;
+      padding: 0;
+      width: 25px;
+      height: 25px;
+      text-align: center;
+      display: inline-flex;
+      justify-content: center;
+      align-items: center;
+      &:hover {
+        opacity: 1;
+      }
+    }
+  }
+  &:hover {
+    .display-settings {
+      opacity: 1;
+    }
   }
 }
 


### PR DESCRIPTION
- add toggle button for split shading versus status-based shading
  - button stays hidden until hovering over the table
  - saved in localstorage (per user), across all pages
- allow multiple feedback submissions
- make shading a bit less Xmasy

![image](https://github.com/growthbook/growthbook/assets/7927873/0310a55b-80ac-4ab6-a5f4-9253c983e4ed)

### Features and Changes

<!--
  Include a description of your changes.
  If there are any new tools, API's, etc. that devs can leverage, it may be helpful to include usage info.
-->

<!--
  Indicate which issue this will close, if applicable
  For multiple issues, add a new `- Closes` or `- Fixes` line
-->

- Closes **(add link to issue here)**

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

<!--
  Please describe how to test these changes.
 -->

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
