### PR TITLE
Fix whitespace bug with saved groups

### DIFF
--- a/packages/front-end/components/SavedGroupForm.tsx
+++ b/packages/front-end/components/SavedGroupForm.tsx
@@ -88,7 +88,10 @@ const SavedGroupForm: FC<{
           value={rawText}
           onChange={(e) => {
             setRawText(e.target.value);
-            form.setValue("groupList", e.target.value.trim().split(","));
+            form.setValue(
+              "groupList",
+              e.target.value.split(",").map((val) => val.trim())
+            );
           }}
         />
       ) : (
@@ -98,7 +101,7 @@ const SavedGroupForm: FC<{
           value={form.watch("groupList")}
           onChange={(values) => {
             form.setValue("groupList", values);
-            setRawText(values.join(", "));
+            setRawText(values.join(","));
           }}
           placeholder="Enter some values..."
           delimiters={["Enter", "Tab"]}


### PR DESCRIPTION
### Features and Changes

<!--
  Include a description of your changes.
  If there are any new tools, API's, etc. that devs can leverage, it may be helpful to include usage info.
-->
Fixes bug that adds whitespace to the beginning of values for a saved group

<!--
  Indicate which issue this will close, if applicable
  For multiple issues, add a new `- Closes` or `- Fixes` line
-->

- Closes #1605 

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

<!--
  Please describe how to test these changes.
 -->

1. Create a saved group
2. Add some values & save
3. Edit the group in raw text mode & save
4. Check audit log for saved group and make sure the change only added the new value and didn't add whitespaces to the previously existing values

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
