### PR TITLE
Validate required columns in Metrics EditSql modal

### DIFF
--- a/packages/front-end/components/Metrics/MetricForm/index.tsx
+++ b/packages/front-end/components/Metrics/MetricForm/index.tsx
@@ -13,7 +13,6 @@ import {
   DEFAULT_REGRESSION_ADJUSTMENT_ENABLED,
 } from "shared/constants";
 import { isDemoDatasourceProject } from "shared/demo-datasource";
-import { TestQueryRow } from "back-end/src/types/Integration";
 import { useOrganizationMetricDefaults } from "@/hooks/useOrganizationMetricDefaults";
 import { getInitialMetricQuery, validateSQL } from "@/services/datasources";
 import { useDefinitions } from "@/services/DefinitionsContext";
@@ -532,21 +531,6 @@ const MetricForm: FC<MetricFormProps> = ({
     return set;
   }, [value.userIdTypes, type]);
 
-  const validateResponse = (result: TestQueryRow) => {
-    if (!result) return;
-
-    const requiredColumnsArray = Array.from(requiredColumns);
-    const missingColumns = requiredColumnsArray.filter(
-      (col) => !((col as string) in result)
-    );
-
-    if (missingColumns.length > 0) {
-      throw new Error(
-        `You are missing the following columns: ${missingColumns.join(", ")}`
-      );
-    }
-  };
-
   useEffect(() => {
     if (type === "binomial") {
       form.setValue("ignoreNulls", false);
@@ -581,7 +565,6 @@ const MetricForm: FC<MetricFormProps> = ({
             "SELECT\n      user_id as user_id, timestamp as timestamp\nFROM\n      test"
           }
           requiredColumns={requiredColumns}
-          validateResponse={validateResponse}
           value={value.sql}
           save={async (sql) => form.setValue("sql", sql)}
           templateVariables={{

--- a/packages/front-end/components/Metrics/MetricForm/index.tsx
+++ b/packages/front-end/components/Metrics/MetricForm/index.tsx
@@ -13,6 +13,7 @@ import {
   DEFAULT_REGRESSION_ADJUSTMENT_ENABLED,
 } from "shared/constants";
 import { isDemoDatasourceProject } from "shared/demo-datasource";
+import { TestQueryRow } from "back-end/src/types/Integration";
 import { useOrganizationMetricDefaults } from "@/hooks/useOrganizationMetricDefaults";
 import { getInitialMetricQuery, validateSQL } from "@/services/datasources";
 import { useDefinitions } from "@/services/DefinitionsContext";
@@ -45,7 +46,6 @@ import { GBCuped } from "@/components/Icons";
 import usePermissions from "@/hooks/usePermissions";
 import { useCurrency } from "@/hooks/useCurrency";
 import { useDemoDataSourceProject } from "@/hooks/useDemoDataSourceProject";
-import { TestQueryRow } from "back-end/src/types/Integration";
 
 const weekAgo = new Date();
 weekAgo.setDate(weekAgo.getDate() - 7);
@@ -536,7 +536,7 @@ const MetricForm: FC<MetricFormProps> = ({
     if (!result) return;
 
     const requiredColumnsArray = Array.from(requiredColumns);
-    let missingColumns = requiredColumnsArray.filter(
+    const missingColumns = requiredColumnsArray.filter(
       (col) => !((col as string) in result)
     );
 

--- a/packages/front-end/components/SchemaBrowser/EditSqlModal.tsx
+++ b/packages/front-end/components/SchemaBrowser/EditSqlModal.tsx
@@ -28,7 +28,7 @@ export interface Props {
   close: () => void;
   requiredColumns: Set<string>;
   placeholder?: string;
-  validateResponse?: (response: TestQueryResults) => void;
+  validateResponse?: (response: TestQueryRow) => void;
   templateVariables?: {
     eventName?: string;
     valueColumn?: string;

--- a/packages/front-end/components/SchemaBrowser/EditSqlModal.tsx
+++ b/packages/front-end/components/SchemaBrowser/EditSqlModal.tsx
@@ -28,7 +28,7 @@ export interface Props {
   close: () => void;
   requiredColumns: Set<string>;
   placeholder?: string;
-  validateResponse?: (response: TestQueryRow) => void;
+  validateResponseOverride?: (response: TestQueryRow) => void;
   templateVariables?: {
     eventName?: string;
     valueColumn?: string;
@@ -42,7 +42,7 @@ export default function EditSqlModal({
   requiredColumns,
   placeholder = "",
   datasourceId,
-  validateResponse,
+  validateResponseOverride,
   templateVariables,
 }: Props) {
   const [
@@ -62,6 +62,21 @@ export default function EditSqlModal({
   const [cursorData, setCursorData] = useState<null | CursorData>(null);
   const [testingQuery, setTestingQuery] = useState(false);
 
+  const validateRequiredColumns = (result: TestQueryRow) => {
+    if (!result) return;
+
+    const requiredColumnsArray = Array.from(requiredColumns);
+    const missingColumns = requiredColumnsArray.filter(
+      (col) => !((col as string) in result)
+    );
+
+    if (missingColumns.length > 0) {
+      throw new Error(
+        `You are missing the following columns: ${missingColumns.join(", ")}`
+      );
+    }
+  };
+
   const runTestQuery = async (sql: string) => {
     validateSQL(sql, []);
     setTestQueryResults(null);
@@ -74,8 +89,12 @@ export default function EditSqlModal({
       }),
     });
 
-    if (res.results?.length && validateResponse) {
-      validateResponse(res.results[0]);
+    if (res.results?.length) {
+      if (validateResponseOverride) {
+        validateResponseOverride(res.results[0]);
+      } else {
+        validateRequiredColumns(res.results[0]);
+      }
     }
 
     return res;
@@ -92,6 +111,7 @@ export default function EditSqlModal({
     }
     setTestingQuery(false);
   };
+
   const datasource = getDatasourceById(datasourceId);
   const supportsSchemaBrowser =
     datasource?.properties?.supportsInformationSchema;

--- a/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/AddEditExperimentAssignmentQueryModal.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/AddEditExperimentAssignmentQueryModal.tsx
@@ -224,7 +224,7 @@ export const AddEditExperimentAssignmentQueryModal: FC<EditExperimentAssignmentQ
           save={async (userEnteredQuery) => {
             form.setValue("query", userEnteredQuery);
           }}
-          validateResponse={validateResponse}
+          validateResponseOverride={validateResponse}
         />
       )}
       <Modal

--- a/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/AddEditExperimentAssignmentQueryModal.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/AddEditExperimentAssignmentQueryModal.tsx
@@ -7,6 +7,7 @@ import { useForm } from "react-hook-form";
 import cloneDeep from "lodash/cloneDeep";
 import uniqId from "uniqid";
 import { FaExclamationTriangle, FaExternalLinkAlt } from "react-icons/fa";
+import { TestQueryRow } from "back-end/src/types/Integration";
 import Code from "@/components/SyntaxHighlighting/Code";
 import StringArrayField from "@/components/Forms/StringArrayField";
 import Toggle from "@/components/Forms/Toggle";
@@ -14,7 +15,6 @@ import Tooltip from "@/components/Tooltip/Tooltip";
 import Modal from "../../../Modal";
 import Field from "../../../Forms/Field";
 import EditSqlModal from "../../../SchemaBrowser/EditSqlModal";
-import { TestQueryRow } from "back-end/src/types/Integration";
 
 type EditExperimentAssignmentQueryProps = {
   exposureQuery?: ExposureQuery;

--- a/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/AddEditExperimentAssignmentQueryModal.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/AddEditExperimentAssignmentQueryModal.tsx
@@ -13,9 +13,8 @@ import Toggle from "@/components/Forms/Toggle";
 import Tooltip from "@/components/Tooltip/Tooltip";
 import Modal from "../../../Modal";
 import Field from "../../../Forms/Field";
-import EditSqlModal, {
-  TestQueryResults,
-} from "../../../SchemaBrowser/EditSqlModal";
+import EditSqlModal from "../../../SchemaBrowser/EditSqlModal";
+import { TestQueryRow } from "back-end/src/types/Integration";
 
 type EditExperimentAssignmentQueryProps = {
   exposureQuery?: ExposureQuery;
@@ -111,7 +110,7 @@ export const AddEditExperimentAssignmentQueryModal: FC<EditExperimentAssignmentQ
     return null;
   }
 
-  const validateResponse = (result: TestQueryResults) => {
+  const validateResponse = (result: TestQueryRow) => {
     if (!result) return;
 
     const namedCols = ["experiment_name", "variation_name"];


### PR DESCRIPTION
### Features and Changes

Before this change we would check the required column only after they close the editsql modal and click next.  Now it will do it as well when they click on the Test Sql button.

There was also a mistyped validateResponse function, but typescript hadn't been complaining.  

### Testing

Add a new metric
Edit Sql
Delete a column
Click Test Sql
See it complain about missing column.
Delete another column
Click Test Sql
See it complain about both missing columns

