### PR TITLE
Make results table / popup work better for mobile & small screens

### DIFF
--- a/packages/front-end/components/Experiment/AlignedGraph.tsx
+++ b/packages/front-end/components/Experiment/AlignedGraph.tsx
@@ -39,8 +39,8 @@ interface Props
   newUi?: boolean;
   rowStatus?: string;
   isHovered?: boolean;
-  onPointerMove?: (e: React.PointerEvent<SVGPathElement>) => void;
-  onPointerLeave?: (e: React.PointerEvent<SVGPathElement>) => void;
+  onMouseMove?: (e: React.MouseEvent<SVGPathElement>) => void;
+  onMouseLeave?: (e: React.MouseEvent<SVGPathElement>) => void;
   onClick?: (e: React.MouseEvent<SVGPathElement, MouseEvent>) => void;
 }
 
@@ -82,8 +82,8 @@ const AlignedGraph: FC<Props> = ({
   newUi = false,
   rowStatus,
   isHovered = false,
-  onPointerMove,
-  onPointerLeave,
+  onMouseMove,
+  onMouseLeave,
   onClick,
 }) => {
   if (newUi) {
@@ -269,8 +269,8 @@ const AlignedGraph: FC<Props> = ({
                       <>
                         {barType === "violin" && (
                           <ViolinPlot
-                            onPointerMove={onPointerMove}
-                            onPointerLeave={onPointerLeave}
+                            onMouseMove={onMouseMove}
+                            onMouseLeave={onMouseLeave}
                             onClick={onClick}
                             className={clsx(
                               "hover-target aligned-graph-violin",
@@ -327,8 +327,8 @@ const AlignedGraph: FC<Props> = ({
                         )}
                         {barType === "pill" && (
                           <rect
-                            onPointerMove={onPointerMove}
-                            onPointerLeave={onPointerLeave}
+                            onMouseMove={onMouseMove}
+                            onMouseLeave={onMouseLeave}
                             onClick={onClick}
                             className={clsx("hover-target aligned-graph-pill", {
                               hover: isHovered,

--- a/packages/front-end/components/Experiment/PercentGraph.tsx
+++ b/packages/front-end/components/Experiment/PercentGraph.tsx
@@ -19,8 +19,8 @@ interface Props
   height?: number;
   newUi?: boolean;
   isHovered?: boolean;
-  onPointerMove?: (e: React.PointerEvent<SVGPathElement>) => void;
-  onPointerLeave?: (e: React.PointerEvent<SVGPathElement>) => void;
+  onMouseMove?: (e: React.MouseEvent<SVGPathElement>) => void;
+  onMouseLeave?: (e: React.MouseEvent<SVGPathElement>) => void;
   onClick?: (e: React.MouseEvent<SVGPathElement, MouseEvent>) => void;
   rowStatus?: string;
 }
@@ -36,8 +36,8 @@ export default function PercentGraph({
   height,
   newUi = false,
   isHovered = false,
-  onPointerMove,
-  onPointerLeave,
+  onMouseMove,
+  onMouseLeave,
   onClick,
   rowStatus,
 }: Props) {
@@ -77,8 +77,8 @@ export default function PercentGraph({
       inverse={!!metric?.inverse}
       newUi={newUi}
       isHovered={isHovered}
-      onPointerMove={onPointerMove}
-      onPointerLeave={onPointerLeave}
+      onMouseMove={onMouseMove}
+      onMouseLeave={onMouseLeave}
       onClick={onClick}
       rowStatus={rowStatus}
     />

--- a/packages/front-end/components/Experiment/ResultsTable.tsx
+++ b/packages/front-end/components/Experiment/ResultsTable.tsx
@@ -295,8 +295,12 @@ export default function ResultsTable({
     if (targetLeft < 0) {
       targetLeft = 0;
     }
-    if (targetLeft + Math.min(TOOLTIP_WIDTH, window.innerWidth) > window.innerWidth) {
-      targetLeft = window.innerWidth - Math.min(TOOLTIP_WIDTH, window.innerWidth);
+    if (
+      targetLeft + Math.min(TOOLTIP_WIDTH, window.innerWidth) >
+      window.innerWidth
+    ) {
+      targetLeft =
+        window.innerWidth - Math.min(TOOLTIP_WIDTH, window.innerWidth);
     }
 
     if (hoveredX === null && hoveredY === null) {

--- a/packages/front-end/components/Experiment/ResultsTable.tsx
+++ b/packages/front-end/components/Experiment/ResultsTable.tsx
@@ -690,7 +690,7 @@ export default function ResultsTable({
                             hover: isHovered,
                           })}
                           newUi={true}
-                          onPointerMove={(e) =>
+                          onMouseMove={(e) =>
                             onPointerMove(e, {
                               x: "element-right",
                               offsetX: -45,
@@ -719,8 +719,8 @@ export default function ResultsTable({
                                 "text-right results-ctw",
                                 resultsHighlightClassname
                               )}
-                              onPointerMove={onPointerMove}
-                              onPointerLeave={onPointerLeave}
+                              onMouseMove={onPointerMove}
+                              onMouseLeave={onPointerLeave}
                               onClick={onPointerMove}
                             />
                           ) : (
@@ -743,8 +743,8 @@ export default function ResultsTable({
                                 "text-right results-pval",
                                 resultsHighlightClassname
                               )}
-                              onPointerMove={onPointerMove}
-                              onPointerLeave={onPointerLeave}
+                              onMouseMove={onPointerMove}
+                              onMouseLeave={onPointerLeave}
                               onClick={onPointerMove}
                             />
                           )
@@ -768,22 +768,22 @@ export default function ResultsTable({
                               height={ROW_HEIGHT}
                               newUi={true}
                               isHovered={isHovered}
-                              onPointerMove={(e) =>
+                              className={resultsHighlightClassname}
+                              rowStatus={rowResults.resultsStatus}
+                              onMouseMove={(e) =>
                                 onPointerMove(e, {
                                   x: "element-center",
                                   targetClassName: "hover-target",
                                   offsetY: -8,
                                 })
                               }
-                              onPointerLeave={onPointerLeave}
+                              onMouseLeave={onPointerLeave}
                               onClick={(e) =>
                                 onPointerMove(e, {
                                   x: "element-center",
                                   offsetY: -8,
                                 })
                               }
-                              className={resultsHighlightClassname}
-                              rowStatus={rowResults.resultsStatus}
                             />
                           ) : (
                             <AlignedGraph
@@ -805,13 +805,13 @@ export default function ResultsTable({
                             rowResults={rowResults}
                             statsEngine={statsEngine}
                             className={resultsHighlightClassname}
-                            onPointerMove={(e) =>
+                            onMouseMove={(e) =>
                               onPointerMove(e, {
                                 x: "element-left",
                                 offsetX: 50,
                               })
                             }
-                            onPointerLeave={onPointerLeave}
+                            onMouseLeave={onPointerLeave}
                             onClick={(e) =>
                               onPointerMove(e, {
                                 x: "element-left",

--- a/packages/front-end/components/Experiment/ResultsTable.tsx
+++ b/packages/front-end/components/Experiment/ResultsTable.tsx
@@ -279,7 +279,7 @@ export default function ResultsTable({
       yAlign = "bottom";
     }
 
-    const targetLeft: number =
+    let targetLeft: number =
       (layoutX === "element-left"
         ? (target.getBoundingClientRect()?.left ?? 0) - TOOLTIP_WIDTH + 25
         : layoutX === "element-right"
@@ -290,6 +290,14 @@ export default function ResultsTable({
             2 -
           TOOLTIP_WIDTH / 2
         : event.clientX + 10) + offsetX;
+
+    // Prevent tooltip from going off the screen (x-axis)
+    if (targetLeft < 0) {
+      targetLeft = 0;
+    }
+    if (targetLeft + Math.min(TOOLTIP_WIDTH, window.innerWidth) > window.innerWidth) {
+      targetLeft = window.innerWidth - Math.min(TOOLTIP_WIDTH, window.innerWidth);
+    }
 
     if (hoveredX === null && hoveredY === null) {
       setHoveredX(targetLeft - containerBounds.left);
@@ -368,6 +376,7 @@ export default function ResultsTable({
           left={hoveredX ?? 0}
           top={hoveredY ?? 0}
           data={tooltipData}
+          tooltipOpen={tooltipOpen}
           close={closeTooltip}
           onPointerMove={resetTimeout}
           onClick={resetTimeout}

--- a/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
@@ -140,11 +140,7 @@ export default function ExperimentHeader({
 
   return (
     <>
-      <div
-        className={clsx("experiment-header bg-white px-3 pt-3", {
-          pinned: headerPinned,
-        })}
-      >
+      <div className="experiment-header bg-white px-3 pt-3">
         {startExperiment && experiment.status === "draft" && (
           <Modal
             open={true}

--- a/packages/front-end/styles/global.scss
+++ b/packages/front-end/styles/global.scss
@@ -451,7 +451,7 @@ pre {
           white-space: normal;
         }
         @media (max-width: 750px) {
-          font-size: 12px;
+          font-size: 10px;
           max-width: 140px;
         }
       }
@@ -461,6 +461,9 @@ pre {
           font-size: 12px;
           margin-right: 0 !important;
           padding: 0 !important;
+        }
+        @media (max-width: 500px) {
+          display: none;
         }
       }
     }


### PR DESCRIPTION
Constrain popup to window bounds, add "clicked away" event, fix some responsive margin issues

<img width="405" alt="image" src="https://github.com/growthbook/growthbook/assets/7927873/3335e22a-d54f-40f7-9eed-4086e9872e00">

### Features and Changes

<!--
  Include a description of your changes.
  If there are any new tools, API's, etc. that devs can leverage, it may be helpful to include usage info.
-->

<!--
  Indicate which issue this will close, if applicable
  For multiple issues, add a new `- Closes` or `- Fixes` line
-->

- Closes **(add link to issue here)**

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

<!--
  Please describe how to test these changes.
 -->

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
