### PR TITLE
Make new experiment results more readable

### DIFF
--- a/packages/front-end/components/Experiment/AlignedGraph.tsx
+++ b/packages/front-end/components/Experiment/AlignedGraph.tsx
@@ -28,6 +28,7 @@ interface Props
   gridColor?: string;
   axisColor?: string;
   zeroLineColor?: string;
+  zeroLineWidth?: number;
   barColor?: string;
   sigBarColorPos?: string;
   sigBarColorNeg?: string;
@@ -72,6 +73,7 @@ const AlignedGraph: FC<Props> = ({
   gridColor = "#5c9ea94c",
   axisColor = "var(--text-link-hover-color)",
   zeroLineColor = "#0077b6",
+  zeroLineWidth = 1,
   barColor = "#aaaaaaaa",
   sigBarColorPos = "#0D8C8Ccc",
   sigBarColorNeg = "#D94032cc",
@@ -87,6 +89,8 @@ const AlignedGraph: FC<Props> = ({
   onClick,
 }) => {
   if (newUi) {
+    zeroLineWidth = 3;
+    gridColor = "#0077b666";
     sigBarColorPos = "#52be5b";
     sigBarColorNeg = "#d35a5a";
     // barColorDraw = "#9C89BE";
@@ -241,10 +245,11 @@ const AlignedGraph: FC<Props> = ({
                         <AxisLeft
                           key={`test`}
                           orientation={Orientation.left}
-                          left={xScale(0)}
+                          left={xScale(0) - Math.floor(zeroLineWidth / 2)}
                           scale={yScale}
                           tickFormat={tickFormat}
                           stroke={zeroLineColor}
+                          strokeWidth={zeroLineWidth}
                           /*tickValues={[-100, -20, -15, -10, -5, 0, 5, 10, 15, 20]}*/
                           numTicks={0}
                         />

--- a/packages/front-end/components/Experiment/AlignedGraph.tsx
+++ b/packages/front-end/components/Experiment/AlignedGraph.tsx
@@ -90,7 +90,7 @@ const AlignedGraph: FC<Props> = ({
 }) => {
   if (newUi) {
     zeroLineWidth = 3;
-    gridColor = "#0077b666";
+    gridColor = "#0077b633";
     sigBarColorPos = "#52be5b";
     sigBarColorNeg = "#d35a5a";
     // barColorDraw = "#9C89BE";

--- a/packages/front-end/components/Experiment/ChanceToWinColumn.tsx
+++ b/packages/front-end/components/Experiment/ChanceToWinColumn.tsx
@@ -52,7 +52,6 @@ export default function ChanceToWinColumn({
           rowResults={rowResults}
           showTimeRemaining={showTimeRemaining}
           showPercentComplete={showPercentComplete}
-          style={{ marginLeft: -20 }}
         />
       ) : (
         <>

--- a/packages/front-end/components/Experiment/PValueColumn.tsx
+++ b/packages/front-end/components/Experiment/PValueColumn.tsx
@@ -73,7 +73,6 @@ export default function PValueColumn({
           rowResults={rowResults}
           showTimeRemaining={showTimeRemaining}
           showPercentComplete={showPercentComplete}
-          style={{ marginLeft: -20 }}
         />
       ) : (
         <div className="d-flex align-items-center justify-content-end">

--- a/packages/front-end/components/Experiment/ResultsTable.tsx
+++ b/packages/front-end/components/Experiment/ResultsTable.tsx
@@ -74,7 +74,7 @@ export type ResultsTableProps = {
 };
 
 const ROW_HEIGHT = 56;
-const METRIC_LABEL_ROW_HEIGHT = 40;
+const METRIC_LABEL_ROW_HEIGHT = 44;
 const SPACER_ROW_HEIGHT = 6;
 
 export default function ResultsTable({
@@ -590,7 +590,23 @@ export default function ResultsTable({
                             width: 220 * tableCellScale,
                           }}
                         >
-                          {v.name}
+                          <div className="d-flex align-items-center">
+                            <span
+                              className="label ml-1"
+                              style={{ width: 20, height: 20 }}
+                            >
+                              {j}
+                            </span>
+                            <span
+                              className="d-inline-block text-ellipsis"
+                              title={v.name}
+                              style={{
+                                width: 165 * tableCellScale,
+                              }}
+                            >
+                              {v.name}
+                            </span>
+                          </div>
                         </td>
                         {j > 0 ? (
                           // draw baseline value once, merge rows

--- a/packages/front-end/components/Experiment/ResultsTable.tsx
+++ b/packages/front-end/components/Experiment/ResultsTable.tsx
@@ -412,8 +412,7 @@ export default function ResultsTable({
                         innerClassName={"text-left"}
                         body={
                           <div style={{ lineHeight: 1.5 }}>
-                            Each variation results is compared against the
-                            baseline variation:
+                            Each variation is compared against the baseline:
                             <div
                               className={`variation variation${baselineRow} with-variation-label d-flex mt-1 align-items-center`}
                               style={{ marginBottom: 2 }}

--- a/packages/front-end/components/Experiment/ResultsTable.tsx
+++ b/packages/front-end/components/Experiment/ResultsTable.tsx
@@ -73,8 +73,8 @@ export type ResultsTableProps = {
   isTabActive: boolean;
 };
 
-const ROW_HEIGHT = 42;
-const METRIC_LABEL_ROW_HEIGHT = 34;
+const ROW_HEIGHT = 56;
+const METRIC_LABEL_ROW_HEIGHT = 40;
 const SPACER_ROW_HEIGHT = 6;
 
 export default function ResultsTable({
@@ -377,10 +377,7 @@ export default function ResultsTable({
 
       <div ref={tableContainerRef} className="experiment-results-wrapper">
         <div className="w-100" style={{ minWidth: 700 }}>
-          <table
-            id="main-results"
-            className="experiment-results table-borderless table-sm"
-          >
+          <table id="main-results" className="experiment-results table-sm">
             <thead>
               <tr className="results-top-row">
                 <th
@@ -414,32 +411,12 @@ export default function ResultsTable({
                       className="axis-col label"
                     >
                       Baseline
-                      <div
-                        className={`variation variation${baselineRow} with-variation-label d-inline-flex align-items-center`}
-                        style={{ marginBottom: 2 }}
-                      >
-                        <span
-                          className="label"
-                          style={{ width: 16, height: 16 }}
-                        >
-                          {baselineRow}
-                        </span>
-                        <span
-                          className="d-inline-block text-ellipsis font-weight-bold"
-                          style={{
-                            width: 80 * tableCellScale,
-                            marginRight: -20,
-                          }}
-                        >
-                          {variations[baselineRow].name}
-                        </span>
-                      </div>
                     </th>
                     <th
                       style={{ width: 120 * tableCellScale }}
                       className="axis-col label"
                     >
-                      Value
+                      Variation
                     </th>
                     <th
                       style={{ width: 100 * tableCellScale }}
@@ -538,13 +515,9 @@ export default function ResultsTable({
               };
 
               return (
-                <tbody
-                  className="results-group-row"
-                  key={i}
-                  style={{ boxShadow: "0 1px #66666620" }}
-                >
+                <tbody className={clsx("results-group-row")} key={i}>
                   {drawEmptyRow({
-                    className: "results-label-row",
+                    className: "results-label-row bg-light",
                     label: renderLabelColumn(row.label, row.metric, row),
                     graphCellWidth,
                     rowHeight: METRIC_LABEL_ROW_HEIGHT,
@@ -617,24 +590,9 @@ export default function ResultsTable({
                             width: 220 * tableCellScale,
                           }}
                         >
-                          <div className="d-flex align-items-center">
-                            <span
-                              className="label ml-1"
-                              style={{ width: 20, height: 20 }}
-                            >
-                              {j}
-                            </span>
-                            <span
-                              className="d-inline-block text-ellipsis"
-                              style={{
-                                width: 165 * tableCellScale,
-                              }}
-                            >
-                              {v.name}
-                            </span>
-                          </div>
+                          {v.name}
                         </td>
-                        {j === 1 ? (
+                        {j > 0 ? (
                           // draw baseline value once, merge rows
                           <MetricValueColumn
                             metric={row.metric}
@@ -644,36 +602,13 @@ export default function ResultsTable({
                             newUi={true}
                           />
                         ) : (
-                          <td className="align-top">
-                            <div
-                              className="border-left"
-                              style={{
-                                marginLeft: "20px",
-                                width: 1,
-                                height:
-                                  ROW_HEIGHT -
-                                  (j < variations.length - 1 ? 0 : 18) -
-                                  (j == 2 ? 5 : 0),
-                                marginTop: j == 2 ? 5 : 0,
-                              }}
-                            />
-                            {j === variations.length - 1 ? (
-                              <div
-                                className="border-top"
-                                style={{
-                                  marginLeft: "16px",
-                                  width: 9,
-                                  height: 1,
-                                }}
-                              />
-                            ) : null}
-                          </td>
+                          <td />
                         )}
                         <MetricValueColumn
                           metric={row.metric}
                           stats={stats}
                           users={stats?.users || 0}
-                          className={clsx("value", resultsHighlightClassname, {
+                          className={clsx("value", {
                             hover: isHovered,
                           })}
                           newUi={true}
@@ -703,7 +638,7 @@ export default function ResultsTable({
                               showTimeRemaining={true}
                               showGuardrailWarning={metricsAsGuardrails}
                               className={clsx(
-                                "text-right results-ctw",
+                                "results-ctw",
                                 resultsHighlightClassname
                               )}
                               onPointerMove={onPointerMove}
@@ -727,7 +662,7 @@ export default function ResultsTable({
                               showUnadjustedPValue={false}
                               showGuardrailWarning={metricsAsGuardrails}
                               className={clsx(
-                                "text-right results-pval",
+                                "results-pval",
                                 resultsHighlightClassname
                               )}
                               onPointerMove={onPointerMove}

--- a/packages/front-end/components/Experiment/ResultsTable.tsx
+++ b/packages/front-end/components/Experiment/ResultsTable.tsx
@@ -382,7 +382,7 @@ export default function ResultsTable({
               <tr className="results-top-row">
                 <th
                   style={{
-                    lineHeight: "16px",
+                    lineHeight: "15px",
                     width: 220 * tableCellScale,
                   }}
                   className="axis-col header-label"
@@ -404,13 +404,41 @@ export default function ResultsTable({
                 {!noMetrics ? (
                   <>
                     <th
-                      style={{
-                        width: 120 * tableCellScale,
-                        lineHeight: "16px",
-                      }}
+                      style={{ width: 120 * tableCellScale }}
                       className="axis-col label"
                     >
-                      Baseline
+                      <Tooltip
+                        usePortal={true}
+                        innerClassName={"text-left"}
+                        body={
+                          <div style={{ lineHeight: 1.5 }}>
+                            Each variation results is compared against the
+                            baseline variation:
+                            <div
+                              className={`variation variation${baselineRow} with-variation-label d-flex mt-1 align-items-center`}
+                              style={{ marginBottom: 2 }}
+                            >
+                              <span
+                                className="label"
+                                style={{ width: 16, height: 16 }}
+                              >
+                                {baselineRow}
+                              </span>
+                              <span
+                                className="d-inline-block text-ellipsis font-weight-bold"
+                                style={{
+                                  width: 80 * tableCellScale,
+                                  marginRight: -20,
+                                }}
+                              >
+                                {variations[baselineRow].name}
+                              </span>
+                            </div>
+                          </div>
+                        }
+                      >
+                        Baseline <RxInfoCircled />
+                      </Tooltip>
                     </th>
                     <th
                       style={{ width: 120 * tableCellScale }}
@@ -419,13 +447,13 @@ export default function ResultsTable({
                       Variation
                     </th>
                     <th
-                      style={{ width: 100 * tableCellScale }}
+                      style={{ width: 120 * tableCellScale }}
                       className="axis-col label text-right"
                     >
                       {statsEngine === "bayesian" ? (
                         <div
                           style={{
-                            lineHeight: "16px",
+                            lineHeight: "15px",
                             marginBottom: 2,
                             marginLeft: -20,
                           }}
@@ -481,7 +509,7 @@ export default function ResultsTable({
                       style={{ width: 140 * tableCellScale }}
                       className="axis-col label text-right"
                     >
-                      <div style={{ lineHeight: "16px", marginBottom: 2 }}>
+                      <div style={{ lineHeight: "15px", marginBottom: 2 }}>
                         <Tooltip
                           usePortal={true}
                           innerClassName={"text-left"}

--- a/packages/front-end/styles/global.scss
+++ b/packages/front-end/styles/global.scss
@@ -498,26 +498,6 @@ pre {
     border-color: transparent;
   }
 
-  .with-variation-label {
-    padding-left: 18px;
-    &.variation0,
-    &.variation4 {
-      box-shadow: inset 10px 0 0 colors.$variant-0;
-    }
-    &.variation1,
-    &.variation5 {
-      box-shadow: inset 10px 0 0 colors.$variant-1;
-    }
-    &.variation2,
-    &.variation6 {
-      box-shadow: inset 10px 0 0 colors.$variant-2;
-    }
-    &.variation3,
-    &.variation7 {
-      box-shadow: inset 10px 0 0 colors.$variant-3;
-    }
-  }
-
   table-layout: fixed;
   width: 100%;
   th,

--- a/packages/front-end/styles/global.scss
+++ b/packages/front-end/styles/global.scss
@@ -481,6 +481,43 @@ pre {
 }
 
 .experiment-results {
+  border-bottom: 1px solid var(--border-color-100);
+
+  tbody tr {
+    // Fake top/bottom border to allow graph axes to be on top
+    box-shadow: rgba(102, 102, 102, 0.125) 0px 1px inset,
+      rgba(102, 102, 102, 0.125) 0px -1px inset;
+    border-left: 1px solid var(--border-color-100);
+  }
+
+  td:not(.graph-cell) {
+    border-right: 1px solid var(--border-color-100);
+  }
+
+  .results-label-row td:not(:last-child) {
+    border-color: transparent;
+  }
+
+  .with-variation-label {
+    padding-left: 18px;
+    &.variation0,
+    &.variation4 {
+      box-shadow: inset 10px 0 0 colors.$variant-0;
+    }
+    &.variation1,
+    &.variation5 {
+      box-shadow: inset 10px 0 0 colors.$variant-1;
+    }
+    &.variation2,
+    &.variation6 {
+      box-shadow: inset 10px 0 0 colors.$variant-2;
+    }
+    &.variation3,
+    &.variation7 {
+      box-shadow: inset 10px 0 0 colors.$variant-3;
+    }
+  }
+
   table-layout: fixed;
   width: 100%;
   th,
@@ -517,11 +554,6 @@ pre {
   .change {
     font-size: 14px;
     line-height: 16px;
-    &:not(.baseline) {
-      .result-number {
-        font-weight: bold;
-      }
-    }
   }
   .graph-cell {
     padding: 0;
@@ -554,7 +586,6 @@ pre {
   }
   .results-change {
     font-size: 12px;
-    font-weight: bold;
     .ci {
       font-weight: normal;
     }
@@ -569,9 +600,11 @@ pre {
   }
   .won {
     color: #09ac17;
+    font-weight: bold;
     &.hover {
       color: #11ce21;
     }
+
     &.results-ctw,
     &.results-pval {
       background: linear-gradient(-40deg, #09ac1730, #09ac1716);
@@ -579,6 +612,7 @@ pre {
   }
   .lost {
     color: #ce3729;
+    font-weight: bold;
     &.hover {
       color: #ee1500;
     }

--- a/packages/front-end/styles/global.scss
+++ b/packages/front-end/styles/global.scss
@@ -300,13 +300,6 @@ pre {
     .label {
       color: var(--text-dark);
     }
-
-    &.won {
-      background-color: #09ac171a;
-    }
-    &.lost {
-      background-color: #d940321a;
-    }
     //&.draw {
     //  background-color: #8e51f11a;
     //}
@@ -366,6 +359,39 @@ pre {
       //    color: #8e51f1;
       //  }
       //}
+    }
+    // make the colors more legible when bg is shaded
+    &.won {
+      background-color: #09ac171a;
+      .results-change {
+        &.winning {
+          .value {
+            color: var(--alert-success-color);
+          }
+        }
+        &.losing {
+          .value {
+            color: var(--alert-danger-color);
+          }
+        }
+      }
+      .results-chance,
+      .results-ci {
+        &.won {
+          .value {
+            color: var(--alert-success-color);
+          }
+        }
+
+        &.lost {
+          .value {
+            color: var(--alert-danger-color);
+          }
+        }
+      }
+    }
+    &.lost {
+      background-color: #d940321a;
     }
     .results-flagged-items {
       .flagged {
@@ -474,28 +500,21 @@ pre {
 }
 
 .experiment-results-wrapper {
-  padding-bottom: 1px; // to allow for bottom border
   @media (max-width: 900px) {
     overflow-x: auto;
   }
 }
 
 .experiment-results {
-  border-bottom: 1px solid var(--border-color-100);
-
-  tbody tr {
-    // Fake top/bottom border to allow graph axes to be on top
-    box-shadow: rgba(102, 102, 102, 0.125) 0px 1px inset,
-      rgba(102, 102, 102, 0.125) 0px -1px inset;
-    border-left: 1px solid var(--border-color-100);
-  }
-
-  td:not(.graph-cell) {
-    border-right: 1px solid var(--border-color-100);
-  }
-
-  .results-label-row td:not(:last-child) {
-    border-color: transparent;
+  tbody {
+    tr {
+      box-shadow: rgba(102, 102, 102, 0.125) 0 -1px inset;
+      &:not(.results-label-row) {
+        td:not(.graph-cell):not(:last-child) {
+          box-shadow: rgba(102, 102, 102, 0.125) -1px 0 inset;
+        }
+      }
+    }
   }
 
   table-layout: fixed;
@@ -579,20 +598,22 @@ pre {
     //}
   }
   .won {
-    color: var(--alert-success-color);
+    color: #09ac17;
     font-weight: bold;
 
     &.results-ctw,
     &.results-pval {
+      color: var(--alert-success-color);
       background: linear-gradient(-40deg, #09ac1730, #09ac1716);
     }
   }
   .lost {
-    color: var(--alert-danger-color);
+    color: #ce3729;
     font-weight: bold;
 
     &.results-ctw,
     &.results-pval {
+      color: var(--alert-danger-color);
       background: linear-gradient(-40deg, #ce372930, #ce372916);
     }
   }
@@ -611,7 +632,7 @@ pre {
   }
   .visx-axis-left .visx-axis-line {
     // axis line has a 0.5 pixel offset. reverse it
-    transform: translateY(-0.5px);
+    transform: translate(0.5px, -0.5px);
   }
 }
 main.main.report {

--- a/packages/front-end/styles/global.scss
+++ b/packages/front-end/styles/global.scss
@@ -579,11 +579,8 @@ pre {
     //}
   }
   .won {
-    color: #09ac17;
+    color: var(--alert-success-color);
     font-weight: bold;
-    &.hover {
-      color: #11ce21;
-    }
 
     &.results-ctw,
     &.results-pval {
@@ -591,11 +588,9 @@ pre {
     }
   }
   .lost {
-    color: #ce3729;
+    color: var(--alert-danger-color);
     font-weight: bold;
-    &.hover {
-      color: #ee1500;
-    }
+
     &.results-ctw,
     &.results-pval {
       background: linear-gradient(-40deg, #ce372930, #ce372916);


### PR DESCRIPTION
### Features and Changes

After launching the new experiment design last week, we received feedback from users that the new page was harder to read and parse what was going on.  This PR attempts to address this issue with several design/style tweaks.

Specific changes:
- Make zero line thicker
- Remove bolding for result numbers
- Duplicate the baseline value for every variation
- Remove win/lose shading from the variation values
- Add table borders
- Simplify headers for baseline/variation
- Taller rows
- Left aligned Chance to Win / P-Value and make won/lost text higher contrast

Before:

![image](https://github.com/growthbook/growthbook/assets/1087514/1c0f79e6-e88d-4d46-8519-87d8b0dbf0d1)

After:

![image](https://github.com/growthbook/growthbook/assets/1087514/5287babb-9928-4e34-9282-d54dfdb09b4b)


Old page for reference:

![image](https://github.com/growthbook/growthbook/assets/1087514/2df7a392-a0bc-4177-9df9-8a82771719ea)

