### PR TITLE
Compact experiment results when there are only 2 variations

### DIFF
--- a/packages/front-end/components/Experiment/CompactResults.tsx
+++ b/packages/front-end/components/Experiment/CompactResults.tsx
@@ -192,7 +192,8 @@ function getRenderLabelColumn(regressionAdjustmentEnabled) {
   return function renderLabelColumn(
     label: string,
     metric: MetricInterface,
-    row: ExperimentTableRow
+    row: ExperimentTableRow,
+    maxWidth?: number
   ) {
     const metricLink = (
       <Tooltip
@@ -207,9 +208,15 @@ function getRenderLabelColumn(regressionAdjustmentEnabled) {
         tipPosition="right"
         className="d-inline-block font-weight-bold metric-label"
       >
-        <Link href={`/metric/${metric.id}`}>
-          <a className="metriclabel text-dark">{label}</a>
-        </Link>
+        {" "}
+        <span
+          className={maxWidth ? "d-inline-block text-ellipsis" : ""}
+          style={maxWidth ? { maxWidth: maxWidth, lineHeight: "1em" } : {}}
+        >
+          <Link href={`/metric/${metric.id}`}>
+            <a className="metriclabel text-dark">{label}</a>
+          </Link>
+        </span>
       </Tooltip>
     );
 

--- a/packages/front-end/components/Experiment/CompactResults.tsx
+++ b/packages/front-end/components/Experiment/CompactResults.tsx
@@ -193,7 +193,7 @@ function getRenderLabelColumn(regressionAdjustmentEnabled) {
     label: string,
     metric: MetricInterface,
     row: ExperimentTableRow,
-    maxWidth?: number
+    maxRows?: number
   ) {
     const metricLink = (
       <Tooltip
@@ -210,8 +210,18 @@ function getRenderLabelColumn(regressionAdjustmentEnabled) {
       >
         {" "}
         <span
-          className={maxWidth ? "d-inline-block text-ellipsis" : ""}
-          style={maxWidth ? { maxWidth: maxWidth, lineHeight: "1em" } : {}}
+          style={
+            maxRows
+              ? {
+                  display: "-webkit-box",
+                  WebkitLineClamp: maxRows,
+                  WebkitBoxOrient: "vertical",
+                  textOverflow: "ellipsis",
+                  overflow: "hidden",
+                  lineHeight: "1.2em",
+                }
+              : {}
+          }
         >
           <Link href={`/metric/${metric.id}`}>
             <a className="metriclabel text-dark">{label}</a>
@@ -255,7 +265,7 @@ function getRenderLabelColumn(regressionAdjustmentEnabled) {
     ) : null;
 
     return (
-      <span style={{ verticalAlign: "-33%" }}>
+      <span style={{ display: "inline-flex", alignItems: "center" }}>
         {metricLink}
         {metricInverseIconDisplay}
         {cupedIconDisplay}

--- a/packages/front-end/components/Experiment/ResultsTable.tsx
+++ b/packages/front-end/components/Experiment/ResultsTable.tsx
@@ -64,7 +64,7 @@ export type ResultsTableProps = {
     label: string,
     metric: MetricInterface,
     row: ExperimentTableRow,
-    maxWidth?: number
+    maxRows?: number
   ) => string | ReactElement;
   dateCreated: Date;
   hasRisk: boolean;
@@ -135,6 +135,8 @@ export default function ResultsTable({
   useEffect(onResize, [isTabActive]);
 
   const baselineRow = 0;
+
+  const compactResults = variations.length === 2;
 
   const rowsResults: (RowResults | "query error" | null)[][] = useMemo(() => {
     const rr: (RowResults | "query error" | null)[][] = [];
@@ -585,7 +587,7 @@ export default function ResultsTable({
 
               return (
                 <tbody className={clsx("results-group-row")} key={i}>
-                  {variations.length > 2 &&
+                  {!compactResults &&
                     drawEmptyRow({
                       className: "results-label-row bg-light",
                       label: renderLabelColumn(row.label, row.metric, row),
@@ -651,10 +653,7 @@ export default function ResultsTable({
 
                     return (
                       <tr
-                        className={clsx(
-                          "results-variation-row align-items-center",
-                          variations.length === 2 ? "extra-bottom-border" : ""
-                        )}
+                        className="results-variation-row align-items-center"
                         key={j}
                       >
                         <td
@@ -663,7 +662,7 @@ export default function ResultsTable({
                             width: 220 * tableCellScale,
                           }}
                         >
-                          {variations.length > 2 ? (
+                          {!compactResults ? (
                             <div className="d-flex align-items-center">
                               <span
                                 className="label ml-1"
@@ -682,12 +681,7 @@ export default function ResultsTable({
                               </span>
                             </div>
                           ) : (
-                            renderLabelColumn(
-                              row.label,
-                              row.metric,
-                              row,
-                              195 * tableCellScale
-                            )
+                            renderLabelColumn(row.label, row.metric, row, 3)
                           )}
                         </td>
                         {j > 0 ? (
@@ -785,7 +779,9 @@ export default function ResultsTable({
                               stats={stats}
                               id={`${id}_violin_row${i}_var${j}`}
                               graphWidth={graphCellWidth}
-                              height={ROW_HEIGHT}
+                              height={
+                                compactResults ? ROW_HEIGHT + 10 : ROW_HEIGHT
+                              }
                               newUi={true}
                               isHovered={isHovered}
                               className={resultsHighlightClassname}

--- a/packages/front-end/components/Experiment/ResultsTable.tsx
+++ b/packages/front-end/components/Experiment/ResultsTable.tsx
@@ -63,7 +63,8 @@ export type ResultsTableProps = {
   renderLabelColumn: (
     label: string,
     metric: MetricInterface,
-    row: ExperimentTableRow
+    row: ExperimentTableRow,
+    maxWidth?: number
   ) => string | ReactElement;
   dateCreated: Date;
   hasRisk: boolean;
@@ -425,24 +426,19 @@ export default function ResultsTable({
                         innerClassName={"text-left"}
                         body={
                           <div style={{ lineHeight: 1.5 }}>
-                            Each variation is compared against the baseline:
+                            The baseline that all variations are compared
+                            against.
                             <div
-                              className={`variation variation${baselineRow} with-variation-label d-flex mt-1 align-items-center`}
+                              className={`variation variation${baselineRow} with-variation-label d-flex mt-1 align-items-top`}
                               style={{ marginBottom: 2 }}
                             >
                               <span
-                                className="label"
-                                style={{ width: 16, height: 16 }}
+                                className="label mr-1"
+                                style={{ width: 16, height: 16, marginTop: 2 }}
                               >
                                 {baselineRow}
                               </span>
-                              <span
-                                className="d-inline-block text-ellipsis font-weight-bold"
-                                style={{
-                                  width: 80 * tableCellScale,
-                                  marginRight: -20,
-                                }}
-                              >
+                              <span className="font-weight-bold">
                                 {variations[baselineRow].name}
                               </span>
                             </div>
@@ -456,7 +452,40 @@ export default function ResultsTable({
                       style={{ width: 120 * tableCellScale }}
                       className="axis-col label"
                     >
-                      Variation
+                      <Tooltip
+                        usePortal={true}
+                        innerClassName={"text-left"}
+                        body={
+                          variations.length > 2 ? (
+                            ""
+                          ) : (
+                            <div style={{ lineHeight: 1.5 }}>
+                              The variation being compared to the baseline.
+                              <div
+                                className={`variation variation1 with-variation-label d-flex mt-1 align-items-top`}
+                                style={{ marginBottom: 2 }}
+                              >
+                                <span
+                                  className="label mr-1"
+                                  style={{
+                                    width: 16,
+                                    height: 16,
+                                    marginTop: 2,
+                                  }}
+                                >
+                                  1
+                                </span>
+                                <span className="font-weight-bold">
+                                  {variations[1]?.name}
+                                </span>
+                              </div>
+                            </div>
+                          )
+                        }
+                      >
+                        Variation{" "}
+                        {variations.length > 2 ? null : <RxInfoCircled />}
+                      </Tooltip>
                     </th>
                     <th
                       style={{ width: 120 * tableCellScale }}
@@ -556,14 +585,15 @@ export default function ResultsTable({
 
               return (
                 <tbody className={clsx("results-group-row")} key={i}>
-                  {drawEmptyRow({
-                    className: "results-label-row bg-light",
-                    label: renderLabelColumn(row.label, row.metric, row),
-                    graphCellWidth,
-                    rowHeight: METRIC_LABEL_ROW_HEIGHT,
-                    id,
-                    domain,
-                  })}
+                  {variations.length > 2 &&
+                    drawEmptyRow({
+                      className: "results-label-row bg-light",
+                      label: renderLabelColumn(row.label, row.metric, row),
+                      graphCellWidth,
+                      rowHeight: METRIC_LABEL_ROW_HEIGHT,
+                      id,
+                      domain,
+                    })}
 
                   {variations.map((v, j) => {
                     const stats = row.variations[j] || {
@@ -621,7 +651,10 @@ export default function ResultsTable({
 
                     return (
                       <tr
-                        className="results-variation-row align-items-center"
+                        className={clsx(
+                          "results-variation-row align-items-center",
+                          variations.length === 2 ? "extra-bottom-border" : ""
+                        )}
                         key={j}
                       >
                         <td
@@ -630,23 +663,32 @@ export default function ResultsTable({
                             width: 220 * tableCellScale,
                           }}
                         >
-                          <div className="d-flex align-items-center">
-                            <span
-                              className="label ml-1"
-                              style={{ width: 20, height: 20 }}
-                            >
-                              {j}
-                            </span>
-                            <span
-                              className="d-inline-block text-ellipsis"
-                              title={v.name}
-                              style={{
-                                width: 165 * tableCellScale,
-                              }}
-                            >
-                              {v.name}
-                            </span>
-                          </div>
+                          {variations.length > 2 ? (
+                            <div className="d-flex align-items-center">
+                              <span
+                                className="label ml-1"
+                                style={{ width: 20, height: 20 }}
+                              >
+                                {j}
+                              </span>
+                              <span
+                                className="d-inline-block text-ellipsis"
+                                title={v.name}
+                                style={{
+                                  width: 165 * tableCellScale,
+                                }}
+                              >
+                                {v.name}
+                              </span>
+                            </div>
+                          ) : (
+                            renderLabelColumn(
+                              row.label,
+                              row.metric,
+                              row,
+                              195 * tableCellScale
+                            )
+                          )}
                         </td>
                         {j > 0 ? (
                           // draw baseline value once, merge rows

--- a/packages/front-end/components/Metrics/MetricTooltipBody.tsx
+++ b/packages/front-end/components/Metrics/MetricTooltipBody.tsx
@@ -118,44 +118,47 @@ const MetricTooltipBody = ({
 
   if (newUi) {
     return (
-      <table className="table table-sm table-bordered text-left mb-0">
-        <tbody>
-          {metricInfo
-            .filter((i) => i.show)
-            .map(({ label, body, markdown }, index) => (
-              <tr key={`metricInfo${index}`}>
-                <td
-                  className="text-right font-weight-bold py-1 align-middle"
-                  style={{
-                    width: 120,
-                    border: "1px solid var(--border-color-100)",
-                    fontSize: "12px",
-                    lineHeight: "14px",
-                  }}
-                >{`${label}`}</td>
-                <td
-                  className="py-1 align-middle"
-                  style={{
-                    minWidth: 180,
-                    border: "1px solid var(--border-color-100)",
-                    fontSize: "12px",
-                    lineHeight: "14px",
-                  }}
-                >
-                  {markdown ? (
-                    <div
-                      className={clsx("border rounded p-1", styles.markdown)}
-                    >
-                      <Markdown>{body}</Markdown>
-                    </div>
-                  ) : (
-                    <span className="font-weight-normal">{body}</span>
-                  )}
-                </td>
-              </tr>
-            ))}
-        </tbody>
-      </table>
+      <div>
+        <h3>{metric.name}</h3>
+        <table className="table table-sm table-bordered text-left mb-0">
+          <tbody>
+            {metricInfo
+              .filter((i) => i.show)
+              .map(({ label, body, markdown }, index) => (
+                <tr key={`metricInfo${index}`}>
+                  <td
+                    className="text-right font-weight-bold py-1 align-middle"
+                    style={{
+                      width: 120,
+                      border: "1px solid var(--border-color-100)",
+                      fontSize: "12px",
+                      lineHeight: "14px",
+                    }}
+                  >{`${label}`}</td>
+                  <td
+                    className="py-1 align-middle"
+                    style={{
+                      minWidth: 180,
+                      border: "1px solid var(--border-color-100)",
+                      fontSize: "12px",
+                      lineHeight: "14px",
+                    }}
+                  >
+                    {markdown ? (
+                      <div
+                        className={clsx("border rounded p-1", styles.markdown)}
+                      >
+                        <Markdown>{body}</Markdown>
+                      </div>
+                    ) : (
+                      <span className="font-weight-normal">{body}</span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+          </tbody>
+        </table>
+      </div>
     );
   }
 

--- a/packages/front-end/styles/global.scss
+++ b/packages/front-end/styles/global.scss
@@ -517,10 +517,6 @@ pre {
           box-shadow: rgba(102, 102, 102, 0.125) -1px 0 inset;
         }
       }
-
-      &.extra-bottom-border {
-        box-shadow: rgba(102, 102, 102, 0.125) 0 -3px inset;
-      }
     }
   }
 

--- a/packages/front-end/styles/global.scss
+++ b/packages/front-end/styles/global.scss
@@ -517,6 +517,10 @@ pre {
           box-shadow: rgba(102, 102, 102, 0.125) -1px 0 inset;
         }
       }
+
+      &.extra-bottom-border {
+        box-shadow: rgba(102, 102, 102, 0.125) 0 -3px inset;
+      }
     }
   }
 


### PR DESCRIPTION
### Features and Changes

Before:

![image](https://github.com/growthbook/growthbook/assets/1087514/3adf6d3b-2ef8-4fec-86aa-2e0bdb2858da)

After:

![image](https://github.com/growthbook/growthbook/assets/1087514/e7eaeb9a-5fb0-4ffa-80fb-c5c4ad33febf)

More than 2 variations: (no change)

![image](https://github.com/growthbook/growthbook/assets/1087514/c516e318-c23c-4787-a552-60e3f9334e4d)

Old design (for reference)

![image](https://github.com/growthbook/growthbook/assets/1087514/87bf4557-6f3c-4baf-8742-ccbf74ae739e)
