### PR TITLE
Fix bugs with project-scoped data sources

### DIFF
--- a/packages/front-end/components/Dimensions/DimensionForm.tsx
+++ b/packages/front-end/components/Dimensions/DimensionForm.tsx
@@ -2,6 +2,7 @@ import { FC, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { DimensionInterface } from "back-end/types/dimension";
 import { FaExternalLinkAlt } from "react-icons/fa";
+import { isProjectListValidForProject } from "shared/util";
 import { validateSQL } from "@/services/datasources";
 import { useAuth } from "@/services/auth";
 import { useDefinitions } from "@/services/DefinitionsContext";
@@ -22,14 +23,22 @@ const DimensionForm: FC<{
     getDatasourceById,
     datasources,
     mutateDefinitions,
+    project,
   } = useDefinitions();
+
+  const validDatasources = datasources.filter(
+    (d) =>
+      d.id === current.datasource ||
+      isProjectListValidForProject(d.projects, project)
+  );
 
   const form = useForm({
     defaultValues: {
       name: current.name || "",
       sql: current.sql || "",
       description: current.description || "",
-      datasource: (current.id ? current.datasource : datasources[0]?.id) || "",
+      datasource:
+        (current.id ? current.datasource : validDatasources[0]?.id) || "",
       userIdType: current.userIdType || "user_id",
       owner: current.owner || "",
     },
@@ -96,7 +105,7 @@ const DimensionForm: FC<{
           value={form.watch("datasource")}
           onChange={(v) => form.setValue("datasource", v)}
           placeholder="Choose one..."
-          options={datasources.map((d) => ({
+          options={validDatasources.map((d) => ({
             value: d.id,
             label: `${d.name}${d.description ? ` — ${d.description}` : ""}`,
           }))}

--- a/packages/front-end/components/Experiment/AnalysisForm.tsx
+++ b/packages/front-end/components/Experiment/AnalysisForm.tsx
@@ -303,8 +303,10 @@ const AnalysisForm: FC<{
           );
         }}
         options={datasources
-          .filter((ds) =>
-            isProjectListValidForProject(ds.projects, experiment.project)
+          .filter(
+            (ds) =>
+              ds.id === experiment.datasource ||
+              isProjectListValidForProject(ds.projects, experiment.project)
           )
           .map((d) => ({
             value: d.id,

--- a/packages/front-end/components/Experiment/ImportExperimentList.tsx
+++ b/packages/front-end/components/Experiment/ImportExperimentList.tsx
@@ -3,6 +3,7 @@ import React, { FC, useCallback, useState } from "react";
 import { PastExperimentsInterface } from "back-end/types/past-experiments";
 import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
 import { getValidDate, ago, date, datetime, daysBetween } from "shared/dates";
+import { isProjectListValidForProject } from "shared/util";
 import { useAddComputedFields, useSearch } from "@/services/search";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import { useAuth } from "@/services/auth";
@@ -120,9 +121,13 @@ const ImportExperimentList: FC<{
     return <LoadingOverlay />;
   }
 
-  const supportedDatasources = datasources.filter(
-    (d) => d?.properties?.pastExperiments
-  );
+  const supportedDatasources = datasources
+    .filter((d) => d?.properties?.pastExperiments)
+    .filter(
+      (d) =>
+        d.id === data?.experiments?.datasource ||
+        isProjectListValidForProject(d.projects, project)
+    );
 
   function clearFilters() {
     setAlreadyImportedFilter(false);

--- a/packages/front-end/components/Experiment/NewExperimentForm.tsx
+++ b/packages/front-end/components/Experiment/NewExperimentForm.tsx
@@ -72,8 +72,10 @@ export function getNewExperimentDatasourceDefaults(
   project?: string,
   initialValue?: Partial<ExperimentInterfaceStringDates>
 ): Pick<ExperimentInterfaceStringDates, "datasource" | "exposureQueryId"> {
-  const validDatasources = datasources.filter((d) =>
-    isProjectListValidForProject(d.projects, project)
+  const validDatasources = datasources.filter(
+    (d) =>
+      d.id === initialValue?.datasource ||
+      isProjectListValidForProject(d.projects, project)
   );
 
   if (!validDatasources.length) return { datasource: "", exposureQueryId: "" };

--- a/packages/front-end/components/Segments/SegmentForm.tsx
+++ b/packages/front-end/components/Segments/SegmentForm.tsx
@@ -2,6 +2,7 @@ import { FC, useMemo, useState } from "react";
 import { SegmentInterface } from "back-end/types/segment";
 import { useForm } from "react-hook-form";
 import { FaExternalLinkAlt } from "react-icons/fa";
+import { isProjectListValidForProject } from "shared/util";
 import Field from "@/components/Forms/Field";
 import SelectField from "@/components/Forms/SelectField";
 import { validateSQL } from "@/services/datasources";
@@ -28,8 +29,15 @@ const SegmentForm: FC<{
     datasources,
     getDatasourceById,
     mutateDefinitions,
+    project,
   } = useDefinitions();
-  const filteredDatasources = datasources.filter((d) => d.properties?.segments);
+  const filteredDatasources = datasources
+    .filter((d) => d.properties?.segments)
+    .filter(
+      (d) =>
+        d.id === current.datasource ||
+        isProjectListValidForProject(d.projects, project)
+    );
   const form = useForm({
     defaultValues: {
       name: current.name || "",

--- a/packages/shared/src/util/index.ts
+++ b/packages/shared/src/util/index.ts
@@ -154,9 +154,9 @@ export function isProjectListValidForProject(
   // If project list is empty, it's always valid no matter what
   if (!projects || !projects.length) return true;
 
-  // If there is no selected project, it's invalid
-  if (!project) return false;
+  // If there is no selected project, it's always valid
+  if (!project) return true;
 
-  // It's valid only if the project list contains the selected project
+  // Otherwise, it's valid only if the project list contains the selected project
   return projects.includes(project);
 }


### PR DESCRIPTION
### Features and Changes

Clean up and standardize how we determine which datasources are valid dropdown options throughout the app.

The following places allow selecting a data source:
- NewExperimentForm
- SegmentForm
- DimensionForm
- MetricForm
- ImportExperimentModal
- AnalysisForm

Now, all of these have the following filtering logic:
- If editing an existing item, the item's current data source is always included
- If the item is not in a specific project, all data sources are included
- If a data source is not restricted by project, it's always included
- If the item's project is included in `datasource.projects`, then it is included
- Otherwise, it is excluded

This fixes a number of bugs where data source options are not showing up where they are expected to.

