### PR TITLE
Bug: Projects SideNavLink not displaying when user has permission

### DIFF
--- a/packages/front-end/components/Layout/SidebarLink.tsx
+++ b/packages/front-end/components/Layout/SidebarLink.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/router";
 import clsx from "clsx";
 import { AccountPlan } from "enterprise";
 import { FiChevronRight } from "react-icons/fi";
-import { Permission } from "back-end/types/organization";
+import { GlobalPermission, Permission } from "back-end/types/organization";
 import { useGrowthBook } from "@growthbook/growthbook-react";
 import { AppFeatures } from "@/types/app-features";
 import { isCloud } from "../../services/env";
@@ -60,7 +60,7 @@ const SidebarLink: FC<SidebarLinkProps> = (props) => {
   if (props.permissions) {
     let allowed = false;
     for (let i = 0; i < props.permissions.length; i++) {
-      if (permissions[props.permissions[i]]) {
+      if (permissions.check(props.permissions[i] as GlobalPermission)) {
         allowed = true;
       }
     }
@@ -140,7 +140,9 @@ const SidebarLink: FC<SidebarLinkProps> = (props) => {
 
               if (l.permissions) {
                 for (let i = 0; i < l.permissions.length; i++) {
-                  if (!permissions[l.permissions[i]]) {
+                  if (
+                    !permissions.check(l.permissions[i] as GlobalPermission)
+                  ) {
                     return null;
                   }
                 }


### PR DESCRIPTION
### Features and Changes

When evaluating permissions for `navLinks`, we do these a little differently than other places in the app, and as a result, the `Projects` link within the Settings dropdown in the `SidebarLink` wasn't being displayed when the user actually had permission. This was due to the fact that this was only checking a user's global permissions, and `manageProjects` is a project-level permission.

To remedy this, rather than dynamically checking, we are leveraging the `permissions.check` logic and casting each `permissions` as a global permission.

### Steps to reproduce

- Log in to GrowthBook off the main branch as an admin and confirm that the `Projects` link isn't rendered
- Pull down this branch, and confirm that the `Projects` link is now rendered.
