### PR TITLE
Bug: Don't show Slack link in SideBar if user doesn't have permission

### DIFF
--- a/packages/back-end/src/util/organization.util.ts
+++ b/packages/back-end/src/util/organization.util.ts
@@ -44,6 +44,7 @@ export const GLOBAL_PERMISSIONS = [
   "manageTargetingAttributes",
   "manageNamespaces",
   "manageSavedGroups",
+  "manageSlack",
   "viewEvents",
 ] as const;
 

--- a/packages/back-end/src/util/organization.util.ts
+++ b/packages/back-end/src/util/organization.util.ts
@@ -44,7 +44,6 @@ export const GLOBAL_PERMISSIONS = [
   "manageTargetingAttributes",
   "manageNamespaces",
   "manageSavedGroups",
-  "manageSlack",
   "viewEvents",
 ] as const;
 

--- a/packages/front-end/components/Layout/Layout.tsx
+++ b/packages/front-end/components/Layout/Layout.tsx
@@ -190,7 +190,7 @@ const navlinks: SidebarLinkProps[] = [
         href: "/integrations/slack",
         path: /^integrations\/slack/,
         feature: "slack-integration",
-        permissions: ["manageSlack"],
+        permissions: ["manageIntegrations"],
       },
       {
         name: "Import your data",

--- a/packages/front-end/components/Layout/Layout.tsx
+++ b/packages/front-end/components/Layout/Layout.tsx
@@ -190,6 +190,7 @@ const navlinks: SidebarLinkProps[] = [
         href: "/integrations/slack",
         path: /^integrations\/slack/,
         feature: "slack-integration",
+        permissions: ["manageSlack"],
       },
       {
         name: "Import your data",


### PR DESCRIPTION
### Features and Changes

Previously, when viewing the SideBar, the "Slack" option nested under settings was being displayed for `engineer`, `analyst`, `experimenter`, and `admin` users, but if any of these user types try to access `/integrations/slack` they get a "You don't have permissions" error message.

The Slack page (`/integrations/slack`) checks if the user has the `manageIntegrations` permission.

This PR updates the SideBar so we only show the Slack link if the user has `manageIntegrations` permissions.


### Testing
- [x] Login as engineer, analyst, or experimenter, and confirm the 'Slack' link is displayed, and you get the error when clicking on it
- [x] Now, pull in this code, and confirm that the 'Slack' link is no longer displayed.
- [x] Now, log in as an admin, and confirm that the 'Slack' link is displayed, and the link works.
