### PR TITLE
Remove bug from old results dimensions view

### DIFF
--- a/packages/front-end/components/Experiment/Results_old.tsx
+++ b/packages/front-end/components/Experiment/Results_old.tsx
@@ -225,7 +225,7 @@ const Results_old: FC<{
           project={experiment.project}
         />
       )}
-      {!hasData &&
+      {hasData &&
         snapshot?.dimension &&
         (snapshot.dimension.substring(0, 8) === "pre:date" ? (
           <DateResults


### PR DESCRIPTION
These tables should render when there is data, not when there is not data...

old (no data even though there should be)
<img width="1229" alt="Screenshot 2023-09-01 at 6 47 56 AM" src="https://github.com/growthbook/growthbook/assets/5298599/2526df5d-1674-4b35-a35e-6db75f765e3a">

new
<img width="1233" alt="Screenshot 2023-09-01 at 6 48 07 AM" src="https://github.com/growthbook/growthbook/assets/5298599/9e6458a3-e059-4d57-87fb-4535a4d2225c">
