### PR TITLE
Change dim switch to always reset analysis settings

### DIFF
--- a/packages/front-end/components/Dimensions/DimensionChooser.tsx
+++ b/packages/front-end/components/Dimensions/DimensionChooser.tsx
@@ -1,8 +1,5 @@
 import { useEffect } from "react";
-import {
-  ExperimentSnapshotAnalysis,
-  ExperimentSnapshotAnalysisSettings,
-} from "back-end/types/experiment-snapshot";
+import { ExperimentSnapshotAnalysisSettings } from "back-end/types/experiment-snapshot";
 import { getExposureQuery } from "@/services/datasources";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import SelectField from "../Forms/SelectField";
@@ -19,7 +16,6 @@ export interface Props {
   newUi?: boolean;
   setVariationFilter?: (variationFilter: number[]) => void;
   setBaselineRow?: (baselineRow: number) => void;
-  analysis?: ExperimentSnapshotAnalysis;
   setAnalysisSettings: (
     settings: ExperimentSnapshotAnalysisSettings | null
   ) => void;
@@ -37,7 +33,6 @@ export default function DimensionChooser({
   newUi = false,
   setVariationFilter,
   setBaselineRow,
-  analysis,
   setAnalysisSettings,
 }: Props) {
   const { dimensions, getDatasourceById } = useDefinitions();
@@ -127,14 +122,7 @@ export default function DimensionChooser({
         value={value}
         onChange={(v) => {
           if (v === value) return;
-          if (analysis?.settings) {
-            const newSettings: ExperimentSnapshotAnalysisSettings = {
-              ...analysis.settings,
-              dimensions: v ? [v] : [],
-              baselineVariationIndex: 0,
-            };
-            setAnalysisSettings(newSettings);
-          }
+          setAnalysisSettings(null);
           setBaselineRow?.(0);
           setVariationFilter?.([]);
           setValue(v);

--- a/packages/front-end/components/Experiment/AnalysisSettingsBar.tsx
+++ b/packages/front-end/components/Experiment/AnalysisSettingsBar.tsx
@@ -189,7 +189,6 @@ export default function AnalysisSettingsBar({
               setVariationFilter={setVariationFilter}
               setBaselineRow={setBaselineRow}
               newUi={newUi}
-              analysis={analysis}
               setAnalysisSettings={setAnalysisSettings}
             />
           </div>


### PR DESCRIPTION
Reset analysis settings when switching between dimensions so that we always get the default (index: 0) analysis when loading a new dimension (and therefore, at least for now, a new snapshot)

Current bug (everything fine until toggling to dim that doesn't exist and toggling back)
https://www.loom.com/share/78361ec5588a4b10b9b46cda688e503f?sid=1cbe8361-359b-4150-a305-3a287f3a7739

Fixed behavior:
https://www.loom.com/share/cc5726a751404ae89ff86ac8bf21b924?sid=bf812470-d087-44c5-9a2e-0ff91f08f872