### PR TITLE
Bug: Visual editor with only javascript changes excluded from SDK payload

### DIFF
--- a/packages/back-end/src/models/VisualChangesetModel.ts
+++ b/packages/back-end/src/models/VisualChangesetModel.ts
@@ -2,6 +2,7 @@ import { keyBy } from "lodash";
 import omit from "lodash/omit";
 import mongoose from "mongoose";
 import uniqid from "uniqid";
+import { hasVisualChanges } from "shared/util";
 import { ExperimentInterface, Variation } from "../../types/experiment";
 import { ApiVisualChangeset } from "../../types/openapi";
 import { OrganizationInterface } from "../../types/organization";
@@ -364,9 +365,6 @@ export const updateVisualChangeset = async ({
   return { nModified: res.modifiedCount, visualChanges };
 };
 
-const hasVisualChanges = ({ visualChanges }: VisualChangesetInterface) =>
-  visualChanges.some((vc) => !!vc.css || !!vc.domMutations.length);
-
 const onVisualChangesetCreate = async ({
   organization,
   visualChangeset,
@@ -376,7 +374,7 @@ const onVisualChangesetCreate = async ({
   visualChangeset: VisualChangesetInterface;
   experiment: ExperimentInterface;
 }) => {
-  if (!hasVisualChanges(visualChangeset)) return;
+  if (!hasVisualChanges(visualChangeset.visualChanges)) return;
 
   const payloadKeys = getPayloadKeys(organization, experiment);
 
@@ -419,7 +417,7 @@ const onVisualChangesetDelete = async ({
   visualChangeset: VisualChangesetInterface;
 }) => {
   // if there were no visual changes before deleting, return early
-  if (!hasVisualChanges(visualChangeset)) return;
+  if (!hasVisualChanges(visualChangeset.visualChanges)) return;
 
   // get payload keys
   const experiment = await getExperimentById(

--- a/packages/front-end/components/Experiment/StartExperimentBanner.tsx
+++ b/packages/front-end/components/Experiment/StartExperimentBanner.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { MdRocketLaunch } from "react-icons/md";
 import { ReactElement } from "react";
 import { FaCheckSquare, FaExternalLinkAlt, FaTimes } from "react-icons/fa";
+import { hasVisualChanges } from "shared/util";
 import track from "@/services/track";
 import { useAuth } from "@/services/auth";
 import Button from "../Button";
@@ -97,10 +98,7 @@ export function StartExperimentBanner({
   // No empty visual changesets
   if (visualChangesets.length > 0) {
     const hasSomeVisualChanges = visualChangesets.some((vc) =>
-      vc.visualChanges.some(
-        (changes) =>
-          changes.css || changes.js || changes.domMutations?.length > 0
-      )
+      hasVisualChanges(vc.visualChanges)
     );
     checklist.push({
       display: "Add changes in the Visual Editor.",

--- a/packages/shared/src/util/index.ts
+++ b/packages/shared/src/util/index.ts
@@ -12,6 +12,7 @@ import {
 } from "back-end/types/experiment-snapshot";
 import { FeatureInterface, FeatureRule } from "back-end/types/feature";
 import { ExperimentReportVariation } from "back-end/types/report";
+import { VisualChange } from "back-end/types/visual-changeset";
 
 export * from "./features";
 
@@ -132,6 +133,9 @@ export function includeExperimentInPayload(
 
   return true;
 }
+
+export const hasVisualChanges = (visualChanges: VisualChange[]) =>
+  visualChanges.some((vc) => !!vc.css || !!vc.domMutations.length || !!vc.js);
 
 export type MatchingRule = {
   environmentId: string;


### PR DESCRIPTION
When an experiment is stopped and a Temporary Rollout is enabled, there's a check to make sure the released variation has actual visual editor changes.  We were checking for CSS and DOM changes, but not Javascript.  This same logic - `hasVisualChanges` was used in 3 different places in the code - 2 of which were missing the check for javascript.

This PR makes a single function in `shared/util` and updates all 3 places in the code to reference it.