### PR TITLE
Revoke all active sessions and reset links when a password is reset

### DIFF
--- a/packages/back-end/src/app.ts
+++ b/packages/back-end/src/app.ts
@@ -272,7 +272,7 @@ const auth = getAuthConnection();
 app.use(auth.middleware);
 
 // Add logged in user props to the request
-app.use(processJWT);
+app.use(asyncHandler(processJWT));
 
 // Add logged in user props to the logger
 app.use(

--- a/packages/back-end/src/controllers/auth.ts
+++ b/packages/back-end/src/controllers/auth.ts
@@ -32,6 +32,8 @@ import {
 import { AuthRequest } from "../types/AuthRequest";
 import { getSSOConnectionByEmailDomain } from "../models/SSOConnectionModel";
 import { UserInterface } from "../../types/user";
+import { resetMinTokenDate } from "../models/UserModel";
+import { AuthRefreshModel } from "../models/AuthRefreshModel";
 
 export async function getHasOrganizations(req: Request, res: Response) {
   const hasOrg = IS_CLOUD ? true : await hasOrganization();
@@ -341,6 +343,13 @@ export async function postResetPassword(
 
   await updatePassword(userId, password);
   await deleteForgotPasswordToken(token);
+
+  // Revoke all refresh tokens for the user
+  // Revoke all active JWT sessions for the user
+  await resetMinTokenDate(userId);
+  await AuthRefreshModel.deleteMany({
+    userId: userId,
+  });
 
   res.status(200).json({
     status: 200,

--- a/packages/back-end/src/models/ForgotPasswordModel.ts
+++ b/packages/back-end/src/models/ForgotPasswordModel.ts
@@ -34,9 +34,12 @@ export const ForgotPasswordModel = mongoose.model<ForgotPasswordInterface>(
 
 export async function createForgotPasswordToken(email: string): Promise<void> {
   const user = await getUserByEmail(email);
-  if (!user) {
+  if (!user || !user.id) {
     throw new Error("Could not find a user with that email address");
   }
+
+  // Delete any existing reset password links
+  await ForgotPasswordModel.deleteMany({ userId: user.id });
 
   const token = crypto.randomBytes(32).toString("hex");
   const doc: ForgotPasswordInterface = {
@@ -69,7 +72,15 @@ export async function getUserIdFromForgotPasswordToken(
     token,
   });
 
-  return doc?.userId || "";
+  if (!doc) return "";
+
+  const lastValidDate = new Date();
+  lastValidDate.setMinutes(lastValidDate.getMinutes() - 30);
+  if (doc.createdAt < lastValidDate) {
+    throw new Error("That password reset link has expired.");
+  }
+
+  return doc.userId;
 }
 
 export async function deleteForgotPasswordToken(token: string) {

--- a/packages/back-end/src/models/UserModel.ts
+++ b/packages/back-end/src/models/UserModel.ts
@@ -14,6 +14,7 @@ const userSchema = new mongoose.Schema({
   passwordHash: String,
   admin: Boolean,
   verified: Boolean,
+  minTokenDate: Date,
 });
 
 export type UserDocument = mongoose.Document & UserInterface;
@@ -60,4 +61,17 @@ export async function findVerifiedEmails(
     });
   }
   return users.map((u) => u.email);
+}
+
+export async function resetMinTokenDate(userId: string) {
+  await UserModel.updateOne(
+    {
+      id: userId,
+    },
+    {
+      $set: {
+        minTokenDate: new Date(),
+      },
+    }
+  );
 }

--- a/packages/back-end/types/user.d.ts
+++ b/packages/back-end/types/user.d.ts
@@ -5,6 +5,7 @@ export interface UserInterface {
   verified: boolean;
   passwordHash?: string;
   admin: boolean;
+  minTokenDate?: Date;
 }
 
 export interface UserRef {


### PR DESCRIPTION
Only applies to self-hosted instances using local auth (i.e. not SSO).

Changes:
1. When a password reset link is requested, first delete any outstanding reset links for the user before generating a new one
2. When a password is reset, revoke all auth refresh tokens for the user (must sign in the next time the app is loaded)
3. When a password is reset, revoke all active sessions
4. Add stricter checks for expired reset password links (relied only on Mongo TTL indexes before, which are not as reliable)