### PR TITLE
Allow editing experiment targeting directly from a feature flag rule

### DIFF
--- a/packages/front-end/components/Experiment/TabbedPage/Implementation.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/Implementation.tsx
@@ -4,20 +4,15 @@ import {
 } from "back-end/types/experiment";
 import { VisualChangesetInterface } from "back-end/types/visual-changeset";
 import { FaPlusCircle } from "react-icons/fa";
-import { MdInfoOutline } from "react-icons/md";
 import { SDKConnectionInterface } from "back-end/types/sdk-connection";
 import usePermissions from "@/hooks/usePermissions";
 import { VisualChangesetTable } from "@/components/Experiment/VisualChangesetTable";
-import ConditionDisplay from "@/components/Features/ConditionDisplay";
 import LinkedFeatureFlag from "@/components/Experiment/LinkedFeatureFlag";
 import track from "@/services/track";
-import { formatTrafficSplit } from "@/services/utils";
-import HeaderWithEdit from "../../Layout/HeaderWithEdit";
-import Tooltip from "../../Tooltip/Tooltip";
-import { HashVersionTooltip } from "../HashVersionSelector";
 import { StartExperimentBanner } from "../StartExperimentBanner";
 import AddLinkedChangesBanner from "../AddLinkedChangesBanner";
 import { useSnapshot } from "../SnapshotProvider";
+import TargetingInfo from "./TargetingInfo";
 import { ExperimentTab, LinkedFeature } from ".";
 
 export interface Props {
@@ -51,15 +46,6 @@ export default function Implementation({
 
   const phases = experiment.phases || [];
   const phase = phases[phaseIndex] as undefined | ExperimentPhaseStringDates;
-  const hasNamespace = phase?.namespace && phase.namespace.enabled;
-  const namespaceRange = hasNamespace
-    ? phase.namespace.range[1] - phase.namespace.range[0]
-    : 1;
-
-  const percentFormatter = new Intl.NumberFormat(undefined, {
-    style: "percent",
-    maximumFractionDigits: 2,
-  });
 
   const permissions = usePermissions();
 
@@ -202,87 +188,11 @@ export default function Implementation({
         {hasLinkedChanges && (
           <div className="col-md-4 col-lg-4 col-12 mb-3">
             <div className="appbox p-3 h-100 mb-0">
-              <HeaderWithEdit
-                edit={editTargeting || undefined}
-                className="h3"
-                containerClassName="mb-3"
-              >
-                Targeting
-              </HeaderWithEdit>
-              {phase ? (
-                <div className="row">
-                  <div className="col">
-                    <div className="mb-3">
-                      <div className="mb-1">
-                        <strong>Experiment Key</strong>{" "}
-                        <Tooltip body="This is hashed together with the assignment attribute (below) to deterministically assign users to a variation." />
-                      </div>
-                      <div>{experiment.trackingKey}</div>
-                    </div>
-                    <div className="mb-3">
-                      <div className="mb-1">
-                        <strong>Assignment Attribute</strong>{" "}
-                        <Tooltip body="This user attribute will be used to assign variations. This is typically either a logged-in user id or an anonymous id stored in a long-lived cookie.">
-                          <MdInfoOutline className="text-info" />
-                        </Tooltip>
-                      </div>
-                      <div>
-                        {experiment.hashAttribute || "id"}{" "}
-                        {
-                          <HashVersionTooltip>
-                            <small className="text-muted ml-1">
-                              (V{experiment.hashVersion || 2} hashing)
-                            </small>
-                          </HashVersionTooltip>
-                        }
-                      </div>
-                    </div>
-                    <div className="mb-3">
-                      <div className="mb-1">
-                        <strong>Targeting Conditions</strong>
-                      </div>
-                      <div>
-                        {phase.condition && phase.condition !== "{}" ? (
-                          <ConditionDisplay condition={phase.condition} />
-                        ) : (
-                          <em>No conditions</em>
-                        )}
-                      </div>
-                    </div>
-                    <div className="mb-3">
-                      <div className="mb-1">
-                        <strong>Traffic</strong>
-                      </div>
-                      <div>
-                        {Math.floor(phase.coverage * 100)}% included,{" "}
-                        {formatTrafficSplit(phase.variationWeights)} split
-                      </div>
-                    </div>
-                    <div className="mb-3">
-                      <div className="mb-1">
-                        <strong>Namespace</strong>{" "}
-                        <Tooltip body="Use namespaces to run mutually exclusive experiments. Manage namespaces under SDK Configuration -> Namespaces">
-                          <MdInfoOutline className="text-info" />
-                        </Tooltip>
-                      </div>
-                      <div>
-                        {hasNamespace ? (
-                          <>
-                            {phase.namespace.name}{" "}
-                            <span className="text-muted">
-                              ({percentFormatter.format(namespaceRange)})
-                            </span>
-                          </>
-                        ) : (
-                          <em>Global (all users)</em>
-                        )}
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              ) : (
-                <em>No targeting configured yet</em>
-              )}
+              <TargetingInfo
+                experiment={experiment}
+                editTargeting={editTargeting}
+                phase={phase}
+              />
             </div>
           </div>
         )}

--- a/packages/front-end/components/Experiment/TabbedPage/TargetingInfo.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/TargetingInfo.tsx
@@ -1,0 +1,118 @@
+import { MdInfoOutline } from "react-icons/md";
+import {
+  ExperimentInterfaceStringDates,
+  ExperimentPhaseStringDates,
+} from "back-end/types/experiment";
+import HeaderWithEdit from "@/components/Layout/HeaderWithEdit";
+import Tooltip from "@/components/Tooltip/Tooltip";
+import ConditionDisplay from "@/components/Features/ConditionDisplay";
+import { formatTrafficSplit } from "@/services/utils";
+import { HashVersionTooltip } from "../HashVersionSelector";
+
+export interface Props {
+  phase?: ExperimentPhaseStringDates;
+  experiment: ExperimentInterfaceStringDates;
+  editTargeting?: (() => void) | null;
+}
+
+const percentFormatter = new Intl.NumberFormat(undefined, {
+  style: "percent",
+  maximumFractionDigits: 2,
+});
+
+export default function TargetingInfo({
+  phase,
+  experiment,
+  editTargeting,
+}: Props) {
+  const hasNamespace = phase?.namespace && phase.namespace.enabled;
+  const namespaceRange = hasNamespace
+    ? phase.namespace.range[1] - phase.namespace.range[0]
+    : 1;
+
+  return (
+    <div>
+      <HeaderWithEdit
+        edit={editTargeting || undefined}
+        className="h3"
+        containerClassName="mb-3"
+      >
+        Targeting
+      </HeaderWithEdit>
+      {phase ? (
+        <div className="row">
+          <div className="col">
+            <div className="mb-3">
+              <div className="mb-1">
+                <strong>Experiment Key</strong>{" "}
+                <Tooltip body="This is hashed together with the assignment attribute (below) to deterministically assign users to a variation." />
+              </div>
+              <div>{experiment.trackingKey}</div>
+            </div>
+            <div className="mb-3">
+              <div className="mb-1">
+                <strong>Assignment Attribute</strong>{" "}
+                <Tooltip body="This user attribute will be used to assign variations. This is typically either a logged-in user id or an anonymous id stored in a long-lived cookie.">
+                  <MdInfoOutline className="text-info" />
+                </Tooltip>
+              </div>
+              <div>
+                {experiment.hashAttribute || "id"}{" "}
+                {
+                  <HashVersionTooltip>
+                    <small className="text-muted ml-1">
+                      (V{experiment.hashVersion || 2} hashing)
+                    </small>
+                  </HashVersionTooltip>
+                }
+              </div>
+            </div>
+            <div className="mb-3">
+              <div className="mb-1">
+                <strong>Targeting Conditions</strong>
+              </div>
+              <div>
+                {phase.condition && phase.condition !== "{}" ? (
+                  <ConditionDisplay condition={phase.condition} />
+                ) : (
+                  <em>No conditions</em>
+                )}
+              </div>
+            </div>
+            <div className="mb-3">
+              <div className="mb-1">
+                <strong>Traffic</strong>
+              </div>
+              <div>
+                {Math.floor(phase.coverage * 100)}% included,{" "}
+                {formatTrafficSplit(phase.variationWeights)} split
+              </div>
+            </div>
+            <div className="mb-3">
+              <div className="mb-1">
+                <strong>Namespace</strong>{" "}
+                <Tooltip body="Use namespaces to run mutually exclusive experiments. Manage namespaces under SDK Configuration -> Namespaces">
+                  <MdInfoOutline className="text-info" />
+                </Tooltip>
+              </div>
+              <div>
+                {hasNamespace ? (
+                  <>
+                    {phase.namespace.name}{" "}
+                    <span className="text-muted">
+                      ({percentFormatter.format(namespaceRange)})
+                    </span>
+                  </>
+                ) : (
+                  <em>Global (all users)</em>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      ) : (
+        <em>No targeting configured yet</em>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
### Features and Changes

When editing an experiment rule, show the targeting info:

![image](https://github.com/growthbook/growthbook/assets/1087514/2efcf354-3152-4273-8d99-569291dcc2a4)

When you click the edit icon next to "Targeting", show the targeting form:

![image](https://github.com/growthbook/growthbook/assets/1087514/f4f1bb2b-de4e-40dc-93a8-8cf0458731fa)

If the experiment is tied to multiple feature flags or has visual editor changes, require the user to view the experiment first before making changes.  This will help prevent accidental mistakes, but should be pretty rare, so will hopefully not be too annoying.

![image](https://github.com/growthbook/growthbook/assets/1087514/7192741c-d68c-45b0-acb0-0916b56b1b2e)
