### PR TITLE
Fix feature bugs when variations are added/removed from experiments.

### DIFF
--- a/packages/front-end/components/Features/ValueDisplay.tsx
+++ b/packages/front-end/components/Features/ValueDisplay.tsx
@@ -14,7 +14,7 @@ export default function ValueDisplay({
 }) {
   const formatted = useMemo(() => {
     if (type === "boolean") return value;
-    if (type === "number") return value;
+    if (type === "number") return value || "null";
     if (type === "string") return '"' + value + '"';
     try {
       return stringify(JSON.parse(value));


### PR DESCRIPTION
### Features and Changes

Fixes the following bugs:
- When a new variation is added or removed from an experiment that is already linked to a feature flag, you are not able to edit the feature flag values
- If a linked experiment is in a different project from the feature, you are not able to edit the feature flag
- If an experiment is deleted and you try to edit the feature flag rule, it prompts you to create a new experiment instead of just showing an error message
- Number feature flags with a null value show up in the UI as an empty string instead of `null`