### PR TITLE
Remove role pill from TopNav

### DIFF
--- a/packages/front-end/components/Layout/TopNav.tsx
+++ b/packages/front-end/components/Layout/TopNav.tsx
@@ -207,9 +207,6 @@ const TopNav: FC<{
               <div className={`mb-2 dropdown-item ${styles.userinfo}`}>
                 <div className="text-muted">{email}</div>
                 {name && <div style={{ fontSize: "1.3em" }}>{name}</div>}
-                {user?.role && (
-                  <span className="badge badge-secondary">{user.role}</span>
-                )}
               </div>
               {datasources?.length > 0 && (
                 <>

--- a/packages/front-end/components/Layout/TopNav.tsx
+++ b/packages/front-end/components/Layout/TopNav.tsx
@@ -32,7 +32,7 @@ const TopNav: FC<{
   useGlobalMenu(".top-nav-user-menu", () => setUserDropdownOpen(false));
   useGlobalMenu(".top-nav-org-menu", () => setOrgDropdownOpen(false));
 
-  const { updateUser, user, name, email } = useUser();
+  const { updateUser, name, email } = useUser();
 
   const { datasources } = useDefinitions();
 


### PR DESCRIPTION
### Features and Changes

With the addition of `teams` to GrowthBook soon (relevant PRs linked below), it will be possible for a user to have an infinite number of roles.

A user will have their normal `global` role, in addition to the existing `projectRoles`, and now, a user can be added to an infinite number of `teams`, each of which have their own `global` role, along with their own `projectRoles`.

As a result, displaying this `role` pill in the TopNav will likely lead to confusion about why someone does/doesn't have permissions based on the role.

To simplify the app, after discussing with Jeremy, we decided the best route, atleast for now, is the remove the pill from the TopNav.

### Dependencies
(Not necessarily dependent, but related)
- Refactor Permissions - https://github.com/growthbook/growthbook/pull/1543
- Add teams permission support - https://github.com/growthbook/growthbook/pull/1640
- Add front-end support for teams - https://github.com/growthbook/growthbook/pull/1657
- Add back-end support for teams - https://github.com/growthbook/growthbook/pull/1582

### Testing

- Ensure the pill is no longer rendered

### Screenshots
<img width="450" alt="Screen Shot 2023-09-08 at 2 01 01 PM" src="https://github.com/growthbook/growthbook/assets/75274610/5a3d575f-4ca1-4a65-9993-fe7e1b5f6de7">
