### PR TITLE
fix bayesian graph split shading for inverse metrics

### DIFF
--- a/packages/front-end/components/Experiment/ResultsTable.tsx
+++ b/packages/front-end/components/Experiment/ResultsTable.tsx
@@ -845,7 +845,11 @@ export default function ResultsTable({
                                 resultsHighlightClassname,
                                 "overflow-hidden"
                               )}
-                              rowStatus={rowResults.resultsStatus}
+                              rowStatus={
+                                statsEngine === "frequentist"
+                                  ? rowResults.resultsStatus
+                                  : undefined
+                              }
                               onMouseMove={(e) =>
                                 onPointerMove(e, {
                                   x: "element-center",


### PR DESCRIPTION
### Features and Changes

The red and green were swapped for violin plots in certain scenarios

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

<!--
  Please describe how to test these changes.
 -->

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
