### PR TITLE
Set experiment start and end dates based on status change

### DIFF
--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -1060,6 +1060,29 @@ export async function postExperimentStatus(
     };
     changes.phases = phases;
   }
+  // If starting an experiment from draft, use the current date as the phase start date
+  else if (
+    experiment.status === "draft" &&
+    status === "running" &&
+    phases?.length > 0
+  ) {
+    phases[phases.length - 1] = {
+      ...phases[phases.length - 1],
+      dateStarted: new Date(),
+    };
+    changes.phases = phases;
+  }
+  // If starting a stopped experiment, clear the phase end date
+  else if (
+    experiment.status === "stopped" &&
+    status === "running" &&
+    phases?.length > 0
+  ) {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- we don't want the dateEnded
+    const { dateEnded: _, ...newPhase } = phases[phases.length - 1];
+    phases[phases.length - 1] = newPhase;
+    changes.phases = phases;
+  }
 
   changes.status = status;
 


### PR DESCRIPTION
### Features and Changes

- when starting a draft experiment, use the current date as start date
- when starting a stopped experiment, remove the end date from the phase

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

<!--
  Please describe how to test these changes.
 -->

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
