### PR TITLE
Results page hotfixes for query error display and tooltip values

### DIFF
--- a/packages/front-end/components/Experiment/PValueColumn.tsx
+++ b/packages/front-end/components/Experiment/PValueColumn.tsx
@@ -45,13 +45,11 @@ export default function PValueColumn({
   if (stats?.pValueAdjusted !== undefined && pValueCorrection) {
     pValText = showUnadjustedPValue ? (
       <>
-        <div>
-          {stats?.pValueAdjusted ? pValueFormatter(stats.pValueAdjusted) : ""}
-        </div>
+        <div>{pValueFormatter(stats.pValueAdjusted)}</div>
         <div className="text-muted">(unadj.:&nbsp;{pValText})</div>
       </>
     ) : (
-      <>{stats?.pValueAdjusted ? pValueFormatter(stats.pValueAdjusted) : ""}</>
+      <>{pValueFormatter(stats.pValueAdjusted)}</>
     );
   }
 

--- a/packages/front-end/components/Experiment/ResultsTable.tsx
+++ b/packages/front-end/components/Experiment/ResultsTable.tsx
@@ -614,6 +614,7 @@ export default function ResultsTable({
                 cr: 0,
                 users: 0,
               };
+              let alreadyShownQueryError = false;
 
               return (
                 <tbody className={clsx("results-group-row")} key={i}>
@@ -638,24 +639,38 @@ export default function ResultsTable({
                       return null;
                     }
                     if (rowResults === "query error") {
-                      if (j > 1) {
-                        return null;
-                      } else {
+                      if (!alreadyShownQueryError) {
+                        alreadyShownQueryError = true;
                         return drawEmptyRow({
                           key: j,
                           className:
                             "results-variation-row align-items-center error-row",
                           label: (
-                            <div className="alert alert-danger px-2 py-1 mb-1 ml-1">
-                              <FaExclamationTriangle className="mr-1" />
-                              Query error
-                            </div>
+                            <>
+                              {compactResults ? (
+                                <div className="mb-1">
+                                  {renderLabelColumn(
+                                    row.label,
+                                    row.metric,
+                                    row
+                                  )}
+                                </div>
+                              ) : null}
+                              <div className="alert alert-danger px-2 py-1 mb-1 ml-1">
+                                <FaExclamationTriangle className="mr-1" />
+                                Query error
+                              </div>
+                            </>
                           ),
                           graphCellWidth,
-                          rowHeight: ROW_HEIGHT,
+                          rowHeight: compactResults
+                            ? ROW_HEIGHT + 20
+                            : ROW_HEIGHT,
                           id,
                           domain,
                         });
+                      } else {
+                        return null;
                       }
                     }
                     const isHovered =

--- a/packages/front-end/components/Experiment/ResultsTableTooltip.tsx
+++ b/packages/front-end/components/Experiment/ResultsTableTooltip.tsx
@@ -144,11 +144,7 @@ export default function ResultsTableTooltip({
   ) {
     pValText = (
       <>
-        <div>
-          {data.stats?.pValueAdjusted
-            ? pValueFormatter(data.stats.pValueAdjusted)
-            : ""}
-        </div>
+        <div>{pValueFormatter(data.stats.pValueAdjusted)}</div>
         <div className="text-muted font-weight-normal">
           (unadj.:&nbsp;{pValText})
         </div>

--- a/packages/front-end/services/experiments.ts
+++ b/packages/front-end/services/experiments.ts
@@ -580,6 +580,10 @@ export function getRowResults({
   experimentStatus: ExperimentStatus;
   displayCurrency: string;
 }): RowResults {
+  const compactNumberFormatter = Intl.NumberFormat("en-US", {
+    notation: "compact",
+    maximumFractionDigits: 2,
+  });
   const percentFormatter = new Intl.NumberFormat(undefined, {
     style: "percent",
     maximumFractionDigits: 2,
@@ -621,7 +625,13 @@ export function getRowResults({
 
   const hasData = !!stats?.value && !!baseline?.value;
   const enoughData = hasEnoughData(baseline, stats, metric, metricDefaults);
-  const enoughDataReason = `This metric has a minimum total of ${minSampleSize}; this value must be reached in one variation before results are displayed. The total metric value of the variation is ${stats.value} and the baseline total is ${baseline.value}.`;
+  const enoughDataReason =
+    `This metric has a minimum total of ${minSampleSize}; this value must be reached in one variation before results are displayed. ` +
+    `The total metric value of the variation is ${compactNumberFormatter.format(
+      stats.value
+    )} and the baseline total is ${compactNumberFormatter.format(
+      baseline.value
+    )}.`;
   const percentComplete =
     minSampleSize > 0
       ? Math.max(stats.value, baseline.value) / minSampleSize


### PR DESCRIPTION
- correctly show query error warnings alongside metric/dimension names when using 2-variant or filtered-variant views
- fix stats.value formatting in tooltip for "not enough data"
- fix display for pValues of 0

### Features and Changes

<!--
  Include a description of your changes.
  If there are any new tools, API's, etc. that devs can leverage, it may be helpful to include usage info.
-->

<!--
  Indicate which issue this will close, if applicable
  For multiple issues, add a new `- Closes` or `- Fixes` line
-->

- Closes **(add link to issue here)**

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

<!--
  Please describe how to test these changes.
 -->

### Screenshots
<img width="1273" alt="image" src="https://github.com/growthbook/growthbook/assets/7927873/a75615ce-f4d9-42d2-8399-6170e061d31a">

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
