### PR TITLE
Add schema format as part of overview table and message

### DIFF
--- a/docs/docs/experimentation-analysis/metrics.mdx
+++ b/docs/docs/experimentation-analysis/metrics.mdx
@@ -314,7 +314,7 @@ If you use the "Experiment Duration" attribution model, we effectively ignore th
 
 ## Auto Generate Metrics
 
-When using GrowthBook with certain event trackers, we may be able to generate metrics for you automatically by identifying the unique events tracked by your event tracker. This is currently only supported for a few event trackers (listed below), but we are working to expand this list.
+When using GrowthBook with certain event trackers, we may be able to generate metrics for you automatically by identifying the unique events tracked by your event tracker. This is currently only supported if, when adding a new datasource you choose "Guided Setup" for a few event trackers (listed below). We are working to expand this list to support more event trackers in the near future.
 
 If you are using one of the supported event trackers and would like to see what metrics we can create for you, head to the `Metrics` page in GrowthBook and select the `Discover Metrics` button.
 

--- a/docs/docs/experimentation-analysis/metrics.mdx
+++ b/docs/docs/experimentation-analysis/metrics.mdx
@@ -314,7 +314,7 @@ If you use the "Experiment Duration" attribution model, we effectively ignore th
 
 ## Auto Generate Metrics
 
-When using GrowthBook with certain event trackers, we may be able to generate metrics for you automatically by identifying the unique events tracked by your event tracker. This is currently only supported if, when adding a new datasource you choose "Guided Setup" for a few event trackers (listed below). We are working to expand this list to support more event trackers in the near future.
+When using GrowthBook with certain event trackers, we may be able to generate metrics for you automatically by identifying the unique events tracked by your event tracker. This is currently only supported if, when adding a new datasource, you choose "Guided Setup" and selected one of a few event trackers (listed below). We are working to expand this list to support more event trackers in the near future.
 
 If you are using one of the supported event trackers and would like to see what metrics we can create for you, head to the `Metrics` page in GrowthBook and select the `Discover Metrics` button.
 

--- a/packages/front-end/components/Settings/DataSources.tsx
+++ b/packages/front-end/components/Settings/DataSources.tsx
@@ -59,8 +59,8 @@ const DataSources: FC = () => {
             <tr>
               <th className="col-2">Display Name</th>
               <th className="col-auto">Description</th>
-              <th className="col-2">Format</th>
-              <th className="col-2">Type</th>
+              <th className="col-2">Event Tracker</th>
+              <th className="col-2">Datasource Type</th>
               <td className="col-2">Projects</td>
               {!hasFileConfig() && <th className="col-2">Last Updated</th>}
             </tr>

--- a/packages/front-end/components/Settings/DataSources.tsx
+++ b/packages/front-end/components/Settings/DataSources.tsx
@@ -13,6 +13,7 @@ import LoadingOverlay from "@/components/LoadingOverlay";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import Tooltip from "@/components/Tooltip/Tooltip";
 import { useDemoDataSourceProject } from "@/hooks/useDemoDataSourceProject";
+import { dataSourceConnections, eventSchemas } from "@/services/eventSchema";
 import NewDataSourceForm from "./NewDataSourceForm";
 
 const DataSources: FC = () => {
@@ -58,6 +59,7 @@ const DataSources: FC = () => {
             <tr>
               <th className="col-2">Display Name</th>
               <th className="col-auto">Description</th>
+              <th className="col-2">Format</th>
               <th className="col-2">Type</th>
               <td className="col-2">Projects</td>
               {!hasFileConfig() && <th className="col-2">Last Updated</th>}
@@ -92,7 +94,18 @@ const DataSources: FC = () => {
                 <td className="pr-5 text-gray" style={{ fontSize: 12 }}>
                   {d.description}
                 </td>
-                <td>{d.type}</td>
+                <td>
+                  {eventSchemas.find((s) => {
+                    return s.value === d.settings.schemaFormat;
+                  })?.label || "Custom"}
+                </td>
+                <td>
+                  {
+                    dataSourceConnections.find((w) => {
+                      return w.type === d.type;
+                    })?.display
+                  }
+                </td>
                 <td>
                   {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
                   {d?.projects?.length > 0 ? (

--- a/packages/front-end/pages/datasources/[did].tsx
+++ b/packages/front-end/pages/datasources/[did].tsx
@@ -31,6 +31,7 @@ import { GBCircleArrowLeft } from "@/components/Icons";
 import DataSourceMetrics from "@/components/Settings/EditDataSource/DataSourceMetrics";
 import { DeleteDemoDatasourceButton } from "@/components/DemoDataSourcePage/DemoDataSourcePage";
 import { useUser } from "@/services/UserContext";
+import { eventSchemas } from "@/services/eventSchema";
 
 function quotePropertyName(name: string) {
   if (name.match(/^[a-zA-Z_][a-zA-Z0-9_]*$/)) {
@@ -300,8 +301,14 @@ mixpanel.init('YOUR PROJECT TOKEN', {
                 d?.settings?.schemaFormat !== "custom" && (
                   <div className="alert alert-info">
                     <FaExclamationTriangle style={{ marginTop: "-2px" }} /> We
-                    have prefilled the identifiers and assignment queries below.
-                    These queries may require editing to fit your data
+                    have prefilled the identifiers and assignment queries below
+                    to fit the{" "}
+                    {
+                      eventSchemas.find((s) => {
+                        return s.value === d.settings.schemaFormat;
+                      })?.label
+                    }{" "}
+                    schema. These queries may require editing to fit your data
                     structure.
                   </div>
                 )}


### PR DESCRIPTION
### Features and Changes
I was trying to help a customer figure out why they weren't seeing the Discover Metrics button and I noticed that we don't show anywhere in our frontend what schemaFormat people chose when initially setting up the data source.  That made it harder to figure out what was going wrong.  

This change:

-   Adds the schemaFormat as part of the message saying that the default queries have been automatically been added.
-   Adds the schemaFormat to the datasource overview page.
-   Changes the label for the datasource type to be the display label rather than the internal id - both because it seems like the right thing to do, and so that it's casing matches the schema formats.
-   Changes the documentation to make it clear that the auto discover metrics only works when choosing a "Guided Setup".

### Testing

1. Go to the datasource overview page.  
2. Add a custom datasource if none exist.  
3. Go back to the datasource overview page.
4. See the format column correctly populated with "Custom" for the custom datasource and the right display name for the others.
5. Add a new guided setup datasource.
6. See the helper message about default values with the correct schemaFormat type.

### Screenshots
The new column and the updated datasource column:
<img width="861" alt="Screenshot 2023-09-15 at 11 40 21 AM" src="https://github.com/growthbook/growthbook/assets/950231/706256f6-2836-4948-af03-0bb4c046307d">
The new message:
<img width="859" alt="Screenshot 2023-09-15 at 11 40 52 AM" src="https://github.com/growthbook/growthbook/assets/950231/fc9747df-a45e-4a4b-acac-2af64902c622">
The new docs:
<img width="869" alt="Screenshot 2023-09-15 at 11 58 24 AM" src="https://github.com/growthbook/growthbook/assets/950231/d7c097d4-7804-4a25-afc0-d5b5fe9fc1d2">

