### PR TITLE
Proxy image uploads through GrowthBook back-end

### DIFF
--- a/packages/back-end/src/app.ts
+++ b/packages/back-end/src/app.ts
@@ -81,7 +81,7 @@ import { getBuild } from "./util/handler";
 import { getCustomLogProps, httpLogger } from "./util/logger";
 import { usersRouter } from "./routers/users/users.router";
 import { organizationsRouter } from "./routers/organizations/organizations.router";
-import { uploadsRouter } from "./routers/upload/upload.router";
+import { putUploadRouter } from "./routers/upload/put-upload.router";
 import { eventsRouter } from "./routers/events/events.router";
 import { eventWebHooksRouter } from "./routers/event-webhooks/event-webhooks.router";
 import { tagRouter } from "./routers/tag/tag.router";
@@ -559,7 +559,7 @@ app.delete(
   discussionsController.deleteComment
 );
 app.get("/discussions/recent/:num", discussionsController.getRecentDiscussions);
-app.use("/upload", uploadsRouter);
+app.use("/putupload", putUploadRouter);
 
 // Teams
 app.use("/teams", teamRouter);

--- a/packages/back-end/src/app.ts
+++ b/packages/back-end/src/app.ts
@@ -14,7 +14,6 @@ import {
   EXPRESS_TRUST_PROXY_OPTS,
   IS_CLOUD,
   SENTRY_DSN,
-  UPLOAD_METHOD,
 } from "./util/secrets";
 import {
   getExperimentConfig,
@@ -97,6 +96,7 @@ import { dataExportRouter } from "./routers/data-export/data-export.router";
 import { demoDatasourceProjectRouter } from "./routers/demo-datasource-project/demo-datasource-project.router";
 import { environmentRouter } from "./routers/environment/environment.router";
 import { teamRouter } from "./routers/teams/teams.router";
+import { staticFilesRouter } from "./routers/upload/static-files.router";
 
 const app = express();
 
@@ -261,11 +261,7 @@ app.post("/auth/refresh", authController.postRefresh);
 app.post("/auth/logout", authController.postLogout);
 app.get("/auth/hasorgs", authController.getHasOrganizations);
 
-// File uploads don't require auth tokens.
-// Upload urls are signed and image access is public.
-if (UPLOAD_METHOD === "local") {
-  app.use("/upload", uploadsRouter);
-}
+app.use("/upload", staticFilesRouter);
 
 // All other routes require a valid JWT
 const auth = getAuthConnection();
@@ -563,7 +559,7 @@ app.delete(
   discussionsController.deleteComment
 );
 app.get("/discussions/recent/:num", discussionsController.getRecentDiscussions);
-app.post("/file/upload/:filetype", discussionsController.postImageUploadUrl);
+app.use("/upload", uploadsRouter);
 
 // Teams
 app.use("/teams", teamRouter);

--- a/packages/back-end/src/controllers/discussions.ts
+++ b/packages/back-end/src/controllers/discussions.ts
@@ -6,7 +6,6 @@ import {
   getDiscussionByParent,
   getLastNDiscussions,
 } from "../services/discussions";
-import { getFileUploadURL } from "../services/files";
 import { getOrgFromReq } from "../services/organizations";
 
 export async function postDiscussions(
@@ -221,26 +220,4 @@ export async function getRecentDiscussions(
       message: e.message,
     });
   }
-}
-
-export async function postImageUploadUrl(
-  req: AuthRequest<null, { filetype: string }>,
-  res: Response
-) {
-  req.checkPermissions("addComments", "");
-
-  const { org } = getOrgFromReq(req);
-  const { filetype } = req.params;
-
-  const now = new Date();
-  const { uploadURL, fileURL } = await getFileUploadURL(
-    filetype,
-    `${org.id}/${now.toISOString().substr(0, 7)}/`
-  );
-
-  res.status(200).json({
-    status: 200,
-    uploadURL,
-    fileURL,
-  });
 }

--- a/packages/back-end/src/routers/upload/put-upload.router.ts
+++ b/packages/back-end/src/routers/upload/put-upload.router.ts
@@ -16,4 +16,4 @@ router.put(
   uploadController.putUpload
 );
 
-export { router as uploadsRouter };
+export { router as putUploadRouter };

--- a/packages/back-end/src/routers/upload/static-files.router.ts
+++ b/packages/back-end/src/routers/upload/static-files.router.ts
@@ -1,0 +1,22 @@
+import fs from "fs";
+import express from "express";
+import { getUploadsDir } from "../../services/files";
+import { UPLOAD_METHOD } from "../../util/secrets";
+
+const router = express.Router();
+
+if (UPLOAD_METHOD === "local") {
+  // Create 'upload' directory if it doesn't exist yet
+  const uploadDir = getUploadsDir();
+  if (!fs.existsSync(uploadDir)) {
+    fs.mkdirSync(uploadDir);
+  }
+  router.use("/", express.static(uploadDir));
+
+  // Stop upload requests from running any of the middleware defined below
+  router.use("/", () => {
+    return;
+  });
+}
+
+export { router as staticFilesRouter };

--- a/packages/back-end/src/routers/upload/upload.controller.ts
+++ b/packages/back-end/src/routers/upload/upload.controller.ts
@@ -23,7 +23,7 @@ export async function putUpload(req: AuthRequest<Buffer>, res: Response) {
     );
   }
 
-  const ext = contentType.split("/")[1];
+  const ext = mimetypes[contentType];
   const { org } = getOrgFromReq(req);
 
   const now = new Date();

--- a/packages/back-end/src/routers/upload/upload.controller.ts
+++ b/packages/back-end/src/routers/upload/upload.controller.ts
@@ -1,11 +1,39 @@
-import { Request, Response } from "express";
+import { Response } from "express";
 import { uploadFile } from "../../services/files";
+import { AuthRequest } from "../../types/AuthRequest";
+import { getOrgFromReq } from "../../services/organizations";
+import uniqid from "uniqid";
 
-export async function putUpload(req: Request, res: Response) {
-  const { signature, path } = req.query as { signature: string; path: string };
-  await uploadFile(path, signature, req.body);
+export async function putUpload(req: AuthRequest<Buffer>, res: Response) {
+  const contentType = req.headers["content-type"] as string;
+  req.checkPermissions("addComments", "");
+
+  const mimetypes: { [key: string]: string } = {
+    "image/png": "png",
+    "image/jpeg": "jpeg",
+    "image/gif": "gif",
+    "image/svg+xml": "svg",
+  };
+
+  if (!(contentType in mimetypes)) {
+    throw new Error(
+      `Invalid image file type. Only ${Object.keys(mimetypes).join(
+        ", "
+      )} accepted.`
+    );
+  }
+
+  const ext = contentType.split("/")[1];
+  const { org } = getOrgFromReq(req);
+
+  const now = new Date();
+  const pathPrefix = `${org.id}/${now.toISOString().substr(0, 7)}/`;
+  const fileName = uniqid("img_");
+  const filePath = `${pathPrefix}${fileName}.${ext}`;
+  const fileURL = await uploadFile(filePath, contentType, req.body);
 
   res.status(200).json({
     status: 200,
+    fileURL,
   });
 }

--- a/packages/back-end/src/routers/upload/upload.controller.ts
+++ b/packages/back-end/src/routers/upload/upload.controller.ts
@@ -12,7 +12,6 @@ export async function putUpload(req: AuthRequest<Buffer>, res: Response) {
     "image/png": "png",
     "image/jpeg": "jpeg",
     "image/gif": "gif",
-    "image/svg+xml": "svg",
   };
 
   if (!(contentType in mimetypes)) {

--- a/packages/back-end/src/routers/upload/upload.controller.ts
+++ b/packages/back-end/src/routers/upload/upload.controller.ts
@@ -1,8 +1,8 @@
 import { Response } from "express";
+import uniqid from "uniqid";
 import { uploadFile } from "../../services/files";
 import { AuthRequest } from "../../types/AuthRequest";
 import { getOrgFromReq } from "../../services/organizations";
-import uniqid from "uniqid";
 
 export async function putUpload(req: AuthRequest<Buffer>, res: Response) {
   const contentType = req.headers["content-type"] as string;

--- a/packages/back-end/src/routers/upload/upload.router.ts
+++ b/packages/back-end/src/routers/upload/upload.router.ts
@@ -1,40 +1,19 @@
-import fs from "fs";
 import bodyParser from "body-parser";
 import express from "express";
-import { getUploadsDir } from "../../services/files";
 import { wrapController } from "../wrapController";
-import { UPLOAD_METHOD } from "../../util/secrets";
 import * as uploadControllerRaw from "./upload.controller";
 
 const router = express.Router();
 
 const uploadController = wrapController(uploadControllerRaw);
 
-if (UPLOAD_METHOD === "local") {
-  // Create 'upload' directory if it doesn't exist yet
-  const uploadDir = getUploadsDir();
-  if (!fs.existsSync(uploadDir)) {
-    fs.mkdirSync(uploadDir);
-  }
-
-  router.put(
-    "/",
-    bodyParser.raw({
-      type: "image/*",
-      limit: "10mb",
-    }),
-    uploadController.putUpload
-  );
-  router.use("/", express.static(uploadDir));
-
-  // Stop upload requests from running any of the middleware defined below
-  router.use("/", () => {
-    return;
-  });
-} else {
-  router.put("/", (req, res) => {
-    return res.status(405).json({ error: "Method Not Allowed" });
-  });
-}
+router.put(
+  "/",
+  bodyParser.raw({
+    type: "image/*",
+    limit: "10mb",
+  }),
+  uploadController.putUpload
+);
 
 export { router as uploadsRouter };

--- a/packages/back-end/src/services/files.ts
+++ b/packages/back-end/src/services/files.ts
@@ -1,11 +1,8 @@
-import crypto from "crypto";
 import path from "path";
 import fs from "fs";
 import AWS from "aws-sdk";
-import uniqid from "uniqid";
-import { Storage, GetSignedUrlConfig } from "@google-cloud/storage";
+import { Storage } from "@google-cloud/storage";
 import {
-  JWT_SECRET,
   S3_BUCKET,
   S3_DOMAIN,
   S3_REGION,
@@ -27,108 +24,50 @@ export function getUploadsDir() {
   return path.join(__dirname, "..", "..", "uploads");
 }
 
-function getFileSignature(filePath: string) {
-  return crypto.createHmac("sha256", JWT_SECRET).update(filePath).digest("hex");
-}
-
 export async function uploadFile(
   filePath: string,
-  signature: string,
+  contentType: string,
   contents: Buffer
 ) {
-  // Make sure signature matches
-  const comp = getFileSignature(filePath);
-  if (!crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(comp))) {
-    throw new Error("Invalid upload signature");
-  }
-
   // Watch out for poison null bytes
   if (filePath.indexOf("\0") !== -1) {
     throw new Error("Error: Filename must not contain null bytes");
   }
-
-  const rootDirectory = getUploadsDir();
-  const fullPath = path.join(rootDirectory, filePath);
-
-  // Prevent directory traversal
-  if (fullPath.indexOf(rootDirectory) !== 0) {
-    throw new Error(
-      "Error: Path must not escape out of the 'uploads' directory."
-    );
-  }
-
-  const dir = path.dirname(fullPath);
-  await fs.promises.mkdir(dir, { recursive: true });
-  await fs.promises.writeFile(fullPath, contents);
-}
-
-export async function getFileUploadURL(ext: string, pathPrefix: string) {
-  const mimetypes: { [key: string]: string } = {
-    png: "image/png",
-    jpg: "image/jpeg",
-    jpeg: "image/jpeg",
-    gif: "image/gif",
-    svg: "text/svg",
-  };
-
-  if (!mimetypes[ext.toLowerCase()]) {
-    throw new Error(
-      `Invalid image file type. Only ${Object.keys(mimetypes).join(
-        ", "
-      )} accepted.`
-    );
-  }
-
-  const filename = uniqid("img_");
-  const filePath = `${pathPrefix}${filename}.${ext}`;
-
-  async function getSignedGoogleUrl() {
-    const storage = new Storage();
-
-    const options: GetSignedUrlConfig = {
-      version: "v4",
-      action: "write",
-      expires: Date.now() + 15 * 60 * 1000,
-      contentType: mimetypes[ext],
-    };
-
-    const [url] = await storage
-      .bucket(GCS_BUCKET_NAME)
-      .file(filePath)
-      .getSignedUrl(options);
-
-    return url;
-  }
+  let fileURL = "";
 
   if (UPLOAD_METHOD === "s3") {
-    const s3Params = {
+    const params = {
       Bucket: S3_BUCKET,
       Key: filePath,
-      ContentType: mimetypes[ext],
-      ACL: "public-read",
+      Body: contents,
+      ContentType: contentType,
     };
-
-    const uploadURL = getS3().getSignedUrl("putObject", s3Params);
-
-    return {
-      uploadURL,
-      fileURL: S3_DOMAIN + (S3_DOMAIN.endsWith("/") ? "" : "/") + filePath,
-    };
+    await getS3().upload(params).promise();
+    fileURL = S3_DOMAIN + (S3_DOMAIN.endsWith("/") ? "" : "/") + filePath;
   } else if (UPLOAD_METHOD === "google-cloud") {
-    const uploadURL = await getSignedGoogleUrl();
+    const storage = new Storage();
 
-    return {
-      uploadURL,
-      fileURL: GCS_DOMAIN + (GCS_DOMAIN.endsWith("/") ? "" : "/") + filePath,
-    };
+    await storage
+      .bucket(GCS_BUCKET_NAME)
+      .file(filePath)
+      .save(contents, { contentType: contentType });
+
+    fileURL = GCS_DOMAIN + (GCS_DOMAIN.endsWith("/") ? "" : "/") + filePath;
   } else {
-    const fileURL = `/upload/${filePath}`;
-    const uploadURL = `/upload?path=${filePath}&signature=${getFileSignature(
-      filePath
-    )}`;
-    return {
-      uploadURL,
-      fileURL,
-    };
+    const rootDirectory = getUploadsDir();
+    const fullPath = path.join(rootDirectory, filePath);
+
+    // Prevent directory traversal
+    if (fullPath.indexOf(rootDirectory) !== 0) {
+      throw new Error(
+        "Error: Path must not escape out of the 'uploads' directory."
+      );
+    }
+
+    const dir = path.dirname(fullPath);
+    await fs.promises.mkdir(dir, { recursive: true });
+    await fs.promises.writeFile(fullPath, contents);
+    fileURL = `/upload/${filePath}`;
   }
+  return fileURL;
 }

--- a/packages/front-end/services/auth.tsx
+++ b/packages/front-end/services/auth.tsx
@@ -244,7 +244,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
       init.headers["Authorization"] = `Bearer ${token}`;
       init.credentials = "include";
 
-      if (init.body) {
+      if (init.body && !init.headers["Content-Type"]) {
         init.headers["Content-Type"] = "application/json";
       }
 

--- a/packages/front-end/services/files.ts
+++ b/packages/front-end/services/files.ts
@@ -2,27 +2,21 @@ import { ApiCallType } from "./auth";
 import { getApiHost } from "./env";
 
 export async function uploadFile(
-  apiCall: ApiCallType<{ uploadURL: string; fileURL: string }>,
+  apiCall: ApiCallType<{ fileURL: string }>,
   file: File
 ) {
-  const ext = file.name.split(".").reverse()[0];
-  const { uploadURL, fileURL } = await apiCall(`/file/upload/${ext}`, {
-    method: "POST",
-  });
-
-  const res = await fetch(
-    uploadURL.match(/^\//) ? getApiHost() + uploadURL : uploadURL,
-    {
+  let fileURL = "";
+  try {
+    ({ fileURL } = await apiCall("/upload", {
       method: "PUT",
+
       headers: {
         "Content-Type": file.type,
       },
       body: file,
-    }
-  );
-
-  if (!res.ok) {
-    throw new Error("Failed to upload file");
+    }));
+  } catch (e) {
+    throw new Error("Failed to upload file: " + e.message);
   }
 
   return {

--- a/packages/front-end/services/files.ts
+++ b/packages/front-end/services/files.ts
@@ -7,7 +7,7 @@ export async function uploadFile(
 ) {
   let fileURL = "";
   try {
-    ({ fileURL } = await apiCall("/upload", {
+    ({ fileURL } = await apiCall("/putupload", {
       method: "PUT",
 
       headers: {


### PR DESCRIPTION
### Features and Changes

A number of people were complaining that file uploads were not working correctly.  This PR simplifies the uploading process to proxy the uploads.  Instead of asking for a signed url allowing uploads and then later on having the client upload using that url, we get rid of that endpoint asking for the signed url and instead just send the file directly using the credentials provided.

- Closes 
https://github.com/growthbook/growthbook/issues/1183
https://github.com/growthbook/growthbook/issues/1408

### Testing

For UPLOAD_METHOD=google-cloud, UPLOAD_METHOD=s3, and UPLOAD_METHOD=local:
Go to an experiment page.
Click on Add screenshot.
Select an image file.
See the new screenshot image.

click on Add screenshot.
Select a non-image file.
See an alert that the image file is a non supported type.

