### PR TITLE
Top Nav Layout and Page Title Improvements

### DIFF
--- a/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
@@ -2,7 +2,6 @@ import {
   ExperimentInterfaceStringDates,
   ExperimentPhaseStringDates,
 } from "back-end/types/experiment";
-import Link from "next/link";
 import { FaHome } from "react-icons/fa";
 import { PiChartBarHorizontalFill } from "react-icons/pi";
 import { useRouter } from "next/router";
@@ -14,7 +13,6 @@ import { SDKConnectionInterface } from "back-end/types/sdk-connection";
 import { VisualChangesetInterface } from "back-end/types/visual-changeset";
 import clsx from "clsx";
 import { useAuth } from "@/services/auth";
-import { GBCircleArrowLeft } from "@/components/Icons";
 import WatchButton from "@/components/WatchButton";
 import MoreMenu from "@/components/Dropdown/MoreMenu";
 import ConfirmButton from "@/components/Modal/ConfirmButton";
@@ -150,21 +148,6 @@ export default function ExperimentHeader({
           </Modal>
         )}
         <div className="container-fluid pagecontents position-relative">
-          <div style={{ marginTop: -8, marginBottom: 8 }}>
-            <Link
-              href={`/experiments${
-                experiment.status === "draft"
-                  ? "#drafts"
-                  : experiment.status === "stopped"
-                  ? "#stopped"
-                  : ""
-              }`}
-            >
-              <a>
-                <GBCircleArrowLeft /> Back to all experiments
-              </a>
-            </Link>
-          </div>
           <div className="d-flex align-items-center">
             <div>
               <HeaderWithEdit

--- a/packages/front-end/components/Layout/Layout.tsx
+++ b/packages/front-end/components/Layout/Layout.tsx
@@ -271,7 +271,7 @@ const Layout = (): React.ReactElement => {
   const settings = useOrgSettings();
   const { accountPlan } = useUser();
 
-  const { pageTitle: defaultPageTitle } = usePageHead();
+  const { breadcrumb } = usePageHead();
 
   const [upgradeModal, setUpgradeModal] = useState(false);
   // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
@@ -286,9 +286,9 @@ const Layout = (): React.ReactElement => {
     return null;
   }
 
-  let pageTitle: string = defaultPageTitle;
+  let pageTitle = breadcrumb.map((b) => b.display).join(" > ");
 
-  // If no page title is explicitly set, try to figure it out from the path
+  // If no breadcrumb provided, try to figure out a page name based on the path
   otherPageTitles.forEach((o) => {
     if (!pageTitle && o.path.test(path)) {
       pageTitle = o.title;

--- a/packages/front-end/components/Layout/Layout.tsx
+++ b/packages/front-end/components/Layout/Layout.tsx
@@ -19,6 +19,7 @@ import ProjectSelector from "./ProjectSelector";
 import SidebarLink, { SidebarLinkProps } from "./SidebarLink";
 import TopNav from "./TopNav";
 import styles from "./Layout.module.scss";
+import { usePageHead } from "./PageHead";
 
 // move experiments inside of 'analysis' menu
 const navlinks: SidebarLinkProps[] = [
@@ -270,6 +271,8 @@ const Layout = (): React.ReactElement => {
   const settings = useOrgSettings();
   const { accountPlan } = useUser();
 
+  const { pageTitle: defaultPageTitle } = usePageHead();
+
   const [upgradeModal, setUpgradeModal] = useState(false);
   // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
   const showUpgradeButton = ["oss", "starter"].includes(accountPlan);
@@ -283,7 +286,9 @@ const Layout = (): React.ReactElement => {
     return null;
   }
 
-  let pageTitle: string;
+  let pageTitle: string = defaultPageTitle;
+
+  // If no page title is explicitly set, try to figure it out from the path
   otherPageTitles.forEach((o) => {
     if (!pageTitle && o.path.test(path)) {
       pageTitle = o.title;
@@ -468,7 +473,6 @@ const Layout = (): React.ReactElement => {
       </div>
 
       <TopNav
-        // @ts-expect-error TS(2454) If you come across this, please fix it!: Variable 'pageTitle' is used before being assigned... Remove this comment to see the full error message
         pageTitle={pageTitle}
         showNotices={true}
         toggleLeftMenu={() => setOpen(!open)}

--- a/packages/front-end/components/Layout/LayoutLite.tsx
+++ b/packages/front-end/components/Layout/LayoutLite.tsx
@@ -35,7 +35,7 @@ const LayoutLite = (): React.ReactElement => {
         </div>
       </div>
 
-      <TopNav showNotices={false} />
+      <TopNav showNotices={false} pageTitle="" />
     </>
   );
 };

--- a/packages/front-end/components/Layout/PageHead.tsx
+++ b/packages/front-end/components/Layout/PageHead.tsx
@@ -1,0 +1,64 @@
+import {
+  ReactNode,
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+
+interface PageHeadContextInterface {
+  pageTitle: string;
+  setPageTitle: (title: string) => void;
+}
+
+export const PageHeadContext = createContext<PageHeadContextInterface>({
+  pageTitle: "",
+  setPageTitle: () => undefined,
+});
+
+export function usePageHead() {
+  return useContext(PageHeadContext);
+}
+
+export function PageHeadProvider({
+  children,
+  pageComponent,
+}: {
+  children: ReactNode;
+  // eslint-disable-next-line
+  pageComponent: any;
+}) {
+  const [pageTitle, setPageTitle] = useState("");
+
+  // Reset page title when the page component changes
+  useEffect(() => {
+    setPageTitle("");
+  }, [pageComponent]);
+
+  return (
+    <PageHeadContext.Provider value={{ pageTitle, setPageTitle }}>
+      {children}
+    </PageHeadContext.Provider>
+  );
+}
+
+export default function PageTitle({
+  children,
+}: {
+  children: string | string[];
+}) {
+  const { setPageTitle, pageTitle } = useContext(PageHeadContext);
+
+  // Passing in a compound string with interpolation comes in as an array of string
+  const desiredPageTitle = Array.isArray(children)
+    ? children.join("")
+    : children;
+
+  useEffect(() => {
+    if (pageTitle !== desiredPageTitle) {
+      setPageTitle(desiredPageTitle);
+    }
+  }, [desiredPageTitle, pageTitle, setPageTitle]);
+
+  return null;
+}

--- a/packages/front-end/components/Layout/PageHead.tsx
+++ b/packages/front-end/components/Layout/PageHead.tsx
@@ -6,59 +6,52 @@ import {
   useState,
 } from "react";
 
+interface BreadCrumbItem {
+  display: string;
+  href?: string;
+}
+
 interface PageHeadContextInterface {
-  pageTitle: string;
-  setPageTitle: (title: string) => void;
+  breadcrumb: BreadCrumbItem[];
+  setBreadcrumb: (breadcrumb: BreadCrumbItem[]) => void;
 }
 
 export const PageHeadContext = createContext<PageHeadContextInterface>({
-  pageTitle: "",
-  setPageTitle: () => undefined,
+  breadcrumb: [],
+  setBreadcrumb: () => undefined,
 });
 
 export function usePageHead() {
   return useContext(PageHeadContext);
 }
 
-export function PageHeadProvider({
-  children,
-  pageComponent,
-}: {
-  children: ReactNode;
-  // eslint-disable-next-line
-  pageComponent: any;
-}) {
-  const [pageTitle, setPageTitle] = useState("");
-
-  // Reset page title when the page component changes
-  useEffect(() => {
-    setPageTitle("");
-  }, [pageComponent]);
+export function PageHeadProvider({ children }: { children: ReactNode }) {
+  const [breadcrumb, setBreadcrumb] = useState<BreadCrumbItem[]>([]);
 
   return (
-    <PageHeadContext.Provider value={{ pageTitle, setPageTitle }}>
+    <PageHeadContext.Provider value={{ breadcrumb, setBreadcrumb }}>
       {children}
     </PageHeadContext.Provider>
   );
 }
 
-export default function PageTitle({
-  children,
+export default function PageHead({
+  breadcrumb,
 }: {
-  children: string | string[];
+  breadcrumb: BreadCrumbItem[];
 }) {
-  const { setPageTitle, pageTitle } = useContext(PageHeadContext);
+  const { setBreadcrumb } = useContext(PageHeadContext);
 
-  // Passing in a compound string with interpolation comes in as an array of string
-  const desiredPageTitle = Array.isArray(children)
-    ? children.join("")
-    : children;
+  const newVal = JSON.stringify(breadcrumb);
 
   useEffect(() => {
-    if (pageTitle !== desiredPageTitle) {
-      setPageTitle(desiredPageTitle);
-    }
-  }, [desiredPageTitle, pageTitle, setPageTitle]);
+    setBreadcrumb(breadcrumb);
+    // Unset when the page unmounts
+    return () => {
+      setBreadcrumb([]);
+    };
+    // eslint-disable-next-line
+  }, [newVal, setBreadcrumb]);
 
   return null;
 }

--- a/packages/front-end/components/Layout/TopNav.module.scss
+++ b/packages/front-end/components/Layout/TopNav.module.scss
@@ -23,6 +23,14 @@ $sidebarwidth: 240px;
   line-height: 1.1;
   color: var(--text-color-main);
   font-weight: 600;
+  flex: 1;
+  min-width: 0;
+
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: inline-block;
+  white-space: nowrap;
+  vertical-align: middle;
 }
 .mobilemenu {
   display: none;
@@ -34,17 +42,14 @@ $sidebarwidth: 240px;
     background: inherit;
   }
 }
-.leftSection {
+
+.navbar {
   display: flex;
   justify-content: flex-start;
   align-items: center;
-  max-width: 30%;
+  width: 100%;
 }
-.rightSection {
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-}
+
 @media (max-width: 1180px) {
   .pagetitle {
     padding-left: 10px;

--- a/packages/front-end/components/Layout/TopNav.tsx
+++ b/packages/front-end/components/Layout/TopNav.tsx
@@ -1,6 +1,6 @@
-import { FC, useState } from "react";
+import { FC, Fragment, useState } from "react";
 import { useForm } from "react-hook-form";
-import { FaBars, FaBell, FaBuilding } from "react-icons/fa";
+import { FaAngleRight, FaBars, FaBell, FaBuilding } from "react-icons/fa";
 import Link from "next/link";
 import clsx from "clsx";
 import Head from "next/head";
@@ -14,14 +14,16 @@ import Modal from "../Modal";
 import Avatar from "../Avatar/Avatar";
 import ChangePasswordModal from "../Auth/ChangePasswordModal";
 import Field from "../Forms/Field";
+import OverflowText from "../Experiment/TabbedPage/OverflowText";
 import styles from "./TopNav.module.scss";
 import { ThemeToggler } from "./ThemeToggler/ThemeToggler";
 import AccountPlanBadge from "./AccountPlanBadge";
 import AccountPlanNotices from "./AccountPlanNotices";
+import { usePageHead } from "./PageHead";
 
 const TopNav: FC<{
   toggleLeftMenu?: () => void;
-  pageTitle?: string;
+  pageTitle: string;
   showNotices?: boolean;
 }> = ({ toggleLeftMenu, pageTitle, showNotices }) => {
   const [userDropdownOpen, setUserDropdownOpen] = useState(false);
@@ -31,6 +33,8 @@ const TopNav: FC<{
   const [changePasswordOpen, setChangePasswordOpen] = useState(false);
   useGlobalMenu(".top-nav-user-menu", () => setUserDropdownOpen(false));
   useGlobalMenu(".top-nav-org-menu", () => setOrgDropdownOpen(false));
+
+  const { breadcrumb } = usePageHead();
 
   const { updateUser, name, email } = useUser();
 
@@ -64,7 +68,7 @@ const TopNav: FC<{
   return (
     <>
       <Head>
-        <title>GrowthBook - {pageTitle}</title>
+        <title>GrowthBook &gt; {pageTitle}</title>
       </Head>
       {editUserOpen && (
         <Modal
@@ -85,7 +89,7 @@ const TopNav: FC<{
           left: toggleLeftMenu ? undefined : 0,
         }}
       >
-        <div className={styles.leftSection}>
+        <div className={styles.navbar}>
           {toggleLeftMenu ? (
             <a
               href="#main-menu"
@@ -109,11 +113,27 @@ const TopNav: FC<{
               />
             </div>
           )}
+          <div className={styles.pagetitle}>
+            {breadcrumb.length > 0 ? (
+              breadcrumb.map((b, i) => (
+                <span
+                  key={i}
+                  className={
+                    i < breadcrumb.length - 1 ? "d-none d-lg-inline" : ""
+                  }
+                  title={b.display}
+                >
+                  {i > 0 && (
+                    <FaAngleRight className="mx-2 d-none d-lg-inline" />
+                  )}
+                  {b.href ? <Link href={b.href}>{b.display}</Link> : b.display}
+                </span>
+              ))
+            ) : (
+              <>{pageTitle}</>
+            )}
+          </div>
 
-          <div className={styles.pagetitle}>{pageTitle}</div>
-        </div>
-
-        <div className={styles.rightSection}>
           <ThemeToggler />
 
           {showNotices && (
@@ -149,7 +169,9 @@ const TopNav: FC<{
                 style={{ cursor: "pointer" }}
               >
                 <FaBuilding className="text-muted mr-1" />
-                <span className="d-none d-lg-inline">{orgName}</span>
+                <span className="d-none d-lg-inline">
+                  <OverflowText maxWidth={200}>{orgName}</OverflowText>
+                </span>
               </div>
               <div
                 className={clsx("dropdown-menu dropdown-menu-right", {
@@ -197,7 +219,9 @@ const TopNav: FC<{
               style={{ cursor: "pointer" }}
             >
               <Avatar email={email || ""} size={26} />{" "}
-              <span className="d-none d-lg-inline">{email}</span>
+              <span className="d-none d-lg-inline">
+                <OverflowText maxWidth={200}>{email}</OverflowText>
+              </span>
             </div>
             <div
               className={clsx("dropdown-menu dropdown-menu-right", {

--- a/packages/front-end/pages/_app.tsx
+++ b/packages/front-end/pages/_app.tsx
@@ -91,7 +91,7 @@ function App({
         preAuth ? (
           <Component {...pageProps} />
         ) : (
-          <PageHeadProvider pageComponent={Component}>
+          <PageHeadProvider>
             <AuthProvider>
               <AppearanceUIThemeProvider>
                 <GrowthBookProvider growthbook={growthbook}>

--- a/packages/front-end/pages/_app.tsx
+++ b/packages/front-end/pages/_app.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react";
 import { GrowthBook, GrowthBookProvider } from "@growthbook/growthbook-react";
 import { OrganizationMessagesContainer } from "@/components/OrganizationMessages/OrganizationMessages";
 import { DemoDataSourceGlobalBannerContainer } from "@/components/DemoDataSourceGlobalBanner/DemoDataSourceGlobalBanner";
+import { PageHeadProvider } from "@/components/Layout/PageHead";
 import { AuthProvider } from "../services/auth";
 import ProtectedPage from "../components/ProtectedPage";
 import { DefinitionsProvider } from "../services/DefinitionsContext";
@@ -90,31 +91,33 @@ function App({
         preAuth ? (
           <Component {...pageProps} />
         ) : (
-          <AuthProvider>
-            <AppearanceUIThemeProvider>
-              <GrowthBookProvider growthbook={growthbook}>
-                <ProtectedPage organizationRequired={organizationRequired}>
-                  {organizationRequired ? (
-                    <DefinitionsProvider>
-                      {!liteLayout && <Layout />}
-                      <main className={`main ${parts[0]}`}>
-                        <OrganizationMessagesContainer />
-                        <DemoDataSourceGlobalBannerContainer />
-                        <Component {...pageProps} />
-                      </main>
-                    </DefinitionsProvider>
-                  ) : (
-                    <div>
-                      <TopNavLite />
-                      <main className="container mt-5">
-                        <Component {...pageProps} />
-                      </main>
-                    </div>
-                  )}
-                </ProtectedPage>
-              </GrowthBookProvider>
-            </AppearanceUIThemeProvider>
-          </AuthProvider>
+          <PageHeadProvider pageComponent={Component}>
+            <AuthProvider>
+              <AppearanceUIThemeProvider>
+                <GrowthBookProvider growthbook={growthbook}>
+                  <ProtectedPage organizationRequired={organizationRequired}>
+                    {organizationRequired ? (
+                      <DefinitionsProvider>
+                        {!liteLayout && <Layout />}
+                        <main className={`main ${parts[0]}`}>
+                          <OrganizationMessagesContainer />
+                          <DemoDataSourceGlobalBannerContainer />
+                          <Component {...pageProps} />
+                        </main>
+                      </DefinitionsProvider>
+                    ) : (
+                      <div>
+                        <TopNavLite />
+                        <main className="container mt-5">
+                          <Component {...pageProps} />
+                        </main>
+                      </div>
+                    )}
+                  </ProtectedPage>
+                </GrowthBookProvider>
+              </AppearanceUIThemeProvider>
+            </AuthProvider>
+          </PageHeadProvider>
         )
       ) : error ? (
         <div className="container mt-3">

--- a/packages/front-end/pages/datasources/[did].tsx
+++ b/packages/front-end/pages/datasources/[did].tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import { useRouter } from "next/router";
 import React, { FC, useCallback, useState } from "react";
 import {
@@ -27,10 +26,10 @@ import Code from "@/components/SyntaxHighlighting/Code";
 import LoadingOverlay from "@/components/LoadingOverlay";
 import Modal from "@/components/Modal";
 import SchemaBrowser from "@/components/SchemaBrowser/SchemaBrowser";
-import { GBCircleArrowLeft } from "@/components/Icons";
 import DataSourceMetrics from "@/components/Settings/EditDataSource/DataSourceMetrics";
 import { DeleteDemoDatasourceButton } from "@/components/DemoDataSourcePage/DemoDataSourcePage";
 import { useUser } from "@/services/UserContext";
+import PageHead from "@/components/Layout/PageHead";
 
 function quotePropertyName(name: string) {
   if (name.match(/^[a-zA-Z_][a-zA-Z0-9_]*$/)) {
@@ -119,13 +118,12 @@ const DataSourcePage: FC = () => {
 
   return (
     <div className="container pagecontents">
-      <div className="mb-2">
-        <Link href="/datasources">
-          <a>
-            <GBCircleArrowLeft /> Back to all data sources
-          </a>
-        </Link>
-      </div>
+      <PageHead
+        breadcrumb={[
+          { display: "Data Sources", href: "/datasources" },
+          { display: d.name },
+        ]}
+      />
 
       {d.projects?.includes(
         getDemoDatasourceProjectIdForOrganization(organization.id)

--- a/packages/front-end/pages/experiment/[eid].tsx
+++ b/packages/front-end/pages/experiment/[eid].tsx
@@ -31,6 +31,7 @@ import { useLocalStorage } from "@/hooks/useLocalStorage";
 import { useFeaturesList } from "@/services/features";
 import FeedbackModal from "@/components/FeedbackModal";
 import track from "@/services/track";
+import PageTitle from "@/components/Layout/PageHead";
 
 const ExperimentPage = (): ReactElement => {
   const permissions = usePermissions();
@@ -211,6 +212,7 @@ const ExperimentPage = (): ReactElement => {
           safeToEdit={safeToEdit}
         />
       )}
+      <PageTitle>Experiment: {experiment.name}</PageTitle>
       <div className="container-fluid position-relative">
         <div
           style={{

--- a/packages/front-end/pages/experiment/[eid].tsx
+++ b/packages/front-end/pages/experiment/[eid].tsx
@@ -215,7 +215,16 @@ const ExperimentPage = (): ReactElement => {
 
       <PageHead
         breadcrumb={[
-          { display: "Experiments", href: "/experiments" },
+          {
+            display: "Experiments",
+            href: `/experiments${
+              experiment.status === "draft"
+                ? "#drafts"
+                : experiment.status === "stopped"
+                ? "#stopped"
+                : ""
+            }`,
+          },
           { display: experiment.name },
         ]}
       />

--- a/packages/front-end/pages/experiment/[eid].tsx
+++ b/packages/front-end/pages/experiment/[eid].tsx
@@ -31,7 +31,7 @@ import { useLocalStorage } from "@/hooks/useLocalStorage";
 import { useFeaturesList } from "@/services/features";
 import FeedbackModal from "@/components/FeedbackModal";
 import track from "@/services/track";
-import PageTitle from "@/components/Layout/PageHead";
+import PageHead from "@/components/Layout/PageHead";
 
 const ExperimentPage = (): ReactElement => {
   const permissions = usePermissions();
@@ -212,7 +212,14 @@ const ExperimentPage = (): ReactElement => {
           safeToEdit={safeToEdit}
         />
       )}
-      <PageTitle>Experiment: {experiment.name}</PageTitle>
+
+      <PageHead
+        breadcrumb={[
+          { display: "Experiments", href: "/experiments" },
+          { display: experiment.name },
+        ]}
+      />
+
       <div className="container-fluid position-relative">
         <div
           style={{

--- a/packages/front-end/pages/features/[fid].tsx
+++ b/packages/front-end/pages/features/[fid].tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import { useRouter } from "next/router";
 import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
 import { FeatureInterface } from "back-end/types/feature";
@@ -9,7 +8,7 @@ import { datetime } from "shared/dates";
 import { getValidation } from "shared/util";
 import { getDemoDatasourceProjectIdForOrganization } from "shared/demo-datasource";
 import MoreMenu from "@/components/Dropdown/MoreMenu";
-import { GBAddCircle, GBCircleArrowLeft, GBEdit } from "@/components/Icons";
+import { GBAddCircle, GBEdit } from "@/components/Icons";
 import LoadingOverlay from "@/components/LoadingOverlay";
 import useApi from "@/hooks/useApi";
 import DeleteButton from "@/components/DeleteButton/DeleteButton";
@@ -52,6 +51,7 @@ import Code from "@/components/SyntaxHighlighting/Code";
 import PremiumTooltip from "@/components/Marketing/PremiumTooltip";
 import { useUser } from "@/services/UserContext";
 import { DeleteDemoDatasourceButton } from "@/components/DemoDataSourcePage/DemoDataSourcePage";
+import PageHead from "@/components/Layout/PageHead";
 
 export default function FeaturePage() {
   const router = useRouter();
@@ -258,6 +258,13 @@ export default function FeaturePage() {
         />
       )}
 
+      <PageHead
+        breadcrumb={[
+          { display: "Features", href: "/features" },
+          { display: data.feature.id },
+        ]}
+      />
+
       {isDraft && (
         <div
           className="alert alert-warning mb-3 text-center shadow-sm"
@@ -296,11 +303,7 @@ export default function FeaturePage() {
 
       <div className="row align-items-center mb-2">
         <div className="col-auto">
-          <Link href="/features">
-            <a>
-              <GBCircleArrowLeft /> Back to all features
-            </a>
-          </Link>
+          <h1 className="mb-0">{fid}</h1>
         </div>
         <div style={{ flex: 1 }} />
         <div className="col-auto">
@@ -402,10 +405,6 @@ export default function FeaturePage() {
             in SDK Endpoints or Webhook payloads.
           </div>
         )}
-      </div>
-
-      <div className="row align-items-center mb-2">
-        <h1 className="col-auto mb-0">{fid}</h1>
       </div>
 
       <div className="mb-2 row">

--- a/packages/front-end/pages/metric/[mid].tsx
+++ b/packages/front-end/pages/metric/[mid].tsx
@@ -3,7 +3,6 @@ import React, { FC, useState, useEffect, Fragment } from "react";
 import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
 import Link from "next/link";
 import {
-  FaAngleLeft,
   FaArchive,
   FaChevronRight,
   FaQuestionCircle,
@@ -62,6 +61,7 @@ import Tooltip from "@/components/Tooltip/Tooltip";
 import { useCurrency } from "@/hooks/useCurrency";
 import { DeleteDemoDatasourceButton } from "@/components/DemoDataSourcePage/DemoDataSourcePage";
 import { useUser } from "@/services/UserContext";
+import PageHead from "@/components/Layout/PageHead";
 
 const MetricPage: FC = () => {
   const router = useRouter();
@@ -380,13 +380,13 @@ const MetricPage: FC = () => {
           segment={metric.segment || ""}
         />
       )}
-      <div className="mb-2">
-        <Link href="/metrics">
-          <a>
-            <FaAngleLeft /> All Metrics
-          </a>
-        </Link>
-      </div>
+
+      <PageHead
+        breadcrumb={[
+          { display: "Metrics", href: "/metrics" },
+          { display: metric.name },
+        ]}
+      />
 
       {metric.status === "archived" && (
         <div className="alert alert-secondary mb-2">

--- a/packages/front-end/pages/sdks/[sdkid].tsx
+++ b/packages/front-end/pages/sdks/[sdkid].tsx
@@ -1,6 +1,5 @@
 import { SDKConnectionInterface } from "back-end/types/sdk-connection";
 import { useRouter } from "next/router";
-import Link from "next/link";
 import { ReactElement, ReactNode, useState } from "react";
 import {
   FaCheckCircle,
@@ -11,7 +10,7 @@ import {
 } from "react-icons/fa";
 import { BsArrowRepeat, BsLightningFill } from "react-icons/bs";
 import LoadingOverlay from "@/components/LoadingOverlay";
-import { GBCircleArrowLeft, GBEdit, GBHashLock } from "@/components/Icons";
+import { GBEdit, GBHashLock } from "@/components/Icons";
 import DeleteButton from "@/components/DeleteButton/DeleteButton";
 import MoreMenu from "@/components/Dropdown/MoreMenu";
 import { useAuth } from "@/services/auth";
@@ -27,6 +26,7 @@ import Button from "@/components/Button";
 import useSDKConnections from "@/hooks/useSDKConnections";
 import { isCloud } from "@/services/env";
 import Tooltip from "@/components/Tooltip/Tooltip";
+import PageHead from "@/components/Layout/PageHead";
 
 function ConnectionDot({ left }: { left: boolean }) {
   return (
@@ -169,15 +169,13 @@ export default function SDKConnectionPage() {
           edit={modalState.mode === "edit"}
         />
       )}
-      <div className="row align-items-center mb-2">
-        <div className="col-auto">
-          <Link href="/sdks">
-            <a>
-              <GBCircleArrowLeft /> Back to all SDK connections
-            </a>
-          </Link>
-        </div>
-      </div>
+
+      <PageHead
+        breadcrumb={[
+          { display: "SDK Connections", href: "/sdks" },
+          { display: connection.name },
+        ]}
+      />
 
       <div className="row align-items-center mb-2">
         <h1 className="col-auto mb-0">{connection.name}</h1>


### PR DESCRIPTION
### Features and Changes

- Fix layout issues in top nav
- Add support for breadcrumb page titles
- Improve detail page titles (experiment, feature, metric, data source, and SDK connection)

### Existing Screenshots

Long org, email, and page name.  If it's long enough, the user dropdown completely disappears and there's no way to log out.

![image](https://github.com/growthbook/growthbook/assets/1087514/80ca8f38-2989-490e-88e6-775fb26ecba6)

Page for a specific experiment uses a generic title

![image](https://github.com/growthbook/growthbook/assets/1087514/f6969d62-74cc-47fd-9264-00161cd3ea9a)

Browser history is difficult to navigate (these are a mix a various experiment list pages and detail pages):

![image](https://github.com/growthbook/growthbook/assets/1087514/19804582-55ec-4594-9d22-7f0bdca8877e)


### New Screenshots

Overflow text for page name, org name, and email. Works on any size screen.

![image](https://github.com/growthbook/growthbook/assets/1087514/1801cb73-eff8-4ad9-96a6-39e70038996c)

Experiment page titles now show a navigable bread crumb:

![image](https://github.com/growthbook/growthbook/assets/1087514/930ef95d-742b-4963-8288-713da4e5d328)

Browser history

![image](https://github.com/growthbook/growthbook/assets/1087514/c8dd3906-7317-48e5-8259-58e6900a3862)




