### PR TITLE
Make it easier to find watched experiments

### DIFF
--- a/packages/front-end/pages/experiments/index.tsx
+++ b/packages/front-end/pages/experiments/index.tsx
@@ -273,6 +273,7 @@ const ExperimentsPage = (): React.ReactElement => {
                 {...searchInputProps}
               />
             </div>
+            <div className="flex-1" />
             <div className="col-auto ml-auto">
               <Toggle
                 id="watched-experiments-toggle"

--- a/packages/front-end/pages/experiments/index.tsx
+++ b/packages/front-end/pages/experiments/index.tsx
@@ -308,9 +308,7 @@ const ExperimentsPage = (): React.ReactElement => {
                   <SortableTH field="projectName">Project</SortableTH>
                 )}
                 <SortableTH field="tags">Tags</SortableTH>
-                {!showMineOnly && (
-                  <SortableTH field="ownerName">Owner</SortableTH>
-                )}
+                <SortableTH field="ownerName">Owner</SortableTH>
                 {tab === "running" && <th>Phase</th>}
                 <SortableTH field="date">
                   {tab === "running"
@@ -400,11 +398,9 @@ const ExperimentsPage = (): React.ReactElement => {
                     <td className="nowrap" data-title="Tags:">
                       <SortedTags tags={Object.values(e.tags)} />
                     </td>
-                    {!showMineOnly && (
-                      <td className="nowrap" data-title="Owner:">
-                        {e.ownerName}
-                      </td>
-                    )}
+                    <td className="nowrap" data-title="Owner:">
+                      {e.ownerName}
+                    </td>
                     {tab === "running" && (
                       <td className="nowrap" data-title="Phase:">
                         {phase && phaseSummary(phase)}

--- a/packages/front-end/pages/experiments/index.tsx
+++ b/packages/front-end/pages/experiments/index.tsx
@@ -148,7 +148,7 @@ const ExperimentsPage = (): React.ReactElement => {
   // Reset to page 1 when a filter is applied or tabs change
   useEffect(() => {
     setCurrentPage(1);
-  }, [items.length, tab, showMineOnly]);
+  }, [items.length, tab, showMineOnly, showWatchedOnly]);
 
   // Show steps if coming from get started page
   useEffect(() => {

--- a/packages/front-end/pages/experiments/index.tsx
+++ b/packages/front-end/pages/experiments/index.tsx
@@ -28,6 +28,7 @@ import { AppFeatures } from "@/types/app-features";
 import { useExperiments } from "@/hooks/useExperiments";
 import Tooltip from "@/components/Tooltip/Tooltip";
 import { useAuth } from "@/services/auth";
+import { useWatching } from "@/services/WatchProvider";
 
 const NUM_PER_PAGE = 20;
 
@@ -45,6 +46,10 @@ const ExperimentsPage = (): React.ReactElement => {
   const [tab, setTab] = useAnchor(["running", "drafts", "stopped", "archived"]);
 
   const [showMineOnly, setShowMineOnly] = useState(false);
+  const [showWatchedOnly, setShowWatchedOnly] = useState(false);
+
+  const { watchedExperiments } = useWatching();
+  console.log(watchedExperiments);
   const router = useRouter();
   const [openNewExperimentModal, setOpenNewExperimentModal] = useState(false);
 
@@ -93,9 +98,12 @@ const ExperimentsPage = (): React.ReactElement => {
       if (showMineOnly) {
         items = items.filter((item) => item.owner === userId);
       }
+      if (showWatchedOnly) {
+        items = items.filter((item) => watchedExperiments.includes(item.id));
+      }
       return items;
     },
-    [showMineOnly, userId]
+    [showMineOnly, showWatchedOnly, userId]
   );
 
   const { items, searchInputProps, isFiltered, SortableTH } = useSearch({
@@ -264,6 +272,17 @@ const ExperimentsPage = (): React.ReactElement => {
                 type="search"
                 {...searchInputProps}
               />
+            </div>
+            <div className="col-auto ml-auto">
+              <Toggle
+                id="watched-experiments-toggle"
+                type="toggle"
+                value={showWatchedOnly}
+                setValue={(value) => {
+                  setShowWatchedOnly(value);
+                }}
+              />{" "}
+              Watched Experiments Only
             </div>
             <div className="col-auto ml-auto">
               <Toggle


### PR DESCRIPTION
### Features and Changes

The experiment list can be hard to filter through and search sometimes if you have a ton of experiments.

While we should add tags and harmonize the search experience across lists, for now we can improve the experience by letting people filter experiments by whether or not they are watching the experiment.

<img width="1468" alt="Screenshot 2023-09-21 at 1 10 52 PM" src="https://github.com/growthbook/growthbook/assets/5298599/7f967d1c-790c-45f0-a701-5fdf34de5071">

<img width="1464" alt="Screenshot 2023-09-21 at 1 10 57 PM" src="https://github.com/growthbook/growthbook/assets/5298599/c82bdef0-d84e-400a-bd2c-74ce019e75a7">
