### PR TITLE
add dimension chooser on [rid] page, tweak ui

### DIFF
--- a/packages/front-end/components/Dimensions/DimensionChooser.tsx
+++ b/packages/front-end/components/Dimensions/DimensionChooser.tsx
@@ -19,6 +19,7 @@ export interface Props {
   setAnalysisSettings?: (
     settings: ExperimentSnapshotAnalysisSettings | null
   ) => void;
+  disabled?: boolean;
 }
 
 export default function DimensionChooser({
@@ -34,6 +35,7 @@ export default function DimensionChooser({
   setVariationFilter,
   setBaselineRow,
   setAnalysisSettings,
+  disabled = false,
 }: Props) {
   const { dimensions, getDatasourceById } = useDefinitions();
   const datasource = datasourceId ? getDatasourceById(datasourceId) : null;
@@ -130,7 +132,7 @@ export default function DimensionChooser({
         helpText={
           showHelp ? "Break down results for each metric by a dimension" : ""
         }
-        // disabled={!setValue}
+        disabled={!setValue || disabled}
       />
     </div>
   );

--- a/packages/front-end/components/Dimensions/DimensionChooser.tsx
+++ b/packages/front-end/components/Dimensions/DimensionChooser.tsx
@@ -6,7 +6,7 @@ import SelectField from "../Forms/SelectField";
 
 export interface Props {
   value: string;
-  setValue: (value: string) => void;
+  setValue?: (value: string) => void;
   datasourceId?: string;
   exposureQueryId?: string;
   activationMetric?: boolean;
@@ -41,7 +41,7 @@ export default function DimensionChooser({
   // If activation metric is not selected, don't allow using that dimension
   useEffect(() => {
     if (value === "pre:activation" && !activationMetric) {
-      setValue("");
+      setValue?.("");
     }
   }, [value, activationMetric]);
 
@@ -125,11 +125,12 @@ export default function DimensionChooser({
           setAnalysisSettings?.(null);
           setBaselineRow?.(0);
           setVariationFilter?.([]);
-          setValue(v);
+          setValue?.(v);
         }}
         helpText={
           showHelp ? "Break down results for each metric by a dimension" : ""
         }
+        // disabled={!setValue}
       />
     </div>
   );

--- a/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
@@ -74,7 +74,7 @@ export default function ExperimentHeader({
   const router = useRouter();
   const permissions = usePermissions();
   const { scrollY } = useScrollPosition();
-  const headerPinned = scrollY > 70;
+  const headerPinned = scrollY > 45;
 
   const phases = experiment.phases || [];
   const lastPhaseIndex = phases.length - 1;

--- a/packages/front-end/pages/report/[rid].tsx
+++ b/packages/front-end/pages/report/[rid].tsx
@@ -121,6 +121,18 @@ export default function ReportPage() {
     },
   });
 
+  useEffect(() => {
+    if (data?.report) {
+      const newVal = {
+        ...form.getValues(),
+        title: data?.report.title,
+        description: data?.report.description,
+        status: data?.report?.status ? data.report.status : "private",
+      };
+      form.reset(newVal);
+    }
+  }, [data?.report]);
+
   const changeDimension = (newDimension: string) => {
     setDimension(newDimension);
     if (report && report?.args?.dimension !== newDimension) {

--- a/packages/front-end/pages/report/[rid].tsx
+++ b/packages/front-end/pages/report/[rid].tsx
@@ -52,7 +52,6 @@ export default function ReportPage() {
     "experiment-results-new-ui-v2",
     true
   );
-
   const router = useRouter();
   const { rid } = router.query;
 
@@ -99,11 +98,20 @@ export default function ReportPage() {
   const [dimension, setDimension] = useState<string>(
     report?.args?.dimension ?? ""
   );
+  const [blockDimensionDropdown, setBlockDimensionDropdown] = useState(
+    status === "running"
+  );
   useEffect(() => {
     if (report?.args) {
       setDimension(report?.args?.dimension ?? "");
     }
   }, [report?.args]);
+  useEffect(() => {
+    const { status } = getQueryStatus(report?.queries || []);
+    if (report?.queries && status !== "running") {
+      setBlockDimensionDropdown(false);
+    }
+  }, [report, setBlockDimensionDropdown]);
 
   const form = useForm({
     defaultValues: {
@@ -116,6 +124,7 @@ export default function ReportPage() {
   const changeDimension = (newDimension: string) => {
     setDimension(newDimension);
     if (report && report?.args?.dimension !== newDimension) {
+      setBlockDimensionDropdown(true);
       const args = {
         ...report.args,
         dimension: newDimension,
@@ -314,6 +323,10 @@ export default function ReportPage() {
                     userIdType={report.args.userIdType}
                     labelClassName="mr-2"
                     newUi={newUi}
+                    disabled={
+                      blockDimensionDropdown ||
+                      !permissions.check("createAnalyses", "")
+                    }
                   />
                   {report && dimension !== report?.args?.dimension ? (
                     <div className="ml-2 mb-1">


### PR DESCRIPTION
### Features and Changes

Dimension chooser on the reports page.

<img width="1261" alt="image" src="https://github.com/growthbook/growthbook/assets/7927873/3f55c52e-a7d2-41b9-a7ec-7ca0e17ce1f8">


### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

<!--
  Please describe how to test these changes.
 -->

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
