### PR TITLE
make experiment results tooltip hover less aggressive

### DIFF
--- a/packages/front-end/components/Experiment/ResultsTable.tsx
+++ b/packages/front-end/components/Experiment/ResultsTable.tsx
@@ -405,7 +405,7 @@ export default function ResultsTable({
           hoveredMetricRow !== null &&
           hoveredVariationRow !== null
         }
-        timeout={0}
+        timeout={200}
         classNames="tooltip-animate"
         appear={true}
       >
@@ -742,19 +742,6 @@ export default function ResultsTable({
                               hover: isHovered,
                             })}
                             newUi={true}
-                            onMouseMove={(e) =>
-                              onPointerMove(e, {
-                                x: "element-right",
-                                offsetX: -45,
-                              })
-                            }
-                            onPointerLeave={onPointerLeave}
-                            onClick={(e) =>
-                              onPointerMove(e, {
-                                x: "element-right",
-                                offsetX: -45,
-                              })
-                            }
                           />
                         ) : (
                           <td />
@@ -767,19 +754,6 @@ export default function ResultsTable({
                             hover: isHovered,
                           })}
                           newUi={true}
-                          onMouseMove={(e) =>
-                            onPointerMove(e, {
-                              x: "element-right",
-                              offsetX: -45,
-                            })
-                          }
-                          onPointerLeave={onPointerLeave}
-                          onClick={(e) =>
-                            onPointerMove(e, {
-                              x: "element-right",
-                              offsetX: -45,
-                            })
-                          }
                         />
                         {j > 0 ? (
                           statsEngine === "bayesian" ? (
@@ -900,19 +874,6 @@ export default function ResultsTable({
                             rowResults={rowResults}
                             statsEngine={statsEngine}
                             className={resultsHighlightClassname}
-                            onMouseMove={(e) =>
-                              onPointerMove(e, {
-                                x: "element-left",
-                                offsetX: 50,
-                              })
-                            }
-                            onMouseLeave={onPointerLeave}
-                            onClick={(e) =>
-                              onPointerMove(e, {
-                                x: "element-left",
-                                offsetX: 50,
-                              })
-                            }
                           />
                         ) : (
                           <td></td>

--- a/packages/front-end/components/Features/CodeSnippetModal.tsx
+++ b/packages/front-end/components/Features/CodeSnippetModal.tsx
@@ -444,7 +444,7 @@ export default function CodeSnippetModal({
 // hashing a secureString attribute
 myAttribute = sha256(salt + myAttribute);
 
-// hashing an secureString[] attribute
+// hashing a secureString[] attribute
 myAttributes = myAttributes.map(attribute => sha256(salt + attribute));`}
                           />
                         </div>

--- a/packages/front-end/styles/global.scss
+++ b/packages/front-end/styles/global.scss
@@ -266,7 +266,7 @@ pre {
   font-size: 12px;
   color: var(--text-color-table);
   pointer-events: all;
-  transition: 150ms all;
+  transition: 250ms all;
 
   .opacity50 {
     opacity: 0.5;


### PR DESCRIPTION
### Features and Changes

- Only allow tooltip hover on CTW/p-value and graph elements
- Add hover delay (200ms)
- Slow down animation

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

<!--
  Please describe how to test these changes.
 -->

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
