### PR TITLE
show dimension on reports

### DIFF
--- a/packages/front-end/components/Dimensions/DimensionChooser.tsx
+++ b/packages/front-end/components/Dimensions/DimensionChooser.tsx
@@ -6,7 +6,7 @@ import SelectField from "../Forms/SelectField";
 
 export interface Props {
   value: string;
-  setValue: (value: string) => void;
+  setValue?: (value: string) => void;
   datasourceId?: string;
   exposureQueryId?: string;
   activationMetric?: boolean;
@@ -19,6 +19,7 @@ export interface Props {
   setAnalysisSettings?: (
     settings: ExperimentSnapshotAnalysisSettings | null
   ) => void;
+  disabled?: boolean;
 }
 
 export default function DimensionChooser({
@@ -34,6 +35,7 @@ export default function DimensionChooser({
   setVariationFilter,
   setBaselineRow,
   setAnalysisSettings,
+  disabled,
 }: Props) {
   const { dimensions, getDatasourceById } = useDefinitions();
   const datasource = datasourceId ? getDatasourceById(datasourceId) : null;
@@ -41,9 +43,9 @@ export default function DimensionChooser({
   // If activation metric is not selected, don't allow using that dimension
   useEffect(() => {
     if (value === "pre:activation" && !activationMetric) {
-      setValue("");
+      setValue?.("");
     }
-  }, [value, activationMetric]);
+  }, [value, setValue, activationMetric]);
 
   // Don't show anything if the datasource doesn't support dimensions
   if (!datasource || !datasource.properties?.dimensions) {
@@ -125,11 +127,12 @@ export default function DimensionChooser({
           setAnalysisSettings?.(null);
           setBaselineRow?.(0);
           setVariationFilter?.([]);
-          setValue(v);
+          setValue?.(v);
         }}
         helpText={
           showHelp ? "Break down results for each metric by a dimension" : ""
         }
+        disabled={disabled}
       />
     </div>
   );

--- a/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
@@ -74,7 +74,7 @@ export default function ExperimentHeader({
   const router = useRouter();
   const permissions = usePermissions();
   const { scrollY } = useScrollPosition();
-  const headerPinned = scrollY > 70;
+  const headerPinned = scrollY > 45;
 
   const phases = experiment.phases || [];
   const lastPhaseIndex = phases.length - 1;

--- a/packages/front-end/pages/report/[rid].tsx
+++ b/packages/front-end/pages/report/[rid].tsx
@@ -44,6 +44,7 @@ import track, { trackReport } from "@/services/track";
 import CompactResults from "@/components/Experiment/CompactResults";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
 import BreakDownResults from "@/components/Experiment/BreakDownResults";
+import OverflowText from "@/components/Experiment/TabbedPage/OverflowText";
 
 export default function ReportPage() {
   const [newUi, setNewUi] = useLocalStorage<boolean>(
@@ -288,6 +289,14 @@ export default function ReportPage() {
                   <h2>Results</h2>
                 </div>
                 <div className="flex-1"></div>
+                <div className="col-auto form-inline pr-3">
+                  <div>
+                    <div className="uppercase-title text-muted">Dimension</div>
+                    <OverflowText maxWidth={220}>
+                      {report.args.dimension || "None"}
+                    </OverflowText>
+                  </div>
+                </div>
                 <div className="col-auto">
                   {hasData &&
                   report.runStarted &&

--- a/packages/front-end/pages/report/[rid].tsx
+++ b/packages/front-end/pages/report/[rid].tsx
@@ -44,7 +44,7 @@ import track, { trackReport } from "@/services/track";
 import CompactResults from "@/components/Experiment/CompactResults";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
 import BreakDownResults from "@/components/Experiment/BreakDownResults";
-import OverflowText from "@/components/Experiment/TabbedPage/OverflowText";
+import DimensionChooser from "@/components/Dimensions/DimensionChooser";
 
 export default function ReportPage() {
   const [newUi, setNewUi] = useLocalStorage<boolean>(
@@ -147,13 +147,6 @@ export default function ReportPage() {
 
   const sequentialTestingEnabled =
     hasSequentialTestingFeature && !!report.args.sequentialTestingEnabled;
-
-  let dimensionText = "None";
-  if (report.args.dimension === "pre:date") {
-    dimensionText = "Date Cohorts (First Exposure)";
-  } else if (report.args.dimension === "pre:activation") {
-    dimensionText = "Activation status";
-  }
 
   return (
     <>
@@ -296,11 +289,17 @@ export default function ReportPage() {
                   <h2>Results</h2>
                 </div>
                 <div className="flex-1"></div>
-                <div className="col-auto form-inline pr-3">
-                  <div>
-                    <div className="uppercase-title text-muted">Dimension</div>
-                    <OverflowText maxWidth={220}>{dimensionText}</OverflowText>
-                  </div>
+                <div className="col-auto d-flex align-items-end mr-3">
+                  <DimensionChooser
+                    value={report.args.dimension ?? ""}
+                    activationMetric={!!report.args.activationMetric}
+                    datasourceId={report.args.datasource}
+                    exposureQueryId={report.args.exposureQueryId}
+                    userIdType={report.args.userIdType}
+                    labelClassName="mr-2"
+                    newUi={true}
+                    disabled={true}
+                  />
                 </div>
                 <div className="col-auto">
                   {hasData &&

--- a/packages/front-end/pages/report/[rid].tsx
+++ b/packages/front-end/pages/report/[rid].tsx
@@ -148,6 +148,13 @@ export default function ReportPage() {
   const sequentialTestingEnabled =
     hasSequentialTestingFeature && !!report.args.sequentialTestingEnabled;
 
+  let dimensionText = "None";
+  if (report.args.dimension === "pre:date") {
+    dimensionText = "Date Cohorts (First Exposure)";
+  } else if (report.args.dimension === "pre:activation") {
+    dimensionText = "Activation status";
+  }
+
   return (
     <>
       <div
@@ -292,9 +299,7 @@ export default function ReportPage() {
                 <div className="col-auto form-inline pr-3">
                   <div>
                     <div className="uppercase-title text-muted">Dimension</div>
-                    <OverflowText maxWidth={220}>
-                      {report.args.dimension || "None"}
-                    </OverflowText>
+                    <OverflowText maxWidth={220}>{dimensionText}</OverflowText>
                   </div>
                 </div>
                 <div className="col-auto">

--- a/packages/front-end/styles/global.scss
+++ b/packages/front-end/styles/global.scss
@@ -2542,6 +2542,16 @@ html {
       box-shadow: none !important;
     }
   }
+  .gb-select-wrapper.disabled {
+    cursor: text !important;
+    .gb-select__control {
+      border-bottom: 1px solid transparent !important;
+      background-color: transparent !important;
+      .gb-select__value-container:after {
+        display: none !important;
+      }
+    }
+  }
 }
 .phase-selector {
   .gb-select__single-value {


### PR DESCRIPTION
### Features and Changes

Adds dimension text to reports
<img width="1071" alt="image" src="https://github.com/growthbook/growthbook/assets/7927873/521240c9-7049-4daf-912b-60c756a57591">


### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

<!--
  Please describe how to test these changes.
 -->

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
