### PR TITLE
Hint that Url targeting attribute is required for visual editor URL targeting

### DIFF
--- a/docs/docs/visual-editor.mdx
+++ b/docs/docs/visual-editor.mdx
@@ -48,6 +48,13 @@ Once you created an experiment, you should be prompted to open the Visual Editor
 
 GrowthBook needs to know what page(s) of your site the experiment should run on.
 
+:::note
+
+For URL Targeting to work, you must pass the `url` targeting attribute into the GrowthBook SDK and also list it in the GrowthBook App.
+See [Targeting Attributes](/features/targeting) to learn more about targeting users with certain attributes.
+
+:::
+
 If your experiment is going to be on a single static page, enter the full URL and submit (e.g. `https://www.example.com/pricing`).
 
 If your experiment is going to be on a page with a dynamic URL (e.g. all pages that start with `/post/`), click on the "Advanced Mode" link.


### PR DESCRIPTION
Most other web based A/B testing packages detect URL via their own script and don't rely on that being passed through. Additionally when you first create an account, the URL attribute is set up automatically. This can mislead users into thinking setting the attribute is not needed.