### PR TITLE
Make it clear Visual editor is compatible with GTM implementation

### DIFF
--- a/docs/docs/guide/google-tag-manager-and-growthbook.mdx
+++ b/docs/docs/guide/google-tag-manager-and-growthbook.mdx
@@ -10,7 +10,7 @@ slug: google-tag-manager-and-growthbook
 Now customers who are familiar with feature management using Google Tag Manager (GTM), yet may lack the engineering resources or capability to implement changes in their codebase, may easily use GrowthBook with GTM to power their AB tests. This setup is commonly used by marketing teams and CRO agencies.
 
 :::note
-GrowthBook also offers a [visual editor](https://docs.growthbook.io/app/visual) for lightweight, no-code UI changes.
+GrowthBook also offers a [visual editor](https://docs.growthbook.io/app/visual) for lightweight, no-code UI changes. This approach is compatible with GTM and the examples provided on this page as long you enable the "Include Visual Experiments" toggle within your SDK Connection.
 :::
 
 In this guide, we will assume familiarity with the GTM platform. We also assume the ability to apply a unique user ID via Google Analytics (`client_id`), cookies, etc; as well as the ability to track events (GA or otherwise).


### PR DESCRIPTION
The documentation for Google Tag Manager can be read in a way that implies that 'visual editor' is an alternate. This commit indicates compatibility between visual editor and GTM and identifies the necessary toggle required to make it work.