### PR TITLE
Change admin -> superAdmin

### DIFF
--- a/packages/back-end/src/controllers/admin.ts
+++ b/packages/back-end/src/controllers/admin.ts
@@ -6,7 +6,7 @@ export async function getOrganizations(
   req: AuthRequest<never, never, { page?: string; search?: string }>,
   res: Response
 ) {
-  if (!req.admin) {
+  if (!req.superAdmin) {
     return res.status(403).json({
       status: 403,
       message: "Only admins can get all organizations",

--- a/packages/back-end/src/models/UserModel.ts
+++ b/packages/back-end/src/models/UserModel.ts
@@ -12,7 +12,7 @@ const userSchema = new mongoose.Schema({
     unique: true,
   },
   passwordHash: String,
-  admin: Boolean,
+  superAdmin: Boolean,
   verified: Boolean,
   minTokenDate: Date,
 });

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -1033,7 +1033,7 @@ export async function signup(req: AuthRequest<SignupBody>, res: Response) {
     // there are odd edge cases where a user can exist, but not an org,
     // so we want to allow org creation this way if there are no other orgs
     // on a local install.
-    if (orgs && !req.admin) {
+    if (orgs && !req.superAdmin) {
       throw new Error("An organization already exists");
     }
   }

--- a/packages/back-end/src/routers/users/users.controller.ts
+++ b/packages/back-end/src/routers/users/users.controller.ts
@@ -75,7 +75,7 @@ export async function getUser(req: AuthRequest, res: Response) {
     userId: userId,
     userName: req.name,
     email: req.email,
-    admin: !!req.admin,
+    admin: !!req.superAdmin,
     license: !IS_CLOUD && getLicense(),
     organizations: validOrgs.map((org) => {
       return {

--- a/packages/back-end/src/routers/users/users.controller.ts
+++ b/packages/back-end/src/routers/users/users.controller.ts
@@ -75,7 +75,7 @@ export async function getUser(req: AuthRequest, res: Response) {
     userId: userId,
     userName: req.name,
     email: req.email,
-    admin: !!req.superAdmin,
+    superAdmin: !!req.superAdmin,
     license: !IS_CLOUD && getLicense(),
     organizations: validOrgs.map((org) => {
       return {

--- a/packages/back-end/src/services/auth/index.ts
+++ b/packages/back-end/src/services/auth/index.ts
@@ -124,7 +124,7 @@ export async function processJWT(
     req.email = user.email;
     req.userId = user.id;
     req.name = user.name;
-    req.admin = !!user.admin;
+    req.superAdmin = !!user.superAdmin;
 
     // If using default Cloud SSO (Auth0), once a user logs in with a verified email address,
     // require all future logins to be verified too.
@@ -150,7 +150,7 @@ export async function processJWT(
       if (req.organization) {
         // Make sure member is part of the organization
         if (
-          !req.admin &&
+          !req.superAdmin &&
           !req.organization.members.filter((m) => m.id === req.userId).length
         ) {
           res.status(403).json({

--- a/packages/back-end/src/services/organizations.ts
+++ b/packages/back-end/src/services/organizations.ts
@@ -185,7 +185,7 @@ export async function userHasAccess(
   req: AuthRequest,
   organization: string
 ): Promise<boolean> {
-  if (req.admin) return true;
+  if (req.superAdmin) return true;
   if (req.organization?.id === organization) return true;
   if (!req.userId) return false;
 

--- a/packages/back-end/src/types/AuthRequest.ts
+++ b/packages/back-end/src/types/AuthRequest.ts
@@ -33,7 +33,7 @@ export type AuthRequest<
   loginMethod?: SSOConnectionInterface;
   authSubject?: string;
   name?: string;
-  admin?: boolean;
+  superAdmin?: boolean;
   organization?: OrganizationInterface;
   audit: (data: Partial<AuditInterface>) => Promise<void>;
 } & PermissionFunctions;

--- a/packages/back-end/src/util/logger.ts
+++ b/packages/back-end/src/util/logger.ts
@@ -50,8 +50,8 @@ export function getCustomLogProps(req: Request) {
   if (typedReq.userId) {
     data.userId = typedReq.userId;
   }
-  if (typedReq.admin) {
-    data.admin = true;
+  if (typedReq.superAdmin) {
+    data.superAdmin = true;
   }
   return data;
 }

--- a/packages/back-end/types/user.d.ts
+++ b/packages/back-end/types/user.d.ts
@@ -4,7 +4,7 @@ export interface UserInterface {
   email: string;
   verified: boolean;
   passwordHash?: string;
-  admin: boolean;
+  superAdmin: boolean;
   minTokenDate?: Date;
 }
 

--- a/packages/front-end/components/Layout/Layout.tsx
+++ b/packages/front-end/components/Layout/Layout.tsx
@@ -211,7 +211,7 @@ const navlinks: SidebarLinkProps[] = [
         name: "Admin",
         href: "/admin",
         path: /^admin/,
-        cloudOnly: true,
+        cloudOnly: false,
         divider: true,
         superAdmin: true,
       },

--- a/packages/front-end/components/Layout/Layout.tsx
+++ b/packages/front-end/components/Layout/Layout.tsx
@@ -211,7 +211,7 @@ const navlinks: SidebarLinkProps[] = [
         name: "Admin",
         href: "/admin",
         path: /^admin/,
-        cloudOnly: false,
+        cloudOnly: true,
         divider: true,
         superAdmin: true,
       },

--- a/packages/front-end/components/Layout/SidebarLink.tsx
+++ b/packages/front-end/components/Layout/SidebarLink.tsx
@@ -33,7 +33,7 @@ export type SidebarLinkProps = {
 };
 
 const SidebarLink: FC<SidebarLinkProps> = (props) => {
-  const { permissions, admin, accountPlan } = useUser();
+  const { permissions, superAdmin, accountPlan } = useUser();
   const router = useRouter();
 
   const path = router.route.substr(1);
@@ -56,7 +56,7 @@ const SidebarLink: FC<SidebarLinkProps> = (props) => {
     return null;
   }
 
-  if (props.superAdmin && !admin) return null;
+  if (props.superAdmin && !superAdmin) return null;
   if (props.permissions) {
     let allowed = false;
     for (let i = 0; i < props.permissions.length; i++) {
@@ -136,7 +136,7 @@ const SidebarLink: FC<SidebarLinkProps> = (props) => {
               (subLink) => !subLink.feature || growthbook.isOn(subLink.feature)
             )
             .map((l) => {
-              if (l.superAdmin && !admin) return null;
+              if (l.superAdmin && !superAdmin) return null;
 
               if (l.permissions) {
                 for (let i = 0; i < l.permissions.length; i++) {

--- a/packages/front-end/pages/admin.tsx
+++ b/packages/front-end/pages/admin.tsx
@@ -108,7 +108,7 @@ const Admin: FC = () => {
 
   const { orgId, setOrgId, setSpecialOrg, apiCall } = useAuth();
 
-  const { admin } = useUser();
+  const { superAdmin } = useUser();
 
   const [orgs, setOrgs] = useState<OrganizationInterface[]>([]);
   const [total, setTotal] = useState(0);
@@ -140,15 +140,15 @@ const Admin: FC = () => {
   );
 
   useEffect(() => {
-    if (!admin) return;
+    if (!superAdmin) return;
 
     loadOrgs(page, search);
     // eslint-disable-next-line
-  }, [admin]);
+  }, [superAdmin]);
 
   const [orgModalOpen, setOrgModalOpen] = useState(false);
 
-  if (!admin) {
+  if (!superAdmin) {
     return (
       <div className="alert alert-danger">
         Only super admins can view this page

--- a/packages/front-end/services/UserContext.tsx
+++ b/packages/front-end/services/UserContext.tsx
@@ -82,7 +82,7 @@ export interface UserContextValue {
   userId?: string;
   name?: string;
   email?: string;
-  admin?: boolean;
+  superAdmin?: boolean;
   license?: LicenseData;
   user?: ExpandedMember;
   users: Map<string, ExpandedMember>;
@@ -107,7 +107,7 @@ interface UserResponse {
   userName: string;
   email: string;
   verified: boolean;
-  admin: boolean;
+  superAdmin: boolean;
   organizations?: UserOrganizations;
   license?: LicenseData;
   currentUserPermissions: UserPermissions;
@@ -199,13 +199,13 @@ export function UserContextProvider({ children }: { children: ReactNode }) {
       environments: [],
       limitAccessByEnvironment: false,
       name: data.userName,
-      role: data.admin ? "admin" : "readonly",
+      role: data.superAdmin ? "admin" : "readonly",
       projectRoles: [],
     };
   }
 
   const role =
-    (data?.admin && "admin") ||
+    (data?.superAdmin && "admin") ||
     (user?.role ?? currentOrg?.organization?.settings?.defaultRole?.role);
 
   // Build out permissions object for backwards-compatible `permissions.manageTeams` style usage
@@ -268,7 +268,7 @@ export function UserContextProvider({ children }: { children: ReactNode }) {
     growthbook.setAttributes({
       id: data?.userId || "",
       name: data?.userName || "",
-      admin: data?.admin || false,
+      superAdmin: data?.superAdmin || false,
       company: currentOrg?.organization?.name || "",
       organizationId: hashedOrganizationId,
       userAgent: window.navigator.userAgent,
@@ -329,7 +329,7 @@ export function UserContextProvider({ children }: { children: ReactNode }) {
         userId: data?.userId,
         name: data?.userName,
         email: data?.email,
-        admin: data?.admin,
+        superAdmin: data?.superAdmin,
         updateUser,
         user,
         users,


### PR DESCRIPTION
### Features and Changes

We have an "admin" role for organizations.  Having "admin" also be a property on the user is confusing, when it is really conferring superAdmin privileges.

### Dependencies

will need to manually update the rows in cloud.  

### Testing

Relying mostly on Typescript saying there is nothing else to change.  
I changed Layout.txt to show admin also not on cloud temporarily and saw the link show up on my user once I had a property called "superAdmin: true" on it.

