### PR TITLE
Move building units table path to within users that asked for units table

### DIFF
--- a/packages/back-end/src/queryRunners/ExperimentResultsQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentResultsQueryRunner.ts
@@ -99,20 +99,21 @@ export const startExperimentResultQueries = async (
       hasPipelineModeFeature) ??
     false;
   let unitQuery: QueryPointer | null = null;
-  // The Mixpanel integration does not support writing tables
-  if (!integration.generateTablePath) {
-    throw new Error(
-      "Unable to generate table; table path generator not specified."
-    );
-  }
-  const unitsTableFullName = integration.generateTablePath(
-    `growthbook_tmp_units_${queryParentId}`,
-    integration.settings.pipelineSettings?.writeDataset,
-    "",
-    true
-  );
+  let unitsTableFullName = "";
 
   if (useUnitsTable) {
+    // The Mixpanel integration does not support writing tables
+    if (!integration.generateTablePath) {
+      throw new Error(
+        "Unable to generate table; table path generator not specified."
+      );
+    }
+    unitsTableFullName = integration.generateTablePath(
+      `growthbook_tmp_units_${queryParentId}`,
+      integration.settings.pipelineSettings?.writeDataset,
+      "",
+      true
+    );
     const unitQueryParams: ExperimentUnitsQueryParams = {
       activationMetric: activationMetric,
       dimension: dimensionObj,


### PR DESCRIPTION
Previous PR was too risky and checked for a default database for everyone when trying to write tables when we only need to use this for people who are writing tables.

This fixes this fragility.