### PR TITLE
Enforce writing error as empty string instead of undefined in queryrunner

### DIFF
--- a/packages/back-end/src/queryRunners/QueryRunner.ts
+++ b/packages/back-end/src/queryRunners/QueryRunner.ts
@@ -144,7 +144,7 @@ export abstract class QueryRunner<
     this.model.queries = queries;
 
     // If already finished (queries were cached)
-    let error: string | undefined = undefined;
+    let error = "";
     let result: Result | undefined = undefined;
 
     const queryStatus = this.getOverallQueryStatus();


### PR DESCRIPTION
### Features and Changes

For the Add Experiment modal powered by the past experiments end points, we weren't clearing old `error` fields in the `pastexperiments` collection when a new query was run.

Now we always set error to `""` when starting a new set of queries.


### Testing

Was able to replicate the persistent error bug on add experiments modal and now it resolves when re-running the query there.