### PR TITLE
Better cloning support for visual experiments

### DIFF
--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -623,20 +623,12 @@ export async function postExperiments(
         org.id
       );
       for (const visualChangeset of visualChangesets) {
-        const newVisualChangeset = await createVisualChangeset({
+        await createVisualChangeset({
           experiment,
           urlPatterns: visualChangeset.urlPatterns,
           editorUrl: visualChangeset.editorUrl,
           organization: org,
-          user: res.locals.eventAudit,
-        });
-        await updateVisualChangeset({
-          visualChangeset: newVisualChangeset,
-          experiment,
-          organization: org,
-          updates: {
-            visualChanges: visualChangeset.visualChanges,
-          },
+          visualChanges: visualChangeset.visualChanges,
           user: res.locals.eventAudit,
         });
       }

--- a/packages/back-end/src/models/ExperimentModel.ts
+++ b/packages/back-end/src/models/ExperimentModel.ts
@@ -711,7 +711,7 @@ export async function deleteExperimentByIdForOrganization(
       organization: organization.id,
     });
 
-    VisualChangesetModel.deleteMany({ experiment: experiment.id });
+    await VisualChangesetModel.deleteMany({ experiment: experiment.id });
 
     await onExperimentDelete(organization, user, experiment);
   } catch (e) {

--- a/packages/back-end/src/models/VisualChangesetModel.ts
+++ b/packages/back-end/src/models/VisualChangesetModel.ts
@@ -255,12 +255,14 @@ export const createVisualChangeset = async ({
   organization,
   urlPatterns,
   editorUrl,
+  visualChanges,
   user,
 }: {
   experiment: ExperimentInterface;
   organization: OrganizationInterface;
   urlPatterns: VisualChangesetURLPattern[];
   editorUrl: VisualChangesetInterface["editorUrl"];
+  visualChanges?: VisualChange[];
   user: EventAuditUser;
 }): Promise<VisualChangesetInterface> => {
   const visualChangeset = toInterface(
@@ -270,7 +272,8 @@ export const createVisualChangeset = async ({
       organization: organization.id,
       urlPatterns,
       editorUrl,
-      visualChanges: experiment.variations.map(genNewVisualChange),
+      visualChanges:
+        visualChanges || experiment.variations.map(genNewVisualChange),
     })
   );
 

--- a/packages/front-end/components/Experiment/NewExperimentForm.tsx
+++ b/packages/front-end/components/Experiment/NewExperimentForm.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactElement, useEffect, useState } from "react";
+import React, { FC, useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import {
   ExperimentInterfaceStringDates,
@@ -19,7 +19,6 @@ import { getEqualWeights } from "@/services/utils";
 import { generateVariationId, useAttributeSchema } from "@/services/features";
 import useOrgSettings from "@/hooks/useOrgSettings";
 import { useDemoDataSourceProject } from "@/hooks/useDemoDataSourceProject";
-import Toggle from "@/components/Forms/Toggle";
 import MarkdownInput from "../Markdown/MarkdownInput";
 import TagsInput from "../Tags/TagsInput";
 import Page from "../Modal/Page";
@@ -117,9 +116,6 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
   const [step, setStep] = useState(initialStep || 0);
   const [allowDuplicateTrackingKey, setAllowDuplicateTrackingKey] = useState(
     false
-  );
-  const [importVisualChangesets, setImportVisualChangesets] = useState(
-    source === "duplicate"
   );
 
   const {
@@ -244,13 +240,8 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
     if (allowDuplicateTrackingKey) {
       params.allowDuplicateTrackingKey = true;
     }
-    if (source === "duplicate") {
-      if (initialValue?.id) {
-        params.originalId = initialValue.id;
-        if (importVisualChangesets) {
-          params.importVisualChangesets = true;
-        }
-      }
+    if (source === "duplicate" && initialValue?.id) {
+      params.originalId = initialValue.id;
     }
 
     const res = await apiCall<
@@ -290,19 +281,8 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
   const { currentProjectIsDemo } = useDemoDataSourceProject();
 
   let header = isNewExperiment ? "New Experiment" : "New Experiment Analysis";
-  let footerElements: ReactElement | null = null;
   if (source === "duplicate") {
     header = "Duplicate Experiment";
-    footerElements = (
-      <div className="form-group position-absolute ml-4" style={{ left: 0 }}>
-        <Toggle
-          id="importVisualChangesets"
-          value={importVisualChangesets}
-          setValue={(v) => setImportVisualChangesets(v)}
-        />
-        <label htmlFor="importVisualChangesets">Import visual changesets</label>
-      </div>
-    );
   }
 
   return (
@@ -317,7 +297,6 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
       step={step}
       setStep={setStep}
       inline={inline}
-      secondaryCTA={footerElements ?? undefined}
     >
       <Page display="Basic Info">
         {msg && <div className="alert alert-info">{msg}</div>}

--- a/packages/front-end/components/Modal.tsx
+++ b/packages/front-end/components/Modal.tsx
@@ -205,9 +205,7 @@ const Modal: FC<ModalProps> = ({
             </button>
           )}
         </div>
-      ) : (
-        ""
-      )}
+      ) : null}
     </div>
   );
 


### PR DESCRIPTION
### Features and Changes

Optionally import visual changesets when cloning an experiment.

<img width="946" alt="image" src="https://github.com/growthbook/growthbook/assets/7927873/0e46f7f3-def4-4f58-a505-610a20f78755">

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

<!--
  Please describe how to test these changes.
 -->

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
