### PR TITLE
Improved Experiment Frequency Graphs

### DIFF
--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -156,11 +156,20 @@ export async function getExperimentsFrequencyMonth(
     stopped: JSON.parse(JSON.stringify(allData)),
   };
 
+  // create stubs for each month by all the projects:
   const dataByProject: Record<string, [{ date: string; numExp: number }]> = {};
   allProjects.forEach((p) => {
     dataByProject[p.id] = JSON.parse(JSON.stringify(allData));
   });
   dataByProject["all"] = JSON.parse(JSON.stringify(allData));
+
+  // create stubs for each month by all the result:
+  const dataByResult = {
+    won: JSON.parse(JSON.stringify(allData)),
+    lost: JSON.parse(JSON.stringify(allData)),
+    inconclusive: JSON.parse(JSON.stringify(allData)),
+    dnf: JSON.parse(JSON.stringify(allData)),
+  };
 
   // now get the right number of experiments:
   experiments.forEach((e) => {
@@ -174,7 +183,6 @@ export async function getExperimentsFrequencyMonth(
       });
     }
     const monthYear = format(getValidDate(dateStarted), "MMM yyy");
-
     allData.forEach((md, i) => {
       const name = format(getValidDate(md.date), "MMM yyy");
       if (name === monthYear) {
@@ -187,6 +195,10 @@ export async function getExperimentsFrequencyMonth(
         } else {
           dataByProject["all"][i].numExp++;
         }
+
+        if (e.results) {
+          dataByResult[e.results][i].numExp++;
+        }
       }
     });
   });
@@ -195,6 +207,7 @@ export async function getExperimentsFrequencyMonth(
     status: 200,
     byStatus: { all: allData, ...dataByStatus },
     byProject: { ...dataByProject },
+    byResults: { ...dataByResult },
   });
 }
 

--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -183,6 +183,7 @@ export async function getExperimentsFrequencyMonth(
       });
     }
     const monthYear = format(getValidDate(dateStarted), "MMM yyy");
+
     allData.forEach((md, i) => {
       const name = format(getValidDate(md.date), "MMM yyy");
       if (name === monthYear) {
@@ -190,6 +191,7 @@ export async function getExperimentsFrequencyMonth(
         // I can do this because the indexes will represent the same month
         dataByStatus[e.status][i].numExp++;
 
+        // experiments without a project, are included in the 'all projects'
         if (e.project) {
           dataByProject[e.project][i].numExp++;
         } else {
@@ -205,7 +207,8 @@ export async function getExperimentsFrequencyMonth(
 
   res.status(200).json({
     status: 200,
-    byStatus: { all: allData, ...dataByStatus },
+    all: allData,
+    byStatus: { ...dataByStatus },
     byProject: { ...dataByProject },
     byResults: { ...dataByResult },
   });

--- a/packages/front-end/components/Experiment/ExperimentGraph.module.scss
+++ b/packages/front-end/components/Experiment/ExperimentGraph.module.scss
@@ -2,11 +2,31 @@
   background-color: #050549;
   border-radius: 2px;
   position: absolute;
-  width: 35px;
+  width: 45px;
   box-shadow: -1px 2px 4px rgba(0, 0, 0, 0.15);
   color: white;
   padding: 3px 4px;
   font-size: 12px;
+}
+.tooltiplg {
+  width: 200px;
+  background-color: #050549;
+  border-radius: 2px;
+  position: absolute;
+  box-shadow: -1px 2px 4px rgba(0, 0, 0, 0.15);
+  color: white;
+  padding: 3px 4px;
+  font-size: 12px;
+}
+.tooltipName {
+  font-weight: bold;
+  font-size: 14px;
+  display: inline;
+  margin-right: 10px;
+}
+.tooltipValue {
+  font-size: 14px;
+  display: inline;
 }
 .barHov:hover {
   fill: #31c0f0;

--- a/packages/front-end/components/Experiment/ExperimentGraph.module.scss
+++ b/packages/front-end/components/Experiment/ExperimentGraph.module.scss
@@ -2,7 +2,8 @@
   background-color: #050549;
   border-radius: 2px;
   position: absolute;
-  width: 45px;
+  width: 100px;
+  text-align: center;
   box-shadow: -1px 2px 4px rgba(0, 0, 0, 0.15);
   color: white;
   padding: 3px 4px;
@@ -11,23 +12,50 @@
 .tooltiplg {
   width: 200px;
   background-color: #050549;
-  border-radius: 2px;
+  border-radius: 6px;
   position: absolute;
   box-shadow: -1px 2px 4px rgba(0, 0, 0, 0.15);
   color: white;
-  padding: 3px 4px;
+  padding: 6px 6px;
   font-size: 12px;
+  opacity: 0.7;
+}
+.tooltipHeader {
+  font-weight: bold;
+  font-size: 14px;
+  margin-bottom: 5px;
 }
 .tooltipName {
   font-weight: bold;
-  font-size: 14px;
+  font-size: 12px;
   display: inline;
   margin-right: 10px;
 }
 .tooltipValue {
-  font-size: 14px;
+  font-size: 12px;
   display: inline;
 }
 .barHov:hover {
   fill: #31c0f0;
+}
+.barHovStacked:hover {
+  stroke: #646464;
+  stroke-width: 1px;
+  stroke-dasharray: 2, 2;
+  stroke-linejoin: round;
+}
+.legendRow {
+  display: flex;
+  align-items: center;
+  margin-bottom: 5px;
+}
+.legendColor {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  margin-right: 5px;
+}
+.legendName {
+  font-size: 12px;
+  margin-right: 10px;
 }

--- a/packages/front-end/components/Experiment/ExperimentGraph.tsx
+++ b/packages/front-end/components/Experiment/ExperimentGraph.tsx
@@ -11,7 +11,7 @@ import { localPoint } from "@visx/event";
 import { getValidDate } from "shared/dates";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import useApi from "@/hooks/useApi";
-import Field from "@/components/Forms/Field";
+import SelectField from "@/components/Forms/SelectField";
 import LoadingOverlay from "../LoadingOverlay";
 import styles from "./ExperimentGraph.module.scss";
 
@@ -51,22 +51,22 @@ export default function ExperimentGraph({
   const showSelectOptions = [
     {
       value: "all",
-      display: "All experiments",
+      label: "All experiments",
     },
     {
       value: "status",
-      display: "By status",
+      label: "By status",
     },
     {
       value: "results",
-      display: "By results",
+      label: "By results",
     },
   ];
   // have a dropdown for projects doesn't make sense when viewing just one project
   if (!project) {
     showSelectOptions.push({
       value: "project",
-      display: "By projects",
+      label: "By projects",
     });
   }
 
@@ -159,20 +159,20 @@ export default function ExperimentGraph({
             {projectMap.has(project) ? "for " + projectMap.get(project) : ""}
           </h4>
         </div>
-        <div className="col-auto small">
-          <Field
-            containerClassName="d-inline-block ml-2 mb-0 small"
+        <div className="col-auto">
+          <SelectField
+            containerClassName="d-inline-block ml-2 mb-0"
             options={showSelectOptions}
             value={showBy}
-            onChange={(e) => {
+            onChange={(value) => {
               if (
-                e.target.value === "user" ||
-                e.target.value === "all" ||
-                e.target.value === "project" ||
-                e.target.value === "results" ||
-                e.target.value === "status"
+                value === "user" ||
+                value === "all" ||
+                value === "project" ||
+                value === "results" ||
+                value === "status"
               ) {
-                setShowBy(e.target.value);
+                setShowBy(value);
               }
             }}
           />

--- a/packages/front-end/components/Experiment/ExperimentGraph.tsx
+++ b/packages/front-end/components/Experiment/ExperimentGraph.tsx
@@ -152,7 +152,7 @@ export default function ExperimentGraph({
 
   return (
     <>
-      <div className="row mb-3 align-content-end">
+      <div className="row mb-1 align-content-end">
         <div className="col">
           <h4 className="mb-0">
             {title}{" "}

--- a/packages/front-end/components/HomePage/Dashboard.tsx
+++ b/packages/front-end/components/HomePage/Dashboard.tsx
@@ -1,7 +1,8 @@
-import React from "react";
+import React, { useState } from "react";
 import Link from "next/link";
 import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
 import { useUser } from "@/services/UserContext";
+import Field from "@/components/Forms/Field";
 import ActivityList from "../ActivityList";
 import ExperimentList from "../Experiment/ExperimentList";
 import ExperimentGraph from "../Experiment/ExperimentGraph";
@@ -15,6 +16,9 @@ export interface Props {
 
 export default function Dashboard({ experiments }: Props) {
   const { name } = useUser();
+  const [showBy, setShowBy] = useState<"status" | "project" | "all" | "user">(
+    "all"
+  );
 
   const nameMap = new Map<string, string>();
   experiments.forEach((e) => {
@@ -33,12 +37,48 @@ export default function Dashboard({ experiments }: Props) {
         <div className="row">
           <div className="col-lg-12 col-md-12 col-xl-8 mb-3">
             <div className="list-group activity-box fixed-height overflow-auto">
-              <h4 className="mb-3">Experiments by month</h4>
+              <div className="row mb-3 align-content-end">
+                <div className="col">
+                  <h4 className="mb-0">Experiments by month</h4>
+                </div>
+                <div className="col-auto small">
+                  Show:
+                  <Field
+                    containerClassName="d-inline-block ml-2 mb-0 small"
+                    options={[
+                      {
+                        value: "all",
+                        display: "All experiments",
+                      },
+                      {
+                        value: "status",
+                        display: "By status",
+                      },
+                      {
+                        value: "project",
+                        display: "By projects",
+                      },
+                    ]}
+                    value={showBy}
+                    onChange={(e) => {
+                      if (
+                        e.target.value === "user" ||
+                        e.target.value === "all" ||
+                        e.target.value === "project" ||
+                        e.target.value === "status"
+                      ) {
+                        setShowBy(e.target.value);
+                      }
+                    }}
+                  />
+                </div>
+              </div>
               <ExperimentGraph
                 resolution={"month"}
                 num={12}
                 status={"all"}
                 height={220}
+                showBy={showBy}
               />
             </div>
           </div>

--- a/packages/front-end/components/HomePage/Dashboard.tsx
+++ b/packages/front-end/components/HomePage/Dashboard.tsx
@@ -32,7 +32,7 @@ export default function Dashboard({ experiments }: Props) {
         </div>
         <div className="row">
           <div className="col-lg-12 col-md-12 col-xl-8 mb-3">
-            <div className="list-group activity-box fixed-height overflow-auto">
+            <div className="list-group activity-box fixed-height">
               <ExperimentGraph
                 resolution={"month"}
                 num={12}

--- a/packages/front-end/components/HomePage/Dashboard.tsx
+++ b/packages/front-end/components/HomePage/Dashboard.tsx
@@ -1,8 +1,7 @@
-import React, { useState } from "react";
+import React from "react";
 import Link from "next/link";
 import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
 import { useUser } from "@/services/UserContext";
-import Field from "@/components/Forms/Field";
 import ActivityList from "../ActivityList";
 import ExperimentList from "../Experiment/ExperimentList";
 import ExperimentGraph from "../Experiment/ExperimentGraph";
@@ -16,9 +15,6 @@ export interface Props {
 
 export default function Dashboard({ experiments }: Props) {
   const { name } = useUser();
-  const [showBy, setShowBy] = useState<"status" | "project" | "all" | "user">(
-    "all"
-  );
 
   const nameMap = new Map<string, string>();
   experiments.forEach((e) => {
@@ -37,48 +33,11 @@ export default function Dashboard({ experiments }: Props) {
         <div className="row">
           <div className="col-lg-12 col-md-12 col-xl-8 mb-3">
             <div className="list-group activity-box fixed-height overflow-auto">
-              <div className="row mb-3 align-content-end">
-                <div className="col">
-                  <h4 className="mb-0">Experiments by month</h4>
-                </div>
-                <div className="col-auto small">
-                  Show:
-                  <Field
-                    containerClassName="d-inline-block ml-2 mb-0 small"
-                    options={[
-                      {
-                        value: "all",
-                        display: "All experiments",
-                      },
-                      {
-                        value: "status",
-                        display: "By status",
-                      },
-                      {
-                        value: "project",
-                        display: "By projects",
-                      },
-                    ]}
-                    value={showBy}
-                    onChange={(e) => {
-                      if (
-                        e.target.value === "user" ||
-                        e.target.value === "all" ||
-                        e.target.value === "project" ||
-                        e.target.value === "status"
-                      ) {
-                        setShowBy(e.target.value);
-                      }
-                    }}
-                  />
-                </div>
-              </div>
               <ExperimentGraph
                 resolution={"month"}
                 num={12}
-                status={"all"}
                 height={220}
-                showBy={showBy}
+                initialShowBy={"all"}
               />
             </div>
           </div>

--- a/packages/front-end/styles/theme.scss
+++ b/packages/front-end/styles/theme.scss
@@ -66,6 +66,25 @@
   --disabled-background: #eaeaea;
 
   --bg-muted-yellow: #f5f2dc;
+
+  --graph-color-1: #73d1f0;
+  --graph-color-2: #7388f0;
+  --graph-color-3: #ab73f0;
+  --graph-color-4: #f073ee;
+  --graph-color-5: #f08273;
+  --graph-color-6: #dfbb6d;
+  --graph-color-7: #a0e572;
+  --graph-color-8: #72e1e5;
+  --graph-color-9: #1637e6;
+  --graph-color-10: #6216e6;
+  --graph-color-11: #b916e6;
+  --graph-color-12: #e616bc;
+  --graph-color-13: #e6161d;
+  --graph-color-14: #e67416;
+  --graph-color-15: #e6ca16;
+  --graph-color-16: #88e616;
+  --graph-color-17: #16e6b5;
+  --graph-color-18: #14b8ff;
 }
 
 @mixin dark-theme {
@@ -137,6 +156,25 @@
   --disabled-background: #3f3f3f;
 
   --bg-muted-yellow: #4c4a44;
+
+  --graph-color-1: #73d1f0;
+  --graph-color-2: #7388f0;
+  --graph-color-3: #ab73f0;
+  --graph-color-4: #f073ee;
+  --graph-color-5: #f08273;
+  --graph-color-6: #dfbb6d;
+  --graph-color-7: #a0e572;
+  --graph-color-8: #72e1e5;
+  --graph-color-9: #1637e6;
+  --graph-color-10: #6216e6;
+  --graph-color-11: #b916e6;
+  --graph-color-12: #e616bc;
+  --graph-color-13: #e6161d;
+  --graph-color-14: #e67416;
+  --graph-color-15: #e6ca16;
+  --graph-color-16: #88e616;
+  --graph-color-17: #16e6b5;
+  --graph-color-18: #14b8ff;
 }
 
 .theme--light {

--- a/packages/front-end/styles/theme.scss
+++ b/packages/front-end/styles/theme.scss
@@ -67,6 +67,15 @@
 
   --bg-muted-yellow: #f5f2dc;
 
+  --results-won: #{colors.$success};
+  --results-lost: #{colors.$danger};
+  --results-dnf: #{colors.$warning};
+  --results-inconclusive: #{colors.$secondary};
+
+  --status-running: #{colors.$info};
+  --status-draft: #{colors.$warning};
+  --status-stopped: #{colors.$secondary};
+
   --graph-color-1: #73d1f0;
   --graph-color-2: #7388f0;
   --graph-color-3: #ab73f0;
@@ -156,6 +165,15 @@
   --disabled-background: #3f3f3f;
 
   --bg-muted-yellow: #4c4a44;
+
+  --results-won: #{colors.$success};
+  --results-lost: #{colors.$danger};
+  --results-dnf: #{colors.$warning};
+  --results-inconclusive: #{colors.$secondary};
+
+  --status-running: #{colors.$info};
+  --status-draft: #{colors.$warning};
+  --status-stopped: #{colors.$secondary};
 
   --graph-color-1: #73d1f0;
   --graph-color-2: #7388f0;


### PR DESCRIPTION
On our dashboard, we have a frequency histogram of the number of experiments. This change adds the ability to split these results by status, project, and results. 

![Screenshot 2023-10-11 at 1 05 31 AM](https://github.com/growthbook/growthbook/assets/46107/038d2b5b-6ad2-4de3-a804-8f6aa68ba252)

![Screenshot 2023-10-11 at 1 05 06 AM](https://github.com/growthbook/growthbook/assets/46107/3b5522e2-bb47-41e3-b450-76ee2d9fcf25)

![Screenshot 2023-10-11 at 1 05 18 AM](https://github.com/growthbook/growthbook/assets/46107/9edde81b-e2bc-4d18-95e8-f2d10765f1ef)

