### PR TITLE
Verify that we are on the real cloud

### DIFF
--- a/.docker-compose-okteto.yml
+++ b/.docker-compose-okteto.yml
@@ -18,6 +18,7 @@ services:
       - API_HOST=https://growthbook-3100-${OKTETO_NAMESPACE}.growthbook.okteto.dev
       - JWT_SECRET=${JWT_SECRET}
       - IS_CLOUD=true
+      - CLOUD_LICENSE_KEY=${CLOUD_LICENSE_KEY}
       - SSO_CONFIG=${SSO_CONFIG}
       - DISABLE_TELEMETRY=debug
     volumes:

--- a/packages/back-end/src/util/secrets.ts
+++ b/packages/back-end/src/util/secrets.ts
@@ -1,30 +1,18 @@
 import fs from "fs";
 import dotenv from "dotenv";
+import trimEnd from "lodash/trimEnd";
+
+export const ENVIRONMENT = process.env.NODE_ENV;
+const prod = ENVIRONMENT === "production";
 
 if (fs.existsSync(".env.local")) {
   dotenv.config({ path: ".env.local" });
 }
 
-import trimEnd from "lodash/trimEnd";
-import { verifyCloud } from "enterprise";
-import { logger } from "./logger";
-
-export const ENVIRONMENT = process.env.NODE_ENV;
-const prod = ENVIRONMENT === "production";
-
 export const IS_CLOUD = !!process.env.IS_CLOUD;
 
-async function checkCloud() {
-  if (IS_CLOUD) {
-    try {
-      await verifyCloud();
-    } catch {
-      logger.error("Failed to verify that we are on the real cloud.");
-      process.kill(process.pid, "SIGTERM");
-    }
-  }
-}
-checkCloud();
+import { verifyCloud } from "enterprise";
+verifyCloud();
 
 export const UPLOAD_METHOD = (() => {
   if (IS_CLOUD) return "s3";

--- a/packages/back-end/src/util/secrets.ts
+++ b/packages/back-end/src/util/secrets.ts
@@ -1,15 +1,30 @@
 import fs from "fs";
 import dotenv from "dotenv";
-import trimEnd from "lodash/trimEnd";
-
-export const ENVIRONMENT = process.env.NODE_ENV;
-const prod = ENVIRONMENT === "production";
 
 if (fs.existsSync(".env.local")) {
   dotenv.config({ path: ".env.local" });
 }
 
+import trimEnd from "lodash/trimEnd";
+import { verifyCloud } from "enterprise";
+import { logger } from "./logger";
+
+export const ENVIRONMENT = process.env.NODE_ENV;
+const prod = ENVIRONMENT === "production";
+
 export const IS_CLOUD = !!process.env.IS_CLOUD;
+
+async function checkCloud() {
+  if (IS_CLOUD) {
+    try {
+      await verifyCloud();
+    } catch {
+      logger.error("Failed to verify that we are on the real cloud.");
+      process.kill(process.pid, "SIGTERM");
+    }
+  }
+}
+checkCloud();
 
 export const UPLOAD_METHOD = (() => {
   if (IS_CLOUD) return "s3";

--- a/packages/enterprise/src/license.ts
+++ b/packages/enterprise/src/license.ts
@@ -267,9 +267,8 @@ export async function verifyCloud() {
     // At startup, it can take longer to fetch the public license key
     const licenseData = await getVerifiedLicenseData(CLOUD_LICENSE_KEY, 10000);
     if (licenseData.ref !== "cloud") {
-      throw new Error(
-        "Not running on the actual cloud server: " + licenseData.ref
-      );
+      logger.error("Failed to verify that we are on the real cloud.");
+      process.kill(process.pid, "SIGTERM");
     }
   }
 }


### PR DESCRIPTION
### Features and Changes

Right now people can set `IS_CLOUD=true` to enable a bunch of enterprise features.  This PR adds a check to make sure that there is a CLOUD_LICENSE_KEY set that is verified.

- Closes **(add link to issue here)**

### Dependencies
Don't deploy this until the CLOUD_LICENSE_KEY is actually set and is a valid one.

### Testing
set IS_CLOUD=true in back-end/.env.local
restart the backend app.
See it die with the message: `Failed to verify that we are on the real cloud.`

set CLOUD_LICENSE_KEY=a real prod license key with ref="cloud"
restart the backend app.
See it serve pages


