### PR TITLE
"Chance to Win" not "Chance to Beat Control"

### DIFF
--- a/docs/docs/statistics/overview.mdx
+++ b/docs/docs/statistics/overview.mdx
@@ -44,9 +44,9 @@ use a Beta-Binomial Prior. For count, duration, and revenue metrics, we use a Ga
 ### Inferential Statistics
 
 GrowthBook uses fast estimation techniques to quickly generate inferential statistics at scale for every metric in an experiment -
-Chance to Beat Control, Relative Uplift, and Risk (or expected loss).
+Chance to Win, Relative Uplift, and Risk (or expected loss).
 
-**Chance to Beat Control** is straight forward. It is simply the probability that a variation is better.
+**Chance to Win** is straight forward. It is simply the probability that a variation is better.
 You typically want to wait until this reaches 95% (or 5% if it's worse).
 
 **Relative Uplift** is similar to a frequentist Confidence Interval. Instead of showing a fixed 95% interval, we show the full


### PR DESCRIPTION

### Features and Changes

Change from "Chance to Beat Control" to "Chance to Win" to match current UI on Results tab


### Screenshots
<img width="806" alt="Screenshot 2023-10-15 at 10 46 04 AM" src="https://github.com/growthbook/growthbook/assets/1626189/c5dece20-5b9d-4dba-b012-e640810a98a3">

