### PR TITLE
Allow users to delete their own personal access tokens.

### DIFF
--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -1344,9 +1344,9 @@ export async function deleteApiKey(
 
   if (keyObj.secret) {
     if (!keyObj.userId) {
-      // If there is no userId, this is an API Key
+      // If there is no userId, this is an API Key, so we check permissions.
       req.checkPermissions("manageApiKeys");
-      // Otherwise, this is a Personal Access Token - users can delete only their own Personal Access Tokens
+      // Otherwise, this is a Personal Access Token (PAT) - users can delete only their own PATs regardless of permission level.
     } else if (keyObj.userId !== userId) {
       throw new Error("You do not have permission to delete this.");
     }

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -1326,7 +1326,7 @@ export async function deleteApiKey(
   req: AuthRequest<{ key?: string; id?: string }>,
   res: Response
 ) {
-  const { org } = getOrgFromReq(req);
+  const { org, userId } = getOrgFromReq(req);
   // Old API keys did not have an id, so we need to delete by the key value itself
   const { key, id } = req.body;
   if (!key && !id) {
@@ -1343,7 +1343,13 @@ export async function deleteApiKey(
   }
 
   if (keyObj.secret) {
-    req.checkPermissions("manageApiKeys");
+    if (!keyObj.userId) {
+      // If there is no userId, this is an API Key
+      req.checkPermissions("manageApiKeys");
+      // Otherwise, this is a Personal Access Token - users can delete only their own Personal Access Tokens
+    } else if (keyObj.userId !== userId) {
+      throw new Error("You do not have permission to delete this.");
+    }
   } else {
     req.checkPermissions("manageEnvironments", "", [keyObj.environment || ""]);
   }


### PR DESCRIPTION
### Features and Changes

A user discovered a bug in which we allow all users (regardless of their role) to create `Personal Access Tokens` - however, when trying to delete a Personal Access Token, we make a check to see if they have permission to `manageApiKeys`, resulting in an error being thrown.

This PR updates the logic so that if a user is attempting to delete a `Personal Access Token` that is tied to their user, we allow them to do so. We only check that they have `manageApiKeys` permissions if the user is attempting to delete an `apiKey`.

### Testing

- [x] Create a new personal access token, and then delete it successfully via the GrowthBook UI.
- [x] Confirm no new regressions were introduced with regular API Key deletion.
