### PR TITLE
Remove required on number format field in fact column

### DIFF
--- a/packages/front-end/components/FactTables/ColumnModal.tsx
+++ b/packages/front-end/components/FactTables/ColumnModal.tsx
@@ -135,7 +135,6 @@ export default function ColumnModal({ existing, factTable, close }: Props) {
               value: "time:seconds",
             },
           ]}
-          required
         />
       )}
 


### PR DESCRIPTION
Error saving any number column with number format as `Plain Number` since the validation fails on the value being `""`. 

Without changing the types and subsequent logic, or our SelectField logic, easiest thing to do is just make the field not required. Since default is `""` this seems reasonable but IDK if there are downstream consequences I haven't tested.