### PR TITLE
Set Snowflake Warehouse setting to optional

### DIFF
--- a/packages/back-end/types/integrations/snowflake.d.ts
+++ b/packages/back-end/types/integrations/snowflake.d.ts
@@ -5,5 +5,5 @@ export interface SnowflakeConnectionParams {
   database: string;
   schema: string;
   role?: string;
-  warehouse: string;
+  warehouse?: string;
 }

--- a/packages/front-end/components/Settings/SnowflakeForm.tsx
+++ b/packages/front-end/components/Settings/SnowflakeForm.tsx
@@ -68,18 +68,6 @@ const SnowflakeForm: FC<{
         />
       </div>
       <div className="form-group col-md-12">
-        <label>Warehouse (Optional) </label>
-        <Tooltip body="If no Warehouse is specified, queries will be executed in the default Warehouse for your User, set in Snowflake." />
-        <input
-          type="text"
-          className="form-control"
-          name="warehouse"
-          value={params.warehouse || ""}
-          onChange={onParamChange}
-          placeholder=""
-        />
-      </div>
-      <div className="form-group col-md-12">
         <label>Role</label>
         <input
           type="text"
@@ -87,6 +75,20 @@ const SnowflakeForm: FC<{
           name="role"
           value={params.role || ""}
           onChange={onParamChange}
+        />
+      </div>
+      <div className="form-group col-md-12">
+        <label>
+          Warehouse (Optional){" "}
+          <Tooltip body="If no Warehouse is specified, queries will be executed in the default Warehouse for your User, set in Snowflake." />
+        </label>
+        <input
+          type="text"
+          className="form-control"
+          name="warehouse"
+          value={params.warehouse || ""}
+          onChange={onParamChange}
+          placeholder=""
         />
       </div>
     </div>

--- a/packages/front-end/components/Settings/SnowflakeForm.tsx
+++ b/packages/front-end/components/Settings/SnowflakeForm.tsx
@@ -1,5 +1,6 @@
 import { FC, ChangeEventHandler } from "react";
 import { SnowflakeConnectionParams } from "back-end/types/integrations/snowflake";
+import Tooltip from "../Tooltip/Tooltip";
 
 const SnowflakeForm: FC<{
   params: Partial<SnowflakeConnectionParams>;
@@ -67,14 +68,15 @@ const SnowflakeForm: FC<{
         />
       </div>
       <div className="form-group col-md-12">
-        <label>Warehouse</label>
+        <label>Warehouse (Optional) </label>
+        <Tooltip body="If no Warehouse is specified, queries will be executed in the default Warehouse for your User, set in Snowflake." />
         <input
           type="text"
           className="form-control"
           name="warehouse"
-          required
           value={params.warehouse || ""}
           onChange={onParamChange}
+          placeholder=""
         />
       </div>
       <div className="form-group col-md-12">


### PR DESCRIPTION
### Features and Changes

The `snowflake-promise` connector doesn't require a `warehouse` and Snowflake is happy to default to the default warehouse for a user you specify if there isn't one in the connected client.

Therefore, specifying warehouse is unnecessary.

This makes it optional.

### Testing

I can save this form as is, which runs a test query:

<img width="810" alt="image" src="https://github.com/growthbook/growthbook/assets/5298599/984c611e-adb4-4bb3-a839-d4b509135375">

I also can run the experiment assignment test query which actually requires a warehouse:
<img width="952" alt="Screenshot 2023-10-18 at 11 07 45 AM" src="https://github.com/growthbook/growthbook/assets/5298599/2405c327-0849-40a2-9d30-1db70cb4975c">


Evidence it set the warehouse:
<img width="1408" alt="Screenshot 2023-10-18 at 11 08 33 AM" src="https://github.com/growthbook/growthbook/assets/5298599/b68229bd-7a81-4e29-a2cf-7c3f21097ae9">
