### PR TITLE
Update putDataSource to handle removing description.

### DIFF
--- a/packages/back-end/src/controllers/datasources.ts
+++ b/packages/back-end/src/controllers/datasources.ts
@@ -428,11 +428,11 @@ export async function putDataSource(
   req: AuthRequest<
     {
       name: string;
-      description: string;
+      description?: string;
       type: DataSourceType;
-      params: DataSourceParams;
+      params?: DataSourceParams;
       settings: DataSourceSettings;
-      projects: string[];
+      projects?: string[];
       metricsToCreate?: { name: string; type: MetricType; sql: string }[];
     },
     { id: string }
@@ -512,16 +512,27 @@ export async function putDataSource(
   }
 
   try {
-    const updates: Partial<DataSourceInterface> = {
-      name,
-      description,
-      settings,
-      projects,
-      dateUpdated: new Date(),
-    };
+    const updates: Partial<DataSourceInterface> = { dateUpdated: new Date() };
+
+    if (name) {
+      updates.name = name;
+    }
+
+    if ("description" in req.body) {
+      updates.description = description;
+    }
+
+    if (settings) {
+      updates.settings = settings;
+    }
+
+    if (projects) {
+      updates.projects = projects;
+    }
 
     if (
       type === "google_analytics" &&
+      params &&
       (params as GoogleAnalyticsParams).refreshToken
     ) {
       const oauth2Client = getOauth2Client();
@@ -536,10 +547,14 @@ export async function putDataSource(
       req.checkPermissions(permissionLevel, updates.projects);
     }
 
-    const integration = getSourceIntegrationObject(datasource);
-    mergeParams(integration, params);
-    await integration.testConnection();
-    updates.params = encryptParams(integration.params);
+    // If the connection params changed, re-validate the connection
+    // If the user is just updating the display name, no need to do this
+    if (params) {
+      const integration = getSourceIntegrationObject(datasource);
+      mergeParams(integration, params);
+      await integration.testConnection();
+      updates.params = encryptParams(integration.params);
+    }
 
     await updateDataSource(datasource, org.id, updates);
 


### PR DESCRIPTION
### Features and Changes

This PR updates the putDataSource method. Initially, this update was just to resolve a bug where the description of a data source object wasn't able to be removed. With the way the code was written, we were only updating the datasource description if a description was passed in - and when removing the description, an empty string is passed in, so the `if (datasource)` check was returning false, and thus skipping the code that actually updates the description.

In looking at the endpoint further, we're actually always passing in a full datasource object (save the dateCreated/dateUpdated fields), so all of the checks in the method that were checking for various properties were unnecessary.

This PR removes the unneeded checks and simplifies the method.

- Closes #1517

### Testing
- [x] Confirm that if you remove a description from a data source via the `DataSourceForm`, the description is actually removed.
- [x] Confirm no new regressions are introduced with this refactor
- [x] Confirm the ability to create a data source still works via this form
- [x] Confirm the ability to edit the name of a data source still works via this form
- [x] Confirm the ability to edit multiple fields on this data source object still works via this form

