### PR TITLE
Feature/alt mongo credentials

### DIFF
--- a/docs/docs/self-host/env.mdx
+++ b/docs/docs/self-host/env.mdx
@@ -66,9 +66,14 @@ growthbook:
 ### Production Settings
 
 - **NODE_ENV** - Set to "production" to turn on additional optimizations and API request logging
-- **MONGODB_URI** - The MongoDB connection string
 - **JWT_SECRET** - Auth signing key (use a long random string)
 - **ENCRYPTION_KEY** - Data source credential encryption key (use a long random string)
+- **MONGODB_URI** - The MongoDB connection string
+- **MONGODB_URI** - If `MONGODB_URI` is not set it can be composed at runtime from the following variables:
+  - **MONGODB_HOST** - Host name of MongoDB like `some.host.com:27017`
+  - **MONGODB_USERNAME** - Username for MongoDB `growthbook_username`
+  - **MONGODB_PASSWORD** - Password for MongoDB `growthbook_password`
+  - **MONGO_DB_EXTRA_ARGS** - Optional set of extra arguments for MongoDB connection string like `?authSource=admin&retryWrites=true&w=majority`
 
 If you change the `ENCRYPTION_KEY`, you will need to migrate any existing data sources using the following script:
 

--- a/docs/docs/self-host/env.mdx
+++ b/docs/docs/self-host/env.mdx
@@ -71,6 +71,7 @@ growthbook:
 - **MONGODB_URI** - The MongoDB connection string
 - **MONGODB_URI** - If `MONGODB_URI` is not set it can be composed at runtime from the following variables:
   - **MONGODB_HOST** - Host name of MongoDB like `some.host.com:27017`
+  - **MONGODB_DBNAME** - Host name of MongoDB like `growthbook`
   - **MONGODB_USERNAME** - Username for MongoDB `growthbook_username`
   - **MONGODB_PASSWORD** - Password for MongoDB `growthbook_password`
   - **MONGO_DB_EXTRA_ARGS** - Optional set of extra arguments for MongoDB connection string like `?authSource=admin&retryWrites=true&w=majority`

--- a/packages/back-end/src/util/secrets.ts
+++ b/packages/back-end/src/util/secrets.ts
@@ -29,9 +29,10 @@ if (!MONGODB_URI) {
   if (
     process.env.MONGODB_USERNAME &&
     process.env.MONGODB_PASSWORD &&
-    process.env.MONGODB_HOSTNAME
+    process.env.MONGODB_HOSTNAME &&
+    process.env.MONGODB_DBNAME
   ) {
-    MONGODB_URI = `mongodb://${process.env.MONGODB_USERNAME}:${process.env.MONGODB_PASSWORD}@${process.env.MONGODB_HOSTNAME}/growthbook`;
+    MONGODB_URI = `mongodb://${process.env.MONGODB_USERNAME}:${process.env.MONGODB_PASSWORD}@${process.env.MONGODB_HOSTNAME}/${process.env.MONGODB_DBNAME}`;
 
     // Add extra args if they exist
     if (process.env.MONGODB_EXTRA_ARGS) {
@@ -40,20 +41,18 @@ if (!MONGODB_URI) {
   }
 }
 
+// For backwards compatibility, if no dbname is explicitly set, use "test" and add the authSource db.
+// This matches the default behavior of the MongoDB driver 3.X, which changed when we updated to 4.X
+if (!MONGODB_URI) {
+  MONGODB_URI = process.env.MONGODB_URI ?? (prod ? "" : "mongodb://root:password@localhost:27017/test?authSource=admin");
+}
+
 // Check if MONGODB_URI is still not set (either from environment or from the above generation)
 if (!MONGODB_URI) {
   throw new Error("Missing MONGODB_URI or required environment variables to generate it");
 }
 
-// For backwards compatibility, if no dbname is explicitly set, use "test" and add the authSource db.
-// This matches the default behavior of the MongoDB driver 3.X, which changed when we updated to 4.X
-if (MONGODB_URI.match(/:27017(\/)?$/)) {
-  MONGODB_URI = trimEnd(MONGODB_URI, "/") + "/test?authSource=admin";
-}
-
 export { MONGODB_URI };
-
-
 
 export const APP_ORIGIN = process.env.APP_ORIGIN || "http://localhost:3000";
 const isLocalhost = APP_ORIGIN.includes("localhost");

--- a/packages/back-end/src/util/secrets.ts
+++ b/packages/back-end/src/util/secrets.ts
@@ -37,7 +37,7 @@ if (!MONGODB_URI) {
 
     // Add extra args if they exist
     if (process.env.MONGODB_EXTRA_ARGS) {
-      MONGODB_URI += `?${process.env.MONGODB_EXTRA_ARGS}`;
+      MONGODB_URI += `${process.env.MONGODB_EXTRA_ARGS}`;
     }
   }
 }

--- a/packages/back-end/src/util/secrets.ts
+++ b/packages/back-end/src/util/secrets.ts
@@ -27,15 +27,15 @@ let MONGODB_URI = process.env.MONGODB_URI;
 if (!MONGODB_URI) {
   // Check for alternate mongo db environment variables
   if (
-    process.env.MONGO_DB_USERNAME &&
-    process.env.MONGO_DB_PASSWORD &&
-    process.env.MONGO_DB_HOSTNAME
+    process.env.MONGODB_USERNAME &&
+    process.env.MONGODB_PASSWORD &&
+    process.env.MONGODB_HOSTNAME
   ) {
-    MONGODB_URI = `mongodb://${process.env.MONGO_DB_USERNAME}:${process.env.MONGO_DB_PASSWORD}@${process.env.MONGO_DB_HOSTNAME}/growthbook`;
+    MONGODB_URI = `mongodb://${process.env.MONGODB_USERNAME}:${process.env.MONGODB_PASSWORD}@${process.env.MONGODB_HOSTNAME}/growthbook`;
 
     // Add extra args if they exist
-    if (process.env.MONGO_DB_EXTRA_ARGS) {
-      MONGODB_URI += `?${process.env.MONGO_DB_EXTRA_ARGS}`;
+    if (process.env.MONGODB_EXTRA_ARGS) {
+      MONGODB_URI += `?${process.env.MONGODB_EXTRA_ARGS}`;
     }
   }
 }

--- a/packages/back-end/src/util/secrets.ts
+++ b/packages/back-end/src/util/secrets.ts
@@ -29,10 +29,11 @@ if (!MONGODB_URI) {
   if (
     process.env.MONGODB_USERNAME &&
     process.env.MONGODB_PASSWORD &&
-    process.env.MONGODB_HOSTNAME &&
-    process.env.MONGODB_DBNAME
+    process.env.MONGODB_HOSTNAME
   ) {
-    MONGODB_URI = `mongodb://${process.env.MONGODB_USERNAME}:${process.env.MONGODB_PASSWORD}@${process.env.MONGODB_HOSTNAME}/${process.env.MONGODB_DBNAME}`;
+
+    const dbname = process.env.MONGODB_DBNAME || "growthbook"
+    MONGODB_URI = `mongodb://${process.env.MONGODB_USERNAME}:${process.env.MONGODB_PASSWORD}@${process.env.MONGODB_HOSTNAME}/${dbname}`;
 
     // Add extra args if they exist
     if (process.env.MONGODB_EXTRA_ARGS) {
@@ -43,13 +44,11 @@ if (!MONGODB_URI) {
 
 // For backwards compatibility, if no dbname is explicitly set, use "test" and add the authSource db.
 // This matches the default behavior of the MongoDB driver 3.X, which changed when we updated to 4.X
-if (!MONGODB_URI) {
-  MONGODB_URI = process.env.MONGODB_URI ?? (prod ? "" : "mongodb://root:password@localhost:27017/test?authSource=admin");
-}
-
-// Check if MONGODB_URI is still not set (either from environment or from the above generation)
-if (!MONGODB_URI) {
-  throw new Error("Missing MONGODB_URI or required environment variables to generate it");
+if(!MONOGODB_URI) {
+   if (prod) {
+      throw new Error("Missing MONGODB_URI or required alternate environment variables to generate it");
+   }
+   MONGODB_URI = "mongodb://root:password@localhost:27017/test?authSource=admin"
 }
 
 export { MONGODB_URI };


### PR DESCRIPTION
### Features and Changes
For some people, especially those who use AWS secrets manager to store secrets might find it easier to store separate env vars for composing their MONGODB_URI.  

https://growthbookusers.slack.com/archives/C01T6Q1SVFV/p1697697307803839

### Testing
Set MONGODB_URI env var.
Start app and see it load.
Remove MONGODB_URI env var and set the other env vars.
Restart the app and see it load.