### PR TITLE
Allow alternative envs to specify MONGODB_URL

### DIFF
--- a/docs/docs/self-host/env.mdx
+++ b/docs/docs/self-host/env.mdx
@@ -66,7 +66,13 @@ growthbook:
 ### Production Settings
 
 - **NODE_ENV** - Set to "production" to turn on additional optimizations and API request logging
-- **MONGODB_URI** - The MongoDB connection string
+- **MONGODB_URI** - The full MongoDB connection string. Alternatively you can specify the following environment variables from which we will compose the full connection string like so `mongodb://${MONGODB_USERNAME}:${MONGODB_PASSWORD}@${MONGODB_HOSTNAME}:${MONGODB_PORT}/${MONGODB_DBNAME}${MONGODB_EXTRA_ARGS}`:
+  - **MONGODB_USERNAME** - Username for MongoDB
+  - **MONGODB_PASSWORD** - Password for MongoDB
+  - **MONGODB_HOST** - Host name of MongoDB excluding port, e.g. `some.host.com`
+  - **MONGODB_PORT** - Port to use for MongoDB (defaults to `27017`)
+  - **MONGODB_DBNAME** - Database name of growthbook database (defaults to `growthbook`)
+  - **MONGODB_EXTRA_ARGS** - Optional set of extra arguments for MongoDB connection string (defaults to <span style={{whiteSpace:'nowrap'}}>`?authSource=admin`</span>)
 - **JWT_SECRET** - Auth signing key (use a long random string)
 - **ENCRYPTION_KEY** - Data source credential encryption key (use a long random string)
 


### PR DESCRIPTION
### Features and Changes
For some people, especially those who use AWS secrets manager to store secrets might find it easier to store separate env vars for composing their MONGODB_URI.

Here are a few links amongst others: 
https://linen.growthbook.io/t/15997670/hello-everybody-a-bit-of-a-weird-question-here-i-was-wonderi
https://linen.growthbook.io/t/15984475/hey-everybody-i-am-currently-running-into-an-issue-that-i-co
https://linen.growthbook.io/t/15866054/can-i-put-the-mongo-db-connection-details-in-config-yml-inst

### Testing
Add debugging line in mongo.ts `logger.error(uri)`
In .env.local set `MONGODB_URI=mongodb://root:password@localhost:27017/growthbook?authSource=admin`
Start app and see it load with the debugging line being the same.

In .env.local set `MONGODB_URI=mongodb://root:password@localhost:27017/`
Start app and see it load with the debugging line being `mongodb://root:password@localhost:27017/test?authSource=admin`

In .env.local set `MONGODB_URI=mongodb://root:password@localhost:27017`
Start app and see it load with the debugging line being `mongodb://root:password@localhost:27017/test?authSource=admin`

In .env.local set 
```
MONGODB_USERNAME=root
MONGODB_PASSWORD=password
MONGODB_HOST=localhost
```
and comment out MONGODB_URI.
Start app and see it load with the debugging line being `mongodb://root:password@localhost:27017/growthbook?authSource=admin`

In .env.local set 
```
MONGODB_USERNAME=root
MONGODB_PASSWORD=password
MONGODB_HOST=localhost
MONGODB_PORT=27018
MONGODB_DATABASE=foo
MONGODB_EXTRA_ARGS=?bar
```
and comment out MONGODB_URI.
Start app and see it crash with the debugging line being `mongodb://root:password@localhost:27018/foo?bar`

Remove all MONGODB_* env vars.
Restart the app and see it load with the debugging line being: `mongodb://root:password@localhost:27017/test?authSource=admin`

Restart the app using `NODE_ENV=production yarn dev`
See the app crash with the error thrown.