### PR TITLE
Fix JS SDK bug with $exists operator and undefined values

### DIFF
--- a/packages/sdk-js/src/mongrule.ts
+++ b/packages/sdk-js/src/mongrule.ts
@@ -169,7 +169,8 @@ function evalOperatorCondition(
     case "$gte":
       return actual >= expected;
     case "$exists":
-      return expected ? actual !== null : actual === null;
+      // Using `!=` and `==` instead of strict checks so it also matches for undefined
+      return expected ? actual != null : actual == null;
     case "$in":
       if (!Array.isArray(expected)) return false;
       return isIn(actual, expected);

--- a/packages/sdk-js/test/mongrule.test.ts
+++ b/packages/sdk-js/test/mongrule.test.ts
@@ -67,5 +67,95 @@ describe("Mongrule", () => {
         )
       ).toBe(false);
     });
+
+    it("Counts both undefined and null attributes as not existing, but not other falsy values", () => {
+      expect(
+        evalCondition(
+          {
+            email: undefined,
+          },
+          {
+            email: { $exists: true },
+          }
+        )
+      ).toBe(false);
+
+      expect(
+        evalCondition(
+          {
+            email: undefined,
+          },
+          {
+            email: { $exists: false },
+          }
+        )
+      ).toBe(true);
+
+      expect(
+        evalCondition(
+          {
+            email: null,
+          },
+          {
+            email: { $exists: true },
+          }
+        )
+      ).toBe(false);
+
+      expect(
+        evalCondition(
+          {
+            email: null,
+          },
+          {
+            email: { $exists: false },
+          }
+        )
+      ).toBe(true);
+
+      expect(
+        evalCondition(
+          {
+            email: "",
+          },
+          {
+            email: { $exists: true },
+          }
+        )
+      ).toBe(true);
+
+      expect(
+        evalCondition(
+          {
+            email: "",
+          },
+          {
+            email: { $exists: false },
+          }
+        )
+      ).toBe(false);
+
+      expect(
+        evalCondition(
+          {
+            email: 0,
+          },
+          {
+            email: { $exists: true },
+          }
+        )
+      ).toBe(true);
+
+      expect(
+        evalCondition(
+          {
+            email: 0,
+          },
+          {
+            email: { $exists: false },
+          }
+        )
+      ).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
### Features and Changes

Fixes #1259

The `$exists` operator made sure an attribute existed and was not set to `null`, but it was not checking if the attribute was set to `undefined`.

```ts
evalCondition(
  { email: undefined },
  { email: {$exists: true}}
)
```

Expected: evaluates to `false`.  Actual: evaluates to `true`.