### PR TITLE
[1204] adding ellipsis on tags when above 20 and adding wrapping

### DIFF
--- a/packages/front-end/components/Experiment/SinglePage.tsx
+++ b/packages/front-end/components/Experiment/SinglePage.tsx
@@ -741,9 +741,7 @@ export default function SinglePage({
           <div className="col-auto pr-3 ml-2">
             Tags:{" "}
             {experiment.tags?.length > 0 ? (
-              <span className="d-inline-block" style={{ maxWidth: 250 }}>
-                <SortedTags tags={experiment.tags} skipFirstMargin={true} />
-              </span>
+              <SortedTags tags={experiment.tags} skipFirstMargin={true} />
             ) : (
               <em className="text-muted">None</em>
             )}{" "}

--- a/packages/front-end/components/Experiment/TabbedPage/ProjectTagBar.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/ProjectTagBar.tsx
@@ -86,9 +86,7 @@ export default function ProjectTagBar({
       <div className="col-auto">
         Tags:{" "}
         {experiment.tags?.length > 0 ? (
-          <span className="d-inline-block" style={{ maxWidth: 250 }}>
-            <SortedTags tags={experiment.tags} skipFirstMargin={true} />
-          </span>
+          <SortedTags tags={experiment.tags} skipFirstMargin={true} />
         ) : (
           <em className="text-muted">None</em>
         )}{" "}

--- a/packages/front-end/components/Metrics/MetricTooltipBody.tsx
+++ b/packages/front-end/components/Metrics/MetricTooltipBody.tsx
@@ -48,7 +48,13 @@ const MetricTooltipBody = ({
     {
       show: (metric.tags?.length ?? 0) > 0,
       label: "Tags",
-      body: <SortedTags tags={metric.tags} skipFirstMargin={true} />,
+      body: (
+        <SortedTags
+          tags={metric.tags}
+          shouldShowEllipsis={false}
+          useFlex={true}
+        />
+      ),
     },
     {
       show:

--- a/packages/front-end/components/Tags/SortedTags.tsx
+++ b/packages/front-end/components/Tags/SortedTags.tsx
@@ -5,12 +5,20 @@ import Tag from "./Tag";
 export interface Props {
   tags?: string[];
   shouldShowEllipsis?: boolean;
+  skipFirstMargin?: boolean;
+  useFlex?: boolean;
+  showEllipsisAtIndex?: number;
 }
 
-export default function SortedTags({ tags, shouldShowEllipsis }: Props) {
+export default function SortedTags({
+  tags,
+  shouldShowEllipsis = true,
+  skipFirstMargin = false,
+  useFlex = false,
+  showEllipsisAtIndex = 6,
+}: Props) {
   const { tags: all } = useDefinitions();
   //index starting at 0
-  const SHOW_ELLIPSIS_AT_INDEX = 6;
   if (!tags || !tags.length) return null;
 
   const sortedIds = all.map((t) => t.id);
@@ -21,15 +29,18 @@ export default function SortedTags({ tags, shouldShowEllipsis }: Props) {
   });
 
   const renderEllipsis = () => {
-    const tags = sorted.slice(SHOW_ELLIPSIS_AT_INDEX);
+    const tags = sorted.slice(showEllipsisAtIndex);
     const tagCopy = `${tags.length} more tags...`;
-
+    const tagElements = renderTags(tags);
     return (
-      <Tooltip body={<>{renderTags(tags)}</>} usePortal={true}>
+      <Tooltip
+        body={<>{renderFlexContainer(tagElements, true)}</>}
+        usePortal={true}
+      >
         <Tag
           tag={tagCopy}
           key="tag-ellipsis"
-          skipMargin={true}
+          skipMargin={useFlex}
           color="#ffffff"
         />
       </Tooltip>
@@ -37,20 +48,33 @@ export default function SortedTags({ tags, shouldShowEllipsis }: Props) {
   };
 
   const renderTags = (tags: string[]) => {
-    return tags.map((tag) => <Tag tag={tag} key={tag} skipMargin={true} />);
+    return tags.map((tag, i) => {
+      const skipMargin = useFlex || (skipFirstMargin && i === 0);
+      return <Tag tag={tag} key={tag} skipMargin={skipMargin} />;
+    });
+  };
+  const renderFlexContainer = (
+    child: JSX.Element | JSX.Element[],
+    shouldUseFlex = useFlex
+  ) => {
+    return shouldUseFlex ? (
+      <div className="tags-container">{child}</div>
+    ) : (
+      child
+    );
   };
 
   const renderTruncatedTags = () => {
-    //only whant to show ellipsis if the length is >  SHOW_ELLIPSIS_AT_INDEX;
     const truncatedTags = shouldShowEllipsis
-      ? sorted.slice(0, SHOW_ELLIPSIS_AT_INDEX - 1)
+      ? sorted.slice(0, showEllipsisAtIndex - 1)
       : sorted;
     const shouldRenderEllipsis =
       shouldShowEllipsis && truncatedTags.length < sorted.length;
-    return (
-      <div className="tags-container">
-        {renderTags(truncatedTags)} {shouldRenderEllipsis && renderEllipsis()}{" "}
-      </div>
+    return renderFlexContainer(
+      <>
+        {renderTags(truncatedTags)}
+        {shouldRenderEllipsis && renderEllipsis()}
+      </>
     );
   };
 

--- a/packages/front-end/components/Tags/SortedTags.tsx
+++ b/packages/front-end/components/Tags/SortedTags.tsx
@@ -24,7 +24,7 @@ export default function SortedTags({
     return sortedIds.indexOf(a) - sortedIds.indexOf(b);
   });
 
-  const renderTag = () => {
+  const renderTags = () => {
     //only whant to show ellipsis if the length is >  SHOW_ELLIPSIS_AT_INDEX;
     shouldShowEllipsis =
       shouldShowEllipsis && sorted.length - 1 !== SHOW_ELLIPSIS_AT_INDEX;
@@ -42,5 +42,5 @@ export default function SortedTags({
     });
   };
 
-  return <>{renderTag()}</>;
+  return <>{renderTags()}</>;
 }

--- a/packages/front-end/components/Tags/SortedTags.tsx
+++ b/packages/front-end/components/Tags/SortedTags.tsx
@@ -31,7 +31,7 @@ export default function SortedTags({
 
     return sorted.map((tag, i) => {
       if (i === SHOW_ELLIPSIS_AT_INDEX && !!shouldShowEllipsis) {
-        return <Tag tag="..." key="tag-ellipsis" />;
+        return <Tag tag="&hellip;" key="tag-ellipsis" />;
       } else if (i < SHOW_ELLIPSIS_AT_INDEX || !shouldShowEllipsis) {
         return (
           <Tag tag={tag} key={tag} skipMargin={skipFirstMargin && i === 0} />

--- a/packages/front-end/components/Tags/SortedTags.tsx
+++ b/packages/front-end/components/Tags/SortedTags.tsx
@@ -1,4 +1,5 @@
 import { useDefinitions } from "@/services/DefinitionsContext";
+import Tooltip from "../Tooltip/Tooltip";
 import Tag from "./Tag";
 
 export interface Props {
@@ -14,7 +15,7 @@ export default function SortedTags({
 }: Props) {
   const { tags: all } = useDefinitions();
   //index starting at 0
-  const SHOW_ELLIPSIS_AT_INDEX = 4;
+  const SHOW_ELLIPSIS_AT_INDEX = 20;
   if (!tags || !tags.length) return null;
 
   const sortedIds = all.map((t) => t.id);
@@ -24,23 +25,31 @@ export default function SortedTags({
     return sortedIds.indexOf(a) - sortedIds.indexOf(b);
   });
 
-  const renderTags = () => {
-    //only whant to show ellipsis if the length is >  SHOW_ELLIPSIS_AT_INDEX;
-    shouldShowEllipsis =
-      shouldShowEllipsis && sorted.length - 1 !== SHOW_ELLIPSIS_AT_INDEX;
+  const renderEllipsis = () => (
+    <Tooltip body={<>{renderTags(sorted)}</>} usePortal={true}>
+      <Tag tag="&hellip;" key="tag-ellipsis" />
+    </Tooltip>
+  );
 
-    return sorted.map((tag, i) => {
-      if (i === SHOW_ELLIPSIS_AT_INDEX && !!shouldShowEllipsis) {
-        return <Tag tag="&hellip;" key="tag-ellipsis" />;
-      } else if (i < SHOW_ELLIPSIS_AT_INDEX || !shouldShowEllipsis) {
-        return (
-          <Tag tag={tag} key={tag} skipMargin={skipFirstMargin && i === 0} />
-        );
-      }
-
-      return null;
-    });
+  const renderTags = (tags: string[]) => {
+    return tags.map((tag, i) => (
+      <Tag tag={tag} key={tag} skipMargin={skipFirstMargin && i === 0} />
+    ));
   };
 
-  return <>{renderTags()}</>;
+  const renderTruncatedTags = () => {
+    //only whant to show ellipsis if the length is >  SHOW_ELLIPSIS_AT_INDEX;
+    const truncatedTags = shouldShowEllipsis
+      ? sorted.slice(0, SHOW_ELLIPSIS_AT_INDEX - 1)
+      : sorted;
+    const shouldRenderEllipsis =
+      shouldShowEllipsis && truncatedTags.length < sorted.length;
+    return (
+      <>
+        {renderTags(truncatedTags)} {shouldRenderEllipsis && renderEllipsis()}{" "}
+      </>
+    );
+  };
+
+  return <>{renderTruncatedTags()}</>;
 }

--- a/packages/front-end/components/Tags/SortedTags.tsx
+++ b/packages/front-end/components/Tags/SortedTags.tsx
@@ -4,11 +4,17 @@ import Tag from "./Tag";
 export interface Props {
   tags?: string[];
   skipFirstMargin?: boolean;
+  shouldShowEllipsis?: boolean;
 }
 
-export default function SortedTags({ tags, skipFirstMargin }: Props) {
+export default function SortedTags({
+  tags,
+  skipFirstMargin,
+  shouldShowEllipsis,
+}: Props) {
   const { tags: all } = useDefinitions();
-
+  //index starting at 0
+  const SHOW_ELLIPSIS_AT_INDEX = 4;
   if (!tags || !tags.length) return null;
 
   const sortedIds = all.map((t) => t.id);
@@ -18,11 +24,23 @@ export default function SortedTags({ tags, skipFirstMargin }: Props) {
     return sortedIds.indexOf(a) - sortedIds.indexOf(b);
   });
 
-  return (
-    <>
-      {sorted.map((tag, i) => (
-        <Tag tag={tag} key={tag} skipMargin={skipFirstMargin && i === 0} />
-      ))}
-    </>
-  );
+  const renderTag = () => {
+    //only whant to show ellipsis if the length is >  SHOW_ELLIPSIS_AT_INDEX;
+    shouldShowEllipsis =
+      shouldShowEllipsis && sorted.length - 1 !== SHOW_ELLIPSIS_AT_INDEX;
+
+    return sorted.map((tag, i) => {
+      if (i === SHOW_ELLIPSIS_AT_INDEX && !!shouldShowEllipsis) {
+        return <Tag tag="..." key="tag-ellipsis" />;
+      } else if (i < SHOW_ELLIPSIS_AT_INDEX || !shouldShowEllipsis) {
+        return (
+          <Tag tag={tag} key={tag} skipMargin={skipFirstMargin && i === 0} />
+        );
+      }
+
+      return null;
+    });
+  };
+
+  return <>{renderTag()}</>;
 }

--- a/packages/front-end/components/Tags/SortedTags.tsx
+++ b/packages/front-end/components/Tags/SortedTags.tsx
@@ -4,18 +4,13 @@ import Tag from "./Tag";
 
 export interface Props {
   tags?: string[];
-  skipFirstMargin?: boolean;
   shouldShowEllipsis?: boolean;
 }
 
-export default function SortedTags({
-  tags,
-  skipFirstMargin,
-  shouldShowEllipsis,
-}: Props) {
+export default function SortedTags({ tags, shouldShowEllipsis }: Props) {
   const { tags: all } = useDefinitions();
   //index starting at 0
-  const SHOW_ELLIPSIS_AT_INDEX = 20;
+  const SHOW_ELLIPSIS_AT_INDEX = 6;
   if (!tags || !tags.length) return null;
 
   const sortedIds = all.map((t) => t.id);
@@ -25,16 +20,24 @@ export default function SortedTags({
     return sortedIds.indexOf(a) - sortedIds.indexOf(b);
   });
 
-  const renderEllipsis = () => (
-    <Tooltip body={<>{renderTags(sorted)}</>} usePortal={true}>
-      <Tag tag="&hellip;" key="tag-ellipsis" />
-    </Tooltip>
-  );
+  const renderEllipsis = () => {
+    const tags = sorted.slice(SHOW_ELLIPSIS_AT_INDEX);
+    const tagCopy = `${tags.length} more tags...`;
+
+    return (
+      <Tooltip body={<>{renderTags(tags)}</>} usePortal={true}>
+        <Tag
+          tag={tagCopy}
+          key="tag-ellipsis"
+          skipMargin={true}
+          color="#ffffff"
+        />
+      </Tooltip>
+    );
+  };
 
   const renderTags = (tags: string[]) => {
-    return tags.map((tag, i) => (
-      <Tag tag={tag} key={tag} skipMargin={skipFirstMargin && i === 0} />
-    ));
+    return tags.map((tag) => <Tag tag={tag} key={tag} skipMargin={true} />);
   };
 
   const renderTruncatedTags = () => {
@@ -45,9 +48,9 @@ export default function SortedTags({
     const shouldRenderEllipsis =
       shouldShowEllipsis && truncatedTags.length < sorted.length;
     return (
-      <>
+      <div className="tags-container">
         {renderTags(truncatedTags)} {shouldRenderEllipsis && renderEllipsis()}{" "}
-      </>
+      </div>
     );
   };
 

--- a/packages/front-end/components/Tags/SortedTags.tsx
+++ b/packages/front-end/components/Tags/SortedTags.tsx
@@ -15,7 +15,7 @@ export default function SortedTags({
   shouldShowEllipsis = true,
   skipFirstMargin = false,
   useFlex = false,
-  showEllipsisAtIndex = 6,
+  showEllipsisAtIndex = 5,
 }: Props) {
   const { tags: all } = useDefinitions();
   //index starting at 0
@@ -30,7 +30,7 @@ export default function SortedTags({
 
   const renderEllipsis = () => {
     const tags = sorted.slice(showEllipsisAtIndex);
-    const tagCopy = `${tags.length} more tags...`;
+    const tagCopy = `${tags.length} more tag${tags.length === 1 ? "" : "s"}...`;
     const tagElements = renderTags(tags);
     return (
       <Tooltip
@@ -65,9 +65,13 @@ export default function SortedTags({
   };
 
   const renderTruncatedTags = () => {
-    const truncatedTags = shouldShowEllipsis
-      ? sorted.slice(0, showEllipsisAtIndex - 1)
-      : sorted;
+    let truncatedTags = sorted;
+    if (sorted.length > showEllipsisAtIndex + 1) {
+      truncatedTags = shouldShowEllipsis
+        ? sorted.slice(0, showEllipsisAtIndex)
+        : sorted;
+    }
+
     const shouldRenderEllipsis =
       shouldShowEllipsis && truncatedTags.length < sorted.length;
     return renderFlexContainer(

--- a/packages/front-end/components/Tags/SortedTags.tsx
+++ b/packages/front-end/components/Tags/SortedTags.tsx
@@ -66,10 +66,8 @@ export default function SortedTags({
 
   const renderTruncatedTags = () => {
     let truncatedTags = sorted;
-    if (sorted.length > showEllipsisAtIndex + 1) {
-      truncatedTags = shouldShowEllipsis
-        ? sorted.slice(0, showEllipsisAtIndex)
-        : sorted;
+    if (shouldShowEllipsis && sorted.length > showEllipsisAtIndex + 1) {
+      truncatedTags = sorted.slice(0, showEllipsisAtIndex);
     }
 
     const shouldRenderEllipsis =

--- a/packages/front-end/pages/experiments/index.tsx
+++ b/packages/front-end/pages/experiments/index.tsx
@@ -410,7 +410,8 @@ const ExperimentsPage = (): React.ReactElement => {
                         )}
                       </td>
                     )}
-                    <td className="nowrap" data-title="Tags:">
+
+                    <td className="col-4" data-title="Tags:">
                       <SortedTags
                         tags={Object.values(e.tags)}
                         shouldShowEllipsis={true}

--- a/packages/front-end/pages/experiments/index.tsx
+++ b/packages/front-end/pages/experiments/index.tsx
@@ -412,10 +412,7 @@ const ExperimentsPage = (): React.ReactElement => {
                     )}
 
                     <td data-title="Tags:" className="table-tags">
-                      <SortedTags
-                        tags={Object.values(e.tags)}
-                        shouldShowEllipsis={true}
-                      />
+                      <SortedTags tags={Object.values(e.tags)} useFlex={true} />
                     </td>
                     <td className="nowrap" data-title="Owner:">
                       {e.ownerName}

--- a/packages/front-end/pages/experiments/index.tsx
+++ b/packages/front-end/pages/experiments/index.tsx
@@ -411,7 +411,10 @@ const ExperimentsPage = (): React.ReactElement => {
                       </td>
                     )}
                     <td className="nowrap" data-title="Tags:">
-                      <SortedTags tags={Object.values(e.tags)} />
+                      <SortedTags
+                        tags={Object.values(e.tags)}
+                        shouldShowEllipsis={true}
+                      />
                     </td>
                     <td className="nowrap" data-title="Owner:">
                       {e.ownerName}

--- a/packages/front-end/pages/experiments/index.tsx
+++ b/packages/front-end/pages/experiments/index.tsx
@@ -411,7 +411,7 @@ const ExperimentsPage = (): React.ReactElement => {
                       </td>
                     )}
 
-                    <td className="col-4" data-title="Tags:">
+                    <td data-title="Tags:" className="table-tags">
                       <SortedTags
                         tags={Object.values(e.tags)}
                         shouldShowEllipsis={true}

--- a/packages/front-end/pages/metrics.tsx
+++ b/packages/front-end/pages/metrics.tsx
@@ -405,6 +405,7 @@ const MetricsPage = (): React.ReactElement => {
               <td className="nowrap">
                 <SortedTags
                   tags={metric.tags ? Object.values(metric.tags) : []}
+                  shouldShowEllipsis={true}
                 />
               </td>
               <td className="col-2">

--- a/packages/front-end/pages/metrics.tsx
+++ b/packages/front-end/pages/metrics.tsx
@@ -30,7 +30,6 @@ import { useAuth } from "@/services/auth";
 import AutoGenerateMetricsModal from "@/components/AutoGenerateMetricsModal";
 import AutoGenerateMetricsButton from "@/components/AutoGenerateMetricsButton";
 import FactBadge from "@/components/FactTables/FactBadge";
-
 interface MetricTableItem {
   id: string;
   name: string;
@@ -402,7 +401,7 @@ const MetricsPage = (): React.ReactElement => {
               </td>
               <td>{metric.type}</td>
 
-              <td className="nowrap">
+              <td className="col-4">
                 <SortedTags
                   tags={metric.tags ? Object.values(metric.tags) : []}
                   shouldShowEllipsis={true}

--- a/packages/front-end/pages/settings/tags.tsx
+++ b/packages/front-end/pages/settings/tags.tsx
@@ -82,7 +82,7 @@ const TagsPage: FC = () => {
                     </td>
                     <td>{t.description}</td>
                     <td>
-                      <Tag tag={t.id} />
+                      <Tag tag={t.id} skipMargin={true} />
                     </td>
                     <td>
                       <button

--- a/packages/front-end/styles/global.scss
+++ b/packages/front-end/styles/global.scss
@@ -3088,6 +3088,16 @@ input:disabled {
     }
   }
 }
-
+.table-tags {
+  min-width: 250px;
+  width: 100%;
+}
+.tags-container {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 7px;
+}
 @import "./components/react-select.scss";
 @import "./components/demo-datasource-banner";


### PR DESCRIPTION
### Features and Changes
Added Ellipsis for tags when the go above 20. and i removed the no-wrap on the tags and added col-4 to the width of the table. you can still see the tags in the experiment page see screenshots below
<!--
  Include a description of your changes.
  If there are any new tools, API's, etc. that devs can leverage, it may be helpful to include usage info.
-->

<!--
  Indicate which issue this will close, if applicable
  For multiple issues, add a new `- Closes` or `- Fixes` line
-->

- Closes **https://github.com/growthbook/growthbook/issues/1204**

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

<!--
  Please describe how to test these changes.
 -->
<img width="558" alt="Screenshot 2023-11-01 at 4 22 51 PM" src="https://github.com/growthbook/growthbook/assets/1596883/a11a24e5-18eb-4208-a542-a92d15099ce1">
<img width="585" alt="Screenshot 2023-11-01 at 4 22 55 PM" src="https://github.com/growthbook/growthbook/assets/1596883/dc525681-d175-468b-8140-a0b2d9d183de">
<img width="895" alt="Screenshot 2023-11-01 at 4 23 04 PM" src="https://github.com/growthbook/growthbook/assets/1596883/38c9e4eb-a745-4e27-a38d-769d21da74f2">
<img width="969" alt="Screenshot 2023-11-01 at 4 23 08 PM" src="https://github.com/growthbook/growthbook/assets/1596883/8f34f575-23f4-46a6-a9b0-c32436b58704">

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
