### PR TITLE
[1250] support cache control with .env

### DIFF
--- a/packages/back-end/.env.example
+++ b/packages/back-end/.env.example
@@ -27,4 +27,9 @@ GOOGLE_OAUTH_CLIENT_SECRET=
 # Express 'trust proxy' options: https://expressjs.com/en/5x/api.html#trust.proxy.options.table
 # Boolean (true/false, 1/0) and string values are supported
 # see getTrustProxyConfig() in secrets.ts for details
-EXPRESS_TRUST_PROXY_OPTS=
+EXPRESS_TRUST_PROXY_OPTS= 
+
+# Cache control
+CACHE_CONTROL_MAX_AGE=
+CACHE_CONTROL_STALE_WHILE_REVALIDATE=
+CACHE_CONTROL_STALE_IF_ERROR=

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -198,7 +198,7 @@ export async function getFeaturesPublic(req: Request, res: Response) {
     // The default is Cache for 30 seconds, serve stale up to 1 hour (10 hours if origin is down)
     res.set(
       "Cache-control",
-      `public, max-age=${CACHE_CONTROL_MAX_AGE}, stale-while-revalidate=${CACHE_CONTROL_STALE_IF_ERROR}, stale-if-error=${CACHE_CONTROL_STALE_WHILE_REVALIDATE}`
+      `public, max-age=${CACHE_CONTROL_MAX_AGE}, stale-while-revalidate=${CACHE_CONTROL_STALE_WHILE_REVALIDATE}, stale-if-error=${CACHE_CONTROL_STALE_IF_ERROR}`
     );
 
     // If using Fastly, add surrogate key header for cache purging

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -57,7 +57,12 @@ import {
 } from "../models/SdkConnectionModel";
 import { logger } from "../util/logger";
 import { addTagsDiff } from "../models/TagModel";
-import { FASTLY_SERVICE_ID } from "../util/secrets";
+import {
+  FASTLY_SERVICE_ID,
+  CACHE_CONTROL_MAX_AGE,
+  CACHE_CONTROL_STALE_IF_ERROR,
+  CACHE_CONTROL_STALE_WHILE_REVALIDATE,
+} from "../util/secrets";
 import { EventAuditUserForResponseLocals } from "../events/event-types";
 import { upsertWatch } from "../models/WatchModel";
 import { getSurrogateKeysFromSDKPayloadKeys } from "../util/cdn.util";
@@ -190,10 +195,10 @@ export async function getFeaturesPublic(req: Request, res: Response) {
       hashSecureAttributes,
     });
 
-    // Cache for 30 seconds, serve stale up to 1 hour (10 hours if origin is down)
+    // The default is Cache for 30 seconds, serve stale up to 1 hour (10 hours if origin is down)
     res.set(
       "Cache-control",
-      "public, max-age=30, stale-while-revalidate=3600, stale-if-error=36000"
+      `public, max-age=${CACHE_CONTROL_MAX_AGE}, stale-while-revalidate=${CACHE_CONTROL_STALE_IF_ERROR}, stale-if-error=${CACHE_CONTROL_STALE_WHILE_REVALIDATE}`
     );
 
     // If using Fastly, add surrogate key header for cache purging

--- a/packages/back-end/src/util/secrets.ts
+++ b/packages/back-end/src/util/secrets.ts
@@ -141,6 +141,16 @@ export const QUERY_CACHE_TTL_MINS =
 export const IMPORT_LIMIT_DAYS =
   parseInt(process.env?.IMPORT_LIMIT_DAYS || "") || 365;
 
+// cache control currently feature only /api/features/*
+export const CACHE_CONTROL_MAX_AGE =
+  parseInt(process.env?.CACHE_CONTROL_MAX_AGE || "") || 30;
+export const CACHE_CONTROL_STALE_WHILE_REVALIDATE =
+  parseInt(process.env?.CACHE_CONTROL_MAX_AGE || "") || 3600;
+export const CACHE_CONTROL_STALE_IF_ERROR =
+  parseInt(process.env?.CACHE_CONTROL_MAX_AGE || "") || 36000;
+
+// update Feature every
+
 export const CRON_ENABLED = !stringToBoolean(process.env.CRON_DISABLED);
 
 export const VERCEL_CLIENT_ID = process.env.VERCEL_CLIENT_ID || "";

--- a/packages/back-end/src/util/secrets.ts
+++ b/packages/back-end/src/util/secrets.ts
@@ -145,9 +145,9 @@ export const IMPORT_LIMIT_DAYS =
 export const CACHE_CONTROL_MAX_AGE =
   parseInt(process.env?.CACHE_CONTROL_MAX_AGE || "") || 30;
 export const CACHE_CONTROL_STALE_WHILE_REVALIDATE =
-  parseInt(process.env?.CACHE_CONTROL_MAX_AGE || "") || 3600;
+  parseInt(process.env?.CACHE_CONTROL_STALE_WHILE_REVALIDATE || "") || 3600;
 export const CACHE_CONTROL_STALE_IF_ERROR =
-  parseInt(process.env?.CACHE_CONTROL_MAX_AGE || "") || 36000;
+  parseInt(process.env?.CACHE_CONTROL_STALE_IF_ERROR || "") || 36000;
 
 // update Feature every
 


### PR DESCRIPTION
… your env

### Features and Changes
adding support so that you can add your own cache controls in .env 
supported functions are:
`max-age`
`stale-while-revalidate`
`stale-if-error`
<!--
  Include a description of your changes.
  If there are any new tools, API's, etc. that devs can leverage, it may be helpful to include usage info.
-->
if you want to add support you need to add here is an example that you can add to your .env file
```
CACHE_CONTROL_MAX_AGE=10
CACHE_CONTROL_STALE_WHILE_REVALIDATE=100
CACHE_CONTROL_STALE_IF_ERROR=1000
```
<!--
  Indicate which issue this will close, if applicable
  For multiple issues, add a new `- Closes` or `- Fixes` line
-->

- Closes #1250

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

<!--
  Please describe how to test these changes.
 -->
- in you env.local add example code above
- create a new sdk feature 
<img width="785" alt="image" src="https://github.com/growthbook/growthbook/assets/1596883/954c1946-d782-4afb-9f07-645e6b50682e">
- copy the url that is generated eg `http://localhost:3100/api/features/sdk-blablaba`
- inspect and check the headers and make sure the cache control is correct 
<img width="708" alt="image" src="https://github.com/growthbook/growthbook/assets/1596883/651ee46d-71ab-4d2a-a6f4-c9b429158a4c">


### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
