### PR TITLE
JS SDK - Bump dom-mutator version

### DIFF
--- a/packages/sdk-js/package.json
+++ b/packages/sdk-js/package.json
@@ -39,7 +39,7 @@
   },
   "author": "Jeremy Dorn",
   "dependencies": {
-    "dom-mutator": "^0.5.0"
+    "dom-mutator": "^0.6.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.19.3",


### PR DESCRIPTION
In anticipation for the new version of the `dom-mutator` package

TODO 
- [ ] update yarn.lock