### PR TITLE
bugfix: Add template variables on creation

### DIFF
--- a/packages/back-end/src/controllers/metrics.ts
+++ b/packages/back-end/src/controllers/metrics.ts
@@ -437,6 +437,7 @@ export async function postMetrics(
     timestampColumn,
     userIdColumns,
     userIdTypes,
+    templateVariables,
   } = req.body;
 
   req.checkPermissions("createMetrics", projects?.length ? projects : "");
@@ -487,6 +488,7 @@ export async function postMetrics(
     regressionAdjustmentOverride,
     regressionAdjustmentEnabled,
     regressionAdjustmentDays,
+    templateVariables,
   });
 
   res.status(200).json({


### PR DESCRIPTION
### Features and Changes
Fixes bug where the templateVariables weren't being saved on metric creation.

### Testing

Create a new metric with template variables set.
Navigated to new metric to see the template variables listed.
Duplicate metric.
Save.
Navigate to duplicated metric to see the template variable listed.

