### PR TITLE
Add new SDK test cases for comparison operators

### DIFF
--- a/docs/docs/lib/build-your-own.mdx
+++ b/docs/docs/lib/build-your-own.mdx
@@ -7,7 +7,7 @@ slug: build-your-own
 
 # Build Your Own SDK
 
-**Latest spec version: 0.5.1 [View Changelog](#changelog)**
+**Latest spec version: 0.5.2 [View Changelog](#changelog)**
 
 This guide is meant for library authors looking to build a GrowthBook SDK in a currently unsupported language.
 
@@ -1147,3 +1147,5 @@ Open a [GitHub issue](https://github.com/growthbook/growthbook/issues) with a li
   - New `isIn` helper function for conditions, plus new evalCondition test cases for `$in` and `$nin` operators when attribute is an array
 - **v0.5.1** 2023-10-19
   - Add 2 new test cases for matching on a `$groups` array attribute
+- **v0.5.2** 2023-10-30
+  - Add 3 new test cases for comparison operators to handle more edge cases

--- a/packages/sdk-js/test/cases.json
+++ b/packages/sdk-js/test/cases.json
@@ -1,5 +1,5 @@
 {
-  "specVersion": "0.5.1",
+  "specVersion": "0.5.2",
   "evalCondition": [
     [
       "$not - pass",
@@ -616,6 +616,46 @@
         "hello": "world"
       },
       false
+    ],
+    [
+      "missing attribute with comparison operators",
+      {
+        "age": {
+          "$gt": -10,
+          "$lt": 10,
+          "$gte": -9,
+          "$lte": 9,
+          "$ne": 10
+        }
+      },
+      {},
+      true
+    ],
+    [
+      "comparing numbers and strings",
+      {
+        "n": {
+          "$gt": 5,
+          "$lt": 10
+        }
+      },
+      {
+        "n": "8"
+      },
+      true
+    ],
+    [
+      "comparing numbers and strings - v2",
+      {
+        "n": {
+          "$gt": "5",
+          "$lt": "10"
+        }
+      },
+      {
+        "n": 8
+      },
+      true
     ],
     [
       "empty $or - pass",
@@ -2275,6 +2315,32 @@
       {
         "attributes": {
           "id": "3"
+        },
+        "features": {
+          "feature": {
+            "defaultValue": 2,
+            "rules": [
+              {
+                "force": 1,
+                "coverage": 0.5
+              }
+            ]
+          }
+        }
+      },
+      "feature",
+      {
+        "value": 1,
+        "on": true,
+        "off": false,
+        "source": "force"
+      }
+    ],
+    [
+      "force rule - coverage with integer hash attribute",
+      {
+        "attributes": {
+          "id": 3
         },
         "features": {
           "feature": {


### PR DESCRIPTION
### Features and Changes

Add new test cases for SDKs
1. Comparison operators when the attribute value is missing or null (e.g. `3 > undefined`)
2. Comparison operators when one value is a number and the other is a string (e.g. `"5" > 4`)

The javascript SDK already passes these test cases and does not require any changes.  Other SDKs (e.g. Ruby) will require changes to be compliant with these new tests.