### PR TITLE
Add LOG_LEVEL env var

### DIFF
--- a/packages/back-end/src/util/logger.ts
+++ b/packages/back-end/src/util/logger.ts
@@ -1,10 +1,10 @@
 import pinoHttp from "pino-http";
 import * as Sentry from "@sentry/node";
 import { Request } from "express";
-import { BaseLogger } from "pino";
+import { BaseLogger, Level } from "pino";
 import { ApiRequestLocals } from "../../types/api";
 import { AuthRequest } from "../types/AuthRequest";
-import { ENVIRONMENT, IS_CLOUD } from "./secrets";
+import { ENVIRONMENT, IS_CLOUD, LOG_LEVEL } from "./secrets";
 
 const redactPaths = [
   "req.headers.authorization",
@@ -55,8 +55,21 @@ export function getCustomLogProps(req: Request) {
   }
   return data;
 }
+
+const isValidLevel = (input: unknown): input is Level => {
+  return ([
+    "fatal",
+    "error",
+    "warn",
+    "info",
+    "debug",
+    "trace",
+  ] as const).includes(input as Level);
+};
+
 export const httpLogger = pinoHttp({
   autoLogging: ENVIRONMENT === "production",
+  useLevel: isValidLevel(LOG_LEVEL) ? LOG_LEVEL : "info",
   redact: {
     paths: redactPaths,
     remove: true,

--- a/packages/back-end/src/util/secrets.ts
+++ b/packages/back-end/src/util/secrets.ts
@@ -6,6 +6,8 @@ import { stringToBoolean } from "shared/util";
 export const ENVIRONMENT = process.env.NODE_ENV;
 const prod = ENVIRONMENT === "production";
 
+export const LOG_LEVEL = process.env.LOG_LEVEL;
+
 if (fs.existsSync(".env.local")) {
   dotenv.config({ path: ".env.local" });
 }


### PR DESCRIPTION
### Features and Changes

Adds a way to override the `pino` `useLevel` option using the `LOG_LEVEL` env var

### Testing

Unit tests & tested locally

### Notes

I'm not super comfortable w/ typescript so if there's a more elegant way to do the type guard, please let me know :)