### PR TITLE
Fix SDK connection form: payload security state change bug

### DIFF
--- a/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
+++ b/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
@@ -176,9 +176,17 @@ export default function SDKConnectionForm({
       const enableEncryption = hasEncryptionFeature;
       const enableSecureAttributes = hasSecureAttributesFeature;
       form.setValue("remoteEvalEnabled", false);
-      form.setValue("encryptPayload", enableEncryption);
-      form.setValue("hashSecureAttributes", enableSecureAttributes);
-      form.setValue("includeExperimentNames", false);
+      if (
+        !(
+          form.watch("encryptPayload") ||
+          form.watch("hashSecureAttributes") ||
+          !form.watch("includeExperimentNames")
+        )
+      ) {
+        form.setValue("encryptPayload", enableEncryption);
+        form.setValue("hashSecureAttributes", enableSecureAttributes);
+        form.setValue("includeExperimentNames", false);
+      }
     } else if (selectedSecurityTab === "remote") {
       if (!enableRemoteEval) {
         form.setValue("remoteEvalEnabled", false);
@@ -187,7 +195,7 @@ export default function SDKConnectionForm({
       form.setValue("remoteEvalEnabled", true);
       form.setValue("encryptPayload", false);
       form.setValue("hashSecureAttributes", false);
-      form.setValue("includeExperimentNames", false);
+      form.setValue("includeExperimentNames", true);
     }
   }, [
     selectedSecurityTab,


### PR DESCRIPTION
### Features and Changes

- setting sub-toggles in the "ciphered" state (such as "encrypt SDK payload" or "hash secure attributes") were forgotten by the UI when the form was reopened. Fixed

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

<!--
  Please describe how to test these changes.
 -->

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
