### PR TITLE
Fix bug: SDK payloads not refreshing

### DIFF
--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -237,8 +237,6 @@ export async function refreshSDKPayloadCache(
       ? allVisualExperiments.filter((e) => e.experiment.project === key.project)
       : allVisualExperiments;
 
-    if (!projectFeatures.length && !projectExperiments.length) continue;
-
     const featureDefinitions = generatePayload({
       features: projectFeatures,
       environment: key.environment,


### PR DESCRIPTION
### Features and Changes

When you stop/disable the only active feature flag or experiment, the SDK payload does not get updated, so the old experiment/feature continues to be served to users.

This was happening because we were skipping the SDK payload refresh if the list of features/experiments was empty.  Removing that check fixes the bug.