### PR TITLE
Fix LOG_LEVEL env var, use correct param

### DIFF
--- a/packages/back-end/src/util/logger.ts
+++ b/packages/back-end/src/util/logger.ts
@@ -69,7 +69,7 @@ const isValidLevel = (input: unknown): input is Level => {
 
 export const httpLogger = pinoHttp({
   autoLogging: ENVIRONMENT === "production",
-  useLevel: isValidLevel(LOG_LEVEL) ? LOG_LEVEL : "info",
+  level: isValidLevel(LOG_LEVEL) ? LOG_LEVEL : "info",
   redact: {
     paths: redactPaths,
     remove: true,

--- a/packages/back-end/src/util/secrets.ts
+++ b/packages/back-end/src/util/secrets.ts
@@ -6,11 +6,11 @@ import { stringToBoolean } from "shared/util";
 export const ENVIRONMENT = process.env.NODE_ENV;
 const prod = ENVIRONMENT === "production";
 
-export const LOG_LEVEL = process.env.LOG_LEVEL;
-
 if (fs.existsSync(".env.local")) {
   dotenv.config({ path: ".env.local" });
 }
+
+export const LOG_LEVEL = process.env.LOG_LEVEL;
 
 export const IS_CLOUD = stringToBoolean(process.env.IS_CLOUD);
 export const IS_MULTI_ORG = stringToBoolean(process.env.IS_MULTI_ORG);


### PR DESCRIPTION
### Features and Changes

In #1808 I added an env var to override the default `info` log level for the pino logger

`useLevel` is only actually used when instantiating the base pino logger, and it will pass whatever's passed onto the `level` of the httpLogger. Since we're directly instantiating an `httpLogger` here we need to use the `level` options param.

Additionally, the `const LOG_LEVEL` was being set before we actually loaded any local env vars (in the case of local development). So I moved the `LOG_LEVEL` instantiation to after the attempt to load local env vars.

### Testing

More local testing