### PR TITLE
Disable additional stats analyses by default (temporary)

### DIFF
--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -335,7 +335,10 @@ export function getAdditionalExperimentAnalysisSettings(
     ...defaultAnalysisSettings,
     differenceType: "scaled",
   });
-  return additionalAnalyses;
+
+  // Skip all of these additional analyses until we fix the performance issues
+  //return additionalAnalyses;
+  return [];
 }
 
 export function getSnapshotSettings({


### PR DESCRIPTION
Temporarily disable additional default stats analyses until we fix performance issues with #1823