### PR TITLE
Add Random On-Screen Celebration Service

### DIFF
--- a/packages/front-end/components/Experiment/StartExperimentBanner.tsx
+++ b/packages/front-end/components/Experiment/StartExperimentBanner.tsx
@@ -198,7 +198,7 @@ export function StartExperimentBanner({
   );
 
   async function startExperiment() {
-    startCelebration(enableCelebrations, 1);
+    startCelebration(enableCelebrations, 5);
     if (!experiment.phases?.length) {
       if (newPhase) {
         newPhase();

--- a/packages/front-end/components/Experiment/StartExperimentBanner.tsx
+++ b/packages/front-end/components/Experiment/StartExperimentBanner.tsx
@@ -198,7 +198,7 @@ export function StartExperimentBanner({
   );
 
   async function startExperiment() {
-    startCelebration(enableCelebrations, 5);
+    startCelebration(enableCelebrations);
     if (!experiment.phases?.length) {
       if (newPhase) {
         newPhase();

--- a/packages/front-end/components/Experiment/StartExperimentBanner.tsx
+++ b/packages/front-end/components/Experiment/StartExperimentBanner.tsx
@@ -8,6 +8,8 @@ import { FaCheckSquare, FaExternalLinkAlt, FaTimes } from "react-icons/fa";
 import { hasVisualChanges } from "shared/util";
 import track from "@/services/track";
 import { useAuth } from "@/services/auth";
+import { startCelebration } from "@/services/celebration";
+import { useLocalStorage } from "@/hooks/useLocalStorage";
 import Button from "../Button";
 import Tooltip from "../Tooltip/Tooltip";
 import ConfirmButton from "../Modal/ConfirmButton";
@@ -39,6 +41,10 @@ export function StartExperimentBanner({
   noConfirm?: boolean;
 }) {
   const { apiCall } = useAuth();
+  const [enableCelebrations] = useLocalStorage<boolean>(
+    `enable_growthbook_celebrations`,
+    true
+  );
 
   if (experiment.status !== "draft") return null;
 
@@ -192,6 +198,7 @@ export function StartExperimentBanner({
   );
 
   async function startExperiment() {
+    startCelebration(enableCelebrations, 1);
     if (!experiment.phases?.length) {
       if (newPhase) {
         newPhase();

--- a/packages/front-end/components/Layout/TopNav.tsx
+++ b/packages/front-end/components/Layout/TopNav.tsx
@@ -10,11 +10,14 @@ import { useUser } from "@/services/UserContext";
 import { useAuth } from "@/services/auth";
 import { usingSSO } from "@/services/env";
 import { useDefinitions } from "@/services/DefinitionsContext";
+import { useLocalStorage } from "@/hooks/useLocalStorage";
 import Modal from "../Modal";
 import Avatar from "../Avatar/Avatar";
 import ChangePasswordModal from "../Auth/ChangePasswordModal";
 import Field from "../Forms/Field";
 import OverflowText from "../Experiment/TabbedPage/OverflowText";
+import Toggle from "../Forms/Toggle";
+import Tooltip from "../Tooltip/Tooltip";
 import styles from "./TopNav.module.scss";
 import { ThemeToggler } from "./ThemeToggler/ThemeToggler";
 import AccountPlanBadge from "./AccountPlanBadge";
@@ -33,6 +36,10 @@ const TopNav: FC<{
   const [changePasswordOpen, setChangePasswordOpen] = useState(false);
   useGlobalMenu(".top-nav-user-menu", () => setUserDropdownOpen(false));
   useGlobalMenu(".top-nav-org-menu", () => setOrgDropdownOpen(false));
+  const [enableCelebrations, setEnableCelebrations] = useLocalStorage<boolean>(
+    `enable_growthbook_celebrations`,
+    true
+  );
 
   const { breadcrumb } = usePageHead();
 
@@ -43,16 +50,24 @@ const TopNav: FC<{
   const { apiCall, logout, organizations, orgId, setOrgId } = useAuth();
 
   const form = useForm({
-    defaultValues: { name: name || "" },
+    defaultValues: { name: name || "", enableCelebrations },
   });
 
-  const onSubmitEditName = form.handleSubmit(async (value) => {
-    await apiCall(`/user/name`, {
-      method: "PUT",
-      body: JSON.stringify(value),
-    });
-    updateUser();
-    setUserDropdownOpen(false);
+  const onSubmitEditProfile = form.handleSubmit(async (value) => {
+    // Update name if it changed
+    if (value.name !== name) {
+      await apiCall(`/user/name`, {
+        method: "PUT",
+        body: JSON.stringify(value),
+      });
+      updateUser();
+      setUserDropdownOpen(false);
+    }
+
+    // Update enableCelebrations value if it changed
+    if (value.enableCelebrations !== enableCelebrations) {
+      setEnableCelebrations(value.enableCelebrations);
+    }
   });
 
   let orgName = orgId || "";
@@ -73,11 +88,31 @@ const TopNav: FC<{
       {editUserOpen && (
         <Modal
           close={() => setEditUserOpen(false)}
-          submit={onSubmitEditName}
+          submit={onSubmitEditProfile}
           header="Edit Profile"
           open={true}
         >
           <Field label="Name" {...form.register("name")} />
+          {/* <Field
+            label="Disable celebration"
+            type="checkbox"
+            {...form.register("disableCelebration")}
+          /> */}
+          {/* <Field labe */}
+          <label className="mr-3">
+            Enable Celebrations{" "}
+            <Tooltip
+              body={
+                "GrowthBook adds on-screen confetti celebrations randomly when you complete certain actions like launching an experiment. You can disable this if you find it distracting."
+              }
+            />
+          </label>
+          <Toggle
+            id="disableCelebration"
+            label="Disable celebration"
+            value={form.watch("enableCelebrations")}
+            setValue={(v) => form.setValue("enableCelebrations", v)}
+          />
         </Modal>
       )}
       {changePasswordOpen && (

--- a/packages/front-end/package.json
+++ b/packages/front-end/package.json
@@ -47,6 +47,7 @@
     "dirty-json": "^0.9.2",
     "enterprise": "0.0.1",
     "fuse.js": "^6.6.2",
+    "js-confetti": "^0.11.0",
     "js-yaml": "^4.1.0",
     "json-stringify-pretty-compact": "^3.0.0",
     "json2csv": "^5.0.7",

--- a/packages/front-end/services/celebration.ts
+++ b/packages/front-end/services/celebration.ts
@@ -1,16 +1,16 @@
 import JSConfetti from "js-confetti";
 
-// likelihood indicates how likely it is that a celebration will occur. 1 is a 100% liklihood. 10 is a 10% likelihood.
+// randomness indicates how likely it is that a celebration will occur. 1 forces the celebration to fire, 5 means it'll fire 50% of the time. 10 means it'll fire 10% of the time.
 export function startCelebration(
   enableCelebration: boolean,
-  likelihood?: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10
+  randomness?: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10
 ) {
   if (!enableCelebration) return;
 
   const jsConfetti = new JSConfetti();
 
-  // Returns a non-zeo number between 1 and the likelihood. If likelihood is not provided, it defaults to 5.
-  const randomNumber = Math.floor(Math.random() * (likelihood || 5 - 1)) + 1;
+  // Returns a non-zeo number between 1 and "randomness". If randomness is not provided, it defaults to 5.
+  const randomNumber = Math.floor(Math.random() * (randomness || 5 - 1)) + 1;
 
   if (randomNumber === 1) {
     jsConfetti.addConfetti({

--- a/packages/front-end/services/celebration.ts
+++ b/packages/front-end/services/celebration.ts
@@ -1,0 +1,21 @@
+import JSConfetti from "js-confetti";
+
+// likelihood indicates how likely it is that a celebration will occur. 1 is a 100% liklihood. 10 is a 10% likelihood.
+export function startCelebration(
+  enableCelebration: boolean,
+  likelihood?: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10
+) {
+  if (!enableCelebration) return;
+
+  const jsConfetti = new JSConfetti();
+
+  // Returns a non-zeo number between 1 and the likelihood. If likelihood is not provided, it defaults to 5.
+  const randomNumber = Math.floor(Math.random() * (likelihood || 5 - 1)) + 1;
+
+  if (randomNumber === 1) {
+    jsConfetti.addConfetti({
+      confettiRadius: 4,
+      confettiNumber: 500,
+    });
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -14120,6 +14120,11 @@ joycon@^3.1.1:
   resolved "https://registry.yarnpkg.com/joycon/-/joycon-3.1.1.tgz#bce8596d6ae808f8b68168f5fc69280996894f03"
   integrity sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==
 
+js-confetti@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/js-confetti/-/js-confetti-0.11.0.tgz#5eb56dc23cba54be98b71afdc69a28bec61880a2"
+  integrity sha512-Hc7I3VI4r4H0nq5q/oQK+JJwGoYRYVHK72fGk8E9Ay1dbh+aiZ9yl0yFp1K4oYeq7YFDQAndYChwqLPA3QWQuA==
+
 js-md4@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/js-md4/-/js-md4-0.3.2.tgz#cd3b3dc045b0c404556c81ddb5756c23e59d7cf5"


### PR DESCRIPTION
### Features and Changes

This PR introduces a new library ([JSConfetti](https://www.npmjs.com/package/js-confetti)). Together, with a new `confetti` service, we can display on-screen celebrations when users complete key tasks (e.g. launch an experiment).

The `startCelebration` method within the `confetti` service does allow the randomness to be configurable from (10% - 100%). It defaults to 20%. So, currently, 20% of the time an organization launches an experiment, they'll get the on-screen celebration.

I did introduce a toggle within the user's edit profile modal that allows the user to disable the celebration, should they choose. This is currently handled via localStorage, rather than persisted in Mongo.

### Testing

- [ ] Add the celebration to the `startExperiment` method and configure the randomness to 1, and confirm that the celebration fires everytime.
- [ ] Remove the `randonmess` argument and ensure the celebration fires 20% of the time
- [ ] Disable the celebration and ensure it never fires

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
