### PR TITLE
Include Shopify and Webflow specifically in Visual Editor section

### DIFF
--- a/docs/docs/visual-editor.mdx
+++ b/docs/docs/visual-editor.mdx
@@ -140,7 +140,7 @@ If you've already been using our front-end SDKs for feature flagging, make sure 
 
 :::
 
-### Option 2: Pre-built Script Tag
+### Option 2: Pre-built Script Tag (best for Shopify, Webflow)
 
 This option is quick and easy and only requires the ability to insert a `<script>` tag into your site's source code. However, you do lose some flexibility compared to a full SDK integration.
 


### PR DESCRIPTION
### Features and Changes

Add references to Shopify and Webflow in the Visual Editor section so it's easy for people using those web platforms to find how to integrate GrowthBook.
