### PR TITLE
Only show Out of Date when adding metrics not in the snapshot

### DIFF
--- a/packages/front-end/components/Experiment/AnalysisSettingsBar.tsx
+++ b/packages/front-end/components/Experiment/AnalysisSettingsBar.tsx
@@ -545,6 +545,15 @@ function isDifferentStringArray(
   if (val1.length !== val2.length) return true;
   return val1.some((v) => !val2.includes(v));
 }
+function parentStringDoesNotContainAllChildrenValues(
+  parent?: string[] | null,
+  child?: string[] | null
+) {
+  if (!parent && !child) return false;
+  if (!parent || !child) return true;
+  if (child.length > parent.length) return true;
+  return child.some((v) => !parent.includes(v));
+}
 function isDifferentDate(val1: Date, val2: Date, threshold: number = 86400000) {
   // 86400000 = 1 day
   return Math.abs(val1.getTime() - val2.getTime()) >= threshold;
@@ -607,9 +616,9 @@ export function isOutdated(
     reasons.push("Attribution model changed");
   }
   if (
-    isDifferentStringArray(
-      [...experiment.metrics, ...(experiment?.guardrails || [])],
-      [...snapshotSettings.goalMetrics, ...snapshotSettings.guardrailMetrics]
+    parentStringDoesNotContainAllChildrenValues(
+      [...snapshotSettings.goalMetrics, ...snapshotSettings.guardrailMetrics],
+      [...experiment.metrics, ...(experiment?.guardrails || [])]
     )
   ) {
     reasons.push("Metrics changed");

--- a/packages/front-end/components/Experiment/AnalysisSettingsBar.tsx
+++ b/packages/front-end/components/Experiment/AnalysisSettingsBar.tsx
@@ -545,14 +545,13 @@ function isDifferentStringArray(
   if (val1.length !== val2.length) return true;
   return val1.some((v) => !val2.includes(v));
 }
-function parentStringDoesNotContainAllChildrenValues(
-  parent?: string[] | null,
-  child?: string[] | null
+function isStringArrayMissingElements(
+  strings: string[] = [],
+  elements: string[] = []
 ) {
-  if (!parent && !child) return false;
-  if (!parent || !child) return true;
-  if (child.length > parent.length) return true;
-  return child.some((v) => !parent.includes(v));
+  if (!elements) return false;
+  if (elements.length > strings.length) return true;
+  return elements.some((v) => !strings.includes(v));
 }
 function isDifferentDate(val1: Date, val2: Date, threshold: number = 86400000) {
   // 86400000 = 1 day
@@ -616,7 +615,7 @@ export function isOutdated(
     reasons.push("Attribution model changed");
   }
   if (
-    parentStringDoesNotContainAllChildrenValues(
+    isStringArrayMissingElements(
       [...snapshotSettings.goalMetrics, ...snapshotSettings.guardrailMetrics],
       [...experiment.metrics, ...(experiment?.guardrails || [])]
     )

--- a/packages/front-end/components/Experiment/AnalysisSettingsBar.tsx
+++ b/packages/front-end/components/Experiment/AnalysisSettingsBar.tsx
@@ -549,7 +549,7 @@ function isStringArrayMissingElements(
   strings: string[] = [],
   elements: string[] = []
 ) {
-  if (!elements) return false;
+  if (!elements.length) return false;
   if (elements.length > strings.length) return true;
   return elements.some((v) => !strings.includes(v));
 }


### PR DESCRIPTION
### Features and Changes

Now only show "Out of Date" on results when adding a metric that isn't there, rather than when removing a metric (which should be fine from the perspective of the user, for the most part).

This keeps "Out of Date" a bit more meaningful in the user's eyes.

### Screenshots

Current and new behavior in one loom: https://www.loom.com/share/0bb91643f4d04b5aaf5b76ae28f07a25?sid=515255c6-e99b-4f2a-9ae4-4ae2d4abbc79