### PR TITLE
Fix missing link when adding an existing feature to an experiment

### DIFF
--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -838,6 +838,13 @@ export async function postFeatureExperimentRefRule(
 
   await addLinkedExperiment(feature, experiment.id);
 
+  await addLinkedFeatureToExperiment(
+    org,
+    res.locals.eventAudit,
+    rule.experimentId,
+    feature.id
+  );
+
   res.status(200).json({
     status: 200,
     version: revision.version,

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -845,7 +845,7 @@ export async function postFeatureExperimentRefRule(
     };
 
     // Revision changes
-    changes.rules[env] = changes.rules[env] || [];
+    changes.rules[env] = feature.environmentSettings?.[env]?.rules || [];
     changes.rules[env].push(envRule);
 
     // Feature updates

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -22,7 +22,6 @@ import {
   updateFeature,
   archiveFeature,
   setJsonSchema,
-  addExperimentRefRule,
   deleteExperimentRefRule,
   publishRevision,
   migrateDraft,
@@ -35,6 +34,7 @@ import {
   addIdsToRules,
   arrayMove,
   evaluateFeature,
+  generateRuleId,
   getFeatureDefinitions,
 } from "../services/features";
 import { FeatureUsageRecords } from "../../types/realtime";
@@ -786,17 +786,14 @@ export async function postFeatureRule(
 }
 
 export async function postFeatureExperimentRefRule(
-  req: AuthRequest<
-    { rule: ExperimentRefRule },
-    { id: string; version: string }
-  >,
+  req: AuthRequest<{ rule: ExperimentRefRule }, { id: string }>,
   res: Response<
     { status: 200; version: number },
     EventAuditUserForResponseLocals
   >
 ) {
   const { org } = getOrgFromReq(req);
-  const { id, version } = req.params;
+  const { id } = req.params;
   const { rule } = req.body;
 
   if (
@@ -808,42 +805,101 @@ export async function postFeatureExperimentRefRule(
     throw new Error("Invalid experiment rule");
   }
 
+  const environments = org.settings?.environments || [];
+  const environmentIds = environments.map((e) => e.id);
+
+  if (!environmentIds.length) {
+    throw new Error(
+      "Must have at least one environment configured to use Feature Flags"
+    );
+  }
+
   const feature = await getFeature(org.id, id);
   if (!feature) {
     throw new Error("Could not find feature");
   }
 
   req.checkPermissions("manageFeatures", feature.project);
-  req.checkPermissions("createFeatureDrafts", feature.project);
+
+  req.checkPermissions(
+    "publishFeatures",
+    feature.project,
+    getEnabledEnvironments(feature)
+  );
 
   const experiment = await getExperimentById(org.id, rule.experimentId);
   if (!experiment) {
     throw new Error("Invalid experiment selected");
   }
 
-  const revision = await getDraftRevision(
-    org,
+  const updates: Partial<FeatureInterface> = {
+    environmentSettings: feature.environmentSettings,
+  };
+  const changes: Pick<FeatureRevisionInterface, "rules"> = {
+    rules: {},
+  };
+  environmentIds.forEach((env) => {
+    const envRule = {
+      ...rule,
+      id: generateRuleId(),
+    };
+
+    // Revision changes
+    changes.rules[env] = changes.rules[env] || [];
+    changes.rules[env].push(envRule);
+
+    // Feature updates
+    updates.environmentSettings = updates.environmentSettings || {};
+    updates.environmentSettings[env] = updates.environmentSettings[env] || {
+      enabled: false,
+      rules: [],
+    };
+    updates.environmentSettings[env].rules =
+      updates.environmentSettings[env].rules || [];
+    updates.environmentSettings[env].rules.push(envRule);
+  });
+
+  const revision = await createRevision({
     feature,
-    parseInt(version),
-    res.locals.eventAudit
-  );
+    user: res.locals.eventAudit,
+    baseVersion: feature.version,
+    publish: true,
+    changes,
+    comment: `Add Experiment - ${experiment.name}`,
+  });
 
-  await addExperimentRefRule(
+  updates.version = revision.version;
+
+  if (!updates.linkedExperiments?.includes(experiment.id)) {
+    updates.linkedExperiments = updates.linkedExperiments || [];
+    updates.linkedExperiments.push(experiment.id);
+  }
+
+  const updatedFeature = await updateFeature(
     org,
-    revision,
-    rule,
-    experiment.name,
-    res.locals.eventAudit
+    res.locals.eventAudit,
+    feature,
+    updates
   );
-
-  await addLinkedExperiment(feature, experiment.id);
 
   await addLinkedFeatureToExperiment(
     org,
     res.locals.eventAudit,
     rule.experimentId,
-    feature.id
+    feature.id,
+    experiment
   );
+
+  await req.audit({
+    event: "feature.update",
+    entity: {
+      object: "feature",
+      id: feature.id,
+    },
+    details: auditDetailsUpdate(feature, updatedFeature, {
+      revision: revision.version,
+    }),
+  });
 
   res.status(200).json({
     status: 200,

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -870,8 +870,8 @@ export async function postFeatureExperimentRefRule(
 
   updates.version = revision.version;
 
-  if (!updates.linkedExperiments?.includes(experiment.id)) {
-    updates.linkedExperiments = updates.linkedExperiments || [];
+  if (!feature.linkedExperiments?.includes(experiment.id)) {
+    updates.linkedExperiments = feature.linkedExperiments || [];
     updates.linkedExperiments.push(experiment.id);
   }
 

--- a/packages/back-end/src/models/ExperimentModel.ts
+++ b/packages/back-end/src/models/ExperimentModel.ts
@@ -893,12 +893,15 @@ export async function addLinkedFeatureToExperiment(
   organization: OrganizationInterface,
   user: EventAuditUser,
   experimentId: string,
-  featureId: string
+  featureId: string,
+  experiment?: ExperimentInterface | null
 ) {
-  const experiment = await findExperiment({
-    experimentId,
-    organizationId: organization.id,
-  });
+  if (!experiment) {
+    experiment = await findExperiment({
+      experimentId,
+      organizationId: organization.id,
+    });
+  }
 
   if (!experiment) return;
 

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -4,7 +4,6 @@ import omit from "lodash/omit";
 import isEqual from "lodash/isEqual";
 import { MergeResultChanges } from "shared/util";
 import {
-  ExperimentRefRule,
   FeatureEnvironment,
   FeatureInterface,
   FeatureRule,
@@ -632,46 +631,6 @@ export async function deleteExperimentRefRule(
       }),
     });
   }
-}
-
-export async function addExperimentRefRule(
-  org: OrganizationInterface,
-  revision: FeatureRevisionInterface,
-  rule: ExperimentRefRule,
-  experimentName: string,
-  user: EventAuditUser
-) {
-  if (!rule.id) {
-    rule.id = generateRuleId();
-  }
-
-  const environments = org.settings?.environments || [];
-  const environmentIds = environments.map((e) => e.id);
-
-  if (!environmentIds.length) {
-    throw new Error(
-      "Must have at least one environment configured to use Feature Flags"
-    );
-  }
-
-  const changes = {
-    rules: revision.rules || {},
-    comment: revision.comment || `Add experiment - ${experimentName}`,
-  };
-  environmentIds.forEach((env) => {
-    changes.rules[env] = changes.rules[env] || [];
-    changes.rules[env].push(rule);
-  });
-
-  await updateRevision(revision, changes, {
-    user,
-    action: "add experiment rule",
-    subject: `to all environments`,
-    value: JSON.stringify({
-      id: rule.experimentId,
-      name: experimentName,
-    }),
-  });
 }
 
 export async function editFeatureRule(

--- a/packages/front-end/components/Experiment/LinkedFeatureFlag.tsx
+++ b/packages/front-end/components/Experiment/LinkedFeatureFlag.tsx
@@ -4,26 +4,16 @@ import {
 } from "back-end/types/experiment";
 import { FaCheck, FaExclamationTriangle } from "react-icons/fa";
 import LinkedChange from "@/components/Experiment/LinkedChange";
-import { useAuth } from "@/services/auth";
 import Tooltip from "../Tooltip/Tooltip";
-import DeleteButton from "../DeleteButton/DeleteButton";
 import ForceSummary from "../Features/ForceSummary";
 
 type Props = {
   info: LinkedFeatureInfo;
   experiment: ExperimentInterfaceStringDates;
-  mutate: () => void;
   open?: boolean;
 };
 
-export default function LinkedFeatureFlag({
-  info,
-  experiment,
-  mutate,
-  open,
-}: Props) {
-  const { apiCall } = useAuth();
-
+export default function LinkedFeatureFlag({ info, experiment, open }: Props) {
   const orderedValues = experiment.variations.map((v) => {
     return info.values.find((v2) => v2.variationId === v.id)?.value || "";
   });
@@ -44,28 +34,6 @@ export default function LinkedFeatureFlag({
       open={open ?? experiment.status === "draft"}
     >
       <div className="mt-2 pb-1 px-3">
-        <div className="d-flex">
-          {experiment.status === "draft" && info.state === "draft" && (
-            <div className="ml-auto">
-              <DeleteButton
-                displayName="Feature Rule"
-                onClick={async () => {
-                  await apiCall(
-                    `/feature/${info.feature.id}/${info.feature.version}/experiment`,
-                    {
-                      method: "DELETE",
-                      body: JSON.stringify({
-                        experimentId: experiment.id,
-                      }),
-                    }
-                  );
-                  mutate();
-                }}
-              />
-            </div>
-          )}
-        </div>
-
         {info.state !== "locked" && (
           <div className="mb-3">
             <div className="font-weight-bold">Environments</div>

--- a/packages/front-end/components/Experiment/SinglePage.tsx
+++ b/packages/front-end/components/Experiment/SinglePage.tsx
@@ -1091,7 +1091,6 @@ export default function SinglePage({
                         info={info}
                         experiment={experiment}
                         key={i}
-                        mutate={mutate}
                       />
                     ))}
                     {experiment.status === "draft" &&

--- a/packages/front-end/components/Experiment/SinglePage.tsx
+++ b/packages/front-end/components/Experiment/SinglePage.tsx
@@ -546,6 +546,7 @@ export default function SinglePage({
         <FeatureFromExperimentModal
           experiment={experiment}
           close={() => setFeatureModal(false)}
+          mutate={mutate}
         />
       )}
       <div className="row align-items-center mb-1">

--- a/packages/front-end/components/Experiment/TabbedPage/Implementation.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/Implementation.tsx
@@ -109,7 +109,6 @@ export default function Implementation({
                     info={info}
                     experiment={experiment}
                     key={i}
-                    mutate={mutate}
                   />
                 ))}
                 {experiment.status === "draft" && hasVisualEditorPermission && (

--- a/packages/front-end/components/Experiment/TabbedPage/index.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/index.tsx
@@ -192,6 +192,7 @@ export default function TabbedPage({
         <FeatureFromExperimentModal
           experiment={experiment}
           close={() => setFeatureModal(false)}
+          mutate={mutate}
         />
       )}
       <ExperimentHeader

--- a/packages/front-end/components/Features/FeatureModal/FeatureFromExperimentModal.tsx
+++ b/packages/front-end/components/Features/FeatureModal/FeatureFromExperimentModal.tsx
@@ -39,6 +39,7 @@ export type Props = {
   cta?: string;
   secondaryCTA?: ReactElement;
   experiment: ExperimentInterfaceStringDates;
+  mutate: () => void;
 };
 
 function parseDefaultValue(
@@ -130,6 +131,7 @@ export default function FeatureFromExperimentModal({
   cta = "Create",
   secondaryCTA,
   experiment,
+  mutate,
 }: Props) {
   const { project, refreshTags } = useDefinitions();
   const environments = useEnvironments();
@@ -143,7 +145,7 @@ export default function FeatureFromExperimentModal({
     project,
   });
 
-  const { features, mutate } = useFeaturesList(false);
+  const { features, mutate: mutateFeatures } = useFeaturesList(false);
 
   // Skip features that already have this experiment
   // TODO: include features where the only reference to this experiment is an old revision
@@ -311,6 +313,7 @@ export default function FeatureFromExperimentModal({
         }
 
         await mutate();
+        await mutateFeatures();
       })}
     >
       <SelectField


### PR DESCRIPTION
When adding an existing feature to an experiment, the feature's `linkedExperiments` was being updated, but the experiment's `linkedFeatures` array was not.