### PR TITLE
WIP: Use central license server

### DIFF
--- a/packages/back-end/src/init/index.ts
+++ b/packages/back-end/src/init/index.ts
@@ -2,6 +2,8 @@ import { licenseInit } from "enterprise";
 import { logger } from "../util/logger";
 import mongoInit from "./mongo";
 import { queueInit } from "./queue";
+import { IS_CLOUD } from "../util/secrets";
+import { getAllUserLicenseCodes } from "../services/users";
 
 let initPromise: Promise<void>;
 export async function init() {
@@ -9,7 +11,10 @@ export async function init() {
     initPromise = (async () => {
       await mongoInit();
       await queueInit();
-      await licenseInit();
+      const allUserLicenseCodes = IS_CLOUD
+        ? []
+        : await getAllUserLicenseCodes();
+      await licenseInit(allUserLicenseCodes);
     })();
   }
   try {

--- a/packages/back-end/src/middleware/authenticateApiRequestMiddleware.ts
+++ b/packages/back-end/src/middleware/authenticateApiRequestMiddleware.ts
@@ -20,7 +20,8 @@ import { ApiKeyInterface } from "../../types/apikey";
 import { insertAudit } from "../models/AuditModel";
 import { getTeamsForOrganization } from "../models/TeamModel";
 import { TeamInterface } from "../../types/team";
-import { getUserById } from "../services/users";
+import { getAllUserLicenseCodes, getUserById } from "../services/users";
+import { IS_CLOUD } from "../util/secrets";
 
 export default function authenticateApiRequestMiddleware(
   req: Request & ApiRequestLocals,
@@ -166,8 +167,12 @@ export default function authenticateApiRequestMiddleware(
         });
       };
 
+      const allUserLicenseCodes = IS_CLOUD
+        ? []
+        : await getAllUserLicenseCodes();
+
       // init license for org if it exists
-      await licenseInit(req.organization.licenseKey);
+      await licenseInit(allUserLicenseCodes, req.organization.licenseKey);
 
       // Continue to the actual request handler
       next();

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -30,7 +30,7 @@ import {
   getNonSensitiveParams,
   getSourceIntegrationObject,
 } from "../../services/datasource";
-import { updatePassword } from "../../services/users";
+import { getAllUserLicenseCodes, updatePassword } from "../../services/users";
 import { getAllTags } from "../../models/TagModel";
 import {
   Invite,
@@ -615,7 +615,11 @@ export async function getOrganization(req: AuthRequest, res: Response) {
     const licenseData = getLicense();
     if (!licenseData || (licenseData.org && licenseData.org !== id)) {
       try {
-        await licenseInit(licenseKey);
+        const allUserLicenseCodes = IS_CLOUD
+          ? []
+          : await getAllUserLicenseCodes();
+
+        await licenseInit(allUserLicenseCodes, licenseKey);
       } catch (e) {
         // eslint-disable-next-line no-console
         console.error("setting license failed", e);
@@ -1745,7 +1749,9 @@ export async function putLicenseKey(
   let licenseData = null;
   try {
     // set new license
-    await licenseInit(licenseKey);
+    const allUserLicenseCodes = IS_CLOUD ? [] : await getAllUserLicenseCodes();
+
+    await licenseInit(allUserLicenseCodes, licenseKey);
     licenseData = getLicense();
   } catch (e) {
     // eslint-disable-next-line no-console

--- a/packages/back-end/src/services/auth/index.ts
+++ b/packages/back-end/src/services/auth/index.ts
@@ -8,7 +8,7 @@ import { getOrganizationById, validateLoginMethod } from "../organizations";
 import { Permission } from "../../../types/organization";
 import { UserInterface } from "../../../types/user";
 import { AuditInterface } from "../../../types/audit";
-import { getUserByEmail } from "../users";
+import { getAllUserLicenseCodes, getUserByEmail } from "../users";
 import { hasOrganization } from "../../models/OrganizationModel";
 import {
   IdTokenCookie,
@@ -187,8 +187,12 @@ export async function processJWT(
           return;
         }
 
+        const allUserLicenseCodes = IS_CLOUD
+          ? []
+          : await getAllUserLicenseCodes();
+
         // init license for org if it exists
-        await licenseInit(req.organization.licenseKey);
+        await licenseInit(allUserLicenseCodes, req.organization.licenseKey);
       } else {
         res.status(404).json({
           status: 404,


### PR DESCRIPTION
### Features and Changes
This change will allow new style license keys that begin with "license_" to instead call the licensing server to get at the license data.  Old keys will continue to work in the old way, which may be needed eternally for installations that don't have an internet connection.

TODO:
- [ ]  Change hard coded license server line to use the real central licensing server
- [ ]  Make the new format for licenseData to be the one that old keys used too, and change all the places where we access the license data.
- [ ] Change error handling

### Testing

visit localhost:3000.
See that with LICENSE_KEY set to an old style license key that the license information is included in the page header.
Set LICENSE_KEY to a new style key.
Restart the server.
Add an additional `logger.info("license data = " + JSON.stringify(licenseData));`
Change the `oneDayAgo` line in license.ts to be one minute ago instead.
visit localhost:3000.
See that with LICENSE_KEY set to an old style license key that the license information is included in the page header.
See that the logger line has all the licenseData filled out.
Refresh the page.
See no new logger line.
Wait a minute.
Refresh the page.
See new logger line.
