### PR TITLE
Expose the promise for the initial `refresh` that is automatically called on initialization of the Growthbook object

### DIFF
--- a/packages/sdk-js/src/GrowthBook.ts
+++ b/packages/sdk-js/src/GrowthBook.ts
@@ -52,6 +52,7 @@ export class GrowthBook<
   public debug: boolean;
   public ready: boolean;
   public version: string;
+  public initializationPromise: null | Promise<void>;
 
   // Properties and methods that start with "_" are mangled by Terser (saves ~150 bytes)
   private _ctx: Context;
@@ -138,8 +139,9 @@ export class GrowthBook<
     }
 
     if (context.clientKey && !context.remoteEval) {
-      this._refresh({}, true, false);
-    }
+      this.initializationPromise = this._refresh({}, true, false);
+    } else {
+      this.initializationPromise = null;
   }
 
   public async loadFeatures(options?: LoadFeaturesOptions): Promise<void> {


### PR DESCRIPTION
## The Bug

Because the `constructor` calls `refresh`, there's not currently a way to `await` for it to complete. This can result in a nasty race condition when offline (e.g. in react-native) w/ a populated cache, where `loadFeatures` returns too quickly, because `cacheInitialized` is already `true`, but the `localStorage.getItem` promise hasn't finished, so the cache isn't actually initialized. idk if that was clear, here's a rough repro:
```
// Simulate a very slow cache
setPolyfills({localStorage: {getItem(key) => new Promise(res => setTimeout(() => res(someCacheData), 1000)}})

const gb = new GrowthBook({clientKey: 'abcxyz'});
// ^ this kicks off a refresh(), which sets cacheInitialized (in feature-repository.ts) to `true`, but it's not yet initialized, is it

await gb.loadFeatures(); // features should be loaded, right??
// ^ but they're not, because the cache isn't actually fully initialized, but loadFeatures thinks that it has been.

const features = gb.getFeatures(); // oh noes, this is an empty object
```

### The Solution
Exposing the result of the `refresh` that's called in the constructor would allow us to do this:
```
setPolyfills({localStorage: {getItem(key) => new Promise(res => setTimeout(() => res(someCacheData), 1000)}})
const gb = new GrowthBook({clientKey: 'abcxyz'});
await gb. initializationPromise; // wait for the init to finish thanks
await gb.loadFeatures();
const features = gb.getFeatures(); // yay it works now
```

### An alternative solution

An alternate solution would be to change `cacheInitialized` to a promise that always gets awaited, and maybe that's what you want to do instead, in any case; exposing the refresh promise would provide a way to ensure that initialization has finished before calling e.g. `getFeatures`

### Another alternative solution:

Add an `option` to prevent calling the `refresh` in the constructor in the first place 🤷. And maybe have it default to not? idk calling an async function in a class constructor feels a little iffy.

### Testing

I can add a test for this if you like