### PR TITLE
No Access role

### DIFF
--- a/packages/back-end/src/util/organization.util.ts
+++ b/packages/back-end/src/util/organization.util.ts
@@ -30,6 +30,7 @@ export const PROJECT_SCOPED_PERMISSIONS = [
   "createDatasources",
   "editDatasourceSettings",
   "runQueries",
+  "readData",
 ] as const;
 
 export const GLOBAL_PERMISSIONS = [
@@ -270,9 +271,15 @@ export function getRoles(_organization: OrganizationInterface): Role[] {
   // TODO: support custom roles?
   return [
     {
+      id: "noaccess",
+      description:
+        "Cannot view any features or experiments. Most useful when combined with project-scoped roles.",
+      permissions: [],
+    },
+    {
       id: "readonly",
       description: "View all features and experiment results",
-      permissions: [],
+      permissions: ["readData"],
     },
     {
       id: "collaborator",

--- a/packages/back-end/types/organization.d.ts
+++ b/packages/back-end/types/organization.d.ts
@@ -30,6 +30,7 @@ export type UserPermissions = {
 };
 
 export type MemberRole =
+  | "noaccess"
   | "readonly"
   | "collaborator"
   | "designer"


### PR DESCRIPTION
### Overview

Add a new role below "readonly" that grants no access at all.

When combined with project-scoped roles, this will let you give a user access to a subset of projects in your organization. Any project the user doesn't have read access to (and all of the items within that project) will be completely hidden from them.

For example, give them the "No Access" role globally, and give them the "Experimenter" role for projects A and B.

### Changes
- [x] New role and permission
- [ ] Update front-end Team page to support new role
- [ ] Update all internal + REST endpoints to use the new permission (see below)
- [ ] When fetching projects, only return ones the user has access to
- [ ] On the front-end, remove the "All Projects" option if the user doesn't have `readData` permission globally

### Checking Permissions in Endpoints

The `readData` permission only applies to project-scoped items.  This includes:
- features
- experiments
- metrics
- fact tables
- data sources
- reports (through experiments / data source)
- sdk connections
- segments (through data sources)
- dimensions (through data sources)
- ideas
- projects

Any endpoint which returns any of the above should filter the returned data to exclude items the user does not have read access to.

For example, on the `/sdks` page, it makes a request to `GET /sdk-connections`.  If the user does not have a global `readData` permission, then filter the list of returned SDK connections to only include ones in a project where the user does have read access to.