### PR TITLE
Add new settings for the new health tab

### DIFF
--- a/packages/back-end/types/datasource.d.ts
+++ b/packages/back-end/types/datasource.d.ts
@@ -140,6 +140,7 @@ export interface ExposureQuery {
   query: string;
   hasNameCol?: boolean;
   dimensions: string[];
+  dimensionsForTraffic?: string[];
   error?: string;
 }
 

--- a/packages/back-end/types/organization.d.ts
+++ b/packages/back-end/types/organization.d.ts
@@ -170,6 +170,8 @@ export interface OrganizationSettings {
   pValueCorrection?: PValueCorrection;
   regressionAdjustmentEnabled?: boolean;
   regressionAdjustmentDays?: number;
+  runHealthTrafficQuery?: boolean;
+  srmThreshold?: number;
   /** @deprecated */
   implementationTypes?: ImplementationType[];
   attributionModel?: AttributionModel;

--- a/packages/front-end/components/Experiment/ManualSnapshotForm.tsx
+++ b/packages/front-end/components/Experiment/ManualSnapshotForm.tsx
@@ -14,9 +14,10 @@ import {
   getMetricFormatter,
 } from "@/services/metrics";
 import { trackSnapshot } from "@/services/track";
+import { DEFAULT_SRM_THRESHOLD } from "@/pages/settings";
+import { useUser } from "@/services/UserContext";
 import Modal from "../Modal";
 import Field from "../Forms/Field";
-import { SRM_THRESHOLD } from "./SRMWarning";
 
 type SnapshotPreview = {
   srm: number;
@@ -33,6 +34,8 @@ const ManualSnapshotForm: FC<{
   const { metrics, getMetricById } = useDefinitions();
   const { apiCall } = useAuth();
   const { getDatasourceById } = useDefinitions();
+  const { settings } = useUser();
+  const srmThreshold = settings.srmThreshold ?? DEFAULT_SRM_THRESHOLD;
 
   const filteredMetrics: MetricInterface[] = [];
 
@@ -254,7 +257,7 @@ const ManualSnapshotForm: FC<{
                 />
               </div>
             ))}
-            {preview && preview.srm < SRM_THRESHOLD && (
+            {preview && preview.srm < srmThreshold && (
               <div className="col-12">
                 <div className="my-2 alert alert-danger">
                   Sample Ratio Mismatch (SRM) detected. Please double check the

--- a/packages/front-end/components/Experiment/SRMWarning.tsx
+++ b/packages/front-end/components/Experiment/SRMWarning.tsx
@@ -1,8 +1,8 @@
 import { FC, useState } from "react";
 import { formatTrafficSplit, getSRMNeededPrecisionP1 } from "@/services/utils";
+import { useUser } from "@/services/UserContext";
+import { DEFAULT_SRM_THRESHOLD } from "@/pages/settings";
 import Modal from "../Modal";
-
-export const SRM_THRESHOLD = 0.001;
 
 const SRMWarning: FC<{
   srm: number;
@@ -10,8 +10,10 @@ const SRMWarning: FC<{
   observed: number[];
 }> = ({ srm, expected, observed }) => {
   const [open, setOpen] = useState(false);
+  const { settings } = useUser();
+  const srmThreshold = settings.srmThreshold ?? DEFAULT_SRM_THRESHOLD;
 
-  if (typeof srm !== "number" || srm >= SRM_THRESHOLD) {
+  if (typeof srm !== "number" || srm >= srmThreshold) {
     return null;
   }
 

--- a/packages/front-end/components/Experiment/UsersTable.tsx
+++ b/packages/front-end/components/Experiment/UsersTable.tsx
@@ -7,8 +7,9 @@ import {
 import { ImTable2 } from "react-icons/im";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import { formatTrafficSplit } from "@/services/utils";
+import { useUser } from "@/services/UserContext";
+import { DEFAULT_SRM_THRESHOLD } from "@/pages/settings";
 import Tooltip from "../Tooltip/Tooltip";
-import { DEFAULT } from "./SRMWarning";
 
 const numberFormatter = new Intl.NumberFormat();
 
@@ -25,7 +26,10 @@ const UsersTable: FC<{
     return getDimensionById(dimensionId)?.name || "Dimension";
   }, [getDimensionById, dimensionId]);
 
-  const hasSrm = (results || []).find((row) => row.srm < SRM_THRESHOLD);
+  const { settings } = useUser();
+  const srmThreshold = settings.srmThreshold ?? DEFAULT_SRM_THRESHOLD;
+
+  const hasSrm = (results || []).find((row) => row.srm < srmThreshold);
 
   if (!hasSrm && !expand) {
     return (
@@ -106,7 +110,7 @@ const UsersTable: FC<{
                   1
                 )}
               </td>
-              {r.srm < SRM_THRESHOLD ? (
+              {r.srm < srmThreshold ? (
                 <td className="bg-danger text-light">
                   <FaExclamationTriangle className="mr-1" />
                   {(r.srm || 0).toFixed(6)}

--- a/packages/front-end/components/Experiment/UsersTable.tsx
+++ b/packages/front-end/components/Experiment/UsersTable.tsx
@@ -8,7 +8,7 @@ import { ImTable2 } from "react-icons/im";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import { formatTrafficSplit } from "@/services/utils";
 import Tooltip from "../Tooltip/Tooltip";
-import { SRM_THRESHOLD } from "./SRMWarning";
+import { DEFAULT } from "./SRMWarning";
 
 const numberFormatter = new Intl.NumberFormat();
 

--- a/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/AddEditExperimentAssignmentQueryModal.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/AddEditExperimentAssignmentQueryModal.tsx
@@ -12,6 +12,7 @@ import Code from "@/components/SyntaxHighlighting/Code";
 import StringArrayField from "@/components/Forms/StringArrayField";
 import Toggle from "@/components/Forms/Toggle";
 import Tooltip from "@/components/Tooltip/Tooltip";
+import MultiSelectField from "@/components/Forms/MultiSelectField";
 import Modal from "../../../Modal";
 import Field from "../../../Forms/Field";
 import EditSqlModal from "../../../SchemaBrowser/EditSqlModal";
@@ -52,7 +53,7 @@ export const AddEditExperimentAssignmentQueryModal: FC<EditExperimentAssignmentQ
 
   const defaultQuery = `SELECT\n  ${defaultUserId} as ${defaultUserId},\n  timestamp as timestamp,\n  experiment_id as experiment_id,\n  variation_id as variation_id\nFROM my_table`;
 
-  const form = useForm<ExposureQuery>({
+  const form = useForm<ExposureQuery & { dimensionsForTraffic: string[] }>({
     defaultValues:
       mode === "edit" && exposureQuery
         ? cloneDeep<ExposureQuery>(exposureQuery)
@@ -61,6 +62,7 @@ export const AddEditExperimentAssignmentQueryModal: FC<EditExperimentAssignmentQ
             id: uniqId("tbl_"),
             name: "",
             dimensions: [],
+            dimensionsForTraffic: [],
             query: defaultQuery,
             userIdType: userIdTypeOptions ? userIdTypeOptions[0]?.value : "",
           },
@@ -321,6 +323,23 @@ export const AddEditExperimentAssignmentQueryModal: FC<EditExperimentAssignmentQ
                       onChange={(dimensions) => {
                         form.setValue("dimensions", dimensions);
                       }}
+                    />
+                    <MultiSelectField
+                      label="Dimensions to use in traffic breakdowns"
+                      value={form.watch("dimensionsForTraffic") || []}
+                      onChange={(ids) => {
+                        const newValue = [...value];
+                        newValue[i] = { ...v };
+                        newValue[i].ids = ids;
+                        setValue(newValue);
+                      }}
+                      options={form.watch("dimensions").map((s) => ({
+                        value: s,
+                        label: s,
+                      }))}
+                      required
+                      placeholder="Select dimensions..."
+                      closeMenuOnSelect={true}
                     />
                   </div>
                 )}

--- a/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/AddEditExperimentAssignmentQueryModal.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/AddEditExperimentAssignmentQueryModal.tsx
@@ -76,6 +76,7 @@ export const AddEditExperimentAssignmentQueryModal: FC<EditExperimentAssignmentQ
   const userEnteredQuery = form.watch("query");
   const userEnteredDimensions = form.watch("dimensions");
   const userEnteredHasNameCol = form.watch("hasNameCol");
+  const userEnteredDimsForTraffic = form.watch("dimensionsForTraffic");
 
   const handleSubmit = form.handleSubmit(async (value) => {
     await onSave(value);
@@ -325,12 +326,20 @@ export const AddEditExperimentAssignmentQueryModal: FC<EditExperimentAssignmentQ
                       value={userEnteredDimensions}
                       onChange={(dimensions) => {
                         form.setValue("dimensions", dimensions);
+                        if (userEnteredDimsForTraffic?.length) {
+                          form.setValue(
+                            "dimensionsForTraffic",
+                            userEnteredDimsForTraffic.filter((d) =>
+                              userEnteredDimensions.includes(d)
+                            )
+                          );
+                        }
                       }}
                     />
                     {healthTabSettingsEnabled && (
                       <MultiSelectField
                         label="Dimensions to use in traffic breakdowns"
-                        value={form.watch("dimensionsForTraffic") || []}
+                        value={userEnteredDimsForTraffic || []}
                         onChange={(dimensions) => {
                           form.setValue("dimensionsForTraffic", dimensions);
                         }}

--- a/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/AddEditExperimentAssignmentQueryModal.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/AddEditExperimentAssignmentQueryModal.tsx
@@ -84,10 +84,7 @@ export const AddEditExperimentAssignmentQueryModal: FC<EditExperimentAssignmentQ
   const userEnteredDimsForTraffic = form.watch("dimensionsForTraffic");
 
   const handleSubmit = form.handleSubmit(async (value) => {
-    // Do a JIT migration if user doesn't supply any dimensions for traffic
-    await onSave(
-      userEnteredDimsForTraffic ? value : { ...value, dimensionsForTraffic: [] }
-    );
+    await onSave(value);
 
     form.reset({
       id: undefined,

--- a/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/AddEditExperimentAssignmentQueryModal.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/AddEditExperimentAssignmentQueryModal.tsx
@@ -8,11 +8,13 @@ import cloneDeep from "lodash/cloneDeep";
 import uniqId from "uniqid";
 import { FaExclamationTriangle, FaExternalLinkAlt } from "react-icons/fa";
 import { TestQueryRow } from "back-end/src/types/Integration";
+import { useFeatureIsOn } from "@growthbook/growthbook-react";
 import Code from "@/components/SyntaxHighlighting/Code";
 import StringArrayField from "@/components/Forms/StringArrayField";
 import Toggle from "@/components/Forms/Toggle";
 import Tooltip from "@/components/Tooltip/Tooltip";
 import MultiSelectField from "@/components/Forms/MultiSelectField";
+import { AppFeatures } from "@/types/app-features";
 import Modal from "../../../Modal";
 import Field from "../../../Forms/Field";
 import EditSqlModal from "../../../SchemaBrowser/EditSqlModal";
@@ -34,6 +36,7 @@ export const AddEditExperimentAssignmentQueryModal: FC<EditExperimentAssignmentQ
 }) => {
   const [showAdvancedMode, setShowAdvancedMode] = useState(false);
   const [sqlOpen, setSqlOpen] = useState(false);
+  const healthTabSettingsEnabled = useFeatureIsOn<AppFeatures>("health-tab");
   const modalTitle =
     mode === "add"
       ? "Add an Experiment Assignment query"
@@ -53,7 +56,7 @@ export const AddEditExperimentAssignmentQueryModal: FC<EditExperimentAssignmentQ
 
   const defaultQuery = `SELECT\n  ${defaultUserId} as ${defaultUserId},\n  timestamp as timestamp,\n  experiment_id as experiment_id,\n  variation_id as variation_id\nFROM my_table`;
 
-  const form = useForm<ExposureQuery & { dimensionsForTraffic: string[] }>({
+  const form = useForm<ExposureQuery>({
     defaultValues:
       mode === "edit" && exposureQuery
         ? cloneDeep<ExposureQuery>(exposureQuery)
@@ -324,20 +327,22 @@ export const AddEditExperimentAssignmentQueryModal: FC<EditExperimentAssignmentQ
                         form.setValue("dimensions", dimensions);
                       }}
                     />
-                    <MultiSelectField
-                      label="Dimensions to use in traffic breakdowns"
-                      value={form.watch("dimensionsForTraffic") || []}
-                      onChange={(dimensions) => {
-                        form.setValue("dimensionsForTraffic", dimensions);
-                      }}
-                      options={form.watch("dimensions").map((s) => ({
-                        value: s,
-                        label: s,
-                      }))}
-                      required
-                      placeholder="Select dimensions..."
-                      closeMenuOnSelect={true}
-                    />
+                    {healthTabSettingsEnabled && (
+                      <MultiSelectField
+                        label="Dimensions to use in traffic breakdowns"
+                        value={form.watch("dimensionsForTraffic") || []}
+                        onChange={(dimensions) => {
+                          form.setValue("dimensionsForTraffic", dimensions);
+                        }}
+                        options={form.watch("dimensions").map((s) => ({
+                          value: s,
+                          label: s,
+                        }))}
+                        required
+                        placeholder="Select dimensions..."
+                        closeMenuOnSelect={true}
+                      />
+                    )}
                   </div>
                 )}
               </div>

--- a/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/AddEditExperimentAssignmentQueryModal.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/AddEditExperimentAssignmentQueryModal.tsx
@@ -327,11 +327,8 @@ export const AddEditExperimentAssignmentQueryModal: FC<EditExperimentAssignmentQ
                     <MultiSelectField
                       label="Dimensions to use in traffic breakdowns"
                       value={form.watch("dimensionsForTraffic") || []}
-                      onChange={(ids) => {
-                        const newValue = [...value];
-                        newValue[i] = { ...v };
-                        newValue[i].ids = ids;
-                        setValue(newValue);
+                      onChange={(dimensions) => {
+                        form.setValue("dimensionsForTraffic", dimensions);
                       }}
                       options={form.watch("dimensions").map((s) => ({
                         value: s,

--- a/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/AddEditExperimentAssignmentQueryModal.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/AddEditExperimentAssignmentQueryModal.tsx
@@ -19,6 +19,7 @@ import { useUser } from "@/services/UserContext";
 import Modal from "../../../Modal";
 import Field from "../../../Forms/Field";
 import EditSqlModal from "../../../SchemaBrowser/EditSqlModal";
+import { TrafficDimensionsTooltip } from "./TrafficDimensionsTooltip";
 
 type EditExperimentAssignmentQueryProps = {
   exposureQuery?: ExposureQuery;
@@ -346,7 +347,14 @@ export const AddEditExperimentAssignmentQueryModal: FC<EditExperimentAssignmentQ
                     />
                     {showDimensionsForTraffic && (
                       <MultiSelectField
-                        label="Dimensions to use in traffic breakdowns"
+                        label={
+                          <>
+                            <span className="mr-2">
+                              Dimensions to use in traffic breakdowns
+                            </span>
+                            <TrafficDimensionsTooltip />
+                          </>
+                        }
                         value={userEnteredDimsForTraffic || []}
                         onChange={(dimensions) => {
                           form.setValue("dimensionsForTraffic", dimensions);

--- a/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/TrafficDimensionsTooltip.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/TrafficDimensionsTooltip.tsx
@@ -1,0 +1,26 @@
+import { ReactNode } from "react";
+import Tooltip from "@/components/Tooltip/Tooltip";
+
+export function TrafficDimensionsTooltip({
+  children,
+}: {
+  children?: ReactNode;
+}) {
+  return (
+    <Tooltip
+      body={
+        <div>
+          Whenever your overall snapshot analysis updates, we will execute
+          another query to pre-compute your overall traffic splits and
+          dimension-specific traffic splits. This setting selects which
+          dimension splits we compute by default. More dimensions, especially
+          those with high cardinality, might cause errors computing traffic
+          results by returning too many rows. For more, see the{" "}
+          <a>[docs here]</a>.
+        </div>
+      }
+    >
+      {children}
+    </Tooltip>
+  );
+}

--- a/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/TrafficDimensionsTooltip.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/TrafficDimensionsTooltip.tsx
@@ -15,8 +15,7 @@ export function TrafficDimensionsTooltip({
           dimension-specific traffic splits. This setting selects which
           dimension splits we compute by default. More dimensions, especially
           those with high cardinality, might cause errors computing traffic
-          results by returning too many rows. For more, see the{" "}
-          <a>[docs here]</a>.
+          results by returning too many rows.
         </div>
       }
     >

--- a/packages/front-end/pages/settings/index.tsx
+++ b/packages/front-end/pages/settings/index.tsx
@@ -465,8 +465,10 @@ const GeneralSettingsPage = (): React.ReactElement => {
       : "";
 
   const srmHighlightColor =
-    // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
-    value.srmThreshold > 0.01 || value.srmThreshold < 0.001 ? "#B39F01" : "";
+    value.srmThreshold &&
+    (value.srmThreshold > 0.01 || value.srmThreshold < 0.001)
+      ? "#B39F01"
+      : "";
 
   const regressionAdjustmentDaysHighlightColor =
     // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
@@ -509,11 +511,9 @@ const GeneralSettingsPage = (): React.ReactElement => {
       : "";
 
   const srmWarningMsg =
-    // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
-    value.srmThreshold > 0.01
+    value.srmThreshold && value.srmThreshold > 0.01
       ? "Thresholds above 0.01 may lead to many false positives, especially if you refresh results regularly"
-      : // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
-      value.srmThreshold < 0.001
+      : value.srmThreshold && value.srmThreshold < 0.001
       ? "Thresholds below 0.001 may make it hard to detect imbalances without lots of traffic."
       : "";
 

--- a/packages/front-end/pages/settings/index.tsx
+++ b/packages/front-end/pages/settings/index.tsx
@@ -348,6 +348,8 @@ const GeneralSettingsPage = (): React.ReactElement => {
     secondaryColor: form.watch("secondaryColor"),
     northStar: form.watch("northStar"),
     updateSchedule: form.watch("updateSchedule"),
+    runHealthTrafficQuery: form.watch("runHealthTrafficQuery"),
+    srmThreshold: form.watch("srmThreshold"),
     multipleExposureMinPercent: form.watch("multipleExposureMinPercent"),
     statsEngine: form.watch("statsEngine"),
     confidenceLevel: form.watch("confidenceLevel"),
@@ -462,6 +464,10 @@ const GeneralSettingsPage = (): React.ReactElement => {
       ? "#B39F01"
       : "";
 
+  const srmHighlightColor =
+    // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
+    value.srmThreshold > 0.01 || value.srmThreshold < 0.001 ? "#B39F01" : "";
+
   const regressionAdjustmentDaysHighlightColor =
     // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
     value.regressionAdjustmentDays > 28 || value.regressionAdjustmentDays < 7
@@ -500,6 +506,15 @@ const GeneralSettingsPage = (): React.ReactElement => {
       : // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
       value.pValueThreshold <= 0.01
       ? "Threshold values of 0.01 and lower can take lots of data to achieve"
+      : "";
+
+  const srmWarningMsg =
+    // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
+    value.srmThreshold > 0.01
+      ? "Thresholds above 0.01 may lead to many false positives, especially if you refresh results regularly"
+      : // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
+      value.srmThreshold < 0.001
+      ? "Thresholds below 0.001 may make it hard to detect imbalances without lots of traffic."
       : "";
 
   const regressionAdjustmentDaysWarningMsg =
@@ -921,14 +936,31 @@ const GeneralSettingsPage = (): React.ReactElement => {
                         label="SRM threshold"
                         type="number"
                         step="0.001"
-                        max="0.5"
-                        min="0.001"
+                        style={{
+                          borderColor: srmHighlightColor,
+                          backgroundColor: srmHighlightColor
+                            ? srmHighlightColor + "15"
+                            : "",
+                        }}
+                        max="0.1"
+                        min="0.00001"
                         className={`ml-2`}
                         containerClassName="mb-3"
                         append=""
                         disabled={hasFileConfig()}
                         helpText={
-                          <span className="ml-2">(0.001 is default)</span>
+                          <>
+                            <span className="ml-2">(0.001 is default)</span>
+                            <div
+                              className="ml-2"
+                              style={{
+                                color: srmHighlightColor,
+                                flexBasis: "100%",
+                              }}
+                            >
+                              {srmWarningMsg}
+                            </div>
+                          </>
                         }
                         {...form.register("srmThreshold", {
                           valueAsNumber: true,

--- a/packages/front-end/pages/settings/index.tsx
+++ b/packages/front-end/pages/settings/index.tsx
@@ -223,6 +223,8 @@ export const supportedCurrencies = {
   ZWL: "Zimbabwe Dollar (ZWL)",
 };
 
+export const DEFAULT_SRM_THRESHOLD = 0.001;
+
 function hasChanges(
   value: OrganizationSettings,
   existing: OrganizationSettings
@@ -311,7 +313,7 @@ const GeneralSettingsPage = (): React.ReactElement => {
         cron: "0 */6 * * *",
       },
       runHealthTrafficQuery: true,
-      srmThreshold: 0.001,
+      srmThreshold: DEFAULT_SRM_THRESHOLD,
       multipleExposureMinPercent: 0.01,
       confidenceLevel: 0.95,
       pValueThreshold: DEFAULT_P_VALUE_THRESHOLD,

--- a/packages/front-end/pages/settings/index.tsx
+++ b/packages/front-end/pages/settings/index.tsx
@@ -512,7 +512,7 @@ const GeneralSettingsPage = (): React.ReactElement => {
 
   const srmWarningMsg =
     value.srmThreshold && value.srmThreshold > 0.01
-      ? "Thresholds above 0.01 may lead to many false positives, especially if you refresh results regularly"
+      ? "Thresholds above 0.01 may lead to many false positives, especially if you refresh results regularly."
       : value.srmThreshold && value.srmThreshold < 0.001
       ? "Thresholds below 0.001 may make it hard to detect imbalances without lots of traffic."
       : "";

--- a/packages/front-end/pages/settings/index.tsx
+++ b/packages/front-end/pages/settings/index.tsx
@@ -902,7 +902,7 @@ const GeneralSettingsPage = (): React.ReactElement => {
                           className="mr-1"
                           htmlFor="toggle-runHealthTrafficQuery"
                         >
-                          Run health traffic query by default
+                          Run traffic query by default
                         </label>
                       </div>
                       <div>

--- a/packages/front-end/pages/settings/index.tsx
+++ b/packages/front-end/pages/settings/index.tsx
@@ -20,7 +20,7 @@ import {
 } from "shared/constants";
 import { OrganizationSettings } from "@/../back-end/types/organization";
 import Link from "next/link";
-import { useGrowthBook } from "@growthbook/growthbook-react";
+import { useFeatureIsOn, useGrowthBook } from "@growthbook/growthbook-react";
 import { useAuth } from "@/services/auth";
 import EditOrganizationModal from "@/components/Settings/EditOrganizationModal";
 import BackupConfigYamlButton from "@/components/Settings/BackupConfigYamlButton";
@@ -251,6 +251,7 @@ const GeneralSettingsPage = (): React.ReactElement => {
   const displayCurrency = useCurrency();
   const growthbook = useGrowthBook<AppFeatures>();
   const { datasources } = useDefinitions();
+  const healthTabSettingsEnabled = useFeatureIsOn<AppFeatures>("health-tab");
 
   const currencyOptions = Object.entries(
     supportedCurrencies
@@ -309,6 +310,8 @@ const GeneralSettingsPage = (): React.ReactElement => {
         hours: 6,
         cron: "0 */6 * * *",
       },
+      runHealthTrafficQuery: true,
+      srmThreshold: 0.001,
       multipleExposureMinPercent: 0.01,
       confidenceLevel: 0.95,
       pValueThreshold: DEFAULT_P_VALUE_THRESHOLD,
@@ -892,6 +895,48 @@ const GeneralSettingsPage = (): React.ReactElement => {
                       </div>
                     )}
                   </div>
+                  {healthTabSettingsEnabled && (
+                    <>
+                      <div>
+                        <label
+                          className="mr-1"
+                          htmlFor="toggle-runHealthTrafficQuery"
+                        >
+                          Run health traffic query by default
+                        </label>
+                      </div>
+                      <div>
+                        <Toggle
+                          id={"toggle-runHealthTrafficQuery"}
+                          value={!!form.watch("runHealthTrafficQuery")}
+                          setValue={(value) => {
+                            form.setValue("runHealthTrafficQuery", value);
+                          }}
+                        />
+                      </div>
+
+                      <Field
+                        label="SRM threshold"
+                        type="number"
+                        step="0.001"
+                        max="0.5"
+                        min="0.001"
+                        className={`ml-2`}
+                        containerClassName="mb-3"
+                        append=""
+                        disabled={hasFileConfig()}
+                        helpText={
+                          <span className="ml-2">(0.001 is default)</span>
+                        }
+                        {...form.register("srmThreshold", {
+                          valueAsNumber: true,
+                          min: 0,
+                          max: 1,
+                        })}
+                      />
+                    </>
+                  )}
+
                   <StatsEngineSelect
                     label="Default Statistics Engine"
                     allowUndefined={false}

--- a/packages/front-end/types/app-features.ts
+++ b/packages/front-end/types/app-features.ts
@@ -38,4 +38,5 @@ export type AppFeatures = {
   "gbdemo-checkout-layout": string;
   "datasource-pipeline-mode": boolean;
   "fact-tables": boolean;
+  "health-tab": boolean;
 };


### PR DESCRIPTION
### Features and Changes

Adds three new settings behind a feature flag:

Organization Settings

- Run traffic query by default (Enabled by default)
- SRM Threshold (0.001 by default)

Data Source Exposure Query Settings

- Dimensions to use in traffic breakdown (empty by default) 

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

<!--
  Please describe how to test these changes.
 -->

- Make sure changes to the new organization settings are persisted
- Make sure the value for `Dimensions to use in traffic breakdown` is changed when on of its values is removed from `Dimensions` (i.e. country is one of the traffic dimensions but its removed from dimensions so we'll want to remove it from traffic dimensions as well) 

### Screenshots

![Screenshot 2023-11-14 at 11 29 52 AM](https://github.com/growthbook/growthbook/assets/14947905/57804f85-73ce-439a-a8a9-ac885811d072)

![Screenshot 2023-11-14 at 11 30 05 AM](https://github.com/growthbook/growthbook/assets/14947905/30bac44b-c040-48c2-bf6e-0a1ea84d577f)

### To-Do

- [x] Need to hook up the SRM threshold setting to the SRM warning
- [x] Fix old references to `SRM_THRESHOLD` and have the srmThreshold setting either return the value in mongo or the default