### PR TITLE
Cancel link now actually cancels queries in BigQuery/Athena

### DIFF
--- a/packages/back-end/src/integrations/Athena.ts
+++ b/packages/back-end/src/integrations/Athena.ts
@@ -1,6 +1,6 @@
 import { decryptDataSourceParams } from "../services/datasource";
-import { runAthenaQuery } from "../services/athena";
-import { QueryResponse } from "../types/Integration";
+import { cancelAthenaQuery, runAthenaQuery } from "../services/athena";
+import { ExternalIdCallback, QueryResponse } from "../types/Integration";
 import { AthenaConnectionParams } from "../../types/integrations/athena";
 import { FormatDialect } from "../util/sql";
 import SqlIntegration from "./SqlIntegration";
@@ -24,8 +24,14 @@ export default class Athena extends SqlIntegration {
   toTimestamp(date: Date) {
     return `from_iso8601_timestamp('${date.toISOString()}')`;
   }
-  runQuery(sql: string): Promise<QueryResponse> {
-    return runAthenaQuery(this.params, sql);
+  runQuery(
+    sql: string,
+    setExternalId: ExternalIdCallback
+  ): Promise<QueryResponse> {
+    return runAthenaQuery(this.params, sql, setExternalId);
+  }
+  async cancelQuery(externalId: string): Promise<void> {
+    await cancelAthenaQuery(this.params, externalId);
   }
   addTime(
     col: string,

--- a/packages/back-end/src/models/ImpactEstimateModel.ts
+++ b/packages/back-end/src/models/ImpactEstimateModel.ts
@@ -94,7 +94,13 @@ export async function getImpactEstimate(
     segment: segmentObj || undefined,
   });
 
-  const queryResponse = await integration.runMetricValueQuery(query);
+  const queryResponse = await integration.runMetricValueQuery(
+    query,
+    // We're not storing a query in Mongo for this, so we don't support cancelling here
+    async () => {
+      // Ignore calls to setExternalId
+    }
+  );
   const value = processMetricValueQueryResponse(queryResponse.rows);
 
   let daysWithData = numDays;

--- a/packages/back-end/src/models/QueryModel.ts
+++ b/packages/back-end/src/models/QueryModel.ts
@@ -34,6 +34,7 @@ const querySchema = new mongoose.Schema({
   startedAt: Date,
   finishedAt: Date,
   heartbeat: Date,
+  externalId: String,
   result: {},
   rawResult: [],
   error: String,

--- a/packages/back-end/src/queryRunners/ExperimentResultsQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentResultsQueryRunner.ts
@@ -128,7 +128,8 @@ export const startExperimentResultQueries = async (
       name: queryParentId,
       query: integration.getExperimentUnitsTableQuery(unitQueryParams),
       dependencies: [],
-      run: (query) => integration.runExperimentUnitsQuery(query),
+      run: (query, setExternalId) =>
+        integration.runExperimentUnitsQuery(query, setExternalId),
       process: (rows) => rows,
     });
     queries.push(unitQuery);
@@ -162,7 +163,8 @@ export const startExperimentResultQueries = async (
         name: m.id,
         query: integration.getExperimentMetricQuery(queryParams),
         dependencies: unitQuery ? [unitQuery.query] : [],
-        run: (query) => integration.runExperimentMetricQuery(query),
+        run: (query, setExternalId) =>
+          integration.runExperimentMetricQuery(query, setExternalId),
         process: (rows) => rows,
       })
     );

--- a/packages/back-end/src/queryRunners/MetricAnalysisQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/MetricAnalysisQueryRunner.ts
@@ -21,7 +21,8 @@ export class MetricAnalysisQueryRunner extends QueryRunner<
         name: "metric",
         query: this.integration.getMetricValueQuery(params),
         dependencies: [],
-        run: (query) => this.integration.runMetricValueQuery(query),
+        run: (query, setExternalId) =>
+          this.integration.runMetricValueQuery(query, setExternalId),
         process: (rows) => processMetricValueQueryResponse(rows),
       }),
     ];

--- a/packages/back-end/src/queryRunners/PastExperimentsQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/PastExperimentsQueryRunner.ts
@@ -26,7 +26,8 @@ export class PastExperimentsQueryRunner extends QueryRunner<
         name: "experiments",
         query: this.integration.getPastExperimentQuery(params),
         dependencies: [],
-        run: (query) => this.integration.runPastExperimentQuery(query),
+        run: (query, setExternalId) =>
+          this.integration.runPastExperimentQuery(query, setExternalId),
         process: (rows) => this.processPastExperimentQueryResponse(rows),
       }),
     ];

--- a/packages/back-end/src/queryRunners/QueryRunner.ts
+++ b/packages/back-end/src/queryRunners/QueryRunner.ts
@@ -13,10 +13,12 @@ import {
   updateQuery,
 } from "../models/QueryModel";
 import {
+  ExternalIdCallback,
   QueryResponse,
   SourceIntegrationInterface,
 } from "../types/Integration";
 import { logger } from "../util/logger";
+import { promiseAllChunks } from "../util/promise";
 
 export type QueryMap = Map<string, QueryInterface>;
 
@@ -44,7 +46,10 @@ export type StartQueryParams<Rows, ProcessedRows> = {
   name: string;
   query: string;
   dependencies: string[];
-  run: (query: string) => Promise<QueryResponse<Rows>>;
+  run: (
+    query: string,
+    setExternalId: ExternalIdCallback
+  ) => Promise<QueryResponse<Rows>>;
   process: (rows: Rows) => ProcessedRows;
 };
 
@@ -84,7 +89,10 @@ export abstract class QueryRunner<
   public error = "";
   public runCallbacks: {
     [key: string]: {
-      run: (query: string) => Promise<QueryResponse<RowsType>>;
+      run: (
+        query: string,
+        setExternalId: ExternalIdCallback
+      ) => Promise<QueryResponse<RowsType>>;
       process: (rows: RowsType) => ProcessedRowsType;
     };
   } = {};
@@ -359,6 +367,35 @@ export abstract class QueryRunner<
         (q) => q.status === "running" || q.status === "queued"
       )
     ) {
+      const runningIds = this.model.queries
+        .filter((q) => q.status === "running")
+        .map((q) => q.query);
+
+      if (runningIds) {
+        const queryDocs = await getQueriesByIds(
+          this.model.organization,
+          runningIds
+        );
+
+        const externalIds = queryDocs.map((q) => q.externalId).filter(Boolean);
+
+        if (externalIds.length) {
+          await promiseAllChunks(
+            externalIds.map((id) => {
+              return async () => {
+                if (!id || !this.integration.cancelQuery) return;
+                try {
+                  await this.integration.cancelQuery(id);
+                } catch (e) {
+                  logger.debug(`Failed to cancel query - ${e.message}`);
+                }
+              };
+            }),
+            5
+          );
+        }
+      }
+
       const newModel = await this.updateModel({
         queries: [],
         status: "failed",
@@ -375,7 +412,10 @@ export abstract class QueryRunner<
     ProcessedRows extends ProcessedRowsType
   >(
     doc: QueryInterface,
-    run: (query: string) => Promise<QueryResponse<Rows>>,
+    run: (
+      query: string,
+      setExternalId: ExternalIdCallback
+    ) => Promise<QueryResponse<Rows>>,
     process: (rows: Rows) => ProcessedRows
   ): Promise<void> {
     // Update heartbeat for the query once every 30 seconds
@@ -395,7 +435,13 @@ export abstract class QueryRunner<
       });
     }
 
-    run(doc.query)
+    const setExternalId = async (id: string) => {
+      await updateQuery(doc, {
+        externalId: id,
+      });
+    };
+
+    run(doc.query, setExternalId)
       .then(async ({ rows, statistics }) => {
         clearInterval(timer);
         logger.debug("Query succeeded");

--- a/packages/back-end/src/queryRunners/QueryRunner.ts
+++ b/packages/back-end/src/queryRunners/QueryRunner.ts
@@ -371,7 +371,7 @@ export abstract class QueryRunner<
         .filter((q) => q.status === "running")
         .map((q) => q.query);
 
-      if (runningIds) {
+      if (runningIds.length) {
         const queryDocs = await getQueriesByIds(
           this.model.organization,
           runningIds

--- a/packages/back-end/src/types/Integration.ts
+++ b/packages/back-end/src/types/Integration.ts
@@ -14,6 +14,8 @@ import { FormatDialect } from "../util/sql";
 import { TemplateVariables } from "../../types/sql";
 import { FactTableMap } from "../models/FactTableModel";
 
+export type ExternalIdCallback = (id: string) => Promise<void>;
+
 export class MissingDatasourceParamsError extends Error {
   constructor(message: string) {
     super(message);
@@ -356,12 +358,22 @@ export interface SourceIntegrationInterface {
   getExperimentMetricQuery(params: ExperimentMetricQueryParams): string;
   getExperimentUnitsTableQuery(params: ExperimentUnitsQueryParams): string;
   getPastExperimentQuery(params: PastExperimentParams): string;
-  runMetricValueQuery(query: string): Promise<MetricValueQueryResponse>;
+  runMetricValueQuery(
+    query: string,
+    setExternalId: ExternalIdCallback
+  ): Promise<MetricValueQueryResponse>;
   runExperimentMetricQuery(
-    query: string
+    query: string,
+    setExternalId: ExternalIdCallback
   ): Promise<ExperimentMetricQueryResponse>;
-  runExperimentUnitsQuery(query: string): Promise<ExperimentUnitsQueryResponse>;
-  runPastExperimentQuery(query: string): Promise<PastExperimentQueryResponse>;
+  runExperimentUnitsQuery(
+    query: string,
+    setExternalId: ExternalIdCallback
+  ): Promise<ExperimentUnitsQueryResponse>;
+  runPastExperimentQuery(
+    query: string,
+    setExternalId: ExternalIdCallback
+  ): Promise<PastExperimentQueryResponse>;
   getEventsTrackedByDatasource?: (
     schemaFormat: SchemaFormat,
     existingMetrics: MetricInterface[],
@@ -379,4 +391,5 @@ export interface SourceIntegrationInterface {
     database?: string,
     requireSchema?: boolean
   ): string;
+  cancelQuery?(externalId: string): Promise<void>;
 }

--- a/packages/back-end/types/query.d.ts
+++ b/packages/back-end/types/query.d.ts
@@ -41,4 +41,5 @@ export interface QueryInterface {
   dependencies?: string[];
   cachedQueryUsed?: string;
   statistics?: QueryStatistics;
+  externalId?: string;
 }


### PR DESCRIPTION
### Features and Changes

Before, the "cancel" queries link would stop waiting for results and update the GrowthBook UI, but the queries would still be executing in the database in the background.

Now, for BigQuery and Athena, we will send a cancel request to the database as well.

Unfortunately, not all db engines support easily cancelling an in-progress query, which is why we're starting with only two.