### PR TITLE
Handle race conditions in the feature toggle endpoint

### DIFF
--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -1140,6 +1140,14 @@ export async function postFeatureToggle(
   const currentState =
     feature.environmentSettings?.[environment]?.enabled || false;
 
+  // If we're already in the desired state, no need to update
+  // This can be caused by race conditions (e.g. two people with the feature open, both toggling at the same time)
+  if (currentState === state) {
+    return res.status(200).json({
+      status: 200,
+    });
+  }
+
   await toggleFeatureEnvironment(
     org,
     res.locals.eventAudit,


### PR DESCRIPTION
This can happen, for example, if two people have the same feature page open and hit the kill switch at the exact same time. It doesn't break anything today, but it does log 2 separate audit events which can be confusing.  The first one would show the proper diff, the second one would be an empty diff (e.g. changing `false` to `false`).

This PR adds an early return if the feature is already in the desired state so we avoid adding that 2nd empty audit entry.