### PR TITLE
Fix denominator for fact ratio metrics in results table

### DIFF
--- a/packages/front-end/components/Experiment/MetricValueColumn.tsx
+++ b/packages/front-end/components/Experiment/MetricValueColumn.tsx
@@ -67,7 +67,7 @@ export default function MetricValueColumn({
         metric.denominator,
         getFactTableById,
         ratioMetric
-      )(numeratorValue, formatterOptions);
+      )(denominatorValue, formatterOptions);
     }
   } else {
     numerator = getMetricFormatter(


### PR DESCRIPTION
Denominator was rendering the numerator for fact ratio metrics. This fixes that.