### PR TITLE
Add new rollback workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,15 +18,10 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
+      - name: Install buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Add tag to latest image
         run: |
           TAG=${GITHUB_REF#refs/tags/v}
-          
-          # Pull the latest image
-          docker pull growthbook/growthbook:latest
-
-          # Add the version tag
-          docker image tag growthbook/growthbook:latest growthbook/growthbook:$TAG
-
-          # Push the new tag
-          docker push growthbook/growthbook:$TAG
+          docker buildx imagetools create -t growthbook/growthbook:$TAG growthbook/growthbook:latest

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -21,8 +21,10 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
-      - name: Build, tag, and push image to Docker Hub
+      - name: Install buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Tag image as latest
         run: |
           docker buildx imagetools create -t growthbook/growthbook:latest growthbook/growthbook:git-${{ inputs.sha }}
 

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -15,39 +15,16 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ inputs.sha }}
-
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
-      - name: Install Depot CLI
-        uses: depot/setup-action@v1
-
-      - name: Prepare build metadata
-        id: metadata
-        run: |
-          # Store current git hash and date in files
-          mkdir -p buildinfo
-          echo "${GITHUB_SHA}" > buildinfo/SHA
-          printf '%(%Y-%m-%dT%H:%M:%SZ)T' > buildinfo/DATE
-          echo "sha=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
-
       - name: Build, tag, and push image to Docker Hub
-        uses: depot/build-push-action@v1
-        with:
-          push: true
-          context: .
-          project: vmp2ssvj9r
-          tags: |
-            growthbook/growthbook:latest
-            growthbook/growthbook:git-${{ steps.metadata.outputs.sha }}
-          platforms: linux/amd64,linux/arm64
+        uses: docker/setup-buildx-action@v3
+        run: |
+          docker buildx imagetools create -t growthbook/growthbook:latest growthbook/growthbook:git-${{ inputs.sha }}
 
   # Deploy the back-end for GrowthBook Cloud
   prod:

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -1,0 +1,66 @@
+name: Rollback to SHA
+on:
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: 'SHA of git commit to be rolled back to'
+        required: true
+        type: string
+jobs:
+  # Build and publish the commit to docker
+  docker:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'growthbook/growthbook' }}
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ inputs.sha }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Install Depot CLI
+        uses: depot/setup-action@v1
+
+      - name: Prepare build metadata
+        id: metadata
+        run: |
+          # Store current git hash and date in files
+          mkdir -p buildinfo
+          echo "${GITHUB_SHA}" > buildinfo/SHA
+          printf '%(%Y-%m-%dT%H:%M:%SZ)T' > buildinfo/DATE
+          echo "sha=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+
+      - name: Build, tag, and push image to Docker Hub
+        uses: depot/build-push-action@v1
+        with:
+          push: true
+          context: .
+          project: vmp2ssvj9r
+          tags: |
+            growthbook/growthbook:latest
+            growthbook/growthbook:git-${{ steps.metadata.outputs.sha }}
+          platforms: linux/amd64,linux/arm64
+
+  # Deploy the back-end for GrowthBook Cloud
+  prod:
+    runs-on: ubuntu-latest
+    needs: [docker]
+    if: ${{ github.repository == 'growthbook/growthbook' }}
+    steps:
+      - name: Configure AWS credentials for GrowthBook Cloud
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Deploy docker image to ECS for GrowthBook Cloud API
+        run: aws ecs update-service --cluster prod-api --service prod-api --force-new-deployment --region us-east-1

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Tag image as latest
         run: |
-          docker buildx imagetools create -t growthbook/growthbook:latest growthbook/growthbook:git-${{ inputs.sha }}
+          docker buildx imagetools create -t growthbook/growthbook:test growthbook/growthbook:git-${{ inputs.sha }}
 
   # Deploy the back-end for GrowthBook Cloud
   prod:


### PR DESCRIPTION
This PR adds a new workflow, `rollback.yml`, that will listen for Workflow Dispatch events so that we can trigger the workflow **ad-hoc** (e.g. via a REST API call or by GitHub's UI) to deploy and release the GrowthBook app at a **specified commit SHA**.

This will allow us to rollback the app to any point in commit history by leveraging our existing GitHub Actions configuration.

Changes:
- Add `rollback.yml` workflow 
  - Receives one input (`sha`) to specify git commit sha to rollback to
    - The `workflow_dispatch` event requires a `ref` to be specified when called. It's not clear if this `ref` can be used as the SHA input, or if we need a separate input to set the specific SHA (since a `ref` is typically a branch or tag name). Will test and adjust in a subsequent PR if necessary.

Related reading:
- [Creating a workflow dispatch event](https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event)
- [workflow_dispatch event reference](https://docs.github.com/en/webhooks/webhook-events-and-payloads#workflow_dispatch)
- [workflow_dispatch implementation example](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch)