### PR TITLE
Fix duplicate experiment rules added to features

### DIFF
--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -863,7 +863,7 @@ export async function postFeatureExperimentRefRule(
     };
 
     // Revision changes
-    changes.rules[env] = feature.environmentSettings?.[env]?.rules || [];
+    changes.rules[env] = [...(feature.environmentSettings?.[env]?.rules || [])];
     changes.rules[env].push(envRule);
 
     // Feature updates


### PR DESCRIPTION
### Features and Changes

Added an existing feature flag to an experiment added 2 duplicate rules to every environment due to a simple copy by reference/value typo.