### PR TITLE
Fix SDK Connection project migration bug

### DIFF
--- a/packages/back-end/src/models/SdkConnectionModel.ts
+++ b/packages/back-end/src/models/SdkConnectionModel.ts
@@ -85,10 +85,11 @@ function toInterface(doc: SDKConnectionDocument): SDKConnectionInterface {
   const conn = doc.toJSON<SDKConnectionDocument>();
   conn.proxy = addEnvProxySettings(conn.proxy);
 
-  if (!conn.projects) {
-    const project = (conn as SDKConnectionDocument & { project?: string })
+  if ((conn as SDKConnectionDocument & { project?: string }).project) {
+    const project = (conn as SDKConnectionDocument & { project: string })
       .project;
-    conn.projects = project ? [project] : [];
+    conn.projects = [project];
+    (conn as SDKConnectionDocument & { project?: string }).project = "";
   }
 
   return omit(conn, ["__v", "_id"]);
@@ -261,6 +262,7 @@ export async function editSDKConnection(
       $set: {
         ...otherChanges,
         proxy: newProxy,
+        project: "",
         dateUpdated: new Date(),
       },
     }

--- a/packages/back-end/src/models/SdkConnectionModel.ts
+++ b/packages/back-end/src/models/SdkConnectionModel.ts
@@ -85,7 +85,11 @@ function toInterface(doc: SDKConnectionDocument): SDKConnectionInterface {
   const conn = doc.toJSON<SDKConnectionDocument>();
   conn.proxy = addEnvProxySettings(conn.proxy);
 
-  if ((conn as SDKConnectionDocument & { project?: string }).project) {
+  // Migrate old project setting to projects
+  if (
+    !conn.projects?.length &&
+    (conn as SDKConnectionDocument & { project?: string }).project
+  ) {
     const project = (conn as SDKConnectionDocument & { project: string })
       .project;
     conn.projects = [project];


### PR DESCRIPTION
### Features and Changes

Projects were not being migrated to the new array format correctly for existing SDK connections