### PR TITLE
Use maximum conversion window of metric chain when 'Exclude in-progress conversions' is selected

### DIFF
--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -1373,19 +1373,16 @@ export default abstract class SqlIntegration
       settings.experimentId
     );
 
-    const initialMetric =
-      denominatorMetrics.length > 0 ? denominatorMetrics[0] : metric;
-
     // Get date range for experiment and analysis
-    const initialConversionWindowHours = getConversionWindowHours(
-      initialMetric
+    const maxDelayAndConversionWindowHours = Math.max(
+      ...orderedMetrics.map(
+        (m) => (m.conversionDelayHours || 0) + getConversionWindowHours(m)
+      )
     );
-    const initialConversionDelayHours = initialMetric.conversionDelayHours || 0;
-
     const startDate: Date = settings.startDate;
     const endDate: Date = this.getExperimentEndDate(
       settings,
-      initialConversionWindowHours + initialConversionDelayHours
+      maxDelayAndConversionWindowHours
     );
 
     if (params.dimensions.length > 1) {


### PR DESCRIPTION
### Features and Changes

When using the 'Exclude in-progress conversions' option, if we have a metric with a denominator, currently the exclusion is done using the denominator's conversion window. We should be using the maximum of the numerator and denominator's conversion windows instead. More generally, the change in this PR takes the maximum conversion window 
of the numerator and the recursive chain of denominators.

- Closes **https://github.com/growthbook/growthbook/issues/1844**

### Testing

Following these steps:
1. Selecting 'Exclude in-progress conversions' option in the experiment
2. Choosing a metric with conversion window of 24 hours, with a denominator of 1 hour (as an example)

in the current behavior, the exclusion was done using a 1 hour period, with this change it's 24 hours instead.

