### PR TITLE
Fix bug: Changing defaultValue to empty string hides the "publish" CTA

### DIFF
--- a/packages/front-end/components/Features/DraftModal.tsx
+++ b/packages/front-end/components/Features/DraftModal.tsx
@@ -3,7 +3,7 @@ import ReactDiffViewer, { DiffMethod } from "react-diff-viewer";
 import { useState, useMemo } from "react";
 import { FaAngleDown, FaAngleRight } from "react-icons/fa";
 import { FeatureRevisionInterface } from "back-end/types/feature-revision";
-import { autoMerge } from "shared/util";
+import { autoMerge, mergeResultHasChanges } from "shared/util";
 import { getAffectedRevisionEnvs, useEnvironments } from "@/services/features";
 import { useAuth } from "@/services/auth";
 import usePermissions from "@/hooks/usePermissions";
@@ -134,10 +134,7 @@ export default function DraftModal({
     getAffectedRevisionEnvs(feature, revision, environments)
   );
 
-  const hasChanges =
-    !mergeResult.success ||
-    Object.keys(mergeResult.result.rules || {}).length > 0 ||
-    !!mergeResult.result.defaultValue;
+  const hasChanges = mergeResultHasChanges(mergeResult);
 
   return (
     <Modal
@@ -223,7 +220,7 @@ export default function DraftModal({
               <ExpandableDiff {...diff} key={diff.title} />
             ))}
           </div>
-          {hasPermission && (
+          {hasPermission ? (
             <Field
               label="Add a Comment (optional)"
               textarea
@@ -233,6 +230,10 @@ export default function DraftModal({
                 setComment(e.target.value);
               }}
             />
+          ) : (
+            <div className="alert alert-info">
+              You do not have permission to publish this draft.
+            </div>
           )}
         </div>
       )}

--- a/packages/front-end/components/Features/FixConflictsModal.tsx
+++ b/packages/front-end/components/Features/FixConflictsModal.tsx
@@ -3,7 +3,12 @@ import ReactDiffViewer, { DiffMethod } from "react-diff-viewer";
 import { useState, useMemo } from "react";
 import { FaAngleDown, FaAngleRight, FaCheck } from "react-icons/fa";
 import { FeatureRevisionInterface } from "back-end/types/feature-revision";
-import { MergeConflict, MergeStrategy, autoMerge } from "shared/util";
+import {
+  MergeConflict,
+  MergeStrategy,
+  autoMerge,
+  mergeResultHasChanges,
+} from "shared/util";
 import clsx from "clsx";
 import { useEnvironments } from "@/services/features";
 import { useAuth } from "@/services/auth";
@@ -181,10 +186,7 @@ export default function FixConflictsModal({
 
   if (!revision || !mergeResult || !mergeResult.conflicts.length) return null;
 
-  const hasChanges =
-    !mergeResult.success ||
-    Object.keys(mergeResult.result.rules || {}).length > 0 ||
-    !!mergeResult.result.defaultValue;
+  const hasChanges = mergeResultHasChanges(mergeResult);
 
   return (
     <PagedModal

--- a/packages/front-end/pages/features/[fid].tsx
+++ b/packages/front-end/pages/features/[fid].tsx
@@ -240,7 +240,8 @@ export default function FeaturePage() {
   const isLive = revision?.version === feature.version;
   const isArchived = feature.archived;
 
-  const revisionHasChanges = mergeResult && mergeResultHasChanges(mergeResult);
+  const revisionHasChanges =
+    !!mergeResult && mergeResultHasChanges(mergeResult);
 
   const enabledEnvs = getEnabledEnvironments(feature, environments);
   const hasJsonValidator = hasCommercialFeature("json-validation");

--- a/packages/front-end/pages/features/[fid].tsx
+++ b/packages/front-end/pages/features/[fid].tsx
@@ -17,12 +17,14 @@ import {
   autoMerge,
   getValidation,
   isFeatureStale,
+  mergeResultHasChanges,
   mergeRevision,
 } from "shared/util";
 import { getDemoDatasourceProjectIdForOrganization } from "shared/demo-datasource";
 import { MdHistory, MdRocketLaunch } from "react-icons/md";
 import { FaPlusMinus } from "react-icons/fa6";
 import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
+import clsx from "clsx";
 import MoreMenu from "@/components/Dropdown/MoreMenu";
 import { GBAddCircle, GBEdit } from "@/components/Icons";
 import LoadingOverlay from "@/components/LoadingOverlay";
@@ -238,11 +240,7 @@ export default function FeaturePage() {
   const isLive = revision?.version === feature.version;
   const isArchived = feature.archived;
 
-  const revisionHasChanges =
-    !!mergeResult &&
-    (!mergeResult.success ||
-      Object.keys(mergeResult.result.rules || {}).length > 0 ||
-      !!mergeResult.result.defaultValue);
+  const revisionHasChanges = mergeResult && mergeResultHasChanges(mergeResult);
 
   const enabledEnvs = getEnabledEnvironments(feature, environments);
   const hasJsonValidator = hasCommercialFeature("json-validation");
@@ -1026,13 +1024,25 @@ export default function FeaturePage() {
                   Make changes below and publish when you are ready
                 </div>
                 <div className="ml-auto"></div>
-                {hasDraftPublishPermission &&
-                  mergeResult?.success &&
-                  revisionHasChanges && (
-                    <div>
+                {mergeResult?.success && (
+                  <div>
+                    <Tooltip
+                      body={
+                        !revisionHasChanges
+                          ? "Draft is identical to the live version. Make changes first before publishing"
+                          : !hasDraftPublishPermission
+                          ? "You do not have permission to publish this draft."
+                          : ""
+                      }
+                    >
                       <a
                         href="#"
-                        className="font-weight-bold text-purple"
+                        className={clsx(
+                          "font-weight-bold",
+                          !hasDraftPublishPermission || !revisionHasChanges
+                            ? "text-muted"
+                            : "text-purple"
+                        )}
                         onClick={(e) => {
                           e.preventDefault();
                           setDraftModal(true);
@@ -1040,11 +1050,12 @@ export default function FeaturePage() {
                       >
                         <MdRocketLaunch /> Review and Publish
                       </a>
-                    </div>
-                  )}
+                    </Tooltip>
+                  </div>
+                )}
                 {canEditDrafts && mergeResult && !mergeResult.success && (
                   <div>
-                    <Tooltip body="There have been new conflicting changes published since you created your draft that must be resolved before you can publish">
+                    <Tooltip body="There have been new conflicting changes published since this draft was created that must be resolved before you can publish">
                       <a
                         href="#"
                         className="font-weight-bold text-purple"

--- a/packages/shared/src/util/features.ts
+++ b/packages/shared/src/util/features.ts
@@ -261,6 +261,16 @@ export type RulesAndValues = Pick<
   "defaultValue" | "rules" | "version"
 >;
 
+export function mergeResultHasChanges(mergeResult: AutoMergeResult): boolean {
+  if (!mergeResult.success) return true;
+
+  if (Object.keys(mergeResult.result.rules || {}).length > 0) return true;
+
+  if (mergeResult.result.defaultValue !== undefined) return true;
+
+  return false;
+}
+
 export function autoMerge(
   live: RulesAndValues,
   base: RulesAndValues,


### PR DESCRIPTION
### Features and Changes

If the default value of a string feature is changed to an empty string and that's the only change in a draft, it is not detected properly and the "publish" button is hidden.

This PR fixes the bug and makes messaging on the page more explicit.  Now, you will always see the "publish" link and we'll just gray it out and show a tooltip if you don't have permission or there are no changes detected.