### PR TITLE
Fix expired license error handling

### DIFF
--- a/packages/back-end/src/services/auth/verifyLicenseMiddleware.ts
+++ b/packages/back-end/src/services/auth/verifyLicenseMiddleware.ts
@@ -1,5 +1,5 @@
 import { Response, NextFunction } from "express";
-import { getLicense, licenseIsExpired } from "enterprise";
+import { getLicense, shouldLimitAccessDueToExpiredLicense } from "enterprise";
 import { IS_CLOUD } from "../../util/secrets";
 import { AuthRequest } from "../../types/AuthRequest";
 
@@ -16,7 +16,7 @@ export default function verifyLicenseMiddleware(
   if (!license) {
     return next();
   }
-  if (licenseIsExpired()) {
+  if (shouldLimitAccessDueToExpiredLicense()) {
     res.locals.licenseError = "License expired";
     res.setHeader("X-License-Error", "License expired");
   }

--- a/packages/back-end/src/services/auth/verifyLicenseMiddleware.ts
+++ b/packages/back-end/src/services/auth/verifyLicenseMiddleware.ts
@@ -1,5 +1,5 @@
 import { Response, NextFunction } from "express";
-import { getLicense } from "enterprise";
+import { getLicense, licenseIsExpired } from "enterprise";
 import { IS_CLOUD } from "../../util/secrets";
 import { AuthRequest } from "../../types/AuthRequest";
 
@@ -16,17 +16,9 @@ export default function verifyLicenseMiddleware(
   if (!license) {
     return next();
   }
-
-  // Check if license is expired (2 day buffer)
-  if (license.dateExpires) {
-    let expiresWithBuffer = new Date(license.dateExpires);
-    expiresWithBuffer = new Date(
-      expiresWithBuffer.setDate(expiresWithBuffer.getDate() + 2)
-    );
-    if (expiresWithBuffer < new Date()) {
-      res.locals.licenseError = "License expired";
-      res.setHeader("X-License-Error", "License expired");
-    }
+  if (licenseIsExpired()) {
+    res.locals.licenseError = "License expired";
+    res.setHeader("X-License-Error", "License expired");
   }
 
   // Validate organization id with license

--- a/packages/enterprise/src/license.ts
+++ b/packages/enterprise/src/license.ts
@@ -206,16 +206,6 @@ export async function getVerifiedLicenseData(
   }
   delete decodedLicense.eat;
 
-  // The `trial` field used to be optional, force it to always be defined
-  decodedLicense.trial = !!decodedLicense.trial;
-
-  // If it's a trial license key, make sure it's not expired yet
-  // For real license keys, we show an "expired" banner in the app instead of throwing an error
-  // We want to be strict for trial keys, but lenient for real Enterprise customers
-  if (decodedLicense.trial && decodedLicense.exp < new Date().toISOString()) {
-    throw new Error(`Your License Key trial expired on ${decodedLicense.exp}.`);
-  }
-
   // We used to only offer license keys for Enterprise plans (not pro)
   if (!decodedLicense.plan) {
     decodedLicense.plan = "enterprise";

--- a/packages/enterprise/src/license.ts
+++ b/packages/enterprise/src/license.ts
@@ -169,7 +169,9 @@ export function orgHasPremiumFeature(
   org: MinimalOrganization,
   feature: CommercialFeature
 ): boolean {
-  return planHasPremiumFeature(getAccountPlan(org), feature);
+  return (
+    !licenseIsExpired() && planHasPremiumFeature(getAccountPlan(org), feature)
+  );
 }
 
 async function getPublicKey(): Promise<Buffer> {

--- a/packages/enterprise/src/license.ts
+++ b/packages/enterprise/src/license.ts
@@ -170,7 +170,8 @@ export function orgHasPremiumFeature(
   feature: CommercialFeature
 ): boolean {
   return (
-    !licenseIsExpired() && planHasPremiumFeature(getAccountPlan(org), feature)
+    !shouldLimitAccessDueToExpiredLicense() &&
+    planHasPremiumFeature(getAccountPlan(org), feature)
   );
 }
 
@@ -454,13 +455,13 @@ export function resetInMemoryLicenseCache(): void {
  * Checks if the license is expired.
  * @returns {boolean} True if the license is expired, false otherwise.
  */
-export function licenseIsExpired(): boolean {
+export function shouldLimitAccessDueToExpiredLicense(): boolean {
   // If licenseData is not available, consider it as not expired
   if (!licenseData) {
     return false;
   }
 
-  // If expiration date is provided in the license data
+  // Check if the license is in trial and has an expiration date
   if (licenseData.isTrial && licenseData.dateExpires) {
     // Create a date object for the expiration date
     const expirationDate = new Date(licenseData.dateExpires);

--- a/packages/enterprise/src/license.ts
+++ b/packages/enterprise/src/license.ts
@@ -207,6 +207,8 @@ export async function getVerifiedLicenseData(
     throw new Error("Invalid License Key - Missing expiration date");
   }
   delete decodedLicense.eat;
+  // The `trial` field used to be optional, force it to always be defined
+  decodedLicense.trial = !!decodedLicense.trial;
 
   // We used to only offer license keys for Enterprise plans (not pro)
   if (!decodedLicense.plan) {

--- a/packages/enterprise/src/license.ts
+++ b/packages/enterprise/src/license.ts
@@ -445,3 +445,29 @@ export function resetInMemoryLicenseCache(): void {
     delete keyToLicenseData[key];
   });
 }
+
+/**
+ * Checks if the license is expired.
+ * @returns {boolean} True if the license is expired, false otherwise.
+ */
+export function licenseIsExpired(): boolean {
+  // If licenseData is not available, consider it as not expired
+  if (!licenseData) {
+    return false;
+  }
+
+  // If expiration date is provided in the license data
+  if (licenseData.isTrial && licenseData.dateExpires) {
+    // Create a date object for the expiration date
+    const expirationDate = new Date(licenseData.dateExpires);
+
+    // Check if the adjusted expiration date is in the past
+    if (expirationDate < new Date()) {
+      // The license is expired
+      return true;
+    }
+  }
+
+  // The license is not expired
+  return false;
+}

--- a/packages/enterprise/test/license.test.ts
+++ b/packages/enterprise/test/license.test.ts
@@ -327,13 +327,6 @@ describe("licenseInit", () => {
       }).rejects.toThrowError("Invalid License Key - Missing expiration date");
     });
 
-    it("should throw an error if the license has expired", async () => {
-      jest.setSystemTime(now.getTime() + 8 * 24 * 60 * 60 * 1000);
-      await expect(async () => {
-        await licenseInit(oldLicenseKey, userLicenseCodes, metaData);
-      }).rejects.toThrowError("Your License Key trial expired on");
-    });
-
     it("should automatically assume enterprise plan if no plan is specified", async () => {
       const oldLicenseOriginalData2 = cloneDeep(oldLicenseOrginalData);
       // @ts-expect-error Ignoring TypeScript error here because we intentionally passed malformed data for testing purposes


### PR DESCRIPTION
### Features and Changes

 - Fixes the issue where an expired license key causes an API error, preventing them from logging in and accessing the UI for license management. This issue was limited to API keys who's trials expired. Paying enterprise members who's license expired did not face this issue.


- Fixes [Expired License Keys Cause API Error State (#1774)](https://github.com/growthbook/growthbook/issues/1774)


### Dependencies

None

### Tests
#### Test 1 - Login
1. Add an enterprise or pro key on a new account through the GrowthBook UI. (Ensure it is a trial key)
2. Allow the key to expire. (Can be simulated by changing your machine's date/time settings)
3. Ensure the license data isn't cached in server memory from when you added the key. (Memory can be flushed by restarting the dev server)
4. Attempt to log in using an account associated with the expired trial key.

Before this change, the login would fail.
After this change, the login succeeds and displays a banner on the top bar.

#### Test 2 - Unauthorized requests
1. Add an enterprise or pro key on a new account through the GrowthBook UI. (Ensure it is a trial key)
2. Allow the key to expire. (Can be simulated by changing your machine's date/time settings)
3. Ensure the license data isn't cached in server memory from when you added the key. (Memory can be flushed by restarting the dev server)
4. Log in using an account associated with the expired trial key.
5. Find an enterprise only feature that has been disabled. We can take exporting logs as json, which can be found in the `/events` route of the frontend.
6. The button will be disabled. Force-enable the button. For the case of the events export feature, this can be done by setting the `disabled` flag on the button in the EventsPage component (`packages/front-end/components/Events/EventsPage/EventsPage.tsx`) to false. 
7. Once the button is enabled, press it.

Before this change, the backend would process the request and provide a valid json response eventhough the license has expired. The feature-blocking was only happening in the frontend logic. (This could have also been bypassed with `curl`)

After this change, the backend will do its own check to see if the license key has expired. If it has, it will not process the request for the premium feature. So in this case, it would not process the invalid request.

### Screenshots (for Test 1)

#### Before
![Before](https://github.com/growthbook/growthbook/assets/49459061/771439b0-3cba-4fbb-995d-a6fd2d2cd259)
#### After
![After](https://github.com/growthbook/growthbook/assets/49459061/167dc272-7129-496f-841c-4b1cadbe8be3)
