### PR TITLE
Visual Editor - Append Query Params util - Fix util; Add tests

### DIFF
--- a/packages/front-end/services/utils.tsx
+++ b/packages/front-end/services/utils.tsx
@@ -167,10 +167,16 @@ export function appendQueryParamsToURL(
   url: string,
   params: Record<string, string | number | undefined>
 ): string {
-  const [root, query] = url.split("?");
+  const [_root, hash] = url.split("#");
+  const [root, query] = _root.split("?");
   const parsed = qs.parse(query ?? "");
-  const queryParams = qs.stringify({ ...parsed, ...params });
-  return `${root}?${queryParams}`;
+  const queryParams = qs.stringify(
+    { ...parsed, ...params },
+    {
+      sort: false,
+    }
+  );
+  return `${root}?${queryParams}${hash ? `#${hash}` : ""}`;
 }
 
 export function capitalizeFirstLetter(string): string {

--- a/packages/front-end/test/services/appendQueryParamsToURL.test.ts
+++ b/packages/front-end/test/services/appendQueryParamsToURL.test.ts
@@ -1,0 +1,43 @@
+import { appendQueryParamsToURL } from "@/services/utils";
+
+describe("appendQueryParamsToURL", () => {
+  describe("when url has no query params", () => {
+    it("should append query params", () => {
+      const url = "http://localhost:3000";
+      const queryParams = { foo: "bar" };
+      const expected = "http://localhost:3000?foo=bar";
+
+      expect(appendQueryParamsToURL(url, queryParams)).toEqual(expected);
+    });
+  });
+
+  describe("when url has existing query params", () => {
+    it("should append query params", () => {
+      const url = "http://localhost:3000?foo=bar";
+      const queryParams = { baz: "qux" };
+      const expected = "http://localhost:3000?foo=bar&baz=qux";
+
+      expect(appendQueryParamsToURL(url, queryParams)).toEqual(expected);
+    });
+  });
+
+  describe("when url has existing query params and new query params have the same key", () => {
+    it("should overwrite query params", () => {
+      const url = "http://localhost:3000?foo=bar";
+      const queryParams = { foo: "qux" };
+      const expected = "http://localhost:3000?foo=qux";
+
+      expect(appendQueryParamsToURL(url, queryParams)).toEqual(expected);
+    });
+  });
+
+  describe("when url has both query params and hash", () => {
+    it("should append query params", () => {
+      const url = "http://localhost:3000?foo=bar#baz";
+      const queryParams = { qux: "quux" };
+      const expected = "http://localhost:3000?foo=bar&qux=quux#baz";
+
+      expect(appendQueryParamsToURL(url, queryParams)).toEqual(expected);
+    });
+  });
+});


### PR DESCRIPTION
This fixes a bug where URLs containing a hash string (`#`) were not being modified properly by our Visual Editor query param utility. 

Adds tests