### PR TITLE
Precommit hook - Only lint staged files

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
       "prettier --write"
     ],
     "./**/*.{ts,tsx}": [
-      "yarn lint"
+      "yarn eslint  --fix --max-warnings 0 --cache --cache-strategy content"
     ],
     "./packages/stats/{gbstats,tests}/**/*.py": [
       "bash -c \"yarn workspace stats lint\" && :"


### PR DESCRIPTION
This change makes it so we only lint staged files in our lint-staged hook.

Previously we were running `yarn lint` which calls `eslint` supplied with paths that effectively crawl the entire codebase, despite only needing to lint staged files.

This makes our pre-commit hook much faster, and also eliminates unnecessary warnings/errors.

