### PR TITLE
Use non-deterministic quantile for ClickHouse capping

### DIFF
--- a/packages/back-end/src/integrations/ClickHouse.ts
+++ b/packages/back-end/src/integrations/ClickHouse.ts
@@ -90,9 +90,8 @@ export default class ClickHouse extends SqlIntegration {
     capPercentile: number,
     metricTable: string
   ): string {
-    const seed = 1234;
     return `
-      SELECT quantileDeterministic(${capPercentile})(value, ${seed}) AS cap_value
+      SELECT quantile(${capPercentile})(value) AS cap_value
       FROM ${metricTable}
       WHERE value IS NOT NULL
     `;


### PR DESCRIPTION
On clickHouse, with > 8192 rows, our percentile function would fail because it was incorrectly set up to use a fixed seed (1234). 

To fix this, this PR just implements the non-deterministic quantile function (which is identical behavior for <= 8192 users and now works for more data but may change from run to run).

Why not other approaches?
* Fixing `quantileDeterministic`: We don't reliably have a numeric value (e.g. a numeric id) in the tables we are getting percentiles over, and it's possible there's some correlation between numeric id and values of interest
* Using `quantileExact`: can be very expensive for large data, and using non-deterministic results is similar to our approach for, say BigQuery.

Fixes: #1881 

## Testing

* capped results unchanged for clickhouse in integration testing queries (although sample data is <= 8192 rows)
* clickhouse cloud sandbox shows improved behavior with > 8192 rows