### PR TITLE
Modify cascading window logic for excluding in-progress conversions

### DIFF
--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -10,6 +10,7 @@ import {
   isRatioMetric,
   ExperimentMetricInterface,
   getMetricTemplateVariables,
+  getMaxHoursToConvert,
 } from "shared/experiments";
 import { MetricInterface, MetricType } from "../../types/metric";
 import {
@@ -1373,19 +1374,15 @@ export default abstract class SqlIntegration
       settings.experimentId
     );
 
-    const initialMetric =
-      denominatorMetrics.length > 0 ? denominatorMetrics[0] : metric;
-
     // Get date range for experiment and analysis
-    const initialConversionWindowHours = getConversionWindowHours(
-      initialMetric
-    );
-    const initialConversionDelayHours = initialMetric.conversionDelayHours || 0;
-
     const startDate: Date = settings.startDate;
     const endDate: Date = this.getExperimentEndDate(
       settings,
-      initialConversionWindowHours + initialConversionDelayHours
+      getMaxHoursToConvert(
+        funnelMetric,
+        [metric].concat(denominatorMetrics),
+        activationMetric
+      )
     );
 
     if (params.dimensions.length > 1) {

--- a/packages/shared/src/experiments.ts
+++ b/packages/shared/src/experiments.ts
@@ -82,6 +82,31 @@ export function getConversionWindowHours(
   return DEFAULT_CONVERSION_WINDOW_HOURS || 72;
 }
 
+export function getMaxHoursToConvert(
+  funnelMetric: boolean,
+  metricAndDenominatorMetrics: ExperimentMetricInterface[],
+  activationMetric: ExperimentMetricInterface | null
+): number {
+  let neededHoursForConversion = 0;
+  metricAndDenominatorMetrics.forEach((m) => {
+    const metricHours =
+      (m.conversionDelayHours || 0) + getConversionWindowHours(m);
+    if (funnelMetric) {
+      // funnel metric windows cab cascade, so sum each metric hours to get max
+      neededHoursForConversion += metricHours;
+    } else if (metricHours > neededHoursForConversion) {
+      neededHoursForConversion = metricHours;
+    }
+  });
+  // activation metrics windows always cascade
+  if (activationMetric) {
+    neededHoursForConversion +=
+      (activationMetric.conversionDelayHours || 0) +
+      getConversionWindowHours(activationMetric);
+  }
+  return neededHoursForConversion;
+}
+
 export function getUserIdTypes(
   metric: ExperimentMetricInterface,
   factTableMap: FactTableMap,

--- a/packages/shared/src/experiments.ts
+++ b/packages/shared/src/experiments.ts
@@ -82,31 +82,6 @@ export function getConversionWindowHours(
   return DEFAULT_CONVERSION_WINDOW_HOURS || 72;
 }
 
-export function getMaxHoursToConvert(
-  funnelMetric: boolean,
-  metricAndDenominatorMetrics: ExperimentMetricInterface[],
-  activationMetric: ExperimentMetricInterface | null
-): number {
-  let neededHoursForConversion = 0;
-  metricAndDenominatorMetrics.forEach((m) => {
-    const metricHours =
-      (m.conversionDelayHours || 0) + getConversionWindowHours(m);
-    if (funnelMetric) {
-      // funnel metric windows cab cascade, so sum each metric hours to get max
-      neededHoursForConversion += metricHours;
-    } else if (metricHours > neededHoursForConversion) {
-      neededHoursForConversion = metricHours;
-    }
-  });
-  // activation metrics windows always cascade
-  if (activationMetric) {
-    neededHoursForConversion +=
-      (activationMetric.conversionDelayHours || 0) +
-      getConversionWindowHours(activationMetric);
-  }
-  return neededHoursForConversion;
-}
-
 export function getUserIdTypes(
   metric: ExperimentMetricInterface,
   factTableMap: FactTableMap,


### PR DESCRIPTION
### Features and Changes

Users can currently choose to 'Exclude in-progress conversions' to drop users that have not had the full time window to convert. However, we don't properly calculate that "full time window". Currently, we just use the metric (or denominator metric if a funnel or ratio metric) conversion window, but we need to take:
* the max of the numerator and denominator windows (for ratio metrics)
* the sum of the numerator and recursive chain of denominators (for funnel metrics, since their conversion windows cascade)

We also need to always add the activation metric (if specified) window to the value of the above since activation metrics start their own conversion windows. So if a user has 72 hours to *activate* and a ratio with (24 hours numerator, 1 hours denominator), we need to give them a total of MAX(24, 1) + 72 hours to convert.

Closes https://github.com/growthbook/growthbook/issues/1844

Also, this followed work in https://github.com/growthbook/growthbook/pull/1880, which, while addressing some issues, didn't capture the full complexity of the above flow.

### Testing

Added unit tests

Tested in-app:
* Created 3 metrics
  * Activation metric with 72 hour conversion window
  * Plain metric with 24 hour conversion window
  * Ratio metric where denominator has 1 hour conversion window
  * Funnel metric where denominator has 1 hour conversion window
* Compared SQL for running experiment for all three metrics with `Exclude In-Progress Conversions`

Results as expected:
* Plain metric has a filter for 24 hours before experiment end
* Ratio metric has a filter with MAX(24, 1)=24 hours before experiment end
* Funnel metric has a filter with SUM(24, 1)=25 hours before experiment end

Adding the activation metric adds 72 hours to all of those above.\

Note: the metric filter in `getMetricEnd` remains a little inefficient because it doesn't know that it only needs the max for ratio metrics rather than the sum for funnel metrics, but it isn't dropping relevant data, just is collecting slightly too much data.