### PR TITLE
Fix unnecessary activation fact metric data retrieval (and two minor FE bugs)

### DIFF
--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -1037,7 +1037,11 @@ export default abstract class SqlIntegration
               activationMetric.conversionDelayHours || 0,
               0
             ),
-            endDate: this.getMetricEnd([activationMetric], settings.endDate),
+            endDate: this.getMetricEnd(
+              [activationMetric],
+              settings.endDate,
+              ignoreConversionEnd
+            ),
             experimentId: settings.experimentId,
             factTableMap,
           })})

--- a/packages/front-end/components/Experiment/SinglePage.tsx
+++ b/packages/front-end/components/Experiment/SinglePage.tsx
@@ -117,7 +117,7 @@ function drawMetricRow(
     (!ignoreConversionEnd && overrideFields.includes("conversionWindowHours"));
 
   const metricHasNoConversionWindow =
-    isFactMetric(metric) && !metric.hasConversionWindow;
+    isFactMetric(newMetric) && !newMetric.hasConversionWindow;
 
   const isArchived = isFactMetric(metric)
     ? false
@@ -143,15 +143,12 @@ function drawMetricRow(
       <div className="col-sm-5 ml-2">
         {newMetric && (
           <div className="small">
-            {metricHasNoConversionWindow ? (
-              "none"
-            ) : (
-              <>
-                {conversionStart}{" "}
-                {ignoreConversionEnd ? "" : "to " + conversionEnd + " "}
-                hours{" "}
-              </>
-            )}
+            <>
+              {conversionStart}{" "}
+              {ignoreConversionEnd || metricHasNoConversionWindow
+                ? " hours to experiment end "
+                : "to " + conversionEnd + " hours "}
+            </>
             {hasOverrides && (
               <span className="font-italic text-purple">(override)</span>
             )}

--- a/packages/front-end/components/Experiment/SinglePage.tsx
+++ b/packages/front-end/components/Experiment/SinglePage.tsx
@@ -116,6 +116,9 @@ function drawMetricRow(
     overrideFields.includes("conversionDelayHours") ||
     (!ignoreConversionEnd && overrideFields.includes("conversionWindowHours"));
 
+  const metricHasNoConversionWindow =
+    isFactMetric(metric) && !metric.hasConversionWindow;
+
   const isArchived = isFactMetric(metric)
     ? false
     : metric.status === "archived";
@@ -140,9 +143,15 @@ function drawMetricRow(
       <div className="col-sm-5 ml-2">
         {newMetric && (
           <div className="small">
-            {conversionStart}{" "}
-            {ignoreConversionEnd ? "" : "to " + conversionEnd + " "}
-            hours{" "}
+            {metricHasNoConversionWindow ? (
+              "none"
+            ) : (
+              <>
+                {conversionStart}{" "}
+                {ignoreConversionEnd ? "" : "to " + conversionEnd + " "}
+                hours{" "}
+              </>
+            )}
             {hasOverrides && (
               <span className="font-italic text-purple">(override)</span>
             )}

--- a/packages/front-end/components/Metrics/MetricTooltipBody.tsx
+++ b/packages/front-end/components/Metrics/MetricTooltipBody.tsx
@@ -40,6 +40,9 @@ const MetricTooltipBody = ({
   const metricOverrideFields = row?.metricOverrideFields ?? [];
 
   const conversionWindowHours = getConversionWindowHours(metric);
+  const metricHasNoConversionWindow =
+    isFactMetric(metric) && !metric.hasConversionWindow;
+
   const metricInfo: MetricInfo[] = [
     {
       show: true,
@@ -79,7 +82,9 @@ const MetricTooltipBody = ({
       ),
     },
     {
-      show: !isNullUndefinedOrEmpty(conversionWindowHours),
+      show:
+        !isNullUndefinedOrEmpty(conversionWindowHours) &&
+        !metricHasNoConversionWindow,
       label: "Conversion Window Hours",
       body: (
         <>

--- a/packages/shared/src/experiments.ts
+++ b/packages/shared/src/experiments.ts
@@ -73,7 +73,6 @@ export function getConversionWindowHours(
   }
 
   if ("conversionWindowValue" in metric) {
-    if (!metric.hasConversionWindow) return 0;
     const value = metric.conversionWindowValue;
     if (metric.conversionWindowUnit === "hours") return value;
     if (metric.conversionWindowUnit === "days") return value * 24;

--- a/packages/shared/src/experiments.ts
+++ b/packages/shared/src/experiments.ts
@@ -73,6 +73,7 @@ export function getConversionWindowHours(
   }
 
   if ("conversionWindowValue" in metric) {
+    if (!metric.hasConversionWindow) return 0;
     const value = metric.conversionWindowValue;
     if (metric.conversionWindowUnit === "hours") return value;
     if (metric.conversionWindowUnit === "days") return value * 24;


### PR DESCRIPTION
### Features and Changes

Fact metrics currently have hidden logic returning conversion windows in a few places where they shouldn't if a conversion window has not been selected.

Back end fix (SqlIntegration.ts):
* Pass `ignoreConversionWindow` through to get metric end filter for activation metric (Closes #1882). Without this change we inefficiently get (by default), 3 extra days of data that we later correctly filter out in the `__distinctUsers` CTE. Now with this PR we just never get those additional 3 extra days of data. 

FE fixes:
* Update the mouseover in the results table to not show a window for a metric when one doesn't exist
* We should update the old view in the config tab showing the overrides to have "none" when there is no conversion window!

### Testing

Some in-app testing with fact metrics that do and do not have conversion windows, showing the correct behavior and generated SQL.

### Screenshots

Metric name mouse over before, even though this metric has conversion window == off
<img width="636" alt="Screenshot 2023-12-05 at 4 40 26 PM" src="https://github.com/growthbook/growthbook/assets/5298599/a73c8a0a-6592-4a48-9df6-39ae8baf90e3">

Metric name mouse over after:
<img width="643" alt="Screenshot 2023-12-05 at 4 40 03 PM" src="https://github.com/growthbook/growthbook/assets/5298599/2dddf09c-c1fb-43b2-9d07-80130cba5195">


old page config tab before, even though number of purchases has no conversion window:
<img width="1408" alt="Screenshot 2023-12-05 at 4 50 48 PM" src="https://github.com/growthbook/growthbook/assets/5298599/a5941c1a-e33c-41d7-8c21-34650f819f20">

old page config tab after:
<img width="1392" alt="Screenshot 2023-12-05 at 4 51 07 PM" src="https://github.com/growthbook/growthbook/assets/5298599/47629c56-eb68-443d-9711-3cfe259b8e9e">

Back-end SQL before:

```
__experimentExposures AS (
    -- Viewed Experiment
    SELECT
      e.user_id as user_id,
      cast(e.variation_id as varchar) as variation,
      e.timestamp as timestamp
    FROM
      __rawExperiment e
    WHERE
      e.experiment_id = 'checkout-layout'
      AND e.timestamp >= '2021-11-22 20:23:00'
      AND e.timestamp <= '2023-10-17 17:04:00'
  ),
  __activationMetric as ( -- Metric (any order)
    SELECT
      user_id as user_id,
      1 as value,
      m.timestamp as timestamp
    FROM
      (
        SELECT
          userid as user_id,
          timestamp as timestamp,
          qty,
          amount
        FROM
          orders
      ) m
    WHERE
      m.timestamp >= '2021-11-22 20:23:00'
      AND m.timestamp <= '2023-10-20 17:04:00'
  ),
  __experimentUnits AS (
    -- One row per user
    SELECT
      e.user_id AS user_id,
      (
        CASE
          WHEN count(distinct e.variation) > 1 THEN '__multiple__'
          ELSE max(e.variation)
        END
      ) AS variation,
      MIN(e.timestamp) AS first_exposure_timestamp,
      MIN(
        (
          CASE
            WHEN a.timestamp >= e.timestamp THEN a.timestamp
            ELSE NULL
          END
        )
      ) AS first_activation_timestamp
    FROM
      __experimentExposures e
      LEFT JOIN __activationMetric a ON (a.user_id = e.user_id)
    GROUP BY
      e.user_id
  ),
  __distinctUsers AS (
    SELECT
      user_id,
      cast('All' as varchar) AS dimension,
      variation,
      first_activation_timestamp AS timestamp,
      date_trunc('day', first_exposure_timestamp) AS first_exposure_date,
      first_exposure_timestamp AS preexposure_end,
      first_exposure_timestamp - INTERVAL '336 hours' AS preexposure_start
    FROM
      __experimentUnits
    WHERE
      first_activation_timestamp IS NOT NULL
      AND first_activation_timestamp <= '2023-10-17 17:04:00'
  ),
  ```
  Notice how we filter out `first_activation_timestamp <= '2023-10-17 17:04:00'` but we're nonsensically getting data in the activation metric CTE with `m.timestamp <= '2023-10-20 17:04:00'`
  
  Now after this change this same SQL snippet is:
  ```
  __experimentExposures AS (
    -- Viewed Experiment
    SELECT
      e.user_id as user_id,
      cast(e.variation_id as varchar) as variation,
      e.timestamp as timestamp
    FROM
      __rawExperiment e
    WHERE
      e.experiment_id = 'checkout-layout'
      AND e.timestamp >= '2021-11-22 20:23:00'
      AND e.timestamp <= '2023-10-17 17:04:00'
  ),
  __activationMetric as ( -- Metric (any order)
    SELECT
      user_id as user_id,
      1 as value,
      m.timestamp as timestamp
    FROM
      (
        SELECT
          userid as user_id,
          timestamp as timestamp,
          qty,
          amount
        FROM
          orders
      ) m
    WHERE
      m.timestamp >= '2021-11-22 20:23:00'
      AND m.timestamp <= '2023-10-17 17:04:00'
  ),
  __experimentUnits AS (
    -- One row per user
    SELECT
      e.user_id AS user_id,
      (
        CASE
          WHEN count(distinct e.variation) > 1 THEN '__multiple__'
          ELSE max(e.variation)
        END
      ) AS variation,
      MIN(e.timestamp) AS first_exposure_timestamp,
      MIN(
        (
          CASE
            WHEN a.timestamp >= e.timestamp THEN a.timestamp
            ELSE NULL
          END
        )
      ) AS first_activation_timestamp
    FROM
      __experimentExposures e
      LEFT JOIN __activationMetric a ON (a.user_id = e.user_id)
    GROUP BY
      e.user_id
  ),
  __distinctUsers AS (
    SELECT
      user_id,
      cast('All' as varchar) AS dimension,
      variation,
      first_activation_timestamp AS timestamp,
      date_trunc('day', first_exposure_timestamp) AS first_exposure_date,
      first_exposure_timestamp AS preexposure_end,
      first_exposure_timestamp - INTERVAL '336 hours' AS preexposure_start
    FROM
      __experimentUnits
    WHERE
      first_activation_timestamp IS NOT NULL
      AND first_activation_timestamp <= '2023-10-17 17:04:00'
  ),
  ```


