### PR TITLE
Fix bug - metric capping cannot be updated on old metrics

### DIFF
--- a/packages/back-end/src/util/migrations.ts
+++ b/packages/back-end/src/util/migrations.ts
@@ -84,7 +84,7 @@ export function upgradeMetricDoc(doc: LegacyMetricInterface): MetricInterface {
     });
   }
 
-  if (doc.cap) {
+  if (!doc.capping && doc.cap) {
     newDoc.capValue = doc.cap;
     newDoc.capping = "absolute";
   }

--- a/packages/back-end/test/migrations.test.ts
+++ b/packages/back-end/test/migrations.test.ts
@@ -132,6 +132,44 @@ describe("Metric Migration", () => {
     });
   });
 
+  it("doesn't overwrite new capping settings", () => {
+    const baseMetric: LegacyMetricInterface = {
+      datasource: "",
+      dateCreated: new Date(),
+      dateUpdated: new Date(),
+      description: "",
+      id: "",
+      ignoreNulls: false,
+      inverse: false,
+      name: "",
+      organization: "",
+      owner: "",
+      queries: [],
+      runStarted: null,
+      capping: "percentile",
+      capValue: 0.99,
+      type: "binomial",
+      userIdColumns: {
+        user_id: "user_id",
+        anonymous_id: "anonymous_id",
+      },
+      userIdTypes: ["anonymous_id", "user_id"],
+    };
+
+    expect(upgradeMetricDoc({ ...baseMetric, cap: 35 })).toEqual({
+      ...baseMetric,
+    });
+
+    const capZeroMetric: LegacyMetricInterface = {
+      ...baseMetric,
+      cap: 0,
+    };
+
+    expect(upgradeMetricDoc(capZeroMetric)).toEqual({
+      ...baseMetric,
+    });
+  });
+
   it("updates old metric objects - userIdType", () => {
     const baseMetric: LegacyMetricInterface = {
       datasource: "",


### PR DESCRIPTION
### Features and Changes

Old metrics that had a cap before we introduced percentile capping are unable to be updated. The new capping value is saved in the database, but it is overridden by the old capping value when used in the app.

This PR fixes the bug and adds a unit test to prevent regressions in the future.