### PR TITLE
Add CTA for users with 2+ exposure queries

### DIFF
--- a/packages/back-end/src/queryRunners/DimensionSlicesQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/DimensionSlicesQueryRunner.ts
@@ -35,7 +35,9 @@ export class DimensionSlicesQueryRunner extends QueryRunner<
     }));
 
     if (!dimensions.length) {
-      throw new Error("Exposure query must have at least 1 dimension.");
+      throw new Error(
+        "Exposure query must have at least 1 dimension to get dimension slices."
+      );
     }
 
     return [

--- a/packages/front-end/components/Experiment/TabbedPage/HealthTab.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/HealthTab.tsx
@@ -11,8 +11,12 @@ import TrafficCard from "@/components/HealthTab/TrafficCard";
 import { IssueTags, IssueValue } from "@/components/HealthTab/IssueTags";
 import LoadingSpinner from "@/components/LoadingSpinner";
 import { useDefinitions } from "@/services/DefinitionsContext";
+import track from "@/services/track";
 import { useSnapshot } from "../SnapshotProvider";
-import { HealthTabOnboardingModal } from "./HealthTabOnboardingModal";
+import {
+  HealthTabConfigParams,
+  HealthTabOnboardingModal,
+} from "./HealthTabOnboardingModal";
 
 export interface Props {
   experiment: ExperimentInterfaceStringDates;
@@ -39,6 +43,11 @@ export default function HealthTab({
   const permissions = usePermissions();
   const { getDatasourceById } = useDefinitions();
   const datasource = getDatasourceById(experiment.datasource);
+
+  const exposureQuery = datasource?.settings.queries?.exposure?.find(
+    (e) => e.id === experiment.exposureQueryId
+  );
+
   const hasPermissionToConfigHealthTag =
     permissions.check("organizationSettings") &&
     permissions.check("runQueries", datasource?.projects || []) &&
@@ -48,6 +57,17 @@ export default function HealthTab({
 
   const [setupModalOpen, setSetupModalOpen] = useState<boolean>(false);
   const [loading, setLoading] = useState<boolean>(false);
+
+  const healthTabConfigParams: HealthTabConfigParams = {
+    experiment: experiment,
+    phase: phase,
+    exposureQueryDimensions: exposureQuery?.dimensions || [],
+    refreshOrganization: refreshOrganization,
+    mutateSnapshot: mutateSnapshot,
+    setAnalysisSettings: setAnalysisSettings,
+    setLoading: setLoading,
+    resetResultsSettings: resetResultsSettings,
+  };
 
   useEffect(() => {
     return () => {
@@ -81,21 +101,19 @@ export default function HealthTab({
             <Button
               className="mt-2 mb-2 ml-auto"
               style={{ width: "200px" }}
-              onClick={async () => setSetupModalOpen(true)}
+              onClick={async () => {
+                track("Health Tab Onboarding Opened", { source: "health-tab" });
+                setSetupModalOpen(true);
+              }}
             >
               Set up Health Tab
             </Button>
             {setupModalOpen ? (
               <HealthTabOnboardingModal
-                experiment={experiment}
-                phase={phase}
                 open={setupModalOpen}
                 close={() => setSetupModalOpen(false)}
-                refreshOrganization={refreshOrganization}
-                mutateSnapshot={mutateSnapshot}
-                setAnalysisSettings={setAnalysisSettings}
-                setLoading={setLoading}
-                resetResultsSettings={resetResultsSettings}
+                healthTabOnboardingPurpose={"setup"}
+                healthTabConfigParams={healthTabConfigParams}
               />
             ) : null}
           </>
@@ -187,6 +205,7 @@ export default function HealthTab({
           variations={variations}
           totalUsers={totalUsers}
           onNotify={handleDrawerNotify}
+          healthTabConfigParams={healthTabConfigParams}
         />
       </div>
 

--- a/packages/front-end/components/Experiment/TabbedPage/HealthTab.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/HealthTab.tsx
@@ -59,14 +59,14 @@ export default function HealthTab({
   const [loading, setLoading] = useState<boolean>(false);
 
   const healthTabConfigParams: HealthTabConfigParams = {
-    experiment: experiment,
-    phase: phase,
+    experiment,
+    phase,
     exposureQueryDimensions: exposureQuery?.dimensions || [],
-    refreshOrganization: refreshOrganization,
-    mutateSnapshot: mutateSnapshot,
-    setAnalysisSettings: setAnalysisSettings,
-    setLoading: setLoading,
-    resetResultsSettings: resetResultsSettings,
+    refreshOrganization,
+    mutateSnapshot,
+    setAnalysisSettings,
+    setLoading,
+    resetResultsSettings,
   };
 
   useEffect(() => {

--- a/packages/front-end/components/Experiment/TabbedPage/HealthTabOnboardingModal.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/HealthTabOnboardingModal.tsx
@@ -210,6 +210,8 @@ export const HealthTabOnboardingModal: FC<HealthTabOnboardingModalProps> = ({
     data?.dimensionSlices?.results &&
     data.dimensionSlices.results.length > 0;
 
+  const showDimensionsPage = exposureQueryDimensions.length > 0;
+
   const pages: {
     header: string;
     children: ReactElement;
@@ -229,7 +231,7 @@ export const HealthTabOnboardingModal: FC<HealthTabOnboardingModalProps> = ({
         <button
           className={`btn btn-primary`}
           type="submit"
-          onClick={() => setStep(exposureQueryDimensions.length ? 1 : 2)}
+          onClick={() => setStep(showDimensionsPage ? 1 : 2)}
         >
           {"Next >"}
         </button>
@@ -264,7 +266,12 @@ export const HealthTabOnboardingModal: FC<HealthTabOnboardingModalProps> = ({
       secondaryCTA: (
         <>
           {healthTabOnboardingPurpose === "setup" ? (
-            <button className={`btn btn-link`} onClick={() => setStep(2)}>
+            <button
+              className={`btn btn-link`}
+              onClick={() => {
+                setStep(2);
+              }}
+            >
               {"Skip"}
             </button>
           ) : null}
@@ -315,7 +322,10 @@ export const HealthTabOnboardingModal: FC<HealthTabOnboardingModalProps> = ({
       ),
       secondaryCTA: (
         <>
-          <button className={`btn btn-link`} onClick={() => setStep(1)}>
+          <button
+            className={`btn btn-link`}
+            onClick={() => setStep(showDimensionsPage ? 1 : 0)}
+          >
             {"< Back"}
           </button>
           <div className="flex-1" />

--- a/packages/front-end/components/HealthTab/DimensionIssues.tsx
+++ b/packages/front-end/components/HealthTab/DimensionIssues.tsx
@@ -8,6 +8,10 @@ import VariationUsersTable from "../Experiment/TabbedPage/VariationUsersTable";
 import Modal from "../Modal";
 import SelectField from "../Forms/SelectField";
 import SRMWarning from "../Experiment/SRMWarning";
+import {
+  HealthTabConfigParams,
+  HealthTabOnboardingModal,
+} from "../Experiment/TabbedPage/HealthTabOnboardingModal";
 import { EXPERIMENT_DIMENSION_PREFIX, srmHealthCheck } from "./SRMDrawer";
 import HealthCard from "./HealthCard";
 import { IssueTags, IssueValue } from "./IssueTags";
@@ -18,6 +22,7 @@ interface Props {
     [dimension: string]: ExperimentSnapshotTrafficDimension[];
   };
   variations: ExperimentReportVariation[];
+  healthTabConfigParams: HealthTabConfigParams;
 }
 
 type DimensionWithIssues = {
@@ -69,9 +74,14 @@ export function transformDimensionData(
   );
 }
 
-export const DimensionIssues = ({ dimensionData, variations }: Props) => {
+export const DimensionIssues = ({
+  dimensionData,
+  variations,
+  healthTabConfigParams,
+}: Props) => {
   const { settings } = useUser();
   const [modalOpen, setModalOpen] = useState(false);
+  const [setupModalOpen, setSetupModalOpen] = useState(false);
 
   const srmThreshold = settings.srmThreshold ?? DEFAULT_SRM_THRESHOLD;
 
@@ -274,11 +284,43 @@ export const DimensionIssues = ({ dimensionData, variations }: Props) => {
             </div>
           </>
         ) : (
-          <div className="pt-4 px-4">
-            <i className="text-muted">
-              No experiment dimensions with pre-defined slices available
-            </i>
-          </div>
+          <>
+            <div className="pt-4 px-4">
+              <i className="text-muted">
+                {`No experiment dimensions ${
+                  healthTabConfigParams.exposureQueryDimensions.length > 0
+                    ? "with pre-defined slices available"
+                    : "available"
+                }`}
+              </i>
+            </div>
+            {healthTabConfigParams.exposureQueryDimensions.length ? (
+              <div className="pt-4 d-flex justify-content-center">
+                <div>
+                  <a
+                    href="#"
+                    className="btn btn-outline-primary"
+                    onClick={() => {
+                      track("Health Tab Onboarding Opened", {
+                        source: "dimension-issues",
+                      });
+                      setSetupModalOpen(true);
+                    }}
+                  >
+                    Configure experiment dimension slices
+                  </a>
+                </div>
+                {setupModalOpen ? (
+                  <HealthTabOnboardingModal
+                    open={setupModalOpen}
+                    close={() => setSetupModalOpen(false)}
+                    healthTabConfigParams={healthTabConfigParams}
+                    healthTabOnboardingPurpose={"dimensions"}
+                  />
+                ) : null}
+              </div>
+            ) : null}
+          </>
         )}
       </div>
     </>

--- a/packages/front-end/components/HealthTab/SRMDrawer.tsx
+++ b/packages/front-end/components/HealthTab/SRMDrawer.tsx
@@ -6,6 +6,7 @@ import { DEFAULT_SRM_THRESHOLD } from "@/pages/settings";
 import VariationUsersTable from "../Experiment/TabbedPage/VariationUsersTable";
 import SRMWarning from "../Experiment/SRMWarning";
 import { DataPointVariation } from "../Experiment/ExperimentDateGraph";
+import { HealthTabConfigParams } from "../Experiment/TabbedPage/HealthTabOnboardingModal";
 import { HealthStatus, StatusBadge } from "./StatusBadge";
 import { DimensionIssues } from "./DimensionIssues";
 import { IssueValue } from "./IssueTags";
@@ -15,6 +16,7 @@ interface Props {
   variations: ExperimentReportVariation[];
   totalUsers: number;
   onNotify: (issue: IssueValue) => void;
+  healthTabConfigParams: HealthTabConfigParams;
 }
 
 export const srmHealthCheck = ({
@@ -43,6 +45,7 @@ export default function SRMDrawer({
   variations,
   totalUsers,
   onNotify,
+  healthTabConfigParams,
 }: Props) {
   const { settings } = useUser();
 
@@ -144,6 +147,7 @@ export default function SRMDrawer({
           <DimensionIssues
             dimensionData={traffic.dimension}
             variations={variations}
+            healthTabConfigParams={healthTabConfigParams}
           />
         </div>
       </div>

--- a/packages/front-end/components/Settings/EditDataSource/DimensionMetadata/UpdateDimensionMetadata.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/DimensionMetadata/UpdateDimensionMetadata.tsx
@@ -429,7 +429,8 @@ export const DimensionSlicesResults: FC<DimensionSlicesProps> = ({
                     </>
                   ) : (
                     <div className="text-muted">
-                      {status !== "running" && !dimensionSlices
+                      {status !== "running" &&
+                      (!dimensionSlices || !dimensionValueResult)
                         ? "Run dimension slices query to populate"
                         : status === "succeeded" &&
                           dimensionSlices?.results?.length === 0


### PR DESCRIPTION
Adds CTA for when health tab == on but no experiment dimensions are configured:
* if they "skipped" during setup
* if they are on a health page for an experiment that is not using the same exposure query as the one they went through setup with

loom: https://www.loom.com/share/5ef2ea800b39405a854ff8ae0fd275f0