### PR TITLE
Better debugging for fact table filters

### DIFF
--- a/packages/back-end/src/routers/fact-table/fact-table.router.ts
+++ b/packages/back-end/src/routers/fact-table/fact-table.router.ts
@@ -10,6 +10,7 @@ import {
   updateFactMetricPropsValidator,
   updateColumnPropsValidator,
   updateFactTablePropsValidator,
+  testFactFilterPropsValidator,
 } from "./fact-table.validators";
 import * as rawFactTableController from "./fact-table.controller";
 
@@ -74,6 +75,15 @@ router.put(
     body: updateFactFilterPropsValidator,
   }),
   factTableController.putFactFilter
+);
+
+router.post(
+  "/fact-tables/:id/test-filter",
+  validateRequestMiddleware({
+    params: factTableParams,
+    body: testFactFilterPropsValidator,
+  }),
+  factTableController.postFactFilterTest
 );
 
 router.delete(

--- a/packages/back-end/src/routers/fact-table/fact-table.validators.ts
+++ b/packages/back-end/src/routers/fact-table/fact-table.validators.ts
@@ -153,3 +153,9 @@ export const updateFactFilterPropsValidator = z
     value: z.string(),
   })
   .strict();
+
+export const testFactFilterPropsValidator = z
+  .object({
+    value: z.string(),
+  })
+  .strict();

--- a/packages/back-end/types/fact-table.d.ts
+++ b/packages/back-end/types/fact-table.d.ts
@@ -14,7 +14,9 @@ import {
   cappingValidator,
   conversionWindowUnitValidator,
   factTableColumnTypeValidator,
+  testFactFilterPropsValidator,
 } from "../src/routers/fact-table/fact-table.validators";
+import { TestQueryRow } from "../src/types/Integration";
 
 export type FactTableColumnType = z.infer<typeof factTableColumnTypeValidator>;
 export type NumberFormat = z.infer<typeof numberFormatValidator>;
@@ -115,6 +117,8 @@ export type CreateFactFilterProps = z.infer<
 export type UpdateFactFilterProps = z.infer<
   typeof updateFactFilterPropsValidator
 >;
+export type TestFactFilterProps = z.infer<typeof testFactFilterPropsValidator>;
+
 export type UpdateColumnProps = z.infer<typeof updateColumnPropsValidator>;
 export type CreateColumnProps = z.infer<typeof createColumnPropsValidator>;
 
@@ -126,3 +130,10 @@ export type UpdateFactMetricProps = z.infer<
 >;
 
 export type FactTableMap = Map<string, FactTableInterface>;
+
+export type FactFilterTestResults = {
+  sql: string;
+  duration?: number;
+  error?: string;
+  results?: TestQueryRow[];
+};

--- a/packages/front-end/components/FactTables/FactFilterModal.tsx
+++ b/packages/front-end/components/FactTables/FactFilterModal.tsx
@@ -234,6 +234,7 @@ export default function FactFilterModal({ existing, factTable, close }: Props) {
             sql={testResult.sql || ""}
             error={testResult.error || ""}
             close={() => setTestResult(null)}
+            expandable={true}
           />
         </div>
       ) : null}

--- a/packages/front-end/components/FactTables/FactFilterModal.tsx
+++ b/packages/front-end/components/FactTables/FactFilterModal.tsx
@@ -156,38 +156,22 @@ export default function FactFilterModal({ existing, factTable, close }: Props) {
             minRows={1}
             helpText={
               <>
-                Will be inserted into a WHERE clause to limit rows included in a
-                fact or metric
+                When this filter is added to a metric, this will be inserted
+                into the WHERE clause.{" "}
+                <a
+                  href="#"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    setShowExamples(!showExamples);
+                  }}
+                >
+                  {showExamples ? "Hide" : "Show"} examples{" "}
+                  {showExamples ? <FaAngleDown /> : <FaAngleRight />}
+                </a>
               </>
             }
             {...form.register("value")}
           />
-
-          <div className="d-flex align-items-center">
-            <Button
-              color="primary"
-              className="btn-sm mr-4"
-              onClick={async () => {
-                await testQuery(form.watch("value"));
-              }}
-            >
-              <span className="pr-2">
-                <FaPlay />
-              </span>
-              Test Query
-            </Button>
-
-            <a
-              href="#"
-              onClick={(e) => {
-                e.preventDefault();
-                setShowExamples(!showExamples);
-              }}
-            >
-              {showExamples ? "Hide" : "Show"} examples{" "}
-              {showExamples ? <FaAngleDown /> : <FaAngleRight />}
-            </a>
-          </div>
 
           {showExamples && (
             <div className="alert alert-info">
@@ -219,6 +203,19 @@ export default function FactFilterModal({ existing, factTable, close }: Props) {
               </table>
             </div>
           )}
+
+          <Button
+            color="primary"
+            className="btn-sm mr-4"
+            onClick={async () => {
+              await testQuery(form.watch("value"));
+            }}
+          >
+            <span className="pr-2">
+              <FaPlay />
+            </span>
+            Test Query
+          </Button>
         </div>
         {factTable.columns?.some((col) => !col.deleted) ? (
           <div className="col-auto border-left">

--- a/packages/front-end/components/FactTables/FactFilterModal.tsx
+++ b/packages/front-end/components/FactTables/FactFilterModal.tsx
@@ -1,12 +1,13 @@
 import {
   CreateFactFilterProps,
   FactFilterInterface,
+  FactFilterTestResults,
   FactTableInterface,
   UpdateFactFilterProps,
 } from "back-end/types/fact-table";
 import { useForm } from "react-hook-form";
 import { useEffect, useState } from "react";
-import { FaAngleDown, FaAngleRight } from "react-icons/fa";
+import { FaAngleDown, FaAngleRight, FaPlay } from "react-icons/fa";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import { useAuth } from "@/services/auth";
 import track from "@/services/track";
@@ -14,6 +15,8 @@ import Modal from "../Modal";
 import Field from "../Forms/Field";
 import MarkdownInput from "../Markdown/MarkdownInput";
 import InlineCode from "../SyntaxHighlighting/InlineCode";
+import DisplayTestQueryResults from "../Settings/DisplayTestQueryResults";
+import Button from "../Button";
 import FactTableSchema from "./FactTableSchema";
 
 export interface Props {
@@ -28,6 +31,12 @@ export default function FactFilterModal({ existing, factTable, close }: Props) {
   const [showDescription, setShowDescription] = useState(
     !!existing?.description?.length
   );
+
+  const [testResult, setTestResult] = useState<null | FactFilterTestResults>(
+    null
+  );
+
+  const [testBeforeSave, setTestBeforeSave] = useState(true);
 
   const [showExamples, setShowExamples] = useState(false);
 
@@ -48,6 +57,18 @@ export default function FactFilterModal({ existing, factTable, close }: Props) {
     );
   }, [isNew]);
 
+  const testQuery = async (value: string) => {
+    setTestResult(null);
+    const result = await apiCall<{
+      result: FactFilterTestResults;
+    }>(`/fact-tables/${factTable.id}/test-filter`, {
+      method: "POST",
+      body: JSON.stringify({ value }),
+    });
+    setTestResult(result.result);
+    return result.result;
+  };
+
   return (
     <Modal
       open={true}
@@ -61,6 +82,13 @@ export default function FactFilterModal({ existing, factTable, close }: Props) {
 
         if (!value.value) {
           throw new Error("Cannot leave Filter SQL blank");
+        }
+
+        if (testBeforeSave) {
+          const result = await testQuery(value.value);
+          if (result.error) {
+            throw new Error("Fix errors before saving");
+          }
         }
 
         if (existing) {
@@ -83,6 +111,17 @@ export default function FactFilterModal({ existing, factTable, close }: Props) {
         }
         mutateDefinitions();
       })}
+      secondaryCTA={
+        <label className="mr-4">
+          <input
+            type="checkbox"
+            className="form-check-input"
+            checked={testBeforeSave}
+            onChange={(e) => setTestBeforeSave(e.target.checked)}
+          />
+          Test before saving
+        </label>
+      }
     >
       <div className="row">
         <div className="col">
@@ -114,6 +153,7 @@ export default function FactFilterModal({ existing, factTable, close }: Props) {
             label="Filter SQL"
             required
             textarea
+            minRows={1}
             helpText={
               <>
                 Will be inserted into a WHERE clause to limit rows included in a
@@ -123,16 +163,32 @@ export default function FactFilterModal({ existing, factTable, close }: Props) {
             {...form.register("value")}
           />
 
-          <a
-            href="#"
-            onClick={(e) => {
-              e.preventDefault();
-              setShowExamples(!showExamples);
-            }}
-          >
-            {showExamples ? "Hide" : "Show"} examples{" "}
-            {showExamples ? <FaAngleDown /> : <FaAngleRight />}
-          </a>
+          <div className="d-flex align-items-center">
+            <Button
+              color="primary"
+              className="btn-sm mr-4"
+              onClick={async () => {
+                await testQuery(form.watch("value"));
+              }}
+            >
+              <span className="pr-2">
+                <FaPlay />
+              </span>
+              Test Query
+            </Button>
+
+            <a
+              href="#"
+              onClick={(e) => {
+                e.preventDefault();
+                setShowExamples(!showExamples);
+              }}
+            >
+              {showExamples ? "Hide" : "Show"} examples{" "}
+              {showExamples ? <FaAngleDown /> : <FaAngleRight />}
+            </a>
+          </div>
+
           {showExamples && (
             <div className="alert alert-info">
               <div className="mb-2">Here are some examples of Filter SQL:</div>
@@ -173,6 +229,17 @@ export default function FactFilterModal({ existing, factTable, close }: Props) {
           </div>
         ) : null}
       </div>
+      {testResult ? (
+        <div className="border-top mt-3 pt-2">
+          <DisplayTestQueryResults
+            duration={testResult.duration || 0}
+            results={testResult.results || []}
+            sql={testResult.sql || ""}
+            error={testResult.error || ""}
+            close={() => setTestResult(null)}
+          />
+        </div>
+      ) : null}
     </Modal>
   );
 }

--- a/packages/front-end/components/Settings/DisplayTestQueryResults.tsx
+++ b/packages/front-end/components/Settings/DisplayTestQueryResults.tsx
@@ -11,6 +11,7 @@ export type Props = {
   sql: string;
   error: string;
   close: () => void;
+  expandable?: boolean;
 };
 
 export default function DisplayTestQueryResults({
@@ -19,6 +20,7 @@ export default function DisplayTestQueryResults({
   sql,
   error,
   close,
+  expandable,
 }: Props) {
   const cols = Object.keys(results?.[0] || {});
 
@@ -114,7 +116,12 @@ export default function DisplayTestQueryResults({
                 </div>
               )
             )}
-            <Code code={sql} language="sql" errorLine={errorLine} />
+            <Code
+              code={sql}
+              language="sql"
+              errorLine={errorLine}
+              expandable={expandable}
+            />
           </div>
         </Tab>
       </ControlledTabs>


### PR DESCRIPTION
### Features and Changes

New "Test Query" button when adding/editing a filter.  Plus, a checkbox to opt-out of testing before saving (for edge cases).

![image](https://github.com/growthbook/growthbook/assets/1087514/10f9baeb-0560-444d-a739-e3a6cb5c147f)

When run, it will show you a sample of 5 rows that match your filter:

![image](https://github.com/growthbook/growthbook/assets/1087514/4ba4c10c-ea22-4fbd-811f-46d19e092f98)

If there's an error or no rows returned, we show you the fully rendered SQL to help with debugging:

![image](https://github.com/growthbook/growthbook/assets/1087514/ede9327e-4c90-463f-b699-4d4327e97b4c)

![image](https://github.com/growthbook/growthbook/assets/1087514/46f5cc30-6fb1-4e50-be34-4b10374ccd7e)


