### PR TITLE
Replace Papercups with Pylon

### DIFF
--- a/packages/front-end/components/Auth/InAppHelp.tsx
+++ b/packages/front-end/components/Auth/InAppHelp.tsx
@@ -8,30 +8,29 @@ import { GBPremiumBadge } from "../Icons";
 import UpgradeModal from "../Settings/UpgradeModal";
 
 export default function InAppHelp() {
-  const { app_id, script_content } = useFeature("pylon-config").value;
+  const config = useFeature("pylon-config").value;
   const [showFreeHelpWidget, setShowFreeHelpWidget] = useState(false);
   const [upgradeModal, setUpgradeModal] = useState(false);
   const { name, email, hasCommercialFeature } = useUser();
-  const showUpgradeModal =
-    app_id && script_content && !hasCommercialFeature("livechat") && isCloud();
+  const showUpgradeModal = !hasCommercialFeature("livechat") && isCloud();
 
   useEffect(() => {
-    if (window["pylon"] || !app_id || !script_content) return;
+    if (window["pylon"] || !config) return;
 
     if (hasCommercialFeature("livechat") && isCloud()) {
       const scriptElement = document.createElement("script");
-      scriptElement.innerHTML = script_content;
+      scriptElement.innerHTML = config.script_content;
 
       document.body.appendChild(scriptElement);
       window["pylon"] = {
         chat_settings: {
-          app_id: app_id,
+          app_id: config.app_id,
           email,
           name,
         },
       };
     }
-  }, [app_id, script_content]);
+  }, [config]);
 
   // If the Pylon key exists on the window, we're showing the Pylon widget, so don't show the freeHelpModal
   if (window["pylon"]) return null;

--- a/packages/front-end/components/Auth/InAppHelp.tsx
+++ b/packages/front-end/components/Auth/InAppHelp.tsx
@@ -8,32 +8,30 @@ import { GBPremiumBadge } from "../Icons";
 import UpgradeModal from "../Settings/UpgradeModal";
 
 export default function InAppHelp() {
-  const config = useFeature("pylon-config").value;
+  const { app_id, script_content } = useFeature("pylon-config").value;
   const [showFreeHelpWidget, setShowFreeHelpWidget] = useState(false);
   const [upgradeModal, setUpgradeModal] = useState(false);
   const { name, email, hasCommercialFeature } = useUser();
   const showUpgradeModal =
-    config && !hasCommercialFeature("livechat") && isCloud();
+    app_id && script_content && !hasCommercialFeature("livechat") && isCloud();
 
   useEffect(() => {
-    if (window["pylon"] || !config) return;
+    if (window["pylon"] || !app_id || !script_content) return;
 
     if (hasCommercialFeature("livechat") && isCloud()) {
       const scriptElement = document.createElement("script");
-      scriptElement.type = "text/javascript";
-      const scriptContent = `(function(){var e=window;var t=document;var n=function(){n.e(arguments)};n.q=[];n.e=function(e){n.q.push(e)};e.Pylon=n;var r=function(){var e=t.createElement("script");e.setAttribute("type","text/javascript");e.setAttribute("async","true");e.setAttribute("src","https://widget.usepylon.com/widget/${config.APP_ID}");var n=t.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};if(t.readyState==="complete"){r()}else if(e.addEventListener){e.addEventListener("load",r,false)}})();`;
-      scriptElement.innerHTML = scriptContent;
+      scriptElement.innerHTML = script_content;
 
       document.body.appendChild(scriptElement);
       window["pylon"] = {
         chat_settings: {
-          app_id: config.APP_ID,
+          app_id: app_id,
           email,
           name,
         },
       };
     }
-  }, [config]);
+  }, [app_id, script_content]);
 
   // If the Pylon key exists on the window, we're showing the Pylon widget, so don't show the freeHelpModal
   if (window["pylon"]) return null;

--- a/packages/front-end/components/Auth/InAppHelp.tsx
+++ b/packages/front-end/components/Auth/InAppHelp.tsx
@@ -8,36 +8,35 @@ import { GBPremiumBadge } from "../Icons";
 import UpgradeModal from "../Settings/UpgradeModal";
 
 export default function InAppHelp() {
-  const config = useFeature("papercups-config").value;
+  const config = useFeature("pylon-config").value;
   const [showFreeHelpWidget, setShowFreeHelpWidget] = useState(false);
   const [upgradeModal, setUpgradeModal] = useState(false);
-  const { name, email, userId, hasCommercialFeature } = useUser();
+  const { name, email, hasCommercialFeature } = useUser();
   const showUpgradeModal =
     config && !hasCommercialFeature("livechat") && isCloud();
 
   useEffect(() => {
-    if (window["Papercups"] || !config) return;
+    if (window["pylon"] || !config) return;
 
     if (hasCommercialFeature("livechat") && isCloud()) {
-      window["Papercups"] = {
-        config: {
-          ...config,
-          customer: {
-            name,
-            email,
-            external_id: userId,
-          },
+      const scriptElement = document.createElement("script");
+      scriptElement.type = "text/javascript";
+      const scriptContent = `(function(){var e=window;var t=document;var n=function(){n.e(arguments)};n.q=[];n.e=function(e){n.q.push(e)};e.Pylon=n;var r=function(){var e=t.createElement("script");e.setAttribute("type","text/javascript");e.setAttribute("async","true");e.setAttribute("src","https://widget.usepylon.com/widget/${config.APP_ID}");var n=t.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};if(t.readyState==="complete"){r()}else if(e.addEventListener){e.addEventListener("load",r,false)}})();`;
+      scriptElement.innerHTML = scriptContent;
+
+      document.body.appendChild(scriptElement);
+      window["pylon"] = {
+        chat_settings: {
+          app_id: config.APP_ID,
+          email,
+          name,
         },
       };
-      const s = document.createElement("script");
-      s.async = true;
-      s.src = config.baseUrl + "/widget.js";
-      document.head.appendChild(s);
     }
   }, [config]);
 
-  // If the Papercup key exists on the window, we're showing the Papercups widget, so don't show the freeHelpModal
-  if (window["Papercups"]) return null;
+  // If the Pylon key exists on the window, we're showing the Pylon widget, so don't show the freeHelpModal
+  if (window["pylon"]) return null;
 
   return (
     <>


### PR DESCRIPTION
### Features and Changes

This PR updates our In-App chat widget to use the Pylon chat widget, rather than the Papercups widget. Accompanied by this, is a new Feature Flag in our GrowthBook org for `pylon-config`.

This PR doesn't change any of the logic of who gets this in-app chat widget, vs the other help widget.

### Screenshots
<img width="1512" alt="Screen Shot 2023-12-13 at 2 28 29 PM" src="https://github.com/growthbook/growthbook/assets/75274610/46ab5dd8-c08c-4317-990e-b78ec71533fa">

<img width="447" alt="Screen Shot 2023-12-14 at 6 37 08 AM" src="https://github.com/growthbook/growthbook/assets/75274610/169c7212-22f4-491c-b7d3-6032ff235e46">

<img width="1512" alt="Screen Shot 2023-12-13 at 2 28 46 PM" src="https://github.com/growthbook/growthbook/assets/75274610/d6714242-ceae-45d5-b276-e709cbf3b1e3">
