### PR TITLE
Fix UI for multiple exposures setting

### DIFF
--- a/packages/front-end/pages/settings/index.tsx
+++ b/packages/front-end/pages/settings/index.tsx
@@ -822,19 +822,24 @@ const GeneralSettingsPage = (): React.ReactElement => {
                   />
 
                   <Field
-                    label="Warn when this percent of experiment users are in multiple variations"
+                    label="Warn when this proportion of experiment users are in multiple variations"
                     type="number"
                     step="any"
                     min="0"
                     max="1"
                     className="ml-2"
                     containerClassName="mb-3"
-                    append="%"
+                    append=""
                     style={{
                       width: "80px",
                     }}
                     disabled={hasFileConfig()}
-                    helpText={<span className="ml-2">from 0 to 1</span>}
+                    helpText={
+                      <span className="ml-2">{`(${
+                        (form.getValues("multipleExposureMinPercent") ?? 0.01) *
+                        100
+                      }% of users)`}</span>
+                    }
                     {...form.register("multipleExposureMinPercent", {
                       valueAsNumber: true,
                       min: 0,


### PR DESCRIPTION
Before: a setting that ranges from 0-1 was called a percent, when really it's a proportion that needs to be * 100 to be a percent
<img width="696" alt="Screenshot 2023-12-13 at 2 01 48 PM" src="https://github.com/growthbook/growthbook/assets/5298599/18a8d4bf-9efd-4512-9ed4-02d3fd11dbe8">


After: just be more explicit about what they're setting
<img width="659" alt="image" src="https://github.com/growthbook/growthbook/assets/5298599/8f814d22-c304-44ae-aa1a-1ad26d7bd0ff">


It'd be great if we could just make the field a percent but I don't want to mess with all our data models and field names for this.