### PR TITLE
Added fix for new line errors on private keys when importing

### DIFF
--- a/packages/back-end/src/services/organizations.ts
+++ b/packages/back-end/src/services/organizations.ts
@@ -621,6 +621,10 @@ export async function importConfig(
         if (!ds) return;
         k = k.toLowerCase();
         try {
+          if (ds?.params && "privateKey" in ds.params) {
+            // Fix newlines in the private keys:
+            ds.params.privateKey = ds.params?.privateKey?.replace(/\\n/g, "\n");
+          }
           const existing = await getDataSourceById(k, organization.id);
           if (existing) {
             let params = existing.params;
@@ -650,7 +654,6 @@ export async function importConfig(
                 },
               },
             };
-
             await updateDataSource(existing, organization.id, updates);
           } else {
             await createDataSource(


### PR DESCRIPTION
When importing previously exported Config.yml files, that have BigQuery data connections, sometimes the privateKey will have doubly encoded new line characters that cause the connection importing to fail. 