### PR TITLE
Fix experiments with broken namespaces

### DIFF
--- a/packages/back-end/src/util/migrations.ts
+++ b/packages/back-end/src/util/migrations.ts
@@ -432,6 +432,15 @@ export function upgradeExperimentDoc(
         name: "",
         range: [0, 1],
       };
+      // Some experiments have a namespace with only `enabled` set, no idea why
+      // This breaks namespaces, so add default values if missing
+      if (!phase.namespace.range) {
+        phase.namespace = {
+          enabled: false,
+          name: "",
+          range: [0, 1],
+        };
+      }
     });
   }
 


### PR DESCRIPTION
### Features and Changes

Some experiments were being saved with invalid namespace settings.  Specifically, one had the namespace set to `{ enabled: true }` (missing the name and range).  This breaks some of the back-end code that is expecting all namespace settings to contain a range.

This PR adds a migration to auto-fix any experiment phases that happen to get into this broken state.  We should also investigate how exactly experiments can get into this broken state in the first place, but this should fix the issue for now.