### PR TITLE
add existence check for settings

### DIFF
--- a/packages/back-end/src/services/licenseData.ts
+++ b/packages/back-end/src/services/licenseData.ts
@@ -41,7 +41,7 @@ async function getMetaData() {
     dataSourceTypes = Array.from(new Set(dataSources.map((ds) => ds.type)));
 
     eventTrackers = Array.from(
-      new Set(dataSources.map((ds) => ds.settings.schemaFormat ?? "custom"))
+      new Set(dataSources.map((ds) => ds.settings?.schemaFormat ?? "custom"))
     );
   }
 


### PR DESCRIPTION
### Features and Changes

Stops an error being thrown if settings doesn't exist on a datasource.  In general that shouldn't happen as it is a required field, but it doesn't hurt being defensive here as this is not used for any core functionality.

### Testing

manually delete the settings from a datasource.
start the app and see it load.
