### PR TITLE
fix: parse form field value to number when attribute datatype is number

### DIFF
--- a/packages/front-end/components/Archetype/AttributeForm.tsx
+++ b/packages/front-end/components/Archetype/AttributeForm.tsx
@@ -152,7 +152,12 @@ export default function AttributeForm({
                 className=""
                 {...attributeForm.register(attribute.property)}
                 onChange={(e) => {
-                  attributeForm.setValue(attribute.property, e.target.value);
+                  attributeForm.setValue(
+                    attribute.property,
+                    attribute.datatype === "number"
+                      ? Number(e.target.value)
+                      : e.target.value
+                  );
                   updateFormValues();
                 }}
               />


### PR DESCRIPTION
### Features and Changes

Add a condition to parse form field value to number when attribute datatype is number

<!--
  Include a description of your changes.
  If there are any new tools, API's, etc. that devs can leverage, it may be helpful to include usage info.
-->

<!--
  Indicate which issue this will close, if applicable
  For multiple issues, add a new `- Closes` or `- Fixes` line
-->

- Closes #1952 

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

<!--
  Please describe how to test these changes.
 -->

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
https://github.com/growthbook/growthbook/assets/39362422/fe4084a9-941c-4b8c-bf08-6c48c795f5ed
