### PR TITLE
Always set snapshot analysis settings to default with new snapshot

### DIFF
--- a/packages/front-end/components/Experiment/AnalysisSettingsBar.tsx
+++ b/packages/front-end/components/Experiment/AnalysisSettingsBar.tsx
@@ -411,6 +411,7 @@ export default function AnalysisSettingsBar({
                     experiment={experiment}
                     lastAnalysis={analysis}
                     dimension={dimension}
+                    setAnalysisSettings={setAnalysisSettings}
                     onSubmit={() => {
                       if (baselineRow !== 0) {
                         setBaselineRow?.(0);

--- a/packages/front-end/components/Experiment/RefreshSnapshotButton.tsx
+++ b/packages/front-end/components/Experiment/RefreshSnapshotButton.tsx
@@ -4,6 +4,7 @@ import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
 import {
   ExperimentSnapshotInterface,
   ExperimentSnapshotAnalysis,
+  ExperimentSnapshotAnalysisSettings,
 } from "back-end/types/experiment-snapshot";
 import { useAuth } from "@/services/auth";
 import { useDefinitions } from "@/services/DefinitionsContext";
@@ -17,6 +18,9 @@ const RefreshSnapshotButton: FC<{
   lastAnalysis?: ExperimentSnapshotAnalysis;
   phase: number;
   dimension?: string;
+  setAnalysisSettings: (
+    settings: ExperimentSnapshotAnalysisSettings | null
+  ) => void;
   onSubmit?: () => void;
   newUi?: boolean;
 }> = ({
@@ -25,6 +29,7 @@ const RefreshSnapshotButton: FC<{
   lastAnalysis,
   phase,
   dimension,
+  setAnalysisSettings,
   onSubmit,
   newUi = false,
 }) => {
@@ -54,6 +59,7 @@ const RefreshSnapshotButton: FC<{
         dimension,
       }),
     });
+    setAnalysisSettings(null);
     trackSnapshot(
       "create",
       "RefreshSnapshotButton",

--- a/packages/front-end/components/Experiment/TabbedPage/AnalysisSettingsSummary.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/AnalysisSettingsSummary.tsx
@@ -392,6 +392,7 @@ export default function AnalysisSettingsSummary({
                   experiment={experiment}
                   lastAnalysis={analysis}
                   dimension={dimension}
+                  setAnalysisSettings={setAnalysisSettings}
                   onSubmit={() => {
                     if (baselineRow !== 0) {
                       setBaselineRow?.(0);
@@ -459,6 +460,12 @@ export default function AnalysisSettingsSummary({
                       }
                     )
                       .then((res) => {
+                        setAnalysisSettings(null);
+                        if (baselineRow !== 0) {
+                          setBaselineRow?.(0);
+                          setVariationFilter?.([]);
+                        }
+                        setDifferenceType("relative");
                         trackSnapshot(
                           "create",
                           "ForceRerunQueriesButton",


### PR DESCRIPTION
Ensure we're always resetting analysis settings. Not sure why this wasn't a problem before, but may have been to do with hoisting up some of the `setBaselineVariation` and `setDifferenceType` functions that I did for the health tab onboarding.

Bugfix, before: https://www.loom.com/share/599c7c295a4e470d82235030604a72c4

After: https://www.loom.com/share/4f9836859a544e5bba3d69748005d11d