### PR TITLE
Pass through databricks error

### DIFF
--- a/packages/back-end/src/services/databricks.ts
+++ b/packages/back-end/src/services/databricks.ts
@@ -74,6 +74,6 @@ export async function runDatabricksQuery<T>(
     if (e.response?.displayMessage) {
       throw new Error(e.response.displayMessage);
     }
-    throw e;
+    throw new Error(e.message);
   }
 }

--- a/packages/back-end/src/services/databricks.ts
+++ b/packages/back-end/src/services/databricks.ts
@@ -15,57 +15,65 @@ export async function runDatabricksQuery<T>(
   // Annoyingly, the `client.connect` method is async, but if there's an error,
   // it just hangs and never rejects. Instead, it emits an "error" event.
   // So we have to wrap everything in a `new Promise()` and handle errors manually
-  const result = await new Promise<T[]>((resolve, reject) => {
-    const client = new DBSQLClient({
-      logger: {
-        log(level, message) {
-          if (ENVIRONMENT !== "production") {
-            logger.info({ db: "Databricks", level }, message);
-          }
+
+  try {
+    const result = await new Promise<T[]>((resolve, reject) => {
+      const client = new DBSQLClient({
+        logger: {
+          log(level, message) {
+            if (ENVIRONMENT !== "production") {
+              logger.info({ db: "Databricks", level }, message);
+            }
+          },
         },
-      },
-    });
-    client
-      .on("error", (error) => {
-        if (!finished) {
-          finished = true;
-          reject(error);
-        }
-      })
-      .connect({
-        token: conn.token,
-        host: conn.host,
-        port: conn.port || 443,
-        path: conn.path,
-      })
-      .then(async () => {
-        const session = await client.openSession();
-        const queryOperation = await session.executeStatement(sql, {
-          runAsync: true,
-          // This is required to have the results returned immediately
-          maxRows: 1000,
-        });
-        const result = ((await queryOperation.fetchAll({
-          progress: false,
-        })) as unknown) as Promise<T[]>;
-
-        // As soon as we have the reuslt, return it
-        if (!finished) {
-          finished = true;
-          resolve(result);
-        }
-
-        // Do cleanup in the background and ignore errors
-        await queryOperation.close();
-        await session.close();
-        await client.close();
-      })
-      .catch((e) => {
-        if (!finished) {
-          finished = true;
-          reject(e);
-        }
       });
-  });
-  return { rows: result };
+      client
+        .on("error", (error) => {
+          if (!finished) {
+            finished = true;
+            reject(error);
+          }
+        })
+        .connect({
+          token: conn.token,
+          host: conn.host,
+          port: conn.port || 443,
+          path: conn.path,
+        })
+        .then(async () => {
+          const session = await client.openSession();
+          const queryOperation = await session.executeStatement(sql, {
+            runAsync: true,
+            // This is required to have the results returned immediately
+            maxRows: 1000,
+          });
+          const result = ((await queryOperation.fetchAll({
+            progress: false,
+          })) as unknown) as Promise<T[]>;
+
+          // As soon as we have the reuslt, return it
+          if (!finished) {
+            finished = true;
+            resolve(result);
+          }
+
+          // Do cleanup in the background and ignore errors
+          await queryOperation.close();
+          await session.close();
+          await client.close();
+        })
+        .catch((e) => {
+          if (!finished) {
+            finished = true;
+            reject(e);
+          }
+        });
+    });
+    return { rows: result };
+  } catch (e) {
+    if (e.response?.displayMessage) {
+      throw new Error(e.response.displayMessage);
+    }
+    throw e;
+  }
 }


### PR DESCRIPTION
Databricks errors can be passed through now. Also sanitizes other generic errors from databricks.

Before:

<img width="1050" alt="Screenshot 2023-12-15 at 3 03 23 PM" src="https://github.com/growthbook/growthbook/assets/5298599/31c07424-0818-4ada-9fd6-127aeecb923c">

After:

<img width="1028" alt="Screenshot 2023-12-15 at 3 02 58 PM" src="https://github.com/growthbook/growthbook/assets/5298599/3a43ab8a-634c-4b2d-bcad-3434b7b94a56">
