### PR TITLE
Upgrade Dockerfile fast follow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
+ARG PYTHON_MAJOR=3.11
+ARG NODE_MAJOR=18
+
 # Build the python gbstats package
-FROM python:3.11.7-slim AS pybuild
+FROM python:${PYTHON_MAJOR}-slim AS pybuild
 WORKDIR /usr/local/src/app
 COPY ./packages/stats .
 RUN \
@@ -9,7 +12,7 @@ RUN \
 
 
 # Build the nodejs app
-FROM node:18-slim AS nodebuild
+FROM node:${NODE_MAJOR}-slim AS nodebuild
 WORKDIR /usr/local/src/app
 # Copy over minimum files to install dependencies
 COPY package.json ./package.json
@@ -38,11 +41,12 @@ RUN \
 
 
 # Package the full app together
-FROM python:3.11.7-slim
+FROM python:${PYTHON_MAJOR}-slim
+ARG NODE_MAJOR
 WORKDIR /usr/local/src/app
 RUN apt-get update && \
   apt-get install -y wget gnupg2 && \
-  echo "deb https://deb.nodesource.com/node_16.x buster main" > /etc/apt/sources.list.d/nodesource.list && \
+  echo "deb https://deb.nodesource.com/node_$NODE_MAJOR.x buster main" > /etc/apt/sources.list.d/nodesource.list && \
   wget -qO- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
   echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list && \
   wget -qO- https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \


### PR DESCRIPTION
Missed a line in previous PR. This uses `ARG` to have our major versions defined in one place and referenced throughout the stages of the build.