### PR TITLE
Use central license server for new enterprise trial keys

### DIFF
--- a/packages/front-end/components/Layout/Layout.tsx
+++ b/packages/front-end/components/Layout/Layout.tsx
@@ -281,7 +281,6 @@ const Layout = (): React.ReactElement => {
   const { breadcrumb } = usePageHead();
 
   const [upgradeModal, setUpgradeModal] = useState(false);
-  // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
   const showUpgradeButton = ["oss", "starter"].includes(accountPlan);
 
   // hacky:

--- a/packages/front-end/components/Layout/SidebarLink.tsx
+++ b/packages/front-end/components/Layout/SidebarLink.tsx
@@ -160,7 +160,6 @@ const SidebarLink: FC<SidebarLinkProps> = (props) => {
               if (l.selfHostedOnly && isCloud()) {
                 return null;
               }
-              // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'AccountPlan | undefined' is not ... Remove this comment to see the full error message
               if (l.accountPlans && !l.accountPlans.includes(accountPlan)) {
                 return null;
               }

--- a/packages/front-end/components/Settings/UpgradeModal/index.tsx
+++ b/packages/front-end/components/Settings/UpgradeModal/index.tsx
@@ -16,14 +16,11 @@ export default function UpgradeModal({ close, source }: Props) {
   const { accountPlan, permissions } = useUser();
 
   useEffect(() => {
-    // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
     if (["pro", "pro_sso", "enterprise"].includes(accountPlan)) {
       close();
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [accountPlan]);
+  }, [accountPlan, close]);
 
-  // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
   if (["pro", "pro_sso", "enterprise"].includes(accountPlan)) {
     return null;
   }
@@ -36,7 +33,6 @@ export default function UpgradeModal({ close, source }: Props) {
         </div>
       ) : isCloud() ? (
         <CloudUpgradeForm
-          // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'AccountPlan | undefined' is not assignable t... Remove this comment to see the full error message
           accountPlan={accountPlan}
           source={source}
           setCloseCta={(s) => setCloseCta(s)}

--- a/packages/front-end/services/UserContext.tsx
+++ b/packages/front-end/services/UserContext.tsx
@@ -103,7 +103,7 @@ export interface UserContextValue {
   permissions: Record<GlobalPermission, boolean> & PermissionFunctions;
   settings: OrganizationSettings;
   enterpriseSSO?: SSOConnectionInterface;
-  accountPlan?: AccountPlan;
+  accountPlan: AccountPlan;
   commercialFeatures: CommercialFeature[];
   apiKeys: ApiKeyInterface[];
   organization: Partial<OrganizationInterface>;
@@ -125,6 +125,8 @@ interface UserResponse {
   currentUserPermissions: UserPermissions;
 }
 
+const defaultAccountPlan: AccountPlan = isCloud() ? "starter" : "oss";
+
 export const UserContext = createContext<UserContextValue>({
   permissions: { ...DEFAULT_PERMISSIONS, check: () => false },
   settings: {},
@@ -142,6 +144,7 @@ export const UserContext = createContext<UserContextValue>({
   organization: {},
   teams: [],
   hasCommercialFeature: () => false,
+  accountPlan: defaultAccountPlan,
 });
 
 export function useUser() {
@@ -375,7 +378,7 @@ export function UserContextProvider({ children }: { children: ReactNode }) {
         settings: currentOrg?.organization?.settings || {},
         license: data?.license,
         enterpriseSSO: currentOrg?.enterpriseSSO || undefined,
-        accountPlan: currentOrg?.accountPlan,
+        accountPlan: currentOrg?.accountPlan || defaultAccountPlan,
         commercialFeatures: currentOrg?.commercialFeatures || [],
         apiKeys: currentOrg?.apiKeys || [],
         // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'OrganizationInterface | undefined' is not as... Remove this comment to see the full error message


### PR DESCRIPTION
### Features and Changes
- Uses central licensing server.
- Fixes a few typescript issues and remove suppression comments.

### Testing

- Remove licenseKey from packages/back-end/.env.local 
- Go to settings page, add new enterprise key.
- Submit form.
- Close modal.
- Click Add new enterprise key again.
- Try and submit again.
- See the key already exists error
- Click Resend Key Button.
- Check email, see both the original email and the resend email
- Check CustomerIO ... see a new user with the email provided.
- Close Modal
- On the license server change the expiry time to some time in the past
- Click Add new enterprise key again.
- Submit form again
- See it say the license is expired message and to reach out to sales.
