### PR TITLE
Fix new gbstats integration if no data returned

### DIFF
--- a/packages/stats/gbstats/gbstats.py
+++ b/packages/stats/gbstats/gbstats.py
@@ -495,6 +495,19 @@ def process_single_metric(
     analyses: List[AnalysisSettingsForStatsEngine],
     var_id_map: Dict[str, int],
 ):
+    # If no data return blank results
+    if len(mdata.rows) == 0:
+        return {
+            "metric": mdata.metric,
+            "analyses": [
+                {
+                    "unknownVariations": [],
+                    "dimensions": [],
+                    "multipleExposures": 0,
+                }
+                for _ in analyses
+            ],
+        }
     rows = pd.DataFrame(mdata.rows)
     inverse = mdata.inverse
     multiple_exposures = mdata.multiple_exposures


### PR DESCRIPTION
Our recently landed PR #1823 didn't handle the case where no data was returned for 1 or more metrics.

Before that PR, if there was missing data, we just skipped the gbstats call altogether here: https://github.com/growthbook/growthbook/blob/ec88dce5a1983f2cfc47d9dba9b6f42fd37995cf/packages/back-end/src/services/stats.ts#L54-L60

After that PR, we removed that check, and were trying to process data with 0 rows in python which was casuing key errors, like this one: https://growthbookapp.slack.com/archives/C02BHUS8NBE/p1702998839752619

Now, we are spinning up python once per analysis, so we need to handle the case where 1 or more metrics are missing data when looping over metrics, which is in gbstats now.

Loom with before and after: https://www.loom.com/share/55099e1de1df400c88de06e77eada25c