### PR TITLE
Allow users to refresh license data from server on demand

### DIFF
--- a/packages/back-end/src/app.ts
+++ b/packages/back-end/src/app.ts
@@ -658,6 +658,7 @@ app.use("/teams", teamRouter);
 
 // Admin
 app.get("/admin/organizations", adminController.getOrganizations);
+app.get("/admin/license", adminController.getLicenseData);
 
 // Meta info
 app.get("/meta/ai", (req, res) => {

--- a/packages/back-end/src/controllers/admin.ts
+++ b/packages/back-end/src/controllers/admin.ts
@@ -1,6 +1,7 @@
 import { Response } from "express";
 import { AuthRequest } from "../types/AuthRequest";
 import { findAllOrganizations } from "../models/OrganizationModel";
+import { initializeLicense } from "../services/licenseData";
 
 export async function getOrganizations(
   req: AuthRequest<never, never, { page?: string; search?: string }>,
@@ -24,5 +25,26 @@ export async function getOrganizations(
     status: 200,
     organizations,
     total,
+  });
+}
+
+/**
+ * An endpoint mostly used to refresh the license data manually, if they
+ * have only recently paid for a subscription or for more seats and don't
+ * want to restart their servers.
+ */
+export async function getLicenseData(req: AuthRequest, res: Response) {
+  // While viewing license data is generally showed to admins, it is not
+  // particularly sensitive data that we need to restrict to admins only.
+
+  // Force refresh the license data
+  const licenseData = await initializeLicense(
+    req.organization?.licenseKey,
+    true
+  );
+
+  return res.status(200).json({
+    status: 200,
+    licenseData,
   });
 }

--- a/packages/back-end/src/services/licenseData.ts
+++ b/packages/back-end/src/services/licenseData.ts
@@ -56,12 +56,20 @@ async function getMetaData() {
   };
 }
 
-export async function initializeLicense(licenseKey?: string) {
+export async function initializeLicense(
+  licenseKey?: string,
+  forceRefresh = false
+) {
   const key = licenseKey || process.env.LICENSE_KEY;
   if (!IS_CLOUD && (!key || key.startsWith("license_"))) {
     const userLicenseCodes = await getUserLicenseCodes();
     const metaData = await getMetaData();
-    return await licenseInit(licenseKey, userLicenseCodes, metaData);
+    return await licenseInit(
+      licenseKey,
+      userLicenseCodes,
+      metaData,
+      forceRefresh
+    );
   }
   return await licenseInit(licenseKey);
 }

--- a/packages/enterprise/src/license.ts
+++ b/packages/enterprise/src/license.ts
@@ -366,7 +366,7 @@ async function getLicenseDataFromServer(
 
   if (!serverResult.ok) {
     logger.warn(
-      ` Falling back to LicenseModel cache because the license server threw a ${serverResult.status} error: ${serverResult.statusText}.`
+      `Falling back to LicenseModel cache because the license server threw a ${serverResult.status} error: ${serverResult.statusText}.`
     );
     return getLicenseDataFromMongoCache(currentCache);
   }
@@ -406,7 +406,8 @@ const keyToLicenseData: Record<string, Partial<LicenseInterface>> = {};
 export async function licenseInit(
   licenseKey?: string,
   userLicenseCodes?: string[],
-  metaData?: LicenseMetaData
+  metaData?: LicenseMetaData,
+  forceRefresh = false
 ) {
   const key = licenseKey || process.env.LICENSE_KEY || null;
 
@@ -418,6 +419,7 @@ export async function licenseInit(
   const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
 
   if (
+    !forceRefresh &&
     key &&
     keyToLicenseData[key] &&
     (cacheDate === null || cacheDate > oneDayAgo)

--- a/packages/enterprise/test/license.test.ts
+++ b/packages/enterprise/test/license.test.ts
@@ -173,6 +173,23 @@ describe("licenseInit", () => {
         expect(fetch).toHaveBeenCalledTimes(2);
       });
 
+      it("should call fetch twice rather than use the in-memory cache if forceRefresh flag is true", async () => {
+        await licenseInit(licenseKey, userLicenseCodes, metaData);
+
+        expect(getLicense()).toEqual(licenseData);
+
+        const mockedResponse2: Response = ({
+          ok: true,
+          json: jest.fn().mockResolvedValueOnce(licenseData2),
+        } as unknown) as Response; // Create a mock Response object
+
+        mockedFetch.mockResolvedValueOnce(Promise.resolve(mockedResponse2));
+
+        await licenseInit(licenseKey, userLicenseCodes, metaData, true);
+        expect(getLicense()).toEqual(licenseData2);
+        expect(fetch).toHaveBeenCalledTimes(2);
+      });
+
       it("should use the LICENSE_KEY env var if licenseKey is not provided", async () => {
         process.env.LICENSE_KEY = licenseKey;
         await licenseInit(undefined, userLicenseCodes, metaData);

--- a/packages/front-end/components/License/RefreshLicenseButton.tsx
+++ b/packages/front-end/components/License/RefreshLicenseButton.tsx
@@ -1,0 +1,35 @@
+import { FC } from "react";
+import { BsArrowRepeat } from "react-icons/bs";
+import { LicenseInterface } from "enterprise";
+import { useAuth } from "@/services/auth";
+import { useUser } from "@/services/UserContext";
+import Button from "../Button";
+
+const RefreshLicenseButton: FC = () => {
+  const { apiCall } = useAuth();
+  const { updateUser } = useUser();
+
+  const refresh = async () => {
+    const res = await apiCall<{ status: number; license: LicenseInterface }>(
+      `/admin/license`,
+      {
+        method: "GET",
+      }
+    );
+
+    if (res.status !== 200) {
+      throw new Error("There was an error fetching the license");
+    }
+    updateUser();
+  };
+
+  return (
+    <>
+      <Button color="outline-primary" onClick={refresh}>
+        <BsArrowRepeat /> Refresh
+      </Button>
+    </>
+  );
+};
+
+export default RefreshLicenseButton;

--- a/packages/front-end/components/License/ShowLicenseInfo.tsx
+++ b/packages/front-end/components/License/ShowLicenseInfo.tsx
@@ -1,0 +1,141 @@
+import { FC, useState } from "react";
+import { FaPencilAlt } from "react-icons/fa";
+import { date } from "shared/dates";
+import usePermissions from "@/hooks/usePermissions";
+import { useUser } from "@/services/UserContext";
+import { isCloud } from "@/services/env";
+import EditLicenseModal from "../Settings/EditLicenseModal";
+import { GBPremiumBadge } from "../Icons";
+import UpgradeModal from "../Settings/UpgradeModal";
+import RefreshLicenseButton from "./RefreshLicenseButton";
+
+const ShowLicenseInfo: FC<{
+  showInput?: boolean;
+}> = ({ showInput = true }) => {
+  const { accountPlan, license, refreshOrganization } = useUser();
+  const permissions = usePermissions();
+
+  const [editLicenseOpen, setEditLicenseOpen] = useState(false);
+
+  const [upgradeModal, setUpgradeModal] = useState(false);
+  const showUpgradeButton = ["oss", "starter"].includes(accountPlan || "");
+  const licensePlanText =
+    (accountPlan === "enterprise"
+      ? "Enterprise"
+      : accountPlan === "pro"
+      ? "Pro"
+      : accountPlan === "pro_sso"
+      ? "Pro + SSO"
+      : "Starter") + (license && license.isTrial ? " (trial)" : "");
+
+  return (
+    <div>
+      {upgradeModal && (
+        <UpgradeModal
+          close={() => setUpgradeModal(false)}
+          reason=""
+          source="settings"
+        />
+      )}
+      {editLicenseOpen && (
+        <EditLicenseModal
+          close={() => setEditLicenseOpen(false)}
+          mutate={refreshOrganization}
+        />
+      )}
+      <div>
+        <div className="divider border-bottom mb-3 mt-3" />
+        <div className="row">
+          <div className="col-sm-3">
+            <h4>License</h4>
+          </div>
+          <div className="col-sm-9">
+            <div className="form-group row mb-2">
+              <div className="col-sm-12">
+                <strong>Plan type: </strong> {licensePlanText}{" "}
+              </div>
+            </div>
+            {showUpgradeButton && (
+              <div className="form-group row mb-1">
+                <div className="col-sm-12">
+                  <button
+                    className="btn btn-premium font-weight-normal"
+                    onClick={() => setUpgradeModal(true)}
+                  >
+                    {accountPlan === "oss" ? (
+                      <>
+                        Try Enterprise <GBPremiumBadge />
+                      </>
+                    ) : (
+                      <>
+                        Try Pro <GBPremiumBadge />
+                      </>
+                    )}
+                  </button>
+                </div>
+              </div>
+            )}
+            {!isCloud() && permissions.manageBilling && (
+              <div className="form-group row mt-3 mb-0">
+                {showInput && (
+                  <div className="col-sm-4">
+                    <div>
+                      <strong>License Key: </strong>
+                    </div>
+                    <div
+                      className="d-inline-block mt-1 mb-2 text-center text-muted"
+                      style={{
+                        width: 100,
+                        borderBottom: "1px solid #cccccc",
+                        pointerEvents: "none",
+                        overflow: "hidden",
+                        verticalAlign: "top",
+                      }}
+                    >
+                      {license ? "***************" : "(none)"}
+                    </div>{" "}
+                    <a
+                      href="#"
+                      className="pl-1"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        setEditLicenseOpen(true);
+                      }}
+                    >
+                      <FaPencilAlt />
+                    </a>
+                  </div>
+                )}
+                {license && (
+                  <>
+                    <div className="col-sm-2">
+                      <div>Issued:</div>
+                      <span className="text-muted">
+                        {date(license.dateCreated)}
+                      </span>
+                    </div>
+                    <div className="col-sm-2">
+                      <div>Expires:</div>
+                      <span className="text-muted">
+                        {date(license.dateExpires)}
+                      </span>
+                    </div>
+                    <div className="col-sm-2">
+                      <div>Seats:</div>
+                      <span className="text-muted">{license.seats}</span>
+                    </div>
+                    <div className="col-sm-2">
+                      {license && <RefreshLicenseButton />}
+                    </div>
+                  </>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ShowLicenseInfo;

--- a/packages/front-end/components/License/ShowLicenseInfo.tsx
+++ b/packages/front-end/components/License/ShowLicenseInfo.tsx
@@ -125,7 +125,9 @@ const ShowLicenseInfo: FC<{
                       <span className="text-muted">{license.seats}</span>
                     </div>
                     <div className="col-sm-2">
-                      {license && <RefreshLicenseButton />}
+                      {license && license.id.startsWith("license") && (
+                        <RefreshLicenseButton />
+                      )}
                     </div>
                   </>
                 )}

--- a/packages/front-end/pages/admin.tsx
+++ b/packages/front-end/pages/admin.tsx
@@ -20,6 +20,7 @@ import { isCloud, isMultiOrg } from "@/services/env";
 import EditOrganization from "@/components/Admin/EditOrganization";
 import LoadingOverlay from "@/components/LoadingOverlay";
 import CreateOrganization from "@/components/Admin/CreateOrganization";
+import ShowLicenseInfo from "@/components/License/ShowLicenseInfo";
 import { useAuth } from "../services/auth";
 
 const numberFormatter = new Intl.NumberFormat();
@@ -210,6 +211,14 @@ const Admin: FC = () => {
           close={() => setOrgModalOpen(false)}
         />
       )}
+      <h1>GrowthBook Admin</h1>
+      {!isCloud() && (
+        <div>
+          <ShowLicenseInfo showInput={false} />{" "}
+          <div className="divider border-bottom mb-3 mt-3" />
+        </div>
+      )}
+      <h4>Organizations</h4>
       <button
         className="btn btn-primary float-right"
         onClick={(e) => {
@@ -219,9 +228,7 @@ const Admin: FC = () => {
       >
         <FaPlus /> New Organization
       </button>
-      <h1>GrowthBook Admin</h1>
       <p>Click an organization name below to switch to it.</p>
-
       <div className="mb-2 row align-items-center">
         <div className="col-auto">
           <form
@@ -253,9 +260,7 @@ const Admin: FC = () => {
           </span>
         </div>
       </div>
-
       {error && <div className="alert alert-danger">{error}</div>}
-
       <div className="position-relative">
         {loading && <LoadingOverlay />}
         <table className="table appbox">
@@ -302,9 +307,8 @@ const Admin: FC = () => {
           }}
         />
       </div>
-
       {!isCloud() && isMultiOrg() && (
-        <div>
+        <div className="divider border-top mt-3">
           <OrphanedUsersList
             mutateUsers={() => {
               loadOrgs(page, search);

--- a/packages/front-end/pages/settings/index.tsx
+++ b/packages/front-end/pages/settings/index.tsx
@@ -37,9 +37,7 @@ import {
 } from "@/hooks/useOrganizationMetricDefaults";
 import { useUser } from "@/services/UserContext";
 import usePermissions from "@/hooks/usePermissions";
-import { GBCuped, GBPremiumBadge, GBSequential } from "@/components/Icons";
-import UpgradeModal from "@/components/Settings/UpgradeModal";
-import EditLicenseModal from "@/components/Settings/EditLicenseModal";
+import { GBCuped, GBSequential } from "@/components/Icons";
 import Toggle from "@/components/Forms/Toggle";
 import PremiumTooltip from "@/components/Marketing/PremiumTooltip";
 import SelectField from "@/components/Forms/SelectField";
@@ -51,6 +49,7 @@ import { useCurrency } from "@/hooks/useCurrency";
 import { AppFeatures } from "@/types/app-features";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import ExperimentCheckListModal from "@/components/Settings/ExperimentCheckListModal";
+import ShowLicenseInfo from "@/components/License/ShowLicenseInfo";
 
 export const supportedCurrencies = {
   AED: "UAE Dirham (AED)",
@@ -240,12 +239,9 @@ const GeneralSettingsPage = (): React.ReactElement => {
     refreshOrganization,
     settings,
     organization,
-    accountPlan,
-    license,
     hasCommercialFeature,
   } = useUser();
   const [editOpen, setEditOpen] = useState(false);
-  const [editLicenseOpen, setEditLicenseOpen] = useState(false);
   const [saveMsg, setSaveMsg] = useState(false);
   const [originalValue, setOriginalValue] = useState<OrganizationSettings>({});
   const [statsEngineTab, setStatsEngineTab] = useState<string>(
@@ -276,17 +272,7 @@ const GeneralSettingsPage = (): React.ReactElement => {
 
   const { metricDefaults } = useOrganizationMetricDefaults();
 
-  const [upgradeModal, setUpgradeModal] = useState(false);
   const [editChecklistOpen, setEditChecklistOpen] = useState(false);
-  const showUpgradeButton = ["oss", "starter"].includes(accountPlan || "");
-  const licensePlanText =
-    (accountPlan === "enterprise"
-      ? "Enterprise"
-      : accountPlan === "pro"
-      ? "Pro"
-      : accountPlan === "pro_sso"
-      ? "Pro + SSO"
-      : "Starter") + (license && license.isTrial ? " (trial)" : "");
 
   const form = useForm<OrganizationSettingsWithMetricDefaults>({
     defaultValues: {
@@ -554,14 +540,6 @@ const GeneralSettingsPage = (): React.ReactElement => {
 
   return (
     <>
-      {upgradeModal && (
-        <UpgradeModal
-          close={() => setUpgradeModal(false)}
-          reason=""
-          source="settings"
-        />
-      )}
-
       {editChecklistOpen ? (
         <ExperimentCheckListModal close={() => setEditChecklistOpen(false)} />
       ) : null}
@@ -571,12 +549,6 @@ const GeneralSettingsPage = (): React.ReactElement => {
           <EditOrganizationModal
             name={organization.name || ""}
             close={() => setEditOpen(false)}
-            mutate={refreshOrganization}
-          />
-        )}
-        {editLicenseOpen && (
-          <EditLicenseModal
-            close={() => setEditLicenseOpen(false)}
             mutate={refreshOrganization}
           />
         )}
@@ -611,96 +583,7 @@ const GeneralSettingsPage = (): React.ReactElement => {
                 </div>
               </div>
             </div>
-            {(isCloud() || !isMultiOrg()) && (
-              <div>
-                <div className="divider border-bottom mb-3 mt-3" />
-                <div className="row">
-                  <div className="col-sm-3">
-                    <h4>License</h4>
-                  </div>
-                  <div className="col-sm-9">
-                    <div className="form-group row mb-2">
-                      <div className="col-sm-12">
-                        <strong>Plan type: </strong> {licensePlanText}{" "}
-                      </div>
-                    </div>
-                    {showUpgradeButton && (
-                      <div className="form-group row mb-1">
-                        <div className="col-sm-12">
-                          <button
-                            className="btn btn-premium font-weight-normal"
-                            onClick={() => setUpgradeModal(true)}
-                          >
-                            {accountPlan === "oss" ? (
-                              <>
-                                Try Enterprise <GBPremiumBadge />
-                              </>
-                            ) : (
-                              <>
-                                Try Pro <GBPremiumBadge />
-                              </>
-                            )}
-                          </button>
-                        </div>
-                      </div>
-                    )}
-                    {!isCloud() && permissions.manageBilling && (
-                      <div className="form-group row mt-3 mb-0">
-                        <div className="col-sm-4">
-                          <div>
-                            <strong>License Key: </strong>
-                          </div>
-                          <div
-                            className="d-inline-block mt-1 mb-2 text-center text-muted"
-                            style={{
-                              width: 100,
-                              borderBottom: "1px solid #cccccc",
-                              pointerEvents: "none",
-                              overflow: "hidden",
-                              verticalAlign: "top",
-                            }}
-                          >
-                            {license ? "***************" : "(none)"}
-                          </div>{" "}
-                          <a
-                            href="#"
-                            className="pl-1"
-                            onClick={(e) => {
-                              e.preventDefault();
-                              setEditLicenseOpen(true);
-                            }}
-                          >
-                            <FaPencilAlt />
-                          </a>
-                        </div>
-                        {license && (
-                          <>
-                            <div className="col-sm-2">
-                              <div>Issued:</div>
-                              <span className="text-muted">
-                                {license.dateCreated}
-                              </span>
-                            </div>
-                            <div className="col-sm-2">
-                              <div>Expires:</div>
-                              <span className="text-muted">
-                                {license.dateExpires}
-                              </span>
-                            </div>
-                            <div className="col-sm-2">
-                              <div>Seats:</div>
-                              <span className="text-muted">
-                                {license.seats}
-                              </span>
-                            </div>
-                          </>
-                        )}
-                      </div>
-                    )}
-                  </div>
-                </div>
-              </div>
-            )}
+            {(isCloud() || !isMultiOrg()) && <ShowLicenseInfo />}
           </div>
 
           <div className="my-3 bg-white p-3 border">


### PR DESCRIPTION
### Features and Changes
Allows users to refresh license data from server on demand.  This might be needed if they recently contacted sales and we converted their trial to a real license, or updated the number of seats.

- Added argument to force refresh license
- Added test to make sure that worked
- Added backend endpoint for refreshing the license
- Moved license data to its own component
- Added RefreshLicenseButton component
- Added ShowLicenseInfo component to admin page (for multi-org)

### Testing

Test non-multi-org:

1. Set IS_MULTI_ORG=false in frontend and backend .env.local
2. Go to general settings page
3. Click on the Upgrade button and see the modal.
4. Click on the Edit license and see the edit license modal
5. Enter in a valid license.
6. See the license data.
7. Change the license data from the central license server
8. Click update
9. See the updated license data on the settings page

Test multi-org:

1. Set IS_MULTI_ORG=true in front end and backend .env.local
2. Remove the licenseKey from the org in mongo.
3. Add the licenseKey to the .env.local on the back end
4. Go to the admin page.
5. See the license data.
6. Change the license data from the central license server
7. Click update
8. See the updated license data on the admin page

### Screenshots
![Screenshot 2023-12-21 at 2 28 47 PM](https://github.com/growthbook/growthbook/assets/950231/db1a7990-6924-4c18-8e4d-a4567cab949b)
![Screenshot 2023-12-21 at 2 27 31 PM](https://github.com/growthbook/growthbook/assets/950231/b3f09220-c1e5-4396-a98b-128c8e3f8202)
