### PR TITLE
Fix reading from in memory cache

### DIFF
--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -1756,8 +1756,7 @@ export async function putLicenseKey(
   let licenseData = null;
   try {
     // set new license
-    await initializeLicense(licenseKey);
-    licenseData = getLicense();
+    licenseData = await initializeLicense(licenseKey);
   } catch (e) {
     // eslint-disable-next-line no-console
     console.error("setting new license failed", e);

--- a/packages/enterprise/src/license.ts
+++ b/packages/enterprise/src/license.ts
@@ -422,6 +422,7 @@ export async function licenseInit(
     keyToLicenseData[key] &&
     (cacheDate === null || cacheDate > oneDayAgo)
   ) {
+    licenseData = keyToLicenseData[key];
     return keyToLicenseData[key];
   }
 
@@ -438,6 +439,7 @@ export async function licenseInit(
   }
 
   keyToLicenseData[key] = licenseData;
+  return licenseData;
 }
 
 export function getLicense() {


### PR DESCRIPTION
### Features and Changes
This was not so much an issue as we don't yet use licenses on cloud and self hosted always use just one license.  I encountered it only when manually deleting a licenseKey stored on the organization.  LicenseInit then got called with null and set `licenseData` to nothing.  Then when re-adding license with a key that was already stored it wasn't updating `licenseData` which is read from getLicense().  It is important to fix this though in case we ever use licenses on cloud.

### Testing

1. Add a license to an org.
2. See it succeed.
3. Delete the licenseKey from the org in Mongo.
4. Try and add the same license on the org again.
5. See it succeed.