### PR TITLE
Fix unnecessary formatting that should never happen

### DIFF
--- a/packages/front-end/components/Experiment/MetricValueColumn.tsx
+++ b/packages/front-end/components/Experiment/MetricValueColumn.tsx
@@ -56,18 +56,15 @@ export default function MetricValueColumn({
   let denominator = numberFormatter.format(denominatorValue);
 
   if (isFactMetric(metric)) {
-    const ratioMetric = metric.metricType === "ratio";
-    numerator = getColumnRefFormatter(
-      metric.numerator,
-      getFactTableById,
-      ratioMetric
-    )(numeratorValue, formatterOptions);
-    if (ratioMetric && metric.denominator) {
-      denominator = getColumnRefFormatter(
-        metric.denominator,
-        getFactTableById,
-        ratioMetric
-      )(denominatorValue, formatterOptions);
+    numerator = getColumnRefFormatter(metric.numerator, getFactTableById)(
+      numeratorValue,
+      formatterOptions
+    );
+    if (metric.metricType === "ratio" && metric.denominator) {
+      denominator = getColumnRefFormatter(metric.denominator, getFactTableById)(
+        denominatorValue,
+        formatterOptions
+      );
     }
   } else {
     numerator = getMetricFormatter(

--- a/packages/front-end/components/Experiment/ResultsTableTooltip.tsx
+++ b/packages/front-end/components/Experiment/ResultsTableTooltip.tsx
@@ -189,8 +189,7 @@ export default function ResultsTableTooltip({
   ) {
     denomFormatter = getColumnRefFormatter(
       data.metric.denominator,
-      getFactTableById,
-      true
+      getFactTableById
     );
   }
   // Lift units

--- a/packages/front-end/services/metrics.tsx
+++ b/packages/front-end/services/metrics.tsx
@@ -138,14 +138,13 @@ export function getColumnFormatter(
 
 export function getColumnRefFormatter(
   columnRef: ColumnRef,
-  getFactTableById: (id: string) => FactTableInterface | null,
-  ratio?: boolean
+  getFactTableById: (id: string) => FactTableInterface | null
 ): (value: number, options?: Intl.NumberFormatOptions) => string {
-  if (columnRef.column === "$$count") {
+  if (
+    columnRef.column === "$$count" ||
+    columnRef.column === "$$distinctUsers"
+  ) {
     return formatNumber;
-  }
-  if (columnRef.column === "$$distinctUsers" && !ratio) {
-    return formatPercent;
   }
 
   const fact = getFactTableById(columnRef.factTableId)?.columns?.find(
@@ -198,11 +197,11 @@ export function getExperimentMetricFormatter(
         }
 
         // Otherwise, just use the numerator to figure out the value type
-        return getColumnRefFormatter(metric.numerator, getFactTableById, true);
+        return getColumnRefFormatter(metric.numerator, getFactTableById);
       })();
 
     case "mean":
-      return getColumnRefFormatter(metric.numerator, getFactTableById, true);
+      return getColumnRefFormatter(metric.numerator, getFactTableById);
   }
 }
 


### PR DESCRIPTION
If you had a ratio metric that you changed to a proportion metric, you may end up with a non-ratio metric with `$$distinctUsers` column value (rather than the default `$$count`. Note that `$$distinctUsers` is technically more correct, but in reality we ignore this field for proportion metrics.

This is an artifact of the fact that we don't update the column value for proportion metrics. In this PR, we handle this edge case better by just removing unnecessary front-end code that we really don't need at all.

A better solution might be to ensure that we always set `column value` to one value for `proportion` metrics, but that can still happen after this change without rolling back this PR at all.

This fixes a bug one user had with a proportion metric that maybe at some point in the past was a ratio metric: https://growthbookapp.slack.com/archives/C02BHUS8NBE/p1702912675817589

Before:
<img width="412" alt="image" src="https://github.com/growthbook/growthbook/assets/5298599/6757817f-c366-4c5e-8b12-f971a0d56260">
"any order" used to be a ratio metric and so it has `$$distinctUsers` as the column value, pretty much just as a legacy of setting that field

After:
<img width="406" alt="Screenshot 2023-12-21 at 10 27 02 AM" src="https://github.com/growthbook/growthbook/assets/5298599/56cb63f2-2c14-4cea-98c4-38c2ab7598ec">