### PR TITLE
Validate advanced targeting condition JSON before saving

### DIFF
--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -16,6 +16,7 @@ import {
   isAnalysisAllowed,
   getMatchingRules,
   MatchingRule,
+  validateCondition,
 } from "shared/util";
 import {
   ExperimentMetricInterface,
@@ -1621,26 +1622,33 @@ export function postExperimentApiPayloadToInterface(
   organization: OrganizationInterface,
   datasource: DataSourceInterface
 ): Omit<ExperimentInterface, "dateCreated" | "dateUpdated" | "id"> {
-  const phases: ExperimentPhase[] = payload.phases?.map((p) => ({
-    ...p,
-    dateStarted: new Date(p.dateStarted),
-    dateEnded: p.dateEnded ? new Date(p.dateEnded) : undefined,
-    reason: p.reason || "",
-    coverage: p.coverage != null ? p.coverage : 1,
-    condition: p.condition || "{}",
-    savedGroups: (p.savedGroupTargeting || []).map((s) => ({
-      match: s.matchType,
-      ids: s.savedGroups,
-    })),
-    namespace: {
-      name: p.namespace?.namespaceId || "",
-      range: toNamespaceRange(p.namespace?.range),
-      enabled: p.namespace?.enabled != null ? p.namespace.enabled : false,
-    },
-    variationWeights:
-      p.variationWeights ||
-      payload.variations.map(() => 1 / payload.variations.length),
-  })) || [
+  const phases: ExperimentPhase[] = payload.phases?.map((p) => {
+    const conditionRes = validateCondition(p.condition);
+    if (!conditionRes.success) {
+      throw new Error(`Invalid targeting condition: ${conditionRes.error}`);
+    }
+
+    return {
+      ...p,
+      dateStarted: new Date(p.dateStarted),
+      dateEnded: p.dateEnded ? new Date(p.dateEnded) : undefined,
+      reason: p.reason || "",
+      coverage: p.coverage != null ? p.coverage : 1,
+      condition: p.condition || "{}",
+      savedGroups: (p.savedGroupTargeting || []).map((s) => ({
+        match: s.matchType,
+        ids: s.savedGroups,
+      })),
+      namespace: {
+        name: p.namespace?.namespaceId || "",
+        range: toNamespaceRange(p.namespace?.range),
+        enabled: p.namespace?.enabled != null ? p.namespace.enabled : false,
+      },
+      variationWeights:
+        p.variationWeights ||
+        payload.variations.map(() => 1 / payload.variations.length),
+    };
+  }) || [
     {
       coverage: 1,
       dateStarted: new Date(),
@@ -1767,29 +1775,38 @@ export function updateExperimentApiPayloadToInterface(
       : {}),
     ...(phases
       ? {
-          phases: phases.map((p) => ({
-            ...p,
-            dateStarted: new Date(p.dateStarted),
-            dateEnded: p.dateEnded ? new Date(p.dateEnded) : undefined,
-            reason: p.reason || "",
-            coverage: p.coverage != null ? p.coverage : 1,
-            condition: p.condition || "{}",
-            savedGroups: (p.savedGroupTargeting || []).map((s) => ({
-              match: s.matchType,
-              ids: s.savedGroups,
-            })),
-            namespace: {
-              name: p.namespace?.namespaceId || "",
-              range: toNamespaceRange(p.namespace?.range),
-              enabled:
-                p.namespace?.enabled != null ? p.namespace.enabled : false,
-            },
-            variationWeights:
-              p.variationWeights ||
-              (payload.variations || experiment.variations)?.map(
-                (_v, _i, arr) => 1 / arr.length
-              ),
-          })),
+          phases: phases.map((p) => {
+            const conditionRes = validateCondition(p.condition);
+            if (!conditionRes.success) {
+              throw new Error(
+                `Invalid targeting condition: ${conditionRes.error}`
+              );
+            }
+
+            return {
+              ...p,
+              dateStarted: new Date(p.dateStarted),
+              dateEnded: p.dateEnded ? new Date(p.dateEnded) : undefined,
+              reason: p.reason || "",
+              coverage: p.coverage != null ? p.coverage : 1,
+              condition: p.condition || "{}",
+              savedGroups: (p.savedGroupTargeting || []).map((s) => ({
+                match: s.matchType,
+                ids: s.savedGroups,
+              })),
+              namespace: {
+                name: p.namespace?.namespaceId || "",
+                range: toNamespaceRange(p.namespace?.range),
+                enabled:
+                  p.namespace?.enabled != null ? p.namespace.enabled : false,
+              },
+              variationWeights:
+                p.variationWeights ||
+                (payload.variations || experiment.variations)?.map(
+                  (_v, _i, arr) => 1 / arr.length
+                ),
+            };
+          }),
         }
       : {}),
     dateUpdated: new Date(),

--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -9,7 +9,7 @@ import {
   AutoExperiment,
   GrowthBook,
 } from "@growthbook/growthbook";
-import { validateFeatureValue } from "shared/util";
+import { validateCondition, validateFeatureValue } from "shared/util";
 import { scrubFeatures, SDKCapability } from "shared/sdk-versioning";
 import {
   AutoExperimentWithProject,
@@ -969,6 +969,13 @@ const fromApiEnvSettingsRulesToFeatureEnvSettingsRules = (
   rules: ApiFeatureEnvSettingsRules
 ): FeatureInterface["environmentSettings"][string]["rules"] =>
   rules.map((r) => {
+    const conditionRes = validateCondition(r.condition);
+    if (!conditionRes.success) {
+      throw new Error(
+        "Invalid targeting condition JSON: " + conditionRes.error
+      );
+    }
+
     if (r.type === "experiment-ref") {
       const experimentRule: ExperimentRefRule = {
         // missing id will be filled in by addIdsToRules

--- a/packages/front-end/components/Experiment/EditPhaseModal.tsx
+++ b/packages/front-end/components/Experiment/EditPhaseModal.tsx
@@ -3,6 +3,7 @@ import {
   ExperimentInterfaceStringDates,
   ExperimentPhaseStringDates,
 } from "back-end/types/experiment";
+import { validateCondition } from "shared/util";
 import { useAuth } from "@/services/auth";
 import Field from "../Forms/Field";
 import Modal from "../Modal";
@@ -50,6 +51,19 @@ export default function EditPhaseModal({
       header={`Edit Analysis Phase #${i + 1}`}
       submit={form.handleSubmit(async (value) => {
         validateSavedGroupTargeting(value.savedGroups);
+
+        const conditionResult = validateCondition(value.condition);
+        if (!conditionResult.success) {
+          if (conditionResult.suggestedValue) {
+            form.setValue("condition", conditionResult.suggestedValue);
+            throw new Error(
+              "We fixed some syntax errors in your targeting condition JSON. Please verify the changes and save again."
+            );
+          }
+          throw new Error(
+            "Invalid targeting condition JSON: " + conditionResult.error
+          );
+        }
 
         await apiCall(`/experiment/${experiment.id}/phase/${i}`, {
           method: "PUT",

--- a/packages/front-end/components/Experiment/EditTargetingModal.tsx
+++ b/packages/front-end/components/Experiment/EditTargetingModal.tsx
@@ -5,6 +5,7 @@ import {
   ExperimentTargetingData,
 } from "back-end/types/experiment";
 import { useEffect, useMemo } from "react";
+import { validateCondition } from "shared/util";
 import { useAuth } from "@/services/auth";
 import { getEqualWeights } from "@/services/utils";
 import { useAttributeSchema } from "@/services/features";
@@ -144,6 +145,19 @@ export default function EditTargetingModal({
       header={`Edit Targeting`}
       submit={form.handleSubmit(async (value) => {
         validateSavedGroupTargeting(value.savedGroups);
+
+        const conditionResult = validateCondition(value.condition);
+        if (!conditionResult.success) {
+          if (conditionResult.suggestedValue) {
+            form.setValue("condition", conditionResult.suggestedValue);
+            throw new Error(
+              "We fixed some syntax errors in your targeting condition JSON. Please verify the changes and save again."
+            );
+          }
+          throw new Error(
+            "Invalid targeting condition JSON: " + conditionResult.error
+          );
+        }
 
         await apiCall(`/experiment/${experiment.id}/targeting`, {
           method: "POST",

--- a/packages/front-end/components/Experiment/NewExperimentForm.tsx
+++ b/packages/front-end/components/Experiment/NewExperimentForm.tsx
@@ -9,7 +9,7 @@ import { useRouter } from "next/router";
 import { getValidDate } from "shared/dates";
 import { DataSourceInterfaceWithParams } from "back-end/types/datasource";
 import { OrganizationSettings } from "back-end/types/organization";
-import { isProjectListValidForProject } from "shared/util";
+import { isProjectListValidForProject, validateCondition } from "shared/util";
 import { useWatching } from "@/services/WatchProvider";
 import { useAuth } from "@/services/auth";
 import track from "@/services/track";
@@ -235,6 +235,19 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
       }
 
       validateSavedGroupTargeting(data.phases[0].savedGroups);
+
+      const conditionResult = validateCondition(data.phases[0].condition);
+      if (!conditionResult.success) {
+        if (conditionResult.suggestedValue) {
+          form.setValue("phases.0.condition", conditionResult.suggestedValue);
+          throw new Error(
+            "We fixed some syntax errors in your targeting condition JSON. Please verify the changes and save again."
+          );
+        }
+        throw new Error(
+          "Invalid targeting condition JSON: " + conditionResult.error
+        );
+      }
     }
 
     const body = JSON.stringify(data);

--- a/packages/front-end/components/Experiment/NewPhaseForm.tsx
+++ b/packages/front-end/components/Experiment/NewPhaseForm.tsx
@@ -4,6 +4,7 @@ import {
   ExperimentPhaseStringDates,
 } from "back-end/types/experiment";
 import { useForm } from "react-hook-form";
+import { validateCondition } from "shared/util";
 import { useAuth } from "@/services/auth";
 import { useWatching } from "@/services/WatchProvider";
 import { getEqualWeights } from "@/services/utils";
@@ -63,6 +64,19 @@ const NewPhaseForm: FC<{
     if (!isValid) throw new Error("Variation weights must sum to 1");
 
     validateSavedGroupTargeting(value.savedGroups);
+
+    const conditionResult = validateCondition(value.condition);
+    if (!conditionResult.success) {
+      if (conditionResult.suggestedValue) {
+        form.setValue("condition", conditionResult.suggestedValue);
+        throw new Error(
+          "We fixed some syntax errors in your targeting condition JSON. Please verify the changes and save again."
+        );
+      }
+      throw new Error(
+        "Invalid targeting condition JSON: " + conditionResult.error
+      );
+    }
 
     await apiCall<{ status: number; message?: string }>(
       `/experiment/${experiment.id}/phase`,

--- a/packages/front-end/components/Features/RuleModal.tsx
+++ b/packages/front-end/components/Features/RuleModal.tsx
@@ -28,6 +28,7 @@ import track from "@/services/track";
 import useOrgSettings from "@/hooks/useOrgSettings";
 import { useExperiments } from "@/hooks/useExperiments";
 import { useDefinitions } from "@/services/DefinitionsContext";
+import useIncrementer from "@/hooks/useIncrementer";
 import Field from "../Forms/Field";
 import Modal from "../Modal";
 import { useAuth } from "../../services/auth";
@@ -92,6 +93,8 @@ export default function RuleModal({
     ruleType: defaultType,
     attributeSchema,
   });
+
+  const [conditionKey, forceConditionRender] = useIncrementer();
 
   const { features } = useFeaturesList();
   const environments = useEnvironments();
@@ -451,6 +454,8 @@ export default function RuleModal({
             error: e.message,
           });
 
+          forceConditionRender();
+
           throw e;
         }
       })}
@@ -627,8 +632,9 @@ export default function RuleModal({
             }
           />
           <ConditionInput
-            defaultValue={defaultValues.condition || ""}
+            defaultValue={form.watch("condition") || ""}
             onChange={(value) => form.setValue("condition", value)}
+            key={conditionKey}
           />
         </>
       )}

--- a/packages/front-end/hooks/useIncrementer.ts
+++ b/packages/front-end/hooks/useIncrementer.ts
@@ -1,0 +1,8 @@
+import { useCallback, useState } from "react";
+
+export default function useIncrementer(): [number, () => void] {
+  const [count, setCount] = useState(0);
+  const increment = useCallback(() => setCount((c) => c + 1), []);
+
+  return [count, increment];
+}

--- a/packages/front-end/services/features.ts
+++ b/packages/front-end/services/features.ts
@@ -22,7 +22,7 @@ import { FeatureUsageRecords } from "back-end/types/realtime";
 import cloneDeep from "lodash/cloneDeep";
 import {
   generateVariationId,
-  validateCondition,
+  validateAndFixCondition,
   validateFeatureValue,
 } from "shared/util";
 import { FeatureRevisionInterface } from "back-end/types/feature-revision";
@@ -212,17 +212,16 @@ export function validateFeatureRule(
   validateSavedGroupTargeting(rule.savedGroups);
 
   if (rule.condition) {
-    const conditionResult = validateCondition(rule.condition);
-    if (!conditionResult.success) {
-      if (conditionResult.suggestedValue) {
+    console.log("Validating condition", rule.condition);
+    validateAndFixCondition(
+      rule.condition,
+      (condition) => {
+        console.log("has suggestion", condition);
         hasChanges = true;
-        ruleCopy.condition = conditionResult.suggestedValue;
-      } else {
-        throw new Error(
-          "Invalid targeting condition JSON: " + conditionResult.error
-        );
-      }
-    }
+        ruleCopy.condition = condition;
+      },
+      false
+    );
   }
   if (rule.type === "force") {
     const newValue = validateFeatureValue(

--- a/packages/front-end/services/features.ts
+++ b/packages/front-end/services/features.ts
@@ -212,11 +212,9 @@ export function validateFeatureRule(
   validateSavedGroupTargeting(rule.savedGroups);
 
   if (rule.condition) {
-    console.log("Validating condition", rule.condition);
     validateAndFixCondition(
       rule.condition,
       (condition) => {
-        console.log("has suggestion", condition);
         hasChanges = true;
         ruleCopy.condition = condition;
       },

--- a/packages/shared/src/util/features.ts
+++ b/packages/shared/src/util/features.ts
@@ -447,7 +447,7 @@ export function validateCondition(condition?: string) {
         suggestedValue: JSON.stringify(fixed),
         error: e.message,
       };
-    } catch (e) {
+    } catch (e2) {
       return { success: false, empty: false, error: e.message };
     }
   }

--- a/packages/shared/src/util/features.ts
+++ b/packages/shared/src/util/features.ts
@@ -452,3 +452,19 @@ export function validateCondition(condition?: string) {
     }
   }
 }
+export function validateAndFixCondition(
+  condition: string | undefined,
+  applySuggestion: (suggestion: string) => void,
+  throwOnSuggestion: boolean = true
+) {
+  const res = validateCondition(condition);
+  if (res.success) return;
+  if (res.suggestedValue) {
+    applySuggestion(res.suggestedValue);
+    if (!throwOnSuggestion) return;
+    throw new Error(
+      "We fixed some syntax errors in your targeting condition JSON. Please verify the changes and save again."
+    );
+  }
+  throw new Error("Invalid targeting condition JSON: " + res.error);
+}

--- a/packages/shared/src/util/features.ts
+++ b/packages/shared/src/util/features.ts
@@ -417,3 +417,38 @@ export function autoMerge(
     result,
   };
 }
+
+export type ValidateConditionReturn = {
+  success: boolean;
+  empty: boolean;
+  suggestedValue?: string;
+  error?: string;
+};
+export function validateCondition(condition?: string) {
+  if (!condition || condition === "{}") {
+    return { success: true, empty: true };
+  }
+
+  try {
+    const res = JSON.parse(condition);
+    if (!res || typeof res !== "object") {
+      return { success: false, empty: false, error: "Must be object" };
+    }
+
+    // TODO: validate beyond just making sure it's valid JSON
+    return { success: true, empty: false };
+  } catch (e) {
+    // Try parsing with dJSON and see if it can be fixed automatically
+    try {
+      const fixed = dJSON.parse(condition);
+      return {
+        success: false,
+        empty: false,
+        suggestedValue: JSON.stringify(fixed),
+        error: e.message,
+      };
+    } catch (e) {
+      return { success: false, empty: false, error: e.message };
+    }
+  }
+}

--- a/packages/shared/test/util/features.test.ts
+++ b/packages/shared/test/util/features.test.ts
@@ -448,7 +448,7 @@ describe("validateCondition", () => {
     expect(validateCondition("{(+")).toEqual({
       success: false,
       empty: false,
-      error: "Found } that I can't handle at line -1:-1",
+      error: "Unexpected token ( in JSON at position 1",
     });
   });
   it("returns error when condition is not an object", () => {

--- a/packages/shared/test/util/features.test.ts
+++ b/packages/shared/test/util/features.test.ts
@@ -6,6 +6,7 @@ import {
   autoMerge,
   RulesAndValues,
   MergeConflict,
+  validateCondition,
 } from "../../src/util";
 
 const feature: FeatureInterface = {
@@ -420,6 +421,55 @@ describe("validateFeatureValue", () => {
       expect(() =>
         validateFeatureValue(feature, value, "testVal")
       ).toThrowError();
+    });
+  });
+});
+
+describe("validateCondition", () => {
+  it("returns success when condition is undefined", () => {
+    expect(validateCondition(undefined)).toEqual({
+      success: true,
+      empty: true,
+    });
+  });
+  it("returns success when condition is empty", () => {
+    expect(validateCondition("")).toEqual({
+      success: true,
+      empty: true,
+    });
+  });
+  it("returns success when condition is empty object", () => {
+    expect(validateCondition("{}")).toEqual({
+      success: true,
+      empty: true,
+    });
+  });
+  it("returns error when condition is completely invalid", () => {
+    expect(validateCondition("{(+")).toEqual({
+      success: false,
+      empty: false,
+      error: "Found } that I can't handle at line -1:-1",
+    });
+  });
+  it("returns error when condition is not an object", () => {
+    expect(validateCondition("123")).toEqual({
+      success: false,
+      empty: false,
+      error: "Must be object",
+    });
+  });
+  it("returns suggested value when condition is invalid, but able to be fixed automatically", () => {
+    expect(validateCondition("{test: true}")).toEqual({
+      success: false,
+      empty: false,
+      error: "Unexpected token t in JSON at position 1",
+      suggestedValue: '{"test":true}',
+    });
+  });
+  it("returns success when condition is valid", () => {
+    expect(validateCondition('{"test": true}')).toEqual({
+      success: true,
+      empty: false,
     });
   });
 });


### PR DESCRIPTION
Before saving advanced targeting conditions, validate the JSON.  

If an error happens in the GrowthBook app and we're able to fix it automatically (e.g. forgetting quotes around key names), do so and ask for confirmation before saving the fixed value.

Fixes #1934

Places to test:
- [x] EditPhaseModal
- [x] NewPhaseForm
- [x] NewExperimentForm
- [x] EditTargetingModal
- [x] RuleModal
- [x] REST endpoint `POST /experiments`
- [x] REST endpoint `POST /experiments/:id`
- [x] REST endpoint `POST /features`
- [x] REST endpoint `POST /features/:id`

Conditions to test:
- Completely invalid input : `{(+`
- Fixable simple input: `{country: "US"}`
- Fixable advanced input: `{$or: [{country: "US"}]}`
- Invalid type: `"country"`
- Valid simple input: `{"country":"US"}`
- Valid advanced input: `{"$or":[{"country":"US"}]}`