### PR TITLE
Introduce new no access role

### DIFF
--- a/packages/back-end/src/scim/users/createUser.ts
+++ b/packages/back-end/src/scim/users/createUser.ts
@@ -14,6 +14,7 @@ import {
 
 export function isRoleValid(role: MemberRole) {
   const validRoles: Record<MemberRole, boolean> = {
+    noaccess: true,
     readonly: true,
     collaborator: true,
     designer: true,

--- a/packages/back-end/src/util/organization.util.ts
+++ b/packages/back-end/src/util/organization.util.ts
@@ -20,6 +20,7 @@ export const ENV_SCOPED_PERMISSIONS = [
 ] as const;
 
 export const PROJECT_SCOPED_PERMISSIONS = [
+  "readData",
   "addComments",
   "createFeatureDrafts",
   "manageFeatures",
@@ -34,6 +35,7 @@ export const PROJECT_SCOPED_PERMISSIONS = [
 ] as const;
 
 export const GLOBAL_PERMISSIONS = [
+  "readData",
   "createPresentations",
   "createDimensions",
   "createSegments",
@@ -320,19 +322,31 @@ export function getRoles(_organization: OrganizationInterface): Role[] {
   // TODO: support custom roles?
   return [
     {
+      id: "noaccess",
+      description:
+        "Cannot view any features or experiments. Most useful when combined with project-scoped roles.",
+      permissions: [],
+    },
+    {
       id: "readonly",
       description: "View all features and experiment results",
-      permissions: [],
+      permissions: ["readData"],
     },
     {
       id: "collaborator",
       description: "Add comments and contribute ideas",
-      permissions: ["addComments", "createIdeas", "createPresentations"],
+      permissions: [
+        "readData",
+        "addComments",
+        "createIdeas",
+        "createPresentations",
+      ],
     },
     {
       id: "engineer",
       description: "Manage features",
       permissions: [
+        "readData",
         "addComments",
         "createIdeas",
         "createPresentations",
@@ -352,6 +366,7 @@ export function getRoles(_organization: OrganizationInterface): Role[] {
       id: "analyst",
       description: "Analyze experiments",
       permissions: [
+        "readData",
         "addComments",
         "createIdeas",
         "createPresentations",
@@ -369,6 +384,7 @@ export function getRoles(_organization: OrganizationInterface): Role[] {
       id: "experimenter",
       description: "Manage features AND Analyze experiments",
       permissions: [
+        "readData",
         "addComments",
         "createIdeas",
         "createPresentations",

--- a/packages/back-end/types/organization.d.ts
+++ b/packages/back-end/types/organization.d.ts
@@ -30,6 +30,7 @@ export type UserPermissions = {
 };
 
 export type MemberRole =
+  | "noaccess"
   | "readonly"
   | "collaborator"
   | "designer"

--- a/packages/front-end/components/Settings/Team/SingleRoleSelector.tsx
+++ b/packages/front-end/components/Settings/Team/SingleRoleSelector.tsx
@@ -2,6 +2,7 @@ import { ReactNode, useMemo } from "react";
 import { MemberRole, MemberRoleInfo } from "back-end/types/organization";
 import uniqid from "uniqid";
 import { roleSupportsEnvLimit } from "shared/permissions";
+import { useGrowthBook } from "@growthbook/growthbook-react";
 import { useUser } from "../../../services/UserContext";
 import { useEnvironments } from "../../../services/features";
 import MultiSelectField from "../../Forms/MultiSelectField";
@@ -22,8 +23,16 @@ export default function SingleRoleSelector({
   includeAdminRole?: boolean;
   disabled?: boolean;
 }) {
+  const growthbook = useGrowthBook();
   const { roles, hasCommercialFeature } = useUser();
   const hasFeature = hasCommercialFeature("advanced-permissions");
+  const isNoAccessRoleEnabled = growthbook?.isOn("no-access-role-type");
+
+  let roleOptions = [...roles];
+
+  if (!hasFeature || !isNoAccessRoleEnabled) {
+    roleOptions = roles.filter((r) => r.id !== "noaccess");
+  }
 
   const availableEnvs = useEnvironments();
 
@@ -40,7 +49,7 @@ export default function SingleRoleSelector({
             role,
           });
         }}
-        options={roles
+        options={roleOptions
           .filter((r) => includeAdminRole || r.id !== "admin")
           .map((r) => ({
             label: r.id,

--- a/packages/front-end/services/UserContext.tsx
+++ b/packages/front-end/services/UserContext.tsx
@@ -87,6 +87,7 @@ export const DEFAULT_PERMISSIONS: Record<GlobalPermission, boolean> = {
   organizationSettings: false,
   superDelete: false,
   viewEvents: false,
+  readData: false,
 };
 
 export interface UserContextValue {


### PR DESCRIPTION
### Features and Changes

This PR introduces a new role called `no access`. This is now the most limited role. In order to support this, we had to add a new permission called `readData` that all roles, excluding the `no access` role receives. 

Previously, the `readOnly` role was our least permissive role, and it didn't have any permissions. Now that we've added a less permissive role (`no access`) we had to make the `readData` permission.

This new `no access` role is an enterprise level feature, so it does require the organization to have the `advanced-permissions` commercial feature.

This allows us to not show the `no access` role option in the `RoleSelector` when inviting/updating a user's global or project-level roles. 

### NOTE: This is the first of many PRs that will be introduced to formally support the no-access role. The goal of this PR is to simply introduce the concept in our application. Pushing this PR will not change any organizations or user's experience.

I've created a new feature flag `no-access-role-type` that ensures even if an org has the `advanced-permissions` commercial feature, they won't be able to add/invite users with this new role in production.

### Testing
- [x] Ensure that if the organization is not enterprise, they do not see the `no access` role regardless of the feature flag's state.
- [x] Ensure that if the organization IS an enterprise org, and the feature flag is enabled for the environment, the `no access` role is an option when inviting or updating a user.
