### PR TITLE
Fallback to env var for LICENSE_KEY

### DIFF
--- a/packages/back-end/src/services/licenseData.ts
+++ b/packages/back-end/src/services/licenseData.ts
@@ -61,7 +61,12 @@ export async function initializeLicense(
   forceRefresh = false
 ) {
   const key = licenseKey || process.env.LICENSE_KEY;
-  if (!IS_CLOUD && (!key || key.startsWith("license_"))) {
+  if (
+    !IS_CLOUD &&
+    (!key ||
+      key.startsWith("license_") ||
+      process.env.LICENSE_KEY?.startsWith("license_"))
+  ) {
     const userLicenseCodes = await getUserLicenseCodes();
     const metaData = await getMetaData();
     return await licenseInit(

--- a/packages/enterprise/src/license.ts
+++ b/packages/enterprise/src/license.ts
@@ -406,7 +406,7 @@ export async function licenseInit(
   userLicenseCodes?: string[],
   metaData?: LicenseMetaData,
   forceRefresh = false
-) {
+): Promise<Partial<LicenseInterface> | undefined> {
   const key = licenseKey || process.env.LICENSE_KEY || null;
 
   if (!key) {
@@ -442,7 +442,19 @@ export async function licenseInit(
     keyToLicenseData[key] = licenseData;
   });
 
-  return keyToLicenseData[key];
+  if (
+    process.env.LICENSE_KEY &&
+    new Date(keyToLicenseData[key]?.dateExpires || "") < new Date()
+  ) {
+    return licenseInit(
+      process.env.LICENSE_KEY,
+      userLicenseCodes,
+      metaData,
+      forceRefresh
+    );
+  } else {
+    return keyToLicenseData[key];
+  }
 }
 
 export function getLicense() {


### PR DESCRIPTION
### Features and Changes

Some people tried to use both an env var and the license key within mongo and couldn't understand why the env var wasn't "taking": https://growthbookapp.slack.com/archives/C03M46VMGTB/p1704321222440419
This change falls back to using the env var if the license key attached to the org has expired.

### Testing

`yarn test`
Added a key to licenseKey.
Restarted App.
Saw the licenseExpired in banner.
Added a LICENSE_KEY of a non-expired license.
Restarted App.
Saw the license in banner without expired message.
