### PR TITLE
[bugfix] Ensure report FE knows difference type is relative

### DIFF
--- a/packages/front-end/pages/report/[rid].tsx
+++ b/packages/front-end/pages/report/[rid].tsx
@@ -484,6 +484,7 @@ export default function ReportPage() {
                     report.args.metricRegressionAdjustmentStatuses
                   }
                   sequentialTestingEnabled={sequentialTestingEnabled}
+                  differenceType={"relative"}
                 />
               ) : (
                 <BreakDownResults_old


### PR DESCRIPTION
On ad-hoc reports with dimension slices, FE was formatting the graph and value change incorrectly because differenceType was undefined.

This sets it to relative, which it always is, and formatting is now correct.