### PR TITLE
Bugfix: JS SDK - Wait for document.body to load

### DIFF
--- a/docs/docs/visual-editor.mdx
+++ b/docs/docs/visual-editor.mdx
@@ -113,6 +113,10 @@ When you're using the Element Selector, after you pick an element to edit, you'l
 
 When you're finished making changes, click the **Done Editing** button to be taken back to GrowthBook.
 
+:::tip Custom JavaScript
+Please be aware that if you add custom JavaScript to a variation, it will start working as soon as the page loads. If your JavaScript changes parts of the webpage (DOM elements), you should use a Mutation Observer or something similar. This ensures that the parts of the webpage you want to change are fully loaded before your JavaScript runs.
+:::
+
 ### Drag and Drop
 
 When in Selection Mode, you can select an element and click to **drag and drop** it positionally on the page.
@@ -126,30 +130,6 @@ When an element is selected, you will see a floating handle to move it positiona
 Once dragging, the cursor will highlight an edge where the dragged element will land. When you release the cursor the element will move to the indicated spot. If you want to undo the move, click the 'Undo' button that is available for elements that have been dragged.
 
 ![Visual Editor Drag and Drop Example](/images/visual-editor-drag-and-drop.gif)
-
-### SDK Warnings
-
-The Visual Editor will present warnings to users who show signs of misconfiguration with respect to their GrowthBook SDK.
-
-**The Visual Editor will still work as intended and save your changes.** However these warnings are to help alert you to issues that may occur when running the visual experiment for your customers.
-
-#### SDK is not present
-
-This message is indicating that the page you are editing does not have a GrowthBook SDK loaded. An SDK is required to be loaded and running on your page for your experiments to run.
-
-<img style={{ width: '400px'}} src="/images/visual-editor-sdk-not-detected.png" alt="SDK is not present"/>
-
-#### SDK is not up to date
-
-This message is indicating that your GrowthBook SDK is working but not up to date. You may encounter unexpected behavior as a result.
-
-<img style={{ width: '400px'}} src="/images/visual-editor-sdk-out-of-date.png" alt="SDK is not present"/>
-
-#### Hash attribute is missing
-
-This message is indicating that the hash attribute defined for your visual experiment is not being provided to the SDK. The hash attribute is required for the SDK to bucket users and without it, it cannot run the visual experiment.
-
-<img style={{ width: '400px'}} src="/images/visual-editor-hash-attr-missing.png" alt="Hash attribute is missing"/>
 
 ### Debug Panel
 

--- a/docs/docs/visual-editor.mdx
+++ b/docs/docs/visual-editor.mdx
@@ -117,7 +117,7 @@ When you're finished making changes, click the **Done Editing** button to be tak
 
 Custom JavaScript is executed as quickly as possible, often times before the page has fully loaded. This gives you the most flexibility in how to implement your experiment.
 
-If you making changes to elements on the page, make sure you wait until they exist. Below is a small helper function you can add to the top of your Custom JavaScript to help with this:
+If you are making changes to elements on the page, make sure you wait until they exist. Below is a small helper function you can add to the top of your Custom JavaScript to help with this:
 
 ```js
 function waitFor(selector) {

--- a/docs/docs/visual-editor.mdx
+++ b/docs/docs/visual-editor.mdx
@@ -113,9 +113,33 @@ When you're using the Element Selector, after you pick an element to edit, you'l
 
 When you're finished making changes, click the **Done Editing** button to be taken back to GrowthBook.
 
-:::tip Custom JavaScript
-Please be aware that if you add custom JavaScript to a variation, it will start working as soon as the page loads. If your JavaScript changes parts of the webpage (DOM elements), you should use a Mutation Observer or something similar. This ensures that the parts of the webpage you want to change are fully loaded before your JavaScript runs.
-:::
+### Custom JavaScript
+
+Custom JavaScript is executed as quickly as possible, often times before the page has fully loaded. This gives you the most flexibility in how to implement your experiment.
+
+If you making changes to elements on the page, make sure you wait until they exist. Below is a small helper function you can add to the top of your Custom JavaScript to help with this:
+
+```js
+function waitFor(selector) {
+  return new Promise(resolve => {
+    const el = document.querySelector(selector);
+    if (el) return resolve(el);
+    const observer = new MutationObserver(() => {
+        const el = document.querySelector(selector);
+        if (el) { observer.disconnect(); resolve(el)}
+    });
+    observer.observe(document, {childList: true, subtree: true});
+  });
+}
+```
+
+Then, you can use it like so:
+
+```js
+waitFor(".my-element").then((el) => {
+  el.innerHTML = "Hello World!";
+});
+```
 
 ### Drag and Drop
 

--- a/packages/sdk-js/src/GrowthBook.ts
+++ b/packages/sdk-js/src/GrowthBook.ts
@@ -1137,7 +1137,7 @@ export class GrowthBook<
     if (changes.js) {
       const script = document.createElement("script");
       script.innerHTML = changes.js;
-      document.body.appendChild(script);
+      document.head.appendChild(script);
       undo.push(() => script.remove());
     }
     if (changes.domMutations) {


### PR DESCRIPTION
### Features and Changes

In some cases the JS SDK will try to apply changes to `document.body` before it has loaded.

This leads to a broken state for the SDK and blocks experiments from running. 


This PR **modifies the way we mount a customers custom JS** by appending the containing `<script>` tag to `document.head` instead.

Also adding docs to remind users that their custom JS will run immediately on page load and to take steps to assert the body or descendant elements exist before executing against them.

<img width="1063" alt="image" src="https://github.com/growthbook/growthbook/assets/2374625/7e2a204c-3c2b-4ff2-9f16-c552fc638a81">

- Closes #1982

### 
Error state

![image](https://github.com/growthbook/growthbook/assets/2374625/7e0a024f-6f21-4c2a-b49c-dd1d9f2d8fba)

### Dependencies

- Requires publishing new version of SDK for changes to be deployed

### Testing

Tested locally
https://www.loom.com/share/61700daefe224a5391986e387cdb663f
Old: ~https://www.loom.com/share/a64ed476288a44608c80d5dbb2236b2a~