### PR TITLE
Make sure enterprise package respects boolean like values in env vars

### DIFF
--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -16,7 +16,9 @@
     "clean": "rimraf node_modules",
     "type-check": "tsc --pretty --noEmit"
   },
-  "dependencies": {},
+  "dependencies": {
+    "shared": "0.0.1"
+  },
   "devDependencies": {
     "@swc/cli": "^0.1.57",
     "@swc/core": "^1.3.4",

--- a/packages/enterprise/src/license.ts
+++ b/packages/enterprise/src/license.ts
@@ -6,6 +6,7 @@ import type Stripe from "stripe";
 import pino from "pino";
 import { omit, sortBy } from "lodash";
 import AsyncLock from "async-lock";
+import { stringToBoolean } from "shared/util";
 import { LicenseDocument, LicenseModel } from "./models/licenseModel";
 
 export const LICENSE_SERVER =
@@ -150,7 +151,7 @@ export function isActiveSubscriptionStatus(
 }
 
 export function getAccountPlan(org: MinimalOrganization): AccountPlan {
-  if (process.env.IS_CLOUD) {
+  if (stringToBoolean(process.env.IS_CLOUD)) {
     if (org.enterprise) return "enterprise";
     if (org.restrictAuthSubPrefix || org.restrictLoginMethod) return "pro_sso";
     if (isActiveSubscriptionStatus(org.subscription?.status)) return "pro";
@@ -225,7 +226,7 @@ export async function getVerifiedLicenseData(
   }
   // Trying to use IS_MULTI_ORG, but the plan doesn't support it
   if (
-    process.env.IS_MULTI_ORG &&
+    stringToBoolean(process.env.IS_MULTI_ORG) &&
     !planHasPremiumFeature(decodedLicense.plan, "multi-org")
   ) {
     throw new Error(
@@ -274,7 +275,7 @@ function checkIfEnvVarSettingsAreAllowedByLicense(license: LicenseInterface) {
   }
   // Trying to use IS_MULTI_ORG, but the plan doesn't support it
   if (
-    process.env.IS_MULTI_ORG &&
+    stringToBoolean(process.env.IS_MULTI_ORG) &&
     !planHasPremiumFeature(license.plan, "multi-org")
   ) {
     throw new Error(

--- a/packages/enterprise/src/sso.ts
+++ b/packages/enterprise/src/sso.ts
@@ -1,11 +1,12 @@
 import type { IssuerMetadata } from "openid-client";
+import { stringToBoolean } from "shared/util";
 import type { SSOConnectionInterface } from "../../back-end/types/sso-connection";
 
 // Self-hosted SSO
 function getSSOConfig() {
   if (!process.env.SSO_CONFIG) return null;
 
-  if (!process.env.IS_CLOUD && !process.env.LICENSE_KEY) {
+  if (!stringToBoolean(process.env.IS_CLOUD) && !process.env.LICENSE_KEY) {
     throw new Error(
       "Must have a commercial License Key to use self-hosted SSO"
     );
@@ -36,7 +37,7 @@ function getSSOConfig() {
 
   // Sanity check for GrowthBook Cloud (to avoid misconfigurations)
   if (
-    process.env.IS_CLOUD &&
+    stringToBoolean(process.env.IS_CLOUD) &&
     config?.metadata?.issuer !== "https://growthbook.auth0.com/"
   ) {
     throw new Error("Invalid SSO configuration for GrowthBook Cloud");

--- a/packages/enterprise/tsconfig.json
+++ b/packages/enterprise/tsconfig.json
@@ -8,7 +8,7 @@
     "moduleResolution": "node",
     "sourceMap": true,
     "outDir": "dist",
-    "typeRoots": ["node_modules/@types"],
+    "typeRoots": ["node_modules/@types", "./typings"],
     "strictNullChecks": true,
     "strictBindCallApply": true,
     "strictPropertyInitialization": true,

--- a/packages/enterprise/typings/dirty-json/index.d.ts
+++ b/packages/enterprise/typings/dirty-json/index.d.ts
@@ -1,0 +1,8 @@
+declare module "dirty-json" {
+  export function parse(
+    text: string,
+    // eslint-disable-next-line
+    config?: Record<string, any>
+    // eslint-disable-next-line
+  ): Record<string, any>;
+}


### PR DESCRIPTION
# Features and Changes

- `IS_CLOUD=false` and `IS_MULTI_ORG=false` was evaluated as `true` before this change.  This fixes that.
- In order to import things from shared in enterprise we needed to add a typing file for dirty-json like we have in back-end package.

# Test Plan
Set `IS_CLOUD=false` and `IS_MULTI_ORG=false` without a LICENSE_KEY in  packages/back-end/.env.local 
Start the server see "Try Enterprise" - which only shows on self-hosted in the menu.
`git grep process.env` manually see that all the boolean env vars have been wrapped.