### PR TITLE
Make no access role new commercial feature

### DIFF
--- a/packages/enterprise/src/license.ts
+++ b/packages/enterprise/src/license.ts
@@ -33,6 +33,7 @@ export type CommercialFeature =
   | "remote-evaluation"
   | "multi-org"
   | "custom-launch-checklist"
+  | "no-access-role"
   | "teams";
 export type CommercialFeaturesMap = Record<AccountPlan, Set<CommercialFeature>>;
 
@@ -131,6 +132,7 @@ export const accountFeatures: CommercialFeaturesMap = {
     "multi-org",
     "teams",
     "custom-launch-checklist",
+    "no-access-role",
   ]),
 };
 

--- a/packages/front-end/components/Settings/Team/SingleRoleSelector.tsx
+++ b/packages/front-end/components/Settings/Team/SingleRoleSelector.tsx
@@ -32,7 +32,7 @@ export default function SingleRoleSelector({
 
   let roleOptions = [...roles];
 
-  if (!hasFeature || !isNoAccessRoleEnabled) {
+  if (!isNoAccessRoleEnabled) {
     roleOptions = roles.filter((r) => r.id !== "noaccess");
   }
 

--- a/packages/front-end/components/Settings/Team/SingleRoleSelector.tsx
+++ b/packages/front-end/components/Settings/Team/SingleRoleSelector.tsx
@@ -26,7 +26,9 @@ export default function SingleRoleSelector({
   const growthbook = useGrowthBook();
   const { roles, hasCommercialFeature } = useUser();
   const hasFeature = hasCommercialFeature("advanced-permissions");
-  const isNoAccessRoleEnabled = growthbook?.isOn("no-access-role-type");
+  const isNoAccessRoleEnabled =
+    growthbook?.isOn("no-access-role-type") &&
+    hasCommercialFeature("no-access-role");
 
   let roleOptions = [...roles];
 


### PR DESCRIPTION
### Features and Changes

This PR adds a new `commercial-feature` for the `no-access-role` and assigns it to all enterprise plans.

- Closes **(add link to issue here)**

### Testing
- [x] Log in with a pro plan and ensure the `no-access-role` isn't selectable/visible
- [x] Switch to an enterprise org and ensure the `no-access-role` is selectable/visible
