### PR TITLE
Add metric overrides to mixpanel

### DIFF
--- a/packages/back-end/src/integrations/GoogleAnalytics.ts
+++ b/packages/back-end/src/integrations/GoogleAnalytics.ts
@@ -1,5 +1,6 @@
 import { analyticsreporting_v4, google } from "googleapis";
 import { DataSourceType } from "aws-sdk/clients/quicksight";
+import cloneDeep from "lodash/cloneDeep";
 import {
   SourceIntegrationConstructor,
   SourceIntegrationInterface,
@@ -27,6 +28,7 @@ import {
 } from "../../types/datasource";
 import { MetricInterface } from "../../types/metric";
 import { ExperimentSnapshotSettings } from "../../types/experiment-snapshot";
+import { applyMetricOverrides } from "../util/integration";
 
 export function getOauth2Client() {
   return new google.auth.OAuth2(
@@ -237,8 +239,13 @@ const GoogleAnalytics: SourceIntegrationConstructor = class
 
   getExperimentResultsQuery(
     snapshotSettings: ExperimentSnapshotSettings,
-    metrics: MetricInterface[]
+    metricDocs: MetricInterface[]
   ): string {
+    const metrics = metricDocs.map((m) => {
+      const mCopy = cloneDeep<MetricInterface>(m);
+      applyMetricOverrides(mCopy, snapshotSettings);
+      return mCopy;
+    });
     const metricExpressions = metrics.map((m) => ({
       expression: m.table,
     }));

--- a/packages/back-end/src/types/Integration.ts
+++ b/packages/back-end/src/types/Integration.ts
@@ -357,8 +357,8 @@ export interface SourceIntegrationInterface {
   getSensitiveParamKeys(): string[];
   getExperimentResultsQuery(
     snapshotSettings: ExperimentSnapshotSettings,
-    metrics: ExperimentMetricInterface[],
-    activationMetric: ExperimentMetricInterface | null,
+    metricDocs: ExperimentMetricInterface[],
+    activationMetricDoc: ExperimentMetricInterface | null,
     dimension: DimensionInterface | null
   ): string;
   getFormatDialect?(): FormatDialect;

--- a/packages/back-end/src/util/integration.ts
+++ b/packages/back-end/src/util/integration.ts
@@ -1,0 +1,35 @@
+import { ExperimentMetricInterface, isFactMetric } from "shared/experiments";
+import { ExperimentSnapshotSettings } from "../../types/experiment-snapshot";
+
+// mutates metric object itself!
+export function applyMetricOverrides(
+  metric: ExperimentMetricInterface,
+  settings: ExperimentSnapshotSettings
+): void {
+  if (!metric) return;
+
+  const computed = settings.metricSettings.find((s) => s.id === metric.id)
+    ?.computedSettings;
+  if (!computed) return;
+
+  metric.conversionDelayHours = computed.conversionDelayHours;
+
+  if (isFactMetric(metric)) {
+    metric.conversionWindowUnit = "hours";
+    metric.conversionWindowValue = computed.conversionWindowHours;
+  } else {
+    metric.conversionWindowHours = computed.conversionWindowHours;
+  }
+
+  metric.regressionAdjustmentEnabled = computed.regressionAdjustmentEnabled;
+  metric.regressionAdjustmentDays = computed.regressionAdjustmentDays;
+
+  // TODO: move this to the form validation when saving this settings
+  if (metric.regressionAdjustmentDays < 0) {
+    metric.regressionAdjustmentDays = 0;
+  }
+  if (metric.regressionAdjustmentDays > 100) {
+    metric.regressionAdjustmentDays = 100;
+  }
+  return;
+}


### PR DESCRIPTION
### Features and Changes

Metric overrides were never applied to mixpanel.

This achieves this by refactoring the override code to a util file so it can be called by either sql or non-sql integrations.

### Testing

SQL overrides work as before.

None for mixpanel, don't have mixpanel.
