### PR TITLE
[bugfix] prevent undefined query result rows from breaking stats engine

### DIFF
--- a/packages/back-end/src/services/stats.ts
+++ b/packages/back-end/src/services/stats.ts
@@ -262,7 +262,7 @@ export async function analyzeExperimentResults({
 
       metricRows.push({
         metric: key,
-        rows: query.result as ExperimentMetricQueryResponseRows,
+        rows: (query.result ?? []) as ExperimentMetricQueryResponseRows,
       });
     });
   }


### PR DESCRIPTION
A customer may have hit a case where `rows` here is actually undefined:

https://github.com/growthbook/growthbook/blob/main/packages/back-end/src/services/stats.ts#L99-L107

Because we just tell Typescript that something potentially undefined (query.result) should be `ExperimentMetricQueryResponseRows`, we should just be safe and let undefined be treated the same as an empty list if they get to this part.

Shouldn't happen if query status is "finished", but maybe it's related to allowing partially completed data to go to the stats engine.