### PR TITLE
Bump JS SDK version to 0.32.0, React SDK version to 0.22.0

### DIFF
--- a/packages/back-end/package.json
+++ b/packages/back-end/package.json
@@ -31,7 +31,7 @@
     "@dqbd/tiktoken": "^1.0.7",
     "@google-cloud/bigquery": "5",
     "@google-cloud/storage": "^5.20.5",
-    "@growthbook/growthbook": "^0.31.0",
+    "@growthbook/growthbook": "^0.32.0",
     "@growthbook/proxy-eval": "^1.0.0",
     "@octokit/auth-app": "^6.0.1",
     "@octokit/core": "^5.0.2",

--- a/packages/front-end/package.json
+++ b/packages/front-end/package.json
@@ -19,7 +19,7 @@
     "@dnd-kit/core": "^4.0.3",
     "@dnd-kit/sortable": "^5.1.0",
     "@floating-ui/react": "^0.25.4",
-    "@growthbook/growthbook-react": "^0.21.0",
+    "@growthbook/growthbook-react": "^0.22.0",
     "@jitsu/sdk-js": "^2.2.0",
     "@jukben/emoji-search": "^2.0.1",
     "@popperjs/core": "^2.11.5",

--- a/packages/sdk-js/CHANGELOG.md
+++ b/packages/sdk-js/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## **0.32.0** - Jan 11, 2024
+
+- Fix bug when visual editor loaded before `document.body` was available
+- Sticky Bucketing support with built-in implementations for persisting in localStorage, cookies (both browser and Node.js), and Redis. Off by default, an implementation must be passed into the GrowthBook constructor to enable.
+- The following methods are now async and return a Promise: `setAttributes`, `setAttributeOverrides`, `setForcedVariations`, `setURL`. No code changes are required since these all returned `void` prior to this.
+
 ## **0.31.0** - Nov 14, 2023
 
 - Fix bug with multi-page visual editor experiments

--- a/packages/sdk-js/package.json
+++ b/packages/sdk-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@growthbook/growthbook",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/sdk-react/package.json
+++ b/packages/sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@growthbook/growthbook-react",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -38,7 +38,7 @@
     "react": "^16.8.0-0 || ^17.0.0-0 || ^18.0.0-0"
   },
   "dependencies": {
-    "@growthbook/growthbook": "^0.31.0"
+    "@growthbook/growthbook": "^0.32.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.19.3",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -17,7 +17,7 @@
     "type-check": "tsc --pretty --noEmit"
   },
   "dependencies": {
-    "@growthbook/growthbook": "^0.31.0",
+    "@growthbook/growthbook": "^0.32.0",
     "ajv": "^8.12.0",
     "date-fns": "^2.15.0",
     "dirty-json": "^0.9.2",

--- a/packages/shared/src/sdk-versioning/sdk-versions/javascript.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/javascript.json
@@ -1,6 +1,9 @@
 {
   "versions": [
     {
+      "version": "0.32.0"
+    },
+    {
       "version": "0.31.0"
     },
     {

--- a/packages/shared/src/sdk-versioning/sdk-versions/nodejs.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/nodejs.json
@@ -1,6 +1,9 @@
 {
   "versions": [
     {
+      "version": "0.32.0"
+    },
+    {
       "version": "0.31.0"
     },
     {

--- a/packages/shared/src/sdk-versioning/sdk-versions/react.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/react.json
@@ -1,6 +1,9 @@
 {
   "versions": [
     {
+      "version": "0.22.0"
+    },
+    {
       "version": "0.21.0"
     },
     {


### PR DESCRIPTION
### Features and Changes

Bump Javascript SDK to `0.32.0`, React SDK to `0.22.0`

Deploy steps:
1. Release Javascript SDK on npm
2. Release React SDK on npm
3. Merge PR