### PR TITLE
Use proxyAgent for license checks

### DIFF
--- a/packages/enterprise/src/license.ts
+++ b/packages/enterprise/src/license.ts
@@ -7,6 +7,7 @@ import pino from "pino";
 import { omit, sortBy } from "lodash";
 import AsyncLock from "async-lock";
 import { stringToBoolean } from "shared/util";
+import { ProxyAgent } from "proxy-agent";
 import { LicenseDocument, LicenseModel } from "./models/licenseModel";
 
 export const LICENSE_SERVER =
@@ -346,6 +347,12 @@ async function getLicenseDataFromServer(
 ): Promise<LicenseInterface> {
   logger.info("Getting license data from server for " + licenseId);
   const url = `${LICENSE_SERVER}license/${licenseId}/check`;
+  const use_proxy =
+    !!process.env.http_proxy ||
+    !!process.env.https_proxy ||
+    !!process.env.HTTPS_PROXY;
+  const agentOptions = use_proxy ? { agent: new ProxyAgent() } : {};
+
   const options = {
     method: "PUT",
     headers: {
@@ -355,6 +362,7 @@ async function getLicenseDataFromServer(
       userHashes: userLicenseCodes,
       metaData,
     }),
+    ...agentOptions,
   };
 
   let serverResult;


### PR DESCRIPTION
### Features and Changes
Enterprise clients might have set up a proxy to route traffic through.  This PR makes sure we use any env vars that specify that the proxy exists.

Implementation note: 
We do have a function in back-end/src/util/http.util.ts to getHttpOptions().  I tried moving this to shared, but proxyAgent isn't compatible with front-end code - it needs `fs`

### Testing

Downloaded and installed fiddler proxy.  
`http_proxy=http://localhost:8866 https_proxy=http://localhost:8866 NODE_TLS_REJECT_UNAUTHORIZED=0 yarn dev`
See that the application loads.
