### PR TITLE
fix expired license never ending loop

### DIFF
--- a/packages/enterprise/src/license.ts
+++ b/packages/enterprise/src/license.ts
@@ -451,6 +451,7 @@ export async function licenseInit(
 
   if (
     process.env.LICENSE_KEY &&
+    key != process.env.LICENSE_KEY &&
     new Date(keyToLicenseData[key]?.dateExpires || "") < new Date()
   ) {
     return licenseInit(


### PR DESCRIPTION
### Features and Changes
This fixes a never ending loop when the license was expired.  Introduced in: https://github.com/growthbook/growthbook/pull/2000

We only want to fall back to the env var, if we did not just check the env var key!  Whoops!

### Testing
in back-end/.env.local add an expired license key.
`yarn dev`
localhost:3000
See that the page loads