### PR TITLE
Download license usage report for old style licenses

### DIFF
--- a/packages/back-end/src/app.ts
+++ b/packages/back-end/src/app.ts
@@ -648,6 +648,7 @@ app.use("/teams", teamRouter);
 // Admin
 app.get("/admin/organizations", adminController.getOrganizations);
 app.get("/admin/license", adminController.getLicenseData);
+app.get("/admin/license-report", adminController.getLicenseReport);
 
 // Meta info
 app.get("/meta/ai", (req, res) => {

--- a/packages/back-end/src/controllers/admin.ts
+++ b/packages/back-end/src/controllers/admin.ts
@@ -1,3 +1,4 @@
+import crypto from "crypto";
 import { Response } from "express";
 import { AuthRequest } from "../types/AuthRequest";
 import { findAllOrganizations } from "../models/OrganizationModel";
@@ -61,9 +62,13 @@ export async function getLicenseReport(req: AuthRequest, res: Response) {
   const licenseMetaData = await getLicenseMetaData();
   const userLicenseCodes = await getUserLicenseCodes();
 
+  // Create a hmac signature of the license data
+  const hmac = crypto.createHmac("sha256", licenseMetaData.installationId);
+
   return res.status(200).json({
     status: 200,
     licenseMetaData,
     userLicenseCodes,
+    signature: hmac.update(JSON.stringify(userLicenseCodes)).digest("hex"),
   });
 }

--- a/packages/back-end/src/controllers/admin.ts
+++ b/packages/back-end/src/controllers/admin.ts
@@ -58,17 +58,22 @@ export async function getLicenseData(req: AuthRequest, res: Response) {
 export async function getLicenseReport(req: AuthRequest, res: Response) {
   req.checkPermissions("manageBilling");
 
-  // Force refresh the license data
+  const timestamp = new Date().toISOString();
   const licenseMetaData = await getLicenseMetaData();
   const userLicenseCodes = await getUserLicenseCodes();
 
   // Create a hmac signature of the license data
   const hmac = crypto.createHmac("sha256", licenseMetaData.installationId);
 
-  return res.status(200).json({
-    status: 200,
+  const report = {
+    timestamp,
     licenseMetaData,
     userLicenseCodes,
-    signature: hmac.update(JSON.stringify(userLicenseCodes)).digest("hex"),
+  };
+
+  return res.status(200).json({
+    status: 200,
+    ...report,
+    signature: hmac.update(JSON.stringify(report)).digest("hex"),
   });
 }

--- a/packages/back-end/src/services/licenseData.ts
+++ b/packages/back-end/src/services/licenseData.ts
@@ -7,7 +7,7 @@ import { IS_CLOUD } from "../util/secrets";
 import { getInstallationDatasources } from "../models/DataSourceModel";
 import { getUserLicenseCodes } from "./users";
 
-async function getMetaData() {
+export async function getLicenseMetaData() {
   const installationId = await getInstallationId();
   const rootPath = path.join(__dirname, "..", "..", "..", "..");
 
@@ -68,7 +68,7 @@ export async function initializeLicense(
       process.env.LICENSE_KEY?.startsWith("license_"))
   ) {
     const userLicenseCodes = await getUserLicenseCodes();
-    const metaData = await getMetaData();
+    const metaData = await getLicenseMetaData();
     return await licenseInit(
       licenseKey,
       userLicenseCodes,

--- a/packages/front-end/components/License/DownloadLicenseUsageButton.tsx
+++ b/packages/front-end/components/License/DownloadLicenseUsageButton.tsx
@@ -1,0 +1,64 @@
+import { FC } from "react";
+import { LicenseMetaData } from "enterprise";
+import { FaDownload } from "react-icons/fa";
+import { snakeCase } from "lodash";
+import { useAuth } from "@/services/auth";
+import { useUser } from "@/services/UserContext";
+import Button from "../Button";
+
+const DownloadLicenseUsageButton: FC = () => {
+  const { apiCall } = useAuth();
+  const { organization, license } = useUser();
+
+  const handleDownload = async () => {
+    try {
+      const res = await apiCall<{
+        status: number;
+        licenseMetaData: LicenseMetaData;
+        userLicenseCodes: string[];
+      }>(`/admin/license-report`, {
+        method: "GET",
+      });
+
+      if (res.status !== 200) {
+        throw new Error("There was an error fetching the license data");
+      }
+
+      const blob = new Blob(
+        [
+          JSON.stringify(
+            {
+              license: license,
+              licenseMetaData: res.licenseMetaData,
+              userLicenseCodes: res.userLicenseCodes,
+              seatsUsed: res.userLicenseCodes.length,
+            },
+            null,
+            2
+          ),
+        ],
+        {
+          type: "application/json",
+        }
+      );
+      const href = window.URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = href;
+      link.download = `${snakeCase(organization.name)}_license_report.json`;
+      link.click();
+      window.URL.revokeObjectURL(href);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  return (
+    <>
+      <Button onClick={handleDownload}>
+        <FaDownload /> Download License Report
+      </Button>
+    </>
+  );
+};
+
+export default DownloadLicenseUsageButton;

--- a/packages/front-end/components/License/DownloadLicenseUsageButton.tsx
+++ b/packages/front-end/components/License/DownloadLicenseUsageButton.tsx
@@ -16,6 +16,7 @@ const DownloadLicenseUsageButton: FC = () => {
         status: number;
         licenseMetaData: LicenseMetaData;
         userLicenseCodes: string[];
+        signature: string;
       }>(`/admin/license-report`, {
         method: "GET",
       });
@@ -32,6 +33,8 @@ const DownloadLicenseUsageButton: FC = () => {
               licenseMetaData: res.licenseMetaData,
               userLicenseCodes: res.userLicenseCodes,
               seatsUsed: res.userLicenseCodes.length,
+              signature: res.signature,
+              timestamp: new Date().toISOString(),
             },
             null,
             2

--- a/packages/front-end/components/License/DownloadLicenseUsageButton.tsx
+++ b/packages/front-end/components/License/DownloadLicenseUsageButton.tsx
@@ -17,6 +17,7 @@ const DownloadLicenseUsageButton: FC = () => {
         licenseMetaData: LicenseMetaData;
         userLicenseCodes: string[];
         signature: string;
+        timestamp: string;
       }>(`/admin/license-report`, {
         method: "GET",
       });
@@ -34,7 +35,7 @@ const DownloadLicenseUsageButton: FC = () => {
               userLicenseCodes: res.userLicenseCodes,
               seatsUsed: res.userLicenseCodes.length,
               signature: res.signature,
-              timestamp: new Date().toISOString(),
+              timestamp: res.timestamp,
             },
             null,
             2

--- a/packages/front-end/components/License/ShowLicenseInfo.tsx
+++ b/packages/front-end/components/License/ShowLicenseInfo.tsx
@@ -9,6 +9,7 @@ import { GBPremiumBadge } from "../Icons";
 import UpgradeModal from "../Settings/UpgradeModal";
 import AccountPlanNotices from "../Layout/AccountPlanNotices";
 import RefreshLicenseButton from "./RefreshLicenseButton";
+import DownloadLicenseUsageButton from "./DownloadLicenseUsageButton";
 
 const ShowLicenseInfo: FC<{
   showInput?: boolean;
@@ -130,11 +131,18 @@ const ShowLicenseInfo: FC<{
                       <div>Seats:</div>
                       <span className="text-muted">{license.seats}</span>
                     </div>
-                    <div className="col-sm-2">
-                      {license && license.id.startsWith("license") && (
+
+                    {license.id.startsWith("license") && (
+                      <div className="col-sm-2">
                         <RefreshLicenseButton />
-                      )}
-                    </div>
+                      </div>
+                    )}
+
+                    {!license.id.startsWith("license") && (
+                      <div className="mt-3">
+                        <DownloadLicenseUsageButton />
+                      </div>
+                    )}
                   </>
                 )}
               </div>


### PR DESCRIPTION
### Features and Changes
Due to legal reasons, some companies will still want air-gapped licenses so they don't have to ping our servers.  This changeset provides companies with such licenses a button to download a usage report and which they can then send to as proof of their usage amounts.  

### Testing
In backend/.env.local set LICENSE_KEY=old style license.
Go to http://localhost:3000/settings
Click "Download License Report" button.
See the save dialog appear with the filename in the form `${organization_name}_license_report.json`
Click Save.
Open file and see something along the lines of:
```
{
  "license": {
    "id": "17bd5e",
    "companyName": "GrowthBook",
    "seats": 40,
    "dateCreated": "2022-09-25",
    "dateExpires": "2023-12-31",
    "isTrial": false,
    "plan": "enterprise"
  },
  "licenseMetaData": {
    "installationId": "installation-04ed35f0-806c-4ecb-b148-051bc42dd3e1",
    "gitSha": "736b3d4bda1bb7eecd701a754305fabd634a43b6\n",
    "gitCommitDate": "2023-11-14T19:51:59Z\n",
    "sdkLanguages": [
      "nodejs"
    ],
    "dataSourceTypes": [
      "bigquery"
    ],
    "eventTrackers": [
      "rudderstack"
    ],
    "isCloud": false
  },
  "userLicenseCodes": [
    "6ef56f32",
    "aa72f161",
    "246a3474",
    "5ba68980"
  ],
  "seatsUsed": 4,
  "signature": "3fab6b4cebbf7e061465c2b0e0f4cec683c8420c38590fe8760d617d6d0404ef",
  "timestamp": "2024-01-16T15:44:44.087Z"
}
```

### Screenshots
![Screenshot 2024-01-16 at 2 46 48 PM](https://github.com/growthbook/growthbook/assets/950231/1f269c07-bad5-434a-9c97-d9a5e0c41711)

