### PR TITLE
Trim license key & Better error message for license errors.

### DIFF
--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -1809,19 +1809,21 @@ export async function putLicenseKey(
     );
   }
 
-  const { licenseKey } = req.body;
+  const licenseKey = req.body.licenseKey.trim();
   if (!licenseKey) {
     throw new Error("missing license key");
   }
 
   const currentLicenseData = getLicense();
   let licenseData = null;
+  let error = null;
   try {
     // set new license
     licenseData = await initializeLicense(licenseKey);
   } catch (e) {
     // eslint-disable-next-line no-console
     console.error("setting new license failed", e);
+    error = e;
   }
   if (!licenseData) {
     // setting license failed, revert to previous
@@ -1833,7 +1835,11 @@ export async function putLicenseKey(
       console.error("reverting to old license failed", e);
       await setLicense(null);
     }
-    throw new Error("Invalid license key");
+    if (error.message.includes("Could not connect")) {
+      throw new Error(error?.message);
+    } else {
+      throw new Error("Invalid license key");
+    }
   }
 
   try {

--- a/packages/enterprise/test/license.test.ts
+++ b/packages/enterprise/test/license.test.ts
@@ -258,6 +258,7 @@ describe("licenseInit", () => {
       beforeEach(() => {
         const mockedResponse: Response = ({
           ok: false,
+          statusText: "internal server error",
         } as unknown) as Response; // Create a mock Response object
 
         mockedFetch.mockResolvedValueOnce(Promise.resolve(mockedResponse));
@@ -273,7 +274,7 @@ describe("licenseInit", () => {
             async () =>
               await licenseInit(licenseKey, userLicenseCodes, metaData)
           ).rejects.toThrowError(
-            "License server is not working and no cached license data exists"
+            "License server errored with internal server error"
           );
         });
       });


### PR DESCRIPTION
### Features and Changes
We weren't trimming the license keys, so copying the key with an extra space would fail.  We also had a generic "Invalid License Key" error which made it hard to determine what was wrong.  Now if the error is due to not being able to reach the license server then we tell them to make sure to whitelist the ip address.

### Testing

Change the LICENSE_SERVER to a made up address.
`yarn build` in enterprise package
Try and add a new license and see it say it could not connect and make sure to whitelist.

Change the LICENSE_SERVER  back.
`yarn build` in enterprise package
Try and add a bad new license and see it error saying "Invalid License Key"

Try and add a new license with extra spaces.
See it succeed.

