### PR TITLE
Return 0s in data to gbstats

### DIFF
--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -573,21 +573,23 @@ export default abstract class SqlIntegration
           count: parseInt(row.users) || 0,
           main_sum: parseFloat(row.main_sum) || 0,
           main_sum_squares: parseFloat(row.main_sum_squares) || 0,
-          ...(row.denominator_sum && {
+          ...(row.denominator_sum !== undefined && {
             denominator_sum: parseFloat(row.denominator_sum) || 0,
             denominator_sum_squares:
               parseFloat(row.denominator_sum_squares) || 0,
             main_denominator_sum_product:
               parseFloat(row.main_denominator_sum_product) || 0,
           }),
-          ...(row.covariate_sum && {
+          ...(row.covariate_sum !== undefined && {
             covariate_sum: parseFloat(row.covariate_sum) || 0,
             covariate_sum_squares: parseFloat(row.covariate_sum_squares) || 0,
             main_covariate_sum_product:
               parseFloat(row.main_covariate_sum_product) || 0,
           }),
-          ...(row.main_cap_value && { main_cap_value: row.main_cap_value }),
-          ...(row.denominator_cap_value && {
+          ...(row.main_cap_value !== undefined && {
+            main_cap_value: row.main_cap_value,
+          }),
+          ...(row.denominator_cap_value !== undefined && {
             denominator_cap_value: row.denominator_cap_value,
           }),
         };

--- a/packages/stats/gbstats/gbstats.py
+++ b/packages/stats/gbstats/gbstats.py
@@ -493,6 +493,7 @@ def process_single_metric(
             ],
         )
     pdrows = pd.DataFrame(rows)
+    # TODO validate data in rows matches metric settings
 
     # Detect any variations that are not in the returned metric rows
     all_var_ids: Set[str] = set([v for a in analyses for v in a.var_ids])


### PR DESCRIPTION
Some users were getting `ValueError: Out of range float values are not JSON compliant` which was due to some `NaN` values getting set in our `gbstats` `Statistic`s objects because the data was missing when we built the internal dataframe to use for analysis.

This should ensure we always return data for given statistic types.