### PR TITLE
Only show the latest 25 revisions for a feature

### DIFF
--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -451,9 +451,7 @@ export async function postFeatureRebase(
   req.checkPermissions("manageFeatures", feature.project);
   req.checkPermissions("createFeatureDrafts", feature.project);
 
-  const revisions = await getRevisions(org.id, feature.id);
-
-  const revision = revisions.find((r) => r.version === parseInt(version));
+  const revision = await getRevision(org.id, feature.id, parseInt(version));
   if (!revision) {
     throw new Error("Could not find feature revision");
   }
@@ -461,10 +459,16 @@ export async function postFeatureRebase(
     throw new Error("Can only fix conflicts for Draft revisions");
   }
 
-  const live = revisions.find((r) => r.version === feature.version);
-  const base = revisions.find((r) => r.version === revision.baseVersion);
+  const live = await getRevision(org.id, feature.id, feature.version);
+  if (!live) {
+    throw new Error("Could not lookup feature history");
+  }
 
-  if (!live || !base) {
+  const base =
+    revision.baseVersion === live.version
+      ? live
+      : await getRevision(org.id, feature.id, revision.baseVersion);
+  if (!base) {
     throw new Error("Could not lookup feature history");
   }
 
@@ -530,9 +534,7 @@ export async function postFeaturePublish(
   }
   req.checkPermissions("manageFeatures", feature.project);
 
-  const revisions = await getRevisions(org.id, feature.id);
-
-  const revision = revisions.find((r) => r.version === parseInt(version));
+  const revision = await getRevision(org.id, feature.id, parseInt(version));
   if (!revision) {
     throw new Error("Could not find feature revision");
   }
@@ -540,10 +542,16 @@ export async function postFeaturePublish(
     throw new Error("Can only publish Draft revisions");
   }
 
-  const live = revisions.find((r) => r.version === feature.version);
-  const base = revisions.find((r) => r.version === revision.baseVersion);
+  const live = await getRevision(org.id, feature.id, feature.version);
+  if (!live) {
+    throw new Error("Could not lookup feature history");
+  }
 
-  if (!live || !base) {
+  const base =
+    revision.baseVersion === live.version
+      ? live
+      : await getRevision(org.id, feature.id, revision.baseVersion);
+  if (!base) {
     throw new Error("Could not lookup feature history");
   }
 

--- a/packages/back-end/src/models/FeatureRevisionModel.ts
+++ b/packages/back-end/src/models/FeatureRevisionModel.ts
@@ -78,7 +78,10 @@ export async function getRevisions(
   const docs: FeatureRevisionDocument[] = await FeatureRevisionModel.find({
     organization,
     featureId,
-  });
+  })
+    .sort({ version: -1 })
+    .limit(25);
+
   // Remove the log when fetching all revisions since it can be large to send over the network
   return docs.map(toInterface).map((d) => {
     delete d.log;

--- a/packages/front-end/pages/features/[fid].tsx
+++ b/packages/front-end/pages/features/[fid].tsx
@@ -122,11 +122,20 @@ export default function FeaturePage() {
 
   const [version, setVersion] = useState<number | null>(null);
 
+  let extraQueryString = "";
+  // Version being forced via querystring
+  if ("v" in router.query) {
+    const v = parseInt(router.query.v as string);
+    if (v) {
+      extraQueryString = `?v=${v}`;
+    }
+  }
+
   const { data, error, mutate } = useApi<{
     feature: FeatureInterface;
     revisions: FeatureRevisionInterface[];
     experiments: ExperimentInterfaceStringDates[];
-  }>(`/feature/${fid}`);
+  }>(`/feature/${fid}${extraQueryString}`);
   const firstFeature = router?.query && "first" in router.query;
   const [showImplementation, setShowImplementation] = useState(firstFeature);
   const environments = useEnvironments();


### PR DESCRIPTION
### Features and Changes

Features can have potentially thousands of revisions.  Instead of reading them all into memory and rendering them all on the front-end, limit to the most recent 25 revisions.  This can help reduce CPU/memory usage on the server.

This PR has some additional code to help solve the following edge cases:
- Going to a specific revision with a `?v=` querystring that's older than 25 revisions ago
- If the live revision is older than 25 revisions ago