### PR TITLE
Fix enterprise package type error fragility

### DIFF
--- a/packages/enterprise/src/pipeline.ts
+++ b/packages/enterprise/src/pipeline.ts
@@ -1,4 +1,4 @@
-import type { DataSourcePipelineSettings } from "../../back-end/types/datasource";
+import type { DataSourcePipelineSettings } from "back-end/types/datasource";
 
 const UNITS_TABLE_RETENTION_HOURS_DEFAULT = 24;
 

--- a/packages/enterprise/src/sso.ts
+++ b/packages/enterprise/src/sso.ts
@@ -1,6 +1,6 @@
 import type { IssuerMetadata } from "openid-client";
 import { stringToBoolean } from "shared/util";
-import type { SSOConnectionInterface } from "../../back-end/types/sso-connection";
+import type { SSOConnectionInterface } from "back-end/types/sso-connection";
 
 // Self-hosted SSO
 function getSSOConfig() {


### PR DESCRIPTION
### Features and Changes

The enterprise and shared packages were extremely fragile.  Adding a seemingly innocuous import in a random back-end file would trigger dozens of errors.

The source of this error were the following imports in the enterprise package:
```ts
import type { Foo } from "../../back-end/types/foo";
```

Because of the relative path to the back-end, the Typescript compiler thought this was a local source file.  As long as that imported package (and all of it's recursive imports) only export types and nothing else, it's fine.  But as soon as that's not true, Typescript would throw errors that `../../back-end/src` is not in the enterprise `rootDir`.

Changing the imports to absolute paths instead fixes the issue:
```ts
import type { Foo } from "back-end/types/foo";
```

Now typescript knows it's pointing to an external package and not a local source file.