### PR TITLE
Do not run preview environments for drafts

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   preview:
     runs-on: ubuntu-latest
-    if: ${{ github.repository == 'growthbook/growthbook' }}
+    if: ${{ github.repository == 'growthbook/growthbook' && github.event.pull_request.draft == false }}
     steps:
     - name: Context
       uses: okteto/context@latest

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -10,6 +10,7 @@ on:
       - "yarn.lock"
       - "Dockerfile"
       - ".dockerignore"
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   preview:

--- a/packages/front-end/pages/features/index.tsx
+++ b/packages/front-end/pages/features/index.tsx
@@ -294,7 +294,7 @@ export default function FeaturesPage() {
                 {showGraphs && (
                   <th>
                     Recent Usage{" "}
-                    <Tooltip body="Client-side feature evaluations for the past 30 minutes. Blue means the feature was 'on', Gray means it was 'off'." />
+                    <Tooltip body="Client-side feature evaluations for the past 30 minutes. Blue means the feature was 'on', Gray means it was 'off'!" />
                   </th>
                 )}
                 <th>Stale</th>

--- a/packages/front-end/pages/features/index.tsx
+++ b/packages/front-end/pages/features/index.tsx
@@ -294,7 +294,7 @@ export default function FeaturesPage() {
                 {showGraphs && (
                   <th>
                     Recent Usage{" "}
-                    <Tooltip body="Client-side feature evaluations for the past 30 minutes. Blue means the feature was 'on', Gray means it was 'off'!" />
+                    <Tooltip body="Client-side feature evaluations for the past 30 minutes. Blue means the feature was 'on', Gray means it was 'off'." />
                   </th>
                 )}
                 <th>Stale</th>


### PR DESCRIPTION
## Tested 

PR in draft state

<img width="932" alt="image" src="https://github.com/growthbook/growthbook/assets/2374625/ca268ff7-0a7d-497f-af0a-d6c04b775f05">

When switching from Draft -> Ready for Review, it triggers the Preview job

<img width="956" alt="Screenshot 2024-01-25 at 6 30 27 PM" src="https://github.com/growthbook/growthbook/assets/2374625/f1e88c2a-28a3-40a8-9cad-45474a77254b">
