### PR TITLE
Update MetricModel & FactTableModel to filter by read access level

### DIFF
--- a/packages/back-end/src/api/bulk-import/postBulkImportFacts.ts
+++ b/packages/back-end/src/api/bulk-import/postBulkImportFacts.ts
@@ -42,9 +42,7 @@ export const postBulkImportFacts = createApiRequestHandler(
 
     const factTableMap = await getFactTableMap(req.organization.id);
 
-    const allFactMetrics = await getAllFactMetricsForOrganization(
-      req.organization.id
-    );
+    const allFactMetrics = await getAllFactMetricsForOrganization(req.context);
     const factMetricMap = new Map<string, FactMetricInterface>(
       allFactMetrics.map((m) => [m.id, m])
     );

--- a/packages/back-end/src/api/bulk-import/postBulkImportFacts.ts
+++ b/packages/back-end/src/api/bulk-import/postBulkImportFacts.ts
@@ -40,7 +40,7 @@ export const postBulkImportFacts = createApiRequestHandler(
       factMetrics: 0,
     };
 
-    const factTableMap = await getFactTableMap(req.organization.id);
+    const factTableMap = await getFactTableMap(req.context);
 
     const allFactMetrics = await getAllFactMetricsForOrganization(req.context);
     const factMetricMap = new Map<string, FactMetricInterface>(

--- a/packages/back-end/src/api/fact-metrics/listFactMetrics.ts
+++ b/packages/back-end/src/api/fact-metrics/listFactMetrics.ts
@@ -11,9 +11,7 @@ export const listFactMetrics = createApiRequestHandler(
   listFactMetricsValidator
 )(
   async (req): Promise<ListFactMetricsResponse> => {
-    const factMetrics = await getAllFactMetricsForOrganization(
-      req.organization.id
-    );
+    const factMetrics = await getAllFactMetricsForOrganization(req.context);
 
     let matches = factMetrics;
     if (req.query.projectId) {

--- a/packages/back-end/src/api/fact-metrics/postFactMetric.ts
+++ b/packages/back-end/src/api/fact-metrics/postFactMetric.ts
@@ -167,8 +167,7 @@ export const postFactMetric = createApiRequestHandler(postFactMetricValidator)(
   async (req): Promise<PostFactMetricResponse> => {
     req.checkPermissions("createMetrics", req.body.projects || "");
 
-    const lookupFactTable = async (id: string) =>
-      getFactTable(req.organization.id, id);
+    const lookupFactTable = async (id: string) => getFactTable(req.context, id);
 
     if (req.body.projects?.length) {
       const projects = await findAllProjectsByOrganization(req.context);

--- a/packages/back-end/src/api/fact-metrics/updateFactMetric.ts
+++ b/packages/back-end/src/api/fact-metrics/updateFactMetric.ts
@@ -106,7 +106,7 @@ export const updateFactMetric = createApiRequestHandler(
     }
 
     await validateFactMetric({ ...factMetric, ...updates }, async (id) => {
-      return getFactTable(req.organization.id, id);
+      return getFactTable(req.context, id);
     });
 
     await updateFactMetricInDb(factMetric, updates);

--- a/packages/back-end/src/api/fact-tables/deleteFactTable.ts
+++ b/packages/back-end/src/api/fact-tables/deleteFactTable.ts
@@ -10,7 +10,7 @@ export const deleteFactTable = createApiRequestHandler(
   deleteFactTableValidator
 )(
   async (req): Promise<DeleteFactTableResponse> => {
-    const factTable = await getFactTable(req.organization.id, req.params.id);
+    const factTable = await getFactTable(req.context, req.params.id);
     if (!factTable) {
       throw new Error(
         "Unable to delete - Could not find factTable with that id"

--- a/packages/back-end/src/api/fact-tables/deleteFactTableFilter.ts
+++ b/packages/back-end/src/api/fact-tables/deleteFactTableFilter.ts
@@ -7,10 +7,7 @@ export const deleteFactTableFilter = createApiRequestHandler(
   deleteFactTableFilterValidator
 )(
   async (req): Promise<DeleteFactTableFilterResponse> => {
-    const factTable = await getFactTable(
-      req.organization.id,
-      req.params.factTableId
-    );
+    const factTable = await getFactTable(req.context, req.params.factTableId);
     if (!factTable) {
       throw new Error(
         "Unable to delete - Could not find factTable with that id"

--- a/packages/back-end/src/api/fact-tables/getFactTable.ts
+++ b/packages/back-end/src/api/fact-tables/getFactTable.ts
@@ -8,10 +8,7 @@ import { getFactTableValidator } from "../../validators/openapi";
 
 export const getFactTable = createApiRequestHandler(getFactTableValidator)(
   async (req): Promise<GetFactTableResponse> => {
-    const factTable = await findFactTableById(
-      req.organization.id,
-      req.params.id
-    );
+    const factTable = await findFactTableById(req.context, req.params.id);
     if (!factTable) {
       throw new Error("Could not find factTable with that id");
     }

--- a/packages/back-end/src/api/fact-tables/getFactTableFilter.ts
+++ b/packages/back-end/src/api/fact-tables/getFactTableFilter.ts
@@ -10,10 +10,7 @@ export const getFactTableFilter = createApiRequestHandler(
   getFactTableFilterValidator
 )(
   async (req): Promise<GetFactTableFilterResponse> => {
-    const factTable = await getFactTable(
-      req.organization.id,
-      req.params.factTableId
-    );
+    const factTable = await getFactTable(req.context, req.params.factTableId);
     if (!factTable) {
       throw new Error("Could not find factTable with that id");
     }

--- a/packages/back-end/src/api/fact-tables/listFactTableFilters.ts
+++ b/packages/back-end/src/api/fact-tables/listFactTableFilters.ts
@@ -10,10 +10,7 @@ export const listFactTableFilters = createApiRequestHandler(
   listFactTableFiltersValidator
 )(
   async (req): Promise<ListFactTableFiltersResponse> => {
-    const factTable = await getFactTable(
-      req.organization.id,
-      req.params.factTableId
-    );
+    const factTable = await getFactTable(req.context, req.params.factTableId);
     if (!factTable) {
       throw new Error("Could not find factTable with that id");
     }

--- a/packages/back-end/src/api/fact-tables/listFactTables.ts
+++ b/packages/back-end/src/api/fact-tables/listFactTables.ts
@@ -9,9 +9,7 @@ import { listFactTablesValidator } from "../../validators/openapi";
 
 export const listFactTables = createApiRequestHandler(listFactTablesValidator)(
   async (req): Promise<ListFactTablesResponse> => {
-    const factTables = await getAllFactTablesForOrganization(
-      req.organization.id
-    );
+    const factTables = await getAllFactTablesForOrganization(req.context);
 
     let matches = factTables;
     if (req.query.projectId) {

--- a/packages/back-end/src/api/fact-tables/postFactTableFilter.ts
+++ b/packages/back-end/src/api/fact-tables/postFactTableFilter.ts
@@ -11,10 +11,7 @@ export const postFactTableFilter = createApiRequestHandler(
   postFactTableFilterValidator
 )(
   async (req): Promise<PostFactTableFilterResponse> => {
-    const factTable = await getFactTable(
-      req.organization.id,
-      req.params.factTableId
-    );
+    const factTable = await getFactTable(req.context, req.params.factTableId);
     if (!factTable) {
       throw new Error("Could not find factTable with that id");
     }

--- a/packages/back-end/src/api/fact-tables/updateFactTable.ts
+++ b/packages/back-end/src/api/fact-tables/updateFactTable.ts
@@ -16,7 +16,7 @@ export const updateFactTable = createApiRequestHandler(
   updateFactTableValidator
 )(
   async (req): Promise<UpdateFactTableResponse> => {
-    const factTable = await getFactTable(req.organization.id, req.params.id);
+    const factTable = await getFactTable(req.context, req.params.id);
     if (!factTable) {
       throw new Error("Could not find factTable with that id");
     }

--- a/packages/back-end/src/api/fact-tables/updateFactTableFilter.ts
+++ b/packages/back-end/src/api/fact-tables/updateFactTableFilter.ts
@@ -11,10 +11,7 @@ export const updateFactTableFilter = createApiRequestHandler(
   updateFactTableFilterValidator
 )(
   async (req): Promise<UpdateFactTableFilterResponse> => {
-    const factTable = await getFactTable(
-      req.organization.id,
-      req.params.factTableId
-    );
+    const factTable = await getFactTable(req.context, req.params.factTableId);
     if (!factTable) {
       throw new Error("Could not find factTable with that id");
     }

--- a/packages/back-end/src/api/metrics/deleteMetric.ts
+++ b/packages/back-end/src/api/metrics/deleteMetric.ts
@@ -5,11 +5,7 @@ import { DeleteMetricResponse } from "../../../types/openapi";
 
 export const deleteMetricHandler = createApiRequestHandler(getMetricValidator)(
   async (req): Promise<DeleteMetricResponse> => {
-    const metric = await getMetricById(
-      req.params.id,
-      req.organization.id,
-      false
-    );
+    const metric = await getMetricById(req.params.id, req.context, false);
 
     req.checkPermissions("createMetrics", metric?.projects ?? "");
 

--- a/packages/back-end/src/api/metrics/getMetric.ts
+++ b/packages/back-end/src/api/metrics/getMetric.ts
@@ -7,11 +7,7 @@ import { getMetricValidator } from "../../validators/openapi";
 
 export const getMetric = createApiRequestHandler(getMetricValidator)(
   async (req): Promise<GetMetricResponse> => {
-    const metric = await getMetricById(
-      req.params.id,
-      req.organization.id,
-      false
-    );
+    const metric = await getMetricById(req.params.id, req.context, false);
     if (!metric) {
       throw new Error("Could not find metric with that id");
     }

--- a/packages/back-end/src/api/metrics/listMetrics.ts
+++ b/packages/back-end/src/api/metrics/listMetrics.ts
@@ -11,7 +11,7 @@ import { listMetricsValidator } from "../../validators/openapi";
 
 export const listMetrics = createApiRequestHandler(listMetricsValidator)(
   async (req): Promise<ListMetricsResponse> => {
-    const metrics = await getMetricsByOrganization(req.organization.id);
+    const metrics = await getMetricsByOrganization(req.context);
 
     const datasources = await getDataSourcesByOrganization(req.organization.id);
 

--- a/packages/back-end/src/api/metrics/putMetric.ts
+++ b/packages/back-end/src/api/metrics/putMetric.ts
@@ -9,7 +9,7 @@ import {
 
 export const putMetric = createApiRequestHandler(putMetricValidator)(
   async (req): Promise<PutMetricResponse> => {
-    const metric = await getMetricById(req.params.id, req.organization.id);
+    const metric = await getMetricById(req.params.id, req.context);
 
     if (!metric) {
       throw new Error("Metric not found");
@@ -25,7 +25,7 @@ export const putMetric = createApiRequestHandler(putMetricValidator)(
 
     const updated = putMetricApiPayloadToMetricInterface(req.body);
 
-    await updateMetric(req.params.id, updated, req.organization.id);
+    await updateMetric(req.params.id, updated, req.context);
 
     return {
       updatedId: req.params.id,

--- a/packages/back-end/src/controllers/datasources.ts
+++ b/packages/back-end/src/controllers/datasources.ts
@@ -198,7 +198,7 @@ Revenue did not reach 95% significance, but the risk is so low it doesn't seem w
       user: res.locals.eventAudit,
     });
 
-    const metricMap = await getMetricMap(org.id);
+    const metricMap = await getMetricMap(context);
 
     await createManualSnapshot(
       experiment,
@@ -257,7 +257,8 @@ export async function deleteDataSource(
   req: AuthRequest<null, { id: string }>,
   res: Response
 ) {
-  const { org } = getContextFromReq(req);
+  const context = getContextFromReq(req);
+  const { org } = context;
   const { id } = req.params;
 
   const datasource = await getDataSourceById(id, org.id);
@@ -277,10 +278,7 @@ export async function deleteDataSource(
   }
 
   // Make sure there are no metrics
-  const metrics = await getMetricsByDatasource(
-    datasource.id,
-    datasource.organization
-  );
+  const metrics = await getMetricsByDatasource(datasource.id, context);
   if (metrics.length > 0) {
     throw new Error(
       "Error: Please delete all metrics tied to this datasource first."
@@ -729,10 +727,10 @@ export async function getDataSourceMetrics(
   req: AuthRequest<null, { id: string }>,
   res: Response
 ) {
-  const { org } = getContextFromReq(req);
+  const context = getContextFromReq(req);
   const { id } = req.params;
 
-  const metrics = await getMetricsByDatasource(id, org.id);
+  const metrics = await getMetricsByDatasource(id, context);
 
   res.status(200).json({
     status: 200,

--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -457,10 +457,7 @@ export async function postExperiments(
   // Validate that specified metrics exist and belong to the organization
   if (data.metrics && data.metrics.length) {
     for (let i = 0; i < data.metrics.length; i++) {
-      const metric = await getExperimentMetricById(
-        data.metrics[i],
-        data.organization
-      );
+      const metric = await getExperimentMetricById(data.metrics[i], context);
 
       if (metric) {
         // Make sure it is tied to the same datasource as the experiment
@@ -668,7 +665,7 @@ export async function postExperiment(
 
   if (data.metrics && data.metrics.length) {
     for (let i = 0; i < data.metrics.length; i++) {
-      const metric = await getExperimentMetricById(data.metrics[i], org.id);
+      const metric = await getExperimentMetricById(data.metrics[i], context);
 
       if (metric) {
         // Make sure it is tied to the same datasource as the experiment
@@ -1701,7 +1698,7 @@ export async function postSnapshot(
     ...(experiment.guardrails ?? []),
   ]);
   const allExperimentMetrics = await Promise.all(
-    allExperimentMetricIds.map((m) => getExperimentMetricById(m, org.id))
+    allExperimentMetricIds.map((m) => getExperimentMetricById(m, context))
   );
   const denominatorMetricIds = uniq<string>(
     allExperimentMetrics
@@ -1709,7 +1706,9 @@ export async function postSnapshot(
       .filter((d) => d && typeof d === "string") as string[]
   );
   const denominatorMetrics = (
-    await Promise.all(denominatorMetricIds.map((m) => getMetricById(m, org.id)))
+    await Promise.all(
+      denominatorMetricIds.map((m) => getMetricById(m, context))
+    )
   ).filter(Boolean) as MetricInterface[];
   const datasource = await getDataSourceById(experiment.datasource, org.id);
 
@@ -1750,7 +1749,7 @@ export async function postSnapshot(
     dimension
   );
 
-  const metricMap = await getMetricMap(org.id);
+  const metricMap = await getMetricMap(context);
   const factTableMap = await getFactTableMap(org.id);
 
   // Manual snapshot
@@ -1892,7 +1891,7 @@ export async function postSnapshotAnalysis(
     await updateSnapshot(org.id, id, { settings: snapshot.settings });
   }
 
-  const metricMap = await getMetricMap(org.id);
+  const metricMap = await getMetricMap(context);
 
   try {
     await createSnapshotAnalysis({

--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -1750,7 +1750,7 @@ export async function postSnapshot(
   );
 
   const metricMap = await getMetricMap(context);
-  const factTableMap = await getFactTableMap(org.id);
+  const factTableMap = await getFactTableMap(context);
 
   // Manual snapshot
   if (!experiment.datasource) {

--- a/packages/back-end/src/controllers/ideas.ts
+++ b/packages/back-end/src/controllers/ideas.ts
@@ -44,6 +44,7 @@ export async function getEstimatedImpact(
 ) {
   req.checkPermissions("createIdeas", "");
 
+  const context = getContextFromReq(req);
   const { metric, segment, ideaId } = req.body;
 
   const idea = await getIdeaById(ideaId || "");
@@ -52,7 +53,7 @@ export async function getEstimatedImpact(
 
   const { org } = getContextFromReq(req);
   const estimate = await getImpactEstimate(
-    org.id,
+    context,
     metric,
     org.settings?.metricAnalysisDays || 30,
     segment

--- a/packages/back-end/src/controllers/metrics.ts
+++ b/packages/back-end/src/controllers/metrics.ts
@@ -83,10 +83,9 @@ export async function deleteMetric(
   req.checkPermissions("createAnalyses", "");
 
   const context = getContextFromReq(req);
-  const { org } = context;
   const { id } = req.params;
 
-  const metric = await getMetricById(id, org.id);
+  const metric = await getMetricById(id, context);
 
   if (!metric) {
     res.status(403).json({
@@ -119,8 +118,8 @@ export async function deleteMetric(
 }
 
 export async function getMetrics(req: AuthRequest, res: Response) {
-  const { org } = getContextFromReq(req);
-  const metrics = await getMetricsByOrganization(org.id);
+  const context = getContextFromReq(req);
+  const metrics = await getMetricsByOrganization(context);
   res.status(200).json({
     status: 200,
     metrics,
@@ -134,7 +133,7 @@ export async function getMetricUsage(
   const { id } = req.params;
   const context = getContextFromReq(req);
   const { org } = context;
-  const metric = await getMetricById(id, org.id);
+  const metric = await getMetricById(id, context);
 
   if (!metric) {
     res.status(403).json({
@@ -180,9 +179,10 @@ export async function cancelMetricAnalysis(
   req: AuthRequest<null, { id: string }>,
   res: Response
 ) {
-  const { org } = getContextFromReq(req);
+  const context = getContextFromReq(req);
+  const { org } = context;
   const { id } = req.params;
-  const metric = await getMetricById(id, org.id, true);
+  const metric = await getMetricById(id, context, true);
   if (!metric) {
     throw new Error("Could not cancel query");
   }
@@ -208,10 +208,11 @@ export async function postMetricAnalysis(
   req: AuthRequest<null, { id: string }>,
   res: Response
 ) {
-  const { org } = getContextFromReq(req);
+  const context = getContextFromReq(req);
+  const { org } = context;
   const { id } = req.params;
 
-  const metric = await getMetricById(id, org.id, true);
+  const metric = await getMetricById(id, context, true);
 
   if (!metric) {
     return res.status(404).json({
@@ -255,10 +256,9 @@ export async function getMetric(
   res: Response
 ) {
   const context = getContextFromReq(req);
-  const { org } = context;
   const { id } = req.params;
 
-  const metric = await getMetricById(id, org.id, true);
+  const metric = await getMetricById(id, context, true);
 
   if (!metric) {
     return res.status(404).json({
@@ -280,7 +280,8 @@ export async function getMetricsFromTrackedEvents(
   req: AuthRequest<{ schema: string }, { datasourceId: string }>,
   res: Response
 ) {
-  const { org } = getContextFromReq(req);
+  const context = getContextFromReq(req);
+  const { org } = context;
   const { schema } = req.body;
   const { datasourceId } = req.params;
 
@@ -311,7 +312,7 @@ export async function getMetricsFromTrackedEvents(
 
     const existingMetrics = await getMetricsByDatasource(
       dataSourceObj.id,
-      org.id
+      context
     );
 
     const trackedEvents: TrackedEventData[] = await integration.getEventsTrackedByDatasource(
@@ -513,9 +514,9 @@ export async function putMetric(
   req: AuthRequest<Partial<MetricInterface>, { id: string }>,
   res: Response
 ) {
-  const { org } = getContextFromReq(req);
+  const context = getContextFromReq(req);
   const { id } = req.params;
-  const metric = await getMetricById(id, org.id);
+  const metric = await getMetricById(id, context);
   if (!metric) {
     throw new Error("Could not find metric");
   }
@@ -537,7 +538,7 @@ export async function putMetric(
     req.checkPermissions("createMetrics", updates.projects);
   }
 
-  await updateMetric(metric.id, updates, org.id);
+  await updateMetric(metric.id, updates, context);
 
   res.status(200).json({
     status: 200,

--- a/packages/back-end/src/controllers/reports.ts
+++ b/packages/back-end/src/controllers/reports.ts
@@ -218,7 +218,7 @@ export async function refreshReport(
       ? !!report.args?.regressionAdjustmentEnabled
       : false;
 
-  const metricMap = await getMetricMap(org.id);
+  const metricMap = await getMetricMap(context);
   const factTableMap = await getFactTableMap(org.id);
 
   const integration = await getIntegrationFromDatasourceId(
@@ -298,7 +298,7 @@ export async function putReport(
     ...updates,
   };
   if (needsRun) {
-    const metricMap = await getMetricMap(org.id);
+    const metricMap = await getMetricMap(context);
     const factTableMap = await getFactTableMap(org.id);
 
     const integration = await getIntegrationFromDatasourceId(
@@ -353,10 +353,10 @@ export async function postNotebook(
   req: AuthRequest<null, { id: string }>,
   res: Response
 ) {
-  const { org } = getContextFromReq(req);
+  const context = getContextFromReq(req);
   const { id } = req.params;
 
-  const notebook = await generateReportNotebook(id, org.id);
+  const notebook = await generateReportNotebook(id, context);
 
   res.status(200).json({
     status: 200,

--- a/packages/back-end/src/controllers/reports.ts
+++ b/packages/back-end/src/controllers/reports.ts
@@ -219,7 +219,7 @@ export async function refreshReport(
       : false;
 
   const metricMap = await getMetricMap(context);
-  const factTableMap = await getFactTableMap(org.id);
+  const factTableMap = await getFactTableMap(context);
 
   const integration = await getIntegrationFromDatasourceId(
     org.id,
@@ -299,7 +299,7 @@ export async function putReport(
   };
   if (needsRun) {
     const metricMap = await getMetricMap(context);
-    const factTableMap = await getFactTableMap(org.id);
+    const factTableMap = await getFactTableMap(context);
 
     const integration = await getIntegrationFromDatasourceId(
       org.id,

--- a/packages/back-end/src/jobs/expireOldQueries.ts
+++ b/packages/back-end/src/jobs/expireOldQueries.ts
@@ -15,6 +15,7 @@ import {
 import { getStaleQueries } from "../models/QueryModel";
 import { findReportsByQueryId, updateReport } from "../models/ReportModel";
 import { logger } from "../util/logger";
+import { getContextForAgendaJobByOrgId } from "../services/organizations";
 
 const JOB_NAME = "expireOldQueries";
 
@@ -68,6 +69,7 @@ export default async function (agenda: Agenda) {
     );
     for (let i = 0; i < metrics.length; i++) {
       const metric = metrics[i];
+      const context = await getContextForAgendaJobByOrgId(metric.organization);
       logger.info("Updating status of metric " + metric.id);
       updateQueryStatus(metric.queries, queryIds);
       await updateMetric(
@@ -77,7 +79,7 @@ export default async function (agenda: Agenda) {
           analysisError:
             "Queries were interupted. Please try re-running the analysis.",
         },
-        metric.organization
+        context
       );
     }
 

--- a/packages/back-end/src/jobs/refreshFactTableColumns.ts
+++ b/packages/back-end/src/jobs/refreshFactTableColumns.ts
@@ -10,6 +10,7 @@ import {
 import { determineColumnTypes } from "../util/sql";
 import { getSourceIntegrationObject } from "../services/datasource";
 import { DataSourceInterface } from "../../types/datasource";
+import { getContextForAgendaJobByOrgId } from "../services/organizations";
 
 const JOB_NAME = "refreshFactTableColumns";
 type RefreshFactTableColumnsJob = Job<{
@@ -92,7 +93,9 @@ export default function (ag: Agenda) {
 
     if (!factTableId || !organization) return;
 
-    const factTable = await getFactTable(organization, factTableId);
+    const context = await getContextForAgendaJobByOrgId(organization);
+
+    const factTable = await getFactTable(context, factTableId);
     if (!factTable) return;
 
     const datasource = await getDataSourceById(

--- a/packages/back-end/src/jobs/updateExperimentResults.ts
+++ b/packages/back-end/src/jobs/updateExperimentResults.ts
@@ -161,7 +161,7 @@ async function updateSingleExperiment(job: UpdateSingleExpJob) {
     );
 
     const metricMap = await getMetricMap(context);
-    const factTableMap = await getFactTableMap(organization.id);
+    const factTableMap = await getFactTableMap(context);
 
     const queryRunner = await createSnapshot({
       experiment,

--- a/packages/back-end/src/models/ImpactEstimateModel.ts
+++ b/packages/back-end/src/models/ImpactEstimateModel.ts
@@ -6,6 +6,8 @@ import { getSourceIntegrationObject } from "../services/datasource";
 import { SegmentInterface } from "../../types/segment";
 import { DEFAULT_CONVERSION_WINDOW_HOURS } from "../util/secrets";
 import { processMetricValueQueryResponse } from "../queryRunners/MetricAnalysisQueryRunner";
+import { ApiReqContext } from "../../types/api";
+import { ReqContext } from "../../types/organization";
 import { findSegmentById } from "./SegmentModel";
 import { getDataSourceById } from "./DataSourceModel";
 
@@ -42,12 +44,12 @@ export async function createImpactEstimate(
 }
 
 export async function getImpactEstimate(
-  organization: string,
+  context: ReqContext | ApiReqContext,
   metric: string,
   numDays: number,
   segment?: string
 ): Promise<ImpactEstimateDocument | null> {
-  const metricObj = await getMetricById(metric, organization);
+  const metricObj = await getMetricById(metric, context);
   if (!metricObj) {
     throw new Error("Metric not found");
   }
@@ -58,7 +60,7 @@ export async function getImpactEstimate(
 
   const datasource = await getDataSourceById(
     metricObj.datasource,
-    organization
+    context.org.id
   );
   if (!datasource) {
     throw new Error("Datasource not found");
@@ -66,7 +68,7 @@ export async function getImpactEstimate(
 
   let segmentObj: SegmentInterface | null = null;
   if (segment) {
-    segmentObj = await findSegmentById(segment, organization);
+    segmentObj = await findSegmentById(segment, context.org.id);
   }
 
   if (segmentObj?.datasource !== metricObj.datasource) {
@@ -111,7 +113,7 @@ export async function getImpactEstimate(
   const conversionsPerDay = value.count / daysWithData;
 
   return createImpactEstimate({
-    organization,
+    organization: context.org.id,
     metric,
     segment: segment || undefined,
     conversionsPerDay: conversionsPerDay,

--- a/packages/back-end/src/models/MetricModel.ts
+++ b/packages/back-end/src/models/MetricModel.ts
@@ -320,7 +320,6 @@ export async function getMetricsByIds(
   );
 }
 
-//TODO: Pickup here
 export async function findRunningMetricsByQueryId(
   orgIds: string[],
   queryIds: string[]
@@ -421,7 +420,6 @@ export async function updateMetric(
       throw new Error("Cannot update. Metrics managed by config.yml");
     }
 
-    //TODO: Should we move the getMetricById call above this update?
     await MetricModel.updateOne(
       { id, organization: context.org.id },
       {

--- a/packages/back-end/src/queryRunners/MetricAnalysisQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/MetricAnalysisQueryRunner.ts
@@ -8,6 +8,7 @@ import {
   MetricValueResult,
 } from "../types/Integration";
 import { meanVarianceFromSums } from "../util/stats";
+import { getContextForAgendaJobByOrgId } from "../services/organizations";
 import { QueryRunner, QueryMap } from "./QueryRunner";
 
 export class MetricAnalysisQueryRunner extends QueryRunner<
@@ -73,11 +74,11 @@ export class MetricAnalysisQueryRunner extends QueryRunner<
     };
   }
   async getLatestModel(): Promise<MetricInterface> {
-    const model = await getMetricById(
-      this.model.id,
-      this.model.organization,
-      true
+    //TODO: Double check this logic
+    const context = await getContextForAgendaJobByOrgId(
+      this.model.organization
     );
+    const model = await getMetricById(this.model.id, context, true);
     if (!model) throw new Error("Could not find metric");
     return model;
   }
@@ -93,6 +94,10 @@ export class MetricAnalysisQueryRunner extends QueryRunner<
     result?: MetricAnalysis | undefined;
     error?: string | undefined;
   }): Promise<MetricInterface> {
+    //TODO: Double check this logic
+    const context = await getContextForAgendaJobByOrgId(
+      this.model.organization
+    );
     const updates: Partial<MetricInterface> = {
       queries,
       ...(runStarted ? { runStarted } : {}),
@@ -100,7 +105,7 @@ export class MetricAnalysisQueryRunner extends QueryRunner<
       analysisError: result ? "" : error,
     };
 
-    await updateMetric(this.model.id, updates, this.model.organization);
+    await updateMetric(this.model.id, updates, context);
 
     return {
       ...this.model,

--- a/packages/back-end/src/routers/demo-datasource-project/demo-datasource-project.controller.ts
+++ b/packages/back-end/src/routers/demo-datasource-project/demo-datasource-project.controller.ts
@@ -386,7 +386,7 @@ spacing and headings.`,
         org.settings?.pValueThreshold ?? DEFAULT_P_VALUE_THRESHOLD,
     };
 
-    const metricMap = await getMetricMap(org.id);
+    const metricMap = await getMetricMap(context);
     const factTableMap = await getFactTableMap(org.id);
 
     await createSnapshot({

--- a/packages/back-end/src/routers/demo-datasource-project/demo-datasource-project.controller.ts
+++ b/packages/back-end/src/routers/demo-datasource-project/demo-datasource-project.controller.ts
@@ -387,7 +387,7 @@ spacing and headings.`,
     };
 
     const metricMap = await getMetricMap(context);
-    const factTableMap = await getFactTableMap(org.id);
+    const factTableMap = await getFactTableMap(context);
 
     await createSnapshot({
       experiment: createdExperiment,

--- a/packages/back-end/src/routers/fact-table/fact-table.controller.ts
+++ b/packages/back-end/src/routers/fact-table/fact-table.controller.ts
@@ -321,9 +321,9 @@ export const getFactMetrics = async (
   req: AuthRequest,
   res: Response<{ status: 200; factMetrics: FactMetricInterface[] }>
 ) => {
-  const { org } = getContextFromReq(req);
+  const context = getContextFromReq(req);
 
-  const factMetrics = await getAllFactMetricsForOrganization(org.id);
+  const factMetrics = await getAllFactMetricsForOrganization(context);
 
   res.status(200).json({
     status: 200,

--- a/packages/back-end/src/routers/fact-table/fact-table.controller.ts
+++ b/packages/back-end/src/routers/fact-table/fact-table.controller.ts
@@ -42,9 +42,9 @@ export const getFactTables = async (
   req: AuthRequest,
   res: Response<{ status: 200; factTables: FactTableInterface[] }>
 ) => {
-  const { org } = getContextFromReq(req);
+  const context = getContextFromReq(req);
 
-  const factTables = await getAllFactTablesForOrganization(org.id);
+  const factTables = await getAllFactTablesForOrganization(context);
 
   res.status(200).json({
     status: 200,
@@ -127,9 +127,10 @@ export const putFactTable = async (
   res: Response<{ status: 200 }>
 ) => {
   const data = req.body;
-  const { org } = getContextFromReq(req);
+  const context = getContextFromReq(req);
+  const { org } = context;
 
-  const factTable = await getFactTable(org.id, req.params.id);
+  const factTable = await getFactTable(context, req.params.id);
   if (!factTable) {
     throw new Error("Could not find fact table with that id");
   }
@@ -170,9 +171,9 @@ export const deleteFactTable = async (
   req: AuthRequest<null, { id: string }>,
   res: Response<{ status: 200 }>
 ) => {
-  const { org } = getContextFromReq(req);
+  const context = getContextFromReq(req);
 
-  const factTable = await getFactTable(org.id, req.params.id);
+  const factTable = await getFactTable(context, req.params.id);
   if (!factTable) {
     throw new Error("Could not find fact table with that id");
   }
@@ -190,9 +191,9 @@ export const putColumn = async (
   res: Response<{ status: 200 }>
 ) => {
   const data = req.body;
-  const { org } = getContextFromReq(req);
+  const context = getContextFromReq(req);
 
-  const factTable = await getFactTable(org.id, req.params.id);
+  const factTable = await getFactTable(context, req.params.id);
   if (!factTable) {
     throw new Error("Could not find fact table with that id");
   }
@@ -214,9 +215,10 @@ export const postFactFilterTest = async (
   }>
 ) => {
   const data = req.body;
-  const { org } = getContextFromReq(req);
+  const context = getContextFromReq(req);
+  const { org } = context;
 
-  const factTable = await getFactTable(org.id, req.params.id);
+  const factTable = await getFactTable(context, req.params.id);
   if (!factTable) {
     throw new Error("Could not find fact table with that id");
   }
@@ -242,9 +244,10 @@ export const postFactFilter = async (
   res: Response<{ status: 200; filterId: string }>
 ) => {
   const data = req.body;
-  const { org } = getContextFromReq(req);
+  const context = getContextFromReq(req);
+  const { org } = context;
 
-  const factTable = await getFactTable(org.id, req.params.id);
+  const factTable = await getFactTable(context, req.params.id);
   if (!factTable) {
     throw new Error("Could not find fact table with that id");
   }
@@ -270,9 +273,10 @@ export const putFactFilter = async (
   res: Response<{ status: 200 }>
 ) => {
   const data = req.body;
-  const { org } = getContextFromReq(req);
+  const context = getContextFromReq(req);
+  const { org } = context;
 
-  const factTable = await getFactTable(org.id, req.params.id);
+  const factTable = await getFactTable(context, req.params.id);
   if (!factTable) {
     throw new Error("Could not find fact table with that id");
   }
@@ -302,9 +306,9 @@ export const deleteFactFilter = async (
   req: AuthRequest<null, { id: string; filterId: string }>,
   res: Response<{ status: 200 }>
 ) => {
-  const { org } = getContextFromReq(req);
+  const context = getContextFromReq(req);
 
-  const factTable = await getFactTable(org.id, req.params.id);
+  const factTable = await getFactTable(context, req.params.id);
   if (!factTable) {
     throw new Error("Could not find filter table with that id");
   }

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -136,7 +136,7 @@ export async function getDefinitions(req: AuthRequest, res: Response) {
     factTables,
     factMetrics,
   ] = await Promise.all([
-    getMetricsByOrganization(orgId),
+    getMetricsByOrganization(context),
     getDataSourcesByOrganization(orgId),
     findDimensionsByOrganization(orgId),
     findSegmentsByOrganization(orgId),
@@ -144,7 +144,7 @@ export async function getDefinitions(req: AuthRequest, res: Response) {
     getAllSavedGroups(orgId),
     findAllProjectsByOrganization(context),
     getAllFactTablesForOrganization(orgId),
-    getAllFactMetricsForOrganization(orgId),
+    getAllFactMetricsForOrganization(context),
   ]);
 
   return res.status(200).json({
@@ -1694,7 +1694,7 @@ export async function postImportConfig(
 ) {
   req.checkPermissions("organizationSettings");
 
-  const { org } = getContextFromReq(req);
+  const context = getContextFromReq(req);
   const { contents } = req.body;
 
   const config: ConfigFile = JSON.parse(contents);
@@ -1702,7 +1702,7 @@ export async function postImportConfig(
     throw new Error("Failed to parse config.yml file contents.");
   }
 
-  await importConfig(config, org);
+  await importConfig(config, context);
 
   res.status(200).json({
     status: 200,

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -143,7 +143,7 @@ export async function getDefinitions(req: AuthRequest, res: Response) {
     getAllTags(orgId),
     getAllSavedGroups(orgId),
     findAllProjectsByOrganization(context),
-    getAllFactTablesForOrganization(orgId),
+    getAllFactTablesForOrganization(context),
     getAllFactMetricsForOrganization(context),
   ]);
 

--- a/packages/back-end/src/routers/segment/segment.controller.ts
+++ b/packages/back-end/src/routers/segment/segment.controller.ts
@@ -101,7 +101,7 @@ export const getSegmentUsage = async (
   const ideas = await getIdeasByQuery(query);
 
   // metricSchema
-  const metrics = await getMetricsUsingSegment(id, org.id);
+  const metrics = await getMetricsUsingSegment(id, context);
 
   // experiments:
   const experiments = await getExperimentsUsingSegment(id, context);
@@ -293,7 +293,7 @@ export const deleteSegment = async (
   }
 
   // metrics
-  const metrics = await getMetricsUsingSegment(id, org.id);
+  const metrics = await getMetricsUsingSegment(id, context);
   if (metrics.length > 0) {
     // as update metric query will fail if they are using a config file,
     // we want to allow for deleting if there are no metrics with this segment.

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -131,12 +131,12 @@ export async function createMetric(data: Partial<MetricInterface>) {
 
 export async function getExperimentMetricById(
   metricId: string,
-  orgId: string
+  context: ReqContext | ApiReqContext
 ): Promise<ExperimentMetricInterface | null> {
   if (isFactMetricId(metricId)) {
-    return getFactMetric(orgId, metricId);
+    return getFactMetric(context.org.id, metricId);
   }
-  return getMetricById(metricId, orgId);
+  return getMetricById(metricId, context);
 }
 
 export async function refreshMetric(
@@ -1825,7 +1825,7 @@ export function updateExperimentApiPayloadToInterface(
 
 export async function getRegressionAdjustmentInfo(
   experiment: ExperimentInterface,
-  organization: OrganizationInterface
+  context: ReqContext | ApiReqContext
 ): Promise<{
   regressionAdjustmentEnabled: boolean;
   metricRegressionAdjustmentStatuses: MetricRegressionAdjustmentStatus[];
@@ -1837,7 +1837,7 @@ export async function getRegressionAdjustmentInfo(
     return { regressionAdjustmentEnabled, metricRegressionAdjustmentStatuses };
   }
 
-  const metricMap = await getMetricMap(organization.id);
+  const metricMap = await getMetricMap(context);
 
   const allExperimentMetricIds = uniq([
     ...experiment.metrics,
@@ -1864,7 +1864,7 @@ export async function getRegressionAdjustmentInfo(
       experimentRegressionAdjustmentEnabled:
         experiment.regressionAdjustmentEnabled ??
         DEFAULT_REGRESSION_ADJUSTMENT_ENABLED,
-      organizationSettings: organization.settings,
+      organizationSettings: context.org.settings,
       metricOverrides: experiment.metricOverrides,
     });
     if (metricRegressionAdjustmentStatus.regressionAdjustmentEnabled) {

--- a/packages/back-end/src/services/notebook.ts
+++ b/packages/back-end/src/services/notebook.ts
@@ -45,15 +45,15 @@ async function getQueryData(
 
 export async function generateReportNotebook(
   reportId: string,
-  organization: string
+  context: ReqContext
 ): Promise<string> {
-  const report = await getReportById(organization, reportId);
+  const report = await getReportById(context.org.id, reportId);
   if (!report) {
     throw new Error("Could not find report");
   }
 
   return generateNotebook(
-    organization,
+    context,
     report.queries,
     report.args,
     `/report/${report.id}`,
@@ -90,7 +90,7 @@ export async function generateExperimentNotebook(
   }
 
   return generateNotebook(
-    context.org.id,
+    context,
     snapshot.queries,
     reportArgsFromSnapshot(experiment, snapshot, analysis.settings),
     `/experiment/${experiment.id}`,
@@ -100,7 +100,7 @@ export async function generateExperimentNotebook(
 }
 
 export async function generateNotebook(
-  organization: string,
+  context: ReqContext,
   queryPointers: Queries,
   args: ExperimentReportArgs,
   url: string,
@@ -108,7 +108,7 @@ export async function generateNotebook(
   description: string
 ) {
   // Get datasource
-  const datasource = await getDataSourceById(args.datasource, organization);
+  const datasource = await getDataSourceById(args.datasource, context.org.id);
   if (!datasource) {
     throw new Error("Cannot find datasource");
   }
@@ -119,10 +119,10 @@ export async function generateNotebook(
   }
 
   // Get metrics
-  const metricMap = await getMetricMap(organization);
+  const metricMap = await getMetricMap(context);
 
   // Get queries
-  const queries = await getQueryData(queryPointers, organization);
+  const queries = await getQueryData(queryPointers, context.org.id);
 
   // use min query run date as end date if missing (legacy reports)
   let createdAt = new Date();

--- a/packages/front-end/components/ProjectBadges.tsx
+++ b/packages/front-end/components/ProjectBadges.tsx
@@ -1,6 +1,7 @@
 import clsx from "clsx";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import Badge from "@/components/Badge";
+import Tooltip from "./Tooltip/Tooltip";
 
 export interface Props {
   projectIds?: string[];
@@ -44,16 +45,20 @@ export default function ProjectBadges({
   return (
     <>
       {filteredProjects.map((p) => {
-        if (!p?.name) return;
         return (
-          <Badge
-            content={p.name}
-            key={p.name}
-            className={clsx(
-              project === p.id ? "badge-primary bg-purple" : "badge-gray",
-              className
-            )}
-          />
+          <Tooltip
+            shouldDisplay={!p?.name ? true : false}
+            body="Unknown Projects are projects that have been deleted or projects you do not have access to."
+            key={p?.name || `Unknown Project ${p?.id}`}
+          >
+            <Badge
+              content={p?.name || "Unknown Project"}
+              className={clsx(
+                project === p?.id ? "badge-primary bg-purple" : "badge-gray",
+                className
+              )}
+            />
+          </Tooltip>
         );
       })}
     </>


### PR DESCRIPTION
### Features and Changes

This PR updates Metrics and Fact Tables to consume the new backend `context` object, as well as the `hasReadAccess` filter method in order to filter metrics and fact tables by the user's read access level.

### Testing
Metrics

- [ ] Log in as an admin user and navigate to the `/metrics` page and ensure all metrics for an organization are returned and accessible
- [ ] Now, log in as a user who's global role is `noaccess` but the user has `experimenter` permissions for a single project and ensure that when you land on the `/metrics` route, only the metrics associated with that project are visible.
- [ ] Now, long in as a user who's global access gives readaccess, but they have a `noaccess` role for a single project. Ensure that all metrics except those associated with the project the user has the `noaccess` role are visible. In the event that a metric is a part of multiple projects, one of which is the project they have `noaccess` to, they should be able to see the metric, but the project tags that the user sees should have an `Unknown Project` tag for the project they have no access to.
- [ ] Ensure that if a metric is associated with a project they don't have access to (and it's not associated with any projects they do have access to) the user is unable to access the `metric/mid` page.

Fact Tables

- [ ] Log in as an admin user and navigate to the `/facttables` page and ensure all fact tables for an organization are returned and accessible
- [ ] Now, log in as a user who's global role is `noaccess` but the user has `experimenter` permissions for a single project and ensure that when you land on the `/facttables` route, only the fact tables associated with that project are visible.
- [ ] Now, long in as a user who's global access gives readaccess, but they have a `noaccess` role for a single project. Ensure that all fact tables except those associated with the project the user has the `noaccess` role are visible. In the event that a fact table is a part of multiple projects, one of which is the project they have `noaccess` to, they should be able to see the fact table, but the project tags that the user sees should have an `Unknown Project` tag for the project they have no access to.
- [ ] Ensure that if a fact table is associated with a project they don't have access to (and it's not associated with any projects they do have access to) the user is unable to access the `facttables/ftid` page.
