### PR TITLE
Handle US Bank payment option

### DIFF
--- a/packages/back-end/src/controllers/stripe.ts
+++ b/packages/back-end/src/controllers/stripe.ts
@@ -68,7 +68,7 @@ export async function postNewSubscription(
 
   const payload: Stripe.Checkout.SessionCreateParams = {
     mode: "subscription",
-    payment_method_types: ["card"],
+    payment_method_types: ["card", "us_bank_account"],
     customer: stripeCustomerId,
     discounts: [
       {

--- a/packages/back-end/src/services/stripe.ts
+++ b/packages/back-end/src/services/stripe.ts
@@ -49,7 +49,6 @@ export async function updateSubscriptionInDb(
   await stripe.paymentMethods
     .list({
       customer: org.stripeCustomerId,
-      type: "card",
     })
     .then((paymentMethodsResponse) => {
       hasPaymentMethod = paymentMethodsResponse.data.length > 0;


### PR DESCRIPTION
### Features and Changes

On our Stripe billing page we accept US bank accounts.  https://dashboard.stripe.com/settings/billing/invoice?tab=general
We have it selected to also accept Sepa direct debit and ACH direct debit but they don't show up.
On the checkout page we were only allowing credit cards.
On our /settings/billing page we warning people that they need to enter a payment option even when they had a bank payment option set up.

- Allows banks on the checkout page
- Shows the missing payment warning only when they have no payment option set, regardless of payment method.

### Testing

Set IS_CLOUD=true in .env.local for both front-end and back-end.
Set STRIPE_SECRET and STRIPE_PRICE to be the test secret and test price.
Start the server.
In mongo set "freeTrialDate" on the organization.
Click "Try Pro".
Click the button to buy.
See the bank option.
Pay by bank.
Click return to Growthbook
Go to http://localhost:3000/settings/billing and see that it says "You have a valid payment method on file. You will be billed automatically on this date."

