### PR TITLE
Fix bug: Empty metric name rendering as 'id' on front-end

### DIFF
--- a/packages/front-end/components/Experiment/MetricSelector.tsx
+++ b/packages/front-end/components/Experiment/MetricSelector.tsx
@@ -105,8 +105,8 @@ const MetricSelector: FC<
           label: m.name,
         };
       })}
-      formatOptionLabel={({ value }) => {
-        return <MetricName id={value} />;
+      formatOptionLabel={({ value, label }) => {
+        return value ? <MetricName id={value} /> : label;
       }}
     />
   );

--- a/packages/front-end/components/Experiment/MetricsSelector.tsx
+++ b/packages/front-end/components/Experiment/MetricsSelector.tsx
@@ -172,8 +172,8 @@ const MetricsSelector: FC<{
         })}
         placeholder="Select metrics..."
         autoFocus={autoFocus}
-        formatOptionLabel={({ value }) => {
-          return <MetricName id={value} />;
+        formatOptionLabel={({ value, label }) => {
+          return value ? <MetricName id={value} /> : label;
         }}
       />
       {Object.keys(tagCounts).length > 0 && (

--- a/packages/front-end/components/Metrics/MetricName.tsx
+++ b/packages/front-end/components/Metrics/MetricName.tsx
@@ -77,7 +77,7 @@ export default function MetricName({
   const { getExperimentMetricById } = useDefinitions();
   const metric = getExperimentMetricById(id);
 
-  if (!metric) return <>id</>;
+  if (!metric) return <>{id}</>;
 
   return (
     <>


### PR DESCRIPTION
### Features and Changes

Small typo causing empty metrics to render as `id` on the front-end instead of an empty string.