### PR TITLE
[bugfix] Fix health queries in clickhouse

### DIFF
--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -1267,22 +1267,26 @@ export default abstract class SqlIntegration
         FROM ${
           useUnitsTable ? `${params.unitsTableFullName}` : "__experimentUnits"
         }
-      )
-      -- One row per variation per dimension slice
-      ${[
-        "dim_exposure_date",
-        ...experimentDimensions.map((d) => `dim_exp_${d.id}`),
-        ...(activationMetric ? ["dim_activated"] : []),
-      ]
-        .map((d) =>
-          this.getUnitCountCTE(
-            d,
-            activationMetric && d !== "dim_activated"
-              ? "WHERE dim_activated = 'Activated'"
-              : ""
+      ),
+      __unitsByDimension AS (
+        -- One row per variation per dimension slice
+        ${[
+          "dim_exposure_date",
+          ...experimentDimensions.map((d) => `dim_exp_${d.id}`),
+          ...(activationMetric ? ["dim_activated"] : []),
+        ]
+          .map((d) =>
+            this.getUnitCountCTE(
+              d,
+              activationMetric && d !== "dim_activated"
+                ? "WHERE dim_activated = 'Activated'"
+                : ""
+            )
           )
-        )
-        .join("\nUNION ALL\n")}
+          .join("\nUNION ALL\n")}
+      )
+      SELECT *
+      FROM __unitsByDimension
       LIMIT ${MAX_ROWS_UNIT_AGGREGATE_QUERY}
     `,
       this.getFormatDialect()
@@ -1291,7 +1295,7 @@ export default abstract class SqlIntegration
 
   getUnitCountCTE(dimensionColumn: string, whereClause?: string): string {
     return ` -- ${dimensionColumn}
-    (SELECT
+    SELECT
       variation AS variation
       , ${dimensionColumn} AS dimension_value
       , MAX(${this.castToString(`'${dimensionColumn}'`)}) AS dimension_name
@@ -1301,7 +1305,7 @@ export default abstract class SqlIntegration
     ${whereClause ?? ""}
     GROUP BY
       variation
-      , ${dimensionColumn})`;
+      , ${dimensionColumn}`;
   }
 
   getDimensionSlicesQuery(params: DimensionSlicesQueryParams): string {
@@ -1349,14 +1353,14 @@ export default abstract class SqlIntegration
       ),
       -- One row per dimension slice
       dim_values AS (
-        (SELECT
+        SELECT
           1 AS variation
           , ${this.castToString("'All'")} AS dimension_value
           , ${this.castToString("'All'")} AS dimension_name
           , COUNT(*) AS units
         FROM
           __distinctUnits
-          ) UNION ALL
+        UNION ALL
         ${params.dimensions
           .map((d) => this.getUnitCountCTE(`dim_exp_${d.id}`))
           .join("\nUNION ALL\n")}


### PR DESCRIPTION
ClickHouse did not enjoy the placement of the `LIMIT` command nor the parentheses after CTE statements that were in the health tab query.

This solves that by creating one additional CTE without parentheses that unions together all the dimension results, and then limiting the results of that CTE.

Closes #2063 

## Testing

New health query tested to be working for:
* ClickHouse (fixed)
* Postgres
* Snowflake
* BigQuery