### PR TITLE
Add configurable agenda env vars

### DIFF
--- a/packages/back-end/src/services/queueing.ts
+++ b/packages/back-end/src/services/queueing.ts
@@ -1,5 +1,12 @@
 import Agenda, { AgendaConfig } from "agenda";
 import mongoose from "mongoose";
+import {
+  AGENDA_DEFAULT_CONCURRENCY,
+  AGENDA_DEFAULT_LOCK_LIMIT,
+  AGENDA_LOCK_LIMIT,
+  AGENDA_MAX_CONCURRENCY,
+} from "../util/secrets";
+import { logger } from "../util/logger";
 
 let agendaInstance: Agenda;
 
@@ -8,8 +15,12 @@ export const getAgendaInstance = (): Agenda => {
     const config: AgendaConfig = {
       // @ts-expect-error - For some reason the Mongoose MongoDB instance does not match (missing 5 properties)
       mongo: mongoose.connection.db,
-      defaultLockLimit: 5,
+      defaultLockLimit: AGENDA_DEFAULT_LOCK_LIMIT,
+      lockLimit: AGENDA_LOCK_LIMIT,
+      defaultConcurrency: AGENDA_DEFAULT_CONCURRENCY,
+      maxConcurrency: AGENDA_MAX_CONCURRENCY,
     };
+    logger.debug(config, "Creating Agenda instance");
 
     agendaInstance = new Agenda(config);
   }

--- a/packages/back-end/src/util/secrets.ts
+++ b/packages/back-end/src/util/secrets.ts
@@ -6,6 +6,21 @@ import { stringToBoolean } from "shared/util";
 import { DEFAULT_METRIC_WINDOW_HOURS } from "shared/constants";
 import { z } from "zod";
 
+// Parses an environment variable as an integer (allowing 0), with a default value in case
+// it's not set or not a valid integer
+function parseEnvInt(
+  envVarValue: string | undefined,
+  defaultValue: number
+): number {
+  if (envVarValue !== undefined) {
+    const parsed = parseInt(envVarValue, 10);
+    if (!isNaN(parsed)) {
+      return parsed;
+    }
+  }
+  return defaultValue;
+}
+
 export const ENVIRONMENT = process.env.NODE_ENV;
 const prod = ENVIRONMENT === "production";
 
@@ -144,6 +159,23 @@ export const CACHE_CONTROL_STALE_WHILE_REVALIDATE =
   parseInt(process.env?.CACHE_CONTROL_STALE_WHILE_REVALIDATE || "") || 3600;
 export const CACHE_CONTROL_STALE_IF_ERROR =
   parseInt(process.env?.CACHE_CONTROL_STALE_IF_ERROR || "") || 36000;
+
+export const AGENDA_DEFAULT_LOCK_LIMIT = parseEnvInt(
+  process.env.AGENDA_DEFAULT_LOCK_LIMIT,
+  5
+);
+
+export const AGENDA_LOCK_LIMIT = parseEnvInt(process.env.AGENDA_LOCK_LIMIT, 5);
+
+export const AGENDA_DEFAULT_CONCURRENCY = parseEnvInt(
+  process.env.AGENDA_DEFAULT_CONCURRENCY,
+  5
+);
+
+export const AGENDA_MAX_CONCURRENCY = parseEnvInt(
+  process.env.AGENDA_MAX_CONCURRENCY,
+  20
+);
 
 // remote Eval Edge
 export const REMOTE_EVAL_EDGE_HOST = process.env.REMOTE_EVAL_EDGE_HOST;


### PR DESCRIPTION
### Context
We found that when a large number of concurrent refreshes were happening, the default agenda config could be a bottleneck for performance - e.g. we had more vCPUs/threads available, and more bigquery slots, but agenda was hitting it's `lockLimit` and `*concurrency` limits, stopping it from kicking off more jobs.

### Features and Changes
Adds environment variables to allow configuring the agenda job manager/runner:

`AGENDA_DEFAULT_LOCK_LIMIT`: [`defaultLockLimit`](https://github.com/agenda/agenda?tab=readme-ov-file#defaultconcurrencynumber)
`AGENDA_LOCK_LIMIT`: [`lockLimit`](https://github.com/agenda/agenda?tab=readme-ov-file#locklimitnumber)
`AGENDA_DEFAULT_CONCURRENCY`: [`defaultConcurrency`](https://github.com/agenda/agenda?tab=readme-ov-file#defaultconcurrencynumber)
`AGENDA_MAX_CONCURRENCY`: [`maxConcurrency`](https://github.com/agenda/agenda?tab=readme-ov-file#defaultconcurrencynumber)

Defaults for these have been set to match what was already present in GrowthBook's `AgendaConfig`, or the default set by agenda when not specified.

### Testing
Tested that setting none of these agenda variables causes defaults to be used, and validated that custom values can be set using the environment variables.