### PR TITLE
queryRunner & error logging improvements

### DIFF
--- a/packages/back-end/src/jobs/expireOldQueries.ts
+++ b/packages/back-end/src/jobs/expireOldQueries.ts
@@ -33,6 +33,8 @@ export default async function (agenda: Agenda) {
 
     if (queryIds.size > 0) {
       logger.info("Found " + queryIds.size + " stale queries");
+    } else {
+      logger.debug("Found no stale queries");
     }
 
     // Look for matching snapshots and update the status

--- a/packages/back-end/src/queryRunners/ExperimentResultsQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentResultsQueryRunner.ts
@@ -430,7 +430,8 @@ export class ExperimentResultsQueryRunner extends QueryRunner<
   }
   async getLatestModel(): Promise<ExperimentSnapshotInterface> {
     const obj = await findSnapshotById(this.model.organization, this.model.id);
-    if (!obj) throw new Error("Could not load snapshot model");
+    if (!obj)
+      throw new Error("Could not load snapshot model: " + this.model.id);
     return obj;
   }
   async updateModel({

--- a/packages/back-end/src/queryRunners/QueryRunner.ts
+++ b/packages/back-end/src/queryRunners/QueryRunner.ts
@@ -147,7 +147,7 @@ export abstract class QueryRunner<
           await this.startReadyQueries(queryMap);
         } catch (e) {
           logger.error(
-            e,
+            { err: e },
             "Error refreshing query statuses for runner of " + this.model.id
           );
         }
@@ -370,6 +370,7 @@ export abstract class QueryRunner<
       } catch (e) {
         error = "Error running analysis: " + e.message;
         logger.error(
+          { err: e },
           `Queries ${newStatus}, failed running analysis: ` + e.message
         );
       }

--- a/packages/back-end/src/queryRunners/QueryRunner.ts
+++ b/packages/back-end/src/queryRunners/QueryRunner.ts
@@ -180,7 +180,7 @@ export abstract class QueryRunner<
         result = await this.runAnalysis(queryMap);
         logger.debug(this.model.id + " runner: Ran analysis successfully");
       } catch (e) {
-        logger.debug(this.model.id + " runner: Error running analysis");
+        logger.error(this.model.id + " runner: Error running analysis");
         error = "Error running analysis: " + e.message;
       }
     } else if (queryStatus === "failed") {
@@ -369,7 +369,7 @@ export abstract class QueryRunner<
         logger.debug(`Queries ${newStatus}, ran analysis successfully`);
       } catch (e) {
         error = "Error running analysis: " + e.message;
-        logger.debug(
+        logger.error(
           `Queries ${newStatus}, failed running analysis: ` + e.message
         );
       }

--- a/packages/back-end/src/queryRunners/QueryRunner.ts
+++ b/packages/back-end/src/queryRunners/QueryRunner.ts
@@ -136,7 +136,13 @@ export abstract class QueryRunner<
       this.timer = setTimeout(async () => {
         this.timer = null;
         try {
-          logger.debug("Getting latest model");
+          logger.debug(
+            "Getting latest model for " +
+              typeof this +
+              " (" +
+              typeof this.model +
+              ")"
+          );
           this.model = await this.getLatestModel();
           const queryMap = await this.refreshQueryStatuses();
           await this.startReadyQueries(queryMap);
@@ -451,7 +457,7 @@ export abstract class QueryRunner<
     run(doc.query, setExternalId)
       .then(async ({ rows, statistics }) => {
         clearInterval(timer);
-        logger.debug("Query succeeded");
+        logger.debug("Query succeeded: " + doc.id);
         await updateQuery(doc, {
           finishedAt: new Date(),
           status: "succeeded",


### PR DESCRIPTION
### Features and Changes
We had a hard time debugging QueryRunner errors, and found in at least one place errors passed to the pino http logger needed to wrap the error in `{err: error}` to get it to actually get printed. Some of these might be a little verbose or redundant, hence setting them to `.debug` instead of `.info`.

### Testing
We've been running this on our prod instance for probably 6 weeks now, so we haven't seen any issues with it.