### PR TITLE
[bugfix] Pass difference type through to results graph

### DIFF
--- a/packages/front-end/components/Experiment/ExperimentDateGraph.tsx
+++ b/packages/front-end/components/Experiment/ExperimentDateGraph.tsx
@@ -33,11 +33,12 @@ export interface ExperimentDateGraphDataPoint {
   variations: DataPointVariation[];
 }
 export interface ExperimentDateGraphProps {
-  yaxis: "users" | "uplift";
+  yaxis: "users" | "effect";
   variationNames: string[];
   label: string;
   datapoints: ExperimentDateGraphDataPoint[];
-  tickFormat: (v: number) => string;
+  formatter: (value: number, options?: Intl.NumberFormatOptions) => string;
+  formatterOptions?: Intl.NumberFormatOptions;
   statsEngine?: StatsEngine;
   hasStats?: boolean;
 }
@@ -53,7 +54,7 @@ type TooltipData = {
   x: number;
   y: number[];
   d: ExperimentDateGraphDataPoint;
-  yaxis: "users" | "uplift";
+  yaxis: "users" | "effect";
 };
 
 const height = 220;
@@ -64,6 +65,8 @@ const getTooltipContents = (
   data: TooltipData,
   variationNames: string[],
   statsEngine: StatsEngine,
+  formatter: (value: number, options?: Intl.NumberFormatOptions) => string,
+  formatterOptions?: Intl.NumberFormatOptions,
   hasStats: boolean = true
 ) => {
   const { d, yaxis } = data;
@@ -71,7 +74,7 @@ const getTooltipContents = (
     <>
       <table
         className={`table-condensed ${styles.table} ${
-          yaxis !== "uplift" && "mt-1"
+          yaxis !== "effect" && "mt-1"
         }`}
       >
         <thead>
@@ -79,10 +82,10 @@ const getTooltipContents = (
             <td></td>
             <td>Users</td>
 
-            {yaxis === "uplift" && (
+            {yaxis === "effect" && (
               <>
                 <td>Value</td>
-                <td>Uplift</td>
+                <td>Change</td>
                 {hasStats && (
                   <>
                     <td>CI</td>
@@ -109,7 +112,7 @@ const getTooltipContents = (
                   {v}
                 </td>
                 {yaxis === "users" && <td>{d.variations[i].v_formatted}</td>}
-                {yaxis === "uplift" && (
+                {yaxis === "effect" && (
                   <>
                     <td>{d.variations[i].users}</td>
                     <td>{d.variations[i].v_formatted}</td>
@@ -117,7 +120,7 @@ const getTooltipContents = (
                       {i > 0 && (
                         <>
                           {((variation.up ?? 0) > 0 ? "+" : "") +
-                            percentFormatter.format(variation.up ?? 0)}
+                            formatter(variation.up ?? 0, formatterOptions)}
                         </>
                       )}
                     </td>
@@ -127,9 +130,15 @@ const getTooltipContents = (
                           {i > 0 && (
                             <>
                               [
-                              {percentFormatter.format(variation?.ci?.[0] ?? 0)}
+                              {formatter(
+                                variation?.ci?.[0] ?? 0,
+                                formatterOptions
+                              )}
                               ,{" "}
-                              {percentFormatter.format(variation?.ci?.[1] ?? 0)}
+                              {formatter(
+                                variation?.ci?.[1] ?? 0,
+                                formatterOptions
+                              )}
                               ]
                             </>
                           )}
@@ -166,7 +175,7 @@ const getTooltipData = (
   datapoints: ExperimentDateGraphDataPoint[],
   yScale: ScaleLinear<number, number, never>,
   xScale,
-  yaxis: "users" | "uplift"
+  yaxis: "users" | "effect"
 ): TooltipData => {
   const innerWidth =
     width - margin[1] - margin[3] + width / datapoints.length - 1;
@@ -183,11 +192,11 @@ const getTooltipData = (
   return { x, y, d, yaxis };
 };
 
-const getYVal = (variation: DataPointVariation, yaxis: "users" | "uplift") => {
+const getYVal = (variation: DataPointVariation, yaxis: "users" | "effect") => {
   switch (yaxis) {
     case "users":
       return variation.v;
-    case "uplift":
+    case "effect":
       return variation.up ?? 0;
     default:
       return variation.v;
@@ -199,7 +208,8 @@ const ExperimentDateGraph: FC<ExperimentDateGraphProps> = ({
   datapoints,
   variationNames,
   label,
-  tickFormat,
+  formatter,
+  formatterOptions,
   statsEngine = "bayesian",
   hasStats = true,
 }) => {
@@ -325,6 +335,8 @@ const ExperimentDateGraph: FC<ExperimentDateGraphProps> = ({
                   tooltipData,
                   variationNames,
                   statsEngine,
+                  formatter,
+                  formatterOptions,
                   hasStats
                 )}
               </TooltipWithBounds>
@@ -357,7 +369,7 @@ const ExperimentDateGraph: FC<ExperimentDateGraphProps> = ({
               {tooltipOpen && (
                 <>
                   {variationNames.map((v, i) => {
-                    if (yaxis === "uplift" && i === 0) {
+                    if (yaxis === "effect" && i === 0) {
                       return;
                     }
                     // Render a dot at the current x location for each variation
@@ -396,7 +408,7 @@ const ExperimentDateGraph: FC<ExperimentDateGraphProps> = ({
                 />
 
                 {variationNames.map((v, i) => {
-                  if (yaxis === "uplift" && i === 0) {
+                  if (yaxis === "effect" && i === 0) {
                     return <></>;
                   }
                   // Render a shaded area for error bars for each variation if defined
@@ -419,7 +431,7 @@ const ExperimentDateGraph: FC<ExperimentDateGraphProps> = ({
                 })}
 
                 {variationNames.map((v, i) => {
-                  if (yaxis === "uplift" && i === 0) {
+                  if (yaxis === "effect" && i === 0) {
                     return <></>;
                   }
                   // Render the actual line chart for each variation
@@ -453,7 +465,7 @@ const ExperimentDateGraph: FC<ExperimentDateGraphProps> = ({
                 <AxisLeft
                   scale={yScale}
                   numTicks={numYTicks}
-                  tickFormat={(v) => tickFormat(v as number)}
+                  tickFormat={(v) => formatter(v as number, formatterOptions)}
                   tickLabelProps={() => ({
                     fill: "var(--text-color-table)",
                     fontSize: 11,

--- a/packages/front-end/components/Experiment/ExperimentDateGraph.tsx
+++ b/packages/front-end/components/Experiment/ExperimentDateGraph.tsx
@@ -465,6 +465,7 @@ const ExperimentDateGraph: FC<ExperimentDateGraphProps> = ({
                 <AxisLeft
                   scale={yScale}
                   numTicks={numYTicks}
+                  labelOffset={50}
                   tickFormat={(v) => formatter(v as number, formatterOptions)}
                   tickLabelProps={() => ({
                     fill: "var(--text-color-table)",

--- a/packages/front-end/components/Experiment/Results.tsx
+++ b/packages/front-end/components/Experiment/Results.tsx
@@ -295,6 +295,7 @@ const Results: FC<{
           seriestype={snapshot.dimension ?? ""}
           variations={variations}
           statsEngine={analysis?.settings?.statsEngine || DEFAULT_STATS_ENGINE}
+          differenceType={analysis.settings?.differenceType}
         />
       ) : showBreakDownResults ? (
         <BreakDownResults

--- a/packages/front-end/components/HealthTab/TrafficCard.tsx
+++ b/packages/front-end/components/HealthTab/TrafficCard.tsx
@@ -10,6 +10,7 @@ import { useUser } from "@/services/UserContext";
 import { DEFAULT_SRM_THRESHOLD } from "@/pages/settings";
 import track from "@/services/track";
 import { formatTrafficSplit } from "@/services/utils";
+import { formatNumber } from "@/services/metrics";
 import ExperimentDateGraph, {
   ExperimentDateGraphDataPoint,
 } from "../Experiment/ExperimentDateGraph";
@@ -234,7 +235,7 @@ export default function TrafficCard({
             variationNames={variations.map((v) => v.name)}
             label="Users"
             datapoints={usersPerDate}
-            tickFormat={(v) => numberFormatter.format(v)}
+            formatter={formatNumber}
           />
         </div>
       )}


### PR DESCRIPTION
Previously you could properly get relative, absolute, or scaled impact numbers, but they would be rendered incorrectly in our date graphs.

This changes our experiment result graphs to properly know what difference type is being used and format the tooltips and axes appropriately.

Before (note the difference type here is Absolute):
<img width="1063" alt="Screenshot 2024-01-31 at 2 14 58 PM" src="https://github.com/growthbook/growthbook/assets/5298599/06ad2af7-6d6f-4fe7-b86b-442c0d3fecae">

After:
<img width="1077" alt="Screenshot 2024-01-31 at 2 14 31 PM" src="https://github.com/growthbook/growthbook/assets/5298599/a140c7d1-4cb8-47d0-bcda-17d75c0326a9">
