### PR TITLE
Add maxAge cache setting for JS SDK (default to 24 hours)

### DIFF
--- a/docs/docs/lib/js.mdx
+++ b/docs/docs/lib/js.mdx
@@ -220,7 +220,7 @@ configureCache({
   // Consider features stale after this much time (60 seconds default)
   staleTTL: 1000 * 60,
   // Cached features older than this will be ignored (24 hours default)
-  maxTTL: 1000 * 60 * 60 * 24,
+  maxAge: 1000 * 60 * 60 * 24,
   // For Remote Eval only - limit the number of cache entries (~1 entry per user)
   maxEntries: 10,
   // Set to `false` to disable SSE streaming

--- a/docs/docs/lib/js.mdx
+++ b/docs/docs/lib/js.mdx
@@ -203,6 +203,35 @@ const gb = new GrowthBook({
 });
 ```
 
+#### Customize the Cache Settings
+
+The JavaScript SDK has a built-in caching layer using a browser's localStorage by default. This localStorage implementation can be polyfilled for mobile or back-end use cases.
+
+There are a number of cache settings you can configure within GrowthBook. This must be done BEFORE creating a GrowthBook instance.
+
+Below are all of the default values. You can call `configureCache` with a subset of these fields and the rest will keep their default values.
+
+```ts
+import { configureCache } from "@growthbook/growthbook";
+
+configureCache({
+  // The localStorage key the cache will be stored under
+  cacheKey: "gbFeaturesCache",
+  // Consider features stale after this much time (60 seconds default)
+  staleTTL: 1000 * 60,
+  // Cached features older than this will be ignored (24 hours default)
+  maxTTL: 1000 * 60 * 60 * 24,
+  // For Remote Eval only - limit the number of cache entries (~1 entry per user)
+  maxEntries: 10,
+  // Set to `false` to disable SSE streaming
+  backgroundSync: true,
+  // When `false`, we add a `visibilitychange` listener to disable SSE when the page is idle
+  disableIdleStreams: false,
+  // Consider a page "idle" when it is hidden for this long (default 20 seconds)
+  idleStreamInterval: 20000,
+})
+```
+
 ### Custom Integration
 
 If you prefer to handle the network and caching logic yourself, you can instead pass in a features JSON object directly. For example, you might store features in Postgres and send it down to your front-end as part of your app's initial bootstrap API call.

--- a/packages/sdk-js/src/feature-repository.ts
+++ b/packages/sdk-js/src/feature-repository.ts
@@ -27,6 +27,8 @@ type ScopedChannel = {
 const cacheSettings: CacheSettings = {
   // Consider a fetch stale after 1 minute
   staleTTL: 1000 * 60,
+  // Max time to keep a fetch in cache (24 hours default)
+  maxTTL: 1000 * 60 * 60 * 24,
   cacheKey: "gbFeaturesCache",
   backgroundSync: true,
   maxEntries: 10,
@@ -195,9 +197,19 @@ async function fetchFeaturesWithCache(
   const key = getKey(instance);
   const cacheKey = getCacheKey(instance);
   const now = new Date();
+
+  const minStaleAt = new Date(
+    now.getTime() - cacheSettings.maxTTL + cacheSettings.staleTTL
+  );
+
   await initializeCache();
   const existing = cache.get(cacheKey);
-  if (existing && !skipCache && (allowStale || existing.staleAt > now)) {
+  if (
+    existing &&
+    !skipCache &&
+    (allowStale || existing.staleAt > now) &&
+    existing.staleAt > minStaleAt
+  ) {
     // Restore from cache whether SSE is supported
     if (existing.sse) supportsSSE.add(key);
 

--- a/packages/sdk-js/src/feature-repository.ts
+++ b/packages/sdk-js/src/feature-repository.ts
@@ -28,7 +28,7 @@ const cacheSettings: CacheSettings = {
   // Consider a fetch stale after 1 minute
   staleTTL: 1000 * 60,
   // Max time to keep a fetch in cache (24 hours default)
-  maxTTL: 1000 * 60 * 60 * 24,
+  maxAge: 1000 * 60 * 60 * 24,
   cacheKey: "gbFeaturesCache",
   backgroundSync: true,
   maxEntries: 10,
@@ -199,7 +199,7 @@ async function fetchFeaturesWithCache(
   const now = new Date();
 
   const minStaleAt = new Date(
-    now.getTime() - cacheSettings.maxTTL + cacheSettings.staleTTL
+    now.getTime() - cacheSettings.maxAge + cacheSettings.staleTTL
   );
 
   await initializeCache();

--- a/packages/sdk-js/src/types/growthbook.ts
+++ b/packages/sdk-js/src/types/growthbook.ts
@@ -297,7 +297,7 @@ export type CacheSettings = {
   backgroundSync: boolean;
   cacheKey: string;
   staleTTL: number;
-  maxTTL: number;
+  maxAge: number;
   maxEntries: number;
   disableIdleStreams: boolean;
   idleStreamInterval: number;

--- a/packages/sdk-js/src/types/growthbook.ts
+++ b/packages/sdk-js/src/types/growthbook.ts
@@ -297,6 +297,7 @@ export type CacheSettings = {
   backgroundSync: boolean;
   cacheKey: string;
   staleTTL: number;
+  maxTTL: number;
   maxEntries: number;
   disableIdleStreams: boolean;
   idleStreamInterval: number;

--- a/packages/sdk-js/test/feature-repo.test.ts
+++ b/packages/sdk-js/test/feature-repo.test.ts
@@ -25,7 +25,7 @@ setPolyfills({
 const localStorageCacheKey = "growthbook:cache:features";
 configureCache({
   staleTTL: 100,
-  maxTTL: 2000,
+  maxAge: 2000,
   cacheKey: localStorageCacheKey,
 });
 
@@ -509,7 +509,7 @@ describe("feature-repo", () => {
     cleanup();
   });
 
-  it("doesn't restore from localStorage cache when ttl is more than maxTTL", async () => {
+  it("doesn't restore from localStorage cache when ttl is more than maxAge", async () => {
     await clearCache();
     await seedLocalStorage(
       false,


### PR DESCRIPTION
### Features and Changes

The Javascript SDK has a client-side cache (using localStorage).  On page load, we immediately use the cached value and if it's older than `staleTTL` (default = 60 seconds), we refresh from the CDN in the background.

This can substantially speed up subsequent page loads, but it does mean some users will get served stale feature definitions.

This PR introduces a new `maxAge` setting (default = 24 hours).  Now, if the cached definitions are older than this, they will not be used and a fresh value will be fetched from the CDN instead.

TODO:
- [x] SDK Changes
- [x] New unit tests
- [x] Update documentation