### PR TITLE
[bugfix] Pass through ra enabled to stats engine

### DIFF
--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -239,7 +239,7 @@ export async function getManualSnapshotData(
     if (!metric) return null;
 
     metricSettings[m] = {
-      ...getMetricSettingsForStatsEngine(metric, metricMap),
+      ...getMetricSettingsForStatsEngine(metric, metricMap, false),
       // no ratio or regression adjustment for manual snapshots
       statistic_type: "mean",
     };

--- a/packages/back-end/src/services/notebook.ts
+++ b/packages/back-end/src/services/notebook.ts
@@ -140,7 +140,8 @@ export async function generateNotebook(
   const { queryResults, metricSettings } = getMetricsAndQueryDataForStatsEngine(
     queries,
     metricMap,
-    args.variations
+    args.variations,
+    args.regressionAdjustmentEnabled ?? false,
   );
 
   const data: DataForStatsEngine = {

--- a/packages/back-end/src/services/notebook.ts
+++ b/packages/back-end/src/services/notebook.ts
@@ -141,7 +141,7 @@ export async function generateNotebook(
     queries,
     metricMap,
     args.variations,
-    args.regressionAdjustmentEnabled ?? false,
+    args.regressionAdjustmentEnabled ?? false
   );
 
   const data: DataForStatsEngine = {

--- a/packages/back-end/src/services/stats.ts
+++ b/packages/back-end/src/services/stats.ts
@@ -211,14 +211,16 @@ print(json.dumps({
 
 export function getMetricSettingsForStatsEngine(
   metric: ExperimentMetricInterface,
-  metricMap: Map<string, ExperimentMetricInterface>
+  metricMap: Map<string, ExperimentMetricInterface>,
+  regressionAdjustmentEnabled: boolean
 ): MetricSettingsForStatsEngine {
   let denominator =
     metric.denominator && !isFactMetric(metric)
       ? metricMap.get(metric.denominator)
       : undefined;
   const ratioMetric = isRatioMetric(metric, denominator);
-  const regressionAdjusted = isRegressionAdjusted(metric, denominator);
+  const regressionAdjusted =
+    regressionAdjustmentEnabled && isRegressionAdjusted(metric, denominator);
   const mainMetricType = isBinomialMetric(metric) ? "binomial" : "count";
   // Fact ratio metrics contain denominator
   if (isFactMetric(metric) && ratioMetric) {
@@ -246,7 +248,8 @@ export function getMetricSettingsForStatsEngine(
 export function getMetricsAndQueryDataForStatsEngine(
   queryData: QueryMap,
   metricMap: Map<string, ExperimentMetricInterface>,
-  variations: (SnapshotSettingsVariation | ExperimentReportVariation)[]
+  variations: (SnapshotSettingsVariation | ExperimentReportVariation)[],
+  regressionAdjustmentEnabled: boolean
 ) {
   const queryResults: QueryResultsForStatsEngine[] = [];
   const metricSettings: Record<string, MetricSettingsForStatsEngine> = {};
@@ -271,7 +274,8 @@ export function getMetricsAndQueryDataForStatsEngine(
           }
           metricSettings[metric] = getMetricSettingsForStatsEngine(
             metricInterface,
-            metricMap
+            metricMap,
+            regressionAdjustmentEnabled
           );
           byMetric[metric].push({
             dimension: row.dimension,
@@ -311,7 +315,8 @@ export function getMetricsAndQueryDataForStatsEngine(
             metricIds.push(metricId);
             metricSettings[metricId] = getMetricSettingsForStatsEngine(
               metric,
-              metricMap
+              metricMap,
+              regressionAdjustmentEnabled
             );
           } else {
             metricIds.push(null);
@@ -328,7 +333,11 @@ export function getMetricsAndQueryDataForStatsEngine(
       // Single metric query, just return rows as-is
       const metric = metricMap.get(key);
       if (!metric) return;
-      metricSettings[key] = getMetricSettingsForStatsEngine(metric, metricMap);
+      metricSettings[key] = getMetricSettingsForStatsEngine(
+        metric,
+        metricMap,
+        regressionAdjustmentEnabled
+      );
       queryResults.push({
         metrics: [key],
         rows: (query.result ?? []) as ExperimentMetricQueryResponseRows,
@@ -359,7 +368,8 @@ export async function analyzeExperimentResults({
   const mdat = getMetricsAndQueryDataForStatsEngine(
     queryData,
     metricMap,
-    snapshotSettings.variations
+    snapshotSettings.variations,
+    snapshotSettings.regressionAdjustmentEnabled
   );
   const { queryResults, metricSettings } = mdat;
   let { unknownVariations } = mdat;


### PR DESCRIPTION
Regression adjustment on by default or metric setting was being passed through to the stats engine even if the analysis was Bayesian. This turns that off and fixes a bug that would prevent analyses in this case.

Test:
* Turn on org default to RA = ON OR set it to on at metric level
* Run analysis with Bayesian engine

Before this would yield: `RegressionAdjustedStatistic cannot be used with the Bayesian statistics engine`

Now it runs fine as expected.