### PR TITLE
Visual experiments - Allow accessing or deleting visual changes during running or stopped experiments

### DIFF
--- a/packages/front-end/components/Experiment/EditDOMMutationsModal.tsx
+++ b/packages/front-end/components/Experiment/EditDOMMutationsModal.tsx
@@ -1,13 +1,15 @@
+import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
 import { VisualChange } from "back-end/types/visual-changeset";
 import { FC, useCallback, useState } from "react";
 import Code from "@/components/SyntaxHighlighting/Code";
 import Modal from "../Modal";
 
 const EditDOMMutatonsModal: FC<{
+  experiment: ExperimentInterfaceStringDates;
   visualChange: VisualChange;
   close: () => void;
   onSave: (newVisualChange: VisualChange) => void;
-}> = ({ close, visualChange, onSave }) => {
+}> = ({ experiment, close, visualChange, onSave }) => {
   const [newVisualChange, setNewVisualChange] = useState<VisualChange>(
     visualChange
   );
@@ -52,6 +54,13 @@ const EditDOMMutatonsModal: FC<{
       cta="Save"
     >
       <div>
+        {experiment.status === "running" && (
+          <div className="alert alert-warning">
+            <strong>Warning:</strong> This experiment is currently running. Any
+            changes made here may introduce unpredictable effects in your
+            experiment results.
+          </div>
+        )}
         <div className="mb-4">
           <h4>
             Global CSS

--- a/packages/front-end/components/Experiment/VisualChangesetTable.tsx
+++ b/packages/front-end/components/Experiment/VisualChangesetTable.tsx
@@ -181,22 +181,21 @@ const drawChange = ({
                   >
                     <div className="d-flex justify-content-between mx-2">
                       <div>
-                        {canEditVisualChangesets &&
-                          experiment.status === "draft" && (
-                            <a
-                              href="#"
-                              className="mr-2"
-                              onClick={() =>
-                                setEditingVisualChange({
-                                  visualChange: changes,
-                                  visualChangeIndex: j,
-                                  visualChangeset: vc,
-                                })
-                              }
-                            >
-                              <FaPencilAlt />
-                            </a>
-                          )}
+                        {canEditVisualChangesets && (
+                          <a
+                            href="#"
+                            className="mr-2"
+                            onClick={() =>
+                              setEditingVisualChange({
+                                visualChange: changes,
+                                visualChangeIndex: j,
+                                visualChangeset: vc,
+                              })
+                            }
+                          >
+                            <FaPencilAlt />
+                          </a>
+                        )}
                         {numChanges} visual change
                         {numChanges === 1 ? "" : "s"}
                       </div>
@@ -410,6 +409,7 @@ export const VisualChangesetTable: FC<Props> = ({
 
       {editingVisualChange ? (
         <EditDOMMutatonsModal
+          experiment={experiment}
           visualChange={editingVisualChange.visualChange}
           close={() => setEditingVisualChange(null)}
           onSave={(newVisualChange) =>


### PR DESCRIPTION
Closes #2101

This gives users the power to access or delete Visual Changes even when an experiment is running or stopped.

We show a warning when the experiment is running in the edit modal:
<img width="2032" alt="image" src="https://github.com/growthbook/growthbook/assets/2374625/002cdd0a-6b88-436d-a11d-52fb7d7158b7">
