### PR TITLE
SDK Connections - Include visual experiments and draft experiments by default

### DIFF
--- a/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
+++ b/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
@@ -183,10 +183,14 @@ export default function SDKConnectionForm({
   }, [languageEnvironment, setSelectedSecurityTab]);
 
   useEffect(() => {
-    if (!showVisualEditorSettings) {
+    if (!edit) {
+      form.setValue("includeVisualExperiments", showVisualEditorSettings);
+      form.setValue("includeDraftExperiments", showVisualEditorSettings);
+    } else if (!showVisualEditorSettings) {
       form.setValue("includeVisualExperiments", false);
+      form.setValue("includeDraftExperiments", false);
     }
-  }, [showVisualEditorSettings, form]);
+  }, [showVisualEditorSettings, form, edit]);
 
   // complex setter for clicking a "SDK Payload Security" button
   useEffect(() => {


### PR DESCRIPTION
A common stumbling block for users is to create SDK Connections without the Visual Experiments toggle enabled. Later, when they reach out to support about their Visual Experiments not working, our first canned response is: 'Have you turned on visual experiments in your SDK connection?'

The reason a user want to omit visual experiments is to have a leaner payload to help with performance. Unfortunately, having this optimization by default is slowing down onboarding for new users.

This PR alters our SDK Connection creation modal so that when creating a new SDK Connection with the `'visualEditor'` capability, we default to having both fields `includeVisualExperiments` and `includeDraftExperiments` set to `true`.

Users who wish to optimize still have the ability to do so. The assumption is that optimization will come later in the user journey and not in the initial onboarding phase for users. 

This behavior does not apply to **editing** an SDK Connection - when editing, we maintain existing values, or set to false if the language selected no longer supports the `'visualEditor'` capability.

![Feb-06-2024 15-53-22](https://github.com/growthbook/growthbook/assets/2374625/2697cb89-5d76-4dd7-aed0-4d27d0397a24)
