### PR TITLE
Allow empty audience for OIDC connections

### DIFF
--- a/packages/back-end/src/services/auth/OpenIdAuthConnection.ts
+++ b/packages/back-end/src/services/auth/OpenIdAuthConnection.ts
@@ -209,7 +209,7 @@ export class OpenIdAuthConnection implements AuthConnection {
       code_challenge,
       code_challenge_method: "S256",
       state,
-      audience: (ssoConnection.metadata?.audience ||
+      audience: (ssoConnection.metadata?.audience ??
         ssoConnection.clientId) as string,
     });
 


### PR DESCRIPTION
### Features and Changes

JumpCloud throws an error when an audience is provided in the OIDC request.  This PR allows an empty audience to be specified in the connection settings.