### PR TITLE
Removes separate user prop from function signature when context is also a prop

### DIFF
--- a/packages/back-end/src/api/experiments/postExperiment.ts
+++ b/packages/back-end/src/api/experiments/postExperiment.ts
@@ -68,7 +68,6 @@ export const postExperiment = createApiRequestHandler(postExperimentValidator)(
     const experiment = await createExperiment({
       data: newExperiment,
       context: req.context,
-      user: req.eventAudit,
     });
 
     // add owner as watcher

--- a/packages/back-end/src/api/experiments/updateExperiment.ts
+++ b/packages/back-end/src/api/experiments/updateExperiment.ts
@@ -62,7 +62,6 @@ export const updateExperiment = createApiRequestHandler(
     const updatedExperiment = await updateExperimentToDb({
       context: req.context,
       experiment: experiment,
-      user: req.eventAudit,
       changes: updateExperimentApiPayloadToInterface(req.body, experiment),
     });
 

--- a/packages/back-end/src/api/features/postFeature.ts
+++ b/packages/back-end/src/api/features/postFeature.ts
@@ -123,7 +123,7 @@ export const postFeature = createApiRequestHandler(postFeatureValidator)(
 
     addIdsToRules(feature.environmentSettings, feature.id);
 
-    await createFeature(req.context, req.eventAudit, feature);
+    await createFeature(req.context, feature);
 
     await req.audit({
       event: "feature.create",

--- a/packages/back-end/src/api/features/toggleFeature.ts
+++ b/packages/back-end/src/api/features/toggleFeature.ts
@@ -38,7 +38,6 @@ export const toggleFeature = createApiRequestHandler(toggleFeatureValidator)(
 
     const updatedFeature = await toggleMultipleEnvironments(
       req.context,
-      req.eventAudit,
       feature,
       toggles
     );

--- a/packages/back-end/src/api/features/updateFeature.ts
+++ b/packages/back-end/src/api/features/updateFeature.ts
@@ -153,7 +153,6 @@ export const updateFeature = createApiRequestHandler(updateFeatureValidator)(
 
     const updatedFeature = await updateFeatureToDb(
       req.context,
-      req.eventAudit,
       feature,
       updates
     );

--- a/packages/back-end/src/api/metrics/deleteMetric.ts
+++ b/packages/back-end/src/api/metrics/deleteMetric.ts
@@ -13,7 +13,7 @@ export const deleteMetricHandler = createApiRequestHandler(getMetricValidator)(
       throw new Error("Could not find metric with that id");
     }
 
-    await deleteMetricById(metric, req.context);
+    await deleteMetricById(req.context, metric);
 
     return {
       deletedId: req.params.id,

--- a/packages/back-end/src/api/visual-changesets/putVisualChangeset.ts
+++ b/packages/back-end/src/api/visual-changesets/putVisualChangeset.ts
@@ -37,7 +37,6 @@ export const putVisualChangeset = createApiRequestHandler(
       experiment,
       context: req.context,
       updates: req.body,
-      user: req.eventAudit,
     });
 
     const updatedVisualChangeset = await findVisualChangesetById(

--- a/packages/back-end/src/controllers/datasources.ts
+++ b/packages/back-end/src/controllers/datasources.ts
@@ -215,7 +215,6 @@ Revenue did not reach 95% significance, but the risk is so low it doesn't seem w
     await createExperiment({
       data: experiment,
       context,
-      user: res.locals.eventAudit,
     });
 
     const metricMap = await getMetricMap(context);
@@ -823,9 +822,9 @@ export async function postDimensionSlices(
   });
 
   const queryRunner = new DimensionSlicesQueryRunner(
+    context,
     model,
-    integration,
-    context
+    integration
   );
   const outputmodel = await queryRunner.startAnalysis({
     exposureQueryId: queryId,
@@ -864,9 +863,9 @@ export async function cancelDimensionSlices(
   const integration = getSourceIntegrationObject(datasource, true);
 
   const queryRunner = new DimensionSlicesQueryRunner(
+    context,
     dimensionSlices,
-    integration,
-    context
+    integration
   );
   await queryRunner.cancelQueries();
 

--- a/packages/back-end/src/controllers/experimentLaunchChecklist.ts
+++ b/packages/back-end/src/controllers/experimentLaunchChecklist.ts
@@ -137,7 +137,6 @@ export async function putManualLaunchChecklist(
   await updateExperiment({
     context,
     experiment,
-    user: res.locals.eventAudit,
     changes: { manualLaunchChecklist: checklist },
   });
 

--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -361,7 +361,7 @@ export async function postSnapshotNotebook(
   const context = getContextFromReq(req);
   const { id } = req.params;
 
-  const notebook = await generateExperimentNotebook(id, context);
+  const notebook = await generateExperimentNotebook(context, id);
 
   res.status(200).json({
     status: 200,
@@ -559,7 +559,6 @@ export async function postExperiments(
     const experiment = await createExperiment({
       data: obj,
       context,
-      user: res.locals.eventAudit,
     });
 
     if (req.query.originalId) {
@@ -574,7 +573,6 @@ export async function postExperiments(
           editorUrl: visualChangeset.editorUrl,
           context,
           visualChanges: visualChangeset.visualChanges,
-          user: res.locals.eventAudit,
         });
       }
     }
@@ -807,7 +805,6 @@ export async function postExperiment(
   const updated = await updateExperiment({
     context,
     experiment,
-    user: res.locals.eventAudit,
     changes,
   });
 
@@ -825,7 +822,6 @@ export async function postExperiment(
             visualChangeset: vc,
             experiment: updated,
             context,
-            user: res.locals.eventAudit,
           })
         )
       );
@@ -899,7 +895,6 @@ export async function postExperimentArchive(
     await updateExperiment({
       context,
       experiment,
-      user: res.locals.eventAudit,
       changes,
     });
 
@@ -958,7 +953,6 @@ export async function postExperimentUnarchive(
     await updateExperiment({
       context,
       experiment,
-      user: res.locals.eventAudit,
       changes,
     });
 
@@ -1059,7 +1053,6 @@ export async function postExperimentStatus(
   const updated = await updateExperiment({
     context,
     experiment,
-    user: res.locals.eventAudit,
     changes,
   });
 
@@ -1152,7 +1145,6 @@ export async function postExperimentStop(
     const updated = await updateExperiment({
       context,
       experiment,
-      user: res.locals.eventAudit,
       changes,
     });
 
@@ -1225,7 +1217,6 @@ export async function deleteExperimentPhase(
   const updated = await updateExperiment({
     context,
     experiment,
-    user: res.locals.eventAudit,
     changes,
   });
 
@@ -1296,7 +1287,6 @@ export async function putExperimentPhase(
   const updated = await updateExperiment({
     context,
     experiment,
-    user: res.locals.eventAudit,
     changes,
   });
 
@@ -1406,7 +1396,6 @@ export async function postExperimentTargeting(
     const updated = await updateExperiment({
       context,
       experiment,
-      user: res.locals.eventAudit,
       changes,
     });
 
@@ -1505,7 +1494,6 @@ export async function postExperimentPhase(
     const updated = await updateExperiment({
       context,
       experiment,
-      user: res.locals.eventAudit,
       changes,
     });
 
@@ -1590,11 +1578,7 @@ export async function deleteExperiment(
   await Promise.all([
     // note: we might want to change this to change the status to
     // 'deleted' instead of actually deleting the document.
-    deleteExperimentByIdForOrganization(
-      experiment,
-      context,
-      res.locals.eventAudit
-    ),
+    deleteExperimentByIdForOrganization(context, experiment),
     removeExperimentFromPresentations(experiment.id),
   ]);
 
@@ -1643,9 +1627,9 @@ export async function cancelSnapshot(
     snapshot.settings.datasourceId
   );
   const queryRunner = new ExperimentResultsQueryRunner(
+    context,
     snapshot,
-    integration,
-    context
+    integration
   );
   await queryRunner.cancelQueries();
   await deleteSnapshotById(org.id, snapshot.id);
@@ -1809,7 +1793,6 @@ export async function postSnapshot(
     const queryRunner = await createSnapshot({
       experiment,
       context,
-      user: res.locals.eventAudit,
       phaseIndex: phase,
       useCache,
       defaultAnalysisSettings: analysisSettings,
@@ -1960,7 +1943,6 @@ export async function deleteScreenshot(
   const updated = await updateExperiment({
     context,
     experiment,
-    user: res.locals.eventAudit,
     changes,
   });
 
@@ -2036,7 +2018,6 @@ export async function addScreenshot(
   await updateExperiment({
     context,
     experiment,
-    user: res.locals.eventAudit,
     changes,
   });
 
@@ -2089,9 +2070,9 @@ export async function cancelPastExperiments(
     pastExperiments.datasource
   );
   const queryRunner = new PastExperimentsQueryRunner(
+    context,
     pastExperiments,
-    integration,
-    context
+    integration
   );
   await queryRunner.cancelQueries();
 
@@ -2188,9 +2169,9 @@ export async function postPastExperiments(
 
   if (needsRun) {
     const queryRunner = new PastExperimentsQueryRunner(
+      context,
       pastExperiments,
-      integration,
-      context
+      integration
     );
     pastExperiments = await queryRunner.startAnalysis({
       from: start,
@@ -2244,7 +2225,6 @@ export async function postVisualChangeset(
     urlPatterns: req.body.urlPatterns,
     editorUrl: req.body.editorUrl,
     context,
-    user: res.locals.eventAudit,
   });
 
   res.status(200).json({
@@ -2278,7 +2258,6 @@ export async function putVisualChangeset(
     experiment,
     context,
     updates: req.body,
-    user: res.locals.eventAudit,
   });
 
   res.status(200).json({
@@ -2315,7 +2294,6 @@ export async function deleteVisualChangeset(
     visualChangeset,
     experiment,
     context,
-    user: res.locals.eventAudit,
   });
 
   res.status(200).json({

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -70,10 +70,7 @@ import {
 } from "../models/SdkConnectionModel";
 import { logger } from "../util/logger";
 import { addTagsDiff } from "../models/TagModel";
-import {
-  EventAuditUser,
-  EventAuditUserForResponseLocals,
-} from "../events/event-types";
+import { EventAuditUserForResponseLocals } from "../events/event-types";
 import {
   FASTLY_SERVICE_ID,
   CACHE_CONTROL_MAX_AGE,

--- a/packages/back-end/src/controllers/metrics.ts
+++ b/packages/back-end/src/controllers/metrics.ts
@@ -99,7 +99,7 @@ export async function deleteMetric(
   );
 
   // now remove the metric itself:
-  await deleteMetricById(metric, context);
+  await deleteMetricById(context, metric);
 
   await req.audit({
     event: "metric.delete",
@@ -194,9 +194,9 @@ export async function cancelMetricAnalysis(
     metric.datasource
   );
   const queryRunner = new MetricAnalysisQueryRunner(
+    context,
     metric,
-    integration,
-    context
+    integration
   );
   await queryRunner.cancelQueries();
 

--- a/packages/back-end/src/controllers/reports.ts
+++ b/packages/back-end/src/controllers/reports.ts
@@ -227,9 +227,9 @@ export async function refreshReport(
     true
   );
   const queryRunner = new ReportQueryRunner(
+    context,
     report,
     integration,
-    context,
     useCache
   );
 
@@ -312,9 +312,9 @@ export async function putReport(
       true
     );
     const queryRunner = new ReportQueryRunner(
+      context,
       updatedReport,
-      integration,
-      context
+      integration
     );
 
     await queryRunner.startAnalysis({
@@ -352,7 +352,7 @@ export async function cancelReport(
     context,
     report.args.datasource
   );
-  const queryRunner = new ReportQueryRunner(report, integration, context);
+  const queryRunner = new ReportQueryRunner(context, report, integration);
   await queryRunner.cancelQueries();
 
   res.status(200).json({ status: 200 });

--- a/packages/back-end/src/jobs/updateExperimentResults.ts
+++ b/packages/back-end/src/jobs/updateExperimentResults.ts
@@ -200,7 +200,6 @@ async function updateSingleExperiment(job: UpdateSingleExpJob) {
       await updateExperiment({
         context,
         experiment,
-        user: null,
         changes: {
           autoSnapshots: false,
         },

--- a/packages/back-end/src/jobs/updateScheduledFeatures.ts
+++ b/packages/back-end/src/jobs/updateScheduledFeatures.ts
@@ -79,7 +79,7 @@ async function updateSingleFeature(job: UpdateSingleFeatureJob) {
     );
 
     // Update the feature in Mongo
-    await updateFeature(context, null, feature, {
+    await updateFeature(context, feature, {
       nextScheduledUpdate: nextScheduledUpdate,
     });
   } catch (e) {

--- a/packages/back-end/src/models/ExperimentModel.ts
+++ b/packages/back-end/src/models/ExperimentModel.ts
@@ -27,7 +27,6 @@ import { logger } from "../util/logger";
 import { upgradeExperimentDoc } from "../util/migrations";
 import { refreshSDKPayloadCache, VisualExperiment } from "../services/features";
 import { SDKPayloadKey } from "../../types/sdk-payload";
-import { EventAuditUser } from "../events/event-types";
 import { FeatureInterface } from "../../types/feature";
 import { getAffectedSDKPayloadKeys } from "../util/features";
 import { getEnvironmentIdsFromOrg } from "../services/organizations";

--- a/packages/back-end/src/models/ExperimentModel.ts
+++ b/packages/back-end/src/models/ExperimentModel.ts
@@ -313,11 +313,9 @@ export async function getSampleExperiment(
 export async function createExperiment({
   data,
   context,
-  user,
 }: {
   data: Partial<ExperimentInterface>;
   context: ReqContext | ApiReqContext;
-  user: EventAuditUser;
 }): Promise<ExperimentInterface> {
   data.organization = context.org.id;
 
@@ -355,7 +353,6 @@ export async function createExperiment({
   await onExperimentCreate({
     context,
     experiment: exp,
-    user,
   });
 
   if (data.tags) {
@@ -368,13 +365,11 @@ export async function createExperiment({
 export async function updateExperiment({
   context,
   experiment,
-  user,
   changes,
   bypassWebhooks = false,
 }: {
   context: ReqContext | ApiReqContext;
   experiment: ExperimentInterface;
-  user: EventAuditUser;
   changes: Changeset;
   bypassWebhooks?: boolean;
 }): Promise<ExperimentInterface | null> {
@@ -394,7 +389,6 @@ export async function updateExperiment({
     context,
     oldExperiment: experiment,
     newExperiment: updated,
-    user,
     bypassWebhooks,
   });
 
@@ -604,10 +598,9 @@ export async function getRecentExperimentsUsingMetric(
 
 export async function deleteExperimentSegment(
   context: ReqContext | ApiReqContext,
-  user: EventAuditUser,
   segment: string
 ): Promise<void> {
-  const exps = await getExperimentsUsingSegment(segment, context);
+  const exps = await getExperimentsUsingSegment(context, segment);
 
   if (!exps.length) return;
 
@@ -627,7 +620,6 @@ export async function deleteExperimentSegment(
       oldExperiment: previous,
       newExperiment: current,
       bypassWebhooks: true,
-      user,
     });
   });
 }
@@ -688,13 +680,11 @@ const findExperiment = async ({
 
 /**
  * @param context
- * @param user
  * @param experiment
  * @return event.id
  */
 const logExperimentCreated = async (
   context: ReqContext | ApiReqContext,
-  user: EventAuditUser,
   experiment: ExperimentInterface
 ): Promise<string | undefined> => {
   const { org: organization } = context;
@@ -702,7 +692,7 @@ const logExperimentCreated = async (
   const payload: ExperimentCreatedNotificationEvent = {
     object: "experiment",
     event: "experiment.created",
-    user,
+    user: context.auditUser,
     data: {
       current: apiExperiment,
     },
@@ -717,18 +707,15 @@ const logExperimentCreated = async (
 
 /**
  * @param context
- * @param user
  * @param current
  * @return previous
  */
 const logExperimentUpdated = async ({
   context,
-  user,
   current,
   previous,
 }: {
   context: ReqContext | ApiReqContext;
-  user: EventAuditUser;
   current: ExperimentInterface;
   previous: ExperimentInterface;
 }): Promise<string | undefined> => {
@@ -748,7 +735,7 @@ const logExperimentUpdated = async ({
   const payload: ExperimentUpdatedNotificationEvent = {
     object: "experiment",
     event: "experiment.updated",
-    user,
+    user: context.auditUser,
     data: {
       previous: previousApiExperiment,
       current: currentApiExperiment,
@@ -766,12 +753,10 @@ const logExperimentUpdated = async ({
  * Deletes an experiment by ID and logs the event for the organization
  * @param experiment
  * @param organization
- * @param user
  */
 export async function deleteExperimentByIdForOrganization(
-  experiment: ExperimentInterface,
   context: ReqContext | ApiReqContext,
-  user: EventAuditUser
+  experiment: ExperimentInterface
 ) {
   try {
     await ExperimentModel.deleteOne({
@@ -781,7 +766,7 @@ export async function deleteExperimentByIdForOrganization(
 
     await VisualChangesetModel.deleteMany({ experiment: experiment.id });
 
-    await onExperimentDelete(context, user, experiment);
+    await onExperimentDelete(context, experiment);
   } catch (e) {
     logger.error(e);
   }
@@ -791,16 +776,13 @@ export async function deleteExperimentByIdForOrganization(
  * Delete experiments belonging to a project
  * @param projectId
  * @param organization
- * @param user
  */
 export async function deleteAllExperimentsForAProject({
   projectId,
   context,
-  user,
 }: {
   projectId: string;
   context: ReqContext | ApiReqContext;
-  user: EventAuditUser;
 }) {
   const experimentsToDelete = await ExperimentModel.find({
     organization: context.org.id,
@@ -810,7 +792,7 @@ export async function deleteAllExperimentsForAProject({
   for (const experiment of experimentsToDelete) {
     await experiment.delete();
     VisualChangesetModel.deleteMany({ experiment: experiment.id });
-    await onExperimentDelete(context, user, experiment);
+    await onExperimentDelete(context, experiment);
   }
 }
 
@@ -818,16 +800,13 @@ export async function deleteAllExperimentsForAProject({
  * Removes the tag from any experiments that have it
  * and logs the experiment.updated event
  * @param context
- * @param user
  * @param tag
  */
 export const removeTagFromExperiments = async ({
   context,
-  user,
   tag,
 }: {
   context: ReqContext | ApiReqContext;
-  user: EventAuditUser;
   tag: string;
 }): Promise<void> => {
   const query = { organization: context.org.id, tags: tag };
@@ -837,15 +816,15 @@ export const removeTagFromExperiments = async ({
     $pull: { tags: tag },
   });
 
-  logAllChanges(context, user, previousExperiments, (exp) => ({
+  logAllChanges(context, previousExperiments, (exp) => ({
     ...exp,
     tags: exp.tags.filter((t) => t !== tag),
   }));
 };
 
 export async function removeMetricFromExperiments(
-  metricId: string,
-  context: ReqContext | ApiReqContext
+  context: ReqContext | ApiReqContext,
+  metricId: string
 ) {
   const oldExperiments: Record<
     string,
@@ -917,23 +896,21 @@ export async function removeMetricFromExperiments(
         oldExperiment: previous,
         newExperiment: current,
         bypassWebhooks: true,
-        user: context.auditUser,
       });
     }
   });
 }
 
 export async function removeProjectFromExperiments(
-  project: string,
   context: ReqContext | ApiReqContext,
-  user: EventAuditUser
+  project: string
 ) {
   const query = { organization: context.org.id, project };
   const previousExperiments = await findExperiments(context, query);
 
   await ExperimentModel.updateMany(query, { $set: { project: "" } });
 
-  logAllChanges(context, user, previousExperiments, (exp) => ({
+  logAllChanges(context, previousExperiments, (exp) => ({
     ...exp,
     project: "",
   }));
@@ -941,7 +918,6 @@ export async function removeProjectFromExperiments(
 
 export async function addLinkedFeatureToExperiment(
   context: ReqContext | ApiReqContext,
-  user: EventAuditUser,
   experimentId: string,
   featureId: string,
   experiment?: ExperimentInterface | null
@@ -976,13 +952,11 @@ export async function addLinkedFeatureToExperiment(
       ...experiment,
       linkedFeatures: [...(experiment.linkedFeatures || []), featureId],
     },
-    user,
   });
 }
 
 export async function removeLinkedFeatureFromExperiment(
   context: ReqContext | ApiReqContext,
-  user: EventAuditUser,
   experimentId: string,
   featureId: string
 ) {
@@ -1016,13 +990,11 @@ export async function removeLinkedFeatureFromExperiment(
         (f) => f !== featureId
       ),
     },
-    user,
   });
 }
 
 function logAllChanges(
   context: ReqContext | ApiReqContext,
-  user: EventAuditUser,
   previousExperiments: ExperimentInterface[],
   applyChanges: (exp: ExperimentInterface) => ExperimentInterface | null
 ) {
@@ -1033,14 +1005,13 @@ function logAllChanges(
       context,
       oldExperiment: previous,
       newExperiment: current,
-      user,
     });
   });
 }
 
 export async function getExperimentsUsingSegment(
-  id: string,
-  context: ReqContext | ApiReqContext
+  context: ReqContext | ApiReqContext,
+  id: string
 ) {
   return await findExperiments(context, {
     organization: context.org.id,
@@ -1050,20 +1021,18 @@ export async function getExperimentsUsingSegment(
 
 /**
  * @param context
- * @param user
  * @param experiment
  * @return experiment
  */
 export const logExperimentDeleted = async (
   context: ReqContext | ApiReqContext,
-  user: EventAuditUser,
   experiment: ExperimentInterface
 ): Promise<string | undefined> => {
   const apiExperiment = await toExperimentApiInterface(context, experiment);
   const payload: ExperimentDeletedNotificationEvent = {
     object: "experiment",
     event: "experiment.deleted",
-    user,
+    user: context.auditUser,
     data: {
       previous: apiExperiment,
     },
@@ -1286,13 +1255,11 @@ const hasChangesForSDKPayloadRefresh = (
 const onExperimentCreate = async ({
   context,
   experiment,
-  user,
 }: {
   context: ReqContext | ApiReqContext;
   experiment: ExperimentInterface;
-  user: EventAuditUser;
 }) => {
-  await logExperimentCreated(context, user, experiment);
+  await logExperimentCreated(context, experiment);
 };
 
 const onExperimentUpdate = async ({
@@ -1300,19 +1267,16 @@ const onExperimentUpdate = async ({
   oldExperiment,
   newExperiment,
   bypassWebhooks = false,
-  user,
 }: {
   context: ReqContext | ApiReqContext;
   oldExperiment: ExperimentInterface;
   newExperiment: ExperimentInterface;
   bypassWebhooks?: boolean;
-  user: EventAuditUser;
 }) => {
   await logExperimentUpdated({
     context,
     current: newExperiment,
     previous: oldExperiment,
-    user,
   });
 
   if (
@@ -1348,10 +1312,9 @@ const onExperimentUpdate = async ({
 
 const onExperimentDelete = async (
   context: ReqContext | ApiReqContext,
-  user: EventAuditUser,
   experiment: ExperimentInterface
 ) => {
-  await logExperimentDeleted(context, user, experiment);
+  await logExperimentDeleted(context, experiment);
 
   const featureIds = [...(experiment.linkedFeatures || [])];
   let linkedFeatures: FeatureInterface[] = [];

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -247,7 +247,6 @@ export async function getFeaturesByIds(
 
 export async function createFeature(
   context: ReqContext | ApiReqContext,
-  user: EventAuditUser,
   data: FeatureInterface
 ) {
   const { org } = context;
@@ -267,24 +266,23 @@ export async function createFeature(
 
   await createInitialRevision(
     toInterface(feature),
-    user,
+    context.auditUser,
     getEnvironmentIdsFromOrg(org)
   );
 
   if (linkedExperiments.length > 0) {
     await Promise.all(
       linkedExperiments.map(async (exp) => {
-        await addLinkedFeatureToExperiment(context, user, exp, data.id);
+        await addLinkedFeatureToExperiment(context, exp, data.id);
       })
     );
   }
 
-  onFeatureCreate(context, user, feature);
+  onFeatureCreate(context, feature);
 }
 
 export async function deleteFeature(
   context: ReqContext | ApiReqContext,
-  user: EventAuditUser,
   feature: FeatureInterface
 ) {
   await FeatureModel.deleteOne({
@@ -296,28 +294,25 @@ export async function deleteFeature(
   if (feature.linkedExperiments) {
     await Promise.all(
       feature.linkedExperiments.map(async (exp) => {
-        await removeLinkedFeatureFromExperiment(context, user, exp, feature.id);
+        await removeLinkedFeatureFromExperiment(context, exp, feature.id);
       })
     );
   }
 
-  onFeatureDelete(context, user, feature);
+  onFeatureDelete(context, feature);
 }
 
 /**
  * Deletes all features belonging to a project
  * @param projectId
  * @param organization
- * @param user
  */
 export async function deleteAllFeaturesForAProject({
   projectId,
   context,
-  user,
 }: {
   projectId: string;
   context: ReqContext | ApiReqContext;
-  user: EventAuditUser;
 }) {
   const featuresToDelete = await FeatureModel.find({
     organization: context.org.id,
@@ -325,7 +320,7 @@ export async function deleteAllFeaturesForAProject({
   });
 
   for (const feature of featuresToDelete) {
-    await deleteFeature(context, user, feature);
+    await deleteFeature(context, feature);
   }
 }
 
@@ -333,13 +328,11 @@ export async function deleteAllFeaturesForAProject({
  * Given the common {@link FeatureInterface} for both previous and next states, and the organization,
  * will log an update event in the events collection
  * @param organization
- * @param user
  * @param previous
  * @param current
  */
 async function logFeatureUpdatedEvent(
   context: ReqContext | ApiReqContext,
-  user: EventAuditUser,
   previous: FeatureInterface,
   current: FeatureInterface
 ): Promise<string | undefined> {
@@ -363,7 +356,7 @@ async function logFeatureUpdatedEvent(
         experimentMap,
       }),
     },
-    user,
+    user: context.auditUser,
   };
 
   const emittedEvent = await createEvent(context.org.id, payload);
@@ -375,13 +368,11 @@ async function logFeatureUpdatedEvent(
 
 /**
  * @param organization
- * @param user
  * @param feature
  * @returns event.id
  */
 async function logFeatureCreatedEvent(
   context: ReqContext | ApiReqContext,
-  user: EventAuditUser,
   feature: FeatureInterface
 ): Promise<string | undefined> {
   const groupMap = await getSavedGroupMap(context.org);
@@ -390,7 +381,7 @@ async function logFeatureCreatedEvent(
   const payload: FeatureCreatedNotificationEvent = {
     object: "feature",
     event: "feature.created",
-    user,
+    user: context.auditUser,
     data: {
       current: getApiFeatureObj({
         feature,
@@ -410,12 +401,10 @@ async function logFeatureCreatedEvent(
 
 /**
  * @param organization
- * @param user
  * @param previousFeature
  */
 async function logFeatureDeletedEvent(
   context: ReqContext | ApiReqContext,
-  user: EventAuditUser,
   previousFeature: FeatureInterface
 ): Promise<string | undefined> {
   const groupMap = await getSavedGroupMap(context.org);
@@ -427,7 +416,7 @@ async function logFeatureDeletedEvent(
   const payload: FeatureDeletedNotificationEvent = {
     object: "feature",
     event: "feature.deleted",
-    user,
+    user: context.auditUser,
     data: {
       previous: getApiFeatureObj({
         feature: previousFeature,
@@ -447,7 +436,6 @@ async function logFeatureDeletedEvent(
 
 async function onFeatureCreate(
   context: ReqContext | ApiReqContext,
-  user: EventAuditUser,
   feature: FeatureInterface
 ) {
   await refreshSDKPayloadCache(
@@ -455,12 +443,11 @@ async function onFeatureCreate(
     getAffectedSDKPayloadKeys([feature], getEnvironmentIdsFromOrg(context.org))
   );
 
-  await logFeatureCreatedEvent(context, user, feature);
+  await logFeatureCreatedEvent(context, feature);
 }
 
 async function onFeatureDelete(
   context: ReqContext | ApiReqContext,
-  user: EventAuditUser,
   feature: FeatureInterface
 ) {
   await refreshSDKPayloadCache(
@@ -468,12 +455,11 @@ async function onFeatureDelete(
     getAffectedSDKPayloadKeys([feature], getEnvironmentIdsFromOrg(context.org))
   );
 
-  await logFeatureDeletedEvent(context, user, feature);
+  await logFeatureDeletedEvent(context, feature);
 }
 
 export async function onFeatureUpdate(
   context: ReqContext | ApiReqContext,
-  user: EventAuditUser,
   feature: FeatureInterface,
   updatedFeature: FeatureInterface,
   skipRefreshForProject?: string
@@ -491,12 +477,11 @@ export async function onFeatureUpdate(
   );
 
   // New event-based webhooks
-  await logFeatureUpdatedEvent(context, user, feature, updatedFeature);
+  await logFeatureUpdatedEvent(context, feature, updatedFeature);
 }
 
 export async function updateFeature(
   context: ReqContext | ApiReqContext,
-  user: EventAuditUser,
   feature: FeatureInterface,
   updates: Partial<FeatureInterface>
 ): Promise<FeatureInterface> {
@@ -537,12 +522,12 @@ export async function updateFeature(
   if (experimentsAdded.size > 0) {
     await Promise.all(
       [...experimentsAdded].map(async (exp) => {
-        await addLinkedFeatureToExperiment(context, user, exp, feature.id);
+        await addLinkedFeatureToExperiment(context, exp, feature.id);
       })
     );
   }
 
-  onFeatureUpdate(context, user, feature, updatedFeature);
+  onFeatureUpdate(context, feature, updatedFeature);
   return updatedFeature;
 }
 
@@ -574,11 +559,10 @@ export async function getScheduledFeaturesToUpdate() {
 
 export async function archiveFeature(
   context: ReqContext | ApiReqContext,
-  user: EventAuditUser,
   feature: FeatureInterface,
   isArchived: boolean
 ) {
-  return await updateFeature(context, user, feature, { archived: isArchived });
+  return await updateFeature(context, feature, { archived: isArchived });
 }
 
 function setEnvironmentSettings(
@@ -602,7 +586,6 @@ function setEnvironmentSettings(
 
 export async function toggleMultipleEnvironments(
   context: ReqContext | ApiReqContext,
-  user: EventAuditUser,
   feature: FeatureInterface,
   toggles: Record<string, boolean>
 ) {
@@ -626,7 +609,7 @@ export async function toggleMultipleEnvironments(
 
   // If there are changes we need to apply
   if (hasChanges) {
-    const updatedFeature = await updateFeature(context, user, feature, {
+    const updatedFeature = await updateFeature(context, feature, {
       environmentSettings: featureCopy.environmentSettings,
     });
     return updatedFeature;
@@ -637,12 +620,11 @@ export async function toggleMultipleEnvironments(
 
 export async function toggleFeatureEnvironment(
   context: ReqContext | ApiReqContext,
-  user: EventAuditUser,
   feature: FeatureInterface,
   environment: string,
   state: boolean
 ) {
-  return await toggleMultipleEnvironments(context, user, feature, {
+  return await toggleMultipleEnvironments(context, feature, {
     [environment]: state,
   });
 }
@@ -700,7 +682,6 @@ export async function editFeatureRule(
 
 export async function removeTagInFeature(
   context: ReqContext | ApiReqContext,
-  user: EventAuditUser,
   tag: string
 ) {
   const query = { organization: context.org.id, tags: tag };
@@ -718,14 +699,13 @@ export async function removeTagInFeature(
       tags: (feature.tags || []).filter((t) => t !== tag),
     };
 
-    onFeatureUpdate(context, user, feature, updatedFeature);
+    onFeatureUpdate(context, feature, updatedFeature);
   });
 }
 
 export async function removeProjectFromFeatures(
-  project: string,
   context: ReqContext | ApiReqContext,
-  user: EventAuditUser
+  project: string
 ) {
   const query = { organization: context.org.id, project };
 
@@ -740,7 +720,7 @@ export async function removeProjectFromFeatures(
       project: "",
     };
 
-    onFeatureUpdate(context, user, feature, updatedFeature, project);
+    onFeatureUpdate(context, feature, updatedFeature, project);
   });
 }
 
@@ -763,12 +743,11 @@ export async function setDefaultValue(
 
 export async function setJsonSchema(
   context: ReqContext | ApiReqContext,
-  user: EventAuditUser,
   feature: FeatureInterface,
   schema: string,
   enabled?: boolean
 ) {
-  return await updateFeature(context, user, feature, {
+  return await updateFeature(context, feature, {
     jsonSchema: { schema, enabled: enabled ?? true, date: new Date() },
   });
 }
@@ -777,8 +756,7 @@ export async function applyRevisionChanges(
   context: ReqContext | ApiReqContext,
   feature: FeatureInterface,
   revision: FeatureRevisionInterface,
-  result: MergeResultChanges,
-  user: EventAuditUser
+  result: MergeResultChanges
 ) {
   let hasChanges = false;
   const changes: Partial<FeatureInterface> = {};
@@ -821,7 +799,7 @@ export async function applyRevisionChanges(
     revision.version,
   ]);
 
-  return await updateFeature(context, user, feature, changes);
+  return await updateFeature(context, feature, changes);
 }
 
 export async function publishRevision(
@@ -829,7 +807,6 @@ export async function publishRevision(
   feature: FeatureInterface,
   revision: FeatureRevisionInterface,
   result: MergeResultChanges,
-  user: EventAuditUser,
   comment?: string
 ) {
   if (revision.status !== "draft") {
@@ -841,11 +818,10 @@ export async function publishRevision(
     context,
     feature,
     revision,
-    result,
-    user
+    result
   );
 
-  await markRevisionAsPublished(revision, user, comment);
+  await markRevisionAsPublished(revision, context.auditUser, comment);
 
   return updatedFeature;
 }
@@ -877,8 +853,7 @@ function getLinkedExperiments(
 export async function toggleNeverStale(
   context: ReqContext | ApiReqContext,
   feature: FeatureInterface,
-  user: EventAuditUser,
   neverStale: boolean
 ) {
-  return await updateFeature(context, user, feature, { neverStale });
+  return await updateFeature(context, feature, { neverStale });
 }

--- a/packages/back-end/src/models/MetricModel.ts
+++ b/packages/back-end/src/models/MetricModel.ts
@@ -156,8 +156,8 @@ export async function insertMetrics(
 }
 
 export async function deleteMetricById(
-  metric: LegacyMetricInterface | MetricInterface,
-  context: ReqContext | ApiReqContext
+  context: ReqContext | ApiReqContext,
+  metric: LegacyMetricInterface | MetricInterface
 ) {
   if (metric.managedBy === "config") {
     throw new Error("Cannot delete a metric managed by config.yml");
@@ -177,7 +177,7 @@ export async function deleteMetricById(
   );
 
   // Experiments
-  await removeMetricFromExperiments(metric.id, context);
+  await removeMetricFromExperiments(context, metric.id);
 
   await MetricModel.deleteOne({
     id: metric.id,
@@ -204,7 +204,7 @@ export async function deleteAllMetricsForAProject({
   });
 
   for (const metric of metricsToDelete) {
-    await deleteMetricById(metric, context);
+    await deleteMetricById(context, metric);
   }
 }
 

--- a/packages/back-end/src/models/VisualChangesetModel.ts
+++ b/packages/back-end/src/models/VisualChangesetModel.ts
@@ -11,7 +11,6 @@ import {
   VisualChangesetInterface,
   VisualChangesetURLPattern,
 } from "../../types/visual-changeset";
-import { EventAuditUser } from "../events/event-types";
 import { refreshSDKPayloadCache } from "../services/features";
 import { visualChangesetsHaveChanges } from "../services/experiments";
 import { ApiReqContext } from "../../types/api";

--- a/packages/back-end/src/models/VisualChangesetModel.ts
+++ b/packages/back-end/src/models/VisualChangesetModel.ts
@@ -257,14 +257,12 @@ export const createVisualChangeset = async ({
   urlPatterns,
   editorUrl,
   visualChanges,
-  user,
 }: {
   experiment: ExperimentInterface;
   context: ReqContext | ApiReqContext;
   urlPatterns: VisualChangesetURLPattern[];
   editorUrl: VisualChangesetInterface["editorUrl"];
   visualChanges?: VisualChange[];
-  user: EventAuditUser;
 }): Promise<VisualChangesetInterface> => {
   const visualChangeset = toInterface(
     await VisualChangesetModel.create({
@@ -284,7 +282,6 @@ export const createVisualChangeset = async ({
       context,
       experiment,
       changes: { hasVisualChangesets: true },
-      user,
       bypassWebhooks: true,
     });
   }
@@ -312,14 +309,12 @@ export const updateVisualChangeset = async ({
   context,
   updates,
   bypassWebhooks,
-  user,
 }: {
   visualChangeset: VisualChangesetInterface;
   experiment: ExperimentInterface | null;
   context: ReqContext | ApiReqContext;
   updates: Partial<VisualChangesetInterface>;
   bypassWebhooks?: boolean;
-  user: EventAuditUser;
 }) => {
   const isUpdatingVisualChanges = _isUpdatingVisualChanges(updates);
 
@@ -349,7 +344,6 @@ export const updateVisualChangeset = async ({
     await updateExperiment({
       context,
       experiment,
-      user,
       changes: { hasVisualChangesets: true },
       bypassWebhooks: true,
     });
@@ -442,12 +436,10 @@ export const syncVisualChangesWithVariations = async ({
   experiment,
   context,
   visualChangeset,
-  user,
 }: {
   experiment: ExperimentInterface;
   context: ReqContext | ApiReqContext;
   visualChangeset: VisualChangesetInterface;
-  user: EventAuditUser;
 }) => {
   const { variations } = experiment;
   const { visualChanges } = visualChangeset;
@@ -464,7 +456,6 @@ export const syncVisualChangesWithVariations = async ({
     updates: { visualChanges: newVisualChanges },
     // bypass webhooks since we are only creating new (empty) visual changes
     bypassWebhooks: true,
-    user,
   });
 };
 
@@ -472,12 +463,10 @@ export const deleteVisualChangesetById = async ({
   visualChangeset,
   experiment,
   context,
-  user,
 }: {
   visualChangeset: VisualChangesetInterface;
   experiment: ExperimentInterface | null;
   context: ReqContext | ApiReqContext;
-  user: EventAuditUser;
 }) => {
   await VisualChangesetModel.deleteOne({
     id: visualChangeset.id,
@@ -496,7 +485,6 @@ export const deleteVisualChangesetById = async ({
         experiment,
         changes: { hasVisualChangesets: false },
         bypassWebhooks: true,
-        user,
       });
     }
   }

--- a/packages/back-end/src/queryRunners/QueryRunner.ts
+++ b/packages/back-end/src/queryRunners/QueryRunner.ts
@@ -105,9 +105,9 @@ export abstract class QueryRunner<
   private useCache: boolean;
 
   public constructor(
+    context: ReqContext | ApiReqContext,
     model: Model,
     integration: SourceIntegrationInterface,
-    context: ReqContext | ApiReqContext,
     useCache = true
   ) {
     this.model = model;

--- a/packages/back-end/src/routers/demo-datasource-project/demo-datasource-project.controller.ts
+++ b/packages/back-end/src/routers/demo-datasource-project/demo-datasource-project.controller.ts
@@ -326,7 +326,6 @@ spacing and headings.`,
     const createdExperiment = await createExperiment({
       data: experimentToCreate,
       context,
-      user: res.locals.eventAudit,
     });
 
     // Create feature
@@ -389,7 +388,7 @@ spacing and headings.`,
       });
     });
 
-    await createFeature(context, res.locals.eventAudit, featureToCreate);
+    await createFeature(context, featureToCreate);
 
     const analysisSettings: ExperimentSnapshotAnalysisSettings = {
       statsEngine: org.settings?.statsEngine || DEFAULT_STATS_ENGINE,

--- a/packages/back-end/src/routers/project/project.controller.ts
+++ b/packages/back-end/src/routers/project/project.controller.ts
@@ -221,7 +221,6 @@ export const deleteProject = async (
       await deleteAllFeaturesForAProject({
         projectId: id,
         context,
-        user: res.locals.eventAudit,
       });
     } catch (e) {
       return res.json({
@@ -230,7 +229,7 @@ export const deleteProject = async (
       });
     }
   } else {
-    await removeProjectFromFeatures(id, context, res.locals.eventAudit);
+    await removeProjectFromFeatures(context, id);
   }
 
   // Clean up experiments
@@ -241,7 +240,6 @@ export const deleteProject = async (
       await deleteAllExperimentsForAProject({
         projectId: id,
         context,
-        user: res.locals.eventAudit,
       });
     } catch (e) {
       return res.json({
@@ -250,7 +248,7 @@ export const deleteProject = async (
       });
     }
   } else {
-    await removeProjectFromExperiments(id, context, res.locals.eventAudit);
+    await removeProjectFromExperiments(context, id);
   }
 
   // Clean up Slack integrations

--- a/packages/back-end/src/routers/segment/segment.controller.ts
+++ b/packages/back-end/src/routers/segment/segment.controller.ts
@@ -104,7 +104,7 @@ export const getSegmentUsage = async (
   const metrics = await getMetricsUsingSegment(context, id);
 
   // experiments:
-  const experiments = await getExperimentsUsingSegment(id, context);
+  const experiments = await getExperimentsUsingSegment(context, id);
 
   res.status(200).json({
     ideas,
@@ -297,7 +297,7 @@ export const deleteSegment = async (
   // metrics
   await removeSegmentFromAllMetrics(org.id, id);
 
-  await deleteExperimentSegment(context, res.locals.eventAudit, id);
+  await deleteExperimentSegment(context, id);
 
   res.status(200).json({
     status: 200,

--- a/packages/back-end/src/routers/tag/tag.controller.ts
+++ b/packages/back-end/src/routers/tag/tag.controller.ts
@@ -72,7 +72,6 @@ export const deleteTag = async (
   // experiments
   await removeTagFromExperiments({
     context,
-    user: res.locals.eventAudit,
     tag: id,
   });
 
@@ -80,7 +79,7 @@ export const deleteTag = async (
   await removeTagInMetrics(org.id, id);
 
   // features
-  await removeTagInFeature(context, res.locals.eventAudit, id);
+  await removeTagInFeature(context, id);
 
   // Slack integrations
   await removeTagFromSlackIntegration({ organizationId: org.id, tag: id });

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -92,7 +92,6 @@ import {
   putMetricValidator,
   updateExperimentValidator,
 } from "../validators/openapi";
-import { EventAuditUser } from "../events/event-types";
 import { VisualChangesetInterface } from "../../types/visual-changeset";
 import { findProjectById } from "../models/ProjectModel";
 import { MetricAnalysisQueryRunner } from "../queryRunners/MetricAnalysisQueryRunner";

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -175,9 +175,9 @@ export async function refreshMetric(
     to.setDate(to.getDate() + 1);
 
     const queryRunner = new MetricAnalysisQueryRunner(
+      context,
       metric,
-      integration,
-      context
+      integration
     );
     await queryRunner.startAnalysis({
       from,
@@ -542,7 +542,6 @@ export function determineNextDate(schedule: ExperimentUpdateSchedule | null) {
 export async function createSnapshot({
   experiment,
   context,
-  user = null,
   phaseIndex,
   useCache = false,
   defaultAnalysisSettings,
@@ -553,7 +552,6 @@ export async function createSnapshot({
 }: {
   experiment: ExperimentInterface;
   context: ReqContext | ApiReqContext;
-  user?: EventAuditUser;
   phaseIndex: number;
   useCache?: boolean;
   defaultAnalysisSettings: ExperimentSnapshotAnalysisSettings;
@@ -615,7 +613,6 @@ export async function createSnapshot({
   await updateExperiment({
     context,
     experiment,
-    user,
     changes: {
       lastSnapshotAttempt: new Date(),
       nextSnapshotAttempt: nextUpdate,
@@ -632,9 +629,9 @@ export async function createSnapshot({
   );
 
   const queryRunner = new ExperimentResultsQueryRunner(
+    context,
     snapshot,
     integration,
-    context,
     useCache
   );
   await queryRunner.startAnalysis({

--- a/packages/back-end/src/services/notebook.ts
+++ b/packages/back-end/src/services/notebook.ts
@@ -64,8 +64,8 @@ export async function generateReportNotebook(
 }
 
 export async function generateExperimentNotebook(
-  snapshotId: string,
-  context: ReqContext
+  context: ReqContext,
+  snapshotId: string
 ): Promise<string> {
   // Get snapshot
   const snapshot = await findSnapshotById(context.org.id, snapshotId);


### PR DESCRIPTION
This is a general cleanup PR. When we first introduced the backend `context` object, it didn't contain the `auditUser`. However, it was later added in [PR 2007](https://github.com/growthbook/growthbook/pull/2007). This PR updates the function signatures whenever we were passing in both the `context` object and the `user: EventAuditUser`, as we can now get that from the `context` object.

This PR also updates the constructor function signature for the QueryRunner service so that the `context` object is the first param, which is a pattern we've also defined.

### Testing
- [x] - Ensure the build builds as expected
- [x] Create a feature flag
- [x] Create an experiment
- [x] Create a metric
- [x] Update an existing feature flag
- [x] Update an existing metric
- [x] Generally move around the app and ensure no regressions were introduced
