### PR TITLE
Fixes issue where MoreMenu wasn't being displayed due to a z-index issue

### DIFF
--- a/packages/front-end/components/Dropdown/MoreMenu.tsx
+++ b/packages/front-end/components/Dropdown/MoreMenu.tsx
@@ -13,8 +13,9 @@ import useGlobalMenu from "@/services/useGlobalMenu";
 const MoreMenu: FC<{
   autoCloseOnClick?: boolean;
   className?: string;
+  zIndex?: number;
   children: ReactNode;
-}> = ({ children, autoCloseOnClick = true, className = "" }) => {
+}> = ({ children, autoCloseOnClick = true, className = "", zIndex = 1020 }) => {
   const [open, setOpen] = useState(false);
   const [id] = useState(() => uniqId("more_menu_"));
   useGlobalMenu(`#${id}`, () => setOpen(false));
@@ -58,7 +59,7 @@ const MoreMenu: FC<{
             }
           }}
           ref={refs.setFloating}
-          style={{ ...floatingStyles, zIndex: 1020, width: "max-content" }}
+          style={{ ...floatingStyles, zIndex, width: "max-content" }}
         >
           {children}
         </div>

--- a/packages/front-end/components/Features/SortableFeatureVariationRow.tsx
+++ b/packages/front-end/components/Features/SortableFeatureVariationRow.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/services/features";
 import MoreMenu from "../Dropdown/MoreMenu";
 import Field from "../Forms/Field";
+import Tooltip from "../Tooltip/Tooltip";
 import FeatureValueField from "./FeatureValueField";
 import styles from "./VariationsInput.module.scss";
 
@@ -181,33 +182,38 @@ export const VariationRow = forwardRef<HTMLTableRowElement, VariationProps>(
             )}
             {setVariations && (
               <div className="col-auto">
-                <MoreMenu>
-                  <button
-                    disabled={variations.length <= 2}
-                    className={clsx(
-                      "dropdown-item",
-                      variations.length > 2 && "text-danger"
-                    )}
-                    onClick={(e) => {
-                      e.preventDefault();
-
-                      const newValues = [...variations];
-                      newValues.splice(i, 1);
-
-                      const newWeights = distributeWeights(
-                        newValues.map((v) => v.weight),
-                        customSplit
-                      );
-
-                      newValues.forEach((v, j) => {
-                        v.weight = newWeights[j] || 0;
-                      });
-                      setVariations(newValues);
-                    }}
-                    type="button"
+                <MoreMenu zIndex={1000000}>
+                  <Tooltip
+                    body="Experiments must have atleast two variations"
+                    shouldDisplay={variations.length <= 2}
                   >
-                    remove
-                  </button>
+                    <button
+                      disabled={variations.length <= 2}
+                      className={clsx(
+                        "dropdown-item",
+                        variations.length > 2 && "text-danger"
+                      )}
+                      onClick={(e) => {
+                        e.preventDefault();
+
+                        const newValues = [...variations];
+                        newValues.splice(i, 1);
+
+                        const newWeights = distributeWeights(
+                          newValues.map((v) => v.weight),
+                          customSplit
+                        );
+
+                        newValues.forEach((v, j) => {
+                          v.weight = newWeights[j] || 0;
+                        });
+                        setVariations(newValues);
+                      }}
+                      type="button"
+                    >
+                      remove
+                    </button>
+                  </Tooltip>
                 </MoreMenu>
               </div>
             )}


### PR DESCRIPTION
### Features and Changes

There was a Z-index issue with the `<MoreMenu>` component within `SortableFeatureVariationRow` that was causing the `MoreMenu` to render behind the modal.

Looking into this, our `Modal` components have a zIndex of `999999` - this PR updates the `MoreMenu` to take in an optional zIndex prop. In this case, I've just passed in a zIndex of `1000000` (aka, 1 more than the `Modal's` zIndex.

I don't love doing this, but it feels like the safer approach vs updating the `Modal` component's default zIndex.

### Testing

- [x] Ensure the `MoreMenu` is displayed in front of the `Modal` component
- [x] Go to other instances of the `MoreMenu` and ensure if no `zIndex` is passed in, it defaults to `1020`.
- [x] Go throughout the App where we have `MoreMenu` and `Modals` and ensure that we haven't introduced any other bugs/regressions.

### Screenshots

After the changes, the `MoreMenu` is now visible
<img width="785" alt="Screen Shot 2024-02-09 at 8 09 15 AM" src="https://github.com/growthbook/growthbook/assets/75274610/cfa5c6ae-d93a-49cd-af37-26192c73de09">

I also added a `ToolTip` message for when there are 2 or less variations that outlines why the `Delete` option is disabled.
<img width="795" alt="Screen Shot 2024-02-09 at 8 09 24 AM" src="https://github.com/growthbook/growthbook/assets/75274610/e9cf75c6-89d7-4353-a8c4-4747e61965ec">

