### PR TITLE
New Initial SDK Connection Form

### DIFF
--- a/packages/front-end/components/Features/SDKConnections/InitialSDKConnectionForm.tsx
+++ b/packages/front-end/components/Features/SDKConnections/InitialSDKConnectionForm.tsx
@@ -71,6 +71,7 @@ export default function InitialSDKConnectionForm({
       close={close}
       edit={false}
       mutate={mutate}
+      cta={"Continue"}
       autoCloseOnSubmit={false}
     />
   );

--- a/packages/front-end/components/Features/SDKConnections/InitialSDKConnectionForm.tsx
+++ b/packages/front-end/components/Features/SDKConnections/InitialSDKConnectionForm.tsx
@@ -71,7 +71,6 @@ export default function InitialSDKConnectionForm({
       close={close}
       edit={false}
       mutate={mutate}
-      initialValue={{}}
       autoCloseOnSubmit={false}
     />
   );

--- a/packages/front-end/components/Features/SDKConnections/InitialSDKConnectionForm.tsx
+++ b/packages/front-end/components/Features/SDKConnections/InitialSDKConnectionForm.tsx
@@ -1,20 +1,10 @@
-import {
-  CreateSDKConnectionParams,
-  SDKConnectionInterface,
-  SDKLanguage,
-} from "back-end/types/sdk-connection";
-import { useForm } from "react-hook-form";
+import { SDKConnectionInterface } from "back-end/types/sdk-connection";
 import React, { ReactElement, useEffect, useState } from "react";
 import { FeatureInterface } from "back-end/types/feature";
 import LoadingOverlay from "@/components/LoadingOverlay";
-import Modal from "@/components/Modal";
-import { useAuth } from "@/services/auth";
-import Field from "@/components/Forms/Field";
-import { useEnvironments } from "@/services/features";
 import useSDKConnections from "@/hooks/useSDKConnections";
-import track from "@/services/track";
 import CodeSnippetModal from "../CodeSnippetModal";
-import SDKLanguageSelector from "./SDKLanguageSelector";
+import SDKConnectionForm from "./SDKConnectionForm";
 
 export default function InitialSDKConnectionForm({
   close,
@@ -36,7 +26,6 @@ export default function InitialSDKConnectionForm({
   const { data, error, mutate } = useSDKConnections();
   const connections = data?.connections;
 
-  const { apiCall } = useAuth();
   const [
     currentConnection,
     setCurrentConnection,
@@ -51,15 +40,6 @@ export default function InitialSDKConnectionForm({
       }
     });
   }, [connections]);
-
-  const environments = useEnvironments();
-
-  const form = useForm<{ name: string; languages: SDKLanguage[] }>({
-    defaultValues: {
-      name: "",
-      languages: [],
-    },
-  });
 
   if (error) {
     return <div className="alert alert-danger">{error.message}</div>;
@@ -87,58 +67,12 @@ export default function InitialSDKConnectionForm({
   }
 
   return (
-    <Modal
-      open={true}
-      inline={inline}
+    <SDKConnectionForm
       close={close}
-      secondaryCTA={secondaryCTA}
-      cta="Continue"
-      header="Create your first SDK connection"
+      edit={false}
+      mutate={mutate}
+      initialValue={{}}
       autoCloseOnSubmit={false}
-      submit={form.handleSubmit(async (value) => {
-        if (!value.languages.length) {
-          value.languages = ["other"];
-        }
-
-        const body: Omit<CreateSDKConnectionParams, "organization"> = {
-          name: value.name,
-          languages: value.languages,
-          encryptPayload: false,
-          hashSecureAttributes: false,
-          remoteEvalEnabled: false,
-          includeVisualExperiments: false,
-          includeDraftExperiments: false,
-          includeExperimentNames: false,
-          environment: environments[0]?.id || "production",
-          projects: [],
-          proxyEnabled: false,
-          proxyHost: "",
-        };
-        await apiCall(`/sdk-connections`, {
-          method: "POST",
-          body: JSON.stringify(body),
-        });
-        track("Create SDK Connection", {
-          source: "initialSDKConnectionForm",
-          languages: body.languages,
-          encryptPayload: body.encryptPayload,
-          hashSecureAttributes: body.hashSecureAttributes,
-          proxyEnabled: body.proxyEnabled,
-        });
-        await mutate();
-      })}
-    >
-      <Field label="Name of your app" {...form.register("name")} required />
-
-      <div className="form-group">
-        <label>SDK Language</label>
-        <SDKLanguageSelector
-          value={form.watch("languages")}
-          setValue={(languages) => form.setValue("languages", languages)}
-          multiple={false}
-          includeOther={true}
-        />
-      </div>
-    </Modal>
+    />
   );
 }

--- a/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
+++ b/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
@@ -53,12 +53,14 @@ export default function SDKConnectionForm({
   close,
   mutate,
   autoCloseOnSubmit = true,
+  cta = "Save",
 }: {
   initialValue?: Partial<SDKConnectionInterface>;
   edit: boolean;
   close?: () => void;
   mutate: () => void;
   autoCloseOnSubmit?: boolean;
+  cta?: string;
 }) {
   const environments = useEnvironments();
   const { project, projects, getProjectById } = useDefinitions();
@@ -305,7 +307,7 @@ export default function SDKConnectionForm({
       }}
       close={close}
       open={true}
-      cta="Save"
+      cta={cta}
     >
       <div className="px-2">
         <Field label="Name" {...form.register("name")} required />

--- a/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
+++ b/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
@@ -52,11 +52,13 @@ export default function SDKConnectionForm({
   edit,
   close,
   mutate,
+  autoCloseOnSubmit = true,
 }: {
   initialValue?: Partial<SDKConnectionInterface>;
   edit: boolean;
-  close: () => void;
+  close?: () => void;
   mutate: () => void;
+  autoCloseOnSubmit?: boolean;
 }) {
   const environments = useEnvironments();
   const { project, projects, getProjectById } = useDefinitions();
@@ -242,6 +244,7 @@ export default function SDKConnectionForm({
     <Modal
       header={edit ? "Edit SDK Connection" : "New SDK Connection"}
       size={"lg"}
+      autoCloseOnSubmit={autoCloseOnSubmit}
       error={form.formState.errors.languages?.message}
       submit={form.handleSubmit(async (value) => {
         // filter for visual experiments
@@ -285,7 +288,9 @@ export default function SDKConnectionForm({
             proxyEnabled: value.proxyEnabled,
           });
           mutate();
-          await router.push(`/sdks/${res.connection.id}`);
+          if (autoCloseOnSubmit) {
+            await router.push(`/sdks/${res.connection.id}`);
+          }
         }
       })}
       customValidation={() => {
@@ -439,7 +444,7 @@ export default function SDKConnectionForm({
                         }
                       >
                         <div className="subtitle">
-                          High cacheable, but may leak sensitive info to users
+                          Highly cacheable, but may leak sensitive info to users
                           <FaInfoCircle className="ml-1" />
                         </div>
                       </Tooltip>

--- a/packages/front-end/components/GuidedGetStarted/CheckSDKConnectionResults.tsx
+++ b/packages/front-end/components/GuidedGetStarted/CheckSDKConnectionResults.tsx
@@ -58,8 +58,7 @@ export default function TestConnectionResults({
           <h2 className={styles.notConnected}>Status: Not Connected</h2>
           <p>
             Something isn&apos;t quite right. Please double check that
-            you&apos;ve created a feature flag and implemented the SDK
-            instructions correctly.{" "}
+            you&apos;ve implemented the SDK instructions correctly.{" "}
             <a href="#" onClick={close} className="pl-1">
               View Implementation Instructions.
             </a>


### PR DESCRIPTION
### Features and Changes

The initial SDK Connection form presented during onboarding was missing many of the recent features that have been added to that form.  This PR brings this up-to-date.

Specifically, it's missing the following:
- SDK Language Version Selector
- Environment selector
- Project selector (when projects are configured)
- Payload security settings (front-end / mobile only)
- Visual editor settings (front-end only) 


Existing form (same for back-end and front-end):

![image](https://github.com/growthbook/growthbook/assets/1087514/e226d8ee-f731-43e1-90d7-8303535fa1ea)

New form (back-end):

![image](https://github.com/growthbook/growthbook/assets/1087514/44d7c8c6-91ed-4cc9-97c9-1ace58f3baaa)

New form (front-end):

![image](https://github.com/growthbook/growthbook/assets/1087514/77cbfe96-10ca-4c46-8a4b-ec820d3585bd)

