### PR TITLE
don't cache error responses in feature repository

### DIFF
--- a/packages/sdk-js/src/feature-repository.ts
+++ b/packages/sdk-js/src/feature-repository.ts
@@ -406,6 +406,9 @@ async function fetchFeatures(
     // TODO: auto-retry if status code indicates a temporary error
     promise = fetcher
       .then((res) => {
+        if (!res.ok) {
+          throw new Error(`HTTP error: ${res.status}`);
+        }
         if (res.headers.get("x-sse-support") === "enabled") {
           supportsSSE.add(key);
         }

--- a/packages/sdk-js/test/feature-repo.test.ts
+++ b/packages/sdk-js/test/feature-repo.test.ts
@@ -41,6 +41,8 @@ function mockApi(
     return new Promise((resolve) => {
       setTimeout(() => {
         resolve({
+          status: data ? 200 : 500,
+          ok: !!data,
           headers: {
             get: (header: string) =>
               header === "x-sse-support" && supportSSE ? "enabled" : undefined,

--- a/packages/sdk-js/test/remote-eval.test.ts
+++ b/packages/sdk-js/test/remote-eval.test.ts
@@ -44,6 +44,8 @@ function mockApi(
     return new Promise((resolve) => {
       setTimeout(() => {
         resolve({
+          status: data ? 200 : 500,
+          ok: !!data,
           headers: {
             get: (header: string) =>
               header === "x-sse-support" && supportSSE ? "enabled" : undefined,

--- a/packages/sdk-js/test/sticky-buckets.test.ts
+++ b/packages/sdk-js/test/sticky-buckets.test.ts
@@ -48,6 +48,8 @@ function mockApi(
     return new Promise((resolve) => {
       setTimeout(() => {
         resolve({
+          status: data ? 200 : 500,
+          ok: !!data,
           headers: {
             get: (header: string) =>
               header === "x-sse-support" && supportSSE ? "enabled" : undefined,
@@ -84,6 +86,8 @@ function mockRemoteEvalApi(
     return new Promise((resolve) => {
       setTimeout(() => {
         resolve({
+          status: data ? 200 : 500,
+          ok: !!data,
           headers: {
             get: (header: string) =>
               header === "x-sse-support" && supportSSE ? "enabled" : undefined,


### PR DESCRIPTION
### Features and Changes

Don't cache error payloads in the feature repository if `resp.ok` is not true.

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

<!--
  Please describe how to test these changes.
 -->

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
