### PR TITLE
allow no-auth smtp configuration

### DIFF
--- a/packages/back-end/src/services/email.ts
+++ b/packages/back-end/src/services/email.ts
@@ -14,16 +14,11 @@ import {
 } from "../util/secrets";
 import { OrganizationInterface } from "../../types/organization";
 import { getEmailFromUserId, getInviteUrl } from "./organizations";
-export function isEmailEnabled(): boolean {
-  if (!EMAIL_ENABLED) return false;
-  if (!EMAIL_HOST) return false;
-  if (!EMAIL_PORT) return false;
-  if (!EMAIL_HOST_USER) return false;
-  if (!EMAIL_HOST_PASSWORD) return false;
-  if (!EMAIL_FROM) return false;
 
-  return true;
+export function isEmailEnabled(): boolean {
+  return !!(EMAIL_ENABLED && EMAIL_HOST && EMAIL_PORT && EMAIL_FROM);
 }
+
 nunjucks.configure(path.join(__dirname, "..", "templates", "email"), {
   autoescape: true,
 });
@@ -33,10 +28,13 @@ const transporter = isEmailEnabled()
       host: EMAIL_HOST,
       port: EMAIL_PORT,
       secure: EMAIL_PORT === 465,
-      auth: {
-        user: EMAIL_HOST_USER,
-        pass: EMAIL_HOST_PASSWORD,
-      },
+      ...(EMAIL_HOST_USER &&
+        EMAIL_HOST_PASSWORD && {
+          auth: {
+            user: EMAIL_HOST_USER,
+            pass: EMAIL_HOST_PASSWORD,
+          },
+        }),
     })
   : null;
 
@@ -74,6 +72,7 @@ async function sendMail({
     headers,
   });
 }
+
 export async function sendInviteEmail(
   organization: OrganizationInterface,
   key: string


### PR DESCRIPTION
### Features and Changes

Tweak SMTP configuration, enabling support for SMTP servers that do not require authentication.