### PR TITLE
Introduces the concept of read only type permissions

### DIFF
--- a/packages/back-end/src/controllers/datasources.ts
+++ b/packages/back-end/src/controllers/datasources.ts
@@ -513,7 +513,7 @@ export async function putDataSource(
     });
     return;
   }
-
+  // Require higher permissions to change connection settings vs updating query settings
   const permissionLevel = params
     ? "createDatasources"
     : "editDatasourceSettings";

--- a/packages/back-end/src/controllers/datasources.ts
+++ b/packages/back-end/src/controllers/datasources.ts
@@ -514,7 +514,10 @@ export async function putDataSource(
     return;
   }
 
-  req.checkPermissions("editDatasourceSettings", datasource.projects);
+  req.checkPermissions(
+    "editDatasourceSettings",
+    datasource?.projects?.length ? datasource.projects : []
+  );
 
   if (type && type !== datasource.type) {
     res.status(400).json({

--- a/packages/back-end/src/controllers/datasources.ts
+++ b/packages/back-end/src/controllers/datasources.ts
@@ -514,9 +514,12 @@ export async function putDataSource(
     return;
   }
 
+  const permissionLevel = params
+    ? "createDatasources"
+    : "editDatasourceSettings";
   req.checkPermissions(
-    "editDatasourceSettings",
-    datasource?.projects?.length ? datasource.projects : []
+    permissionLevel,
+    datasource?.projects?.length ? datasource.projects : ""
   );
 
   if (type && type !== datasource.type) {
@@ -570,7 +573,7 @@ export async function putDataSource(
     }
 
     if (updates?.projects?.length) {
-      req.checkPermissions("editDatasourceSettings", updates.projects);
+      req.checkPermissions(permissionLevel, updates.projects);
     }
 
     // If the connection params changed, re-validate the connection

--- a/packages/back-end/src/controllers/datasources.ts
+++ b/packages/back-end/src/controllers/datasources.ts
@@ -513,14 +513,8 @@ export async function putDataSource(
     });
     return;
   }
-  // Require higher permissions to change connection settings vs updating query settings
-  const permissionLevel = params
-    ? "createDatasources"
-    : "editDatasourceSettings";
-  req.checkPermissions(
-    permissionLevel,
-    datasource?.projects?.length ? datasource.projects : ""
-  );
+
+  req.checkPermissions("editDatasourceSettings", datasource.projects);
 
   if (type && type !== datasource.type) {
     res.status(400).json({
@@ -573,7 +567,7 @@ export async function putDataSource(
     }
 
     if (updates?.projects?.length) {
-      req.checkPermissions(permissionLevel, updates.projects);
+      req.checkPermissions("editDatasourceSettings", updates.projects);
     }
 
     // If the connection params changed, re-validate the connection

--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -2130,7 +2130,10 @@ export async function postPastExperiments(
   if (!datasourceObj) {
     throw new Error("Could not find datasource");
   }
-  req.checkPermissions("runQueries", datasourceObj.projects);
+  req.checkPermissions(
+    "runQueries",
+    datasourceObj?.projects?.length ? datasourceObj.projects : []
+  );
 
   const integration = getSourceIntegrationObject(datasourceObj, true);
 

--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -2130,10 +2130,7 @@ export async function postPastExperiments(
   if (!datasourceObj) {
     throw new Error("Could not find datasource");
   }
-  req.checkPermissions(
-    "runQueries",
-    datasourceObj?.projects?.length ? datasourceObj.projects : ""
-  );
+  req.checkPermissions("runQueries", datasourceObj.projects);
 
   const integration = getSourceIntegrationObject(datasourceObj, true);
 

--- a/packages/back-end/src/controllers/metrics.ts
+++ b/packages/back-end/src/controllers/metrics.ts
@@ -221,7 +221,10 @@ export async function postMetricAnalysis(
     });
   }
 
-  req.checkPermissions("runQueries", metric.projects);
+  req.checkPermissions(
+    "runQueries",
+    metric.projects?.length ? metric.projects : []
+  );
 
   try {
     await refreshMetric(

--- a/packages/back-end/src/controllers/metrics.ts
+++ b/packages/back-end/src/controllers/metrics.ts
@@ -221,10 +221,7 @@ export async function postMetricAnalysis(
     });
   }
 
-  req.checkPermissions(
-    "runQueries",
-    metric.projects?.length ? metric.projects : ""
-  );
+  req.checkPermissions("runQueries", metric.projects);
 
   try {
     await refreshMetric(

--- a/packages/back-end/src/routers/fact-table/fact-table.controller.ts
+++ b/packages/back-end/src/routers/fact-table/fact-table.controller.ts
@@ -100,7 +100,7 @@ export const postFactTable = async (
   if (!datasource) {
     throw new Error("Could not find datasource");
   }
-  req.checkPermissions("runQueries", datasource.projects);
+  req.checkPermissions("runQueries", datasource.projects || []);
 
   data.columns = await runRefreshColumnsQuery(
     datasource,
@@ -143,7 +143,7 @@ export const putFactTable = async (
   if (!datasource) {
     throw new Error("Could not find datasource");
   }
-  req.checkPermissions("runQueries", datasource.projects);
+  req.checkPermissions("runQueries", datasource.projects || []);
 
   // Update the columns
   data.columns = await runRefreshColumnsQuery(datasource, {
@@ -226,7 +226,7 @@ export const postFactFilterTest = async (
   if (!datasource) {
     throw new Error("Could not find datasource");
   }
-  req.checkPermissions("runQueries", datasource.projects);
+  req.checkPermissions("runQueries", datasource.projects || []);
 
   const result = await testFilterQuery(datasource, factTable, data.value);
 
@@ -254,7 +254,7 @@ export const postFactFilter = async (
   if (!datasource) {
     throw new Error("Could not find datasource");
   }
-  req.checkPermissions("runQueries", datasource.projects);
+  req.checkPermissions("runQueries", datasource.projects || []);
 
   const filter = await createFactFilter(factTable, data);
 
@@ -287,7 +287,7 @@ export const putFactFilter = async (
     if (!datasource) {
       throw new Error("Could not find datasource");
     }
-    req.checkPermissions("runQueries", datasource.projects);
+    req.checkPermissions("runQueries", datasource.projects || []);
   }
 
   await updateFactFilter(context, factTable, req.params.filterId, data);

--- a/packages/back-end/src/routers/fact-table/fact-table.controller.ts
+++ b/packages/back-end/src/routers/fact-table/fact-table.controller.ts
@@ -100,7 +100,7 @@ export const postFactTable = async (
   if (!datasource) {
     throw new Error("Could not find datasource");
   }
-  req.checkPermissions("runQueries", datasource.projects || "");
+  req.checkPermissions("runQueries", datasource.projects);
 
   data.columns = await runRefreshColumnsQuery(
     datasource,
@@ -143,7 +143,7 @@ export const putFactTable = async (
   if (!datasource) {
     throw new Error("Could not find datasource");
   }
-  req.checkPermissions("runQueries", datasource.projects || "");
+  req.checkPermissions("runQueries", datasource.projects);
 
   // Update the columns
   data.columns = await runRefreshColumnsQuery(datasource, {
@@ -226,7 +226,7 @@ export const postFactFilterTest = async (
   if (!datasource) {
     throw new Error("Could not find datasource");
   }
-  req.checkPermissions("runQueries", datasource.projects || "");
+  req.checkPermissions("runQueries", datasource.projects);
 
   const result = await testFilterQuery(datasource, factTable, data.value);
 
@@ -254,7 +254,7 @@ export const postFactFilter = async (
   if (!datasource) {
     throw new Error("Could not find datasource");
   }
-  req.checkPermissions("runQueries", datasource.projects || "");
+  req.checkPermissions("runQueries", datasource.projects);
 
   const filter = await createFactFilter(factTable, data);
 
@@ -287,7 +287,7 @@ export const putFactFilter = async (
     if (!datasource) {
       throw new Error("Could not find datasource");
     }
-    req.checkPermissions("runQueries", datasource.projects || "");
+    req.checkPermissions("runQueries", datasource.projects);
   }
 
   await updateFactFilter(context, factTable, req.params.filterId, data);

--- a/packages/back-end/src/services/auth/index.ts
+++ b/packages/back-end/src/services/auth/index.ts
@@ -103,6 +103,14 @@ export async function processJWT(
     }
 
     if (READ_ONLY_PERMISSIONS.includes(permission)) {
+      if (
+        projects.length === 1 &&
+        projects[0] === undefined &&
+        Object.keys(userPermissions.projects).length
+      ) {
+        // check to see if the user has permission globally or via any of their project specific permissions
+        projects.push(...Object.keys(userPermissions.projects));
+      }
       // Read only type permissions grant permission if the user has the permission globally or in atleast 1 project
       return projects.some((p) =>
         hasPermission(userPermissions, permission, p, envs)
@@ -130,12 +138,7 @@ export async function processJWT(
     );
     let checkProjects: (string | undefined)[];
     if (Array.isArray(project)) {
-      checkProjects =
-        project.length > 0
-          ? project
-          : Object.keys(userPermissions.projects).length
-          ? Object.keys(userPermissions.projects)
-          : [undefined];
+      checkProjects = project.length > 0 ? project : [undefined];
     } else {
       checkProjects = [project];
     }

--- a/packages/back-end/src/services/auth/index.ts
+++ b/packages/back-end/src/services/auth/index.ts
@@ -25,7 +25,6 @@ import {
   EventAuditUserLoggedIn,
 } from "../../events/event-types";
 import { insertAudit } from "../../models/AuditModel";
-import { TeamInterface } from "../../../types/team";
 import { getTeamsForOrganization } from "../../models/TeamModel";
 import { initializeLicense } from "../licenseData";
 import { AuthConnection } from "./AuthConnection";

--- a/packages/back-end/src/services/auth/index.ts
+++ b/packages/back-end/src/services/auth/index.ts
@@ -73,6 +73,7 @@ function getInitialDataFromJWT(user: IdToken): JWTInfo {
 }
 
 export async function processJWT(
+  // eslint-disable-next-line
   req: AuthRequest & { user: IdToken },
   res: Response<unknown, EventAuditUserForResponseLocals>,
   next: NextFunction

--- a/packages/back-end/src/services/auth/index.ts
+++ b/packages/back-end/src/services/auth/index.ts
@@ -92,7 +92,6 @@ export async function processJWT(
   const userHasPermission = (
     userPermissions: UserPermissions,
     permission: Permission,
-    teams: TeamInterface[],
     projects: (string | undefined)[],
     envs?: string[]
   ): boolean => {
@@ -133,7 +132,11 @@ export async function processJWT(
     let checkProjects: (string | undefined)[];
     if (Array.isArray(project)) {
       checkProjects =
-        project.length > 0 ? project : Object.keys(userPermissions.projects);
+        project.length > 0
+          ? project
+          : Object.keys(userPermissions.projects).length
+          ? Object.keys(userPermissions.projects)
+          : [undefined];
     } else {
       checkProjects = [project];
     }
@@ -142,7 +145,6 @@ export async function processJWT(
       !userHasPermission(
         userPermissions,
         permission,
-        req.teams,
         checkProjects,
         envs ? [...envs] : undefined
       )

--- a/packages/back-end/src/util/organization.util.ts
+++ b/packages/back-end/src/util/organization.util.ts
@@ -62,8 +62,6 @@ export const ALL_PERMISSIONS = [
   ...ENV_SCOPED_PERMISSIONS,
 ];
 
-export const READ_ONLY_PERMISSIONS = ["readData", "viewEvents", "runQueries"];
-
 function hasEnvScopedPermissions(userPermission: PermissionsObject): boolean {
   const envLimitedPermissions: Permission[] = ENV_SCOPED_PERMISSIONS.map(
     (permission) => permission

--- a/packages/back-end/src/util/organization.util.ts
+++ b/packages/back-end/src/util/organization.util.ts
@@ -1,5 +1,9 @@
 import { cloneDeep } from "lodash";
-import { roleSupportsEnvLimit } from "shared/permissions";
+import {
+  ALL_PERMISSIONS,
+  ENV_SCOPED_PERMISSIONS,
+  roleSupportsEnvLimit,
+} from "shared/permissions";
 import {
   MemberRole,
   MemberRoleInfo,
@@ -12,55 +16,6 @@ import {
   UserPermissions,
 } from "../../types/organization";
 import { TeamInterface } from "../../types/team";
-
-export const ENV_SCOPED_PERMISSIONS = [
-  "publishFeatures",
-  "manageEnvironments",
-  "runExperiments",
-] as const;
-
-export const PROJECT_SCOPED_PERMISSIONS = [
-  "readData",
-  "addComments",
-  "createFeatureDrafts",
-  "manageFeatures",
-  "manageProjects",
-  "createAnalyses",
-  "createIdeas",
-  "createMetrics",
-  "manageFactTables",
-  "createDatasources",
-  "editDatasourceSettings",
-  "runQueries",
-  "manageVisualChanges",
-] as const;
-
-export const GLOBAL_PERMISSIONS = [
-  "readData",
-  "createPresentations",
-  "createDimensions",
-  "createSegments",
-  "organizationSettings",
-  "superDelete",
-  "manageTeam",
-  "manageTags",
-  "manageApiKeys",
-  "manageIntegrations",
-  "manageWebhooks",
-  "manageBilling",
-  "manageNorthStarMetric",
-  "manageTargetingAttributes",
-  "manageNamespaces",
-  "manageSavedGroups",
-  "manageArchetype",
-  "viewEvents",
-] as const;
-
-export const ALL_PERMISSIONS = [
-  ...GLOBAL_PERMISSIONS,
-  ...PROJECT_SCOPED_PERMISSIONS,
-  ...ENV_SCOPED_PERMISSIONS,
-];
 
 function hasEnvScopedPermissions(userPermission: PermissionsObject): boolean {
   const envLimitedPermissions: Permission[] = ENV_SCOPED_PERMISSIONS.map(

--- a/packages/back-end/src/util/organization.util.ts
+++ b/packages/back-end/src/util/organization.util.ts
@@ -62,6 +62,8 @@ export const ALL_PERMISSIONS = [
   ...ENV_SCOPED_PERMISSIONS,
 ];
 
+export const READ_ONLY_PERMISSIONS = ["readData", "viewEvents", "runQueries"];
+
 function hasEnvScopedPermissions(userPermission: PermissionsObject): boolean {
   const envLimitedPermissions: Permission[] = ENV_SCOPED_PERMISSIONS.map(
     (permission) => permission

--- a/packages/back-end/types/organization.d.ts
+++ b/packages/back-end/types/organization.d.ts
@@ -1,10 +1,10 @@
 import Stripe from "stripe";
-import { ReadAccessFilter } from "shared/permissions";
 import {
   ENV_SCOPED_PERMISSIONS,
   GLOBAL_PERMISSIONS,
   PROJECT_SCOPED_PERMISSIONS,
-} from "../src/util/organization.util";
+  ReadAccessFilter,
+} from "shared/permissions";
 import { EventAuditUser } from "../src/events/event-types";
 import { AttributionModel, ImplementationType } from "./experiment";
 import type { PValueCorrection, StatsEngine } from "./stats";

--- a/packages/front-end/components/Experiment/ImportExperimentModal.tsx
+++ b/packages/front-end/components/Experiment/ImportExperimentModal.tsx
@@ -5,6 +5,7 @@ import { useDefinitions } from "@/services/DefinitionsContext";
 import { useAuth } from "@/services/auth";
 import useOrgSettings from "@/hooks/useOrgSettings";
 import Modal from "../Modal";
+import SelectField from "../Forms/SelectField";
 import ImportExperimentList from "./ImportExperimentList";
 import NewExperimentForm from "./NewExperimentForm";
 
@@ -29,6 +30,7 @@ const ImportExperimentModal: FC<{
   ] = useState<null | Partial<ExperimentInterfaceStringDates>>(
     initialValue ?? null
   );
+  const [error, setError] = useState<string | null>(null);
   const [importModal, setImportModal] = useState<boolean>(importMode);
   const [datasourceId, setDatasourceId] = useState(() => {
     const validDatasources = datasources
@@ -53,6 +55,7 @@ const ImportExperimentModal: FC<{
   const { apiCall } = useAuth();
 
   const getImportId = async () => {
+    setError(null);
     if (datasourceId) {
       try {
         const res = await apiCall<{ id: string }>("/experiments/import", {
@@ -65,6 +68,9 @@ const ImportExperimentModal: FC<{
           setImportId(res.id);
         }
       } catch (e) {
+        setError(
+          e.message ?? "An error occurred. Please refresh and try again."
+        );
         console.error(e);
       }
     }
@@ -115,6 +121,17 @@ const ImportExperimentModal: FC<{
           importId={importId}
         />
       )}
+      {error ? (
+        <>
+          <div className="alert alert-danger">{error}</div>
+          <SelectField
+            label="Choose a Data Source"
+            value={datasourceId}
+            onChange={(value) => setDatasourceId(value)}
+            options={datasources.map((d) => ({ label: d.name, value: d.id }))}
+          />
+        </>
+      ) : null}
     </Modal>
   );
 };

--- a/packages/front-end/components/HomePage/NorthStarMetricDisplay.tsx
+++ b/packages/front-end/components/HomePage/NorthStarMetricDisplay.tsx
@@ -81,7 +81,7 @@ const NorthStarMetricDisplay = ({
         ) : (
           <div className="mb-4">
             <h4 className="my-3">{metric.name}</h4>
-            {permissions.check("runQueries", metric.projects) && (
+            {permissions.check("runQueries", metric.projects || []) && (
               <form
                 onSubmit={async (e) => {
                   e.preventDefault();

--- a/packages/front-end/components/HomePage/NorthStarMetricDisplay.tsx
+++ b/packages/front-end/components/HomePage/NorthStarMetricDisplay.tsx
@@ -81,7 +81,7 @@ const NorthStarMetricDisplay = ({
         ) : (
           <div className="mb-4">
             <h4 className="my-3">{metric.name}</h4>
-            {permissions.check("runQueries", metric.projects || "") && (
+            {permissions.check("runQueries", metric.projects) && (
               <form
                 onSubmit={async (e) => {
                   e.preventDefault();

--- a/packages/front-end/components/Layout/ProjectSelector.tsx
+++ b/packages/front-end/components/Layout/ProjectSelector.tsx
@@ -104,7 +104,7 @@ export default function ProjectSelector() {
   if (!projects.length) return null;
 
   // If globalRole doesn't give readAccess & user can only access 1 project, don't show dropdown
-  if (projects.length === 1 && !permissions.check("readData")) {
+  if (projects.length === 1 && !permissions.check("readData", "")) {
     setProject(projects[0].id);
     return (
       <li

--- a/packages/front-end/components/Settings/EditDataSource/DimensionMetadata/UpdateDimensionMetadata.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/DimensionMetadata/UpdateDimensionMetadata.tsx
@@ -242,7 +242,7 @@ export const DimensionSlicesRunner: FC<DimensionSlicesRunnerProps> = ({
       <div className="col-12">
         <div className="col-auto ml-auto">
           <div className="row align-items-center mb-3">
-            {permissions.check("runQueries", dataSource.projects || "") ? (
+            {permissions.check("runQueries", dataSource.projects) ? (
               <div className="mr-2">
                 <form
                   onSubmit={async (e) => {

--- a/packages/front-end/components/Settings/EditDataSource/DimensionMetadata/UpdateDimensionMetadata.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/DimensionMetadata/UpdateDimensionMetadata.tsx
@@ -242,7 +242,7 @@ export const DimensionSlicesRunner: FC<DimensionSlicesRunnerProps> = ({
       <div className="col-12">
         <div className="col-auto ml-auto">
           <div className="row align-items-center mb-3">
-            {permissions.check("runQueries", dataSource.projects) ? (
+            {permissions.check("runQueries", dataSource.projects || []) ? (
               <div className="mr-2">
                 <form
                   onSubmit={async (e) => {

--- a/packages/front-end/pages/datasources/[did].tsx
+++ b/packages/front-end/pages/datasources/[did].tsx
@@ -62,6 +62,12 @@ const DataSourcePage: FC = () => {
       !hasFileConfig()) ||
     false;
 
+  const canEditAndDelete =
+    (d &&
+      permissions.check("createDatasources", d.projects || []) &&
+      !hasFileConfig()) ||
+    false;
+
   const pipelineEnabled =
     useFeatureIsOn("datasource-pipeline-mode") &&
     hasCommercialFeature("pipeline-mode");
@@ -192,16 +198,17 @@ const DataSourcePage: FC = () => {
             {canEdit && (
               <div className="d-md-flex w-100 justify-content-between">
                 <div>
-                  <button
-                    className="btn btn-outline-primary mr-2 mt-1 font-weight-bold"
-                    onClick={(e) => {
-                      e.preventDefault();
-                      setEditConn(true);
-                    }}
-                  >
-                    <FaKey /> Edit Connection Info
-                  </button>
-
+                  {canEditAndDelete ? (
+                    <button
+                      className="btn btn-outline-primary mr-2 mt-1 font-weight-bold"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        setEditConn(true);
+                      }}
+                    >
+                      <FaKey /> Edit Connection Info
+                    </button>
+                  ) : null}
                   <DocLink
                     className="btn btn-outline-secondary mr-2 mt-1 font-weight-bold"
                     docSection={d.type as DocSection}
@@ -223,7 +230,7 @@ const DataSourcePage: FC = () => {
                 </div>
 
                 <div>
-                  {canEdit && (
+                  {canEditAndDelete && (
                     <DeleteButton
                       displayName={d.name}
                       className="font-weight-bold mt-1"

--- a/packages/front-end/pages/datasources/[did].tsx
+++ b/packages/front-end/pages/datasources/[did].tsx
@@ -58,7 +58,7 @@ const DataSourcePage: FC = () => {
 
   const canEdit =
     (d &&
-      permissions.check("editDatasourceSettings", d.projects) &&
+      permissions.check("editDatasourceSettings", d.projects || []) &&
       !hasFileConfig()) ||
     false;
 

--- a/packages/front-end/pages/datasources/[did].tsx
+++ b/packages/front-end/pages/datasources/[did].tsx
@@ -18,7 +18,6 @@ import { DataSourceInlineEditIdentityJoins } from "@/components/Settings/EditDat
 import { ExperimentAssignmentQueries } from "@/components/Settings/EditDataSource/ExperimentAssignmentQueries/ExperimentAssignmentQueries";
 import { DataSourceViewEditExperimentProperties } from "@/components/Settings/EditDataSource/DataSourceExperimentProperties/DataSourceViewEditExperimentProperties";
 import { DataSourceJupyterNotebookQuery } from "@/components/Settings/EditDataSource/DataSourceJupypterQuery/DataSourceJupyterNotebookQuery";
-import { checkDatasourceProjectPermissions } from "@/services/datasources";
 import ProjectBadges from "@/components/ProjectBadges";
 import usePermissions from "@/hooks/usePermissions";
 import DeleteButton from "@/components/DeleteButton/DeleteButton";
@@ -59,7 +58,7 @@ const DataSourcePage: FC = () => {
 
   const canEdit =
     (d &&
-      checkDatasourceProjectPermissions(d, permissions, "createDatasources") &&
+      permissions.check("editDatasourceSettings", d.projects) &&
       !hasFileConfig()) ||
     false;
 

--- a/packages/front-end/pages/metric/[mid].tsx
+++ b/packages/front-end/pages/metric/[mid].tsx
@@ -586,7 +586,7 @@ const MetricPage: FC = () => {
                               {canEditMetric &&
                                 permissions.check(
                                   "runQueries",
-                                  metric.projects
+                                  metric.projects || []
                                 ) && (
                                   <a
                                     onClick={(e) => {
@@ -603,7 +603,10 @@ const MetricPage: FC = () => {
                         </div>
                         <div style={{ flex: 1 }} />
                         <div className="col-auto">
-                          {permissions.check("runQueries", metric.projects) && (
+                          {permissions.check(
+                            "runQueries",
+                            metric.projects || []
+                          ) && (
                             <form
                               onSubmit={async (e) => {
                                 e.preventDefault();

--- a/packages/front-end/pages/metric/[mid].tsx
+++ b/packages/front-end/pages/metric/[mid].tsx
@@ -586,7 +586,7 @@ const MetricPage: FC = () => {
                               {canEditMetric &&
                                 permissions.check(
                                   "runQueries",
-                                  metric.projects || ""
+                                  metric.projects
                                 ) && (
                                   <a
                                     onClick={(e) => {
@@ -603,10 +603,7 @@ const MetricPage: FC = () => {
                         </div>
                         <div style={{ flex: 1 }} />
                         <div className="col-auto">
-                          {permissions.check(
-                            "runQueries",
-                            metric.projects || ""
-                          ) && (
+                          {permissions.check("runQueries", metric.projects) && (
                             <form
                               onSubmit={async (e) => {
                                 e.preventDefault();

--- a/packages/front-end/pages/metrics.tsx
+++ b/packages/front-end/pages/metrics.tsx
@@ -496,7 +496,13 @@ const MetricsPage = (): React.ReactElement => {
                   }}
                 >
                   {moreMenuLinks.length ? (
-                    <MoreMenu>{moreMenuLinks}</MoreMenu>
+                    <MoreMenu>
+                      {moreMenuLinks.map((menuItem, i) => (
+                        <div key={`${menuItem}-${i}`} className="d-inline">
+                          {menuItem}
+                        </div>
+                      ))}
+                    </MoreMenu>
                   ) : null}
                 </td>
               </tr>

--- a/packages/front-end/pages/metrics.tsx
+++ b/packages/front-end/pages/metrics.tsx
@@ -371,122 +371,130 @@ const MetricsPage = (): React.ReactElement => {
           </tr>
         </thead>
         <tbody>
-          {items.map((metric) => (
-            <tr
-              key={metric.id}
-              onClick={(e) => {
-                e.preventDefault();
-                router.push(getMetricLink(metric.id));
-              }}
-              style={{ cursor: "pointer" }}
-              className={metric.archived ? "text-muted" : ""}
-            >
-              <td>
-                <Link href={getMetricLink(metric.id)}>
-                  <a
-                    className={`${
-                      metric.archived ? "text-muted" : "text-dark"
-                    } font-weight-bold`}
-                  >
-                    <MetricName id={metric.id} />
-                  </a>
-                </Link>
-              </td>
-              <td>{metric.type}</td>
-
-              <td className="col-4">
-                <SortedTags
-                  tags={metric.tags ? Object.values(metric.tags) : []}
-                  shouldShowEllipsis={true}
-                />
-              </td>
-              <td className="col-2">
-                {metric && (metric.projects || []).length > 0 ? (
-                  <ProjectBadges
-                    resourceType="metric"
-                    projectIds={metric.projects}
-                    className="badge-ellipsis short align-middle"
-                  />
-                ) : (
-                  <ProjectBadges
-                    resourceType="metric"
-                    className="badge-ellipsis short align-middle"
-                  />
-                )}
-              </td>
-              <td>{metric.owner}</td>
-              <td className="d-none d-lg-table-cell">
-                {metric.datasourceName}
-                {metric.datasourceDescription && (
-                  <div
-                    className="text-gray font-weight-normal small text-ellipsis"
-                    style={{ maxWidth: 350 }}
-                  >
-                    {metric.datasourceDescription}
-                  </div>
-                )}
-              </td>
-              <td
-                title={datetime(metric.dateUpdated || "")}
-                className="d-none d-md-table-cell"
-              >
-                {metric.managedBy === "config"
-                  ? ""
-                  : ago(metric.dateUpdated || "")}
-              </td>
-              <td className="text-muted">
-                {metric.archived && (
-                  <Tooltip
-                    body={"Archived"}
-                    innerClassName="p-2"
-                    tipMinWidth="auto"
-                  >
-                    <FaArchive />
-                  </Tooltip>
-                )}
-              </td>
-              <td
-                style={{ cursor: "initial" }}
+          {items.map((metric) => {
+            const showMoreMenu: boolean =
+              (metric.onDuplicate && editMetricsPermissions[metric.id]) ||
+              (!metric.managedBy &&
+                metric.onArchive &&
+                editMetricsPermissions[metric.id]) ||
+              false;
+            return (
+              <tr
+                key={metric.id}
                 onClick={(e) => {
-                  e.stopPropagation();
                   e.preventDefault();
+                  router.push(getMetricLink(metric.id));
                 }}
+                style={{ cursor: "pointer" }}
+                className={metric.archived ? "text-muted" : ""}
               >
-                {canCreateMetrics() && (
-                  <MoreMenu>
-                    {metric.onDuplicate && editMetricsPermissions[metric.id] && (
-                      <button
-                        className="btn dropdown-item py-2"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          e.preventDefault();
-                          metric.onDuplicate && metric.onDuplicate();
-                        }}
-                      >
-                        <FaRegCopy /> Duplicate
-                      </button>
-                    )}
-                    {!metric.managedBy &&
-                      metric.onArchive &&
-                      editMetricsPermissions[metric.id] && (
+                <td>
+                  <Link href={getMetricLink(metric.id)}>
+                    <a
+                      className={`${
+                        metric.archived ? "text-muted" : "text-dark"
+                      } font-weight-bold`}
+                    >
+                      <MetricName id={metric.id} />
+                    </a>
+                  </Link>
+                </td>
+                <td>{metric.type}</td>
+
+                <td className="col-4">
+                  <SortedTags
+                    tags={metric.tags ? Object.values(metric.tags) : []}
+                    shouldShowEllipsis={true}
+                  />
+                </td>
+                <td className="col-2">
+                  {metric && (metric.projects || []).length > 0 ? (
+                    <ProjectBadges
+                      resourceType="metric"
+                      projectIds={metric.projects}
+                      className="badge-ellipsis short align-middle"
+                    />
+                  ) : (
+                    <ProjectBadges
+                      resourceType="metric"
+                      className="badge-ellipsis short align-middle"
+                    />
+                  )}
+                </td>
+                <td>{metric.owner}</td>
+                <td className="d-none d-lg-table-cell">
+                  {metric.datasourceName}
+                  {metric.datasourceDescription && (
+                    <div
+                      className="text-gray font-weight-normal small text-ellipsis"
+                      style={{ maxWidth: 350 }}
+                    >
+                      {metric.datasourceDescription}
+                    </div>
+                  )}
+                </td>
+                <td
+                  title={datetime(metric.dateUpdated || "")}
+                  className="d-none d-md-table-cell"
+                >
+                  {metric.managedBy === "config"
+                    ? ""
+                    : ago(metric.dateUpdated || "")}
+                </td>
+                <td className="text-muted">
+                  {metric.archived && (
+                    <Tooltip
+                      body={"Archived"}
+                      innerClassName="p-2"
+                      tipMinWidth="auto"
+                    >
+                      <FaArchive />
+                    </Tooltip>
+                  )}
+                </td>
+                <td
+                  style={{ cursor: "initial" }}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    e.preventDefault();
+                  }}
+                >
+                  {canCreateMetrics() && showMoreMenu && (
+                    <MoreMenu>
+                      {metric.onDuplicate && editMetricsPermissions[metric.id] && (
                         <button
                           className="btn dropdown-item py-2"
-                          onClick={async (e) => {
+                          onClick={(e) => {
+                            e.stopPropagation();
                             e.preventDefault();
-                            metric.onArchive &&
-                              (await metric.onArchive(!metric.archived));
-                            mutateDefinitions({});
+                            metric.onDuplicate && metric.onDuplicate();
                           }}
                         >
-                          <FaArchive />{" "}
-                          {metric.archived ? "Unarchive" : "Archive"}
+                          <FaRegCopy /> Duplicate
                         </button>
                       )}
-                  </MoreMenu>
-                )}
-              </td>
-            </tr>
-          ))}
+                      {!metric.managedBy &&
+                        metric.onArchive &&
+                        editMetricsPermissions[metric.id] && (
+                          <button
+                            className="btn dropdown-item py-2"
+                            onClick={async (e) => {
+                              e.preventDefault();
+                              metric.onArchive &&
+                                (await metric.onArchive(!metric.archived));
+                              mutateDefinitions({});
+                            }}
+                          >
+                            <FaArchive />{" "}
+                            {metric.archived ? "Unarchive" : "Archive"}
+                          </button>
+                        )}
+                    </MoreMenu>
+                  )}
+                </td>
+              </tr>
+            );
+          })}
 
           {!items.length && (isFiltered || tagsFilter.tags.length > 0) && (
             <tr>

--- a/packages/front-end/services/UserContext.tsx
+++ b/packages/front-end/services/UserContext.tsx
@@ -333,19 +333,24 @@ export function UserContextProvider({ children }: { children: ReactNode }) {
 
       let checkProjects: (string | undefined)[];
       if (Array.isArray(projects)) {
-        checkProjects =
-          projects.length > 0
-            ? projects
-            : Object.keys(currentOrg.currentUserPermissions.projects).length
-            ? Object.keys(currentOrg.currentUserPermissions.projects)
-            : [undefined];
+        checkProjects = projects.length > 0 ? projects : [undefined];
       } else {
         checkProjects = [projects];
       }
-
-      //TODO: The READ_ONLY_PERMISSIONS array isn't in the shared folder
+      // Read only type permissions grant permission if the user has the permission globally or in atleast 1 project
       if (["readOnly", "runQueries", "viewEvents"].includes(permission)) {
-        // Read only type permissions grant permission if the user has the permission globally or in atleast 1 project
+        // if the resource is in "ALL PROJECTS", & the user has project-specific permissions, add those to the checkProjects array
+        // so we look at the user's global permissions, as well as all of their project-specific permissions
+        if (
+          checkProjects.length === 1 &&
+          checkProjects[0] === undefined &&
+          Object.keys(currentOrg.currentUserPermissions.projects).length
+        ) {
+          checkProjects.push(
+            ...Object.keys(currentOrg.currentUserPermissions.projects)
+          );
+        }
+        // if the user has permission globally, or via at least 1 of their project-specific roles, they have permission
         return checkProjects.some((p) =>
           hasPermission(currentOrg.currentUserPermissions, permission, p, envs)
         );

--- a/packages/front-end/services/UserContext.tsx
+++ b/packages/front-end/services/UserContext.tsx
@@ -336,7 +336,9 @@ export function UserContextProvider({ children }: { children: ReactNode }) {
         checkProjects =
           projects.length > 0
             ? projects
-            : Object.keys(currentOrg.currentUserPermissions.projects);
+            : Object.keys(currentOrg.currentUserPermissions.projects).length
+            ? Object.keys(currentOrg.currentUserPermissions.projects)
+            : [undefined];
       } else {
         checkProjects = [projects];
       }

--- a/packages/shared/src/permissions/permissions.utils.ts
+++ b/packages/shared/src/permissions/permissions.utils.ts
@@ -5,15 +5,18 @@ import {
 } from "back-end/types/organization";
 
 export function hasPermission(
-  userPermissions: UserPermissions,
+  userPermissions: UserPermissions | undefined,
   permissionToCheck: Permission,
   project?: string | undefined,
   envs?: string[]
 ): boolean {
   const usersPermissionsToCheck =
-    (project && userPermissions.projects[project]) || userPermissions.global;
+    (project && userPermissions?.projects[project]) || userPermissions?.global;
 
-  if (!usersPermissionsToCheck.permissions[permissionToCheck]) {
+  if (
+    !usersPermissionsToCheck ||
+    !usersPermissionsToCheck.permissions[permissionToCheck]
+  ) {
     return false;
   }
 

--- a/packages/shared/src/permissions/permissions.utils.ts
+++ b/packages/shared/src/permissions/permissions.utils.ts
@@ -4,6 +4,57 @@ import {
   MemberRole,
 } from "back-end/types/organization";
 
+export const ENV_SCOPED_PERMISSIONS = [
+  "publishFeatures",
+  "manageEnvironments",
+  "runExperiments",
+] as const;
+
+export const PROJECT_SCOPED_PERMISSIONS = [
+  "readData",
+  "addComments",
+  "createFeatureDrafts",
+  "manageFeatures",
+  "manageProjects",
+  "createAnalyses",
+  "createIdeas",
+  "createMetrics",
+  "manageFactTables",
+  "createDatasources",
+  "editDatasourceSettings",
+  "runQueries",
+  "manageVisualChanges",
+] as const;
+
+export const GLOBAL_PERMISSIONS = [
+  "readData",
+  "createPresentations",
+  "createDimensions",
+  "createSegments",
+  "organizationSettings",
+  "superDelete",
+  "manageTeam",
+  "manageTags",
+  "manageApiKeys",
+  "manageIntegrations",
+  "manageWebhooks",
+  "manageBilling",
+  "manageNorthStarMetric",
+  "manageTargetingAttributes",
+  "manageNamespaces",
+  "manageSavedGroups",
+  "manageArchetype",
+  "viewEvents",
+] as const;
+
+export const ALL_PERMISSIONS = [
+  ...GLOBAL_PERMISSIONS,
+  ...PROJECT_SCOPED_PERMISSIONS,
+  ...ENV_SCOPED_PERMISSIONS,
+];
+
+export const READ_ONLY_PERMISSIONS = ["readData", "viewEvents", "runQueries"];
+
 export function hasPermission(
   userPermissions: UserPermissions | undefined,
   permissionToCheck: Permission,
@@ -46,7 +97,7 @@ export const userHasPermission = (
     checkProjects = [project];
   }
 
-  if (["readData", "viewEvents", "runQueries"].includes(permission)) {
+  if (READ_ONLY_PERMISSIONS.includes(permission)) {
     if (
       checkProjects.length === 1 &&
       checkProjects[0] === undefined &&


### PR DESCRIPTION
### Features and Changes

This PR introduces an update to our permission check logic (both on the front end and backend). 

Previously, when evaluating whether a user had permission to perform a certain action, we'd go through the following logic:
 - If the permission was a `GLOBAL_SCOPED_PERMISSION`, we'd look to see if the user's global role gave them permission
 - If the permission was a 'PROJECT_SCOPED_PERMISSION' we'd look to see if either the user's global role gave them permission. If not, we'd loop through all of the user's project-specific permissions and if the user had the permission for EVERY project, we'd grant them permission.
 
 This worked well, but there are a few cases where we want to give the user permission for a `PROJECT_SCOPED_PERMISSION` if atleast 1 of their project-specific permissions give them access.
 
 Notably, these are `readData`, `viewEvents`, and `runQueries`.
 
 So now, when evaluating these permissions, if the user's global role doesn't give them permission, but atleast 1 of their project specific permissions does, we'll grant them access.
 
 As part of this PR, I've also updated a lot of `permission.check()` and `req.checkPermission()` calls to ensure that when checking permissions for resources that contain a `projects` array (datasources, metrics, etc) we always pass in the resource's `projects` array. Passing a string into the second argument of `req.checkPermissions` means that we're only evaluating the user's permissions via their global role.

### Testing

- [x] Scenario 1:

User’s global role is no access, but they have a project specific role of experimenter for a single project

On a datasource id page, if the datasource is in “All Projects” the user should not have edit capabilities

On a datasource id page, if the datasource is ONLY in the project the user has the experimenter role for, they should have edit capabilities

On a datasource id page, if the datasource is in multiple projects, but they don’t have explicit `experimenter` role for all of the projects, they should not have edit capabilities

If this users goes to the /experiments page, and attempts to import a previous experiment, they should be able to do so as long as the datasource is in “ALL PROJECTS” or the datasource is associated with at least 1 project that the user has experimenter permissions for (note: for datasources that have a projects array and that array doesn’t overlap with any projects the user has “readData” permissions for, the user shouldn’t even see the datasource in the list 


- [x] Scenario 2: 

User’s global role is experimenter, but they have a project specific role of no access for 1 project

On a datasource id page, if the datasource is in “All Projects” the user should have edit capabilities

On a datasource id page, if the datasource is ONLY in the project they have a no access role for, they shouldn’t even see it

On a datasource id page, if the datasource is in multiple projects, one of which is the project they have no access for, they should see it, but not be able to edit

If this users goes to the /experiments page, and attempts to import a previous experiment, they should be able to run the query. If a datasource has a projects array that ONLY contains the project the user has the `no access` role for, they shouldn't even see the datasource in the dropdown

- [x] Scenario 3:

User’s global role is experimenter, and they have no project-specific roles

On a datasource id page, if the datasource is in “All Projects” the user should have edit capabilities

On a datasource id page, if the datasource is a part of a project the user should have edit capabilities

On a datasource id page, if the datasource is in multiple projects, the user should have edit capabilities
