### PR TITLE
Switch variation chooser and baseline chooser around

### DIFF
--- a/packages/front-end/components/Experiment/AnalysisSettingsBar.tsx
+++ b/packages/front-end/components/Experiment/AnalysisSettingsBar.tsx
@@ -158,16 +158,6 @@ export default function AnalysisSettingsBar({
           {newUi && setVariationFilter && setBaselineRow ? (
             <>
               <div className="col-auto form-inline pr-5">
-                <VariationChooser
-                  variations={experiment.variations}
-                  variationFilter={variationFilter ?? []}
-                  setVariationFilter={setVariationFilter}
-                  baselineRow={baselineRow ?? 0}
-                  dropdownEnabled={snapshot?.dimension !== "pre:date"}
-                />
-                <em className="text-muted mx-3" style={{ marginTop: 15 }}>
-                  vs
-                </em>
                 <BaselineChooser
                   variations={experiment.variations}
                   setVariationFilter={setVariationFilter}
@@ -182,6 +172,16 @@ export default function AnalysisSettingsBar({
                     !manualSnapshot && snapshot?.dimension !== "pre:date"
                   }
                   dimension={dimension}
+                />
+                <em className="text-muted mx-3" style={{ marginTop: 15 }}>
+                  vs
+                </em>
+                <VariationChooser
+                  variations={experiment.variations}
+                  variationFilter={variationFilter ?? []}
+                  setVariationFilter={setVariationFilter}
+                  baselineRow={baselineRow ?? 0}
+                  dropdownEnabled={snapshot?.dimension !== "pre:date"}
                 />
               </div>
             </>


### PR DESCRIPTION
While Variance - Baseline makes sense mathmatically, we always present them in the other order in the UI and it is causing confusion and several people suggest we switch them around.

That makes sense, and this PR does that.

Closes #1725

### Screenshots

**Before**
<img width="507" alt="image" src="https://github.com/growthbook/growthbook/assets/5298599/d1b3679b-8475-4773-8c7b-c7fa372d7fe7">


**After**
<img width="510" alt="image" src="https://github.com/growthbook/growthbook/assets/5298599/15828723-489b-44f2-9521-1add04520965">
