### PR TITLE
Fix saved group deletion when using config.yml

### DIFF
--- a/packages/back-end/src/models/SavedGroupModel.ts
+++ b/packages/back-end/src/models/SavedGroupModel.ts
@@ -115,10 +115,6 @@ export async function updateSavedGroupById(
 }
 
 export async function deleteSavedGroupById(id: string, organization: string) {
-  if (usingFileConfig()) {
-    throw new Error("Cannot delete. Saved Groups managed by config.yml");
-  }
-
   await SavedGroupModel.deleteOne({
     id,
     organization,

--- a/packages/back-end/src/models/SavedGroupModel.ts
+++ b/packages/back-end/src/models/SavedGroupModel.ts
@@ -8,7 +8,6 @@ import {
   SavedGroupInterface,
   UpdateSavedGroupProps,
 } from "../../types/saved-group";
-import { usingFileConfig } from "../init/config";
 import { migrateSavedGroup } from "../util/migrations";
 
 const savedGroupSchema = new mongoose.Schema({


### PR DESCRIPTION
### Features and Changes

For instances using config.yml is not possible to remove saved groups created from the UI. This PR removes the check as AFAIK "Saved Groups" can't be managed using config.yml, and the rest of the actions are allowed.

### Testing

- Start Growthbook using config.yml
- Add manually a saved group
- Try to delete it.


