### PR TITLE
Cleanup curl doc examples.

### DIFF
--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -215,7 +215,7 @@ paths:
         - lang: cURL
           source: |
             curl -X POST https://api.growthbook.io/api/v1/features \
-              -d '{ id: "test-01", description: "A cool feature", ... }'
+              -d '{ "id": "test-01", "description": "A cool feature", ... }'
               -u secret_abc123DEF456:
       requestBody:
         required: true
@@ -459,7 +459,7 @@ paths:
         - lang: cURL
           source: |
             curl -X POST https://api.growthbook.io/api/v1/features/test-01 \
-              -d '{ description: "A cool feature flag", ... }'
+              -d '{ "description": "A cool feature flag", ... }'
               -u secret_abc123DEF456:
       requestBody:
         required: true
@@ -515,9 +515,8 @@ paths:
         - lang: cURL
           source: |
             curl -X POST https://api.growthbook.io/api/v1/features/my-feature/toggle \
-              -u secret_abc123DEF456: \
-              -d "environments[production]"=false \
-              -d reason="Kill switch activated"
+              -d '{ "reason": "Kill switch activated", "environments": { "production": false } }' \
+              -u secret_abc123DEF456:
       requestBody:
         required: true
         content:
@@ -876,7 +875,7 @@ paths:
         - lang: cURL
           source: |
             curl -X POST https://api.growthbook.io/api/v1/experiments \
-              -d '{ name: "test_experiment", "owner": "weijie.ou@example.com" ... }'
+              -d '{"name": "test_experiment", "owner": "weijie.ou@example.com", ...}'
               -u secret_abc123DEF456:
       requestBody:
         required: true
@@ -1114,7 +1113,7 @@ paths:
         - lang: cURL
           source: |
             curl -X POST https://api.growthbook.io/api/v1/experiments/exp_1234 \
-              -d '{ name: "test_experiment", "owner": "weijie.ou@example.com" ... }'
+              -d '{ "name": "test_experiment", "owner": "weijie.ou@example.com", ... }' \
               -u secret_abc123DEF456:
       requestBody:
         required: true
@@ -1380,7 +1379,7 @@ paths:
         - lang: cURL
           source: |
             curl -X POST https://api.growthbook.io/api/v1/metrics \
-              -d '{ datasourceId: "ds_abc123", ... }'
+              -d '{ "datasourceId": "ds_abc123", ... }'
               -u secret_abc123DEF456:
       requestBody:
         required: true
@@ -1661,9 +1660,8 @@ paths:
         - lang: cURL
           source: |
             curl -XPUT https://api.growthbook.io/api/v1/metrics/met_123abc \
-              -u secret_abc123DEF456 \
-              -H "Content-Type: application/json" \
-              -d '{"name": "net revenue", "description":"revenue minus lacroix spend"}'
+              -d '{"name": "net revenue", "description":"revenue minus lacroix spend"}' \
+              -u secret_abc123DEF456:
       requestBody:
         required: true
         content:
@@ -1989,9 +1987,8 @@ paths:
         - lang: cURL
           source: |
             curl -XPUT https://api.growthbook.io/api/v1/visual-changesets/vc_123abc
-              -u secret_abc123DEF456 \
-              -H "Content-Type: application/json" \
-                                                 -d '{"editorUrl": "https://docs.growthbook.io", "urlPatterns":"[{ ... }]"}'
+              -d '{"editorUrl": "https://docs.growthbook.io", "urlPatterns":"[{ ... }]"}' \
+              -u secret_abc123DEF456:
       responses:
         '200':
           content:
@@ -2018,9 +2015,8 @@ paths:
         - lang: cURL
           source: |
             curl -XPOST https://api.growthbook.io/api/v1/visual-changesets/vc_123abc/visual-change \
-              -u secret_abc123DEF456 \
-              -H "Content-Type: application/json" \
-              -d '{"variation": "v_123abc", "domMutations":"[]"}'
+              -d '{"variation": "v_123abc", "domMutations":"[]"}' \
+              -u secret_abc123DEF456:
       responses:
         '200':
           content:
@@ -2045,9 +2041,8 @@ paths:
         - lang: cURL
           source: |
             curl -XPUT https://api.growthbook.io/api/v1/visual-changesets/vc_123abc/visual-change/vch_abc123 \
-              -u secret_abc123DEF456 \
-              -H "Content-Type: application/json" \
-              -d '{"variation": "v_123abc", "domMutations":"[]"}'
+              -d '{"variation": "v_123abc", "domMutations":"[]"}' \
+              -u secret_abc123DEF456:
       responses:
         '200':
           content:
@@ -2098,9 +2093,8 @@ paths:
         - lang: cURL
           source: |
             curl -X POST https://api.growthbook.io/api/v1/saved-groups \
-              -H "Content-Type: application/json" \
-              -u secret_abc123DEF456: \
-              -d '{"name": "interal-users", "values": ["userId-123", "userId-345", "userId-678"], "attributeKey": "userId", "owner": ""}'
+              -d '{"name": "interal-users", "values": ["userId-123", "userId-345", "userId-678"], "attributeKey": "userId", "owner": ""}' \
+              -u secret_abc123DEF456:
       requestBody:
         required: true
         content:
@@ -2179,9 +2173,8 @@ paths:
         - lang: cURL
           source: |
             curl -X POST https://api.growthbook.io/api/v1/saved-groups/grp_123abc \
-              -H "Content-Type: application/json" \
-              -u secret_abc123DEF456: \
-              -d '{"values": [ "userId-123", "userId-345" ]}'
+              -d '{"values": [ "userId-123", "userId-345" ]}' \
+              -u secret_abc123DEF456:
       requestBody:
         required: true
         content:
@@ -2282,7 +2275,7 @@ paths:
         - lang: cURL
           source: |
             curl -X POST https://api.growthbook.io/api/v1/organizations \
-              -d '{ name: "My Subsidiary" }' \
+              -d '{ "name": "My Subsidiary" }' \
               -u secret_abc123DEF456:
       requestBody:
         required: true
@@ -2322,8 +2315,7 @@ paths:
         - lang: cURL
           source: |
             curl -X PUT https://api.growthbook.io/api/v1/organizations/org_abc123 \
-              -d '{ name: "My Subsidiary" }' \
-              -d '{ externalId: "subsidiary-123" }'
+              -d '{ "name": "My Subsidiary", "externalId": "subsidiary-123" }' \
               -u secret_abc123DEF456:
       requestBody:
         required: true

--- a/packages/back-end/src/api/openapi/paths/postExperiment.yaml
+++ b/packages/back-end/src/api/openapi/paths/postExperiment.yaml
@@ -7,7 +7,7 @@ x-codeSamples:
   - lang: 'cURL'
     source: |
       curl -X POST https://api.growthbook.io/api/v1/experiments \
-        -d '{ name: "test_experiment", "owner": "weijie.ou@example.com" ... }'
+        -d '{"name": "test_experiment", "owner": "weijie.ou@example.com", ...}'
         -u secret_abc123DEF456:
 requestBody:
   required: true

--- a/packages/back-end/src/api/openapi/paths/postFeature.yaml
+++ b/packages/back-end/src/api/openapi/paths/postFeature.yaml
@@ -7,7 +7,7 @@ x-codeSamples:
   - lang: "cURL"
     source: |
       curl -X POST https://api.growthbook.io/api/v1/features \
-        -d '{ id: "test-01", description: "A cool feature", ... }'
+        -d '{ "id": "test-01", "description": "A cool feature", ... }'
         -u secret_abc123DEF456:
 requestBody:
   required: true

--- a/packages/back-end/src/api/openapi/paths/postMetric.yaml
+++ b/packages/back-end/src/api/openapi/paths/postMetric.yaml
@@ -7,7 +7,7 @@ x-codeSamples:
   - lang: 'cURL'
     source: |
       curl -X POST https://api.growthbook.io/api/v1/metrics \
-        -d '{ datasourceId: "ds_abc123", ... }'
+        -d '{ "datasourceId": "ds_abc123", ... }'
         -u secret_abc123DEF456:
 requestBody:
   required: true

--- a/packages/back-end/src/api/openapi/paths/postOrganization.yaml
+++ b/packages/back-end/src/api/openapi/paths/postOrganization.yaml
@@ -7,7 +7,7 @@ x-codeSamples:
   - lang: "cURL"
     source: |
       curl -X POST https://api.growthbook.io/api/v1/organizations \
-        -d '{ name: "My Subsidiary" }' \
+        -d '{ "name": "My Subsidiary" }' \
         -u secret_abc123DEF456:
 requestBody:
   required: true

--- a/packages/back-end/src/api/openapi/paths/postSavedGroup.yaml
+++ b/packages/back-end/src/api/openapi/paths/postSavedGroup.yaml
@@ -7,9 +7,8 @@ x-codeSamples:
   - lang: "cURL"
     source: |
       curl -X POST https://api.growthbook.io/api/v1/saved-groups \
-        -H "Content-Type: application/json" \
-        -u secret_abc123DEF456: \
-        -d '{"name": "interal-users", "values": ["userId-123", "userId-345", "userId-678"], "attributeKey": "userId", "owner": ""}'
+        -d '{"name": "interal-users", "values": ["userId-123", "userId-345", "userId-678"], "attributeKey": "userId", "owner": ""}' \
+        -u secret_abc123DEF456:
 requestBody:
   required: true
   content:

--- a/packages/back-end/src/api/openapi/paths/postVisualChange.yaml
+++ b/packages/back-end/src/api/openapi/paths/postVisualChange.yaml
@@ -9,9 +9,8 @@ post:
     - lang: "cURL"
       source: |
         curl -XPOST https://api.growthbook.io/api/v1/visual-changesets/vc_123abc/visual-change \
-          -u secret_abc123DEF456 \
-          -H "Content-Type: application/json" \
-          -d '{"variation": "v_123abc", "domMutations":"[]"}'
+          -d '{"variation": "v_123abc", "domMutations":"[]"}' \
+          -u secret_abc123DEF456:
   responses:
     "200":
       content:

--- a/packages/back-end/src/api/openapi/paths/putMetric.yaml
+++ b/packages/back-end/src/api/openapi/paths/putMetric.yaml
@@ -8,9 +8,8 @@ x-codeSamples:
   - lang: "cURL"
     source: |
       curl -XPUT https://api.growthbook.io/api/v1/metrics/met_123abc \
-        -u secret_abc123DEF456 \
-        -H "Content-Type: application/json" \
-        -d '{"name": "net revenue", "description":"revenue minus lacroix spend"}'
+        -d '{"name": "net revenue", "description":"revenue minus lacroix spend"}' \
+        -u secret_abc123DEF456:
 requestBody:
   required: true
   content:

--- a/packages/back-end/src/api/openapi/paths/putOrganization.yaml
+++ b/packages/back-end/src/api/openapi/paths/putOrganization.yaml
@@ -8,8 +8,7 @@ x-codeSamples:
   - lang: "cURL"
     source: |
       curl -X PUT https://api.growthbook.io/api/v1/organizations/org_abc123 \
-        -d '{ name: "My Subsidiary" }' \
-        -d '{ externalId: "subsidiary-123" }'
+        -d '{ "name": "My Subsidiary", "externalId": "subsidiary-123" }' \
         -u secret_abc123DEF456:
 requestBody:
   required: true

--- a/packages/back-end/src/api/openapi/paths/putVisualChange.yaml
+++ b/packages/back-end/src/api/openapi/paths/putVisualChange.yaml
@@ -10,9 +10,8 @@ put:
     - lang: "cURL"
       source: |
         curl -XPUT https://api.growthbook.io/api/v1/visual-changesets/vc_123abc/visual-change/vch_abc123 \
-          -u secret_abc123DEF456 \
-          -H "Content-Type: application/json" \
-          -d '{"variation": "v_123abc", "domMutations":"[]"}'
+          -d '{"variation": "v_123abc", "domMutations":"[]"}' \
+          -u secret_abc123DEF456:
   responses:
     "200":
       content:

--- a/packages/back-end/src/api/openapi/paths/putVisualChangeset.yaml
+++ b/packages/back-end/src/api/openapi/paths/putVisualChangeset.yaml
@@ -8,9 +8,8 @@ x-codeSamples:
   - lang: "cURL"
     source: |
       curl -XPUT https://api.growthbook.io/api/v1/visual-changesets/vc_123abc
-        -u secret_abc123DEF456 \
-        -H "Content-Type: application/json" \
-                                           -d '{"editorUrl": "https://docs.growthbook.io", "urlPatterns":"[{ ... }]"}'
+        -d '{"editorUrl": "https://docs.growthbook.io", "urlPatterns":"[{ ... }]"}' \
+        -u secret_abc123DEF456:
 responses:
   "200":
     content:

--- a/packages/back-end/src/api/openapi/paths/toggleFeature.yaml
+++ b/packages/back-end/src/api/openapi/paths/toggleFeature.yaml
@@ -9,9 +9,8 @@ post:
     - lang: 'cURL'
       source: |
         curl -X POST https://api.growthbook.io/api/v1/features/my-feature/toggle \
-          -u secret_abc123DEF456: \
-          -d "environments[production]"=false \
-          -d reason="Kill switch activated"
+          -d '{ "reason": "Kill switch activated", "environments": { "production": false } }' \
+          -u secret_abc123DEF456:
   requestBody:
     required: true
     content:

--- a/packages/back-end/src/api/openapi/paths/updateExperiment.yaml
+++ b/packages/back-end/src/api/openapi/paths/updateExperiment.yaml
@@ -8,7 +8,7 @@ x-codeSamples:
   - lang: "cURL"
     source: |
       curl -X POST https://api.growthbook.io/api/v1/experiments/exp_1234 \
-        -d '{ name: "test_experiment", "owner": "weijie.ou@example.com" ... }'
+        -d '{ "name": "test_experiment", "owner": "weijie.ou@example.com", ... }' \
         -u secret_abc123DEF456:
 requestBody:
   required: true

--- a/packages/back-end/src/api/openapi/paths/updateFeature.yaml
+++ b/packages/back-end/src/api/openapi/paths/updateFeature.yaml
@@ -8,7 +8,7 @@ x-codeSamples:
   - lang: "cURL"
     source: |
       curl -X POST https://api.growthbook.io/api/v1/features/test-01 \
-        -d '{ description: "A cool feature flag", ... }'
+        -d '{ "description": "A cool feature flag", ... }'
         -u secret_abc123DEF456:
 requestBody:
   required: true

--- a/packages/back-end/src/api/openapi/paths/updateSavedGroup.yaml
+++ b/packages/back-end/src/api/openapi/paths/updateSavedGroup.yaml
@@ -8,9 +8,8 @@ x-codeSamples:
   - lang: "cURL"
     source: |
       curl -X POST https://api.growthbook.io/api/v1/saved-groups/grp_123abc \
-        -H "Content-Type: application/json" \
-        -u secret_abc123DEF456: \
-        -d '{"values": [ "userId-123", "userId-345" ]}'
+        -d '{"values": [ "userId-123", "userId-345" ]}' \
+        -u secret_abc123DEF456:
 requestBody:
   required: true
   content:


### PR DESCRIPTION
This PR cleans up and normalizes some of the curl request samples:
* Consistently removes optional `application/json` header
* Fixes JSON payloads to actually be JSON
* Normalizes arguments order