### PR TITLE
Redirect to register screen when login via our cloud and there is no prior account found in the client's local storage.

### DIFF
--- a/packages/front-end/services/DefinitionsContext.tsx
+++ b/packages/front-end/services/DefinitionsContext.tsx
@@ -115,6 +115,8 @@ export function useDefinitions() {
   return useContext(DefinitionsContext);
 }
 
+export const LOCALSTORAGE_PROJECT_KEY = "gb_current_project" as const;
+
 export const DefinitionsProvider: FC<{ children: ReactNode }> = ({
   children,
 }) => {
@@ -122,7 +124,7 @@ export const DefinitionsProvider: FC<{ children: ReactNode }> = ({
     "/organization/definitions"
   );
 
-  const [project, setProject] = useLocalStorage("gb_current_project", "");
+  const [project, setProject] = useLocalStorage(LOCALSTORAGE_PROJECT_KEY, "");
 
   const activeMetrics = useMemo(() => {
     if (!data || !data.metrics) {

--- a/packages/front-end/services/auth.tsx
+++ b/packages/front-end/services/auth.tsx
@@ -21,6 +21,7 @@ import Modal from "../components/Modal";
 import { DocLink } from "../components/DocLink";
 import Welcome from "../components/Auth/Welcome";
 import { getApiHost, getAppOrigin, isCloud, isSentryEnabled } from "./env";
+import { LOCALSTORAGE_PROJECT_KEY } from "./DefinitionsContext";
 
 export type UserOrganizations = { id: string; name: string }[];
 
@@ -102,7 +103,9 @@ const isUnregisteredCloudUser = () => {
   if (!isCloud()) return false;
 
   try {
-    const currentProject = window.localStorage.getItem("gb_current_project");
+    const currentProject = window.localStorage.getItem(
+      LOCALSTORAGE_PROJECT_KEY
+    );
     return currentProject === null;
   } catch (_) {
     return true;

--- a/packages/front-end/services/auth.tsx
+++ b/packages/front-end/services/auth.tsx
@@ -32,7 +32,7 @@ export interface AuthContextValue {
   loading: boolean;
   logout: () => Promise<void>;
   apiCall: <T>(url: string | null, options?: RequestInit) => Promise<T>;
-  orgId?: string;
+  orgId: string | null;
   setOrgId?: (orgId: string) => void;
   organizations?: UserOrganizations;
   setOrganizations?: (orgs: UserOrganizations) => void;
@@ -52,6 +52,7 @@ export const AuthContext = React.createContext<AuthContextValue>({
     let x: any;
     return x;
   },
+  orgId: null,
 });
 
 export const useAuth = (): AuthContextValue => useContext(AuthContext);
@@ -171,7 +172,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
 }) => {
   const [loading, setLoading] = useState(true);
   const [token, setToken] = useState("");
-  const [orgId, setOrgId] = useState<string | undefined>();
+  const [orgId, setOrgId] = useState<string | null>(null);
   const [organizations, setOrganizations] = useState<UserOrganizations>([]);
   const [
     specialOrg,
@@ -427,7 +428,6 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
             method: "POST",
             credentials: "include",
           });
-          // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'null' is not assignable to param... Remove this comment to see the full error message
           setOrgId(null);
           setOrganizations([]);
           setSpecialOrg(null);


### PR DESCRIPTION
This PR adds a parameter to the redirect URL for cloud logins when there is no prior account to force a redirect to the sign-up screen.

This was tested locally.

## Screenshots

After a redirect to the register workflow:

<img width="1512" alt="Screenshot 2024-02-20 at 9 58 08 AM" src="https://github.com/growthbook/growthbook/assets/160149598/15aa437d-e205-4c46-ab09-629c9aef183d">

After a redirect to the login workflow:

<img width="1439" alt="Screenshot 2024-02-20 at 10 02 55 AM" src="https://github.com/growthbook/growthbook/assets/160149598/5bfb5bfc-95fe-4d9e-91a8-7dc9a27d510e">

