### PR TITLE
Add schema if specified in auto metrics SQL

### DIFF
--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -2806,7 +2806,12 @@ AND event_name = '${eventName}'`,
         COUNT (*) as count,
         MAX(${timestampColumn}) as lastTrackedAt
       FROM
-        ${this.generateTablePath(trackedEventTableName, schema)}
+        ${this.generateTablePath(
+          trackedEventTableName,
+          schema,
+          undefined,
+          !!schema
+        )}
       WHERE ${getDateLimitClause(start, end)}
       AND ${eventColumn} NOT IN ('experiment_viewed', 'experiment_started')
       GROUP BY ${groupByColumn || eventColumn}


### PR DESCRIPTION
Problem: Right now we don't properly pass the schema through in auto-metric generation if `requiresSchema` is false for a SQL integration.

Fix: If schema exists when generating tracked events SQL, then make sure it gets added to the SQL. This will affect any auto-metric Integration with `requiresSchema = false`, but it seems like without this it will fail and this fix generates the expected path for Snowflake.

Loom showing before and after: https://www.loom.com/share/0fda8d56d1e94983916e57b2b39a63f6