### PR TITLE
Fix undefined prerequisite feature bug when building SDK payload

### DIFF
--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -1220,7 +1220,7 @@ export const reduceFeaturesWithPrerequisites = (
   // block "always off" rules, or reduce "always on" rules
   for (let i = 0; i < newFeatures.length; i++) {
     const feature = newFeatures[i];
-    if (!feature.environmentSettings[environment]) continue;
+    if (!feature.environmentSettings[environment]?.rules) continue;
 
     const newFeatureRules: FeatureRule[] = [];
 


### PR DESCRIPTION
### Features and Changes

Uncaught error when generating SDK payloads for a feature that does not have any rules in an environment.