### PR TITLE
Features page - Prevent horizontal scrolling

### DIFF
--- a/packages/front-end/styles/global.scss
+++ b/packages/front-end/styles/global.scss
@@ -3129,6 +3129,7 @@ input:disabled {
 @import "./components/demo-datasource-banner";
 
 .main.features {
+  overflow-x: hidden;
   .features-header {
     margin: -4px -8px 0;
   }


### PR DESCRIPTION
Due to recent merge #2075 there is a horizontal scrollbar that appears on the Features page. This is due to the negative margin positioning of the header (as is done on the Experiments page).

We hide x-axis overflow since the body of the features page is contained within a`'pagecontents'` class styling which sets a hard limit on width. 