### PR TITLE
Remove extra check on licenses for sso

### DIFF
--- a/packages/enterprise/src/sso.ts
+++ b/packages/enterprise/src/sso.ts
@@ -6,12 +6,6 @@ import type { SSOConnectionInterface } from "back-end/types/sso-connection";
 function getSSOConfig() {
   if (!process.env.SSO_CONFIG) return null;
 
-  if (!stringToBoolean(process.env.IS_CLOUD) && !process.env.LICENSE_KEY) {
-    throw new Error(
-      "Must have a commercial License Key to use self-hosted SSO"
-    );
-  }
-
   const config: SSOConnectionInterface = JSON.parse(process.env.SSO_CONFIG);
   // Must include clientId and specific metadata
   const requiredMetadataKeys: (keyof IssuerMetadata)[] = [


### PR DESCRIPTION
### Features and Changes

A self hosted customer signing up for a trial enterprise license complained that their server was crashing with SSO error "Must have a commercial License Key to use self-hosted SSO".  They must have been saving their license key in mongo from settings/general.  We check for enterprise license again though in enterprise/license.ts which works whether the key is from the env var or from mongo, so this extra check in sso.ts is not needed.

### Testing

save licenseKey="AN ENTERPRISE LICENSE KEY" onto organization in mongo.  
Remove any mention of LICENSE_KEY in packages/back-end/.env.local
ADD SSO_CONFIG in packages/back-end/.env.local.
Load the app.  
See the page load successfully

save licenseKey="AN ENTERPRISE LICENSE KEY" onto organization in mongo.  
Reload the app, see the error message on signing in.

### Screenshots
![Screenshot 2024-02-23 at 3 29 45 PM](https://github.com/growthbook/growthbook/assets/950231/87c639f8-7be6-49a8-9d02-fde927a30ae6)

