### PR TITLE
[bugfix] Apply metric overrides which carry computed RA settings

### DIFF
--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -25,6 +25,7 @@ import {
 import {
   ExperimentMetricInterface,
   getRegressionAdjustmentsForMetric,
+  isBinomialMetric,
   isFactMetric,
   isFactMetricId,
 } from "shared/experiments";
@@ -111,7 +112,6 @@ import {
   QueryResultsForStatsEngine,
   analyzeExperimentMetric,
   analyzeExperimentResults,
-  getMetricSettingsForStatsEngine,
 } from "./stats";
 import { getEnvironmentIdsFromOrg } from "./organizations";
 
@@ -241,8 +241,20 @@ export async function getManualSnapshotData(
     const metric = metricMap.get(m);
     if (!metric) return null;
 
+    const denominator =
+      metric.denominator && !isFactMetric(metric)
+        ? metricMap.get(metric.denominator)
+        : undefined;
     metricSettings[m] = {
-      ...getMetricSettingsForStatsEngine(metric, metricMap, false),
+      id: metric.id,
+      name: metric.name,
+      inverse: !!metric.inverse,
+      main_metric_type: isBinomialMetric(metric) ? "binomial" : "count",
+      ...(denominator && {
+        denominator_metric_type: isBinomialMetric(denominator)
+          ? "binomial"
+          : "count",
+      }),
       // no ratio or regression adjustment for manual snapshots
       statistic_type: "mean",
     };

--- a/packages/back-end/src/services/notebook.ts
+++ b/packages/back-end/src/services/notebook.ts
@@ -15,7 +15,6 @@ import { getQueriesByIds } from "../models/QueryModel";
 import { ReqContext } from "../../types/organization";
 import { ApiReqContext } from "../../types/api";
 import {
-  getAnalysisSettingsFromReportArgs,
   getSnapshotSettingsFromReportArgs,
   reportArgsFromSnapshot,
 } from "./reports";
@@ -138,7 +137,10 @@ export async function generateNotebook(
   const phaseLengthDays =
     Math.max(hoursBetween(args.startDate, args.endDate), 1) / 24;
 
-  const { snapshotSettings, analysisSettings } = getSnapshotSettingsFromReportArgs(args, metricMap);
+  const {
+    snapshotSettings,
+    analysisSettings,
+  } = getSnapshotSettingsFromReportArgs(args, metricMap);
   const { queryResults, metricSettings } = getMetricsAndQueryDataForStatsEngine(
     queries,
     metricMap,

--- a/packages/back-end/src/services/notebook.ts
+++ b/packages/back-end/src/services/notebook.ts
@@ -16,6 +16,7 @@ import { ReqContext } from "../../types/organization";
 import { ApiReqContext } from "../../types/api";
 import {
   getAnalysisSettingsFromReportArgs,
+  getSnapshotSettingsFromReportArgs,
   reportArgsFromSnapshot,
 } from "./reports";
 import {
@@ -140,8 +141,7 @@ export async function generateNotebook(
   const { queryResults, metricSettings } = getMetricsAndQueryDataForStatsEngine(
     queries,
     metricMap,
-    args.variations,
-    args.regressionAdjustmentEnabled ?? false
+    getSnapshotSettingsFromReportArgs(args, metricMap).snapshotSettings
   );
 
   const data: DataForStatsEngine = {

--- a/packages/back-end/src/services/notebook.ts
+++ b/packages/back-end/src/services/notebook.ts
@@ -138,16 +138,17 @@ export async function generateNotebook(
   const phaseLengthDays =
     Math.max(hoursBetween(args.startDate, args.endDate), 1) / 24;
 
+  const { snapshotSettings, analysisSettings } = getSnapshotSettingsFromReportArgs(args, metricMap);
   const { queryResults, metricSettings } = getMetricsAndQueryDataForStatsEngine(
     queries,
     metricMap,
-    getSnapshotSettingsFromReportArgs(args, metricMap).snapshotSettings
+    snapshotSettings
   );
 
   const data: DataForStatsEngine = {
     analyses: [
       getAnalysisSettingsForStatsEngine(
-        getAnalysisSettingsFromReportArgs(args),
+        analysisSettings,
         args.variations,
         args.coverage ?? 1,
         phaseLengthDays

--- a/packages/back-end/src/services/stats.ts
+++ b/packages/back-end/src/services/stats.ts
@@ -218,11 +218,14 @@ export function getMetricSettingsForStatsEngine(
 ): MetricSettingsForStatsEngine {
   const metric = cloneDeep<ExperimentMetricInterface>(metricDoc);
   applyMetricOverrides(metric, settings);
-  let denominator =
+
+  const denominatorDoc =
     metric.denominator && !isFactMetric(metric)
       ? metricMap.get(metric.denominator)
       : undefined;
-  if (denominator) {
+  let denominator: undefined | ExperimentMetricInterface = undefined;
+  if (denominatorDoc) {
+    denominator = cloneDeep<ExperimentMetricInterface>(denominatorDoc);
     applyMetricOverrides(denominator, settings);
   }
 


### PR DESCRIPTION
Previously, if a metric had its own `RegressionAdjustedEnabled: False` set to off, but there are org or experiment level settings that override it, that override wasn't applied properly.

So we have to use `applyMetricOverride` when building the metric settings for the stats engine to ensure these computed fields get passed through (even if there aren't specifically Experiment Metric Overrides), because the Snapshot Settings contains some of these overrides from other sources.

Demonstrating the issue and that it is resolved: https://www.loom.com/share/4634c16254a348c9a9f3b782ebceb92b