### PR TITLE
Missing 'Show Archived' toggle on metric list page

### DIFF
--- a/packages/front-end/pages/metrics.tsx
+++ b/packages/front-end/pages/metrics.tsx
@@ -59,7 +59,7 @@ const MetricsPage = (): React.ReactElement => {
   const {
     getDatasourceById,
     mutateDefinitions,
-    metrics: inlineMetrics,
+    _metricsIncludingArchived: inlineMetrics,
     factMetrics,
     project,
     ready,
@@ -265,7 +265,7 @@ const MetricsPage = (): React.ReactElement => {
     );
   }
 
-  const hasArchivedMetrics = filteredMetrics.find((m) => m.archived);
+  const hasArchivedMetrics = filteredMetrics.some((m) => m.archived);
 
   return (
     <div className="container-fluid py-3 p-3 pagecontents">

--- a/packages/front-end/services/DefinitionsContext.tsx
+++ b/packages/front-end/services/DefinitionsContext.tsx
@@ -23,6 +23,7 @@ import { useLocalStorage } from "@/hooks/useLocalStorage";
 
 type Definitions = {
   metrics: MetricInterface[];
+  _metricsIncludingArchived: MetricInterface[];
   datasources: DataSourceInterfaceWithParams[];
   dimensions: DimensionInterface[];
   segments: SegmentInterface[];
@@ -65,6 +66,7 @@ const defaultValue: DefinitionContextValue = {
   },
   project: "",
   metrics: [],
+  _metricsIncludingArchived: [],
   datasources: [],
   dimensions: [],
   segments: [],
@@ -133,6 +135,13 @@ export const DefinitionsProvider: FC<{ children: ReactNode }> = ({
     return data.metrics.filter((m) => m.status !== "archived");
   }, [data?.metrics]);
 
+  const allMetrics = useMemo(() => {
+    if (!data || !data.metrics) {
+      return [];
+    }
+    return data.metrics;
+  }, [data?.metrics]);
+
   const getMetricById = useGetById(data?.metrics);
   const getDatasourceById = useGetById(data?.datasources);
   const getDimensionById = useGetById(data?.dimensions);
@@ -166,6 +175,7 @@ export const DefinitionsProvider: FC<{ children: ReactNode }> = ({
     value = {
       ready: true,
       metrics: activeMetrics,
+      _metricsIncludingArchived: allMetrics,
       datasources: data.datasources,
       dimensions: data.dimensions,
       segments: data.segments,


### PR DESCRIPTION
### Features and Changes

Bug fix: The "Show Archived" toggle was not showing up on the metrics page, even when there were archived metrics that could be shown.