### PR TITLE
Simplify hasReadAccess to use req.checkPermissions

### DIFF
--- a/packages/back-end/src/init/config.ts
+++ b/packages/back-end/src/init/config.ts
@@ -200,7 +200,7 @@ export function getConfigMetrics(
         managedBy: "config",
       });
     })
-    .filter((m) => hasReadAccess(context.readAccessFilter, m.projects || []));
+    .filter((m) => hasReadAccess(context, m.projects || []));
 }
 
 export function getConfigDimensions(

--- a/packages/back-end/src/middleware/authenticateApiRequestMiddleware.ts
+++ b/packages/back-end/src/middleware/authenticateApiRequestMiddleware.ts
@@ -62,7 +62,7 @@ export default function authenticateApiRequestMiddleware(
   // Lookup organization by secret key and store in req
   lookupOrganizationByApiKey(secretKey)
     .then(async (apiKeyPartial) => {
-      const { organization, secret, id, userId, role } = apiKeyPartial;
+      const { organization, secret, id, userId } = apiKeyPartial;
       if (!organization) {
         throw new Error("Invalid API key");
       }

--- a/packages/back-end/src/middleware/authenticateApiRequestMiddleware.ts
+++ b/packages/back-end/src/middleware/authenticateApiRequestMiddleware.ts
@@ -124,17 +124,6 @@ export default function authenticateApiRequestMiddleware(
         apiKey: id || "unknown",
       };
 
-      req.context = {
-        org,
-        userId: req.user?.id,
-        email: req.user?.email,
-        environments: getEnvironmentIdsFromOrg(org),
-        userName: req.user?.name,
-        //TODO: Update this with actual value
-        checkPermissions: () => true,
-        auditUser: eventAudit,
-      };
-
       // Check permissions for user API keys
       req.checkPermissions = (
         permission: Permission,
@@ -162,6 +151,16 @@ export default function authenticateApiRequestMiddleware(
             teams,
           });
         }
+      };
+
+      req.context = {
+        org,
+        userId: req.user?.id,
+        email: req.user?.email,
+        environments: getEnvironmentIdsFromOrg(org),
+        userName: req.user?.name,
+        checkPermissions: req.checkPermissions,
+        auditUser: eventAudit,
       };
 
       // Add user info to logger

--- a/packages/back-end/src/middleware/authenticateApiRequestMiddleware.ts
+++ b/packages/back-end/src/middleware/authenticateApiRequestMiddleware.ts
@@ -1,9 +1,5 @@
 import { Request, Response, NextFunction } from "express";
-import {
-  getApiKeyReadAccessFilter,
-  getReadAccessFilter,
-  hasPermission,
-} from "shared/permissions";
+import { hasPermission } from "shared/permissions";
 import { ApiRequestLocals } from "../../types/api";
 import { lookupOrganizationByApiKey } from "../models/ApiKeyModel";
 import {
@@ -134,11 +130,8 @@ export default function authenticateApiRequestMiddleware(
         email: req.user?.email,
         environments: getEnvironmentIdsFromOrg(org),
         userName: req.user?.name,
-        readAccessFilter: userId
-          ? getReadAccessFilter(
-              getUserPermissions(userId, req.organization, teams)
-            )
-          : getApiKeyReadAccessFilter(role),
+        //TODO: Update this with actual value
+        checkPermissions: () => true,
         auditUser: eventAudit,
       };
 

--- a/packages/back-end/src/models/ApiKeyModel.ts
+++ b/packages/back-end/src/models/ApiKeyModel.ts
@@ -284,7 +284,7 @@ export async function getApiKeyByIdOrKey(
 ): Promise<ApiKeyInterface | null> {
   if (!id && !key) return null;
 
-  const { org, readAccessFilter } = context;
+  const { org } = context;
 
   const doc = await ApiKeyModel.findOne(
     id ? { organization: org.id, id } : { organization: org.id, key }
@@ -294,7 +294,7 @@ export async function getApiKeyByIdOrKey(
 
   const apiKey = toInterface(doc);
 
-  return hasReadAccess(readAccessFilter, apiKey.project) ? apiKey : null;
+  return hasReadAccess(context, apiKey.project) ? apiKey : null;
 }
 
 export async function getVisualEditorApiKey(
@@ -337,7 +337,7 @@ export async function lookupOrganizationByApiKey(
 export async function getAllApiKeysByOrganization(
   context: ReqContext
 ): Promise<ApiKeyInterface[]> {
-  const { org, readAccessFilter } = context;
+  const { org } = context;
 
   const docs: ApiKeyDocument[] = await ApiKeyModel.find(
     {
@@ -353,7 +353,7 @@ export async function getAllApiKeysByOrganization(
     return json;
   });
 
-  return keys.filter((k) => hasReadAccess(readAccessFilter, k.project));
+  return keys.filter((k) => hasReadAccess(context, k.project));
 }
 
 export async function getFirstPublishableApiKey(

--- a/packages/back-end/src/models/DataSourceModel.ts
+++ b/packages/back-end/src/models/DataSourceModel.ts
@@ -84,9 +84,7 @@ export async function getDataSourcesByOrganization(
 
   const datasources = docs.map(toInterface);
 
-  return datasources.filter((ds) =>
-    hasReadAccess(context.readAccessFilter, ds.projects || [])
-  );
+  return datasources.filter((ds) => hasReadAccess(context, ds.projects || []));
 }
 
 export async function getDataSourceById(
@@ -109,9 +107,7 @@ export async function getDataSourceById(
 
   const datasource = toInterface(doc);
 
-  return hasReadAccess(context.readAccessFilter, datasource.projects)
-    ? datasource
-    : null;
+  return hasReadAccess(context, datasource.projects) ? datasource : null;
 }
 
 export async function removeProjectFromDatasources(

--- a/packages/back-end/src/models/ExperimentModel.ts
+++ b/packages/back-end/src/models/ExperimentModel.ts
@@ -228,9 +228,7 @@ async function findExperiments(
   }
   const experiments = (await cursor).map(toInterface);
 
-  return experiments.filter((exp) =>
-    hasReadAccess(context.readAccessFilter, exp.project)
-  );
+  return experiments.filter((exp) => hasReadAccess(context, exp.project));
 }
 
 export async function getExperimentById(
@@ -246,9 +244,7 @@ export async function getExperimentById(
 
   const experiment = toInterface(doc);
 
-  return hasReadAccess(context.readAccessFilter, experiment.project)
-    ? experiment
-    : null;
+  return hasReadAccess(context, experiment.project) ? experiment : null;
 }
 
 export async function getAllExperiments(
@@ -279,9 +275,7 @@ export async function getExperimentByTrackingKey(
 
   const experiment = toInterface(doc);
 
-  return hasReadAccess(context.readAccessFilter, experiment.project)
-    ? experiment
-    : null;
+  return hasReadAccess(context, experiment.project) ? experiment : null;
 }
 
 export async function getExperimentsByIds(
@@ -462,9 +456,7 @@ export async function getExperimentByIdea(
 
   const experiment = toInterface(doc);
 
-  return hasReadAccess(context.readAccessFilter, experiment.project)
-    ? experiment
-    : null;
+  return hasReadAccess(context, experiment.project) ? experiment : null;
 }
 
 export async function getExperimentsToUpdate(
@@ -554,7 +546,7 @@ export async function getPastExperimentsByDatasource(
   );
 
   const experimentsUserCanAccess = experiments.filter((exp) =>
-    hasReadAccess(context.readAccessFilter, exp.project)
+    hasReadAccess(context, exp.project)
   );
 
   return experimentsUserCanAccess.map((exp) => ({
@@ -650,7 +642,7 @@ export async function getExperimentsForActivityFeed(
   );
 
   const filteredExperiments = experiments.filter((exp) =>
-    hasReadAccess(context.readAccessFilter, exp.project)
+    hasReadAccess(context, exp.project)
   );
 
   return filteredExperiments.map((exp) => ({
@@ -677,9 +669,7 @@ const findExperiment = async ({
 
   const experiment = toInterface(doc);
 
-  return hasReadAccess(context.readAccessFilter, experiment.project)
-    ? experiment
-    : null;
+  return hasReadAccess(context, experiment.project) ? experiment : null;
 };
 
 // region Events

--- a/packages/back-end/src/models/FactMetricModel.ts
+++ b/packages/back-end/src/models/FactMetricModel.ts
@@ -88,7 +88,7 @@ export async function getAllFactMetricsForOrganization(
   const docs = await FactMetricModel.find({ organization: context.org.id });
   return docs
     .map((doc) => toInterface(doc))
-    .filter((f) => hasReadAccess(context.readAccessFilter, f.projects || []));
+    .filter((f) => hasReadAccess(context, f.projects || []));
 }
 
 export async function getFactMetric(
@@ -103,7 +103,7 @@ export async function getFactMetric(
   if (!doc) return null;
 
   const factMetric = toInterface(doc);
-  if (!hasReadAccess(context.readAccessFilter, factMetric.projects || [])) {
+  if (!hasReadAccess(context, factMetric.projects || [])) {
     return null;
   }
 

--- a/packages/back-end/src/models/FactTableModel.ts
+++ b/packages/back-end/src/models/FactTableModel.ts
@@ -78,7 +78,7 @@ export async function getAllFactTablesForOrganization(
   const docs = await FactTableModel.find({ organization: context.org.id });
   return docs
     .map((doc) => toInterface(doc))
-    .filter((f) => hasReadAccess(context.readAccessFilter, f.projects || []));
+    .filter((f) => hasReadAccess(context, f.projects || []));
 }
 
 export type FactTableMap = Map<string, FactTableInterface>;
@@ -102,7 +102,7 @@ export async function getFactTable(
   if (!doc) return null;
 
   const factTable = toInterface(doc);
-  if (!hasReadAccess(context.readAccessFilter, factTable.projects || [])) {
+  if (!hasReadAccess(context, factTable.projects || [])) {
     return null;
   }
   return factTable;

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -3,7 +3,7 @@ import cloneDeep from "lodash/cloneDeep";
 import omit from "lodash/omit";
 import isEqual from "lodash/isEqual";
 import { MergeResultChanges } from "shared/util";
-import { hasReadAccess } from "shared/permissions";
+import { hasReadAccess, hasReadAccess2 } from "shared/permissions";
 import {
   FeatureEnvironment,
   FeatureInterface,
@@ -176,6 +176,7 @@ export async function getAllFeaturesWithLinkedExperiments(
   features: FeatureInterface[];
   experiments: ExperimentInterface[];
 }> {
+  console.log("getAllFeaturesWithLinkedExperiments");
   const q: FilterQuery<FeatureDocument> = { organization: context.org.id };
   if (project) {
     q.project = project;
@@ -186,6 +187,25 @@ export async function getAllFeaturesWithLinkedExperiments(
   const features = allFeatures.filter((feature) =>
     hasReadAccess(context.readAccessFilter, feature.project)
   );
+
+  const featuresFilteredByReadAccess = features.filter((feature) =>
+    hasReadAccess(context.readAccessFilter, feature.project)
+  );
+
+  console.log(
+    "featuresFilteredByReadAccess length",
+    featuresFilteredByReadAccess.length
+  );
+
+  const featuresFilteredByPermission = features.filter((feature) =>
+    hasReadAccess2(context, feature.project)
+  );
+
+  console.log(
+    "featuresFilteredByPermission length",
+    featuresFilteredByPermission.length
+  );
+
   const expIds = new Set<string>(
     features
       .map((f) => f.linkedExperiments)

--- a/packages/back-end/src/models/MetricModel.ts
+++ b/packages/back-end/src/models/MetricModel.ts
@@ -267,9 +267,7 @@ async function findMetrics(
     metrics.push(toInterface(doc));
   });
 
-  return metrics.filter((m) =>
-    hasReadAccess(context.readAccessFilter, m.projects || [])
-  );
+  return metrics.filter((m) => hasReadAccess(context, m.projects || []));
 }
 
 export async function getMetricsByOrganization(
@@ -291,7 +289,7 @@ export async function getSampleMetrics(context: ReqContext | ApiReqContext) {
     organization: context.org.id,
   });
   return docs
-    .filter((m) => hasReadAccess(context.readAccessFilter, m.projects || []))
+    .filter((m) => hasReadAccess(context, m.projects || []))
     .map(toInterface);
 }
 
@@ -329,10 +327,7 @@ export async function getMetricById(
 
   const metric = res ? toInterface(res) : null;
 
-  if (
-    !metric ||
-    !hasReadAccess(context.readAccessFilter, metric.projects || [])
-  ) {
+  if (!metric || !hasReadAccess(context, metric.projects || [])) {
     return null;
   }
   return metric;
@@ -368,9 +363,7 @@ export async function getMetricsByIds(
       metrics.push(toInterface(doc));
     });
   }
-  return metrics.filter((m) =>
-    hasReadAccess(context.readAccessFilter, m.projects || [])
-  );
+  return metrics.filter((m) => hasReadAccess(context, m.projects || []));
 }
 
 export async function findRunningMetricsByQueryId(

--- a/packages/back-end/src/models/ProjectModel.ts
+++ b/packages/back-end/src/models/ProjectModel.ts
@@ -57,19 +57,19 @@ export async function createProject(
 export async function findAllProjectsByOrganization(
   context: ReqContext | ApiReqContext
 ) {
-  const { org, readAccessFilter } = context;
+  const { org } = context;
   const docs = await ProjectModel.find({
     organization: org.id,
   });
 
   const projects = docs.map(toInterface);
-  return projects.filter((p) => hasReadAccess(readAccessFilter, p.id));
+  return projects.filter((p) => hasReadAccess(context, p.id));
 }
 export async function findProjectById(
   context: ReqContext | ApiReqContext,
   projectId: string
 ) {
-  const { org, readAccessFilter } = context;
+  const { org } = context;
   const doc = await ProjectModel.findOne({
     id: projectId,
     organization: org.id,
@@ -78,7 +78,7 @@ export async function findProjectById(
 
   const project = toInterface(doc);
 
-  return hasReadAccess(readAccessFilter, project.id) ? project : null;
+  return hasReadAccess(context, project.id) ? project : null;
 }
 export async function deleteProjectById(id: string, organization: string) {
   await ProjectModel.deleteOne({

--- a/packages/back-end/src/models/SdkConnectionModel.ts
+++ b/packages/back-end/src/models/SdkConnectionModel.ts
@@ -113,9 +113,7 @@ export async function findSDKConnectionById(
   if (!doc) return null;
 
   const connection = toInterface(doc);
-  return hasReadAccess(context.readAccessFilter, connection.projects || [])
-    ? connection
-    : null;
+  return hasReadAccess(context, connection.projects || []) ? connection : null;
 }
 
 export async function findSDKConnectionsByOrganization(
@@ -127,7 +125,7 @@ export async function findSDKConnectionsByOrganization(
 
   const connections = docs.map(toInterface);
   return connections.filter((conn) =>
-    hasReadAccess(context.readAccessFilter, conn.projects || [])
+    hasReadAccess(context, conn.projects || [])
   );
 }
 

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -1499,7 +1499,7 @@ export async function getWebhooks(req: AuthRequest, res: Response) {
   res.status(200).json({
     status: 200,
     webhooks: webhooks.filter((webhook) =>
-      hasReadAccess(context.readAccessFilter, webhook.project)
+      hasReadAccess(context, webhook.project)
     ),
   });
 }

--- a/packages/back-end/src/services/organizations.ts
+++ b/packages/back-end/src/services/organizations.ts
@@ -115,6 +115,7 @@ export function getContextFromReq(req: AuthRequest): ReqContext {
     userId: req.userId,
     email: req.email,
     environments: getEnvironmentIdsFromOrg(req.organization),
+    checkPermissions: req.checkPermissions,
     userName: req.name || "",
     readAccessFilter: getReadAccessFilter(
       getUserPermissions(req.userId, req.organization, req.teams)
@@ -983,6 +984,7 @@ export function getContextForAgendaJobByOrgObject(
     org: organization,
     environments: getEnvironmentIdsFromOrg(organization),
     readAccessFilter: FULL_ACCESS_PERMISSIONS,
+    checkPermissions: () => true,
     auditUser: null,
   };
 }

--- a/packages/back-end/src/services/organizations.ts
+++ b/packages/back-end/src/services/organizations.ts
@@ -2,10 +2,6 @@ import { randomBytes } from "crypto";
 import { freeEmailDomains } from "free-email-domains-typescript";
 import { cloneDeep } from "lodash";
 import {
-  FULL_ACCESS_PERMISSIONS,
-  getReadAccessFilter,
-} from "shared/permissions";
-import {
   createOrganization,
   findAllOrganizations,
   findOrganizationById,
@@ -50,7 +46,7 @@ import { DimensionInterface } from "../../types/dimension";
 import { DataSourceInterface } from "../../types/datasource";
 import { SSOConnectionInterface } from "../../types/sso-connection";
 import { logger } from "../util/logger";
-import { getDefaultRole, getUserPermissions } from "../util/organization.util";
+import { getDefaultRole } from "../util/organization.util";
 import { SegmentInterface } from "../../types/segment";
 import {
   createSegment,
@@ -102,7 +98,12 @@ export function validateLoginMethod(
   return true;
 }
 
-export function getContextFromReq(req: AuthRequest): ReqContext {
+export function getContextFromReq(
+  req: Pick<
+    AuthRequest,
+    "organization" | "userId" | "email" | "checkPermissions" | "teams" | "name"
+  >
+): ReqContext {
   if (!req.organization) {
     throw new Error("Must be part of an organization to make that request");
   }
@@ -117,9 +118,6 @@ export function getContextFromReq(req: AuthRequest): ReqContext {
     environments: getEnvironmentIdsFromOrg(req.organization),
     checkPermissions: req.checkPermissions,
     userName: req.name || "",
-    readAccessFilter: getReadAccessFilter(
-      getUserPermissions(req.userId, req.organization, req.teams)
-    ),
     auditUser: {
       type: "dashboard",
       id: req.userId,
@@ -983,7 +981,6 @@ export function getContextForAgendaJobByOrgObject(
   return {
     org: organization,
     environments: getEnvironmentIdsFromOrg(organization),
-    readAccessFilter: FULL_ACCESS_PERMISSIONS,
     checkPermissions: () => true,
     auditUser: null,
   };

--- a/packages/back-end/test/models/dataSourceModel.test.ts
+++ b/packages/back-end/test/models/dataSourceModel.test.ts
@@ -1,4 +1,3 @@
-import { FULL_ACCESS_PERMISSIONS } from "shared/permissions";
 import {
   updateDataSource,
   validateExposureQueriesAndAddMissingIds,
@@ -308,7 +307,13 @@ describe("dataSourceModel", () => {
               settings: {},
             },
             environments: [],
-            readAccessFilter: FULL_ACCESS_PERMISSIONS,
+            checkPermissions: () => true,
+            auditUser: {
+              type: "dashboard",
+              id: "test",
+              email: "test",
+              name: "test",
+            },
           },
           datasource,
           updates

--- a/packages/back-end/types/organization.d.ts
+++ b/packages/back-end/types/organization.d.ts
@@ -290,7 +290,9 @@ export type ReqContext = {
   environments: string[];
   userName: string;
   auditUser: EventAuditUser;
-  //TODO: Update this with actual type
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  checkPermissions: any;
+  checkPermissions: (
+    permission: Permission,
+    project?: string | (string | undefined)[] | undefined,
+    envs?: string[] | Set<string>
+  ) => void;
 };

--- a/packages/back-end/types/organization.d.ts
+++ b/packages/back-end/types/organization.d.ts
@@ -3,7 +3,6 @@ import {
   ENV_SCOPED_PERMISSIONS,
   GLOBAL_PERMISSIONS,
   PROJECT_SCOPED_PERMISSIONS,
-  ReadAccessFilter,
 } from "shared/permissions";
 import { EventAuditUser } from "../src/events/event-types";
 import { AttributionModel, ImplementationType } from "./experiment";
@@ -290,8 +289,8 @@ export type ReqContext = {
   email: string;
   environments: string[];
   userName: string;
-  readAccessFilter: ReadAccessFilter;
   auditUser: EventAuditUser;
+  //TODO: Update this with actual type
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   checkPermissions: any;
 };

--- a/packages/back-end/types/organization.d.ts
+++ b/packages/back-end/types/organization.d.ts
@@ -292,4 +292,6 @@ export type ReqContext = {
   userName: string;
   readAccessFilter: ReadAccessFilter;
   auditUser: EventAuditUser;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  checkPermissions: any;
 };

--- a/packages/shared/src/permissions/permissions.utils.ts
+++ b/packages/shared/src/permissions/permissions.utils.ts
@@ -124,91 +124,14 @@ export function roleSupportsEnvLimit(role: MemberRole): boolean {
   return ["engineer", "experimenter"].includes(role);
 }
 
-export type ReadAccessFilter = {
-  globalReadAccess: boolean;
-  projects: { id: string; readAccess: boolean }[];
-};
-
-// there are some cases, like in async jobs, where we need to provide the job with full access permission. E.G. updateScheduledFeature
-export const FULL_ACCESS_PERMISSIONS: ReadAccessFilter = {
-  globalReadAccess: true,
-  projects: [],
-};
-
-export function getApiKeyReadAccessFilter(
-  role: string | undefined
-): ReadAccessFilter {
-  let readAccessFilter: ReadAccessFilter = {
-    globalReadAccess: false,
-    projects: [],
-  };
-
-  // Eventually, we may support API keys that don't have readAccess for all projects
-  if (role && (role === "admin" || role === "readonly")) {
-    readAccessFilter = FULL_ACCESS_PERMISSIONS;
-  }
-
-  return readAccessFilter;
-}
-
-export function getReadAccessFilter(userPermissions: UserPermissions) {
-  const readAccess: ReadAccessFilter = {
-    globalReadAccess: userPermissions.global.permissions.readData || false,
-    projects: [],
-  };
-
-  Object.entries(userPermissions.projects).forEach(
-    ([project, projectPermissions]) => {
-      readAccess.projects.push({
-        id: project,
-        readAccess: projectPermissions.permissions.readData || false,
-      });
-    }
-  );
-
-  return readAccess;
-}
 export function hasReadAccess(
-  filter: ReadAccessFilter,
-  projects: string | string[] | undefined
-): boolean {
-  // If the resource is available to all projects (an empty array), then everyone should have read access
-  if (Array.isArray(projects) && !projects?.length) {
-    return true;
-  }
-
-  const hasGlobaReadAccess = filter.globalReadAccess;
-
-  // if the user doesn't have project specific roles or resource doesn't have a project (project is an empty string), fallback to user's global role
-  if (!filter.projects.length || !projects) {
-    return hasGlobaReadAccess;
-  }
-
-  const resourceProjects = Array.isArray(projects) ? projects : [projects];
-
-  // if the user doesn't have global read access, but they do have read access for atleast one of the resource's projects, allow read access to resource
-  if (!hasGlobaReadAccess) {
-    return resourceProjects.some((project) => {
-      return filter.projects.some((p) => p.id === project && p.readAccess);
-    });
-  }
-
-  // otherwise, don't allow read access only if the user's project-specific roles restrict read access for all of the resource's projects
-  const everyProjectRestrictsReadAccess = resourceProjects.every((project) => {
-    return filter.projects.some((p) => p.id === project && !p.readAccess);
-  });
-
-  return everyProjectRestrictsReadAccess ? false : true;
-}
-
-export function hasReadAccess2(
   context: ReqContext | ApiReqContext,
   projects: string | string[] | undefined
 ): boolean {
   try {
     context.checkPermissions("readData", projects);
   } catch (e) {
-    console.log("hasReadAccess2 error", e);
+    // The checkPermission functions throws an error if the user doesn't have permission - here was just want to return false
     return false;
   }
   return true;

--- a/packages/shared/src/permissions/permissions.utils.ts
+++ b/packages/shared/src/permissions/permissions.utils.ts
@@ -1,7 +1,9 @@
+import { ApiReqContext } from "back-end/types/api";
 import {
   Permission,
   UserPermissions,
   MemberRole,
+  ReqContext,
 } from "back-end/types/organization";
 
 export const ENV_SCOPED_PERMISSIONS = [
@@ -197,4 +199,17 @@ export function hasReadAccess(
   });
 
   return everyProjectRestrictsReadAccess ? false : true;
+}
+
+export function hasReadAccess2(
+  context: ReqContext | ApiReqContext,
+  projects: string | string[] | undefined
+): boolean {
+  try {
+    context.checkPermissions("readData", projects);
+  } catch (e) {
+    console.log("hasReadAccess2 error", e);
+    return false;
+  }
+  return true;
 }


### PR DESCRIPTION
### Features and Changes

Now that we have the concept of READ_ONLY_PERMISSIONS the logic of hasReadAccess and checkPermissions is duplicated, so I've got a draft PR up that adds checkPermissions to the backend context object, which allows us to use checkPermissions when using the hasReadAccess filter function.

Currently, checkPermissions throws an error if the user doesn't have permission, but hasReadAccess is used to filter resources so we only return resources the user has readData permission for, so we don't want it to throw an error, but simply return false if the user doesn't have permission. As such, hasReadAccess still exists as a function, but it's a wrapper that calls checkPermissions.

### Testing

<!--
  Please describe how to test these changes.
 -->

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
