### PR TITLE
Update Test Query permission check

### DIFF
--- a/packages/back-end/src/controllers/datasources.ts
+++ b/packages/back-end/src/controllers/datasources.ts
@@ -725,7 +725,7 @@ export async function testLimitedQuery(
     });
   }
   req.checkPermissions(
-    "editDatasourceSettings",
+    "runQueries",
     datasource?.projects?.length ? datasource.projects : ""
   );
 


### PR DESCRIPTION
### Features and Changes

Previously, when a user was trying to test a query for a metric, we were checking the `editDatasourceSettings` permission, when in reality we should've just been checking the `runQueries` permission. 

The latter permission, is a `read-only-type` which means the user just needs to have that permission in at least 1 project that the metric is associated with, in order to have permission.

### Testing

- [x] Log in as a user with a global role of `noaccess` and a project-level role of `experimenter` and ensure that they can test queries.
