### PR TITLE
custom results info banner

### DIFF
--- a/packages/front-end/.env.example
+++ b/packages/front-end/.env.example
@@ -3,3 +3,5 @@ API_HOST=http://localhost:3100
 # We collect anonymous telemetry data to help improve GrowthBook
 # Setting the below to "true" disables this behavior
 DISABLE_TELEMETRY=true
+
+NEXT_PUBLIC_RESULTS_CUSTOM_INFO_BANNER=false

--- a/packages/front-end/components/Experiment/CustomInfoBanner.tsx
+++ b/packages/front-end/components/Experiment/CustomInfoBanner.tsx
@@ -1,0 +1,19 @@
+import clsx from "clsx";
+
+const CustomInfoBanner = () => {
+  // To enable this component, set NEXT_PUBLIC_RESULTS_CUSTOM_INFO_BANNER to true
+  // You can access internal models and hooks here as well, for example:
+  // const { experiment } = useSnapshot();
+  // const orgSettings = useOrgSettings();
+  return (
+    <div
+      className={clsx("alert mb-0 rounded-0", {
+        "alert-info": true,
+      })}
+    >
+      <a>Add a custom info banner here!</a>
+    </div>
+  );
+};
+
+export default CustomInfoBanner;

--- a/packages/front-end/components/Experiment/DynamicComponentLoader.tsx
+++ b/packages/front-end/components/Experiment/DynamicComponentLoader.tsx
@@ -1,0 +1,29 @@
+import React, { Suspense, lazy } from "react";
+
+// Optional: Define a mapping if you have a limited set of components to choose from
+const envVarMapping = {
+  CustomInfoBanner: process.env.NEXT_PUBLIC_RESULTS_CUSTOM_INFO_BANNER,
+};
+
+const componentMapping = {
+  CustomInfoBanner: lazy(() => import("./CustomInfoBanner")),
+};
+
+const DynamicComponentLoader = ({ componentName }) => {
+  if (envVarMapping[componentName] === "false") {
+    return null;
+  }
+  const ComponentToRender = componentMapping[componentName];
+
+  if (!ComponentToRender) {
+    return null; // or some fallback UI
+  }
+
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <ComponentToRender />
+    </Suspense>
+  );
+};
+
+export default DynamicComponentLoader;

--- a/packages/front-end/components/Experiment/Results.tsx
+++ b/packages/front-end/components/Experiment/Results.tsx
@@ -20,6 +20,7 @@ import { GBCuped, GBSequential } from "@/components/Icons";
 import useOrgSettings from "@/hooks/useOrgSettings";
 import { trackSnapshot } from "@/services/track";
 import { ExperimentTab } from "./TabbedPage";
+import DynamicComponentLoader from "./DynamicComponentLoader";
 
 const BreakDownResults = dynamic(
   () => import("@/components/Experiment/BreakDownResults")
@@ -169,29 +170,32 @@ const Results: FC<{
   return (
     <>
       {!draftMode ? (
-        <AnalysisSettingsBar
-          mutateExperiment={mutateExperiment}
-          setAnalysisSettings={setAnalysisSettings}
-          editMetrics={editMetrics}
-          variations={variations}
-          editPhases={editPhases}
-          alwaysShowPhaseSelector={alwaysShowPhaseSelector}
-          statsEngine={statsEngine}
-          regressionAdjustmentAvailable={regressionAdjustmentAvailable}
-          regressionAdjustmentEnabled={regressionAdjustmentEnabled}
-          regressionAdjustmentHasValidMetrics={
-            regressionAdjustmentHasValidMetrics
-          }
-          onRegressionAdjustmentChange={onRegressionAdjustmentChange}
-          newUi={true}
-          showMoreMenu={false}
-          variationFilter={variationFilter}
-          setVariationFilter={(v: number[]) => setVariationFilter?.(v)}
-          baselineRow={baselineRow}
-          setBaselineRow={(b: number) => setBaselineRow?.(b)}
-          differenceType={differenceType}
-          setDifferenceType={setDifferenceType}
-        />
+        <>
+          <DynamicComponentLoader componentName="CustomInfoBanner" />
+          <AnalysisSettingsBar
+            mutateExperiment={mutateExperiment}
+            setAnalysisSettings={setAnalysisSettings}
+            editMetrics={editMetrics}
+            variations={variations}
+            editPhases={editPhases}
+            alwaysShowPhaseSelector={alwaysShowPhaseSelector}
+            statsEngine={statsEngine}
+            regressionAdjustmentAvailable={regressionAdjustmentAvailable}
+            regressionAdjustmentEnabled={regressionAdjustmentEnabled}
+            regressionAdjustmentHasValidMetrics={
+              regressionAdjustmentHasValidMetrics
+            }
+            onRegressionAdjustmentChange={onRegressionAdjustmentChange}
+            newUi={true}
+            showMoreMenu={false}
+            variationFilter={variationFilter}
+            setVariationFilter={(v: number[]) => setVariationFilter?.(v)}
+            baselineRow={baselineRow}
+            setBaselineRow={(b: number) => setBaselineRow?.(b)}
+            differenceType={differenceType}
+            setDifferenceType={setDifferenceType}
+          />
+        </>
       ) : (
         <StatusBanner
           mutateExperiment={mutateExperiment}

--- a/packages/front-end/components/Experiment/StatusBanner.tsx
+++ b/packages/front-end/components/Experiment/StatusBanner.tsx
@@ -4,13 +4,14 @@ import { useAuth } from "@/services/auth";
 import Button from "@/components/Button";
 import Markdown from "@/components/Markdown/Markdown";
 import { useSnapshot } from "./SnapshotProvider";
+import DynamicComponentLoader from "./DynamicComponentLoader";
 
 export interface Props {
   mutateExperiment: () => void;
   editResult?: () => void;
 }
 
-export default function StatusBanner({ mutateExperiment, editResult }: Props) {
+function StatusBannerInner({ mutateExperiment, editResult }: Props) {
   const { experiment } = useSnapshot();
   const { apiCall } = useAuth();
 
@@ -143,4 +144,17 @@ export default function StatusBanner({ mutateExperiment, editResult }: Props) {
   }
 
   return null;
+}
+
+export default function StatusBanner({ mutateExperiment, editResult }: Props) {
+  return (
+    <>
+      <DynamicComponentLoader componentName="CustomInfoBanner" />
+      <br />
+      <StatusBannerInner
+        mutateExperiment={mutateExperiment}
+        editResult={editResult}
+      />
+    </>
+  );
 }


### PR DESCRIPTION
### Features and Changes

Adds an environment variable toggle-able "CustomInfoBanner" that can be used to provide a custom banner on the experiment results view for self-hosted deployments.

This is achieved via a "DynamicComponentLoader" class that takes a `componentName` property and looks at env var flags (currently only one), and based on that conditionally loads a mapped component.

We use this currently to inform users of new features, documentation, or changes in how we are using GrowthBook internally. Ideally this would be something that's supported on the cloud-hosted instance as well, but I'm not sure really how that'd be able to be implemented (unless it just allowed completely static HTML). This solution is nice as it allows for dynamically loading a pre-compiled component, which can import and access experiment/org/user models and dynamically change the content based on that.

To enable this info banner the environment variable `NEXT_PUBLIC_RESULTS_CUSTOM_INFO_BANNER` needs to be set to `true` (otherwise the DynamicComponentLoader just returns `null`, resulting in no additional component being added to the results view).

### Testing

I've attached screenshots showing an example of how we're using it, as well as what the results view looks like with `NEXT_PUBLIC_RESULTS_CUSTOM_INFO_BANNER` enabled (but no changes to `CustomInfoBanner.tsx`), as well as when the env var is unset/set to false.

### Screenshots

![Screenshot 2024-02-29 at 10 39 02 AM](https://github.com/discord/growthbook/assets/990274/fea7f9c4-5e04-4766-908b-ed90ece74d54)

![Screenshot 2024-02-29 at 10 54 52 AM](https://github.com/discord/growthbook/assets/990274/75c2997f-c2c3-47ff-9bcd-77ee32e85095)

![Screenshot 2024-02-29 at 11 04 46 AM](https://github.com/growthbook/growthbook/assets/990274/0099c9fe-e487-4df5-b6f9-0c4bd6738dbc)
