### PR TITLE
Coderefs - Bump to latest

### DIFF
--- a/.github/workflows/coderefs.yml
+++ b/.github/workflows/coderefs.yml
@@ -17,7 +17,7 @@ jobs:
           # https://github.com/growthbook/gb-find-code-refs#searching-for-unused-flags-extinctions
           fetch-depth: 11 
       - name: GrowthBook Code References
-        uses: growthbook/coderefs-action@2.11.5-13
+        uses: growthbook/coderefs-action@2.11.5-14
         with:
           apiKey: ${{ secrets.GB_API_TOKEN }}
           apiHost: ${{ secrets.GB_API_HOST }}


### PR DESCRIPTION
The versioning for [coderefs-action](https://github.com/growthbook/coderefs-action) was out of sync (see [here](https://github.com/growthbook/coderefs-action/issues/1)) and has been updated. This PR puts us on latest.