### PR TITLE
Escape single quotes in Traffic SQL query

### DIFF
--- a/packages/back-end/src/integrations/BigQuery.ts
+++ b/packages/back-end/src/integrations/BigQuery.ts
@@ -148,7 +148,7 @@ export default class BigQuery extends SqlIntegration {
     return `cast(${col} as string)`;
   }
   escapeStringLiteral(value: string): string {
-    return value.replace(/'/g, `\\'`);
+    return value.replace(/(['\\])/g, "\\$1");
   }
   castUserDateCol(column: string): string {
     return `CAST(${column} as DATETIME)`;

--- a/packages/back-end/src/integrations/BigQuery.ts
+++ b/packages/back-end/src/integrations/BigQuery.ts
@@ -147,6 +147,9 @@ export default class BigQuery extends SqlIntegration {
   castToString(col: string): string {
     return `cast(${col} as string)`;
   }
+  escapeStringLiteral(value: string): string {
+    return value.replace(/'/g, `\\'`);
+  }
   castUserDateCol(column: string): string {
     return `CAST(${column} as DATETIME)`;
   }

--- a/packages/back-end/src/integrations/Databricks.ts
+++ b/packages/back-end/src/integrations/Databricks.ts
@@ -48,6 +48,9 @@ export default class Databricks extends SqlIntegration {
   ensureFloat(col: string): string {
     return `cast(${col} as double)`;
   }
+  escapeStringLiteral(value: string): string {
+    return value.replace(/'/g, `\\'`);
+  }
 
   getDefaultDatabase(): string {
     return this.params.catalog;

--- a/packages/back-end/src/integrations/Databricks.ts
+++ b/packages/back-end/src/integrations/Databricks.ts
@@ -49,7 +49,7 @@ export default class Databricks extends SqlIntegration {
     return `cast(${col} as double)`;
   }
   escapeStringLiteral(value: string): string {
-    return value.replace(/'/g, `\\'`);
+    return value.replace(/(['\\])/g, "\\$1");
   }
 
   getDefaultDatabase(): string {

--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -221,6 +221,9 @@ export default abstract class SqlIntegration
   ensureFloat(col: string): string {
     return col;
   }
+  escapeStringLiteral(value: string): string {
+    return value.replace(/'/g, `''`);
+  }
   castUserDateCol(column: string): string {
     return column;
   }
@@ -1030,7 +1033,9 @@ export default abstract class SqlIntegration
 
   getDimensionInStatement(dimension: string, values: string[]): string {
     return this.ifElse(
-      `${this.castToString(dimension)} IN ('${values.join("','")}')`,
+      `${this.castToString(dimension)} IN (${values
+        .map((v) => `'` + this.escapeStringLiteral(v) + `'`)
+        .join(",")})`,
       this.castToString(dimension),
       this.castToString(`'${AUTOMATIC_DIMENSION_OTHER_NAME}'`)
     );

--- a/packages/back-end/test/sqlintegration.test.ts
+++ b/packages/back-end/test/sqlintegration.test.ts
@@ -2,8 +2,9 @@ import BigQuery from "../src/integrations/BigQuery";
 import { MetricInterface } from "../types/metric";
 
 describe("bigquery integration", () => {
+  const bqIntegration = new BigQuery("", {});
+
   it("builds the correct aggregate metric column", () => {
-    const bqIntegration = new BigQuery("", {});
     const baseMetric: MetricInterface = {
       datasource: "",
       dateCreated: new Date(),
@@ -213,5 +214,10 @@ describe("bigquery integration", () => {
         activationMetric
       )
     ).toEqual(92);
+  });
+  it("escape single quotes and backslash correctly", () => {
+    expect(bqIntegration["escapeStringLiteral"](`test\\'string`)).toEqual(
+      `test\\\\\\'string`
+    );
   });
 });


### PR DESCRIPTION
If a pre-specified dimension value had a single quote in it (`'`), it would fail when creating the categories in the traffic health query.

This PR adds a new method `escapeStringLiteral` which can be used to ensure string literals are well formatted.

Most SQL engines can just use `''` to represent `'`, but BigQuery and Databricks need `\'`. This approach satisfies both.

Tested in app by creating fake dimension with single quotes and verifying traffic query works correctly:

* BigQuery
* Postgres

Tested just that the escaping works in a simple test query:

* Databricks