### PR TITLE
Fixes permission bug with deleting metrics.

### DIFF
--- a/packages/back-end/src/controllers/datasources.ts
+++ b/packages/back-end/src/controllers/datasources.ts
@@ -726,7 +726,7 @@ export async function testLimitedQuery(
   }
   req.checkPermissions(
     "runQueries",
-    datasource?.projects?.length ? datasource.projects : []
+    datasource?.projects?.length ? datasource.projects : ""
   );
 
   const { results, sql, duration, error } = await testQuery(
@@ -811,7 +811,7 @@ export async function postDimensionSlices(
   }
   req.checkPermissions(
     "runQueries",
-    datasourceObj?.projects?.length ? datasourceObj.projects : []
+    datasourceObj?.projects?.length ? datasourceObj.projects : ""
   );
 
   const integration = getSourceIntegrationObject(datasourceObj, true);
@@ -858,7 +858,7 @@ export async function cancelDimensionSlices(
 
   req.checkPermissions(
     "runQueries",
-    datasource.projects ? datasource.projects : []
+    datasource.projects ? datasource.projects : ""
   );
 
   const integration = getSourceIntegrationObject(datasource, true);

--- a/packages/back-end/src/controllers/datasources.ts
+++ b/packages/back-end/src/controllers/datasources.ts
@@ -726,7 +726,7 @@ export async function testLimitedQuery(
   }
   req.checkPermissions(
     "runQueries",
-    datasource?.projects?.length ? datasource.projects : ""
+    datasource?.projects?.length ? datasource.projects : []
   );
 
   const { results, sql, duration, error } = await testQuery(
@@ -811,7 +811,7 @@ export async function postDimensionSlices(
   }
   req.checkPermissions(
     "runQueries",
-    datasourceObj?.projects?.length ? datasourceObj.projects : ""
+    datasourceObj?.projects?.length ? datasourceObj.projects : []
   );
 
   const integration = getSourceIntegrationObject(datasourceObj, true);
@@ -858,7 +858,7 @@ export async function cancelDimensionSlices(
 
   req.checkPermissions(
     "runQueries",
-    datasource.projects ? datasource.projects : ""
+    datasource.projects ? datasource.projects : []
   );
 
   const integration = getSourceIntegrationObject(datasource, true);

--- a/packages/back-end/src/controllers/informationSchemas.ts
+++ b/packages/back-end/src/controllers/informationSchemas.ts
@@ -224,8 +224,8 @@ export async function putInformationSchema(
   }
 
   req.checkPermissions(
-    "editDatasourceSettings",
-    datasource?.projects?.length ? datasource.projects : ""
+    "runQueries",
+    datasource?.projects?.length ? datasource.projects : []
   );
 
   await queueUpdateInformationSchema(

--- a/packages/back-end/src/controllers/metrics.ts
+++ b/packages/back-end/src/controllers/metrics.ts
@@ -189,7 +189,7 @@ export async function cancelMetricAnalysis(
 
   req.checkPermissions(
     "runQueries",
-    metric.projects?.length ? metric.projects : []
+    metric.projects?.length ? metric.projects : ""
   );
 
   const integration = await getIntegrationFromDatasourceId(

--- a/packages/back-end/src/controllers/metrics.ts
+++ b/packages/back-end/src/controllers/metrics.ts
@@ -78,8 +78,6 @@ export async function deleteMetric(
   req: AuthRequest<null, { id: string }>,
   res: Response<unknown, EventAuditUserForResponseLocals>
 ) {
-  req.checkPermissions("createAnalyses", "");
-
   const context = getContextFromReq(req);
   const { id } = req.params;
 
@@ -92,6 +90,11 @@ export async function deleteMetric(
     });
     return;
   }
+
+  req.checkPermissions(
+    "createAnalyses",
+    metric?.projects?.length ? metric.projects : ""
+  );
 
   req.checkPermissions(
     "createMetrics",

--- a/packages/back-end/src/controllers/metrics.ts
+++ b/packages/back-end/src/controllers/metrics.ts
@@ -189,7 +189,7 @@ export async function cancelMetricAnalysis(
 
   req.checkPermissions(
     "runQueries",
-    metric.projects?.length ? metric.projects : ""
+    metric.projects?.length ? metric.projects : []
   );
 
   const integration = await getIntegrationFromDatasourceId(

--- a/packages/shared/src/permissions/permissions.utils.ts
+++ b/packages/shared/src/permissions/permissions.utils.ts
@@ -100,7 +100,7 @@ export const userHasPermission = (
   if (READ_ONLY_PERMISSIONS.includes(permission)) {
     if (
       checkProjects.length === 1 &&
-      checkProjects[0] === undefined &&
+      !checkProjects[0] &&
       Object.keys(userPermissions.projects).length
     ) {
       // add all of the projects the user has project-level roles for

--- a/packages/shared/src/permissions/permissions.utils.ts
+++ b/packages/shared/src/permissions/permissions.utils.ts
@@ -102,7 +102,7 @@ export const userHasPermission = (
   if (READ_ONLY_PERMISSIONS.includes(permission)) {
     if (
       checkProjects.length === 1 &&
-      !checkProjects[0] &&
+      checkProjects[0] === undefined &&
       Object.keys(userPermissions.projects).length
     ) {
       // add all of the projects the user has project-level roles for


### PR DESCRIPTION
### Features and Changes

When deleting metrics, we were checking for `createAnalyses` permissions, but not passing in the projects the metric is associated with, so it was defaulting to checking the user's global role.

This PR also updates the `userHasPermission` logic for `READ_ONLY_TYPE` permissions so that it's less fragile around if an empty string or an empty array is passed in for the `project` prop.

I'd like to do a follow up PR that updates the signature of `userHasPermission` so it only accepts an array of strings (or its undefined).

This will remove the need for engineers to pass in an empty string or empty array for any resource that can be in multiple projects (e.g. metrics, datasources, etc). And for resources that can only be a part of a single project (feature, experiment, idea) - the engineer will either need to pass in the resource's project, if there is one, or any empty array. 

### Testing

- [x] Ensure that analysts and experimenters can delete metrics they have created or any metrics that have the ability to edit (e.g. metrics where they have create/edit metrics permissions in every one of the projects the metric is in)
- [x] Ensure that users with a global role of `noaccess` and project specific `experimenter` permissions can create/test metrics that are connected to a datasource that is in "All Projects".
