### PR TITLE
When generating the SDK payload, always use context w/ full read access

### DIFF
--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -69,7 +69,11 @@ import {
 import { ArchetypeAttributeValues } from "../../types/archetype";
 import { FeatureRevisionInterface } from "../../types/feature-revision";
 import { triggerWebhookJobs } from "../jobs/updateAllJobs";
-import { getEnvironmentIdsFromOrg, getOrganizationById } from "./organizations";
+import {
+  getContextForAgendaJobByOrgObject,
+  getEnvironmentIdsFromOrg,
+  getOrganizationById,
+} from "./organizations";
 
 export type AttributeMap = Map<string, string>;
 
@@ -260,12 +264,16 @@ export async function getSavedGroupMap(
 }
 
 export async function refreshSDKPayloadCache(
-  context: ReqContext | ApiReqContext,
+  baseContext: ReqContext | ApiReqContext,
   payloadKeys: SDKPayloadKey[],
   allFeatures: FeatureInterface[] | null = null,
   experimentMap?: Map<string, ExperimentInterface>,
   skipRefreshForProject?: string
 ) {
+  // This is a background job, so switch to using a background context
+  // This is required so that we have full read access to the entire org's data
+  const context = getContextForAgendaJobByOrgObject(baseContext.org);
+
   logger.debug(
     `Refreshing SDK Payloads for ${context.org.id}: ${JSON.stringify(
       payloadKeys

--- a/packages/back-end/src/services/savedGroups.ts
+++ b/packages/back-end/src/services/savedGroups.ts
@@ -9,12 +9,18 @@ import { getAffectedSDKPayloadKeys } from "../util/features";
 import { SDKPayloadKey } from "../../types/sdk-payload";
 import { ApiReqContext } from "../../types/api";
 import { refreshSDKPayloadCache } from "./features";
-import { getEnvironmentIdsFromOrg } from "./organizations";
+import {
+  getContextForAgendaJobByOrgObject,
+  getEnvironmentIdsFromOrg,
+} from "./organizations";
 
 export async function savedGroupUpdated(
-  context: ReqContext | ApiReqContext,
+  baseContext: ReqContext | ApiReqContext,
   id: string
 ) {
+  // This is a background job, so create a new context with full read permissions
+  const context = getContextForAgendaJobByOrgObject(baseContext.org);
+
   // Use a map to build a list of unique SDK payload keys
   const payloadKeys: Map<string, SDKPayloadKey> = new Map();
   const addKeys = (keys: SDKPayloadKey[]) =>


### PR DESCRIPTION
### Features and Changes

Fixes bug when a user with limited read access in some projects updates a feature they do have access to.

Currently, this will result in a broken SDK payload since it will be missing any features/experiments the user doesn't have read access to.  

After this PR, the code that generates the SDK payload will always have full read access, even if the user who kicked off the job doesn't.