### PR TITLE
Update GB app/sdk to support sticky bucketing for remote eval

### DIFF
--- a/docs/docs/lib/js.mdx
+++ b/docs/docs/lib/js.mdx
@@ -203,6 +203,12 @@ const gb = new GrowthBook({
 });
 ```
 
+:::note
+
+If you would like to implement Sticky Bucketing while using Remote Evaluation, you must configure your remote evaluation backend to support Sticky Bucketing. In the case of the GrowthBook Proxy Server, this means implementing a Redis database for sticky bucketing use. You will not need to provide a StickyBucketService instance to the client side SDK.
+
+:::
+
 #### Customize the Cache Settings
 
 The JavaScript SDK has a built-in caching layer using a browser's localStorage by default. This localStorage implementation can be polyfilled for mobile or back-end use cases.

--- a/docs/docs/lib/react.mdx
+++ b/docs/docs/lib/react.mdx
@@ -208,6 +208,12 @@ const gb = new GrowthBook({
 });
 ```
 
+:::note
+
+If you would like to implement Sticky Bucketing while using Remote Evaluation, you must configure your remote evaluation backend to support Sticky Bucketing. In the case of the GrowthBook Proxy Server, this means implementing a Redis database for sticky bucketing use. You will not need to provide a StickyBucketService instance to the client side SDK.
+
+:::
+
 ### Custom Integration
 
 If you prefer to handle the network and caching logic yourself, you can instead pass in a features JSON object directly. For example, you might store features in Postgres and send it down to your front-end as part of your app's initial bootstrap API call.

--- a/packages/back-end/package.json
+++ b/packages/back-end/package.json
@@ -32,7 +32,7 @@
     "@google-cloud/bigquery": "5",
     "@google-cloud/storage": "^5.20.5",
     "@growthbook/growthbook": "^0.34.0",
-    "@growthbook/proxy-eval": "^1.0.0",
+    "@growthbook/proxy-eval": "^1.0.2",
     "@octokit/auth-app": "^6.0.1",
     "@octokit/core": "^5.0.2",
     "@octokit/oauth-methods": "^4.0.1",

--- a/packages/sdk-js/src/index.ts
+++ b/packages/sdk-js/src/index.ts
@@ -26,6 +26,10 @@ export type {
   AutoExperiment,
   AutoExperimentVariation,
   UrlTargetType,
+  StickyAttributeKey,
+  StickyExperimentKey,
+  StickyAssignments,
+  StickyAssignmentsDocument,
 } from "./types/growthbook";
 
 export type {

--- a/packages/sdk-js/src/sticky-bucket-service.ts
+++ b/packages/sdk-js/src/sticky-bucket-service.ts
@@ -237,7 +237,7 @@ export class RedisStickyBucketService extends StickyBucketService {
       ([attributeName, attributeValue]) => `${attributeName}||${attributeValue}`
     );
     if (!this.redis) return docs;
-    this.redis.mget(...keys).then((values) => {
+    await this.redis.mget(...keys).then((values) => {
       values.forEach((raw) => {
         try {
           const data = JSON.parse(raw || "{}");

--- a/yarn.lock
+++ b/yarn.lock
@@ -2802,19 +2802,12 @@
     teeny-request "^8.0.0"
     uuid "^8.0.0"
 
-"@growthbook/growthbook@^0.29.0":
-  version "0.29.0"
-  resolved "https://registry.yarnpkg.com/@growthbook/growthbook/-/growthbook-0.29.0.tgz#357f005d9fc28b4b018358d1dd2839066fca807a"
-  integrity sha512-hRYtBw1cg3fqjBRKRfazkRfCJyFpIxjdEUjmwkFaSBorzVDiX35gcp8x83vytQdx5E9xfQo3x/m9Z1yEMDrN7A==
+"@growthbook/proxy-eval@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@growthbook/proxy-eval/-/proxy-eval-1.0.2.tgz#d5b24b3308b98365eb0b04e0e7f94497543e824c"
+  integrity sha512-2VSFhQ0VJSQuYGCw0c1OQCdVrtdD/6vMvtmxR9bB2WwSNJ6ITdCI/mmwE83MiUlKLBoRAkACI/xyOJFbTmqt7Q==
   dependencies:
-    dom-mutator "^0.5.0"
-
-"@growthbook/proxy-eval@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@growthbook/proxy-eval/-/proxy-eval-1.0.0.tgz#fbe53876fb312b9147e5187242a6c6bfcb87569e"
-  integrity sha512-I6V+GDmzXLYcT5iGXpoDxwiWJmNRHZAQdAKJBMnzVXDaOngBPbbUs/ZgHhuo/2p2VWo5EtOhTUO4xl6xcFTJaQ==
-  dependencies:
-    "@growthbook/growthbook" "^0.29.0"
+    "@growthbook/growthbook" "^0.34.0"
 
 "@grpc/grpc-js@^1.7.1":
   version "1.8.17"
@@ -11182,11 +11175,6 @@ dom-helpers@^5.0.1:
   dependencies:
     "@babel/runtime" "^7.8.7"
     csstype "^3.0.2"
-
-dom-mutator@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.npmjs.org/dom-mutator/-/dom-mutator-0.5.0.tgz"
-  integrity sha512-bbeX8HWE8JGzraFgbVBX4ws2g3heZFuTtrleQBuN7huy+7n2n7etSuVnot3/1z3jdY2MiwuvoS4Ep1UT2rrGBw==
 
 dom-mutator@^0.6.0:
   version "0.6.0"


### PR DESCRIPTION
### Features and Changes

- export helper types from SDK
- fix async bug in example Redis StickyBucketService
- update docs
- update in-app remote eval endpoint with latest sdk (doesn't implement sticky bucketing, but does support prerequisites)


### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

<!--
  Please describe how to test these changes.
 -->

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
