### PR TITLE
Add request body validation for visual change(set) endpoints in REST API

### DIFF
--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -2009,6 +2009,72 @@ paths:
             curl -XPUT https://api.growthbook.io/api/v1/visual-changesets/vc_123abc
               -d '{"editorUrl": "https://docs.growthbook.io", "urlPatterns":"[{ ... }]"}' \
               -u secret_abc123DEF456:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                urlPatterns:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - type
+                      - pattern
+                    properties:
+                      include:
+                        type: boolean
+                      type:
+                        type: string
+                        enum:
+                          - simple
+                          - regex
+                      pattern: string
+                editorUrl:
+                  type: string
+                visualChanges:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - variation
+                      - domMutations
+                    properties:
+                      description:
+                        type: string
+                      css:
+                        type: string
+                      js:
+                        type: string
+                      variation:
+                        type: string
+                      domMutations:
+                        type: array
+                        items:
+                          type: object
+                          required:
+                            - selector
+                            - action
+                            - attribute
+                          properties:
+                            selector:
+                              type: string
+                            action:
+                              type: string
+                              enum:
+                                - append
+                                - set
+                                - remove
+                            attribute:
+                              type: string
+                            value:
+                              type: string
+                            parentSelector:
+                              type: string
+                            insertBeforeSelector:
+                              type: string
       responses:
         '200':
           content:
@@ -2037,6 +2103,44 @@ paths:
             curl -XPOST https://api.growthbook.io/api/v1/visual-changesets/vc_123abc/visual-change \
               -d '{"variation": "v_123abc", "domMutations":"[]"}' \
               -u secret_abc123DEF456:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                description:
+                  type: string
+                css:
+                  type: string
+                js:
+                  type: string
+                domMutations:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - selector
+                      - action
+                      - attribute
+                    properties:
+                      selector:
+                        type: string
+                      action:
+                        type: string
+                        enum:
+                          - append
+                          - set
+                          - remove
+                      attribute:
+                        type: string
+                      value:
+                        type: string
+                      parentSelector:
+                        type: string
+                      insertBeforeSelector:
+                        type: string
       responses:
         '200':
           content:
@@ -2063,6 +2167,44 @@ paths:
             curl -XPUT https://api.growthbook.io/api/v1/visual-changesets/vc_123abc/visual-change/vch_abc123 \
               -d '{"variation": "v_123abc", "domMutations":"[]"}' \
               -u secret_abc123DEF456:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                description:
+                  type: string
+                css:
+                  type: string
+                js:
+                  type: string
+                domMutations:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - selector
+                      - action
+                      - attribute
+                    properties:
+                      selector:
+                        type: string
+                      action:
+                        type: string
+                        enum:
+                          - append
+                          - set
+                          - remove
+                      attribute:
+                        type: string
+                      value:
+                        type: string
+                      parentSelector:
+                        type: string
+                      insertBeforeSelector:
+                        type: string
       responses:
         '200':
           content:

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -2021,6 +2021,7 @@ paths:
                   items:
                     type: object
                     required:
+                      - include
                       - type
                       - pattern
                     properties:
@@ -2031,7 +2032,8 @@ paths:
                         enum:
                           - simple
                           - regex
-                      pattern: string
+                      pattern:
+                        type: string
                 editorUrl:
                   type: string
                 visualChanges:
@@ -2109,12 +2111,17 @@ paths:
           application/json:
             schema:
               type: object
+              required:
+                - variation
+                - domMutations
               properties:
                 description:
                   type: string
                 css:
                   type: string
                 js:
+                  type: string
+                variation:
                   type: string
                 domMutations:
                   type: array

--- a/packages/back-end/src/api/openapi/paths/postVisualChange.yaml
+++ b/packages/back-end/src/api/openapi/paths/postVisualChange.yaml
@@ -11,6 +11,12 @@ post:
         curl -XPOST https://api.growthbook.io/api/v1/visual-changesets/vc_123abc/visual-change \
           -d '{"variation": "v_123abc", "domMutations":"[]"}' \
           -u secret_abc123DEF456:
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: "../payload-schemas/PostVisualChangePayload.yaml"
   responses:
     "200":
       content:

--- a/packages/back-end/src/api/openapi/paths/putVisualChange.yaml
+++ b/packages/back-end/src/api/openapi/paths/putVisualChange.yaml
@@ -12,6 +12,12 @@ put:
         curl -XPUT https://api.growthbook.io/api/v1/visual-changesets/vc_123abc/visual-change/vch_abc123 \
           -d '{"variation": "v_123abc", "domMutations":"[]"}' \
           -u secret_abc123DEF456:
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: "../payload-schemas/PutVisualChangePayload.yaml"
   responses:
     "200":
       content:

--- a/packages/back-end/src/api/openapi/paths/putVisualChangeset.yaml
+++ b/packages/back-end/src/api/openapi/paths/putVisualChangeset.yaml
@@ -10,6 +10,12 @@ x-codeSamples:
       curl -XPUT https://api.growthbook.io/api/v1/visual-changesets/vc_123abc
         -d '{"editorUrl": "https://docs.growthbook.io", "urlPatterns":"[{ ... }]"}' \
         -u secret_abc123DEF456:
+requestBody:
+  required: true
+  content:
+    application/json:
+      schema:
+        $ref: "../payload-schemas/PutVisualChangesetPayload.yaml"
 responses:
   "200":
     content:

--- a/packages/back-end/src/api/openapi/payload-schemas/PostVisualChangePayload.yaml
+++ b/packages/back-end/src/api/openapi/payload-schemas/PostVisualChangePayload.yaml
@@ -1,0 +1,30 @@
+type: object
+properties:
+  description:
+    type: string
+  css:
+    type: string
+  js:
+    type: string
+  domMutations:
+    type: array
+    items:
+      type: object
+      required:
+        - selector
+        - action
+        - attribute
+      properties:
+        selector:
+          type: string
+        action:
+          type: string
+          enum: [append, set, remove]
+        attribute:
+          type: string
+        value:
+          type: string
+        parentSelector:
+          type: string
+        insertBeforeSelector:
+          type: string

--- a/packages/back-end/src/api/openapi/payload-schemas/PostVisualChangePayload.yaml
+++ b/packages/back-end/src/api/openapi/payload-schemas/PostVisualChangePayload.yaml
@@ -1,10 +1,15 @@
 type: object
+required:
+  - variation
+  - domMutations
 properties:
   description:
     type: string
   css:
     type: string
   js:
+    type: string
+  variation:
     type: string
   domMutations:
     type: array

--- a/packages/back-end/src/api/openapi/payload-schemas/PutVisualChangePayload.yaml
+++ b/packages/back-end/src/api/openapi/payload-schemas/PutVisualChangePayload.yaml
@@ -1,0 +1,30 @@
+type: object
+properties:
+  description:
+    type: string
+  css:
+    type: string
+  js:
+    type: string
+  domMutations:
+    type: array
+    items:
+      type: object
+      required:
+        - selector
+        - action
+        - attribute
+      properties:
+        selector:
+          type: string
+        action:
+          type: string
+          enum: [append, set, remove]
+        attribute:
+          type: string
+        value:
+          type: string
+        parentSelector:
+          type: string
+        insertBeforeSelector:
+          type: string

--- a/packages/back-end/src/api/openapi/payload-schemas/PutVisualChangesetPayload.yaml
+++ b/packages/back-end/src/api/openapi/payload-schemas/PutVisualChangesetPayload.yaml
@@ -5,6 +5,7 @@ properties:
     items:
       type: object
       required:
+        - include
         - type
         - pattern
       properties:
@@ -13,7 +14,8 @@ properties:
         type:
           type: string
           enum: [simple, regex]
-        pattern: string
+        pattern:
+          type: string
   editorUrl:
     type: string
   visualChanges:

--- a/packages/back-end/src/api/openapi/payload-schemas/PutVisualChangesetPayload.yaml
+++ b/packages/back-end/src/api/openapi/payload-schemas/PutVisualChangesetPayload.yaml
@@ -1,0 +1,56 @@
+type: object
+properties:
+  urlPatterns:
+    type: array
+    items:
+      type: object
+      required:
+        - type
+        - pattern
+      properties:
+        include:
+          type: boolean
+        type:
+          type: string
+          enum: [simple, regex]
+        pattern: string
+  editorUrl:
+    type: string
+  visualChanges:
+    type: array
+    items:
+      type: object
+      required:
+        - variation
+        - domMutations
+      properties:
+        description:
+          type: string
+        css:
+          type: string
+        js:
+          type: string
+        variation:
+          type: string
+        domMutations:
+          type: array
+          items:
+            type: object
+            required:
+              - selector
+              - action
+              - attribute
+            properties:
+              selector:
+                type: string
+              action:
+                type: string
+                enum: [append, set, remove]
+              attribute:
+                type: string
+              value:
+                type: string
+              parentSelector:
+                type: string
+              insertBeforeSelector:
+                type: string

--- a/packages/back-end/src/api/visual-changesets/postVisualChange.ts
+++ b/packages/back-end/src/api/visual-changesets/postVisualChange.ts
@@ -21,11 +21,11 @@ export const postVisualChange = createApiRequestHandler(
 
     req.checkPermissions("manageVisualChanges", experiment.project);
 
-    const res = await createVisualChange(
-      req.params.id,
-      req.organization.id,
-      req.body
-    );
+    const res = await createVisualChange(req.params.id, req.organization.id, {
+      ...req.body,
+      css: req.body.css || "",
+      description: req.body.description || "",
+    });
 
     return res;
   }

--- a/packages/back-end/src/api/visual-changesets/putVisualChangeset.ts
+++ b/packages/back-end/src/api/visual-changesets/putVisualChangeset.ts
@@ -32,11 +32,20 @@ export const putVisualChangeset = createApiRequestHandler(
 
     req.checkPermissions("manageVisualChanges", experiment.project);
 
+    const visualChanges = req.body.visualChanges || [];
+
     const res = await updateVisualChangeset({
       visualChangeset,
       experiment,
       context: req.context,
-      updates: req.body,
+      updates: {
+        ...req.body,
+        visualChanges: visualChanges.map((vc) => ({
+          ...vc,
+          description: vc.description || "",
+          css: vc.css || "",
+        })),
+      },
     });
 
     const updatedVisualChangeset = await findVisualChangesetById(

--- a/packages/back-end/src/validators/openapi.ts
+++ b/packages/back-end/src/validators/openapi.ts
@@ -175,13 +175,13 @@ export const getVisualChangesetValidator = {
 };
 
 export const putVisualChangesetValidator = {
-  bodySchema: z.object({"urlPatterns":z.array(z.object({"include":z.boolean().optional(),"type":z.enum(["simple","regex"]),"pattern":z.unknown()})).optional(),"editorUrl":z.string().optional(),"visualChanges":z.array(z.object({"description":z.string().optional(),"css":z.string().optional(),"js":z.string().optional(),"variation":z.string(),"domMutations":z.array(z.object({"selector":z.string(),"action":z.enum(["append","set","remove"]),"attribute":z.string(),"value":z.string().optional(),"parentSelector":z.string().optional(),"insertBeforeSelector":z.string().optional()}))})).optional()}).strict(),
+  bodySchema: z.object({"urlPatterns":z.array(z.object({"include":z.boolean(),"type":z.enum(["simple","regex"]),"pattern":z.string()})).optional(),"editorUrl":z.string().optional(),"visualChanges":z.array(z.object({"description":z.string().optional(),"css":z.string().optional(),"js":z.string().optional(),"variation":z.string(),"domMutations":z.array(z.object({"selector":z.string(),"action":z.enum(["append","set","remove"]),"attribute":z.string(),"value":z.string().optional(),"parentSelector":z.string().optional(),"insertBeforeSelector":z.string().optional()}))})).optional()}).strict(),
   querySchema: z.never(),
   paramsSchema: z.object({"id":z.string()}).strict(),
 };
 
 export const postVisualChangeValidator = {
-  bodySchema: z.object({"description":z.string().optional(),"css":z.string().optional(),"js":z.string().optional(),"domMutations":z.array(z.object({"selector":z.string(),"action":z.enum(["append","set","remove"]),"attribute":z.string(),"value":z.string().optional(),"parentSelector":z.string().optional(),"insertBeforeSelector":z.string().optional()})).optional()}).strict(),
+  bodySchema: z.object({"description":z.string().optional(),"css":z.string().optional(),"js":z.string().optional(),"variation":z.string(),"domMutations":z.array(z.object({"selector":z.string(),"action":z.enum(["append","set","remove"]),"attribute":z.string(),"value":z.string().optional(),"parentSelector":z.string().optional(),"insertBeforeSelector":z.string().optional()}))}).strict(),
   querySchema: z.never(),
   paramsSchema: z.object({"id":z.string()}).strict(),
 };

--- a/packages/back-end/src/validators/openapi.ts
+++ b/packages/back-end/src/validators/openapi.ts
@@ -175,19 +175,19 @@ export const getVisualChangesetValidator = {
 };
 
 export const putVisualChangesetValidator = {
-  bodySchema: z.never(),
+  bodySchema: z.object({"urlPatterns":z.array(z.object({"include":z.boolean().optional(),"type":z.enum(["simple","regex"]),"pattern":z.unknown()})).optional(),"editorUrl":z.string().optional(),"visualChanges":z.array(z.object({"description":z.string().optional(),"css":z.string().optional(),"js":z.string().optional(),"variation":z.string(),"domMutations":z.array(z.object({"selector":z.string(),"action":z.enum(["append","set","remove"]),"attribute":z.string(),"value":z.string().optional(),"parentSelector":z.string().optional(),"insertBeforeSelector":z.string().optional()}))})).optional()}).strict(),
   querySchema: z.never(),
   paramsSchema: z.object({"id":z.string()}).strict(),
 };
 
 export const postVisualChangeValidator = {
-  bodySchema: z.never(),
+  bodySchema: z.object({"description":z.string().optional(),"css":z.string().optional(),"js":z.string().optional(),"domMutations":z.array(z.object({"selector":z.string(),"action":z.enum(["append","set","remove"]),"attribute":z.string(),"value":z.string().optional(),"parentSelector":z.string().optional(),"insertBeforeSelector":z.string().optional()})).optional()}).strict(),
   querySchema: z.never(),
   paramsSchema: z.object({"id":z.string()}).strict(),
 };
 
 export const putVisualChangeValidator = {
-  bodySchema: z.never(),
+  bodySchema: z.object({"description":z.string().optional(),"css":z.string().optional(),"js":z.string().optional(),"domMutations":z.array(z.object({"selector":z.string(),"action":z.enum(["append","set","remove"]),"attribute":z.string(),"value":z.string().optional(),"parentSelector":z.string().optional(),"insertBeforeSelector":z.string().optional()})).optional()}).strict(),
   querySchema: z.never(),
   paramsSchema: z.object({"id":z.string(),"visualChangeId":z.string()}).strict(),
 };

--- a/packages/back-end/types/openapi.d.ts
+++ b/packages/back-end/types/openapi.d.ts
@@ -4457,6 +4457,34 @@ export interface operations {
         id: string;
       };
     };
+    requestBody: {
+      content: {
+        "application/json": {
+          urlPatterns?: ({
+              include?: boolean;
+              /** @enum {string} */
+              type: "simple" | "regex";
+              pattern: string;
+            })[];
+          editorUrl?: string;
+          visualChanges?: ({
+              description?: string;
+              css?: string;
+              js?: string;
+              variation: string;
+              domMutations: ({
+                  selector: string;
+                  /** @enum {string} */
+                  action: "append" | "set" | "remove";
+                  attribute: string;
+                  value?: string;
+                  parentSelector?: string;
+                  insertBeforeSelector?: string;
+                })[];
+            })[];
+        };
+      };
+    };
     responses: {
       200: {
         content: {
@@ -4495,6 +4523,24 @@ export interface operations {
   };
   postVisualChange: {
     /** Create a visual change for a visual changeset */
+    requestBody: {
+      content: {
+        "application/json": {
+          description?: string;
+          css?: string;
+          js?: string;
+          domMutations?: ({
+              selector: string;
+              /** @enum {string} */
+              action: "append" | "set" | "remove";
+              attribute: string;
+              value?: string;
+              parentSelector?: string;
+              insertBeforeSelector?: string;
+            })[];
+        };
+      };
+    };
     responses: {
       200: {
         content: {
@@ -4507,6 +4553,24 @@ export interface operations {
   };
   putVisualChange: {
     /** Update a visual change for a visual changeset */
+    requestBody: {
+      content: {
+        "application/json": {
+          description?: string;
+          css?: string;
+          js?: string;
+          domMutations?: ({
+              selector: string;
+              /** @enum {string} */
+              action: "append" | "set" | "remove";
+              attribute: string;
+              value?: string;
+              parentSelector?: string;
+              insertBeforeSelector?: string;
+            })[];
+        };
+      };
+    };
     responses: {
       200: {
         content: {

--- a/packages/back-end/types/openapi.d.ts
+++ b/packages/back-end/types/openapi.d.ts
@@ -4461,7 +4461,7 @@ export interface operations {
       content: {
         "application/json": {
           urlPatterns?: ({
-              include?: boolean;
+              include: boolean;
               /** @enum {string} */
               type: "simple" | "regex";
               pattern: string;
@@ -4529,7 +4529,8 @@ export interface operations {
           description?: string;
           css?: string;
           js?: string;
-          domMutations?: ({
+          variation: string;
+          domMutations: ({
               selector: string;
               /** @enum {string} */
               action: "append" | "set" | "remove";

--- a/packages/back-end/types/visual-changeset.d.ts
+++ b/packages/back-end/types/visual-changeset.d.ts
@@ -30,3 +30,9 @@ export interface VisualChangesetInterface {
   experiment: string;
   visualChanges: VisualChange[];
 }
+
+export type UpdateVisualChangesetInterface = Partial<
+  Omit<VisualChangesetInterface, "visualChanges">
+> & {
+  visualChanges?: Omit<VisualChange, "id">[];
+};


### PR DESCRIPTION
This PR adds missing request body validations for our VisualChange(set) endpoints in the REST API.

Was revealed in a support issue regarding the Devtools extension. The customer revealed they had used the API to create their visual experiments, which had inexplicable values set for their variation payloads.