### PR TITLE
Bump Javascript SDK to 0.35.0, React to 0.25.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,14 +165,15 @@ Releasing SDK updates is a very manual process right now. It requires bumping ve
    - Bump dependency version in `package/front-end/package.json`
    - Add new entry to `packages/shared/src/sdk-versioning/sdk-versions/react.json`
 4. Do a global search for the old version strings for both Javascript and React to make sure nothing was missed. Update these instructions if needed.
-5. Create a PR and let CI complete successfully
-6. Publish the Javascript SDK
+5. Run `yarn install`
+6. Create a PR and let CI complete successfully
+7. Publish the Javascript SDK
    - `yarn build`
    - `npm publish`
-7. Publish the React SDK
+8. Publish the React SDK
    - `yarn build`
    - `npm publish`
-8. Merge the PR
+9. Merge the PR
 
 ### Working on the stats engine
 

--- a/package.json
+++ b/package.json
@@ -63,6 +63,9 @@
       "bash -c \"yarn workspace stats lint\" && :"
     ]
   },
+  "resolutions": {
+    "@growthbook/growthbook": "0.35.0"
+  },
   "prettier": {
     "overrides": [
       {

--- a/packages/back-end/package.json
+++ b/packages/back-end/package.json
@@ -31,7 +31,7 @@
     "@dqbd/tiktoken": "^1.0.7",
     "@google-cloud/bigquery": "5",
     "@google-cloud/storage": "^5.20.5",
-    "@growthbook/growthbook": "^0.34.0",
+    "@growthbook/growthbook": "^0.35.0",
     "@growthbook/proxy-eval": "^1.0.2",
     "@octokit/auth-app": "^6.0.1",
     "@octokit/core": "^5.0.2",

--- a/packages/front-end/package.json
+++ b/packages/front-end/package.json
@@ -19,7 +19,7 @@
     "@dnd-kit/core": "^4.0.3",
     "@dnd-kit/sortable": "^5.1.0",
     "@floating-ui/react": "^0.25.4",
-    "@growthbook/growthbook-react": "^0.24.0",
+    "@growthbook/growthbook-react": "^0.25.0",
     "@jitsu/sdk-js": "^2.2.0",
     "@jukben/emoji-search": "^2.0.1",
     "@popperjs/core": "^2.11.5",

--- a/packages/sdk-js/CHANGELOG.md
+++ b/packages/sdk-js/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## **0.35.0** - Mar 8, 2024
+
+- New `updateAttributes` method to make partial updates
+- Fix missing `await` in RedisStickyBucketService
+- New `context.renderer` option
+- Various improvements to `auto.min.js` script
+  - New `window.growthbook_queue` to make it easier to work with an async script tag
+  - New `pageTitle` auto attribute
+  - Fixed bugs with built-in GA4 and GTM tracking calls
+  - New `growthbookrefresh` DOM event you can trigger to for re-evaluation of auto attributes
+
 ## **0.34.0** - Feb 20, 2024
 
 - Prerequisite feature support for feature rules and experiments

--- a/packages/sdk-js/package.json
+++ b/packages/sdk-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@growthbook/growthbook",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/sdk-react/package.json
+++ b/packages/sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@growthbook/growthbook-react",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -38,7 +38,7 @@
     "react": "^16.8.0-0 || ^17.0.0-0 || ^18.0.0-0"
   },
   "dependencies": {
-    "@growthbook/growthbook": "^0.34.0"
+    "@growthbook/growthbook": "^0.35.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.19.3",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -17,7 +17,7 @@
     "type-check": "tsc --pretty --noEmit"
   },
   "dependencies": {
-    "@growthbook/growthbook": "^0.34.0",
+    "@growthbook/growthbook": "^0.35.0",
     "ajv": "^8.12.0",
     "date-fns": "^2.15.0",
     "dirty-json": "^0.9.2",

--- a/packages/shared/src/sdk-versioning/sdk-versions/javascript.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/javascript.json
@@ -1,6 +1,9 @@
 {
   "versions": [
     {
+      "version": "0.35.0"
+    },
+    {
       "version": "0.34.0",
       "capabilities": ["prerequisites"]
     },

--- a/packages/shared/src/sdk-versioning/sdk-versions/nodejs.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/nodejs.json
@@ -1,6 +1,9 @@
 {
   "versions": [
     {
+      "version": "0.35.0"
+    },
+    {
       "version": "0.34.0",
       "capabilities": ["prerequisites"]
     },

--- a/packages/shared/src/sdk-versioning/sdk-versions/react.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/react.json
@@ -1,6 +1,9 @@
 {
   "versions": [
     {
+      "version": "0.25.0"
+    },
+    {
       "version": "0.24.0",
       "capabilities": ["prerequisites"]
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2802,6 +2802,13 @@
     teeny-request "^8.0.0"
     uuid "^8.0.0"
 
+"@growthbook/growthbook@^0.34.0":
+  version "0.34.0"
+  resolved "https://registry.yarnpkg.com/@growthbook/growthbook/-/growthbook-0.34.0.tgz#df5275fafbbe055c7cfeea2953a4218a9ec9027f"
+  integrity sha512-3K5JL8QftX7y77EpieYg9anXVYb6+ZafTsrNCWp0HOdmtf4lxHOzCUYwuYDaS3bvmaeIUWJ5hYcOTc6WhNbfJw==
+  dependencies:
+    dom-mutator "^0.6.0"
+
 "@growthbook/proxy-eval@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@growthbook/proxy-eval/-/proxy-eval-1.0.2.tgz#d5b24b3308b98365eb0b04e0e7f94497543e824c"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2803,9 +2803,7 @@
     uuid "^8.0.0"
 
 "@growthbook/growthbook@^0.34.0":
-  version "0.34.0"
-  resolved "https://registry.yarnpkg.com/@growthbook/growthbook/-/growthbook-0.34.0.tgz#df5275fafbbe055c7cfeea2953a4218a9ec9027f"
-  integrity sha512-3K5JL8QftX7y77EpieYg9anXVYb6+ZafTsrNCWp0HOdmtf4lxHOzCUYwuYDaS3bvmaeIUWJ5hYcOTc6WhNbfJw==
+  version "0.35.0"
   dependencies:
     dom-mutator "^0.6.0"
 


### PR DESCRIPTION
### Changes
- New `updateAttributes` method to make partial updates
- Fix missing `await` in RedisStickyBucketService
- New `context.renderer` option
- Various improvements to `auto.min.js` script
  - New `window.growthbook_queue` to make it easier to work with an async script tag
  - New `pageTitle` auto attribute
  - Fixed bugs with built-in GA4 and GTM tracking calls
  - New `growthbookrefresh` DOM event you can trigger to force re-evaluation of auto attributes