### PR TITLE
Deploy after CI has ran.

### DIFF
--- a/.github/workflows/ci-nochanges.yml
+++ b/.github/workflows/ci-nochanges.yml
@@ -1,13 +1,5 @@
 name: CI
 on:
-  push:
-    branches: main
-    paths-ignore:
-      - "packages/**"
-      - "yarn.lock"
-      - ".eslintrc"
-      - ".eslintignore"
-      - ".prettierignore"
   pull_request:
     paths-ignore:
       - "packages/**"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,10 @@ on:
     branches: main
     paths:
       - "packages/**"
+      - "!**.md"
       - "yarn.lock"
-      - ".eslintrc"
-      - ".eslintignore"
-      - ".prettierignore"
+      - "Dockerfile"
+      - ".dockerignore"
   pull_request:
     paths:
       - "packages/**"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,16 +1,12 @@
 name: Deploy
 
 on:
-  # Push to the main branch
-  push:
-    branches:
-      - main
-    paths:
-      - "packages/**"
-      - "!**.md"
-      - "yarn.lock"
-      - "Dockerfile"
-      - ".dockerignore"
+  workflow_run:
+    workflows: ["CI"]
+    branches: [main]
+    types:
+      - completed
+
 jobs:
   # Build and publish the commit to docker
   docker:


### PR DESCRIPTION
This PR changes the deploy logic to run only after the CI has passed.

When merging PRs, it is always possible that anything can have changed between the last run of the CI on the PR and the actual code being deployed. Thus, running the CI before actually deploying can act as a last safeguard to prevent deploying faulty code to production.

Another good measure to add would be the merge queue which also always run the code against the latest `main` before merging.
