### PR TITLE
Minor report fixes

### DIFF
--- a/packages/front-end/components/Report/ConfigureReport.tsx
+++ b/packages/front-end/components/Report/ConfigureReport.tsx
@@ -304,7 +304,7 @@ export default function ConfigureReport({
             labelClassName="font-weight-bold"
             type="datetime-local"
             {...form.register("startDate")}
-            helpText="Only include users who entered the experiment on or after this date"
+            helpText="Only include users who entered the experiment between the start and end dates"
           />
         </div>
         <div className="col">
@@ -313,7 +313,23 @@ export default function ConfigureReport({
             labelClassName="font-weight-bold"
             type="datetime-local"
             {...form.register("endDate")}
-            helpText="Only include users who entered the experiment on or before this date"
+            helpText={
+              <div>
+                <div style={{ marginRight: -10 }}>
+                  <a
+                    role="button"
+                    className="a"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      form.setValue("endDate", "");
+                    }}
+                  >
+                    Clear input
+                  </a>{" "}
+                  to use latest data whenever report is run
+                </div>
+              </div>
+            }
           />
         </div>
       </div>

--- a/packages/front-end/components/Report/ConfigureReport.tsx
+++ b/packages/front-end/components/Report/ConfigureReport.tsx
@@ -308,15 +308,13 @@ export default function ConfigureReport({
           />
         </div>
         <div className="col">
-          {form.watch("endDate") && (
-            <Field
-              label="End Date (UTC)"
-              labelClassName="font-weight-bold"
-              type="datetime-local"
-              {...form.register("endDate")}
-              helpText="Only include users who entered the experiment on or before this date"
-            />
-          )}
+          <Field
+            label="End Date (UTC)"
+            labelClassName="font-weight-bold"
+            type="datetime-local"
+            {...form.register("endDate")}
+            helpText="Only include users who entered the experiment on or before this date"
+          />
         </div>
       </div>
 

--- a/packages/front-end/pages/report/[rid].tsx
+++ b/packages/front-end/pages/report/[rid].tsx
@@ -40,6 +40,7 @@ import { trackReport } from "@/services/track";
 import CompactResults from "@/components/Experiment/CompactResults";
 import BreakDownResults from "@/components/Experiment/BreakDownResults";
 import DimensionChooser from "@/components/Dimensions/DimensionChooser";
+import PageHead from "@/components/Layout/PageHead";
 
 export default function ReportPage() {
   const router = useRouter();
@@ -139,367 +140,334 @@ export default function ReportPage() {
     hasSequentialTestingFeature && !!report.args.sequentialTestingEnabled;
 
   return (
-    <div className="container-fluid pagecontents experiment-details">
-      {editModalOpen && (
-        <Modal
-          open={true}
-          submit={form.handleSubmit(async (value) => {
-            await apiCall(`/report/${report.id}`, {
-              method: "PUT",
-              body: JSON.stringify(value),
-            });
-            mutate();
-          })}
-          close={() => {
-            setEditModalOpen(false);
-          }}
-          header="Edit Report"
-          overflowAuto={false}
-        >
-          <Field label="Title" {...form.register("title")} />
-          <div className="form-group">
-            <label>Description</label>
-            <MarkdownInput
-              setValue={(value) => {
-                form.setValue("description", value);
-              }}
-              value={form.watch("description")}
-            />
-          </div>
-          Publish:{" "}
-          <Toggle
-            id="toggle-status"
-            value={form.watch("status") === "published"}
-            label="published"
-            setValue={(value) => {
-              const newStatus = value ? "published" : "private";
-              form.setValue("status", newStatus);
+    <>
+      <PageHead
+        breadcrumb={[
+          {
+            display: `Experiments`,
+            href: `/experiments`,
+          },
+          {
+            display: `${experimentData?.experiment.name ?? "Report"}`,
+            href: experimentData?.experiment.id
+              ? `/experiment/${experimentData.experiment.id}`
+              : undefined,
+          },
+          { display: report.title },
+        ]}
+      />
+      <div className="container-fluid pagecontents experiment-details">
+        {editModalOpen && (
+          <Modal
+            open={true}
+            submit={form.handleSubmit(async (value) => {
+              await apiCall(`/report/${report.id}`, {
+                method: "PUT",
+                body: JSON.stringify(value),
+              });
+              mutate();
+            })}
+            close={() => {
+              setEditModalOpen(false);
             }}
-          />
-          <Tooltip
-            body={
-              "A published report will be visible to other users of your team"
-            }
-          />
-        </Modal>
-      )}
-      <div className="mb-3">
-        {report?.experimentId && (
-          <Link href={`/experiment/${report.experimentId}#results`}>
-            <GBCircleArrowLeft className="mr-2" />
-            Go to experiment results
-          </Link>
-        )}
-        {permissions.check("createAnalyses", "") &&
-          (userId === report?.userId || !report?.userId) && (
-            <DeleteButton
-              displayName="Custom Report"
-              link={false}
-              className="float-right btn-sm"
-              text="delete"
-              useIcon={true}
-              onClick={async () => {
-                await apiCall<{ status: number; message?: string }>(
-                  `/report/${report.id}`,
-                  {
-                    method: "DELETE",
-                  }
-                );
-                trackReport(
-                  "delete",
-                  "DeleteButton",
-                  datasource?.type || null,
-                  report
-                );
-                router.push(`/experiment/${report.experimentId}#results`);
+            header="Edit Report"
+            overflowAuto={false}
+          >
+            <Field label="Title" {...form.register("title")} />
+            <div className="form-group">
+              <label>Description</label>
+              <MarkdownInput
+                setValue={(value) => {
+                  form.setValue("description", value);
+                }}
+                value={form.watch("description")}
+              />
+            </div>
+            Publish:{" "}
+            <Toggle
+              id="toggle-status"
+              value={form.watch("status") === "published"}
+              label="published"
+              setValue={(value) => {
+                const newStatus = value ? "published" : "private";
+                form.setValue("status", newStatus);
               }}
             />
+            <Tooltip
+              body={
+                "A published report will be visible to other users of your team"
+              }
+            />
+          </Modal>
+        )}
+        <div className="mb-3">
+          {report?.experimentId && (
+            <Link href={`/experiment/${report.experimentId}#results`}>
+              <GBCircleArrowLeft className="mr-2" />
+              Go to experiment results
+            </Link>
           )}
-        <h1 className="mb-0 mt-2">
-          {report.title}{" "}
           {permissions.check("createAnalyses", "") &&
             (userId === report?.userId || !report?.userId) && (
-              <a
-                className="ml-2 cursor-pointer"
-                onClick={() => setEditModalOpen(true)}
-              >
-                <GBEdit />
-              </a>
+              <DeleteButton
+                displayName="Custom Report"
+                link={false}
+                className="float-right btn-sm"
+                text="delete"
+                useIcon={true}
+                onClick={async () => {
+                  await apiCall<{ status: number; message?: string }>(
+                    `/report/${report.id}`,
+                    {
+                      method: "DELETE",
+                    }
+                  );
+                  trackReport(
+                    "delete",
+                    "DeleteButton",
+                    datasource?.type || null,
+                    report
+                  );
+                  router.push(`/experiment/${report.experimentId}#results`);
+                }}
+              />
             )}
-        </h1>
-        <div className="mb-1">
-          <small className="text-muted">
-            Created {report?.userId && <>by {getUserDisplay(report.userId)} </>}{" "}
-            on {date(report.dateCreated)} -{" "}
-            <span className="badge badge-secondary">
-              {form.watch("status") === "published" ? "Published" : "Private"}
-            </span>
-          </small>
-        </div>
-        {report.description && (
-          <div className="mb-3">
-            <Markdown>{report.description}</Markdown>
+          <h1 className="mb-0 mt-2">
+            {report.title}{" "}
+            {permissions.check("createAnalyses", "") &&
+              (userId === report?.userId || !report?.userId) && (
+                <a
+                  className="ml-2 cursor-pointer"
+                  onClick={() => setEditModalOpen(true)}
+                >
+                  <GBEdit />
+                </a>
+              )}
+          </h1>
+          <div className="mb-1">
+            <small className="text-muted">
+              Created{" "}
+              {report?.userId && <>by {getUserDisplay(report.userId)} </>} on{" "}
+              {date(report.dateCreated)} -{" "}
+              <span className="badge badge-secondary">
+                {form.watch("status") === "published" ? "Published" : "Private"}
+              </span>
+            </small>
           </div>
-        )}
-      </div>
+          {report.description && (
+            <div className="mb-3">
+              <Markdown>{report.description}</Markdown>
+            </div>
+          )}
+        </div>
 
-      <ControlledTabs
-        active={active}
-        setActive={setActive}
-        newStyle={true}
-        navClassName={permissions.check("createAnalyses", "") ? "" : "d-none"}
-      >
-        <Tab key="results" anchor="results" display="Results" padding={false}>
-          <div className="pt-3 px-3">
-            <div className="row align-items-center mb-2">
-              <div className="col">
-                <h2>Results</h2>
-              </div>
-              <div className="flex-1"></div>
-              <div className="col-auto d-flex align-items-end mr-3">
-                <DimensionChooser
-                  value={report.args.dimension ?? ""}
-                  activationMetric={!!report.args.activationMetric}
-                  datasourceId={report.args.datasource}
-                  exposureQueryId={report.args.exposureQueryId}
-                  userIdType={report.args.userIdType}
-                  labelClassName="mr-2"
-                  disabled={true}
-                />
-              </div>
-              <div className="col-auto">
-                {hasData &&
-                report.runStarted &&
-                queryStatusData.status !== "running" ? (
-                  <div
-                    className="text-muted text-right"
-                    style={{ width: 100, fontSize: "0.8em" }}
-                    title={datetime(report.runStarted)}
-                  >
-                    <div
-                      className="font-weight-bold"
-                      style={{ lineHeight: 1.2 }}
-                    >
-                      updated
-                    </div>
-                    <div className="d-inline-block" style={{ lineHeight: 1 }}>
-                      {ago(report.runStarted)}
+        <ControlledTabs
+          active={active}
+          setActive={setActive}
+          newStyle={true}
+          navClassName={permissions.check("createAnalyses", "") ? "" : "d-none"}
+        >
+          <Tab key="results" anchor="results" display="Results" padding={false}>
+            <div className="pt-3 px-3">
+              <div className="row align-items-center mb-2">
+                <div className="col">
+                  <h2>Results</h2>
+                </div>
+                <div className="flex-1"></div>
+                <div className="col-auto d-flex align-items-end mr-3">
+                  <DimensionChooser
+                    value={report.args.dimension ?? ""}
+                    activationMetric={!!report.args.activationMetric}
+                    datasourceId={report.args.datasource}
+                    exposureQueryId={report.args.exposureQueryId}
+                    userIdType={report.args.userIdType}
+                    labelClassName="mr-2"
+                    disabled={true}
+                  />
+                </div>
+                <div className="col-auto d-flex align-items-end mr-3">
+                  <div>
+                    <div className="uppercase-title text-muted">Date range</div>
+                    <div className="relative">
+                      <span className="date-label">
+                        {date(report.args.startDate)} —{" "}
+                        {report.args.endDate
+                          ? date(report.args.endDate)
+                          : "now"}
+                      </span>
                     </div>
                   </div>
-                ) : (
-                  ""
-                )}
-              </div>
-              <div className="col-auto">
-                {permissions.check(
-                  "runQueries",
-                  experimentData?.experiment.project || ""
-                ) && (
-                  <form
-                    onSubmit={async (e) => {
-                      e.preventDefault();
+                </div>
+                <div className="col-auto">
+                  {hasData &&
+                  report.runStarted &&
+                  queryStatusData.status !== "running" ? (
+                    <div
+                      className="text-muted text-right"
+                      style={{ width: 100, fontSize: "0.8em" }}
+                      title={datetime(report.runStarted)}
+                    >
+                      <div
+                        className="font-weight-bold"
+                        style={{ lineHeight: 1.2 }}
+                      >
+                        updated
+                      </div>
+                      <div className="d-inline-block" style={{ lineHeight: 1 }}>
+                        {ago(report.runStarted)}
+                      </div>
+                    </div>
+                  ) : (
+                    ""
+                  )}
+                </div>
+                <div className="col-auto">
+                  {permissions.check(
+                    "runQueries",
+                    experimentData?.experiment.project || ""
+                  ) && (
+                    <form
+                      onSubmit={async (e) => {
+                        e.preventDefault();
+                        try {
+                          const res = await apiCall<{
+                            report: ReportInterface;
+                          }>(`/report/${report.id}/refresh`, {
+                            method: "POST",
+                          });
+                          trackReport(
+                            "update",
+                            "RefreshData",
+                            datasource?.type || null,
+                            res.report
+                          );
+                          mutate();
+                          setRefreshError("");
+                        } catch (e) {
+                          setRefreshError(e.message);
+                        }
+                      }}
+                    >
+                      <RunQueriesButton
+                        icon="refresh"
+                        cta="Refresh Data"
+                        mutate={mutate}
+                        model={report}
+                        cancelEndpoint={`/report/${report.id}/cancel`}
+                        color="outline-primary"
+                      />
+                    </form>
+                  )}
+                </div>
+                <div className="col-auto">
+                  <ResultMoreMenu
+                    id={report.id}
+                    hasData={hasData}
+                    forceRefresh={async () => {
                       try {
-                        const res = await apiCall<{
-                          report: ReportInterface;
-                        }>(`/report/${report.id}/refresh`, {
-                          method: "POST",
-                        });
+                        const res = await apiCall<{ report: ReportInterface }>(
+                          `/report/${report.id}/refresh?force=true`,
+                          {
+                            method: "POST",
+                          }
+                        );
                         trackReport(
                           "update",
-                          "RefreshData",
+                          "ForceRefreshData",
                           datasource?.type || null,
                           res.report
                         );
                         mutate();
-                        setRefreshError("");
                       } catch (e) {
-                        setRefreshError(e.message);
+                        console.error(e);
                       }
                     }}
-                  >
-                    <RunQueriesButton
-                      icon="refresh"
-                      cta="Refresh Data"
-                      mutate={mutate}
-                      model={report}
-                      cancelEndpoint={`/report/${report.id}/cancel`}
-                      color="outline-primary"
-                    />
-                  </form>
-                )}
-              </div>
-              <div className="col-auto">
-                <ResultMoreMenu
-                  id={report.id}
-                  hasData={hasData}
-                  forceRefresh={async () => {
-                    try {
-                      const res = await apiCall<{ report: ReportInterface }>(
-                        `/report/${report.id}/refresh?force=true`,
-                        {
-                          method: "POST",
-                        }
-                      );
-                      trackReport(
-                        "update",
-                        "ForceRefreshData",
-                        datasource?.type || null,
-                        res.report
-                      );
-                      mutate();
-                    } catch (e) {
-                      console.error(e);
+                    supportsNotebooks={!!datasource?.settings?.notebookRunQuery}
+                    // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '(() => void) | null' is not assignable to ty... Remove this comment to see the full error message
+                    editMetrics={
+                      permissions.check("createAnalyses", "")
+                        ? () => setActive("Configuration")
+                        : null
                     }
-                  }}
-                  supportsNotebooks={!!datasource?.settings?.notebookRunQuery}
-                  // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '(() => void) | null' is not assignable to ty... Remove this comment to see the full error message
-                  editMetrics={
-                    permissions.check("createAnalyses", "")
-                      ? () => setActive("Configuration")
-                      : null
-                  }
-                  generateReport={false}
-                  notebookUrl={`/report/${report.id}/notebook`}
-                  notebookFilename={report.title}
-                  queries={report.queries}
-                  queryError={report.error}
-                  // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
-                  results={report.results.dimensions}
-                  variations={variations}
-                  metrics={report.args.metrics}
-                  trackingKey={report.title}
-                />
+                    generateReport={false}
+                    notebookUrl={`/report/${report.id}/notebook`}
+                    notebookFilename={report.title}
+                    queries={report.queries}
+                    queryError={report.error}
+                    // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
+                    results={report.results.dimensions}
+                    variations={variations}
+                    metrics={report.args.metrics}
+                    trackingKey={report.title}
+                  />
+                </div>
               </div>
-            </div>
-            {report.error ? (
-              <div className="alert alert-danger">
-                <strong>Error generating the report: </strong> {report.error}
-              </div>
-            ) : null}
-            {refreshError && (
-              <div className="alert alert-danger">
-                <strong>Error refreshing data: </strong> {refreshError}
-              </div>
-            )}
-            {report.args.metrics.length === 0 && (
-              <div className="alert alert-info">
-                Add at least 1 metric to view results.
-              </div>
-            )}
-            {!hasData &&
-              // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
-              !report.results.unknownVariations?.length &&
-              queryStatusData.status !== "running" &&
-              report.args.metrics.length > 0 && (
-                <div className="alert alert-info">
-                  No data yet.{" "}
-                  {report.results &&
-                    phaseAgeMinutes >= 120 &&
-                    "Make sure your experiment is tracking properly."}
-                  {report.results &&
-                    phaseAgeMinutes < 120 &&
-                    "It was just started " +
-                      ago(report.args.startDate) +
-                      ". Give it a little longer and click the 'Refresh' button to check again."}
-                  {!report.results &&
-                    permissions.check(
-                      "runQueries",
-                      experimentData?.experiment.project || ""
-                    ) &&
-                    `Click the "Refresh" button.`}
+              {report.error ? (
+                <div className="alert alert-danger">
+                  <strong>Error generating the report: </strong> {report.error}
+                </div>
+              ) : null}
+              {refreshError && (
+                <div className="alert alert-danger">
+                  <strong>Error refreshing data: </strong> {refreshError}
                 </div>
               )}
-          </div>
-          {hasData &&
-            report.args.dimension &&
-            (report.args.dimension.substring(0, 8) === "pre:date" ? (
-              <DateResults
-                metrics={report.args.metrics}
-                guardrails={report.args.guardrails}
+              {report.args.metrics.length === 0 && (
+                <div className="alert alert-info">
+                  Add at least 1 metric to view results.
+                </div>
+              )}
+              {!hasData &&
                 // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
-                results={report.results.dimensions}
-                seriestype={report.args.dimension}
-                variations={variations}
-                statsEngine={report.args.statsEngine}
-              />
-            ) : (
-              <BreakDownResults
-                isLatestPhase={true}
-                metrics={report.args.metrics}
-                // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'MetricOverride[] | undefined' is not assigna... Remove this comment to see the full error message
-                metricOverrides={report.args.metricOverrides}
-                reportDate={report.dateCreated}
-                results={report.results?.dimensions || []}
-                status={"stopped"}
-                startDate={getValidDate(report.args.startDate).toISOString()}
-                dimensionId={report.args.dimension}
-                activationMetric={report.args.activationMetric}
-                guardrails={report.args.guardrails}
-                variations={variations}
-                key={report.args.dimension}
-                statsEngine={report.args.statsEngine || DEFAULT_STATS_ENGINE}
-                pValueCorrection={pValueCorrection}
-                regressionAdjustmentEnabled={regressionAdjustmentEnabled}
-                metricRegressionAdjustmentStatuses={
-                  report.args.metricRegressionAdjustmentStatuses
-                }
-                sequentialTestingEnabled={sequentialTestingEnabled}
-                differenceType={"relative"}
-              />
-            ))}
-          {report.results && !report.args.dimension && (
-            <VariationIdWarning
-              unknownVariations={report.results?.unknownVariations || []}
-              isUpdating={status === "running"}
-              setVariationIds={async (ids) => {
-                const args: ExperimentReportArgs = {
-                  ...report.args,
-                  variations: report.args.variations.map((v, i) => {
-                    return {
-                      ...v,
-                      id: ids[i] ?? v.id,
-                    };
-                  }),
-                };
-
-                const res = await apiCall<{ updatedReport: ReportInterface }>(
-                  `/report/${report.id}`,
-                  {
-                    method: "PUT",
-                    body: JSON.stringify({
-                      args,
-                    }),
-                  }
-                );
-                trackReport(
-                  "update",
-                  "VariationIdWarning",
-                  datasource?.type || null,
-                  res.updatedReport
-                );
-                mutate();
-              }}
-              variations={variations}
-              results={report.results?.dimensions?.[0]}
-            />
-          )}
-          {hasData &&
-            !report.args.dimension &&
-            report.results?.dimensions?.[0] !== undefined && (
-              <div className="mt-0 mb-3">
-                <CompactResults
-                  variations={variations}
-                  multipleExposures={report.results?.multipleExposures || 0}
-                  results={report.results?.dimensions?.[0]}
-                  queryStatusData={queryStatusData}
-                  reportDate={report.dateCreated}
-                  startDate={getValidDate(report.args.startDate).toISOString()}
-                  isLatestPhase={true}
-                  status={"stopped"}
+                !report.results.unknownVariations?.length &&
+                queryStatusData.status !== "running" &&
+                report.args.metrics.length > 0 && (
+                  <div className="alert alert-info">
+                    No data yet.{" "}
+                    {report.results &&
+                      phaseAgeMinutes >= 120 &&
+                      "Make sure your experiment is tracking properly."}
+                    {report.results &&
+                      phaseAgeMinutes < 120 &&
+                      "It was just started " +
+                        ago(report.args.startDate) +
+                        ". Give it a little longer and click the 'Refresh' button to check again."}
+                    {!report.results &&
+                      permissions.check(
+                        "runQueries",
+                        experimentData?.experiment.project || ""
+                      ) &&
+                      `Click the "Refresh" button.`}
+                  </div>
+                )}
+            </div>
+            {hasData &&
+              report.args.dimension &&
+              (report.args.dimension.substring(0, 8) === "pre:date" ? (
+                <DateResults
                   metrics={report.args.metrics}
-                  metricOverrides={report.args.metricOverrides ?? []}
                   guardrails={report.args.guardrails}
-                  id={report.id}
+                  // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
+                  results={report.results.dimensions}
+                  seriestype={report.args.dimension}
+                  variations={variations}
+                  statsEngine={report.args.statsEngine}
+                />
+              ) : (
+                <BreakDownResults
+                  isLatestPhase={true}
+                  metrics={report.args.metrics}
+                  // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'MetricOverride[] | undefined' is not assigna... Remove this comment to see the full error message
+                  metricOverrides={report.args.metricOverrides}
+                  reportDate={report.dateCreated}
+                  results={report.results?.dimensions || []}
+                  status={"stopped"}
+                  startDate={getValidDate(report.args.startDate).toISOString()}
+                  dimensionId={report.args.dimension}
+                  activationMetric={report.args.activationMetric}
+                  guardrails={report.args.guardrails}
+                  variations={variations}
+                  key={report.args.dimension}
                   statsEngine={report.args.statsEngine || DEFAULT_STATS_ENGINE}
                   pValueCorrection={pValueCorrection}
                   regressionAdjustmentEnabled={regressionAdjustmentEnabled}
@@ -508,81 +476,149 @@ export default function ReportPage() {
                   }
                   sequentialTestingEnabled={sequentialTestingEnabled}
                   differenceType={"relative"}
-                  isTabActive={true}
                 />
+              ))}
+            {report.results && !report.args.dimension && (
+              <VariationIdWarning
+                unknownVariations={report.results?.unknownVariations || []}
+                isUpdating={status === "running"}
+                setVariationIds={async (ids) => {
+                  const args: ExperimentReportArgs = {
+                    ...report.args,
+                    variations: report.args.variations.map((v, i) => {
+                      return {
+                        ...v,
+                        id: ids[i] ?? v.id,
+                      };
+                    }),
+                  };
+
+                  const res = await apiCall<{ updatedReport: ReportInterface }>(
+                    `/report/${report.id}`,
+                    {
+                      method: "PUT",
+                      body: JSON.stringify({
+                        args,
+                      }),
+                    }
+                  );
+                  trackReport(
+                    "update",
+                    "VariationIdWarning",
+                    datasource?.type || null,
+                    res.updatedReport
+                  );
+                  mutate();
+                }}
+                variations={variations}
+                results={report.results?.dimensions?.[0]}
+              />
+            )}
+            {hasData &&
+              !report.args.dimension &&
+              report.results?.dimensions?.[0] !== undefined && (
+                <div className="mt-0 mb-3">
+                  <CompactResults
+                    variations={variations}
+                    multipleExposures={report.results?.multipleExposures || 0}
+                    results={report.results?.dimensions?.[0]}
+                    queryStatusData={queryStatusData}
+                    reportDate={report.dateCreated}
+                    startDate={getValidDate(
+                      report.args.startDate
+                    ).toISOString()}
+                    isLatestPhase={true}
+                    status={"stopped"}
+                    metrics={report.args.metrics}
+                    metricOverrides={report.args.metricOverrides ?? []}
+                    guardrails={report.args.guardrails}
+                    id={report.id}
+                    statsEngine={
+                      report.args.statsEngine || DEFAULT_STATS_ENGINE
+                    }
+                    pValueCorrection={pValueCorrection}
+                    regressionAdjustmentEnabled={regressionAdjustmentEnabled}
+                    metricRegressionAdjustmentStatuses={
+                      report.args.metricRegressionAdjustmentStatuses
+                    }
+                    sequentialTestingEnabled={sequentialTestingEnabled}
+                    differenceType={"relative"}
+                    isTabActive={true}
+                  />
+                </div>
+              )}
+            {hasData && (
+              <div className="row align-items-center mx-2 my-3">
+                <div className="col-auto small" style={{ lineHeight: 1.2 }}>
+                  <div className="text-muted mb-1">
+                    The above results were computed with:
+                  </div>
+                  <div>
+                    <span className="text-muted">Engine:</span>{" "}
+                    <span>
+                      {report.args?.statsEngine === "frequentist"
+                        ? "Frequentist"
+                        : "Bayesian"}
+                    </span>
+                  </div>
+                  {report.args?.statsEngine === "frequentist" && (
+                    <>
+                      <div>
+                        <span className="text-muted">
+                          <GBCuped size={13} /> CUPED:
+                        </span>{" "}
+                        <span>
+                          {report.args?.regressionAdjustmentEnabled
+                            ? "Enabled"
+                            : "Disabled"}
+                        </span>
+                      </div>
+                      <div>
+                        <span className="text-muted">
+                          <GBSequential size={13} /> Sequential:
+                        </span>{" "}
+                        <span>
+                          {report.args?.sequentialTestingEnabled
+                            ? "Enabled"
+                            : "Disabled"}
+                        </span>
+                      </div>
+                    </>
+                  )}
+                  <div>
+                    <span className="text-muted">Run date:</span>{" "}
+                    <span>
+                      {getValidDate(report.runStarted).toLocaleString([], {
+                        year: "numeric",
+                        month: "numeric",
+                        day: "numeric",
+                        hour: "numeric",
+                        minute: "2-digit",
+                      })}
+                    </span>
+                  </div>
+                </div>
               </div>
             )}
-          {hasData && (
-            <div className="row align-items-center mx-2 my-3">
-              <div className="col-auto small" style={{ lineHeight: 1.2 }}>
-                <div className="text-muted mb-1">
-                  The above results were computed with:
-                </div>
-                <div>
-                  <span className="text-muted">Engine:</span>{" "}
-                  <span>
-                    {report.args?.statsEngine === "frequentist"
-                      ? "Frequentist"
-                      : "Bayesian"}
-                  </span>
-                </div>
-                {report.args?.statsEngine === "frequentist" && (
-                  <>
-                    <div>
-                      <span className="text-muted">
-                        <GBCuped size={13} /> CUPED:
-                      </span>{" "}
-                      <span>
-                        {report.args?.regressionAdjustmentEnabled
-                          ? "Enabled"
-                          : "Disabled"}
-                      </span>
-                    </div>
-                    <div>
-                      <span className="text-muted">
-                        <GBSequential size={13} /> Sequential:
-                      </span>{" "}
-                      <span>
-                        {report.args?.sequentialTestingEnabled
-                          ? "Enabled"
-                          : "Disabled"}
-                      </span>
-                    </div>
-                  </>
-                )}
-                <div>
-                  <span className="text-muted">Run date:</span>{" "}
-                  <span>
-                    {getValidDate(report.runStarted).toLocaleString([], {
-                      year: "numeric",
-                      month: "numeric",
-                      day: "numeric",
-                      hour: "numeric",
-                      minute: "2-digit",
-                    })}
-                  </span>
-                </div>
-              </div>
-            </div>
-          )}
-        </Tab>
-        {permissions.check("createAnalyses", "") && (
-          <Tab
-            key="configuration"
-            anchor="configuration"
-            display="Configuration"
-            visible={permissions.check("createAnalyses", "")}
-            forceRenderOnFocus={true}
-          >
-            <h2>Configuration</h2>
-            <ConfigureReport
-              mutate={mutate}
-              report={report}
-              viewResults={() => setActive("Results")}
-            />
           </Tab>
-        )}
-      </ControlledTabs>
-    </div>
+          {permissions.check("createAnalyses", "") && (
+            <Tab
+              key="configuration"
+              anchor="configuration"
+              display="Configuration"
+              visible={permissions.check("createAnalyses", "")}
+              forceRenderOnFocus={true}
+            >
+              <h2>Configuration</h2>
+              <ConfigureReport
+                mutate={mutate}
+                report={report}
+                viewResults={() => setActive("Results")}
+              />
+            </Tab>
+          )}
+        </ControlledTabs>
+      </div>
+    </>
   );
 }


### PR DESCRIPTION
## Features and Changes
### Adds end date component even if empty

Fixes it so that end date always shows even if it is empty (which is a state you can currently get to).

Before
<img width="1383" alt="Screenshot 2024-03-12 at 9 25 51 AM" src="https://github.com/growthbook/growthbook/assets/5298599/d6d6acc8-f9cb-454e-9d7e-4d47fb59721e">

After
<img width="1148" alt="Screenshot 2024-03-12 at 9 02 42 AM" src="https://github.com/growthbook/growthbook/assets/5298599/c4c19791-6d5a-4dde-ad7b-7e2834c4af62">

### Adds date range to report page

Before
<img width="1139" alt="Screenshot 2024-03-12 at 9 25 42 AM" src="https://github.com/growthbook/growthbook/assets/5298599/4f247ef1-ab0a-4435-a9ea-f88d4bbd5e8c">

After
<img width="1144" alt="Screenshot 2024-03-12 at 9 02 38 AM" src="https://github.com/growthbook/growthbook/assets/5298599/cfede017-df3d-40e1-a98b-a0ff15240091">

### Adds crumbs to reports

Before (notice page header and lack of header crumb)
<img width="825" alt="Screenshot 2024-03-12 at 9 25 26 AM" src="https://github.com/growthbook/growthbook/assets/5298599/bf40771a-b3b5-403b-855b-8245a88d9b93">

Going back is also painful
<img width="493" alt="Screenshot 2024-03-12 at 9 25 33 AM" src="https://github.com/growthbook/growthbook/assets/5298599/073ad2d8-2ea7-47f9-94bf-7f69e4b2f5b3">

After
<img width="1419" alt="Screenshot 2024-03-12 at 9 28 41 AM" src="https://github.com/growthbook/growthbook/assets/5298599/e6106cf4-bea0-4191-a7bd-d349a7b1ac0c">


Going back is more informative
<img width="777" alt="Screenshot 2024-03-12 at 9 23 52 AM" src="https://github.com/growthbook/growthbook/assets/5298599/a03a84aa-2a76-439a-a3a2-7a6fe0c058c3">