### PR TITLE
Fixes createMetric permission bug

### DIFF
--- a/packages/back-end/src/controllers/metrics.ts
+++ b/packages/back-end/src/controllers/metrics.ts
@@ -534,7 +534,7 @@ export async function putMetric(
     }
   });
 
-  if (updates?.projects?.length) {
+  if (updates?.projects) {
     req.checkPermissions("createMetrics", updates.projects);
   }
 

--- a/packages/front-end/pages/metric/[mid].tsx
+++ b/packages/front-end/pages/metric/[mid].tsx
@@ -139,8 +139,6 @@ const MetricPage: FC = () => {
   const metric = data.metric;
   const canEditMetric =
     checkMetricProjectPermissions(metric, permissions) && !metric.managedBy;
-  const canEditProjects =
-    permissions.check("createMetrics", "") && !metric.managedBy;
   const datasource = metric.datasource
     ? getDatasourceById(metric.datasource)
     : null;
@@ -459,7 +457,7 @@ const MetricPage: FC = () => {
               className="badge-ellipsis align-middle"
             />
           )}
-          {canEditProjects && (
+          {canEditMetric && (
             <a
               href="#"
               className="ml-2"
@@ -963,7 +961,7 @@ const MetricPage: FC = () => {
             <RightRailSection
               title="Projects"
               open={() => setEditProjects(true)}
-              canOpen={canEditProjects}
+              canOpen={canEditMetric}
             >
               <RightRailSectionGroup>
                 {metric?.projects?.length ? (


### PR DESCRIPTION
### Features and Changes

This is a simple PR that fixes a bug on `[mid].tsx`.

The bug:
- When determining if a user had permission to edit a metric's projects, we were only looking at the user's global role. So if the user had a global role of `noaccess`, but then had a project specific role of `experimenter` they were unable to edit the metric's projects.
- Once this bug was resolved, we then needed to add extra protection to the `putMetric` controller method. Otherwise, it would've been possible for a user to remove all projects from a metric. And, if they had the role above, they would then no longer be able to edit it. Plus, with the role above, they technically don't have permission to edit metrics in `All Projects`.

### Testing

- [x] Ensure that a user with a global `noaccess` role and a project-specific `experimenter` role can edit the projects (within scope of their permissions) accurately.
- [x] Ensure that if a user tries to update a metric's projects outside of their permission (e.g. they're global role is `noaccess` and they try to remove all projects from a metric, they get a permission error thrown.
- [x] Ensure no regressions are introduced for other role combinations

### Screenshots
Before (No 'Edit' button next to the projects section
<img width="418" alt="Screen Shot 2024-03-15 at 9 29 29 AM" src="https://github.com/growthbook/growthbook/assets/75274610/848b281c-bf3a-4a11-b3c2-33c3d5fdd98e">

After ('Edit' button is visible)
<img width="421" alt="Screen Shot 2024-03-15 at 9 30 12 AM" src="https://github.com/growthbook/growthbook/assets/75274610/fda0a30b-b708-4b79-92b1-d0c6ba4a5281">
