### PR TITLE
Fixes Estimate Impact bug

### DIFF
--- a/packages/back-end/src/controllers/ideas.ts
+++ b/packages/back-end/src/controllers/ideas.ts
@@ -42,8 +42,6 @@ export async function getEstimatedImpact(
   req: AuthRequest<{ metric: string; segment?: string; ideaId?: string }>,
   res: Response
 ) {
-  req.checkPermissions("createIdeas", "");
-
   const { metric, segment, ideaId } = req.body;
 
   const idea = await getIdeaById(ideaId || "");

--- a/packages/front-end/components/Ideas/ImpactModal.tsx
+++ b/packages/front-end/components/Ideas/ImpactModal.tsx
@@ -61,7 +61,7 @@ const ImpactModal: FC<{
               body: JSON.stringify({
                 metric: value.metric,
                 segment: value.segment || null,
-                idea: idea?.id || null,
+                ideaId: idea?.id || null,
               }),
             }
           );

--- a/packages/front-end/pages/idea/[iid].tsx
+++ b/packages/front-end/pages/idea/[iid].tsx
@@ -131,84 +131,86 @@ const IdeaPage = (): ReactElement => {
             </a>
           </div>
         )}
-      <div className="mb-2 mt-2 row d-flex">
-        <div className="col-auto">
-          <Link href="/ideas">
-            <FaAngleLeft />
-            All Ideas
-          </Link>
-        </div>
-        {idea.archived && (
+      <div className="mb-2 mt-2 row d-flex justify-content-between align-items-center">
+        <div>
           <div className="col-auto">
-            <div
-              className="badge badge-secondary"
-              style={{ fontSize: "1.1em" }}
-            >
-              Archived
-            </div>
+            <Link href="/ideas">
+              <FaAngleLeft />
+              All Ideas
+            </Link>
           </div>
-        )}
-        <div className="col"></div>
-        {!idea.archived &&
-          permissions.check("createAnalyses", idea.project) &&
-          !data.experiment && (
-            <div className="col-md-auto">
-              <button
-                className="btn btn-outline-primary mr-3"
-                onClick={() => {
-                  setNewExperiment(true);
-                }}
+          {idea.archived && (
+            <div className="col-auto">
+              <div
+                className="badge badge-secondary"
+                style={{ fontSize: "1.1em" }}
               >
-                Convert Idea to Experiment
-              </button>
+                Archived
+              </div>
             </div>
           )}
-        {canEdit && (
-          <div className="col-auto">
-            <MoreMenu>
-              <a
-                href="#"
-                className="dropdown-item"
-                onClick={async (e) => {
-                  e.preventDefault();
-                  await apiCall(`/idea/${iid}`, {
-                    method: "POST",
-                    body: JSON.stringify({
-                      archived: !idea.archived,
-                    }),
-                  });
-                  mutate({
-                    ...data,
-                    idea: {
-                      ...data.idea,
-                      archived: !idea.archived,
-                    },
-                  });
-                }}
-              >
-                <FaArchive /> {idea.archived ? "Unarchive" : "Archive"}
-              </a>
-              <DeleteButton
-                displayName="Idea"
-                link={true}
-                className="dropdown-item text-dark"
-                text="Delete"
-                onClick={async () => {
-                  await apiCall<{ status: number; message?: string }>(
-                    `/idea/${iid}`,
-                    {
-                      method: "DELETE",
-                      body: JSON.stringify({ id: iid }),
-                    }
-                  );
+        </div>
+        <div className="d-flex align-items-center">
+          {!idea.archived &&
+            permissions.check("createAnalyses", idea.project) &&
+            !data.experiment && (
+              <div className="col-md-auto">
+                <button
+                  className="btn btn-outline-primary"
+                  onClick={() => {
+                    setNewExperiment(true);
+                  }}
+                >
+                  Convert Idea to Experiment
+                </button>
+              </div>
+            )}
+          {canEdit && (
+            <div className="col-auto d-flex">
+              <MoreMenu>
+                <a
+                  href="#"
+                  className="dropdown-item"
+                  onClick={async (e) => {
+                    e.preventDefault();
+                    await apiCall(`/idea/${iid}`, {
+                      method: "POST",
+                      body: JSON.stringify({
+                        archived: !idea.archived,
+                      }),
+                    });
+                    mutate({
+                      ...data,
+                      idea: {
+                        ...data.idea,
+                        archived: !idea.archived,
+                      },
+                    });
+                  }}
+                >
+                  <FaArchive /> {idea.archived ? "Unarchive" : "Archive"}
+                </a>
+                <DeleteButton
+                  displayName="Idea"
+                  link={true}
+                  className="dropdown-item text-dark"
+                  text="Delete"
+                  onClick={async () => {
+                    await apiCall<{ status: number; message?: string }>(
+                      `/idea/${iid}`,
+                      {
+                        method: "DELETE",
+                        body: JSON.stringify({ id: iid }),
+                      }
+                    );
 
-                  push("/ideas");
-                }}
-              />
-            </MoreMenu>
-          </div>
-        )}
-        {canEstimateImpact && <div className="col-md-3"></div>}
+                    push("/ideas");
+                  }}
+                />
+              </MoreMenu>
+            </div>
+          )}
+        </div>
       </div>
       {data.experiment && (
         <div className="bg-white border border-info p-3 mb-3">


### PR DESCRIPTION
### Features and Changes

I identified two bugs with regards to the `[iid].tsx` idea page.

Bug 1: This was purely visual, but there were some extra (empty) divs that were causing the UI to behave differently from our existing patterns.

Before:
(Desktop)
<img width="1483" alt="Screen Shot 2024-03-15 at 9 56 09 AM" src="https://github.com/growthbook/growthbook/assets/75274610/0b519e6b-58f2-457c-b481-3bd7f396e1c4">

(Mobile)
<img width="353" alt="Screen Shot 2024-03-15 at 9 55 59 AM" src="https://github.com/growthbook/growthbook/assets/75274610/c7a8c7a3-8e47-4950-b541-e44185d3b16c">

After:
(Desktop)
<img width="1489" alt="Screen Shot 2024-03-15 at 9 49 37 AM" src="https://github.com/growthbook/growthbook/assets/75274610/0b798229-1646-4af4-94d0-dfe07130ceb2">

(Mobile)
<img width="346" alt="Screen Shot 2024-03-15 at 9 50 09 AM" src="https://github.com/growthbook/growthbook/assets/75274610/95969240-9786-4da8-9dc5-4aa5d76276a9">

Bug 2: There were two bugs here. Initially, when making the `POST` request to `/ideas/impact` - we were passing in a body property for `idea`, but within the `getEstimatedImpact` controller function, we were expecting `ideaId`. As a result, when we were checking for `runQuery` permissions, `idea?.project` would always be null, so we'd end up only looking to see if the user had this permission at the global level.

- Closes **(add link to issue here)**

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

- [x] Ensure that if a user is able to see the `Estimate Impact` button, they do not receive a permission error.

