### PR TITLE
Updates addComment as a READ_ONLY type permission.

### DIFF
--- a/packages/back-end/src/controllers/discussions.ts
+++ b/packages/back-end/src/controllers/discussions.ts
@@ -15,7 +15,7 @@ export async function postDiscussions(
   >,
   res: Response
 ) {
-  req.checkPermissions("addComments", "");
+  req.checkPermissions("addComments", []);
 
   const { org, userId, email, userName } = getContextFromReq(req);
   const { parentId, parentType } = req.params;
@@ -53,7 +53,7 @@ export async function deleteComment(
   >,
   res: Response
 ) {
-  req.checkPermissions("addComments", "");
+  req.checkPermissions("addComments", []);
 
   const { org, userId } = getContextFromReq(req);
   const { parentId, parentType, index } = req.params;
@@ -103,7 +103,7 @@ export async function putComment(
   >,
   res: Response
 ) {
-  req.checkPermissions("addComments", "");
+  req.checkPermissions("addComments", []);
 
   const { org, userId } = getContextFromReq(req);
   const { parentId, parentType, index } = req.params;

--- a/packages/back-end/src/routers/upload/upload.controller.ts
+++ b/packages/back-end/src/routers/upload/upload.controller.ts
@@ -20,7 +20,7 @@ const extensionsToMimetype: Record<string, string> = {
 
 export async function putUpload(req: AuthRequest<Buffer>, res: Response) {
   const contentType = req.headers["content-type"] as string;
-  req.checkPermissions("addComments", "");
+  req.checkPermissions("addComments", []);
 
   if (!(contentType in mimetypes)) {
     throw new Error(

--- a/packages/shared/src/permissions/permissions.utils.ts
+++ b/packages/shared/src/permissions/permissions.utils.ts
@@ -55,7 +55,12 @@ export const ALL_PERMISSIONS = [
   ...ENV_SCOPED_PERMISSIONS,
 ];
 
-export const READ_ONLY_PERMISSIONS = ["readData", "viewEvents", "runQueries"];
+export const READ_ONLY_PERMISSIONS = [
+  "readData",
+  "viewEvents",
+  "runQueries",
+  "addComments",
+];
 
 export function hasPermission(
   userPermissions: UserPermissions | undefined,


### PR DESCRIPTION
### Features and Changes

This PR makes the `addComment` permission a `READ_ONLY_TYPE`. Meaning, if the user has the permission either globally, or in atleast 1 project a resource is associated with, they have the permission.

This means, if a user doesn't have the `addComment` permission through their global role, but atleast 1 of their project-specific roles does grant them permission, they'd be able to, for instance, add a comment on a metric that is in `All Projects`. Before this, their global role would've prevent this from happening. The metric would've needed to have specific projects associated with it, and the user would've needed to have the permission for every one of those projects.

Now, let's take the same situation, the `createMetrics` permission does require the user to have permission in every project a metric is associated with, so the user wouldn't have permission to edit this metric. But now, they could make a comment, for instance, to request a slight change to the metric.

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

<!--
  Please describe how to test these changes.
 -->

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
