### PR TITLE
Webhook test event

### DIFF
--- a/packages/back-end/src/events/base-types.ts
+++ b/packages/back-end/src/events/base-types.ts
@@ -15,7 +15,7 @@ export const notificationEventNames = [
   // User
   "user.login",
   // Test
-  "test.event",
+  "webhook.test",
 ] as const;
 
 export type NotificationEventName = typeof notificationEventNames[number];
@@ -27,6 +27,7 @@ export const notificationEventResources = [
   "feature",
   "experiment",
   "user",
+  "webhook",
 ] as const;
 export type NotificationEventResource = typeof notificationEventResources[number];
 

--- a/packages/back-end/src/events/base-types.ts
+++ b/packages/back-end/src/events/base-types.ts
@@ -14,6 +14,8 @@ export const notificationEventNames = [
   "experiment.deleted",
   // User
   "user.login",
+  // Test
+  "test.event",
 ] as const;
 
 export type NotificationEventName = typeof notificationEventNames[number];

--- a/packages/back-end/src/events/handlers/slack/slack-event-handler-utils.ts
+++ b/packages/back-end/src/events/handlers/slack/slack-event-handler-utils.ts
@@ -24,13 +24,10 @@ type DataForNotificationEvent = {
   slackMessage: SlackMessage;
 };
 
-export const getSlackDataForNotificationEvent = (
+export const getSlackMessageForNotificationEvent = (
   event: NotificationEvent,
   eventId: string
-): DataForNotificationEvent | null => {
-  const filterData = getFilterDataForNotificationEvent(event);
-  if (!filterData) return null;
-
+): SlackMessage | null => {
   let invalidEvent: never;
 
   switch (event.event) {
@@ -38,62 +35,45 @@ export const getSlackDataForNotificationEvent = (
       return null;
 
     case "feature.created":
-      return {
-        filterData,
-        slackMessage: buildSlackMessageForFeatureCreatedEvent(event, eventId),
-      };
+      return buildSlackMessageForFeatureCreatedEvent(event, eventId);
 
     case "feature.updated":
-      return {
-        filterData,
-        slackMessage: buildSlackMessageForFeatureUpdatedEvent(event, eventId),
-      };
+      return buildSlackMessageForFeatureUpdatedEvent(event, eventId);
 
     case "feature.deleted":
-      return {
-        filterData,
-        slackMessage: buildSlackMessageForFeatureDeletedEvent(event, eventId),
-      };
+      return buildSlackMessageForFeatureDeletedEvent(event, eventId);
 
     case "experiment.created":
-      return {
-        filterData,
-        slackMessage: buildSlackMessageForExperimentCreatedEvent(
-          event,
-          eventId
-        ),
-      };
+      return buildSlackMessageForExperimentCreatedEvent(event, eventId);
 
     case "experiment.updated":
-      return {
-        filterData,
-        slackMessage: buildSlackMessageForExperimentUpdatedEvent(
-          event,
-          eventId
-        ),
-      };
+      return buildSlackMessageForExperimentUpdatedEvent(event, eventId);
 
     case "experiment.deleted":
-      return {
-        filterData,
-        slackMessage: buildSlackMessageForExperimentDeletedEvent(
-          event,
-          eventId
-        ),
-      };
+      return buildSlackMessageForExperimentDeletedEvent(event, eventId);
 
     case "webhook.test":
-      return {
-        filterData,
-        slackMessage: buildSlackMessageForWebhookTestEvent(
-          event.data.webhookId
-        ),
-      };
+      return buildSlackMessageForWebhookTestEvent(event.data.webhookId);
 
     default:
       invalidEvent = event;
       throw `Invalid event: ${invalidEvent}`;
   }
+};
+
+export const getSlackDataForNotificationEvent = (
+  event: NotificationEvent,
+  eventId: string
+): DataForNotificationEvent | null => {
+  if (event.event === "webhook.test") return null;
+
+  const filterData = getFilterDataForNotificationEvent(event);
+  if (!filterData) return null;
+
+  const slackMessage = getSlackMessageForNotificationEvent(event, eventId);
+  if (!slackMessage) return null;
+
+  return { filterData, slackMessage };
 };
 
 // endregion Filtering -> feature

--- a/packages/back-end/src/events/handlers/slack/slack-event-handler-utils.ts
+++ b/packages/back-end/src/events/handlers/slack/slack-event-handler-utils.ts
@@ -82,6 +82,12 @@ export const getSlackDataForNotificationEvent = (
         ),
       };
 
+    case "test.event":
+      return {
+        filterData,
+        slackMessage: buildSlackMessageForTestEvent(event.data.webhookId),
+      };
+
     default:
       invalidEvent = event;
       throw `Invalid event: ${invalidEvent}`;
@@ -257,6 +263,19 @@ const buildSlackMessageForExperimentUpdatedEvent = (
     ],
   };
 };
+
+const buildSlackMessageForTestEvent = (webhookId: string): SlackMessage => ({
+  text: `This is a test event for webhook ${webhookId}`,
+  blocks: [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `This is a *test event* for ${webhookId}`,
+      },
+    },
+  ],
+});
 
 const buildSlackMessageForExperimentDeletedEvent = (
   experimentEvent: ExperimentDeletedNotificationEvent,

--- a/packages/back-end/src/events/handlers/slack/slack-event-handler-utils.ts
+++ b/packages/back-end/src/events/handlers/slack/slack-event-handler-utils.ts
@@ -82,10 +82,12 @@ export const getSlackDataForNotificationEvent = (
         ),
       };
 
-    case "test.event":
+    case "webhook.test":
       return {
         filterData,
-        slackMessage: buildSlackMessageForTestEvent(event.data.webhookId),
+        slackMessage: buildSlackMessageForWebhookTestEvent(
+          event.data.webhookId
+        ),
       };
 
     default:
@@ -264,7 +266,9 @@ const buildSlackMessageForExperimentUpdatedEvent = (
   };
 };
 
-const buildSlackMessageForTestEvent = (webhookId: string): SlackMessage => ({
+const buildSlackMessageForWebhookTestEvent = (
+  webhookId: string
+): SlackMessage => ({
   text: `This is a test event for webhook ${webhookId}`,
   blocks: [
     {

--- a/packages/back-end/src/events/handlers/utils.ts
+++ b/packages/back-end/src/events/handlers/utils.ts
@@ -83,7 +83,7 @@ export const getFilterDataForNotificationEvent = (
           : [],
       };
 
-    case "test.event":
+    case "webhook.test":
       return { tags: [], projects: [] };
 
     default:
@@ -122,7 +122,7 @@ export const filterEventForEnvironments = ({
         environments,
       });
 
-    case "test.event":
+    case "webhook.test":
       return true;
 
     default:

--- a/packages/back-end/src/events/handlers/utils.ts
+++ b/packages/back-end/src/events/handlers/utils.ts
@@ -83,6 +83,9 @@ export const getFilterDataForNotificationEvent = (
           : [],
       };
 
+    case "test.event":
+      return { tags: [], projects: [] };
+
     default:
       invalidEvent = event;
       throw `Invalid event: ${invalidEvent}`;
@@ -118,6 +121,9 @@ export const filterEventForEnvironments = ({
         featureEvent: event,
         environments,
       });
+
+    case "test.event":
+      return true;
 
     default:
       invalidEvent = event;

--- a/packages/back-end/src/events/handlers/webhooks/EventWebHookNotifier.ts
+++ b/packages/back-end/src/events/handlers/webhooks/EventWebHookNotifier.ts
@@ -10,7 +10,7 @@ import { findOrganizationById } from "../../../models/OrganizationModel";
 import { createEventWebHookLog } from "../../../models/EventWebHookLogModel";
 import { logger } from "../../../util/logger";
 import { cancellableFetch } from "../../../util/http.util";
-import { getSlackDataForNotificationEvent } from "../slack/slack-event-handler-utils";
+import { getSlackMessageForNotificationEvent } from "../slack/slack-event-handler-utils";
 import {
   EventWebHookErrorResult,
   EventWebHookResult,
@@ -113,19 +113,18 @@ export class EventWebHookNotifier implements Notifier {
           return eventPayload;
 
         case "slack": {
-          const data = getSlackDataForNotificationEvent(eventPayload, eventId);
-
-          if (!data) return null;
-
-          return data.slackMessage;
+          return getSlackMessageForNotificationEvent(eventPayload, eventId);
         }
 
         case "discord": {
-          const data = getSlackDataForNotificationEvent(eventPayload, eventId);
+          const data = getSlackMessageForNotificationEvent(
+            eventPayload,
+            eventId
+          );
 
           if (!data) return null;
 
-          return { content: data.slackMessage.text };
+          return { content: data.text };
         }
 
         case "ms-teams":

--- a/packages/back-end/src/events/handlers/webhooks/webHooksEventHandler.ts
+++ b/packages/back-end/src/events/handlers/webhooks/webHooksEventHandler.ts
@@ -1,4 +1,7 @@
-import { getAllEventWebHooksForEvent } from "../../../models/EventWebhookModel";
+import {
+  getEventWebHookById,
+  getAllEventWebHooksForEvent,
+} from "../../../models/EventWebhookModel";
 import { NotificationEventHandler } from "../../notifiers/EventNotifier";
 import {
   getFilterDataForNotificationEvent,
@@ -15,17 +18,30 @@ export const webHooksEventHandler: NotificationEventHandler = async (event) => {
     projects: [],
   };
 
-  const eventWebHooks = (
-    (await getAllEventWebHooksForEvent({
-      organizationId: event.organizationId,
-      eventName: event.data.event,
-      enabled: true,
-      tags,
-      projects,
-    })) || []
-  ).filter(({ environments = [] }) =>
-    filterEventForEnvironments({ event: event.data, environments })
-  );
+  const eventWebHooks = await (async () => {
+    if (event.data.event === "test.event") {
+      const webhook = await getEventWebHookById(
+        event.data.data.webhookId,
+        event.organizationId
+      );
+
+      if (!webhook) return [];
+
+      return [webhook];
+    } else {
+      return (
+        (await getAllEventWebHooksForEvent({
+          organizationId: event.organizationId,
+          eventName: event.data.event,
+          enabled: true,
+          tags,
+          projects,
+        })) || []
+      ).filter(({ environments = [] }) =>
+        filterEventForEnvironments({ event: event.data, environments })
+      );
+    }
+  })();
 
   eventWebHooks.forEach((eventWebHook) => {
     const notifier = new EventWebHookNotifier({

--- a/packages/back-end/src/events/handlers/webhooks/webHooksEventHandler.ts
+++ b/packages/back-end/src/events/handlers/webhooks/webHooksEventHandler.ts
@@ -19,7 +19,7 @@ export const webHooksEventHandler: NotificationEventHandler = async (event) => {
   };
 
   const eventWebHooks = await (async () => {
-    if (event.data.event === "test.event") {
+    if (event.data.event === "webhook.test") {
       const webhook = await getEventWebHookById(
         event.data.data.webhookId,
         event.organizationId

--- a/packages/back-end/src/events/notification-events.d.ts
+++ b/packages/back-end/src/events/notification-events.d.ts
@@ -70,9 +70,9 @@ export type ExperimentDeletedNotificationEvent = NotificationEventPayload<
   }
 >;
 
-export type TestEvent = NotificationEventPayload<
-  "test.event",
-  unknown,
+export type WebhookTestEvent = NotificationEventPayload<
+  "webhook.test",
+  "webhook",
   { webhookId: string }
 >;
 
@@ -89,4 +89,4 @@ export type NotificationEvent =
   | ExperimentCreatedNotificationEvent
   | ExperimentUpdatedNotificationEvent
   | ExperimentDeletedNotificationEvent
-  | TestEvent;
+  | WebhookTestEvent;

--- a/packages/back-end/src/events/notification-events.d.ts
+++ b/packages/back-end/src/events/notification-events.d.ts
@@ -70,6 +70,12 @@ export type ExperimentDeletedNotificationEvent = NotificationEventPayload<
   }
 >;
 
+export type TestEvent = NotificationEventPayload<
+  "test.event",
+  unknown,
+  { webhookId: string }
+>;
+
 // endregion Experiment
 
 /**
@@ -82,4 +88,5 @@ export type NotificationEvent =
   | FeatureDeletedNotificationEvent
   | ExperimentCreatedNotificationEvent
   | ExperimentUpdatedNotificationEvent
-  | ExperimentDeletedNotificationEvent;
+  | ExperimentDeletedNotificationEvent
+  | TestEvent;

--- a/packages/back-end/src/routers/event-webhooks/event-webhooks.router.ts
+++ b/packages/back-end/src/routers/event-webhooks/event-webhooks.router.ts
@@ -122,4 +122,16 @@ router.put(
   eventWebHooksController.putEventWebHook
 );
 
+router.post(
+  "/event-webhooks/test",
+  validateRequestMiddleware({
+    body: z
+      .object({
+        webhookId: z.string().trim().min(1),
+      })
+      .strict(),
+  }),
+  eventWebHooksController.createTestEventWebHook
+);
+
 export { router as eventWebHooksRouter };

--- a/packages/front-end/components/EventWebHooks/EventWebHookDetail/EventWebHookDetail.stories.tsx
+++ b/packages/front-end/components/EventWebHooks/EventWebHookDetail/EventWebHookDetail.stories.tsx
@@ -70,6 +70,7 @@ export const SuccessfulRun = () => {
         action("onEdit")();
       }}
       eventWebHook={eventWebHookSuccessState}
+      mutateEventWebHook={() => undefined}
     />
   );
 };
@@ -88,6 +89,7 @@ export const FailedRun = () => {
         action("onEdit")();
       }}
       eventWebHook={eventWebHookFailedState}
+      mutateEventWebHook={() => undefined}
     />
   );
 };
@@ -106,6 +108,7 @@ export const WithoutRuns = () => {
         action("onEdit")();
       }}
       eventWebHook={eventWebHookNoState}
+      mutateEventWebHook={() => undefined}
     />
   );
 };
@@ -137,6 +140,7 @@ export const LotsOfEvents = () => {
         ...eventWebHookSuccessState,
         events: eventsList,
       }}
+      mutateEventWebHook={() => undefined}
     />
   );
 };

--- a/packages/front-end/components/EventWebHooks/EventWebHookDetail/EventWebHookDetail.tsx
+++ b/packages/front-end/components/EventWebHooks/EventWebHookDetail/EventWebHookDetail.tsx
@@ -13,6 +13,7 @@ import { useAuth } from "@/services/auth";
 import Badge from "@/components/Badge";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import useApi from "@/hooks/useApi";
+import { useEventWebhookLogs } from "@/hooks/useEventWebhookLogs";
 import {
   EventWebHookEditParams,
   useIconForState,
@@ -22,6 +23,7 @@ import { EventWebHookAddEditModal } from "@/components/EventWebHooks/EventWebHoo
 
 type EventWebHookDetailProps = {
   eventWebHook: EventWebHookInterface;
+  mutateEventWebHook: () => void;
   onEdit: (data: EventWebHookEditParams) => Promise<void>;
   onDelete: () => Promise<void>;
   onEditModalOpen: () => void;
@@ -32,6 +34,7 @@ type EventWebHookDetailProps = {
 
 export const EventWebHookDetail: FC<EventWebHookDetailProps> = ({
   eventWebHook,
+  mutateEventWebHook,
   onEdit,
   onDelete,
   onEditModalOpen,
@@ -50,6 +53,7 @@ export const EventWebHookDetail: FC<EventWebHookDetailProps> = ({
   } = eventWebHook;
 
   const { apiCall } = useAuth();
+  const { mutate: mutateEventLogs } = useEventWebhookLogs(webhookId);
 
   const iconForState = useIconForState(eventWebHook.lastState);
 
@@ -77,10 +81,15 @@ export const EventWebHookDetail: FC<EventWebHookDetailProps> = ({
       } else {
         //setCreateError(null);
       }
+
+      setTimeout(() => {
+        mutateEventLogs();
+        mutateEventWebHook();
+      }, 1000);
     } catch (e) {
       //handleCreateError("Unknown error");
     }
-  }, [webhookId, apiCall]);
+  }, [mutateEventLogs, mutateEventWebHook, webhookId, apiCall]);
 
   return (
     <div>
@@ -332,6 +341,7 @@ export const EventWebHookDetailContainer = () => {
       onModalClose={() => setIsEditModalOpen(false)}
       eventWebHook={data.eventWebHook}
       editError={editError}
+      mutateEventWebHook={mutate}
     />
   );
 };

--- a/packages/front-end/components/EventWebHooks/EventWebHookDetail/EventWebHookDetail.tsx
+++ b/packages/front-end/components/EventWebHooks/EventWebHookDetail/EventWebHookDetail.tsx
@@ -2,7 +2,7 @@ import { EventWebHookInterface } from "back-end/types/event-webhook";
 import React, { FC, useCallback, useState } from "react";
 import pick from "lodash/pick";
 import { TbWebhook } from "react-icons/tb";
-import { FaAngleLeft, FaPencilAlt } from "react-icons/fa";
+import { FaAngleLeft, FaPencilAlt, FaPaperPlane } from "react-icons/fa";
 import classNames from "classnames";
 import { useRouter } from "next/router";
 import Link from "next/link";
@@ -39,13 +39,48 @@ export const EventWebHookDetail: FC<EventWebHookDetailProps> = ({
   isModalOpen,
   editError,
 }) => {
-  const { lastState, lastRunAt, url, events, name, signingKey } = eventWebHook;
+  const {
+    id: webhookId,
+    lastState,
+    lastRunAt,
+    url,
+    events,
+    name,
+    signingKey,
+  } = eventWebHook;
+
+  const { apiCall } = useAuth();
 
   const iconForState = useIconForState(eventWebHook.lastState);
 
   const { performCopy, copySuccess, copySupported } = useCopyToClipboard({
     timeout: 1500,
   });
+
+  const onTestWebhook = useCallback(async () => {
+    // Keep the modal open and display error
+    //const handleCreateError = (message: string) => {
+    //setCreateError(`Failed to test webhook: ${message}`);
+    //};
+
+    try {
+      const response = await apiCall<{
+        error?: string;
+        eventId?: string;
+      }>("/event-webhooks/test", {
+        method: "POST",
+        body: JSON.stringify({ webhookId }),
+      });
+
+      if (response.error) {
+        //handleCreateError(response.error || "Unknown error");
+      } else {
+        //setCreateError(null);
+      }
+    } catch (e) {
+      //handleCreateError("Unknown error");
+    }
+  }, [webhookId, apiCall]);
 
   return (
     <div>
@@ -70,6 +105,14 @@ export const EventWebHookDetail: FC<EventWebHookDetailProps> = ({
           >
             <FaPencilAlt className="mr-1" />
             Edit
+          </button>
+
+          <button
+            onClick={onTestWebhook}
+            className="btn btn-sm btn-outline-secondary mr-1"
+          >
+            <FaPaperPlane className="mr-1" />
+            Test
           </button>
 
           <DeleteButton

--- a/packages/front-end/components/EventWebHooks/EventWebHookDetail/EventWebHookDetail.tsx
+++ b/packages/front-end/components/EventWebHooks/EventWebHookDetail/EventWebHookDetail.tsx
@@ -74,10 +74,6 @@ export const EventWebHookDetail: FC<EventWebHookDetailProps> = ({
   });
 
   const onTestWebhook = useCallback(async () => {
-    //const handleCreateError = (message: string) => {
-    //setCreateError(`Failed to test webhook: ${message}`);
-    //};
-
     try {
       const response = await apiCall<{
         error?: string;

--- a/packages/front-end/components/EventWebHooks/EventWebHookDetail/EventWebHookDetail.tsx
+++ b/packages/front-end/components/EventWebHooks/EventWebHookDetail/EventWebHookDetail.tsx
@@ -32,6 +32,17 @@ type EventWebHookDetailProps = {
   editError: string | null;
 };
 
+type State =
+  | {
+      type: "danger";
+      message: string;
+    }
+  | {
+      type: "success";
+      message: string;
+    }
+  | undefined;
+
 export const EventWebHookDetail: FC<EventWebHookDetailProps> = ({
   eventWebHook,
   mutateEventWebHook,
@@ -54,6 +65,7 @@ export const EventWebHookDetail: FC<EventWebHookDetailProps> = ({
 
   const { apiCall } = useAuth();
   const { mutate: mutateEventLogs } = useEventWebhookLogs(webhookId);
+  const [state, setState] = useState<State>();
 
   const iconForState = useIconForState(eventWebHook.lastState);
 
@@ -62,7 +74,6 @@ export const EventWebHookDetail: FC<EventWebHookDetailProps> = ({
   });
 
   const onTestWebhook = useCallback(async () => {
-    // Keep the modal open and display error
     //const handleCreateError = (message: string) => {
     //setCreateError(`Failed to test webhook: ${message}`);
     //};
@@ -77,27 +88,39 @@ export const EventWebHookDetail: FC<EventWebHookDetailProps> = ({
       });
 
       if (response.error) {
-        //handleCreateError(response.error || "Unknown error");
-      } else {
-        //setCreateError(null);
+        setState({
+          type: "danger",
+          message: `Failed to test webhook: ${
+            response.error || "Unknown error"
+          }`,
+        });
+        return;
       }
+
+      setState({ type: "success", message: "Test event sucessfully sent!" });
 
       setTimeout(() => {
         mutateEventLogs();
         mutateEventWebHook();
       }, 1000);
     } catch (e) {
-      //handleCreateError("Unknown error");
+      setState({ type: "danger", message: "Unknown error" });
     }
   }, [mutateEventLogs, mutateEventWebHook, webhookId, apiCall]);
 
   return (
     <div>
-      <div className="mb-3">
-        <Link href="/settings/webhooks">
+      <div className="d-sm-flex mb-3 justify-content-between">
+        <Link href="/settings/webhooks" className="p-sm-1">
           <FaAngleLeft />
           All Webhooks
         </Link>
+
+        {state && (
+          <div className={`p-sm-1 mb-0 alert alert-${state.type}`}>
+            {state.message}
+          </div>
+        )}
       </div>
 
       <div className="d-sm-flex justify-content-between mb-3 mb-sm-0">

--- a/packages/front-end/components/EventWebHooks/EventWebHookDetail/EventWebHookDetail.tsx
+++ b/packages/front-end/components/EventWebHooks/EventWebHookDetail/EventWebHookDetail.tsx
@@ -41,6 +41,7 @@ type State =
       type: "success";
       message: string;
     }
+  | { type: "loading" }
   | undefined;
 
 export const EventWebHookDetail: FC<EventWebHookDetailProps> = ({
@@ -74,6 +75,8 @@ export const EventWebHookDetail: FC<EventWebHookDetailProps> = ({
   });
 
   const onTestWebhook = useCallback(async () => {
+    setState({ type: "loading" });
+
     try {
       const response = await apiCall<{
         error?: string;
@@ -112,7 +115,7 @@ export const EventWebHookDetail: FC<EventWebHookDetailProps> = ({
           All Webhooks
         </Link>
 
-        {state && (
+        {state && state.type !== "loading" && (
           <div className={`p-sm-1 mb-0 alert alert-${state.type}`}>
             {state.message}
           </div>
@@ -138,6 +141,7 @@ export const EventWebHookDetail: FC<EventWebHookDetailProps> = ({
           <button
             onClick={onTestWebhook}
             className="btn btn-sm btn-outline-secondary mr-1"
+            disabled={state && state.type === "loading"}
           >
             <FaPaperPlane className="mr-1" />
             Test

--- a/packages/front-end/components/EventWebHooks/EventWebHookLogs/EventWebHookLogs.tsx
+++ b/packages/front-end/components/EventWebHooks/EventWebHookLogs/EventWebHookLogs.tsx
@@ -2,7 +2,7 @@ import React, { FC, useCallback, useEffect, useMemo, useState } from "react";
 import _ from "lodash";
 import { EventWebHookLogInterface } from "back-end/types/event-webhook-log";
 import { useRouter } from "next/router";
-import useApi from "@/hooks/useApi";
+import { useEventWebhookLogs } from "@/hooks/useEventWebhookLogs";
 import { EventWebHookLogItem } from "./EventWebHookLogItem/EventWebHookLogItem";
 import { EventWebHookLogActiveItem } from "./EventWebHookLogActiveItem/EventWebHookLogActiveItem";
 
@@ -65,9 +65,7 @@ export const EventWebHookLogs: FC<EventWebHookLogsProps> = ({
 export const EventWebHookLogsContainer = () => {
   const router = useRouter();
   const { eventwebhookid: eventWebHookId } = router.query;
-  const { data, error } = useApi<{
-    eventWebHookLogs: EventWebHookLogInterface[];
-  }>(`/event-webhooks/logs/${eventWebHookId}`);
+  const { data, error } = useEventWebhookLogs(`${eventWebHookId}`);
 
   const [activeLog, setActiveLog] = useState<EventWebHookLogInterface | null>(
     null

--- a/packages/front-end/hooks/useEventWebhookLogs.ts
+++ b/packages/front-end/hooks/useEventWebhookLogs.ts
@@ -1,0 +1,7 @@
+import { EventWebHookLogInterface } from "back-end/types/event-webhook-log";
+import useApi from "./useApi";
+
+export const useEventWebhookLogs = (eventWebHookId: string) =>
+  useApi<{
+    eventWebHookLogs: EventWebHookLogInterface[];
+  }>(`/event-webhooks/logs/${eventWebHookId}`);


### PR DESCRIPTION
This PR adds a new "test" button to webhooks to test them.

The implementation creates a new event of type `webhook.test`. This event is created in a webhook-specific endpoint and routed through the regular event notifier but notification is explicitely disable for slack integration.

### Demo

https://www.loom.com/share/f85f8f20e3f84513b9452bf55b8432a9
