### PR TITLE
Fix ClickHouse host handling

### DIFF
--- a/packages/back-end/src/util/sql.ts
+++ b/packages/back-end/src/util/sql.ts
@@ -181,9 +181,13 @@ export function getHost(
   port: number
 ): string | undefined {
   if (!url) return undefined;
-  const host = new URL(url);
-  if (!host.port && port) host.port = port + "";
-  return host.origin;
+  try {
+    const host = new URL(url);
+    if (!host.port && port) host.port = port + "";
+    return host.origin;
+  } catch (e) {
+    return `${url}:${port}`;
+  }
 }
 
 // Recursively create list of metric denominators in order

--- a/packages/back-end/src/util/sql.ts
+++ b/packages/back-end/src/util/sql.ts
@@ -181,13 +181,9 @@ export function getHost(
   port: number
 ): string | undefined {
   if (!url) return undefined;
-  try {
-    const host = new URL(url);
-    if (!host.port && port) host.port = port + "";
-    return host.origin;
-  } catch (e) {
-    return `${url}:${port}`;
-  }
+  const host = new URL(!url.match(/^https?/) ? `http://${url}` : url);
+  if (!host.port && port) host.port = port + "";
+  return host.origin;
 }
 
 // Recursively create list of metric denominators in order

--- a/packages/back-end/test/util/sql.test.ts
+++ b/packages/back-end/test/util/sql.test.ts
@@ -388,6 +388,9 @@ from
 describe("getHost", () => {
   it("works as expected", () => {
     expect(getHost("http://localhost", 8080)).toEqual("http://localhost:8080");
+    expect(getHost("https://localhost", 8080)).toEqual(
+      "https://localhost:8080"
+    );
   });
   it("prefers port in url", () => {
     expect(getHost("http://localhost:8888", 8080)).toEqual(
@@ -395,6 +398,6 @@ describe("getHost", () => {
     );
   });
   it("tries best if URL is malformed", () => {
-    expect(getHost("localhost", 8080)).toEqual("localhost:8080");
+    expect(getHost("localhost", 8080)).toEqual("http://localhost:8080");
   });
 });

--- a/packages/back-end/test/util/sql.test.ts
+++ b/packages/back-end/test/util/sql.test.ts
@@ -394,9 +394,7 @@ describe("getHost", () => {
       "http://localhost:8888"
     );
   });
-  it("errors if url is malformed", () => {
-    expect(() => {
-      getHost("localhost", 8080);
-    }).toThrow(TypeError("Invalid URL"));
+  it("tries best if URL is malformed", () => {
+    expect(getHost("localhost", 8080)).toEqual("localhost:8080");
   });
 });


### PR DESCRIPTION
Make sure it is backwards compatible with the old client by adding "http://" if the host has no http(s) prefix