### PR TITLE
Use metric's projects, not current.project, when checking createMetric permission in edit metric form

### DIFF
--- a/packages/front-end/components/Metrics/MetricForm/index.tsx
+++ b/packages/front-end/components/Metrics/MetricForm/index.tsx
@@ -580,15 +580,13 @@ const MetricForm: FC<MetricFormProps> = ({
   );
 
   let ctaEnabled = true;
-  let disabledMessage = null;
+  let disabledMessage: string | null = null;
 
   if (riskError) {
     ctaEnabled = false;
-    // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '"The acceptable risk percentage cannot be hi... Remove this comment to see the full error message
     disabledMessage = riskError;
-  } else if (!permissionsUtil.canCreateMetric({ projects: [project] })) {
+  } else if (!permissionsUtil.canCreateMetric({ projects: value.projects })) {
     ctaEnabled = false;
-    // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '"You don't have permission to create metrics... Remove this comment to see the full error message
     disabledMessage = "You don't have permission to create metrics.";
   }
 


### PR DESCRIPTION
### Features and Changes

When determining whether or not a user had permission to edit a metric, we were using the currently selected project, rather than the metric's projects. So if "All Projects" was selected, and the user's global role did not provide `createMetrics` permission, they were receiving the error, even if the user had project-specific permissions that should've granted them permission to edit the metric.