### PR TITLE
Bump SDK versions - Javascript 0.36.0, React 0.26.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,12 +160,14 @@ Releasing SDK updates is a very manual process right now. It requires bumping ve
    - Add new entry to `packages/sdk-js/CHANGELOG.md`
    - Add new entry to `packages/shared/src/sdk-versioning/sdk-versions/javascript.json`
    - Add new entry to `packages/shared/src/sdk-versioning/sdk-versions/nodejs.json`
+   - If any new capabilities were introduced and they work by default, update `packages/shared/src/sdk-versioning/sdk-versions/nocode.json`.
+   - Update resolutions in `package.json`
 3. Bump versions of the React SDK
    - Bump version in `packages/sdk-react/package.json`
    - Bump dependency version in `package/front-end/package.json`
    - Add new entry to `packages/shared/src/sdk-versioning/sdk-versions/react.json`
 4. Do a global search for the old version strings for both Javascript and React to make sure nothing was missed. Update these instructions if needed.
-5. Run `yarn install`
+5. Run `yarn install`. There should be zero changes to `yarn.lock`. If there are, you missed something above.
 6. Create a PR and let CI complete successfully
 7. Publish the Javascript SDK
    - `yarn build`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,7 +168,7 @@ Releasing SDK updates is a very manual process right now. It requires bumping ve
    - Add new entry to `packages/shared/src/sdk-versioning/sdk-versions/react.json`
 4. Do a global search for the old version strings for both Javascript and React to make sure nothing was missed. Update these instructions if needed.
 5. Run `yarn install`. There should be zero changes to `yarn.lock`. If there are, you missed something above.
-6. Create a PR and let CI complete successfully
+6. Create a PR and let CI complete successfully. Use the changelog entry as the PR description.
 7. Publish the Javascript SDK
    - `yarn build`
    - `npm publish`

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     ]
   },
   "resolutions": {
-    "@growthbook/growthbook": "0.35.0"
+    "@growthbook/growthbook": "0.36.0"
   },
   "prettier": {
     "overrides": [

--- a/packages/back-end/package.json
+++ b/packages/back-end/package.json
@@ -32,7 +32,7 @@
     "@dqbd/tiktoken": "^1.0.7",
     "@google-cloud/bigquery": "5",
     "@google-cloud/storage": "^5.20.5",
-    "@growthbook/growthbook": "^0.35.0",
+    "@growthbook/growthbook": "^0.36.0",
     "@growthbook/proxy-eval": "^1.0.2",
     "@octokit/auth-app": "^6.0.1",
     "@octokit/core": "^5.0.2",

--- a/packages/front-end/package.json
+++ b/packages/front-end/package.json
@@ -19,7 +19,7 @@
     "@dnd-kit/core": "^4.0.3",
     "@dnd-kit/sortable": "^5.1.0",
     "@floating-ui/react": "^0.25.4",
-    "@growthbook/growthbook-react": "^0.25.0",
+    "@growthbook/growthbook-react": "^0.26.0",
     "@jitsu/sdk-js": "^2.2.0",
     "@jukben/emoji-search": "^2.0.1",
     "@popperjs/core": "^2.11.5",

--- a/packages/sdk-js/CHANGELOG.md
+++ b/packages/sdk-js/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## **0.36.0** - Mar 21, 2024
+
+- Support for URL Redirect tests. New context options `navigate` (defualt `(url) => window.location.replace(url)`) and `navigateDelay` (default 100ms) for browsers. Plus, new method `getRedirectUrl()` for back-end/edge implementations.
+- Built-in anti-flicker snippet. Set context option `antiFlicker` to true to enable (defualt false). Control timeout with option `antiFlickerTimerout` (default 3500ms)
+- New methods to deal with deferred tracking calls and server/client hydration
+  - `setTrackingCallback` - Set or update the trackingCallback after initialization. Until a trackingCallback is set, all calls will be queued up.
+  - `getDeferredTrackingCalls` - Get all queued tracking calls (in JSON format)
+  - `setDeferredTrackingCalls` - Hydrate the GrowthBook instance with queued tracking calls (in JSON format). Does not fire these calls immediately.
+  - `fireDeferredTrackingCalls` - Manually fire all queued tracking calls.
+- Various improvements to `auto.min.js` script
+  - New `uuid` context property to use your own user id instead of the auto-generated one.
+  - New `data-no-auto-cookies` script attribute and `growthbookpersist` event listener to more easily work with cookie consent banners
+  - New `growthbookdata` DOM event to attach multiple renderers to a single GrowthBook instance
+- Fix bug with prerequisite feature checks failing on initial page load when used with visual editor experiments
+
 ## **0.35.0** - Mar 8, 2024
 
 - New `updateAttributes` method to make partial updates

--- a/packages/sdk-js/CHANGELOG.md
+++ b/packages/sdk-js/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## **0.36.0** - Mar 21, 2024
 
 - Support for URL Redirect tests. New context options `navigate` (defualt `(url) => window.location.replace(url)`) and `navigateDelay` (default 100ms) for browsers. Plus, new method `getRedirectUrl()` for back-end/edge implementations.
-- Built-in anti-flicker snippet. Set context option `antiFlicker` to true to enable (defualt false). Control timeout with option `antiFlickerTimerout` (default 3500ms)
+- Built-in anti-flicker snippet. Set context option `antiFlicker` to true to enable (defualt false). Control timeout with option `antiFlickerTimeout` (default 3500ms)
 - New methods to deal with deferred tracking calls and server/client hydration
   - `setTrackingCallback` - Set or update the trackingCallback after initialization. Until a trackingCallback is set, all calls will be queued up.
   - `getDeferredTrackingCalls` - Get all queued tracking calls (in JSON format)

--- a/packages/sdk-js/CHANGELOG.md
+++ b/packages/sdk-js/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## **0.36.0** - Mar 21, 2024
 
-- Support for URL Redirect tests. New context options `navigate` (defualt `(url) => window.location.replace(url)`) and `navigateDelay` (default 100ms) for browsers. Plus, new method `getRedirectUrl()` for back-end/edge implementations.
+- Support for URL Redirect tests. New context options `navigate` (default `(url) => window.location.replace(url)`) and `navigateDelay` (default 100ms) for browsers. Plus, new method `getRedirectUrl()` for back-end/edge implementations.
 - Built-in anti-flicker snippet. Set context option `antiFlicker` to true to enable (defualt false). Control timeout with option `antiFlickerTimeout` (default 3500ms)
 - New methods to deal with deferred tracking calls and server/client hydration
   - `setTrackingCallback` - Set or update the trackingCallback after initialization. Until a trackingCallback is set, all calls will be queued up.

--- a/packages/sdk-js/package.json
+++ b/packages/sdk-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@growthbook/growthbook",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/sdk-react/package.json
+++ b/packages/sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@growthbook/growthbook-react",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -38,7 +38,7 @@
     "react": "^16.8.0-0 || ^17.0.0-0 || ^18.0.0-0"
   },
   "dependencies": {
-    "@growthbook/growthbook": "^0.35.0"
+    "@growthbook/growthbook": "^0.36.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.19.3",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -17,7 +17,7 @@
     "type-check": "tsc --pretty --noEmit"
   },
   "dependencies": {
-    "@growthbook/growthbook": "^0.35.0",
+    "@growthbook/growthbook": "^0.36.0",
     "ajv": "^8.12.0",
     "date-fns": "^2.15.0",
     "dirty-json": "^0.9.2",

--- a/packages/shared/src/sdk-versioning/sdk-versions/javascript.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/javascript.json
@@ -1,6 +1,10 @@
 {
   "versions": [
     {
+      "version": "0.36.0",
+      "capabilities": ["redirects"]
+    },
+    {
       "version": "0.35.0"
     },
     {

--- a/packages/shared/src/sdk-versioning/sdk-versions/nocode.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/nocode.json
@@ -12,7 +12,8 @@
         "visualEditorJS",
         "remoteEval",
         "visualEditorDragDrop",
-        "prerequisites"
+        "prerequisites",
+        "redirects"
       ]
     }
   ]

--- a/packages/shared/src/sdk-versioning/sdk-versions/nodejs.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/nodejs.json
@@ -1,6 +1,10 @@
 {
   "versions": [
     {
+      "version": "0.36.0",
+      "capabilities": ["redirects"]
+    },
+    {
       "version": "0.35.0"
     },
     {

--- a/packages/shared/src/sdk-versioning/sdk-versions/react.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/react.json
@@ -1,6 +1,10 @@
 {
   "versions": [
     {
+      "version": "0.26.0",
+      "capabilities": ["redirects"]
+    },
+    {
       "version": "0.25.0"
     },
     {

--- a/packages/shared/src/sdk-versioning/types.ts
+++ b/packages/shared/src/sdk-versioning/types.ts
@@ -10,7 +10,8 @@ export type SDKCapability =
   | "visualEditorDragDrop"
   | "stickyBucketing"
   | "urlRedirects"
-  | "prerequisites";
+  | "prerequisites"
+  | "redirects";
 
 export type CapabilityStrategy =
   | "min-ver-intersection" // intersection of capabilities using default SDK versions


### PR DESCRIPTION
## Changes

- Support for URL Redirect tests. New context options `navigate` (defualt `(url) => window.location.replace(url)`) and `navigateDelay` (default 100ms) for browsers. Plus, new method `getRedirectUrl()` for back-end/edge implementations.
- Built-in anti-flicker snippet. Set context option `antiFlicker` to true to enable (defualt false). Control timeout with option `antiFlickerTimeout` (default 3500ms)
- New methods to deal with deferred tracking calls and server/client hydration
  - `setTrackingCallback` - Set or update the trackingCallback after initialization. Until a trackingCallback is set, all calls will be queued up.
  - `getDeferredTrackingCalls` - Get all queued tracking calls (in JSON format)
  - `setDeferredTrackingCalls` - Hydrate the GrowthBook instance with queued tracking calls (in JSON format). Does not fire these calls immediately.
  - `fireDeferredTrackingCalls` - Manually fire all queued tracking calls.
- Various improvements to `auto.min.js` script
  - New `uuid` context property to use your own user id instead of the auto-generated one.
  - New `data-no-auto-cookies` script attribute and `growthbookpersist` event listener to more easily work with cookie consent banners
  - New `growthbookdata` DOM event to attach multiple renderers to a single GrowthBook instance
- Fix bug with prerequisite feature checks failing on initial page load when used with visual editor experiments


TODO:
- [x] Build and release Javascript SDK to npm
- [x] Build and release React SDK to npm
- [ ] Merge PR