### PR TITLE
Fix events data generation.

### DIFF
--- a/packages/back-end/test/data-generator/new-generator.ts
+++ b/packages/back-end/test/data-generator/new-generator.ts
@@ -141,6 +141,9 @@ function getBrowser(): string {
 }
 
 function normalInt(min: number, max: number): number {
+  if (max < min) throw "Invalid value!";
+  if (min === max) return min;
+
   const mean = (max - min) / 2 + min;
   const stddev = (max - min) / 3;
 


### PR DESCRIPTION
`@stdlib/random/base/normal` returns `NaN` when the standard deviation is `<= 0`: https://stdlib.io/docs/api/latest/@stdlib/random/base/normal

