### PR TITLE
Remove double navigation in the experiments list

### DIFF
--- a/packages/front-end/pages/experiments/index.tsx
+++ b/packages/front-end/pages/experiments/index.tsx
@@ -355,55 +355,46 @@ const ExperimentsPage = (): React.ReactElement => {
                         type="icon"
                       />
                     </td>
-                    <td
-                      onClick={() => {
-                        router.push(`/experiment/${e.id}`);
-                      }}
-                      className="cursor-pointer"
-                      data-title="Experiment name:"
-                    >
-                      <div className="d-flex flex-column">
-                        <div className="d-flex">
-                          <Link
-                            href={`/experiment/${e.id}`}
-                            className="testname"
-                          >
-                            {e.name}
-                          </Link>
-                          {e.hasVisualChangesets ? (
-                            <Tooltip
-                              className="d-flex align-items-center ml-2"
-                              body="Visual experiment"
+                    <td data-title="Experiment name:">
+                      <Link href={`/experiment/${e.id}`}>
+                        <div className="d-flex flex-column">
+                          <div className="d-flex">
+                            <span className="testname">{e.name}</span>
+                            {e.hasVisualChangesets ? (
+                              <Tooltip
+                                className="d-flex align-items-center ml-2"
+                                body="Visual experiment"
+                              >
+                                <RxDesktop className="text-blue" />
+                              </Tooltip>
+                            ) : null}
+                            {(e.linkedFeatures || []).length > 0 ? (
+                              <Tooltip
+                                className="d-flex align-items-center ml-2"
+                                body="Linked Feature Flag"
+                              >
+                                <BsFlag className="text-blue" />
+                              </Tooltip>
+                            ) : null}
+                            {e.hasURLRedirects ? (
+                              <Tooltip
+                                className="d-flex align-items-center ml-2"
+                                body="URL Redirect experiment"
+                              >
+                                <PiShuffle className="text-blue" />
+                              </Tooltip>
+                            ) : null}
+                          </div>
+                          {isFiltered && e.trackingKey && (
+                            <span
+                              className="testid text-muted small"
+                              title="Experiment Id"
                             >
-                              <RxDesktop className="text-blue" />
-                            </Tooltip>
-                          ) : null}
-                          {(e.linkedFeatures || []).length > 0 ? (
-                            <Tooltip
-                              className="d-flex align-items-center ml-2"
-                              body="Linked Feature Flag"
-                            >
-                              <BsFlag className="text-blue" />
-                            </Tooltip>
-                          ) : null}
-                          {e.hasURLRedirects ? (
-                            <Tooltip
-                              className="d-flex align-items-center ml-2"
-                              body="URL Redirect experiment"
-                            >
-                              <PiShuffle className="text-blue" />
-                            </Tooltip>
-                          ) : null}
+                              {e.trackingKey}
+                            </span>
+                          )}
                         </div>
-                        {isFiltered && e.trackingKey && (
-                          <span
-                            className="testid text-muted small"
-                            title="Experiment Id"
-                          >
-                            {e.trackingKey}
-                          </span>
-                        )}
-                      </div>
+                      </Link>
                     </td>
                     {showProjectColumn && (
                       <td className="nowrap" data-title="Project:">

--- a/packages/front-end/pages/experiments/index.tsx
+++ b/packages/front-end/pages/experiments/index.tsx
@@ -355,8 +355,11 @@ const ExperimentsPage = (): React.ReactElement => {
                         type="icon"
                       />
                     </td>
-                    <td data-title="Experiment name:">
-                      <Link href={`/experiment/${e.id}`}>
+                    <td data-title="Experiment name:" className="p-0">
+                      <Link
+                        href={`/experiment/${e.id}`}
+                        className="d-block p-2"
+                      >
                         <div className="d-flex flex-column">
                           <div className="d-flex">
                             <span className="testname">{e.name}</span>


### PR DESCRIPTION
### Features and Changes

This PR removes the `onClick` handler from the table element in the experiment list. This handler overrode default behavior, which caused the current tab to navigate to the location when using `ctrl/cmd + click`, for example.

### Testing

You can go to the experiment list before and after the changes, `ctrl/cmd + click` on an experiment name, and notice you will open a new tab with the experiment and navigate to the experiment on the current tab.

### Screenshots
HTML before the changes:
<img width="535" alt="image" src="https://github.com/growthbook/growthbook/assets/52393857/def62622-31ed-4281-8081-0c0978a08697">

HTML after the changes:
<img width="587" alt="image" src="https://github.com/growthbook/growthbook/assets/52393857/ac8f3108-2a35-4bec-bcc8-8a99cdacdb57">

List before the changes:
<img width="1329" alt="image" src="https://github.com/growthbook/growthbook/assets/52393857/44c41ffe-55c0-421f-b2a4-9c54c6b156ab">


List after the changes:
<img width="1319" alt="image" src="https://github.com/growthbook/growthbook/assets/52393857/ab58d5a0-9530-4285-bdc4-89b75d718cbc">


It's worth noting the clickable area is now smaller since the `td` element padding is no longer clickable.