### PR TITLE
Add CI SKIP to github deploy action.

### DIFF
--- a/.github/scripts/ci-skip.sh
+++ b/.github/scripts/ci-skip.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+shopt -s nocasematch
+
+# Only check for line:
+CHECKED=`echo "${COMMIT_MESSAGE}" | head -n 1`
+
+echo "Checking ${CHECKED}"
+
+if [[ "${CHECKED}}" =~ CI\ SKIP ]]; then
+  echo "CI skip!"
+  echo "ci_skip=true" >> "${GITHUB_OUTPUT}"
+  exit 0
+fi
+
+if [[ "${CHECKED}" =~ CI_SKIP ]]; then
+  echo "CI skip!"
+  echo "ci_skip=true" >> "${GITHUB_OUTPUT}"
+  exit 0
+fi
+
+echo "Proceed with CI"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,10 +12,27 @@ on:
       - "Dockerfile"
       - ".dockerignore"
 jobs:
+  check_ci_skip:
+    runs-on: ubuntu-latest
+    outputs:
+      ci_skip: ${{ steps.check_ci_skip.outputs.ci_skip }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Check if CI should be skipped
+        id: check_ci_skip
+        shell: bash
+        env:
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+        run: |
+          ./.github/scripts/ci-skip.sh
+
   # Build and publish the commit to docker
   docker:
     runs-on: ubuntu-latest
-    if: ${{ github.repository == 'growthbook/growthbook' }}
+    needs: [check_ci_skip]
+    if: ${{ github.repository == 'growthbook/growthbook' && needs.check_ci_skip.outputs.ci_skip != 'true' }}
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
This PR adds support for a case insensitive optional `CI SKIP` or `CI_SKIP` tag in commit titles. When this tag is found, production deploys are skipped.