### PR TITLE
Fix bug when adding rule to feature in a new environment

### DIFF
--- a/packages/front-end/components/Features/PrerequisiteTargetingField.tsx
+++ b/packages/front-end/components/Features/PrerequisiteTargetingField.tsx
@@ -73,8 +73,9 @@ export default function PrerequisiteTargetingField({
   }).includes("prerequisites");
 
   const { hasCommercialFeature } = useUser();
-  const hasPrerequisitesCommercialFeature =
-    true || hasCommercialFeature("prerequisite-targeting");
+  const hasPrerequisitesCommercialFeature = hasCommercialFeature(
+    "prerequisite-targeting"
+  );
 
   useEffect(() => {
     for (let i = 0; i < value.length; i++) {

--- a/packages/front-end/components/Features/PrerequisiteTargetingField.tsx
+++ b/packages/front-end/components/Features/PrerequisiteTargetingField.tsx
@@ -73,9 +73,8 @@ export default function PrerequisiteTargetingField({
   }).includes("prerequisites");
 
   const { hasCommercialFeature } = useUser();
-  const hasPrerequisitesCommercialFeature = hasCommercialFeature(
-    "prerequisite-targeting"
-  );
+  const hasPrerequisitesCommercialFeature =
+    true || hasCommercialFeature("prerequisite-targeting");
 
   useEffect(() => {
     for (let i = 0; i < value.length; i++) {
@@ -154,6 +153,8 @@ export default function PrerequisiteTargetingField({
           enabled: true,
         };
         if (newRevision) {
+          newRevision.rules[environments[0]] =
+            newRevision.rules[environments[0]] || [];
           newRevision.rules[environments[0]].push(fakeRule);
         } else {
           newFeature.environmentSettings[environments[0]].rules.push(fakeRule);

--- a/packages/front-end/components/Features/RuleModal.tsx
+++ b/packages/front-end/components/Features/RuleModal.tsx
@@ -171,6 +171,7 @@ export default function RuleModal({
     if (newRevision) {
       // merge form values into revision
       const newRule = form.getValues() as FeatureRule;
+      newRevision.rules[environment] = newRevision.rules[environment] || [];
       newRevision.rules[environment][i] = newRule;
     }
     const featuresMap = new Map(features.map((f) => [f.id, f]));


### PR DESCRIPTION
### Features and Changes

This PR fixes 2 errors on feature pages when adding new rules, both related to prerequisites and adding/deleting environments from an organization.

To reproduce error 1:
1. Create a feature
2. Delete one of the environments from the organization
3. Add a rule to your feature (don't publish, just let it stay in draft)
4. Add back the deleted environment
5. Try to add another rule to your feature in the now-restored environment

To reproduce error 2:
1. Create a feature
2. Add a new environment to the organization
3. Go to add a new Force Rule to a feature
4. Click to add prerequisite targeting