### PR TITLE
Fix bug with air gapped licenses

### DIFF
--- a/packages/enterprise/src/license.ts
+++ b/packages/enterprise/src/license.ts
@@ -778,7 +778,7 @@ function shouldLimitAccess(org: MinimalOrganization): boolean {
     return true;
   }
 
-  if (!licenseData.emailVerified) {
+  if (org.licenseKey?.startsWith("license") && !licenseData.emailVerified) {
     return true;
   }
 


### PR DESCRIPTION
### Features and Changes
Air-gapped licenses don't have emailVerified, so we should ignore them now.

We should show the reason that access has been limited in another PR.

### Testing
Add an air-gapped license to env vars.
See that it remains the Pro tag in the header.
