### PR TITLE
Adds word-wrapping to data type column on attribute table.

### DIFF
--- a/packages/front-end/pages/attributes.tsx
+++ b/packages/front-end/pages/attributes.tsx
@@ -35,7 +35,10 @@ const FeatureAttributesPage = (): React.ReactElement => {
           <span className="badge badge-secondary ml-2">archived</span>
         )}
       </td>
-      <td className="text-gray">
+      <td
+        className="text-gray"
+        style={{ maxWidth: "25vh", wordWrap: "break-word" }}
+      >
         {v.datatype}
         {v.datatype === "enum" && <>: ({v.enum})</>}
         {v.format && (

--- a/packages/front-end/pages/attributes.tsx
+++ b/packages/front-end/pages/attributes.tsx
@@ -37,7 +37,7 @@ const FeatureAttributesPage = (): React.ReactElement => {
       </td>
       <td
         className="text-gray"
-        style={{ maxWidth: "25vh", wordWrap: "break-word" }}
+        style={{ maxWidth: "20vw", wordWrap: "break-word" }}
       >
         {v.datatype}
         {v.datatype === "enum" && <>: ({v.enum})</>}


### PR DESCRIPTION
### Features and Changes

The data type column on `/attributes` didn't have any `maxWidth` or `wordWrap` properties, so in the event the datatype was an `enum` and the csv was really long, it was causing a horizontal scroll situation.

Now, the column will at max, be 20% of the viewport width, and we now wrap the text, even if it means breaking the word.

### Screenshots

Before:
<img width="1511" alt="Screen Shot 2024-03-26 at 2 15 27 PM" src="https://github.com/growthbook/growthbook/assets/75274610/2df2184c-3210-463a-ad4e-42c71728a95a">

After:
<img width="1507" alt="Screen Shot 2024-03-26 at 2 21 56 PM" src="https://github.com/growthbook/growthbook/assets/75274610/b766b27b-baa5-4c9f-a1b7-eb2f57cec629">
