### PR TITLE
Fix CTA on health tab.

### DIFF
--- a/packages/front-end/components/Experiment/TabbedPage/HealthTabOnboardingModal.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/HealthTabOnboardingModal.tsx
@@ -344,7 +344,7 @@ export const HealthTabOnboardingModal: FC<HealthTabOnboardingModalProps> = ({
         setLastStep(step);
         setStep(-1);
       }}
-      includeCloseCta={false}
+      includeCloseCta={true}
       secondaryCTA={secondaryCTA}
       size="lg"
       header={header}


### PR DESCRIPTION
Quick PR to fix the CTA on the first health tag modal:

**Before**:

<img width="958" alt="Screenshot 2024-03-26 at 2 15 57 PM" src="https://github.com/growthbook/growthbook/assets/160149598/eafc0abd-a8cd-4a1b-8b86-efe149c73cc1">


**After:**

<img width="918" alt="Screenshot 2024-03-26 at 2 22 53 PM" src="https://github.com/growthbook/growthbook/assets/160149598/059087a0-175c-4232-8409-a991e75098a4">
