### PR TITLE
Bugfix: Updating url patterns for visual changesets

### DIFF
--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -1961,21 +1961,27 @@ export function visualChangesetsHaveChanges({
   oldVisualChangeset: VisualChangesetInterface;
   newVisualChangeset: VisualChangesetInterface;
 }): boolean {
-  // If there are visual change differences
-  const oldVisualChanges = oldVisualChangeset.visualChanges.map(
-    ({ css, js, domMutations }) => ({ css, js, domMutations })
-  );
-  const newVisualChanges = newVisualChangeset.visualChanges.map(
-    ({ css, js, domMutations }) => ({ css, js, domMutations })
-  );
-  if (!isEqual(oldVisualChanges, newVisualChanges)) {
-    return true;
-  }
-
   // If there are URL targeting differences
   if (
     !isEqual(oldVisualChangeset.urlPatterns, newVisualChangeset.urlPatterns)
   ) {
+    return true;
+  }
+
+  // If there are visual change differences
+  const oldVisualChanges = oldVisualChangeset.visualChanges?.map(
+    ({ css, js, domMutations }) => ({ css, js, domMutations })
+  );
+  const newVisualChanges = newVisualChangeset.visualChanges?.map(
+    ({ css, js, domMutations }) => ({ css, js, domMutations })
+  );
+
+  // If there are no visual changes in either set, there are no changes
+  if (!oldVisualChanges || !newVisualChanges) {
+    return false;
+  }
+
+  if (!isEqual(oldVisualChanges, newVisualChanges)) {
     return true;
   }
 


### PR DESCRIPTION
The code diff looks confusing but basically swapped the ordering of checks in `visualChangesetsHaveChanges`.

From: 
- check for visual changes
- check for urlPatterns changes

To:
- check for urlPatterns changes
- check for visual changes

Also, return early if `visualChanges` for either visualchangeset is undefined (since this doesn't signify a change, just a malformed object).

Fixes #2283 
