### PR TITLE
Modify QuantileClusteredStatistic name; move unneeded input statistic…

### DIFF
--- a/packages/stats/gbstats/bayesian/tests.py
+++ b/packages/stats/gbstats/bayesian/tests.py
@@ -22,7 +22,7 @@ from gbstats.models.statistics import (
     SampleMeanStatistic,
     TestStatistic,
     QuantileStatistic,
-    QuantileStatisticClustered,
+    QuantileClusteredStatistic,
 )
 from gbstats.frequentist.tests import frequentist_diff, frequentist_variance
 
@@ -332,13 +332,13 @@ class GaussianEffectABTest(BayesianABTest):
             SampleMeanStatistic,
             RatioStatistic,
             QuantileStatistic,
-            QuantileStatisticClustered,
+            QuantileClusteredStatistic,
         ],
         stat_b: Union[
             SampleMeanStatistic,
             RatioStatistic,
             QuantileStatistic,
-            QuantileStatisticClustered,
+            QuantileClusteredStatistic,
         ],
         config: EffectBayesianConfig,
     ):

--- a/packages/stats/gbstats/gbstats.py
+++ b/packages/stats/gbstats/gbstats.py
@@ -45,7 +45,7 @@ from gbstats.models.settings import (
 from gbstats.models.statistics import (
     ProportionStatistic,
     QuantileStatistic,
-    QuantileStatisticClustered,
+    QuantileClusteredStatistic,
     RatioStatistic,
     RegressionAdjustedStatistic,
     SampleMeanStatistic,
@@ -224,10 +224,10 @@ def get_configured_test(
         stat_a_proportion = isinstance(stat_a, ProportionStatistic)
         stat_b_proportion = isinstance(stat_b, ProportionStatistic)
         stat_a_quantile = isinstance(
-            stat_a, (QuantileStatistic, QuantileStatisticClustered)
+            stat_a, (QuantileStatistic, QuantileClusteredStatistic)
         )
         stat_b_quantile = isinstance(
-            stat_b, (QuantileStatistic, QuantileStatisticClustered)
+            stat_b, (QuantileStatistic, QuantileClusteredStatistic)
         )
 
         if stat_a_proportion and stat_b_proportion:

--- a/packages/stats/gbstats/models/statistics.py
+++ b/packages/stats/gbstats/models/statistics.py
@@ -207,11 +207,6 @@ class QuantileStatistic(Statistic):
     quantile_hat: float  # sample estimate
     quantile_lower: float
     quantile_upper: float
-    main_sum: float  # numerator sum
-    main_sum_squares: float
-    denominator_sum: float  # denominator sum
-    denominator_sum_squares: float
-    main_denominator_sum_product: float
 
     @property
     def _has_zero_variance(self) -> bool:
@@ -245,7 +240,12 @@ class QuantileStatistic(Statistic):
 
 
 @dataclass
-class QuantileStatisticClustered(QuantileStatistic):
+class QuantileClusteredStatistic(QuantileStatistic):
+    main_sum: float  # numerator sum
+    main_sum_squares: float
+    denominator_sum: float  # denominator sum
+    denominator_sum_squares: float
+    main_denominator_sum_product: float
     n_clusters: int
 
     @property
@@ -287,5 +287,5 @@ TestStatistic = Union[
     RegressionAdjustedStatistic,
     RatioStatistic,
     QuantileStatistic,
-    QuantileStatisticClustered,
+    QuantileClusteredStatistic,
 ]

--- a/packages/stats/tests/bayesian/test_tests.py
+++ b/packages/stats/tests/bayesian/test_tests.py
@@ -20,7 +20,6 @@ from gbstats.models.statistics import (
     ProportionStatistic,
     SampleMeanStatistic,
     QuantileStatistic,
-    QuantileStatisticClustered,
 )
 from gbstats.models.tests import Uplift
 
@@ -164,8 +163,6 @@ class TestNorm(TestCase):
 class TestGaussianEffectABTest(TestCase):
     def test_bayesian_effect_ab_test(self):
         nu = 0.9
-        n_clusters = 10000
-        alpha = 0.05
         n_c = 11054
         n_t = 10861
         quantile_hat_c = 7.157987489967789
@@ -174,17 +171,6 @@ class TestGaussianEffectABTest(TestCase):
         quantile_lower_t = 7.64180598628119
         quantile_upper_c = 7.217194843758751
         quantile_upper_t = 7.747193868770344
-
-        main_sum_c = 9948.0
-        main_sum_t = 9774.0
-        denominator_sum_c = 11054.0
-        denominator_sum_t = 10861.0
-        main_sum_squares_c = 13574.870870870867
-        main_sum_squares_t = 13190.114114114094
-        denominator_sum_squares_c = 10815.8998998999
-        denominator_sum_squares_t = 9893.572572572573
-        denominator_sum_product_c = 9394.202202202203
-        denominator_sum_product_t = 9206.792792792792
 
         gaussian_flat_prior = GaussianPrior(variance=float(1e6), pseudo_n=1)
         gaussian_inf_prior = GaussianPrior(variance=float(1), pseudo_n=1)
@@ -208,11 +194,6 @@ class TestGaussianEffectABTest(TestCase):
             quantile_hat=quantile_hat_c,
             quantile_lower=quantile_lower_c,
             quantile_upper=quantile_upper_c,
-            main_sum=main_sum_c,
-            denominator_sum=denominator_sum_c,
-            main_sum_squares=main_sum_squares_c,
-            denominator_sum_squares=denominator_sum_squares_c,
-            main_denominator_sum_product=denominator_sum_product_c,
         )
         q_stat_t = QuantileStatistic(
             n=n_t,
@@ -221,11 +202,6 @@ class TestGaussianEffectABTest(TestCase):
             quantile_hat=quantile_hat_t,
             quantile_lower=quantile_lower_t,
             quantile_upper=quantile_upper_t,
-            main_sum=main_sum_t,
-            denominator_sum=denominator_sum_t,
-            main_sum_squares=main_sum_squares_t,
-            denominator_sum_squares=denominator_sum_squares_t,
-            main_denominator_sum_product=denominator_sum_product_t,
         )
 
         b_flat = GaussianEffectABTest(


### PR DESCRIPTION
Renames `QuantileStatisticClustered` to `QuantileClusteredStatistic` Just to keep naming consistent with Statistic as the suffix.

Also moves `main_sum`, `denominator_sum` etc. metrics to the `QuantileClusteredStatistic` which are only used by the clustered quantile case (editing test to remove unnecessary data for that test).