### PR TITLE
Ensure secondary cta gets displayed in Modal

### DIFF
--- a/packages/front-end/components/Modal.tsx
+++ b/packages/front-end/components/Modal.tsx
@@ -173,7 +173,7 @@ const Modal: FC<ModalProps> = ({
           children
         )}
       </div>
-      {submit || (close && includeCloseCta) ? (
+      {submit || secondaryCTA || (close && includeCloseCta) ? (
         <div className="modal-footer">
           {error && (
             <div className="alert alert-danger mr-auto">


### PR DESCRIPTION
#2188 changed Modals so that you could not have a `secondaryCTA` and set `includeCloseCta` to false to remove the `cancel` button from the modal.

IMO that's the wrong behavior to have secondaryCTA depend on having `includeCloseCta` be true, and it adversely affected the health tab onboarding modal (see #2286).

I propose this simple change to make sure secondaryCTA can be built regardless of what `includeCloseCta` is set to and the logic now seems more consistent.

## Health Tab

This also fixes the health tab issue and keeps it inline with the original design, where there is no cancel button and there is just the X in the topright corner. I prefer we land this to #2286 .

Before
<img width="704" alt="Screenshot 2024-03-26 at 10 27 22 PM" src="https://github.com/growthbook/growthbook/assets/5298599/9ced09df-dc54-4747-bc92-6aee59dbef72">

After
<img width="719" alt="Screenshot 2024-03-26 at 10 26 10 PM" src="https://github.com/growthbook/growthbook/assets/5298599/7787d887-af25-44f9-a077-0254f8aa0bf0">
