### PR TITLE
Check license key first on license refresh.

### DIFF
--- a/packages/back-end/src/controllers/license.ts
+++ b/packages/back-end/src/controllers/license.ts
@@ -28,12 +28,13 @@ export async function getLicenseData(req: AuthRequest, res: Response) {
 
   let licenseData;
 
-  // TODO: Get rid of updateSubscriptionInDb one we have moved the license off the organizations
-  if (req.organization?.subscription) {
-    await updateSubscriptionInDb(req.organization.subscription.id);
-  } else {
+  if (req.organization?.licenseKey) {
     // Force refresh the license data
     licenseData = await initializeLicenseForOrg(req.organization, true);
+  } else if (req.organization?.subscription) {
+    // TODO: Get rid of updateSubscriptionInDb one we have moved the license off the organizations
+    // This is to update the subscription data in the organization from stripe if they have it
+    await updateSubscriptionInDb(req.organization.subscription.id);
   }
 
   return res.status(200).json({


### PR DESCRIPTION
### Features and Changes

For cloud users who had pro trial/pro but then cancelled, we allow them currently to still sign up for a new license.  Not ideal, but that will go away once we fully migrate and remove old license data.  
But in the mean time when trying to update the license we were checking first the old subscription, which being cancelled ended up returning an error that was caught and nothing changed.


### Testing

create an organization in GB while manually adding "subscription" object.
Update the license in retool/locally running license server.
Go to general settings and hit refresh on the license and see the new data.
