### PR TITLE
Add loading overlay when starting a pro trial

### DIFF
--- a/packages/front-end/components/Modal.tsx
+++ b/packages/front-end/components/Modal.tsx
@@ -24,6 +24,7 @@ type ModalProps = {
   disabledMessage?: string;
   docSection?: DocSection;
   error?: string;
+  loading?: boolean;
   size?: "md" | "lg" | "max" | "fill";
   sizeY?: "max" | "fill";
   inline?: boolean;
@@ -65,6 +66,7 @@ const Modal: FC<ModalProps> = ({
   autoFocusSelector = "input:not(:disabled),textarea:not(:disabled),select:not(:disabled)",
   solidOverlay = false,
   error: externalError,
+  loading: externalLoading,
   secondaryCTA,
   tertiaryCTA,
   successMessage,
@@ -83,6 +85,10 @@ const Modal: FC<ModalProps> = ({
   useEffect(() => {
     setError(externalError || null);
   }, [externalError]);
+
+  useEffect(() => {
+    setLoading(externalLoading || false);
+  }, [externalLoading]);
 
   const bodyRef = useRef<HTMLDivElement>(null);
   useEffect(() => {

--- a/packages/front-end/components/Settings/UpgradeModal/index.tsx
+++ b/packages/front-end/components/Settings/UpgradeModal/index.tsx
@@ -23,6 +23,7 @@ export default function UpgradeModal({ close, source }: Props) {
   const [error, setError] = useState("");
   const { apiCall } = useAuth();
 
+  const [loading, setLoading] = useState(false);
   const [showSHProTrial, setShowSHProTrial] = useState(false);
   const [showSHProTrialSuccess, setShowSHProTrialSuccess] = useState(false);
   const [showSHEnterpriseTrial, setShowSHEnterpriseTrial] = useState(false);
@@ -100,6 +101,7 @@ export default function UpgradeModal({ close, source }: Props) {
 
   const startPro = async () => {
     setError("");
+    setLoading(true);
     try {
       if (
         license?.stripeSubscription &&
@@ -128,6 +130,7 @@ export default function UpgradeModal({ close, source }: Props) {
           }),
         });
 
+        setLoading(false);
         if (resp.session?.url) {
           track(
             "Start Stripe Checkout For Pro Without Existing Subscription",
@@ -139,6 +142,7 @@ export default function UpgradeModal({ close, source }: Props) {
         }
       }
     } catch (e) {
+      setLoading(false);
       setError(e.message);
     }
   };
@@ -213,8 +217,8 @@ export default function UpgradeModal({ close, source }: Props) {
           },
         }),
       });
-
       track("Generate enterprise trial license", trackContext);
+
       await refreshOrganization();
       if (isCloud()) {
         setShowCloudEnterpriseTrialSuccess(true);
@@ -319,6 +323,7 @@ export default function UpgradeModal({ close, source }: Props) {
           close={close}
           size="lg"
           header={<>Get more out of GrowthBook</>}
+          loading={loading}
         >
           {!permissions.check("manageBilling") ? (
             <div className="text-center mt-4 mb-5">


### PR DESCRIPTION
### Features and Changes
Adding pro can take several seconds to connect to license server, call stripe, return stripe session, and redirect.  During that time it looks like nothing happened and might cause them to click again or something.  So we add a loading screen to make sure that they can't re-click until the call completes, and they know something is happening.

### Testing
Set `LICENSE_SERVER_URL=http://localhost:8080/api/v1/` in packages/back-end/
Start local central-license-service with `yarn dev` in that repo
Remove any license key on your org.
Sign up for pro.
See loading sign.
Finish pro sign up.
Delete the licenseKey from the organization.
Try signing up for pro again.
See loading sign.
See loading sign removed and an error shown saying that an existing license already exists.

