### PR TITLE
Bugfix: Error for updating Visual Changeset URL patterns 

### DIFF
--- a/packages/back-end/src/models/ExperimentModel.ts
+++ b/packages/back-end/src/models/ExperimentModel.ts
@@ -203,7 +203,7 @@ const experimentSchema = new mongoose.Schema({
 
 type ExperimentDocument = mongoose.Document & ExperimentInterface;
 
-const ExperimentModel = mongoose.model<ExperimentInterface>(
+export const ExperimentModel = mongoose.model<ExperimentInterface>(
   "Experiment",
   experimentSchema
 );

--- a/packages/back-end/src/models/VisualChangesetModel.ts
+++ b/packages/back-end/src/models/VisualChangesetModel.ts
@@ -323,7 +323,7 @@ export const updateVisualChangeset = async ({
         ...vc,
         id: vc.id || uniqid("vc_"),
       }))
-    : [];
+    : visualChangeset.visualChanges || [];
 
   const res = await VisualChangesetModel.updateOne(
     {
@@ -333,7 +333,7 @@ export const updateVisualChangeset = async ({
     {
       $set: {
         ...updates,
-        ...(isUpdatingVisualChanges ? { visualChanges } : {}),
+        visualChanges,
       },
     }
   );
@@ -353,7 +353,7 @@ export const updateVisualChangeset = async ({
     newVisualChangeset: {
       ...visualChangeset,
       ...updates,
-      ...(isUpdatingVisualChanges ? { visualChanges } : {}),
+      visualChanges,
     },
     context,
     bypassWebhooks,

--- a/packages/back-end/test/models/VisualChangesetModel.test.ts
+++ b/packages/back-end/test/models/VisualChangesetModel.test.ts
@@ -1,0 +1,137 @@
+import {
+  VisualChangesetModel,
+  updateVisualChangeset,
+} from "../../src/models/VisualChangesetModel";
+import { ExperimentModel } from "../../src/models/ExperimentModel";
+import { ReqContext } from "../../types/organization";
+import { VisualChangesetInterface } from "../../types/visual-changeset";
+
+describe("updateVisualChangeset", () => {
+  const context: ReqContext = {
+    // @ts-expect-error TODO
+    org: {
+      id: "org_123",
+      name: "org_name",
+    },
+    readAccessFilter: {
+      projects: [],
+      globalReadAccess: true,
+    },
+  };
+  const experiment = {
+    hasVisualChangesets: true,
+    variations: [],
+    toJSON: () => ({
+      hasVisualChangesets: true,
+      variations: [],
+    }),
+  };
+
+  describe("when a visual changeset has existing visual changes", () => {
+    const visualChangeset: VisualChangesetInterface = {
+      id: "vc_123",
+      editorUrl: "https://editor.url",
+      experiment: "exp_123",
+      organization: "org_123",
+      urlPatterns: [],
+      visualChanges: [
+        {
+          id: "vch_123",
+          css: "",
+          description: "",
+          variation: "var_123",
+          domMutations: [],
+        },
+      ],
+    };
+    describe("and incoming updates has visualChanges undefined", () => {
+      const updates = {
+        editorUrl: "https://editor2.url",
+        urlPatterns: [],
+        visualChanges: undefined,
+      };
+      const updateFn = jest
+        .spyOn(VisualChangesetModel, "updateOne")
+        .mockResolvedValue({
+          acknowledged: true,
+          matchedCount: 1,
+          modifiedCount: 1,
+          upsertedCount: 0,
+          upsertedId: null,
+        });
+      it("should keep the existing visual changes", async () => {
+        await updateVisualChangeset({
+          visualChangeset,
+          // @ts-expect-error TODO
+          experiment,
+          updates,
+          context,
+        });
+        expect(updateFn).toHaveBeenCalledWith(
+          {
+            id: visualChangeset.id,
+            organization: context.org.id,
+          },
+          {
+            $set: {
+              ...updates,
+              visualChanges: visualChangeset.visualChanges,
+            },
+          }
+        );
+      });
+    });
+    describe("and incoming updates has new visualChanges", () => {
+      const updates = {
+        editorUrl: "https://editor2.url",
+        urlPatterns: [],
+        visualChanges: [
+          {
+            id: "vch_123",
+            css: "",
+            description: "",
+            variation: "var_123",
+            domMutations: [],
+          },
+          {
+            id: "vch_456",
+            css: "",
+            description: "",
+            variation: "var_456",
+            domMutations: [],
+          },
+        ],
+      };
+      const updateFn = jest
+        .spyOn(VisualChangesetModel, "updateOne")
+        .mockResolvedValue({
+          acknowledged: true,
+          matchedCount: 1,
+          modifiedCount: 1,
+          upsertedCount: 0,
+          upsertedId: null,
+        });
+      jest.spyOn(ExperimentModel, "findOne").mockResolvedValue(null);
+      it("should overwrite the existing visual changes with new changes", async () => {
+        await updateVisualChangeset({
+          visualChangeset,
+          // @ts-expect-error TODO
+          experiment,
+          updates,
+          context,
+        });
+        expect(updateFn).toHaveBeenCalledWith(
+          {
+            id: visualChangeset.id,
+            organization: context.org.id,
+          },
+          {
+            $set: {
+              ...updates,
+            },
+          }
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
Fixes #2283 

Bug was introduced on Mar 21 in https://github.com/growthbook/growthbook/pull/2062/files#diff-927559bb0a1c6030d6f19383870f6f89ca3d5537f91116531fb65f2e651ed46fR2303

This PR ensures that visual changes on a changeset are only overriden when provided with a non-empty list of visual changes. For the case we want to remove visual changes, there should be at minimum a visual change per variation that have all values (css, js, dom mutations) set as empty, which is existing behavior.