### PR TITLE
Leverage type inference for base model.

### DIFF
--- a/packages/back-end/src/models/BaseModel.ts
+++ b/packages/back-end/src/models/BaseModel.ts
@@ -555,3 +555,15 @@ export abstract class BaseModel<T extends BaseSchema> {
     return omit(doc, ["__v", "_id"]) as unknown;
   }
 }
+
+export const MakeModelClass = <T extends BaseSchema>(
+  config: ModelConfig<T>
+) => {
+  abstract class Model extends BaseModel<T> {
+    getConfig() {
+      return config;
+    }
+  }
+
+  return Model;
+};

--- a/packages/back-end/src/models/FactMetricModel.ts
+++ b/packages/back-end/src/models/FactMetricModel.ts
@@ -8,30 +8,25 @@ import { ApiFactMetric } from "../../types/openapi";
 import { factMetricValidator } from "../routers/fact-table/fact-table.validators";
 import { DEFAULT_CONVERSION_WINDOW_HOURS } from "../util/secrets";
 import { UpdateProps } from "../../types/models";
-import { BaseModel, ModelConfig } from "./BaseModel";
+import { MakeModelClass } from "./BaseModel";
 import { getFactTableMap } from "./FactTableModel";
 
-type FactMetricSchema = typeof factMetricValidator;
+const BaseClass = MakeModelClass({
+  schema: factMetricValidator,
+  collectionName: "factmetrics",
+  idPrefix: "fact__",
+  auditLog: {
+    entity: "metric",
+    createEvent: "metric.create",
+    updateEvent: "metric.update",
+    deleteEvent: "metric.delete",
+  },
+  projectScoping: "multiple",
+  globallyUniqueIds: false,
+  readonlyFields: ["datasource"],
+});
 
-export class FactMetricModel extends BaseModel<FactMetricSchema> {
-  protected getConfig() {
-    const config: ModelConfig<FactMetricSchema> = {
-      schema: factMetricValidator,
-      collectionName: "factmetrics",
-      idPrefix: "fact__",
-      auditLog: {
-        entity: "metric",
-        createEvent: "metric.create",
-        updateEvent: "metric.update",
-        deleteEvent: "metric.delete",
-      },
-      projectScoping: "multiple",
-      globallyUniqueIds: false,
-      readonlyFields: ["datasource"],
-    };
-    return config;
-  }
-
+export class FactMetricModel extends BaseClass {
   protected canRead(doc: FactMetricInterface): boolean {
     return this.context.hasPermission("readData", doc.projects || []);
   }


### PR DESCRIPTION
Add a function API to the new model class to be able to levarage type-inference and not have to declare/repeat base types when creating new model class.