### PR TITLE
Fix air-gapped pro license add user bug

### DIFF
--- a/packages/back-end/src/services/organizations.ts
+++ b/packages/back-end/src/services/organizations.ts
@@ -2,7 +2,11 @@ import { randomBytes } from "crypto";
 import { freeEmailDomains } from "free-email-domains-typescript";
 import { cloneDeep } from "lodash";
 import { Request } from "express";
-import { getLicense, postSubscriptionUpdateToLicenseServer } from "enterprise";
+import {
+  getLicense,
+  isAirGappedLicenseKey,
+  postSubscriptionUpdateToLicenseServer,
+} from "enterprise";
 import {
   createOrganization,
   findAllOrganizations,
@@ -249,7 +253,10 @@ export function getInviteUrl(key: string) {
 async function updateSubscriptionIfProLicense(
   organization: OrganizationInterface
 ) {
-  if (organization.licenseKey) {
+  if (
+    organization.licenseKey &&
+    !isAirGappedLicenseKey(organization.licenseKey)
+  ) {
     const license = await getLicense(organization.licenseKey);
     if (license?.plan === "pro") {
       // Only pro plans have a Stripe subscription that needs to get updated

--- a/packages/enterprise/src/license.ts
+++ b/packages/enterprise/src/license.ts
@@ -679,7 +679,7 @@ export async function licenseInit(
         !keyToLicenseData[key] ||
         (keyToCacheDate[key] !== null && keyToCacheDate[key] <= oneDayAgo)
       ) {
-        if (key.startsWith("license_")) {
+        if (!isAirGappedLicenseKey(key)) {
           if (!userLicenseCodes || !metaData) {
             throw new Error(
               "Missing userLicenseCodes or metaData for license key"
@@ -791,7 +791,7 @@ function shouldLimitAccess(org: MinimalOrganization): boolean {
     return true;
   }
 
-  if (org.licenseKey?.startsWith("license") && !licenseData.emailVerified) {
+  if (!isAirGappedLicenseKey(org.licenseKey) && !licenseData.emailVerified) {
     return true;
   }
 
@@ -808,6 +808,11 @@ function shouldLimitAccess(org: MinimalOrganization): boolean {
   }
 
   return false;
+}
+
+export function isAirGappedLicenseKey(licenseKey: string | undefined): boolean {
+  if (!licenseKey) return false;
+  return !licenseKey.startsWith("license");
 }
 
 export function getEffectiveAccountPlan(org: MinimalOrganization): AccountPlan {


### PR DESCRIPTION
### Features and Changes
This fixes the rare case of SH pro users who have a hard coded license and they set that license in Mongo, rather than an env var.  If they then try and modify their users, it tried to contact the license server and might not have been able to reach it, or the license server wouldn't have found the key and so it errored.  

If they are SH pro with a hard coded license, then they are not connected directly with stripe, so we don't need to update stripe, so we now filter that out.

### Testing
Add a air gapped license into licenseKey field in mongo on an org.
Invite a user.
Remove a current user.
Add a user back in.
See no errors while doing so.

