### PR TITLE
Fix force refresh

### DIFF
--- a/packages/enterprise/src/license.ts
+++ b/packages/enterprise/src/license.ts
@@ -689,7 +689,11 @@ export async function licenseInit(
           let license: LicenseInterface;
           const mongoCache = await LicenseModel.findOne({ id: key });
           const oneWeekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000); // 7 days
-          if (mongoCache && new Date(mongoCache?.dateUpdated) > oneDayAgo) {
+          if (
+            !forceRefresh &&
+            mongoCache &&
+            new Date(mongoCache?.dateUpdated) > oneDayAgo
+          ) {
             license = mongoCache.toJSON();
           } else {
             try {

--- a/packages/enterprise/test/license.test.ts
+++ b/packages/enterprise/test/license.test.ts
@@ -337,6 +337,13 @@ describe("licenseInit and getLicense", () => {
           json: jest.fn().mockResolvedValueOnce(licenseData2),
         } as unknown) as Response; // Create a mock Response object
 
+        jest.spyOn(LicenseModel, "findOne").mockResolvedValue({
+          ...licenseData,
+          toJSON: () => licenseData,
+          save: jest.fn(),
+          set: jest.fn(),
+        });
+
         mockedFetch.mockResolvedValueOnce(Promise.resolve(mockedResponse2));
 
         await licenseInit(licenseKey, userLicenseCodes, metaData, true);


### PR DESCRIPTION
### Features and Changes

In https://github.com/growthbook/growthbook/pull/2304 we added a datastore layer to the cache before fetching from the server, rather than as a one week backup in case the license server goes down.  However we didn't disregard that cache if forceRefresh is true, and unfortunately the test we had didn't catch it because the datastore is mocked and it didn't set the expected mocked return value.

- Fixes test to include the mocked return value so that it is actually testing this use case
- Disregards the mongoCache if forceRefresh is true.

### Testing
`yarn test`

