### PR TITLE
Migrates createIdeas to permissionClass.

### DIFF
--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -345,7 +345,6 @@ const sidebars = {
               id: "statistics/quantile",
               label: "Quantile Testing",
             },
-
           ],
         },
       ],

--- a/packages/back-end/src/controllers/ideas.ts
+++ b/packages/back-end/src/controllers/ideas.ts
@@ -75,8 +75,10 @@ export async function postIdeas(
   const { org, userId } = context;
   const data = req.body;
 
-  if (context.permissions.canCreateIdeas(data.project))
-    data.organization = org.id;
+  if (!context.permissions.canCreateIdea(data)) {
+    context.permissions.throwPermissionError();
+  }
+  data.organization = org.id;
   data.source = "web";
   data.userId = userId;
   const idea = await createIdea(data);

--- a/packages/back-end/test/permissions.test.ts
+++ b/packages/back-end/test/permissions.test.ts
@@ -1812,6 +1812,439 @@ describe("hasReadAccess filter", () => {
   });
 });
 
+describe("PermissionsUtilClass.canViewIdeaModal check", () => {
+  const testOrg: OrganizationInterface = {
+    id: "org_sktwi1id9l7z9xkjb",
+    name: "Test Org",
+    ownerEmail: "test@test.com",
+    url: "https://test.com",
+    dateCreated: new Date(),
+    invites: [],
+    members: [
+      {
+        id: "base_user_123",
+        role: "readonly",
+        dateCreated: new Date(),
+        limitAccessByEnvironment: false,
+        environments: [],
+        projectRoles: [],
+        teams: [],
+      },
+    ],
+    settings: {
+      environments: [
+        { id: "development" },
+        { id: "staging" },
+        { id: "production" },
+      ],
+    },
+  };
+
+  it("User with global readonly role can not create idea without a project", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("readonly", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(permissions.canViewIdeaModal()).toEqual(false);
+  });
+
+  it("User with global collaborator role can create idea without a project", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("collaborator", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(permissions.canViewIdeaModal()).toEqual(true);
+  });
+
+  it("User with global readonly role can not create idea with a project if they don't have a project specific role that gives them permission", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("readonly", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(permissions.canViewIdeaModal("abc123")).toEqual(false);
+  });
+
+  it("User with global readonly role can create idea with a project if they do have a project specific role that gives them permission", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("readonly", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {
+          abc123: {
+            permissions: roleToPermissionMap("collaborator", testOrg),
+            limitAccessByEnvironment: false,
+            environments: [],
+          },
+        },
+      },
+      false
+    );
+
+    expect(permissions.canViewIdeaModal("abc123")).toEqual(true);
+  });
+});
+
+describe("PermissionsUtilClass.canCreateIdea check", () => {
+  const testOrg: OrganizationInterface = {
+    id: "org_sktwi1id9l7z9xkjb",
+    name: "Test Org",
+    ownerEmail: "test@test.com",
+    url: "https://test.com",
+    dateCreated: new Date(),
+    invites: [],
+    members: [
+      {
+        id: "base_user_123",
+        role: "readonly",
+        dateCreated: new Date(),
+        limitAccessByEnvironment: false,
+        environments: [],
+        projectRoles: [],
+        teams: [],
+      },
+    ],
+    settings: {
+      environments: [
+        { id: "development" },
+        { id: "staging" },
+        { id: "production" },
+      ],
+    },
+  };
+
+  it("User with global readonly role can not create idea without a project", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("readonly", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(permissions.canCreateIdea({ project: "" })).toEqual(false);
+  });
+
+  it("User with global collaborator role can create idea without a project", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("collaborator", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(permissions.canCreateIdea({ project: "" })).toEqual(true);
+  });
+
+  it("User with global readonly role can not create idea with a project if they don't have a project specific role that gives them permission", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("readonly", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(permissions.canCreateIdea({ project: "abc123" })).toEqual(false);
+  });
+
+  it("User with global readonly role can create idea with a project if they do have a project specific role that gives them permission", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("readonly", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {
+          abc123: {
+            permissions: roleToPermissionMap("collaborator", testOrg),
+            limitAccessByEnvironment: false,
+            environments: [],
+          },
+        },
+      },
+      false
+    );
+
+    expect(permissions.canCreateIdea({ project: "abc123" })).toEqual(true);
+  });
+});
+
+describe("PermissionsUtilClass.canUpdateIdea check", () => {
+  const testOrg: OrganizationInterface = {
+    id: "org_sktwi1id9l7z9xkjb",
+    name: "Test Org",
+    ownerEmail: "test@test.com",
+    url: "https://test.com",
+    dateCreated: new Date(),
+    invites: [],
+    members: [
+      {
+        id: "base_user_123",
+        role: "readonly",
+        dateCreated: new Date(),
+        limitAccessByEnvironment: false,
+        environments: [],
+        projectRoles: [],
+        teams: [],
+      },
+    ],
+    settings: {
+      environments: [
+        { id: "development" },
+        { id: "staging" },
+        { id: "production" },
+      ],
+    },
+  };
+
+  it("User with global readonly role can not update idea without a project", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("readonly", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(
+      permissions.canUpdateIdea({ project: "" }, { project: "abc123" })
+    ).toEqual(false);
+  });
+
+  it("User with global collaborator role can update idea without a project", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("collaborator", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(
+      permissions.canUpdateIdea({ project: "" }, { project: "abc123" })
+    ).toEqual(true);
+  });
+
+  it("User with global readonly role can not update idea with a project if they don't have a project specific role that gives them permission", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("readonly", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(
+      permissions.canUpdateIdea({ project: "abc123" }, { project: "" })
+    ).toEqual(false);
+  });
+
+  it("User with global readonly role can not remove project from idea if they do have a project specific role that gives them permission in the new project", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("readonly", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {
+          abc123: {
+            permissions: roleToPermissionMap("collaborator", testOrg),
+            limitAccessByEnvironment: false,
+            environments: [],
+          },
+        },
+      },
+      false
+    );
+
+    expect(
+      permissions.canUpdateIdea({ project: "abc123" }, { project: "" })
+    ).toEqual(false);
+  });
+
+  it("User with global readonly role can update idea's project from idea if they do have a project specific role that gives them permission in the new project", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("readonly", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {
+          abc123: {
+            permissions: roleToPermissionMap("collaborator", testOrg),
+            limitAccessByEnvironment: false,
+            environments: [],
+          },
+          def456: {
+            permissions: roleToPermissionMap("collaborator", testOrg),
+            limitAccessByEnvironment: false,
+            environments: [],
+          },
+        },
+      },
+      false
+    );
+
+    expect(
+      permissions.canUpdateIdea({ project: "abc123" }, { project: "def456" })
+    ).toEqual(true);
+  });
+});
+
+describe("PermissionsUtilClass.canDeleteIdea check", () => {
+  const testOrg: OrganizationInterface = {
+    id: "org_sktwi1id9l7z9xkjb",
+    name: "Test Org",
+    ownerEmail: "test@test.com",
+    url: "https://test.com",
+    dateCreated: new Date(),
+    invites: [],
+    members: [
+      {
+        id: "base_user_123",
+        role: "readonly",
+        dateCreated: new Date(),
+        limitAccessByEnvironment: false,
+        environments: [],
+        projectRoles: [],
+        teams: [],
+      },
+    ],
+    settings: {
+      environments: [
+        { id: "development" },
+        { id: "staging" },
+        { id: "production" },
+      ],
+    },
+  };
+
+  it("User with global readonly role can not delete idea without a project", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("readonly", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(permissions.canDeleteIdea({ project: "" })).toEqual(false);
+  });
+
+  it("User with global collaborator role can delete idea without a project", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("collaborator", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(permissions.canDeleteIdea({ project: "" })).toEqual(true);
+  });
+
+  it("User with global readonly role can not delete idea with a project if they don't have a project specific role that gives them permission", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("readonly", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(permissions.canDeleteIdea({ project: "abc123" })).toEqual(false);
+  });
+
+  it("User with global readonly role can delete idea with a project if they do have a project specific role that gives them permission", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("readonly", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {
+          abc123: {
+            permissions: roleToPermissionMap("collaborator", testOrg),
+            limitAccessByEnvironment: false,
+            environments: [],
+          },
+        },
+      },
+      false
+    );
+
+    expect(permissions.canDeleteIdea({ project: "abc123" })).toEqual(true);
+  });
+});
+
 describe("PermissionsUtilClass.canCreateMetric check", () => {
   const testOrg: OrganizationInterface = {
     id: "org_sktwi1id9l7z9xkjb",

--- a/packages/front-end/pages/idea/[iid].tsx
+++ b/packages/front-end/pages/idea/[iid].tsx
@@ -104,7 +104,7 @@ const IdeaPage = (): ReactElement => {
   const estimate = data.estimate;
 
   const canEdit = permissionsUtil.canUpdateIdea(idea, {});
-  const canCreateIdeasInCurrentProject = permissionsUtil.canCreateIdeas(
+  const canCreateIdeasInCurrentProject = permissionsUtil.canShowCreateIdeasButton(
     project
   );
 

--- a/packages/front-end/pages/idea/[iid].tsx
+++ b/packages/front-end/pages/idea/[iid].tsx
@@ -34,6 +34,7 @@ import SelectField from "@/components/Forms/SelectField";
 import { useUser } from "@/services/UserContext";
 import SortedTags from "@/components/Tags/SortedTags";
 import MarkdownInlineEdit from "@/components/Markdown/MarkdownInlineEdit";
+import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 
 const IdeaPage = (): ReactElement => {
   const router = useRouter();
@@ -53,6 +54,7 @@ const IdeaPage = (): ReactElement => {
   } = useDefinitions();
 
   const { permissions, getUserDisplay } = useUser();
+  const permissionsUtil = usePermissionsUtil();
 
   const { apiCall } = useAuth();
 
@@ -101,14 +103,17 @@ const IdeaPage = (): ReactElement => {
   const idea = data.idea;
   const estimate = data.estimate;
 
-  const canEdit = permissions.check("createIdeas", idea.project);
+  const canEdit = permissionsUtil.canUpdateIdea(idea, {});
+  const canCreateIdeasInCurrentProject = permissionsUtil.canCreateIdeas(
+    project
+  );
 
   return (
     <div className="container-fluid pagecontents pt-3">
       {project &&
         project !== idea.project &&
         canEdit &&
-        permissions.check("createIdeas", project) && (
+        canCreateIdeasInCurrentProject && (
           <div className="bg-info p-2 mb-3 text-center text-white">
             This idea is in a different project. Move it to{" "}
             <a

--- a/packages/front-end/pages/idea/[iid].tsx
+++ b/packages/front-end/pages/idea/[iid].tsx
@@ -104,7 +104,7 @@ const IdeaPage = (): ReactElement => {
   const estimate = data.estimate;
 
   const canEdit = permissionsUtil.canUpdateIdea(idea, {});
-  const canCreateIdeasInCurrentProject = permissionsUtil.canShowCreateIdeasButton(
+  const canCreateIdeasInCurrentProject = permissionsUtil.canViewIdeaModal(
     project
   );
 

--- a/packages/front-end/pages/ideas.tsx
+++ b/packages/front-end/pages/ideas.tsx
@@ -42,7 +42,7 @@ const IdeasPage = (): React.ReactElement => {
     return <LoadingOverlay />;
   }
 
-  const canCreateIdeas = permissionsUtil.canShowCreateIdeasButton(project);
+  const canCreateIdeas = permissionsUtil.canViewIdeaModal(project);
 
   if (!data.ideas.length) {
     return (

--- a/packages/front-end/pages/ideas.tsx
+++ b/packages/front-end/pages/ideas.tsx
@@ -12,6 +12,7 @@ import { useDefinitions } from "@/services/DefinitionsContext";
 import { useUser } from "@/services/UserContext";
 import SortedTags from "@/components/Tags/SortedTags";
 import Field from "@/components/Forms/Field";
+import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 
 const IdeasPage = (): React.ReactElement => {
   const [includeArchived, setIncludeArchived] = useState(false);
@@ -24,7 +25,8 @@ const IdeasPage = (): React.ReactElement => {
 
   const [current, setCurrent] = useState<Partial<IdeaInterface> | null>(null);
 
-  const { getUserDisplay, permissions } = useUser();
+  const { getUserDisplay } = useUser();
+  const permissionsUtil = usePermissionsUtil();
 
   const { items: displayedIdeas, searchInputProps } = useSearch({
     items: data?.ideas || [],
@@ -39,6 +41,8 @@ const IdeasPage = (): React.ReactElement => {
   if (!data) {
     return <LoadingOverlay />;
   }
+
+  const canCreateIdeas = permissionsUtil.canCreateIdeas(project);
   if (!data.ideas.length) {
     return (
       <div className="container p-4">
@@ -56,7 +60,7 @@ const IdeasPage = (): React.ReactElement => {
           When you&apos;re ready to test an idea, easily convert it to a full
           blown Experiment.
         </p>
-        {permissions.check("createIdeas", project) && (
+        {canCreateIdeas ? (
           <button
             className="btn btn-success btn-lg"
             onClick={() => {
@@ -65,7 +69,7 @@ const IdeasPage = (): React.ReactElement => {
           >
             <FaPlus /> Add your first Idea
           </button>
-        )}
+        ) : null}
         {current && (
           <IdeaForm
             mutate={mutate}
@@ -114,7 +118,7 @@ const IdeasPage = (): React.ReactElement => {
             </div>
           )}
           <div style={{ flex: 1 }} />
-          {permissions.check("createIdeas", project) && (
+          {canCreateIdeas ? (
             <div className="col-auto">
               <button
                 className="btn btn-primary float-left"
@@ -125,7 +129,7 @@ const IdeasPage = (): React.ReactElement => {
                 New Idea
               </button>
             </div>
-          )}
+          ) : null}
         </div>
         <div className="row">
           {displayedIdeas

--- a/packages/front-end/pages/ideas.tsx
+++ b/packages/front-end/pages/ideas.tsx
@@ -42,7 +42,8 @@ const IdeasPage = (): React.ReactElement => {
     return <LoadingOverlay />;
   }
 
-  const canCreateIdeas = permissionsUtil.canCreateIdeas(project);
+  const canCreateIdeas = permissionsUtil.canShowCreateIdeasButton(project);
+
   if (!data.ideas.length) {
     return (
       <div className="container p-4">

--- a/packages/shared/src/permissions/permissionsClass.ts
+++ b/packages/shared/src/permissions/permissionsClass.ts
@@ -18,7 +18,8 @@ export class Permissions {
     this.superAdmin = superAdmin;
   }
 
-  public canShowCreateIdeasButton = (project?: string): boolean => {
+  // This is a helper method to use on the frontend to determine whether or not to show certain UI elements
+  public canViewIdeaModal = (project?: string): boolean => {
     return this.checkProjectFilterPermission(
       {
         projects: project ? [project] : [],

--- a/packages/shared/src/permissions/permissionsClass.ts
+++ b/packages/shared/src/permissions/permissionsClass.ts
@@ -18,10 +18,19 @@ export class Permissions {
     this.superAdmin = superAdmin;
   }
 
-  public canCreateIdeas = (project?: string): boolean => {
+  public canShowCreateIdeasButton = (project?: string): boolean => {
     return this.checkProjectFilterPermission(
       {
         projects: project ? [project] : [],
+      },
+      "createIdeas"
+    );
+  };
+
+  public canCreateIdea = (idea: Pick<IdeaInterface, "project">): boolean => {
+    return this.checkProjectFilterPermission(
+      {
+        projects: idea.project ? [idea.project] : [],
       },
       "createIdeas"
     );

--- a/packages/shared/src/permissions/permissionsClass.ts
+++ b/packages/shared/src/permissions/permissionsClass.ts
@@ -1,6 +1,7 @@
 import { FeatureInterface } from "back-end/types/feature";
 import { MetricInterface } from "back-end/types/metric";
 import { Permission, UserPermissions } from "back-end/types/organization";
+import { IdeaInterface } from "back-end/types/idea";
 import { READ_ONLY_PERMISSIONS } from "./permissions.utils";
 class PermissionError extends Error {
   constructor(message: string) {
@@ -16,6 +17,33 @@ export class Permissions {
     this.userPermissions = permissions;
     this.superAdmin = superAdmin;
   }
+
+  public canCreateIdeas = (project?: string): boolean => {
+    return this.checkProjectFilterPermission(
+      {
+        projects: project ? [project] : [],
+      },
+      "createIdeas"
+    );
+  };
+
+  public canUpdateIdea = (
+    existing: Pick<IdeaInterface, "project">,
+    updated: Pick<IdeaInterface, "project">
+  ): boolean => {
+    return this.checkProjectFilterUpdatePermission(
+      { projects: existing.project ? [existing.project] : [] },
+      updated.project ? { projects: [updated.project] } : {},
+      "createIdeas"
+    );
+  };
+
+  public canDeleteIdea = (idea: Pick<IdeaInterface, "project">): boolean => {
+    return this.checkProjectFilterPermission(
+      { projects: idea.project ? [idea.project] : [] },
+      "createIdeas"
+    );
+  };
 
   public canCreateMetric = (
     metric: Pick<MetricInterface, "projects">

--- a/packages/shared/src/permissions/permissionsClass.ts
+++ b/packages/shared/src/permissions/permissionsClass.ts
@@ -43,7 +43,7 @@ export class Permissions {
   ): boolean => {
     return this.checkProjectFilterUpdatePermission(
       { projects: existing.project ? [existing.project] : [] },
-      updated.project ? { projects: [updated.project] } : {},
+      "project" in updated ? { projects: [updated.project || ""] } : {},
       "createIdeas"
     );
   };


### PR DESCRIPTION
### Features and Changes

This PR migrates the `createIdeas` permission to the permissionClass and introduces 4 new helper methods - `canViewIdeaModal`, `canCreateIdea`, `canUpdateIdea`, and `canDeleteIdea`. 

Currently, all of these modals are leveraging the `createIdeas` permission, but as we introduce finer-grain permissions, we can do so in 1 place, rather than all throughout the app.

Additionally, this PR introduces a new pattern `canViewIdeaModal` that takes in an optional project string. This is to be used exclusively on the frontend as a UI check. If we like this pattern, I'll go in an update all of the previous permissions that've been migrated.

### Testing

- See test suite