### PR TITLE
Fix multiorg license report

### DIFF
--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -623,7 +623,7 @@ export async function getOrganization(req: AuthRequest, res: Response) {
   let license;
   if (licenseKey || process.env.LICENSE_KEY) {
     // automatically set the license data based on org license key
-    license = getLicense(org.licenseKey || process.env.LICENSE_KEY);
+    license = getLicense(licenseKey || process.env.LICENSE_KEY);
     if (!license || (license.organizationId && license.organizationId !== id)) {
       try {
         license = await initializeLicenseForOrg(org);

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -621,9 +621,9 @@ export async function getOrganization(req: AuthRequest, res: Response) {
   } = org;
 
   let license;
-  if (licenseKey) {
+  if (licenseKey || process.env.LICENSE_KEY) {
     // automatically set the license data based on org license key
-    license = getLicense(org.licenseKey);
+    license = getLicense(org.licenseKey || process.env.LICENSE_KEY);
     if (!license || (license.organizationId && license.organizationId !== id)) {
       try {
         license = await initializeLicenseForOrg(org);

--- a/packages/front-end/components/License/DownloadLicenseUsageButton.tsx
+++ b/packages/front-end/components/License/DownloadLicenseUsageButton.tsx
@@ -36,9 +36,8 @@ const DownloadLicenseUsageButton: FC = () => {
               userEmailCodes: res.userEmailCodes,
               inviteEmailCodes: res.inviteEmailCodes,
               activeSeatsUsed: res.userEmailCodes.length,
-              seatsUsed: Array.from(
-                new Set(res.userEmailCodes.concat(res.inviteEmailCodes))
-              ).length,
+              seatsUsed: 
+                new Set(res.userEmailCodes.concat(res.inviteEmailCodes).size,
               signature: res.signature,
               timestamp: res.timestamp,
             },

--- a/packages/front-end/components/License/DownloadLicenseUsageButton.tsx
+++ b/packages/front-end/components/License/DownloadLicenseUsageButton.tsx
@@ -15,7 +15,8 @@ const DownloadLicenseUsageButton: FC = () => {
       const res = await apiCall<{
         status: number;
         licenseMetaData: LicenseMetaData;
-        userLicenseCodes: string[];
+        userEmailCodes: string[];
+        inviteEmailCodes: string[];
         signature: string;
         timestamp: string;
       }>(`/license/report`, {
@@ -32,8 +33,12 @@ const DownloadLicenseUsageButton: FC = () => {
             {
               license: license,
               licenseMetaData: res.licenseMetaData,
-              userLicenseCodes: res.userLicenseCodes,
-              seatsUsed: res.userLicenseCodes.length,
+              userEmailCodes: res.userEmailCodes,
+              inviteEmailCodes: res.inviteEmailCodes,
+              activeSeatsUsed: res.userEmailCodes.length,
+              seatsUsed: Array.from(
+                new Set(res.userEmailCodes.concat(res.inviteEmailCodes))
+              ).length,
               signature: res.signature,
               timestamp: res.timestamp,
             },

--- a/packages/front-end/components/License/DownloadLicenseUsageButton.tsx
+++ b/packages/front-end/components/License/DownloadLicenseUsageButton.tsx
@@ -36,8 +36,9 @@ const DownloadLicenseUsageButton: FC = () => {
               userEmailCodes: res.userEmailCodes,
               inviteEmailCodes: res.inviteEmailCodes,
               activeSeatsUsed: res.userEmailCodes.length,
-              seatsUsed: 
-                new Set(res.userEmailCodes.concat(res.inviteEmailCodes).size,
+              seatsUsed: new Set(
+                res.userEmailCodes.concat(res.inviteEmailCodes)
+              ).size,
               signature: res.signature,
               timestamp: res.timestamp,
             },

--- a/packages/front-end/components/License/ShowLicenseInfo.tsx
+++ b/packages/front-end/components/License/ShowLicenseInfo.tsx
@@ -7,6 +7,7 @@ import EditLicenseModal from "@/components/Settings/EditLicenseModal";
 import { GBPremiumBadge } from "@/components/Icons";
 import UpgradeModal from "@/components/Settings/UpgradeModal";
 import AccountPlanNotices from "@/components/Layout/AccountPlanNotices";
+import { isCloud } from "@/services/env";
 import RefreshLicenseButton from "./RefreshLicenseButton";
 import DownloadLicenseUsageButton from "./DownloadLicenseUsageButton";
 
@@ -35,7 +36,7 @@ const ShowLicenseInfo: FC<{
 
   // TODO: Remove this once we have migrated all organizations to use the license key
   const usesLicenseInfoOnModel =
-    !showUpgradeButton && !organization?.licenseKey;
+    isCloud() && !showUpgradeButton && !organization?.licenseKey;
 
   return (
     <div>


### PR DESCRIPTION
### Features and Changes
- We weren't sending down the license data correctly on the org for companies using the LICENSE_KEY env var, but now are.
- We weren't correctly showing the license info for companies using the LICENSE_KEY env var, but now are.
- Updated the license report to separate out invite users and all users, just in case someone is using SCIM and we think the total invites shouldn't be what we count for seats for them - before this we weren't including the invites at all on the report (we were only counting it for non-airgapped licenses)

### Testing

set `IS_MULTI_ORG=true` in both front-end/.env.local and back-end/.env.local
set up growthbook with at least two orgs.
add some duplicate users in both orgs, and some unique.
add some duplicate invites in both orgs, and some unique.
Make sure the current user logged in has `superAdmin: true`
Go to /admin
Click "Download License Report" button.
Open the json and see something like this - making sure the seatsUsed and activeSeatsUsed matches the number of users and invites.
```
{
  "license": {
    "id": "11335",
    "companyName": "Universal Paperclips",
    "seats": 100,
    "hardCap": true,
    "dateCreated": "2024-03-29",
    "dateExpires": "2044-06-29",
    "isTrial": false,
    "plan": "enterprise"
  },
  "licenseMetaData": {
    "installationId": "installation-04ed35f0-806c-4ecb-b148-051bc42dd3e1",
    "gitSha": "736b3d4bda1bb7eecd701a754305fabd634a43b6\n",
    "gitCommitDate": "2023-11-14T19:51:59Z\n",
    "sdkLanguages": [
      "nodejs"
    ],
    "dataSourceTypes": [
      "bigquery",
      "postgres"
    ],
    "eventTrackers": [
      "rudderstack",
      "custom"
    ],
    "isCloud": false
  },
  "userEmailCodes": [
    "3b742502",
    "76ad3c40",
    "aa72f161",
    "246a3474",
    "5ba68980",
    "9460c8e6"
  ],
  "inviteEmailCodes": [
    "9a3b4b5d",
    "a556b45d",
    "af9cad30",
    "279748e4",
    "21b19980",
    "76ad3c40",
    "246a3474"
  ],
  "activeSeatsUsed": 6,
  "seatsUsed": 11,
  "signature": "6b08a6e0e749856ae1caaf77c4bbafdcc250979875703e2323ad9fd7f467e56f",
  "timestamp": "2024-03-29T21:07:26.790Z"
}
```

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
