### PR TITLE
updating risk inside of Bayesian quantile

### DIFF
--- a/packages/stats/gbstats/bayesian/tests.py
+++ b/packages/stats/gbstats/bayesian/tests.py
@@ -433,29 +433,21 @@ class GaussianEffectABTest(BayesianABTest):
 
     @property
     def risk(self) -> List[float]:
-        truncated_means = [
-            self.truncated_normal_mean(
-                mu=self.mean_diff, sigma=self.std_diff, a=0, b=np.inf
-            ),
-            self.truncated_normal_mean(
-                mu=self.mean_diff, sigma=self.std_diff, a=-np.inf, b=0.0
-            ),
-        ]
-        return [
-            -1
-            * truncated_mean
-            * np.max(
-                [
-                    float(1e-5),
-                    norm.cdf(0, loc=self.mean_diff, scale=self.std_diff),
-                ]  # type: ignore
-            )
-            for truncated_mean in truncated_means
-        ]
+        prob_ctrl_is_better = norm.cdf(0.0, loc=self.mean_diff, scale=self.std_diff)
+        mn_neg = self.truncated_normal_mean(
+            mu=self.mean_diff, sigma=self.std_diff, a=-np.inf, b=0.0
+        )
+        mn_pos = self.truncated_normal_mean(
+            mu=self.mean_diff, sigma=self.std_diff, a=0, b=np.inf
+        )
+        risk_ctrl = float((1.0 - prob_ctrl_is_better) * mn_pos)
+        risk_trt = -float(prob_ctrl_is_better * mn_neg)
+        return [risk_trt, risk_ctrl]
 
     @staticmethod
     def truncated_normal_mean(mu, sigma, a, b):
         # parameterized in scipy.stats as number of sds from mu
+        # rescaling for readability
         a, b = (a - mu) / sigma, (b - mu) / sigma
         mn, _, _, _ = truncnorm.stats(a, b, loc=mu, scale=sigma, moments="mvsk")
         return mn


### PR DESCRIPTION
I noticed two issues with how risk is currently calculated inside of quantile:
there can be numerical errors with the truncated_mean method when the posterior mean has essentially no mass above zero (or below zero).  I updated the method to use scipy.stats, which resolved these issues.  
the risk calculation for the control variation currently multiplies the truncated_mean by -1, which results in negative risk.  
This PR fixes these issues, and has a unit test for bayesian risk for quantiles.  