### PR TITLE
SH Pro has unlimited users

### DIFF
--- a/packages/front-end/components/Settings/UpgradeModal/index.tsx
+++ b/packages/front-end/components/Settings/UpgradeModal/index.tsx
@@ -431,7 +431,11 @@ export default function UpgradeModal({ close, source }: Props) {
                     <div className="border-top p-0 flex-grow-1">
                       <ul className="pt-4">
                         <li>
-                          <b>Up to 100 team members</b>
+                          <b>
+                            {isCloud()
+                              ? "Up to 100 team members"
+                              : "Unlimited users"}
+                          </b>
                         </li>
                         <li>
                           <b>Advanced permissioning</b>


### PR DESCRIPTION
### Features and Changes
Since self-hosted free is unlimited users, it makes sense that self-hosted pro is also unlimited users?

### Testing
Start dev server with `isCloud: false` in front-end/.env.local
Remove any licenseKey in Mongo on the organization.
Click upgrade modal and see the new message.
