### PR TITLE
Fix free seat limit on self hosted

### DIFF
--- a/packages/front-end/components/Settings/Team/InviteModal.tsx
+++ b/packages/front-end/components/Settings/Team/InviteModal.tsx
@@ -9,6 +9,7 @@ import useOrgSettings from "@/hooks/useOrgSettings";
 import StringArrayField from "@/components/Forms/StringArrayField";
 import UpgradeModal from "@/components/Settings/UpgradeModal";
 import { useUser } from "@/services/UserContext";
+import { isCloud } from "@/services/env";
 import RoleSelector from "./RoleSelector";
 import InviteModalSubscriptionInfo from "./InviteModalSubscriptionInfo";
 
@@ -50,7 +51,7 @@ const InviteModal: FC<{ mutate: () => void; close: () => void }> = ({
     activeAndInvitedUsers,
   } = useStripeSubscription();
   const [showUpgradeModal, setShowUpgradeModal] = useState(
-    canSubscribe && activeAndInvitedUsers >= freeSeats
+    isCloud() && canSubscribe && activeAndInvitedUsers >= freeSeats
       ? "Whoops! You reached your free seat limit."
       : ""
   );
@@ -90,6 +91,7 @@ const InviteModal: FC<{ mutate: () => void; close: () => void }> = ({
     const { email: emails } = value;
 
     if (
+      isCloud() &&
       canSubscribe &&
       activeAndInvitedUsers + value.email.length > freeSeats
     ) {


### PR DESCRIPTION
### Features and Changes

In https://github.com/growthbook/growthbook/pull/2271/files#diff-8fd09e306257bfb50c244e009b467e2e633a4682a1b8eda9a7aac448541dc618L85
we started allowing people to self serve pro on self hosted.  So now we need to check whether they are self hosted or not when limiting people the number of new users they can have.

### Testing
Remove any `licenseKeys`, `subscription`, and `freeSeats` from organization in mongo db.
Add over three users on self-hosted see it not show the upgrade modal.  

