### PR TITLE
Use connection key for global webhook key

### DIFF
--- a/packages/back-end/src/jobs/sdkWebhooks.ts
+++ b/packages/back-end/src/jobs/sdkWebhooks.ts
@@ -164,7 +164,7 @@ export async function fireWebhook({
   } catch (error) {
     createSdkWebhookLog({
       webhookId,
-      webhookReduestId: webhookID,
+      webhookRequestId: webhookID,
       organizationId,
       payload: JSON.parse(payload),
       result: {
@@ -196,7 +196,7 @@ export async function fireWebhook({
   ).catch((e) => {
     createSdkWebhookLog({
       webhookId,
-      webhookReduestId: webhookID,
+      webhookRequestId: webhookID,
       organizationId,
       payload: JSON.parse(payload),
       result: {
@@ -210,7 +210,7 @@ export async function fireWebhook({
 
   createSdkWebhookLog({
     webhookId,
-    webhookReduestId: webhookID,
+    webhookRequestId: webhookID,
     organizationId,
     payload: JSON.parse(payload),
     result: {
@@ -302,7 +302,6 @@ export async function queueGlobalWebhooks(
     const {
       url,
       signingKey,
-      key,
       method,
       headers,
       sendPayload,
@@ -355,7 +354,7 @@ export async function queueGlobalWebhooks(
           organizationId: context.org.id,
           url,
           signingKey,
-          key,
+          key: connection.key,
           payload,
           method,
           sendPayload,

--- a/packages/back-end/src/models/SdkWebhookLogModel.ts
+++ b/packages/back-end/src/models/SdkWebhookLogModel.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "crypto";
 import omit from "lodash/omit";
 import mongoose from "mongoose";
+import { migrateSdkWebhookLogModel } from "@back-end/src/util/migrations";
 import { SdkWebHookLogInterface } from "../../types/sdk-webhook-log";
 
 const sdkWebHookLogSchema = new mongoose.Schema({
@@ -46,10 +47,12 @@ const sdkWebHookLogSchema = new mongoose.Schema({
 
 sdkWebHookLogSchema.index({ eventWebHookId: 1 });
 
-type SdkWebHookLogDocument = mongoose.Document & SdkWebHookLogInterface;
+export type SdkWebHookLogDocument = mongoose.Document & SdkWebHookLogInterface;
 
-const toInterface = (doc: SdkWebHookLogDocument): SdkWebHookLogDocument =>
-  omit(doc.toJSON(), ["__v", "_id"]) as SdkWebHookLogDocument;
+const toInterface = (doc: SdkWebHookLogDocument): SdkWebHookLogDocument => {
+  const asJson = omit(doc.toJSON(), ["__v", "_id"]) as SdkWebHookLogDocument;
+  return migrateSdkWebhookLogModel(asJson);
+};
 
 const SdkWebHookLogModel = mongoose.model<SdkWebHookLogInterface>(
   "SdkWebHookLog",

--- a/packages/back-end/src/models/SdkWebhookLogModel.ts
+++ b/packages/back-end/src/models/SdkWebhookLogModel.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "crypto";
 import omit from "lodash/omit";
 import mongoose from "mongoose";
-import { migrateSdkWebhookLogModel } from "@back-end/src/util/migrations";
+import { migrateSdkWebhookLogModel } from "../util/migrations";
 import { SdkWebHookLogInterface } from "../../types/sdk-webhook-log";
 
 const sdkWebHookLogSchema = new mongoose.Schema({

--- a/packages/back-end/src/models/SdkWebhookLogModel.ts
+++ b/packages/back-end/src/models/SdkWebhookLogModel.ts
@@ -17,7 +17,7 @@ const sdkWebHookLogSchema = new mongoose.Schema({
     type: String,
     required: true,
   },
-  webhookReduestId: {
+  webhookRequestId: {
     type: String,
     required: true,
   },
@@ -59,7 +59,7 @@ const SdkWebHookLogModel = mongoose.model<SdkWebHookLogInterface>(
 type CreateSdkWebHookLogOptions = {
   organizationId: string;
   webhookId: string;
-  webhookReduestId: string;
+  webhookRequestId: string;
   payload: Record<string, unknown>;
   result:
     | {
@@ -81,7 +81,7 @@ type CreateSdkWebHookLogOptions = {
  */
 export const createSdkWebhookLog = async ({
   webhookId,
-  webhookReduestId,
+  webhookRequestId,
   organizationId,
   payload,
   result: resultState,
@@ -92,7 +92,7 @@ export const createSdkWebhookLog = async ({
     id: `swhl-${randomUUID()}`,
     dateCreated: now,
     webhookId,
-    webhookReduestId,
+    webhookRequestId,
     organizationId,
     result: resultState.state,
     responseCode: resultState.responseCode,
@@ -106,7 +106,7 @@ export const createSdkWebhookLog = async ({
 /**
  * Get the latest web hook runs for a web hook
  * @param organizationId
- * @param eventWebHookId
+ * @param sdkWebHookId
  * @param limit
  * @returns
  */

--- a/packages/back-end/src/models/SdkWebhookLogModel.ts
+++ b/packages/back-end/src/models/SdkWebhookLogModel.ts
@@ -18,6 +18,11 @@ const sdkWebHookLogSchema = new mongoose.Schema({
     type: String,
     required: true,
   },
+  /** @deprecated */
+  webhookReduestId: {
+    type: String,
+    required: false,
+  },
   webhookRequestId: {
     type: String,
     required: true,

--- a/packages/back-end/src/util/migrations.ts
+++ b/packages/back-end/src/util/migrations.ts
@@ -741,7 +741,7 @@ export function migrateSavedGroup(
 export function migrateSdkWebhookLogModel(
   doc: SdkWebHookLogDocument
 ): SdkWebHookLogDocument {
-  if (doc?.webhookRequestId) {
+  if (doc?.webhookReduestId) {
     doc.webhookRequestId = doc.webhookReduestId;
     delete doc.webhookReduestId;
   }

--- a/packages/back-end/src/util/migrations.ts
+++ b/packages/back-end/src/util/migrations.ts
@@ -4,7 +4,7 @@ import {
   DEFAULT_SEQUENTIAL_TESTING_TUNING_PARAMETER,
   DEFAULT_STATS_ENGINE,
 } from "shared/constants";
-import { SdkWebHookLogDocument } from "@back-end/src/models/SdkWebhookLogModel";
+import { SdkWebHookLogDocument } from "../models/SdkWebhookLogModel";
 import { LegacyMetricInterface, MetricInterface } from "../../types/metric";
 import {
   DataSourceInterface,

--- a/packages/back-end/src/util/migrations.ts
+++ b/packages/back-end/src/util/migrations.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_SEQUENTIAL_TESTING_TUNING_PARAMETER,
   DEFAULT_STATS_ENGINE,
 } from "shared/constants";
+import { SdkWebHookLogDocument } from "@back-end/src/models/SdkWebhookLogModel";
 import { LegacyMetricInterface, MetricInterface } from "../../types/metric";
 import {
   DataSourceInterface,
@@ -735,4 +736,14 @@ export function migrateSavedGroup(
   }
 
   return group;
+}
+
+export function migrateSdkWebhookLogModel(
+  doc: SdkWebHookLogDocument
+): SdkWebHookLogDocument {
+  if (doc?.webhookRequestId) {
+    doc.webhookRequestId = doc.webhookReduestId;
+    delete doc.webhookReduestId;
+  }
+  return doc;
 }

--- a/packages/back-end/types/sdk-webhook-log.d.ts
+++ b/packages/back-end/types/sdk-webhook-log.d.ts
@@ -1,7 +1,7 @@
 export interface SdkWebHookLogInterface {
   id: string;
   webhookId: string;
-  webhookReduestId: string;
+  webhookRequestId: string;
   organizationId: string;
   dateCreated: Date;
   responseCode: number | null;

--- a/packages/back-end/types/sdk-webhook-log.d.ts
+++ b/packages/back-end/types/sdk-webhook-log.d.ts
@@ -1,7 +1,9 @@
 export interface SdkWebHookLogInterface {
   id: string;
   webhookId: string;
-  webhookRequestId: string;
+  /** @deprecated */
+  webhookReduestId?: string;
+  webhookRequestId?: string;
   organizationId: string;
   dateCreated: Date;
   responseCode: number | null;


### PR DESCRIPTION
### Features and Changes

Global webhooks were using a hardcoded key from the environment variable when they should be using a dynamic key from the SDK connection (to match how SDK webhooks work).

Also fixed a spelling error in one of the related types + migration

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

<!--
  Please describe how to test these changes.
 -->

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
