### PR TITLE
Centralize license error handling to always downgrade and show error message.

### DIFF
--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -6,6 +6,7 @@ import {
   getAccountPlan,
   getEffectiveAccountPlan,
   getLicense,
+  getLicenseError,
   orgHasPremiumFeature,
 } from "enterprise";
 import { hasReadAccess } from "shared/permissions";
@@ -667,6 +668,7 @@ export async function getOrganization(req: AuthRequest, res: Response) {
     enterpriseSSO,
     accountPlan: getAccountPlan(org),
     effectiveAccountPlan: getEffectiveAccountPlan(org),
+    licenseError: getLicenseError(org),
     commercialFeatures: [...accountFeatures[getEffectiveAccountPlan(org)]],
     roles: getRoles(org),
     members: expandedMembers,

--- a/packages/back-end/src/util/secrets.ts
+++ b/packages/back-end/src/util/secrets.ts
@@ -16,12 +16,6 @@ export const LOG_LEVEL = process.env.LOG_LEVEL;
 export const IS_CLOUD = stringToBoolean(process.env.IS_CLOUD);
 export const IS_MULTI_ORG = stringToBoolean(process.env.IS_MULTI_ORG);
 
-if (!IS_CLOUD && IS_MULTI_ORG && !process.env.LICENSE_KEY) {
-  throw new Error(
-    "Must have a commercial license key to be allowed to have multiple organizations."
-  );
-}
-
 // Default to true
 export const ALLOW_SELF_ORG_CREATION = stringToBoolean(
   process.env.ALLOW_SELF_ORG_CREATION,

--- a/packages/enterprise/src/license.ts
+++ b/packages/enterprise/src/license.ts
@@ -769,7 +769,7 @@ export function getLicenseError(org: MinimalOrganization): string {
   }
 
   if (licenseData.usingMongoCache && licenseData.dateUpdated) {
-    const oneWeekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000); // 7 days
+    const oneWeekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
     if (new Date(licenseData.dateUpdated) < oneWeekAgo) {
       return "License server down for too long";
     }

--- a/packages/enterprise/test/license.test.ts
+++ b/packages/enterprise/test/license.test.ts
@@ -36,6 +36,7 @@ describe("licenseInit, getLicense, and getLicenseError", () => {
     isTrial: true,
     plan: "starter",
     emailVerified: true,
+    remoteDowngrade: false,
     archived: false,
     dateCreated: "2023-11-10T17:15:11.274Z",
     dateExpires: "2024-10-23T00:00:00.000Z",
@@ -48,14 +49,42 @@ describe("licenseInit, getLicense, and getLicenseError", () => {
       },
     },
     signedChecksum:
-      "JbSjKDDBxAu-8BtOrBCsPMl9vGUpdIYwOi6AIHdLE9y7NJfdsjK_oMeL8FrSY9BiBOIrzLR3qV6_AG-62L-nd5HOHo_YTbrCKCrOKxVO1_HpqzbBcfBaMIIF___7GYilnH5vncnJxIhxu3n2ZJTnmbjVfCGkz6-NEiU-oI5ifGI1akK7l3kTTz-X7M0N3c-8vkt2AwbxmBq0MoVU0Ekrf25_ybexRZVY0LhjHX_DYjQwCbZafdtC5E-1XsfvTX-zyUo2pZP7lEyGcV8BQso1psLB5AAt_2m8aMNJTK5Gi6JhA8wepyiel-G8dCTCjHs7NrVHqbn9uNVnAtUwpcFJcscJx0ZWcJXMFwrkKBp-jq6i94-1ridYJO1DFnGy23iTKAaKmcP5QLhbPaCBm4_EYMp2k4BQPHbRQyERzDF-I2rRphJGa3h3ZAUJjdjcnDzqinnDJcnqU1waWauIclvE51l3g0LFL6YTg4CSZm0VavKfrvcK2-ofCD66kuFhXVoxg3rUvufC1SWd9RoMCd8BEng3XEPzJIOD4f_s8Nl8XAldlQVDj4gUKm_Jb5tUYi2CQwti6PVg39XGFLw7CxrndeLZ46jd35k10HMXzkEvL_wCswh9e2NEzKDc-sHfjmNMqm5R2xNd2pfwIMyjFUQZCHcXn58QysX5dARJbHRJjH0",
+      "ceT1mfCsWyyRE3B1CaaK6bXF5zUIXPIM1bASRRftDLLnFwGAjp8bAxGERzqVPeTLjy9eOAvC3nkpQhcb29jNJSy0f7d-6InMYsRPXln3fQ-EpZpxQOhoaPv2-cElier0wXmUM8jFI7FGAMZ-uugxhM4ofvoeIwrLghTHeelILNcUBiGk4AYCQrwZquTK9BXPyPCaBFrGhqM0RRZzHTpimEMS9TcmR90rrHEtXTagPVp_gEP508J1IYaVsymEt9N6Dp5Wk7ohb8XtODURsxiDJmrcqEQODvyabrNetSo3qVXsJ-qd4x6Imr79RfjLeR82lByZNqfH9r1V3omARlinDmq1VHoA3cRzA98iwcQBND1MWFZa5wikMkgQxxGqixQE6PCqAtfooBLdb_kqe_wHz3pU4qjVSw10_VjEiqlxXBLuYn20FgKMcpI5qwTUQiS0gJomkY2Nq5GQjXm-040VEgn6TqhRDQAlv4yWMBO6NaSVYQmwMjRhXLQ9mOYX6vugQMbpIO7NjvGWGoD8d_KoHZL0sriKJlVsYn3iFiIEkZIzD3mBwtMh2YCrPvX4OTCm4CSrWoEvaprx4JfFI4mgD5-XUBG_lBjb74hiLA7NdV8c3zD47BTu187PwC2-GC1Y521Y_IU8eMqW7bGJYnuSroNV7C8ccU4rRMPY9asRN0E",
   };
   const licenseData2 = cloneDeep(licenseData);
   licenseData2.seatsInUse = 2;
   licenseData2.signedChecksum =
-    "DHUuQecjo2Q4NDY3Xz69d6SR2n7lvmf2YL8Nbg8no3-YGN3tv4x8T1saKA5lHcW2VDTH9OXSLHNZNIMZFZUu-a6kZigC8QHykYOHYomyBzOzwjrbH2iSoLcEhucyyWzKAts6wWGrSkyjosXD1tFi9O1loShdmKc16hTunt4NNOHRmJ_ae-V8fWiQHPVrZ7c9tHrcCbXPgONvcNBYq4GRC-mx2aVH1rXoxDQe0sbwHFlOoRbDshPmfR7LBSWbPgQ_ptI8jlaJ1Jko_IClK2EsZYthGfcNjnZOPXz2_Kiwd6U7VY0uMBd6YvWj-rsd5vgTQUaiXl7CRJp3Y6ZDqdLvz1lQOMWw7gOxh_T3djYStWsNcCVBXQn5fqG-81AOY_hsABG21sM8XR4Or8JwmjEWHsjI0pObgD-bptEcTJhMmLQaLnoj77IyRNwQJeVVMm3DKpayugFBSZp71FrhNvfI2hv92QTzaN6OludkfUGspI-_aFbfP2m69xwVf-f0r2iELzlkOB-aCsK1daltFeDD-F1m-Bc-Do3NVrquM4mMuYkvJ9G2OxVO_lioCLE4f_BwawB71BXLQRrGxsV8mF6F3ZST0pytfZSlSkX5iHBVFTE8J2eIlcZXuMgh6Jj2ZS1qCiAsUn6EknEE1GcemOHbykkxNG_835Iati3Y4obBx3k";
+    "Agiu1qpYlPE5BzpLfiA7V9fCCrW-0_jqQYel-ok7TRAh5jP0F_BbXZOeNCcOz1RvRZ6wKrcznwbD0P9QXO-WfJuS9kQ_B4m5ljvlb57mTufq9YtroBJlNwJNKPbXFcjxXJxXNP1Vu3nJr2lSLiXAGaVXDZwVCCiTvksPQx5wIB1acyGCp-AuHp-Zj-3gGxYNZxG49fxIkZwvYCCbro95dAUcRngjU30H1hKzyPry3Fxuhl06mGVnG74xYOdzZmsx65TS4U-cHs9mI-tzL_nTxxIrWi3lX0_-KZVghLZqjXw9pzeWeQaUY8IukJ7hB4pPnOESvmIZkAKzMApoo7bwjt-ndeBbE9LAyyfA0Ha9KH4vd6zP5ZPvKXINw8DEfk67npUZIvH6GNAsSyMR0zOhNnyt9g81M-UJMJ96-OJMd_5H9--wHPGp6JXqJGIoqL-bvZiXbJhC-5heO2Ux0Dd-sOCdzvgmDd0hOqPa36lUUrZTidvbzJQ17pg66yO3kj4urxSSHZcPNKe3wc3cIcw9gU5wF_eJSsuyC2_PGBIizJdg1cEK25yGAj_vo24fCghcwNWtlCI3Tlv98j1Bn6lsALnafDfrQevHJeJPTcDE_0w_d_Ng77wPFqC_uiJlJxk0RI_08l7FuyWOJtRNMGR-xQRth45OKncxYwCeu-jHTzo";
+
+  const oldLicenseKey =
+    "eyJyZWYiOiIyNDAzMjEiLCJzdWIiOiJBY21lIiwib3JnIjoib3JnXzEyMyIsInF0eSI6MywiaWF0IjoiMjAyMy0xMS0xOCIsImV4cCI6IjIwMjMtMTEtMTkiLCJ0cmlhbCI6dHJ1ZSwicGxhbiI6InBybyJ9.Wf_rdgs4Ice1aFImF9bFBVeyP3gfo1V9CyNh9U5kJguKvzpLJEDE7x1bU4zsenaY-sBBv_IeD5UrCf-7ktcW9AQBuQa_c8IK96Dq57gCDGJ5fmTpqL8jZJF9d0HJd-uDhbXqNXway7a3MLK7lwo9BxD4ZiANafrn9qKH0tB30gUChCm61h9trxDmcWIGYi9HFtICvqkKLXthgKgQYV7pHhnB3BzhUXu6p2iDURSIQhergUv3y833tjJ-I_rtMxpeKumJOHAqQDPF3hlNzL4y6WIVAp0RyDEYD3PyfQVsJpY5QRK2cZEwWJr_JRFOmou5O79oZjyAPsbjw2J-41BsNGnshA00MS6l74Aae1zFES10zwxo0En8TS5CqrwIW05hSs1pp-UKM56RFsPTjayGmiGdUSGf7vMo4e7RtE73T9RIntbfqTXYg2FTPiergiYr7gVBPi-JNiicwKOxGChoaIwVkha8Pp3B9yUfTyjWNEm0S9xTlv3l8dRmla2_62YAU3hlvQqZQvRXciOrMPyBQnPuQq9srRSFi2kFYMefgXCSTnFSi9pz9uOiJix7REYlEVOq_qujoRVYHY2h7zZwsIBiR_jCZTX8gJXxPDSDseiWzgXY11YZNWuNC551cRrBurNP1M_M_Z6-A7IXyfrhzBJizYw6a81R6NBBulCVDLc";
+
+  const oldLicenseOrginalData = {
+    ref: "240321",
+    sub: "Acme",
+    org: "org_123",
+    qty: 3,
+    hardCap: false,
+    trial: true,
+    iat: "2023-11-18",
+    exp: "2023-11-19",
+    plan: "pro",
+  };
+
+  const oldLicenseData = {
+    id: "240321",
+    companyName: "Acme",
+    organizationId: "org_123",
+    seats: 3,
+    hardCap: false,
+    isTrial: true,
+    dateCreated: "2023-11-18",
+    dateExpires: "2023-11-19",
+    plan: "pro",
+  };
 
   const now = new Date("2023-11-21T12:08:12.610Z");
+  const old_license_now = new Date(Date.UTC(2023, 10, 18, 18, 45, 4, 713));
 
   beforeEach(() => {
     jest.resetModules();
@@ -70,6 +99,7 @@ describe("licenseInit, getLicense, and getLicenseError", () => {
     jest.spyOn(JSON, "parse").mockRestore();
     jest.spyOn(LicenseModel, "findOne").mockRestore();
     jest.useRealTimers();
+    mockedFetch.mockReset();
     process.env = env;
   });
 
@@ -93,19 +123,153 @@ describe("licenseInit, getLicense, and getLicenseError", () => {
       });
     });
 
+    describe("when there is a license but it has no plan", () => {
+      const licenseDataNoPlan = cloneDeep(licenseData);
+      licenseDataNoPlan.plan = "";
+      licenseDataNoPlan.remoteDowngrade = true; // This would cause the function to return an error, if there was a plan
+      licenseDataNoPlan.signedChecksum =
+        "boEq4MLvkvfrbuTEnN-aOZy6Vz32z7btChuS4pONGP88NDIju6FR36KBu0-8VSC2jbqEhbyMdGqG5FCmJRB-RHOk5TDazLvS1h1YDBb-3y5fbRgQCsSMMv8eyr_wG_OEG-p7eHwk-T5h0U77iONad5M3tX_rJ5gQOLdTJdjKRsB6F9Tib8t7V3BFy0CH9jmyaidrRalGPBxKa5rKiFEf9jp5jifZTD9qHq-Os9-BOYBqrfUKcnjvaGmnAJcQy6GyLqxNuq5yElupvmE0nUFXhjIi4NtSW-P5jn3FdAq05p9UQ8R1O0uOyykj36w0Cs7ATZeCNxixGoejmz2d70AV9vuoGdOtqcq6g7IJjAOOo7dsfTQBHZV-KnFracm3dFVljo5NHddykIkTYntK2TpmIQUP9jLFkgVPdKfkip2oMxqF5_TMlhneDqhY9ENXI-ThjAAVta2VR6CC0npRJvQjxU_4o1Nf0C0MN9iZI1qwtlKrNqjDP8lz2IQCKciZnH-yNrqoCLFkz3yngKOYpQH8Q2lwqnS2l3qpMR4iiAR8Nw8ViZQ62eWPN12fmF9_MVxfhC_esdiUSU1-MvFZIz8jXHGuFnAiOfWdLgutA1lBCXKGqBMI_o1hs0akJaEq8-eHF8E0cfjWMb3wdgfFNCl7PfQcNVxU2tNhsOFHwuW6PIY";
+
+      beforeEach(async () => {
+        const mockedResponse: Response = ({
+          ok: true,
+          json: jest.fn().mockResolvedValueOnce(licenseDataNoPlan),
+        } as unknown) as Response;
+
+        mockedFetch.mockResolvedValueOnce(Promise.resolve(mockedResponse));
+        await licenseInit(licenseKey, userLicenseCodes, metaData);
+      });
+
+      it("should not have an error since no plan means it was an abandoned stripe checkout and not a full license", () => {
+        expect(getLicenseError(org)).toBe("");
+      });
+    });
+
+    describe("when there is a license but it is too out of date", () => {
+      const licenseDataTooOld = {
+        ...cloneDeep(licenseData),
+        usingMongoCache: true,
+        dateUpdated: new Date(
+          now.getTime() - 8 * 24 * 60 * 60 * 1000
+        ).toISOString(),
+      };
+
+      beforeEach(async () => {
+        const mockedResponse: Response = ({
+          ok: true,
+          json: jest.fn().mockResolvedValueOnce(licenseDataTooOld),
+        } as unknown) as Response;
+
+        mockedFetch.mockResolvedValueOnce(Promise.resolve(mockedResponse));
+        await licenseInit(licenseKey, userLicenseCodes, metaData);
+      });
+
+      it("should return an error saying the server is down too long", () => {
+        expect(getLicenseError(org)).toBe("License server down for too long");
+      });
+    });
+
+    describe("when there is a license but has expired", () => {
+      const expiredLicense = cloneDeep(licenseData);
+      expiredLicense.dateExpires = new Date(
+        now.getTime() - 8 * 24 * 60 * 60 * 1000
+      ).toISOString();
+      expiredLicense.signedChecksum =
+        "dmFmZdVbiR3Ed-s9lyHys2hqmu_fMYMS7EreU4g6FKipPatQL-dsrC-vvUo3DYhEWZzC72T5mPoRcsUWPUWNp_wtpuYnozDbLCVs4nzbr0yQJ32eSFlO3qvTkzElVWCipILDKHKmzs6JXUSerljxOAI0TtXxkXkWMdTuOvxEwwO0KMTazz9c-rLg4P4iuFhSvZmnE82kecLvf0ZeRImQuW_8Ts7dT1L-5uzVH0eQjz2S0e3xdwYFE5F0vBufxkizg-68RG_AFmJ8sqO53Ys316Q3S2dwNFlA-dmAGc3TVJKis9D-TZCkHENuSdKfbj4nKwql3Uye8Vj9LxMHI2Vps-R6RXr2f-r2IKk6aqqUGl9A3p2FFvrf1QhFrmyQBKOeyvRI_tojd0F7rh4-FptLV8_Z46KUblGSSdhjg79JZV-KpH4h_uH0HwVtyFoi-deI4A-4cRynYJEu2IWvDCc5XJr6tspC_tuNX37D_Nw17uxC1Gy9a7vk832zkUdQlwOtzt2GV23QUSSOYFjSkOgoCAybbcWNSeZuaE3sEsso_Gwq9aqPrN1FlcNuyIVlmXWJt-0rI9uUD5hmpcTeH01m3AmNOu8es4yjTz1JmJY3TTQ4JgZqRyMvasxgZcEUCF_4p9Qn58l1kWo4AHkvlbHAHEHovwPX1YdiacBux82ORIk";
+      beforeEach(async () => {
+        const mockedResponse: Response = ({
+          ok: true,
+          json: jest.fn().mockResolvedValueOnce(expiredLicense),
+        } as unknown) as Response;
+
+        mockedFetch.mockResolvedValueOnce(Promise.resolve(mockedResponse));
+        await licenseInit(licenseKey, userLicenseCodes, metaData);
+      });
+
+      it("should return an error if the license is too old", () => {
+        expect(getLicenseError(org)).toBe("License expired");
+      });
+    });
+
+    describe("when there is a license but the email is not verified", () => {
+      const licenseWithUnverifiedEmail = cloneDeep(licenseData);
+      licenseWithUnverifiedEmail.emailVerified = false;
+      beforeEach(async () => {
+        const mockedResponse: Response = ({
+          ok: true,
+          json: jest.fn().mockResolvedValueOnce(licenseWithUnverifiedEmail),
+        } as unknown) as Response;
+
+        mockedFetch.mockResolvedValueOnce(Promise.resolve(mockedResponse));
+        await licenseInit(licenseKey, userLicenseCodes, metaData);
+        await licenseInit(oldLicenseKey);
+      });
+
+      it("should return an error saying the email is not verified", () => {
+        expect(getLicenseError(org)).toBe("Email not verified");
+      });
+
+      it("should not throw an error if it is an old syle license", () => {
+        jest.setSystemTime(old_license_now);
+        const org_with_old_style_license = {
+          id: "org_123",
+          licenseKey: oldLicenseKey,
+        };
+        expect(getLicenseError(org_with_old_style_license)).toBe("");
+      });
+    });
+
+    describe("when there is a license but the org does not match", () => {
+      const licenseWithWrongOrg = cloneDeep(licenseData);
+      licenseWithWrongOrg.organizationId = "org_wrong";
+      licenseWithWrongOrg.signedChecksum =
+        "TKz09mcJa0411s0VYJEJ5-nkmJY13LIQapY4-t1-4C9CbK4m4FTzGlLC4kee163bqisRcinfq10TLXgUHTYaPW2WbUfMIz57iVhN5QoXpGBVGVNIqBHS4jiVvrLfUoV_Ms-9GBvvYb-KfxkkPqizn5bE27BrIpasVXJg8RbYfN7rNc3cYPTD5rKhZaIyeDjyHtff1_M9GVTHRV1-F9_mzoE1znZ_ln0-JRWtAaISeY6gzXOW84LcQusx_O--7i_1hJxQlnsJ6qZ1XTcCbmfgWi3wbYI1815BU9UvnMC1qcLh3ALpN918NXhyMMeLEql6W71ftZaM4i_LLjKPzXb39bC9okc1tVoisGs2burhWK0DxVM6TWcv7QDd2q9u48bv3bIIxJ1Aw94ob6DHOmr3klFk9_5mwFPTzx4Y34uVX0gUgCo0ndPi5RLf3NHAm8f6OZ-h-9hrSEv_uqwfBWaSlmc7193lBzKssvbvDYHLLWnqI0iRs4usHPlyttqVSyHwTBF2omqGsx5ggvujT2e1wFsQTjWDBGzAG37ruJglCGFrozHiDhT-NyOtRTxjFcMJr13CevQ8BPiyKtQE_lguvbw-eB6BZsXDxsMXzwi1sxc31xJ4e0kpJdwUvn5G_XKKCcgYugHzDZieeuzYDoWF3ITr3eFnXuVp6cYsK5xRpU8";
+
+      beforeEach(async () => {
+        const mockedResponse: Response = ({
+          ok: true,
+          json: jest.fn().mockResolvedValueOnce(licenseWithWrongOrg),
+        } as unknown) as Response;
+
+        mockedFetch.mockResolvedValueOnce(Promise.resolve(mockedResponse));
+        await licenseInit(licenseKey, userLicenseCodes, metaData);
+      });
+
+      it("should return an error that the license is invalid", () => {
+        expect(getLicenseError(org)).toBe("Invalid license");
+      });
+    });
+
+    describe("when there is a license but it has been remotely downgraded", () => {
+      const licenseWithWrongOrg = cloneDeep(licenseData);
+      licenseWithWrongOrg.remoteDowngrade = true;
+      licenseWithWrongOrg.signedChecksum =
+        "QZ3S5mm_sCcUA5z1zIJdRpveNkmwKzf15zlFf_8sMqflKsWpzKw9R1-xUItQ8l6AXdgA5_ohdBglfTvNu4efkS8DdT3oavN0o2XVx_ZmIUkSWyudmqv6HOFba6r9vidaQ6Qhyvu7vVIL2RwLnOlFTaud1pD0OZolKW8iut1PV9QSo1upUO50DTbJ3PGZQcDBNUN8EfExcG7K-gfeaRYud9LFVKU0kd_xM4hg9XhgCQuEvtfblbXB56uFRm9Gbm9KdlV6APZFmOm8DTqkUqvJCdV3ySuEmmAqLW2K6unQRQBJy7pYFV0rXhSYVB6DtmUPlq4k-8BwCvYGO5DDZpsj3k0pGW5BIE90QrdgnqbuB8xXTnAm5YwVCAv0fWxjoRi00RhjKDpEEgwNxX2qzYDQMU5SbUJLJcWRoijyWrmOOzBPfvUxg8FiU_hIVAAmPYO3JxYgBrleaetYZu7hcSPYIOk7It1OWYCuVfFfHiYtwvBc_--Bg4rUitGZu7OxSJYvTPC3THJmc8_UgXNe9hImMLRvA4y-BdZrDXRDPhZSKPuymla8yMFEM0FoXdm6PBlTK2f5tCkyduQptxTibk9pQ8GBkeDmvM0qTfJp3So8OnriYowJyqQL8rSo__oVzyp5TZ5cQAsj0HvQXe5W9aqgd4VJFrvlk7tGPKFKUp4aq6E";
+
+      beforeEach(async () => {
+        const mockedResponse: Response = ({
+          ok: true,
+          json: jest.fn().mockResolvedValueOnce(licenseWithWrongOrg),
+        } as unknown) as Response;
+
+        mockedFetch.mockResolvedValueOnce(Promise.resolve(mockedResponse));
+        await licenseInit(licenseKey, userLicenseCodes, metaData);
+      });
+
+      it("should return an error that the license is invalid", () => {
+        expect(getLicenseError(org)).toBe("License invalidated");
+      });
+    });
+
     describe("when there is a valid license on the org", () => {
-      beforeEach(() => {
+      beforeEach(async () => {
         const mockedResponse: Response = ({
           ok: true,
           json: jest.fn().mockResolvedValueOnce(licenseData),
         } as unknown) as Response;
 
         mockedFetch.mockResolvedValueOnce(Promise.resolve(mockedResponse));
-        licenseInit(licenseKey, userLicenseCodes, metaData);
-      });
-
-      afterEach(() => {
-        mockedFetch.mockReset();
+        await licenseInit(licenseKey, userLicenseCodes, metaData);
       });
 
       it("should not have an error if the license is valid", () => {
@@ -141,10 +305,6 @@ describe("licenseInit, getLicense, and getLicenseError", () => {
         } as unknown) as Response;
 
         mockedFetch.mockResolvedValueOnce(Promise.resolve(mockedResponse));
-      });
-
-      afterEach(() => {
-        mockedFetch.mockReset();
       });
 
       it("should use the env variable if licenseKey argument is not provided", async () => {
@@ -459,42 +619,13 @@ describe("licenseInit, getLicense, and getLicenseError", () => {
   });
 
   describe("old style licenses where licenseKey does NOT start with 'license_' but contains the license data encoded in itself", () => {
-    const now2 = new Date(Date.UTC(2023, 10, 18, 18, 45, 4, 713));
-
-    const oldLicenseKey =
-      "eyJyZWYiOiIyNDAzMjEiLCJzdWIiOiJBY21lIiwib3JnIjoib3JnXzEyMyIsInF0eSI6MywiaWF0IjoiMjAyMy0xMS0xOCIsImV4cCI6IjIwMjMtMTEtMTkiLCJ0cmlhbCI6dHJ1ZSwicGxhbiI6InBybyJ9.Wf_rdgs4Ice1aFImF9bFBVeyP3gfo1V9CyNh9U5kJguKvzpLJEDE7x1bU4zsenaY-sBBv_IeD5UrCf-7ktcW9AQBuQa_c8IK96Dq57gCDGJ5fmTpqL8jZJF9d0HJd-uDhbXqNXway7a3MLK7lwo9BxD4ZiANafrn9qKH0tB30gUChCm61h9trxDmcWIGYi9HFtICvqkKLXthgKgQYV7pHhnB3BzhUXu6p2iDURSIQhergUv3y833tjJ-I_rtMxpeKumJOHAqQDPF3hlNzL4y6WIVAp0RyDEYD3PyfQVsJpY5QRK2cZEwWJr_JRFOmou5O79oZjyAPsbjw2J-41BsNGnshA00MS6l74Aae1zFES10zwxo0En8TS5CqrwIW05hSs1pp-UKM56RFsPTjayGmiGdUSGf7vMo4e7RtE73T9RIntbfqTXYg2FTPiergiYr7gVBPi-JNiicwKOxGChoaIwVkha8Pp3B9yUfTyjWNEm0S9xTlv3l8dRmla2_62YAU3hlvQqZQvRXciOrMPyBQnPuQq9srRSFi2kFYMefgXCSTnFSi9pz9uOiJix7REYlEVOq_qujoRVYHY2h7zZwsIBiR_jCZTX8gJXxPDSDseiWzgXY11YZNWuNC551cRrBurNP1M_M_Z6-A7IXyfrhzBJizYw6a81R6NBBulCVDLc";
-
-    const oldLicenseOrginalData = {
-      ref: "240321",
-      sub: "Acme",
-      org: "org_123",
-      qty: 3,
-      hardCap: false,
-      trial: true,
-      iat: "2023-11-18",
-      exp: "2023-11-19",
-      plan: "pro",
-    };
-
-    const oldLicenseData = {
-      id: "240321",
-      companyName: "Acme",
-      organizationId: "org_123",
-      seats: 3,
-      hardCap: false,
-      isTrial: true,
-      dateCreated: "2023-11-18",
-      dateExpires: "2023-11-19",
-      plan: "pro",
-    };
-
     it("should use the env variable if the licenseKey argument references an expired license", async () => {
       const licenseData3 = cloneDeep(licenseData);
-      const tenDaysAgo = new Date(now2);
+      const tenDaysAgo = new Date(now);
       tenDaysAgo.setDate(tenDaysAgo.getDate() - 10);
       licenseData3.dateExpires = tenDaysAgo.toISOString();
       licenseData3.signedChecksum =
-        "n7Xk1JleapEAyV1s78HqeUXX0-e5Yboz02JRIbfB7zkRtx_s0DnH3IqtDGcTCjs76oB3wZfp31Wf47vbNNA5YWWgqr6Ct_R0-he9sA6tpbTfAa3ev67PanXGzJ36Zqe3tpyXz5vkKVlNEwokneIKurggBowuGF14BxDNN_uzFN8DjbHHDuCrFdyqjdII8tg2SfKz7ybbMm-smYfXvhaayLBQdkWpJ1ZwgPeRsnO-suhRyq_dyFuQk7lkS8DGckNDg3GnJCcrM0olxU7S1EMvcj6BUcECkiDF5xDltFXfKQB8SwiWiDjP04OlJDoDxar3z0maTLilIcP6NtzMbUonuJZhj8qwNrYYM79grhMhsS2a3pN1RQ4jxmCbpxs6VNrEM4u8X6hKPLsqoYqlgyV_UPlNo04Fz5iIfTiy45BVyn2uCiMFkRr58tXNILA2dZjhh_V-9nTSRx2A8XZixjQJzXCbQBz_Q3PoPtdAtiFtRdm_ZHLbHP9c64--vfEqtlNVcc4huUvlwsf5ia1CQFnpbbo0-8_qUAWJUkFilo802aiWW-kwyXmXNjP7jEvBkkd8Oc8l2QUjZCbx3PwDhRacQ-ybr2Df9ZIMmeDLlfU2fDO129W0r1KQNVedCRL2oMcnwRbag9sJF2VTZL8ABi5jhWdJJdK6vTTd9p3AcFNDQ3c";
+        "O8U7fSZb2eA_NIi6N5MJSxqsHNZ98E_nkoyBK7tQ_0pIGhXpQCrAy04ec_l_YLiNCVR8UKeZVQuf58_bdgBCXVQsEZSWDRSpmf_8lw3NjwHEBgh9KdDzsZVIN-bzywA27sQIsR4MS6kmZOgm2ml91WfRblCUf9q6kbXfXFBKgtt-afGUZDqYVnC-bPbZvoRKmyREpnw3u-CMlTvMPrxkpUuRCCWWcQe6o5S7LUW_L3Z9e-9kEEYC3mh2ERnjojSblR_sdSa_mDgLA20p9w0_Amhrw-6zKIi6ZyMUHHz3iUKXjvEpp4OqqHhm5Fooax07Hn4e18Om9ZisaZ22IRKeJyjjuZdGMnK3cfNhUaHkWW_FSHaDnTouQRdtA-hBP5l4ktauLKKVKuomvwunDq5-MHrcENfcUedV6eB68R0OGEi8bQVCGSnLrO48gTrQzbwVem5EAgr1n7PwpCdzZntUZfQ9QnoPhRRBPNFPGcCJih4ZlOsuDpYRpie7ritAupI7sRbuw_vk00fEBb0NAqA5pNBH7JMjUPhsUwYtXJumkbHZt8p1gz1U5A9UIgZT8rjiwHifqgOyo435M2xcHDHqPahjRDq8K11NZATNAf9AFlnIPPiYg-hHMIhugArpG-EuOsEekVQqjzGfm6CC24f6cyllhRYk22ae04cdbcm4iaA";
       const mockedResponse3: Response = ({
         ok: true,
         json: jest.fn().mockResolvedValueOnce(licenseData3),
@@ -525,11 +656,12 @@ describe("licenseInit, getLicense, and getLicenseError", () => {
     });
 
     it("should read license data from the key itself and use the in-memory cache if called a second time, even if a long time has passed, as old style license keys should never expire", async () => {
-      await licenseInit(oldLicenseKey, userLicenseCodes, metaData);
+      await licenseInit(oldLicenseKey);
 
       expect(getLicense(oldLicenseKey)).toEqual(oldLicenseData);
 
-      const tenYearsFromNow = now2.getTime() + 10 * 365 * 24 * 60 * 60 * 1000;
+      const tenYearsFromNow =
+        old_license_now.getTime() + 10 * 365 * 24 * 60 * 60 * 1000;
       jest.setSystemTime(tenYearsFromNow);
       jest.spyOn(JSON, "parse").mockReturnValue({ foo: "bar" }); // This is an invalid license, but we should use the cache so won't see an error.
 
@@ -539,12 +671,7 @@ describe("licenseInit, getLicense, and getLicenseError", () => {
 
     it("should throw an error if the data doesn't match the signature", async () => {
       await expect(
-        async () =>
-          await licenseInit(
-            oldLicenseKey + "extrasignature",
-            userLicenseCodes,
-            metaData
-          )
+        async () => await licenseInit(oldLicenseKey + "extrasignature")
       ).rejects.toThrowError("Invalid license key signature");
     });
 
@@ -556,7 +683,7 @@ describe("licenseInit, getLicense, and getLicenseError", () => {
       delete oldLicenseOriginalData2.exp;
       jest.spyOn(JSON, "parse").mockReturnValue(oldLicenseOriginalData2);
 
-      await licenseInit(oldLicenseKey, userLicenseCodes, metaData);
+      await licenseInit(oldLicenseKey);
 
       expect(getLicense(oldLicenseKey)).toEqual(oldLicenseData);
     });
@@ -568,7 +695,7 @@ describe("licenseInit, getLicense, and getLicenseError", () => {
       jest.spyOn(JSON, "parse").mockReturnValue(oldLicenseOriginalData2);
 
       await expect(async () => {
-        await licenseInit(oldLicenseKey, userLicenseCodes, metaData);
+        await licenseInit(oldLicenseKey);
       }).rejects.toThrowError("Invalid License Key - Missing expiration date");
     });
 
@@ -578,7 +705,7 @@ describe("licenseInit, getLicense, and getLicenseError", () => {
       delete oldLicenseOriginalData2.plan;
       jest.spyOn(JSON, "parse").mockReturnValue(oldLicenseOriginalData2);
 
-      await licenseInit(oldLicenseKey, userLicenseCodes, metaData);
+      await licenseInit(oldLicenseKey);
 
       const expected = cloneDeep(oldLicenseData);
       expected.plan = "enterprise";

--- a/packages/front-end/components/Layout/AccountPlanNotices.tsx
+++ b/packages/front-end/components/Layout/AccountPlanNotices.tsx
@@ -13,7 +13,7 @@ export default function AccountPlanNotices() {
   const [upgradeModal, setUpgradeModal] = useState(false);
   const permissions = usePermissions();
   const router = useRouter();
-  const { license, organization } = useUser();
+  const { license, licenseError } = useUser();
   const {
     showSeatOverageBanner,
     canSubscribe,
@@ -101,6 +101,146 @@ export default function AccountPlanNotices() {
 
   // Notices for accounts using a license key
   if (license) {
+    if (licenseError) {
+      switch (licenseError) {
+        case "Invalid license key signature":
+          return (
+            <Tooltip
+              body={
+                <>
+                  There is something wrong with your license. Please contact
+                  support@growthbook.io.
+                </>
+              }
+            >
+              <div className="alert alert-danger py-1 px-2 mb-0 d-none d-md-block mr-1">
+                <FaExclamationTriangle /> invalid license key signature
+              </div>
+            </Tooltip>
+          );
+        case "License server down for too long":
+          return (
+            <Tooltip
+              body={<>Please make sure that you have whitelisted 75.2.109.47</>}
+            >
+              <div className="alert alert-danger py-1 px-2 mb-0 d-none d-md-block mr-1">
+                <FaExclamationTriangle /> Could not contact license server.
+              </div>
+            </Tooltip>
+          );
+        case "No support for SSO":
+          return (
+            <Tooltip
+              body={
+                <>
+                  Your license doesn&apos;t support SSO. Upgrade to Enterprise
+                  or remove SSO_CONFIG env variable.
+                </>
+              }
+            >
+              <div className="alert alert-danger py-1 px-2 mb-0 d-none d-md-block mr-1">
+                <FaExclamationTriangle /> invalid sso configuration
+              </div>
+            </Tooltip>
+          );
+        case "No support for multi-org":
+          return (
+            <Tooltip
+              body={
+                <>
+                  Your license doesn&apos;t support multi-org. Upgrade to
+                  Enterprise or remove IS_MULTI_ORG env variable.
+                </>
+              }
+            >
+              <div className="alert alert-danger py-1 px-2 mb-0 d-none d-md-block mr-1">
+                <FaExclamationTriangle /> invalid multi-org configuration
+              </div>
+            </Tooltip>
+          );
+        case "License expired":
+          return (
+            <Tooltip
+              body={
+                license.plan === "enterprise" ? (
+                  <>
+                    Your license expired on{" "}
+                    <strong>{date(license.dateExpires)}</strong>. Contact
+                    sales@growthbook.io to renew.
+                  </>
+                ) : (
+                  <>
+                    Your license expired on{" "}
+                    <strong>{date(license.dateExpires)}</strong>. Go to your
+                    settings &gt; billing page to renew.
+                  </>
+                )
+              }
+            >
+              <div className="alert alert-danger py-1 px-2 d-none d-md-block mb-0 mr-1">
+                <FaExclamationTriangle /> license expired
+              </div>
+            </Tooltip>
+          );
+        case "Email not verified":
+          return (
+            <Tooltip
+              body={
+                <>
+                  An email was sent to {license.email}. If you can&apos;t find
+                  it, check your spam folder, or restart the upgrade process.
+                </>
+              }
+            >
+              <div className="alert alert-danger py-1 px-2 mb-0 d-none d-md-block mr-1">
+                Check email to verify account and activate {license.plan}{" "}
+                {license.isTrial ? "trial" : "license"}.
+              </div>
+            </Tooltip>
+          );
+        case "Invalid license":
+          return (
+            <Tooltip
+              body={
+                <>
+                  Your license key appears to be invalid. Please contact
+                  sales@growthbook.io for assistance.
+                </>
+              }
+            >
+              <div className="alert alert-danger py-1 px-2 mb-0 d-none d-md-block mr-1">
+                <FaExclamationTriangle /> invalid license
+              </div>
+            </Tooltip>
+          );
+        case "License invalidated":
+          return (
+            <Tooltip
+              body={
+                <>
+                  Your license has been invalidated. Please contact
+                  sales@growthbook.io to resolve this issue.
+                </>
+              }
+            >
+              <div className="alert alert-danger py-1 px-2 mb-0 d-none d-md-block mr-1">
+                <FaExclamationTriangle /> license invalidated
+              </div>
+            </Tooltip>
+          );
+        default:
+          return (
+            <Tooltip
+              body={<>Please contact support@growthbook.io for assistance.</>}
+            >
+              <div className="alert alert-danger py-1 px-2 mb-0 d-none d-md-block mr-1">
+                <FaExclamationTriangle /> {licenseError.toLowerCase()}
+              </div>
+            </Tooltip>
+          );
+      }
+    }
+
     if (license?.usingMongoCache) {
       // Cache is good for a week
       const cachedDataGoodUntil = new Date(
@@ -120,108 +260,45 @@ export default function AccountPlanNotices() {
         );
       }
     }
-
-    // Trial license is up
-    const licenseTrialRemaining = license.isTrial
-      ? daysLeft(license.dateExpires)
-      : -1;
-    if (license?.organizationId && license.organizationId !== organization.id) {
-      return (
-        <Tooltip
-          body={
-            <>
-              Your license key appears to be invalid. Please contact
-              sales@growthbook.io for assistance.
-            </>
-          }
-        >
-          <div className="alert alert-danger py-1 px-2 mb-0 d-none d-md-block mr-1">
-            <FaExclamationTriangle /> Invalid license
-          </div>
-        </Tooltip>
-      );
-    }
-
-    if (license.emailVerified === false && license.plan) {
-      return (
-        <Tooltip
-          body={
-            <>
-              An email was sent to {license.email}. If you can&apos;t find it,
-              check your spam folder, or restart the upgrade process.
-            </>
-          }
-        >
-          <div className="alert alert-danger py-1 px-2 mb-0 d-none d-md-block mr-1">
-            Check email to verify account and activate {license.plan}{" "}
-            {license.isTrial ? "trial" : "license"}.
-          </div>
-        </Tooltip>
-      );
-    }
-
-    if (licenseTrialRemaining >= 0) {
-      if (license.plan === "enterprise") {
-        return (
-          <Tooltip
-            body={
-              <>
-                Contact sales@growthbook.io if you need more time or would like
-                to upgrade
-              </>
-            }
-          >
-            <div className="alert alert-warning py-1 px-2 mb-0 d-none d-md-block mr-1">
-              <span className="badge badge-warning">
-                {licenseTrialRemaining}
-              </span>{" "}
+    // Trial license is almost up
+    if (license.isTrial) {
+      const licenseTrialRemaining = daysLeft(license.dateExpires);
+      if (licenseTrialRemaining >= 0) {
+        if (license.plan === "enterprise") {
+          return (
+            <Tooltip
+              body={
+                <>
+                  Contact sales@growthbook.io if you need more time or would
+                  like to upgrade
+                </>
+              }
+            >
+              <div className="alert alert-warning py-1 px-2 mb-0 d-none d-md-block mr-1">
+                <span className="badge badge-warning">
+                  {licenseTrialRemaining}
+                </span>{" "}
+                day
+                {licenseTrialRemaining === 1 ? "" : "s"} left in trial
+              </div>
+            </Tooltip>
+          );
+        } else {
+          return (
+            <button
+              className="alert alert-warning py-1 px-2 mb-0 d-none d-md-block mr-1"
+              onClick={(e) => {
+                e.preventDefault();
+                router.push("/settings/billing");
+              }}
+            >
+              <div className="badge badge-warning">{licenseTrialRemaining}</div>{" "}
               day
               {licenseTrialRemaining === 1 ? "" : "s"} left in trial
-            </div>
-          </Tooltip>
-        );
-      } else {
-        return (
-          <button
-            className="alert alert-warning py-1 px-2 mb-0 d-none d-md-block mr-1"
-            onClick={(e) => {
-              e.preventDefault();
-              router.push("/settings/billing");
-            }}
-          >
-            <div className="badge badge-warning">{licenseTrialRemaining}</div>{" "}
-            day
-            {licenseTrialRemaining === 1 ? "" : "s"} left in trial
-          </button>
-        );
+            </button>
+          );
+        }
       }
-    }
-
-    // License expired
-    if (license.dateExpires < new Date().toISOString().substring(0, 10)) {
-      return (
-        <Tooltip
-          body={
-            license.plan === "enterprise" ? (
-              <>
-                Your license expired on{" "}
-                <strong>{date(license.dateExpires)}</strong>. Contact
-                sales@growthbook.io to renew.
-              </>
-            ) : (
-              <>
-                Your license expired on{" "}
-                <strong>{date(license.dateExpires)}</strong>. Go to your
-                settings &gt; billing page to renew.
-              </>
-            )
-          }
-        >
-          <div className="alert alert-danger py-1 px-2 d-none d-md-block mb-0 mr-1">
-            <FaExclamationTriangle /> license expired
-          </div>
-        </Tooltip>
-      );
     }
 
     // More seats than the license allows for


### PR DESCRIPTION
### Features and Changes

- Verification, Misconfiguration, and license down and cache too old errors were throwing errors that would appear only in the logs.  We are now centralizing all errors to be handled the same way by displaying a message and downgrading their functionality to starter. Verification is left as is that is handled differently in old (airGapped) and new style licenses and it really shouldn't ever error unless they are trying to fake a license.
- The SSO while not on enterprise env var error still throws an error otherwise they would still be able to log in as SSO, but be downgraded to the free version and see a warning, and hence get Starter+SSO for free.
- Errors thrown in organization endpoint are now shown in the UserContext - so users would still be able to see the error message.  Before the page would just have a loading spinner forever.
- We were not saving a license if it returned a license with some errors before but throwing an error, and now we allow it to save, but show the error message in the interface instead.

### Dependencies


### Testing
Sign up for pro trial license.
See the verify email warning.

Click on link in email.
See the 13 days left in trial warning and enterprise pill tag.

In mongo set dateExpires to be some time in the past.
In General -> Settings -> License click “Refresh”
See the license expired message and no license pill tag.

In Mongo set dateExpires to be in the future again. Set remoteDowngrade: true.
In General -> Settings -> License click “Refresh”
See the license invalidated message and no license pill tag.

In Mongo set remoteDowngrade: false.  Set orgnizationId to be different.
In General -> Settings -> License click “Refresh”
See the invalid license message and no license pill tag.

In Mongo set the organizationId back to what it had been.
In back-end/.env.local set SSO_CONFIG=something
Restart the server.
Refresh the page.
See the “Your license does not support SSO.  Either upgrade to Enterprise or remove SSO_CONFIG environment variable.”
In back-end/.env.local remove SSO_CONFIG=something add IS_MULTI_ORG=true

Restart the server.
Refresh the page and log in and see the “invalid multi-org configuration” error message and no license pill tag.
Set IS_MULTI_ORG back to false 

`yarn test`

