### PR TITLE
Fix namespace usage includes inactive experiments

### DIFF
--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -9,6 +9,7 @@ import {
   orgHasPremiumFeature,
 } from "enterprise";
 import { hasReadAccess } from "shared/permissions";
+import { experimentHasLinkedChanges } from "shared/util";
 import {
   AuthRequest,
   ResponseWithStatusAndError,
@@ -709,9 +710,10 @@ export async function getNamespaces(req: AuthRequest, res: Response) {
 
   const namespaces: NamespaceUsage = {};
 
-  // Get all of the active experiments that are tied to a namespace
+  // Get active legacy experiment rules on features
   const allFeatures = await getAllFeatures(context);
   allFeatures.forEach((f) => {
+    if (f.archived) return;
     environments.forEach((env) => {
       if (!f.environmentSettings?.[env]?.enabled) return;
       const rules = f.environmentSettings?.[env]?.rules || [];
@@ -741,6 +743,20 @@ export async function getNamespaces(req: AuthRequest, res: Response) {
 
   const allExperiments = await getAllExperiments(context);
   allExperiments.forEach((e) => {
+    if (e.archived) return;
+
+    // Skip experiments that are not linked to any changes since they aren't included in the payload
+    if (!experimentHasLinkedChanges(e)) return;
+
+    // Skip if experiment is stopped and doesn't have a temporary rollout enabled
+    if (
+      e.status === "stopped" &&
+      (e.excludeFromPayload || !e.releasedVariationId)
+    ) {
+      return;
+    }
+
+    // Skip if a namespace isn't enabled on the latest phase
     if (!e.phases) return;
     const phase = e.phases[e.phases.length - 1];
     if (!phase) return;


### PR DESCRIPTION
### Features and Changes

When calculating which part of a namespace was being used, we weren't properly filtering out experiments that were stopped or inactive in some way.

Now it excludes if any of the following are true:
- Experiment or feature is archived
- Experiment does not have any linked changes
- Experiment is stopped and doesn't have a temporary rollout enabled

We ARE still including draft experiments and feature rules.  We do this to avoid race conditions where two drafts are being worked on at the same time.  We want them to be aware of each other when configuring namespaces since we don't know when they will launch.