### PR TITLE
Migrate manageTargetingAttributes to permissionClass

### DIFF
--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -1308,9 +1308,13 @@ export const autoAddGroupsAttribute = async (
   res: Response<{ status: 200; added: boolean }>
 ) => {
   // Add missing `$groups` attribute automatically if it's being referenced by a Saved Group
-  const { org } = getContextFromReq(req);
+  const context = getContextFromReq(req);
+  const { org } = context;
 
-  req.checkPermissions("manageTargetingAttributes", []);
+  // TODO: When we add project-scoping to saved groups - pass in the actual projects array below
+  if (!context.permissions.canCreateAttribute({})) {
+    context.permissions.throwPermissionError();
+  }
 
   let added = false;
 

--- a/packages/back-end/test/permissions.test.ts
+++ b/packages/back-end/test/permissions.test.ts
@@ -1812,6 +1812,568 @@ describe("hasReadAccess filter", () => {
   });
 });
 
+describe("PermissionsUtilClass.canViewAttributeModal check", () => {
+  const testOrg: OrganizationInterface = {
+    id: "org_sktwi1id9l7z9xkjb",
+    name: "Test Org",
+    ownerEmail: "test@test.com",
+    url: "https://test.com",
+    dateCreated: new Date(),
+    invites: [],
+    members: [
+      {
+        id: "base_user_123",
+        role: "readonly",
+        dateCreated: new Date(),
+        limitAccessByEnvironment: false,
+        environments: [],
+        projectRoles: [],
+        teams: [],
+      },
+    ],
+    settings: {
+      environments: [
+        { id: "development" },
+        { id: "staging" },
+        { id: "production" },
+      ],
+    },
+  };
+
+  it("User with global readonly role can not view modal in 'All Projects'", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("readonly", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(permissions.canViewIdeaModal()).toEqual(false);
+  });
+
+  it("User with global engineer role can view modal in 'All Projects'", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("engineer", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(permissions.canViewIdeaModal()).toEqual(true);
+  });
+
+  it("User with global readonly role can not view modal in project 'ABC123'", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("readonly", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(permissions.canViewIdeaModal("ABC123")).toEqual(false);
+  });
+
+  it("User with global readonly role can view modal in project 'ABC123' if they have an engineer role for that project", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("readonly", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {
+          ABC123: {
+            permissions: roleToPermissionMap("engineer", testOrg),
+            limitAccessByEnvironment: false,
+            environments: [],
+          },
+        },
+      },
+      false
+    );
+
+    expect(permissions.canViewIdeaModal("ABC123")).toEqual(true);
+  });
+});
+
+describe("PermissionsUtilClass.canCreateAttribute check", () => {
+  const testOrg: OrganizationInterface = {
+    id: "org_sktwi1id9l7z9xkjb",
+    name: "Test Org",
+    ownerEmail: "test@test.com",
+    url: "https://test.com",
+    dateCreated: new Date(),
+    invites: [],
+    members: [
+      {
+        id: "base_user_123",
+        role: "readonly",
+        dateCreated: new Date(),
+        limitAccessByEnvironment: false,
+        environments: [],
+        projectRoles: [],
+        teams: [],
+      },
+    ],
+    settings: {
+      environments: [
+        { id: "development" },
+        { id: "staging" },
+        { id: "production" },
+      ],
+    },
+  };
+
+  it("User with global readonly role can not create attribute in 'All Projects'", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("readonly", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(permissions.canCreateAttribute({})).toEqual(false);
+  });
+
+  it("User with global engineer role can create attribute in in 'All Projects'", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("engineer", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(permissions.canCreateAttribute({})).toEqual(true);
+  });
+
+  it("User with global readonly role can not create attribute in in project 'ABC123'", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("readonly", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(permissions.canCreateAttribute({ projects: ["ABC123"] })).toEqual(
+      false
+    );
+  });
+
+  it("User with global readonly role can create attribute in in project 'ABC123' if they have an engineer role for that project", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("readonly", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {
+          ABC123: {
+            permissions: roleToPermissionMap("engineer", testOrg),
+            limitAccessByEnvironment: false,
+            environments: [],
+          },
+        },
+      },
+      false
+    );
+
+    expect(permissions.canCreateAttribute({ projects: ["ABC123"] })).toEqual(
+      true
+    );
+  });
+
+  it("User with global engineer role can not create attribute in in project 'ABC123' if they have a readonly role for that project", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("engineer", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {
+          ABC123: {
+            permissions: roleToPermissionMap("readonly", testOrg),
+            limitAccessByEnvironment: false,
+            environments: [],
+          },
+        },
+      },
+      false
+    );
+
+    expect(permissions.canCreateAttribute({ projects: ["ABC123"] })).toEqual(
+      false
+    );
+  });
+
+  it("User with global readonly role can not create attribute in in project 'ABC123' and 'DEF456 if they have a engineer role for only one of the projects", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("readonly", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {
+          ABC123: {
+            permissions: roleToPermissionMap("engineer", testOrg),
+            limitAccessByEnvironment: false,
+            environments: [],
+          },
+        },
+      },
+      false
+    );
+
+    expect(
+      permissions.canCreateAttribute({ projects: ["ABC123", "DEF456"] })
+    ).toEqual(false);
+  });
+
+  it("User with global readonly role can create attribute in in project 'ABC123' and 'DEF456 if they have a engineer role for both projects", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("readonly", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {
+          ABC123: {
+            permissions: roleToPermissionMap("engineer", testOrg),
+            limitAccessByEnvironment: false,
+            environments: [],
+          },
+          DEF456: {
+            permissions: roleToPermissionMap("engineer", testOrg),
+            limitAccessByEnvironment: false,
+            environments: [],
+          },
+        },
+      },
+      false
+    );
+
+    expect(
+      permissions.canCreateAttribute({ projects: ["ABC123", "DEF456"] })
+    ).toEqual(true);
+  });
+});
+
+describe("PermissionsUtilClass.canUpdateAttribute check", () => {
+  const testOrg: OrganizationInterface = {
+    id: "org_sktwi1id9l7z9xkjb",
+    name: "Test Org",
+    ownerEmail: "test@test.com",
+    url: "https://test.com",
+    dateCreated: new Date(),
+    invites: [],
+    members: [
+      {
+        id: "base_user_123",
+        role: "readonly",
+        dateCreated: new Date(),
+        limitAccessByEnvironment: false,
+        environments: [],
+        projectRoles: [],
+        teams: [],
+      },
+    ],
+    settings: {
+      environments: [
+        { id: "development" },
+        { id: "staging" },
+        { id: "production" },
+      ],
+    },
+  };
+
+  it("User with global readonly role and engineer role on project ABC123 can not remove all projects from existing attribute", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("readonly", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {
+          ABC123: {
+            permissions: roleToPermissionMap("engineer", testOrg),
+            limitAccessByEnvironment: false,
+            environments: [],
+          },
+        },
+      },
+      false
+    );
+
+    expect(
+      permissions.canUpdateAttribute({ projects: ["ABC123"] }, { projects: [] })
+    ).toEqual(false);
+  });
+
+  it("User with global engineer role can remove all projects from existing attribute", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("engineer", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(
+      permissions.canUpdateAttribute({ projects: ["ABC123"] }, { projects: [] })
+    ).toEqual(true);
+  });
+
+  it("User with global readonly role can update an attribute from being in project ABC123 to being in ABC123 and DEF456", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("readonly", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {
+          ABC123: {
+            permissions: roleToPermissionMap("engineer", testOrg),
+            limitAccessByEnvironment: false,
+            environments: [],
+          },
+          DEF456: {
+            permissions: roleToPermissionMap("engineer", testOrg),
+            limitAccessByEnvironment: false,
+            environments: [],
+          },
+        },
+      },
+      false
+    );
+
+    expect(
+      permissions.canUpdateAttribute(
+        { projects: ["ABC123"] },
+        { projects: ["ABC123", "DEF456"] }
+      )
+    ).toEqual(true);
+  });
+});
+
+describe("PermissionsUtilClass.canDeleteAttribute check", () => {
+  const testOrg: OrganizationInterface = {
+    id: "org_sktwi1id9l7z9xkjb",
+    name: "Test Org",
+    ownerEmail: "test@test.com",
+    url: "https://test.com",
+    dateCreated: new Date(),
+    invites: [],
+    members: [
+      {
+        id: "base_user_123",
+        role: "readonly",
+        dateCreated: new Date(),
+        limitAccessByEnvironment: false,
+        environments: [],
+        projectRoles: [],
+        teams: [],
+      },
+    ],
+    settings: {
+      environments: [
+        { id: "development" },
+        { id: "staging" },
+        { id: "production" },
+      ],
+    },
+  };
+
+  it("User with global readonly role can not delete attribute in 'All Projects'", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("readonly", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(permissions.canDeleteAttribute({})).toEqual(false);
+  });
+
+  it("User with global engineer role can delete attribute in in 'All Projects'", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("engineer", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(permissions.canDeleteAttribute({})).toEqual(true);
+  });
+
+  it("User with global readonly role can not delete attribute in in project 'ABC123'", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("readonly", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(permissions.canDeleteAttribute({ projects: ["ABC123"] })).toEqual(
+      false
+    );
+  });
+
+  it("User with global readonly role can delete attribute in in project 'ABC123' if they have an engineer role for that project", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("readonly", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {
+          ABC123: {
+            permissions: roleToPermissionMap("engineer", testOrg),
+            limitAccessByEnvironment: false,
+            environments: [],
+          },
+        },
+      },
+      false
+    );
+
+    expect(permissions.canDeleteAttribute({ projects: ["ABC123"] })).toEqual(
+      true
+    );
+  });
+
+  it("User with global engineer role can not delete attribute in in project 'ABC123' if they have a readonly role for that project", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("engineer", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {
+          ABC123: {
+            permissions: roleToPermissionMap("readonly", testOrg),
+            limitAccessByEnvironment: false,
+            environments: [],
+          },
+        },
+      },
+      false
+    );
+
+    expect(permissions.canDeleteAttribute({ projects: ["ABC123"] })).toEqual(
+      false
+    );
+  });
+
+  it("User with global readonly role can not delete attribute in in project 'ABC123' and 'DEF456 if they have a engineer role for only one of the projects", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("readonly", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {
+          ABC123: {
+            permissions: roleToPermissionMap("engineer", testOrg),
+            limitAccessByEnvironment: false,
+            environments: [],
+          },
+        },
+      },
+      false
+    );
+
+    expect(
+      permissions.canDeleteAttribute({ projects: ["ABC123", "DEF456"] })
+    ).toEqual(false);
+  });
+
+  it("User with global readonly role can delete attribute in in project 'ABC123' and 'DEF456 if they have a engineer role for both projects", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("readonly", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {
+          ABC123: {
+            permissions: roleToPermissionMap("engineer", testOrg),
+            limitAccessByEnvironment: false,
+            environments: [],
+          },
+          DEF456: {
+            permissions: roleToPermissionMap("engineer", testOrg),
+            limitAccessByEnvironment: false,
+            environments: [],
+          },
+        },
+      },
+      false
+    );
+
+    expect(
+      permissions.canDeleteAttribute({ projects: ["ABC123", "DEF456"] })
+    ).toEqual(true);
+  });
+});
+
 describe("PermissionsUtilClass.canViewIdeaModal check", () => {
   const testOrg: OrganizationInterface = {
     id: "org_sktwi1id9l7z9xkjb",

--- a/packages/front-end/pages/attributes.tsx
+++ b/packages/front-end/pages/attributes.tsx
@@ -3,7 +3,6 @@ import { FaQuestionCircle } from "react-icons/fa";
 import { SDKAttribute } from "back-end/types/organization";
 import Tooltip from "@/components/Tooltip/Tooltip";
 import { GBAddCircle } from "@/components/Icons";
-import usePermissions from "@/hooks/usePermissions";
 import MoreMenu from "@/components/Dropdown/MoreMenu";
 import { useAuth } from "@/services/auth";
 import { useAttributeSchema } from "@/services/features";
@@ -12,17 +11,15 @@ import DeleteButton from "@/components/DeleteButton/DeleteButton";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import ProjectBadges from "@/components/ProjectBadges";
 import { useUser } from "@/services/UserContext";
+import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 
 const FeatureAttributesPage = (): React.ReactElement => {
-  const permissions = usePermissions();
+  const permissionsUtil = usePermissionsUtil();
   const { apiCall } = useAuth();
   const { project } = useDefinitions();
   const attributeSchema = useAttributeSchema(true, project);
 
-  const canCreateAttributes = permissions.check(
-    "manageTargetingAttributes",
-    project
-  );
+  const canCreateAttributes = permissionsUtil.canViewAttributeModal(project);
 
   const [modalData, setModalData] = useState<null | string>(null);
   const { refreshOrganization } = useUser();
@@ -56,7 +53,7 @@ const FeatureAttributesPage = (): React.ReactElement => {
       </td>
       <td className="text-gray">{v.hashAttribute && <>yes</>}</td>
       <td>
-        {permissions.check("manageTargetingAttributes", v.projects || []) ? (
+        {permissionsUtil.canCreateAttribute(v) ? (
           <MoreMenu>
             {!v.archived && (
               <button

--- a/packages/front-end/pages/saved-groups.tsx
+++ b/packages/front-end/pages/saved-groups.tsx
@@ -3,13 +3,13 @@ import Link from "next/link";
 import IdLists from "@/components/SavedGroups/IdLists";
 import ConditionGroups from "@/components/SavedGroups/ConditionGroups";
 import { useUser } from "@/services/UserContext";
-import usePermissions from "@/hooks/usePermissions";
 import { useAuth } from "@/services/auth";
 import { useAttributeSchema } from "@/services/features";
 import LoadingOverlay from "@/components/LoadingOverlay";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import Modal from "@/components/Modal";
 import HistoryTable from "@/components/HistoryTable";
+import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 
 export const getSavedGroupMessage = (
   featuresUsingSavedGroups: Set<string> | undefined
@@ -57,7 +57,7 @@ export default function SavedGroupsPage() {
 
   const { refreshOrganization } = useUser();
 
-  const permissions = usePermissions();
+  const permissionsUtil = usePermissionsUtil();
   const { apiCall } = useAuth();
   const attributeSchema = useAttributeSchema();
 
@@ -76,7 +76,7 @@ export default function SavedGroupsPage() {
 
     // If user has permissions to manage attributes, auto-add $groups attribute
     //TODO: When we make Saved Groups a project-level feature, we should pass in the Saved Groups projects below
-    if (permissions.check("manageTargetingAttributes", [])) {
+    if (permissionsUtil.canCreateAttribute({})) {
       apiCall<{ added: boolean }>("/organization/auto-groups-attribute", {
         method: "POST",
       })
@@ -89,7 +89,13 @@ export default function SavedGroupsPage() {
           // Ignore errors
         });
     }
-  }, [apiCall, refreshOrganization, attributeSchema, savedGroups, permissions]);
+  }, [
+    apiCall,
+    refreshOrganization,
+    attributeSchema,
+    savedGroups,
+    permissionsUtil,
+  ]);
 
   if (!savedGroups) return <LoadingOverlay />;
 

--- a/packages/shared/src/permissions/permissionsClass.ts
+++ b/packages/shared/src/permissions/permissionsClass.ts
@@ -1,6 +1,10 @@
 import { FeatureInterface } from "back-end/types/feature";
 import { MetricInterface } from "back-end/types/metric";
-import { Permission, UserPermissions } from "back-end/types/organization";
+import {
+  Permission,
+  SDKAttribute,
+  UserPermissions,
+} from "back-end/types/organization";
 import { IdeaInterface } from "back-end/types/idea";
 import { READ_ONLY_PERMISSIONS } from "./permissions.utils";
 class PermissionError extends Error {
@@ -17,6 +21,45 @@ export class Permissions {
     this.userPermissions = permissions;
     this.superAdmin = superAdmin;
   }
+
+  // This is a helper method to use on the frontend to determine whether or not to show certain UI elements
+  public canViewAttributeModal = (project?: string): boolean => {
+    return this.checkProjectFilterPermission(
+      {
+        projects: project ? [project] : [],
+      },
+      "manageTargetingAttributes"
+    );
+  };
+
+  public canCreateAttribute = (
+    attribute: Pick<SDKAttribute, "projects">
+  ): boolean => {
+    return this.checkProjectFilterPermission(
+      attribute,
+      "manageTargetingAttributes"
+    );
+  };
+
+  public canUpdateAttribute = (
+    existing: Pick<SDKAttribute, "projects">,
+    updates: Pick<SDKAttribute, "projects">
+  ): boolean => {
+    return this.checkProjectFilterUpdatePermission(
+      existing,
+      updates,
+      "manageTargetingAttributes"
+    );
+  };
+
+  public canDeleteAttribute = (
+    attribute: Pick<SDKAttribute, "projects">
+  ): boolean => {
+    return this.checkProjectFilterPermission(
+      attribute,
+      "manageTargetingAttributes"
+    );
+  };
 
   // This is a helper method to use on the frontend to determine whether or not to show certain UI elements
   public canViewIdeaModal = (project?: string): boolean => {


### PR DESCRIPTION
### Features and Changes

This PR migrates the `manageTargetingAttributes` permission to the `permissionsClass` and adds 4 new helper methods: `canViewAttributeModal`, `canCreateAttribute`, `canUpdateAttribute`, and `canDeleteAttribute`.

This permission was a pretty straight forward migration, nothing out of the ordinary or anything to call out.

### Testing

- See test suite
