### PR TITLE
Make sure we don't get duplicates in the license cache

### DIFF
--- a/packages/enterprise/test/license.test.ts
+++ b/packages/enterprise/test/license.test.ts
@@ -165,8 +165,12 @@ describe("licenseInit and getLicense", () => {
         await licenseInit(licenseKey, userLicenseCodes, metaData);
         expect(getLicense(licenseKey)).toEqual(licenseData);
         expect(fetch).toHaveBeenCalledTimes(1);
-        expect(LicenseModel.create).toHaveBeenCalledTimes(1);
-        expect(LicenseModel.create).toHaveBeenCalledWith(licenseData);
+        expect(LicenseModel.findOneAndUpdate).toHaveBeenCalledTimes(1);
+        expect(LicenseModel.findOneAndUpdate).toHaveBeenCalledWith(
+          { id: licenseKey },
+          { $set: licenseData },
+          { upsert: true }
+        );
         expect(LicenseModel.findOne).toHaveBeenCalledTimes(1);
       });
 
@@ -199,8 +203,12 @@ describe("licenseInit and getLicense", () => {
 
         expect(getLicense(licenseKey)).toEqual(licenseData);
         expect(fetch).toHaveBeenCalledTimes(1);
-        expect(LicenseModel.create).toHaveBeenCalledTimes(1);
-        expect(LicenseModel.create).toHaveBeenCalledWith(licenseData);
+        expect(LicenseModel.findOneAndUpdate).toHaveBeenCalledTimes(1);
+        expect(LicenseModel.findOneAndUpdate).toHaveBeenCalledWith(
+          { id: licenseKey },
+          { $set: licenseData },
+          { upsert: true }
+        );
         expect(LicenseModel.findOne).toHaveBeenCalledTimes(2);
       });
 


### PR DESCRIPTION
### Features and Changes

Unfortunately we weren't creating and setting the mongo cache transactionally.  Also the lock on making duplicate calls to the license server on a missing/out of date cache doesn't work across multiple machines like we have on cloud.  This ended up causing us to have multiple cache's, some of which became out of date.
https://growthbookapp.slack.com/archives/C046L8DQD6F/p1712323400369189


### Testing
`yarn test`
Delete all license_keys on organization and the "licenses" collection in growthbook db.
Sign up for a new license. 
 See one entry in the licenses collection. 
Click refresh in general -> settings -> licenses
Still see just one entry in the licenses collection.

