### PR TITLE
Upgrade ClickHouse client; add request_timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "packages/*"
   ],
   "dependencies": {
-    "@clickhouse/client": "^1.0.1",
     "patch-package": "^8.0.0",
     "wsrun": "^5.2.4"
   },

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "packages/*"
   ],
   "dependencies": {
+    "@clickhouse/client": "^1.0.1",
     "patch-package": "^8.0.0",
     "wsrun": "^5.2.4"
   },

--- a/packages/back-end/package.json
+++ b/packages/back-end/package.json
@@ -27,7 +27,7 @@
     "generate-api-types": "yarn generate-api-models && swagger-cli bundle -t yaml src/api/openapi/openapi.tmp.yaml -o generated/spec.yaml && node src/scripts/generate-openapi.mjs"
   },
   "dependencies": {
-    "@clickhouse/client": "^0.2.10",
+    "@clickhouse/client": "^1.0.1",
     "@databricks/sql": "^1.8.1",
     "@dqbd/tiktoken": "^1.0.7",
     "@google-cloud/bigquery": "5",

--- a/packages/back-end/src/integrations/ClickHouse.ts
+++ b/packages/back-end/src/integrations/ClickHouse.ts
@@ -36,6 +36,7 @@ export default class ClickHouse extends SqlIntegration {
       password: this.params.password,
       database: this.params.database,
       application: "GrowthBook",
+      request_timeout: 3620_000,
       clickhouse_settings: {
         max_execution_time: Math.min(
           this.params.maxExecutionTime ?? 1800,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2364,24 +2364,12 @@
   resolved "https://registry.yarnpkg.com/@clickhouse/client-common/-/client-common-0.2.10.tgz#62f454d2cc2ee27a325034a2cca47c6f5c90d22e"
   integrity sha512-BvTY0IXS96y9RUeNCpKL4HUzHmY80L0lDcGN0lmUD6zjOqYMn78+xyHYJ/AIAX7JQsc+/KwFt2soZutQTKxoGQ==
 
-"@clickhouse/client-common@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@clickhouse/client-common/-/client-common-1.0.1.tgz#c7dde5eafaad8189649373ecc23354c7a32847b3"
-  integrity sha512-3L6e0foP6VOktScoi6XWMjJyOpKCWgLUYgPVxP2c7gm6Kotq+iRmmmXtXTSg7B7uozcLZycTtPfIw2d80SYsYw==
-
 "@clickhouse/client@^0.2.10":
   version "0.2.10"
   resolved "https://registry.yarnpkg.com/@clickhouse/client/-/client-0.2.10.tgz#519561f3a4fff837bb606c52abfe74e5e7e9abb3"
   integrity sha512-ZwBgzjEAFN/ogS0ym5KHVbR7Hx/oYCX01qGp2baEyfN2HM73kf/7Vp3GvMHWRy+zUXISONEtFv7UTViOXnmFrg==
   dependencies:
     "@clickhouse/client-common" "0.2.10"
-
-"@clickhouse/client@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@clickhouse/client/-/client-1.0.1.tgz#364db28d9ef9beaf19104f962c2b06090cb10468"
-  integrity sha512-fluUNnE2R7COJ6rn6DorYfi4D+AQn3t2qeBtEq37bQV3pD4EbKrBfKAwJ13e1lmMWdQ2B9bJUTMqGsRIDdWhJw==
-  dependencies:
-    "@clickhouse/client-common" "1.0.1"
 
 "@colors/colors@1.5.0":
   version "1.5.0"
@@ -2776,7 +2764,7 @@
     uuid "^8.0.0"
 
 "@growthbook/growthbook@^0.34.0":
-  version "0.36.0"
+  version "0.35.0"
   dependencies:
     dom-mutator "^0.6.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2359,17 +2359,17 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@clickhouse/client-common@0.2.10":
-  version "0.2.10"
-  resolved "https://registry.yarnpkg.com/@clickhouse/client-common/-/client-common-0.2.10.tgz#62f454d2cc2ee27a325034a2cca47c6f5c90d22e"
-  integrity sha512-BvTY0IXS96y9RUeNCpKL4HUzHmY80L0lDcGN0lmUD6zjOqYMn78+xyHYJ/AIAX7JQsc+/KwFt2soZutQTKxoGQ==
+"@clickhouse/client-common@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@clickhouse/client-common/-/client-common-1.0.1.tgz#c7dde5eafaad8189649373ecc23354c7a32847b3"
+  integrity sha512-3L6e0foP6VOktScoi6XWMjJyOpKCWgLUYgPVxP2c7gm6Kotq+iRmmmXtXTSg7B7uozcLZycTtPfIw2d80SYsYw==
 
-"@clickhouse/client@^0.2.10":
-  version "0.2.10"
-  resolved "https://registry.yarnpkg.com/@clickhouse/client/-/client-0.2.10.tgz#519561f3a4fff837bb606c52abfe74e5e7e9abb3"
-  integrity sha512-ZwBgzjEAFN/ogS0ym5KHVbR7Hx/oYCX01qGp2baEyfN2HM73kf/7Vp3GvMHWRy+zUXISONEtFv7UTViOXnmFrg==
+"@clickhouse/client@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@clickhouse/client/-/client-1.0.1.tgz#364db28d9ef9beaf19104f962c2b06090cb10468"
+  integrity sha512-fluUNnE2R7COJ6rn6DorYfi4D+AQn3t2qeBtEq37bQV3pD4EbKrBfKAwJ13e1lmMWdQ2B9bJUTMqGsRIDdWhJw==
   dependencies:
-    "@clickhouse/client-common" "0.2.10"
+    "@clickhouse/client-common" "1.0.1"
 
 "@colors/colors@1.5.0":
   version "1.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2364,12 +2364,24 @@
   resolved "https://registry.yarnpkg.com/@clickhouse/client-common/-/client-common-0.2.10.tgz#62f454d2cc2ee27a325034a2cca47c6f5c90d22e"
   integrity sha512-BvTY0IXS96y9RUeNCpKL4HUzHmY80L0lDcGN0lmUD6zjOqYMn78+xyHYJ/AIAX7JQsc+/KwFt2soZutQTKxoGQ==
 
+"@clickhouse/client-common@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@clickhouse/client-common/-/client-common-1.0.1.tgz#c7dde5eafaad8189649373ecc23354c7a32847b3"
+  integrity sha512-3L6e0foP6VOktScoi6XWMjJyOpKCWgLUYgPVxP2c7gm6Kotq+iRmmmXtXTSg7B7uozcLZycTtPfIw2d80SYsYw==
+
 "@clickhouse/client@^0.2.10":
   version "0.2.10"
   resolved "https://registry.yarnpkg.com/@clickhouse/client/-/client-0.2.10.tgz#519561f3a4fff837bb606c52abfe74e5e7e9abb3"
   integrity sha512-ZwBgzjEAFN/ogS0ym5KHVbR7Hx/oYCX01qGp2baEyfN2HM73kf/7Vp3GvMHWRy+zUXISONEtFv7UTViOXnmFrg==
   dependencies:
     "@clickhouse/client-common" "0.2.10"
+
+"@clickhouse/client@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@clickhouse/client/-/client-1.0.1.tgz#364db28d9ef9beaf19104f962c2b06090cb10468"
+  integrity sha512-fluUNnE2R7COJ6rn6DorYfi4D+AQn3t2qeBtEq37bQV3pD4EbKrBfKAwJ13e1lmMWdQ2B9bJUTMqGsRIDdWhJw==
+  dependencies:
+    "@clickhouse/client-common" "1.0.1"
 
 "@colors/colors@1.5.0":
   version "1.5.0"
@@ -2764,7 +2776,7 @@
     uuid "^8.0.0"
 
 "@growthbook/growthbook@^0.34.0":
-  version "0.35.0"
+  version "0.36.0"
   dependencies:
     dom-mutator "^0.6.0"
 


### PR DESCRIPTION
Adds `request_timeout` to be greater than max server timeout the user sets, to prevent the client timing out.

Users may still hit a load balancer limit which will throw a 504 error.