### PR TITLE
OpenVisualEditorLink - Ensure we send creds msg when bypassing checks

### DIFF
--- a/packages/front-end/components/OpenVisualEditorLink.tsx
+++ b/packages/front-end/components/OpenVisualEditorLink.tsx
@@ -9,7 +9,6 @@ import { growthbook } from "@/pages/_app";
 import Modal from "./Modal";
 import Button from "./Button";
 
-// TODO - parameterize this
 const CHROME_EXTENSION_LINK =
   "https://chrome.google.com/webstore/detail/growthbook-devtools/opemhndcehfgipokneipaafbglcecjia";
 
@@ -78,27 +77,28 @@ export async function openVisualEditor(
       });
       return { error: "NO_EXTENSION" };
     }
+  }
 
-    try {
-      const res = await apiCall<{ key: string }>("/visual-editor/key", {
-        method: "GET",
-      });
-      const apiKey = res.key;
-      window.postMessage(
-        {
-          type: "GB_REQUEST_OPEN_VISUAL_EDITOR",
-          data: {
-            apiHost,
-            apiKey,
-          },
+  try {
+    const res = await apiCall<{ key: string }>("/visual-editor/key", {
+      method: "GET",
+    });
+    const apiKey = res.key;
+    window.postMessage(
+      {
+        type: "GB_REQUEST_OPEN_VISUAL_EDITOR",
+        data: {
+          apiHost,
+          apiKey,
         },
-        window.location.origin
-      );
-      // Give time for the Chrome extension to receive the API host/key
-      await new Promise((resolve) => setTimeout(resolve, 300));
-    } catch (e) {
-      console.error("Failed to set visual editor key automatically", e);
-    }
+      },
+      window.location.origin
+    );
+
+    // Give time for the Chrome extension to receive the API host/key
+    await new Promise((resolve) => setTimeout(resolve, 300));
+  } catch (e) {
+    console.error("Failed to set visual editor key automatically", e);
   }
 
   track("Open visual editor", {


### PR DESCRIPTION
Our logic was a little to restrictive with regards to opening the Visual Editor.

This change is so that we broadcast API credits to the chrome extension when we are bypassing extension checks.

This specifically addresses the local development use case. It doesn't introduce any new security holes that didn't already exist.