### PR TITLE
Ji/fix sso

### DIFF
--- a/packages/enterprise/src/license.ts
+++ b/packages/enterprise/src/license.ts
@@ -768,6 +768,7 @@ export function getLicenseError(org: MinimalOrganization): string {
   }
 
   if (
+    !stringToBoolean(process.env.IS_CLOUD) &&
     process.env.SSO_CONFIG &&
     !planHasPremiumFeature(licenseData.plan, "sso")
   ) {

--- a/packages/enterprise/src/license.ts
+++ b/packages/enterprise/src/license.ts
@@ -780,6 +780,7 @@ export function getLicenseError(org: MinimalOrganization): string {
   }
 
   if (
+    !stringToBoolean(process.env.IS_CLOUD) &&
     stringToBoolean(process.env.IS_MULTI_ORG) &&
     !planHasPremiumFeature(licenseData.plan, "multi-org")
   ) {

--- a/packages/enterprise/test/license.test.ts
+++ b/packages/enterprise/test/license.test.ts
@@ -300,6 +300,13 @@ describe("licenseInit, getLicense, and getLicenseError", () => {
 
         expect(getLicenseError(org)).toBe("No support for multi-org");
       });
+
+      it("should not throw an error if multi-org is enabled on cloud even if the license does not support it", () => {
+        process.env.IS_MULTI_ORG = "true";
+        process.env.IS_CLOUD = "true";
+
+        expect(getLicenseError(org)).toBe("");
+      });
     });
   });
 

--- a/packages/enterprise/test/license.test.ts
+++ b/packages/enterprise/test/license.test.ts
@@ -288,6 +288,13 @@ describe("licenseInit, getLicense, and getLicenseError", () => {
         );
       });
 
+      it("should not throw an error if SSO is enabled on cloud even if the license does not support it", () => {
+        process.env.SSO_CONFIG = "true";
+        process.env.IS_CLOUD = "true";
+
+        expect(getLicenseError(org)).toBe("");
+      });
+
       it("should return multi org error if the license does not support multi org", () => {
         process.env.IS_MULTI_ORG = "true";
 


### PR DESCRIPTION
### Features and Changes

Whoops.  Cloud has multiple licenses and the env var warnings should not apply to them.

- Closes **(add link to issue here)**

### Dependencies

### Testing

yarn test
Set IS_MULTI_ORG = true
Set IS_CLOUD=true
set SSO_CONFIG=...
on both front-end and back-end/.env.local
Start server and load an organization with a Pro account.
See no errors.
