### PR TITLE
Migrates manageVisualChanges to permissionClass

### DIFF
--- a/packages/back-end/src/api/visual-changesets/postVisualChange.ts
+++ b/packages/back-end/src/api/visual-changesets/postVisualChange.ts
@@ -19,7 +19,9 @@ export const postVisualChange = createApiRequestHandler(
       throw new Error("Experiment not found");
     }
 
-    req.checkPermissions("manageVisualChanges", experiment.project);
+    if (!req.context.permissions.canCreateVisualChange(experiment)) {
+      req.context.permissions.throwPermissionError();
+    }
 
     const res = await createVisualChange(
       req.params.id,

--- a/packages/back-end/src/api/visual-changesets/putVisualChange.ts
+++ b/packages/back-end/src/api/visual-changesets/putVisualChange.ts
@@ -24,7 +24,9 @@ export const putVisualChange = createApiRequestHandler(
       throw new Error("Experiment not found");
     }
 
-    req.checkPermissions("manageVisualChanges", experiment.project);
+    if (!req.context.permissions.canUpdateVisualChange(experiment)) {
+      req.context.permissions.throwPermissionError();
+    }
 
     const res = await updateVisualChange({
       changesetId,

--- a/packages/back-end/src/api/visual-changesets/putVisualChangeset.ts
+++ b/packages/back-end/src/api/visual-changesets/putVisualChangeset.ts
@@ -30,7 +30,9 @@ export const putVisualChangeset = createApiRequestHandler(
       throw new Error("Experiment not found");
     }
 
-    req.checkPermissions("manageVisualChanges", experiment.project);
+    if (!req.context.permissions.canUpdateVisualChange(experiment)) {
+      req.context.permissions.throwPermissionError();
+    }
 
     const res = await updateVisualChangeset({
       visualChangeset,

--- a/packages/back-end/test/permissions.test.ts
+++ b/packages/back-end/test/permissions.test.ts
@@ -3278,3 +3278,158 @@ describe("PermissionsUtilClass.canReviewFeatureDrafts", () => {
     expect(permissions.canReviewFeatureDrafts({ project: "" })).toEqual(true);
   });
 });
+
+describe("PermissionsUtilClass.canCreateVisualChange", () => {
+  const testOrg: OrganizationInterface = {
+    id: "org_sktwi1id9l7z9xkjb",
+    name: "Test Org",
+    ownerEmail: "test@test.com",
+    url: "https://test.com",
+    dateCreated: new Date(),
+    invites: [],
+    members: [
+      {
+        id: "base_user_123",
+        role: "readonly",
+        dateCreated: new Date(),
+        limitAccessByEnvironment: false,
+        environments: [],
+        projectRoles: [],
+        teams: [],
+      },
+    ],
+    settings: {
+      environments: [
+        { id: "development" },
+        { id: "staging" },
+        { id: "production" },
+      ],
+    },
+  };
+
+  it("User with global visualEditor role able to createVisualChange", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("visualEditor", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(permissions.canCreateVisualChange({})).toEqual(true);
+  });
+
+  it("User with global collaborator role not able to createVisualChange", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("collaborator", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(permissions.canCreateVisualChange({})).toEqual(false);
+  });
+
+  it("User with global collaborator role and project-specific visualEditor role able to createVisualChange", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("collaborator", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {
+          ABC123: {
+            permissions: roleToPermissionMap("visualEditor", testOrg),
+            limitAccessByEnvironment: false,
+            environments: [],
+          },
+        },
+      },
+      false
+    );
+
+    expect(permissions.canCreateVisualChange({ project: "ABC123" })).toEqual(
+      true
+    );
+  });
+
+  it("User with global collaborator role and project-specific visualEditor role not able to createVisualChange if experiment is not in a project", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("collaborator", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {
+          ABC123: {
+            permissions: roleToPermissionMap("visualEditor", testOrg),
+            limitAccessByEnvironment: false,
+            environments: [],
+          },
+        },
+      },
+      false
+    );
+
+    expect(permissions.canCreateVisualChange({})).toEqual(false);
+  });
+
+  it("user with global engineer role able to createVisualChange", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("engineer", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(permissions.canCreateVisualChange({})).toEqual(true);
+  });
+
+  it("user with global analyst role able to createVisualChange", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("analyst", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(permissions.canCreateVisualChange({})).toEqual(true);
+  });
+
+  it("user with global experimenter role able to createVisualChange", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("experimenter", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(permissions.canCreateVisualChange({})).toEqual(true);
+  });
+});

--- a/packages/shared/src/permissions/permissionsClass.ts
+++ b/packages/shared/src/permissions/permissionsClass.ts
@@ -2,6 +2,7 @@ import { FeatureInterface } from "back-end/types/feature";
 import { MetricInterface } from "back-end/types/metric";
 import { Permission, UserPermissions } from "back-end/types/organization";
 import { IdeaInterface } from "back-end/types/idea";
+import { ExperimentInterface } from "back-end/types/experiment";
 import { READ_ONLY_PERMISSIONS } from "./permissions.utils";
 class PermissionError extends Error {
   constructor(message: string) {
@@ -17,6 +18,24 @@ export class Permissions {
     this.userPermissions = permissions;
     this.superAdmin = superAdmin;
   }
+
+  public canCreateVisualChange = (
+    experiment: Pick<ExperimentInterface, "project">
+  ): boolean => {
+    return this.checkProjectFilterPermission(
+      { projects: experiment.project ? [experiment.project] : [] },
+      "manageVisualChanges"
+    );
+  };
+
+  public canUpdateVisualChange = (
+    experiment: Pick<ExperimentInterface, "project">
+  ): boolean => {
+    return this.checkProjectFilterPermission(
+      { projects: experiment.project ? [experiment.project] : [] },
+      "manageVisualChanges"
+    );
+  };
 
   // This is a helper method to use on the frontend to determine whether or not to show certain UI elements
   public canViewIdeaModal = (project?: string): boolean => {


### PR DESCRIPTION
### Features and Changes

This is a relatively simple migration that moves the `manageVisualChanges` permission to the permissionClass, and in doing so, introduces two, finer-grained helper methods: `canCreateVisualChange` and `canUpdateVisualChange` - both of which take in an experiment, and use the `experiment.project` to determine the user's permission level.

### Testing

- See test suite
