### PR TITLE
Fix airgapped licenses made with env var

### DIFF
--- a/packages/enterprise/src/license.ts
+++ b/packages/enterprise/src/license.ts
@@ -752,7 +752,8 @@ export function resetInMemoryLicenseCache(): void {
 }
 
 export function getLicenseError(org: MinimalOrganization): string {
-  const licenseData = getLicense(org.licenseKey);
+  const key = org.licenseKey || process.env.LICENSE_KEY;
+  const licenseData = getLicense(key);
 
   // If there is no license it can't have an error
   // Licenses might not have a plan if sign up for pro, but abandon checkout
@@ -792,7 +793,7 @@ export function getLicenseError(org: MinimalOrganization): string {
     return "License expired";
   }
 
-  if (!isAirGappedLicenseKey(org.licenseKey) && !licenseData.emailVerified) {
+  if (!isAirGappedLicenseKey(key) && !licenseData.emailVerified) {
     return "Email not verified";
   }
 

--- a/packages/enterprise/test/license.test.ts
+++ b/packages/enterprise/test/license.test.ts
@@ -217,6 +217,15 @@ describe("licenseInit, getLicense, and getLicenseError", () => {
         };
         expect(getLicenseError(org_with_old_style_license)).toBe("");
       });
+
+      it("should not throw an error if it is an old syle license in the env var", () => {
+        jest.setSystemTime(old_license_now);
+        process.env.LICENSE_KEY = oldLicenseKey;
+        const org_with_old_style_license = {
+          id: "org_123",
+        };
+        expect(getLicenseError(org_with_old_style_license)).toBe("");
+      });
     });
 
     describe("when there is a license but the org does not match", () => {


### PR DESCRIPTION
### Features and Changes
Airgapped licenses where the license key was set by an env var was not checked.

### Testing

`yarn test`
Set LICENSE_KEY=old style license
restart back-end service
load a page and see the full license tag with no error message.