### PR TITLE
Undo re-flipping risk for inverse metrics

### DIFF
--- a/packages/front-end/components/Experiment/BreakDownResults.tsx
+++ b/packages/front-end/components/Experiment/BreakDownResults.tsx
@@ -16,8 +16,8 @@ import {
   applyMetricOverrides,
   setAdjustedPValuesOnResults,
   ExperimentTableRow,
-  useRiskVariation,
   setAdjustedCIs,
+  hasRisk,
 } from "@/services/experiments";
 import ResultsTable from "@/components/Experiment/ResultsTable";
 import { QueryStatusData } from "@/components/Queries/RunQueriesButton";
@@ -164,8 +164,7 @@ const BreakDownResults: FC<{
     metricFilter,
   ]);
 
-  const risk = useRiskVariation(
-    variations.length,
+  const _hasRisk = hasRisk(
     ([] as ExperimentTableRow[]).concat(...tables.map((t) => t.rows))
   );
 
@@ -215,7 +214,7 @@ const BreakDownResults: FC<{
               rows={table.rows}
               dimension={dimension}
               id={table.metric.id}
-              hasRisk={risk.hasRisk}
+              hasRisk={_hasRisk}
               tableRowAxis="dimension" // todo: dynamic grouping?
               labelHeader={
                 <div style={{ marginBottom: 2 }}>

--- a/packages/front-end/components/Experiment/CompactResults.tsx
+++ b/packages/front-end/components/Experiment/CompactResults.tsx
@@ -20,8 +20,8 @@ import {
   applyMetricOverrides,
   setAdjustedPValuesOnResults,
   ExperimentTableRow,
-  useRiskVariation,
   setAdjustedCIs,
+  hasRisk,
 } from "@/services/experiments";
 import { GBCuped } from "@/components/Icons";
 import { QueryStatusData } from "@/components/Queries/RunQueriesButton";
@@ -203,7 +203,6 @@ const CompactResults: FC<{
     const vars = results?.variations;
     return variations.map((v, i) => vars?.[i]?.users || 0);
   }, [results, variations]);
-  const risk = useRiskVariation(variations.length, rows);
 
   return (
     <>
@@ -258,7 +257,7 @@ const CompactResults: FC<{
         baselineRow={baselineRow}
         rows={rows.filter((r) => !r.isGuardrail)}
         id={id}
-        hasRisk={risk.hasRisk}
+        hasRisk={hasRisk(rows)}
         tableRowAxis="metric"
         labelHeader="Goal Metrics"
         editMetrics={editMetrics}
@@ -288,7 +287,7 @@ const CompactResults: FC<{
             baselineRow={baselineRow}
             rows={rows.filter((r) => r.isGuardrail)}
             id={id}
-            hasRisk={risk.hasRisk}
+            hasRisk={hasRisk(rows)}
             tableRowAxis="metric"
             labelHeader="Guardrail Metrics"
             editMetrics={editMetrics}

--- a/packages/front-end/services/experiments.ts
+++ b/packages/front-end/services/experiments.ts
@@ -129,7 +129,7 @@ export function getRisk(
   // separate CR because sometimes "baseline" above is the variation
   baselineCR: number
 ): { risk: number; relativeRisk: number; showRisk: boolean } {
-  const risk = stats.risk?.[1]?? 0;
+  const risk = stats.risk?.[1] ?? 0;
   const relativeRisk = baselineCR ? risk / baselineCR : 0;
   const showRisk =
     baseline.cr > 0 &&
@@ -178,9 +178,7 @@ export function getRiskByVariation(
   }
 }
 
-export function hasRisk(
-  rows: ExperimentTableRow[]
-) {
+export function hasRisk(rows: ExperimentTableRow[]) {
   return rows.filter((row) => row.variations[1]?.risk?.length).length > 0;
 }
 


### PR DESCRIPTION
### FE bugfix for risk for inverse metrics

Both our stats engine AND our FE after some recent refactors were flipping "risk" for inverse metrics, meaning we were flipping it, and then flipping it back.

This PR undoes this by having the FE receive risk as expected for inverse metrics from the stats engine (which is the same as how it deals with ChanceToWin, which also is returned from the stats engine depending on `inverse`). Users will have their FE reflect the right data as soon as they get this PR in their GrowthBook.

But note that the results data in the DB depend on `metric.inverse` for both chance to win and risk, which means if the metric def changes you have to refresh results to get the UI to show the right data.

### Rip out unused risk code

Also noticed we had some duplicated risk logic that was never used; we only used a duplication of the business logic computing relative risk depending on `inverse` to check if risk existed (in the old `useRiskVariations` method). I simplified this to just check `hasRisk` which was all that method was used for anyways (presumably after ripping out the old results UI).

### Screenshots

Bugged before
<img width="1289" alt="Screenshot 2024-04-08 at 10 09 23 AM" src="https://github.com/growthbook/growthbook/assets/5298599/d361362e-a863-4b2a-ad9d-9009a752b006">

Fixed after (no need to re-run results).
<img width="1250" alt="Screenshot 2024-04-08 at 10 09 53 AM" src="https://github.com/growthbook/growthbook/assets/5298599/744c4653-3130-4437-915f-32cde75e4b96">
