### PR TITLE
Fetch from license server in the background

### DIFF
--- a/packages/back-end/src/controllers/license.ts
+++ b/packages/back-end/src/controllers/license.ts
@@ -32,7 +32,7 @@ export async function getLicenseData(req: AuthRequest, res: Response) {
 
   let licenseData;
 
-  if (req.organization?.licenseKey) {
+  if (req.organization?.licenseKey || process.env.LICENSE_KEY) {
     // Force refresh the license data
     licenseData = await initializeLicenseForOrg(req.organization, true);
   } else if (req.organization?.subscription) {

--- a/packages/back-end/src/controllers/stripe.ts
+++ b/packages/back-end/src/controllers/stripe.ts
@@ -30,10 +30,10 @@ import { logger } from "../util/logger";
 import { updateOrganization } from "../models/OrganizationModel";
 import { initializeLicenseForOrg } from "../services/licenseData";
 
-function withLicenseServerErrorHandling(
-  fn: (req: AuthRequest, res: Response) => Promise<void>
+function withLicenseServerErrorHandling<T>(
+  fn: (req: AuthRequest<T>, res: Response) => Promise<void>
 ) {
-  return async (req: AuthRequest, res: Response) => {
+  return async (req: AuthRequest<T>, res: Response) => {
     try {
       return await fn(req, res);
     } catch (e) {

--- a/packages/enterprise/src/license.ts
+++ b/packages/enterprise/src/license.ts
@@ -8,7 +8,7 @@ import { pick, sortBy } from "lodash";
 import AsyncLock from "async-lock";
 import { stringToBoolean } from "shared/util";
 import { ProxyAgent } from "proxy-agent";
-import { LicenseModel } from "./models/licenseModel";
+import { LicenseDocument, LicenseModel } from "./models/licenseModel";
 
 export const LICENSE_SERVER_URL =
   process.env.LICENSE_SERVER_URL ||
@@ -102,6 +102,9 @@ export interface LicenseInterface {
   archived: boolean; // True if this license has been deleted/archived
   dateUpdated: string; // Date the license was last updated
   usingMongoCache: boolean; // True if the license data was retrieved from the cache
+  firstFailedFetchDate?: Date; // Date of the first failed fetch
+  lastFailedFetchDate?: Date; // Date of the last failed fetch
+  lastServerErrorMessage?: string; // The last error message from a failed fetch
   signedChecksum: string; // Checksum of the license data signed with the private key
 }
 
@@ -330,6 +333,15 @@ function getVerifiedLicenseData(key: string): Partial<LicenseInterface> {
 }
 
 function verifyLicenseInterface(license: LicenseInterface) {
+  if (
+    license.usingMongoCache &&
+    license.firstFailedFetchDate &&
+    !license.signedChecksum
+  ) {
+    // If there has never been a successful fetch, don't verify the license, it just contains the server error message
+    return;
+  }
+
   const publicKey = getPublicKey();
 
   // In order to verify the license key, we need to strip out the fields that are not part of the signed license data
@@ -602,6 +614,54 @@ async function getLicenseDataFromServer(
   return license;
 }
 
+async function updateLicenseFromServer(
+  licenseKey: string,
+  userLicenseCodes: string[],
+  metaData: LicenseMetaData,
+  mongoCache?: LicenseDocument | null
+) {
+  let license: LicenseInterface;
+  try {
+    license = await getLicenseDataFromServer(
+      licenseKey,
+      userLicenseCodes,
+      metaData
+    );
+    createOrUpdateLicenseMongoCache(license).catch((e) => {
+      logger.error(`Error creating mongo cache: ${e}`);
+      throw e;
+    });
+  } catch (e) {
+    // attach error data to the cache so we know how long the server has been down for
+    const now = new Date();
+    if (mongoCache === undefined) {
+      // We haven't fetched the chache yet
+      mongoCache = await LicenseModel.findOne({ id: licenseKey });
+    }
+    if (mongoCache === null) {
+      // We have fetched the cache, but it doesn't exist
+      license = new LicenseModel({
+        id: licenseKey,
+        firstFailedFetchDate: now,
+      });
+    } else {
+      // At this point we know the cache exists and can't be undefined, but TS doesn't, hence the !.
+      license = mongoCache!;
+      if (!license.firstFailedFetchDate) {
+        license.firstFailedFetchDate = now;
+      }
+    }
+    license.lastFailedFetchDate = now;
+    license.lastServerErrorMessage = e.message;
+    license.usingMongoCache = true;
+    createOrUpdateLicenseMongoCache(license).catch((e) => {
+      logger.error(`Error creating mongo cache: ${e}`);
+      throw e;
+    });
+  }
+  return license;
+}
+
 export interface LicenseMetaData {
   installationId: string;
   gitSha: string;
@@ -617,6 +677,8 @@ const lock = new AsyncLock();
 // in-memory cache to avoid hitting the license server on every request
 const keyToLicenseData: Record<string, Partial<LicenseInterface>> = {};
 const keyToCacheDate: Record<string, Date> = {};
+
+export let backgroundUpdateLicenseFromServerForTests: Promise<void | LicenseInterface>;
 
 export async function licenseInit(
   licenseKey?: string,
@@ -654,45 +716,38 @@ export async function licenseInit(
 
           let license: LicenseInterface;
           const mongoCache = await LicenseModel.findOne({ id: key });
-          const oneWeekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000); // 7 days
+          const oneWeekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
           if (
-            !forceRefresh &&
-            mongoCache &&
-            new Date(mongoCache?.dateUpdated) > oneDayAgo
+            forceRefresh ||
+            !mongoCache ||
+            new Date(mongoCache.dateUpdated) < oneWeekAgo
           ) {
-            license = mongoCache.toJSON();
+            license = await updateLicenseFromServer(
+              key,
+              userLicenseCodes,
+              metaData,
+              mongoCache
+            );
           } else {
-            try {
-              license = await getLicenseDataFromServer(
+            // Use the cache
+            license = mongoCache.toJSON();
+            license.usingMongoCache = true;
+            if (new Date(mongoCache.dateUpdated) < oneDayAgo) {
+              // But if it is older than a day update it in the background
+              backgroundUpdateLicenseFromServerForTests = updateLicenseFromServer(
                 key,
                 userLicenseCodes,
-                metaData
-              );
-              createOrUpdateLicenseMongoCache(license).catch((e) => {
-                logger.error(`Error creating mongo cache: ${e}`);
-                throw e;
+                metaData,
+                mongoCache
+              ).catch((e) => {
+                logger.error(
+                  `Failed to update license ${key} in the background: ${e}`
+                );
               });
-            } catch (e) {
-              if (
-                mongoCache &&
-                new Date(mongoCache?.dateUpdated) > oneWeekAgo
-              ) {
-                logger.warn(
-                  "Could not connect to license server. Falling back to cache."
-                );
-                license = mongoCache.toJSON();
-              } else if (mongoCache) {
-                throw new Error(
-                  "License server is not working and cached license data is too old"
-                );
-              } else {
-                throw e;
-              }
             }
           }
 
           verifyLicenseInterface(license);
-
           keyToLicenseData[key] = license;
           keyToCacheDate[key] = new Date();
         } else {
@@ -761,8 +816,22 @@ export function getLicenseError(org: MinimalOrganization): string {
   }
 
   if (licenseData.usingMongoCache && licenseData.dateUpdated) {
-    const oneWeekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
-    if (new Date(licenseData.dateUpdated) < oneWeekAgo) {
+    const dateUpdated = new Date(licenseData.dateUpdated);
+
+    let cachedDataGoodUntil = new Date(
+      dateUpdated.getTime() + 7 * 24 * 60 * 60 * 1000
+    );
+    if (
+      licenseData.firstFailedFetchDate &&
+      licenseData.firstFailedFetchDate < cachedDataGoodUntil
+    ) {
+      // As long as the first failed fetch date is within the last week, we allow the cache to be used for seven days from the first failed fetch
+      cachedDataGoodUntil = new Date(
+        licenseData.firstFailedFetchDate.getTime() + 7 * 24 * 60 * 60 * 1000
+      );
+    }
+
+    if (new Date() > cachedDataGoodUntil) {
       return "License server down for too long";
     }
   }

--- a/packages/enterprise/src/models/licenseModel.ts
+++ b/packages/enterprise/src/models/licenseModel.ts
@@ -40,6 +40,9 @@ const licenseSchema = new mongoose.Schema({
     of: { _id: false, date: Date, userHashes: [String] },
   }, // Map of first 7 chars of user email shas to the last time they were in a usage request
   usingMongoCache: { type: Boolean, default: true }, // True if the license is using the mongo cache
+  firstFailedFetchDate: Date, // Date of the first failed fetch
+  lastFailedFetchDate: Date, // Date of the last failed fetch
+  lastServerErrorMessage: String, // The last error message from a failed fetch
   signedChecksum: String, // Checksum of the license key
   dateCreated: Date, // Date the license was issued
   dateExpires: Date, // Date the license expires

--- a/packages/enterprise/test/license.test.ts
+++ b/packages/enterprise/test/license.test.ts
@@ -7,15 +7,18 @@ import {
   getLicense,
   resetInMemoryLicenseCache,
   getLicenseError,
+  backgroundUpdateLicenseFromServerForTests,
 } from "../src/license";
-import { LicenseModel } from "../src/models/licenseModel";
+import * as LicenseModelModule from "../src/models/licenseModel";
+
+const LicenseModel = LicenseModelModule.LicenseModel;
 
 jest.mock("node-fetch");
 jest.mock("../src/models/licenseModel");
 
 const mockedFetch = fetch as jest.MockedFunction<typeof fetch>;
 
-describe("licenseInit, getLicense, and getLicenseError", () => {
+describe("src/license", () => {
   const env = process.env;
   const userLicenseCodes = ["code1", "code2"];
   const metaData = {
@@ -107,13 +110,6 @@ describe("licenseInit, getLicense, and getLicenseError", () => {
     expect(LICENSE_SERVER_URL).not.toContain("localhost");
   });
 
-  it("should set licenseData to null if licenseKey is not provided", async () => {
-    const result = await licenseInit(undefined, userLicenseCodes, metaData);
-
-    expect(result).toBeUndefined();
-    expect(getLicense()).toBeNull();
-  });
-
   describe("getLicenseError", () => {
     const org = { id: "org_id", licenseKey };
 
@@ -145,13 +141,59 @@ describe("licenseInit, getLicense, and getLicenseError", () => {
       });
     });
 
-    describe("when there is a license but it is too out of date", () => {
+    describe("when there is a license, and it is using cache but it is way too out of date", () => {
       const licenseDataTooOld = {
         ...cloneDeep(licenseData),
         usingMongoCache: true,
         dateUpdated: new Date(
-          now.getTime() - 8 * 24 * 60 * 60 * 1000
+          now.getTime() - 15 * 24 * 60 * 60 * 1000
         ).toISOString(),
+      };
+
+      beforeEach(async () => {
+        const mockedResponse: Response = ({
+          ok: true,
+          json: jest.fn().mockResolvedValueOnce(licenseDataTooOld),
+        } as unknown) as Response;
+
+        mockedFetch.mockResolvedValueOnce(Promise.resolve(mockedResponse));
+        await licenseInit(licenseKey, userLicenseCodes, metaData);
+      });
+
+      it("should return an error saying the server is down too long", () => {
+        expect(getLicenseError(org)).toBe("License server down for too long");
+      });
+    });
+
+    describe("when there is a license, and it is using cache and it is out of date, but it is less than 7 days since the first failed fetch", () => {
+      const licenseDataTooOld = {
+        ...cloneDeep(licenseData),
+        usingMongoCache: true,
+        firstFailedFetchDate: new Date(now.getTime() - 6 * 24 * 60 * 60 * 1000),
+        dateUpdated: new Date(now.getTime() - 12 * 24 * 60 * 60 * 1000),
+      };
+
+      beforeEach(async () => {
+        const mockedResponse: Response = ({
+          ok: true,
+          json: jest.fn().mockResolvedValueOnce(licenseDataTooOld),
+        } as unknown) as Response;
+
+        mockedFetch.mockResolvedValueOnce(Promise.resolve(mockedResponse));
+        await licenseInit(licenseKey, userLicenseCodes, metaData);
+      });
+
+      it("should still use cache (but we will show a warning)", () => {
+        expect(getLicenseError(org)).toBe("");
+      });
+    });
+
+    describe("when there is a license, and it is using cache and it is out of date, but it is more than 7 days since the first failed fetch", () => {
+      const licenseDataTooOld = {
+        ...cloneDeep(licenseData),
+        usingMongoCache: true,
+        firstFailedFetchDate: new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000),
+        dateUpdated: new Date(now.getTime() - 12 * 24 * 60 * 60 * 1000),
       };
 
       beforeEach(async () => {
@@ -310,428 +352,544 @@ describe("licenseInit, getLicense, and getLicenseError", () => {
     });
   });
 
-  describe("new style licenses where licenseKey starts with 'license_'", () => {
-    describe("and when the license server is up", () => {
-      beforeEach(() => {
-        const mockedResponse: Response = ({
-          ok: true,
-          json: jest.fn().mockResolvedValueOnce(licenseData),
-        } as unknown) as Response;
+  describe("licenseInit and getLicense", () => {
+    it("should set licenseData to null if licenseKey is not provided", async () => {
+      const result = await licenseInit(undefined, userLicenseCodes, metaData);
 
-        mockedFetch.mockResolvedValueOnce(Promise.resolve(mockedResponse));
-      });
-
-      it("should use the env variable if licenseKey argument is not provided", async () => {
-        process.env.LICENSE_KEY = licenseKey;
-        const result = await licenseInit(undefined, userLicenseCodes, metaData);
-
-        expect(getLicense()).toEqual(licenseData);
-        expect(result).toEqual(licenseData);
-      });
-
-      it("should throw an error if we call the function without userLicenseCodes or metadata", async () => {
-        expect.assertions(2);
-
-        await expect(
-          licenseInit(licenseKey, userLicenseCodes, undefined)
-        ).rejects.toThrowError(
-          "Missing userLicenseCodes or metaData for license key"
-        );
-
-        await expect(
-          licenseInit(licenseKey, undefined, metaData)
-        ).rejects.toThrowError(
-          "Missing userLicenseCodes or metaData for license key"
-        );
-      });
-
-      it("should call fetch once and the second time return in-memory cached license data if it exists and is not too old", async () => {
-        await licenseInit(licenseKey, userLicenseCodes, metaData);
-
-        expect(fetch).toHaveBeenCalledWith(
-          `${LICENSE_SERVER_URL}license/${licenseKey}/check`,
-          expect.objectContaining({
-            method: "PUT",
-            headers: {
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify({
-              userHashes: userLicenseCodes,
-              metaData,
-            }),
-          })
-        );
-
-        expect(getLicense(licenseKey)).toEqual(licenseData);
-
-        await licenseInit(licenseKey, userLicenseCodes, metaData);
-        expect(getLicense(licenseKey)).toEqual(licenseData);
-        expect(fetch).toHaveBeenCalledTimes(1);
-        expect(LicenseModel.findOneAndUpdate).toHaveBeenCalledTimes(1);
-        expect(LicenseModel.findOneAndUpdate).toHaveBeenCalledWith(
-          { id: licenseKey },
-          { $set: licenseData },
-          { upsert: true }
-        );
-        expect(LicenseModel.findOne).toHaveBeenCalledTimes(1);
-      });
-
-      it("should fetch the license from datastore if it is not in memory", async () => {
-        await licenseInit(licenseKey, userLicenseCodes, metaData);
-
-        expect(fetch).toHaveBeenCalledWith(
-          `${LICENSE_SERVER_URL}license/${licenseKey}/check`,
-          expect.objectContaining({
-            method: "PUT",
-            headers: {
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify({
-              userHashes: userLicenseCodes,
-              metaData,
-            }),
-          })
-        );
-
-        expect(getLicense(licenseKey)).toEqual(licenseData);
-        resetInMemoryLicenseCache();
-        jest.spyOn(LicenseModel, "findOne").mockResolvedValue({
-          ...licenseData,
-          toJSON: () => licenseData,
-          save: jest.fn(),
-          set: jest.fn(),
-        });
-        await licenseInit(licenseKey, userLicenseCodes, metaData);
-
-        expect(getLicense(licenseKey)).toEqual(licenseData);
-        expect(fetch).toHaveBeenCalledTimes(1);
-        expect(LicenseModel.findOneAndUpdate).toHaveBeenCalledTimes(1);
-        expect(LicenseModel.findOneAndUpdate).toHaveBeenCalledWith(
-          { id: licenseKey },
-          { $set: licenseData },
-          { upsert: true }
-        );
-        expect(LicenseModel.findOne).toHaveBeenCalledTimes(2);
-      });
-
-      it("should fetch the license from the license server if the license is not in memory and the datastore is too old", async () => {
-        await licenseInit(licenseKey, userLicenseCodes, metaData);
-
-        expect(fetch).toHaveBeenCalledWith(
-          `${LICENSE_SERVER_URL}license/${licenseKey}/check`,
-          expect.objectContaining({
-            method: "PUT",
-            headers: {
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify({
-              userHashes: userLicenseCodes,
-              metaData,
-            }),
-          })
-        );
-
-        expect(getLicense(licenseKey)).toEqual(licenseData);
-
-        jest.spyOn(LicenseModel, "findOne").mockResolvedValue({
-          ...licenseData,
-          toJSON: () => licenseData,
-          save: jest.fn(),
-          set: jest.fn(),
-        });
-
-        const twoDaysFromNow = now.getTime() + 2 * 24 * 60 * 60 * 1000;
-        jest.setSystemTime(twoDaysFromNow);
-
-        const mockedResponse2: Response = ({
-          ok: true,
-          json: jest.fn().mockResolvedValueOnce(licenseData2),
-        } as unknown) as Response; // Create a mock Response object
-
-        mockedFetch.mockResolvedValueOnce(Promise.resolve(mockedResponse2));
-
-        await licenseInit(licenseKey, userLicenseCodes, metaData);
-        expect(getLicense(licenseKey)).toEqual(licenseData2);
-        expect(fetch).toHaveBeenCalledTimes(2);
-      });
-
-      it("should call fetch once for each key when called with multiple keys simultaneously, and getLicense should return correct licenseData for each key", async () => {
-        mockedFetch.mockReset(); // this test is different from the others
-
-        const licenseKey2 = "license_19exntswvlosvp1dasdfads";
-        const mockedResponse: Response = ({
-          ok: true,
-          json: jest.fn().mockResolvedValueOnce(licenseData),
-        } as unknown) as Response;
-
-        const licenseData3 = cloneDeep(licenseData2);
-        licenseData3.id = licenseKey2;
-
-        const mockedResponse2: Response = ({
-          ok: true,
-          json: jest.fn().mockResolvedValueOnce(licenseData3),
-        } as unknown) as Response;
-
-        mockedFetch
-          .mockResolvedValueOnce(Promise.resolve(mockedResponse))
-          .mockResolvedValueOnce(Promise.resolve(mockedResponse2));
-
-        // Number of concurrent requests
-        const numRequests = 10;
-
-        // Execute multiple concurrent requests
-        const results = await Promise.all(
-          Array.from({ length: numRequests }).map(async (_, i) => {
-            if (i % 2 === 0) {
-              return await licenseInit(licenseKey, userLicenseCodes, metaData);
-            } else {
-              return await licenseInit(licenseKey2, userLicenseCodes, metaData);
-            }
-          })
-        );
-
-        expect(fetch).toHaveBeenCalledTimes(2);
-
-        expect(results[0]).toEqual(licenseData);
-        expect(results[1]).toEqual(licenseData3);
-        expect(
-          results.every((result, i) =>
-            i % 2 === 0 ? result === licenseData : result === licenseData3
-          )
-        ).toBe(true);
-
-        expect(getLicense(licenseKey)).toEqual(licenseData);
-        expect(getLicense(licenseKey2)).toEqual(licenseData3);
-      });
-
-      it("should call fetch twice rather than use the in-memory cache if it has been over a day since the last fetch, and update the licenseData", async () => {
-        await licenseInit(licenseKey, userLicenseCodes, metaData);
-
-        expect(fetch).toHaveBeenCalledWith(
-          `${LICENSE_SERVER_URL}license/${licenseKey}/check`,
-          expect.objectContaining({
-            method: "PUT",
-            headers: {
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify({
-              userHashes: userLicenseCodes,
-              metaData,
-            }),
-          })
-        );
-
-        expect(getLicense(licenseKey)).toEqual(licenseData);
-        const tenDaysFromNow = now.getTime() + 10 * 24 * 60 * 60 * 1000;
-        jest.setSystemTime(tenDaysFromNow);
-
-        const mockedResponse2: Response = ({
-          ok: true,
-          json: jest.fn().mockResolvedValueOnce(licenseData2),
-        } as unknown) as Response; // Create a mock Response object
-
-        mockedFetch.mockResolvedValueOnce(Promise.resolve(mockedResponse2));
-
-        await licenseInit(licenseKey, userLicenseCodes, metaData);
-        expect(getLicense(licenseKey)).toEqual(licenseData2);
-        expect(fetch).toHaveBeenCalledTimes(2);
-      });
-
-      it("should call fetch twice rather than use the in-memory cache if forceRefresh flag is true", async () => {
-        await licenseInit(licenseKey, userLicenseCodes, metaData);
-
-        expect(getLicense(licenseKey)).toEqual(licenseData);
-
-        const mockedResponse2: Response = ({
-          ok: true,
-          json: jest.fn().mockResolvedValueOnce(licenseData2),
-        } as unknown) as Response; // Create a mock Response object
-
-        jest.spyOn(LicenseModel, "findOne").mockResolvedValue({
-          ...licenseData,
-          toJSON: () => licenseData,
-          save: jest.fn(),
-          set: jest.fn(),
-        });
-
-        mockedFetch.mockResolvedValueOnce(Promise.resolve(mockedResponse2));
-
-        await licenseInit(licenseKey, userLicenseCodes, metaData, true);
-        expect(getLicense(licenseKey)).toEqual(licenseData2);
-        expect(fetch).toHaveBeenCalledTimes(2);
-      });
-
-      it("should throw an error if the data doesn't match the signature", async () => {
-        mockedFetch.mockReset(); // this test's fetch result should be different from the others
-        const licenseDateWithBadSignature = cloneDeep(licenseData);
-        licenseDateWithBadSignature.signedChecksum = "bad signature";
-        const mockedResponse3: Response = ({
-          ok: true,
-          json: jest.fn().mockResolvedValueOnce(licenseDateWithBadSignature),
-        } as unknown) as Response; // Create a mock Response object
-
-        mockedFetch.mockResolvedValueOnce(Promise.resolve(mockedResponse3));
-
-        await expect(
-          async () => await licenseInit(licenseKey, userLicenseCodes, metaData)
-        ).rejects.toThrowError("Invalid license key signature");
-      });
+      expect(result).toBeUndefined();
+      expect(getLicense()).toBeNull();
     });
 
-    describe("and when the license server is down", () => {
-      beforeEach(() => {
-        const mockedResponse: Response = ({
-          ok: false,
-          statusText: "internal server error",
-          text: jest.fn().mockResolvedValueOnce("internal server error"),
-        } as unknown) as Response; // Create a mock Response object
+    describe("new style licenses where licenseKey starts with 'license_'", () => {
+      describe("and when the license server is up", () => {
+        beforeEach(() => {
+          const mockedResponse: Response = ({
+            ok: true,
+            json: jest.fn().mockResolvedValueOnce(licenseData),
+          } as unknown) as Response;
 
-        mockedFetch.mockResolvedValueOnce(Promise.resolve(mockedResponse));
-      });
+          mockedFetch.mockResolvedValueOnce(Promise.resolve(mockedResponse));
 
-      afterEach(() => {
-        mockedFetch.mockReset();
-      });
+          jest.spyOn(LicenseModel, "findOne").mockResolvedValueOnce(null);
+        });
 
-      describe("and when there is no cached data in LicenseModel", () => {
-        it("should throw error if the license server is down and there is no cached data in LicenseModel", async () => {
+        it("should use the env variable if licenseKey argument is not provided", async () => {
+          process.env.LICENSE_KEY = licenseKey;
+          const result = await licenseInit(
+            undefined,
+            userLicenseCodes,
+            metaData
+          );
+
+          expect(getLicense()).toEqual(licenseData);
+          expect(result).toEqual(licenseData);
+        });
+
+        it("should throw an error if we call the function without userLicenseCodes or metadata", async () => {
+          expect.assertions(2);
+
           await expect(
-            async () =>
-              await licenseInit(licenseKey, userLicenseCodes, metaData)
+            licenseInit(licenseKey, userLicenseCodes, undefined)
           ).rejects.toThrowError(
-            "License server errored with: internal server error"
+            "Missing userLicenseCodes or metaData for license key"
+          );
+
+          await expect(
+            licenseInit(licenseKey, undefined, metaData)
+          ).rejects.toThrowError(
+            "Missing userLicenseCodes or metaData for license key"
           );
         });
-      });
 
-      describe("and when there is cached data in LicenseModel", () => {
-        beforeEach(() => {
+        it("should call fetch once and the second time return in-memory cached license data if it exists and is not too old", async () => {
+          await licenseInit(licenseKey, userLicenseCodes, metaData);
+
+          expect(fetch).toHaveBeenCalledWith(
+            `${LICENSE_SERVER_URL}license/${licenseKey}/check`,
+            expect.objectContaining({
+              method: "PUT",
+              headers: {
+                "Content-Type": "application/json",
+              },
+              body: JSON.stringify({
+                userHashes: userLicenseCodes,
+                metaData,
+              }),
+            })
+          );
+
+          expect(getLicense(licenseKey)).toEqual(licenseData);
+
+          await licenseInit(licenseKey, userLicenseCodes, metaData);
+          expect(getLicense(licenseKey)).toEqual(licenseData);
+          expect(fetch).toHaveBeenCalledTimes(1);
+          expect(LicenseModel.findOneAndUpdate).toHaveBeenCalledTimes(1);
+          expect(LicenseModel.findOneAndUpdate).toHaveBeenCalledWith(
+            { id: licenseKey },
+            { $set: licenseData },
+            { upsert: true }
+          );
+          expect(LicenseModel.findOne).toHaveBeenCalledTimes(1);
+        });
+
+        it("should fetch the license from datastore if it is not in memory", async () => {
+          await licenseInit(licenseKey, userLicenseCodes, metaData);
+
+          expect(fetch).toHaveBeenCalledWith(
+            `${LICENSE_SERVER_URL}license/${licenseKey}/check`,
+            expect.objectContaining({
+              method: "PUT",
+              headers: {
+                "Content-Type": "application/json",
+              },
+              body: JSON.stringify({
+                userHashes: userLicenseCodes,
+                metaData,
+              }),
+            })
+          );
+
+          expect(getLicense(licenseKey)).toEqual(licenseData);
+          resetInMemoryLicenseCache();
+          jest.spyOn(LicenseModel, "findOne").mockResolvedValue({
+            ...licenseData,
+            toJSON: function () {
+              return { ...licenseData };
+            },
+          });
+          await licenseInit(licenseKey, userLicenseCodes, metaData);
+
+          expect(getLicense(licenseKey)).toEqual({
+            ...licenseData,
+            usingMongoCache: true,
+          });
+          expect(fetch).toHaveBeenCalledTimes(1);
+          expect(LicenseModel.findOneAndUpdate).toHaveBeenCalledTimes(1);
+          expect(LicenseModel.findOneAndUpdate).toHaveBeenCalledWith(
+            { id: licenseKey },
+            { $set: licenseData },
+            { upsert: true }
+          );
+          expect(LicenseModel.findOne).toHaveBeenCalledTimes(2);
+        });
+
+        it("should fetch the license from the license server if the license is not in memory and the datastore is too old", async () => {
+          await licenseInit(licenseKey, userLicenseCodes, metaData);
+
+          expect(fetch).toHaveBeenCalledWith(
+            `${LICENSE_SERVER_URL}license/${licenseKey}/check`,
+            expect.objectContaining({
+              method: "PUT",
+              headers: {
+                "Content-Type": "application/json",
+              },
+              body: JSON.stringify({
+                userHashes: userLicenseCodes,
+                metaData,
+              }),
+            })
+          );
+
+          expect(getLicense(licenseKey)).toEqual(licenseData);
+
           jest.spyOn(LicenseModel, "findOne").mockResolvedValue({
             ...licenseData,
             toJSON: () => licenseData,
             save: jest.fn(),
             set: jest.fn(),
           });
-        });
 
-        it("should return cache from LicenseModel if the license server is down and a cache exists in licenseModel that is less than 7 days", async () => {
-          jest.setSystemTime(now.getTime() + 2 * 24 * 60 * 60 * 1000);
-          const mockedResponse: Response = ({
-            ok: false,
+          const twoDaysFromNow = now.getTime() + 8 * 24 * 60 * 60 * 1000;
+          jest.setSystemTime(twoDaysFromNow);
+
+          const mockedResponse2: Response = ({
+            ok: true,
+            json: jest.fn().mockResolvedValueOnce(licenseData2),
           } as unknown) as Response; // Create a mock Response object
 
-          mockedFetch.mockResolvedValueOnce(Promise.resolve(mockedResponse));
+          mockedFetch.mockResolvedValueOnce(Promise.resolve(mockedResponse2));
+
+          await licenseInit(licenseKey, userLicenseCodes, metaData);
+          expect(getLicense(licenseKey)).toEqual(licenseData2);
+          expect(fetch).toHaveBeenCalledTimes(2);
+        });
+
+        it("should call fetch once for each key when called with multiple keys simultaneously, and getLicense should return correct licenseData for each key", async () => {
+          mockedFetch.mockReset(); // this test is different from the others
+
+          const mockedResponse: Response = ({
+            ok: true,
+            json: jest.fn().mockResolvedValueOnce(licenseData),
+          } as unknown) as Response;
+
+          const licenseKey2 = "license_19exntswvlosvp1dasdfads";
+          const licenseData3 = cloneDeep(licenseData2);
+          licenseData3.id = licenseKey2;
+
+          const mockedResponse2: Response = ({
+            ok: true,
+            json: jest.fn().mockResolvedValueOnce(licenseData3),
+          } as unknown) as Response;
+
+          mockedFetch.mockImplementation((url) => {
+            const urlString = String(url);
+            if (urlString.includes(licenseKey)) {
+              return Promise.resolve(mockedResponse);
+            } else if (urlString.includes(licenseKey2)) {
+              return Promise.resolve(mockedResponse2);
+            }
+            return Promise.reject({} as Response);
+          });
+
+          // Number of concurrent requests
+          const numRequests = 10;
+
+          // Execute multiple concurrent requests
+          const results = await Promise.all(
+            Array.from({ length: numRequests }).map(async (_, i) => {
+              if (i % 2 === 0) {
+                return await licenseInit(
+                  licenseKey,
+                  userLicenseCodes,
+                  metaData
+                );
+              } else {
+                return await licenseInit(
+                  licenseKey2,
+                  userLicenseCodes,
+                  metaData
+                );
+              }
+            })
+          );
+
+          expect(fetch).toHaveBeenCalledTimes(2);
+
+          expect(results[0]).toEqual(licenseData);
+          expect(results[1]).toEqual(licenseData3);
+          expect(
+            results.every((result, i) =>
+              i % 2 === 0 ? result === licenseData : result === licenseData3
+            )
+          ).toBe(true);
+
+          expect(getLicense(licenseKey)).toEqual(licenseData);
+          expect(getLicense(licenseKey2)).toEqual(licenseData3);
+        });
+
+        it("should call fetch twice rather than use the in-memory cache if it has been over a day since the last fetch, and update the licenseData", async () => {
+          await licenseInit(licenseKey, userLicenseCodes, metaData);
+
+          expect(fetch).toHaveBeenCalledWith(
+            `${LICENSE_SERVER_URL}license/${licenseKey}/check`,
+            expect.objectContaining({
+              method: "PUT",
+              headers: {
+                "Content-Type": "application/json",
+              },
+              body: JSON.stringify({
+                userHashes: userLicenseCodes,
+                metaData,
+              }),
+            })
+          );
+
+          expect(getLicense(licenseKey)).toEqual(licenseData);
+          const tenDaysFromNow = now.getTime() + 10 * 24 * 60 * 60 * 1000;
+          jest.setSystemTime(tenDaysFromNow);
+
+          const mockedResponse2: Response = ({
+            ok: true,
+            json: jest.fn().mockResolvedValueOnce(licenseData2),
+          } as unknown) as Response; // Create a mock Response object
+
+          mockedFetch.mockResolvedValueOnce(Promise.resolve(mockedResponse2));
+
+          await licenseInit(licenseKey, userLicenseCodes, metaData);
+          expect(getLicense(licenseKey)).toEqual(licenseData2);
+          expect(fetch).toHaveBeenCalledTimes(2);
+        });
+
+        it("should call fetch twice rather than use the in-memory cache if forceRefresh flag is true", async () => {
           await licenseInit(licenseKey, userLicenseCodes, metaData);
 
           expect(getLicense(licenseKey)).toEqual(licenseData);
+
+          const mockedResponse2: Response = ({
+            ok: true,
+            json: jest.fn().mockResolvedValueOnce(licenseData2),
+          } as unknown) as Response; // Create a mock Response object
+
+          jest.spyOn(LicenseModel, "findOne").mockResolvedValue({
+            ...licenseData,
+            toJSON: () => licenseData,
+            save: jest.fn(),
+            set: jest.fn(),
+          });
+
+          mockedFetch.mockResolvedValueOnce(Promise.resolve(mockedResponse2));
+
+          await licenseInit(licenseKey, userLicenseCodes, metaData, true);
+          expect(getLicense(licenseKey)).toEqual(licenseData2);
+          expect(fetch).toHaveBeenCalledTimes(2);
         });
 
-        it("should throw an error if the license server is down and a cache exists in licenseModel but it is older than 7 days.", async () => {
-          jest.setSystemTime(now.getTime() + 8 * 24 * 60 * 60 * 1000);
+        it("should throw an error if the data doesn't match the signature", async () => {
+          mockedFetch.mockReset(); // this test's fetch result should be different from the others
+          const licenseDateWithBadSignature = cloneDeep(licenseData);
+          licenseDateWithBadSignature.signedChecksum = "bad signature";
+          const mockedResponse3: Response = ({
+            ok: true,
+            json: jest.fn().mockResolvedValueOnce(licenseDateWithBadSignature),
+          } as unknown) as Response; // Create a mock Response object
+
+          mockedFetch.mockResolvedValueOnce(Promise.resolve(mockedResponse3));
 
           await expect(
             async () =>
               await licenseInit(licenseKey, userLicenseCodes, metaData)
-          ).rejects.toThrowError(
-            "License server is not working and cached license data is too old"
-          );
+          ).rejects.toThrowError("Invalid license key signature");
+        });
+      });
+
+      describe("and when the license server is down", () => {
+        beforeEach(() => {
+          const mockedResponse: Response = ({
+            ok: false,
+            statusText: "internal server error",
+            text: jest.fn().mockResolvedValue("internal server error"),
+          } as unknown) as Response;
+
+          mockedFetch.mockResolvedValue(Promise.resolve(mockedResponse));
+        });
+
+        afterEach(() => {
+          mockedFetch.mockReset();
+        });
+
+        describe("and when there is no cached data in LicenseModel", () => {
+          beforeEach(() => {
+            jest.spyOn(LicenseModel, "findOne").mockResolvedValue(null);
+
+            // Mock out the constructor so new LicenseModel(data) => data
+            jest
+              .spyOn(LicenseModelModule, "LicenseModel")
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              .mockImplementation((data: any) => {
+                return data;
+              });
+          });
+
+          it("should throw error if the license server is down and there is no cached data in LicenseModel", async () => {
+            await licenseInit(licenseKey, userLicenseCodes, metaData);
+            expect(getLicense(licenseKey)).toEqual({
+              firstFailedFetchDate: now,
+              id: "license_19exntswvlosvp1d6",
+              lastServerErrorMessage:
+                "License server errored with: internal server error",
+              lastFailedFetchDate: now,
+              usingMongoCache: true,
+            });
+          });
+        });
+
+        describe("and when there is cached data in LicenseModel", () => {
+          const mockFindOneAndUpdate = jest.fn();
+          let previousCache;
+
+          beforeEach(() => {
+            previousCache = {
+              ...licenseData,
+              toJSON: () => licenseData,
+              findOneAndUpdate: mockFindOneAndUpdate,
+            };
+            jest
+              .spyOn(LicenseModel, "findOne")
+              .mockResolvedValue(previousCache);
+          });
+
+          it("should return cache from LicenseModel if the license server is down and a cache exists in licenseModel that is less than 7 days and save the failures in the mongo cache", async () => {
+            const firstCallTime = now.getTime() + 2 * 24 * 60 * 60 * 1000;
+            jest.setSystemTime(firstCallTime);
+
+            await licenseInit(licenseKey, userLicenseCodes, metaData);
+
+            expect(getLicense(licenseKey)).toEqual(licenseData);
+
+            await backgroundUpdateLicenseFromServerForTests;
+
+            expect(LicenseModel.findOneAndUpdate).toHaveBeenCalledTimes(1);
+            expect(LicenseModel.findOneAndUpdate).toHaveBeenCalledWith(
+              { id: licenseKey },
+              {
+                $set: {
+                  ...previousCache,
+                  usingMongoCache: true,
+                  firstFailedFetchDate: new Date(firstCallTime),
+                  lastFailedFetchDate: new Date(firstCallTime),
+                  lastServerErrorMessage:
+                    "License server errored with: internal server error",
+                },
+              },
+              { upsert: true }
+            );
+
+            const mockedResponse: Response = ({
+              ok: false,
+              statusText: "different error",
+              text: jest.fn().mockResolvedValueOnce("different error"),
+            } as unknown) as Response;
+
+            mockedFetch.mockResolvedValue(Promise.resolve(mockedResponse));
+
+            const secondCallTime = now.getTime() + 4 * 24 * 60 * 60 * 1000;
+            jest.setSystemTime(secondCallTime);
+            await licenseInit(licenseKey, userLicenseCodes, metaData);
+
+            expect(getLicense(licenseKey)).toEqual(licenseData);
+            await backgroundUpdateLicenseFromServerForTests;
+
+            expect(LicenseModel.findOneAndUpdate).toHaveBeenCalledTimes(2);
+            expect(LicenseModel.findOneAndUpdate).toHaveBeenCalledWith(
+              { id: licenseKey },
+              {
+                $set: {
+                  ...previousCache,
+                  usingMongoCache: true,
+                  firstFailedFetchDate: new Date(firstCallTime),
+                  lastFailedFetchDate: new Date(secondCallTime),
+                  lastServerErrorMessage:
+                    "License server errored with: different error",
+                },
+              },
+              { upsert: true }
+            );
+
+            return Promise;
+          });
+
+          it("should return the cache that exists (getLicenseError will return a too old message)", async () => {
+            const callTime = now.getTime() + 8 * 24 * 60 * 60 * 1000;
+            jest.setSystemTime(callTime);
+
+            await licenseInit(licenseKey, userLicenseCodes, metaData);
+
+            expect(getLicense(licenseKey)).toEqual({
+              ...previousCache,
+              usingMongoCache: true,
+              firstFailedFetchDate: new Date(callTime),
+              lastFailedFetchDate: new Date(callTime),
+              lastServerErrorMessage:
+                "License server errored with: internal server error",
+            });
+          });
         });
       });
     });
-  });
 
-  describe("old style licenses where licenseKey does NOT start with 'license_' but contains the license data encoded in itself", () => {
-    it("should use the env variable if the licenseKey argument references an expired license", async () => {
-      const licenseData3 = cloneDeep(licenseData);
-      const tenDaysAgo = new Date(now);
-      tenDaysAgo.setDate(tenDaysAgo.getDate() - 10);
-      licenseData3.dateExpires = tenDaysAgo.toISOString();
-      licenseData3.signedChecksum =
-        "O8U7fSZb2eA_NIi6N5MJSxqsHNZ98E_nkoyBK7tQ_0pIGhXpQCrAy04ec_l_YLiNCVR8UKeZVQuf58_bdgBCXVQsEZSWDRSpmf_8lw3NjwHEBgh9KdDzsZVIN-bzywA27sQIsR4MS6kmZOgm2ml91WfRblCUf9q6kbXfXFBKgtt-afGUZDqYVnC-bPbZvoRKmyREpnw3u-CMlTvMPrxkpUuRCCWWcQe6o5S7LUW_L3Z9e-9kEEYC3mh2ERnjojSblR_sdSa_mDgLA20p9w0_Amhrw-6zKIi6ZyMUHHz3iUKXjvEpp4OqqHhm5Fooax07Hn4e18Om9ZisaZ22IRKeJyjjuZdGMnK3cfNhUaHkWW_FSHaDnTouQRdtA-hBP5l4ktauLKKVKuomvwunDq5-MHrcENfcUedV6eB68R0OGEi8bQVCGSnLrO48gTrQzbwVem5EAgr1n7PwpCdzZntUZfQ9QnoPhRRBPNFPGcCJih4ZlOsuDpYRpie7ritAupI7sRbuw_vk00fEBb0NAqA5pNBH7JMjUPhsUwYtXJumkbHZt8p1gz1U5A9UIgZT8rjiwHifqgOyo435M2xcHDHqPahjRDq8K11NZATNAf9AFlnIPPiYg-hHMIhugArpG-EuOsEekVQqjzGfm6CC24f6cyllhRYk22ae04cdbcm4iaA";
-      const mockedResponse3: Response = ({
-        ok: true,
-        json: jest.fn().mockResolvedValueOnce(licenseData3),
-      } as unknown) as Response;
+    describe("old style licenses where licenseKey does NOT start with 'license_' but contains the license data encoded in itself", () => {
+      it("should use the env variable if the licenseKey argument references an expired license", async () => {
+        const licenseData3 = cloneDeep(licenseData);
+        const tenDaysAgo = new Date(now);
+        tenDaysAgo.setDate(tenDaysAgo.getDate() - 10);
+        licenseData3.dateExpires = tenDaysAgo.toISOString();
+        licenseData3.signedChecksum =
+          "O8U7fSZb2eA_NIi6N5MJSxqsHNZ98E_nkoyBK7tQ_0pIGhXpQCrAy04ec_l_YLiNCVR8UKeZVQuf58_bdgBCXVQsEZSWDRSpmf_8lw3NjwHEBgh9KdDzsZVIN-bzywA27sQIsR4MS6kmZOgm2ml91WfRblCUf9q6kbXfXFBKgtt-afGUZDqYVnC-bPbZvoRKmyREpnw3u-CMlTvMPrxkpUuRCCWWcQe6o5S7LUW_L3Z9e-9kEEYC3mh2ERnjojSblR_sdSa_mDgLA20p9w0_Amhrw-6zKIi6ZyMUHHz3iUKXjvEpp4OqqHhm5Fooax07Hn4e18Om9ZisaZ22IRKeJyjjuZdGMnK3cfNhUaHkWW_FSHaDnTouQRdtA-hBP5l4ktauLKKVKuomvwunDq5-MHrcENfcUedV6eB68R0OGEi8bQVCGSnLrO48gTrQzbwVem5EAgr1n7PwpCdzZntUZfQ9QnoPhRRBPNFPGcCJih4ZlOsuDpYRpie7ritAupI7sRbuw_vk00fEBb0NAqA5pNBH7JMjUPhsUwYtXJumkbHZt8p1gz1U5A9UIgZT8rjiwHifqgOyo435M2xcHDHqPahjRDq8K11NZATNAf9AFlnIPPiYg-hHMIhugArpG-EuOsEekVQqjzGfm6CC24f6cyllhRYk22ae04cdbcm4iaA";
+        const mockedResponse3: Response = ({
+          ok: true,
+          json: jest.fn().mockResolvedValueOnce(licenseData3),
+        } as unknown) as Response;
 
-      mockedFetch.mockResolvedValueOnce(Promise.resolve(mockedResponse3));
+        mockedFetch.mockResolvedValueOnce(Promise.resolve(mockedResponse3));
 
-      process.env.LICENSE_KEY = oldLicenseKey;
-      const result = await licenseInit(licenseKey, userLicenseCodes, metaData);
+        process.env.LICENSE_KEY = oldLicenseKey;
+        const result = await licenseInit(
+          licenseKey,
+          userLicenseCodes,
+          metaData
+        );
 
-      expect(getLicense(licenseKey)).toEqual(oldLicenseData);
-      expect(result).toEqual(oldLicenseData);
-    });
+        expect(getLicense(licenseKey)).toEqual(oldLicenseData);
+        expect(result).toEqual(oldLicenseData);
+      });
 
-    it("should not use the env variable if the licenseKey argument does not reference an expired license", async () => {
-      const mockedResponse: Response = ({
-        ok: true,
-        json: jest.fn().mockResolvedValueOnce(licenseData),
-      } as unknown) as Response;
+      it("should not use the env variable if the licenseKey argument does not reference an expired license", async () => {
+        const mockedResponse: Response = ({
+          ok: true,
+          json: jest.fn().mockResolvedValueOnce(licenseData),
+        } as unknown) as Response;
 
-      mockedFetch.mockResolvedValueOnce(Promise.resolve(mockedResponse));
+        mockedFetch.mockResolvedValueOnce(Promise.resolve(mockedResponse));
 
-      process.env.LICENSE_KEY = oldLicenseKey;
-      const result = await licenseInit(licenseKey, userLicenseCodes, metaData);
+        process.env.LICENSE_KEY = oldLicenseKey;
+        const result = await licenseInit(
+          licenseKey,
+          userLicenseCodes,
+          metaData
+        );
 
-      expect(getLicense(licenseKey)).toEqual(licenseData);
-      expect(result).toEqual(licenseData);
-    });
+        expect(getLicense(licenseKey)).toEqual(licenseData);
+        expect(result).toEqual(licenseData);
+      });
 
-    it("should read license data from the key itself and use the in-memory cache if called a second time, even if a long time has passed, as old style license keys should never expire", async () => {
-      await licenseInit(oldLicenseKey);
-
-      expect(getLicense(oldLicenseKey)).toEqual(oldLicenseData);
-
-      const tenYearsFromNow =
-        old_license_now.getTime() + 10 * 365 * 24 * 60 * 60 * 1000;
-      jest.setSystemTime(tenYearsFromNow);
-      jest.spyOn(JSON, "parse").mockReturnValue({ foo: "bar" }); // This is an invalid license, but we should use the cache so won't see an error.
-
-      await licenseInit(oldLicenseKey, userLicenseCodes, metaData);
-      expect(getLicense(oldLicenseKey)).toEqual(oldLicenseData);
-    });
-
-    it("should throw an error if the data doesn't match the signature", async () => {
-      await expect(
-        async () => await licenseInit(oldLicenseKey + "extrasignature")
-      ).rejects.toThrowError("Invalid license key signature");
-    });
-
-    it("should use the old expiry date 'eat' if the new one 'exp' is not present", async () => {
-      const oldLicenseOriginalData2 = cloneDeep(oldLicenseOrginalData);
-      // @ts-expect-error Ignoring TypeScript error here because we intentionally passed malformed data for testing purposes
-      oldLicenseOriginalData2.eat = oldLicenseOriginalData2.exp;
-      // @ts-expect-error Ignoring TypeScript error here because we intentionally passed malformed data for testing purposes
-      delete oldLicenseOriginalData2.exp;
-      jest.spyOn(JSON, "parse").mockReturnValue(oldLicenseOriginalData2);
-
-      await licenseInit(oldLicenseKey);
-
-      expect(getLicense(oldLicenseKey)).toEqual(oldLicenseData);
-    });
-
-    it("should throw an error if there is no expiry date on the license", async () => {
-      const oldLicenseOriginalData2 = cloneDeep(oldLicenseOrginalData);
-      // @ts-expect-error Ignoring TypeScript error here because we intentionally passed malformed data for testing purposes
-      delete oldLicenseOriginalData2.exp;
-      jest.spyOn(JSON, "parse").mockReturnValue(oldLicenseOriginalData2);
-
-      await expect(async () => {
+      it("should read license data from the key itself and use the in-memory cache if called a second time, even if a long time has passed, as old style license keys should never expire", async () => {
         await licenseInit(oldLicenseKey);
-      }).rejects.toThrowError("Invalid License Key - Missing expiration date");
-    });
 
-    it("should automatically assume enterprise plan if no plan is specified", async () => {
-      const oldLicenseOriginalData2 = cloneDeep(oldLicenseOrginalData);
-      // @ts-expect-error Ignoring TypeScript error here because we intentionally passed malformed data for testing purposes
-      delete oldLicenseOriginalData2.plan;
-      jest.spyOn(JSON, "parse").mockReturnValue(oldLicenseOriginalData2);
+        expect(getLicense(oldLicenseKey)).toEqual(oldLicenseData);
 
-      await licenseInit(oldLicenseKey);
+        const tenYearsFromNow =
+          old_license_now.getTime() + 10 * 365 * 24 * 60 * 60 * 1000;
+        jest.setSystemTime(tenYearsFromNow);
+        jest.spyOn(JSON, "parse").mockReturnValue({ foo: "bar" }); // This is an invalid license, but we should use the cache so won't see an error.
 
-      const expected = cloneDeep(oldLicenseData);
-      expected.plan = "enterprise";
-      expect(getLicense(oldLicenseKey)).toEqual(expected);
+        await licenseInit(oldLicenseKey, userLicenseCodes, metaData);
+        expect(getLicense(oldLicenseKey)).toEqual(oldLicenseData);
+      });
+
+      it("should throw an error if the data doesn't match the signature", async () => {
+        await expect(
+          async () => await licenseInit(oldLicenseKey + "extrasignature")
+        ).rejects.toThrowError("Invalid license key signature");
+      });
+
+      it("should use the old expiry date 'eat' if the new one 'exp' is not present", async () => {
+        const oldLicenseOriginalData2 = cloneDeep(oldLicenseOrginalData);
+        // @ts-expect-error Ignoring TypeScript error here because we intentionally passed malformed data for testing purposes
+        oldLicenseOriginalData2.eat = oldLicenseOriginalData2.exp;
+        // @ts-expect-error Ignoring TypeScript error here because we intentionally passed malformed data for testing purposes
+        delete oldLicenseOriginalData2.exp;
+        jest.spyOn(JSON, "parse").mockReturnValue(oldLicenseOriginalData2);
+
+        await licenseInit(oldLicenseKey);
+
+        expect(getLicense(oldLicenseKey)).toEqual(oldLicenseData);
+      });
+
+      it("should throw an error if there is no expiry date on the license", async () => {
+        const oldLicenseOriginalData2 = cloneDeep(oldLicenseOrginalData);
+        // @ts-expect-error Ignoring TypeScript error here because we intentionally passed malformed data for testing purposes
+        delete oldLicenseOriginalData2.exp;
+        jest.spyOn(JSON, "parse").mockReturnValue(oldLicenseOriginalData2);
+
+        await expect(async () => {
+          await licenseInit(oldLicenseKey);
+        }).rejects.toThrowError(
+          "Invalid License Key - Missing expiration date"
+        );
+      });
+
+      it("should automatically assume enterprise plan if no plan is specified", async () => {
+        const oldLicenseOriginalData2 = cloneDeep(oldLicenseOrginalData);
+        // @ts-expect-error Ignoring TypeScript error here because we intentionally passed malformed data for testing purposes
+        delete oldLicenseOriginalData2.plan;
+        jest.spyOn(JSON, "parse").mockReturnValue(oldLicenseOriginalData2);
+
+        await licenseInit(oldLicenseKey);
+
+        const expected = cloneDeep(oldLicenseData);
+        expected.plan = "enterprise";
+        expect(getLicense(oldLicenseKey)).toEqual(expected);
+      });
     });
   });
 });

--- a/packages/front-end/components/Layout/AccountPlanNotices.tsx
+++ b/packages/front-end/components/Layout/AccountPlanNotices.tsx
@@ -99,7 +99,7 @@ export default function AccountPlanNotices() {
     }
   }
 
-  // Notices for accounts using a license key
+  // Notices for accounts using a license key that result in a downgrade to starter
   if (license) {
     if (licenseError) {
       switch (licenseError) {
@@ -119,12 +119,20 @@ export default function AccountPlanNotices() {
             </Tooltip>
           );
         case "License server down for too long":
-          return (
+          return license.lastServerErrorMessage?.includes(
+            "Could not connect"
+          ) ? (
             <Tooltip
               body={<>Please make sure that you have whitelisted 75.2.109.47</>}
             >
               <div className="alert alert-danger py-1 px-2 mb-0 d-none d-md-block mr-1">
                 <FaExclamationTriangle /> Could not contact license server.
+              </div>
+            </Tooltip>
+          ) : (
+            <Tooltip body={<>{license.lastServerErrorMessage}</>}>
+              <div className="alert alert-danger py-1 px-2 mb-0 d-none d-md-block mr-1">
+                <FaExclamationTriangle /> License server error.
               </div>
             </Tooltip>
           );
@@ -241,23 +249,50 @@ export default function AccountPlanNotices() {
       }
     }
 
-    if (license?.usingMongoCache) {
-      // Cache is good for a week
+    //Warnings that don't result in a downgrade
+
+    if (
+      license?.usingMongoCache &&
+      license.firstFailedFetchDate &&
+      license.lastFailedFetchDate
+    ) {
+      // Cache is good for a week from the first failed fetch date
       const cachedDataGoodUntil = new Date(
-        new Date(license.dateUpdated).getTime() + 7 * 24 * 60 * 60 * 1000
+        new Date(license.firstFailedFetchDate).getTime() +
+          7 * 24 * 60 * 60 * 1000
       );
+
       const daysLeftInCache = daysLeft(cachedDataGoodUntil.toDateString());
-      if (daysLeftInCache < 5) {
-        return (
-          <Tooltip
-            body={<>Please make sure that you have whitelisted 75.2.109.47</>}
-          >
-            <div className="alert alert-danger py-1 px-2 mb-0 d-none d-md-block mr-1">
-              <FaExclamationTriangle /> Could not contact license server. Fix
-              within {daysLeftInCache} days.
-            </div>
-          </Tooltip>
-        );
+      const daysDown =
+        daysLeft(new Date(license.lastFailedFetchDate).toDateString()) -
+        daysLeft(new Date(license.firstFailedFetchDate).toDateString());
+
+      if (daysDown > 1 && license.lastServerErrorMessage) {
+        if (license.lastServerErrorMessage.startsWith("Could not connect")) {
+          return (
+            <Tooltip
+              body={<>Please make sure that you have whitelisted 75.2.109.47</>}
+            >
+              <div className="alert alert-danger py-1 px-2 mb-0 d-none d-md-block mr-1">
+                <FaExclamationTriangle /> Could not connect to license server
+                {/*license keys specified in env vars that have never connected to the license server successfully won't have any plan and hence aren't in danger of being downgraded */}
+                {license.plan
+                  ? `. Fix within ${daysLeftInCache} day${
+                      daysLeftInCache != 1 ? "s" : ""
+                    }.`
+                  : ""}
+              </div>
+            </Tooltip>
+          );
+        } else {
+          return (
+            <Tooltip body={<>{license.lastServerErrorMessage}</>}>
+              <div className="alert alert-danger py-1 px-2 mb-0 d-none d-md-block mr-1">
+                <FaExclamationTriangle /> License server error
+              </div>
+            </Tooltip>
+          );
+        }
       }
     }
     // Trial license is almost up

--- a/packages/front-end/components/License/ShowLicenseInfo.tsx
+++ b/packages/front-end/components/License/ShowLicenseInfo.tsx
@@ -114,22 +114,23 @@ const ShowLicenseInfo: FC<{
                 {license &&
                   license.plan && ( // A license might not have a plan if a stripe pro form is not filled out
                     <>
-                      {["pro", "pro_sso"].includes(license.plan) && (
-                        <div className="col-sm-2">
-                          <div>Status:</div>
-                          <span
-                            className={`text-muted ${
-                              !["active", "trialing"].includes(
-                                license.stripeSubscription?.status || ""
-                              )
-                                ? "alert-danger"
-                                : ""
-                            }`}
-                          >
-                            {license.stripeSubscription?.status}
-                          </span>
-                        </div>
-                      )}
+                      {["pro", "pro_sso"].includes(license.plan) &&
+                        license.stripeSubscription?.status && (
+                          <div className="col-sm-2">
+                            <div>Status:</div>
+                            <span
+                              className={`text-muted ${
+                                !["active", "trialing"].includes(
+                                  license.stripeSubscription?.status || ""
+                                )
+                                  ? "alert-danger"
+                                  : ""
+                              }`}
+                            >
+                              {license.stripeSubscription?.status}
+                            </span>
+                          </div>
+                        )}
                       <div className="col-sm-2">
                         <div>Issued:</div>
                         <span className="text-muted">


### PR DESCRIPTION
### Features and Changes
The license server can take 2-7s to respond depending upon if it is a cold start, and if it is pro and hitting stripe endpoints, and if stripe is slow or not. Hence to make sure our users are never slowed down by the license server checks (except for the very initial time) we use the mongo cache first as long as the cache is less than 7 days old, and then fetch the license in the background.

This meant that any license errors won't be immediately available on the page load.  To make sure they still are able to see any error message we now save the `lastServerErrorMessage` onto the mongo cache.  We had been wanting to show the error message if the license server was down for more than 2 days, but didn't quite have that logic right since we started using the cache first.  If they fetched the license and then didn't use the license for 6 days then fetched and found the license server down we said they had 0 days to fix.  Now we also save `firstServerErrorDate` and `lastServerErrorDate` whenever we get a license server error as well.  As long as that firstServerErrorDate is within the original 7 days from the updateDate, we let them keep using the cache from 7 days from the firstServerErrorDate.  If they then don't use GB for 3 more days, then load a page again, it will again use the cache to begin with and load the license in the background.  So only then on the following load from /organization will it show that the lastServerErrorDate-firstServerError date is > 2 days and it will show the error message.

- Update the license in the background
- Save error messages into the cache
- Show error messages only if it is down for >= 2 days.
- Let them keep using the cache for 7 days, or for 7 days from the time the license server first went down, to a maximum of 14 days from the update.
- For env var pro license keys that don't have a stripeSubscription.status on them, don't show them the status field.
- Allow Refresh button to work for env var license keys
- Fixed a TS issue in controllers/stripe.ts (not sure why it didn't complain in the past)
- When the central license server throws an error, it ends up as json with "error" property as the message.  When it does a `this.response.status(500).send("active license exists");` it returns a text error message.  We now handle either format.

### Testing
`yarn test`

#### Never had a successful connect due to license server being unreachable
set LICENSE_SERVER_URL=localhost:Anything
Empty growthbook/licenses collection. 
Start server
See "Could not contact license server" in account plan notice
Hover over the notice and see "Please make sure that you have whitelisted 75.2..."

#### Never had a successful connect due to a license server error
set LICENSE_SERVER_URL=http://localhost:8080/api/v1/
start dev central license server
Go to General->Settings->License->Refresh.
See "License server error" as the AccountNotice message.
Hover over the Account Notice: see "License not found".

#### Never had a successful connect due to a license server text error
Temporarily change the central license server code to do
```
 this.response.status(500).send("License not found alt");
        return;
```
instead of throwing the error.
Go to General->Settings->License->Refresh.
See "License server error" as the AccountNotice message.
Hover over the Account Notice: see "License not found alt".
Reset Central license server code.

#### Never had a successful connect for a long time should not affect the error message show.
In MongoDb Compass growthbook.licenses collection set firstFailedFetchDate to a month earlier. (The earlier date should not affect this since it doesn't have a plan - it never had a successful connect).
Go to General->Settings->License->Refresh.
See "License server error" as the AccountNotice message.
Hover over the Account Notice: see "License not found".

#### Setting a bad license key
Go to General->Settings->License and click edit license key pencil icon.
Put in bad key and submit
See "Invalid license key" message

#### Setting a real license key then disconnecting
Put in a valid key in the licenses.newLicenses collection.
Save.
See the license plan in the AccountPlan component in the top nav.
Kill the dev central license server.
Go to General->Settings->License->Refresh.
See no change in the account plan notice (We don't want to show error message within 2 days of the server going down, to give us time to fix any problem with the server before they realize it)

#### Simulating the server being down for 2 days
In MongoDb Compass growthbook.licenses collection set `dateUpdated` to 5 days earlier, set `firstFailedFetchDate` to 3 days earlier.
Go to General->Settings->License->Refresh.
See "Could not connect to license server. Fix within 3 day." in the AccountPlanNotics
Hover over the notice and see the "Please make sure that you have whitelisted 75.2..." message.

#### Simulating the server being down for 8 days and automatically getting downgraded.
In MongoDb Compass growthbook.licenses collection set `dateUpdated` to 8 days earlier, set `firstFailedFetchDate` to 8 days earlier. 
Go to General->Settings->License->Refresh.
See "Could not connect to license server." in the AccountPlanNotice
Hover over the notice and see the "Please make sure that you have whitelisted 75.2..." message.
See no plan tag anymore in the AccountPlan component in the top nav.