### PR TITLE
Add attribute name to delete modal

### DIFF
--- a/packages/front-end/pages/attributes.tsx
+++ b/packages/front-end/pages/attributes.tsx
@@ -96,7 +96,7 @@ const FeatureAttributesPage = (): React.ReactElement => {
               displayName="Attribute"
               deleteMessage={
                 <>
-                  Are you sure you want to delete the attribute:{" "}
+                  Are you sure you want to delete the {v.datatype} attribute:{" "}
                   <code className="font-weight-bold">{v.property}</code>?
                   <br />
                   This action cannot be undone.

--- a/packages/front-end/pages/attributes.tsx
+++ b/packages/front-end/pages/attributes.tsx
@@ -96,7 +96,9 @@ const FeatureAttributesPage = (): React.ReactElement => {
               displayName="Attribute"
               deleteMessage={
                 <>
-                  Are you sure you want to delete the {v.datatype} attribute:{" "}
+                  Are you sure you want to delete the{" "}
+                  {v.hashAttribute ? "identifier " : ""}
+                  {v.datatype} attribute:{" "}
                   <code className="font-weight-bold">{v.property}</code>?
                   <br />
                   This action cannot be undone.

--- a/packages/front-end/pages/attributes.tsx
+++ b/packages/front-end/pages/attributes.tsx
@@ -94,6 +94,14 @@ const FeatureAttributesPage = (): React.ReactElement => {
             </button>
             <DeleteButton
               displayName="Attribute"
+              deleteMessage={
+                <>
+                  Are you sure you want to delete the attribute:{" "}
+                  <code className="font-weight-bold">{v.property}</code>?
+                  <br />
+                  This action cannot be undone.
+                </>
+              }
               className="dropdown-item text-danger"
               onClick={async () => {
                 await apiCall<{


### PR DESCRIPTION
Mostly fixes #2365 - does not require entering the name of the attribute, but adds the attribute name and type. 

<img width="511" alt="Screenshot 2024-04-09 at 1 13 56 PM" src="https://github.com/growthbook/growthbook/assets/46107/f68b34e4-c060-4c21-b561-1f0dc58eb090">
