### PR TITLE
reduce in memory cache to just one minute

### DIFF
--- a/packages/enterprise/src/license.ts
+++ b/packages/enterprise/src/license.ts
@@ -699,6 +699,7 @@ export async function licenseInit(
   }
 
   const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
+  const oneMinuteAgo = new Date(Date.now() - 60 * 1000);
 
   // When hitting a page for a new license we often make many simulataneous requests
   // By acquiring a lock we make sure to only call the license server once, the remaining
@@ -711,7 +712,7 @@ export async function licenseInit(
       if (
         forceRefresh ||
         !keyToLicenseData[key] ||
-        (keyToCacheDate[key] !== null && keyToCacheDate[key] <= oneDayAgo)
+        (keyToCacheDate[key] !== null && keyToCacheDate[key] <= oneMinuteAgo)
       ) {
         if (!isAirGappedLicenseKey(key)) {
           if (!userLicenseCodes || !metaData) {


### PR DESCRIPTION
### Features and Changes

There is a customer who is seeing inconsistent license behavior. I'm pretty sure that the issue now is that the in-memory caches on some of machines will have a stale cache.  This reduces the in-memory cache to just one minute, relying thereafter on the datastore cache.  Since /organization is called so often on many pages it's still possible people see inconsistent behavior right after signing up, or upping the number of customers on a license, but at least it is limited.

We could alternatively:

1. Set up session affinity. (Less than ideal as the distributions of requests won't be as even among other disadvantages).
2. Set up a redis/memcache.  Likely something we will want longer term, but not so quick to implement.
3. Get rid of the in-memory cache all together. It has the advantage of never being out of date with the datastore cache - though that may still be out of date with the license server.  The disadvantage is an extra datastore call on every page, albeit probably a quick one.

### Testing

`yarn test`
Start server.
Load webpage of an organization that has a license.
In Mongo growthbook.licenses collection change the dateCreated.
Wait a minute and reload the page.

