### PR TITLE
Add simulation class to gbstats

### DIFF
--- a/packages/stats/gbstats/devtools/simulation.py
+++ b/packages/stats/gbstats/devtools/simulation.py
@@ -27,6 +27,7 @@ class SimulationStudy(ABC):
         self.test_names = list(test_dict.keys())
         self.tests = list([v[0] for v in test_dict.values()])
         self.configs = list([v[1] for v in test_dict.values()])
+        self.n_tests = len(self.tests)
         self.data_params = data_params
         self.create_storage_arrays()
 
@@ -48,7 +49,7 @@ class SimulationStudy(ABC):
             self.results[i, j] = test_result
 
     def create_storage_arrays(self):
-        array_shape = (self.n_sim, len(self.tests))
+        array_shape = (self.n_sim, self.n_tests)
         self.pt = np.empty(array_shape)
         self.se = np.empty(array_shape)
         self.theta = np.empty(array_shape)
@@ -68,7 +69,7 @@ class SimulationStudy(ABC):
                 (self.lower_limit[:, j] <= self.theta[:, j])
                 * (self.upper_limit[:, j] >= self.theta[:, j])
             )
-            for j in range(len(self.tests))
+            for j in range(self.n_tests)
         ]
 
     @property
@@ -76,22 +77,20 @@ class SimulationStudy(ABC):
         return [
             1.0
             - np.mean((self.lower_limit[:, j] < 0.0) * (self.upper_limit[:, j] > 0.0))
-            for j in range(len(self.tests))
+            for j in range(self.n_tests)
         ]
 
     @property
     def mse(self):
         return [
             np.mean((self.pt[:, j] - self.theta[:, j]) ** 2)
-            for j in range(len(self.tests))
+            for j in range(self.n_tests)
         ]
 
     @property
     def bias(self):
-        return [
-            np.mean(self.pt[:, j] - self.theta[:, j]) for j in range(len(self.tests))
-        ]
+        return [np.mean(self.pt[:, j] - self.theta[:, j]) for j in range(self.n_tests)]
 
     @property
     def variance(self):
-        return [np.var(self.pt[:, j]) for j in range(len(self.tests))]
+        return [np.var(self.pt[:, j]) for j in range(self.n_tests)]

--- a/packages/stats/gbstats/devtools/simulation.py
+++ b/packages/stats/gbstats/devtools/simulation.py
@@ -45,6 +45,7 @@ class SimulationStudy(ABC):
             self.lower_limit[i, j] = test_result.ci[0]
             self.upper_limit[i, j] = test_result.ci[1]
             self.theta[i, j] = estimand
+            self.results[i, j] = test_result
 
     def create_storage_arrays(self):
         array_shape = (self.n_sim, len(self.tests))
@@ -53,6 +54,7 @@ class SimulationStudy(ABC):
         self.theta = np.empty(array_shape)
         self.lower_limit = np.empty(array_shape)
         self.upper_limit = np.empty(array_shape)
+        self.results = np.empty(array_shape, dtype=object)
 
     @abstractmethod
     def generate_data(self) -> Tuple[TestStatistic, TestStatistic, float]:

--- a/packages/stats/gbstats/devtools/simulation.py
+++ b/packages/stats/gbstats/devtools/simulation.py
@@ -40,7 +40,7 @@ class SimulationStudy(ABC):
         for j, test in enumerate(self.tests):
             t = test(stat_a, stat_b, self.configs[j])
             test_result = t.compute_result()
-            self.pt[i, j] = test_result.uplift.mean
+            self.pt[i, j] = test_result.expected
             self.se[i, j] = test_result.uplift.stddev
             self.lower_limit[i, j] = test_result.ci[0]
             self.upper_limit[i, j] = test_result.ci[1]

--- a/packages/stats/gbstats/devtools/simulation.py
+++ b/packages/stats/gbstats/devtools/simulation.py
@@ -1,0 +1,102 @@
+import numpy as np
+from pydantic.dataclasses import dataclass
+from scipy.stats import norm
+from typing import cast
+
+##############################################
+# this file is used for internal testing only.
+# no methods from this file should be exported.
+###############################################
+# Doesnt it seem like you should pass in some estimator class
+# that always returns a point estimate and a standard error,
+# and more or less everything else is handled by this simulation engine?
+
+# You basically need to have fixed interfaces across classes
+# (input: Statistic output: se and mean ). Which we kind of have.
+
+
+@dataclass
+class Estimator:
+    n_sim: int
+    theta: float
+    alpha: float = 0.05
+
+    def create_arrays(self):
+        array_shape = (self.n_sim,)
+        self.pt = np.empty(array_shape)
+        self.se = np.empty(array_shape)
+
+    @property
+    def multiplier(self):
+        return norm.ppf(1.0 - 0.5 * self.alpha, loc=0, scale=1)
+
+    @property
+    def lower_limit(self) -> np.ndarray:
+        return self.pt - self.se * self.multiplier
+
+    @property
+    def upper_limit(self) -> np.ndarray:
+        return self.pt + self.se * self.multiplier
+
+    @property
+    def coverage(self) -> float:
+        """computes coverage."""
+        return cast(
+            float,
+            np.mean(
+                (self.lower_limit <= self.theta) * (self.upper_limit >= self.theta)
+            ),
+        )
+
+    @property
+    def reject(self):
+        zero_in_interval = (self.lower_limit < 0.0) * (self.upper_limit > 0.0)
+        return 1.0 - np.mean(zero_in_interval)
+
+    @property
+    def mse(self):
+        return np.mean((self.pt - self.theta) ** 2, axis=0)
+
+
+@dataclass
+class SimulationStudy:
+    n_sim: int = 100
+    alpha: float = 0.05
+    seed: int = 20240401
+
+    def run_sim(self):
+        self.create_storage_arrays()
+        self.run_all_iterations()
+        self.calculate_sim_coverage()
+        self.calculate_sim_mse()
+        self.calculate_sim_rejection_rates()
+
+    def run_all_iterations(self):
+        for i in range(self.n_sim):
+            self.run_iteration(i)
+
+    def run_iteration(self, i):
+        np.random.seed(self.seed + i)
+        self.generate_data()
+
+    def create_storage_arrays(self):
+        pass
+
+    def generate_data(self):
+        pass
+
+    def get_standard_error_from_interval(self, lower, upper):
+        return (upper - lower) / (2 * self.multiplier)
+
+    def calculate_sim_coverage(self):
+        pass
+
+    def calculate_sim_mse(self):
+        pass
+
+    def calculate_sim_rejection_rates(self):
+        pass
+
+    @property
+    def multiplier(self):
+        return norm.ppf(1.0 - 0.5 * self.alpha, loc=0, scale=1)

--- a/packages/stats/gbstats/devtools/simulation.py
+++ b/packages/stats/gbstats/devtools/simulation.py
@@ -18,13 +18,13 @@ from typing import cast
 @dataclass
 class Estimator:
     n_sim: int
-    theta: float
     alpha: float = 0.05
 
     def create_arrays(self):
         array_shape = (self.n_sim,)
         self.pt = np.empty(array_shape)
         self.se = np.empty(array_shape)
+        self.theta = np.empty(array_shape)
 
     @property
     def multiplier(self):
@@ -57,6 +57,14 @@ class Estimator:
     def mse(self):
         return np.mean((self.pt - self.theta) ** 2, axis=0)
 
+    @property
+    def bias(self):
+        return np.mean(self.pt - self.theta)
+
+    @property
+    def variance(self):
+        return np.var(self.pt)
+
 
 @dataclass
 class SimulationStudy:
@@ -67,9 +75,6 @@ class SimulationStudy:
     def run_sim(self):
         self.create_storage_arrays()
         self.run_all_iterations()
-        self.calculate_sim_coverage()
-        self.calculate_sim_mse()
-        self.calculate_sim_rejection_rates()
 
     def run_all_iterations(self):
         for i in range(self.n_sim):
@@ -87,15 +92,6 @@ class SimulationStudy:
 
     def get_standard_error_from_interval(self, lower, upper):
         return (upper - lower) / (2 * self.multiplier)
-
-    def calculate_sim_coverage(self):
-        pass
-
-    def calculate_sim_mse(self):
-        pass
-
-    def calculate_sim_rejection_rates(self):
-        pass
 
     @property
     def multiplier(self):

--- a/packages/stats/gbstats/devtools/simulation.py
+++ b/packages/stats/gbstats/devtools/simulation.py
@@ -1,98 +1,95 @@
+from abc import ABC, abstractmethod
+from typing import Dict, Mapping, Tuple, Type
+
 import numpy as np
-from pydantic.dataclasses import dataclass
-from scipy.stats import norm
-from typing import cast
+
+from gbstats.models.statistics import TestStatistic
+from gbstats.models.tests import BaseABTest, BaseConfig
 
 ##############################################
 # this file is used for internal testing only.
 # no methods from this file should be exported.
 ###############################################
-# Doesnt it seem like you should pass in some estimator class
-# that always returns a point estimate and a standard error,
-# and more or less everything else is handled by this simulation engine?
-
-# You basically need to have fixed interfaces across classes
-# (input: Statistic output: se and mean ). Which we kind of have.
 
 
-@dataclass
-class Estimator:
-    n_sim: int
-    alpha: float = 0.05
-
-    def create_arrays(self):
-        array_shape = (self.n_sim,)
-        self.pt = np.empty(array_shape)
-        self.se = np.empty(array_shape)
-        self.theta = np.empty(array_shape)
-
-    @property
-    def multiplier(self):
-        return norm.ppf(1.0 - 0.5 * self.alpha, loc=0, scale=1)
-
-    @property
-    def lower_limit(self) -> np.ndarray:
-        return self.pt - self.se * self.multiplier
-
-    @property
-    def upper_limit(self) -> np.ndarray:
-        return self.pt + self.se * self.multiplier
-
-    @property
-    def coverage(self) -> float:
-        """computes coverage."""
-        return cast(
-            float,
-            np.mean(
-                (self.lower_limit <= self.theta) * (self.upper_limit >= self.theta)
-            ),
-        )
-
-    @property
-    def reject(self):
-        zero_in_interval = (self.lower_limit < 0.0) * (self.upper_limit > 0.0)
-        return 1.0 - np.mean(zero_in_interval)
-
-    @property
-    def mse(self):
-        return np.mean((self.pt - self.theta) ** 2, axis=0)
-
-    @property
-    def bias(self):
-        return np.mean(self.pt - self.theta)
-
-    @property
-    def variance(self):
-        return np.var(self.pt)
-
-
-@dataclass
-class SimulationStudy:
-    n_sim: int = 100
-    alpha: float = 0.05
-    seed: int = 20240401
+class SimulationStudy(ABC):
+    def __init__(
+        self,
+        test_dict: Mapping[str, Tuple[Type[BaseABTest], BaseConfig]],
+        data_params: Dict,
+        seed: int,
+        n_sim: int = 100,
+        alpha: float = 0.05,
+    ):
+        self.n_sim = n_sim
+        self.alpha = alpha
+        self.seed = seed
+        self.test_names = list(test_dict.keys())
+        self.tests = list([v[0] for v in test_dict.values()])
+        self.configs = list([v[1] for v in test_dict.values()])
+        self.data_params = data_params
+        self.create_storage_arrays()
 
     def run_sim(self):
-        self.create_storage_arrays()
-        self.run_all_iterations()
-
-    def run_all_iterations(self):
         for i in range(self.n_sim):
             self.run_iteration(i)
 
     def run_iteration(self, i):
         np.random.seed(self.seed + i)
-        self.generate_data()
+        stat_a, stat_b, estimand = self.generate_data()
+        for j, test in enumerate(self.tests):
+            t = test(stat_a, stat_b, self.configs[j])
+            test_result = t.compute_result()
+            self.pt[i, j] = test_result.uplift.mean
+            self.se[i, j] = test_result.uplift.stddev
+            self.lower_limit[i, j] = test_result.ci[0]
+            self.upper_limit[i, j] = test_result.ci[1]
+            self.theta[i, j] = estimand
 
     def create_storage_arrays(self):
-        pass
+        array_shape = (self.n_sim, len(self.tests))
+        self.pt = np.empty(array_shape)
+        self.se = np.empty(array_shape)
+        self.theta = np.empty(array_shape)
+        self.lower_limit = np.empty(array_shape)
+        self.upper_limit = np.empty(array_shape)
 
-    def generate_data(self):
+    @abstractmethod
+    def generate_data(self) -> Tuple[TestStatistic, TestStatistic, float]:
         pass
-
-    def get_standard_error_from_interval(self, lower, upper):
-        return (upper - lower) / (2 * self.multiplier)
 
     @property
-    def multiplier(self):
-        return norm.ppf(1.0 - 0.5 * self.alpha, loc=0, scale=1)
+    def coverage(self):
+        """computes coverage."""
+        return [
+            np.mean(
+                (self.lower_limit[:, j] <= self.theta[:, j])
+                * (self.upper_limit[:, j] >= self.theta[:, j])
+            )
+            for j in range(len(self.tests))
+        ]
+
+    @property
+    def reject(self):
+        return [
+            1.0
+            - np.mean((self.lower_limit[:, j] < 0.0) * (self.upper_limit[:, j] > 0.0))
+            for j in range(len(self.tests))
+        ]
+
+    @property
+    def mse(self):
+        return [
+            np.mean((self.pt[:, j] - self.theta[:, j]) ** 2)
+            for j in range(len(self.tests))
+        ]
+
+    @property
+    def bias(self):
+        return [
+            np.mean(self.pt[:, j] - self.theta[:, j]) for j in range(len(self.tests))
+        ]
+
+    @property
+    def variance(self):
+        return [np.var(self.pt[:, j]) for j in range(len(self.tests))]

--- a/packages/stats/gbstats/models/tests.py
+++ b/packages/stats/gbstats/models/tests.py
@@ -36,6 +36,7 @@ class BaseABTest(ABC):
         self,
         stat_a: TestStatistic,
         stat_b: TestStatistic,
+        config: BaseConfig = BaseConfig(),
     ):
         self.stat_a = stat_a
         self.stat_b = stat_b


### PR DESCRIPTION
Adds a simulation base class to gbstats to aid in future simulations.

Only change to prod code is a base config input that gets ignored in the base AB test.