### PR TITLE
Mk/migrate create presentation

### DIFF
--- a/packages/back-end/src/controllers/presentations.ts
+++ b/packages/back-end/src/controllers/presentations.ts
@@ -88,10 +88,13 @@ export async function deletePresentation(
   req: AuthRequest<ExperimentInterface, { id: string }>,
   res: Response
 ) {
-  req.checkPermissions("createPresentations");
-
   const { id } = req.params;
-  const { org } = getContextFromReq(req);
+  const context = getContextFromReq(req);
+  const { org } = context;
+
+  if (!context.permissions.canDeletePresentation()) {
+    context.permissions.throwPermissionError();
+  }
 
   const p = await getPresentationById(id);
 
@@ -130,10 +133,14 @@ export async function postPresentation(
   req: AuthRequest<Partial<PresentationInterface>>,
   res: Response
 ) {
-  req.checkPermissions("createPresentations");
-
   const data = req.body;
-  const { org } = getContextFromReq(req);
+  const context = getContextFromReq(req);
+  const { org } = context;
+
+  if (!context.permissions.canCreatePresentation()) {
+    context.permissions.throwPermissionError();
+  }
+
   data.organization = org.id;
 
   data.userId = req.userId;
@@ -154,11 +161,14 @@ export async function updatePresentation(
   req: AuthRequest<PresentationInterface, { id: string }>,
   res: Response
 ) {
-  req.checkPermissions("createPresentations");
-
   const { id } = req.params;
   const data = req.body;
-  const { org } = getContextFromReq(req);
+  const context = getContextFromReq(req);
+  const { org } = context;
+
+  if (!context.permissions.canUpdatePresentation()) {
+    context.permissions.throwPermissionError();
+  }
 
   const p = await getPresentationById(id);
 

--- a/packages/back-end/src/routers/dimension/dimension.controller.ts
+++ b/packages/back-end/src/routers/dimension/dimension.controller.ts
@@ -67,9 +67,11 @@ export const postDimension = async (
   req: CreateDimensionRequest,
   res: Response<CreateDimensionResponse | PrivateApiErrorResponse>
 ) => {
-  req.checkPermissions("createDimensions");
-
   const context = getContextFromReq(req);
+
+  if (!context.permissions.canCreateDimension()) {
+    context.permissions.throwPermissionError();
+  }
   const { org, userName } = context;
   const { datasource, name, sql, userIdType, description } = req.body;
 
@@ -128,9 +130,10 @@ export const putDimension = async (
   req: PutDimensionRequest,
   res: Response<PutDimensionResponse>
 ) => {
-  req.checkPermissions("createDimensions");
-
   const context = getContextFromReq(req);
+  if (!context.permissions.canUpdateDimension()) {
+    context.permissions.throwPermissionError();
+  }
   const { org } = context;
   const { id } = req.params;
   const dimension = await findDimensionById(id, org.id);
@@ -181,10 +184,12 @@ export const deleteDimension = async (
   req: DeleteDimensionRequest,
   res: Response<DeleteDimensionResponse | PrivateApiErrorResponse>
 ) => {
-  req.checkPermissions("createDimensions");
-
   const { id } = req.params;
-  const { org } = getContextFromReq(req);
+  const context = getContextFromReq(req);
+  if (!context.permissions.canDeleteDimension()) {
+    context.permissions.throwPermissionError();
+  }
+  const { org } = context;
   const dimension = await findDimensionById(id, org.id);
 
   if (!dimension) {

--- a/packages/back-end/test/permissions.test.ts
+++ b/packages/back-end/test/permissions.test.ts
@@ -2044,6 +2044,237 @@ describe("PermissionsUtilClass.canDeletePresentation check", () => {
   });
 });
 
+describe("PermissionsUtilClass.canCreateDimension check", () => {
+  const testOrg: OrganizationInterface = {
+    id: "org_sktwi1id9l7z9xkjb",
+    name: "Test Org",
+    ownerEmail: "test@test.com",
+    url: "https://test.com",
+    dateCreated: new Date(),
+    invites: [],
+    members: [
+      {
+        id: "base_user_123",
+        role: "readonly",
+        dateCreated: new Date(),
+        limitAccessByEnvironment: false,
+        environments: [],
+        projectRoles: [],
+        teams: [],
+      },
+    ],
+    settings: {
+      environments: [
+        { id: "development" },
+        { id: "staging" },
+        { id: "production" },
+      ],
+    },
+  };
+
+  it("User with global readonly role can not create dimension", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("readonly", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(permissions.canCreateDimension()).toEqual(false);
+  });
+
+  it("User with global collaborator role can create dimension", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("collaborator", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(permissions.canCreateDimension()).toEqual(false);
+  });
+
+  it("User with global analyst role can create dimension", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("analyst", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(permissions.canCreateDimension()).toEqual(true);
+  });
+});
+
+describe("PermissionsUtilClass.canUpdateDimension check", () => {
+  const testOrg: OrganizationInterface = {
+    id: "org_sktwi1id9l7z9xkjb",
+    name: "Test Org",
+    ownerEmail: "test@test.com",
+    url: "https://test.com",
+    dateCreated: new Date(),
+    invites: [],
+    members: [
+      {
+        id: "base_user_123",
+        role: "readonly",
+        dateCreated: new Date(),
+        limitAccessByEnvironment: false,
+        environments: [],
+        projectRoles: [],
+        teams: [],
+      },
+    ],
+    settings: {
+      environments: [
+        { id: "development" },
+        { id: "staging" },
+        { id: "production" },
+      ],
+    },
+  };
+
+  it("User with global readonly role can not update dimension", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("readonly", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(permissions.canUpdateDimension()).toEqual(false);
+  });
+
+  it("User with global collaborator role can update dimension", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("collaborator", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(permissions.canUpdateDimension()).toEqual(false);
+  });
+
+  it("User with global analyst role can update dimension", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("analyst", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(permissions.canUpdateDimension()).toEqual(true);
+  });
+});
+
+describe("PermissionsUtilClass.canDeleteDimension check", () => {
+  const testOrg: OrganizationInterface = {
+    id: "org_sktwi1id9l7z9xkjb",
+    name: "Test Org",
+    ownerEmail: "test@test.com",
+    url: "https://test.com",
+    dateCreated: new Date(),
+    invites: [],
+    members: [
+      {
+        id: "base_user_123",
+        role: "readonly",
+        dateCreated: new Date(),
+        limitAccessByEnvironment: false,
+        environments: [],
+        projectRoles: [],
+        teams: [],
+      },
+    ],
+    settings: {
+      environments: [
+        { id: "development" },
+        { id: "staging" },
+        { id: "production" },
+      ],
+    },
+  };
+
+  it("User with global readonly role can not delete dimension", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("readonly", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(permissions.canDeleteDimension()).toEqual(false);
+  });
+
+  it("User with global collaborator role can delete dimension", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("collaborator", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(permissions.canDeleteDimension()).toEqual(false);
+  });
+
+  it("User with global analyst role can delete dimension", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("analyst", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(permissions.canDeleteDimension()).toEqual(true);
+  });
+});
+// permissionsClass Project Permissions Test
 describe("PermissionsUtilClass.canViewIdeaModal check", () => {
   const testOrg: OrganizationInterface = {
     id: "org_sktwi1id9l7z9xkjb",

--- a/packages/back-end/test/permissions.test.ts
+++ b/packages/back-end/test/permissions.test.ts
@@ -1812,6 +1812,238 @@ describe("hasReadAccess filter", () => {
   });
 });
 
+// permissionsClass Global Permissions Test
+describe("PermissionsUtilClass.canCreatePresentation check", () => {
+  const testOrg: OrganizationInterface = {
+    id: "org_sktwi1id9l7z9xkjb",
+    name: "Test Org",
+    ownerEmail: "test@test.com",
+    url: "https://test.com",
+    dateCreated: new Date(),
+    invites: [],
+    members: [
+      {
+        id: "base_user_123",
+        role: "readonly",
+        dateCreated: new Date(),
+        limitAccessByEnvironment: false,
+        environments: [],
+        projectRoles: [],
+        teams: [],
+      },
+    ],
+    settings: {
+      environments: [
+        { id: "development" },
+        { id: "staging" },
+        { id: "production" },
+      ],
+    },
+  };
+
+  it("User with global readonly role can not create presentation", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("readonly", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(permissions.canCreatePresentation()).toEqual(false);
+  });
+
+  it("User with global collaborator role can create presentation", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("collaborator", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(permissions.canCreatePresentation()).toEqual(true);
+  });
+
+  it("User with global engineer role can create presentation", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("engineer", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(permissions.canCreatePresentation()).toEqual(true);
+  });
+});
+
+describe("PermissionsUtilClass.canUpdatePresentation check", () => {
+  const testOrg: OrganizationInterface = {
+    id: "org_sktwi1id9l7z9xkjb",
+    name: "Test Org",
+    ownerEmail: "test@test.com",
+    url: "https://test.com",
+    dateCreated: new Date(),
+    invites: [],
+    members: [
+      {
+        id: "base_user_123",
+        role: "readonly",
+        dateCreated: new Date(),
+        limitAccessByEnvironment: false,
+        environments: [],
+        projectRoles: [],
+        teams: [],
+      },
+    ],
+    settings: {
+      environments: [
+        { id: "development" },
+        { id: "staging" },
+        { id: "production" },
+      ],
+    },
+  };
+
+  it("User with global readonly role can not update presentation", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("readonly", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(permissions.canUpdatePresentation()).toEqual(false);
+  });
+
+  it("User with global collaborator role can update presentation", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("collaborator", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(permissions.canUpdatePresentation()).toEqual(true);
+  });
+
+  it("User with global engineer role can update presentation", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("engineer", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(permissions.canUpdatePresentation()).toEqual(true);
+  });
+});
+
+describe("PermissionsUtilClass.canDeletePresentation check", () => {
+  const testOrg: OrganizationInterface = {
+    id: "org_sktwi1id9l7z9xkjb",
+    name: "Test Org",
+    ownerEmail: "test@test.com",
+    url: "https://test.com",
+    dateCreated: new Date(),
+    invites: [],
+    members: [
+      {
+        id: "base_user_123",
+        role: "readonly",
+        dateCreated: new Date(),
+        limitAccessByEnvironment: false,
+        environments: [],
+        projectRoles: [],
+        teams: [],
+      },
+    ],
+    settings: {
+      environments: [
+        { id: "development" },
+        { id: "staging" },
+        { id: "production" },
+      ],
+    },
+  };
+
+  it("User with global readonly role can not delete presentation", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("readonly", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(permissions.canDeletePresentation()).toEqual(false);
+  });
+
+  it("User with global collaborator role can delete presentation", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("collaborator", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(permissions.canDeletePresentation()).toEqual(true);
+  });
+
+  it("User with global engineer role can delete presentation", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("engineer", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(permissions.canDeletePresentation()).toEqual(true);
+  });
+});
+
 describe("PermissionsUtilClass.canViewIdeaModal check", () => {
   const testOrg: OrganizationInterface = {
     id: "org_sktwi1id9l7z9xkjb",

--- a/packages/front-end/pages/presentations.tsx
+++ b/packages/front-end/pages/presentations.tsx
@@ -11,6 +11,7 @@ import { useAuth } from "@/services/auth";
 import Modal from "@/components/Modal";
 import CopyToClipboard from "@/components/CopyToClipboard";
 import { useUser } from "@/services/UserContext";
+import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 
 const PresentationPage = (): React.ReactElement => {
   const [openNewPresentationModal, setOpenNewPresentationModal] = useState(
@@ -29,8 +30,13 @@ const PresentationPage = (): React.ReactElement => {
   const [deleteId, setDeleteId] = useState<string | null>(null);
   const [deleteLoading, setDeleteLoading] = useState<boolean>(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
-  const { getUserDisplay, permissions } = useUser();
+  const { getUserDisplay } = useUser();
+  const permissionsUtil = usePermissionsUtil();
   const { apiCall } = useAuth();
+
+  const canCreatePresentation = permissionsUtil.canCreatePresentation();
+  const canDeletePresentation = permissionsUtil.canDeletePresentation();
+  const canEditPresentation = permissionsUtil.canUpdatePresentation();
 
   const { data: p, error: error, mutate } = useApi<{
     presentations: PresentationInterface[];
@@ -61,7 +67,7 @@ const PresentationPage = (): React.ReactElement => {
           suggest tweaks and follow-up variations.
         </p>
 
-        {permissions.createPresentations && (
+        {canCreatePresentation && (
           <button
             className="btn btn-success btn-lg"
             onClick={() => {
@@ -151,45 +157,45 @@ const PresentationPage = (): React.ReactElement => {
                 </div>
               </div>
               <div className="">
-                {permissions.createPresentations && (
-                  <>
-                    <div
-                      className="delete delete-right"
-                      style={{ lineHeight: "36px" }}
-                      onClick={() => {
-                        deleteConfirm(pres.id);
-                      }}
+                {canDeletePresentation ? (
+                  <div
+                    className="delete delete-right"
+                    style={{ lineHeight: "36px" }}
+                    onClick={() => {
+                      deleteConfirm(pres.id);
+                    }}
+                  >
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      width="24"
                     >
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        height="24"
-                        viewBox="0 0 24 24"
-                        width="24"
-                      >
-                        <path d="M0 0h24v24H0V0z" fill="none" />
-                        <path d="M16 9v10H8V9h8m-1.5-6h-5l-1 1H5v2h14V4h-3.5l-1-1zM18 7H6v12c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7z" />
-                      </svg>
-                    </div>
-                    <div
-                      className="edit edit-right"
-                      style={{ lineHeight: "36px" }}
-                      onClick={() => {
-                        setSpecificPresentation(pres);
-                        setOpenEditPresentationModal(true);
-                      }}
+                      <path d="M0 0h24v24H0V0z" fill="none" />
+                      <path d="M16 9v10H8V9h8m-1.5-6h-5l-1 1H5v2h14V4h-3.5l-1-1zM18 7H6v12c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7z" />
+                    </svg>
+                  </div>
+                ) : null}
+                {canEditPresentation ? (
+                  <div
+                    className="edit edit-right"
+                    style={{ lineHeight: "36px" }}
+                    onClick={() => {
+                      setSpecificPresentation(pres);
+                      setOpenEditPresentationModal(true);
+                    }}
+                  >
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      width="24"
                     >
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        height="24"
-                        viewBox="0 0 24 24"
-                        width="24"
-                      >
-                        <path d="M0 0h24v24H0V0z" fill="none" />
-                        <path d="M14.06 9.02l.92.92L5.92 19H5v-.92l9.06-9.06M17.66 3c-.25 0-.51.1-.7.29l-1.83 1.83 3.75 3.75 1.83-1.83c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.2-.2-.45-.29-.71-.29zm-3.6 3.19L3 17.25V21h3.75L17.81 9.94l-3.75-3.75z" />
-                      </svg>
-                    </div>
-                  </>
-                )}
+                      <path d="M0 0h24v24H0V0z" fill="none" />
+                      <path d="M14.06 9.02l.92.92L5.92 19H5v-.92l9.06-9.06M17.66 3c-.25 0-.51.1-.7.29l-1.83 1.83 3.75 3.75 1.83-1.83c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.2-.2-.45-.29-.71-.29zm-3.6 3.19L3 17.25V21h3.75L17.81 9.94l-3.75-3.75z" />
+                    </svg>
+                  </div>
+                ) : null}
                 <Link
                   href={`/present/${pres.id}`}
                   className="btn btn-primary mr-3"
@@ -238,7 +244,7 @@ const PresentationPage = (): React.ReactElement => {
       <div className="container-fluid pagecontents pt-4 shares learnings">
         <div className=" mb-3">
           <div className="share-list mb-3">{presList}</div>
-          {permissions.createPresentations && (
+          {canCreatePresentation && (
             <button
               className="btn btn-primary"
               onClick={() => {

--- a/packages/shared/src/permissions/permissionsClass.ts
+++ b/packages/shared/src/permissions/permissionsClass.ts
@@ -36,6 +36,19 @@ export class Permissions {
     return this.checkGlobalFilterPermission("createPresentations");
   };
 
+  public canCreateDimension = (): boolean => {
+    return this.checkGlobalFilterPermission("createDimensions");
+  };
+
+  public canUpdateDimension = (): boolean => {
+    return this.checkGlobalFilterPermission("createDimensions");
+  };
+
+  public canDeleteDimension = (): boolean => {
+    return this.checkGlobalFilterPermission("createDimensions");
+  };
+
+  //Project Permissions
   // This is a helper method to use on the frontend to determine whether or not to show certain UI elements
   public canViewIdeaModal = (project?: string): boolean => {
     return this.checkProjectFilterPermission(

--- a/packages/shared/src/permissions/permissionsClass.ts
+++ b/packages/shared/src/permissions/permissionsClass.ts
@@ -25,27 +25,27 @@ export class Permissions {
 
   //Global Permissions
   public canCreatePresentation = (): boolean => {
-    return this.checkGlobalFilterPermission("createPresentations");
+    return this.checkGlobalPermission("createPresentations");
   };
 
   public canUpdatePresentation = (): boolean => {
-    return this.checkGlobalFilterPermission("createPresentations");
+    return this.checkGlobalPermission("createPresentations");
   };
 
   public canDeletePresentation = (): boolean => {
-    return this.checkGlobalFilterPermission("createPresentations");
+    return this.checkGlobalPermission("createPresentations");
   };
 
   public canCreateDimension = (): boolean => {
-    return this.checkGlobalFilterPermission("createDimensions");
+    return this.checkGlobalPermission("createDimensions");
   };
 
   public canUpdateDimension = (): boolean => {
-    return this.checkGlobalFilterPermission("createDimensions");
+    return this.checkGlobalPermission("createDimensions");
   };
 
   public canDeleteDimension = (): boolean => {
-    return this.checkGlobalFilterPermission("createDimensions");
+    return this.checkGlobalPermission("createDimensions");
   };
 
   //Project Permissions
@@ -137,14 +137,8 @@ export class Permissions {
     );
   }
 
-  private checkGlobalFilterPermission(
-    permissionToCheck: GlobalPermission
-  ): boolean {
-    if (this.superAdmin) {
-      return true;
-    }
-
-    return this.userPermissions.global.permissions[permissionToCheck] || false;
+  private checkGlobalPermission(permission: GlobalPermission): boolean {
+    return this.hasPermission(permission, "");
   }
 
   private checkProjectFilterPermission(

--- a/packages/shared/src/permissions/permissionsClass.ts
+++ b/packages/shared/src/permissions/permissionsClass.ts
@@ -1,6 +1,11 @@
 import { FeatureInterface } from "back-end/types/feature";
 import { MetricInterface } from "back-end/types/metric";
-import { Permission, UserPermissions } from "back-end/types/organization";
+import {
+  GlobalPermission,
+  Permission,
+  ProjectScopedPermission,
+  UserPermissions,
+} from "back-end/types/organization";
 import { IdeaInterface } from "back-end/types/idea";
 import { READ_ONLY_PERMISSIONS } from "./permissions.utils";
 class PermissionError extends Error {
@@ -17,6 +22,19 @@ export class Permissions {
     this.userPermissions = permissions;
     this.superAdmin = superAdmin;
   }
+
+  //Global Permissions
+  public canCreatePresentation = (): boolean => {
+    return this.checkGlobalFilterPermission("createPresentations");
+  };
+
+  public canUpdatePresentation = (): boolean => {
+    return this.checkGlobalFilterPermission("createPresentations");
+  };
+
+  public canDeletePresentation = (): boolean => {
+    return this.checkGlobalFilterPermission("createPresentations");
+  };
 
   // This is a helper method to use on the frontend to determine whether or not to show certain UI elements
   public canViewIdeaModal = (project?: string): boolean => {
@@ -106,9 +124,19 @@ export class Permissions {
     );
   }
 
+  private checkGlobalFilterPermission(
+    permissionToCheck: GlobalPermission
+  ): boolean {
+    if (this.superAdmin) {
+      return true;
+    }
+
+    return this.userPermissions.global.permissions[permissionToCheck] || false;
+  }
+
   private checkProjectFilterPermission(
     obj: { projects?: string[] },
-    permission: Permission
+    permission: ProjectScopedPermission
   ): boolean {
     const projects = obj.projects?.length ? obj.projects : [""];
 
@@ -130,7 +158,7 @@ export class Permissions {
   private checkProjectFilterUpdatePermission(
     existing: { projects?: string[] },
     updates: { projects?: string[] },
-    permission: Permission
+    permission: ProjectScopedPermission
   ): boolean {
     // check if the user has permission to update based on the existing projects
     if (!this.checkProjectFilterPermission(existing, permission)) {


### PR DESCRIPTION
### Features and Changes

This PR introduces the first `GLOBAL_PERMISSION` to the `permissionsClass`, and in doing so, introduces three new helper methods: `canCreatePresentation`, `canUpdatePresentation`, and `canDeletePresentation`.

Additionally, I've introduced a new private method within `permissionsClass` that handles checking these global permissions.

I went back and forth on whether to use the existing `hasPermission` method within the class, or add this helper. Adding the helper feels like it makes the code a bit more readable, as when reading it, we only have to worry about the user's global role.

I've also updated the type for `checkProjectFilterUpdatePermission`, so we don't accidentally pass in a permission other than `ProjectScopedPermission`.

### Testing

- See test suite

