### PR TITLE
Migrates createDimensions to permissionsClass

### DIFF
--- a/packages/back-end/src/routers/dimension/dimension.controller.ts
+++ b/packages/back-end/src/routers/dimension/dimension.controller.ts
@@ -67,9 +67,11 @@ export const postDimension = async (
   req: CreateDimensionRequest,
   res: Response<CreateDimensionResponse | PrivateApiErrorResponse>
 ) => {
-  req.checkPermissions("createDimensions");
-
   const context = getContextFromReq(req);
+
+  if (!context.permissions.canCreateDimension()) {
+    context.permissions.throwPermissionError();
+  }
   const { org, userName } = context;
   const { datasource, name, sql, userIdType, description } = req.body;
 
@@ -128,9 +130,10 @@ export const putDimension = async (
   req: PutDimensionRequest,
   res: Response<PutDimensionResponse>
 ) => {
-  req.checkPermissions("createDimensions");
-
   const context = getContextFromReq(req);
+  if (!context.permissions.canUpdateDimension()) {
+    context.permissions.throwPermissionError();
+  }
   const { org } = context;
   const { id } = req.params;
   const dimension = await findDimensionById(id, org.id);
@@ -181,10 +184,12 @@ export const deleteDimension = async (
   req: DeleteDimensionRequest,
   res: Response<DeleteDimensionResponse | PrivateApiErrorResponse>
 ) => {
-  req.checkPermissions("createDimensions");
-
   const { id } = req.params;
-  const { org } = getContextFromReq(req);
+  const context = getContextFromReq(req);
+  if (!context.permissions.canDeleteDimension()) {
+    context.permissions.throwPermissionError();
+  }
+  const { org } = context;
   const dimension = await findDimensionById(id, org.id);
 
   if (!dimension) {

--- a/packages/back-end/test/permissions.test.ts
+++ b/packages/back-end/test/permissions.test.ts
@@ -2044,6 +2044,237 @@ describe("PermissionsUtilClass.canDeletePresentation check", () => {
   });
 });
 
+describe("PermissionsUtilClass.canCreateDimension check", () => {
+  const testOrg: OrganizationInterface = {
+    id: "org_sktwi1id9l7z9xkjb",
+    name: "Test Org",
+    ownerEmail: "test@test.com",
+    url: "https://test.com",
+    dateCreated: new Date(),
+    invites: [],
+    members: [
+      {
+        id: "base_user_123",
+        role: "readonly",
+        dateCreated: new Date(),
+        limitAccessByEnvironment: false,
+        environments: [],
+        projectRoles: [],
+        teams: [],
+      },
+    ],
+    settings: {
+      environments: [
+        { id: "development" },
+        { id: "staging" },
+        { id: "production" },
+      ],
+    },
+  };
+
+  it("User with global readonly role can not create dimension", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("readonly", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(permissions.canCreateDimension()).toEqual(false);
+  });
+
+  it("User with global collaborator role can create dimension", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("collaborator", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(permissions.canCreateDimension()).toEqual(false);
+  });
+
+  it("User with global analyst role can create dimension", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("analyst", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(permissions.canCreateDimension()).toEqual(true);
+  });
+});
+
+describe("PermissionsUtilClass.canUpdateDimension check", () => {
+  const testOrg: OrganizationInterface = {
+    id: "org_sktwi1id9l7z9xkjb",
+    name: "Test Org",
+    ownerEmail: "test@test.com",
+    url: "https://test.com",
+    dateCreated: new Date(),
+    invites: [],
+    members: [
+      {
+        id: "base_user_123",
+        role: "readonly",
+        dateCreated: new Date(),
+        limitAccessByEnvironment: false,
+        environments: [],
+        projectRoles: [],
+        teams: [],
+      },
+    ],
+    settings: {
+      environments: [
+        { id: "development" },
+        { id: "staging" },
+        { id: "production" },
+      ],
+    },
+  };
+
+  it("User with global readonly role can not update dimension", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("readonly", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(permissions.canUpdateDimension()).toEqual(false);
+  });
+
+  it("User with global collaborator role can update dimension", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("collaborator", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(permissions.canUpdateDimension()).toEqual(false);
+  });
+
+  it("User with global analyst role can update dimension", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("analyst", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(permissions.canUpdateDimension()).toEqual(true);
+  });
+});
+
+describe("PermissionsUtilClass.canDeleteDimension check", () => {
+  const testOrg: OrganizationInterface = {
+    id: "org_sktwi1id9l7z9xkjb",
+    name: "Test Org",
+    ownerEmail: "test@test.com",
+    url: "https://test.com",
+    dateCreated: new Date(),
+    invites: [],
+    members: [
+      {
+        id: "base_user_123",
+        role: "readonly",
+        dateCreated: new Date(),
+        limitAccessByEnvironment: false,
+        environments: [],
+        projectRoles: [],
+        teams: [],
+      },
+    ],
+    settings: {
+      environments: [
+        { id: "development" },
+        { id: "staging" },
+        { id: "production" },
+      ],
+    },
+  };
+
+  it("User with global readonly role can not delete dimension", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("readonly", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(permissions.canDeleteDimension()).toEqual(false);
+  });
+
+  it("User with global collaborator role can delete dimension", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("collaborator", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(permissions.canDeleteDimension()).toEqual(false);
+  });
+
+  it("User with global analyst role can delete dimension", async () => {
+    const permissions = new Permissions(
+      {
+        global: {
+          permissions: roleToPermissionMap("analyst", testOrg),
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
+      },
+      false
+    );
+
+    expect(permissions.canDeleteDimension()).toEqual(true);
+  });
+});
+// permissionsClass Project Permissions Test
 describe("PermissionsUtilClass.canViewIdeaModal check", () => {
   const testOrg: OrganizationInterface = {
     id: "org_sktwi1id9l7z9xkjb",

--- a/packages/shared/src/permissions/permissionsClass.ts
+++ b/packages/shared/src/permissions/permissionsClass.ts
@@ -36,6 +36,19 @@ export class Permissions {
     return this.checkGlobalFilterPermission("createPresentations");
   };
 
+  public canCreateDimension = (): boolean => {
+    return this.checkGlobalFilterPermission("createDimensions");
+  };
+
+  public canUpdateDimension = (): boolean => {
+    return this.checkGlobalFilterPermission("createDimensions");
+  };
+
+  public canDeleteDimension = (): boolean => {
+    return this.checkGlobalFilterPermission("createDimensions");
+  };
+
+  //Project Permissions
   // This is a helper method to use on the frontend to determine whether or not to show certain UI elements
   public canViewIdeaModal = (project?: string): boolean => {
     return this.checkProjectFilterPermission(


### PR DESCRIPTION
### Features and Changes

NOTE: This PR is currently based on `mk/migrate-createPresentation` - before we merge, we'll want to make sure we merge in https://github.com/growthbook/growthbook/pull/2372, and change this to merge into main. I've got it set to merge into `mk/migrate-createPresentation` in order to show a clean diff for review.

This PR migrates `createPresentation` to the `permissionClass` and introduces 3 new helper methods: `canCreatePresentation`, `canUpdatePresentation`, and `canDeletePresentation`.

While they all use `createPresentations` under the hood, this will make it easier to introduce finer grain permissions down the road.

### Dependencies

This PR needs to be merged after https://github.com/growthbook/growthbook/pull/2372

### Testing

- See test suite

