### PR TITLE
Refactor Significance to Shared Package

### DIFF
--- a/packages/front-end/components/Experiment/DateResults.tsx
+++ b/packages/front-end/components/Experiment/DateResults.tsx
@@ -4,20 +4,20 @@ import {
   ExperimentReportVariation,
 } from "back-end/types/report";
 import { getValidDate, getValidDateOffsetByUTC } from "shared/dates";
+import {
+  ExperimentMetricInterface,
+  isExpectedDirection,
+  isStatSig,
+  shouldHighlight,
+} from "shared/experiments";
 import { DifferenceType, StatsEngine } from "back-end/types/stats";
-import { ExperimentMetricInterface } from "shared/experiments";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import {
   formatNumber,
   formatPercent,
   getExperimentMetricFormatter,
 } from "@/services/metrics";
-import {
-  getEffectLabel,
-  isExpectedDirection,
-  isStatSig,
-  shouldHighlight,
-} from "@/services/experiments";
+import { getEffectLabel } from "@/services/experiments";
 import { useCurrency } from "@/hooks/useCurrency";
 import useConfidenceLevels from "@/hooks/useConfidenceLevels";
 import usePValueThreshold from "@/hooks/usePValueThreshold";

--- a/packages/front-end/components/Experiment/PercentGraph.tsx
+++ b/packages/front-end/components/Experiment/PercentGraph.tsx
@@ -1,8 +1,11 @@
 import { SnapshotMetric } from "back-end/types/experiment-snapshot";
 import React, { DetailedHTMLProps, HTMLAttributes } from "react";
-import { ExperimentMetricInterface } from "shared/experiments";
+import {
+  ExperimentMetricInterface,
+  hasEnoughData,
+  isStatSig,
+} from "shared/experiments";
 import useConfidenceLevels from "@/hooks/useConfidenceLevels";
-import { hasEnoughData, isStatSig } from "@/services/experiments";
 import { useOrganizationMetricDefaults } from "@/hooks/useOrganizationMetricDefaults";
 import usePValueThreshold from "@/hooks/usePValueThreshold";
 import AlignedGraph from "./AlignedGraph";

--- a/packages/front-end/services/experiments.ts
+++ b/packages/front-end/services/experiments.ts
@@ -18,7 +18,11 @@ import { isNil } from "lodash";
 import { FactTableInterface } from "back-end/types/fact-table";
 import {
   ExperimentMetricInterface,
+  getMetricResultStatus,
+  getMetricSampleSize,
+  hasEnoughData,
   isBinomialMetric,
+  isSuspiciousUplift,
   quantileMetricType,
 } from "shared/experiments";
 import { useOrganizationMetricDefaults } from "@/hooks/useOrganizationMetricDefaults";
@@ -37,89 +41,6 @@ export type ExperimentTableRow = {
   regressionAdjustmentStatus?: MetricRegressionAdjustmentStatus;
   isGuardrail?: boolean;
 };
-
-function getMetricSampleSize(
-  baseline: SnapshotMetric,
-  stats: SnapshotMetric,
-  metric: ExperimentMetricInterface
-): { baselineValue?: number; variationValue?: number } {
-  return quantileMetricType(metric)
-    ? {
-        baselineValue: baseline?.stats?.count,
-        variationValue: stats?.stats?.count,
-      }
-    : { baselineValue: baseline.value, variationValue: stats.value };
-}
-
-export function hasEnoughData(
-  baseline: SnapshotMetric,
-  stats: SnapshotMetric,
-  metric: ExperimentMetricInterface,
-  metricDefaults: MetricDefaults
-): boolean {
-  const { baselineValue, variationValue } = getMetricSampleSize(
-    baseline,
-    stats,
-    metric
-  );
-  if (!baselineValue || !variationValue) return false;
-
-  const minSampleSize =
-    metric.minSampleSize || metricDefaults.minimumSampleSize || 0;
-
-  return Math.max(baselineValue, variationValue) >= minSampleSize;
-}
-
-export function isSuspiciousUplift(
-  baseline: SnapshotMetric,
-  stats: SnapshotMetric,
-  metric: { maxPercentChange?: number },
-  metricDefaults: MetricDefaults
-): boolean {
-  if (!baseline?.cr || !stats?.cr) return false;
-
-  const maxPercentChange =
-    metric.maxPercentChange ?? metricDefaults?.maxPercentageChange ?? 0;
-
-  return Math.abs(baseline.cr - stats.cr) / baseline.cr >= maxPercentChange;
-}
-
-export function isBelowMinChange(
-  baseline: SnapshotMetric,
-  stats: SnapshotMetric,
-  metric: { minPercentChange?: number },
-  metricDefaults: MetricDefaults
-): boolean {
-  if (!baseline?.cr || !stats?.cr) return false;
-
-  const minPercentChange =
-    metric.minPercentChange || metricDefaults.minPercentageChange;
-
-  // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
-  return Math.abs(baseline.cr - stats.cr) / baseline.cr < minPercentChange;
-}
-
-export function shouldHighlight({
-  metric,
-  baseline,
-  stats,
-  hasEnoughData,
-  belowMinChange,
-}: {
-  metric: { id: string };
-  baseline: SnapshotMetric;
-  stats: SnapshotMetric;
-  hasEnoughData: boolean;
-  belowMinChange: boolean;
-}): boolean {
-  return !!(
-    metric &&
-    baseline?.value &&
-    stats?.value &&
-    hasEnoughData &&
-    !belowMinChange
-  );
-}
 
 export function getRisk(
   stats: SnapshotMetric,
@@ -276,21 +197,6 @@ export function applyMetricOverrides<T extends ExperimentMetricInterface>(
     }
   }
   return { newMetric, overrideFields };
-}
-
-export function isExpectedDirection(
-  stats: SnapshotMetric,
-  metric: { inverse?: boolean }
-): boolean {
-  const expected: number = stats?.expected ?? 0;
-  if (metric.inverse) {
-    return expected < 0;
-  }
-  return expected > 0;
-}
-
-export function isStatSig(pValue: number, pValueThreshold: number): boolean {
-  return pValue < pValueThreshold;
 }
 
 export function pValueFormatter(pValue: number, digits: number = 3): string {
@@ -526,40 +432,6 @@ export function getRowResults({
     maximumFractionDigits: 2,
   });
 
-  const inverse = metric?.inverse;
-  const directionalStatus: "winning" | "losing" =
-    (stats.expected ?? 0) * (inverse ? -1 : 1) > 0 ? "winning" : "losing";
-
-  let significant: boolean;
-  let significantUnadjusted: boolean;
-  let significantReason = "";
-  if (statsEngine === "bayesian") {
-    if (
-      (stats.chanceToWin ?? 0) > ciUpper ||
-      (stats.chanceToWin ?? 0) < ciLower
-    ) {
-      significant = true;
-      significantUnadjusted = true;
-    } else {
-      significant = false;
-      significantUnadjusted = false;
-      significantReason = `This metric is not statistically significant. The chance to win is outside the CI interval [${percentFormatter.format(
-        ciLower
-      )}, ${percentFormatter.format(ciUpper)}].`;
-    }
-  } else {
-    significant = isStatSig(
-      stats.pValueAdjusted ?? stats.pValue ?? 1,
-      pValueThreshold
-    );
-    significantUnadjusted = isStatSig(stats.pValue ?? 1, pValueThreshold);
-    if (!significant) {
-      significantReason = `This metric is not statistically significant. The p-value (${pValueFormatter(
-        stats.pValueAdjusted ?? stats.pValue ?? 1
-      )}) is greater than the threshold (${pValueFormatter(pValueThreshold)}).`;
-    }
-  }
-
   const hasData = !!stats?.value && !!baseline?.value;
   const metricSampleSize = getMetricSampleSize(baseline, stats, metric);
   const baselineSampleSize = metricSampleSize.baselineValue ?? baseline.value;
@@ -610,13 +482,6 @@ export function getRowResults({
       )}).`
     : "";
 
-  const belowMinChange = isBelowMinChange(
-    baseline,
-    stats,
-    metric,
-    metricDefaults
-  );
-
   const { risk, relativeRisk, showRisk } = getRisk(
     stats,
     baseline,
@@ -662,56 +527,62 @@ export function getRowResults({
     riskReason,
   };
 
-  const _shouldHighlight = shouldHighlight({
+  const {
+    belowMinChange,
+    significant,
+    significantUnadjusted,
+    resultsStatus,
+    directionalStatus,
+  } = getMetricResultStatus({
     metric,
+    metricDefaults,
     baseline,
     stats,
-    hasEnoughData: enoughData,
-    belowMinChange,
+    ciLower,
+    ciUpper,
+    pValueThreshold,
+    statsEngine,
   });
 
-  let resultsStatus: "won" | "lost" | "draw" | "" = "";
+  let significantReason = "";
+  if (!significant) {
+    if (statsEngine === "bayesian") {
+      significantReason = `This metric is not statistically significant. The chance to win is not less than ${percentFormatter.format(
+        ciLower
+      )} or greater than ${percentFormatter.format(ciUpper)}.`;
+    } else {
+      significantReason = `This metric is not statistically significant. The p-value (${pValueFormatter(
+        stats.pValueAdjusted ?? stats.pValue ?? 1
+      )}) is greater than the threshold (${pValueFormatter(pValueThreshold)}).`;
+    }
+  }
+
   let resultsReason = "";
   if (statsEngine === "bayesian") {
-    if (_shouldHighlight && (stats.chanceToWin ?? 0) > ciUpper) {
+    if (resultsStatus === "won") {
       resultsReason = `Significant win as the chance to win is above the ${percentFormatter.format(
         ciUpper
       )} threshold and the change is in the desired direction.`;
-      resultsStatus = "won";
-    } else if (_shouldHighlight && (stats.chanceToWin ?? 0) < ciLower) {
+    } else if (resultsStatus === "lost") {
       resultsReason = `Significant loss as the chance to win is below the ${percentFormatter.format(
         ciLower
       )} threshold and the change is not in the desired direction.`;
-      resultsStatus = "lost";
-    }
-    if (
-      enoughData &&
-      belowMinChange &&
-      ((stats.chanceToWin ?? 0) > ciUpper || (stats.chanceToWin ?? 0) < ciLower)
-    ) {
+    } else if (resultsStatus === "draw") {
       resultsReason =
         "The change is significant, but too small to matter (below the min detectable change threshold). Consider this a draw.";
-      resultsStatus = "draw";
     }
   } else {
-    if (_shouldHighlight && significant && directionalStatus === "winning") {
+    if (resultsStatus === "won") {
       resultsReason = `Significant win as the p-value is below the ${numberFormatter.format(
         pValueThreshold
       )} threshold`;
-      resultsStatus = "won";
-    } else if (
-      _shouldHighlight &&
-      significant &&
-      directionalStatus === "losing"
-    ) {
+    } else if (resultsStatus === "lost") {
       resultsReason = `Significant loss as the p-value is below the ${numberFormatter.format(
         pValueThreshold
       )} threshold`;
-      resultsStatus = "lost";
-    } else if (enoughData && significant && belowMinChange) {
+    } else if (resultsStatus === "draw") {
       resultsReason =
         "The change is significant, but too small to matter (below the min detectable change threshold). Consider this a draw.";
-      resultsStatus = "draw";
     }
   }
 


### PR DESCRIPTION
In prep for more robust alerting and notifications, this PR refactors the metric significance logic to the shared package where it will be used by back-end code for building metric notifications.

TODO:
- [x] Share code on how to use this to build notifs
- [x] Check for other instances of significance logic in the code base to centralize business logic (there is the sendSignificanceEmail but that is well out of date and should be deprecated eventually)

How this can be used to build notifs (pseudo-code that belongs in shared/experiments.ts for discussion):

```ts


function getMetricStatusesInSnapshot(
  metrics: ExperimentMetricInterface[],
  baseline: SnapshotVariation,
  variation: SnapshotVariation,
  // some org settings
  statsEngine: StatsEngine,
  metricDefaults: MetricDefaults,
  confidenceLevel: number,
  pValueThreshold: number,
): Record<string,  "won" | "lost" | "draw" | ""> {


  const ciUpper = confidenceLevel || 0.95;
  const ciLower = 1 - ciUpper;
  // may be a better way to handle metrics for which we cannot compute results for some reason
  // than just omitting them from response like I do here
  const metricStatuses: Record<string,  "won" | "lost" | "draw" | ""> = {};

  metrics.forEach((metric) => {
    const baselineStats = baseline.metrics[metric.id];
    const variationStats = variation.metrics[metric.id];
    if (!baselineStats || !variationStats) return;

    const {resultsStatus} = getMetricResultStatus({metric, metricDefaults, baseline: baselineStats, stats: variationStats, ciLower, ciUpper, pValueThreshold, statsEngine: statsEngine});
    
    metricStatuses[metric.id] = resultsStatus
  });
  return metricStatuses;
}


// FIRST approach uses the full last snapshot object
function getExperimentMetricNotifications(
  currentSnapshot: ExperimentSnapshotInterface,
  lastSnapshot: ExperimentSnapshotInterface | undefined,
  // some org settings
  metricDefaults: MetricDefaults,
  confidenceLevel: number,
  pValueThreshold: number,
  // the mettings they've selected to notify on
  metricsToNotify: ExperimentMetricInterface[], // await getMetricsByIds(context, metricIdsToNotify);
): Record<string,  "won" | "lost" | "">[] {

  const notifications: Record<string,  "won" | "lost" | "">[] = [];

  // Only fire events for overall dimension values, this logic should probably not be specific
  // to this method 
  if (currentSnapshot.dimension) return notifications;
  // TODO only automatic updates?
  // TODO validate both snapshots have same N variations
  

  const analysis = currentSnapshot.analyses?.[0];
  const results = analysis.results?.[0]
  if (!results) return notifications;
  const baselineVariation = results.variations[0];

  const lastAnalysis = lastSnapshot?.analyses?.[0];
  const lastResults = lastAnalysis?.results?.[0];
  const lastBaselineVariation = lastResults?.variations[0];

  results.variations.forEach((variation, i) => {
    if (i === 0) return;
    const variationNotifications: Record<string,  "won" | "lost" | ""> = {};
    const currentMetricStatuses = getMetricStatusesInSnapshot(metricsToNotify, baselineVariation, variation, analysis.settings.statsEngine, metricDefaults, confidenceLevel, pValueThreshold);

    const lastVariation = lastResults?.variations[i];
    const lastMetricStatuses = lastAnalysis && lastBaselineVariation && lastVariation &&  getMetricStatusesInSnapshot(metricsToNotify, lastBaselineVariation, lastVariation, lastAnalysis.settings.statsEngine, metricDefaults, confidenceLevel, pValueThreshold);
      
    for (const metric in currentMetricStatuses) {
      if (currentMetricStatuses[metric] === "won" && (!lastMetricStatuses || lastMetricStatuses[metric] !== "won")) {
        variationNotifications[metric] = "won"; // Metric X is now significantly winning
      }
      if (currentMetricStatuses[metric] === "" && (!!lastMetricStatuses && lastMetricStatuses[metric] !== "")) {
        variationNotifications[metric] = ""; // Metric X is no longer statistically significant
      }
      if (currentMetricStatuses[metric] === "lost" && (!lastMetricStatuses || lastMetricStatuses[metric] !== "lost")) {
        variationNotifications[metric] = "lost"; // Metric X is now significantly losing
      }
    }
    notifications.push(variationNotifications);
  });

  return notifications;

}

// SECOND approach only uses the last notification object, not the full snapshot
function getExperimentMetricNotifications2(
  currentSnapshot: ExperimentSnapshotInterface,
  lastNotifications: Record<string,  "won" | "lost" | "">[],
  // some org settings
  metricDefaults: MetricDefaults,
  confidenceLevel: number,
  pValueThreshold: number,
  // the mettings they've selected to notify on
  metricsToNotify: ExperimentMetricInterface[], // await getMetricsByIds(context, metricIdsToNotify);
): Record<string,  "won" | "lost" | "">[] {

  const notifications: Record<string,  "won" | "lost" | "">[] = [];

  // Only fire events for overall dimension values, this logic should probably not be specific
  // to this method 
  if (currentSnapshot.dimension) return notifications;
  // TODO only automatic updates?
  // TODO validate both snapshots have same N variations
  

  const analysis = currentSnapshot.analyses?.[0];
  const results = analysis.results?.[0]
  if (!results) return notifications;
  const baselineVariation = results.variations[0];

  results.variations.forEach((variation, i) => {
    if (i === 0) return;
    const variationNotifications: Record<string,  "won" | "lost" | ""> = {};
    const currentMetricStatuses = getMetricStatusesInSnapshot(metricsToNotify, baselineVariation, variation, analysis.settings.statsEngine, metricDefaults, confidenceLevel, pValueThreshold);
  
    const lastVariationNotifications = lastNotifications?.[i-1];

    for (const metric in currentMetricStatuses) {

      if (currentMetricStatuses[metric] === "won" && (!lastVariationNotifications || lastVariationNotifications[metric] !== "won")) {
        variationNotifications[metric] = "won"; // Metric X is now significantly winning
      }
      if (currentMetricStatuses[metric] === "" && (!!lastVariationNotifications && lastVariationNotifications[metric] !== "")) {
        variationNotifications[metric] = ""; // Metric X is no longer statistically significant
      }
      if (currentMetricStatuses[metric] === "lost" && (!lastVariationNotifications || lastVariationNotifications[metric] !== "lost")) {
        variationNotifications[metric] = "lost"; // Metric X is now significantly losing
      }
    }
    notifications.push(variationNotifications);
  });

  return notifications;

}
```