### PR TITLE
Fix typo in License Quota Exceeded message

### DIFF
--- a/packages/front-end/components/Layout/AccountPlanNotices.tsx
+++ b/packages/front-end/components/Layout/AccountPlanNotices.tsx
@@ -353,7 +353,7 @@ export default function AccountPlanNotices() {
           }
         >
           <div className="alert alert-danger py-1 px-2 d-none d-md-block mb-0 mr-1">
-            <FaExclamationTriangle /> license quota exceded
+            <FaExclamationTriangle /> license quota exceeded
           </div>
         </Tooltip>
       );


### PR DESCRIPTION
Fix typo in License Quota Exceeded message

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->

<img width="375" alt="image" src="https://github.com/growthbook/growthbook/assets/13710518/6f7e4753-4951-47ab-a3e2-cca273fc32b0">
