### PR TITLE
Add new Python SDK Version

### DIFF
--- a/docs/docs/lib/python.mdx
+++ b/docs/docs/lib/python.mdx
@@ -238,6 +238,55 @@ In addition, you can use `gb.evalFeature("feature-key")` to get back a `FeatureR
 - **experiment** - Information about the experiment (if any) which was used to assign the value to the user
 - **experimentResult** - The result of the experiment (if any) which was used to assign the value to the user
 
+## Sticky Bucketing
+
+**Available starting in version 1.1.0**
+
+By default GrowthBook does not persist assigned experiment variations for a user. We rely on deterministic hashing to ensure that the same user attributes always map to the same experiment variation. However, there are cases where this isn't good enough. For example, if you change targeting conditions in the middle of an experiment, users may stop being shown a variation even if they were previously bucketed into it.
+
+Sticky Bucketing is a solution to these issues. You can provide a Sticky Bucket Service to the GrowthBook instance to persist previously seen variations and ensure that the user experience remains consistent for your users.
+
+A sample `InMemoryStickyBucketService` implementation is provided for reference, but in production you will definitely want to implement your own version using a database, cookies, or similar for persistence.
+
+Sticky Bucket documents contain three fields
+
+- `attributeName` - The name of the attribute used to identify the user (e.g. `id`, `cookie_id`, etc.)
+- `attributeValue` - The value of the attribute (e.g. `123`)
+- `assignments` - A dictionary of persisted experiment assignments. For example: `{"exp1__0":"control"}`
+
+The attributeName/attributeValue combo is the primary key.
+
+Here's an example implementation using a theoretical `db` object:
+
+```python
+from growthbook import AbstractStickyBucketService, GrowthBook
+
+class MyStickyBucketService(AbstractStickyBucketService):
+    # Lookup a sticky bucket document
+    def get_assignments(self, attributeName: str, attributeValue: str) -> Optional[Dict]:
+        return db.find({
+          "attributeName": attributeName,
+          "attributeValue": attributeValue
+        })
+
+    def save_assignments(self, doc: Dict) -> None:
+        # Insert new record if not exists, otherwise update
+        db.upsert({
+            "attributeName": doc["attributeName"],
+            "attributeValue": doc["attributeValue"]
+        }, {
+          "$set": {
+            "assignments": doc["assignments"]
+          }
+        })
+
+# Pass in an instance of this service to your GrowthBook constructor
+
+gb = GrowthBook(
+  sticky_bucket_service = MyStickyBucketService()
+)
+```
+
 ## Inline Experiments
 
 Instead of declaring all features up-front and referencing them by ids in your code, you can also just run an experiment directly. This is done with the `run` method:

--- a/packages/front-end/components/Archetype/AssignmentTester.tsx
+++ b/packages/front-end/components/Archetype/AssignmentTester.tsx
@@ -3,6 +3,7 @@ import { FeatureInterface, FeatureTestResult } from "back-end/types/feature";
 import { FaChevronRight } from "react-icons/fa";
 import { ArchetypeInterface } from "back-end/types/archetype";
 import { FiAlertTriangle } from "react-icons/fi";
+import MinSDKVersions from "@/components/Features/MinSDKVersions";
 import { useAuth } from "@/services/auth";
 import ValueDisplay from "@/components/Features/ValueDisplay";
 import Code from "@/components/SyntaxHighlighting/Code";
@@ -13,7 +14,6 @@ import AttributeForm from "@/components/Archetype/AttributeForm";
 import Modal from "@/components/Modal";
 import { useUser } from "@/services/UserContext";
 import PremiumTooltip from "@/components/Marketing/PremiumTooltip";
-import { NewBucketingSDKList } from "@/components/Experiment/HashVersionSelector";
 import Toggle from "@/components/Forms/Toggle";
 import { useIncrementer } from "@/hooks/useIncrementer";
 import styles from "./AssignmentTester.module.scss";
@@ -379,7 +379,7 @@ export default function AssignmentTester({ feature, version }: Props) {
                           <br />
                           <br />
                           The following SDK versions support V2 hashing:
-                          <NewBucketingSDKList />
+                          <MinSDKVersions capability="bucketingV2" />
                         </>
                       }
                     >

--- a/packages/front-end/components/Archetype/AssignmentTester.tsx
+++ b/packages/front-end/components/Archetype/AssignmentTester.tsx
@@ -3,7 +3,6 @@ import { FeatureInterface, FeatureTestResult } from "back-end/types/feature";
 import { FaChevronRight } from "react-icons/fa";
 import { ArchetypeInterface } from "back-end/types/archetype";
 import { FiAlertTriangle } from "react-icons/fi";
-import MinSDKVersions from "@/components/Features/MinSDKVersions";
 import { useAuth } from "@/services/auth";
 import ValueDisplay from "@/components/Features/ValueDisplay";
 import Code from "@/components/SyntaxHighlighting/Code";
@@ -16,6 +15,7 @@ import { useUser } from "@/services/UserContext";
 import PremiumTooltip from "@/components/Marketing/PremiumTooltip";
 import Toggle from "@/components/Forms/Toggle";
 import { useIncrementer } from "@/hooks/useIncrementer";
+import MinSDKVersionsList from "@/components/Features/MinSDKVersionsList";
 import styles from "./AssignmentTester.module.scss";
 
 export interface Props {
@@ -379,7 +379,7 @@ export default function AssignmentTester({ feature, version }: Props) {
                           <br />
                           <br />
                           The following SDK versions support V2 hashing:
-                          <MinSDKVersions capability="bucketingV2" />
+                          <MinSDKVersionsList capability="bucketingV2" />
                         </>
                       }
                     >

--- a/packages/front-end/components/Experiment/HashVersionSelector.tsx
+++ b/packages/front-end/components/Experiment/HashVersionSelector.tsx
@@ -5,24 +5,7 @@ import { SDKConnectionInterface } from "back-end/types/sdk-connection";
 import useSDKConnections from "@/hooks/useSDKConnections";
 import SelectField from "@/components/Forms/SelectField";
 import Tooltip from "@/components/Tooltip/Tooltip";
-
-export function NewBucketingSDKList() {
-  return (
-    <ul>
-      <li>JavaScript &gt;= 0.23.0</li>
-      <li>React &gt;= 0.12.0</li>
-      <li>PHP &gt;= 1.2.0</li>
-      <li>Ruby &gt;= 1.0.0</li>
-      <li>Python &gt;= 1.0.0</li>
-      <li>Java &gt;= 0.6.0</li>
-      <li>Go &gt;= 0.1.4</li>
-      <li>Kotlin - no support yet</li>
-      <li>Swift - no support yet</li>
-      <li>Flutter - no support yet</li>
-      <li>C# - no support yet</li>
-    </ul>
-  );
-}
+import MinSDKVersions from "@/components/Features/MinSDKVersions";
 
 export function HashVersionTooltip({ children }: { children: ReactNode }) {
   return (
@@ -31,7 +14,7 @@ export function HashVersionTooltip({ children }: { children: ReactNode }) {
         <>
           V2 fixes potential bias issues when using similarly named tracking
           keys, but is only supported in the following SDKs and versions:
-          <NewBucketingSDKList />
+          <MinSDKVersions capability="bucketingV2" />
           Unsupported SDKs will fall back to using the V1 algorithm
           automatically.
         </>

--- a/packages/front-end/components/Experiment/HashVersionSelector.tsx
+++ b/packages/front-end/components/Experiment/HashVersionSelector.tsx
@@ -5,7 +5,7 @@ import { SDKConnectionInterface } from "back-end/types/sdk-connection";
 import useSDKConnections from "@/hooks/useSDKConnections";
 import SelectField from "@/components/Forms/SelectField";
 import Tooltip from "@/components/Tooltip/Tooltip";
-import MinSDKVersions from "@/components/Features/MinSDKVersions";
+import MinSDKVersionsList from "@/components/Features/MinSDKVersionsList";
 
 export function HashVersionTooltip({ children }: { children: ReactNode }) {
   return (
@@ -14,7 +14,7 @@ export function HashVersionTooltip({ children }: { children: ReactNode }) {
         <>
           V2 fixes potential bias issues when using similarly named tracking
           keys, but is only supported in the following SDKs and versions:
-          <MinSDKVersions capability="bucketingV2" />
+          <MinSDKVersionsList capability="bucketingV2" />
           Unsupported SDKs will fall back to using the V1 algorithm
           automatically.
         </>

--- a/packages/front-end/components/Experiment/UrlRedirectModal.tsx
+++ b/packages/front-end/components/Experiment/UrlRedirectModal.tsx
@@ -17,6 +17,7 @@ import Field from "@/components/Forms/Field";
 import Modal from "@/components/Modal";
 import Tooltip from "@/components/Tooltip/Tooltip";
 import Toggle from "@/components/Forms/Toggle";
+import MinSDKVersions from "@/components/Features/MinSDKVersions";
 
 function validateUrl(
   urlString: string
@@ -81,11 +82,7 @@ const UrlRedirectSdkAlert = ({
             <>
               URL Redirects are only supported in the following SDKs and
               versions:
-              <ul className="mb-1">
-                <li>Javascript &gt;= 0.36.0</li>
-                <li>React &gt;= 0.26.0</li>
-                <li>Node &gt;= 0.36.0</li>
-              </ul>
+              <MinSDKVersions capability="redirects" />
             </>
           }
         />

--- a/packages/front-end/components/Experiment/UrlRedirectModal.tsx
+++ b/packages/front-end/components/Experiment/UrlRedirectModal.tsx
@@ -17,7 +17,7 @@ import Field from "@/components/Forms/Field";
 import Modal from "@/components/Modal";
 import Tooltip from "@/components/Tooltip/Tooltip";
 import Toggle from "@/components/Forms/Toggle";
-import MinSDKVersions from "@/components/Features/MinSDKVersions";
+import MinSDKVersionsList from "@/components/Features/MinSDKVersionsList";
 
 function validateUrl(
   urlString: string
@@ -82,7 +82,7 @@ const UrlRedirectSdkAlert = ({
             <>
               URL Redirects are only supported in the following SDKs and
               versions:
-              <MinSDKVersions capability="redirects" />
+              <MinSDKVersionsList capability="redirects" />
             </>
           }
         />

--- a/packages/front-end/components/Features/AttributeModal.tsx
+++ b/packages/front-end/components/Features/AttributeModal.tsx
@@ -15,6 +15,8 @@ import Toggle from "@/components/Forms/Toggle";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import MultiSelectField from "@/components/Forms/MultiSelectField";
 import { useUser } from "@/services/UserContext";
+import Tooltip from "@/components/Tooltip/Tooltip";
+import MinSDKVersionsList from "./MinSDKVersionsList";
 
 export interface Props {
   close: () => void;
@@ -195,10 +197,14 @@ export default function AttributeModal({ close, attribute }: Props) {
           {form.watch("format") === "version" && (
             <div className="alert alert-warning">
               <strong>Warning:</strong> Version string attributes are only
-              supported in the latest Javascript and React SDK versions. Other
-              language support is coming soon. Do not use this format if you are
-              using an older SDK version or a different language as it will
-              break any filtering based on the attribute.
+              supported in{" "}
+              <Tooltip
+                body={<MinSDKVersionsList capability="semverTargeting" />}
+              >
+                <span className="text-primary">some SDK versions</span>
+              </Tooltip>
+              . Do not use this format if you are using an incompatible SDK as
+              it will break any filtering based on the attribute.
             </div>
           )}
         </>

--- a/packages/front-end/components/Features/FallbackAttributeSelector.tsx
+++ b/packages/front-end/components/Features/FallbackAttributeSelector.tsx
@@ -18,6 +18,7 @@ import useSDKConnections from "@/hooks/useSDKConnections";
 import { DocLink } from "@/components/DocLink";
 import SelectField from "@/components/Forms/SelectField";
 import Toggle from "@/components/Forms/Toggle";
+import MinSDKVersions from "@/components/Features/MinSDKVersions";
 
 export interface Props {
   // eslint-disable-next-line
@@ -199,10 +200,7 @@ export function StickyBucketingTooltip() {
       <div className="mb-2">
         Sticky Bucketing requires changes to your SDK implementation and is only
         supported in the following SDKs and versions:
-        <ul className="mb-1">
-          <li>Javascript &gt;= 0.32.0</li>
-          <li>React &gt;= 0.22.0</li>
-        </ul>
+        <MinSDKVersions capability="stickyBucketing" />
       </div>
     </>
   );

--- a/packages/front-end/components/Features/FallbackAttributeSelector.tsx
+++ b/packages/front-end/components/Features/FallbackAttributeSelector.tsx
@@ -18,7 +18,7 @@ import useSDKConnections from "@/hooks/useSDKConnections";
 import { DocLink } from "@/components/DocLink";
 import SelectField from "@/components/Forms/SelectField";
 import Toggle from "@/components/Forms/Toggle";
-import MinSDKVersions from "@/components/Features/MinSDKVersions";
+import MinSDKVersionsList from "@/components/Features/MinSDKVersionsList";
 
 export interface Props {
   // eslint-disable-next-line
@@ -200,7 +200,7 @@ export function StickyBucketingTooltip() {
       <div className="mb-2">
         Sticky Bucketing requires changes to your SDK implementation and is only
         supported in the following SDKs and versions:
-        <MinSDKVersions capability="stickyBucketing" />
+        <MinSDKVersionsList capability="stickyBucketing" />
       </div>
     </>
   );

--- a/packages/front-end/components/Features/MinSDKVersions.tsx
+++ b/packages/front-end/components/Features/MinSDKVersions.tsx
@@ -1,0 +1,25 @@
+import {
+  SDKCapability,
+  getMinSupportedSDKVersions,
+} from "shared/sdk-versioning";
+import { languageMapping } from "./SDKConnections/SDKLanguageLogo";
+
+export default function MinSDKVersions({
+  capability,
+}: {
+  capability: SDKCapability;
+}) {
+  const minVersions = getMinSupportedSDKVersions(capability);
+  return (
+    <ul className="mb-1">
+      {minVersions.map(({ language, minVersion }) => {
+        const display = languageMapping[language]?.label || language;
+        return (
+          <li key={language}>
+            {display} &gt;= {minVersion}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/packages/front-end/components/Features/MinSDKVersionsList.tsx
+++ b/packages/front-end/components/Features/MinSDKVersionsList.tsx
@@ -4,7 +4,7 @@ import {
 } from "shared/sdk-versioning";
 import { languageMapping } from "./SDKConnections/SDKLanguageLogo";
 
-export default function MinSDKVersions({
+export default function MinSDKVersionsList({
   capability,
 }: {
   capability: SDKCapability;

--- a/packages/front-end/components/Features/MinSDKVersionsList.tsx
+++ b/packages/front-end/components/Features/MinSDKVersionsList.tsx
@@ -10,16 +10,24 @@ export default function MinSDKVersionsList({
   capability: SDKCapability;
 }) {
   const minVersions = getMinSupportedSDKVersions(capability);
+
+  const hasNoCode = minVersions.some(({ language }) =>
+    language.startsWith("nocode")
+  );
+
   return (
     <ul className="mb-1">
-      {minVersions.map(({ language, minVersion }) => {
-        const display = languageMapping[language]?.label || language;
-        return (
-          <li key={language}>
-            {display} &gt;= {minVersion}
-          </li>
-        );
-      })}
+      {hasNoCode && <li key="nocode">HTML Script Tag</li>}
+      {minVersions
+        .filter(({ language }) => !language.startsWith("nocode"))
+        .map(({ language, minVersion }) => {
+          const display = languageMapping[language]?.label || language;
+          return (
+            <li key={language}>
+              {display} &gt;= {minVersion}
+            </li>
+          );
+        })}
     </ul>
   );
 }

--- a/packages/front-end/components/Features/PrerequisiteTargetingField.tsx
+++ b/packages/front-end/components/Features/PrerequisiteTargetingField.tsx
@@ -38,7 +38,7 @@ import { useUser } from "@/services/UserContext";
 import { DocLink } from "@/components/DocLink";
 import SelectField from "@/components/Forms/SelectField";
 import { GBAddCircle } from "@/components/Icons";
-import MinSDKVersions from "@/components/Features/MinSDKVersions";
+import MinSDKVersionsList from "@/components/Features/MinSDKVersionsList";
 
 export interface Props {
   value: FeaturePrerequisite[];
@@ -608,7 +608,7 @@ export const PrerequisiteAlerts = ({
             <>
               Prerequisite evaluation is only supported in the following SDKs
               and versions:
-              <MinSDKVersions capability="prerequisites" />
+              <MinSDKVersionsList capability="prerequisites" />
             </>
           }
         />

--- a/packages/front-end/components/Features/PrerequisiteTargetingField.tsx
+++ b/packages/front-end/components/Features/PrerequisiteTargetingField.tsx
@@ -38,6 +38,7 @@ import { useUser } from "@/services/UserContext";
 import { DocLink } from "@/components/DocLink";
 import SelectField from "@/components/Forms/SelectField";
 import { GBAddCircle } from "@/components/Icons";
+import MinSDKVersions from "@/components/Features/MinSDKVersions";
 
 export interface Props {
   value: FeaturePrerequisite[];
@@ -607,10 +608,7 @@ export const PrerequisiteAlerts = ({
             <>
               Prerequisite evaluation is only supported in the following SDKs
               and versions:
-              <ul className="mb-1">
-                <li>Javascript &gt;= 0.33.0</li>
-                <li>React &gt;= 0.23.0</li>
-              </ul>
+              <MinSDKVersions capability="prerequisites" />
             </>
           }
         />

--- a/packages/shared/src/sdk-versioning/index.ts
+++ b/packages/shared/src/sdk-versioning/index.ts
@@ -233,7 +233,7 @@ export function getMinSupportedSDKVersions(
   languages.forEach((language) => {
     const minVersion = getSDKCapabilityVersion(language, capability);
 
-    if (minVersion && minVersion !== "0.0.0") {
+    if (minVersion) {
       matches.push({ language, minVersion });
     }
   });

--- a/packages/shared/src/sdk-versioning/index.ts
+++ b/packages/shared/src/sdk-versioning/index.ts
@@ -221,6 +221,25 @@ export const getSDKCapabilityVersion = (
   return null;
 };
 
+export type MinSupportedSDKVersions = {
+  language: SDKLanguage;
+  minVersion: string;
+};
+export function getMinSupportedSDKVersions(
+  capability: SDKCapability
+): MinSupportedSDKVersions[] {
+  const languages = Object.keys(sdks) as SDKLanguage[];
+  const matches: MinSupportedSDKVersions[] = [];
+  languages.forEach((language) => {
+    const minVersion = getSDKCapabilityVersion(language, capability);
+
+    if (minVersion && minVersion !== "0.0.0") {
+      matches.push({ language, minVersion });
+    }
+  });
+  return matches;
+}
+
 // Copied from the JS SDK's mongrule.ts
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function paddedVersionString(input: any): string {

--- a/packages/shared/src/sdk-versioning/sdk-versions/python.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/python.json
@@ -1,6 +1,15 @@
 {
   "versions": [
     {
+      "version": "1.1.0",
+      "capabilities": [
+        "looseUnmarshalling",
+        "prerequisites",
+        "stickyBucketing",
+        "semverTargeting"
+      ]
+    },
+    {
       "version": "1.0.0",
       "capabilities": ["bucketingV2", "encryption"]
     }


### PR DESCRIPTION
### Features and Changes

- Add latest Python SDK version `1.1.0` with new capabilities - looseUnmarshalling, prerequisites, stickyBucketing, and semverTargeting
- New `MinSDKVersionsList` component to render a list of supported SDKs and their minimum supported versions for a given capability