### PR TITLE
enable cloud license key editting

### DIFF
--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -1958,11 +1958,8 @@ export async function putLicenseKey(
     throw new Error("Must be part of an organization");
   }
   req.checkPermissions("manageBilling");
-  if (IS_CLOUD) {
-    throw new Error("License keys are only applicable to self-hosted accounts");
-  }
 
-  if (IS_MULTI_ORG) {
+  if (!IS_CLOUD && IS_MULTI_ORG) {
     throw new Error(
       "You must use the LICENSE_KEY environmental variable on multi org sites."
     );

--- a/packages/front-end/components/Settings/EditLicenseModal.tsx
+++ b/packages/front-end/components/Settings/EditLicenseModal.tsx
@@ -1,8 +1,7 @@
-import React, { FC, useEffect, useState } from "react";
+import React, { FC, useState } from "react";
 import { useForm } from "react-hook-form";
 import { FaExclamationTriangle } from "react-icons/fa";
 import { useAuth } from "@/services/auth";
-import { isCloud } from "@/services/env";
 import { useUser } from "@/services/UserContext";
 import Field from "@/components/Forms/Field";
 import Modal from "@/components/Modal";
@@ -23,17 +22,6 @@ const EditLicenseModal: FC<{
       licenseKey: "",
     },
   });
-
-  useEffect(() => {
-    if (isCloud()) {
-      close();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isCloud]);
-
-  if (isCloud()) {
-    return null;
-  }
 
   return (
     <Modal


### PR DESCRIPTION
### Features and Changes

Eventually we will have ability to select a cloud organization in Retool and automatically add the licenseKey for them.  Until then, by enabling editing the licenseKey on cloud we can have sales create the license in Retool then give it to the cloud user to enter into their settings->general->licenseKey.

- enables editing license key on cloud

### Testing
in back-end/.env.local
```
IS_MULTI_ORG=true
IS_CLOUD=true
SSO_CONFIG=...a valid sso config
# LICENSE_KEY = ... make sure this line is commented out
```
make sure your organization in mongo doesn't have a licenseKey set.
start dev server
go to general->settings
click the pencil icon next to the license.
add a valid license key.
see that it is successfully saved.
