### PR TITLE
Temporarily add a job to retag 2.9 release to latest

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -1,7 +1,9 @@
-name: Manual 2.9.0 Retag Release
+name: One-time 2.9.0 Retag Release
 
 on:
-  workflow_dispatch:
+  push:
+    branches:
+      - ji/retag2.9
 
 jobs:
   # Tag the latest docker release with the tag

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -1,0 +1,23 @@
+name: Manual 2.9.0 Retag Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  # Tag the latest docker release with the tag
+  docker:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'growthbook/growthbook' }}
+    steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Install buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Add tag to latest image
+        run: |
+          docker buildx imagetools create -t growthbook/growthbook:2.9.0 growthbook/growthbook:latest


### PR DESCRIPTION
### Features and Changes

To avoid self-hosted users with air-gapped licenses from getting downgraded on 2.9 we have added a job to retag 2.9.
