### PR TITLE
Fix handling incorrect login method errors

### DIFF
--- a/packages/back-end/src/services/auth/index.ts
+++ b/packages/back-end/src/services/auth/index.ts
@@ -129,7 +129,7 @@ export async function processJWT(
     if (IS_CLOUD && !req.loginMethod?.id && user.verified && !req.verified) {
       res.status(406).json({
         status: 406,
-        message: "You must verify your email address before using GrowthBook",
+        message: "You must log in via SSO to use GrowthBook",
       });
       return;
     }


### PR DESCRIPTION
### Features and Changes

In the past whenever people logged in via email when they had already once logged in via SSO ProtectedPage handled the error via the error property on UserConext. Errors that occurred during the organization endpoint would resulting in a loading spinner forever. As part of https://github.com/growthbook/growthbook/pull/2339 a new modal was made to handle all errors from the organization endpoint.  Unfortunately that new modal didn't have the header tab with the log out, nor enable people to log out again, and that modal took precedence over ProtectedPage, and hence people who log in via email rather than SSO when they have logged in as SSO before, can't log out again to fix the situation.

This change adds any errors that come from the organization endpoint to the error property of the UserContext and hence ProtectedPage will also show any errors there.

It also updates the message to be a clearer reminder to the user to not use email to sign in, in the case they forgot to use SSO.

### Testing

In `front-end/.env.local` set 
```
IS_MULTI_ORG=true
IS_CLOUD=true
```
In `back-end/.env.local` set
```
IS_MULTI_ORG=true
IS_CLOUD=true
SSO_CONFIG=valid SSO config
```
Start the server.
Login via email.
See the logout button.
Logout.
Login via SSO.
See it log in correctly.
.....
In `front-end/.env.local` set 
```
IS_MULTI_ORG=false
IS_CLOUD=false
```
In `back-end/.env.local` set
```
LICENSE_KEY=A pro license
IS_MULTI_ORG=false
IS_CLOUD=false
SSO_CONFIG=valid SSO config
```
Remove any licenseKey from organization in mongo.
Start the server.
See the error message "Your license does not support SSO. Either upgrade to enterprise or remove SSO_CONFIG environment variable." also with the logout button now.
