### PR TITLE
Fix project roles missing when invitation accepted

### DIFF
--- a/packages/back-end/src/services/organizations.ts
+++ b/packages/back-end/src/services/organizations.ts
@@ -465,6 +465,8 @@ export async function acceptInvite(key: string, userId: string) {
       role: invite.role || "admin",
       limitAccessByEnvironment: !!invite.limitAccessByEnvironment,
       environments: invite.environments || [],
+      projectRoles: invite.projectRoles,
+      teams: invite.teams,
       dateCreated: new Date(),
     },
   ];


### PR DESCRIPTION
### Features and Changes

When an invitation is accepted, we were not copying over the project roles, only the global role.