### PR TITLE
Fix feature draft base revision bug

### DIFF
--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -1270,6 +1270,7 @@ async function getDraftRevision(
       feature,
       user: context.auditUser,
       environments: getEnvironmentIdsFromOrg(context.org),
+      baseVersion: version,
       org,
     });
 


### PR DESCRIPTION
### Features and Changes

If you create and discard a draft, new draft revisions you create will be based on top of that discarded draft instead of the published feature version.  This can cause some weird states, like a revision having "no changes" even though it's clearly different from the published version.