### PR TITLE
Adds difference type chooser to Reports

### DIFF
--- a/packages/back-end/src/services/reports.ts
+++ b/packages/back-end/src/services/reports.ts
@@ -111,7 +111,7 @@ export function getAnalysisSettingsFromReportArgs(
     sequentialTesting: args.sequentialTestingEnabled,
     sequentialTestingTuningParameter: args.sequentialTestingTuningParameter,
     pValueThreshold: args.pValueThreshold,
-    differenceType: "relative",
+    differenceType: args.differenceType ?? "relative",
     baselineVariationIndex: 0,
   };
 }

--- a/packages/back-end/types/report.d.ts
+++ b/packages/back-end/types/report.d.ts
@@ -1,7 +1,7 @@
 import { AttributionModel, MetricOverride } from "./experiment";
 import { SnapshotVariation } from "./experiment-snapshot";
 import { Queries } from "./query";
-import { StatsEngine } from "./stats";
+import { DifferenceType, StatsEngine } from "./stats";
 
 export interface ReportInterfaceBase {
   id: string;
@@ -61,6 +61,7 @@ export interface ExperimentReportArgs {
   sequentialTestingEnabled?: boolean;
   sequentialTestingTuningParameter?: number;
   pValueThreshold?: number;
+  differenceType?: DifferenceType;
 }
 export interface ExperimentReportResultDimension {
   name: string;

--- a/packages/front-end/components/Experiment/DifferenceTypeChooser.tsx
+++ b/packages/front-end/components/Experiment/DifferenceTypeChooser.tsx
@@ -65,6 +65,7 @@ export interface Props {
   ) => void;
   loading: boolean;
   mutate: () => void;
+  disabled?: boolean;
 }
 
 export default function DifferenceTypeChooser({
@@ -76,6 +77,7 @@ export default function DifferenceTypeChooser({
   setAnalysisSettings,
   loading,
   mutate,
+  disabled,
 }: Props) {
   const { apiCall } = useAuth();
 
@@ -118,11 +120,13 @@ export default function DifferenceTypeChooser({
         uuid={"difference-type-selector"}
         right={false}
         className="mt-2"
-        toggleClassName="d-inline-block dropdown-underline"
+        toggleClassName={`d-inline-block ${
+          disabled ? "" : "dropdown-underline"
+        }`}
         header={<div className="h6 mb-0">Difference Type</div>}
         toggle={<div className="d-inline-flex align-items-center">{title}</div>}
-        caret={true}
-        enabled={true}
+        caret={!disabled}
+        enabled={!disabled}
         open={open}
         setOpen={(b: boolean) => setOpen(b)}
       >

--- a/packages/front-end/components/Report/ConfigureReport.tsx
+++ b/packages/front-end/components/Report/ConfigureReport.tsx
@@ -192,7 +192,7 @@ export default function ConfigureReport({
           ...value,
           skipPartialData: !!value.skipPartialData,
         };
-        console.log(args);
+
         if (value.regressionAdjustmentEnabled) {
           args.metricRegressionAdjustmentStatuses = metricRegressionAdjustmentStatuses;
         }

--- a/packages/front-end/components/Report/ConfigureReport.tsx
+++ b/packages/front-end/components/Report/ConfigureReport.tsx
@@ -18,6 +18,7 @@ import { getValidDate } from "shared/dates";
 import { getScopedSettings } from "shared/settings";
 import { MetricInterface } from "back-end/types/metric";
 import { getRegressionAdjustmentsForMetric } from "shared/experiments";
+import { DifferenceType } from "@back-end/types/stats";
 import { useAuth } from "@/services/auth";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import { getExposureQuery } from "@/services/datasources";
@@ -103,6 +104,7 @@ export default function ConfigureReport({
   const form = useForm({
     defaultValues: {
       ...report.args,
+      differenceType: report.args.differenceType ?? "relative",
       exposureQueryId:
         getExposureQuery(
           datasource?.settings,
@@ -190,6 +192,7 @@ export default function ConfigureReport({
           ...value,
           skipPartialData: !!value.skipPartialData,
         };
+        console.log(args);
         if (value.regressionAdjustmentEnabled) {
           args.metricRegressionAdjustmentStatuses = metricRegressionAdjustmentStatuses;
         }
@@ -380,6 +383,28 @@ export default function ConfigureReport({
         labelClassName="font-weight-bold"
         showHelp={true}
         newUi={false}
+      />
+      <SelectField
+        label="Difference Type"
+        labelClassName="font-weight-bold"
+        value={form.watch("differenceType")}
+        onChange={(v) => form.setValue("differenceType", v as DifferenceType)}
+        sort={false}
+        options={[
+          {
+            label: "Relative",
+            value: "relative",
+          },
+          {
+            label: "Absolute",
+            value: "absolute",
+          },
+          {
+            label: "Scaled Impact",
+            value: "scaled",
+          },
+        ]}
+        helpText="Choose the units to display lifts in"
       />
       <MetricSelector
         datasource={form.watch("datasource")}

--- a/packages/front-end/pages/report/[rid].tsx
+++ b/packages/front-end/pages/report/[rid].tsx
@@ -41,6 +41,7 @@ import CompactResults from "@/components/Experiment/CompactResults";
 import BreakDownResults from "@/components/Experiment/BreakDownResults";
 import DimensionChooser from "@/components/Dimensions/DimensionChooser";
 import PageHead from "@/components/Layout/PageHead";
+import DifferenceTypeChooser from "@/components/Experiment/DifferenceTypeChooser";
 
 export default function ReportPage() {
   const router = useRouter();
@@ -143,6 +144,7 @@ export default function ReportPage() {
 
   const sequentialTestingEnabled =
     hasSequentialTestingFeature && !!report.args.sequentialTestingEnabled;
+  const differenceType = report.args.differenceType ?? "relative";
 
   return (
     <>
@@ -287,6 +289,19 @@ export default function ReportPage() {
                     userIdType={report.args.userIdType}
                     labelClassName="mr-2"
                     disabled={true}
+                  />
+                </div>
+                <div className="col-auto d-flex align-items-end mr-3">
+                  <DifferenceTypeChooser
+                    differenceType={report.args.differenceType ?? "relative"}
+                    // ensure disabled is true to style correctly
+                    // and callbacks are not needed
+                    disabled={true}
+                    phase={0}
+                    setDifferenceType={() => {}}
+                    setAnalysisSettings={() => {}}
+                    loading={false}
+                    mutate={() => {}}
                   />
                 </div>
                 <div className="col-auto d-flex align-items-end mr-3">
@@ -450,6 +465,7 @@ export default function ReportPage() {
                   seriestype={report.args.dimension}
                   variations={variations}
                   statsEngine={report.args.statsEngine}
+                  differenceType={differenceType}
                 />
               ) : (
                 <BreakDownResults
@@ -473,7 +489,7 @@ export default function ReportPage() {
                     report.args.metricRegressionAdjustmentStatuses
                   }
                   sequentialTestingEnabled={sequentialTestingEnabled}
-                  differenceType={"relative"}
+                  differenceType={differenceType}
                 />
               ))}
             {report.results && !report.args.dimension && (
@@ -540,7 +556,7 @@ export default function ReportPage() {
                       report.args.metricRegressionAdjustmentStatuses
                     }
                     sequentialTestingEnabled={sequentialTestingEnabled}
-                    differenceType={"relative"}
+                    differenceType={differenceType}
                     isTabActive={true}
                   />
                 </div>


### PR DESCRIPTION
Adds difference type selector to report config and to report results.

This is not as "slick" as in main results as it requires a full update of the report; furthermore, since we don't have caching on report queries and I don't want to wire that up as we want to move to using snapshots instead of reports to store custom reports, changing these settings will require users to run new queries I think. In any case, the "Save and Run" language makes that clear.

## Snapshots

<img width="1471" alt="Screenshot 2024-04-18 at 8 43 21 AM" src="https://github.com/growthbook/growthbook/assets/5298599/6ece38e2-0792-4b69-bd7d-7f07bf6f3ee9">

<img width="1243" alt="Screenshot 2024-04-18 at 8 49 58 AM" src="https://github.com/growthbook/growthbook/assets/5298599/56929be8-e49b-4bf6-bee3-ab8e8aee29be">

## Testing

Tested report with all 3 snapshot times and all three result types (no dim, dim, date dim)