### PR TITLE
Replace license on refetching

### DIFF
--- a/packages/enterprise/src/license.ts
+++ b/packages/enterprise/src/license.ts
@@ -580,16 +580,20 @@ export async function postResendEmailVerificationEmailToLicenseServer(
   );
 }
 
-// Creates or updates the license in the MongoDB cache in case the license server goes down.
-async function createOrReplaceLicenseMongoCache(license: LicenseInterface) {
-  await LicenseModel.findOneAndReplace(
-    { id: license.id },
-    { $set: license },
-    { upsert: true }
-  );
+// Creates or replaces the license in the MongoDB cache in case the license server goes down.
+async function createOrReplaceLicenseMongoCache(
+  license: LicenseInterface | LicenseDocument
+) {
+  const licenseObject =
+    license.constructor.name === "model"
+      ? (license as LicenseDocument).toObject()
+      : license;
+  await LicenseModel.findOneAndReplace({ id: license.id }, licenseObject, {
+    upsert: true,
+  });
 }
 
-// Updates the local daily cache, the one week backup Mongo cache, and verifies the license.
+// Updates the in memory cache, the one week backup Mongo cache, and verifies the license.
 export function setAndVerifyServerLicenseData(license: LicenseInterface) {
   verifyLicenseInterface(license);
   keyToLicenseData[license.id] = license;

--- a/packages/enterprise/src/license.ts
+++ b/packages/enterprise/src/license.ts
@@ -582,7 +582,7 @@ export async function postResendEmailVerificationEmailToLicenseServer(
 
 // Creates or updates the license in the MongoDB cache in case the license server goes down.
 async function createOrUpdateLicenseMongoCache(license: LicenseInterface) {
-  await LicenseModel.findOneAndUpdate(
+  await LicenseModel.findOneAndReplace(
     { id: license.id },
     { $set: license },
     { upsert: true }

--- a/packages/enterprise/src/license.ts
+++ b/packages/enterprise/src/license.ts
@@ -581,7 +581,7 @@ export async function postResendEmailVerificationEmailToLicenseServer(
 }
 
 // Creates or updates the license in the MongoDB cache in case the license server goes down.
-async function createOrUpdateLicenseMongoCache(license: LicenseInterface) {
+async function createOrReplaceLicenseMongoCache(license: LicenseInterface) {
   await LicenseModel.findOneAndReplace(
     { id: license.id },
     { $set: license },
@@ -594,7 +594,7 @@ export function setAndVerifyServerLicenseData(license: LicenseInterface) {
   verifyLicenseInterface(license);
   keyToLicenseData[license.id] = license;
   keyToCacheDate[license.id] = new Date();
-  createOrUpdateLicenseMongoCache(license).catch((e) => {
+  createOrReplaceLicenseMongoCache(license).catch((e) => {
     logger.error(`Error creating mongo cache: ${e}`);
     throw e;
   });
@@ -633,7 +633,7 @@ async function updateLicenseFromServer(
       userLicenseCodes,
       metaData
     );
-    createOrUpdateLicenseMongoCache(license).catch((e) => {
+    createOrReplaceLicenseMongoCache(license).catch((e) => {
       logger.error(`Error creating mongo cache: ${e}`);
       throw e;
     });
@@ -660,7 +660,7 @@ async function updateLicenseFromServer(
     license.lastFailedFetchDate = now;
     license.lastServerErrorMessage = e.message;
     license.usingMongoCache = true;
-    createOrUpdateLicenseMongoCache(license).catch((e) => {
+    createOrReplaceLicenseMongoCache(license).catch((e) => {
       logger.error(`Error creating mongo cache: ${e}`);
       throw e;
     });

--- a/packages/enterprise/src/models/licenseModel.ts
+++ b/packages/enterprise/src/models/licenseModel.ts
@@ -1,4 +1,5 @@
 import mongoose from "mongoose";
+import omit from "lodash/omit";
 import { LicenseInterface } from "../license";
 
 const licenseSchema = new mongoose.Schema({
@@ -54,3 +55,15 @@ export type LicenseDocument = mongoose.Document & LicenseInterface;
 const LicenseModel = mongoose.model<LicenseDocument>("License", licenseSchema);
 
 export { LicenseModel };
+
+export function toInterface(doc: LicenseDocument): LicenseInterface {
+  const ret = doc.toJSON<LicenseDocument>();
+  return omit(ret, ["__v", "_id"]);
+}
+
+export async function getLicenseByKey(
+  key: string
+): Promise<LicenseInterface | null> {
+  const doc = await LicenseModel.findOne({ id: key });
+  return doc ? toInterface(doc) : null;
+}

--- a/packages/enterprise/test/license.test.ts
+++ b/packages/enterprise/test/license.test.ts
@@ -435,7 +435,7 @@ describe("src/license", () => {
           expect(LicenseModel.findOneAndReplace).toHaveBeenCalledTimes(1);
           expect(LicenseModel.findOneAndReplace).toHaveBeenCalledWith(
             { id: licenseKey },
-            { $set: licenseData },
+            licenseData,
             { upsert: true }
           );
           expect(LicenseModel.findOne).toHaveBeenCalledTimes(1);
@@ -476,7 +476,7 @@ describe("src/license", () => {
           expect(LicenseModel.findOneAndReplace).toHaveBeenCalledTimes(1);
           expect(LicenseModel.findOneAndReplace).toHaveBeenCalledWith(
             { id: licenseKey },
-            { $set: licenseData },
+            licenseData,
             { upsert: true }
           );
           expect(LicenseModel.findOne).toHaveBeenCalledTimes(2);
@@ -731,14 +731,12 @@ describe("src/license", () => {
             expect(LicenseModel.findOneAndReplace).toHaveBeenCalledWith(
               { id: licenseKey },
               {
-                $set: {
-                  ...previousCache,
-                  usingMongoCache: true,
-                  firstFailedFetchDate: new Date(firstCallTime),
-                  lastFailedFetchDate: new Date(firstCallTime),
-                  lastServerErrorMessage:
-                    "License server errored with: internal server error",
-                },
+                ...previousCache,
+                usingMongoCache: true,
+                firstFailedFetchDate: new Date(firstCallTime),
+                lastFailedFetchDate: new Date(firstCallTime),
+                lastServerErrorMessage:
+                  "License server errored with: internal server error",
               },
               { upsert: true }
             );
@@ -762,14 +760,12 @@ describe("src/license", () => {
             expect(LicenseModel.findOneAndReplace).toHaveBeenCalledWith(
               { id: licenseKey },
               {
-                $set: {
-                  ...previousCache,
-                  usingMongoCache: true,
-                  firstFailedFetchDate: new Date(firstCallTime),
-                  lastFailedFetchDate: new Date(secondCallTime),
-                  lastServerErrorMessage:
-                    "License server errored with: different error",
-                },
+                ...previousCache,
+                usingMongoCache: true,
+                firstFailedFetchDate: new Date(firstCallTime),
+                lastFailedFetchDate: new Date(secondCallTime),
+                lastServerErrorMessage:
+                  "License server errored with: different error",
               },
               { upsert: true }
             );

--- a/packages/enterprise/test/license.test.ts
+++ b/packages/enterprise/test/license.test.ts
@@ -432,8 +432,8 @@ describe("src/license", () => {
           await licenseInit(licenseKey, userLicenseCodes, metaData);
           expect(getLicense(licenseKey)).toEqual(licenseData);
           expect(fetch).toHaveBeenCalledTimes(1);
-          expect(LicenseModel.findOneAndUpdate).toHaveBeenCalledTimes(1);
-          expect(LicenseModel.findOneAndUpdate).toHaveBeenCalledWith(
+          expect(LicenseModel.findOneAndReplace).toHaveBeenCalledTimes(1);
+          expect(LicenseModel.findOneAndReplace).toHaveBeenCalledWith(
             { id: licenseKey },
             { $set: licenseData },
             { upsert: true }
@@ -473,8 +473,8 @@ describe("src/license", () => {
             usingMongoCache: true,
           });
           expect(fetch).toHaveBeenCalledTimes(1);
-          expect(LicenseModel.findOneAndUpdate).toHaveBeenCalledTimes(1);
-          expect(LicenseModel.findOneAndUpdate).toHaveBeenCalledWith(
+          expect(LicenseModel.findOneAndReplace).toHaveBeenCalledTimes(1);
+          expect(LicenseModel.findOneAndReplace).toHaveBeenCalledWith(
             { id: licenseKey },
             { $set: licenseData },
             { upsert: true }
@@ -703,14 +703,14 @@ describe("src/license", () => {
         });
 
         describe("and when there is cached data in LicenseModel", () => {
-          const mockFindOneAndUpdate = jest.fn();
+          const mockfindOneAndReplace = jest.fn();
           let previousCache;
 
           beforeEach(() => {
             previousCache = {
               ...licenseData,
               toJSON: () => licenseData,
-              findOneAndUpdate: mockFindOneAndUpdate,
+              findOneAndReplace: mockfindOneAndReplace,
             };
             jest
               .spyOn(LicenseModel, "findOne")
@@ -727,8 +727,8 @@ describe("src/license", () => {
 
             await backgroundUpdateLicenseFromServerForTests;
 
-            expect(LicenseModel.findOneAndUpdate).toHaveBeenCalledTimes(1);
-            expect(LicenseModel.findOneAndUpdate).toHaveBeenCalledWith(
+            expect(LicenseModel.findOneAndReplace).toHaveBeenCalledTimes(1);
+            expect(LicenseModel.findOneAndReplace).toHaveBeenCalledWith(
               { id: licenseKey },
               {
                 $set: {
@@ -758,8 +758,8 @@ describe("src/license", () => {
             expect(getLicense(licenseKey)).toEqual(licenseData);
             await backgroundUpdateLicenseFromServerForTests;
 
-            expect(LicenseModel.findOneAndUpdate).toHaveBeenCalledTimes(2);
-            expect(LicenseModel.findOneAndUpdate).toHaveBeenCalledWith(
+            expect(LicenseModel.findOneAndReplace).toHaveBeenCalledTimes(2);
+            expect(LicenseModel.findOneAndReplace).toHaveBeenCalledWith(
               { id: licenseKey },
               {
                 $set: {


### PR DESCRIPTION
### Features and Changes
When a new license was fetched from the license server we were updating the cache, but we really meant to be replacing what was there.  When the license server goes down we set properties on the license in the cache detailing the error message, and if we just update the cache those properties will remain.

We also had been saving what the license server returned as long as it 200ed in the mongo cache and erroring if the signature didn't match.  Now we verify after all successful calls to get a new license and only save when it is verified successfully.  

### Testing
`yarn test`

Set `LICENSE_SERVER_URL=anything` in back-end/.env.local
Restart the dev server.
Hit a page.
See in mongo growthbook/license collection that lastServerErrorMessage has been set.
Remove LICENSE_SERVER_URL line in back-end/.env.local
Restart the dev server
Hit a page.
See in mongo growthbook/license collection that lastServerErrorMessage is no longer there.

