### PR TITLE
Remove percent rollouts with 0% from SDK Payload

### DIFF
--- a/packages/back-end/src/util/features.ts
+++ b/packages/back-end/src/util/features.ts
@@ -149,6 +149,13 @@ export function isRuleEnabled(rule: FeatureRule): boolean {
     return false;
   }
 
+  // Disable if percent rollout is 0
+  // Fixes a bug in SDKs where ~1 out of 10,000 users would get a feature even if it was set to 0% rollout
+  // If we ever add sticky bucketing to rollouts, we will need to remove this
+  if (rule.type === "rollout" && rule.coverage === 0) {
+    return false;
+  }
+
   return true;
 }
 


### PR DESCRIPTION
### Features and Changes

Our SDKs have a bug when percent rollouts have 0% coverage.  Due to rounding, ~1 out of 10,000 users will be included in the rollout when it should be 0.

This PR fixes the problem by removing 0% rollout rules from the SDK payload entirely.  We will still want to eventually patch this rounding bug in the SDKs themselves, but that will take time to update all of them.