### PR TITLE
Show error if first license load fails

### DIFF
--- a/packages/enterprise/src/license.ts
+++ b/packages/enterprise/src/license.ts
@@ -727,7 +727,7 @@ export async function licenseInit(
           if (
             forceRefresh ||
             !mongoCache ||
-            !mongoCache.dateUpdated ||
+            !mongoCache.dateUpdated || // If the first call to get the license errors, the cache will be created with no dateUpdated
             new Date(mongoCache.dateUpdated) < oneWeekAgo
           ) {
             license = await updateLicenseFromServer(
@@ -822,8 +822,10 @@ export function getLicenseError(org: MinimalOrganization): string {
   // Licenses might not have a plan if sign up for pro, but abandon checkout, in which case we don't want to show an error
   // Or it might not have a plan if the license is set in the env var but the license server wasn't whitelisted, in which case we do want to show the error
   if (!licenseData || !licenseData.plan) {
-    if (licenseData?.lastServerErrorMessage) {
-      return "License server down for too long";
+    if (licenseData?.lastServerErrorMessage?.includes("Could not connect")) {
+      return "License server unreachable for too long";
+    } else if (licenseData?.lastServerErrorMessage) {
+      return "License server erroring for too long";
     }
     return "";
   }
@@ -845,7 +847,14 @@ export function getLicenseError(org: MinimalOrganization): string {
     }
 
     if (new Date() > cachedDataGoodUntil) {
-      return "License server down for too long";
+      if (
+        !licenseData?.lastServerErrorMessage ||
+        licenseData?.lastServerErrorMessage?.includes("Could not connect")
+      ) {
+        return "License server unreachable for too long";
+      } else {
+        return "License server erroring for too long";
+      }
     }
   }
 

--- a/packages/front-end/components/Layout/AccountPlanNotices.tsx
+++ b/packages/front-end/components/Layout/AccountPlanNotices.tsx
@@ -118,10 +118,8 @@ export default function AccountPlanNotices() {
               </div>
             </Tooltip>
           );
-        case "License server down for too long":
-          return license.lastServerErrorMessage?.includes(
-            "Could not connect"
-          ) ? (
+        case "License server unreachable for too long":
+          return (
             <Tooltip
               body={<>Please make sure that you have whitelisted 75.2.109.47</>}
             >
@@ -129,7 +127,9 @@ export default function AccountPlanNotices() {
                 <FaExclamationTriangle /> license server unreachable
               </div>
             </Tooltip>
-          ) : (
+          );
+        case "License server erroring for too long":
+          return (
             <Tooltip body={<>{license.lastServerErrorMessage}</>}>
               <div className="alert alert-danger py-1 px-2 mb-0 d-none d-md-block mr-1">
                 <FaExclamationTriangle /> license server error


### PR DESCRIPTION
### Features and Changes

If there is a brand new installation and the server is not reachable, or throws an error such as the license not being found we want that error to display.  

### Testing

`yarn test`
Empty growthbook.licenses in mongo.
Remove any license_key on organization in mongo.
set `LICENSE_SERVER_URL=anything` in back-end/.env.local and run `yarn dev`
hit localhost:3000 and see the error message that the license server is not reachable

kill the back-end server
reset `LICENSE_SERVER_URL`
set `LICENSE_KEY=license_bad_key` in back-end/.env.local and run `yarn dev`
hit localhost:3000 and see the error message that there was a license server error and the license could not be found.

kill the back-end server
reset the `LICENSE_KEY` to a valid key  in back-end/.env.local and run `yarn dev`
hit localhost:3000 and see no error message and the license plan in the AccountPlan component in the topnav.
