### PR TITLE
fixing docs typo to align w/ Equation 9 in Waudby-Smith

### DIFF
--- a/docs/docs/statistics/sequential.mdx
+++ b/docs/docs/statistics/sequential.mdx
@@ -42,7 +42,7 @@ For GrowthBook, we selected a method that would work for the wide variety of exp
 
 Specifically, GrowthBook's confidence sequences, which take the place of confidence intervals, become:
 
-$$\left(\hat{\mu} \pm \hat{\sigma}*\sqrt{\frac{2(N\rho^2 + 1)}{N\rho^2}\log\left(\frac{\sqrt{N\rho^2 + 1}}{\alpha}\right)}\right)$$
+$$\left(\hat{\mu} \pm \hat{\sigma}*\sqrt{N}*\sqrt{\frac{2(N\rho^2 + 1)}{N^{2}\rho^2}\log\left(\frac{\sqrt{N\rho^2 + 1}}{\alpha}\right)}\right)$$
 
 $$\rho = \sqrt{\frac{-2\text{log}(\alpha) + \text{log}(-2 \text{log}(\alpha) + 1)}{N^*}}$$
 

--- a/docs/docs/statistics/sequential.mdx
+++ b/docs/docs/statistics/sequential.mdx
@@ -42,7 +42,7 @@ For GrowthBook, we selected a method that would work for the wide variety of exp
 
 Specifically, GrowthBook's confidence sequences, which take the place of confidence intervals, become:
 
-$$\left(\hat{\mu} \pm \hat{\sigma}*N * \sqrt{\frac{2(N\rho^2 + 1)}{N^2\rho^2}\log\left(\frac{\sqrt{N\rho^2 + 1}}{\alpha}\right)}\right)$$
+$$\left(\hat{\mu} \pm \hat{\sigma}*\sqrt{\frac{2(N\rho^2 + 1)}{N\rho^2}\log\left(\frac{\sqrt{N\rho^2 + 1}}{\alpha}\right)}\right)$$
 
 $$\rho = \sqrt{\frac{-2\text{log}(\alpha) + \text{log}(-2 \text{log}(\alpha) + 1)}{N^*}}$$
 


### PR DESCRIPTION
In the original Waudby-Smith doc Equation 9 is framed as sample standard deviation of the data times term that is $$o\left(\sqrt{\log(\sqrt{n})/n}\right)$$.  We have sample standard error in our documentation; this should be multiplied by root N, not N.   