### PR TITLE
Show org id for airgapped license creation

### DIFF
--- a/packages/front-end/components/GeneralSettings/OrganizationAndLicenseSettings.tsx
+++ b/packages/front-end/components/GeneralSettings/OrganizationAndLicenseSettings.tsx
@@ -48,6 +48,13 @@ export default function OrganizationAndLicenseSettings({
                 <strong>Owner:</strong> {org.ownerEmail}
               </div>
             </div>
+            {!isCloud() && !isMultiOrg() && (
+              <div className="form-group row">
+                <div className="col-sm-12">
+                  <strong>Organization Id:</strong> {org.id}
+                </div>
+              </div>
+            )}
           </div>
         </div>
         {(isCloud() || !isMultiOrg()) && <ShowLicenseInfo />}


### PR DESCRIPTION
### Features and Changes
In order to create an air-gapped license that is locked onto a particular organization we need some way for customers to find out their org Id and send it to us.  So now we show it in Settings->General->Organization.

### Testing
set 
`IS_CLOUD=false`
`IS_MULTI_ORG=false`
in `front-end/.env.local`

`yarn dev`
Go to:
http://localhost:3000/settings
and see orgId listed.

### Screenshots
![Screenshot 2024-04-23 at 1 07 53 PM](https://github.com/growthbook/growthbook/assets/950231/61b410c4-f85d-4b38-af89-3742bd28aff9)
