### PR TITLE
Hide billing for annual pro users

### DIFF
--- a/packages/front-end/hooks/useStripeSubscription.ts
+++ b/packages/front-end/hooks/useStripeSubscription.ts
@@ -71,6 +71,28 @@ export default function useStripeSubscription() {
     trialEnd = getValidDate(trialEnd * 1000);
   }
 
+  const canSubscribe = () => {
+    if (disableSelfServeBilling) return false;
+
+    if (organization?.enterprise) return false; //TODO: Remove this once we have moved the license off the organization
+
+    if (license?.plan === "enterprise") return false;
+
+    // if already on pro, they must have a stripeSubscription - some self-hosted pro have an annual contract not directly through stripe.
+    if (
+      license &&
+      ["pro", "pro_sso"].includes(license.plan) &&
+      !license.stripeSubscription
+    )
+      return false;
+
+    if (!selfServePricingEnabled) return false;
+
+    if (hasActiveSubscription) return false;
+
+    return true;
+  };
+
   return {
     freeSeats,
     quote: quote,
@@ -85,14 +107,6 @@ export default function useStripeSubscription() {
     trialEnd: trialEnd as null | Date,
     showSeatOverageBanner,
     loading: !quote || !organization,
-    canSubscribe:
-      !disableSelfServeBilling &&
-      !organization?.enterprise && //TODO: Remove this once we have moved the license off the organization
-      license?.plan != "enterprise" &&
-      (!license || // TODO: Can remove the !license check once we have moved the license off the organization
-        !["pro", "pro_sso"].includes(license.plan) || // they must be on free plan
-        license?.stripeSubscription !== undefined) && // if on pro, they must have a subscription - some self-hosted pro have an annual contract not directly through stripe.
-      selfServePricingEnabled &&
-      !hasActiveSubscription,
+    canSubscribe: canSubscribe(),
   };
 }

--- a/packages/front-end/hooks/useStripeSubscription.ts
+++ b/packages/front-end/hooks/useStripeSubscription.ts
@@ -89,6 +89,9 @@ export default function useStripeSubscription() {
       !disableSelfServeBilling &&
       !organization?.enterprise && //TODO: Remove this once we have moved the license off the organization
       license?.plan != "enterprise" &&
+      (!license || // TODO: Can remove the !license check once we have moved the license off the organization
+        !["pro", "pro_sso"].includes(license.plan) || // they must be on free plan
+        license?.stripeSubscription !== undefined) && // if on pro, they must have a subscription - some self-hosted pro have an annual contract not directly through stripe.
       selfServePricingEnabled &&
       !hasActiveSubscription,
   };


### PR DESCRIPTION
### Features and Changes

Some self hosted pro users have an annual contract that sales manage.   We can tell that by there not being any `stripeSubscription` info on their license.

- old cloud users who don't have a license are not affected by this change
- free users are not affected by this change
- pro and pro_sso users that have a stripeSubscription attached are not affected by this change
- pro and pro_sso users on a license that don't have a stripeSubscription including airgapped pro plans will be affected:
  - `canSubscribe` will now be false
  - billing page will say "Contact sales@growthbook.io to make changes to your subscription plan."

The other places where `canSubscribe` is used should not be affected as they have other conditions in place such as `isCloud()`, `subscriptionStatus`, or `activeAndInvidedUsers>freeSeats` which would not occur for self-hosted pro licenses without a stripeSubscription.

### Testing

#### Test Free plan
Remove any "subscription" on the organization in mongo.
Remove and "licenseKey" on the organization in mongo.
Remove any LICENSE_KEY in env vars.
`yarn dev`
Go to /billing page and see "You are on the free plan \<Upgrade\>"

#### Test Enterprise
In central-license-server repo run `yarn dev`.
Click Upgrade and choose enterprise trial.
Click link in email.
Go to /billing page and see the message that enterprise customers must talk to account manager.

#### Test Pro without a stripe subscription
In mongo change license.newlicenses collection to set `plan` to be `pro_sso`. (mimics a pro account without a stripe supscription.)
Go to Settings->general.  Click refresh on the license.
Go to /billing page and see the "Contact sales@growthbook.io to make changes to your subscription plan."

#### Test pro with a stripe subscription
In mongo delete all license.newlicenses collection and remove licenseKey on the growthbook.organizations.
Upgrade to pro.
go to /billing
See "You have a valid payment method on file. You will be billed automatically on this date." and "\<Plan Detail\>".

#### Test airgapped pro.
In mongo delete all license.newlicenses collection and remove licenseKey on the growthbook.organizations.
Set LICENSE_KEY=...dev airgapped pro license
Restart the server
Go to /billing
See the  "Contact sales@growthbook.io to make changes to your subscription plan."