### PR TITLE
fix a type check due to allowing plan be undefined

### DIFF
--- a/packages/front-end/hooks/useStripeSubscription.ts
+++ b/packages/front-end/hooks/useStripeSubscription.ts
@@ -81,7 +81,7 @@ export default function useStripeSubscription() {
     // if already on pro, they must have a stripeSubscription - some self-hosted pro have an annual contract not directly through stripe.
     if (
       license &&
-      ["pro", "pro_sso"].includes(license.plan) &&
+      ["pro", "pro_sso"].includes(license.plan || "") &&
       !license.stripeSubscription
     )
       return false;


### PR DESCRIPTION
### Features and Changes
For some reason ci when deploying broke but when reviewing it had said it was ok.

### Testing
`yarn type-check`
see it pass

