### PR TITLE
Change Default value to OFF instead of foo

### DIFF
--- a/packages/front-end/services/features.ts
+++ b/packages/front-end/services/features.ts
@@ -339,7 +339,7 @@ export function getDefaultValue(valueType: FeatureValueType): string {
     return "1";
   }
   if (valueType === "string") {
-    return "foo";
+    return "OFF"; // Default Values should be the OFF State to match most platforms.
   }
   if (valueType === "json") {
     return "{}";


### PR DESCRIPTION
### Features and Changes

Modify the default string from being "foo" -> "OFF" when you select a string feature type.

### Testing
UI -> Features -> Add a Feature -> Select String

### Screenshots
<img width="795" alt="image" src="https://github.com/growthbook/growthbook/assets/33769422/88bd7ff6-f804-4e01-815e-7f072227e6c6">
<img width="795" alt="image" src="https://github.com/growthbook/growthbook/assets/33769422/3d0ff6d2-fc39-461c-bf88-39ff44bb87a2">
