### PR TITLE
Use aws-sdk v3 for athena connection

### DIFF
--- a/packages/back-end/package.json
+++ b/packages/back-end/package.json
@@ -27,6 +27,7 @@
     "generate-api-types": "yarn generate-api-models && swagger-cli bundle -t yaml src/api/openapi/openapi.tmp.yaml -o generated/spec.yaml && node src/scripts/generate-openapi.mjs"
   },
   "dependencies": {
+    "@aws-sdk/client-athena": "^3.564.0",
     "@clickhouse/client": "^1.0.1",
     "@databricks/sql": "^1.8.1",
     "@dqbd/tiktoken": "^1.0.7",

--- a/packages/back-end/src/services/athena.ts
+++ b/packages/back-end/src/services/athena.ts
@@ -16,7 +16,6 @@ function getAthenaInstance(params: AthenaConnectionParams) {
       accessKeyId: params.accessKeyId || '',
       secretAccessKey: params.secretAccessKey || '',
     },
-
     region: params.region,
   });
 }


### PR DESCRIPTION
### Features and Changes

Update athena-client to use aws-sdk v3.
This enables GB to connect to athena running in another aws account using cross account assume role.

https://docs.aws.amazon.com/sdkref/latest/guide/feature-assume-role-credentials.html

```
SDK	                Supported	Notes or more information
SDK for JavaScript 3.x	Yes	
SDK for JavaScript 2.x	Partial	        credential_source not supported.
```

aws-sdk v2 is also in maintenance mode & marked for deprecation:
https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-javascript-v2/

### Dependencies

None.

### Testing

Updated existing athena connected GB instance.

### Screenshots

No UI-changes.
