### PR TITLE
Hide value column when the sql no longer has it

### DIFF
--- a/packages/front-end/pages/metric/[mid].tsx
+++ b/packages/front-end/pages/metric/[mid].tsx
@@ -33,7 +33,7 @@ import LoadingOverlay from "@/components/LoadingOverlay";
 import DeleteButton from "@/components/DeleteButton/DeleteButton";
 import { useAuth } from "@/services/auth";
 import { getMetricFormatter } from "@/services/metrics";
-import MetricForm from "@/components/Metrics/MetricForm";
+import MetricForm, { usesValueColumn } from "@/components/Metrics/MetricForm";
 import Tabs from "@/components/Tabs/Tabs";
 import Tab from "@/components/Tabs/Tab";
 import StatusIndicator from "@/components/Experiment/StatusIndicator";
@@ -1011,7 +1011,8 @@ const MetricPage: FC = () => {
                         </RightRailSectionGroup>
                       )}
                       {metric.type != "binomial" &&
-                        metric.templateVariables?.valueColumn && (
+                        metric.templateVariables?.valueColumn &&
+                        usesValueColumn(metric.sql) && (
                           <RightRailSectionGroup
                             title="Value Column"
                             type="custom"


### PR DESCRIPTION
### Features and Changes

Hides valueColumn when it is no longer used in the sql.

### Testing

Go to /metrics
Choose `Purchases - Number of Orders (72 hour window)` from the sample data.
Click "Edit" under "Query Settings"
Click "Edit Sql"
Modify the query replacing `1 as value` with `{{valueColumn}} as value`.
Uncheck "Test Query before confirming"
Click "Confirm Changes".
Put `1` in the valueColumn field.
Click "Next"
Click "Save"
Look in the "Query Settings" section and see `Value Column: 1`.
Click "Edit" again under "Query Settings"
Click "Edit Sql"
Modify the query replacing `{{valueColumn}} as value` with `1 as value`.
Click "Next"
Click "Save"
Now there is something in valueColumn but it is not actually used in the metric sql anymore so it doesn't make sense to show it in the query settings window.
Look in the query settings window and no longer see `Value Column: 1`.


### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
