### PR TITLE
Fix changing users on a cancelled subscription

### DIFF
--- a/packages/back-end/src/services/organizations.ts
+++ b/packages/back-end/src/services/organizations.ts
@@ -4,6 +4,7 @@ import { cloneDeep } from "lodash";
 import { Request } from "express";
 import {
   getLicense,
+  isActiveSubscriptionStatus,
   isAirGappedLicenseKey,
   postSubscriptionUpdateToLicenseServer,
 } from "enterprise";
@@ -258,7 +259,10 @@ async function updateSubscriptionIfProLicense(
     !isAirGappedLicenseKey(organization.licenseKey)
   ) {
     const license = await getLicense(organization.licenseKey);
-    if (license?.plan === "pro") {
+    if (
+      license?.plan === "pro" &&
+      isActiveSubscriptionStatus(license?.stripeSubscription?.status)
+    ) {
       // Only pro plans have a Stripe subscription that needs to get updated
       const seatsInUse = getNumberOfUniqueMembersAndInvites(organization);
       await postSubscriptionUpdateToLicenseServer(


### PR DESCRIPTION
### Features and Changes

Stripe will error if trying to update the number of users on a subscription.  That error got passed down through the license server back to growthbook.  This change makes it such that it won't call the license server if the subscription is cancelled.

### Testing

Start the license dev server.
Set `LICENSE_SERVER_URL=http://localhost:8080/api/v1/` in back-end/.env.local
Sign up for a pro plan.
Cancel plan.
Go to stripe. 
Find the plan and in the action menu click "Cancel Now"
Go to the team page.
Delete a user and see no error.
Invite a user and see a warning message that they have more than the free number of users and need to sign up for pro again.
Sign up for pro again.
Add a user.
