### PR TITLE
Set results UI denominator correctly when it is 0

### DIFF
--- a/packages/front-end/components/Experiment/MetricValueColumn.tsx
+++ b/packages/front-end/components/Experiment/MetricValueColumn.tsx
@@ -3,6 +3,7 @@ import { CSSProperties, DetailedHTMLProps, TdHTMLAttributes } from "react";
 import {
   ExperimentMetricInterface,
   isFactMetric,
+  isRatioMetric,
   quantileMetricType,
 } from "shared/experiments";
 import {
@@ -52,7 +53,10 @@ export default function MetricValueColumn({
   );
 
   const numeratorValue = stats.value;
-  const denominatorValue = stats.denominator || stats.users || users;
+  const denominatorValue =
+    metric.denominator || isRatioMetric(metric)
+      ? stats.denominator ?? stats.users
+      : stats.users || users;
 
   let numerator: string;
   let denominator = numberFormatter.format(denominatorValue);

--- a/packages/front-end/components/Metrics/MetricForm/index.tsx
+++ b/packages/front-end/components/Metrics/MetricForm/index.tsx
@@ -406,9 +406,7 @@ const MetricForm: FC<MetricFormProps> = ({
         // If the numerator has a value (not binomial),
         // then count metrics can be used as the denominator as well (as long as they don't have their own denominator)
         // This makes it act like a true ratio metric
-        return (
-          value.type !== "binomial" && m.type === "count" && !m.denominator
-        );
+        return value.type !== "binomial" && !m.denominator;
       })
       .map((m) => {
         return {


### PR DESCRIPTION
If a denominator is 0 for a ratio metric, we should return that rather than fall back to users. This PR does that.

Because the stats engine will always return denominator = 0 for non-ratio metrics, we have to use the kind of logic I've built into the FE here.

This PR also allows for any non-binomial metric to be a ratio denominator (for classic metrics), not just count metrics.

Before (non-sensical results):
<img width="1242" alt="Screenshot 2024-04-29 at 12 20 20 PM" src="https://github.com/growthbook/growthbook/assets/5298599/a0c470c2-844c-4f81-baad-72304f7675fa">

After (more sensical results):
<img width="1301" alt="Screenshot 2024-04-29 at 12 19 59 PM" src="https://github.com/growthbook/growthbook/assets/5298599/00957efb-a3d4-4643-b8ff-93388b8c237f">
