### PR TITLE
Throw an error if force refresh fails

### DIFF
--- a/packages/enterprise/src/license.ts
+++ b/packages/enterprise/src/license.ts
@@ -652,6 +652,7 @@ async function updateLicenseFromServer(
     license.lastServerErrorMessage = e.message;
     license.usingMongoCache = true;
     verifyAndSetServerLicenseData(license);
+    throw e;
   }
   return license;
 }

--- a/packages/front-end/components/License/ShowLicenseInfo.tsx
+++ b/packages/front-end/components/License/ShowLicenseInfo.tsx
@@ -152,7 +152,7 @@ const ShowLicenseInfo: FC<{
                 {license && (
                   <>
                     {license.id.startsWith("license") && (
-                      <div className="col-sm-2">
+                      <div className="col">
                         <RefreshLicenseButton />
                       </div>
                     )}


### PR DESCRIPTION
### Features and Changes

Since we moved to relying on the mongoCache first and sometimes doing the refresh in the background, we stopped throwing an error when forceRefresh is true.  When setting a bad license key we were relying on the thrown error to display the error to the user.

- Throws an error and displays it when a license is set via general->settings and there is an error.
- Adds tests to make sure the license errors on forceRefresh is true.
- Changes the UI slightly so that when there is an error during a "Refresh License" call that the whole error gets displayed rather than getting cut off.

### Testing

`yarn test`
In back-end/.env.local set:
`LICENSE_SERVER_URL=http://anything`
Go to general->settings.  
Click "Refresh License"
See the full error message.

In back-end/.env.local set:
`LICENSE_SERVER_URL=http://localhost:8080/api/v1/`
Start the dev license server.
Click the pencil icon by "License Key"
Enter "license_bad" and click submit.
See "Invalid license key" error message.

### Screenshots
![Screenshot 2024-04-30 at 11 26 44 AM](https://github.com/growthbook/growthbook/assets/950231/9061eab4-5f8e-4c2b-a667-f9ecfc48e709)

