### PR TITLE
Set license key in admin on cloud

### DIFF
--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -1983,7 +1983,7 @@ async function setLicenseKey(org: OrganizationInterface, licenseKey: string) {
 
   try {
     org.licenseKey = licenseKey;
-    await initializeLicenseForOrg(org, licenseKey, true);
+    await initializeLicenseForOrg(org, true);
   } catch (error) {
     // As we show this error on the front-end, show a more generic invalid license key error
     // if the error is not related to being able to connect to the license server

--- a/packages/front-end/components/Admin/EditOrganization.tsx
+++ b/packages/front-end/components/Admin/EditOrganization.tsx
@@ -1,6 +1,7 @@
 import { useState, FC } from "react";
 import { useAuth } from "@/services/auth";
 import Modal from "@/components/Modal";
+import { isCloud } from "@/services/env";
 
 const EditOrganization: FC<{
   onEdit: () => void;
@@ -8,17 +9,18 @@ const EditOrganization: FC<{
   id: string;
   currentName: string;
   currentExternalId: string;
-  showExternalId?: boolean;
+  currentLicenseKey: string;
 }> = ({
   onEdit,
   close,
   id,
   currentName,
   currentExternalId,
-  showExternalId,
+  currentLicenseKey,
 }) => {
   const [name, setName] = useState(currentName);
   const [externalId, setExternalId] = useState(currentExternalId);
+  const [licenseKey, setLicenseKey] = useState(currentLicenseKey);
 
   const { apiCall } = useAuth();
 
@@ -27,12 +29,14 @@ const EditOrganization: FC<{
       status: number;
       message?: string;
       orgId?: string;
+      licenseKey?: string;
     }>("/organization", {
       method: "PUT",
       headers: { "X-Organization": id },
       body: JSON.stringify({
         name,
         externalId,
+        licenseKey,
       }),
     });
     onEdit();
@@ -57,7 +61,17 @@ const EditOrganization: FC<{
           minLength={3}
           onChange={(e) => setName(e.target.value)}
         />
-        {showExternalId && (
+        {isCloud() ? (
+          <div className="mt-3">
+            License Key
+            <input
+              type="text"
+              className="form-control"
+              value={licenseKey}
+              onChange={(e) => setLicenseKey(e.target.value)}
+            />
+          </div>
+        ) : (
           <div className="mt-3">
             External Id: Id used for the organization within your company
             (optional)

--- a/packages/front-end/components/GeneralSettings/OrganizationAndLicenseSettings.tsx
+++ b/packages/front-end/components/GeneralSettings/OrganizationAndLicenseSettings.tsx
@@ -57,7 +57,9 @@ export default function OrganizationAndLicenseSettings({
             )}
           </div>
         </div>
-        {(isCloud() || !isMultiOrg()) && <ShowLicenseInfo />}
+        {(isCloud() || !isMultiOrg()) && (
+          <ShowLicenseInfo showInput={!isCloud()} />
+        )}
       </div>
     </>
   );

--- a/packages/front-end/pages/admin.tsx
+++ b/packages/front-end/pages/admin.tsx
@@ -50,7 +50,7 @@ function OrganizationRow({
           id={organization.id}
           currentName={organization.name}
           currentExternalId={organization.externalId || ""}
-          showExternalId={!isCloud()}
+          currentLicenseKey={organization.licenseKey || ""}
           onEdit={onEdit}
           close={() => setEditOrgModalOpen(false)}
         />


### PR DESCRIPTION
### Features and Changes

On cloud, only super admins should be able to set licenseKeys when not going through regular upgrade process.

- Adds LicenseKey field to EditOrganization admin component
- Handles LicenseKey in Put organization endpoint
- Moves check for showing externalId field to the EditOrganization component itself to be consistent with checking whether to show the licenseKey field

### Testing

#### Testing Cloud
`yarn test`
in back-end and front-end/.env.local
```
IS_CLOUD=true
IS_MULTI_ORG=true
SSO_CONFIG=valid SSO config
```
restart the server
Go to settings->general - see no input to edit the license.
Go to settings->admin - click org and the pencil icon
Edit the license with a bad license
See invalid licenseKey message
Enter in a valid licenseKey
See it update successfully.
Refresh the page, and see the new license show up.

#### Testing Self-Hosted Multi-Org (license key should only set by env var)
in back-end and front-end/.env.local
```
IS_CLOUD=false
IS_MULTI_ORG=true
```
restart server
Go to Settings->admin page
Click pencil icon on an organization
See the externalId, but not the licenseKey field.
Go to Settings->General
See no license section at all.

#### Testing normal Self-Hosted
in back-end and front-end/.env.local
```
IS_CLOUD=false
IS_MULTI_ORG=false
```
restart server
Go to Settings->General
Click pencil icon by license.
Enter "license_bad"
See "Invalid license key" message upon submit
Put in a valid license key.
See it succeed.

