### PR TITLE
Only rely on stats.denominator for true ratio metrics in Results UI

### DIFF
--- a/packages/front-end/components/Experiment/MetricValueColumn.tsx
+++ b/packages/front-end/components/Experiment/MetricValueColumn.tsx
@@ -45,7 +45,7 @@ export default function MetricValueColumn({
 }: Props) {
   const displayCurrency = useCurrency();
   const formatterOptions = { currency: displayCurrency };
-  const { getFactTableById } = useDefinitions();
+  const { getFactTableById, getMetricById } = useDefinitions();
 
   const overall = getExperimentMetricFormatter(metric, getFactTableById)(
     stats.cr,
@@ -53,10 +53,14 @@ export default function MetricValueColumn({
   );
 
   const numeratorValue = stats.value;
-  const denominatorValue =
-    metric.denominator || isRatioMetric(metric)
-      ? stats.denominator ?? stats.users
-      : stats.users || users;
+  const denominatorValue = isRatioMetric(
+    metric,
+    !isFactMetric(metric) && metric.denominator
+      ? getMetricById(metric.denominator) ?? undefined
+      : undefined
+  )
+    ? stats.denominator ?? stats.users
+    : stats.users || users;
 
   let numerator: string;
   let denominator = numberFormatter.format(denominatorValue);

--- a/packages/front-end/components/Experiment/MetricValueColumn.tsx
+++ b/packages/front-end/components/Experiment/MetricValueColumn.tsx
@@ -60,7 +60,7 @@ export default function MetricValueColumn({
       : undefined
   )
     ? stats.denominator ?? stats.users
-    : stats.users || users;
+    : stats.denominator || stats.users || users;
 
   let numerator: string;
   let denominator = numberFormatter.format(denominatorValue);


### PR DESCRIPTION
I broke the UI for denominator value for non-fact binomial metrics with a binomial denominator.

Before (zero denom metric is right, but the zero denom in the last any purchase/any purchase) metric is wrong:
<img width="1244" alt="Screenshot 2024-05-02 at 9 39 22 AM" src="https://github.com/growthbook/growthbook/assets/5298599/30ea1560-ed69-480f-9db3-6b7c7ecd3bd4">


After (fixed):
<img width="1242" alt="Screenshot 2024-05-02 at 9 39 31 AM" src="https://github.com/growthbook/growthbook/assets/5298599/53af138e-a98f-41da-8ea3-d44d5a535892">
