### PR TITLE
Added Support for performing Assume role with Athena Connections

### DIFF
--- a/packages/back-end/package.json
+++ b/packages/back-end/package.json
@@ -27,6 +27,8 @@
     "generate-api-types": "yarn generate-api-models && swagger-cli bundle -t yaml src/api/openapi/openapi.tmp.yaml -o generated/spec.yaml && node src/scripts/generate-openapi.mjs"
   },
   "dependencies": {
+    "@aws-sdk/client-sts": "^3.567.0",
+    "@aws-sdk/client-athena": "^3.564.0",
     "@clickhouse/client": "^1.0.1",
     "@databricks/sql": "^1.8.1",
     "@dqbd/tiktoken": "^1.0.7",

--- a/packages/back-end/src/services/athena.ts
+++ b/packages/back-end/src/services/athena.ts
@@ -27,7 +27,7 @@ async function getAthenaInstance(params: AthenaConnectionParams) {
   }
 
   // handle assuming a role first
-  if (!IS_CLOUD && params.authType == "assumeRole") {
+  if (!IS_CLOUD && params.authType === "assumeRole") {
     // use client to assume another role
     const credentials = await assumeRole(params);
 

--- a/packages/back-end/src/services/athena.ts
+++ b/packages/back-end/src/services/athena.ts
@@ -1,20 +1,52 @@
-import { Athena } from "aws-sdk";
-import { ResultSet } from "aws-sdk/clients/athena";
+import { STSClient, AssumeRoleCommand } from "@aws-sdk/client-sts";
+import { Athena, ResultSet } from "@aws-sdk/client-athena";
 import { AthenaConnectionParams } from "../../types/integrations/athena";
 import { logger } from "../util/logger";
 import { IS_CLOUD } from "../util/secrets";
 import { ExternalIdCallback, QueryResponse } from "../types/Integration";
 
-function getAthenaInstance(params: AthenaConnectionParams) {
+async function assumeRole(params: AthenaConnectionParams) {
+  // build sts client
+  const client = new STSClient({ region: "us-east-1" });
+  const command = new AssumeRoleCommand({
+    RoleArn: params.assumeRoleARN,
+    RoleSessionName: params.roleSessionName,
+    ExternalId: params.externalId,
+    DurationSeconds: 900,
+  });
+
+  return await client.send(command);
+}
+
+async function getAthenaInstance(params: AthenaConnectionParams) {
+  // handle the instance profile
   if (!IS_CLOUD && params.authType === "auto") {
     return new Athena({
       region: params.region,
     });
   }
 
+  // handle assuming a role first
+  if (!IS_CLOUD && params.authType == "assumeRole") {
+    // use client to assume another role
+    const credentials = await assumeRole(params);
+
+    return new Athena({
+      credentials: {
+        accessKeyId: credentials?.Credentials?.AccessKeyId || "",
+        secretAccessKey: credentials?.Credentials?.SecretAccessKey || "",
+        sessionToken: credentials?.Credentials?.SessionToken || "",
+      },
+      region: params.region,
+    });
+  }
+
+  // handle access key + secret key
   return new Athena({
-    accessKeyId: params.accessKeyId,
-    secretAccessKey: params.secretAccessKey,
+    credentials: {
+      accessKeyId: params.accessKeyId || "",
+      secretAccessKey: params.secretAccessKey || "",
+    },
     region: params.region,
   });
 }
@@ -23,12 +55,10 @@ export async function cancelAthenaQuery(
   conn: AthenaConnectionParams,
   id: string
 ) {
-  const athena = getAthenaInstance(conn);
-  await athena
-    .stopQueryExecution({
-      QueryExecutionId: id,
-    })
-    .promise();
+  const athena = await getAthenaInstance(conn);
+  await athena.stopQueryExecution({
+    QueryExecutionId: id,
+  });
 }
 
 export async function runAthenaQuery(
@@ -36,29 +66,27 @@ export async function runAthenaQuery(
   sql: string,
   setExternalId: ExternalIdCallback
 ): Promise<QueryResponse> {
-  const athena = getAthenaInstance(conn);
+  const athena = await getAthenaInstance(conn);
 
   const { database, bucketUri, workGroup, catalog } = conn;
 
   const retryWaitTime =
     (parseInt(process.env.ATHENA_RETRY_WAIT_TIME || "60") || 60) * 1000;
 
-  const { QueryExecutionId } = await athena
-    .startQueryExecution({
-      QueryString: sql,
-      QueryExecutionContext: {
-        Database: database || undefined,
-        Catalog: catalog || undefined,
+  const { QueryExecutionId } = await athena.startQueryExecution({
+    QueryString: sql,
+    QueryExecutionContext: {
+      Database: database || undefined,
+      Catalog: catalog || undefined,
+    },
+    ResultConfiguration: {
+      EncryptionConfiguration: {
+        EncryptionOption: "SSE_S3",
       },
-      ResultConfiguration: {
-        EncryptionConfiguration: {
-          EncryptionOption: "SSE_S3",
-        },
-        OutputLocation: bucketUri,
-      },
-      WorkGroup: workGroup || "primary",
-    })
-    .promise();
+      OutputLocation: bucketUri,
+    },
+    WorkGroup: workGroup || "primary",
+  });
 
   if (!QueryExecutionId) {
     throw new Error("Failed to start query");
@@ -74,7 +102,6 @@ export async function runAthenaQuery(
       setTimeout(() => {
         athena
           .getQueryExecution({ QueryExecutionId })
-          .promise()
           .then((resp) => {
             const State = resp.QueryExecution?.Status?.State;
             const StateChangeReason =
@@ -118,7 +145,6 @@ export async function runAthenaQuery(
             } else {
               athena
                 .getQueryResults({ QueryExecutionId })
-                .promise()
                 .then(({ ResultSet }) => {
                   if (ResultSet) {
                     resolve(ResultSet);
@@ -152,7 +178,7 @@ export async function runAthenaQuery(
           const obj: any = {};
           if (row.Data) {
             row.Data.forEach((value, i) => {
-              obj[keys[i]] = value.VarCharValue || null;
+              obj[keys[i] as string] = value.VarCharValue || null;
             });
           }
           return obj;
@@ -162,6 +188,6 @@ export async function runAthenaQuery(
   }
 
   // Cancel the query if it reaches this point
-  await athena.stopQueryExecution({ QueryExecutionId }).promise();
+  await athena.stopQueryExecution({ QueryExecutionId });
   throw new Error("Query timed out after 30 minutes");
 }

--- a/packages/back-end/src/services/athena.ts
+++ b/packages/back-end/src/services/athena.ts
@@ -7,12 +7,12 @@ import { ExternalIdCallback, QueryResponse } from "../types/Integration";
 
 async function assumeRole(params: AthenaConnectionParams) {
   // build sts client
-  const client = new STSClient({ region: "us-east-1" });
+  const client = new STSClient();
   const command = new AssumeRoleCommand({
     RoleArn: params.assumeRoleARN,
     RoleSessionName: params.roleSessionName,
     ExternalId: params.externalId,
-    DurationSeconds: 900,
+    DurationSeconds: params.durationSeconds,
   });
 
   return await client.send(command);

--- a/packages/back-end/types/integrations/athena.d.ts
+++ b/packages/back-end/types/integrations/athena.d.ts
@@ -1,7 +1,11 @@
 export interface AthenaConnectionParams {
-  authType?: "auto" | "accessKey";
+  authType?: "auto" | "accessKey" | "assumeRole";
   accessKeyId?: string;
   secretAccessKey?: string;
+  assumeRoleARN?: string;
+  roleSessionName?: string;
+  durationSeconds?: string;
+  externalId?: string;
   region: string;
   database?: string;
   bucketUri: string;

--- a/packages/back-end/types/integrations/athena.d.ts
+++ b/packages/back-end/types/integrations/athena.d.ts
@@ -4,7 +4,7 @@ export interface AthenaConnectionParams {
   secretAccessKey?: string;
   assumeRoleARN?: string;
   roleSessionName?: string;
-  durationSeconds?: string;
+  durationSeconds?: number;
   externalId?: string;
   region: string;
   database?: string;

--- a/packages/front-end/components/Settings/AthenaForm.tsx
+++ b/packages/front-end/components/Settings/AthenaForm.tsx
@@ -39,7 +39,7 @@ const AthenaForm: FC<{
           />
         </div>
       )}
-      {(isCloud() || params.authType == "accessKey") && (
+      {(isCloud() || params.authType === "accessKey") && (
         <>
           <div className="form-group col-md-12">
             <label>AWS Access Key</label>
@@ -68,7 +68,7 @@ const AthenaForm: FC<{
           </div>
         </>
       )}
-      {!isCloud() && params.authType == "assumeRole" && (
+      {!isCloud() && params.authType === "assumeRole" && (
         <>
           <div className="form-group col-md-12">
             <label>AWS IAM Role ARN</label>
@@ -148,7 +148,7 @@ const AthenaForm: FC<{
           type="text"
           className="form-control"
           name="catalog"
-          value={params.catalog || ""}
+          value={params.catalog || "AwsDataCatalog"}
           onChange={onParamChange}
         />
       </div>

--- a/packages/front-end/components/Settings/AthenaForm.tsx
+++ b/packages/front-end/components/Settings/AthenaForm.tsx
@@ -39,7 +39,8 @@ const AthenaForm: FC<{
           />
         </div>
       )}
-      {(isCloud() || params.authType === "accessKey") && (
+      {(isCloud() ||
+        (params.authType !== "assumeRole" && params.authType !== "auto")) && (
         <>
           <div className="form-group col-md-12">
             <label>AWS Access Key</label>

--- a/packages/front-end/components/Settings/AthenaForm.tsx
+++ b/packages/front-end/components/Settings/AthenaForm.tsx
@@ -30,7 +30,7 @@ const AthenaForm: FC<{
               },
             ]}
             helpText="'Auto-discovery' will look for credentials in environment variables and instance metadata. 'Assume IAM Role' uses the current role to assume another role and execute Athena with temporary credentials."
-            value={params.authType || "auto"}
+            value={params.authType || "accessKey"}
             onChange={(e) => {
               setParams({
                 authType: e.target.value,
@@ -68,7 +68,7 @@ const AthenaForm: FC<{
           </div>
         </>
       )}
-      {(isCloud() || params.authType == "assumeRole") && (
+      {!isCloud() && params.authType == "assumeRole" && (
         <>
           <div className="form-group col-md-12">
             <label>AWS IAM Role ARN</label>
@@ -102,6 +102,18 @@ const AthenaForm: FC<{
               name="externalId"
               required={!existing}
               value={params.externalId || ""}
+              onChange={onParamChange}
+              placeholder={existing ? "(Keep existing)" : ""}
+            />
+          </div>
+          <div className="form-group col-md-12">
+            <label>Session Duration</label>
+            <input
+              type="number"
+              className="form-control"
+              name="durationSeconds"
+              required={!existing}
+              value={params.durationSeconds || 900}
               onChange={onParamChange}
               placeholder={existing ? "(Keep existing)" : ""}
             />

--- a/packages/front-end/components/Settings/AthenaForm.tsx
+++ b/packages/front-end/components/Settings/AthenaForm.tsx
@@ -24,9 +24,13 @@ const AthenaForm: FC<{
                 value: "auto",
                 display: "Auto-discovery",
               },
+              {
+                value: "assumeRole",
+                display: "Assume IAM Role",
+              },
             ]}
-            helpText="'Auto-discovery' will look for credentials in environment variables and instance metadata."
-            value={params.authType || "accessKey"}
+            helpText="'Auto-discovery' will look for credentials in environment variables and instance metadata. 'Assume IAM Role' uses the current role to assume another role and execute Athena with temporary credentials."
+            value={params.authType || "auto"}
             onChange={(e) => {
               setParams({
                 authType: e.target.value,
@@ -35,29 +39,7 @@ const AthenaForm: FC<{
           />
         </div>
       )}
-      <div className="form-group col-md-12">
-        <label>AWS Region</label>
-        <input
-          type="text"
-          className="form-control"
-          name="region"
-          required
-          value={params.region || ""}
-          onChange={onParamChange}
-        />
-      </div>
-      <div className="form-group col-md-12">
-        <label>Workgroup (optional)</label>
-        <input
-          type="text"
-          className="form-control"
-          name="workGroup"
-          placeholder="primary"
-          value={params.workGroup || ""}
-          onChange={onParamChange}
-        />
-      </div>
-      {(isCloud() || params.authType !== "auto") && (
+      {(isCloud() || params.authType == "accessKey") && (
         <>
           <div className="form-group col-md-12">
             <label>AWS Access Key</label>
@@ -86,6 +68,68 @@ const AthenaForm: FC<{
           </div>
         </>
       )}
+      {(isCloud() || params.authType == "assumeRole") && (
+        <>
+          <div className="form-group col-md-12">
+            <label>AWS IAM Role ARN</label>
+            <input
+              type="text"
+              className="form-control"
+              name="assumeRoleARN"
+              required={!existing}
+              value={params.assumeRoleARN || ""}
+              onChange={onParamChange}
+              placeholder={existing ? "(Keep existing)" : ""}
+            />
+          </div>
+          <div className="form-group col-md-12">
+            <label>Role Session Name</label>
+            <input
+              type="text"
+              className="form-control"
+              name="roleSessionName"
+              required={!existing}
+              value={params.roleSessionName || ""}
+              onChange={onParamChange}
+              placeholder={existing ? "(Keep existing)" : ""}
+            />
+          </div>
+          <div className="form-group col-md-12">
+            <label>External ID</label>
+            <input
+              type="text"
+              className="form-control"
+              name="externalId"
+              required={!existing}
+              value={params.externalId || ""}
+              onChange={onParamChange}
+              placeholder={existing ? "(Keep existing)" : ""}
+            />
+          </div>
+        </>
+      )}
+      <div className="form-group col-md-12">
+        <label>AWS Region</label>
+        <input
+          type="text"
+          className="form-control"
+          name="region"
+          required
+          value={params.region || ""}
+          onChange={onParamChange}
+        />
+      </div>
+      <div className="form-group col-md-12">
+        <label>Workgroup (optional)</label>
+        <input
+          type="text"
+          className="form-control"
+          name="workGroup"
+          placeholder="primary"
+          value={params.workGroup || ""}
+          onChange={onParamChange}
+        />
+      </div>
       <div className="form-group col-md-12">
         <label>Default Catalog (optional)</label>
         <input

--- a/yarn.lock
+++ b/yarn.lock
@@ -200,6 +200,52 @@
     "@aws-sdk/types" "3.212.0"
     tslib "^2.3.1"
 
+"@aws-sdk/client-athena@^3.564.0":
+  version "3.567.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-athena/-/client-athena-3.567.0.tgz#ca68c12f11e7c540a325cfb78ccb51d476d2445c"
+  integrity sha512-AbVGNgKHP+iNe5Fw1Pzhy+M6Viq13U3s5qmovE7BsXUiABsmOC2pYFsR8vVhLw2uR6R3CZGTYJZ8NJKm2ckh4g==
+  dependencies:
+    "@aws-crypto/sha256-browser" "3.0.0"
+    "@aws-crypto/sha256-js" "3.0.0"
+    "@aws-sdk/core" "3.567.0"
+    "@aws-sdk/credential-provider-node" "3.567.0"
+    "@aws-sdk/middleware-host-header" "3.567.0"
+    "@aws-sdk/middleware-logger" "3.567.0"
+    "@aws-sdk/middleware-recursion-detection" "3.567.0"
+    "@aws-sdk/middleware-user-agent" "3.567.0"
+    "@aws-sdk/region-config-resolver" "3.567.0"
+    "@aws-sdk/types" "3.567.0"
+    "@aws-sdk/util-endpoints" "3.567.0"
+    "@aws-sdk/util-user-agent-browser" "3.567.0"
+    "@aws-sdk/util-user-agent-node" "3.567.0"
+    "@smithy/config-resolver" "^2.2.0"
+    "@smithy/core" "^1.4.2"
+    "@smithy/fetch-http-handler" "^2.5.0"
+    "@smithy/hash-node" "^2.2.0"
+    "@smithy/invalid-dependency" "^2.2.0"
+    "@smithy/middleware-content-length" "^2.2.0"
+    "@smithy/middleware-endpoint" "^2.5.1"
+    "@smithy/middleware-retry" "^2.3.1"
+    "@smithy/middleware-serde" "^2.3.0"
+    "@smithy/middleware-stack" "^2.2.0"
+    "@smithy/node-config-provider" "^2.3.0"
+    "@smithy/node-http-handler" "^2.5.0"
+    "@smithy/protocol-http" "^3.3.0"
+    "@smithy/smithy-client" "^2.5.1"
+    "@smithy/types" "^2.12.0"
+    "@smithy/url-parser" "^2.2.0"
+    "@smithy/util-base64" "^2.3.0"
+    "@smithy/util-body-length-browser" "^2.2.0"
+    "@smithy/util-body-length-node" "^2.3.0"
+    "@smithy/util-defaults-mode-browser" "^2.2.1"
+    "@smithy/util-defaults-mode-node" "^2.3.1"
+    "@smithy/util-endpoints" "^1.2.0"
+    "@smithy/util-middleware" "^2.2.0"
+    "@smithy/util-retry" "^2.2.0"
+    "@smithy/util-utf8" "^2.3.0"
+    tslib "^2.6.2"
+    uuid "^9.0.1"
+
 "@aws-sdk/client-cognito-identity@3.212.0":
   version "3.212.0"
   resolved "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.212.0.tgz"
@@ -469,6 +515,50 @@
     "@smithy/util-utf8" "^2.3.0"
     tslib "^2.6.2"
 
+"@aws-sdk/client-sso@3.567.0":
+  version "3.567.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sso/-/client-sso-3.567.0.tgz#e6686d81d9fde9d1ef51285f9b701ed4fed4552b"
+  integrity sha512-jcnT1m+altt9Xm2QErZBnETh+4ioeCb/p9bo0adLb9JCAuI/VcnIui5+CykvCzOAxQ8c8Soa19qycqCuUcjiCw==
+  dependencies:
+    "@aws-crypto/sha256-browser" "3.0.0"
+    "@aws-crypto/sha256-js" "3.0.0"
+    "@aws-sdk/core" "3.567.0"
+    "@aws-sdk/middleware-host-header" "3.567.0"
+    "@aws-sdk/middleware-logger" "3.567.0"
+    "@aws-sdk/middleware-recursion-detection" "3.567.0"
+    "@aws-sdk/middleware-user-agent" "3.567.0"
+    "@aws-sdk/region-config-resolver" "3.567.0"
+    "@aws-sdk/types" "3.567.0"
+    "@aws-sdk/util-endpoints" "3.567.0"
+    "@aws-sdk/util-user-agent-browser" "3.567.0"
+    "@aws-sdk/util-user-agent-node" "3.567.0"
+    "@smithy/config-resolver" "^2.2.0"
+    "@smithy/core" "^1.4.2"
+    "@smithy/fetch-http-handler" "^2.5.0"
+    "@smithy/hash-node" "^2.2.0"
+    "@smithy/invalid-dependency" "^2.2.0"
+    "@smithy/middleware-content-length" "^2.2.0"
+    "@smithy/middleware-endpoint" "^2.5.1"
+    "@smithy/middleware-retry" "^2.3.1"
+    "@smithy/middleware-serde" "^2.3.0"
+    "@smithy/middleware-stack" "^2.2.0"
+    "@smithy/node-config-provider" "^2.3.0"
+    "@smithy/node-http-handler" "^2.5.0"
+    "@smithy/protocol-http" "^3.3.0"
+    "@smithy/smithy-client" "^2.5.1"
+    "@smithy/types" "^2.12.0"
+    "@smithy/url-parser" "^2.2.0"
+    "@smithy/util-base64" "^2.3.0"
+    "@smithy/util-body-length-browser" "^2.2.0"
+    "@smithy/util-body-length-node" "^2.3.0"
+    "@smithy/util-defaults-mode-browser" "^2.2.1"
+    "@smithy/util-defaults-mode-node" "^2.3.1"
+    "@smithy/util-endpoints" "^1.2.0"
+    "@smithy/util-middleware" "^2.2.0"
+    "@smithy/util-retry" "^2.2.0"
+    "@smithy/util-utf8" "^2.3.0"
+    tslib "^2.6.2"
+
 "@aws-sdk/client-sts@3.212.0":
   version "3.212.0"
   resolved "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.212.0.tgz"
@@ -555,6 +645,51 @@
     "@smithy/util-utf8" "^2.3.0"
     tslib "^2.6.2"
 
+"@aws-sdk/client-sts@^3.567.0":
+  version "3.567.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-sts/-/client-sts-3.567.0.tgz#a69b8702f80739d0e9195a54b1fdb8ad67269859"
+  integrity sha512-Hsbj/iJJZbajdYRja4MiqK7chaXim+cltaIslqjhTFCHlOct88qQRUAz2GHzNkyIH9glubLdwHqQZ+QmCf+4Vw==
+  dependencies:
+    "@aws-crypto/sha256-browser" "3.0.0"
+    "@aws-crypto/sha256-js" "3.0.0"
+    "@aws-sdk/core" "3.567.0"
+    "@aws-sdk/credential-provider-node" "3.567.0"
+    "@aws-sdk/middleware-host-header" "3.567.0"
+    "@aws-sdk/middleware-logger" "3.567.0"
+    "@aws-sdk/middleware-recursion-detection" "3.567.0"
+    "@aws-sdk/middleware-user-agent" "3.567.0"
+    "@aws-sdk/region-config-resolver" "3.567.0"
+    "@aws-sdk/types" "3.567.0"
+    "@aws-sdk/util-endpoints" "3.567.0"
+    "@aws-sdk/util-user-agent-browser" "3.567.0"
+    "@aws-sdk/util-user-agent-node" "3.567.0"
+    "@smithy/config-resolver" "^2.2.0"
+    "@smithy/core" "^1.4.2"
+    "@smithy/fetch-http-handler" "^2.5.0"
+    "@smithy/hash-node" "^2.2.0"
+    "@smithy/invalid-dependency" "^2.2.0"
+    "@smithy/middleware-content-length" "^2.2.0"
+    "@smithy/middleware-endpoint" "^2.5.1"
+    "@smithy/middleware-retry" "^2.3.1"
+    "@smithy/middleware-serde" "^2.3.0"
+    "@smithy/middleware-stack" "^2.2.0"
+    "@smithy/node-config-provider" "^2.3.0"
+    "@smithy/node-http-handler" "^2.5.0"
+    "@smithy/protocol-http" "^3.3.0"
+    "@smithy/smithy-client" "^2.5.1"
+    "@smithy/types" "^2.12.0"
+    "@smithy/url-parser" "^2.2.0"
+    "@smithy/util-base64" "^2.3.0"
+    "@smithy/util-body-length-browser" "^2.2.0"
+    "@smithy/util-body-length-node" "^2.3.0"
+    "@smithy/util-defaults-mode-browser" "^2.2.1"
+    "@smithy/util-defaults-mode-node" "^2.3.1"
+    "@smithy/util-endpoints" "^1.2.0"
+    "@smithy/util-middleware" "^2.2.0"
+    "@smithy/util-retry" "^2.2.0"
+    "@smithy/util-utf8" "^2.3.0"
+    tslib "^2.6.2"
+
 "@aws-sdk/config-resolver@3.212.0":
   version "3.212.0"
   resolved "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.212.0.tgz"
@@ -570,6 +705,19 @@
   version "3.556.0"
   resolved "https://registry.yarnpkg.com/@aws-sdk/core/-/core-3.556.0.tgz#d0f4431a72282b71cfbcaedfb803f7f2807cf60b"
   integrity sha512-vJaSaHw2kPQlo11j/Rzuz0gk1tEaKdz+2ser0f0qZ5vwFlANjt08m/frU17ctnVKC1s58bxpctO/1P894fHLrA==
+  dependencies:
+    "@smithy/core" "^1.4.2"
+    "@smithy/protocol-http" "^3.3.0"
+    "@smithy/signature-v4" "^2.3.0"
+    "@smithy/smithy-client" "^2.5.1"
+    "@smithy/types" "^2.12.0"
+    fast-xml-parser "4.2.5"
+    tslib "^2.6.2"
+
+"@aws-sdk/core@3.567.0":
+  version "3.567.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/core/-/core-3.567.0.tgz#f0b93ba1541dcc179438fb8d80b2a80ec865b623"
+  integrity sha512-zUDEQhC7blOx6sxhHdT75x98+SXQVdUIMu8z8AjqMWiYK2v4WkOS8i6dOS4E5OjL5J1Ac+ruy8op/Bk4AFqSIw==
   dependencies:
     "@smithy/core" "^1.4.2"
     "@smithy/protocol-http" "^3.3.0"
@@ -608,12 +756,37 @@
     "@smithy/types" "^2.12.0"
     tslib "^2.6.2"
 
+"@aws-sdk/credential-provider-env@3.567.0":
+  version "3.567.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-env/-/credential-provider-env-3.567.0.tgz#6e545c047871bf91cce2dbe1db11e99283442295"
+  integrity sha512-2V9O9m/hrWtIBKfg+nYHTYUHSKOZdSWL53JRaN28zYoX4dPDWwP1GacP/Mq6LJhKRnByfmqh3W3ZBsKizauSug==
+  dependencies:
+    "@aws-sdk/types" "3.567.0"
+    "@smithy/property-provider" "^2.2.0"
+    "@smithy/types" "^2.12.0"
+    tslib "^2.6.2"
+
 "@aws-sdk/credential-provider-http@3.552.0":
   version "3.552.0"
   resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-http/-/credential-provider-http-3.552.0.tgz#ecc88d02cba95621887e6b85b2583e756ad29eb6"
   integrity sha512-vsmu7Cz1i45pFEqzVb4JcFmAmVnWFNLsGheZc8SCptlqCO5voETrZZILHYIl4cjKkSDk3pblBOf0PhyjqWW6WQ==
   dependencies:
     "@aws-sdk/types" "3.535.0"
+    "@smithy/fetch-http-handler" "^2.5.0"
+    "@smithy/node-http-handler" "^2.5.0"
+    "@smithy/property-provider" "^2.2.0"
+    "@smithy/protocol-http" "^3.3.0"
+    "@smithy/smithy-client" "^2.5.1"
+    "@smithy/types" "^2.12.0"
+    "@smithy/util-stream" "^2.2.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-http@3.567.0":
+  version "3.567.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-http/-/credential-provider-http-3.567.0.tgz#4016128d4a6cc6e8ae36890121e09bab055c589e"
+  integrity sha512-MVSFmKo9ukxNyMYOk/u6gupGqktsbTZWh2uyULp0KLhuHPDTvWLmk96+6h6V2+GAp/J2QRK72l0EtjnHmcn3kg==
+  dependencies:
+    "@aws-sdk/types" "3.567.0"
     "@smithy/fetch-http-handler" "^2.5.0"
     "@smithy/node-http-handler" "^2.5.0"
     "@smithy/property-provider" "^2.2.0"
@@ -665,6 +838,22 @@
     "@smithy/types" "^2.12.0"
     tslib "^2.6.2"
 
+"@aws-sdk/credential-provider-ini@3.567.0":
+  version "3.567.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.567.0.tgz#c9a1fc570de43ba6997631690e0910bc45fc525f"
+  integrity sha512-azbZ3jYZmSD3oCzbjPOrI+pilRDV6H9qtJ3J4MCnbRYQxR8eu80l4Y0tXl0+GfHZCpdOJ9+uEhqU+yTiVrrOXg==
+  dependencies:
+    "@aws-sdk/credential-provider-env" "3.567.0"
+    "@aws-sdk/credential-provider-process" "3.567.0"
+    "@aws-sdk/credential-provider-sso" "3.567.0"
+    "@aws-sdk/credential-provider-web-identity" "3.567.0"
+    "@aws-sdk/types" "3.567.0"
+    "@smithy/credential-provider-imds" "^2.3.0"
+    "@smithy/property-provider" "^2.2.0"
+    "@smithy/shared-ini-file-loader" "^2.4.0"
+    "@smithy/types" "^2.12.0"
+    tslib "^2.6.2"
+
 "@aws-sdk/credential-provider-node@3.212.0":
   version "3.212.0"
   resolved "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.212.0.tgz"
@@ -699,6 +888,24 @@
     "@smithy/types" "^2.12.0"
     tslib "^2.6.2"
 
+"@aws-sdk/credential-provider-node@3.567.0":
+  version "3.567.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-node/-/credential-provider-node-3.567.0.tgz#fd14f011ade3d9704ef0f261607fab36f1c8ec68"
+  integrity sha512-/kwYs2URdcXjKCPClUYrvdhhh7oRh1PWC0mehzy92c0I8hMdhIIpOmwJj8IoRIWdsCnPRatWBJBuE553y+HaUQ==
+  dependencies:
+    "@aws-sdk/credential-provider-env" "3.567.0"
+    "@aws-sdk/credential-provider-http" "3.567.0"
+    "@aws-sdk/credential-provider-ini" "3.567.0"
+    "@aws-sdk/credential-provider-process" "3.567.0"
+    "@aws-sdk/credential-provider-sso" "3.567.0"
+    "@aws-sdk/credential-provider-web-identity" "3.567.0"
+    "@aws-sdk/types" "3.567.0"
+    "@smithy/credential-provider-imds" "^2.3.0"
+    "@smithy/property-provider" "^2.2.0"
+    "@smithy/shared-ini-file-loader" "^2.4.0"
+    "@smithy/types" "^2.12.0"
+    tslib "^2.6.2"
+
 "@aws-sdk/credential-provider-process@3.212.0":
   version "3.212.0"
   resolved "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.212.0.tgz"
@@ -715,6 +922,17 @@
   integrity sha512-9O1OaprGCnlb/kYl8RwmH7Mlg8JREZctB8r9sa1KhSsWFq/SWO0AuJTyowxD7zL5PkeS4eTvzFFHWCa3OO5epA==
   dependencies:
     "@aws-sdk/types" "3.535.0"
+    "@smithy/property-provider" "^2.2.0"
+    "@smithy/shared-ini-file-loader" "^2.4.0"
+    "@smithy/types" "^2.12.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-process@3.567.0":
+  version "3.567.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-process/-/credential-provider-process-3.567.0.tgz#c90775b612e711914a94660d74f5460614ce5002"
+  integrity sha512-Bsp1bj8bnsvdLec9aXpBsHMlwCmO9TmRrZYyji7ZEUB003ZkxIgbqhe6TEKByrJd53KHfgeF+U4mWZAgBHDXfQ==
+  dependencies:
+    "@aws-sdk/types" "3.567.0"
     "@smithy/property-provider" "^2.2.0"
     "@smithy/shared-ini-file-loader" "^2.4.0"
     "@smithy/types" "^2.12.0"
@@ -745,6 +963,19 @@
     "@smithy/types" "^2.12.0"
     tslib "^2.6.2"
 
+"@aws-sdk/credential-provider-sso@3.567.0":
+  version "3.567.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.567.0.tgz#8b37246c1bdc82b582bd95556beb0f44fb9edd1c"
+  integrity sha512-7TjvMiMsyYANNBiWBArEe7SvqSkZH0FleGUzp+AgT8/CDyGDRdLk7ve2n9f1+iH28av5J0Nw8+TfscHCImrDrQ==
+  dependencies:
+    "@aws-sdk/client-sso" "3.567.0"
+    "@aws-sdk/token-providers" "3.567.0"
+    "@aws-sdk/types" "3.567.0"
+    "@smithy/property-provider" "^2.2.0"
+    "@smithy/shared-ini-file-loader" "^2.4.0"
+    "@smithy/types" "^2.12.0"
+    tslib "^2.6.2"
+
 "@aws-sdk/credential-provider-web-identity@3.212.0":
   version "3.212.0"
   resolved "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.212.0.tgz"
@@ -761,6 +992,16 @@
   dependencies:
     "@aws-sdk/client-sts" "3.556.0"
     "@aws-sdk/types" "3.535.0"
+    "@smithy/property-provider" "^2.2.0"
+    "@smithy/types" "^2.12.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-web-identity@3.567.0":
+  version "3.567.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.567.0.tgz#57792f7854da0379b714766a832156638c78f6e1"
+  integrity sha512-0J7LgR7ll0glMFBz0d4ijCBB61G7ZNucbEKsCGpFk2csytXNPCZYobjzXpJO8QxxgQUGnb68CRB0bo+GQq8nPg==
+  dependencies:
+    "@aws-sdk/types" "3.567.0"
     "@smithy/property-provider" "^2.2.0"
     "@smithy/types" "^2.12.0"
     tslib "^2.6.2"
@@ -900,6 +1141,16 @@
     "@smithy/types" "^2.12.0"
     tslib "^2.6.2"
 
+"@aws-sdk/middleware-host-header@3.567.0":
+  version "3.567.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-host-header/-/middleware-host-header-3.567.0.tgz#52f278234458ec3035e9534fee582c95a8fec4f7"
+  integrity sha512-zQHHj2N3in9duKghH7AuRNrOMLnKhW6lnmb7dznou068DJtDr76w475sHp2TF0XELsOGENbbBsOlN/S5QBFBVQ==
+  dependencies:
+    "@aws-sdk/types" "3.567.0"
+    "@smithy/protocol-http" "^3.3.0"
+    "@smithy/types" "^2.12.0"
+    tslib "^2.6.2"
+
 "@aws-sdk/middleware-location-constraint@3.535.0":
   version "3.535.0"
   resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.535.0.tgz#718c776c118ef78a33117fa353803d079ebcc8fa"
@@ -926,6 +1177,15 @@
     "@smithy/types" "^2.12.0"
     tslib "^2.6.2"
 
+"@aws-sdk/middleware-logger@3.567.0":
+  version "3.567.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-logger/-/middleware-logger-3.567.0.tgz#bc2fc2c7cbbcf0c6aaaeaab2df0e38ab4af4b9db"
+  integrity sha512-12oUmPfSqzaTxO29TXJ9GnJ5qI6ed8iOvHvRLOoqI/TrFqLJnFwCka8E9tpP/sftMchd7wfefbhHhZK4J3ek8Q==
+  dependencies:
+    "@aws-sdk/types" "3.567.0"
+    "@smithy/types" "^2.12.0"
+    tslib "^2.6.2"
+
 "@aws-sdk/middleware-recursion-detection@3.212.0":
   version "3.212.0"
   resolved "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.212.0.tgz"
@@ -941,6 +1201,16 @@
   integrity sha512-am2qgGs+gwqmR4wHLWpzlZ8PWhm4ktj5bYSgDrsOfjhdBlWNxvPoID9/pDAz5RWL48+oH7I6SQzMqxXsFDikrw==
   dependencies:
     "@aws-sdk/types" "3.535.0"
+    "@smithy/protocol-http" "^3.3.0"
+    "@smithy/types" "^2.12.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/middleware-recursion-detection@3.567.0":
+  version "3.567.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.567.0.tgz#95d91f071b57fb5245d522db70df1652275f06ac"
+  integrity sha512-rFk3QhdT4IL6O/UWHmNdjJiURutBCy+ogGqaNHf/RELxgXH3KmYorLwCe0eFb5hq8f6vr3zl4/iH7YtsUOuo1w==
+  dependencies:
+    "@aws-sdk/types" "3.567.0"
     "@smithy/protocol-http" "^3.3.0"
     "@smithy/types" "^2.12.0"
     tslib "^2.6.2"
@@ -1053,6 +1323,17 @@
     "@smithy/types" "^2.12.0"
     tslib "^2.6.2"
 
+"@aws-sdk/middleware-user-agent@3.567.0":
+  version "3.567.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.567.0.tgz#0dbedb18b33a7f490948f8b153301bd4bc7e825d"
+  integrity sha512-a7DBGMRBLWJU3BqrQjOtKS4/RcCh/BhhKqwjCE0FEhhm6A/GGuAs/DcBGOl6Y8Wfsby3vejSlppTLH/qtV1E9w==
+  dependencies:
+    "@aws-sdk/types" "3.567.0"
+    "@aws-sdk/util-endpoints" "3.567.0"
+    "@smithy/protocol-http" "^3.3.0"
+    "@smithy/types" "^2.12.0"
+    tslib "^2.6.2"
+
 "@aws-sdk/node-config-provider@3.212.0":
   version "3.212.0"
   resolved "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.212.0.tgz"
@@ -1121,6 +1402,18 @@
   integrity sha512-IXOznDiaItBjsQy4Fil0kzX/J3HxIOknEphqHbOfUf+LpA5ugcsxuQQONrbEQusCBnfJyymrldBvBhFmtlU9Wg==
   dependencies:
     "@aws-sdk/types" "3.535.0"
+    "@smithy/node-config-provider" "^2.3.0"
+    "@smithy/types" "^2.12.0"
+    "@smithy/util-config-provider" "^2.3.0"
+    "@smithy/util-middleware" "^2.2.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/region-config-resolver@3.567.0":
+  version "3.567.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/region-config-resolver/-/region-config-resolver-3.567.0.tgz#c3ad943d3debcfb0c50ce3556ed183195f8590f9"
+  integrity sha512-VMDyYi5Dh2NydDiIARZ19DwMfbyq0llS736cp47qopmO6wzdeul7WRTx8NKfEYN0/AwEaqmTW0ohx58jSB1lYg==
+  dependencies:
+    "@aws-sdk/types" "3.567.0"
     "@smithy/node-config-provider" "^2.3.0"
     "@smithy/types" "^2.12.0"
     "@smithy/util-config-provider" "^2.3.0"
@@ -1196,6 +1489,17 @@
     "@smithy/types" "^2.12.0"
     tslib "^2.6.2"
 
+"@aws-sdk/token-providers@3.567.0":
+  version "3.567.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/token-providers/-/token-providers-3.567.0.tgz#a962cae500895848fdaa247b5aec6be9d7bdb528"
+  integrity sha512-W9Zd7/504wGrNjHHbJeCms1j1M6/88cHtBhRTKOWa7mec1gCjrd0VB3JE1cRodc6OrbJZ9TmyarBg8er6X5aiA==
+  dependencies:
+    "@aws-sdk/types" "3.567.0"
+    "@smithy/property-provider" "^2.2.0"
+    "@smithy/shared-ini-file-loader" "^2.4.0"
+    "@smithy/types" "^2.12.0"
+    tslib "^2.6.2"
+
 "@aws-sdk/types@3.212.0", "@aws-sdk/types@^3.1.0", "@aws-sdk/types@^3.110.0":
   version "3.212.0"
   resolved "https://registry.npmjs.org/@aws-sdk/types/-/types-3.212.0.tgz"
@@ -1205,6 +1509,14 @@
   version "3.535.0"
   resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-3.535.0.tgz#5e6479f31299dd9df170e63f4d10fe739008cf04"
   integrity sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==
+  dependencies:
+    "@smithy/types" "^2.12.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/types@3.567.0":
+  version "3.567.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-3.567.0.tgz#b2dc88e154140b1ff87e94f63c97447bdb1c1738"
+  integrity sha512-JBznu45cdgQb8+T/Zab7WpBmfEAh77gsk99xuF4biIb2Sw1mdseONdoGDjEJX57a25TzIv/WUJ2oABWumckz1A==
   dependencies:
     "@smithy/types" "^2.12.0"
     tslib "^2.6.2"
@@ -1302,6 +1614,16 @@
     "@smithy/util-endpoints" "^1.2.0"
     tslib "^2.6.2"
 
+"@aws-sdk/util-endpoints@3.567.0":
+  version "3.567.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-endpoints/-/util-endpoints-3.567.0.tgz#c536ad8b9acf99ad762ab949fe0fed943c6f5a12"
+  integrity sha512-WVhot3qmi0BKL9ZKnUqsvCd++4RF2DsJIG32NlRaml1FT9KaqSzNv0RXeA6k/kYwiiNT7y3YWu3Lbzy7c6vG9g==
+  dependencies:
+    "@aws-sdk/types" "3.567.0"
+    "@smithy/types" "^2.12.0"
+    "@smithy/util-endpoints" "^1.2.0"
+    tslib "^2.6.2"
+
 "@aws-sdk/util-hex-encoding@3.201.0":
   version "3.201.0"
   resolved "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz"
@@ -1349,6 +1671,16 @@
     bowser "^2.11.0"
     tslib "^2.6.2"
 
+"@aws-sdk/util-user-agent-browser@3.567.0":
+  version "3.567.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.567.0.tgz#1ef37a87b28155274d62e31c1ac5c1c043dcd0b3"
+  integrity sha512-cqP0uXtZ7m7hRysf3fRyJwcY1jCgQTpJy7BHB5VpsE7DXlXHD5+Ur5L42CY7UrRPrB6lc6YGFqaAOs5ghMcLyA==
+  dependencies:
+    "@aws-sdk/types" "3.567.0"
+    "@smithy/types" "^2.12.0"
+    bowser "^2.11.0"
+    tslib "^2.6.2"
+
 "@aws-sdk/util-user-agent-node@3.212.0":
   version "3.212.0"
   resolved "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.212.0.tgz"
@@ -1364,6 +1696,16 @@
   integrity sha512-dRek0zUuIT25wOWJlsRm97nTkUlh1NDcLsQZIN2Y8KxhwoXXWtJs5vaDPT+qAg+OpcNj80i1zLR/CirqlFg/TQ==
   dependencies:
     "@aws-sdk/types" "3.535.0"
+    "@smithy/node-config-provider" "^2.3.0"
+    "@smithy/types" "^2.12.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/util-user-agent-node@3.567.0":
+  version "3.567.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.567.0.tgz#ed70834431df12f6248814fcee9ba09f18b1e1d1"
+  integrity sha512-Fph602FBhLssed0x2GsRZyqJB8thcrKzbS53v57rQ6XHSQ6T8t2BUyrlXcBfDpoZQjnqobr0Uu2DG5UI3cgR6g==
+  dependencies:
+    "@aws-sdk/types" "3.567.0"
     "@smithy/node-config-provider" "^2.3.0"
     "@smithy/types" "^2.12.0"
     tslib "^2.6.2"


### PR DESCRIPTION
### Features and Changes

Provides the UI and backend for performing an assume role before running Athena queries. Since the `getAthenaInstance` function is used to obtain a client, this can also be used to interact with sts beforehand before returning the client with embedded credentials - this also incorporates the JavaScript v3 SDK.

I'm not to sure how the errors are propagated up the UI but it seems to work pretty well - so that should be one area to improve. Also the session is currently defaults to 900 seconds which could be too short for some beefy queries.