### PR TITLE
Zero downtime deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,8 +43,11 @@ jobs:
 
       - name: Build, tag, and push image to Docker Hub
         uses: depot/build-push-action@v1
+
         with:
           push: true
+          build-args: |
+            IS_CLOUD=true
           context: .
           project: vmp2ssvj9r
           tags: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,10 +72,12 @@ jobs:
           docker cp temp-container:/usr/local/src/app/packages/front-end/.next/static ./static
           docker cp temp-container:/usr/local/src/app/packages/front-end/public ./public
           docker cp temp-container:/usr/local/src/app/buildinfo/SHA ./SHA
+          docker cp temp-container:/usr/local/src/app/buildinfo/DATE ./DATE
           docker rm temp-container
           SHA=$(cat ./SHA)
-          aws s3 sync ./static s3://growthbook-cloud-static-files/$SHA/_next/static
-          aws s3 sync ./public s3://growthbook-cloud-static-files/$SHA/public
+          DATE=$(cat ./DATE)
+          aws s3 sync ./static s3://growthbook-cloud-static-files/$DATE/$SHA/_next/static
+          aws s3 sync ./public s3://growthbook-cloud-static-files/$DATE/$SHA/public
 
       - name: Deploy docker image to ECS for GrowthBook Cloud API
         run: aws ecs update-service --cluster prod-api --service prod-api --force-new-deployment --region us-east-1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,8 +12,8 @@ on:
       - "Dockerfile"
       - ".dockerignore"
 jobs:
-  # Build and publish the commit to docker
-  docker:
+  # Build and publish the commit to a mutli-architecture docker image for self-hosted installation
+  create-docker-self-hosted-image:
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'growthbook/growthbook' }}
     permissions:
@@ -43,11 +43,8 @@ jobs:
 
       - name: Build, tag, and push image to Docker Hub
         uses: depot/build-push-action@v1
-
         with:
           push: true
-          build-args: |
-            IS_CLOUD=true
           context: .
           project: vmp2ssvj9r
           tags: |
@@ -55,10 +52,51 @@ jobs:
             growthbook/growthbook:git-${{ steps.metadata.outputs.sha }}
           platforms: linux/amd64,linux/arm64
 
+  # Build and publish the commit to a linux/amd64-only docker for cloud installation
+  create-docker-cloud-image:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'growthbook/growthbook' }}
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Install Depot CLI
+        uses: depot/setup-action@v1
+
+      - name: Prepare build metadata
+        id: metadata
+        run: |
+          # Store current git hash and date in files
+          mkdir -p buildinfo
+          echo "${GITHUB_SHA}" > buildinfo/SHA
+          printf '%(%Y-%m-%dT%H:%M:%SZ)T' > buildinfo/DATE
+          echo "sha=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+
+      - name: Build, tag, and push image to Docker Hub
+        uses: depot/build-push-action@v1
+        with:
+          push: true
+          build-args: |
+            USE_REMOTE_ASSETS=true
+          context: .
+          project: vmp2ssvj9r
+          tags: |
+            growthbook/growthbook:latest-cloud
+          platforms: linux/amd64
+
   # Deploy the back-end for GrowthBook Cloud
   prod:
     runs-on: ubuntu-latest
-    needs: [docker]
+    needs: [create-docker-cloud-image]
     if: ${{ github.repository == 'growthbook/growthbook' }}
     steps:
       - name: Configure AWS credentials for GrowthBook Cloud
@@ -70,8 +108,8 @@ jobs:
 
       - name: Extract static assets from Docker image and upload to S3
         run: |
-          docker pull growthbook/growthbook:latest
-          docker create --name temp-container growthbook/growthbook:latest
+          docker pull growthbook/growthbook:latest-cloud
+          docker create --name temp-container growthbook/growthbook:latest-cloud
           docker cp temp-container:/usr/local/src/app/packages/front-end/.next/static ./static
           docker cp temp-container:/usr/local/src/app/packages/front-end/public ./public
           docker cp temp-container:/usr/local/src/app/buildinfo/SHA ./SHA

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,5 +65,17 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
 
+      - name: Extract static assets from Docker image and upload to S3
+        run: |
+          docker pull growthbook/growthbook:latest
+          docker create --name temp-container growthbook/growthbook:latest
+          docker cp temp-container:/usr/local/src/app/packages/front-end/.next/static ./static
+          docker cp temp-container:/usr/local/src/app/packages/front-end/public ./public
+          docker cp temp-container:/usr/local/src/app/buildinfo/SHA ./SHA
+          docker rm temp-container
+          SHA=$(cat ./SHA)
+          aws s3 sync ./static s3://growthbook-cloud-static-files/$SHA/_next/static
+          aws s3 sync ./public s3://growthbook-cloud-static-files/$SHA/public
+
       - name: Deploy docker image to ECS for GrowthBook Cloud API
         run: aws ecs update-service --cluster prod-api --service prod-api --force-new-deployment --region us-east-1

--- a/.github/workflows/test-deploy-with-s3.yml
+++ b/.github/workflows/test-deploy-with-s3.yml
@@ -84,15 +84,7 @@ jobs:
           project: vmp2ssvj9r
           tags: |
             growthbook/growthbook:deploy-with-s3-test-cloud
-          platforms: linux/amd64,linux/arm64
-
-      - name: Determine if with load it gets the right docker layer
-        run: |
-          docker pull growthbook/growthbook:deploy-with-s3-test-cloud
-          docker history growthbook/growthbook:deploy-with-s3-test-cloud
-          docker create --name temp-container growthbook/growthbook:deploy-with-s3-test-cloud
-          docker cp temp-container:/usr/local/src/app/packages/front-end/.next/static ./static
-          ls -la ./static
+          platforms: linux/amd64
 
   # Deploy the back-end for GrowthBook Cloud
   prod:

--- a/.github/workflows/test-deploy-with-s3.yml
+++ b/.github/workflows/test-deploy-with-s3.yml
@@ -5,7 +5,7 @@ on:
   push:
 
 jobs:
-  # Build and publish the commit to docker
+  # Build and publish the commit to docker for self-hosted
   docker:
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'growthbook/growthbook' }}
@@ -38,27 +38,57 @@ jobs:
         uses: depot/build-push-action@v1
         with:
           push: true
-          build-args: |
-            IS_CLOUD=true
           context: .
           project: vmp2ssvj9r
           tags: |
             growthbook/growthbook:deploy-with-s3-test
           platforms: linux/amd64,linux/arm64
 
-    #   - name: Extract static assets from Docker image and upload to S3
-    #     env:
-    #       DEPOT_TOKEN: ${{ secrets.DEPOT_TOKEN }}
-    #     run: |
-    #       depot build . -t static-files --output=type=local,dest=./public
-    #       ls ./public
-    #       echo "would run aws s3 sync ./static s3://growthbook-cloud-static-files/$sha/.next/static"
-    #       echo "would run aws s3 sync ./public s3://growthbook-cloud-static-files/$sha/public"
+  # Build and publish the commit to docker for cloud
+  docker-cloud:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'growthbook/growthbook' }}
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Install Depot CLI
+        uses: depot/setup-action@v1
+
+      - name: Prepare build metadata
+        id: metadata
+        run: |
+          # Store current git hash and date in files
+          mkdir -p buildinfo
+          echo "${GITHUB_SHA}" > buildinfo/SHA
+          printf '%(%Y-%m-%dT%H:%M:%SZ)T' > buildinfo/DATE
+          echo "sha=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+
+      - name: Build, tag, and push image to Docker Hub
+        uses: depot/build-push-action@v1
+        with:
+          push: true
+          build-args: |
+            USE_REMOTE_ASSETS=true
+          context: .
+          project: vmp2ssvj9r
+          tags: |
+            growthbook/growthbook:deploy-with-s3-test-cloud
+          platforms: linux/amd64,linux/arm64
 
   # Deploy the back-end for GrowthBook Cloud
   prod:
     runs-on: ubuntu-latest
-    needs: [docker]
+    needs: [docker-cloud]
     if: ${{ github.repository == 'growthbook/growthbook' }}
     steps:
       - name: Configure AWS credentials for GrowthBook Cloud
@@ -70,8 +100,8 @@ jobs:
 
       - name: Extract static assets from Docker image and upload to S3
         run: |
-          docker pull growthbook/growthbook:deploy-with-s3-test
-          docker create --name temp-container growthbook/growthbook:deploy-with-s3-test
+          docker pull growthbook/growthbook:deploy-with-s3-test-cloud
+          docker create --name temp-container growthbook/growthbook:deploy-with-s3-test-cloud
           docker cp temp-container:/usr/local/src/app/packages/front-end/.next/static ./static
           docker cp temp-container:/usr/local/src/app/packages/front-end/public ./public
           docker cp temp-container:/usr/local/src/app/buildinfo/SHA ./SHA

--- a/.github/workflows/test-deploy-with-s3.yml
+++ b/.github/workflows/test-deploy-with-s3.yml
@@ -77,6 +77,7 @@ jobs:
         uses: depot/build-push-action@v1
         with:
           push: true
+          load: true
           build-args: |
             USE_REMOTE_ASSETS=true
           context: .
@@ -84,6 +85,13 @@ jobs:
           tags: |
             growthbook/growthbook:deploy-with-s3-test-cloud
           platforms: linux/amd64,linux/arm64
+
+      - name: Determine if with load it gets the right docker layer
+        run: |
+          docker pull growthbook/growthbook:deploy-with-s3-test-cloud
+          docker create --name temp-container growthbook/growthbook:deploy-with-s3-test-cloud
+          docker cp temp-container:/usr/local/src/app/packages/front-end/.next/static ./static
+          ls -la ./static
 
   # Deploy the back-end for GrowthBook Cloud
   prod:

--- a/.github/workflows/test-deploy-with-s3.yml
+++ b/.github/workflows/test-deploy-with-s3.yml
@@ -44,14 +44,14 @@ jobs:
             growthbook/growthbook:deploy-with-s3-test
           platforms: linux/amd64,linux/arm64
 
-      - name: Extract static assets from Docker image and upload to S3
-        env:
-          DEPOT_TOKEN: ${{ secrets.DEPOT_TOKEN }}
-        run: |
-          depot build . -t static-files --output=type=local,dest=./public
-          ls ./public
-          echo "would run aws s3 sync ./static s3://growthbook-cloud-static-files/$sha/.next/static"
-          echo "would run aws s3 sync ./public s3://growthbook-cloud-static-files/$sha/public"
+    #   - name: Extract static assets from Docker image and upload to S3
+    #     env:
+    #       DEPOT_TOKEN: ${{ secrets.DEPOT_TOKEN }}
+    #     run: |
+    #       depot build . -t static-files --output=type=local,dest=./public
+    #       ls ./public
+    #       echo "would run aws s3 sync ./static s3://growthbook-cloud-static-files/$sha/.next/static"
+    #       echo "would run aws s3 sync ./public s3://growthbook-cloud-static-files/$sha/public"
 
   # Deploy the back-end for GrowthBook Cloud
   prod:
@@ -75,5 +75,5 @@ jobs:
           docker cp temp-container:/usr/local/src/app/buildinfo/SHA ./SHA
           docker rm temp-container
           SHA=$(cat ./SHA)
-          echo "would run aws s3 sync ./static s3://growthbook-cloud-static-files/$SHA/.next/static"
-          echo "would run aws s3 sync ./public s3://growthbook-cloud-static-files/$SHA/public"
+          aws s3 sync ./static s3://growthbook-cloud-static-files/$SHA/.next/static
+          aws s3 sync ./public s3://growthbook-cloud-static-files/$SHA/public

--- a/.github/workflows/test-deploy-with-s3.yml
+++ b/.github/workflows/test-deploy-with-s3.yml
@@ -73,7 +73,9 @@ jobs:
           docker cp temp-container:/usr/local/src/app/packages/front-end/.next/static ./static
           docker cp temp-container:/usr/local/src/app/packages/front-end/public ./public
           docker cp temp-container:/usr/local/src/app/buildinfo/SHA ./SHA
+          docker cp temp-container:/usr/local/src/app/buildinfo/DATE ./DATE
           docker rm temp-container
           SHA=$(cat ./SHA)
-          aws s3 sync ./static s3://growthbook-cloud-static-files/$SHA/_next/static
-          aws s3 sync ./public s3://growthbook-cloud-static-files/$SHA/public
+          DATE=$(cat ./DATE)
+          aws s3 sync ./static s3://growthbook-cloud-static-files/$DATE/$SHA/_next/static
+          aws s3 sync ./public s3://growthbook-cloud-static-files/$DATE/$SHA/public

--- a/.github/workflows/test-deploy-with-s3.yml
+++ b/.github/workflows/test-deploy-with-s3.yml
@@ -103,6 +103,7 @@ jobs:
           docker pull growthbook/growthbook:deploy-with-s3-test-cloud
           docker create --name temp-container growthbook/growthbook:deploy-with-s3-test-cloud
           docker cp temp-container:/usr/local/src/app/packages/front-end/.next/static ./static
+          ls -la ./static
           docker cp temp-container:/usr/local/src/app/packages/front-end/public ./public
           docker cp temp-container:/usr/local/src/app/buildinfo/SHA ./SHA
           docker cp temp-container:/usr/local/src/app/buildinfo/DATE ./DATE

--- a/.github/workflows/test-deploy-with-s3.yml
+++ b/.github/workflows/test-deploy-with-s3.yml
@@ -88,7 +88,7 @@ jobs:
   # Deploy the back-end for GrowthBook Cloud
   prod:
     runs-on: ubuntu-latest
-    needs: [docker-cloud]
+    needs: [create-docker-cloud-image]
     if: ${{ github.repository == 'growthbook/growthbook' }}
     steps:
       - name: Configure AWS credentials for GrowthBook Cloud

--- a/.github/workflows/test-deploy-with-s3.yml
+++ b/.github/workflows/test-deploy-with-s3.yml
@@ -1,7 +1,7 @@
 name: Temp Test Fake Deploy With S3
 
 on:
-  # Push to any branch ... this one in particular.  Will delete this file. Just testing.
+  # Push to any branch ... this one in particular.  Will delete this file. Just testing2.
   push:
 
 jobs:

--- a/.github/workflows/test-deploy-with-s3.yml
+++ b/.github/workflows/test-deploy-with-s3.yml
@@ -38,6 +38,8 @@ jobs:
         uses: depot/build-push-action@v1
         with:
           push: true
+          build-args: |
+            IS_CLOUD=true
           context: .
           project: vmp2ssvj9r
           tags: |

--- a/.github/workflows/test-deploy-with-s3.yml
+++ b/.github/workflows/test-deploy-with-s3.yml
@@ -75,5 +75,5 @@ jobs:
           docker cp temp-container:/usr/local/src/app/buildinfo/SHA ./SHA
           docker rm temp-container
           SHA=$(cat ./SHA)
-          aws s3 sync ./static s3://growthbook-cloud-static-files/$SHA/.next/static
+          aws s3 sync ./static s3://growthbook-cloud-static-files/$SHA/_next/static
           aws s3 sync ./public s3://growthbook-cloud-static-files/$SHA/public

--- a/.github/workflows/test-deploy-with-s3.yml
+++ b/.github/workflows/test-deploy-with-s3.yml
@@ -1,0 +1,82 @@
+name: Temp Test Fake Deploy With S3
+
+on:
+  # Push to any branch ... this one in particular.  Will delete this file.
+  push:
+
+jobs:
+  # Build and publish the commit to docker
+  docker:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'growthbook/growthbook' }}
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Install Depot CLI
+        uses: depot/setup-action@v1
+
+      - name: Prepare build metadata
+        id: metadata
+        run: |
+          # Store current git hash and date in files
+          mkdir -p buildinfo
+          echo "${GITHUB_SHA}" > buildinfo/SHA
+          printf '%(%Y-%m-%dT%H:%M:%SZ)T' > buildinfo/DATE
+          echo "sha=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+
+      - name: Build, tag, and push image to Docker Hub
+        uses: depot/build-push-action@v1
+        with:
+          push: true
+          context: .
+          project: vmp2ssvj9r
+          tags: |
+            growthbook/growthbook:deploy-with-s3-test
+          platforms: linux/amd64,linux/arm64
+
+      - name: Extract static assets from Docker image and upload to S3
+        run: |
+          docker pull growthbook/growthbook:deploy-with-s3-test
+          docker create --name temp-container growthbook/growthbook:deploy-with-s3-test
+          docker cp temp-container:/usr/local/src/app/packages/front-end/.next/static ./static
+          docker cp temp-container:/usr/local/src/app/packages/front-end/public ./public
+          docker cp temp-container:/usr/local/src/app/buildinfo/SHA ./SHA
+          docker rm temp-container
+          SHA=$(cat ./SHA)
+          echo "would run aws s3 sync ./static s3://growthbook-cloud-static-files/$SHA/.next/static"
+          echo "would run aws s3 sync ./public s3://growthbook-cloud-static-files/$SHA/public"
+
+  # Deploy the back-end for GrowthBook Cloud
+  prod:
+    runs-on: ubuntu-latest
+    needs: [docker]
+    if: ${{ github.repository == 'growthbook/growthbook' }}
+    steps:
+      - name: Configure AWS credentials for GrowthBook Cloud
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Extract static assets from Docker image and upload to S3
+        run: |
+          docker pull growthbook/growthbook:deploy-with-s3-test
+          docker create --name temp-container growthbook/growthbook:deploy-with-s3-test
+          docker cp temp-container:/usr/local/src/app/packages/front-end/.next/static ./static
+          docker cp temp-container:/usr/local/src/app/packages/front-end/public ./public
+          docker cp temp-container:/usr/local/src/app/buildinfo/SHA ./SHA
+          docker rm temp-container
+          SHA=$(cat ./SHA)
+          echo "would run aws s3 sync ./static s3://growthbook-cloud-static-files/$SHA/.next/static"
+          echo "would run aws s3 sync ./public s3://growthbook-cloud-static-files/$SHA/public"

--- a/.github/workflows/test-deploy-with-s3.yml
+++ b/.github/workflows/test-deploy-with-s3.yml
@@ -1,7 +1,7 @@
 name: Temp Test Fake Deploy With S3
 
 on:
-  # Push to any branch ... this one in particular.  Will delete this file.
+  # Push to any branch ... this one in particular.  Will delete this file. Just testing.
   push:
 
 jobs:

--- a/.github/workflows/test-deploy-with-s3.yml
+++ b/.github/workflows/test-deploy-with-s3.yml
@@ -38,7 +38,6 @@ jobs:
         uses: depot/build-push-action@v1
         with:
           push: true
-          load: true
           context: .
           project: vmp2ssvj9r
           tags: |
@@ -47,15 +46,10 @@ jobs:
 
       - name: Extract static assets from Docker image and upload to S3
         run: |
-          docker pull growthbook/growthbook:deploy-with-s3-test
-          docker create --name temp-container growthbook/growthbook:deploy-with-s3-test
-          docker cp temp-container:/usr/local/src/app/packages/front-end/.next/static ./static
-          docker cp temp-container:/usr/local/src/app/packages/front-end/public ./public
-          docker cp temp-container:/usr/local/src/app/buildinfo/SHA ./SHA
-          docker rm temp-container
-          SHA=$(cat ./SHA)
-          echo "would run aws s3 sync ./static s3://growthbook-cloud-static-files/$SHA/.next/static"
-          echo "would run aws s3 sync ./public s3://growthbook-cloud-static-files/$SHA/public"
+          depot build . -t static-files --output=type=local,dest=./public
+          ls ./public
+          echo "would run aws s3 sync ./static s3://growthbook-cloud-static-files/$sha/.next/static"
+          echo "would run aws s3 sync ./public s3://growthbook-cloud-static-files/$sha/public"
 
   # Deploy the back-end for GrowthBook Cloud
   prod:

--- a/.github/workflows/test-deploy-with-s3.yml
+++ b/.github/workflows/test-deploy-with-s3.yml
@@ -38,6 +38,7 @@ jobs:
         uses: depot/build-push-action@v1
         with:
           push: true
+          load: true
           context: .
           project: vmp2ssvj9r
           tags: |

--- a/.github/workflows/test-deploy-with-s3.yml
+++ b/.github/workflows/test-deploy-with-s3.yml
@@ -77,7 +77,6 @@ jobs:
         uses: depot/build-push-action@v1
         with:
           push: true
-          load: true
           build-args: |
             USE_REMOTE_ASSETS=true
           context: .
@@ -102,10 +101,8 @@ jobs:
       - name: Extract static assets from Docker image and upload to S3
         run: |
           docker pull growthbook/growthbook:deploy-with-s3-test-cloud
-          docker history growthbook/growthbook:deploy-with-s3-test-cloud
           docker create --name temp-container growthbook/growthbook:deploy-with-s3-test-cloud
           docker cp temp-container:/usr/local/src/app/packages/front-end/.next/static ./static
-          ls -la ./static
           docker cp temp-container:/usr/local/src/app/packages/front-end/public ./public
           docker cp temp-container:/usr/local/src/app/buildinfo/SHA ./SHA
           docker cp temp-container:/usr/local/src/app/buildinfo/DATE ./DATE

--- a/.github/workflows/test-deploy-with-s3.yml
+++ b/.github/workflows/test-deploy-with-s3.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   # Build and publish the commit to docker for self-hosted
-  docker:
+  create-docker-self-hosted-image:
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'growthbook/growthbook' }}
     permissions:
@@ -45,7 +45,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
 
   # Build and publish the commit to docker for cloud
-  docker-cloud:
+  create-docker-cloud-image:
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'growthbook/growthbook' }}
     permissions:

--- a/.github/workflows/test-deploy-with-s3.yml
+++ b/.github/workflows/test-deploy-with-s3.yml
@@ -89,6 +89,7 @@ jobs:
       - name: Determine if with load it gets the right docker layer
         run: |
           docker pull growthbook/growthbook:deploy-with-s3-test-cloud
+          docker history growthbook/growthbook:deploy-with-s3-test-cloud
           docker create --name temp-container growthbook/growthbook:deploy-with-s3-test-cloud
           docker cp temp-container:/usr/local/src/app/packages/front-end/.next/static ./static
           ls -la ./static
@@ -109,6 +110,7 @@ jobs:
       - name: Extract static assets from Docker image and upload to S3
         run: |
           docker pull growthbook/growthbook:deploy-with-s3-test-cloud
+          docker history growthbook/growthbook:deploy-with-s3-test-cloud
           docker create --name temp-container growthbook/growthbook:deploy-with-s3-test-cloud
           docker cp temp-container:/usr/local/src/app/packages/front-end/.next/static ./static
           ls -la ./static

--- a/.github/workflows/test-deploy-with-s3.yml
+++ b/.github/workflows/test-deploy-with-s3.yml
@@ -45,6 +45,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
 
       - name: Extract static assets from Docker image and upload to S3
+        env:
+          DEPOT_TOKEN: ${{ secrets.DEPOT_TOKEN }}
         run: |
           depot build . -t static-files --output=type=local,dest=./public
           ls ./public

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ packages/back-end/src/api/openapi/openapi.tmp.yaml
 
 # package lock files
 package-lock.json
+
+# compile time scss file
+packages/front-end/src/styles/variables.scss

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,11 @@ RUN \
   && yarn install --frozen-lockfile --production=true --ignore-optional
 RUN yarn postinstall
 
+# this stage is just for capturing the contents of /app/public
+FROM scratch AS static-files
+WORKDIR /usr/local/src/app
+COPY --from=nodebuild packages/front-end/.next/static static
+COPY --from=nodebuild packages/front-end/public public
 
 # Package the full app together
 FROM python:${PYTHON_MAJOR}-slim

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,8 +41,11 @@ RUN yarn install --frozen-lockfile --ignore-optional
 RUN yarn postinstall
 # Build the app and do a clean install with only production dependencies
 COPY packages ./packages
+# Args needed for frontend next.config.js to know what it should set its assetPrefix to
 ARG IS_CLOUD
 ENV IS_CLOUD=$IS_CLOUD
+# wildcard used to act as 'copy if exists'
+COPY buildinfo* ./buildinfo
 RUN \
   yarn build \
   && rm -rf node_modules \

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,8 +42,8 @@ RUN yarn postinstall
 # Build the app and do a clean install with only production dependencies
 COPY packages ./packages
 # Args needed for frontend next.config.js to know what it should set its assetPrefix to
-ARG IS_CLOUD
-ENV IS_CLOUD=$IS_CLOUD
+ARG USE_REMOTE_ASSETS
+ENV USE_REMOTE_ASSETS=$USE_REMOTE_ASSETS
 # wildcard used to act as 'copy if exists'
 COPY buildinfo* ./buildinfo
 RUN \

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,8 @@ RUN yarn install --frozen-lockfile --ignore-optional
 RUN yarn postinstall
 # Build the app and do a clean install with only production dependencies
 COPY packages ./packages
+ARG IS_CLOUD
+ENV IS_CLOUD=$IS_CLOUD
 RUN \
   yarn build \
   && rm -rf node_modules \
@@ -53,12 +55,6 @@ RUN \
   && rm -rf packages/sdk-react/node_modules \
   && yarn install --frozen-lockfile --production=true --ignore-optional
 RUN yarn postinstall
-
-# this stage is just for capturing the contents of /app/public
-FROM scratch AS static-files
-WORKDIR /usr/local/src/app
-COPY --from=nodebuild packages/front-end/.next/static static
-COPY --from=nodebuild packages/front-end/public public
 
 # Package the full app together
 FROM python:${PYTHON_MAJOR}-slim

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,7 @@ RUN \
   && rm -rf packages/sdk-react/node_modules \
   && yarn install --frozen-lockfile --production=true --ignore-optional
 RUN yarn postinstall
+RUN ls -la packages/front-end/.next/static
 
 # Package the full app together
 FROM python:${PYTHON_MAJOR}-slim

--- a/Dockerfile
+++ b/Dockerfile
@@ -89,5 +89,7 @@ RUN pip3 install /usr/local/src/gbstats/*.whl
 EXPOSE 3000
 # The back-end api (Express)
 EXPOSE 3100
+
+RUN ls -la packages/front-end/.next/static
 # Start both front-end and back-end at once
 CMD ["yarn","start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     volumes:
       - mongodata:/data/db
   growthbook:
-    image: "growthbook/growthbook:deploy-with-s3-test"
+    image: "growthbook/growthbook:deploy-with-s3-test-cloud"
     ports:
       - "3000:3000"
       - "3100:3100"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     volumes:
       - mongodata:/data/db
   growthbook:
-    image: "growthbook/growthbook:latest"
+    image: "growthbook/growthbook:deploy-with-s3-test"
     ports:
       - "3000:3000"
       - "3100:3100"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     volumes:
       - mongodata:/data/db
   growthbook:
-    image: "growthbook/growthbook:deploy-with-s3-test-cloud"
+    image: "growthbook/growthbook:latest"
     ports:
       - "3000:3000"
       - "3100:3100"

--- a/packages/front-end/components/Auth/InAppHelp.tsx
+++ b/packages/front-end/components/Auth/InAppHelp.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 import { BsQuestionLg, BsXLg } from "react-icons/bs";
 import { FaArrowRight } from "react-icons/fa";
 import { useUser } from "@/services/UserContext";
-import { isCloud } from "@/services/env";
+import { getPublicAssetsPath, isCloud } from "@/services/env";
 import { GBPremiumBadge } from "@/components/Icons";
 import UpgradeModal from "@/components/Settings/UpgradeModal";
 
@@ -58,7 +58,7 @@ export default function InAppHelp() {
           <div className="bg-purple rounded-top p-3 pb-4 d-flex align-items-center">
             <img
               alt="GrowthBook"
-              src="/logo/growth-book-logomark-white.svg"
+              src={`${getPublicAssetsPath()}/logo/growth-book-logomark-white.svg`}
               className="mb-1 pr-1"
               style={{ height: 30 }}
             />

--- a/packages/front-end/components/Auth/WelcomeFrame.tsx
+++ b/packages/front-end/components/Auth/WelcomeFrame.tsx
@@ -1,5 +1,6 @@
 import { ReactNode, FC, ReactElement } from "react";
 import LoadingOverlay from "@/components/LoadingOverlay";
+import { getPublicAssetsPath } from "@/services/env";
 
 type WelcomeFrameProps = {
   leftside: string | ReactElement | boolean;
@@ -28,7 +29,7 @@ const WelcomeFrame: FC<WelcomeFrameProps> = ({
                 rel="noreferrer"
               >
                 <img
-                  src="/logo/growth-book-logo-white.png"
+                  src={`${getPublicAssetsPath()}/logo/growth-book-logo-white.png`}
                   style={{ maxWidth: "150px" }}
                 />
               </a>

--- a/packages/front-end/components/Features/ExperimentSummary.tsx
+++ b/packages/front-end/components/Features/ExperimentSummary.tsx
@@ -10,6 +10,7 @@ import {
 import ValidateValue from "@/components/Features/ValidateValue";
 import NewExperimentForm from "@/components/Experiment/NewExperimentForm";
 import Modal from "@/components/Modal";
+import { getPublicAssetsPath } from "@/services/env";
 import ValueDisplay from "./ValueDisplay";
 import ExperimentSplitVisual from "./ExperimentSplitVisual";
 
@@ -82,7 +83,7 @@ export default function ExperimentSummary({
             <div className="col-4">
               <img
                 className=""
-                src="/images/add-graph.svg"
+                src={`${getPublicAssetsPath()}/images/add-graph.svg`}
                 alt=""
                 style={{ width: "100%", maxWidth: "200px" }}
               />

--- a/packages/front-end/components/GuidedGetStarted/GuidedGetStarted.tsx
+++ b/packages/front-end/components/GuidedGetStarted/GuidedGetStarted.tsx
@@ -18,6 +18,7 @@ import NewDataSourceForm from "@/components/Settings/NewDataSourceForm";
 import { DocLink, DocSection } from "@/components/DocLink";
 import InitialSDKConnectionForm from "@/components/Features/SDKConnections/InitialSDKConnectionForm";
 import MetricForm from "@/components/Metrics/MetricForm";
+import { getPublicAssetsPath } from "@/services/env";
 import styles from "./GuidedGetStarted.module.scss";
 import GetStartedSteps from "./GetStartedSteps";
 import SuccessCard from "./SuccessCard";
@@ -94,7 +95,7 @@ export default function GuidedGetStarted({
               <img
                 role="button"
                 className={styles.videoPreview}
-                src="/images/intro-video-cover.png"
+                src={`${getPublicAssetsPath()}/images/intro-video-cover.png`}
                 width={"100%"}
                 onClick={async () => {
                   setShowVideo(true);

--- a/packages/front-end/components/HomePage/GetStartedStep.tsx
+++ b/packages/front-end/components/HomePage/GetStartedStep.tsx
@@ -3,6 +3,7 @@ import { ReactElement } from "react";
 import { FaCheck } from "react-icons/fa";
 import { FiArrowRight } from "react-icons/fi";
 import Button from "@/components/Button";
+import { getPublicAssetsPath } from "@/services/env";
 
 export type Props = {
   current: boolean;
@@ -40,7 +41,7 @@ export default function GetStartedStep({
       <img
         className=""
         style={{ width: "100%", maxWidth: "200px", maxHeight: "160px" }}
-        src={image}
+        src={`${getPublicAssetsPath()}${image}`}
         alt=""
       />
     </div>

--- a/packages/front-end/components/Layout/Layout.tsx
+++ b/packages/front-end/components/Layout/Layout.tsx
@@ -10,7 +10,7 @@ import {
 } from "react-icons/bs";
 import { FaArrowRight } from "react-icons/fa";
 import { GlobalPermission } from "@back-end/types/organization";
-import { getGrowthBookBuild } from "@/services/env";
+import { getGrowthBookBuild, getPublicAssetsPath } from "@/services/env";
 import { useUser } from "@/services/UserContext";
 import useStripeSubscription from "@/hooks/useStripeSubscription";
 import useOrgSettings from "@/hooks/useOrgSettings";
@@ -386,7 +386,7 @@ const Layout = (): React.ReactElement => {
                       <img
                         className={styles.userlogo}
                         alt="GrowthBook"
-                        src={settings.logoPath}
+                        src={`${getPublicAssetsPath()}${settings.logoPath}`}
                       />
                     </>
                   ) : (
@@ -394,12 +394,12 @@ const Layout = (): React.ReactElement => {
                       <img
                         className={styles.logo}
                         alt="GrowthBook"
-                        src="/logo/growth-book-logomark-white.svg"
+                        src={`${getPublicAssetsPath()}/logo/growth-book-logomark-white.svg`}
                       />
                       <img
                         className={styles.logotext}
                         alt="GrowthBook"
-                        src="/logo/growth-book-name-white.svg"
+                        src={`${getPublicAssetsPath()}/logo/growth-book-name-white.svg`}
                       />
                     </>
                   )}

--- a/packages/front-end/components/Layout/LayoutLite.tsx
+++ b/packages/front-end/components/Layout/LayoutLite.tsx
@@ -1,4 +1,5 @@
 import clsx from "clsx";
+import { getPublicAssetsPath } from "@/services/env";
 import styles from "./LayoutLite.module.scss";
 import TopNav from "./TopNav";
 
@@ -21,12 +22,12 @@ const LayoutLite = (): React.ReactElement => {
                   <img
                     className={styles.logo}
                     alt="GrowthBook"
-                    src="/logo/growth-book-logomark-white.svg"
+                    src={`${getPublicAssetsPath()}/logo/growth-book-logomark-white.svg`}
                   />
                   <img
                     className={styles.logotext}
                     alt="GrowthBook"
-                    src="/logo/growth-book-name-white.svg"
+                    src={`${getPublicAssetsPath()}/logo/growth-book-name-white.svg`}
                   />
                 </div>
               </div>

--- a/packages/front-end/components/Layout/SidebarLink.tsx
+++ b/packages/front-end/components/Layout/SidebarLink.tsx
@@ -8,7 +8,7 @@ import { GrowthBook, useGrowthBook } from "@growthbook/growthbook-react";
 import { GlobalPermission } from "@back-end/types/organization";
 import { Permissions } from "shared/permissions";
 import { AppFeatures } from "@/types/app-features";
-import { isCloud, isMultiOrg } from "@/services/env";
+import { getPublicAssetsPath, isCloud, isMultiOrg } from "@/services/env";
 import { PermissionFunctions, useUser } from "@/services/UserContext";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 import styles from "./SidebarLink.module.scss";
@@ -114,7 +114,7 @@ const SidebarLink: FC<SidebarLinkProps> = (props) => {
           {props.Icon && <props.Icon className={styles.icon} />}
           {props.icon && (
             <span>
-              <img src={`/icons/${props.icon}`} />
+              <img src={`${getPublicAssetsPath()}/icons/${props.icon}`} />
             </span>
           )}
           {props.name}
@@ -156,7 +156,9 @@ const SidebarLink: FC<SidebarLinkProps> = (props) => {
                       {l.Icon && <l.Icon className={styles.icon} />}
                       {l.icon && (
                         <span>
-                          <img src={`/icons/${l.icon}`} />
+                          <img
+                            src={`${getPublicAssetsPath()}/icons/${l.icon}`}
+                          />
                         </span>
                       )}
                     </>

--- a/packages/front-end/components/Layout/TopNav.tsx
+++ b/packages/front-end/components/Layout/TopNav.tsx
@@ -8,7 +8,7 @@ import { useWatching } from "@/services/WatchProvider";
 import useGlobalMenu from "@/services/useGlobalMenu";
 import { useUser } from "@/services/UserContext";
 import { useAuth } from "@/services/auth";
-import { usingSSO } from "@/services/env";
+import { getPublicAssetsPath, usingSSO } from "@/services/env";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import { useCelebrationLocalStorage } from "@/hooks/useCelebration";
 import Modal from "@/components/Modal";
@@ -135,7 +135,7 @@ const TopNav: FC<{
             <div>
               <img
                 alt="GrowthBook"
-                src="/logo/growthbook-logo.png"
+                src={`${getPublicAssetsPath()}/logo/growthbook-logo.png`}
                 style={{ height: 40 }}
               />
             </div>

--- a/packages/front-end/components/Layout/TopNavLite.tsx
+++ b/packages/front-end/components/Layout/TopNavLite.tsx
@@ -3,6 +3,7 @@ import { safeLogout } from "@/services/auth";
 import { useUser } from "@/services/UserContext";
 import Avatar from "@/components/Avatar/Avatar";
 import Button from "@/components/Button";
+import { getPublicAssetsPath } from "@/services/env";
 import { ThemeToggler } from "./ThemeToggler/ThemeToggler";
 
 export default function TopNavLite() {
@@ -15,7 +16,7 @@ export default function TopNavLite() {
       <div>
         <img
           alt="GrowthBook"
-          src="/logo/growthbook-logo.png"
+          src={`${getPublicAssetsPath()}/logo/growthbook-logo.png`}
           style={{ height: 36 }}
         />
       </div>

--- a/packages/front-end/components/Modal.tsx
+++ b/packages/front-end/components/Modal.tsx
@@ -1,5 +1,6 @@
 import { FC, useRef, useEffect, useState, ReactNode } from "react";
 import clsx from "clsx";
+import { getPublicAssetsPath } from "@/services/env";
 import LoadingOverlay from "./LoadingOverlay";
 import Portal from "./Modal/Portal";
 import Tooltip from "./Tooltip/Tooltip";
@@ -116,7 +117,7 @@ const Modal: FC<ModalProps> = ({
             {header === "logo" ? (
               <img
                 alt="GrowthBook"
-                src="/logo/growthbook-logo.png"
+                src={`${getPublicAssetsPath()}/logo/growthbook-logo.png`}
                 style={{ height: 40 }}
               />
             ) : (

--- a/packages/front-end/components/importing/ImportFromServiceCard/ImportFromServiceCard.tsx
+++ b/packages/front-end/components/importing/ImportFromServiceCard/ImportFromServiceCard.tsx
@@ -1,5 +1,6 @@
 import React, { FC, PropsWithChildren } from "react";
 import Link from "next/link";
+import { getPublicAssetsPath } from "@/services/env";
 
 type ImportFromServiceCardProps = PropsWithChildren<{
   service: string;
@@ -28,7 +29,7 @@ export const ImportFromServiceCard: FC<ImportFromServiceCardProps> = ({
           }}
         >
           <img
-            src={`/images/3rd-party-logos/importing/icons/${icon}.svg`}
+            src={`${getPublicAssetsPath()}/images/3rd-party-logos/importing/icons/${icon}.svg`}
             style={{
               width: 40,
             }}

--- a/packages/front-end/next.config.js
+++ b/packages/front-end/next.config.js
@@ -21,9 +21,6 @@ const cspHeader = `
 module.exports = {
   // We already run eslint and typescript in CI/CD
   // Disable here to speed up production builds
-  assetPrefix: process.env.IS_CLOUD
-    ? `https://growthbook-cloud-static-files.s3.amazonaws.com/${gitCommitDate}/${gitSha}/`
-    : "",
   eslint: {
     ignoreDuringBuilds: true,
   },
@@ -45,4 +42,7 @@ module.exports = {
       ],
     },
   ],
+  assetPrefix: process.env.USE_REMOTE_ASSETS
+    ? `https://growthbook-cloud-static-files.s3.amazonaws.com/${gitCommitDate}/${gitSha}/`
+    : "",
 };

--- a/packages/front-end/next.config.js
+++ b/packages/front-end/next.config.js
@@ -6,9 +6,10 @@ const rootPath = path.join(__dirname, "..", "..");
 let gitSha = "";
 let gitCommitDate = "";
 if (fs.existsSync(path.join(rootPath, "buildinfo", "SHA"))) {
-  gitSha = trim(
-    fs.readFileSync(path.join(rootPath, "buildinfo", "SHA")).toString().trim()
-  );
+  gitSha = fs
+    .readFileSync(path.join(rootPath, "buildinfo", "SHA"))
+    .toString()
+    .trim();
 }
 if (fs.existsSync(path.join(rootPath, "buildinfo", "DATE"))) {
   gitCommitDate = fs

--- a/packages/front-end/next.config.js
+++ b/packages/front-end/next.config.js
@@ -1,3 +1,19 @@
+const fs = require("fs");
+const path = require("path");
+
+const rootPath = path.join(__dirname, "..", "..");
+
+let gitSha = "";
+let gitCommitDate = "";
+if (fs.existsSync(path.join(rootPath, "buildinfo", "SHA"))) {
+  gitSha = fs.readFileSync(path.join(rootPath, "buildinfo", "SHA")).toString();
+}
+if (fs.existsSync(path.join(rootPath, "buildinfo", "DATE"))) {
+  gitCommitDate = fs
+    .readFileSync(path.join(rootPath, "buildinfo", "DATE"))
+    .toString();
+}
+
 const cspHeader = `
     frame-ancestors 'none';
 `;
@@ -5,6 +21,9 @@ const cspHeader = `
 module.exports = {
   // We already run eslint and typescript in CI/CD
   // Disable here to speed up production builds
+  assetPrefix: process.env.IS_CLOUD
+    ? `https://growthbook-cloud-static-files.s3.amazonaws.com/${gitCommitDate}/${gitSha}/`
+    : "",
   eslint: {
     ignoreDuringBuilds: true,
   },

--- a/packages/front-end/next.config.js
+++ b/packages/front-end/next.config.js
@@ -6,12 +6,15 @@ const rootPath = path.join(__dirname, "..", "..");
 let gitSha = "";
 let gitCommitDate = "";
 if (fs.existsSync(path.join(rootPath, "buildinfo", "SHA"))) {
-  gitSha = fs.readFileSync(path.join(rootPath, "buildinfo", "SHA")).toString();
+  gitSha = trim(
+    fs.readFileSync(path.join(rootPath, "buildinfo", "SHA")).toString().trim()
+  );
 }
 if (fs.existsSync(path.join(rootPath, "buildinfo", "DATE"))) {
   gitCommitDate = fs
     .readFileSync(path.join(rootPath, "buildinfo", "DATE"))
-    .toString();
+    .toString()
+    .trim();
 }
 
 fs.writeFileSync(

--- a/packages/front-end/next.config.js
+++ b/packages/front-end/next.config.js
@@ -14,6 +14,15 @@ if (fs.existsSync(path.join(rootPath, "buildinfo", "DATE"))) {
     .toString();
 }
 
+fs.writeFileSync(
+  path.join(__dirname, "styles", "variables.scss"),
+  `$public-asset-prefix: "${
+    process.env.USE_REMOTE_ASSETS
+      ? `https://growthbook-cloud-static-files.s3.amazonaws.com/${gitCommitDate}/${gitSha}/public`
+      : ""
+  }";`
+);
+
 const cspHeader = `
     frame-ancestors 'none';
 `;

--- a/packages/front-end/pages/404.tsx
+++ b/packages/front-end/pages/404.tsx
@@ -1,7 +1,7 @@
 import * as Sentry from "@sentry/react";
 import { useRouter } from "next/router";
 import { useEffect } from "react";
-import { isSentryEnabled } from "@/services/env";
+import { getPublicAssetsPath, isSentryEnabled } from "@/services/env";
 
 export default function Custom404() {
   const ind = Math.ceil(Math.random() * 2);
@@ -23,7 +23,7 @@ export default function Custom404() {
   return (
     <div className="container d-flex justify-content-center h-100 align-items-center flex-column">
       <img
-        src={`/images/errors/404-${ind}.png`}
+        src={`${getPublicAssetsPath()}/images/errors/404-${ind}.png`}
         alt="404"
         style={{ maxWidth: "400px", width: "50%", minWidth: "230px" }}
       />

--- a/packages/front-end/pages/api/init.ts
+++ b/packages/front-end/pages/api/init.ts
@@ -24,6 +24,7 @@ export interface EnvironmentInitValue {
   storeSegmentsInMongo: boolean;
   allowCreateMetrics: boolean;
   usingFileProxy: boolean;
+  publicAssetsPath: string;
 }
 
 // Get env variables at runtime on the front-end while still using SSG
@@ -38,6 +39,7 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
     CDN_HOST,
     IS_CLOUD,
     IS_MULTI_ORG,
+    USE_REMOTE_ASSETS,
     ALLOW_SELF_ORG_CREATION,
     DISABLE_TELEMETRY,
     DEFAULT_CONVERSION_WINDOW_HOURS,
@@ -69,6 +71,11 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
       .toString();
   }
 
+  const publicAssetsPath =
+    IS_CLOUD && USE_REMOTE_ASSETS
+      ? `https://growthbook-cloud-static-files.s3.amazonaws.com/${build.date}/${build.sha}/public`
+      : "";
+
   const body: EnvironmentInitValue = {
     appOrigin: APP_ORIGIN || "http://localhost:3000",
     apiHost: API_HOST || "http://localhost:3100",
@@ -99,6 +106,7 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
     usingSSO: !!SSO_CONFIG, // No matter what SSO_CONFIG is set to we want it to count as using it.
     storeSegmentsInMongo: stringToBoolean(STORE_SEGMENTS_IN_MONGO),
     usingFileProxy: stringToBoolean(USING_FILE_PROXY),
+    publicAssetsPath,
   };
 
   res.status(200).json(body);

--- a/packages/front-end/pages/dashboard.tsx
+++ b/packages/front-end/pages/dashboard.tsx
@@ -5,6 +5,7 @@ import Dashboard from "@/components/HomePage/Dashboard";
 import LoadingOverlay from "@/components/LoadingOverlay";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import ExperimentsGetStarted from "@/components/HomePage/ExperimentsGetStarted";
+import { getPublicAssetsPath } from "@/services/env";
 
 export default function Analysis(): React.ReactElement {
   const { ready, error: definitionsError, project } = useDefinitions();
@@ -34,7 +35,7 @@ export default function Analysis(): React.ReactElement {
     <>
       <Head>
         <title>GrowthBook</title>
-        <link rel="icon" href="/favicon.ico" />
+        <link rel="icon" href={`${getPublicAssetsPath()}/favicon.ico`} />
       </Head>
 
       <div className="container pagecontents position-relative">

--- a/packages/front-end/pages/getstarted.tsx
+++ b/packages/front-end/pages/getstarted.tsx
@@ -14,6 +14,7 @@ import { useFeaturesList } from "@/services/features";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import GuidedGetStarted from "@/components/GuidedGetStarted/GuidedGetStarted";
 import styles from "@/components/GuidedGetStarted/GuidedGetStarted.module.scss";
+import { getPublicAssetsPath } from "@/services/env";
 
 const GetStartedPage = (): React.ReactElement => {
   const { ready, error: definitionsError } = useDefinitions();
@@ -73,7 +74,7 @@ const GetStartedPage = (): React.ReactElement => {
               <img
                 role="button"
                 className={styles.videoPreview}
-                src="/images/intro-video-cover.png"
+                src={`${getPublicAssetsPath()}/images/intro-video-cover.png`}
                 width={"100%"}
                 onClick={async () => {
                   setShowVideo(true);

--- a/packages/front-end/pages/sdks/[sdkid].tsx
+++ b/packages/front-end/pages/sdks/[sdkid].tsx
@@ -29,7 +29,7 @@ import SDKLanguageLogo from "@/components/Features/SDKConnections/SDKLanguageLog
 import ProxyTestButton from "@/components/Features/SDKConnections/ProxyTestButton";
 import Button from "@/components/Button";
 import useSDKConnections from "@/hooks/useSDKConnections";
-import { isCloud } from "@/services/env";
+import { getPublicAssetsPath, isCloud } from "@/services/env";
 import Tooltip from "@/components/Tooltip/Tooltip";
 import PageHead from "@/components/Layout/PageHead";
 import { useEnvironments } from "@/services/features";
@@ -439,7 +439,7 @@ export default function SDKConnectionPage() {
           title={
             <>
               <img
-                src="/logo/growthbook-logo.png"
+                src={`${getPublicAssetsPath()}/logo/growthbook-logo.png`}
                 style={{ width: 130 }}
                 alt="GrowthBook"
               />

--- a/packages/front-end/services/env.ts
+++ b/packages/front-end/services/env.ts
@@ -18,6 +18,7 @@ const env: EnvironmentInitValue = {
   storeSegmentsInMongo: false,
   allowCreateMetrics: true,
   usingFileProxy: false,
+  publicAssetsPath: "",
 };
 
 export async function initEnv() {
@@ -86,4 +87,7 @@ export function storeSegmentsInMongo() {
 }
 export function usingFileProxy() {
   return env.usingFileProxy;
+}
+export function getPublicAssetsPath() {
+  return env.publicAssetsPath;
 }

--- a/packages/front-end/styles/global.scss
+++ b/packages/front-end/styles/global.scss
@@ -10,6 +10,8 @@
 // Bootstrap theme overrides must be loaded AFTER Bootstrap
 @import "_bootstrap-theme-overrides";
 
+@import "variables";
+
 html,
 body,
 #__next,
@@ -1363,7 +1365,8 @@ main.main.report {
     min-height: 100%;
   }
   .ghosted-logo {
-    background: transparent url("/logo/growth-book-logomark-ghosted.png") 50%
+    background: transparent
+      url("#{$public-asset-prefix}/logo/growth-book-logomark-ghosted.png") 50%
       50%;
     background-size: contain;
     background-repeat: no-repeat;
@@ -2371,7 +2374,7 @@ li.metrics a span img {
   .image-blank {
     background-size: contain;
     background: var(--surface-background-color-alt)
-      url("/images/image-blank.png") no-repeat 50% 50%;
+      url("#{$public-asset-prefix}/images/image-blank.png") no-repeat 50% 50%;
     min-height: 200px;
     border-top: 1px solid var(--border-color-300);
     border-bottom: 1px solid var(--border-color-300);
@@ -2753,7 +2756,7 @@ html {
     border-radius: 3px;
 
     & > div {
-      background-image: url("/images/getstarted-explore.svg");
+      background-image: url("#{$public-asset-prefix}/images/getstarted-explore.svg");
       background-repeat: no-repeat;
       background-position: bottom right;
       min-height: 110px;


### PR DESCRIPTION
### Features and Changes
On each deploy some frontends that were loaded from an old server might try and read the files from a new server and vice-versa.  This PR tries to fix that situation by:
- deploying our static files to s3 in a bucket with the git date and hash prepended.
- building a `latest-cloud` docker image where the front-end app has an assetPrefix for nextJS that will look for static files that are normally in `.next/static` locally from s3 instead
- automatically creates a `variables.scss` file with a `$public-asset-prefix` variable that can be imported in scss files and prepended to an urls that would normally be looking for the files in `front-end/public`
- if `IS_CLOUD=true` will set a new `getPublicAssetsPath()` function to return the s3 public url.
- Updates all the images in the front end that had been reading from `front-end/public` to prepend the `getPublicAssetsPath()` function

### Dependencies

- [ ] CDN must be pointing to correct s3 bucket
- [ ] Must update urls to use the cdn instead of the s3 bucket directly
- [ ] Remove the test-deploy-with-s3.yml file

### Testing
Have the github action run with test-deploy-with-s3 action which is a modified deploy workflow that overwrites the latest tags to instead push to only test tags, and it doesn't actually do the deploy to ECS step.

Then locally do:
`docker pull --platform linux/amd64 growthbook/growthbook:deploy-with-s3-test-cloud`

Then modify docker-compose.yml:
```
version: "3"
services:
  mongo:
    image: "mongo:latest"
    environment:
      - MONGO_INITDB_ROOT_USERNAME=root
      - MONGO_INITDB_ROOT_PASSWORD=password
    volumes:
      - mongodata:/data/db
  growthbook:
    image: "growthbook/growthbook:latest"
    ports:
      - "3000:3000"
      - "3100:3100"
    depends_on:
      - mongo
    environment:
      - MONGODB_URI=mongodb://root:password@mongo:27017/growthbook?authSource=admin
      - IS_CLOUD=true
      - IS_MULTI_ORG=true
      - NODE_ENV=production
      - DISABLE_TELEMETRY=debug
      - LICENSE_SERVER_URL=http://localhost:8080/api/v1/
      - ENCRYPTION_KEY=asdkfjdkasljnvjkcnqeirnfioernf90nfi34nkjrncoip24inf
      - SSO_CONFIG= <VALID_SSO_CONFIG>
      - USE_REMOTE_ASSETS=true
    volumes:
      - uploads:/usr/local/src/app/packages/back-end/uploads
volumes:
  uploads:
  mongodata:
```

Then run `docker-compose up -d`

Then go to localhost:3000, open up the dev console networking tab, add "url" to the columns.  See that all the urls are hitting the cdn.
