### PR TITLE
add deploy job step to push static files to s3

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,5 +65,13 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
 
+      - name: Extract static assets from Docker image and upload to S3
+        run: |
+          docker pull growthbook/growthbook:latest
+          docker create --name temp-container growthbook/growthbook:latest
+          docker cp temp-container:/usr/local/src/app/packages/front-end/.next/static ./static
+          docker rm temp-container
+          aws s3 sync ./static s3://growthbook-cloud-static-files/_next/static
+
       - name: Deploy docker image to ECS for GrowthBook Cloud API
         run: aws ecs update-service --cluster prod-api --service prod-api --force-new-deployment --region us-east-1


### PR DESCRIPTION
### Features and Changes

On each deploy some frontends that were loaded from an old server might try and read the files from a new server and vice-versa. This PR will send the files to a new s3 bucket.  All the files that next makes have a hash appended to the file name so they can live in the same directory.  Both old and new files should be available at deploy time then.

We will then update the load balancer to send requests to /_next/static to instead be re-routed either to our cdn or directly to s3.

### Test Plan
Ran the commands locally.
Saw the files get to S3: https://us-east-1.console.aws.amazon.com/s3/buckets/growthbook-cloud-static-files?region=us-east-1&bucketType=general&tab=objects