### PR TITLE
Bug: Not showing duplicate experiment option

### DIFF
--- a/packages/front-end/pages/experiment/[eid].tsx
+++ b/packages/front-end/pages/experiment/[eid].tsx
@@ -78,7 +78,7 @@ const ExperimentPage = (): ReactElement => {
   } = data;
 
   const canEditExperiment =
-    !permissionsUtil.canViewExperimentModal(experiment.project) &&
+    permissionsUtil.canViewExperimentModal(experiment.project) &&
     !experiment.archived;
 
   let canRunExperiment = !experiment.archived;


### PR DESCRIPTION
### Features and Changes

When https://github.com/growthbook/growthbook/pull/2359 was merged in - there was one bang operator (`!`) that wasn't removed from testing that was causing the duplicate experiment option to render incorrectly. It was only showing if the user didn't have permission and the experiment wasn't archived, when it needs to be shown when the user DOES have permission and the experiment isn't archived.

### Testing

- [x] Ensure that if a user has permission to create experiments in a certain project, they see the duplicate experiment option for non-archived experiments
