### PR TITLE
Feature Regex Validator - Validate Name of Feature Id's with custom rules

### DIFF
--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -405,6 +405,15 @@ export async function postFeatures(
     throw new Error("Must specify feature key");
   }
 
+  if (org.settings?.featureRegexValidator) {
+    const regex = new RegExp(org.settings.featureRegexValidator);
+    if (!regex.test(id)) {
+      throw new Error(
+        `Feature key must match the regex validator. '${org.settings.featureRegexValidator}' Example: '${org.settings.featureKeyExample}'`
+      );
+    }
+  }
+
   if (!environmentSettings) {
     throw new Error("Feature missing initial environment toggle settings");
   }

--- a/packages/back-end/types/organization.d.ts
+++ b/packages/back-end/types/organization.d.ts
@@ -197,6 +197,8 @@ export interface OrganizationSettings {
   codeRefsBranchesToFilter?: string[];
   codeRefsPlatformUrl?: string;
   powerCalculatorEnabled?: boolean;
+  featureKeyExample?: string; // Example Key of feature flag (e.g. "feature-20240201-name")
+  featureRegexValidator?: string; // Regex to validate feature flag name (e.g. ^.+-\d{8}-.+$)
 }
 
 export interface SubscriptionQuote {

--- a/packages/front-end/components/Button.tsx
+++ b/packages/front-end/components/Button.tsx
@@ -34,11 +34,21 @@ const Button: FC<Props> = ({
   ...otherProps
 }) => {
   const [_internalLoading, setLoading] = useState(false);
-  const [error, setError] = useState<boolean | null>(false);
+  const [error, setError] = useState<string | null>(null);
   const loading = _externalLoading || _internalLoading;
 
   return (
     <>
+      {error && (
+        <div className="alert alert-danger mr-auto">
+          {error
+            .split("\n")
+            .filter((v) => !!v.trim())
+            .map((s, i) => (
+              <div key={i}>{s}</div>
+            ))}
+        </div>
+      )}
       <button
         {...otherProps}
         className={clsx("btn", className, {
@@ -70,7 +80,6 @@ const Button: FC<Props> = ({
           children
         )}
       </button>
-      {error && <pre className="text-danger ml-2">{error}</pre>}
       {!error && !loading && description ? (
         <small>
           <em>{description}</em>

--- a/packages/front-end/components/Features/FeatureModal/FeatureFromExperimentModal.tsx
+++ b/packages/front-end/components/Features/FeatureModal/FeatureFromExperimentModal.tsx
@@ -32,6 +32,7 @@ import MarkdownInput from "@/components/Markdown/MarkdownInput";
 import SelectField from "@/components/Forms/SelectField";
 import FeatureValueField from "@/components/Features/FeatureValueField";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
+import useOrgSettings from "@/hooks/useOrgSettings";
 import FeatureKeyField from "./FeatureKeyField";
 import EnvironmentSelect from "./EnvironmentSelect";
 import TagsField from "./TagsField";
@@ -192,6 +193,7 @@ export default function FeatureFromExperimentModal({
       "You don't have permission to create feature flag drafts.";
   }
 
+  const orgSettings = useOrgSettings();
   const existing = form.watch("existing");
 
   function updateValuesOnTypeChange(val: FeatureValueType) {
@@ -352,7 +354,10 @@ export default function FeatureFromExperimentModal({
 
       {!existing && (
         <>
-          <FeatureKeyField keyField={form.register("id")} />
+          <FeatureKeyField
+            keyField={form.register("id")}
+            placeHolder={orgSettings.featureKeyExample || "my-feature"}
+          />
 
           {showTags ? (
             <TagsField

--- a/packages/front-end/components/Features/FeatureModal/FeatureKeyField.tsx
+++ b/packages/front-end/components/Features/FeatureModal/FeatureKeyField.tsx
@@ -2,14 +2,15 @@ import { FC } from "react";
 import { UseFormRegisterReturn } from "react-hook-form";
 import Field from "@/components/Forms/Field";
 
-const FeatureKeyField: FC<{ keyField: UseFormRegisterReturn }> = ({
-  keyField,
-}) => (
+const FeatureKeyField: FC<{
+  keyField: UseFormRegisterReturn;
+  placeHolder: string;
+}> = ({ keyField, placeHolder }) => (
   <Field
     label="Feature Key"
     {...keyField}
     pattern="^[a-zA-Z0-9_.:|-]+$"
-    placeholder="my-feature"
+    placeholder={placeHolder}
     required
     title="Only letters, numbers, and the characters '_-.:|' allowed. No spaces."
     helpText={

--- a/packages/front-end/components/Features/FeatureModal/index.tsx
+++ b/packages/front-end/components/Features/FeatureModal/index.tsx
@@ -23,6 +23,7 @@ import MarkdownInput from "@/components/Markdown/MarkdownInput";
 import { useDemoDataSourceProject } from "@/hooks/useDemoDataSourceProject";
 import FeatureValueField from "@/components/Features/FeatureValueField";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
+import useOrgSettings from "@/hooks/useOrgSettings";
 import FeatureKeyField from "./FeatureKeyField";
 import EnvironmentSelect from "./EnvironmentSelect";
 import TagsField from "./TagsField";
@@ -146,6 +147,7 @@ export default function FeatureModal({
   const permissions = usePermissions();
   const permissionsUtil = usePermissionsUtil();
   const { refreshWatching } = useWatching();
+  const orgSettings = useOrgSettings();
 
   const defaultValues = genFormDefaultValues({
     environments,
@@ -245,8 +247,10 @@ export default function FeatureModal({
         </div>
       )}
 
-      <FeatureKeyField keyField={form.register("id")} />
-
+      <FeatureKeyField
+        keyField={form.register("id")}
+        placeHolder={orgSettings.featureKeyExample || "my-feature"}
+      />
       {showTags ? (
         <TagsField
           value={form.watch("tags") || []}

--- a/packages/front-end/components/GeneralSettings/FeaturesSettings.tsx
+++ b/packages/front-end/components/GeneralSettings/FeaturesSettings.tsx
@@ -99,7 +99,40 @@ export default function FeaturesSettings() {
             {...form.register("secureAttributeSalt")}
           />
         </div>
-
+        <div>
+          <label htmlFor="featureKeyExample">
+            Feature Key Example (Optional)
+          </label>
+          <Field
+            id="featureKeyExample"
+            {...form.register("featureKeyExample")}
+            placeholder="growth-20240531-newFeature"
+          />
+          <p>
+            <small className="text-muted mb-3">
+              When creating a new feature, this example will be shown. Only
+              letters, numbers, and the characters _, -, ., :, and | allowed. No
+              spaces.
+            </small>
+          </p>
+        </div>
+        <div>
+          <label htmlFor="featureRegexValidator">
+            Feature Key Regex Validator (Optional)
+          </label>
+          <Field
+            id="featureRegexValidator"
+            {...form.register("featureRegexValidator")}
+            placeholder="^.*-\d{8}-.*$"
+          />
+          <p>
+            <small className="text-muted mb-3">
+              When using the create feature modal, it will validate the feature
+              key against this regex. This will not block API feature creation,
+              and is used to enforce naming conventions at some companies.
+            </small>
+          </p>
+        </div>
         <div>
           <label className="mr-1" htmlFor="toggle-killswitchConfirmation">
             Require confirmation when changing an environment kill switch

--- a/packages/front-end/pages/settings/index.tsx
+++ b/packages/front-end/pages/settings/index.tsx
@@ -125,6 +125,8 @@ const GeneralSettingsPage = (): React.ReactElement => {
       codeReferencesEnabled: false,
       codeRefsBranchesToFilter: [],
       codeRefsPlatformUrl: "",
+      featureKeyExample: "",
+      featureRegexValidator: "",
     },
   });
   const { apiCall } = useAuth();
@@ -254,6 +256,44 @@ const GeneralSettingsPage = (): React.ReactElement => {
       multipleExposureMinPercent:
         (value.multipleExposureMinPercent ?? 0.01) / 100,
     };
+
+    // Make sure the feature key example is valid
+    if (
+      !(transformedOrgSettings.featureKeyExample ?? "").match(
+        /^[a-zA-Z0-9_.:|-]+$/
+      )
+    ) {
+      throw new Error(
+        "Feature key examples can only include letters, numbers, hyphens, and underscores."
+      );
+    }
+
+    // If the regex validator exists, then the feature key example must match the regex and be valid.
+    if (
+      transformedOrgSettings.featureRegexValidator &&
+      transformedOrgSettings.featureRegexValidator.length >= 1
+    ) {
+      if (
+        !transformedOrgSettings.featureKeyExample ||
+        !transformedOrgSettings.featureRegexValidator ||
+        transformedOrgSettings.featureKeyExample?.trim().length == 0
+      ) {
+        throw new Error(
+          "Feature key example must not be empty when a regex validator is defined."
+        );
+      }
+
+      const regexValidator = transformedOrgSettings.featureRegexValidator;
+      if (
+        !new RegExp(regexValidator).test(
+          transformedOrgSettings.featureKeyExample
+        )
+      ) {
+        throw new Error(
+          `Feature key example does not match the regex validator. '${transformedOrgSettings.featureRegexValidator}' Example: '${transformedOrgSettings.featureKeyExample}'`
+        );
+      }
+    }
 
     await apiCall(`/organization`, {
       method: "PUT",

--- a/packages/shared/src/settings/index.ts
+++ b/packages/shared/src/settings/index.ts
@@ -85,6 +85,8 @@ export const resolvers: Record<
   secureAttributeSalt: genDefaultResolver("secureAttributeSalt"),
   killswitchConfirmation: genDefaultResolver("killswitchConfirmation"),
   requireReviews: genDefaultResolver("requireReviews"),
+  featureKeyExample: genDefaultResolver("featureKeyExample"),
+  featureRegexValidator: genDefaultResolver("featureRegexValidator"),
 };
 
 const scopeSettings = (

--- a/packages/shared/src/settings/resolvers/genDefaultSettings.ts
+++ b/packages/shared/src/settings/resolvers/genDefaultSettings.ts
@@ -30,7 +30,10 @@ export const DEFAULT_LOSE_RISK = null;
 export const DEFAULT_WIN_RISK = null;
 export const DEFAULT_SECURE_ATTRIBUTE_SALT = "";
 export const DEFAULT_KILLSWITCH_CONFIRMATION = false;
+export const DEFAULT_REQUIRE_REVIEW = false;
 export const DEFAULT_REUIRE_REVIEW = false;
+export const DEFAULT_FEATURE_KEY_EXAMPLE = "";
+export const DEFAULT_FEATURE_REGEX_VALIDATOR = "";
 
 export const DEFAULT_METRIC_DEFAULTS: MetricDefaults = {
   maxPercentageChange: 0.5,
@@ -72,6 +75,8 @@ export default function genDefaultSettings(): Settings {
     winRisk: DEFAULT_WIN_RISK,
     secureAttributeSalt: DEFAULT_SECURE_ATTRIBUTE_SALT,
     killswitchConfirmation: DEFAULT_KILLSWITCH_CONFIRMATION,
-    requireReviews: DEFAULT_REUIRE_REVIEW,
+    requireReviews: DEFAULT_REQUIRE_REVIEW,
+    featureKeyExample: DEFAULT_FEATURE_KEY_EXAMPLE,
+    featureRegexValidator: DEFAULT_FEATURE_REGEX_VALIDATOR,
   };
 }

--- a/packages/shared/src/settings/types.ts
+++ b/packages/shared/src/settings/types.ts
@@ -82,6 +82,8 @@ interface BaseSettings {
   secureAttributeSalt: string;
   killswitchConfirmation: boolean;
   requireReviews: boolean | RequireReview[];
+  featureKeyExample: string;
+  featureRegexValidator: string;
 }
 
 // todo: encapsulate all settings, including experiment


### PR DESCRIPTION
Feature Regex Validator

### Features and Changes

The main new feature is that you can setup a default Feature placeholder, as well as a regex string to validate any new features.

This allows large companies to enforce naming notations, so in code its easy to read what the feature does & when it was made.

e.g.  "Team-Date-Feature" would be one example
Payments-20240231-NewPaymentMethod
Payments team created it, on 2024-02-31, and its a feature called NewPaymentMethod


**Additional Fixes**: 
The Setting Page error text used to be plain red text that was hidden below the button, i've changed the button error style to match the other pages and corrected the type to string. This makes the error text at least easily visible, which fixes a long standing issue of hard to error read text on this page.

### Testing

Tested on the UI.

### Screenshots of the Settings Page
<img width="1107" alt="Screenshot 2024-05-05 at 9 44 43 PM" src="https://github.com/growthbook/growthbook/assets/33769422/92a17241-b87a-4fcc-b9ae-b09226c2d0e9">

### Error / Validation
<img width="1107" alt="Screenshot 2024-05-05 at 10 06 38 PM" src="https://github.com/growthbook/growthbook/assets/33769422/99413419-243b-4073-a370-48a3616b18db">
<img width="1107" alt="Screenshot 2024-05-05 at 10 05 54 PM" src="https://github.com/growthbook/growthbook/assets/33769422/ce63cedf-be8b-439e-9eab-6aa375554014">


### Screenshots of the Feature Page
<img width="1107" alt="Screenshot 2024-05-05 at 10 08 04 PM" src="https://github.com/growthbook/growthbook/assets/33769422/020dd758-8eec-4773-b04f-911412c8f9c5">

### Error / Validation

<img width="928" alt="Screenshot 2024-05-05 at 9 44 25 PM" src="https://github.com/growthbook/growthbook/assets/33769422/0a0dbce7-d5fe-4e84-afb7-fc840a882ead">
