### PR TITLE
WIP: Migrates readData to permissionsClass

### DIFF
--- a/packages/back-end/src/controllers/datasources.ts
+++ b/packages/back-end/src/controllers/datasources.ts
@@ -548,11 +548,6 @@ export async function getDataSourceQueries(
     throw new Error("Could not find datasource");
   }
 
-  req.checkPermissions(
-    "readData",
-    datasourceObj?.projects?.length ? datasourceObj.projects : []
-  );
-
   const queries = await getQueriesByDatasource(context.org.id, id);
 
   res.status(200).json({

--- a/packages/back-end/src/models/FactMetricModel.ts
+++ b/packages/back-end/src/models/FactMetricModel.ts
@@ -28,7 +28,7 @@ const BaseClass = MakeModelClass({
 
 export class FactMetricModel extends BaseClass {
   protected canRead(doc: FactMetricInterface): boolean {
-    return this.context.hasPermission("readData", doc.projects || []);
+    return this.context.permissions.canReadMetric(doc);
   }
   protected canCreate(doc: FactMetricInterface): boolean {
     return this.context.permissions.canCreateMetric(doc);

--- a/packages/back-end/src/models/MetricModel.ts
+++ b/packages/back-end/src/models/MetricModel.ts
@@ -1,6 +1,5 @@
 import mongoose from "mongoose";
 import { ExperimentMetricInterface } from "shared/experiments";
-import { hasReadAccess } from "shared/permissions";
 import { LegacyMetricInterface, MetricInterface } from "../../types/metric";
 import { getConfigMetrics, usingFileConfig } from "../init/config";
 import { upgradeMetricDoc } from "../util/migrations";
@@ -266,9 +265,7 @@ async function findMetrics(
     metrics.push(toInterface(doc));
   });
 
-  return metrics.filter((m) =>
-    hasReadAccess(context.readAccessFilter, m.projects || [])
-  );
+  return metrics.filter((m) => context.permissions.canReadMetric(m));
 }
 
 export async function getMetricsByOrganization(
@@ -290,7 +287,7 @@ export async function getSampleMetrics(context: ReqContext | ApiReqContext) {
     organization: context.org.id,
   });
   return docs
-    .filter((m) => hasReadAccess(context.readAccessFilter, m.projects || []))
+    .filter((m) => context.permissions.canReadMetric(m))
     .map(toInterface);
 }
 
@@ -328,10 +325,7 @@ export async function getMetricById(
 
   const metric = res ? toInterface(res) : null;
 
-  if (
-    !metric ||
-    !hasReadAccess(context.readAccessFilter, metric.projects || [])
-  ) {
+  if (!metric || !context.permissions.canReadMetric(metric)) {
     return null;
   }
   return metric;
@@ -367,9 +361,7 @@ export async function getMetricsByIds(
       metrics.push(toInterface(doc));
     });
   }
-  return metrics.filter((m) =>
-    hasReadAccess(context.readAccessFilter, m.projects || [])
-  );
+  return metrics.filter((m) => context.permissions.canReadMetric(m));
 }
 
 export async function findRunningMetricsByQueryId(

--- a/packages/front-end/components/Layout/ProjectSelector.tsx
+++ b/packages/front-end/components/Layout/ProjectSelector.tsx
@@ -6,7 +6,7 @@ import { useDefinitions } from "@/services/DefinitionsContext";
 import { useAuth } from "@/services/auth";
 import Field from "@/components/Forms/Field";
 import { useSearch } from "@/services/search";
-import usePermissions from "@/hooks/usePermissions";
+import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 import Dropdown from "@/components/Dropdown/Dropdown";
 import DropdownLink from "@/components/Dropdown/DropdownLink";
 import LetterAvatar from "./LetterAvatar";
@@ -87,7 +87,7 @@ export default function ProjectSelector() {
   const { projects, project, getProjectById, setProject } = useDefinitions();
   const { orgId } = useAuth();
   const current = getProjectById(project);
-  const permissions = usePermissions();
+  const permissionsUtil = usePermissionsUtil();
 
   const currentProjectIsDemoProject = isDemoDatasourceProject({
     projectId: current?.id || "",
@@ -102,15 +102,15 @@ export default function ProjectSelector() {
   });
 
   useEffect(() => {
-    if (projects?.length === 1 && !permissions.check("readData", "")) {
+    if (projects?.length === 1 && !permissionsUtil.canReadAllProjects()) {
       setProject(projects[0].id);
     }
-  }, [projects, permissions, setProject]);
+  }, [permissionsUtil, projects, setProject]);
 
   if (!projects.length) return null;
 
   // If globalRole doesn't give readAccess & user can only access 1 project, don't show dropdown
-  if (projects.length === 1 && !permissions.check("readData", "")) {
+  if (projects.length === 1 && !permissionsUtil.canReadAllProjects()) {
     return (
       <li
         style={{

--- a/packages/front-end/pages/datasources/queries/[did].tsx
+++ b/packages/front-end/pages/datasources/queries/[did].tsx
@@ -17,17 +17,13 @@ import LoadingOverlay from "@/components/LoadingOverlay";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import Modal from "@/components/Modal";
 import ExpandableQuery from "@/components/Queries/ExpandableQuery";
-import usePermissions from "@/hooks/usePermissions";
 
 const DataSourceQueries = (): React.ReactElement => {
-  const permissions = usePermissions();
   const [modalData, setModalData] = useState<QueryInterface | null>(null);
   const router = useRouter();
   const { did } = router.query as { did: string };
   const { getDatasourceById, ready, error: datasourceError } = useDefinitions();
   const d = getDatasourceById(did);
-
-  const canView = d && permissions.check("readData", d.projects || []);
 
   const { data, error: queriesError } = useApi<{
     queries: QueryInterface[];
@@ -41,16 +37,6 @@ const DataSourceQueries = (): React.ReactElement => {
     localStorageKey: "datasourceQueries",
     searchFields: ["status", "queryType", "externalId"],
   });
-
-  if (!canView) {
-    return (
-      <div className="container pagecontents">
-        <div className="alert alert-danger">
-          You do not have access to view this page.
-        </div>
-      </div>
-    );
-  }
 
   if (datasourceError || queriesError) {
     return (

--- a/packages/shared/src/permissions/permissionsClass.ts
+++ b/packages/shared/src/permissions/permissionsClass.ts
@@ -31,6 +31,9 @@ export class Permissions {
   }
 
   //Global Permissions
+  public canReadAllProjects = (): boolean => {
+    return this.checkGlobalPermission("readData");
+  };
   public canCreatePresentation = (): boolean => {
     return this.checkGlobalPermission("createPresentations");
   };
@@ -398,6 +401,15 @@ export class Permissions {
     factTable: Pick<FactTableInterface, "projects">
   ): boolean => {
     return this.checkProjectFilterPermission(factTable, "manageFactTables");
+  };
+
+  public canReadMetric = (
+    metric: Pick<MetricInterface, "projects">
+  ): boolean => {
+    return this.checkProjectFilterPermission(
+      { projects: metric.projects || [] },
+      "readData"
+    );
   };
 
   public canCreateMetric = (


### PR DESCRIPTION
## Note:
This is a work-in-progress. I've checked in some work thus far that models how we might handle migrating `readData` to the permissionsClass. Currently, I've modeled how it could work for `metrics` with a `canReadMetric` helper method.

This approach provides flexibility should we want orgs to be able to control read access level by resources, not just by project. This approach also lends itself to creating policies for each resources similar to `readMetricsPolicy` and `readWriteMetricsPolicy`.

Going this approach will allow us to get rid of the `readAccessFilter` and `hasReadAccess` filter, and further consolidate the permissioning logic.

Alternatively, if we don't want to support resource-level read access filtering, I can create 2 helper methods (canReadGlobalData and canReadProjectLevelData) - the former can be used to check read access level for any global resource, and the latter can be used to check read access level for any project-scoped resource.

This would reduce the amount of code written within the `permissionClass` object (as we could write 2 methods as oppposed to ~10), but it would still require updating anywhere we're currently filtering/checking read access permission with `hasReadAccess` and the user's `readAccessFilter`.

Additionally, if we introduce helper methods on the `Permissions` class, we can remove the `getApiKeyReadAccessFilter` method since we're already building the `userPermissions` for non-users (aka, those using secret api keys) with the rest API.

### Features and Changes

<!--
  Include a description of your changes.
  If there are any new tools, API's, etc. that devs can leverage, it may be helpful to include usage info.
-->

<!--
  Indicate which issue this will close, if applicable
  For multiple issues, add a new `- Closes` or `- Fixes` line
-->

- Closes **(add link to issue here)**

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

<!--
  Please describe how to test these changes.
 -->

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
