### PR TITLE
Migrates runExperiments to permissionClass

### DIFF
--- a/packages/back-end/src/controllers/experimentLaunchChecklist.ts
+++ b/packages/back-end/src/controllers/experimentLaunchChecklist.ts
@@ -137,7 +137,9 @@ export async function putManualLaunchChecklist(
 
   const envs = experiment ? getAffectedEnvsForExperiment({ experiment }) : [];
 
-  req.checkPermissions("runExperiments", experiment?.project || "", envs);
+  if (!context.permissions.canRunExperiment(experiment, envs)) {
+    context.permissions.throwPermissionError();
+  }
 
   await updateExperiment({
     context,

--- a/packages/back-end/src/routers/url-redirects/url-redirects.controller.ts
+++ b/packages/back-end/src/routers/url-redirects/url-redirects.controller.ts
@@ -137,8 +137,13 @@ export const postURLRedirect = async (
   const envs = getAffectedEnvsForExperiment({
     experiment,
   });
-  envs.length > 0 &&
-    req.checkPermissions("runExperiments", experiment.project, envs);
+
+  if (
+    envs.length > 0 &&
+    !context.permissions.canRunExperiment(experiment, envs)
+  ) {
+    context.permissions.throwPermissionError();
+  }
 
   const urlRedirect = await createURLRedirect({
     experiment,
@@ -198,8 +203,9 @@ export const putURLRedirect = async (
   };
 
   const envs = experiment ? getAffectedEnvsForExperiment({ experiment }) : [];
-  req.checkPermissions("runExperiments", experiment?.project || "", envs);
-
+  if (!context.permissions.canRunExperiment(experiment || {}, envs)) {
+    context.permissions.throwPermissionError();
+  }
   await updateURLRedirect({
     urlRedirect,
     experiment,
@@ -228,7 +234,9 @@ export const deleteURLRedirect = async (
   const experiment = await getExperimentById(context, urlRedirect.experiment);
 
   const envs = experiment ? getAffectedEnvsForExperiment({ experiment }) : [];
-  req.checkPermissions("runExperiments", experiment?.project || "", envs);
+  if (!context.permissions.canRunExperiment(experiment || {}, envs)) {
+    context.permissions.throwPermissionError();
+  }
 
   await deleteURLRedirectById({
     urlRedirect,

--- a/packages/front-end/components/Experiment/AddExperimentModal.tsx
+++ b/packages/front-end/components/Experiment/AddExperimentModal.tsx
@@ -3,7 +3,6 @@ import { IconType } from "react-icons";
 import { GoBeaker, GoGraph } from "react-icons/go";
 import clsx from "clsx";
 import track from "@/services/track";
-import usePermissions from "@/hooks/usePermissions";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import Modal from "@/components/Modal";

--- a/packages/front-end/components/Experiment/AddExperimentModal.tsx
+++ b/packages/front-end/components/Experiment/AddExperimentModal.tsx
@@ -4,6 +4,7 @@ import { GoBeaker, GoGraph } from "react-icons/go";
 import clsx from "clsx";
 import track from "@/services/track";
 import usePermissions from "@/hooks/usePermissions";
+import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import Modal from "@/components/Modal";
 import styles from "./AddExperimentModal.module.scss";
@@ -52,10 +53,9 @@ const AddExperimentModal: FC<{
 }> = ({ onClose, source }) => {
   const { project } = useDefinitions();
 
-  const permissions = usePermissions();
-  const hasRunExperimentsPermission = permissions.check(
-    "runExperiments",
-    project,
+  const permissionsUtil = usePermissionsUtil();
+  const hasRunExperimentsPermission = permissionsUtil.canRunExperiment(
+    { project },
     []
   );
 

--- a/packages/front-end/components/Experiment/AnalysisForm.tsx
+++ b/packages/front-end/components/Experiment/AnalysisForm.tsx
@@ -19,7 +19,7 @@ import useOrgSettings from "@/hooks/useOrgSettings";
 import PremiumTooltip from "@/components/Marketing/PremiumTooltip";
 import { useUser } from "@/services/UserContext";
 import { hasFileConfig } from "@/services/env";
-import usePermissions from "@/hooks/usePermissions";
+import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 import { GBSequential } from "@/components/Icons";
 import StatsEngineSelect from "@/components/Settings/forms/StatsEngineSelect";
 import Modal from "@/components/Modal";
@@ -65,14 +65,13 @@ const AnalysisForm: FC<{
 
   const { organization, hasCommercialFeature } = useUser();
 
-  const permissions = usePermissions();
+  const permissionsUtil = usePermissionsUtil();
 
   const orgSettings = useOrgSettings();
 
   const hasOverrideMetricsFeature = hasCommercialFeature("override-metrics");
-  const [hasMetricOverrideRiskError, setHasMetricOverrideRiskError] = useState(
-    false
-  );
+  const [hasMetricOverrideRiskError, setHasMetricOverrideRiskError] =
+    useState(false);
   const [upgradeModal, setUpgradeModal] = useState(false);
 
   const pid = experiment?.project;
@@ -83,14 +82,13 @@ const AnalysisForm: FC<{
     project: project ?? undefined,
   });
 
-  const hasSequentialTestingFeature = hasCommercialFeature(
-    "sequential-testing"
-  );
+  const hasSequentialTestingFeature =
+    hasCommercialFeature("sequential-testing");
 
   let canRunExperiment = !experiment.archived;
   const envs = getAffectedEnvsForExperiment({ experiment });
   if (envs.length > 0) {
-    if (!permissions.check("runExperiments", experiment.project, envs)) {
+    if (!permissionsUtil.canRunExperiment(experiment, envs)) {
       canRunExperiment = false;
     }
   }
@@ -143,10 +141,8 @@ const AnalysisForm: FC<{
     },
   });
 
-  const [
-    usingSequentialTestingDefault,
-    setUsingSequentialTestingDefault,
-  ] = useState(experiment.sequentialTestingEnabled === undefined);
+  const [usingSequentialTestingDefault, setUsingSequentialTestingDefault] =
+    useState(experiment.sequentialTestingEnabled === undefined);
   const setSequentialTestingToDefault = useCallback(
     (enable: boolean) => {
       if (enable) {
@@ -227,7 +223,8 @@ const AnalysisForm: FC<{
         }
         if (usingSequentialTestingDefault) {
           // User checked the org default checkbox; ignore form values
-          body.sequentialTestingEnabled = !!orgSettings.sequentialTestingEnabled;
+          body.sequentialTestingEnabled =
+            !!orgSettings.sequentialTestingEnabled;
           body.sequentialTestingTuningParameter =
             orgSettings.sequentialTestingTuningParameter ??
             DEFAULT_SEQUENTIAL_TESTING_TUNING_PARAMETER;
@@ -657,7 +654,7 @@ const AnalysisForm: FC<{
               <MetricsOverridesSelector
                 experiment={experiment}
                 form={
-                  (form as unknown) as UseFormReturn<EditMetricsFormInterface>
+                  form as unknown as UseFormReturn<EditMetricsFormInterface>
                 }
                 disabled={!hasOverrideMetricsFeature}
                 setHasMetricOverrideRiskError={(v: boolean) =>

--- a/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
@@ -140,7 +140,7 @@ export default function ExperimentHeader({
   let hasRunExperimentsPermission = true;
   const envs = getAffectedEnvsForExperiment({ experiment });
   if (envs.length > 0) {
-    if (!permissions.check("runExperiments", experiment.project, envs)) {
+    if (!permissionsUtil.canRunExperiment(experiment, envs)) {
       hasRunExperimentsPermission = false;
     }
   }

--- a/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
@@ -20,7 +20,6 @@ import ConfirmButton from "@/components/Modal/ConfirmButton";
 import DeleteButton from "@/components/DeleteButton/DeleteButton";
 import TabButtons from "@/components/Tabs/TabButtons";
 import TabButton from "@/components/Tabs/TabButton";
-import usePermissions from "@/hooks/usePermissions";
 import HeaderWithEdit from "@/components/Layout/HeaderWithEdit";
 import Modal from "@/components/Modal";
 import { useScrollPosition } from "@/hooks/useScrollPosition";

--- a/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
@@ -102,7 +102,6 @@ export default function ExperimentHeader({
 }: Props) {
   const { apiCall } = useAuth();
   const router = useRouter();
-  const permissions = usePermissions();
   const permissionsUtil = usePermissionsUtil();
   const { getDatasourceById } = useDefinitions();
   const dataSource = getDatasourceById(experiment.datasource);

--- a/packages/front-end/components/Experiment/TabbedPage/Implementation.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/Implementation.tsx
@@ -4,7 +4,6 @@ import {
 } from "back-end/types/experiment";
 import { VisualChangesetInterface } from "back-end/types/visual-changeset";
 import { URLRedirectInterface } from "@back-end/types/url-redirect";
-import usePermissions from "@/hooks/usePermissions";
 import AddLinkedChanges from "@/components/Experiment/LinkedChanges/AddLinkedChanges";
 import RedirectLinkedChanges from "@/components/Experiment/LinkedChanges/RedirectLinkedChanges";
 import FeatureLinkedChanges from "@/components/Experiment/LinkedChanges/FeatureLinkedChanges";
@@ -37,7 +36,6 @@ export default function Implementation({
 }: Props) {
   const phases = experiment.phases || [];
 
-  const permissions = usePermissions();
   const permissionsUtil = usePermissionsUtil();
 
   const canEditExperiment =
@@ -45,8 +43,7 @@ export default function Implementation({
     permissionsUtil.canViewExperimentModal(experiment.project);
 
   const hasVisualEditorPermission =
-    canEditExperiment &&
-    permissions.check("runExperiments", experiment.project, []);
+    canEditExperiment && permissionsUtil.canRunExperiment(experiment, []);
 
   const canAddLinkedChanges =
     hasVisualEditorPermission && experiment.status === "draft";

--- a/packages/front-end/pages/experiment/[eid].tsx
+++ b/packages/front-end/pages/experiment/[eid].tsx
@@ -16,7 +16,6 @@ import LoadingOverlay from "@/components/LoadingOverlay";
 import useSwitchOrg from "@/services/useSwitchOrg";
 import EditMetricsForm from "@/components/Experiment/EditMetricsForm";
 import StopExperimentForm from "@/components/Experiment/StopExperimentForm";
-import usePermissions from "@/hooks/usePermissions";
 import EditVariationsForm from "@/components/Experiment/EditVariationsForm";
 import NewExperimentForm from "@/components/Experiment/NewExperimentForm";
 import EditTagsForm from "@/components/Tags/EditTagsForm";
@@ -32,7 +31,6 @@ import PageHead from "@/components/Layout/PageHead";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 
 const ExperimentPage = (): ReactElement => {
-  const permissions = usePermissions();
   const permissionsUtil = usePermissionsUtil();
   const router = useRouter();
   const { eid } = router.query;

--- a/packages/front-end/pages/experiment/[eid].tsx
+++ b/packages/front-end/pages/experiment/[eid].tsx
@@ -84,7 +84,7 @@ const ExperimentPage = (): ReactElement => {
   let canRunExperiment = !experiment.archived;
   const envs = getAffectedEnvsForExperiment({ experiment });
   if (envs.length > 0) {
-    if (!permissions.check("runExperiments", experiment.project, envs)) {
+    if (!permissionsUtil.canRunExperiment(experiment, envs)) {
       canRunExperiment = false;
     }
   }

--- a/packages/shared/src/permissions/permissionsClass.ts
+++ b/packages/shared/src/permissions/permissionsClass.ts
@@ -1,6 +1,7 @@
 import { FeatureInterface } from "back-end/types/feature";
 import { MetricInterface } from "back-end/types/metric";
 import {
+  EnvScopedPermission,
   GlobalPermission,
   Permission,
   ProjectScopedPermission,
@@ -584,6 +585,20 @@ export class Permissions {
     return this.checkProjectFilterPermission(datasource, "runQueries");
   };
 
+  // ENV_SCOPED_PERMISSIONS
+  public canRunExperiment = (
+    experiment: Pick<ExperimentInterface, "project">,
+    environments: string[]
+  ): boolean => {
+    return this.checkEnvFilterPermission(
+      {
+        projects: experiment.project ? [experiment.project] : [],
+      },
+      environments,
+      "runExperiments"
+    );
+  };
+
   public throwPermissionError(): void {
     throw new PermissionError(
       "You do not have permission to perform this action"
@@ -637,6 +652,18 @@ export class Permissions {
       return false;
     }
     return true;
+  }
+
+  public checkEnvFilterPermission(
+    obj: { projects?: string[] },
+    envs: string[],
+    permission: EnvScopedPermission
+  ): boolean {
+    const projects = obj.projects?.length ? obj.projects : [""];
+
+    return projects.every((project) =>
+      this.hasPermission(permission, project, envs)
+    );
   }
 
   private hasPermission(


### PR DESCRIPTION
### Features and Changes

This PR migrates the `runExperiments` permission to the Permissions Class and adds a new helper method `canRunExperiments`.

### Testing

<!--
  Please describe how to test these changes.
 -->

