### PR TITLE
Adds specific helper methods for Fact Metric permissions

### DIFF
--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -833,19 +833,17 @@ export async function postExperiment(
   }
 
   // Only some fields affect production SDK payloads
-  const needsRunExperimentsPermission = (
-    [
-      "phases",
-      "variations",
-      "project",
-      "name",
-      "trackingKey",
-      "archived",
-      "status",
-      "releasedVariationId",
-      "excludeFromPayload",
-    ] as (keyof ExperimentInterfaceStringDates)[]
-  ).some((key) => key in changes);
+  const needsRunExperimentsPermission = ([
+    "phases",
+    "variations",
+    "project",
+    "name",
+    "trackingKey",
+    "archived",
+    "status",
+    "releasedVariationId",
+    "excludeFromPayload",
+  ] as (keyof ExperimentInterfaceStringDates)[]).some((key) => key in changes);
   if (needsRunExperimentsPermission) {
     const envs = getAffectedEnvsForExperiment({
       experiment,
@@ -1797,8 +1795,7 @@ async function createExperimentSnapshot({
   }
 
   const { org } = context;
-  const orgSettings: OrganizationSettings =
-    org.settings as OrganizationSettings;
+  const orgSettings: OrganizationSettings = org.settings as OrganizationSettings;
   const { settings } = getScopedSettings({
     organization: org,
     project: project ?? undefined,
@@ -1824,18 +1821,20 @@ async function createExperimentSnapshot({
     )
   ).filter(Boolean) as MetricInterface[];
 
-  const { metricRegressionAdjustmentStatuses, regressionAdjustmentEnabled } =
-    getAllMetricRegressionAdjustmentStatuses({
-      allExperimentMetrics,
-      denominatorMetrics,
-      orgSettings,
-      statsEngine,
-      experimentRegressionAdjustmentEnabled:
-        experiment.regressionAdjustmentEnabled,
-      experimentMetricOverrides: experiment.metricOverrides,
-      datasourceType: datasource?.type,
-      hasRegressionAdjustmentFeature: true,
-    });
+  const {
+    metricRegressionAdjustmentStatuses,
+    regressionAdjustmentEnabled,
+  } = getAllMetricRegressionAdjustmentStatuses({
+    allExperimentMetrics,
+    denominatorMetrics,
+    orgSettings,
+    statsEngine,
+    experimentRegressionAdjustmentEnabled:
+      experiment.regressionAdjustmentEnabled,
+    experimentMetricOverrides: experiment.metricOverrides,
+    datasourceType: datasource?.type,
+    hasRegressionAdjustmentFeature: true,
+  });
 
   const analysisSettings = getDefaultExperimentAnalysisSettings(
     statsEngine,

--- a/packages/back-end/src/models/FactMetricModel.ts
+++ b/packages/back-end/src/models/FactMetricModel.ts
@@ -37,9 +37,7 @@ export class FactMetricModel extends BaseClass {
     existing: FactMetricInterface,
     updates: UpdateProps<FactMetricInterface>
   ): boolean {
-    return this.context.permissions.canUpdateFactMetric(existing, {
-      projects: updates.projects || existing.projects,
-    });
+    return this.context.permissions.canUpdateFactMetric(existing, updates);
   }
   protected canDelete(doc: FactMetricInterface): boolean {
     return this.context.permissions.canDeleteFactMetric(doc);

--- a/packages/back-end/src/models/FactMetricModel.ts
+++ b/packages/back-end/src/models/FactMetricModel.ts
@@ -38,8 +38,7 @@ export class FactMetricModel extends BaseClass {
     updates: UpdateProps<FactMetricInterface>
   ): boolean {
     return this.context.permissions.canUpdateFactMetric(existing, {
-      ...existing,
-      ...updates,
+      projects: updates.projects || existing.projects,
     });
   }
   protected canDelete(doc: FactMetricInterface): boolean {

--- a/packages/back-end/src/models/FactMetricModel.ts
+++ b/packages/back-end/src/models/FactMetricModel.ts
@@ -31,16 +31,19 @@ export class FactMetricModel extends BaseClass {
     return this.context.hasPermission("readData", doc.projects || []);
   }
   protected canCreate(doc: FactMetricInterface): boolean {
-    return this.context.permissions.canCreateMetric(doc);
+    return this.context.permissions.canCreateFactMetric(doc);
   }
   protected canUpdate(
     existing: FactMetricInterface,
     updates: UpdateProps<FactMetricInterface>
   ): boolean {
-    return this.context.permissions.canUpdateMetric(existing, updates);
+    return this.context.permissions.canUpdateFactMetric(existing, {
+      ...existing,
+      ...updates,
+    });
   }
   protected canDelete(doc: FactMetricInterface): boolean {
-    return this.context.permissions.canDeleteMetric(doc);
+    return this.context.permissions.canDeleteFactMetric(doc);
   }
 
   public static upgradeFactMetricDoc(

--- a/packages/front-end/components/Experiment/AnalysisForm.tsx
+++ b/packages/front-end/components/Experiment/AnalysisForm.tsx
@@ -70,8 +70,9 @@ const AnalysisForm: FC<{
   const orgSettings = useOrgSettings();
 
   const hasOverrideMetricsFeature = hasCommercialFeature("override-metrics");
-  const [hasMetricOverrideRiskError, setHasMetricOverrideRiskError] =
-    useState(false);
+  const [hasMetricOverrideRiskError, setHasMetricOverrideRiskError] = useState(
+    false
+  );
   const [upgradeModal, setUpgradeModal] = useState(false);
 
   const pid = experiment?.project;
@@ -82,8 +83,9 @@ const AnalysisForm: FC<{
     project: project ?? undefined,
   });
 
-  const hasSequentialTestingFeature =
-    hasCommercialFeature("sequential-testing");
+  const hasSequentialTestingFeature = hasCommercialFeature(
+    "sequential-testing"
+  );
 
   let canRunExperiment = !experiment.archived;
   const envs = getAffectedEnvsForExperiment({ experiment });
@@ -141,8 +143,10 @@ const AnalysisForm: FC<{
     },
   });
 
-  const [usingSequentialTestingDefault, setUsingSequentialTestingDefault] =
-    useState(experiment.sequentialTestingEnabled === undefined);
+  const [
+    usingSequentialTestingDefault,
+    setUsingSequentialTestingDefault,
+  ] = useState(experiment.sequentialTestingEnabled === undefined);
   const setSequentialTestingToDefault = useCallback(
     (enable: boolean) => {
       if (enable) {
@@ -223,8 +227,7 @@ const AnalysisForm: FC<{
         }
         if (usingSequentialTestingDefault) {
           // User checked the org default checkbox; ignore form values
-          body.sequentialTestingEnabled =
-            !!orgSettings.sequentialTestingEnabled;
+          body.sequentialTestingEnabled = !!orgSettings.sequentialTestingEnabled;
           body.sequentialTestingTuningParameter =
             orgSettings.sequentialTestingTuningParameter ??
             DEFAULT_SEQUENTIAL_TESTING_TUNING_PARAMETER;
@@ -654,7 +657,7 @@ const AnalysisForm: FC<{
               <MetricsOverridesSelector
                 experiment={experiment}
                 form={
-                  form as unknown as UseFormReturn<EditMetricsFormInterface>
+                  (form as unknown) as UseFormReturn<EditMetricsFormInterface>
                 }
                 disabled={!hasOverrideMetricsFeature}
                 setHasMetricOverrideRiskError={(v: boolean) =>

--- a/packages/front-end/components/FactTables/FactMetricList.tsx
+++ b/packages/front-end/components/FactTables/FactMetricList.tsx
@@ -51,7 +51,7 @@ export default function FactMetricList({ factTable }: Props) {
     searchFields: ["name^3", "description"],
   });
 
-  const canCreateMetrics = permissionsUtil.canCreateMetric({
+  const canCreateMetrics = permissionsUtil.canCreateFactMetric({
     projects: factTable.projects,
   });
 

--- a/packages/front-end/pages/fact-metrics/[fmid].tsx
+++ b/packages/front-end/pages/fact-metrics/[fmid].tsx
@@ -216,9 +216,11 @@ export default function FactMetricPage() {
   }
 
   const canEdit =
-    permissionsUtil.canUpdateMetric(factMetric, {}) && !factMetric.managedBy;
+    permissionsUtil.canUpdateFactMetric(factMetric, {
+      projects: factMetric.projects,
+    }) && !factMetric.managedBy;
   const canDelete =
-    permissionsUtil.canDeleteMetric(factMetric) && !factMetric.managedBy;
+    permissionsUtil.canDeleteFactMetric(factMetric) && !factMetric.managedBy;
 
   let regressionAdjustmentAvailableForMetric = true;
   let regressionAdjustmentAvailableForMetricReason = <></>;

--- a/packages/front-end/pages/fact-metrics/[fmid].tsx
+++ b/packages/front-end/pages/fact-metrics/[fmid].tsx
@@ -216,9 +216,8 @@ export default function FactMetricPage() {
   }
 
   const canEdit =
-    permissionsUtil.canUpdateFactMetric(factMetric, {
-      projects: factMetric.projects,
-    }) && !factMetric.managedBy;
+    permissionsUtil.canUpdateFactMetric(factMetric, {}) &&
+    !factMetric.managedBy;
   const canDelete =
     permissionsUtil.canDeleteFactMetric(factMetric) && !factMetric.managedBy;
 

--- a/packages/shared/src/permissions/permissionsClass.ts
+++ b/packages/shared/src/permissions/permissionsClass.ts
@@ -16,6 +16,7 @@ import {
 } from "back-end/types/fact-table";
 import { ExperimentInterface } from "back-end/types/experiment";
 import { DataSourceInterface } from "back-end/types/datasource";
+import { UpdateProps } from "back-end/types/models";
 import { READ_ONLY_PERMISSIONS } from "./permissions.utils";
 class PermissionError extends Error {
   constructor(message: string) {
@@ -438,7 +439,7 @@ export class Permissions {
 
   public canUpdateFactMetric = (
     existing: Pick<FactMetricInterface, "projects">,
-    updates: Pick<FactMetricInterface, "projects">
+    updates: UpdateProps<FactMetricInterface>
   ): boolean => {
     return this.checkProjectFilterUpdatePermission(
       existing,

--- a/packages/shared/src/permissions/permissionsClass.ts
+++ b/packages/shared/src/permissions/permissionsClass.ts
@@ -9,6 +9,7 @@ import {
 } from "back-end/types/organization";
 import { IdeaInterface } from "back-end/types/idea";
 import {
+  FactMetricInterface,
   FactTableInterface,
   UpdateFactTableProps,
 } from "back-end/types/fact-table";
@@ -426,6 +427,29 @@ export class Permissions {
     factTable: Pick<FactTableInterface, "projects">
   ): boolean => {
     return this.checkProjectFilterPermission(factTable, "manageFactTables");
+  };
+
+  public canCreateFactMetric = (
+    metric: Pick<FactMetricInterface, "projects">
+  ): boolean => {
+    return this.checkProjectFilterPermission(metric, "createMetrics");
+  };
+
+  public canUpdateFactMetric = (
+    existing: Pick<FactMetricInterface, "projects">,
+    updates: Pick<FactMetricInterface, "projects">
+  ): boolean => {
+    return this.checkProjectFilterUpdatePermission(
+      existing,
+      updates,
+      "createMetrics"
+    );
+  };
+
+  public canDeleteFactMetric = (
+    metric: Pick<FactMetricInterface, "projects">
+  ): boolean => {
+    return this.checkProjectFilterPermission(metric, "createMetrics");
   };
 
   public canCreateMetric = (


### PR DESCRIPTION
### Features and Changes

This PR introduces 3 new helper methods that allow us to differentiate permissions for managing Fact Metrics. Previously, we were grouping Fact Metrics and Non Fact Metrics together under the `canXYZMetric` methods. 

Some orgs have mentioned they don't want users to be able to use Fact Metrics, so by breaking it out, we're able to give them that flexibility.

This is the first permission that updates the `BaseModel` class. As a result, we do have to deviate from our existing `canUpdateXYZ` pattern given that `Fact Metrics`, AFAIK, are the first resource were the `projects` array isn't optional. This means that we have to pass in a `projects` array as the second argument to the `canUpdateFactMetrics`. This is unlike others where the `project` or `projects` property is optional. In those cases, we assume the `project` or `projects` isn't changing, so we don't check the permission again. Now, I'm checking if the `updates` object includes any updates to the `projects` array, and if so, passing it along, otherwise, passing in the `existing.projects` array.

This results in a second `hasPermission` check, but I think thats ok.

Open to feedback on that approach.

### Testing

- [x] Ensure that only admins, experimenters, and analysts can create Fact Metrics

### Note
- This issue is still present at the time of writing this where if a datasource that a Fact Table is built upon has more projects than the Fact Table, and the user doesn't have `createMetrics` permission on all of the data source's project, a user can get a "You don't have permission" message, even though it looks like they should based on the Fact Table's projects.

