### PR TITLE
Added SQL Server request timeout settings

### DIFF
--- a/packages/back-end/src/integrations/Mssql.ts
+++ b/packages/back-end/src/integrations/Mssql.ts
@@ -28,6 +28,7 @@ export default class Mssql extends SqlIntegration {
       user: this.params.user,
       password: this.params.password,
       database: this.params.database,
+      requestTimeout: (this.params.requestTimeout ?? 0) * 1000,
       options: this.params.options,
     });
 

--- a/packages/back-end/types/integrations/mssql.d.ts
+++ b/packages/back-end/types/integrations/mssql.d.ts
@@ -5,6 +5,7 @@ export interface MssqlConnectionParams {
   password: string;
   port: number;
   defaultSchema?: string;
+  requestTimeout?: number;
   options?: {
     encrypt?: boolean; // for azure
     trustServerCertificate?: boolean; // change to true for local dev / self-signed certs

--- a/packages/front-end/components/Settings/MssqlForm.tsx
+++ b/packages/front-end/components/Settings/MssqlForm.tsx
@@ -15,8 +15,7 @@ const MssqlForm: FC<{
   return (
     <>
       <HostWarning
-        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
-        host={params.server}
+        host={params.server ?? ""}
         setHost={(host) => {
           setParams({
             server: host,
@@ -79,6 +78,21 @@ const MssqlForm: FC<{
             onChange={onParamChange}
             placeholder={existing ? "(Keep existing)" : ""}
           />
+        </div>
+        <div className="form-group col-md-12">
+          <label>Request Timeout</label>
+          <input
+            type="number"
+            className="form-control"
+            name="requestTimeout"
+            value={params.requestTimeout || ""}
+            onChange={onParamChange}
+            placeholder="(optional - in seconds. If empty, it will be disabled)"
+          />
+          <div className="form-text text-muted small">
+            The number of seconds before a request is considered failed. The
+            connection default is 15 seconds. Set to 0 to disable timeout.
+          </div>
         </div>
         <div className="form-group col-md-12">
           <label>Default Schema</label>

--- a/packages/front-end/services/eventSchema.tsx
+++ b/packages/front-end/services/eventSchema.tsx
@@ -575,6 +575,7 @@ export const dataSourceConnections: {
       database: "",
       user: "",
       password: "",
+      requestTimeout: 120,
       options: {
         trustServerCertificate: true,
         encrypt: true,


### PR DESCRIPTION
SQL Server connections have a default timeout of 15 seconds. This has to be set when connecting. This PR adds a request timeout field that is user adjustable, and also increases the default time to 120 seconds. 

<img width="807" alt="Screenshot 2024-05-08 at 1 22 33 AM" src="https://github.com/growthbook/growthbook/assets/46107/20bfbd3f-67b2-4e2c-a2d3-b44f2104b91f">
