### PR TITLE
Creates separate helpers for managing fact table filters.

### DIFF
--- a/packages/back-end/src/api/bulk-import/postBulkImportFacts.ts
+++ b/packages/back-end/src/api/bulk-import/postBulkImportFacts.ts
@@ -151,7 +151,7 @@ export const postBulkImportFacts = createApiRequestHandler(
             `Could not find fact table ${factTableId} for filter ${id}`
           );
         }
-        if (!req.context.permissions.canUpdateFactTable(factTable, {})) {
+        if (!req.context.permissions.canCreateAndUpdateFactFilter(factTable)) {
           req.context.permissions.throwPermissionError();
         }
 

--- a/packages/back-end/src/api/fact-tables/deleteFactTableFilter.ts
+++ b/packages/back-end/src/api/fact-tables/deleteFactTableFilter.ts
@@ -14,7 +14,7 @@ export const deleteFactTableFilter = createApiRequestHandler(
       );
     }
 
-    if (!req.context.permissions.canUpdateFactTable(factTable, {})) {
+    if (!req.context.permissions.canDeleteFactFilter(factTable)) {
       req.context.permissions.throwPermissionError();
     }
     await deleteFactFilter(req.context, factTable, req.params.id);

--- a/packages/back-end/src/api/fact-tables/postFactTableFilter.ts
+++ b/packages/back-end/src/api/fact-tables/postFactTableFilter.ts
@@ -16,7 +16,7 @@ export const postFactTableFilter = createApiRequestHandler(
       throw new Error("Could not find factTable with that id");
     }
 
-    if (!req.context.permissions.canUpdateFactTable(factTable, {})) {
+    if (!req.context.permissions.canCreateAndUpdateFactFilter(factTable)) {
       req.context.permissions.throwPermissionError();
     }
 

--- a/packages/back-end/src/api/fact-tables/updateFactTableFilter.ts
+++ b/packages/back-end/src/api/fact-tables/updateFactTableFilter.ts
@@ -15,7 +15,8 @@ export const updateFactTableFilter = createApiRequestHandler(
     if (!factTable) {
       throw new Error("Could not find factTable with that id");
     }
-    if (!req.context.permissions.canUpdateFactTable(factTable, {})) {
+
+    if (!req.context.permissions.canCreateAndUpdateFactFilter(factTable)) {
       req.context.permissions.throwPermissionError();
     }
 

--- a/packages/back-end/src/routers/fact-table/fact-table.controller.ts
+++ b/packages/back-end/src/routers/fact-table/fact-table.controller.ts
@@ -223,7 +223,7 @@ export const postFactFilterTest = async (
     throw new Error("Could not find fact table with that id");
   }
 
-  if (!context.permissions.canUpdateFactTable(factTable, {})) {
+  if (!context.permissions.canCreateAndUpdateFactFilter(factTable)) {
     context.permissions.throwPermissionError();
   }
 
@@ -257,7 +257,7 @@ export const postFactFilter = async (
     throw new Error("Could not find fact table with that id");
   }
 
-  if (!context.permissions.canUpdateFactTable(factTable, {})) {
+  if (!context.permissions.canCreateAndUpdateFactFilter(factTable)) {
     context.permissions.throwPermissionError();
   }
 
@@ -286,7 +286,7 @@ export const putFactFilter = async (
     throw new Error("Could not find fact table with that id");
   }
 
-  if (!context.permissions.canUpdateFactTable(factTable, {})) {
+  if (!context.permissions.canCreateAndUpdateFactFilter(factTable)) {
     context.permissions.throwPermissionError();
   }
 
@@ -307,7 +307,7 @@ export const deleteFactFilter = async (
   if (!factTable) {
     throw new Error("Could not find filter table with that id");
   }
-  if (!context.permissions.canUpdateFactTable(factTable, {})) {
+  if (!context.permissions.canDeleteFactFilter(factTable)) {
     context.permissions.throwPermissionError();
   }
 

--- a/packages/front-end/components/FactTables/FactFilterList.tsx
+++ b/packages/front-end/components/FactTables/FactFilterList.tsx
@@ -34,7 +34,8 @@ export default function FactFilterList({ factTable }: Props) {
     searchFields: ["name^3", "description", "value^2"],
   });
 
-  const canEdit = permissionsUtil.canViewEditFactTableModal(factTable);
+  const canAddAndEdit = permissionsUtil.canCreateAndUpdateFactFilter(factTable);
+  const canDelete = permissionsUtil.canDeleteFactFilter(factTable);
 
   return (
     <>
@@ -65,17 +66,19 @@ export default function FactFilterList({ factTable }: Props) {
         <div className="col-auto">
           <Tooltip
             body={
-              canEdit ? "" : `You don't have permission to edit this fact table`
+              canAddAndEdit
+                ? ""
+                : `You don't have permission to edit this fact table`
             }
           >
             <button
               className="btn btn-primary"
               onClick={(e) => {
                 e.preventDefault();
-                if (!canEdit) return;
+                if (!canAddAndEdit) return;
                 setNewOpen(true);
               }}
-              disabled={!canEdit}
+              disabled={!canAddAndEdit}
             >
               <GBAddCircle /> Add Filter
             </button>
@@ -105,8 +108,8 @@ export default function FactFilterList({ factTable }: Props) {
                     </div>
                   </td>
                   <td style={{ verticalAlign: "top" }}>
-                    {canEdit && !filter.managedBy && (
-                      <MoreMenu>
+                    <MoreMenu>
+                      {canAddAndEdit && !filter.managedBy ? (
                         <button
                           className="dropdown-item"
                           onClick={(e) => {
@@ -116,6 +119,8 @@ export default function FactFilterList({ factTable }: Props) {
                         >
                           Edit
                         </button>
+                      ) : null}
+                      {canDelete && !filter.managedBy ? (
                         <DeleteButton
                           displayName="Filter"
                           className="dropdown-item"
@@ -131,8 +136,8 @@ export default function FactFilterList({ factTable }: Props) {
                             mutateDefinitions();
                           }}
                         />
-                      </MoreMenu>
-                    )}
+                      ) : null}
+                    </MoreMenu>
                   </td>
                 </tr>
               ))}

--- a/packages/shared/src/permissions/permissionsClass.ts
+++ b/packages/shared/src/permissions/permissionsClass.ts
@@ -431,6 +431,18 @@ export class Permissions {
     return this.checkProjectFilterPermission(factTable, "manageFactTables");
   };
 
+  public canCreateAndUpdateFactFilter = (
+    factTable: Pick<FactTableInterface, "projects">
+  ): boolean => {
+    return this.checkProjectFilterPermission(factTable, "manageFactTables");
+  };
+
+  public canDeleteFactFilter = (
+    factTable: Pick<FactTableInterface, "projects">
+  ): boolean => {
+    return this.checkProjectFilterPermission(factTable, "manageFactTables");
+  };
+
   public canCreateFactMetric = (
     metric: Pick<FactMetricInterface, "projects">
   ): boolean => {


### PR DESCRIPTION
### Features and Changes

This PR introduces 2 new helper methods: `canCreateAndUpdateFactFilters`, and `canDeleteFactFilters` - previously, we were checking for `canUpdateFactTable`, but its likely that orgs will want to let users create filters, but not give them access to update the Fact Table itself, so this paves the way for doing that.

Fact Filters inherit their projects via their parent Fact Table, so both of these methods take in the connected Fact Table as an argument.

I chose to group `create` and `update` into a singular method, as updating a FactFilter doesn't change the connected Fact Table's projects, so we don't need to use the existing `canUpdate` pattern of taking in the `existing` object and the `updates` and checking permissions against both of those. As a result, the logic between canCreate and canUpdate is shared, so I grouped them together.

### Testing

- [x] Ensure that if a user has the `manageFactTables` permission, they can create, update, and delete Fact Metrics.
