### PR TITLE
Power updates - add fact metrics; block ratio metrics

### DIFF
--- a/packages/front-end/components/PowerCalculation/PowerCalculationSettingsModal.tsx
+++ b/packages/front-end/components/PowerCalculation/PowerCalculationSettingsModal.tsx
@@ -6,6 +6,7 @@ import {
   isBinomialMetric,
   isFactMetric,
   isRatioMetric,
+  quantileMetricType,
 } from "shared/experiments";
 import Modal from "@/components/Modal";
 import MultiSelectField from "@/components/Forms/MultiSelectField";
@@ -45,7 +46,7 @@ const SelectStep = ({
     factMetrics: appFactMetrics,
     getExperimentMetricById,
   } = useDefinitions();
-  // combine both metrics and remove ratio metrics
+  // combine both metrics and remove ratio and quntile metrics
   const allAppMetrics: ExperimentMetricInterface[] = [
     ...appMetrics,
     ...appFactMetrics,
@@ -54,7 +55,8 @@ const SelectStep = ({
       m.denominator && !isFactMetric(m)
         ? getExperimentMetricById(m.denominator) ?? undefined
         : undefined;
-    return !isRatioMetric(m, denominator);
+    const isQuantileMetric = quantileMetricType(m) !== "";
+    return !isRatioMetric(m, denominator) && !isQuantileMetric;
   });
   const usersPerWeek = form.watch("usersPerWeek");
   const metrics = form.watch("metrics");
@@ -96,7 +98,9 @@ const SelectStep = ({
           <>
             <span className="mr-auto font-weight-bold">
               Select Metrics{" "}
-              <Tooltip body={"Ratio metrics can not be selected"} />
+              <Tooltip
+                body={"Ratio and quantile metrics can not be selected."}
+              />
             </span>{" "}
             Limit 5
           </>


### PR DESCRIPTION
Adds fact metrics to power calculator list.

Filters out ratio metrics from the list.

Adds tooltip that ratio metrics are not available.

<img width="337" alt="Screenshot 2024-05-08 at 10 54 39 AM" src="https://github.com/growthbook/growthbook/assets/5298599/b494aabc-1349-4b1f-992b-f0a19bb75221">
