### PR TITLE
Update copy on experiment without results

### DIFF
--- a/packages/front-end/components/Experiment/Results.tsx
+++ b/packages/front-end/components/Experiment/Results.tsx
@@ -2,7 +2,7 @@ import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
 import React, { FC, useEffect } from "react";
 import dynamic from "next/dynamic";
 import { DifferenceType, StatsEngine } from "back-end/types/stats";
-import { getValidDate, ago } from "shared/dates";
+import { getValidDate, ago, relativeDate } from "shared/dates";
 import { DEFAULT_STATS_ENGINE } from "shared/constants";
 import { ExperimentMetricInterface } from "shared/experiments";
 import { ExperimentSnapshotInterface } from "@back-end/types/experiment-snapshot";
@@ -229,9 +229,13 @@ const Results: FC<{
               "Make sure your experiment is tracking properly."}
             {snapshot &&
               phaseAgeMinutes < 120 &&
-              "It was just started " +
-                ago(experiment.phases[phase]?.dateStarted ?? "") +
-                ". Give it a little longer and click the 'Update' button above to check again."}
+              (phaseAgeMinutes < 0
+                ? "This experiment will start " +
+                  relativeDate(experiment.phases[phase]?.dateStarted ?? "") +
+                  ". Wait until it's been running for a little while and click the 'Update' button above to check again."
+                : "It was just started " +
+                  ago(experiment.phases[phase]?.dateStarted ?? "") +
+                  ". Give it a little longer and click the 'Update' button above to check again.")}
             {!snapshot &&
               datasource &&
               permissionsUtil.canRunExperimentQueries(datasource) &&

--- a/packages/shared/src/dates.ts
+++ b/packages/shared/src/dates.ts
@@ -3,6 +3,7 @@ import formatDistance from "date-fns/formatDistance";
 import differenceInDays from "date-fns/differenceInDays";
 import differenceInHours from "date-fns/differenceInHours";
 import addMonths from "date-fns/addMonths";
+import formatRelative from "date-fns/formatRelative";
 
 export function date(date: string | Date): string {
   if (!date) return "";
@@ -11,6 +12,10 @@ export function date(date: string | Date): string {
 export function datetime(date: string | Date): string {
   if (!date) return "";
   return format(getValidDate(date), "PPp");
+}
+export function relativeDate(date: string | Date): string {
+  if (!date) return "";
+  return formatRelative(getValidDate(date), new Date());
 }
 export function ago(date: string | Date): string {
   if (!date) return "";


### PR DESCRIPTION
### Features and Changes

Change text when experiment hasn't started yet to fix awkward copy

Also added a new helper to the shared dates utils to grab the relative date compared to now, as `ago` doesn't work well for future dates.


- Closes https://github.com/growthbook/growthbook/issues/318

### Dependencies

None

### Testing

* Open a sample experiment and edit the main phase to start at a future date
![image](https://github.com/growthbook/growthbook/assets/10674248/5a6e9a33-c323-4d14-bd0e-8670eb6333a7)

* Also verify that using a timestamp in the last 2 hours still triggers the existing copy

* And check that setting the phase to start > 2 hours ago allows results to show again

### Screenshots

Existing copy still applies:
![image](https://github.com/growthbook/growthbook/assets/10674248/d46cdacd-e950-4509-9aa2-b7febad30a63)

Examples of copy with future dates:
![image](https://github.com/growthbook/growthbook/assets/10674248/8b3f35be-92a2-41d1-8fc1-c2c1b4557dd2)
![image](https://github.com/growthbook/growthbook/assets/10674248/00d801af-ba66-4769-a023-4138cc3b85bf)
![image](https://github.com/growthbook/growthbook/assets/10674248/af3598a3-a38e-492c-b98c-a6d40679bee6)
![image](https://github.com/growthbook/growthbook/assets/10674248/84f1441f-e327-4267-8a22-604695d9f315)





Experiment results are not hidden when the phase properly starts in the past:
![image](https://github.com/growthbook/growthbook/assets/10674248/c36454d6-e499-43c5-9130-61fbbc3f81bb)
