### PR TITLE
Move highlightExp to resolve dashboard crashes

### DIFF
--- a/packages/front-end/components/Metrics/DateGraph.tsx
+++ b/packages/front-end/components/Metrics/DateGraph.tsx
@@ -235,6 +235,11 @@ const DateGraph: FC<DateGraphProps> = ({
   const experimentDates: ExperimentDisplayData[] = [];
   const bands = new Map();
 
+  const [
+    highlightExp,
+    setHighlightExp,
+  ] = useState<null | ExperimentDisplayData>(null);
+
   if (experiments && experiments.length > 0) {
     experiments.forEach((e) => {
       if (e.status !== "draft") {
@@ -379,11 +384,6 @@ const DateGraph: FC<DateGraphProps> = ({
   const [toolTipTimer, setToolTipTimer] = useState<
     undefined | ReturnType<typeof setTimeout>
   >();
-
-  const [
-    highlightExp,
-    setHighlightExp,
-  ] = useState<null | ExperimentDisplayData>(null);
 
   useEffect(() => {
     if (!hoverDate) {


### PR DESCRIPTION
Some customers are reporting a crash on the dashboard, which is erroring in the following location

![image](https://github.com/growthbook/growthbook/assets/5298599/82fd6513-9da9-40a7-a703-f8d487090e9c)

```
­ Z && Z.length > 0 && (Z.forEach(e=>{
­                if ("draft" !== e.status) {
­                    let t = {
­                        name: e.name,
­                        id: e.id,
­                        color: "rgb(136, 132, 216)",
­                        band: 0,
­                        result: e.results,
­                        status: e.status,
­                        analysis: e.analysis,
­                        opacity: eh && eh.id === e.id ? 1 : .35
­                    };
­                    "running" === e.status && (t.color = "rgb(206,181,20)"),
­                    "won" === e.results ? t.color = "rgba(20,206,134)" : "lost" === e.results && (t.color = "rgb(199,51,51)"),
­                    (null == e ? void 0 : e.phases) && (null == e || e.phases.forEach(e=>{
­                        t.dateStarted ? e.dateStarted && e.dateStarted < t.dateStarted && (t.dateStarted = e.dateStarted) : t.dateStarted = e.dateStarted,
­                        t.dateEnded ? e.dateEnded && e.dateEnded > t.dateEnded && (t.dateEnded = e.dateEnded) : t.dateEnded = e.dateEnded
­                    }
­                    )),
­                    "running" !== e.status || t.dateEnded || (t.dateEnded = new Date().toISOString()),
­                    t.dateStarted && t.dateEnded && z.push(t)
­                }
­            }
­            ),
```

Which seems to be from highlightExp not being initialized. It's unclear why this happens for only some folks, but hopefully this resolves the issue.