### PR TITLE
Add typeguard for filtering out undefined

### DIFF
--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -1,15 +1,14 @@
 import { Response } from "express";
-
 import uniqid from "uniqid";
 import format from "date-fns/format";
 import cloneDeep from "lodash/cloneDeep";
 import { DEFAULT_SEQUENTIAL_TESTING_TUNING_PARAMETER } from "shared/constants";
 import { getValidDate } from "shared/dates";
-import { getAffectedEnvsForExperiment } from "shared/util";
+import { getAffectedEnvsForExperiment, isDefined } from "shared/util";
+import { getAllMetricSettingsForSnapshot } from "shared/experiments";
 import { getScopedSettings } from "shared/settings";
 import { v4 as uuidv4 } from "uuid";
 import uniq from "lodash/uniq";
-import { getAllMetricSettingsForSnapshot } from "shared/experiments";
 import { DataSourceInterface } from "@back-end/types/datasource";
 import { AuthRequest, ResponseWithStatusAndError } from "../types/AuthRequest";
 import {
@@ -21,7 +20,7 @@ import {
   getExperimentMetricById,
   getLinkedFeatureInfo,
 } from "../services/experiments";
-import { MetricInterface, MetricStats } from "../../types/metric";
+import { MetricStats } from "../../types/metric";
 import {
   createExperiment,
   deleteExperimentByIdForOrganization,
@@ -1819,7 +1818,7 @@ async function createExperimentSnapshot({
     await Promise.all(
       denominatorMetricIds.map((m) => getMetricById(context, m))
     )
-  ).filter(Boolean) as MetricInterface[];
+  ).filter(isDefined);
 
   const {
     settingsForSnapshotMetrics,

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -22,6 +22,7 @@ import {
   getMatchingRules,
   MatchingRule,
   validateCondition,
+  isDefined,
 } from "shared/util";
 import {
   ExperimentMetricInterface,
@@ -39,7 +40,6 @@ import {
   ExperimentSnapshotAnalysisSettings,
   ExperimentSnapshotInterface,
   ExperimentSnapshotSettings,
-  MetricForSnapshot,
   SnapshotVariation,
 } from "../../types/experiment-snapshot";
 import {
@@ -404,7 +404,7 @@ export function getSnapshotSettings({
         experiment.metricOverrides
       )
     )
-    .filter(Boolean) as MetricForSnapshot[];
+    .filter(isDefined);
 
   return {
     manual: !experiment.datasource,
@@ -1967,7 +1967,7 @@ export async function getSettingsForSnapshotMetrics(
   ]);
   const allExperimentMetrics = allExperimentMetricIds
     .map((id) => metricMap.get(id))
-    .filter(Boolean);
+    .filter(isDefined);
 
   const denominatorMetrics = allExperimentMetrics
     .filter((m) => m && !isFactMetric(m) && m.denominator)

--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -8,11 +8,11 @@ import {
   FeatureRule as FeatureDefinitionRule,
   AutoExperiment,
   GrowthBook,
-  ParentConditionInterface,
 } from "@growthbook/growthbook";
 import {
   evalDeterministicPrereqValue,
   evaluatePrerequisiteState,
+  isDefined,
   PrerequisiteStateResult,
   validateCondition,
   validateFeatureValue,
@@ -192,7 +192,7 @@ export function generateAutoExperimentsPayload({
             condition,
           };
         })
-        .filter(Boolean) as ParentConditionInterface[];
+        .filter(isDefined);
 
       if (!phase) return null;
 
@@ -774,7 +774,7 @@ export function evaluateFeature({
         const rulesWithPrereqs: FeatureDefinitionRule[] = [];
         if (scrubPrerequisites) {
           definition.rules = definition.rules
-            ? (definition?.rules
+            ? definition?.rules
                 ?.map((rule) => {
                   if (rule?.parentConditions?.length) {
                     rulesWithPrereqs.push(rule);
@@ -790,7 +790,7 @@ export function evaluateFeature({
                   }
                   return rule;
                 })
-                .filter(Boolean) as FeatureDefinitionRule[])
+                .filter(isDefined)
             : undefined;
         }
 

--- a/packages/back-end/src/services/reports.ts
+++ b/packages/back-end/src/services/reports.ts
@@ -11,6 +11,7 @@ import {
   isBinomialMetric,
   ExperimentMetricInterface,
 } from "shared/experiments";
+import { isDefined } from "shared/util";
 import {
   ExperimentReportArgs,
   ExperimentReportVariation,
@@ -147,7 +148,7 @@ export function getSnapshotSettingsFromReportArgs(
           args.metricOverrides
         )
       )
-      .filter(Boolean) as MetricForSnapshot[],
+      .filter(isDefined),
     activationMetric: args.activationMetric || null,
     attributionModel: args.attributionModel || "firstExposure",
     datasourceId: args.datasource,

--- a/packages/back-end/src/util/features.ts
+++ b/packages/back-end/src/util/features.ts
@@ -1,10 +1,9 @@
 import isEqual from "lodash/isEqual";
 import {
   ConditionInterface,
-  ParentConditionInterface,
   FeatureRule as FeatureDefinitionRule,
 } from "@growthbook/growthbook";
-import { includeExperimentInPayload } from "shared/util";
+import { includeExperimentInPayload, isDefined } from "shared/util";
 import {
   FeatureInterface,
   FeatureRule,
@@ -354,7 +353,7 @@ export function getFeatureDefinition({
         ],
       };
     })
-    .filter(Boolean) as FeatureDefinitionRule[];
+    .filter(isDefined);
 
   const isRule = (
     rule: FeatureDefinitionRule | null
@@ -477,7 +476,7 @@ export function getFeatureDefinition({
               condition,
             };
           })
-          .filter(Boolean) as ParentConditionInterface[];
+          .filter(isDefined);
         if (prerequisites?.length) {
           rule.parentConditions = prerequisites;
         }

--- a/packages/front-end/components/Experiment/BreakDownResults.tsx
+++ b/packages/front-end/components/Experiment/BreakDownResults.tsx
@@ -11,6 +11,7 @@ import {
   StatsEngine,
 } from "back-end/types/stats";
 import { ExperimentMetricInterface } from "shared/experiments";
+import { isDefined } from "shared/util";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import {
   applyMetricOverrides,
@@ -112,7 +113,7 @@ const BreakDownResults: FC<{
 
     const metricDefs = [...metrics, ...(guardrails || [])]
       .map((metricId) => getExperimentMetricById(metricId))
-      .filter(Boolean) as ExperimentMetricInterface[];
+      .filter(isDefined);
     const sortedFilteredMetrics = sortAndFilterMetricsByTags(
       metricDefs,
       metricFilter

--- a/packages/front-end/components/Experiment/CompactResults.tsx
+++ b/packages/front-end/components/Experiment/CompactResults.tsx
@@ -15,6 +15,7 @@ import Link from "next/link";
 import { FaAngleRight, FaTimes, FaUsers } from "react-icons/fa";
 import Collapsible from "react-collapsible";
 import { ExperimentMetricInterface, getMetricLink } from "shared/experiments";
+import { isDefined } from "shared/util";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import {
   applyMetricOverrides,
@@ -168,7 +169,7 @@ const CompactResults: FC<{
 
     const metricDefs = metrics
       .map((metricId) => getExperimentMetricById(metricId))
-      .filter(Boolean) as ExperimentMetricInterface[];
+      .filter(isDefined);
     const sortedFilteredMetrics = sortAndFilterMetricsByTags(
       metricDefs,
       metricFilter
@@ -176,7 +177,7 @@ const CompactResults: FC<{
 
     const guardrailDefs = guardrails
       .map((metricId) => getExperimentMetricById(metricId))
-      .filter(Boolean) as ExperimentMetricInterface[];
+      .filter(isDefined);
     const sortedFilteredGuardrails = sortAndFilterMetricsByTags(
       guardrailDefs,
       metricFilter
@@ -184,10 +185,10 @@ const CompactResults: FC<{
 
     const retMetrics = sortedFilteredMetrics
       .map((metricId) => getRow(metricId, false))
-      .filter((row) => row?.metric) as ExperimentTableRow[];
+      .filter(isDefined);
     const retGuardrails = sortedFilteredGuardrails
       .map((metricId) => getRow(metricId, true))
-      .filter((row) => row?.metric) as ExperimentTableRow[];
+      .filter(isDefined);
     return [...retMetrics, ...retGuardrails];
   }, [
     results,

--- a/packages/front-end/components/Experiment/TabbedPage/ResultsTab.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/ResultsTab.tsx
@@ -10,9 +10,9 @@ import { VisualChangesetInterface } from "back-end/types/visual-changeset";
 import { SDKConnectionInterface } from "back-end/types/sdk-connection";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { MetricInterface } from "back-end/types/metric";
 import { DifferenceType } from "back-end/types/stats";
 import { getAllMetricSettingsForSnapshot } from "shared/experiments";
+import { isDefined } from "shared/util";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import { useUser } from "@/services/UserContext";
 import useOrgSettings from "@/hooks/useOrgSettings";
@@ -120,7 +120,7 @@ export default function ResultsTab({
   );
   const denominatorMetrics = denominatorMetricIds
     .map((m) => getMetricById(m as string))
-    .filter(Boolean) as MetricInterface[];
+    .filter(isDefined);
 
   const orgSettings = useOrgSettings();
 

--- a/packages/front-end/components/Experiment/TabbedPage/index.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/index.tsx
@@ -4,7 +4,7 @@ import {
 } from "back-end/types/experiment";
 import { IdeaInterface } from "back-end/types/idea";
 import { VisualChangesetInterface } from "back-end/types/visual-changeset";
-import { includeExperimentInPayload } from "shared/util";
+import { includeExperimentInPayload, isDefined } from "shared/util";
 import { useCallback, useEffect, useState } from "react";
 import { FaChartBar } from "react-icons/fa";
 import clsx from "clsx";
@@ -178,8 +178,8 @@ export default function TabbedPage({
   // Get name or email of all active users watching this experiment
   const usersWatching = (watcherIds?.data?.userIds || [])
     .map((id) => users.get(id))
-    .filter(Boolean)
-    .map((u) => u?.name || u?.email);
+    .filter(isDefined)
+    .map((u) => u.name || u.email);
 
   const safeToEdit = experiment.status !== "running" || !hasLiveLinkedChanges;
 

--- a/packages/front-end/components/Features/ConditionDisplay.tsx
+++ b/packages/front-end/components/Features/ConditionDisplay.tsx
@@ -6,6 +6,7 @@ import {
   SavedGroupTargeting,
 } from "back-end/types/feature";
 import Link from "next/link";
+import { isDefined } from "shared/util";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import { Condition, jsonToConds, useAttributeMap } from "@/services/features";
 import Tooltip from "@/components/Tooltip/Tooltip";
@@ -315,7 +316,7 @@ export default function ConditionDisplay({
         });
         return cond;
       })
-      .filter(Boolean) as ConditionWithParentId[][];
+      .filter(isDefined);
 
     const prereqConds =
       prereqConditionsGrouped.reduce(

--- a/packages/front-end/components/Forms/MultiSelectField.tsx
+++ b/packages/front-end/components/Forms/MultiSelectField.tsx
@@ -18,6 +18,7 @@ import {
 } from "react-sortable-hoc";
 import { arrayMove } from "@dnd-kit/sortable";
 import CreatableSelect from "react-select/creatable";
+import { isDefined } from "shared/util";
 import {
   GroupedValue,
   ReactSelectProps,
@@ -112,7 +113,7 @@ const MultiSelectField: FC<
   ...otherProps
 }) => {
   const [map, sorted] = useSelectOptions(options, initialOption, sort);
-  const selected = value.map((v) => map.get(v)).filter(Boolean);
+  const selected = value.map((v) => map.get(v)).filter(isDefined);
 
   // eslint-disable-next-line
   const fieldProps = otherProps as any;
@@ -122,7 +123,6 @@ const MultiSelectField: FC<
   const onSortEnd: SortEndHandler = ({ oldIndex, newIndex }) => {
     onChange(
       arrayMove(
-        // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
         selected.map((v) => v.value),
         oldIndex,
         newIndex
@@ -164,7 +164,6 @@ const MultiSelectField: FC<
             }}
             closeMenuOnSelect={closeMenuOnSelect}
             autoFocus={autoFocus}
-            // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '(SingleValue | undefined)[]' is not assignab... Remove this comment to see the full error message
             value={selected}
             placeholder={initialOption ?? placeholder}
             {...{ ...ReactSelectProps, ...mergeStyles }}

--- a/packages/front-end/components/GuidedGetStarted/GuidedGetStarted.tsx
+++ b/packages/front-end/components/GuidedGetStarted/GuidedGetStarted.tsx
@@ -178,8 +178,9 @@ export default function GuidedGetStarted({
       learnMoreLink: "Learn more about our SDKs.",
       docSection: "sdks",
       completed:
-        // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
-        SDKData?.connections.length > 0 || skippedSteps["install-sdk"] || false,
+        (SDKData?.connections?.length || 0) > 0 ||
+        skippedSteps["install-sdk"] ||
+        false,
       render: (
         <InitialSDKConnectionForm
           inline={true}

--- a/packages/front-end/components/Ideas/ImpactModal.tsx
+++ b/packages/front-end/components/Ideas/ImpactModal.tsx
@@ -23,12 +23,9 @@ const ImpactModal: FC<{
     defaultValues: {
       metric: estimate?.metric || metrics[0]?.id || "",
       segment: estimate?.segment || "",
-      // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
-      userAdjustment: idea.estimateParams?.userAdjustment || 100,
-      // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
-      numVariations: idea.estimateParams?.numVariations || 2,
-      // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
-      improvement: idea.estimateParams?.improvement || 10,
+      userAdjustment: idea?.estimateParams?.userAdjustment || 100,
+      numVariations: idea?.estimateParams?.numVariations || 2,
+      improvement: idea?.estimateParams?.improvement || 10,
     },
   });
 
@@ -100,8 +97,7 @@ const ImpactModal: FC<{
           },
         };
 
-        // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
-        await apiCall(`/idea/${idea.id}`, {
+        await apiCall(`/idea/${idea?.id}`, {
           method: "POST",
           body: JSON.stringify(data),
         });

--- a/packages/front-end/components/Ideas/ImpactModal.tsx
+++ b/packages/front-end/components/Ideas/ImpactModal.tsx
@@ -10,7 +10,7 @@ import Field from "@/components/Forms/Field";
 import SelectField from "@/components/Forms/SelectField";
 
 const ImpactModal: FC<{
-  idea?: IdeaInterface;
+  idea: IdeaInterface;
   estimate?: ImpactEstimateInterface;
   close: () => void;
   mutate: () => void;
@@ -23,9 +23,9 @@ const ImpactModal: FC<{
     defaultValues: {
       metric: estimate?.metric || metrics[0]?.id || "",
       segment: estimate?.segment || "",
-      userAdjustment: idea?.estimateParams?.userAdjustment || 100,
-      numVariations: idea?.estimateParams?.numVariations || 2,
-      improvement: idea?.estimateParams?.improvement || 10,
+      userAdjustment: idea.estimateParams.userAdjustment || 100,
+      numVariations: idea.estimateParams.numVariations || 2,
+      improvement: idea.estimateParams.improvement || 10,
     },
   });
 
@@ -58,7 +58,7 @@ const ImpactModal: FC<{
               body: JSON.stringify({
                 metric: value.metric,
                 segment: value.segment || null,
-                ideaId: idea?.id || null,
+                ideaId: idea.id || null,
               }),
             }
           );
@@ -97,7 +97,7 @@ const ImpactModal: FC<{
           },
         };
 
-        await apiCall(`/idea/${idea?.id}`, {
+        await apiCall(`/idea/${idea.id}`, {
           method: "POST",
           body: JSON.stringify(data),
         });

--- a/packages/front-end/components/Report/ConfigureReport.tsx
+++ b/packages/front-end/components/Report/ConfigureReport.tsx
@@ -16,6 +16,7 @@ import { getScopedSettings } from "shared/settings";
 import { MetricInterface } from "back-end/types/metric";
 import { DifferenceType } from "@back-end/types/stats";
 import { getMetricSnapshotSettings } from "shared/experiments";
+import { isDefined } from "shared/util";
 import { useAuth } from "@/services/auth";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import { getExposureQuery } from "@/services/datasources";
@@ -96,7 +97,7 @@ export default function ConfigureReport({
   const denominatorMetrics: MetricInterface[] = useMemo(() => {
     return denominatorMetricIds
       .map((m) => getMetricById(m as string))
-      .filter(Boolean) as MetricInterface[];
+      .filter(isDefined);
   }, [denominatorMetricIds, getMetricById]);
 
   // todo: type this form

--- a/packages/front-end/components/Segments/SegmentForm.tsx
+++ b/packages/front-end/components/Segments/SegmentForm.tsx
@@ -113,8 +113,7 @@ const SegmentForm: FC<{
           }))}
           className="portal-overflow-ellipsis"
         />
-        {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
-        {datasource?.properties.userIds && (
+        {datasource?.properties?.userIds && (
           <SelectField
             label="Identifier Type"
             required

--- a/packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentityJoins/AddEditIdentityJoinModal.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentityJoins/AddEditIdentityJoinModal.tsx
@@ -32,10 +32,8 @@ export const AddEditIdentityJoinModal: FC<AddEditIdentityJoinModalProps> = ({
     dataSource.settings.userIdTypes,
   ]);
   const existingIdentityJoins = useMemo(
-    // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
-    () => dataSource.settings.queries.identityJoins || [],
-    // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
-    [dataSource.settings.queries.identityJoins]
+    () => dataSource.settings.queries?.identityJoins || [],
+    [dataSource.settings.queries?.identityJoins]
   );
 
   const defaultQuery = useMemo(() => {

--- a/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/ExperimentAssignmentQueries.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/ExperimentAssignmentQueries.tsx
@@ -59,10 +59,8 @@ export const ExperimentAssignmentQueries: FC<ExperimentAssignmentQueriesProps> =
   }, [onCancel]);
 
   const experimentExposureQueries = useMemo(
-    // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
-    () => dataSource.settings?.queries.exposure || [],
-    // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
-    [dataSource.settings?.queries.exposure]
+    () => dataSource.settings?.queries?.exposure || [],
+    [dataSource.settings?.queries?.exposure]
   );
 
   const handleAdd = useCallback(() => {

--- a/packages/front-end/components/Settings/MssqlForm.tsx
+++ b/packages/front-end/components/Settings/MssqlForm.tsx
@@ -102,8 +102,7 @@ const MssqlForm: FC<{
             <Toggle
               id="trust-server-cert"
               label="Trust server certificate"
-              // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
-              value={params.options.trustServerCertificate === true}
+              value={params.options?.trustServerCertificate === true}
               setValue={(value) => {
                 const opt = {
                   ...params.options,
@@ -122,8 +121,7 @@ const MssqlForm: FC<{
             <Toggle
               id="encryption"
               label="Enable encryption"
-              // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
-              value={params.options.encrypt === true}
+              value={params.options?.encrypt === true}
               setValue={(value) => {
                 const opt = { ...params.options, encrypt: value };
                 setParams({

--- a/packages/front-end/components/Settings/NewDataSourceForm.tsx
+++ b/packages/front-end/components/Settings/NewDataSourceForm.tsx
@@ -302,13 +302,10 @@ const NewDataSourceForm: FC<{
       source,
       newDatasourceForm: true,
     });
-    // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
-    if (s.types.length === 1) {
-      // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
+    if (s.types?.length === 1) {
       const data = dataSourcesMap.get(s.types[0]);
       setDatasource({
         ...datasource,
-        // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
         type: s.types[0],
         name: `${s.label}`,
         params: data.default,

--- a/packages/front-end/components/Settings/SSOSettings.tsx
+++ b/packages/front-end/components/Settings/SSOSettings.tsx
@@ -1,5 +1,6 @@
 import { SSOConnectionInterface } from "back-end/types/sso-connection";
 import { useState } from "react";
+import { isDefined } from "shared/util";
 import { isCloud } from "@/services/env";
 import Code from "@/components/SyntaxHighlighting/Code";
 
@@ -18,29 +19,26 @@ export default function SSOSettings({ ssoConnection }: Props) {
       <div className="d-flex">
         <div>
           <h3>Enterprise SSO Enabled</h3>
-          {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
-          {ssoConnection?.emailDomains?.length > 0 && (
-            <div>
-              Users can auto-join your account when signing in through your
-              Identity Provider with an email matching{" "}
-              {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
-              <strong>*@{ssoConnection.emailDomains[0]}</strong>
-              {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
-              {ssoConnection.emailDomains.length > 1 && (
-                <div className="small mt-1">
-                  or any of the following email domains:{" "}
-                  {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
-                  {ssoConnection.emailDomains.slice(1).map((d, i) => (
-                    <>
-                      <strong key={i}>{d}</strong>
-                      {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
-                      {i < ssoConnection.emailDomains.length - 2 && ", "}
-                    </>
-                  ))}
-                </div>
-              )}
-            </div>
-          )}
+          {isDefined(ssoConnection.emailDomains) &&
+            ssoConnection.emailDomains.length > 0 && (
+              <div>
+                Users can auto-join your account when signing in through your
+                Identity Provider with an email matching{" "}
+                <strong>*@{ssoConnection.emailDomains[0]}</strong>
+                {ssoConnection.emailDomains.length > 1 && (
+                  <div className="small mt-1">
+                    or any of the following email domains:{" "}
+                    {ssoConnection.emailDomains.slice(1).map((d, i) => (
+                      <>
+                        <strong key={i}>{d}</strong>
+                        {i < (ssoConnection.emailDomains?.length || 0) - 2 &&
+                          ", "}
+                      </>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
           {isCloud() && (
             <div className="mt-2">
               Contact{" "}

--- a/packages/front-end/components/SyntaxHighlighting/Snippets/TargetingAttributeCodeSnippet.tsx
+++ b/packages/front-end/components/SyntaxHighlighting/Snippets/TargetingAttributeCodeSnippet.tsx
@@ -62,8 +62,7 @@ function getExampleAttributes({
         ? ["foo", "bar"].map((v) => sha256(v, secureAttributeSalt))
         : ["foo", "bar"];
     } else if (datatype === "enum") {
-      // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
-      value = enumList.split(",").map((v) => v.trim())[0] ?? null;
+      value = enumList?.split(",").map((v) => v.trim())[0] ?? null;
     }
 
     // @ts-expect-error TS(2538) If you come across this, please fix it!: Type 'undefined' cannot be used as an index type.

--- a/packages/front-end/components/Tabs/TabButton.tsx
+++ b/packages/front-end/components/Tabs/TabButton.tsx
@@ -1,4 +1,5 @@
 import clsx from "clsx";
+import { isNumber } from "lodash";
 import { ReactElement } from "react";
 
 export interface Props {
@@ -53,8 +54,7 @@ export default function TabButton({
       }}
     >
       {display}
-      {/* @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'. */}
-      {(showActiveCount || !active) && (count === 0 || count > 0) ? (
+      {(showActiveCount || !active) && isNumber(count) && count >= 0 ? (
         <span className={`badge badge-gray ml-2`}>{count}</span>
       ) : (
         ""

--- a/packages/front-end/components/Tags/TagsFilter.tsx
+++ b/packages/front-end/components/Tags/TagsFilter.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { isDefined } from "shared/util";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import TagsInput from "./TagsInput";
@@ -101,8 +102,7 @@ export default function TagsFilter({
         prompt={"Filter by tags..."}
         autoFocus={open && autofocus}
         closeMenuOnSelect={true}
-        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type '(TagInterface | null)[]' is not assignable t... Remove this comment to see the full error message
-        tagOptions={availableTags.map((t) => getTagById(t)).filter(Boolean)}
+        tagOptions={availableTags.map((t) => getTagById(t)).filter(isDefined)}
         creatable={false}
       />
     </div>

--- a/packages/front-end/components/Tags/TagsInput.tsx
+++ b/packages/front-end/components/Tags/TagsInput.tsx
@@ -44,6 +44,7 @@ const TagsInput: FC<{
   tagOptions = [...tagOptions];
   value.forEach((value) => {
     if (!tagSet.has(value)) {
+      // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
       tagOptions.push({
         id: value,
         description: "",

--- a/packages/front-end/components/Tags/TagsInput.tsx
+++ b/packages/front-end/components/Tags/TagsInput.tsx
@@ -44,7 +44,6 @@ const TagsInput: FC<{
   tagOptions = [...tagOptions];
   value.forEach((value) => {
     if (!tagSet.has(value)) {
-      // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
       tagOptions.push({
         id: value,
         description: "",

--- a/packages/front-end/services/datasources.ts
+++ b/packages/front-end/services/datasources.ts
@@ -96,8 +96,7 @@ const SnowplowSchema: SchemaInterface = {
     "os",
   ],
   getExperimentSQL: (tablePrefix, userId, options) => {
-    // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
-    const actionName = options.actionName || "Experiment Viewed";
+    const actionName = options?.actionName || "Experiment Viewed";
     const userCol = userId === "user_id" ? "user_id" : "domain_userid";
 
     return `SELECT
@@ -181,8 +180,7 @@ const AmplitudeSchema: SchemaInterface = {
   experimentDimensions: ["country", "device", "os", "paying"],
   getExperimentSQL: (tablePrefix, userId, options) => {
     const userCol = userId === "user_id" ? "user_id" : "amplitude_id";
-    // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
-    const eventType = options.eventType || "Experiment Viewed";
+    const eventType = options?.eventType || "Experiment Viewed";
     const projectId = options?.projectId || "AMPLITUDE_PROJECT_ID";
 
     return `SELECT

--- a/packages/front-end/services/organizations.tsx
+++ b/packages/front-end/services/organizations.tsx
@@ -3,10 +3,10 @@ import { OrganizationInterface } from "back-end/types/organization";
 export function getNumberOfUniqueMembersAndInvites(
   organization: Partial<OrganizationInterface>
 ) {
-  // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
-  const numMembers = new Set(organization.members.map((m) => m.id)).size;
-  // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
-  const numInvites = new Set(organization.invites.map((i) => i.email)).size;
+  const numMembers = new Set((organization.members || []).map((m) => m.id))
+    .size;
+  const numInvites = new Set((organization.invites || []).map((i) => i.email))
+    .size;
 
   return numMembers + numInvites;
 }

--- a/packages/shared/src/util/features.ts
+++ b/packages/shared/src/util/features.ts
@@ -20,7 +20,7 @@ import {
 } from "back-end/types/organization";
 import { ProjectInterface } from "back-end/types/project";
 import { getValidDate } from "../dates";
-import { getMatchingRules, includeExperimentInPayload } from ".";
+import { getMatchingRules, includeExperimentInPayload, isDefined } from ".";
 
 export function getValidation(feature: FeatureInterface) {
   try {
@@ -226,7 +226,7 @@ export function isFeatureStale({
 
       const linkedExperiments = (feature?.linkedExperiments ?? [])
         .map((id) => experimentMap.get(id))
-        .filter(Boolean) as ExperimentInterfaceStringDates[];
+        .filter(isDefined);
 
       const twoWeeksAgo = subWeeks(new Date(), 2);
       const dateUpdated = getValidDate(feature.dateUpdated);

--- a/packages/shared/src/util/index.ts
+++ b/packages/shared/src/util/index.ts
@@ -220,3 +220,8 @@ export function stringToBoolean(
     return false;
   return defaultValue;
 }
+
+// Typeguard to help with type narrowing for built-ins such as Array.prototype.filter
+export function isDefined<T>(x: T | undefined | null): x is T {
+  return x !== undefined && x !== null;
+}


### PR DESCRIPTION
### Features and Changes

Found an easy fix for many instances of TS(2532) across the codebase while working on a separate bug. Added a new shared typeguard `isDefined` which will help methods like `Array.prototype.filter` to correctly infer the type of the result.
Searched the codebase for both instances of 2532 and `filter(Boolean)` and updated the usage manually to reduce the likelihood of unintentional bugs. For cases where it wasn't obviously an easy fix, I left the original ts-expect-error and functionality in place.

### Dependencies

None?

### Testing

There's too many files to do manual testing, so instead I'm focusing on thoroughly reading the PR & letting the test suite check for any large-scale issues