### PR TITLE
Split out prettier, add prettierrc.

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "trailingComma": "none",
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": false
+}

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "eslint-import-resolver-typescript": "^3.5.1",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-no-async-foreach": "^0.1.1",
-    "eslint-plugin-prettier": "^3.1.3",
     "eslint-plugin-react": "^7.30.1",
     "growthbook": "^0.2.1",
     "husky": "^7.0.0",
@@ -54,8 +53,8 @@
     "typescript": "5.3.3"
   },
   "lint-staged": {
-    "./**/*.{json,css,scss,md,mdx}": [
-      "prettier --write"
+    "./**/*.{json,css,scss,md,mdx,ts,tsx}": [
+      "yarn prettier --write"
     ],
     "./**/*.{ts,tsx}": [
       "yarn eslint  --fix --max-warnings 0 --cache --cache-strategy content"


### PR DESCRIPTION
Following the debacle around upgrading TS and prettier, it became pretty clear that we should be able to upgrade our formatting toolchain or our linting toolchain without impacting each other.

This PR splits out formatting from linting. This is inline with the most recent recommendations from eslint: https://eslint.org/blog/2023/10/deprecating-formatting-rules/

A `.prettierc` file is added to maintain consistency accros editors and formatting setups.

Some changes will happen in the existing code, mostly around max line width. This might be related to how `prettier` makes line breaking decisions vs. eslint. See: https://prettier.io/docs/en/options.html#print-width