### PR TITLE
Create new admin putOrg endpoint

### DIFF
--- a/packages/back-end/src/app.ts
+++ b/packages/back-end/src/app.ts
@@ -683,6 +683,7 @@ app.use("/teams", teamRouter);
 
 // Admin
 app.get("/admin/organizations", adminController.getOrganizations);
+app.put("/admin/organization", adminController.putOrganization);
 
 // License
 app.get("/license", licenseController.getLicenseData);

--- a/packages/back-end/src/controllers/admin.ts
+++ b/packages/back-end/src/controllers/admin.ts
@@ -1,6 +1,13 @@
 import { Response } from "express";
+import { OrganizationInterface } from "@back-end/types/organization";
 import { AuthRequest } from "../types/AuthRequest";
-import { findAllOrganizations } from "../models/OrganizationModel";
+import {
+  findAllOrganizations,
+  updateOrganization,
+} from "../models/OrganizationModel";
+import { getOrganizationById } from "../services/organizations";
+import { setLicenseKey } from "../routers/organizations/organizations.controller";
+import { auditDetailsUpdate } from "../services/audit";
 
 export async function getOrganizations(
   req: AuthRequest<never, never, { page?: string; search?: string }>,
@@ -9,7 +16,7 @@ export async function getOrganizations(
   if (!req.superAdmin) {
     return res.status(403).json({
       status: 403,
-      message: "Only admins can get all organizations",
+      message: "Only superAdmins can get all organizations",
     });
   }
 
@@ -24,5 +31,63 @@ export async function getOrganizations(
     status: 200,
     organizations,
     total,
+  });
+}
+
+export async function putOrganization(
+  req: AuthRequest<{
+    orgId: string;
+    name: string;
+    externalId: string;
+    licenseKey: string;
+  }>,
+  res: Response
+) {
+  if (!req.superAdmin) {
+    return res.status(403).json({
+      status: 403,
+      message: "Only superAdmins can update organizations via admin page",
+    });
+  }
+
+  const { orgId, name, externalId, licenseKey } = req.body;
+  const updates: Partial<OrganizationInterface> = {};
+  const orig: Partial<OrganizationInterface> = {};
+  const org = await getOrganizationById(orgId);
+
+  if (!org) {
+    return res.status(404).json({
+      status: 404,
+      message: "Organization not found",
+    });
+  }
+
+  if (name) {
+    updates.name = name;
+    orig.name = org.name;
+  }
+  if (externalId !== undefined) {
+    updates.externalId = externalId;
+    orig.externalId = org.externalId;
+  }
+  if (licenseKey && licenseKey.trim() !== org.licenseKey) {
+    updates.licenseKey = licenseKey.trim();
+    orig.licenseKey = org.licenseKey;
+    await setLicenseKey(org, updates.licenseKey);
+  }
+
+  await updateOrganization(org.id, updates);
+
+  await req.audit({
+    event: "organization.update",
+    entity: {
+      object: "organization",
+      id: org.id,
+    },
+    details: auditDetailsUpdate(orig, updates),
+  });
+
+  return res.status(200).json({
+    status: 200,
   });
 }

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -2097,7 +2097,10 @@ export async function putAdminResetUserPassword(
   });
 }
 
-async function setLicenseKey(org: OrganizationInterface, licenseKey: string) {
+export async function setLicenseKey(
+  org: OrganizationInterface,
+  licenseKey: string
+) {
   if (!IS_CLOUD && IS_MULTI_ORG) {
     throw new Error(
       "You must use the LICENSE_KEY environmental variable on multi org sites."

--- a/packages/front-end/components/Admin/EditOrganization.tsx
+++ b/packages/front-end/components/Admin/EditOrganization.tsx
@@ -28,12 +28,10 @@ const EditOrganization: FC<{
     await apiCall<{
       status: number;
       message?: string;
-      orgId?: string;
-      licenseKey?: string;
-    }>("/organization", {
+    }>("/admin/organization", {
       method: "PUT",
-      headers: { "X-Organization": id },
       body: JSON.stringify({
+        orgId: id,
         name,
         externalId,
         licenseKey,


### PR DESCRIPTION
### Features and Changes

In https://github.com/growthbook/growthbook/pull/2452 we added ability for editing licenseKeys on the admin page.  However it only worked if the superAdmin was also a member of the org.  It is also possible that superAdmin's had in the past been able to edit any org, but we got rid of that to make sure superAdmins generally have read only access.  However on the /admin page we want them to have certain limited abilities to edit.  Hence this PR adds a new admin specific PutOrganization method that only allows putting the attributes we want them to be able to edit.

### Testing
For the following tests use a user that has a "superAdmin: true" property set, but which is not a member of the organization that is being edited:

#### Testing Cloud
`yarn test`
in back-end and front-end/.env.local
```
IS_CLOUD=true
IS_MULTI_ORG=true
SSO_CONFIG=valid SSO config
```
restart the server
Go to settings->general - see no input to edit the license.
Go to settings->admin - click org and the pencil icon
Edit the license with a bad license
See invalid licenseKey message
Enter in a valid licenseKey
See it update successfully.
Refresh the page, and see the new license show up.

#### Testing Self-Hosted Multi-Org (license key should only set by env var)
in back-end and front-end/.env.local
```
IS_CLOUD=false
IS_MULTI_ORG=true
```
restart server
Go to Settings->admin page
Click pencil icon on an organization
See the externalId, but not the licenseKey field.
Go to Settings->General
See no license section at all.

#### Testing normal Self-Hosted
in back-end and front-end/.env.local
```
IS_CLOUD=false
IS_MULTI_ORG=false
```
restart server
Go to Settings->General
Click pencil icon by license.
Enter "license_bad"
See "Invalid license key" message upon submit
Put in a valid license key.
See it succeed.

