### PR TITLE
Add concurrency limit to QueryRunner and DataSourceSettings

### DIFF
--- a/packages/back-end/src/models/QueryModel.ts
+++ b/packages/back-end/src/models/QueryModel.ts
@@ -75,6 +75,17 @@ export async function getQueriesByDatasource(
   return docs.map((doc) => toInterface(doc));
 }
 
+export async function countRunningQueries(
+  organization: string,
+  datasource: string
+) {
+  return await QueryModel.find({
+    organization,
+    datasource,
+    status: "running",
+  }).count();
+}
+
 export async function updateQuery(
   query: QueryInterface,
   changes: Partial<QueryInterface>

--- a/packages/back-end/src/queryRunners/ExperimentResultsQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentResultsQueryRunner.ts
@@ -274,7 +274,7 @@ export const startExperimentResultQueries = async (
     org
   );
 
-  const singlePromises = singles.map(async (m) => {
+  for (const m of singles) {
     const denominatorMetrics: MetricInterface[] = [];
     if (!isFactMetric(m) && m.denominator) {
       denominatorMetrics.push(
@@ -308,9 +308,9 @@ export const startExperimentResultQueries = async (
         queryType: "experimentMetric",
       })
     );
-  });
+  }
 
-  const groupPromises = groups.map(async (m, i) => {
+  for (const [i, m] of groups.entries()) {
     const queryParams: ExperimentFactMetricsQueryParams = {
       activationMetric,
       dimensions: dimensionObj ? [dimensionObj] : [],
@@ -343,9 +343,7 @@ export const startExperimentResultQueries = async (
         queryType: "experimentMultiMetric",
       })
     );
-  });
-
-  await Promise.all([...singlePromises, ...groupPromises]);
+  }
 
   let trafficQuery: QueryPointer | null = null;
   if (runTrafficQuery) {

--- a/packages/back-end/src/queryRunners/QueryRunner.ts
+++ b/packages/back-end/src/queryRunners/QueryRunner.ts
@@ -7,6 +7,7 @@ import {
   QueryType,
 } from "../../types/query";
 import {
+  countRunningQueries,
   createNewQuery,
   createNewQueryFromCached,
   getQueriesByIds,
@@ -60,6 +61,10 @@ export type StartQueryParams<Rows, ProcessedRows> = {
 };
 
 const FINISH_EVENT = "finish";
+// How long to wait before retrying a query that was queued due to concurrency limit.
+// Wait is doubled on subsequent retries, capped at the maximum
+const INITIAL_CONCURRENCY_TIMEOUT = 250;
+const MAX_CONCURRENCY_TIMEOUT = 4000;
 
 export async function getQueryMap(
   organization: string,
@@ -104,6 +109,7 @@ export abstract class QueryRunner<
     };
   } = {};
   private useCache: boolean;
+  private queuedQueryTimers: Record<string, NodeJS.Timeout> = {};
 
   public constructor(
     context: ReqContext | ApiReqContext,
@@ -261,76 +267,88 @@ export abstract class QueryRunner<
         this.model.id
       } runner that are ready: ${queuedQueries.map((q) => q.id)}`
     );
-    await Promise.all(
-      queuedQueries.map(async (query) => {
-        // check if all dependencies are finished
-        // assumes all dependencies are within the model; if any are not, query will hang
-        // in queued state
+    for (const query of queuedQueries) {
+      // If the query already has a timeout set, we don't need to queue it up again.
+      if (this.queuedQueryTimers[query.id]) {
+        return;
+      }
+      // check if all dependencies are finished
+      // assumes all dependencies are within the model; if any are not, query will hang
+      // in queued state
 
-        const failedDependencies: QueryPointer[] = [];
-        const succeededDependencies: QueryPointer[] = [];
-        const pendingDependencies: QueryPointer[] = [];
+      const failedDependencies: QueryPointer[] = [];
+      const succeededDependencies: QueryPointer[] = [];
+      const pendingDependencies: QueryPointer[] = [];
 
-        const dependencyIds: string[] = query.dependencies ?? [];
-        dependencyIds.forEach((dependencyId) => {
-          const dependencyQuery = this.model.queries.find(
-            (q) => q.query == dependencyId
-          );
-          if (dependencyQuery === undefined) {
-            throw new Error(`Dependency ${dependencyId} not found in model`);
-          } else if (dependencyQuery.status === "succeeded") {
-            succeededDependencies.push(dependencyQuery);
-          } else if (dependencyQuery.status === "failed") {
-            failedDependencies.push(dependencyQuery);
-          } else {
-            pendingDependencies.push(dependencyQuery);
-          }
+      const dependencyIds: string[] = query.dependencies ?? [];
+      dependencyIds.forEach((dependencyId) => {
+        const dependencyQuery = this.model.queries.find(
+          (q) => q.query == dependencyId
+        );
+        if (dependencyQuery === undefined) {
+          throw new Error(`Dependency ${dependencyId} not found in model`);
+        } else if (dependencyQuery.status === "succeeded") {
+          succeededDependencies.push(dependencyQuery);
+        } else if (dependencyQuery.status === "failed") {
+          failedDependencies.push(dependencyQuery);
+        } else {
+          pendingDependencies.push(dependencyQuery);
+        }
+      });
+
+      if (failedDependencies.length) {
+        logger.debug(`${query.id}: Dependency failed...`);
+        await updateQuery(query, {
+          finishedAt: new Date(),
+          status: "failed",
+          error: `Dependencies failed: ${failedDependencies.map(
+            (q) => q.query
+          )}`,
         });
+        this.onQueryFinish();
+        return;
+      }
+      if (pendingDependencies.length) {
+        logger.debug(`${query.id}: Dependencies pending...`);
+        return;
+      }
 
-        if (failedDependencies.length) {
-          logger.debug(`${query.id}: Dependency failed...`);
+      // if `runAtEnd = true` run if all queries that are not marked
+      // `runAtEnd` are finished
+      if (query.runAtEnd) {
+        const pendingQueries = this.model.queries.filter(
+          (q) =>
+            !queryMap.get(q.name)?.runAtEnd &&
+            (q.status === "queued" || q.status === "running")
+        );
+        if (pendingQueries.length) {
+          logger.debug(
+            `${query.id}: "Run at end query" waiting for other queries to finish...`
+          );
+          return;
+        }
+      }
+
+      if (succeededDependencies.length === dependencyIds.length) {
+        logger.debug(`${query.id}: Dependencies completed, running...`);
+        const runCallbacks = this.runCallbacks[query.id];
+        if (runCallbacks === undefined) {
+          logger.debug(`${query.id}: Run callbacks not found..`);
           await updateQuery(query, {
             finishedAt: new Date(),
             status: "failed",
-            error: `Dependencies failed: ${failedDependencies.map(
-              (q) => q.query
-            )}`,
+            error: `Run callbacks not found`,
           });
           this.onQueryFinish();
-          return;
-        }
-        if (pendingDependencies.length) {
-          logger.debug(`${query.id}: Dependencies pending...`);
-          return;
-        }
-
-        // if `runAtEnd = true` run if all queries that are not marked
-        // `runAtEnd` are finished
-        if (query.runAtEnd) {
-          const pendingQueries = this.model.queries.filter(
-            (q) =>
-              !queryMap.get(q.name)?.runAtEnd &&
-              (q.status === "queued" || q.status === "running")
-          );
-          if (pendingQueries.length) {
-            logger.debug(
-              `${query.id}: "Run at end query" waiting for other queries to finish...`
-            );
-            return;
-          }
-        }
-
-        if (succeededDependencies.length === dependencyIds.length) {
-          logger.debug(`${query.id}: Dependencies completed, running...`);
-          const runCallbacks = this.runCallbacks[query.id];
-          if (runCallbacks === undefined) {
-            logger.debug(`${query.id}: Run callbacks not found..`);
-            await updateQuery(query, {
-              finishedAt: new Date(),
-              status: "failed",
-              error: `Run callbacks not found`,
-            });
-            this.onQueryFinish();
+        } else {
+          if (await this.concurrencyLimitReached()) {
+            this.queuedQueryTimers[query.id] = setTimeout(() => {
+              this.executeQueryWhenReady(
+                query,
+                runCallbacks.run,
+                runCallbacks.process
+              );
+            }, INITIAL_CONCURRENCY_TIMEOUT);
           } else {
             await this.executeQuery(
               query,
@@ -339,8 +357,8 @@ export abstract class QueryRunner<
             );
           }
         }
-      })
-    );
+      }
+    }
   }
 
   public async refreshQueryStatuses(): Promise<QueryMap> {
@@ -459,6 +477,35 @@ export abstract class QueryRunner<
 
       this.setStatus("finished", "Queries cancelled by user");
     }
+  }
+
+  public async executeQueryWhenReady<
+    Rows extends RowsType,
+    ProcessedRows extends ProcessedRowsType
+  >(
+    doc: QueryInterface,
+    run: (
+      query: string,
+      setExternalId: ExternalIdCallback
+    ) => Promise<QueryResponse<Rows>>,
+    process: (rows: Rows) => ProcessedRows,
+    currentTimeout: number = INITIAL_CONCURRENCY_TIMEOUT
+  ): Promise<void> {
+    // If too many queries are running against the datastore, use capped exponential backoff to wait until they've finished
+    const concurrencyLimitReached = await this.concurrencyLimitReached();
+    if (concurrencyLimitReached) {
+      logger.debug(
+        `${doc.id}: Query concurrency limit reached, waiting ${currentTimeout} before retrying`
+      );
+      this.runCallbacks[doc.id] = { run, process };
+      const nextTimeout = Math.min(currentTimeout * 2, MAX_CONCURRENCY_TIMEOUT);
+      this.queuedQueryTimers[doc.id] = setTimeout(() => {
+        this.executeQueryWhenReady(doc, run, process, nextTimeout);
+      }, currentTimeout);
+      return;
+    }
+    delete this.queuedQueryTimers[doc.id];
+    return this.executeQuery(doc, run, process);
   }
 
   public async executeQuery<
@@ -607,7 +654,10 @@ export abstract class QueryRunner<
 
     // Create a new query in mongo
     logger.debug("Creating query for: " + name);
-    const readyToRun = dependencies.length === 0 && !runAtEnd;
+    const concurrencyLimitReached = await this.concurrencyLimitReached();
+    const dependenciesComplete = dependencies.length === 0;
+    const readyToRun =
+      dependenciesComplete && !runAtEnd && !concurrencyLimitReached;
     const doc = await createNewQuery({
       query,
       queryType,
@@ -622,6 +672,10 @@ export abstract class QueryRunner<
     logger.debug("Created new query " + doc.id + " for " + name);
     if (readyToRun) {
       this.executeQuery(doc, run, process);
+    } else if (dependenciesComplete && !runAtEnd) {
+      this.queuedQueryTimers[doc.id] = setTimeout(() => {
+        this.executeQueryWhenReady(doc, run, process);
+      }, INITIAL_CONCURRENCY_TIMEOUT);
     } else {
       // save callback methods for execution later
       this.runCallbacks[doc.id] = { run, process };
@@ -632,6 +686,22 @@ export abstract class QueryRunner<
       query: doc.id,
       status: doc.status,
     };
+  }
+
+  // Limit number of currently running queries
+  private async concurrencyLimitReached(): Promise<boolean> {
+    if (this.integration.datasource.settings.maxConcurrentQueries) {
+      const numRunningQueries = await countRunningQueries(
+        this.integration.context.org.id,
+        this.integration.datasource.id
+      );
+      return (
+        numRunningQueries >=
+        this.integration.datasource.settings.maxConcurrentQueries
+      );
+    } else {
+      return new Promise<boolean>((resolve) => resolve(false));
+    }
   }
 
   private getOverallQueryStatus(): QueryStatus {

--- a/packages/back-end/types/datasource.d.ts
+++ b/packages/back-end/types/datasource.d.ts
@@ -220,6 +220,7 @@ export type DataSourceSettings = {
     userIdColumn?: string;
   };
   pipelineSettings?: DataSourcePipelineSettings;
+  maxConcurrentQueries?: number;
 };
 
 interface DataSourceBase {

--- a/packages/front-end/components/Queries/AsyncQueriesModal.tsx
+++ b/packages/front-end/components/Queries/AsyncQueriesModal.tsx
@@ -20,6 +20,7 @@ const AsyncQueriesModal: FC<{
 
   const [showStats, setShowStats] = useState(false);
   const hasStats = data?.queries?.some((q) => q.statistics !== undefined);
+  const datasourceId = data?.queries?.find((q) => q.datasource)?.datasource;
 
   const contents = (
     <>
@@ -37,6 +38,15 @@ const AsyncQueriesModal: FC<{
           running them again.
         </div>
       )}
+      {data &&
+        data.queries.filter((q) => q?.status === "queued").length > 0 &&
+        datasourceId && (
+          <div className="alert alert-warning">
+            One or more of these queries is waiting to run. Click{" "}
+            <a href={`/datasources/queries/${datasourceId}`}>here</a> to see the
+            status of all your queries
+          </div>
+        )}
       {hasStats ? (
         <div className="mb-4">
           <a

--- a/packages/front-end/components/Queries/ExpandableQuery.tsx
+++ b/packages/front-end/components/Queries/ExpandableQuery.tsx
@@ -162,6 +162,15 @@ const ExpandableQuery: FC<{
                   )}
                 </strong>
               </div>
+              <div className="col-auto mb-2">
+                <em>Time queued</em>:{" "}
+                <strong>
+                  {formatDistanceStrict(
+                    getValidDate(query.createdAt),
+                    getValidDate(query.startedAt)
+                  )}
+                </strong>
+              </div>
             </div>
           )}
         </div>

--- a/packages/front-end/components/Settings/ConnectionSettings.tsx
+++ b/packages/front-end/components/Settings/ConnectionSettings.tsx
@@ -11,6 +11,7 @@ import PrestoForm from "./PrestoForm";
 import SnowflakeForm from "./SnowflakeForm";
 import MssqlForm from "./MssqlForm";
 import DatabricksForm from "./DatabricksForm";
+import SharedConnectionSettings from "./SharedConnectionSettings";
 
 export interface Props {
   datasource: Partial<DataSourceInterfaceWithParams>;
@@ -27,12 +28,20 @@ export default function ConnectionSettings({
   setDirty,
   hasError,
 }: Props) {
-  const setParams = (params: { [key: string]: string }) => {
+  // Set the new params (specific per-datasource) and optionally settings (shared between datasources)
+  const setParams = (
+    params: { [key: string]: string },
+    settings: { [key: string]: string } = {}
+  ) => {
     const newVal = {
       ...datasource,
       params: {
         ...datasource.params,
         ...params,
+      },
+      settings: {
+        ...datasource.settings,
+        ...settings,
       },
     };
 
@@ -42,6 +51,9 @@ export default function ConnectionSettings({
   const onParamChange: ChangeEventHandler<HTMLInputElement> = (e) => {
     setParams({ [e.target.name]: e.target.value });
   };
+  const onSettingChange: ChangeEventHandler<HTMLInputElement> = (e) => {
+    setParams({}, { [e.target.name]: e.target.value });
+  };
   const onManualParamChange = (name, value) => {
     setParams({ [name]: value });
   };
@@ -49,9 +61,10 @@ export default function ConnectionSettings({
   if (!datasource.type) return null;
 
   let invalidType: never;
+  let datasourceComponent = <></>;
   switch (datasource.type) {
     case "athena":
-      return (
+      datasourceComponent = (
         <AthenaForm
           existing={existing}
           onParamChange={onParamChange}
@@ -59,9 +72,9 @@ export default function ConnectionSettings({
           setParams={setParams}
         />
       );
-
+      break;
     case "presto":
-      return (
+      datasourceComponent = (
         <PrestoForm
           existing={existing}
           onParamChange={onParamChange}
@@ -70,9 +83,9 @@ export default function ConnectionSettings({
           params={datasource?.params || {}}
         />
       );
-
+      break;
     case "databricks":
-      return (
+      datasourceComponent = (
         <DatabricksForm
           existing={existing}
           onParamChange={onParamChange}
@@ -80,9 +93,9 @@ export default function ConnectionSettings({
           params={datasource?.params || {}}
         />
       );
-
+      break;
     case "redshift":
-      return (
+      datasourceComponent = (
         <PostgresForm
           existing={existing}
           onParamChange={onParamChange}
@@ -90,9 +103,9 @@ export default function ConnectionSettings({
           params={datasource?.params || {}}
         />
       );
-
+      break;
     case "postgres":
-      return (
+      datasourceComponent = (
         <PostgresForm
           existing={existing}
           onParamChange={onParamChange}
@@ -100,9 +113,9 @@ export default function ConnectionSettings({
           params={datasource?.params || {}}
         />
       );
-
+      break;
     case "vertica":
-      return (
+      datasourceComponent = (
         <PostgresForm
           existing={existing}
           onParamChange={onParamChange}
@@ -110,9 +123,9 @@ export default function ConnectionSettings({
           params={datasource?.params || {}}
         />
       );
-
+      break;
     case "mysql":
-      return (
+      datasourceComponent = (
         <MysqlForm
           existing={existing}
           onParamChange={onParamChange}
@@ -120,9 +133,9 @@ export default function ConnectionSettings({
           params={datasource?.params || {}}
         />
       );
-
+      break;
     case "mssql":
-      return (
+      datasourceComponent = (
         <MssqlForm
           existing={existing}
           onParamChange={onParamChange}
@@ -130,9 +143,9 @@ export default function ConnectionSettings({
           params={datasource?.params || {}}
         />
       );
-
+      break;
     case "google_analytics":
-      return (
+      datasourceComponent = (
         <GoogleAnalyticsForm
           existing={existing}
           onParamChange={onParamChange}
@@ -142,18 +155,18 @@ export default function ConnectionSettings({
           projects={datasource?.projects || []}
         />
       );
-
+      break;
     case "snowflake":
-      return (
+      datasourceComponent = (
         <SnowflakeForm
           existing={existing}
           onParamChange={onParamChange}
           params={datasource?.params || {}}
         />
       );
-
+      break;
     case "clickhouse":
-      return (
+      datasourceComponent = (
         <ClickHouseForm
           existing={existing}
           onParamChange={onParamChange}
@@ -161,9 +174,9 @@ export default function ConnectionSettings({
           params={datasource?.params || {}}
         />
       );
-
+      break;
     case "bigquery":
-      return (
+      datasourceComponent = (
         <BigQueryForm
           existing={existing}
           setParams={setParams}
@@ -171,9 +184,9 @@ export default function ConnectionSettings({
           onParamChange={onParamChange}
         />
       );
-
+      break;
     case "mixpanel":
-      return (
+      datasourceComponent = (
         <MixpanelForm
           existing={existing}
           onParamChange={onParamChange}
@@ -181,9 +194,18 @@ export default function ConnectionSettings({
           params={datasource?.params || {}}
         />
       );
-
+      break;
     default:
       invalidType = datasource.type;
       throw `Invalid type: ${invalidType}`;
   }
+  return (
+    <>
+      {datasourceComponent}
+      <SharedConnectionSettings
+        onSettingChange={onSettingChange}
+        settings={datasource?.settings || {}}
+      />
+    </>
+  );
 }

--- a/packages/front-end/components/Settings/SharedConnectionSettings.tsx
+++ b/packages/front-end/components/Settings/SharedConnectionSettings.tsx
@@ -1,0 +1,44 @@
+import { DataSourceSettings } from "@back-end/types/datasource";
+import { ChangeEventHandler } from "react";
+import Tooltip from "@/components/Tooltip/Tooltip";
+import Field from "@/components/Forms/Field";
+
+export interface Props {
+  settings: Partial<DataSourceSettings>;
+  onSettingChange: ChangeEventHandler<HTMLInputElement | HTMLSelectElement>;
+}
+
+export default function SharedConnectionSettings({
+  settings,
+  onSettingChange,
+}: Props) {
+  return (
+    <>
+      <div className="row">
+        <div className="col-md-12">
+          <Field
+            name="maxConcurrentQueries"
+            type="number"
+            label={
+              <>
+                Maximum Concurrent Queries (Optional){" "}
+                <Tooltip
+                  body={
+                    "When executing queries against this datasource, if this many queries are already" +
+                    " running then new connections will wait for existing connections to finish. This" +
+                    " limit is not exact, e.g. if set to 100 it still might allow slightly over 100" +
+                    " queries to run simultaneously if many are initiated by a single experiment update"
+                  }
+                />
+              </>
+            }
+            helpText="A value of 0 or an empty field will result in no limit on the number of queries"
+            value={settings.maxConcurrentQueries || ""}
+            onChange={onSettingChange}
+            min={0}
+          />
+        </div>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
### Features and Changes

Creates a new field in `DataSourceSettings`: `maxConcurrentQueries`. This field is respected by `QueryRunner`'s  `startQuery` and `startReadyQueries` entrypoints, which now check the number of running queries before committing to starting a new query.

Added a helper to `QueryModel` to grab the count of running queries & a new section to the `ConnectionSettings` modal to allow for editing of this setting (and create a place for other future shared settings to live).

### Testing

1. Set up at least one experiment which makes multiple queries
2. Edit the settings for the datastore and provide a concurrency limit (probably 1)
3. Open the datastore queries list page in a new tab
4. Force update the results for the experiment(s) and check the queries list page to see that some have been queued.
  a. (If the delay isn't noticeable, you can change the `INITIAL_CONCURRENCY_TIMEOUT` to 8000.)

### Screenshots
<img src="https://github.com/growthbook/growthbook/assets/10674248/82f0ac7e-c2f0-479a-8971-e5cf0e7eca70" height="600px">

![image](https://github.com/growthbook/growthbook/assets/10674248/7247ca7c-0af4-4354-b8b7-6acc2f9f0bae)

![image](https://github.com/growthbook/growthbook/assets/10674248/63323612-0171-4e96-b14e-d80617858a0c)

Here's a screen recording of the UX with a concurrency limit of 1

![queryconcurrency_ux](https://github.com/growthbook/growthbook/assets/10674248/016c777e-25f1-4049-a208-ae61eb6a8cf0)


And here's a corresponding recording of what's happening on the backend with a few extra `console.log`s added for clarity.
![queryconcurrency_backend](https://github.com/growthbook/growthbook/assets/10674248/f2b9a733-128b-4fc0-939f-af8c77297319)
