### PR TITLE
Update section name for Data Sources

### DIFF
--- a/docs/docs/warehouses/bigquery.mdx
+++ b/docs/docs/warehouses/bigquery.mdx
@@ -77,7 +77,7 @@ This will cause the JSON key to be downloaded to your computer.
 
 ## 2. Connect GrowthBook to BigQuery
 
-From the Analysis → Data Source page, click on add new data source and select the event tracker you're using. If your event tracker is not listed, or you're using something custom, click on the "Custom" button at the bottom.
+From the Metrics and Data → Data Source page, click on add new data source and select the event tracker you're using. If your event tracker is not listed, or you're using something custom, click on the "Custom" button at the bottom.
 
 Selecting an event tracker here will pre-populate the experiment exposure query which is need to determine which user saw which experiment
 variation. Depending on your needs, you may still need to adjust these queries to match your specific schema.


### PR DESCRIPTION
It is "Metrics and Data" now

![image](https://github.com/growthbook/growthbook/assets/237722/0d25720a-aafe-4fa0-a763-4b92822d5d57)
