### PR TITLE
Grant first user on a new installation super admin access

### DIFF
--- a/packages/back-end/src/controllers/auth.ts
+++ b/packages/back-end/src/controllers/auth.ts
@@ -225,7 +225,7 @@ export async function postRegister(
   }
 
   // Create new account
-  const user = await createUser(name, email, password);
+  const user = await createUser({ name, email, password });
   sendLocalSuccessResponse(req, res, user);
 }
 
@@ -276,7 +276,9 @@ export async function postFirstTimeRegister(
     });
   }
 
-  const user = await createUser(name, email, password);
+  // grant the first user on a new installation super admin access
+  const user = await createUser({ name, email, password, superAdmin: true });
+
   await createOrganization({
     email,
     userId: user.id,

--- a/packages/back-end/src/controllers/auth.ts
+++ b/packages/back-end/src/controllers/auth.ts
@@ -13,7 +13,6 @@ import {
   deleteAuthCookies,
   getAuthConnection,
   isNewInstallation,
-  markInstalled,
   validatePasswordFormat,
 } from "../services/auth";
 import {
@@ -284,7 +283,6 @@ export async function postFirstTimeRegister(
     userId: user.id,
     name: companyname,
   });
-  markInstalled();
 
   sendLocalSuccessResponse(req, res, user);
 }

--- a/packages/back-end/src/routers/users/users.controller.ts
+++ b/packages/back-end/src/routers/users/users.controller.ts
@@ -29,7 +29,12 @@ function isValidWatchEntityType(type: string): boolean {
 export async function getUser(req: AuthRequest, res: Response) {
   // If using SSO, auto-create users in Mongo who we don't recognize yet
   if (!req.userId && usingOpenId()) {
-    const user = await createUser(req.name || "", req.email, "", req.verified);
+    const user = await createUser({
+      name: req.name || "",
+      email: req.email,
+      password: "",
+      verified: req.verified,
+    });
     req.userId = user.id;
   }
 

--- a/packages/back-end/src/scim/users/createUser.ts
+++ b/packages/back-end/src/scim/users/createUser.ts
@@ -72,7 +72,7 @@ export async function createUser(
       let newUser = await getUserByEmail(userName);
 
       if (!newUser) {
-        newUser = await createNewUser(displayName, userName);
+        newUser = await createNewUser({ name: displayName, email: userName });
       }
 
       await addMemberToOrg({

--- a/packages/back-end/src/services/auth/index.ts
+++ b/packages/back-end/src/services/auth/index.ts
@@ -256,7 +256,7 @@ export function validatePasswordFormat(password?: string): string {
   return password;
 }
 
-async function checkNewInstallation() {
+export async function isNewInstallation() {
   const doc = await hasOrganization();
   if (doc) {
     return false;
@@ -268,17 +268,6 @@ async function checkNewInstallation() {
   }
 
   return true;
-}
-
-let newInstallationPromise: Promise<boolean>;
-export function isNewInstallation() {
-  if (!newInstallationPromise) {
-    newInstallationPromise = checkNewInstallation();
-  }
-  return newInstallationPromise;
-}
-export function markInstalled() {
-  newInstallationPromise = new Promise((resolve) => resolve(false));
 }
 
 export function usingOpenId() {

--- a/packages/back-end/src/services/organizations.ts
+++ b/packages/back-end/src/services/organizations.ts
@@ -63,7 +63,6 @@ import {
 import { getAllExperiments } from "../models/ExperimentModel";
 import { LegacyExperimentPhase } from "../../types/experiment";
 import { addTags } from "../models/TagModel";
-import { markInstalled } from "./auth";
 import {
   encryptParams,
   getSourceIntegrationObject,
@@ -941,7 +940,6 @@ export async function addMemberFromSSOConnection(
         userId: req.userId,
         name: "My Organization",
       });
-      markInstalled();
       return organization;
     }
 

--- a/packages/back-end/src/services/users.ts
+++ b/packages/back-end/src/services/users.ts
@@ -109,12 +109,19 @@ export async function updatePassword(userId: string, password: string) {
   );
 }
 
-export async function createUser(
-  name: string,
-  email: string,
-  password?: string,
-  verified: boolean = false
-) {
+export async function createUser({
+  name,
+  email,
+  password,
+  verified = false,
+  superAdmin = false,
+}: {
+  name: string;
+  email: string;
+  password?: string;
+  verified?: boolean;
+  superAdmin?: boolean;
+}) {
   let passwordHash = "";
 
   if (!usingOpenId()) {
@@ -128,6 +135,7 @@ export async function createUser(
     passwordHash,
     id: uniqid("u_"),
     verified,
+    superAdmin,
   });
 }
 


### PR DESCRIPTION
RE: [Thread on a previous PR](https://github.com/growthbook/growthbook/pull/2182#discussion_r1595506259), we want to grant the first user to be created on a new installation with super admin access.

Changes
- Updated `createUser` method to take single object argument
  - Add optional `superAdmin` property, defaults to `false`
- We only grant super admin access in the `/auth/firsttime` endpoint
	- Endpoint used in situations where a 'new installation' is asserted (i.e., no existing orgs, no existing users)

Questions
- Briefly had similar changes in the `/auth/signup` endpoint but reverted since it seemed like an impossible scenario. Could use confirmation on this and any add'l insights on what could have been missed.