### PR TITLE
Added metric description to metric selector for experiments

### DIFF
--- a/packages/front-end/components/Experiment/MetricsSelector.tsx
+++ b/packages/front-end/components/Experiment/MetricsSelector.tsx
@@ -12,6 +12,7 @@ import ClickToCopy from "@/components/Settings/ClickToCopy";
 type MetricOption = {
   id: string;
   name: string;
+  description: string;
   datasource: string;
   tags: string[];
   projects: string[];
@@ -105,6 +106,7 @@ const MetricsSelector: FC<{
     ...metrics.map((m) => ({
       id: m.id,
       name: m.name,
+      description: m.description || "",
       datasource: m.datasource || "",
       tags: m.tags || [],
       projects: m.projects || [],
@@ -115,6 +117,7 @@ const MetricsSelector: FC<{
       ? factMetrics.map((m) => ({
           id: m.id,
           name: m.name,
+          description: m.description || "",
           datasource: m.datasource,
           tags: m.tags || [],
           projects: m.projects || [],
@@ -169,12 +172,17 @@ const MetricsSelector: FC<{
           return {
             value: m.id,
             label: m.name,
+            tooltip: m.description,
           };
         })}
         placeholder="Select metrics..."
         autoFocus={autoFocus}
-        formatOptionLabel={({ value, label }) => {
-          return value ? <MetricName id={value} /> : label;
+        formatOptionLabel={({ value, label }, { context }) => {
+          return value ? (
+            <MetricName id={value} showDescription={context !== "value"} />
+          ) : (
+            label
+          );
         }}
         onPaste={(e) => {
           try {

--- a/packages/front-end/components/Forms/MultiSelectField.tsx
+++ b/packages/front-end/components/Forms/MultiSelectField.tsx
@@ -7,6 +7,7 @@ import ReactSelect, {
   Props,
   StylesConfig,
   OptionProps,
+  FormatOptionLabelMeta,
 } from "react-select";
 import {
   SortableContainer,
@@ -87,7 +88,10 @@ const MultiSelectField: FC<
     customClassName?: string;
     closeMenuOnSelect?: boolean;
     creatable?: boolean;
-    formatOptionLabel?: (value: SingleValue) => ReactNode;
+    formatOptionLabel?: (
+      value: SingleValue,
+      meta: FormatOptionLabelMeta<SingleValue>
+    ) => ReactNode;
     onPaste?: (e: React.ClipboardEvent<HTMLInputElement>) => void;
   }
 > = ({

--- a/packages/front-end/components/Metrics/MetricName.tsx
+++ b/packages/front-end/components/Metrics/MetricName.tsx
@@ -107,9 +107,7 @@ export default function MetricName({
   if (!metric) return <>{id}</>;
 
   return (
-    <div
-      style={{ textOverflow: "ellipsis", overflow: "auto", maxWidth: "100%" }}
-    >
+    <>
       {metric.name}
       {showDescription && metric.description ? (
         <span className="text-muted">
@@ -128,6 +126,6 @@ export default function MetricName({
         disableTooltip={disableTooltip}
         showOfficialLabel={showOfficialLabel}
       />
-    </div>
+    </>
   );
 }

--- a/packages/front-end/components/Metrics/MetricName.tsx
+++ b/packages/front-end/components/Metrics/MetricName.tsx
@@ -94,10 +94,12 @@ export default function MetricName({
   id,
   disableTooltip,
   showOfficialLabel,
+  showDescription,
 }: {
   id: string;
   disableTooltip?: boolean;
   showOfficialLabel?: boolean;
+  showDescription?: boolean;
 }) {
   const { getExperimentMetricById } = useDefinitions();
   const metric = getExperimentMetricById(id);
@@ -105,14 +107,27 @@ export default function MetricName({
   if (!metric) return <>{id}</>;
 
   return (
-    <>
+    <div
+      style={{ textOverflow: "ellipsis", overflow: "auto", maxWidth: "100%" }}
+    >
       {metric.name}
+      {showDescription && metric.description ? (
+        <span className="text-muted">
+          {" "}
+          -{" "}
+          {metric?.description.length > 50
+            ? metric?.description.substring(0, 50) + "..."
+            : metric?.description}
+        </span>
+      ) : (
+        ""
+      )}
       <OfficialBadge
         type="metric"
         managedBy={metric.managedBy}
         disableTooltip={disableTooltip}
         showOfficialLabel={showOfficialLabel}
       />
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
Added the metric description to the multi select menu so users can get more info when selecting. 

<img width="814" alt="Screenshot 2024-05-14 at 5 21 00 PM" src="https://github.com/growthbook/growthbook/assets/46107/88dcae52-4dfc-4b15-9e03-c7aeef0f4f98">
