### PR TITLE
Memoize usePermissionsUtil to reduce API calls

### DIFF
--- a/packages/front-end/components/Settings/UpgradeModal/index.tsx
+++ b/packages/front-end/components/Settings/UpgradeModal/index.tsx
@@ -52,7 +52,7 @@ export default function UpgradeModal({ close, source }: Props) {
   const { organization, refreshOrganization } = useUser();
 
   const currentUsers =
-    (organization?.members?.length || 0) + (organization?.invites?.length || 0);
+    (organization.members?.length || 0) + (organization.invites?.length || 0);
 
   const licensePlanText =
     (accountPlan === "enterprise"

--- a/packages/front-end/components/Settings/UpgradeModal/index.tsx
+++ b/packages/front-end/components/Settings/UpgradeModal/index.tsx
@@ -52,7 +52,7 @@ export default function UpgradeModal({ close, source }: Props) {
   const { organization, refreshOrganization } = useUser();
 
   const currentUsers =
-    (organization.members?.length || 0) + (organization.invites?.length || 0);
+    (organization?.members?.length || 0) + (organization?.invites?.length || 0);
 
   const licensePlanText =
     (accountPlan === "enterprise"

--- a/packages/front-end/services/UserContext.tsx
+++ b/packages/front-end/services/UserContext.tsx
@@ -396,8 +396,7 @@ export function UserContextProvider({ children }: { children: ReactNode }) {
         licenseError: currentOrg?.licenseError || "",
         commercialFeatures: currentOrg?.commercialFeatures || [],
         apiKeys: currentOrg?.apiKeys || [],
-        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'OrganizationInterface | undefined' is not as... Remove this comment to see the full error message
-        organization: currentOrg?.organization,
+        organization: currentOrg?.organization || {},
         seatsInUse: currentOrg?.seatsInUse || 0,
         teams,
         error: error || orgLoadingError?.message,

--- a/packages/front-end/services/UserContext.tsx
+++ b/packages/front-end/services/UserContext.tsx
@@ -355,17 +355,19 @@ export function UserContextProvider({ children }: { children: ReactNode }) {
     permissionsCheck,
   ]);
 
-  const permissionsUtil = new Permissions(
-    currentOrg?.currentUserPermissions || {
-      global: {
-        permissions: {},
-        limitAccessByEnvironment: false,
-        environments: [],
+  const permissionsUtil = useMemo(() => {
+    return new Permissions(
+      currentOrg?.currentUserPermissions || {
+        global: {
+          permissions: {},
+          limitAccessByEnvironment: false,
+          environments: [],
+        },
+        projects: {},
       },
-      projects: {},
-    },
-    data?.superAdmin || false
-  );
+      data?.superAdmin || false
+    );
+  }, [currentOrg?.currentUserPermissions, data?.superAdmin]);
 
   return (
     <UserContext.Provider


### PR DESCRIPTION
### Features and Changes

Memoize the return value of `usePermissionsUtil()` so we can use it in useEffect dependency hooks.  Prior to this change, every page load by an admin would trigger at least 6 API requests to `/subscription/quote`, not it only triggers 1-2 times.  There are likely other places throughout the code where we use permissions as a hook dependency that are less obvious, but this will also improve performance there as well.

Also fixes an obscure bug on Cloud.  If you are on the "Accept Invite" page and you open the in-app chat and click "Upgrade", it would throw an uncaught error.