### PR TITLE
[Bug Fix] Adds permission check around Create Experiment Report button.

### DIFF
--- a/packages/front-end/components/Experiment/TabbedPage/ResultsTab.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/ResultsTab.tsx
@@ -23,6 +23,7 @@ import Results, { ResultsMetricFilters } from "@/components/Experiment/Results";
 import AnalysisForm from "@/components/Experiment/AnalysisForm";
 import ExperimentReportsList from "@/components/Experiment/ExperimentReportsList";
 import { useSnapshot } from "@/components/Experiment/SnapshotProvider";
+import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 import AnalysisSettingsSummary from "./AnalysisSettingsSummary";
 import { ExperimentTab } from ".";
 
@@ -84,6 +85,8 @@ export default function ResultsTab({
   const router = useRouter();
 
   const { snapshot } = useSnapshot();
+  const permissionsUtil = usePermissionsUtil();
+  const canCreateReports = permissionsUtil.canCreateReport(experiment);
 
   const [analysisSettingsOpen, setAnalysisSettingsOpen] = useState(false);
 
@@ -278,26 +281,28 @@ export default function ResultsTab({
           <div className="row mx-2 py-3 d-flex align-items-center">
             <div className="col h3 ml-2 mb-0">Custom Reports</div>
             <div className="col-auto mr-2">
-              <Button
-                className="btn btn-outline-primary float-right"
-                color="outline-info"
-                stopPropagation={true}
-                onClick={async () => {
-                  const res = await apiCall<{ report: ReportInterface }>(
-                    `/experiments/report/${snapshot.id}`,
-                    {
-                      method: "POST",
+              {canCreateReports ? (
+                <Button
+                  className="btn btn-outline-primary float-right"
+                  color="outline-info"
+                  stopPropagation={true}
+                  onClick={async () => {
+                    const res = await apiCall<{ report: ReportInterface }>(
+                      `/experiments/report/${snapshot.id}`,
+                      {
+                        method: "POST",
+                      }
+                    );
+                    if (!res.report) {
+                      throw new Error("Failed to create report");
                     }
-                  );
-                  if (!res.report) {
-                    throw new Error("Failed to create report");
-                  }
-                  await router.push(`/report/${res.report.id}`);
-                }}
-              >
-                <GBAddCircle className="pr-1" />
-                Custom Report
-              </Button>
+                    await router.push(`/report/${res.report.id}`);
+                  }}
+                >
+                  <GBAddCircle className="pr-1" />
+                  Custom Report
+                </Button>
+              ) : null}
             </div>
           </div>
           <ExperimentReportsList experiment={experiment} />

--- a/packages/front-end/components/Experiment/TabbedPage/ResultsTab.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/ResultsTab.tsx
@@ -86,7 +86,6 @@ export default function ResultsTab({
 
   const { snapshot } = useSnapshot();
   const permissionsUtil = usePermissionsUtil();
-  const canCreateReports = permissionsUtil.canCreateReport(experiment);
 
   const [analysisSettingsOpen, setAnalysisSettingsOpen] = useState(false);
 
@@ -281,7 +280,7 @@ export default function ResultsTab({
           <div className="row mx-2 py-3 d-flex align-items-center">
             <div className="col h3 ml-2 mb-0">Custom Reports</div>
             <div className="col-auto mr-2">
-              {canCreateReports ? (
+              {permissionsUtil.canCreateReport(experiment) ? (
                 <Button
                   className="btn btn-outline-primary float-right"
                   color="outline-info"


### PR DESCRIPTION
### Features and Changes

Previously we were not conditionally rendering the `Create Report` button on the experiment results page based on the user's permissions.

Now, we check the user has permission before rendering the button.

My plan initially was to simply disable the button, and wrap the button in a `Tooltip` so we can communicate to the user why the button is disabled. But I came across a weird side effect of wrapping a `<Button/>` component with a `Tooltip`. On hover, if you hovered over the text, it caused the tooltip to flicker.

Looking through our app, it appears we're not wrapping buttons with tooltips anywhere else.

Here is a video of the flickering https://www.loom.com/share/49607451ee394eb28114c9be6bc808af. I restarted my app and updated chrome just to make sure it wasn't an issue with an older version.

### Testing

- [x] Ensure that only users with `createAnalyses` permissions can create an experiment report
