### PR TITLE
Added description to attributes

### DIFF
--- a/packages/back-end/src/routers/attributes/attributes.controller.ts
+++ b/packages/back-end/src/routers/attributes/attributes.controller.ts
@@ -11,6 +11,7 @@ export const postAttribute = async (
 ) => {
   const {
     property,
+    description,
     datatype,
     projects,
     format,
@@ -37,6 +38,7 @@ export const postAttribute = async (
         ...attributeSchema,
         {
           property,
+          description,
           datatype,
           projects,
           format,
@@ -61,6 +63,7 @@ export const postAttribute = async (
             ...attributeSchema,
             {
               property,
+              description,
               datatype,
               projects,
               format,
@@ -83,6 +86,7 @@ export const putAttribute = async (
 ) => {
   const {
     property,
+    description,
     datatype,
     projects,
     format,
@@ -123,6 +127,7 @@ export const putAttribute = async (
   attributeSchema[index] = {
     ...attributeSchema[index],
     property,
+    description,
     datatype,
     projects,
     format,

--- a/packages/back-end/src/routers/attributes/attributes.router.ts
+++ b/packages/back-end/src/routers/attributes/attributes.router.ts
@@ -14,6 +14,7 @@ router.post(
   validateRequestMiddleware({
     body: z.object({
       property: z.string(),
+      description: z.string().optional(),
       datatype: z.enum(attributeDataTypes),
       projects: z.array(z.string()),
       format: z.string(),
@@ -29,6 +30,7 @@ router.put(
   validateRequestMiddleware({
     body: z.object({
       property: z.string(),
+      description: z.string().optional(),
       datatype: z.enum(attributeDataTypes),
       projects: z.array(z.string()),
       format: z.string(),

--- a/packages/back-end/types/organization.d.ts
+++ b/packages/back-end/types/organization.d.ts
@@ -134,6 +134,7 @@ export type SDKAttributeType = typeof attributeDataTypes[number];
 export type SDKAttribute = {
   property: string;
   datatype: SDKAttributeType;
+  description?: string;
   hashAttribute?: boolean;
   enum?: string;
   archived?: boolean;

--- a/packages/front-end/components/Features/AttributeModal.tsx
+++ b/packages/front-end/components/Features/AttributeModal.tsx
@@ -5,6 +5,7 @@ import {
   SDKAttributeType,
 } from "back-end/types/organization";
 import { FaExclamationCircle, FaInfoCircle } from "react-icons/fa";
+import React from "react";
 import { useAttributeSchema } from "@/services/features";
 import { useAuth } from "@/services/auth";
 import Modal from "@/components/Modal";
@@ -35,6 +36,7 @@ export default function AttributeModal({ close, attribute }: Props) {
   const form = useForm<SDKAttribute>({
     defaultValues: {
       property: attribute || "",
+      description: current?.description || "",
       datatype: current?.datatype || "string",
       projects: attribute ? current?.projects || [] : project ? [project] : [],
       format: current?.format || "",
@@ -82,6 +84,7 @@ export default function AttributeModal({ close, attribute }: Props) {
         const attributeObj: SDKAttribute & { previousName?: string } = {
           property: value.property,
           datatype: value.datatype,
+          description: value.description,
           projects: value.projects,
           format: value.format,
           enum: value.enum,
@@ -103,7 +106,16 @@ export default function AttributeModal({ close, attribute }: Props) {
         refreshOrganization();
       })}
     >
-      <Field label="Attribute" {...form.register("property")} />
+      <Field
+        label={
+          <>
+            Attribute{" "}
+            <Tooltip body={"This is the attribute name used in the SDK"} />
+          </>
+        }
+        required={true}
+        {...form.register("property")}
+      />
       {attribute && form.watch("property") !== attribute ? (
         <div className="alert alert-warning">
           Be careful changing the attribute name. Any existing targeting
@@ -111,6 +123,16 @@ export default function AttributeModal({ close, attribute }: Props) {
           and will still reference the old attribute name.
         </div>
       ) : null}
+      <div className="form-group">
+        <label>
+          Description <small className="text-muted">(optional)</small>
+        </label>
+        <Field
+          className="form-control"
+          {...form.register("description")}
+          textarea={true}
+        />
+      </div>
       {projects?.length > 0 && (
         <div className="form-group">
           <MultiSelectField

--- a/packages/front-end/components/Features/AttributeModal.tsx
+++ b/packages/front-end/components/Features/AttributeModal.tsx
@@ -124,11 +124,13 @@ export default function AttributeModal({ close, attribute }: Props) {
         </div>
       ) : null}
       <div className="form-group">
-        <label>
-          Description <small className="text-muted">(optional)</small>
-        </label>
         <Field
           className="form-control"
+          label={
+            <>
+              Description <small className="text-muted">(optional)</small>
+            </>
+          }
           {...form.register("description")}
           textarea={true}
         />

--- a/packages/front-end/components/Features/ConditionInput.tsx
+++ b/packages/front-end/components/Features/ConditionInput.tsx
@@ -299,7 +299,11 @@ export default function ConditionInput(props: Props) {
                       options={attributeSchema.map((s) => ({
                         label: s.property,
                         value: s.property,
+                        tooltip: s.description || "",
                       }))}
+                      formatOptionLabel={(o) => (
+                        <span title={o.tooltip}>{o.label}</span>
+                      )}
                       name="field"
                       className={styles.firstselect}
                       onChange={(value) => {

--- a/packages/front-end/pages/attributes.tsx
+++ b/packages/front-end/pages/attributes.tsx
@@ -32,6 +32,7 @@ const FeatureAttributesPage = (): React.ReactElement => {
           <span className="badge badge-secondary ml-2">archived</span>
         )}
       </td>
+      <td className="text-gray">{v.description}</td>
       <td
         className="text-gray"
         style={{ maxWidth: "20vw", wordWrap: "break-word" }}
@@ -153,6 +154,7 @@ const FeatureAttributesPage = (): React.ReactElement => {
             <thead>
               <tr>
                 <th>Attribute</th>
+                <th>Description</th>
                 <th>Data Type</th>
                 <th>Projects</th>
                 <th>


### PR DESCRIPTION
![Screenshot 2024-05-15 at 12 15 46 PM](https://github.com/growthbook/growthbook/assets/46107/17c3b7d6-aa89-4270-8819-c1152fa7b91f)

Attributes show up on the listing page, as well as in a tooltip/title tag when mousing over an attribute on the conditional Inputs.