### PR TITLE
Extra safety with prior settings for fact metrics

### DIFF
--- a/packages/front-end/components/FactTables/FactMetricModal.tsx
+++ b/packages/front-end/components/FactTables/FactMetricModal.tsx
@@ -405,7 +405,6 @@ export default function FactMetricModal({
     },
   });
 
-  console.log(form.getValues("priorSettings"));
   const selectedDataSource = getDatasourceById(form.watch("datasource"));
 
   const [advancedOpen, setAdvancedOpen] = useState(

--- a/packages/front-end/components/FactTables/FactMetricModal.tsx
+++ b/packages/front-end/components/FactTables/FactMetricModal.tsx
@@ -405,6 +405,7 @@ export default function FactMetricModal({
     },
   });
 
+  console.log(form.getValues("priorSettings"));
   const selectedDataSource = getDatasourceById(form.watch("datasource"));
 
   const [advancedOpen, setAdvancedOpen] = useState(
@@ -488,6 +489,15 @@ export default function FactMetricModal({
       submit={form.handleSubmit(async (values) => {
         if (values.denominator && !values.denominator.factTableId) {
           values.denominator = null;
+        }
+
+        if (values.priorSettings === undefined) {
+          values.priorSettings = {
+            override: false,
+            proper: false,
+            mean: 0,
+            stddev: DEFAULT_PROPER_PRIOR_STDDEV,
+          };
         }
 
         if (values.metricType === "ratio" && !values.denominator)


### PR DESCRIPTION
Some errors with priorSettings being undefined when creating fact metrics still seem to be occurring, even though we are setting it in the default values for the fact metric. This should provide an additional safety check/fallback but may not be necessary to land.