### PR TITLE
Show full error when trying to set a new license

### DIFF
--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -1978,18 +1978,8 @@ export async function setLicenseKey(
     );
   }
 
-  try {
-    org.licenseKey = licenseKey;
-    await initializeLicenseForOrg(org, true);
-  } catch (error) {
-    // As we show this error on the front-end, show a more generic invalid license key error
-    // if the error is not related to being able to connect to the license server
-    if (error.message.includes("Could not connect")) {
-      throw new Error(error?.message);
-    } else {
-      throw new Error("Invalid license key");
-    }
-  }
+  org.licenseKey = licenseKey;
+  await initializeLicenseForOrg(org, true);
 }
 
 export async function putLicenseKey(

--- a/packages/enterprise/src/license.ts
+++ b/packages/enterprise/src/license.ts
@@ -284,7 +284,12 @@ function getVerifiedLicenseData(key: string): Partial<LicenseInterface> {
     .split(".")
     .map((s) => Buffer.from(s, "base64url"));
 
-  const decodedLicense: LicenseData = JSON.parse(license.toString());
+  let decodedLicense: LicenseData;
+  try {
+    decodedLicense = JSON.parse(license.toString());
+  } catch {
+    throw new Error("Could not parse license");
+  }
 
   // Support old way of storing expiration date
   decodedLicense.exp = decodedLicense.exp || decodedLicense.eat || "";


### PR DESCRIPTION
### Features and Changes

We had been catching all errors and giving a generic error when setting a license.  This makes it really hard to debug what is going on when people got an "Invalid License Key" message.

- Shows the error message as is
- Makes JSON parsing errors a bit nicer to read.

### Testing
set `LICENSE_SERVER_URL=http://localhost:8080/api/v1/` in .env.local
and start dev license server
Remove licenseKey on organization in mongodb
Set a license "bad" and see "Could not parse license"
Set a license "license_bad" and see "License server errored with: License not found"
Kill the dev license server
Set "license_bad" and see "Could not connect to license server. Make sure to whitelist 75.2.109.47."
Start the dev license server
Set an actual license and see it accept it.
