### PR TITLE
Bug - Adds permission check to event webhook id page before fetching details

### DIFF
--- a/packages/front-end/pages/settings/webhooks/event/[eventwebhookid].tsx
+++ b/packages/front-end/pages/settings/webhooks/event/[eventwebhookid].tsx
@@ -2,8 +2,20 @@ import React from "react";
 import { NextPage } from "next";
 import { EventWebHookDetailContainer } from "@/components/EventWebHooks/EventWebHookDetail/EventWebHookDetail";
 import { EventWebHookLogsContainer } from "@/components/EventWebHooks/EventWebHookLogs/EventWebHookLogs";
+import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 
 const EventWebHookDetailPage: NextPage = () => {
+  const permissionsUtil = usePermissionsUtil();
+
+  if (!permissionsUtil.canViewEventWebhook()) {
+    return (
+      <div className="container pagecontents">
+        <div className="alert alert-danger">
+          You do not have permission to view this page.
+        </div>
+      </div>
+    );
+  }
   return (
     <div className="container pagecontents">
       <EventWebHookDetailContainer />


### PR DESCRIPTION
### Features and Changes

Previously the webhook event details page `/settings/webhooks/event/:eventWebhookId` didn't have a permission check on the front-end in front of the api call to fetch the details.

As a result, the endpoint was throwing an error, when in reality, we should be checking the user's permission level before we fetch the details.

Its likely orgs were using the event webhooks and a user was clicking on the slack link or notification to see what changed, but their role doesn't provide access to view that info.


### Testing

- [x] Navigate to an event webhook id page directly as a non-admin and confirm that rather than us doing a network call that throws an error, we get a frontend error and the network call isn't made
- [x] Ensure admins can still view the page without issue
