### PR TITLE
Adds character counter to Field component

### DIFF
--- a/packages/front-end/components/Forms/Field.tsx
+++ b/packages/front-end/components/Forms/Field.tsx
@@ -41,6 +41,7 @@ export type BaseFieldProps = {
   prepend?: ReactElement | string;
   append?: ReactElement | string;
   comboBox?: boolean;
+  currentLength?: number;
 };
 
 export type FieldProps = BaseFieldProps &
@@ -214,11 +215,18 @@ const Field = forwardRef(
           render ? customClassName : ""
         )}
       >
-        {label && (
-          <label htmlFor={fieldId} className={clsx(labelClassName)}>
-            {label}
-          </label>
-        )}
+        <div className="d-flex flex-row justify-content-between">
+          {label && (
+            <label htmlFor={fieldId} className={clsx(labelClassName)}>
+              {label}
+            </label>
+          )}
+          {otherProps.currentLength !== undefined && otherProps.maxLength ? (
+            <div className="font-weight-light">
+              <small>{`${otherProps.currentLength} / ${otherProps.maxLength}`}</small>
+            </div>
+          ) : null}
+        </div>
         {component}
         {error && <div className="form-text text-danger">{error}</div>}
         {helpText && <small className="form-text text-muted">{helpText}</small>}

--- a/packages/front-end/components/Teams/Roles/RoleForm.tsx
+++ b/packages/front-end/components/Teams/Roles/RoleForm.tsx
@@ -95,6 +95,7 @@ export default function RoleForm({
           disabled={status !== "creating"}
           autoComplete="company"
           maxLength={40}
+          currentLength={currentValue.id.length}
           placeholder="Name your Custom Role"
           labelClassName="font-weight-bold"
           {...form.register("id")}
@@ -112,6 +113,7 @@ export default function RoleForm({
         <Field
           label="Description"
           disabled={status === "viewing"}
+          currentLength={currentValue.description.length}
           placeholder="Briefly describe what this role will permit users to do"
           maxLength={100}
           labelClassName="font-weight-bold"


### PR DESCRIPTION
### Features and Changes

Within the mocks for the **Custom Roles UI** Kari included a live character counter on the name and description fields.

Under the hood, both of these are using the `Field` component. With this update, I've added a new supported prop (`currentLength`) to the `Field` component. And now, if you pass in both the `currentLength` and a `maxLength` we will render the live character counter like in the screenshot below.

### Screenshots
Mock up:
<img width="855" alt="Screen Shot 2024-05-16 at 12 08 47 PM" src="https://github.com/growthbook/growthbook/assets/75274610/c08aa3df-9644-4b78-96f1-6429a9ad83fe">

Live example:
<img width="1097" alt="Screen Shot 2024-05-16 at 12 12 35 PM" src="https://github.com/growthbook/growthbook/assets/75274610/01d3e919-8b92-46c4-9645-cdbc7dcf1246">

### Notes
I did explore going down the route of calculating the `currentLength` within the `Field` component, but I abandoned that when I started thinking about the developer experience of using the `Field` component. If an engineer wanted to enable the character counter, they'd need to then pass in a new prop (maybe `enableCharacterCounter`) in addition to the `maxLength` and then in the code we'd need to check for that, and also make sure we had values for `currentLength` and `maxLength`. With this, now if you pass in both `currentLength` and `maxLength`, it automatically renders (assuming both of those props are not undefined).

**Open to suggestions/feedback if you have a different approach that you think would be better. This is a highly used component so I want to make sure we get it right.**

### Testing

-[x] Test out a handful of `Field` components in the app and ensure this doesn't introduce any regressions at popular screensizes.
-[x] Ensure that the character counters are accurate
