### PR TITLE
View events refactor

### DIFF
--- a/packages/back-end/src/events/base-types.ts
+++ b/packages/back-end/src/events/base-types.ts
@@ -47,4 +47,8 @@ export type NotificationEventPayload<
   object: ResourceType;
   data: DataType;
   user: EventAuditUser;
+  projects: string[];
+  tags: string[];
+  environments: string[];
+  containsSecrets: boolean;
 };

--- a/packages/back-end/src/events/handlers/utils.ts
+++ b/packages/back-end/src/events/handlers/utils.ts
@@ -1,10 +1,6 @@
-import uniq from "lodash/uniq";
 import isEqual from "lodash/isEqual";
 import intersection from "lodash/intersection";
-import {
-  FeatureUpdatedNotificationEvent,
-  NotificationEvent,
-} from "../notification-events";
+import { NotificationEvent } from "../notification-events";
 import { ApiFeature } from "../../../types/openapi";
 
 export type FilterDataForNotificationEvent = {
@@ -15,83 +11,10 @@ export type FilterDataForNotificationEvent = {
 export const getFilterDataForNotificationEvent = (
   event: NotificationEvent
 ): FilterDataForNotificationEvent | null => {
-  let invalidEvent: never;
-
-  switch (event.event) {
-    case "user.login":
-      return null;
-
-    case "feature.created":
-      return {
-        tags: event.data.current.tags || [],
-        projects: event.data.current.project
-          ? [event.data.current.project]
-          : [],
-      };
-
-    case "feature.updated":
-      return {
-        tags: uniq(
-          (event.data.current.tags || []).concat(event.data.previous.tags || [])
-        ),
-        projects: uniq(
-          (event.data.current.project
-            ? [event.data.current.project]
-            : []
-          ).concat(
-            event.data.previous.project ? [event.data.previous.project] : []
-          )
-        ),
-      };
-
-    case "feature.deleted":
-      return {
-        tags: event.data.previous.tags || [],
-        projects: event.data.previous.project
-          ? [event.data.previous.project]
-          : [],
-      };
-
-    case "experiment.created":
-      return {
-        tags: event.data.current.tags || [],
-        projects: event.data.current.project
-          ? [event.data.current.project]
-          : [],
-      };
-
-    case "experiment.updated":
-      return {
-        tags: uniq(
-          (event.data.current.tags || []).concat(event.data.previous.tags || [])
-        ),
-        projects: uniq(
-          (event.data.current.project
-            ? [event.data.current.project]
-            : []
-          ).concat(
-            event.data.previous.project ? [event.data.previous.project] : []
-          )
-        ),
-      };
-
-    case "experiment.deleted":
-      return {
-        tags: event.data.previous.tags || [],
-        projects: event.data.previous.project
-          ? [event.data.previous.project]
-          : [],
-      };
-
-    case "experiment.info":
-    case "experiment.warning":
-    case "webhook.test":
-      return { tags: [], projects: [] };
-
-    default:
-      invalidEvent = event;
-      throw `Invalid event: ${invalidEvent}`;
-  }
+  return {
+    tags: event.tags || [],
+    projects: event.projects || [],
+  };
 };
 
 // Will only notify for environments in which rules were modified.
@@ -103,36 +26,12 @@ export const filterEventForEnvironments = ({
   event: NotificationEvent;
   environments: string[];
 }): boolean => {
-  let invalidEvent: never;
-
-  switch (event.event) {
-    case "user.login":
-      return false;
-
-    case "experiment.created":
-    case "experiment.updated":
-    case "experiment.deleted":
-    case "experiment.info":
-    case "experiment.warning":
-      return true;
-
-    case "feature.created":
-    case "feature.deleted":
-      return true;
-
-    case "feature.updated":
-      return filterFeatureUpdatedNotificationEventForEnvironments({
-        featureEvent: event,
-        environments,
-      });
-
-    case "webhook.test":
-      return true;
-
-    default:
-      invalidEvent = event;
-      throw `Invalid event: ${invalidEvent}`;
+  // if the environments are not specified, notify for all environments
+  if (environments.length === 0) {
+    return true;
   }
+
+  return intersection(event.environments || [], environments).length > 0;
 };
 
 // Some of the feature keys that change affect all enabled environments
@@ -144,33 +43,25 @@ export const RELEVANT_KEYS_FOR_ALL_ENVS: (keyof ApiFeature)[] = [
   "valueType",
 ];
 
-export const filterFeatureUpdatedNotificationEventForEnvironments = ({
-  featureEvent,
-  environments,
-}: {
-  featureEvent: FeatureUpdatedNotificationEvent;
-  environments: string[];
-}): boolean => {
-  const { previous, current } = featureEvent.data;
-  if (previous.archived && current.archived) {
-    // Do not notify for archived features
-    return false;
-  }
+export function getChangedApiFeatureEnvironments(
+  previous: ApiFeature,
+  current: ApiFeature
+): string[] {
+  const allEnvs = Array.from(
+    new Set([
+      ...Object.keys(previous.environments),
+      ...Object.keys(current.environments),
+    ])
+  );
 
   if (
     RELEVANT_KEYS_FOR_ALL_ENVS.some((k) => !isEqual(previous[k], current[k]))
   ) {
     // Some of the relevant keys for all environments has changed.
-    return true;
+    return allEnvs;
   }
 
   // Manual environment filtering
-
-  const allEnvs = new Set([
-    ...Object.keys(previous.environments),
-    ...Object.keys(current.environments),
-  ]);
-
   const changedEnvironments = new Set<string>();
 
   // Add in environments if their specific settings changed
@@ -189,16 +80,5 @@ export const filterFeatureUpdatedNotificationEventForEnvironments = ({
     }
   });
 
-  const environmentChangesAreRelevant = changedEnvironments.size > 0;
-
-  if (!environmentChangesAreRelevant) {
-    return false;
-  }
-
-  // if the environments are not specified, notify for all environments
-  if (environments.length === 0) {
-    return true;
-  }
-
-  return intersection(Array.from(changedEnvironments), environments).length > 0;
-};
+  return Array.from(changedEnvironments);
+}

--- a/packages/back-end/src/models/EventModel.ts
+++ b/packages/back-end/src/models/EventModel.ts
@@ -43,6 +43,10 @@ const eventSchema = new mongoose.Schema({
             event: z.enum(notificationEventNames),
             object: z.enum(notificationEventResources),
             data: z.any(),
+            projects: z.array(z.string()),
+            environments: z.array(z.string()),
+            tags: z.array(z.string()),
+            containsSecrets: z.boolean(),
             user: z.union([
               z
                 .object({

--- a/packages/back-end/src/models/ExperimentModel.ts
+++ b/packages/back-end/src/models/ExperimentModel.ts
@@ -709,6 +709,13 @@ const logExperimentCreated = async (
 ): Promise<string | undefined> => {
   const { org: organization } = context;
   const apiExperiment = await toExperimentApiInterface(context, experiment);
+
+  // If experiment is part of the SDK payload, it affects all environments
+  // Otherwise, it doesn't affect any
+  const changedEnvs = includeExperimentInPayload(experiment)
+    ? getEnvironmentIdsFromOrg(context.org)
+    : [];
+
   const payload: ExperimentCreatedNotificationEvent = {
     object: "experiment",
     event: "experiment.created",
@@ -716,6 +723,10 @@ const logExperimentCreated = async (
     data: {
       current: apiExperiment,
     },
+    projects: [apiExperiment.project],
+    tags: apiExperiment.tags,
+    environments: changedEnvs,
+    containsSecrets: false,
   };
 
   const emittedEvent = await createEvent(organization.id, payload);
@@ -752,6 +763,13 @@ const logExperimentUpdated = async ({
     currentApiExperimentPromise,
   ]);
 
+  // If experiment is part of the SDK payload, it affects all environments
+  // Otherwise, it doesn't affect any
+  const hasPayloadChanges = hasChangesForSDKPayloadRefresh(previous, current);
+  const changedEnvs = hasPayloadChanges
+    ? getEnvironmentIdsFromOrg(context.org)
+    : [];
+
   const payload: ExperimentUpdatedNotificationEvent = {
     object: "experiment",
     event: "experiment.updated",
@@ -760,6 +778,14 @@ const logExperimentUpdated = async ({
       previous: previousApiExperiment,
       current: currentApiExperiment,
     },
+    projects: Array.from(
+      new Set([previousApiExperiment.project, currentApiExperiment.project])
+    ),
+    tags: Array.from(
+      new Set([...previousApiExperiment.tags, ...currentApiExperiment.tags])
+    ),
+    environments: changedEnvs,
+    containsSecrets: false,
   };
 
   const emittedEvent = await createEvent(context.org.id, payload);
@@ -1049,6 +1075,13 @@ export const logExperimentDeleted = async (
   experiment: ExperimentInterface
 ): Promise<string | undefined> => {
   const apiExperiment = await toExperimentApiInterface(context, experiment);
+
+  // If experiment is part of the SDK payload, it affects all environments
+  // Otherwise, it doesn't affect any
+  const changedEnvs = includeExperimentInPayload(experiment)
+    ? getEnvironmentIdsFromOrg(context.org)
+    : [];
+
   const payload: ExperimentDeletedNotificationEvent = {
     object: "experiment",
     event: "experiment.deleted",
@@ -1056,6 +1089,10 @@ export const logExperimentDeleted = async (
     data: {
       previous: apiExperiment,
     },
+    projects: [apiExperiment.project],
+    environments: changedEnvs,
+    tags: apiExperiment.tags,
+    containsSecrets: false,
   };
 
   const emittedEvent = await createEvent(context.org.id, payload);

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -2,7 +2,7 @@ import mongoose, { FilterQuery } from "mongoose";
 import cloneDeep from "lodash/cloneDeep";
 import omit from "lodash/omit";
 import isEqual from "lodash/isEqual";
-import { MergeResultChanges } from "shared/util";
+import { MergeResultChanges, getApiFeatureEnabledEnvs } from "shared/util";
 import {
   FeatureEnvironment,
   FeatureInterface,
@@ -34,6 +34,7 @@ import { FeatureRevisionInterface } from "../../types/feature-revision";
 import { logger } from "../util/logger";
 import { getEnvironmentIdsFromOrg } from "../services/organizations";
 import { ApiReqContext } from "../../types/api";
+import { getChangedApiFeatureEnvironments } from "../events/handlers/utils";
 import { createEvent } from "./EventModel";
 import {
   addLinkedFeatureToExperiment,
@@ -345,24 +346,38 @@ async function logFeatureUpdatedEvent(
   const groupMap = await getSavedGroupMap(context.org);
   const experimentMap = await getExperimentMapForFeature(context, current.id);
 
+  const currentApiFeature = getApiFeatureObj({
+    feature: current,
+    organization: context.org,
+    groupMap,
+    experimentMap,
+  });
+  const previousApiFeature = getApiFeatureObj({
+    feature: previous,
+    organization: context.org,
+    groupMap,
+    experimentMap,
+  });
+
   const payload: FeatureUpdatedNotificationEvent = {
     object: "feature",
     event: "feature.updated",
     data: {
-      current: getApiFeatureObj({
-        feature: current,
-        organization: context.org,
-        groupMap,
-        experimentMap,
-      }),
-      previous: getApiFeatureObj({
-        feature: previous,
-        organization: context.org,
-        groupMap,
-        experimentMap,
-      }),
+      current: currentApiFeature,
+      previous: previousApiFeature,
     },
     user: context.auditUser,
+    projects: Array.from(
+      new Set([previousApiFeature.project, currentApiFeature.project])
+    ),
+    tags: Array.from(
+      new Set([...previousApiFeature.tags, ...currentApiFeature.tags])
+    ),
+    environments: getChangedApiFeatureEnvironments(
+      previousApiFeature,
+      currentApiFeature
+    ),
+    containsSecrets: false,
   };
 
   const emittedEvent = await createEvent(context.org.id, payload);
@@ -384,18 +399,24 @@ async function logFeatureCreatedEvent(
   const groupMap = await getSavedGroupMap(context.org);
   const experimentMap = await getExperimentMapForFeature(context, feature.id);
 
+  const apiFeature = getApiFeatureObj({
+    feature,
+    organization: context.org,
+    groupMap,
+    experimentMap,
+  });
+
   const payload: FeatureCreatedNotificationEvent = {
     object: "feature",
     event: "feature.created",
     user: context.auditUser,
     data: {
-      current: getApiFeatureObj({
-        feature,
-        organization: context.org,
-        groupMap,
-        experimentMap,
-      }),
+      current: apiFeature,
     },
+    projects: [apiFeature.project],
+    tags: apiFeature.tags,
+    environments: getApiFeatureEnabledEnvs(apiFeature),
+    containsSecrets: false,
   };
 
   const emittedEvent = await createEvent(context.org.id, payload);
@@ -419,18 +440,24 @@ async function logFeatureDeletedEvent(
     previousFeature.id
   );
 
+  const apiFeature = getApiFeatureObj({
+    feature: previousFeature,
+    organization: context.org,
+    groupMap,
+    experimentMap,
+  });
+
   const payload: FeatureDeletedNotificationEvent = {
     object: "feature",
     event: "feature.deleted",
     user: context.auditUser,
     data: {
-      previous: getApiFeatureObj({
-        feature: previousFeature,
-        organization: context.org,
-        groupMap,
-        experimentMap,
-      }),
+      previous: apiFeature,
     },
+    projects: [apiFeature.project],
+    tags: apiFeature.tags,
+    environments: getApiFeatureEnabledEnvs(apiFeature),
+    containsSecrets: false,
   };
 
   const emittedEvent = await createEvent(context.org.id, payload);

--- a/packages/back-end/src/routers/data-export/data-export.controller.ts
+++ b/packages/back-end/src/routers/data-export/data-export.controller.ts
@@ -23,7 +23,7 @@ export const getDataExportForEvents = async (
   const context = getContextFromReq(req);
   const { org } = context;
 
-  if (!context.permissions.canViewEvents()) {
+  if (!context.permissions.canViewAuditLogs()) {
     context.permissions.throwPermissionError();
   }
 

--- a/packages/back-end/src/routers/event-webhooks/event-webhooks.controller.ts
+++ b/packages/back-end/src/routers/event-webhooks/event-webhooks.controller.ts
@@ -302,6 +302,10 @@ export const createTestEventWebHook = async (
           name: req.name || "",
         }
       : null,
+    projects: [],
+    tags: [],
+    environments: [],
+    containsSecrets: false,
   };
 
   const emittedEvent = await createEvent(organizationId, payload);

--- a/packages/back-end/src/services/experimentNotifications.ts
+++ b/packages/back-end/src/services/experimentNotifications.ts
@@ -1,4 +1,4 @@
-import { getAffectedEnvsForExperiment } from "shared/util";
+import { includeExperimentInPayload } from "shared/util";
 import { Context } from "../models/BaseModel";
 import { createEvent } from "../models/EventModel";
 import { getExperimentById, updateExperiment } from "../models/ExperimentModel";
@@ -15,6 +15,7 @@ import {
 import { ExperimentReportResultDimension } from "../../types/report";
 import { ExperimentWarningNotificationPayload } from "../types/ExperimentNotification";
 import { IfEqual } from "../util/types";
+import { getEnvironmentIdsFromOrg } from "./organizations";
 
 // This ensures that the two types remain equal.
 
@@ -33,6 +34,10 @@ const dispatchEvent = async (
   experiment: ExperimentInterface,
   data: ExperimentWarningNotificationData
 ) => {
+  const changedEnvs = includeExperimentInPayload(experiment)
+    ? getEnvironmentIdsFromOrg(context.org)
+    : [];
+
   const payload: ExperimentWarningNotificationEvent = {
     event: "experiment.warning",
     object: "experiment",
@@ -44,7 +49,7 @@ const dispatchEvent = async (
       name: context.userName,
     },
     projects: [experiment.project || ""],
-    environments: getAffectedEnvsForExperiment({ experiment }),
+    environments: changedEnvs,
     tags: experiment.tags || [],
     containsSecrets: false,
   };

--- a/packages/back-end/src/services/users.ts
+++ b/packages/back-end/src/services/users.ts
@@ -203,6 +203,12 @@ export async function trackLoginForUser({
     data: {
       current: auditedData,
     },
+    projects: [],
+    tags: [],
+    environments: [],
+    // The event contains the ip, userAgent, etc. of users
+    // When marked as containing secrets, view access will be restricted to admins
+    containsSecrets: true,
   };
 
   try {

--- a/packages/front-end/components/Events/EventsPage/EventsPage.tsx
+++ b/packages/front-end/components/Events/EventsPage/EventsPage.tsx
@@ -41,7 +41,7 @@ export const EventsPage: FC<EventsPageProps> = ({
 }) => {
   const permissionsUtil = usePermissionsUtil();
 
-  if (!permissionsUtil.canViewEvents()) {
+  if (!permissionsUtil.canViewAuditLogs()) {
     return (
       <div className="container pagecontents">
         <div className="alert alert-danger">

--- a/packages/front-end/components/Layout/Layout.tsx
+++ b/packages/front-end/components/Layout/Layout.tsx
@@ -194,7 +194,7 @@ const navlinks: SidebarLinkProps[] = [
         name: "Logs",
         href: "/events",
         path: /^events/,
-        filter: ({ permissionsUtils }) => permissionsUtils.canViewEvents(),
+        filter: ({ permissionsUtils }) => permissionsUtils.canViewAuditLogs(),
       },
       {
         name: "Slack",

--- a/packages/front-end/services/UserContext.tsx
+++ b/packages/front-end/services/UserContext.tsx
@@ -92,7 +92,7 @@ export const DEFAULT_PERMISSIONS: Record<GlobalPermission, boolean> = {
   manageIntegrations: false,
   organizationSettings: false,
   superDeleteReport: false,
-  viewEvents: false,
+  viewAuditLog: false,
   readData: false,
   manageCustomRoles: false,
 };

--- a/packages/shared/src/permissions/permissions.constants.ts
+++ b/packages/shared/src/permissions/permissions.constants.ts
@@ -101,9 +101,9 @@ export const POLICY_PERMISSION_MAP: Record<Policy, Permission[]> = {
   TagsFullAccess: ["readData", "manageTags"],
   APIKeysFullAccess: ["readData", "manageApiKeys"],
   IntegrationsFullAccess: ["readData", "manageIntegrations"],
-  EventWebhooksFullAccess: ["readData", "manageEventWebhooks"],
+  EventWebhooksFullAccess: ["readData", "manageEventWebhooks", "viewAuditLog"],
   BillingFullAccess: ["readData", "manageBilling"],
-  AuditLogsFullAccess: ["readData", "viewEvents"],
+  AuditLogsFullAccess: ["readData", "viewAuditLog"],
   CustomRolesFullAccess: ["readData", "manageTeam", "manageCustomRoles"],
 };
 
@@ -497,7 +497,7 @@ export const GLOBAL_PERMISSIONS = [
   "manageSavedGroups",
   "manageArchetype",
   "manageCustomRoles",
-  "viewEvents",
+  "viewAuditLog",
 ] as const;
 
 export const ALL_PERMISSIONS = [
@@ -508,7 +508,7 @@ export const ALL_PERMISSIONS = [
 
 export const READ_ONLY_PERMISSIONS = [
   "readData",
-  "viewEvents",
+  "viewAuditLog",
   "runQueries",
   "addComments",
 ];

--- a/packages/shared/src/util/features.ts
+++ b/packages/shared/src/util/features.ts
@@ -19,6 +19,7 @@ import {
   Environment,
 } from "back-end/types/organization";
 import { ProjectInterface } from "back-end/types/project";
+import { ApiFeature } from "back-end/types/openapi";
 import { getValidDate } from "../dates";
 import { getMatchingRules, includeExperimentInPayload } from ".";
 
@@ -975,4 +976,15 @@ export function getDisallowedProjects(
   return allProjects.filter((p) =>
     getDisallowedProjectIds(projects, environment).includes(p.id)
   );
+}
+
+export function getApiFeatureEnabledEnvs(feature: ApiFeature) {
+  if (feature.archived) return [];
+  const envs = new Set<string>();
+  Object.entries(feature.environments).forEach(([env, settings]) => {
+    if (settings?.enabled) {
+      envs.add(env);
+    }
+  });
+  return Array.from(envs);
 }

--- a/packages/shared/test/permissions.test.ts
+++ b/packages/shared/test/permissions.test.ts
@@ -38,6 +38,8 @@ describe("Role permissions", () => {
   const envs = ["production"];
   const sdkConnection = { projects: [], environment: "" };
   const updates = {};
+  const event = { containsSecrets: false, projects: [] };
+  const secretEvent = { containsSecrets: true, projects: [] };
 
   it("has correct permissions for noaccess", () => {
     const p = getPermissions("noaccess");
@@ -127,7 +129,9 @@ describe("Role permissions", () => {
     expect(p.canViewCreateFactTableModal()).toBe(false);
     expect(p.canViewEditFactTableModal(projectsResource)).toBe(false);
     expect(p.canViewEventWebhook()).toBe(false);
-    expect(p.canViewEvents()).toBe(false);
+    expect(p.canViewAuditLogs()).toBe(false);
+    expect(p.canViewEvent(event)).toBe(false);
+    expect(p.canViewEvent(secretEvent)).toBe(false);
     expect(p.canViewExperimentModal()).toBe(false);
     expect(p.canViewFeatureModal()).toBe(false);
     expect(p.canViewIdeaModal()).toBe(false);
@@ -233,7 +237,9 @@ describe("Role permissions", () => {
     expect(p.canViewCreateFactTableModal()).toBe(false);
     expect(p.canViewEditFactTableModal(projectsResource)).toBe(false);
     expect(p.canViewEventWebhook()).toBe(false);
-    expect(p.canViewEvents()).toBe(false);
+    expect(p.canViewAuditLogs()).toBe(false);
+    expect(p.canViewEvent(event)).toBe(true);
+    expect(p.canViewEvent(secretEvent)).toBe(false);
     expect(p.canViewExperimentModal()).toBe(false);
     expect(p.canViewFeatureModal()).toBe(false);
     expect(p.canViewIdeaModal()).toBe(false);
@@ -339,7 +345,9 @@ describe("Role permissions", () => {
     expect(p.canViewCreateFactTableModal()).toBe(false);
     expect(p.canViewEditFactTableModal(projectsResource)).toBe(false);
     expect(p.canViewEventWebhook()).toBe(false);
-    expect(p.canViewEvents()).toBe(false);
+    expect(p.canViewAuditLogs()).toBe(false);
+    expect(p.canViewEvent(event)).toBe(true);
+    expect(p.canViewEvent(secretEvent)).toBe(false);
     expect(p.canViewExperimentModal()).toBe(false);
     expect(p.canViewFeatureModal()).toBe(false);
     expect(p.canViewIdeaModal()).toBe(false);
@@ -445,7 +453,9 @@ describe("Role permissions", () => {
     expect(p.canViewCreateFactTableModal()).toBe(false);
     expect(p.canViewEditFactTableModal(projectsResource)).toBe(false);
     expect(p.canViewEventWebhook()).toBe(false);
-    expect(p.canViewEvents()).toBe(false);
+    expect(p.canViewAuditLogs()).toBe(false);
+    expect(p.canViewEvent(event)).toBe(true);
+    expect(p.canViewEvent(secretEvent)).toBe(false);
     expect(p.canViewExperimentModal()).toBe(false);
     expect(p.canViewFeatureModal()).toBe(false);
     expect(p.canViewIdeaModal()).toBe(true);
@@ -551,7 +561,9 @@ describe("Role permissions", () => {
     expect(p.canViewCreateFactTableModal()).toBe(false);
     expect(p.canViewEditFactTableModal(projectsResource)).toBe(false);
     expect(p.canViewEventWebhook()).toBe(false);
-    expect(p.canViewEvents()).toBe(false);
+    expect(p.canViewAuditLogs()).toBe(false);
+    expect(p.canViewEvent(event)).toBe(true);
+    expect(p.canViewEvent(secretEvent)).toBe(false);
     expect(p.canViewExperimentModal()).toBe(false);
     expect(p.canViewFeatureModal()).toBe(true);
     expect(p.canViewIdeaModal()).toBe(true);
@@ -657,7 +669,9 @@ describe("Role permissions", () => {
     expect(p.canViewCreateFactTableModal()).toBe(true);
     expect(p.canViewEditFactTableModal(projectsResource)).toBe(true);
     expect(p.canViewEventWebhook()).toBe(false);
-    expect(p.canViewEvents()).toBe(false);
+    expect(p.canViewAuditLogs()).toBe(false);
+    expect(p.canViewEvent(event)).toBe(true);
+    expect(p.canViewEvent(secretEvent)).toBe(false);
     expect(p.canViewExperimentModal()).toBe(true);
     expect(p.canViewFeatureModal()).toBe(false);
     expect(p.canViewIdeaModal()).toBe(true);
@@ -763,7 +777,9 @@ describe("Role permissions", () => {
     expect(p.canViewCreateFactTableModal()).toBe(true);
     expect(p.canViewEditFactTableModal(projectsResource)).toBe(true);
     expect(p.canViewEventWebhook()).toBe(false);
-    expect(p.canViewEvents()).toBe(false);
+    expect(p.canViewAuditLogs()).toBe(false);
+    expect(p.canViewEvent(event)).toBe(true);
+    expect(p.canViewEvent(secretEvent)).toBe(false);
     expect(p.canViewExperimentModal()).toBe(true);
     expect(p.canViewFeatureModal()).toBe(true);
     expect(p.canViewIdeaModal()).toBe(true);
@@ -869,7 +885,9 @@ describe("Role permissions", () => {
     expect(p.canViewCreateFactTableModal()).toBe(true);
     expect(p.canViewEditFactTableModal(projectsResource)).toBe(true);
     expect(p.canViewEventWebhook()).toBe(true);
-    expect(p.canViewEvents()).toBe(true);
+    expect(p.canViewAuditLogs()).toBe(true);
+    expect(p.canViewEvent(event)).toBe(true);
+    expect(p.canViewEvent(secretEvent)).toBe(true);
     expect(p.canViewExperimentModal()).toBe(true);
     expect(p.canViewFeatureModal()).toBe(true);
     expect(p.canViewIdeaModal()).toBe(true);


### PR DESCRIPTION
### Features and Changes

Today, only admins can view an audit log of events for their org.  This makes sense for events like `user.login` - we don't want to expose the login ip/userAgent of everyone in the org to non-admins.  But for other events like `feature.updated`, it's too restrictive - we want users to be able to click from a Slack notification and view the event details without being admins.

This PR changes the logic for viewing event details.  There are some events that contain sensitive info (like `user.login`) that we want to keep admin-only.  But for everything else, we now use the event subject (e.g. the feature or experiment) to determine view access.  If a user is able to view an experiment, they are now also able to view events about that experiment.

1. Add new top-level fields to events: `projects`, `tags`, `environments`, and `containsSecrets`
2. Simplified webhook filtering logic to use these new fields
3. Replaced permission `viewEvents`/`canViewEvents` with `viewAuditLogs`/`canViewAuditLogs`
4. Added new permission function `canViewEvent(eventPayload)` that checks read permission based on the new top-level event fields.

Testing
- [x] Test webhook filtering on project/tag/environment for features
- [x] Test webhook filtering on project/tag/environment for experiments
- [x] Able to view non-sensitive events with `readonly` role
- [x] Only able to view sensitive events with `admin` role