### PR TITLE
Add owner and owner edit to fact metrics page

### DIFF
--- a/packages/front-end/components/Features/FeaturesOverview.tsx
+++ b/packages/front-end/components/Features/FeaturesOverview.tsx
@@ -1256,8 +1256,8 @@ export default function FeaturesOverview({
                 method: "PUT",
                 body: JSON.stringify({ owner }),
               });
-              mutate();
             }}
+            mutate={mutate}
           />
         )}
         {editValidator && (

--- a/packages/front-end/components/Owner/EditOwnerModal.tsx
+++ b/packages/front-end/components/Owner/EditOwnerModal.tsx
@@ -8,7 +8,8 @@ const EditOwnerModal: FC<{
   owner: string;
   save: (ownerName: string) => Promise<void>;
   cancel: () => void;
-}> = ({ owner, save, cancel }) => {
+  mutate: () => void;
+}> = ({ owner, save, cancel, mutate }) => {
   const { memberUsernameOptions } = useMembers();
   const form = useForm({
     defaultValues: {
@@ -23,6 +24,7 @@ const EditOwnerModal: FC<{
       close={cancel}
       submit={form.handleSubmit(async (data) => {
         await save(data.owner);
+        mutate();
       })}
       cta="Save"
     >

--- a/packages/front-end/pages/fact-metrics/[fmid].tsx
+++ b/packages/front-end/pages/fact-metrics/[fmid].tsx
@@ -32,6 +32,7 @@ import { capitalizeFirstLetter } from "@/services/utils";
 import MetricName from "@/components/Metrics/MetricName";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 import { MetricPriorRightRailSectionGroup } from "@/components/Metrics/MetricPriorRightRailSectionGroup";
+import EditOwnerModal from "@/components/Owner/EditOwnerModal";
 
 function FactTableLink({ id }: { id?: string }) {
   const { getFactTableById } = useDefinitions();
@@ -181,6 +182,7 @@ export default function FactMetricPage() {
 
   const [editProjectsOpen, setEditProjectsOpen] = useState(false);
   const [editTagsModal, setEditTagsModal] = useState(false);
+  const [editOwnerModal, setEditOwnerModal] = useState(false);
 
   const { apiCall } = useAuth();
 
@@ -255,6 +257,19 @@ export default function FactMetricPage() {
           }}
           mutate={mutateDefinitions}
           entityName="Metric"
+        />
+      )}
+      {editOwnerModal && (
+        <EditOwnerModal
+          cancel={() => setEditOwnerModal(false)}
+          owner={factMetric.owner}
+          save={async (owner) => {
+            await apiCall(`/fact-metrics/${factMetric.id}`, {
+              method: "PUT",
+              body: JSON.stringify({ owner }),
+            });
+          }}
+          mutate={mutateDefinitions}
         />
       )}
       {editTagsModal && (
@@ -345,6 +360,17 @@ export default function FactMetricPage() {
             <a
               className="ml-1 cursor-pointer"
               onClick={() => setEditTagsModal(true)}
+            >
+              <GBEdit />
+            </a>
+          )}
+        </div>
+        <div className="col-auto">
+          Owner:{` ${factMetric.owner ?? ""}`}
+          {canEdit && (
+            <a
+              className="ml-1 cursor-pointer"
+              onClick={() => setEditOwnerModal(true)}
             >
               <GBEdit />
             </a>

--- a/packages/front-end/pages/metric/[mid].tsx
+++ b/packages/front-end/pages/metric/[mid].tsx
@@ -342,8 +342,8 @@ const MetricPage: FC = () => {
               method: "PUT",
               body: JSON.stringify({ owner }),
             });
-            mutate();
           }}
+          mutate={mutate}
         />
       )}
       {segmentOpen && (


### PR DESCRIPTION
### Features and Changes

Adds fact metric owner to fact metric page, along with facility to update it and immediately refresh the page.

### Testing

* Loading both [mid] and [fmid] works with owner
* Can change owner on both metric types

### Screenshots

New fmid page (see at the top next to tags)

<img width="1402" alt="Screenshot 2024-05-16 at 11 12 43 AM" src="https://github.com/growthbook/growthbook/assets/5298599/0765575b-dd18-48da-80a9-d16cb9ee91c2">

<img width="819" alt="Screenshot 2024-05-16 at 11 12 47 AM" src="https://github.com/growthbook/growthbook/assets/5298599/0edf6bdc-a7ac-4245-947c-e3110686aa1d">

<img width="153" alt="Screenshot 2024-05-16 at 11 12 49 AM" src="https://github.com/growthbook/growthbook/assets/5298599/4eb3fd2b-2582-4af1-855b-026e6deb3e4b">
