### PR TITLE
Allow super admins to delete organizations

### DIFF
--- a/packages/back-end/src/app.ts
+++ b/packages/back-end/src/app.ts
@@ -686,6 +686,7 @@ app.get("/admin/organizations", adminController.getOrganizations);
 app.put("/admin/organization", adminController.putOrganization);
 app.get("/admin/organization/:orgId/users", adminController.getUsersForOrg);
 app.post("/admin/user/:userId", adminController.updateUser);
+app.delete("/admin/organization/:orgId", adminController.deleteOrganization);
 
 // License
 app.get("/license", licenseController.getLicenseData);

--- a/packages/back-end/src/controllers/admin.ts
+++ b/packages/back-end/src/controllers/admin.ts
@@ -6,6 +6,7 @@ import {
   findAllOrganizations,
   findOrganizationById,
   updateOrganization,
+  deleteOrganizationData,
 } from "../models/OrganizationModel";
 import {
   findUserById,
@@ -161,5 +162,32 @@ export async function updateUser(
 
   return res.status(200).json({
     updated,
+  });
+}
+
+export async function deleteOrganization(
+  req: AuthRequest<null, { orgId: string }>,
+  res: Response
+) {
+  if (!req.superAdmin)
+    return res.status(403).json({
+      status: 403,
+      message: "Only super admins can access this endpoint",
+    });
+
+  await deleteOrganizationData(req.params.orgId);
+
+  req.audit({
+    event: "organization.delete",
+    entity: {
+      object: "organization",
+      id: req.params.orgId,
+    },
+  });
+
+  return res.status(200).json({
+    status: 200,
+    message: "Organization and all related data deleted",
+    orgId: req.params.orgId,
   });
 }

--- a/packages/front-end/components/Admin/DeleteOrganizationModal.tsx
+++ b/packages/front-end/components/Admin/DeleteOrganizationModal.tsx
@@ -1,0 +1,63 @@
+import { useState, FC } from "react";
+import { useAuth } from "@/services/auth";
+import Modal from "@/components/Modal";
+
+const DeleteOrganization: FC<{
+  onDelete: () => void;
+  close?: () => void;
+  id: string;
+  currentName: string;
+}> = ({ onDelete, close, id, currentName }) => {
+  const [error, setError] = useState("");
+  const [name, setName] = useState("");
+
+  const { apiCall } = useAuth();
+
+  const handleSubmit = async () => {
+    try {
+      await apiCall<{
+        status: number;
+        message?: string;
+        orgId?: string;
+      }>(`/admin/organization/${id}`, {
+        method: "DELETE",
+      });
+      onDelete();
+    } catch (e) {
+      setError(`There was an error deleting the org: ${e.message}`);
+    }
+  };
+
+  return (
+    <Modal
+      error={error}
+      submit={handleSubmit}
+      open={true}
+      header={"Delete Organization"}
+      cta={"Delete"}
+      close={close}
+      ctaEnabled={name === currentName}
+    >
+      <p>
+        Are you <strong>absolutely sure</strong> that you want to delete this
+        organization? This data will be lost and will not be recoverable.
+      </p>
+      <div className="form-group alert alert-danger">
+        <p>
+          Please type the organization name to confirm:{" "}
+          <strong>{currentName}</strong>
+        </p>
+        <input
+          type="text"
+          className="form-control"
+          value={name}
+          required
+          minLength={3}
+          onChange={(e) => setName(e.target.value)}
+        />
+      </div>
+    </Modal>
+  );
+};
+
+export default DeleteOrganization;

--- a/packages/front-end/pages/admin/OrganizationRow.tsx
+++ b/packages/front-end/pages/admin/OrganizationRow.tsx
@@ -1,12 +1,19 @@
 import { useState } from "react";
 import { OrganizationInterface } from "@back-end/types/organization";
 import clsx from "clsx";
-import { FaAngleDown, FaAngleRight, FaPencilAlt } from "react-icons/fa";
+import {
+  FaAngleDown,
+  FaAngleRight,
+  FaPencilAlt,
+  FaTrash,
+} from "react-icons/fa";
 import { date } from "shared/dates";
 import stringify from "json-stringify-pretty-compact";
 import Collapsible from "react-collapsible";
+import { useLocalStorage } from "@/hooks/useLocalStorage";
 import EditOrganization from "@/components/Admin/EditOrganization";
 import Code from "@/components/SyntaxHighlighting/Code";
+import DeleteOrganizationModal from "@/components/Admin/DeleteOrganizationModal";
 import MembersTable from "./MembersTable";
 
 export default function OrganizationRow({
@@ -24,6 +31,11 @@ export default function OrganizationRow({
 }) {
   const [expanded, setExpanded] = useState(false);
   const [editOrgModalOpen, setEditOrgModalOpen] = useState(false);
+  const [deleteOrgModalOpen, setDeleteOrgModalOpen] = useState(false);
+  const [lastPickedOrg, setLastPickedOrg] = useLocalStorage(
+    "gb-last-picked-org",
+    ""
+  );
 
   const { settings, members, ...otherAttributes } = organization;
 
@@ -37,6 +49,17 @@ export default function OrganizationRow({
           currentLicenseKey={organization.licenseKey || ""}
           onEdit={onUpdate}
           close={() => setEditOrgModalOpen(false)}
+        />
+      )}
+      {deleteOrgModalOpen && (
+        <DeleteOrganizationModal
+          id={organization.id}
+          currentName={organization.name}
+          onDelete={() => {
+            if (lastPickedOrg === organization.id) setLastPickedOrg("");
+            window.location.reload();
+          }}
+          close={() => setDeleteOrgModalOpen(false)}
         />
       )}
       <tr
@@ -77,6 +100,17 @@ export default function OrganizationRow({
             style={{ lineHeight: "40px" }}
           >
             <FaPencilAlt />
+          </a>
+          <a
+            href="#"
+            className="w-100 h-100 mx-2 text-danger"
+            onClick={(e) => {
+              e.preventDefault();
+              setDeleteOrgModalOpen(true);
+            }}
+            style={{ lineHeight: "40px" }}
+          >
+            <FaTrash />
           </a>
         </td>
         <td style={{ width: 40 }} className="p-0 text-center">

--- a/packages/front-end/services/auth.tsx
+++ b/packages/front-end/services/auth.tsx
@@ -17,6 +17,7 @@ import {
 } from "back-end/types/sso-connection";
 import * as Sentry from "@sentry/react";
 import { roleSupportsEnvLimit } from "shared/permissions";
+import { useLocalStorage } from "@/hooks/useLocalStorage";
 import Modal from "@/components/Modal";
 import { DocLink } from "@/components/DocLink";
 import Welcome from "@/components/Auth/Welcome";
@@ -196,6 +197,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
   const [sessionError, setSessionError] = useState(false);
   const router = useRouter();
   const initialOrgId = router.query.org ? router.query.org + "" : null;
+  const [lastPickedOrg] = useLocalStorage("gb-last-picked-org", "");
 
   async function init() {
     const resp = await refreshToken();
@@ -374,10 +376,9 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
 
       if (orgs.length > 0) {
         try {
-          const pickedOrg = localStorage.getItem("gb-last-picked-org");
-          if (pickedOrg && !router.query.org) {
+          if (lastPickedOrg && !router.query.org) {
             try {
-              setOrgId(JSON.parse(pickedOrg));
+              setOrgId(lastPickedOrg);
             } catch (e) {
               setOrgId(orgs[0].id);
             }
@@ -389,7 +390,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
         }
       }
     },
-    [initialOrgId, orgId, router.query.org, specialOrg?.id]
+    [initialOrgId, orgId, router.query.org, specialOrg?.id, lastPickedOrg]
   );
 
   if (initError) {


### PR DESCRIPTION
Targets https://github.com/growthbook/growthbook/pull/2528

Changes
- Adds `DELETE /admin/organizations/:orgId` endpoint
	- Restricted to superAdmins
	- Appends 'organization.delete' event to audit log
- Adds relevant UI to super admin dashboard to delete orgs
	- Deleting an org requires confirmation	
- Fixes inconsistency with how we store `gb-last-picked-org` in browser's local storage

Tested locally
<img width="1824" alt="Screenshot 2024-05-16 at 1 18 44 PM" src="https://github.com/growthbook/growthbook/assets/2374625/737e9cfc-1ebd-483f-aff8-56f2eb6a89fc">

Confirmation modal
<img width="1624" alt="image" src="https://github.com/growthbook/growthbook/assets/2374625/75659a59-9ae0-43c2-882d-f053d0fa8196">

