### PR TITLE
Exp checklist permission mismatch bug.

### DIFF
--- a/packages/back-end/src/controllers/experimentLaunchChecklist.ts
+++ b/packages/back-end/src/controllers/experimentLaunchChecklist.ts
@@ -1,5 +1,6 @@
 import { Response } from "express";
 import { orgHasPremiumFeature } from "enterprise";
+import { ExperimentInterface } from "@back-end/types/experiment";
 import { getContextFromReq } from "../services/organizations";
 import { AuthRequest } from "../types/AuthRequest";
 import {
@@ -128,21 +129,24 @@ export async function putManualLaunchChecklist(
   const { id } = req.params;
   const { checklist } = req.body;
 
+  const changes: Partial<ExperimentInterface> = {
+    manualLaunchChecklist: checklist,
+  };
+
   const experiment = await getExperimentById(context, id);
 
   if (!experiment) {
     throw new Error("Could not find experiment");
   }
 
-  const updatedExperiment = { ...experiment, manualLaunchChecklist: checklist };
-  if (!context.permissions.canUpdateExperiment(experiment, updatedExperiment)) {
+  if (!context.permissions.canUpdateExperiment(experiment, changes)) {
     context.permissions.throwPermissionError();
   }
 
   await updateExperiment({
     context,
     experiment,
-    changes: { manualLaunchChecklist: checklist },
+    changes,
   });
 
   await req.audit({

--- a/packages/back-end/src/controllers/experimentLaunchChecklist.ts
+++ b/packages/back-end/src/controllers/experimentLaunchChecklist.ts
@@ -1,5 +1,4 @@
 import { Response } from "express";
-import { getAffectedEnvsForExperiment } from "shared/util";
 import { orgHasPremiumFeature } from "enterprise";
 import { getContextFromReq } from "../services/organizations";
 import { AuthRequest } from "../types/AuthRequest";

--- a/packages/back-end/src/controllers/experimentLaunchChecklist.ts
+++ b/packages/back-end/src/controllers/experimentLaunchChecklist.ts
@@ -134,7 +134,8 @@ export async function putManualLaunchChecklist(
     throw new Error("Could not find experiment");
   }
 
-  if (!context.permissions.canViewExperimentModal(experiment.project)) {
+  const updatedExperiment = { ...experiment, manualLaunchChecklist: checklist };
+  if (!context.permissions.canUpdateExperiment(experiment, updatedExperiment)) {
     context.permissions.throwPermissionError();
   }
 

--- a/packages/back-end/src/controllers/experimentLaunchChecklist.ts
+++ b/packages/back-end/src/controllers/experimentLaunchChecklist.ts
@@ -135,9 +135,7 @@ export async function putManualLaunchChecklist(
     throw new Error("Could not find experiment");
   }
 
-  const envs = experiment ? getAffectedEnvsForExperiment({ experiment }) : [];
-
-  if (!context.permissions.canRunExperiment(experiment, envs)) {
+  if (!context.permissions.canViewExperimentModal(experiment.project)) {
     context.permissions.throwPermissionError();
   }
 

--- a/packages/front-end/components/Experiment/PreLaunchChecklist.tsx
+++ b/packages/front-end/components/Experiment/PreLaunchChecklist.tsx
@@ -60,8 +60,7 @@ export function PreLaunchChecklist({
     hasCommercialFeature("custom-launch-checklist") &&
     permissionsUtil.canManageOrgSettings();
   const canEditExperiment =
-    !experiment.archived &&
-    permissionsUtil.canViewExperimentModal(experiment.project);
+    !experiment.archived && permissionsUtil.canUpdateExperiment(experiment, {});
 
   const { data } = useApi<{ checklist: ExperimentLaunchChecklistInterface }>(
     "/experiments/launch-checklist"


### PR DESCRIPTION
### Features and Changes

Our sentry logs indicated a user received an error when attempting to edit an experiment's checklist.

When digging in, it appeared that this error was thrown for an `analyst` user trying to update a manual checklist item on an experiment's checklist. After some digging, I found that on the frontend, when determining whether the user should have edit access, we were checking `canViewExperimentModal` which checks the `createAnalyses` permission, but on the backend, we were checking `canRunExperiment` which checks the `runExperiments` permission.

Looking at the roles and policies, an `analyst` is described as being able to create, edit, and delete experiments, so my understanding is the backend check we were doing was checking too high of a permission level.

This PR updates the backend to check the same permission that we're checking on the frontend so no users will get UI that says they can update, but the backend says otherwise.

### Testing

- [x] Ensure that analysts, experiments, and admins can edit manual checklist items, but no other roles.
