### PR TITLE
Experiment page permission fixes

### DIFF
--- a/packages/front-end/components/DemoDataSourcePage/DemoDataSourcePage.tsx
+++ b/packages/front-end/components/DemoDataSourcePage/DemoDataSourcePage.tsx
@@ -8,6 +8,7 @@ import { useDemoDataSourceProject } from "@/hooks/useDemoDataSourceProject";
 import { useUser } from "@/services/UserContext";
 import track from "@/services/track";
 import Button from "@/components/Button";
+import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 
 type DemoDataSourcePageProps = {
   error: string | null;
@@ -104,6 +105,15 @@ export function DeleteDemoDatasourceButton({
   const { apiCall } = useAuth();
   const { mutateDefinitions, setProject, project } = useDefinitions();
 
+  const demoProjectId = getDemoDatasourceProjectIdForOrganization(
+    organization.id
+  );
+
+  const permissionsUtil = usePermissionsUtil();
+  if (!permissionsUtil.canDeleteProject(demoProjectId)) {
+    return null;
+  }
+
   return (
     <DeleteButton
       displayName="Sample Data"
@@ -111,9 +121,6 @@ export function DeleteDemoDatasourceButton({
       text="Delete Sample Data"
       outline={false}
       onClick={async () => {
-        const demoProjectId = getDemoDatasourceProjectIdForOrganization(
-          organization.id
-        );
         track("Delete Sample Project", {
           source,
         });

--- a/packages/front-end/components/Experiment/AnalysisSettingsBar.tsx
+++ b/packages/front-end/components/Experiment/AnalysisSettingsBar.tsx
@@ -26,6 +26,7 @@ import { trackSnapshot } from "@/services/track";
 import VariationChooser from "@/components/Experiment/VariationChooser";
 import BaselineChooser from "@/components/Experiment/BaselineChooser";
 import DimensionChooser from "@/components/Dimensions/DimensionChooser";
+import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 import AnalysisForm from "./AnalysisForm";
 import ResultMoreMenu from "./ResultMoreMenu";
 import PhaseSelector from "./PhaseSelector";
@@ -62,7 +63,7 @@ export default function AnalysisSettingsBar({
   regressionAdjustmentAvailable?: boolean;
   regressionAdjustmentEnabled?: boolean;
   regressionAdjustmentHasValidMetrics?: boolean;
-  onRegressionAdjustmentChange?: (enabled: boolean) => void;
+  onRegressionAdjustmentChange?: (enabled: boolean) => Promise<void>;
   showMoreMenu?: boolean;
   variationFilter?: number[];
   setVariationFilter?: (variationFilter: number[]) => void;
@@ -90,6 +91,10 @@ export default function AnalysisSettingsBar({
   const hasRegressionAdjustmentFeature = hasCommercialFeature(
     "regression-adjustment"
   );
+
+  const permissionsUtil = usePermissionsUtil();
+  const canEditAnalysisSettings =
+    experiment && permissionsUtil.canUpdateExperiment(experiment, {});
 
   const [modalOpen, setModalOpen] = useState(false);
 
@@ -208,12 +213,17 @@ export default function AnalysisSettingsBar({
                         onRegressionAdjustmentChange &&
                         hasRegressionAdjustmentFeature
                       ) {
-                        onRegressionAdjustmentChange(value);
+                        onRegressionAdjustmentChange(value).catch((e) => {
+                          console.error(e);
+                        });
                       }
                     }}
                     className={`teal m-0`}
                     style={{ transform: "scale(0.8)" }}
-                    disabled={!hasRegressionAdjustmentFeature}
+                    disabled={
+                      !hasRegressionAdjustmentFeature ||
+                      !canEditAnalysisSettings
+                    }
                   />
                   {!regressionAdjustmentHasValidMetrics && (
                     <Tooltip

--- a/packages/front-end/components/Experiment/Results.tsx
+++ b/packages/front-end/components/Experiment/Results.tsx
@@ -45,7 +45,7 @@ const Results: FC<{
   regressionAdjustmentAvailable?: boolean;
   regressionAdjustmentEnabled?: boolean;
   regressionAdjustmentHasValidMetrics?: boolean;
-  onRegressionAdjustmentChange?: (enabled: boolean) => void;
+  onRegressionAdjustmentChange?: (enabled: boolean) => Promise<void>;
   variationFilter?: number[];
   setVariationFilter?: (variationFilter: number[]) => void;
   baselineRow?: number;

--- a/packages/front-end/components/Experiment/TabbedPage/AnalysisSettingsSummary.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/AnalysisSettingsSummary.tsx
@@ -79,6 +79,11 @@ export default function AnalysisSettingsSummary({
     phase,
   } = useSnapshot();
 
+  const canEditAnalysisSettings = permissionsUtil.canUpdateExperiment(
+    experiment,
+    {}
+  );
+
   const hasData = (analysis?.results?.[0]?.variations?.length ?? 0) > 0;
   const [refreshError, setRefreshError] = useState("");
 
@@ -224,15 +229,19 @@ export default function AnalysisSettingsSummary({
       )}
       <div className="row align-items-center text-muted">
         <div className="col-auto">
-          <a
-            href="#"
-            onClick={(e) => {
-              e.preventDefault();
-              setAnalysisModal(true);
-            }}
-          >
-            <span className="text-dark">Analysis Settings</span> <GBEdit />
-          </a>
+          {canEditAnalysisSettings ? (
+            <a
+              href="#"
+              onClick={(e) => {
+                e.preventDefault();
+                setAnalysisModal(true);
+              }}
+            >
+              <span className="text-dark">Analysis Settings</span> <GBEdit />
+            </a>
+          ) : (
+            <span>Analysis Settings</span>
+          )}
         </div>
         {items.map((item, i) => (
           <Tooltip

--- a/packages/front-end/components/Experiment/TabbedPage/HealthTab.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/HealthTab.tsx
@@ -235,6 +235,7 @@ export default function HealthTab({
           dataSource={datasource}
           exposureQuery={exposureQuery}
           healthTabConfigParams={healthTabConfigParams}
+          canConfigHealthTab={hasPermissionToConfigHealthTag}
         />
       </div>
 

--- a/packages/front-end/components/HealthTab/DimensionIssues.tsx
+++ b/packages/front-end/components/HealthTab/DimensionIssues.tsx
@@ -29,6 +29,7 @@ interface Props {
   exposureQuery?: ExposureQuery;
   variations: ExperimentReportVariation[];
   healthTabConfigParams: HealthTabConfigParams;
+  canConfigHealthTab: boolean;
 }
 
 type DimensionWithIssues = {
@@ -86,6 +87,7 @@ export const DimensionIssues = ({
   dataSource,
   exposureQuery,
   healthTabConfigParams,
+  canConfigHealthTab,
 }: Props) => {
   const { settings } = useUser();
   const [modalOpen, setModalOpen] = useState(false);
@@ -304,6 +306,7 @@ export const DimensionIssues = ({
             </div>
             {exposureQuery?.dimensions &&
             dataSource &&
+            canConfigHealthTab &&
             exposureQuery.dimensions.length > 0 ? (
               <div className="pt-4 d-flex justify-content-center">
                 <div>

--- a/packages/front-end/components/HealthTab/SRMDrawer.tsx
+++ b/packages/front-end/components/HealthTab/SRMDrawer.tsx
@@ -23,6 +23,7 @@ interface Props {
   dataSource: DataSourceInterfaceWithParams | null;
   exposureQuery?: ExposureQuery;
   healthTabConfigParams: HealthTabConfigParams;
+  canConfigHealthTab: boolean;
 }
 
 export const srmHealthCheck = ({
@@ -54,6 +55,7 @@ export default function SRMDrawer({
   dataSource,
   exposureQuery,
   healthTabConfigParams,
+  canConfigHealthTab,
 }: Props) {
   const { settings } = useUser();
 
@@ -160,6 +162,7 @@ export default function SRMDrawer({
             dataSource={dataSource}
             exposureQuery={exposureQuery}
             healthTabConfigParams={healthTabConfigParams}
+            canConfigHealthTab={canConfigHealthTab}
           />
         </div>
       </div>


### PR DESCRIPTION
### Features and Changes

Back-end permission checks are all working as expected.  This PR just updates the front-end to disable buttons in the UI that are just going to result in a back-end error.

Includes the following fixes:
- "Delete Demo Datasource" button showing up for users without permission to delete
- Users without update permission able to view and attempt to submit the Analysis Settings modal
- Users without update permission able to attempt to toggle CUPED on/off
- Uncaught errors in the CUPED toggle crashed the experiment page (permission errors or others)
- "Configure experiment dimension slices" showing up for users without permission