### PR TITLE
Must select value type of new feature instead of defaulting to Boolean

### DIFF
--- a/packages/front-end/components/Features/FeatureModal/ValueTypeField.tsx
+++ b/packages/front-end/components/Features/FeatureModal/ValueTypeField.tsx
@@ -11,15 +11,18 @@ const ValueTypeField: FC<{
       label="Value Type"
       value={value}
       onChange={onChange}
+      initialOption="Select Type..."
       options={[
         {
-          label: "boolean (true/false)",
+          label: "Boolean (true/false)",
           value: "boolean",
         },
-        { label: "number", value: "number" },
-        { label: "string", value: "string" },
+        { label: "String", value: "string" },
+        { label: "Number", value: "number" },
         { label: "JSON", value: "json" },
       ]}
+      required
+      sort={false}
     />
   );
 };

--- a/packages/front-end/components/Features/FeatureModal/ValueTypeField.tsx
+++ b/packages/front-end/components/Features/FeatureModal/ValueTypeField.tsx
@@ -11,7 +11,7 @@ const ValueTypeField: FC<{
       label="Value Type"
       value={value}
       onChange={onChange}
-      initialOption="Select Type..."
+      placeholder="Select Type..."
       options={[
         {
           label: "Boolean (true/false)",

--- a/packages/front-end/components/Features/FeatureModal/index.tsx
+++ b/packages/front-end/components/Features/FeatureModal/index.tsx
@@ -122,7 +122,7 @@ const genFormDefaultValues = ({
         environmentSettings,
       }
     : {
-        valueType: "boolean",
+        valueType: "" as FeatureValueType,
         defaultValue: getDefaultValue("boolean"),
         description: "",
         id: "",
@@ -197,7 +197,12 @@ export default function FeatureModal({
       secondaryCTA={secondaryCTA}
       submit={form.handleSubmit(async (values) => {
         const { defaultValue, ...feature } = values;
-        const valueType = feature.valueType as FeatureValueType;
+        const valueType = feature.valueType;
+
+        if (!valueType) {
+          throw new Error("Please select a value type");
+        }
+
         const passedFeature = feature as FeatureInterface;
         const newDefaultValue = validateFeatureValue(
           passedFeature,
@@ -310,7 +315,7 @@ export default function FeatureModal({
           decision of which rule to display (out of potentially many) in the
           modal is not deterministic.
       */}
-      {!featureToDuplicate && (
+      {!featureToDuplicate && valueType && (
         <>
           <FeatureValueField
             label={"Default Value when Enabled"}


### PR DESCRIPTION
### Features and Changes

When creating a new feature, we now require you to select the value type instead of defaulting to Boolean.

This addresses an issue where users mistakenly create Boolean flags for things they meant to be strings/json.  By forcing people to make a choice, we hope to reduce these accidents.

This PR also re-orders the value type options.  It now goes Boolean -> String -> Number -> JSON

New default modal view:

![image](https://github.com/growthbook/growthbook/assets/1087514/1bac8573-191f-4b3c-b4bc-0a7f804d13a1)