### PR TITLE
Add input validation to RoleForm

### DIFF
--- a/packages/front-end/components/Teams/Roles/RoleForm.tsx
+++ b/packages/front-end/components/Teams/Roles/RoleForm.tsx
@@ -60,8 +60,18 @@ export default function RoleForm({
 
   const saveSettings = form.handleSubmit(async (currentValue) => {
     setError(null);
+
+    if (!currentValue.id.length) {
+      setError("Name field is required");
+      return;
+    }
+
+    if (!/^[a-zA-Z0-9_]+$/.test(currentValue.id)) {
+      setError("Name field can only contain letters, numbers, and hyphens.");
+      return;
+    }
+
     try {
-      console.log("Hit save");
       if (status === "creating") {
         await apiCall("/custom-roles", {
           method: "POST",

--- a/packages/front-end/components/Teams/Roles/RoleForm.tsx
+++ b/packages/front-end/components/Teams/Roles/RoleForm.tsx
@@ -45,7 +45,7 @@ export default function RoleForm({
     }
 
     if (!/^[a-zA-Z0-9_]+$/.test(input.id)) {
-      setError("Name field can only contain letters, numbers, and hyphens.");
+      setError("Name can only contain letters, numbers, and underscores.");
       return false;
     }
     return true;

--- a/packages/front-end/components/Teams/Roles/RoleForm.tsx
+++ b/packages/front-end/components/Teams/Roles/RoleForm.tsx
@@ -29,6 +29,28 @@ export default function RoleForm({
     action
   );
 
+  const validateInputs = (input: {
+    id: string;
+    description: string;
+    policies: Policy[];
+  }): boolean => {
+    if (!input.id.length) {
+      setError("Name field is required");
+      return false;
+    }
+
+    if (RESERVED_ROLE_IDS.includes(input.id)) {
+      setError("That role id is reserved and cannot be used");
+      return false;
+    }
+
+    if (!/^[a-zA-Z0-9_]+$/.test(input.id)) {
+      setError("Name field can only contain letters, numbers, and hyphens.");
+      return false;
+    }
+    return true;
+  };
+
   const form = useForm<{
     id: string;
     description: string;
@@ -61,15 +83,7 @@ export default function RoleForm({
   const saveSettings = form.handleSubmit(async (currentValue) => {
     setError(null);
 
-    if (!currentValue.id.length) {
-      setError("Name field is required");
-      return;
-    }
-
-    if (!/^[a-zA-Z0-9_]+$/.test(currentValue.id)) {
-      setError("Name field can only contain letters, numbers, and hyphens.");
-      return;
-    }
+    if (!validateInputs(currentValue)) return;
 
     try {
       if (status === "creating") {

--- a/packages/front-end/components/Teams/Roles/RoleForm.tsx
+++ b/packages/front-end/components/Teams/Roles/RoleForm.tsx
@@ -103,7 +103,6 @@ export default function RoleForm({
           required
           autoFocus
           disabled={status !== "creating"}
-          autoComplete="company"
           maxLength={40}
           currentLength={currentValue.id.length}
           placeholder="Name your Custom Role"


### PR DESCRIPTION
### Features and Changes

Adds basic input validation to the `RoleForm` to prevent the roundtrip API call when we know an exception will be thown.

### Testing

- [x] Ensure a user can't submit the form with no `id` value set
- [x] Ensure a user can't submit the form to create a new role if the role is a reserved role id
- [x] Ensure a user can't submit the form to create a new role if the role id contains anything other than letters, numbers, or underscores
- [x] Ensure a user can submit the form to update a custom role and we don't do any validation on the role id (since it's not editable)

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
