### PR TITLE
Fix import experiment modal scrolling with long ids

### DIFF
--- a/packages/front-end/components/Experiment/ImportExperimentList.tsx
+++ b/packages/front-end/components/Experiment/ImportExperimentList.tsx
@@ -492,8 +492,12 @@ const ImportExperimentList: FC<{
 
                 return (
                   <tr key={key}>
-                    <td>{e.exposureQueryName}</td>
-                    <td>{e.experimentName || e.trackingKey}</td>
+                    <td style={{ wordBreak: "break-word" }}>
+                      {e.exposureQueryName}
+                    </td>
+                    <td style={{ wordBreak: "break-word" }}>
+                      {e.experimentName || e.trackingKey}
+                    </td>
                     <td>
                       <Tooltip
                         body={

--- a/packages/front-end/components/Experiment/ImportExperimentList.tsx
+++ b/packages/front-end/components/Experiment/ImportExperimentList.tsx
@@ -513,8 +513,8 @@ const ImportExperimentList: FC<{
                     <td>{date(e.endDate)}</td>
                     <td>{e.numVariations}</td>
                     <td>{numberFormatter.format(e.users)}</td>
-                    <td>
-                      {e.weights.map((w) => Math.round(w * 100)).join("/")}
+                    <td style={{ maxWidth: 180 }}>
+                      {e.weights.map((w) => Math.round(w * 100)).join(" / ")}
                     </td>
                     <td>
                       {existingId ? (


### PR DESCRIPTION
### Features and Changes

Long experiment ids or a large number of variations was causing the Import Experiments list to horizontally scroll, hiding the import button off screen.  This PR forces long columns to break onto multiple lines if required to keep everything on a single screen.