### PR TITLE
Added condition so owners of the personal token can see their persona…

### DIFF
--- a/packages/back-end/src/models/ApiKeyModel.ts
+++ b/packages/back-end/src/models/ApiKeyModel.ts
@@ -351,7 +351,10 @@ export async function getAllApiKeysByOrganization(
   });
 
   return keys.filter((k) => {
-    return context.permissions.canReadSingleProjectResource(k.project);
+    return (
+      context.permissions.canReadSingleProjectResource(k.project) ||
+      k.userId == context.userId
+    );
   });
 }
 

--- a/packages/back-end/src/models/ApiKeyModel.ts
+++ b/packages/back-end/src/models/ApiKeyModel.ts
@@ -353,7 +353,7 @@ export async function getAllApiKeysByOrganization(
   return keys.filter((k) => {
     return (
       context.permissions.canReadSingleProjectResource(k.project) ||
-      k.userId == context.userId
+      k.userId === context.userId
     );
   });
 }


### PR DESCRIPTION
### Features and Changes

Fixed Personal Token not visible to the user with no-access role.


- Closes **https://github.com/growthbook/growthbook/issues/2474**

### Testing

1. Create a Personal access token with a user
2. Assign this user a no-access role.
3. Check if the user can see their Personal Access Token.
