### PR TITLE
Fix: Remove brief error message, new sso users see on initial signing in

### DIFF
--- a/packages/front-end/services/UserContext.tsx
+++ b/packages/front-end/services/UserContext.tsx
@@ -192,7 +192,9 @@ export function UserContextProvider({ children }: { children: ReactNode }) {
     data: currentOrg,
     mutate: refreshOrganization,
     error: orgLoadingError,
-  } = useApi<OrgSettingsResponse>(isAuthenticated ? `/organization` : null);
+  } = useApi<OrgSettingsResponse>(
+    isAuthenticated && data?.userId ? `/organization` : null
+  );
 
   const [hashedOrganizationId, setHashedOrganizationId] = useState<string>("");
   useEffect(() => {
@@ -269,13 +271,13 @@ export function UserContextProvider({ children }: { children: ReactNode }) {
     };
   }, [orgId, data?.userId, role]);
 
-  // Refresh organization data when switching orgs or license key changes
+  // Refresh organization data when switching orgs or a new user gets an id.
   useEffect(() => {
-    if (orgId) {
+    if (orgId && data?.userId) {
       void refreshOrganization();
       track("Organization Loaded");
     }
-  }, [orgId, refreshOrganization]);
+  }, [orgId, data?.userId, refreshOrganization]);
 
   // Once authenticated, get userId, orgId from API
   useEffect(() => {


### PR DESCRIPTION
### Features and Changes
Fixes a temporary error message from showing where, for new SSO users, we were calling /organization before the new user was actually created.  We now wait for /user endpoint to complete before calling /organization.  We were already waiting for /auth/refresh to complete before calling organization, so it shouldn't slow things down too much in the general case where there isn't a new user.

### Testing

#### Set up
- Set up a backend/.env.local with 
```
SSO_CONFIG=<A Valid SSO config>
IS_MULTI_ORG=true, 
LICENSE_KEY=a valid enterprise license key
```

- Set up frontend/.env.local with 
```
ALLOW_SELF_ORG_CREATION=true
IS_MULTI_ORG=true
```

- Have an organization in mongo with verifiedDomain="growthbook.io"
- Remove your growthbook.io user from all organizations in mongo (You might need to log in on a personal account first, and make them admin.)

#### Test
- Go to localhost:3000 and sign in via Google SSO.
- Choose your growthbook.io email account.
- See "Invitation Required" message directly. (Before this change it would briefly show an error message saying "Error Signing in: Must be authenticated. Try refreshing the page.")