### PR TITLE
Fix legacy webhooks bug

### DIFF
--- a/packages/back-end/src/models/WebhookModel.ts
+++ b/packages/back-end/src/models/WebhookModel.ts
@@ -74,7 +74,7 @@ export async function findAllLegacySdkWebhooks(
   return (
     await WebhookModel.find({
       organization: context.org.id,
-      useSdkMode: false,
+      useSdkMode: { $ne: true },
     })
   ).map((e) => toInterface(e));
 }


### PR DESCRIPTION
### Features and Changes

Old legacy SDK webhooks that were missing `sdkMode: false` in Mongo were not being triggered.  Changed the condition to check `sdkMode: {$ne: true}` instead.