### PR TITLE
Add guardrails to CSV export

### DIFF
--- a/packages/front-end/components/Experiment/AnalysisSettingsBar.tsx
+++ b/packages/front-end/components/Experiment/AnalysisSettingsBar.tsx
@@ -290,7 +290,10 @@ export default function AnalysisSettingsBar({
                 queryError={snapshot?.error}
                 supportsNotebooks={!!datasource?.settings?.notebookRunQuery}
                 hasData={hasData}
-                metrics={experiment.metrics}
+                metrics={[
+                  ...experiment.metrics,
+                  ...(experiment.guardrails || []),
+                ]}
                 results={analysis?.results}
                 variations={variations}
                 trackingKey={experiment.trackingKey}

--- a/packages/front-end/components/Experiment/TabbedPage/AnalysisSettingsSummary.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/AnalysisSettingsSummary.tsx
@@ -495,7 +495,7 @@ export default function AnalysisSettingsSummary({
             queryError={snapshot?.error}
             supportsNotebooks={!!datasource?.settings?.notebookRunQuery}
             hasData={hasData}
-            metrics={experiment.metrics}
+            metrics={[...experiment.metrics, ...(experiment.guardrails || [])]}
             results={analysis?.results}
             variations={variations}
             trackingKey={experiment.trackingKey}

--- a/packages/front-end/pages/report/[rid].tsx
+++ b/packages/front-end/pages/report/[rid].tsx
@@ -407,10 +407,12 @@ export default function ReportPage() {
                     notebookFilename={report.title}
                     queries={report.queries}
                     queryError={report.error}
-                    // @ts-expect-error TS(2532) If you come across this, please fix it!: Object is possibly 'undefined'.
-                    results={report.results.dimensions}
+                    results={report.results?.dimensions}
                     variations={variations}
-                    metrics={report.args.metrics}
+                    metrics={[
+                      ...report.args.metrics,
+                      ...(report.args.guardrails || []),
+                    ]}
                     trackingKey={report.title}
                     project={experimentData?.experiment.project || ""}
                   />


### PR DESCRIPTION
Previously, guardrails were not included in CSV exports as the code to generate the CSV just looped over the `experiment.metrics`. Now it loops over both `metrics` and `guardrails`.