### PR TITLE
Fix Member's Page Horizontal Scroll

### DIFF
--- a/packages/front-end/components/Settings/Team/InviteList.tsx
+++ b/packages/front-end/components/Settings/Team/InviteList.tsx
@@ -148,109 +148,111 @@ const InviteList: FC<{
       />
       {resending && <LoadingOverlay />}
       {resendMessage}
-      <table className="table appbox gbtable table-hover">
-        <thead>
-          <tr>
-            <th>Email</th>
-            <th>Date Invited</th>
-            <th>{project ? "Project Role" : "Global Role"}</th>
-            {!project && <th>Project Roles</th>}
-            {environments.map((env) => (
-              <th key={env.id}>{env.id}</th>
-            ))}
-            <th style={{ width: 50 }} />
-          </tr>
-        </thead>
-        <tbody>
-          {invites.map(({ email, key, dateCreated, ...member }) => {
-            const roleInfo =
-              (project &&
-                member.projectRoles?.find((r) => r.project === project)) ||
-              member;
-            return (
-              <tr key={key}>
-                <td>{email}</td>
-                <td>{datetime(dateCreated)}</td>
-                <td>{roleInfo.role}</td>
-                {!project && (
-                  <td className="col-3">
-                    {member.projectRoles?.map((pr) => {
-                      const p = projects.find((p) => p.id === pr.project);
-                      if (p?.name) {
-                        return (
-                          <div key={`project-tags-${p.id}`}>
-                            <ProjectBadges
-                              resourceType="member"
-                              projectIds={[p.id]}
-                              className="badge-ellipsis short align-middle font-weight-normal"
-                            />{" "}
-                            — {pr.role}
-                          </div>
-                        );
-                      }
-                      return null;
-                    })}
-                  </td>
-                )}
-                {environments.map((env) => {
-                  const access = roleHasAccessToEnv(
-                    roleInfo,
-                    env.id,
-                    organization
-                  );
-                  return (
-                    <td key={env.id}>
-                      {access === "N/A" ? (
-                        <span className="text-muted">N/A</span>
-                      ) : access === "yes" ? (
-                        <FaCheck className="text-success" />
-                      ) : (
-                        <FaTimes className="text-danger" />
-                      )}
+      <div style={{ overflowY: "auto" }}>
+        <table className="table appbox gbtable table-hover">
+          <thead>
+            <tr>
+              <th>Email</th>
+              <th>Date Invited</th>
+              <th>{project ? "Project Role" : "Global Role"}</th>
+              {!project && <th>Project Roles</th>}
+              {environments.map((env) => (
+                <th key={env.id}>{env.id}</th>
+              ))}
+              <th style={{ width: 50 }} />
+            </tr>
+          </thead>
+          <tbody>
+            {invites.map(({ email, key, dateCreated, ...member }) => {
+              const roleInfo =
+                (project &&
+                  member.projectRoles?.find((r) => r.project === project)) ||
+                member;
+              return (
+                <tr key={key}>
+                  <td>{email}</td>
+                  <td>{datetime(dateCreated)}</td>
+                  <td>{roleInfo.role}</td>
+                  {!project && (
+                    <td className="col-3">
+                      {member.projectRoles?.map((pr) => {
+                        const p = projects.find((p) => p.id === pr.project);
+                        if (p?.name) {
+                          return (
+                            <div key={`project-tags-${p.id}`}>
+                              <ProjectBadges
+                                resourceType="member"
+                                projectIds={[p.id]}
+                                className="badge-ellipsis short align-middle font-weight-normal"
+                              />{" "}
+                              — {pr.role}
+                            </div>
+                          );
+                        }
+                        return null;
+                      })}
                     </td>
-                  );
-                })}
-                <td>
-                  <MoreMenu>
-                    <button
-                      className="dropdown-item"
-                      onClick={(e) => {
-                        e.preventDefault();
-                        setRoleModal({
-                          key,
-                          displayInfo: email,
-                          roleInfo,
-                        });
-                      }}
-                    >
-                      Edit Role
-                    </button>
-                    <button
-                      className="dropdown-item"
-                      onClick={(e) => {
-                        e.preventDefault();
-                        onResend(key, email);
-                      }}
-                    >
-                      Resend Invite
-                    </button>
-                    <button
-                      className="dropdown-item"
-                      onClick={(e) => {
-                        e.preventDefault();
-                        setDeleteInvite({ email, key });
-                        setResendMessage(null);
-                      }}
-                    >
-                      Remove
-                    </button>
-                  </MoreMenu>
-                </td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
+                  )}
+                  {environments.map((env) => {
+                    const access = roleHasAccessToEnv(
+                      roleInfo,
+                      env.id,
+                      organization
+                    );
+                    return (
+                      <td key={env.id}>
+                        {access === "N/A" ? (
+                          <span className="text-muted">N/A</span>
+                        ) : access === "yes" ? (
+                          <FaCheck className="text-success" />
+                        ) : (
+                          <FaTimes className="text-danger" />
+                        )}
+                      </td>
+                    );
+                  })}
+                  <td>
+                    <MoreMenu>
+                      <button
+                        className="dropdown-item"
+                        onClick={(e) => {
+                          e.preventDefault();
+                          setRoleModal({
+                            key,
+                            displayInfo: email,
+                            roleInfo,
+                          });
+                        }}
+                      >
+                        Edit Role
+                      </button>
+                      <button
+                        className="dropdown-item"
+                        onClick={(e) => {
+                          e.preventDefault();
+                          onResend(key, email);
+                        }}
+                      >
+                        Resend Invite
+                      </button>
+                      <button
+                        className="dropdown-item"
+                        onClick={(e) => {
+                          e.preventDefault();
+                          setDeleteInvite({ email, key });
+                          setResendMessage(null);
+                        }}
+                      >
+                        Remove
+                      </button>
+                    </MoreMenu>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 };

--- a/packages/front-end/components/Settings/Team/MemberList.tsx
+++ b/packages/front-end/components/Settings/Team/MemberList.tsx
@@ -108,8 +108,12 @@ const MemberList: FC<{
             )}
           </div>
         </div>
-        {/* @ts-expect-error TS(2322) If you come across this, please fix it!: Type '{ maxHeight: number; overflowY: "auto"; } | ... Remove this comment to see the full error message */}
-        <div style={maxHeight ? { maxHeight, overflowY: "auto" } : null}>
+        <div
+          style={{
+            overflowY: "auto",
+            ...(maxHeight ? { maxHeight } : {}),
+          }}
+        >
           <table className="table appbox gbtable">
             <thead>
               <tr>


### PR DESCRIPTION
### Features and Changes

When viewing the `MembersList` and `InviteList` on `/settings/team` if the org has a decent number of environments, it was causing a weird horizontal scroll for the Members and Invites table.

It looks like we had some `overflowY: "auto"` styling in place, but it was only being applied to the `MembersList` when there was a `maxHeight` set.

Now, this is always being set. This is definitely not the ideal permanent solution, but I know there is a mock of a redesigned Members page, so this is just an attempt to fix what is otherwise a visual bug until we do that redesign.

This page needs a little love - I've outlined 1 issue with it here for tracking purposes - https://github.com/growthbook/growthbook/issues/2581.

### Screenshots

Before:
<img width="1539" alt="Screen Shot 2024-05-29 at 2 22 51 PM" src="https://github.com/growthbook/growthbook/assets/75274610/bdda3ab6-17e3-4828-9c88-2e2b3c6b2221">

(And after scrolling)
<img width="1545" alt="Screen Shot 2024-05-29 at 2 22 59 PM" src="https://github.com/growthbook/growthbook/assets/75274610/3bde9066-6137-47af-b80f-9b1ce2959130">

After:
<img width="1545" alt="Screen Shot 2024-05-29 at 2 22 12 PM" src="https://github.com/growthbook/growthbook/assets/75274610/bc3ac2c4-8900-49a8-82ea-9b5f8b491ee1">
