### PR TITLE
Show license info in cloud admin view

### DIFF
--- a/packages/back-end/src/controllers/license.ts
+++ b/packages/back-end/src/controllers/license.ts
@@ -28,10 +28,11 @@ import { updateSubscriptionInDb } from "../services/stripe";
  * want to restart their servers.
  */
 export async function getLicenseData(req: AuthRequest, res: Response) {
-  const context = getContextFromReq(req);
-
-  if (!context.permissions.canManageBilling()) {
-    context.permissions.throwPermissionError();
+  if (!req.superAdmin) {
+    const context = getContextFromReq(req);
+    if (!context.permissions.canManageBilling()) {
+      context.permissions.throwPermissionError();
+    }
   }
 
   let licenseData;

--- a/packages/front-end/pages/admin.tsx
+++ b/packages/front-end/pages/admin.tsx
@@ -49,7 +49,7 @@ function OrganizationRow({
   const { apiCall } = useAuth();
 
   useEffect(() => {
-    if (expanded && !license) {
+    if (isCloud() && expanded && !license) {
       const fetchLicense = async () => {
         setLicenseLoading(true);
         const res = await apiCall<{
@@ -140,7 +140,7 @@ function OrganizationRow({
       </tr>
       {expanded && (
         <tr>
-          <td colSpan={6} className="bg-light">
+          <td colSpan={isCloud() ? 6 : 7} className="bg-light">
             <div className="mb-3">
               <h3>Info</h3>
               <Code language="json" code={stringify(otherAttributes)} />
@@ -167,23 +167,24 @@ function OrganizationRow({
             >
               <Code language="json" code={stringify(members)} />
             </Collapsible>
-
-            <div className="mt-3">
-              <Collapsible
-                trigger={
-                  <h3>
-                    License <FaAngleRight className="chevron" />
-                  </h3>
-                }
-                transitionTime={150}
-              >
-                {licenseLoading && <FaSpinner />}
-                {(license && (
-                  <Code language="json" code={stringify(license)} />
-                )) ||
-                  "No license found for this organization."}
-              </Collapsible>
-            </div>
+            {isCloud() && (
+              <div className="mt-3">
+                <Collapsible
+                  trigger={
+                    <h3>
+                      License <FaAngleRight className="chevron" />
+                    </h3>
+                  }
+                  transitionTime={150}
+                >
+                  {licenseLoading && <FaSpinner />}
+                  {(license && (
+                    <Code language="json" code={stringify(license)} />
+                  )) ||
+                    "No license found for this organization."}
+                </Collapsible>
+              </div>
+            )}
           </td>
         </tr>
       )}

--- a/packages/front-end/pages/admin.tsx
+++ b/packages/front-end/pages/admin.tsx
@@ -7,10 +7,12 @@ import {
   FaPencilAlt,
   FaPlus,
   FaSearch,
+  FaSpinner,
 } from "react-icons/fa";
 import { date } from "shared/dates";
 import stringify from "json-stringify-pretty-compact";
 import Collapsible from "react-collapsible";
+import { LicenseInterface } from "enterprise";
 import Field from "@/components/Forms/Field";
 import Pagination from "@/components/Pagination";
 import { useUser } from "@/services/UserContext";
@@ -42,6 +44,33 @@ function OrganizationRow({
   const [editOrgModalOpen, setEditOrgModalOpen] = useState(false);
 
   const { settings, members, ...otherAttributes } = organization;
+  const [license, setLicense] = useState<LicenseInterface | null>(null);
+  const [licenseLoading, setLicenseLoading] = useState(false);
+  const { apiCall } = useAuth();
+
+  useEffect(() => {
+    if (expanded && !license) {
+      const fetchLicense = async () => {
+        setLicenseLoading(true);
+        const res = await apiCall<{
+          status: number;
+          licenseData: LicenseInterface;
+        }>(`/license`, {
+          method: "GET",
+          headers: { "X-Organization": organization.id },
+        });
+
+        setLicenseLoading(false);
+        if (res.status !== 200) {
+          throw new Error("There was an error fetching the license");
+        }
+
+        setLicense(res.licenseData);
+      };
+
+      fetchLicense();
+    }
+  }, [expanded, apiCall, license, organization]);
 
   return (
     <>
@@ -111,7 +140,7 @@ function OrganizationRow({
       </tr>
       {expanded && (
         <tr>
-          <td colSpan={5} className="bg-light">
+          <td colSpan={6} className="bg-light">
             <div className="mb-3">
               <h3>Info</h3>
               <Code language="json" code={stringify(otherAttributes)} />
@@ -138,6 +167,23 @@ function OrganizationRow({
             >
               <Code language="json" code={stringify(members)} />
             </Collapsible>
+
+            <div className="mt-3">
+              <Collapsible
+                trigger={
+                  <h3>
+                    License <FaAngleRight className="chevron" />
+                  </h3>
+                }
+                transitionTime={150}
+              >
+                {licenseLoading && <FaSpinner />}
+                {(license && (
+                  <Code language="json" code={stringify(license)} />
+                )) ||
+                  "No license found for this organization."}
+              </Collapsible>
+            </div>
           </td>
         </tr>
       )}
@@ -263,7 +309,7 @@ const Admin: FC = () => {
       {error && <div className="alert alert-danger">{error}</div>}
       <div className="position-relative">
         {loading && <LoadingOverlay />}
-        <table className="table appbox">
+        <table className="table appbox" style={{ tableLayout: "fixed" }}>
           <thead>
             <tr>
               <th>Name</th>
@@ -271,8 +317,8 @@ const Admin: FC = () => {
               <th>Created</th>
               <th>Id</th>
               {!isCloud() && <th>External Id</th>}
-              <th></th>
-              <th></th>
+              <th style={{ width: "14px" }}></th>
+              <th style={{ width: "40px" }}></th>
             </tr>
           </thead>
           <tbody>


### PR DESCRIPTION
### Features and Changes
When we update a cloud license in Retool, we need a way to refresh the mongo cache of their license in the growthbook app.  It would also be good for superAdmin's to be able to see the license data that it took.  So now we do a force refresh of the license when an org is expanded in the admin view, and show that info.  

Since the license checksum can be very long and lived in a table, it ended up expanding the size of the table, so we had to change the `tableLayout` to `fixed`, which then caused all columns to be equal width, so had to narrow the action columns to the width of their icon's to look correct.

- Allows license get endpoint to be viewed by superAdmins.
- Calls the license get endpoint when expanding an organization.
- Displays the license data on cloud.
- Fixes the expanded column width, to be the correct number of columns that the table has.

### Testing

In the `.env.local` files set 
```
IS_MULTI_ORG=true
IS_CLOUD=true
```
Restart the server
Login as a super admin that is not a member of every organization.
Set a licenseKey on an org that the superAdmin is not a member of in Mongosh.
On the /admin page expand the org
Expand the license collapsible and see the license data.
Expand another org that has no licenseKey set.
Expand the license collapsible and see it say there is no license data.
See that the expanded `td` width is the entire table width.

In the `.env.local` files set 
```
IS_MULTI_ORG=true
IS_CLOUD=false
```
Restart the server
Login as a super admin 
Go to /admin page and expand any org
See no License section.
See that the expanded `td` width is the entire table width.

### Screenshots
![Screenshot 2024-05-30 at 5 53 38 PM](https://github.com/growthbook/growthbook/assets/950231/1528a695-1307-481c-a70c-df454ff136d3)


