### PR TITLE
replace deprecated argument to poetry

### DIFF
--- a/packages/stats/package.json
+++ b/packages/stats/package.json
@@ -7,7 +7,7 @@
     "lint": ". $(poetry env info --path)/bin/activate && black gbstats tests && flake8 && pyright gbstats",
     "lint:ci": ". $(poetry env info --path)/bin/activate && black gbstats tests --check && flake8 && pyright gbstats",
     "setup": "poetry install",
-    "build:export": "poetry export -f requirements.txt --output requirements.txt && poetry export --dev -f requirements.txt --output dev-requirements.txt",
+    "build:export": "poetry export -f requirements.txt --output requirements.txt && poetry export --with dev -f requirements.txt --output dev-requirements.txt",
     "build": "poetry build && yarn build:export",
     "notebook": ". $(poetry env info --path)/bin/activate && jupyter notebook"
   }


### PR DESCRIPTION
### Features and Changes

There was a deprecated `--dev` argument to poetry with a deprecation message to use `--with dev` instead which this PR does.

### Testing

`yarn build` See no deprecation message or any warnings/errors.