### PR TITLE
BUG - InAppChat not rendering for paid cloud users

### DIFF
--- a/packages/front-end/components/Auth/InAppHelp.tsx
+++ b/packages/front-end/components/Auth/InAppHelp.tsx
@@ -11,7 +11,7 @@ export default function InAppHelp() {
   const config = useFeature("pylon-config").value;
   const [showFreeHelpWidget, setShowFreeHelpWidget] = useState(false);
   const [upgradeModal, setUpgradeModal] = useState(false);
-  const { name, email, hasCommercialFeature } = useUser();
+  const { name, email, hasCommercialFeature, commercialFeatures } = useUser();
   const showUpgradeModal = !hasCommercialFeature("livechat") && isCloud();
 
   useEffect(() => {
@@ -30,7 +30,7 @@ export default function InAppHelp() {
         },
       };
     }
-  }, [config]);
+  }, [config, commercialFeatures]);
 
   // If the Pylon key exists on the window, we're showing the Pylon widget, so don't show the freeHelpModal
   if (window["pylon"]) return null;


### PR DESCRIPTION
### Features and Changes
Recently, the Pylon In-App chat widget stopped rendering for paid cloud users. After doing some testing, the `hasCommercialFeature` check within `InAppHelp.tsx` was returning false on the initial render, and then never re-evaluating.

Updating the dependency array so the useEffect hook runs anytime the `config` object or the org's `commercialFeatures` array updates resolves the issue.

The underlying cause is still TBD. Given that, I'd ultimately like to identify that underlying cause as that could change the fix for this.

### Testing

- [x] Ensure the in-app help chat widget only renders on the page for paid cloud users.
