### PR TITLE
Change the default for ALLOW_SELF_ORG_CREATION to be false

### DIFF
--- a/packages/front-end/pages/api/init.ts
+++ b/packages/front-end/pages/api/init.ts
@@ -82,7 +82,7 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
     cdnHost: CDN_HOST || "",
     cloud: stringToBoolean(IS_CLOUD),
     isMultiOrg: stringToBoolean(IS_MULTI_ORG),
-    allowSelfOrgCreation: stringToBoolean(ALLOW_SELF_ORG_CREATION, true), // Default to true
+    allowSelfOrgCreation: stringToBoolean(ALLOW_SELF_ORG_CREATION),
     config: hasConfigFile ? "file" : "db",
     allowCreateMetrics: !hasConfigFile || stringToBoolean(ALLOW_CREATE_METRICS),
     build,

--- a/packages/front-end/services/env.ts
+++ b/packages/front-end/services/env.ts
@@ -5,7 +5,7 @@ const env: EnvironmentInitValue = {
   telemetry: "enable",
   cloud: false,
   isMultiOrg: false,
-  allowSelfOrgCreation: true,
+  allowSelfOrgCreation: false,
   appOrigin: "",
   apiHost: "",
   s3domain: "",


### PR DESCRIPTION
### Features and Changes
We want to update the default value of ALLOW_SELF_ORG_CREATION to be false as that is what most self-hosted multi-orgs will want. 

### Dependencies
On cloud however we need it to be true. We need to land https://github.com/growthbook/terraform/pull/27 before this and make sure it successfully deploys.

### Testing
Set the following env var: 
```
IS_MULTI_ORG=true
```
Login as a new user.
See "You must be invited by an administrator in order to use GrowthBook." message.

