### PR TITLE
Save agenda job meterics under a combined metric name, with a jobname label

### DIFF
--- a/packages/back-end/src/services/otel.ts
+++ b/packages/back-end/src/services/otel.ts
@@ -33,14 +33,14 @@ export const trackJob = (
 
   // init metrics
   try {
-    counter = getUpDownCounter(`jobs.${jobName}.running_count`);
-    counter.add(1);
+    counter = getUpDownCounter(`jobs.running_count`);
+    counter.add(1, { jobName });
     hasMetricsStarted = true;
   } catch (e) {
     logger.error(`error init'ing counter for job: ${jobName}: ${e}`);
   }
   try {
-    histogram = getHistogram(`jobs.${jobName}.duration`);
+    histogram = getHistogram(`jobs.duration`);
   } catch (e) {
     logger.error(`error init'ing histogram for job: ${jobName}: ${e}`);
   }
@@ -48,13 +48,13 @@ export const trackJob = (
   // wrap up metrics function, to be called at the end of the job
   const wrapUpMetrics = () => {
     try {
-      histogram?.record(new Date().getTime() - startTime);
+      histogram?.record(new Date().getTime() - startTime, { jobName });
     } catch (e) {
       logger.error(`error recording duration metric for job: ${jobName}: ${e}`);
     }
     if (!hasMetricsStarted) return;
     try {
-      counter.add(-1);
+      counter.add(-1, { jobName });
     } catch (e) {
       logger.error(`error decrementing count metric for job: ${jobName}: ${e}`);
     }
@@ -68,7 +68,7 @@ export const trackJob = (
     logger.error(`error running job: ${jobName}: ${e}`);
     try {
       wrapUpMetrics();
-      getCounter(`jobs.${jobName}.errors`).add(1);
+      getCounter(`jobs.errors`).add(1, { jobName });
     } catch (e) {
       logger.error(`error wrapping up metrics: ${jobName}: ${e}`);
     }
@@ -78,7 +78,7 @@ export const trackJob = (
   // on successful job
   try {
     wrapUpMetrics();
-    getCounter(`jobs.${jobName}.successes`).add(1);
+    getCounter(`jobs.successes`).add(1, { jobName });
   } catch (e) {
     logger.error(`error wrapping up metrics: ${jobName}: ${e}`);
   }


### PR DESCRIPTION
### Features and Changes
We had given each job it's own metric name such as `jobs.fireWebhooks.successes`. That makes it a bit harder to create nice graphs in Datadog.  Having them all post to `jobs.successes` and then sending a label `jobname=fireWebhooks` with it is more flexible.  You can create just a single metric graph and use template variables to see a dashboard of the different jobs. 

This PR does that.

I had considered adding these as additional metrics.  However some providers such as Datadog can charge per unique custom metric, so this would have double the cost.  Furthermore, these metrics weren't working until recently, so few if any clients will have been monitoring them until now.

### Testing

Set up a datadog Agent locally.  Hit some pages and saw the metrics appearing on datadog.:
https://us5.datadoghq.com/metric/explorer?fromUser=false&start=1717691101447&end=1717691401447&paused=false#N4Ig7glgJg5gpgFxALlAGwIYE8D2BXJVEADxQEYAaELcqyKBAC1pEbghkcLIF8qo4AMwgA7CAgg4RKUAiwAHOChASAtnADOcAE4RNIKtrgBHPJoQaUAbVBGN8qVoD6gnNtUZCKiOq279VKY6epbINiAiGOrKQdpYZAYgUJ4YThr42gDGSsgg6gi6mZaBZnHKGniqyABWOABGGgB0FZnZGloawH4AbhDZNVGaALQY8hA8AAR1WBPAtXWR6jyNGBpOmfgiCAAUAJQgPAC6VK7ueJih4aeq5xgxpfEHxyAacmg5oPIY7wgIOUk4GDrC4aPqJNCiOBOOSKco4CFQcGQpz0JjKERuDxoA78CD2TBYaEKf4QkRKI48PgveQQhAAYSkwhgKBE5zQPCAA

