### PR TITLE
Use snake case for datadog tags

### DIFF
--- a/packages/back-end/src/services/otel.ts
+++ b/packages/back-end/src/services/otel.ts
@@ -17,7 +17,13 @@ const getHistogram = (name: string) => {
   return getMeter(name).createHistogram(name);
 };
 
-const normalizeJobName = (jobName: string) => jobName.replace(/\s/g, "_");
+// Datadog downcases tag values, so it is best to use snake case
+const normalizeJobName = (jobName: string) => {
+  return jobName
+    .replace(/\s/g, "_")
+    .replace(/([a-z0-9]|(?=[A-Z]))([A-Z])/g, "$1_$2")
+    .toLowerCase();
+};
 
 export const trackJob = (
   jobNameRaw: string,
@@ -29,12 +35,15 @@ export const trackJob = (
 
   const jobName = normalizeJobName(jobNameRaw);
 
+  // DataDog downcases tag names, so converting to snakecase here
+  const attributes = { job_name: jobName };
+
   const startTime = new Date().getTime();
 
   // init metrics
   try {
     counter = getUpDownCounter(`jobs.running_count`);
-    counter.add(1, { jobName });
+    counter.add(1, attributes);
     hasMetricsStarted = true;
   } catch (e) {
     logger.error(`error init'ing counter for job: ${jobName}: ${e}`);
@@ -48,13 +57,13 @@ export const trackJob = (
   // wrap up metrics function, to be called at the end of the job
   const wrapUpMetrics = () => {
     try {
-      histogram?.record(new Date().getTime() - startTime, { jobName });
+      histogram?.record(new Date().getTime() - startTime, attributes);
     } catch (e) {
       logger.error(`error recording duration metric for job: ${jobName}: ${e}`);
     }
     if (!hasMetricsStarted) return;
     try {
-      counter.add(-1, { jobName });
+      counter.add(-1, attributes);
     } catch (e) {
       logger.error(`error decrementing count metric for job: ${jobName}: ${e}`);
     }
@@ -68,7 +77,7 @@ export const trackJob = (
     logger.error(`error running job: ${jobName}: ${e}`);
     try {
       wrapUpMetrics();
-      getCounter(`jobs.errors`).add(1, { jobName });
+      getCounter(`jobs.errors`).add(1, attributes);
     } catch (e) {
       logger.error(`error wrapping up metrics: ${jobName}: ${e}`);
     }
@@ -78,7 +87,7 @@ export const trackJob = (
   // on successful job
   try {
     wrapUpMetrics();
-    getCounter(`jobs.successes`).add(1, { jobName });
+    getCounter(`jobs.successes`).add(1, attributes);
   } catch (e) {
     logger.error(`error wrapping up metrics: ${jobName}: ${e}`);
   }


### PR DESCRIPTION
### Features and Changes
Datadog downcases all tag names and attributes, hence making it a bit more unreadable.  As we just started using these tags it is safe to change their names now to a more readable snake_case.

### Dependencies
After landing this will need to update Datadog Agenda Job dashboard to use the new tag name.  https://us5.datadoghq.com/dashboard/ajq-6yb-5u2/agenda-jobs

### Testing
Run datadog agent locally.
Run `yarn start:with-tracing`
Start seeing snake case name and attributes in datadog.
https://us5.datadoghq.com/metric/explorer?fromUser=false&start=1717757892358&end=1717758197021&paused=true#N4Ig7glgJg5gpgFxALlAGwIYE8D2BXJVEADxQEYAaELcqyKBAC1pEbghkcLIF8qo4AMwgA7CAgg4RKUAiwAHOChASAtnADOcAE4RNIKtrgBHPJoQaUAbVBGN8qVoD6gnNtUZCKiOq279VKY6epbINiAiGOrKQdpYZAYgUJ4YThr42gDGSsgg6gi6mZaBZnHKGniqyABWOABGGgB0FZnZGloawH4AbhDZNVGaALQY8hA8AAR1WBPAtXVOkeo8jRgaTpn4IggAFACUIDwAulSu7niYoeFnqhcYMaXxhycgGnJoOaDyGB8ICDlJHAwDaXDR9RJoURwJxyRTlHCQqAQqFOehMZQiNweNCHfgQeyYLAwhQAyEiJTHHh8V7ySEIADCUmEMBQIguaB4QA