### PR TITLE
Enhance types for events.

### DIFF
--- a/packages/back-end/src/events/base-types.ts
+++ b/packages/back-end/src/events/base-types.ts
@@ -1,3 +1,4 @@
+import { UnionToTuple } from "../util/types";
 import { EventAuditUser } from "./event-types";
 
 export const notificationEvents = {
@@ -7,10 +8,15 @@ export const notificationEvents = {
   webhook: ["test"],
 } as const;
 
-export type NotificationEvents = typeof notificationEvents;
+type NotificationEvents = typeof notificationEvents;
+
+/**
+ * Supported resources for event notifications
+ */
 export const notificationEventResources = Object.keys(notificationEvents) as [
   keyof NotificationEvents
 ];
+
 export type NotificationEventResource = typeof notificationEventResources[number];
 
 export type NotificationEventNames<K> = K extends NotificationEventResource
@@ -31,9 +37,7 @@ export const notificationEventNames = (Object.keys(notificationEvents) as [
   [] as NotificationEventName[]
 );
 
-export type OptionalNotificationEventNames<
-  R
-> = R extends NotificationEventResource
+type OptionalNotificationEventNames<R> = R extends NotificationEventResource
   ? NotificationEventNames<R>
   : NotificationEventName;
 
@@ -41,7 +45,7 @@ export type OptionalNotificationEventNames<
  * Event Notification payload
  */
 export type NotificationEventPayload<
-  ResourceType extends NotificationEventName | unknown,
+  ResourceType extends NotificationEventResource | undefined,
   EventName extends OptionalNotificationEventNames<ResourceType> = OptionalNotificationEventNames<ResourceType>,
   DataType = unknown
 > = {
@@ -55,27 +59,5 @@ export type NotificationEventPayload<
   containsSecrets: boolean;
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (
-  k: infer I
-) => void
-  ? I
-  : never;
-
-type LastOf<T> =
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  UnionToIntersection<T extends any ? () => T : never> extends () => infer R
-    ? R
-    : never;
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type Push<T extends any[], V> = [...T, V];
-
-type TuplifyUnion<
-  T,
-  L = LastOf<T>,
-  N = [T] extends [never] ? true : false
-> = true extends N ? [] : Push<TuplifyUnion<Exclude<T, L>>, L>;
-
 // Only use this for zod validations!
-export const zodNotificationEventNamesEnum = notificationEventNames as TuplifyUnion<NotificationEventName>;
+export const zodNotificationEventNamesEnum = notificationEventNames as UnionToTuple<NotificationEventName>;

--- a/packages/back-end/src/events/base-types.ts
+++ b/packages/back-end/src/events/base-types.ts
@@ -1,46 +1,48 @@
 import { EventAuditUser } from "./event-types";
 
-/**
- * Supported events for event notifications
- */
-export const notificationEventNames = [
-  // Features
-  "feature.created",
-  "feature.updated",
-  "feature.deleted",
-  // Experiments
-  "experiment.created",
-  "experiment.updated",
-  "experiment.deleted",
-  "experiment.warning",
-  "experiment.info",
-  // User
-  "user.login",
-  // Test
-  "webhook.test",
-] as const;
+export const notificationEvents = {
+  feature: ["created", "updated", "deleted"],
+  experiment: ["created", "updated", "deleted", "warning", "info"],
+  user: ["login"],
+  webhook: ["test"],
+} as const;
 
-export type NotificationEventName = typeof notificationEventNames[number];
-
-/**
- * Supported resources for event notifications
- */
-export const notificationEventResources = [
-  "feature",
-  "experiment",
-  "user",
-  "webhook",
-] as const;
-
+export type NotificationEvents = typeof notificationEvents;
+export const notificationEventResources = Object.keys(notificationEvents) as [
+  keyof NotificationEvents
+];
 export type NotificationEventResource = typeof notificationEventResources[number];
+
+export type NotificationEventNames<K> = K extends NotificationEventResource
+  ? `${K}.${NotificationEvents[K][number]}`
+  : never;
+
+export type NotificationEventName = NotificationEventNames<NotificationEventResource>;
+
+export const notificationEventNames = (Object.keys(notificationEvents) as [
+  NotificationEventResource
+]).reduce<NotificationEventName[]>(
+  (names, key) => [
+    ...names,
+    ...notificationEvents[key].map(
+      (n) => `${key}.${n}` as NotificationEventName
+    ),
+  ],
+  [] as NotificationEventName[]
+);
+
+export type OptionalNotificationEventNames<
+  R
+> = R extends NotificationEventResource
+  ? NotificationEventNames<R>
+  : NotificationEventName;
 
 /**
  * Event Notification payload
  */
 export type NotificationEventPayload<
-  EventName extends NotificationEventName &
-    (ResourceType extends string ? `${ResourceType}.${string}` : unknown),
-  ResourceType extends NotificationEventResource | unknown,
+  ResourceType extends NotificationEventName | unknown,
+  EventName extends OptionalNotificationEventNames<ResourceType>,
   DataType
 > = {
   event: EventName;
@@ -52,3 +54,28 @@ export type NotificationEventPayload<
   environments: string[];
   containsSecrets: boolean;
 };
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (
+  k: infer I
+) => void
+  ? I
+  : never;
+
+type LastOf<T> =
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  UnionToIntersection<T extends any ? () => T : never> extends () => infer R
+    ? R
+    : never;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Push<T extends any[], V> = [...T, V];
+
+type TuplifyUnion<
+  T,
+  L = LastOf<T>,
+  N = [T] extends [never] ? true : false
+> = true extends N ? [] : Push<TuplifyUnion<Exclude<T, L>>, L>;
+
+// Only use this for zod validations!
+export const zodNotificationEventNamesEnum = notificationEventNames as TuplifyUnion<NotificationEventName>;

--- a/packages/back-end/src/events/base-types.ts
+++ b/packages/back-end/src/events/base-types.ts
@@ -42,8 +42,8 @@ export type OptionalNotificationEventNames<
  */
 export type NotificationEventPayload<
   ResourceType extends NotificationEventName | unknown,
-  EventName extends OptionalNotificationEventNames<ResourceType>,
-  DataType
+  EventName extends OptionalNotificationEventNames<ResourceType> = OptionalNotificationEventNames<ResourceType>,
+  DataType = unknown
 > = {
   event: EventName;
   object: ResourceType;

--- a/packages/back-end/src/events/notification-events.d.ts
+++ b/packages/back-end/src/events/notification-events.d.ts
@@ -7,8 +7,8 @@ import { UserLoginAuditableProperties } from "./event-types";
 // region User
 
 export type UserLoginNotificationEvent = NotificationEventPayload<
-  "user.login",
   "user",
+  "user.login",
   {
     current: UserLoginAuditableProperties;
   }
@@ -19,16 +19,16 @@ export type UserLoginNotificationEvent = NotificationEventPayload<
 // region Feature
 
 export type FeatureCreatedNotificationEvent = NotificationEventPayload<
-  "feature.created",
   "feature",
+  "feature.created",
   {
     current: ApiFeature;
   }
 >;
 
 export type FeatureUpdatedNotificationEvent = NotificationEventPayload<
-  "feature.updated",
   "feature",
+  "feature.updated",
   {
     current: ApiFeature;
     previous: ApiFeature;
@@ -36,8 +36,8 @@ export type FeatureUpdatedNotificationEvent = NotificationEventPayload<
 >;
 
 export type FeatureDeletedNotificationEvent = NotificationEventPayload<
-  "feature.deleted",
   "feature",
+  "feature.deleted",
   {
     previous: ApiFeature;
   }
@@ -48,16 +48,16 @@ export type FeatureDeletedNotificationEvent = NotificationEventPayload<
 // region Experiment
 
 export type ExperimentCreatedNotificationEvent = NotificationEventPayload<
-  "experiment.created",
   "experiment",
+  "experiment.created",
   {
     current: ApiExperiment;
   }
 >;
 
 export type ExperimentUpdatedNotificationEvent = NotificationEventPayload<
-  "experiment.updated",
   "experiment",
+  "experiment.updated",
   {
     current: ApiExperiment;
     previous: ApiExperiment;
@@ -65,28 +65,28 @@ export type ExperimentUpdatedNotificationEvent = NotificationEventPayload<
 >;
 
 export type ExperimentDeletedNotificationEvent = NotificationEventPayload<
-  "experiment.deleted",
   "experiment",
+  "experiment.deleted",
   {
     previous: ApiExperiment;
   }
 >;
 
 export type ExperimentInfoNotificationEvent = NotificationEventPayload<
-  "experiment.info",
   "experiment",
+  "experiment.info",
   null
 >;
 
 export type ExperimentWarningNotificationEvent = NotificationEventPayload<
-  "experiment.warning",
   "experiment",
+  "experiment.warning",
   ExperimentWarningNotificationPayload
 >;
 
 export type WebhookTestEvent = NotificationEventPayload<
-  "webhook.test",
   "webhook",
+  "webhook.test",
   { webhookId: string }
 >;
 

--- a/packages/back-end/src/models/EventModel.ts
+++ b/packages/back-end/src/models/EventModel.ts
@@ -3,7 +3,7 @@ import z from "zod";
 import omit from "lodash/omit";
 import mongoose from "mongoose";
 import {
-  notificationEventNames,
+  zodNotificationEventNamesEnum,
   notificationEventResources,
 } from "../events/base-types";
 import { EventInterface } from "../../types/event";
@@ -30,7 +30,7 @@ const eventSchema = new mongoose.Schema({
   event: {
     type: String,
     required: true,
-    enum: notificationEventNames,
+    enum: zodNotificationEventNamesEnum,
   },
   data: {
     type: Object,
@@ -40,7 +40,7 @@ const eventSchema = new mongoose.Schema({
         // NotificationEventPayload<EventName, ResourceType, DataType>
         const zodSchema = z
           .object({
-            event: z.enum(notificationEventNames),
+            event: z.enum(zodNotificationEventNamesEnum),
             object: z.enum(notificationEventResources),
             data: z.any(),
             projects: z.array(z.string()),

--- a/packages/back-end/src/models/EventWebhookModel.ts
+++ b/packages/back-end/src/models/EventWebhookModel.ts
@@ -6,7 +6,7 @@ import mongoose from "mongoose";
 import intersection from "lodash/intersection";
 import {
   NotificationEventName,
-  notificationEventNames,
+  zodNotificationEventNamesEnum,
 } from "../events/base-types";
 import { errorStringFromZodResult } from "../util/validation";
 import { EventWebHookInterface } from "../../types/event-webhook";
@@ -114,7 +114,7 @@ const eventWebHookSchema = new mongoose.Schema({
     required: true,
     validate: {
       validator(value: unknown) {
-        const zodSchema = z.array(z.enum(notificationEventNames)).min(1);
+        const zodSchema = z.array(z.enum(zodNotificationEventNamesEnum)).min(1);
 
         const result = zodSchema.safeParse(value);
 

--- a/packages/back-end/src/models/SlackIntegrationModel.ts
+++ b/packages/back-end/src/models/SlackIntegrationModel.ts
@@ -7,7 +7,7 @@ import { z } from "zod";
 import { SlackIntegrationInterface } from "../../types/slack-integration";
 import {
   NotificationEventName,
-  notificationEventNames,
+  zodNotificationEventNamesEnum,
 } from "../events/base-types";
 import { logger } from "../util/logger";
 import { errorStringFromZodResult } from "../util/validation";
@@ -52,7 +52,7 @@ const slackIntegrationSchema = new mongoose.Schema({
     required: true,
     validate: {
       validator(value: unknown) {
-        const zodSchema = z.array(z.enum(notificationEventNames));
+        const zodSchema = z.array(z.enum(zodNotificationEventNamesEnum));
 
         const result = zodSchema.safeParse(value);
 

--- a/packages/back-end/src/routers/event-webhooks/event-webhooks.router.ts
+++ b/packages/back-end/src/routers/event-webhooks/event-webhooks.router.ts
@@ -2,7 +2,7 @@ import express from "express";
 import z from "zod";
 import { wrapController } from "../wrapController";
 import { validateRequestMiddleware } from "../utils/validateRequestMiddleware";
-import { notificationEventNames } from "../../events/base-types";
+import { zodNotificationEventNamesEnum } from "../../events/base-types";
 import {
   eventWebHookMethods,
   eventWebHookPayloadTypes,
@@ -30,7 +30,7 @@ router.post(
       .object({
         url: z.string().url(),
         name: z.string().trim().min(2),
-        events: z.array(z.enum(notificationEventNames)).min(1),
+        events: z.array(z.enum(zodNotificationEventNamesEnum)).min(1),
         enabled: z.boolean(),
         projects: z.array(z.string()),
         tags: z.array(z.string()),
@@ -108,7 +108,7 @@ router.put(
       .object({
         url: z.string().url(),
         name: z.string().trim().min(2),
-        events: z.array(z.enum(notificationEventNames)).min(1),
+        events: z.array(z.enum(zodNotificationEventNamesEnum)).min(1),
         enabled: z.boolean(),
         projects: z.array(z.string()),
         tags: z.array(z.string()),

--- a/packages/back-end/src/routers/slack-integration/slack-integration.router.ts
+++ b/packages/back-end/src/routers/slack-integration/slack-integration.router.ts
@@ -2,7 +2,7 @@ import express from "express";
 import z from "zod";
 import { wrapController } from "../wrapController";
 import { validateRequestMiddleware } from "../utils/validateRequestMiddleware";
-import { notificationEventNames } from "../../events/base-types";
+import { zodNotificationEventNamesEnum } from "../../events/base-types";
 import * as rawSlackIntegrationController from "./slack-integration.controller";
 
 const router = express.Router();
@@ -34,7 +34,7 @@ router.post(
         description: z.string(),
         projects: z.array(z.string()),
         environments: z.array(z.string()),
-        events: z.array(z.enum(notificationEventNames)),
+        events: z.array(z.enum(zodNotificationEventNamesEnum)),
         tags: z.array(z.string()),
         slackAppId: z.string(),
         slackSigningKey: z.string(),
@@ -62,7 +62,7 @@ router.put(
         description: z.string(),
         projects: z.array(z.string()),
         environments: z.array(z.string()),
-        events: z.array(z.enum(notificationEventNames)),
+        events: z.array(z.enum(zodNotificationEventNamesEnum)),
         tags: z.array(z.string()),
         slackAppId: z.string(),
         slackSigningKey: z.string(),

--- a/packages/back-end/src/types/Audit.ts
+++ b/packages/back-end/src/types/Audit.ts
@@ -48,11 +48,8 @@ export type EntityEvents = typeof entityEvents;
 export const EntityType = Object.keys(entityEvents) as [keyof EntityEvents];
 export type EntityType = typeof EntityType[number];
 
-export type EventTypes<
-  k extends EntityType
-> = `${k}.${EntityEvents[k][number]}`;
-export type EventType = EntityType extends unknown
-  ? EntityEvents[EntityType][number] extends unknown
-    ? `${EntityType}.${EntityEvents[EntityType][number]}`
-    : never
+export type EventTypes<K> = K extends EntityType
+  ? `${K}.${EntityEvents[K][number]}`
   : never;
+
+export type EventType = EventTypes<EntityType>;

--- a/packages/back-end/src/util/types.ts
+++ b/packages/back-end/src/util/types.ts
@@ -1,6 +1,54 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 // Check if two types are equal
 export type IfEqual<U, V, True, False = never> = [U] extends [V]
   ? [V] extends [U]
     ? True
     : False
   : False;
+
+export type IsTuple<Tuple extends any[]> = {
+  empty: true;
+  nonEmpty: ((...p: Tuple) => any) extends (
+    p1: infer First,
+    ...p: infer Rest
+  ) => any
+    ? IsTuple<Rest>
+    : false;
+  infinite: false;
+}[Tuple extends []
+  ? "empty"
+  : Tuple extends (infer Element)[]
+  ? Element[] extends Tuple
+    ? "infinite"
+    : "nonEmpty"
+  : never];
+
+export type TupleToUnion<T> = T extends (infer E)[] ? E : never;
+
+export type UnionPop<U> = (
+  (U extends any ? (k: (x: U) => void) => void : never) extends (
+    k: infer I
+  ) => void
+    ? I
+    : never
+) extends { (a: infer A): void }
+  ? A
+  : never;
+
+export type TuplePrepend<T extends any[], E> = ((
+  a: E,
+  ...r: T
+) => void) extends (...r: infer R) => void
+  ? R
+  : never;
+
+type UnionToTupleRecursively<Union, Result extends any[]> = {
+  1: Result;
+  0: UnionToTupleRecursively<
+    Exclude<Union, UnionPop<Union>>,
+    TuplePrepend<Result, UnionPop<Union>>
+  >;
+}[[Union] extends [never] ? 1 : 0];
+
+export type UnionToTuple<U> = UnionToTupleRecursively<U, []>;

--- a/packages/front-end/components/Events/EventDetail/EventDetail.tsx
+++ b/packages/front-end/components/Events/EventDetail/EventDetail.tsx
@@ -1,24 +1,14 @@
 import React, { FC } from "react";
 import { useRouter } from "next/router";
-import {
-  EventInterface,
-  NotificationEventName,
-  NotificationEventPayload,
-  NotificationEventResource,
-} from "back-end/types/event";
+import { EventInterface } from "back-end/types/event";
 import { datetime } from "shared/dates";
+import { NotificationEvent } from "back-end/src/events/notification-events";
 import useApi from "@/hooks/useApi";
 import LoadingSpinner from "@/components/LoadingSpinner";
 import Code from "@/components/SyntaxHighlighting/Code";
 
 type EventDetailProps = {
-  event: EventInterface<
-    NotificationEventPayload<
-      NotificationEventName,
-      NotificationEventResource,
-      unknown
-    >
-  >;
+  event: EventInterface<NotificationEvent>;
 };
 
 export const EventDetail: FC<EventDetailProps> = ({ event }) => {
@@ -41,13 +31,7 @@ export const EventDetailContainer = () => {
   const { eventid: eventId } = router.query;
 
   const { data, error, isValidating } = useApi<{
-    event: EventInterface<
-      NotificationEventPayload<
-        NotificationEventName,
-        NotificationEventResource,
-        unknown
-      >
-    >;
+    event: EventInterface<NotificationEvent>;
   }>(`/events/${eventId}`);
 
   const event = data?.event;

--- a/packages/front-end/components/Events/EventsPage/EventsPage.tsx
+++ b/packages/front-end/components/Events/EventsPage/EventsPage.tsx
@@ -1,10 +1,6 @@
 import React, { FC } from "react";
-import {
-  EventInterface,
-  NotificationEventName,
-  NotificationEventPayload,
-  NotificationEventResource,
-} from "back-end/types/event";
+import { EventInterface } from "back-end/types/event";
+import { NotificationEvent } from "back-end/src/events/notification-events";
 import { FaDownload } from "react-icons/fa";
 import useApi from "@/hooks/useApi";
 import { useDownloadDataExport } from "@/hooks/useDownloadDataExport";
@@ -21,13 +17,7 @@ type EventsPageProps = {
   hasExportError: boolean;
   performDownload: () => void;
   isDownloading: boolean;
-  events: EventInterface<
-    NotificationEventPayload<
-      NotificationEventName,
-      NotificationEventResource,
-      unknown
-    >
-  >[];
+  events: EventInterface<NotificationEvent>[];
 };
 
 export const EventsPage: FC<EventsPageProps> = ({
@@ -121,13 +111,7 @@ export const EventsPage: FC<EventsPageProps> = ({
 
 export const EventsPageContainer = () => {
   const { data, error, isValidating } = useApi<{
-    events: EventInterface<
-      NotificationEventPayload<
-        NotificationEventName,
-        NotificationEventResource,
-        unknown
-      >
-    >[];
+    events: EventInterface<NotificationEvent>[];
   }>("/events");
 
   const {

--- a/packages/front-end/components/Events/EventsPage/EventsTableRow.tsx
+++ b/packages/front-end/components/Events/EventsPage/EventsTableRow.tsx
@@ -1,21 +1,11 @@
 import React, { FC } from "react";
-import {
-  EventInterface,
-  NotificationEventName,
-  NotificationEventPayload,
-  NotificationEventResource,
-} from "back-end/types/event";
+import { EventInterface } from "back-end/types/event";
+import { NotificationEvent } from "back-end/src/events/notification-events";
 import { datetime } from "shared/dates";
 import { getEventText } from "./utils";
 
 type EventsTableRowProps = {
-  event: EventInterface<
-    NotificationEventPayload<
-      NotificationEventName,
-      NotificationEventResource,
-      unknown
-    >
-  >;
+  event: EventInterface<NotificationEvent>;
 };
 
 export const EventsTableRow: FC<EventsTableRowProps> = ({ event }) => {

--- a/packages/front-end/components/Events/EventsPage/utils.ts
+++ b/packages/front-end/components/Events/EventsPage/utils.ts
@@ -6,20 +6,12 @@ import {
   FeatureCreatedNotificationEvent,
   FeatureDeletedNotificationEvent,
   FeatureUpdatedNotificationEvent,
-  NotificationEventName,
-  NotificationEventPayload,
-  NotificationEventResource,
   UserLoginNotificationEvent,
 } from "back-end/types/event";
+import { NotificationEvent } from "back-end/src/events/notification-events";
 
 export const getEventText = (
-  event: EventInterface<
-    NotificationEventPayload<
-      NotificationEventName,
-      NotificationEventResource,
-      unknown
-    >
-  >
+  event: EventInterface<NotificationEvent>
 ): string => {
   switch (event.data.event) {
     case "user.login":


### PR DESCRIPTION
This PR enhances the typing for `events` to derive all types from a constant declaration of resource to event name mappings.

This should help preventing gaps between resource names and full expanded event names and makes it possible to restrict event names only to the proper event associated with a given resource.

Types can be hard to follow sometimes. Here's a [link to a TS playground](https://www.typescriptlang.org/play/?#code/KYDwDg9gTgLgBAYwgOwM72RGBLAZthAQxxQFEA3YZGVOAXjgG8AoOOXYYgVymAC44AbQBECXsWAATYQBphXMJInS5k4ABtgMKcIC6M1nFBhgUbAFsqMASLGdtKuPMXLZTtZodvhAd0JRkbGQAc28g3Ag9AzYuVFMbYXUIYKCowx9gACMACwgIAGsE7XQ9ZgBfOEJaJDQYAG5mZmNoeBgATxM4ADksPAJibDJKaloGdpMIXDhMHHwiEmQKK1QG5thEFHRp3rmBoasAJWBUCB4EY-o4AHlMgCtgBBgAOnzgNtQAChm++cHF4ZoAEpKrRBK82pNujt+gsliNdKtwC04ONgFDZjC-nCYEcTmc0WMOsBId9drCAbjTlBzqhBMguOZMqYEY01q0ieifnt-lYuoRLKgADwAaQAfJdhUYQNpkJJaD0Mb99tRKfi4AB+OAAAwAJIxhWUnnqFVzyctBMLdHSGUyoLoylq4AJkMBKFAGk0ketUZyyViAXzLJcTX7lTBA8dBSHMWHVdTgKKPWyNrVtorudiI6M4B8bvdHi83p9DKSYzyRgZgVUhNGleWcccqeddICnrxJFxzlHoXXM-zgIJdKKPoYvv3UDI4ODgXRxYJDGwnkvkOPomw4EunqXewDaeDdE9zIQwB8vjPxbrGODDXrkA6Qb6y33LIC1-pDIOH7WMwH+4PKx6PoAKqBCgAAqEAAJLUKYcSPH8gpAeKdCjkBUoynKlTIG0Go5oUcBAeecDkBA2CSE60yuqYwKgBhtCnvh4SmHAkFESRZHApqkEUS6brMD6AAyVQwFcuCCmByGGCBfwQdB2hQHBCziehVCYYQ2G4R8RFgTxVFQOKtGqfRREfExUBwAcnEWbpfH8RyAAKsTZMphmyrQ6ltP+cAAGrIUIm5gZO3ksnZnRgQo6h4G00koOJk4CZcQnoKJ4mipOXSXIIYG6CpblCLxzK4TAUBcGiAi4IQ6hxJJbDFaVuWYRlmqfgIjmoM54VgJFuDRaByCCqQIAIOoXBqHFcACaKaUTaKjQAPRzdcyDqDhsRojA2TYLQETmQAXhA5HkJVZHcqgACEnqQOsNRbPtkjfma1BZqQ9LmJc24-ry44Pp13W9QhD3+l9liJo0tUcgAYnkwY9p9T3joKwjGKYFhWMIs2GMmPpXGACyVYDYZZoKBzipcBwNfKsOPQ2eLxrhBP1kTJMUQzz7AB64OdDj8AMNzfz41TQPwwKgpcLKwD4C6kig4YPo9Nzlx8ygAvptTRNI+AKOWNQ6Osl67KdKzAL2YQbRJIQkiCoYcbnGBHKuY1guE-2cAAD5wGL+SYD4yBrmzFPXLj-PqEbwORjbwB2yYaWGAAIsQhBRwSHvi5LUgGH5LBsFR1ACGzDRsBAdwPNYFmNviScF3ASgwIQAjx7XleGGAUAQPmNACOgZghIOVe18EqCd8VQTBL3mPIOQ2Ct8g2sd3AXcj2PbA1LXQSoAAyg8vBz5keSaOpDRlBzcALXAvApCgBFxFAetXQbaJAdfAnJEEofUDDqtCzAJtmxAFtW2weQ19ZCGCAaYJ4SQUjIBATLU+qlz5-CvqYeai0EGXwhvYHgwBb7Ih9Bg7gvAADC4gHBvx5o+HcVgf7m0tqAjgBDgAgMAfQmAWCnh2FcBnJM+sUSQ0wbwICLhSFO3rB-U0X9qF-1ocw-hjC1zCBYWwhQNcdBcJwd6PhDDY4aC0FIMhYjQz1kkf-OhsimFOEUbwJ4HhdEqGYLAxa8DgAX2QHAfBrDeAoLPs4xBg0TBmFnuo++cA-FaysMQ+weiRHYgMU+Y2psaEAKcMjAJaN5EpNRtQdhJDVH2O4XfXhnRQmpOoIIlR91okAliZQ6gxjpHJM1iUmA5iNb+Myc8ZRnC8lBMKWiYp7TtGeCiZ-MM1S4bfwSVIpJrSwk63SY09p1idFeDUZdXBHJ+mz2ghEfRDAyF1OmRk2eLSjlWCeOESIqysYbIWbPAA6v4QIIRdkUPGQc0Bpy5kfNuWcvwAQR4wPyeszodysi5AKGBY4MAYl7MqVQyZJjAEZByHkfILTkXgvyE8YozTVk+gAILqBDnC9+KE2Du0fqYZ+UCyGGHdu4rBETlC0vJW42RZTmUkpgHStlWjlnDPEWGHlmzwk5IqSM+swqfmlKEQKwx2IpVtNnoM2xLK3YhOlTAbZEA1XuxFdQB5-znlcp5aClFEKoXYiBRozokFcCkAAI5cEqohIKk4wIlWAJOCGlU4jvT0n5QQQEcoO1BMFQwzVgoByDboBcuEPWlTjQIH1VVsFsGTb69mjQfTaLTpIbEdTLiEuJRK7EIgc7NJCqfAAsoQV488sFwAyHAbIhBKCVDgGABF5EdpGEIAgbIvS4CQgraFNELy7WOudeoJJZCIxrmLWQ8tAI0hsEXSaxMQA) exemplifying those in this PR: