### PR TITLE
Bug - estimateParams can be undefined

### DIFF
--- a/packages/back-end/types/idea.d.ts
+++ b/packages/back-end/types/idea.d.ts
@@ -19,7 +19,7 @@ export interface IdeaInterface {
   dateUpdated: Date;
   impactScore: number;
   experimentLength: number;
-  estimateParams: {
+  estimateParams?: {
     estimate: string;
     improvement: number;
     numVariations: number;

--- a/packages/front-end/components/Ideas/ImpactModal.tsx
+++ b/packages/front-end/components/Ideas/ImpactModal.tsx
@@ -23,9 +23,9 @@ const ImpactModal: FC<{
     defaultValues: {
       metric: estimate?.metric || metrics[0]?.id || "",
       segment: estimate?.segment || "",
-      userAdjustment: idea.estimateParams.userAdjustment || 100,
-      numVariations: idea.estimateParams.numVariations || 2,
-      improvement: idea.estimateParams.improvement || 10,
+      userAdjustment: idea.estimateParams?.userAdjustment || 100,
+      numVariations: idea.estimateParams?.numVariations || 2,
+      improvement: idea.estimateParams?.improvement || 10,
     },
   });
 


### PR DESCRIPTION
### Features and Changes

A user reported an error when attempting to generate an impact score for an idea - when defining the default values for `userAdjustment`, `numVariations`, and `improvement` within the `ImpactModal.tsx` component, the `idea.estimateParams` was expected to be defined, but it's possible for an idea to have this be `undefined`. This seems to be somewhat expected given the fallback values. But, in the event of this happening, there was an error thrown.

Now, if you create a new idea (that doesn't have an `estimateParams` property, we correctly use the fallback values.
