### PR TITLE
Show full dates on feature revisions

### DIFF
--- a/docs/docs/lib/edge/lambda.mdx
+++ b/docs/docs/lib/edge/lambda.mdx
@@ -314,9 +314,10 @@ export async function handler(event, ctx, callback) {
   if (growthbook.isOn("my-feature")) {
     const resp = { status: "200", body: "<h1>foo</h1>" };
     callback(null, resp);
+  } else {
+    const resp = { status: "200", body: "<h1>bar</h1>" };
+    callback(null, resp);
   }
-  const resp = { status: "200", body: "<h1>bar</h1>" };
-  callback(null, resp);
 }
 ```
 

--- a/packages/front-end/components/Features/FeaturesOverview.tsx
+++ b/packages/front-end/components/Features/FeaturesOverview.tsx
@@ -11,7 +11,7 @@ import {
   FaLock,
   FaTimes,
 } from "react-icons/fa";
-import { ago, date } from "shared/dates";
+import { ago, datetime } from "shared/dates";
 import {
   autoMerge,
   checkIfRevisionNeedsReview,
@@ -949,7 +949,7 @@ export default function FeaturesOverview({
                 <span className="text-muted">Revision created by</span>{" "}
                 <AuditUser user={revision.createdBy} display="name" />{" "}
                 <span className="text-muted">on</span>{" "}
-                {date(revision.dateCreated)}
+                {datetime(revision.dateCreated)}
               </div>
               <div className="col-auto">
                 <span className="text-muted">Revision Comment:</span>{" "}
@@ -971,7 +971,7 @@ export default function FeaturesOverview({
               {revision.status === "published" && revision.datePublished && (
                 <div className="col-auto">
                   <span className="text-muted">Published on</span>{" "}
-                  {date(revision.datePublished)}
+                  {datetime(revision.datePublished)}
                 </div>
               )}
               {revision.status === "draft" && (

--- a/packages/front-end/components/Features/RevisionDropdown.tsx
+++ b/packages/front-end/components/Features/RevisionDropdown.tsx
@@ -1,6 +1,6 @@
 import { FeatureInterface } from "back-end/types/feature";
 import { FeatureRevisionInterface } from "back-end/types/feature-revision";
-import { ago } from "shared/dates";
+import { datetime } from "shared/dates";
 import SelectField from "@/components/Forms/SelectField";
 import AuditUser from "@/components/Avatar/AuditUser";
 
@@ -65,7 +65,9 @@ export default function RevisionDropdown({
               ) : null}
               {context !== "value" && (
                 <div style={{ marginTop: -4 }}>
-                  {date && <small className="text-muted">{ago(date)}</small>}
+                  {date && (
+                    <small className="text-muted">{datetime(date)}</small>
+                  )}
                 </div>
               )}
             </div>

--- a/packages/front-end/components/SyntaxHighlighting/Snippets/BooleanFeatureCodeSnippet.tsx
+++ b/packages/front-end/components/SyntaxHighlighting/Snippets/BooleanFeatureCodeSnippet.tsx
@@ -229,9 +229,10 @@ return new Response("<h1>bar</h1>");
 if (growthbook.isOn("my-feature")) {
   const resp = { status: "200", body: "<h1>foo</h1>" };
   callback(null, resp);
+} else {
+  const resp = { status: "200", body: "<h1>bar</h1>" };
+  callback(null, resp);
 }
-const resp = { status: "200", body: "<h1>bar</h1>" };
-callback(null, resp);
         `.trim()}
       />
     );

--- a/packages/front-end/components/SyntaxHighlighting/Snippets/MultivariateFeatureCodeSnippet.tsx
+++ b/packages/front-end/components/SyntaxHighlighting/Snippets/MultivariateFeatureCodeSnippet.tsx
@@ -259,9 +259,10 @@ return new Response("<h1>bar</h1>");
 if (growthbook.isOn("my-feature")) {
   const resp = { status: "200", body: "<h1>foo</h1>" };
   callback(null, resp);
+} else {
+  const resp = { status: "200", body: "<h1>bar</h1>" };
+  callback(null, resp);
 }
-const resp = { status: "200", body: "<h1>bar</h1>" };
-callback(null, resp);
         `.trim()}
       />
     );


### PR DESCRIPTION
### Features and Changes

Full dates on feature revisions for easier date comparison. Prior to this, it would say things like "about 1 hour ago" or "about 1 day ago", which was not specific enough.

Also fixes some unrelated code snippets.

<img width="541" alt="image" src="https://github.com/growthbook/growthbook/assets/7927873/f80a089f-6a4c-45d4-aa5f-d04448bde412">

<img width="1349" alt="image" src="https://github.com/growthbook/growthbook/assets/7927873/b50a4ce0-a6ae-43f9-9ab6-27e260b15115">
