### PR TITLE
Call metadata and get user keys right before license server call

### DIFF
--- a/packages/back-end/src/jobs/updateLicense.ts
+++ b/packages/back-end/src/jobs/updateLicense.ts
@@ -5,10 +5,14 @@
  * void within a week if something is not done to unblock the connection.
  */
 import Agenda from "agenda";
+import { licenseInit } from "enterprise";
 import { getSelfHostedOrganization } from "../models/OrganizationModel";
 import { trackJob } from "../services/otel";
 import { IS_CLOUD } from "../util/secrets";
-import { initializeLicenseForOrg } from "../services/licenseData";
+import {
+  getLicenseMetaData,
+  getUserCodesForOrg,
+} from "../services/licenseData";
 
 const UPDATE_LICENSES_JOB_NAME = "updateLicenses";
 
@@ -19,7 +23,7 @@ const updateLicense = trackJob(UPDATE_LICENSES_JOB_NAME, async () => {
 
   const org = await getSelfHostedOrganization();
   if (org) {
-    initializeLicenseForOrg(org);
+    licenseInit(org, getUserCodesForOrg, getLicenseMetaData);
   }
 });
 

--- a/packages/back-end/src/middleware/authenticateApiRequestMiddleware.ts
+++ b/packages/back-end/src/middleware/authenticateApiRequestMiddleware.ts
@@ -1,5 +1,6 @@
 import { Request, Response, NextFunction } from "express";
 import { hasPermission } from "shared/permissions";
+import { licenseInit } from "enterprise";
 import { ApiRequestLocals } from "../../types/api";
 import { lookupOrganizationByApiKey } from "../models/ApiKeyModel";
 import { getOrganizationById } from "../services/organizations";
@@ -15,7 +16,10 @@ import { ApiKeyInterface } from "../../types/apikey";
 import { getTeamsForOrganization } from "../models/TeamModel";
 import { TeamInterface } from "../../types/team";
 import { getUserById } from "../services/users";
-import { initializeLicenseForOrg } from "../services/licenseData";
+import {
+  getLicenseMetaData,
+  getUserCodesForOrg,
+} from "../services/licenseData";
 import { ReqContextClass } from "../services/context";
 
 export default function authenticateApiRequestMiddleware(
@@ -167,7 +171,7 @@ export default function authenticateApiRequestMiddleware(
       };
 
       // init license for org if it exists
-      await initializeLicenseForOrg(req.organization);
+      await licenseInit(org, getUserCodesForOrg, getLicenseMetaData);
 
       // Continue to the actual request handler
       next();

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -7,6 +7,7 @@ import {
   getEffectiveAccountPlan,
   getLicense,
   getLicenseError,
+  licenseInit,
 } from "enterprise";
 import { experimentHasLinkedChanges } from "shared/util";
 import {
@@ -123,7 +124,10 @@ import { getTeamsForOrganization } from "../../models/TeamModel";
 import { getAllFactTablesForOrganization } from "../../models/FactTableModel";
 import { TeamInterface } from "../../../types/team";
 import { fireSdkWebhook } from "../../jobs/sdkWebhooks";
-import { initializeLicenseForOrg } from "../../services/licenseData";
+import {
+  getLicenseMetaData,
+  getUserCodesForOrg,
+} from "../../services/licenseData";
 import { findSDKConnectionsByIds } from "../../models/SdkConnectionModel";
 
 export async function getDefinitions(req: AuthRequest, res: Response) {
@@ -664,7 +668,11 @@ export async function getOrganization(req: AuthRequest, res: Response) {
     license = getLicense(licenseKey || process.env.LICENSE_KEY);
     if (!license || (license.organizationId && license.organizationId !== id)) {
       try {
-        license = await initializeLicenseForOrg(org);
+        license = await licenseInit(
+          org,
+          getUserCodesForOrg,
+          getLicenseMetaData
+        );
       } catch (e) {
         // eslint-disable-next-line no-console
         console.error("setting license failed", e);
@@ -1938,7 +1946,7 @@ export async function setLicenseKey(
   }
 
   org.licenseKey = licenseKey;
-  await initializeLicenseForOrg(org, true);
+  await licenseInit(org, getUserCodesForOrg, getLicenseMetaData, true);
 }
 
 export async function putLicenseKey(

--- a/packages/back-end/src/services/auth/index.ts
+++ b/packages/back-end/src/services/auth/index.ts
@@ -1,5 +1,5 @@
 import { NextFunction, Request, Response } from "express";
-import { SSO_CONFIG } from "enterprise";
+import { licenseInit, SSO_CONFIG } from "enterprise";
 import { userHasPermission } from "shared/permissions";
 import { logger } from "../../util/logger";
 import { IS_CLOUD } from "../../util/secrets";
@@ -24,7 +24,7 @@ import {
 } from "../../events/event-types";
 import { insertAudit } from "../../models/AuditModel";
 import { getTeamsForOrganization } from "../../models/TeamModel";
-import { initializeLicenseForOrg } from "../licenseData";
+import { getLicenseMetaData, getUserCodesForOrg } from "../licenseData";
 import { AuthConnection } from "./AuthConnection";
 import { OpenIdAuthConnection } from "./OpenIdAuthConnection";
 import { LocalAuthConnection } from "./LocalAuthConnection";
@@ -194,7 +194,11 @@ export async function processJWT(
         }
 
         // init license for org if it exists
-        await initializeLicenseForOrg(req.organization);
+        await licenseInit(
+          req.organization,
+          getUserCodesForOrg,
+          getLicenseMetaData
+        );
       } else {
         res.status(404).json({
           status: 404,

--- a/packages/back-end/src/services/licenseData.ts
+++ b/packages/back-end/src/services/licenseData.ts
@@ -1,6 +1,5 @@
 import path from "path";
 import fs from "fs";
-import { licenseInit } from "enterprise";
 import md5 from "md5";
 import { findAllSDKConnectionsAcrossAllOrgs } from "../models/SdkConnectionModel";
 import { getInstallationId } from "../models/InstallationModel";
@@ -65,68 +64,53 @@ export async function getLicenseMetaData() {
   };
 }
 
-export async function initializeLicenseForOrg(
-  org?: OrganizationInterface,
-  forceRefresh = false
-) {
-  const key = org?.licenseKey || process.env.LICENSE_KEY;
-
-  if (!key) {
-    return;
-  }
-
-  if (key.startsWith("license_")) {
-    let userLicenseCodes: string[] = [];
-    if (IS_CLOUD && org) {
-      const memberIds = org.members.map((member) => member.id);
-      const memberEmails = (await getUsersByIds(memberIds)).map(
-        (user) => user.email
-      );
-      const inviteEmails = org.invites.map((invite) => invite.email);
-      const membersAndInviteEmails = memberEmails.concat(inviteEmails);
-      userLicenseCodes = membersAndInviteEmails.map((email) => {
-        return md5(email).slice(0, 8);
-      });
-    } else {
-      // Self-Host logic
-      // get all users and invites codes across all orgs in the db
-      // that are part of at least one organization
-      // there may be multiple orgs in case it is a MULTI_ORG site
-      const users = await UserModel.aggregate([
-        {
-          $lookup: {
-            from: "organizations",
-            localField: "id",
-            foreignField: "members.id",
-            as: "orgs",
-          },
+export async function getUserCodesForOrg(org: OrganizationInterface) {
+  let userLicenseCodes: string[] = [];
+  if (IS_CLOUD && org) {
+    const memberIds = org.members.map((member) => member.id);
+    const memberEmails = (await getUsersByIds(memberIds)).map(
+      (user) => user.email
+    );
+    const inviteEmails = org.invites.map((invite) => invite.email);
+    const membersAndInviteEmails = memberEmails.concat(inviteEmails);
+    userLicenseCodes = membersAndInviteEmails.map((email) => {
+      return md5(email).slice(0, 8);
+    });
+  } else {
+    // Self-Host logic
+    // get all users and invites codes across all orgs in the db
+    // that are part of at least one organization
+    // there may be multiple orgs in case it is a MULTI_ORG site
+    const users = await UserModel.aggregate([
+      {
+        $lookup: {
+          from: "organizations",
+          localField: "id",
+          foreignField: "members.id",
+          as: "orgs",
         },
-        {
-          $match: {
-            "orgs.0": { $exists: true },
-          },
+      },
+      {
+        $match: {
+          "orgs.0": { $exists: true },
         },
-      ]);
+      },
+    ]);
 
-      const userEmailCodes = await Promise.all(
-        users.map(async (user) => {
-          return md5(user.email).slice(0, 8);
-        })
-      );
+    const userEmailCodes = await Promise.all(
+      users.map(async (user) => {
+        return md5(user.email).slice(0, 8);
+      })
+    );
 
-      const inviteEmails = await getAllInviteEmailsInDb();
-      const inviteEmailCodes: string[] = inviteEmails.map((email) => {
-        return md5(email).slice(0, 8);
-      });
+    const inviteEmails = await getAllInviteEmailsInDb();
+    const inviteEmailCodes: string[] = inviteEmails.map((email) => {
+      return md5(email).slice(0, 8);
+    });
 
-      userLicenseCodes = Array.from(
-        new Set(userEmailCodes.concat(inviteEmailCodes))
-      );
-    }
-
-    const metaData = await getLicenseMetaData();
-
-    return await licenseInit(key, userLicenseCodes, metaData, forceRefresh);
+    userLicenseCodes = Array.from(
+      new Set(userEmailCodes.concat(inviteEmailCodes))
+    );
   }
-  return await licenseInit(key);
+  return userLicenseCodes;
 }

--- a/packages/enterprise/test/license.test.ts
+++ b/packages/enterprise/test/license.test.ts
@@ -31,7 +31,10 @@ describe("src/license", () => {
     eventTrackers: ["rudderstack"],
     isCloud: false,
   };
+  const getUserCodesForOrg = () => Promise.resolve(userLicenseCodes);
+  const getLicenseMetaData = () => Promise.resolve(metaData);
   const licenseKey = "license_19exntswvlosvp1d6";
+  const org = { id: "org_id", licenseKey };
   const licenseData = {
     id: "license_19exntswvlosvp1d6",
     companyName: "Acme",
@@ -138,7 +141,7 @@ describe("src/license", () => {
         } as unknown) as Response;
 
         mockedFetch.mockResolvedValueOnce(Promise.resolve(mockedResponse));
-        await licenseInit(licenseKey, userLicenseCodes, metaData);
+        await licenseInit(org, getUserCodesForOrg, getLicenseMetaData);
       });
 
       it("should not have an error since no plan means it was an abandoned stripe checkout and not a full license", () => {
@@ -161,7 +164,7 @@ describe("src/license", () => {
         } as unknown) as Response;
 
         mockedFetch.mockResolvedValueOnce(Promise.resolve(mockedResponse));
-        await licenseInit(licenseKey, userLicenseCodes, metaData);
+        await licenseInit(org, getUserCodesForOrg, getLicenseMetaData);
       });
 
       it("should have an error since no plan but an error means the license server errored or could not connect on first ever try", () => {
@@ -186,7 +189,7 @@ describe("src/license", () => {
         } as unknown) as Response;
 
         mockedFetch.mockResolvedValueOnce(Promise.resolve(mockedResponse));
-        await licenseInit(licenseKey, userLicenseCodes, metaData);
+        await licenseInit(org, getUserCodesForOrg, getLicenseMetaData);
       });
 
       it("should have an error since no plan but an error means the license server errored or could not connect on first ever try", () => {
@@ -212,7 +215,7 @@ describe("src/license", () => {
         } as unknown) as Response;
 
         mockedFetch.mockResolvedValueOnce(Promise.resolve(mockedResponse));
-        await licenseInit(licenseKey, userLicenseCodes, metaData);
+        await licenseInit(org, getUserCodesForOrg, getLicenseMetaData);
       });
 
       it("should return an error saying the server is down too long", () => {
@@ -237,7 +240,7 @@ describe("src/license", () => {
         } as unknown) as Response;
 
         mockedFetch.mockResolvedValueOnce(Promise.resolve(mockedResponse));
-        await licenseInit(licenseKey, userLicenseCodes, metaData);
+        await licenseInit(org, getUserCodesForOrg, getLicenseMetaData);
       });
 
       it("should still use cache (but we will show a warning)", () => {
@@ -261,7 +264,7 @@ describe("src/license", () => {
         } as unknown) as Response;
 
         mockedFetch.mockResolvedValueOnce(Promise.resolve(mockedResponse));
-        await licenseInit(licenseKey, userLicenseCodes, metaData);
+        await licenseInit(org, getUserCodesForOrg, getLicenseMetaData);
       });
 
       it("should return an error saying the server is down too long", () => {
@@ -287,7 +290,7 @@ describe("src/license", () => {
         } as unknown) as Response;
 
         mockedFetch.mockResolvedValueOnce(Promise.resolve(mockedResponse));
-        await licenseInit(licenseKey, userLicenseCodes, metaData);
+        await licenseInit(org, getUserCodesForOrg, getLicenseMetaData);
       });
 
       it("should return an error saying the server is down too long", () => {
@@ -311,7 +314,7 @@ describe("src/license", () => {
         } as unknown) as Response;
 
         mockedFetch.mockResolvedValueOnce(Promise.resolve(mockedResponse));
-        await licenseInit(licenseKey, userLicenseCodes, metaData);
+        await licenseInit(org, getUserCodesForOrg, getLicenseMetaData);
       });
 
       it("should return an error if the license is too old", () => {
@@ -329,8 +332,8 @@ describe("src/license", () => {
         } as unknown) as Response;
 
         mockedFetch.mockResolvedValueOnce(Promise.resolve(mockedResponse));
-        await licenseInit(licenseKey, userLicenseCodes, metaData);
-        await licenseInit(oldLicenseKey);
+        await licenseInit(org, getUserCodesForOrg, getLicenseMetaData);
+        await licenseInit({ id: org.id, licenseKey: oldLicenseKey });
       });
 
       it("should return an error saying the email is not verified", () => {
@@ -369,7 +372,7 @@ describe("src/license", () => {
         } as unknown) as Response;
 
         mockedFetch.mockResolvedValueOnce(Promise.resolve(mockedResponse));
-        await licenseInit(licenseKey, userLicenseCodes, metaData);
+        await licenseInit(org, getUserCodesForOrg, getLicenseMetaData);
       });
 
       it("should return an error that the license is invalid", () => {
@@ -390,7 +393,7 @@ describe("src/license", () => {
         } as unknown) as Response;
 
         mockedFetch.mockResolvedValueOnce(Promise.resolve(mockedResponse));
-        await licenseInit(licenseKey, userLicenseCodes, metaData);
+        await licenseInit(org, getUserCodesForOrg, getLicenseMetaData);
       });
 
       it("should return an error that the license is invalid", () => {
@@ -406,7 +409,7 @@ describe("src/license", () => {
         } as unknown) as Response;
 
         mockedFetch.mockResolvedValueOnce(Promise.resolve(mockedResponse));
-        await licenseInit(licenseKey, userLicenseCodes, metaData);
+        await licenseInit(org, getUserCodesForOrg, getLicenseMetaData);
       });
 
       it("should not have an error if the license is valid", () => {
@@ -449,7 +452,11 @@ describe("src/license", () => {
 
   describe("licenseInit and getLicense", () => {
     it("should set licenseData to null if licenseKey is not provided", async () => {
-      const result = await licenseInit(undefined, userLicenseCodes, metaData);
+      const result = await licenseInit(
+        { id: org.id },
+        getUserCodesForOrg,
+        getLicenseMetaData
+      );
 
       expect(result).toBeUndefined();
       expect(getLicense()).toBeNull();
@@ -473,33 +480,33 @@ describe("src/license", () => {
         it("should use the env variable if licenseKey argument is not provided", async () => {
           process.env.LICENSE_KEY = licenseKey;
           const result = await licenseInit(
-            undefined,
-            userLicenseCodes,
-            metaData
+            { id: org.id },
+            getUserCodesForOrg,
+            getLicenseMetaData
           );
 
           expect(getLicense()).toEqual(licenseData);
           expect(result).toEqual(licenseData);
         });
 
-        it("should throw an error if we call the function without userLicenseCodes or metadata", async () => {
+        it("should throw an error if we call the function without getUserCodesForOrg, or getLicenseMetaData", async () => {
           expect.assertions(2);
 
           await expect(
-            licenseInit(licenseKey, userLicenseCodes, undefined)
+            licenseInit(org, undefined, getLicenseMetaData)
           ).rejects.toThrowError(
-            "Missing userLicenseCodes or metaData for license key"
+            "Missing org, getUserCodesForOrg, or getLicenseMetaData for connected license key"
           );
 
           await expect(
-            licenseInit(licenseKey, undefined, metaData)
+            licenseInit(org, getUserCodesForOrg, undefined)
           ).rejects.toThrowError(
-            "Missing userLicenseCodes or metaData for license key"
+            "Missing org, getUserCodesForOrg, or getLicenseMetaData for connected license key"
           );
         });
 
         it("should call fetch once and the second time return in-memory cached license data if it exists and is not too old", async () => {
-          await licenseInit(licenseKey, userLicenseCodes, metaData);
+          await licenseInit(org, getUserCodesForOrg, getLicenseMetaData);
 
           expect(fetch).toHaveBeenCalledWith(
             `${LICENSE_SERVER_URL}license/${licenseKey}/check`,
@@ -517,7 +524,7 @@ describe("src/license", () => {
 
           expect(getLicense(licenseKey)).toEqual(licenseData);
 
-          await licenseInit(licenseKey, userLicenseCodes, metaData);
+          await licenseInit(org, getUserCodesForOrg, getLicenseMetaData);
           expect(getLicense(licenseKey)).toEqual(licenseData);
           expect(fetch).toHaveBeenCalledTimes(1);
           expect(LicenseModel.findOneAndReplace).toHaveBeenCalledTimes(1);
@@ -530,7 +537,7 @@ describe("src/license", () => {
         });
 
         it("should fetch the license from datastore if it is not in memory", async () => {
-          await licenseInit(licenseKey, userLicenseCodes, metaData);
+          await licenseInit(org, getUserCodesForOrg, getLicenseMetaData);
 
           expect(fetch).toHaveBeenCalledWith(
             `${LICENSE_SERVER_URL}license/${licenseKey}/check`,
@@ -551,7 +558,7 @@ describe("src/license", () => {
           jest
             .spyOn(LicenseModelModule, "getLicenseByKey")
             .mockResolvedValue(cloneDeep(licenseData));
-          await licenseInit(licenseKey, userLicenseCodes, metaData);
+          await licenseInit(org, getUserCodesForOrg, getLicenseMetaData);
 
           expect(getLicense(licenseKey)).toEqual({
             ...licenseData,
@@ -568,7 +575,7 @@ describe("src/license", () => {
         });
 
         it("should fetch the license from the license server if the license is not in memory and the datastore is too old", async () => {
-          await licenseInit(licenseKey, userLicenseCodes, metaData);
+          await licenseInit(org, getUserCodesForOrg, getLicenseMetaData);
 
           expect(fetch).toHaveBeenCalledWith(
             `${LICENSE_SERVER_URL}license/${licenseKey}/check`,
@@ -603,7 +610,7 @@ describe("src/license", () => {
 
           mockedFetch.mockResolvedValueOnce(Promise.resolve(mockedResponse2));
 
-          await licenseInit(licenseKey, userLicenseCodes, metaData);
+          await licenseInit(org, getUserCodesForOrg, getLicenseMetaData);
           expect(getLicense(licenseKey)).toEqual(licenseData2);
           expect(fetch).toHaveBeenCalledTimes(2);
         });
@@ -643,15 +650,15 @@ describe("src/license", () => {
             Array.from({ length: numRequests }).map(async (_, i) => {
               if (i % 2 === 0) {
                 return await licenseInit(
-                  licenseKey,
-                  userLicenseCodes,
-                  metaData
+                  org,
+                  getUserCodesForOrg,
+                  getLicenseMetaData
                 );
               } else {
                 return await licenseInit(
-                  licenseKey2,
-                  userLicenseCodes,
-                  metaData
+                  { id: org.id, licenseKey: licenseKey2 },
+                  getUserCodesForOrg,
+                  getLicenseMetaData
                 );
               }
             })
@@ -672,7 +679,7 @@ describe("src/license", () => {
         });
 
         it("should call fetch twice rather than use the in-memory cache if it has been over a day since the last fetch, and update the licenseData", async () => {
-          await licenseInit(licenseKey, userLicenseCodes, metaData);
+          await licenseInit(org, getUserCodesForOrg, getLicenseMetaData);
 
           expect(fetch).toHaveBeenCalledWith(
             `${LICENSE_SERVER_URL}license/${licenseKey}/check`,
@@ -699,13 +706,13 @@ describe("src/license", () => {
 
           mockedFetch.mockResolvedValueOnce(Promise.resolve(mockedResponse2));
 
-          await licenseInit(licenseKey, userLicenseCodes, metaData);
+          await licenseInit(org, getUserCodesForOrg, getLicenseMetaData);
           expect(getLicense(licenseKey)).toEqual(licenseData2);
           expect(fetch).toHaveBeenCalledTimes(2);
         });
 
         it("should call fetch twice rather than use the in-memory cache if forceRefresh flag is true", async () => {
-          await licenseInit(licenseKey, userLicenseCodes, metaData);
+          await licenseInit(org, getUserCodesForOrg, getLicenseMetaData);
 
           expect(getLicense(licenseKey)).toEqual(licenseData);
 
@@ -723,7 +730,7 @@ describe("src/license", () => {
 
           mockedFetch.mockResolvedValueOnce(Promise.resolve(mockedResponse2));
 
-          await licenseInit(licenseKey, userLicenseCodes, metaData, true);
+          await licenseInit(org, getUserCodesForOrg, getLicenseMetaData, true);
           expect(getLicense(licenseKey)).toEqual(licenseData2);
           expect(fetch).toHaveBeenCalledTimes(2);
         });
@@ -746,7 +753,12 @@ describe("src/license", () => {
 
           // Use force refresh to make sure the bad data is returned
           await expect(async () => {
-            await licenseInit(licenseKey, userLicenseCodes, metaData, true);
+            await licenseInit(
+              org,
+              getUserCodesForOrg,
+              getLicenseMetaData,
+              true
+            );
           }).rejects.toThrowError("Invalid license key signature");
 
           const expectedLicenseData = {
@@ -799,7 +811,7 @@ describe("src/license", () => {
 
           it("should throw error if the license server is down and there is no cached data in LicenseModel", async () => {
             await expect(async () => {
-              await licenseInit(licenseKey, userLicenseCodes, metaData);
+              await licenseInit(org, getUserCodesForOrg, getLicenseMetaData);
             }).rejects.toThrowError(
               "License server errored with: internal server error"
             );
@@ -823,7 +835,12 @@ describe("src/license", () => {
 
           it("should throw an error if force refresh is true and save the failures in the mongo cache", async () => {
             await expect(async () => {
-              await licenseInit(licenseKey, userLicenseCodes, metaData, true);
+              await licenseInit(
+                org,
+                getUserCodesForOrg,
+                getLicenseMetaData,
+                true
+              );
             }).rejects.toThrowError(
               "License server errored with: internal server error"
             );
@@ -851,7 +868,7 @@ describe("src/license", () => {
             const firstCallTime = now.getTime() + 2 * 24 * 60 * 60 * 1000;
             jest.setSystemTime(firstCallTime);
 
-            await licenseInit(licenseKey, userLicenseCodes, metaData);
+            await licenseInit(org, getUserCodesForOrg, getLicenseMetaData);
 
             // The previous license data in mongo cache should be returned as it calls the license server in the background
             expect(getLicense(licenseKey)).toEqual({
@@ -887,7 +904,7 @@ describe("src/license", () => {
 
             const secondCallTime = now.getTime() + 4 * 24 * 60 * 60 * 1000;
             jest.setSystemTime(secondCallTime);
-            await licenseInit(licenseKey, userLicenseCodes, metaData);
+            await licenseInit(org, getUserCodesForOrg, getLicenseMetaData);
 
             // The previous license data in mongo cache should be returned as it calls the license server in the background
             expect(getLicense(licenseKey)).toEqual(expectedLicenseData);
@@ -917,7 +934,12 @@ describe("src/license", () => {
             jest.setSystemTime(callTime);
 
             await expect(async () => {
-              await licenseInit(licenseKey, userLicenseCodes, metaData, true);
+              await licenseInit(
+                org,
+                getUserCodesForOrg,
+                getLicenseMetaData,
+                true
+              );
             }).rejects.toThrowError(
               "License server errored with: internal server error"
             );
@@ -947,7 +969,7 @@ describe("src/license", () => {
 
           it("should await fetch", async () => {
             await expect(async () => {
-              await licenseInit(licenseKey, userLicenseCodes, metaData);
+              await licenseInit(org, getUserCodesForOrg, getLicenseMetaData);
             }).rejects.toThrowError(
               "License server errored with: internal server error"
             );
@@ -966,6 +988,8 @@ describe("src/license", () => {
     });
 
     describe("old style licenses where licenseKey does NOT start with 'license_' but contains the license data encoded in itself", () => {
+      const orgWithOldKey = { id: "org_123", licenseKey: oldLicenseKey };
+
       it("should use the env variable if the licenseKey argument references an expired license", async () => {
         const licenseData3 = cloneDeep(licenseData);
         const tenDaysAgo = new Date(now);
@@ -982,9 +1006,9 @@ describe("src/license", () => {
 
         process.env.LICENSE_KEY = oldLicenseKey;
         const result = await licenseInit(
-          licenseKey,
-          userLicenseCodes,
-          metaData
+          org,
+          getUserCodesForOrg,
+          getLicenseMetaData
         );
 
         expect(getLicense(licenseKey)).toEqual(oldLicenseData);
@@ -1001,9 +1025,9 @@ describe("src/license", () => {
 
         process.env.LICENSE_KEY = oldLicenseKey;
         const result = await licenseInit(
-          licenseKey,
-          userLicenseCodes,
-          metaData
+          org,
+          getUserCodesForOrg,
+          getLicenseMetaData
         );
 
         expect(getLicense(licenseKey)).toEqual(licenseData);
@@ -1011,7 +1035,7 @@ describe("src/license", () => {
       });
 
       it("should read license data from the key itself and use the in-memory cache if called a second time, even if a long time has passed, as old style license keys should never expire", async () => {
-        await licenseInit(oldLicenseKey);
+        await licenseInit(orgWithOldKey);
 
         expect(getLicense(oldLicenseKey)).toEqual(oldLicenseData);
 
@@ -1020,13 +1044,21 @@ describe("src/license", () => {
         jest.setSystemTime(tenYearsFromNow);
         jest.spyOn(JSON, "parse").mockReturnValue({ foo: "bar" }); // This is an invalid license, but we should use the cache so won't see an error.
 
-        await licenseInit(oldLicenseKey, userLicenseCodes, metaData);
+        await licenseInit(
+          orgWithOldKey,
+          getUserCodesForOrg,
+          getLicenseMetaData
+        );
         expect(getLicense(oldLicenseKey)).toEqual(oldLicenseData);
       });
 
       it("should throw an error if the data doesn't match the signature", async () => {
         await expect(
-          async () => await licenseInit(oldLicenseKey + "extrasignature")
+          async () =>
+            await licenseInit({
+              id: org.id,
+              licenseKey: oldLicenseKey + "extrasignature",
+            })
         ).rejects.toThrowError("Invalid license key signature");
       });
 
@@ -1038,7 +1070,7 @@ describe("src/license", () => {
         delete oldLicenseOriginalData2.exp;
         jest.spyOn(JSON, "parse").mockReturnValue(oldLicenseOriginalData2);
 
-        await licenseInit(oldLicenseKey);
+        await licenseInit(orgWithOldKey);
 
         expect(getLicense(oldLicenseKey)).toEqual(oldLicenseData);
       });
@@ -1050,7 +1082,7 @@ describe("src/license", () => {
         jest.spyOn(JSON, "parse").mockReturnValue(oldLicenseOriginalData2);
 
         await expect(async () => {
-          await licenseInit(oldLicenseKey);
+          await licenseInit(orgWithOldKey);
         }).rejects.toThrowError(
           "Invalid License Key - Missing expiration date"
         );
@@ -1062,7 +1094,7 @@ describe("src/license", () => {
         delete oldLicenseOriginalData2.plan;
         jest.spyOn(JSON, "parse").mockReturnValue(oldLicenseOriginalData2);
 
-        await licenseInit(oldLicenseKey);
+        await licenseInit(orgWithOldKey);
 
         const expected = cloneDeep(oldLicenseData);
         expected.plan = "enterprise";


### PR DESCRIPTION
### Features and Changes
We were calling to get the meta data and user keys on every request when we only need when we call the license server. This PR ends up passing the org, and the functions needed to get the metadata and user codes into license init instead of the codes and the metadata itself.  This we can call it right before we call the license server.

In doing so it removed the need to have a separate getLicenseKeyForOrg function and the callers can call licenseInit directly.

### Testing
`yarn test`
Set the following env vars:
`LICENSE_SERVER_URL=http://localhost:8080/api/v1/`
and `LICENSE_KEY=<A valid license key>` on the dev license server
Remove any licenses in `growthbook.licenses` in mongo.

Start the dev license server.
Start the dev growthbook server and see that it fetches the license from the license server in the logger info.
Look at the most recent audit in `license.audits` in mongo and see that the latest `license.check` type audit just happened.
See that the user license codes and the meta data are part of the audit's `data`.

Remove the `LICENSE_KEY` env var.
Restart the dev growthbook server and see that it fetches the license from the license server in the logger info.
Look at the most recent audit in `license.audits` in mongo and see that the latest `license.check` type audit just happened.
See that the user license codes and the meta data are part of the audit's `data`
