### PR TITLE
Only lock for licenses when actually about to fetch.

### DIFF
--- a/packages/enterprise/test/license.test.ts
+++ b/packages/enterprise/test/license.test.ts
@@ -533,7 +533,7 @@ describe("src/license", () => {
             licenseData,
             { upsert: true }
           );
-          expect(LicenseModelModule.getLicenseByKey).toHaveBeenCalledTimes(1);
+          expect(LicenseModelModule.getLicenseByKey).toHaveBeenCalledTimes(2);
         });
 
         it("should fetch the license from datastore if it is not in memory", async () => {
@@ -571,7 +571,7 @@ describe("src/license", () => {
             licenseData,
             { upsert: true }
           );
-          expect(LicenseModelModule.getLicenseByKey).toHaveBeenCalledTimes(2);
+          expect(LicenseModelModule.getLicenseByKey).toHaveBeenCalledTimes(3);
         });
 
         it("should fetch the license from the license server if the license is not in memory and the datastore is too old", async () => {


### PR DESCRIPTION
### Features and Changes
The license server is not guaranteed to be fast. When we hit a page we often send off numerous back-end requests, which when it is time to fetch a license would fetch it multiple times.  So we had a lock to make sure that we only call it once and the remaining requests on the one server or others wait for the cache to be populated.  However this locking was done on pretty much ever request, and if there was database contention would end up slowing all requests as it read from the cache one after the other.  

This PR first checks the cache and only locks if we really need to call the license server, which happens once a day.  It does mean we need to read from the cache a second time in case a different server wrote to the mongo cache in this instance.  But that extra slight inefficiency is outweighed by reducing the possibility of lock contention down to a few seconds once a day.    

### Testing

`yarn test`
