### PR TITLE
Don't allow superAdmins to create extra organizations if the license doesn't allow it

### DIFF
--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -8,6 +8,7 @@ import {
   getLicense,
   getLicenseError,
   licenseInit,
+  orgHasPremiumFeature,
 } from "enterprise";
 import { experimentHasLinkedChanges } from "shared/util";
 import {
@@ -1200,8 +1201,11 @@ export async function signup(req: AuthRequest<SignupBody>, res: Response) {
     // there are odd edge cases where a user can exist, but not an org,
     // so we want to allow org creation this way if there are no other orgs
     // on a local install.
-    if (orgs && !req.superAdmin) {
-      throw new Error("An organization already exists");
+    if (orgs) {
+      const { org } = getContextFromReq(req);
+      if (!req.superAdmin || !orgHasPremiumFeature(org, "multi-org")) {
+        throw new Error("An organization already exists");
+      }
     }
   }
 

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -8,7 +8,6 @@ import {
   getLicense,
   getLicenseError,
   licenseInit,
-  orgHasPremiumFeature,
 } from "enterprise";
 import { experimentHasLinkedChanges } from "shared/util";
 import {
@@ -1197,16 +1196,9 @@ export async function signup(req: AuthRequest<SignupBody>, res: Response) {
   const { company, externalId } = req.body;
 
   const orgs = await hasOrganization();
-  if (!IS_MULTI_ORG) {
-    // there are odd edge cases where a user can exist, but not an org,
-    // so we want to allow org creation this way if there are no other orgs
-    // on a local install.
-    if (orgs) {
-      const { org } = getContextFromReq(req);
-      if (!req.superAdmin || !orgHasPremiumFeature(org, "multi-org")) {
-        throw new Error("An organization already exists");
-      }
-    }
+  // Only allow one organization per site unless IS_MULTI_ORG is true
+  if (!IS_MULTI_ORG && orgs) {
+    throw new Error("An organization already exists");
   }
 
   let verifiedDomain = "";


### PR DESCRIPTION
### Features and Changes

If someone sets superAdmin in mongo, even when IS_MULTI_ORG=false, and then they navigate to /admin page directly they see the page.  Furthermore they were able to add a new organization as we were were not throwing an error if they were a superAdmin.  But if IS_MULTI_ORG is false then superAdmin's shouldn't even exist.

In separate PRs I will close down the other back-end routes, and then another one the front-end /admin page.  I'm doing it separately otherwise the testing would be too tricky.

### Testing
In .env.local set 
```
IS_MULTI_ORG=false
```
Set superAdmin=true on your user in mongo
Go to /admin page.
Click Add Organization.
Fill out the form and submit.
See the error that "An organization already exists".