### PR TITLE
No /admin page access if they are not enterprise

### DIFF
--- a/packages/front-end/pages/admin.tsx
+++ b/packages/front-end/pages/admin.tsx
@@ -198,8 +198,7 @@ const Admin: FC = () => {
 
   const { orgId, setOrgId, setSpecialOrg, apiCall } = useAuth();
 
-  const { superAdmin } = useUser();
-
+  const { license, superAdmin } = useUser();
   const [orgs, setOrgs] = useState<OrganizationInterface[]>([]);
   const [total, setTotal] = useState(0);
   const [error, setError] = useState("");
@@ -239,10 +238,10 @@ const Admin: FC = () => {
 
   const [orgModalOpen, setOrgModalOpen] = useState(false);
 
-  if (!superAdmin) {
+  if (license?.plan != "enterprise" || !superAdmin) {
     return (
       <div className="alert alert-danger">
-        Only super admins can view this page
+        Only super admins on an enterprise license can view this page
       </div>
     );
   }


### PR DESCRIPTION
### Features and Changes

https://github.com/growthbook/growthbook/pull/2643 stopped someone just setting themselves to be superAdmin in order to be able to create multiple orgs, there is no need for them to see the admin page at all unless they have an enterprise license.

### Testing

In .env.local set
```
IS_MULTI_ORG=false
```
Set superAdmin=true on your user in mongo
Go to /admin page.
See the error message "Only super admins on an enterprise license can view this page"
