### PR TITLE
Add job to delete old AgendaJobs

### DIFF
--- a/packages/back-end/src/init/queue.ts
+++ b/packages/back-end/src/init/queue.ts
@@ -32,6 +32,9 @@ export async function queueInit() {
   refreshFactTableColumns(agenda);
   addSdkWebhooksJob(agenda);
   updateLicenseJob(agenda);
+
+  // Make sure we have index needed to delete efficiently
+  agenda._collection.createIndex({ lastFinishedAt: -1, nextRunAt: -1 });
   deleteOldAgendaJobs(agenda);
 
   await agenda.start();

--- a/packages/back-end/src/init/queue.ts
+++ b/packages/back-end/src/init/queue.ts
@@ -34,7 +34,7 @@ export async function queueInit() {
   updateLicenseJob(agenda);
 
   // Make sure we have index needed to delete efficiently
-  agenda._collection.createIndex({ lastFinishedAt: -1, nextRunAt: -1 });
+  agenda._collection.createIndex({ lastFinishedAt: 1, nextRunAt: 1 });
   deleteOldAgendaJobs(agenda);
 
   await agenda.start();

--- a/packages/back-end/src/init/queue.ts
+++ b/packages/back-end/src/init/queue.ts
@@ -13,6 +13,7 @@ import updateStaleInformationSchemaTable from "../jobs/updateStaleInformationSch
 import expireOldQueries from "../jobs/expireOldQueries";
 import addSdkWebhooksJob from "../jobs/sdkWebhooks";
 import updateLicenseJob, { queueUpdateLicense } from "../jobs/updateLicense";
+import deleteOldAgendaJobs from "../jobs/deleteOldAgendaJobs";
 
 export async function queueInit() {
   if (!CRON_ENABLED) return;
@@ -31,6 +32,7 @@ export async function queueInit() {
   refreshFactTableColumns(agenda);
   addSdkWebhooksJob(agenda);
   updateLicenseJob(agenda);
+  deleteOldAgendaJobs(agenda);
 
   await agenda.start();
 

--- a/packages/back-end/src/jobs/deleteOldAgendaJobs.ts
+++ b/packages/back-end/src/jobs/deleteOldAgendaJobs.ts
@@ -13,7 +13,7 @@ const deleteOldAgendaJobs = trackJob(JOB_NAME, async () => {
   const res = await agenda._collection
     .find(
       {
-        lastFinishedAt: { $lt: new Date(Date.now() - 0.0 * 24 * 3600 * 1000) },
+        lastFinishedAt: { $lt: new Date(Date.now() - 7 * 24 * 3600 * 1000) },
         nextRunAt: null,
       },
       {

--- a/packages/back-end/src/jobs/deleteOldAgendaJobs.ts
+++ b/packages/back-end/src/jobs/deleteOldAgendaJobs.ts
@@ -1,0 +1,26 @@
+import Agenda from "agenda";
+import { trackJob } from "../services/otel";
+import { getAgendaInstance } from "../services/queueing";
+import { logger } from "../util/logger";
+const JOB_NAME = "deleteOldAgendaJobs";
+
+const deleteOldAgendaJobs = trackJob(JOB_NAME, async () => {
+  // Delete old agenda jobs that finished over 24 hours ago and are not going to be repeated
+  const agenda = getAgendaInstance();
+
+  const numDeleted = await agenda.cancel({
+    lastFinishedAt: { $lt: new Date(Date.now() - 24 * 3600 * 1000) },
+    nextRunAt: null,
+  });
+
+  logger.info(`Deleted ${numDeleted} old agenda jobs`);
+});
+
+export default async function (agenda: Agenda) {
+  agenda.define(JOB_NAME, deleteOldAgendaJobs);
+
+  const job = agenda.create(JOB_NAME, {});
+  job.unique({});
+  job.repeatEvery("1 day");
+  await job.save();
+}

--- a/packages/back-end/src/jobs/deleteOldAgendaJobs.ts
+++ b/packages/back-end/src/jobs/deleteOldAgendaJobs.ts
@@ -4,8 +4,8 @@ import { getAgendaInstance } from "../services/queueing";
 import { logger } from "../util/logger";
 const JOB_NAME = "deleteOldAgendaJobs";
 
+// Delete old agenda jobs that finished over one week ago and are not going to be repeated
 const deleteOldAgendaJobs = trackJob(JOB_NAME, async () => {
-  // Delete old agenda jobs that finished over 24 hours ago and are not going to be repeated
   const agenda = getAgendaInstance();
 
   const startDate = Date.now();


### PR DESCRIPTION
### Features and Changes

Cloud currently has 5M AgendaJobs.  The sheer number on cloud and other self hosted installations might be causing queries to run slower than they normally would have.

I have run an aggregation which took about 5s before the index to find a count of the documents that would be deleted on Cloud.  After the index it took around 30ms.  We tried deleteing in the way we have in this PR and it took about 1ms per job.  1000 was taking about 1s.  

We have about 4912012 jobs. 
We create about 33226 a day.
Hence we do a write every 2-3s.
Hence blocking write for 1s every 5 minutes shouldn't have too many knock on effects.

We need to delete 4878786 jobs.
So the cron would need to run approx 5k times.
So it should catch up in about 4878 * 5 /60 / 24 = 17 days. 
Plus another 2 days or so for all the new jobs we will create in that time.

- Closes https://github.com/growthbook/growthbook/issues/2116

### Testing

Search in Mongo 
```
{
    lastFinishedAt: { $lt: new Date(Date.now() - 24 * 3600 * 1000) },
    nextRunAt: null,
  }
```
on AgendaJobs and saw there were 17 documents.
Started dev server and saw in the logs that it deleted 17 documents.
Looked in Mongo and saw that there were 17 fewer AgendaJob documents afterwards.
