### PR TITLE
Make `useFeatureIsOn` reactive to growthbook value

### DIFF
--- a/packages/sdk-react/package.json
+++ b/packages/sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@growthbook/growthbook-react",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/sdk-react/src/GrowthBookReact.tsx
+++ b/packages/sdk-react/src/GrowthBookReact.tsx
@@ -79,7 +79,7 @@ export function useFeatureIsOn<
   AppFeatures extends Record<string, any> = Record<string, any>
 >(id: string & keyof AppFeatures): boolean {
   const growthbook = useGrowthBook<AppFeatures>();
-  const [isOn, setIsOn] = React.useState(false);
+  const [isOn, setIsOn] = React.useState(growthbook.isOn(id));
 
   React.useEffect(() => {
     if (growthbook) {

--- a/packages/sdk-react/src/GrowthBookReact.tsx
+++ b/packages/sdk-react/src/GrowthBookReact.tsx
@@ -82,9 +82,7 @@ export function useFeatureIsOn<
   const [isOn, setIsOn] = React.useState(growthbook.isOn(id));
 
   React.useEffect(() => {
-    if (growthbook) {
-      setIsOn(growthbook.isOn(id));
-    }
+    setIsOn(growthbook.isOn(id));
   }, [id, growthbook]);
 
   return isOn;

--- a/packages/sdk-react/src/GrowthBookReact.tsx
+++ b/packages/sdk-react/src/GrowthBookReact.tsx
@@ -79,7 +79,15 @@ export function useFeatureIsOn<
   AppFeatures extends Record<string, any> = Record<string, any>
 >(id: string & keyof AppFeatures): boolean {
   const growthbook = useGrowthBook<AppFeatures>();
-  return growthbook.isOn(id);
+  const [isOn, setIsOn] = React.useState(false);
+
+  React.useEffect(() => {
+    if (growthbook) {
+      setIsOn(growthbook.isOn(id));
+    }
+  }, [id, growthbook]);
+
+  return isOn;
 }
 
 export function useFeatureValue<T extends JSONValue = any>(

--- a/packages/shared/src/sdk-versioning/sdk-versions/react.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/react.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "version": "1.0.1"
+      "version": "1.0.2"
     },
     {
       "version": "1.0.0"


### PR DESCRIPTION
### Features and Changes
Makes `useFeatureIsOn` reactive to growthbook value. 

- `useFeatureIsOn` returned `false` when called before growthbook has loaded.
- This change introduces a state variable and a useEffect hook to listen for updates from growthbook and keep `useFeatureIsOn` reactive.

- Closes [https://github.com/growthbook/growthbook/issues/2594](https://github.com/growthbook/growthbook/issues/2594)

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

<!--
  Please describe how to test these changes.
 -->

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
