### PR TITLE
Fix yarn clean

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lint:ci": "eslint './**/*.{ts,tsx,js,jsx}' --max-warnings 0 --cache --cache-strategy content",
     "pretty": "prettier --write ./**/*.{json,css,scss,md,mdx}",
     "type-check": "wsrun -m type-check",
-    "clean": "rimraf node_modules && wsrun -m clean && yarn cache clean",
+    "clean": "wsrun -m clean && rimraf node_modules && yarn cache clean",
     "unused-export-check": "wsrun -m unused-export-check",
     "test": "wsrun -m test",
     "dev:apps": "wsrun -p 'back-end' -p 'front-end' -p 'shared' -p 'enterprise' -c dev",


### PR DESCRIPTION
### Features and Changes
`yarn clean` was failing because after node_modules from the root directory was removed then `wsrun` no longer existed and I was getting a `command not found` on it.  So I had to swap the order so first it cleaned all the packages first and then the root directory.

### Testing
`yarn clean`
Saw it complete without errors.
