### PR TITLE
Fix super admin page on cloud

### DIFF
--- a/packages/front-end/pages/admin.tsx
+++ b/packages/front-end/pages/admin.tsx
@@ -238,10 +238,17 @@ const Admin: FC = () => {
 
   const [orgModalOpen, setOrgModalOpen] = useState(false);
 
-  if (license?.plan != "enterprise" || !superAdmin) {
+  if (!superAdmin) {
     return (
       <div className="alert alert-danger">
-        Only super admins on an enterprise license can view this page
+        Only super admins can view this page
+      </div>
+    );
+  }
+  if (!isCloud() && license?.plan != "enterprise") {
+    return (
+      <div className="alert alert-danger">
+        You must be on an enterprise license to view this page
       </div>
     );
   }


### PR DESCRIPTION
### Features and Changes

The super admin page currently requires an enterprise license key to view.  This makes sense on self-hosted installations, but on Cloud, every org has their own license and the super admin page lives at a higher level.