### PR TITLE
Fix Create Sample Data button

### DIFF
--- a/packages/back-end/src/models/BaseModel.ts
+++ b/packages/back-end/src/models/BaseModel.ts
@@ -393,9 +393,6 @@ export abstract class BaseModel<
   ) {
     const props = this.createValidator.parse(rawData);
 
-    if (this.config.globallyUniqueIds && "id" in props) {
-      throw new Error("Cannot set a custom id for this model");
-    }
     if ("organization" in props) {
       throw new Error("Cannot set organization field");
     }


### PR DESCRIPTION
### Features and Changes

The button to view the sample experiment in Get Started was unintentionally broken in #2505 due to unnecessarily strict validation in the new data model classes.  This PR relaxes the checks.