### PR TITLE
Fix missing dateUpdated for experiments

### DIFF
--- a/packages/back-end/src/models/ExperimentModel.ts
+++ b/packages/back-end/src/models/ExperimentModel.ts
@@ -388,18 +388,23 @@ export async function updateExperiment({
   changes: Changeset;
   bypassWebhooks?: boolean;
 }): Promise<ExperimentInterface> {
+  // TODO: are there some changes where we don't want to update the dateUpdated?
+  const allChanges = { ...changes };
+  allChanges.dateUpdated = new Date();
+
   await ExperimentModel.updateOne(
     {
       id: experiment.id,
       organization: context.org.id,
     },
     {
-      $set: changes,
+      $set: allChanges,
     }
   );
 
-  const updated = { ...experiment, ...changes };
+  const updated = { ...experiment, ...allChanges };
 
+  // TODO: are there some changes where we want to skip calling this?
   await onExperimentUpdate({
     context,
     oldExperiment: experiment,


### PR DESCRIPTION
### Features and Changes

When making experiment updates, we were not setting the `dateUpdated` field properly.  This isn't used for anything in the app, but it is exposed via the REST api, so having an accurate date here is important for people building workflows on top of GrowthBook.