### PR TITLE
Make proxy webhooks optional

### DIFF
--- a/docs/docs/self-host/proxy.mdx
+++ b/docs/docs/self-host/proxy.mdx
@@ -70,7 +70,10 @@ SECRET_API_KEY=something_secret
 
 ### Cloud Customers
 
-For cloud customers who self-host a proxy server, you must configure each SDK Connection to use a custom proxy webhook URL.
+For cloud customers who self-host a proxy server, you must configure each SDK Connection to use the proxy server.
+
+You may optionally enter your proxy server's public host URL. This enables faster rollouts by allowing GrowthBook to push updates to your proxy whenever your feature definitions change. If you do not provide a proxy host URL, your proxy server the proxy will fall back to a pull-based stale-while-revalidate caching strategy.
+
 Go to **SDK Configuration → SDK Connections** in the GrowthBook app to configure the proxy server per each connection.
 
 ## Using with the SDKs

--- a/docs/docs/self-host/proxy.mdx
+++ b/docs/docs/self-host/proxy.mdx
@@ -68,6 +68,8 @@ PROXY_HOST_PUBLIC=https://growthbook-proxy.example.com
 SECRET_API_KEY=something_secret
 ```
 
+Note: Setting `PROXY_HOST_PUBLIC` is not strictly required, but is considered a best practice. Setting it enables faster rollouts by allowing GrowthBook to push updates to your proxy whenever feature definitions change.
+
 ### Cloud Customers
 
 For cloud customers who self-host a proxy server, you must configure each SDK Connection to use the proxy server.

--- a/docs/docs/webhooks/overview.mdx
+++ b/docs/docs/webhooks/overview.mdx
@@ -57,7 +57,7 @@ These are similar to SDK webhooks, but are not limited to a single SDK Connectio
 
 Similar to SDK webhooks, this webhook is a special use webhook for communicating with the GrowthBook Proxy. Unlike SDK webhooks, proxy webhooks are not customizable.
 
-- Self-hosted users must configure a single global proxy webhook using environment variables.
+- Self-hosted users should configure a single global proxy webhook using environment variables.
 - Cloud users may optionally configure a GrowthBook Proxy webhook for each SDK Connection.
 
 ## Notable Mentions

--- a/docs/docs/webhooks/overview.mdx
+++ b/docs/docs/webhooks/overview.mdx
@@ -58,7 +58,7 @@ These are similar to SDK webhooks, but are not limited to a single SDK Connectio
 Similar to SDK webhooks, this webhook is a special use webhook for communicating with the GrowthBook Proxy. Unlike SDK webhooks, proxy webhooks are not customizable.
 
 - Self-hosted users must configure a single global proxy webhook using environment variables.
-- Cloud users must configure a GrowthBook Proxy webhook for each SDK Connection.
+- Cloud users may optionally configure a GrowthBook Proxy webhook for each SDK Connection.
 
 ## Notable Mentions
 

--- a/packages/back-end/src/jobs/proxyUpdate.ts
+++ b/packages/back-end/src/jobs/proxyUpdate.ts
@@ -60,6 +60,14 @@ const proxyUpdate = trackJob(
       return;
     }
 
+    if (!useCloudProxy && !connection.proxy.host) {
+      logger.error("proxyUpdate: Proxy host is missing", {
+        connectionId,
+        useCloudProxy,
+      });
+      return;
+    }
+
     const environmentDoc = context.org?.settings?.environments?.find(
       (e) => e.id === connection.environment
     );

--- a/packages/back-end/src/models/SdkConnectionModel.ts
+++ b/packages/back-end/src/models/SdkConnectionModel.ts
@@ -74,6 +74,7 @@ const SDKConnectionModel = mongoose.model<SDKConnectionInterface>(
 );
 
 function addEnvProxySettings(proxy: ProxyConnection): ProxyConnection {
+  // TOOD: remove when done testing!!!
   return proxy;
   if (IS_CLOUD) return proxy;
 

--- a/packages/back-end/src/models/SdkConnectionModel.ts
+++ b/packages/back-end/src/models/SdkConnectionModel.ts
@@ -483,7 +483,7 @@ export async function testProxyConnection(
       error:
         e?.code === "ECONNREFUSED"
           ? "Failed to connect to proxy server (ECONNREFUSED)"
-          : e.message,
+          : e.message || "Failed to connect to proxy server",
       version: "",
       url,
     };

--- a/packages/back-end/src/routers/sdk-connection/sdk-connection.controller.ts
+++ b/packages/back-end/src/routers/sdk-connection/sdk-connection.controller.ts
@@ -172,7 +172,7 @@ export const checkSDKConnectionProxyStatus = async (
   req: AuthRequest<null, { id: string }>,
   res: Response<{
     status: 200;
-    result: ProxyTestResult;
+    result?: ProxyTestResult;
   }>
 ) => {
   const { id } = req.params;

--- a/packages/front-end/components/Features/CodeSnippetModal.tsx
+++ b/packages/front-end/components/Features/CodeSnippetModal.tsx
@@ -35,9 +35,11 @@ function trimTrailingSlash(str: string): string {
 }
 
 export function getApiBaseUrl(connection?: SDKConnectionInterface): string {
-  if (connection && connection.proxy.enabled && connection.proxy.host) {
+  if (connection && connection.proxy.enabled) {
     return trimTrailingSlash(
-      connection.proxy.hostExternal || connection.proxy.host
+      connection.proxy.hostExternal ||
+        connection.proxy.host ||
+        "https://proxy.yoursite.io"
     );
   }
 
@@ -115,8 +117,7 @@ export default function CodeSnippetModal({
   }
 
   const { docs, docLabel, label } = languageMapping[language];
-  const hasProxy =
-    currentConnection.proxy.enabled && !!currentConnection.proxy.host;
+  const hasProxy = currentConnection.proxy.enabled;
   const apiHost = getApiBaseUrl(currentConnection);
   const clientKey = currentConnection.key;
   const featuresEndpoint = apiHost + "/api/features/" + clientKey;

--- a/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
+++ b/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
@@ -1031,10 +1031,8 @@ export default function SDKConnectionForm({
         {isCloud() && (
           <div className="mt-5">
             <label className="mb-1">GrowthBook Proxy</label>
-            <div
-              className="d-flex align-items-top mt-2"
-              style={{ justifyContent: "space-between" }}
-            >
+            <div className="mt-2">
+              {/*<div className="bg-highlight rounded pt-3 pb-3 px-4 mb-4">*/}
               <div className="d-flex align-items-center">
                 <Toggle
                   id="sdk-connection-proxy-toggle"
@@ -1048,24 +1046,39 @@ export default function SDKConnectionForm({
                   Use GrowthBook Proxy
                 </label>
               </div>
-
               {form.watch("proxyEnabled") && (
-                <div className="d-flex align-items-center">
-                  <label
-                    className="mr-2 mb-0"
-                    htmlFor="sdk-connection-proxyHost"
-                  >
-                    Proxy Host URL
-                  </label>
-                  <Field
-                    id="sdk-connection-proxyHost"
-                    required
-                    placeholder="https://"
-                    type="url"
-                    style={{ width: 350 }}
-                    {...form.register("proxyHost")}
-                  />
-                </div>
+                <Field
+                  id="sdk-connection-proxyHost"
+                  containerClassName="mt-3"
+                  label={
+                    <>
+                      Proxy Host URL <small>(optional)</small>
+                      <Tooltip
+                        className="ml-1"
+                        body={
+                          <>
+                            <p>
+                              Optionally add your proxy&apos;s public URL to
+                              enable faster rollouts. Providing your proxy host
+                              will allow GrowthBook to push updates to your
+                              proxy whenever feature definitions change.
+                            </p>
+                            <p className="mb-0">
+                              Without GrowthBook&apos;s push updates, the proxy
+                              will fall back to a stale-while-revalidate caching
+                              strategy.
+                            </p>
+                          </>
+                        }
+                      >
+                        <FaInfoCircle />
+                      </Tooltip>
+                    </>
+                  }
+                  placeholder="https://"
+                  type="url"
+                  {...form.register("proxyHost")}
+                />
               )}
             </div>
           </div>

--- a/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
+++ b/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
@@ -1032,7 +1032,6 @@ export default function SDKConnectionForm({
           <div className="mt-5">
             <label className="mb-1">GrowthBook Proxy</label>
             <div className="mt-2">
-              {/*<div className="bg-highlight rounded pt-3 pb-3 px-4 mb-4">*/}
               <div className="d-flex align-items-center">
                 <Toggle
                   id="sdk-connection-proxy-toggle"

--- a/packages/front-end/components/Features/SDKConnections/SDKLanguageLogo.tsx
+++ b/packages/front-end/components/Features/SDKConnections/SDKLanguageLogo.tsx
@@ -188,7 +188,7 @@ export const languageMapping: Record<SDKLanguage, LanguageLogo> = {
     docLabel: "Fastly Compute",
     docs: "edge",
     type: "edge",
-    filters: ["edge"],
+    filters: ["edge", "popular"],
     extra: (
       <span
         className="badge badge-purple text-uppercase position-absolute"

--- a/packages/front-end/components/Features/SDKConnections/SDKLanguageSelector.tsx
+++ b/packages/front-end/components/Features/SDKConnections/SDKLanguageSelector.tsx
@@ -29,7 +29,7 @@ function LanguageOption({
 }) {
   return (
     <div
-      className={`hover-highlight cursor-pointer border rounded mr-2 mb-2 ${
+      className={`hover-highlight cursor-pointer border rounded ${
         selected.has(language) ? "bg-light" : ""
       }`}
       style={{
@@ -109,7 +109,7 @@ export default function SDKLanguageSelector({
     );
   };
 
-  const frontEnd = filterLanguages(["javascript", "react"]);
+  const frontEnd = filterLanguages(["javascript", "react", "nocode-other"]);
   const backEnd = filterLanguages([
     "nodejs",
     "php",
@@ -131,7 +131,6 @@ export default function SDKLanguageSelector({
     "nocode-shopify",
     "nocode-wordpress",
     "nocode-webflow",
-    "nocode-other",
   ]);
 
   if (useTabs) {
@@ -159,7 +158,10 @@ export default function SDKLanguageSelector({
             }
             padding={false}
           >
-            <div className="d-flex flex-wrap">
+            <div
+              className="d-flex flex-wrap pb-3"
+              style={{ rowGap: "1em", columnGap: "0.6em" }}
+            >
               {languages.map((l) => (
                 <LanguageOption
                   key={l}
@@ -186,7 +188,10 @@ export default function SDKLanguageSelector({
                 <strong>Back-end</strong>
               </div>
             )}
-            <div className="d-flex flex-wrap">
+            <div
+              className="d-flex flex-wrap pb-3"
+              style={{ rowGap: "1em", columnGap: "0.6em" }}
+            >
               {backEnd.map((l) => (
                 <LanguageOption
                   key={l}
@@ -206,7 +211,10 @@ export default function SDKLanguageSelector({
                 <strong>Front-end</strong>
               </div>
             )}
-            <div className="d-flex align-items-center">
+            <div
+              className="d-flex flex-wrap pb-3"
+              style={{ rowGap: "1em", columnGap: "0.6em" }}
+            >
               {frontEnd.map((l) => (
                 <LanguageOption
                   key={l}
@@ -226,7 +234,10 @@ export default function SDKLanguageSelector({
                 <strong>Mobile</strong>
               </div>
             )}
-            <div className="d-flex">
+            <div
+              className="d-flex flex-wrap pb-3"
+              style={{ rowGap: "1em", columnGap: "0.6em" }}
+            >
               {mobile.map((l) => (
                 <LanguageOption
                   key={l}
@@ -246,7 +257,10 @@ export default function SDKLanguageSelector({
                 <strong>Edge</strong>
               </div>
             )}
-            <div className="d-flex">
+            <div
+              className="d-flex flex-wrap pb-3"
+              style={{ rowGap: "1em", columnGap: "0.6em" }}
+            >
               {edge.map((l) => (
                 <LanguageOption
                   key={l}
@@ -266,7 +280,10 @@ export default function SDKLanguageSelector({
                 <strong>No/Low Code Platform</strong>
               </div>
             )}
-            <div className="d-flex">
+            <div
+              className="d-flex flex-wrap pb-3"
+              style={{ rowGap: "1em", columnGap: "0.6em" }}
+            >
               {nocode.map((l) => (
                 <LanguageOption
                   key={l}

--- a/packages/front-end/pages/sdks/[sdkid].tsx
+++ b/packages/front-end/pages/sdks/[sdkid].tsx
@@ -400,17 +400,15 @@ export default function SDKConnectionPage() {
           connected={connection.connected}
           canRefresh={canUpdate && !connection.connected}
           refresh={
-            connection.proxy.host ? (
-              <Button
-                color="link"
-                className="btn-sm"
-                onClick={async () => {
-                  await mutate();
-                }}
-              >
-                <BsArrowRepeat /> re-check
-              </Button>
-            ) : undefined
+            <Button
+              color="link"
+              className="btn-sm"
+              onClick={async () => {
+                await mutate();
+              }}
+            >
+              <BsArrowRepeat /> re-check
+            </Button>
           }
         />
         {hasProxy && (
@@ -431,18 +429,16 @@ export default function SDKConnectionPage() {
 
             <ConnectionStatus
               connected={connection.proxy.connected}
-              canRefresh={canUpdate}
+              canRefresh={canUpdate && connection.proxy.host}
               error={!connection.proxy.connected}
               errorTxt={connection.proxy.error}
               refresh={
-                connection.proxy.host ? (
-                  <ProxyTestButton
-                    host={connection.proxy.host}
-                    id={connection.id}
-                    mutate={mutate}
-                    showButton={true}
-                  />
-                ) : undefined
+                <ProxyTestButton
+                  host={connection.proxy.host}
+                  id={connection.id}
+                  mutate={mutate}
+                  showButton={true}
+                />
               }
             />
           </>

--- a/packages/front-end/pages/sdks/[sdkid].tsx
+++ b/packages/front-end/pages/sdks/[sdkid].tsx
@@ -195,7 +195,7 @@ export default function SDKConnectionPage() {
     ...disallowedProjectIds,
   ];
 
-  const hasProxy = connection?.proxy?.enabled && !!connection?.proxy?.host;
+  const hasProxy = connection?.proxy?.enabled;
 
   if (error) {
     return <div className="alert alert-danger">{error.message}</div>;
@@ -421,7 +421,7 @@ export default function SDKConnectionPage() {
               }
             >
               <code className="text-muted">
-                {connection.proxy.host || connection.proxy.hostExternal}
+                {connection.proxy.host || connection.proxy.hostExternal || "Unknown host"}
               </code>
             </ConnectionNode>
 

--- a/packages/front-end/pages/sdks/[sdkid].tsx
+++ b/packages/front-end/pages/sdks/[sdkid].tsx
@@ -400,15 +400,17 @@ export default function SDKConnectionPage() {
           connected={connection.connected}
           canRefresh={canUpdate && !connection.connected}
           refresh={
-            <Button
-              color="link"
-              className="btn-sm"
-              onClick={async () => {
-                await mutate();
-              }}
-            >
-              <BsArrowRepeat /> re-check
-            </Button>
+            connection.proxy.host ? (
+              <Button
+                color="link"
+                className="btn-sm"
+                onClick={async () => {
+                  await mutate();
+                }}
+              >
+                <BsArrowRepeat /> re-check
+              </Button>
+            ) : undefined
           }
         />
         {hasProxy && (
@@ -421,7 +423,9 @@ export default function SDKConnectionPage() {
               }
             >
               <code className="text-muted">
-                {connection.proxy.host || connection.proxy.hostExternal || "Unknown host"}
+                {connection.proxy.host ||
+                  connection.proxy.hostExternal ||
+                  "https://proxy.yoursite.io"}
               </code>
             </ConnectionNode>
 
@@ -431,12 +435,14 @@ export default function SDKConnectionPage() {
               error={!connection.proxy.connected}
               errorTxt={connection.proxy.error}
               refresh={
-                <ProxyTestButton
-                  host={connection.proxy.host}
-                  id={connection.id}
-                  mutate={mutate}
-                  showButton={true}
-                />
+                connection.proxy.host ? (
+                  <ProxyTestButton
+                    host={connection.proxy.host}
+                    id={connection.id}
+                    mutate={mutate}
+                    showButton={true}
+                  />
+                ) : undefined
               }
             />
           </>

--- a/packages/front-end/pages/sdks/[sdkid].tsx
+++ b/packages/front-end/pages/sdks/[sdkid].tsx
@@ -429,7 +429,7 @@ export default function SDKConnectionPage() {
 
             <ConnectionStatus
               connected={connection.proxy.connected}
-              canRefresh={canUpdate && connection.proxy.host}
+              canRefresh={canUpdate && !!connection.proxy.host}
               error={!connection.proxy.connected}
               errorTxt={connection.proxy.error}
               refresh={


### PR DESCRIPTION
### Features and Changes

- Closes https://github.com/growthbook/growthbook/issues/2661

Makes proxy webhooks optional for both cloud and self-hosted customers. The proxy webhook is not actually needed for the proxy to minimally function; its purpose is to make rollouts instantaneous (push-based). Without the webhook, the proxy still stays somewhat up-to-date via SWR.

<img width="856" alt="image" src="https://github.com/growthbook/growthbook/assets/7927873/87181b97-ea72-463f-a434-3e992a6926df">

<img width="791" alt="image" src="https://github.com/growthbook/growthbook/assets/7927873/f2253b73-d9cc-4fc3-8d5a-703ee06e948c">


### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

<!--
  Please describe how to test these changes.
 -->

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
