### PR TITLE
Fix experiment updates when schedule = never

### DIFF
--- a/packages/back-end/src/jobs/updateExperimentResults.ts
+++ b/packages/back-end/src/jobs/updateExperimentResults.ts
@@ -132,7 +132,17 @@ async function updateSingleExperiment(job: UpdateSingleExpJob) {
     project: project ?? undefined,
   });
 
-  if (organization?.settings?.updateSchedule?.type === "never") return;
+  if (organization?.settings?.updateSchedule?.type === "never") {
+    // Disable auto snapshots for the experiment so it doesn't keep trying to update
+    await updateExperiment({
+      context,
+      experiment,
+      changes: {
+        autoSnapshots: false,
+      },
+    });
+    return;
+  }
 
   try {
     logger.info("Start Refreshing Results for experiment " + experimentId);


### PR DESCRIPTION
### Features and Changes

Turn off auto-snapshots for experiments when the organization update schedule is set to `never`.  Prior to this change, it continues to queue these experiments for updates every 10 minutes.  The updates themselves were skipped, so it wasn't really noticeable.  The problem is that we limit our update job to 100 experiments at a time, so these could clog it up and prevent other experiment updates from running.