### PR TITLE
Add support for big saved groups to JS sdk

### DIFF
--- a/docs/docs/lib/build-your-own.mdx
+++ b/docs/docs/lib/build-your-own.mdx
@@ -7,7 +7,7 @@ slug: build-your-own
 
 # Build Your Own SDK
 
-**Latest spec version: 0.6.0 [View Changelog](#changelog)**
+**Latest spec version: 0.7.0 [View Changelog](#changelog)**
 
 This guide is meant for library authors looking to build a GrowthBook SDK in a currently unsupported language.
 
@@ -1117,6 +1117,7 @@ The cases.json file is an object. The keys are the function being tested, and th
   - condition
   - attributes
   - expected return value (boolean)
+  - definitions for ID Lists referenced in the test case (object of keys: ID of list -> values: array of members)
 - **hash**
   - seed (string)
   - value to hash (string)
@@ -1240,3 +1241,7 @@ Open a [GitHub issue](https://github.com/growthbook/growthbook/issues) with a li
 - **v0.6.1** 2024-05-13
   - Update logic in `evalCondition` to allow for and/or/not/nor operators to appear at the same level as other conditions
   - Added test cases for multiple operators on the same level
+- **v0.7.0** 2024-06-25
+  - New Operators `$inGroup` and `$notInGroup` to check ID List saved groups by reference
+  - Add argument to `evalCondition` for definition of ID Lists
+  - Add test cases for `evalCondition`, `feature`, and `run` using the new operators

--- a/docs/docs/lib/build-your-own.mdx
+++ b/docs/docs/lib/build-your-own.mdx
@@ -1117,7 +1117,7 @@ The cases.json file is an object. The keys are the function being tested, and th
   - condition
   - attributes
   - expected return value (boolean)
-  - definitions for ID Lists referenced in the test case (object of keys: ID of list -> values: array of members)
+  - definitions for Saved Groups referenced in the test case (object of keys: ID of list -> values: array of members)
 - **hash**
   - seed (string)
   - value to hash (string)
@@ -1242,6 +1242,6 @@ Open a [GitHub issue](https://github.com/growthbook/growthbook/issues) with a li
   - Update logic in `evalCondition` to allow for and/or/not/nor operators to appear at the same level as other conditions
   - Added test cases for multiple operators on the same level
 - **v0.7.0** 2024-06-25
-  - New Operators `$inGroup` and `$notInGroup` to check ID List saved groups by reference
-  - Add argument to `evalCondition` for definition of ID Lists
+  - New Operators `$inGroup` and `$notInGroup` to check Saved Groups by reference
+  - Add argument to `evalCondition` for definition of Saved Groups
   - Add test cases for `evalCondition`, `feature`, and `run` using the new operators

--- a/packages/sdk-js/src/GrowthBook.ts
+++ b/packages/sdk-js/src/GrowthBook.ts
@@ -204,10 +204,10 @@ export class GrowthBook<
       this._ctx.experiments = data.experiments;
       this._updateAllAutoExperiments();
     }
-    if (data.idLists) {
-      this._ctx.idLists = {};
-      Object.entries(data.idLists).forEach(([key, valueList]) => {
-        this._ctx.idLists![key] = new Set(valueList);
+    if (data.savedGroups) {
+      this._ctx.savedGroups = {};
+      Object.entries(data.savedGroups).forEach(([key, valueList]) => {
+        this._ctx.savedGroups![key] = new Set(valueList);
       });
     }
     this.ready = true;
@@ -464,10 +464,10 @@ export class GrowthBook<
       );
       delete data.encryptedExperiments;
     }
-    if (data.encryptedIdLists) {
-      data.idLists = JSON.parse(
+    if (data.encryptedSavedGroups) {
+      data.savedGroups = JSON.parse(
         await decrypt(
-          data.encryptedIdLists,
+          data.encryptedSavedGroups,
           decryptionKey || this._ctx.decryptionKey,
           subtle
         )
@@ -1158,7 +1158,7 @@ export class GrowthBook<
     return evalCondition(
       this.getAttributes(),
       condition,
-      this._ctx.idLists || {}
+      this._ctx.savedGroups || {}
     );
   }
 

--- a/packages/sdk-js/src/GrowthBook.ts
+++ b/packages/sdk-js/src/GrowthBook.ts
@@ -977,7 +977,7 @@ export class GrowthBook<
             const evaled = evalCondition(
               evalObj,
               parentCondition.condition || {},
-              this._ctx.idLists || {}
+              {}
             );
             if (!evaled) {
               // blocking prerequisite eval failed: feature evaluation fails
@@ -1326,13 +1326,7 @@ export class GrowthBook<
           }
 
           const evalObj = { value: parentResult.value };
-          if (
-            !evalCondition(
-              evalObj,
-              parentCondition.condition || {},
-              this._ctx.idLists || {}
-            )
-          ) {
+          if (!evalCondition(evalObj, parentCondition.condition || {}, {})) {
             process.env.NODE_ENV !== "production" &&
               this.log("Skip because prerequisite evaluation fails", {
                 id: key,

--- a/packages/sdk-js/src/GrowthBook.ts
+++ b/packages/sdk-js/src/GrowthBook.ts
@@ -452,7 +452,6 @@ export class GrowthBook<
         );
       } catch (e) {
         console.error(e);
-        data.features = {};
       }
       delete data.encryptedFeatures;
     }
@@ -467,7 +466,6 @@ export class GrowthBook<
         );
       } catch (e) {
         console.error(e);
-        data.experiments = [];
       }
       delete data.encryptedExperiments;
     }
@@ -482,7 +480,6 @@ export class GrowthBook<
         );
       } catch (e) {
         console.error(e);
-        data.savedGroups = {};
       }
       delete data.encryptedSavedGroups;
     }

--- a/packages/sdk-js/src/GrowthBook.ts
+++ b/packages/sdk-js/src/GrowthBook.ts
@@ -205,7 +205,10 @@ export class GrowthBook<
       this._updateAllAutoExperiments();
     }
     if (data.idLists) {
-      this._ctx.idLists = data.idLists;
+      this._ctx.idLists = {};
+      Object.entries(data.idLists).forEach(([key, valueList]) => {
+        this._ctx.idLists![key] = new Set(valueList);
+      });
     }
     this.ready = true;
     this._render();

--- a/packages/sdk-js/src/GrowthBook.ts
+++ b/packages/sdk-js/src/GrowthBook.ts
@@ -977,8 +977,7 @@ export class GrowthBook<
             const evalObj = { value: parentResult.value };
             const evaled = evalCondition(
               evalObj,
-              parentCondition.condition || {},
-              {}
+              parentCondition.condition || {}
             );
             if (!evaled) {
               // blocking prerequisite eval failed: feature evaluation fails
@@ -1327,7 +1326,7 @@ export class GrowthBook<
           }
 
           const evalObj = { value: parentResult.value };
-          if (!evalCondition(evalObj, parentCondition.condition || {}, {})) {
+          if (!evalCondition(evalObj, parentCondition.condition || {})) {
             process.env.NODE_ENV !== "production" &&
               this.log("Skip because prerequisite evaluation fails", {
                 id: key,

--- a/packages/sdk-js/src/GrowthBook.ts
+++ b/packages/sdk-js/src/GrowthBook.ts
@@ -200,15 +200,12 @@ export class GrowthBook<
     if (data.features) {
       this._ctx.features = data.features;
     }
+    if (data.savedGroups) {
+      this._ctx.savedGroups = data.savedGroups;
+    }
     if (data.experiments) {
       this._ctx.experiments = data.experiments;
       this._updateAllAutoExperiments();
-    }
-    if (data.savedGroups) {
-      this._ctx.savedGroups = {};
-      Object.entries(data.savedGroups).forEach(([key, valueList]) => {
-        this._ctx.savedGroups![key] = new Set(valueList);
-      });
     }
     this.ready = true;
     this._render();
@@ -472,6 +469,7 @@ export class GrowthBook<
           subtle
         )
       );
+      delete data.encryptedSavedGroups;
     }
     return data;
   }

--- a/packages/sdk-js/src/GrowthBook.ts
+++ b/packages/sdk-js/src/GrowthBook.ts
@@ -442,33 +442,48 @@ export class GrowthBook<
   ): Promise<FeatureApiResponse> {
     data = { ...data };
     if (data.encryptedFeatures) {
-      data.features = JSON.parse(
-        await decrypt(
-          data.encryptedFeatures,
-          decryptionKey || this._ctx.decryptionKey,
-          subtle
-        )
-      );
+      try {
+        data.features = JSON.parse(
+          await decrypt(
+            data.encryptedFeatures,
+            decryptionKey || this._ctx.decryptionKey,
+            subtle
+          )
+        );
+      } catch (e) {
+        console.error(e);
+        data.features = {};
+      }
       delete data.encryptedFeatures;
     }
     if (data.encryptedExperiments) {
-      data.experiments = JSON.parse(
-        await decrypt(
-          data.encryptedExperiments,
-          decryptionKey || this._ctx.decryptionKey,
-          subtle
-        )
-      );
+      try {
+        data.experiments = JSON.parse(
+          await decrypt(
+            data.encryptedExperiments,
+            decryptionKey || this._ctx.decryptionKey,
+            subtle
+          )
+        );
+      } catch (e) {
+        console.error(e);
+        data.experiments = [];
+      }
       delete data.encryptedExperiments;
     }
     if (data.encryptedSavedGroups) {
-      data.savedGroups = JSON.parse(
-        await decrypt(
-          data.encryptedSavedGroups,
-          decryptionKey || this._ctx.decryptionKey,
-          subtle
-        )
-      );
+      try {
+        data.savedGroups = JSON.parse(
+          await decrypt(
+            data.encryptedSavedGroups,
+            decryptionKey || this._ctx.decryptionKey,
+            subtle
+          )
+        );
+      } catch (e) {
+        console.error(e);
+        data.savedGroups = {};
+      }
       delete data.encryptedSavedGroups;
     }
     return data;

--- a/packages/sdk-js/src/mongrule.ts
+++ b/packages/sdk-js/src/mongrule.ts
@@ -139,12 +139,25 @@ function elemMatch(actual: any, expected: any, idLists: IdLists) {
   return false;
 }
 
-function isIn(actual: any, expected: Array<any>): boolean {
-  // Do an intersection is attribute is an array
-  if (Array.isArray(actual)) {
-    return actual.some((el) => expected.includes(el));
+function setOrArrayContains(
+  value: any,
+  collection: Array<any> | Set<any>
+): boolean {
+  if (collection instanceof Set) {
+    return collection.has(value);
   }
-  return expected.includes(actual);
+  if (Array.isArray(collection)) {
+    return collection.includes(value);
+  }
+  return false;
+}
+
+function isIn(actual: any, expected: Array<any> | Set<any>): boolean {
+  // Do an intersection if attribute is an array
+  if (Array.isArray(actual)) {
+    return actual.some((el) => setOrArrayContains(el, expected));
+  }
+  return setOrArrayContains(actual, expected);
 }
 
 // Evaluate a single operator condition
@@ -186,9 +199,9 @@ function evalOperatorCondition(
       if (!Array.isArray(expected)) return false;
       return isIn(actual, expected);
     case "$inGroup":
-      return isIn(actual, idLists[expected] || []);
+      return isIn(actual, idLists[expected] || new Set());
     case "$notInGroup":
-      return !isIn(actual, idLists[expected] || []);
+      return !isIn(actual, idLists[expected] || new Set());
     case "$nin":
       if (!Array.isArray(expected)) return false;
       return !isIn(actual, expected);

--- a/packages/sdk-js/src/mongrule.ts
+++ b/packages/sdk-js/src/mongrule.ts
@@ -19,6 +19,7 @@ export function evalCondition(
   condition: ConditionInterface,
   idLists: IdLists
 ): boolean {
+  idLists = idLists || {};
   // Condition is an object, keys are either specific operators or object paths
   // values are either arguments for operators or conditions for paths
   for (const [k, v] of Object.entries(condition)) {

--- a/packages/sdk-js/src/mongrule.ts
+++ b/packages/sdk-js/src/mongrule.ts
@@ -17,7 +17,8 @@ const _regexCache: { [key: string]: RegExp } = {};
 export function evalCondition(
   obj: TestedObj,
   condition: ConditionInterface,
-  savedGroups: SavedGroupsValues
+  // Must be included for `condition` to correctly evaluate group Operators
+  savedGroups?: SavedGroupsValues
 ): boolean {
   savedGroups = savedGroups || {};
   // Condition is an object, keys are either specific operators or object paths

--- a/packages/sdk-js/src/types/growthbook.ts
+++ b/packages/sdk-js/src/types/growthbook.ts
@@ -235,7 +235,7 @@ export interface Context {
   antiFlicker?: boolean;
   antiFlickerTimeout?: number;
   applyDomChangesCallback?: ApplyDomChangesCallback;
-  idLists?: IdLists;
+  savedGroups?: SavedGroups;
 }
 
 export type PrefetchOptions = Pick<
@@ -320,8 +320,8 @@ export type FeatureApiResponse = {
   encryptedFeatures?: string;
   experiments?: AutoExperiment[];
   encryptedExperiments?: string;
-  idLists?: IdLists;
-  encryptedIdLists?: string;
+  savedGroups?: SavedGroups;
+  encryptedSavedGroups?: string;
 };
 
 // Alias
@@ -438,4 +438,4 @@ export interface StickyAssignmentsDocument {
 }
 
 type IdCollection = (string | number)[] | Set<string | number>;
-export type IdLists = Record<string, IdCollection>;
+export type SavedGroups = Record<string, IdCollection>;

--- a/packages/sdk-js/src/types/growthbook.ts
+++ b/packages/sdk-js/src/types/growthbook.ts
@@ -437,4 +437,5 @@ export interface StickyAssignmentsDocument {
   assignments: StickyAssignments;
 }
 
-export type IdLists = Record<string, (string | number)[]>;
+type IdCollection = (string | number)[] | Set<string | number>;
+export type IdLists = Record<string, IdCollection>;

--- a/packages/sdk-js/src/types/growthbook.ts
+++ b/packages/sdk-js/src/types/growthbook.ts
@@ -235,7 +235,7 @@ export interface Context {
   antiFlicker?: boolean;
   antiFlickerTimeout?: number;
   applyDomChangesCallback?: ApplyDomChangesCallback;
-  savedGroups?: SavedGroups;
+  savedGroups?: SavedGroupsValues;
 }
 
 export type PrefetchOptions = Pick<
@@ -320,7 +320,7 @@ export type FeatureApiResponse = {
   encryptedFeatures?: string;
   experiments?: AutoExperiment[];
   encryptedExperiments?: string;
-  savedGroups?: SavedGroups;
+  savedGroups?: SavedGroupsValues;
   encryptedSavedGroups?: string;
 };
 
@@ -437,5 +437,4 @@ export interface StickyAssignmentsDocument {
   assignments: StickyAssignments;
 }
 
-type IdCollection = (string | number)[] | Set<string | number>;
-export type SavedGroups = Record<string, IdCollection>;
+export type SavedGroupsValues = Record<string, (string | number)[]>;

--- a/packages/sdk-js/src/types/growthbook.ts
+++ b/packages/sdk-js/src/types/growthbook.ts
@@ -235,6 +235,7 @@ export interface Context {
   antiFlicker?: boolean;
   antiFlickerTimeout?: number;
   applyDomChangesCallback?: ApplyDomChangesCallback;
+  idLists?: IdLists;
 }
 
 export type PrefetchOptions = Pick<
@@ -319,6 +320,8 @@ export type FeatureApiResponse = {
   encryptedFeatures?: string;
   experiments?: AutoExperiment[];
   encryptedExperiments?: string;
+  idLists?: IdLists;
+  encryptedIdLists?: string;
 };
 
 // Alias
@@ -433,3 +436,5 @@ export interface StickyAssignmentsDocument {
   attributeValue: string;
   assignments: StickyAssignments;
 }
+
+export type IdLists = Record<string, (string | number)[]>;

--- a/packages/sdk-js/src/types/mongrule.ts
+++ b/packages/sdk-js/src/types/mongrule.ts
@@ -12,7 +12,9 @@ type NotCondition = {
 };
 export type Operator =
   | "$in"
+  | "$inGroup"
   | "$nin"
+  | "$notInGroup"
   | "$gt"
   | "$gte"
   | "$lt"
@@ -42,7 +44,9 @@ export type VarType =
   | "undefined";
 export type OperatorConditionValue = {
   $in?: (string | number)[];
+  $inGroup?: string;
   $nin?: (string | number)[];
+  $notInGroup?: string;
   $gt?: number | string;
   $gte?: number | string;
   $lt?: number | string;

--- a/packages/sdk-js/test/cases.json
+++ b/packages/sdk-js/test/cases.json
@@ -1,5 +1,5 @@
 {
-  "specVersion": "0.6.0",
+  "specVersion": "0.7.0",
   "evalCondition": [
     [
       "$not - pass",
@@ -2882,6 +2882,24 @@
       { "id": 1 },
       true,
       { "group_id": [1, 2, 3] }
+    ],
+    [
+      "$inGroup passes for properly typed data",
+      {
+        "id": { "$inGroup": "group_id" }
+      },
+      { "id": "2" },
+      true,
+      { "group_id": [1, "2", 3] }
+    ],
+    [
+      "$inGroup fails for improperly typed data",
+      {
+        "id": { "$inGroup": "group_id" }
+      },
+      { "id": "3" },
+      false,
+      { "group_id": [1, "2", 3] }
     ]
   ],
   "hash": [
@@ -4472,6 +4490,87 @@
         "off": true,
         "source": "cyclicPrerequisite"
       }
+    ],
+    [
+      "IDLists correctly pulled from context for force rule",
+      {
+        "attributes": {
+          "id": 123
+        },
+        "features": {
+          "inGroup_force_rule": {
+            "defaultValue": false,
+            "rules": [
+              {
+                "force": true,
+                "condition": { "id": { "$inGroup": "group_id" } }
+              }
+            ]
+          }
+        },
+        "idLists": {
+          "group_id": [123, 456]
+        }
+      },
+      "inGroup_force_rule",
+      { "value": true, "on": true, "off": false, "source": "force" }
+    ],
+    [
+      "IDLists correctly pulled from context for experiment rule",
+      {
+        "attributes": {
+          "id": 123
+        },
+        "features": {
+          "inGroup_experiment_rule": {
+            "defaultValue": 0,
+            "rules": [
+              {
+                "key": "experiment",
+                "condition": { "id": { "$inGroup": "group_id" } },
+                "hashVersion": 2,
+                "variations": [1, 2],
+                "ranges": [
+                  [0, 0.5],
+                  [0.5, 1.0]
+                ]
+              }
+            ]
+          }
+        },
+        "idLists": {
+          "group_id": [123, 456]
+        }
+      },
+      "inGroup_experiment_rule",
+      {
+        "value": 1,
+        "on": true,
+        "off": false,
+        "source": "experiment",
+        "experiment": {
+          "hashVersion": 2,
+          "condition": { "id": { "$inGroup": "group_id" } },
+          "variations": [1, 2],
+          "ranges": [
+            [0, 0.5],
+            [0.5, 1.0]
+          ],
+          "key": "experiment"
+        },
+        "experimentResult": {
+          "featureId": "inGroup_experiment_rule",
+          "hashAttribute": "id",
+          "hashUsed": true,
+          "hashValue": 123,
+          "inExperiment": true,
+          "key": "0",
+          "value": 1,
+          "variationId": 0,
+          "bucket": 0.1736,
+          "stickyBucketUsed": false
+        }
+      }
     ]
   ],
   "run": [
@@ -5354,6 +5453,23 @@
       0,
       false,
       false
+    ],
+    [
+      "IDLists correctly pulled from context for experiment",
+      {
+        "attributes": { "id": "4" },
+        "idLists": { "group_id": ["4", "5", "6"] }
+      },
+      {
+        "key": "group-filtered-test",
+        "condition": {
+          "id": { "$inGroup": "group_id" }
+        },
+        "variations": [0, 1, 2]
+      },
+      0,
+      true,
+      true
     ]
   ],
   "chooseVariation": [

--- a/packages/sdk-js/test/cases.json
+++ b/packages/sdk-js/test/cases.json
@@ -4492,7 +4492,7 @@
       }
     ],
     [
-      "IDLists correctly pulled from context for force rule",
+      "SavedGroups correctly pulled from context for force rule",
       {
         "attributes": {
           "id": 123
@@ -4508,7 +4508,7 @@
             ]
           }
         },
-        "idLists": {
+        "savedGroups": {
           "group_id": [123, 456]
         }
       },
@@ -4516,7 +4516,7 @@
       { "value": true, "on": true, "off": false, "source": "force" }
     ],
     [
-      "IDLists correctly pulled from context for experiment rule",
+      "SavedGroups correctly pulled from context for experiment rule",
       {
         "attributes": {
           "id": 123
@@ -4538,7 +4538,7 @@
             ]
           }
         },
-        "idLists": {
+        "savedGroups": {
           "group_id": [123, 456]
         }
       },
@@ -5455,10 +5455,10 @@
       false
     ],
     [
-      "IDLists correctly pulled from context for experiment",
+      "SavedGroups correctly pulled from context for experiment",
       {
         "attributes": { "id": "4" },
-        "idLists": { "group_id": ["4", "5", "6"] }
+        "savedGroups": { "group_id": ["4", "5", "6"] }
       },
       {
         "key": "group-filtered-test",

--- a/packages/sdk-js/test/cases.json
+++ b/packages/sdk-js/test/cases.json
@@ -2828,6 +2828,60 @@
         "empty": 1
       },
       true
+    ],
+    [
+      "$inGroup passes for member of known group id",
+      {
+        "id": { "$inGroup": "group_id" }
+      },
+      { "id": 1 },
+      true,
+      { "group_id": [1, 2, 3] }
+    ],
+    [
+      "$inGroup fails for non-member of known group id",
+      {
+        "id": { "$inGroup": "group_id" }
+      },
+      { "id": 5 },
+      false,
+      { "group_id": [1, 2, 3] }
+    ],
+    [
+      "$inGroup fails for unknown group id",
+      {
+        "id": { "$inGroup": "unknowngroup_id" }
+      },
+      { "id": 1 },
+      false,
+      { "group_id": [1, 2, 3] }
+    ],
+    [
+      "$notInGroup fails for member of known group id",
+      {
+        "id": { "$notInGroup": "group_id" }
+      },
+      { "id": 1 },
+      false,
+      { "group_id": [1, 2, 3] }
+    ],
+    [
+      "$notInGroup passes for non-member of known group id",
+      {
+        "id": { "$notInGroup": "group_id" }
+      },
+      { "id": 5 },
+      true,
+      { "group_id": [1, 2, 3] }
+    ],
+    [
+      "$notInGroup passes for unknown group id",
+      {
+        "id": { "$notInGroup": "unknowngroup_id" }
+      },
+      { "id": 1 },
+      true,
+      { "group_id": [1, 2, 3] }
     ]
   ],
   "hash": [

--- a/packages/sdk-js/test/json.test.ts
+++ b/packages/sdk-js/test/json.test.ts
@@ -11,7 +11,7 @@ import {
 } from "../src";
 import { evalCondition } from "../src/mongrule";
 import {
-  IdLists,
+  SavedGroups,
   StickyAssignmentsDocument,
   StickyAttributeKey,
   VariationRange,
@@ -36,7 +36,7 @@ type Cases = {
   // name, context, feature key, result
   feature: [string, Context, string, Omit<FeatureResult, "ruleId">][];
   // name, condition, attribute, result
-  evalCondition: [string, any, any, boolean, IdLists][];
+  evalCondition: [string, any, any, boolean, SavedGroups][];
   // name, args ([numVariations, coverage, weights]), result
   getBucketRange: [
     string,
@@ -100,11 +100,11 @@ describe("json test suite", () => {
 
   it.each((cases as Cases).evalCondition)(
     "evalCondition[%#] %s",
-    (name, condition, value, expected, idLists = {}) => {
+    (name, condition, value, expected, savedGroups = {}) => {
       const consoleErrorMock = jest
         .spyOn(console, "error")
         .mockImplementation();
-      expect(evalCondition(value, condition, idLists)).toEqual(expected);
+      expect(evalCondition(value, condition, savedGroups)).toEqual(expected);
       consoleErrorMock.mockRestore();
     }
   );

--- a/packages/sdk-js/test/json.test.ts
+++ b/packages/sdk-js/test/json.test.ts
@@ -99,11 +99,11 @@ describe("json test suite", () => {
 
   it.each((cases as Cases).evalCondition)(
     "evalCondition[%#] %s",
-    (name, condition, value, expected) => {
+    (name, condition, value, expected, idLists = {}) => {
       const consoleErrorMock = jest
         .spyOn(console, "error")
         .mockImplementation();
-      expect(evalCondition(value, condition)).toEqual(expected);
+      expect(evalCondition(value, condition, idLists)).toEqual(expected);
       consoleErrorMock.mockRestore();
     }
   );

--- a/packages/sdk-js/test/json.test.ts
+++ b/packages/sdk-js/test/json.test.ts
@@ -11,7 +11,7 @@ import {
 } from "../src";
 import { evalCondition } from "../src/mongrule";
 import {
-  SavedGroups,
+  SavedGroupsValues,
   StickyAssignmentsDocument,
   StickyAttributeKey,
   VariationRange,
@@ -36,7 +36,7 @@ type Cases = {
   // name, context, feature key, result
   feature: [string, Context, string, Omit<FeatureResult, "ruleId">][];
   // name, condition, attribute, result
-  evalCondition: [string, any, any, boolean, SavedGroups][];
+  evalCondition: [string, any, any, boolean, SavedGroupsValues][];
   // name, args ([numVariations, coverage, weights]), result
   getBucketRange: [
     string,

--- a/packages/sdk-js/test/json.test.ts
+++ b/packages/sdk-js/test/json.test.ts
@@ -11,6 +11,7 @@ import {
 } from "../src";
 import { evalCondition } from "../src/mongrule";
 import {
+  IdLists,
   StickyAssignmentsDocument,
   StickyAttributeKey,
   VariationRange,
@@ -35,7 +36,7 @@ type Cases = {
   // name, context, feature key, result
   feature: [string, Context, string, Omit<FeatureResult, "ruleId">][];
   // name, condition, attribute, result
-  evalCondition: [string, any, any, boolean][];
+  evalCondition: [string, any, any, boolean, IdLists][];
   // name, args ([numVariations, coverage, weights]), result
   getBucketRange: [
     string,

--- a/packages/sdk-js/test/mongrule.test.ts
+++ b/packages/sdk-js/test/mongrule.test.ts
@@ -8,7 +8,8 @@ describe("Mongrule", () => {
           { userId: null },
           {
             userId: null,
-          }
+          },
+          {}
         )
       ).toBe(true);
 
@@ -17,7 +18,8 @@ describe("Mongrule", () => {
           {},
           {
             userId: null,
-          }
+          },
+          {}
         )
       ).toBe(true);
     });
@@ -30,7 +32,8 @@ describe("Mongrule", () => {
           },
           {
             userId: null,
-          }
+          },
+          {}
         )
       ).toBe(false);
     });
@@ -43,7 +46,8 @@ describe("Mongrule", () => {
           },
           {
             userId: null,
-          }
+          },
+          {}
         )
       ).toBe(false);
 
@@ -54,7 +58,8 @@ describe("Mongrule", () => {
           },
           {
             userId: null,
-          }
+          },
+          {}
         )
       ).toBe(false);
 
@@ -63,7 +68,8 @@ describe("Mongrule", () => {
           { userId: undefined },
           {
             userId: null,
-          }
+          },
+          {}
         )
       ).toBe(false);
     });
@@ -76,7 +82,8 @@ describe("Mongrule", () => {
           },
           {
             email: { $exists: true },
-          }
+          },
+          {}
         )
       ).toBe(false);
 
@@ -87,7 +94,8 @@ describe("Mongrule", () => {
           },
           {
             email: { $exists: false },
-          }
+          },
+          {}
         )
       ).toBe(true);
 
@@ -98,7 +106,8 @@ describe("Mongrule", () => {
           },
           {
             email: { $exists: true },
-          }
+          },
+          {}
         )
       ).toBe(false);
 
@@ -109,7 +118,8 @@ describe("Mongrule", () => {
           },
           {
             email: { $exists: false },
-          }
+          },
+          {}
         )
       ).toBe(true);
 
@@ -120,7 +130,8 @@ describe("Mongrule", () => {
           },
           {
             email: { $exists: true },
-          }
+          },
+          {}
         )
       ).toBe(true);
 
@@ -131,7 +142,8 @@ describe("Mongrule", () => {
           },
           {
             email: { $exists: false },
-          }
+          },
+          {}
         )
       ).toBe(false);
 
@@ -142,7 +154,8 @@ describe("Mongrule", () => {
           },
           {
             email: { $exists: true },
-          }
+          },
+          {}
         )
       ).toBe(true);
 
@@ -153,7 +166,8 @@ describe("Mongrule", () => {
           },
           {
             email: { $exists: false },
-          }
+          },
+          {}
         )
       ).toBe(false);
     });

--- a/packages/shared/src/util/features.ts
+++ b/packages/shared/src/util/features.ts
@@ -744,7 +744,7 @@ export function evalDeterministicPrereqValue(
   const parsedCondition = getParsedPrereqCondition(condition);
   if (!parsedCondition) return "fail";
   const evalObj = { value: value };
-  const pass = evalCondition(evalObj, parsedCondition);
+  const pass = evalCondition(evalObj, parsedCondition, {});
   return pass ? "pass" : "fail";
 }
 

--- a/packages/shared/src/util/features.ts
+++ b/packages/shared/src/util/features.ts
@@ -744,7 +744,7 @@ export function evalDeterministicPrereqValue(
   const parsedCondition = getParsedPrereqCondition(condition);
   if (!parsedCondition) return "fail";
   const evalObj = { value: value };
-  const pass = evalCondition(evalObj, parsedCondition, {});
+  const pass = evalCondition(evalObj, parsedCondition);
   return pass ? "pass" : "fail";
 }
 


### PR DESCRIPTION
### Features and Changes

Splits the JS sdk logic out of #2616 so that it can be merged first. The new logic is all backwards compatible, so this will allow us to release the new 1.0.2 version of the sdk ahead of time and prevent any issues with the proxy server.


### Testing
Setup:
1. Checkout the `kc/saved-groups-improvements` branch to grab the code that generates the new style of payload
2. Run `yarn link` in the `sdk-js` package and start running `yarn dev`
3. Clone the https://github.com/growthbook/kevin-sdk-testing/tree/main/sdk-js repo and run `yarn dev` there

Changing the saved group & feature definitions in your app should result in the correct feature evaluation in the next app.
