### PR TITLE
[bugfix] Inject template variables for entire fact table SQL

### DIFF
--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -3532,7 +3532,8 @@ AND event_name = '${eventName}'`,
       where.push(`${cols.timestamp} <= ${this.toTimestamp(endDate)}`);
     }
 
-    return `-- Metric (${metric.name})
+    return compileSqlTemplate(
+      `-- Metric (${metric.name})
       SELECT
         ${userIdCol} as ${baseIdType},
         ${cols.value} as value,
@@ -3541,16 +3542,7 @@ AND event_name = '${eventName}'`,
         ${
           queryFormat === "sql" || queryFormat === "fact"
             ? `(
-              ${compileSqlTemplate(sql, {
-                startDate,
-                endDate: endDate || undefined,
-                experimentId,
-                templateVariables: getMetricTemplateVariables(
-                  metric,
-                  factTableMap,
-                  useDenominator
-                ),
-              })}
+              ${sql}
             )`
             : !isFact
             ? (schema && !metric.table?.match(/\./) ? schema + "." : "") +
@@ -3559,7 +3551,18 @@ AND event_name = '${eventName}'`,
         } m
         ${join}
         ${where.length ? `WHERE ${where.join(" AND ")}` : ""}
-    `;
+    `,
+      {
+        startDate,
+        endDate: endDate || undefined,
+        experimentId,
+        templateVariables: getMetricTemplateVariables(
+          metric,
+          factTableMap,
+          useDenominator
+        ),
+      }
+    );
   }
 
   // Only include users who entered the experiment before this timestamp

--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -3395,26 +3395,29 @@ AND event_name = '${eventName}'`,
       }
     });
 
-    return `-- Fact Table (${factTable.name})
+    return compileSqlTemplate(
+      `-- Fact Table (${factTable.name})
       SELECT
         ${userIdCol} as ${baseIdType},
         ${timestampDateTimeColumn} as timestamp,
         ${metricCols.join(",\n")}
       FROM(
-          ${compileSqlTemplate(sql, {
-            startDate,
-            endDate: endDate || undefined,
-            experimentId,
-            templateVariables: getMetricTemplateVariables(
-              metrics[0],
-              factTableMap,
-              false
-            ),
-          })}
+          ${sql}
         ) m
         ${join}
         ${where.length ? `WHERE ${where.join(" AND ")}` : ""}
-    `;
+    `,
+      {
+        startDate,
+        endDate: endDate || undefined,
+        experimentId,
+        templateVariables: getMetricTemplateVariables(
+          metrics[0],
+          factTableMap,
+          false
+        ),
+      }
+    );
   }
 
   private getMetricCTE({


### PR DESCRIPTION
Filters were used in case when statements in the actual optimized __factTable CTE, and that part of the CTE wasn't compiled with SQL templates, so SQL templates like `{{ experimentId }}` weren't being rendered correctly.

The same issue occurred in the `WHERE` clause of the __metric CTE when fact optimization was off.

This fixes that bug in both cases.