### PR TITLE
[docs] Fix power doc

### DIFF
--- a/docs/docs/statistics/power.mdx
+++ b/docs/docs/statistics/power.mdx
@@ -214,7 +214,7 @@ $\rho = \sqrt{\frac{-2\text{log}(\alpha) + \text{log}(-2 \text{log}(\alpha) + 1)
 
 and $N^{\star}$ is a tuning parameter. This approach relies upon asymptotic normality. For power analysis we rewrite the confidence interval as
 
-$\left(\hat{\tau} \pm \hat{\sigma}*\sqrt{N} * \sqrt{\frac{2(N\rho^2 + 1)}{N^2\rho^2}\log\left(\frac{\sqrt{N\rho^2 + 1}}{\alpha}\right)}\frac{Z_{1-\alpha/2}}{Z_{1-\alpha/2}}\right)$$=\left(\hat{\tau} \pm \tilde{\sigma}Z_{1-\alpha/2}\right)$
+$\left(\hat{\tau} \pm \tilde{\sigma}Z_{1-\alpha/2}\right)$
 
 where
 


### PR DESCRIPTION
Update the broken katex for the confidence interval.

## Broken equation:
![image](https://github.com/growthbook/growthbook/assets/48868107/3bd3ea26-496e-4089-9f50-9f10a37585cf)

## Updated:
![image](https://github.com/growthbook/growthbook/assets/48868107/fdda2935-e3b5-436f-8620-441240ec7d52)
