### PR TITLE
Add google analytics to docs site

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -64,6 +64,9 @@ const config = {
             require.resolve("modern-normalize/modern-normalize.css"),
           ],
         },
+        gtag: {
+          trackingID: "G-3W683MDLMQ",
+        },
       }),
     ],
     [
@@ -175,8 +178,8 @@ const config = {
         },
       ],
       prism: {
-        theme: require('prism-react-renderer').themes.github,
-        darkTheme: require('prism-react-renderer').themes.dracula,
+        theme: require("prism-react-renderer").themes.github,
+        darkTheme: require("prism-react-renderer").themes.dracula,
         additionalLanguages: [
           "csharp",
           "ruby",


### PR DESCRIPTION
### Features and Changes

Added GA ID according to https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-google-gtag

