### PR TITLE
JS SDK v1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     ]
   },
   "resolutions": {
-    "@growthbook/growthbook": "1.0.1"
+    "@growthbook/growthbook": "1.1.0"
   },
   "prettier": {
     "overrides": [

--- a/packages/back-end/package.json
+++ b/packages/back-end/package.json
@@ -34,7 +34,7 @@
     "@dqbd/tiktoken": "^1.0.7",
     "@google-cloud/bigquery": "5",
     "@google-cloud/storage": "^5.20.5",
-    "@growthbook/growthbook": "^1.0.1",
+    "@growthbook/growthbook": "^1.1.0",
     "@growthbook/proxy-eval": "^1.0.3",
     "@octokit/auth-app": "^6.0.1",
     "@octokit/core": "^5.0.2",

--- a/packages/front-end/package.json
+++ b/packages/front-end/package.json
@@ -17,7 +17,7 @@
     "@dnd-kit/core": "^4.0.3",
     "@dnd-kit/sortable": "^5.1.0",
     "@floating-ui/react": "^0.25.4",
-    "@growthbook/growthbook-react": "^1.0.1",
+    "@growthbook/growthbook-react": "^1.1.0",
     "@jitsu/sdk-js": "^2.2.0",
     "@jukben/emoji-search": "^2.0.1",
     "@popperjs/core": "^2.11.5",

--- a/packages/sdk-js/CHANGELOG.md
+++ b/packages/sdk-js/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## **1.1.0** - July 1, 2024
 
+- Fix package.json ESM exports. Can now load the SDK in Astro and Node (with `type="module"`) without errors.
 - Support for larger saved groups (up to 1MB)
   - New `$inGroup` and `$notInGroup` condition operators which check for membership of a given group ID
   - New `savedGroups` and `encryptedSavedGroups` payload keys define the members for each saved group

--- a/packages/sdk-js/CHANGELOG.md
+++ b/packages/sdk-js/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## **1.1.0** - July 1, 2024
+
+- Support for larger saved groups (up to 1MB)
+  - New `$inGroup` and `$notInGroup` condition operators which check for membership of a given group ID
+  - New `savedGroups` and `encryptedSavedGroups` payload keys define the members for each saved group
+  - Optimization to prevent including a saved group's members multiple times in one payload
+
 ## **1.0.1** - June 11, 2024
 
 - Small refactor to avoid circular dependency warning

--- a/packages/sdk-js/package.json
+++ b/packages/sdk-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@growthbook/growthbook",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.mjs",

--- a/packages/sdk-react/package.json
+++ b/packages/sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@growthbook/growthbook-react",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -38,7 +38,7 @@
     "react": "^16.8.0-0 || ^17.0.0-0 || ^18.0.0-0"
   },
   "dependencies": {
-    "@growthbook/growthbook": "^1.0.1"
+    "@growthbook/growthbook": "^1.1.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.19.3",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -18,7 +18,7 @@
     "generate-sdk-report": "node -r @swc-node/register ./src/sdk-versioning/sdk-report.ts ./src/sdk-versioning/CAPABILITIES.md"
   },
   "dependencies": {
-    "@growthbook/growthbook": "^1.0.1",
+    "@growthbook/growthbook": "^1.1.0",
     "ajv": "^8.12.0",
     "date-fns": "^2.15.0",
     "dirty-json": "^0.9.2",

--- a/packages/shared/src/sdk-versioning/sdk-versions/javascript.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/javascript.json
@@ -1,6 +1,10 @@
 {
   "versions": [
     {
+      "version": "1.1.0",
+      "capabilities": ["savedGroupReferences"]
+    },
+    {
       "version": "1.0.1"
     },
     {

--- a/packages/shared/src/sdk-versioning/sdk-versions/nocode.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/nocode.json
@@ -14,7 +14,8 @@
         "visualEditorDragDrop",
         "prerequisites",
         "redirects",
-        "stickyBucketing"
+        "stickyBucketing",
+        "savedGroupReferences"
       ]
     }
   ]

--- a/packages/shared/src/sdk-versioning/sdk-versions/nodejs.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/nodejs.json
@@ -1,6 +1,10 @@
 {
   "versions": [
     {
+      "version": "1.1.0",
+      "capabilities": ["savedGroupReferences"]
+    },
+    {
       "version": "1.0.1"
     },
     {

--- a/packages/shared/src/sdk-versioning/sdk-versions/react.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/react.json
@@ -1,6 +1,10 @@
 {
   "versions": [
     {
+      "version": "1.1.0",
+      "capabilities": ["savedGroupReferences"]
+    },
+    {
       "version": "1.0.1"
     },
     {

--- a/packages/shared/src/sdk-versioning/types.ts
+++ b/packages/shared/src/sdk-versioning/types.ts
@@ -10,7 +10,8 @@ export type SDKCapability =
   | "visualEditorDragDrop"
   | "stickyBucketing"
   | "redirects"
-  | "prerequisites";
+  | "prerequisites"
+  | "savedGroupReferences";
 
 export type CapabilityStrategy =
   | "min-ver-intersection" // intersection of capabilities using default SDK versions


### PR DESCRIPTION
- Fix package.json ESM exports. Can now load the SDK in Astro and Node (with `type="module"`) without errors.
- Support for larger saved groups (up to 1MB)
  - New `$inGroup` and `$notInGroup` condition operators which check for membership of a given group ID
  - New `savedGroups` and `encryptedSavedGroups` payload keys define the members for each saved group
  - Optimization to prevent including a saved group's members multiple times in one payload