### PR TITLE
Fix SDK package.json exports for Astro

### DIFF
--- a/packages/sdk-js/package.json
+++ b/packages/sdk-js/package.json
@@ -7,9 +7,17 @@
   "types": "dist/index.d.ts",
   "typings": "dist/index.d.ts",
   "exports": {
-    "require": "./dist/cjs/index.js",
-    "import": "./dist/esm/index.js",
-    "types": "./dist/index.d.ts"
+    "./package.json": "./package.json",
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/cjs/index.js"
+      }
+    }
   },
   "files": [
     "dist",


### PR DESCRIPTION
### Features and Changes

Changed the structure of the `exports` field in `package.json` for the JavaScript SDK.  Tested with the following frameworks/bundlers/runtimes:

- Next.js
- Astro (was broken before this change)
- Remix
- Svelte
- Node Typescript
- Node Javascript CommonJS