### PR TITLE
Add a way to test Smokescreen Proxy end to end

### DIFF
--- a/packages/back-end/src/util/http.util.ts
+++ b/packages/back-end/src/util/http.util.ts
@@ -14,7 +14,21 @@ export type CancellableFetchReturn = {
   stringBody: string;
 };
 
-export function getHttpOptions() {
+export function getHttpOptions(url?: string) {
+  // if there is a ?proxy argument in the url, use that as the proxy
+  if (url) {
+    // parse the url and extract the proxy argument
+    const urlObj = new URL(url);
+    const proxy = urlObj.searchParams.get("proxy_test");
+    if (proxy) {
+      return {
+        agent: new ProxyAgent({
+          getProxyForUrl: () => proxy,
+        }),
+      };
+    }
+  }
+
   if (WEBHOOK_PROXY) {
     return {
       agent: new ProxyAgent({
@@ -22,6 +36,7 @@ export function getHttpOptions() {
       }),
     };
   }
+
   if (USE_PROXY) {
     return { agent: new ProxyAgent() };
   }
@@ -63,7 +78,7 @@ export const cancellableFetch = async (
   try {
     response = await fetch(url, {
       signal: abortController.signal,
-      ...getHttpOptions(),
+      ...getHttpOptions(url),
       ...fetchOptions,
     });
 


### PR DESCRIPTION
### Features and Changes
In order to test the webhook proxy end to end we need a way to use the request even if the env var is false on cloud.  By adding proxy_test query parameter it will try and forward it through that proxy.  I have left it as variable in case we want to change it's ip address at some point or try and get https working for the proxy.

### Testing
Run smokescreen proxy locally by checking out smokescreen repo and running:
`go run . --config-file config.yaml --allow-address 127.0.0.1:8080 --allow-address "[::1]:8080"`

In General->Settings->Webhooks
Set a new webhook to be something like: 
`https://b966-80-187-83-255.ngrok-free.app?proxy_test=http://localhost:4750`
Click Test

See the log hit on the smokescreen proxy that it allowed the request.  Then see the correct output from the webhook endpoint.

#### Test that other routes don't go through the proxy
Edit the webhook, changing the query parmeter to something else like "proxy".  
Hit test again.
See no logs in smokescreen.
See the correct output still for the webhook endpoint.