### PR TITLE
Add SDK Webhook payload formatters, update docs

### DIFF
--- a/docs/docs/lib/edge/cloudflare.mdx
+++ b/docs/docs/lib/edge/cloudflare.mdx
@@ -341,15 +341,15 @@ For KV stored payloads (1), we eliminate network requests from edge to GrowthBoo
 https://api.cloudflare.com/client/v4/accounts/{accountId}/storage/kv/namespaces/{namespaceId}/values/gb_payload
 ```
 
-3. Enable the **Send Payload** toggle.
-4. Change the **Method** to `PUT`.
-5. Add appropriate authorization and content-type headers:
+3. Change the **Method** to `PUT`.
+4. Add appropriate authorization header:
 
 ```json
 {
-  "Authorization": "Bearer YOUR_CF_REST_API_TOKEN",
-  "Content-Type": "application/json"
+  "Authorization": "Bearer YOUR_CF_REST_API_TOKEN"
 }
 ```
+
+5. Set the **Payload format** to "SDK Payload only".
 
 Now whenever feature and experiment values change, your Cloudflare worker will have immediate access to the latest values. You can also test the webhook by using the "Test Webhook" button on the SDK Connection page.

--- a/docs/docs/lib/edge/fastly.mdx
+++ b/docs/docs/lib/edge/fastly.mdx
@@ -414,15 +414,15 @@ For KV stored payloads (1), we eliminate network requests from edge to GrowthBoo
 https://api.fastly.com/resources/stores/kv/{store_id}/keys/gb_payload
 ```
 
-3. Enable the **Send Payload** toggle.
-4. Change the **Method** to `PUT`.
-5. Add appropriate authorization and content-type headers:
+3. Change the **Method** to `PUT`.
+4. Add appropriate authorization header:
 
 ```json
 {
-  "Fastly-Key": "YOUR_FASTLY_REST_API_TOKEN",
-  "Content-Type": "application/json"
+  "Fastly-Key": "YOUR_FASTLY_REST_API_TOKEN"
 }
 ```
+
+5. Set the **Payload format** to "SDK Payload only".
 
 Now whenever feature and experiment values change, your Fastly worker will have immediate access to the latest values. You can also test the webhook by using the "Test Webhook" button on the SDK Connection page.

--- a/docs/docs/lib/edge/lambda.mdx
+++ b/docs/docs/lib/edge/lambda.mdx
@@ -340,8 +340,7 @@ For key-val stored payloads (1), we eliminate network requests from edge to Grow
 
 1. Create an [SDK Webhook](/app/webhooks/sdk-webhooks) on the same SDK Connection that you are using for edge integration.
 2. Set the **Endpoint URL** to your key-val store's REST API endpoint, if available. You may need to build your own private Lambda endpoint to handle the webhook, in which case webhook verification may be important.
-
-3. Enable the **Send Payload** toggle.
-4. Change the **Method** to `PUT` (or whichever verb is required by your endpoint).
+3. Change the **Method** to `PUT` (or whichever verb is required by your endpoint).
+4. Set the **Payload format** to "SDK Payload only".
 
 Now whenever feature and experiment values change, your edge worker will have immediate access to the latest values. You can also test the webhook by using the "Test Webhook" button on the SDK Connection page.

--- a/docs/docs/lib/edge/other.mdx
+++ b/docs/docs/lib/edge/other.mdx
@@ -348,16 +348,15 @@ For key-val stored payloads (1), we eliminate network requests from edge to Grow
 
 1. Create an [SDK Webhook](/app/webhooks/sdk-webhooks) on the same SDK Connection that you are using for edge integration.
 2. Set the **Endpoint URL** to your key-val provider's REST API endpoint. However, not all edge vendors will have a public REST endpoint for setting the key-val cache. You may need to build your own endpoint to handle the webhook, in which case webhook verification may be important.
-
-3. Enable the **Send Payload** toggle.
-4. Change the **Method** to `PUT` (or whichever verb is required by your vendor or endpoint).
-5. Add any vendor-specific authorization headers and/or and content-type headers. This may not be required depending on your specific vendor:
+3. Change the **Method** to `PUT` (or whichever verb is required by your vendor or endpoint).
+4. Add any vendor-specific authorization headers. This may not be required depending on your specific vendor:
 
 ```json
 {
-  "Authorization": "Bearer YOUR_REST_API_TOKEN",
-  "Content-Type": "application/json"
+  "Authorization": "Bearer YOUR_REST_API_TOKEN"
 }
 ```
+
+5. Set the **Payload format** to "SDK Payload only".
 
 Now whenever feature and experiment values change, your edge worker will have immediate access to the latest values. You can also test the webhook by using the "Test Webhook" button on the SDK Connection page.

--- a/docs/docs/webhooks/global-sdk-webhooks.mdx
+++ b/docs/docs/webhooks/global-sdk-webhooks.mdx
@@ -11,7 +11,7 @@ Global SDK Webhooks are only available for self-hosted GrowthBook installations.
 
 :::
 
-Global SDK Webhooks are just like [SDK webhooks](/app/webhooks/sdk-webhooks), but configured via environment variables instead of the GrowthBook UI.
+Global SDK Webhooks are just like [SDK Webhooks](/app/webhooks/sdk-webhooks), but configured via environment variables instead of the GrowthBook UI.
 
 When any SDK Connection payloads changes in any organization, all of your Global SDK Webhooks will be triggered.
 
@@ -19,7 +19,7 @@ When any SDK Connection payloads changes in any organization, all of your Global
 
 Define a `WEBHOOKS` environment variable as a JSON string of an array of global webhook objects.
 
-The only required field for a global webhook is `url`. Here's a minimal example:
+The only required field for a global webhook is **`url`**. Here's a minimal example:
 
 ```
 [{"url":"https://example.com"}]
@@ -27,15 +27,19 @@ The only required field for a global webhook is `url`. Here's a minimal example:
 
 There are additional fields you can specify:
 
-- `signingKey` (string) - Will be used to add a signature header that enables you to verify the webhook origin
-- `method` (string) - One of `GET`, `PUT`, `POST`, `PURGE`, or `DELETE`. Defaults to `POST` if omitted
-- `sendPayload` (boolean) - Whether or not to include the full SDK Payload in the body (ignored when method = "GET"). Default `false`
-- `headers` (object) - Additional headers to add to the webhook request. Useful for adding auth headers for example. Default `{}`.
+- **`signingKey`** (string) - Will be used to add a signature header that enables you to verify the webhook origin
+- **`method`** (string) - One of `GET`, `PUT`, `POST`, `PURGE`, or `DELETE`. Defaults to `POST` if omitted
+- **`headers`** (object) - Additional headers to add to the webhook request. Useful for adding auth headers for example. Default `{}`.
+- **`payloadFormat`** (string) - How to format the body (ignored when method = "GET"). One of `standard`, `standard-no-payload`, `sdkPayload` or `none`. Defaults to `standard`. Read more about the different formats in the SDK Webhooks [Payload Format docs](/app/webhooks/sdk-webhooks#payload-format).
+
+_Deprecated:_
+
+- **`sendPayload`** (boolean) - Whether or not to include the full SDK Payload in the body. `true` maps to `payloadFormat = standard`; false maps to `payloadFormat = standard-no-payload`.
 
 Here's a full example using all of the fields:
 
 ```
-[{"url":"https://example.com","signingKey":"abc123","method":"PUT","headers":{"X-Custom-Header":"foo"},"sendPayload":true}]
+[{"url":"https://example.com","signingKey":"abc123","method":"PUT","headers":{"X-Custom-Header":"foo"},"payloadFormat":"sdkPayload"}]
 ```
 
 ## Verify Signatures

--- a/docs/docs/webhooks/sdk-webhooks.mdx
+++ b/docs/docs/webhooks/sdk-webhooks.mdx
@@ -120,25 +120,30 @@ Webhooks are retried up to 2 additional times with an exponential back-off betwe
 
 You can view the status of your webhooks in the GrowthBook app under **SDK Connections**.
 
-## Supported HTTP Types
+## Supported HTTP Methods
 
+- **GET**
 - **POST**
 - **PUT**
-- **GET**
 - **DELETE**
 - **PURGE**
 
-### Sending Payload
+## Payload Format
 
-If you opt to include a payload in your webhook request, the body will be in the following format:
+For all methods other than `GET`, you may send a payload body. By default, webhooks will send in the "Standard" format.
+
+### Standard
+
+Follows the **Standard Webhooks** specification. Inludes a JSON-encoded SDK Payload in the `data.payload` field.
+
+Example payload:
 
 ```json
 {
   "type": "payload.changed",
   "timestamp": "2024-04-03T01:54:20.449Z",
-  "data":{
-    "payload":"{\"features\":{\"my-feature\":{\"defaultValue\":true}}}"
-    }
+  "data": {
+    "payload": "{\"features\":{\"my-feature\":{\"defaultValue\":true}}}"
   }
 }
 ```
@@ -152,4 +157,28 @@ const gb = new GrowthBook();
 await gb.init({
   payload: payload
 });
+```
+
+### Standard (no SDK Payload)
+
+Same as above, but without the `data.payload` field.
+
+Example payload:
+
+```json
+{
+  "type": "payload.changed",
+  "timestamp": "2024-04-03T01:54:20.449Z",
+}
+```
+
+### SDK Payload
+
+Sends the raw SDK Payload using the same format as our SDK features endpoint. This is usually the correct format if you are using the webhook to set
+a cache value or assigning key/value storage.
+
+Example payload:
+
+```json
+{"features":{"my-feature":{"defaultValue":true}}}
 ```

--- a/packages/back-end/src/jobs/sdkWebhooks.ts
+++ b/packages/back-end/src/jobs/sdkWebhooks.ts
@@ -179,10 +179,19 @@ async function runWebhookFetch({
 
   const timestamp = Math.floor(date.getTime() / 1000);
 
-  let body: string | undefined = undefined;
+  let body: string | undefined;
+  const standardBody = JSON.stringify({
+    type: "payload.changed",
+    timestamp: date.toISOString(),
+    data: { payload },
+  });
+  let invalidValue: never;
 
   if (method !== "GET") {
     switch (payloadFormat) {
+      case "none":
+        body = undefined;
+        break;
       case "standard-no-payload":
         body = JSON.stringify({
           type: "payload.changed",
@@ -193,12 +202,12 @@ async function runWebhookFetch({
         body = payload;
         break;
       case "standard":
+        body = standardBody;
+        break;
       default:
-        body = JSON.stringify({
-          type: "payload.changed",
-          timestamp: date.toISOString(),
-          data: { payload },
-        });
+        body = standardBody;
+        invalidValue = payloadFormat;
+        logger.error(`Invalid webhook payload format: ${invalidValue}`);
     }
   }
 

--- a/packages/back-end/src/jobs/sdkWebhooks.ts
+++ b/packages/back-end/src/jobs/sdkWebhooks.ts
@@ -34,6 +34,7 @@ type SDKWebhookJob = Job<{
   webhookId: string;
   retryCount: number;
 }>;
+const sendPayloadFormats = ["standard", "sdkPayload"];
 
 const fireWebhooks = trackJob(
   SDK_WEBHOOKS_JOB_NAME,
@@ -161,14 +162,13 @@ async function runWebhookFetch({
   const signingKey = webhook.signingKey;
   const headers = webhook.headers || "";
   const method = webhook.httpMethod || "POST";
-  // todo: better inference based on sendPayload
   const payloadFormat = webhook.payloadFormat || "standard";
   const organizationId = webhook.organization;
   const requestTimeout = 30000;
   const maxContentSize = 1000;
 
   const sendPayload =
-    method !== "GET" && ["standard", "sdkPayload"].includes(payloadFormat);
+    method !== "GET" && sendPayloadFormats.includes(payloadFormat);
 
   const date = new Date();
   const signature = createHmac("sha256", signingKey)
@@ -292,7 +292,7 @@ export async function fireSdkWebhook(
     let payload = "";
     const sendPayload =
       webhook.httpMethod !== "GET" &&
-      ["standard", "sdkPayload"].includes(webhook.payloadFormat ?? "standard");
+      sendPayloadFormats.includes(webhook.payloadFormat ?? "standard");
     if (sendPayload) {
       const environmentDoc = webhookContext.org?.settings?.environments?.find(
         (e) => e.id === connection.environment

--- a/packages/back-end/src/jobs/sdkWebhooks.ts
+++ b/packages/back-end/src/jobs/sdkWebhooks.ts
@@ -182,19 +182,23 @@ async function runWebhookFetch({
   let body: string | undefined = undefined;
 
   if (method !== "GET") {
-    if (payloadFormat === "standard") {
-      body = JSON.stringify({
-        type: "payload.changed",
-        timestamp: date.toISOString(),
-        data: { payload },
-      });
-    } else if (payloadFormat === "standard-no-payload") {
-      body = JSON.stringify({
-        type: "payload.changed",
-        timestamp: date.toISOString(),
-      });
-    } else if (payloadFormat === "sdkPayload") {
-      body = payload;
+    switch (payloadFormat) {
+      case "standard-no-payload":
+        body = JSON.stringify({
+          type: "payload.changed",
+          timestamp: date.toISOString(),
+        });
+        break;
+      case "sdkPayload":
+        body = payload;
+        break;
+      case "standard":
+      default:
+        body = JSON.stringify({
+          type: "payload.changed",
+          timestamp: date.toISOString(),
+          data: { payload },
+        });
     }
   }
 

--- a/packages/back-end/src/util/migrations.ts
+++ b/packages/back-end/src/util/migrations.ts
@@ -7,7 +7,9 @@ import {
 } from "shared/constants";
 import { RESERVED_ROLE_IDS, getDefaultRole } from "shared/permissions";
 import { accountFeatures, getAccountPlan } from "enterprise";
+import { omit } from "lodash";
 import { LegacyReportInterface, ReportInterface } from "@back-end/types/report";
+import { WebhookInterface } from "@back-end/types/webhook";
 import { SdkWebHookLogDocument } from "../models/SdkWebhookLogModel";
 import { LegacyMetricInterface, MetricInterface } from "../../types/metric";
 import {
@@ -851,4 +853,18 @@ export function migrateSdkWebhookLogModel(
     delete doc.webhookReduestId;
   }
   return doc;
+}
+
+export function migrateWebhookModel(doc: WebhookInterface): WebhookInterface {
+  const newDoc = omit(doc, ["sendPayload"]) as WebhookInterface;
+  if (!doc.payloadFormat) {
+    if (doc.httpMethod === "GET") {
+      newDoc.payloadFormat = "none";
+    } else if (doc.sendPayload) {
+      newDoc.payloadFormat = "standard";
+    } else {
+      newDoc.payloadFormat = "standard-no-payload";
+    }
+  }
+  return newDoc;
 }

--- a/packages/back-end/src/util/secrets.ts
+++ b/packages/back-end/src/util/secrets.ts
@@ -200,6 +200,8 @@ const webhooksValidator = z.array(
       signingKey: z.string().optional(),
       method: z.enum(["GET", "POST", "PUT", "DELETE", "PURGE"]).optional(),
       sendPayload: z.boolean().optional(),
+      payloadFormat: z.enum(["standard", "standard-no-payload", "sdkPayload", "none"])
+        .optional(),
     })
     .strict()
 );

--- a/packages/back-end/src/util/secrets.ts
+++ b/packages/back-end/src/util/secrets.ts
@@ -200,7 +200,8 @@ const webhooksValidator = z.array(
       signingKey: z.string().optional(),
       method: z.enum(["GET", "POST", "PUT", "DELETE", "PURGE"]).optional(),
       sendPayload: z.boolean().optional(),
-      payloadFormat: z.enum(["standard", "standard-no-payload", "sdkPayload", "none"])
+      payloadFormat: z
+        .enum(["standard", "standard-no-payload", "sdkPayload", "none"])
         .optional(),
     })
     .strict()

--- a/packages/back-end/types/webhook.d.ts
+++ b/packages/back-end/types/webhook.d.ts
@@ -11,13 +11,21 @@ export interface WebhookInterface {
   error: string;
   created: Date;
   useSdkMode: boolean;
-  sendPayload: boolean;
+  /** @deprecated */
+  sendPayload?: boolean;
+  payloadFormat?: WebhookPayloadFormat;
   sdks: string[];
   headers?: string;
   httpMethod?: WebhookMethod;
 }
 
 export type WebhookMethod = "GET" | "PUT" | "POST" | "DELETE" | "PURGE";
+
+export type WebhookPayloadFormat =
+  | "standard"
+  | "standard-no-payload"
+  | "sdkPayload"
+  | "none";
 
 export type {
   UpdateSdkWebhookProps,

--- a/packages/front-end/components/DocLink.tsx
+++ b/packages/front-end/components/DocLink.tsx
@@ -14,6 +14,7 @@ const docSections = {
   api: "/app/api",
   eventWebhooks: "/app/webhooks/event-webhooks",
   sdkWebhooks: "/app/webhooks/sdk-webhooks",
+  "sdkWebhooks#payload-format": "/app/webhooks/sdk-webhooks#payload-format",
   //DataSourceType
   athena: "/app/datasources#aws-athena",
   mixpanel: "/guide/mixpanel",

--- a/packages/front-end/components/Settings/MixpanelForm.tsx
+++ b/packages/front-end/components/Settings/MixpanelForm.tsx
@@ -61,6 +61,7 @@ const MixpanelForm: FC<{
           <label>API Server</label>
           <SelectField
             name="server"
+            // todo: better inference
             value={params.server || "standard"}
             onChange={(v) => {
               onManualParamChange("server", v);

--- a/packages/front-end/components/Settings/WebhooksModal.tsx
+++ b/packages/front-end/components/Settings/WebhooksModal.tsx
@@ -224,7 +224,7 @@ const WebhooksModal: FC<{
             sort={false}
           />
           <div className="small">
-            <DocLink docSection="statisticsSequential">
+            <DocLink docSection="sdkWebhooks#payload-format">
               Learn More <FaExternalLinkAlt />
             </DocLink>
           </div>

--- a/packages/front-end/components/Settings/WebhooksModal.tsx
+++ b/packages/front-end/components/Settings/WebhooksModal.tsx
@@ -39,7 +39,6 @@ const WebhooksModal: FC<{
       name: current.name || "My Webhook",
       endpoint: current.endpoint || "",
       useSdkMode: true,
-      // todo: better inference based on sendPayload
       payloadFormat: current?.payloadFormat || "standard",
       httpMethod: current?.httpMethod || "POST",
       headers: current?.headers || "{}",

--- a/packages/front-end/pages/sdks/SdkWebhooks.tsx
+++ b/packages/front-end/pages/sdks/SdkWebhooks.tsx
@@ -17,6 +17,13 @@ import { DocLink } from "@/components/DocLink";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 import ClickToReveal from "@/components/Settings/ClickToReveal";
 
+const payloadFormatLabels = {
+  standard: "Standard",
+  "standard-no-payload": "Standard (no SDK Payload)",
+  sdkPayload: "SDK Payload only",
+  none: "none",
+};
+
 export default function SdkWebhooks({
   connection,
 }: {
@@ -54,7 +61,10 @@ export default function SdkWebhooks({
         >
           <code className="text-main small">{webhook.endpoint}</code>
         </td>
-        <td>{webhook.sendPayload ? "yes" : "no"}</td>
+        <td className="small">{webhook.httpMethod}</td>
+        <td className="small">
+          {payloadFormatLabels?.[webhook?.payloadFormat ?? "standard"]}
+        </td>
         <td className="nowrap">
           {webhook.signingKey ? (
             <ClickToReveal
@@ -199,9 +209,10 @@ export default function SdkWebhooks({
             <tr>
               <th>Webhook</th>
               <th>Endpoint</th>
-              <th>Send Payload</th>
+              <th>Method</th>
+              <th style={{ width: 110 }}>Format</th>
               <th>Shared Secret</th>
-              <th>Last Success</th>
+              <th style={{ width: 125 }}>Last Success</th>
               <th />
               <th style={{ width: 50 }} />
             </tr>

--- a/packages/front-end/pages/sdks/SdkWebhooks.tsx
+++ b/packages/front-end/pages/sdks/SdkWebhooks.tsx
@@ -1,8 +1,12 @@
-import React, { useState } from "react";
+import React, { ReactElement, useState } from "react";
 import { WebhookInterface } from "back-end/types/webhook";
-import { FaCheck, FaExclamationTriangle, FaInfoCircle } from "react-icons/fa";
+import {
+  FaCheck,
+  FaExclamationTriangle,
+  FaInfoCircle,
+  FaPaperPlane,
+} from "react-icons/fa";
 import { ago } from "shared/dates";
-import { BsArrowRepeat } from "react-icons/bs";
 import { SDKConnectionInterface } from "@back-end/types/sdk-connection";
 import useApi from "@/hooks/useApi";
 import WebhooksModal from "@/components/Settings/WebhooksModal";
@@ -17,9 +21,15 @@ import { DocLink } from "@/components/DocLink";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 import ClickToReveal from "@/components/Settings/ClickToReveal";
 
-const payloadFormatLabels = {
+const payloadFormatLabels: Record<string, string | ReactElement> = {
   standard: "Standard",
-  "standard-no-payload": "Standard (no SDK Payload)",
+  "standard-no-payload": (
+    <>
+      Standard
+      <br />
+      (no SDK Payload)
+    </>
+  ),
   sdkPayload: "SDK Payload only",
   none: "none",
 };
@@ -106,7 +116,7 @@ export default function SdkWebhooks({
           <Button
             color="outline-primary"
             className="btn-sm"
-            style={{ width: 120 }}
+            style={{ width: 80 }}
             disabled={!canUpdateWebhook}
             onClick={async () => {
               await apiCall(`/sdk-webhooks/${webhook.id}/test`, {
@@ -115,11 +125,12 @@ export default function SdkWebhooks({
               mutate();
             }}
           >
-            <BsArrowRepeat /> Test Webhook
+            <FaPaperPlane className="mr-1" />
+            Test
           </Button>
         </td>
-        <td>
-          <div className="col-auto">
+        <td className="px-0">
+          <div className="col-auto mr-1">
             <MoreMenu>
               {canUpdateWebhook ? (
                 <button
@@ -210,11 +221,11 @@ export default function SdkWebhooks({
               <th>Webhook</th>
               <th>Endpoint</th>
               <th>Method</th>
-              <th style={{ width: 110 }}>Format</th>
+              <th style={{ width: 130 }}>Format</th>
               <th>Shared Secret</th>
               <th style={{ width: 125 }}>Last Success</th>
               <th />
-              <th style={{ width: 50 }} />
+              <th className="px-0" style={{ width: 35 }} />
             </tr>
           </thead>
           <tbody>{renderTableRows()}</tbody>


### PR DESCRIPTION
### Features and Changes

- Provide some purpose-driven formatters for SDK webhooks. The current format is not conducive for key/val storage (for example when using an Edge SDK) or for setting caches.

- Add a migration (`sendPayload` field is deprecated)

- Update the docs (sdk webhooks and edge sdks)



<img width="1356" alt="image" src="https://github.com/growthbook/growthbook/assets/7927873/cf1797e5-3c33-4f34-8953-c47ca07fe4d9">

<img width="831" alt="image" src="https://github.com/growthbook/growthbook/assets/7927873/80311358-74bb-4c40-8d21-2882544dd07f">

