### PR TITLE
[Docs] Add code experimentation path in Quick Start

### DIFF
--- a/docs/docs/quick-start.mdx
+++ b/docs/docs/quick-start.mdx
@@ -77,6 +77,8 @@ if (gb.isOn("my-feature")) {
 
 It really is that simple to get started! For next steps, we recommend reading our [Feature Flag Basics](/features/basics) page, which goes into more depth.
 
+Feature flags are the foundation for powerful experimentation. In the next section, we show you how to use them to run no-code experimentation using our Visual Editor. Need more advanced options? Dive into our [complete guide for code-based experimentation](/feature-flag-experiments).
+
 ## No-Code Experimentation
 
 :::info


### PR DESCRIPTION
### Features and Changes
While our Quick Start guide includes instructions for running no-code experimentation, it doesn't provide a path for those looking to code experiments in code. 

This change adds that pathway via a link (as an interim solution).

Ref: https://growthbookapp.slack.com/archives/C07BMHJKG2U/p1720657551924339