### PR TITLE
Redesign webhook details page

### DIFF
--- a/packages/back-end/src/models/EventWebHookLogModel.ts
+++ b/packages/back-end/src/models/EventWebHookLogModel.ts
@@ -1,7 +1,11 @@
 import { randomUUID } from "crypto";
 import omit from "lodash/omit";
 import mongoose from "mongoose";
-import { EventWebHookLegacyLogInterface, EventWebHookLogInterface } from "../../types/event-webhook-log";
+import {
+  EventWebHookLegacyLogInterface,
+  EventWebHookLogInterface,
+} from "../../types/event-webhook-log";
+import { EventWebHookMethod } from "../../types/event-webhook";
 import { NotificationEventName } from "../../types/event";
 
 const eventWebHookLogSchema = new mongoose.Schema({
@@ -11,6 +15,8 @@ const eventWebHookLogSchema = new mongoose.Schema({
     required: true,
   },
   event: String,
+  url: String,
+  method: String,
   eventWebHookId: {
     type: String,
     required: true,
@@ -46,9 +52,12 @@ eventWebHookLogSchema.index({ eventWebHookId: 1 });
 
 type EventWebHookLogDocument = mongoose.Document & EventWebHookLogInterface;
 
-type EventWebHookLegacyLogDocument = mongoose.Document & EventWebHookLegacyLogInterface;
+type EventWebHookLegacyLogDocument = mongoose.Document &
+  EventWebHookLegacyLogInterface;
 
-const toLegacyInterface = (doc: EventWebHookLegacyLogDocument): EventWebHookLegacyLogDocument =>
+const toLegacyInterface = (
+  doc: EventWebHookLegacyLogDocument
+): EventWebHookLegacyLogDocument =>
   omit(doc.toJSON(), ["__v", "_id"]) as EventWebHookLegacyLogDocument;
 
 const toInterface = (doc: EventWebHookLogDocument): EventWebHookLogDocument =>
@@ -67,7 +76,9 @@ const EventWebHookLogModel = mongoose.model<EventWebHookLogInterface>(
 type CreateEventWebHookLogOptions = {
   organizationId: string;
   eventWebHookId: string;
-  event: NotificationEventName; 
+  event: NotificationEventName;
+  url: string;
+  method: EventWebHookMethod;
   payload: Record<string, unknown>;
   result:
     | {
@@ -92,6 +103,8 @@ export const createEventWebHookLog = async ({
   organizationId,
   payload,
   event,
+  url,
+  method,
   result: resultState,
 }: CreateEventWebHookLogOptions): Promise<EventWebHookLogInterface> => {
   const now = new Date();
@@ -100,6 +113,8 @@ export const createEventWebHookLog = async ({
     id: `ewhl-${randomUUID()}`,
     dateCreated: now,
     event,
+    url,
+    method,
     eventWebHookId,
     organizationId,
     result: resultState.state,

--- a/packages/back-end/src/models/EventWebhookModel.ts
+++ b/packages/back-end/src/models/EventWebhookModel.ts
@@ -287,10 +287,17 @@ export const deleteOrganizationventWebHook = async (
   return result.deletedCount > 0;
 };
 
-type UpdateEventWebHookAttributes = {
-  name?: string;
-  url?: string;
-  events?: NotificationEventName[];
+export type UpdateEventWebHookAttributes = {
+    name?: string;
+    url?: string;
+    enabled?: boolean;
+    events?: NotificationEventName[];
+    tags?: string[];
+    environments?: string[];
+    projects?: string[];
+    payloadType?: EventWebHookPayloadType;
+    method?: EventWebHookMethod;
+    headers?: Record<string, string>;
 };
 
 /**

--- a/packages/back-end/src/models/EventWebhookModel.ts
+++ b/packages/back-end/src/models/EventWebhookModel.ts
@@ -288,16 +288,16 @@ export const deleteOrganizationventWebHook = async (
 };
 
 export type UpdateEventWebHookAttributes = {
-    name?: string;
-    url?: string;
-    enabled?: boolean;
-    events?: NotificationEventName[];
-    tags?: string[];
-    environments?: string[];
-    projects?: string[];
-    payloadType?: EventWebHookPayloadType;
-    method?: EventWebHookMethod;
-    headers?: Record<string, string>;
+  name?: string;
+  url?: string;
+  enabled?: boolean;
+  events?: NotificationEventName[];
+  tags?: string[];
+  environments?: string[];
+  projects?: string[];
+  payloadType?: EventWebHookPayloadType;
+  method?: EventWebHookMethod;
+  headers?: Record<string, string>;
 };
 
 /**

--- a/packages/back-end/src/routers/event-webhooks/event-webhooks.controller.ts
+++ b/packages/back-end/src/routers/event-webhooks/event-webhooks.controller.ts
@@ -17,7 +17,10 @@ import * as EventWebHookLog from "../../models/EventWebHookLogModel";
 
 import { AuthRequest } from "../../types/AuthRequest";
 import { getContextFromReq } from "../../services/organizations";
-import { EventWebHookLegacyLogInterface, EventWebHookLogInterface } from "../../../types/event-webhook-log";
+import {
+  EventWebHookLegacyLogInterface,
+  EventWebHookLogInterface,
+} from "../../../types/event-webhook-log";
 import { WebhookTestEvent } from "../../events/notification-events";
 import { NotificationEventName } from "../../events/base-types";
 import { EventNotifier } from "../../events/notifiers/EventNotifier";
@@ -32,7 +35,7 @@ type GetEventWebHooks = {
 
 export const getEventWebHooks = async (
   req: GetEventWebHooksRequest,
-  res: Response<GetEventWebHooks>,
+  res: Response<GetEventWebHooks>
 ) => {
   const context = getContextFromReq(req);
 
@@ -57,7 +60,7 @@ type GetEventWebHookByIdResponse = {
 
 export const getEventWebHook = async (
   req: GetEventWebHookByIdRequest,
-  res: Response<GetEventWebHookByIdResponse | PrivateApiErrorResponse>,
+  res: Response<GetEventWebHookByIdResponse | PrivateApiErrorResponse>
 ) => {
   const context = getContextFromReq(req);
 
@@ -69,7 +72,7 @@ export const getEventWebHook = async (
 
   const eventWebHook = await getEventWebHookById(
     eventWebHookId,
-    context.org.id,
+    context.org.id
   );
 
   if (!eventWebHook) {
@@ -106,7 +109,7 @@ type PostEventWebHooksResponse = {
 
 export const createEventWebHook = async (
   req: PostEventWebHooksRequest,
-  res: Response<PostEventWebHooksResponse | PrivateApiErrorResponse>,
+  res: Response<PostEventWebHooksResponse | PrivateApiErrorResponse>
 ) => {
   const context = getContextFromReq(req);
 
@@ -161,7 +164,7 @@ type GetEventWebHookLogsResponse = {
 
 export const getEventWebHookLogs = async (
   req: GetEventWebHookLogsRequest,
-  res: Response<GetEventWebHookLogsResponse | PrivateApiErrorResponse>,
+  res: Response<GetEventWebHookLogsResponse | PrivateApiErrorResponse>
 ) => {
   const context = getContextFromReq(req);
 
@@ -172,7 +175,7 @@ export const getEventWebHookLogs = async (
   const eventWebHookLogs = await EventWebHookLog.getLatestRunsForWebHook(
     context.org.id,
     req.params.eventWebHookId,
-    50,
+    50
   );
 
   return res.json({ eventWebHookLogs });
@@ -190,7 +193,7 @@ type DeleteEventWebhookResponse = {
 
 export const deleteEventWebHook = async (
   req: DeleteEventWebhookRequest,
-  res: Response<DeleteEventWebhookResponse | PrivateApiErrorResponse>,
+  res: Response<DeleteEventWebhookResponse | PrivateApiErrorResponse>
 ) => {
   const context = getContextFromReq(req);
 
@@ -225,7 +228,7 @@ type UpdateEventWebHookResponse = {
 
 export const putEventWebHook = async (
   req: UpdateEventWebHookRequest,
-  res: Response<UpdateEventWebHookResponse>,
+  res: Response<UpdateEventWebHookResponse>
 ) => {
   const context = getContextFromReq(req);
 
@@ -238,7 +241,7 @@ export const putEventWebHook = async (
       eventWebHookId: req.params.eventWebHookId,
       organizationId: context.org.id,
     },
-    req.body,
+    req.body
   );
 
   const status = successful ? 200 : 404;
@@ -264,7 +267,7 @@ type PostToggleEventWebHooksResponse = {
 
 export const toggleEventWebHook = async (
   req: PostToggleEventWebHooksRequest,
-  res: Response<PostToggleEventWebHooksResponse | PrivateApiErrorResponse>,
+  res: Response<PostToggleEventWebHooksResponse | PrivateApiErrorResponse>
 ) => {
   const context = getContextFromReq(req);
 
@@ -279,7 +282,7 @@ export const toggleEventWebHook = async (
 
   const webhook = await EventWebHook.getEventWebHookById(
     webhookId,
-    organizationId,
+    organizationId
   );
 
   const enabled = !webhook?.enabled;
@@ -289,7 +292,7 @@ export const toggleEventWebHook = async (
       eventWebHookId: webhookId,
       organizationId,
     },
-    { enabled },
+    { enabled }
   );
 
   const status = successful ? 200 : 404;
@@ -315,7 +318,7 @@ type PostTestEventWebHooksResponse = {
 
 export const createTestEventWebHook = async (
   req: PostTestEventWebHooksRequest,
-  res: Response<PostTestEventWebHooksResponse | PrivateApiErrorResponse>,
+  res: Response<PostTestEventWebHooksResponse | PrivateApiErrorResponse>
 ) => {
   const context = getContextFromReq(req);
 
@@ -329,7 +332,7 @@ export const createTestEventWebHook = async (
 
   const webhook = await EventWebHook.getEventWebHookById(
     webhookId,
-    organizationId,
+    organizationId
   );
 
   if (!webhook) throw new Error(`Cannot find webhook with id ${webhookId}`);

--- a/packages/back-end/src/routers/event-webhooks/event-webhooks.router.ts
+++ b/packages/back-end/src/routers/event-webhooks/event-webhooks.router.ts
@@ -134,4 +134,16 @@ router.post(
   eventWebHooksController.createTestEventWebHook
 );
 
+router.post(
+  "/event-webhooks/toggle",
+  validateRequestMiddleware({
+    body: z
+      .object({
+        webhookId: z.string().trim().min(1),
+      })
+      .strict(),
+  }),
+  eventWebHooksController.toggleEventWebHook
+);
+
 export { router as eventWebHooksRouter };

--- a/packages/back-end/test/events/EventWebHookNotifier.test.ts
+++ b/packages/back-end/test/events/EventWebHookNotifier.test.ts
@@ -24,6 +24,7 @@ describe("EventWebHookNotifier", () => {
         url: "http://foo.com/bla",
         signingKey: "the signing key",
       },
+      method: "POST",
     });
 
     expect(result).toEqual({
@@ -62,6 +63,7 @@ describe("EventWebHookNotifier", () => {
         url: "http://foo.com/bla",
         signingKey: "the signing key",
       },
+      method: "POST",
     });
 
     expect(result).toEqual({
@@ -94,9 +96,9 @@ describe("EventWebHookNotifier", () => {
       payload: "the payload",
       eventWebHook: {
         url: "http://foo.com/bla",
-        method: "PATCH",
         signingKey: "the signing key",
       },
+      method: "PATCH",
     });
 
     expect(result).toEqual({
@@ -132,6 +134,7 @@ describe("EventWebHookNotifier", () => {
         headers: { foo: "bar" },
         signingKey: "the signing key",
       },
+      method: "POST",
     });
 
     expect(result).toEqual({

--- a/packages/back-end/types/event-webhook-log.d.ts
+++ b/packages/back-end/types/event-webhook-log.d.ts
@@ -1,8 +1,11 @@
 import { NotificationEventName } from "./event";
+import { EventWebHookMethod } from "./event-webhook";
 
 export interface EventWebHookLegacyLogInterface {
   id: string;
   event?: NotificationEventName;
+  url?: string;
+  method?: EventWebHookMethod;
   eventWebHookId: string;
   organizationId: string;
   dateCreated: Date;

--- a/packages/back-end/types/event-webhook-log.d.ts
+++ b/packages/back-end/types/event-webhook-log.d.ts
@@ -18,4 +18,6 @@ export interface EventWebHookLegacyLogInterface {
 export interface EventWebHookLogInterface
   extends EventWebHookLegacyLogInterface {
   event: NotificationEventName;
+  url: string;
+  method: EventWebHookMethod;
 }

--- a/packages/back-end/types/event-webhook-log.d.ts
+++ b/packages/back-end/types/event-webhook-log.d.ts
@@ -1,5 +1,8 @@
-export interface EventWebHookLogInterface {
+import { NotificationEventName } from "./event";
+
+export interface EventWebHookLegacyLogInterface {
   id: string;
+  event?: NotificationEventName;
   eventWebHookId: string;
   organizationId: string;
   dateCreated: Date;
@@ -7,4 +10,9 @@ export interface EventWebHookLogInterface {
   responseBody: string | null;
   result: "error" | "success";
   payload: Record<string, unknown>;
+}
+
+export interface EventWebHookLogInterface
+  extends EventWebHookLegacyLogInterface {
+  event: NotificationEventName;
 }

--- a/packages/front-end/components/EventWebHooks/EventWebHookDetail/EventWebHookDetail.tsx
+++ b/packages/front-end/components/EventWebHooks/EventWebHookDetail/EventWebHookDetail.tsx
@@ -12,7 +12,6 @@ import DeleteButton from "@/components/DeleteButton/DeleteButton";
 import { useAuth } from "@/services/auth";
 import Badge from "@/components/Badge";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
-import useApi from "@/hooks/useApi";
 import { useEventWebhookLogs } from "@/hooks/useEventWebhookLogs";
 import {
   EventWebHookEditParams,
@@ -271,15 +270,17 @@ export const EventWebHookDetail: FC<EventWebHookDetailProps> = ({
   );
 };
 
-export const EventWebHookDetailContainer = () => {
+export const EventWebHookDetailContainer = ({
+  eventWebHook,
+  mutateEventWebHook,
+}: {
+  eventWebHook: EventWebHookInterface;
+  mutateEventWebHook: () => void;
+}) => {
   const router = useRouter();
   const { eventwebhookid: eventWebHookId } = router.query;
 
   const { apiCall } = useAuth();
-
-  const { data, error, mutate } = useApi<{
-    eventWebHook: EventWebHookInterface;
-  }>(`/event-webhooks/${eventWebHookId}`);
 
   const [isEditModalOpen, setIsEditModalOpen] = useState<boolean>(false);
   const [editError, setEditError] = useState<string | null>(null);
@@ -319,14 +320,14 @@ export const EventWebHookDetailContainer = () => {
         if (response.error) {
           handleUpdateError(response.error || "Unknown error");
         } else {
-          mutate();
+          mutateEventWebHook();
           setEditError(null);
         }
       } catch (e) {
         handleUpdateError("Unknown error");
       }
     },
-    [mutate, apiCall, eventWebHookId]
+    [mutateEventWebHook, apiCall, eventWebHookId]
   );
 
   const handleDelete = useCallback(async () => {
@@ -340,18 +341,6 @@ export const EventWebHookDetailContainer = () => {
     router.replace("/settings/webhooks");
   }, [eventWebHookId, apiCall, router]);
 
-  if (error) {
-    return (
-      <div className="alert alert-danger">
-        Unable to fetch event web hook {eventWebHookId}
-      </div>
-    );
-  }
-
-  if (!data) {
-    return null;
-  }
-
   return (
     <EventWebHookDetail
       isModalOpen={isEditModalOpen}
@@ -362,9 +351,9 @@ export const EventWebHookDetailContainer = () => {
         setEditError(null);
       }}
       onModalClose={() => setIsEditModalOpen(false)}
-      eventWebHook={data.eventWebHook}
+      eventWebHook={eventWebHook}
       editError={editError}
-      mutateEventWebHook={mutate}
+      mutateEventWebHook={mutateEventWebHook}
     />
   );
 };

--- a/packages/front-end/components/EventWebHooks/EventWebHookDetail/EventWebHookDetail.tsx
+++ b/packages/front-end/components/EventWebHooks/EventWebHookDetail/EventWebHookDetail.tsx
@@ -220,7 +220,7 @@ export const EventWebHookDetail: FC<EventWebHookDetailProps> = ({
           {!lastRunAt ? (
             <div className="text-muted">No runs</div>
           ) : (
-            <div className="text-main d-flex">
+            <div className="text-main d-flex align-items-center">
               <b className="mr-1">Last run:</b> {datetime(lastRunAt)}
               <span className="ml-2" style={{ fontSize: "1.5rem" }}>
                 {iconForState}

--- a/packages/front-end/components/EventWebHooks/EventWebHookDetail/EventWebHookDetail.tsx
+++ b/packages/front-end/components/EventWebHooks/EventWebHookDetail/EventWebHookDetail.tsx
@@ -1,24 +1,23 @@
 import { EventWebHookInterface } from "back-end/types/event-webhook";
-import React, { FC, useCallback, useState } from "react";
+import React, { FC, useRef, useCallback, useState } from "react";
 import pick from "lodash/pick";
-import { TbWebhook } from "react-icons/tb";
-import { FaAngleLeft, FaPencilAlt, FaPaperPlane } from "react-icons/fa";
-import classNames from "classnames";
+import { FaPencilAlt } from "react-icons/fa";
 import { useRouter } from "next/router";
-import Link from "next/link";
 import { HiOutlineClipboard, HiOutlineClipboardCheck } from "react-icons/hi";
 import { datetime } from "shared/dates";
 import DeleteButton from "@/components/DeleteButton/DeleteButton";
 import { useAuth } from "@/services/auth";
-import Badge from "@/components/Badge";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import { useEventWebhookLogs } from "@/hooks/useEventWebhookLogs";
 import {
   EventWebHookEditParams,
   useIconForState,
+  webhookIcon,
+  displayedEvents,
 } from "@/components/EventWebHooks/utils";
-import { SimpleTooltip } from "@/components/SimpleTooltip/SimpleTooltip";
 import { EventWebHookAddEditModal } from "@/components/EventWebHooks/EventWebHookAddEditModal/EventWebHookAddEditModal";
+import MoreMenu from "@/components/Dropdown/MoreMenu";
+import { useDefinitions } from "@/services/DefinitionsContext";
 
 type EventWebHookDetailProps = {
   eventWebHook: EventWebHookInterface;
@@ -53,25 +52,72 @@ export const EventWebHookDetail: FC<EventWebHookDetailProps> = ({
   isModalOpen,
   editError,
 }) => {
+  const { getProjectById } = useDefinitions();
+
   const {
     id: webhookId,
-    lastState,
     lastRunAt,
-    url,
+    payloadType,
+    enabled,
+    environments = [],
+    projects: projectIds,
+    tags = [],
     events,
     name,
     signingKey,
   } = eventWebHook;
 
+  const defined = <T,>(v: T): v is NonNullable<T> => !!v;
+
+  const projects = (projectIds || []).map(getProjectById).filter(defined);
   const { apiCall } = useAuth();
   const { mutate: mutateEventLogs } = useEventWebhookLogs(webhookId);
-  const [state, setState] = useState<State>();
+  const [state, setStateRaw] = useState<State>();
+  const stateTimeout = useRef<undefined | ReturnType<typeof setTimeout>>();
+
+  const setState = useCallback((state) => {
+    setStateRaw(state);
+
+    if (stateTimeout.current) clearTimeout(stateTimeout.current);
+    stateTimeout.current = setTimeout(() => setStateRaw(undefined), 1500);
+  }, []);
 
   const iconForState = useIconForState(eventWebHook.lastState);
 
   const { performCopy, copySuccess, copySupported } = useCopyToClipboard({
     timeout: 1500,
   });
+
+  const onToggleWebhook = useCallback(async () => {
+    setState({ type: "loading" });
+
+    try {
+      const response = await apiCall<{
+        enabled: boolean;
+        error?: string;
+      }>("/event-webhooks/toggle", {
+        method: "POST",
+        body: JSON.stringify({ webhookId }),
+      });
+
+      if (response.error) {
+        setState({
+          type: "danger",
+          message: `Failed to enable or disable webhook: ${response.error}`,
+        });
+        return;
+      }
+
+      setState({
+        type: "success",
+        message: `Wehook ${response.enabled ? "enabled" : "disabled"}`,
+      });
+
+      mutateEventWebHook();
+    } catch (e) {
+      setState({ type: "danger", message: "Unknown error" });
+    }
+  }, [mutateEventWebHook, webhookId, apiCall, setState]);
 
   const onTestWebhook = useCallback(async () => {
     setState({ type: "loading" });
@@ -100,20 +146,17 @@ export const EventWebHookDetail: FC<EventWebHookDetailProps> = ({
       setTimeout(() => {
         mutateEventLogs();
         mutateEventWebHook();
-      }, 1000);
+      }, 1500);
     } catch (e) {
       setState({ type: "danger", message: "Unknown error" });
     }
-  }, [mutateEventLogs, mutateEventWebHook, webhookId, apiCall]);
+  }, [setState, mutateEventLogs, mutateEventWebHook, webhookId, apiCall]);
+
+  if (!payloadType) return null;
 
   return (
     <div>
       <div className="d-sm-flex mb-3 justify-content-between">
-        <Link href="/settings/webhooks" className="p-sm-1">
-          <FaAngleLeft />
-          All Webhooks
-        </Link>
-
         {state && state.type !== "loading" && (
           <div className={`p-sm-1 mb-0 alert alert-${state.type}`}>
             {state.message}
@@ -121,123 +164,150 @@ export const EventWebHookDetail: FC<EventWebHookDetailProps> = ({
         )}
       </div>
 
-      <div className="d-sm-flex justify-content-between mb-3 mb-sm-0">
-        <div>
+      <div className="justify-content-between mb-3 mb-sm-0">
+        <div className="d-flex align-items-center">
           {/* Title */}
+          <div className="m-2 p-2 border rounded">
+            <img
+              src={webhookIcon[payloadType]}
+              style={{ height: "2rem", width: "2rem" }}
+            />
+          </div>
           <h1>{name}</h1>
+          {enabled && (
+            <div>
+              <span className="badge badge-gray text-uppercase ml-2">
+                Enabled
+              </span>
+            </div>
+          )}
+
+          <div className="ml-auto d-flex align-items-center">
+            <button className="btn btn-primary" onClick={onEditModalOpen}>
+              <FaPencilAlt className="mr-1" /> Edit
+            </button>
+            <MoreMenu className="ml-2">
+              <button
+                onClick={onTestWebhook}
+                className="btn dropdown-item pb-2"
+                disabled={state && state.type === "loading"}
+              >
+                Send Test
+              </button>
+
+              <button
+                onClick={onToggleWebhook}
+                className="btn dropdown-item pb-2"
+                disabled={state && state.type === "loading"}
+              >
+                {enabled ? "Disable" : "Enable"}
+              </button>
+
+              <hr className="m-1" />
+              <DeleteButton
+                displayName="Webhook"
+                onClick={onDelete}
+                useIcon={false}
+                className="dropdown-item text-danger"
+                text="Delete"
+                disabled={state && state.type === "loading"}
+              />
+            </MoreMenu>
+          </div>
         </div>
 
-        <div>
-          {/* Actions */}
-          <button
-            onClick={onEditModalOpen}
-            className="btn btn-sm btn-outline-primary mr-1"
-          >
-            <FaPencilAlt className="mr-1" />
-            Edit
-          </button>
+        <div className="ml-2">
+          {!lastRunAt ? (
+            <div className="text-muted">No runs</div>
+          ) : (
+            <div className="text-main d-flex">
+              <b className="mr-1">Last run:</b> {datetime(lastRunAt)}
+              <span className="ml-2" style={{ fontSize: "1.5rem" }}>
+                {iconForState}
+              </span>
+            </div>
+          )}
+        </div>
 
-          <button
-            onClick={onTestWebhook}
-            className="btn btn-sm btn-outline-secondary mr-1"
-            disabled={state && state.type === "loading"}
-          >
-            <FaPaperPlane className="mr-1" />
-            Test
-          </button>
+        <div className="ml-2 d-flex align-items-center">
+          <div className="text-main">
+            <b>Secret:</b>
+          </div>
+          <span className="ml-1">
+            <code className="text-main text-break">{signingKey}</code>
+          </span>
 
-          <DeleteButton
-            displayName={name}
-            onClick={onDelete}
-            outline={true}
-            className="btn-sm"
-            text="Delete"
-          />
+          <span className="ml-2">
+            {copySupported ? (
+              <button
+                className="btn p-0 pb-1"
+                onClick={() => performCopy(signingKey)}
+              >
+                <span className="text-main" style={{ fontSize: "1.1rem" }}>
+                  {copySuccess ? (
+                    <HiOutlineClipboardCheck />
+                  ) : (
+                    <HiOutlineClipboard />
+                  )}
+                </span>
+              </button>
+            ) : null}
+          </span>
         </div>
       </div>
 
-      <h3 className="text-muted text-break font-weight-bold">{url}</h3>
-
-      <div className="card mt-3 p-3">
+      <div className="card mt-3 p-3 p-4">
         <div className="row">
           <div className="col-xs-12 col-md-6">
-            <div className="d-flex font-weight-bold align-items-center">
-              {/* Last run state & date */}
-              <span className="mr-2" style={{ fontSize: "1.5rem" }}>
-                {iconForState}
-              </span>
-              {lastRunAt ? (
-                <span
-                  className={classNames("", {
-                    "text-success": lastState === "success",
-                    "text-danger": lastState === "error",
-                  })}
-                >
-                  Last run on {datetime(lastRunAt)}
-                </span>
+            <div className="align-items-center mt-2">
+              <span className="font-weight-bold">Events enabled</span>
+              <div className="mt-1">{displayedEvents(events)}</div>
+            </div>
+          </div>
+        </div>
+
+        <div className="row mt-4">
+          <div className="col mt-2 mt-md-0">
+            <div className="align-items-center mt-2">
+              <div className="font-weight-bold mb-1">Environments</div>
+              {environments.length ? (
+                environments.map((env) => (
+                  <span className="mr-2 badge badge-purple" key={env}>
+                    {env}
+                  </span>
+                ))
               ) : (
-                <span className="text-muted">
-                  This webhook has not yet run.
-                </span>
+                <span className="font-italic">All</span>
               )}
             </div>
           </div>
 
-          <div className="col-xs-12 col-md-6 mt-2 mt-md-0">
-            <div className="d-flex align-items-center">
-              {copySupported ? (
-                <button
-                  className="btn p-0"
-                  onClick={() => performCopy(signingKey)}
-                >
-                  <span className="text-main" style={{ fontSize: "1.1rem" }}>
-                    {copySuccess ? (
-                      <HiOutlineClipboardCheck />
-                    ) : (
-                      <HiOutlineClipboard />
-                    )}
+          <div className="col mt-2 mt-md-0">
+            <div className="align-items-center mt-2">
+              <div className="font-weight-bold mb-1">Projects</div>
+              {projects.length ? (
+                projects.map((proj) => (
+                  <span className="mr-2 badge badge-purple" key={proj.id}>
+                    {proj.name}
                   </span>
-                </button>
-              ) : null}
-              <span className="ml-3">
-                <code className="text-main text-break">{signingKey}</code>
-              </span>
-
-              {copySuccess ? (
-                <SimpleTooltip position="bottom">
-                  Webhook secret copied to clipboard!
-                </SimpleTooltip>
-              ) : null}
-            </div>
-          </div>
-        </div>
-
-        <div className="row">
-          <div className="col-xs-12 col-md-6">
-            <div className="d-flex align-items-center mt-2">
-              <span
-                className="text-muted ml-1 mr-2"
-                style={{ fontSize: "1rem" }}
-              >
-                <TbWebhook className="d-block" />
-              </span>
-              <span className="font-weight-bold">&nbsp;Events</span>
-              <div className="flex-grow-1 d-flex flex-wrap ml-3">
-                {events.map((eventName) => (
-                  <span key={eventName} className="mr-2 badge badge-purple">
-                    {eventName}
-                  </span>
-                ))}
-              </div>
-            </div>
-          </div>
-
-          <div className="col-xs-12 col-md-6">
-            <div className="mt-2">
-              {eventWebHook.enabled ? (
-                <Badge className="badge-green" content="Webhook enabled" />
+                ))
               ) : (
-                <Badge className="badge-red" content="Webhook disabled" />
+                <span className="font-italic">All</span>
+              )}
+            </div>
+          </div>
+
+          <div className="col mt-2 mt-md-0">
+            <div className="align-items-center mt-2">
+              <div className="font-weight-bold mb-1">Tags</div>
+              {tags.length ? (
+                tags.map((tag) => (
+                  <span className="mr-2 badge badge-purple" key={tag}>
+                    {tag}
+                  </span>
+                ))
+              ) : (
+                <span className="font-italic">All</span>
               )}
             </div>
           </div>

--- a/packages/front-end/components/EventWebHooks/EventWebHookList/EventWebHookListItem/EventWebHookListItem.tsx
+++ b/packages/front-end/components/EventWebHooks/EventWebHookList/EventWebHookListItem/EventWebHookListItem.tsx
@@ -13,6 +13,8 @@ type EventWebHookListItemProps = {
   eventWebHook: EventWebHookInterface;
 };
 
+const MAX_EVENTS_DISPLAY = 5;
+
 export const EventWebHookListItem: FC<EventWebHookListItemProps> = ({
   href,
   eventWebHook,
@@ -77,7 +79,10 @@ export const EventWebHookListItem: FC<EventWebHookListItemProps> = ({
             )}
           </div>
           <div className="text-main">
-            <b>Events enabled:</b> {displayedEvents(events)}
+            <b>Events enabled:</b>{" "}
+            {displayedEvents(events, {
+              maxEventsDisplay: MAX_EVENTS_DISPLAY,
+            })}
           </div>
         </div>
       </div>

--- a/packages/front-end/components/EventWebHooks/EventWebHookList/EventWebHookListItem/EventWebHookListItem.tsx
+++ b/packages/front-end/components/EventWebHooks/EventWebHookList/EventWebHookListItem/EventWebHookListItem.tsx
@@ -2,7 +2,11 @@ import React, { FC } from "react";
 import Link from "next/link";
 import { EventWebHookInterface } from "back-end/types/event-webhook";
 import { datetime } from "shared/dates";
-import { webhookIcon, useIconForState, displayedEvents } from "@/components/EventWebHooks/utils";
+import {
+  webhookIcon,
+  useIconForState,
+  displayedEvents,
+} from "@/components/EventWebHooks/utils";
 
 type EventWebHookListItemProps = {
   href: string;
@@ -73,8 +77,7 @@ export const EventWebHookListItem: FC<EventWebHookListItemProps> = ({
             )}
           </div>
           <div className="text-main">
-            <b>Events enabled:</b>{" "}
-            {displayedEvents(events)}
+            <b>Events enabled:</b> {displayedEvents(events)}
           </div>
         </div>
       </div>

--- a/packages/front-end/components/EventWebHooks/EventWebHookList/EventWebHookListItem/EventWebHookListItem.tsx
+++ b/packages/front-end/components/EventWebHooks/EventWebHookList/EventWebHookListItem/EventWebHookListItem.tsx
@@ -2,20 +2,12 @@ import React, { FC } from "react";
 import Link from "next/link";
 import { EventWebHookInterface } from "back-end/types/event-webhook";
 import { datetime } from "shared/dates";
-import { useIconForState } from "@/components/EventWebHooks/utils";
+import { webhookIcon, useIconForState, displayedEvents } from "@/components/EventWebHooks/utils";
 
 type EventWebHookListItemProps = {
   href: string;
   eventWebHook: EventWebHookInterface;
 };
-
-const MAX_EVENTS_DISPLAY = 5;
-
-const webhookIcon = {
-  discord: "/images/discord.png",
-  slack: "/images/slack.png",
-  raw: "/images/raw-webhook.png",
-} as const;
 
 export const EventWebHookListItem: FC<EventWebHookListItemProps> = ({
   href,
@@ -34,13 +26,6 @@ export const EventWebHookListItem: FC<EventWebHookListItemProps> = ({
   const iconForState = useIconForState(lastState);
 
   if (!payloadType) return null;
-
-  const displayedEvents = [
-    ...events
-      .slice(0, MAX_EVENTS_DISPLAY)
-      .map((event) => <code key={event}>{event}</code>),
-    ...(events.length > MAX_EVENTS_DISPLAY ? ["..."] : []),
-  ];
 
   return (
     <Link href={href} style={{ textDecoration: "none" }} className="card p-3">
@@ -89,15 +74,7 @@ export const EventWebHookListItem: FC<EventWebHookListItemProps> = ({
           </div>
           <div className="text-main">
             <b>Events enabled:</b>{" "}
-            {displayedEvents.reduce(
-              (element, text) => (
-                <>
-                  {element ? <>{element}, </> : null}
-                  {text}
-                </>
-              ),
-              null
-            )}
+            {displayedEvents(events)}
           </div>
         </div>
       </div>

--- a/packages/front-end/components/EventWebHooks/EventWebHookLogs/EventWebHookLogActiveItem/EventWebHookLogActiveItem.tsx
+++ b/packages/front-end/components/EventWebHooks/EventWebHookLogs/EventWebHookLogActiveItem/EventWebHookLogActiveItem.tsx
@@ -1,8 +1,8 @@
 import React, { FC } from "react";
 import { EventWebHookLogInterface } from "back-end/types/event-webhook-log";
-import { NotificationEvent } from "back-end/src/events/notification-events";
 import { useIconForState } from "@/components/EventWebHooks/utils";
 import Code from "@/components/SyntaxHighlighting/Code";
+import { datetime } from "shared/dates";
 
 type EventWebHookLogActiveItemProps = {
   log: EventWebHookLogInterface;
@@ -11,27 +11,27 @@ type EventWebHookLogActiveItemProps = {
 export const EventWebHookLogActiveItem: FC<EventWebHookLogActiveItemProps> = ({
   log,
 }) => {
-  const iconForState = useIconForState(log.result);
+  const iconForState = useIconForState(log.result, { text: true });
 
   return (
     <div>
-      {/* Title with status icon */}
-      <h3 className="d-flex align-items-center">
-        <span className="d-inline-block mr-1" style={{ fontSize: "1.7rem" }}>
-          {iconForState}
-        </span>
-        {(log.payload as NotificationEvent).event}
-      </h3>
+      <div className="d-flex align-items-center">
+        <h4 className="mb-0">
+          {log.event ?? <span className="font-italic">unknown</span>}
+        </h4>
+        <span className="d-inline-block ml-2 pt-1">{iconForState}</span>
+        <span className="ml-auto mr-2">{datetime(log.dateCreated)}</span>
+      </div>
 
-      <h4 className="mt-4">Response Code</h4>
-      <p>{log.responseCode || "None"}</p>
-
-      <h4 className="mt-4 mb-3">Payload</h4>
+      <h4 className="mt-4 mb-3">Request Payload</h4>
       <Code
         expandable={true}
         code={JSON.stringify(log.payload, null, 2)}
         language="json"
       />
+
+      <h4 className="mt-4">Response Code</h4>
+      <p>{log.responseCode || "None"}</p>
 
       <h4 className="mt-4">Response Body</h4>
       <code className="text-main">{log.responseBody}</code>

--- a/packages/front-end/components/EventWebHooks/EventWebHookLogs/EventWebHookLogActiveItem/EventWebHookLogActiveItem.tsx
+++ b/packages/front-end/components/EventWebHooks/EventWebHookLogs/EventWebHookLogActiveItem/EventWebHookLogActiveItem.tsx
@@ -1,8 +1,8 @@
 import React, { FC } from "react";
 import { EventWebHookLogInterface } from "back-end/types/event-webhook-log";
+import { datetime } from "shared/dates";
 import { useIconForState } from "@/components/EventWebHooks/utils";
 import Code from "@/components/SyntaxHighlighting/Code";
-import { datetime } from "shared/dates";
 
 type EventWebHookLogActiveItemProps = {
   log: EventWebHookLogInterface;
@@ -22,6 +22,22 @@ export const EventWebHookLogActiveItem: FC<EventWebHookLogActiveItemProps> = ({
         <span className="d-inline-block ml-2 pt-1">{iconForState}</span>
         <span className="ml-auto mr-2">{datetime(log.dateCreated)}</span>
       </div>
+
+      {log.url && (
+        <>
+          <div className="mt-4 mb-3 d-flex align-items-center">
+            <h4 className="mb-0">Request URL</h4>
+            {log.method && (
+              <span className="p-1 px-2 mb-0 rounded-pill badge badge-light d-flex align-items-center">
+                <span className="ml-1 mb-0 text-muted font-weight-normal">
+                  {log.method}
+                </span>
+              </span>
+            )}
+          </div>
+          <p className="text-muted">{log.url}</p>
+        </>
+      )}
 
       <h4 className="mt-4 mb-3">Request Payload</h4>
       <Code

--- a/packages/front-end/components/EventWebHooks/EventWebHookLogs/EventWebHookLogItem/EventWebHookLogItem.tsx
+++ b/packages/front-end/components/EventWebHooks/EventWebHookLogs/EventWebHookLogItem/EventWebHookLogItem.tsx
@@ -1,5 +1,4 @@
 import React, { FC } from "react";
-import { NotificationEvent } from "back-end/src/events/notification-events";
 import { EventWebHookLogInterface } from "back-end/types/event-webhook-log";
 import classNames from "classnames";
 import { datetime } from "shared/dates";
@@ -16,8 +15,6 @@ export const EventWebHookLogItem: FC<EventWebHookLogItemProps> = ({
   activeLogId,
   onClick,
 }) => {
-  const payload = log.payload as NotificationEvent;
-
   const iconForState = useIconForState(log.result);
 
   return (
@@ -27,15 +24,19 @@ export const EventWebHookLogItem: FC<EventWebHookLogItemProps> = ({
       })}
       onClick={() => onClick(log.id)}
     >
-      <td className="text-center">
+      <td className="text-left table-column-fit-width pr-5">
+        {datetime(log.dateCreated)}
+      </td>
+      <td className="text-left">
+        <code className="text-main">
+          {log.event ?? <span className="font-italic">unknown</span>}
+        </code>
+      </td>
+      <td className="text-left">
         <span className="d-inline-block" style={{ fontSize: "1.5rem" }}>
           {iconForState}
         </span>
       </td>
-      <td className="text-left">
-        <code className="text-main">{payload.event}</code>
-      </td>
-      <td className="text-left">{datetime(log.dateCreated)}</td>
     </tr>
   );
 };

--- a/packages/front-end/components/EventWebHooks/EventWebHookLogs/EventWebHookLogs.tsx
+++ b/packages/front-end/components/EventWebHooks/EventWebHookLogs/EventWebHookLogs.tsx
@@ -31,8 +31,8 @@ export const EventWebHookLogs: FC<EventWebHookLogsProps> = ({
             <table className="table appbox gbtable table-hover">
               <thead>
                 <tr>
-		  <th className="text-left">Timestamp</th>
-		  <th className="text-left">Event</th>
+                  <th className="text-left">Timestamp</th>
+                  <th className="text-left">Event</th>
                   <th className="text=left">Result</th>
                 </tr>
               </thead>

--- a/packages/front-end/components/EventWebHooks/EventWebHookLogs/EventWebHookLogs.tsx
+++ b/packages/front-end/components/EventWebHooks/EventWebHookLogs/EventWebHookLogs.tsx
@@ -31,9 +31,9 @@ export const EventWebHookLogs: FC<EventWebHookLogsProps> = ({
             <table className="table appbox gbtable table-hover">
               <thead>
                 <tr>
-                  <th className="text-center">Result</th>
-                  <th className="text-left">Event</th>
-                  <th className="text-left">Timestamp</th>
+		  <th className="text-left">Timestamp</th>
+		  <th className="text-left">Event</th>
+                  <th className="text=left">Result</th>
                 </tr>
               </thead>
               <tbody>

--- a/packages/front-end/components/EventWebHooks/utils.tsx
+++ b/packages/front-end/components/EventWebHooks/utils.tsx
@@ -157,14 +157,15 @@ export const webhookIcon = {
   raw: "/images/raw-webhook.png",
 } as const;
 
-const MAX_EVENTS_DISPLAY = 5;
-
-export const displayedEvents = (events: string[]) =>
+export const displayedEvents = (
+  events: string[],
+  { maxEventsDisplay }: { maxEventsDisplay?: number } = {}
+) =>
   [
     ...events
-      .slice(0, MAX_EVENTS_DISPLAY)
+      .slice(0, maxEventsDisplay)
       .map((event) => <code key={event}>{event}</code>),
-    ...(events.length > MAX_EVENTS_DISPLAY ? ["..."] : []),
+    ...(maxEventsDisplay && events.length > maxEventsDisplay ? ["..."] : []),
   ].reduce(
     (element, text) => (
       <>

--- a/packages/front-end/components/EventWebHooks/utils.tsx
+++ b/packages/front-end/components/EventWebHooks/utils.tsx
@@ -1,6 +1,10 @@
 import { NotificationEventName } from "back-end/src/events/base-types";
 import React, { ReactNode, useMemo } from "react";
-import { BsCheck, BsQuestion, BsX } from "react-icons/bs";
+import {
+  PiQuestionLight,
+  PiXSquareLight,
+  PiCheckCircleLight,
+} from "react-icons/pi";
 import {
   EventWebHookPayloadType,
   EventWebHookMethod,
@@ -95,17 +99,78 @@ export type EventWebHookModalMode =
  * @param state
  */
 export const useIconForState = (
-  state: "none" | "success" | "error"
+  state: "none" | "success" | "error",
+  { text }: { text: boolean } = { text: false },
 ): ReactNode =>
   useMemo(() => {
+    let invalidState: never;
+
     switch (state) {
-      case "none":
-        return <BsQuestion className="d-block text-muted" />;
-      case "success":
-        return <BsCheck className="d-block text-success" />;
-      case "error":
-        return <BsX className="d-block text-danger" />;
+      case "none": {
+        const icon = <PiQuestionLight className="d-block text-muted" />;
+        if (text)
+          return (
+            <span className="p-1 px-2 rounded-pill badge badge badge-light d-flex align-items-center">
+              {icon}{" "}
+              <span className="ml-1 mb-0 text-mutex font-weight-normal">
+                Not ran
+              </span>
+            </span>
+          );
+        else return icon;
+      }
+      case "success": {
+        const icon = <PiCheckCircleLight className="d-block text-success" />;
+        if (text)
+          return (
+            <span className="p-1 px-2 rounded-pill badge badge-success-light d-flex align-items-center">
+              {icon}{" "}
+              <span className="ml-1 mb-0 text-success font-weight-normal">
+                Successful
+              </span>
+            </span>
+          );
+        else return icon;
+      }
+      case "error": {
+        const icon = <PiXSquareLight className="d-block text-danger" />;
+        if (text)
+          return (
+            <span className="p-1 px-2 rounded-pill badge badge-danger-light d-flex align-items-center">
+              {icon}{" "}
+              <span className="ml-1 mb-0 text-danger font-weight-normal">
+                Failed
+              </span>
+            </span>
+          );
+        else return icon;
+      }
       default:
-        return null;
+        invalidState = state;
+        throw new Error(`Invalid state: ${invalidState}`);
     }
-  }, [state]);
+  }, [state, text]);
+
+export const webhookIcon = {
+  discord: "/images/discord.png",
+  slack: "/images/slack.png",
+  raw: "/images/raw-webhook.png",
+} as const;
+
+const MAX_EVENTS_DISPLAY = 5;
+
+export const displayedEvents = (events: string[]) =>
+  [
+    ...events
+      .slice(0, MAX_EVENTS_DISPLAY)
+      .map((event) => <code key={event}>{event}</code>),
+    ...(events.length > MAX_EVENTS_DISPLAY ? ["..."] : []),
+  ].reduce(
+    (element, text) => (
+      <>
+        {element ? <>{element}, </> : null}
+        {text}
+      </>
+    ),
+    null,
+  );

--- a/packages/front-end/components/EventWebHooks/utils.tsx
+++ b/packages/front-end/components/EventWebHooks/utils.tsx
@@ -100,7 +100,7 @@ export type EventWebHookModalMode =
  */
 export const useIconForState = (
   state: "none" | "success" | "error",
-  { text }: { text: boolean } = { text: false },
+  { text }: { text: boolean } = { text: false }
 ): ReactNode =>
   useMemo(() => {
     let invalidState: never;
@@ -110,9 +110,9 @@ export const useIconForState = (
         const icon = <PiQuestionLight className="d-block text-muted" />;
         if (text)
           return (
-            <span className="p-1 px-2 rounded-pill badge badge badge-light d-flex align-items-center">
+            <span className="p-1 px-2 rounded-pill badge badge-light d-flex align-items-center">
               {icon}{" "}
-              <span className="ml-1 mb-0 text-mutex font-weight-normal">
+              <span className="ml-1 mb-0 text-muted font-weight-normal">
                 Not ran
               </span>
             </span>
@@ -172,5 +172,5 @@ export const displayedEvents = (events: string[]) =>
         {text}
       </>
     ),
-    null,
+    null
   );

--- a/packages/front-end/components/PowerCalculation/PowerCalculationSettingsModal.tsx
+++ b/packages/front-end/components/PowerCalculation/PowerCalculationSettingsModal.tsx
@@ -369,10 +369,7 @@ const MetricParamsInput = ({
 }) => {
   const metrics = form.watch("metrics");
   // eslint-disable-next-line
-  const {
-    name,
-    ...params
-  } = sortParams(ensureAndReturn(metrics[metricId]));
+  const { name, ...params } = sortParams(ensureAndReturn(metrics[metricId]));
 
   const isBayesianParamDisabled = (entity) => {
     if (params.overrideProper) return false;

--- a/packages/front-end/pages/settings/webhooks/event/[eventwebhookid].tsx
+++ b/packages/front-end/pages/settings/webhooks/event/[eventwebhookid].tsx
@@ -1,17 +1,53 @@
 import React from "react";
 import { NextPage } from "next";
+import { useRouter } from "next/router";
+import { EventWebHookInterface } from "back-end/types/event-webhook";
 import { EventWebHookDetailContainer } from "@/components/EventWebHooks/EventWebHookDetail/EventWebHookDetail";
 import { EventWebHookLogsContainer } from "@/components/EventWebHooks/EventWebHookLogs/EventWebHookLogs";
+import useApi from "@/hooks/useApi";
+import PageHead from "@/components/Layout/PageHead";
 
 const EventWebHookDetailPage: NextPage = () => {
-  return (
-    <div className="container pagecontents">
-      <EventWebHookDetailContainer />
+  const router = useRouter();
+  const { eventwebhookid: eventWebHookId } = router.query;
 
-      <div className="mt-4">
-        <EventWebHookLogsContainer />
+  const { data, mutate: mutateEventWebHook, error } = useApi<{
+    eventWebHook: EventWebHookInterface;
+  }>(`/event-webhooks/${eventWebHookId}`);
+
+  if (error)
+    return (
+      <div className="alert alert-danger">
+        Unable to fetch event web hook {eventWebHookId}
       </div>
-    </div>
+    );
+
+  if (!data) return null;
+
+  const { eventWebHook } = data;
+
+  return (
+    <>
+      <PageHead
+        breadcrumb={[
+          {
+            display: "Webhooks",
+            href: `/webhooks`,
+          },
+          { display: eventWebHook.name },
+        ]}
+      />
+      <div className="container pagecontents">
+        <EventWebHookDetailContainer
+          eventWebHook={eventWebHook}
+          mutateEventWebHook={mutateEventWebHook}
+        />
+
+        <div className="mt-4">
+          <EventWebHookLogsContainer />
+        </div>
+      </div>
+    </>
   );
 };
 

--- a/packages/front-end/pages/settings/webhooks/event/[eventwebhookid].tsx
+++ b/packages/front-end/pages/settings/webhooks/event/[eventwebhookid].tsx
@@ -32,7 +32,7 @@ const EventWebHookDetailPage: NextPage = () => {
         breadcrumb={[
           {
             display: "Webhooks",
-            href: `/webhooks`,
+            href: `/settings/webhooks`,
           },
           { display: eventWebHook.name },
         ]}

--- a/packages/front-end/styles/global.scss
+++ b/packages/front-end/styles/global.scss
@@ -1810,6 +1810,14 @@ main.main.report {
   }
 }
 
+.badge-success-light {
+  background-color: var(--win-background);
+}
+
+.badge-danger-light {
+  background-color: var(--lose-background);
+}
+
 .tooltip-experimentDateGraph {
   td.won {
     background-color: var(--win-background);
@@ -3260,4 +3268,9 @@ input:disabled {
 }
 .enterprise-text-color {
   color: var(--text-color-enterprise);
+}
+
+.table-column-fit-width {
+  width: 1px;
+  white-space: nowrap;
 }


### PR DESCRIPTION
This PR implements the new design for webhook details page as outlined at https://www.figma.com/design/lJ5VnBNTwIP4VGgeBEU2bM/Experiment-Notifications?node-id=53-5770&t=QP2Ft7FHwG1VWqXb-0

### Backend changes

The webhook log model did not record the event names, url and method. This is now added. Unfortunately, legacy entries will have to return `undefined` and display `unknown` for event type.

### Screenshots

<img width="1258" alt="Screenshot 2024-07-15 at 11 03 10 AM" src="https://github.com/user-attachments/assets/5e6703cf-1027-4321-9f04-44b2c6f46784">

Failed badge:
<img width="252" alt="Screenshot 2024-07-15 at 11 41 20 AM" src="https://github.com/user-attachments/assets/c895b515-f101-4a70-989f-56318ce55a36">

### Design changes

API key was added:

<img width="459" alt="Screenshot 2024-07-15 at 11 43 54 AM" src="https://github.com/user-attachments/assets/fca58fbd-bcaa-4b98-b7cf-8e8eba4ad5e5">

Request/response was reorganized to follow the timeline order. URL/methods were added as well as the log's timestamp to clarify which log is being displayed:
<img width="642" alt="Screenshot 2024-07-15 at 11 29 16 AM" src="https://github.com/user-attachments/assets/171bd39c-1de0-40ba-87d7-827ed7952b62">


