### PR TITLE
Automatically disable the webhook proxy

### DIFF
--- a/packages/back-end/src/util/http.util.ts
+++ b/packages/back-end/src/util/http.util.ts
@@ -108,7 +108,6 @@ export const cancellableFetch = async (
     if (
       useWebhookProxy &&
       WEBHOOK_PROXY &&
-      process.env.GROWTHBOOK_API_KEY &&
       e.name === "FetchError" &&
       e.code === "ECONNREFUSED"
     ) {

--- a/packages/back-end/src/util/http.util.ts
+++ b/packages/back-end/src/util/http.util.ts
@@ -3,6 +3,8 @@ import { ProxyAgent } from "proxy-agent";
 import { logger } from "./logger";
 import { USE_PROXY, WEBHOOK_PROXY } from "./secrets";
 
+let useWebhookProxy = true;
+
 export type CancellableFetchCriteria = {
   maxContentSize: number;
   maxTimeMs: number;
@@ -29,12 +31,15 @@ export function getHttpOptions(url?: string) {
     }
   }
 
-  if (WEBHOOK_PROXY) {
+  if (useWebhookProxy && WEBHOOK_PROXY) {
+    logger.debug("using webhook proxy");
     return {
       agent: new ProxyAgent({
         getProxyForUrl: () => WEBHOOK_PROXY,
       }),
     };
+  } else if (WEBHOOK_PROXY) {
+    logger.debug("not using webhook proxy");
   }
 
   if (USE_PROXY) {
@@ -95,6 +100,20 @@ export const cancellableFetch = async (
         responseWithoutBody: response,
         stringBody,
       };
+    }
+
+    // If we are using the webhook proxy then any ECONNREFUSED error would come from the proxy itself.
+    // If the endpoint would have been down but the proxy was up, we would have gotten a 502 from the proxy instead.
+    // Hence if we see one we can be sure the webhook proxy is having issues and it is best to disable it.
+    if (
+      useWebhookProxy &&
+      WEBHOOK_PROXY &&
+      process.env.GROWTHBOOK_API_KEY &&
+      e.name === "FetchError" &&
+      e.code === "ECONNREFUSED"
+    ) {
+      logger.error("Disabling webhook proxy");
+      useWebhookProxy = false;
     }
 
     throw e;


### PR DESCRIPTION
### Features and Changes
This implements a quick and dirty way to turn off the webhook proxy if it goes down.  When it goes down a `ECONNREFUSED` error is thrown.  This can be distinguished from the endpoint itself throwing that error because when using the proxy, the proxy returns a 502 if the endpoint can't be reached.  

### Testing

Start Smokescreen proxy allowing some local ports
`
git clone git@github.com:growthbook/smokescreen.git
cd smokescreen
go run . --config-file config.yaml --allow-address 127.0.0.1:8080 --allow-address "[::1]:8080" --allow-address 127.0.0.1:8085 --allow-address "[::1]:8085" --allow-address 127.0.0.1:3300 --allow-address "[::1]:3300"
`


Start a simple web server on 8080:
Make a server.js file
```
const http = require("http");
const fs = require("fs");
const port = 8080;

const requestHandler = (request, response) => {
  let body = "";
  request.on("data", (chunk) => {
    body += chunk.toString(); // Convert Buffer to string
  });
  request.on("end", () => {
    const xForwardedFor = request.headers["x-forwarded-for"] || "Not provided";
    console.log(request.url);
    console.log("body", body);
    console.log("X-Forwarded-For:", xForwardedFor);
    // Log the request body along with the request line
    fs.appendFileSync(
      "request.log",
      `${new Date().toISOString()} - ${request.method} ${
        request.url
      } - Body: ${body} - X-Forwarded-For: ${xForwardedFor}\n`
    );
    response.end(`Received - X-Forwarded-For: ${xForwardedFor}`);
  });
};

const server = http.createServer(requestHandler);

server.listen(port, () => {
  console.log(`Server is listening on http://localhost:${port}`);
});
```
Run: `node server.js`

Set the following in .env.local
```
WEBHOOK_PROXY=http://localhost:4750
```
Run `LOG_LEVEL=debug yarn dev`

Create a webhook that points to http://localhost:8080
Test it and see it succeed.
See the "Using Webhook Proxy" debug line.
Kill the Webhook Proxy Server.
Test it and see it fail.
See the "Disabling Webhook Proxy" debug line.
Test it again immediately and see that it succeeds.
See the "not using webhook proxy" debug line.
See on the /features page that use-webhook-proxy has been turned off via the API.
