### PR TITLE
New webhook modal design.

### DIFF
--- a/packages/back-end/src/events/handlers/webhooks/EventWebHookNotifier.ts
+++ b/packages/back-end/src/events/handlers/webhooks/EventWebHookNotifier.ts
@@ -131,10 +131,6 @@ export class EventWebHookNotifier implements Notifier {
           return { content: data.text };
         }
 
-        case "ms-teams":
-          // TODO: not implemented
-          return eventPayload;
-
         default:
           invalidPayloadType = payloadType;
           throw `Invalid payload type: ${invalidPayloadType}`;

--- a/packages/back-end/src/types/EventWebHook.ts
+++ b/packages/back-end/src/types/EventWebHook.ts
@@ -2,7 +2,6 @@ export const eventWebHookPayloadTypes = [
   "raw",
   "slack",
   "discord",
-  "ms-teams",
 ] as const;
 
 export type EventWebHookPayloadType = typeof eventWebHookPayloadTypes[number];

--- a/packages/back-end/types/event-webhook.d.ts
+++ b/packages/back-end/types/event-webhook.d.ts
@@ -1,7 +1,13 @@
+import {
+  EventWebHookPayloadType,
+  EventWebHookMethod,
+} from "../src/types/EventWebHook";
 import { NotificationEventName } from "./event";
 
-export type EventWebHookPayloadType = "raw" | "slack" | "discord" | "ms-teams";
-export type EventWebHookMethod = "PUT" | "POST" | "PATCH";
+export {
+  EventWebHookPayloadType,
+  EventWebHookMethod,
+} from "../src/types/EventWebHook";
 
 export interface EventWebHookInterface {
   id: string;

--- a/packages/front-end/components/EventWebHooks/EventWebHookAddEditModal/EventWebHookAddEditModal.tsx
+++ b/packages/front-end/components/EventWebHooks/EventWebHookAddEditModal/EventWebHookAddEditModal.tsx
@@ -7,7 +7,6 @@ import MultiSelectField from "@/components/Forms/MultiSelectField";
 import Field from "@/components/Forms/Field";
 import SelectField from "@/components/Forms/SelectField";
 import CodeTextArea from "@/components/Forms/CodeTextArea";
-import Toggle from "@/components/Forms/Toggle";
 import {
   eventWebHookMethods,
   EventWebHookMethod,
@@ -16,10 +15,12 @@ import {
   eventWebHookEventOptions,
   EventWebHookModalMode,
   notificationEventNames,
+  webhookIcon,
 } from "@/components/EventWebHooks/utils";
 import { useEnvironments } from "@/services/features";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import TagsInput from "@/components/Tags/TagsInput";
+import clsx from "clsx";
 
 type EventWebHookAddEditModalProps = {
   isOpen: boolean;
@@ -45,7 +46,6 @@ const eventWebHookPayloadValues: { [k in EventWebHookPayloadType]: string } = {
   raw: "Raw",
   slack: "Slack",
   discord: "Discord",
-  "ms-teams": "Microsoft Teams",
 } as const;
 
 export const EventWebHookAddEditModal: FC<EventWebHookAddEditModalProps> = ({
@@ -95,7 +95,7 @@ export const EventWebHookAddEditModal: FC<EventWebHookAddEditModalProps> = ({
 
   const filteredValues = useCallback(
     (values) => ({ ...values, ...forcedParams }),
-    [forcedParams]
+    [forcedParams],
   );
 
   const handleSubmit = form.handleSubmit(async (rawValues) => {
@@ -127,6 +127,11 @@ export const EventWebHookAddEditModal: FC<EventWebHookAddEditModalProps> = ({
     setCtaEnabled(schema.safeParse(formValues).success);
   }, [filteredValues, form]);
 
+  const selectedPayloadType = form.watch("payloadType");
+  const selectedEnvironments = form.watch("environments");
+  const selectedProjects = form.watch("projects");
+  const selectedTags = form.watch("tags");
+
   if (!isOpen) return null;
 
   return (
@@ -138,91 +143,25 @@ export const EventWebHookAddEditModal: FC<EventWebHookAddEditModalProps> = ({
       submit={handleSubmit}
       error={error ?? undefined}
       ctaEnabled={ctaEnabled}
+      bodyClassName="mt-2"
       size="lg"
     >
-      <Field
-        label="Webhook Name"
-        placeholder="My Webhook"
-        {...form.register("name")}
-        onChange={(evt) => {
-          form.setValue("name", evt.target.value);
-          handleFormValidation();
-        }}
-      />
-
-      <Field
-        label="Endpoint URL"
-        placeholder="https://example.com/growthbook-webhook"
-        {...form.register("url")}
-        helpText={
-          <>
-            Must accept <code>{form.watch("method")}</code> requests
-          </>
-        }
-        onChange={(evt) => {
-          form.setValue("url", evt.target.value);
-          handleFormValidation();
-        }}
-      />
-
       <SelectField
-        label="Method"
-        value={forcedParams?.method || form.watch("method")}
-        placeholder="Choose HTTP method"
-        disabled={!!forcedParams}
-        options={eventWebHookMethods.map((method) => ({
-          label: method,
-          value: method,
-        }))}
-        onChange={(value: EventWebHookMethod) => {
-          form.setValue("method", value);
-          handleFormValidation();
-        }}
-      />
-
-      <CodeTextArea
-        label="Headers"
-        language="json"
-        minLines={forcedParams ? 1 : 3}
-        maxLines={6}
-        value={forcedParams?.headers || form.watch("headers")}
-        disabled={!!forcedParams}
-        setValue={(headers) => {
-          form.setValue("headers", headers);
-          handleFormValidation();
-        }}
-        helpText={
-          <>
-            {!validHeaders ? (
-              <div className="alert alert-danger mr-auto">Invalid JSON</div>
-            ) : (
-              <div>JSON format for headers.</div>
-            )}
-          </>
-        }
-      />
-
-      <MultiSelectField
-        label="Events"
-        value={form.watch("events")}
-        placeholder="Choose events"
-        sort={false}
-        options={eventWebHookEventOptions.map(({ id }) => ({
-          label: id,
-          value: id,
-        }))}
-        onChange={(value: string[]) => {
-          form.setValue("events", value as NotificationEventName[]);
-          handleFormValidation();
-        }}
-      />
-
-      <SelectField
-        label="Payload Type"
+        label={<b>Payload Type</b>}
         value={form.watch("payloadType")}
         placeholder="Choose payload type"
+        formatOptionLabel={({ label }) => (
+          <span>
+            <img
+              src={webhookIcon[label]}
+              className="mr-3"
+              style={{ height: "2rem", width: "2rem" }}
+            />
+            {eventWebHookPayloadValues[label]}
+          </span>
+        )}
         options={eventWebHookPayloadTypes.map((key) => ({
-          label: eventWebHookPayloadValues[key],
+          label: key,
           value: key,
         }))}
         onChange={(value: EventWebHookPayloadType) => {
@@ -231,69 +170,232 @@ export const EventWebHookAddEditModal: FC<EventWebHookAddEditModalProps> = ({
         }}
       />
 
-      <MultiSelectField
-        label="Environment filters"
-        helpText="Only receive notifications for matching environments. Leave blank to receive all."
-        sort={false}
-        value={form.watch("environments")}
-        options={environments.map((env) => ({
-          label: env,
-          value: env,
-        }))}
-        onChange={(value: string[]) => {
-          form.setValue("environments", value);
-          handleFormValidation();
-        }}
-      />
-
-      <MultiSelectField
-        label="Project filters"
-        helpText="Only receive notifications for matching projects. Leave blank to receive all."
-        sort={false}
-        value={form.watch("projects")}
-        options={projects.map(({ name, id }) => ({
-          label: name,
-          value: id,
-        }))}
-        onChange={(value: string[]) => {
-          form.setValue("projects", value);
-          handleFormValidation();
-        }}
-      />
-
-      <div className="form-group">
-        <label className="d-block">Tag filters</label>
-        <div className="mt-1">
-          <TagsInput
-            tagOptions={tags}
-            value={form.watch("tags")}
-            onChange={(selected: string[]) => {
-              form.setValue(
-                "tags",
-                selected.map((item) => item)
-              );
-              handleFormValidation();
-            }}
-          />
-          <small className="text-muted">
-            Only receive notifications for matching tags. Leave blank to receive
-            all.
-          </small>
-        </div>
-      </div>
-
-      <div className="form-group">
-        <Toggle
-          id="EventWebHookAddModal-enabled"
-          value={form.watch("enabled")}
-          setValue={(value) => {
-            form.setValue("enabled", value);
+      <div className="mt-4">
+        <Field
+          label={<b>Webhook Name</b>}
+          placeholder="My Webhook"
+          {...form.register("name")}
+          onChange={(evt) => {
+            form.setValue("name", evt.target.value);
             handleFormValidation();
           }}
         />
-        <label htmlFor="EventWebHookAddModal-enabled">
-          Enable the webhook?
-        </label>
+      </div>
+
+      {selectedPayloadType === "raw" && (
+        <div className="mt-4">
+          <SelectField
+            label={<b>Method</b>}
+            value={forcedParams?.method || form.watch("method")}
+            placeholder="Choose HTTP method"
+            disabled={!!forcedParams}
+            options={eventWebHookMethods.map((method) => ({
+              label: method,
+              value: method,
+            }))}
+            onChange={(value: EventWebHookMethod) => {
+              form.setValue("method", value);
+              handleFormValidation();
+            }}
+          />
+        </div>
+      )}
+
+      <div className="mt-4">
+        <Field
+          label={<b>Endpoint URL</b>}
+          placeholder="https://example.com/growthbook-webhook"
+          {...form.register("url")}
+          helpText={
+            selectedPayloadType === "raw" && (
+              <>
+                Must accept <code>{form.watch("method")}</code> requests
+              </>
+            )
+          }
+          onChange={(evt) => {
+            form.setValue("url", evt.target.value);
+            handleFormValidation();
+          }}
+        />
+      </div>
+
+      {selectedPayloadType === "raw" && (
+        <div className="mt-4">
+          <CodeTextArea
+            label={
+              <>
+                <b>Headers</b> (JSON)
+              </>
+            }
+            language="json"
+            minLines={forcedParams ? 1 : 3}
+            maxLines={6}
+            value={forcedParams?.headers || form.watch("headers")}
+            disabled={!!forcedParams}
+            setValue={(headers) => {
+              form.setValue("headers", headers);
+              handleFormValidation();
+            }}
+            helpText={
+              <>
+                {!validHeaders ? (
+                  <div className="alert alert-danger mr-auto">Invalid JSON</div>
+                ) : (
+                  <div>JSON format for headers.</div>
+                )}
+              </>
+            }
+          />
+        </div>
+      )}
+
+      <div className="mt-4">
+        <MultiSelectField
+          label={<b>Events</b>}
+          value={form.watch("events")}
+          placeholder="Choose events"
+          sort={false}
+          options={eventWebHookEventOptions.map(({ id }) => ({
+            label: id,
+            value: id,
+          }))}
+          onChange={(value: string[]) => {
+            form.setValue("events", value as NotificationEventName[]);
+            handleFormValidation();
+          }}
+        />
+      </div>
+
+      <div className="mt-4 webhook-filters">
+        <b>Apply Filters</b>
+
+        <div className="graybox mt-2 border border-rounded">
+          <div
+            className={clsx({
+              "select-all": !selectedEnvironments.length,
+            })}
+          >
+            <MultiSelectField
+              label={
+                <div className="d-flex align-items-center">
+                  <div>
+                    <b>Environment</b>
+                  </div>
+                  <div className="ml-auto d-flex align-items-center">
+                    <input
+                      type="checkbox"
+                      className="mr-1"
+                      disabled={!selectedEnvironments.length}
+                      checked={!selectedEnvironments.length}
+                      onChange={() =>
+                        selectedEnvironments.length
+                          ? form.setValue("environments", [])
+                          : undefined
+                      }
+                    />
+                    Receive notifications for{" "}
+                    <b className="ml-1">all Environments</b>
+                  </div>
+                </div>
+              }
+              labelClassName="w-100"
+              sort={false}
+              value={form.watch("environments")}
+              options={environments.map((env) => ({
+                label: env,
+                value: env,
+              }))}
+              onChange={(value: string[]) => {
+                form.setValue("environments", value);
+                handleFormValidation();
+              }}
+            />
+          </div>
+
+          <div
+            className={clsx({
+              "select-all": !selectedProjects.length,
+            })}
+          >
+            <MultiSelectField
+              label={
+                <div className="d-flex align-items-center">
+                  <div>
+                    <b>Projects</b>
+                  </div>
+                  <div className="ml-auto d-flex align-items-center">
+                    <input
+                      type="checkbox"
+                      className="mr-1"
+                      disabled={!selectedProjects.length}
+                      checked={!selectedProjects.length}
+                      onChange={() =>
+                        selectedProjects.length
+                          ? form.setValue("projects", [])
+                          : undefined
+                      }
+                    />
+                    Receive notifications for{" "}
+                    <b className="ml-1">all Projects</b>
+                  </div>
+                </div>
+              }
+              labelClassName="w-100"
+              sort={false}
+              value={form.watch("projects")}
+              options={projects.map(({ name, id }) => ({
+                label: name,
+                value: id,
+              }))}
+              onChange={(value: string[]) => {
+                form.setValue("projects", value);
+                handleFormValidation();
+              }}
+            />
+          </div>
+
+          <div
+            className={clsx("form-group", {
+              "select-all": !selectedTags.length,
+            })}
+          >
+            <label className="d-block w-100">
+              <div className="d-flex align-items-center">
+                <div>
+                  <b>Tags</b>
+                </div>
+                <div className="ml-auto d-flex align-items-center">
+                  <input
+                    type="checkbox"
+                    className="mr-1"
+                    disabled={!selectedTags.length}
+                    checked={!selectedTags.length}
+                    onChange={() =>
+                      selectedTags.length
+                        ? form.setValue("tags", [])
+                        : undefined
+                    }
+                  />
+                  Receive notifications for <b className="ml-1">all Tags</b>
+                </div>
+              </div>
+            </label>
+            <div className="mt-1">
+              <TagsInput
+                tagOptions={tags}
+                value={form.watch("tags")}
+                onChange={(selected: string[]) => {
+                  form.setValue(
+                    "tags",
+                    selected.map((item) => item),
+                  );
+                  handleFormValidation();
+                }}
+              />
+            </div>
+          </div>
+        </div>
       </div>
     </Modal>
   );

--- a/packages/front-end/components/EventWebHooks/utils.tsx
+++ b/packages/front-end/components/EventWebHooks/utils.tsx
@@ -19,7 +19,6 @@ export const eventWebHookPayloadTypes = [
   "raw",
   "slack",
   "discord",
-  "ms-teams",
 ] as const;
 
 export const eventWebHookMethods = ["POST", "PUT", "PATCH"] as const;

--- a/packages/front-end/styles/global.scss
+++ b/packages/front-end/styles/global.scss
@@ -820,6 +820,10 @@ main.main.report {
   background-color: var(--table-row-highlight-background-color);
 }
 
+.webhook-filters .select-all .gb-multi-select__control {
+  background-color: var(--table-row-highlight-background-color) !important;
+}
+
 .experiment-switch-page {
   opacity: 0.6;
   transition: opacity 0.2s;


### PR DESCRIPTION
This PR implements the new UI/UX for webhook create/edit modal as outlined at: https://www.figma.com/design/lJ5VnBNTwIP4VGgeBEU2bM/Experiment-Notifications?node-id=60-9869&t=AxMWenhwBLswO95Y-0

The only part that is left is the new modal to test the webhood before saving.

## Screenshots

### Raw webhook 
<img width="793" alt="Screenshot 2024-07-17 at 10 24 32 AM" src="https://github.com/user-attachments/assets/d893619e-b8c9-419d-8c7d-5981fe27c9d6">

### Payload type selection

<img width="826" alt="Screenshot 2024-07-17 at 10 24 36 AM" src="https://github.com/user-attachments/assets/cf588416-151b-493d-bba2-11c483d4e740">

### Discord webhook

<img width="799" alt="Screenshot 2024-07-17 at 10 24 42 AM" src="https://github.com/user-attachments/assets/aaf9e290-6fa4-4d0b-ac11-d665597edf03">

### Select all behavior

The checkbox is disabled when no selection has been made:

<img width="800" alt="Screenshot 2024-07-17 at 10 24 57 AM" src="https://github.com/user-attachments/assets/8178a216-e25e-4f7d-8486-c9802d8196a0">

It becomes enabled again when a selection is made:

<img width="827" alt="Screenshot 2024-07-17 at 10 28 00 AM" src="https://github.com/user-attachments/assets/9656014e-28b8-4eaa-be7a-bbedee789a92">

Upon checking the box, all selections are discarded and we are back at the first screenshot.


