### PR TITLE
[bugfix] Reset numerator column for proportion fact metric

### DIFF
--- a/packages/front-end/components/FactTables/FactMetricModal.tsx
+++ b/packages/front-end/components/FactTables/FactMetricModal.tsx
@@ -510,12 +510,9 @@ export default function FactMetricModal({
         // reset numerator for proportion metrics
         if (
           values.metricType === "proportion" &&
-          !["$$count", "$$distinctUser"].includes(values.numerator.column)
+          values.numerator.column !== "$$distinctUsers"
         ) {
-          values.numerator = {
-            ...values.numerator,
-            column: "$$count",
-          };
+          values.numerator.column = "$$distinctUsers";
         }
 
         if (!selectedDataSource) throw new Error("Must select a data source");

--- a/packages/front-end/components/FactTables/FactMetricModal.tsx
+++ b/packages/front-end/components/FactTables/FactMetricModal.tsx
@@ -507,6 +507,17 @@ export default function FactMetricModal({
           values.denominator = null;
         }
 
+        // reset numerator for proportion metrics
+        if (
+          values.metricType === "proportion" &&
+          !["$$count", "$$distinctUser"].includes(values.numerator.column)
+        ) {
+          values.numerator = {
+            ...values.numerator,
+            column: "$$count",
+          };
+        }
+
         if (!selectedDataSource) throw new Error("Must select a data source");
 
         // Correct percent values

--- a/packages/front-end/services/metrics.tsx
+++ b/packages/front-end/services/metrics.tsx
@@ -140,7 +140,6 @@ export function getColumnRefFormatter(
   columnRef: ColumnRef,
   getFactTableById: (id: string) => FactTableInterface | null
 ): (value: number, options?: Intl.NumberFormatOptions) => string {
-  console.log(columnRef);
   if (
     columnRef.column === "$$count" ||
     columnRef.column === "$$distinctUsers"

--- a/packages/front-end/services/metrics.tsx
+++ b/packages/front-end/services/metrics.tsx
@@ -140,6 +140,7 @@ export function getColumnRefFormatter(
   columnRef: ColumnRef,
   getFactTableById: (id: string) => FactTableInterface | null
 ): (value: number, options?: Intl.NumberFormatOptions) => string {
+  console.log(columnRef);
   if (
     columnRef.column === "$$count" ||
     columnRef.column === "$$distinctUsers"


### PR DESCRIPTION
As you can see, when creating a proportion you cannot pick a column:
<img width="795" alt="Screenshot 2024-07-17 at 1 45 28 PM" src="https://github.com/user-attachments/assets/b8539009-7631-4354-9c7f-4d95c1db1cb1">

However, if you picked a column when setting up a mean metric and switched to proportion, we persisted the `value` field in the numerator columnref and never removed it. It didn't impact the SQL, but it could mess up the formatting and result in $ signs in the MetricValueColumn for proportion metrics (nonsensical):
<img width="574" alt="Screenshot 2024-07-17 at 1 40 55 PM" src="https://github.com/user-attachments/assets/bf67a164-14a6-4516-8d53-10bc5311b0ad">

This fixes that to match something we do with fact metric post requests (https://github.com/growthbook/growthbook/blob/main/packages/back-end/src/api/fact-metrics/postFactMetric.ts#L50-L57) by having some validation done to reset the `value` column for proportion metrics in the fact metric modal on submit.

Fixed screenshot
<img width="429" alt="Screenshot 2024-07-17 at 1 49 53 PM" src="https://github.com/user-attachments/assets/4b2cfbbe-febf-4f7d-8146-b77de4a75be6">


If a user has this problem, they just have to go "edit" the metric, do nothing, and click save and it will reset.