### PR TITLE
Webhook test before create

### DIFF
--- a/packages/back-end/src/routers/event-webhooks/event-webhooks.controller.ts
+++ b/packages/back-end/src/routers/event-webhooks/event-webhooks.controller.ts
@@ -307,7 +307,7 @@ export const toggleEventWebHook = async (
 
 // region POST /event-webhooks/test-params
 
-const testParamsPayload = (name) => ({
+const testParamsPayload = (name: string) => ({
   text: `Hi there! This is a test event from GrowthBook to see if the params for webhook ${name} are correct.`,
   blocks: [
     {
@@ -342,10 +342,13 @@ export const testWebHookParams = async (
     if (response.ok) return res.json({ success: true });
 
     return res.status(403).json({
-      error: `Request failed: ${response.status} - ${response.statusText}`,
+      status: 403,
+      message: `Request failed: ${response.status} - ${response.statusText}`,
     });
   } catch (e) {
-    return res.status(403).json({ error: `Request failed: ${e}` });
+    return res
+      .status(403)
+      .json({ status: 403, message: `Request failed: ${e}` });
   }
 };
 

--- a/packages/back-end/src/routers/event-webhooks/event-webhooks.router.ts
+++ b/packages/back-end/src/routers/event-webhooks/event-webhooks.router.ts
@@ -123,6 +123,20 @@ router.put(
 );
 
 router.post(
+  "/event-webhooks/test-params",
+  validateRequestMiddleware({
+    body: z
+      .object({
+        name: z.string().trim().min(1),
+        method: z.enum(eventWebHookMethods),
+        url: z.string().trim().min(1),
+      })
+      .strict(),
+  }),
+  eventWebHooksController.testWebHookParams
+);
+
+router.post(
   "/event-webhooks/test",
   validateRequestMiddleware({
     body: z

--- a/packages/front-end/components/EventWebHooks/EventWebHookAddEditModal/EventWebHookAddEditModal.tsx
+++ b/packages/front-end/components/EventWebHooks/EventWebHookAddEditModal/EventWebHookAddEditModal.tsx
@@ -421,11 +421,31 @@ const EventWebHookAddEditSettings = ({
 
 type Step = "create" | "confirm" | "edit";
 
-const buttonText = {
-  create: "Next >",
-  confirm: "Create",
-  edit: "Save",
-} as const;
+const buttonText = ({
+  step,
+  payloadType,
+}: {
+  step: Step;
+  payloadType: EventWebHookPayloadType;
+}) => {
+  let invalidStep: never;
+
+  switch (step) {
+    case "create":
+      if (payloadType === "raw") return "Create";
+      return "Next >";
+
+    case "confirm":
+      return "Create";
+
+    case "edit":
+      return "Save";
+
+    default:
+      invalidStep = step;
+      throw new Error(`Invalid step: ${invalidStep}`);
+  }
+};
 
 export const EventWebHookAddEditModal: FC<EventWebHookAddEditModalProps> = ({
   isOpen,
@@ -514,7 +534,7 @@ export const EventWebHookAddEditModal: FC<EventWebHookAddEditModalProps> = ({
   return (
     <Modal
       header={modalTitle}
-      cta={buttonText[step]}
+      cta={buttonText({ step, payloadType: form.watch("payloadType") })}
       includeCloseCta={false}
       open={isOpen}
       error={error ?? undefined}
@@ -537,7 +557,7 @@ export const EventWebHookAddEditModal: FC<EventWebHookAddEditModalProps> = ({
           onClick={handleSubmit}
           className="btn btn-primary"
         >
-          {buttonText[step]}
+          {buttonText({ step, payloadType: form.watch("payloadType") })}
         </button>
       }
     >

--- a/packages/front-end/components/EventWebHooks/EventWebHookDetail/EventWebHookDetail.tsx
+++ b/packages/front-end/components/EventWebHooks/EventWebHookDetail/EventWebHookDetail.tsx
@@ -393,6 +393,7 @@ export const EventWebHookDetailContainer = ({
           handleUpdateError(response.error || "Unknown error");
         } else {
           mutateEventWebHook();
+          setIsEditModalOpen(false);
           setEditError(null);
         }
       } catch (e) {

--- a/packages/front-end/components/EventWebHooks/EventWebHookList/EventWebHookList.tsx
+++ b/packages/front-end/components/EventWebHooks/EventWebHookList/EventWebHookList.tsx
@@ -154,6 +154,7 @@ export const EventWebHookListContainer = () => {
           handleCreateError(response.error || "Unknown error");
         } else {
           setCreateError(null);
+          setIsModalOpen(false);
           mutate();
         }
       } catch (e) {


### PR DESCRIPTION
This PR implements the last bit of webhook settings revamp, i.e. ability to test the parameters before saving.

Figma files: https://www.figma.com/design/lJ5VnBNTwIP4VGgeBEU2bM/Experiment-Notifications?node-id=64-12888&t=UOuIRhMo7zbSjIQW-0

### Changes and technical notes

Have done some slight changes in the workflow to follow more closely the async flow.

Also, disabled testing webhook params when payload type is `raw`. For those webhooks, the secret should be used and it's not yet available. I would imagine that users setting up raw webhooks are typically more advanced and need less guidance during the setup.

Lastly, I tried to implement the HTTP query directly in the browder but it is running afoul of the CORS limitation so we have to pass it down to the BE...

### Demo

Loom: https://www.loom.com/share/d56d3e85720d47219ce927aa2d27b097