### PR TITLE
Save/display owner in fact tables.

### DIFF
--- a/packages/back-end/src/models/FactTableModel.ts
+++ b/packages/back-end/src/models/FactTableModel.ts
@@ -74,8 +74,9 @@ function toInterface(doc: FactTableDocument): FactTableInterface {
 
 function createPropsToInterface(
   context: ReqContext | ApiReqContext,
-  props: CreateFactTableProps
+  rawProps: CreateFactTableProps
 ): FactTableInterface {
+  const props = { ...rawProps, owner: rawProps.owner || context.userName };
   const id = props.id || uniqid("ftb_");
   if (!id.match(/^[-a-zA-Z0-9_]+$/)) {
     throw new Error(

--- a/packages/front-end/pages/fact-tables/[ftid].tsx
+++ b/packages/front-end/pages/fact-tables/[ftid].tsx
@@ -2,6 +2,7 @@ import { useRouter } from "next/router";
 import Link from "next/link";
 import { useState } from "react";
 import { FaAngleDown, FaAngleRight } from "react-icons/fa";
+import EditOwnerModal from "@/components/Owner/EditOwnerModal";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import LoadingOverlay from "@/components/LoadingOverlay";
 import { GBEdit } from "@/components/Icons";
@@ -28,6 +29,7 @@ export default function FactTablePage() {
 
   const [editOpen, setEditOpen] = useState(false);
   const [showSQL, setShowSQL] = useState(false);
+  const [editOwnerModal, setEditOwnerModal] = useState(false);
 
   const [editProjectsOpen, setEditProjectsOpen] = useState(false);
   const [editTagsModal, setEditTagsModal] = useState(false);
@@ -67,6 +69,19 @@ export default function FactTablePage() {
     <div className="pagecontents container-fluid">
       {editOpen && (
         <FactTableModal close={() => setEditOpen(false)} existing={factTable} />
+      )}
+      {editOwnerModal && (
+        <EditOwnerModal
+          cancel={() => setEditOwnerModal(false)}
+          owner={factTable.owner}
+          save={async (owner) => {
+            await apiCall(`/fact-tables/${factTable.id}`, {
+              method: "PUT",
+              body: JSON.stringify({ owner }),
+            });
+          }}
+          mutate={mutateDefinitions}
+        />
       )}
       {editProjectsOpen && (
         <EditProjectsForm
@@ -176,6 +191,19 @@ export default function FactTablePage() {
             </a>
           )}
         </div>
+        {(factTable.owner || canEdit) && (
+          <div className="col-auto">
+            Owner: {factTable.owner}
+            {canEdit && (
+              <a
+                className="ml-1 cursor-pointer"
+                onClick={() => setEditOwnerModal(true)}
+              >
+                <GBEdit />
+              </a>
+            )}
+          </div>
+        )}
         <div className="col-auto">
           Data source:{" "}
           <Link
@@ -185,9 +213,6 @@ export default function FactTablePage() {
             {getDatasourceById(factTable.datasource)?.name || "Unknown"}
           </Link>
         </div>
-        {factTable.owner && (
-          <div className="col-auto">Owner: {factTable.owner}</div>
-        )}
       </div>
 
       <div className="appbox p-3 bg-white mb-3">

--- a/packages/front-end/pages/fact-tables/[ftid].tsx
+++ b/packages/front-end/pages/fact-tables/[ftid].tsx
@@ -185,6 +185,9 @@ export default function FactTablePage() {
             {getDatasourceById(factTable.datasource)?.name || "Unknown"}
           </Link>
         </div>
+        {factTable.owner && (
+          <div className="col-auto">Owner: {factTable.owner}</div>
+        )}
       </div>
 
       <div className="appbox p-3 bg-white mb-3">

--- a/packages/front-end/pages/fact-tables/index.tsx
+++ b/packages/front-end/pages/fact-tables/index.tsx
@@ -279,6 +279,7 @@ export default function FactTablesPage() {
                 <SortableTH field="userIdTypes">Identifier Types</SortableTH>
                 <SortableTH field="numMetrics">Metrics</SortableTH>
                 <SortableTH field="numFilters">Filters</SortableTH>
+                <SortableTH field="dateUpdated">Owner</SortableTH>
                 <SortableTH field="dateUpdated">Last Updated</SortableTH>
               </tr>
             </thead>
@@ -323,6 +324,7 @@ export default function FactTablesPage() {
                   </td>
                   <td>{f.numMetrics}</td>
                   <td>{f.numFilters}</td>
+                  <td>{f.owner}</td>
                   <td>{f.dateUpdated ? date(f.dateUpdated) : null}</td>
                 </tr>
               ))}

--- a/packages/front-end/pages/fact-tables/index.tsx
+++ b/packages/front-end/pages/fact-tables/index.tsx
@@ -279,7 +279,7 @@ export default function FactTablesPage() {
                 <SortableTH field="userIdTypes">Identifier Types</SortableTH>
                 <SortableTH field="numMetrics">Metrics</SortableTH>
                 <SortableTH field="numFilters">Filters</SortableTH>
-                <SortableTH field="dateUpdated">Owner</SortableTH>
+                <SortableTH field="owner">Owner</SortableTH>
                 <SortableTH field="dateUpdated">Last Updated</SortableTH>
               </tr>
             </thead>


### PR DESCRIPTION
This is one of low-hanging fruits for 3.1: https://www.notion.so/growthbook/GrowthBook-3-1-5daeabb771174970814be4956befa3ab?p=8ab043b9ba5d4e1583c0bda3a78a3343&pm=s

### Screenshots

<img width="1275" alt="Screenshot 2024-07-19 at 10 05 39 AM" src="https://github.com/user-attachments/assets/87b6a6ea-b49b-4971-940a-0414ff684d93">

<img width="645" alt="Screenshot 2024-07-19 at 2 04 33 PM" src="https://github.com/user-attachments/assets/4680fae9-97ca-4a07-bc28-aaf11b79445d">

<img width="682" alt="Screenshot 2024-07-19 at 2 04 39 PM" src="https://github.com/user-attachments/assets/1bc30eae-cb97-4268-b68c-46f32345af14">


