### PR TITLE
Fix styling for custom markdown premium badge

### DIFF
--- a/packages/front-end/pages/settings/index.tsx
+++ b/packages/front-end/pages/settings/index.tsx
@@ -360,9 +360,9 @@ const GeneralSettingsPage = (): React.ReactElement => {
           </div>
           <div className="my-3 bg-white p-3 border">
             <div className="row">
-              <div className="col-sm-3">
+              <div className="col-sm-3 h4">
                 <PremiumTooltip commercialFeature="custom-markdown">
-                  <h4>Custom Markdown</h4>
+                  Custom Markdown
                 </PremiumTooltip>
               </div>
               <div className="col-sm-9">


### PR DESCRIPTION
### Features and Changes

Heading for Custom Markdown settings section in general settings currently renders below the premium badge when it appears. This fixes the styling so the badge and the header are inline.

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
Before
<img width="261" alt="Screenshot 2024-07-19 at 11 22 44 AM" src="https://github.com/user-attachments/assets/e01dd851-7e19-40b9-a1b2-c6a538893eb8">

After
<img width="260" alt="Screenshot 2024-07-19 at 11 27 13 AM" src="https://github.com/user-attachments/assets/3b4b7105-e990-4f95-9209-66c332089c95">

