### PR TITLE
Handle adding users after plan being downgraded on self hosted

### DIFF
--- a/packages/front-end/components/Settings/Team/AddOrphanedUserModal.tsx
+++ b/packages/front-end/components/Settings/Team/AddOrphanedUserModal.tsx
@@ -14,7 +14,7 @@ const AddOrphanedUserModal: FC<{
   email: string;
   id: string;
 }> = ({ mutate, close, name, email, id }) => {
-  const { license, seatsInUse, organization } = useUser();
+  const { license, seatsInUse, organization, effectiveAccountPlan } = useUser();
 
   const [showUpgradeModal, setShowUpgradeModal] = useState(false);
 
@@ -36,7 +36,12 @@ const AddOrphanedUserModal: FC<{
   }
 
   // Hit a hard cap and needs to contact sales to increase the number of seats on their license
-  if (license && license.hardCap && license.seats < seatsInUse + 1) {
+  if (
+    ["pro", "pro_sso", "enterprise"].includes(effectiveAccountPlan || "") &&
+    license &&
+    license.hardCap &&
+    license.seats < seatsInUse + 1
+  ) {
     return (
       <Modal open={true} close={close} size="md" header={"Reached seat limit"}>
         <div className="my-3">

--- a/packages/front-end/components/Settings/Team/InviteModal.tsx
+++ b/packages/front-end/components/Settings/Team/InviteModal.tsx
@@ -22,7 +22,7 @@ const InviteModal: FC<{ mutate: () => void; close: () => void }> = ({
   mutate,
   close,
 }) => {
-  const { license, seatsInUse, organization } = useUser();
+  const { license, seatsInUse, organization, effectiveAccountPlan } = useUser();
 
   const form = useForm<{
     email: string[];
@@ -53,7 +53,10 @@ const InviteModal: FC<{ mutate: () => void; close: () => void }> = ({
   );
 
   const [showContactSupport, setShowContactSupport] = useState(
-    license && license.hardCap && license.seats <= seatsInUse
+    ["pro", "pro_sso", "enterprise"].includes(effectiveAccountPlan || "") &&
+      license &&
+      license.hardCap &&
+      license.seats <= seatsInUse
   );
 
   // Hit their free limit and needs to upgrade to invite more team members
@@ -96,6 +99,7 @@ const InviteModal: FC<{ mutate: () => void; close: () => void }> = ({
     }
 
     if (
+      ["pro", "pro_sso", "enterprise"].includes(effectiveAccountPlan || "") &&
       license &&
       license.hardCap &&
       license.seats < seatsInUse + value.email.length


### PR DESCRIPTION
### Features and Changes
When a user tried out pro or enterprise and then lets it expire, they are reverted to free.  Which should allow them to add as many users as they like, but we were not checking for that.  Now that is fixed.

### Testing

In env vars set `LICENSE_SERVER_URL=http://localhost:8080/api/v1/`
In central-license-server repo do `yarn dev`
Set the licenseKey to a licenseKey on the local dev license.newLicenses db/Create a new license.
In mongo change 
```
seats:1
hardCap:true
isTrial:true
dateExpires:<SOME DATE IN THE PAST>
```

Try adding a user.  See no errors.
Remove the user and then add the user back via Orphaned users.
