### PR TITLE
Fix conversion window logic for Mixpanel

### DIFF
--- a/packages/back-end/src/integrations/Mixpanel.ts
+++ b/packages/back-end/src/integrations/Mixpanel.ts
@@ -670,6 +670,7 @@ function is${name}(event) {
 
   private getConversionWindowCondition(
     metric: MetricInterface,
+    experimentEnd: Date,
     conversionWindowStart: string = ""
   ) {
     const windowHours = getConversionWindowHours(metric.windowSettings);
@@ -686,8 +687,10 @@ function is${name}(event) {
     }
     // if lookback window, add additional lookback start
     if (metric.windowSettings.type === "lookback") {
-      const lookbackStart = windowHours * 60 * 60 * 1000;
-      checks.push(`event.time - ${conversionWindowStart} >= ${lookbackStart}`);
+      const lookbackLength = windowHours * 60 * 60 * 1000;
+      checks.push(
+        `${experimentEnd.getTime()} - event.time <= ${lookbackLength}`
+      );
     }
     return checks.length ? checks.join(" && ") : "";
   }

--- a/packages/back-end/src/integrations/Mixpanel.ts
+++ b/packages/back-end/src/integrations/Mixpanel.ts
@@ -675,7 +675,7 @@ function is${name}(event) {
     const windowHours = getConversionWindowHours(metric.windowSettings);
     const checks: string[] = [];
     const start = (metric.windowSettings.delayHours || 0) * 60 * 60 * 1000;
-    // and conversion delay
+    // add conversion delay
     if (start) {
       checks.push(`event.time - ${conversionWindowStart} >= ${start}`);
     }

--- a/packages/back-end/src/integrations/Mixpanel.ts
+++ b/packages/back-end/src/integrations/Mixpanel.ts
@@ -286,6 +286,7 @@ export default class Mixpanel implements SourceIntegrationInterface {
               .map((metric, i) => {
                 const conversionWindowCondition = this.getConversionWindowCondition(
                   metric,
+                  snapshotSettings.endDate,
                   "state.start"
                 );
 


### PR DESCRIPTION
Our latest conversion window updates did not apply to Mixpanel. This fixes that.

Unable to test due to lack of mixpanel integration and JQL sunsetting.