### PR TITLE
Added state for SDK creating when lacking permissions

### DIFF
--- a/packages/front-end/components/Features/SDKConnections/SDKConnectionsList.tsx
+++ b/packages/front-end/components/Features/SDKConnections/SDKConnectionsList.tsx
@@ -292,7 +292,18 @@ export default function SDKConnectionsList() {
             </div>
           ) : null}
         </>
-      ) : null}
+      ) : (
+        <>
+          {connections.length === 0 ? (
+            <div className="appbox p-5 text-center">
+              <p>
+                You do not have permission to create SDK connections. Please
+                contact your account administrator
+              </p>
+            </div>
+          ) : null}
+        </>
+      )}
     </div>
   );
 }

--- a/packages/front-end/components/Features/SDKConnections/SDKConnectionsList.tsx
+++ b/packages/front-end/components/Features/SDKConnections/SDKConnectionsList.tsx
@@ -272,9 +272,9 @@ export default function SDKConnectionsList() {
         </table>
       )}
 
-      {canCreateSDKConnections ? (
+      {connections.length === 0 ? (
         <>
-          {connections.length === 0 ? (
+          {canCreateSDKConnections ? (
             <div className="appbox p-5 text-center">
               <p>
                 <strong>SDK Connections</strong> make it easy to integrate
@@ -290,20 +290,16 @@ export default function SDKConnectionsList() {
                 <GBAddCircle /> Create New SDK Connection
               </button>
             </div>
-          ) : null}
-        </>
-      ) : (
-        <>
-          {connections.length === 0 ? (
+          ) : (
             <div className="appbox p-5 text-center">
               <p>
                 You do not have permission to create SDK connections. Please
                 contact your account administrator
               </p>
             </div>
-          ) : null}
+          )}
         </>
-      )}
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
If an account has no SDK connections, and a member who cannot create SDKs visits, it will show as a blank page with no message. This fix adds a message to help address this edge state.

