### PR TITLE
[bug] Fix crash when using old GA data sources that are missing settings

### DIFF
--- a/packages/back-end/src/util/migrations.ts
+++ b/packages/back-end/src/util/migrations.ts
@@ -180,6 +180,8 @@ FROM
 export function upgradeDatasourceObject(
   datasource: DataSourceInterface
 ): DataSourceInterface {
+  datasource.settings = datasource.settings || {};
+
   const settings = datasource.settings;
 
   // Add default randomization units

--- a/packages/back-end/test/migrations.test.ts
+++ b/packages/back-end/test/migrations.test.ts
@@ -510,6 +510,35 @@ describe("Metric Migration", () => {
 });
 
 describe("Datasource Migration", () => {
+  it("adds settings when missing completely", () => {
+    const datasource: DataSourceInterface = {
+      dateCreated: new Date(),
+      dateUpdated: new Date(),
+      id: "",
+      description: "",
+      name: "",
+      organization: "",
+      params: encryptParams({
+        projectId: "",
+        secret: "",
+        username: "",
+      } as MixpanelConnectionParams),
+      type: "mixpanel",
+    } as DataSourceInterface;
+
+    expect(upgradeDatasourceObject({ ...datasource }).settings).toEqual({
+      userIdTypes: [
+        {
+          userIdType: "user_id",
+          description: "Logged-in user id",
+        },
+        {
+          userIdType: "anonymous_id",
+          description: "Anonymous visitor id",
+        },
+      ],
+    });
+  });
   it("updates old datasource objects - userIdTypes", () => {
     const baseDatasource: DataSourceInterface = {
       dateCreated: new Date(),


### PR DESCRIPTION
### Features and Changes

The app would crash when loading if the organization had a super old GA data source.  We are expecting all data sources to have a `settings` property defined, but some of these old ones in Mongo are missing that field.  This PR migrates those old data sources to have an empty object instead.