### PR TITLE
Fix fact metric project resetting

### DIFF
--- a/packages/front-end/components/FactTables/FactMetricModal.tsx
+++ b/packages/front-end/components/FactTables/FactMetricModal.tsx
@@ -351,7 +351,7 @@ export default function FactMetricModal({
         column: "$$count",
         filters: [],
       },
-      projects: [],
+      projects: existing?.projects || [],
       denominator: existing?.denominator || null,
       datasource:
         existing?.datasource ||


### PR DESCRIPTION
Projects were getting reset when saving edits to a Fact Metric.

This fixes that.

Before
https://www.loom.com/share/9674805d29d54c42b7f6861c3ce960f2

After
https://www.loom.com/share/7050e02cdcee4bcaab487547e514376f