### PR TITLE
Allow min sample size to be 0 in results table

### DIFF
--- a/packages/shared/src/experiments.ts
+++ b/packages/shared/src/experiments.ts
@@ -424,7 +424,7 @@ export function hasEnoughData(
   if (!baselineValue || !variationValue) return false;
 
   const minSampleSize =
-    metric.minSampleSize || metricDefaults.minimumSampleSize || 0;
+    metric.minSampleSize ?? metricDefaults.minimumSampleSize ?? 0;
 
   return Math.max(baselineValue, variationValue) >= minSampleSize;
 }


### PR DESCRIPTION
If metric min sample size was 0 and metric default min sample size was greater than 0, we weren't letting that 0 fall through.

Before
<img width="1398" alt="Screenshot 2024-07-24 at 10 35 52 AM" src="https://github.com/user-attachments/assets/7b8f4b8b-6bed-45ac-8a80-e8c5978beee7">

After
<img width="1358" alt="Screenshot 2024-07-24 at 10 36 09 AM" src="https://github.com/user-attachments/assets/f11e5212-feb5-411b-8778-7826cc1c500d">
