### PR TITLE
fix scrubbing/filtering for experiment by changeType

### DIFF
--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -7,6 +7,7 @@ import { orgHasPremiumFeature } from "enterprise";
 import {
   AutoExperiment,
   FeatureRule as FeatureDefinitionRule,
+  getAutoExperimentChangeType,
   GrowthBook,
 } from "@growthbook/growthbook";
 import {
@@ -522,10 +523,14 @@ async function getFeatureDefinitionsResponse({
 
   if (includeAutoExperiments) {
     if (!includeRedirectExperiments) {
-      experiments = experiments.filter((e) => e.changeType !== "redirect");
+      experiments = experiments.filter(
+        (e) => getAutoExperimentChangeType(e) !== "redirect"
+      );
     }
     if (!includeVisualExperiments) {
-      experiments = experiments.filter((e) => e.changeType === "redirect");
+      experiments = experiments.filter(
+        (e) => getAutoExperimentChangeType(e) !== "visual"
+      );
     }
   }
 

--- a/packages/back-end/types/api.d.ts
+++ b/packages/back-end/types/api.d.ts
@@ -30,7 +30,6 @@ export type FeatureDefinitionWithProject = FeatureDefinition & {
 
 export type AutoExperimentWithProject = AutoExperiment & {
   project?: string;
-  changeType?: "redirect" | "visual";
 };
 
 export interface ExperimentOverridesResponse {

--- a/packages/shared/src/sdk-versioning/sdk-payload.ts
+++ b/packages/shared/src/sdk-versioning/sdk-payload.ts
@@ -4,6 +4,7 @@ import {
 } from "back-end/types/api";
 import { pick, omit } from "lodash";
 import cloneDeep from "lodash/cloneDeep";
+import { getAutoExperimentChangeType } from "@growthbook/growthbook";
 import { SDKCapability } from "./index";
 
 const strictFeatureKeys = ["defaultValue", "rules"];
@@ -114,7 +115,10 @@ export const scrubExperiments = (
 
   for (let experiment of experiments) {
     // Filter out any url redirect auto experiments if not supported
-    if (!supportsRedirects && experiment.changeType === "redirect") {
+    if (
+      !supportsRedirects &&
+      getAutoExperimentChangeType(experiment) === "redirect"
+    ) {
       continue;
     }
 


### PR DESCRIPTION
### Features and Changes

Somehow `experiment.changeType` was not getting set on the backend and thus our scrubbing and filtering methods were missing them. Now, compute changeType on the fly in the same manner as the SDK.

fixes https://github.com/growthbook/growthbook/issues/2785
### Testing

<!--
  Please describe how to test these changes.
 -->

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
