### PR TITLE
Allow updating `windowSettings` on `PUT /metric/:id`

### DIFF
--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -1663,6 +1663,20 @@ export function putMetricApiPayloadToMetricInterface(
         metric.windowSettings.windowValue =
           behavior.conversionWindowEnd - behavior.conversionWindowStart;
       }
+    } else {
+      metric.windowSettings = {
+        type:
+          behavior.windowSettings?.type == "none"
+            ? ""
+            : behavior.windowSettings?.type ?? DEFAULT_METRIC_WINDOW,
+        delayHours:
+          behavior.windowSettings?.delayHours ??
+          DEFAULT_METRIC_WINDOW_DELAY_HOURS,
+        windowValue:
+          behavior.windowSettings?.windowValue ??
+          DEFAULT_CONVERSION_WINDOW_HOURS,
+        windowUnit: behavior.windowSettings?.windowUnit ?? "hours",
+      };
     }
 
     if (typeof behavior.maxPercentChange !== "undefined") {

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -1646,7 +1646,21 @@ export function putMetricApiPayloadToMetricInterface(
       };
     }
 
-    if (typeof behavior.conversionWindowStart !== "undefined") {
+    if (typeof behavior.windowSettings !== "undefined") {
+      metric.windowSettings = {
+        type:
+          behavior.windowSettings?.type == "none"
+            ? ""
+            : behavior.windowSettings?.type ?? DEFAULT_METRIC_WINDOW,
+        delayHours:
+          behavior.windowSettings?.delayHours ??
+          DEFAULT_METRIC_WINDOW_DELAY_HOURS,
+        windowValue:
+          behavior.windowSettings?.windowValue ??
+          DEFAULT_CONVERSION_WINDOW_HOURS,
+        windowUnit: behavior.windowSettings?.windowUnit ?? "hours",
+      };
+    } else if (typeof behavior.conversionWindowStart !== "undefined") {
       // The start of a Conversion Window relative to the exposure date, in hours. This is equivalent to the Conversion Delay
       metric.windowSettings = {
         type: DEFAULT_METRIC_WINDOW,
@@ -1663,20 +1677,6 @@ export function putMetricApiPayloadToMetricInterface(
         metric.windowSettings.windowValue =
           behavior.conversionWindowEnd - behavior.conversionWindowStart;
       }
-    } else {
-      metric.windowSettings = {
-        type:
-          behavior.windowSettings?.type == "none"
-            ? ""
-            : behavior.windowSettings?.type ?? DEFAULT_METRIC_WINDOW,
-        delayHours:
-          behavior.windowSettings?.delayHours ??
-          DEFAULT_METRIC_WINDOW_DELAY_HOURS,
-        windowValue:
-          behavior.windowSettings?.windowValue ??
-          DEFAULT_CONVERSION_WINDOW_HOURS,
-        windowUnit: behavior.windowSettings?.windowUnit ?? "hours",
-      };
     }
 
     if (typeof behavior.maxPercentChange !== "undefined") {


### PR DESCRIPTION
### Features and Changes
Fixes: #2795

It looks like PUT metric was changed (or maybe it never allowed it, I didn't dig deep enough to find out for sure) and the `windowSettings` weren't being copied over from the payload to the updated metric.

### Testing
Tested locally and on our internal deployment