### PR TITLE
Add padding to the very last element right under `main`

### DIFF
--- a/packages/front-end/styles/global.scss
+++ b/packages/front-end/styles/global.scss
@@ -14,6 +14,10 @@ body,
 #__next,
 main {
   height: 100%;
+
+  > *:last-child {
+    padding-bottom: 70px !important;
+  }
 }
 
 body {


### PR DESCRIPTION
This is a follow-up from https://github.com/growthbook/growthbook/pull/2790 which was too rough.

This time, we tap directly into the app's main Layout: https://github.com/growthbook/growthbook/blob/main/packages/front-end/pages/_app.tsx#L108

Assuming that `<main>...</main>` always contains the main content of the app, we ask CSS to add some padding to the very last immediate child, which should be reasonable and achieve what we intend to here, which is to give some scrolling leeway when needer to scroll past the help button.

This has also been confirmed to not add scrolling when the page does not reach the bottom of the screen.