### PR TITLE
Issue 2693: Added ProjectSelectField to Feature Modal

### DIFF
--- a/packages/front-end/components/Features/FeatureModal/ProjectSelectField.tsx
+++ b/packages/front-end/components/Features/FeatureModal/ProjectSelectField.tsx
@@ -1,0 +1,28 @@
+import { FC } from "react";
+import SelectField, {
+  SingleValue,
+  GroupedValue,
+} from "@/components/Forms/SelectField";
+
+const ProjectSelectField: FC<{
+  onChange: (v?: string) => void;
+  value: string;
+  placeholder: string;
+  required: boolean;
+  sort: boolean;
+  options: (SingleValue | GroupedValue)[];
+}> = ({ onChange, value, options }) => {
+  return (
+    <SelectField
+      label="Project"
+      value={value}
+      onChange={onChange}
+      placeholder="Select Type..."
+      options={options}
+      required
+      sort={false}
+    />
+  );
+};
+
+export default ProjectSelectField;

--- a/packages/front-end/components/Features/FeatureModal/ProjectSelectField.tsx
+++ b/packages/front-end/components/Features/FeatureModal/ProjectSelectField.tsx
@@ -8,8 +8,6 @@ const ProjectSelectField: FC<{
   onChange: (v?: string) => void;
   value: string;
   placeholder: string;
-  required: boolean;
-  sort: boolean;
   options: (SingleValue | GroupedValue)[];
 }> = ({ onChange, value, options }) => {
   return (
@@ -19,7 +17,7 @@ const ProjectSelectField: FC<{
       onChange={onChange}
       placeholder="Select Type..."
       options={options}
-      required
+      required={false}
       sort={false}
     />
   );

--- a/packages/front-end/components/Features/FeatureModal/index.tsx
+++ b/packages/front-end/components/Features/FeatureModal/index.tsx
@@ -348,8 +348,6 @@ export default function FeatureModal({
         }}
         placeholder="Select Project"
         options={projectOptions}
-        required
-        sort={false}
       />
     </Modal>
   );

--- a/packages/front-end/components/Features/FeatureModal/index.tsx
+++ b/packages/front-end/components/Features/FeatureModal/index.tsx
@@ -20,10 +20,12 @@ import {
 import { useWatching } from "@/services/WatchProvider";
 import MarkdownInput from "@/components/Markdown/MarkdownInput";
 import { useDemoDataSourceProject } from "@/hooks/useDemoDataSourceProject";
+import useProjectOptions from "@/hooks/useProjectOptions";
 import FeatureValueField from "@/components/Features/FeatureValueField";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 import FeatureKeyField from "./FeatureKeyField";
 import EnvironmentSelect from "./EnvironmentSelect";
+import ProjectSelectField from "./ProjectSelectField";
 import TagsField from "./TagsField";
 import ValueTypeField from "./ValueTypeField";
 
@@ -171,6 +173,12 @@ export default function FeatureModal({
   let ctaEnabled = true;
   let disabledMessage: string | undefined;
 
+  const projectOptions = useProjectOptions(
+    (project) => permissionsUtil.canCreateFeature({ project }),
+    [project] || []
+  );
+  const selectedProject = form.watch("project");
+
   if (
     !permissionsUtil.canManageFeatureDrafts({
       project: featureToDuplicate?.project ?? project,
@@ -182,7 +190,7 @@ export default function FeatureModal({
   }
 
   // We want to show a warning when someone tries to create a feature under the demo project
-  const { currentProjectIsDemo } = useDemoDataSourceProject();
+  const { projectId } = useDemoDataSourceProject();
 
   return (
     <Modal
@@ -242,7 +250,7 @@ export default function FeatureModal({
         await onSuccess(res.feature);
       })}
     >
-      {currentProjectIsDemo && (
+      {projectId === selectedProject && (
         <div className="alert alert-warning">
           You are creating a feature under the demo datasource project.
         </div>
@@ -333,6 +341,16 @@ export default function FeatureModal({
           </div>
         </>
       )}
+      <ProjectSelectField
+        value={selectedProject || project}
+        onChange={(v) => {
+          form.setValue("project", v);
+        }}
+        placeholder="Select Project"
+        options={projectOptions}
+        required
+        sort={false}
+      />
     </Modal>
   );
 }


### PR DESCRIPTION
### Features and Changes

<!--
  Include a description of your changes.
  If there are any new tools, API's, etc. that devs can leverage, it may be helpful to include usage info.
-->
Added a field for user to choose project while creating the Feature
<!--
  Indicate which issue this will close, if applicable
  For multiple issues, add a new `- Closes` or `- Fixes` line
-->

- Closes **https://github.com/growthbook/growthbook/issues/2693**

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->
NA

### Testing

<!--
  Please describe how to test these changes.
 -->
  1. User must be able to select project while creating the Feature.
  2. Feature must be assigned to respective project right after creation automatically.
  3. User must see the warning upon selecting Sample-Data project.
  4. User must also be able to create feature without selecting any project. 

### Screenshots
https://github.com/user-attachments/assets/e732ff4e-9117-4e48-85e0-48750f87b122

