### PR TITLE
Remove confusing Stop Time field when stopping an experiment

### DIFF
--- a/packages/front-end/components/Experiment/StopExperimentForm.tsx
+++ b/packages/front-end/components/Experiment/StopExperimentForm.tsx
@@ -21,6 +21,8 @@ const StopExperimentForm: FC<{
 }> = ({ experiment, close, mutate }) => {
   const isStopped = experiment.status === "stopped";
 
+  const hasLinkedChanges = experimentHasLinkedChanges(experiment);
+
   const form = useForm({
     defaultValues: {
       reason: "",
@@ -89,11 +91,13 @@ const StopExperimentForm: FC<{
             {...form.register("reason")}
             placeholder="(optional)"
           />
-          <Field
-            label="Stop Time (UTC)"
-            type="datetime-local"
-            {...form.register("dateEnded")}
-          />
+          {!hasLinkedChanges && (
+            <Field
+              label="Stop Time (UTC)"
+              type="datetime-local"
+              {...form.register("dateEnded")}
+            />
+          )}
         </>
       )}
       <div className="row">
@@ -154,7 +158,7 @@ const StopExperimentForm: FC<{
           />
         )}
       </div>
-      {experimentHasLinkedChanges(experiment) && (
+      {hasLinkedChanges && (
         <>
           <div className="row">
             <div className="form-group col">


### PR DESCRIPTION
### Features and Changes

The `Stop Time` field when stopping an experiment is misleading and confusing.  People expect to be able to use this to schedule an end date in the future.  However, the field is only used for documentation purposes and has no effect on anything else.

This PR removes the field for any experiment that has linked changes (feature flags, visual editor, URL redirects).  If an experiment doesn't have any linked changes, the field is not as misleading since it's clear that GrowthBook is only being used for analysis and not for actually running the experiment.

Fixes #2818 
