### PR TITLE
Add "format" option to string properties in json-schema.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ This repository is a monorepo with the following packages:
 
 - **packages/front-end** is a Next.js app and contains the full UI of the GrowthBook app.
 - **packages/back-end** is an Express app and serves as the REST api for the front-end.
-- **package/shared** is a collection of Typescript functions and constants shared between the front-end and back-end.
+- **packages/shared** is a collection of Typescript functions and constants shared between the front-end and back-end.
 - **package/enterprise** contains proprietary code governed under the GrowthBook Enterprise license. We typically do not accept outside contributions for this package.
 - **packages/sdk-js** is our javascript SDK (`@growthbook/growthbook` on npm)
 - **packages/sdk-react** is our React SDK (`@growthbook/growthbook-react` on npm)

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@growthbook/growthbook": "^1.1.0",
     "ajv": "^8.12.0",
+    "ajv-formats": "^3.0.1",
     "date-fns": "^2.15.0",
     "dirty-json": "^0.9.2",
     "json-stringify-pretty-compact": "^3.0.0",

--- a/packages/shared/src/util/features.ts
+++ b/packages/shared/src/util/features.ts
@@ -1,4 +1,5 @@
 import Ajv from "ajv";
+import addFormats from "ajv-formats";
 import { subWeeks } from "date-fns";
 import dJSON from "dirty-json";
 import stringify from "json-stringify-pretty-compact";
@@ -85,9 +86,13 @@ export function mergeRevision(
 }
 
 export function getJSONValidator() {
-  return new Ajv({
+  const ajv = new Ajv({
     strictSchema: false,
   });
+
+  addFormats(ajv);
+
+  return ajv;
 }
 
 export function validateJSONFeatureValue(

--- a/yarn.lock
+++ b/yarn.lock
@@ -8889,6 +8889,13 @@ ajv-draft-04@^1.0.0:
   resolved "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz"
   integrity sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==
 
+ajv-formats@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-3.0.1.tgz#3d5dc762bca17679c3c2ea7e90ad6b7532309578"
+  integrity sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==
+  dependencies:
+    ajv "^8.0.0"
+
 ajv@^6.10.0, ajv@^6.12.4:
   version "6.12.6"
   resolved "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz"
@@ -8898,6 +8905,16 @@ ajv@^6.10.0, ajv@^6.12.4:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
+
+ajv@^8.0.0:
+  version "8.17.1"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.17.1.tgz#37d9a5c776af6bc92d7f4f9510eba4c0a60d11a6"
+  integrity sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    fast-uri "^3.0.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
 
 ajv@^8.12.0, ajv@^8.6.3:
   version "8.12.0"
@@ -12100,6 +12117,11 @@ fast-text-encoding@^1.0.0:
   version "1.0.4"
   resolved "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.4.tgz"
   integrity sha512-x6lDDm/tBAzX9kmsPcZsNbvDs3Zey3+scsxaZElS8xWLgUMAg/oFLeewfUz0mu1CblHhhsu15jGkraldkFh8KQ==
+
+fast-uri@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.0.1.tgz#cddd2eecfc83a71c1be2cc2ef2061331be8a7134"
+  integrity sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw==
 
 fast-url-parser@^1.1.3:
   version "1.1.3"


### PR DESCRIPTION
### Features and Changes
This PR enables `ajv` to validate string property _formats_, as provided by the `format` key.

Updated tests and cleaned them up a bit to make it clearer what each test is asserting on.

Added `ajv-formats` package. (Officially maintained by ajv. See https://ajv.js.org/packages/ajv-formats.html for plugin details and list of possible formats.)

### Testing
#### Setup
In the growthbook frontend, create a JSON feature flag and provide a JSON schema including a formatted string property. For example:
```json
{
  "type": "object",
  "properties": {
    "example": {
      "type": "string",
      "format": "date-time"
    }
  }
}
```
#### Test 1
Assert that this error is not encountered and the schema saves successfully.
![image](https://github.com/user-attachments/assets/b3a51a90-62ed-4e61-b3f8-beae747d9bcb)

#### Test 2
Assert that changing the format to an invalid option (i.e. `"format": "nope"`) displays a validation error. 

#### Test 3
Assert that the feature flag values are set using the validation as defined by the schema.