### PR TITLE
doc(script-tag): fix CSP script source typos

### DIFF
--- a/docs/docs/lib/script-tag.mdx
+++ b/docs/docs/lib/script-tag.mdx
@@ -275,13 +275,13 @@ If your site uses a Content Security Policy, you may need to make a few changes 
 
 First, make sure to add `https://cdn.jsdelivr.net` so the script itself can load. If this isn't possible, you can save the contents of the script and host it on your own domain instead. Just note that doing that means you will no longer get automatic updates when we make improvements to the script tag.
 
-Second, if you plan to use the Visual Editor to inject custom javascript into your site, you need to allow both `usafe-inline` and `unsafe-eval`. If this isn't possible, we have an alternative using nonces (see below).
+Second, if you plan to use the Visual Editor to inject custom javascript into your site, you need to allow both `unsafe-inline` and `unsafe-eval`. If this isn't possible, we have an alternative using nonces (see below).
 
 ### Using Script Nonces
 
 As an alternative to allowing `unsafe-inline`, we support "nonces", although this requires some very technical and custom configuration to hook up. This is only required if you plan to use the Visual Editor to inject custom javascript into your site.
 
-You will still need to allow `usafe-eval` due to how our Visual Editor works under-the-hood.
+You will still need to allow `unsafe-eval` due to how our Visual Editor works under-the-hood.
 
 First, you will need to generate a unique nonce value for every request and add it to your CSP header. This can be done on the edge such as with a Cloudflare Worker.
 


### PR DESCRIPTION
### Features and Changes

I found two typos on **SDK > Front-end > HTML Script Tag** documentation:
<img width="1408" alt="image" src="https://github.com/user-attachments/assets/37b220eb-8c53-4ad4-aa61-6273f1701d57">

These typos only appear here, I also check the Content Security Policy on [Running Experiments](https://docs.growthbook.io/app/visual#content-security-policy-csp-changes) part and it looks fine.

### Dependencies

None

### Testing

Just redeploy the project and it will work.

### Screenshots
After typos are fixed 👇
<img width="1364" alt="image" src="https://github.com/user-attachments/assets/245b13ad-c5ef-43f9-b87f-0ed4ee226810">

