### PR TITLE
fix(incompatible-node): update the minimum node version requirement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ If you just want to contribute a client library in a new language and not make c
 ## Requirements
 
 - MacOS or Linux (Windows may work too, but we haven't tested it)
-- [NodeJS](https://nodejs.org/en/download/package-manager/) 16.x or above
+- [NodeJS](https://nodejs.org/en/download/package-manager/) 18.x or above
   - Check version by running `node -v` on terminal
 - [Yarn](https://classic.yarnpkg.com/en/docs/install)
 - [Python](https://www.python.org/downloads/) 3.8+ (for the stats engine)

--- a/package.json
+++ b/package.json
@@ -77,5 +77,8 @@
       }
     ]
   },
-  "license": "MIT"
+  "license": "MIT",
+  "engines": {
+    "node": ">=18"
+  }
 }


### PR DESCRIPTION
### Features and Changes

👋 Hi GrowthBook maintainers!

Today I worked through the contribution guidelines and realized something went wrong:
![image](https://github.com/user-attachments/assets/8bd247df-bac6-4eac-a936-2bc7bc01e0c2)

<img width="887" alt="image" src="https://github.com/user-attachments/assets/7b2662f6-fe9d-48da-8baa-741b7bdaafef">

Therefore, I decide to help update it for the future followers :)

### Dependencies

None

### Testing

```sh
nvm use v16
yarn
```

### Screenshots

After the bugfix, it will still show a similar error message but this time it could be quick:
![image](https://github.com/user-attachments/assets/69430ce6-7ecb-421a-9fae-4ace332879c6)

In this way, we can ensure the development onboarding guideline is always up-to-date 😎 

