### PR TITLE
fix DateGraph datapoint alignment

### DIFF
--- a/packages/front-end/components/Metrics/DateGraph.tsx
+++ b/packages/front-end/components/Metrics/DateGraph.tsx
@@ -16,7 +16,7 @@ import {
 } from "@visx/tooltip";
 import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
 import { ScaleLinear } from "d3-scale";
-import { date, getValidDate } from "shared/dates";
+import { date, getValidDate, getValidDateOffsetByUTC } from "shared/dates";
 import { addDays, setHours, setMinutes } from "date-fns";
 import cloneDeep from "lodash/cloneDeep";
 import { getMetricFormatter } from "@/services/metrics";
@@ -209,7 +209,7 @@ const DateGraph: FC<DateGraphProps> = ({
     const desiredHour = lastDate.getUTCHours();
     const desiredMinute = lastDate.getUTCMinutes();
     sortedDates = sortedDates.map((d) => {
-      let date = getValidDate(d.d);
+      let date = getValidDateOffsetByUTC(d.d);
       date = setMinutes(setHours(date, desiredHour), desiredMinute);
       d.d = date;
       return d;


### PR DESCRIPTION
### Features and Changes
The DateGraph on the metric analysis page was mixing some UTC & local-timezone dates, which would result in the tooltip showing datapoints being offset by a day (datapoint is for 00:00 UTC on some date, but would get -08:00 or whatever in PST, and get displayed as the previous day):

Data here shows a main sum squares of 12484 for 7-31:
![Screenshot 2024-08-02 at 11 50 44 AM](https://github.com/user-attachments/assets/273a1346-ee92-49e1-a10f-19afee196b59)

But the tooltip shows that value for 7-30:
![Screenshot 2024-08-02 at 11 50 51 AM](https://github.com/user-attachments/assets/1c3a5b2d-fc86-4046-b32e-96024018b27b)

Adjusting `sortedDates` with `getValidDateOffsetByUTC` instead of `getValidDate` appears to fix this:

Data from query:
<img width="1351" alt="Screenshot 2024-08-02 at 12 17 54 PM" src="https://github.com/user-attachments/assets/778811e5-6287-40b0-9afc-7f5a279a625b">

Graph without this change:
<img width="820" alt="Screenshot 2024-08-02 at 12 14 52 PM" src="https://github.com/user-attachments/assets/eafefa98-0802-44d1-9c8f-5091c37b3ebf">

Graph with this change:
<img width="837" alt="Screenshot 2024-08-02 at 12 16 19 PM" src="https://github.com/user-attachments/assets/5da5e064-fb51-41d9-a597-097e04a91e2b">

