### PR TITLE
Add batch metric delete API

### DIFF
--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -2488,6 +2488,47 @@ paths:
                 properties:
                   metric:
                     $ref: '#/components/schemas/Metric'
+    delete:
+      parameters:
+        - $ref: '#/components/parameters/delete'
+      tags:
+        - metrics
+      summary: Archives (or deletes) a set of metrics by IDs
+      operationId: deleteMetrics
+      x-codeSamples:
+        - lang: cURL
+          source: |
+            curl -X DELETE --data '{"ids": ["met_123", "met_456"]}' https://api.growthbook.io/api/v1/metrics?delete=true \
+              -u secret_abc123DEF456:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - ids
+              properties:
+                ids:
+                  type: array
+                  items:
+                    type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - modifiedIds
+                  - deleted
+                properties:
+                  modifiedIds:
+                    type: array
+                    items:
+                      type: string
+                  deleted:
+                    type: boolean
   '/metrics/{id}':
     get:
       parameters:
@@ -5042,6 +5083,14 @@ components:
       description: The id of the requested resource
       schema:
         type: string
+    delete:
+      name: delete
+      in: query
+      required: false
+      description: 'If true, the metrics will be deleted instead of archived'
+      schema:
+        type: boolean
+        default: false
     limit:
       name: limit
       in: query

--- a/packages/back-end/src/api/metrics/deleteMetrics.ts
+++ b/packages/back-end/src/api/metrics/deleteMetrics.ts
@@ -1,0 +1,77 @@
+import { z } from "zod";
+import { createApiRequestHandler } from "../../util/handler";
+import { deleteMetricsValidator } from "../../validators/openapi";
+import {
+  deleteMetricById,
+  getMetricsByIds,
+  updateMetric,
+} from "../../models/MetricModel";
+import { DeleteMetricsResponse } from "../../../types/openapi";
+
+export const deleteMetricsHandler = createApiRequestHandler({
+  bodySchema: deleteMetricsValidator.bodySchema,
+  querySchema: z
+    .object({
+      delete: z.preprocess((val) => {
+        if (typeof val === "string") {
+          if (val.toLowerCase() === "true") return true;
+          if (val.toLowerCase() === "false") return false;
+        }
+        return val;
+      }, z.boolean()),
+    })
+    .strict(),
+  paramsSchema: deleteMetricsValidator.paramsSchema,
+})(
+  async (req): Promise<DeleteMetricsResponse> => {
+    if (req.body.ids.length === 0) {
+      throw new Error(
+        `Must provide at least one metric ID to ${
+          req.query.delete ? "delete" : "archive"
+        }`
+      );
+    }
+
+    const metrics = await getMetricsByIds(req.context, req.body.ids);
+
+    const metricMap = new Map(metrics.map((m) => [m.id, m]));
+
+    // get IDs that were in request body (metricIdSet) but not found
+    const notFoundIds = req.body.ids.filter((id) => !metricMap.has(id));
+
+    if (notFoundIds.length > 0) {
+      throw new Error(
+        "Could not find metrics with IDs: " + notFoundIds.join(", ")
+      );
+    }
+
+    for (const metric of metrics) {
+      if (req.query.delete) {
+        if (!req.context.permissions.canDeleteMetric(metric)) {
+          req.context.permissions.throwPermissionError();
+        }
+      } else {
+        if (
+          !req.context.permissions.canUpdateMetric(metric, {
+            projects: metric.projects,
+          })
+        ) {
+          req.context.permissions.throwPermissionError();
+        }
+      }
+    }
+
+    for (const metric of metrics) {
+      if (req.query.delete) {
+        await deleteMetricById(req.context, metric);
+      } else {
+        await updateMetric(req.context, metric, { status: "archived" });
+      }
+    }
+
+    return {
+      modifiedIds: req.body.ids,
+      deleted: req.query.delete,
+    };
+  }
+);

--- a/packages/back-end/src/api/metrics/metrics.router.ts
+++ b/packages/back-end/src/api/metrics/metrics.router.ts
@@ -4,6 +4,7 @@ import { listMetrics } from "./listMetrics";
 import { postMetric } from "./postMetric";
 import { putMetric } from "./putMetric";
 import { deleteMetricHandler as deleteMetric } from "./deleteMetric";
+import { deleteMetricsHandler as deleteMetrics } from "./deleteMetrics";
 
 const router = Router();
 
@@ -11,6 +12,7 @@ const router = Router();
 // Mounted at /api/v1/metrics
 router.get("/", listMetrics);
 router.post("/", postMetric);
+router.delete("/", deleteMetrics);
 
 router.get("/:id", getMetric);
 router.put("/:id", putMetric);

--- a/packages/back-end/src/api/openapi/openapi.yaml
+++ b/packages/back-end/src/api/openapi/openapi.yaml
@@ -200,6 +200,8 @@ paths:
       $ref: "./paths/listMetrics.yaml"
     post:
       $ref: "./paths/postMetric.yaml"
+    delete:
+      $ref: "./paths/deleteMetrics.yaml"
   /metrics/{id}:
     get:
       $ref: "./paths/getMetric.yaml"

--- a/packages/back-end/src/api/openapi/parameters.yaml
+++ b/packages/back-end/src/api/openapi/parameters.yaml
@@ -5,6 +5,14 @@ id:
   description: The id of the requested resource
   schema:
     type: string
+delete:
+  name: delete
+  in: query
+  required: false
+  description: If true, the metrics will be deleted instead of archived
+  schema:
+    type: boolean
+    default: false
 limit:
   name: limit
   in: query

--- a/packages/back-end/src/api/openapi/paths/deleteMetrics.yaml
+++ b/packages/back-end/src/api/openapi/paths/deleteMetrics.yaml
@@ -1,0 +1,33 @@
+parameters:
+  - $ref: "../parameters.yaml#/delete"
+tags:
+  - metrics
+summary: Archives (or deletes) a set of metrics by IDs
+operationId: deleteMetrics
+x-codeSamples:
+  - lang: "cURL"
+    source: |
+      curl -X DELETE --data '{"ids": ["met_123", "met_456"]}' https://api.growthbook.io/api/v1/metrics?delete=true \
+        -u secret_abc123DEF456:
+requestBody:
+  required: true
+  content:
+    application/json:
+      schema:
+        $ref: "../payload-schemas/DeleteMetricsPayload.yaml"
+responses:
+  "200":
+    content:
+      application/json:
+        schema:
+          type: object
+          required:
+            - modifiedIds
+            - deleted
+          properties:
+            modifiedIds:
+              type: array
+              items:
+                type: string
+            deleted:
+              type: boolean

--- a/packages/back-end/src/api/openapi/payload-schemas/DeleteMetricsPayload.yaml
+++ b/packages/back-end/src/api/openapi/payload-schemas/DeleteMetricsPayload.yaml
@@ -1,0 +1,8 @@
+type: object
+required:
+  - ids
+properties:
+  ids:
+    type: array
+    items:
+      type: string

--- a/packages/back-end/src/app.ts
+++ b/packages/back-end/src/app.ts
@@ -464,6 +464,7 @@ app.get("/ideas/recent/:num", ideasController.getRecentIdeas);
 // Metrics
 app.get("/metrics", metricsController.getMetrics);
 app.post("/metrics", metricsController.postMetrics);
+app.delete("/metrics", metricsController.deleteMetrics);
 app.post(
   "/metrics/tracked-events/:datasourceId",
   metricsController.getMetricsFromTrackedEvents

--- a/packages/back-end/src/validators/openapi.ts
+++ b/packages/back-end/src/validators/openapi.ts
@@ -286,6 +286,12 @@ export const postMetricValidator = {
   paramsSchema: z.never(),
 };
 
+export const deleteMetricsValidator = {
+  bodySchema: z.object({ "ids": z.array(z.string()) }).strict(),
+  querySchema: z.object({ "delete": z.boolean().default(false) }).strict(),
+  paramsSchema: z.never(),
+};
+
 export const getMetricValidator = {
   bodySchema: z.never(),
   querySchema: z.never(),

--- a/packages/back-end/types/openapi.d.ts
+++ b/packages/back-end/types/openapi.d.ts
@@ -168,6 +168,8 @@ export interface paths {
     get: operations["listMetrics"];
     /** Create a single metric */
     post: operations["postMetric"];
+    /** Archives (or deletes) a set of metrics by IDs */
+    delete: operations["deleteMetrics"];
   };
   "/metrics/{id}": {
     /** Get a single metric */
@@ -2267,6 +2269,8 @@ export interface components {
   parameters: {
     /** @description The id of the requested resource */
     id: string;
+    /** @description If true, the metrics will be deleted instead of archived */
+    delete: boolean;
     /** @description The number of items to return */
     limit: number;
     /** @description How many items to skip (use in conjunction with limit for pagination) */
@@ -6340,6 +6344,32 @@ export interface operations {
       };
     };
   };
+  deleteMetrics: {
+    /** Archives (or deletes) a set of metrics by IDs */
+    parameters: {
+        /** @description If true, the metrics will be deleted instead of archived */
+      query: {
+        delete?: boolean;
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          ids: (string)[];
+        };
+      };
+    };
+    responses: {
+      200: {
+        content: {
+          "application/json": {
+            modifiedIds: (string)[];
+            deleted: boolean;
+          };
+        };
+      };
+    };
+  };
   getMetric: {
     /** Get a single metric */
     parameters: {
@@ -9199,6 +9229,7 @@ export type ListVisualChangesetsResponse = operations["listVisualChangesets"]["r
 export type GetExperimentSnapshotResponse = operations["getExperimentSnapshot"]["responses"]["200"]["content"]["application/json"];
 export type ListMetricsResponse = operations["listMetrics"]["responses"]["200"]["content"]["application/json"];
 export type PostMetricResponse = operations["postMetric"]["responses"]["200"]["content"]["application/json"];
+export type DeleteMetricsResponse = operations["deleteMetrics"]["responses"]["200"]["content"]["application/json"];
 export type GetMetricResponse = operations["getMetric"]["responses"]["200"]["content"]["application/json"];
 export type PutMetricResponse = operations["putMetric"]["responses"]["200"]["content"]["application/json"];
 export type DeleteMetricResponse = operations["deleteMetric"]["responses"]["200"]["content"]["application/json"];


### PR DESCRIPTION
### Features and Changes
addresses #2630

Adds a `DELETE` resource on `/api/v1/metrics` that takes a json body w/ a list of metrics and a query parameter (`delete`) to either archive or for-real-delete multiple metrics at once.

I'm still a little unfamiliar with zod but I think this usage of `preprocess` gets what we want? It might be better to just make the query parameter a string type (instead of boolean) and only strictly accept `true` and `false`.

It might also make more sense to move the archiving functionality to a batch metric PUT api, but re-using `DELETE` for archiving seemed somewhat intuitive

### Testing
Breaks when using query parameter other than `delete`:
```
curl -H "Content-Type: application/json" -H "Authorization: Bearer ..." -X DELETE --data '{"ids": ["met_6y4deo1kzblyxky4ef", "met_6y4depgjpklzbvdhdo"]}' localhost:3100/api/v1/metrics\?deleted=true
{
  "message": "Querystring: [] Unrecognized key(s) in object: 'deleted'"
}
```

archive one or more metrics with `delete=false`:
```
curl -H "Content-Type: application/json" -H "Authorization: Bearer ..." -X DELETE --data '{"ids": ["met_6y4deo1kzblyxky3ad"]}' localhost:3100/api/v1/metrics\?delete=false
{
  "modifiedIds": [
    "met_6y4deo1kzblyxky3ad"
  ],
  "deleted": false
}
curl -H "Content-Type: application/json" -H "Authorization: Bearer ..." -X DELETE --data '{"ids": ["met_6y4deo1kzblyxky44p", "met_6y4deo1kzblyxky2jw"]}' localhost:3100/api/v1/metrics\?delete=false
{
  "modifiedIds": [
    "met_6y4deo1kzblyxky44p",
    "met_6y4deo1kzblyxky2jw"
  ],
  "deleted": false
}
```

delete multiple metrics with `delete=true`:
```
> curl -H "Content-Type: application/json" -H "Authorization: Bearer ..." -X DELETE --data '{"ids": ["met_6y4deo1kzblyxky4ef", "met_6y4depgjpklzbvdhdo"]}' localhost:3100/api/v1/metrics\?delete=true
{
  "modifiedIds": [
    "met_6y4deo1kzblyxky4ef",
    "met_6y4depgjpklzbvdhdo"
  ],
  "deleted": true
}
```

must provide delete param of `true/false`:
```
> curl -H "Content-Type: application/json" -H "Authorization: Bearer ..." -X DELETE --data '{"ids": ["met_6y4deo1kzblyxky5hj"]}' localhost:3100/api/v1/metrics\?delete=something
{
  "message": "Querystring: [delete] Expected boolean, received string"
}
> curl -H "Content-Type: application/json" -H "Authorization: Bearer ..." -X DELETE --data '{"ids": ["met_6y4deo1kzblyxky5hj"]}' localhost:3100/api/v1/metrics\?delete
{
  "message": "Querystring: [delete] Expected boolean, received string"
}
> curl -H "Content-Type: application/json" -H "Authorization: Bearer ..." -X DELETE --data '{"ids": ["met_6y4deo1kzblyxky5hj"]}' localhost:3100/api/v1/metrics\?delete=f
{
  "message": "Querystring: [delete] Expected boolean, received string"
}
> curl -H "Content-Type: application/json" -H "Authorization: Bearer ..." -X DELETE --data '{"ids": ["met_6y4deo1kzblyxky5hj"]}' localhost:3100/api/v1/metrics\?delete=0
{
  "message": "Querystring: [delete] Expected boolean, received string"
}
> curl -H "Content-Type: application/json" -H "Authorization: Bearer ..." -X DELETE --data '{"ids": ["met_6y4deo1kzblyxky5hj"]}' localhost:3100/api/v1/metrics\?delete=1
{
  "message": "Querystring: [delete] Expected boolean, received string"
}
```
