### PR TITLE
add experiment & metric api edits to audit log

### DIFF
--- a/packages/back-end/src/api/experiments/postExperiment.ts
+++ b/packages/back-end/src/api/experiments/postExperiment.ts
@@ -16,6 +16,7 @@ import { upsertWatch } from "back-end/src/models/WatchModel";
 import { getMetricMap } from "back-end/src/models/MetricModel";
 import { validateVariationIds } from "back-end/src/controllers/experiments";
 import { Variation } from "back-end/src/validators/experiments";
+import { auditDetailsCreate } from "back-end/src/services/audit";
 
 export const postExperiment = createApiRequestHandler(postExperimentValidator)(
   async (req): Promise<PostExperimentResponse> => {
@@ -133,6 +134,15 @@ export const postExperiment = createApiRequestHandler(postExperimentValidator)(
     const experiment = await createExperiment({
       data: newExperiment,
       context: req.context,
+    });
+
+    await req.audit({
+      event: "experiment.create",
+      entity: {
+        object: "experiment",
+        id: experiment.id,
+      },
+      details: auditDetailsCreate(experiment, {}),
     });
 
     if (ownerId) {

--- a/packages/back-end/src/api/experiments/updateExperiment.ts
+++ b/packages/back-end/src/api/experiments/updateExperiment.ts
@@ -15,159 +15,194 @@ import { updateExperimentValidator } from "back-end/src/validators/openapi";
 import { getMetricMap } from "back-end/src/models/MetricModel";
 import { validateVariationIds } from "back-end/src/controllers/experiments";
 import { Variation } from "back-end/src/validators/experiments";
+import { auditDetailsUpdate } from "back-end/src/services/audit";
 
 export const updateExperiment = createApiRequestHandler(
   updateExperimentValidator
-)(
-  async (req): Promise<UpdateExperimentResponse> => {
-    const experiment = await getExperimentById(req.context, req.params.id);
-    if (!experiment) {
-      throw new Error("Could not find the experiment to update");
-    }
+)(async (req): Promise<UpdateExperimentResponse> => {
+  const experiment = await getExperimentById(req.context, req.params.id);
+  if (!experiment) {
+    throw new Error("Could not find the experiment to update");
+  }
 
-    // Validate projects - We can remove this validation when FeatureModel is migrated to BaseModel
-    if (req.body.project) {
-      await req.context.models.projects.ensureProjectsExist([req.body.project]);
-    }
+  // Validate projects - We can remove this validation when FeatureModel is migrated to BaseModel
+  if (req.body.project) {
+    await req.context.models.projects.ensureProjectsExist([req.body.project]);
+  }
 
-    if (!req.context.permissions.canUpdateExperiment(experiment, req.body)) {
-      req.context.permissions.throwPermissionError();
-    }
+  if (!req.context.permissions.canUpdateExperiment(experiment, req.body)) {
+    req.context.permissions.throwPermissionError();
+  }
 
-    // validate datasource only if updating
-    const datasourceId = req.body.datasourceId ?? experiment.datasource;
-    const datasource = datasourceId
-      ? await getDataSourceById(req.context, datasourceId)
-      : null;
+  // validate datasource only if updating
+  const datasourceId = req.body.datasourceId ?? experiment.datasource;
+  const datasource = datasourceId
+    ? await getDataSourceById(req.context, datasourceId)
+    : null;
 
-    if (
-      req.body.datasourceId !== undefined &&
-      req.body.datasourceId !== experiment.datasource
-    ) {
-      if (experiment.datasource) {
-        throw new Error(
-          "Cannot change datasource via API if one is already set."
-        );
-      }
-      if (!datasource) {
-        throw new Error("Datasource not found.");
-      }
-    }
-
-    // check for associated assignment query id
-    if (
-      req.body.assignmentQueryId !== undefined &&
-      req.body.assignmentQueryId !== experiment.exposureQueryId
-    ) {
-      if (!datasource) {
-        throw new Error("Datasource not found.");
-      }
-      if (
-        !datasource.settings.queries?.exposure?.some(
-          (q) => q.id === req.body.assignmentQueryId
-        )
-      ) {
-        throw new Error(
-          `Unrecognized assignment query ID: ${req.body.assignmentQueryId}`
-        );
-      }
-    }
-
-    // check if tracking key is unique
-    if (
-      req.body.trackingKey != null &&
-      req.body.trackingKey !== experiment.trackingKey
-    ) {
-      const existingByTrackingKey = await getExperimentByTrackingKey(
-        req.context,
-        req.body.trackingKey
+  if (
+    req.body.datasourceId !== undefined &&
+    req.body.datasourceId !== experiment.datasource
+  ) {
+    if (experiment.datasource) {
+      throw new Error(
+        "Cannot change datasource via API if one is already set."
       );
-      if (existingByTrackingKey) {
-        throw new Error(
-          `Experiment with tracking key already exists: ${req.body.trackingKey}`
-        );
-      }
     }
+    if (!datasource) {
+      throw new Error("Datasource not found.");
+    }
+  }
 
-    // Validate that specified metrics exist and belong to the organization
-    const oldMetricIds = getAllMetricIdsFromExperiment(experiment);
-    const newMetricIds = getAllMetricIdsFromExperiment({
-      goalMetrics: req.body.metrics,
-      secondaryMetrics: req.body.secondaryMetrics,
-      guardrailMetrics: req.body.guardrailMetrics,
-      activationMetric: req.body.activationMetric,
-    }).filter((m) => !oldMetricIds.includes(m));
+  // check for associated assignment query id
+  if (
+    req.body.assignmentQueryId !== undefined &&
+    req.body.assignmentQueryId !== experiment.exposureQueryId
+  ) {
+    if (!datasource) {
+      throw new Error("Datasource not found.");
+    }
+    if (
+      !datasource.settings.queries?.exposure?.some(
+        (q) => q.id === req.body.assignmentQueryId
+      )
+    ) {
+      throw new Error(
+        `Unrecognized assignment query ID: ${req.body.assignmentQueryId}`
+      );
+    }
+  }
 
-    const map = await getMetricMap(req.context);
+  // check if tracking key is unique
+  if (
+    req.body.trackingKey != null &&
+    req.body.trackingKey !== experiment.trackingKey
+  ) {
+    const existingByTrackingKey = await getExperimentByTrackingKey(
+      req.context,
+      req.body.trackingKey
+    );
+    if (existingByTrackingKey) {
+      throw new Error(
+        `Experiment with tracking key already exists: ${req.body.trackingKey}`
+      );
+    }
+  }
 
-    if (newMetricIds.length) {
-      if (!datasource) {
-        throw new Error("Must provide a datasource when including metrics");
-      }
-      for (let i = 0; i < newMetricIds.length; i++) {
-        const metric = map.get(newMetricIds[i]);
-        if (metric) {
+  // Validate that specified metrics exist and belong to the organization
+  const oldMetricIds = getAllMetricIdsFromExperiment(experiment);
+  const newMetricIds = getAllMetricIdsFromExperiment({
+    goalMetrics: req.body.metrics,
+    secondaryMetrics: req.body.secondaryMetrics,
+    guardrailMetrics: req.body.guardrailMetrics,
+    activationMetric: req.body.activationMetric,
+  }).filter((m) => !oldMetricIds.includes(m));
+
+  const map = await getMetricMap(req.context);
+
+  if (newMetricIds.length) {
+    if (!datasource) {
+      throw new Error("Must provide a datasource when including metrics");
+    }
+    for (let i = 0; i < newMetricIds.length; i++) {
+      const metric = map.get(newMetricIds[i]);
+      if (metric) {
+        // Make sure it is tied to the same datasource as the experiment
+        if (datasource.id && metric.datasource !== datasource.id) {
+          throw new Error(
+            "Metrics must be tied to the same datasource as the experiment: " +
+              newMetricIds[i]
+          );
+        }
+      } else {
+        // check to see if this metric is actually a metric group
+        const metricGroup = await req.context.models.metricGroups.getById(
+          newMetricIds[i]
+        );
+        if (metricGroup) {
           // Make sure it is tied to the same datasource as the experiment
-          if (datasource.id && metric.datasource !== datasource.id) {
+          if (datasource.id && metricGroup.datasource !== datasource.id) {
             throw new Error(
               "Metrics must be tied to the same datasource as the experiment: " +
                 newMetricIds[i]
             );
           }
         } else {
-          // check to see if this metric is actually a metric group
-          const metricGroup = await req.context.models.metricGroups.getById(
-            newMetricIds[i]
-          );
-          if (metricGroup) {
-            // Make sure it is tied to the same datasource as the experiment
-            if (datasource.id && metricGroup.datasource !== datasource.id) {
-              throw new Error(
-                "Metrics must be tied to the same datasource as the experiment: " +
-                  newMetricIds[i]
-              );
-            }
-          } else {
-            // new metric that's not recognized...
-            throw new Error("Unknown metric: " + newMetricIds[i]);
-          }
+          // new metric that's not recognized...
+          throw new Error("Unknown metric: " + newMetricIds[i]);
         }
       }
     }
-
-    if (req.body.variations) {
-      validateVariationIds(req.body.variations as Variation[]);
-    }
-
-    if (
-      req.body.type &&
-      req.body.type !== (experiment.type || "standard") &&
-      experiment.status !== "draft" &&
-      req.body.status !== "draft"
-    ) {
-      throw new Error("Can only convert experiment types while in draft mode.");
-    }
-
-    const updatedExperiment = await updateExperimentToDb({
-      context: req.context,
-      experiment: experiment,
-      changes: updateExperimentApiPayloadToInterface(
-        req.body,
-        experiment,
-        map,
-        req.organization
-      ),
-    });
-
-    if (updatedExperiment === null) {
-      throw new Error("Error happened during updating experiment.");
-    }
-    const apiExperiment = await toExperimentApiInterface(
-      req.context,
-      updatedExperiment
-    );
-    return {
-      experiment: apiExperiment,
-    };
   }
-);
+
+  if (req.body.variations) {
+    validateVariationIds(req.body.variations as Variation[]);
+  }
+
+  if (
+    req.body.type &&
+    req.body.type !== (experiment.type || "standard") &&
+    experiment.status !== "draft" &&
+    req.body.status !== "draft"
+  ) {
+    throw new Error("Can only convert experiment types while in draft mode.");
+  }
+
+  const updatedExperiment = await updateExperimentToDb({
+    context: req.context,
+    experiment: experiment,
+    changes: updateExperimentApiPayloadToInterface(
+      req.body,
+      experiment,
+      map,
+      req.organization
+    ),
+  });
+
+  if (updatedExperiment === null) {
+    throw new Error("Error happened during updating experiment.");
+  }
+
+  let archivedEvent: "experiment.archive" | "experiment.unarchive" | undefined =
+    undefined;
+  if (!experiment.archived && updatedExperiment.archived) {
+    archivedEvent = "experiment.archive";
+  } else if (experiment.archived && !updatedExperiment.archived) {
+    archivedEvent = "experiment.unarchive";
+  }
+
+  const auditDetails: string = auditDetailsUpdate(
+    experiment,
+    updatedExperiment,
+    {}
+  );
+
+  if (archivedEvent !== undefined) {
+    await req.audit({
+      event: archivedEvent,
+      entity: {
+        object: "experiment",
+        id: experiment.id,
+      },
+      details: auditDetails,
+    });
+  }
+
+  // would be great to only emit this when something other then archived status changes
+  await req.audit({
+    event: "experiment.update",
+    entity: {
+      object: "experiment",
+      id: experiment.id,
+    },
+    details: auditDetails,
+  });
+
+  const apiExperiment = await toExperimentApiInterface(
+    req.context,
+    updatedExperiment
+  );
+  return {
+    experiment: apiExperiment,
+  };
+});

--- a/packages/back-end/src/api/metrics/deleteMetric.ts
+++ b/packages/back-end/src/api/metrics/deleteMetric.ts
@@ -5,6 +5,7 @@ import {
   deleteMetricById,
 } from "back-end/src/models/MetricModel";
 import { DeleteMetricResponse } from "back-end/types/openapi";
+import { auditDetailsDelete } from "back-end/src/services/audit";
 
 export const deleteMetricHandler = createApiRequestHandler(getMetricValidator)(
   async (req): Promise<DeleteMetricResponse> => {
@@ -19,6 +20,15 @@ export const deleteMetricHandler = createApiRequestHandler(getMetricValidator)(
     }
 
     await deleteMetricById(req.context, metric);
+
+    await req.audit({
+      event: "metric.delete",
+      entity: {
+        object: "metric",
+        id: req.params.id,
+      },
+      details: auditDetailsDelete(metric, {}),
+    });
 
     return {
       deletedId: req.params.id,

--- a/packages/back-end/src/api/metrics/postMetric.ts
+++ b/packages/back-end/src/api/metrics/postMetric.ts
@@ -1,12 +1,12 @@
 import { PostMetricResponse } from "back-end/types/openapi";
 import { createApiRequestHandler } from "back-end/src/util/handler";
-import { postMetricValidator } from "back-end/src/validators/openapi";
 import {
   createMetric,
   postMetricApiPayloadIsValid,
   postMetricApiPayloadToMetricInterface,
   toMetricApiInterface,
 } from "back-end/src/services/experiments";
+import { auditDetailsCreate } from "back-end/src/services/audit";
 import { getDataSourceById } from "back-end/src/models/DataSourceModel";
 
 export const postMetric = createApiRequestHandler(postMetricValidator)(
@@ -38,6 +38,15 @@ export const postMetric = createApiRequestHandler(postMetricValidator)(
     }
 
     const createdMetric = await createMetric(metric);
+
+    await req.audit({
+      event: "metric.create",
+      entity: {
+        object: "metric",
+        id: createdMetric.id,
+      },
+      details: auditDetailsCreate(metric, {}),
+    });
 
     return {
       metric: toMetricApiInterface(req.organization, createdMetric, datasource),

--- a/packages/back-end/src/api/metrics/putMetric.ts
+++ b/packages/back-end/src/api/metrics/putMetric.ts
@@ -1,7 +1,8 @@
+import { putMetricValidator } from "back-end/src/validators/openapi";
+import { auditDetailsUpdate } from "back-end/src/services/audit";
 import { createApiRequestHandler } from "back-end/src/util/handler";
 import { getMetricById, updateMetric } from "back-end/src/models/MetricModel";
 import { PutMetricResponse } from "back-end/types/openapi";
-import { putMetricValidator } from "back-end/src/validators/openapi";
 import {
   putMetricApiPayloadIsValid,
   putMetricApiPayloadToMetricInterface,
@@ -32,6 +33,17 @@ export const putMetric = createApiRequestHandler(putMetricValidator)(
     }
 
     await updateMetric(req.context, metric, updated);
+
+    if (updated.id !== undefined) {
+      await req.audit({
+        event: "metric.update",
+        entity: {
+          object: "metric",
+          id: updated.id,
+        },
+        details: auditDetailsUpdate(metric, updated, {}),
+      });
+    }
 
     return {
       updatedId: req.params.id,

--- a/packages/back-end/src/services/audit.ts
+++ b/packages/back-end/src/services/audit.ts
@@ -67,33 +67,52 @@ export async function getRecentWatchedAudits(
   return all;
 }
 
+const sortKeysReplacer = (_: never, value: unknown) =>
+  value instanceof Object && !(value instanceof Array)
+    ? Object.keys(value)
+        .sort()
+        .reduce((sorted: Record<string, unknown>, key) => {
+          sorted[key] = (value as Record<string, unknown>)[key];
+          return sorted;
+        }, {})
+    : value;
+
 export function auditDetailsCreate<T>(
   post: T,
   context: Record<string, unknown> = {}
 ): string {
-  return JSON.stringify({
-    post,
-    context,
-  });
+  return JSON.stringify(
+    {
+      post,
+      context,
+    },
+    sortKeysReplacer
+  );
 }
 export function auditDetailsUpdate<T>(
   pre: T,
   post: T,
   context: Record<string, unknown> = {}
 ): string {
-  return JSON.stringify({
-    pre,
-    post,
-    context,
-  });
+  return JSON.stringify(
+    {
+      pre,
+      post,
+      context,
+    },
+    sortKeysReplacer
+  );
 }
 
 export function auditDetailsDelete<T>(
   pre: T,
   context: Record<string, unknown> = {}
 ): string {
-  return JSON.stringify({
-    pre,
-    context,
-  });
+  return JSON.stringify(
+    {
+      pre,
+      context,
+    },
+    sortKeysReplacer
+  );
 }


### PR DESCRIPTION
### Features and Changes
Adds audits for metrics & experiments created & updated via API.

I also included a custom replacer thats passed to `JSON.stringify()` when creating any audits, as ordering of keys and list items would sometimes change and make the audits harder to parse.

### Screenshots
![Screenshot 2024-08-05 at 4 12 08 PM](https://github.com/user-attachments/assets/e9719682-c84d-462d-81a0-792b98daf532)
![Screenshot 2024-08-05 at 4 12 24 PM](https://github.com/user-attachments/assets/6f123f2e-2b18-48b9-8c87-24090015385c)
![Screenshot 2024-08-05 at 4 12 31 PM](https://github.com/user-attachments/assets/88a59aeb-789d-495e-bc7b-3a1079419336)

