### PR TITLE
Fix seat info in admin summary

### DIFF
--- a/packages/front-end/pages/admin.tsx
+++ b/packages/front-end/pages/admin.tsx
@@ -31,6 +31,7 @@ import ControlledTabs from "@/components/Tabs/ControlledTabs";
 import Tab from "@/components/Tabs/Tab";
 import Modal from "@/components/Modal";
 import Toggle from "@/components/Forms/Toggle";
+import LoadingSpinner from "@/components/LoadingSpinner";
 
 interface memberOrgProps {
   id: string;
@@ -249,41 +250,62 @@ function OrganizationRow({
                   {organization.invites.length}
                 </div>
               </div>
-              <div className="row">
-                <div className="col-2 text-right">Subscription:</div>
-                <div className="col-auto font-weight-bold">
-                  {organization?.subscription?.planNickname
-                    ? organization?.subscription?.planNickname +
-                      " (" +
-                      organization?.subscription?.status +
-                      ")"
-                    : "none"}
-                </div>
-              </div>
-              <div className="row">
-                <div className="col-2 text-right">Seats on subscription:</div>
-                <div className="col-auto font-weight-bold">
-                  {organization?.subscription?.qty &&
-                  organization?.subscription?.status === "active"
-                    ? organization.subscription.qty
-                    : ""}
-                  {organization?.freeSeats
-                    ? ` (${organization.freeSeats} free seats)`
-                    : ""}
-                </div>
-              </div>
-              <div className="row">
-                <div className="col-2 text-right">Enterprise (legacy):</div>
-                <div className="col-auto font-weight-bold">
-                  {organization?.enterprise ? "yes" : "no"}
-                </div>
-              </div>
-              <div className="row">
-                <div className="col-2 text-right">License Key:</div>
-                <div className="col-auto font-weight-bold">
-                  {organization?.licenseKey ? organization.licenseKey : "-"}
-                </div>
-              </div>
+              {isCloud() && (
+                <>
+                  <div className="row">
+                    <div className="col-2 text-right">
+                      Subscription (legacy):
+                    </div>
+                    <div className="col-auto font-weight-bold">
+                      {organization?.subscription?.planNickname
+                        ? organization?.subscription?.planNickname +
+                          " (" +
+                          organization?.subscription?.status +
+                          ")"
+                        : "none"}
+                    </div>
+                  </div>
+                  <div className="row">
+                    <div className="col-2 text-right">Enterprise (legacy):</div>
+                    <div className="col-auto font-weight-bold">
+                      {organization?.enterprise ? "yes" : "no"}
+                    </div>
+                  </div>
+                  <div className="row">
+                    <div className="col-2 text-right">License Key:</div>
+                    <div className="col-auto font-weight-bold">
+                      {organization?.licenseKey ? organization.licenseKey : "-"}
+                    </div>
+                  </div>
+                  {((license ||
+                    licenseLoading ||
+                    organization?.subscription?.status === "active") && (
+                    <div className="row">
+                      <div className="col-2 text-right">Seats</div>
+                      <div className="col-auto font-weight-bold">
+                        {licenseLoading && <LoadingSpinner />}
+                        {license && license.seats}
+                        {!licenseLoading && !license && (
+                          <>
+                            {organization?.subscription?.qty &&
+                            organization?.subscription?.status === "active"
+                              ? organization.subscription.qty
+                              : ""}
+                          </>
+                        )}
+                      </div>
+                    </div>
+                  )) || // Only show free seats if they are on a free plan, ie. there is no license, no subscription, nor are they on a legacy enterprise
+                    (!organization?.enterprise && (
+                      <div className="row">
+                        <div className="col-2 text-right">Free Seats:</div>
+                        <div className="col-auto font-weight-bold">
+                          {organization?.freeSeats ?? 3}
+                        </div>
+                      </div>
+                    ))}
+                </>
+              )}
             </div>
             <div className="mb-3">
               <Collapsible


### PR DESCRIPTION
### Features and Changes

- Only show licensing info for Cloud (self hosted has license info at the top of the page and applies to all orgs in a multi-org installation)
- Only show free seats info when they are on a free license (which is the only time it comes into play)
- Shows seats based upon the license (falls back to the legacy subscription if it exists).

### Testing

In `.env/local` set: `IS_CLOUD=true`
In Mongo set an org to have a licenseKey.
Load /admin
Open up that orgs extra info
See that it shows the seats based upon what's on the license.

In Mongo remove the licenseKey
Load /admin
Open up that orgs extra info
See that it shows 3 free seats

In Mongo set `freeSeats: 5`
Load /admin
Open up that orgs extra info
See it says 5 free seats

In Mongo set `enterprise: true`
Load /admin
Open up that orgs extra info
See that it shows enterprise as true
See that it doesn't show free seat info
