### PR TITLE
Replace Mongoose with Mongo driver for ExperimentModel reads

### DIFF
--- a/packages/back-end/src/models/ExperimentModel.ts
+++ b/packages/back-end/src/models/ExperimentModel.ts
@@ -548,7 +548,7 @@ export async function getExperimentsToUpdateLegacy(
       organization: true,
     })
     .limit(100)
-    .sort({ lastSnapshotAttempt: 1 })
+    .sort({ nextSnapshotAttempt: 1 })
     .toArray();
 
   return experiments.map((exp) => ({

--- a/packages/back-end/test/models/VisualChangesetModel.test.ts
+++ b/packages/back-end/test/models/VisualChangesetModel.test.ts
@@ -2,9 +2,11 @@ import {
   VisualChangesetModel,
   updateVisualChangeset,
 } from "../../src/models/VisualChangesetModel";
-import { ExperimentModel } from "../../src/models/ExperimentModel";
 import { ReqContext } from "../../types/organization";
 import { VisualChangesetInterface } from "../../types/visual-changeset";
+import { getCollection } from "../../src/util/mongo.util";
+
+jest.mock("../../src/util/mongo.util");
 
 describe("updateVisualChangeset", () => {
   const context: ReqContext = {
@@ -22,6 +24,10 @@ describe("updateVisualChangeset", () => {
       variations: [],
     }),
   };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
 
   describe("when a visual changeset has existing visual changes", () => {
     const visualChangeset: VisualChangesetInterface = {
@@ -107,8 +113,12 @@ describe("updateVisualChangeset", () => {
           upsertedCount: 0,
           upsertedId: null,
         });
-      jest.spyOn(ExperimentModel, "findOne").mockResolvedValue(null);
+
       it("should overwrite the existing visual changes with new changes", async () => {
+        (getCollection as jest.Mock).mockReturnValue({
+          findOne: jest.fn().mockResolvedValue(null),
+        });
+
         await updateVisualChangeset({
           visualChangeset,
           // @ts-expect-error TODO


### PR DESCRIPTION
### Features and Changes

Switch `ExperimentModel` to use the native MongoDB driver instead of Mongoose for reading

### Testing
Hit localhost:3000/experiments and then in dev console looked at the network call to experiments to get the bearer token and the org id.
Ran 
```
curl 'http://localhost:3100/experiments?project=&includeArchived=' \
  -H 'Authorization: Bearer TOKEN_COPIED_FROM_BROWSER \
  -H 'X-Organization: ORG_ID_COPIED_FROM_BROWSER'  > before.out
```
applied the change and ran it again piping it to > after.out.
Then did `diff before.out after.out` and saw it return nothing.
Ran 
```
wrk -t1 -c1 -d30s \
  -H 'Authorization: Bearer TOKEN_COPIED_FROM_BROWSER \
  -H 'X-Organization: ORG_ID_COPIED_FROM_BROWSER' \
  'http://localhost:3100/experiments?project=&includeArchived=' 
```
saw before:
```
Running 30s test @ http://localhost:3100/experiments?project=&includeArchived=
  1 threads and 1 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   232.43ms   34.13ms 567.02ms   96.15%
    Req/Sec     3.86      0.69     5.00     56.59%
  129 requests in 30.03s, 371.06MB read
Requests/sec:      4.30
Transfer/sec:     12.36MB
```
Saw after:
```
Running 30s test @ http://localhost:3100/experiments?project=&includeArchived=
  1 threads and 1 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   133.59ms   24.64ms 377.91ms   89.38%
    Req/Sec     7.91      2.64    10.00     68.44%
  225 requests in 30.02s, 647.20MB read
Requests/sec:      7.50
Transfer/sec:     21.56MB
```

Create a new experiment in the UI and see it succeed and go to the new experiment page.
