### PR TITLE
Fix setting metrics bug on update experiment via API

### DIFF
--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -2037,7 +2037,7 @@ export function updateExperimentApiPayloadToInterface(
     ...(tags ? { tags } : {}),
     ...(description !== undefined ? { description } : {}),
     ...(hypothesis !== undefined ? { hypothesis } : {}),
-    ...(metrics ? { metrics } : {}),
+    ...(metrics ? { goalMetrics: metrics } : {}),
     ...(guardrailMetrics ? { guardrails: guardrailMetrics } : {}),
     ...(archived !== undefined ? { archived } : {}),
     ...(status ? { status } : {}),

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -2025,6 +2025,7 @@ export function updateExperimentApiPayloadToInterface(
     attributionModel,
     statsEngine,
     regressionAdjustmentEnabled,
+    secondaryMetrics,
   } = payload;
   return {
     ...(trackingKey ? { trackingKey } : {}),
@@ -2038,7 +2039,8 @@ export function updateExperimentApiPayloadToInterface(
     ...(description !== undefined ? { description } : {}),
     ...(hypothesis !== undefined ? { hypothesis } : {}),
     ...(metrics ? { goalMetrics: metrics } : {}),
-    ...(guardrailMetrics ? { guardrails: guardrailMetrics } : {}),
+    ...(guardrailMetrics ? { guardrailMetrics } : {}),
+    ...(secondaryMetrics ? { secondaryMetrics } : {}),
     ...(archived !== undefined ? { archived } : {}),
     ...(status ? { status } : {}),
     ...(releasedVariationId !== undefined ? { releasedVariationId } : {}),


### PR DESCRIPTION
### Features and Changes
It looks like in #2620 `updateExperimentApiPayloadToInterface` wasn't updated to map `metrics` to `goalMetrics`, which was causing `updateExperiment` to succeed (and update the experiment's `metrics` field, but not `goalMetrics`) which is what's actually used now when generating a new results snapshot.

This change fixes this so experiment metrics can be updated via API.