### PR TITLE
Use a set to keep track of metric ids for perf gains

### DIFF
--- a/packages/back-end/src/models/MetricModel.ts
+++ b/packages/back-end/src/models/MetricModel.ts
@@ -230,6 +230,7 @@ async function findMetrics(
   additionalQuery?: Partial<MetricInterface>
 ) {
   const metrics: MetricInterface[] = [];
+  const metricIds = new Set<string>();
 
   // If using config.yml, first check there
   if (usingFileConfig()) {
@@ -250,6 +251,7 @@ async function findMetrics(
       .filter((m) => !filter || filter(m))
       .forEach((m) => {
         metrics.push(m);
+        metricIds.add(m.id);
       });
 
     // If metrics are locked down to just a config file, return immediately
@@ -272,10 +274,11 @@ async function findMetrics(
     )
     .toArray();
   docs.forEach((doc) => {
-    if (metrics.some((m) => m.id === doc.id)) {
+    if (metricIds.has(doc.id)) {
       return;
     }
     metrics.push(toInterface(doc));
+    metricIds.add(doc.id);
   });
 
   return metrics.filter((m) =>


### PR DESCRIPTION
### Features and Changes
Speeds up organization/definitions route for orgs with a lot of metrics by looking up the metrics in O(1) time.

### Testing

Ran 
```
curl 'http://localhost:3100/organization/definitions' \
  -H 'Authorization: Bearer TOKEN_COPIED_FROM_BROWSER \
  -H 'X-Organization: ORG_ID_COPIED_FROM_BROWSER'  > before.out
```
applied the change and ran it again piping it to > after.out.
Then did `diff before.out after.out` and saw it return nothing.

Then did some benchmarking:
```
wrk -t1 -c1 -d30s \
  -H 'Authorization: Bearer COPIED FROM BROWSER REQUEST' \
  -H 'X-Organization: COPIED FROM BROWSER REQUEST' \
'http://localhost:3100/organization/definitions'
```

**Before**:
```
Running 30s test @ http://localhost:3100/organization/definitions
  1 threads and 1 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   425.98ms   59.91ms 778.62ms   94.29%
    Req/Sec     1.86      0.43     3.00     80.00%
  70 requests in 30.03s, 544.66MB read
Requests/sec:      2.33
Transfer/sec:     18.14MB
```

**Using MetricId sets**:
```
Running 30s test @ http://localhost:3100/organization/definitions
  1 threads and 1 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   327.55ms   77.21ms 576.97ms   90.00%
    Req/Sec     2.77      0.86     5.00     86.67%
  30 requests in 30.03s, 233.43MB read
  Socket errors: connect 0, read 75314, write 5356, timeout 0
Requests/sec:      1.00
Transfer/sec:      7.77MB
```
