### PR TITLE
temp rollouts will change coverage to 100%. warn in ui

### DIFF
--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -1248,6 +1248,7 @@ export async function postExperimentStop(
     phases[phases.length - 1] = {
       ...phases[phases.length - 1],
       dateEnded: dateEnded ? getValidDate(dateEnded + ":00Z") : new Date(),
+      coverage: !excludeFromPayload ? 1 : phases[phases.length - 1].coverage,
       reason,
     };
     changes.phases = phases;

--- a/packages/front-end/components/Experiment/StopExperimentForm.tsx
+++ b/packages/front-end/components/Experiment/StopExperimentForm.tsx
@@ -5,6 +5,7 @@ import {
 } from "back-end/types/experiment";
 import { useForm } from "react-hook-form";
 import { experimentHasLinkedChanges } from "shared/util";
+import { FaExclamationTriangle } from "react-icons/fa";
 import { useAuth } from "@/services/auth";
 import track from "@/services/track";
 import SelectField from "@/components/Forms/SelectField";
@@ -22,6 +23,15 @@ const StopExperimentForm: FC<{
   const isStopped = experiment.status === "stopped";
 
   const hasLinkedChanges = experimentHasLinkedChanges(experiment);
+
+  const phases = experiment.phases || [];
+  const lastPhaseIndex = phases.length - 1;
+  const lastPhase = phases[lastPhaseIndex];
+
+  const percentFormatter = new Intl.NumberFormat(undefined, {
+    style: "percent",
+    maximumFractionDigits: 2,
+  });
 
   const form = useForm({
     defaultValues: {
@@ -181,6 +191,18 @@ const StopExperimentForm: FC<{
               </small>
             </div>
           </div>
+
+          {(lastPhase?.coverage ?? 1) < 1 ? (
+            <div className="alert alert-warning">
+              <FaExclamationTriangle className="mr-1" />
+              Currently only{" "}
+              <strong>{percentFormatter.format(lastPhase.coverage)}</strong> of
+              traffic is directed at this experiment. Upon rollout,{" "}
+              <strong>100%</strong> of traffic will be directed towards the
+              released variation.
+            </div>
+          ) : null}
+
           {!form.watch("excludeFromPayload") ? (
             <div className="row">
               <SelectField

--- a/packages/front-end/components/Experiment/StopExperimentForm.tsx
+++ b/packages/front-end/components/Experiment/StopExperimentForm.tsx
@@ -192,7 +192,8 @@ const StopExperimentForm: FC<{
             </div>
           </div>
 
-          {(lastPhase?.coverage ?? 1) < 1 ? (
+          {!form.watch("excludeFromPayload") &&
+          (lastPhase?.coverage ?? 1) < 1 ? (
             <div className="alert alert-warning">
               <FaExclamationTriangle className="mr-1" />
               Currently only{" "}


### PR DESCRIPTION
### Features and Changes

There is a bug that causes variation hopping when using a temp rollout on experiment with coverage < 100%. Make all temp rollouts set coverage to 100 and inform the user in the UI to resolve this.

<img width="702" alt="image" src="https://github.com/user-attachments/assets/7858c941-f3ca-4c15-891a-d50475bdf3fe">


### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

<!--
  Please describe how to test these changes.
 -->

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
