### PR TITLE
hotfix: always show the disable toggle if something is hidden, fix rule render

### DIFF
--- a/packages/front-end/components/Features/RuleList.tsx
+++ b/packages/front-end/components/Features/RuleList.tsx
@@ -71,19 +71,13 @@ export default function RuleList({
   );
 
   const disabledRules = items.filter((r) => isRuleDisabled(r, experimentsMap));
-  const showInactiveToggle = items.length > 3 && disabledRules.length;
+  const showInactiveToggle =
+    (items.length > 3 && disabledRules.length) || hideDisabled;
 
   if (!items.length) {
     return (
       <div className="px-3 mb-3">
         <em>None</em>
-      </div>
-    );
-  }
-  if (disabledRules.length === items.length && hideDisabled) {
-    return (
-      <div className="px-3 mb-3">
-        <em>No Active Rules</em>
       </div>
     );
   }
@@ -168,6 +162,11 @@ export default function RuleList({
           </label>
         </div>
       ) : null}
+      {disabledRules.length === items.length && hideDisabled && (
+        <div className="px-3 mb-3">
+          <em>No Active Rules</em>
+        </div>
+      )}
       <SortableContext items={items} strategy={verticalListSortingStrategy}>
         {items.map(({ ...rule }, i) => (
           <SortableRule


### PR DESCRIPTION

### Features and Changes

Reliance on localstorage based on when the user was last viewing the page is dangerous. It can get out of sync with the actual rules present on page. Another user can cause the magic disabled rule number to go back and forth past the 3 threshold, which would soft-lock the rule view for the original user.

Needed an escape hatch (and remove early render exits) to untoggle if toggled.

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

<!--
  Please describe how to test these changes.
 -->

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
