### PR TITLE
treat pending review linked FFs the same as draft

### DIFF
--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -2207,7 +2207,7 @@ export async function getLinkedFeatureInfo(
 
     const draftMatches =
       revisions
-        .filter((r) => r.status === "draft")
+        .filter((r) => r.status === "draft" || r.status === "pending-review")
         .map((r) => getMatchingRules(feature, filter, environments, r))
         .filter((matches) => matches.length > 0)[0] || [];
 

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -22,6 +22,7 @@ import {
   MatchingRule,
   validateCondition,
   isDefined,
+  DRAFT_REVISION_STATUSES,
 } from "shared/util";
 import {
   ExperimentMetricInterface,
@@ -2207,7 +2208,7 @@ export async function getLinkedFeatureInfo(
 
     const draftMatches =
       revisions
-        .filter((r) => r.status === "draft" || r.status === "pending-review")
+        .filter((r) => DRAFT_REVISION_STATUSES.includes(r.status))
         .map((r) => getMatchingRules(feature, filter, environments, r))
         .filter((matches) => matches.length > 0)[0] || [];
 

--- a/packages/shared/src/util/features.ts
+++ b/packages/shared/src/util/features.ts
@@ -25,6 +25,13 @@ import { ApiFeature } from "back-end/types/openapi";
 import { getValidDate } from "../dates";
 import { getMatchingRules, includeExperimentInPayload, isDefined } from ".";
 
+export const DRAFT_REVISION_STATUSES = [
+  "draft",
+  "approved",
+  "changes-requested",
+  "pending-review",
+];
+
 export function getValidation(feature: FeatureInterface) {
   try {
     if (!feature?.jsonSchema) {


### PR DESCRIPTION
### Features and Changes

Hotfix: the linked features module on an experiment page was failing to include any newly added feature flag, because that change would put the flag into "pending-review" status, leading to a very confusing UX. The linkage only worked for "draft" status flags.

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

<!--
  Please describe how to test these changes.
 -->

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
