### PR TITLE
Speed up most requests by a few ms by omitting omit

### DIFF
--- a/packages/back-end/src/util/mongo.util.ts
+++ b/packages/back-end/src/util/mongo.util.ts
@@ -148,7 +148,7 @@ export function removeMongooseFields<T>(
   }
 
   // Copy the object and delete mongoose fields rather than using lodash.omit for perf reasons since this is called a lot
-  const result = { ...doc } as MongooseDocument & T;
+  const result = { ...doc } as T & { _id?: string; __v?: unknown };
   delete result._id;
   delete result.__v;
   return result;

--- a/packages/back-end/src/util/mongo.util.ts
+++ b/packages/back-end/src/util/mongo.util.ts
@@ -147,10 +147,11 @@ export function removeMongooseFields<T>(
     doc = doc.toJSON({ flattenMaps: true });
   }
 
-  // Delete mongoose fields rather than using lodash.omit for perf reasons since this is called a lot
-  delete doc._id;
-  delete doc.__v;
-  return doc as T;
+  // Copy the object and delete mongoose fields rather than using lodash.omit for perf reasons since this is called a lot
+  const result = { ...doc } as MongooseDocument & T;
+  delete result._id;
+  delete result.__v;
+  return result;
 }
 
 export function getCollection(name: string) {

--- a/packages/back-end/src/util/mongo.util.ts
+++ b/packages/back-end/src/util/mongo.util.ts
@@ -146,6 +146,8 @@ export function removeMongooseFields<T>(
   if (doc.toJSON) {
     doc = doc.toJSON({ flattenMaps: true });
   }
+
+  // Delete mongoose fields rather than using lodash.omit for perf reasons since this is called a lot
   delete doc._id;
   delete doc.__v;
   return doc as T;

--- a/packages/back-end/src/util/mongo.util.ts
+++ b/packages/back-end/src/util/mongo.util.ts
@@ -1,4 +1,3 @@
-import { omit } from "lodash";
 import type { Document } from "mongodb";
 import type { Document as MongooseDocument } from "mongoose";
 import mongoose from "mongoose";
@@ -147,7 +146,9 @@ export function removeMongooseFields<T>(
   if (doc.toJSON) {
     doc = doc.toJSON({ flattenMaps: true });
   }
-  return omit(doc, ["_id", "__v"]) as T;
+  delete doc._id;
+  delete doc.__v;
+  return doc as T;
 }
 
 export function getCollection(name: string) {


### PR DESCRIPTION
### Features and Changes
This replaces `lodash.omit` with just using `delete` in `removeMongooseFields`.  

This perf improvement is arguably barely worth the style change. However we call `removeMongooseFields` once for each doc we process. On the organization/definitions endpoint we seem to call it twice for each metric.  For 6000 metrics it would then get called 12000 times which takes about 37ms on my speedy dev machine.  When I tested on my dev env with 6000 metrics that saved 30ms which is around 12% of the total request time.

### Testing

```
let metric = {
  "_id": {
    "$oid": "665d712b53e63039f9b640c5"
  },
  "id": "met_4posgreilwynj2n6",
  "organization": "org_4posg171hlwgd3d5z",
  "owner": "",
  "datasource": "ds_4posgreilwynj0w0",
  "name": "Retention - [1, 14) Days",
  "description": "Whether the user logged in 1-14 days after experiment exposure",
  "type": "binomial",
  "windowSettings": {
    "type": "conversion",
    "delayHours": 24,
    "windowValue": 13,
    "windowUnit": "days"
  },
  "dateCreated": {
    "$date": "2024-06-03T07:30:51.809Z"
  },
  "dateUpdated": {
    "$date": "2024-06-03T07:30:51.809Z"
  },
  "userIdTypes": [
    "user_id"
  ],
  "userIdColumns": {
    "user_id": "user_id"
  },
  "sql": "SELECT\nuserId AS user_id,\ntimestamp AS timestamp\nFROM pages WHERE path = '/'",
  "tags": [
    "growthbook-demo"
  ],
  "projects": [
    "prj_org_4posg171hlwgd3d5z_demo-datasource-project"
  ],
  "analysis": {
    "histogram": [],
    "dates": []
  },
  "conditions": [],
  "queries": [],
  "__v": 0
};

_lodash = require('lodash');

function r(doc) {
    if (doc.toJSON) {
        doc = doc.toJSON({
            flattenMaps: true
        });
    }
    return (0, _lodash.omit)(doc, [
        "_id",
        "__v"
    ]);
}


function r2(doc) {
    if (doc.toJSON) {
        doc = doc.toJSON({
            flattenMaps: true
        });
    }
    const result = { ... doc };
    delete result._id;
    delete result.__v;
    return result;
}

console.time('r');
for (let i = 0; i < 12000; i++) {
  r(metric);
}
console.timeEnd('r');

console.time('r2');
for (let i = 0; i < 12000; i++) {
  r2(metric);
}
console.timeEnd('r2');
```
Prints out:
```
r: 37.312ms
r2: 8.016ms
```
