### PR TITLE
Add Access URL to Snowflake data source connections

### DIFF
--- a/packages/back-end/src/services/snowflake.ts
+++ b/packages/back-end/src/services/snowflake.ts
@@ -33,6 +33,7 @@ export async function runSnowflakeQuery<T extends Record<string, any>>(
   const account = conn.account.replace(/\.us-west-2$/, "");
   const connection = createConnection({
     account,
+    accessUrl: conn.accessUrl,
     username: conn.username,
     password: conn.password,
     database: conn.database,

--- a/packages/back-end/src/services/snowflake.ts
+++ b/packages/back-end/src/services/snowflake.ts
@@ -31,9 +31,9 @@ export async function runSnowflakeQuery<T extends Record<string, any>>(
 ): Promise<QueryResponse<T[]>> {
   //remove out the .us-west-2 from the account name
   const account = conn.account.replace(/\.us-west-2$/, "");
+
   const connection = createConnection({
     account,
-    accessUrl: conn.accessUrl,
     username: conn.username,
     password: conn.password,
     database: conn.database,
@@ -42,6 +42,7 @@ export async function runSnowflakeQuery<T extends Record<string, any>>(
     role: conn.role,
     ...getProxySettings(),
     application: "GrowthBook_GrowthBook",
+    accessUrl: conn.accessUrl ? conn.accessUrl : undefined,
   });
   // promise with timeout to prevent hanging
   await new Promise((resolve, reject) => {

--- a/packages/back-end/types/integrations/snowflake.d.ts
+++ b/packages/back-end/types/integrations/snowflake.d.ts
@@ -1,5 +1,6 @@
 export interface SnowflakeConnectionParams {
   account: string;
+  accessUrl?: string;
   username: string;
   password: string;
   database: string;

--- a/packages/front-end/components/Settings/ConnectionSettings.tsx
+++ b/packages/front-end/components/Settings/ConnectionSettings.tsx
@@ -148,6 +148,7 @@ export default function ConnectionSettings({
         <SnowflakeForm
           existing={existing}
           onParamChange={onParamChange}
+          onManualParamChange={onManualParamChange}
           params={datasource?.params || {}}
         />
       );

--- a/packages/front-end/components/Settings/SnowflakeForm.tsx
+++ b/packages/front-end/components/Settings/SnowflakeForm.tsx
@@ -9,7 +9,7 @@ const SnowflakeForm: FC<{
   onParamChange: ChangeEventHandler<HTMLInputElement>;
   onManualParamChange: (name: string, value: string) => void;
 }> = ({ params, existing, onParamChange, onManualParamChange }) => {
-  const [useAccessUrl, setUseAccessUrl] = useState(false);
+  const [useAccessUrl, setUseAccessUrl] = useState(!!params.accessUrl);
   return (
     <div className="row">
       <div className="form-group col-md-12">

--- a/packages/front-end/components/Settings/SnowflakeForm.tsx
+++ b/packages/front-end/components/Settings/SnowflakeForm.tsx
@@ -1,12 +1,15 @@
-import { FC, ChangeEventHandler } from "react";
+import { FC, ChangeEventHandler, useState } from "react";
 import { SnowflakeConnectionParams } from "back-end/types/integrations/snowflake";
 import Tooltip from "@/components/Tooltip/Tooltip";
+import Toggle from "@/components/Forms/Toggle";
 
 const SnowflakeForm: FC<{
   params: Partial<SnowflakeConnectionParams>;
   existing: boolean;
   onParamChange: ChangeEventHandler<HTMLInputElement>;
-}> = ({ params, existing, onParamChange }) => {
+  onManualParamChange: (name: string, value: string) => void;
+}> = ({ params, existing, onParamChange, onManualParamChange }) => {
+  const [useAccessUrl, setUseAccessUrl] = useState(false);
   return (
     <div className="row">
       <div className="form-group col-md-12">
@@ -91,19 +94,40 @@ const SnowflakeForm: FC<{
           placeholder=""
         />
       </div>
-      <div className="form-group col-md-12">
-        <label>
-          Access URL (Optional){" "}
-          <Tooltip body="Overrides Account to point GrowthBook at a specific URL" />
-        </label>
-        <input
-          type="text"
-          className="form-control"
-          name="accessUrl"
-          value={params.accessUrl || ""}
-          onChange={onParamChange}
-        />
+      <div className="col-md-12">
+        <div className="form-group">
+          <label htmlFor="access-url" className="mr-2">
+            Use Access URL (Optional)
+          </label>
+          <Toggle
+            id="access-url"
+            label="Use Access URL (Optional)"
+            value={useAccessUrl}
+            setValue={(v) => {
+              setUseAccessUrl(v);
+              if (!v) {
+                onManualParamChange("accessUrl", "");
+              }
+            }}
+          />
+        </div>
       </div>
+      {useAccessUrl ? (
+        <div className="form-group col-md-12">
+          <label>
+            Access URL{" "}
+            <Tooltip body="Overrides Account to point GrowthBook at a specific URL" />
+          </label>
+          <input
+            type="text"
+            className="form-control"
+            name="accessUrl"
+            required
+            value={params.accessUrl || ""}
+            onChange={onParamChange}
+          />
+        </div>
+      ) : null}
     </div>
   );
 };

--- a/packages/front-end/components/Settings/SnowflakeForm.tsx
+++ b/packages/front-end/components/Settings/SnowflakeForm.tsx
@@ -91,6 +91,19 @@ const SnowflakeForm: FC<{
           placeholder=""
         />
       </div>
+      <div className="form-group col-md-12">
+        <label>
+          Access URL (Optional){" "}
+          <Tooltip body="Overrides Account to point GrowthBook at a specific URL" />
+        </label>
+        <input
+          type="text"
+          className="form-control"
+          name="accessUrl"
+          value={params.accessUrl || ""}
+          onChange={onParamChange}
+        />
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
### Features and Changes

Adds optional Access URL specification to Snowflake Data Source form: https://docs.snowflake.com/en/developer-guide/node-js/nodejs-driver-options#additional-connection-options. Uses a toggle because we want it to be undefined for sure if a user doesn't want to use it. If users leave some value in this field by accident it can cause unclear errors.

For advanced configs, this may be helpful; it overrides the `Account` connection method.

### Testing

Can connect to our GrowthBook "SAMPLE" database using this access URL; leaving it unset also works; as does setting and unsetting it.

### Screenshots

![Screenshot 2024-08-16 at 3 19 57 PM](https://github.com/user-attachments/assets/673edb9f-3b83-43a9-90ef-959a1cdc577a)

![Screenshot 2024-08-16 at 3 20 02 PM](https://github.com/user-attachments/assets/99bbbb47-9e0f-4f5d-8b3c-c689d391569f)
