### PR TITLE
Add feature flag for opting orgs out of large saved groups

### DIFF
--- a/packages/front-end/components/SavedGroups/IdListItemInput.tsx
+++ b/packages/front-end/components/SavedGroups/IdListItemInput.tsx
@@ -9,6 +9,7 @@ import {
   FaRetweet,
 } from "react-icons/fa";
 import clsx from "clsx";
+import { useFeatureValue } from "@growthbook/growthbook-react";
 import Field from "@/components/Forms/Field";
 import StringArrayField from "@/components/Forms/StringArrayField";
 import LargeSavedGroupSupportWarning, {
@@ -51,6 +52,10 @@ export const IdListItemInput: FC<{
   );
   const [fileName, setFileName] = useState("");
   const [fileErrorMessage, setFileErrorMessage] = useState("");
+  const orgBypassSmallListSizeLimit = !useFeatureValue(
+    "apply-saved-group-id-list-size-limit",
+    false
+  );
 
   const {
     supportedConnections,
@@ -70,14 +75,24 @@ export const IdListItemInput: FC<{
   const [nonLegacyImport, setNonLegacyImport] = useState(false);
 
   useEffect(() => {
-    if (values.length > limit && !bypassSmallListSizeLimit) {
+    if (
+      values.length > limit &&
+      !bypassSmallListSizeLimit &&
+      !orgBypassSmallListSizeLimit
+    ) {
       setNonLegacyImport(true);
       setPassByReferenceOnly(true);
     } else {
       setNonLegacyImport(false);
       setPassByReferenceOnly(false);
     }
-  }, [values, limit, bypassSmallListSizeLimit, setPassByReferenceOnly]);
+  }, [
+    values,
+    limit,
+    bypassSmallListSizeLimit,
+    orgBypassSmallListSizeLimit,
+    setPassByReferenceOnly,
+  ]);
 
   useEffect(() => {
     if (supportedConnections.length > 0) {
@@ -85,7 +100,8 @@ export const IdListItemInput: FC<{
     } else if (
       nonLegacyImport &&
       !passByReferenceOnly &&
-      !bypassSmallListSizeLimit
+      !bypassSmallListSizeLimit &&
+      !orgBypassSmallListSizeLimit
     ) {
       setDisableSubmit(true);
     } else {
@@ -97,6 +113,7 @@ export const IdListItemInput: FC<{
     nonLegacyImport,
     passByReferenceOnly,
     bypassSmallListSizeLimit,
+    orgBypassSmallListSizeLimit,
   ]);
 
   return (
@@ -136,21 +153,23 @@ export const IdListItemInput: FC<{
           </label>
         </div>
       </div>
-      {!passByReferenceOnly && !bypassSmallListSizeLimit && (
-        <LargeSavedGroupSupportWarning
-          type={
-            groupReferencedByUnsupportedSdks
-              ? "in_use_saved_group"
-              : "saved_group_creation"
-          }
-          openUpgradeModal={openUpgradeModal}
-          hasLargeSavedGroupFeature={hasLargeSavedGroupFeature}
-          supportedConnections={supportedConnections}
-          unsupportedConnections={unsupportedConnections}
-          unversionedConnections={unversionedConnections}
-          upgradeWarningToError={disableSubmit}
-        />
-      )}
+      {!passByReferenceOnly &&
+        !bypassSmallListSizeLimit &&
+        !orgBypassSmallListSizeLimit && (
+          <LargeSavedGroupSupportWarning
+            type={
+              groupReferencedByUnsupportedSdks
+                ? "in_use_saved_group"
+                : "saved_group_creation"
+            }
+            openUpgradeModal={openUpgradeModal}
+            hasLargeSavedGroupFeature={hasLargeSavedGroupFeature}
+            supportedConnections={supportedConnections}
+            unsupportedConnections={unsupportedConnections}
+            unversionedConnections={unversionedConnections}
+            upgradeWarningToError={disableSubmit}
+          />
+        )}
       {importMethod === "file" && (
         <>
           <div

--- a/packages/front-end/types/app-features.ts
+++ b/packages/front-end/types/app-features.ts
@@ -43,4 +43,8 @@ export type AppFeatures = {
   "pylon-config": Record<string, unknown>;
   "no-access-role-type": boolean;
   "quantile-metrics": boolean;
+  "new-message": boolean;
+  "show-3.0-release": boolean;
+  "improve-h1-heading-feature-flag": boolean;
+  "apply-saved-group-id-list-size-limit": boolean;
 };


### PR DESCRIPTION
### Features and Changes

Adds a new feature flag for dogfooding the large saved group changes from #2616. The default behavior is to bypass the limits (and use the old, non-performant saved group implementation) if our dogfood feature isn't enabled. The feature will be default-enabled with specific exceptions for organizations as needed until we can add a better flow in the UI for users being able to opt out on their own.

[Dogfooding feature](https://app.growthbook.io/features/apply-saved-group-id-list-size-limit)

### Testing

Running the app locally with at least one unsupported SDK connection (old version or non-JS), the saved group support warning should pop when adding a new ID List. 
After adding a rule to exclude the local organization in the dogfooding feature, the warnings should disappear and >100 items can be imported without a list being marked as PBRO

### Screenshots

![image](https://github.com/user-attachments/assets/b398c23e-7311-4b44-9b2e-316b5ec14cba)
![image](https://github.com/user-attachments/assets/ece7d98d-e11f-493d-a303-7828370c032e)


