### PR TITLE
Fix secureString hashing in saved groups

### DIFF
--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -35,6 +35,7 @@ import {
   SavedGroupsValues,
   SavedGroupInterface,
 } from "shared/src/types";
+import { clone } from "lodash";
 import {
   ApiReqContext,
   AutoExperimentWithProject,
@@ -1222,7 +1223,8 @@ export function applySavedGroupHashing(
   attributes: SDKAttributeSchema,
   salt: string
 ): SavedGroupInterface[] {
-  return savedGroups.map((group) => {
+  const clonedGroups = clone(savedGroups);
+  clonedGroups.forEach((group) => {
     const attribute = attributes.find(
       (attr) => attr.property === group.attributeKey
     );
@@ -1235,8 +1237,8 @@ export function applySavedGroupHashing(
         doHash: attribute.hashAttribute,
       });
     }
-    return group;
   });
+  return clonedGroups;
 }
 
 interface hashStringsArgs {

--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -498,7 +498,6 @@ export type FeatureDefinitionsResponseArgs = {
   projects: string[];
   capabilities: SDKCapability[];
   savedGroups: SavedGroupInterface[];
-  savedGroupAttributeKeys?: Record<string, string>;
   savedGroupReferencesEnabled?: boolean;
   organization: OrganizationInterface;
 };
@@ -516,7 +515,6 @@ async function getFeatureDefinitionsResponse({
   projects,
   capabilities,
   savedGroups,
-  savedGroupAttributeKeys,
   savedGroupReferencesEnabled = false,
   organization,
 }: FeatureDefinitionsResponseArgs) {
@@ -573,10 +571,6 @@ async function getFeatureDefinitionsResponse({
   const hasSecureAttributes = attributes?.some((a) =>
     ["secureString", "secureString[]"].includes(a.datatype)
   );
-  let savedGroupsValues = getSavedGroupsValuesFromInterfaces(
-    savedGroups,
-    organization
-  );
   if (attributes && hasSecureAttributes && secureAttributeSalt !== undefined) {
     features = applyFeatureHashing(features, attributes, secureAttributeSalt);
 
@@ -588,15 +582,17 @@ async function getFeatureDefinitionsResponse({
       );
     }
 
-    if (savedGroupAttributeKeys) {
-      savedGroupsValues = applySavedGroupHashing(
-        savedGroupsValues,
-        attributes,
-        savedGroupAttributeKeys,
-        secureAttributeSalt
-      );
-    }
+    savedGroups = applySavedGroupHashing(
+      savedGroups,
+      attributes,
+      secureAttributeSalt
+    );
   }
+
+  const savedGroupsValues = getSavedGroupsValuesFromInterfaces(
+    savedGroups,
+    organization
+  );
 
   features = scrubFeatures(
     features,
@@ -722,9 +718,6 @@ export async function getFeatureDefinitions({
       }
       let attributes: SDKAttributeSchema | undefined = undefined;
       let secureAttributeSalt: string | undefined = undefined;
-      let savedGroupAttributeKeys:
-        | Record<string, string>
-        | undefined = undefined;
       const { features, experiments, savedGroupsInUse } = cached.contents;
       const usedSavedGroups = await getSavedGroupsById(
         savedGroupsInUse,
@@ -734,12 +727,6 @@ export async function getFeatureDefinitions({
         if (orgHasPremiumFeature(context.org, "hash-secure-attributes")) {
           secureAttributeSalt = context.org.settings?.secureAttributeSalt;
           attributes = context.org.settings?.attributeSchema;
-          savedGroupAttributeKeys = Object.fromEntries(
-            usedSavedGroups.map((savedGroup) => [
-              savedGroup.id,
-              savedGroup.attributeKey || "",
-            ])
-          );
         }
       }
 
@@ -757,7 +744,6 @@ export async function getFeatureDefinitions({
         projects: projects || [],
         capabilities,
         savedGroups: usedSavedGroups || [],
-        savedGroupAttributeKeys,
         savedGroupReferencesEnabled,
         organization: context.org,
       });
@@ -774,7 +760,6 @@ export async function getFeatureDefinitions({
       attributes = context.org.settings?.attributeSchema;
     }
   }
-  let savedGroupAttributeKeys: Record<string, string> | undefined = undefined;
   const savedGroups = await getAllSavedGroups(context.org.id, {
     includeLargeSavedGroupValues: true,
   });
@@ -785,12 +770,6 @@ export async function getFeatureDefinitions({
   ) {
     secureAttributeSalt = context.org?.settings?.secureAttributeSalt;
     attributes = context.org.settings?.attributeSchema;
-    savedGroupAttributeKeys = Object.fromEntries(
-      savedGroups.map((savedGroup) => [
-        savedGroup.id,
-        savedGroup.attributeKey || "",
-      ])
-    );
   }
 
   // Generate the feature definitions
@@ -869,7 +848,6 @@ export async function getFeatureDefinitions({
     projects: projects || [],
     capabilities,
     savedGroups,
-    savedGroupAttributeKeys,
     savedGroupReferencesEnabled,
     organization: context.org,
   });
@@ -1238,32 +1216,27 @@ export function applyExperimentHashing(
   });
 }
 
-// Specific hashing entrypoint for idList values
+// Specific hashing entrypoint for SavedGroup objects
 export function applySavedGroupHashing(
-  savedGroups: SavedGroupsValues,
+  savedGroups: SavedGroupInterface[],
   attributes: SDKAttributeSchema,
-  savedGroupAttributeKeys: Record<string, string>,
   salt: string
-): SavedGroupsValues {
-  return Object.fromEntries(
-    Object.entries(savedGroups).map(([savedGroupId, savedGroupItems]) => {
-      const attribute = attributes.find(
-        (attr) => attr.property === savedGroupAttributeKeys[savedGroupId]
-      );
-      return attribute
-        ? [
-            savedGroupId,
-            hashStrings({
-              obj: savedGroupItems,
-              salt,
-              attributes,
-              attribute,
-              doHash: attribute.hashAttribute,
-            }),
-          ]
-        : [savedGroupId, savedGroupItems];
-    })
-  );
+): SavedGroupInterface[] {
+  return savedGroups.map((group) => {
+    const attribute = attributes.find(
+      (attr) => attr.property === group.attributeKey
+    );
+    if (attribute) {
+      group.values = hashStrings({
+        obj: group.values,
+        salt,
+        attributes,
+        attribute,
+        doHash: attribute.hashAttribute,
+      });
+    }
+    return group;
+  });
 }
 
 interface hashStringsArgs {

--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -502,7 +502,7 @@ export type FeatureDefinitionsResponseArgs = {
   savedGroupReferencesEnabled?: boolean;
   organization: OrganizationInterface;
 };
-async function getFeatureDefinitionsResponse({
+export async function getFeatureDefinitionsResponse({
   features,
   experiments,
   dateUpdated,

--- a/packages/back-end/test/features.test.ts
+++ b/packages/back-end/test/features.test.ts
@@ -1,5 +1,5 @@
 import cloneDeep from "lodash/cloneDeep";
-import { GroupMap } from "shared/src/types";
+import { GroupMap, SavedGroupInterface } from "shared/src/types";
 import {
   getAffectedSDKPayloadKeys,
   getEnabledEnvironments,
@@ -12,9 +12,18 @@ import {
 } from "../src/util/features";
 import { getCurrentEnabledState } from "../src/util/scheduleRules";
 import { FeatureInterface, ScheduleRule } from "../types/feature";
-import { hashStrings } from "../src/services/features";
-import { SDKAttributeSchema } from "../types/organization";
+import {
+  getFeatureDefinitionsResponse,
+  hashStrings,
+  sha256,
+} from "../src/services/features";
+import {
+  OrganizationInterface,
+  SDKAttribute,
+  SDKAttributeSchema,
+} from "../types/organization";
 import { ExperimentInterface } from "../types/experiment";
+import { FeatureDefinitionWithProject } from "../types/api";
 
 const groupMap: GroupMap = new Map();
 const experimentMap = new Map();
@@ -40,6 +49,16 @@ const baseFeature: FeatureInterface = {
       rules: [],
     },
   },
+};
+
+const baseOrganization: OrganizationInterface = {
+  id: "123",
+  url: "foo",
+  dateCreated: new Date(),
+  name: "",
+  ownerEmail: "",
+  members: [],
+  invites: [],
 };
 
 describe("getParsedCondition", () => {
@@ -1441,6 +1460,102 @@ describe("SDK Payloads", () => {
           key: "testing",
         },
       ],
+    });
+  });
+
+  describe("Saved Groups", () => {
+    const secureStringAttr: SDKAttribute = {
+      property: "id",
+      datatype: "secureString",
+      hashAttribute: true,
+    };
+    const groupDef: SavedGroupInterface = {
+      id: "groupId",
+      type: "list",
+      attributeKey: "id",
+      values: ["1", "2", "3"],
+      organization: "123",
+      groupName: "",
+      owner: "",
+      dateCreated: new Date(),
+      dateUpdated: new Date(),
+    };
+    const featureDef: FeatureDefinitionWithProject = {
+      defaultValue: true,
+      rules: [
+        {
+          id: "1",
+          condition: {
+            id: {
+              $inGroup: "groupId",
+            },
+          },
+          force: false,
+        },
+      ],
+    };
+
+    it("Hashes secure attributes in inline saved groups", async () => {
+      const { features, savedGroups } = await getFeatureDefinitionsResponse({
+        features: { featureName: cloneDeep(featureDef) },
+        experiments: [],
+        dateUpdated: new Date(),
+        projects: [],
+        capabilities: [],
+        savedGroups: [cloneDeep(groupDef)],
+        organization: baseOrganization,
+        attributes: [secureStringAttr],
+        secureAttributeSalt: "salt",
+      });
+      expect(features).toEqual({
+        featureName: {
+          defaultValue: true,
+          rules: [
+            {
+              condition: {
+                id: {
+                  $in: ["1", "2", "3"].map((val) => sha256(val, "salt")),
+                },
+              },
+              force: false,
+            },
+          ],
+        },
+      });
+      expect(savedGroups).toEqual(undefined);
+    });
+
+    it("Hashes secure attributes in referenced saved groups", async () => {
+      const { features, savedGroups } = await getFeatureDefinitionsResponse({
+        features: { featureName: cloneDeep(featureDef) },
+        experiments: [],
+        dateUpdated: new Date(),
+        projects: [],
+        capabilities: ["savedGroupReferences"],
+        savedGroupReferencesEnabled: true,
+        savedGroups: [cloneDeep(groupDef)],
+        organization: baseOrganization,
+        attributes: [secureStringAttr],
+        secureAttributeSalt: "salt",
+      });
+      expect(features).toEqual({
+        featureName: {
+          defaultValue: true,
+          rules: [
+            {
+              condition: {
+                id: {
+                  $inGroup: "groupId",
+                },
+              },
+              force: false,
+            },
+          ],
+        },
+      });
+      expect(savedGroups).toEqual({
+        groupId: ["1", "2", "3"].map((val) => sha256(val, "salt")),
+      });
     });
   });
 });

--- a/packages/back-end/test/features.test.ts
+++ b/packages/back-end/test/features.test.ts
@@ -1469,6 +1469,10 @@ describe("SDK Payloads", () => {
       datatype: "secureString",
       hashAttribute: true,
     };
+    const organization = cloneDeep(baseOrganization);
+    organization.settings = {
+      attributeSchema: [secureStringAttr],
+    };
     const groupDef: SavedGroupInterface = {
       id: "groupId",
       type: "list",
@@ -1503,7 +1507,7 @@ describe("SDK Payloads", () => {
         projects: [],
         capabilities: [],
         savedGroups: [cloneDeep(groupDef)],
-        organization: baseOrganization,
+        organization: organization,
         attributes: [secureStringAttr],
         secureAttributeSalt: "salt",
       });
@@ -1534,7 +1538,7 @@ describe("SDK Payloads", () => {
         capabilities: ["savedGroupReferences"],
         savedGroupReferencesEnabled: true,
         savedGroups: [cloneDeep(groupDef)],
-        organization: baseOrganization,
+        organization: organization,
         attributes: [secureStringAttr],
         secureAttributeSalt: "salt",
       });


### PR DESCRIPTION
### Features and Changes

Fixes a bug where saved groups of secureString attributes stopped hashing the contents sometime in the last week.



### Testing

Added a unit test which fails on main (`git checkout main && git cherry-pick 9d92b11a5 && yarn run test`) but passes with the fix
Manually tested with the sdk feature enabled and disabled

### Screenshots

Hashing in referenced groups (some plain strings as well)
![image](https://github.com/user-attachments/assets/beceb312-de2f-4bb0-8daa-56b98ade7552)

Hashing in inline groups
![image](https://github.com/user-attachments/assets/5ca2d7c5-cfc8-4962-a9d6-231e97b43a92)
