### PR TITLE
Add link to info about SRM warnings with URL Redirects to Troubleshooting Experiments page

### DIFF
--- a/docs/docs/kb/experiments/troubleshooting-experiments.mdx
+++ b/docs/docs/kb/experiments/troubleshooting-experiments.mdx
@@ -82,7 +82,7 @@ If your experiment is suffering from these issues, unfortunately the only soluti
 
 ### Solution 5 (URL Redirects): Ensure Tracking Callback fires
 
-If you're seeing SRM warnings while running a URL Redirect test, especially if you are using a front-end SDK such as the HTML, JavaScript, React or Vue.js SDKs, please review the [Sample Ratio Mismatch (SRM) Warnings on URL Redirect Tests](https://docs.growthbook.io/app/url-redirects#sample-ratio-mismatch-srm-warnings-url-redirect-tests) documentation.
+If you're seeing SRM warnings while running a URL Redirect test, especially if you are using a front-end SDK such as the HTML, JavaScript, React or Vue.js SDKs, please review the [Sample Ratio Mismatch (SRM) Warnings on URL Redirect Tests](https://docs.growthbook.io/app/url-redirects#sample-ratio-mismatch-srm-warnings-on-url-redirect-tests) documentation.
 
 ## Problem 3: Multiple Exposures
 

--- a/docs/docs/kb/experiments/troubleshooting-experiments.mdx
+++ b/docs/docs/kb/experiments/troubleshooting-experiments.mdx
@@ -80,6 +80,10 @@ You can read more about the [rules for changing experiment targeting](/app/makin
 
 If your experiment is suffering from these issues, unfortunately the only solution may be to restart the experiment (you can do this by creating a new phase and choosing to re-randomize traffic). Of course, some amount of bias and SRM may be preferable to throwing out your data, but this depends on the magnitude of the problem.
 
+### Solution 5 (URL Redirects): Ensure Tracking Callback fires
+
+If you're seeing SRM warnings while running a URL Redirect test, especially if you are using a front-end SDK such as the HTML, JavaScript, React or Vue.js SDKs, please review the [Sample Ratio Mismatch (SRM) Warnings on URL Redirect Tests](https://docs.growthbook.io/app/url-redirects#sample-ratio-mismatch-srm-warnings-url-redirect-tests) documentation.
+
 ## Problem 3: Multiple Exposures
 
 We default to allowing 1 percent of units (e.g. users) in an experiment have multiple exposures without raising a warning due to the fact that many experimenters have slight mismatches in hashing attributes and warehouse tracking that can cause minor errors. You can adjust this in your organization settings under Settings > General > Experiment Settings.


### PR DESCRIPTION
### Features and Changes

Adds a 5th Solution to the "Troubleshooting Experiments" doc under the "Problem 1: No traffic flowing into the experiment" section, which links out to the new SRM Warnings section of the URL Redirects documentation.