### PR TITLE
Moves Edit Modals to FeaturesHeader

### DIFF
--- a/packages/front-end/components/Features/FeaturesHeader.tsx
+++ b/packages/front-end/components/Features/FeaturesHeader.tsx
@@ -30,6 +30,9 @@ import StaleDetectionModal from "@/components/Features/StaleDetectionModal";
 import { FeatureTab } from "@/pages/features/[fid]";
 import MoreMenu from "@/components/Dropdown/MoreMenu";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
+import EditTagsForm from "@/components/Tags/EditTagsForm";
+import EditProjectForm from "@/components/Experiment/EditProjectForm";
+import EditOwnerModal from "@/components/Owner/EditOwnerModal";
 
 export default function FeaturesHeader({
   feature,
@@ -38,9 +41,6 @@ export default function FeaturesHeader({
   mutate,
   tab,
   setTab,
-  setEditProjectModal,
-  setEditTagsModal,
-  setEditOwnerModal,
   dependents,
 }: {
   feature: FeatureInterface;
@@ -49,9 +49,6 @@ export default function FeaturesHeader({
   mutate: () => void;
   tab: FeatureTab;
   setTab: (tab: FeatureTab) => void;
-  setEditProjectModal: (open: boolean) => void;
-  setEditTagsModal: (open: boolean) => void;
-  setEditOwnerModal: (open: boolean) => void;
   dependents: number;
 }) {
   const router = useRouter();
@@ -61,6 +58,9 @@ export default function FeaturesHeader({
   const [duplicateModal, setDuplicateModal] = useState(false);
   const [staleFFModal, setStaleFFModal] = useState(false);
   const [showImplementation, setShowImplementation] = useState(firstFeature);
+  const [editTagsModal, setEditTagsModal] = useState(false);
+  const [editProjectModal, setEditProjectModal] = useState(false);
+  const [editOwnerModal, setEditOwnerModal] = useState(false);
 
   const { organization } = useUser();
   const permissionsUtil = usePermissionsUtil();
@@ -94,367 +94,430 @@ export default function FeaturesHeader({
   const isArchived = feature.archived;
 
   return (
-    <div>
-      <div className="container-fluid">
-        <div className="features-header bg-white pt-3 px-4 border-bottom">
-          <div className="pagecontents mx-auto px-3">
-            {projectId ===
-              getDemoDatasourceProjectIdForOrganization(organization.id) && (
-              <div className="alert alert-info mb-3 d-flex align-items-center">
-                <div className="flex-1">
-                  This feature is part of our sample dataset and shows how
-                  Feature Flags and Experiments can be linked together. You can
-                  delete this once you are done exploring.
-                </div>
-                <div style={{ width: 180 }} className="ml-2">
-                  <DeleteDemoDatasourceButton
-                    onDelete={() => router.push("/features")}
-                    source="feature"
-                  />
-                </div>
-              </div>
-            )}
-
-            <div className="row align-items-center mb-2">
-              <div className="col-auto d-flex align-items-center">
-                <h1 className="mb-0">{feature.id}</h1>
-                {stale && (
-                  <div className="ml-2">
-                    <StaleFeatureIcon
-                      staleReason={reason}
-                      onClick={() => setStaleFFModal(true)}
+    <>
+      {editTagsModal && (
+        <EditTagsForm
+          tags={feature.tags || []}
+          save={async (tags) => {
+            await apiCall(`/feature/${feature.id}`, {
+              method: "PUT",
+              body: JSON.stringify({ tags }),
+            });
+          }}
+          cancel={() => setEditTagsModal(false)}
+          mutate={mutate}
+        />
+      )}
+      {editProjectModal && (
+        <EditProjectForm
+          label={
+            <>
+              Projects{" "}
+              <Tooltip
+                body={
+                  "The dropdown below has been filtered to only include projects where you have permission to update Features"
+                }
+              />
+            </>
+          }
+          permissionRequired={(project) =>
+            permissionsUtil.canUpdateFeature({ project }, {})
+          }
+          apiEndpoint={`/feature/${feature.id}`}
+          cancel={() => setEditProjectModal(false)}
+          mutate={mutate}
+          method="PUT"
+          current={feature.project}
+          additionalMessage={
+            <div className="alert alert-danger">
+              Changing the project may prevent this Feature Flag and any linked
+              Experiments from being sent to users.
+            </div>
+          }
+        />
+      )}
+      {editOwnerModal && (
+        <EditOwnerModal
+          cancel={() => setEditOwnerModal(false)}
+          owner={feature.owner}
+          save={async (owner) => {
+            await apiCall(`/feature/${feature.id}`, {
+              method: "PUT",
+              body: JSON.stringify({ owner }),
+            });
+          }}
+          mutate={mutate}
+        />
+      )}
+      <div>
+        <div className="container-fluid">
+          <div className="features-header bg-white pt-3 px-4 border-bottom">
+            <div className="pagecontents mx-auto px-3">
+              {projectId ===
+                getDemoDatasourceProjectIdForOrganization(organization.id) && (
+                <div className="alert alert-info mb-3 d-flex align-items-center">
+                  <div className="flex-1">
+                    This feature is part of our sample dataset and shows how
+                    Feature Flags and Experiments can be linked together. You
+                    can delete this once you are done exploring.
+                  </div>
+                  <div style={{ width: 180 }} className="ml-2">
+                    <DeleteDemoDatasourceButton
+                      onDelete={() => router.push("/features")}
+                      source="feature"
                     />
                   </div>
-                )}
+                </div>
+              )}
+
+              <div className="row align-items-center mb-2">
+                <div className="col-auto d-flex align-items-center">
+                  <h1 className="mb-0">{feature.id}</h1>
+                  {stale && (
+                    <div className="ml-2">
+                      <StaleFeatureIcon
+                        staleReason={reason}
+                        onClick={() => setStaleFFModal(true)}
+                      />
+                    </div>
+                  )}
+                </div>
+                <div style={{ flex: 1 }} />
+                <div className="col-auto">
+                  <MoreMenu>
+                    <a
+                      className="dropdown-item"
+                      href="#"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        setShowImplementation(true);
+                      }}
+                    >
+                      Show implementation
+                    </a>
+                    {canEdit && (
+                      <a
+                        className="dropdown-item"
+                        href="#"
+                        onClick={(e) => {
+                          e.preventDefault();
+                          setStaleFFModal(true);
+                        }}
+                      >
+                        {feature.neverStale
+                          ? "Enable stale detection"
+                          : "Disable stale detection"}
+                      </a>
+                    )}
+                    {canEdit && canPublish && (
+                      <a
+                        className="dropdown-item"
+                        href="#"
+                        onClick={(e) => {
+                          e.preventDefault();
+                          setDuplicateModal(true);
+                        }}
+                      >
+                        Duplicate
+                      </a>
+                    )}
+                    {canEdit && canPublish && (
+                      <Tooltip
+                        shouldDisplay={dependents > 0}
+                        usePortal={true}
+                        body={
+                          <>
+                            <ImBlocked className="text-danger" /> This feature
+                            has{" "}
+                            <strong>
+                              {dependents} dependent{dependents !== 1 && "s"}
+                            </strong>
+                            . This feature cannot be archived until{" "}
+                            {dependents === 1 ? "it has" : "they have"} been
+                            removed.
+                          </>
+                        }
+                      >
+                        <ConfirmButton
+                          onClick={async () => {
+                            await apiCall(`/feature/${feature.id}/archive`, {
+                              method: "POST",
+                            });
+                            mutate();
+                          }}
+                          modalHeader={
+                            isArchived ? "Unarchive Feature" : "Archive Feature"
+                          }
+                          confirmationText={
+                            isArchived ? (
+                              <>
+                                <p>
+                                  Are you sure you want to continue? This will
+                                  make the current feature active again.
+                                </p>
+                              </>
+                            ) : (
+                              <>
+                                <p>
+                                  Are you sure you want to continue? This will
+                                  make the current feature inactive. It will not
+                                  be included in API responses or Webhook
+                                  payloads.
+                                </p>
+                              </>
+                            )
+                          }
+                          cta={isArchived ? "Unarchive" : "Archive"}
+                          ctaColor="danger"
+                          disabled={dependents > 0}
+                        >
+                          <button className="dropdown-item">
+                            {isArchived ? "Unarchive" : "Archive"}
+                          </button>
+                        </ConfirmButton>
+                      </Tooltip>
+                    )}
+                    {canEdit && canPublish && (
+                      <Tooltip
+                        shouldDisplay={dependents > 0}
+                        usePortal={true}
+                        body={
+                          <>
+                            <ImBlocked className="text-danger" /> This feature
+                            has{" "}
+                            <strong>
+                              {dependents} dependent{dependents !== 1 && "s"}
+                            </strong>
+                            . This feature cannot be deleted until{" "}
+                            {dependents === 1 ? "it has" : "they have"} been
+                            removed.
+                          </>
+                        }
+                      >
+                        <DeleteButton
+                          useIcon={false}
+                          displayName="Feature"
+                          onClick={async () => {
+                            await apiCall(`/feature/${feature.id}`, {
+                              method: "DELETE",
+                            });
+                            router.push("/features");
+                          }}
+                          className="dropdown-item text-danger"
+                          text="Delete"
+                          disabled={dependents > 0}
+                        />
+                      </Tooltip>
+                    )}
+                  </MoreMenu>
+                </div>
               </div>
-              <div style={{ flex: 1 }} />
-              <div className="col-auto">
-                <MoreMenu>
+              <div className="mb-2 row">
+                {(projects.length > 0 || projectIsDeReferenced) && (
+                  <div className="col-auto">
+                    Project:{" "}
+                    {projectIsDeReferenced ? (
+                      <Tooltip
+                        body={
+                          <>
+                            Project <code>{projectId}</code> not found
+                          </>
+                        }
+                      >
+                        <span className="text-danger">
+                          <FaExclamationTriangle /> Invalid project
+                        </span>
+                      </Tooltip>
+                    ) : currentProject && currentProject !== feature.project ? (
+                      <Tooltip
+                        body={<>This feature is not in your current project.</>}
+                      >
+                        {projectId ? (
+                          <strong>{projectName}</strong>
+                        ) : (
+                          <em className="text-muted">None</em>
+                        )}{" "}
+                        <FaExclamationTriangle className="text-warning" />
+                      </Tooltip>
+                    ) : projectId ? (
+                      <strong>{projectName}</strong>
+                    ) : (
+                      <em className="text-muted">None</em>
+                    )}
+                    {canEdit && canPublish && (
+                      <Tooltip
+                        shouldDisplay={dependents > 0}
+                        body={
+                          <>
+                            <ImBlocked className="text-danger" /> This feature
+                            has{" "}
+                            <strong>
+                              {dependents} dependent{dependents !== 1 && "s"}
+                            </strong>
+                            . The project cannot be changed until{" "}
+                            {dependents === 1 ? "it has" : "they have"} been
+                            removed.
+                          </>
+                        }
+                      >
+                        <a
+                          className="ml-2 cursor-pointer"
+                          onClick={() => {
+                            dependents === 0 && setEditProjectModal(true);
+                          }}
+                        >
+                          <GBEdit />
+                        </a>
+                      </Tooltip>
+                    )}
+                  </div>
+                )}
+
+                <div className="col-auto">
+                  Tags: <SortedTags tags={feature.tags || []} />
+                  {canEdit && (
+                    <a
+                      className="ml-1 cursor-pointer"
+                      onClick={() => setEditTagsModal(true)}
+                    >
+                      <GBEdit />
+                    </a>
+                  )}
+                </div>
+
+                <div className="col-auto">
+                  Type: {feature.valueType || "unknown"}
+                </div>
+
+                <div className="col-auto">
+                  Owner: {feature.owner ? feature.owner : "None"}
+                  {canEdit && (
+                    <a
+                      className="ml-1 cursor-pointer"
+                      onClick={() => setEditOwnerModal(true)}
+                    >
+                      <GBEdit />
+                    </a>
+                  )}
+                </div>
+
+                <div className="col-auto ml-auto">
                   <a
-                    className="dropdown-item"
                     href="#"
                     onClick={(e) => {
                       e.preventDefault();
-                      setShowImplementation(true);
+                      setAuditModal(true);
                     }}
                   >
-                    Show implementation
+                    View Audit Log
                   </a>
-                  {canEdit && (
-                    <a
-                      className="dropdown-item"
-                      href="#"
-                      onClick={(e) => {
-                        e.preventDefault();
-                        setStaleFFModal(true);
-                      }}
-                    >
-                      {feature.neverStale
-                        ? "Enable stale detection"
-                        : "Disable stale detection"}
-                    </a>
-                  )}
-                  {canEdit && canPublish && (
-                    <a
-                      className="dropdown-item"
-                      href="#"
-                      onClick={(e) => {
-                        e.preventDefault();
-                        setDuplicateModal(true);
-                      }}
-                    >
-                      Duplicate
-                    </a>
-                  )}
-                  {canEdit && canPublish && (
-                    <Tooltip
-                      shouldDisplay={dependents > 0}
-                      usePortal={true}
-                      body={
-                        <>
-                          <ImBlocked className="text-danger" /> This feature has{" "}
-                          <strong>
-                            {dependents} dependent{dependents !== 1 && "s"}
-                          </strong>
-                          . This feature cannot be archived until{" "}
-                          {dependents === 1 ? "it has" : "they have"} been
-                          removed.
-                        </>
-                      }
-                    >
-                      <ConfirmButton
-                        onClick={async () => {
-                          await apiCall(`/feature/${feature.id}/archive`, {
-                            method: "POST",
-                          });
-                          mutate();
-                        }}
-                        modalHeader={
-                          isArchived ? "Unarchive Feature" : "Archive Feature"
-                        }
-                        confirmationText={
-                          isArchived ? (
-                            <>
-                              <p>
-                                Are you sure you want to continue? This will
-                                make the current feature active again.
-                              </p>
-                            </>
-                          ) : (
-                            <>
-                              <p>
-                                Are you sure you want to continue? This will
-                                make the current feature inactive. It will not
-                                be included in API responses or Webhook
-                                payloads.
-                              </p>
-                            </>
-                          )
-                        }
-                        cta={isArchived ? "Unarchive" : "Archive"}
-                        ctaColor="danger"
-                        disabled={dependents > 0}
-                      >
-                        <button className="dropdown-item">
-                          {isArchived ? "Unarchive" : "Archive"}
-                        </button>
-                      </ConfirmButton>
-                    </Tooltip>
-                  )}
-                  {canEdit && canPublish && (
-                    <Tooltip
-                      shouldDisplay={dependents > 0}
-                      usePortal={true}
-                      body={
-                        <>
-                          <ImBlocked className="text-danger" /> This feature has{" "}
-                          <strong>
-                            {dependents} dependent{dependents !== 1 && "s"}
-                          </strong>
-                          . This feature cannot be deleted until{" "}
-                          {dependents === 1 ? "it has" : "they have"} been
-                          removed.
-                        </>
-                      }
-                    >
-                      <DeleteButton
-                        useIcon={false}
-                        displayName="Feature"
-                        onClick={async () => {
-                          await apiCall(`/feature/${feature.id}`, {
-                            method: "DELETE",
-                          });
-                          router.push("/features");
-                        }}
-                        className="dropdown-item text-danger"
-                        text="Delete"
-                        disabled={dependents > 0}
-                      />
-                    </Tooltip>
-                  )}
-                </MoreMenu>
-              </div>
-            </div>
-            <div className="mb-2 row">
-              {(projects.length > 0 || projectIsDeReferenced) && (
+                </div>
                 <div className="col-auto">
-                  Project:{" "}
-                  {projectIsDeReferenced ? (
-                    <Tooltip
-                      body={
-                        <>
-                          Project <code>{projectId}</code> not found
-                        </>
-                      }
-                    >
-                      <span className="text-danger">
-                        <FaExclamationTriangle /> Invalid project
-                      </span>
-                    </Tooltip>
-                  ) : currentProject && currentProject !== feature.project ? (
-                    <Tooltip
-                      body={<>This feature is not in your current project.</>}
-                    >
-                      {projectId ? (
-                        <strong>{projectName}</strong>
-                      ) : (
-                        <em className="text-muted">None</em>
-                      )}{" "}
-                      <FaExclamationTriangle className="text-warning" />
-                    </Tooltip>
-                  ) : projectId ? (
-                    <strong>{projectName}</strong>
-                  ) : (
-                    <em className="text-muted">None</em>
-                  )}
-                  {canEdit && canPublish && (
-                    <Tooltip
-                      shouldDisplay={dependents > 0}
-                      body={
-                        <>
-                          <ImBlocked className="text-danger" /> This feature has{" "}
-                          <strong>
-                            {dependents} dependent{dependents !== 1 && "s"}
-                          </strong>
-                          . The project cannot be changed until{" "}
-                          {dependents === 1 ? "it has" : "they have"} been
-                          removed.
-                        </>
-                      }
-                    >
-                      <a
-                        className="ml-2 cursor-pointer"
-                        onClick={() => {
-                          dependents === 0 && setEditProjectModal(true);
-                        }}
-                      >
-                        <GBEdit />
-                      </a>
-                    </Tooltip>
-                  )}
+                  <WatchButton
+                    item={feature.id}
+                    itemType="feature"
+                    type="link"
+                  />
                 </div>
-              )}
-
-              <div className="col-auto">
-                Tags: <SortedTags tags={feature.tags || []} />
-                {canEdit && (
-                  <a
-                    className="ml-1 cursor-pointer"
-                    onClick={() => setEditTagsModal(true)}
-                  >
-                    <GBEdit />
-                  </a>
+              </div>
+              <div>
+                {isArchived && (
+                  <div className="alert alert-secondary mb-2">
+                    <strong>This feature is archived.</strong> It will not be
+                    included in SDK Endpoints or Webhook payloads.
+                  </div>
                 )}
               </div>
 
-              <div className="col-auto">
-                Type: {feature.valueType || "unknown"}
-              </div>
-
-              <div className="col-auto">
-                Owner: {feature.owner ? feature.owner : "None"}
-                {canEdit && (
-                  <a
-                    className="ml-1 cursor-pointer"
-                    onClick={() => setEditOwnerModal(true)}
-                  >
-                    <GBEdit />
-                  </a>
-                )}
-              </div>
-
-              <div className="col-auto ml-auto">
-                <a
-                  href="#"
-                  onClick={(e) => {
-                    e.preventDefault();
-                    setAuditModal(true);
-                  }}
-                >
-                  View Audit Log
-                </a>
-              </div>
-              <div className="col-auto">
-                <WatchButton item={feature.id} itemType="feature" type="link" />
-              </div>
-            </div>
-            <div>
-              {isArchived && (
-                <div className="alert alert-secondary mb-2">
-                  <strong>This feature is archived.</strong> It will not be
-                  included in SDK Endpoints or Webhook payloads.
+              <div className="mb-3">
+                <div className={feature.description ? "appbox mb-4 p-3" : ""}>
+                  <MarkdownInlineEdit
+                    value={feature.description || ""}
+                    canEdit={canEdit}
+                    canCreate={canEdit}
+                    save={async (description) => {
+                      await apiCall(`/feature/${feature.id}`, {
+                        method: "PUT",
+                        body: JSON.stringify({
+                          description,
+                        }),
+                      });
+                      track("Update Feature Description");
+                      mutate();
+                    }}
+                  />
                 </div>
-              )}
-            </div>
-
-            <div className="mb-3">
-              <div className={feature.description ? "appbox mb-4 p-3" : ""}>
-                <MarkdownInlineEdit
-                  value={feature.description || ""}
-                  canEdit={canEdit}
-                  canCreate={canEdit}
-                  save={async (description) => {
-                    await apiCall(`/feature/${feature.id}`, {
-                      method: "PUT",
-                      body: JSON.stringify({
-                        description,
-                      }),
-                    });
-                    track("Update Feature Description");
-                    mutate();
-                  }}
-                />
               </div>
-            </div>
-            <div id="feature-page-tabs">
-              <TabButtons className="mb-0 pb-0">
-                <TabButton
-                  active={tab === "overview"}
-                  display={
-                    <>
-                      <FaHome /> Overview
-                    </>
-                  }
-                  anchor="overview"
-                  onClick={() => setTab("overview")}
-                  newStyle={false}
-                  activeClassName="active-tab"
-                />
-                <TabButton
-                  active={tab === "stats"}
-                  display={
-                    <>
-                      <FaCode /> Code Refs
-                    </>
-                  }
-                  anchor="stats"
-                  onClick={() => setTab("stats")}
-                  newStyle={false}
-                  activeClassName="active-tab"
-                />
-              </TabButtons>
+              <div id="feature-page-tabs">
+                <TabButtons className="mb-0 pb-0">
+                  <TabButton
+                    active={tab === "overview"}
+                    display={
+                      <>
+                        <FaHome /> Overview
+                      </>
+                    }
+                    anchor="overview"
+                    onClick={() => setTab("overview")}
+                    newStyle={false}
+                    activeClassName="active-tab"
+                  />
+                  <TabButton
+                    active={tab === "stats"}
+                    display={
+                      <>
+                        <FaCode /> Code Refs
+                      </>
+                    }
+                    anchor="stats"
+                    onClick={() => setTab("stats")}
+                    newStyle={false}
+                    activeClassName="active-tab"
+                  />
+                </TabButtons>
+              </div>
             </div>
           </div>
+          {auditModal && (
+            <Modal
+              open={true}
+              header="Audit Log"
+              close={() => setAuditModal(false)}
+              size="max"
+              closeCta="Close"
+            >
+              <HistoryTable type="feature" id={feature.id} />
+            </Modal>
+          )}
+          {duplicateModal && (
+            <FeatureModal
+              cta={"Duplicate"}
+              close={() => setDuplicateModal(false)}
+              onSuccess={async (feature) => {
+                const url = `/features/${feature.id}`;
+                router.push(url);
+              }}
+              featureToDuplicate={feature}
+            />
+          )}
+          {staleFFModal && (
+            <StaleDetectionModal
+              close={() => setStaleFFModal(false)}
+              feature={feature}
+              mutate={mutate}
+            />
+          )}
+          {showImplementation && (
+            <FeatureImplementationModal
+              feature={feature}
+              first={firstFeature}
+              close={() => {
+                setShowImplementation(false);
+              }}
+            />
+          )}
         </div>
-        {auditModal && (
-          <Modal
-            open={true}
-            header="Audit Log"
-            close={() => setAuditModal(false)}
-            size="max"
-            closeCta="Close"
-          >
-            <HistoryTable type="feature" id={feature.id} />
-          </Modal>
-        )}
-        {duplicateModal && (
-          <FeatureModal
-            cta={"Duplicate"}
-            close={() => setDuplicateModal(false)}
-            onSuccess={async (feature) => {
-              const url = `/features/${feature.id}`;
-              router.push(url);
-            }}
-            featureToDuplicate={feature}
-          />
-        )}
-        {staleFFModal && (
-          <StaleDetectionModal
-            close={() => setStaleFFModal(false)}
-            feature={feature}
-            mutate={mutate}
-          />
-        )}
-        {showImplementation && (
-          <FeatureImplementationModal
-            feature={feature}
-            first={firstFeature}
-            close={() => {
-              setShowImplementation(false);
-            }}
-          />
-        )}
       </div>
-    </div>
+    </>
   );
 }

--- a/packages/front-end/components/Features/FeaturesOverview.tsx
+++ b/packages/front-end/components/Features/FeaturesOverview.tsx
@@ -38,8 +38,6 @@ import RuleList from "@/components/Features/RuleList";
 import track from "@/services/track";
 import EditDefaultValueModal from "@/components/Features/EditDefaultValueModal";
 import EnvironmentToggle from "@/components/Features/EnvironmentToggle";
-import EditProjectForm from "@/components/Experiment/EditProjectForm";
-import EditTagsForm from "@/components/Tags/EditTagsForm";
 import ControlledTabs from "@/components/Tabs/ControlledTabs";
 import {
   getFeatureDefaultValue,
@@ -56,7 +54,6 @@ import Modal from "@/components/Modal";
 import DraftModal from "@/components/Features/DraftModal";
 import RevisionDropdown from "@/components/Features/RevisionDropdown";
 import DiscussionThread from "@/components/DiscussionThread";
-import EditOwnerModal from "@/components/Owner/EditOwnerModal";
 import Tooltip from "@/components/Tooltip/Tooltip";
 import EditSchemaModal from "@/components/Features/EditSchemaModal";
 import Code from "@/components/SyntaxHighlighting/Code";
@@ -88,12 +85,6 @@ export default function FeaturesOverview({
   revisions,
   experiments,
   mutate,
-  editProjectModal,
-  setEditProjectModal,
-  editTagsModal,
-  setEditTagsModal,
-  editOwnerModal,
-  setEditOwnerModal,
   version,
   setVersion,
   dependents,
@@ -106,12 +97,6 @@ export default function FeaturesOverview({
   revisions: FeatureRevisionInterface[];
   experiments: ExperimentInterfaceStringDates[] | undefined;
   mutate: () => Promise<unknown>;
-  editProjectModal: boolean;
-  setEditProjectModal: (b: boolean) => void;
-  editTagsModal: boolean;
-  setEditTagsModal: (b: boolean) => void;
-  editOwnerModal: boolean;
-  setEditOwnerModal: (b: boolean) => void;
   version: number | null;
   setVersion: (v: number) => void;
   dependents: number;
@@ -1220,19 +1205,6 @@ export default function FeaturesOverview({
             setVersion={setVersion}
           />
         )}
-        {editOwnerModal && (
-          <EditOwnerModal
-            cancel={() => setEditOwnerModal(false)}
-            owner={feature.owner}
-            save={async (owner) => {
-              await apiCall(`/feature/${feature.id}`, {
-                method: "PUT",
-                body: JSON.stringify({ owner }),
-              });
-            }}
-            mutate={mutate}
-          />
-        )}
         {editValidator && (
           <EditSchemaModal
             close={() => setEditValidator(false)}
@@ -1264,34 +1236,6 @@ export default function FeaturesOverview({
             mutate={mutate}
           />
         )}
-        {editProjectModal && (
-          <EditProjectForm
-            label={
-              <>
-                Projects{" "}
-                <Tooltip
-                  body={
-                    "The dropdown below has been filtered to only include projects where you have permission to update Features"
-                  }
-                />
-              </>
-            }
-            permissionRequired={(project) =>
-              permissionsUtil.canUpdateFeature({ project }, {})
-            }
-            apiEndpoint={`/feature/${feature.id}`}
-            cancel={() => setEditProjectModal(false)}
-            mutate={mutate}
-            method="PUT"
-            current={feature.project}
-            additionalMessage={
-              <div className="alert alert-danger">
-                Changing the project may prevent this Feature Flag and any
-                linked Experiments from being sent to users.
-              </div>
-            }
-          />
-        )}
         {revertIndex > 0 && (
           <RevertModal
             close={() => setRevertIndex(0)}
@@ -1316,19 +1260,6 @@ export default function FeaturesOverview({
             <h3>Revision {revision.version}</h3>
             <Revisionlog feature={feature} revision={revision} />
           </Modal>
-        )}
-        {editTagsModal && (
-          <EditTagsForm
-            tags={feature.tags || []}
-            save={async (tags) => {
-              await apiCall(`/feature/${feature.id}`, {
-                method: "PUT",
-                body: JSON.stringify({ tags }),
-              });
-            }}
-            cancel={() => setEditTagsModal(false)}
-            mutate={mutate}
-          />
         )}
         {reviewModal && revision && (
           <RequestReviewModal

--- a/packages/front-end/pages/features/[fid].tsx
+++ b/packages/front-end/pages/features/[fid].tsx
@@ -27,9 +27,6 @@ export default function FeaturePage() {
   const router = useRouter();
   const orgSettings = useOrgSettings();
   const { fid } = router.query;
-  const [editProjectModal, setEditProjectModal] = useState(false);
-  const [editTagsModal, setEditTagsModal] = useState(false);
-  const [editOwnerModal, setEditOwnerModal] = useState(false);
   const [version, setVersion] = useState<number | null>(null);
 
   const { features } = useFeaturesList(false);
@@ -197,9 +194,6 @@ export default function FeaturePage() {
         mutate={mutate}
         tab={tab}
         setTab={setTabAndScroll}
-        setEditProjectModal={setEditProjectModal}
-        setEditTagsModal={setEditTagsModal}
-        setEditOwnerModal={setEditOwnerModal}
         dependents={dependents}
       />
 
@@ -211,12 +205,6 @@ export default function FeaturePage() {
           revisions={data.revisions}
           experiments={experiments}
           mutate={mutate}
-          editProjectModal={editProjectModal}
-          setEditProjectModal={setEditProjectModal}
-          editTagsModal={editTagsModal}
-          setEditTagsModal={setEditTagsModal}
-          editOwnerModal={editOwnerModal}
-          setEditOwnerModal={setEditOwnerModal}
           version={version}
           setVersion={setVersion}
           dependents={dependents}


### PR DESCRIPTION
### Features and Changes

Previously, the modals for editing a features project, tags, and owner lived in the `FeaturesOverview` component, so if a user was viewing the `Code Refs` tag on a Feature Flag Id page, the modals weren't opening as expected.

Now, those modals have been moved to the `FearuresOverview` component, so the functionality can be accessed and shared, regardless of the tab the user has selected.

- Closes **(https://github.com/growthbook/growthbook/issues/2898**

### Testing

- [x] Ensure that regardless of the tab selected (Overview or Code Refs) the user can edit a feature's projects
- [x] Ensure that regardless of the tab selected (Overview or Code Refs) the user can edit a feature's tags
- [x] Ensure that regardless of the tab selected (Overview or Code Refs) the user can edit a feature's owner
- [x] Ensure that regardless of the tab selected (Overview or Code Refs) the user can view a feature's audit log
- [x] Ensure that regardless of the tab selected (Overview or Code Refs) the user can start or stop watching the feature
- [x] Ensure that regardless of the tab selected (Overview or Code Refs) the user can duplicate, archive, or delete a feature
- [x] Ensure that regardless of the tab selected (Overview or Code Refs) the user can edit a feature's description
- [x] Ensure that a user's permissions are respected - e.g. collaborators can't edit any of the fields above
