### PR TITLE
Disallow nonstandard types for saved groups

### DIFF
--- a/packages/back-end/src/api/saved-groups/postSavedGroup.ts
+++ b/packages/back-end/src/api/saved-groups/postSavedGroup.ts
@@ -1,4 +1,4 @@
-import { validateCondition } from "shared/util";
+import { ID_LIST_DATATYPES, validateCondition } from "shared/util";
 import { PostSavedGroupResponse } from "../../../types/openapi";
 import {
   createSavedGroup,
@@ -46,6 +46,18 @@ export const postSavedGroup = createApiRequestHandler(postSavedGroupValidator)(
       if (!attributeKey || !values) {
         throw new Error(
           "Must specify an attributeKey and values for list groups"
+        );
+      }
+      const attributeSchema = req.organization.settings?.attributeSchema || [];
+      const datatype = attributeSchema.find(
+        (sdkAttr) => sdkAttr.property === attributeKey
+      )?.datatype;
+      if (!datatype) {
+        throw new Error("Unknown attributeKey");
+      }
+      if (!ID_LIST_DATATYPES.includes(datatype)) {
+        throw new Error(
+          "Cannot create an ID List for the given attribute key. Try using a condition group instead."
         );
       }
       if (condition) {

--- a/packages/back-end/src/api/saved-groups/postSavedGroup.ts
+++ b/packages/back-end/src/api/saved-groups/postSavedGroup.ts
@@ -57,7 +57,7 @@ export const postSavedGroup = createApiRequestHandler(postSavedGroupValidator)(
       }
       if (!ID_LIST_DATATYPES.includes(datatype)) {
         throw new Error(
-          "Cannot create an ID List for the given attribute key. Try using a condition group instead."
+          "Cannot create an ID List for the given attribute key. Try using a Condition Group instead."
         );
       }
       if (condition) {

--- a/packages/back-end/src/routers/saved-group/saved-group.controller.ts
+++ b/packages/back-end/src/routers/saved-group/saved-group.controller.ts
@@ -105,7 +105,7 @@ export const postSavedGroup = async (
   if (!context.permissions.canCreateSavedGroup()) {
     context.permissions.throwPermissionError();
   }
-  const uniqValues: string[] | undefined = undefined;
+  let uniqValues: string[] | undefined = undefined;
   // If this is a condition group, make sure the condition is valid and not empty
   if (type === "condition") {
     const conditionRes = validateCondition(condition);
@@ -115,9 +115,8 @@ export const postSavedGroup = async (
     if (conditionRes.empty) {
       throw new Error("Condition cannot be empty");
     }
-  }
-  // If this is a list group, make sure the attributeKey is specified
-  else if (type === "list") {
+  } else if (type === "list") {
+    // If this is a list group, make sure the attributeKey is specified
     if (!attributeKey) {
       throw new Error("Must specify an attributeKey");
     }
@@ -133,7 +132,7 @@ export const postSavedGroup = async (
         "Cannot create an ID List for the given attribute key. Try using a Condition Group instead."
       );
     }
-    const uniqValues = [...new Set(values)];
+    uniqValues = [...new Set(values)];
     if (
       new Blob([JSON.stringify(uniqValues)]).size > LARGE_GROUP_SIZE_LIMIT_BYTES
     ) {

--- a/packages/back-end/src/routers/saved-group/saved-group.controller.ts
+++ b/packages/back-end/src/routers/saved-group/saved-group.controller.ts
@@ -389,7 +389,7 @@ export const postSavedGroupRemoveItems = async (
     (value) => !toRemove.has(value)
   );
   const changes = await updateSavedGroupById(id, org.id, {
-    values: [...newValues],
+    values: newValues,
   });
 
   const updatedSavedGroup = { ...savedGroup, ...changes };

--- a/packages/front-end/components/SavedGroups/SavedGroupForm.tsx
+++ b/packages/front-end/components/SavedGroups/SavedGroupForm.tsx
@@ -212,12 +212,6 @@ const SavedGroupForm: FC<{
               value: a.property,
               label: a.property,
             }))}
-            isOptionDisabled={({ label }) =>
-              !isIdListSupportedDatatype(
-                attributeSchema.find((attr) => attr.property === label)
-                  ?.datatype
-              )
-            }
             formatOptionLabel={({ label }) => {
               const attr = attributeSchema.find(
                 (attr) => attr.property === label

--- a/packages/front-end/components/SavedGroups/SavedGroupForm.tsx
+++ b/packages/front-end/components/SavedGroups/SavedGroupForm.tsx
@@ -238,9 +238,7 @@ const SavedGroupForm: FC<{
           />
           {!current.id && (
             <IdListItemInput
-              values={(form.watch("values") || []).map((val: number | string) =>
-                val.toString()
-              )}
+              values={form.watch("values") || []}
               passByReferenceOnly={false}
               bypassSmallListSizeLimit={false}
               setValues={(newValues) => {

--- a/packages/front-end/components/SavedGroups/SavedGroupForm.tsx
+++ b/packages/front-end/components/SavedGroups/SavedGroupForm.tsx
@@ -4,9 +4,13 @@ import {
   UpdateSavedGroupProps,
 } from "back-end/types/saved-group";
 import { useForm } from "react-hook-form";
-import { validateAndFixCondition } from "shared/util";
+import {
+  isIdListSupportedDatatype,
+  validateAndFixCondition,
+} from "shared/util";
 import { FaPlusCircle } from "react-icons/fa";
 import { SavedGroupInterface, SavedGroupType } from "shared/src/types";
+import clsx from "clsx";
 import { useIncrementer } from "@/hooks/useIncrementer";
 import { useAuth } from "@/services/auth";
 import useMembers from "@/hooks/useMembers";
@@ -18,6 +22,7 @@ import SelectField from "@/components/Forms/SelectField";
 import ConditionInput from "@/components/Features/ConditionInput";
 import { IdListItemInput } from "@/components/SavedGroups/IdListItemInput";
 import UpgradeModal from "@/components/Settings/UpgradeModal";
+import Tooltip from "@/components/Tooltip/Tooltip";
 
 const SavedGroupForm: FC<{
   close: () => void;
@@ -207,11 +212,41 @@ const SavedGroupForm: FC<{
               value: a.property,
               label: a.property,
             }))}
+            isOptionDisabled={({ label }) =>
+              !isIdListSupportedDatatype(
+                attributeSchema.find((attr) => attr.property === label)
+                  ?.datatype
+              )
+            }
+            formatOptionLabel={({ label }) => {
+              const attr = attributeSchema.find(
+                (attr) => attr.property === label
+              );
+              if (!attr) return label;
+              const unsupported = !isIdListSupportedDatatype(attr.datatype);
+              return (
+                <div className={clsx(unsupported ? "disabled" : "")}>
+                  {label}
+                  {unsupported && (
+                    <span className="float-right">
+                      <Tooltip
+                        body="The datatype for this attribute key isn't valid for ID Lists. Try using a Condition Group instead"
+                        tipPosition="top"
+                      >
+                        unsupported datatype
+                      </Tooltip>
+                    </span>
+                  )}
+                </div>
+              );
+            }}
             helpText={current.attributeKey && "This field cannot be edited."}
           />
           {!current.id && (
             <IdListItemInput
-              values={form.watch("values") || []}
+              values={(form.watch("values") || []).map((val: number | string) =>
+                val.toString()
+              )}
               passByReferenceOnly={false}
               bypassSmallListSizeLimit={false}
               setValues={(newValues) => {

--- a/packages/front-end/components/SavedGroups/SavedGroupForm.tsx
+++ b/packages/front-end/components/SavedGroups/SavedGroupForm.tsx
@@ -212,6 +212,13 @@ const SavedGroupForm: FC<{
               value: a.property,
               label: a.property,
             }))}
+            isOptionDisabled={({ label }) => {
+              const attr = attributeSchema.find(
+                (attr) => attr.property === label
+              );
+              if (!attr) return false;
+              return !isIdListSupportedDatatype(attr.datatype);
+            }}
             formatOptionLabel={({ label }) => {
               const attr = attributeSchema.find(
                 (attr) => attr.property === label

--- a/packages/shared/src/util/saved-groups.ts
+++ b/packages/shared/src/util/saved-groups.ts
@@ -1,9 +1,22 @@
-import { OrganizationInterface } from "back-end/types/organization";
+import {
+  SDKAttributeType,
+  OrganizationInterface,
+} from "back-end/types/organization";
 import { AttributeMap } from "back-end/src/services/features";
 import { GroupMap, SavedGroupsValues, SavedGroupInterface } from "../types";
 
 export const SMALL_GROUP_SIZE_LIMIT = 100;
 export const LARGE_GROUP_SIZE_LIMIT_BYTES = 1024 * 1024;
+export const ID_LIST_DATATYPES: SDKAttributeType[] = [
+  "number",
+  "string",
+  "secureString",
+] as const;
+export function isIdListSupportedDatatype(
+  datatype?: SDKAttributeType
+): datatype is "number" | "string" | "secureString" {
+  return !!datatype && ID_LIST_DATATYPES.includes(datatype);
+}
 
 export function getSavedGroupsValuesFromGroupMap(
   groupMap: GroupMap


### PR DESCRIPTION
### Features and Changes

Prevents creation of and addition to ID Lists of types other than `string`, `secureString`, and `number`. These lists don't currently serve the correct values in SDK payloads, and likely never have. Instead, users will be directed to create a condition group for other datatypes.

### Testing

- [x] Saved group form should show attribute keys are unsupported based on datatype
- [x] Even if they're not disabled in the form, controller should throw an error
- [x] Existing (legacy) groups with the wrong attribute type should show a warning on the [sgid] page
- [x] Existing (legacy) groups with the wrong attribute type should throw an error when attempting to add/remove items.

### Screenshots

![image](https://github.com/user-attachments/assets/35e504c2-dd61-4644-9e26-18e2160f66a8)

![image](https://github.com/user-attachments/assets/e68ce8af-b752-40ed-8424-c516fa3d2680)

![image](https://github.com/user-attachments/assets/66bd6787-573a-4a8e-bf24-7b68c2a8d2c7)

![image](https://github.com/user-attachments/assets/b38317b0-4c33-4069-ab2c-7c454800fa7c)

![image](https://github.com/user-attachments/assets/70d4f6df-a1fb-480c-a732-3c70dcf1a89a)
