### PR TITLE
Make it possible to duplicate/archive fact metrics & archive fact tables

### DIFF
--- a/packages/back-end/src/models/FactTableModel.ts
+++ b/packages/back-end/src/models/FactTableModel.ts
@@ -56,6 +56,7 @@ const factTableSchema = new mongoose.Schema({
       managedBy: String,
     },
   ],
+  archived: Boolean,
 });
 
 factTableSchema.index({ id: 1, organization: 1 }, { unique: true });

--- a/packages/back-end/src/routers/fact-table/fact-table.controller.ts
+++ b/packages/back-end/src/routers/fact-table/fact-table.controller.ts
@@ -182,22 +182,6 @@ export const archiveFactTable = async (
 
   await updateFactTable(context, factTable, { archived: true });
 
-  // Archive all fact metrics in the fact table
-  const allFactMetrics = await context.models.factMetrics.getAll();
-  const factTableMetrics = allFactMetrics.filter(
-    (m) =>
-      m.numerator.factTableId === factTable.id ||
-      (m.denominator && m.denominator.factTableId === factTable.id)
-  );
-
-  await Promise.all(
-    factTableMetrics.map(async (metric) => {
-      await context.models.factMetrics.updateById(metric.id, {
-        archived: true,
-      });
-    })
-  );
-
   res.status(200).json({
     status: 200,
   });
@@ -219,22 +203,6 @@ export const unarchiveFactTable = async (
   }
 
   await updateFactTable(context, factTable, { archived: false });
-
-  // Unarchive all fact metrics in the fact table
-  const allFactMetrics = await context.models.factMetrics.getAll();
-  const factTableMetrics = allFactMetrics.filter(
-    (m) =>
-      m.numerator.factTableId === factTable.id ||
-      (m.denominator && m.denominator.factTableId === factTable.id)
-  );
-
-  await Promise.all(
-    factTableMetrics.map(async (metric) => {
-      await context.models.factMetrics.updateById(metric.id, {
-        archived: false,
-      });
-    })
-  );
 
   res.status(200).json({
     status: 200,

--- a/packages/back-end/src/routers/fact-table/fact-table.router.ts
+++ b/packages/back-end/src/routers/fact-table/fact-table.router.ts
@@ -39,6 +39,13 @@ router.put(
   factTableController.putFactTable
 );
 
+router.post("/fact-tables/:id/archive", factTableController.archiveFactTable);
+
+router.post(
+  "/fact-tables/:id/unarchive",
+  factTableController.unarchiveFactTable
+);
+
 router.delete(
   "/fact-tables/:id",
   validateRequestMiddleware({

--- a/packages/back-end/src/routers/fact-table/fact-table.validators.ts
+++ b/packages/back-end/src/routers/fact-table/fact-table.validators.ts
@@ -125,6 +125,7 @@ export const factMetricValidator = z
     tags: z.array(z.string()).default([]),
     projects: z.array(z.string()),
     inverse: z.boolean(),
+    status: z.enum(["active", "archived"]).optional(),
 
     metricType: metricTypeValidator,
     numerator: columnRefValidator,

--- a/packages/back-end/src/routers/fact-table/fact-table.validators.ts
+++ b/packages/back-end/src/routers/fact-table/fact-table.validators.ts
@@ -126,6 +126,7 @@ export const factMetricValidator = z
     projects: z.array(z.string()),
     inverse: z.boolean(),
     status: z.enum(["active", "archived"]).optional(),
+    archived: z.boolean().optional(),
 
     metricType: metricTypeValidator,
     numerator: columnRefValidator,

--- a/packages/back-end/src/routers/fact-table/fact-table.validators.ts
+++ b/packages/back-end/src/routers/fact-table/fact-table.validators.ts
@@ -61,6 +61,7 @@ export const updateFactTablePropsValidator = z
     columns: z.array(createColumnPropsValidator).optional(),
     managedBy: z.enum(["", "api"]).optional(),
     columnsError: z.string().nullable().optional(),
+    archived: z.boolean().optional(),
   })
   .strict();
 
@@ -125,7 +126,6 @@ export const factMetricValidator = z
     tags: z.array(z.string()).default([]),
     projects: z.array(z.string()),
     inverse: z.boolean(),
-    status: z.enum(["active", "archived"]).optional(),
     archived: z.boolean().optional(),
 
     metricType: metricTypeValidator,

--- a/packages/back-end/types/fact-table.d.ts
+++ b/packages/back-end/types/fact-table.d.ts
@@ -64,6 +64,7 @@ export interface FactTableInterface {
   columns: ColumnInterface[];
   columnsError?: string | null;
   filters: FactFilterInterface[];
+  archived?: boolean;
 }
 
 export type ColumnRef = z.infer<typeof columnRefValidator>;

--- a/packages/front-end/components/FactTables/FactMetricList.tsx
+++ b/packages/front-end/components/FactTables/FactMetricList.tsx
@@ -2,7 +2,7 @@ import {
   FactMetricInterface,
   FactTableInterface,
 } from "back-end/types/fact-table";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import Link from "next/link";
 import { date } from "shared/dates";
 import MoreMenu from "@/components/Dropdown/MoreMenu";
@@ -36,13 +36,7 @@ export function getMetricsForFactTable(
 
 export default function FactMetricList({ factTable }: Props) {
   const [newOpen, setNewOpen] = useState(false);
-  const [showArchived, setShowArchived] = useState(
-    factTable.archived ? true : false
-  );
-
-  useEffect(() => {
-    setShowArchived(factTable.archived ? true : false);
-  }, [factTable]);
+  const [showArchived, setShowArchived] = useState(false);
 
   const { apiCall } = useAuth();
   const [isDeleting, setIsDeleting] = useState(false);
@@ -103,7 +97,7 @@ export default function FactMetricList({ factTable }: Props) {
           close={() => setDuplicateMetric(undefined)}
           existing={duplicateMetric}
           duplicate
-          source="fact-table"
+          source="fact-table-duplicate"
         />
       )}
 

--- a/packages/front-end/components/FactTables/FactMetricModal.tsx
+++ b/packages/front-end/components/FactTables/FactMetricModal.tsx
@@ -52,6 +52,7 @@ export interface Props {
   close?: () => void;
   initialFactTable?: string;
   existing?: FactMetricInterface;
+  duplicate?: boolean;
   showAdvancedSettings?: boolean;
   onSave?: () => void;
   goBack?: () => void;
@@ -313,6 +314,7 @@ export default function FactMetricModal({
   close,
   initialFactTable,
   existing,
+  duplicate = false,
   showAdvancedSettings,
   onSave,
   goBack,
@@ -483,7 +485,9 @@ export default function FactMetricModal({
   return (
     <Modal
       open={true}
-      header={existing ? "Edit Metric" : "Create Fact Table Metric"}
+      header={
+        existing && !duplicate ? "Edit Metric" : "Create Fact Table Metric"
+      }
       close={close}
       submit={form.handleSubmit(async (values) => {
         if (values.denominator && !values.denominator.factTableId) {
@@ -553,7 +557,7 @@ export default function FactMetricModal({
             values.numerator.factTableId === values.denominator?.factTableId,
         };
 
-        if (existing) {
+        if (existing && !duplicate) {
           const updatePayload: UpdateFactMetricProps = omit(values, [
             "datasource",
           ]);

--- a/packages/front-end/pages/fact-metrics/[fmid].tsx
+++ b/packages/front-end/pages/fact-metrics/[fmid].tsx
@@ -309,7 +309,7 @@ export default function FactMetricPage() {
           { display: factMetric.name },
         ]}
       />
-      {factMetric.status === "archived" && (
+      {factMetric.archived && (
         <div className="alert alert-secondary mb-2">
           <strong>This metric is archived.</strong> Existing references will
           continue working, but you will be unable to add this metric to new
@@ -354,18 +354,16 @@ export default function FactMetricPage() {
               <button
                 className="btn dropdown-item"
                 onClick={async () => {
-                  const newStatus =
-                    factMetric.status === "archived" ? "active" : "archived";
                   await apiCall(`/fact-metrics/${factMetric.id}`, {
                     method: "PUT",
                     body: JSON.stringify({
-                      status: newStatus,
+                      archived: !factMetric.archived,
                     }),
                   });
                   mutateDefinitions();
                 }}
               >
-                {factMetric.status === "archived" ? "Unarchive" : "Archive"}
+                {factMetric.archived ? "Unarchive" : "Archive"}
               </button>
             )}
           </MoreMenu>

--- a/packages/front-end/pages/fact-metrics/[fmid].tsx
+++ b/packages/front-end/pages/fact-metrics/[fmid].tsx
@@ -309,6 +309,13 @@ export default function FactMetricPage() {
           { display: factMetric.name },
         ]}
       />
+      {factMetric.status === "archived" && (
+        <div className="alert alert-secondary mb-2">
+          <strong>This metric is archived.</strong> Existing references will
+          continue working, but you will be unable to add this metric to new
+          experiments.
+        </div>
+      )}
       <div className="row mb-3">
         <div className="col-auto">
           <h1 className="mb-0">
@@ -317,7 +324,7 @@ export default function FactMetricPage() {
         </div>
         <div className="ml-auto">
           <MoreMenu>
-            {canEdit ? (
+            {canEdit && (
               <button
                 className="dropdown-item"
                 onClick={(e) => {
@@ -327,8 +334,8 @@ export default function FactMetricPage() {
               >
                 Edit Metric
               </button>
-            ) : null}
-            {canDelete ? (
+            )}
+            {canDelete && (
               <DeleteButton
                 className="dropdown-item"
                 displayName="Metric"
@@ -342,7 +349,25 @@ export default function FactMetricPage() {
                   router.push("/metrics");
                 }}
               />
-            ) : null}
+            )}
+            {canEdit && (
+              <button
+                className="btn dropdown-item"
+                onClick={async () => {
+                  const newStatus =
+                    factMetric.status === "archived" ? "active" : "archived";
+                  await apiCall(`/fact-metrics/${factMetric.id}`, {
+                    method: "PUT",
+                    body: JSON.stringify({
+                      status: newStatus,
+                    }),
+                  });
+                  mutateDefinitions();
+                }}
+              >
+                {factMetric.status === "archived" ? "Unarchive" : "Archive"}
+              </button>
+            )}
           </MoreMenu>
         </div>
       </div>

--- a/packages/front-end/pages/fact-tables/[ftid].tsx
+++ b/packages/front-end/pages/fact-tables/[ftid].tsx
@@ -40,14 +40,14 @@ export default function FactTablePage() {
   const permissionsUtil = usePermissionsUtil();
 
   const {
-    factTables,
+    getFactTableById,
     ready,
     mutateDefinitions,
     getProjectById,
     projects,
     getDatasourceById,
   } = useDefinitions();
-  const factTable = factTables.find((f) => f.id === ftid);
+  const factTable = getFactTableById(ftid as string);
 
   if (!ready) return <LoadingOverlay />;
 

--- a/packages/front-end/pages/fact-tables/[ftid].tsx
+++ b/packages/front-end/pages/fact-tables/[ftid].tsx
@@ -132,6 +132,13 @@ export default function FactTablePage() {
           { display: factTable.name },
         ]}
       />
+      {factTable.archived && (
+        <div className="alert alert-secondary mb-2">
+          <strong>This Fact Table is archived.</strong> Existing references will
+          continue working, but you will be unable to add metrics from this Fact
+          Table to new experiments.
+        </div>
+      )}
       <div className="row mb-3">
         <div className="col-auto">
           <h1 className="mb-0">
@@ -150,6 +157,22 @@ export default function FactTablePage() {
                 }}
               >
                 Edit Fact Table
+              </button>
+              <button
+                className="dropdown-item"
+                onClick={async () => {
+                  await apiCall(
+                    `/fact-tables/${factTable.id}/${
+                      factTable.archived ? "unarchive" : "archive"
+                    }`,
+                    {
+                      method: "POST",
+                    }
+                  );
+                  mutateDefinitions();
+                }}
+              >
+                {factTable.archived ? "Unarchive" : "Archive"} Fact Table
               </button>
               <DeleteButton
                 className="dropdown-item"

--- a/packages/front-end/pages/fact-tables/index.tsx
+++ b/packages/front-end/pages/fact-tables/index.tsx
@@ -26,7 +26,7 @@ import Toggle from "@/components/Forms/Toggle";
 
 export default function FactTablesPage() {
   const {
-    factTables,
+    _factTablesIncludingArchived: factTables,
     getDatasourceById,
     project,
     factMetrics,

--- a/packages/front-end/pages/fact-tables/index.tsx
+++ b/packages/front-end/pages/fact-tables/index.tsx
@@ -22,6 +22,7 @@ import InlineCode from "@/components/SyntaxHighlighting/InlineCode";
 import { OfficialBadge } from "@/components/Metrics/MetricName";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 import AutoGenerateFactTableModal from "@/components/AutoGenerateFactTablesModal";
+import Toggle from "@/components/Forms/Toggle";
 
 export default function FactTablesPage() {
   const {
@@ -44,6 +45,7 @@ export default function FactTablesPage() {
 
   const [createFactOpen, setCreateFactOpen] = useState(false);
   const [discoverFactOpen, setDiscoverFactOpen] = useState(false);
+  const [showArchived, setShowArchived] = useState(false);
 
   const factMetricCounts: Record<string, number> = {};
   factMetrics.forEach((m) => {
@@ -63,6 +65,8 @@ export default function FactTablesPage() {
         isProjectListValidForProject(t.projects, project)
       )
     : factTables;
+
+  const hasArchivedFactTables = factTables.some((t) => t.archived);
 
   const canCreate = permissionsUtil.canViewCreateFactTableModal(project);
 
@@ -92,7 +96,9 @@ export default function FactTablesPage() {
   );
 
   const { items, searchInputProps, isFiltered, SortableTH, clear } = useSearch({
-    items: factTablesWithLabels,
+    items: showArchived
+      ? factTablesWithLabels
+      : factTablesWithLabels.filter((t) => !t.archived),
     defaultSortField: "name",
     localStorageKey: "factTables",
     searchFields: [
@@ -211,6 +217,17 @@ export default function FactTablesPage() {
                 {...searchInputProps}
               />
             </div>
+            {hasArchivedFactTables && (
+              <div className="col-auto text-muted">
+                <Toggle
+                  value={showArchived}
+                  setValue={setShowArchived}
+                  id="show-archived"
+                  label="show archived"
+                />
+                Show archived
+              </div>
+            )}
             <div className="col-auto">
               <TagsFilter filter={tagsFilter} items={items} />
             </div>

--- a/packages/front-end/pages/metrics.tsx
+++ b/packages/front-end/pages/metrics.tsx
@@ -62,7 +62,7 @@ const MetricsPage = (): React.ReactElement => {
     getDatasourceById,
     mutateDefinitions,
     _metricsIncludingArchived: inlineMetrics,
-    factMetrics,
+    _factMetricsIncludingArchived: factMetrics,
     project,
     ready,
   } = useDefinitions();
@@ -128,7 +128,7 @@ const MetricsPage = (): React.ReactElement => {
       const item: MetricTableItem = {
         id: m.id,
         managedBy: m.managedBy || "",
-        archived: false,
+        archived: m.status === "archived",
         datasource: m.datasource,
         dateUpdated: m.dateUpdated,
         dateCreated: m.dateCreated,
@@ -138,6 +138,22 @@ const MetricsPage = (): React.ReactElement => {
         tags: m.tags || [],
         isRatio: m.metricType === "ratio",
         type: m.metricType,
+        onArchive: async (desiredState) => {
+          const newStatus = desiredState ? "archived" : "active";
+          await apiCall(`/fact-metrics/${m.id}`, {
+            method: "PUT",
+            body: JSON.stringify({
+              status: newStatus,
+            }),
+          });
+          if (newStatus === "archived") {
+            setRecentlyArchived((set) => new Set([...set, m.id]));
+          } else {
+            setRecentlyArchived(
+              (set) => new Set([...set].filter((id) => id !== m.id))
+            );
+          }
+        },
       };
       return item;
     }),

--- a/packages/front-end/pages/metrics.tsx
+++ b/packages/front-end/pages/metrics.tsx
@@ -128,7 +128,7 @@ const MetricsPage = (): React.ReactElement => {
       const item: MetricTableItem = {
         id: m.id,
         managedBy: m.managedBy || "",
-        archived: m.status === "archived",
+        archived: !!m.archived,
         datasource: m.datasource,
         dateUpdated: m.dateUpdated,
         dateCreated: m.dateCreated,
@@ -138,15 +138,14 @@ const MetricsPage = (): React.ReactElement => {
         tags: m.tags || [],
         isRatio: m.metricType === "ratio",
         type: m.metricType,
-        onArchive: async (desiredState) => {
-          const newStatus = desiredState ? "archived" : "active";
+        onArchive: async (archivedState) => {
           await apiCall(`/fact-metrics/${m.id}`, {
             method: "PUT",
             body: JSON.stringify({
-              status: newStatus,
+              archived: archivedState,
             }),
           });
-          if (newStatus === "archived") {
+          if (archivedState) {
             setRecentlyArchived((set) => new Set([...set, m.id]));
           } else {
             setRecentlyArchived(

--- a/packages/front-end/services/DefinitionsContext.tsx
+++ b/packages/front-end/services/DefinitionsContext.tsx
@@ -148,7 +148,7 @@ export const DefinitionsProvider: FC<{ children: ReactNode }> = ({
     if (!data || !data.factMetrics) {
       return [];
     }
-    return data.factMetrics.filter((m) => m.status !== "archived");
+    return data.factMetrics.filter((m) => !m.archived);
   }, [data?.factMetrics]);
 
   const allFactMetrics = useMemo(() => {

--- a/packages/front-end/services/DefinitionsContext.tsx
+++ b/packages/front-end/services/DefinitionsContext.tsx
@@ -31,6 +31,7 @@ type Definitions = {
   savedGroups: SavedGroupInterface[];
   tags: TagInterface[];
   factTables: FactTableInterface[];
+  _factTablesIncludingArchived: FactTableInterface[];
   factMetrics: FactMetricInterface[];
   _factMetricsIncludingArchived: FactMetricInterface[];
 };
@@ -75,6 +76,7 @@ const defaultValue: DefinitionContextValue = {
   savedGroups: [],
   projects: [],
   factTables: [],
+  _factTablesIncludingArchived: [],
   factMetrics: [],
   _factMetricsIncludingArchived: [],
   getMetricById: () => null,
@@ -148,7 +150,20 @@ export const DefinitionsProvider: FC<{ children: ReactNode }> = ({
     if (!data || !data.factMetrics) {
       return [];
     }
-    return data.factMetrics.filter((m) => !m.archived);
+    return data.factMetrics.filter((m) => {
+      const numeratorFactTable = data.factTables.find(
+        (f) => f.id === m.denominator?.factTableId
+      );
+      const denominatorFactTable = m.denominator?.factTableId
+        ? data.factTables.find((f) => f.id === m.denominator?.factTableId)
+        : null;
+
+      return (
+        !m.archived &&
+        !numeratorFactTable?.archived &&
+        !denominatorFactTable?.archived
+      );
+    });
   }, [data?.factMetrics]);
 
   const allFactMetrics = useMemo(() => {
@@ -157,6 +172,22 @@ export const DefinitionsProvider: FC<{ children: ReactNode }> = ({
     }
     return data.factMetrics;
   }, [data?.factMetrics]);
+
+  const activeFactTables = useMemo(() => {
+    if (!data || !data.factTables) {
+      return [];
+    }
+
+    return data.factTables.filter((t) => !t.archived);
+  }, [data?.factTables]);
+
+  const allFactTables = useMemo(() => {
+    if (!data || !data.factTables) {
+      return [];
+    }
+
+    return data.factTables;
+  }, [data?.factTables]);
 
   const getMetricById = useGetById(data?.metrics);
   const getDatasourceById = useGetById(data?.datasources);
@@ -199,7 +230,8 @@ export const DefinitionsProvider: FC<{ children: ReactNode }> = ({
       savedGroups: data.savedGroups,
       projects: data.projects,
       project: filteredProject,
-      factTables: data.factTables,
+      factTables: activeFactTables,
+      _factTablesIncludingArchived: allFactTables,
       factMetrics: activeFactMetrics,
       _factMetricsIncludingArchived: allFactMetrics,
       setProject,

--- a/packages/front-end/services/DefinitionsContext.tsx
+++ b/packages/front-end/services/DefinitionsContext.tsx
@@ -32,6 +32,7 @@ type Definitions = {
   tags: TagInterface[];
   factTables: FactTableInterface[];
   factMetrics: FactMetricInterface[];
+  _factMetricsIncludingArchived: FactMetricInterface[];
 };
 
 type DefinitionContextValue = Definitions & {
@@ -75,6 +76,7 @@ const defaultValue: DefinitionContextValue = {
   projects: [],
   factTables: [],
   factMetrics: [],
+  _factMetricsIncludingArchived: [],
   getMetricById: () => null,
   getDatasourceById: () => null,
   getDimensionById: () => null,
@@ -142,6 +144,20 @@ export const DefinitionsProvider: FC<{ children: ReactNode }> = ({
     return data.metrics;
   }, [data?.metrics]);
 
+  const activeFactMetrics = useMemo(() => {
+    if (!data || !data.factMetrics) {
+      return [];
+    }
+    return data.factMetrics.filter((m) => m.status !== "archived");
+  }, [data?.factMetrics]);
+
+  const allFactMetrics = useMemo(() => {
+    if (!data || !data.factMetrics) {
+      return [];
+    }
+    return data.factMetrics;
+  }, [data?.factMetrics]);
+
   const getMetricById = useGetById(data?.metrics);
   const getDatasourceById = useGetById(data?.datasources);
   const getDimensionById = useGetById(data?.dimensions);
@@ -184,7 +200,8 @@ export const DefinitionsProvider: FC<{ children: ReactNode }> = ({
       projects: data.projects,
       project: filteredProject,
       factTables: data.factTables,
-      factMetrics: data.factMetrics,
+      factMetrics: activeFactMetrics,
+      _factMetricsIncludingArchived: allFactMetrics,
       setProject,
       getMetricById,
       getDatasourceById,


### PR DESCRIPTION
### Features and Changes

Allows users to duplicate/archive fact metrics and archive fact tables. For duplicating fact metrics we're only allowing users to do it within its parent fact table and not in the overall metrics list. I felt like it would be a weird UX to allow duplication from that overall list.


### Testing

1. Create a few fact tables with metrics
2. Archive some of the fact tables and make sure their associated fact metrics don't show up as potential metrics for experiments.
3. Make sure the show archived toggles work as expected
4. Try archiving metrics within a fact table
5. Archive and unarchive a fact table with some archived metrics and make sure their archived state remains the same

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->

### To-Do

- [x] Show which metrics have been archived within a Fact Table page 
