### PR TITLE
Fix concurrency limit being handled improperly when set to 0

### DIFF
--- a/packages/back-end/types/datasource.d.ts
+++ b/packages/back-end/types/datasource.d.ts
@@ -220,7 +220,7 @@ export type DataSourceSettings = {
     userIdColumn?: string;
   };
   pipelineSettings?: DataSourcePipelineSettings;
-  maxConcurrentQueries?: number;
+  maxConcurrentQueries?: string;
 };
 
 interface DataSourceBase {


### PR DESCRIPTION
### Features and Changes

Organization settings are stored as strings, and the string `"0"` is truthy while the number `0` is falsy. Also, apparently numeric comparisons work against strings with numbers, hence why the `if (this.integration.datasource.settings.maxConcurrentQueries)` didn't protect us.

This changes the Typescript definition for the setting to a `string` to reflect reality, and parses the value when needed, checking for `NaN` before using it

### Testing

Try a concurrency limit of `0`, `1`, and an empty string to observe the expected behavior:
- 0 or empty string should run all queries at the same time (takes about 3 seconds for my testing experiment)
- 1 runs one query and queues the rest, and they slowly make their way out of the queue and are completed in a total of ~20s
