### PR TITLE
Fix metric analysis for ratio metrics with capping

### DIFF
--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -808,6 +808,19 @@ export default abstract class SqlIntegration
                   ignoreZeros:
                     metricData.metric.cappingSettings.ignoreZeros ?? false,
                 },
+                ...(metricData.ratioMetric
+                  ? [
+                      {
+                        valueCol: "denominator",
+                        outputCol: "denominator_capped",
+                        percentile:
+                          metricData.metric.cappingSettings.value ?? 1,
+                        ignoreZeros:
+                          metricData.metric.cappingSettings.ignoreZeros ??
+                          false,
+                      },
+                    ]
+                  : []),
               ],
               "__userMetricOverall"
             )}
@@ -819,6 +832,7 @@ export default abstract class SqlIntegration
           SELECT
             date
             , MAX(${this.castToString("'date'")}) AS data_type
+            , '${metric.cappingSettings.type ? "capped" : "uncapped"}' AS capped
             ${this.getMetricAnalysisStatisticClauses(
               finalValueColumn,
               finalDenominatorColumn,
@@ -843,6 +857,7 @@ export default abstract class SqlIntegration
           SELECT
             ${this.castToDate("NULL")} AS date
             , MAX(${this.castToString("'overall'")}) AS data_type
+            , '${metric.cappingSettings.type ? "capped" : "uncapped"}' AS capped
             ${this.getMetricAnalysisStatisticClauses(
               finalValueColumn,
               finalDenominatorColumn,


### PR DESCRIPTION
Previously, capping was causing ratio metrics to break in the new Metric Analysis tool.

This fixes that.

Fixed behavior:
<img width="1343" alt="Screenshot 2024-08-22 at 1 58 32 PM" src="https://github.com/user-attachments/assets/9983fb64-9670-451a-8e6b-9f614084fa80">
