### PR TITLE
Update JS SDK to be compatible with the JSR

### DIFF
--- a/packages/sdk-js/jsr.json
+++ b/packages/sdk-js/jsr.json
@@ -1,0 +1,5 @@
+{
+  "name": "@growthbook/growthbook",
+  "version": "0.0.1",
+  "exports": "./src/index.ts"
+}

--- a/packages/sdk-js/jsr.json
+++ b/packages/sdk-js/jsr.json
@@ -1,5 +1,8 @@
 {
   "name": "@growthbook/growthbook",
   "version": "0.0.1",
-  "exports": "./src/index.ts"
+  "exports": "./src/index.ts",
+  "publish": {
+    "include": ["README.md", "CHANGELOG.md", "src/**/*.ts"]
+  }
 }

--- a/packages/sdk-js/src/GrowthBook.ts
+++ b/packages/sdk-js/src/GrowthBook.ts
@@ -503,7 +503,7 @@ export class GrowthBook<
     this._updateAllAutoExperiments();
   }
 
-  public async updateAttributes(attributes: Attributes) {
+  public async updateAttributes(attributes: Attributes): Promise<void> {
     return this.setAttributes({ ...this._ctx.attributes, ...attributes });
   }
 
@@ -548,32 +548,35 @@ export class GrowthBook<
     this._updateAllAutoExperiments(true);
   }
 
-  public getAttributes() {
+  public getAttributes(): Attributes {
     return { ...this._ctx.attributes, ...this._attributeOverrides };
   }
 
-  public getForcedVariations() {
+  public getForcedVariations(): Record<string, number> {
     return this._ctx.forcedVariations || {};
   }
 
-  public getForcedFeatures() {
+  public getForcedFeatures(): Map<string, unknown> {
     // eslint-disable-next-line
     return this._forcedFeatureValues || new Map<string, any>();
   }
 
-  public getStickyBucketAssignmentDocs() {
+  public getStickyBucketAssignmentDocs(): Record<
+    string,
+    StickyAssignmentsDocument
+  > {
     return this._ctx.stickyBucketAssignmentDocs || {};
   }
 
-  public getUrl() {
+  public getUrl(): string {
     return this._ctx.url || "";
   }
 
-  public getFeatures() {
+  public getFeatures(): Record<string, FeatureDefinition> {
     return this._ctx.features || {};
   }
 
-  public getExperiments() {
+  public getExperiments(): AutoExperiment[] {
     return this._ctx.experiments || [];
   }
 
@@ -603,7 +606,10 @@ export class GrowthBook<
     }
   }
 
-  public getAllResults() {
+  public getAllResults(): Map<
+    string,
+    { experiment: Experiment<unknown>; result: Result<unknown> }
+  > {
     return new Map(this._assigned);
   }
 
@@ -655,7 +661,9 @@ export class GrowthBook<
     return result;
   }
 
-  public triggerExperiment(key: string) {
+  public triggerExperiment(
+    key: string
+  ): Result<AutoExperimentVariation>[] | null {
     this._triggeredExpKeys.add(key);
     if (!this._ctx.experiments) return null;
     const experiments = this._ctx.experiments.filter((exp) => exp.key === key);
@@ -663,7 +671,7 @@ export class GrowthBook<
       .map((exp) => {
         return this._runAutoExperiment(exp);
       })
-      .filter((res) => res !== null);
+      .filter((res): res is Result<AutoExperimentVariation> => res !== null);
   }
 
   public triggerAutoExperiments() {

--- a/packages/sdk-js/src/sticky-bucket-service.ts
+++ b/packages/sdk-js/src/sticky-bucket-service.ts
@@ -91,7 +91,10 @@ export class LocalStorageStickyBucketService extends StickyBucketService {
       // Ignore localStorage errors
     }
   }
-  async getAssignments(attributeName: string, attributeValue: string) {
+  async getAssignments(
+    attributeName: string,
+    attributeValue: string
+  ): Promise<StickyAssignmentsDocument | null> {
     const key = `${attributeName}||${attributeValue}`;
     let doc: StickyAssignmentsDocument | null = null;
     if (!this.localStorage) return doc;
@@ -146,7 +149,10 @@ export class ExpressCookieStickyBucketService extends StickyBucketService {
     this.res = res;
     this.cookieAttributes = cookieAttributes;
   }
-  async getAssignments(attributeName: string, attributeValue: string) {
+  async getAssignments(
+    attributeName: string,
+    attributeValue: string
+  ): Promise<StickyAssignmentsDocument | null> {
     const key = `${attributeName}||${attributeValue}`;
     let doc: StickyAssignmentsDocument | null = null;
     if (!this.req) return doc;
@@ -198,7 +204,10 @@ export class BrowserCookieStickyBucketService extends StickyBucketService {
     this.jsCookie = jsCookie;
     this.cookieAttributes = cookieAttributes;
   }
-  async getAssignments(attributeName: string, attributeValue: string) {
+  async getAssignments(
+    attributeName: string,
+    attributeValue: string
+  ): Promise<StickyAssignmentsDocument | null> {
     const key = `${attributeName}||${attributeValue}`;
     let doc: StickyAssignmentsDocument | null = null;
     if (!this.jsCookie) return doc;
@@ -253,7 +262,10 @@ export class RedisStickyBucketService extends StickyBucketService {
     return docs;
   }
 
-  async getAssignments(_attributeName: string, _attributeValue: string) {
+  async getAssignments(
+    _attributeName: string,
+    _attributeValue: string
+  ): Promise<null> {
     // not implemented
     return null;
   }

--- a/packages/sdk-js/src/types/growthbook.ts
+++ b/packages/sdk-js/src/types/growthbook.ts
@@ -1,13 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import type { GrowthBook, StickyBucketService } from "..";
+import type { StickyBucketService } from "..";
 import { ConditionInterface, ParentConditionInterface } from "./mongrule";
-
-declare global {
-  interface Window {
-    _growthbook?: GrowthBook;
-  }
-}
 
 export type VariationMeta = {
   passthrough?: boolean;

--- a/packages/sdk-js/src/util.ts
+++ b/packages/sdk-js/src/util.ts
@@ -83,7 +83,7 @@ export function getUrlRegExp(regexString: string): RegExp | undefined {
   }
 }
 
-export function isURLTargeted(url: string, targets: UrlTarget[]) {
+export function isURLTargeted(url: string, targets: UrlTarget[]): boolean {
   if (!targets.length) return false;
   let hasIncludeRules = false;
   let isIncluded = false;


### PR DESCRIPTION
### Features and Changes
The [JSR (JavaScript Registry)](https://jsr.io/) is an open-source package registry (it builds on npm). In order to publish our JS SDK, we need to make a few updates to our codebase:

- Define explicit return types
- Remove or refactor global type declarations

The reason is that JSR allows you to publish TS directly to the registry. They then handle building compatible versions for users. For this and features, JSR analyzes source code, and it turns out that certain[ types are slow](https://jsr.io/docs/about-slow-types). 

These changes enable us to publish to the registry and, in theory, should improve type analysis.

### Dependencies

None

### Testing
Passes all tests in the SDK test suite.



