### PR TITLE
Default protocol ports for proxy uri parsing

### DIFF
--- a/packages/back-end/test/services/snowflake.test.ts
+++ b/packages/back-end/test/services/snowflake.test.ts
@@ -1,0 +1,103 @@
+import { getProxySettings } from "../../src/services/snowflake";
+
+describe("snowflake", () => {
+  describe("getProxySettings", () => {
+    it("should return an empty object for proxy settings if the uri is not set", () => {
+      const proxySettings = getProxySettings(undefined);
+
+      expect(proxySettings).toEqual({});
+    });
+
+    it("should return a parsed protocol, host, and port for a url", () => {
+      const proxySettings = getProxySettings(
+        "http://local.snowflake.proxy:8000"
+      );
+
+      expect(proxySettings).toEqual({
+        proxyProtocol: "http:",
+        proxyHost: "local.snowflake.proxy",
+        proxyPort: 8000,
+      });
+    });
+
+    it("should return a parsed protocol, host, port, username, and password for a url", () => {
+      const proxySettings = getProxySettings(
+        "http://snowflakeUser:snowflakePassword@local.snowflake.proxy:8000"
+      );
+
+      expect(proxySettings).toEqual({
+        proxyProtocol: "http:",
+        proxyHost: "local.snowflake.proxy",
+        proxyPort: 8000,
+        proxyUser: "snowflakeUser",
+        proxyPassword: "snowflakePassword",
+      });
+    });
+
+    it("should return the default port for a parsed https protocol because the snowflake sdk requires a port", () => {
+      const proxySettings = getProxySettings("https://local.snowflake.proxy");
+
+      expect(proxySettings).toEqual({
+        proxyProtocol: "https:",
+        proxyHost: "local.snowflake.proxy",
+        proxyPort: 443,
+      });
+    });
+
+    it("should return the default port for a parsed https protocol when it's specified because nodejs removes it during parsing", () => {
+      const proxySettings = getProxySettings(
+        "https://local.snowflake.proxy:443"
+      );
+
+      expect(proxySettings).toEqual({
+        proxyProtocol: "https:",
+        proxyHost: "local.snowflake.proxy",
+        proxyPort: 443,
+      });
+    });
+
+    it("should return the specified non-default port for a parsed https protocol", () => {
+      const proxySettings = getProxySettings(
+        "https://local.snowflake.proxy:8000"
+      );
+
+      expect(proxySettings).toEqual({
+        proxyProtocol: "https:",
+        proxyHost: "local.snowflake.proxy",
+        proxyPort: 8000,
+      });
+    });
+
+    it("should return the default port for a parsed http protocol because the snowflake sdk requires a port", () => {
+      const proxySettings = getProxySettings("http://local.snowflake.proxy");
+
+      expect(proxySettings).toEqual({
+        proxyProtocol: "http:",
+        proxyHost: "local.snowflake.proxy",
+        proxyPort: 80,
+      });
+    });
+
+    it("should return the default port for a parsed http protocol when it's specified because nodejs removes it during parsing", () => {
+      const proxySettings = getProxySettings("http://local.snowflake.proxy:80");
+
+      expect(proxySettings).toEqual({
+        proxyProtocol: "http:",
+        proxyHost: "local.snowflake.proxy",
+        proxyPort: 80,
+      });
+    });
+
+    it("should return the specified non-default port for a parsed http protocol", () => {
+      const proxySettings = getProxySettings(
+        "http://local.snowflake.proxy:8000"
+      );
+
+      expect(proxySettings).toEqual({
+        proxyProtocol: "http:",
+        proxyHost: "local.snowflake.proxy",
+        proxyPort: 8000,
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Features and Changes

Our company uses the "Yuki" cost optimization tool on our snowflake instance.  I attempted to use the `SNOWFLAKE_PROXY` environment override on our self-hosted instance.  The yuki proxy is not a self hosted authenticated proxy, but instead a fully qualified https access point to our snowflake database.  The nodejs URL constructor drops port definitions when parsing a uri, and the snowflake sdk requires a port when you specify a proxy host.  Therefore if you specify a proxy uri such as `https://abcd-wxyz.yukicomputing.com:443`, node will drop the 443 port definition, and the snowflake sdk will throw an error saying that you must specify the `proxyPort`.  

Ultimately, our company actually needs the results of this [PR](https://github.com/growthbook/growthbook/pull/2890).  I didn't discover it until now, but figured I'd throw this up in case it's needed by someone else.

### Testing

- Included automated testing for the proxy settings parsing logic
