### PR TITLE
Fix 'undefined' appearing in nodeSDK instructions

### DIFF
--- a/packages/front-end/components/SyntaxHighlighting/Snippets/GrowthBookSetupCodeSnippet.tsx
+++ b/packages/front-end/components/SyntaxHighlighting/Snippets/GrowthBookSetupCodeSnippet.tsx
@@ -190,10 +190,11 @@ const { setPolyfills } = require("@growthbook/growthbook");
 setPolyfills({
   // Required for Node 17 or earlier
   fetch: require("cross-fetch"),${
-    encryptionKey &&
-    `
+    encryptionKey
+      ? `
   // Required for Node 18 or earlier
   SubtleCrypto: require("node:crypto").webcrypto.subtle,`
+      : ""
   }
   // Optional, can make feature rollouts faster
   EventSource: require("eventsource")


### PR DESCRIPTION
`undefined && 'something' === undefined`, so switched to using a ternary to avoid 'undefined' getting printed out in the instructions.