### PR TITLE
Add tracking event props to Modal

### DIFF
--- a/packages/front-end/components/Admin/CreateOrganization.tsx
+++ b/packages/front-end/components/Admin/CreateOrganization.tsx
@@ -30,7 +30,6 @@ const CreateOrganization: FC<{
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       submit={handleSubmit}
       open={true}
       header={"Create New Organization"}

--- a/packages/front-end/components/Admin/CreateOrganization.tsx
+++ b/packages/front-end/components/Admin/CreateOrganization.tsx
@@ -29,6 +29,7 @@ const CreateOrganization: FC<{
 
   return (
     <Modal
+      trackingEventName=""
       submit={handleSubmit}
       open={true}
       header={"Create New Organization"}

--- a/packages/front-end/components/Admin/CreateOrganization.tsx
+++ b/packages/front-end/components/Admin/CreateOrganization.tsx
@@ -29,7 +29,8 @@ const CreateOrganization: FC<{
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       submit={handleSubmit}
       open={true}
       header={"Create New Organization"}

--- a/packages/front-end/components/Admin/EditOrganization.tsx
+++ b/packages/front-end/components/Admin/EditOrganization.tsx
@@ -52,6 +52,7 @@ const EditOrganization: FC<{
 
   return (
     <Modal
+      trackingEventName=""
       submit={handleSubmit}
       open={true}
       header={"Edit Organization"}

--- a/packages/front-end/components/Admin/EditOrganization.tsx
+++ b/packages/front-end/components/Admin/EditOrganization.tsx
@@ -52,7 +52,8 @@ const EditOrganization: FC<{
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       submit={handleSubmit}
       open={true}
       header={"Edit Organization"}

--- a/packages/front-end/components/Admin/EditOrganization.tsx
+++ b/packages/front-end/components/Admin/EditOrganization.tsx
@@ -53,7 +53,6 @@ const EditOrganization: FC<{
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       submit={handleSubmit}
       open={true}
       header={"Edit Organization"}

--- a/packages/front-end/components/Archetype/ArchetypeAttributesModal.tsx
+++ b/packages/front-end/components/Archetype/ArchetypeAttributesModal.tsx
@@ -35,7 +35,8 @@ const ArchetypeAttributesModal: FC<{
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       open={true}
       autoCloseOnSubmit={false}
       close={close}

--- a/packages/front-end/components/Archetype/ArchetypeAttributesModal.tsx
+++ b/packages/front-end/components/Archetype/ArchetypeAttributesModal.tsx
@@ -36,7 +36,6 @@ const ArchetypeAttributesModal: FC<{
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       open={true}
       autoCloseOnSubmit={false}
       close={close}

--- a/packages/front-end/components/Archetype/ArchetypeAttributesModal.tsx
+++ b/packages/front-end/components/Archetype/ArchetypeAttributesModal.tsx
@@ -35,6 +35,7 @@ const ArchetypeAttributesModal: FC<{
 
   return (
     <Modal
+      trackingEventName=""
       open={true}
       autoCloseOnSubmit={false}
       close={close}

--- a/packages/front-end/components/Archetype/AssignmentTester.tsx
+++ b/packages/front-end/components/Archetype/AssignmentTester.tsx
@@ -382,7 +382,8 @@ export default function AssignmentTester({ feature, version }: Props) {
             />
           ) : (
             <Modal
-              trackingEventName=""
+              trackingEventModalType=""
+              trackingEventModalSource=""
               open={true}
               close={() => setOpenArchetypeModal(null)}
             >

--- a/packages/front-end/components/Archetype/AssignmentTester.tsx
+++ b/packages/front-end/components/Archetype/AssignmentTester.tsx
@@ -381,7 +381,11 @@ export default function AssignmentTester({ feature, version }: Props) {
               header="Save Archetype"
             />
           ) : (
-            <Modal open={true} close={() => setOpenArchetypeModal(null)}>
+            <Modal
+              trackingEventName=""
+              open={true}
+              close={() => setOpenArchetypeModal(null)}
+            >
               <div className="p-3">
                 Archetypes allow you set up user attribute traits to test how
                 feature will be applied to your real users. This feature is part

--- a/packages/front-end/components/Archetype/AssignmentTester.tsx
+++ b/packages/front-end/components/Archetype/AssignmentTester.tsx
@@ -383,7 +383,6 @@ export default function AssignmentTester({ feature, version }: Props) {
           ) : (
             <Modal
               trackingEventModalType=""
-              trackingEventModalSource=""
               open={true}
               close={() => setOpenArchetypeModal(null)}
             >

--- a/packages/front-end/components/Auth/ChangePasswordModal.tsx
+++ b/packages/front-end/components/Auth/ChangePasswordModal.tsx
@@ -17,7 +17,8 @@ const ChangePasswordModal: FC<{
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       header="Change Password"
       open={true}
       autoCloseOnSubmit={false}

--- a/packages/front-end/components/Auth/ChangePasswordModal.tsx
+++ b/packages/front-end/components/Auth/ChangePasswordModal.tsx
@@ -17,6 +17,7 @@ const ChangePasswordModal: FC<{
 
   return (
     <Modal
+      trackingEventName=""
       header="Change Password"
       open={true}
       autoCloseOnSubmit={false}

--- a/packages/front-end/components/Auth/ChangePasswordModal.tsx
+++ b/packages/front-end/components/Auth/ChangePasswordModal.tsx
@@ -18,7 +18,6 @@ const ChangePasswordModal: FC<{
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       header="Change Password"
       open={true}
       autoCloseOnSubmit={false}

--- a/packages/front-end/components/AutoGenerateFactTablesModal.tsx
+++ b/packages/front-end/components/AutoGenerateFactTablesModal.tsx
@@ -272,7 +272,8 @@ export default function AutoGenerateFactTableModal({
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       size="lg"
       open={true}
       header="Discover Fact Tables"

--- a/packages/front-end/components/AutoGenerateFactTablesModal.tsx
+++ b/packages/front-end/components/AutoGenerateFactTablesModal.tsx
@@ -273,7 +273,6 @@ export default function AutoGenerateFactTableModal({
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       size="lg"
       open={true}
       header="Discover Fact Tables"

--- a/packages/front-end/components/AutoGenerateFactTablesModal.tsx
+++ b/packages/front-end/components/AutoGenerateFactTablesModal.tsx
@@ -272,6 +272,7 @@ export default function AutoGenerateFactTableModal({
 
   return (
     <Modal
+      trackingEventName=""
       size="lg"
       open={true}
       header="Discover Fact Tables"

--- a/packages/front-end/components/AutoGenerateMetricsModal.tsx
+++ b/packages/front-end/components/AutoGenerateMetricsModal.tsx
@@ -275,6 +275,7 @@ export default function AutoGenerateMetricsModal({
 
   return (
     <Modal
+      trackingEventName=""
       size="lg"
       open={true}
       header="Discover Metrics"

--- a/packages/front-end/components/AutoGenerateMetricsModal.tsx
+++ b/packages/front-end/components/AutoGenerateMetricsModal.tsx
@@ -275,7 +275,8 @@ export default function AutoGenerateMetricsModal({
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       size="lg"
       open={true}
       header="Discover Metrics"

--- a/packages/front-end/components/AutoGenerateMetricsModal.tsx
+++ b/packages/front-end/components/AutoGenerateMetricsModal.tsx
@@ -276,7 +276,6 @@ export default function AutoGenerateMetricsModal({
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       size="lg"
       open={true}
       header="Discover Metrics"

--- a/packages/front-end/components/Carousel.tsx
+++ b/packages/front-end/components/Carousel.tsx
@@ -48,7 +48,6 @@ const Carousel: FC<{
       {modalOpen && currentChild && (
         <Modal
           trackingEventModalType=""
-          trackingEventModalSource=""
           open={true}
           header={"Screenshot"}
           close={() => setModalOpen(false)}

--- a/packages/front-end/components/Carousel.tsx
+++ b/packages/front-end/components/Carousel.tsx
@@ -47,6 +47,7 @@ const Carousel: FC<{
     <div className="carousel slide my-2">
       {modalOpen && currentChild && (
         <Modal
+          trackingEventName=""
           open={true}
           header={"Screenshot"}
           close={() => setModalOpen(false)}

--- a/packages/front-end/components/Carousel.tsx
+++ b/packages/front-end/components/Carousel.tsx
@@ -47,7 +47,8 @@ const Carousel: FC<{
     <div className="carousel slide my-2">
       {modalOpen && currentChild && (
         <Modal
-          trackingEventName=""
+          trackingEventModalType=""
+          trackingEventModalSource=""
           open={true}
           header={"Screenshot"}
           close={() => setModalOpen(false)}

--- a/packages/front-end/components/DeleteButton/DeleteButton.tsx
+++ b/packages/front-end/components/DeleteButton/DeleteButton.tsx
@@ -60,7 +60,6 @@ const DeleteButton: FC<{
       {confirming ? (
         <Modal
           trackingEventModalType=""
-          trackingEventModalSource=""
           header={`Delete ${displayName}`}
           close={() => setConfirming(false)}
           open={true}

--- a/packages/front-end/components/DeleteButton/DeleteButton.tsx
+++ b/packages/front-end/components/DeleteButton/DeleteButton.tsx
@@ -59,6 +59,7 @@ const DeleteButton: FC<{
     <>
       {confirming ? (
         <Modal
+          trackingEventName=""
           header={`Delete ${displayName}`}
           close={() => setConfirming(false)}
           open={true}

--- a/packages/front-end/components/DeleteButton/DeleteButton.tsx
+++ b/packages/front-end/components/DeleteButton/DeleteButton.tsx
@@ -59,7 +59,8 @@ const DeleteButton: FC<{
     <>
       {confirming ? (
         <Modal
-          trackingEventName=""
+          trackingEventModalType=""
+          trackingEventModalSource=""
           header={`Delete ${displayName}`}
           close={() => setConfirming(false)}
           open={true}

--- a/packages/front-end/components/Dimensions/DimensionForm.tsx
+++ b/packages/front-end/components/Dimensions/DimensionForm.tsx
@@ -72,7 +72,8 @@ const DimensionForm: FC<{
         />
       )}
       <Modal
-        trackingEventName=""
+        trackingEventModalType=""
+        trackingEventModalSource=""
         close={close}
         open={true}
         size="md"

--- a/packages/front-end/components/Dimensions/DimensionForm.tsx
+++ b/packages/front-end/components/Dimensions/DimensionForm.tsx
@@ -73,7 +73,6 @@ const DimensionForm: FC<{
       )}
       <Modal
         trackingEventModalType=""
-        trackingEventModalSource=""
         close={close}
         open={true}
         size="md"

--- a/packages/front-end/components/Dimensions/DimensionForm.tsx
+++ b/packages/front-end/components/Dimensions/DimensionForm.tsx
@@ -72,6 +72,7 @@ const DimensionForm: FC<{
         />
       )}
       <Modal
+        trackingEventName=""
         close={close}
         open={true}
         size="md"

--- a/packages/front-end/components/EventWebHooks/EventWebHookAddEditModal/EventWebHookAddEditModal.tsx
+++ b/packages/front-end/components/EventWebHooks/EventWebHookAddEditModal/EventWebHookAddEditModal.tsx
@@ -533,7 +533,8 @@ export const EventWebHookAddEditModal: FC<EventWebHookAddEditModalProps> = ({
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       header={modalTitle}
       cta={buttonText({ step, payloadType: form.watch("payloadType") })}
       includeCloseCta={false}

--- a/packages/front-end/components/EventWebHooks/EventWebHookAddEditModal/EventWebHookAddEditModal.tsx
+++ b/packages/front-end/components/EventWebHooks/EventWebHookAddEditModal/EventWebHookAddEditModal.tsx
@@ -534,7 +534,6 @@ export const EventWebHookAddEditModal: FC<EventWebHookAddEditModalProps> = ({
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       header={modalTitle}
       cta={buttonText({ step, payloadType: form.watch("payloadType") })}
       includeCloseCta={false}

--- a/packages/front-end/components/EventWebHooks/EventWebHookAddEditModal/EventWebHookAddEditModal.tsx
+++ b/packages/front-end/components/EventWebHooks/EventWebHookAddEditModal/EventWebHookAddEditModal.tsx
@@ -533,6 +533,7 @@ export const EventWebHookAddEditModal: FC<EventWebHookAddEditModalProps> = ({
 
   return (
     <Modal
+      trackingEventName=""
       header={modalTitle}
       cta={buttonText({ step, payloadType: form.watch("payloadType") })}
       includeCloseCta={false}

--- a/packages/front-end/components/Experiment/AddExperimentModal.tsx
+++ b/packages/front-end/components/Experiment/AddExperimentModal.tsx
@@ -102,7 +102,13 @@ const AddExperimentModal: FC<{
       return <ImportExperimentModal onClose={onClose} source={source} />;
     default:
       return (
-        <Modal open close={() => onClose()} size="lg" header="Add Experiment">
+        <Modal
+          trackingEventName=""
+          open
+          close={() => onClose()}
+          size="lg"
+          header="Add Experiment"
+        >
           <div
             style={{
               display: "flex",

--- a/packages/front-end/components/Experiment/AddExperimentModal.tsx
+++ b/packages/front-end/components/Experiment/AddExperimentModal.tsx
@@ -103,7 +103,8 @@ const AddExperimentModal: FC<{
     default:
       return (
         <Modal
-          trackingEventName=""
+          trackingEventModalType=""
+          trackingEventModalSource=""
           open
           close={() => onClose()}
           size="lg"

--- a/packages/front-end/components/Experiment/AddExperimentModal.tsx
+++ b/packages/front-end/components/Experiment/AddExperimentModal.tsx
@@ -104,7 +104,6 @@ const AddExperimentModal: FC<{
       return (
         <Modal
           trackingEventModalType=""
-          trackingEventModalSource=""
           open
           close={() => onClose()}
           size="lg"

--- a/packages/front-end/components/Experiment/AnalysisForm.tsx
+++ b/packages/front-end/components/Experiment/AnalysisForm.tsx
@@ -208,6 +208,7 @@ const AnalysisForm: FC<{
 
   return (
     <Modal
+      trackingEventName=""
       header={"Experiment Settings"}
       open={true}
       close={cancel}

--- a/packages/front-end/components/Experiment/AnalysisForm.tsx
+++ b/packages/front-end/components/Experiment/AnalysisForm.tsx
@@ -208,7 +208,8 @@ const AnalysisForm: FC<{
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       header={"Experiment Settings"}
       open={true}
       close={cancel}

--- a/packages/front-end/components/Experiment/AnalysisForm.tsx
+++ b/packages/front-end/components/Experiment/AnalysisForm.tsx
@@ -209,7 +209,6 @@ const AnalysisForm: FC<{
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       header={"Experiment Settings"}
       open={true}
       close={cancel}

--- a/packages/front-end/components/Experiment/EditDOMMutationsModal.tsx
+++ b/packages/front-end/components/Experiment/EditDOMMutationsModal.tsx
@@ -162,7 +162,6 @@ const EditDOMMutatonsModal: FC<{
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       open
       close={close}
       size="lg"

--- a/packages/front-end/components/Experiment/EditDOMMutationsModal.tsx
+++ b/packages/front-end/components/Experiment/EditDOMMutationsModal.tsx
@@ -161,6 +161,7 @@ const EditDOMMutatonsModal: FC<{
 
   return (
     <Modal
+      trackingEventName=""
       open
       close={close}
       size="lg"

--- a/packages/front-end/components/Experiment/EditDOMMutationsModal.tsx
+++ b/packages/front-end/components/Experiment/EditDOMMutationsModal.tsx
@@ -161,7 +161,8 @@ const EditDOMMutatonsModal: FC<{
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       open
       close={close}
       size="lg"

--- a/packages/front-end/components/Experiment/EditDataSourceForm.tsx
+++ b/packages/front-end/components/Experiment/EditDataSourceForm.tsx
@@ -36,7 +36,6 @@ const EditDataSourceForm: FC<{
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       header={"Edit Data Source Settings"}
       open={true}
       close={cancel}

--- a/packages/front-end/components/Experiment/EditDataSourceForm.tsx
+++ b/packages/front-end/components/Experiment/EditDataSourceForm.tsx
@@ -35,6 +35,7 @@ const EditDataSourceForm: FC<{
 
   return (
     <Modal
+      trackingEventName=""
       header={"Edit Data Source Settings"}
       open={true}
       close={cancel}

--- a/packages/front-end/components/Experiment/EditDataSourceForm.tsx
+++ b/packages/front-end/components/Experiment/EditDataSourceForm.tsx
@@ -35,7 +35,8 @@ const EditDataSourceForm: FC<{
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       header={"Edit Data Source Settings"}
       open={true}
       close={cancel}

--- a/packages/front-end/components/Experiment/EditExperimentNameForm.tsx
+++ b/packages/front-end/components/Experiment/EditExperimentNameForm.tsx
@@ -19,7 +19,8 @@ const EditExperimentNameForm: FC<{
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       header={"Edit Name"}
       open={true}
       close={cancel}

--- a/packages/front-end/components/Experiment/EditExperimentNameForm.tsx
+++ b/packages/front-end/components/Experiment/EditExperimentNameForm.tsx
@@ -19,6 +19,7 @@ const EditExperimentNameForm: FC<{
 
   return (
     <Modal
+      trackingEventName=""
       header={"Edit Name"}
       open={true}
       close={cancel}

--- a/packages/front-end/components/Experiment/EditExperimentNameForm.tsx
+++ b/packages/front-end/components/Experiment/EditExperimentNameForm.tsx
@@ -20,7 +20,6 @@ const EditExperimentNameForm: FC<{
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       header={"Edit Name"}
       open={true}
       close={cancel}

--- a/packages/front-end/components/Experiment/EditMetricsForm.tsx
+++ b/packages/front-end/components/Experiment/EditMetricsForm.tsx
@@ -169,7 +169,8 @@ const EditMetricsForm: FC<{
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       autoFocusSelector=""
       header="Edit Metrics"
       size="lg"

--- a/packages/front-end/components/Experiment/EditMetricsForm.tsx
+++ b/packages/front-end/components/Experiment/EditMetricsForm.tsx
@@ -169,6 +169,7 @@ const EditMetricsForm: FC<{
 
   return (
     <Modal
+      trackingEventName=""
       autoFocusSelector=""
       header="Edit Metrics"
       size="lg"

--- a/packages/front-end/components/Experiment/EditMetricsForm.tsx
+++ b/packages/front-end/components/Experiment/EditMetricsForm.tsx
@@ -170,7 +170,6 @@ const EditMetricsForm: FC<{
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       autoFocusSelector=""
       header="Edit Metrics"
       size="lg"

--- a/packages/front-end/components/Experiment/EditPhaseModal.tsx
+++ b/packages/front-end/components/Experiment/EditPhaseModal.tsx
@@ -44,7 +44,8 @@ export default function EditPhaseModal({
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       open={true}
       close={close}
       header={`Edit Analysis Phase #${i + 1}`}

--- a/packages/front-end/components/Experiment/EditPhaseModal.tsx
+++ b/packages/front-end/components/Experiment/EditPhaseModal.tsx
@@ -44,6 +44,7 @@ export default function EditPhaseModal({
 
   return (
     <Modal
+      trackingEventName=""
       open={true}
       close={close}
       header={`Edit Analysis Phase #${i + 1}`}

--- a/packages/front-end/components/Experiment/EditPhaseModal.tsx
+++ b/packages/front-end/components/Experiment/EditPhaseModal.tsx
@@ -45,7 +45,6 @@ export default function EditPhaseModal({
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       open={true}
       close={close}
       header={`Edit Analysis Phase #${i + 1}`}

--- a/packages/front-end/components/Experiment/EditPhasesModal.tsx
+++ b/packages/front-end/components/Experiment/EditPhasesModal.tsx
@@ -73,6 +73,7 @@ export default function EditPhasesModal({
 
   return (
     <Modal
+      trackingEventName=""
       open={true}
       header="Edit Phases"
       close={close}

--- a/packages/front-end/components/Experiment/EditPhasesModal.tsx
+++ b/packages/front-end/components/Experiment/EditPhasesModal.tsx
@@ -74,7 +74,6 @@ export default function EditPhasesModal({
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       open={true}
       header="Edit Phases"
       close={close}

--- a/packages/front-end/components/Experiment/EditPhasesModal.tsx
+++ b/packages/front-end/components/Experiment/EditPhasesModal.tsx
@@ -73,7 +73,8 @@ export default function EditPhasesModal({
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       open={true}
       header="Edit Phases"
       close={close}

--- a/packages/front-end/components/Experiment/EditProjectForm.tsx
+++ b/packages/front-end/components/Experiment/EditProjectForm.tsx
@@ -39,7 +39,8 @@ const EditProjectForm: FC<{
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       header={"Edit Project"}
       open={true}
       close={cancel}

--- a/packages/front-end/components/Experiment/EditProjectForm.tsx
+++ b/packages/front-end/components/Experiment/EditProjectForm.tsx
@@ -39,6 +39,7 @@ const EditProjectForm: FC<{
 
   return (
     <Modal
+      trackingEventName=""
       header={"Edit Project"}
       open={true}
       close={cancel}

--- a/packages/front-end/components/Experiment/EditProjectForm.tsx
+++ b/packages/front-end/components/Experiment/EditProjectForm.tsx
@@ -40,7 +40,6 @@ const EditProjectForm: FC<{
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       header={"Edit Project"}
       open={true}
       close={cancel}

--- a/packages/front-end/components/Experiment/EditStatusModal.tsx
+++ b/packages/front-end/components/Experiment/EditStatusModal.tsx
@@ -29,6 +29,7 @@ export default function EditStatusModal({ experiment, close, mutate }: Props) {
 
   return (
     <Modal
+      trackingEventName=""
       header={"Change Experiment Status"}
       close={close}
       open={true}

--- a/packages/front-end/components/Experiment/EditStatusModal.tsx
+++ b/packages/front-end/components/Experiment/EditStatusModal.tsx
@@ -30,7 +30,6 @@ export default function EditStatusModal({ experiment, close, mutate }: Props) {
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       header={"Change Experiment Status"}
       close={close}
       open={true}

--- a/packages/front-end/components/Experiment/EditStatusModal.tsx
+++ b/packages/front-end/components/Experiment/EditStatusModal.tsx
@@ -29,7 +29,8 @@ export default function EditStatusModal({ experiment, close, mutate }: Props) {
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       header={"Change Experiment Status"}
       close={close}
       open={true}

--- a/packages/front-end/components/Experiment/EditTargetingModal.tsx
+++ b/packages/front-end/components/Experiment/EditTargetingModal.tsx
@@ -181,7 +181,6 @@ export default function EditTargetingModal({
     return (
       <Modal
         trackingEventModalType=""
-        trackingEventModalSource=""
         open={true}
         close={close}
         header={`Edit Targeting`}

--- a/packages/front-end/components/Experiment/EditTargetingModal.tsx
+++ b/packages/front-end/components/Experiment/EditTargetingModal.tsx
@@ -180,7 +180,8 @@ export default function EditTargetingModal({
   if (safeToEdit) {
     return (
       <Modal
-        trackingEventName=""
+        trackingEventModalType=""
+        trackingEventModalSource=""
         open={true}
         close={close}
         header={`Edit Targeting`}

--- a/packages/front-end/components/Experiment/EditTargetingModal.tsx
+++ b/packages/front-end/components/Experiment/EditTargetingModal.tsx
@@ -180,6 +180,7 @@ export default function EditTargetingModal({
   if (safeToEdit) {
     return (
       <Modal
+        trackingEventName=""
         open={true}
         close={close}
         header={`Edit Targeting`}

--- a/packages/front-end/components/Experiment/EditVariationsForm.tsx
+++ b/packages/front-end/components/Experiment/EditVariationsForm.tsx
@@ -43,7 +43,8 @@ const EditVariationsForm: FC<{
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       header={"Edit Variations"}
       open={true}
       close={cancel}

--- a/packages/front-end/components/Experiment/EditVariationsForm.tsx
+++ b/packages/front-end/components/Experiment/EditVariationsForm.tsx
@@ -44,7 +44,6 @@ const EditVariationsForm: FC<{
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       header={"Edit Variations"}
       open={true}
       close={cancel}

--- a/packages/front-end/components/Experiment/EditVariationsForm.tsx
+++ b/packages/front-end/components/Experiment/EditVariationsForm.tsx
@@ -43,6 +43,7 @@ const EditVariationsForm: FC<{
 
   return (
     <Modal
+      trackingEventName=""
       header={"Edit Variations"}
       open={true}
       close={cancel}

--- a/packages/front-end/components/Experiment/FilterSummary.tsx
+++ b/packages/front-end/components/Experiment/FilterSummary.tsx
@@ -48,7 +48,8 @@ const FilterSummary: FC<{
         </a>
       </span>
       <Modal
-        trackingEventName=""
+        trackingEventModalType=""
+        trackingEventModalSource=""
         header={"Experiment Details and Filters"}
         open={showExpandedFilter}
         closeCta="Close"

--- a/packages/front-end/components/Experiment/FilterSummary.tsx
+++ b/packages/front-end/components/Experiment/FilterSummary.tsx
@@ -49,7 +49,6 @@ const FilterSummary: FC<{
       </span>
       <Modal
         trackingEventModalType=""
-        trackingEventModalSource=""
         header={"Experiment Details and Filters"}
         open={showExpandedFilter}
         closeCta="Close"

--- a/packages/front-end/components/Experiment/FilterSummary.tsx
+++ b/packages/front-end/components/Experiment/FilterSummary.tsx
@@ -48,6 +48,7 @@ const FilterSummary: FC<{
         </a>
       </span>
       <Modal
+        trackingEventName=""
         header={"Experiment Details and Filters"}
         open={showExpandedFilter}
         closeCta="Close"

--- a/packages/front-end/components/Experiment/FixVariationIds.tsx
+++ b/packages/front-end/components/Experiment/FixVariationIds.tsx
@@ -26,7 +26,8 @@ export default function FixVariationIds({
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       open={true}
       submit={form.handleSubmit(async (value) => {
         const ids = value.ids.map((id, i) => (id ? id : expected[i]));

--- a/packages/front-end/components/Experiment/FixVariationIds.tsx
+++ b/packages/front-end/components/Experiment/FixVariationIds.tsx
@@ -27,7 +27,6 @@ export default function FixVariationIds({
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       open={true}
       submit={form.handleSubmit(async (value) => {
         const ids = value.ids.map((id, i) => (id ? id : expected[i]));

--- a/packages/front-end/components/Experiment/FixVariationIds.tsx
+++ b/packages/front-end/components/Experiment/FixVariationIds.tsx
@@ -26,6 +26,7 @@ export default function FixVariationIds({
 
   return (
     <Modal
+      trackingEventName=""
       open={true}
       submit={form.handleSubmit(async (value) => {
         const ids = value.ids.map((id, i) => (id ? id : expected[i]));

--- a/packages/front-end/components/Experiment/ImportExperimentModal.tsx
+++ b/packages/front-end/components/Experiment/ImportExperimentModal.tsx
@@ -93,6 +93,7 @@ const ImportExperimentModal: FC<{
 
   return (
     <Modal
+      trackingEventName=""
       header="Add Experiment"
       open={true}
       size="max"

--- a/packages/front-end/components/Experiment/ImportExperimentModal.tsx
+++ b/packages/front-end/components/Experiment/ImportExperimentModal.tsx
@@ -94,7 +94,6 @@ const ImportExperimentModal: FC<{
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       header="Add Experiment"
       open={true}
       size="max"

--- a/packages/front-end/components/Experiment/ImportExperimentModal.tsx
+++ b/packages/front-end/components/Experiment/ImportExperimentModal.tsx
@@ -93,7 +93,8 @@ const ImportExperimentModal: FC<{
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       header="Add Experiment"
       open={true}
       size="max"

--- a/packages/front-end/components/Experiment/ManualSnapshotForm.tsx
+++ b/packages/front-end/components/Experiment/ManualSnapshotForm.tsx
@@ -163,7 +163,8 @@ const ManualSnapshotForm: FC<{
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       open={true}
       size="lg"
       close={close}

--- a/packages/front-end/components/Experiment/ManualSnapshotForm.tsx
+++ b/packages/front-end/components/Experiment/ManualSnapshotForm.tsx
@@ -164,7 +164,6 @@ const ManualSnapshotForm: FC<{
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       open={true}
       size="lg"
       close={close}

--- a/packages/front-end/components/Experiment/ManualSnapshotForm.tsx
+++ b/packages/front-end/components/Experiment/ManualSnapshotForm.tsx
@@ -163,6 +163,7 @@ const ManualSnapshotForm: FC<{
 
   return (
     <Modal
+      trackingEventName=""
       open={true}
       size="lg"
       close={close}

--- a/packages/front-end/components/Experiment/NamespaceModal.tsx
+++ b/packages/front-end/components/Experiment/NamespaceModal.tsx
@@ -28,6 +28,7 @@ export default function NamespaceModal({
 
   return (
     <Modal
+      trackingEventName=""
       open={true}
       close={close}
       cta={existing ? "Update" : "Create"}

--- a/packages/front-end/components/Experiment/NamespaceModal.tsx
+++ b/packages/front-end/components/Experiment/NamespaceModal.tsx
@@ -29,7 +29,6 @@ export default function NamespaceModal({
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       open={true}
       close={close}
       cta={existing ? "Update" : "Create"}

--- a/packages/front-end/components/Experiment/NamespaceModal.tsx
+++ b/packages/front-end/components/Experiment/NamespaceModal.tsx
@@ -28,7 +28,8 @@ export default function NamespaceModal({
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       open={true}
       close={close}
       cta={existing ? "Update" : "Create"}

--- a/packages/front-end/components/Experiment/NewPhaseForm.tsx
+++ b/packages/front-end/components/Experiment/NewPhaseForm.tsx
@@ -89,7 +89,8 @@ const NewPhaseForm: FC<{
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       header={firstPhase ? "Start Experiment" : "New Experiment Phase"}
       close={close}
       open={true}

--- a/packages/front-end/components/Experiment/NewPhaseForm.tsx
+++ b/packages/front-end/components/Experiment/NewPhaseForm.tsx
@@ -90,7 +90,6 @@ const NewPhaseForm: FC<{
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       header={firstPhase ? "Start Experiment" : "New Experiment Phase"}
       close={close}
       open={true}

--- a/packages/front-end/components/Experiment/NewPhaseForm.tsx
+++ b/packages/front-end/components/Experiment/NewPhaseForm.tsx
@@ -89,6 +89,7 @@ const NewPhaseForm: FC<{
 
   return (
     <Modal
+      trackingEventName=""
       header={firstPhase ? "Start Experiment" : "New Experiment Phase"}
       close={close}
       open={true}

--- a/packages/front-end/components/Experiment/QueryModal.tsx
+++ b/packages/front-end/components/Experiment/QueryModal.tsx
@@ -10,6 +10,7 @@ const QueryModal: FC<{
 }> = ({ queries, language, close }) => {
   return (
     <Modal
+      trackingEventName=""
       close={close}
       header="View Query"
       open={true}

--- a/packages/front-end/components/Experiment/QueryModal.tsx
+++ b/packages/front-end/components/Experiment/QueryModal.tsx
@@ -11,7 +11,6 @@ const QueryModal: FC<{
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       close={close}
       header="View Query"
       open={true}

--- a/packages/front-end/components/Experiment/QueryModal.tsx
+++ b/packages/front-end/components/Experiment/QueryModal.tsx
@@ -10,7 +10,8 @@ const QueryModal: FC<{
 }> = ({ queries, language, close }) => {
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       close={close}
       header="View Query"
       open={true}

--- a/packages/front-end/components/Experiment/SRMWarning.tsx
+++ b/packages/front-end/components/Experiment/SRMWarning.tsx
@@ -92,7 +92,6 @@ const SRMWarning: FC<{
       {type === "with_modal" && (
         <Modal
           trackingEventModalType=""
-          trackingEventModalSource=""
           close={() => setOpen(false)}
           open={open}
           header={

--- a/packages/front-end/components/Experiment/SRMWarning.tsx
+++ b/packages/front-end/components/Experiment/SRMWarning.tsx
@@ -91,6 +91,7 @@ const SRMWarning: FC<{
     <>
       {type === "with_modal" && (
         <Modal
+          trackingEventName=""
           close={() => setOpen(false)}
           open={open}
           header={

--- a/packages/front-end/components/Experiment/SRMWarning.tsx
+++ b/packages/front-end/components/Experiment/SRMWarning.tsx
@@ -91,7 +91,8 @@ const SRMWarning: FC<{
     <>
       {type === "with_modal" && (
         <Modal
-          trackingEventName=""
+          trackingEventModalType=""
+          trackingEventModalSource=""
           close={() => setOpen(false)}
           open={open}
           header={

--- a/packages/front-end/components/Experiment/StopExperimentForm.tsx
+++ b/packages/front-end/components/Experiment/StopExperimentForm.tsx
@@ -85,7 +85,8 @@ const StopExperimentForm: FC<{
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       header={isStopped ? "Edit Experiment Results" : "Stop Experiment"}
       close={close}
       open={true}

--- a/packages/front-end/components/Experiment/StopExperimentForm.tsx
+++ b/packages/front-end/components/Experiment/StopExperimentForm.tsx
@@ -85,6 +85,7 @@ const StopExperimentForm: FC<{
 
   return (
     <Modal
+      trackingEventName=""
       header={isStopped ? "Edit Experiment Results" : "Stop Experiment"}
       close={close}
       open={true}

--- a/packages/front-end/components/Experiment/StopExperimentForm.tsx
+++ b/packages/front-end/components/Experiment/StopExperimentForm.tsx
@@ -86,7 +86,6 @@ const StopExperimentForm: FC<{
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       header={isStopped ? "Edit Experiment Results" : "Stop Experiment"}
       close={close}
       open={true}

--- a/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
@@ -191,6 +191,7 @@ export default function ExperimentHeader({
         )}
         {showStartExperiment && experiment.status === "draft" && (
           <Modal
+            trackingEventName=""
             open={true}
             size="md"
             closeCta={

--- a/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
@@ -191,7 +191,8 @@ export default function ExperimentHeader({
         )}
         {showStartExperiment && experiment.status === "draft" && (
           <Modal
-            trackingEventName=""
+            trackingEventModalType=""
+            trackingEventModalSource=""
             open={true}
             size="md"
             closeCta={

--- a/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
@@ -192,7 +192,6 @@ export default function ExperimentHeader({
         {showStartExperiment && experiment.status === "draft" && (
           <Modal
             trackingEventModalType=""
-            trackingEventModalSource=""
             open={true}
             size="md"
             closeCta={

--- a/packages/front-end/components/Experiment/TabbedPage/HealthTabOnboardingModal.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/HealthTabOnboardingModal.tsx
@@ -164,7 +164,8 @@ export const HealthTabOnboardingModal: FC<HealthTabOnboardingModalProps> = ({
   if (step === -1) {
     return (
       <Modal
-        trackingEventName=""
+        trackingEventModalType=""
+        trackingEventModalSource=""
         open={open}
         submit={close}
         cta={"Confirm"}
@@ -340,7 +341,8 @@ export const HealthTabOnboardingModal: FC<HealthTabOnboardingModalProps> = ({
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       open={open}
       close={() => {
         setLastStep(step);

--- a/packages/front-end/components/Experiment/TabbedPage/HealthTabOnboardingModal.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/HealthTabOnboardingModal.tsx
@@ -165,7 +165,6 @@ export const HealthTabOnboardingModal: FC<HealthTabOnboardingModalProps> = ({
     return (
       <Modal
         trackingEventModalType=""
-        trackingEventModalSource=""
         open={open}
         submit={close}
         cta={"Confirm"}
@@ -342,7 +341,6 @@ export const HealthTabOnboardingModal: FC<HealthTabOnboardingModalProps> = ({
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       open={open}
       close={() => {
         setLastStep(step);

--- a/packages/front-end/components/Experiment/TabbedPage/HealthTabOnboardingModal.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/HealthTabOnboardingModal.tsx
@@ -164,6 +164,7 @@ export const HealthTabOnboardingModal: FC<HealthTabOnboardingModalProps> = ({
   if (step === -1) {
     return (
       <Modal
+        trackingEventName=""
         open={open}
         submit={close}
         cta={"Confirm"}
@@ -339,6 +340,7 @@ export const HealthTabOnboardingModal: FC<HealthTabOnboardingModalProps> = ({
 
   return (
     <Modal
+      trackingEventName=""
       open={open}
       close={() => {
         setLastStep(step);

--- a/packages/front-end/components/Experiment/TabbedPage/index.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/index.tsx
@@ -202,6 +202,7 @@ export default function TabbedPage({
       )}
       {auditModal && (
         <Modal
+          trackingEventName=""
           open={true}
           header="Audit Log"
           close={() => setAuditModal(false)}
@@ -213,6 +214,7 @@ export default function TabbedPage({
       )}
       {watchersModal && (
         <Modal
+          trackingEventName=""
           open={true}
           header="Experiment Watchers"
           close={() => setWatchersModal(false)}

--- a/packages/front-end/components/Experiment/TabbedPage/index.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/index.tsx
@@ -202,7 +202,8 @@ export default function TabbedPage({
       )}
       {auditModal && (
         <Modal
-          trackingEventName=""
+          trackingEventModalType=""
+          trackingEventModalSource=""
           open={true}
           header="Audit Log"
           close={() => setAuditModal(false)}
@@ -214,7 +215,8 @@ export default function TabbedPage({
       )}
       {watchersModal && (
         <Modal
-          trackingEventName=""
+          trackingEventModalType=""
+          trackingEventModalSource=""
           open={true}
           header="Experiment Watchers"
           close={() => setWatchersModal(false)}

--- a/packages/front-end/components/Experiment/TabbedPage/index.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/index.tsx
@@ -203,7 +203,6 @@ export default function TabbedPage({
       {auditModal && (
         <Modal
           trackingEventModalType=""
-          trackingEventModalSource=""
           open={true}
           header="Audit Log"
           close={() => setAuditModal(false)}
@@ -216,7 +215,6 @@ export default function TabbedPage({
       {watchersModal && (
         <Modal
           trackingEventModalType=""
-          trackingEventModalSource=""
           open={true}
           header="Experiment Watchers"
           close={() => setWatchersModal(false)}

--- a/packages/front-end/components/Experiment/UrlRedirectModal.tsx
+++ b/packages/front-end/components/Experiment/UrlRedirectModal.tsx
@@ -174,7 +174,8 @@ const UrlRedirectModal: FC<{
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       autoCloseOnSubmit={false}
       open
       disabledMessage={

--- a/packages/front-end/components/Experiment/UrlRedirectModal.tsx
+++ b/packages/front-end/components/Experiment/UrlRedirectModal.tsx
@@ -175,7 +175,6 @@ const UrlRedirectModal: FC<{
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       autoCloseOnSubmit={false}
       open
       disabledMessage={

--- a/packages/front-end/components/Experiment/UrlRedirectModal.tsx
+++ b/packages/front-end/components/Experiment/UrlRedirectModal.tsx
@@ -174,6 +174,7 @@ const UrlRedirectModal: FC<{
 
   return (
     <Modal
+      trackingEventName=""
       autoCloseOnSubmit={false}
       open
       disabledMessage={

--- a/packages/front-end/components/Experiment/VisualChangesetModal.tsx
+++ b/packages/front-end/components/Experiment/VisualChangesetModal.tsx
@@ -101,6 +101,7 @@ const VisualChangesetModal: FC<{
 
   return (
     <Modal
+      trackingEventName=""
       open
       close={close}
       size="lg"

--- a/packages/front-end/components/Experiment/VisualChangesetModal.tsx
+++ b/packages/front-end/components/Experiment/VisualChangesetModal.tsx
@@ -101,7 +101,8 @@ const VisualChangesetModal: FC<{
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       open
       close={close}
       size="lg"

--- a/packages/front-end/components/Experiment/VisualChangesetModal.tsx
+++ b/packages/front-end/components/Experiment/VisualChangesetModal.tsx
@@ -102,7 +102,6 @@ const VisualChangesetModal: FC<{
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       open
       close={close}
       size="lg"

--- a/packages/front-end/components/FactTables/ColumnModal.tsx
+++ b/packages/front-end/components/FactTables/ColumnModal.tsx
@@ -43,7 +43,6 @@ export default function ColumnModal({ existing, factTable, close }: Props) {
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       open={true}
       close={close}
       cta={"Save"}

--- a/packages/front-end/components/FactTables/ColumnModal.tsx
+++ b/packages/front-end/components/FactTables/ColumnModal.tsx
@@ -42,7 +42,8 @@ export default function ColumnModal({ existing, factTable, close }: Props) {
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       open={true}
       close={close}
       cta={"Save"}

--- a/packages/front-end/components/FactTables/ColumnModal.tsx
+++ b/packages/front-end/components/FactTables/ColumnModal.tsx
@@ -42,6 +42,7 @@ export default function ColumnModal({ existing, factTable, close }: Props) {
 
   return (
     <Modal
+      trackingEventName=""
       open={true}
       close={close}
       cta={"Save"}

--- a/packages/front-end/components/FactTables/FactFilterModal.tsx
+++ b/packages/front-end/components/FactTables/FactFilterModal.tsx
@@ -71,7 +71,8 @@ export default function FactFilterModal({ existing, factTable, close }: Props) {
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       open={true}
       close={close}
       cta={"Save"}

--- a/packages/front-end/components/FactTables/FactFilterModal.tsx
+++ b/packages/front-end/components/FactTables/FactFilterModal.tsx
@@ -71,6 +71,7 @@ export default function FactFilterModal({ existing, factTable, close }: Props) {
 
   return (
     <Modal
+      trackingEventName=""
       open={true}
       close={close}
       cta={"Save"}

--- a/packages/front-end/components/FactTables/FactFilterModal.tsx
+++ b/packages/front-end/components/FactTables/FactFilterModal.tsx
@@ -72,7 +72,6 @@ export default function FactFilterModal({ existing, factTable, close }: Props) {
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       open={true}
       close={close}
       cta={"Save"}

--- a/packages/front-end/components/FactTables/FactMetricModal.tsx
+++ b/packages/front-end/components/FactTables/FactMetricModal.tsx
@@ -482,7 +482,8 @@ export default function FactMetricModal({
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       open={true}
       header={existing ? "Edit Metric" : "Create Fact Table Metric"}
       close={close}

--- a/packages/front-end/components/FactTables/FactMetricModal.tsx
+++ b/packages/front-end/components/FactTables/FactMetricModal.tsx
@@ -483,7 +483,6 @@ export default function FactMetricModal({
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       open={true}
       header={existing ? "Edit Metric" : "Create Fact Table Metric"}
       close={close}

--- a/packages/front-end/components/FactTables/FactMetricModal.tsx
+++ b/packages/front-end/components/FactTables/FactMetricModal.tsx
@@ -482,6 +482,7 @@ export default function FactMetricModal({
 
   return (
     <Modal
+      trackingEventName=""
       open={true}
       header={existing ? "Edit Metric" : "Create Fact Table Metric"}
       close={close}

--- a/packages/front-end/components/FactTables/FactTableModal.tsx
+++ b/packages/front-end/components/FactTables/FactTableModal.tsx
@@ -110,6 +110,7 @@ export default function FactTableModal({ existing, close }: Props) {
         />
       )}
       <Modal
+        trackingEventName=""
         open={true}
         close={close}
         cta={"Save"}

--- a/packages/front-end/components/FactTables/FactTableModal.tsx
+++ b/packages/front-end/components/FactTables/FactTableModal.tsx
@@ -110,7 +110,8 @@ export default function FactTableModal({ existing, close }: Props) {
         />
       )}
       <Modal
-        trackingEventName=""
+        trackingEventModalType=""
+        trackingEventModalSource=""
         open={true}
         close={close}
         cta={"Save"}

--- a/packages/front-end/components/FactTables/FactTableModal.tsx
+++ b/packages/front-end/components/FactTables/FactTableModal.tsx
@@ -111,7 +111,6 @@ export default function FactTableModal({ existing, close }: Props) {
       )}
       <Modal
         trackingEventModalType=""
-        trackingEventModalSource=""
         open={true}
         close={close}
         cta={"Save"}

--- a/packages/front-end/components/Features/AttributeModal.tsx
+++ b/packages/front-end/components/Features/AttributeModal.tsx
@@ -71,6 +71,7 @@ export default function AttributeModal({ close, attribute }: Props) {
 
   return (
     <Modal
+      trackingEventName=""
       open={true}
       close={close}
       header={title}

--- a/packages/front-end/components/Features/AttributeModal.tsx
+++ b/packages/front-end/components/Features/AttributeModal.tsx
@@ -71,7 +71,8 @@ export default function AttributeModal({ close, attribute }: Props) {
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       open={true}
       close={close}
       header={title}

--- a/packages/front-end/components/Features/AttributeModal.tsx
+++ b/packages/front-end/components/Features/AttributeModal.tsx
@@ -72,7 +72,6 @@ export default function AttributeModal({ close, attribute }: Props) {
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       open={true}
       close={close}
       header={title}

--- a/packages/front-end/components/Features/CodeSnippetModal.tsx
+++ b/packages/front-end/components/Features/CodeSnippetModal.tsx
@@ -164,7 +164,6 @@ export default function CodeSnippetModal({
       )}
       <Modal
         trackingEventModalType=""
-        trackingEventModalSource=""
         close={close}
         secondaryCTA={secondaryCTA}
         className="mb-4"

--- a/packages/front-end/components/Features/CodeSnippetModal.tsx
+++ b/packages/front-end/components/Features/CodeSnippetModal.tsx
@@ -163,7 +163,8 @@ export default function CodeSnippetModal({
         />
       )}
       <Modal
-        trackingEventName=""
+        trackingEventModalType=""
+        trackingEventModalSource=""
         close={close}
         secondaryCTA={secondaryCTA}
         className="mb-4"

--- a/packages/front-end/components/Features/CodeSnippetModal.tsx
+++ b/packages/front-end/components/Features/CodeSnippetModal.tsx
@@ -163,6 +163,7 @@ export default function CodeSnippetModal({
         />
       )}
       <Modal
+        trackingEventName=""
         close={close}
         secondaryCTA={secondaryCTA}
         className="mb-4"

--- a/packages/front-end/components/Features/CopyRuleModal.tsx
+++ b/packages/front-end/components/Features/CopyRuleModal.tsx
@@ -82,6 +82,7 @@ export default function CopyRuleModal({
 
   return (
     <Modal
+      trackingEventName=""
       header={`Copy ${ruleTxt} to environment(s)`}
       open={true}
       close={cancel}

--- a/packages/front-end/components/Features/CopyRuleModal.tsx
+++ b/packages/front-end/components/Features/CopyRuleModal.tsx
@@ -82,7 +82,8 @@ export default function CopyRuleModal({
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       header={`Copy ${ruleTxt} to environment(s)`}
       open={true}
       close={cancel}

--- a/packages/front-end/components/Features/CopyRuleModal.tsx
+++ b/packages/front-end/components/Features/CopyRuleModal.tsx
@@ -83,7 +83,6 @@ export default function CopyRuleModal({
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       header={`Copy ${ruleTxt} to environment(s)`}
       open={true}
       close={cancel}

--- a/packages/front-end/components/Features/DraftModal.tsx
+++ b/packages/front-end/components/Features/DraftModal.tsx
@@ -142,6 +142,7 @@ export default function DraftModal({
 
   return (
     <Modal
+      trackingEventName=""
       open={true}
       header={"Review Draft Changes"}
       submit={

--- a/packages/front-end/components/Features/DraftModal.tsx
+++ b/packages/front-end/components/Features/DraftModal.tsx
@@ -142,7 +142,8 @@ export default function DraftModal({
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       open={true}
       header={"Review Draft Changes"}
       submit={

--- a/packages/front-end/components/Features/DraftModal.tsx
+++ b/packages/front-end/components/Features/DraftModal.tsx
@@ -143,7 +143,6 @@ export default function DraftModal({
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       open={true}
       header={"Review Draft Changes"}
       submit={

--- a/packages/front-end/components/Features/EditDefaultValueModal.tsx
+++ b/packages/front-end/components/Features/EditDefaultValueModal.tsx
@@ -30,7 +30,8 @@ export default function EditDefaultValueModal({
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       header="Edit Default Value"
       submit={form.handleSubmit(async (value) => {
         const newDefaultValue = validateFeatureValue(

--- a/packages/front-end/components/Features/EditDefaultValueModal.tsx
+++ b/packages/front-end/components/Features/EditDefaultValueModal.tsx
@@ -31,7 +31,6 @@ export default function EditDefaultValueModal({
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       header="Edit Default Value"
       submit={form.handleSubmit(async (value) => {
         const newDefaultValue = validateFeatureValue(

--- a/packages/front-end/components/Features/EditDefaultValueModal.tsx
+++ b/packages/front-end/components/Features/EditDefaultValueModal.tsx
@@ -30,6 +30,7 @@ export default function EditDefaultValueModal({
 
   return (
     <Modal
+      trackingEventName=""
       header="Edit Default Value"
       submit={form.handleSubmit(async (value) => {
         const newDefaultValue = validateFeatureValue(

--- a/packages/front-end/components/Features/EditRevisionCommentModal.tsx
+++ b/packages/front-end/components/Features/EditRevisionCommentModal.tsx
@@ -24,7 +24,6 @@ export default function EditRevisionCommentModal({
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       open={true}
       close={close}
       header="Edit Revision Comment"

--- a/packages/front-end/components/Features/EditRevisionCommentModal.tsx
+++ b/packages/front-end/components/Features/EditRevisionCommentModal.tsx
@@ -23,6 +23,7 @@ export default function EditRevisionCommentModal({
 
   return (
     <Modal
+      trackingEventName=""
       open={true}
       close={close}
       header="Edit Revision Comment"

--- a/packages/front-end/components/Features/EditRevisionCommentModal.tsx
+++ b/packages/front-end/components/Features/EditRevisionCommentModal.tsx
@@ -23,7 +23,8 @@ export default function EditRevisionCommentModal({
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       open={true}
       close={close}
       header="Edit Revision Comment"

--- a/packages/front-end/components/Features/EditSchemaModal.tsx
+++ b/packages/front-end/components/Features/EditSchemaModal.tsx
@@ -444,6 +444,7 @@ export default function EditSchemaModal({ feature, close, mutate }: Props) {
 
   return (
     <Modal
+      trackingEventName=""
       header="Edit Feature Validation"
       cta="Save"
       size="lg"

--- a/packages/front-end/components/Features/EditSchemaModal.tsx
+++ b/packages/front-end/components/Features/EditSchemaModal.tsx
@@ -445,7 +445,6 @@ export default function EditSchemaModal({ feature, close, mutate }: Props) {
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       header="Edit Feature Validation"
       cta="Save"
       size="lg"

--- a/packages/front-end/components/Features/EditSchemaModal.tsx
+++ b/packages/front-end/components/Features/EditSchemaModal.tsx
@@ -444,7 +444,8 @@ export default function EditSchemaModal({ feature, close, mutate }: Props) {
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       header="Edit Feature Validation"
       cta="Save"
       size="lg"

--- a/packages/front-end/components/Features/EnvironmentToggle.tsx
+++ b/packages/front-end/components/Features/EnvironmentToggle.tsx
@@ -69,7 +69,6 @@ export default function EnvironmentToggle({
       {confirming ? (
         <Modal
           trackingEventModalType=""
-          trackingEventModalSource=""
           header="Toggle environment"
           close={() => {
             setConfirming(false);

--- a/packages/front-end/components/Features/EnvironmentToggle.tsx
+++ b/packages/front-end/components/Features/EnvironmentToggle.tsx
@@ -68,7 +68,8 @@ export default function EnvironmentToggle({
     <>
       {confirming ? (
         <Modal
-          trackingEventName=""
+          trackingEventModalType=""
+          trackingEventModalSource=""
           header="Toggle environment"
           close={() => {
             setConfirming(false);

--- a/packages/front-end/components/Features/EnvironmentToggle.tsx
+++ b/packages/front-end/components/Features/EnvironmentToggle.tsx
@@ -68,6 +68,7 @@ export default function EnvironmentToggle({
     <>
       {confirming ? (
         <Modal
+          trackingEventName=""
           header="Toggle environment"
           close={() => {
             setConfirming(false);

--- a/packages/front-end/components/Features/ExperimentSummary.tsx
+++ b/packages/front-end/components/Features/ExperimentSummary.tsx
@@ -58,6 +58,7 @@ export default function ExperimentSummary({
       )}
       {experimentInstructions && (
         <Modal
+          trackingEventName=""
           header={"Experiments need to be set up first"}
           open={true}
           size="lg"

--- a/packages/front-end/components/Features/ExperimentSummary.tsx
+++ b/packages/front-end/components/Features/ExperimentSummary.tsx
@@ -59,7 +59,6 @@ export default function ExperimentSummary({
       {experimentInstructions && (
         <Modal
           trackingEventModalType=""
-          trackingEventModalSource=""
           header={"Experiments need to be set up first"}
           open={true}
           size="lg"

--- a/packages/front-end/components/Features/ExperimentSummary.tsx
+++ b/packages/front-end/components/Features/ExperimentSummary.tsx
@@ -58,7 +58,8 @@ export default function ExperimentSummary({
       )}
       {experimentInstructions && (
         <Modal
-          trackingEventName=""
+          trackingEventModalType=""
+          trackingEventModalSource=""
           header={"Experiments need to be set up first"}
           open={true}
           size="lg"

--- a/packages/front-end/components/Features/FeatureImplementationModal.tsx
+++ b/packages/front-end/components/Features/FeatureImplementationModal.tsx
@@ -38,6 +38,7 @@ export default function FeatureImplementationModal({
 
   return (
     <Modal
+      trackingEventName=""
       open={true}
       close={close}
       size="lg"

--- a/packages/front-end/components/Features/FeatureImplementationModal.tsx
+++ b/packages/front-end/components/Features/FeatureImplementationModal.tsx
@@ -39,7 +39,6 @@ export default function FeatureImplementationModal({
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       open={true}
       close={close}
       size="lg"

--- a/packages/front-end/components/Features/FeatureImplementationModal.tsx
+++ b/packages/front-end/components/Features/FeatureImplementationModal.tsx
@@ -38,7 +38,8 @@ export default function FeatureImplementationModal({
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       open={true}
       close={close}
       size="lg"

--- a/packages/front-end/components/Features/FeatureModal/FeatureFromExperimentModal.tsx
+++ b/packages/front-end/components/Features/FeatureModal/FeatureFromExperimentModal.tsx
@@ -226,7 +226,6 @@ export default function FeatureFromExperimentModal({
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       open
       size="lg"
       inline={inline}

--- a/packages/front-end/components/Features/FeatureModal/FeatureFromExperimentModal.tsx
+++ b/packages/front-end/components/Features/FeatureModal/FeatureFromExperimentModal.tsx
@@ -225,7 +225,8 @@ export default function FeatureFromExperimentModal({
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       open
       size="lg"
       inline={inline}

--- a/packages/front-end/components/Features/FeatureModal/FeatureFromExperimentModal.tsx
+++ b/packages/front-end/components/Features/FeatureModal/FeatureFromExperimentModal.tsx
@@ -225,6 +225,7 @@ export default function FeatureFromExperimentModal({
 
   return (
     <Modal
+      trackingEventName=""
       open
       size="lg"
       inline={inline}

--- a/packages/front-end/components/Features/FeatureModal/index.tsx
+++ b/packages/front-end/components/Features/FeatureModal/index.tsx
@@ -186,7 +186,8 @@ export default function FeatureModal({
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       open
       size="lg"
       inline={inline}

--- a/packages/front-end/components/Features/FeatureModal/index.tsx
+++ b/packages/front-end/components/Features/FeatureModal/index.tsx
@@ -186,6 +186,7 @@ export default function FeatureModal({
 
   return (
     <Modal
+      trackingEventName=""
       open
       size="lg"
       inline={inline}

--- a/packages/front-end/components/Features/FeatureModal/index.tsx
+++ b/packages/front-end/components/Features/FeatureModal/index.tsx
@@ -187,7 +187,6 @@ export default function FeatureModal({
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       open
       size="lg"
       inline={inline}

--- a/packages/front-end/components/Features/FeatureValueField.tsx
+++ b/packages/front-end/components/Features/FeatureValueField.tsx
@@ -395,6 +395,7 @@ function SimpleSchemaEditor({
       <>
         {open ? (
           <Modal
+            trackingEventName=""
             open={true}
             header="Edit Value"
             size="lg"

--- a/packages/front-end/components/Features/FeatureValueField.tsx
+++ b/packages/front-end/components/Features/FeatureValueField.tsx
@@ -396,7 +396,6 @@ function SimpleSchemaEditor({
         {open ? (
           <Modal
             trackingEventModalType=""
-            trackingEventModalSource=""
             open={true}
             header="Edit Value"
             size="lg"

--- a/packages/front-end/components/Features/FeatureValueField.tsx
+++ b/packages/front-end/components/Features/FeatureValueField.tsx
@@ -395,7 +395,8 @@ function SimpleSchemaEditor({
       <>
         {open ? (
           <Modal
-            trackingEventName=""
+            trackingEventModalType=""
+            trackingEventModalSource=""
             open={true}
             header="Edit Value"
             size="lg"

--- a/packages/front-end/components/Features/FeaturesHeader.tsx
+++ b/packages/front-end/components/Features/FeaturesHeader.tsx
@@ -418,7 +418,8 @@ export default function FeaturesHeader({
         </div>
         {auditModal && (
           <Modal
-            trackingEventName=""
+            trackingEventModalType=""
+            trackingEventModalSource=""
             open={true}
             header="Audit Log"
             close={() => setAuditModal(false)}

--- a/packages/front-end/components/Features/FeaturesHeader.tsx
+++ b/packages/front-end/components/Features/FeaturesHeader.tsx
@@ -419,7 +419,6 @@ export default function FeaturesHeader({
         {auditModal && (
           <Modal
             trackingEventModalType=""
-            trackingEventModalSource=""
             open={true}
             header="Audit Log"
             close={() => setAuditModal(false)}

--- a/packages/front-end/components/Features/FeaturesHeader.tsx
+++ b/packages/front-end/components/Features/FeaturesHeader.tsx
@@ -418,6 +418,7 @@ export default function FeaturesHeader({
         </div>
         {auditModal && (
           <Modal
+            trackingEventName=""
             open={true}
             header="Audit Log"
             close={() => setAuditModal(false)}

--- a/packages/front-end/components/Features/FeaturesOverview.tsx
+++ b/packages/front-end/components/Features/FeaturesOverview.tsx
@@ -1308,7 +1308,6 @@ export default function FeaturesOverview({
         {logModal && revision && (
           <Modal
             trackingEventModalType=""
-            trackingEventModalSource=""
             open={true}
             close={() => setLogModal(false)}
             header="Revision Log"
@@ -1370,7 +1369,6 @@ export default function FeaturesOverview({
         {confirmDiscard && (
           <Modal
             trackingEventModalType=""
-            trackingEventModalSource=""
             open={true}
             close={() => setConfirmDiscard(false)}
             header="Discard Draft"

--- a/packages/front-end/components/Features/FeaturesOverview.tsx
+++ b/packages/front-end/components/Features/FeaturesOverview.tsx
@@ -1307,7 +1307,8 @@ export default function FeaturesOverview({
         )}
         {logModal && revision && (
           <Modal
-            trackingEventName=""
+            trackingEventModalType=""
+            trackingEventModalSource=""
             open={true}
             close={() => setLogModal(false)}
             header="Revision Log"
@@ -1368,7 +1369,8 @@ export default function FeaturesOverview({
         )}
         {confirmDiscard && (
           <Modal
-            trackingEventName=""
+            trackingEventModalType=""
+            trackingEventModalSource=""
             open={true}
             close={() => setConfirmDiscard(false)}
             header="Discard Draft"

--- a/packages/front-end/components/Features/FeaturesOverview.tsx
+++ b/packages/front-end/components/Features/FeaturesOverview.tsx
@@ -1307,6 +1307,7 @@ export default function FeaturesOverview({
         )}
         {logModal && revision && (
           <Modal
+            trackingEventName=""
             open={true}
             close={() => setLogModal(false)}
             header="Revision Log"
@@ -1367,6 +1368,7 @@ export default function FeaturesOverview({
         )}
         {confirmDiscard && (
           <Modal
+            trackingEventName=""
             open={true}
             close={() => setConfirmDiscard(false)}
             header="Discard Draft"

--- a/packages/front-end/components/Features/PrerequisiteModal.tsx
+++ b/packages/front-end/components/Features/PrerequisiteModal.tsx
@@ -181,7 +181,8 @@ export default function PrerequisiteModal({
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       open={true}
       close={close}
       size="lg"

--- a/packages/front-end/components/Features/PrerequisiteModal.tsx
+++ b/packages/front-end/components/Features/PrerequisiteModal.tsx
@@ -181,6 +181,7 @@ export default function PrerequisiteModal({
 
   return (
     <Modal
+      trackingEventName=""
       open={true}
       close={close}
       size="lg"

--- a/packages/front-end/components/Features/PrerequisiteModal.tsx
+++ b/packages/front-end/components/Features/PrerequisiteModal.tsx
@@ -182,7 +182,6 @@ export default function PrerequisiteModal({
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       open={true}
       close={close}
       size="lg"

--- a/packages/front-end/components/Features/RequestReviewModal.tsx
+++ b/packages/front-end/components/Features/RequestReviewModal.tsx
@@ -204,6 +204,7 @@ export default function RequestReviewModal({
   const renderRequestAndViewModal = () => {
     return (
       <Modal
+        trackingEventName=""
         open={true}
         header={"Review Draft Changes"}
         cta={ctaCopy}
@@ -339,6 +340,7 @@ export default function RequestReviewModal({
   const renderReviewAndSubmitModal = () => {
     return (
       <Modal
+        trackingEventName=""
         open={true}
         close={close}
         header={"Review Draft Changes"}

--- a/packages/front-end/components/Features/RequestReviewModal.tsx
+++ b/packages/front-end/components/Features/RequestReviewModal.tsx
@@ -204,7 +204,8 @@ export default function RequestReviewModal({
   const renderRequestAndViewModal = () => {
     return (
       <Modal
-        trackingEventName=""
+        trackingEventModalType=""
+        trackingEventModalSource=""
         open={true}
         header={"Review Draft Changes"}
         cta={ctaCopy}
@@ -340,7 +341,8 @@ export default function RequestReviewModal({
   const renderReviewAndSubmitModal = () => {
     return (
       <Modal
-        trackingEventName=""
+        trackingEventModalType=""
+        trackingEventModalSource=""
         open={true}
         close={close}
         header={"Review Draft Changes"}

--- a/packages/front-end/components/Features/RequestReviewModal.tsx
+++ b/packages/front-end/components/Features/RequestReviewModal.tsx
@@ -205,7 +205,6 @@ export default function RequestReviewModal({
     return (
       <Modal
         trackingEventModalType=""
-        trackingEventModalSource=""
         open={true}
         header={"Review Draft Changes"}
         cta={ctaCopy}
@@ -342,7 +341,6 @@ export default function RequestReviewModal({
     return (
       <Modal
         trackingEventModalType=""
-        trackingEventModalSource=""
         open={true}
         close={close}
         header={"Review Draft Changes"}

--- a/packages/front-end/components/Features/RevertModal.tsx
+++ b/packages/front-end/components/Features/RevertModal.tsx
@@ -68,7 +68,8 @@ export default function RevertModal({
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       open={true}
       header={`Revert`}
       submit={

--- a/packages/front-end/components/Features/RevertModal.tsx
+++ b/packages/front-end/components/Features/RevertModal.tsx
@@ -69,7 +69,6 @@ export default function RevertModal({
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       open={true}
       header={`Revert`}
       submit={

--- a/packages/front-end/components/Features/RevertModal.tsx
+++ b/packages/front-end/components/Features/RevertModal.tsx
@@ -68,6 +68,7 @@ export default function RevertModal({
 
   return (
     <Modal
+      trackingEventName=""
       open={true}
       header={`Revert`}
       submit={

--- a/packages/front-end/components/Features/RuleModal.tsx
+++ b/packages/front-end/components/Features/RuleModal.tsx
@@ -286,6 +286,7 @@ export default function RuleModal({
 
   return (
     <Modal
+      trackingEventName=""
       open={true}
       close={close}
       size="lg"

--- a/packages/front-end/components/Features/RuleModal.tsx
+++ b/packages/front-end/components/Features/RuleModal.tsx
@@ -286,7 +286,8 @@ export default function RuleModal({
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       open={true}
       close={close}
       size="lg"

--- a/packages/front-end/components/Features/RuleModal.tsx
+++ b/packages/front-end/components/Features/RuleModal.tsx
@@ -287,7 +287,6 @@ export default function RuleModal({
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       open={true}
       close={close}
       size="lg"

--- a/packages/front-end/components/Features/SDKConnections/ProxyTestButton.tsx
+++ b/packages/front-end/components/Features/SDKConnections/ProxyTestButton.tsx
@@ -32,7 +32,8 @@ export default function ProxyTestButton({
     <>
       {proxyTestResult && (
         <Modal
-          trackingEventName=""
+          trackingEventModalType=""
+          trackingEventModalSource=""
           header="Proxy Status"
           open={true}
           close={() => setProxyTestResult(null)}

--- a/packages/front-end/components/Features/SDKConnections/ProxyTestButton.tsx
+++ b/packages/front-end/components/Features/SDKConnections/ProxyTestButton.tsx
@@ -33,7 +33,6 @@ export default function ProxyTestButton({
       {proxyTestResult && (
         <Modal
           trackingEventModalType=""
-          trackingEventModalSource=""
           header="Proxy Status"
           open={true}
           close={() => setProxyTestResult(null)}

--- a/packages/front-end/components/Features/SDKConnections/ProxyTestButton.tsx
+++ b/packages/front-end/components/Features/SDKConnections/ProxyTestButton.tsx
@@ -32,6 +32,7 @@ export default function ProxyTestButton({
     <>
       {proxyTestResult && (
         <Modal
+          trackingEventName=""
           header="Proxy Status"
           open={true}
           close={() => setProxyTestResult(null)}

--- a/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
+++ b/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
@@ -323,7 +323,8 @@ export default function SDKConnectionForm({
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       header={edit ? "Edit SDK Connection" : "New SDK Connection"}
       size={"lg"}
       autoCloseOnSubmit={autoCloseOnSubmit}

--- a/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
+++ b/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
@@ -324,7 +324,6 @@ export default function SDKConnectionForm({
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       header={edit ? "Edit SDK Connection" : "New SDK Connection"}
       size={"lg"}
       autoCloseOnSubmit={autoCloseOnSubmit}

--- a/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
+++ b/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
@@ -323,6 +323,7 @@ export default function SDKConnectionForm({
 
   return (
     <Modal
+      trackingEventName=""
       header={edit ? "Edit SDK Connection" : "New SDK Connection"}
       size={"lg"}
       autoCloseOnSubmit={autoCloseOnSubmit}

--- a/packages/front-end/components/Features/StaleDetectionModal.tsx
+++ b/packages/front-end/components/Features/StaleDetectionModal.tsx
@@ -15,7 +15,6 @@ export default function StaleDetectionModal({
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       open
       close={close}
       header={`${

--- a/packages/front-end/components/Features/StaleDetectionModal.tsx
+++ b/packages/front-end/components/Features/StaleDetectionModal.tsx
@@ -14,7 +14,8 @@ export default function StaleDetectionModal({
   const { apiCall } = useAuth();
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       open
       close={close}
       header={`${

--- a/packages/front-end/components/Features/StaleDetectionModal.tsx
+++ b/packages/front-end/components/Features/StaleDetectionModal.tsx
@@ -14,6 +14,7 @@ export default function StaleDetectionModal({
   const { apiCall } = useAuth();
   return (
     <Modal
+      trackingEventName=""
       open
       close={close}
       header={`${

--- a/packages/front-end/components/FeedbackModal.tsx
+++ b/packages/front-end/components/FeedbackModal.tsx
@@ -39,7 +39,6 @@ export default function FeedbackModal({
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       open={open}
       header={header}
       cta={ctaEnabled ? cta : sentCta ?? cta}

--- a/packages/front-end/components/FeedbackModal.tsx
+++ b/packages/front-end/components/FeedbackModal.tsx
@@ -38,6 +38,7 @@ export default function FeedbackModal({
 
   return (
     <Modal
+      trackingEventName=""
       open={open}
       header={header}
       cta={ctaEnabled ? cta : sentCta ?? cta}

--- a/packages/front-end/components/FeedbackModal.tsx
+++ b/packages/front-end/components/FeedbackModal.tsx
@@ -38,7 +38,8 @@ export default function FeedbackModal({
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       open={open}
       header={header}
       cta={ctaEnabled ? cta : sentCta ?? cta}

--- a/packages/front-end/components/GuidedGetStarted/CheckSDKConnectionModal.tsx
+++ b/packages/front-end/components/GuidedGetStarted/CheckSDKConnectionModal.tsx
@@ -22,7 +22,6 @@ export default function CheckSDKConnectionModal({
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       open={true}
       close={showModalClose ? close : undefined}
       closeCta="Close"

--- a/packages/front-end/components/GuidedGetStarted/CheckSDKConnectionModal.tsx
+++ b/packages/front-end/components/GuidedGetStarted/CheckSDKConnectionModal.tsx
@@ -21,7 +21,8 @@ export default function CheckSDKConnectionModal({
 }: Props) {
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       open={true}
       close={showModalClose ? close : undefined}
       closeCta="Close"

--- a/packages/front-end/components/GuidedGetStarted/CheckSDKConnectionModal.tsx
+++ b/packages/front-end/components/GuidedGetStarted/CheckSDKConnectionModal.tsx
@@ -21,6 +21,7 @@ export default function CheckSDKConnectionModal({
 }: Props) {
   return (
     <Modal
+      trackingEventName=""
       open={true}
       close={showModalClose ? close : undefined}
       closeCta="Close"

--- a/packages/front-end/components/HealthTab/DimensionIssues.tsx
+++ b/packages/front-end/components/HealthTab/DimensionIssues.tsx
@@ -146,7 +146,6 @@ export const DimensionIssues = ({
     <>
       <Modal
         trackingEventModalType=""
-        trackingEventModalSource=""
         close={() => setModalOpen(false)}
         open={modalOpen}
         closeCta={"Close"}

--- a/packages/front-end/components/HealthTab/DimensionIssues.tsx
+++ b/packages/front-end/components/HealthTab/DimensionIssues.tsx
@@ -145,7 +145,8 @@ export const DimensionIssues = ({
   return (
     <>
       <Modal
-        trackingEventName=""
+        trackingEventModalType=""
+        trackingEventModalSource=""
         close={() => setModalOpen(false)}
         open={modalOpen}
         closeCta={"Close"}

--- a/packages/front-end/components/HealthTab/DimensionIssues.tsx
+++ b/packages/front-end/components/HealthTab/DimensionIssues.tsx
@@ -145,6 +145,7 @@ export const DimensionIssues = ({
   return (
     <>
       <Modal
+        trackingEventName=""
         close={() => setModalOpen(false)}
         open={modalOpen}
         closeCta={"Close"}

--- a/packages/front-end/components/HomePage/NorthStar.tsx
+++ b/packages/front-end/components/HomePage/NorthStar.tsx
@@ -131,7 +131,8 @@ const NorthStar: FC<{
       )}
       {openNorthStarModal && (
         <Modal
-          trackingEventName=""
+          trackingEventModalType=""
+          trackingEventModalSource=""
           close={() => setOpenNorthStarModal(false)}
           overflowAuto={false}
           autoFocusSelector={""}

--- a/packages/front-end/components/HomePage/NorthStar.tsx
+++ b/packages/front-end/components/HomePage/NorthStar.tsx
@@ -131,6 +131,7 @@ const NorthStar: FC<{
       )}
       {openNorthStarModal && (
         <Modal
+          trackingEventName=""
           close={() => setOpenNorthStarModal(false)}
           overflowAuto={false}
           autoFocusSelector={""}

--- a/packages/front-end/components/HomePage/NorthStar.tsx
+++ b/packages/front-end/components/HomePage/NorthStar.tsx
@@ -132,7 +132,6 @@ const NorthStar: FC<{
       {openNorthStarModal && (
         <Modal
           trackingEventModalType=""
-          trackingEventModalSource=""
           close={() => setOpenNorthStarModal(false)}
           overflowAuto={false}
           autoFocusSelector={""}

--- a/packages/front-end/components/Ideas/IdeaForm.tsx
+++ b/packages/front-end/components/Ideas/IdeaForm.tsx
@@ -44,7 +44,6 @@ const IdeaForm: FC<{
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       header={edit ? "Edit Idea" : "New Idea"}
       close={close}
       open={true}

--- a/packages/front-end/components/Ideas/IdeaForm.tsx
+++ b/packages/front-end/components/Ideas/IdeaForm.tsx
@@ -43,7 +43,8 @@ const IdeaForm: FC<{
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       header={edit ? "Edit Idea" : "New Idea"}
       close={close}
       open={true}

--- a/packages/front-end/components/Ideas/IdeaForm.tsx
+++ b/packages/front-end/components/Ideas/IdeaForm.tsx
@@ -43,6 +43,7 @@ const IdeaForm: FC<{
 
   return (
     <Modal
+      trackingEventName=""
       header={edit ? "Edit Idea" : "New Idea"}
       close={close}
       open={true}

--- a/packages/front-end/components/Ideas/ImpactModal.tsx
+++ b/packages/front-end/components/Ideas/ImpactModal.tsx
@@ -41,6 +41,7 @@ const ImpactModal: FC<{
 
   return (
     <Modal
+      trackingEventName=""
       header="Impact Score Parameters"
       open={true}
       submit={form.handleSubmit(async (value) => {

--- a/packages/front-end/components/Ideas/ImpactModal.tsx
+++ b/packages/front-end/components/Ideas/ImpactModal.tsx
@@ -42,7 +42,6 @@ const ImpactModal: FC<{
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       header="Impact Score Parameters"
       open={true}
       submit={form.handleSubmit(async (value) => {

--- a/packages/front-end/components/Ideas/ImpactModal.tsx
+++ b/packages/front-end/components/Ideas/ImpactModal.tsx
@@ -41,7 +41,8 @@ const ImpactModal: FC<{
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       header="Impact Score Parameters"
       open={true}
       submit={form.handleSubmit(async (value) => {

--- a/packages/front-end/components/Layout/TopNav.tsx
+++ b/packages/front-end/components/Layout/TopNav.tsx
@@ -395,6 +395,7 @@ const TopNav: FC<{
       </Head>
       {editUserOpen && (
         <Modal
+          trackingEventName=""
           close={() => setEditUserOpen(false)}
           submit={onSubmitEditProfile}
           header="Edit Profile"

--- a/packages/front-end/components/Layout/TopNav.tsx
+++ b/packages/front-end/components/Layout/TopNav.tsx
@@ -396,7 +396,6 @@ const TopNav: FC<{
       {editUserOpen && (
         <Modal
           trackingEventModalType=""
-          trackingEventModalSource=""
           close={() => setEditUserOpen(false)}
           submit={onSubmitEditProfile}
           header="Edit Profile"

--- a/packages/front-end/components/Layout/TopNav.tsx
+++ b/packages/front-end/components/Layout/TopNav.tsx
@@ -395,7 +395,8 @@ const TopNav: FC<{
       </Head>
       {editUserOpen && (
         <Modal
-          trackingEventName=""
+          trackingEventModalType=""
+          trackingEventModalSource=""
           close={() => setEditUserOpen(false)}
           submit={onSubmitEditProfile}
           header="Edit Profile"

--- a/packages/front-end/components/Markdown/CustomMarkdown.tsx
+++ b/packages/front-end/components/Markdown/CustomMarkdown.tsx
@@ -58,7 +58,8 @@ const CustomMarkdown: React.FC<Props> = ({ page, variables }) => {
     <>
       {showModal && (
         <Modal
-          trackingEventName=""
+          trackingEventModalType=""
+          trackingEventModalSource=""
           open={true}
           header={<h4>{PAGE_TO_CTA[page] + organization.name}</h4>}
           close={() => setShowModal(false)}

--- a/packages/front-end/components/Markdown/CustomMarkdown.tsx
+++ b/packages/front-end/components/Markdown/CustomMarkdown.tsx
@@ -59,7 +59,6 @@ const CustomMarkdown: React.FC<Props> = ({ page, variables }) => {
       {showModal && (
         <Modal
           trackingEventModalType=""
-          trackingEventModalSource=""
           open={true}
           header={<h4>{PAGE_TO_CTA[page] + organization.name}</h4>}
           close={() => setShowModal(false)}

--- a/packages/front-end/components/Markdown/CustomMarkdown.tsx
+++ b/packages/front-end/components/Markdown/CustomMarkdown.tsx
@@ -58,6 +58,7 @@ const CustomMarkdown: React.FC<Props> = ({ page, variables }) => {
     <>
       {showModal && (
         <Modal
+          trackingEventName=""
           open={true}
           header={<h4>{PAGE_TO_CTA[page] + organization.name}</h4>}
           close={() => setShowModal(false)}

--- a/packages/front-end/components/Modal.tsx
+++ b/packages/front-end/components/Modal.tsx
@@ -8,6 +8,7 @@ import {
   useCallback,
 } from "react";
 import clsx from "clsx";
+import { truncateString } from "shared/util";
 import track, { TrackEventProps } from "@/services/track";
 import LoadingOverlay from "./LoadingOverlay";
 import Portal from "./Modal/Portal";
@@ -254,7 +255,7 @@ const Modal: FC<ModalProps> = ({
   }
 
   const sendTrackingEvent = useCallback(
-    (eventName: string) => {
+    (eventName: string, additionalProps?: Record<string, unknown>) => {
       if (trackingEventModalType === "") {
         return;
       }
@@ -262,6 +263,7 @@ const Modal: FC<ModalProps> = ({
         type: trackingEventModalType,
         source: trackingEventModalSource,
         ...allowlistedTrackingEventProps,
+        ...(additionalProps || {}),
       });
     },
     [
@@ -323,9 +325,11 @@ const Modal: FC<ModalProps> = ({
                 }
                 sendTrackingEvent("modal-submit-success");
               } catch (e) {
-                sendTrackingEvent("modal-submit-error");
                 setError(e.message);
                 setLoading(false);
+                sendTrackingEvent("modal-submit-error", {
+                  error: truncateString(e.message, 32),
+                });
               }
             }}
           >

--- a/packages/front-end/components/Modal.tsx
+++ b/packages/front-end/components/Modal.tsx
@@ -18,6 +18,7 @@ type ModalProps = {
   open: boolean;
   // An empty string will prevent firing a tracking event, but the prop is still required to encourage developers to add tracking
   trackingEventModalType: string;
+  // The source (likely page or component) causing the modal to be shown
   trackingEventModalSource?: string;
   className?: string;
   submitColor?: string;

--- a/packages/front-end/components/Modal.tsx
+++ b/packages/front-end/components/Modal.tsx
@@ -80,7 +80,7 @@ const Modal: FC<ModalProps> = ({
   customValidation,
   increasedElevation,
   trackingEventName,
-  trackingEventProps,
+  trackingEventProps = {},
 }) => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);

--- a/packages/front-end/components/Modal.tsx
+++ b/packages/front-end/components/Modal.tsx
@@ -7,7 +7,7 @@ import {
   CSSProperties,
 } from "react";
 import clsx from "clsx";
-import track, { TrackEventProps } from "@/services/track";
+import track from "@/services/track";
 import LoadingOverlay from "./LoadingOverlay";
 import Portal from "./Modal/Portal";
 import Tooltip from "./Tooltip/Tooltip";
@@ -17,7 +17,8 @@ type ModalProps = {
   header?: "logo" | string | ReactNode | boolean;
   open: boolean;
   // An empty string will prevent firing a tracking event, but the prop is still required to encourage developers to add tracking
-  trackingEventName: string;
+  trackingEventModalType: string;
+  trackingEventModalSource?: string;
   className?: string;
   submitColor?: string;
   cta?: string | ReactNode;
@@ -46,7 +47,6 @@ type ModalProps = {
   formRef?: React.RefObject<HTMLFormElement>;
   customValidation?: () => Promise<boolean> | boolean;
   increasedElevation?: boolean;
-  trackingEventProps?: TrackEventProps;
 };
 const Modal: FC<ModalProps> = ({
   header = "logo",
@@ -79,8 +79,8 @@ const Modal: FC<ModalProps> = ({
   formRef,
   customValidation,
   increasedElevation,
-  trackingEventName,
-  trackingEventProps = {},
+  trackingEventModalType,
+  trackingEventModalSource,
 }) => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -248,10 +248,13 @@ const Modal: FC<ModalProps> = ({
   }
 
   const sendTrackingEvent = () => {
-    if (trackingEventName === "") {
+    if (trackingEventModalType === "") {
       return;
     }
-    track(trackingEventName, trackingEventProps);
+    track("modal-submit", {
+      type: trackingEventModalType,
+      source: trackingEventModalSource,
+    });
   };
 
   const modalHtml = (

--- a/packages/front-end/components/Modal.tsx
+++ b/packages/front-end/components/Modal.tsx
@@ -7,6 +7,7 @@ import {
   CSSProperties,
 } from "react";
 import clsx from "clsx";
+import track, { TrackEventProps } from "@/services/track";
 import LoadingOverlay from "./LoadingOverlay";
 import Portal from "./Modal/Portal";
 import Tooltip from "./Tooltip/Tooltip";
@@ -15,6 +16,8 @@ import { DocLink, DocSection } from "./DocLink";
 type ModalProps = {
   header?: "logo" | string | ReactNode | boolean;
   open: boolean;
+  // An empty string will prevent firing a tracking event, but the prop is still required to encourage developers to add tracking
+  trackingEventName: string;
   className?: string;
   submitColor?: string;
   cta?: string | ReactNode;
@@ -43,6 +46,7 @@ type ModalProps = {
   formRef?: React.RefObject<HTMLFormElement>;
   customValidation?: () => Promise<boolean> | boolean;
   increasedElevation?: boolean;
+  trackingEventProps?: TrackEventProps;
 };
 const Modal: FC<ModalProps> = ({
   header = "logo",
@@ -75,6 +79,8 @@ const Modal: FC<ModalProps> = ({
   formRef,
   customValidation,
   increasedElevation,
+  trackingEventName,
+  trackingEventProps,
 }) => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -241,6 +247,13 @@ const Modal: FC<ModalProps> = ({
     overlayStyle.zIndex = 1500;
   }
 
+  const sendTrackingEvent = () => {
+    if (trackingEventName === "") {
+      return;
+    }
+    track(trackingEventName, trackingEventProps);
+  };
+
   const modalHtml = (
     <div
       className={clsx("modal", { show: open })}
@@ -278,6 +291,7 @@ const Modal: FC<ModalProps> = ({
               }
               try {
                 await submit();
+                sendTrackingEvent();
 
                 setLoading(false);
                 if (successMessage) {

--- a/packages/front-end/components/Modal/ConfirmButton.tsx
+++ b/packages/front-end/components/Modal/ConfirmButton.tsx
@@ -23,7 +23,8 @@ const ConfirmButton: FC<{
     <>
       {confirming ? (
         <Modal
-          trackingEventName=""
+          trackingEventModalType=""
+          trackingEventModalSource=""
           header={modalHeader}
           close={() => setConfirming(false)}
           open={true}

--- a/packages/front-end/components/Modal/ConfirmButton.tsx
+++ b/packages/front-end/components/Modal/ConfirmButton.tsx
@@ -23,6 +23,7 @@ const ConfirmButton: FC<{
     <>
       {confirming ? (
         <Modal
+          trackingEventName=""
           header={modalHeader}
           close={() => setConfirming(false)}
           open={true}

--- a/packages/front-end/components/Modal/ConfirmButton.tsx
+++ b/packages/front-end/components/Modal/ConfirmButton.tsx
@@ -24,7 +24,6 @@ const ConfirmButton: FC<{
       {confirming ? (
         <Modal
           trackingEventModalType=""
-          trackingEventModalSource=""
           header={modalHeader}
           close={() => setConfirming(false)}
           open={true}

--- a/packages/front-end/components/Modal/PagedModal.tsx
+++ b/packages/front-end/components/Modal/PagedModal.tsx
@@ -107,7 +107,8 @@ const PagedModal: FC<Props> = (props) => {
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       inline={inline}
       size={size}
       disabledMessage={disabledMessage}

--- a/packages/front-end/components/Modal/PagedModal.tsx
+++ b/packages/front-end/components/Modal/PagedModal.tsx
@@ -107,6 +107,7 @@ const PagedModal: FC<Props> = (props) => {
 
   return (
     <Modal
+      trackingEventName=""
       inline={inline}
       size={size}
       disabledMessage={disabledMessage}

--- a/packages/front-end/components/Modal/PagedModal.tsx
+++ b/packages/front-end/components/Modal/PagedModal.tsx
@@ -108,7 +108,6 @@ const PagedModal: FC<Props> = (props) => {
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       inline={inline}
       size={size}
       disabledMessage={disabledMessage}

--- a/packages/front-end/components/OpenVisualEditorLink.tsx
+++ b/packages/front-end/components/OpenVisualEditorLink.tsx
@@ -153,7 +153,6 @@ const OpenVisualEditorLink: FC<{
       {showEditorUrlDialog && openSettings && (
         <Modal
           trackingEventModalType=""
-          trackingEventModalSource=""
           open
           header="Visual Editor Target URL"
           close={() => setShowEditorUrlDialog(false)}
@@ -171,7 +170,6 @@ const OpenVisualEditorLink: FC<{
       {showExtensionDialog && (
         <Modal
           trackingEventModalType=""
-          trackingEventModalSource=""
           open
           header="GrowthBook DevTools Extension"
           close={() => setShowExtensionDialog(false)}

--- a/packages/front-end/components/OpenVisualEditorLink.tsx
+++ b/packages/front-end/components/OpenVisualEditorLink.tsx
@@ -152,7 +152,8 @@ const OpenVisualEditorLink: FC<{
 
       {showEditorUrlDialog && openSettings && (
         <Modal
-          trackingEventName=""
+          trackingEventModalType=""
+          trackingEventModalSource=""
           open
           header="Visual Editor Target URL"
           close={() => setShowEditorUrlDialog(false)}
@@ -169,7 +170,8 @@ const OpenVisualEditorLink: FC<{
 
       {showExtensionDialog && (
         <Modal
-          trackingEventName=""
+          trackingEventModalType=""
+          trackingEventModalSource=""
           open
           header="GrowthBook DevTools Extension"
           close={() => setShowExtensionDialog(false)}

--- a/packages/front-end/components/OpenVisualEditorLink.tsx
+++ b/packages/front-end/components/OpenVisualEditorLink.tsx
@@ -152,6 +152,7 @@ const OpenVisualEditorLink: FC<{
 
       {showEditorUrlDialog && openSettings && (
         <Modal
+          trackingEventName=""
           open
           header="Visual Editor Target URL"
           close={() => setShowEditorUrlDialog(false)}
@@ -168,6 +169,7 @@ const OpenVisualEditorLink: FC<{
 
       {showExtensionDialog && (
         <Modal
+          trackingEventName=""
           open
           header="GrowthBook DevTools Extension"
           close={() => setShowExtensionDialog(false)}

--- a/packages/front-end/components/Owner/EditOwnerModal.tsx
+++ b/packages/front-end/components/Owner/EditOwnerModal.tsx
@@ -20,7 +20,6 @@ const EditOwnerModal: FC<{
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       header={"Edit Owner"}
       open={true}
       close={cancel}

--- a/packages/front-end/components/Owner/EditOwnerModal.tsx
+++ b/packages/front-end/components/Owner/EditOwnerModal.tsx
@@ -19,7 +19,8 @@ const EditOwnerModal: FC<{
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       header={"Edit Owner"}
       open={true}
       close={cancel}

--- a/packages/front-end/components/Owner/EditOwnerModal.tsx
+++ b/packages/front-end/components/Owner/EditOwnerModal.tsx
@@ -19,6 +19,7 @@ const EditOwnerModal: FC<{
 
   return (
     <Modal
+      trackingEventName=""
       header={"Edit Owner"}
       open={true}
       close={cancel}

--- a/packages/front-end/components/PowerCalculation/PowerCalculationSettingsModal.tsx
+++ b/packages/front-end/components/PowerCalculation/PowerCalculationSettingsModal.tsx
@@ -116,7 +116,8 @@ const SelectStep = ({
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       open
       size="lg"
       header="New Calculation"
@@ -458,7 +459,8 @@ const SetParamsStep = ({
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       open
       size="lg"
       header="New Calculation"

--- a/packages/front-end/components/PowerCalculation/PowerCalculationSettingsModal.tsx
+++ b/packages/front-end/components/PowerCalculation/PowerCalculationSettingsModal.tsx
@@ -117,7 +117,6 @@ const SelectStep = ({
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       open
       size="lg"
       header="New Calculation"
@@ -460,7 +459,6 @@ const SetParamsStep = ({
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       open
       size="lg"
       header="New Calculation"

--- a/packages/front-end/components/PowerCalculation/PowerCalculationSettingsModal.tsx
+++ b/packages/front-end/components/PowerCalculation/PowerCalculationSettingsModal.tsx
@@ -116,6 +116,7 @@ const SelectStep = ({
 
   return (
     <Modal
+      trackingEventName=""
       open
       size="lg"
       header="New Calculation"
@@ -457,6 +458,7 @@ const SetParamsStep = ({
 
   return (
     <Modal
+      trackingEventName=""
       open
       size="lg"
       header="New Calculation"

--- a/packages/front-end/components/PowerCalculation/PowerCalculationStatsEngineSettingsModal.tsx
+++ b/packages/front-end/components/PowerCalculation/PowerCalculationStatsEngineSettingsModal.tsx
@@ -28,7 +28,6 @@ export default function PowerCalculationStatsEngineSettingsModal({
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       open
       size="lg"
       header="Analysis Settings"

--- a/packages/front-end/components/PowerCalculation/PowerCalculationStatsEngineSettingsModal.tsx
+++ b/packages/front-end/components/PowerCalculation/PowerCalculationStatsEngineSettingsModal.tsx
@@ -27,7 +27,8 @@ export default function PowerCalculationStatsEngineSettingsModal({
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       open
       size="lg"
       header="Analysis Settings"

--- a/packages/front-end/components/PowerCalculation/PowerCalculationStatsEngineSettingsModal.tsx
+++ b/packages/front-end/components/PowerCalculation/PowerCalculationStatsEngineSettingsModal.tsx
@@ -27,6 +27,7 @@ export default function PowerCalculationStatsEngineSettingsModal({
 
   return (
     <Modal
+      trackingEventName=""
       open
       size="lg"
       header="Analysis Settings"

--- a/packages/front-end/components/Projects/EditProjectsForm.tsx
+++ b/packages/front-end/components/Projects/EditProjectsForm.tsx
@@ -29,6 +29,7 @@ const EditProjectsForm: FC<{
 
   return (
     <Modal
+      trackingEventName=""
       header={"Edit Projects"}
       open={true}
       close={cancel}

--- a/packages/front-end/components/Projects/EditProjectsForm.tsx
+++ b/packages/front-end/components/Projects/EditProjectsForm.tsx
@@ -30,7 +30,6 @@ const EditProjectsForm: FC<{
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       header={"Edit Projects"}
       open={true}
       close={cancel}

--- a/packages/front-end/components/Projects/EditProjectsForm.tsx
+++ b/packages/front-end/components/Projects/EditProjectsForm.tsx
@@ -29,7 +29,8 @@ const EditProjectsForm: FC<{
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       header={"Edit Projects"}
       open={true}
       close={cancel}

--- a/packages/front-end/components/Projects/ProjectModal.tsx
+++ b/packages/front-end/components/Projects/ProjectModal.tsx
@@ -23,6 +23,7 @@ export default function ProjectModal({
 
   return (
     <Modal
+      trackingEventName=""
       open={true}
       close={close}
       header={existing.id ? "Edit Project" : "Create Project"}

--- a/packages/front-end/components/Projects/ProjectModal.tsx
+++ b/packages/front-end/components/Projects/ProjectModal.tsx
@@ -24,7 +24,6 @@ export default function ProjectModal({
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       open={true}
       close={close}
       header={existing.id ? "Edit Project" : "Create Project"}

--- a/packages/front-end/components/Projects/ProjectModal.tsx
+++ b/packages/front-end/components/Projects/ProjectModal.tsx
@@ -23,7 +23,8 @@ export default function ProjectModal({
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       open={true}
       close={close}
       header={existing.id ? "Edit Project" : "Create Project"}

--- a/packages/front-end/components/Queries/AsyncQueriesModal.tsx
+++ b/packages/front-end/components/Queries/AsyncQueriesModal.tsx
@@ -96,7 +96,8 @@ const AsyncQueriesModal: FC<{
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       close={close}
       header="Queries"
       open={true}

--- a/packages/front-end/components/Queries/AsyncQueriesModal.tsx
+++ b/packages/front-end/components/Queries/AsyncQueriesModal.tsx
@@ -96,6 +96,7 @@ const AsyncQueriesModal: FC<{
 
   return (
     <Modal
+      trackingEventName=""
       close={close}
       header="Queries"
       open={true}

--- a/packages/front-end/components/Queries/AsyncQueriesModal.tsx
+++ b/packages/front-end/components/Queries/AsyncQueriesModal.tsx
@@ -97,7 +97,6 @@ const AsyncQueriesModal: FC<{
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       close={close}
       header="Queries"
       open={true}

--- a/packages/front-end/components/Report/ConfigureReport.tsx
+++ b/packages/front-end/components/Report/ConfigureReport.tsx
@@ -182,6 +182,7 @@ export default function ConfigureReport({
 
   return (
     <Modal
+      trackingEventName=""
       inline={true}
       header=""
       size="fill"

--- a/packages/front-end/components/Report/ConfigureReport.tsx
+++ b/packages/front-end/components/Report/ConfigureReport.tsx
@@ -182,7 +182,8 @@ export default function ConfigureReport({
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       inline={true}
       header=""
       size="fill"

--- a/packages/front-end/components/Report/ConfigureReport.tsx
+++ b/packages/front-end/components/Report/ConfigureReport.tsx
@@ -183,7 +183,6 @@ export default function ConfigureReport({
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       inline={true}
       header=""
       size="fill"

--- a/packages/front-end/components/Report/EditTitleDescription.tsx
+++ b/packages/front-end/components/Report/EditTitleDescription.tsx
@@ -25,7 +25,6 @@ export default function EditTitleDescription({
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       open={true}
       submit={form.handleSubmit(async (value) => {
         await apiCall(`/report/${report.id}`, {

--- a/packages/front-end/components/Report/EditTitleDescription.tsx
+++ b/packages/front-end/components/Report/EditTitleDescription.tsx
@@ -24,6 +24,7 @@ export default function EditTitleDescription({
 
   return (
     <Modal
+      trackingEventName=""
       open={true}
       submit={form.handleSubmit(async (value) => {
         await apiCall(`/report/${report.id}`, {

--- a/packages/front-end/components/Report/EditTitleDescription.tsx
+++ b/packages/front-end/components/Report/EditTitleDescription.tsx
@@ -24,7 +24,8 @@ export default function EditTitleDescription({
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       open={true}
       submit={form.handleSubmit(async (value) => {
         await apiCall(`/report/${report.id}`, {

--- a/packages/front-end/components/SavedGroups/SavedGroupForm.tsx
+++ b/packages/front-end/components/SavedGroups/SavedGroupForm.tsx
@@ -74,6 +74,7 @@ const SavedGroupForm: FC<{
     />
   ) : (
     <Modal
+      trackingEventName=""
       close={close}
       open={true}
       size="lg"

--- a/packages/front-end/components/SavedGroups/SavedGroupForm.tsx
+++ b/packages/front-end/components/SavedGroups/SavedGroupForm.tsx
@@ -74,7 +74,12 @@ const SavedGroupForm: FC<{
     />
   ) : (
     <Modal
-      trackingEventName=""
+      trackingEventName="savedGroupFormSubmit"
+      trackingEventProps={{
+        action: current.id ? "update" : "create",
+        groupType: type,
+        numItems: (form.watch("values") || []).length,
+      }}
       close={close}
       open={true}
       size="lg"

--- a/packages/front-end/components/SavedGroups/SavedGroupForm.tsx
+++ b/packages/front-end/components/SavedGroups/SavedGroupForm.tsx
@@ -74,12 +74,7 @@ const SavedGroupForm: FC<{
     />
   ) : (
     <Modal
-      trackingEventName="savedGroupFormSubmit"
-      trackingEventProps={{
-        action: current.id ? "update" : "create",
-        groupType: type,
-        numItems: (form.watch("values") || []).length,
-      }}
+      trackingEventModalType="saved-group-form"
       close={close}
       open={true}
       size="lg"

--- a/packages/front-end/components/SchemaBrowser/EditSqlModal.tsx
+++ b/packages/front-end/components/SchemaBrowser/EditSqlModal.tsx
@@ -155,6 +155,7 @@ export default function EditSqlModal({
 
   return (
     <Modal
+      trackingEventName=""
       open
       header="Edit SQL"
       submit={form.handleSubmit(async (value) => {

--- a/packages/front-end/components/SchemaBrowser/EditSqlModal.tsx
+++ b/packages/front-end/components/SchemaBrowser/EditSqlModal.tsx
@@ -156,7 +156,6 @@ export default function EditSqlModal({
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       open
       header="Edit SQL"
       submit={form.handleSubmit(async (value) => {

--- a/packages/front-end/components/SchemaBrowser/EditSqlModal.tsx
+++ b/packages/front-end/components/SchemaBrowser/EditSqlModal.tsx
@@ -155,7 +155,8 @@ export default function EditSqlModal({
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       open
       header="Edit SQL"
       submit={form.handleSubmit(async (value) => {

--- a/packages/front-end/components/Segments/FactSegmentForm.tsx
+++ b/packages/front-end/components/Segments/FactSegmentForm.tsx
@@ -63,7 +63,8 @@ export default function FactSegmentForm({
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       close={close}
       open={true}
       size={"lg"}

--- a/packages/front-end/components/Segments/FactSegmentForm.tsx
+++ b/packages/front-end/components/Segments/FactSegmentForm.tsx
@@ -63,6 +63,7 @@ export default function FactSegmentForm({
 
   return (
     <Modal
+      trackingEventName=""
       close={close}
       open={true}
       size={"lg"}

--- a/packages/front-end/components/Segments/FactSegmentForm.tsx
+++ b/packages/front-end/components/Segments/FactSegmentForm.tsx
@@ -64,7 +64,6 @@ export default function FactSegmentForm({
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       close={close}
       open={true}
       size={"lg"}

--- a/packages/front-end/components/Segments/PickSegmentModal.tsx
+++ b/packages/front-end/components/Segments/PickSegmentModal.tsx
@@ -36,6 +36,7 @@ export default function PickSegmentModal({
 
   return (
     <Modal
+      trackingEventName=""
       open={true}
       close={close}
       header="Apply a Segment"

--- a/packages/front-end/components/Segments/PickSegmentModal.tsx
+++ b/packages/front-end/components/Segments/PickSegmentModal.tsx
@@ -37,7 +37,6 @@ export default function PickSegmentModal({
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       open={true}
       close={close}
       header="Apply a Segment"

--- a/packages/front-end/components/Segments/PickSegmentModal.tsx
+++ b/packages/front-end/components/Segments/PickSegmentModal.tsx
@@ -36,7 +36,8 @@ export default function PickSegmentModal({
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       open={true}
       close={close}
       header="Apply a Segment"

--- a/packages/front-end/components/Segments/SegmentForm.tsx
+++ b/packages/front-end/components/Segments/SegmentForm.tsx
@@ -94,7 +94,6 @@ const SegmentForm: FC<{
       )}
       <Modal
         trackingEventModalType=""
-        trackingEventModalSource=""
         close={close}
         open={true}
         size={"lg"}

--- a/packages/front-end/components/Segments/SegmentForm.tsx
+++ b/packages/front-end/components/Segments/SegmentForm.tsx
@@ -93,6 +93,7 @@ const SegmentForm: FC<{
         />
       )}
       <Modal
+        trackingEventName=""
         close={close}
         open={true}
         size={"lg"}

--- a/packages/front-end/components/Segments/SegmentForm.tsx
+++ b/packages/front-end/components/Segments/SegmentForm.tsx
@@ -93,7 +93,8 @@ const SegmentForm: FC<{
         />
       )}
       <Modal
-        trackingEventName=""
+        trackingEventModalType=""
+        trackingEventModalSource=""
         close={close}
         open={true}
         size={"lg"}

--- a/packages/front-end/components/Settings/ApiKeysModal.tsx
+++ b/packages/front-end/components/Settings/ApiKeysModal.tsx
@@ -39,7 +39,8 @@ const ApiKeysModal: FC<{
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       close={close}
       header={"Create API Key"}
       open={true}

--- a/packages/front-end/components/Settings/ApiKeysModal.tsx
+++ b/packages/front-end/components/Settings/ApiKeysModal.tsx
@@ -39,6 +39,7 @@ const ApiKeysModal: FC<{
 
   return (
     <Modal
+      trackingEventName=""
       close={close}
       header={"Create API Key"}
       open={true}

--- a/packages/front-end/components/Settings/ApiKeysModal.tsx
+++ b/packages/front-end/components/Settings/ApiKeysModal.tsx
@@ -40,7 +40,6 @@ const ApiKeysModal: FC<{
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       close={close}
       header={"Create API Key"}
       open={true}

--- a/packages/front-end/components/Settings/DataSourceForm.tsx
+++ b/packages/front-end/components/Settings/DataSourceForm.tsx
@@ -163,7 +163,8 @@ const DataSourceForm: FC<{
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       inline={inline}
       open={true}
       submit={handleSubmit}

--- a/packages/front-end/components/Settings/DataSourceForm.tsx
+++ b/packages/front-end/components/Settings/DataSourceForm.tsx
@@ -164,7 +164,6 @@ const DataSourceForm: FC<{
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       inline={inline}
       open={true}
       submit={handleSubmit}

--- a/packages/front-end/components/Settings/DataSourceForm.tsx
+++ b/packages/front-end/components/Settings/DataSourceForm.tsx
@@ -163,6 +163,7 @@ const DataSourceForm: FC<{
 
   return (
     <Modal
+      trackingEventName=""
       inline={inline}
       open={true}
       submit={handleSubmit}

--- a/packages/front-end/components/Settings/EditDataSource/DataSourceExperimentProperties/DataSourceEditExperimentEventPropertiesModal.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/DataSourceExperimentProperties/DataSourceEditExperimentEventPropertiesModal.tsx
@@ -49,6 +49,7 @@ export const DataSourceEditExperimentEventPropertiesModal: FC<DataSourceEditExpe
 
   return (
     <Modal
+      trackingEventName=""
       open={true}
       submit={handleSubmit}
       close={onCancel}

--- a/packages/front-end/components/Settings/EditDataSource/DataSourceExperimentProperties/DataSourceEditExperimentEventPropertiesModal.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/DataSourceExperimentProperties/DataSourceEditExperimentEventPropertiesModal.tsx
@@ -49,7 +49,8 @@ export const DataSourceEditExperimentEventPropertiesModal: FC<DataSourceEditExpe
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       open={true}
       submit={handleSubmit}
       close={onCancel}

--- a/packages/front-end/components/Settings/EditDataSource/DataSourceExperimentProperties/DataSourceEditExperimentEventPropertiesModal.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/DataSourceExperimentProperties/DataSourceEditExperimentEventPropertiesModal.tsx
@@ -50,7 +50,6 @@ export const DataSourceEditExperimentEventPropertiesModal: FC<DataSourceEditExpe
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       open={true}
       submit={handleSubmit}
       close={onCancel}

--- a/packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentifierTypes/EditIdentifierType.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentifierTypes/EditIdentifierType.tsx
@@ -64,7 +64,6 @@ export const EditIdentifierType: FC<EditIdentifierTypeProps> = ({
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       open={true}
       submit={handleSubmit}
       close={onCancel}

--- a/packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentifierTypes/EditIdentifierType.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentifierTypes/EditIdentifierType.tsx
@@ -63,6 +63,7 @@ export const EditIdentifierType: FC<EditIdentifierTypeProps> = ({
 
   return (
     <Modal
+      trackingEventName=""
       open={true}
       submit={handleSubmit}
       close={onCancel}

--- a/packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentifierTypes/EditIdentifierType.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentifierTypes/EditIdentifierType.tsx
@@ -63,7 +63,8 @@ export const EditIdentifierType: FC<EditIdentifierTypeProps> = ({
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       open={true}
       submit={handleSubmit}
       close={onCancel}

--- a/packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentityJoins/AddEditIdentityJoinModal.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentityJoins/AddEditIdentityJoinModal.tsx
@@ -115,6 +115,7 @@ export const AddEditIdentityJoinModal: FC<AddEditIdentityJoinModalProps> = ({
         />
       )}
       <Modal
+        trackingEventName=""
         open={true}
         submit={handleSubmit}
         close={onCancel}

--- a/packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentityJoins/AddEditIdentityJoinModal.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentityJoins/AddEditIdentityJoinModal.tsx
@@ -116,7 +116,6 @@ export const AddEditIdentityJoinModal: FC<AddEditIdentityJoinModalProps> = ({
       )}
       <Modal
         trackingEventModalType=""
-        trackingEventModalSource=""
         open={true}
         submit={handleSubmit}
         close={onCancel}

--- a/packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentityJoins/AddEditIdentityJoinModal.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentityJoins/AddEditIdentityJoinModal.tsx
@@ -115,7 +115,8 @@ export const AddEditIdentityJoinModal: FC<AddEditIdentityJoinModalProps> = ({
         />
       )}
       <Modal
-        trackingEventName=""
+        trackingEventModalType=""
+        trackingEventModalSource=""
         open={true}
         submit={handleSubmit}
         close={onCancel}

--- a/packages/front-end/components/Settings/EditDataSource/DataSourceJupypterQuery/EditJupyterNotebookQueryRunner.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/DataSourceJupypterQuery/EditJupyterNotebookQueryRunner.tsx
@@ -33,7 +33,6 @@ export const EditJupyterNotebookQueryRunner: FC<EditJupyterNotebookQueryRunnerPr
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       open={true}
       submit={handleSubmit}
       close={onCancel}

--- a/packages/front-end/components/Settings/EditDataSource/DataSourceJupypterQuery/EditJupyterNotebookQueryRunner.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/DataSourceJupypterQuery/EditJupyterNotebookQueryRunner.tsx
@@ -32,7 +32,8 @@ export const EditJupyterNotebookQueryRunner: FC<EditJupyterNotebookQueryRunnerPr
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       open={true}
       submit={handleSubmit}
       close={onCancel}

--- a/packages/front-end/components/Settings/EditDataSource/DataSourceJupypterQuery/EditJupyterNotebookQueryRunner.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/DataSourceJupypterQuery/EditJupyterNotebookQueryRunner.tsx
@@ -32,6 +32,7 @@ export const EditJupyterNotebookQueryRunner: FC<EditJupyterNotebookQueryRunnerPr
 
   return (
     <Modal
+      trackingEventName=""
       open={true}
       submit={handleSubmit}
       close={onCancel}

--- a/packages/front-end/components/Settings/EditDataSource/DataSourcePipeline/EditDataSourcePipeline.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/DataSourcePipeline/EditDataSourcePipeline.tsx
@@ -45,7 +45,8 @@ export const EditDataSourcePipeline: FC<EditDataSourcePipelineProps> = ({
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       open={true}
       submit={handleSubmit}
       close={onCancel}

--- a/packages/front-end/components/Settings/EditDataSource/DataSourcePipeline/EditDataSourcePipeline.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/DataSourcePipeline/EditDataSourcePipeline.tsx
@@ -46,7 +46,6 @@ export const EditDataSourcePipeline: FC<EditDataSourcePipelineProps> = ({
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       open={true}
       submit={handleSubmit}
       close={onCancel}

--- a/packages/front-end/components/Settings/EditDataSource/DataSourcePipeline/EditDataSourcePipeline.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/DataSourcePipeline/EditDataSourcePipeline.tsx
@@ -45,6 +45,7 @@ export const EditDataSourcePipeline: FC<EditDataSourcePipelineProps> = ({
 
   return (
     <Modal
+      trackingEventName=""
       open={true}
       submit={handleSubmit}
       close={onCancel}

--- a/packages/front-end/components/Settings/EditDataSource/DimensionMetadata/UpdateDimensionMetadata.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/DimensionMetadata/UpdateDimensionMetadata.tsx
@@ -140,7 +140,6 @@ export const UpdateDimensionMetadataModal: FC<UpdateDimensionMetadataModalProps>
     <>
       <Modal
         trackingEventModalType=""
-        trackingEventModalSource=""
         open={true}
         close={close}
         secondaryCTA={secondaryCTA}

--- a/packages/front-end/components/Settings/EditDataSource/DimensionMetadata/UpdateDimensionMetadata.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/DimensionMetadata/UpdateDimensionMetadata.tsx
@@ -139,7 +139,8 @@ export const UpdateDimensionMetadataModal: FC<UpdateDimensionMetadataModalProps>
   return (
     <>
       <Modal
-        trackingEventName=""
+        trackingEventModalType=""
+        trackingEventModalSource=""
         open={true}
         close={close}
         secondaryCTA={secondaryCTA}

--- a/packages/front-end/components/Settings/EditDataSource/DimensionMetadata/UpdateDimensionMetadata.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/DimensionMetadata/UpdateDimensionMetadata.tsx
@@ -139,6 +139,7 @@ export const UpdateDimensionMetadataModal: FC<UpdateDimensionMetadataModalProps>
   return (
     <>
       <Modal
+        trackingEventName=""
         open={true}
         close={close}
         secondaryCTA={secondaryCTA}

--- a/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/AddEditExperimentAssignmentQueryModal.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/AddEditExperimentAssignmentQueryModal.tsx
@@ -229,7 +229,8 @@ export const AddEditExperimentAssignmentQueryModal: FC<EditExperimentAssignmentQ
       )}
 
       <Modal
-        trackingEventName=""
+        trackingEventModalType=""
+        trackingEventModalSource=""
         open={true}
         submit={handleSubmit}
         close={onCancel}

--- a/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/AddEditExperimentAssignmentQueryModal.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/AddEditExperimentAssignmentQueryModal.tsx
@@ -229,6 +229,7 @@ export const AddEditExperimentAssignmentQueryModal: FC<EditExperimentAssignmentQ
       )}
 
       <Modal
+        trackingEventName=""
         open={true}
         submit={handleSubmit}
         close={onCancel}

--- a/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/AddEditExperimentAssignmentQueryModal.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/AddEditExperimentAssignmentQueryModal.tsx
@@ -230,7 +230,6 @@ export const AddEditExperimentAssignmentQueryModal: FC<EditExperimentAssignmentQ
 
       <Modal
         trackingEventModalType=""
-        trackingEventModalSource=""
         open={true}
         submit={handleSubmit}
         close={onCancel}

--- a/packages/front-end/components/Settings/EditLicenseModal.tsx
+++ b/packages/front-end/components/Settings/EditLicenseModal.tsx
@@ -26,7 +26,6 @@ const EditLicenseModal: FC<{
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       header="Enter License Key"
       open={true}
       close={close}

--- a/packages/front-end/components/Settings/EditLicenseModal.tsx
+++ b/packages/front-end/components/Settings/EditLicenseModal.tsx
@@ -25,6 +25,7 @@ const EditLicenseModal: FC<{
 
   return (
     <Modal
+      trackingEventName=""
       header="Enter License Key"
       open={true}
       close={close}

--- a/packages/front-end/components/Settings/EditLicenseModal.tsx
+++ b/packages/front-end/components/Settings/EditLicenseModal.tsx
@@ -25,7 +25,8 @@ const EditLicenseModal: FC<{
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       header="Enter License Key"
       open={true}
       close={close}

--- a/packages/front-end/components/Settings/EditOrganizationModal.tsx
+++ b/packages/front-end/components/Settings/EditOrganizationModal.tsx
@@ -28,7 +28,8 @@ const EditOrganizationModal: FC<{
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       header="Edit Organization"
       open={true}
       close={close}

--- a/packages/front-end/components/Settings/EditOrganizationModal.tsx
+++ b/packages/front-end/components/Settings/EditOrganizationModal.tsx
@@ -29,7 +29,6 @@ const EditOrganizationModal: FC<{
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       header="Edit Organization"
       open={true}
       close={close}

--- a/packages/front-end/components/Settings/EditOrganizationModal.tsx
+++ b/packages/front-end/components/Settings/EditOrganizationModal.tsx
@@ -28,6 +28,7 @@ const EditOrganizationModal: FC<{
 
   return (
     <Modal
+      trackingEventName=""
       header="Edit Organization"
       open={true}
       close={close}

--- a/packages/front-end/components/Settings/EnvironmentModal.tsx
+++ b/packages/front-end/components/Settings/EnvironmentModal.tsx
@@ -64,7 +64,8 @@ export default function EnvironmentModal({
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       open={true}
       close={close}
       header={

--- a/packages/front-end/components/Settings/EnvironmentModal.tsx
+++ b/packages/front-end/components/Settings/EnvironmentModal.tsx
@@ -64,6 +64,7 @@ export default function EnvironmentModal({
 
   return (
     <Modal
+      trackingEventName=""
       open={true}
       close={close}
       header={

--- a/packages/front-end/components/Settings/EnvironmentModal.tsx
+++ b/packages/front-end/components/Settings/EnvironmentModal.tsx
@@ -65,7 +65,6 @@ export default function EnvironmentModal({
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       open={true}
       close={close}
       header={

--- a/packages/front-end/components/Settings/ExperimentCheckListModal.tsx
+++ b/packages/front-end/components/Settings/ExperimentCheckListModal.tsx
@@ -65,7 +65,8 @@ export default function ExperimentCheckListModal({
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       open={true}
       close={close}
       size="max"

--- a/packages/front-end/components/Settings/ExperimentCheckListModal.tsx
+++ b/packages/front-end/components/Settings/ExperimentCheckListModal.tsx
@@ -65,6 +65,7 @@ export default function ExperimentCheckListModal({
 
   return (
     <Modal
+      trackingEventName=""
       open={true}
       close={close}
       size="max"

--- a/packages/front-end/components/Settings/ExperimentCheckListModal.tsx
+++ b/packages/front-end/components/Settings/ExperimentCheckListModal.tsx
@@ -66,7 +66,6 @@ export default function ExperimentCheckListModal({
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       open={true}
       close={close}
       size="max"

--- a/packages/front-end/components/Settings/NewDataSourceForm.tsx
+++ b/packages/front-end/components/Settings/NewDataSourceForm.tsx
@@ -648,7 +648,8 @@ const NewDataSourceForm: FC<{
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       open={true}
       header={existing ? "Edit Data Source" : "Add Data Source"}
       close={onCancel}

--- a/packages/front-end/components/Settings/NewDataSourceForm.tsx
+++ b/packages/front-end/components/Settings/NewDataSourceForm.tsx
@@ -649,7 +649,6 @@ const NewDataSourceForm: FC<{
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       open={true}
       header={existing ? "Edit Data Source" : "Add Data Source"}
       close={onCancel}

--- a/packages/front-end/components/Settings/NewDataSourceForm.tsx
+++ b/packages/front-end/components/Settings/NewDataSourceForm.tsx
@@ -648,6 +648,7 @@ const NewDataSourceForm: FC<{
 
   return (
     <Modal
+      trackingEventName=""
       open={true}
       header={existing ? "Edit Data Source" : "Add Data Source"}
       close={onCancel}

--- a/packages/front-end/components/Settings/Team/AddOrphanedUserModal.tsx
+++ b/packages/front-end/components/Settings/Team/AddOrphanedUserModal.tsx
@@ -45,7 +45,6 @@ const AddOrphanedUserModal: FC<{
     return (
       <Modal
         trackingEventModalType=""
-        trackingEventModalSource=""
         open={true}
         close={close}
         size="md"
@@ -66,7 +65,6 @@ const AddOrphanedUserModal: FC<{
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       close={close}
       header="Add User"
       open={true}

--- a/packages/front-end/components/Settings/Team/AddOrphanedUserModal.tsx
+++ b/packages/front-end/components/Settings/Team/AddOrphanedUserModal.tsx
@@ -43,7 +43,13 @@ const AddOrphanedUserModal: FC<{
     license.seats < seatsInUse + 1
   ) {
     return (
-      <Modal open={true} close={close} size="md" header={"Reached seat limit"}>
+      <Modal
+        trackingEventName=""
+        open={true}
+        close={close}
+        size="md"
+        header={"Reached seat limit"}
+      >
         <div className="my-3">
           Whoops! You reached the seat limit on your license. To increase your
           number of seats, please contact{" "}
@@ -58,6 +64,7 @@ const AddOrphanedUserModal: FC<{
 
   return (
     <Modal
+      trackingEventName=""
       close={close}
       header="Add User"
       open={true}

--- a/packages/front-end/components/Settings/Team/AddOrphanedUserModal.tsx
+++ b/packages/front-end/components/Settings/Team/AddOrphanedUserModal.tsx
@@ -44,7 +44,8 @@ const AddOrphanedUserModal: FC<{
   ) {
     return (
       <Modal
-        trackingEventName=""
+        trackingEventModalType=""
+        trackingEventModalSource=""
         open={true}
         close={close}
         size="md"
@@ -64,7 +65,8 @@ const AddOrphanedUserModal: FC<{
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       close={close}
       header="Add User"
       open={true}

--- a/packages/front-end/components/Settings/Team/AdminSetPasswordModal.tsx
+++ b/packages/front-end/components/Settings/Team/AdminSetPasswordModal.tsx
@@ -20,7 +20,8 @@ export default function AdminSetPasswordModal({ member, close }: Props) {
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       close={close}
       header="Change Password"
       open={true}

--- a/packages/front-end/components/Settings/Team/AdminSetPasswordModal.tsx
+++ b/packages/front-end/components/Settings/Team/AdminSetPasswordModal.tsx
@@ -20,6 +20,7 @@ export default function AdminSetPasswordModal({ member, close }: Props) {
 
   return (
     <Modal
+      trackingEventName=""
       close={close}
       header="Change Password"
       open={true}

--- a/packages/front-end/components/Settings/Team/AdminSetPasswordModal.tsx
+++ b/packages/front-end/components/Settings/Team/AdminSetPasswordModal.tsx
@@ -21,7 +21,6 @@ export default function AdminSetPasswordModal({ member, close }: Props) {
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       close={close}
       header="Change Password"
       open={true}

--- a/packages/front-end/components/Settings/Team/ChangeRoleModal.tsx
+++ b/packages/front-end/components/Settings/Team/ChangeRoleModal.tsx
@@ -26,7 +26,8 @@ const ChangeRoleModal: FC<{
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       close={close}
       header="Change Role"
       open={true}

--- a/packages/front-end/components/Settings/Team/ChangeRoleModal.tsx
+++ b/packages/front-end/components/Settings/Team/ChangeRoleModal.tsx
@@ -27,7 +27,6 @@ const ChangeRoleModal: FC<{
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       close={close}
       header="Change Role"
       open={true}

--- a/packages/front-end/components/Settings/Team/ChangeRoleModal.tsx
+++ b/packages/front-end/components/Settings/Team/ChangeRoleModal.tsx
@@ -26,6 +26,7 @@ const ChangeRoleModal: FC<{
 
   return (
     <Modal
+      trackingEventName=""
       close={close}
       header="Change Role"
       open={true}

--- a/packages/front-end/components/Settings/Team/InviteModal.tsx
+++ b/packages/front-end/components/Settings/Team/InviteModal.tsx
@@ -74,7 +74,8 @@ const InviteModal: FC<{ mutate: () => void; close: () => void }> = ({
   if (showContactSupport) {
     return (
       <Modal
-        trackingEventName=""
+        trackingEventModalType=""
+        trackingEventModalSource=""
         open={true}
         close={close}
         size="md"
@@ -154,7 +155,8 @@ const InviteModal: FC<{ mutate: () => void; close: () => void }> = ({
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       close={close}
       header="Invite Member"
       open={true}

--- a/packages/front-end/components/Settings/Team/InviteModal.tsx
+++ b/packages/front-end/components/Settings/Team/InviteModal.tsx
@@ -75,7 +75,6 @@ const InviteModal: FC<{ mutate: () => void; close: () => void }> = ({
     return (
       <Modal
         trackingEventModalType=""
-        trackingEventModalSource=""
         open={true}
         close={close}
         size="md"
@@ -156,7 +155,6 @@ const InviteModal: FC<{ mutate: () => void; close: () => void }> = ({
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       close={close}
       header="Invite Member"
       open={true}

--- a/packages/front-end/components/Settings/Team/InviteModal.tsx
+++ b/packages/front-end/components/Settings/Team/InviteModal.tsx
@@ -73,7 +73,13 @@ const InviteModal: FC<{ mutate: () => void; close: () => void }> = ({
   // Hit a hard cap and needs to contact sales to increase the number of seats on their license
   if (showContactSupport) {
     return (
-      <Modal open={true} close={close} size="md" header={"Reached seat limit"}>
+      <Modal
+        trackingEventName=""
+        open={true}
+        close={close}
+        size="md"
+        header={"Reached seat limit"}
+      >
         <div className="my-3">
           Whoops! You reached the seat limit on your license. To increase your
           number of seats, please contact{" "}
@@ -148,6 +154,7 @@ const InviteModal: FC<{ mutate: () => void; close: () => void }> = ({
 
   return (
     <Modal
+      trackingEventName=""
       close={close}
       header="Invite Member"
       open={true}

--- a/packages/front-end/components/Settings/Teams/PermissionModal.tsx
+++ b/packages/front-end/components/Settings/Teams/PermissionModal.tsx
@@ -32,6 +32,7 @@ export const PermissionsModal = ({
 
   return (
     <Modal
+      trackingEventName=""
       open={open}
       close={() => onClose()}
       header={"Edit Team Permissions"}

--- a/packages/front-end/components/Settings/Teams/PermissionModal.tsx
+++ b/packages/front-end/components/Settings/Teams/PermissionModal.tsx
@@ -32,7 +32,8 @@ export const PermissionsModal = ({
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       open={open}
       close={() => onClose()}
       header={"Edit Team Permissions"}

--- a/packages/front-end/components/Settings/Teams/PermissionModal.tsx
+++ b/packages/front-end/components/Settings/Teams/PermissionModal.tsx
@@ -33,7 +33,6 @@ export const PermissionsModal = ({
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       open={open}
       close={() => onClose()}
       header={"Edit Team Permissions"}

--- a/packages/front-end/components/Settings/UpgradeModal/CloudTrialConfirmationModal.tsx
+++ b/packages/front-end/components/Settings/UpgradeModal/CloudTrialConfirmationModal.tsx
@@ -15,7 +15,8 @@ export default function CloudTrialConfirmationModal({
 }: Props) {
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       open={true}
       close={close}
       size="md"

--- a/packages/front-end/components/Settings/UpgradeModal/CloudTrialConfirmationModal.tsx
+++ b/packages/front-end/components/Settings/UpgradeModal/CloudTrialConfirmationModal.tsx
@@ -16,7 +16,6 @@ export default function CloudTrialConfirmationModal({
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       open={true}
       close={close}
       size="md"

--- a/packages/front-end/components/Settings/UpgradeModal/CloudTrialConfirmationModal.tsx
+++ b/packages/front-end/components/Settings/UpgradeModal/CloudTrialConfirmationModal.tsx
@@ -15,6 +15,7 @@ export default function CloudTrialConfirmationModal({
 }: Props) {
   return (
     <Modal
+      trackingEventName=""
       open={true}
       close={close}
       size="md"

--- a/packages/front-end/components/Settings/UpgradeModal/LicenseSuccessModal.tsx
+++ b/packages/front-end/components/Settings/UpgradeModal/LicenseSuccessModal.tsx
@@ -16,6 +16,7 @@ export default function LicenseSuccessModal({
 }: Props) {
   return (
     <Modal
+      trackingEventName=""
       open={true}
       cta="Invite Members"
       closeCta={"Skip"}

--- a/packages/front-end/components/Settings/UpgradeModal/LicenseSuccessModal.tsx
+++ b/packages/front-end/components/Settings/UpgradeModal/LicenseSuccessModal.tsx
@@ -16,7 +16,8 @@ export default function LicenseSuccessModal({
 }: Props) {
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       open={true}
       cta="Invite Members"
       closeCta={"Skip"}

--- a/packages/front-end/components/Settings/UpgradeModal/LicenseSuccessModal.tsx
+++ b/packages/front-end/components/Settings/UpgradeModal/LicenseSuccessModal.tsx
@@ -17,7 +17,6 @@ export default function LicenseSuccessModal({
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       open={true}
       cta="Invite Members"
       closeCta={"Skip"}

--- a/packages/front-end/components/Settings/UpgradeModal/PleaseVerifyEmailModal.tsx
+++ b/packages/front-end/components/Settings/UpgradeModal/PleaseVerifyEmailModal.tsx
@@ -62,7 +62,6 @@ export default function PleaseVerifyEmailModal({
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       open={true}
       cta="Close"
       includeCloseCta={false}

--- a/packages/front-end/components/Settings/UpgradeModal/PleaseVerifyEmailModal.tsx
+++ b/packages/front-end/components/Settings/UpgradeModal/PleaseVerifyEmailModal.tsx
@@ -61,7 +61,8 @@ export default function PleaseVerifyEmailModal({
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       open={true}
       cta="Close"
       includeCloseCta={false}

--- a/packages/front-end/components/Settings/UpgradeModal/PleaseVerifyEmailModal.tsx
+++ b/packages/front-end/components/Settings/UpgradeModal/PleaseVerifyEmailModal.tsx
@@ -61,6 +61,7 @@ export default function PleaseVerifyEmailModal({
 
   return (
     <Modal
+      trackingEventName=""
       open={true}
       cta="Close"
       includeCloseCta={false}

--- a/packages/front-end/components/Settings/UpgradeModal/SelfHostedTrialConfirmationModal.tsx
+++ b/packages/front-end/components/Settings/UpgradeModal/SelfHostedTrialConfirmationModal.tsx
@@ -26,7 +26,6 @@ export default function SelfHostedTrialConfirmationModal({
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       open={true}
       includeCloseCta={false}
       close={close}

--- a/packages/front-end/components/Settings/UpgradeModal/SelfHostedTrialConfirmationModal.tsx
+++ b/packages/front-end/components/Settings/UpgradeModal/SelfHostedTrialConfirmationModal.tsx
@@ -25,7 +25,8 @@ export default function SelfHostedTrialConfirmationModal({
   });
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       open={true}
       includeCloseCta={false}
       close={close}

--- a/packages/front-end/components/Settings/UpgradeModal/SelfHostedTrialConfirmationModal.tsx
+++ b/packages/front-end/components/Settings/UpgradeModal/SelfHostedTrialConfirmationModal.tsx
@@ -25,6 +25,7 @@ export default function SelfHostedTrialConfirmationModal({
   });
   return (
     <Modal
+      trackingEventName=""
       open={true}
       includeCloseCta={false}
       close={close}

--- a/packages/front-end/components/Settings/UpgradeModal/VerifyingEmailModal.tsx
+++ b/packages/front-end/components/Settings/UpgradeModal/VerifyingEmailModal.tsx
@@ -69,6 +69,7 @@ export default function VerifyingEmailModal() {
 
   return (
     <Modal
+      trackingEventName=""
       open={true}
       cta="Invite Members"
       error={verifyEmailError}

--- a/packages/front-end/components/Settings/UpgradeModal/VerifyingEmailModal.tsx
+++ b/packages/front-end/components/Settings/UpgradeModal/VerifyingEmailModal.tsx
@@ -70,7 +70,6 @@ export default function VerifyingEmailModal() {
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       open={true}
       cta="Invite Members"
       error={verifyEmailError}

--- a/packages/front-end/components/Settings/UpgradeModal/VerifyingEmailModal.tsx
+++ b/packages/front-end/components/Settings/UpgradeModal/VerifyingEmailModal.tsx
@@ -69,7 +69,8 @@ export default function VerifyingEmailModal() {
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       open={true}
       cta="Invite Members"
       error={verifyEmailError}

--- a/packages/front-end/components/Settings/UpgradeModal/index.tsx
+++ b/packages/front-end/components/Settings/UpgradeModal/index.tsx
@@ -320,7 +320,6 @@ export default function UpgradeModal({ close, source }: Props) {
       ) : (
         <Modal
           trackingEventModalType=""
-          trackingEventModalSource=""
           open={true}
           includeCloseCta={false}
           close={close}

--- a/packages/front-end/components/Settings/UpgradeModal/index.tsx
+++ b/packages/front-end/components/Settings/UpgradeModal/index.tsx
@@ -319,7 +319,8 @@ export default function UpgradeModal({ close, source }: Props) {
         />
       ) : (
         <Modal
-          trackingEventName=""
+          trackingEventModalType=""
+          trackingEventModalSource=""
           open={true}
           includeCloseCta={false}
           close={close}

--- a/packages/front-end/components/Settings/UpgradeModal/index.tsx
+++ b/packages/front-end/components/Settings/UpgradeModal/index.tsx
@@ -319,6 +319,7 @@ export default function UpgradeModal({ close, source }: Props) {
         />
       ) : (
         <Modal
+          trackingEventName=""
           open={true}
           includeCloseCta={false}
           close={close}

--- a/packages/front-end/components/Settings/WebhooksModal.tsx
+++ b/packages/front-end/components/Settings/WebhooksModal.tsx
@@ -524,6 +524,7 @@ const EditSDKWebhooksModal: FC<{
 
   return (
     <Modal
+      trackingEventName=""
       close={close}
       header={current.id ? "Update Webhook" : "Create New Webhook"}
       open={true}

--- a/packages/front-end/components/Settings/WebhooksModal.tsx
+++ b/packages/front-end/components/Settings/WebhooksModal.tsx
@@ -524,7 +524,8 @@ const EditSDKWebhooksModal: FC<{
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       close={close}
       header={current.id ? "Update Webhook" : "Create New Webhook"}
       open={true}

--- a/packages/front-end/components/Settings/WebhooksModal.tsx
+++ b/packages/front-end/components/Settings/WebhooksModal.tsx
@@ -163,6 +163,7 @@ export function CreateSDKWebhookModal({
 
   return (
     <Modal
+      trackingEventModalType=""
       close={close}
       header="Create New SDK Webhook"
       open={true}
@@ -525,7 +526,6 @@ const EditSDKWebhooksModal: FC<{
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       close={close}
       header={current.id ? "Update Webhook" : "Create New Webhook"}
       open={true}

--- a/packages/front-end/components/SlackIntegrations/SlackIntegrationAddEditModal/SlackIntegrationAddEditModal.tsx
+++ b/packages/front-end/components/SlackIntegrations/SlackIntegrationAddEditModal/SlackIntegrationAddEditModal.tsx
@@ -101,7 +101,6 @@ export const SlackIntegrationAddEditModal: FC<SlackIntegrationAddEditModalProps>
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       header={modalTitle}
       cta={buttonText}
       close={onClose}

--- a/packages/front-end/components/SlackIntegrations/SlackIntegrationAddEditModal/SlackIntegrationAddEditModal.tsx
+++ b/packages/front-end/components/SlackIntegrations/SlackIntegrationAddEditModal/SlackIntegrationAddEditModal.tsx
@@ -100,7 +100,8 @@ export const SlackIntegrationAddEditModal: FC<SlackIntegrationAddEditModalProps>
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       header={modalTitle}
       cta={buttonText}
       close={onClose}

--- a/packages/front-end/components/SlackIntegrations/SlackIntegrationAddEditModal/SlackIntegrationAddEditModal.tsx
+++ b/packages/front-end/components/SlackIntegrations/SlackIntegrationAddEditModal/SlackIntegrationAddEditModal.tsx
@@ -100,6 +100,7 @@ export const SlackIntegrationAddEditModal: FC<SlackIntegrationAddEditModalProps>
 
   return (
     <Modal
+      trackingEventName=""
       header={modalTitle}
       cta={buttonText}
       close={onClose}

--- a/packages/front-end/components/Tags/EditTagsForm.tsx
+++ b/packages/front-end/components/Tags/EditTagsForm.tsx
@@ -22,7 +22,6 @@ const EditTagsForm: FC<{
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       header={"Edit Tags"}
       open={true}
       close={cancel}

--- a/packages/front-end/components/Tags/EditTagsForm.tsx
+++ b/packages/front-end/components/Tags/EditTagsForm.tsx
@@ -21,6 +21,7 @@ const EditTagsForm: FC<{
 
   return (
     <Modal
+      trackingEventName=""
       header={"Edit Tags"}
       open={true}
       close={cancel}

--- a/packages/front-end/components/Tags/EditTagsForm.tsx
+++ b/packages/front-end/components/Tags/EditTagsForm.tsx
@@ -21,7 +21,8 @@ const EditTagsForm: FC<{
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       header={"Edit Tags"}
       open={true}
       close={cancel}

--- a/packages/front-end/components/Tags/TagsModal.tsx
+++ b/packages/front-end/components/Tags/TagsModal.tsx
@@ -40,6 +40,7 @@ export default function TagsModal({
 
   return (
     <Modal
+      trackingEventName=""
       open={true}
       close={close}
       cta={existing?.id ? "Save Changes" : "Create Tag"}

--- a/packages/front-end/components/Tags/TagsModal.tsx
+++ b/packages/front-end/components/Tags/TagsModal.tsx
@@ -41,7 +41,6 @@ export default function TagsModal({
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       open={true}
       close={close}
       cta={existing?.id ? "Save Changes" : "Create Tag"}

--- a/packages/front-end/components/Tags/TagsModal.tsx
+++ b/packages/front-end/components/Tags/TagsModal.tsx
@@ -40,7 +40,8 @@ export default function TagsModal({
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       open={true}
       close={close}
       cta={existing?.id ? "Save Changes" : "Create Tag"}

--- a/packages/front-end/components/Teams/AddMembersModal.tsx
+++ b/packages/front-end/components/Teams/AddMembersModal.tsx
@@ -39,6 +39,7 @@ export const AddMembersModal = ({
 
   return (
     <Modal
+      trackingEventName=""
       open={open}
       close={() => handleClose()}
       header={"Add Team Members"}

--- a/packages/front-end/components/Teams/AddMembersModal.tsx
+++ b/packages/front-end/components/Teams/AddMembersModal.tsx
@@ -40,7 +40,6 @@ export const AddMembersModal = ({
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       open={open}
       close={() => handleClose()}
       header={"Add Team Members"}

--- a/packages/front-end/components/Teams/AddMembersModal.tsx
+++ b/packages/front-end/components/Teams/AddMembersModal.tsx
@@ -39,7 +39,8 @@ export const AddMembersModal = ({
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       open={open}
       close={() => handleClose()}
       header={"Add Team Members"}

--- a/packages/front-end/components/Teams/TeamModal.tsx
+++ b/packages/front-end/components/Teams/TeamModal.tsx
@@ -38,7 +38,6 @@ export default function TeamModal({
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       open={true}
       close={close}
       header={existing.id ? "Edit Team Metadata" : "Create Team"}

--- a/packages/front-end/components/Teams/TeamModal.tsx
+++ b/packages/front-end/components/Teams/TeamModal.tsx
@@ -37,6 +37,7 @@ export default function TeamModal({
 
   return (
     <Modal
+      trackingEventName=""
       open={true}
       close={close}
       header={existing.id ? "Edit Team Metadata" : "Create Team"}

--- a/packages/front-end/components/Teams/TeamModal.tsx
+++ b/packages/front-end/components/Teams/TeamModal.tsx
@@ -37,7 +37,8 @@ export default function TeamModal({
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       open={true}
       close={close}
       header={existing.id ? "Edit Team Metadata" : "Create Team"}

--- a/packages/front-end/components/importing/ImportFromLaunchDarkly/ImportFromLaunchDarkly.tsx
+++ b/packages/front-end/components/importing/ImportFromLaunchDarkly/ImportFromLaunchDarkly.tsx
@@ -552,7 +552,6 @@ function FeatureImportRow({
       {open && data.feature && (
         <Modal
           trackingEventModalType=""
-          trackingEventModalSource=""
           open
           close={() => setOpen(false)}
           header={`Feature Details`}

--- a/packages/front-end/components/importing/ImportFromLaunchDarkly/ImportFromLaunchDarkly.tsx
+++ b/packages/front-end/components/importing/ImportFromLaunchDarkly/ImportFromLaunchDarkly.tsx
@@ -551,6 +551,7 @@ function FeatureImportRow({
       </tr>
       {open && data.feature && (
         <Modal
+          trackingEventName=""
           open
           close={() => setOpen(false)}
           header={`Feature Details`}

--- a/packages/front-end/components/importing/ImportFromLaunchDarkly/ImportFromLaunchDarkly.tsx
+++ b/packages/front-end/components/importing/ImportFromLaunchDarkly/ImportFromLaunchDarkly.tsx
@@ -551,7 +551,8 @@ function FeatureImportRow({
       </tr>
       {open && data.feature && (
         <Modal
-          trackingEventName=""
+          trackingEventModalType=""
+          trackingEventModalSource=""
           open
           close={() => setOpen(false)}
           header={`Feature Details`}

--- a/packages/front-end/pages/admin.tsx
+++ b/packages/front-end/pages/admin.tsx
@@ -840,7 +840,6 @@ const EditMember: FC<{
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       submit={handleSubmit}
       open={true}
       header={"Edit Member"}

--- a/packages/front-end/pages/admin.tsx
+++ b/packages/front-end/pages/admin.tsx
@@ -839,6 +839,7 @@ const EditMember: FC<{
 
   return (
     <Modal
+      trackingEventName=""
       submit={handleSubmit}
       open={true}
       header={"Edit Member"}

--- a/packages/front-end/pages/admin.tsx
+++ b/packages/front-end/pages/admin.tsx
@@ -839,7 +839,8 @@ const EditMember: FC<{
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       submit={handleSubmit}
       open={true}
       header={"Edit Member"}

--- a/packages/front-end/pages/datasources/[did].tsx
+++ b/packages/front-end/pages/datasources/[did].tsx
@@ -400,6 +400,7 @@ mixpanel.init('YOUR PROJECT TOKEN', {
       )}
       {viewSchema && (
         <Modal
+          trackingEventName=""
           open={true}
           close={() => setViewSchema(false)}
           closeCta="Close"

--- a/packages/front-end/pages/datasources/[did].tsx
+++ b/packages/front-end/pages/datasources/[did].tsx
@@ -401,7 +401,6 @@ mixpanel.init('YOUR PROJECT TOKEN', {
       {viewSchema && (
         <Modal
           trackingEventModalType=""
-          trackingEventModalSource=""
           open={true}
           close={() => setViewSchema(false)}
           closeCta="Close"

--- a/packages/front-end/pages/datasources/[did].tsx
+++ b/packages/front-end/pages/datasources/[did].tsx
@@ -400,7 +400,8 @@ mixpanel.init('YOUR PROJECT TOKEN', {
       )}
       {viewSchema && (
         <Modal
-          trackingEventName=""
+          trackingEventModalType=""
+          trackingEventModalSource=""
           open={true}
           close={() => setViewSchema(false)}
           closeCta="Close"

--- a/packages/front-end/pages/datasources/queries/[did].tsx
+++ b/packages/front-end/pages/datasources/queries/[did].tsx
@@ -90,6 +90,7 @@ const DataSourceQueries = (): React.ReactElement => {
     <div className="container pagecontents">
       {modalData && (
         <Modal
+          trackingEventName=""
           open
           close={() => setModalData(null)}
           size="lg"

--- a/packages/front-end/pages/datasources/queries/[did].tsx
+++ b/packages/front-end/pages/datasources/queries/[did].tsx
@@ -90,7 +90,8 @@ const DataSourceQueries = (): React.ReactElement => {
     <div className="container pagecontents">
       {modalData && (
         <Modal
-          trackingEventName=""
+          trackingEventModalType=""
+          trackingEventModalSource=""
           open
           close={() => setModalData(null)}
           size="lg"

--- a/packages/front-end/pages/datasources/queries/[did].tsx
+++ b/packages/front-end/pages/datasources/queries/[did].tsx
@@ -91,7 +91,6 @@ const DataSourceQueries = (): React.ReactElement => {
       {modalData && (
         <Modal
           trackingEventModalType=""
-          trackingEventModalSource=""
           open
           close={() => setModalData(null)}
           size="lg"

--- a/packages/front-end/pages/integrations/vercel/index.tsx
+++ b/packages/front-end/pages/integrations/vercel/index.tsx
@@ -67,7 +67,8 @@ export default function VercelIntegrationPage() {
     <>
       {integrationAlreadyExists ? (
         <Modal
-          trackingEventName=""
+          trackingEventModalType=""
+          trackingEventModalSource=""
           open
           close={() => window.close()}
           cta="Continue"
@@ -95,7 +96,8 @@ export default function VercelIntegrationPage() {
             />
           ) : (
             <Modal
-              trackingEventName=""
+              trackingEventModalType=""
+              trackingEventModalSource=""
               submit={async () => {
                 await apiCall("/vercel/env-vars", {
                   method: "POST",

--- a/packages/front-end/pages/integrations/vercel/index.tsx
+++ b/packages/front-end/pages/integrations/vercel/index.tsx
@@ -68,7 +68,6 @@ export default function VercelIntegrationPage() {
       {integrationAlreadyExists ? (
         <Modal
           trackingEventModalType=""
-          trackingEventModalSource=""
           open
           close={() => window.close()}
           cta="Continue"
@@ -97,7 +96,6 @@ export default function VercelIntegrationPage() {
           ) : (
             <Modal
               trackingEventModalType=""
-              trackingEventModalSource=""
               submit={async () => {
                 await apiCall("/vercel/env-vars", {
                   method: "POST",

--- a/packages/front-end/pages/integrations/vercel/index.tsx
+++ b/packages/front-end/pages/integrations/vercel/index.tsx
@@ -67,6 +67,7 @@ export default function VercelIntegrationPage() {
     <>
       {integrationAlreadyExists ? (
         <Modal
+          trackingEventName=""
           open
           close={() => window.close()}
           cta="Continue"
@@ -94,6 +95,7 @@ export default function VercelIntegrationPage() {
             />
           ) : (
             <Modal
+              trackingEventName=""
               submit={async () => {
                 await apiCall("/vercel/env-vars", {
                   method: "POST",

--- a/packages/front-end/pages/presentations.tsx
+++ b/packages/front-end/pages/presentations.tsx
@@ -284,7 +284,6 @@ const PresentationPage = (): React.ReactElement => {
       {sharableLinkModal && (
         <Modal
           trackingEventModalType=""
-          trackingEventModalSource=""
           open={true}
           header={"Sharable link"}
           close={() => setSharableLinkModal(false)}

--- a/packages/front-end/pages/presentations.tsx
+++ b/packages/front-end/pages/presentations.tsx
@@ -283,7 +283,8 @@ const PresentationPage = (): React.ReactElement => {
       />
       {sharableLinkModal && (
         <Modal
-          trackingEventName=""
+          trackingEventModalType=""
+          trackingEventModalSource=""
           open={true}
           header={"Sharable link"}
           close={() => setSharableLinkModal(false)}

--- a/packages/front-end/pages/presentations.tsx
+++ b/packages/front-end/pages/presentations.tsx
@@ -283,6 +283,7 @@ const PresentationPage = (): React.ReactElement => {
       />
       {sharableLinkModal && (
         <Modal
+          trackingEventName=""
           open={true}
           header={"Sharable link"}
           close={() => setSharableLinkModal(false)}

--- a/packages/front-end/pages/report/[rid].tsx
+++ b/packages/front-end/pages/report/[rid].tsx
@@ -168,6 +168,7 @@ export default function ReportPage() {
       <div className="container-fluid pagecontents experiment-details">
         {editModalOpen && (
           <Modal
+            trackingEventName=""
             open={true}
             submit={form.handleSubmit(async (value) => {
               await apiCall(`/report/${report.id}`, {

--- a/packages/front-end/pages/report/[rid].tsx
+++ b/packages/front-end/pages/report/[rid].tsx
@@ -169,7 +169,6 @@ export default function ReportPage() {
         {editModalOpen && (
           <Modal
             trackingEventModalType=""
-            trackingEventModalSource=""
             open={true}
             submit={form.handleSubmit(async (value) => {
               await apiCall(`/report/${report.id}`, {

--- a/packages/front-end/pages/report/[rid].tsx
+++ b/packages/front-end/pages/report/[rid].tsx
@@ -168,7 +168,8 @@ export default function ReportPage() {
       <div className="container-fluid pagecontents experiment-details">
         {editModalOpen && (
           <Modal
-            trackingEventName=""
+            trackingEventModalType=""
+            trackingEventModalSource=""
             open={true}
             submit={form.handleSubmit(async (value) => {
               await apiCall(`/report/${report.id}`, {

--- a/packages/front-end/pages/reset-password.tsx
+++ b/packages/front-end/pages/reset-password.tsx
@@ -50,7 +50,6 @@ export default function ResetPasswordPage(): ReactElement {
   return (
     <Modal
       trackingEventModalType=""
-      trackingEventModalSource=""
       open={true}
       autoCloseOnSubmit={false}
       submit={

--- a/packages/front-end/pages/reset-password.tsx
+++ b/packages/front-end/pages/reset-password.tsx
@@ -49,6 +49,7 @@ export default function ResetPasswordPage(): ReactElement {
 
   return (
     <Modal
+      trackingEventName=""
       open={true}
       autoCloseOnSubmit={false}
       submit={

--- a/packages/front-end/pages/reset-password.tsx
+++ b/packages/front-end/pages/reset-password.tsx
@@ -49,7 +49,8 @@ export default function ResetPasswordPage(): ReactElement {
 
   return (
     <Modal
-      trackingEventName=""
+      trackingEventModalType=""
+      trackingEventModalSource=""
       open={true}
       autoCloseOnSubmit={false}
       submit={

--- a/packages/front-end/pages/saved-groups/[sgid].tsx
+++ b/packages/front-end/pages/saved-groups/[sgid].tsx
@@ -148,10 +148,7 @@ export default function EditSavedGroupPage() {
       )}
       {addItems && (
         <Modal
-          trackingEventName="editSavedGroupAddItems"
-          trackingEventProps={{
-            numItems: itemsToAdd.length,
-          }}
+          trackingEventModalType="edit-saved-group-add-items"
           close={() => {
             setAddItems(false);
             setItemsToAdd([]);

--- a/packages/front-end/pages/saved-groups/[sgid].tsx
+++ b/packages/front-end/pages/saved-groups/[sgid].tsx
@@ -148,6 +148,7 @@ export default function EditSavedGroupPage() {
       )}
       {addItems && (
         <Modal
+          trackingEventName=""
           close={() => {
             setAddItems(false);
             setItemsToAdd([]);

--- a/packages/front-end/pages/saved-groups/[sgid].tsx
+++ b/packages/front-end/pages/saved-groups/[sgid].tsx
@@ -148,7 +148,10 @@ export default function EditSavedGroupPage() {
       )}
       {addItems && (
         <Modal
-          trackingEventName=""
+          trackingEventName="editSavedGroupAddItems"
+          trackingEventProps={{
+            numItems: itemsToAdd.length,
+          }}
           close={() => {
             setAddItems(false);
             setItemsToAdd([]);

--- a/packages/front-end/pages/saved-groups/index.tsx
+++ b/packages/front-end/pages/saved-groups/index.tsx
@@ -204,6 +204,7 @@ export default function SavedGroupsPage() {
 
       {auditModal && (
         <Modal
+          trackingEventName=""
           open={true}
           header="Audit Log"
           close={() => setAuditModal(false)}

--- a/packages/front-end/pages/saved-groups/index.tsx
+++ b/packages/front-end/pages/saved-groups/index.tsx
@@ -204,7 +204,8 @@ export default function SavedGroupsPage() {
 
       {auditModal && (
         <Modal
-          trackingEventName=""
+          trackingEventModalType=""
+          trackingEventModalSource=""
           open={true}
           header="Audit Log"
           close={() => setAuditModal(false)}

--- a/packages/front-end/pages/saved-groups/index.tsx
+++ b/packages/front-end/pages/saved-groups/index.tsx
@@ -205,7 +205,6 @@ export default function SavedGroupsPage() {
       {auditModal && (
         <Modal
           trackingEventModalType=""
-          trackingEventModalSource=""
           open={true}
           header="Audit Log"
           close={() => setAuditModal(false)}

--- a/packages/front-end/pages/settings/custom-markdown.tsx
+++ b/packages/front-end/pages/settings/custom-markdown.tsx
@@ -98,6 +98,7 @@ const CustomMarkdown: React.FC = () => {
         <DocLink docSection={"customMarkdown"}>View Documentation &gt;</DocLink>
       </p>
       <Modal
+        trackingEventName=""
         cta={"Save"}
         header={false}
         open

--- a/packages/front-end/pages/settings/custom-markdown.tsx
+++ b/packages/front-end/pages/settings/custom-markdown.tsx
@@ -98,7 +98,8 @@ const CustomMarkdown: React.FC = () => {
         <DocLink docSection={"customMarkdown"}>View Documentation &gt;</DocLink>
       </p>
       <Modal
-        trackingEventName=""
+        trackingEventModalType=""
+        trackingEventModalSource=""
         cta={"Save"}
         header={false}
         open

--- a/packages/front-end/pages/settings/custom-markdown.tsx
+++ b/packages/front-end/pages/settings/custom-markdown.tsx
@@ -99,7 +99,6 @@ const CustomMarkdown: React.FC = () => {
       </p>
       <Modal
         trackingEventModalType=""
-        trackingEventModalSource=""
         cta={"Save"}
         header={false}
         open

--- a/packages/front-end/services/auth.tsx
+++ b/packages/front-end/services/auth.tsx
@@ -225,7 +225,8 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
       if (resp.confirm) {
         setAuthComponent(
           <Modal
-            trackingEventName=""
+            trackingEventModalType=""
+            trackingEventModalSource=""
             open={true}
             submit={async () => {
               await redirectWithTimeout(resp.redirectURI);
@@ -422,7 +423,8 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
   if (initError) {
     return (
       <Modal
-        trackingEventName=""
+        trackingEventModalType=""
+        trackingEventModalSource=""
         header="logo"
         open={true}
         cta="Try Again"
@@ -448,7 +450,8 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
   if (sessionError) {
     return (
       <Modal
-        trackingEventName=""
+        trackingEventModalType=""
+        trackingEventModalSource=""
         open={true}
         cta="OK"
         submit={async () => {

--- a/packages/front-end/services/auth.tsx
+++ b/packages/front-end/services/auth.tsx
@@ -225,6 +225,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
       if (resp.confirm) {
         setAuthComponent(
           <Modal
+            trackingEventName=""
             open={true}
             submit={async () => {
               await redirectWithTimeout(resp.redirectURI);
@@ -421,6 +422,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
   if (initError) {
     return (
       <Modal
+        trackingEventName=""
         header="logo"
         open={true}
         cta="Try Again"
@@ -446,6 +448,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
   if (sessionError) {
     return (
       <Modal
+        trackingEventName=""
         open={true}
         cta="OK"
         submit={async () => {

--- a/packages/front-end/services/auth.tsx
+++ b/packages/front-end/services/auth.tsx
@@ -226,7 +226,6 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
         setAuthComponent(
           <Modal
             trackingEventModalType=""
-            trackingEventModalSource=""
             open={true}
             submit={async () => {
               await redirectWithTimeout(resp.redirectURI);
@@ -424,7 +423,6 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
     return (
       <Modal
         trackingEventModalType=""
-        trackingEventModalSource=""
         header="logo"
         open={true}
         cta="Try Again"
@@ -451,7 +449,6 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
     return (
       <Modal
         trackingEventModalType=""
-        trackingEventModalSource=""
         open={true}
         cta="OK"
         submit={async () => {

--- a/packages/front-end/services/track.ts
+++ b/packages/front-end/services/track.ts
@@ -26,7 +26,7 @@ import {
   isTelemetryEnabled,
 } from "./env";
 
-type TrackEventProps = Record<string, unknown>;
+export type TrackEventProps = Record<string, unknown>;
 
 export interface TrackSnapshotProps {
   id: string;

--- a/packages/front-end/services/track.ts
+++ b/packages/front-end/services/track.ts
@@ -26,7 +26,7 @@ import {
   isTelemetryEnabled,
 } from "./env";
 
-export type TrackEventProps = Record<string, unknown>;
+type TrackEventProps = Record<string, unknown>;
 
 export interface TrackSnapshotProps {
   id: string;


### PR DESCRIPTION
### Features and Changes

Adds new props to the base `Modal` component: `trackingEventName` and `trackingEventProps`. The event name is required to force devs to consider whether to track new Modals that they add, but allows for an empty string to be passed to skip tracking unimportant modals.

### Testing

Spot checked various modals around the site to make sure that the new props don't interfere with the regular submit behavior when the event name is empty.


### Screenshots

![image](https://github.com/user-attachments/assets/40831f9e-3adc-45a4-89bd-79bb5e15a948)
