### PR TITLE
Add extra handling for saved group encryption in sdk payloads

### DIFF
--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -647,10 +647,9 @@ export async function getFeatureDefinitionsResponse({
     ? await encrypt(JSON.stringify(experiments || []), encryptionKey)
     : undefined;
 
-  const encryptedSavedGroups = await encrypt(
-    JSON.stringify(scrubbedSavedGroups),
-    encryptionKey
-  );
+  const encryptedSavedGroups = scrubbedSavedGroups
+    ? await encrypt(JSON.stringify(scrubbedSavedGroups), encryptionKey)
+    : undefined;
 
   return {
     features: {},
@@ -658,7 +657,6 @@ export async function getFeatureDefinitionsResponse({
     dateUpdated,
     encryptedFeatures,
     ...(includeAutoExperiments && { encryptedExperiments }),
-    savedGroups: {},
     encryptedSavedGroups: encryptedSavedGroups,
   };
 }


### PR DESCRIPTION
### Features and Changes

Adds a bit of extra safety around encrypting and using `undefined` saved groups when generating the SDK payload.
This should prevent users from running into spurious console errors in their SDK code when it tries to parse invalid decrypted JSON.