### PR TITLE
Create CountrySelector and add isoCountryCode attribute type

### DIFF
--- a/packages/back-end/src/util/organization.util.ts
+++ b/packages/back-end/src/util/organization.util.ts
@@ -307,4 +307,5 @@ export const attributeDataTypes = [
   "string[]",
   "number[]",
   "secureString[]",
+  "isoCountryCode",
 ] as const;

--- a/packages/front-end/components/Features/AttributeModal.tsx
+++ b/packages/front-end/components/Features/AttributeModal.tsx
@@ -185,6 +185,7 @@ export default function AttributeModal({ close, attribute }: Props) {
           { value: "string", label: "String" },
           { value: "enum", label: "Enum" },
           { value: "secureString", label: "Secure String" },
+          { value: "isoCountryCode", label: "ISO Country Code" },
           { value: "number[]", label: "Array of Numbers" },
           { value: "string[]", label: "Array of Strings" },
           {

--- a/packages/front-end/components/Features/ConditionInput.tsx
+++ b/packages/front-end/components/Features/ConditionInput.tsx
@@ -21,6 +21,9 @@ import Field from "@/components/Forms/Field";
 import SelectField from "@/components/Forms/SelectField";
 import CodeTextArea from "@/components/Forms/CodeTextArea";
 import StringArrayField from "@/components/Forms/StringArrayField";
+import CountrySelector, {
+  ALL_COUNTRY_CODES,
+} from "@/components/Forms/CountrySelector";
 import styles from "./ConditionInput.module.scss";
 
 interface Props {
@@ -73,6 +76,8 @@ export default function ConditionInput(props: Props) {
       value: "$notInGroup",
     },
   ];
+
+  const listOperators = ["$in", "$nin"];
 
   if (advanced || !attributes.size || !simpleAllowed) {
     const hasSecureAttributes = some(
@@ -304,6 +309,7 @@ export default function ConditionInput(props: Props) {
               | "enum"
               | "number"
               | "string"
+              | "isoCountryCode"
               | null = null;
             if (
               [
@@ -316,7 +322,9 @@ export default function ConditionInput(props: Props) {
               ].includes(operator)
             ) {
               displayType = "select-only";
-            } else if (["$in", "$nin"].includes(operator)) {
+            } else if (attribute.enum === ALL_COUNTRY_CODES) {
+              displayType = "isoCountryCode";
+            } else if (listOperators.includes(operator)) {
               displayType = "array-field";
             } else if (attribute.enum.length) {
               displayType = "enum";
@@ -437,6 +445,26 @@ export default function ConditionInput(props: Props) {
                         Switch to {rawTextMode ? "token" : "raw text"} mode
                       </span>
                     </div>
+                  ) : displayType === "isoCountryCode" ? (
+                    listOperators.includes(operator) ? (
+                      <CountrySelector
+                        selectAmount="multi"
+                        displayFlags={true}
+                        value={
+                          value ? value.split(",").map((val) => val.trim()) : []
+                        }
+                        onChange={handleListChange}
+                      />
+                    ) : (
+                      <CountrySelector
+                        selectAmount="single"
+                        displayFlags={true}
+                        value={value}
+                        onChange={(v) => {
+                          handleCondsChange(v, "value");
+                        }}
+                      />
+                    )
                   ) : displayType === "enum" ? (
                     <SelectField
                       options={attribute.enum.map((v) => ({

--- a/packages/front-end/components/Forms/CountrySelector.tsx
+++ b/packages/front-end/components/Forms/CountrySelector.tsx
@@ -1,0 +1,52 @@
+import {
+  countries,
+  getCountryFlagEmojiFromCountryCode,
+} from "country-codes-flags-phone-codes";
+import SelectField, { SelectFieldProps } from "./SelectField";
+import MultiSelectField, { MultiSelectFieldProps } from "./MultiSelectField";
+
+export const ALL_COUNTRY_CODES = countries.map((country) => country.code);
+
+interface CountrySelectorBaseProps {
+  displayFlags: boolean;
+}
+type SingleCountrySelectorProps = Omit<SelectFieldProps, "options"> & {
+  selectAmount: "single";
+} & CountrySelectorBaseProps;
+type MultiCountrySelectorProps = Omit<MultiSelectFieldProps, "options"> & {
+  selectAmount: "multi";
+} & CountrySelectorBaseProps;
+type CountrySelectorProps =
+  | SingleCountrySelectorProps
+  | MultiCountrySelectorProps;
+
+export default function CountrySelector(props: CountrySelectorProps) {
+  const options = countries.map((country) => ({
+    label: country.name,
+    value: country.code,
+  }));
+
+  const formatOptionLabel = ({ label, value }, { context }) => {
+    const text = context === "menu" ? label : value;
+    const flag = getCountryFlagEmojiFromCountryCode(value);
+    return `${props.displayFlags && flag ? flag + " " : ""}${text}`;
+  };
+
+  if (props.selectAmount === "single") {
+    return (
+      <SelectField
+        options={options}
+        formatOptionLabel={formatOptionLabel}
+        {...props}
+      />
+    );
+  } else {
+    return (
+      <MultiSelectField
+        options={options}
+        formatOptionLabel={formatOptionLabel}
+        {...props}
+      />
+    );
+  }
+}

--- a/packages/front-end/components/Forms/MultiSelectField.tsx
+++ b/packages/front-end/components/Forms/MultiSelectField.tsx
@@ -74,30 +74,30 @@ const Input = (props: InputProps) => {
   return <components.Input onPaste={onPaste} {...props} />;
 };
 
-const MultiSelectField: FC<
-  Omit<
-    FieldProps,
-    "value" | "onChange" | "options" | "multi" | "initialOption" | "placeholder"
-  > & {
-    value: string[];
-    placeholder?: string;
-    options: Option[];
-    initialOption?: string;
-    onChange: (value: string[]) => void;
-    sort?: boolean;
-    customStyles?: StylesConfig;
-    customClassName?: string;
-    closeMenuOnSelect?: boolean;
-    creatable?: boolean;
-    formatOptionLabel?: (
-      value: SingleValue,
-      meta: FormatOptionLabelMeta<SingleValue>
-    ) => ReactNode;
-    onPaste?: (e: React.ClipboardEvent<HTMLInputElement>) => void;
-    isOptionDisabled?: (_: Option) => boolean;
-    noMenu?: boolean;
-  }
-> = ({
+export type MultiSelectFieldProps = Omit<
+  FieldProps,
+  "value" | "onChange" | "options" | "multi" | "initialOption" | "placeholder"
+> & {
+  value: string[];
+  placeholder?: string;
+  options: Option[];
+  initialOption?: string;
+  onChange: (value: string[]) => void;
+  sort?: boolean;
+  customStyles?: StylesConfig;
+  customClassName?: string;
+  closeMenuOnSelect?: boolean;
+  creatable?: boolean;
+  formatOptionLabel?: (
+    value: SingleValue,
+    meta: FormatOptionLabelMeta<SingleValue>
+  ) => ReactNode;
+  onPaste?: (e: React.ClipboardEvent<HTMLInputElement>) => void;
+  isOptionDisabled?: (_: Option) => boolean;
+  noMenu?: boolean;
+};
+
+const MultiSelectField: FC<MultiSelectFieldProps> = ({
   value,
   options,
   onChange,

--- a/packages/front-end/package.json
+++ b/packages/front-end/package.json
@@ -39,6 +39,7 @@
     "back-end": "0.0.1",
     "bootstrap": "^4.5.0",
     "clsx": "^1.1.1",
+    "country-codes-flags-phone-codes": "^1.1.1",
     "cronstrue": "^1.122.0",
     "date-fns": "^2.15.0",
     "date-fns-tz": "^1.3.7",

--- a/packages/front-end/services/features.ts
+++ b/packages/front-end/services/features.ts
@@ -33,6 +33,7 @@ import { validateSavedGroupTargeting } from "@/components/Features/SavedGroupTar
 import useOrgSettings from "@/hooks/useOrgSettings";
 import useApi from "@/hooks/useApi";
 import { isExperimentRefRuleSkipped } from "@/components/Features/ExperimentRefSummary";
+import { ALL_COUNTRY_CODES } from "@/components/Forms/CountrySelector";
 import { useDefinitions } from "./DefinitionsContext";
 
 export { generateVariationId } from "shared/util";
@@ -859,7 +860,8 @@ export function condToJson(
 function getAttributeDataType(type: SDKAttributeType) {
   if (type === "boolean" || type === "number" || type === "string") return type;
 
-  if (type === "enum" || type === "string[]") return "string";
+  if (type === "enum" || type === "string[]" || type === "isoCountryCode")
+    return "string";
 
   if (type === "secureString" || type === "secureString[]")
     return "secureString";
@@ -886,6 +888,8 @@ export function useAttributeMap(
         enum:
           schema.datatype === "enum" && schema.enum
             ? schema.enum.split(",").map((x) => x.trim())
+            : schema.datatype === "isoCountryCode"
+            ? ALL_COUNTRY_CODES
             : [],
         identifier: !!schema.hashAttribute,
         archived: !!schema.archived,

--- a/yarn.lock
+++ b/yarn.lock
@@ -10494,6 +10494,11 @@ cosmiconfig@^7.0.0:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
+country-codes-flags-phone-codes@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/country-codes-flags-phone-codes/-/country-codes-flags-phone-codes-1.1.1.tgz#84c647470de04e59ef0d45d98d7aeac90c3209f9"
+  integrity sha512-90bZHByeKNlLKadeMWLBf8YNL0mHWdO2ESD8ts4ggYwmSo/vY3BGwMUQ2/lTfmMkQNLdIZNP1cjbiXWP9lEYIQ==
+
 create-emotion@^10.0.14, create-emotion@^10.0.27:
   version "10.0.27"
   resolved "https://registry.npmjs.org/create-emotion/-/create-emotion-10.0.27.tgz"


### PR DESCRIPTION
### Features and Changes

Adds a new frontend component - `<CountrySelector>` which wraps the existing `<SelectField>` and `<MultiSelectField>` with a definition of the country codes to display & an option for whether to display the flags for each country. Uses the 2-character country code for the value but displays the full name in the dropdown. Type-ahead search works based on both the label & value already, so e.g. "Algeria" with country code "DZ" can be found by searching either "Alg" or "D".

The CountrySelector is used in attribute targeting for the new datatype of `isoCountryCode`. For list operations (`$in`/`$nin`), it renders the multiselect variant, otherwise it's a single dropdown (with the same typeahead behavior). The new datatype is treated as an enum, and collapsed to a string as its base datatype.

### Testing

First, create a new attribute to use the country codes
- [x] Creating a condition saved group renders working selectors for
  - [x] List-type operations
  - [x] Single value operations
- [x] A new feature targeting rule against that attribute renders working selectors for
  - [x] List-type operations
  - [x] Single value operations
  - [x] Saved group operations
- [x]  Existing SDK connections produce valid JSON with the 2-character strings for each country code
- [x] An existing JS SDK (v1.1.0) can pass in the country code attribute (as a plain string) without needing to be updated, and the user is included in the previously created feature targeting rule

### Screenshots

![country_code_filtering](https://github.com/user-attachments/assets/11a6db9b-7abe-4f5f-a8e2-04aa787ca16b)

![image](https://github.com/user-attachments/assets/ed1c29cf-8e91-43d9-9946-29aa60311508)

![image](https://github.com/user-attachments/assets/9febd951-9623-484a-98a6-2e903483e4df)

