### PR TITLE
Fix link in Vue docs

### DIFF
--- a/docs/docs/lib/vue.mdx
+++ b/docs/docs/lib/vue.mdx
@@ -242,7 +242,7 @@ new Vue({
 
 ```
 
-You can find your features endpoint on the [Environments &rarr; SDK Endpoints page <ExternalLink/>](https://app.growthbook.io/environments).
+Find your features endpoint on the [SDK page <ExternalLink/>](https://app.growthbook.io/sdks).
 
 ### Use GrowthBook in your components
 

--- a/docs/docs/lib/vue.mdx
+++ b/docs/docs/lib/vue.mdx
@@ -242,7 +242,7 @@ new Vue({
 
 ```
 
-Find your features endpoint on the [SDK page <ExternalLink/>](https://app.growthbook.io/sdks).
+Find your features endpoint via the [**SDK Connections** page <ExternalLink/>](https://app.growthbook.io/sdks). Choose your SDK connection and scroll to **Full API Endpoint**.
 
 ### Use GrowthBook in your components
 


### PR DESCRIPTION
## Features and Changes

Update Vue docs to correct link
Closes: https://growthbookusers.slack.com/archives/C01T6Q0TEG3/p1725870777650699
