### PR TITLE
Swap ContentType for robots.txt

### DIFF
--- a/packages/back-end/src/app.ts
+++ b/packages/back-end/src/app.ts
@@ -168,7 +168,7 @@ app.get("/robots.txt", (_req, res) => {
   }
 
   res.setHeader("Cache-Control", "max-age=3600");
-  res.setHeader("Content-Type", "text/yaml");
+  res.setHeader("Content-Type", "text/plain");
   res.send(robotsTxt);
 });
 


### PR DESCRIPTION
### Features and Changes

Change the Content-Type header for the robots.txt path to text/plain (text/yaml was a mistaken holdover from the route this code was copied from)