### PR TITLE
Fix sdk-webhook docs

### DIFF
--- a/docs/docs/webhooks/sdk-webhooks.mdx
+++ b/docs/docs/webhooks/sdk-webhooks.mdx
@@ -84,12 +84,10 @@ app.post(
     const signature = rawSignature.split(",")[1];
 
     if (id && timestamp && signature) {
-      // Base64 encode the secret
-      const base64_secret = btoa(GROWTHBOOK_WEBHOOK_SECRET);
 
       // Compute the signature
       const computed = crypto
-        .createHmac("sha256", base64_secret)
+        .createHmac("sha256", GROWTHBOOK_WEBHOOK_SECRET)
         .update(`${id}.${timestamp}.${body}`)
         .digest("base64");
 


### PR DESCRIPTION
### Features and Changes

I fixed the SDK-Webhook Documentation to align with proper usage after wondering why standard-web-hooks version worked and the docs code didn't.
The HMAC SHA-256 hash needs to be applied to the decoded version of the Secret not the encoded
References: 
https://github.com/growthbook/growthbook/blob/ee9704e46493de6c43b0f62f923f48b5e3444421/packages/back-end/src/jobs/sdkWebhooks.ts#L179 or: 
https://github.com/standard-webhooks/standard-webhooks/blob/c54a58db59ece0485623cf08741fe92325db8254/libraries/javascript/src/webhook.test.ts#L29

- didn't find any related issues and decided to instant PR instead of opening one

### Testing

- Compare with the given references.
or
- run a quick nodejs and growthbook docker and try the code
