### PR TITLE
Allow for a second user-defined tracking callback in script tag SDK

### DIFF
--- a/packages/sdk-js/src/auto-wrapper.ts
+++ b/packages/sdk-js/src/auto-wrapper.ts
@@ -7,6 +7,7 @@ import {
   GrowthBook,
   LocalStorageStickyBucketService,
   StickyBucketService,
+  TrackingCallback,
 } from "./index";
 
 type WindowContext = Context & {
@@ -21,6 +22,7 @@ type WindowContext = Context & {
   cacheSettings?: CacheSettings;
   antiFlicker?: boolean;
   antiFlickerTimeout?: number;
+  additionalTrackingCallback?: TrackingCallback;
 };
 declare global {
   interface Window {
@@ -286,6 +288,12 @@ const gb = new GrowthBook({
   trackingCallback: async (e, r) => {
     const promises: Promise<unknown>[] = [];
     const eventParams = { experiment_id: e.key, variation_id: r.key };
+
+    if (windowContext.additionalTrackingCallback) {
+      promises.push(
+        Promise.resolve(windowContext.additionalTrackingCallback(e, r))
+      );
+    }
 
     // GA4 - gtag
     if (window.gtag) {


### PR DESCRIPTION
### Features and Changes

Adds an optional second tracking callback to the window context object so that users of the script tag SDK can configure their own callback without clobbering the built-in one which handles logging automagically.

### Testing

1. Create an auto-experiment (e.g. a visual editor change) and don't add any targeting restrictions. 
2. Spin up a local script tag environment if you don't have one, or use [this barebones one I made](https://github.com/growthbook/kevin-sdk-testing/tree/main/autowrapper)
3. Configure an `additionalTrackingCallback` on the `window.growthbook_config` object with a visible effect e.g. a console log
4. Load the local testing site and observe that the two effects have fired:
  - [x] The custom `additionalTrackingCallback`
  - [x] The built-in `window.dataLayer` push

### Screenshots

![image](https://github.com/user-attachments/assets/faeaf0ad-636b-4f72-a5b9-c87aba8cefd8)

![image](https://github.com/user-attachments/assets/4d0e3d91-477d-4bdd-bd92-f19f86bdcc83)
