### PR TITLE
Swap isoCountryCode to string format not attribute type

### DIFF
--- a/packages/back-end/src/util/organization.util.ts
+++ b/packages/back-end/src/util/organization.util.ts
@@ -307,5 +307,4 @@ export const attributeDataTypes = [
   "string[]",
   "number[]",
   "secureString[]",
-  "isoCountryCode",
 ] as const;

--- a/packages/back-end/types/organization.d.ts
+++ b/packages/back-end/types/organization.d.ts
@@ -132,7 +132,7 @@ export interface Namespaces {
   status: "active" | "inactive";
 }
 
-export type SDKAttributeFormat = "" | "version" | "date";
+export type SDKAttributeFormat = "" | "version" | "date" | "isoCountryCode";
 
 export type SDKAttributeType = typeof attributeDataTypes[number];
 

--- a/packages/front-end/components/Features/AttributeModal.tsx
+++ b/packages/front-end/components/Features/AttributeModal.tsx
@@ -185,7 +185,6 @@ export default function AttributeModal({ close, attribute }: Props) {
           { value: "string", label: "String" },
           { value: "enum", label: "Enum" },
           { value: "secureString", label: "Secure String" },
-          { value: "isoCountryCode", label: "ISO Country Code" },
           { value: "number[]", label: "Array of Numbers" },
           { value: "string[]", label: "Array of Strings" },
           {
@@ -242,6 +241,7 @@ export default function AttributeModal({ close, attribute }: Props) {
             options={[
               { value: "version", label: "Version string" },
               { value: "date", label: "Date string" },
+              { value: "isoCountryCode", label: "ISO Country Code (2 digit)" },
             ]}
             sort={false}
             helpText="Affects the targeting attribute UI and string comparison logic. More formats coming soon."

--- a/packages/front-end/services/features.ts
+++ b/packages/front-end/services/features.ts
@@ -860,8 +860,7 @@ export function condToJson(
 function getAttributeDataType(type: SDKAttributeType) {
   if (type === "boolean" || type === "number" || type === "string") return type;
 
-  if (type === "enum" || type === "string[]" || type === "isoCountryCode")
-    return "string";
+  if (type === "enum" || type === "string[]") return "string";
 
   if (type === "secureString" || type === "secureString[]")
     return "secureString";
@@ -888,7 +887,7 @@ export function useAttributeMap(
         enum:
           schema.datatype === "enum" && schema.enum
             ? schema.enum.split(",").map((x) => x.trim())
-            : schema.datatype === "isoCountryCode"
+            : schema.format === "isoCountryCode"
             ? ALL_COUNTRY_CODES
             : [],
         identifier: !!schema.hashAttribute,


### PR DESCRIPTION
### Features and Changes

We realized after shipping #2958 it probably makes more sense for isoCountryCode to be a string format rather than a type of attribute on its own. This PR makes that adjustment as a fast-follow to the original launch.

Note: any customers who have already (in the past ~2 hours) created a country code attribute will likely need to delete their attribute and start over. This is likely to be a small enough population that it's not worth adding extra code to automatically make the conversion

### Testing
Coming soon

### Screenshots

Coming soon