### PR TITLE
Remove @back-end imports

### DIFF
--- a/docs/scripts/gen-event-webhook-doc.ts
+++ b/docs/scripts/gen-event-webhook-doc.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { notificationEvents } from "@back-end/src/events/base-types";
+import { notificationEvents } from "back-end/src/events/base-types";
 
 const basePath = path.resolve(path.dirname(process.argv[1]), "..");
 

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -2,10 +2,7 @@
   // This file is not used in compilation. It is here just for a nice editor experience.
   "extends": "@docusaurus/tsconfig",
   "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "@back-end/*": ["../packages/back-end/*"]
-    }
+    "baseUrl": "."
   },
   "exclude": ["./scripts/*.ts"],
   "ts-node": {

--- a/packages/back-end/jest.config.js
+++ b/packages/back-end/jest.config.js
@@ -6,6 +6,5 @@ module.exports = {
   testMatch: ["**/test/**/*.test.(ts|js)"],
   moduleNameMapper: {
     "^axios$": "axios/dist/axios.js",
-    "@back-end/(.*)": "<rootDir>/$1",
   },
 };

--- a/packages/back-end/src/controllers/admin.ts
+++ b/packages/back-end/src/controllers/admin.ts
@@ -1,6 +1,6 @@
 import { Response } from "express";
-import { OrganizationInterface } from "@back-end/types/organization";
-import { UserInterface } from "@back-end/types/user";
+import { OrganizationInterface } from "back-end/types/organization";
+import { UserInterface } from "back-end/types/user";
 import { getAllSSOConnections } from "../models/SSOConnectionModel";
 import {
   getAllUsersFiltered,

--- a/packages/back-end/src/controllers/datasources.ts
+++ b/packages/back-end/src/controllers/datasources.ts
@@ -4,7 +4,7 @@ import * as bq from "@google-cloud/bigquery";
 import {
   CreateFactTableProps,
   FactTableInterface,
-} from "@back-end/types/fact-table";
+} from "back-end/types/fact-table";
 import { AuthRequest } from "../types/AuthRequest";
 import { getContextFromReq } from "../services/organizations";
 import {

--- a/packages/back-end/src/controllers/experimentLaunchChecklist.ts
+++ b/packages/back-end/src/controllers/experimentLaunchChecklist.ts
@@ -1,6 +1,6 @@
 import { Response } from "express";
 import { orgHasPremiumFeature } from "enterprise";
-import { ExperimentInterface } from "@back-end/types/experiment";
+import { ExperimentInterface } from "back-end/types/experiment";
 import { getContextFromReq } from "../services/organizations";
 import { AuthRequest } from "../types/AuthRequest";
 import {

--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -16,7 +16,7 @@ import {
 import { getScopedSettings } from "shared/settings";
 import { v4 as uuidv4 } from "uuid";
 import uniq from "lodash/uniq";
-import { DataSourceInterface } from "@back-end/types/datasource";
+import { DataSourceInterface } from "back-end/types/datasource";
 import { AuthRequest, ResponseWithStatusAndError } from "../types/AuthRequest";
 import {
   _getSnapshots,

--- a/packages/back-end/src/integrations/Presto.ts
+++ b/packages/back-end/src/integrations/Presto.ts
@@ -1,6 +1,6 @@
 /// <reference types="../../typings/presto-client" />
 import { Client, IPrestoClientOptions } from "presto-client";
-import { QueryStatistics } from "@back-end/types/query";
+import { QueryStatistics } from "back-end/types/query";
 import { decryptDataSourceParams } from "../services/datasource";
 import { PrestoConnectionParams } from "../../types/integrations/presto";
 import { FormatDialect } from "../util/sql";

--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -18,7 +18,7 @@ import {
   DEFAULT_TEST_QUERY_DAYS,
   DEFAULT_METRIC_HISTOGRAM_BINS,
 } from "shared/constants";
-import { MetricAnalysisSettings } from "@back-end/types/metric-analysis";
+import { MetricAnalysisSettings } from "back-end/types/metric-analysis";
 import { UNITS_TABLE_PREFIX } from "../queryRunners/ExperimentResultsQueryRunner";
 import { ReqContext } from "../../types/organization";
 import { MetricInterface, MetricType } from "../../types/metric";

--- a/packages/back-end/src/jobs/createAutoGeneratedFactTables.ts
+++ b/packages/back-end/src/jobs/createAutoGeneratedFactTables.ts
@@ -1,5 +1,5 @@
 import Agenda, { Job } from "agenda";
-import { CreateFactTableProps } from "@back-end/types/fact-table";
+import { CreateFactTableProps } from "back-end/types/fact-table";
 import { getDataSourceById } from "../models/DataSourceModel";
 import { getSourceIntegrationObject } from "../services/datasource";
 import { logger } from "../util/logger";

--- a/packages/back-end/src/models/GeneratedHypothesis.ts
+++ b/packages/back-end/src/models/GeneratedHypothesis.ts
@@ -1,9 +1,9 @@
 import { omit } from "lodash";
 import mongoose from "mongoose";
 import uniqid from "uniqid";
-import { ReqContext } from "@back-end/types/organization";
-import { GeneratedHypothesisInterface } from "@back-end/types/generated-hypothesis";
-import { ExperimentInterface } from "@back-end/types/experiment";
+import { ReqContext } from "back-end/types/organization";
+import { GeneratedHypothesisInterface } from "back-end/types/generated-hypothesis";
+import { ExperimentInterface } from "back-end/types/experiment";
 import { createExperiment } from "./ExperimentModel";
 import { upsertWatch } from "./WatchModel";
 import { createVisualChangeset } from "./VisualChangesetModel";

--- a/packages/back-end/src/models/MetricAnalysisModel.ts
+++ b/packages/back-end/src/models/MetricAnalysisModel.ts
@@ -1,4 +1,4 @@
-import { MetricAnalysisInterface } from "@back-end/types/metric-analysis";
+import { MetricAnalysisInterface } from "back-end/types/metric-analysis";
 import { metricAnalysisInterfaceValidator } from "../routers/metric-analysis/metric-analysis.validators";
 import { MakeModelClass } from "./BaseModel";
 

--- a/packages/back-end/src/models/OrganizationModel.ts
+++ b/packages/back-end/src/models/OrganizationModel.ts
@@ -3,7 +3,7 @@ import uniqid from "uniqid";
 import { cloneDeep } from "lodash";
 import { POLICIES, RESERVED_ROLE_IDS } from "shared/permissions";
 import { z } from "zod";
-import { TeamInterface } from "@back-end/types/team";
+import { TeamInterface } from "back-end/types/team";
 import {
   Invite,
   Member,

--- a/packages/back-end/src/models/SegmentModel.ts
+++ b/packages/back-end/src/models/SegmentModel.ts
@@ -1,4 +1,4 @@
-import { SegmentInterface } from "@back-end/types/segment";
+import { SegmentInterface } from "back-end/types/segment";
 import { getConfigSegments, usingFileConfig } from "../init/config";
 import { segmentValidator } from "../routers/segment/segment.validators";
 import { STORE_SEGMENTS_IN_MONGO } from "../util/secrets";

--- a/packages/back-end/src/queryRunners/ExperimentResultsQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentResultsQueryRunner.ts
@@ -7,7 +7,7 @@ import {
   quantileMetricType,
 } from "shared/experiments";
 import chunk from "lodash/chunk";
-import { ApiReqContext } from "@back-end/types/api";
+import { ApiReqContext } from "back-end/types/api";
 import {
   ExperimentSnapshotAnalysis,
   ExperimentSnapshotHealth,

--- a/packages/back-end/src/routers/metric-analysis/metric-analysis.controller.ts
+++ b/packages/back-end/src/routers/metric-analysis/metric-analysis.controller.ts
@@ -5,7 +5,7 @@ import {
   CreateMetricAnalysisProps,
   MetricAnalysisInterface,
   MetricAnalysisSettings,
-} from "@back-end/types/metric-analysis";
+} from "back-end/types/metric-analysis";
 import { createMetricAnalysis } from "../../services/metric-analysis";
 import { MetricAnalysisQueryRunner } from "../../queryRunners/MetricAnalysisQueryRunner";
 import { getExperimentMetricById } from "../../services/experiments";

--- a/packages/back-end/src/routers/users/users.controller.ts
+++ b/packages/back-end/src/routers/users/users.controller.ts
@@ -1,5 +1,5 @@
 import { Response } from "express";
-import { OrganizationInterface } from "@back-end/types/organization";
+import { OrganizationInterface } from "back-end/types/organization";
 import { IS_CLOUD } from "../../util/secrets";
 import { AuthRequest } from "../../types/AuthRequest";
 import { usingOpenId } from "../../services/auth";

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -33,7 +33,7 @@ import {
 } from "shared/experiments";
 import { orgHasPremiumFeature } from "enterprise";
 import { hoursBetween } from "shared/dates";
-import { MetricPriorSettings } from "@back-end/types/fact-table";
+import { MetricPriorSettings } from "back-end/types/fact-table";
 import { promiseAllChunks } from "../util/promise";
 import { updateExperiment } from "../models/ExperimentModel";
 import { Context } from "../models/BaseModel";

--- a/packages/back-end/src/services/metric-analysis.ts
+++ b/packages/back-end/src/services/metric-analysis.ts
@@ -1,5 +1,5 @@
-import { FactMetricInterface } from "@back-end/types/fact-table";
-import { MetricAnalysisSettings } from "@back-end/types/metric-analysis";
+import { FactMetricInterface } from "back-end/types/fact-table";
+import { MetricAnalysisSettings } from "back-end/types/metric-analysis";
 import { MetricAnalysisQueryRunner } from "../queryRunners/MetricAnalysisQueryRunner";
 import { getFactTableMap } from "../models/FactTableModel";
 import { Context } from "../models/BaseModel";

--- a/packages/back-end/src/services/segments.ts
+++ b/packages/back-end/src/services/segments.ts
@@ -1,5 +1,5 @@
-import { ApiSegment } from "@back-end/types/openapi";
-import { SegmentInterface } from "@back-end/types/segment";
+import { ApiSegment } from "back-end/types/openapi";
+import { SegmentInterface } from "back-end/types/segment";
 
 export function toSegmentApiInterface(segment: SegmentInterface): ApiSegment {
   return {

--- a/packages/back-end/src/types/Integration.ts
+++ b/packages/back-end/src/types/Integration.ts
@@ -1,6 +1,6 @@
 import { BigQueryTimestamp } from "@google-cloud/bigquery";
 import { ExperimentMetricInterface } from "shared/experiments";
-import { MetricAnalysisSettings } from "@back-end/types/metric-analysis";
+import { MetricAnalysisSettings } from "back-end/types/metric-analysis";
 import { ReqContext } from "../../types/organization";
 import {
   AutoFactTableSchemas,

--- a/packages/back-end/src/util/migrations.ts
+++ b/packages/back-end/src/util/migrations.ts
@@ -13,8 +13,8 @@ import {
   ExperimentReportArgs,
   LegacyReportInterface,
   ReportInterface,
-} from "@back-end/types/report";
-import { WebhookInterface } from "@back-end/types/webhook";
+} from "back-end/types/report";
+import { WebhookInterface } from "back-end/types/webhook";
 import { SdkWebHookLogDocument } from "../models/SdkWebhookLogModel";
 import { LegacyMetricInterface, MetricInterface } from "../../types/metric";
 import {

--- a/packages/back-end/test/events/experiment.test.ts
+++ b/packages/back-end/test/events/experiment.test.ts
@@ -3,16 +3,16 @@ import {
   logExperimentUpdated,
   logExperimentDeleted,
   ExperimentModel,
-} from "@back-end/src/models/ExperimentModel";
-import { getLegacyMessageForNotificationEvent } from "@back-end/src/events/handlers/legacy";
-import { experimentSnapshot } from "@back-end/test/snapshots/experiment.snapshot";
+} from "back-end/src/models/ExperimentModel";
+import { getLegacyMessageForNotificationEvent } from "back-end/src/events/handlers/legacy";
+import { experimentSnapshot } from "back-end/test/snapshots/experiment.snapshot";
 import {
   notifyMultipleExposures,
   notifySrm,
-} from "@back-end/src/services/experimentNotifications";
-import { EventModel } from "@back-end/src/models/EventModel";
+} from "back-end/src/services/experimentNotifications";
+import { EventModel } from "back-end/src/models/EventModel";
 
-jest.mock("@back-end/src/events/notifiers/EventNotifier", () => ({
+jest.mock("back-end/src/events/notifiers/EventNotifier", () => ({
   EventNotifier: class Dummy {
     perform() {
       return undefined;

--- a/packages/back-end/test/events/feature.test.ts
+++ b/packages/back-end/test/events/feature.test.ts
@@ -2,13 +2,13 @@ import {
   logFeatureCreatedEvent,
   logFeatureUpdatedEvent,
   logFeatureDeletedEvent,
-} from "@back-end/src/models/FeatureModel";
-import { getLegacyMessageForNotificationEvent } from "@back-end/src/events/handlers/legacy";
-import { featureSnapshot } from "@back-end/test/snapshots/feature.snapshot";
-import { EventModel } from "@back-end/src/models/EventModel";
+} from "back-end/src/models/FeatureModel";
+import { getLegacyMessageForNotificationEvent } from "back-end/src/events/handlers/legacy";
+import { featureSnapshot } from "back-end/test/snapshots/feature.snapshot";
+import { EventModel } from "back-end/src/models/EventModel";
 import { setupApp } from "../api/api.setup";
 
-jest.mock("@back-end/src/events/notifiers/EventNotifier", () => ({
+jest.mock("back-end/src/events/notifiers/EventNotifier", () => ({
   EventNotifier: class Dummy {
     perform() {
       return undefined;

--- a/packages/back-end/test/events/user.test.ts
+++ b/packages/back-end/test/events/user.test.ts
@@ -1,18 +1,18 @@
-import { findOrganizationsByMemberId } from "@back-end/src/models/OrganizationModel";
-import { getUserByEmail } from "@back-end/src/models/UserModel";
-import { trackLoginForUser } from "@back-end/src/services/users";
-import { createEventWithPayload } from "@back-end/src/models/EventModel";
-import { getLegacyMessageForNotificationEvent } from "@back-end/src/events/handlers/legacy";
+import { findOrganizationsByMemberId } from "back-end/src/models/OrganizationModel";
+import { getUserByEmail } from "back-end/src/models/UserModel";
+import { trackLoginForUser } from "back-end/src/services/users";
+import { createEventWithPayload } from "back-end/src/models/EventModel";
+import { getLegacyMessageForNotificationEvent } from "back-end/src/events/handlers/legacy";
 
-jest.mock("@back-end/src/models/OrganizationModel", () => ({
+jest.mock("back-end/src/models/OrganizationModel", () => ({
   findOrganizationsByMemberId: jest.fn(),
 }));
 
-jest.mock("@back-end/src/models/UserModel", () => ({
+jest.mock("back-end/src/models/UserModel", () => ({
   getUserByEmail: jest.fn(),
 }));
 
-jest.mock("@back-end/src/models/EventModel", () => ({
+jest.mock("back-end/src/models/EventModel", () => ({
   createEventWithPayload: jest.fn(),
 }));
 

--- a/packages/back-end/tsconfig.json
+++ b/packages/back-end/tsconfig.json
@@ -13,9 +13,6 @@
     "strictBindCallApply": true,
     "strictPropertyInitialization": true,
     "rootDir": "src",
-    "paths": {
-      "@back-end/*": ["./*"]
-    },
     "resolveJsonModule": true
   },
   "include": ["src/**/*", "types/**/*.d.ts", "typings/**/*.d.ts"]

--- a/packages/back-end/types/organization.d.ts
+++ b/packages/back-end/types/organization.d.ts
@@ -6,7 +6,7 @@ import {
   Policy,
 } from "shared/permissions";
 import { z } from "zod";
-import { environment } from "@back-end/src/routers/environment/environment.validators";
+import { environment } from "back-end/src/routers/environment/environment.validators";
 import type { ReqContextClass } from "../src/services/context";
 import { attributeDataTypes } from "../src/util/organization.util";
 import { AttributionModel, ImplementationType } from "./experiment";

--- a/packages/back-end/types/segment.d.ts
+++ b/packages/back-end/types/segment.d.ts
@@ -1,4 +1,4 @@
 import { z } from "zod";
-import { segmentValidator } from "@back-end/src/routers/segment/segment.validators";
+import { segmentValidator } from "back-end/src/routers/segment/segment.validators";
 
 export type SegmentInterface = z.infer<typeof segmentValidator>;

--- a/packages/enterprise/tsconfig.json
+++ b/packages/enterprise/tsconfig.json
@@ -13,9 +13,6 @@
     "strictBindCallApply": true,
     "strictPropertyInitialization": true,
     "rootDir": "src",
-    "paths": {
-      "@back-end/*": ["../back-end/*"]
-    },
     "resolveJsonModule": true
   },
   "include": ["src/**/*"]

--- a/packages/front-end/components/Admin/EditOrganization.tsx
+++ b/packages/front-end/components/Admin/EditOrganization.tsx
@@ -1,5 +1,5 @@
 import { useState, FC } from "react";
-import { OrganizationInterface } from "@back-end/types/organization";
+import { OrganizationInterface } from "back-end/types/organization";
 import { useAuth } from "@/services/auth";
 import Modal from "@/components/Modal";
 import { isCloud } from "@/services/env";

--- a/packages/front-end/components/AutoGenerateFactTablesModal.tsx
+++ b/packages/front-end/components/AutoGenerateFactTablesModal.tsx
@@ -2,8 +2,8 @@ import { useState, useEffect, useCallback, Fragment } from "react";
 import {
   AutoFactTableToCreate,
   InformationSchemaInterface,
-} from "@back-end/src/types/Integration";
-import { DataSourceInterfaceWithParams } from "@back-end/types/datasource";
+} from "back-end/src/types/Integration";
+import { DataSourceInterfaceWithParams } from "back-end/types/datasource";
 import { cloneDeep } from "lodash";
 import { useForm } from "react-hook-form";
 import { FaExternalLinkAlt, FaRedo } from "react-icons/fa";

--- a/packages/front-end/components/AutoGenerateMetricsButton.tsx
+++ b/packages/front-end/components/AutoGenerateMetricsButton.tsx
@@ -1,4 +1,4 @@
-import { DataSourceInterfaceWithParams } from "@back-end/types/datasource";
+import { DataSourceInterfaceWithParams } from "back-end/types/datasource";
 import { FaPlus } from "react-icons/fa";
 import clsx from "clsx";
 import { useMemo } from "react";

--- a/packages/front-end/components/AutoGenerateMetricsModal.tsx
+++ b/packages/front-end/components/AutoGenerateMetricsModal.tsx
@@ -3,11 +3,11 @@ import {
   AutoMetricToCreate,
   AutoMetricTrackedEvent,
   InformationSchemaInterface,
-} from "@back-end/src/types/Integration";
+} from "back-end/src/types/Integration";
 import {
   DataSourceInterfaceWithParams,
   DataSourceSettings,
-} from "@back-end/types/datasource";
+} from "back-end/types/datasource";
 import { cloneDeep } from "lodash";
 import { useForm } from "react-hook-form";
 import { FaRedo } from "react-icons/fa";

--- a/packages/front-end/components/Experiment/ExperimentVariationsInput.tsx
+++ b/packages/front-end/components/Experiment/ExperimentVariationsInput.tsx
@@ -1,4 +1,4 @@
-import { Variation } from "@back-end/types/experiment";
+import { Variation } from "back-end/types/experiment";
 import { generateVariationId } from "@/services/features";
 import { GBAddCircle } from "@/components/Icons";
 import SortableVariationsList from "@/components/Features/SortableVariationsList";

--- a/packages/front-end/components/Experiment/ResultMoreMenu.tsx
+++ b/packages/front-end/components/Experiment/ResultMoreMenu.tsx
@@ -8,7 +8,7 @@ import {
   ReportInterface,
 } from "back-end/types/report";
 import { BsArrowRepeat } from "react-icons/bs";
-import { DataSourceInterfaceWithParams } from "@back-end/types/datasource";
+import { DataSourceInterfaceWithParams } from "back-end/types/datasource";
 import { useAuth } from "@/services/auth";
 import ResultsDownloadButton from "@/components/Experiment/ResultsDownloadButton";
 import Button from "@/components/Button";

--- a/packages/front-end/components/Experiment/Results.tsx
+++ b/packages/front-end/components/Experiment/Results.tsx
@@ -8,8 +8,8 @@ import {
   DEFAULT_STATS_ENGINE,
 } from "shared/constants";
 import { ExperimentMetricInterface } from "shared/experiments";
-import { ExperimentSnapshotInterface } from "@back-end/types/experiment-snapshot";
-import { MetricSnapshotSettings } from "@back-end/types/report";
+import { ExperimentSnapshotInterface } from "back-end/types/experiment-snapshot";
+import { MetricSnapshotSettings } from "back-end/types/report";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import { useAuth } from "@/services/auth";
 import { getQueryStatus } from "@/components/Queries/RunQueriesButton";

--- a/packages/front-end/components/Experiment/TabbedPage/Implementation.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/Implementation.tsx
@@ -3,7 +3,7 @@ import {
   LinkedFeatureInfo,
 } from "back-end/types/experiment";
 import { VisualChangesetInterface } from "back-end/types/visual-changeset";
-import { URLRedirectInterface } from "@back-end/types/url-redirect";
+import { URLRedirectInterface } from "back-end/types/url-redirect";
 import AddLinkedChanges from "@/components/Experiment/LinkedChanges/AddLinkedChanges";
 import RedirectLinkedChanges from "@/components/Experiment/LinkedChanges/RedirectLinkedChanges";
 import FeatureLinkedChanges from "@/components/Experiment/LinkedChanges/FeatureLinkedChanges";

--- a/packages/front-end/components/Experiment/VariationIdWarning.tsx
+++ b/packages/front-end/components/Experiment/VariationIdWarning.tsx
@@ -4,7 +4,7 @@ import {
   ExperimentReportResultDimension,
   ExperimentReportVariation,
 } from "back-end/types/report";
-import { DataSourceInterfaceWithParams } from "@back-end/types/datasource";
+import { DataSourceInterfaceWithParams } from "back-end/types/datasource";
 import FixVariationIds from "@/components/Experiment/FixVariationIds";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 

--- a/packages/front-end/components/Features/CopyRuleModal.tsx
+++ b/packages/front-end/components/Features/CopyRuleModal.tsx
@@ -1,4 +1,4 @@
-import { FeatureInterface, FeatureRule } from "@back-end/types/feature";
+import { FeatureInterface, FeatureRule } from "back-end/types/feature";
 import { filterEnvironmentsByFeature } from "shared/dist/util";
 import { useState } from "react";
 import { getRules, useEnvironments } from "@/services/features";

--- a/packages/front-end/components/Features/FallbackAttributeSelector.tsx
+++ b/packages/front-end/components/Features/FallbackAttributeSelector.tsx
@@ -8,7 +8,7 @@ import {
 } from "react-icons/fa";
 import { FaGear } from "react-icons/fa6";
 import { getConnectionsSDKCapabilities } from "shared/sdk-versioning";
-import { SDKAttribute } from "@back-end/types/organization";
+import { SDKAttribute } from "back-end/types/organization";
 import useOrgSettings from "@/hooks/useOrgSettings";
 import PremiumTooltip from "@/components/Marketing/PremiumTooltip";
 import { useUser } from "@/services/UserContext";

--- a/packages/front-end/components/Features/SortableFeatureVariationRow.tsx
+++ b/packages/front-end/components/Features/SortableFeatureVariationRow.tsx
@@ -6,7 +6,7 @@ import {
   ExperimentValue,
   FeatureInterface,
   FeatureValueType,
-} from "@back-end/types/feature";
+} from "back-end/types/feature";
 import clsx from "clsx";
 import {
   decimalToPercent,

--- a/packages/front-end/components/GeneralSettings/ExperimentSettings/StatsEngineSettings.tsx
+++ b/packages/front-end/components/GeneralSettings/ExperimentSettings/StatsEngineSettings.tsx
@@ -5,7 +5,7 @@ import {
   DEFAULT_STATS_ENGINE,
 } from "shared/constants";
 import { StatsEngine, PValueCorrection } from "back-end/types/stats";
-import { MetricDefaults } from "@back-end/types/organization";
+import { MetricDefaults } from "back-end/types/organization";
 import ControlledTabs from "@/components/Tabs/ControlledTabs";
 import StatsEngineSelect from "@/components/Settings/forms/StatsEngineSelect";
 import Tab from "@/components/Tabs/Tab";

--- a/packages/front-end/components/GetStarted/ViewSampleDataButton.tsx
+++ b/packages/front-end/components/GetStarted/ViewSampleDataButton.tsx
@@ -1,4 +1,4 @@
-import { ProjectInterface } from "@back-end/types/project";
+import { ProjectInterface } from "back-end/types/project";
 import { useRouter } from "next/router";
 import { useDemoDataSourceProject } from "@/hooks/useDemoDataSourceProject";
 import Button from "@/components/Button";

--- a/packages/front-end/components/Layout/SidebarLink.tsx
+++ b/packages/front-end/components/Layout/SidebarLink.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/router";
 import clsx from "clsx";
 import { FiChevronRight } from "react-icons/fi";
 import { GrowthBook, useGrowthBook } from "@growthbook/growthbook-react";
-import { GlobalPermission } from "@back-end/types/organization";
+import { GlobalPermission } from "back-end/types/organization";
 import { Permissions } from "shared/permissions";
 import { AppFeatures } from "@/types/app-features";
 import { isCloud, isMultiOrg } from "@/services/env";

--- a/packages/front-end/components/MetricAnalysis/MetricAnalysisMoreMenu.tsx
+++ b/packages/front-end/components/MetricAnalysis/MetricAnalysisMoreMenu.tsx
@@ -1,5 +1,5 @@
 import { BsArrowRepeat } from "react-icons/bs";
-import { MetricAnalysisInterface } from "@back-end/types/metric-analysis";
+import { MetricAnalysisInterface } from "back-end/types/metric-analysis";
 import MoreMenu from "@/components/Dropdown/MoreMenu";
 import ViewAsyncQueriesButton from "@/components/Queries/ViewAsyncQueriesButton";
 

--- a/packages/front-end/components/MetricAnalysis/PopulationChooser.tsx
+++ b/packages/front-end/components/MetricAnalysis/PopulationChooser.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { FaQuestionCircle } from "react-icons/fa";
-import { MetricAnalysisPopulationType } from "@back-end/types/metric-analysis";
+import { MetricAnalysisPopulationType } from "back-end/types/metric-analysis";
 import SelectField from "@/components/Forms/SelectField";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import { useUser } from "@/services/UserContext";

--- a/packages/front-end/components/MetricExperiments/MetricExperiments.tsx
+++ b/packages/front-end/components/MetricExperiments/MetricExperiments.tsx
@@ -8,12 +8,12 @@ import {
   getMetricResultStatus,
   isFactMetric,
 } from "shared/experiments";
-import { StatsEngine } from "@back-end/types/stats";
+import { StatsEngine } from "back-end/types/stats";
 import {
   ExperimentWithSnapshot,
   SnapshotMetric,
-} from "@back-end/types/experiment-snapshot";
-import { ExperimentStatus } from "@back-end/types/experiment";
+} from "back-end/types/experiment-snapshot";
+import { ExperimentStatus } from "back-end/types/experiment";
 import useApi from "@/hooks/useApi";
 import ExperimentStatusIndicator from "@/components/Experiment/TabbedPage/ExperimentStatusIndicator";
 import ChangeColumn from "@/components/Experiment/ChangeColumn";

--- a/packages/front-end/components/Metrics/MetricForm/MetricPriorSettingsForm.tsx
+++ b/packages/front-end/components/Metrics/MetricForm/MetricPriorSettingsForm.tsx
@@ -1,5 +1,5 @@
-import { MetricPriorSettings } from "@back-end/types/fact-table";
-import { MetricDefaults } from "@back-end/types/organization";
+import { MetricPriorSettings } from "back-end/types/fact-table";
+import { MetricDefaults } from "back-end/types/organization";
 import { DEFAULT_PROPER_PRIOR_STDDEV } from "shared/constants";
 import { useState } from "react";
 import Toggle from "@/components/Forms/Toggle";

--- a/packages/front-end/components/Metrics/MetricTooltipBody.tsx
+++ b/packages/front-end/components/Metrics/MetricTooltipBody.tsx
@@ -6,7 +6,7 @@ import {
 } from "shared/experiments";
 import React from "react";
 import { DEFAULT_PROPER_PRIOR_STDDEV } from "shared/constants";
-import { StatsEngine } from "@back-end/types/stats";
+import { StatsEngine } from "back-end/types/stats";
 import {
   capitalizeFirstLetter,
   isNullUndefinedOrEmpty,

--- a/packages/front-end/components/PowerCalculation/PowerCalculationSettingsModal.tsx
+++ b/packages/front-end/components/PowerCalculation/PowerCalculationSettingsModal.tsx
@@ -8,8 +8,8 @@ import {
   isRatioMetric,
   quantileMetricType,
 } from "shared/experiments";
-import { OrganizationSettings } from "@back-end/types/organization";
-import { MetricPriorSettings } from "@back-end/types/fact-table";
+import { OrganizationSettings } from "back-end/types/organization";
+import { MetricPriorSettings } from "back-end/types/fact-table";
 import useOrgSettings from "@/hooks/useOrgSettings";
 import Modal from "@/components/Modal";
 import MultiSelectField from "@/components/Forms/MultiSelectField";

--- a/packages/front-end/components/PowerCalculation/types.ts
+++ b/packages/front-end/components/PowerCalculation/types.ts
@@ -1,5 +1,5 @@
-import { OrganizationSettings } from "@back-end/types/organization";
-import { MetricPriorSettings } from "@back-end/types/fact-table";
+import { OrganizationSettings } from "back-end/types/organization";
+import { MetricPriorSettings } from "back-end/types/fact-table";
 import { DEFAULT_PROPER_PRIOR_STDDEV } from "shared/constants";
 
 export interface MetricParamsBase {

--- a/packages/front-end/components/Report/ConfigureReport.tsx
+++ b/packages/front-end/components/Report/ConfigureReport.tsx
@@ -14,7 +14,7 @@ import {
 import { getValidDate } from "shared/dates";
 import { getScopedSettings } from "shared/settings";
 import { MetricInterface } from "back-end/types/metric";
-import { DifferenceType } from "@back-end/types/stats";
+import { DifferenceType } from "back-end/types/stats";
 import {
   getAllMetricIdsFromExperiment,
   getMetricSnapshotSettings,

--- a/packages/front-end/components/SavedGroups/LargeSavedGroupSupportWarning.tsx
+++ b/packages/front-end/components/SavedGroups/LargeSavedGroupSupportWarning.tsx
@@ -1,5 +1,5 @@
 import { getConnectionSDKCapabilities } from "shared/sdk-versioning";
-import { SDKConnectionInterface } from "@back-end/types/sdk-connection";
+import { SDKConnectionInterface } from "back-end/types/sdk-connection";
 import Link from "next/link";
 import React from "react";
 import { PiInfoFill } from "react-icons/pi";

--- a/packages/front-end/components/SchemaBrowser/DatasourceTableData.tsx
+++ b/packages/front-end/components/SchemaBrowser/DatasourceTableData.tsx
@@ -1,4 +1,4 @@
-import { InformationSchemaTablesInterface } from "@back-end/src/types/Integration";
+import { InformationSchemaTablesInterface } from "back-end/src/types/Integration";
 import React, { useEffect, useState } from "react";
 import { FaRedo, FaTable } from "react-icons/fa";
 import { useAuth } from "@/services/auth";

--- a/packages/front-end/components/SchemaBrowser/RetryInformationSchemaCard.tsx
+++ b/packages/front-end/components/SchemaBrowser/RetryInformationSchemaCard.tsx
@@ -1,4 +1,4 @@
-import { InformationSchemaInterface } from "@back-end/src/types/Integration";
+import { InformationSchemaInterface } from "back-end/src/types/Integration";
 import Tooltip from "@/components/Tooltip/Tooltip";
 
 export default function RetryInformationSchemaCard({

--- a/packages/front-end/components/SchemaBrowser/SchemaBrowser.tsx
+++ b/packages/front-end/components/SchemaBrowser/SchemaBrowser.tsx
@@ -1,5 +1,5 @@
-import { InformationSchemaInterface } from "@back-end/src/types/Integration";
-import { DataSourceInterfaceWithParams } from "@back-end/types/datasource";
+import { InformationSchemaInterface } from "back-end/src/types/Integration";
+import { DataSourceInterfaceWithParams } from "back-end/types/datasource";
 import React, { Fragment, useCallback, useEffect, useState } from "react";
 import Collapsible from "react-collapsible";
 import { FaAngleDown, FaAngleRight, FaTable } from "react-icons/fa";

--- a/packages/front-end/components/SchemaBrowser/SchemaBrowserWrapper.tsx
+++ b/packages/front-end/components/SchemaBrowser/SchemaBrowserWrapper.tsx
@@ -1,4 +1,4 @@
-import { InformationSchemaInterface } from "@back-end/src/types/Integration";
+import { InformationSchemaInterface } from "back-end/src/types/Integration";
 import { FaDatabase, FaRedo } from "react-icons/fa";
 import { useAuth } from "@/services/auth";
 import Tooltip from "@/components/Tooltip/Tooltip";

--- a/packages/front-end/components/Segments/FactSegmentForm.tsx
+++ b/packages/front-end/components/Segments/FactSegmentForm.tsx
@@ -1,6 +1,6 @@
 import { useForm } from "react-hook-form";
-import { DataSourceInterfaceWithParams } from "@back-end/types/datasource";
-import { SegmentInterface } from "@back-end/types/segment";
+import { DataSourceInterfaceWithParams } from "back-end/types/datasource";
+import { SegmentInterface } from "back-end/types/segment";
 import { GBArrowLeft } from "@/components/Icons";
 import Modal from "@/components/Modal";
 import Field from "@/components/Forms/Field";

--- a/packages/front-end/components/Settings/AutoMetricCard.tsx
+++ b/packages/front-end/components/Settings/AutoMetricCard.tsx
@@ -1,7 +1,7 @@
 import { ago } from "shared/dates";
 import { cloneDeep } from "lodash";
 import { useState } from "react";
-import { AutoMetricTrackedEvent } from "@back-end/src/types/Integration";
+import { AutoMetricTrackedEvent } from "back-end/src/types/Integration";
 import Tooltip from "@/components/Tooltip/Tooltip";
 import Toggle from "@/components/Forms/Toggle";
 import Button from "@/components/Button";

--- a/packages/front-end/components/Settings/BayesianPriorSettings.tsx
+++ b/packages/front-end/components/Settings/BayesianPriorSettings.tsx
@@ -1,6 +1,6 @@
 import { useFormContext } from "react-hook-form";
 import { DEFAULT_PROPER_PRIOR_STDDEV } from "shared/constants";
-import { MetricDefaults } from "@back-end/types/organization";
+import { MetricDefaults } from "back-end/types/organization";
 import { hasFileConfig } from "@/services/env";
 import Field from "@/components/Forms/Field";
 import Toggle from "@/components/Forms/Toggle";

--- a/packages/front-end/components/Settings/EditDataSource/DataSourceMetrics.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/DataSourceMetrics.tsx
@@ -1,4 +1,4 @@
-import { MetricInterface } from "@back-end/types/metric";
+import { MetricInterface } from "back-end/types/metric";
 import { useState } from "react";
 import { FaArchive, FaChevronRight, FaPlus, FaRegCopy } from "react-icons/fa";
 import Link from "next/link";

--- a/packages/front-end/components/Settings/NewDataSourceForm.tsx
+++ b/packages/front-end/components/Settings/NewDataSourceForm.tsx
@@ -10,7 +10,7 @@ import {
   DataSourceSettings,
 } from "back-end/types/datasource";
 import { useForm } from "react-hook-form";
-import { MetricType } from "@back-end/types/metric";
+import { MetricType } from "back-end/types/metric";
 import clsx from "clsx";
 import { isDemoDatasourceProject } from "shared/demo-datasource";
 import { useRouter } from "next/router";

--- a/packages/front-end/components/Settings/SharedConnectionSettings.tsx
+++ b/packages/front-end/components/Settings/SharedConnectionSettings.tsx
@@ -1,4 +1,4 @@
-import { DataSourceSettings } from "@back-end/types/datasource";
+import { DataSourceSettings } from "back-end/types/datasource";
 import { ChangeEventHandler } from "react";
 import Tooltip from "@/components/Tooltip/Tooltip";
 import Field from "@/components/Forms/Field";

--- a/packages/front-end/components/Settings/WebhooksModal.tsx
+++ b/packages/front-end/components/Settings/WebhooksModal.tsx
@@ -8,7 +8,7 @@ import {
   WebhookPayloadFormat,
 } from "back-end/types/webhook";
 import { FaExternalLinkAlt } from "react-icons/fa";
-import { SDKLanguage } from "@back-end/types/sdk-connection";
+import { SDKLanguage } from "back-end/types/sdk-connection";
 import { useAuth } from "@/services/auth";
 import track from "@/services/track";
 import { isCloud } from "@/services/env";

--- a/packages/front-end/components/Teams/Roles/RoleForm.tsx
+++ b/packages/front-end/components/Teams/Roles/RoleForm.tsx
@@ -5,7 +5,7 @@ import {
   RESERVED_ROLE_IDS,
 } from "shared/permissions";
 import { FormProvider, useForm } from "react-hook-form";
-import { Role } from "@back-end/types/organization";
+import { Role } from "back-end/types/organization";
 import router from "next/router";
 import { useState } from "react";
 import Field from "@/components/Forms/Field";

--- a/packages/front-end/hooks/useProjectOptions.ts
+++ b/packages/front-end/hooks/useProjectOptions.ts
@@ -1,4 +1,4 @@
-import { ProjectInterface } from "@back-end/types/project";
+import { ProjectInterface } from "back-end/types/project";
 import { useDefinitions } from "@/services/DefinitionsContext";
 
 // This hook returns list of projects user has permission for along with any projects already associated with a resource (e.g. metric.projects)

--- a/packages/front-end/hooks/useSchemaFormOptions.ts
+++ b/packages/front-end/hooks/useSchemaFormOptions.ts
@@ -2,8 +2,8 @@ import { useState } from "react";
 import {
   InformationSchemaInterface,
   InformationSchemaTablesInterface,
-} from "@back-end/src/types/Integration";
-import { DataSourceInterfaceWithParams } from "@back-end/types/datasource";
+} from "back-end/src/types/Integration";
+import { DataSourceInterfaceWithParams } from "back-end/types/datasource";
 import { GroupedValue, SingleValue } from "@/components/Forms/SelectField";
 import useApi from "./useApi";
 

--- a/packages/front-end/pages/experiments/index.tsx
+++ b/packages/front-end/pages/experiments/index.tsx
@@ -7,7 +7,7 @@ import { BsFlag } from "react-icons/bs";
 import clsx from "clsx";
 import { PiShuffle } from "react-icons/pi";
 import { getAllMetricIdsFromExperiment } from "shared/experiments";
-import { ExperimentInterfaceStringDates } from "@back-end/types/experiment";
+import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
 import useOrgSettings from "@/hooks/useOrgSettings";
 import LoadingOverlay from "@/components/LoadingOverlay";
 import { phaseSummary } from "@/services/utils";

--- a/packages/front-end/pages/getstarted/experiment-guide.tsx
+++ b/packages/front-end/pages/getstarted/experiment-guide.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { getDemoDatasourceProjectIdForOrganization } from "shared/demo-datasource";
 import clsx from "clsx";
 import { useRouter } from "next/router";
-import { GeneratedHypothesisInterface } from "@back-end/types/generated-hypothesis";
+import { GeneratedHypothesisInterface } from "back-end/types/generated-hypothesis";
 import DocumentationSidebar from "@/components/GetStarted/DocumentationSidebar";
 import UpgradeModal from "@/components/Settings/UpgradeModal";
 import useSDKConnections from "@/hooks/useSDKConnections";

--- a/packages/front-end/pages/sdks/SdkWebhooks.tsx
+++ b/packages/front-end/pages/sdks/SdkWebhooks.tsx
@@ -7,7 +7,7 @@ import {
   FaPaperPlane,
 } from "react-icons/fa";
 import { ago } from "shared/dates";
-import { SDKConnectionInterface } from "@back-end/types/sdk-connection";
+import { SDKConnectionInterface } from "back-end/types/sdk-connection";
 import useApi from "@/hooks/useApi";
 import EditSDKWebhooksModal, {
   CreateSDKWebhookModal,

--- a/packages/front-end/pages/sdks/index.tsx
+++ b/packages/front-end/pages/sdks/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { ApiKeyInterface } from "back-end/types/apikey";
-import { WebhookInterface } from "@back-end/types/webhook";
+import { WebhookInterface } from "back-end/types/webhook";
 import SDKConnectionsList from "@/components/Features/SDKConnections/SDKConnectionsList";
 import SDKEndpoints, {
   getPublishableKeys,

--- a/packages/front-end/pages/settings/index.tsx
+++ b/packages/front-end/pages/settings/index.tsx
@@ -10,7 +10,7 @@ import {
   DEFAULT_STATS_ENGINE,
   DEFAULT_TEST_QUERY_DAYS,
 } from "shared/constants";
-import { OrganizationSettings } from "@back-end/types/organization";
+import { OrganizationSettings } from "back-end/types/organization";
 import Link from "next/link";
 import { useAuth } from "@/services/auth";
 import { hasFileConfig, isCloud } from "@/services/env";

--- a/packages/front-end/pages/settings/role/[rid].tsx
+++ b/packages/front-end/pages/settings/role/[rid].tsx
@@ -1,6 +1,6 @@
 import { FC } from "react";
 import router from "next/router";
-import { Role } from "@back-end/types/organization";
+import { Role } from "back-end/types/organization";
 import RoleForm from "@/components/Teams/Roles/RoleForm";
 import RoleFormWrapper from "@/components/Teams/Roles/RoleFormWrapper";
 import { useUser } from "@/services/UserContext";

--- a/packages/front-end/pages/settings/role/duplicate/[rid].tsx
+++ b/packages/front-end/pages/settings/role/duplicate/[rid].tsx
@@ -1,6 +1,6 @@
 import { FC } from "react";
 import router from "next/router";
-import { Role } from "@back-end/types/organization";
+import { Role } from "back-end/types/organization";
 import RoleForm from "@/components/Teams/Roles/RoleForm";
 import RoleFormWrapper from "@/components/Teams/Roles/RoleFormWrapper";
 import { useUser } from "@/services/UserContext";

--- a/packages/front-end/services/track.ts
+++ b/packages/front-end/services/track.ts
@@ -10,12 +10,12 @@ Track anonymous usage statistics
 
 import { jitsuClient, JitsuClient } from "@jitsu/sdk-js";
 import md5 from "md5";
-import { StatsEngine } from "@back-end/types/stats";
+import { StatsEngine } from "back-end/types/stats";
 import {
   ExperimentSnapshotAnalysis,
   ExperimentSnapshotInterface,
-} from "@back-end/types/experiment-snapshot";
-import { ExperimentReportInterface } from "@back-end/types/report";
+} from "back-end/types/experiment-snapshot";
+import { ExperimentReportInterface } from "back-end/types/report";
 import { DEFAULT_STATS_ENGINE } from "shared/constants";
 import { getCurrentUser } from "./UserContext";
 import {

--- a/packages/front-end/tsconfig.json
+++ b/packages/front-end/tsconfig.json
@@ -16,8 +16,7 @@
     "jsx": "preserve",
     "baseUrl": "./",
     "paths": {
-      "@/*": ["./*"],
-      "@back-end/*": ["../back-end/*"]
+      "@/*": ["./*"]
     },
     "incremental": true
   },

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -13,9 +13,6 @@
     "strictBindCallApply": true,
     "strictPropertyInitialization": true,
     "rootDir": "src",
-    "paths": {
-      "@back-end/*": ["../back-end/*"]
-    },
     "resolveJsonModule": true
   },
   "include": ["src/**/*", "typings.d.ts"]


### PR DESCRIPTION
### Features and Changes

Using `@back-end` within shared package causes both swc and tsc to barf with misleading error messages.  swc creates extra .js and .js.map files within the /back-end/src dir which then cause files in the dist dir to be mangled.  tsc complains about `'rootDir' is expected to contain all source files`.

With the `@back-end` alias there VS-code will suggest that missing imports get added from there which can then waste a lot of developers time.

There is no need for the `@back-end` alias at all though since it is a package name, and pack-names work as is. 

### Testing

`yarn dev`.  Poke around the app
`yarn build`.  See it complete with no errors.
`yarn test`. 
`git grep "@back-end"` and see no results.
Click around the preview app and see no errors.

