### PR TITLE
Report minor fixes

### DIFF
--- a/packages/front-end/pages/report/[rid].tsx
+++ b/packages/front-end/pages/report/[rid].tsx
@@ -416,6 +416,7 @@ export default function ReportPage() {
                     variations={variations}
                     metrics={getAllMetricIdsFromExperiment(report.args, false)}
                     trackingKey={report.title}
+                    dimension={report.args.dimension ?? undefined}
                     project={experimentData?.experiment.project || ""}
                   />
                 </div>
@@ -478,6 +479,7 @@ export default function ReportPage() {
                   metricOverrides={report.args.metricOverrides || []}
                   reportDate={report.dateCreated}
                   results={report.results?.dimensions || []}
+                  queryStatusData={queryStatusData}
                   status={"stopped"}
                   startDate={getValidDate(report.args.startDate).toISOString()}
                   dimensionId={report.args.dimension}


### PR DESCRIPTION
Fixes #2975 and #2954 .

Both one line changes where more data needed to be added to a prop used by Reports.

## Testing

Dimension Report CSV now has dimension column.

Query errors now render in dimension reports for partially-succeeded runs.

<img width="1027" alt="Screenshot 2024-09-13 at 11 22 56 AM" src="https://github.com/user-attachments/assets/26b2bd70-a645-44d7-ba3f-0ec46804d26f">
