### PR TITLE
Updated the skipPartialData default value

### DIFF
--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -535,7 +535,7 @@ export async function postExperiments(
     activationMetric: data.activationMetric || "",
     segment: data.segment || "",
     queryFilter: data.queryFilter || "",
-    skipPartialData: !!data.skipPartialData,
+    skipPartialData: data.skipPartialData || true,
     attributionModel: data.attributionModel || "firstExposure",
     variations: data.variations || [],
     implementation: data.implementation || "code",

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -2005,7 +2005,7 @@ export function postExperimentApiPayloadToInterface(
     activationMetric: "",
     segment: "",
     queryFilter: "",
-    skipPartialData: payload.inProgressConversions === "strict",
+    skipPartialData: payload.inProgressConversions === "loose",
     attributionModel: payload.attributionModel || "firstExposure",
     ...(payload.statsEngine ? { statsEngine: payload.statsEngine } : {}),
     variations:
@@ -2088,7 +2088,7 @@ export function updateExperimentApiPayloadToInterface(
     ...(releasedVariationId !== undefined ? { releasedVariationId } : {}),
     ...(excludeFromPayload !== undefined ? { excludeFromPayload } : {}),
     ...(inProgressConversions !== undefined
-      ? { skipPartialData: inProgressConversions === "strict" }
+      ? { skipPartialData: inProgressConversions === "loose" }
       : {}),
     ...(attributionModel !== undefined ? { attributionModel } : {}),
     ...(statsEngine !== undefined ? { statsEngine } : {}),


### PR DESCRIPTION
### Features and Changes

<!--
  Include a description of your changes.
  If there are any new tools, API's, etc. that devs can leverage, it may be helpful to include usage info.
-->
Updated the default value of skipPartialData from false to true. This variable is later used to set the value of **Metric Conversion Windows**. Hence the default value of **Metric Conversion Windows** is updated to **Exclude in Progress Conversions**

<!--
  Indicate which issue this will close, if applicable
  For multiple issues, add a new `- Closes` or `- Fixes` line
-->

- Closes #2962 

