### PR TITLE
Show ISO country codes in selection dropdown

### DIFF
--- a/packages/front-end/components/Forms/CountrySelector.tsx
+++ b/packages/front-end/components/Forms/CountrySelector.tsx
@@ -27,7 +27,7 @@ export default function CountrySelector(props: CountrySelectorProps) {
   }));
 
   const formatOptionLabel = ({ label, value }, { context }) => {
-    const text = context === "menu" ? label : value;
+    const text = context === "menu" ? label + ` (${value})` : value;
     const flag = getCountryFlagEmojiFromCountryCode(value);
     return `${props.displayFlags && flag ? flag + " " : ""}${text}`;
   };

--- a/packages/front-end/components/Forms/CountrySelector.tsx
+++ b/packages/front-end/components/Forms/CountrySelector.tsx
@@ -27,7 +27,7 @@ export default function CountrySelector(props: CountrySelectorProps) {
   }));
 
   const formatOptionLabel = ({ label, value }, { context }) => {
-    const text = context === "menu" ? label + ` (${value})` : value;
+    const text = context === "menu" ? `${label} (${value})` : value;
     const flag = getCountryFlagEmojiFromCountryCode(value);
     return `${props.displayFlags && flag ? flag + " " : ""}${text}`;
   };


### PR DESCRIPTION
### Features and Changes

One-liner to add the 2-digit country code to the dropdown so people can more easily see what value the country's name will correspond to. Especially helpful with odd cases like Algeria becoming DZ

### Testing

Played with the selector modal. Typeahead still works effectively & the value being selected is still just the 2-digit code

### Screenshots
![image](https://github.com/user-attachments/assets/f137a9b7-e47b-4047-874a-b311d98f623f)


![image](https://github.com/user-attachments/assets/ce2d9b1e-6574-4912-8d95-066ef158a190)


![image](https://github.com/user-attachments/assets/5927a625-0828-451a-8776-637134755223)


![image](https://github.com/user-attachments/assets/05103dc8-25f6-4a44-bc31-3f820e9f5892)

