### PR TITLE
Take beta label off of fact tables

### DIFF
--- a/packages/front-end/components/Layout/Layout.tsx
+++ b/packages/front-end/components/Layout/Layout.tsx
@@ -63,7 +63,6 @@ const navlinks: SidebarLinkProps[] = [
         name: "Fact Tables",
         href: "/fact-tables",
         path: /^fact-tables/,
-        beta: true,
       },
       {
         name: "Segments",

--- a/packages/front-end/pages/fact-tables/index.tsx
+++ b/packages/front-end/pages/fact-tables/index.tsx
@@ -125,12 +125,7 @@ export default function FactTablesPage() {
         />
       )}
       <PageHead breadcrumb={[{ display: "Fact Tables" }]} />
-      <h1>
-        Fact Tables
-        <Tooltip body="This initial release of Fact Tables is an early preview of what's to come. Expect some rough edges and bugs.">
-          <span className="badge badge-purple border ml-2">beta</span>
-        </Tooltip>
-      </h1>
+      <h1>Fact Tables</h1>
       <div className="mb-3">
         <a
           className="font-weight-bold"


### PR DESCRIPTION
### Features and Changes

Remove beta label from Fact Tables in the side bar; removes language about it in beta from Fact Tables page.
