### PR TITLE
Scaled Impact for Bandits

### DIFF
--- a/packages/back-end/src/models/ExperimentModel.ts
+++ b/packages/back-end/src/models/ExperimentModel.ts
@@ -43,7 +43,6 @@ import {
   VisualChangesetModel,
 } from "./VisualChangesetModel";
 import { getFeaturesByIds } from "./FeatureModel";
-import { number } from "zod";
 
 const COLLECTION = "experiments";
 
@@ -69,7 +68,7 @@ const banditResultObject = {
     },
   ],
   weights: [Number],
-  srm: Number, 
+  srm: Number,
   bestArmProbabilities: [Number],
   additionalReward: Number,
   seed: Number,

--- a/packages/back-end/src/models/ExperimentSnapshotModel.ts
+++ b/packages/back-end/src/models/ExperimentSnapshotModel.ts
@@ -29,6 +29,7 @@ const banditResultObject = {
     },
   ],
   weights: [Number],
+  srm: Number,
   bestArmProbabilities: [Number],
   additionalReward: Number,
   seed: Number,

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -575,40 +575,47 @@ export function determineNextBanditSchedule(
 ): Date | undefined {
   const start = exp?.banditPhaseDateStarted?.getTime() ?? Date.now();
 
-  if (exp.banditPhase === "explore") {
-    if (exp.banditBurnInValue === undefined) {
-      throw new Error(
-        "Cannot schedule next experiment update. banditBurnInValue is unset."
-      );
-    }
-    if (exp.banditBurnInUnit === undefined) {
-      throw new Error(
-        "Cannot schedule next experiment update. banditBurnInUnit is unset."
-      );
-    }
-
-    const hoursMultiple = exp.banditBurnInUnit === "days" ? 24 : 1;
-    return new Date(
-      start + exp.banditBurnInValue * hoursMultiple * 60 * 60 * 1000
+  if (exp.banditBurnInValue === undefined) {
+    throw new Error(
+      "Cannot schedule next experiment update. banditBurnInValue is unset."
     );
-  } else if (exp.banditPhase === "exploit") {
-    if (exp.banditScheduleValue === undefined) {
-      throw new Error(
-        "Cannot schedule next experiment update. banditScheduleValue is unset."
-      );
-    }
-    if (exp.banditScheduleUnit === undefined) {
-      throw new Error(
-        "Cannot schedule next experiment update. banditScheduleUnit is unset."
-      );
-    }
-
-    const hoursMultiple = exp.banditScheduleUnit === "days" ? 24 : 1;
-    const interval = exp.banditScheduleValue * hoursMultiple * 60 * 60 * 1000;
-    const elapsedTime = Date.now() - start;
-    const intervalsPassed = Math.floor(elapsedTime / interval);
-    return new Date(start + (intervalsPassed + 1) * interval);
   }
+  if (exp.banditBurnInUnit === undefined) {
+    throw new Error(
+      "Cannot schedule next experiment update. banditBurnInUnit is unset."
+    );
+  }
+  if (exp.banditScheduleValue === undefined) {
+    throw new Error(
+      "Cannot schedule next experiment update. banditScheduleValue is unset."
+    );
+  }
+  if (exp.banditScheduleUnit === undefined) {
+    throw new Error(
+      "Cannot schedule next experiment update. banditScheduleUnit is unset."
+    );
+  }
+
+  const standardHoursMultiple = exp.banditScheduleUnit === "days" ? 24 : 1;
+  const standardInterval =
+    exp.banditScheduleValue * standardHoursMultiple * 60 * 60 * 1000;
+  const elapsedTime = Date.now() - start;
+  const intervalsPassed = Math.floor(elapsedTime / standardInterval);
+  const nextStandardRunDate = new Date(
+    start + (intervalsPassed + 1) * standardInterval
+  );
+
+  if (exp.banditPhase === "explore") {
+    const burnInHoursMultiple = exp.banditBurnInUnit === "days" ? 24 : 1;
+    const burnInRunDate = new Date(
+      start + exp.banditBurnInValue * burnInHoursMultiple * 60 * 60 * 1000
+    );
+    if (burnInRunDate < nextStandardRunDate) {
+      return burnInRunDate;
+    }
+  }
+
+  return nextStandardRunDate;
 }
 
 export function resetExperimentBanditSettings({
@@ -660,30 +667,62 @@ export function updateExperimentBanditSettings({
   changes,
   snapshot,
   reweight = false,
-  scheduleNextUpdate = false,
+  isScheduled = false,
 }: {
   experiment: ExperimentInterface;
   changes?: Changeset;
   snapshot?: ExperimentSnapshotInterface;
   reweight?: boolean;
-  scheduleNextUpdate?: boolean;
+  isScheduled?: boolean;
 }): Changeset {
-  if (!changes) {
-    changes = {};
-  }
+  if (!changes) changes = {};
   if (!changes.phases) {
     changes.phases = [...experiment.phases];
   }
   const phase = changes.phases.length - 1;
 
   const banditResult: BanditResult | undefined = snapshot?.banditResult;
-  const dateCreated = snapshot?.analyses?.[0]?.dateCreated ?? new Date();
+  const snapshotDateCreated =
+    snapshot?.analyses?.[0]?.dateCreated ?? new Date();
 
+  // Check if we need to move from explore to exploit phase:
+  let startNextBanditPhase = false;
+  if (experiment.banditPhase === "explore") {
+    if (!isScheduled && reweight) {
+      // manual reweights during explore immediately start the exploit phase
+      startNextBanditPhase = true;
+    } else {
+      // if we are past the burn-in period, start the exploit phase
+      const banditPhaseStartDate =
+        experiment?.banditPhaseDateStarted ??
+        experiment.phases[phase]?.dateStarted ??
+        new Date();
+      const hoursMultiple = experiment.banditBurnInUnit === "days" ? 24 : 1;
+      const interval =
+        (experiment.banditBurnInValue ?? 0) * hoursMultiple * 60 * 60 * 1000;
+
+      if (
+        snapshotDateCreated.getTime() >
+        banditPhaseStartDate.getTime() + interval
+      ) {
+        if (isScheduled) reweight = true;
+        startNextBanditPhase = true;
+      }
+    }
+  }
+
+  if (startNextBanditPhase) {
+    changes.banditPhase = "exploit";
+    changes.banditPhaseDateStarted = new Date();
+  }
+
+  // Apply the bandit results:
   if (banditResult) {
     if (reweight) {
       // apply the latest weights (SDK level)
       changes.phases[phase].variationWeights = banditResult.weights;
     } else {
+      // todo: remove this case?
       // ignore (revert) the weight changes (for graphing)
       banditResult.weights = changes.phases[phase].variationWeights;
     }
@@ -693,7 +732,7 @@ export function updateExperimentBanditSettings({
       changes.phases[phase].banditEvents = [];
     }
     changes.phases[phase].banditEvents?.push({
-      date: dateCreated,
+      date: snapshotDateCreated,
       banditResult: { ...banditResult, reweight },
       snapshotId: snapshot?.id,
     });
@@ -705,16 +744,14 @@ export function updateExperimentBanditSettings({
   }
 
   // scheduling
-  if (scheduleNextUpdate) {
-    if (
-      changes.banditPhase === "exploit" ||
-      experiment.banditPhase === "exploit"
-    ) {
-      changes.nextSnapshotAttempt = determineNextBanditSchedule({
-        ...experiment,
-        ...changes,
-      } as ExperimentInterface);
-    }
+  if (
+    changes.banditPhase === "exploit" ||
+    experiment.banditPhase === "exploit"
+  ) {
+    changes.nextSnapshotAttempt = determineNextBanditSchedule({
+      ...experiment,
+      ...changes,
+    } as ExperimentInterface);
   }
 
   return changes;
@@ -796,13 +833,15 @@ export async function createSnapshot({
 
   let scheduleNextSnapshot = true;
   if (experiment.type === "multi-armed-bandit" && type !== "standard") {
+    // explore tab actions should never trigger the next schedule for bandits
     scheduleNextSnapshot = false;
   }
 
   if (scheduleNextSnapshot) {
     const nextUpdate =
-      determineNextDate(organization.settings?.updateSchedule || null) ||
-      undefined;
+      (experiment.type !== "multi-armed-bandit"
+        ? determineNextDate(organization.settings?.updateSchedule || null)
+        : determineNextBanditSchedule(experiment)) || undefined;
 
     await updateExperiment({
       context,

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -573,7 +573,11 @@ export function determineNextDate(schedule: ExperimentUpdateSchedule | null) {
 export function determineNextBanditSchedule(
   exp: ExperimentInterface
 ): Date | undefined {
-  const start = exp?.banditPhaseDateStarted?.getTime() ?? Date.now();
+  const start = (
+    exp?.banditPhaseDateStarted ??
+    exp.phases?.[exp.phases.length]?.dateStarted ??
+    new Date()
+  ).getTime();
 
   if (exp.banditBurnInValue === undefined) {
     throw new Error(

--- a/packages/front-end/components/Experiment/BanditDateGraph.tsx
+++ b/packages/front-end/components/Experiment/BanditDateGraph.tsx
@@ -548,7 +548,7 @@ const BanditDateGraph: FC<BanditDateGraphProps> = ({
               stroke="#66a9"
             />
             <text
-              x={xScale(exploitDate) - 5}
+              x={xScale(exploitDate) - 10}
               y={yMax + 36}
               fill="#66a"
               textAnchor="middle"

--- a/packages/front-end/components/Experiment/RefreshBanditButton.tsx
+++ b/packages/front-end/components/Experiment/RefreshBanditButton.tsx
@@ -51,7 +51,7 @@ const RefreshBanditButton: FC<{
           style={{ width: 150 }}
           errorClassName="position-absolute small text-danger"
           errorStyle={{
-            top: 40,
+            top: 36,
             left: 0,
             width: 200,
             whiteSpace: "normal",


### PR DESCRIPTION
### Features and Changes

Updating science code to permit scaled impact for Bandits.  The updated code will apply to both bandits and A/B tests.  For A/B tests, the updated code will have slightly less variability than current prod code. 


### Dependencies

None

### Testing
compared results to `main` for freq and Bayesian, and they are appropriately similar (pls see screenshots)
<img width="1728" alt="scaled_impact_smith_freq" src="https://github.com/user-attachments/assets/52217673-c7f6-4760-b188-c777e02205d4">



### Screenshots
<img width="1728" alt="scaled_impact_main_bayes" src="https://github.com/user-attachments/assets/e8efc106-ecd7-47ac-9c18-7062387ac003">
<img width="1728" alt="scaled_impact_main_freq" src="https://github.com/user-attachments/assets/eda06791-2ae8-4281-92da-fce9dd7a200e">
<img width="1728" alt="scaled_impact_smith_bayes" src="https://github.com/user-attachments/assets/34cfba04-82b9-4bcc-a2c9-497f0fecedc8">

