### PR TITLE
Add names for modal tracking events

### DIFF
--- a/packages/front-end/components/Admin/CreateOrganization.tsx
+++ b/packages/front-end/components/Admin/CreateOrganization.tsx
@@ -30,6 +30,7 @@ const CreateOrganization: FC<{
   return (
     <Modal
       trackingEventModalType="create-organization"
+      trackingEventModalSource="admin"
       submit={handleSubmit}
       open={true}
       header={"Create New Organization"}

--- a/packages/front-end/components/Admin/CreateOrganization.tsx
+++ b/packages/front-end/components/Admin/CreateOrganization.tsx
@@ -29,7 +29,7 @@ const CreateOrganization: FC<{
 
   return (
     <Modal
-      trackingEventModalType=""
+      trackingEventModalType="create-organization"
       submit={handleSubmit}
       open={true}
       header={"Create New Organization"}

--- a/packages/front-end/components/Admin/EditOrganization.tsx
+++ b/packages/front-end/components/Admin/EditOrganization.tsx
@@ -52,7 +52,7 @@ const EditOrganization: FC<{
 
   return (
     <Modal
-      trackingEventModalType=""
+      trackingEventModalType="edit-organization"
       submit={handleSubmit}
       open={true}
       header={"Edit Organization"}

--- a/packages/front-end/components/Admin/EditOrganization.tsx
+++ b/packages/front-end/components/Admin/EditOrganization.tsx
@@ -53,6 +53,7 @@ const EditOrganization: FC<{
   return (
     <Modal
       trackingEventModalType="edit-organization"
+      trackingEventModalSource="admin"
       submit={handleSubmit}
       open={true}
       header={"Edit Organization"}

--- a/packages/front-end/components/Archetype/ArchetypeAttributesModal.tsx
+++ b/packages/front-end/components/Archetype/ArchetypeAttributesModal.tsx
@@ -35,7 +35,7 @@ const ArchetypeAttributesModal: FC<{
 
   return (
     <Modal
-      trackingEventModalType=""
+      trackingEventModalType="archetype-attributes"
       open={true}
       autoCloseOnSubmit={false}
       close={close}

--- a/packages/front-end/components/Archetype/AssignmentTester.tsx
+++ b/packages/front-end/components/Archetype/AssignmentTester.tsx
@@ -382,7 +382,7 @@ export default function AssignmentTester({ feature, version }: Props) {
             />
           ) : (
             <Modal
-              trackingEventModalType=""
+              trackingEventModalType="assignment-tester-archetype-paywall"
               open={true}
               close={() => setOpenArchetypeModal(null)}
             >

--- a/packages/front-end/components/Auth/ChangePasswordModal.tsx
+++ b/packages/front-end/components/Auth/ChangePasswordModal.tsx
@@ -17,7 +17,7 @@ const ChangePasswordModal: FC<{
 
   return (
     <Modal
-      trackingEventModalType=""
+      trackingEventModalType="change-password"
       header="Change Password"
       open={true}
       autoCloseOnSubmit={false}

--- a/packages/front-end/components/AutoGenerateFactTablesModal.tsx
+++ b/packages/front-end/components/AutoGenerateFactTablesModal.tsx
@@ -272,7 +272,7 @@ export default function AutoGenerateFactTableModal({
 
   return (
     <Modal
-      trackingEventModalType=""
+      trackingEventModalType="auto-generate-fact-tables"
       size="lg"
       open={true}
       header="Discover Fact Tables"

--- a/packages/front-end/components/AutoGenerateMetricsModal.tsx
+++ b/packages/front-end/components/AutoGenerateMetricsModal.tsx
@@ -275,7 +275,7 @@ export default function AutoGenerateMetricsModal({
 
   return (
     <Modal
-      trackingEventModalType=""
+      trackingEventModalType="auto-generate-metrics"
       size="lg"
       open={true}
       header="Discover Metrics"

--- a/packages/front-end/components/AutoGenerateMetricsModal.tsx
+++ b/packages/front-end/components/AutoGenerateMetricsModal.tsx
@@ -276,6 +276,12 @@ export default function AutoGenerateMetricsModal({
   return (
     <Modal
       trackingEventModalType="auto-generate-metrics"
+      trackingEventModalSource={source}
+      allowlistedTrackingEventProps={{
+        type: selectedDatasource?.type,
+        dataSourceId: selectedDatasource?.id,
+        schema: selectedDatasource?.settings?.schemaFormat,
+      }}
       size="lg"
       open={true}
       header="Discover Metrics"

--- a/packages/front-end/components/Carousel.tsx
+++ b/packages/front-end/components/Carousel.tsx
@@ -15,7 +15,8 @@ const Carousel: FC<{
   deleteImage?: (i: number) => Promise<void>;
   children: ReactNode;
   maxChildHeight?: number;
-}> = ({ children, deleteImage, maxChildHeight }) => {
+  trackingEventModalType: string;
+}> = ({ children, deleteImage, maxChildHeight, trackingEventModalType }) => {
   const [active, setActive] = useState(0);
   const [modalOpen, setModalOpen] = useState(false);
 
@@ -47,7 +48,7 @@ const Carousel: FC<{
     <div className="carousel slide my-2">
       {modalOpen && currentChild && (
         <Modal
-          trackingEventModalType=""
+          trackingEventModalType={trackingEventModalType}
           open={true}
           header={"Screenshot"}
           close={() => setModalOpen(false)}

--- a/packages/front-end/components/DeleteButton/DeleteButton.tsx
+++ b/packages/front-end/components/DeleteButton/DeleteButton.tsx
@@ -59,7 +59,7 @@ const DeleteButton: FC<{
     <>
       {confirming ? (
         <Modal
-          trackingEventModalType=""
+          trackingEventModalType="delete-button-confirmation"
           header={`Delete ${displayName}`}
           close={() => setConfirming(false)}
           open={true}

--- a/packages/front-end/components/DeleteButton/DeleteButton.tsx
+++ b/packages/front-end/components/DeleteButton/DeleteButton.tsx
@@ -60,6 +60,7 @@ const DeleteButton: FC<{
       {confirming ? (
         <Modal
           trackingEventModalType="delete-button-confirmation"
+          allowlistedTrackingEventProps={{ type: displayName }}
           header={`Delete ${displayName}`}
           close={() => setConfirming(false)}
           open={true}

--- a/packages/front-end/components/Dimensions/DimensionForm.tsx
+++ b/packages/front-end/components/Dimensions/DimensionForm.tsx
@@ -72,7 +72,7 @@ const DimensionForm: FC<{
         />
       )}
       <Modal
-        trackingEventModalType="dimension-form"
+        trackingEventModalType={`${current.id ? "create" : "edit"}-dimension`}
         close={close}
         open={true}
         size="md"

--- a/packages/front-end/components/Dimensions/DimensionForm.tsx
+++ b/packages/front-end/components/Dimensions/DimensionForm.tsx
@@ -72,7 +72,7 @@ const DimensionForm: FC<{
         />
       )}
       <Modal
-        trackingEventModalType=""
+        trackingEventModalType="dimension-form"
         close={close}
         open={true}
         size="md"

--- a/packages/front-end/components/EventWebHooks/EventWebHookAddEditModal/EventWebHookAddEditModal.tsx
+++ b/packages/front-end/components/EventWebHooks/EventWebHookAddEditModal/EventWebHookAddEditModal.tsx
@@ -548,7 +548,7 @@ export const EventWebHookAddEditModal: FC<EventWebHookAddEditModalProps> = ({
 
   return (
     <Modal
-      trackingEventModalType=""
+      trackingEventModalType="event-webhook-add-edit"
       header={modalTitle}
       cta={buttonText({ step, payloadType: form.watch("payloadType") })}
       includeCloseCta={false}

--- a/packages/front-end/components/Experiment/AddExperimentModal.tsx
+++ b/packages/front-end/components/Experiment/AddExperimentModal.tsx
@@ -103,7 +103,7 @@ const AddExperimentModal: FC<{
     default:
       return (
         <Modal
-          trackingEventModalType=""
+          trackingEventModalType="add-experiment-deprecated-flow"
           open
           close={() => onClose()}
           size="lg"

--- a/packages/front-end/components/Experiment/AnalysisForm.tsx
+++ b/packages/front-end/components/Experiment/AnalysisForm.tsx
@@ -208,7 +208,7 @@ const AnalysisForm: FC<{
 
   return (
     <Modal
-      trackingEventModalType=""
+      trackingEventModalType="experiment-analysis-settings"
       header={"Experiment Settings"}
       open={true}
       close={cancel}

--- a/packages/front-end/components/Experiment/EditDOMMutationsModal.tsx
+++ b/packages/front-end/components/Experiment/EditDOMMutationsModal.tsx
@@ -161,7 +161,7 @@ const EditDOMMutatonsModal: FC<{
 
   return (
     <Modal
-      trackingEventModalType=""
+      trackingEventModalType="visual-editor-edit-dom-mutations"
       open
       close={close}
       size="lg"

--- a/packages/front-end/components/Experiment/EditDataSourceForm.tsx
+++ b/packages/front-end/components/Experiment/EditDataSourceForm.tsx
@@ -35,7 +35,7 @@ const EditDataSourceForm: FC<{
 
   return (
     <Modal
-      trackingEventModalType=""
+      trackingEventModalType="datasource-settings"
       header={"Edit Data Source Settings"}
       open={true}
       close={cancel}

--- a/packages/front-end/components/Experiment/EditExperimentNameForm.tsx
+++ b/packages/front-end/components/Experiment/EditExperimentNameForm.tsx
@@ -19,7 +19,7 @@ const EditExperimentNameForm: FC<{
 
   return (
     <Modal
-      trackingEventModalType=""
+      trackingEventModalType="edit-experiment-name"
       header={"Edit Name"}
       open={true}
       close={cancel}

--- a/packages/front-end/components/Experiment/EditMetricsForm.tsx
+++ b/packages/front-end/components/Experiment/EditMetricsForm.tsx
@@ -169,7 +169,7 @@ const EditMetricsForm: FC<{
 
   return (
     <Modal
-      trackingEventModalType=""
+      trackingEventModalType="edit-metrics"
       autoFocusSelector=""
       header="Edit Metrics"
       size="lg"

--- a/packages/front-end/components/Experiment/EditPhaseModal.tsx
+++ b/packages/front-end/components/Experiment/EditPhaseModal.tsx
@@ -44,7 +44,7 @@ export default function EditPhaseModal({
 
   return (
     <Modal
-      trackingEventModalType=""
+      trackingEventModalType="edit-analysis-phase"
       open={true}
       close={close}
       header={`Edit Analysis Phase #${i + 1}`}

--- a/packages/front-end/components/Experiment/EditPhasesModal.tsx
+++ b/packages/front-end/components/Experiment/EditPhasesModal.tsx
@@ -73,7 +73,7 @@ export default function EditPhasesModal({
 
   return (
     <Modal
-      trackingEventModalType=""
+      trackingEventModalType="edit-experiment-phases"
       open={true}
       header="Edit Phases"
       close={close}

--- a/packages/front-end/components/Experiment/EditProjectForm.tsx
+++ b/packages/front-end/components/Experiment/EditProjectForm.tsx
@@ -39,7 +39,7 @@ const EditProjectForm: FC<{
 
   return (
     <Modal
-      trackingEventModalType=""
+      trackingEventModalType="edit-project"
       header={"Edit Project"}
       open={true}
       close={cancel}

--- a/packages/front-end/components/Experiment/EditStatusModal.tsx
+++ b/packages/front-end/components/Experiment/EditStatusModal.tsx
@@ -29,7 +29,7 @@ export default function EditStatusModal({ experiment, close, mutate }: Props) {
 
   return (
     <Modal
-      trackingEventModalType=""
+      trackingEventModalType="edit-experiment-status"
       header={"Change Experiment Status"}
       close={close}
       open={true}

--- a/packages/front-end/components/Experiment/EditTargetingModal.tsx
+++ b/packages/front-end/components/Experiment/EditTargetingModal.tsx
@@ -180,7 +180,7 @@ export default function EditTargetingModal({
   if (safeToEdit) {
     return (
       <Modal
-        trackingEventModalType=""
+        trackingEventModalType="edit-experiment-targeting"
         open={true}
         close={close}
         header={`Edit Targeting`}

--- a/packages/front-end/components/Experiment/EditVariationsForm.tsx
+++ b/packages/front-end/components/Experiment/EditVariationsForm.tsx
@@ -43,7 +43,7 @@ const EditVariationsForm: FC<{
 
   return (
     <Modal
-      trackingEventModalType=""
+      trackingEventModalType="edit-experiment-variations"
       header={"Edit Variations"}
       open={true}
       close={cancel}

--- a/packages/front-end/components/Experiment/FilterSummary.tsx
+++ b/packages/front-end/components/Experiment/FilterSummary.tsx
@@ -48,7 +48,7 @@ const FilterSummary: FC<{
         </a>
       </span>
       <Modal
-        trackingEventModalType=""
+        trackingEventModalType="experiment-filter-summary"
         header={"Experiment Details and Filters"}
         open={showExpandedFilter}
         closeCta="Close"

--- a/packages/front-end/components/Experiment/FixVariationIds.tsx
+++ b/packages/front-end/components/Experiment/FixVariationIds.tsx
@@ -26,7 +26,7 @@ export default function FixVariationIds({
 
   return (
     <Modal
-      trackingEventModalType=""
+      trackingEventModalType="fix-experiment-variation-ids"
       open={true}
       submit={form.handleSubmit(async (value) => {
         const ids = value.ids.map((id, i) => (id ? id : expected[i]));

--- a/packages/front-end/components/Experiment/ImportExperimentModal.tsx
+++ b/packages/front-end/components/Experiment/ImportExperimentModal.tsx
@@ -93,7 +93,7 @@ const ImportExperimentModal: FC<{
 
   return (
     <Modal
-      trackingEventModalType=""
+      trackingEventModalType="import-experiment"
       header="Add Experiment"
       open={true}
       size="max"

--- a/packages/front-end/components/Experiment/ManualSnapshotForm.tsx
+++ b/packages/front-end/components/Experiment/ManualSnapshotForm.tsx
@@ -163,7 +163,7 @@ const ManualSnapshotForm: FC<{
 
   return (
     <Modal
-      trackingEventModalType=""
+      trackingEventModalType="experiment-manual-snapshot"
       open={true}
       size="lg"
       close={close}

--- a/packages/front-end/components/Experiment/NamespaceModal.tsx
+++ b/packages/front-end/components/Experiment/NamespaceModal.tsx
@@ -28,7 +28,7 @@ export default function NamespaceModal({
 
   return (
     <Modal
-      trackingEventModalType=""
+      trackingEventModalType="namespace-form"
       open={true}
       close={close}
       cta={existing ? "Update" : "Create"}

--- a/packages/front-end/components/Experiment/NewPhaseForm.tsx
+++ b/packages/front-end/components/Experiment/NewPhaseForm.tsx
@@ -89,7 +89,7 @@ const NewPhaseForm: FC<{
 
   return (
     <Modal
-      trackingEventModalType=""
+      trackingEventModalType="experiment-new-phase"
       header={firstPhase ? "Start Experiment" : "New Experiment Phase"}
       close={close}
       open={true}

--- a/packages/front-end/components/Experiment/QueryModal.tsx
+++ b/packages/front-end/components/Experiment/QueryModal.tsx
@@ -10,7 +10,7 @@ const QueryModal: FC<{
 }> = ({ queries, language, close }) => {
   return (
     <Modal
-      trackingEventModalType=""
+      trackingEventModalType="view-query"
       close={close}
       header="View Query"
       open={true}

--- a/packages/front-end/components/Experiment/SRMWarning.tsx
+++ b/packages/front-end/components/Experiment/SRMWarning.tsx
@@ -91,7 +91,7 @@ const SRMWarning: FC<{
     <>
       {type === "with_modal" && (
         <Modal
-          trackingEventModalType=""
+          trackingEventModalType="srm-warning"
           close={() => setOpen(false)}
           open={open}
           header={

--- a/packages/front-end/components/Experiment/StopExperimentForm.tsx
+++ b/packages/front-end/components/Experiment/StopExperimentForm.tsx
@@ -85,7 +85,7 @@ const StopExperimentForm: FC<{
 
   return (
     <Modal
-      trackingEventModalType=""
+      trackingEventModalType="stop-experiment"
       header={isStopped ? "Edit Experiment Results" : "Stop Experiment"}
       close={close}
       open={true}

--- a/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
@@ -191,7 +191,7 @@ export default function ExperimentHeader({
         )}
         {showStartExperiment && experiment.status === "draft" && (
           <Modal
-            trackingEventModalType=""
+            trackingEventModalType="start-experiment"
             open={true}
             size="md"
             closeCta={

--- a/packages/front-end/components/Experiment/TabbedPage/HealthTabOnboardingModal.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/HealthTabOnboardingModal.tsx
@@ -164,7 +164,7 @@ export const HealthTabOnboardingModal: FC<HealthTabOnboardingModalProps> = ({
   if (step === -1) {
     return (
       <Modal
-        trackingEventModalType=""
+        trackingEventModalType="exit-health-tab-onboarding"
         open={open}
         submit={close}
         cta={"Confirm"}
@@ -340,7 +340,7 @@ export const HealthTabOnboardingModal: FC<HealthTabOnboardingModalProps> = ({
 
   return (
     <Modal
-      trackingEventModalType=""
+      trackingEventModalType="health-tab-onboarding"
       open={open}
       close={() => {
         setLastStep(step);

--- a/packages/front-end/components/Experiment/TabbedPage/index.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/index.tsx
@@ -202,7 +202,7 @@ export default function TabbedPage({
       )}
       {auditModal && (
         <Modal
-          trackingEventModalType=""
+          trackingEventModalType="experiment-audit-modal"
           open={true}
           header="Audit Log"
           close={() => setAuditModal(false)}
@@ -214,7 +214,7 @@ export default function TabbedPage({
       )}
       {watchersModal && (
         <Modal
-          trackingEventModalType=""
+          trackingEventModalType="experiment-users-watching"
           open={true}
           header="Experiment Watchers"
           close={() => setWatchersModal(false)}

--- a/packages/front-end/components/Experiment/UrlRedirectModal.tsx
+++ b/packages/front-end/components/Experiment/UrlRedirectModal.tsx
@@ -174,7 +174,7 @@ const UrlRedirectModal: FC<{
 
   return (
     <Modal
-      trackingEventModalType=""
+      trackingEventModalType="experiment-url-redirect"
       autoCloseOnSubmit={false}
       open
       disabledMessage={

--- a/packages/front-end/components/Experiment/VariationsTable.tsx
+++ b/packages/front-end/components/Experiment/VariationsTable.tsx
@@ -30,6 +30,7 @@ const ScreenshotCarousel: FC<{
 
   return (
     <Carousel
+      trackingEventModalType="variations-table-carousel"
       deleteImage={
         !canEditExperiment
           ? undefined

--- a/packages/front-end/components/Experiment/VisualChangesetModal.tsx
+++ b/packages/front-end/components/Experiment/VisualChangesetModal.tsx
@@ -101,7 +101,7 @@ const VisualChangesetModal: FC<{
 
   return (
     <Modal
-      trackingEventModalType=""
+      trackingEventModalType="visual-editor-url-targeting"
       open
       close={close}
       size="lg"

--- a/packages/front-end/components/FactTables/ColumnModal.tsx
+++ b/packages/front-end/components/FactTables/ColumnModal.tsx
@@ -42,7 +42,7 @@ export default function ColumnModal({ existing, factTable, close }: Props) {
 
   return (
     <Modal
-      trackingEventModalType=""
+      trackingEventModalType="fact-table-column-form"
       open={true}
       close={close}
       cta={"Save"}

--- a/packages/front-end/components/FactTables/FactFilterModal.tsx
+++ b/packages/front-end/components/FactTables/FactFilterModal.tsx
@@ -71,7 +71,7 @@ export default function FactFilterModal({ existing, factTable, close }: Props) {
 
   return (
     <Modal
-      trackingEventModalType=""
+      trackingEventModalType="fact-table-filter-form"
       open={true}
       close={close}
       cta={"Save"}

--- a/packages/front-end/components/FactTables/FactMetricModal.tsx
+++ b/packages/front-end/components/FactTables/FactMetricModal.tsx
@@ -482,7 +482,7 @@ export default function FactMetricModal({
 
   return (
     <Modal
-      trackingEventModalType=""
+      trackingEventModalType="fact-table-metric-form"
       open={true}
       header={existing ? "Edit Metric" : "Create Fact Table Metric"}
       close={close}

--- a/packages/front-end/components/FactTables/FactTableModal.tsx
+++ b/packages/front-end/components/FactTables/FactTableModal.tsx
@@ -110,7 +110,7 @@ export default function FactTableModal({ existing, close }: Props) {
         />
       )}
       <Modal
-        trackingEventModalType=""
+        trackingEventModalType="fact-table-form"
         open={true}
         close={close}
         cta={"Save"}

--- a/packages/front-end/components/Features/AttributeModal.tsx
+++ b/packages/front-end/components/Features/AttributeModal.tsx
@@ -71,7 +71,7 @@ export default function AttributeModal({ close, attribute }: Props) {
 
   return (
     <Modal
-      trackingEventModalType=""
+      trackingEventModalType="attribute-form"
       open={true}
       close={close}
       header={title}

--- a/packages/front-end/components/Features/CodeSnippetModal.tsx
+++ b/packages/front-end/components/Features/CodeSnippetModal.tsx
@@ -163,7 +163,7 @@ export default function CodeSnippetModal({
         />
       )}
       <Modal
-        trackingEventModalType=""
+        trackingEventModalType="starter-code-snippet"
         close={close}
         secondaryCTA={secondaryCTA}
         className="mb-4"

--- a/packages/front-end/components/Features/CopyRuleModal.tsx
+++ b/packages/front-end/components/Features/CopyRuleModal.tsx
@@ -82,7 +82,7 @@ export default function CopyRuleModal({
 
   return (
     <Modal
-      trackingEventModalType=""
+      trackingEventModalType="copy-feature-rule-to-environments"
       header={`Copy ${ruleTxt} to environment(s)`}
       open={true}
       close={cancel}

--- a/packages/front-end/components/Features/DraftModal.tsx
+++ b/packages/front-end/components/Features/DraftModal.tsx
@@ -142,7 +142,7 @@ export default function DraftModal({
 
   return (
     <Modal
-      trackingEventModalType=""
+      trackingEventModalType="review-feature-draft"
       open={true}
       header={"Review Draft Changes"}
       submit={

--- a/packages/front-end/components/Features/EditDefaultValueModal.tsx
+++ b/packages/front-end/components/Features/EditDefaultValueModal.tsx
@@ -30,7 +30,7 @@ export default function EditDefaultValueModal({
 
   return (
     <Modal
-      trackingEventModalType=""
+      trackingEventModalType="edit-feature-default-value"
       header="Edit Default Value"
       submit={form.handleSubmit(async (value) => {
         const newDefaultValue = validateFeatureValue(

--- a/packages/front-end/components/Features/EditRevisionCommentModal.tsx
+++ b/packages/front-end/components/Features/EditRevisionCommentModal.tsx
@@ -23,7 +23,7 @@ export default function EditRevisionCommentModal({
 
   return (
     <Modal
-      trackingEventModalType=""
+      trackingEventModalType="edit-feature-revision-comment"
       open={true}
       close={close}
       header="Edit Revision Comment"

--- a/packages/front-end/components/Features/EditSchemaModal.tsx
+++ b/packages/front-end/components/Features/EditSchemaModal.tsx
@@ -444,7 +444,7 @@ export default function EditSchemaModal({ feature, close, mutate }: Props) {
 
   return (
     <Modal
-      trackingEventModalType=""
+      trackingEventModalType="edit-feature-validation"
       header="Edit Feature Validation"
       cta="Save"
       size="lg"

--- a/packages/front-end/components/Features/EnvironmentToggle.tsx
+++ b/packages/front-end/components/Features/EnvironmentToggle.tsx
@@ -68,7 +68,7 @@ export default function EnvironmentToggle({
     <>
       {confirming ? (
         <Modal
-          trackingEventModalType=""
+          trackingEventModalType="toggle-feature-environment"
           header="Toggle environment"
           close={() => {
             setConfirming(false);

--- a/packages/front-end/components/Features/ExperimentSummary.tsx
+++ b/packages/front-end/components/Features/ExperimentSummary.tsx
@@ -58,7 +58,7 @@ export default function ExperimentSummary({
       )}
       {experimentInstructions && (
         <Modal
-          trackingEventModalType=""
+          trackingEventModalType="feature-experiment-instructions"
           header={"Experiments need to be set up first"}
           open={true}
           size="lg"

--- a/packages/front-end/components/Features/FeatureImplementationModal.tsx
+++ b/packages/front-end/components/Features/FeatureImplementationModal.tsx
@@ -38,7 +38,7 @@ export default function FeatureImplementationModal({
 
   return (
     <Modal
-      trackingEventModalType=""
+      trackingEventModalType="feature-implementation-code-snippet"
       open={true}
       close={close}
       size="lg"

--- a/packages/front-end/components/Features/FeatureModal/FeatureFromExperimentModal.tsx
+++ b/packages/front-end/components/Features/FeatureModal/FeatureFromExperimentModal.tsx
@@ -225,7 +225,7 @@ export default function FeatureFromExperimentModal({
 
   return (
     <Modal
-      trackingEventModalType=""
+      trackingEventModalType="feature-from-experiment"
       open
       size="lg"
       inline={inline}

--- a/packages/front-end/components/Features/FeatureModal/index.tsx
+++ b/packages/front-end/components/Features/FeatureModal/index.tsx
@@ -186,7 +186,7 @@ export default function FeatureModal({
 
   return (
     <Modal
-      trackingEventModalType=""
+      trackingEventModalType="feature-create-or-duplicate"
       open
       size="lg"
       inline={inline}

--- a/packages/front-end/components/Features/FeatureValueField.tsx
+++ b/packages/front-end/components/Features/FeatureValueField.tsx
@@ -395,7 +395,7 @@ function SimpleSchemaEditor({
       <>
         {open ? (
           <Modal
-            trackingEventModalType=""
+            trackingEventModalType="feature-edit-value"
             open={true}
             header="Edit Value"
             size="lg"

--- a/packages/front-end/components/Features/FeaturesHeader.tsx
+++ b/packages/front-end/components/Features/FeaturesHeader.tsx
@@ -418,7 +418,7 @@ export default function FeaturesHeader({
         </div>
         {auditModal && (
           <Modal
-            trackingEventModalType=""
+            trackingEventModalType="feature-audit-log"
             open={true}
             header="Audit Log"
             close={() => setAuditModal(false)}

--- a/packages/front-end/components/Features/FeaturesOverview.tsx
+++ b/packages/front-end/components/Features/FeaturesOverview.tsx
@@ -1307,7 +1307,7 @@ export default function FeaturesOverview({
         )}
         {logModal && revision && (
           <Modal
-            trackingEventModalType=""
+            trackingEventModalType="feature-revision-log"
             open={true}
             close={() => setLogModal(false)}
             header="Revision Log"
@@ -1368,7 +1368,7 @@ export default function FeaturesOverview({
         )}
         {confirmDiscard && (
           <Modal
-            trackingEventModalType=""
+            trackingEventModalType="feature-discard-draft"
             open={true}
             close={() => setConfirmDiscard(false)}
             header="Discard Draft"

--- a/packages/front-end/components/Features/PrerequisiteModal.tsx
+++ b/packages/front-end/components/Features/PrerequisiteModal.tsx
@@ -181,7 +181,7 @@ export default function PrerequisiteModal({
 
   return (
     <Modal
-      trackingEventModalType=""
+      trackingEventModalType="feature-prerequisite-form"
       open={true}
       close={close}
       size="lg"

--- a/packages/front-end/components/Features/RequestReviewModal.tsx
+++ b/packages/front-end/components/Features/RequestReviewModal.tsx
@@ -204,7 +204,8 @@ export default function RequestReviewModal({
   const renderRequestAndViewModal = () => {
     return (
       <Modal
-        trackingEventModalType=""
+        trackingEventModalType="feature-review-draft"
+        trackingEventModalSource="request-and-view-modal"
         open={true}
         header={"Review Draft Changes"}
         cta={ctaCopy}
@@ -340,7 +341,8 @@ export default function RequestReviewModal({
   const renderReviewAndSubmitModal = () => {
     return (
       <Modal
-        trackingEventModalType=""
+        trackingEventModalType="feature-review-draft"
+        trackingEventModalSource="review-and-submit-modal"
         open={true}
         close={close}
         header={"Review Draft Changes"}

--- a/packages/front-end/components/Features/RevertModal.tsx
+++ b/packages/front-end/components/Features/RevertModal.tsx
@@ -68,7 +68,7 @@ export default function RevertModal({
 
   return (
     <Modal
-      trackingEventModalType=""
+      trackingEventModalType="feature-revert-version"
       open={true}
       header={`Revert`}
       submit={

--- a/packages/front-end/components/Features/RuleModal.tsx
+++ b/packages/front-end/components/Features/RuleModal.tsx
@@ -287,7 +287,7 @@ export default function RuleModal({
 
   return (
     <Modal
-      trackingEventModalType=""
+      trackingEventModalType="feature-rule-form"
       open={true}
       close={close}
       size="lg"

--- a/packages/front-end/components/Features/SDKConnections/ProxyTestButton.tsx
+++ b/packages/front-end/components/Features/SDKConnections/ProxyTestButton.tsx
@@ -32,7 +32,7 @@ export default function ProxyTestButton({
     <>
       {proxyTestResult && (
         <Modal
-          trackingEventModalType=""
+          trackingEventModalType="feature-sdk-proxy-test-button"
           header="Proxy Status"
           open={true}
           close={() => setProxyTestResult(null)}

--- a/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
+++ b/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
@@ -323,7 +323,7 @@ export default function SDKConnectionForm({
 
   return (
     <Modal
-      trackingEventModalType=""
+      trackingEventModalType="sdk-connection-form"
       header={edit ? "Edit SDK Connection" : "New SDK Connection"}
       size={"lg"}
       autoCloseOnSubmit={autoCloseOnSubmit}

--- a/packages/front-end/components/Features/StaleDetectionModal.tsx
+++ b/packages/front-end/components/Features/StaleDetectionModal.tsx
@@ -14,7 +14,7 @@ export default function StaleDetectionModal({
   const { apiCall } = useAuth();
   return (
     <Modal
-      trackingEventModalType=""
+      trackingEventModalType="feature-stale-flag-detection"
       open
       close={close}
       header={`${

--- a/packages/front-end/components/FeedbackModal.tsx
+++ b/packages/front-end/components/FeedbackModal.tsx
@@ -38,7 +38,7 @@ export default function FeedbackModal({
 
   return (
     <Modal
-      trackingEventModalType=""
+      trackingEventModalType="customer-feedback"
       open={open}
       header={header}
       cta={ctaEnabled ? cta : sentCta ?? cta}

--- a/packages/front-end/components/GuidedGetStarted/CheckSDKConnectionModal.tsx
+++ b/packages/front-end/components/GuidedGetStarted/CheckSDKConnectionModal.tsx
@@ -21,7 +21,7 @@ export default function CheckSDKConnectionModal({
 }: Props) {
   return (
     <Modal
-      trackingEventModalType=""
+      trackingEventModalType="sdk-check-connection"
       open={true}
       close={showModalClose ? close : undefined}
       closeCta="Close"

--- a/packages/front-end/components/HealthTab/DimensionIssues.tsx
+++ b/packages/front-end/components/HealthTab/DimensionIssues.tsx
@@ -145,7 +145,7 @@ export const DimensionIssues = ({
   return (
     <>
       <Modal
-        trackingEventModalType=""
+        trackingEventModalType="health-tab-dimension-issues"
         close={() => setModalOpen(false)}
         open={modalOpen}
         closeCta={"Close"}

--- a/packages/front-end/components/HomePage/NorthStar.tsx
+++ b/packages/front-end/components/HomePage/NorthStar.tsx
@@ -131,7 +131,7 @@ const NorthStar: FC<{
       )}
       {openNorthStarModal && (
         <Modal
-          trackingEventModalType=""
+          trackingEventModalType="north-star-metric"
           close={() => setOpenNorthStarModal(false)}
           overflowAuto={false}
           autoFocusSelector={""}

--- a/packages/front-end/components/Ideas/IdeaForm.tsx
+++ b/packages/front-end/components/Ideas/IdeaForm.tsx
@@ -43,7 +43,7 @@ const IdeaForm: FC<{
 
   return (
     <Modal
-      trackingEventModalType=""
+      trackingEventModalType="idea-form"
       header={edit ? "Edit Idea" : "New Idea"}
       close={close}
       open={true}

--- a/packages/front-end/components/Ideas/ImpactModal.tsx
+++ b/packages/front-end/components/Ideas/ImpactModal.tsx
@@ -41,7 +41,7 @@ const ImpactModal: FC<{
 
   return (
     <Modal
-      trackingEventModalType=""
+      trackingEventModalType="idea-impact-score"
       header="Impact Score Parameters"
       open={true}
       submit={form.handleSubmit(async (value) => {

--- a/packages/front-end/components/Layout/TopNav.tsx
+++ b/packages/front-end/components/Layout/TopNav.tsx
@@ -395,7 +395,7 @@ const TopNav: FC<{
       </Head>
       {editUserOpen && (
         <Modal
-          trackingEventModalType=""
+          trackingEventModalType="edit-user-profile"
           close={() => setEditUserOpen(false)}
           submit={onSubmitEditProfile}
           header="Edit Profile"

--- a/packages/front-end/components/Markdown/CustomMarkdown.tsx
+++ b/packages/front-end/components/Markdown/CustomMarkdown.tsx
@@ -58,7 +58,7 @@ const CustomMarkdown: React.FC<Props> = ({ page, variables }) => {
     <>
       {showModal && (
         <Modal
-          trackingEventModalType=""
+          trackingEventModalType="custom-markdown"
           open={true}
           header={<h4>{PAGE_TO_CTA[page] + organization.name}</h4>}
           close={() => setShowModal(false)}

--- a/packages/front-end/components/Modal.tsx
+++ b/packages/front-end/components/Modal.tsx
@@ -260,7 +260,7 @@ const Modal: FC<ModalProps> = ({
         return;
       }
       track(eventName, {
-        type: trackingEventModalType,
+        modalType: trackingEventModalType,
         source: trackingEventModalSource,
         ...allowlistedTrackingEventProps,
         ...(additionalProps || {}),

--- a/packages/front-end/components/Modal/ConfirmButton.tsx
+++ b/packages/front-end/components/Modal/ConfirmButton.tsx
@@ -23,7 +23,7 @@ const ConfirmButton: FC<{
     <>
       {confirming ? (
         <Modal
-          trackingEventModalType=""
+          trackingEventModalType="confirm-button"
           header={modalHeader}
           close={() => setConfirming(false)}
           open={true}

--- a/packages/front-end/components/OpenVisualEditorLink.tsx
+++ b/packages/front-end/components/OpenVisualEditorLink.tsx
@@ -152,7 +152,7 @@ const OpenVisualEditorLink: FC<{
 
       {showEditorUrlDialog && openSettings && (
         <Modal
-          trackingEventModalType=""
+          trackingEventModalType="visual-editor-configure-url"
           open
           header="Visual Editor Target URL"
           close={() => setShowEditorUrlDialog(false)}
@@ -169,7 +169,7 @@ const OpenVisualEditorLink: FC<{
 
       {showExtensionDialog && (
         <Modal
-          trackingEventModalType=""
+          trackingEventModalType="visual-editor-install-devtools"
           open
           header="GrowthBook DevTools Extension"
           close={() => setShowExtensionDialog(false)}

--- a/packages/front-end/components/Owner/EditOwnerModal.tsx
+++ b/packages/front-end/components/Owner/EditOwnerModal.tsx
@@ -19,7 +19,7 @@ const EditOwnerModal: FC<{
 
   return (
     <Modal
-      trackingEventModalType=""
+      trackingEventModalType="edit-owner"
       header={"Edit Owner"}
       open={true}
       close={cancel}

--- a/packages/front-end/components/importing/ImportFromLaunchDarkly/ImportFromLaunchDarkly.tsx
+++ b/packages/front-end/components/importing/ImportFromLaunchDarkly/ImportFromLaunchDarkly.tsx
@@ -551,7 +551,7 @@ function FeatureImportRow({
       </tr>
       {open && data.feature && (
         <Modal
-          trackingEventModalType=""
+          trackingEventModalType="launchdarkly-import-feature"
           open
           close={() => setOpen(false)}
           header={`Feature Details`}


### PR DESCRIPTION
### Features and Changes

Adds tracking event names to a smattering of existing modals

### Testing

I haven't tested this at all yet; we should do at least a spot check of a few random modals and make sure the tracking events are firing correctly to Jitsu.