### PR TITLE
Fix the plan name for self-hosted Pro

### DIFF
--- a/packages/front-end/components/Settings/SubscriptionInfo.tsx
+++ b/packages/front-end/components/Settings/SubscriptionInfo.tsx
@@ -4,6 +4,7 @@ import { redirectWithTimeout, useAuth } from "@/services/auth";
 import useStripeSubscription from "@/hooks/useStripeSubscription";
 import LoadingOverlay from "@/components/LoadingOverlay";
 import Button from "@/components/Button";
+import { isCloud } from "@/services/env";
 import UpgradeModal from "./UpgradeModal";
 
 export default function SubscriptionInfo() {
@@ -35,7 +36,7 @@ export default function SubscriptionInfo() {
         />
       )}
       <div className="col-auto mb-3">
-        <strong>Current Plan:</strong> Cloud Pro
+        <strong>Current Plan:</strong> {isCloud() ? "Cloud" : "Self-Hosted"} Pro
         {subscriptionStatus === "trialing" && (
           <>
             {" "}


### PR DESCRIPTION
### Features and Changes

Make the plan name on the billing page be dependent upon IS_CLOUD env var

### Testing

set LICENSE_KEY to a pro license.
set `IS_CLOUD=false` in `.env.local`.  
Start the server
Go to /billing see "Self-Hosted Pro"

set `IS_CLOUD=true` in `.env.local`
Restart the server
Go to /billing and see "Cloud Pro"
