### PR TITLE
Add org date created as SDK attribute

### DIFF
--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -776,6 +776,7 @@ export async function getOrganization(req: AuthRequest, res: Response) {
       messages: messages || [],
       pendingMembers: org.pendingMembers,
       getStartedChecklistItems: org.getStartedChecklistItems,
+      dateCreated: org.dateCreated,
     },
     seatsInUse,
   });

--- a/packages/front-end/services/UserContext.tsx
+++ b/packages/front-end/services/UserContext.tsx
@@ -32,6 +32,7 @@ import {
 import * as Sentry from "@sentry/react";
 import { GROWTHBOOK_SECURE_ATTRIBUTE_SALT } from "shared/constants";
 import { Permissions, userHasPermission } from "shared/permissions";
+import { getValidDate } from "shared/dates";
 import {
   getSuperadminDefaultRole,
   isCloud,
@@ -290,6 +291,7 @@ export function UserContextProvider({ children }: { children: ReactNode }) {
 
   // Update growthbook tarageting attributes
   const growthbook = useGrowthBook<AppFeatures>();
+  console.log(currentOrg?.organization?.dateCreated);
   useEffect(() => {
     growthbook?.setAttributes({
       id: data?.userId || "",
@@ -297,6 +299,9 @@ export function UserContextProvider({ children }: { children: ReactNode }) {
       superAdmin: data?.superAdmin || false,
       company: currentOrg?.organization?.name || "",
       organizationId: hashedOrganizationId,
+      orgDateCreated: currentOrg?.organization?.dateCreated
+        ? getValidDate(currentOrg.organization.dateCreated).toISOString()
+        : "",
       userAgent: window.navigator.userAgent,
       url: router?.pathname || "",
       cloud: isCloud(),

--- a/packages/front-end/services/UserContext.tsx
+++ b/packages/front-end/services/UserContext.tsx
@@ -291,7 +291,7 @@ export function UserContextProvider({ children }: { children: ReactNode }) {
 
   // Update growthbook tarageting attributes
   const growthbook = useGrowthBook<AppFeatures>();
-  console.log(currentOrg?.organization?.dateCreated);
+
   useEffect(() => {
     growthbook?.setAttributes({
       id: data?.userId || "",


### PR DESCRIPTION
### Features and Changes

Adds org date created as an attribute, useful for targeting to recent orgs, old orgs, etc. 

First use will be to hide the "Slack" sidebar button since it is currently not used in favor of Webhooks and clutters the UI for no reason. That sidebar button and subsequent flow is also undocumented.

### Screenshots

Targeting in `dev` if the date created is after today to remove Slack from sidebar.

You can see my old dev org gets the right date and I still get the slack sidebar:
<img width="1728" alt="Screenshot 2024-09-18 at 11 29 16 AM" src="https://github.com/user-attachments/assets/9b8dea06-86e0-4c68-bdff-84fab146974f">
<img width="672" alt="Screenshot 2024-09-18 at 11 33 41 AM" src="https://github.com/user-attachments/assets/b72544c7-db3b-4bc7-8a7b-b14b1627f8c4">


When I modify the user attributes to be `""` it correctly is not greater than a date as well, and when I set the date to the future, the slack sidebar goes away:
<img width="1724" alt="Screenshot 2024-09-18 at 11 30 57 AM" src="https://github.com/user-attachments/assets/1855ddcd-0f9d-4c9c-bb58-8f36ebce4fe2">
