### PR TITLE
Update SQL for no bandit_period

### DIFF
--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -1075,7 +1075,6 @@ export default abstract class SqlIntegration
         return {
           variation: row.variation ?? "",
           dimension: row.dimension || "",
-          bandit_period: row.bandit_period ?? 0,
           users: parseInt(row.users) || 0,
           count: parseInt(row.users) || 0,
           ...metricData,
@@ -1095,7 +1094,6 @@ export default abstract class SqlIntegration
         return {
           variation: row.variation ?? "",
           dimension: row.dimension || "",
-          bandit_period: row.bandit_period ?? 0,
           users: parseInt(row.users) || 0,
           count: parseInt(row.users) || 0,
           main_sum: parseFloat(row.main_sum) || 0,
@@ -3131,6 +3129,20 @@ export default abstract class SqlIntegration
         `
           : ""
       }
+      ${
+        banditDates?.length
+          ? this.getBanditStatisticsCTE({
+              baseIdType,
+              capCoalesceMetric,
+              isPercentileCapped,
+              capCoalesceDenominator,
+              ratioMetric,
+              denominatorIsPercentileCapped,
+              regressionAdjusted,
+              capCoalesceCovariate,
+              ignoreNulls: "ignoreNulls" in metric && metric.ignoreNulls,
+            })
+          : `
       -- One row per variation/dimension with aggregations
       SELECT
         m.variation AS variation,
@@ -3228,9 +3240,196 @@ export default abstract class SqlIntegration
         m.variation
         , ${cumulativeDate ? `${this.formatDate("m.day")}` : "m.dimension"}
         ${banditDates?.length ? ", m.bandit_period" : ""}
-    `,
+    `
+      }`,
       this.getFormatDialect()
     );
+  }
+
+  getBanditStatisticsCTE({
+    baseIdType,
+    capCoalesceMetric,
+    isPercentileCapped,
+    capCoalesceDenominator,
+    ratioMetric,
+    denominatorIsPercentileCapped,
+    regressionAdjusted,
+    capCoalesceCovariate,
+    ignoreNulls,
+  }: {
+    baseIdType: string;
+    capCoalesceMetric: string;
+    isPercentileCapped: boolean;
+    capCoalesceDenominator: string;
+    ratioMetric: boolean;
+    denominatorIsPercentileCapped: boolean;
+    regressionAdjusted: boolean;
+    capCoalesceCovariate: string;
+    ignoreNulls: boolean;
+  }): string {
+    // todo percentile capped
+    return `-- One row per variation/dimension with aggregations
+      , __banditPeriodStatistics AS (
+        SELECT
+          m.variation AS variation
+          , m.dimension AS dimension
+          , m.bandit_period AS bandit_period
+          , COUNT(*) AS users
+          ${
+            isPercentileCapped
+              ? ", MAX(COALESCE(cap.cap_value, 0)) as main_cap_value"
+              : ""
+          }
+          , SUM(${capCoalesceMetric}) AS main_sum
+          , SUM(POWER(${capCoalesceMetric}, 2)) AS main_sum_squares
+          ${
+            ratioMetric
+              ? `
+            ${
+              denominatorIsPercentileCapped
+                ? ", MAX(COALESCE(capd.cap_value, 0)) as denominator_cap_value"
+                : ""
+            }
+            , SUM(${capCoalesceDenominator}) AS denominator_sum
+            , SUM(POWER(${capCoalesceDenominator}, 2)) AS denominator_sum_squares
+            , SUM(${capCoalesceDenominator} * ${capCoalesceMetric}) AS main_denominator_sum_product
+          `
+              : ""
+          }
+          ${
+            regressionAdjusted
+              ? `
+            , SUM(${capCoalesceCovariate}) AS covariate_sum
+            , SUM(POWER(${capCoalesceCovariate}, 2)) AS covariate_sum_squares
+            , SUM(${capCoalesceMetric} * ${capCoalesceCovariate}) AS main_covariate_sum_product
+            `
+              : ""
+          }
+        FROM
+          __userMetricAgg m
+        ${
+          ratioMetric
+            ? `LEFT JOIN __userDenominatorAgg d ON (
+                d.${baseIdType} = m.${baseIdType}
+              )
+              ${
+                denominatorIsPercentileCapped
+                  ? "CROSS JOIN __capValueDenominator capd"
+                  : ""
+              }`
+            : ""
+        }
+        ${
+          regressionAdjusted
+            ? `
+            LEFT JOIN __userCovariateMetric c
+            ON (c.${baseIdType} = m.${baseIdType})
+            `
+            : ""
+        }
+        ${isPercentileCapped ? `CROSS JOIN __capValue cap` : ""}
+        ${ignoreNulls ? `WHERE m.value != 0` : ""}
+        GROUP BY
+          m.variation
+          , m.bandit_period
+          , m.dimension
+      ),
+      __dimensionTotals AS (
+        SELECT
+          dimension
+          , SUM(users) AS total_users
+        FROM 
+          __banditPeriodStatistics
+        GROUP BY
+          dimension
+      ),
+      __banditPeriodWeights AS (
+        SELECT
+          bps.bandit_period
+          , bps.dimension
+          , SUM(bps.users) / MAX(dt.total_users) AS weight
+          , SUM(bps.users) AS n_t
+             ${
+               regressionAdjusted
+                 ? `
+          , SUM(bps.main_sum / bps.users * bps.users / SUM(bps.users))
+        `
+                 : ""
+             }
+        FROM 
+          __banditPeriodStatistics bps
+        LEFT JOIN
+          __dimensionTotals dt 
+          ON (bps.dimension = dt.dimension)
+        GROUP BY
+          bps.bandit_period
+          , bps.dimension
+      )
+      SELECT
+        bps.variation
+        , bps.dimension
+        , SUM(bps.users) AS users
+        , SUM(bpw.weight * bps.main_sum / bps.users) * SUM(bps.users) AS main_sum
+        , SUM(bps.users) * (SUM(
+          POWER(bpw.weight, 2) * ((bps.main_sum_squares - POWER(bps.main_sum, 2) / bps.users) / (bps.users - 1)) / bps.users
+        ) * (SUM(bps.users) - 1) + POWER(SUM(bpw.weight * bps.main_sum / bps.users), 2)) as main_sum_squares
+        ${
+          ratioMetric
+            ? `
+          , SUM(bpw.weight * bps.denominator_sum / bps.users) * SUM(bps.users) AS denominator_sum
+          , SUM(bps.users) * (SUM(
+            POWER(bpw.weight, 2) * ((bps.denominator_sum_squares - POWER(bps.denominator_sum, 2) / bps.users) / (bps.users - 1)) / bps.users
+          ) * (SUM(bps.users) - 1) + POWER(SUM(bpw.weight * bps.denominator_sum / bps.users), 2)) as denominator_sum_squares
+          
+          , SUM(bps.users) * (
+              SUM(
+                POWER(bpw.weight, 2) / bpw.n_t * (bps.main_denominator_sum_product / bps.users - bps.main_sum / bps.users * bps.denominator_sum / bps.users)
+              ) +
+              (
+                SUM(bpw.weight * bps.main_sum / bps.users) * SUM(bpw.weight * bps.denominator_sum / bps.users)
+              )
+            ) AS main_denominator_sum_product`
+            : ""
+        }
+        -- TODO CUPED
+        ${
+          regressionAdjusted
+            ? `
+          , SUM(bpw.weight * bps.covariate_sum / bps.users) * SUM(bps.users) AS covariate_sum
+          , SUM(bps.users) * (SUM(
+            POWER(bpw.weight, 2) * ((bps.covariate_sum_squares - POWER(bps.covariate_sum, 2) / bps.users) / (bps.users - 1)) / bps.users
+          ) * (SUM(bps.users) - 1) + POWER(SUM(bpw.weight * bps.covariate_sum / bps.users), 2)) as covariate_sum_squares
+          , SUM(bps.users) * (
+            SUM(
+              POWER(bpw.weight, 2) / bpw.n_t * (bps.main_covariate_sum_product / bps.users - bps.main_sum / bps.users * bps.covariate_sum / bps.users)
+            ) +
+            (
+              SUM(bpw.weight * bps.main_sum / bps.users) * SUM(bpw.weight * bps.covariate_sum / bps.users)
+            ) AS main_covariate_sum_product
+             
+          , SUM(
+            POWER(bpw.weight, 2) * (
+
+              )
+            ) / 
+            SUM(
+              POWER(bpw.weight, 2) / bpw.n_t
+            ) AS theta
+            `
+            : ""
+        }
+      FROM 
+        __banditPeriodStatistics bps
+      LEFT JOIN
+        __banditPeriodWeights bpw
+        ON (
+          bps.bandit_period = bpw.bandit_period 
+          AND bps.dimension = bpw.dimension
+        )
+      GROUP BY
+        bps.variation
+        , bps.dimension
+      `;
   }
 
   getQuantileBoundValues(

--- a/packages/back-end/src/types/Integration.ts
+++ b/packages/back-end/src/types/Integration.ts
@@ -338,7 +338,6 @@ export type PastExperimentResponseRows = {
 
 export type ExperimentMetricQueryResponseRows = {
   dimension: string;
-  bandit_period?: string;
   variation: string;
   users: number;
   count: number;


### PR DESCRIPTION
Incomplete.

Mean and proportion working, ratio variance (covariance, specifically) not working, no CUPED implementation.

Doesn't work with gbstats yet.