### PR TITLE
Move generation of the key to store/retrieve a sticky bucket assignment into separate method

### DIFF
--- a/packages/sdk-js/test/sticky-buckets.test.ts
+++ b/packages/sdk-js/test/sticky-buckets.test.ts
@@ -904,4 +904,16 @@ describe("sticky-buckets", () => {
 
     localStorage.clear();
   });
+
+  describe("getKey", () => {
+    it("returns the correct key", async () => {
+      const sbs = new LocalStorageStickyBucketService();
+      expect(sbs.getKey("foo", "bar")).toBe("gbStickyBuckets__foo||bar");
+    });
+
+    it("returns the correct key when a prefix is provided", async () => {
+      const sbs = new LocalStorageStickyBucketService({ prefix: "test_" });
+      expect(sbs.getKey("foo", "bar")).toBe("test_foo||bar");
+    });
+  });
 });


### PR DESCRIPTION
### Move generation of the key to store/retrieve a sticky bucket assignment into separate method

<!--
  Include a description of your changes.
  If there are any new tools, API's, etc. that devs can leverage, it may be helpful to include usage info.
-->

In this PR we moved the generation of  the key to store/retrieve a sticky bucket assignment into separate method.
It should help to use custom logic to generate a keys with custom sticky bucket services. Also, it will make code more clear.

Example:

```js
class MyBrowserCookieStickyBucketService extends BrowserCookieStickyBucketService {
  getKey(attributeName, attributeValue) {
    // Some web servers can encode cookie keys with `||` into `%7C%7C`
    //  In this case, we can override the `getKey` and use other characters, e.g. `XX`
    return `${this.prefix}${attributeName}XX${attributeValue}`;
  }
}
```

<!--
  Indicate which issue this will close, if applicable
  For multiple issues, add a new `- Closes` or `- Fixes` line
-->

- Closes **(add link to issue here)**

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

<!--
  Please describe how to test these changes.
 -->

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
