### PR TITLE
create ConditionalWrapper components, use to fix modal footer

### DIFF
--- a/packages/front-end/components/ConditionalWrapper.tsx
+++ b/packages/front-end/components/ConditionalWrapper.tsx
@@ -1,0 +1,25 @@
+import {
+  ComponentType,
+  ReactNode,
+  FC,
+  isValidElement,
+  cloneElement,
+} from "react";
+
+const ConditionalWrapper: FC<{
+  condition: boolean;
+  wrapper?: ComponentType<{ children: ReactNode }> | ReactNode;
+  children: ReactNode;
+}> = ({ condition, wrapper, children }) => {
+  if (condition && wrapper) {
+    if (isValidElement(wrapper)) {
+      return cloneElement(wrapper, {}, children);
+    } else if (typeof wrapper === "function") {
+      const Component = wrapper as ComponentType<{ children: ReactNode }>;
+      return <Component>{children}</Component>;
+    }
+  }
+  return <>{children}</>;
+};
+
+export default ConditionalWrapper;

--- a/packages/front-end/components/Modal.tsx
+++ b/packages/front-end/components/Modal.tsx
@@ -205,18 +205,7 @@ const Modal: FC<ModalProps> = ({
       </div>
       {submit || secondaryCTA || (close && includeCloseCta) ? (
         <div
-          className="modal-footer"
-          style={
-            stickyFooter
-              ? {
-                  position: "fixed",
-                  left: "0",
-                  bottom: "0",
-                  width: "100%",
-                  backgroundColor: "var(--surface-background-color-alt)",
-                }
-              : undefined
-          }
+          className={clsx("modal-footer", { "sticky-footer": stickyFooter })}
         >
           {error && (
             <div className="alert alert-danger mr-auto">

--- a/packages/front-end/components/Modal.tsx
+++ b/packages/front-end/components/Modal.tsx
@@ -10,6 +10,7 @@ import {
 import clsx from "clsx";
 import { truncateString } from "shared/util";
 import track, { TrackEventProps } from "@/services/track";
+import ConditionalWrapper from "@/components/ConditionalWrapper";
 import LoadingOverlay from "./LoadingOverlay";
 import Portal from "./Modal/Portal";
 import Tooltip from "./Tooltip/Tooltip";
@@ -227,11 +228,14 @@ const Modal: FC<ModalProps> = ({
                 ))}
             </div>
           )}
-          <div
-            className={
-              stickyFooter ? "container pagecontents mx-auto text-right" : ""
+          <ConditionalWrapper
+            condition={stickyFooter}
+            wrapper={
+              <div
+                className="container pagecontents mx-auto text-right"
+                style={{ maxWidth: 1100 }}
+              />
             }
-            style={stickyFooter ? { maxWidth: "1100px" } : undefined}
           >
             {secondaryCTA}
             {submit && !isSuccess ? (
@@ -266,7 +270,7 @@ const Modal: FC<ModalProps> = ({
               </button>
             ) : null}
             {tertiaryCTA}
-          </div>
+          </ConditionalWrapper>
         </div>
       ) : null}
     </div>

--- a/packages/front-end/styles/global.scss
+++ b/packages/front-end/styles/global.scss
@@ -918,6 +918,13 @@ main.main.report {
     color: colors.$highlight-purple;
     font-weight: 600;
   }
+  .modal-footer.sticky-footer {
+    position: fixed;
+    left: 0;
+    bottom: 0;
+    width: 100%;
+    background-color: var(--surface-background-color-alt);
+  }
 }
 .modal-dialog.modal-fill {
   margin: 0 auto;


### PR DESCRIPTION
Helper HOC for wrapping things with things based on a condition. Apply it to modal footer to fix UI regression.

before:
![image](https://github.com/user-attachments/assets/7c66b1b2-f27c-4ada-b501-442a34f0f86f)

after:
<img width="814" alt="image" src="https://github.com/user-attachments/assets/94d2e3df-6014-4db5-9e33-16f0721a87a3">

