### PR TITLE
Add cla bot infra

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,30 @@
+name: "CLA Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+permissions:
+  actions: write
+  contents: read
+  pull-requests: write
+  statuses: write
+jobs:
+  CLAAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # the below token should have repo scope and must be manually added by you in the repository's secret
+          # This token is required only if you have configured to store the signatures in a remote repository/organization
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        with:
+          path-to-signatures: "signatures/version1/cla.json"
+          path-to-document: "https://github.com/growthbook/growthbook/blob/main/CLA.md"
+          branch: "main"
+          allowlist: bot*,august-growthbook,Auz,bryce-fitzsimons,gazzding,jdorn,lukebrawleysmith,lukesonnet,madhuchavva,mattdp,mknowlton89,msamper,natasha-growthbook,romain-growthbook,toots,tzjames,Kevin-Chant
+          remote-organization-name: growthbook
+          remote-repository-name: cla

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,54 @@
+# GrowthBook Contributor License Agreement (CLA)
+
+**Please read this document carefully before contributing to the Project.**
+
+### 1. Definitions
+
+- **"Contribution"** means any original work of authorship, including any modifications or additions to an existing work, that is intentionally submitted by You to GrowthBook for inclusion in, or documentation of, the Project. This includes, but is not limited to, code, documentation, designs, and ideas.
+- **"Project"** means any GrowthBook product, project, or repository that explicitly states that this CLA applies.
+- **"You"** (or **"Your"**) means the individual or legal entity making the Contribution. If You are contributing on behalf of Your employer, You represent that You have the necessary rights and authorizations to do so.
+
+### 2. Grant of Copyright License
+
+By submitting a Contribution, You grant GrowthBook a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute Your Contributions and such derivative works in connection with the Project.
+
+### 3. Grant of Patent License
+
+By submitting a Contribution, You grant GrowthBook a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Project, where such license applies only to those patent claims licensable by You that are necessarily infringed by Your Contribution(s) alone or by the combination of Your Contribution(s) with the Project to which such Contribution(s) was submitted.
+
+This patent license shall terminate with respect to any Contribution upon the earlier of:
+
+- Your formal written withdrawal of the Contribution (e.g., via email, pull request comment, etc.); or
+- The removal of the Contribution from the Project by GrowthBook.
+
+Any patent license granted prior to such withdrawal or removal remains valid for Contributions already incorporated into the Project.
+
+### 4. Original Work and Third-Party Content
+
+You represent that each of Your Contributions is Your original creation or that You have obtained all necessary rights and permissions from any third parties to contribute the material. You further represent that Your Contributions do not knowingly infringe any third-party rights.
+
+If Your Contribution includes or relies on any third-party materials, including but not limited to libraries, code, or design elements, You must identify such third-party materials and the licenses under which they are provided. You also agree to inform GrowthBook of any third-party licenses, patents, or trademarks of which You are aware that relate to Your Contribution.
+
+### 5. No Warranty
+
+You are not expected to provide support for Your Contributions, except to the extent You desire to provide support. Unless required by applicable law or agreed to in writing, You provide Your Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+### 6. Indemnity
+
+To the extent permitted by law, You agree to indemnify, defend, and hold harmless GrowthBook, its officers, and contributors against any claims, demands, suits, or legal proceedings initiated by third parties that arise from or relate to Your Contribution.
+
+### 7. Electronic Signatures
+
+You agree that Your electronic submissions constitute Your agreement to the terms of this CLA. Your use of the GitHub CLA Assistant Lite constitutes Your electronic signature.
+
+### 8. Governing Law
+
+This Agreement shall be governed by and construed in accordance with the laws of the State of California, without regard to its conflict of law provisions. Any disputes arising under this Agreement will be resolved through mediation or arbitration before any court action.
+
+### 9. Data Processing
+
+You acknowledge that GrowthBook may process personal data related to Your Contributions, including but not limited to Your name, email, and other identifying information, solely for the purpose of managing the Project. GrowthBook agrees to process such data in compliance with applicable data protection laws.
+
+### 10. Entire Agreement
+
+This Agreement constitutes the entire agreement between You and GrowthBook relating to Your Contributions to the Project and supersedes all prior or contemporaneous communications and proposals, whether oral or written, between You and GrowthBook.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -215,6 +215,10 @@ If you see this warning, it is likely because you ran `yarn setup` from within a
 
 To resolve this, ensure you are not using a Python virtual environment and re-run `yarn setup` from the project root.
 
+## Contributor License Agreeement (CLA)
+
+All contributors are required to sign GrowthBook's [CLA](./CLA.md), which ensures the community is free to use your contributions. When opening your first pull request, an automated action will prompt you to review and sign the CLA via a comment. Agreement is required for all pull requests.
+
 ## Getting Help
 
 Join our [Slack community](https://slack.growthbook.io?ref=contributing) if you need help getting set up or want to chat. We're also happy to hop on a call and do some pair programming.


### PR DESCRIPTION
Adds initial infra for CLA assistant lite
https://github.com/contributor-assistant/github-action

Todo
[] Add PAT for CLA repo (where signatures are stored)