### PR TITLE
Send release info to sentry

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,22 +52,22 @@ jobs:
             growthbook/growthbook:git-${{ steps.metadata.outputs.sha }}
           platforms: linux/amd64,linux/arm64
 
-      - name: Notify Sentry of new release
+  sentry-release:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'growthbook/growthbook' }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Create Sentry release
+        uses: getsentry/action-release@v1.7.0
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: growthbook
           SENTRY_PROJECT: api
-        run: |
-          # Install the cli
-          curl -sL https://sentry.io/get-cli/ | bash
-
-          # Setup configuration values
-          VERSION=growthbook@${{ steps.metadata.outputs.sha }}
-
-          # Workflow to create releases
-          sentry-cli releases new "$VERSION"
-          sentry-cli releases set-commits "$VERSION" --auto
-          sentry-cli releases finalize "$VERSION"
+        with:
+          environment: production
 
   # Deploy the back-end for GrowthBook Cloud
   prod:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,6 +52,23 @@ jobs:
             growthbook/growthbook:git-${{ steps.metadata.outputs.sha }}
           platforms: linux/amd64,linux/arm64
 
+      - name: Notify Sentry of new release
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: growthbook
+          SENTRY_PROJECT: api
+        run: |
+          # Install the cli
+          curl -sL https://sentry.io/get-cli/ | bash
+
+          # Setup configuration values
+          VERSION=growthbook@${{ steps.metadata.outputs.sha }}
+
+          # Workflow to create releases
+          sentry-cli releases new "$VERSION"
+          sentry-cli releases set-commits "$VERSION" --auto
+          sentry-cli releases finalize "$VERSION"
+
   # Deploy the back-end for GrowthBook Cloud
   prod:
     runs-on: ubuntu-latest

--- a/packages/back-end/src/app.ts
+++ b/packages/back-end/src/app.ts
@@ -26,9 +26,14 @@ import { getAuthConnection, processJWT, usingOpenId } from "./services/auth";
 import { wrapController } from "./routers/wrapController";
 import apiRouter from "./api/api.router";
 import scimRouter from "./scim/scim.router";
+import { getBuild } from "./util/handler";
 
 if (SENTRY_DSN) {
-  Sentry.init({ dsn: SENTRY_DSN });
+  const buildInfo = getBuild();
+
+  Sentry.init({ dsn: SENTRY_DSN, release: `growthbook@${buildInfo.sha}` });
+
+  Sentry.setTag("build_date", buildInfo.date);
 }
 
 // Begin Controllers
@@ -88,7 +93,6 @@ const informationSchemasController = wrapController(
 
 import { isEmailEnabled } from "./services/email";
 import { init } from "./init";
-import { getBuild } from "./util/handler";
 import { getCustomLogProps, httpLogger } from "./util/logger";
 import { usersRouter } from "./routers/users/users.router";
 import { organizationsRouter } from "./routers/organizations/organizations.router";

--- a/packages/back-end/src/app.ts
+++ b/packages/back-end/src/app.ts
@@ -31,9 +31,7 @@ import { getBuild } from "./util/handler";
 if (SENTRY_DSN) {
   const buildInfo = getBuild();
 
-  Sentry.init({ dsn: SENTRY_DSN, release: `growthbook@${buildInfo.sha}` });
-
-  Sentry.setTag("build_date", buildInfo.date);
+  Sentry.init({ dsn: SENTRY_DSN, release: buildInfo.sha });
 }
 
 // Begin Controllers


### PR DESCRIPTION
### Features and Changes

Send release info to Sentry so we can more accurately detect issues.

- Uses Sentry Github Action
- Sets release info following these instructions https://docs.sentry.io/platforms/javascript/guides/node/configuration/releases/#setting-a-release

### Dependencies

- [ ] Add SENTRY_AUTH_TOKEN to github secrets.  Tokens can be found/created here: https://growthbook.sentry.io/settings/auth-tokens/
- [ ] https://github.com/marketplace/actions/sentry-release?version=v1.7.0#create-a-sentry-internal-integration

### Testing
cross-fingers and hopes the deploy works.
