### PR TITLE
Fix recommended metric defaults

### DIFF
--- a/packages/front-end/components/FactTables/FactMetricModal.tsx
+++ b/packages/front-end/components/FactTables/FactMetricModal.tsx
@@ -416,6 +416,7 @@ export function getDefaultFactMetricProps({
   project,
   datasources,
   initialFactTable,
+  convertToPercents,
 }: {
   metricDefaults: MetricDefaults;
   settings: OrganizationSettings;
@@ -423,7 +424,10 @@ export function getDefaultFactMetricProps({
   datasources: DataSourceInterfaceWithParams[];
   existing?: Partial<FactMetricInterface>;
   initialFactTable?: FactTableInterface;
+  convertToPercents: boolean;
 }): CreateFactMetricProps {
+  const multiplier = convertToPercents ? 100 : 1;
+
   return {
     name: existing?.name || "",
     owner: existing?.owner || "",
@@ -457,19 +461,19 @@ export function getDefaultFactMetricProps({
       windowUnit: "days",
       windowValue: 3,
     },
-    winRisk: (existing?.winRisk || DEFAULT_WIN_RISK_THRESHOLD) * 100,
-    loseRisk: (existing?.loseRisk || DEFAULT_LOSE_RISK_THRESHOLD) * 100,
+    winRisk: (existing?.winRisk ?? DEFAULT_WIN_RISK_THRESHOLD) * multiplier,
+    loseRisk: (existing?.loseRisk ?? DEFAULT_LOSE_RISK_THRESHOLD) * multiplier,
     minPercentChange:
-      (existing?.minPercentChange ||
-        metricDefaults.minPercentageChange ||
-        DEFAULT_MIN_PERCENT_CHANGE) * 100,
+      (existing?.minPercentChange ??
+        metricDefaults.minPercentageChange ??
+        DEFAULT_MIN_PERCENT_CHANGE) * multiplier,
     maxPercentChange:
-      (existing?.maxPercentChange ||
-        metricDefaults.maxPercentageChange ||
-        DEFAULT_MAX_PERCENT_CHANGE) * 100,
+      (existing?.maxPercentChange ??
+        metricDefaults.maxPercentageChange ??
+        DEFAULT_MAX_PERCENT_CHANGE) * multiplier,
     minSampleSize:
-      existing?.minSampleSize ||
-      metricDefaults.minimumSampleSize ||
+      existing?.minSampleSize ??
+      metricDefaults.minimumSampleSize ??
       DEFAULT_MIN_SAMPLE_SIZE,
     regressionAdjustmentOverride:
       existing?.regressionAdjustmentOverride || false,
@@ -477,8 +481,9 @@ export function getDefaultFactMetricProps({
       existing?.regressionAdjustmentEnabled ||
       DEFAULT_REGRESSION_ADJUSTMENT_ENABLED,
     regressionAdjustmentDays:
-      existing?.regressionAdjustmentDays ||
-      (settings.regressionAdjustmentDays ?? DEFAULT_REGRESSION_ADJUSTMENT_DAYS),
+      existing?.regressionAdjustmentDays ??
+      settings.regressionAdjustmentDays ??
+      DEFAULT_REGRESSION_ADJUSTMENT_DAYS,
     priorSettings:
       existing?.priorSettings ||
       (metricDefaults.priorSettings ?? {
@@ -529,6 +534,7 @@ export default function FactMetricModal({
       existing,
       settings,
       project,
+      convertToPercents: true,
       initialFactTable: initialFactTable
         ? getFactTableById(initialFactTable) || undefined
         : undefined,

--- a/packages/front-end/components/FactTables/RecommendedFactMetricsModal.tsx
+++ b/packages/front-end/components/FactTables/RecommendedFactMetricsModal.tsx
@@ -191,6 +191,7 @@ export default function RecommendedFactMetricsModal({
             metricDefaults,
             project,
             settings,
+            convertToPercents: false,
             existing: {
               ...metrics[i],
               datasource: factTable.datasource,

--- a/packages/front-end/components/FactTables/RecommendedFactMetricsModal.tsx
+++ b/packages/front-end/components/FactTables/RecommendedFactMetricsModal.tsx
@@ -191,7 +191,6 @@ export default function RecommendedFactMetricsModal({
             metricDefaults,
             project,
             settings,
-            convertToPercents: false,
             existing: {
               ...metrics[i],
               datasource: factTable.datasource,


### PR DESCRIPTION
### Features and Changes

Fixes 2 bugs with fact metrics
1. If minSampleSize was set to `0`, editing and saving the metric was resetting it to the org default
2. When creating fact metrics through the new "Recommended" flow, percent settings (minRisk, minPercentChange, etc.) were being multiplied by 100