### PR TITLE
Base Radix badge component.

### DIFF
--- a/packages/front-end/components/Radix/Badge.tsx
+++ b/packages/front-end/components/Radix/Badge.tsx
@@ -1,0 +1,33 @@
+import { Flex, Badge as RadixBadge } from "@radix-ui/themes";
+import { MarginProps } from "@radix-ui/themes/dist/cjs/props/margin.props";
+import { RadixColor } from "@/components/Radix/HelperText";
+
+type Props = {
+  content: string;
+  color?: RadixColor;
+  variant?: "solid" | "soft" | "surface" | "outline";
+  highContrast?: boolean;
+  radius?: "none" | "small" | "medium" | "large" | "full";
+} & MarginProps;
+
+export default function Badge({
+  content,
+  color,
+  variant,
+  highContrast,
+  radius,
+  ...containerProps
+}: Props) {
+  return (
+    <Flex {...containerProps}>
+      <RadixBadge
+        color={color}
+        variant={variant}
+        highContrast={highContrast}
+        radius={radius}
+      >
+        {content}
+      </RadixBadge>
+    </Flex>
+  );
+}

--- a/packages/front-end/components/Radix/HelperText.tsx
+++ b/packages/front-end/components/Radix/HelperText.tsx
@@ -9,6 +9,8 @@ import {
 
 export type Status = "info" | "warning" | "error" | "success";
 
+export type RadixColor = TextProps["color"];
+
 export function getRadixColor(status: Status): TextProps["color"] {
   switch (status) {
     case "info":

--- a/packages/front-end/pages/design-system/index.tsx
+++ b/packages/front-end/pages/design-system/index.tsx
@@ -2,6 +2,7 @@ import { Flex } from "@radix-ui/themes";
 import { useState } from "react";
 import HelperText from "@/components/Radix/HelperText";
 import Checkbox from "@/components/Radix/Checkbox";
+import Badge from "@/components/Radix/Badge";
 
 export default function DesignSystemPage() {
   const [checked, setChecked] = useState(false);
@@ -22,6 +23,24 @@ export default function DesignSystemPage() {
           <HelperText status="warning">This is a warning message</HelperText>
           <HelperText status="error">This is an error message</HelperText>
           <HelperText status="success">This is a success message</HelperText>
+        </Flex>
+      </div>
+      <div className="appbox p-3">
+        <h3>Badge</h3>
+        <Flex direction="column" gap="3">
+          <Badge content="Label" />
+          <Badge content="Label" color="indigo" />
+          <Badge content="Label" color="cyan" />
+          <Badge content="Label" color="orange" />
+          <Badge content="Label" color="crimson" />
+          <Badge content="Label" variant="solid" />
+          <Badge content="Label" variant="surface" />
+          <Badge content="Label" variant="outline" />
+          <Badge content="Label" highContrast={true} />
+          <Badge content="Label" radius="small" />
+          <Badge content="Label" radius="medium" />
+          <Badge content="Label" radius="large" />
+          <Badge content="Label" radius="full" />
         </Flex>
       </div>
       <div className="appbox p-3">


### PR DESCRIPTION
This PR adds the base `Badge` component for Radix:

<img width="164" alt="Screenshot 2024-10-02 at 3 31 13 PM" src="https://github.com/user-attachments/assets/081e26fb-e30e-4152-89cc-5b31b83142e2">
<img width="112" alt="Screenshot 2024-10-02 at 3 31 21 PM" src="https://github.com/user-attachments/assets/84fd8f91-c387-424b-af83-428c254c9ce3">
