### PR TITLE
[Radix] Create wrapper around Radix Callout component

### DIFF
--- a/packages/front-end/components/InitialSetup/InitialSetup.module.scss
+++ b/packages/front-end/components/InitialSetup/InitialSetup.module.scss
@@ -1,7 +1,3 @@
-.setupPage p {
-  margin-bottom: 0;
-}
-
 .diagram {
   div:not(:last-child):after {
     content: "";

--- a/packages/front-end/components/InitialSetup/SelectDataSourcePage.tsx
+++ b/packages/front-end/components/InitialSetup/SelectDataSourcePage.tsx
@@ -1,13 +1,13 @@
-import { PiInfo, PiPaperPlaneTiltFill } from "react-icons/pi";
+import { PiPaperPlaneTiltFill } from "react-icons/pi";
 import { useState } from "react";
 import { SchemaFormat } from "back-end/types/datasource";
-import { Callout } from "@radix-ui/themes";
 import clsx from "clsx";
 import DataSourceLogo, {
   eventTrackerMapping,
 } from "@/components/DataSources/DataSourceLogo";
 import InviteModal from "@/components/Settings/Team/InviteModal";
 import { useUser } from "@/services/UserContext";
+import Callout from "@/components/Radix/Callout";
 import styles from "./InitialSetup.module.scss";
 
 interface Props {
@@ -29,10 +29,7 @@ const SelectDataSourcePage = ({ eventTracker, setEventTracker }: Props) => {
           defaultRole="analyst"
         />
       )}
-      <div
-        className={clsx(styles.setupPage, "mt-5")}
-        style={{ padding: "0px 57px" }}
-      >
+      <div className="mt-5" style={{ padding: "0px 57px" }}>
         <div className="d-flex mb-3">
           <h3 className="mb-0 align-self-center">Select your Event Tracker</h3>
 
@@ -49,16 +46,11 @@ const SelectDataSourcePage = ({ eventTracker, setEventTracker }: Props) => {
             </button>
           </div>
         </div>
-        <Callout.Root>
-          <Callout.Icon>
-            <PiInfo />
-          </Callout.Icon>
-          <Callout.Text>
-            To analyze experiment results, connect an event tracker and data
-            source. If using GrowthBook to manage feature flags only, feel free
-            to skip this step.
-          </Callout.Text>
-        </Callout.Root>
+        <Callout type="info">
+          To analyze experiment results, connect an event tracker and data
+          source. If using GrowthBook to manage feature flags only, feel free to
+          skip this step.
+        </Callout>
         <div className="row mt-3 mb-5">
           <div className="col-auto">
             <div

--- a/packages/front-end/components/InitialSetup/SelectDataSourcePage.tsx
+++ b/packages/front-end/components/InitialSetup/SelectDataSourcePage.tsx
@@ -46,7 +46,7 @@ const SelectDataSourcePage = ({ eventTracker, setEventTracker }: Props) => {
             </button>
           </div>
         </div>
-        <Callout type="info">
+        <Callout status="info">
           To analyze experiment results, connect an event tracker and data
           source. If using GrowthBook to manage feature flags only, feel free to
           skip this step.

--- a/packages/front-end/components/InitialSetup/VerifyConnectionPage.tsx
+++ b/packages/front-end/components/InitialSetup/VerifyConnectionPage.tsx
@@ -6,8 +6,8 @@ import {
   FaExclamationCircle,
   FaExclamationTriangle,
 } from "react-icons/fa";
-import { Callout, Link } from "@radix-ui/themes";
-import { PiArrowRight, PiInfo, PiPaperPlaneTiltFill } from "react-icons/pi";
+import { Link } from "@radix-ui/themes";
+import { PiArrowRight, PiPaperPlaneTiltFill } from "react-icons/pi";
 import clsx from "clsx";
 import LoadingOverlay from "@/components/LoadingOverlay";
 import { getApiBaseUrl } from "@/components/Features/CodeSnippetModal";
@@ -24,6 +24,7 @@ import CheckSDKConnectionModal from "@/components/GuidedGetStarted/CheckSDKConne
 import useSDKConnections from "@/hooks/useSDKConnections";
 import { DocLink } from "@/components/DocLink";
 import { languageMapping } from "@/components/Features/SDKConnections/SDKLanguageLogo";
+import Callout from "@/components/Radix/Callout";
 import styles from "./InitialSetup.module.scss";
 
 interface Props {
@@ -120,19 +121,13 @@ const VerifyConnectionPage = ({
           <DocLink docSection={docs}>
             View documentation <PiArrowRight />
           </DocLink>
-          <Callout.Root className="mt-3">
-            <Callout.Icon>
-              <PiInfo />
-            </Callout.Icon>
-            <Callout.Text>
-              <>
-                Each environment requires its own SDK connection. Add more
-                environments via <b>SDK Configuration {">"} Environments</b>.
-                Then, create the SDK connection for each environment.
-              </>
-            </Callout.Text>
-          </Callout.Root>
-
+          <div className="mt-3">
+            <Callout type="info">
+              Each environment requires its own SDK connection. Add more
+              environments via <b>SDK Configuration {">"} Environments</b>.
+              Then, create the SDK connection for each environment.
+            </Callout>
+          </div>
           <div className="mt-4 mb-3">
             <h4
               className="cursor-pointer"

--- a/packages/front-end/components/InitialSetup/VerifyConnectionPage.tsx
+++ b/packages/front-end/components/InitialSetup/VerifyConnectionPage.tsx
@@ -122,7 +122,7 @@ const VerifyConnectionPage = ({
             View documentation <PiArrowRight />
           </DocLink>
           <div className="mt-3">
-            <Callout type="info">
+            <Callout status="info">
               Each environment requires its own SDK connection. Add more
               environments via <b>SDK Configuration {">"} Environments</b>.
               Then, create the SDK connection for each environment.

--- a/packages/front-end/components/InitialSetup/VerifyConnectionPage.tsx
+++ b/packages/front-end/components/InitialSetup/VerifyConnectionPage.tsx
@@ -121,13 +121,11 @@ const VerifyConnectionPage = ({
           <DocLink docSection={docs}>
             View documentation <PiArrowRight />
           </DocLink>
-          <div className="mt-3">
-            <Callout status="info">
-              Each environment requires its own SDK connection. Add more
-              environments via <b>SDK Configuration {">"} Environments</b>.
-              Then, create the SDK connection for each environment.
-            </Callout>
-          </div>
+          <Callout status="info" mt="3">
+            Each environment requires its own SDK connection. Add more
+            environments via <b>SDK Configuration {">"} Environments</b>. Then,
+            create the SDK connection for each environment.
+          </Callout>
           <div className="mt-4 mb-3">
             <h4
               className="cursor-pointer"

--- a/packages/front-end/components/Radix/Callout.tsx
+++ b/packages/front-end/components/Radix/Callout.tsx
@@ -1,20 +1,25 @@
 import { Callout as RadixCallout } from "@radix-ui/themes";
 import { ReactNode } from "react";
+import { MarginProps } from "@radix-ui/themes/dist/cjs/props/margin.props";
 import { RadixStatusIcon, Status, getRadixColor } from "./HelperText";
 import styles from "./RadixOverrides.module.scss";
+
+type Props = {
+  children: ReactNode;
+  status: Status;
+} & MarginProps;
 
 export default function Callout({
   children,
   status,
-}: {
-  children: ReactNode;
-  status: Status;
-}) {
+  ...containerProps
+}: Props) {
   return (
     <RadixCallout.Root
       className={styles.callout}
       color={getRadixColor(status)}
       role={status === "error" ? "alert" : undefined}
+      {...containerProps}
     >
       <RadixCallout.Icon>
         <RadixStatusIcon status={status} />

--- a/packages/front-end/components/Radix/Callout.tsx
+++ b/packages/front-end/components/Radix/Callout.tsx
@@ -5,19 +5,19 @@ import styles from "./RadixOverrides.module.scss";
 
 export default function Callout({
   children,
-  type,
+  status,
 }: {
   children: ReactNode;
-  type: Status;
+  status: Status;
 }) {
   return (
     <RadixCallout.Root
       className={styles.callout}
-      color={getRadixColor(type)}
-      role={type === "error" ? "alert" : undefined}
+      color={getRadixColor(status)}
+      role={status === "error" ? "alert" : undefined}
     >
       <RadixCallout.Icon>
-        <RadixStatusIcon status={type} />
+        <RadixStatusIcon status={status} />
       </RadixCallout.Icon>
       <RadixCallout.Text>{children}</RadixCallout.Text>
     </RadixCallout.Root>

--- a/packages/front-end/components/Radix/Callout.tsx
+++ b/packages/front-end/components/Radix/Callout.tsx
@@ -1,0 +1,25 @@
+import { Callout as RadixCallout } from "@radix-ui/themes";
+import { ReactNode } from "react";
+import { RadixStatusIcon, Status, getRadixColor } from "./HelperText";
+import styles from "./RadixOverrides.module.scss";
+
+export default function Callout({
+  children,
+  type,
+}: {
+  children: ReactNode;
+  type: Status;
+}) {
+  return (
+    <RadixCallout.Root
+      className={styles.callout}
+      color={getRadixColor(type)}
+      role={type === "error" ? "alert" : undefined}
+    >
+      <RadixCallout.Icon>
+        <RadixStatusIcon status={type} />
+      </RadixCallout.Icon>
+      <RadixCallout.Text>{children}</RadixCallout.Text>
+    </RadixCallout.Root>
+  );
+}

--- a/packages/front-end/components/Radix/RadixOverrides.module.scss
+++ b/packages/front-end/components/Radix/RadixOverrides.module.scss
@@ -1,0 +1,3 @@
+.callout p {
+  margin-bottom: 0;
+}

--- a/packages/front-end/pages/design-system/index.tsx
+++ b/packages/front-end/pages/design-system/index.tsx
@@ -19,10 +19,10 @@ export default function DesignSystemPage() {
       <div className="appbox p-3">
         <h3>Callout</h3>
         <Flex direction="column" gap="3">
-          <Callout type="info">This is an informational callout.</Callout>
-          <Callout type="warning">This is a warning callout.</Callout>
-          <Callout type="error">This is an error callout.</Callout>
-          <Callout type="success">This is a success callout.</Callout>
+          <Callout status="info">This is an informational callout.</Callout>
+          <Callout status="warning">This is a warning callout.</Callout>
+          <Callout status="error">This is an error callout.</Callout>
+          <Callout status="success">This is a success callout.</Callout>
         </Flex>
       </div>
       <div className="appbox p-3">

--- a/packages/front-end/pages/design-system/index.tsx
+++ b/packages/front-end/pages/design-system/index.tsx
@@ -2,6 +2,7 @@ import { Flex } from "@radix-ui/themes";
 import { useState } from "react";
 import HelperText from "@/components/Radix/HelperText";
 import Checkbox from "@/components/Radix/Checkbox";
+import Callout from "@/components/Radix/Callout";
 
 export default function DesignSystemPage() {
   const [checked, setChecked] = useState(false);
@@ -16,12 +17,12 @@ export default function DesignSystemPage() {
 
       <h2>Components</h2>
       <div className="appbox p-3">
-        <h3>HelperText</h3>
+        <h3>Callout</h3>
         <Flex direction="column" gap="3">
-          <HelperText status="info">This is an info message</HelperText>
-          <HelperText status="warning">This is a warning message</HelperText>
-          <HelperText status="error">This is an error message</HelperText>
-          <HelperText status="success">This is a success message</HelperText>
+          <Callout type="info">This is an informational callout.</Callout>
+          <Callout type="warning">This is a warning callout.</Callout>
+          <Callout type="error">This is an error callout.</Callout>
+          <Callout type="success">This is a success callout.</Callout>
         </Flex>
       </div>
       <div className="appbox p-3">
@@ -68,6 +69,15 @@ export default function DesignSystemPage() {
             }}
             disabled
           />
+        </Flex>
+      </div>
+      <div className="appbox p-3">
+        <h3>HelperText</h3>
+        <Flex direction="column" gap="3">
+          <HelperText status="info">This is an info message</HelperText>
+          <HelperText status="warning">This is a warning message</HelperText>
+          <HelperText status="error">This is an error message</HelperText>
+          <HelperText status="success">This is a success message</HelperText>
         </Flex>
       </div>
     </div>


### PR DESCRIPTION
### Features and Changes

Creates a wrapped Radix Callout component based on our design system. Replaced both uses of the Radix Callout component in the new setup flow with our new wrapped component.

I also went ahead and alphabetized the existing components on the design system page to make it easier to find them in the future.

### Screenshots

![Screenshot 2024-10-02 at 1 48 50 PM](https://github.com/user-attachments/assets/ba7b1682-c269-46f1-bfd3-bf6b77a055f6)

