### PR TITLE
Block dimension analyses from firing significance events

### DIFF
--- a/packages/back-end/src/services/experimentNotifications.ts
+++ b/packages/back-end/src/services/experimentNotifications.ts
@@ -418,6 +418,9 @@ export const notifyExperimentChange = async ({
   const experiment = await getExperimentById(context, snapshot.experiment);
   if (!experiment) throw new Error("Error while fetching experiment!");
 
+  // do not fire significance or error events for dimension analyses
+  if (snapshot.dimension) return;
+
   await notifySignificance({ context, experiment, snapshot });
 
   const results = getDefaultAnalysisResults(snapshot);


### PR DESCRIPTION
### Features and Changes

Do not fire `experiment.info.significance` or `experiment.warning` events for dimensional analyses.

### Testing

* On main, get an experiment with a stat sig metric
* Delete all snapshots so it will notify
* If I do a dimension analysis, it notifies

* Switch to this branch, delete that old snapshot from mongo
* Run dimension analysis, no notification
* Non-dimension analysis notifies!

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
