### PR TITLE
Add snapshot type and configure notifications

### DIFF
--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -1799,15 +1799,15 @@ function getSnapshotType({
 }): SnapshotType {
   // dimension analyses are ad-hoc
   if (dimension) {
-    return "ad-hoc";
+    return "exploratory";
   }
 
   // analyses of old phases are ad-hoc
   if (phaseIndex !== experiment.phases.length - 1) {
-    return "ad-hoc";
+    return "exploratory";
   }
 
-  return "manual";
+  return "standard";
 }
 
 async function createExperimentSnapshot({
@@ -1895,6 +1895,7 @@ async function createExperimentSnapshot({
     metricMap,
     factTableMap,
     type: snapshotType,
+    triggeredBy: "manual"
   });
   const snapshot = queryRunner.model;
 

--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -92,6 +92,7 @@ import {
 import {
   ExperimentSnapshotAnalysisSettings,
   ExperimentSnapshotInterface,
+  SnapshotType,
 } from "back-end/types/experiment-snapshot";
 import { VisualChangesetInterface } from "back-end/types/visual-changeset";
 import { ApiReqContext, PrivateApiErrorResponse } from "back-end/types/api";
@@ -1787,6 +1788,28 @@ export async function cancelSnapshot(
   res.status(200).json({ status: 200 });
 }
 
+function getSnapshotType({
+  experiment,
+  dimension,
+  phaseIndex,
+}: {
+  experiment: ExperimentInterface;
+  dimension: string | undefined;
+  phaseIndex: number;
+}): SnapshotType {
+  // dimension analyses are ad-hoc
+  if (dimension) {
+    return "ad-hoc";
+  }
+
+  // analyses of old phases are ad-hoc
+  if (phaseIndex !== experiment.phases.length - 1) {
+    return "ad-hoc";
+  }
+
+  return "manual";
+}
+
 async function createExperimentSnapshot({
   context,
   experiment,
@@ -1851,7 +1874,11 @@ async function createExperimentSnapshot({
     dimension
   );
 
-  const snapshotType = dimension ? "ad-hoc" : "manual";
+  const snapshotType = getSnapshotType({
+    experiment,
+    dimension,
+    phaseIndex: phase,
+  });
 
   const factTableMap = await getFactTableMap(context);
 

--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -1851,6 +1851,8 @@ async function createExperimentSnapshot({
     dimension
   );
 
+  const snapshotType = dimension ? "ad-hoc" : "manual";
+
   const factTableMap = await getFactTableMap(context);
 
   const queryRunner = await createSnapshot({
@@ -1865,6 +1867,7 @@ async function createExperimentSnapshot({
     settingsForSnapshotMetrics,
     metricMap,
     factTableMap,
+    type: snapshotType,
   });
   const snapshot = queryRunner.model;
 

--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -1895,7 +1895,7 @@ async function createExperimentSnapshot({
     metricMap,
     factTableMap,
     type: snapshotType,
-    triggeredBy: "manual"
+    triggeredBy: "manual",
   });
   const snapshot = queryRunner.model;
 
@@ -2102,16 +2102,13 @@ export async function postSnapshotAnalysis(
   const metricMap = await getMetricMap(context);
 
   try {
-    await createSnapshotAnalysis(
-      {
-        experiment: experiment,
-        organization: org,
-        analysisSettings: analysisSettings,
-        metricMap: metricMap,
-        snapshot: snapshot,
-      },
-      context
-    );
+    await createSnapshotAnalysis({
+      experiment: experiment,
+      organization: org,
+      analysisSettings: analysisSettings,
+      metricMap: metricMap,
+      snapshot: snapshot,
+    });
     res.status(200).json({
       status: 200,
     });

--- a/packages/back-end/src/jobs/updateExperimentResults.ts
+++ b/packages/back-end/src/jobs/updateExperimentResults.ts
@@ -170,6 +170,7 @@ async function updateSingleExperiment(job: UpdateSingleExpJob) {
       metricMap,
       factTableMap,
       useCache: true,
+      type: "standard",
     });
     await queryRunner.waitForResults();
 

--- a/packages/back-end/src/jobs/updateExperimentResults.ts
+++ b/packages/back-end/src/jobs/updateExperimentResults.ts
@@ -171,6 +171,7 @@ async function updateSingleExperiment(job: UpdateSingleExpJob) {
       factTableMap,
       useCache: true,
       type: "standard",
+      triggeredBy: "schedule",
     });
     await queryRunner.waitForResults();
 

--- a/packages/back-end/src/models/ExperimentSnapshotModel.ts
+++ b/packages/back-end/src/models/ExperimentSnapshotModel.ts
@@ -26,6 +26,7 @@ const experimentSnapshotSchema = new mongoose.Schema({
   experiment: String,
   phase: Number,
   type: { type: String },
+  triggeredBy: String,
   dateCreated: Date,
   runStarted: Date,
   manual: Boolean,
@@ -232,12 +233,10 @@ export async function updateSnapshotAnalysis({
   organization,
   id,
   analysis,
-  context,
 }: {
   organization: string;
   id: string;
   analysis: ExperimentSnapshotAnalysis;
-  context: Context;
 }) {
   await ExperimentSnapshotModel.updateOne(
     {
@@ -256,10 +255,12 @@ export async function updateSnapshotAnalysis({
   });
   if (!experimentSnapshotModel) throw "Internal error";
 
-  await notifyExperimentChange({
-    context,
-    snapshot: experimentSnapshotModel,
-  });
+  // Not notifying on new analysis because new analyses in an existing snapshot
+  // are akin to ad-hoc snapshots
+  // await notifyExperimentChange({
+  //   context,
+  //   snapshot: experimentSnapshotModel,
+  // });
 }
 
 export async function deleteSnapshotById(organization: string, id: string) {

--- a/packages/back-end/src/models/ExperimentSnapshotModel.ts
+++ b/packages/back-end/src/models/ExperimentSnapshotModel.ts
@@ -204,13 +204,12 @@ export type AddOrUpdateSnapshotAnalysisParams = {
   organization: string;
   id: string;
   analysis: ExperimentSnapshotAnalysis;
-  context: Context;
 };
 
 export async function addOrUpdateSnapshotAnalysis(
   params: AddOrUpdateSnapshotAnalysisParams
 ) {
-  const { organization, id, analysis, context } = params;
+  const { organization, id, analysis } = params;
   // looks for snapshots with this ID but WITHOUT these analysis settings
   const experimentSnapshotModel = await ExperimentSnapshotModel.updateOne(
     {
@@ -225,7 +224,7 @@ export async function addOrUpdateSnapshotAnalysis(
   // if analysis already exist, no documents will be returned by above query
   // so instead find and update existing analysis in DB
   if (experimentSnapshotModel.matchedCount === 0) {
-    await updateSnapshotAnalysis({ organization, id, analysis, context });
+    await updateSnapshotAnalysis({ organization, id, analysis });
   }
 }
 

--- a/packages/back-end/src/routers/demo-datasource-project/demo-datasource-project.controller.ts
+++ b/packages/back-end/src/routers/demo-datasource-project/demo-datasource-project.controller.ts
@@ -423,6 +423,7 @@ spacing and headings.`,
       factTableMap,
       useCache: true,
       type: "standard",
+      triggeredBy: "manual",
     });
 
     res.status(200).json({

--- a/packages/back-end/src/routers/demo-datasource-project/demo-datasource-project.controller.ts
+++ b/packages/back-end/src/routers/demo-datasource-project/demo-datasource-project.controller.ts
@@ -422,6 +422,7 @@ spacing and headings.`,
       metricMap: metricMap,
       factTableMap,
       useCache: true,
+      type: "standard",
     });
 
     res.status(200).json({

--- a/packages/back-end/src/services/experimentNotifications.ts
+++ b/packages/back-end/src/services/experimentNotifications.ts
@@ -390,8 +390,8 @@ export const notifySignificance = async ({
 
   if (!experimentChanges.length) return;
 
-  // send email if enabled and the snapshot is standard
-  if (isEmailEnabled() && snapshot.type === "standard")
+  // send email if enabled and the snapshot is scheduled standard analysis
+  if (isEmailEnabled() && snapshot.triggeredBy === "schedule" && snapshot.type === "standard")
     await sendSignificanceEmail(experiment, experimentChanges);
 
   await Promise.all(
@@ -418,10 +418,12 @@ export const notifyExperimentChange = async ({
   const experiment = await getExperimentById(context, snapshot.experiment);
   if (!experiment) throw new Error("Error while fetching experiment!");
 
-  // do not fire significance or error events for ad-hoc analyses
-  if (snapshot.type === "ad-hoc") return;
+  // do not fire significance or error events for exploratory analyses
+  if (snapshot.type === "exploratory") return;
   // do not fire significance events for old snapshots that have no type
   if (snapshot.type === undefined) return;
+  // do not fire for snapshots where statistics are manually entered in the UI
+  if (snapshot.manual) return;
 
   await notifySignificance({ context, experiment, snapshot });
 

--- a/packages/back-end/src/services/experimentNotifications.ts
+++ b/packages/back-end/src/services/experimentNotifications.ts
@@ -420,6 +420,8 @@ export const notifyExperimentChange = async ({
 
   // do not fire significance or error events for ad-hoc analyses
   if (snapshot.type === "ad-hoc") return;
+  // do not fire significance events for old snapshots that have no type
+  if (snapshot.type === undefined) return;
 
   await notifySignificance({ context, experiment, snapshot });
 

--- a/packages/back-end/src/services/experimentNotifications.ts
+++ b/packages/back-end/src/services/experimentNotifications.ts
@@ -391,8 +391,13 @@ export const notifySignificance = async ({
   if (!experimentChanges.length) return;
 
   // send email if enabled and the snapshot is scheduled standard analysis
-  if (isEmailEnabled() && snapshot.triggeredBy === "schedule" && snapshot.type === "standard")
+  if (
+    isEmailEnabled() &&
+    snapshot.triggeredBy === "schedule" &&
+    snapshot.type === "standard"
+  ) {
     await sendSignificanceEmail(experiment, experimentChanges);
+  }
 
   await Promise.all(
     experimentChanges.map((change) =>

--- a/packages/back-end/src/services/experimentNotifications.ts
+++ b/packages/back-end/src/services/experimentNotifications.ts
@@ -419,7 +419,7 @@ export const notifyExperimentChange = async ({
   if (!experiment) throw new Error("Error while fetching experiment!");
 
   // do not fire significance or error events for ad-hoc analyses
-  if ((snapshot.type ?? "manual") === "ad-hoc") return;
+  if (snapshot.type === "ad-hoc") return;
 
   await notifySignificance({ context, experiment, snapshot });
 

--- a/packages/back-end/src/services/experimentNotifications.ts
+++ b/packages/back-end/src/services/experimentNotifications.ts
@@ -390,8 +390,8 @@ export const notifySignificance = async ({
 
   if (!experimentChanges.length) return;
 
-  // If email is not configured, there's nothing else to do
-  if (isEmailEnabled())
+  // send email if enabled and the snapshot is standard
+  if (isEmailEnabled() && snapshot.type === "standard")
     await sendSignificanceEmail(experiment, experimentChanges);
 
   await Promise.all(
@@ -418,8 +418,8 @@ export const notifyExperimentChange = async ({
   const experiment = await getExperimentById(context, snapshot.experiment);
   if (!experiment) throw new Error("Error while fetching experiment!");
 
-  // do not fire significance or error events for dimension analyses
-  if (snapshot.dimension) return;
+  // do not fire significance or error events for ad-hoc analyses
+  if ((snapshot.type ?? "manual") === "ad-hoc") return;
 
   await notifySignificance({ context, experiment, snapshot });
 

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -43,6 +43,7 @@ import {
   ExperimentSnapshotAnalysisSettings,
   ExperimentSnapshotInterface,
   ExperimentSnapshotSettings,
+  SnapshotType,
   SnapshotVariation,
 } from "back-end/types/experiment-snapshot";
 import {
@@ -580,6 +581,7 @@ export function determineNextDate(schedule: ExperimentUpdateSchedule | null) {
 export async function createSnapshot({
   experiment,
   context,
+  type,
   phaseIndex,
   useCache = false,
   defaultAnalysisSettings,
@@ -590,6 +592,7 @@ export async function createSnapshot({
 }: {
   experiment: ExperimentInterface;
   context: ReqContext | ApiReqContext;
+  type: SnapshotType;
   phaseIndex: number;
   useCache?: boolean;
   defaultAnalysisSettings: ExperimentSnapshotAnalysisSettings;
@@ -621,6 +624,7 @@ export async function createSnapshot({
     queries: [],
     dimension: dimension || null,
     settings: snapshotSettings,
+    type: type,
     unknownVariations: [],
     multipleExposures: 0,
     analyses: [

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -778,7 +778,6 @@ async function getSnapshotAnalyses(
           organization: organization.id,
           id: snapshot.id,
           analysis,
-          context,
         })
       );
 
@@ -845,12 +844,11 @@ export async function createSnapshotAnalyses(
   );
 
   // parses results and writes to mongo
-  await writeSnapshotAnalyses(results, analysisParamsMap, context);
+  await writeSnapshotAnalyses(results, analysisParamsMap);
 }
 
 export async function createSnapshotAnalysis(
-  params: SnapshotAnalysisParams,
-  context: Context
+  params: SnapshotAnalysisParams
 ): Promise<void> {
   const {
     snapshot,
@@ -882,7 +880,6 @@ export async function createSnapshotAnalysis(
     organization: organization.id,
     id: snapshot.id,
     analysis,
-    context,
   });
 
   // Format data correctly
@@ -907,7 +904,6 @@ export async function createSnapshotAnalysis(
     organization: organization.id,
     id: snapshot.id,
     analysis,
-    context,
   });
 }
 

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -43,6 +43,7 @@ import {
   ExperimentSnapshotAnalysisSettings,
   ExperimentSnapshotInterface,
   ExperimentSnapshotSettings,
+  SnapshotTriggeredBy,
   SnapshotType,
   SnapshotVariation,
 } from "back-end/types/experiment-snapshot";
@@ -582,6 +583,7 @@ export async function createSnapshot({
   experiment,
   context,
   type,
+  triggeredBy,
   phaseIndex,
   useCache = false,
   defaultAnalysisSettings,
@@ -593,6 +595,7 @@ export async function createSnapshot({
   experiment: ExperimentInterface;
   context: ReqContext | ApiReqContext;
   type: SnapshotType;
+  triggeredBy: SnapshotTriggeredBy;
   phaseIndex: number;
   useCache?: boolean;
   defaultAnalysisSettings: ExperimentSnapshotAnalysisSettings;
@@ -625,6 +628,7 @@ export async function createSnapshot({
     dimension: dimension || null,
     settings: snapshotSettings,
     type: type,
+    triggeredBy: triggeredBy,
     unknownVariations: [],
     multipleExposures: 0,
     analyses: [

--- a/packages/back-end/src/services/stats.ts
+++ b/packages/back-end/src/services/stats.ts
@@ -33,7 +33,6 @@ import {
   ExperimentReportResults,
   ExperimentReportVariation,
 } from "back-end/types/report";
-import { ReqContext } from "back-end/types/organization";
 import { checkSrm } from "back-end/src/util/stats";
 import { promiseAllChunks } from "back-end/src/util/promise";
 import { logger } from "back-end/src/util/logger";
@@ -529,8 +528,7 @@ function parseStatsEngineResult(
 
 export async function writeSnapshotAnalyses(
   results: MultipleExperimentMetricAnalysis[],
-  paramsMap: Map<string, ExperimentAnalysisParamsContextData>,
-  context: ReqContext
+  paramsMap: Map<string, ExperimentAnalysisParamsContextData>
 ) {
   const promises: (() => Promise<void>)[] = [];
   results.map((result) => {
@@ -564,7 +562,6 @@ export async function writeSnapshotAnalyses(
         organization,
         id: snapshot,
         analysis: analysisObj,
-        context,
       })
     );
   });

--- a/packages/back-end/types/experiment-snapshot.d.ts
+++ b/packages/back-end/types/experiment-snapshot.d.ts
@@ -127,7 +127,8 @@ export interface SnapshotSettingsVariation {
   weight: number;
 }
 
-export type SnapshotType = "standard" | "ad-hoc" | "manual"; // todo: add "report" type?
+export type SnapshotType = "standard" | "exploratory";
+export type SnapshotTriggeredBy = "schedule" | "manual";
 
 // Settings that control which queries are run
 // Used to determine which types of analyses are possible
@@ -170,6 +171,7 @@ export interface ExperimentSnapshotInterface {
   status: "running" | "success" | "error";
   settings: ExperimentSnapshotSettings;
   type?: SnapshotType;
+  triggeredBy?: SnapshotTriggeredBy;
 
   // List of queries that were run as part of this snapshot
   queries: Queries;

--- a/packages/back-end/types/experiment-snapshot.d.ts
+++ b/packages/back-end/types/experiment-snapshot.d.ts
@@ -127,6 +127,8 @@ export interface SnapshotSettingsVariation {
   weight: number;
 }
 
+export type SnapshotType = "standard" | "ad-hoc" | "manual"; // todo: add "report" type?
+
 // Settings that control which queries are run
 // Used to determine which types of analyses are possible
 // Also used to determine when to show "out-of-date" in the UI
@@ -167,6 +169,7 @@ export interface ExperimentSnapshotInterface {
   runStarted: Date | null;
   status: "running" | "success" | "error";
   settings: ExperimentSnapshotSettings;
+  type?: SnapshotType;
 
   // List of queries that were run as part of this snapshot
   queries: Queries;


### PR DESCRIPTION
### Features and Changes

Adds a snapshot type to each snapshot:
* "standard" <- default analysis settings for that snapshot
* "exploratory" <- some custom exploratory (old phase or dimension slice) analysis

Adds `triggeredBy` field to designate how the snapshot was created:
* "scheduled" <- triggered by agenda job
* "manual" <- triggered by user action in the UI (refresh, importing existing experiment)

Also tweaks significance emails to only send for "scheduled", "standard" updates.

Webhooks still fire for all "standard" updates (whether scheduled or manual).

Also stops checking significance when new analyses are added to an existing snapshot.

### Testing


TESTS BELOW ARE OLD, BUT WERE REPEATED WITH NEW FIELDS ABOVE

Manual refresh sets type manul
<img width="439" alt="Screenshot 2024-10-03 at 10 20 57 AM" src="https://github.com/user-attachments/assets/71c1318b-b97e-470e-9b1b-d5d12512cea2">

Dimension refresh sets type adhoc
<img width="453" alt="Screenshot 2024-10-03 at 10 21 13 AM" src="https://github.com/user-attachments/assets/8d6d5d19-1d59-4c95-8a50-b3aa15d191f9">

Adding a phase1 and then going back to phase0 and refreshing sets type adhoc
<img width="463" alt="Screenshot 2024-10-03 at 10 21 46 AM" src="https://github.com/user-attachments/assets/b0db9368-ace0-40b3-8490-6b18fdcc7ce7">

Scheduled update sets type standard
<img width="495" alt="Screenshot 2024-10-03 at 10 27 27 AM" src="https://github.com/user-attachments/assets/651e5052-a480-49e9-ba9e-9d216f6926fe">

confirmed events don't fire for ad-hoc analyses

still can't confirm emails send, waiting for auto-update
