### PR TITLE
Use correct path for logo mark

### DIFF
--- a/packages/front-end/components/InitialSetup/SelectDataSourcePage.tsx
+++ b/packages/front-end/components/InitialSetup/SelectDataSourcePage.tsx
@@ -118,7 +118,7 @@ const SelectDataSourcePage = ({ eventTracker, setEventTracker }: Props) => {
               style={{ maxWidth: 325 }}
             >
               <img
-                src="/logo/logo-mark.png"
+                src="/logo/Logo-mark.png"
                 style={{ width: 40 }}
                 alt="GrowthBook"
               />


### PR DESCRIPTION
### Features and Changes

Fixes image path for the GrowthBook logo mark used for the datasource diagram in the setup flow. Linux file paths are case sensitive and Mac file paths aren't so this wasn't caught during local development.
