### PR TITLE
Documentation for self-hosted CDNs

### DIFF
--- a/docs/docs/api-overview.mdx
+++ b/docs/docs/api-overview.mdx
@@ -17,7 +17,7 @@ In addition to the REST API above, there is one additional readonly endpoint - t
 
 The SDK Connection Endpoint provides readonly access to a subset of your feature flag data, just enough for the [GrowthBook SDKs](/lib) to assign values to users. They are meant to be public and do not require authentication to view.
 
-In **GrowthBook Cloud**, the SDK Connection Endpoints are served from our global CDN: `https://cdn.growthbook.io/api/features/...`. If you are self-hosting, you can run the [GrowthBook Proxy server](/self-host/proxy), which provides built-in caching and performance optimizations.
+In **GrowthBook Cloud**, the SDK Connection Endpoints are served from our global CDN: `https://cdn.growthbook.io/api/features/...`. If you are self-hosting, you can use [your own CDN](/self-host/cdn) or run the [GrowthBook Proxy server](/self-host/proxy), which provides built-in caching and performance optimizations.
 
 SDK Connection Endpoints are scoped to a single Environment (e.g. `dev` or `production`) and can also be scoped to a single Project. Manage all of your SDK Connections on the **Features → SDKs** page.
 

--- a/docs/docs/faq.mdx
+++ b/docs/docs/faq.mdx
@@ -105,7 +105,7 @@ The GrowthBook application is very lightweight and efficient. For most usecases,
 
 GrowthBook only deals with aggregate data and the bulk of the processing is offloaded to your data source. Because of this, you can easily analyze terrabytes of data from your laptop or a small container in the cloud.
 
-If you are using feature flags, **we strongly recommend** adding a caching layer between the GrowthBook API and your application in production. This will also help you stay within the limits of our [Fair Use Policy](https://www.growthbook.io/fair-use). Some of our [code examples](https://github.com/growthbook/examples) implement caching. We offer a pre-built [GrowthBook Proxy server](/self-host/proxy) you can run that handles caching and invalidation automatically. You can also setup your own custom system using a CDN or distributed cache like Redis.
+If you are using feature flags, **we strongly recommend** adding a caching layer between the GrowthBook API and your application in production. This will also help you stay within the limits of our [Fair Use Policy](https://www.growthbook.io/fair-use). Some of our [code examples](https://github.com/growthbook/examples) implement caching. We offer a pre-built [GrowthBook Proxy server](/self-host/proxy) you can run that handles caching and invalidation automatically. You can also setup [your own CDN](/self-host/cdn) or distributed cache like Redis.
 
 ## I can't upload to S3/getting 400 error when uploading to S3?
 

--- a/docs/docs/self-host/cdn.mdx
+++ b/docs/docs/self-host/cdn.mdx
@@ -1,7 +1,7 @@
 ---
 title: Using a CDN
 description: Adding a CDN in front of GrowthBook is a cheap and easy way to scale
-sidebar_label: GrowthBook CDN
+sidebar_label: Using a CDN
 slug: cdn
 ---
 
@@ -38,11 +38,15 @@ public, max-age=30, stale-while-revalidate=3600, stale-if-error=36000
 
 This will serve all requests from cache and refresh in the background every 30 seconds. You can override these settings in your CDN if desired.
 
-**Important**: Make sure to block all other routes besides `/api/features/*`. This will greatly increase security by limiting the potential attack surface.
+**Important**: Make sure to block all other routes besides `/api/features/*`. Doing this will greatly increase security by limiting the potential attack surface.
 
 ### Health Checks
 
 The GrowthBook API server exposes a `/healthcheck` route. You can optionally use this in your CDN so it can tell if your origin server goes down.
+
+## SDK Configuration
+
+Most of our SDKs accept an `apiHost` setting. Simply change this from your GrowthBook API server to the new CDN domain.
 
 ## Purging / Invalidation
 

--- a/docs/docs/self-host/cdn.mdx
+++ b/docs/docs/self-host/cdn.mdx
@@ -1,0 +1,66 @@
+---
+title: Using a CDN
+description: Adding a CDN in front of GrowthBook is a cheap and easy way to scale
+sidebar_label: GrowthBook CDN
+slug: cdn
+---
+
+# Using a CDN
+
+You can add a CDN in between your GrowthBook SDKs and your GrowthBook API Server. This will act as a caching layer when serving feature flags and enable virtually limitless scaling with very low maintenance costs.
+
+All major CDNs are supported including Cloudflare, Fastly, Akamai, CloudFront, Azure Front Door, and Google Cloud CDN.
+
+Using a CDN is a quick and easy solution to scaling. If you want more power and control, we recommend deploying our [GrowthBook Proxy Server](/self-host/proxy) instead.
+
+::: note
+
+GrowthBook Cloud provides its own CDN for free for low/medium traffic apps (less than 10 million requests per month). If you plan to go above that limit, this guide will work for you as well. Just use `https://cdn.growthbook.io` as your Origin instead of a self-hosted GrowthBook API server.
+
+:::
+
+## How it Works
+
+1. Add a CDN that sits in front of your GrowthBook API server
+2. Configure the CDN to cache requests to `/api/features/*` (and deny all other routes)
+3. Point your SDKs to your CDN's domain instead of your GrowthBook API Server
+4. (optional) Configure a Webhook to invalidate the CDN cache when features change within GrowthBook
+
+## Configuring your CDN
+
+### Caching Rules
+
+The `/api/features/*` route includes a default `Cache-control` header that should work out-of-the-box for most CDNs:
+
+```
+public, max-age=30, stale-while-revalidate=3600, stale-if-error=36000
+```
+
+This will serve all requests from cache and refresh in the background every 30 seconds. You can override these settings in your CDN if desired.
+
+**Important**: Make sure to block all other routes besides `/api/features/*`. This will greatly increase security by limiting the potential attack surface.
+
+### Health Checks
+
+The GrowthBook API server exposes a `/healthcheck` route. You can optionally use this in your CDN so it can tell if your origin server goes down.
+
+## Purging / Invalidation
+
+When you make changes withing GrowthBook, the CDN will not pick up the changes until it refreshes its cache (default 30 seconds).
+
+For most apps, this short delay is perfectly fine. If you want faster rollouts, you can have GrowthBook tell your CDN to refresh as soon as changes are made.
+
+### Fastly
+
+If you use Fastly as your CDN and are self-hosting GrowthBook, you can set the following environment variables to automatically purge URLs:
+
+- `FASTLY_SERVICE_ID`
+- `FASTLY_API_TOKEN`
+
+### HTTP PURGE Requests
+
+If your CDN supports invalidaing URLs with simple HTTP PURGE requests, you can add an [SDK Webhook](/app/webhooks/sdk-webhooks) in GrowthBook and set the method as PURGE with no payload.
+
+### Other
+
+If the methods above are not available for your CDN, you can configure a custom [SDK Webhook](/app/webhooks/sdk-webhooks). We let you customize the HTTP method and headers, but if you need more control, you may need to set up a custom script that sits between the webhook and the CDN.

--- a/docs/docs/self-host/cdn.mdx
+++ b/docs/docs/self-host/cdn.mdx
@@ -13,7 +13,7 @@ All major CDNs are supported including Cloudflare, Fastly, Akamai, CloudFront, A
 
 Using a CDN is a quick and easy solution to scaling. If you want more power and control, we recommend deploying our [GrowthBook Proxy Server](/self-host/proxy) instead.
 
-::: note
+:::note
 
 GrowthBook Cloud provides its own CDN for free for low/medium traffic apps (less than 10 million requests per month). If you plan to go above that limit, this guide will work for you as well. Just use `https://cdn.growthbook.io` as your Origin instead of a self-hosted GrowthBook API server.
 

--- a/docs/docs/self-host/production.mdx
+++ b/docs/docs/self-host/production.mdx
@@ -37,7 +37,7 @@ The most secure thing you can do is to put your entire GrowthBook deployment beh
 If you are using GrowthBook to serve feature flags to client-side apps, you will need some way for your end users to download the feature flag payload outside of the firewall or VPN. There are a few secure approaches for this:
 
 1. Use a [**GrowthBook Proxy**](/self-host/proxy) server. This way, your main GrowthBook instance can remain on a private subnet and only the Proxy needs to be exposed to the internet. The Proxy has a very small attack surface compared to the full GrowthBook app.
-2. Use a **CDN**. If you go this route, it's very important to only allow requests to the `/api/features/*` endpoint in your CDN. If you allow access to other endpoints (e.g. `/auth/*` or other API routes) you lose many of the benefits of a Firewall or VPN.
+2. Use a [**CDN**](/self-host/cdn). If you go this route, it's very important to only allow requests to the `/api/features/*` endpoint in your CDN. If you allow access to other endpoints (e.g. `/auth/*` or other API routes) you lose many of the benefits of a Firewall or VPN.
 3. Use **SDK Webhooks** to send your feature payload to a publically accessible place (e.g. a public S3 bucket). This switches GrowthBook from a "pull" model to a "push" model and you no longer need to allow any incoming requests from users at all.
 
 ### Authentication and Permissions

--- a/docs/docs/self-host/proxy.mdx
+++ b/docs/docs/self-host/proxy.mdx
@@ -9,6 +9,8 @@ slug: proxy
 
 The GrowthBook Proxy server sits between your application and GrowthBook (both Cloud or Self-hosted instances). It turbocharges your GrowthBook implementation by providing **speed**, **scalability**, **security**, and **real-time** feature rollouts.
 
+The GrowthBook Proxy does require spinning up infrastructure and all of the maintenance/devops costs associated with that. If you are looking for a simpler hands-off alternative, you can use a [CDN](/self-host/cdn) instead.
+
 ## Features
 
 - **Caching** - Significantly faster feature lookups!

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -469,6 +469,7 @@ const sidebars = {
         "self-host/environment-variables",
         "self-host/config-yml",
         "self-host/production",
+        { type: "doc", id: "self-host/cdn" },
         { type: "doc", id: "self-host/proxy", label: "Proxy" },
       ],
     },


### PR DESCRIPTION
### Features and Changes

Document how to add your own CDN in front of GrowthBook.  This is a simpler alternative to using the GrowthBook Proxy.