### PR TITLE
Fix results table svg plots where id has invalid characters

### DIFF
--- a/packages/front-end/components/Experiment/AlignedGraph.tsx
+++ b/packages/front-end/components/Experiment/AlignedGraph.tsx
@@ -64,6 +64,7 @@ const AlignedGraph: FC<Props> = ({
   onMouseLeave,
   onClick,
 }) => {
+  id = id.replaceAll("%20", "_").replace(/[\W]+/g, "_");
   const axisColor = "var(--text-link-hover-color)";
   const zeroLineColor = "#0077b6";
   const zeroLineWidth = 3;


### PR DESCRIPTION
Dimension names with spaces were causing plot fills to have invalid IDs. Example:
`url(#gr_met_sktwido9laa36npx_violin_row6_var2_undefined_web%20browser)'`
%20 broke the plot. The fix makes %20 and anything non-alphanumeric an underscore.