### PR TITLE
Fix race condition when DISABLE_TELEMETRY is set

### DIFF
--- a/packages/front-end/services/env.ts
+++ b/packages/front-end/services/env.ts
@@ -2,7 +2,7 @@ import * as Sentry from "@sentry/react";
 import { EnvironmentInitValue } from "@/./pages/api/init";
 
 const env: EnvironmentInitValue = {
-  telemetry: "enable",
+  telemetry: "disable",
   cloud: false,
   isMultiOrg: false,
   allowSelfOrgCreation: false,


### PR DESCRIPTION
### Features and Changes

- Telemetry now always starts as disabled until the env var is loaded and parsed (previously it started as "enabled")
- Delay firing the first `page-view` event and enabling realtime feature usage tracking until after the env vars are ready
- Fix how the URL is being updated in GrowthBook for client-side navigations