### PR TITLE
Remove outer label from radix Radio Group

### DIFF
--- a/packages/front-end/components/Radix/RadioGroup.tsx
+++ b/packages/front-end/components/Radix/RadioGroup.tsx
@@ -35,7 +35,7 @@ export default function RadioGroup({
   return (
     <Flex {...containerProps}>
       <Flex direction={"column"}>
-        <Text as="label" size="2" color={disabled ? "gray" : undefined}>
+        <Text size="2" color={disabled ? "gray" : undefined}>
           <RadixRadioGroup.Root
             value={value}
             onValueChange={(val) => setValue(val)}


### PR DESCRIPTION
Removes outer label from RadioGroup to prevent clicking between buttons resetting value to top radio button.