### PR TITLE
Update dependencies for SDKs (1.2.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     ]
   },
   "resolutions": {
-    "@growthbook/growthbook": "1.2.0"
+    "@growthbook/growthbook": "1.2.1"
   },
   "prettier": {
     "overrides": [

--- a/packages/back-end/package.json
+++ b/packages/back-end/package.json
@@ -34,7 +34,7 @@
     "@dqbd/tiktoken": "^1.0.7",
     "@google-cloud/bigquery": "5",
     "@google-cloud/storage": "^5.20.5",
-    "@growthbook/growthbook": "^1.2.0",
+    "@growthbook/growthbook": "^1.2.1",
     "@growthbook/proxy-eval": "^1.0.3",
     "@octokit/auth-app": "^6.0.1",
     "@octokit/core": "^5.0.2",

--- a/packages/front-end/package.json
+++ b/packages/front-end/package.json
@@ -17,7 +17,7 @@
     "@dnd-kit/core": "^4.0.3",
     "@dnd-kit/sortable": "^5.1.0",
     "@floating-ui/react": "^0.25.4",
-    "@growthbook/growthbook-react": "^1.2.0",
+    "@growthbook/growthbook-react": "^1.2.1",
     "@jitsu/sdk-js": "^2.2.0",
     "@jukben/emoji-search": "^2.0.1",
     "@popperjs/core": "^2.11.5",

--- a/packages/sdk-js/package.json
+++ b/packages/sdk-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@growthbook/growthbook",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.mjs",

--- a/packages/sdk-react/package.json
+++ b/packages/sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@growthbook/growthbook-react",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -38,7 +38,7 @@
     "react": "^16.8.0-0 || ^17.0.0-0 || ^18.0.0-0"
   },
   "dependencies": {
-    "@growthbook/growthbook": "^1.2.0"
+    "@growthbook/growthbook": "^1.2.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.19.3",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -18,7 +18,7 @@
     "generate-sdk-report": "node -r @swc-node/register ./src/sdk-versioning/sdk-report.ts ./src/sdk-versioning/CAPABILITIES.md"
   },
   "dependencies": {
-    "@growthbook/growthbook": "^1.2.0",
+    "@growthbook/growthbook": "^1.2.1",
     "ajv": "^8.12.0",
     "date-fns": "^2.15.0",
     "dirty-json": "^0.9.2",

--- a/packages/shared/src/sdk-versioning/sdk-versions/edge-cloudflare.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/edge-cloudflare.json
@@ -1,6 +1,9 @@
 {
   "versions": [
     {
+      "version": "0.1.13"
+    },
+    {
       "version": "0.1.12",
       "capabilities": ["savedGroupReferences"]
     },

--- a/packages/shared/src/sdk-versioning/sdk-versions/edge-fastly.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/edge-fastly.json
@@ -1,6 +1,9 @@
 {
   "versions": [
     {
+      "version": "0.1.7"
+    },
+    {
       "version": "0.1.6",
       "capabilities": ["savedGroupReferences"]
     },

--- a/packages/shared/src/sdk-versioning/sdk-versions/edge-lambda.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/edge-lambda.json
@@ -1,6 +1,9 @@
 {
   "versions": [
     {
+      "version": "0.0.8"
+    },
+    {
       "version": "0.0.7",
       "capabilities": ["savedGroupReferences"]
     },

--- a/packages/shared/src/sdk-versioning/sdk-versions/edge-other.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/edge-other.json
@@ -1,6 +1,9 @@
 {
   "versions": [
     {
+      "version": "0.1.6"
+    },
+    {
       "version": "0.1.5",
       "capabilities": ["savedGroupReferences"]
     },

--- a/packages/shared/src/sdk-versioning/sdk-versions/javascript.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/javascript.json
@@ -1,6 +1,9 @@
 {
   "versions": [
     {
+      "version": "1.2.1"
+    },
+    {
       "version": "1.2.0"
     },
     {

--- a/packages/shared/src/sdk-versioning/sdk-versions/nodejs.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/nodejs.json
@@ -1,6 +1,9 @@
 {
   "versions": [
     {
+      "version": "1.2.1"
+    },
+    {
       "version": "1.2.0"
     },
     {

--- a/packages/shared/src/sdk-versioning/sdk-versions/react.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/react.json
@@ -1,6 +1,9 @@
 {
   "versions": [
     {
+      "version": "1.2.1"
+    },
+    {
       "version": "1.2.0"
     },
     {


### PR DESCRIPTION
Update GB to use 1.2.1 SDKs (already live on NPM)