### PR TITLE
Modify snowflake integration proxy settings

### DIFF
--- a/packages/back-end/src/services/snowflake.ts
+++ b/packages/back-end/src/services/snowflake.ts
@@ -16,7 +16,7 @@ function getProxySettings(): ProxyOptions {
 
   const parsed = new URL(uri);
   return {
-    proxyProtocol: parsed.protocol,
+    proxyProtocol: parsed.protocol.replace(":", ""),
     proxyHost: parsed.hostname,
     proxyPort: (parsed.port ? parseInt(parsed.port) : 0) || undefined,
     proxyUser: parsed.username || undefined,

--- a/patches/snowflake-sdk+1.10.1.patch
+++ b/patches/snowflake-sdk+1.10.1.patch
@@ -1,0 +1,16 @@
+diff --git a/node_modules/snowflake-sdk/lib/http/base.js b/node_modules/snowflake-sdk/lib/http/base.js
+index 626c313..224e8e9 100644
+--- a/node_modules/snowflake-sdk/lib/http/base.js
++++ b/node_modules/snowflake-sdk/lib/http/base.js
+@@ -232,6 +232,11 @@ function prepareRequestOptions(options) {
+     requestOptions.httpAgent = agent;
+   }
+ 
++  // Proxy is already being handled by Snowflake, tell Axios not to try proxying as well
++  if (this._connectionConfig.getProxy()) {
++    requestOptions.proxy = false;
++  }
++
+   return requestOptions;
+ }
+ 


### PR DESCRIPTION
### Features and Changes

`URL` protocol attribute returns `http:` with the colon, but it looks like [Snowflake](https://github.com/search?q=repo%3Asnowflakedb%2Fsnowflake-connector-nodejs%20proxyProtocol&type=code) expects `http` without the colon. Furthermore, there's been some back and forth about this in `node` anyways, so it looks like this could fix some errors with snowflake proxies.

Also disables axios proxy when SNOWFLAKE_PROXY is specified, a known issue with the snowflake sdk (see https://github.com/snowflakedb/snowflake-connector-nodejs/issues/761) 

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

@aarons  at Square tested it in their (staging?) set up and it worked for them.

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
