### PR TITLE
user lookup mem perf improvement

### DIFF
--- a/packages/back-end/src/models/UserModel.ts
+++ b/packages/back-end/src/models/UserModel.ts
@@ -218,6 +218,7 @@ export async function getAllUserEmailsAcrossAllOrgs(): Promise<string[]> {
         localField: "id",
         foreignField: "members.id",
         as: "orgs",
+        pipeline: [{ $project: { _id: 0, members: 1 } }],
       },
     },
     {
@@ -225,7 +226,10 @@ export async function getAllUserEmailsAcrossAllOrgs(): Promise<string[]> {
         "orgs.0": { $exists: true },
       },
     },
-  ]);
+    {
+      $project: { email: 1 },
+    },
+  ]).allowDiskUse(true);
 
   return users.map((u) => u.email);
 }


### PR DESCRIPTION
### Features and Changes

Some [large self hosted ](https://growthbookapp.slack.com/archives/C05QYS2UFRD/p1728491460870439) users have been seeing: `Exceeded memory limit for $group or $lookup. Pass allowDiskUse:true to opt in`.  I find it a bit hard to believe that getting all users and all orgs would exceed even the minimum memory mongo could have of 250MB. 

This change uses projects to limit the amount of memory needed by the query.
It also does set allowDiskUse: true.  As this query is only run once a day at most, this should not affect performance too much.

When I explain the query with the projections it ends up being a much more simple plan, so it is possible that was enough but I set `allowDiskUse(true)` so that there are not too many back and forths of whether it is working.

### Testing

Download Report from /admin page and see that it is the same before and after this change except the dateCreated and signature fields.