### PR TITLE
passing through error about needed sample size for bandits

### DIFF
--- a/packages/stats/gbstats/bayesian/bandits.py
+++ b/packages/stats/gbstats/bayesian/bandits.py
@@ -234,7 +234,7 @@ class Bandits(ABC):
             for mn, s in zip(self.variation_means, np.sqrt(self.posterior_variance))
         ]
         min_n = 100 * self.num_variations
-        enough_data = sum(self.variation_counts) >= min_n
+        enough_data = self.current_sample_size >= min_n
 
         return BanditResponse(
             users=self.variation_counts.tolist(),
@@ -245,7 +245,10 @@ class Bandits(ABC):
             seed=seed,
             bandit_update_message=update_message
             if enough_data
-            else "total sample size is less than 100 times number of variations",
+            else "total sample size is only "
+            + str(self.current_sample_size)
+            + " and it needs to be at least 100 * "
+            + str(self.num_variations),
         )
 
     # function that takes weights for largest realization and turns into top two weights
@@ -430,12 +433,11 @@ class BanditsCuped(Bandits):
     # for cuped, when producing intervals for the leaderboard, add back in the pooled baseline mean
     @property
     def addback(self) -> float:
-        total_n = sum(self.variation_counts)
-        if total_n:
+        if self.current_sample_size:
             return float(
                 self.theta
                 * np.sum(self.variation_counts * self.variation_means_pre)
-                / total_n
+                / self.current_sample_size
             )
         else:
             return 0

--- a/packages/stats/gbstats/gbstats.py
+++ b/packages/stats/gbstats/gbstats.py
@@ -683,8 +683,13 @@ def get_bandit_result(
                 reweight=bandit_settings.reweight,
             )
         else:
+            error_message = (
+                bandit_result.bandit_update_message
+                if bandit_result.bandit_update_message
+                else "unknown error in get_bandit_result"
+            )
             return get_error_bandit_result(
-                error="bandit result computation failed",
+                error=error_message,
                 reweight=bandit_settings.reweight,
                 current_weights=bandit_settings.current_weights,
             )


### PR DESCRIPTION
currently if the sample size is too small for a bandit update, we return a generic error message to the UI.  This PR updates the error message to specify both the current sample size and the needed sample size for results to be shown on the UI.  


<img width="1728" alt="Screenshot 2024-10-15 at 5 33 05 PM" src="https://github.com/user-attachments/assets/68063cdd-be06-41df-9764-87dc61190c7a">
