### PR TITLE
[docs]: react-native localStorage polyfills example should not parse/stringify

### DIFF
--- a/docs/docs/lib/react-native.mdx
+++ b/docs/docs/lib/react-native.mdx
@@ -240,7 +240,7 @@ npm install --save react-native-sse
 The, tell GrowthBook to use this polyfill:
 
 ```js
-import { setPolyfills } from "@growthbook/growthbook";
+import { setPolyfills } from "@growthbook/growthbook-react";
 import EventSource from "react-native-sse";
 
 // Configure GrowthBook to use the eventsource library
@@ -301,14 +301,13 @@ npm install --save @react-native-async-storage/async-storage
 ```
 
 ```jsx
+import { setPolyfills } from "@growthbook/growthbook-react";
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { setPolyfills } from "@growthbook/growthbook";
 
 setPolyfills({
   localStorage: {
-    // Example using Redis
-    getItem: (key) => JSON.parse(AsyncStorage.getItem(key) || "null")
-    setItem: (key, value) => AsyncStorage.setItem(key, JSON.stringify(value))
+    getItem: (key) => AsyncStorage.getItem(key),
+    setItem: (key, value) => AsyncStorage.setItem(key, value)
   }
 });
 ```
@@ -320,7 +319,7 @@ There are a number of cache settings you can configure within GrowthBook. This m
 Below are all of the default values. You can call `configureCache` with a subset of these fields and the rest will keep their default values.
 
 ```ts
-import { configureCache } from "@growthbook/growthbook";
+import { configureCache } from "@growthbook/growthbook-react";
 
 configureCache({
   // The localStorage key the cache will be stored under


### PR DESCRIPTION
### Features and Changes

The React Native documentation had a code example which stringified and parsed data in the localStorage polyfill. This should not be needed as the value we're storing should be a `string` in the first place. Meaning we'd be calling `JSON.stringify` twice when storing a value, once in growthbook's code and once in user code. Same is happening with `JSON.parse` when retrieving a value.

An additional change was to change any imports in the file from `@growthbook/growthbook`  to `@growthbook/growthbook-react` to match the package name that was installed.

### Screenshots

#### Before:

<img width="781" alt="Screenshot 2024-10-16 at 11 34 08 AM" src="https://github.com/user-attachments/assets/0d7b8969-6c63-45a2-af45-b4fa525fd731">

#### After:

<img width="780" alt="Screenshot 2024-10-16 at 11 36 37 AM" src="https://github.com/user-attachments/assets/164a211f-77c1-495d-93d7-83a97677c390">
