### PR TITLE
Athena enable query reuse

### DIFF
--- a/packages/back-end/src/services/athena.ts
+++ b/packages/back-end/src/services/athena.ts
@@ -77,13 +77,14 @@ export async function runAthenaQuery(
     (parseInt(process.env.ATHENA_RETRY_WAIT_TIME || "60") || 60) * 1000;
 
   const resultReuseSettings =
-    typeof conn.resultReuseMaxAgeInMinutes === "undefined"
+    typeof conn.resultReuseMaxAgeInMinutes === "undefined" ||
+    conn.resultReuseMaxAgeInMinutes === "0"
       ? {
           Enabled: false,
         }
       : {
           Enabled: true,
-          MaxAgeInMinutes: conn.resultReuseMaxAgeInMinutes,
+          MaxAgeInMinutes: parseInt(conn.resultReuseMaxAgeInMinutes),
         };
 
   const { QueryExecutionId } = await athena.startQueryExecution({

--- a/packages/back-end/src/services/athena.ts
+++ b/packages/back-end/src/services/athena.ts
@@ -76,6 +76,16 @@ export async function runAthenaQuery(
   const retryWaitTime =
     (parseInt(process.env.ATHENA_RETRY_WAIT_TIME || "60") || 60) * 1000;
 
+  const resultReuseSettings =
+    typeof conn.resultReuseMaxAgeInMinutes === "undefined"
+      ? {
+          Enabled: false,
+        }
+      : {
+          Enabled: true,
+          MaxAgeInMinutes: conn.resultReuseMaxAgeInMinutes,
+        };
+
   const { QueryExecutionId } = await athena.startQueryExecution({
     QueryString: sql,
     QueryExecutionContext: {
@@ -89,9 +99,7 @@ export async function runAthenaQuery(
       OutputLocation: bucketUri,
     },
     ResultReuseConfiguration: {
-      ResultReuseByAgeConfiguration: {
-        Enabled: true,
-      },
+      ResultReuseByAgeConfiguration: resultReuseSettings,
     },
     WorkGroup: workGroup || "primary",
   });

--- a/packages/back-end/src/services/athena.ts
+++ b/packages/back-end/src/services/athena.ts
@@ -88,6 +88,11 @@ export async function runAthenaQuery(
       },
       OutputLocation: bucketUri,
     },
+    ResultReuseConfiguration: {
+      ResultReuseByAgeConfiguration: {
+        Enabled: true,
+      },
+    },
     WorkGroup: workGroup || "primary",
   });
 

--- a/packages/back-end/src/services/athena.ts
+++ b/packages/back-end/src/services/athena.ts
@@ -76,16 +76,18 @@ export async function runAthenaQuery(
   const retryWaitTime =
     (parseInt(process.env.ATHENA_RETRY_WAIT_TIME || "60") || 60) * 1000;
 
-  const resultReuseSettings =
-    typeof conn.resultReuseMaxAgeInMinutes === "undefined" ||
-    conn.resultReuseMaxAgeInMinutes === "0"
-      ? {
-          Enabled: false,
-        }
-      : {
-          Enabled: true,
-          MaxAgeInMinutes: parseInt(conn.resultReuseMaxAgeInMinutes),
-        };
+  const resultReuseMaxAgeInMinutes = conn.resultReuseMaxAgeInMinutes
+    ? parseInt(conn.resultReuseMaxAgeInMinutes)
+    : undefined;
+  // Skipped when parsed setting is 0, NaN, or not present
+  const resultReuseSettings = !resultReuseMaxAgeInMinutes
+    ? {
+        Enabled: false,
+      }
+    : {
+        Enabled: true,
+        MaxAgeInMinutes: resultReuseMaxAgeInMinutes,
+      };
 
   const { QueryExecutionId } = await athena.startQueryExecution({
     QueryString: sql,

--- a/packages/back-end/types/integrations/athena.d.ts
+++ b/packages/back-end/types/integrations/athena.d.ts
@@ -11,4 +11,5 @@ export interface AthenaConnectionParams {
   bucketUri: string;
   workGroup?: string;
   catalog?: string;
+  resultReuseMaxAgeInMinutes?: number;
 }

--- a/packages/back-end/types/integrations/athena.d.ts
+++ b/packages/back-end/types/integrations/athena.d.ts
@@ -11,5 +11,5 @@ export interface AthenaConnectionParams {
   bucketUri: string;
   workGroup?: string;
   catalog?: string;
-  resultReuseMaxAgeInMinutes?: number;
+  resultReuseMaxAgeInMinutes?: string;
 }

--- a/packages/front-end/components/Settings/AthenaForm.tsx
+++ b/packages/front-end/components/Settings/AthenaForm.tsx
@@ -174,6 +174,17 @@ const AthenaForm: FC<{
           onChange={onParamChange}
         />
       </div>
+      <div className="form-group col-md-12">
+        <Field
+          name="resultReuseMaxAgeInMinutes"
+          type="number"
+          label="Reuse Query Results Within Past (minutes)"
+          helpText="A value of 0 or an empty field will disable reuse of query results"
+          value={params.resultReuseMaxAgeInMinutes || ""}
+          onChange={onParamChange}
+          min={0}
+        />
+      </div>
     </div>
   );
 };

--- a/packages/front-end/components/Settings/AthenaForm.tsx
+++ b/packages/front-end/components/Settings/AthenaForm.tsx
@@ -178,7 +178,7 @@ const AthenaForm: FC<{
         <Field
           name="resultReuseMaxAgeInMinutes"
           type="number"
-          label="Reuse Query Results Within Past (minutes)"
+          label="Reuse query results within past X minutes (optional)"
           helpText="A value of 0 or an empty field will disable reuse of query results"
           value={params.resultReuseMaxAgeInMinutes || ""}
           onChange={onParamChange}

--- a/packages/front-end/components/Settings/SharedConnectionSettings.tsx
+++ b/packages/front-end/components/Settings/SharedConnectionSettings.tsx
@@ -21,7 +21,7 @@ export default function SharedConnectionSettings({
             type="number"
             label={
               <>
-                Maximum Concurrent Queries (Optional){" "}
+                Maximum Concurrent Queries (optional){" "}
                 <Tooltip
                   body={
                     "When executing queries against this datasource, if this many queries are already" +


### PR DESCRIPTION
### Features and Changes

Adds an option to Athena connection settings for enabling re-use of query results up to a certain age limit.
 
- Closes #2994 

### Testing

This hasn't been manually tested as we don't have access to an Athena DB to test against in dev. The code should prevent any changes for datasources that don't have the new setting enabled so it should be safe to ship as-is and iterate if needed

### Screenshots

![image](https://github.com/user-attachments/assets/67939dd0-d7fd-46c7-9d04-ade12f0add07)
