### PR TITLE
Fix useFeaturesList changing object pointers every rerender

### DIFF
--- a/packages/front-end/services/features.ts
+++ b/packages/front-end/services/features.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   Environment,
   NamespaceUsage,
@@ -187,6 +187,11 @@ export function findGaps(
 
 export function useFeaturesList(withProject = true, includeArchived = false) {
   const { project } = useDefinitions();
+  const [features, setFeatures] = useState<FeatureInterface[]>([]);
+  const [experiments, setExperiments] = useState<
+    ExperimentInterfaceStringDates[]
+  >([]);
+  const [hasArchived, setHasArchived] = useState(false);
 
   const qs = new URLSearchParams();
   if (withProject) {
@@ -204,13 +209,21 @@ export function useFeaturesList(withProject = true, includeArchived = false) {
     hasArchived: boolean;
   }>(url);
 
+  useEffect(() => {
+    if (data) {
+      setFeatures(data.features);
+      setExperiments(data.linkedExperiments);
+      setHasArchived(data.hasArchived);
+    }
+  }, [data]);
+
   return {
-    features: data?.features || [],
-    experiments: data?.linkedExperiments || [],
+    features,
+    experiments,
     loading: !data,
     error,
     mutate,
-    hasArchived: data?.hasArchived || false,
+    hasArchived,
   };
 }
 


### PR DESCRIPTION
### Features and Changes

On Firefox there's been a general error "the operation is insecure" on the main `/features` page for a few weeks now.
The reason for this is we have a `useMemo` in `services/search.tsx` which does a shallow replace on the router's query params whenever an object changes. That object in turn is a `useMemo` based on the items being searched over, and those items (in the case of `/features`) are the `FeatureInterface[]` returned by `useFeaturesList`.

The problem is that each time the hook is called (due to re-rendering for other reasons) the default empty array that's returned is a new object, so this was causing us to change the query params hundreds of times, which Firefox blocked as a security issue.

### Testing

Using Firefox, load http://localhost:3000/features on `main` and on this branch and observe the difference.
Optionally, add a console log to the `if (updateSearchQueryOnChange)` clause in `services/search.tsx` to see the frequency at which we call `router.replace`

### Screenshots

#### Before

![image](https://github.com/user-attachments/assets/ff90d0a8-0d17-483c-bcea-57904301218d)

#### After

![image](https://github.com/user-attachments/assets/e6780424-85b8-41d5-9bc7-fc8efdfed065)

