### PR TITLE
Fix savedGroups sometimes hashing non-securestring attributes

### DIFF
--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -1238,7 +1238,7 @@ export function applySavedGroupHashing(
         salt,
         attributes,
         attribute,
-        doHash: attribute.hashAttribute,
+        doHash: shouldHash(attribute),
       });
     }
   });
@@ -1287,15 +1287,7 @@ any {
       // check if a new attribute is referenced, and whether we need to hash it
       // otherwise, inherit the previous attribute and hashing status
       attribute = attributes.find((a) => a.property === key) ?? attribute;
-      doHash = attribute
-        ? !!(
-            attribute?.datatype &&
-            ["secureString", "secureString[]"].includes(
-              attribute?.datatype ?? ""
-            ) &&
-            !["$inGroup", "$notInGroup"].includes(key)
-          )
-        : doHash;
+      doHash = attribute ? shouldHash(attribute, key) : doHash;
 
       newObj[key] = processVal({
         obj: obj[key],
@@ -1333,6 +1325,13 @@ any {
       return obj;
     }
   }
+}
+
+function shouldHash(attribute: SDKAttribute, operator?: string) {
+  return !!(
+    ["secureString", "secureString[]"].includes(attribute.datatype) &&
+    (!operator || !["$inGroup", "$notInGroup"].includes(operator))
+  );
 }
 
 export function sha256(str: string, salt: string): string {

--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -1329,7 +1329,8 @@ any {
 
 function shouldHash(attribute: SDKAttribute, operator?: string) {
   return !!(
-    ["secureString", "secureString[]"].includes(attribute.datatype) &&
+    attribute?.datatype &&
+    ["secureString", "secureString[]"].includes(attribute?.datatype ?? "") &&
     (!operator || !["$inGroup", "$notInGroup"].includes(operator))
   );
 }


### PR DESCRIPTION
### Features and Changes

A customer reported an issue where when they updated GrowthBook their feature payload started hashing the contents of saved groups even if they were only plain string IDs.

This only happens on a subset of codepaths which is why we didn't notice it yet, but it seems the original logic for `doHash` was incorrectly set to hash (cipher) attributes which can be used for hashing (experiment assignment).

This PR fixes the issue by extracting the existing, correct logic into a helper and calling that helper instead.


### Testing

My repro steps on `main` which no longer reproduce the bug on this branch were:

#### Setup

1. Ensure you have an  `id` attribute of type String which is a Unique Identifier
2. Create an ID List saved group for that attribute and populate it with a few simple values
3. Create a feature and add a targeting rule referencing that ID List
4. Generate the feature payload for an SDK with "Hash secure attributes" on but "Pass Saved Groups by reference" off

#### Reproduction steps

Most of the time, this results in the correct payload (when it's leveraging the cache). To reproduce the issue, toggle the feature off and back on, then refresh the SDK endpoint without changing any code (this would send it down a working code branch).

### Screenshots

Following the steps on `main`
![image](https://github.com/user-attachments/assets/485a70fa-d2b2-47d7-8fc5-b4c4b1f72ced)

Following the steps on this branch
![image](https://github.com/user-attachments/assets/f4e94c85-3be3-467a-82ce-6f54e5f91d65)
