### PR TITLE
Put secondaryCTA back in.

### DIFF
--- a/packages/front-end/components/Modal/PagedModal.tsx
+++ b/packages/front-end/components/Modal/PagedModal.tsx
@@ -57,6 +57,7 @@ const PagedModal: FC<Props> = (props) => {
     ctaEnabled = true,
     forceCtaText,
     inline,
+    secondaryCTA,
     size,
     className,
     bodyClassName,
@@ -153,7 +154,9 @@ const PagedModal: FC<Props> = (props) => {
         ) : null
       }
       secondaryCTA={
-        onSkip ? (
+        secondaryCTA ? (
+          secondaryCTA
+        ) : onSkip ? (
           <button
             className={`btn btn-link mr-3`}
             onClick={(e) => {


### PR DESCRIPTION
### Features and Changes

In https://github.com/growthbook/growthbook/pull/3145/files#diff-86418e5d5fa9fd150fc0aea44353752c3974b9b3818c5c6fe4d8837918ae01bd it seems we accidentally got rid of the secondaryCTA if it existed. 

- Closes
https://github.com/growthbook/growthbook/issues/3155

### Testing

Change a running test.  See the confirm box on the last page. On checking the check box see that "Publish Changes" is now clickable.

### Screen shots
<img width="795" alt="Screenshot 2024-10-23 at 2 17 44 PM" src="https://github.com/user-attachments/assets/c8976f81-4671-4c70-9af7-0f67c40fab26">



