### PR TITLE
Factor out datasource creation/update permissions.

### DIFF
--- a/packages/back-end/src/controllers/datasources.ts
+++ b/packages/back-end/src/controllers/datasources.ts
@@ -212,7 +212,7 @@ export async function postDataSources(
   const { name, description, type, params, projects } = req.body;
   const settings = req.body.settings || {};
 
-  if (!context.permissions.canCreateDataSource({ projects })) {
+  if (!context.permissions.canCreateDataSource({ projects, type })) {
     context.permissions.throwPermissionError();
   }
 
@@ -625,7 +625,8 @@ export async function postGoogleOauthRedirect(
   const context = getContextFromReq(req);
   const { projects } = req.body;
 
-  if (!context.permissions.canCreateDataSource({ projects })) {
+  // Huh, why? -- rb
+  if (!context.permissions.canCreateDataSource({ projects, type: undefined })) {
     context.permissions.throwPermissionError();
   }
 

--- a/packages/back-end/src/routers/demo-datasource-project/demo-datasource-project.controller.ts
+++ b/packages/back-end/src/routers/demo-datasource-project/demo-datasource-project.controller.ts
@@ -181,7 +181,10 @@ export const postDemoDatasourceProject = async (
 
   if (
     !context.permissions.canCreateMetric({ projects: [demoProjId] }) ||
-    !context.permissions.canCreateDataSource({ projects: [demoProjId] })
+    !context.permissions.canCreateDataSource({
+      projects: [demoProjId],
+      type: undefined,
+    })
   ) {
     context.permissions.throwPermissionError();
   }

--- a/packages/front-end/components/Settings/DataSourceForm.tsx
+++ b/packages/front-end/components/Settings/DataSourceForm.tsx
@@ -56,8 +56,14 @@ const DataSourceForm: FC<{
 
   const permissionRequired = (project: string) => {
     return existing
-      ? permissionsUtil.canUpdateDataSourceParams({ projects: [project] })
-      : permissionsUtil.canCreateDataSource({ projects: [project] });
+      ? permissionsUtil.canUpdateDataSourceParams({
+          projects: [project],
+          type: datasource?.type,
+        })
+      : permissionsUtil.canCreateDataSource({
+          projects: [project],
+          type: datasource?.type,
+        });
   };
 
   const projectOptions = useProjectOptions(

--- a/packages/front-end/components/Settings/NewDataSourceForm.tsx
+++ b/packages/front-end/components/Settings/NewDataSourceForm.tsx
@@ -210,7 +210,11 @@ const NewDataSourceForm: FC<{
       })
   );
   const projectOptions = useProjectOptions(
-    (project) => permissionsUtil.canCreateDataSource({ projects: [project] }),
+    (project) =>
+      permissionsUtil.canCreateDataSource({
+        projects: [project],
+        type: undefined,
+      }),
     []
   );
 

--- a/packages/front-end/pages/datasources/[did].tsx
+++ b/packages/front-end/pages/datasources/[did].tsx
@@ -61,10 +61,7 @@ const DataSourcePage: FC = () => {
     (d && permissionsUtil.canDeleteDataSource(d) && !hasFileConfig()) || false;
 
   const canUpdateConnectionParams =
-    (d &&
-      permissionsUtil.canUpdateDataSourceParams(d) &&
-      !hasFileConfig() &&
-      d.type != "growthbook_clickhouse") ||
+    (d && permissionsUtil.canUpdateDataSourceParams(d) && !hasFileConfig()) ||
     false;
 
   const canUpdateDataSourceSettings =

--- a/packages/shared/src/permissions/permissionsClass.ts
+++ b/packages/shared/src/permissions/permissionsClass.ts
@@ -567,18 +567,27 @@ export class Permissions {
   };
 
   public canViewCreateDataSourceModal = (project?: string): boolean => {
-    return this.canCreateDataSource({ projects: project ? [project] : [] });
+    return this.canCreateDataSource({
+      projects: project ? [project] : [],
+      type: undefined,
+    });
   };
 
-  public canCreateDataSource = (
-    datasource: Pick<DataSourceInterface, "projects">
-  ): boolean => {
+  public canCreateDataSource = (datasource: {
+    projects?: DataSourceInterface["projects"];
+    type: DataSourceInterface["type"] | undefined;
+  }): boolean => {
+    if (datasource?.type === "growthbook_clickhouse") return false;
+
     return this.checkProjectFilterPermission(datasource, "createDatasources");
   };
 
-  public canUpdateDataSourceParams = (
-    datasource: Pick<DataSourceInterface, "projects">
-  ): boolean => {
+  public canUpdateDataSourceParams = (datasource: {
+    projects?: DataSourceInterface["projects"];
+    type: DataSourceInterface["type"] | undefined;
+  }): boolean => {
+    if (datasource?.type === "growthbook_clickhouse") return false;
+
     return this.checkProjectFilterPermission(datasource, "createDatasources");
   };
 


### PR DESCRIPTION
This PR factors out the logic for data source creation/update to include internal data warehouse logic.

The `type` attribute has been made explitly present but with possible `undefined` value to make sure that it is taken into account when calling the permission API.