### PR TITLE
Fix replace error on an undefined exposureTableName

### DIFF
--- a/packages/back-end/types/datasource.d.ts
+++ b/packages/back-end/types/datasource.d.ts
@@ -75,7 +75,13 @@ export type SchemaOption = {
 
 type GetExperimentSqlOptions = {
   exposureTableName?: string;
-  [key: string]: string | number | undefined;
+  actionName?: string;
+  eventType?: string;
+  projectId?: string;
+  tablePrefix?: string;
+  actionPrefix?: string;
+  siteId?: string | number;
+  categoryName?: string;
 };
 
 export interface SchemaInterface {

--- a/packages/back-end/types/datasource.d.ts
+++ b/packages/back-end/types/datasource.d.ts
@@ -73,11 +73,16 @@ export type SchemaOption = {
   helpText?: string;
 };
 
+type GetExperimentSqlOptions = {
+  exposureTableName?: string;
+  [key: string]: string | number | undefined;
+};
+
 export interface SchemaInterface {
   getExperimentSQL(
     tablePrefix: string,
     userId: string,
-    options?: Record<string, string | number>
+    options?: GetExperimentSqlOptions
   ): string;
   getIdentitySQL(
     tablePrefix: string,

--- a/packages/front-end/services/datasources.ts
+++ b/packages/front-end/services/datasources.ts
@@ -22,7 +22,7 @@ import {
 import { getDefaultFactMetricProps } from "@/services/metrics";
 import { ApiCallType } from "@/services/auth";
 
-function camelToUnderscore(orig) {
+function camelToUnderscore(orig: string) {
   return orig
     .replace(/\s+/g, "_")
     .replace(/([A-Z]+)([A-Z][a-z])/, "$1_$2")
@@ -242,7 +242,8 @@ const SegmentSchema: SchemaInterface = {
   experimentDimensions: ["source", "medium", "device", "browser"],
   getExperimentSQL: (tablePrefix, userId, options) => {
     const exposureTableName =
-      camelToUnderscore(options?.exposureTableName) || "experiment_viewed";
+      camelToUnderscore(options?.exposureTableName || "") ||
+      "experiment_viewed";
     return `SELECT
   ${userId},
   received_at as timestamp,
@@ -296,7 +297,8 @@ const RudderstackSchema: SchemaInterface = {
   experimentDimensions: ["device", "browser"],
   getExperimentSQL: (tablePrefix, userId, options) => {
     const exposureTableName =
-      camelToUnderscore(options?.exposureTableName) || "experiment_viewed";
+      camelToUnderscore(options?.exposureTableName || "") ||
+      "experiment_viewed";
     return `SELECT
   ${userId},
   received_at as timestamp,
@@ -395,7 +397,8 @@ const FreshpaintSchema: SchemaInterface = {
   experimentDimensions: ["source", "medium", "campaign", "os", "browser"],
   getExperimentSQL: (tablePrefix, userId, options) => {
     const exposureTableName =
-      camelToUnderscore(options?.exposureTableName) || "experiment_viewed";
+      camelToUnderscore(options?.exposureTableName || "") ||
+      "experiment_viewed";
     return `SELECT
   ${userId},
   time as timestamp,
@@ -448,7 +451,8 @@ const HeapSchema: SchemaInterface = {
   ],
   getExperimentSQL: (tablePrefix, userId, options) => {
     const exposureTableName =
-      camelToUnderscore(options?.exposureTableName) || "experiment_viewed";
+      camelToUnderscore(options?.exposureTableName || "") ||
+      "experiment_viewed";
     return `SELECT
   ${userId},
   time as timestamp,
@@ -485,7 +489,7 @@ const FullStorySchema: SchemaInterface = {
   experimentDimensions: ["source"],
   getExperimentSQL: (tablePrefix, userId) => {
     // const exposureTableName =
-    //   camelToUnderscore(options?.exposureTableName) || "experiment_viewed";
+    //   camelToUnderscore(options?.exposureTableName || "") || "experiment_viewed";
     return `
 -- Modify the below query to match your exported data
 SELECT


### PR DESCRIPTION
### Features and Changes

In  https://github.com/growthbook/growthbook/pull/3062/files#diff-a53cd0bc9ff62a2a185eb0e0945bf972c84ba70eb2213fcb0821f5ea7a5d78b4R299 we stopped sending `{exposureTableName: 'experiment_viewed'}` to `getInitialSettings`  and so `getExperimentSQL`  passed `undefined` to `camelToUnderscore` which errored.  

This:
- Adds a type check to `camelToUnderscore` to make sure it is a `string`
- Makes the type of the options more specific to make sure that `getExposureTable` is a string and not a number.
- If it is not defined when we call `camelToUnderscore` pass in `""` instead.

- Closes https://github.com/growthbook/growthbook/issues/3162

### Testing

Add a datasource and click next, and see that it either succeeds or returns a timeout error if the settings you entered weren't a real db settings.
