### PR TITLE
Add dogfooded event tracking to frontend

### DIFF
--- a/packages/front-end/pages/_app.tsx
+++ b/packages/front-end/pages/_app.tsx
@@ -31,6 +31,7 @@ import { AppFeatures } from "@/./types/app-features";
 import GetStartedProvider from "@/services/GetStartedProvider";
 import GuidedGetStartedBar from "@/components/Layout/GuidedGetStartedBar";
 import LayoutLite from "@/components/Layout/LayoutLite";
+import { GB_SDK_ID } from "@/services/utils";
 
 // If loading a variable font, you don't need to specify the font weight
 const inter = Inter({ subsets: ["latin"] });
@@ -46,10 +47,7 @@ type ModAppProps = AppProps & {
 
 const gbContext: Context = {
   apiHost: "https://cdn.growthbook.io",
-  clientKey:
-    process.env.NODE_ENV === "production"
-      ? "sdk-ueFMOgZ2daLa0M"
-      : "sdk-UmQ03OkUDAu7Aox",
+  clientKey: GB_SDK_ID,
   enableDevMode: true,
   trackingCallback: (experiment, result) => {
     track("Experiment Viewed", {

--- a/packages/front-end/pages/api/init.ts
+++ b/packages/front-end/pages/api/init.ts
@@ -9,6 +9,7 @@ export interface EnvironmentInitValue {
   isMultiOrg?: boolean;
   allowSelfOrgCreation: boolean;
   showMultiOrgSelfSelector: boolean;
+  dataWarehouseUrl?: string;
   appOrigin: string;
   apiHost: string;
   s3domain: string;
@@ -41,6 +42,7 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
     CDN_HOST,
     IS_CLOUD,
     IS_MULTI_ORG,
+    DATAWAREHOUSE_URL,
     ALLOW_SELF_ORG_CREATION,
     SHOW_MULTI_ORG_SELF_SELECTOR,
     DISABLE_TELEMETRY,
@@ -99,6 +101,7 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
     cdnHost: CDN_HOST || "",
     cloud: stringToBoolean(IS_CLOUD),
     isMultiOrg: stringToBoolean(IS_MULTI_ORG),
+    ...(DATAWAREHOUSE_URL ? { dataWarehouseUrl: DATAWAREHOUSE_URL } : {}),
     allowSelfOrgCreation: stringToBoolean(ALLOW_SELF_ORG_CREATION),
     showMultiOrgSelfSelector: stringToBoolean(
       SHOW_MULTI_ORG_SELF_SELECTOR,

--- a/packages/front-end/services/env.ts
+++ b/packages/front-end/services/env.ts
@@ -22,10 +22,14 @@ const env: EnvironmentInitValue = {
   superadminDefaultRole: "readonly",
 };
 
+export let dataWarehouseUrl;
+
 export async function initEnv() {
   const res = await fetch("/api/init");
   const json = await res.json();
   Object.assign(env, json);
+
+  dataWarehouseUrl = env.dataWarehouseUrl;
 
   if (env.sentryDSN) {
     Sentry.init({

--- a/packages/front-end/services/utils.tsx
+++ b/packages/front-end/services/utils.tsx
@@ -3,6 +3,11 @@ import React, { ReactNode } from "react";
 import qs from "query-string";
 import { getEqualWeights } from "shared/experiments";
 
+export const GB_SDK_ID =
+  process.env.NODE_ENV === "production"
+    ? "sdk-ueFMOgZ2daLa0M"
+    : "sdk-UmQ03OkUDAu7Aox";
+
 export function trafficSplitPercentages(weights: number[]): number[] {
   const sum = weights.reduce((sum, n) => sum + n, 0);
   return weights.map((w) => +((w / sum) * 100));


### PR DESCRIPTION
### Features and Changes

Creates a new side effect of calling `track()` which sends the event to the configured ingestion endpoint. This will enable dogfooding of our automated event tracking

### Dependencies

1. Ingestion endpoint must be ready & configured for production
2. #3165 must be deployed for the data enrichment endpoint to exist