### PR TITLE
Fix tracking for fact metric duplicate action

### DIFF
--- a/packages/front-end/components/FactTables/FactMetricModal.tsx
+++ b/packages/front-end/components/FactTables/FactMetricModal.tsx
@@ -775,7 +775,7 @@ export default function FactMetricModal({
       ? "Lookback periods under 7 days tend not to capture enough metric data to reduce variance and may be subject to weekly seasonality"
       : "";
 
-  const isNew = !existing;
+  const isNew = !existing || duplicate;
   const initialType = existing?.metricType;
   useEffect(() => {
     if (isNew) {

--- a/packages/front-end/components/FactTables/NewMetricModal.tsx
+++ b/packages/front-end/components/FactTables/NewMetricModal.tsx
@@ -42,7 +42,7 @@ export function MetricModal({
         current={currentMetric}
         edit={mode === "edit"}
         duplicate={mode === "duplicate"}
-        source={source}
+        source={source + (mode === "duplicate" ? "-duplicate" : "")}
         onClose={close}
       />
     );
@@ -50,7 +50,7 @@ export function MetricModal({
     return (
       <FactMetricModal
         close={close}
-        source={source}
+        source={source + (mode === "duplicate" ? "-duplicate" : "")}
         duplicate={mode === "duplicate"}
         existing={currentFactMetric}
       />


### PR DESCRIPTION
### Features and Changes

The Duplicate Fact Metric action was being tracked incorrectly. It was treated as an "Edit" event when viewing the modal and a "Create" event when submitting.