### PR TITLE
changing small sample size error to warning

### DIFF
--- a/packages/stats/gbstats/bayesian/bandits.py
+++ b/packages/stats/gbstats/bayesian/bandits.py
@@ -38,7 +38,8 @@ class BanditResponse:
     bandit_weights: Optional[List[float]]
     best_arm_probabilities: Optional[List[float]]
     seed: int
-    bandit_update_message: Optional[str]
+    bandit_update_message: str
+    enough_units: Optional[bool]
 
 
 def get_error_bandit_result(
@@ -51,7 +52,7 @@ def get_error_bandit_result(
         srm=1,
         bestArmProbabilities=None,
         seed=0,
-        updateMessage="not updated",
+        updateMessage=update_message,
         error=error,
         reweight=reweight,
     )
@@ -229,21 +230,22 @@ class Bandits(ABC):
             for mn, s in zip(self.variation_means, np.sqrt(self.posterior_variance))
         ]
         min_n = 100 * self.num_variations
-        enough_data = self.current_sample_size >= min_n
+        enough_units = self.current_sample_size >= min_n
 
         return BanditResponse(
             users=self.variation_counts.tolist(),
             cr=(self.variation_means).tolist(),
             ci=credible_intervals,
-            bandit_weights=p.tolist() if enough_data else None,
+            bandit_weights=p.tolist() if enough_units else None,
             best_arm_probabilities=best_arm_probabilities.tolist(),
             seed=seed,
             bandit_update_message=update_message
-            if enough_data
+            if enough_units
             else "total sample size is only "
             + str(self.current_sample_size)
             + " and it needs to be at least 100 * "
             + str(self.num_variations),
+            enough_units=enough_units,
         )
 
     # function that takes weights for largest realization and turns into top two weights

--- a/packages/stats/gbstats/bayesian/bandits.py
+++ b/packages/stats/gbstats/bayesian/bandits.py
@@ -42,7 +42,7 @@ class BanditResponse:
 
 
 def get_error_bandit_result(
-    error: str, reweight: bool, current_weights: List[float]
+    update_message: str, error: str, reweight: bool, current_weights: List[float]
 ) -> BanditResult:
     return BanditResult(
         singleVariationResults=None,

--- a/packages/stats/gbstats/gbstats.py
+++ b/packages/stats/gbstats/gbstats.py
@@ -650,12 +650,25 @@ def get_bandit_result(
     if b:
         if any(value is None for value in b.stats):
             return get_error_bandit_result(
+                update_message="not updated",
                 error="not all statistics are instance of type BanditStatistic",
                 reweight=bandit_settings.reweight,
                 current_weights=bandit_settings.current_weights,
             )
         srm_p_value = b.compute_srm()
         bandit_result = b.compute_result()
+        if (
+            bandit_result.bandit_update_message
+            and bandit_result.bandit_update_message.startswith(
+                "total sample size is only "
+            )
+        ):
+            return get_error_bandit_result(
+                update_message=bandit_result.bandit_update_message,
+                error="",
+                reweight=bandit_settings.reweight,
+                current_weights=bandit_settings.current_weights,
+            )
         if (
             bandit_result.bandit_update_message == "successfully updated"
             and bandit_result.ci
@@ -689,11 +702,13 @@ def get_bandit_result(
                 else "unknown error in get_bandit_result"
             )
             return get_error_bandit_result(
+                update_message="not updated",
                 error=error_message,
                 reweight=bandit_settings.reweight,
                 current_weights=bandit_settings.current_weights,
             )
     return get_error_bandit_result(
+        update_message="not updated",
         error="no data froms sql query matches dimension",
         reweight=bandit_settings.reweight,
         current_weights=bandit_settings.current_weights,
@@ -778,6 +793,7 @@ def process_experiment_results(
                 else:
                     if d.bandit_settings:
                         bandit_result = get_error_bandit_result(
+                            update_message="not updated",
                             error="no rows",
                             reweight=d.bandit_settings.reweight,
                             current_weights=d.bandit_settings.current_weights,

--- a/packages/stats/gbstats/gbstats.py
+++ b/packages/stats/gbstats/gbstats.py
@@ -657,12 +657,7 @@ def get_bandit_result(
             )
         srm_p_value = b.compute_srm()
         bandit_result = b.compute_result()
-        if (
-            bandit_result.bandit_update_message
-            and bandit_result.bandit_update_message.startswith(
-                "total sample size is only "
-            )
-        ):
+        if not bandit_result.enough_units:
             return get_error_bandit_result(
                 update_message=bandit_result.bandit_update_message,
                 error="",


### PR DESCRIPTION
### Features and Changes
when sample size is small for a bandit, return warning rather than error
previous: 
<img width="1728" alt="error" src="https://github.com/user-attachments/assets/f9931aa3-2bb5-48ce-9285-17e3a855e15a">
updated: 
<img width="1728" alt="warning" src="https://github.com/user-attachments/assets/df75659b-e395-46dd-afeb-eb8c787b6992">
