### PR TITLE
Add MultiSelect for list conditions on enum attributes

### DIFF
--- a/packages/front-end/components/Features/ConditionInput.tsx
+++ b/packages/front-end/components/Features/ConditionInput.tsx
@@ -24,6 +24,7 @@ import StringArrayField from "@/components/Forms/StringArrayField";
 import CountrySelector, {
   ALL_COUNTRY_CODES,
 } from "@/components/Forms/CountrySelector";
+import MultiSelectField from "@/components/Forms/MultiSelectField";
 import styles from "./ConditionInput.module.scss";
 
 interface Props {
@@ -332,10 +333,10 @@ export default function ConditionInput(props: Props) {
               displayType = "select-only";
             } else if (attribute.enum === ALL_COUNTRY_CODES) {
               displayType = "isoCountryCode";
-            } else if (listOperators.includes(operator)) {
-              displayType = "array-field";
             } else if (attribute.enum.length) {
               displayType = "enum";
+            } else if (listOperators.includes(operator)) {
+              displayType = "array-field";
             } else if (attribute.datatype === "number") {
               displayType = "number";
             } else if (
@@ -474,20 +475,36 @@ export default function ConditionInput(props: Props) {
                       />
                     )
                   ) : displayType === "enum" ? (
-                    <SelectField
-                      options={attribute.enum.map((v) => ({
-                        label: v,
-                        value: v,
-                      }))}
-                      value={value}
-                      onChange={(v) => {
-                        handleCondsChange(v, "value");
-                      }}
-                      name="value"
-                      initialOption="Choose One..."
-                      containerClassName="col-sm-12 col-md mb-2"
-                      required
-                    />
+                    listOperators.includes(operator) ? (
+                      <MultiSelectField
+                        options={attribute.enum.map((v) => ({
+                          label: v,
+                          value: v,
+                        }))}
+                        value={
+                          value ? value.split(",").map((val) => val.trim()) : []
+                        }
+                        onChange={handleListChange}
+                        name="value"
+                        containerClassName="col-sm-12 col-md mb-2"
+                        required
+                      />
+                    ) : (
+                      <SelectField
+                        options={attribute.enum.map((v) => ({
+                          label: v,
+                          value: v,
+                        }))}
+                        value={value}
+                        onChange={(v) => {
+                          handleCondsChange(v, "value");
+                        }}
+                        name="value"
+                        initialOption="Choose One..."
+                        containerClassName="col-sm-12 col-md mb-2"
+                        required
+                      />
+                    )
                   ) : displayType === "number" ? (
                     <Field
                       type="number"


### PR DESCRIPTION
### Features and Changes

Changes the `ConditionInput` logic to use a `MultiSelectField` when using a list operator on an enum field.

- Closes #3180

### Testing

* Checked that the UX works correctly (typeahead, enter to select, doesn't allow a value outside of the enum) in simple mode
* If an invalid value is entered in advanced mode, handles it gracefully (allows it to exist but doesn't render in simple mode. If updated in simple, the invalid value is purged)

### Screenshots

![image](https://github.com/user-attachments/assets/c78d09bd-4dd6-4da7-8214-0f0cafe81aa5)

![image](https://github.com/user-attachments/assets/440326dd-c329-4075-ab5f-b763fc35b2bf)
