### PR TITLE
Smith/bandits return user counts

### DIFF
--- a/packages/stats/gbstats/bayesian/bandits.py
+++ b/packages/stats/gbstats/bayesian/bandits.py
@@ -7,7 +7,7 @@ import random
 from pydantic.dataclasses import dataclass
 from scipy.stats import chi2  # type: ignore
 
-from gbstats.models.results import BanditResult
+from gbstats.models.results import BanditResult, SingleVariationResult
 from gbstats.models.statistics import (
     SampleMeanStatistic,
     RatioStatistic,
@@ -43,10 +43,14 @@ class BanditResponse:
 
 
 def get_error_bandit_result(
-    update_message: str, error: str, reweight: bool, current_weights: List[float]
+    single_variation_results: Optional[List[SingleVariationResult]],
+    update_message: str,
+    error: str,
+    reweight: bool,
+    current_weights: List[float],
 ) -> BanditResult:
     return BanditResult(
-        singleVariationResults=None,
+        singleVariationResults=single_variation_results,
         currentWeights=current_weights,
         updatedWeights=current_weights,
         srm=1,

--- a/packages/stats/gbstats/gbstats.py
+++ b/packages/stats/gbstats/gbstats.py
@@ -650,6 +650,7 @@ def get_bandit_result(
     if b:
         if any(value is None for value in b.stats):
             return get_error_bandit_result(
+                single_variation_results=None,
                 update_message="not updated",
                 error="not all statistics are instance of type BanditStatistic",
                 reweight=bandit_settings.reweight,
@@ -657,13 +658,6 @@ def get_bandit_result(
             )
         srm_p_value = b.compute_srm()
         bandit_result = b.compute_result()
-        if not bandit_result.enough_units:
-            return get_error_bandit_result(
-                update_message=bandit_result.bandit_update_message,
-                error="",
-                reweight=bandit_settings.reweight,
-                current_weights=bandit_settings.current_weights,
-            )
         if (
             bandit_result.bandit_update_message == "successfully updated"
             and bandit_result.ci
@@ -677,6 +671,16 @@ def get_bandit_result(
                     bandit_result.ci,
                 )
             ]
+            if not bandit_result.enough_units:
+                raise ValueError("jill")
+                return get_error_bandit_result(
+                    single_variation_results=single_variation_results,
+                    update_message=bandit_result.bandit_update_message,
+                    error="",
+                    reweight=bandit_settings.reweight,
+                    current_weights=bandit_settings.current_weights,
+                )
+
             return BanditResult(
                 singleVariationResults=single_variation_results,
                 currentWeights=bandit_settings.current_weights,
@@ -697,12 +701,14 @@ def get_bandit_result(
                 else "unknown error in get_bandit_result"
             )
             return get_error_bandit_result(
+                single_variation_results=None,
                 update_message="not updated",
                 error=error_message,
                 reweight=bandit_settings.reweight,
                 current_weights=bandit_settings.current_weights,
             )
     return get_error_bandit_result(
+        single_variation_results=None,
         update_message="not updated",
         error="no data froms sql query matches dimension",
         reweight=bandit_settings.reweight,
@@ -788,6 +794,7 @@ def process_experiment_results(
                 else:
                     if d.bandit_settings:
                         bandit_result = get_error_bandit_result(
+                            single_variation_results=None,
                             update_message="not updated",
                             error="no rows",
                             reweight=d.bandit_settings.reweight,

--- a/packages/stats/gbstats/gbstats.py
+++ b/packages/stats/gbstats/gbstats.py
@@ -658,11 +658,7 @@ def get_bandit_result(
             )
         srm_p_value = b.compute_srm()
         bandit_result = b.compute_result()
-        if (
-            bandit_result.bandit_update_message == "successfully updated"
-            and bandit_result.ci
-            and bandit_result.bandit_weights
-        ):
+        if bandit_result.ci:
             single_variation_results = [
                 SingleVariationResult(n, mn, ci)
                 for n, mn, ci in zip(
@@ -672,7 +668,6 @@ def get_bandit_result(
                 )
             ]
             if not bandit_result.enough_units:
-                raise ValueError("jill")
                 return get_error_bandit_result(
                     single_variation_results=single_variation_results,
                     update_message=bandit_result.bandit_update_message,
@@ -680,20 +675,23 @@ def get_bandit_result(
                     reweight=bandit_settings.reweight,
                     current_weights=bandit_settings.current_weights,
                 )
-
-            return BanditResult(
-                singleVariationResults=single_variation_results,
-                currentWeights=bandit_settings.current_weights,
-                updatedWeights=bandit_result.bandit_weights
-                if bandit_settings.reweight
-                else bandit_settings.current_weights,
-                srm=srm_p_value,
-                bestArmProbabilities=bandit_result.best_arm_probabilities,
-                seed=bandit_result.seed,
-                updateMessage=bandit_result.bandit_update_message,
-                error="",
-                reweight=bandit_settings.reweight,
-            )
+            if (
+                bandit_result.bandit_update_message == "successfully updated"
+                and bandit_result.bandit_weights
+            ):
+                return BanditResult(
+                    singleVariationResults=single_variation_results,
+                    currentWeights=bandit_settings.current_weights,
+                    updatedWeights=bandit_result.bandit_weights
+                    if bandit_settings.reweight
+                    else bandit_settings.current_weights,
+                    srm=srm_p_value,
+                    bestArmProbabilities=bandit_result.best_arm_probabilities,
+                    seed=bandit_result.seed,
+                    updateMessage=bandit_result.bandit_update_message,
+                    error="",
+                    reweight=bandit_settings.reweight,
+                )
         else:
             error_message = (
                 bandit_result.bandit_update_message


### PR DESCRIPTION
return variation sample sizes when the total sample size is too small to run bandit.  useful for displaying current sample sizes by variation, so the customer knows if the bandit is running.  
