### PR TITLE
Add null typeguard for window history

### DIFF
--- a/packages/front-end/services/track.ts
+++ b/packages/front-end/services/track.ts
@@ -111,7 +111,7 @@ function getOrGenerateDeviceId() {
 function getOrGeneratePageId() {
   // On initial load if the router hasn't initialized a state change yet then history.state will be null.
   // Since this only happens on one pageload, using a hardcoded default key should still work as its own key
-  if (!((window.history.state?.key || "null") in pageIds)) {
+  if (!((window.history.state?.key || "") in pageIds)) {
     pageIds[window.history.state.key] = uuidv4();
   }
   return pageIds[window.history.state.key];

--- a/packages/front-end/services/track.ts
+++ b/packages/front-end/services/track.ts
@@ -111,7 +111,6 @@ function getOrGenerateDeviceId() {
 function getOrGeneratePageId() {
   // On initial load if the router hasn't initialized a state change yet then history.state will be null.
   // Since this only happens on one pageload, using a hardcoded default key should still work as its own key
-  console.log(window.history.state?.key || "null");
   if (!((window.history.state?.key || "null") in pageIds)) {
     pageIds[window.history.state.key] = uuidv4();
   }

--- a/packages/front-end/services/track.ts
+++ b/packages/front-end/services/track.ts
@@ -109,7 +109,10 @@ function getOrGenerateDeviceId() {
 }
 
 function getOrGeneratePageId() {
-  if (!(window.history.state.key in pageIds)) {
+  // On initial load if the router hasn't initialized a state change yet then history.state will be null.
+  // Since this only happens on one pageload, using a hardcoded default key should still work as its own key
+  console.log(window.history.state?.key || "null");
+  if (!((window.history.state?.key || "null") in pageIds)) {
     pageIds[window.history.state.key] = uuidv4();
   }
   return pageIds[window.history.state.key];


### PR DESCRIPTION
### Features and Changes

We have a few instances coming through of `window.history.state is null`, which can be easily fixed by allowing a default key for the initial pageload before the router has populated the history. It's possible that this can make two events on that initial pageview appear under different page ids depending on timing, but I think that should be an insignificant edge case.

### Testing

I haven't been able to reproduce a case where this codepath naturally runs on a null history, but you can check the behavior in the console on a new tab with no history 

### Screenshots

On a new tab before navigating
![image](https://github.com/user-attachments/assets/926b71f6-efd4-465c-afc1-d6239e8b7b55)

On that tab after navigating to a non-spa site
![image](https://github.com/user-attachments/assets/c7cf18a2-d807-4756-82d7-a8aa130c7ea1)

On a new tab after loading growthbook
![image](https://github.com/user-attachments/assets/19ed30d3-20d7-46a2-a2a2-2edd8cea6890)
