### PR TITLE
Add anonymoud_id attribute to internal GrowthBook implementation

### DIFF
--- a/packages/front-end/services/UserContext.tsx
+++ b/packages/front-end/services/UserContext.tsx
@@ -41,7 +41,7 @@ import {
 } from "@/services/env";
 import useApi from "@/hooks/useApi";
 import { useAuth, UserOrganizations } from "@/services/auth";
-import track from "@/services/track";
+import track, { getJitsuClient } from "@/services/track";
 import { AppFeatures } from "@/types/app-features";
 import { sha256 } from "@/services/utils";
 
@@ -301,7 +301,23 @@ export function UserContextProvider({ children }: { children: ReactNode }) {
   const growthbook = useGrowthBook<AppFeatures>();
 
   useEffect(() => {
+    let anonymous_id = "";
+    // This is an undocumented way to get the anonymous id from Jitsu
+    // Lots of type guards added to avoid breaking if we update Jitsu in the future
+    const jitsu = getJitsuClient();
+    if (
+      jitsu &&
+      "getAnonymousId" in jitsu &&
+      typeof jitsu.getAnonymousId === "function"
+    ) {
+      const _anonymous_id = jitsu.getAnonymousId();
+      if (typeof _anonymous_id === "string") {
+        anonymous_id = _anonymous_id;
+      }
+    }
+
     growthbook?.setAttributes({
+      anonymous_id,
       id: data?.userId || "",
       name: data?.userName || "",
       superAdmin: data?.superAdmin || false,

--- a/packages/front-end/services/track.ts
+++ b/packages/front-end/services/track.ts
@@ -134,7 +134,24 @@ function getOrGenerateSessionId() {
   return sessionId;
 }
 
-let jitsu: JitsuClient;
+let _jitsu: JitsuClient;
+export function getJitsuClient(): JitsuClient | null {
+  if (isTelemetryEnabled()) return null;
+
+  if (!_jitsu) {
+    _jitsu = jitsuClient({
+      key: "js.y6nea.yo6e8isxplieotd6zxyeu5",
+      log_level: "ERROR",
+      tracking_host: "https://t.growthbook.io",
+      cookie_name: "__growthbookid",
+      capture_3rd_party_cookies: isCloud() ? ["_ga"] : false,
+      randomize_url: true,
+    });
+  }
+
+  return _jitsu;
+}
+
 export default function track(
   event: string,
   props: TrackEventProps = {}
@@ -198,18 +215,10 @@ export default function track(
   }
   if (!isTelemetryEnabled()) return;
 
-  if (!jitsu) {
-    jitsu = jitsuClient({
-      key: "js.y6nea.yo6e8isxplieotd6zxyeu5",
-      log_level: "ERROR",
-      tracking_host: "https://t.growthbook.io",
-      cookie_name: "__growthbookid",
-      capture_3rd_party_cookies: isCloud() ? ["_ga"] : false,
-      randomize_url: true,
-    });
+  const jitsu = getJitsuClient();
+  if (jitsu) {
+    jitsu.track(event, trackProps);
   }
-
-  jitsu.track(event, trackProps);
 }
 
 export function trackSnapshot(

--- a/packages/front-end/services/track.ts
+++ b/packages/front-end/services/track.ts
@@ -136,7 +136,7 @@ function getOrGenerateSessionId() {
 
 let _jitsu: JitsuClient;
 export function getJitsuClient(): JitsuClient | null {
-  if (isTelemetryEnabled()) return null;
+  if (!isTelemetryEnabled()) return null;
 
   if (!_jitsu) {
     _jitsu = jitsuClient({
@@ -213,7 +213,6 @@ export default function track(
   if (inTelemetryDebugMode()) {
     console.log("Telemetry Event - ", event, trackProps);
   }
-  if (!isTelemetryEnabled()) return;
 
   const jitsu = getJitsuClient();
   if (jitsu) {


### PR DESCRIPTION
### Features and Changes

Allows us to dogfood Bandits on the GrowthBook app (and any other experiments we want to randomize at the device level).