### PR TITLE
Fix ClickHouse NULL date in Metric Analysis query

### DIFF
--- a/packages/back-end/src/integrations/ClickHouse.ts
+++ b/packages/back-end/src/integrations/ClickHouse.ts
@@ -85,6 +85,10 @@ export default class ClickHouse extends SqlIntegration {
   ifElse(condition: string, ifTrue: string, ifFalse: string) {
     return `if(${condition}, ${ifTrue}, ${ifFalse})`;
   }
+  castToDate(col: string): string {
+    const columType = col === "NULL" ? "Nullable(DATE)" : "DATE";
+    return `CAST(${col} AS ${columType})`;
+  }
   castToString(col: string): string {
     return `toString(${col})`;
   }


### PR DESCRIPTION
### Features and Changes

Must case NULL as nullable date in clickhouse to fix bug in Metric Analysis query.

- Closes #3129 

### Testing

Recreated bug and the user suggested fix worked

### Screenshots

<img width="510" alt="Screenshot 2024-10-28 at 2 52 01 PM" src="https://github.com/user-attachments/assets/0f0e8e68-4e80-47fe-9e1e-46ec7de7f38e">

<img width="1093" alt="Screenshot 2024-10-28 at 2 52 12 PM" src="https://github.com/user-attachments/assets/ebe8f62b-6845-4c2e-ae09-38cffbd523ce">
