### PR TITLE
Reset nested bold in labels

### DIFF
--- a/packages/front-end/components/Experiment/TabbedPage/TrafficAndTargeting.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/TrafficAndTargeting.tsx
@@ -92,6 +92,11 @@ export default function TrafficAndTargeting({
                     </HashVersionTooltip>
                   }
                 </div>
+                {experiment.disableStickyBucketing ? (
+                  <div className="mt-1">
+                    Sticky bucketing: <em>disabled</em>
+                  </div>
+                ) : null}
               </div>
 
               <div className="col-4">

--- a/packages/front-end/components/Experiment/TabbedPage/TrafficAndTargeting.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/TrafficAndTargeting.tsx
@@ -92,11 +92,6 @@ export default function TrafficAndTargeting({
                     </HashVersionTooltip>
                   }
                 </div>
-                {experiment.disableStickyBucketing ? (
-                  <div className="mt-1">
-                    Sticky bucketing: <em>disabled</em>
-                  </div>
-                ) : null}
               </div>
 
               <div className="col-4">

--- a/packages/front-end/components/Settings/forms/StatsEngineSelect.tsx
+++ b/packages/front-end/components/Settings/forms/StatsEngineSelect.tsx
@@ -12,7 +12,7 @@ export default function StatsEngineSelect({
   className = "w-200px",
   value,
   onChange,
-  labelClassName = "font-weight-bold text-muted mr-2",
+  labelClassName = "mr-2",
   disabled,
 }: {
   value?: StatsEngine;

--- a/packages/front-end/styles/global.scss
+++ b/packages/front-end/styles/global.scss
@@ -1223,6 +1223,10 @@ main.main.report {
   label:not(.rt-Text) {
     color: var(--text-color-main);
     font-weight: 600;
+    strong,
+    b {
+      font-weight: 800;
+    }
   }
 }
 


### PR DESCRIPTION
`<label><strong>bold text</strong> in a label</label>`
bold text in a label was being made overly-bold due to conflicting modal and radix styles. Fixed nested rules.