### PR TITLE
BUGFIX: Do not close modal when 'Enter' is presser while an input is focused

### DIFF
--- a/packages/front-end/components/Modal.tsx
+++ b/packages/front-end/components/Modal.tsx
@@ -255,6 +255,7 @@ const Modal: FC<ModalProps> = ({
           >
             {close && includeCloseCta ? (
               <button
+                type="button"
                 className={closeCtaClassName}
                 onClick={async (e) => {
                   e.preventDefault();

--- a/packages/front-end/components/Modal/PagedModal.tsx
+++ b/packages/front-end/components/Modal/PagedModal.tsx
@@ -200,6 +200,7 @@ const PagedModal: FC<Props> = (props) => {
       backCTA={
         backButton && (step >= 1 || onBackFirstStep) ? (
           <button
+            type="button"
             className={`btn btn-link mr-3`}
             onClick={(e) => {
               e.preventDefault();
@@ -220,6 +221,7 @@ const PagedModal: FC<Props> = (props) => {
           secondaryCTA
         ) : onSkip ? (
           <button
+            type="button"
             className={`btn btn-link mr-3`}
             onClick={(e) => {
               e.preventDefault();


### PR DESCRIPTION
### Behavior

When a modal is open and we have a input selected, pressing Enter would immediately close the modal which is not the intended behavior.

### Fix

Now when Enter is pressed we will submit the form instead (same as clicking Submit on bottom right).

### Fix explanation

Because the button type was not specified, it defaults to `submit`.

When there are multiple submit buttons in the DOM, the browser will call the first one which in this case was the Cancel button on the bottom actions.

