### PR TITLE
BUGFIX: Ensure name is updated when creating a new Experiment by pressing enter

### DIFF
--- a/packages/front-end/components/Experiment/NewExperimentForm.tsx
+++ b/packages/front-end/components/Experiment/NewExperimentForm.tsx
@@ -399,6 +399,11 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
   }
   const trackingEventModalType = kebabCase(header);
 
+  const nameFieldHandlers = form.register("name", {
+    setValueAs: (s) => s?.trim(),
+  });
+  const trackingKeyFieldHandlers = form.register("trackingKey");
+
   return (
     <FormProvider {...form}>
       <PagedModal
@@ -433,8 +438,11 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
               label={isBandit ? "Bandit Name" : "Experiment Name"}
               required
               minLength={2}
-              {...form.register("name", { setValueAs: (s) => s?.trim() })}
+              {...nameFieldHandlers}
               onChange={async (e) => {
+                // Ensure the name field is updated and then sync with trackingKey if possible
+                nameFieldHandlers.onChange(e);
+
                 if (!isNewExperiment) return;
                 if (!linkNameWithTrackingKey) return;
                 const val = e?.target?.value ?? form.watch("name");
@@ -455,11 +463,14 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
 
             <Field
               label="Tracking Key"
-              {...form.register("trackingKey")}
               helpText={`Unique identifier for this ${
                 isBandit ? "Bandit" : "Experiment"
               }, used to track impressions and analyze results`}
-              onChange={() => setLinkNameWithTrackingKey(false)}
+              {...trackingKeyFieldHandlers}
+              onChange={(e) => {
+                trackingKeyFieldHandlers.onChange(e);
+                setLinkNameWithTrackingKey(false);
+              }}
             />
 
             {!isBandit && (


### PR DESCRIPTION
### Features and Changes

When testing the keyboard Enter behavior in the Create Experiment modal I noticed that using `enter` to submit would not update the form value properly.

Calling the field `onChange` manually on our override fixes the problem.

### Screenshots

#### Before fix

Notice how the name field is empty when we go back. It would also show up as an error on the last step.

![before](https://github.com/user-attachments/assets/eeda609d-26e3-47de-b522-7d3085560284)

#### After fix

Name is properly synced.

![after](https://github.com/user-attachments/assets/873f16f0-807c-445b-9e9d-0cbba87a5e8c)