### PR TITLE
Fact Metrics - inherit projects from fact table by default

### DIFF
--- a/packages/front-end/components/FactTables/FactMetricModal.tsx
+++ b/packages/front-end/components/FactTables/FactMetricModal.tsx
@@ -908,7 +908,8 @@ export default function FactMetricModal({
         } else {
           const createPayload: CreateFactMetricProps = {
             ...values,
-            projects: selectedDataSource.projects || [],
+            projects:
+              numeratorFactTable?.projects || selectedDataSource.projects || [],
           };
 
           await apiCall<{


### PR DESCRIPTION
### Features and Changes

Currently it's inheriting projects from the data source, but inheriting from the fact table makes more sense.