### PR TITLE
Fix metric override text in dark mode

### DIFF
--- a/packages/front-end/components/Experiment/MetricsOverridesSelector.tsx
+++ b/packages/front-end/components/Experiment/MetricsOverridesSelector.tsx
@@ -218,7 +218,7 @@ export default function MetricsOverridesSelector({
 
               <div>
                 <label className="mb-1">
-                  <strong className="text-body">
+                  <strong>
                     <MetricName id={metricDefinition?.id || ""} />
                   </strong>
                 </label>


### PR DESCRIPTION
The only use of "text-body" class in the code base, so I removed it as it was causing issues in dark mode.

Before (you have to squint to see the title)
<img width="770" alt="Screenshot 2024-10-30 at 8 20 35 AM" src="https://github.com/user-attachments/assets/dd3dbabc-7ebf-4d4e-ab80-96b4dcebadd4">


After
<img width="803" alt="Screenshot 2024-10-30 at 8 22 25 AM" src="https://github.com/user-attachments/assets/1a26391b-8e76-4b2a-b84c-8ca328aa2059">
