### PR TITLE
Fix multiple exposures error in GrowthBook App

### DIFF
--- a/packages/front-end/services/UserContext.tsx
+++ b/packages/front-end/services/UserContext.tsx
@@ -221,6 +221,7 @@ export function UserContextProvider({ children }: { children: ReactNode }) {
   const [hashedOrganizationId, setHashedOrganizationId] = useState<string>("");
   useEffect(() => {
     const id = currentOrg?.organization?.id || "";
+    if (!id) return;
     sha256(GROWTHBOOK_SECURE_ATTRIBUTE_SALT + id).then((hashedOrgId) => {
       setHashedOrganizationId(hashedOrgId);
     });


### PR DESCRIPTION
### Features and Changes

There is a race condition in the GrowthBook App.  On the first render, the `organizationId` attribute we pass into the GrowthBook instance is set to `sha256(salt + "")` and then on a subsequent render it's set to `sha256(salt + orgId)`.

This can cause a multiple exposures warning when assigning experiment traffic on page load using that attribute.

This PR skips setting the `organizationId` attribute until `orgId` is a non-empty string.