### PR TITLE
only performing srm for bandits when n is at least 5 in each cell

### DIFF
--- a/packages/front-end/components/HealthTab/BanditSRMCard.tsx
+++ b/packages/front-end/components/HealthTab/BanditSRMCard.tsx
@@ -24,7 +24,7 @@ export const srmHealthCheck = ({
   srmThreshold: number;
   totalUsers: number;
 }): HealthStatus => {
-  if (totalUsers && totalUsers < 8 * numVariations) {
+  if (totalUsers && totalUsers < 5 * numVariations) {
     return "Not enough traffic";
   } else if (srm >= srmThreshold) {
     return "healthy";

--- a/packages/stats/gbstats/bayesian/bandits.py
+++ b/packages/stats/gbstats/bayesian/bandits.py
@@ -103,7 +103,12 @@ class Bandits(ABC):
 
     @property
     def enough_samples_for_srm(self):
-        return all(self.variation_counts >= 5)
+        expected_count = (
+            self.current_sample_size / self.num_variations
+            if self.num_variations > 0
+            else 0
+        )
+        return expected_count >= 5
 
     @property
     def historical_weights_array(self) -> np.ndarray:

--- a/packages/stats/gbstats/bayesian/bandits.py
+++ b/packages/stats/gbstats/bayesian/bandits.py
@@ -45,6 +45,7 @@ class BanditResponse:
 def get_error_bandit_result(
     single_variation_results: Optional[List[SingleVariationResult]],
     update_message: str,
+    srm: float,
     error: str,
     reweight: bool,
     current_weights: List[float],
@@ -53,7 +54,7 @@ def get_error_bandit_result(
         singleVariationResults=single_variation_results,
         currentWeights=current_weights,
         updatedWeights=current_weights,
-        srm=1,
+        srm=srm,
         bestArmProbabilities=None,
         seed=0,
         updateMessage=update_message,
@@ -99,6 +100,10 @@ class Bandits(ABC):
     @property
     def current_sample_size(self):
         return sum(self.variation_counts)
+
+    @property
+    def enough_samples_for_srm(self):
+        return all(self.variation_counts >= 5)
 
     @property
     def historical_weights_array(self) -> np.ndarray:

--- a/packages/stats/gbstats/gbstats.py
+++ b/packages/stats/gbstats/gbstats.py
@@ -657,7 +657,7 @@ def get_bandit_result(
                 reweight=bandit_settings.reweight,
                 current_weights=bandit_settings.current_weights,
             )
-        srm_p_value = b.compute_srm() if b.enough_samples_for_srm else 1
+        srm_p_value = b.compute_srm()
         bandit_result = b.compute_result()
         if bandit_result.ci:
             single_variation_results = [

--- a/packages/stats/gbstats/gbstats.py
+++ b/packages/stats/gbstats/gbstats.py
@@ -652,11 +652,12 @@ def get_bandit_result(
             return get_error_bandit_result(
                 single_variation_results=None,
                 update_message="not updated",
+                srm=1,
                 error="not all statistics are instance of type BanditStatistic",
                 reweight=bandit_settings.reweight,
                 current_weights=bandit_settings.current_weights,
             )
-        srm_p_value = b.compute_srm()
+        srm_p_value = b.compute_srm() if b.enough_samples_for_srm else 1
         bandit_result = b.compute_result()
         if bandit_result.ci:
             single_variation_results = [
@@ -671,6 +672,7 @@ def get_bandit_result(
                 return get_error_bandit_result(
                     single_variation_results=single_variation_results,
                     update_message=bandit_result.bandit_update_message,
+                    srm=srm_p_value,
                     error="",
                     reweight=bandit_settings.reweight,
                     current_weights=bandit_settings.current_weights,
@@ -701,6 +703,7 @@ def get_bandit_result(
             return get_error_bandit_result(
                 single_variation_results=None,
                 update_message="not updated",
+                srm=1,
                 error=error_message,
                 reweight=bandit_settings.reweight,
                 current_weights=bandit_settings.current_weights,
@@ -708,6 +711,7 @@ def get_bandit_result(
     return get_error_bandit_result(
         single_variation_results=None,
         update_message="not updated",
+        srm=1,
         error="no data froms sql query matches dimension",
         reweight=bandit_settings.reweight,
         current_weights=bandit_settings.current_weights,
@@ -794,6 +798,7 @@ def process_experiment_results(
             single_variation_results=None,
             update_message="not updated",
             error="no rows",
+            srm=1,
             reweight=d.bandit_settings.reweight,
             current_weights=d.bandit_settings.current_weights,
         )


### PR DESCRIPTION
returning SRM for bandits when the expected number of users per variation arm is at least 5, which is consistent with statistical theory.  currently we do not return SRM unless we have at least 100 units per variation arm.  

When n <=1 in all arms, SRM doesn't run anymore 
<img width="1728" alt="srm_1" src="https://github.com/user-attachments/assets/ddf04cfa-4264-4f0e-b5c7-907d75883e78">

<img width="1728" alt="health_tab_1" src="https://github.com/user-attachments/assets/0b2deb53-7147-4883-8a8b-63f2dd7d7a07">

when expected n = 5 in all arms, srm runs
<img width="1728" alt="srm_5" src="https://github.com/user-attachments/assets/b022216b-aded-42ee-a1fd-eeada3547eba">

SRM now shows results on health tab when total number of users is at least 5*num_variations (seems to be bug in first 
<img width="1728" alt="srm_5" src="https://github.com/user-attachments/assets/d586df55-1eff-498d-837e-eb6134c8225a">


