### PR TITLE
Fix Change Password menu option hover color and close dropdown when clicked

### DIFF
--- a/packages/front-end/components/Layout/TopNav.tsx
+++ b/packages/front-end/components/Layout/TopNav.tsx
@@ -374,13 +374,7 @@ const TopNav: FC<{
   const renderChangePassword = () => {
     if (!usingSSO()) {
       return (
-        <DropdownMenu.Item
-          className="dropdown-item"
-          onSelect={(e) => {
-            e.preventDefault();
-            setChangePasswordOpen(true);
-          }}
-        >
+        <DropdownMenu.Item onSelect={() => setChangePasswordOpen(true)}>
           Change Password
         </DropdownMenu.Item>
       );


### PR DESCRIPTION
### Features and Changes

- Make 'Change Password' have the same background color as other options on hover
- Close menu when 'Change Password' is selected

### Screenshots

| Before | After |
|--------|--------|
| ![change-pass-before](https://github.com/user-attachments/assets/74d15e6d-a373-4fc8-b1ed-c149fdeb7ad5) | ![change-pass-after](https://github.com/user-attachments/assets/e3547198-bf54-4865-bd63-3ea17837199a) |
