### PR TITLE
removing bug where control variation statistic can be a ProportionSta…

### DIFF
--- a/packages/stats/gbstats/gbstats.py
+++ b/packages/stats/gbstats/gbstats.py
@@ -592,8 +592,8 @@ def create_bandit_statistics(
     s = reduced.iloc[0]
     s0 = variation_statistic_from_metric_row(row=s, prefix="baseline", metric=metric)
     # for bandits we weight by period; iid data over periods no longer holds
-    # if isinstance(s0, ProportionStatistic):
-    #    s0 = SampleMeanStatistic(n=s0.n, sum=s0.sum, sum_squares=s0.sum)
+    if isinstance(s0, ProportionStatistic):
+        s0 = SampleMeanStatistic(n=s0.n, sum=s0.sum, sum_squares=s0.sum)
     stats = [s0]
     for i in range(1, num_variations):
         s1 = variation_statistic_from_metric_row(row=s, prefix=f"v{i}", metric=metric)


### PR DESCRIPTION
removing bug where the control variation statistic can be of type ProportionStatistic for a bandit.  We don't allow this, as the iid assumption on the variance for a proportion statistic is not satisfied.  