### PR TITLE
UX fixes: fact table SQL editing, paginated metric and member lists

### DIFF
--- a/packages/front-end/README.md
+++ b/packages/front-end/README.md
@@ -154,28 +154,29 @@ Any normal HTML props can be passed as well and will be passed onto the underlyi
 
 ### Select Dropdowns
 
-Select dropdowns have 2 additional props:
+Use the `SelectField` component to render a dropdown.
 
-- **options** (required)
-- **initialOption** (optional, string)
+It has many of the same properties as `Field`, but there are 2 main differences:
 
-The `options` prop can be an array of strings, an array of `{value: "...", display: "..."}` objects, or an object mapping (e.g. `{fname: "First Name", lname: "Last Name"}`). Use the `initialOption` prop if you want to add a blank option to the top of the list (e.g. `Choose one...`).
+1. Must pass in `options`
+2. Cannot use `form.register`. Instead specify a `value` and `setValue` prop.
 
-Examples:
+Example:
 
 ```tsx
-<Field initialOption="Pick One" options={["one", "two"]}/>
-
-<Field options={[
-  {value: "1", display: "One"},
-  {value: "2", display: "Two"},
-]}/>
-
-<Field options={{
-  "1": "One",
-  "2": "Two",
-}}/>
+<SelectField
+  options={[
+    {value: "1", label: "One"},
+    {value: "2", label: "Two"}
+  ]}
+  value={form.watch("myField")}
+  setValue={(val) => form.setValue("myField", val)}
+>
 ```
+
+There is also a `MultiSelectField` component where the value is an array of strings instead of a single string.
+
+Both `SelectField` and `MultiSelectField` have a `createable` prop that makes it act more like an auto-complete field than a true dropdown.
 
 ### Textareas
 
@@ -204,7 +205,7 @@ There is also a `render` prop for completely custom inputs.
 />
 ```
 
-## Searching and Sorting
+## Searching, Sorting, and Pagination
 
 Whenever we show a list of items, we typically render a table and provide searching and sorting functionality.
 
@@ -217,11 +218,12 @@ The `useSearch` hook makes this process much simpler and removes a lot of boiler
 const features: FeatureInterface[];
 
 // Filter by search term and sort results
-const { items, searchInputProps, SortableTH } = useSearch({
+const { items, searchInputProps, SortableTH, pagination } = useSearch({
   items: features,
   localStorageKey: "features",
   searchFields: ["id", "description"],
   defaultSortField: "id",
+  pageSize: 20,
 });
 
 // Render the UI
@@ -248,6 +250,7 @@ return (
         ))}
       </tbody>
     </table>
+    {pagination}
   </div>
 );
 ```
@@ -390,6 +393,18 @@ return (
   </table>
 );
 ```
+
+### Pagination
+
+By default, pagination is disabled. Specify a `pageSize` in the `useSearch` hook to enable it.
+
+There are also 3 return properties from the hook:
+
+- `pagination` - Make sure to render this right after your table
+- `page` - The current page
+- `resetPage` - A callback you can call to reset to page 1
+
+Note: Pagination is done client-side and does not reduce the memory consumption or network usage. It can however reduce CPU by limiting the number of components rendered to the screen.
 
 ### Custom search syntax (advanced)
 

--- a/packages/front-end/components/FactTables/ColumnList.tsx
+++ b/packages/front-end/components/FactTables/ColumnList.tsx
@@ -41,11 +41,19 @@ export default function ColumnList({ factTable }: Props) {
         : column.datatype,
   }));
 
-  const { items, searchInputProps, isFiltered, SortableTH, clear } = useSearch({
+  const {
+    items,
+    searchInputProps,
+    isFiltered,
+    SortableTH,
+    clear,
+    pagination,
+  } = useSearch({
     items: columns,
     defaultSortField: "dateCreated",
     localStorageKey: "factColumns",
     searchFields: ["name^3", "description", "column^2"],
+    pageSize: 10,
   });
 
   const canEdit = permissionsUtil.canViewEditFactTableModal(factTable);
@@ -105,87 +113,90 @@ export default function ColumnList({ factTable }: Props) {
         </div>
       )}
       {columns.length > 0 ? (
-        <table className="table appbox gbtable mt-2 mb-0">
-          <thead>
-            <tr>
-              <SortableTH field="column">Column</SortableTH>
-              <th></th>
-              <SortableTH field="type">Type</SortableTH>
-              <th style={{ width: 30 }}></th>
-            </tr>
-          </thead>
-          <tbody>
-            {items.map((col) => (
-              <tr key={col.column}>
-                <td>
-                  {col.column}{" "}
-                  {col.identifier && (
-                    <Tooltip body="User Identifier Type">
-                      <span className="badge badge-purple">
-                        <FaUser />
-                      </span>
-                    </Tooltip>
-                  )}
-                  {col.column === "timestamp" && (
-                    <Tooltip body="Main date field used for sorting and filtering">
-                      <span className="badge badge-purple">
-                        <FaClock />
-                      </span>
-                    </Tooltip>
-                  )}
-                  {col.alwaysInlineFilter && (
-                    <Tooltip body="Prompt all metrics to filter on this column">
-                      <span className="badge badge-purple">
-                        <FaFilter />
-                      </span>
-                    </Tooltip>
-                  )}
-                </td>
-                <td>{col.name !== col.column ? `"${col.name}"` : ""}</td>
-                <td>
-                  {col.datatype || "unknown"}{" "}
-                  {col.datatype === "number" && col.numberFormat && (
-                    <>({col.numberFormat})</>
-                  )}
-                  {col.datatype === "" && (
-                    <Tooltip body="Unable to detect the data type. Edit this column to set one.">
-                      <FaTriangleExclamation className="text-danger" />
-                    </Tooltip>
-                  )}
-                </td>
-                <td>
-                  {canEdit && (
-                    <button
-                      className="btn btn-link btn-sm"
+        <>
+          <table className="table appbox gbtable mt-2 mb-0">
+            <thead>
+              <tr>
+                <SortableTH field="column">Column</SortableTH>
+                <th></th>
+                <SortableTH field="type">Type</SortableTH>
+                <th style={{ width: 30 }}></th>
+              </tr>
+            </thead>
+            <tbody>
+              {items.map((col) => (
+                <tr key={col.column}>
+                  <td>
+                    {col.column}{" "}
+                    {col.identifier && (
+                      <Tooltip body="User Identifier Type">
+                        <span className="badge badge-purple">
+                          <FaUser />
+                        </span>
+                      </Tooltip>
+                    )}
+                    {col.column === "timestamp" && (
+                      <Tooltip body="Main date field used for sorting and filtering">
+                        <span className="badge badge-purple">
+                          <FaClock />
+                        </span>
+                      </Tooltip>
+                    )}
+                    {col.alwaysInlineFilter && (
+                      <Tooltip body="Prompt all metrics to filter on this column">
+                        <span className="badge badge-purple">
+                          <FaFilter />
+                        </span>
+                      </Tooltip>
+                    )}
+                  </td>
+                  <td>{col.name !== col.column ? `"${col.name}"` : ""}</td>
+                  <td>
+                    {col.datatype || "unknown"}{" "}
+                    {col.datatype === "number" && col.numberFormat && (
+                      <>({col.numberFormat})</>
+                    )}
+                    {col.datatype === "" && (
+                      <Tooltip body="Unable to detect the data type. Edit this column to set one.">
+                        <FaTriangleExclamation className="text-danger" />
+                      </Tooltip>
+                    )}
+                  </td>
+                  <td>
+                    {canEdit && (
+                      <button
+                        className="btn btn-link btn-sm"
+                        onClick={(e) => {
+                          e.preventDefault();
+                          setEditOpen(col.column);
+                        }}
+                      >
+                        <GBEdit />
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              ))}
+              {!items.length && isFiltered && (
+                <tr>
+                  <td colSpan={4} align={"center"}>
+                    No matching columns.{" "}
+                    <a
+                      href="#"
                       onClick={(e) => {
                         e.preventDefault();
-                        setEditOpen(col.column);
+                        clear();
                       }}
                     >
-                      <GBEdit />
-                    </button>
-                  )}
-                </td>
-              </tr>
-            ))}
-            {!items.length && isFiltered && (
-              <tr>
-                <td colSpan={4} align={"center"}>
-                  No matching columns.{" "}
-                  <a
-                    href="#"
-                    onClick={(e) => {
-                      e.preventDefault();
-                      clear();
-                    }}
-                  >
-                    Clear search field
-                  </a>
-                </td>
-              </tr>
-            )}
-          </tbody>
-        </table>
+                      Clear search field
+                    </a>
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+          {pagination}
+        </>
       ) : (
         <div className="alert alert-warning mt-3">
           <strong>Unable to Auto-Detect Columns</strong>. Double check your SQL

--- a/packages/front-end/components/FactTables/ColumnList.tsx
+++ b/packages/front-end/components/FactTables/ColumnList.tsx
@@ -53,7 +53,7 @@ export default function ColumnList({ factTable }: Props) {
     defaultSortField: "dateCreated",
     localStorageKey: "factColumns",
     searchFields: ["name^3", "description", "column^2"],
-    pageSize: 10,
+    pageSize: 5,
   });
 
   const canEdit = permissionsUtil.canViewEditFactTableModal(factTable);

--- a/packages/front-end/components/FactTables/EditFactTableSQLModal.tsx
+++ b/packages/front-end/components/FactTables/EditFactTableSQLModal.tsx
@@ -1,0 +1,82 @@
+import { isEqual } from "lodash";
+import { useRef, useState } from "react";
+import { FactTableInterface } from "back-end/types/fact-table";
+import EditSqlModal from "@/components/SchemaBrowser/EditSqlModal";
+import { useDefinitions } from "@/services/DefinitionsContext";
+
+export interface Props {
+  factTable: Pick<
+    FactTableInterface,
+    "datasource" | "sql" | "eventName" | "userIdTypes"
+  >;
+  close: () => void;
+  save: (data: {
+    sql: string;
+    eventName: string;
+    userIdTypes: string[];
+  }) => Promise<void>;
+}
+
+export default function EditFactTableSQLModal({
+  factTable,
+  close,
+  save,
+}: Props) {
+  const { getDatasourceById } = useDefinitions();
+  const [eventName, setEventName] = useState(factTable.eventName);
+  const userIdTypes = useRef(factTable.userIdTypes);
+
+  const selectedDataSource = getDatasourceById(factTable.datasource);
+
+  return (
+    <EditSqlModal
+      close={close}
+      datasourceId={factTable.datasource}
+      placeholder={
+        "SELECT\n      user_id as user_id, timestamp as timestamp\nFROM\n      test"
+      }
+      requiredColumns={new Set(["timestamp"])}
+      value={factTable.sql}
+      save={async (sql) => {
+        await save({
+          eventName,
+          userIdTypes: userIdTypes.current,
+          sql,
+        });
+      }}
+      templateVariables={{
+        eventName: eventName,
+      }}
+      setTemplateVariables={({ eventName }) => {
+        setEventName(eventName || "");
+      }}
+      validateResponseOverride={(response) => {
+        const possibleUserIdTypes =
+          selectedDataSource?.settings?.userIdTypes?.map((t) => t.userIdType) ||
+          [];
+
+        const currentUserIdTypes = userIdTypes.current;
+
+        const cols = Object.keys(response);
+        const newUserIdTypes: string[] = [];
+        for (const col of cols) {
+          if (possibleUserIdTypes.includes(col)) {
+            newUserIdTypes.push(col);
+          }
+        }
+
+        if (!newUserIdTypes.length) {
+          throw new Error(
+            `You must select at least 1 identifier column from the list: ${possibleUserIdTypes.join(
+              ", "
+            )}`
+          );
+        }
+
+        if (!isEqual(newUserIdTypes, currentUserIdTypes)) {
+          userIdTypes.current = newUserIdTypes;
+        }
+      }}
+    />
+  );
+}

--- a/packages/front-end/components/FactTables/FactFilterList.tsx
+++ b/packages/front-end/components/FactTables/FactFilterList.tsx
@@ -27,11 +27,19 @@ export default function FactFilterList({ factTable }: Props) {
 
   const permissionsUtil = usePermissionsUtil();
 
-  const { items, searchInputProps, isFiltered, SortableTH, clear } = useSearch({
+  const {
+    items,
+    searchInputProps,
+    isFiltered,
+    SortableTH,
+    clear,
+    pagination,
+  } = useSearch({
     items: factTable?.filters || [],
     defaultSortField: "name",
     localStorageKey: "factFilters",
     searchFields: ["name^3", "description", "value^2"],
+    pageSize: 10,
   });
 
   const canAddAndEdit = permissionsUtil.canCreateAndUpdateFactFilter(factTable);
@@ -162,6 +170,7 @@ export default function FactFilterList({ factTable }: Props) {
               )}
             </tbody>
           </table>
+          {pagination}
         </>
       )}
     </>

--- a/packages/front-end/components/FactTables/FactMetricList.tsx
+++ b/packages/front-end/components/FactTables/FactMetricList.tsx
@@ -68,11 +68,19 @@ export default function FactMetricList({ factTable }: Props) {
   const canDelete = (factMetric: FactMetricInterface) =>
     permissionsUtil.canDeleteFactMetric(factMetric) && !factMetric.managedBy;
 
-  const { items, searchInputProps, isFiltered, SortableTH, clear } = useSearch({
+  const {
+    items,
+    searchInputProps,
+    isFiltered,
+    SortableTH,
+    clear,
+    pagination,
+  } = useSearch({
     items: showArchived ? metrics : metrics.filter((m) => !m.archived) || [],
     defaultSortField: "name",
     localStorageKey: "factmetrics",
     searchFields: ["name^3", "description"],
+    pageSize: 10,
   });
 
   const canCreateMetrics = permissionsUtil.canCreateFactMetric({
@@ -293,6 +301,7 @@ export default function FactMetricList({ factTable }: Props) {
               )}
             </tbody>
           </table>
+          {pagination}
         </>
       )}
     </>

--- a/packages/front-end/components/FactTables/FactTableModal.tsx
+++ b/packages/front-end/components/FactTables/FactTableModal.tsx
@@ -7,7 +7,7 @@ import { useForm } from "react-hook-form";
 import { useRouter } from "next/router";
 import { isProjectListValidForProject } from "shared/util";
 import { useEffect, useState } from "react";
-import { FaExternalLinkAlt } from "react-icons/fa";
+import { FaAngleDown, FaAngleRight, FaExternalLinkAlt } from "react-icons/fa";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import { useAuth } from "@/services/auth";
 import useOrgSettings from "@/hooks/useOrgSettings";
@@ -18,9 +18,9 @@ import Field from "@/components/Forms/Field";
 import SelectField from "@/components/Forms/SelectField";
 import { getNewExperimentDatasourceDefaults } from "@/components/Experiment/NewExperimentForm";
 import MultiSelectField from "@/components/Forms/MultiSelectField";
-import EditSqlModal from "@/components/SchemaBrowser/EditSqlModal";
 import Code from "@/components/SyntaxHighlighting/Code";
 import { usesEventName } from "@/components/Metrics/MetricForm";
+import EditFactTableSQLModal from "@/components/FactTables/EditFactTableSQLModal";
 
 export interface Props {
   existing?: FactTableInterface;
@@ -43,6 +43,8 @@ export default function FactTableModal({ existing, close }: Props) {
     showAdditionalColumnMessage,
     setShowAdditionalColumnMessage,
   ] = useState(false);
+
+  const [showIdentifierTypes, setShowIdentifierTypes] = useState(false);
 
   const { apiCall } = useAuth();
 
@@ -90,22 +92,18 @@ export default function FactTableModal({ existing, close }: Props) {
   return (
     <>
       {sqlOpen && (
-        <EditSqlModal
+        <EditFactTableSQLModal
           close={() => setSqlOpen(false)}
-          datasourceId={form.watch("datasource")}
-          placeholder={
-            "SELECT\n      user_id as user_id, timestamp as timestamp\nFROM\n      test"
-          }
-          requiredColumns={new Set(["timestamp", ...form.watch("userIdTypes")])}
-          value={form.watch("sql")}
-          save={async (sql) => {
+          factTable={{
+            datasource: form.watch("datasource"),
+            sql: form.watch("sql"),
+            eventName: form.watch("eventName"),
+            userIdTypes: form.watch("userIdTypes"),
+          }}
+          save={async ({ sql, userIdTypes, eventName }) => {
             form.setValue("sql", sql);
-          }}
-          templateVariables={{
-            eventName: form.watch("eventName") || "",
-          }}
-          setTemplateVariables={({ eventName }) => {
-            form.setValue("eventName", eventName || "");
+            form.setValue("userIdTypes", userIdTypes);
+            form.setValue("eventName", eventName);
           }}
         />
       )}
@@ -192,22 +190,6 @@ export default function FactTableModal({ existing, close }: Props) {
           />
         )}
 
-        {selectedDataSource && (
-          <MultiSelectField
-            value={form.watch("userIdTypes")}
-            onChange={(types) => {
-              form.setValue("userIdTypes", types);
-            }}
-            options={(selectedDataSource.settings.userIdTypes || []).map(
-              ({ userIdType }) => ({
-                value: userIdType,
-                label: userIdType,
-              })
-            )}
-            label="Identifier Types Supported"
-          />
-        )}
-
         {selectedDataSource && usesEventName(form.watch("sql")) && (
           <Field
             label="Event Name in Database"
@@ -248,6 +230,39 @@ export default function FactTableModal({ existing, close }: Props) {
               </button>
             </div>
           </div>
+        )}
+
+        {selectedDataSource && (
+          <>
+            <a
+              href="#"
+              onClick={(e) => {
+                e.preventDefault();
+                setShowIdentifierTypes(!showIdentifierTypes);
+              }}
+            >
+              Edit Identifier Types{" "}
+              {showIdentifierTypes ? <FaAngleDown /> : <FaAngleRight />}
+            </a>
+            {showIdentifierTypes && (
+              <div className="pt-1">
+                <MultiSelectField
+                  value={form.watch("userIdTypes")}
+                  onChange={(types) => {
+                    form.setValue("userIdTypes", types);
+                  }}
+                  options={(selectedDataSource.settings.userIdTypes || []).map(
+                    ({ userIdType }) => ({
+                      value: userIdType,
+                      label: userIdType,
+                    })
+                  )}
+                  helpText="The default values were auto-detected from your SQL query."
+                  autoFocus={true}
+                />
+              </div>
+            )}
+          </>
         )}
       </Modal>
     </>

--- a/packages/front-end/components/FactTables/FactTableModal.tsx
+++ b/packages/front-end/components/FactTables/FactTableModal.tsx
@@ -199,7 +199,7 @@ export default function FactTableModal({ existing, close }: Props) {
           />
         )}
 
-        {selectedDataSource && (
+        {selectedDataSource && !existing?.id && (
           <div className="form-group">
             <label>Query</label>
             {showAdditionalColumnMessage && (
@@ -232,7 +232,7 @@ export default function FactTableModal({ existing, close }: Props) {
           </div>
         )}
 
-        {selectedDataSource && (
+        {selectedDataSource && !existing?.id && (
           <>
             <a
               href="#"

--- a/packages/front-end/components/Metrics/MetricsList.tsx
+++ b/packages/front-end/components/Metrics/MetricsList.tsx
@@ -281,7 +281,13 @@ const MetricsList = (): React.ReactElement => {
     [showArchived, recentlyArchived, tagsFilter.tags]
   );
 
-  const { items, searchInputProps, isFiltered, SortableTH } = useSearch({
+  const {
+    items,
+    searchInputProps,
+    isFiltered,
+    SortableTH,
+    pagination,
+  } = useSearch({
     items: filteredMetrics,
     defaultSortField: "name",
     localStorageKey: "metrics",
@@ -320,6 +326,7 @@ const MetricsList = (): React.ReactElement => {
       datasource: (item) => [item.datasource, item.datasourceName],
     },
     filterResults,
+    pageSize: 20,
   });
 
   if (!ready) {
@@ -646,6 +653,7 @@ const MetricsList = (): React.ReactElement => {
           )}
         </tbody>
       </table>
+      {pagination}
     </div>
   );
 };

--- a/packages/front-end/components/Settings/Team/MemberList.tsx
+++ b/packages/front-end/components/Settings/Team/MemberList.tsx
@@ -26,14 +26,12 @@ const MemberList: FC<{
   canEditRoles?: boolean;
   canDeleteMembers?: boolean;
   canInviteMembers?: boolean;
-  maxHeight?: number | null;
 }> = ({
   mutate,
   project,
   canEditRoles = true,
   canDeleteMembers = true,
   canInviteMembers = true,
-  maxHeight = null,
 }) => {
   const [inviting, setInviting] = useState(!!router.query["just-subscribed"]);
   const { apiCall } = useAuth();
@@ -136,154 +134,143 @@ const MemberList: FC<{
             )}
           </div>
         </div>
-        <div
-          style={{
-            overflowY: "auto",
-            ...(maxHeight ? { maxHeight } : {}),
-          }}
-        >
-          <table className="table appbox gbtable">
-            <thead>
-              <tr>
-                <SortableTH field="name">Name</SortableTH>
-                <SortableTH field="email">Email</SortableTH>
-                <SortableTH field="dateCreated">Date Joined</SortableTH>
-                <SortableTH field="lastLoginDate">Last Login</SortableTH>
-                <th>{project ? "Project Role" : "Global Role"}</th>
-                {!project && <th>Project Roles</th>}
-                {environments.map((env) => (
-                  <th key={env.id}>{env.id}</th>
-                ))}
-                <SortableTH field="numTeams">Teams</SortableTH>
-                <th style={{ width: 50 }} />
-              </tr>
-            </thead>
-            <tbody>
-              {items.map((member) => {
-                const roleInfo =
-                  (project &&
-                    member.projectRoles?.find((r) => r.project === project)) ||
-                  member;
-                return (
-                  <tr key={member.id}>
-                    <td>{member.name}</td>
-                    <td>
-                      <div className="d-flex align-items-center">
-                        {member.managedByIdp ? (
-                          <Tooltip
-                            className="mr-2"
-                            body="This user is managed by an external identity provider."
-                          >
-                            <RxIdCard className="text-blue" />
-                          </Tooltip>
-                        ) : null}
-                        {member.email}
-                      </div>
+        <table className="table appbox gbtable">
+          <thead>
+            <tr>
+              <SortableTH field="name">Name</SortableTH>
+              <SortableTH field="email">Email</SortableTH>
+              <SortableTH field="dateCreated">Date Joined</SortableTH>
+              <SortableTH field="lastLoginDate">Last Login</SortableTH>
+              <th>{project ? "Project Role" : "Global Role"}</th>
+              {!project && <th>Project Roles</th>}
+              {environments.map((env) => (
+                <th key={env.id}>{env.id}</th>
+              ))}
+              <SortableTH field="numTeams">Teams</SortableTH>
+              <th style={{ width: 50 }} />
+            </tr>
+          </thead>
+          <tbody>
+            {items.map((member) => {
+              const roleInfo =
+                (project &&
+                  member.projectRoles?.find((r) => r.project === project)) ||
+                member;
+              return (
+                <tr key={member.id}>
+                  <td>{member.name}</td>
+                  <td>
+                    <div className="d-flex align-items-center">
+                      {member.managedByIdp ? (
+                        <Tooltip
+                          className="mr-2"
+                          body="This user is managed by an external identity provider."
+                        >
+                          <RxIdCard className="text-blue" />
+                        </Tooltip>
+                      ) : null}
+                      {member.email}
+                    </div>
+                  </td>
+                  <td>{member.dateCreated && datetime(member.dateCreated)}</td>
+                  <td>{member.lastLoginDate && date(member.lastLoginDate)}</td>
+                  <td>{roleInfo.role}</td>
+                  {!project && (
+                    <td className="col-2">
+                      {member.projectRoles?.map((pr) => {
+                        const p = projects.find((p) => p.id === pr.project);
+                        if (p?.name) {
+                          return (
+                            <div key={`project-tags-${p.id}`}>
+                              <ProjectBadges
+                                resourceType="member"
+                                projectIds={[p.id]}
+                                className="badge-ellipsis short align-middle font-weight-normal"
+                              />{" "}
+                              — {pr.role}
+                            </div>
+                          );
+                        }
+                        return null;
+                      })}
                     </td>
-                    <td>
-                      {member.dateCreated && datetime(member.dateCreated)}
-                    </td>
-                    <td>
-                      {member.lastLoginDate && date(member.lastLoginDate)}
-                    </td>
-                    <td>{roleInfo.role}</td>
-                    {!project && (
-                      <td className="col-2">
-                        {member.projectRoles?.map((pr) => {
-                          const p = projects.find((p) => p.id === pr.project);
-                          if (p?.name) {
-                            return (
-                              <div key={`project-tags-${p.id}`}>
-                                <ProjectBadges
-                                  resourceType="member"
-                                  projectIds={[p.id]}
-                                  className="badge-ellipsis short align-middle font-weight-normal"
-                                />{" "}
-                                — {pr.role}
-                              </div>
-                            );
-                          }
-                          return null;
-                        })}
+                  )}
+                  {environments.map((env) => {
+                    const access = roleHasAccessToEnv(
+                      roleInfo,
+                      env.id,
+                      organization
+                    );
+                    return (
+                      <td key={env.id}>
+                        {access === "N/A" ? (
+                          <span className="text-muted">N/A</span>
+                        ) : access === "yes" ? (
+                          <FaCheck className="text-success" />
+                        ) : (
+                          <FaTimes className="text-danger" />
+                        )}
                       </td>
-                    )}
-                    {environments.map((env) => {
-                      const access = roleHasAccessToEnv(
-                        roleInfo,
-                        env.id,
-                        organization
-                      );
-                      return (
-                        <td key={env.id}>
-                          {access === "N/A" ? (
-                            <span className="text-muted">N/A</span>
-                          ) : access === "yes" ? (
-                            <FaCheck className="text-success" />
-                          ) : (
-                            <FaTimes className="text-danger" />
-                          )}
-                        </td>
-                      );
-                    })}
+                    );
+                  })}
 
-                    <td>{member.teams ? member.teams.length : 0}</td>
+                  <td>{member.teams ? member.teams.length : 0}</td>
 
-                    <td>
-                      {canEditRoles && member.id !== userId && (
-                        <>
-                          <MoreMenu>
+                  <td>
+                    {canEditRoles && member.id !== userId && (
+                      <>
+                        <MoreMenu>
+                          <button
+                            className="dropdown-item"
+                            onClick={(e) => {
+                              e.preventDefault();
+                              setRoleModal(member.id);
+                            }}
+                          >
+                            Edit Role
+                          </button>
+                          {canDeleteMembers && !usingSSO() && (
                             <button
                               className="dropdown-item"
                               onClick={(e) => {
                                 e.preventDefault();
-                                setRoleModal(member.id);
+                                setPasswordResetModal(member);
                               }}
                             >
-                              Edit Role
+                              Reset Password
                             </button>
-                            {canDeleteMembers && !usingSSO() && (
-                              <button
-                                className="dropdown-item"
-                                onClick={(e) => {
-                                  e.preventDefault();
-                                  setPasswordResetModal(member);
-                                }}
-                              >
-                                Reset Password
-                              </button>
-                            )}
-                            {canDeleteMembers && !member.managedByIdp && (
-                              <DeleteButton
-                                link={true}
-                                text="Remove User"
-                                useIcon={false}
-                                className="dropdown-item"
-                                displayName={member.email}
-                                onClick={async () => {
-                                  await apiCall(`/member/${member.id}`, {
-                                    method: "DELETE",
-                                  });
-                                  mutate();
-                                }}
-                              />
-                            )}
-                          </MoreMenu>
-                        </>
-                      )}
-                    </td>
-                  </tr>
-                );
-              })}
-              {!items.length && isFiltered && (
-                <tr>
-                  <td colSpan={4} align={"center"}>
-                    No matching members found.
+                          )}
+                          {canDeleteMembers && !member.managedByIdp && (
+                            <DeleteButton
+                              link={true}
+                              text="Remove User"
+                              useIcon={false}
+                              className="dropdown-item"
+                              displayName={member.email}
+                              onClick={async () => {
+                                await apiCall(`/member/${member.id}`, {
+                                  method: "DELETE",
+                                });
+                                mutate();
+                              }}
+                            />
+                          )}
+                        </MoreMenu>
+                      </>
+                    )}
                   </td>
                 </tr>
-              )}
-            </tbody>
-          </table>
-        </div>
+              );
+            })}
+            {!items.length && isFiltered && (
+              <tr>
+                <td colSpan={4} align={"center"}>
+                  No matching members found.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
         {pagination}
       </div>
     </>

--- a/packages/front-end/components/Settings/Team/MemberList.tsx
+++ b/packages/front-end/components/Settings/Team/MemberList.tsx
@@ -70,11 +70,18 @@ const MemberList: FC<{
       } as ExpandedMember;
     }) || [];
 
-  const { items, searchInputProps, isFiltered, SortableTH } = useSearch({
+  const {
+    items,
+    searchInputProps,
+    isFiltered,
+    SortableTH,
+    pagination,
+  } = useSearch({
     items: membersList || [],
     localStorageKey: "members",
     defaultSortField: "name",
     searchFields: ["name", "email"],
+    pageSize: 20,
   });
   return (
     <>
@@ -277,6 +284,7 @@ const MemberList: FC<{
             </tbody>
           </table>
         </div>
+        {pagination}
       </div>
     </>
   );

--- a/packages/front-end/components/SyntaxHighlighting/Code.tsx
+++ b/packages/front-end/components/SyntaxHighlighting/Code.tsx
@@ -60,6 +60,7 @@ export default function Code({
   highlightLine,
   startingLineNumber,
   showLineNumbers = true,
+  maxHeight,
 }: {
   code: string;
   language: Language;
@@ -72,6 +73,7 @@ export default function Code({
   highlightLine?: number;
   startingLineNumber?: number;
   showLineNumbers?: boolean;
+  maxHeight?: string;
 }) {
   language = language || "none";
   if (language === "sh") language = "bash";
@@ -93,6 +95,10 @@ export default function Code({
   };
   style['pre[class*="language-"]'].backgroundColor = codeBackgrounds[theme];
   style['pre[class*="language-"]'].border = "1px solid var(--border-color-200)";
+
+  if (maxHeight) {
+    style['pre[class*="language-"]'].maxHeight = maxHeight;
+  }
 
   const display =
     filename ||

--- a/packages/front-end/pages/fact-tables/[ftid].tsx
+++ b/packages/front-end/pages/fact-tables/[ftid].tsx
@@ -281,46 +281,45 @@ export default function FactTablePage() {
         />
       </div>
 
-      <div className="mb-5">
-        <h3>SQL Definition</h3>
-        <Code
-          code={factTable.sql}
-          language="sql"
-          containerClassName="m-0"
-          filename={
-            canEdit ? (
-              <a
-                href="#"
-                onClick={(e) => {
-                  e.preventDefault();
-                  setEditSQLOpen(true);
-                }}
-              >
-                Edit SQL <GBEdit />
-              </a>
-            ) : (
-              "SQL"
-            )
-          }
-          expandable={true}
-        />
-        {usesEventName(factTable.sql) && (
-          <div className="p-2 bg-light border border-top-0">
-            <strong>eventName</strong> = <code>{factTable.eventName}</code>
-          </div>
-        )}
-      </div>
-
       <div className="row mb-4">
         <div className="col d-flex flex-column">
+          <h3>SQL Definition</h3>
+          <Code
+            code={factTable.sql}
+            language="sql"
+            containerClassName="m-0 flex-1"
+            className="flex-1"
+            filename={
+              canEdit ? (
+                <a
+                  href="#"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    setEditSQLOpen(true);
+                  }}
+                >
+                  Edit SQL <GBEdit />
+                </a>
+              ) : (
+                "SQL"
+              )
+            }
+          />
+          {usesEventName(factTable.sql) && (
+            <div className="p-2 bg-light border border-top-0">
+              <strong>eventName</strong> = <code>{factTable.eventName}</code>
+            </div>
+          )}
+        </div>
+        <div className="col d-flex flex-column">
           <h3>Columns</h3>
-          <div className="mb-1">
-            All of the columns returned by the Fact Table SQL.
-          </div>
-          <div className="appbox p-3 flex-1">
+          <div className="appbox p-3 flex-1 mb-0">
             <ColumnList factTable={factTable} />
           </div>
         </div>
+      </div>
+
+      <div className="row mb-4">
         <div className="col d-flex flex-column">
           <h3>Filters</h3>
           <div className="mb-1">

--- a/packages/front-end/pages/fact-tables/[ftid].tsx
+++ b/packages/front-end/pages/fact-tables/[ftid].tsx
@@ -282,13 +282,14 @@ export default function FactTablePage() {
       </div>
 
       <div className="row mb-4">
-        <div className="col d-flex flex-column">
+        <div className="col col-md-6 d-flex flex-column">
           <h3>SQL Definition</h3>
           <Code
             code={factTable.sql}
             language="sql"
             containerClassName="m-0 flex-1"
             className="flex-1"
+            maxHeight="405px"
             filename={
               canEdit ? (
                 <a
@@ -311,7 +312,7 @@ export default function FactTablePage() {
             </div>
           )}
         </div>
-        <div className="col d-flex flex-column">
+        <div className="col col-md-6 d-flex flex-column">
           <h3>Columns</h3>
           <div className="appbox p-3 flex-1 mb-0">
             <ColumnList factTable={factTable} />

--- a/packages/front-end/pages/fact-tables/[ftid].tsx
+++ b/packages/front-end/pages/fact-tables/[ftid].tsx
@@ -1,7 +1,6 @@
 import { useRouter } from "next/router";
 import Link from "next/link";
 import { useState } from "react";
-import { FaAngleDown, FaAngleRight } from "react-icons/fa";
 import EditOwnerModal from "@/components/Owner/EditOwnerModal";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import LoadingOverlay from "@/components/LoadingOverlay";
@@ -23,13 +22,14 @@ import { usesEventName } from "@/components/Metrics/MetricForm";
 import { OfficialBadge } from "@/components/Metrics/MetricName";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 import Tooltip from "@/components/Tooltip/Tooltip";
+import EditFactTableSQLModal from "@/components/FactTables/EditFactTableSQLModal";
 
 export default function FactTablePage() {
   const router = useRouter();
   const { ftid } = router.query;
 
   const [editOpen, setEditOpen] = useState(false);
-  const [showSQL, setShowSQL] = useState(false);
+  const [editSQLOpen, setEditSQLOpen] = useState(false);
   const [editOwnerModal, setEditOwnerModal] = useState(false);
 
   const [editProjectsOpen, setEditProjectsOpen] = useState(false);
@@ -64,12 +64,23 @@ export default function FactTablePage() {
     !factTable.managedBy &&
     permissionsUtil.canViewEditFactTableModal(factTable);
 
-  const hasColumns = factTable.columns?.some((col) => !col.deleted);
-
   return (
     <div className="pagecontents container-fluid">
       {editOpen && (
         <FactTableModal close={() => setEditOpen(false)} existing={factTable} />
+      )}
+      {editSQLOpen && (
+        <EditFactTableSQLModal
+          close={() => setEditSQLOpen(false)}
+          factTable={factTable}
+          save={async (data) => {
+            await apiCall(`/fact-tables/${factTable.id}`, {
+              method: "PUT",
+              body: JSON.stringify(data),
+            });
+            await mutateDefinitions();
+          }}
+        />
       )}
       {editOwnerModal && (
         <EditOwnerModal
@@ -270,76 +281,54 @@ export default function FactTablePage() {
         />
       </div>
 
-      <div className="mb-4">
-        {hasColumns && (
-          <a
-            href="#"
-            onClick={(e) => {
-              e.preventDefault();
-              setShowSQL(!showSQL);
-            }}
-            className="text-dark"
-          >
-            {showSQL ? "Hide" : "Show"} Fact Table SQL{" "}
-            {showSQL ? <FaAngleDown /> : <FaAngleRight />}
-          </a>
-        )}
-        {(showSQL || !hasColumns) && (
-          <div className="appbox p-3">
-            <Code
-              code={factTable.sql}
-              language="sql"
-              containerClassName="m-0"
-              className="mb-4"
-              filename={
-                canEdit ? (
-                  <a
-                    href="#"
-                    onClick={(e) => {
-                      e.preventDefault();
-                      setEditOpen(true);
-                    }}
-                  >
-                    Edit SQL <GBEdit />
-                  </a>
-                ) : (
-                  "SQL"
-                )
-              }
-            />
-            {usesEventName(factTable.sql) && (
-              <div className="mt-2">
-                <strong>eventName</strong> = <code>{factTable.eventName}</code>
-              </div>
-            )}
+      <div className="mb-5">
+        <h3>SQL Definition</h3>
+        <Code
+          code={factTable.sql}
+          language="sql"
+          containerClassName="m-0"
+          filename={
+            canEdit ? (
+              <a
+                href="#"
+                onClick={(e) => {
+                  e.preventDefault();
+                  setEditSQLOpen(true);
+                }}
+              >
+                Edit SQL <GBEdit />
+              </a>
+            ) : (
+              "SQL"
+            )
+          }
+          expandable={true}
+        />
+        {usesEventName(factTable.sql) && (
+          <div className="p-2 bg-light border border-top-0">
+            <strong>eventName</strong> = <code>{factTable.eventName}</code>
           </div>
         )}
       </div>
 
       <div className="row mb-4">
-        <div className="col">
-          <div className="mb-4">
-            <h3>Columns</h3>
-            <div className="mb-1">
-              All of the columns returned by the Fact Table SQL.
-            </div>
-            <div className="appbox p-3">
-              <ColumnList factTable={factTable} />
-            </div>
+        <div className="col d-flex flex-column">
+          <h3>Columns</h3>
+          <div className="mb-1">
+            All of the columns returned by the Fact Table SQL.
+          </div>
+          <div className="appbox p-3 flex-1">
+            <ColumnList factTable={factTable} />
           </div>
         </div>
-        <div className="col">
-          <div className="mb-4">
-            <h3>Filters</h3>
-            <div className="mb-4">
-              <div className="mb-1">
-                Filters are re-usable SQL snippets that let you limit the rows
-                that are included in a Metric.
-              </div>
-              <div className="appbox p-3">
-                <FactFilterList factTable={factTable} />
-              </div>
-            </div>
+        <div className="col d-flex flex-column">
+          <h3>Filters</h3>
+          <div className="mb-1">
+            Filters are re-usable SQL snippets that let you limit the rows that
+            are included in a Metric.
+          </div>
+          <div className="appbox p-3 flex-1">
+            <FactFilterList factTable={factTable} />
           </div>
         </div>
       </div>

--- a/packages/front-end/pages/project/[pid].tsx
+++ b/packages/front-end/pages/project/[pid].tsx
@@ -162,7 +162,6 @@ const ProjectPage: FC = () => {
             canEditRoles={canManageTeam}
             canDeleteMembers={false}
             canInviteMembers={false}
-            maxHeight={500}
           />
         </div>
 

--- a/packages/front-end/pages/reports.tsx
+++ b/packages/front-end/pages/reports.tsx
@@ -55,7 +55,13 @@ const ReportsPage = (): React.ReactElement => {
     },
     [onlyMyReports, userId]
   );
-  const { items, searchInputProps, isFiltered, SortableTH } = useSearch({
+  const {
+    items,
+    searchInputProps,
+    isFiltered,
+    SortableTH,
+    pagination,
+  } = useSearch({
     items: reports,
     localStorageKey: "reports",
     defaultSortField: "dateUpdated",
@@ -68,6 +74,7 @@ const ReportsPage = (): React.ReactElement => {
       "dateUpdated",
     ],
     filterResults,
+    pageSize: 20,
   });
 
   if (error) {
@@ -202,6 +209,7 @@ const ReportsPage = (): React.ReactElement => {
           )}
         </tbody>
       </table>
+      {pagination}
     </div>
   );
 };


### PR DESCRIPTION
### Features and Changes

- Always show fact table SQL on the page instead of collapsing by default and show next to columns
- "Edit SQL" link for fact tables now directly opens the SQL editor instead of requiring a 2nd click
- You no longer need to specify Identifier Types when editing a fact table. They are detected automatically from the SQL that is entered.
- Add pagination to several pages: Metrics, Members, Fact Table columns, Fact Table filters, Reports
- Update README for front-end package documenting new pagination options and fixing outdated form info

![image](https://github.com/user-attachments/assets/2ff64cde-cc60-4bdd-8f04-73fcbde0815a)
