### PR TITLE
Make sure targeting is copied when duplicating an experiment

### DIFF
--- a/packages/front-end/components/Experiment/NewExperimentForm.tsx
+++ b/packages/front-end/components/Experiment/NewExperimentForm.tsx
@@ -6,6 +6,7 @@ import {
   Variation,
 } from "back-end/types/experiment";
 import { useRouter } from "next/router";
+import { getValidDate } from "shared/dates";
 import { DataSourceInterfaceWithParams } from "back-end/types/datasource";
 import { OrganizationSettings } from "back-end/types/organization";
 import {
@@ -193,6 +194,7 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
     : hashAttributes[0] || "id";
 
   const orgStickyBucketing = !!settings.useStickyBucketing;
+  const lastPhase = (initialValue?.phases?.length ?? 1) - 1;
 
   const form = useForm<Partial<ExperimentInterfaceStringDates>>({
     defaultValues: {
@@ -229,8 +231,25 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
         ...(initialValue?.phases?.[initialValue?.phases?.length - 1]
           ? [
               {
-                ...initialValue.phases[initialValue.phases.length - 1],
+                ...initialValue.phases[lastPhase],
+                coverage: initialValue.phases?.[lastPhase]?.coverage || 1,
+                dateStarted: getValidDate(
+                  initialValue.phases?.[lastPhase]?.dateStarted ?? ""
+                )
+                  .toISOString()
+                  .substr(0, 16),
+                dateEnded: getValidDate(
+                  initialValue.phases?.[lastPhase]?.dateEnded ?? ""
+                )
+                  .toISOString()
+                  .substr(0, 16),
+                name: initialValue.phases?.[lastPhase]?.name || "Main",
                 reason: "",
+                variationWeights:
+                  initialValue.phases?.[lastPhase]?.variationWeights ||
+                  getEqualWeights(
+                    initialValue.variations ? initialValue.variations.length : 2
+                  ),
               },
             ]
           : [

--- a/packages/front-end/components/Experiment/NewExperimentForm.tsx
+++ b/packages/front-end/components/Experiment/NewExperimentForm.tsx
@@ -13,7 +13,7 @@ import {
   validateAndFixCondition,
 } from "shared/util";
 import { getScopedSettings } from "shared/settings";
-import { generateTrackingKey } from "shared/experiments";
+import { generateTrackingKey, getEqualWeights } from "shared/experiments";
 import { kebabCase } from "lodash";
 import { useWatching } from "@/services/WatchProvider";
 import { useAuth } from "@/services/auth";
@@ -235,7 +235,12 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
                 dateEnded: new Date().toISOString().substr(0, 16),
                 name: "Main",
                 reason: "",
-                variationWeights: [0.5, 0.5],
+                variationWeights: getEqualWeights(
+                  (initialValue?.variations
+                    ? initialValue.variations
+                    : getDefaultVariations(initialNumVariations)
+                  )?.length || 2
+                ),
               },
             ]),
       ],

--- a/packages/front-end/components/Experiment/NewExperimentForm.tsx
+++ b/packages/front-end/components/Experiment/NewExperimentForm.tsx
@@ -226,8 +226,13 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
         ? initialValue.variations
         : getDefaultVariations(initialNumVariations),
       phases: [
-        ...(initialValue?.phases?.length
-          ? initialValue?.phases || []
+        ...(initialValue?.phases?.[initialValue?.phases?.length - 1]
+          ? [
+              {
+                ...initialValue.phases[initialValue.phases.length - 1],
+                reason: "",
+              },
+            ]
           : [
               {
                 coverage: 1,

--- a/packages/front-end/components/Experiment/NewExperimentForm.tsx
+++ b/packages/front-end/components/Experiment/NewExperimentForm.tsx
@@ -228,7 +228,7 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
         ? initialValue.variations
         : getDefaultVariations(initialNumVariations),
       phases: [
-        ...(initialValue?.phases?.[initialValue?.phases?.length - 1]
+        ...(initialValue?.phases?.[lastPhase]
           ? [
               {
                 ...initialValue.phases[lastPhase],

--- a/packages/front-end/components/Experiment/NewExperimentForm.tsx
+++ b/packages/front-end/components/Experiment/NewExperimentForm.tsx
@@ -255,6 +255,8 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
     },
   });
 
+  const lastPhase = (form.watch("phases")?.length ?? 1) - 1;
+
   const datasource = form.watch("datasource")
     ? getDatasourceById(form.watch("datasource") ?? "")
     : null;
@@ -290,7 +292,7 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
       validateSavedGroupTargeting(data.phases[0].savedGroups);
 
       validateAndFixCondition(data.phases[0].condition, (condition) => {
-        form.setValue("phases.0.condition", condition);
+        form.setValue(`phases.${lastPhase}.condition`, condition);
         forceConditionRender();
       });
 
@@ -509,14 +511,14 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
                   <Field
                     label="Start Date (UTC)"
                     type="datetime-local"
-                    {...form.register("phases.0.dateStarted")}
+                    {...form.register(`phases.${lastPhase}.dateStarted`)}
                   />
                 )}
                 {status === "stopped" && (
                   <Field
                     label="End Date (UTC)"
                     type="datetime-local"
-                    {...form.register("phases.0.dateEnded")}
+                    {...form.register(`phases.${lastPhase}.dateEnded`)}
                   />
                 )}
               </>
@@ -537,39 +539,52 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
                     environments={envs}
                     noSchedule={true}
                     prerequisiteValue={
-                      form.watch("phases.0.prerequisites") || []
+                      form.watch(`phases.${lastPhase}.prerequisites`) || []
                     }
                     setPrerequisiteValue={(prerequisites) =>
-                      form.setValue("phases.0.prerequisites", prerequisites)
+                      form.setValue(
+                        `phases.${lastPhase}.prerequisites`,
+                        prerequisites
+                      )
                     }
                     setPrerequisiteTargetingSdkIssues={
                       setPrerequisiteTargetingSdkIssues
                     }
-                    savedGroupValue={form.watch("phases.0.savedGroups") || []}
+                    savedGroupValue={
+                      form.watch(`phases.${lastPhase}.savedGroups`) || []
+                    }
                     setSavedGroupValue={(savedGroups) =>
-                      form.setValue("phases.0.savedGroups", savedGroups)
+                      form.setValue(
+                        `phases.${lastPhase}.savedGroups`,
+                        savedGroups
+                      )
                     }
                     defaultConditionValue={
-                      form.watch("phases.0.condition") || ""
+                      form.watch(`phases.${lastPhase}.condition`) || ""
                     }
                     setConditionValue={(value) =>
-                      form.setValue("phases.0.condition", value)
+                      form.setValue(`phases.${lastPhase}.condition`, value)
                     }
                     conditionKey={conditionKey}
-                    namespaceFormPrefix={"phases.0."}
-                    coverage={form.watch("phases.0.coverage")}
+                    namespaceFormPrefix={`phases.${lastPhase}.`}
+                    coverage={form.watch(`phases.${lastPhase}.coverage`)}
                     setCoverage={(coverage) =>
-                      form.setValue("phases.0.coverage", coverage)
+                      form.setValue(`phases.${lastPhase}.coverage`, coverage)
                     }
                     setWeight={(i, weight) =>
-                      form.setValue(`phases.0.variationWeights.${i}`, weight)
+                      form.setValue(
+                        `phases.${lastPhase}.variationWeights.${i}`,
+                        weight
+                      )
                     }
                     variations={
                       form.watch("variations")?.map((v, i) => {
                         return {
                           value: v.key || "",
                           name: v.name,
-                          weight: form.watch(`phases.0.variationWeights.${i}`),
+                          weight: form.watch(
+                            `phases.${lastPhase}.variationWeights.${i}`
+                          ),
                           id: v.id,
                         };
                       }) ?? []
@@ -588,7 +603,7 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
                         })
                       );
                       form.setValue(
-                        "phases.0.variationWeights",
+                        `phases.${lastPhase}.variationWeights`,
                         v.map((v) => v.weight)
                       );
                     }}
@@ -620,39 +635,52 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
                     project={project}
                     environments={envs}
                     prerequisiteValue={
-                      form.watch("phases.0.prerequisites") || []
+                      form.watch(`phases.${lastPhase}.prerequisites`) || []
                     }
                     setPrerequisiteValue={(prerequisites) =>
-                      form.setValue("phases.0.prerequisites", prerequisites)
+                      form.setValue(
+                        `phases.${lastPhase}.prerequisites`,
+                        prerequisites
+                      )
                     }
                     setPrerequisiteTargetingSdkIssues={
                       setPrerequisiteTargetingSdkIssues
                     }
-                    savedGroupValue={form.watch("phases.0.savedGroups") || []}
+                    savedGroupValue={
+                      form.watch(`phases.${lastPhase}.savedGroups`) || []
+                    }
                     setSavedGroupValue={(savedGroups) =>
-                      form.setValue("phases.0.savedGroups", savedGroups)
+                      form.setValue(
+                        `phases.${lastPhase}.savedGroups`,
+                        savedGroups
+                      )
                     }
                     defaultConditionValue={
-                      form.watch("phases.0.condition") || ""
+                      form.watch(`phases.${lastPhase}.condition`) || ""
                     }
                     setConditionValue={(value) =>
-                      form.setValue("phases.0.condition", value)
+                      form.setValue(`phases.${lastPhase}.condition`, value)
                     }
                     conditionKey={conditionKey}
-                    namespaceFormPrefix={"phases.0."}
-                    coverage={form.watch("phases.0.coverage")}
+                    namespaceFormPrefix={`phases.${lastPhase}.`}
+                    coverage={form.watch(`phases.${lastPhase}.coverage`)}
                     setCoverage={(coverage) =>
-                      form.setValue("phases.0.coverage", coverage)
+                      form.setValue(`phases.${lastPhase}.coverage`, coverage)
                     }
                     setWeight={(i, weight) =>
-                      form.setValue(`phases.0.variationWeights.${i}`, weight)
+                      form.setValue(
+                        `phases.${lastPhase}.variationWeights.${i}`,
+                        weight
+                      )
                     }
                     variations={
                       form.watch("variations")?.map((v, i) => {
                         return {
                           value: v.key || "",
                           name: v.name,
-                          weight: form.watch(`phases.0.variationWeights.${i}`),
+                          weight: form.watch(
+                            `phases.${lastPhase}.variationWeights.${i}`
+                          ),
                           id: v.id,
                         };
                       }) ?? []
@@ -671,7 +699,7 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
                         })
                       );
                       form.setValue(
-                        "phases.0.variationWeights",
+                        `phases.${lastPhase}.variationWeights`,
                         v.map((v) => v.weight)
                       );
                     }}
@@ -722,26 +750,36 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
 
                   <hr />
                   <SavedGroupTargetingField
-                    value={form.watch("phases.0.savedGroups") || []}
+                    value={form.watch(`phases.${lastPhase}.savedGroups`) || []}
                     setValue={(savedGroups) =>
-                      form.setValue("phases.0.savedGroups", savedGroups)
+                      form.setValue(
+                        `phases.${lastPhase}.savedGroups`,
+                        savedGroups
+                      )
                     }
                     project={project}
                   />
                   <hr />
                   <ConditionInput
-                    defaultValue={form.watch("phases.0.condition") || ""}
+                    defaultValue={
+                      form.watch(`phases.${lastPhase}.condition`) || ""
+                    }
                     onChange={(value) =>
-                      form.setValue("phases.0.condition", value)
+                      form.setValue(`phases.${lastPhase}.condition`, value)
                     }
                     key={conditionKey}
                     project={project}
                   />
                   <hr />
                   <PrerequisiteTargetingField
-                    value={form.watch("phases.0.prerequisites") || []}
+                    value={
+                      form.watch(`phases.${lastPhase}.prerequisites`) || []
+                    }
                     setValue={(prerequisites) =>
-                      form.setValue("phases.0.prerequisites", prerequisites)
+                      form.setValue(
+                        `phases.${lastPhase}.prerequisites`,
+                        prerequisites
+                      )
                     }
                     environments={envs}
                     project={form.watch("project")}
@@ -751,7 +789,7 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
                   />
                   <hr />
                   <NamespaceSelector
-                    formPrefix="phases.0."
+                    formPrefix={`phases.${lastPhase}.`}
                     form={form}
                     featureId={""}
                     trackingKey={""}
@@ -768,9 +806,9 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
               )}
               <FeatureVariationsInput
                 valueType="string"
-                coverage={form.watch("phases.0.coverage")}
+                coverage={form.watch(`phases.${lastPhase}.coverage`)}
                 setCoverage={(coverage) =>
-                  form.setValue("phases.0.coverage", coverage)
+                  form.setValue(`phases.${lastPhase}.coverage`, coverage)
                 }
                 coverageTooltip={
                   isNewExperiment
@@ -778,7 +816,10 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
                     : "This is just for documentation purposes and has no effect on the analysis."
                 }
                 setWeight={(i, weight) =>
-                  form.setValue(`phases.0.variationWeights.${i}`, weight)
+                  form.setValue(
+                    `phases.${lastPhase}.variationWeights.${i}`,
+                    weight
+                  )
                 }
                 valueAsId={true}
                 variations={
@@ -786,7 +827,9 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
                     return {
                       value: v.key || "",
                       name: v.name,
-                      weight: form.watch(`phases.0.variationWeights.${i}`),
+                      weight: form.watch(
+                        `phases.${lastPhase}.variationWeights.${i}`
+                      ),
                       id: v.id,
                     };
                   }) ?? []
@@ -805,7 +848,7 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
                     })
                   );
                   form.setValue(
-                    "phases.0.variationWeights",
+                    `phases.${lastPhase}.variationWeights`,
                     v.map((v) => v.weight)
                   );
                 }}

--- a/packages/front-end/components/Experiment/NewExperimentForm.tsx
+++ b/packages/front-end/components/Experiment/NewExperimentForm.tsx
@@ -6,7 +6,6 @@ import {
   Variation,
 } from "back-end/types/experiment";
 import { useRouter } from "next/router";
-import { getValidDate } from "shared/dates";
 import { DataSourceInterfaceWithParams } from "back-end/types/datasource";
 import { OrganizationSettings } from "back-end/types/organization";
 import {
@@ -14,7 +13,7 @@ import {
   validateAndFixCondition,
 } from "shared/util";
 import { getScopedSettings } from "shared/settings";
-import { generateTrackingKey, getEqualWeights } from "shared/experiments";
+import { generateTrackingKey } from "shared/experiments";
 import { kebabCase } from "lodash";
 import { useWatching } from "@/services/WatchProvider";
 import { useAuth } from "@/services/auth";
@@ -227,33 +226,18 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
         ? initialValue.variations
         : getDefaultVariations(initialNumVariations),
       phases: [
-        initialValue
-          ? {
-              coverage: initialValue.phases?.[0].coverage || 1,
-              dateStarted: getValidDate(
-                initialValue.phases?.[0]?.dateStarted ?? ""
-              )
-                .toISOString()
-                .substr(0, 16),
-              dateEnded: getValidDate(initialValue.phases?.[0]?.dateEnded ?? "")
-                .toISOString()
-                .substr(0, 16),
-              name: initialValue.phases?.[0].name || "Main",
-              reason: "",
-              variationWeights:
-                initialValue.phases?.[0].variationWeights ||
-                getEqualWeights(
-                  initialValue.variations ? initialValue.variations.length : 2
-                ),
-            }
-          : {
-              coverage: 1,
-              dateStarted: new Date().toISOString().substr(0, 16),
-              dateEnded: new Date().toISOString().substr(0, 16),
-              name: "Main",
-              reason: "",
-              variationWeights: [0.5, 0.5],
-            },
+        ...(initialValue?.phases?.length
+          ? initialValue?.phases || []
+          : [
+              {
+                coverage: 1,
+                dateStarted: new Date().toISOString().substr(0, 16),
+                dateEnded: new Date().toISOString().substr(0, 16),
+                name: "Main",
+                reason: "",
+                variationWeights: [0.5, 0.5],
+              },
+            ]),
       ],
       status: !isImport ? "draft" : initialValue?.status || "running",
       ideaSource: idea || "",

--- a/packages/front-end/components/Experiment/NewExperimentForm.tsx
+++ b/packages/front-end/components/Experiment/NewExperimentForm.tsx
@@ -255,8 +255,6 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
     },
   });
 
-  const lastPhase = (form.watch("phases")?.length ?? 1) - 1;
-
   const datasource = form.watch("datasource")
     ? getDatasourceById(form.watch("datasource") ?? "")
     : null;
@@ -292,7 +290,7 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
       validateSavedGroupTargeting(data.phases[0].savedGroups);
 
       validateAndFixCondition(data.phases[0].condition, (condition) => {
-        form.setValue(`phases.${lastPhase}.condition`, condition);
+        form.setValue("phases.0.condition", condition);
         forceConditionRender();
       });
 
@@ -511,14 +509,14 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
                   <Field
                     label="Start Date (UTC)"
                     type="datetime-local"
-                    {...form.register(`phases.${lastPhase}.dateStarted`)}
+                    {...form.register("phases.0.dateStarted")}
                   />
                 )}
                 {status === "stopped" && (
                   <Field
                     label="End Date (UTC)"
                     type="datetime-local"
-                    {...form.register(`phases.${lastPhase}.dateEnded`)}
+                    {...form.register("phases.0.dateEnded")}
                   />
                 )}
               </>
@@ -539,52 +537,39 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
                     environments={envs}
                     noSchedule={true}
                     prerequisiteValue={
-                      form.watch(`phases.${lastPhase}.prerequisites`) || []
+                      form.watch("phases.0.prerequisites") || []
                     }
                     setPrerequisiteValue={(prerequisites) =>
-                      form.setValue(
-                        `phases.${lastPhase}.prerequisites`,
-                        prerequisites
-                      )
+                      form.setValue("phases.0.prerequisites", prerequisites)
                     }
                     setPrerequisiteTargetingSdkIssues={
                       setPrerequisiteTargetingSdkIssues
                     }
-                    savedGroupValue={
-                      form.watch(`phases.${lastPhase}.savedGroups`) || []
-                    }
+                    savedGroupValue={form.watch("phases.0.savedGroups") || []}
                     setSavedGroupValue={(savedGroups) =>
-                      form.setValue(
-                        `phases.${lastPhase}.savedGroups`,
-                        savedGroups
-                      )
+                      form.setValue("phases.0.savedGroups", savedGroups)
                     }
                     defaultConditionValue={
-                      form.watch(`phases.${lastPhase}.condition`) || ""
+                      form.watch("phases.0.condition") || ""
                     }
                     setConditionValue={(value) =>
-                      form.setValue(`phases.${lastPhase}.condition`, value)
+                      form.setValue("phases.0.condition", value)
                     }
                     conditionKey={conditionKey}
-                    namespaceFormPrefix={`phases.${lastPhase}.`}
-                    coverage={form.watch(`phases.${lastPhase}.coverage`)}
+                    namespaceFormPrefix={"phases.0."}
+                    coverage={form.watch("phases.0.coverage")}
                     setCoverage={(coverage) =>
-                      form.setValue(`phases.${lastPhase}.coverage`, coverage)
+                      form.setValue("phases.0.coverage", coverage)
                     }
                     setWeight={(i, weight) =>
-                      form.setValue(
-                        `phases.${lastPhase}.variationWeights.${i}`,
-                        weight
-                      )
+                      form.setValue(`phases.0.variationWeights.${i}`, weight)
                     }
                     variations={
                       form.watch("variations")?.map((v, i) => {
                         return {
                           value: v.key || "",
                           name: v.name,
-                          weight: form.watch(
-                            `phases.${lastPhase}.variationWeights.${i}`
-                          ),
+                          weight: form.watch(`phases.0.variationWeights.${i}`),
                           id: v.id,
                         };
                       }) ?? []
@@ -603,7 +588,7 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
                         })
                       );
                       form.setValue(
-                        `phases.${lastPhase}.variationWeights`,
+                        "phases.0.variationWeights",
                         v.map((v) => v.weight)
                       );
                     }}
@@ -635,52 +620,39 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
                     project={project}
                     environments={envs}
                     prerequisiteValue={
-                      form.watch(`phases.${lastPhase}.prerequisites`) || []
+                      form.watch("phases.0.prerequisites") || []
                     }
                     setPrerequisiteValue={(prerequisites) =>
-                      form.setValue(
-                        `phases.${lastPhase}.prerequisites`,
-                        prerequisites
-                      )
+                      form.setValue("phases.0.prerequisites", prerequisites)
                     }
                     setPrerequisiteTargetingSdkIssues={
                       setPrerequisiteTargetingSdkIssues
                     }
-                    savedGroupValue={
-                      form.watch(`phases.${lastPhase}.savedGroups`) || []
-                    }
+                    savedGroupValue={form.watch("phases.0.savedGroups") || []}
                     setSavedGroupValue={(savedGroups) =>
-                      form.setValue(
-                        `phases.${lastPhase}.savedGroups`,
-                        savedGroups
-                      )
+                      form.setValue("phases.0.savedGroups", savedGroups)
                     }
                     defaultConditionValue={
-                      form.watch(`phases.${lastPhase}.condition`) || ""
+                      form.watch("phases.0.condition") || ""
                     }
                     setConditionValue={(value) =>
-                      form.setValue(`phases.${lastPhase}.condition`, value)
+                      form.setValue("phases.0.condition", value)
                     }
                     conditionKey={conditionKey}
-                    namespaceFormPrefix={`phases.${lastPhase}.`}
-                    coverage={form.watch(`phases.${lastPhase}.coverage`)}
+                    namespaceFormPrefix={"phases.0."}
+                    coverage={form.watch("phases.0.coverage")}
                     setCoverage={(coverage) =>
-                      form.setValue(`phases.${lastPhase}.coverage`, coverage)
+                      form.setValue("phases.0.coverage", coverage)
                     }
                     setWeight={(i, weight) =>
-                      form.setValue(
-                        `phases.${lastPhase}.variationWeights.${i}`,
-                        weight
-                      )
+                      form.setValue(`phases.0.variationWeights.${i}`, weight)
                     }
                     variations={
                       form.watch("variations")?.map((v, i) => {
                         return {
                           value: v.key || "",
                           name: v.name,
-                          weight: form.watch(
-                            `phases.${lastPhase}.variationWeights.${i}`
-                          ),
+                          weight: form.watch(`phases.0.variationWeights.${i}`),
                           id: v.id,
                         };
                       }) ?? []
@@ -699,7 +671,7 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
                         })
                       );
                       form.setValue(
-                        `phases.${lastPhase}.variationWeights`,
+                        "phases.0.variationWeights",
                         v.map((v) => v.weight)
                       );
                     }}
@@ -750,36 +722,26 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
 
                   <hr />
                   <SavedGroupTargetingField
-                    value={form.watch(`phases.${lastPhase}.savedGroups`) || []}
+                    value={form.watch("phases.0.savedGroups") || []}
                     setValue={(savedGroups) =>
-                      form.setValue(
-                        `phases.${lastPhase}.savedGroups`,
-                        savedGroups
-                      )
+                      form.setValue("phases.0.savedGroups", savedGroups)
                     }
                     project={project}
                   />
                   <hr />
                   <ConditionInput
-                    defaultValue={
-                      form.watch(`phases.${lastPhase}.condition`) || ""
-                    }
+                    defaultValue={form.watch("phases.0.condition") || ""}
                     onChange={(value) =>
-                      form.setValue(`phases.${lastPhase}.condition`, value)
+                      form.setValue("phases.0.condition", value)
                     }
                     key={conditionKey}
                     project={project}
                   />
                   <hr />
                   <PrerequisiteTargetingField
-                    value={
-                      form.watch(`phases.${lastPhase}.prerequisites`) || []
-                    }
+                    value={form.watch("phases.0.prerequisites") || []}
                     setValue={(prerequisites) =>
-                      form.setValue(
-                        `phases.${lastPhase}.prerequisites`,
-                        prerequisites
-                      )
+                      form.setValue("phases.0.prerequisites", prerequisites)
                     }
                     environments={envs}
                     project={form.watch("project")}
@@ -789,7 +751,7 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
                   />
                   <hr />
                   <NamespaceSelector
-                    formPrefix={`phases.${lastPhase}.`}
+                    formPrefix="phases.0."
                     form={form}
                     featureId={""}
                     trackingKey={""}
@@ -806,9 +768,9 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
               )}
               <FeatureVariationsInput
                 valueType="string"
-                coverage={form.watch(`phases.${lastPhase}.coverage`)}
+                coverage={form.watch("phases.0.coverage")}
                 setCoverage={(coverage) =>
-                  form.setValue(`phases.${lastPhase}.coverage`, coverage)
+                  form.setValue("phases.0.coverage", coverage)
                 }
                 coverageTooltip={
                   isNewExperiment
@@ -816,10 +778,7 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
                     : "This is just for documentation purposes and has no effect on the analysis."
                 }
                 setWeight={(i, weight) =>
-                  form.setValue(
-                    `phases.${lastPhase}.variationWeights.${i}`,
-                    weight
-                  )
+                  form.setValue(`phases.0.variationWeights.${i}`, weight)
                 }
                 valueAsId={true}
                 variations={
@@ -827,9 +786,7 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
                     return {
                       value: v.key || "",
                       name: v.name,
-                      weight: form.watch(
-                        `phases.${lastPhase}.variationWeights.${i}`
-                      ),
+                      weight: form.watch(`phases.0.variationWeights.${i}`),
                       id: v.id,
                     };
                   }) ?? []
@@ -848,7 +805,7 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
                     })
                   );
                   form.setValue(
-                    `phases.${lastPhase}.variationWeights`,
+                    "phases.0.variationWeights",
                     v.map((v) => v.weight)
                   );
                 }}


### PR DESCRIPTION
Targeting conditions (which live in the `phases` array) were not being copied over on duplicate.