### PR TITLE
Bugfix darkmode feature page bugs

### DIFF
--- a/packages/front-end/components/Markdown/Markdown.module.scss
+++ b/packages/front-end/components/Markdown/Markdown.module.scss
@@ -6,7 +6,7 @@
     overflow: auto;
     font-size: 85%;
     line-height: 1.45;
-    background-color: #f6f8fa;
+    background-color: var(--markdown-code-background);
     border-radius: 6px;
   }
   ul,
@@ -46,9 +46,6 @@
     color: #fff;
     padding: 3px 8px;
     border-radius: 5px;
-  }
-  code[class*="language-"] {
-    color: #333;
   }
   table {
     border-collapse: collapse;

--- a/packages/front-end/styles/theme.scss
+++ b/packages/front-end/styles/theme.scss
@@ -31,6 +31,8 @@
   --form-switch-background: #{colors.$gray-300};
   --form-switch-background-active: #{colors.$purple};
 
+  --markdown-code-background: #f6f8fa;
+
   --alert-success-background: #d4edda;
   --alert-success-border-color: #c3e6cb;
   --alert-success-color: #155724;
@@ -155,6 +157,8 @@
   --form-multivalue-text-color: #{colors.$black};
   --form-switch-background: #{colors.$gray-800};
   --form-switch-background-active: #{colors.$highlight-purple};
+
+  --markdown-code-background: #05054920;
 
   --alert-success-background: #{darken(#155724, 8%)};
   --alert-success-border-color: #{darken(#155724, 0%)};


### PR DESCRIPTION
### Features and Changes

Resolve two dark mode issues on the Feature page.

- Closes #3160 

| Before | After |
|--------|--------|
|  <img width="550" alt="Screenshot 2024-11-01 at 3 23 26 PM" src="https://github.com/user-attachments/assets/4972e943-3ff8-402a-8bbc-77d672ae5d69"> | <img width="393" alt="Screenshot 2024-11-01 at 3 22 30 PM" src="https://github.com/user-attachments/assets/3ff6602f-3f94-4359-85a3-03725c0d20b2"> | 
|  <img width="1325" alt="Screenshot 2024-11-01 at 3 23 29 PM" src="https://github.com/user-attachments/assets/1efd7416-e167-441b-a334-224b8f533885"> | <img width="1347" alt="Screenshot 2024-11-01 at 3 22 35 PM" src="https://github.com/user-attachments/assets/e20784d9-8d2c-42ca-b719-6606fc4540fa"> | 


Light mode for comparison (only slight change in text from grey to black for "Not included" text)

| Before | After |
|--------|--------|
|  <img width="463" alt="Screenshot 2024-11-01 at 3 23 16 PM" src="https://github.com/user-attachments/assets/fd7028d9-8996-4ccd-9720-f957f92f6bc3"> | <img width="435" alt="Screenshot 2024-11-01 at 3 22 43 PM" src="https://github.com/user-attachments/assets/4f3f87c3-867c-4ff7-bfb1-20cc480d0d41"> | 
| <img width="1311" alt="Screenshot 2024-11-01 at 3 23 21 PM" src="https://github.com/user-attachments/assets/87c8d9fa-f2d6-4d23-a3a4-75c51d329743">  |  <img width="1338" alt="Screenshot 2024-11-01 at 3 22 46 PM" src="https://github.com/user-attachments/assets/b0ca5d2c-12b2-48e7-8b81-7025654b9283"> | 
