### PR TITLE
Fix analysis settings bar flicker

### DIFF
--- a/packages/front-end/components/Experiment/AnalysisSettingsBar.tsx
+++ b/packages/front-end/components/Experiment/AnalysisSettingsBar.tsx
@@ -138,12 +138,10 @@ export default function AnalysisSettingsBar({
                   snapshot={snapshot}
                   analysis={analysis}
                   setAnalysisSettings={setAnalysisSettings}
-                  loading={false}
                   mutate={mutate}
                   dropdownEnabled={
                     !manualSnapshot && snapshot?.dimension !== "pre:date"
                   }
-                  dimension={dimension}
                 />
                 <em className="text-muted mx-3" style={{ marginTop: 15 }}>
                   vs
@@ -181,7 +179,6 @@ export default function AnalysisSettingsBar({
                 snapshot={snapshot}
                 analysis={analysis}
                 setAnalysisSettings={setAnalysisSettings}
-                loading={false}
                 mutate={mutate}
                 phase={phase}
               />

--- a/packages/front-end/components/Experiment/AnalysisSettingsBar.tsx
+++ b/packages/front-end/components/Experiment/AnalysisSettingsBar.tsx
@@ -88,7 +88,6 @@ export default function AnalysisSettingsBar({
     phase,
     setDimension,
     setSnapshotType,
-    loading,
   } = useSnapshot();
   const { getDatasourceById } = useDefinitions();
   const datasource = experiment
@@ -139,7 +138,7 @@ export default function AnalysisSettingsBar({
                   snapshot={snapshot}
                   analysis={analysis}
                   setAnalysisSettings={setAnalysisSettings}
-                  loading={!!loading}
+                  loading={false}
                   mutate={mutate}
                   dropdownEnabled={
                     !manualSnapshot && snapshot?.dimension !== "pre:date"
@@ -182,7 +181,7 @@ export default function AnalysisSettingsBar({
                 snapshot={snapshot}
                 analysis={analysis}
                 setAnalysisSettings={setAnalysisSettings}
-                loading={!!loading}
+                loading={false}
                 mutate={mutate}
                 phase={phase}
               />

--- a/packages/front-end/components/Experiment/BaselineChooser.tsx
+++ b/packages/front-end/components/Experiment/BaselineChooser.tsx
@@ -23,10 +23,8 @@ export interface Props {
   setAnalysisSettings: (
     settings: ExperimentSnapshotAnalysisSettings | null
   ) => void;
-  loading: boolean;
   mutate: () => void;
   dropdownEnabled: boolean;
-  dimension: string;
 }
 
 export default function BaselineChooser({
@@ -37,10 +35,8 @@ export default function BaselineChooser({
   snapshot,
   analysis,
   setAnalysisSettings,
-  loading,
   mutate,
   dropdownEnabled,
-  dimension,
 }: Props) {
   const { apiCall } = useAuth();
 
@@ -125,11 +121,7 @@ export default function BaselineChooser({
         >
           {baselineVariation.name}
         </span>
-        {((loading &&
-          dropdownEnabled &&
-          dimension === "" && // todo: remove when dimensions are supported
-          baselineRow !== analysis?.settings?.baselineVariationIndex) ||
-          postLoading) && <LoadingSpinner className="ml-1" />}
+        {postLoading && <LoadingSpinner className="ml-1" />}
       </div>
     </div>
   );

--- a/packages/front-end/components/Experiment/DifferenceTypeChooser.tsx
+++ b/packages/front-end/components/Experiment/DifferenceTypeChooser.tsx
@@ -63,7 +63,6 @@ export interface Props {
   setAnalysisSettings: (
     settings: ExperimentSnapshotAnalysisSettings | null
   ) => void;
-  loading: boolean;
   mutate: () => void;
   disabled?: boolean;
 }
@@ -75,7 +74,6 @@ export default function DifferenceTypeChooser({
   phase,
   analysis,
   setAnalysisSettings,
-  loading,
   mutate,
   disabled,
 }: Props) {
@@ -107,8 +105,7 @@ export default function DifferenceTypeChooser({
     <div className="d-inline-flex align-items-center">
       <div className={`d-flex align-items-center`}>
         <span className="hover">{selectedDifferenceName}</span>
-        {((loading && differenceType !== analysis?.settings?.differenceType) ||
-          postLoading) && <LoadingSpinner className="ml-1" />}
+        {postLoading && <LoadingSpinner className="ml-1" />}
       </div>
     </div>
   );

--- a/packages/front-end/pages/report/[rid].tsx
+++ b/packages/front-end/pages/report/[rid].tsx
@@ -302,7 +302,6 @@ export default function ReportPage() {
                     phase={0}
                     setDifferenceType={() => {}}
                     setAnalysisSettings={() => {}}
-                    loading={false}
                     mutate={() => {}}
                   />
                 </div>


### PR DESCRIPTION
Analysis settings bar used to flicker when loading a snapshot when none with results existed, and loading didn't seem to be used in happy path so I decided to remove it from the two selectors.

Before
https://www.loom.com/share/2a8cc9d786ef4975bac3c3231984fbd6

After
https://www.loom.com/share/a9e4448e96ee4d38a53e46dd02ace747

Also, the loading symbol when you actually change baselines still works, so it doesn't affect the main purpose of showing loading in this bar:
https://www.loom.com/share/980e75bc940640499c32c66a3a646517