### PR TITLE
More graceful handling of fact table failure

### DIFF
--- a/packages/back-end/src/services/stats.ts
+++ b/packages/back-end/src/services/stats.ts
@@ -452,6 +452,7 @@ export function getMetricsAndQueryDataForStatsEngine(
       // Multi-metric query
       if (key.match(/group_/)) {
         const rows = query.result as ExperimentFactMetricsQueryResponseRows;
+        if (!rows?.length) return;
         const metricIds: (string | null)[] = [];
         for (let i = 0; i < 100; i++) {
           const prefix = `m${i}_`;


### PR DESCRIPTION
If you have a fact metric optimized query that returns no rows, but other queries work (e.g. > 50% of queries succeed so analysis goes through) we return a cryptic error that breaks the analysis.

This PR changes that so the other queries can be analyzed safely with the usual error warnings at the top (although note for fact metric optimized queries we don't have the ability to mark those rows as "query error") yet.

Before
<img width="1548" alt="Screenshot 2024-11-01 at 4 13 38 PM" src="https://github.com/user-attachments/assets/c5ad8dfd-918f-44f7-96bb-8314807ff2e9">

After
<img width="1420" alt="Screenshot 2024-11-01 at 4 20 57 PM" src="https://github.com/user-attachments/assets/426d3a0d-7df4-48fc-8a91-9c85780990d0">
<img width="1420" alt="Screenshot 2024-11-01 at 4 20 57 PM" src="https://github.com/user-attachments/assets/4a3296fe-5797-4d4a-8280-8c0a2f0a7e32">


Before: https://www.loom.com/share/55b25bd003de4ace99a1cc3e572a2dcd

After: https://www.loom.com/share/0c315a427dd0423bb8f1a6fc72f14ee9