### PR TITLE
Fix copy/paste metrics in the Analysis settings screen

### DIFF
--- a/packages/front-end/components/Experiment/MetricsSelector.tsx
+++ b/packages/front-end/components/Experiment/MetricsSelector.tsx
@@ -247,7 +247,14 @@ const MetricsSelector: FC<{
         try {
           const clipboard = e.clipboardData;
           const data = JSON.parse(clipboard.getData("Text"));
-          if (data.every((d) => d.startsWith("met_") || d.startsWith("mg_"))) {
+          if (
+            data.every(
+              (d) =>
+                d.startsWith("met_") ||
+                d.startsWith("mg_") ||
+                d.startsWith("fact_")
+            )
+          ) {
             e.preventDefault();
             e.stopPropagation();
             onChange(data);

--- a/packages/front-end/components/Experiment/MetricsSelector.tsx
+++ b/packages/front-end/components/Experiment/MetricsSelector.tsx
@@ -252,7 +252,7 @@ const MetricsSelector: FC<{
               (d) =>
                 d.startsWith("met_") ||
                 d.startsWith("mg_") ||
-                d.startsWith("fact_")
+                d.startsWith("fact__")
             )
           ) {
             e.preventDefault();


### PR DESCRIPTION
### Features and Changes

Originally implemented in #2368 it likely broke when we added Fact Tables as a new metric source.

This fixes it.