### PR TITLE
[HOTFIX] Convert Tag radix colors to hex colors in TagsInput for correct color rendering

### DIFF
--- a/packages/front-end/components/Tags/TagsInput.tsx
+++ b/packages/front-end/components/Tags/TagsInput.tsx
@@ -4,6 +4,7 @@ import { TagInterface } from "back-end/types/tag";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import MultiSelectField from "@/components/Forms/MultiSelectField";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
+import { TAG_COLORS_MAP } from "@/services/tags";
 import { isLight } from "./Tag";
 
 export interface ColorOption {
@@ -14,6 +15,8 @@ export interface ColorOption {
   readonly isFixed?: boolean;
   readonly isDisabled?: boolean;
 }
+
+const DEFAULT_TAG_COLOR = TAG_COLORS_MAP["blue"];
 
 const TagsInput: FC<{
   onChange: (tags: string[]) => void;
@@ -70,7 +73,7 @@ const TagsInput: FC<{
         display: "flex",
         // add a colored dot:
         ":before": {
-          backgroundColor: data.color,
+          backgroundColor: displayColor,
           borderRadius: 10,
           content: '" "',
           display: "block",
@@ -109,10 +112,12 @@ const TagsInput: FC<{
     <MultiSelectField
       options={
         tagOptions.map((t) => {
+          // Converts Radix color to hex color to make it compatible with MultiSelectField
+          const hexColor = TAG_COLORS_MAP[t.color] ?? DEFAULT_TAG_COLOR;
           return {
             value: t.id,
             label: t.id,
-            color: t.color || "var(--form-multivalue-text-color)",
+            color: hexColor || "var(--form-multivalue-text-color)",
             tooltip: t.description,
           };
         }) ?? []

--- a/packages/front-end/components/Tags/TagsInput.tsx
+++ b/packages/front-end/components/Tags/TagsInput.tsx
@@ -73,7 +73,7 @@ const TagsInput: FC<{
         display: "flex",
         // add a colored dot:
         ":before": {
-          backgroundColor: displayColor,
+          backgroundColor: data.color,
           borderRadius: 10,
           content: '" "',
           display: "block",

--- a/packages/front-end/services/tags.tsx
+++ b/packages/front-end/services/tags.tsx
@@ -28,7 +28,7 @@ import {
 } from "@radix-ui/colors";
 import { RadixColor } from "@/components/Radix/HelperText";
 
-const TAG_COLORS_MAP: Record<NonNullable<RadixColor>, string> = {
+export const TAG_COLORS_MAP: Record<NonNullable<RadixColor>, string> = {
   gray: gray.gray11,
   gold: gold.gold11,
   bronze: bronze.bronze11,


### PR DESCRIPTION
### Features and Changes

`TagsInput` uses `MultiSelectField` under the hood which doesn't support Radix colors. 
Converts Radix colors to hex colors to render colors appropriately.

### Screenshots

Before (invisible "brand new tag")
<img width="514" alt="Screenshot 2024-11-05 at 12 00 47 PM" src="https://github.com/user-attachments/assets/8e897774-96e5-4808-b8e1-85e95160a5b9">

After
<img width="507" alt="Screenshot 2024-11-05 at 12 01 37 PM" src="https://github.com/user-attachments/assets/5908b882-5dfd-49b9-bd05-b2cd59458039">

