### PR TITLE
fixing typo around quotes

### DIFF
--- a/docs/docs/experimentation-analysis/data-source-configuration.mdx
+++ b/docs/docs/experimentation-analysis/data-source-configuration.mdx
@@ -158,7 +158,7 @@ WHERE
 
 :::note
 
-The inserted values do not have surrounding quotes, so you must add those yourself (e.g. use `'{{&nbsp;startDate&nbsp;}}'` instead of just `{{&nbsp;startDate&nbsp;}}`)
+The inserted values do not have surrounding quotes, so you must add those yourself (e.g. use `{{ 'startDate' }}` instead of `{{ startDate }}`).
 
 :::
 

--- a/docs/docs/experimentation-analysis/metrics.mdx
+++ b/docs/docs/experimentation-analysis/metrics.mdx
@@ -140,7 +140,7 @@ WHERE
 
 :::note
 
-The inserted values do not have surrounding quotes, so you must add those yourself (e.g. use `'{{&nbsp;startDate&nbsp;}}'` instead of just `{{&nbsp;startDate&nbsp;}}`
+The inserted values do not have surrounding quotes, so you must add those yourself (e.g. use `{{ 'startDate' }}` instead of `{{ startDate }}`).
 
 :::
 


### PR DESCRIPTION
removing typo located in docs in multiple places displaying &nbsp

current: 
![image](https://github.com/user-attachments/assets/539b8673-2fe7-4f67-abe6-e702998aad48)

new: 
<img width="1728" alt="Screenshot 2024-11-05 at 4 21 10 PM" src="https://github.com/user-attachments/assets/24b2b522-5d3c-42ea-833d-995e2e974178">

