### PR TITLE
Add schedule controls for existing exp rules

### DIFF
--- a/packages/front-end/components/Features/RuleModal/ExperimentRefFields.tsx
+++ b/packages/front-end/components/Features/RuleModal/ExperimentRefFields.tsx
@@ -1,8 +1,9 @@
 import { useFormContext } from "react-hook-form";
-import { FeatureInterface } from "back-end/types/feature";
-import { FaExternalLinkAlt } from "react-icons/fa";
+import { FeatureInterface, FeatureRule } from "back-end/types/feature";
+import { FaClock, FaExternalLinkAlt } from "react-icons/fa";
 import { date } from "shared/dates";
 import Link from "next/link";
+import React from "react";
 import Field from "@/components/Forms/Field";
 import FeatureValueField from "@/components/Features/FeatureValueField";
 import SelectField from "@/components/Forms/SelectField";
@@ -10,22 +11,32 @@ import {
   getDefaultVariationValue,
   getFeatureDefaultValue,
   getRules,
+  NewExperimentRefRule,
 } from "@/services/features";
 import StatusIndicator from "@/components/Experiment/StatusIndicator";
 import TargetingInfo from "@/components/Experiment/TabbedPage/TargetingInfo";
 import { useExperiments } from "@/hooks/useExperiments";
 import Callout from "@/components/Radix/Callout";
+import ScheduleInputs from "@/components/Features/ScheduleInputs";
 
 export default function ExperimentRefFields({
   feature,
   environment,
   i,
+  defaultValues,
   changeRuleType,
+  noSchedule,
+  scheduleToggleEnabled,
+  setScheduleToggleEnabled,
 }: {
   feature: FeatureInterface;
   environment: string;
   i: number;
+  defaultValues?: FeatureRule | NewExperimentRefRule;
   changeRuleType: (v: string) => void;
+  noSchedule?: boolean;
+  scheduleToggleEnabled?: boolean;
+  setScheduleToggleEnabled?: (b: boolean) => void;
 }) {
   const form = useFormContext();
 
@@ -89,11 +100,17 @@ export default function ExperimentRefFields({
                     <div className="ml-4 text-muted">
                       Created: {date(exp.dateCreated)}
                     </div>
-                    <div className="ml-auto">
+                    <div className="ml-auto d-flex align-items-center">
                       <StatusIndicator
                         archived={exp.archived}
                         status={exp.status}
                       />
+                      {!noSchedule ? (
+                        <div className="small text-muted ml-3">
+                          <FaClock className="mr-1" />
+                          Scheduled
+                        </div>
+                      ) : null}
                     </div>
                   </div>
                 );
@@ -164,6 +181,17 @@ export default function ExperimentRefFields({
         {...form.register("description")}
         placeholder="Short human-readable description of the rule"
       />
+
+      {!noSchedule && setScheduleToggleEnabled ? (
+        <div className="mt-4 mb-3">
+          <ScheduleInputs
+            defaultValue={defaultValues?.scheduleRules || []}
+            onChange={(value) => form.setValue("scheduleRules", value)}
+            scheduleToggleEnabled={!!scheduleToggleEnabled}
+            setScheduleToggleEnabled={setScheduleToggleEnabled}
+          />
+        </div>
+      ) : null}
     </>
   );
 }

--- a/packages/front-end/components/Features/RuleModal/ExperimentRefNewFields.tsx
+++ b/packages/front-end/components/Features/RuleModal/ExperimentRefNewFields.tsx
@@ -39,7 +39,6 @@ export default function ExperimentRefNewFields({
   environment,
   environments,
   defaultValues,
-  noSchedule,
   revisions,
   version,
   prerequisiteValue,
@@ -69,7 +68,6 @@ export default function ExperimentRefNewFields({
   environment?: string;
   environments?: string[];
   defaultValues?: FeatureRule | NewExperimentRefRule;
-  noSchedule?: boolean;
   revisions?: FeatureRevisionInterface[];
   version?: number;
   prerequisiteValue: FeaturePrerequisite[];
@@ -245,44 +243,35 @@ export default function ExperimentRefNewFields({
             </div>
           )}
 
-          {!noSchedule && form.watch("type") === "experiment-ref-new" ? (
-            <>
-              <hr />
-              <div className="mt-4 mb-3">
-                <Toggle
-                  value={form.watch("autoStart")}
-                  setValue={(v) => form.setValue("autoStart", v)}
-                  id="auto-start-new-experiment"
-                />{" "}
-                <label
-                  htmlFor="auto-start-new-experiment"
-                  className="text-dark"
-                >
-                  Start Experiment Immediately
-                </label>
-                <div>
-                  <small className="form-text text-muted">
-                    If On, the Experiment will start serving traffic as soon as
-                    the feature is published. Leave Off if you want to make
-                    additional changes before starting.
-                  </small>
-                </div>
-                {!form.watch("autoStart") && setScheduleToggleEnabled ? (
-                  <div>
-                    <hr />
-                    <ScheduleInputs
-                      defaultValue={defaultValues?.scheduleRules || []}
-                      onChange={(value) =>
-                        form.setValue("scheduleRules", value)
-                      }
-                      scheduleToggleEnabled={!!scheduleToggleEnabled}
-                      setScheduleToggleEnabled={setScheduleToggleEnabled}
-                    />
-                  </div>
-                ) : null}
+          <hr />
+          <div className="mt-4 mb-3">
+            <Toggle
+              value={form.watch("autoStart")}
+              setValue={(v) => form.setValue("autoStart", v)}
+              id="auto-start-new-experiment"
+            />{" "}
+            <label htmlFor="auto-start-new-experiment" className="text-dark">
+              Start Experiment Immediately
+            </label>
+            <div>
+              <small className="form-text text-muted">
+                If On, the Experiment will start serving traffic as soon as the
+                feature is published. Leave Off if you want to make additional
+                changes before starting.
+              </small>
+            </div>
+            {!form.watch("autoStart") && setScheduleToggleEnabled ? (
+              <div>
+                <hr />
+                <ScheduleInputs
+                  defaultValue={defaultValues?.scheduleRules || []}
+                  onChange={(value) => form.setValue("scheduleRules", value)}
+                  scheduleToggleEnabled={!!scheduleToggleEnabled}
+                  setScheduleToggleEnabled={setScheduleToggleEnabled}
+                />
               </div>
-            </>
-          ) : null}
+            ) : null}
+          </div>
         </>
       ) : null}
     </>

--- a/packages/front-end/components/Features/RuleModal/index.tsx
+++ b/packages/front-end/components/Features/RuleModal/index.tsx
@@ -131,10 +131,11 @@ export default function RuleModal({
     defaultValues,
   });
 
+  const defaultHasSchedule = (defaultValues.scheduleRules || []).some(
+    (scheduleRule) => scheduleRule.timestamp !== null
+  );
   const [scheduleToggleEnabled, setScheduleToggleEnabled] = useState(
-    (defaultValues.scheduleRules || []).some(
-      (scheduleRule) => scheduleRule.timestamp !== null
-    )
+    defaultHasSchedule
   );
 
   const orgStickyBucketing = !!settings.useStickyBucketing;
@@ -771,7 +772,11 @@ export default function RuleModal({
             feature={feature}
             environment={environment}
             i={i}
+            defaultValues={defaultValues}
             changeRuleType={changeRuleType}
+            noSchedule={!defaultHasSchedule}
+            scheduleToggleEnabled={scheduleToggleEnabled}
+            setScheduleToggleEnabled={setScheduleToggleEnabled}
           />
         ) : null}
 


### PR DESCRIPTION
- ensure schedule controls are present if existing experiment rule has a schedule
- add schedule indicator in rule's experiment status indicator
- 
<img width="674" alt="image" src="https://github.com/user-attachments/assets/7f413024-50cf-44fa-997a-4313dc4aa88a">