### PR TITLE
Fix loading flicker on features, metrics, and other pages

### DIFF
--- a/packages/front-end/pages/_app.tsx
+++ b/packages/front-end/pages/_app.tsx
@@ -19,7 +19,10 @@ import { PageHeadProvider } from "@/components/Layout/PageHead";
 import { RadixTheme } from "@/services/RadixTheme";
 import { AuthProvider } from "@/services/auth";
 import ProtectedPage from "@/components/ProtectedPage";
-import { DefinitionsProvider } from "@/services/DefinitionsContext";
+import {
+  DefinitionsGuard,
+  DefinitionsProvider,
+} from "@/services/DefinitionsContext";
 import track from "@/services/track";
 import { initEnv, isTelemetryEnabled } from "@/services/env";
 import LoadingOverlay from "@/components/LoadingOverlay";
@@ -161,7 +164,9 @@ function App({
                               <GuidedGetStartedBar />
                               <OrganizationMessagesContainer />
                               <DemoDataSourceGlobalBannerContainer />
-                              <Component {...pageProps} />
+                              <DefinitionsGuard>
+                                <Component {...pageProps} />
+                              </DefinitionsGuard>
                             </main>
                           </DefinitionsProvider>
                         </GetStartedProvider>

--- a/packages/front-end/services/DefinitionsContext.tsx
+++ b/packages/front-end/services/DefinitionsContext.tsx
@@ -10,6 +10,7 @@ import {
   FC,
   ReactNode,
   useCallback,
+  ReactElement,
 } from "react";
 import { TagInterface } from "back-end/types/tag";
 import {
@@ -21,6 +22,7 @@ import { SavedGroupInterface } from "shared/src/types";
 import { MetricGroupInterface } from "back-end/types/metric-groups";
 import useApi from "@/hooks/useApi";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
+import LoadingOverlay from "@/components/LoadingOverlay";
 import { findClosestRadixColor } from "./tags";
 
 type Definitions = {
@@ -308,3 +310,13 @@ export const DefinitionsProvider: FC<{ children: ReactNode }> = ({
     </DefinitionsContext.Provider>
   );
 };
+
+export function DefinitionsGuard({ children }: { children: ReactElement }) {
+  const { ready, error } = useDefinitions();
+
+  if (!error && !ready) {
+    return <LoadingOverlay />;
+  }
+
+  return children;
+}

--- a/packages/front-end/services/features.ts
+++ b/packages/front-end/services/features.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo } from "react";
 import {
   Environment,
   NamespaceUsage,
@@ -187,11 +187,6 @@ export function findGaps(
 
 export function useFeaturesList(withProject = true, includeArchived = false) {
   const { project } = useDefinitions();
-  const [features, setFeatures] = useState<FeatureInterface[]>([]);
-  const [experiments, setExperiments] = useState<
-    ExperimentInterfaceStringDates[]
-  >([]);
-  const [hasArchived, setHasArchived] = useState(false);
 
   const qs = new URLSearchParams();
   if (withProject) {
@@ -209,12 +204,19 @@ export function useFeaturesList(withProject = true, includeArchived = false) {
     hasArchived: boolean;
   }>(url);
 
-  useEffect(() => {
+  const { features, experiments, hasArchived } = useMemo(() => {
     if (data) {
-      setFeatures(data.features);
-      setExperiments(data.linkedExperiments);
-      setHasArchived(data.hasArchived);
+      return {
+        features: data.features,
+        experiments: data.linkedExperiments,
+        hasArchived: data.hasArchived,
+      };
     }
+    return {
+      features: [],
+      experiments: [],
+      hasArchived: false,
+    };
   }, [data]);
 
   return {


### PR DESCRIPTION
### Features and Changes

The `/features` page was briefly flickering on page load.  It would show the empty state before immediately re-rendering with the features table.  This was due to using `useEffect` and `useState` instead of `useMemo`.

The `/metrics` page (and others) were also flickering on page load.  This was due to us rendering pages before `DefinitionsContext` was ready.  Instead of adding a `ready` check in every page, I just prevent the entire app from rendering until definitions are ready which simplifies a lot.