### PR TITLE
Introducing GrowthBook Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
     <a href="https://github.com/growthbook/growthbook/github/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/growthbook/growthbook/ci.yml?branch=main" alt="Build Status" height="22"/></a>
     <a href="https://github.com/growthbook/growthbook/releases"><img src="https://img.shields.io/github/v/release/growthbook/growthbook?color=blue&sort=semver" alt="Release" height="22"/></a>
     <a href="https://slack.growthbook.io?ref=readme-badge"><img src="https://img.shields.io/badge/slack-join-E01E5A?logo=slack" alt="Join us on Slack" height="22"/></a>
+    <a href="https://gurubase.io/g/growthbook"><img src="https://img.shields.io/badge/Gurubase-Ask%20GrowthBook%20Guru-006BFF" alt="Ask GrowthBook Guru" height="22"/></a>
 </p>
 
 Get up and running in 1 minute with:


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [GrowthBook Guru](https://gurubase.io/g/growthbook) to Gurubase. GrowthBook Guru uses the data from this repo and data from the [docs](https://docs.growthbook.io) to answer questions by leveraging the LLM.

In this PR, I showcased the "GrowthBook Guru", which highlights that GrowthBook now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable GrowthBook Guru in Gurubase, just let me know that's totally fine.
