### PR TITLE
Add new Radix link component

### DIFF
--- a/packages/front-end/components/Radix/Link.tsx
+++ b/packages/front-end/components/Radix/Link.tsx
@@ -1,0 +1,32 @@
+import clsx from "clsx";
+import NextLink from "next/link";
+import { LinkProps, Link as RadixLink } from "@radix-ui/themes";
+import styles from "./RadixOverrides.module.scss";
+
+type RadixProps = Omit<LinkProps, "color"> & {
+  color?: LinkProps["color"] | "dark";
+};
+
+type NextProps = React.ComponentProps<typeof NextLink>;
+
+export default function Link({
+  children,
+  className,
+  color,
+  ...props
+}: RadixProps & NextProps) {
+  const isCustomDarkColor = color === "dark";
+
+  return (
+    <RadixLink
+      className={clsx(styles.link, className, {
+        [styles.darkLink]: isCustomDarkColor,
+      })}
+      color={isCustomDarkColor ? undefined : color}
+      {...props}
+      asChild
+    >
+      <NextLink {...props}>{children}</NextLink>
+    </RadixLink>
+  );
+}

--- a/packages/front-end/components/Radix/Link.tsx
+++ b/packages/front-end/components/Radix/Link.tsx
@@ -1,21 +1,73 @@
 import clsx from "clsx";
-import NextLink from "next/link";
-import { LinkProps, Link as RadixLink } from "@radix-ui/themes";
+import NextLink, { LinkProps as NextLinkProps } from "next/link";
+import {
+  Link as RadixLink,
+  LinkProps as RadixLinkProps,
+} from "@radix-ui/themes";
 import styles from "./RadixOverrides.module.scss";
 
-type RadixProps = Omit<LinkProps, "color"> & {
-  color?: LinkProps["color"] | "dark";
+type RadixProps = Omit<RadixLinkProps, "color" | "href"> & {
+  color?: RadixLinkProps["color"] | "dark";
 };
 
-type NextProps = React.ComponentProps<typeof NextLink>;
+type NextProps = Omit<
+  NextLinkProps,
+  "onClick" | "onMouseEnter" | "onTouchStart" | "href" | "passHref"
+>;
+
+// Ensure we always have at least `href` or `onClick`
+// Also allows both to be present
+type ConditionalProps =
+  | ({
+      href: NextLinkProps["href"];
+    } & NextProps)
+  | {
+      href?: never;
+      onClick: RadixLinkProps["onClick"];
+    };
 
 export default function Link({
   children,
   className,
   color,
+  href,
   ...props
-}: RadixProps & NextProps) {
+}: RadixProps & ConditionalProps) {
   const isCustomDarkColor = color === "dark";
+
+  let childrenWrapper: JSX.Element | null = null;
+  let radixProps = props;
+
+  if (href === undefined) {
+    childrenWrapper = <button type="button">{children}</button>;
+  } else {
+    const {
+      replace,
+      as,
+      scroll,
+      shallow,
+      prefetch,
+      locale,
+      legacyBehavior,
+      ...rest
+    } = props as NextProps;
+    radixProps = rest;
+
+    childrenWrapper = (
+      <NextLink
+        href={href}
+        replace={replace}
+        as={as}
+        scroll={scroll}
+        shallow={shallow}
+        prefetch={prefetch}
+        locale={locale}
+        legacyBehavior={legacyBehavior}
+      >
+        {children}
+      </NextLink>
+    );
+  }
 
   return (
     <RadixLink
@@ -23,10 +75,10 @@ export default function Link({
         [styles.darkLink]: isCustomDarkColor,
       })}
       color={isCustomDarkColor ? undefined : color}
-      {...props}
+      {...radixProps}
       asChild
     >
-      <NextLink {...props}>{children}</NextLink>
+      {childrenWrapper}
     </RadixLink>
   );
 }

--- a/packages/front-end/components/Radix/RadixOverrides.module.scss
+++ b/packages/front-end/components/Radix/RadixOverrides.module.scss
@@ -9,3 +9,22 @@
     max-height: 100%;
   }
 }
+
+.link {
+  &:hover {
+    color: var(--accent-10);
+  }
+
+  // Override needed because of bootstrap
+  &:global(.rt-underline-none):hover {
+    text-decoration: none;
+  }
+}
+
+.darkLink {
+  color: var(--color-text-high);
+
+  &:hover {
+    color: var(--color-text-mid);
+  }
+}

--- a/packages/front-end/components/Radix/RadixOverrides.module.scss
+++ b/packages/front-end/components/Radix/RadixOverrides.module.scss
@@ -11,6 +11,10 @@
 }
 
 .link {
+  // Ensures consistent underline color between button and link
+  // Can be removed when bootstrap is removed.
+  text-decoration-color: inherit;
+
   &:hover {
     color: var(--accent-10);
   }

--- a/packages/front-end/pages/design-system/index.tsx
+++ b/packages/front-end/pages/design-system/index.tsx
@@ -1,4 +1,4 @@
-import { Flex, Slider } from "@radix-ui/themes";
+import { Box, Flex, Slider } from "@radix-ui/themes";
 import React, { useState } from "react";
 import { FaDownload, FaExternalLinkAlt } from "react-icons/fa";
 import { BsArrowRepeat } from "react-icons/bs";
@@ -24,6 +24,7 @@ import RadioCards from "@/components/Radix/RadioCards";
 import PremiumTooltip from "@/components/Marketing/PremiumTooltip";
 import DataList from "@/components/Radix/DataList";
 import Stepper from "@/components/Stepper/Stepper";
+import Link from "@/components/Radix/Link";
 
 export default function DesignSystemPage() {
   const [checked, setChecked] = useState<"indeterminate" | boolean>(false);
@@ -174,6 +175,47 @@ export default function DesignSystemPage() {
           >
             A disabled link
           </LinkButton>
+        </Flex>
+      </div>
+
+      <div className="appbox p-3">
+        <h3>Link</h3>
+        <Flex direction="column" gap="3">
+          <Box>
+            Here we have <Link href="#">a link</Link> within a sentence.
+          </Box>
+          <Box>
+            <Link href="#" weight="bold">
+              Bold link
+            </Link>
+          </Box>
+          <Box>
+            <Link href="#" weight="bold" underline="none">
+              Link without underline affordance
+            </Link>
+          </Box>
+          <Box>
+            And you can{" "}
+            <Link color="gray" href="#">
+              override
+            </Link>{" "}
+            the{" "}
+            <Link color="sky" href="#">
+              link color
+            </Link>{" "}
+            with{" "}
+            <Link color="sky" href="#">
+              Radix colors
+            </Link>
+            .
+          </Box>
+          <Box>
+            And we also have{" "}
+            <Link href="#" color="dark" weight="bold">
+              a custom dark/white color
+            </Link>
+            .
+          </Box>
         </Flex>
       </div>
 

--- a/packages/front-end/pages/design-system/index.tsx
+++ b/packages/front-end/pages/design-system/index.tsx
@@ -210,11 +210,19 @@ export default function DesignSystemPage() {
             .
           </Box>
           <Box>
-            And we also have{" "}
+            We also have{" "}
             <Link href="#" color="dark" weight="bold">
               a custom dark/white color
             </Link>
             .
+          </Box>
+
+          <Box>
+            Here&apos;s the Link without href where it{" "}
+            <Link onClick={() => alert("Hello there")}>
+              automatically adapts to a button
+            </Link>{" "}
+            while keeping the same style.
           </Box>
         </Flex>
       </div>

--- a/packages/front-end/styles/theme-config.css
+++ b/packages/front-end/styles/theme-config.css
@@ -15,8 +15,14 @@
 .light-theme {
   --color-page-background: #f5f7fa;
   --color-background: #faf8ff;
+
+  --color-text-high: #1f2d5c;
+  --color-text-mid: rgba(31, 45, 92, 0.85);
 }
 .dark,
 .dark-theme {
   --color-background: #10172e;
+
+  --color-text-high: white;
+  --color-text-mid: rgba(255, 255, 255, 0.85);
 }


### PR DESCRIPTION
### Features and Changes

- Add a new `Link` component that merges `Radix/Link` and `next/link`.
- Add new `color` option `dark` which is used in the Get Started page.

### Screenshots


Note: I am hovering over the second item on both screenshots.

<img width="412" alt="Screenshot 2024-11-08 at 3 36 05 PM" src="https://github.com/user-attachments/assets/ca07bc82-7381-4b23-bcd1-79976668712c">
<img width="457" alt="Screenshot 2024-11-08 at 3 35 57 PM" src="https://github.com/user-attachments/assets/c4f0b1ee-7868-41e2-a98b-768a68dea5ce">