### PR TITLE
Increase non-test snowflake timeout

### DIFF
--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -101,6 +101,7 @@ import { ReqContextClass } from "back-end/src/services/context";
 
 export const MAX_ROWS_UNIT_AGGREGATE_QUERY = 3000;
 export const MAX_ROWS_PAST_EXPERIMENTS_QUERY = 3000;
+export const TEST_QUERY_SQL = "SELECT 1";
 
 const N_STAR_VALUES = [
   100,
@@ -182,7 +183,7 @@ export default abstract class SqlIntegration
   }
 
   async testConnection(): Promise<boolean> {
-    await this.runQuery("select 1");
+    await this.runQuery(TEST_QUERY_SQL);
     return true;
   }
 

--- a/packages/back-end/src/services/snowflake.ts
+++ b/packages/back-end/src/services/snowflake.ts
@@ -2,6 +2,7 @@ import { createConnection } from "snowflake-sdk";
 import { SnowflakeConnectionParams } from "back-end/types/integrations/snowflake";
 import { QueryResponse } from "back-end/src/types/Integration";
 import { logger } from "back-end/src/util/logger";
+import { TEST_QUERY_SQL } from "back-end/src/integrations/SqlIntegration";
 
 type ProxyOptions = {
   proxyHost?: string;
@@ -44,11 +45,12 @@ export async function runSnowflakeQuery<T extends Record<string, any>>(
     application: "GrowthBook_GrowthBook",
     accessUrl: conn.accessUrl ? conn.accessUrl : undefined,
   });
-  // promise with timeout to prevent hanging
+  // promise with timeout to prevent hanging, esp. for test query
+  const connectionTimeout = sql === TEST_QUERY_SQL ? 30000 : 600000;
   await new Promise((resolve, reject) => {
     const promiseTimeout = setTimeout(() => {
       reject(new Error("Snowflake connection timeout"));
-    }, 30000);
+    }, connectionTimeout);
     connection.connect((err, conn) => {
       clearTimeout(promiseTimeout);
       if (err) {


### PR DESCRIPTION
Updates the manual GrowthBook snowflake timeout to only be 30s on the connection test query, and 10min otherwise.