### PR TITLE
Remove getStartedPage class in favor of Radix Separator

### DIFF
--- a/packages/front-end/components/GetStarted/GetStarted.module.scss
+++ b/packages/front-end/components/GetStarted/GetStarted.module.scss
@@ -10,12 +10,6 @@
   inherits: false;
 }
 
-.getStartedPage {
-  hr {
-    border-color: var(--border-color-100);
-  }
-}
-
 .animatedCard {
   --myColor1: var(--get-started-background-inactive);
   --myColor2: var(--get-started-background-inactive);

--- a/packages/front-end/pages/getstarted.tsx
+++ b/packages/front-end/pages/getstarted.tsx
@@ -14,6 +14,7 @@ import {
 import { IconType } from "react-icons";
 import clsx from "clsx";
 import { useRouter } from "next/router";
+import { Separator } from "@radix-ui/themes";
 import DocumentationSidebar from "@/components/GetStarted/DocumentationSidebar";
 import UpgradeModal from "@/components/Settings/UpgradeModal";
 import styles from "@/components/GetStarted/GetStarted.module.scss";
@@ -121,7 +122,7 @@ const GetStartedPage = (): React.ReactElement => {
   }, [clearStep]);
 
   return (
-    <div className={clsx(styles.getStartedPage, "container pagecontents p-4")}>
+    <div className="container pagecontents p-4">
       {upgradeModal && (
         <UpgradeModal
           close={() => setUpgradeModal(false)}
@@ -322,7 +323,7 @@ const GetStartedPage = (): React.ReactElement => {
               </Link>
             </div>
 
-            <hr />
+            <Separator size="4" my="4" />
 
             <div className="mt-4 mb-4">
               <h6 className="text-muted mb-3">PRODUCT OVERVIEW</h6>

--- a/packages/front-end/pages/getstarted/experiment-guide.tsx
+++ b/packages/front-end/pages/getstarted/experiment-guide.tsx
@@ -2,7 +2,7 @@ import { PiArrowRight, PiCheckCircleFill } from "react-icons/pi";
 import { useState, useEffect } from "react";
 import Link from "next/link";
 import { getDemoDatasourceProjectIdForOrganization } from "shared/demo-datasource";
-import clsx from "clsx";
+import { Box, Separator } from "@radix-ui/themes";
 import { useRouter } from "next/router";
 import { GeneratedHypothesisInterface } from "back-end/types/generated-hypothesis";
 import DocumentationSidebar from "@/components/GetStarted/DocumentationSidebar";
@@ -17,7 +17,6 @@ import { useDefinitions } from "@/services/DefinitionsContext";
 import { useGetStarted } from "@/services/GetStartedProvider";
 import LoadingOverlay from "@/components/LoadingOverlay";
 import ViewSampleDataButton from "@/components/GetStarted/ViewSampleDataButton";
-import styles from "@/components/GetStarted/GetStarted.module.scss";
 
 const ExperimentGuide = (): React.ReactElement => {
   const { organization } = useUser();
@@ -116,7 +115,7 @@ const ExperimentGuide = (): React.ReactElement => {
       : false;
 
   return (
-    <div className={clsx(styles.getStartedPage, "container pagecontents p-4")}>
+    <div className="container pagecontents p-4">
       <PageHead
         breadcrumb={[
           { display: "Get Started", href: "/getstarted" },
@@ -188,10 +187,8 @@ const ExperimentGuide = (): React.ReactElement => {
                 >
                   Integrate the GrowthBook SDK into your app
                 </Link>
-                <p className="mt-2">
-                  Allow GrowthBook to communicate with your app.
-                </p>
-                <hr />
+                <Box mt="2">Allow GrowthBook to communicate with your app.</Box>
+                <Separator size="4" my="4" />
               </div>
             </div>
 
@@ -298,11 +295,11 @@ const ExperimentGuide = (): React.ReactElement => {
                       ? "Design the First Experiment for this Project"
                       : "Design Your Organization’s First Experiment"}
                   </Link>
-                  <p className="mt-2">
+                  <Box mt="2">
                     Create an experiment and change variations. Choose from
                     Feature Flags, URL Redirects, or the Visual Editor (Pro).
-                  </p>
-                  <hr />
+                  </Box>
+                  <Separator size="4" my="4" />
                 </div>
               </div>
             )}
@@ -376,11 +373,11 @@ const ExperimentGuide = (): React.ReactElement => {
                       Start the Test
                     </Tooltip>
                   </Link>
-                  <p className="mt-2">
+                  <Box mt="2">
                     Define any additional settings, rules and targeting as
                     desired. Then, click “Run experiment.”
-                  </p>
-                  <hr />
+                  </Box>
+                  <Separator size="4" my="4" />
                 </div>
               </div>
             )}
@@ -429,11 +426,10 @@ const ExperimentGuide = (): React.ReactElement => {
                 >
                   Connect to Your Data Warehouse
                 </Link>
-                <p className="mt-2">
+                <Box mt="2">
                   Allow GrowthBook to query your warehouse to compute traffic
                   totals and metric results.
-                </p>
-                <hr />
+                </Box>
               </div>
             </div>
           </div>

--- a/packages/front-end/pages/getstarted/feature-flag-guide.tsx
+++ b/packages/front-end/pages/getstarted/feature-flag-guide.tsx
@@ -2,7 +2,7 @@ import { PiArrowRight, PiCheckCircleFill } from "react-icons/pi";
 import { useState, useEffect } from "react";
 import Link from "next/link";
 import { getDemoDatasourceProjectIdForOrganization } from "shared/demo-datasource";
-import clsx from "clsx";
+import { Box, Separator } from "@radix-ui/themes";
 import DocumentationSidebar from "@/components/GetStarted/DocumentationSidebar";
 import UpgradeModal from "@/components/Settings/UpgradeModal";
 import useSDKConnections from "@/hooks/useSDKConnections";
@@ -13,7 +13,6 @@ import { useDefinitions } from "@/services/DefinitionsContext";
 import { useGetStarted } from "@/services/GetStartedProvider";
 import LoadingOverlay from "@/components/LoadingOverlay";
 import ViewSampleDataButton from "@/components/GetStarted/ViewSampleDataButton";
-import styles from "@/components/GetStarted/GetStarted.module.scss";
 
 const CreateFeatureFlagsGuide = (): React.ReactElement => {
   const { organization } = useUser();
@@ -51,7 +50,7 @@ const CreateFeatureFlagsGuide = (): React.ReactElement => {
     : features.some((f) => f.project !== demoProjectId);
 
   return (
-    <div className={clsx(styles.getStartedPage, "container pagecontents p-4")}>
+    <div className="container pagecontents p-4">
       <PageHead
         breadcrumb={[
           { display: "Get Started", href: "/getstarted" },
@@ -122,10 +121,8 @@ const CreateFeatureFlagsGuide = (): React.ReactElement => {
                 >
                   Integrate the GrowthBook SDK into your app
                 </Link>
-                <p className="mt-2">
-                  Allow GrowthBook to communicate with your app.
-                </p>
-                <hr />
+                <Box mt="2">Allow GrowthBook to communicate with your app.</Box>
+                <Separator size="4" my="4" />
               </div>
             </div>
 
@@ -174,9 +171,9 @@ const CreateFeatureFlagsGuide = (): React.ReactElement => {
                 >
                   Create a Test Feature Flag{project && " in this Project"}
                 </Link>
-                <p className="mt-2">
+                <Box mt="2">
                   Add your first feature flag to test your setup.
-                </p>
+                </Box>
               </div>
             </div>
           </div>

--- a/packages/front-end/pages/getstarted/imported-experiment-guide.tsx
+++ b/packages/front-end/pages/getstarted/imported-experiment-guide.tsx
@@ -2,7 +2,7 @@ import { PiArrowRight, PiCheckCircleFill } from "react-icons/pi";
 import { useState, useEffect } from "react";
 import Link from "next/link";
 import { getDemoDatasourceProjectIdForOrganization } from "shared/demo-datasource";
-import clsx from "clsx";
+import { Box, Separator } from "@radix-ui/themes";
 import DocumentationSidebar from "@/components/GetStarted/DocumentationSidebar";
 import UpgradeModal from "@/components/Settings/UpgradeModal";
 import { useUser } from "@/services/UserContext";
@@ -10,7 +10,6 @@ import PageHead from "@/components/Layout/PageHead";
 import { useExperiments } from "@/hooks/useExperiments";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import LoadingOverlay from "@/components/LoadingOverlay";
-import styles from "@/components/GetStarted/GetStarted.module.scss";
 import { useGetStarted } from "@/services/GetStartedProvider";
 
 const ImportedExperimentGuide = (): React.ReactElement => {
@@ -58,7 +57,7 @@ const ImportedExperimentGuide = (): React.ReactElement => {
   );
 
   return (
-    <div className={clsx(styles.getStartedPage, "container pagecontents p-4")}>
+    <div className="container pagecontents p-4">
       <PageHead
         breadcrumb={[
           { display: "Get Started", href: "/getstarted" },
@@ -126,11 +125,11 @@ const ImportedExperimentGuide = (): React.ReactElement => {
                 >
                   Connect to Your Data Warehouse
                 </Link>
-                <p className="mt-2">
+                <Box mt="2">
                   Allow GrowthBook to query your warehouse to compute traffic
                   totals and metric results.
-                </p>
-                <hr />
+                </Box>
+                <Separator size="4" my="4" />
               </div>
             </div>
 
@@ -178,11 +177,11 @@ const ImportedExperimentGuide = (): React.ReactElement => {
                 >
                   Define Fact Tables and Metrics
                 </Link>
-                <p className="mt-2">
+                <Box mt="2">
                   Define fact tables for the main events in your data warehouse
                   and build metrics based on those events.
-                </p>
-                <hr />
+                </Box>
+                <Separator size="4" my="4" />
               </div>
             </div>
 
@@ -233,10 +232,10 @@ const ImportedExperimentGuide = (): React.ReactElement => {
                   Import Your First Experiment{project && " in this Project"} &
                   View Results
                 </Link>
-                <p className="mt-2">
+                <Box mt="2">
                   Navigate to Experiments {">"} Add Experiment. In the popup,
                   select “Analyze an Existing Experiment”
-                </p>
+                </Box>
               </div>
             </div>
           </div>


### PR DESCRIPTION
### Features and Changes

Small clean up in preparation for bigger changes in the Get Started page.
- Removed custom css class that customized `hr`
  - Using `Separator` now
  - Updated some `p` tags to `Box` to remove the default browser margin.
