### PR TITLE
Tune DatePicker for mobile and safari

### DIFF
--- a/packages/front-end/components/DatePicker/index.tsx
+++ b/packages/front-end/components/DatePicker/index.tsx
@@ -17,7 +17,7 @@ type Props = {
   label?: ReactNode;
   label2?: ReactNode;
   helpText?: ReactNode;
-  inputWidth?: number | string;
+  inputWidth?: number;
   precision?: "datetime" | "date";
   disableBefore?: Date | string;
   disableAfter?: Date | string;
@@ -43,7 +43,7 @@ export default function DatePicker({
   label,
   label2,
   helpText,
-  inputWidth = "100%",
+  inputWidth,
   precision = "datetime",
   disableBefore,
   disableAfter,
@@ -125,12 +125,16 @@ export default function DatePicker({
         }}
       >
         <Popover.Trigger asChild>
-          <Flex gap="1rem">
-            <div style={{ width: inputWidth, minHeight: 38 }}>
+          <Flex gap="1rem" display={inputWidth ? "inline-flex" : "flex"}>
+            <div style={{ width: inputWidth || "100%", minHeight: 38 }}>
               {label ? <label>{label}</label> : null}
               <div
                 className="form-control p-0"
-                style={{ width: inputWidth, minHeight: 38, overflow: "clip" }}
+                style={{
+                  width: inputWidth || "100%",
+                  minHeight: 38,
+                  overflow: "clip",
+                }}
               >
                 <Field
                   style={{
@@ -139,10 +143,8 @@ export default function DatePicker({
                     width: "calc(100% + 30px)",
                     minHeight: 38,
                     cursor: "pointer",
-                    fontFamily: "var(--font-family-sans-serif)",
-                    textAlign: "left",
                   }}
-                  className={clsx({ "text-muted": !date })}
+                  className={clsx("date-picker-field", { "text-muted": !date })}
                   type={precision === "datetime" ? "datetime-local" : "date"}
                   value={
                     date
@@ -173,7 +175,7 @@ export default function DatePicker({
               </div>
             </div>
             {isRange && (
-              <div style={{ width: inputWidth, minHeight: 38 }}>
+              <div style={{ width: inputWidth || "100%", minHeight: 38 }}>
                 {label2 ? <label>{label2}</label> : null}
                 <div
                   className="form-control p-0"
@@ -186,10 +188,10 @@ export default function DatePicker({
                       width: "calc(100% + 30px)",
                       minHeight: 38,
                       cursor: "pointer",
-                      fontFamily: "var(--font-family-sans-serif)",
-                      textAlign: "left",
                     }}
-                    className={clsx({ "text-muted": !date2 })}
+                    className={clsx("date-picker-field", {
+                      "text-muted": !date2,
+                    })}
                     type={precision === "datetime" ? "datetime-local" : "date"}
                     value={
                       date2

--- a/packages/front-end/components/DatePicker/index.tsx
+++ b/packages/front-end/components/DatePicker/index.tsx
@@ -119,8 +119,8 @@ export default function DatePicker({
           }
           if (!o && +new Date() - +fieldClickedTime.current > 10) {
             setOpen(false);
-            setOriginalDate(date);
-            setOriginalDate2(date2);
+            setOriginalDate(getValidDate(date));
+            setOriginalDate2(getValidDate(date2));
           }
         }}
       >

--- a/packages/front-end/package.json
+++ b/packages/front-end/package.json
@@ -65,7 +65,7 @@
     "react-beautiful-dnd": "^13.1.0",
     "react-collapsible": "^2.10.0",
     "react-colorful": "^5.3.0",
-    "react-day-picker": "^9.3.0",
+    "react-day-picker": "^9.3.1",
     "react-diff-viewer": "^3.1.1",
     "react-dom": "^18.2.0",
     "react-dropzone": "^11.3.2",

--- a/packages/front-end/pages/design-system/index.tsx
+++ b/packages/front-end/pages/design-system/index.tsx
@@ -188,13 +188,22 @@ export default function DesignSystemPage() {
         <h3>Date Picker</h3>
         <Flex direction="column" gap="3">
           <DatePicker
+            label="Choose Date"
+            helpText="width: 170"
             date={date1}
             setDate={setDate1}
             precision="datetime"
             disableBefore={new Date()}
-            inputWidth={150}
+            inputWidth={170}
           />
-          <hr />
+
+          <DatePicker
+            helpText="width: default (100%)"
+            date={date1}
+            setDate={setDate1}
+            precision="datetime"
+            disableBefore={new Date()}
+          />
 
           <DatePicker
             date={date1}

--- a/packages/front-end/styles/global-radix-overrides.scss
+++ b/packages/front-end/styles/global-radix-overrides.scss
@@ -162,6 +162,21 @@
     min-height: 234px;
   }
 }
+// Safari web
+@supports (font: -apple-system-body) and (-webkit-appearance: none) {
+  .date-picker-field {
+    padding-left: 8px;
+    font-family: "Arial", sans-serif;
+  }
+}
+// Mobile-like devices
+@media screen and (hover: none) and (pointer: coarse) {
+  .date-picker-field {
+    width: 100% !important;
+    margin-right: 0 !important;
+    pointer-events: none;
+  }
+}
 
 // Radio
 .rt-RadioGroupItem {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3347,7 +3347,7 @@
     uuid "^9.0.0"
     winston "^3.8.2"
 
-"@date-fns/tz@^1.1.2":
+"@date-fns/tz@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@date-fns/tz/-/tz-1.2.0.tgz#81cb3211693830babaf3b96aff51607e143030a6"
   integrity sha512-LBrd7MiJZ9McsOgxqWX7AaxrDjcFVjWH/tIKJd7pnR7McaslGYOP1QmmiBXdJH/H/yLCT+rcQ7FaPBUxRGUtrg==
@@ -18405,12 +18405,12 @@ react-colorful@^5.3.0:
   resolved "https://registry.npmjs.org/react-colorful/-/react-colorful-5.5.1.tgz"
   integrity sha512-M1TJH2X3RXEt12sWkpa6hLc/bbYS0H6F4rIqjQZ+RxNBstpY67d9TrFXtqdZwhpmBXcCwEi7stKqFue3ZRkiOg==
 
-react-day-picker@^9.3.0:
-  version "9.3.0"
-  resolved "https://registry.yarnpkg.com/react-day-picker/-/react-day-picker-9.3.0.tgz#00e979a495d98ce8886bb3625c51133ba5c2acc8"
-  integrity sha512-xXgZISTXlwQ1Igt4cBttXF+aK1Xvd00azcGVY74PNCAe8PxtULFVWGT1UfdavFiVScF04dyV8QcybKZAw570QQ==
+react-day-picker@^9.3.1:
+  version "9.3.1"
+  resolved "https://registry.yarnpkg.com/react-day-picker/-/react-day-picker-9.3.1.tgz#9a396076730642f8f0f2c929caaaeef1b6d7b3a6"
+  integrity sha512-cljrZdUy5EHe+iwOPuyp9nsCqHUZwFZRkM0XrOOPMaXjdNR2An+4NyJxgT3Ruxy8zBbU8Cz5u8XoDCCIZFvVrw==
   dependencies:
-    "@date-fns/tz" "^1.1.2"
+    "@date-fns/tz" "^1.2.0"
     date-fns "^4.1.0"
 
 react-diff-viewer@^3.1.1:


### PR DESCRIPTION
- fix some flex / click area issues
- input field style overrides for safari (desktop) and mobile devices
- prevent native calendar for safari (desktop)