### PR TITLE
Wrapping of feature values to support long json objects

### DIFF
--- a/packages/front-end/components/SyntaxHighlighting/InlineCode.tsx
+++ b/packages/front-end/components/SyntaxHighlighting/InlineCode.tsx
@@ -28,6 +28,9 @@ export default function InlineCode({ code, language, className }: Props) {
   style['code[class*="language-"]'].fontSize = "0.85rem";
   style['code[class*="language-"]'].lineHeight = 1.5;
   style['code[class*="language-"]'].fontWeight = 600;
+  // this next line actually doesn't do anything- its overridden somewhere in Prism.
+  style['code[class*="language-"]'].whiteSpace = "pre-wrap";
+  style['pre[class*="language-"]'].whiteSpace = "pre-wrap";
 
   return (
     <Suspense
@@ -43,7 +46,7 @@ export default function InlineCode({ code, language, className }: Props) {
       <Prism
         language={language}
         style={style}
-        className={clsx("border-0 p-0 m-0 bg-transparent", className)}
+        className={clsx("border-0 p-0 m-0 bg-transparent wrap-code", className)}
         showLineNumbers={false}
       >
         {code}

--- a/packages/front-end/styles/global.scss
+++ b/packages/front-end/styles/global.scss
@@ -45,6 +45,10 @@ body {
   white-space: nowrap;
   text-overflow: ellipsis;
 }
+.wrap-code,
+.wrap-code code {
+  white-space: pre-wrap !important;
+}
 
 #block-menu-container {
   z-index: 990;


### PR DESCRIPTION
Adds wrapping for JSON feature values. 
Fixes #3307

<img width="1304" alt="Screenshot 2024-11-16 at 2 29 48 AM" src="https://github.com/user-attachments/assets/e255c769-c33e-4376-a6e2-be720c85ffe3">
