### PR TITLE
Add button on superadmin page to create an inbuilt clickhouse datasource

### DIFF
--- a/packages/back-end/src/controllers/admin.ts
+++ b/packages/back-end/src/controllers/admin.ts
@@ -18,6 +18,7 @@ import {
 import { getOrganizationById } from "back-end/src/services/organizations";
 import { setLicenseKey } from "back-end/src/routers/organizations/organizations.controller";
 import { auditDetailsUpdate } from "back-end/src/services/audit";
+import { _dangerourslyGetAllDatasourcesByOrganizations } from "back-end/src/models/DataSourceModel";
 
 export async function getOrganizations(
   req: AuthRequest<never, never, { page?: string; search?: string }>,
@@ -47,10 +48,17 @@ export async function getOrganizations(
     };
   });
 
+  const orgIds = organizations.map((o) => o.id);
+
+  const datasources = await _dangerourslyGetAllDatasourcesByOrganizations(
+    orgIds
+  );
+
   return res.status(200).json({
     status: 200,
     organizations,
     ssoConnections,
+    datasources,
     total,
   });
 }

--- a/packages/back-end/src/controllers/datasources.ts
+++ b/packages/back-end/src/controllers/datasources.ts
@@ -266,6 +266,13 @@ export async function postInbuiltDataSource(
       }
   >
 ) {
+  if (!req.superAdmin) {
+    return res.status(403).json({
+      status: 403,
+      message: "Only super admins can add a datasource for now.",
+    });
+  }
+
   const context = getContextFromReq(req);
   const new_datasource_id = req.params.id || uniqid("ds_");
   const params = await createClickhouseUser(context, new_datasource_id);

--- a/packages/back-end/src/models/DataSourceModel.ts
+++ b/packages/back-end/src/models/DataSourceModel.ts
@@ -90,6 +90,22 @@ export async function getDataSourcesByOrganization(
     context.permissions.canReadMultiProjectResource(ds.projects)
   );
 }
+
+// WARNING: This does not restrict by organization
+export async function _dangerourslyGetAllDatasourcesByOrganizations(
+  organizations: string[]
+): Promise<DataSourceInterface[]> {
+  if (usingFileConfig()) {
+    return getConfigDatasources(organizations[0]);
+  }
+
+  const docs: DataSourceDocument[] = await DataSourceModel.find({
+    organization: { $in: organizations },
+  });
+
+  return docs.map(toInterface);
+}
+
 // WARNING: This does not restrict by organization
 export async function _dangerousGetAllGrowthbookClickhouseDataSources() {
   const docs: DataSourceDocument[] = await DataSourceModel.find({

--- a/packages/back-end/src/models/DataSourceModel.ts
+++ b/packages/back-end/src/models/DataSourceModel.ts
@@ -95,10 +95,6 @@ export async function getDataSourcesByOrganization(
 export async function _dangerourslyGetAllDatasourcesByOrganizations(
   organizations: string[]
 ): Promise<DataSourceInterface[]> {
-  if (usingFileConfig()) {
-    return getConfigDatasources(organizations[0]);
-  }
-
   const docs: DataSourceDocument[] = await DataSourceModel.find({
     organization: { $in: organizations },
   });

--- a/packages/back-end/src/services/clickhouse.ts
+++ b/packages/back-end/src/services/clickhouse.ts
@@ -52,13 +52,6 @@ export async function createClickhouseUser(
   context: ReqContext,
   datasourceId: string
 ): Promise<DataSourceParams> {
-  // Temporary protection to prevent users from manually changing feature flag to create Clickhouse users.
-  if (ENVIRONMENT === "production" && context.org.id != "org_24yyifrkf649iz6") {
-    throw new Error(
-      "Clickhouse user creation is only allowed for the Growthbook organization"
-    );
-  }
-
   const client = createAdminClickhouseClient();
 
   const orgId = context.org.id;

--- a/packages/front-end/pages/admin.tsx
+++ b/packages/front-end/pages/admin.tsx
@@ -207,35 +207,37 @@ function OrganizationRow({
             <FaPencilAlt />
           </a>
         </td>
-        <td className="p-0 text-center">
-          <Tooltip
-            body={
-              hasGrowthbookClickhouse
-                ? "Already has an Inbuilt Growthbook Datasource"
-                : "Create Inbuilt Growthbook Clickhouse DataSource"
-            }
-          >
-            <a
-              href="#"
-              className={clsx("d-block w-100 h-100", {
-                "text-muted": hasGrowthbookClickhouse,
-              })}
-              onClick={(e) => {
-                e.preventDefault();
-                if (!hasGrowthbookClickhouse) {
-                  setClickhouseModalOpen(true);
-                }
-              }}
-              style={{
-                lineHeight: "40px",
-                pointerEvents: hasGrowthbookClickhouse ? "none" : "auto",
-              }}
-              title={"Create Clickhouse Data Source"}
+        {isCloud() && (
+          <td className="p-0 text-center">
+            <Tooltip
+              body={
+                hasGrowthbookClickhouse
+                  ? "Already has an Inbuilt Growthbook Datasource"
+                  : "Create Inbuilt Growthbook Clickhouse DataSource"
+              }
             >
-              <FaDatabase />
-            </a>
-          </Tooltip>
-        </td>
+              <a
+                href="#"
+                className={clsx("d-block w-100 h-100", {
+                  "text-muted": hasGrowthbookClickhouse,
+                })}
+                onClick={(e) => {
+                  e.preventDefault();
+                  if (!hasGrowthbookClickhouse) {
+                    setClickhouseModalOpen(true);
+                  }
+                }}
+                style={{
+                  lineHeight: "40px",
+                  pointerEvents: hasGrowthbookClickhouse ? "none" : "auto",
+                }}
+                title={"Create Clickhouse Data Source"}
+              >
+                <FaDatabase />
+              </a>
+            </Tooltip>
+          </td>
+        )}
         <td style={{ width: 40 }} className="p-0 text-center">
           <a
             href="#"
@@ -252,7 +254,7 @@ function OrganizationRow({
       </tr>
       {expanded && (
         <tr>
-          <td colSpan={9} className="bg-light">
+          <td colSpan={isCloud() ? 9 : 8} className="bg-light">
             <h3>Summary</h3>
             <div
               className="mb-3 bg-white border p-3"
@@ -503,7 +505,7 @@ function MemberRow({
       </tr>
       {expanded && (
         <tr>
-          <td colSpan={9} className="bg-light">
+          <td colSpan={isCloud() ? 9 : 8} className="bg-light">
             <div className="mb-3">
               <h4>Organization Info</h4>
               <div className="row">
@@ -733,7 +735,7 @@ const Admin: FC = () => {
                   {!isCloud() && <th>External Id</th>}
                   <th style={{ width: "120px" }}>Members</th>
                   <th style={{ width: "14px" }}></th>
-                  <th style={{ width: "14px" }}></th>
+                  {isCloud() && <th style={{ width: "14px" }}></th>}
                   <th style={{ width: "40px" }}></th>
                 </tr>
               </thead>

--- a/packages/front-end/pages/admin.tsx
+++ b/packages/front-end/pages/admin.tsx
@@ -11,11 +11,13 @@ import {
   FaPlus,
   FaSearch,
   FaSpinner,
+  FaDatabase,
 } from "react-icons/fa";
 import { date } from "shared/dates";
 import stringify from "json-stringify-pretty-compact";
 import Collapsible from "react-collapsible";
 import { LicenseInterface } from "enterprise";
+import { DataSourceInterface } from "back-end/types/datasource";
 import Field from "@/components/Forms/Field";
 import Pagination from "@/components/Pagination";
 import { useUser } from "@/services/UserContext";
@@ -32,6 +34,7 @@ import Tab from "@/components/Tabs/Tab";
 import Modal from "@/components/Modal";
 import Toggle from "@/components/Forms/Toggle";
 import LoadingSpinner from "@/components/LoadingSpinner";
+import Tooltip from "@/components/Tooltip/Tooltip";
 
 interface memberOrgProps {
   id: string;
@@ -54,6 +57,7 @@ function OrganizationRow({
   showVerfiedDomain,
   onEdit,
   ssoInfo,
+  datasources,
 }: {
   organization: OrganizationInterface;
   switchTo: (organization: OrganizationInterface) => void;
@@ -62,6 +66,7 @@ function OrganizationRow({
   showVerfiedDomain: boolean;
   onEdit: () => void;
   ssoInfo: ssoInfoProps | undefined;
+  datasources: DataSourceInterface[];
 }) {
   const [expanded, setExpanded] = useState(false);
   const [editOrgModalOpen, setEditOrgModalOpen] = useState(false);
@@ -73,6 +78,10 @@ function OrganizationRow({
   const [license, setLicense] = useState<LicenseInterface | null>(null);
   const [licenseLoading, setLicenseLoading] = useState(false);
   const { apiCall } = useAuth();
+  const [clickhouseModalOpen, setClickhouseModalOpen] = useState(false);
+  const [hasGrowthbookClickhouse, setHasGrowthbookClickhouse] = useState(
+    datasources.find((ds) => ds.type === "growthbook_clickhouse") ? true : false
+  );
 
   useEffect(() => {
     if (isCloud() && expanded && !license) {
@@ -118,6 +127,15 @@ function OrganizationRow({
     }
   }, [expanded, apiCall, orgMembers, organization]);
 
+  const createClickhouseDatasource = async () => {
+    await apiCall(`/datasource/create-inbuilt`, {
+      method: "POST",
+      headers: { "X-Organization": organization.id },
+    });
+    setClickhouseModalOpen(false);
+    setHasGrowthbookClickhouse(true);
+  };
+
   return (
     <>
       {editOrgModalOpen && (
@@ -128,6 +146,19 @@ function OrganizationRow({
           onEdit={onEdit}
           close={() => setEditOrgModalOpen(false)}
         />
+      )}
+      {clickhouseModalOpen && (
+        <Modal
+          open={true}
+          header="Create Clickhouse Data Source"
+          close={() => setClickhouseModalOpen(false)}
+          submit={createClickhouseDatasource}
+          cta="Yes"
+          trackingEventModalType=""
+        >
+          Are you sure you want to create an inbuilt Clickhouse data source for
+          this organization?
+        </Modal>
       )}
       <tr
         className={clsx({
@@ -176,6 +207,35 @@ function OrganizationRow({
             <FaPencilAlt />
           </a>
         </td>
+        <td className="p-0 text-center">
+          <Tooltip
+            body={
+              hasGrowthbookClickhouse
+                ? "Already has an Inbuilt Growthbook Datasource"
+                : "Create Inbuilt Growthbook Clickhouse DataSource"
+            }
+          >
+            <a
+              href="#"
+              className={clsx("d-block w-100 h-100", {
+                "text-muted": hasGrowthbookClickhouse,
+              })}
+              onClick={(e) => {
+                e.preventDefault();
+                if (!hasGrowthbookClickhouse) {
+                  setClickhouseModalOpen(true);
+                }
+              }}
+              style={{
+                lineHeight: "40px",
+                pointerEvents: hasGrowthbookClickhouse ? "none" : "auto",
+              }}
+              title={"Create Clickhouse Data Source"}
+            >
+              <FaDatabase />
+            </a>
+          </Tooltip>
+        </td>
         <td style={{ width: 40 }} className="p-0 text-center">
           <a
             href="#"
@@ -192,7 +252,7 @@ function OrganizationRow({
       </tr>
       {expanded && (
         <tr>
-          <td colSpan={8} className="bg-light">
+          <td colSpan={9} className="bg-light">
             <h3>Summary</h3>
             <div
               className="mb-3 bg-white border p-3"
@@ -443,7 +503,7 @@ function MemberRow({
       </tr>
       {expanded && (
         <tr>
-          <td colSpan={8} className="bg-light">
+          <td colSpan={9} className="bg-light">
             <div className="mb-3">
               <h4>Organization Info</h4>
               <div className="row">
@@ -492,6 +552,7 @@ const Admin: FC = () => {
   const { license, superAdmin } = useUser();
   const [orgs, setOrgs] = useState<OrganizationInterface[]>([]);
   const [ssoConnections, setSsoConnections] = useState<ssoInfoProps[]>([]);
+  const [datasources, setDatasources] = useState<DataSourceInterface[]>([]);
   const [total, setTotal] = useState(0);
   const [members, setMembers] = useState<ExpandedMember[]>([]);
   const [memberOrgs, setMemberOrgs] = useState<{
@@ -515,11 +576,13 @@ const Admin: FC = () => {
         const res = await apiCall<{
           organizations: OrganizationInterface[];
           ssoConnections: ssoInfoProps[];
+          datasources: DataSourceInterface[];
           total: number;
         }>(`/admin/organizations?${params.toString()}`);
         setOrgs(res.organizations);
         setTotal(res.total);
         setSsoConnections(res.ssoConnections);
+        setDatasources(res.datasources);
         setError("");
       } catch (e) {
         setError(e.message);
@@ -670,6 +733,7 @@ const Admin: FC = () => {
                   {!isCloud() && <th>External Id</th>}
                   <th style={{ width: "120px" }}>Members</th>
                   <th style={{ width: "14px" }}></th>
+                  <th style={{ width: "14px" }}></th>
                   <th style={{ width: "40px" }}></th>
                 </tr>
               </thead>
@@ -679,6 +743,9 @@ const Admin: FC = () => {
                     organization={o}
                     ssoInfo={ssoConnections.find(
                       (sso) => sso.organization === o.id
+                    )}
+                    datasources={datasources.filter(
+                      (ds) => ds.organization === o.id
                     )}
                     showExternalId={!isCloud()}
                     showVerfiedDomain={isCloud()}


### PR DESCRIPTION
### Features and Changes

- Adds button to create the clickhouse warehouse
- Adds tooltip
- Adds modal to ask if they are sure
- Got rid of check to make sure that it is only the main growthbook org on prod.
- Makes a superadmin check for adding the clickhouse warehouse

### Dependencies

- Might want to land fact table creation before using this.

### Testing

- Set `IS_CLOUD=true` and `SSO_CONFIG` in .env.local.
- Start server
- Go to /admin
- See the DB icons.
- Hover over one and see the tooltip message
- Click on the button and see the modal
- Click on Create
- See the button is grayed out
- Hover over and see the tooltip message

### Screenshots

<img width="627" alt="Screenshot 2024-11-18 at 7 21 47 PM" src="https://github.com/user-attachments/assets/043a60e3-cb37-453a-82a7-73798fe25254">
<img width="411" alt="Screenshot 2024-11-18 at 7 21 36 PM" src="https://github.com/user-attachments/assets/08bcb132-0193-410e-9312-b5452a418ebb">

