### PR TITLE
docs: Small formatting fix

### DIFF
--- a/docs/docs/statistics/power.mdx
+++ b/docs/docs/statistics/power.mdx
@@ -22,7 +22,7 @@ You should run power analysis before your experiment starts, to determine how lo
 
 ## What is a minimum detectable effect, and how do I interpret it?
 
-Recall that your relative effect size (which we often refer to as simply the effect size), is the percentage improvement in your metric caused by your feature. For example, suppose that average revenue per customer under control is \$100, while under treatment you expect that it will be $102. This corresponds to a ($102-$100)/$100 = 2% effect size. Effect size is often referred to as lift.
+Recall that your relative effect size (which we often refer to as simply the effect size), is the percentage improvement in your metric caused by your feature. For example, suppose that average revenue per customer under control is \$100, while under treatment you expect that it will be \$102. This corresponds to a (\$102-\$100)/\$100 = 2% effect size. Effect size is often referred to as lift.
 
 Given the sample variance of your metric and the sample size, the minimum detectable effect (MDE) is the smallest effect size for which your power will be at least 80%.
 


### PR DESCRIPTION
### Features and Changes

Fix formatting in the Power Calculator docs by escaping $.

See second to last line in the screenshot below:

| Before | After |
|--------|--------|
| <img width="695" alt="Screenshot 2024-11-18 at 11 31 53 AM" src="https://github.com/user-attachments/assets/c583e8a6-f759-435d-9a22-599cf50e8419"> | <img width="694" alt="Screenshot 2024-11-18 at 11 31 48 AM" src="https://github.com/user-attachments/assets/468770ee-c13e-4b00-a57b-5313481639af"> | 