### PR TITLE
Fixes Premium ToolTip misalignment

### DIFF
--- a/packages/front-end/components/Features/FeaturesStats.tsx
+++ b/packages/front-end/components/Features/FeaturesStats.tsx
@@ -63,8 +63,11 @@ export default function FeaturesStats({
               alignItems: "center",
             }}
           >
-            <PremiumTooltip commercialFeature="code-references">
-              <span className="h2">Enable Code References</span>
+            <PremiumTooltip
+              commercialFeature="code-references"
+              className="mb-2"
+            >
+              <h2 className="m-0 ml-1">Enable Code References</h2>
             </PremiumTooltip>
             <p style={{ width: "32rem" }}>
               Quickly see instances of feature flags being leveraged in your

--- a/packages/front-end/components/GeneralSettings/ExperimentSettings/index.tsx
+++ b/packages/front-end/components/GeneralSettings/ExperimentSettings/index.tsx
@@ -286,14 +286,12 @@ export default function ExperimentSettings({
             </div>
           </div>
 
-          <div className="mb-3 form-group flex-column align-items-start">
+          <div className="mb-3 mt-4 form-group flex-column align-items-start">
             <PremiumTooltip
               commercialFeature="custom-launch-checklist"
               premiumText="Custom pre-launch checklists are available to Enterprise customers"
             >
-              <div className="d-inline-block h4 mt-4 mb-0">
-                Experiment Pre-Launch Checklist
-              </div>
+              <h4 className="m-0">Experiment Pre-Launch Checklist</h4>
             </PremiumTooltip>
             <p className="pt-2">
               Configure required steps that need to be completed before an

--- a/packages/front-end/components/GeneralSettings/FeaturesSettings.tsx
+++ b/packages/front-end/components/GeneralSettings/FeaturesSettings.tsx
@@ -236,14 +236,11 @@ export default function FeaturesSettings() {
             ))}
           </>
         )}
-        <div className="my-3">
+        <div className="my-3 pt-4">
           <PremiumTooltip commercialFeature="code-references">
-            <div
-              className="d-inline-block h4 mt-4 mb-0"
-              id="configure-code-refs"
-            >
+            <h4 className="mb-0" id="configure-code-refs">
               Configure Code References
-            </div>
+            </h4>
           </PremiumTooltip>
           <div>
             <label className="mr-1" htmlFor="toggle-codeReferences">

--- a/packages/front-end/components/Marketing/PremiumTooltip.tsx
+++ b/packages/front-end/components/Marketing/PremiumTooltip.tsx
@@ -66,14 +66,16 @@ export default function PremiumTooltip({
       trackingEventTooltipSource={commercialFeature}
       {...otherProps}
     >
-      {!hasFeature && (
-        <GBPremiumBadge
-          className="text-premium"
-          shouldDisplay={!hasFeature}
-          prependsText={true}
-        />
-      )}
-      {children}
+      <div className="d-flex align-items-center">
+        {!hasFeature && (
+          <GBPremiumBadge
+            className="text-premium"
+            shouldDisplay={!hasFeature}
+            prependsText={true}
+          />
+        )}
+        {children}
+      </div>
     </Tooltip>
   );
 }


### PR DESCRIPTION
### Features and Changes

This PR fixes the alignment issue with the `PremiumTooltip` component, specifically  at the `/bandits` route.

Previously, the `PremiumToolTip` component didn't explicitly align the `GBPremiumBadge` and it's children. Now, we'll always explicitly align these components.

In making this change, there were a few areas of the application that needed some attention, namely the `General Settings` page, and the section in the app where users could enable the code references. In these cases, we were passing in `h4` elements that with Bootstrap inherit some margin - as a result of this margin, there was an undesired offset. This has been addressed in this PR.

As always, there are 100 different ways to remedy this issue. If there is a better way utilizing our newly adopted Radix library that I may've missed during my leave, please let me know.

### Dependencies

n/a

### Testing

- [x] Ensure the `Add Bandit` CTAs on the `/bandits` route empty state are aligned correctly
- [x] Ensure that all other uses of the `PremiumToolTip` are aligned correctly

### Screenshots

Before
<img width="1508" alt="Screenshot 2024-11-18 at 2 51 25 PM" src="https://github.com/user-attachments/assets/594e5329-d4ae-4965-9c4b-20450d553870">

After
<img width="1164" alt="Screenshot 2024-11-18 at 3 41 53 PM" src="https://github.com/user-attachments/assets/da43fbe0-6150-49db-95fe-3dc450cc4e20">
