### PR TITLE
fix experiment variation editor / variations.length mismatch

### DIFF
--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -777,6 +777,7 @@ export async function postExperiment(
       currentPhase?: number;
       phaseStartDate?: string;
       phaseEndDate?: string;
+      variationWeights?: number[];
     },
     { id: string }
   >,
@@ -1009,6 +1010,16 @@ export async function postExperiment(
         ...changes,
       } as ExperimentInterface);
     }
+  }
+
+  if (data.variationWeights) {
+    const phases = [...experiment.phases];
+    const lastIndex = phases.length - 1;
+    phases[lastIndex] = {
+      ...phases[lastIndex],
+      variationWeights: data.variationWeights,
+    };
+    changes.phases = phases;
   }
 
   // Only some fields affect production SDK payloads

--- a/packages/front-end/components/Experiment/EditTargetingModal.tsx
+++ b/packages/front-end/components/Experiment/EditTargetingModal.tsx
@@ -577,7 +577,7 @@ function TargetingForm({
               ? "Variation Weights"
               : "Traffic Percentage & Variation Weights"
           }
-          customSplitOn={true}
+          startEditingSplits={true}
         />
       )}
     </div>

--- a/packages/front-end/components/Experiment/EditVariationsForm.tsx
+++ b/packages/front-end/components/Experiment/EditVariationsForm.tsx
@@ -9,6 +9,7 @@ import { useAuth } from "@/services/auth";
 import Modal from "@/components/Modal";
 import track from "@/services/track";
 import FeatureVariationsInput from "@/components/Features/FeatureVariationsInput";
+import { distributeWeights } from "@/services/utils";
 
 const EditVariationsForm: FC<{
   experiment: ExperimentInterfaceStringDates;
@@ -47,6 +48,16 @@ const EditVariationsForm: FC<{
       submit={form.handleSubmit(async (value) => {
         const data = { ...value };
         data.variations = [...data.variations];
+
+        // fix some common bugs
+        const newWeights = [
+          ...data.variations.map(
+            (_, i) =>
+              data.variationWeights?.[i] || data.variations.length || 0.5
+          ),
+        ];
+        const newWeightsFixed = distributeWeights(newWeights, true);
+        data.variationWeights = newWeightsFixed;
 
         await apiCall(`/experiment/${experiment.id}`, {
           method: "POST",

--- a/packages/front-end/components/Experiment/EditVariationsForm.tsx
+++ b/packages/front-end/components/Experiment/EditVariationsForm.tsx
@@ -51,9 +51,14 @@ const EditVariationsForm: FC<{
 
         // fix some common bugs
         const newWeights = [
-          ...data.variations.map(
-            (_, i) =>
-              data.variationWeights?.[i] || data.variations.length || 0.5
+          ...data.variations.map((_, i) =>
+            Math.min(
+              Math.max(
+                data.variationWeights?.[i] ?? 1 / data.variations.length ?? 0.5,
+                0
+              ),
+              1
+            )
           ),
         ];
         const newWeightsFixed = distributeWeights(newWeights, true);

--- a/packages/front-end/components/Experiment/EditVariationsForm.tsx
+++ b/packages/front-end/components/Experiment/EditVariationsForm.tsx
@@ -34,6 +34,8 @@ const EditVariationsForm: FC<{
   });
   const { apiCall } = useAuth();
 
+  const isBandit = experiment.type === "multi-armed-bandit";
+
   return (
     <Modal
       trackingEventModalType="edit-variations-form"
@@ -60,7 +62,8 @@ const EditVariationsForm: FC<{
         setWeight={(i, weight) => {
           form.setValue(`variationWeights.${i}`, weight);
         }}
-        // hideValueField
+        valueAsId={isBandit}
+        hideSplits={isBandit}
         showDescriptions
         variations={
           form.watch("variations")?.map((v, i) => {
@@ -68,7 +71,7 @@ const EditVariationsForm: FC<{
               value: v.key || "",
               name: v.name,
               description: v.description,
-              weight: form.watch(`variationWeights.${i}`), // todo: use current phase
+              weight: form.watch(`variationWeights.${i}`),
               id: v.id,
             };
           }) ?? []

--- a/packages/front-end/components/Experiment/NewExperimentForm.tsx
+++ b/packages/front-end/components/Experiment/NewExperimentForm.tsx
@@ -630,6 +630,8 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
                         v.map((v) => v.weight)
                       );
                     }}
+                    variationValuesAsIds={true}
+                    hideVariationIds={!isImport}
                     orgStickyBucketing={orgStickyBucketing}
                   />
                 </Page>
@@ -818,7 +820,8 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
                 setWeight={(i, weight) =>
                   form.setValue(`phases.0.variationWeights.${i}`, weight)
                 }
-                valueAsId={true}
+                valueAsId={false}
+                startEditingIndexes={true}
                 variations={
                   form.watch("variations")?.map((v, i) => {
                     return {
@@ -847,6 +850,7 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
                     v.map((v) => v.weight)
                   );
                 }}
+                hideVariationIds={false}
                 showPreview={!!isNewExperiment}
                 disableCustomSplit={type === "multi-armed-bandit"}
               />

--- a/packages/front-end/components/Experiment/SortableExperimentVariationRow.tsx
+++ b/packages/front-end/components/Experiment/SortableExperimentVariationRow.tsx
@@ -1,0 +1,256 @@
+import { forwardRef, useEffect, useState } from "react";
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { FaArrowsAlt } from "react-icons/fa";
+import {
+  ExperimentValue,
+  FeatureInterface,
+  FeatureValueType,
+} from "back-end/types/feature";
+import clsx from "clsx";
+import {
+  decimalToPercent,
+  distributeWeights,
+  floatRound,
+  rebalance,
+} from "@/services/utils";
+import {
+  getVariationColor,
+  getVariationDefaultName,
+} from "@/services/features";
+import MoreMenu from "@/components/Dropdown/MoreMenu";
+import Field from "@/components/Forms/Field";
+import Tooltip from "@/components/Tooltip/Tooltip";
+import styles from "@/components/Features/VariationsInput.module.scss";
+import FeatureValueField from "@/components/Features/FeatureValueField";
+
+export type SortableVariation = ExperimentValue & {
+  id: string;
+};
+
+interface SortableProps {
+  i: number;
+  variation: SortableVariation;
+  variations: SortableVariation[];
+  valueType: FeatureValueType;
+  setVariations?: (value: ExperimentValue[]) => void;
+  setWeight?: (i: number, weight: number) => void;
+  customSplit: boolean;
+  valueAsId: boolean;
+  feature?: FeatureInterface;
+}
+
+type VariationProps = SortableProps &
+  React.HTMLAttributes<HTMLTableRowElement> & {
+    handle?: React.HTMLAttributes<HTMLDivElement>;
+  };
+
+export const ExperimentVariationRow = forwardRef<
+  HTMLTableRowElement,
+  VariationProps
+>(
+  (
+    {
+      i,
+      variations,
+      variation,
+      handle,
+      valueAsId,
+      setVariations,
+      valueType,
+      customSplit,
+      setWeight,
+      feature,
+      ...props
+    },
+    ref
+  ) => {
+    const weights = variations.map((v) => v.weight);
+    const weight = weights[i];
+    const weightPercent = floatRound(weight * 100, 2);
+    const [val, setVal] = useState<number>(weightPercent);
+    useEffect(() => {
+      if (val !== weight) {
+        setVal(weightPercent);
+      }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [weightPercent]);
+
+    const rebalanceAndUpdate = (
+      i: number,
+      newValue: number,
+      precision: number = 4
+    ) => {
+      if (!setWeight) return;
+      rebalance(weights, i, newValue, precision).forEach((w, j) => {
+        // The weight needs updating
+        if (w !== weights[j]) {
+          setWeight(j, w);
+        }
+      });
+    };
+
+    return (
+      <tr ref={ref} {...props} key={`${variation.id}__${i}`}>
+        {!valueAsId && (
+          <td
+            style={{ width: 45 }}
+            className="position-relative pl-3"
+            key={`${variation.id}__${i}__0`}
+          >
+            <div
+              className={styles.colorMarker}
+              style={{
+                backgroundColor: getVariationColor(i, true),
+              }}
+            />
+            {i}
+          </td>
+        )}
+        <td key={`${variation.id}__${i}__1`}>
+          {setVariations ? (
+            <FeatureValueField
+              id={`value_${i}`}
+              value={variation.value}
+              placeholder={valueAsId ? i + "" : ""}
+              setValue={(value) => {
+                const newVariations = [...variations];
+                newVariations[i] = {
+                  ...variation,
+                  value,
+                };
+                setVariations(newVariations);
+              }}
+              label=""
+              valueType={valueType}
+              feature={feature}
+              renderJSONInline={false}
+            />
+          ) : (
+            <>{variation.value}</>
+          )}
+        </td>
+        <td key={`${variation.id}__${i}__2`}>
+          {setVariations ? (
+            <Field
+              label=""
+              placeholder={`${getVariationDefaultName(variation, valueType)}`}
+              value={variation.name || ""}
+              onChange={(e) => {
+                const newVariations = [...variations];
+                newVariations[i] = {
+                  ...variation,
+                  name: e.target.value,
+                };
+                setVariations(newVariations);
+              }}
+            />
+          ) : (
+            <strong>{variation.name || ""}</strong>
+          )}
+        </td>
+        <td key={`${variation.id}__${i}__3`} style={{ width: 210 }}>
+          <div className="row align-items-center">
+            {customSplit ? (
+              <div className="col d-flex flex-row">
+                <div className={`position-relative ${styles.percentInputWrap}`}>
+                  <Field
+                    id={`${variation.id}__${i}__3__input`}
+                    style={{ width: 95 }}
+                    value={val}
+                    onChange={(e) => {
+                      setVal(parseFloat(e.target.value));
+                    }}
+                    onBlur={() => {
+                      const decimal = (val >= 0 ? val : 0) / 100;
+                      rebalanceAndUpdate(i, decimal);
+                    }}
+                    type="number"
+                    min={0}
+                    max={100}
+                    step="any"
+                    className={styles.percentInput}
+                    disabled={!setWeight}
+                  />
+                  <span>%</span>
+                </div>
+              </div>
+            ) : (
+              <div className="col d-flex flex-row">
+                {decimalToPercent(weights[i])}%
+              </div>
+            )}
+            {variations.length > 1 && setVariations && (
+              <div {...handle} title="Drag and drop to re-order rules">
+                <FaArrowsAlt />
+              </div>
+            )}
+            {setVariations && (
+              <div className="col-auto">
+                <MoreMenu zIndex={1000000}>
+                  <Tooltip
+                    body="Experiments must have at least two variations"
+                    shouldDisplay={variations.length <= 2}
+                  >
+                    <button
+                      disabled={variations.length <= 2}
+                      className={clsx(
+                        "dropdown-item",
+                        variations.length > 2 && "text-danger"
+                      )}
+                      onClick={(e) => {
+                        e.preventDefault();
+
+                        const newValues = [...variations];
+                        newValues.splice(i, 1);
+
+                        const newWeights = distributeWeights(
+                          newValues.map((v) => v.weight),
+                          customSplit
+                        );
+
+                        newValues.forEach((v, j) => {
+                          v.weight = newWeights[j] || 0;
+                        });
+                        setVariations(newValues);
+                      }}
+                      type="button"
+                    >
+                      remove
+                    </button>
+                  </Tooltip>
+                </MoreMenu>
+              </div>
+            )}
+          </div>
+        </td>
+      </tr>
+    );
+  }
+);
+
+ExperimentVariationRow.displayName = "ExperimentVariationRow";
+
+export function SortableExperimentVariationRow(props: SortableProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+  } = useSortable({ id: props.variation.id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <ExperimentVariationRow
+      {...props}
+      ref={setNodeRef}
+      style={style}
+      handle={{ ...attributes, ...listeners }}
+    />
+  );
+}

--- a/packages/front-end/components/Features/FeatureValueField.tsx
+++ b/packages/front-end/components/Features/FeatureValueField.tsx
@@ -22,7 +22,7 @@ import Tooltip from "@/components/Tooltip/Tooltip";
 
 export interface Props {
   valueType?: FeatureValueType;
-  label: string;
+  label?: string;
   value: string;
   setValue: (v: string) => void;
   id: string;
@@ -73,8 +73,8 @@ export default function FeatureValueField({
 
   if (valueType === "boolean") {
     return (
-      <div className="form-group">
-        <label>{label}</label>
+      <div className={clsx("form-group", { "mb-0": label === undefined })}>
+        {label !== undefined && <label>{label}</label>}
         <div>
           <Toggle
             id={id + "__toggle"}
@@ -127,7 +127,13 @@ export default function FeatureValueField({
           }
         : {})}
       helpText={helpText}
-      style={valueType === undefined ? { width: 80 } : undefined}
+      style={
+        valueType === undefined
+          ? { width: 80 }
+          : valueType === "number"
+          ? { width: 120 }
+          : undefined
+      }
     />
   );
 }

--- a/packages/front-end/components/Features/FeatureValueField.tsx
+++ b/packages/front-end/components/Features/FeatureValueField.tsx
@@ -21,7 +21,7 @@ import { GBAddCircle } from "@/components/Icons";
 import Tooltip from "@/components/Tooltip/Tooltip";
 
 export interface Props {
-  valueType: FeatureValueType;
+  valueType?: FeatureValueType;
   label: string;
   value: string;
   setValue: (v: string) => void;
@@ -120,11 +120,14 @@ export default function FeatureValueField({
             min: "any",
             max: "any",
           }
-        : {
+        : valueType === "string"
+        ? {
             textarea: true,
             minRows: 1,
-          })}
+          }
+        : {})}
       helpText={helpText}
+      style={valueType === undefined ? { width: 80 } : undefined}
     />
   );
 }

--- a/packages/front-end/components/Features/FeatureVariationsInput.tsx
+++ b/packages/front-end/components/Features/FeatureVariationsInput.tsx
@@ -185,7 +185,7 @@ export default function FeatureVariationsInput({
           />
         </>
       ) : (
-        <div className="gbtable">
+        <>
           {!hideCoverage && coverage !== undefined ? (
             <div className="px-3 pt-3 bg-highlight rounded mb-3">
               <label className="mb-0">
@@ -253,8 +253,8 @@ export default function FeatureVariationsInput({
             )}
 
           {!hideVariations && (
-            <table className="table mb-0">
-              <thead>
+            <table className="table table-borderless mb-0">
+              <thead className={styles.thead}>
                 <tr>
                   {!hideVariationIds && (
                     <th className="pl-3 pr-0">
@@ -310,7 +310,8 @@ export default function FeatureVariationsInput({
                     />
                   ))}
                 </SortableVariationsList>
-
+              </tbody>
+              <tfoot>
                 {!disableVariations && (
                   <tr>
                     <td colSpan={10}>
@@ -394,10 +395,10 @@ export default function FeatureVariationsInput({
                     </td>
                   </tr>
                 ) : null}
-              </tbody>
+              </tfoot>
             </table>
           )}
-        </div>
+        </>
       )}
     </div>
   );

--- a/packages/front-end/components/Features/FeatureVariationsInput.tsx
+++ b/packages/front-end/components/Features/FeatureVariationsInput.tsx
@@ -2,7 +2,7 @@ import { FeatureInterface, FeatureValueType } from "back-end/types/feature";
 import { Slider } from "@radix-ui/themes";
 import React, { useState } from "react";
 import { getEqualWeights } from "shared/experiments";
-import { PiLockSimpleFill } from "react-icons/pi";
+import { PiArrowsClockwise, PiLockSimpleFill } from "react-icons/pi";
 import {
   decimalToPercent,
   distributeWeights,
@@ -273,7 +273,11 @@ export default function FeatureVariationsInput({
                       {!disableVariations &&
                         !disableCustomSplit &&
                         !editingSplits && (
-                          <Tooltip body="Customize split">
+                          <Tooltip
+                            body="Customize split"
+                            usePortal={true}
+                            tipPosition="top"
+                          >
                             <a
                               role="button"
                               className="ml-1 mb-0"
@@ -288,6 +292,25 @@ export default function FeatureVariationsInput({
                             </a>
                           </Tooltip>
                         )}
+                      {!isEqualWeights && !disableCustomSplit && !hideSplits && (
+                        <Tooltip
+                          body="Assign equal weights to all variations"
+                          usePortal={true}
+                          tipPosition="top"
+                        >
+                          <a
+                            role="button"
+                            className="ml-2 link-purple small"
+                            onClick={(e) => {
+                              e.preventDefault();
+                              setEqualWeights();
+                            }}
+                          >
+                            <PiArrowsClockwise className="mr-1" size={12} />
+                            set equal
+                          </a>
+                        </Tooltip>
+                      )}
                     </th>
                   )}
                 </tr>
@@ -377,20 +400,6 @@ export default function FeatureVariationsInput({
                             </>
                           )}
                         </div>
-                        {!isEqualWeights && !disableCustomSplit && !hideSplits && (
-                          <div className="col-auto text-right">
-                            <a
-                              role="button"
-                              className="font-weight-bold link-purple"
-                              onClick={(e) => {
-                                e.preventDefault();
-                                setEqualWeights();
-                              }}
-                            >
-                              set equal weights
-                            </a>
-                          </div>
-                        )}
                       </div>
                     </td>
                   </tr>

--- a/packages/front-end/components/Features/FeatureVariationsInput.tsx
+++ b/packages/front-end/components/Features/FeatureVariationsInput.tsx
@@ -45,6 +45,7 @@ export interface Props {
   disableCoverage?: boolean;
   disableVariations?: boolean;
   disableCustomSplit?: boolean;
+  hideSplits?: boolean;
   label?: string | null;
   feature?: FeatureInterface;
   hideVariations?: boolean;
@@ -72,6 +73,7 @@ export default function FeatureVariationsInput({
   disableCoverage = false,
   disableVariations = false,
   disableCustomSplit = false,
+  hideSplits = false,
   label: _label,
   feature,
   hideVariations,
@@ -265,27 +267,29 @@ export default function FeatureVariationsInput({
                   {hideVariationIds && !valueAsId && <th>Value to Force</th>}
                   <th>Variation Name</th>
                   {showDescriptions && <th>Description</th>}
-                  <th>
-                    Split
-                    {!disableVariations &&
-                      !disableCustomSplit &&
-                      !editingSplits && (
-                        <Tooltip body="Customize split">
-                          <a
-                            role="button"
-                            className="ml-1 mb-0"
-                            onClick={() => {
-                              setEditingSplits(true);
-                            }}
-                          >
-                            <PiLockSimpleFill
-                              className="text-purple"
-                              size={15}
-                            />
-                          </a>
-                        </Tooltip>
-                      )}
-                  </th>
+                  {!hideSplits && (
+                    <th>
+                      Split
+                      {!disableVariations &&
+                        !disableCustomSplit &&
+                        !editingSplits && (
+                          <Tooltip body="Customize split">
+                            <a
+                              role="button"
+                              className="ml-1 mb-0"
+                              onClick={() => {
+                                setEditingSplits(true);
+                              }}
+                            >
+                              <PiLockSimpleFill
+                                className="text-purple"
+                                size={15}
+                              />
+                            </a>
+                          </Tooltip>
+                        )}
+                    </th>
+                  )}
                 </tr>
               </thead>
               <tbody>
@@ -309,6 +313,7 @@ export default function FeatureVariationsInput({
                       valueAsId={valueAsId}
                       hideVariationIds={hideVariationIds}
                       hideValueField={hideValueField || !editingIds}
+                      hideSplit={hideSplits}
                       feature={feature}
                       showDescription={showDescriptions}
                     />
@@ -372,7 +377,7 @@ export default function FeatureVariationsInput({
                             </>
                           )}
                         </div>
-                        {!isEqualWeights && !disableCustomSplit && (
+                        {!isEqualWeights && !disableCustomSplit && !hideSplits && (
                           <div className="col-auto text-right">
                             <a
                               role="button"

--- a/packages/front-end/components/Features/FeatureVariationsInput.tsx
+++ b/packages/front-end/components/Features/FeatureVariationsInput.tsx
@@ -99,8 +99,6 @@ export default function FeatureVariationsInput({
     });
   };
 
-  console.log({ hideVariationIds, valueAsId, hideValueField, editingIds });
-
   const label = _label
     ? _label
     : simple
@@ -272,21 +270,27 @@ export default function FeatureVariationsInput({
                     {!disableVariations &&
                       !disableCustomSplit &&
                       !editingSplits && (
-                        <a
-                          role="button"
-                          className="ml-1 mb-0"
-                          onClick={() => {
-                            setEditingSplits(true);
-                          }}
-                        >
-                          <PiLockSimpleFill className="text-purple" size={15} />
-                        </a>
+                        <Tooltip body="Customize split">
+                          <a
+                            role="button"
+                            className="ml-1 mb-0"
+                            onClick={() => {
+                              setEditingSplits(true);
+                            }}
+                          >
+                            <PiLockSimpleFill
+                              className="text-purple"
+                              size={15}
+                            />
+                          </a>
+                        </Tooltip>
                       )}
                   </th>
                 </tr>
               </thead>
               <tbody>
                 <SortableVariationsList
+                  valuesAsIds={idsMatchIndexes}
                   variations={variations}
                   setVariations={!disableVariations ? setVariations : undefined}
                 >
@@ -334,7 +338,7 @@ export default function FeatureVariationsInput({
                                     value: getDefaultVariationValue(
                                       defaultValue
                                     ),
-                                    name: "",
+                                    name: `Variation ${variations.length}`,
                                     weight: 0,
                                     id: generateVariationId(),
                                   },
@@ -343,6 +347,11 @@ export default function FeatureVariationsInput({
                                   v.weight = newWeights[i] || 0;
                                 });
                                 setVariations(newValues);
+                                if (isEqualWeights) {
+                                  getEqualWeights(
+                                    newValues.length
+                                  ).forEach((w, i) => setWeight(i, w));
+                                }
                               }}
                             >
                               <GBAddCircle className="mr-1" />

--- a/packages/front-end/components/Features/FeatureVariationsInput.tsx
+++ b/packages/front-end/components/Features/FeatureVariationsInput.tsx
@@ -30,8 +30,8 @@ export interface Props {
   variations: SortableVariation[];
   setWeight: (i: number, weight: number) => void;
   setVariations?: (variations: SortableVariation[]) => void;
-  coverage: number;
-  setCoverage: (coverage: number) => void;
+  coverage?: number;
+  setCoverage?: (coverage: number) => void;
   coverageLabel?: string;
   coverageTooltip?: string;
   valueAsId?: boolean;
@@ -99,7 +99,7 @@ export default function FeatureVariationsInput({
       <label>{label}</label>
       {simple ? (
         <>
-          {!hideCoverage && (
+          {!hideCoverage && coverage !== undefined ? (
             <div className="px-3 pt-3 bg-highlight rounded mb-3">
               <label className="mb-0">
                 {coverageLabel} <Tooltip body={coverageTooltip} />
@@ -116,7 +116,7 @@ export default function FeatureVariationsInput({
                       let decimal = percentToDecimalForNumber(e[0]);
                       if (decimal > 1) decimal = 1;
                       if (decimal < 0) decimal = 0;
-                      setCoverage(decimal);
+                      setCoverage?.(decimal);
                     }}
                   />
                 </div>
@@ -131,7 +131,7 @@ export default function FeatureVariationsInput({
                         let decimal = percentToDecimal(e.target.value);
                         if (decimal > 1) decimal = 1;
                         if (decimal < 0) decimal = 0;
-                        setCoverage(decimal);
+                        setCoverage?.(decimal);
                       }}
                       type="number"
                       min={0}
@@ -144,7 +144,7 @@ export default function FeatureVariationsInput({
                 </div>
               </div>
             </div>
-          )}
+          ) : null}
           <Field
             label="Number of Variations"
             type="number"
@@ -169,7 +169,7 @@ export default function FeatureVariationsInput({
         </>
       ) : (
         <div className="gbtable">
-          {!hideCoverage && (
+          {!hideCoverage && coverage !== undefined ? (
             <div className="px-3 pt-3 bg-highlight rounded mb-3">
               <label className="mb-0">
                 {coverageLabel} <Tooltip body={coverageTooltip} />
@@ -186,7 +186,7 @@ export default function FeatureVariationsInput({
                       let decimal = percentToDecimalForNumber(e[0]);
                       if (decimal > 1) decimal = 1;
                       if (decimal < 0) decimal = 0;
-                      setCoverage(decimal);
+                      setCoverage?.(decimal);
                     }}
                   />
                 </div>
@@ -201,7 +201,7 @@ export default function FeatureVariationsInput({
                         let decimal = percentToDecimal(e.target.value);
                         if (decimal > 1) decimal = 1;
                         if (decimal < 0) decimal = 0;
-                        setCoverage(decimal);
+                        setCoverage?.(decimal);
                       }}
                       type="number"
                       min={0}
@@ -214,7 +214,7 @@ export default function FeatureVariationsInput({
                 </div>
               </div>
             </div>
-          )}
+          ) : null}
           {!hideVariations && (
             <table className="table mb-0">
               <thead className={`${styles.variationSplitHeader}`}>
@@ -347,7 +347,7 @@ export default function FeatureVariationsInput({
                   </tr>
                 )}
 
-                {showPreview && (
+                {showPreview && coverage !== undefined ? (
                   <tr>
                     <td colSpan={4} className="px-0 border-0">
                       <div className="box pt-3 px-3">
@@ -359,7 +359,7 @@ export default function FeatureVariationsInput({
                       </div>
                     </td>
                   </tr>
-                )}
+                ) : null}
               </tbody>
             </table>
           )}

--- a/packages/front-end/components/Features/RuleModal/ExperimentRefNewFields.tsx
+++ b/packages/front-end/components/Features/RuleModal/ExperimentRefNewFields.tsx
@@ -62,6 +62,7 @@ export default function ExperimentRefNewFields({
   setVariations,
   variationValuesAsIds = false,
   hideVariationIds = true,
+  startEditingIndexes = false,
   orgStickyBucketing,
 }: {
   step: number;
@@ -94,6 +95,7 @@ export default function ExperimentRefNewFields({
   setVariations: (v: SortableVariation[]) => void;
   variationValuesAsIds?: boolean;
   hideVariationIds?: boolean;
+  startEditingIndexes?: boolean;
   orgStickyBucketing?: boolean;
 }) {
   const form = useFormContext();
@@ -204,6 +206,7 @@ export default function ExperimentRefNewFields({
             feature={feature}
             valueAsId={variationValuesAsIds}
             hideVariationIds={hideVariationIds}
+            startEditingIndexes={startEditingIndexes}
           />
 
           {namespaces && namespaces.length > 0 && (

--- a/packages/front-end/components/Features/RuleModal/ExperimentRefNewFields.tsx
+++ b/packages/front-end/components/Features/RuleModal/ExperimentRefNewFields.tsx
@@ -60,6 +60,8 @@ export default function ExperimentRefNewFields({
   setWeight,
   variations,
   setVariations,
+  variationValuesAsIds = false,
+  hideVariationIds = true,
   orgStickyBucketing,
 }: {
   step: number;
@@ -90,6 +92,8 @@ export default function ExperimentRefNewFields({
   setWeight: (i: number, w: number) => void;
   variations: SortableVariation[];
   setVariations: (v: SortableVariation[]) => void;
+  variationValuesAsIds?: boolean;
+  hideVariationIds?: boolean;
   orgStickyBucketing?: boolean;
 }) {
   const form = useFormContext();
@@ -189,7 +193,7 @@ export default function ExperimentRefNewFields({
           <FeatureVariationsInput
             label="Traffic Percent & Variations"
             defaultValue={feature ? getFeatureDefaultValue(feature) : undefined}
-            valueType={feature?.valueType ?? "string"}
+            valueType={feature?.valueType}
             coverageLabel="Traffic included in this Experiment"
             coverageTooltip={`Users not included in the Experiment will skip this ${source}`}
             coverage={coverage}
@@ -198,6 +202,8 @@ export default function ExperimentRefNewFields({
             variations={variations}
             setVariations={setVariations}
             feature={feature}
+            valueAsId={variationValuesAsIds}
+            hideVariationIds={hideVariationIds}
           />
 
           {namespaces && namespaces.length > 0 && (

--- a/packages/front-end/components/Features/RuleModal/index.tsx
+++ b/packages/front-end/components/Features/RuleModal/index.tsx
@@ -849,6 +849,8 @@ export default function RuleModal({
                   setVariations={(variations) =>
                     form.setValue("values", variations)
                   }
+                  variationValuesAsIds={false}
+                  hideVariationIds={true}
                   orgStickyBucketing={orgStickyBucketing}
                 />
               </Page>

--- a/packages/front-end/components/Features/RuleModal/index.tsx
+++ b/packages/front-end/components/Features/RuleModal/index.tsx
@@ -851,6 +851,7 @@ export default function RuleModal({
                   }
                   variationValuesAsIds={false}
                   hideVariationIds={true}
+                  startEditingIndexes={true}
                   orgStickyBucketing={orgStickyBucketing}
                 />
               </Page>

--- a/packages/front-end/components/Features/SortableFeatureVariationRow.tsx
+++ b/packages/front-end/components/Features/SortableFeatureVariationRow.tsx
@@ -262,7 +262,7 @@ export const VariationRow = forwardRef<HTMLTableRowElement, VariationProps>(
                       }}
                       type="button"
                     >
-                      remove
+                      Remove
                     </button>
                   </Tooltip>
                 </MoreMenu>

--- a/packages/front-end/components/Features/SortableFeatureVariationRow.tsx
+++ b/packages/front-end/components/Features/SortableFeatureVariationRow.tsx
@@ -133,7 +133,6 @@ export const VariationRow = forwardRef<HTMLTableRowElement, VariationProps>(
                   };
                   setVariations(newVariations);
                 }}
-                label=""
                 valueType={valueType}
                 feature={feature}
                 renderJSONInline={false}
@@ -146,7 +145,6 @@ export const VariationRow = forwardRef<HTMLTableRowElement, VariationProps>(
         <td key={`${variation.id}__${i}__2`}>
           {setVariations ? (
             <Field
-              label=""
               placeholder={`${getVariationDefaultName(
                 variation,
                 valueType ?? "string"
@@ -169,7 +167,6 @@ export const VariationRow = forwardRef<HTMLTableRowElement, VariationProps>(
           <td key={`${variation.id}__${i}__3`}>
             {setVariations ? (
               <Field
-                label=""
                 value={variation.description || ""}
                 onChange={(e) => {
                   const newVariations = [...variations];

--- a/packages/front-end/components/Features/SortableFeatureVariationRow.tsx
+++ b/packages/front-end/components/Features/SortableFeatureVariationRow.tsx
@@ -26,18 +26,22 @@ import styles from "./VariationsInput.module.scss";
 
 export type SortableVariation = ExperimentValue & {
   id: string;
+  description?: string;
 };
 
 interface SortableProps {
   i: number;
   variation: SortableVariation;
   variations: SortableVariation[];
-  valueType: FeatureValueType;
+  valueType?: FeatureValueType;
+  hideVariationIds?: boolean;
+  hideValueField?: boolean;
   setVariations?: (value: ExperimentValue[]) => void;
   setWeight?: (i: number, weight: number) => void;
   customSplit: boolean;
   valueAsId: boolean;
   feature?: FeatureInterface;
+  showDescription?: boolean;
 }
 
 type VariationProps = SortableProps &
@@ -55,9 +59,12 @@ export const VariationRow = forwardRef<HTMLTableRowElement, VariationProps>(
       valueAsId,
       setVariations,
       valueType,
+      hideVariationIds,
+      hideValueField,
       customSplit,
       setWeight,
       feature,
+      showDescription,
       ...props
     },
     ref
@@ -88,11 +95,16 @@ export const VariationRow = forwardRef<HTMLTableRowElement, VariationProps>(
     };
 
     return (
-      <tr ref={ref} {...props} key={`${variation.id}__${i}`}>
-        {!valueAsId && (
+      <tr
+        ref={ref}
+        {...props}
+        key={`${variation.id}__${i}`}
+        className="bg-white"
+      >
+        {!hideVariationIds && (
           <td
             style={{ width: 45 }}
-            className="position-relative pl-3"
+            className="position-relative pl-3 pr-0"
             key={`${variation.id}__${i}__0`}
           >
             <div
@@ -104,34 +116,39 @@ export const VariationRow = forwardRef<HTMLTableRowElement, VariationProps>(
             {i}
           </td>
         )}
-        <td key={`${variation.id}__${i}__1`}>
-          {setVariations ? (
-            <FeatureValueField
-              id={`value_${i}`}
-              value={variation.value}
-              placeholder={valueAsId ? i + "" : ""}
-              setValue={(value) => {
-                const newVariations = [...variations];
-                newVariations[i] = {
-                  ...variation,
-                  value,
-                };
-                setVariations(newVariations);
-              }}
-              label=""
-              valueType={valueType}
-              feature={feature}
-              renderJSONInline={false}
-            />
-          ) : (
-            <>{variation.value}</>
-          )}
-        </td>
+        {!hideValueField && (
+          <td key={`${variation.id}__${i}__1`}>
+            {setVariations ? (
+              <FeatureValueField
+                id={`value_${i}`}
+                value={variation.value}
+                placeholder={valueAsId ? i + "" : ""}
+                setValue={(value) => {
+                  const newVariations = [...variations];
+                  newVariations[i] = {
+                    ...variation,
+                    value,
+                  };
+                  setVariations(newVariations);
+                }}
+                label=""
+                valueType={valueType}
+                feature={feature}
+                renderJSONInline={false}
+              />
+            ) : (
+              <>{variation.value}</>
+            )}
+          </td>
+        )}
         <td key={`${variation.id}__${i}__2`}>
           {setVariations ? (
             <Field
               label=""
-              placeholder={`${getVariationDefaultName(variation, valueType)}`}
+              placeholder={`${getVariationDefaultName(
+                variation,
+                valueType ?? "string"
+              )}`}
               value={variation.name || ""}
               onChange={(e) => {
                 const newVariations = [...variations];
@@ -146,7 +163,27 @@ export const VariationRow = forwardRef<HTMLTableRowElement, VariationProps>(
             <strong>{variation.name || ""}</strong>
           )}
         </td>
-        <td key={`${variation.id}__${i}__3`} style={{ width: 210 }}>
+        {showDescription && (
+          <td key={`${variation.id}__${i}__3`}>
+            {setVariations ? (
+              <Field
+                label=""
+                value={variation.description || ""}
+                onChange={(e) => {
+                  const newVariations = [...variations];
+                  newVariations[i] = {
+                    ...variation,
+                    description: e.target.value,
+                  };
+                  setVariations(newVariations);
+                }}
+              />
+            ) : (
+              <span>{variation.description || ""}</span>
+            )}
+          </td>
+        )}
+        <td key={`${variation.id}__${i}__4`} style={{ width: 180 }}>
           <div className="row align-items-center">
             {customSplit ? (
               <div className="col d-flex flex-row">

--- a/packages/front-end/components/Features/SortableFeatureVariationRow.tsx
+++ b/packages/front-end/components/Features/SortableFeatureVariationRow.tsx
@@ -39,6 +39,7 @@ interface SortableProps {
   setVariations?: (value: ExperimentValue[]) => void;
   setWeight?: (i: number, weight: number) => void;
   customSplit: boolean;
+  hideSplit: boolean;
   valueAsId: boolean;
   feature?: FeatureInterface;
   showDescription?: boolean;
@@ -63,6 +64,7 @@ export const VariationRow = forwardRef<HTMLTableRowElement, VariationProps>(
       hideVariationIds,
       hideValueField,
       customSplit,
+      hideSplit,
       setWeight,
       feature,
       showDescription,
@@ -184,36 +186,45 @@ export const VariationRow = forwardRef<HTMLTableRowElement, VariationProps>(
             )}
           </td>
         )}
-        <td key={`${variation.id}__${i}__4`} style={{ width: 180 }}>
+        <td
+          key={`${variation.id}__${i}__4`}
+          style={{ width: !hideSplit ? 180 : 60 }}
+        >
           <div className="row align-items-center">
-            {customSplit ? (
-              <div className="col d-flex flex-row">
-                <div className={`position-relative ${styles.percentInputWrap}`}>
-                  <Field
-                    id={`${variation.id}__${i}__3__input`}
-                    style={{ width: 95 }}
-                    value={val}
-                    onChange={(e) => {
-                      setVal(parseFloat(e.target.value));
-                    }}
-                    onBlur={() => {
-                      const decimal = (val >= 0 ? val : 0) / 100;
-                      rebalanceAndUpdate(i, decimal);
-                    }}
-                    type="number"
-                    min={0}
-                    max={100}
-                    step="any"
-                    className={styles.percentInput}
-                    disabled={!setWeight}
-                  />
-                  <span>%</span>
-                </div>
-              </div>
-            ) : (
-              <div className="col d-flex flex-row">
-                {decimalToPercent(weights[i])}%
-              </div>
+            {!hideSplit && (
+              <>
+                {customSplit ? (
+                  <div className="col d-flex flex-row">
+                    <div
+                      className={`position-relative ${styles.percentInputWrap}`}
+                    >
+                      <Field
+                        id={`${variation.id}__${i}__3__input`}
+                        style={{ width: 95 }}
+                        value={val}
+                        onChange={(e) => {
+                          setVal(parseFloat(e.target.value));
+                        }}
+                        onBlur={() => {
+                          const decimal = (val >= 0 ? val : 0) / 100;
+                          rebalanceAndUpdate(i, decimal);
+                        }}
+                        type="number"
+                        min={0}
+                        max={100}
+                        step="any"
+                        className={styles.percentInput}
+                        disabled={!setWeight}
+                      />
+                      <span>%</span>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="col d-flex flex-row">
+                    {decimalToPercent(weights[i])}%
+                  </div>
+                )}
+              </>
             )}
             {variations.length > 1 && setVariations && (
               <div {...handle} title="Drag and drop to re-order rules">

--- a/packages/front-end/components/Features/SortableFeatureVariationRow.tsx
+++ b/packages/front-end/components/Features/SortableFeatureVariationRow.tsx
@@ -42,6 +42,7 @@ interface SortableProps {
   valueAsId: boolean;
   feature?: FeatureInterface;
   showDescription?: boolean;
+  dragging?: boolean;
 }
 
 type VariationProps = SortableProps &
@@ -65,6 +66,7 @@ export const VariationRow = forwardRef<HTMLTableRowElement, VariationProps>(
       setWeight,
       feature,
       showDescription,
+      dragging,
       ...props
     },
     ref
@@ -99,7 +101,7 @@ export const VariationRow = forwardRef<HTMLTableRowElement, VariationProps>(
         ref={ref}
         {...props}
         key={`${variation.id}__${i}`}
-        className="bg-white"
+        className={`bg-white ${styles.tr} ${dragging && styles.dragging}`}
       >
         {!hideVariationIds && (
           <td
@@ -177,6 +179,8 @@ export const VariationRow = forwardRef<HTMLTableRowElement, VariationProps>(
                   };
                   setVariations(newVariations);
                 }}
+                textarea
+                minRows={1}
               />
             ) : (
               <span>{variation.description || ""}</span>
@@ -272,11 +276,13 @@ export function SortableFeatureVariationRow(props: SortableProps) {
     setNodeRef,
     transform,
     transition,
+    active,
   } = useSortable({ id: props.variation.id });
 
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
+    border: "1px solid red !important",
   };
 
   return (
@@ -284,6 +290,7 @@ export function SortableFeatureVariationRow(props: SortableProps) {
       {...props}
       ref={setNodeRef}
       style={style}
+      dragging={active?.id === props?.variation?.id}
       handle={{ ...attributes, ...listeners }}
     />
   );

--- a/packages/front-end/components/Features/SortableVariationsList.tsx
+++ b/packages/front-end/components/Features/SortableVariationsList.tsx
@@ -57,11 +57,9 @@ const SortableVariationsList: FC<{
 
           if (oldIndex === -1 || newIndex === -1) return;
 
-          const newVariations = arrayMove<SortableVariation | Variation>(
-            variations,
-            oldIndex,
-            newIndex
-          );
+          const newVariations = arrayMove<
+            SortableVariation | (Variation & { value?: string })
+          >(variations, oldIndex, newIndex);
           if (valuesAsIds) {
             newVariations.forEach((variation, i) => {
               if (variation.value === undefined) return;

--- a/packages/front-end/components/Features/SortableVariationsList.tsx
+++ b/packages/front-end/components/Features/SortableVariationsList.tsx
@@ -21,11 +21,13 @@ const SortableVariationsList: FC<{
   children: ReactNode;
   variations: (SortableVariation | Variation)[];
   setVariations?: (variations: (SortableVariation | Variation)[]) => void;
+  valuesAsIds?: boolean;
   sortingStrategy?: "vertical" | "rect";
 }> = ({
   children,
   variations,
   setVariations,
+  valuesAsIds = false,
   sortingStrategy = "vertical",
 }) => {
   const sensors = useSensors(
@@ -60,6 +62,12 @@ const SortableVariationsList: FC<{
             oldIndex,
             newIndex
           );
+          if (valuesAsIds) {
+            newVariations.forEach((variation, i) => {
+              if (variation.value === undefined) return;
+              variation.value = i + "";
+            });
+          }
 
           setVariations(newVariations);
         }

--- a/packages/front-end/components/Features/VariationsInput.module.scss
+++ b/packages/front-end/components/Features/VariationsInput.module.scss
@@ -1,11 +1,33 @@
 @import "../../styles/colors.scss";
 
+.dragging {
+  z-index: 1;
+  box-shadow: 0 5px 10px rgba(0, 0, 0, 0.1);
+}
+.thead {
+  tr th {
+    padding-bottom: 0;
+  }
+}
+.tr {
+  td {
+    padding-top: 12px;
+    padding-bottom: 12px;
+    vertical-align: middle;
+    border-top: none;
+    border-bottom: 1px solid var(--border-color-100);
+  }
+}
+.tr:last-of-type td {
+  border-bottom: none !important;
+}
+
 .colorMarker {
-  width: 6px;
+  width: 4px;
   position: absolute;
-  top: 0;
-  bottom: 0;
+  top: 15px;
   left: 0;
+  height: calc(100% - 30px);
 }
 
 .percentInput {

--- a/packages/front-end/components/Features/VariationsInput.module.scss
+++ b/packages/front-end/components/Features/VariationsInput.module.scss
@@ -1,7 +1,7 @@
 @import "../../styles/colors.scss";
 
 .dragging {
-  z-index: 1;
+  z-index: 100 !important;
   box-shadow: 0 5px 10px rgba(0, 0, 0, 0.1);
 }
 .thead {
@@ -10,6 +10,7 @@
   }
 }
 .tr {
+  position: relative;
   td {
     padding-top: 12px;
     padding-bottom: 12px;
@@ -25,9 +26,9 @@
 .colorMarker {
   width: 4px;
   position: absolute;
-  top: 15px;
+  top: 12px;
   left: 0;
-  height: calc(100% - 30px);
+  height: calc(100% - 24px);
 }
 
 .percentInput {

--- a/packages/front-end/components/Features/VariationsInput.module.scss
+++ b/packages/front-end/components/Features/VariationsInput.module.scss
@@ -6,7 +6,7 @@
 }
 .thead {
   tr th {
-    padding-bottom: 0;
+    padding-bottom: 4px;
   }
 }
 .tr {
@@ -26,9 +26,11 @@
 .colorMarker {
   width: 4px;
   position: absolute;
-  top: 12px;
+  //top: 12px;
+  top: 0;
   left: 0;
-  height: calc(100% - 24px);
+  //height: calc(100% - 24px);
+  height: 100%;
 }
 
 .percentInput {

--- a/packages/front-end/components/Features/VariationsInput.module.scss
+++ b/packages/front-end/components/Features/VariationsInput.module.scss
@@ -1,10 +1,5 @@
 @import "../../styles/colors.scss";
 
-.variationSplitHeader {
-  th {
-    background-color: var(--table-row-hover-background-color);
-  }
-}
 .colorMarker {
   width: 6px;
   position: absolute;

--- a/packages/front-end/components/Features/VariationsInput.module.scss
+++ b/packages/front-end/components/Features/VariationsInput.module.scss
@@ -6,7 +6,7 @@
 }
 .thead {
   tr th {
-    padding-bottom: 4px;
+    padding-bottom: 0;
   }
 }
 .tr {
@@ -26,11 +26,9 @@
 .colorMarker {
   width: 4px;
   position: absolute;
-  //top: 12px;
-  top: 0;
+  top: 12px;
   left: 0;
-  //height: calc(100% - 24px);
-  height: 100%;
+  height: calc(100% - 24px);
 }
 
 .percentInput {

--- a/packages/front-end/services/features.ts
+++ b/packages/front-end/services/features.ts
@@ -549,12 +549,12 @@ export function getDefaultRuleValue({
         {
           value: defaultValue,
           weight: 0.5,
-          name: "",
+          name: "Control",
         },
         {
           value: value,
           weight: 0.5,
-          name: "",
+          name: "Variation 1",
         },
       ],
       coverage: 1,

--- a/packages/front-end/styles/global.scss
+++ b/packages/front-end/styles/global.scss
@@ -972,7 +972,6 @@ main.main.report {
 .gbtable {
   background-color: var(--surface-background-color);
   margin-bottom: 0;
-
   thead {
     th {
       font-size: 11px;


### PR DESCRIPTION
- Improve component UI/UX, especially when used in a "Edit Variations" context
- Ensure adding/removing variations does not corrupt phase's variationWeights
- hide editing "id" field unless necessary

https://www.loom.com/share/dccbdceb5e914521906783ce72e83bda?sid=c7b6dd4d-0239-444a-8cf0-0683c8c20617

<img width="869" alt="image" src="https://github.com/user-attachments/assets/db50a299-07f4-4207-97bc-00a24b34023b">
<img width="818" alt="Screenshot 2024-11-19 at 9 35 55 PM" src="https://github.com/user-attachments/assets/95896e79-ad08-4cb7-a328-3e77632fd06a">


todo:

- [x] check EditTargetingModal
  - [x] safe mode
  - [x] Make Changes
- [x] NewPhaseForm
- [x] BanditRefNewFields