### PR TITLE
Make FeatureValueField a radio instead of a toggle

### DIFF
--- a/packages/front-end/components/Features/FeatureValueField.tsx
+++ b/packages/front-end/components/Features/FeatureValueField.tsx
@@ -19,6 +19,7 @@ import MultiSelectField from "@/components/Forms/MultiSelectField";
 import Modal from "@/components/Modal";
 import { GBAddCircle } from "@/components/Icons";
 import Tooltip from "@/components/Tooltip/Tooltip";
+import RadioGroup from "@/components/Radix/RadioGroup";
 
 export interface Props {
   valueType: FeatureValueType;
@@ -38,7 +39,6 @@ export default function FeatureValueField({
   label,
   value,
   setValue,
-  id,
   helpText,
   placeholder,
   feature,
@@ -76,17 +76,22 @@ export default function FeatureValueField({
       <div className="form-group">
         <label>{label}</label>
         <div>
-          <Toggle
-            id={id + "__toggle"}
-            value={value === "true"}
+          <RadioGroup
+            options={[
+              {
+                label: "TRUE",
+                value: "true",
+              },
+              {
+                label: "FALSE",
+                value: "false",
+              },
+            ]}
+            value={value}
             setValue={(v) => {
-              setValue(v ? "true" : "false");
+              setValue(v);
             }}
-            type="featureValue"
           />
-          <span className="text-gray font-weight-bold pl-2">
-            {value === "true" ? "TRUE" : "FALSE"}
-          </span>
         </div>
         {helpText && <small className="text-muted">{helpText}</small>}
       </div>

--- a/packages/front-end/components/Features/FeatureValueField.tsx
+++ b/packages/front-end/components/Features/FeatureValueField.tsx
@@ -12,7 +12,6 @@ import { BsBoxArrowUpRight } from "react-icons/bs";
 import dJSON from "dirty-json";
 import clsx from "clsx";
 import Field from "@/components/Forms/Field";
-import Toggle from "@/components/Forms/Toggle";
 import { useUser } from "@/services/UserContext";
 import SelectField from "@/components/Forms/SelectField";
 import MultiSelectField from "@/components/Forms/MultiSelectField";
@@ -226,13 +225,21 @@ function SimpleSchemaPrimitiveEditor<T = unknown>({
             {label}
           </label>
           <div>
-            <Toggle
-              id={uuid}
-              value={value as boolean}
+            <RadioGroup
+              options={[
+                {
+                  label: "TRUE",
+                  value: "true",
+                },
+                {
+                  label: "FALSE",
+                  value: "false",
+                },
+              ]}
+              value={value as string}
               setValue={(v) => {
                 setValue(v as T);
               }}
-              type="featureValue"
               disabled={!field.required && !isset}
             />
           </div>
@@ -243,13 +250,21 @@ function SimpleSchemaPrimitiveEditor<T = unknown>({
       ) : (
         <>
           <div>
-            <Toggle
-              id={uuid}
-              value={value as boolean}
+            <RadioGroup
+              options={[
+                {
+                  label: "TRUE",
+                  value: "true",
+                },
+                {
+                  label: "FALSE",
+                  value: "false",
+                },
+              ]}
+              value={value as string}
               setValue={(v) => {
                 setValue(v as T);
               }}
-              type="featureValue"
               disabled={!field.required && !isset}
             />
           </div>


### PR DESCRIPTION
### Features and Changes

Swaps toggle used for selecting default feature values with a radio group to be in line with new designs

### Screenshots

<img width="224" alt="Screenshot 2024-11-21 at 5 41 40 PM" src="https://github.com/user-attachments/assets/db4ad99b-8856-4f53-923f-32a60a6792f8">

