### PR TITLE
Make schema browser robust to switching databases

### DIFF
--- a/packages/back-end/src/services/informationSchema.ts
+++ b/packages/back-end/src/services/informationSchema.ts
@@ -26,10 +26,11 @@ export function getRecentlyDeletedTables(
       (updatedInformationSchemaRecord) =>
         updatedInformationSchemaRecord.databaseName === database.databaseName
     );
+    if (!database.schemas) return;
     database.schemas.forEach((schema) => {
       const correspondingSchemaIndex = updatedInformationSchema[
         correspondingIndex
-      ].schemas.findIndex(
+      ]?.schemas.findIndex(
         (updatedSchemaRecord) =>
           updatedSchemaRecord.schemaName === schema.schemaName
       );
@@ -88,21 +89,21 @@ export async function mergeStaleInformationSchemaWithUpdate(
     database.schemas.forEach((schema) => {
       const correspondingSchemaIndex = staleInformationSchema[
         correspondingIndex
-      ].schemas.findIndex(
+      ]?.schemas.findIndex(
         (staleSchemaRecord) =>
           staleSchemaRecord.schemaName === schema.schemaName
       );
 
       if (correspondingSchemaIndex > -1) {
         schema.dateCreated =
-          staleInformationSchema[correspondingIndex].schemas[
+          staleInformationSchema[correspondingIndex]?.schemas[
             correspondingSchemaIndex
           ].dateCreated;
       }
       if (!schema.tables) return;
       schema.tables.forEach((table) => {
         const staleInformationSchemaTables =
-          staleInformationSchema[correspondingIndex].schemas[
+          staleInformationSchema[correspondingIndex]?.schemas[
             correspondingSchemaIndex
           ]?.tables || [];
         const correspondingTableIndex = staleInformationSchemaTables.findIndex(

--- a/packages/back-end/src/services/informationSchema.ts
+++ b/packages/back-end/src/services/informationSchema.ts
@@ -26,7 +26,7 @@ export function getRecentlyDeletedTables(
       (updatedInformationSchemaRecord) =>
         updatedInformationSchemaRecord.databaseName === database.databaseName
     );
-    if (!database.schemas) return;
+    if (!database.schemas || correspondingIndex === -1) return;
     database.schemas.forEach((schema) => {
       const correspondingSchemaIndex = updatedInformationSchema[
         correspondingIndex
@@ -85,7 +85,7 @@ export async function mergeStaleInformationSchemaWithUpdate(
       database.dateCreated =
         staleInformationSchema[correspondingIndex].dateCreated;
     }
-    if (!database.schemas) return;
+    if (!database.schemas || correspondingIndex === -1) return;
     database.schemas.forEach((schema) => {
       const correspondingSchemaIndex = staleInformationSchema[
         correspondingIndex

--- a/packages/back-end/src/services/informationSchema.ts
+++ b/packages/back-end/src/services/informationSchema.ts
@@ -100,7 +100,7 @@ export async function mergeStaleInformationSchemaWithUpdate(
             correspondingSchemaIndex
           ].dateCreated;
       }
-      if (!schema.tables) return;
+      if (!schema.tables || correspondingSchemaIndex === -1) return;
       schema.tables.forEach((table) => {
         const staleInformationSchemaTables =
           staleInformationSchema[correspondingIndex]?.schemas[

--- a/packages/front-end/components/SchemaBrowser/SchemaBrowser.tsx
+++ b/packages/front-end/components/SchemaBrowser/SchemaBrowser.tsx
@@ -157,7 +157,6 @@ export default function SchemaBrowser({
         datasourceName={datasource.name}
         datasourceId={datasource.id}
         canRunQueries={canRunQueries}
-        // @ts-expect-error TS(2322) If you come across this, please fix it!: Type 'InformationSchemaInterface | undefined' is n... Remove this comment to see the full error message
         informationSchema={informationSchema}
         setFetching={setFetching}
         fetching={fetching}
@@ -299,12 +298,14 @@ export default function SchemaBrowser({
         </>
       </SchemaBrowserWrapper>
       {error && <div className="alert alert-danger mt-2 mb-0">{error}</div>}
-      <DatasourceTableData
-        canRunQueries={canRunQueries}
-        tableId={currentTable}
-        datasourceId={datasource.id}
-        setError={setError}
-      />
+      {currentTable ? (
+        <DatasourceTableData
+          canRunQueries={canRunQueries}
+          tableId={currentTable}
+          datasourceId={datasource.id}
+          setError={setError}
+        />
+      ) : null}
     </div>
   );
 }

--- a/packages/front-end/components/SchemaBrowser/SchemaBrowserWrapper.tsx
+++ b/packages/front-end/components/SchemaBrowser/SchemaBrowserWrapper.tsx
@@ -17,8 +17,8 @@ export default function SchemaBrowserWrapper({
   children: React.ReactNode;
   datasourceName: string;
   datasourceId: string;
-  informationSchema: InformationSchemaInterface;
-  setError: (error: string) => void;
+  informationSchema?: InformationSchemaInterface;
+  setError: (error: string | null) => void;
   setFetching: (fetching: boolean) => void;
   canRunQueries: boolean;
   fetching: boolean;
@@ -59,7 +59,6 @@ export default function SchemaBrowserWrapper({
                 }
                 onClick={async (e) => {
                   e.preventDefault();
-                  // @ts-expect-error TS(2345) If you come across this, please fix it!: Argument of type 'null' is not assignable to param... Remove this comment to see the full error message
                   setError(null);
                   try {
                     await apiCall<{


### PR DESCRIPTION
### Features and Changes

If you changed the dataset for a datasource that already had a schema browser, it would struggle to update the old schemas since they no longer exist in the new datasource. This makes that process a bit safer by only trying to do the update logic on an old schema if it can find it

Before (when I switched datasources and the information schema had stale schemas that were not updating)
<img width="548" alt="Screenshot 2024-11-20 at 11 08 59 AM" src="https://github.com/user-attachments/assets/e8822b82-ef2c-4031-966e-5b6c4015b253">


After (shows only the new, appropriate schema)
<img width="607" alt="Screenshot 2024-11-20 at 11 29 10 AM" src="https://github.com/user-attachments/assets/eb382e69-8d2e-4e39-8da3-81014a8b36ee">
