### PR TITLE
fix attribute date targeting (date format)

### DIFF
--- a/packages/front-end/components/Features/ConditionInput.tsx
+++ b/packages/front-end/components/Features/ConditionInput.tsx
@@ -9,7 +9,7 @@ import {
 } from "react-icons/fa";
 import { RxLoop } from "react-icons/rx";
 import clsx from "clsx";
-import { datetime } from "shared/dates";
+import format from "date-fns/format";
 import {
   condToJson,
   jsonToConds,
@@ -525,7 +525,10 @@ export default function ConditionInput(props: Props) {
                         <DatePicker
                           date={value}
                           setDate={(v) => {
-                            handleCondsChange(v ? datetime(v) : "", "value");
+                            handleCondsChange(
+                              v ? format(v, "yyyy-MM-dd'T'HH:mm") : "",
+                              "value"
+                            );
                           }}
                           inputWidth={180}
                           containerClassName="col-sm-12 col-md mb-2"


### PR DESCRIPTION
Date-formatted attribute targeting rules were formatting as a date string when they should have used a short ISO string.