### PR TITLE
Init license for agenda jobs and sdk requests

### DIFF
--- a/packages/back-end/src/services/organizations.ts
+++ b/packages/back-end/src/services/organizations.ts
@@ -6,6 +6,7 @@ import {
   getLicense,
   isActiveSubscriptionStatus,
   isAirGappedLicenseKey,
+  licenseInit,
   postSubscriptionUpdateToLicenseServer,
 } from "enterprise";
 import {
@@ -80,6 +81,10 @@ import { getAllExperiments } from "back-end/src/models/ExperimentModel";
 import { LegacyExperimentPhase } from "back-end/types/experiment";
 import { addTags } from "back-end/src/models/TagModel";
 import { getUsersByIds } from "back-end/src/models/UserModel";
+import {
+  getLicenseMetaData,
+  getUserCodesForOrg,
+} from "back-end/src/services/licenseData";
 import {
   encryptParams,
   getSourceIntegrationObject,
@@ -1122,6 +1127,10 @@ export async function getContextForAgendaJobByOrgId(
   const organization = await findOrganizationById(orgId);
 
   if (!organization) throw new Error("Organization not found");
+
+  if (organization.licenseKey && !getLicense(organization.licenseKey)) {
+    await licenseInit(organization, getUserCodesForOrg, getLicenseMetaData);
+  }
 
   return getContextForAgendaJobByOrgObject(organization);
 }


### PR DESCRIPTION
### Features and Changes

We were not initializing licenses for SDK requests.  If it happened to be the first request since the server loaded the license wouldn't exist and they would be on the starter plan.  The SDK checks to see if they have enterprise before hashing attributes. This change makes sure we initialize the license when the `getFeaturesPublic` function calls `getContextForAgendaJobByOrgId`.  The function is a bit of a misnomer since it is called from `getFeaturesPublic` which is not an agenda Job.  Presumably Agenda jobs before this change also might not have had the license initialized for the org, though it is possible that none of them needed a license check.

There are a few other requests that also happen above the JWT middleware.  The apiRoute and scimRouter call the apiMiddleware that does the init.  
- `getEvaluatedFeaturesPublic`, `getExperimentConfig` and `getExperimentsScript` all call `getContextForAgendaJobByOrgId` and so should be covered by this change.
- `slackController.postIdeas` gets the org from the slack team, and does not call `getContextForAgendaJobByOrgId` but also does not do any permission checks
- `stripeController.postWebhook` is specifically for orgs that don't have a licenseKey
- The `/` route - just hardcodes data and does no permission checks.
- `robots.txt` `favicon.ico` and `healthcheck` are not tied to any org in anyway.

### Testing
Start the dev server.
Set up an org with a enterprise licenseKey.
Set up an sdk connection to have a ciphered SDK payload, but with 
Encrypt SDK payload `false`
and Hash Secure Attributes `true`.
Set up an attribute to be a SecureString from http://localhost:3000/attributes
Add a Feature with a rule that mentions that string from
Restart the dev server
hit the sdk endpoint: http://localhost:3100/api/features/[sdk-key]
see the attribute encrypted in the results.
