### PR TITLE
Don't check for the hash-secure-attributes permission

### DIFF
--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -3,7 +3,6 @@ import { createHash } from "crypto";
 import uniqid from "uniqid";
 import isEqual from "lodash/isEqual";
 import omit from "lodash/omit";
-import { orgHasPremiumFeature } from "enterprise";
 import {
   AutoExperiment,
   FeatureRule as FeatureDefinitionRule,
@@ -763,20 +762,13 @@ export async function getFeatureDefinitions({
   let attributes: SDKAttributeSchema | undefined = undefined;
   let secureAttributeSalt: string | undefined = undefined;
   if (hashSecureAttributes) {
-    if (orgHasPremiumFeature(context.org, "hash-secure-attributes")) {
-      secureAttributeSalt = context.org.settings?.secureAttributeSalt;
-      attributes = context.org.settings?.attributeSchema;
-    }
-  }
-  const savedGroups = await getAllSavedGroups(context.org.id);
-
-  if (
-    hashSecureAttributes &&
-    orgHasPremiumFeature(context.org, "hash-secure-attributes")
-  ) {
-    secureAttributeSalt = context.org?.settings?.secureAttributeSalt;
+    // Note: We don't check for whether the org has the hash-secure-attributes premium feature here because
+    // if they ever get downgraded for any reason we would be exposing secure attributes in the payload
+    // which would expose private data publicly.
+    secureAttributeSalt = context.org.settings?.secureAttributeSalt;
     attributes = context.org.settings?.attributeSchema;
   }
+  const savedGroups = await getAllSavedGroups(context.org.id);
 
   // Generate the feature definitions
   const features = await getAllFeatures(context);

--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -731,10 +731,11 @@ export async function getFeatureDefinitions({
         context.org.id
       );
       if (hashSecureAttributes) {
-        if (orgHasPremiumFeature(context.org, "hash-secure-attributes")) {
-          secureAttributeSalt = context.org.settings?.secureAttributeSalt;
-          attributes = context.org.settings?.attributeSchema;
-        }
+        // Note: We don't check for whether the org has the hash-secure-attributes premium feature here because
+        // if they ever get downgraded for any reason we would be exposing secure attributes in the payload
+        // which would expose private data publicly.
+        secureAttributeSalt = context.org.settings?.secureAttributeSalt;
+        attributes = context.org.settings?.attributeSchema;
       }
 
       return await getFeatureDefinitionsResponse({


### PR DESCRIPTION

### Features and Changes
Orgs can hash attributes in the sdk payload to avoid exposing private data publicly.  This is an enterprise feature.  We make sure that they can't set these properties on the org unless they are enterprise.  However if for whatever reason an org gets downgraded we would be exposing secure attributes in the payload which would expose private data publicly.  That is way worse than if a former enterprise customer gets away with using hashed attributes without paying which is not very likely.  So this change set gets rid of the check alltogether. 

### Testing
Start the dev server.
Set up an org with a enterprise licenseKey.
Set up an sdk connection to have a ciphered SDK payload, but with
Encrypt SDK payload false
and Hash Secure Attributes true.
Set up an attribute to be a SecureString from http://localhost:3000/attributes
Add a Feature with a rule that mentions that string from
In Mongo set licenseKey on the org to licenseKey2 instead getting rid of enterprise.
Restart the dev server
hit the sdk endpoint: [http://localhost:3100/api/features/[sdk-key]](http://localhost:3100/api/features/%5Bsdk-key%5D)
see the attribute encrypted in the results.