### PR TITLE
cleanup experiment variation editor value

### DIFF
--- a/packages/front-end/components/Experiment/EditVariationsForm.tsx
+++ b/packages/front-end/components/Experiment/EditVariationsForm.tsx
@@ -115,16 +115,14 @@ const EditVariationsForm: FC<{
           form.setValue(
             "variations",
             v.map((data) => {
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              const newData: any = { ...data };
-              newData.key = data.value;
-              delete newData.value;
+              const { value, ...newData } = data;
               return {
                 // default values
                 name: "",
                 description: "",
                 screenshots: [],
                 ...newData,
+                key: value,
               };
             })
           );

--- a/packages/front-end/components/Experiment/EditVariationsForm.tsx
+++ b/packages/front-end/components/Experiment/EditVariationsForm.tsx
@@ -112,13 +112,16 @@ const EditVariationsForm: FC<{
           form.setValue(
             "variations",
             v.map((data, i) => {
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              const newData: any = { ...data };
+              newData.key = data.value || `${i}`;
+              delete newData.value;
               return {
                 // default values
                 name: "",
                 description: "",
                 screenshots: [],
-                ...data,
-                key: data.value || `${i}` || "",
+                ...newData,
               };
             })
           );

--- a/packages/front-end/components/Experiment/EditVariationsForm.tsx
+++ b/packages/front-end/components/Experiment/EditVariationsForm.tsx
@@ -47,7 +47,10 @@ const EditVariationsForm: FC<{
       size="lg"
       submit={form.handleSubmit(async (value) => {
         const data = { ...value };
-        data.variations = [...data.variations];
+        data.variations = [...data.variations].map((variation, i) => {
+          if (!variation.key) variation.key = i + "";
+          return variation;
+        });
 
         // fix some common bugs
         if (!isBandit) {
@@ -111,10 +114,10 @@ const EditVariationsForm: FC<{
         setVariations={(v) => {
           form.setValue(
             "variations",
-            v.map((data, i) => {
+            v.map((data) => {
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
               const newData: any = { ...data };
-              newData.key = data.value || `${i}`;
+              newData.key = data.value;
               delete newData.value;
               return {
                 // default values


### PR DESCRIPTION
- don't send "value" to endpoint (unused field)
- validate key on save