### PR TITLE
Add CORS back to track calls temporarily

### DIFF
--- a/packages/front-end/services/track.ts
+++ b/packages/front-end/services/track.ts
@@ -94,8 +94,9 @@ const dataWareHouseTrack = async (event: DataWarehouseTrackedEvent) => {
         Accept: "application/json",
         "Content-Type": "application/json",
       },
-      credentials: "omit",
-      mode: "no-cors",
+      // TODO: Make ingestor accept text/plain content type so we can disable cors
+      //credentials: "omit",
+      //mode: "no-cors",
     });
   } catch (e) {
     if (inTelemetryDebugMode()) {


### PR DESCRIPTION
### Features and Changes

We need to make some changes to the ingestor endpoint to support text/plain calls before we can disable CORS.  The reason we want to disable CORS is so we can cut the number of requests in half (no OPTION request required).