### PR TITLE
Adds overflow scroll to InformationSchema table list to improve viewing

### DIFF
--- a/packages/front-end/pages/datasources/[did].tsx
+++ b/packages/front-end/pages/datasources/[did].tsx
@@ -402,6 +402,7 @@ mixpanel.init('YOUR PROJECT TOKEN', {
         <Modal
           trackingEventModalType=""
           open={true}
+          size={"lg"}
           close={() => setViewSchema(false)}
           closeCta="Close"
           header="Schema Browser"
@@ -411,7 +412,12 @@ mixpanel.init('YOUR PROJECT TOKEN', {
               Explore the schemas, tables, and table metadata of your connected
               datasource.
             </p>
-            <div className="border rounded">
+            <div
+              className="border rounded"
+              style={{
+                maxHeight: "calc(93vh - 140px)",
+              }}
+            >
               <SchemaBrowser datasource={d} />
             </div>
           </>

--- a/packages/front-end/pages/datasources/[did].tsx
+++ b/packages/front-end/pages/datasources/[did].tsx
@@ -406,21 +406,22 @@ mixpanel.init('YOUR PROJECT TOKEN', {
           close={() => setViewSchema(false)}
           closeCta="Close"
           header="Schema Browser"
+          overflowAuto={false}
         >
-          <>
+          <div className="d-flex row">
             <p>
               Explore the schemas, tables, and table metadata of your connected
               datasource.
             </p>
             <div
-              className="border rounded"
+              className="border rounded w-100"
               style={{
                 maxHeight: "calc(93vh - 140px)",
               }}
             >
               <SchemaBrowser datasource={d} />
             </div>
-          </>
+          </div>
         </Modal>
       )}
     </div>


### PR DESCRIPTION
### Features and Changes

The behavior of the SchemaBrowser was different, depending on if you viewed the SchemaBrowser via the Data Source page's "View Schema Browser" CTA or if you viewed it via the `Edit SQL Modal`.

Within the EditSQLModal, once a table was selected, the div displaying the tables would have a max height set and a scroll overflow, which make viewing the table's metadata easier. This wasn't happening when viewing the SchemaBrowser via the "View Schema Browser" CTA on the Data Source page, despite them using the same component.

I've updated the modal that opens via the "View Schema Browser" CTA so it has a maxHeight that matches that of the `EditSQLModal`.

Additionally, I've also increased the size (width) of the modal to make for a better viewing experience for our users.
