### PR TITLE
Adds project validation to create and update feature endpoints.

### DIFF
--- a/packages/back-end/src/api/features/postFeature.ts
+++ b/packages/back-end/src/api/features/postFeature.ts
@@ -85,6 +85,16 @@ export const postFeature = createApiRequestHandler(postFeatureValidator)(
       Object.keys(req.body.environments ?? {})
     );
 
+    // Validate projects - We can remove this validation when FeatureModel is migrated to BaseModel
+    if (req.body.project) {
+      const projects = await req.context.getProjects();
+      if (!projects.some((p) => p.id === req.body.project)) {
+        throw new Error(
+          `Project id ${req.body.project} is not a valid project.`
+        );
+      }
+    }
+
     const tags = req.body.tags || [];
 
     if (tags.length > 0) {

--- a/packages/back-end/src/api/features/updateFeature.ts
+++ b/packages/back-end/src/api/features/updateFeature.ts
@@ -56,6 +56,16 @@ export const updateFeature = createApiRequestHandler(updateFeatureValidator)(
       }
     }
 
+    // Validate projects - We can remove this validation when FeatureModel is migrated to BaseModel
+    if (project) {
+      const projects = await req.context.getProjects();
+      if (!projects.some((p) => p.id === req.body.project)) {
+        throw new Error(
+          `Project id ${req.body.project} is not a valid project.`
+        );
+      }
+    }
+
     // ensure environment keys are valid
     if (req.body.environments != null) {
       validateEnvKeys(orgEnvs, Object.keys(req.body.environments ?? {}));

--- a/packages/back-end/test/api/features.test.ts
+++ b/packages/back-end/test/api/features.test.ts
@@ -40,6 +40,7 @@ describe("features API", () => {
         canPublishFeature: () => true,
         canCreateFeature: () => true,
       },
+      getProjects: async () => [{ id: "project" }],
     });
 
     createFeature.mockImplementation((v) => v);


### PR DESCRIPTION
### Features and Changes

It was reported that we weren't doing any validation of the `project` property of the create or update REST API Endpoints for Features. As a result, an org could pass in a non-existent project Id and the feature would be created, but the UI would break as the project was invalid.

This PR adds validation to the create and update feature REST API endpoints.

It's worth noting that we're lacking this validation on a number of other resources - namely create and update requests for components that aren't built upon the `BaseModel` model. Any resources built upon the `BaseModel` have this logic built in.

If we like this approach, happy to add validation to the other resources as a stop-gap until we can migrate all of the resources over to the `BaseModel` model.

- Closes **(https://github.com/growthbook/growthbook/issues/3343)**

### Testing

- [x] Pass in a valid project when creating a new feature and ensure it works as expected
- [x] Pass in a valid project when updating an existing feature and ensure it works as expected
- [x] Pass in an invalid project id when creating a new feature and ensure an error is thrown and the feature is not created
- [x] Pass in an invalid project id when updating an existing feature and ensure an error is thrown and the feature is not created

