### PR TITLE
Support legacy "inline experiment" rule editing

### DIFF
--- a/packages/front-end/components/Features/Rule.tsx
+++ b/packages/front-end/components/Features/Rule.tsx
@@ -1,7 +1,7 @@
 import { FeatureInterface, FeatureRule } from "back-end/types/feature";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import React, { forwardRef } from "react";
+import React, { forwardRef, ReactElement } from "react";
 import {
   FaArrowsAlt,
   FaExclamationTriangle,
@@ -19,6 +19,7 @@ import Button from "@/components/Button";
 import DeleteButton from "@/components/DeleteButton/DeleteButton";
 import MoreMenu from "@/components/Dropdown/MoreMenu";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
+import HelperText from "@/components/Radix/HelperText";
 import ConditionDisplay from "./ConditionDisplay";
 import ForceSummary from "./ForceSummary";
 import RolloutSummary from "./RolloutSummary";
@@ -81,9 +82,23 @@ export const Rule = forwardRef<HTMLDivElement, RuleProps>(
     const allEnvironments = useEnvironments();
     const environments = filterEnvironmentsByFeature(allEnvironments, feature);
 
-    const title =
+    let title: string | ReactElement =
       rule.description ||
       rule.type[0].toUpperCase() + rule.type.slice(1) + " Rule";
+    if (rule.type === "experiment") {
+      title = (
+        <div className="d-flex align-items-center">
+          {title}
+          <Tooltip
+            body={`This is a legacy "inline experiment" feature rule. New experiment rules must be created as references to experiments.`}
+          >
+            <HelperText status="info" size="sm" ml="3">
+              legacy
+            </HelperText>
+          </Tooltip>
+        </div>
+      );
+    }
 
     const linkedExperiment =
       rule.type === "experiment-ref" && experimentsMap.get(rule.experimentId);

--- a/packages/front-end/components/Features/RuleModal/index.tsx
+++ b/packages/front-end/components/Features/RuleModal/index.tsx
@@ -728,7 +728,7 @@ export default function RuleModal({
         }
         step={step}
         setStep={setStep}
-        hideNav={ruleType !== "experiment-ref-new"}
+        hideNav={ruleType !== "experiment-ref-new" && ruleType !== "experiment"}
         backButton={true}
         onBackFirstStep={
           isNewRule ? () => setNewRuleOverviewPage(true) : undefined
@@ -795,7 +795,9 @@ export default function RuleModal({
           />
         ) : null}
 
-        {ruleType === "experiment-ref-new" && experimentType === "experiment"
+        {(ruleType === "experiment-ref-new" &&
+          experimentType === "experiment") ||
+        ruleType === "experiment"
           ? ["Overview", "Traffic", "Targeting"].map((p, i) => (
               <Page display={p} key={i}>
                 <ExperimentRefNewFields


### PR DESCRIPTION
As part of redesign work, we removed the ability to edit existing legacy experiment rules (which users haven't been able to create for about 2 years). This adds back some minimal editing and display capabilities.

<img width="1322" alt="image" src="https://github.com/user-attachments/assets/12d9684e-c298-4c65-ba7d-115caf6f96d6">
<img width="832" alt="image" src="https://github.com/user-attachments/assets/a0d5671f-c0bf-4821-a726-99177ed740db">
