### PR TITLE
Fixes issue with edit buttons not being displayed on experiment id page.

### DIFF
--- a/packages/front-end/components/Experiment/TabbedPage/index.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/index.tsx
@@ -124,8 +124,7 @@ export default function TabbedPage({
     return () => window.removeEventListener("hashchange", handler, false);
   }, [setTab]);
 
-  // const { phase, setPhase } = useSnapshot();
-  const phase = experiment.phases?.length - 1 || 0;
+  const { phase, setPhase } = useSnapshot();
 
   const variables = {
     experiment: experiment.name,
@@ -332,8 +331,7 @@ export default function TabbedPage({
                   role="button"
                   onClick={(e) => {
                     e.preventDefault();
-                    mutate();
-                    // setPhase(experiment.phases.length - 1);
+                    setPhase(experiment.phases.length - 1);
                   }}
                 >
                   Switch to the latest phase
@@ -366,14 +364,12 @@ export default function TabbedPage({
             experiment={experiment}
             mutate={mutate}
             safeToEdit={safeToEdit}
-            // editVariations={!viewingOldPhase ? editVariations : undefined}
             editVariations={editVariations}
             setFeatureModal={setFeatureModal}
             setVisualEditorModal={setVisualEditorModal}
             setUrlRedirectModal={setUrlRedirectModal}
             visualChangesets={visualChangesets}
             urlRedirects={urlRedirects}
-            // editTargeting={!viewingOldPhase ? editTargeting : undefined}
             editTargeting={editTargeting}
             linkedFeatures={linkedFeatures}
           />

--- a/packages/front-end/components/Experiment/TabbedPage/index.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/index.tsx
@@ -124,7 +124,8 @@ export default function TabbedPage({
     return () => window.removeEventListener("hashchange", handler, false);
   }, [setTab]);
 
-  const { phase, setPhase } = useSnapshot();
+  // const { phase, setPhase } = useSnapshot();
+  const phase = experiment.phases?.length - 1 || 0;
 
   const variables = {
     experiment: experiment.name,
@@ -331,7 +332,8 @@ export default function TabbedPage({
                   role="button"
                   onClick={(e) => {
                     e.preventDefault();
-                    setPhase(experiment.phases.length - 1);
+                    mutate();
+                    // setPhase(experiment.phases.length - 1);
                   }}
                 >
                   Switch to the latest phase
@@ -364,13 +366,15 @@ export default function TabbedPage({
             experiment={experiment}
             mutate={mutate}
             safeToEdit={safeToEdit}
-            editVariations={!viewingOldPhase ? editVariations : undefined}
+            // editVariations={!viewingOldPhase ? editVariations : undefined}
+            editVariations={editVariations}
             setFeatureModal={setFeatureModal}
             setVisualEditorModal={setVisualEditorModal}
             setUrlRedirectModal={setUrlRedirectModal}
             visualChangesets={visualChangesets}
             urlRedirects={urlRedirects}
-            editTargeting={!viewingOldPhase ? editTargeting : undefined}
+            // editTargeting={!viewingOldPhase ? editTargeting : undefined}
+            editTargeting={editTargeting}
             linkedFeatures={linkedFeatures}
           />
           {experiment.status !== "draft" && (


### PR DESCRIPTION
### Features and Changes

The `Overview` tab on an Experiment Id's page only deals with the latest phase, so we don't need to disable editing if an old phase is selected under the `Results` tab.

- Closes **(https://github.com/growthbook/growthbook/issues/3248)**
