### PR TITLE
Skip Preview step when closing PR

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -51,5 +51,6 @@ jobs:
 
       - name: Allocate public IP
         run: flyctl ips allocate-v4 --shared -a pr-${{ github.event.number }}-growthbook
+        if: ${{ github.event.action != 'closed' }}
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
### Features and Changes

Right now when we merge the PR the workflow is executed so we can clean the app on Fly, but it is currently failing because after removing the app we try to make sure it has an allocated ip address but the app does not exist anymore.

So we will skip this step when the PR is closed.