### PR TITLE
Use text/plain to send events to the ingestor

### DIFF
--- a/packages/front-end/services/track.ts
+++ b/packages/front-end/services/track.ts
@@ -92,11 +92,9 @@ const dataWareHouseTrack = async (event: DataWarehouseTrackedEvent) => {
       body: JSON.stringify(event),
       headers: {
         Accept: "application/json",
-        "Content-Type": "application/json",
+        "Content-Type": "text/plain",
       },
-      // TODO: Make ingestor accept text/plain content type so we can disable cors
-      //credentials: "omit",
-      //mode: "no-cors",
+      credentials: "omit",
     });
   } catch (e) {
     if (inTelemetryDebugMode()) {


### PR DESCRIPTION
### Features and Changes
Send plain/text.  This will cut the number of network calls in half by getting rid of OPTION requests. The body will still be JSON, only the content-type header is different.

### Dependencies
Needs to first land:
https://github.com/growthbook/growthbook-ingestor/pull/28

### Testing
In .env.local set: `INGESTOR_HOST=http://localhost:3003`
Load a page.
See in the dev console that only a single call gets sent to the /track endpoint (no option call) and that it returns a 200 response.
