### PR TITLE
Add an enable-debug mode for ingestor calls

### DIFF
--- a/packages/front-end/pages/api/init.ts
+++ b/packages/front-end/pages/api/init.ts
@@ -4,7 +4,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 import { stringToBoolean } from "shared/util";
 
 export interface EnvironmentInitValue {
-  telemetry: "debug" | "enable" | "disable" | "enable-debug";
+  telemetry: "debug" | "enable" | "disable" | "enable-with-debug";
   cloud: boolean;
   isMultiOrg?: boolean;
   allowSelfOrgCreation: boolean;
@@ -115,8 +115,8 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
     telemetry:
       DISABLE_TELEMETRY === "debug"
         ? "debug"
-        : DISABLE_TELEMETRY === "enable-debug"
-        ? "enable-debug"
+        : DISABLE_TELEMETRY === "enable-with-debug"
+        ? "enable-with-debug"
         : DISABLE_TELEMETRY
         ? "disable"
         : "enable",

--- a/packages/front-end/pages/api/init.ts
+++ b/packages/front-end/pages/api/init.ts
@@ -4,7 +4,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 import { stringToBoolean } from "shared/util";
 
 export interface EnvironmentInitValue {
-  telemetry: "debug" | "enable" | "disable";
+  telemetry: "debug" | "enable" | "disable" | "enable-debug";
   cloud: boolean;
   isMultiOrg?: boolean;
   allowSelfOrgCreation: boolean;
@@ -115,6 +115,8 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
     telemetry:
       DISABLE_TELEMETRY === "debug"
         ? "debug"
+        : DISABLE_TELEMETRY === "enable-debug"
+        ? "enable-debug"
         : DISABLE_TELEMETRY
         ? "disable"
         : "enable",

--- a/packages/front-end/services/env.ts
+++ b/packages/front-end/services/env.ts
@@ -64,10 +64,10 @@ export function showMultiOrgSelfSelector(): boolean {
   return env.showMultiOrgSelfSelector;
 }
 export function isTelemetryEnabled(): boolean {
-  return env.telemetry === "enable" || env.telemetry === "enable-debug";
+  return env.telemetry === "enable" || env.telemetry === "enable-with-debug";
 }
 export function inTelemetryDebugMode(): boolean {
-  return env.telemetry === "debug" || env.telemetry === "enable-debug";
+  return env.telemetry === "debug" || env.telemetry === "enable-with-debug";
 }
 export function hasFileConfig() {
   return env.config === "file";

--- a/packages/front-end/services/env.ts
+++ b/packages/front-end/services/env.ts
@@ -64,10 +64,10 @@ export function showMultiOrgSelfSelector(): boolean {
   return env.showMultiOrgSelfSelector;
 }
 export function isTelemetryEnabled(): boolean {
-  return env.telemetry === "enable";
+  return env.telemetry === "enable" || env.telemetry === "enable-debug";
 }
 export function inTelemetryDebugMode(): boolean {
-  return env.telemetry === "debug";
+  return env.telemetry === "debug" || env.telemetry === "enable-debug";
 }
 export function hasFileConfig() {
   return env.config === "file";

--- a/packages/front-end/services/track.ts
+++ b/packages/front-end/services/track.ts
@@ -87,15 +87,28 @@ const dataWareHouseTrack = async (event: DataWarehouseTrackedEvent) => {
   if (!isTelemetryEnabled()) return;
 
   try {
-    await fetch(`${getIngestorHost()}/track?client_key=${GB_SDK_ID}`, {
-      method: "POST",
-      body: JSON.stringify(event),
-      headers: {
-        Accept: "application/json",
-        "Content-Type": "text/plain",
-      },
-      credentials: "omit",
-    });
+    const result = await fetch(
+      `${getIngestorHost()}/track?client_key=${GB_SDK_ID}`,
+      {
+        method: "POST",
+        body: JSON.stringify(event),
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "text/plain",
+        },
+        credentials: "omit",
+      }
+    );
+    if (inTelemetryDebugMode()) {
+      if (!result.ok) {
+        console.error(
+          `Telemetry - Ingestor returned a ${result.status}`,
+          await result.json()
+        );
+      } else {
+        console.log("Telemetry - Successfully recorded event");
+      }
+    }
   } catch (e) {
     if (inTelemetryDebugMode()) {
       console.error("Failed to fire tracking event");

--- a/packages/front-end/services/track.ts
+++ b/packages/front-end/services/track.ts
@@ -86,33 +86,28 @@ const dataWareHouseTrack = async (event: DataWarehouseTrackedEvent) => {
   }
   if (!isTelemetryEnabled()) return;
 
+  let result;
   try {
-    const result = await fetch(
-      `${getIngestorHost()}/track?client_key=${GB_SDK_ID}`,
-      {
-        method: "POST",
-        body: JSON.stringify(event),
-        headers: {
-          Accept: "application/json",
-          "Content-Type": "text/plain",
-        },
-        credentials: "omit",
-      }
-    );
-    if (inTelemetryDebugMode()) {
-      if (!result.ok) {
-        console.error(
-          `Telemetry - Ingestor returned a ${result.status}`,
-          await result.json()
-        );
-      } else {
-        console.log("Telemetry - Successfully recorded event");
-      }
+    result = await fetch(`${getIngestorHost()}/track?client_key=${GB_SDK_ID}`, {
+      method: "POST",
+      body: JSON.stringify(event),
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "text/plain",
+      },
+      credentials: "omit",
+    });
+    if (!result.ok) {
+      throw new Error(`Telemetry - Ingestor returned a ${result.status}`);
     }
   } catch (e) {
     if (inTelemetryDebugMode()) {
-      console.error("Failed to fire tracking event");
-      console.error(e);
+      const body = await result?.json();
+      if (body) {
+        console.error(e.message, body);
+      } else {
+        console.error("Telemety - Failed to fire tracking event", e);
+      }
     }
   }
 };


### PR DESCRIPTION
### Features and Changes
In "debug" mode we don't actually send the telemetry data to the ingestor, but just output the event in the console.  So there was no way to actually see if the request failed to send, or had an error response since it was impossible to be both `isTelemetryEnabled()` and `inTelemetryDebugMode()`.  This PR adds an "enable-debug" mode.

### Dependencies
Needs to first land
https://github.com/growthbook/growthbook-ingestor/pull/28

### Testing

Set `DISABLE_TELEMETRY=enable-debug` in .env.local
In .env.local set: `INGESTOR_HOST=http://localhost:3003`
Load a page.
See in the dev console that only a single call gets sent to the /track endpoint (no option call) and that it returns a 200 response.
See the console.log "Telemetry Event - Successfully recorded event"
Edit track.ts to comment out one of the required properties in `dataWareHouseTrack()` call.
Reload the page.
See in the dev console that only a single call gets sent to the /track endpoint (no option call) and that it returns a 400 response.
See the console.log show "Tracking event - Ingestor returned a 400" with the body of the response.

