### PR TITLE
Fix cumulative ratio + quantile date cohort graph

### DIFF
--- a/packages/front-end/components/Experiment/ExperimentDateGraph.tsx
+++ b/packages/front-end/components/Experiment/ExperimentDateGraph.tsx
@@ -285,7 +285,6 @@ const ExperimentDateGraph: FC<ExperimentDateGraphProps> = ({
         }
       }
     }
-
     return filledDates;
   }, [_datapoints, cumulative, maxGapHours]);
 


### PR DESCRIPTION
### Features and Changes

Removes non-sense cumulative date cohort graph for quantiles.

Fixes cumulative denominator for ratio metric cumulative date cohort graph.

### Testing

Quantile metrics hide when toggling on Cumulative.

Ratio metrics change, haven't confirmed exact values.

### Screenshots

Quantile new state
![Screenshot 2024-12-03 at 11 10 55 AM](https://github.com/user-attachments/assets/46a45d4e-c345-4f5c-b482-a60277781659)
