### PR TITLE
Add Feature id validation to postFeature endpoint

### DIFF
--- a/packages/back-end/src/api/features/postFeature.ts
+++ b/packages/back-end/src/api/features/postFeature.ts
@@ -77,6 +77,12 @@ export const postFeature = createApiRequestHandler(postFeatureValidator)(
       throw new Error(`Feature id '${req.body.id}' already exists.`);
     }
 
+    if (!req.body.id.match(/^[a-zA-Z0-9_.:|-]+$/)) {
+      throw new Error(
+        "Feature keys can only include letters, numbers, hyphens, and underscores."
+      );
+    }
+
     const orgEnvs = getEnvironments(req.context.org);
 
     // ensure environment keys are valid


### PR DESCRIPTION
### Features and Changes

Previously, we weren't doing any validation on the `postFeature` Rest API endpoint when it came to the feature's id. Unlike our internal API, where we validate that the `id` only contains letters, numbers, hyphens, and underscores. This means, it was possible for an org to create a feature containing things like slashes, asterisks, etc via the REST API. The API would create them but then the features were not accessible via the UI.

This PR adds the same validation we use on our internal API to the `postFeature` rest api endpoint.

- Closes **(https://github.com/growthbook/growthbook/issues/3345)**

### Testing
 - [x] Create a feature that only contains letters, numbers, hyphens, and underscores, and ensure the feature is created correctly
 - [x] Create a feature who's id includes a slash, and ensure that the feature isn't created and an error is returned
 - [x] Create a feature who's id includes an asterisk, and ensure that the feature isn't created and an error is returned
 - [x] Create a feature who's id includes an ampersand, and ensure that the feature isn't created and an error is returned

