### PR TITLE
Make uncontrolled tabs use URL hash by default

### DIFF
--- a/packages/front-end/components/Radix/Tabs.tsx
+++ b/packages/front-end/components/Radix/Tabs.tsx
@@ -1,4 +1,5 @@
 import { Tabs as RadixTabs } from "@radix-ui/themes";
+import useURLHash from "@/hooks/useURLHash";
 
 /**
  * See more examples in design-system/index.tsx
@@ -16,11 +17,51 @@ import { Tabs as RadixTabs } from "@radix-ui/themes";
  * ```
  */
 
+type ControlledTabsProps = {
+  defaultValue?: never;
+  value?: string;
+};
+
+type UncontrolledTabsProps = {
+  defaultValue?: string;
+  value?: never;
+};
+
+type TabsProps = (ControlledTabsProps | UncontrolledTabsProps) &
+  Omit<React.ComponentProps<typeof RadixTabs.Root>, "defaultValue" | "value">;
+
 export function Tabs({
   children,
+  defaultValue,
+  value,
+  onValueChange,
   ...props
-}: React.ComponentProps<typeof RadixTabs.Root>) {
-  return <RadixTabs.Root {...props}>{children}</RadixTabs.Root>;
+}: TabsProps) {
+  let innerValue: string | undefined;
+  let innerOnValueChange: ((value: string) => void) | undefined;
+
+  // For uncontrolled tabs always set the value in URL
+  const [urlHash, setUrlHash] = useURLHash();
+  if (defaultValue) {
+    innerValue = urlHash ?? defaultValue;
+    innerOnValueChange = (value) => {
+      setUrlHash(value as string);
+      onValueChange?.(value);
+    };
+  } else {
+    innerValue = value;
+    innerOnValueChange = onValueChange;
+  }
+
+  return (
+    <RadixTabs.Root
+      value={innerValue}
+      onValueChange={innerOnValueChange}
+      {...props}
+    >
+      {children}
+    </RadixTabs.Root>
+  );
 }
 
 export function TabsList({

--- a/packages/front-end/hooks/useURLHash.ts
+++ b/packages/front-end/hooks/useURLHash.ts
@@ -1,7 +1,8 @@
 import { useEffect, useState } from "react";
 
 /**
- * Hook to sync a component's state with the URL hash
+ * Hook to sync a component's state with the URL hash.
+ * If validIds is provided, this hook will only update the URL hash if the new value is in the list of validIds.
  *
  * @param validIds - Array of valid hash values that this component can handle
  * @returns [currentHash, setHash] - Current hash value and function to update it
@@ -22,15 +23,21 @@ import { useEffect, useState } from "react";
  * );
  * ```
  */
-export default function useURLHash<Id extends string>(validIds: Id[]) {
+export default function useURLHash<Id extends string>(
+  validIds: Id[] | undefined = undefined
+) {
   const [hash, setHashState] = useState(() => {
-    // Get initial hash from URL, defaulting to first valid slug
+    // Get initial hash from URL
     const urlHash = window.location.hash.slice(1);
-    return validIds.includes(urlHash as Id) ? urlHash : undefined;
+    if (validIds === undefined) {
+      return urlHash === "" ? undefined : urlHash;
+    } else {
+      return validIds.includes(urlHash as Id) ? urlHash : undefined;
+    }
   });
 
   const setHashAndURL = (newHash: Id) => {
-    if (validIds.includes(newHash)) {
+    if (validIds === undefined || validIds.includes(newHash)) {
       window.location.hash = newHash;
     }
   };
@@ -39,8 +46,8 @@ export default function useURLHash<Id extends string>(validIds: Id[]) {
   useEffect(() => {
     const handler = () => {
       const newHash = window.location.hash.slice(1);
-      if (validIds.includes(newHash as Id)) {
-        setHashState(newHash);
+      if (validIds === undefined || validIds.includes(newHash as Id)) {
+        setHashState(newHash === "" ? undefined : newHash);
       }
     };
 

--- a/packages/front-end/pages/design-system/index.tsx
+++ b/packages/front-end/pages/design-system/index.tsx
@@ -34,7 +34,6 @@ import {
   TabsContent,
 } from "@/components/Radix/Tabs";
 import DatePicker from "@/components/DatePicker";
-import useURLHash from "@/hooks/useURLHash";
 
 export default function DesignSystemPage() {
   const [checked, setChecked] = useState<"indeterminate" | boolean>(false);
@@ -50,8 +49,7 @@ export default function DesignSystemPage() {
   const [sliderVal, setSliderVal] = useState(10);
   const [stepperStep, setStepperStep] = useState(0);
   const [selectValue, setSelectValue] = useState("carrot");
-  const [activeTab, setActiveTab] = useState("tab1");
-  const [tabInUrlHash, setUrlHash] = useURLHash(["tab1", "tab2"]);
+  const [activeControlledTab, setActiveControlledTab] = useState("tab1");
 
   return (
     <div className="pagecontents container-fluid">
@@ -667,14 +665,7 @@ export default function DesignSystemPage() {
         <Flex direction="column" gap="3">
           <Box>
             Uncontrolled tabs with persistance in the URL
-            <Tabs
-              value={tabInUrlHash ?? "tab1"}
-              onValueChange={(tab) => {
-                if (tab === "tab1" || tab === "tab2") {
-                  setUrlHash(tab);
-                }
-              }}
-            >
+            <Tabs defaultValue="tab1">
               <TabsList>
                 <TabsTrigger value="tab1">
                   <PiHourglassMedium style={{ color: "var(--accent-10)" }} />{" "}
@@ -693,7 +684,10 @@ export default function DesignSystemPage() {
           <Box>
             Tabs are lazy loaded by default, but you can use forceMount to
             disable this behavior (see console for output).
-            <Tabs value={activeTab} onValueChange={(tab) => setActiveTab(tab)}>
+            <Tabs
+              value={activeControlledTab}
+              onValueChange={(tab) => setActiveControlledTab(tab)}
+            >
               <TabsList>
                 <TabsTrigger value="tab1">Tab 1</TabsTrigger>
                 <TabsTrigger value="tab2">Tab 2</TabsTrigger>

--- a/packages/front-end/services/search.tsx
+++ b/packages/front-end/services/search.tsx
@@ -130,12 +130,32 @@ export function useSearch<T>({
       filtered = fuse.search(searchTerm).map((item) => item.item);
     }
     if (updateSearchQueryOnChange) {
-      const queryParams = value.length > 0 ? `?q=${encodeURI(value)}` : "";
-      router
-        .replace(router.pathname + queryParams, undefined, {
-          shallow: true,
-        })
-        .then();
+      const searchParams = new URLSearchParams(window.location.search);
+      const currentQ = searchParams.has("q") ? searchParams.get("q") : null;
+
+      const shouldRemoveQ = value.length === 0 && currentQ !== null;
+      const shouldSetQ = value !== currentQ;
+      const shouldUpdateURL = shouldRemoveQ || shouldSetQ;
+
+      if (shouldRemoveQ) {
+        searchParams.delete("q");
+      } else if (shouldSetQ) {
+        searchParams.set("q", value);
+      }
+
+      if (shouldUpdateURL) {
+        router
+          .replace(
+            router.pathname +
+              (searchParams.size > 0 ? `?${searchParams.toString()}` : "") +
+              window.location.hash,
+            undefined,
+            {
+              shallow: true,
+            }
+          )
+          .then();
+      }
     }
 
     // Search term filters


### PR DESCRIPTION
### Features and Changes

When using uncontrolled Tabs now we will store the hash in the URL by default.
If we want a different behavior we can use a controlled Tabs with `useURLHash` hook directly and any other option (like useLocalStorage).

Additionally had to do some updates to the `useSearch` hook to not modify the URL when it is not needed as React was complaining about it.
