### PR TITLE
Make the schema browser work for the built-in Growthbook datasource

### DIFF
--- a/packages/back-end/src/services/clickhouse.ts
+++ b/packages/back-end/src/services/clickhouse.ts
@@ -164,6 +164,14 @@ WHERE organization = '${orgId}';`,
   logger.info(`Granting select permissions on ${viewName} to ${user}`);
   await client.command({ query: `GRANT SELECT ON ${viewName} TO ${user}` });
 
+  logger.info(
+    `Granting select permissions on information_schema.columns to ${user}`
+  );
+  // For schema browser.  They can only see info on tables that they have select permissions on.
+  await client.command({
+    query: `GRANT SELECT(data_type, table_name, table_catalog, table_schema, column_name) ON information_schema.columns TO ${user}`,
+  });
+
   logger.info(`Clickhouse user ${user} created`);
 
   const url = new URL(CLICKHOUSE_HOST);

--- a/packages/front-end/components/SchemaBrowser/DatasourceTableData.tsx
+++ b/packages/front-end/components/SchemaBrowser/DatasourceTableData.tsx
@@ -1,3 +1,4 @@
+import { DataSourceInterfaceWithParams } from "back-end/types/datasource";
 import { InformationSchemaTablesInterface } from "back-end/src/types/Integration";
 import React, { useEffect, useState } from "react";
 import { FaRedo, FaTable } from "react-icons/fa";
@@ -7,6 +8,7 @@ import LoadingSpinner from "@/components/LoadingSpinner";
 import Tooltip from "@/components/Tooltip/Tooltip";
 
 type Props = {
+  datasource: DataSourceInterfaceWithParams;
   datasourceId: string;
   tableId: string;
   setError: (error: string | null) => void;
@@ -14,6 +16,7 @@ type Props = {
 };
 
 export default function DatasourceSchema({
+  datasource,
   tableId,
   datasourceId,
   setError,
@@ -91,7 +94,11 @@ export default function DatasourceSchema({
           <div>
             <FaTable />{" "}
             {table ? (
-              `${table.tableSchema}.${table.tableName}`
+              datasource.type === "growthbook_clickhouse" ? (
+                `${table.tableName}`
+              ) : (
+                `${table.tableSchema}.${table.tableName}`
+              )
             ) : (
               <LoadingSpinner />
             )}

--- a/packages/front-end/components/SchemaBrowser/SchemaBrowser.tsx
+++ b/packages/front-end/components/SchemaBrowser/SchemaBrowser.tsx
@@ -215,6 +215,12 @@ export default function SchemaBrowser({
                                   <FaAngleRight />
                                   {`${database.databaseName}.${schema.schemaName}`}
                                 </>
+                              ) : datasource.type ===
+                                "growthbook_clickhouse" ? (
+                                <>
+                                  <FaAngleRight />
+                                  Tables
+                                </>
                               ) : (
                                 <>
                                   <FaAngleRight />
@@ -229,6 +235,12 @@ export default function SchemaBrowser({
                                 <>
                                   <FaAngleDown />
                                   {`${database.databaseName}.${schema.schemaName}`}
+                                </>
+                              ) : datasource.type ===
+                                "growthbook_clickhouse" ? (
+                                <>
+                                  <FaAngleRight />
+                                  Tables
                                 </>
                               ) : (
                                 <>
@@ -300,6 +312,7 @@ export default function SchemaBrowser({
       {error && <div className="alert alert-danger mt-2 mb-0">{error}</div>}
       {currentTable ? (
         <DatasourceTableData
+          datasource={datasource}
           canRunQueries={canRunQueries}
           tableId={currentTable}
           datasourceId={datasource.id}


### PR DESCRIPTION
### Features and Changes

- Give the right permissions when creating a new in built datastore
- Show "Tables" as the database name for inbuilt Clickhouse
- Show just the table name as the table name, rather than also showing the schema name for inbuilt clickhouse.

### Testing
Go to /admin
Click Create Growthbook Datastore button on an org that does not have it
Change to that org
Go to the Data Sources page
Click on Schema Browser
See "Tables" -> "Events" Click "Events" and see the columns.
Edit a query and also see the Browser there.

### Screenshots
![Screenshot 2024-12-09 at 3 57 51 PM](https://github.com/user-attachments/assets/f0d7aeb7-cf9b-4494-9f9e-6201a1c11ac7)

![Screenshot 2024-12-09 at 3 58 11 PM](https://github.com/user-attachments/assets/0f3425d7-050f-4d5e-9207-fdc470ec6b81)
