### PR TITLE
Remove auto-refresh imports on EAQ save

### DIFF
--- a/packages/front-end/components/Experiment/ImportExperimentList.tsx
+++ b/packages/front-end/components/Experiment/ImportExperimentList.tsx
@@ -258,14 +258,34 @@ const ImportExperimentList: FC<{
           <Callout status="error" my="3">
             <p>Error importing experiments.</p>
             {datasource?.id && (
-              <p>
-                Your datasource&apos;s <em>Experiment Assignment Queries</em>{" "}
-                may be misconfigured.{" "}
-                <Link href={`/datasources/${datasource.id}?openAll=1`}>
-                  Edit the datasource
-                </Link>
-              </p>
+              <>
+                {!!datasource?.dateUpdated &&
+                datasource?.dateUpdated > data?.experiments?.dateUpdated ? (
+                  <p>
+                    Your datasource&apos;s{" "}
+                    <em>Experiment Assignment Queries</em> may have been
+                    misconfigured. The datasource has been modified since the
+                    last data refresh, so use the &apos;Get New Data&apos;
+                    button above to check if the issue has been resolved.
+                    Otherwise,{" "}
+                    <Link href={`/datasources/${datasource.id}?openAll=1`}>
+                      edit the datasource
+                    </Link>
+                    .
+                  </p>
+                ) : (
+                  <p>
+                    Your datasource&apos;s{" "}
+                    <em>Experiment Assignment Queries</em> may be misconfigured.{" "}
+                    <Link href={`/datasources/${datasource.id}?openAll=1`}>
+                      Edit the datasource
+                    </Link>
+                    .
+                  </p>
+                )}
+              </>
             )}
+
             <span>
               <ViewAsyncQueriesButton
                 queries={data.experiments.queries?.map((q) => q.query) ?? []}

--- a/packages/front-end/pages/datasources/[did].tsx
+++ b/packages/front-end/pages/datasources/[did].tsx
@@ -85,22 +85,9 @@ const DataSourcePage: FC = () => {
         method: "PUT",
         body: JSON.stringify(updates),
       });
-      const queriesUpdated =
-        d &&
-        JSON.stringify(d.settings?.queries) !==
-          JSON.stringify(dataSource.settings?.queries);
-      if (queriesUpdated) {
-        apiCall<{ id: string }>("/experiments/import", {
-          method: "POST",
-          body: JSON.stringify({
-            datasource: dataSource.id,
-            force: true,
-          }),
-        });
-      }
       await mutateDefinitions({});
     },
-    [mutateDefinitions, apiCall, d]
+    [mutateDefinitions, apiCall]
   );
 
   if (error) {


### PR DESCRIPTION
### Features and Changes

Rolls back #749 as it probably resulted in too many queries being run unnecessarily. We will no longer auto-update the imported experiments list when the EAQs change (this was happening even for users that didn't use the import modal, which is the majority of users).

Instead solves the issue of the import modal error message being unclear (#598) by stating that there has been an update to the Datasource and provide clearer information to let the user click "refresh" which does the same refresh that used to auto-run on the [did] page.

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

<!--
  Please describe how to test these changes.
 -->

### Screenshots

When datasource dateUpdated > import dateUpdated (and there is an error)
<img width="974" alt="Screenshot 2024-12-09 at 2 30 22 PM" src="https://github.com/user-attachments/assets/872b106d-0cc5-4e79-b49f-299f8289b8a5">

If there's an error but datasource dateUpdated is older than run attempt (status quo)
<img width="1404" alt="Screenshot 2024-12-09 at 2 34 38 PM" src="https://github.com/user-attachments/assets/388524f3-95be-4e74-96b4-4e6e1867c0a7">


Loom: https://www.loom.com/share/560478a7baae4c77b6b64aca515312e4
