### PR TITLE
Revert "Clean up orphaned feature rules on env deletion"

### DIFF
--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -3366,16 +3366,6 @@ paths:
       summary: Deletes a single environment
       parameters:
         - $ref: '#/components/parameters/id'
-      requestBody:
-        required: false
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                removeAssociatedFeatureRules:
-                  type: boolean
-                  description: Whether to also remove rules from features for the environment to be deleted
       tags:
         - environments
       operationId: deleteEnvironment

--- a/packages/back-end/src/api/environments/deleteEnvironment.ts
+++ b/packages/back-end/src/api/environments/deleteEnvironment.ts
@@ -4,7 +4,6 @@ import { deleteEnvironmentValidator } from "back-end/src/validators/openapi";
 import { updateOrganization } from "back-end/src/models/OrganizationModel";
 import { OrganizationInterface } from "back-end/types/organization";
 import { auditDetailsDelete } from "back-end/src/services/audit";
-import { removeEnvironmentFromFeatureRules } from "back-end/src/models/FeatureModel";
 
 export const deleteEnvironment = createApiRequestHandler(
   deleteEnvironmentValidator
@@ -13,7 +12,6 @@ export const deleteEnvironment = createApiRequestHandler(
     const id = req.params.id;
     const org = req.context.org;
     const environments = org.settings?.environments || [];
-    const { removeAssociatedFeatureRules } = req.body;
 
     const environment = environments.find((env) => env.id === id);
     if (!environment) {
@@ -31,11 +29,6 @@ export const deleteEnvironment = createApiRequestHandler(
     };
 
     await updateOrganization(org.id, updates);
-
-    if (removeAssociatedFeatureRules) {
-      // Asynchronously removes all feature rules that would be orphaned by deleting this environment
-      removeEnvironmentFromFeatureRules(req.context, id);
-    }
 
     await req.audit({
       event: "environment.delete",

--- a/packages/back-end/src/api/openapi/paths/deleteEnvironment.yaml
+++ b/packages/back-end/src/api/openapi/paths/deleteEnvironment.yaml
@@ -1,16 +1,6 @@
 summary: Deletes a single environment
 parameters:
   - $ref: "../parameters.yaml#/id"
-requestBody:
-  required: false
-  content:
-    application/json:
-      schema:
-        type: object
-        properties:
-          removeAssociatedFeatureRules:
-            type: boolean
-            description: "Whether to also remove rules from features for the environment to be deleted"
 tags:
   - environments
 operationId: deleteEnvironment

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -368,24 +368,6 @@ export async function deleteAllFeaturesForAProject({
   }
 }
 
-/**
- * Deletes rules for a given environment from all features
- */
-export async function removeEnvironmentFromFeatureRules(
-  context: ReqContext | ApiReqContext,
-  envId: string
-) {
-  const environmentKey = `environmentSettings.${envId}`;
-  const query = {
-    organization: context.org.id,
-    [environmentKey]: { $exists: true },
-  };
-
-  await FeatureModel.updateMany(query, {
-    $unset: { [environmentKey]: "" },
-  });
-}
-
 export const createFeatureEvent = async <
   Event extends ResourceEvents<"feature">
 >(eventData: {

--- a/packages/back-end/src/routers/environment/environment.controller.ts
+++ b/packages/back-end/src/routers/environment/environment.controller.ts
@@ -19,7 +19,6 @@ import { EventUserForResponseLocals } from "back-end/src/events/event-types";
 import { Environment } from "back-end/types/organization";
 import { addEnvironmentToOrganizationEnvironments } from "back-end/src/util/environments";
 import { updateOrganization } from "back-end/src/models/OrganizationModel";
-import { removeEnvironmentFromFeatureRules } from "back-end/src/models/FeatureModel";
 import {
   createEnvValidator,
   deleteEnvValidator,
@@ -310,15 +309,11 @@ export const postEnvironment = async (
 // endregion POST /environment
 
 export const deleteEnvironment = async (
-  req: AuthRequest<
-    { removeAssociatedFeatureRules: boolean },
-    DeleteEnvironmentProps
-  >,
+  req: AuthRequest<null, DeleteEnvironmentProps>,
   res: Response
 ) => {
-  const { id } = req.params;
+  const id = req.params.id;
   const context = getContextFromReq(req);
-  const { removeAssociatedFeatureRules } = req.body;
   const { org } = context;
 
   const existingEnvs = org.settings?.environments || [];
@@ -357,11 +352,6 @@ export const deleteEnvironment = async (
       organizationId: org.id,
       envId: id,
     });
-
-    if (removeAssociatedFeatureRules) {
-      // Asynchronously removes all feature rules that would be orphaned by deleting this environment
-      removeEnvironmentFromFeatureRules(context, id);
-    }
 
     res.status(200).json({
       status: 200,

--- a/packages/back-end/src/validators/openapi.ts
+++ b/packages/back-end/src/validators/openapi.ts
@@ -409,7 +409,7 @@ export const putEnvironmentValidator = {
 };
 
 export const deleteEnvironmentValidator = {
-  bodySchema: z.object({ "removeAssociatedFeatureRules": z.boolean().describe("Whether to also remove rules from features for the environment to be deleted").optional() }).strict(),
+  bodySchema: z.never(),
   querySchema: z.never(),
   paramsSchema: z.object({ "id": z.string() }).strict(),
 };

--- a/packages/back-end/types/openapi.d.ts
+++ b/packages/back-end/types/openapi.d.ts
@@ -6072,14 +6072,6 @@ export interface operations {
         id: string;
       };
     };
-    requestBody?: {
-      content: {
-        "application/json": {
-          /** @description Whether to also remove rules from features for the environment to be deleted */
-          removeAssociatedFeatureRules?: boolean;
-        };
-      };
-    };
     responses: {
       200: {
         content: {

--- a/packages/front-end/pages/environments.tsx
+++ b/packages/front-end/pages/environments.tsx
@@ -17,7 +17,6 @@ import EnvironmentModal from "@/components/Settings/EnvironmentModal";
 import DeleteButton from "@/components/DeleteButton/DeleteButton";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 import Button from "@/components/Radix/Button";
-import Checkbox from "@/components/Radix/Checkbox";
 
 const EnvironmentsPage: FC = () => {
   const { project } = useDefinitions();
@@ -40,7 +39,6 @@ const EnvironmentsPage: FC = () => {
   }, [sdkConnectionData]);
 
   const [showConnections, setShowConnections] = useState<number | null>(null);
-  const [deleteAssociatedRules, setDeleteAssociatedRules] = useState(false);
 
   const { refreshOrganization } = useUser();
   // const permissions = usePermissions();
@@ -270,25 +268,7 @@ const EnvironmentsPage: FC = () => {
                           }
                         >
                           <DeleteButton
-                            deleteMessage={
-                              <>
-                                <p>
-                                  Are you sure you want to delete this
-                                  environment?
-                                </p>
-                                <div>
-                                  <Checkbox
-                                    value={deleteAssociatedRules}
-                                    weight="regular"
-                                    setValue={(v) =>
-                                      setDeleteAssociatedRules(v === true)
-                                    }
-                                    label="Also delete feature rules associated with this
-                                  environment"
-                                  />
-                                </div>
-                              </>
-                            }
+                            deleteMessage="Are you you want to delete this environment?"
                             displayName={e.id}
                             className="dropdown-item text-danger"
                             text="Delete"
@@ -302,10 +282,8 @@ const EnvironmentsPage: FC = () => {
                                       (env) => env.id !== e.id
                                     ),
                                   },
-                                  removeAssociatedFeatureRules: deleteAssociatedRules,
                                 }),
                               });
-                              setDeleteAssociatedRules(false);
                               refreshOrganization();
                             }}
                             disabled={numConnections > 0}


### PR DESCRIPTION
Reverts growthbook/growthbook#3285

We're opting not to use this deletion logic because it adds more dependencies to environment forking and isn't necessary for performance reasons like I initially thought