### PR TITLE
api(teams): Add check for the org

### DIFF
--- a/packages/back-end/src/routers/teams/teams.controller.ts
+++ b/packages/back-end/src/routers/teams/teams.controller.ts
@@ -51,9 +51,7 @@ export const postTeam = async (
   const { name, description, permissions } = req.body;
 
   if (!orgHasPremiumFeature(org, "teams")) {
-    throw new Error(
-      "Must have a commercial License Key to restrict permissions by environment."
-    );
+    throw new Error("Must have a commercial License Key to create a team.");
   }
 
   if (!context.permissions.canManageTeam()) {

--- a/packages/back-end/src/routers/teams/teams.controller.ts
+++ b/packages/back-end/src/routers/teams/teams.controller.ts
@@ -1,5 +1,6 @@
 import type { Response } from "express";
 import { areProjectRolesValid, isRoleValid } from "shared/permissions";
+import { orgHasPremiumFeature } from "enterprise";
 import { TeamInterface } from "back-end/types/team";
 import {
   createTeam,
@@ -48,6 +49,12 @@ export const postTeam = async (
   const context = getContextFromReq(req);
   const { org, userName } = context;
   const { name, description, permissions } = req.body;
+
+  if (!orgHasPremiumFeature(org, "teams")) {
+    throw new Error(
+      "Must have a commercial License Key to restrict permissions by environment."
+    );
+  }
 
   if (!context.permissions.canManageTeam()) {
     context.permissions.throwPermissionError();


### PR DESCRIPTION
### Features and Changes

While the `teams` feature is available only for Enterprise licenses, we were not doing the proper check in the API.

This fixes it by validating the license when creating a team.