### PR TITLE
Coerce custom fields length into a boolean value to avoid rendering a 0 in NewExperimentForm

### DIFF
--- a/packages/front-end/components/Experiment/NewExperimentForm.tsx
+++ b/packages/front-end/components/Experiment/NewExperimentForm.tsx
@@ -599,7 +599,7 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
               </>
             )}
             {hasCommercialFeature("custom-metadata") &&
-              customFields?.length && (
+              !!customFields?.length && (
                 <CustomFieldInput
                   customFields={customFields}
                   form={form}


### PR DESCRIPTION
### Features and Changes

Right now if you have the `custom-metadata` feature, but no custom fields the overview tab of `NewExperimentForm` will render a 0 under tags. This PR coerces the custom fields length value into a boolean to simply render nothing if there are no custom fields.