### PR TITLE
Add retention window to retention metrics

### DIFF
--- a/packages/front-end/components/FactTables/FactMetricModal.tsx
+++ b/packages/front-end/components/FactTables/FactMetricModal.tsx
@@ -269,37 +269,50 @@ function getAggregationOptions(
 
 function RetentionWindowSelector({
   form,
+  isNew,
 }: {
   form: UseFormReturn<CreateFactMetricProps>;
+  isNew: boolean;
 }) {
+  const [useConversionWindow, setUseConversionWindow] = useState(
+    form.getValues("windowSettings.type") === "conversion"
+  );
+
   return (
     <div>
+      <label>Retention Window</label>
       <div className="appbox px-3 pt-3 bg-light">
         <div className="row align-items-center mb-3">
-          <div className="col-auto">Event must be at least</div>
+          <div className="col-auto" style={{ width: 60 }}>
+            Start:
+          </div>
           <div className="col-auto">
             <Field
               {...form?.register("windowSettings.delayValue", {
                 valueAsNumber: true,
               })}
               type="number"
-              min={1}
-              max={999}
+              max={99999}
               step={1}
               style={{ width: 70 }}
               required
               autoFocus
             />
           </div>
-          <div className="col-auto ">
+          <div className="col-auto">
             <SelectField
               value={form?.watch("windowSettings.delayUnit") ?? "days"}
               onChange={(value) => {
                 form.setValue(
                   "windowSettings.delayUnit",
-                  value as "days" | "hours" | "weeks"
+                  value as "minutes" | "hours" | "days" | "weeks"
+                );
+                form.setValue(
+                  "windowSettings.windowUnit",
+                  value as "minutes" | "hours" | "days" | "weeks"
                 );
               }}
+              style={{ width: 120 }}
               sort={false}
               options={[
                 {
@@ -322,6 +335,86 @@ function RetentionWindowSelector({
             />
           </div>
           <div className="col-auto">after experiment exposure</div>
+        </div>
+        <div className="row align-items-center mb-3" style={{ height: 38 }}>
+          <div className="col-auto" style={{ width: 60 }}>
+            End:
+          </div>
+          {useConversionWindow ? (
+            <>
+              <div className="col-auto">
+                <Field
+                  {...form?.register("windowSettings.windowValue", {
+                    valueAsNumber: true,
+                  })}
+                  type="number"
+                  min={form.watch("windowSettings.delayValue")}
+                  max={99999}
+                  step={1}
+                  style={{ width: 70 }}
+                  required
+                  autoFocus
+                />
+              </div>
+              <div className="col-auto">
+                <SelectField
+                  value={form?.watch("windowSettings.windowUnit")}
+                  onChange={() => {}}
+                  disabled={true}
+                  style={{ width: 120 }}
+                  sort={false}
+                  options={[
+                    {
+                      label: "Minutes",
+                      value: "minutes",
+                    },
+                    {
+                      label: "Hours",
+                      value: "hours",
+                    },
+                    {
+                      label: "Days",
+                      value: "days",
+                    },
+                    {
+                      label: "Weeks",
+                      value: "weeks",
+                    },
+                  ]}
+                />
+              </div>
+              <div className="col-auto">after experiment exposure</div>
+            </>
+          ) : (
+            <div className="col-auto">End of experiment</div>
+          )}
+          <div style={{ flex: 1 }} />
+          <div className="col-auto">
+            <a
+              href="#"
+              onClick={(e) => {
+                e.preventDefault();
+                if (!useConversionWindow) {
+                  form.setValue("windowSettings.type", "conversion");
+                  if (isNew) {
+                    form.setValue(
+                      "windowSettings.windowUnit",
+                      form.getValues("windowSettings.delayUnit")
+                    );
+                    form.setValue(
+                      "windowSettings.windowValue",
+                      form.getValues("windowSettings.delayValue")
+                    );
+                  }
+                } else {
+                  form.setValue("windowSettings.type", "");
+                }
+                setUseConversionWindow(!useConversionWindow);
+              }}
+            >
+              {`(${useConversionWindow ? "remove" : "add"} end date)`}
+            </a>
+          </div>
         </div>
       </div>
     </div>
@@ -842,39 +935,44 @@ function getWHERE({
         windowSettings.delayValue
       } ${windowSettings.delayUnit ?? "days"}')`
     );
-  } else if (windowSettings.delayValue) {
-    whereParts.push(
-      `-- Only after seeing the experiment + delay\ntimestamp > (exposure_timestamp + '${windowSettings.delayValue} ${windowSettings.delayUnit}')`
-    );
-  } else {
-    whereParts.push(
-      `-- Only after seeing the experiment\ntimestamp > exposure_timestamp`
-    );
-  }
 
-  if (windowSettings.type === "lookback") {
-    whereParts.push(
-      `-- Lookback Metric Window\ntimestamp > (NOW() - '${windowSettings.windowValue} ${windowSettings.windowUnit}')`
-    );
-  } else if (windowSettings.type === "conversion") {
-    if (type === "retention") {
+    if (windowSettings.type === "conversion") {
       whereParts.push(
-        `-- Conversion Metric Window\ntimestamp < (exposure_timestamp + '${
-          windowSettings.delayValue
-        } ${windowSettings.delayUnit ?? "days"}' + '${
-          windowSettings.windowValue
-        } ${windowSettings.windowUnit}')`
+        `timestamp < (exposure_timestamp + '${windowSettings.delayValue} ${
+          windowSettings.delayUnit ?? "days"
+        }' + '${windowSettings.windowValue - windowSettings.delayValue} ${
+          windowSettings.windowUnit
+        }')`
       );
-    } else if (windowSettings.delayValue) {
+    }
+  } else {
+    if (windowSettings.delayValue) {
       whereParts.push(
-        `-- Conversion Metric Window\ntimestamp < (exposure_timestamp + '${windowSettings.delayValue} ${windowSettings.delayUnit}' + '${windowSettings.windowValue} ${windowSettings.windowUnit}')`
+        `-- Only after seeing the experiment + delay\ntimestamp > (exposure_timestamp + '${windowSettings.delayValue} ${windowSettings.delayUnit}')`
       );
     } else {
       whereParts.push(
-        `-- Conversion Metric Window\ntimestamp < (exposure_timestamp + '${windowSettings.windowValue} ${windowSettings.windowUnit}')`
+        `-- Only after seeing the experiment\ntimestamp > exposure_timestamp`
       );
     }
+
+    if (windowSettings.type === "lookback") {
+      whereParts.push(
+        `-- Lookback Metric Window\ntimestamp > (NOW() - '${windowSettings.windowValue} ${windowSettings.windowUnit}')`
+      );
+    } else if (windowSettings.type === "conversion") {
+      if (windowSettings.delayValue) {
+        whereParts.push(
+          `-- Conversion Metric Window\ntimestamp < (exposure_timestamp + '${windowSettings.delayValue} ${windowSettings.delayUnit}' + '${windowSettings.windowValue} ${windowSettings.windowUnit}')`
+        );
+      } else {
+        whereParts.push(
+          `-- Conversion Metric Window\ntimestamp < (exposure_timestamp + '${windowSettings.windowValue} ${windowSettings.windowUnit}')`
+        );
+      }
+    }
   }
+
   if (
     type === "quantile" &&
     quantileSettings.type === "event" &&
@@ -1394,7 +1492,6 @@ export default function FactMetricModal({
   const showSQLPreview = true;
 
   const [showExperimentSQL, setShowExperimentSQL] = useState(false);
-
   const {
     datasources,
     getDatasourceById,
@@ -1574,6 +1671,21 @@ export default function FactMetricModal({
           values.numerator.column !== "$$distinctUsers"
         ) {
           values.numerator.column = "$$distinctUsers";
+        }
+
+        // reset conversion window for retention metrics
+        if (values.metricType === "retention") {
+          if (values.windowSettings.type === "conversion") {
+            values.windowSettings.windowUnit = values.windowSettings.delayUnit;
+            values.windowSettings.windowValue =
+              values.windowSettings.windowValue -
+              values.windowSettings.delayValue;
+            if (values.windowSettings.windowValue <= 0) {
+              throw new Error("Must use non-zero retention window length.");
+            }
+          } else {
+            values.windowSettings.type = "";
+          }
         }
 
         if (values.cappingSettings?.type) {
@@ -1924,15 +2036,12 @@ export default function FactMetricModal({
                     />
                   </div>
                   <div className="form-group">
-                    <RetentionWindowSelector form={form} />
+                    <RetentionWindowSelector form={form} isNew={isNew} />
                   </div>
                   <HelperText status="info">
                     The final metric value will be the percent of users in the
-                    experiment that match the retention event at least
-                    {` ${windowSettings?.windowValue || "X"} ${
-                      windowSettings?.windowUnit || "days"
-                    } `}
-                    after experiment exposure.
+                    experiment that match the retention event in the retention
+                    window above.
                   </HelperText>
                 </div>
               ) : type === "mean" ? (
@@ -2116,7 +2225,11 @@ export default function FactMetricModal({
                 <p>Select a metric type above</p>
               )}
 
-              <MetricWindowSettingsForm form={form} type={type} />
+              {type !== "retention" ? (
+                <MetricWindowSettingsForm form={form} type={type} />
+              ) : (
+                <div className="mb-3 mt-4"></div>
+              )}
 
               {!advancedOpen && (
                 <a

--- a/packages/front-end/components/Metrics/MetricTooltipBody.tsx
+++ b/packages/front-end/components/Metrics/MetricTooltipBody.tsx
@@ -98,6 +98,23 @@ const MetricTooltipBody = ({
     },
     {
       show:
+        (metric.windowSettings.delayValue ?? 0) !== 0 ||
+        metricOverrideFields.includes("delayHours"),
+      label:
+        isFactMetric(metric) && metric.metricType === "retention"
+          ? "Retention Window"
+          : "Metric Delay",
+      body: (
+        <>
+          {`${metric.windowSettings.delayValue} ${metric.windowSettings.delayUnit}`}
+          {metricOverrideFields.includes("delayHours") ? (
+            <small className="text-purple ml-1">(override)</small>
+          ) : null}
+        </>
+      ),
+    },
+    {
+      show:
         (!isNullUndefinedOrEmpty(metric.windowSettings.type) ||
           metricOverrideFields.includes("windowType")) &&
         (metric.windowSettings.windowValue !== 0 ||
@@ -112,23 +129,6 @@ const MetricTooltipBody = ({
             : ""}
           {metricOverrideFields.includes("windowType") ||
           metricOverrideFields.includes("windowHours") ? (
-            <small className="text-purple ml-1">(override)</small>
-          ) : null}
-        </>
-      ),
-    },
-    {
-      show:
-        (metric.windowSettings.delayValue ?? 0) !== 0 ||
-        metricOverrideFields.includes("delayHours"),
-      label:
-        isFactMetric(metric) && metric.metricType === "retention"
-          ? "Retention Window"
-          : "Metric Delay",
-      body: (
-        <>
-          {`${metric.windowSettings.delayValue} ${metric.windowSettings.delayUnit}`}
-          {metricOverrideFields.includes("delayHours") ? (
             <small className="text-purple ml-1">(override)</small>
           ) : null}
         </>

--- a/packages/front-end/pages/fact-metrics/[fmid].tsx
+++ b/packages/front-end/pages/fact-metrics/[fmid].tsx
@@ -7,6 +7,7 @@ import {
   getAggregateFilters,
   isBinomialMetric,
   isRatioMetric,
+  isRetentionMetric,
   quantileMetricType,
 } from "shared/experiments";
 import {
@@ -597,7 +598,29 @@ export default function FactMetricPage() {
           <div className="mb-4">
             <h3>Metric Window</h3>
             <div className="appbox p-3 mb-3">
-              {factMetric.windowSettings.type === "conversion" ? (
+              {isRetentionMetric(factMetric) ? (
+                <>
+                <em className="font-weight-bold">Retention Window</em>{" - "}{
+                  factMetric.windowSettings.type !== "conversion" ? (
+                    <>Require events to happen{" "}
+                    <strong>
+                      {factMetric.windowSettings.delayValue}{" "}
+                      {factMetric.windowSettings.delayUnit}
+                    </strong>{" "}
+                    after first experiment exposure.
+                  </>) :
+                  (<>Require events to happen between{" "}
+                    <strong>
+                      {factMetric.windowSettings.delayValue}</strong>{" and "}<strong>
+                      {factMetric.windowSettings.delayValue + factMetric.windowSettings.windowValue}{" "}
+                      {factMetric.windowSettings.delayUnit}
+                    </strong>{" "}
+                    after first experiment exposure.
+                  </>
+                  )
+                }
+              </>
+              ) : factMetric.windowSettings.type === "conversion" ? (
                 <>
                   <em className="font-weight-bold">Conversion Window</em> -
                   Require conversions to happen within{" "}
@@ -606,9 +629,7 @@ export default function FactMetricPage() {
                     {factMetric.windowSettings.windowUnit}
                   </strong>{" "}
                   of first experiment exposure
-                  {factMetric.metricType === "retention"
-                    ? " plus the retention window"
-                    : factMetric.windowSettings.delayValue
+                  {factMetric.windowSettings.delayValue
                     ? " plus the metric delay"
                     : ""}
                   .
@@ -627,9 +648,7 @@ export default function FactMetricPage() {
                 <>
                   <em className="font-weight-bold">Disabled</em> - Include all
                   metric data after first experiment exposure
-                  {factMetric.metricType === "retention"
-                    ? " plus the retention window"
-                    : factMetric.windowSettings.delayValue
+                  {factMetric.windowSettings.delayValue
                     ? " plus the metric delay"
                     : ""}
                   .
@@ -645,14 +664,12 @@ export default function FactMetricPage() {
               open={() => setEditOpen(true)}
               canOpen={canEdit}
             >
-              {factMetric.windowSettings.delayValue ? (
+              {factMetric.windowSettings.delayValue && !isRetentionMetric(factMetric) ? (
                 <RightRailSectionGroup type="custom" empty="" className="mt-3">
                   <ul className="right-rail-subsection list-unstyled mb-4">
                     <li className="mt-3 mb-1">
                       <span className="uppercase-title lg">
-                        {factMetric.metricType === "retention"
-                          ? "Retention Window"
-                          : "Metric Delay"}
+                        {"Metric Delay"}
                       </span>
                     </li>
                     <li className="mb-2">

--- a/packages/front-end/pages/fact-metrics/[fmid].tsx
+++ b/packages/front-end/pages/fact-metrics/[fmid].tsx
@@ -600,26 +600,31 @@ export default function FactMetricPage() {
             <div className="appbox p-3 mb-3">
               {isRetentionMetric(factMetric) ? (
                 <>
-                <em className="font-weight-bold">Retention Window</em>{" - "}{
-                  factMetric.windowSettings.type !== "conversion" ? (
-                    <>Require events to happen{" "}
-                    <strong>
-                      {factMetric.windowSettings.delayValue}{" "}
-                      {factMetric.windowSettings.delayUnit}
-                    </strong>{" "}
-                    after first experiment exposure.
-                  </>) :
-                  (<>Require events to happen between{" "}
-                    <strong>
-                      {factMetric.windowSettings.delayValue}</strong>{" and "}<strong>
-                      {factMetric.windowSettings.delayValue + factMetric.windowSettings.windowValue}{" "}
-                      {factMetric.windowSettings.delayUnit}
-                    </strong>{" "}
-                    after first experiment exposure.
-                  </>
-                  )
-                }
-              </>
+                  <em className="font-weight-bold">Retention Window</em>
+                  {" - "}
+                  {factMetric.windowSettings.type !== "conversion" ? (
+                    <>
+                      Require events to happen{" "}
+                      <strong>
+                        {factMetric.windowSettings.delayValue}{" "}
+                        {factMetric.windowSettings.delayUnit}
+                      </strong>{" "}
+                      after first experiment exposure.
+                    </>
+                  ) : (
+                    <>
+                      Require events to happen between{" "}
+                      <strong>{factMetric.windowSettings.delayValue}</strong>
+                      {" and "}
+                      <strong>
+                        {factMetric.windowSettings.delayValue +
+                          factMetric.windowSettings.windowValue}{" "}
+                        {factMetric.windowSettings.delayUnit}
+                      </strong>{" "}
+                      after first experiment exposure.
+                    </>
+                  )}
+                </>
               ) : factMetric.windowSettings.type === "conversion" ? (
                 <>
                   <em className="font-weight-bold">Conversion Window</em> -
@@ -664,7 +669,8 @@ export default function FactMetricPage() {
               open={() => setEditOpen(true)}
               canOpen={canEdit}
             >
-              {factMetric.windowSettings.delayValue && !isRetentionMetric(factMetric) ? (
+              {factMetric.windowSettings.delayValue &&
+              !isRetentionMetric(factMetric) ? (
                 <RightRailSectionGroup type="custom" empty="" className="mt-3">
                   <ul className="right-rail-subsection list-unstyled mb-4">
                     <li className="mt-3 mb-1">

--- a/packages/front-end/services/metrics.tsx
+++ b/packages/front-end/services/metrics.tsx
@@ -28,9 +28,9 @@ import {
   OrganizationSettings,
 } from "back-end/types/organization";
 import { DataSourceInterfaceWithParams } from "back-end/types/datasource";
+import cloneDeep from "lodash/cloneDeep";
 import { decimalToPercent } from "@/services/utils";
 import { getNewExperimentDatasourceDefaults } from "@/components/Experiment/NewExperimentForm";
-import cloneDeep from "lodash/cloneDeep";
 
 export function getInitialInlineFilters(
   factTable: FactTableInterface,
@@ -62,7 +62,6 @@ export function getDefaultFactMetricProps({
   existing?: Partial<FactMetricInterface>;
   initialFactTable?: FactTableInterface;
 }): CreateFactMetricProps {
-
   const defaultWindowSettings: MetricWindowSettings = {
     type: DEFAULT_FACT_METRIC_WINDOW,
     windowUnit: "days",
@@ -101,7 +100,9 @@ export function getDefaultFactMetricProps({
       value: 0,
     },
     quantileSettings: existing?.quantileSettings || null,
-    windowSettings: !!existing?.windowSettings ? cloneDeep<MetricWindowSettings>(existing.windowSettings) : defaultWindowSettings,
+    windowSettings: existing?.windowSettings
+      ? cloneDeep<MetricWindowSettings>(existing.windowSettings)
+      : defaultWindowSettings,
     winRisk: existing?.winRisk ?? DEFAULT_WIN_RISK_THRESHOLD,
     loseRisk: existing?.loseRisk ?? DEFAULT_LOSE_RISK_THRESHOLD,
     minPercentChange:
@@ -136,8 +137,12 @@ export function getDefaultFactMetricProps({
   };
 
   // add back in delay to make UI more intuitive
-  if (defaultProps.metricType === "retention" && defaultProps.windowSettings.type === "conversion") {
-    defaultProps.windowSettings.windowValue += defaultProps.windowSettings.delayValue;
+  if (
+    defaultProps.metricType === "retention" &&
+    defaultProps.windowSettings.type === "conversion"
+  ) {
+    defaultProps.windowSettings.windowValue +=
+      defaultProps.windowSettings.delayValue;
   }
 
   return defaultProps;


### PR DESCRIPTION
### Features and Changes

* Removes conversion window selection and instead puts the conversion window in the retention window filter, creating a more intuitive UI.
* Removes UI support for lookback windows for retention metrics, but still possible via API.

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

Created a few metrics, edited them, they work as expected.

### Screenshots
<img width="1471" alt="Screenshot 2024-12-16 at 1 48 47 PM" src="https://github.com/user-attachments/assets/10f749ed-3eef-4575-b980-b51e137754ea" />
<img width="1444" alt="Screenshot 2024-12-16 at 1 48 43 PM" src="https://github.com/user-attachments/assets/d31f9bfe-b1a9-46b6-a47e-d9faa1eb5a18" />
![Uploading Screenshot 2024-12-16 at 1.48.38 PM.png…]()
