### PR TITLE
Shareable experiments

### DIFF
--- a/packages/back-end/src/app.ts
+++ b/packages/back-end/src/app.ts
@@ -291,6 +291,15 @@ app.get(
   }),
   reportsController.getReportPublic
 );
+// public shareable experiments
+app.get(
+  "/api/experiment/public/:uid",
+  cors({
+    credentials: false,
+    origin: "*",
+  }),
+  experimentsController.getExperimentPublic
+);
 
 // Secret API routes (no JWT or CORS)
 app.use(

--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -1030,6 +1030,7 @@ export async function postExperiment(
     "banditBurnInUnit",
     "customFields",
     "shareLevel",
+    "uid",
   ];
   let changes: Changeset = {};
 

--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -356,8 +356,14 @@ export async function getExperimentPublic(
       message: "Experiment not found",
     });
   }
-  const phase = experiment.phases.length - 1;
+  if (experiment.shareLevel !== "public") {
+    return res.status(401).json({
+      message: "Unauthorized",
+    });
+  }
+
   const context = await getContextForAgendaJobByOrgId(experiment.organization);
+  const phase = experiment.phases.length - 1;
 
   const snapshot =
     (await getLatestSnapshot({

--- a/packages/back-end/src/controllers/reports.ts
+++ b/packages/back-end/src/controllers/reports.ts
@@ -40,7 +40,10 @@ import {
 import { AuthRequest } from "back-end/src/types/AuthRequest";
 import { getFactTableMap } from "back-end/src/models/FactTableModel";
 import { experimentAnalysisSettings } from "back-end/src/validators/experiments";
-import {createReportSnapshot, generateExperimentReportSSRData} from "back-end/src/services/reports";
+import {
+  createReportSnapshot,
+  generateExperimentReportSSRData,
+} from "back-end/src/services/reports";
 import { ExperimentResultsQueryRunner } from "back-end/src/queryRunners/ExperimentResultsQueryRunner";
 
 export async function postReportFromSnapshot(
@@ -254,10 +257,8 @@ export async function getReportPublic(
   const ssrData = await generateExperimentReportSSRData({
     context,
     organization: report.organization,
-    snapshot
+    snapshot,
   });
-
-  console.log({ssrData})
 
   res.status(200).json({
     status: 200,

--- a/packages/back-end/src/controllers/reports.ts
+++ b/packages/back-end/src/controllers/reports.ts
@@ -4,15 +4,12 @@ import { getValidDate } from "shared/dates";
 import { getSnapshotAnalysis } from "shared/util";
 import { pick, omit } from "lodash";
 import uniqid from "uniqid";
-import uniq from "lodash/uniq";
-import { expandMetricGroups } from "shared/experiments";
 import {
   ExperimentReportAnalysisSettings,
   ExperimentReportInterface,
   ExperimentSnapshotReportArgs,
   ExperimentSnapshotReportInterface,
   ReportInterface,
-  SSRExperimentReportData,
 } from "back-end/types/report";
 import {
   getExperimentById,
@@ -23,7 +20,7 @@ import {
   findLatestRunningSnapshotByReportId,
   findSnapshotById,
 } from "back-end/src/models/ExperimentSnapshotModel";
-import { getMetricMap, getMetricsByIds } from "back-end/src/models/MetricModel";
+import { getMetricMap } from "back-end/src/models/MetricModel";
 import {
   createReport,
   deleteReportById,
@@ -41,16 +38,9 @@ import {
   getContextFromReq,
 } from "back-end/src/services/organizations";
 import { AuthRequest } from "back-end/src/types/AuthRequest";
-import {
-  getFactTableMap,
-  getFactTablesByIds,
-} from "back-end/src/models/FactTableModel";
+import { getFactTableMap } from "back-end/src/models/FactTableModel";
 import { experimentAnalysisSettings } from "back-end/src/validators/experiments";
-import { FactMetricInterface } from "back-end/types/fact-table";
-import { MetricInterface } from "back-end/types/metric";
-import { OrganizationSettings } from "back-end/types/organization";
-import { findDimensionsByOrganization } from "back-end/src/models/DimensionModel";
-import { createReportSnapshot } from "back-end/src/services/reports";
+import {createReportSnapshot, generateExperimentReportSSRData} from "back-end/src/services/reports";
 import { ExperimentResultsQueryRunner } from "back-end/src/queryRunners/ExperimentResultsQueryRunner";
 
 export async function postReportFromSnapshot(
@@ -74,8 +64,6 @@ export async function postReportFromSnapshot(
     // fix a weird corruption in the model where formerly-empty Mongoose Map comes back missing:
     snapshot.health.traffic.dimension = {};
   }
-
-  // todo: hash dependencies so we can see if settings/inputs are stale
 
   const experiment = await getExperimentById(context, snapshot.experiment);
 
@@ -263,105 +251,13 @@ export async function getReportPublic(
     : undefined;
   const experiment = pick(_experiment, ["id", "name", "type"]);
 
-  const metricGroups = await context.models.metricGroups.getAll();
-  const experimentMetricIds = expandMetricGroups(
-    uniq([
-      ...(snapshot?.settings?.goalMetrics ?? []),
-      ...(snapshot?.settings?.secondaryMetrics ?? []),
-      ...(snapshot?.settings?.guardrailMetrics ?? []),
-    ]),
-    metricGroups
-  );
-
-  const metricIds = uniq([
-    ...experimentMetricIds,
-    ...(snapshot?.settings?.activationMetric
-      ? [snapshot?.settings?.activationMetric]
-      : []),
-  ]);
-
-  const metrics: MetricInterface[] = await getMetricsByIds(
+  const ssrData = await generateExperimentReportSSRData({
     context,
-    metricIds.filter((m) => m.startsWith("met_"))
-  );
-  const factMetrics: FactMetricInterface[] = await context.models.factMetrics.getByIds(
-    metricIds.filter((m) => m.startsWith("fact__"))
-  );
-
-  const denominatorMetricIds = uniq(
-    metrics
-      .filter((m) => !!m.denominator)
-      .map((m) => m.denominator)
-      .filter((id) => id && !metricIds.includes(id)) as string[]
-  );
-  const denominatorMetrics = await getMetricsByIds(
-    context,
-    denominatorMetricIds
-  );
-
-  const metricMap = [...metrics, ...factMetrics, ...denominatorMetrics].reduce(
-    (map, metric) =>
-      Object.assign(map, {
-        [metric.id]: omit(metric, [
-          "queries",
-          "runStarted",
-          "analysis",
-          "analysisError",
-          "table",
-          "column",
-          "timestampColumn",
-          "conditions",
-          "queryFormat",
-        ]),
-      }),
-    {}
-  );
-
-  let factTableIds: string[] = [];
-  factMetrics.forEach((m) => {
-    if (m?.numerator?.factTableId) factTableIds.push(m.numerator.factTableId);
-    if (m?.denominator?.factTableId)
-      factTableIds.push(m.denominator.factTableId);
+    organization: report.organization,
+    snapshot
   });
-  factTableIds = uniq(factTableIds);
-  const factTables = await getFactTablesByIds(context, factTableIds);
-  const factTableMap = factTables.reduce(
-    (map, factTable) => Object.assign(map, { [factTable.id]: factTable }),
-    {}
-  );
 
-  const allDimensions = await findDimensionsByOrganization(report.organization);
-  const dimension = allDimensions.find((d) => d.id === snapshot?.dimension);
-  const dimensions = dimension ? [dimension] : [];
-
-  const settingsKeys = [
-    "confidenceLevel",
-    "metricDefaults",
-    "multipleExposureMinPercent",
-    "statsEngine",
-    "pValueThreshold",
-    "pValueCorrection",
-    "regressionAdjustmentEnabled",
-    "regressionAdjustmentDays",
-    "srmThreshold",
-    "attributionModel",
-    "sequentialTestingEnabled",
-    "sequentialTestingTuningParameter",
-    "displayCurrency",
-  ];
-  const orgSettings: OrganizationSettings = pick(
-    context.org.settings,
-    settingsKeys
-  );
-  // todo: consider including experiment's project settings in future? likely not...
-
-  const ssrData: SSRExperimentReportData = {
-    metrics: metricMap,
-    metricGroups: metricGroups,
-    factTables: factTableMap,
-    settings: orgSettings,
-    dimensions,
-  };
+  console.log({ssrData})
 
   res.status(200).json({
     status: 200,

--- a/packages/back-end/src/models/ExperimentModel.ts
+++ b/packages/back-end/src/models/ExperimentModel.ts
@@ -81,6 +81,7 @@ const banditResultObject = {
 
 const experimentSchema = new mongoose.Schema({
   id: String,
+  uid: String,
   trackingKey: String,
   organization: {
     type: String,
@@ -248,6 +249,7 @@ const experimentSchema = new mongoose.Schema({
   banditBurnInValue: Number,
   banditBurnInUnit: String,
   customFields: {},
+  shareLevel: String,
 });
 
 type ExperimentDocument = mongoose.Document & ExperimentInterface;
@@ -305,6 +307,16 @@ export async function getExperimentById(
   return context.permissions.canReadSingleProjectResource(experiment.project)
     ? experiment
     : null;
+}
+
+export async function getExperimentByUid(
+  uid: string
+): Promise<ExperimentInterface | null> {
+  const doc = await getCollection(COLLECTION).findOne({
+    uid,
+  });
+
+  return doc ? toInterface(doc) : null;
 }
 
 export async function getAllExperiments(
@@ -431,6 +443,7 @@ export async function createExperiment({
 
   const exp = await ExperimentModel.create({
     id: uniqid("exp_"),
+    uid: uuidv4().replace(/-/g, ""),
     // If this is a sample experiment, we'll override the id with data.id
     ...data,
     //set the default phase seed to uuid

--- a/packages/back-end/src/services/reports.ts
+++ b/packages/back-end/src/services/reports.ts
@@ -62,7 +62,7 @@ import { DataSourceInterface } from "back-end/types/datasource";
 import { ReqContextClass } from "back-end/src/services/context";
 import { getMetricsByIds } from "back-end/src/models/MetricModel";
 import { findDimensionsByOrganization } from "back-end/src/models/DimensionModel";
-import {ProjectInterface} from "back-end/src/models/ProjectModel";
+import { ProjectInterface } from "back-end/types/project";
 
 export function getReportVariations(
   experiment: ExperimentInterface,
@@ -673,9 +673,13 @@ export async function generateExperimentReportSSRData({
     settingsKeys
   );
 
-  const projectObj = project ? (await context.models.projects.getById(project) || undefined) : undefined;
-  const _project: Partial<ProjectInterface> | undefined = projectObj ? pick(projectObj, ["name", "id", "settings"]) : undefined;
-  const projectMap = _project ? {[_project.id] : _project} : [];
+  const projectObj = project
+    ? (await context.models.projects.getById(project)) || undefined
+    : undefined;
+  const _project: ProjectInterface | undefined = projectObj
+    ? (pick(projectObj, ["name", "id", "settings"]) as ProjectInterface)
+    : undefined;
+  const projectMap = _project?.id ? { [_project.id]: _project } : {};
 
   return {
     metrics: metricMap,

--- a/packages/back-end/src/util/migrations.ts
+++ b/packages/back-end/src/util/migrations.ts
@@ -9,6 +9,7 @@ import { RESERVED_ROLE_IDS, getDefaultRole } from "shared/permissions";
 import { accountFeatures, getAccountPlan } from "enterprise";
 import { omit } from "lodash";
 import { SavedGroupInterface } from "shared/src/types";
+import { v4 as uuidv4 } from "uuid";
 import {
   ExperimentReportArgs,
   ExperimentReportInterface,
@@ -43,7 +44,6 @@ import {
 import { getEnvironments } from "back-end/src/services/organizations";
 import { LegacySavedGroupInterface } from "back-end/types/saved-group";
 import { DEFAULT_CONVERSION_WINDOW_HOURS } from "./secrets";
-import {v4 as uuidv4} from "uuid";
 
 function roundVariationWeight(num: number): number {
   return Math.round(num * 1000) / 1000;

--- a/packages/back-end/src/util/migrations.ts
+++ b/packages/back-end/src/util/migrations.ts
@@ -43,6 +43,7 @@ import {
 import { getEnvironments } from "back-end/src/services/organizations";
 import { LegacySavedGroupInterface } from "back-end/types/saved-group";
 import { DEFAULT_CONVERSION_WINDOW_HOURS } from "./secrets";
+import {v4 as uuidv4} from "uuid";
 
 function roundVariationWeight(num: number): number {
   return Math.round(num * 1000) / 1000;
@@ -619,6 +620,9 @@ export function upgradeExperimentDoc(
 
   if (!("shareLevel" in experiment)) {
     experiment.shareLevel = "organization";
+  }
+  if (!("uid" in experiment)) {
+    experiment.uid = uuidv4().replace(/-/g, "");
   }
 
   return experiment as ExperimentInterface;

--- a/packages/back-end/src/util/migrations.ts
+++ b/packages/back-end/src/util/migrations.ts
@@ -617,6 +617,10 @@ export function upgradeExperimentDoc(
     experiment.sequentialTestingTuningParameter = DEFAULT_SEQUENTIAL_TESTING_TUNING_PARAMETER;
   }
 
+  if (!("shareLevel" in experiment)) {
+    experiment.shareLevel = "organization";
+  }
+
   return experiment as ExperimentInterface;
 }
 

--- a/packages/back-end/src/validators/experiments.ts
+++ b/packages/back-end/src/validators/experiments.ts
@@ -220,7 +220,7 @@ export const experimentInterface = z
     banditBurnInValue: z.number().optional(),
     banditBurnInUnit: z.enum(["hours", "days"]).optional(),
     customFields: z.record(z.any()).optional(),
-    shareLevel: z.enum(["public", "organization", "private"]).optional(),
+    shareLevel: z.enum(["public", "organization"]).optional(),
   })
   .strict()
   .merge(experimentAnalysisSettings);

--- a/packages/back-end/src/validators/experiments.ts
+++ b/packages/back-end/src/validators/experiments.ts
@@ -161,6 +161,7 @@ export type ExperimentAnalysisSettings = z.infer<
 export const experimentInterface = z
   .object({
     id: z.string(),
+    uid: z.string().optional(),
     organization: z.string(),
     project: z.string().optional(),
     owner: z.string(),
@@ -219,6 +220,7 @@ export const experimentInterface = z
     banditBurnInValue: z.number().optional(),
     banditBurnInUnit: z.enum(["hours", "days"]).optional(),
     customFields: z.record(z.any()).optional(),
+    shareLevel: z.enum(["public", "organization", "private"]).optional(),
   })
   .strict()
   .merge(experimentAnalysisSettings);

--- a/packages/back-end/test/migrations.test.ts
+++ b/packages/back-end/test/migrations.test.ts
@@ -1177,6 +1177,7 @@ describe("Experiment Migration", () => {
         name: "New Name",
       },
     ],
+    uid: "1234",
   };
 
   const upgraded = {
@@ -1236,6 +1237,8 @@ describe("Experiment Migration", () => {
     ],
     sequentialTestingEnabled: false,
     sequentialTestingTuningParameter: DEFAULT_SEQUENTIAL_TESTING_TUNING_PARAMETER,
+    uid: "1234",
+    shareLevel: "organization",
   };
 
   it("upgrades experiment objects", () => {

--- a/packages/back-end/types/report.d.ts
+++ b/packages/back-end/types/report.d.ts
@@ -2,6 +2,7 @@ import { ExperimentMetricInterface } from "shared/experiments";
 import { OrganizationSettings } from "back-end/types/organization";
 import { MetricGroupInterface } from "back-end/types/metric-groups";
 import { DimensionInterface } from "back-end/types/dimension";
+import { ProjectInterface } from "back-end/src/models/ProjectModel";
 import { FactTableInterface, MetricPriorSettings } from "./fact-table";
 import {
   AttributionModel,
@@ -14,7 +15,6 @@ import {
 import { SnapshotVariation } from "./experiment-snapshot";
 import { Queries } from "./query";
 import { DifferenceType, StatsEngine } from "./stats";
-import {ProjectInterface} from "back-end/src/models/ProjectModel";
 
 export interface ReportInterfaceBase {
   id: string;
@@ -167,6 +167,6 @@ export type ExperimentReportSSRData = {
   metricGroups: MetricGroupInterface[];
   factTables: Record<string, FactTableInterface>;
   settings: OrganizationSettings;
-  projects: Record<string, Partial<ProjectInterface>>;
+  projects: Record<string, ProjectInterface>;
   dimensions: DimensionInterface[];
 };

--- a/packages/back-end/types/report.d.ts
+++ b/packages/back-end/types/report.d.ts
@@ -14,6 +14,7 @@ import {
 import { SnapshotVariation } from "./experiment-snapshot";
 import { Queries } from "./query";
 import { DifferenceType, StatsEngine } from "./stats";
+import {ProjectInterface} from "back-end/src/models/ProjectModel";
 
 export interface ReportInterfaceBase {
   id: string;
@@ -166,5 +167,6 @@ export type ExperimentReportSSRData = {
   metricGroups: MetricGroupInterface[];
   factTables: Record<string, FactTableInterface>;
   settings: OrganizationSettings;
+  projects: Record<string, Partial<ProjectInterface>>;
   dimensions: DimensionInterface[];
 };

--- a/packages/back-end/types/report.d.ts
+++ b/packages/back-end/types/report.d.ts
@@ -161,7 +161,7 @@ export type LegacyReportInterface = Omit<ExperimentReportInterface, "args"> & {
   };
 };
 
-export type SSRExperimentReportData = {
+export type ExperimentReportSSRData = {
   metrics: Record<string, ExperimentMetricInterface>;
   metricGroups: MetricGroupInterface[];
   factTables: Record<string, FactTableInterface>;

--- a/packages/front-end/components/Experiment/BanditSummaryTable.tsx
+++ b/packages/front-end/components/Experiment/BanditSummaryTable.tsx
@@ -270,9 +270,9 @@ export default function BanditSummaryTable({
                 <th
                   className="axis-col graph-cell"
                   style={{
-                    width: window.innerWidth < 900 ? graphCellWidth : undefined,
+                    width: (globalThis?.window?.innerWidth ?? 1000) < 900 ? graphCellWidth : undefined,
                     minWidth:
-                      window.innerWidth >= 900 ? graphCellWidth : undefined,
+                      (globalThis?.window?.innerWidth ?? 1000) >= 900 ? graphCellWidth : undefined,
                   }}
                 >
                   <div className="position-relative">

--- a/packages/front-end/components/Experiment/BanditSummaryTable.tsx
+++ b/packages/front-end/components/Experiment/BanditSummaryTable.tsx
@@ -13,6 +13,7 @@ import { TooltipHoverSettings } from "@/components/Experiment/ResultsTableToolti
 import { getExperimentMetricFormatter } from "@/services/metrics";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import { useCurrency } from "@/hooks/useCurrency";
+import { SSRPolyfills } from "@/hooks/useSSRPolyfills";
 import AlignedGraph from "./AlignedGraph";
 
 export const WIN_THRESHOLD_PROBABILITY = 0.95;
@@ -24,6 +25,7 @@ export type BanditSummaryTableProps = {
   metric: ExperimentMetricInterface | null;
   phase: number;
   isTabActive: boolean;
+  ssrPolyfills?: SSRPolyfills;
 };
 
 const numberFormatter = Intl.NumberFormat();
@@ -33,10 +35,14 @@ export default function BanditSummaryTable({
   metric,
   phase,
   isTabActive,
+  ssrPolyfills,
 }: BanditSummaryTableProps) {
-  const { getFactTableById } = useDefinitions();
-  const metricDisplayCurrency = useCurrency();
-  const metricFormatterOptions = { currency: metricDisplayCurrency };
+  const _displayCurrency = useCurrency();
+  const { getFactTableById: _getFactTableById } = useDefinitions();
+
+  const getFactTableById = ssrPolyfills?.getFactTableById || _getFactTableById;
+  const displayCurrency = ssrPolyfills?.useCurrency() || _displayCurrency;
+  const metricFormatterOptions = { currency: displayCurrency };
 
   const tableContainerRef = useRef<HTMLDivElement | null>(null);
   const [graphCellWidth, setGraphCellWidth] = useState(800);
@@ -222,6 +228,7 @@ export default function BanditSummaryTable({
           onPointerMove={resetTimeout}
           onClick={resetTimeout}
           onPointerLeave={leaveRow}
+          ssrPolyfills={ssrPolyfills}
         />
       </CSSTransition>
 
@@ -279,6 +286,7 @@ export default function BanditSummaryTable({
                       percent={false}
                       height={45}
                       metricForFormatting={metric}
+                      ssrPolyfills={ssrPolyfills}
                     />
                   </div>
                 </th>
@@ -428,6 +436,7 @@ export default function BanditSummaryTable({
                             offsetY: -8,
                           })
                         }
+                        ssrPolyfills={ssrPolyfills}
                       />
                     </td>
                   </tr>

--- a/packages/front-end/components/Experiment/BanditSummaryTable.tsx
+++ b/packages/front-end/components/Experiment/BanditSummaryTable.tsx
@@ -270,9 +270,14 @@ export default function BanditSummaryTable({
                 <th
                   className="axis-col graph-cell"
                   style={{
-                    width: (globalThis?.window?.innerWidth ?? 1000) < 900 ? graphCellWidth : undefined,
+                    width:
+                      (globalThis?.window?.innerWidth ?? 1000) < 900
+                        ? graphCellWidth
+                        : undefined,
                     minWidth:
-                      (globalThis?.window?.innerWidth ?? 1000) >= 900 ? graphCellWidth : undefined,
+                      (globalThis?.window?.innerWidth ?? 1000) >= 900
+                        ? graphCellWidth
+                        : undefined,
                   }}
                 >
                   <div className="position-relative">

--- a/packages/front-end/components/Experiment/BanditSummaryTableTooltip/BanditSummaryTooltip.tsx
+++ b/packages/front-end/components/Experiment/BanditSummaryTableTooltip/BanditSummaryTooltip.tsx
@@ -15,6 +15,7 @@ import { getExperimentMetricFormatter } from "@/services/metrics";
 import { useCurrency } from "@/hooks/useCurrency";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import { GBCuped } from "@/components/Icons";
+import { SSRPolyfills } from "@/hooks/useSSRPolyfills";
 
 export const TOOLTIP_WIDTH = 350;
 export const TOOLTIP_HEIGHT = 300; // Used for over/under layout calculation. Actual height may vary.
@@ -52,6 +53,7 @@ interface Props
   data?: TooltipData;
   tooltipOpen: boolean;
   close: () => void;
+  ssrPolyfills?: SSRPolyfills;
 }
 export default function BanditSummaryTooltip({
   left,
@@ -59,6 +61,7 @@ export default function BanditSummaryTooltip({
   data,
   tooltipOpen,
   close,
+  ssrPolyfills,
   ...otherProps
 }: Props) {
   useEffect(() => {
@@ -80,9 +83,12 @@ export default function BanditSummaryTooltip({
     };
   }, [data, tooltipOpen, close]);
 
-  const metricDisplayCurrency = useCurrency();
-  const metricFormatterOptions = { currency: metricDisplayCurrency };
-  const { getFactTableById } = useDefinitions();
+  const _displayCurrency = useCurrency();
+  const { getFactTableById: _getFactTableById } = useDefinitions();
+
+  const getFactTableById = ssrPolyfills?.getFactTableById || _getFactTableById;
+  const displayCurrency = ssrPolyfills?.useCurrency() || _displayCurrency;
+  const metricFormatterOptions = { currency: displayCurrency };
 
   if (!data) {
     return null;

--- a/packages/front-end/components/Experiment/LinkedChanges/FeatureLinkedChanges.tsx
+++ b/packages/front-end/components/Experiment/LinkedChanges/FeatureLinkedChanges.tsx
@@ -14,7 +14,7 @@ export default function FeatureLinkedChanges({
   experiment,
   canAddChanges,
 }: {
-  setFeatureModal: (open: boolean) => void;
+  setFeatureModal?: (open: boolean) => void;
   linkedFeatures: LinkedFeatureInfo[];
   experiment: ExperimentInterfaceStringDates;
   canAddChanges: boolean;
@@ -29,7 +29,7 @@ export default function FeatureLinkedChanges({
       type="feature-flag"
       experimentStatus={experiment.status}
       onAddChange={() => {
-        setFeatureModal(true);
+        setFeatureModal?.(true);
         track("Open linked feature modal", {
           source: "linked-changes",
           action: "add",

--- a/packages/front-end/components/Experiment/LinkedChanges/FeatureLinkedChanges.tsx
+++ b/packages/front-end/components/Experiment/LinkedChanges/FeatureLinkedChanges.tsx
@@ -52,7 +52,7 @@ export default function FeatureLinkedChanges({
             <LinkedFeatureFlag info={info} experiment={experiment} key={i} />
           ))}
         </>
-      ): null}
+      ) : null}
     </LinkedChangesContainer>
   );
 }

--- a/packages/front-end/components/Experiment/LinkedChanges/FeatureLinkedChanges.tsx
+++ b/packages/front-end/components/Experiment/LinkedChanges/FeatureLinkedChanges.tsx
@@ -13,11 +13,13 @@ export default function FeatureLinkedChanges({
   linkedFeatures,
   experiment,
   canAddChanges,
+  isPublic,
 }: {
   setFeatureModal?: (open: boolean) => void;
   linkedFeatures: LinkedFeatureInfo[];
   experiment: ExperimentInterfaceStringDates;
   canAddChanges: boolean;
+  isPublic?: boolean;
 }) {
   const featureFlagCount = linkedFeatures.length;
   const hasDraftFeatures = linkedFeatures.some((lf) => lf.state === "draft");
@@ -36,19 +38,21 @@ export default function FeatureLinkedChanges({
         });
       }}
     >
-      <>
-        {hasDraftFeatures && (
-          <div className="alert alert-info my-3">
-            <FaInfoCircle className="mr-2" />
-            Features in <strong>Draft</strong> mode will not allow experiments
-            to run. Publish Feature from the Feature Flag detail page to
-            unblock.
-          </div>
-        )}
-        {linkedFeatures.map((info, i) => (
-          <LinkedFeatureFlag info={info} experiment={experiment} key={i} />
-        ))}
-      </>
+      {!isPublic ? (
+        <>
+          {hasDraftFeatures ? (
+            <div className="alert alert-info my-3">
+              <FaInfoCircle className="mr-2" />
+              Features in <strong>Draft</strong> mode will not allow experiments
+              to run. Publish Feature from the Feature Flag detail page to
+              unblock.
+            </div>
+          ) : null}
+          {linkedFeatures.map((info, i) => (
+            <LinkedFeatureFlag info={info} experiment={experiment} key={i} />
+          ))}
+        </>
+      ): null}
     </LinkedChangesContainer>
   );
 }

--- a/packages/front-end/components/Experiment/LinkedChanges/LinkedChangesContainer.tsx
+++ b/packages/front-end/components/Experiment/LinkedChanges/LinkedChangesContainer.tsx
@@ -11,7 +11,7 @@ import {
 export interface Props {
   type: LinkedChange;
   canAddChanges: boolean;
-  children: JSX.Element;
+  children: JSX.Element | null;
   changeCount: number;
   experimentStatus: ExperimentStatus;
   onAddChange: () => void;
@@ -38,7 +38,7 @@ export default function LinkedChangesContainer({
 
   return (
     <div className="appbox px-4 py-3 mb-4">
-      <div className="d-flex mb-3 align-items-center">
+      <div className={`d-flex mb-${children ? "3" : "0"} align-items-center`}>
         <span
           className="mr-3"
           style={{
@@ -64,7 +64,7 @@ export default function LinkedChangesContainer({
             <div className="h4 mb-0 align-self-center">
               {header}{" "}
               {!!changeCount && (
-                <small className="text-muted">({changeCount})</small>
+                <span className="font-weight-normal">({changeCount})</span>
               )}
             </div>
             {canAddChanges ? (

--- a/packages/front-end/components/Experiment/LinkedChanges/RedirectLinkedChanges.tsx
+++ b/packages/front-end/components/Experiment/LinkedChanges/RedirectLinkedChanges.tsx
@@ -114,7 +114,7 @@ const Redirect = ({
                   await apiCall(`/url-redirects/${urlRedirect.id}`, {
                     method: "DELETE",
                   });
-                  mutate();
+                  mutate?.();
                 }}
               >
                 Remove

--- a/packages/front-end/components/Experiment/LinkedChanges/RedirectLinkedChanges.tsx
+++ b/packages/front-end/components/Experiment/LinkedChanges/RedirectLinkedChanges.tsx
@@ -16,6 +16,7 @@ interface RedirectLinkedChangesProps {
   experiment: ExperimentInterfaceStringDates;
   canAddChanges: boolean;
   mutate?: () => void;
+  isPublic?: boolean;
 }
 
 interface RedirectProps {
@@ -182,6 +183,7 @@ export default function RedirectLinkedChanges({
   experiment,
   canAddChanges,
   mutate,
+  isPublic,
 }: RedirectLinkedChangesProps) {
   const redirectCount = urlRedirects.length;
 
@@ -193,18 +195,20 @@ export default function RedirectLinkedChanges({
       type="redirects"
       onAddChange={() => setUrlRedirectModal?.(true)}
     >
-      <div>
-        {urlRedirects.map((r, i) => (
-          <div className={i > 0 ? "mt-3" : undefined} key={r.id}>
-            <Redirect
-              urlRedirect={r}
-              experiment={experiment}
-              mutate={mutate}
-              canEdit={canAddChanges}
-            />
-          </div>
-        ))}
-      </div>
+      {!isPublic ? (
+        <>
+          {urlRedirects.map((r, i) => (
+            <div className={i > 0 ? "mt-3" : undefined} key={r.id}>
+              <Redirect
+                urlRedirect={r}
+                experiment={experiment}
+                mutate={mutate}
+                canEdit={canAddChanges}
+              />
+            </div>
+          ))}
+        </>
+      ): null}
     </LinkedChangesContainer>
   );
 }

--- a/packages/front-end/components/Experiment/LinkedChanges/RedirectLinkedChanges.tsx
+++ b/packages/front-end/components/Experiment/LinkedChanges/RedirectLinkedChanges.tsx
@@ -11,18 +11,18 @@ import Tooltip from "@/components/Tooltip/Tooltip";
 import Link from "@/components/Radix/Link";
 
 interface RedirectLinkedChangesProps {
-  setUrlRedirectModal: (boolean) => void;
+  setUrlRedirectModal?: (boolean) => void;
   urlRedirects: URLRedirectInterface[];
   experiment: ExperimentInterfaceStringDates;
   canAddChanges: boolean;
-  mutate: () => void;
+  mutate?: () => void;
 }
 
 interface RedirectProps {
   urlRedirect: URLRedirectInterface;
   experiment: ExperimentInterfaceStringDates;
   canEdit: boolean;
-  mutate: () => void;
+  mutate?: () => void;
 }
 
 function UrlDifferenceRenderer({ url1, url2 }: { url1: string; url2: string }) {
@@ -77,7 +77,7 @@ const Redirect = ({
 
   return (
     <>
-      {editingRedirect ? (
+      {editingRedirect && mutate ? (
         <UrlRedirectModal
           mode="edit"
           experiment={experiment}
@@ -191,7 +191,7 @@ export default function RedirectLinkedChanges({
       changeCount={redirectCount}
       experimentStatus={experiment.status}
       type="redirects"
-      onAddChange={() => setUrlRedirectModal(true)}
+      onAddChange={() => setUrlRedirectModal?.(true)}
     >
       <div>
         {urlRedirects.map((r, i) => (

--- a/packages/front-end/components/Experiment/LinkedChanges/RedirectLinkedChanges.tsx
+++ b/packages/front-end/components/Experiment/LinkedChanges/RedirectLinkedChanges.tsx
@@ -208,7 +208,7 @@ export default function RedirectLinkedChanges({
             </div>
           ))}
         </>
-      ): null}
+      ) : null}
     </LinkedChangesContainer>
   );
 }

--- a/packages/front-end/components/Experiment/LinkedChanges/VisualLinkedChanges.tsx
+++ b/packages/front-end/components/Experiment/LinkedChanges/VisualLinkedChanges.tsx
@@ -44,7 +44,7 @@ export default function VisualLinkedChanges({
           mutate={mutate}
           canEditVisualChangesets={canEditVisualChangesets}
         />
-      ): null}
+      ) : null}
     </LinkedChangesContainer>
   );
 }

--- a/packages/front-end/components/Experiment/LinkedChanges/VisualLinkedChanges.tsx
+++ b/packages/front-end/components/Experiment/LinkedChanges/VisualLinkedChanges.tsx
@@ -1,6 +1,8 @@
 import track from "@/services/track";
 import { VisualChangesetTable } from "@/components/Experiment/VisualChangesetTable";
 import LinkedChangesContainer from "@/components/Experiment/LinkedChanges/LinkedChangesContainer";
+import {VisualChangesetInterface} from "back-end/types/visual-changeset";
+import {ExperimentInterfaceStringDates} from "back-end/types/experiment";
 
 export default function VisualLinkedChanges({
   setVisualEditorModal,
@@ -9,6 +11,13 @@ export default function VisualLinkedChanges({
   mutate,
   canAddChanges,
   canEditVisualChangesets,
+}: {
+  setVisualEditorModal?: (b: boolean) => void;
+  visualChangesets: VisualChangesetInterface[];
+  experiment: ExperimentInterfaceStringDates;
+  mutate?: () => void;
+  canAddChanges: boolean;
+  canEditVisualChangesets;
 }) {
   const visualChangeCount = visualChangesets.length;
 
@@ -19,7 +28,7 @@ export default function VisualLinkedChanges({
       changeCount={visualChangeCount}
       experimentStatus={experiment.status}
       onAddChange={() => {
-        setVisualEditorModal(true);
+        setVisualEditorModal?.(true);
         track("Open visual editor modal", {
           source: "visual-editor-ui",
           action: "add",

--- a/packages/front-end/components/Experiment/LinkedChanges/VisualLinkedChanges.tsx
+++ b/packages/front-end/components/Experiment/LinkedChanges/VisualLinkedChanges.tsx
@@ -11,13 +11,15 @@ export default function VisualLinkedChanges({
   mutate,
   canAddChanges,
   canEditVisualChangesets,
+  isPublic,
 }: {
   setVisualEditorModal?: (b: boolean) => void;
   visualChangesets: VisualChangesetInterface[];
   experiment: ExperimentInterfaceStringDates;
   mutate?: () => void;
   canAddChanges: boolean;
-  canEditVisualChangesets;
+  canEditVisualChangesets: boolean;
+  isPublic?: boolean;
 }) {
   const visualChangeCount = visualChangesets.length;
 
@@ -35,12 +37,14 @@ export default function VisualLinkedChanges({
         });
       }}
     >
-      <VisualChangesetTable
-        experiment={experiment}
-        visualChangesets={visualChangesets}
-        mutate={mutate}
-        canEditVisualChangesets={canEditVisualChangesets}
-      />
+      {!isPublic ? (
+        <VisualChangesetTable
+          experiment={experiment}
+          visualChangesets={visualChangesets}
+          mutate={mutate}
+          canEditVisualChangesets={canEditVisualChangesets}
+        />
+      ): null}
     </LinkedChangesContainer>
   );
 }

--- a/packages/front-end/components/Experiment/LinkedChanges/VisualLinkedChanges.tsx
+++ b/packages/front-end/components/Experiment/LinkedChanges/VisualLinkedChanges.tsx
@@ -1,8 +1,8 @@
+import { VisualChangesetInterface } from "back-end/types/visual-changeset";
+import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
 import track from "@/services/track";
 import { VisualChangesetTable } from "@/components/Experiment/VisualChangesetTable";
 import LinkedChangesContainer from "@/components/Experiment/LinkedChanges/LinkedChangesContainer";
-import {VisualChangesetInterface} from "back-end/types/visual-changeset";
-import {ExperimentInterfaceStringDates} from "back-end/types/experiment";
 
 export default function VisualLinkedChanges({
   setVisualEditorModal,

--- a/packages/front-end/components/Experiment/Public/PublicExperimentAnalysisSettingsBar.tsx
+++ b/packages/front-end/components/Experiment/Public/PublicExperimentAnalysisSettingsBar.tsx
@@ -1,0 +1,141 @@
+import { ExperimentSnapshotInterface } from "back-end/types/experiment-snapshot";
+import { getSnapshotAnalysis } from "shared/util";
+import { ago, date, datetime } from "shared/dates";
+import { PiEye } from "react-icons/pi";
+import {ExperimentInterfaceStringDates} from "back-end/types/experiment";
+import { SSRPolyfills } from "@/hooks/useSSRPolyfills";
+import DimensionChooser from "@/components/Dimensions/DimensionChooser";
+import DifferenceTypeChooser from "@/components/Experiment/DifferenceTypeChooser";
+import { DropdownMenu } from "@/components/Radix/DropdownMenu";
+import Metadata from "@/components/Radix/Metadata";
+import Link from "@/components/Radix/Link";
+
+export default function PublicExperimentAnalysisSettingsBar({
+  experiment,
+  snapshot,
+  ssrPolyfills,
+}: {
+  experiment: ExperimentInterfaceStringDates;
+  snapshot?: ExperimentSnapshotInterface;
+  ssrPolyfills?: SSRPolyfills;
+}) {
+  const analysis = snapshot
+    ? getSnapshotAnalysis(snapshot) ?? undefined
+    : undefined;
+
+  const hasData = (analysis?.results?.[0]?.variations?.length ?? 0) > 0;
+
+  if (!snapshot) return null;
+
+  return (
+    <>
+      <div className="mb-1 d-flex align-items-center justify-content-end">
+        <DropdownMenu
+          trigger={
+            <Link>
+              <PiEye className="mr-1" />
+              View details
+            </Link>
+          }
+          menuPlacement="end"
+        >
+          <div style={{ minWidth: 250 }} className="p-2">
+            <h5>Results computed with:</h5>
+            <Metadata
+              label="Engine"
+              value={
+                analysis?.settings?.statsEngine ===
+                "frequentist"
+                  ? "Frequentist"
+                  : "Bayesian"
+              }
+            />
+            <Metadata
+              label="CUPED"
+              value={
+                snapshot?.settings?.regressionAdjustmentEnabled
+                  ? "Enabled"
+                  : "Disabled"
+              }
+            />
+            <Metadata
+              label="Sequential"
+              value={
+                analysis?.settings?.sequentialTesting
+                  ? "Enabled"
+                  : "Disabled"
+              }
+            />
+            {snapshot.runStarted && (
+              <div className="text-right mt-3">
+                <Metadata
+                  label="Run date"
+                  value={datetime(snapshot.runStarted)}
+                />
+              </div>
+            )}
+          </div>
+        </DropdownMenu>
+      </div>
+      <div className="py-1 d-flex mb-2">
+        <div className="row align-items-center" style={{ gap: "0.5rem 1rem" }}>
+          <div className="col-auto d-flex align-items-end">
+            <DimensionChooser
+              value={snapshot.dimension ?? ""}
+              activationMetric={!!snapshot.settings.activationMetric}
+              datasourceId={snapshot.settings.datasourceId}
+              exposureQueryId={snapshot.settings.exposureQueryId}
+              userIdType={experiment?.userIdType}
+              labelClassName="mr-2"
+              disabled={true}
+              ssrPolyfills={ssrPolyfills}
+            />
+          </div>
+          <div className="col-auto d-flex align-items-end">
+            <DifferenceTypeChooser
+              differenceType={
+                analysis?.settings?.differenceType ?? "relative"
+              }
+              disabled={true}
+              phase={0}
+              setDifferenceType={() => {}}
+              setAnalysisSettings={() => {}}
+              mutate={() => {}}
+            />
+          </div>
+          <div className="col-auto d-flex align-items-end">
+            <div>
+              <div className="uppercase-title text-muted">Date range</div>
+              <div className="relative">
+                <span className="date-label">
+                  {date(snapshot.settings.startDate)} —{" "}
+                  {snapshot.settings.endDate
+                    ? date(snapshot.settings.endDate)
+                    : "now"}
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div className="row flex-grow-1 flex-shrink-0 pt-1 px-2 justify-content-end">
+          <div className="col-auto px-0">
+            {hasData && snapshot.runStarted ? (
+              <div
+                className="text-muted text-right"
+                style={{ width: 130, fontSize: "0.8em" }}
+                title={datetime(snapshot.runStarted)}
+              >
+                <div className="font-weight-bold" style={{ lineHeight: 1.2 }}>
+                  last updated
+                </div>
+                <div className="d-inline-block" style={{ lineHeight: 1 }}>
+                  {ago(snapshot.runStarted)}
+                </div>
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/packages/front-end/components/Experiment/Public/PublicExperimentMetaInfo.tsx
+++ b/packages/front-end/components/Experiment/Public/PublicExperimentMetaInfo.tsx
@@ -1,0 +1,107 @@
+import { PiLink, PiCheck } from "react-icons/pi";
+import { Flex } from "@radix-ui/themes";
+import { date } from "shared/dates";
+import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
+import Button from "@/components/Radix/Button";
+import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
+import LinkButton from "@/components/Radix/LinkButton";
+import track from "@/services/track";
+import Metadata from "@/components/Radix/Metadata";
+import ExperimentStatusIndicator from "@/components/Experiment/TabbedPage/ExperimentStatusIndicator";
+
+export default function PublicExperimentMetaInfo({
+  experiment,
+  showPrivateLink,
+}: {
+  experiment: ExperimentInterfaceStringDates;
+  showPrivateLink?: boolean;
+}) {
+  const HOST = globalThis?.window?.location?.origin;
+  const shareableLink = experiment.uid
+    ? `${HOST}/public/r/${experiment.uid}`
+    : `${HOST}/report/${experiment.id}`;
+
+  const { performCopy, copySuccess } = useCopyToClipboard({
+    timeout: 800,
+  });
+
+  const shareLinkButton =
+    experiment.shareLevel !== "public" ? null : copySuccess ? (
+      <Button style={{ width: 150 }} icon={<PiCheck />}>
+        Link copied
+      </Button>
+    ) : (
+      <Button
+        icon={<PiLink />}
+        onClick={() => {
+          if (!copySuccess) performCopy(shareableLink);
+          track("Experiment: Click Copy Link", {
+            source: "public page",
+            type: experiment.shareLevel,
+          });
+        }}
+        style={{ width: 150 }}
+      >
+        Copy Link
+      </Button>
+    );
+
+  return (
+        <div className="container-fluid pagecontents d-flex mb-3">
+          <div className="flex-1">
+            <h1 className="mt-1 mb-3 mr-2">
+              {experiment.name}
+            </h1>
+
+            <Flex gap="3" mt="2" mb="1">
+              <Metadata
+                label="Experiment Key"
+                value={experiment.trackingKey || "None"}
+              />
+              <Metadata
+                label="Created"
+                value={date(experiment.dateCreated)}
+              />
+            </Flex>
+          </div>
+          <div className="flex-shrink-0">
+            <div className="d-flex align-items-center">
+              <div className="mr-3">
+                {experiment.archived ? (
+                  <div className="badge badge-secondary">archived</div>
+                ) : (
+                  <ExperimentStatusIndicator
+                    status={experiment.status}
+                    subStatus={
+                      experiment.type === "multi-armed-bandit" &&
+                      experiment.status === "running" &&
+                      experiment.banditStage === "explore"
+                        ? "exploratory"
+                        : undefined
+                    }
+                  />
+                )}
+              </div>
+              {showPrivateLink && (
+                <LinkButton
+                  variant="outline"
+                  href={`/${
+                    experiment?.type === "multi-armed-bandit"
+                      ? "bandit"
+                      : "experiment"
+                  }/${experiment?.id}`}
+                  mr="4"
+                >
+                  Edit {
+                  experiment?.type === "multi-armed-bandit"
+                    ? "Bandit"
+                    : "Experiment"
+                }
+                </LinkButton>
+              )}
+              {shareLinkButton}
+            </div>
+          </div>
+        </div>
+  );
+}

--- a/packages/front-end/components/Experiment/Public/PublicExperimentMetaInfo.tsx
+++ b/packages/front-end/components/Experiment/Public/PublicExperimentMetaInfo.tsx
@@ -18,8 +18,11 @@ export default function PublicExperimentMetaInfo({
 }) {
   const HOST = globalThis?.window?.location?.origin;
   const shareableLink = experiment.uid
-    ? `${HOST}/public/r/${experiment.uid}`
-    : `${HOST}/report/${experiment.id}`;
+    ? `${HOST}/public/e/${experiment.uid}`
+    : `${HOST}/${experiment?.type === "multi-armed-bandit"
+                      ? "bandit"
+                      : "experiment"
+                  }/${experiment.id}`;
 
   const { performCopy, copySuccess } = useCopyToClipboard({
     timeout: 800,
@@ -65,7 +68,7 @@ export default function PublicExperimentMetaInfo({
             </Flex>
           </div>
           <div className="flex-shrink-0">
-            <div className="d-flex align-items-center">
+            <div className="d-flex align-items-center" style={{ height: 40 }}>
               <div className="mr-3">
                 {experiment.archived ? (
                   <div className="badge badge-secondary">archived</div>
@@ -90,7 +93,7 @@ export default function PublicExperimentMetaInfo({
                       ? "bandit"
                       : "experiment"
                   }/${experiment?.id}`}
-                  mr="4"
+                  mr={experiment.shareLevel === "public" ? "4" : "0"}
                 >
                   Edit {
                   experiment?.type === "multi-armed-bandit"

--- a/packages/front-end/components/Experiment/Public/PublicExperimentOverview.tsx
+++ b/packages/front-end/components/Experiment/Public/PublicExperimentOverview.tsx
@@ -1,0 +1,98 @@
+import {ExperimentInterfaceStringDates, LinkedFeatureInfo} from "back-end/types/experiment";
+import React from "react";
+import {VisualChangesetInterface} from "back-end/types/visual-changeset";
+import {URLRedirectInterface} from "back-end/types/url-redirect";
+import Markdown from "@/components/Markdown/Markdown";
+import VariationsTable from "@/components/Experiment/VariationsTable";
+import VisualLinkedChanges from "@/components/Experiment/LinkedChanges/VisualLinkedChanges";
+import FeatureLinkedChanges from "@/components/Experiment/LinkedChanges/FeatureLinkedChanges";
+import RedirectLinkedChanges from "@/components/Experiment/LinkedChanges/RedirectLinkedChanges";
+import TrafficAndTargeting from "@/components/Experiment/TabbedPage/TrafficAndTargeting";
+import AnalysisSettings from "@/components/Experiment/TabbedPage/AnalysisSettings";
+import {SSRPolyfills} from "@/hooks/useSSRPolyfills";
+
+export default function PublicExperimentOverview({
+  experiment,
+  visualChangesets,
+  urlRedirects,
+  linkedFeatures,
+  ssrPolyfills,
+}: {
+  experiment: ExperimentInterfaceStringDates;
+  visualChangesets: VisualChangesetInterface[];
+  urlRedirects: URLRedirectInterface[];
+  linkedFeatures: LinkedFeatureInfo[];
+  ssrPolyfills: SSRPolyfills;
+}) {
+  const phases = experiment?.phases || [];
+  const lastPhaseIndex = phases.length - 1;
+
+  const hasLinkedChanges =
+    experiment?.hasVisualChangesets ||
+    (linkedFeatures?.length ?? 0) > 0 ||
+    experiment?.hasURLRedirects;
+
+  return (
+    <>
+      <h2>Overview</h2>
+
+      <div className="box px-4 py-3 mb-4">
+        <h4>Description</h4>
+        <Markdown>
+          {experiment?.description}
+        </Markdown>
+      </div>
+
+      {experiment?.type !== "multi-armed-bandit" && experiment?.hypothesis ? (
+        <div className="box px-4 py-3 mb-4">
+          <h4>Hypothesis</h4>
+          {experiment?.hypothesis}
+        </div>
+      ) : null}
+
+      <h2>Implementation</h2>
+
+      <div className="box px-2 py-3 mb-4">
+        <h4 className="mx-3">Variations</h4>
+        <VariationsTable
+          experiment={experiment}
+          canEditExperiment={false}
+        />
+      </div>
+
+      {hasLinkedChanges ? (
+        <>
+          <VisualLinkedChanges
+            visualChangesets={visualChangesets}
+            canAddChanges={false}
+            canEditVisualChangesets={false}
+            experiment={experiment}
+          />
+          <FeatureLinkedChanges
+            linkedFeatures={linkedFeatures}
+            experiment={experiment}
+            canAddChanges={false}
+          />
+          <RedirectLinkedChanges
+            urlRedirects={urlRedirects}
+            experiment={experiment}
+            canAddChanges={false}
+          />
+
+          <TrafficAndTargeting
+            experiment={experiment}
+            phaseIndex={lastPhaseIndex}
+          />
+
+          <AnalysisSettings
+            experiment={experiment}
+            envs={[]}
+            canEdit={false}
+            ssrPolyfills={ssrPolyfills}
+            isPublic={true}
+          />
+        </>
+      ) : null}
+    </>
+  );
+}

--- a/packages/front-end/components/Experiment/Public/PublicExperimentOverview.tsx
+++ b/packages/front-end/components/Experiment/Public/PublicExperimentOverview.tsx
@@ -7,7 +7,6 @@ import VariationsTable from "@/components/Experiment/VariationsTable";
 import VisualLinkedChanges from "@/components/Experiment/LinkedChanges/VisualLinkedChanges";
 import FeatureLinkedChanges from "@/components/Experiment/LinkedChanges/FeatureLinkedChanges";
 import RedirectLinkedChanges from "@/components/Experiment/LinkedChanges/RedirectLinkedChanges";
-import TrafficAndTargeting from "@/components/Experiment/TabbedPage/TrafficAndTargeting";
 import AnalysisSettings from "@/components/Experiment/TabbedPage/AnalysisSettings";
 import {SSRPolyfills} from "@/hooks/useSSRPolyfills";
 
@@ -24,9 +23,6 @@ export default function PublicExperimentOverview({
   linkedFeatures: LinkedFeatureInfo[];
   ssrPolyfills: SSRPolyfills;
 }) {
-  const phases = experiment?.phases || [];
-  const lastPhaseIndex = phases.length - 1;
-
   const hasLinkedChanges =
     experiment?.hasVisualChangesets ||
     (linkedFeatures?.length ?? 0) > 0 ||
@@ -39,7 +35,7 @@ export default function PublicExperimentOverview({
       <div className="box px-4 py-3 mb-4">
         <h4>Description</h4>
         <Markdown>
-          {experiment?.description}
+          {experiment?.description || "_no description_"}
         </Markdown>
       </div>
 
@@ -67,21 +63,19 @@ export default function PublicExperimentOverview({
             canAddChanges={false}
             canEditVisualChangesets={false}
             experiment={experiment}
+            isPublic={true}
           />
           <FeatureLinkedChanges
             linkedFeatures={linkedFeatures}
             experiment={experiment}
             canAddChanges={false}
+            isPublic={true}
           />
           <RedirectLinkedChanges
             urlRedirects={urlRedirects}
             experiment={experiment}
             canAddChanges={false}
-          />
-
-          <TrafficAndTargeting
-            experiment={experiment}
-            phaseIndex={lastPhaseIndex}
+            isPublic={true}
           />
 
           <AnalysisSettings

--- a/packages/front-end/components/Experiment/Public/PublicExperimentResults.tsx
+++ b/packages/front-end/components/Experiment/Public/PublicExperimentResults.tsx
@@ -1,0 +1,193 @@
+import { ExperimentSnapshotInterface } from "back-end/types/experiment-snapshot";
+import {
+  MetricSnapshotSettings,
+} from "back-end/types/report";
+import { getSnapshotAnalysis } from "shared/util";
+import {
+  DEFAULT_PROPER_PRIOR_STDDEV,
+  DEFAULT_STATS_ENGINE,
+} from "shared/constants";
+import {ExperimentInterfaceStringDates} from "back-end/types/experiment";
+import { SSRPolyfills } from "@/hooks/useSSRPolyfills";
+import { getQueryStatus } from "@/components/Queries/RunQueriesButton";
+import useOrgSettings from "@/hooks/useOrgSettings";
+import Callout from "@/components/Radix/Callout";
+import DateResults from "@/components/Experiment/DateResults";
+import BreakDownResults from "@/components/Experiment/BreakDownResults";
+import CompactResults from "@/components/Experiment/CompactResults";
+import LoadingSpinner from "@/components/LoadingSpinner";
+import PublicExperimentAnalysisSettingsBar from "@/components/Experiment/Public/PublicExperimentAnalysisSettingsBar";
+
+export default function PublicExperimentResults({
+  experiment,
+  snapshot,
+  snapshotError,
+  ssrPolyfills,
+  isTabActive,
+}: {
+  experiment: ExperimentInterfaceStringDates;
+  snapshot?: ExperimentSnapshotInterface;
+  snapshotError?: Error;
+  ssrPolyfills: SSRPolyfills;
+  isTabActive: boolean;
+}) {
+  const phases = experiment.phases;
+  const phase = phases.length - 1;
+  const phaseObj = phases[phase];
+
+  const variations = experiment.variations.map((v, i) => {
+    return {
+      id: v.key || i + "",
+      name: v.name,
+      weight: phaseObj?.variationWeights?.[i] || 0,
+    };
+  });
+  const analysis = snapshot
+    ? getSnapshotAnalysis(snapshot) ?? undefined
+    : undefined;
+  const queryStatusData = getQueryStatus(
+    snapshot?.queries || [],
+    snapshot?.error
+  );
+
+  const settingsForSnapshotMetrics: MetricSnapshotSettings[] =
+    snapshot?.settings?.metricSettings?.map((m) => ({
+      metric: m.id,
+      properPrior: m.computedSettings?.properPrior ?? false,
+      properPriorMean: m.computedSettings?.properPriorMean ?? 0,
+      properPriorStdDev:
+        m.computedSettings?.properPriorStdDev ?? DEFAULT_PROPER_PRIOR_STDDEV,
+      regressionAdjustmentReason:
+        m.computedSettings?.regressionAdjustmentReason || "",
+      regressionAdjustmentDays:
+        m.computedSettings?.regressionAdjustmentDays || 0,
+      regressionAdjustmentEnabled: !!m.computedSettings
+        ?.regressionAdjustmentEnabled,
+      regressionAdjustmentAvailable: !!m.computedSettings
+        ?.regressionAdjustmentAvailable,
+    })) || [];
+
+  const _orgSettings = useOrgSettings();
+  const pValueCorrection =
+    ssrPolyfills?.useOrgSettings?.()?.pValueCorrection ||
+    _orgSettings?.pValueCorrection;
+
+  const hasData = (analysis?.results?.[0]?.variations?.length ?? 0) > 0;
+
+  const isBandit = experiment?.type === "multi-armed-bandit";
+
+  const showBreakDownResults =
+    hasData &&
+    !!snapshot?.dimension &&
+    snapshot.dimension.substring(0, 8) !== "pre:date" &&
+    !!analysis?.settings?.dimensions?.length;
+
+  const showDateResults =
+    hasData &&
+    snapshot?.dimension?.substring(0, 8) === "pre:date" &&
+    !!analysis?.settings?.dimensions?.length;
+
+  const showCompactResults =
+    hasData &&
+    !!snapshot &&
+    !!analysis &&
+    !analysis?.settings?.dimensions?.length;
+
+  return (
+    <>
+      <PublicExperimentAnalysisSettingsBar
+        experiment={experiment}
+        snapshot={snapshot ?? undefined}
+        ssrPolyfills={ssrPolyfills}
+      />
+
+      <div className="bg-white border pt-3 mb-5">
+        {snapshotError ? (
+          <div className="mx-3 mb-3">
+            <Callout status="error">
+              Experiment snapshot error
+            </Callout>
+          </div>
+        ) : snapshot && !analysis ? (
+          <div className="mx-3 mb-3">
+            <Callout status="error">
+              Missing analysis
+            </Callout>
+          </div>
+        ) : !snapshot ? (
+          <div className="d-flex justify-content-center my-4">
+            <LoadingSpinner />
+          </div>
+        ) : (
+          <>
+            {showDateResults ? (
+              <DateResults
+                goalMetrics={experiment.goalMetrics}
+                secondaryMetrics={experiment.secondaryMetrics}
+                guardrailMetrics={experiment.guardrailMetrics}
+                results={analysis?.results ?? []}
+                seriestype={snapshot.dimension ?? ""}
+                variations={variations}
+                statsEngine={analysis?.settings?.statsEngine || DEFAULT_STATS_ENGINE}
+                differenceType={analysis.settings?.differenceType}
+                ssrPolyfills={ssrPolyfills}
+              />
+            ) : showBreakDownResults ? (
+              <BreakDownResults
+                key={snapshot.dimension}
+                results={analysis?.results ?? []}
+                queryStatusData={queryStatusData}
+                variations={variations}
+                goalMetrics={experiment.goalMetrics}
+                secondaryMetrics={experiment.secondaryMetrics}
+                guardrailMetrics={experiment.guardrailMetrics}
+                metricOverrides={experiment.metricOverrides ?? []}
+                dimensionId={snapshot.dimension ?? ""}
+                isLatestPhase={phase === experiment.phases.length - 1}
+                startDate={phaseObj?.dateStarted ?? ""}
+                reportDate={snapshot.dateCreated}
+                activationMetric={experiment.activationMetric}
+                status={experiment.status}
+                statsEngine={analysis.settings.statsEngine}
+                pValueCorrection={pValueCorrection}
+                regressionAdjustmentEnabled={analysis?.settings?.regressionAdjusted}
+                settingsForSnapshotMetrics={settingsForSnapshotMetrics}
+                sequentialTestingEnabled={analysis?.settings?.sequentialTesting}
+                differenceType={analysis.settings?.differenceType}
+                isBandit={isBandit}
+                ssrPolyfills={ssrPolyfills}
+                hideDetails={true}
+              />
+            ) : showCompactResults ? (
+              <CompactResults
+                variations={variations}
+                multipleExposures={snapshot.multipleExposures || 0}
+                results={analysis.results[0]}
+                queryStatusData={queryStatusData}
+                reportDate={snapshot.dateCreated}
+                startDate={phaseObj?.dateStarted ?? ""}
+                isLatestPhase={phase === experiment.phases.length - 1}
+                status={experiment.status}
+                goalMetrics={experiment.goalMetrics}
+                secondaryMetrics={experiment.secondaryMetrics}
+                guardrailMetrics={experiment.guardrailMetrics}
+                metricOverrides={experiment.metricOverrides ?? []}
+                id={experiment.id}
+                statsEngine={analysis.settings.statsEngine}
+                pValueCorrection={pValueCorrection}
+                regressionAdjustmentEnabled={analysis.settings?.regressionAdjusted}
+                settingsForSnapshotMetrics={settingsForSnapshotMetrics}
+                sequentialTestingEnabled={analysis.settings?.sequentialTesting}
+                differenceType={analysis.settings?.differenceType}
+                isTabActive={isTabActive}
+                experimentType={experiment.type}
+                ssrPolyfills={ssrPolyfills}
+                hideDetails={true}
+              />
+            ) : null}
+          </>
+        )}
+      </div>
+    </>
+  );
+}

--- a/packages/front-end/components/Experiment/TabbedPage/AnalysisSettings.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/AnalysisSettings.tsx
@@ -7,15 +7,23 @@ import { useDefinitions } from "@/services/DefinitionsContext";
 import { useUser } from "@/services/UserContext";
 import AnalysisForm from "@/components/Experiment/AnalysisForm";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
+import {SSRPolyfills} from "@/hooks/useSSRPolyfills";
 
 export interface Props {
   experiment: ExperimentInterfaceStringDates;
   envs: string[];
   mutate?: () => void;
   canEdit: boolean;
+  ssrPolyfills?: SSRPolyfills;
 }
 
-export default function AnalysisSettings({ experiment, mutate, envs, canEdit }: Props) {
+export default function AnalysisSettings({
+  experiment,
+  mutate,
+  envs,
+  canEdit,
+  ssrPolyfills,
+}: Props) {
   const {
     getDatasourceById,
     getProjectById,
@@ -29,10 +37,8 @@ export default function AnalysisSettings({ experiment, mutate, envs, canEdit }: 
 
   const project = getProjectById(experiment.project || "");
 
-  const canEditAnalysisSettings = canEdit && permissionsUtil.canUpdateExperiment(
-    experiment,
-    {}
-  );
+  const canEditAnalysisSettings =
+    canEdit && permissionsUtil.canUpdateExperiment(experiment, {});
 
   const { settings: scopedSettings } = getScopedSettings({
     organization,

--- a/packages/front-end/components/Experiment/TabbedPage/AnalysisSettings.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/AnalysisSettings.tsx
@@ -1,5 +1,5 @@
 import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import { getScopedSettings } from "shared/settings";
 import { upperFirst } from "lodash";
 import { expandMetricGroups } from "shared/experiments";
@@ -7,7 +7,8 @@ import { useDefinitions } from "@/services/DefinitionsContext";
 import { useUser } from "@/services/UserContext";
 import AnalysisForm from "@/components/Experiment/AnalysisForm";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
-import {SSRPolyfills} from "@/hooks/useSSRPolyfills";
+import { SSRPolyfills } from "@/hooks/useSSRPolyfills";
+import useOrgSettings from "@/hooks/useOrgSettings";
 
 export interface Props {
   experiment: ExperimentInterfaceStringDates;
@@ -15,6 +16,7 @@ export interface Props {
   mutate?: () => void;
   canEdit: boolean;
   ssrPolyfills?: SSRPolyfills;
+  isPublic?: boolean;
 }
 
 export default function AnalysisSettings({
@@ -23,6 +25,7 @@ export default function AnalysisSettings({
   envs,
   canEdit,
   ssrPolyfills,
+  isPublic,
 }: Props) {
   const {
     getDatasourceById,
@@ -31,17 +34,23 @@ export default function AnalysisSettings({
     metricGroups,
   } = useDefinitions();
   const { organization } = useUser();
+  const _settings = useOrgSettings();
+  const settings = ssrPolyfills?.useOrgSettings() || _settings;
   const permissionsUtil = usePermissionsUtil();
 
   const [analysisModal, setAnalysisModal] = useState(false);
 
-  const project = getProjectById(experiment.project || "");
+  const project =
+    ssrPolyfills?.getProjectById(experiment.project || "") ||
+    getProjectById(experiment.project || "");
 
   const canEditAnalysisSettings =
     canEdit && permissionsUtil.canUpdateExperiment(experiment, {});
 
   const { settings: scopedSettings } = getScopedSettings({
-    organization,
+    organization: organization?.settings
+      ? organization
+      : { settings: settings },
     project: project ?? undefined,
     experiment: experiment,
   });
@@ -56,27 +65,54 @@ export default function AnalysisSettings({
 
   const statsEngine = scopedSettings.statsEngine.value;
 
+  const {
+    expandedGoals,
+    expandedSecondaries,
+    expandedGuardrails,
+  } = useMemo(() => {
+    const expandedGoals = expandMetricGroups(
+      experiment.goalMetrics,
+      ssrPolyfills?.metricGroups || metricGroups
+    );
+    const expandedSecondaries = expandMetricGroups(
+      experiment.secondaryMetrics,
+      ssrPolyfills?.metricGroups || metricGroups
+    );
+    const expandedGuardrails = expandMetricGroups(
+      experiment.guardrailMetrics,
+      ssrPolyfills?.metricGroups || metricGroups
+    );
+
+    return { expandedGoals, expandedSecondaries, expandedGuardrails };
+  }, [
+    experiment.goalMetrics,
+    experiment.secondaryMetrics,
+    experiment.guardrailMetrics,
+    metricGroups,
+    ssrPolyfills?.metricGroups,
+  ]);
+
   const goals: string[] = [];
-  expandMetricGroups(experiment.goalMetrics ?? [], metricGroups).forEach(
-    (m) => {
-      const name = getExperimentMetricById(m)?.name;
-      if (name) goals.push(name);
-    }
-  );
+  expandedGoals.forEach((m) => {
+    const name =
+      ssrPolyfills?.getExperimentMetricById?.(m)?.name ||
+      getExperimentMetricById(m)?.name;
+    if (name) goals.push(name);
+  });
   const secondary: string[] = [];
-  expandMetricGroups(experiment.secondaryMetrics ?? [], metricGroups).forEach(
-    (m) => {
-      const name = getExperimentMetricById(m)?.name;
-      if (name) secondary.push(name);
-    }
-  );
+  expandedSecondaries.forEach((m) => {
+    const name =
+      ssrPolyfills?.getExperimentMetricById?.(m)?.name ||
+      getExperimentMetricById(m)?.name;
+    if (name) secondary.push(name);
+  });
   const guardrails: string[] = [];
-  expandMetricGroups(experiment.guardrailMetrics ?? [], metricGroups).forEach(
-    (m) => {
-      const name = getExperimentMetricById(m)?.name;
-      if (name) guardrails.push(name);
-    }
-  );
+  expandedGuardrails.forEach((m) => {
+    const name =
+      ssrPolyfills?.getExperimentMetricById?.(m)?.name ||
+      getExperimentMetricById(m)?.name;
+    if (name) guardrails.push(name);
+  });
 
   const isBandit = experiment.type === "multi-armed-bandit";
 
@@ -112,34 +148,38 @@ export default function AnalysisSettings({
           ) : null}
         </div>
 
-        <div className="row">
-          <div className="col-4">
-            <div className="h5">Data Source</div>
-            <div>{datasource ? datasource.name : <em>none</em>}</div>
-          </div>
-
-          <div className="col-4">
-            <div className="h5">Experiment Assignment Table</div>
-            <div>{assignmentQuery ? assignmentQuery.name : <em>none</em>}</div>
-          </div>
-
-          {!isBandit && (
+        {!isPublic && (
+          <div className="row">
             <div className="col-4">
-              <div className="h5">Stats Engine</div>
-              <div>{upperFirst(statsEngine)}</div>
+              <div className="h5">Data Source</div>
+              <div>{datasource ? datasource.name : <em>none</em>}</div>
             </div>
-          )}
-          {isBandit && (
+
             <div className="col-4">
-              <div className="h5">CUPED</div>
+              <div className="h5">Experiment Assignment Table</div>
               <div>
-                {experiment.regressionAdjustmentEnabled
-                  ? "Enabled"
-                  : "Disabled"}
+                {assignmentQuery ? assignmentQuery.name : <em>none</em>}
               </div>
             </div>
-          )}
-        </div>
+
+            {!isBandit && (
+              <div className="col-4">
+                <div className="h5">Stats Engine</div>
+                <div>{upperFirst(statsEngine)}</div>
+              </div>
+            )}
+            {isBandit && (
+              <div className="col-4">
+                <div className="h5">CUPED</div>
+                <div>
+                  {experiment.regressionAdjustmentEnabled
+                    ? "Enabled"
+                    : "Disabled"}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
 
         <div className="row mt-4">
           <div className="col-4">

--- a/packages/front-end/components/Experiment/TabbedPage/AnalysisSettings.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/AnalysisSettings.tsx
@@ -11,10 +11,11 @@ import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 export interface Props {
   experiment: ExperimentInterfaceStringDates;
   envs: string[];
-  mutate: () => void;
+  mutate?: () => void;
+  canEdit: boolean;
 }
 
-export default function AnalysisSettings({ experiment, mutate, envs }: Props) {
+export default function AnalysisSettings({ experiment, mutate, envs, canEdit }: Props) {
   const {
     getDatasourceById,
     getProjectById,
@@ -28,7 +29,7 @@ export default function AnalysisSettings({ experiment, mutate, envs }: Props) {
 
   const project = getProjectById(experiment.project || "");
 
-  const canEditAnalysisSettings = permissionsUtil.canUpdateExperiment(
+  const canEditAnalysisSettings = canEdit && permissionsUtil.canUpdateExperiment(
     experiment,
     {}
   );
@@ -75,7 +76,7 @@ export default function AnalysisSettings({ experiment, mutate, envs }: Props) {
 
   return (
     <>
-      {analysisModal && (
+      {analysisModal && mutate ? (
         <AnalysisForm
           cancel={() => setAnalysisModal(false)}
           experiment={experiment}
@@ -87,7 +88,7 @@ export default function AnalysisSettings({ experiment, mutate, envs }: Props) {
           source={"analysis-settings"}
           envs={envs}
         />
-      )}
+      ) : null}
 
       <div className="box p-4 my-4">
         <div className="d-flex flex-row align-items-center justify-content-between text-dark mb-4">

--- a/packages/front-end/components/Experiment/TabbedPage/BanditSummaryResultsTab.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/BanditSummaryResultsTab.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from "react";
 import { LiaChartLineSolid } from "react-icons/lia";
 import { TbChartAreaLineFilled } from "react-icons/tb";
 import { BanditEvent } from "back-end/src/validators/experiments";
+import { ExperimentSnapshotInterface } from "back-end/types/experiment-snapshot";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
 import BanditSummaryTable from "@/components/Experiment/BanditSummaryTable";
 import { useDefinitions } from "@/services/DefinitionsContext";
@@ -16,25 +17,39 @@ import Callout from "@/components/Radix/Callout";
 import MultipleExposureWarning from "@/components/Experiment/MultipleExposureWarning";
 import SRMWarning from "@/components/Experiment/SRMWarning";
 import { useSnapshot } from "@/components/Experiment/SnapshotProvider";
+import { SSRPolyfills } from "@/hooks/useSSRPolyfills";
 
 export interface Props {
   experiment: ExperimentInterfaceStringDates;
-  mutate: () => void;
+  mutate?: () => void;
   isTabActive?: boolean;
+  ssrSnapshot?: ExperimentSnapshotInterface;
+  ssrPolyfills?: SSRPolyfills;
+  isPublic?: boolean;
 }
 
 export default function BanditSummaryResultsTab({
   experiment,
   mutate,
   isTabActive,
+  ssrSnapshot,
+  ssrPolyfills,
+  isPublic,
 }: Props) {
   const { getExperimentMetricById } = useDefinitions();
 
   const [chartMode, setChartMode] = useLocalStorage<
     "values" | "probabilities" | "weights"
-  >(`banditSummaryResultsChartMode__${experiment.id}`, "values");
+  >(
+    `banditSummaryResultsChartMode__${isPublic ? "public__" : ""}${
+      experiment.id
+    }`,
+    "values"
+  );
   const [chartType, setChartType] = useLocalStorage<"area" | "line">(
-    `banditSummaryResultsChartType__${experiment.id}`,
+    `banditSummaryResultsChartType__${isPublic ? "public__" : ""}${
+      experiment.id
+    }`,
     "area"
   );
   const numPhases = experiment.phases.length;
@@ -46,9 +61,12 @@ export default function BanditSummaryResultsTab({
   }, [numPhases, setPhase]);
 
   const mid = experiment?.goalMetrics?.[0];
-  const metric = getExperimentMetricById(mid ?? "");
+  const metric =
+    ssrPolyfills?.getExperimentMetricById?.(mid) ||
+    getExperimentMetricById(mid ?? "");
 
-  const { latest } = useSnapshot();
+  const { latest: _latest } = useSnapshot();
+  const latest = _latest ?? ssrSnapshot;
   const multipleExposures = latest?.multipleExposures;
 
   const phaseObj = experiment.phases[phase];
@@ -75,9 +93,11 @@ export default function BanditSummaryResultsTab({
       <div className="d-flex mt-4 mb-3 align-items-end">
         <h3 className="mb-0">Bandit Leaderboard</h3>
         <div className="flex-1" />
-        <div style={{ marginBottom: -5 }}>
-          <PhaseSelector phase={phase} setPhase={setPhase} isBandit={true} />
-        </div>
+        {!isPublic && (
+          <div style={{ marginBottom: -5 }}>
+            <PhaseSelector phase={phase} setPhase={setPhase} isBandit={true} />
+          </div>
+        )}
       </div>
       <div className="box pt-3">
         {experiment.status === "draft" && (
@@ -108,25 +128,31 @@ export default function BanditSummaryResultsTab({
           </Callout>
         ) : null}
 
-        <div className="mx-3">
-          <SRMWarning
-            srm={event?.banditResult?.srm ?? Infinity}
-            users={users}
-            showWhenHealthy={false}
-            isBandit={true}
-          />
-          <MultipleExposureWarning
-            users={users}
-            multipleExposures={multipleExposures ?? 0}
-          />
-        </div>
+        {!isPublic && (
+          <div className="mx-3">
+            <SRMWarning
+              srm={event?.banditResult?.srm ?? Infinity}
+              users={users}
+              showWhenHealthy={false}
+              isBandit={true}
+            />
+            <MultipleExposureWarning
+              users={users}
+              multipleExposures={multipleExposures ?? 0}
+            />
+          </div>
+        )}
 
         {showVisualizations && (
           <>
             <div className="d-flex mx-3 align-items-center">
               <div className="h4 mb-0">
                 {metric
-                  ? getRenderLabelColumn(false, "bayesian")("", metric)
+                  ? getRenderLabelColumn(
+                      false,
+                      "bayesian",
+                      isPublic
+                    )("", metric)
                   : null}
               </div>
               <div className="flex-1" />
@@ -143,7 +169,11 @@ export default function BanditSummaryResultsTab({
               )}
               {isCurrentPhase && (
                 <div className="d-flex align-items-center">
-                  <BanditUpdateStatus experiment={experiment} mutate={mutate} />
+                  <BanditUpdateStatus
+                    experiment={experiment}
+                    mutate={mutate}
+                    isPublic={isPublic}
+                  />
                 </div>
               )}
             </div>
@@ -152,6 +182,7 @@ export default function BanditSummaryResultsTab({
               metric={metric}
               phase={phase}
               isTabActive={!!isTabActive}
+              ssrPolyfills={ssrPolyfills}
             />
           </>
         )}
@@ -216,6 +247,8 @@ export default function BanditSummaryResultsTab({
               }
               mode={chartMode}
               type={chartMode === "values" ? "line" : chartType}
+              ssrPolyfills={ssrPolyfills}
+              isPublic={isPublic}
             />
           </div>
         </>

--- a/packages/front-end/components/Experiment/TabbedPage/BanditUpdateStatus.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/BanditUpdateStatus.tsx
@@ -14,11 +14,16 @@ import { getQueryStatus } from "@/components/Queries/RunQueriesButton";
 export default function BanditUpdateStatus({
   experiment,
   mutate,
+  isPublic,
+  ssrSnapshot,
 }: {
   experiment: ExperimentInterfaceStringDates;
-  mutate: () => void;
+  mutate?: () => void;
+  isPublic?: boolean;
+  ssrSnapshot?: ExperimentSnapshotInterface;
 }) {
-  const { latest } = useSnapshot();
+  const { latest: _latest } = useSnapshot();
+  const latest = _latest ?? ssrSnapshot;
   const { status } = getQueryStatus(latest?.queries || [], latest?.error);
 
   const phase = experiment.phases?.[experiment.phases.length - 1];
@@ -70,7 +75,7 @@ export default function BanditUpdateStatus({
             style={{ maxWidth: 130, fontSize: "0.8em" }}
           >
             <div className="font-weight-bold" style={{ lineHeight: 1.2 }}>
-              {error ? (
+              {error && !isPublic ? (
                 <FaExclamationTriangle
                   className="text-danger mr-1 mb-1"
                   size={14}
@@ -125,6 +130,7 @@ export default function BanditUpdateStatus({
                 </tr>
               ) : null}
               {experiment.status === "running" &&
+                !isPublic &&
                 ["explore", "exploit"].includes(
                   experiment.banditStage ?? ""
                 ) && (
@@ -148,15 +154,17 @@ export default function BanditUpdateStatus({
                   </>
                 )}
             </tbody>
-            <tbody>
-              <tr>
-                <td className="text-muted">Current schedule:</td>
-                <td>
-                  every {experiment.banditScheduleValue ?? ""}{" "}
-                  {experiment.banditScheduleUnit ?? ""}
-                </td>
-              </tr>
-            </tbody>
+            {!isPublic && (
+              <tbody>
+                <tr>
+                  <td className="text-muted">Current schedule:</td>
+                  <td>
+                    every {experiment.banditScheduleValue ?? ""}{" "}
+                    {experiment.banditScheduleUnit ?? ""}
+                  </td>
+                </tr>
+              </tbody>
+            )}
           </table>
 
           <div className="mx-2" style={{ fontSize: "12px" }}>
@@ -178,14 +186,16 @@ export default function BanditUpdateStatus({
               ) : (
                 "not running"
               )}
-              {experiment.status === "running" &&
+              {!isPublic &&
+                experiment.status === "running" &&
                 experiment.banditStage === "explore" && (
                   <> and is waiting until more data is collected</>
                 )}
               .
             </p>
 
-            {experiment.status === "running" &&
+            {!isPublic &&
+              experiment.status === "running" &&
               experiment.banditStage === "explore" && (
                 <p>
                   {" "}
@@ -196,7 +206,7 @@ export default function BanditUpdateStatus({
               )}
           </div>
 
-          {error ? (
+          {!isPublic && error ? (
             <div className="alert small alert-danger mx-2 px-1 pt-2 pb-1 row align-items-start">
               <div className="col">
                 <FaExclamationTriangle className="mr-1" />
@@ -222,7 +232,7 @@ export default function BanditUpdateStatus({
             </div>
           ) : null}
 
-          {experiment.status === "running" && (
+          {!isPublic && experiment.status === "running" && mutate && (
             <>
               <hr className="mx-2" />
               <RefreshBanditButton

--- a/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
@@ -14,6 +14,12 @@ import { SDKConnectionInterface } from "back-end/types/sdk-connection";
 import Link from "next/link";
 import Collapsible from "react-collapsible";
 import { useGrowthBook } from "@growthbook/growthbook-react";
+import { PiCheck, PiLink } from "react-icons/pi";
+import {
+  ExperimentSnapshotReportArgs,
+  ExperimentSnapshotReportInterface,
+  ReportInterface,
+} from "back-end/types/report";
 import { useAuth } from "@/services/auth";
 import WatchButton from "@/components/WatchButton";
 import MoreMenu from "@/components/Dropdown/MoreMenu";
@@ -37,9 +43,15 @@ import PremiumTooltip from "@/components/Marketing/PremiumTooltip";
 import { formatPercent } from "@/services/metrics";
 import { AppFeatures } from "@/types/app-features";
 import { useSnapshot } from "@/components/Experiment/SnapshotProvider";
-import ExperimentStatusIndicator from "./ExperimentStatusIndicator";
-import ExperimentActionButtons from "./ExperimentActionButtons";
+import Button from "@/components/Radix/Button";
+import Callout from "@/components/Radix/Callout";
+import SelectField from "@/components/Forms/SelectField";
+import LoadingSpinner from "@/components/LoadingSpinner";
+import HelperText from "@/components/Radix/HelperText";
+import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import ProjectTagBar from "./ProjectTagBar";
+import ExperimentActionButtons from "./ExperimentActionButtons";
+import ExperimentStatusIndicator from "./ExperimentStatusIndicator";
 import { ExperimentTab } from ".";
 
 export interface Props {
@@ -92,6 +104,9 @@ const DisabledHealthTabTooltip = ({
 // NB: Keep in sync with .experiment-tabs top property in global.scss
 const TABS_HEADER_HEIGHT_PX = 55;
 
+type ShareLevel = "public" | "organization";
+const SAVE_SETTING_TIMEOUT_MS = 3000;
+
 export default function ExperimentHeader({
   tab,
   setTab,
@@ -126,9 +141,38 @@ export default function ExperimentHeader({
   const dataSource = getDatasourceById(experiment.datasource);
   const startCelebration = useCelebration();
   const { data: sdkConnections } = useSDKConnections();
-  const { phase, analysis } = useSnapshot();
+  const { snapshot, phase, analysis } = useSnapshot();
   const connections = sdkConnections?.connections || [];
+
   const [showSdkForm, setShowSdkForm] = useState(false);
+
+  const [shareModalOpen, setShareModalOpen] = useState(false);
+  const [shareLevel, setShareLevel] = useState<ShareLevel>(
+    experiment.shareLevel || "organization"
+  );
+  const [saveShareLevelStatus, setSaveShareLevelStatus] = useState<
+    null | "loading" | "success" | "fail"
+  >(null);
+  const saveShareLevelTimeout = useRef<number | undefined>();
+  const { performCopy, copySuccess } = useCopyToClipboard({
+    timeout: 800,
+  });
+  const HOST = globalThis?.window?.location?.origin;
+  const shareableLink = experiment.uid
+    ? `${HOST}/public/e/${experiment.uid}`
+    : `${HOST}/${
+        experiment?.type === "multi-armed-bandit" ? "bandit" : "experiment"
+      }/${experiment.id}`;
+  const datasourceSettings = experiment.datasource
+    ? getDatasourceById(experiment.datasource)?.settings
+    : undefined;
+  const userIdType = datasourceSettings?.queries?.exposure?.find(
+    (e) => e.id === experiment.exposureQueryId
+  )?.userIdType;
+
+  const reportArgs: ExperimentSnapshotReportArgs = {
+    userIdType: userIdType as "user" | "anonymous" | undefined,
+  };
 
   const tabsRef = useRef<HTMLDivElement>(null);
   const [headerPinned, setHeaderPinned] = useState(false);
@@ -225,6 +269,73 @@ export default function ExperimentHeader({
       throw e;
     }
   }
+
+  useEffect(() => {
+    if (experiment.shareLevel !== shareLevel) {
+      setSaveShareLevelStatus("loading");
+      window.clearTimeout(saveShareLevelTimeout.current);
+      apiCall<{
+        updatedReport: ExperimentSnapshotReportInterface;
+      }>(`/experiment/${experiment.id}`, {
+        method: "POST",
+        body: JSON.stringify({ shareLevel, uid: experiment.uid }),
+      })
+        .then(() => {
+          mutate?.();
+          setSaveShareLevelStatus("success");
+          saveShareLevelTimeout.current = window.setTimeout(
+            () => setSaveShareLevelStatus(null),
+            SAVE_SETTING_TIMEOUT_MS
+          );
+        })
+        .catch(() => {
+          setSaveShareLevelStatus("fail");
+          saveShareLevelTimeout.current = window.setTimeout(
+            () => setSaveShareLevelStatus(null),
+            SAVE_SETTING_TIMEOUT_MS
+          );
+        });
+      track("Experiment: Set Share Level", {
+        source: "private page",
+        type: shareLevel,
+      });
+    }
+  }, [
+    experiment.id,
+    experiment.uid,
+    experiment.shareLevel,
+    shareLevel,
+    mutate,
+    setSaveShareLevelStatus,
+    apiCall,
+  ]);
+
+  const shareLinkButton = (size?: "sm" | "md" = "md") =>
+    experiment.shareLevel !== "public" ? null : copySuccess ? (
+      <Button
+        size={size}
+        style={{ width: size === "md" ? 150 : 130 }}
+        icon={<PiCheck />}
+      >
+        Link copied
+      </Button>
+    ) : (
+      <Button
+        size={size}
+        icon={<PiLink />}
+        onClick={() => {
+          if (!copySuccess) performCopy(shareableLink);
+          setTimeout(() => setShareModalOpen(false), 810);
+          track("Experiment: Click Copy Link", {
+            source: "private page",
+            type: shareLevel,
+          });
+        }}
+        style={{ width: size === "md" ? 150 : 130 }}
+      >
+        Copy Link
+      </Button>
+    );
 
   return (
     <>
@@ -331,6 +442,64 @@ export default function ExperimentHeader({
             </div>
           </Modal>
         )}
+
+        {shareModalOpen && (
+          <Modal
+            open={true}
+            trackingEventModalType="share-experiment-settings"
+            close={() => setShareModalOpen(false)}
+            closeCta="Close"
+            header={`Share "${experiment.name}"`}
+            useRadixButton={true}
+            secondaryCTA={shareLinkButton()}
+          >
+            <div className="mb-3">
+              {shareLevel === "organization" ? (
+                <Callout status="info" size="sm">
+                  This {isBandit ? "Bandit" : "Experiment"} is only viewable
+                  within your organization.
+                </Callout>
+              ) : shareLevel === "public" ? (
+                <>
+                  <Callout status="warning" size="sm">
+                    Anyone with the link can view this{" "}
+                    {isBandit ? "Bandit" : "Experiment"}, even those outside
+                    your organization.
+                  </Callout>
+                </>
+              ) : null}
+            </div>
+
+            <SelectField
+              label="View access"
+              value={shareLevel}
+              onChange={(v: ShareLevel) => setShareLevel(v)}
+              containerClassName="mb-2"
+              sort={false}
+              disabled={!hasUpdatePermissions}
+              options={[
+                { value: "organization", label: "Only organization members" },
+                { value: "public", label: "Anyone with the link" },
+              ]}
+            />
+            <div className="mb-1" style={{ height: 24 }}>
+              {saveShareLevelStatus === "loading" ? (
+                <div className="position-relative" style={{ top: -6 }}>
+                  <LoadingSpinner />
+                </div>
+              ) : saveShareLevelStatus === "success" ? (
+                <HelperText status="success" size="sm">
+                  Sharing status has been updated
+                </HelperText>
+              ) : saveShareLevelStatus === "fail" ? (
+                <HelperText status="error" size="sm">
+                  Unable to update sharing status
+                </HelperText>
+              ) : null}
+            </div>
+          </Modal>
+        )}
+
         <div className="container-fluid pagecontents position-relative">
           <div className="d-flex align-items-center">
             <div>
@@ -414,7 +583,23 @@ export default function ExperimentHeader({
               </div>
             ) : null}
 
-            <div className="ml-2">
+            <div className="d-flex ml-2 align-items-center">
+              {experiment.status === "stopped" && experiment.results ? (
+                <>
+                  {canEditExperiment ? (
+                    <Button
+                      size="sm"
+                      ml="2"
+                      mr="3"
+                      onClick={() => setShareModalOpen(true)}
+                    >
+                      Share...
+                    </Button>
+                  ) : shareLevel === "public" ? (
+                    <div className="ml-2 mr-3">{shareLinkButton("sm")}</div>
+                  ) : null}
+                </>
+              ) : null}
               <MoreMenu>
                 {experiment.status !== "running" && editTargeting && (
                   <button
@@ -449,6 +634,13 @@ export default function ExperimentHeader({
                     mutate={mutate}
                   />
                 )}
+                <button
+                  className="dropdown-item"
+                  onClick={() => setAuditModal(true)}
+                >
+                  Audit log
+                </button>
+                <hr className="mx-4 my-2" />
                 <WatchButton
                   itemType="experiment"
                   item={experiment.id}
@@ -463,12 +655,48 @@ export default function ExperimentHeader({
                     {usersWatching.length}
                   </span>
                 </button>
-                <button
-                  className="dropdown-item"
-                  onClick={() => setAuditModal(true)}
-                >
-                  Audit log
-                </button>
+                {canEditExperiment ||
+                duplicate ||
+                canRunExperiment ||
+                (hasUpdatePermissions &&
+                  experiment.archived &&
+                  permissionsUtil.canCreateReport(experiment) &&
+                  snapshot) ? (
+                  <hr className="mx-4 my-2" />
+                ) : null}
+                {canEditExperiment && (
+                  <button
+                    className="dropdown-item"
+                    onClick={() => setShareModalOpen(true)}
+                  >
+                    Share {isBandit ? "Bandit" : "Experiment"}
+                  </button>
+                )}
+                {permissionsUtil.canCreateReport(experiment) && snapshot ? (
+                  <button
+                    className="dropdown-item"
+                    onClick={async () => {
+                      const res = await apiCall<{ report: ReportInterface }>(
+                        `/experiments/report/${snapshot.id}`,
+                        {
+                          method: "POST",
+                          body: reportArgs
+                            ? JSON.stringify(reportArgs)
+                            : undefined,
+                        }
+                      );
+                      if (!res.report) {
+                        throw new Error("Failed to create report");
+                      }
+                      track("Experiment Report: Create", {
+                        source: "experiment more menu",
+                      });
+                      await router.push(`/report/${res.report.id}`);
+                    }}
+                  >
+                    Create shareable report
+                  </button>
+                ) : null}
                 {duplicate && (
                   <button className="dropdown-item" onClick={duplicate}>
                     Duplicate

--- a/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
@@ -135,10 +135,8 @@ export default function ExperimentHeader({
   const { scrollY } = useScrollPosition();
   useEffect(() => {
     if (!tabsRef.current) return;
-
     const isHeaderSticky =
       tabsRef.current.getBoundingClientRect().top <= TABS_HEADER_HEIGHT_PX;
-
     setHeaderPinned(isHeaderSticky);
   }, [scrollY]);
 

--- a/packages/front-end/components/Experiment/TabbedPage/Implementation.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/Implementation.tsx
@@ -148,7 +148,12 @@ export default function Implementation({
         phaseIndex={phases.length - 1}
       />
 
-      <AnalysisSettings experiment={experiment} mutate={mutate} envs={envs} />
+      <AnalysisSettings
+        experiment={experiment}
+        mutate={mutate}
+        envs={envs}
+        canEdit={!!editTargeting}
+      />
     </div>
   );
 }

--- a/packages/front-end/components/Experiment/TabbedPage/ResultsTab.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/ResultsTab.tsx
@@ -317,14 +317,14 @@ export default function ResultsTab({
           )}
         </div>
       </div>
-      {snapshot && !isBandit && (
+      {snapshot && (
         <div className="bg-white border mt-4">
           <div className="row mx-2 py-3 d-flex align-items-center">
             <div className="col ml-2">
               <div className="h3">Custom Reports</div>
               <div>
-                Create and share an ad-hoc analysis without affecting this
-                experiment.
+                Create and share an ad-hoc analysis without affecting this{" "}
+                {isBandit ? "Bandit" : "Experiment"}.
               </div>
             </div>
             <div className="col-auto mr-2">

--- a/packages/front-end/components/Experiment/VariationsTable.tsx
+++ b/packages/front-end/components/Experiment/VariationsTable.tsx
@@ -16,7 +16,7 @@ const ScreenshotCarousel: FC<{
   variation: Variation;
   canEditExperiment: boolean;
   experiment: ExperimentInterfaceStringDates;
-  mutate: () => void;
+  mutate?: () => void;
   maxChildHeight?: number;
 }> = ({
   canEditExperiment,
@@ -50,7 +50,7 @@ const ScreenshotCarousel: FC<{
                 );
               }
 
-              mutate();
+              mutate?.();
             }
       }
       maxChildHeight={maxChildHeight}
@@ -75,7 +75,7 @@ const ScreenshotCarousel: FC<{
 interface Props {
   experiment: ExperimentInterfaceStringDates;
   canEditExperiment: boolean;
-  mutate: () => void;
+  mutate?: () => void;
 }
 
 const VariationsTable: FC<Props> = ({
@@ -180,7 +180,7 @@ const VariationsTable: FC<Props> = ({
                       <ScreenshotUpload
                         variation={i}
                         experiment={experiment.id}
-                        onSuccess={() => mutate()}
+                        onSuccess={() => mutate?.()}
                       />
                     </div>
                   </td>

--- a/packages/front-end/components/Experiment/VisualChangesetTable.tsx
+++ b/packages/front-end/components/Experiment/VisualChangesetTable.tsx
@@ -25,7 +25,7 @@ import LinkedChange from "@/components/Experiment/LinkedChange";
 type Props = {
   experiment: ExperimentInterfaceStringDates;
   visualChangesets: VisualChangesetInterface[];
-  mutate: () => void;
+  mutate?: () => void;
   canEditVisualChangesets: boolean;
 };
 
@@ -254,7 +254,7 @@ export const VisualChangesetTable: FC<Props> = ({
       await apiCall(`/visual-changesets/${id}`, {
         method: "DELETE",
       });
-      mutate();
+      mutate?.();
       track("Delete visual changeset", {
         source: "visual-editor-ui",
       });
@@ -282,7 +282,7 @@ export const VisualChangesetTable: FC<Props> = ({
         method: "PUT",
         body: JSON.stringify(newVisualChangeset),
       });
-      mutate();
+      mutate?.();
       track("Delete visual changeset", {
         source: "visual-editor-ui",
       });
@@ -350,7 +350,7 @@ export const VisualChangesetTable: FC<Props> = ({
         );
       })}
 
-      {editingVisualChangeset ? (
+      {editingVisualChangeset && mutate ? (
         <VisualChangesetModal
           mode="edit"
           experiment={experiment}

--- a/packages/front-end/components/Report/ConfigureReport.tsx
+++ b/packages/front-end/components/Report/ConfigureReport.tsx
@@ -110,6 +110,8 @@ export default function ConfigureReport({
     "sequential-testing"
   );
 
+  const isBandit = experiment?.type === "multi-armed-bandit";
+
   return (
     <Modal
       open={true}
@@ -205,7 +207,7 @@ export default function ConfigureReport({
                   }
                 >
                   <div style={{ lineHeight: 1.25 }}>
-                    Use Experiment start date
+                    Use {isBandit ? "Bandit" : "Experiment"} start date
                     <br />
                     <small>
                       {date(experiment?.phases?.[0]?.dateStarted || "")}

--- a/packages/front-end/components/Report/ReportAnalysisSettingsBar.tsx
+++ b/packages/front-end/components/Report/ReportAnalysisSettingsBar.tsx
@@ -51,15 +51,6 @@ export default function ReportAnalysisSettingsBar({
     }
   }, [_snapshot, snapshot]);
 
-  const variations = report.experimentMetadata.variations.map(
-    (variation, i) => ({
-      id: variation.id,
-      name: variation.name,
-      weight:
-        report.experimentMetadata.phases?.[snapshot?.phase || 0]
-          ?.variationWeights?.[i] || 1 / (variations?.length || 2),
-    })
-  );
   const analysis = snapshot
     ? getSnapshotAnalysis(snapshot) ?? undefined
     : undefined;

--- a/packages/front-end/components/Report/ReportMetaInfo.tsx
+++ b/packages/front-end/components/Report/ReportMetaInfo.tsx
@@ -35,7 +35,7 @@ import ShareStatusBadge from "@/components/Report/ShareStatusBadge";
 
 type ShareLevel = "public" | "organization" | "private";
 type EditLevel = "organization" | "private";
-const saveSettingTimeoutMs = 3000;
+const SAVE_SETTING_TIMEOUT_MS = 3000;
 
 export default function ReportMetaInfo({
   report,
@@ -109,7 +109,7 @@ export default function ReportMetaInfo({
       name: variation.name,
       weight:
         report.experimentMetadata.phases?.[snapshot?.phase || 0]
-          ?.variationWeights?.[i] || 1 / (variations?.length || 2),
+          ?.variationWeights?.[i] || 1 / (report.experimentMetadata?.variations?.length || 2),
     })
   );
   const analysis = snapshot
@@ -132,14 +132,14 @@ export default function ReportMetaInfo({
           setSaveShareLevelStatus("success");
           saveShareLevelTimeout.current = window.setTimeout(
             () => setSaveShareLevelStatus(null),
-            saveSettingTimeoutMs
+            SAVE_SETTING_TIMEOUT_MS
           );
         })
         .catch(() => {
           setSaveShareLevelStatus("fail");
           saveShareLevelTimeout.current = window.setTimeout(
             () => setSaveShareLevelStatus(null),
-            saveSettingTimeoutMs
+            SAVE_SETTING_TIMEOUT_MS
           );
         });
       track("Experiment Report: Set Share Level", {
@@ -152,7 +152,7 @@ export default function ReportMetaInfo({
     report.shareLevel,
     shareLevel,
     mutate,
-    setSaveEditLevelStatus,
+    setSaveShareLevelStatus,
     apiCall,
     showEditControls,
   ]);

--- a/packages/front-end/components/Report/ReportMetaInfo.tsx
+++ b/packages/front-end/components/Report/ReportMetaInfo.tsx
@@ -330,7 +330,7 @@ export default function ReportMetaInfo({
                 <LinkButton
                   variant="outline"
                   href={`/report/${report.id}`}
-                  mr="4"
+                  mr={showEditControls ? "4" : "0"}
                 >
                   Edit Report
                 </LinkButton>

--- a/packages/front-end/components/Report/ReportMetaInfo.tsx
+++ b/packages/front-end/components/Report/ReportMetaInfo.tsx
@@ -109,7 +109,8 @@ export default function ReportMetaInfo({
       name: variation.name,
       weight:
         report.experimentMetadata.phases?.[snapshot?.phase || 0]
-          ?.variationWeights?.[i] || 1 / (report.experimentMetadata?.variations?.length || 2),
+          ?.variationWeights?.[i] ||
+        1 / (report.experimentMetadata?.variations?.length || 2),
     })
   );
   const analysis = snapshot
@@ -330,7 +331,7 @@ export default function ReportMetaInfo({
                 <LinkButton
                   variant="outline"
                   href={`/report/${report.id}`}
-                  mr={showEditControls ? "4" : "0"}
+                  mr="4"
                 >
                   Edit Report
                 </LinkButton>

--- a/packages/front-end/components/Report/ReportResults.tsx
+++ b/packages/front-end/components/Report/ReportResults.tsx
@@ -53,7 +53,7 @@ export default function ReportResults({
       name: variation.name,
       weight:
         report.experimentMetadata.phases?.[snapshot?.phase || 0]
-          ?.variationWeights?.[i] || 1 / (variations?.length || 2),
+          ?.variationWeights?.[i] || 1 / (report.experimentMetadata?.variations?.length || 2),
     })
   );
   const analysis = snapshot
@@ -250,7 +250,13 @@ export default function ReportResults({
                 ssrPolyfills={ssrPolyfills}
                 hideDetails={!showDetails}
               />
-            ) : null}
+            ): (
+              <div className="mx-3 mb-3">
+                <Callout status="error">
+                  No analysis found for this report
+                </Callout>
+              </div>
+            )}
           </>
         )}
       </div>

--- a/packages/front-end/components/Report/ReportResults.tsx
+++ b/packages/front-end/components/Report/ReportResults.tsx
@@ -53,7 +53,8 @@ export default function ReportResults({
       name: variation.name,
       weight:
         report.experimentMetadata.phases?.[snapshot?.phase || 0]
-          ?.variationWeights?.[i] || 1 / (report.experimentMetadata?.variations?.length || 2),
+          ?.variationWeights?.[i] ||
+        1 / (report.experimentMetadata?.variations?.length || 2),
     })
   );
   const analysis = snapshot
@@ -250,7 +251,7 @@ export default function ReportResults({
                 ssrPolyfills={ssrPolyfills}
                 hideDetails={!showDetails}
               />
-            ): (
+            ) : (
               <div className="mx-3 mb-3">
                 <Callout status="error">
                   No analysis found for this report

--- a/packages/front-end/components/Report/ShareStatusBadge.tsx
+++ b/packages/front-end/components/Report/ShareStatusBadge.tsx
@@ -16,7 +16,7 @@ export default function ShareStatusBadge({
       {shareLevel === "private" ? (
         <Badge variant="soft" color="gray" label="Private" radius="full" />
       ) : shareLevel === "organization" ? (
-        <Badge variant="soft" label="Published" radius="full" />
+        <Badge variant="soft" color="green" label="Published" radius="full" />
       ) : shareLevel === "public" ? (
         <Badge variant="soft" color="orange" label="Public" radius="full" />
       ) : null}

--- a/packages/front-end/components/WatchButton.tsx
+++ b/packages/front-end/components/WatchButton.tsx
@@ -29,9 +29,9 @@ const WatchButton: FC<{
   let text = "";
   if (type === "button") {
     classNames += " btn btn-link";
-    text = isWatching ? "watching" : "watch";
+    text = isWatching ? "Watching" : "Watch";
   } else if (type === "link") {
-    text = isWatching ? "watching" : "watch";
+    text = isWatching ? "Watching" : "Watch";
   }
   if (loading) {
     classNames += " disabled";

--- a/packages/front-end/hooks/useLocalStorage.ts
+++ b/packages/front-end/hooks/useLocalStorage.ts
@@ -3,7 +3,7 @@ import { useState, useEffect, Dispatch, SetStateAction } from "react";
 const getValueFromLocalStorage = (key: string, defaultValue) => {
   let value = defaultValue;
   try {
-    const item = localStorage.getItem(key);
+    const item = globalThis?.localStorage?.getItem(key) || null;
     if (item !== null) {
       value = JSON.parse(item) ?? value;
     }
@@ -23,7 +23,7 @@ export const useLocalStorage = <T>(
 
   useEffect(() => {
     try {
-      localStorage.setItem(key, JSON.stringify(value));
+      globalThis?.localStorage?.setItem(key, JSON.stringify(value));
     } catch (e) {
       console.error(e);
     }

--- a/packages/front-end/hooks/useSSRPolyfills.ts
+++ b/packages/front-end/hooks/useSSRPolyfills.ts
@@ -40,6 +40,7 @@ export default function useSSRPolyfills(
     metricGroups,
     dimensions,
     getDimensionById,
+    getProjectById,
   } = useDefinitions();
 
   const hasCsrSettings = !!Object.keys(useOrgSettings() || {})?.length;
@@ -69,6 +70,10 @@ export default function useSSRPolyfills(
     const orgSettings = useOrgSettings();
     return hasCsrSettings ? orgSettings : ssrData?.settings || {};
   };
+  const getProjectByIdSSR = useCallback(
+    (id) => getProjectById(id) || ssrData?.projects?.[id] || null,
+    [getProjectById, ssrData?.projects]
+  );
   const useCurrencySSR = () => {
     const currency = useCurrency();
     if (hasCsrSettings) return currency;
@@ -120,6 +125,7 @@ export default function useSSRPolyfills(
     getMetricGroupById: getMetricGroupByIdSSR,
     getFactTableById: getFactTableByIdSSR,
     useOrgSettings: useOrgSettingsSSR,
+    getProjectById: getProjectByIdSSR,
     useCurrency: useCurrencySSR,
     usePValueThreshold: usePValueThresholdSSR,
     useConfidenceLevels: useConfidenceLevelsSSR,

--- a/packages/front-end/hooks/useSSRPolyfills.ts
+++ b/packages/front-end/hooks/useSSRPolyfills.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from "react";
 import { DEFAULT_P_VALUE_THRESHOLD } from "shared/constants";
-import { SSRExperimentReportData } from "back-end/types/report";
+import { ExperimentReportSSRData } from "back-end/types/report";
 import { ExperimentMetricInterface } from "shared/experiments";
 import { MetricGroupInterface } from "back-end/types/metric-groups";
 import { FactTableInterface } from "back-end/types/fact-table";
@@ -31,7 +31,7 @@ export interface SSRPolyfills {
 }
 
 export default function useSSRPolyfills(
-  ssrData: SSRExperimentReportData | null
+  ssrData: ExperimentReportSSRData | null
 ): SSRPolyfills {
   const {
     getExperimentMetricById,

--- a/packages/front-end/hooks/useSSRPolyfills.ts
+++ b/packages/front-end/hooks/useSSRPolyfills.ts
@@ -5,6 +5,7 @@ import { ExperimentMetricInterface } from "shared/experiments";
 import { MetricGroupInterface } from "back-end/types/metric-groups";
 import { FactTableInterface } from "back-end/types/fact-table";
 import { DimensionInterface } from "back-end/types/dimension";
+import { ProjectInterface } from "back-end/types/project";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import useOrgSettings from "@/hooks/useOrgSettings";
 import useConfidenceLevels from "@/hooks/useConfidenceLevels";
@@ -22,6 +23,7 @@ export interface SSRPolyfills {
   getMetricGroupById: (id: string) => null | MetricGroupInterface;
   getFactTableById: (id: string) => null | FactTableInterface;
   useOrgSettings: typeof useOrgSettings;
+  getProjectById: (id: string) => null | ProjectInterface;
   useCurrency: typeof useCurrency;
   usePValueThreshold: typeof usePValueThreshold;
   useConfidenceLevels: typeof useConfidenceLevels;
@@ -62,7 +64,7 @@ export default function useSSRPolyfills(
     [getMetricGroupById, metricGroupsSSR]
   );
   const getFactTableByIdSSR = useCallback(
-    (id) => getFactTableById(id) || ssrData?.factTables?.[id] || null,
+    (id: string) => getFactTableById(id) || ssrData?.factTables?.[id] || null,
     [getFactTableById, ssrData?.factTables]
   );
 
@@ -71,7 +73,7 @@ export default function useSSRPolyfills(
     return hasCsrSettings ? orgSettings : ssrData?.settings || {};
   };
   const getProjectByIdSSR = useCallback(
-    (id) => getProjectById(id) || ssrData?.projects?.[id] || null,
+    (id: string) => getProjectById(id) || ssrData?.projects?.[id] || null,
     [getProjectById, ssrData?.projects]
   );
   const useCurrencySSR = () => {

--- a/packages/front-end/hooks/useScrollPosition.ts
+++ b/packages/front-end/hooks/useScrollPosition.ts
@@ -2,19 +2,19 @@ import { useEffect, useState } from "react";
 
 export function useScrollPosition() {
   const [scrollPosition, setScrollPosition] = useState({
-    scrollX: window.pageXOffset,
-    scrollY: window.pageYOffset,
+    scrollX: globalThis?.window?.pageXOffset || 0,
+    scrollY: globalThis?.window?.pageYOffset || 0,
   });
   useEffect(() => {
     function onScroll() {
       setScrollPosition({
-        scrollX: window.pageXOffset,
-        scrollY: window.pageYOffset,
+        scrollX: globalThis?.window?.pageXOffset || 0,
+        scrollY: globalThis?.window?.pageYOffset || 0,
       });
     }
 
-    window.addEventListener("scroll", onScroll, { passive: true });
-    return () => window.removeEventListener("scroll", onScroll);
+    globalThis?.window?.addEventListener("scroll", onScroll, { passive: true });
+    return () => globalThis?.window?.removeEventListener("scroll", onScroll);
   }, []);
   return scrollPosition;
 }

--- a/packages/front-end/hooks/useURLHash.ts
+++ b/packages/front-end/hooks/useURLHash.ts
@@ -53,7 +53,8 @@ export default function useURLHash<Id extends string>(
     };
 
     globalThis?.window?.addEventListener("hashchange", handler, false);
-    return () => globalThis?.window?.removeEventListener("hashchange", handler, false);
+    return () =>
+      globalThis?.window?.removeEventListener("hashchange", handler, false);
   }, [validIds]);
 
   return [hash, setHashAndURL] as const;

--- a/packages/front-end/hooks/useURLHash.ts
+++ b/packages/front-end/hooks/useURLHash.ts
@@ -28,7 +28,7 @@ export default function useURLHash<Id extends string>(
 ) {
   const [hash, setHashState] = useState(() => {
     // Get initial hash from URL
-    const urlHash = window.location.hash.slice(1);
+    const urlHash = globalThis?.window?.location?.hash?.slice(1) || "";
     if (validIds === undefined) {
       return urlHash === "" ? undefined : urlHash;
     } else {
@@ -37,6 +37,7 @@ export default function useURLHash<Id extends string>(
   });
 
   const setHashAndURL = (newHash: Id) => {
+    if (!globalThis?.window?.location?.hash) return;
     if (validIds === undefined || validIds.includes(newHash)) {
       window.location.hash = newHash;
     }
@@ -45,14 +46,14 @@ export default function useURLHash<Id extends string>(
   // Listen for URL changes
   useEffect(() => {
     const handler = () => {
-      const newHash = window.location.hash.slice(1);
+      const newHash = globalThis?.window?.location?.hash?.slice(1) || "";
       if (validIds === undefined || validIds.includes(newHash as Id)) {
         setHashState(newHash === "" ? undefined : newHash);
       }
     };
 
-    window.addEventListener("hashchange", handler, false);
-    return () => window.removeEventListener("hashchange", handler, false);
+    globalThis?.window?.addEventListener("hashchange", handler, false);
+    return () => globalThis?.window?.removeEventListener("hashchange", handler, false);
   }, [validIds]);
 
   return [hash, setHashAndURL] as const;

--- a/packages/front-end/pages/public/e/[e].tsx
+++ b/packages/front-end/pages/public/e/[e].tsx
@@ -20,6 +20,7 @@ import {useLocalStorage} from "@/hooks/useLocalStorage";
 import {ExperimentTab} from "@/components/Experiment/TabbedPage";
 import PublicExperimentOverview from "@/components/Experiment/Public/PublicExperimentOverview";
 import PublicExperimentResults from "@/components/Experiment/Public/PublicExperimentResults";
+import BanditSummaryResultsTab from "@/components/Experiment/TabbedPage/BanditSummaryResultsTab";
 
 export async function getServerSideProps(context) {
   const { e } = context.params;
@@ -217,7 +218,23 @@ export default function PublicExperimentPage(props: PublicExperimentPageProps) {
               ssrPolyfills={ssrPolyfills}
             />
           </div>
-          {/*todo: bandit summary results*/}
+
+          {isBandit ? (
+            <div
+              className={
+                isBandit && tab === "results" ? "d-block" : "d-none d-print-block"
+              }
+            >
+              <BanditSummaryResultsTab
+                experiment={experiment}
+                isTabActive={tab === "results"}
+                ssrSnapshot={snapshot ?? undefined}
+                ssrPolyfills={ssrPolyfills}
+                isPublic={true}
+              />
+            </div>
+          ) : null}
+
           <div
             className={
               (!isBandit && tab === "results") || (isBandit && tab === "explore")

--- a/packages/front-end/pages/public/e/[e].tsx
+++ b/packages/front-end/pages/public/e/[e].tsx
@@ -1,0 +1,333 @@
+import {
+  ExperimentReportSSRData,
+} from "back-end/types/report";
+import { ExperimentSnapshotInterface } from "back-end/types/experiment-snapshot";
+import Head from "next/head";
+import {ExperimentInterfaceStringDates, ExperimentPhaseStringDates, LinkedFeatureInfo} from "back-end/types/experiment";
+import { truncateString } from "shared/util";
+import {date, daysBetween} from "shared/dates";
+import PageHead from "@/components/Layout/PageHead";
+import { useUser } from "@/services/UserContext";
+import useSSRPolyfills from "@/hooks/useSSRPolyfills";
+import PublicExperimentMetaInfo from "@/components/Experiment/Public/PublicExperimentMetaInfo";
+import Markdown from "@/components/Markdown/Markdown";
+import React, {useEffect, useRef, useState} from "react";
+import clsx from "clsx";
+import {Tabs, TabsList, TabsTrigger} from "@/components/Radix/Tabs";
+import {useScrollPosition} from "@/hooks/useScrollPosition";
+import {useLocalStorage} from "@/hooks/useLocalStorage";
+import {ExperimentTab} from "@/components/Experiment/TabbedPage";
+import VariationsTable from "@/components/Experiment/VariationsTable";
+import {VisualChangesetInterface} from "back-end/types/visual-changeset";
+import {URLRedirectInterface} from "back-end/types/url-redirect";
+import VisualLinkedChanges from "@/components/Experiment/LinkedChanges/VisualLinkedChanges";
+import FeatureLinkedChanges from "@/components/Experiment/LinkedChanges/FeatureLinkedChanges";
+import RedirectLinkedChanges from "@/components/Experiment/LinkedChanges/RedirectLinkedChanges";
+import TrafficAndTargeting from "@/components/Experiment/TabbedPage/TrafficAndTargeting";
+import AnalysisSettings from "@/components/Experiment/TabbedPage/AnalysisSettings";
+
+export async function getServerSideProps(context) {
+  const { e } = context.params;
+  const apiHost =
+    (process.env.API_HOST ?? "").replace(/\/$/, "") || "http://localhost:3100";
+
+  try {
+    const resp = await fetch(apiHost + `/api/experiment/public/${e}`);
+    const data = await resp.json();
+    const experiment = data?.experiment;
+    if (!experiment) {
+      context.res.statusCode = 404;
+    }
+
+    const snapshot = data?.snapshot;
+    const visualChangesets = data?.visualChangesets;
+    const urlRedirects = data?.urlRedirects;
+    const linkedFeatures = data?.linkedFeatures;
+    const ssrData = data?.ssrData;
+
+    return {
+      props: {
+        experiment: experiment || null,
+        snapshot: snapshot || null,
+        visualChangesets: visualChangesets || null,
+        urlRedirects: urlRedirects || null,
+        linkedFeatures: linkedFeatures || null,
+        ssrData: ssrData || null,
+      },
+    };
+  } catch (e) {
+    console.error(e);
+    return {
+      notFound: true,
+    };
+  }
+}
+
+interface PublicExperimentPageProps {
+  experiment: ExperimentInterfaceStringDates | null;
+  snapshot: ExperimentSnapshotInterface | null;
+  visualChangesets: VisualChangesetInterface[] | null;
+  urlRedirects: URLRedirectInterface[] | null;
+  linkedFeatures: LinkedFeatureInfo[] | null;
+  ssrData: ExperimentReportSSRData | null;
+}
+
+const TABS_HEADER_HEIGHT_PX = 55;
+
+export default function PublicExperimentPage(props: PublicExperimentPageProps) {
+  const { userId, organization: userOrganization, superAdmin} = useUser();
+  const {
+    experiment,
+    snapshot,
+    visualChangesets,
+    urlRedirects,
+    linkedFeatures,
+    ssrData
+  } = props;
+
+  console.log({
+    experiment,
+    snapshot,
+    visualChangesets,
+    urlRedirects,
+    linkedFeatures,
+    ssrData
+  });
+  const isOrgMember =
+    (!!userId && experiment?.organization === userOrganization.id) || !!superAdmin;
+
+  const ssrPolyfills = useSSRPolyfills(ssrData);
+
+  const [tab, setTab] = useLocalStorage<ExperimentTab>(
+    `tabbedPageTab__public__${experiment?.id}`,
+    "overview"
+  );
+  const tabsRef = useRef<HTMLDivElement>(null);
+  const [headerPinned, setHeaderPinned] = useState(false);
+  const { scrollY } = useScrollPosition();
+  useEffect(() => {
+    if (!tabsRef.current) return;
+    const isHeaderSticky =
+      tabsRef.current.getBoundingClientRect().top <= TABS_HEADER_HEIGHT_PX;
+    setHeaderPinned(isHeaderSticky);
+  }, [scrollY]);
+
+  const phases = experiment?.phases || [];
+  const lastPhaseIndex = phases.length - 1;
+  const lastPhase = phases[lastPhaseIndex] as
+    | undefined
+    | ExperimentPhaseStringDates;
+  const startDate = phases?.[0]?.dateStarted
+    ? date(phases[0].dateStarted)
+    : null;
+  const endDate =
+    phases.length > 0
+      ? lastPhase?.dateEnded
+        ? date(lastPhase.dateEnded ?? "")
+        : "now"
+      : date(new Date());
+  const dateRangeLabel = startDate
+    ? `${date(startDate)} — ${
+      endDate ? date(endDate) : "now"
+    }`
+    : "";
+
+  const analysis = snapshot?.analyses?.[0];
+  const hasResults = !!analysis?.results?.[0];
+  const shouldHideTabs = !experiment ||
+    (experiment?.status === "draft" && !hasResults && phases.length === 1);
+
+  const hasLinkedChanges =
+    experiment?.hasVisualChangesets ||
+    (linkedFeatures?.length ?? 0) > 0 ||
+    experiment?.hasURLRedirects;
+
+  const isBandit = experiment?.type === "multi-armed-bandit";
+
+  return (
+    <div className={`container-fluid public ${isBandit ? "bandit" : "experiment"}`}>
+      <Head>
+        <title>{experiment?.name || "Experiment not found"}</title>
+        <meta
+          property="og:title"
+          content={experiment?.name || "Experiment not found"}
+        />
+        <meta
+          property="og:description"
+          content={truncateString(experiment?.description || "", 500)}
+        />
+        <meta property="twitter:label1" content="Status" />
+        <meta property="twitter:data1" content={experiment?.status} />
+        <meta property="twitter:label2" content="Date Range" />
+        <meta property="twitter:data2" content={dateRangeLabel} />
+      </Head>
+
+      <PageHead
+        breadcrumb={[
+          {
+            display: isBandit ? "Bandits" : "Experiments",
+            href: isBandit ? "/bandits" : "/experiments",
+          },
+          {
+            display:
+              experiment?.name ?? (experiment ? "(no title)" : "(experiment not found)"),
+          },
+        ]}
+      />
+
+      {experiment ? (
+        <PublicExperimentMetaInfo
+          experiment={experiment}
+          showPrivateLink={isOrgMember}
+        />
+      ) : null}
+
+      {shouldHideTabs ? null : (
+        <div
+          className={clsx("experiment-tabs d-print-none", {
+            pinned: headerPinned,
+          })}
+        >
+          <div className="container-fluid pagecontents position-relative">
+            <div className="row header-tabs position-relative" ref={tabsRef}>
+              <Tabs
+                value={tab}
+                onValueChange={(t: ExperimentTab) => setTab(t)}
+                style={{ width: "100%" }}
+              >
+                <TabsList size="3">
+                  <TabsTrigger value="overview">Overview</TabsTrigger>
+                  <TabsTrigger value="results">Results</TabsTrigger>
+                  {isBandit ? (
+                    <TabsTrigger value="explore">Explore</TabsTrigger>
+                  ) : null}
+                </TabsList>
+              </Tabs>
+
+              <div className="col-auto experiment-date-range">
+                {startDate && (
+                  <span>
+                    {startDate} — {endDate}{" "}
+                    <span className="text-muted">
+                      ({daysBetween(startDate, endDate)} days)
+                    </span>
+                  </span>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {experiment ? (
+        <div className="mt-3 container-fluid pagecontents">
+          <div
+            className={clsx(
+              "pt-3",
+              tab === "overview" ? "d-block" : "d-none d-print-block"
+            )}
+          >
+            <h2>Overview</h2>
+
+            <div className="box px-4 py-3 mb-4">
+              <h4>Description</h4>
+              <Markdown>
+                {experiment?.description}
+              </Markdown>
+            </div>
+
+            {experiment?.type !== "multi-armed-bandit" && experiment?.hypothesis ? (
+              <div className="box px-4 py-3 mb-4">
+                <h4>Hypothesis</h4>
+                {experiment?.hypothesis}
+              </div>
+            ) : null}
+
+            <h2>Implementation</h2>
+
+            <div className="box px-2 py-3 mb-4">
+              <h4 className="mx-3">Variations</h4>
+              <VariationsTable
+                experiment={experiment}
+                canEditExperiment={false}
+              />
+            </div>
+
+            {hasLinkedChanges ? (
+              <>
+                <VisualLinkedChanges
+                  visualChangesets={visualChangesets ?? []}
+                  canAddChanges={false}
+                  canEditVisualChangesets={false}
+                  experiment={experiment}
+                />
+                <FeatureLinkedChanges
+                  linkedFeatures={linkedFeatures ?? []}
+                  experiment={experiment}
+                  canAddChanges={false}
+                />
+                <RedirectLinkedChanges
+                  urlRedirects={urlRedirects ?? []}
+                  experiment={experiment}
+                  canAddChanges={false}
+                />
+              </>
+            ) : null}
+          </div>
+
+          <TrafficAndTargeting
+            experiment={experiment}
+            phaseIndex={lastPhaseIndex}
+          />
+
+          <AnalysisSettings
+            experiment={experiment}
+            envs={[]}
+            canEdit={false}
+          />
+
+        </div>
+      ): null}
+
+      {/*{report ? (*/}
+      {/*  <>*/}
+      {/*    <ReportMetaInfo*/}
+      {/*      report={report}*/}
+      {/*      experiment={experiment ?? undefined}*/}
+      {/*      canView={canView}*/}
+      {/*      showPrivateLink={isOrgMember}*/}
+      {/*    />*/}
+
+      {/*    {canView ? (*/}
+      {/*      <ReportResults*/}
+      {/*        report={report}*/}
+      {/*        snapshot={snapshot ?? undefined}*/}
+      {/*        snapshotError={*/}
+      {/*          !snapshot ? new Error("Missing snapshot") : undefined*/}
+      {/*        }*/}
+      {/*        showDetails={isOrgMember}*/}
+      {/*        ssrPolyfills={ssrPolyfills}*/}
+      {/*      />*/}
+      {/*    ) : (*/}
+      {/*      <Callout status="error">*/}
+      {/*        This report is not shared publicly.*/}
+      {/*        {!userReady && (*/}
+      {/*          <>*/}
+      {/*            {" "}*/}
+      {/*            <Link href="/">Log in</Link> to view this link.*/}
+      {/*          </>*/}
+      {/*        )}*/}
+      {/*      </Callout>*/}
+      {/*    )}*/}
+      {/*  </>*/}
+      {/*) : (*/}
+      {/*  <Callout status="error">This report was not found.</Callout>*/}
+      {/*)}*/}
+    </div>
+  );
+}
+
+PublicExperimentPage.preAuth = true;
+PublicExperimentPage.progressiveAuth = true;
+PublicExperimentPage.progressiveAuthTopNav = true;
+PublicExperimentPage.noLoadingOverlay = true;

--- a/packages/front-end/pages/public/e/[e].tsx
+++ b/packages/front-end/pages/public/e/[e].tsx
@@ -85,18 +85,11 @@ export default function PublicExperimentPage(props: PublicExperimentPageProps) {
     ssrData
   } = props;
 
-  console.log({
-    experiment,
-    snapshot,
-    visualChangesets,
-    urlRedirects,
-    linkedFeatures,
-    ssrData
-  });
   const isOrgMember =
     (!!userId && experiment?.organization === userOrganization.id) || !!superAdmin;
 
   const ssrPolyfills = useSSRPolyfills(ssrData);
+  console.log(ssrPolyfills)
 
   const [tab, setTab] = useLocalStorage<ExperimentTab>(
     `tabbedPageTab__public__${experiment?.id}`,
@@ -284,45 +277,12 @@ export default function PublicExperimentPage(props: PublicExperimentPageProps) {
             experiment={experiment}
             envs={[]}
             canEdit={false}
+            ssrPolyfills={ssrPolyfills}
           />
 
         </div>
       ): null}
 
-      {/*{report ? (*/}
-      {/*  <>*/}
-      {/*    <ReportMetaInfo*/}
-      {/*      report={report}*/}
-      {/*      experiment={experiment ?? undefined}*/}
-      {/*      canView={canView}*/}
-      {/*      showPrivateLink={isOrgMember}*/}
-      {/*    />*/}
-
-      {/*    {canView ? (*/}
-      {/*      <ReportResults*/}
-      {/*        report={report}*/}
-      {/*        snapshot={snapshot ?? undefined}*/}
-      {/*        snapshotError={*/}
-      {/*          !snapshot ? new Error("Missing snapshot") : undefined*/}
-      {/*        }*/}
-      {/*        showDetails={isOrgMember}*/}
-      {/*        ssrPolyfills={ssrPolyfills}*/}
-      {/*      />*/}
-      {/*    ) : (*/}
-      {/*      <Callout status="error">*/}
-      {/*        This report is not shared publicly.*/}
-      {/*        {!userReady && (*/}
-      {/*          <>*/}
-      {/*            {" "}*/}
-      {/*            <Link href="/">Log in</Link> to view this link.*/}
-      {/*          </>*/}
-      {/*        )}*/}
-      {/*      </Callout>*/}
-      {/*    )}*/}
-      {/*  </>*/}
-      {/*) : (*/}
-      {/*  <Callout status="error">This report was not found.</Callout>*/}
-      {/*)}*/}
     </div>
   );
 }

--- a/packages/front-end/pages/public/r/[r].tsx
+++ b/packages/front-end/pages/public/r/[r].tsx
@@ -1,6 +1,6 @@
 import {
   ExperimentSnapshotReportInterface,
-  SSRExperimentReportData,
+  ExperimentReportSSRData,
 } from "back-end/types/report";
 import { ExperimentSnapshotInterface } from "back-end/types/experiment-snapshot";
 import Head from "next/head";
@@ -51,7 +51,7 @@ interface ReportPageProps {
   report: ExperimentSnapshotReportInterface | null;
   snapshot: ExperimentSnapshotInterface | null;
   experiment: Partial<ExperimentInterfaceStringDates> | null;
-  ssrData: SSRExperimentReportData | null;
+  ssrData: ExperimentReportSSRData | null;
 }
 
 export default function ReportPage(props: ReportPageProps) {

--- a/packages/front-end/pages/report/[rid].tsx
+++ b/packages/front-end/pages/report/[rid].tsx
@@ -91,17 +91,21 @@ export default function ReportPage() {
   const isAdmin = permissionsUtil.canSuperDeleteReport();
   const canDelete = isOwner || isAdmin;
 
+  const isBandit = experiment?.type === "multi-armed-bandit";
+
   return (
     <div className="pagecontents container-fluid">
       <PageHead
         breadcrumb={[
           {
-            display: `Experiments`,
-            href: `/experiments`,
+            display: isBandit ? `Bandits` : `Experiments`,
+            href: isBandit ? `/bandits` : `/experiments`,
           },
           {
             display: `${experiment?.name ?? "Report"}`,
-            href: experiment?.id ? `/experiment/${experiment.id}` : undefined,
+            href: experiment?.id
+              ? `/${isBandit ? `bandit` : `experiment`}/${experiment.id}`
+              : undefined,
           },
           { display: report.title },
         ]}

--- a/packages/front-end/styles/global.scss
+++ b/packages/front-end/styles/global.scss
@@ -569,8 +569,7 @@ pre {
 .main.experiment,
 .main.bandit,
 .public.experiment,
-.public.bandit,
-  {
+.public.bandit {
   .experiment-header {
     margin: -4px -8px 0;
     .border {
@@ -580,9 +579,10 @@ pre {
   .experiment-tabs {
     background-color: var(--background-color);
     // NB: Keep top property in sync with TABS_HEADER_HEIGHT_PX in ExperimentHeader.tsx
+    // also, make sure shared reports & shared experiments look good
     top: 55px;
     height: 40px;
-    margin: 0 -8px -3px;
+    margin: 0 -16px -3px;
     transition: 150ms all;
     .header-tabs {
       flex-wrap: nowrap;
@@ -626,9 +626,13 @@ pre {
     &.pinned {
       position: sticky;
       z-index: 830;
-      box-shadow: var(--shadow-3);
+      // ensure no shadow bleeds above component, otherwise noticeable when scrolling quickly
+      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1), 0 4px 4px rgba(0, 0, 0, 0.025);
       .header-tabs .tab-wrapper {
         overflow: hidden;
+      }
+      .rt-BaseTabList {
+        box-shadow: none !important;
       }
     }
   }
@@ -796,12 +800,20 @@ pre {
     transform: translate(0.5px, -0.5px);
   }
 }
-main.main.report,
-main.main.r {
+main.main.report {
   .experiment-results {
     th {
       &.axis-col {
         top: 50px;
+      }
+    }
+  }
+}
+main.main.public {
+  .experiment-results {
+    th {
+      &.axis-col {
+        top: 95px;
       }
     }
   }

--- a/packages/front-end/styles/global.scss
+++ b/packages/front-end/styles/global.scss
@@ -567,7 +567,10 @@ pre {
 }
 
 .main.experiment,
-.main.bandit {
+.main.bandit,
+.public.experiment,
+.public.bandit,
+  {
   .experiment-header {
     margin: -4px -8px 0;
     .border {


### PR DESCRIPTION
Makes entire experiments/bandits shareable (not shared by default)

share link visible when experiment is in a "stopped" state:
<img width="1372" alt="image" src="https://github.com/user-attachments/assets/20ce4754-fede-4e8a-be93-36031db18c42" />

pops a modal, nearly identical to shareable reports:
<img width="569" alt="image" src="https://github.com/user-attachments/assets/a076f2db-a612-40f3-b3b0-dbe4eff34ad7" />

if user does not have permissions to change share status, they just get a "copy link" button instead (or if the report is not shared, no button is rendered):
<img width="1210" alt="image" src="https://github.com/user-attachments/assets/90cb1e12-4056-49f3-8739-de1460252efb" />

You can also share (2 ways!) from the dropdown menu:
<img width="342" alt="image" src="https://github.com/user-attachments/assets/9b38a847-6dc6-40e8-9f10-144b81676e15" />

Public shared report page mirrors the actual experiment page, but scrubs a bunch of extraneous or sensitive information away:
<img width="1138" alt="image" src="https://github.com/user-attachments/assets/62d77aeb-f04c-46dc-886a-322b983d4983" />

<img width="1136" alt="image" src="https://github.com/user-attachments/assets/9ead9ff7-f4cb-4b19-a4a5-c870b4648854" />

Also works for Bandits:
<img width="1136" alt="image" src="https://github.com/user-attachments/assets/4db62684-f891-4030-a0a9-f8377b75de4c" />

