### PR TITLE
Ensure validity query respects test query length setting

### DIFF
--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -1233,12 +1233,13 @@ export default abstract class SqlIntegration
   //Test the validity of a query as cheaply as possible
   getTestValidityQuery(
     query: string,
+    testDays?: number,
     templateVariables?: TemplateVariables
   ): string {
     return this.getTestQuery({
       query,
       templateVariables,
-      testDays: DEFAULT_TEST_QUERY_DAYS,
+      testDays: testDays ?? DEFAULT_TEST_QUERY_DAYS,
       limit: 1,
     });
   }

--- a/packages/back-end/src/models/DataSourceModel.ts
+++ b/packages/back-end/src/models/DataSourceModel.ts
@@ -276,7 +276,11 @@ export async function validateExposureQueriesAndAddMissingIds(
         }
         if (checkValidity) {
           const integration = getSourceIntegrationObject(context, datasource);
-          exposure.error = await testQueryValidity(integration, exposure);
+          exposure.error = await testQueryValidity(
+            integration,
+            exposure,
+            context.org.settings?.testQueryDays
+          );
         }
       })
     );

--- a/packages/back-end/src/services/datasource.ts
+++ b/packages/back-end/src/services/datasource.ts
@@ -187,7 +187,8 @@ export async function testQuery(
 // Return any errors that result when running the query otherwise return undefined
 export async function testQueryValidity(
   integration: SourceIntegrationInterface,
-  query: ExposureQuery
+  query: ExposureQuery,
+  testDays?: number
 ): Promise<string | undefined> {
   // The Mixpanel integration does not support test queries
   if (!integration.getTestValidityQuery || !integration.runTestQuery) {
@@ -203,7 +204,7 @@ export async function testQueryValidity(
     ...(query.hasNameCol ? ["experiment_name", "variation_name"] : []),
   ]);
 
-  const sql = integration.getTestValidityQuery(query.query);
+  const sql = integration.getTestValidityQuery(query.query, testDays);
   try {
     const results = await integration.runTestQuery(sql);
     if (results.results.length === 0) {

--- a/packages/back-end/src/types/Integration.ts
+++ b/packages/back-end/src/types/Integration.ts
@@ -525,6 +525,7 @@ export interface SourceIntegrationInterface {
   getInformationSchema?(): Promise<InformationSchema[]>;
   getTestValidityQuery?(
     query: string,
+    testDays?: number,
     templateVariables?: TemplateVariables
   ): string;
   getTestQuery?(params: TestQueryParams): string;

--- a/packages/back-end/test/services/datasource.test.ts
+++ b/packages/back-end/test/services/datasource.test.ts
@@ -49,7 +49,8 @@ describe("testQueryValidity", () => {
 
     expect(result).toBe("No rows returned");
     expect(mockDataSourceIntegration.getTestValidityQuery).toHaveBeenCalledWith(
-      query.query
+      query.query,
+      undefined
     );
     expect(mockDataSourceIntegration.runTestQuery).toHaveBeenCalledWith(
       "SELECT * FROM experiments"
@@ -85,7 +86,8 @@ describe("testQueryValidity", () => {
       "Missing required columns in response: user_id, country, experiment_name, variation_name"
     );
     expect(mockDataSourceIntegration.getTestValidityQuery).toHaveBeenCalledWith(
-      query.query
+      query.query,
+      undefined
     );
     expect(mockDataSourceIntegration.runTestQuery).toHaveBeenCalledWith(
       "SELECT * FROM experiments"
@@ -123,7 +125,8 @@ describe("testQueryValidity", () => {
 
     expect(result).toBeUndefined();
     expect(mockDataSourceIntegration.getTestValidityQuery).toHaveBeenCalledWith(
-      query.query
+      query.query,
+      undefined
     );
     expect(mockDataSourceIntegration.runTestQuery).toHaveBeenCalledWith(
       "SELECT * FROM experiments"
@@ -151,7 +154,8 @@ describe("testQueryValidity", () => {
 
     expect(result).toBe("Test query failed");
     expect(mockDataSourceIntegration.getTestValidityQuery).toHaveBeenCalledWith(
-      query.query
+      query.query,
+      undefined
     );
     expect(mockDataSourceIntegration.runTestQuery).toHaveBeenCalledWith(
       "SELECT * FROM experiments"


### PR DESCRIPTION
### Features and Changes

When editing an EAQ, even if you uncheck "test query before saving" in the SQL edit modal, it does run a validity check when you finally save it. This last test query doesn't respect the test days window, and I believe it should. 

This PR enables that.

We should also consider letting users disable this validity query if they want.

### Dependencies

### Testing

Tested on my dev instance that when saving edits to an EAQ, it now uses the org setting for number of test days rather than the default of 30.

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
