### PR TITLE
Update DataDog docs to use onFeatureUsage

### DIFF
--- a/docs/docs/integrations/datadog.mdx
+++ b/docs/docs/integrations/datadog.mdx
@@ -14,12 +14,14 @@ If your DataDog RUM browser SDK version is below v5.17.0, [enable feature flags 
 
 :::
 
-We can report all feature flag evaluations to DataDog using GrowthBook’s SDK `trackingCallback` function, as shown in the snippet below.
+We can report all feature flag evaluations to DataDog using GrowthBook’s SDK `onFeatureUsage` callback, as shown in the snippet below.
 
-```
-trackingCallback: (experiment, result) => {
-  datadogRum.addFeatureFlagEvaluation(experiment.key, result.key);
-}
+```javascript
+const gb = new GrowthBookClient({
+  onFeatureUsage: (featureKey, result) => {
+    datadogRum.addFeatureFlagEvaluation(featureKey, result.value);
+  }
+});
 ```
 
 ### Advanced example


### PR DESCRIPTION
### Features and Changes

`trackingCallback` is called only on experiments, so for Feature Flags not linked to an experiment this solution does not work.

Updated it to use the proper `onFeatureUsage` callback that works for both Experiment-linked Feature Flags and unlinked ones.