### PR TITLE
Test SQL: Fix scroll not working

### DIFF
--- a/packages/front-end/components/SchemaBrowser/EditSqlModal.tsx
+++ b/packages/front-end/components/SchemaBrowser/EditSqlModal.tsx
@@ -312,15 +312,13 @@ export default function EditSqlModal({
               />
             </div>
             {testQueryResults && (
-              <div className="" style={{ flex: 1, maxHeight: "45%" }}>
-                <DisplayTestQueryResults
-                  duration={parseInt(testQueryResults.duration || "0")}
-                  results={testQueryResults.results || []}
-                  sql={testQueryResults.sql || ""}
-                  error={testQueryResults.error || ""}
-                  close={() => setTestQueryResults(null)}
-                />
-              </div>
+              <DisplayTestQueryResults
+                duration={parseInt(testQueryResults.duration || "0")}
+                results={testQueryResults.results || []}
+                sql={testQueryResults.sql || ""}
+                error={testQueryResults.error || ""}
+                close={() => setTestQueryResults(null)}
+              />
             )}
           </div>
         </div>

--- a/packages/front-end/components/Settings/DisplayTestQueryResults.tsx
+++ b/packages/front-end/components/Settings/DisplayTestQueryResults.tsx
@@ -37,89 +37,106 @@ export default function DisplayTestQueryResults({
     : undefined;
 
   return (
-    <>
-      <Tabs defaultValue={forceShowSql ? "sql" : "results"}>
-        <TabsList>
-          {!forceShowSql && <TabsTrigger value="results">Results</TabsTrigger>}
-          <TabsTrigger value="sql">Rendered SQL</TabsTrigger>
-          <div className="flex-grow-1">
-            <button
-              type="button"
-              className="close"
-              style={{ padding: "0.3rem 1rem" }}
-              onClick={(e) => {
-                e.preventDefault();
-                close();
-              }}
-              aria-label="Close"
-            >
-              <span aria-hidden="true">×</span>
-            </button>
-          </div>
-        </TabsList>
+    <Tabs
+      defaultValue={forceShowSql ? "sql" : "results"}
+      style={{ maxHeight: "50%", overflow: "hidden" }}
+    >
+      <TabsList>
+        {!forceShowSql && <TabsTrigger value="results">Results</TabsTrigger>}
+        <TabsTrigger value="sql">Rendered SQL</TabsTrigger>
+        <div className="flex-grow-1">
+          <button
+            type="button"
+            className="close"
+            style={{ padding: "0.3rem 1rem" }}
+            onClick={(e) => {
+              e.preventDefault();
+              close();
+            }}
+            aria-label="Close"
+          >
+            <span aria-hidden="true">×</span>
+          </button>
+        </div>
+      </TabsList>
 
-        {!forceShowSql && (
-          <TabsContent value="results">
-            <div className="border mt-2 rounded p-2 bg-light">
-              <div className="row">
-                <div className="col-auto">
-                  <strong>Sample {results?.length} Rows</strong>
-                </div>
-                <div className="col-auto ml-auto">
-                  <div className="text-success">
-                    <FaCheck />
-                    <span className="pl-2">Succeeded in {duration}ms</span>
-                  </div>
+      {!forceShowSql && (
+        <TabsContent
+          value="results"
+          style={{ display: "flex", flexDirection: "column", height: "100%" }}
+        >
+          <div className="border mt-2 rounded p-2 bg-light">
+            <div className="row">
+              <div className="col-auto">
+                <strong>Sample {results?.length} Rows</strong>
+              </div>
+              <div className="col-auto ml-auto">
+                <div className="text-success">
+                  <FaCheck />
+                  <span className="pl-2">Succeeded in {duration}ms</span>
                 </div>
               </div>
             </div>
-            <div style={{ width: "100%", overflow: "auto" }} className="mb-3">
-              <table
-                className="table table-bordered table-sm appbox w-100 mb-0"
-                style={{ overflow: "auto" }}
+          </div>
+          <div
+            style={{ width: "100%", overflow: "auto", flexGrow: 1 }}
+            className="mb-3"
+          >
+            <table
+              className="table table-bordered table-sm appbox w-100 mb-0"
+              style={{ position: "relative" }}
+            >
+              <thead
+                style={{
+                  position: "sticky",
+                  top: 0,
+                  zIndex: 2,
+                  background: "white",
+                }}
               >
-                <thead>
-                  <tr>
-                    {cols.map((col) => (
-                      <th key={col}>{col}</th>
+                <tr>
+                  {cols.map((col) => (
+                    <th key={col}>{col}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {results.map((result, i) => (
+                  <tr key={i}>
+                    {Object.values(result).map((val, j) => (
+                      <td key={j}>{JSON.stringify(val)}</td>
                     ))}
                   </tr>
-                </thead>
-                <tbody>
-                  {results.map((result, i) => (
-                    <tr key={i}>
-                      {Object.values(result).map((val, j) => (
-                        <td key={j}>{JSON.stringify(val)}</td>
-                      ))}
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          </TabsContent>
-        )}
-
-        <TabsContent value="sql">
-          <div style={{ overflowY: "auto", height: "100%" }}>
-            {error ? (
-              <div className="alert alert-danger mr-auto">{error}</div>
-            ) : (
-              !results.length && (
-                <div className="alert alert-warning mr-auto">
-                  <FaExclamationTriangle /> No rows returned, could not verify
-                  result
-                </div>
-              )
-            )}
-            <Code
-              code={sql}
-              language="sql"
-              errorLine={errorLine}
-              expandable={expandable}
-            />
+                ))}
+              </tbody>
+            </table>
           </div>
         </TabsContent>
-      </Tabs>
-    </>
+      )}
+
+      <TabsContent
+        value="sql"
+        style={{ display: "flex", flexDirection: "column", height: "100%" }}
+      >
+        <div style={{ overflowY: "auto", height: "100%" }}>
+          {error ? (
+            <div className="alert alert-danger mr-auto">{error}</div>
+          ) : (
+            !results.length && (
+              <div className="alert alert-warning mr-auto">
+                <FaExclamationTriangle /> No rows returned, could not verify
+                result
+              </div>
+            )
+          )}
+          <Code
+            code={sql}
+            language="sql"
+            errorLine={errorLine}
+            expandable={expandable}
+          />
+        </div>
+      </TabsContent>
+    </Tabs>
   );
 }


### PR DESCRIPTION
### Features and Changes

When we made the switch to Radix Tabs, I think a UI issue was introduced that broke the scrolling within the `DisplayTestQueryResults`. With this change, we're back to the experience we previously had where any overflow is visible via a scroll. Additionally, when rendering the results, I've made it so the table header row is sticky so the user doesn't have to scroll up to remember which column they're looking at.

- Closes **(https://github.com/growthbook/growthbook/issues/3456)**

### Testing
 
- [x] Ensure that when viewing the results and the rendered SQL, there is both a horizontal and vertical scroll when necessary
- [x] Ensure that everything works on both large and small screens

### Loom Walkthough
https://www.loom.com/share/5e6ce23655814051b5ecaae71294ac01
