### PR TITLE
Improve order when sorting by Status

### DIFF
--- a/packages/front-end/pages/experiments/index.tsx
+++ b/packages/front-end/pages/experiments/index.tsx
@@ -38,6 +38,23 @@ import {
 
 const NUM_PER_PAGE = 20;
 
+// Most actionable status have higher numbers
+function getExperimentStatusSortOrder(
+  e: ExperimentInterfaceStringDates
+): number {
+  if (e.archived) return 0;
+  if (e.status === "stopped") {
+    if (e.results === "dnf") return 1;
+    if (e.results === "inconclusive") return 2;
+    if (e.results === "lost") return 3;
+    if (e.results === "won") return 4;
+    return 5;
+  }
+  if (e.status === "draft") return 6;
+  if (e.status === "running") return 7;
+  return 8;
+}
+
 export function experimentDate(exp: ExperimentInterfaceStringDates): string {
   return (
     (exp.archived
@@ -92,6 +109,7 @@ const ExperimentsPage = (): React.ReactElement => {
       const projectId = exp.project;
       const projectName = projectId ? getProjectById(projectId)?.name : "";
       const projectIsDeReferenced = projectId && !projectName;
+      const statusSortOrder = getExperimentStatusSortOrder(exp);
 
       return {
         ownerName: getUserDisplay(exp.owner, false) || "",
@@ -108,6 +126,7 @@ const ExperimentsPage = (): React.ReactElement => {
           ? "drafts"
           : exp.status,
         date: experimentDate(exp),
+        statusSortOrder,
       };
     },
     [getExperimentMetricById, getProjectById, getUserDisplay]
@@ -460,7 +479,12 @@ const ExperimentsPage = (): React.ReactElement => {
                     <SortableTH field="tags">Tags</SortableTH>
                     <SortableTH field="ownerName">Owner</SortableTH>
                     <SortableTH field="date">Date</SortableTH>
-                    <SortableTH field="status">Status</SortableTH>
+                    <SortableTH
+                      field="statusSortOrder"
+                      style={{ minWidth: "150px" }}
+                    >
+                      Status
+                    </SortableTH>
                   </tr>
                 </thead>
                 <tbody>

--- a/packages/front-end/services/search.tsx
+++ b/packages/front-end/services/search.tsx
@@ -72,6 +72,7 @@ export interface SearchReturn<T> {
     field: keyof T;
     className?: string;
     children: ReactNode;
+    style?: React.CSSProperties;
   }>;
   page: number;
   resetPage: () => void;
@@ -238,10 +239,18 @@ export function useSearch<T>({
       field: keyof T;
       className?: string;
       children: ReactNode;
-    }> = ({ children, field, className = "" }) => {
-      if (isFiltered) return <th className={className}>{children}</th>;
+      style?: React.CSSProperties;
+    }> = ({ children, field, className = "", style }) => {
+      if (isFiltered) {
+        return (
+          <th className={className} style={style}>
+            {children}
+          </th>
+        );
+      }
+
       return (
-        <th className={className}>
+        <th className={className} style={style}>
           <span
             className="cursor-pointer"
             onClick={(e) => {


### PR DESCRIPTION
### Features and Changes

- Improve the order of the experiments when sorting by Status
- Add `min-width` to the Status column to avoid content jumping around when changing sort order

### Screenshots

| Before | After |
|--------|--------|
| ![descending-before](https://github.com/user-attachments/assets/77348997-519d-422c-b645-e6a973838e9e) | ![descending-after](https://github.com/user-attachments/assets/36ee942a-f947-4886-9c29-c9d820fceb37) |
| ![ascending-before](https://github.com/user-attachments/assets/bcccde3e-aaeb-4264-851e-922f55160799) | ![ascending-after](https://github.com/user-attachments/assets/0acd1c2b-3a10-4550-b606-7015cfbeb508) | 