### PR TITLE
hotfix for "stopped" sub-statuses on metric pages

### DIFF
--- a/packages/front-end/components/MetricExperiments/MetricExperiments.tsx
+++ b/packages/front-end/components/MetricExperiments/MetricExperiments.tsx
@@ -13,7 +13,10 @@ import {
   ExperimentWithSnapshot,
   SnapshotMetric,
 } from "back-end/types/experiment-snapshot";
-import { ExperimentStatus } from "back-end/types/experiment";
+import {
+  ExperimentResultsType,
+  ExperimentStatus,
+} from "back-end/types/experiment";
 import useApi from "@/hooks/useApi";
 import ExperimentStatusIndicator from "@/components/Experiment/TabbedPage/ExperimentStatusIndicator";
 import ChangeColumn from "@/components/Experiment/ChangeColumn";
@@ -44,6 +47,7 @@ interface MetricExperimentData {
   date: string;
   name: string;
   status: ExperimentStatus;
+  results: ExperimentResultsType;
   archived: boolean;
   statsEngine: StatsEngine;
   variationId: number;
@@ -93,6 +97,7 @@ function MetricExperimentResultTab({
         date: experimentDate(e),
         name: e.name,
         status: e.status,
+        results: e.results,
         archived: e.archived,
         statsEngine: statsEngine,
         variationId: i,

--- a/packages/front-end/components/MetricExperiments/MetricExperiments.tsx
+++ b/packages/front-end/components/MetricExperiments/MetricExperiments.tsx
@@ -47,7 +47,7 @@ interface MetricExperimentData {
   date: string;
   name: string;
   status: ExperimentStatus;
-  results: ExperimentResultsType;
+  results?: ExperimentResultsType;
   archived: boolean;
   statsEngine: StatsEngine;
   variationId: number;


### PR DESCRIPTION
On metric pages, we list experiments and also show those experiments' statuses. These statuses were not picking up the correct stopped state and were defaulting to "Stopped: Awaiting decision" even for won/lost/etc.