### PR TITLE
Add environment to the response of the data-enrichment endpoint

### DIFF
--- a/packages/back-end/src/api/ingestion/ingestion.router.ts
+++ b/packages/back-end/src/api/ingestion/ingestion.router.ts
@@ -12,6 +12,7 @@ interface SdkInfo {
   organization: string;
   client_key: string;
   datasource: string;
+  environment: string;
 }
 
 interface GetDataEnrichmentResponse {
@@ -24,6 +25,7 @@ function sdkInfo(conn: SDKConnectionInterface, datasource: string): SdkInfo {
   return {
     organization: conn.organization,
     client_key: conn.key,
+    environment: conn.environment,
     datasource,
   };
 }


### PR DESCRIPTION
### Features and Changes

For feature-usage we want to be able to show which environment the feature was used for. 

### Dependencies
https://github.com/growthbook/growthbook-ingestor/pull/34
needs to land first otherwise the ingestor will start to 500.

### Testing
Run the growthbook-ingestor with https://github.com/growthbook/growthbook-ingestor/pull/34
In .env.local
set `INGESTOR_HOST=http://localhost:3003`
See new events in confluent have "environment" set.
