### PR TITLE
Apply enterprise license check for environment inheritance

### DIFF
--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -3359,6 +3359,7 @@ paths:
                     type: string
                 parent:
                   type: string
+                  description: An environment that the new environment should inherit feature rules from. Requires an enterprise license
       responses:
         '200':
           content:

--- a/packages/back-end/src/api/environments/validations.ts
+++ b/packages/back-end/src/api/environments/validations.ts
@@ -32,5 +32,9 @@ export const validatePayload = async (
       );
   }
 
+  if (parent && !context.hasPremiumFeature("environment-inheritance")) {
+    throw new Error("Environment inheritance requires an enterprise license");
+  }
+
   return { id, projects, description, toggleOnList, defaultState, parent };
 };

--- a/packages/back-end/src/api/openapi/paths/postEnvironment.yaml
+++ b/packages/back-end/src/api/openapi/paths/postEnvironment.yaml
@@ -35,6 +35,7 @@ requestBody:
               type: string
           parent:
             type: string
+            description: An environment that the new environment should inherit feature rules from. Requires an enterprise license
 responses:
   "200":
     content:

--- a/packages/back-end/src/validators/openapi.ts
+++ b/packages/back-end/src/validators/openapi.ts
@@ -403,7 +403,7 @@ export const listEnvironmentsValidator = {
 };
 
 export const postEnvironmentValidator = {
-  bodySchema: z.object({ "id": z.string().describe("The ID of the new environment"), "description": z.string().describe("The description of the new environment").optional(), "toggleOnList": z.any().describe("Show toggle on feature list").optional(), "defaultState": z.any().describe("Default state for new features").optional(), "projects": z.array(z.string()).optional(), "parent": z.string().optional() }).strict(),
+  bodySchema: z.object({ "id": z.string().describe("The ID of the new environment"), "description": z.string().describe("The description of the new environment").optional(), "toggleOnList": z.any().describe("Show toggle on feature list").optional(), "defaultState": z.any().describe("Default state for new features").optional(), "projects": z.array(z.string()).optional(), "parent": z.string().describe("An environment that the new environment should inherit feature rules from. Requires an enterprise license").optional() }).strict(),
   querySchema: z.never(),
   paramsSchema: z.never(),
 };

--- a/packages/back-end/types/openapi.d.ts
+++ b/packages/back-end/types/openapi.d.ts
@@ -6064,6 +6064,7 @@ export interface operations {
           /** @description Default state for new features */
           defaultState?: any;
           projects?: (string)[];
+          /** @description An environment that the new environment should inherit feature rules from. Requires an enterprise license */
           parent?: string;
         };
       };

--- a/packages/enterprise/src/license.ts
+++ b/packages/enterprise/src/license.ts
@@ -69,7 +69,8 @@ export type CommercialFeature =
   | "metric-populations"
   | "large-saved-groups"
   | "multi-armed-bandits"
-  | "metric-groups";
+  | "metric-groups"
+  | "environment-inheritance";
 
 export type CommercialFeaturesMap = Record<AccountPlan, Set<CommercialFeature>>;
 
@@ -243,6 +244,7 @@ export const accountFeatures: CommercialFeaturesMap = {
     "large-saved-groups",
     "multi-armed-bandits",
     "metric-groups",
+    "environment-inheritance",
   ]),
 };
 


### PR DESCRIPTION
### Features and Changes

The new logic for handling environment parents is meant to be only for enterprise customers, but initially didn't have a license check. This PR adds the check to the validation helper on the only entrypoint for environment inheritance.
Also adds a description to the API documentation for `parent` to clarify its usage and that it is only for enterprise users.

### Testing

- [ ] Enterprise org can create environment with a parent and the behavior still works as expected
- [ ] Free org gets a permission error trying to create an environment with a parent
- [ ] Pro org gets a permission error trying to create an environment with a parent
- [ ] Updating an existing environment to try to add a parent ignores the parent key from the payload (inheritance is only relevant when creating an environment)
