### PR TITLE
Shared experiments: show analysis settings even when no linked changes

### DIFF
--- a/packages/front-end/components/Experiment/Public/PublicExperimentOverview.tsx
+++ b/packages/front-end/components/Experiment/Public/PublicExperimentOverview.tsx
@@ -77,16 +77,16 @@ export default function PublicExperimentOverview({
             canAddChanges={false}
             isPublic={true}
           />
-
-          <AnalysisSettings
-            experiment={experiment}
-            envs={[]}
-            canEdit={false}
-            ssrPolyfills={ssrPolyfills}
-            isPublic={true}
-          />
         </>
       ) : null}
+
+      <AnalysisSettings
+        experiment={experiment}
+        envs={[]}
+        canEdit={false}
+        ssrPolyfills={ssrPolyfills}
+        isPublic={true}
+      />
     </>
   );
 }


### PR DESCRIPTION
Public/shared experiments: We were erroneously scrubbing analysis settings from the UI when there were no linked changes.