### PR TITLE
Added the ability to make a metric custom field

### DIFF
--- a/packages/back-end/src/routers/custom-fields/custom-fields.validators.ts
+++ b/packages/back-end/src/routers/custom-fields/custom-fields.validators.ts
@@ -13,6 +13,7 @@ export const customFieldTypes = z.enum([
   "boolean",
   "date",
   "datetime",
+  "metrics",
 ]);
 
 export const customFieldsPropsValidator = z.object({

--- a/packages/front-end/components/CustomFields/CustomFieldDisplay.tsx
+++ b/packages/front-end/components/CustomFields/CustomFieldDisplay.tsx
@@ -1,8 +1,9 @@
-import React, { FC, useState } from "react";
+import React, { FC, Fragment, useState } from "react";
 import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
 import { useForm } from "react-hook-form";
 import { CustomField, CustomFieldSection } from "back-end/types/custom-fields";
 import { FeatureInterface } from "back-end/types/feature";
+import { getMetricLink } from "shared/experiments";
 import { useUser } from "@/services/UserContext";
 import { useAuth } from "@/services/auth";
 import PremiumTooltip from "@/components/Marketing/PremiumTooltip";
@@ -13,6 +14,8 @@ import {
 import Markdown from "@/components/Markdown/Markdown";
 import Modal from "@/components/Modal";
 import DataList, { DataListItem } from "@/components/Radix/DataList";
+import MetricName from "@/components/Metrics/MetricName";
+import Link from "@/components/Radix/Link";
 import CustomFieldInput from "./CustomFieldInput";
 
 const CustomFieldDisplay: FC<{
@@ -95,6 +98,30 @@ const CustomFieldDisplay: FC<{
       return value;
     }
   };
+  const getMetricValue = (value: string) => {
+    try {
+      const metrics = JSON.parse(value);
+      if (metrics.length > 1) {
+        return metrics.map((v) => (
+          <ul key={v} className="mb-0">
+            <li>
+              <Link color="dark" href={getMetricLink(v)}>
+                <MetricName id={v} disableTooltip />
+              </Link>
+            </li>
+          </ul>
+        ));
+      } else {
+        return (
+          <Link color="dark" href={getMetricLink(metrics[0])} className="mr-2">
+            <MetricName id={metrics[0]} disableTooltip />
+          </Link>
+        );
+      }
+    } catch (e) {
+      return value;
+    }
+  };
   const getDisplayValue = (v: CustomField, cValue: string) => {
     return v.type === "multiselect" ? (
       getMultiSelectValue(cValue)
@@ -106,6 +133,8 @@ const CustomFieldDisplay: FC<{
       <a href={cValue} target="_blank" rel="noreferrer">
         {cValue ?? ""}
       </a>
+    ) : v.type === "metrics" ? (
+      getMetricValue(cValue)
     ) : v.type === "boolean" ? (
       <>{cValue ? "yes" : "no"}</>
     ) : cValue ? (

--- a/packages/front-end/components/CustomFields/CustomFieldInput.tsx
+++ b/packages/front-end/components/CustomFields/CustomFieldInput.tsx
@@ -6,6 +6,7 @@ import Field from "@/components/Forms/Field";
 import SelectField from "@/components/Forms/SelectField";
 import MultiSelectField from "@/components/Forms/MultiSelectField";
 import Toggle from "@/components/Forms/Toggle";
+import MetricsSelector from "@/components/Experiment/MetricsSelector";
 
 const CustomFieldInput: FC<{
   customFields: CustomField[];
@@ -81,6 +82,7 @@ const CustomFieldInput: FC<{
         ) : (
           <>
             {availableFields.map((v, i) => {
+              console.log("current value", currentCustomFields?.[v.id]);
               return (
                 <div key={i}>
                   {v.type === "boolean" ? (
@@ -129,6 +131,32 @@ const CustomFieldInput: FC<{
                       }}
                       helpText={v.description}
                     />
+                  ) : v.type === "metrics" ? (
+                    <>
+                      <label className="d-block position-relative">
+                        {v.name}
+                        {v.required && (
+                          <span className="text-danger ml-1">*</span>
+                        )}
+                      </label>
+                      <MetricsSelector
+                        selected={
+                          Array.isArray(currentCustomFields?.[v.id])
+                            ? currentCustomFields?.[v.id]
+                            : currentCustomFields?.[v.id]
+                            ? getMultiSelectValue(currentCustomFields?.[v.id])
+                            : v?.defaultValue
+                            ? [v?.defaultValue]
+                            : []
+                        }
+                        onChange={(metricIds) => {
+                          updateCustomField(v.id, JSON.stringify(metricIds));
+                        }}
+                        includeFacts={true}
+                        includeGroups={false}
+                        excludeQuantiles={false}
+                      />
+                    </>
                   ) : v.type === "multiselect" ? (
                     <MultiSelectField
                       label={

--- a/packages/front-end/components/CustomFields/CustomFieldModal.tsx
+++ b/packages/front-end/components/CustomFields/CustomFieldModal.tsx
@@ -62,6 +62,7 @@ export default function CustomFieldModal({
     "boolean",
     "url",
     "date",
+    "metrics",
   ];
 
   const availableProjects: (SingleValue | GroupedValue)[] = projects

--- a/packages/front-end/components/Forms/SelectField.tsx
+++ b/packages/front-end/components/Forms/SelectField.tsx
@@ -48,7 +48,7 @@ export function useSelectOptions(
     const clone = cloneDeep(options);
     if (sort) {
       clone.sort((a, b) => {
-        return a.label.localeCompare(b.label);
+        return a.label ? a.label.localeCompare(b.label) : 0;
       });
     }
     clone.forEach((o) => {


### PR DESCRIPTION
Allows for custom fields to be of type "metrics" and let the user select from existing metrics. This functionality allows for users to add, for example, a field for OEC, and then let the creator of the experiment specify what metric(s) that is. 