### PR TITLE
Force experiments with no tabs to overview page

### DIFF
--- a/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
@@ -228,6 +228,12 @@ export default function ExperimentHeader({
   const shouldHideTabs =
     experiment.status === "draft" && !hasResults && phases.length === 1;
 
+  useEffect(() => {
+    if (shouldHideTabs) {
+      setTab("overview");
+    }
+  }, [shouldHideTabs, setTab]);
+
   const getMemberIdFromName = (owner) => {
     let ownerId: string | null = null;
     Array.from(users.entries()).forEach((info) => {


### PR DESCRIPTION
### Features and Changes

We recently decided to hide tabs when an experiment is in draft and has no results. However, for users with old draft experiments on the results page (e.g. if they navigated there for any reason before starting the experiment), this change locked them out of getting to the overview page unless they updated the URL with the anchor `#overview`.

This PR fixes this problem by forcing all users without access to tabs to go to the overview page, no matter what tab they were on before or what anchor they use.

- Closes #3474  (note: missing tabs reported as a bug is not a bug, but it had some side-effects that this PR fixes)
 
### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

Did not create a draft and update my branch to ensure my hypothesis is correct, but I can no longer use anchors or set local storage to take me to the results tab when tabs are hidden.
