### PR TITLE
Report use experiment end date and use as default

### DIFF
--- a/packages/back-end/src/controllers/reports.ts
+++ b/packages/back-end/src/controllers/reports.ts
@@ -104,6 +104,14 @@ export async function postReportFromSnapshot(
     _experimentAnalysisSettings.dateStarted =
       experiment.phases?.[phaseIndex]?.dateStarted ?? new Date();
   }
+  if (
+    !_experimentAnalysisSettings.dateEnded &&
+    experiment?.status === "stopped" &&
+    experiment.phases?.[phaseIndex]?.dateEnded
+  ) {
+    _experimentAnalysisSettings.dateEnded =
+      experiment.phases?.[phaseIndex]?.dateEnded;
+  }
 
   const doc = await createReport(org.id, {
     experimentId: experiment.id,

--- a/packages/front-end/components/Report/ConfigureReport.tsx
+++ b/packages/front-end/components/Report/ConfigureReport.tsx
@@ -91,6 +91,11 @@ export default function ConfigureReport({
 
   const latestPhaseIndex = (experiment?.phases?.length ?? 1) - 1;
   const experimentEndDate = experiment?.phases?.[latestPhaseIndex]?.dateEnded;
+  console.log(
+    experimentEndDate,
+    experiment?.phases?.[latestPhaseIndex],
+    experiment
+  );
 
   const datasource = experiment?.datasource
     ? getDatasourceById(experiment.datasource)
@@ -271,10 +276,11 @@ export default function ConfigureReport({
                     )}
                   />
                 )}
-                <div className="row align-items-center">
+                <div className="d-flex align-items-center">
                   {experiment?.status === "stopped" &&
+                  experimentEndDate &&
                   getValidDate(experimentEndDate) ? (
-                    <div className="col-auto mt-1">
+                    <div className="flex-1">
                       <Button
                         variant="ghost"
                         size="sm"
@@ -289,16 +295,17 @@ export default function ConfigureReport({
                         }}
                       >
                         <div style={{ lineHeight: 1.25, padding: "3px 0" }}>
-                          Use Experiment end date
+                          Use {isBandit ? "Bandit" : "Experiment"} end date
                           <br />
                           <small>{date(experimentEndDate || "")}</small>
                         </div>
                       </Button>
                     </div>
                   ) : null}
-                  <div className="col-auto">
+                  <div className="d-flex align-items-center mr-2">
                     <Checkbox
                       label="Today"
+                      mb="0"
                       value={useToday}
                       setValue={(v) => setUseToday(v as boolean)}
                     />

--- a/packages/front-end/components/Report/ConfigureReport.tsx
+++ b/packages/front-end/components/Report/ConfigureReport.tsx
@@ -90,6 +90,8 @@ export default function ConfigureReport({
   const experiment = experimentData?.experiment;
 
   const latestPhaseIndex = (experiment?.phases?.length ?? 1) - 1;
+  const experimentEndDate = experiment?.phases?.[latestPhaseIndex]?.dateEnded;
+
   const datasource = experiment?.datasource
     ? getDatasourceById(experiment.datasource)
     : null;
@@ -269,11 +271,39 @@ export default function ConfigureReport({
                     )}
                   />
                 )}
-                <Checkbox
-                  label="Today"
-                  value={useToday}
-                  setValue={(v) => setUseToday(v as boolean)}
-                />
+                <div className="row align-items-center">
+                  {experiment?.status === "stopped" &&
+                  getValidDate(experimentEndDate) ? (
+                    <div className="col-auto mt-1">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        mt="2"
+                        style={{ height: 45, textAlign: "left" }}
+                        onClick={() => {
+                          form.setValue(
+                            "experimentAnalysisSettings.dateEnded",
+                            getValidDate(experimentEndDate)
+                          );
+                          setUseToday(false);
+                        }}
+                      >
+                        <div style={{ lineHeight: 1.25, padding: "3px 0" }}>
+                          Use Experiment end date
+                          <br />
+                          <small>{date(experimentEndDate || "")}</small>
+                        </div>
+                      </Button>
+                    </div>
+                  ) : null}
+                  <div className="col-auto">
+                    <Checkbox
+                      label="Today"
+                      value={useToday}
+                      setValue={(v) => setUseToday(v as boolean)}
+                    />
+                  </div>
+                </div>
               </div>
             </div>
           </TabsContent>

--- a/packages/front-end/components/Report/ConfigureReport.tsx
+++ b/packages/front-end/components/Report/ConfigureReport.tsx
@@ -91,11 +91,6 @@ export default function ConfigureReport({
 
   const latestPhaseIndex = (experiment?.phases?.length ?? 1) - 1;
   const experimentEndDate = experiment?.phases?.[latestPhaseIndex]?.dateEnded;
-  console.log(
-    experimentEndDate,
-    experiment?.phases?.[latestPhaseIndex],
-    experiment
-  );
 
   const datasource = experiment?.datasource
     ? getDatasourceById(experiment.datasource)


### PR DESCRIPTION
### Features and Changes

Adds use experiment end date button to report settings, and sets as default for stopped experiments.

- Closes #3477 

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

<!--
  Please describe how to test these changes.
 -->

### Screenshots

https://www.loom.com/share/8902af0d8d4f44d696c302c4ddccef5f