### PR TITLE
fix a couple of date picker issues

### DIFF
--- a/packages/front-end/components/DatePicker/index.tsx
+++ b/packages/front-end/components/DatePicker/index.tsx
@@ -232,6 +232,7 @@ export default function DatePicker({
                     to: getValidDate(date2),
                   }}
                   onSelect={(daterange: DateRange) => {
+                    if (!daterange) return;
                     setDate(daterange?.from);
                     setDate2?.(daterange?.to);
                     if (daterange?.from)
@@ -252,6 +253,7 @@ export default function DatePicker({
                   mode="single"
                   selected={getValidDate(date)}
                   onSelect={(selectedDate: Date) => {
+                    if (!selectedDate) selectedDate = new Date();
                     setDate(selectedDate);
                     setBufferedDate(format(selectedDate, dateFormat));
                   }}

--- a/packages/front-end/components/DatePicker/index.tsx
+++ b/packages/front-end/components/DatePicker/index.tsx
@@ -2,10 +2,11 @@ import { DateRange, DayPicker, Matcher } from "react-day-picker";
 import "react-day-picker/dist/style.css";
 import * as Popover from "@radix-ui/react-popover";
 import { format } from "date-fns";
-import React, { ReactNode, useRef, useState } from "react";
+import React, { ReactNode, useMemo, useRef, useState } from "react";
 import { getValidDate } from "shared/dates";
 import { Flex } from "@radix-ui/themes";
 import clsx from "clsx";
+import { debounce } from "lodash";
 import Field from "@/components/Forms/Field";
 import { RadixTheme } from "@/services/RadixTheme";
 import styles from "./DatePicker.module.scss";
@@ -55,24 +56,21 @@ export default function DatePicker({
   scheduleEndDate,
   containerClassName = "form-group",
 }: Props) {
-  if (typeof date === "string") {
-    date = date ? getValidDate(date) : undefined;
-  }
-  if (typeof date2 === "string") {
-    date2 = date2 ? getValidDate(date2) : undefined;
-  }
-
-  // todo: update calendar's month when interacting with field and month changes
-
-  const [originalDate, setOriginalDate] = useState(date);
-  const [originalDate2, setOriginalDate2] = useState(date2);
-  const [calendarMonth, setCalendarMonth] = useState(
-    new Date(
-      (date ?? new Date()).getUTCFullYear(),
-      (date ?? new Date()).getUTCMonth()
-    )
+  const dateFormat =
+    precision === "datetime" ? "yyyy-MM-dd'T'HH:mm" : "yyyy-MM-dd";
+  const [bufferedDate, setBufferedDate] = useState(
+    date ? format(getValidDate(date), dateFormat) : ""
+  );
+  const [bufferedDate2, setBufferedDate2] = useState(
+    date2 ? format(getValidDate(date2), dateFormat) : ""
   );
 
+  const [calendarMonth, setCalendarMonth] = useState(
+    new Date(
+      getValidDate(date ?? new Date()).getUTCFullYear(),
+      getValidDate(date ?? new Date()).getUTCMonth()
+    )
+  );
   const [open, setOpen] = useState(false);
   const fieldClickedTime = useRef(new Date());
 
@@ -85,11 +83,11 @@ export default function DatePicker({
   }
 
   const markedDays: Record<string, Matcher | Matcher[] | undefined> = {};
-  if (originalDate) {
-    markedDays.originalDate = originalDate;
+  if (date) {
+    markedDays.originalDate = getValidDate(date);
   }
-  if (originalDate2) {
-    markedDays.originalDate2 = originalDate2;
+  if (date2) {
+    markedDays.originalDate2 = getValidDate(date2);
   }
   if (activeDates?.length) {
     markedDays.activeDates = activeDates.map((d) => getValidDate(d));
@@ -103,14 +101,36 @@ export default function DatePicker({
 
   const isRange = !!setDate2;
 
-  const handleDateSelect = (date: Date) => {
-    setDate(date);
-  };
-
-  const handleDateRangeSelect = (daterange: DateRange) => {
-    setDate(daterange?.from);
-    setDate2?.(daterange?.to);
-  };
+  const debouncedSetDate = useMemo(() => {
+    return debounce((value: string, field: "date" | "date2" = "date") => {
+      const parsedDate = getValidDate(value);
+      let finalDate = parsedDate;
+      if (disableBefore && parsedDate < getValidDate(disableBefore)) {
+        finalDate = getValidDate(disableBefore);
+      } else if (disableAfter && parsedDate > getValidDate(disableAfter)) {
+        finalDate = getValidDate(disableAfter);
+      }
+      if (field === "date") {
+        setDate(finalDate);
+        setBufferedDate(format(finalDate, dateFormat));
+      } else if (field === "date2") {
+        setDate2?.(finalDate);
+        setBufferedDate2(format(finalDate, dateFormat));
+      }
+      setCalendarMonth(
+        new Date(finalDate.getUTCFullYear(), finalDate.getUTCMonth())
+      );
+    }, 500);
+  }, [
+    disableBefore,
+    disableAfter,
+    setDate,
+    setBufferedDate,
+    setCalendarMonth,
+    setDate2,
+    setBufferedDate2,
+    dateFormat,
+  ]);
 
   return (
     <div className={containerClassName}>
@@ -119,11 +139,8 @@ export default function DatePicker({
         onOpenChange={(o) => {
           if (o) {
             setOpen(true);
-          }
-          if (!o && +new Date() - +fieldClickedTime.current > 10) {
+          } else {
             setOpen(false);
-            setOriginalDate(getValidDate(date));
-            setOriginalDate2(getValidDate(date2));
           }
         }}
       >
@@ -150,26 +167,12 @@ export default function DatePicker({
                   }}
                   className={clsx("date-picker-field", { "text-muted": !date })}
                   type={precision === "datetime" ? "datetime-local" : "date"}
-                  value={
-                    date
-                      ? format(
-                          getValidDate(date),
-                          precision === "datetime"
-                            ? "yyyy-MM-dd'T'HH:mm"
-                            : "yyyy-MM-dd"
-                        )
-                      : ""
-                  }
+                  value={bufferedDate}
                   onChange={(e) => {
-                    let d = getValidDate(e?.target?.value, getValidDate(date));
-                    if (disableBefore && d < getValidDate(disableBefore)) {
-                      d = getValidDate(disableBefore);
-                    } else if (disableAfter && d > getValidDate(disableAfter)) {
-                      d = getValidDate(disableAfter);
-                    }
-                    setDate(d);
-                    setCalendarMonth(d);
+                    setBufferedDate(e.target.value);
+                    debouncedSetDate(e.target.value);
                   }}
+                  onBlur={() => debouncedSetDate.flush()} // Ensure immediate validation on blur
                   onClick={(e) => {
                     e.preventDefault();
                     fieldClickedTime.current = new Date();
@@ -197,32 +200,12 @@ export default function DatePicker({
                       "text-muted": !date2,
                     })}
                     type={precision === "datetime" ? "datetime-local" : "date"}
-                    value={
-                      date2
-                        ? format(
-                            getValidDate(date2),
-                            precision === "datetime"
-                              ? "yyyy-MM-dd'T'HH:mm"
-                              : "yyyy-MM-dd"
-                          )
-                        : ""
-                    }
+                    value={bufferedDate2}
                     onChange={(e) => {
-                      let d = getValidDate(
-                        e?.target?.value,
-                        getValidDate(date2)
-                      );
-                      if (disableBefore && d < getValidDate(disableBefore)) {
-                        d = getValidDate(disableBefore);
-                      } else if (
-                        disableAfter &&
-                        d > getValidDate(disableAfter)
-                      ) {
-                        d = getValidDate(disableAfter);
-                      }
-                      setDate2?.(d);
-                      setCalendarMonth(d);
+                      setBufferedDate2(e.target.value);
+                      debouncedSetDate(e.target.value, "date2");
                     }}
+                    onBlur={() => debouncedSetDate.flush()} // Ensure immediate validation on blur
                     onClick={(e) => {
                       e.preventDefault();
                       fieldClickedTime.current = new Date();
@@ -244,8 +227,18 @@ export default function DatePicker({
               {isRange ? (
                 <DayPicker
                   mode="range"
-                  selected={{ from: date, to: date2 }}
-                  onSelect={handleDateRangeSelect}
+                  selected={{
+                    from: getValidDate(date),
+                    to: getValidDate(date2),
+                  }}
+                  onSelect={(daterange: DateRange) => {
+                    setDate(daterange?.from);
+                    setDate2?.(daterange?.to);
+                    if (daterange?.from)
+                      setBufferedDate(format(daterange.from, dateFormat));
+                    if (daterange?.to)
+                      setBufferedDate2(format(daterange.to, dateFormat));
+                  }}
                   disabled={disabledMatchers}
                   modifiers={markedDays}
                   modifiersClassNames={modifiersClassNames}
@@ -257,8 +250,11 @@ export default function DatePicker({
               ) : (
                 <DayPicker
                   mode="single"
-                  selected={date}
-                  onSelect={handleDateSelect}
+                  selected={getValidDate(date)}
+                  onSelect={(selectedDate: Date) => {
+                    setDate(selectedDate);
+                    setBufferedDate(format(selectedDate, dateFormat));
+                  }}
                   disabled={disabledMatchers}
                   modifiers={markedDays}
                   modifiersClassNames={modifiersClassNames}

--- a/packages/front-end/components/Report/ConfigureReport.tsx
+++ b/packages/front-end/components/Report/ConfigureReport.tsx
@@ -37,7 +37,7 @@ import { useUser } from "@/services/UserContext";
 import FeatureVariationsInput from "@/components/Features/FeatureVariationsInput";
 import { useAuth } from "@/services/auth";
 import Modal from "@/components/Modal";
-import {useIncrementer} from "@/hooks/useIncrementer";
+import { useIncrementer } from "@/hooks/useIncrementer";
 
 type TabOptions = "overview" | "metrics" | "analysis" | "variations";
 export default function ConfigureReport({
@@ -64,12 +64,16 @@ export default function ConfigureReport({
       ...report,
       experimentAnalysisSettings: {
         ...report.experimentAnalysisSettings,
-        dateStarted: new Date(getValidDate(report.experimentAnalysisSettings?.dateStarted ?? "")
-          .toISOString()
-          .substr(0, 16)),
-        dateEnded: new Date(getValidDate(report.experimentAnalysisSettings?.dateEnded ?? "")
-          .toISOString()
-          .substr(0, 16)),
+        dateStarted: new Date(
+          getValidDate(report.experimentAnalysisSettings?.dateStarted ?? "")
+            .toISOString()
+            .substr(0, 16)
+        ),
+        dateEnded: new Date(
+          getValidDate(report.experimentAnalysisSettings?.dateEnded ?? "")
+            .toISOString()
+            .substr(0, 16)
+        ),
       },
     },
   });
@@ -217,9 +221,11 @@ export default function ConfigureReport({
                   onClick={() => {
                     form.setValue(
                       "experimentAnalysisSettings.dateStarted",
-                      new Date(getValidDate(experiment?.phases?.[0]?.dateStarted)
-                        .toISOString()
-                        .substr(0, 16))
+                      new Date(
+                        getValidDate(experiment?.phases?.[0]?.dateStarted)
+                          .toISOString()
+                          .substr(0, 16)
+                      )
                     );
                     incrementDatePickerKey();
                   }}
@@ -246,9 +252,14 @@ export default function ConfigureReport({
                       onClick={() => {
                         form.setValue(
                           "experimentAnalysisSettings.dateStarted",
-                          new Date(getValidDate(experiment?.phases?.[latestPhaseIndex]?.dateStarted ?? "")
-                            .toISOString()
-                            .substr(0, 16))
+                          new Date(
+                            getValidDate(
+                              experiment?.phases?.[latestPhaseIndex]
+                                ?.dateStarted ?? ""
+                            )
+                              .toISOString()
+                              .substr(0, 16)
+                          )
                         );
                         incrementDatePickerKey();
                       }}
@@ -258,8 +269,10 @@ export default function ConfigureReport({
                         <br />
                         <small>
                           {date(
-                            getValidDate(experiment?.phases?.[latestPhaseIndex]
-                              ?.dateStarted)
+                            getValidDate(
+                              experiment?.phases?.[latestPhaseIndex]
+                                ?.dateStarted
+                            )
                               .toISOString()
                               .substr(0, 16)
                           )}
@@ -307,9 +320,14 @@ export default function ConfigureReport({
                         onClick={() => {
                           form.setValue(
                             "experimentAnalysisSettings.dateStarted",
-                            new Date(getValidDate(experiment?.phases?.[latestPhaseIndex]?.dateEnded)
-                              .toISOString()
-                              .substr(0, 16))
+                            new Date(
+                              getValidDate(
+                                experiment?.phases?.[latestPhaseIndex]
+                                  ?.dateEnded
+                              )
+                                .toISOString()
+                                .substr(0, 16)
+                            )
                           );
                           incrementDatePickerKey();
                           setUseToday(false);
@@ -318,11 +336,16 @@ export default function ConfigureReport({
                         <div style={{ lineHeight: 1.25, padding: "3px 0" }}>
                           Use {isBandit ? "Bandit" : "Experiment"} end date
                           <br />
-                          <small>{date(
-                            getValidDate(experiment?.phases?.[latestPhaseIndex]?.dateEnded)
-                              .toISOString()
-                              .substr(0, 16)
-                          )}</small>
+                          <small>
+                            {date(
+                              getValidDate(
+                                experiment?.phases?.[latestPhaseIndex]
+                                  ?.dateEnded
+                              )
+                                .toISOString()
+                                .substr(0, 16)
+                            )}
+                          </small>
                         </div>
                       </Button>
                     </div>

--- a/packages/front-end/components/Report/ConfigureReport.tsx
+++ b/packages/front-end/components/Report/ConfigureReport.tsx
@@ -5,7 +5,7 @@ import {
   AttributionModel,
   ExperimentInterfaceStringDates,
 } from "back-end/types/experiment";
-import { date, getValidDate } from "shared/dates";
+import { getValidDate } from "shared/dates";
 import { DifferenceType } from "back-end/types/stats";
 import { MdInfoOutline } from "react-icons/md";
 import { DEFAULT_SEQUENTIAL_TESTING_TUNING_PARAMETER } from "shared/constants";
@@ -254,11 +254,11 @@ export default function ConfigureReport({
                     Use {isBandit ? "Bandit" : "Experiment"} start date
                     <br />
                     <small>
-                      {date(
+                      {new Date(
                         getValidDate(experiment?.phases?.[0]?.dateStarted)
                           .toISOString()
                           .substr(0, 16)
-                      )}
+                      ).toLocaleDateString()}
                     </small>
                   </div>
                 </Button>
@@ -288,14 +288,14 @@ export default function ConfigureReport({
                         Use latest phase ({latestPhaseIndex + 1}) start date
                         <br />
                         <small>
-                          {date(
+                          {new Date(
                             getValidDate(
                               experiment?.phases?.[latestPhaseIndex]
                                 ?.dateStarted
                             )
                               .toISOString()
                               .substr(0, 16)
-                          )}
+                          ).toLocaleDateString()}
                         </small>
                       </div>
                     </Button>
@@ -357,14 +357,14 @@ export default function ConfigureReport({
                           Use {isBandit ? "Bandit" : "Experiment"} end date
                           <br />
                           <small>
-                            {date(
+                            {new Date(
                               getValidDate(
                                 experiment?.phases?.[latestPhaseIndex]
                                   ?.dateEnded
                               )
                                 .toISOString()
                                 .substr(0, 16)
-                            )}
+                            ).toLocaleDateString()}
                           </small>
                         </div>
                       </Button>

--- a/packages/front-end/components/Report/ConfigureReport.tsx
+++ b/packages/front-end/components/Report/ConfigureReport.tsx
@@ -83,6 +83,23 @@ export default function ConfigureReport({
     if (useToday && value.experimentAnalysisSettings) {
       value.experimentAnalysisSettings.dateEnded = null;
     }
+    const d = new Date();
+    value.experimentAnalysisSettings = {
+      ...value.experimentAnalysisSettings,
+      dateStarted: new Date(
+        getValidDate(
+          value.experimentAnalysisSettings?.dateStarted ?? ""
+        ).getTime() -
+          d.getTimezoneOffset() * 60 * 1000
+      ).toISOString(),
+      dateEnded: value.experimentAnalysisSettings?.dateEnded
+        ? new Date(
+            getValidDate(value.experimentAnalysisSettings.dateEnded).getTime() -
+              d.getTimezoneOffset() * 60 * 1000
+          ).toISOString()
+        : null,
+    };
+
     await apiCall<{
       updatedReport: ExperimentSnapshotReportInterface;
     }>(`/report/${report.id}`, {

--- a/packages/front-end/components/Report/ConfigureReport.tsx
+++ b/packages/front-end/components/Report/ConfigureReport.tsx
@@ -69,11 +69,13 @@ export default function ConfigureReport({
             .toISOString()
             .substr(0, 16)
         ),
-        dateEnded: new Date(
-          getValidDate(report.experimentAnalysisSettings?.dateEnded ?? "")
-            .toISOString()
-            .substr(0, 16)
-        ),
+        dateEnded: report.experimentAnalysisSettings?.dateEnded
+          ? new Date(
+              getValidDate(report.experimentAnalysisSettings.dateEnded)
+                .toISOString()
+                .substr(0, 16)
+            )
+          : null,
       },
     },
   });
@@ -84,6 +86,7 @@ export default function ConfigureReport({
       value.experimentAnalysisSettings.dateEnded = null;
     }
     const d = new Date();
+    // @ts-expect-error types are good enough for CRUD
     value.experimentAnalysisSettings = {
       ...value.experimentAnalysisSettings,
       dateStarted: new Date(
@@ -91,12 +94,12 @@ export default function ConfigureReport({
           value.experimentAnalysisSettings?.dateStarted ?? ""
         ).getTime() -
           d.getTimezoneOffset() * 60 * 1000
-      ).toISOString(),
+      ),
       dateEnded: value.experimentAnalysisSettings?.dateEnded
         ? new Date(
             getValidDate(value.experimentAnalysisSettings.dateEnded).getTime() -
               d.getTimezoneOffset() * 60 * 1000
-          ).toISOString()
+          )
         : null,
     };
 

--- a/packages/front-end/components/Report/ConfigureReport.tsx
+++ b/packages/front-end/components/Report/ConfigureReport.tsx
@@ -339,7 +339,7 @@ export default function ConfigureReport({
                         style={{ height: 45, textAlign: "left" }}
                         onClick={() => {
                           form.setValue(
-                            "experimentAnalysisSettings.dateStarted",
+                            "experimentAnalysisSettings.dateEnded",
                             new Date(
                               getValidDate(
                                 experiment?.phases?.[latestPhaseIndex]

--- a/packages/front-end/styles/global-radix-overrides.scss
+++ b/packages/front-end/styles/global-radix-overrides.scss
@@ -107,8 +107,8 @@
   .rdp-day {
     padding: 0 !important;
     &.rdp-disabled {
-      background-color: var(--gray-a3);
-      color: var(--gray-9);
+      background-color: var(--sand-a4);
+      color: var(--sand-9);
     }
     .rdp-day_button {
       position: relative;
@@ -137,6 +137,9 @@
   }
   .rdp-range_end .rdp-day_button {
     border-radius: 0 8px 8px 0;
+  }
+  .rdp-range_start.rdp-range_end .rdp-day_button {
+    border-radius: 8px;
   }
   .rdp-selected:not(.rdp-range_middle) {
     .rdp-day_button {


### PR DESCRIPTION
Fix a couple of date picker issues:

- general issue: buffer date picker field input by default (allow for easier keyboard entry / delayed validation by default)
- report-specific issue: fix ISO issues with report date fields (truncate/ignore the timezone)
