### PR TITLE
Fix report permission checks

### DIFF
--- a/packages/back-end/src/controllers/reports.ts
+++ b/packages/back-end/src/controllers/reports.ts
@@ -326,6 +326,20 @@ export async function refreshReport(
   const useCache = !req.query["force"];
 
   if (report.type === "experiment-snapshot") {
+    const experiment = await getExperimentById(
+      context,
+      report.experimentId || ""
+    );
+    const isOwner = report.userId === req.userId;
+    const canUpdateReport = context.permissions.canUpdateReport(
+      experiment || {}
+    );
+    if (
+      !(isOwner || (report.editLevel === "organization" && canUpdateReport))
+    ) {
+      context.permissions.throwPermissionError();
+    }
+
     const snapshot =
       (await findSnapshotById(report.organization, report.snapshot)) ||
       undefined;
@@ -393,6 +407,20 @@ export async function putReport(
     throw new Error("Unknown report id");
   }
   if (report.type === "experiment-snapshot") {
+    const experiment = await getExperimentById(
+      context,
+      report.experimentId || ""
+    );
+    const isOwner = report.userId === req.userId;
+    const canUpdateReport = context.permissions.canUpdateReport(
+      experiment || {}
+    );
+    if (
+      !(isOwner || (report.editLevel === "organization" && canUpdateReport))
+    ) {
+      context.permissions.throwPermissionError();
+    }
+
     const data = req.body as ExperimentSnapshotReportInterface;
     if (!data) {
       throw new Error("Malformed data");

--- a/packages/front-end/components/Report/ReportMetaInfo.tsx
+++ b/packages/front-end/components/Report/ReportMetaInfo.tsx
@@ -119,6 +119,8 @@ export default function ReportMetaInfo({
   const hasData = (analysis?.results?.[0]?.variations?.length ?? 0) > 0;
 
   useEffect(() => {
+    if (!(isAdmin || isOwner)) return;
+
     if (report.shareLevel !== shareLevel) {
       setSaveShareLevelStatus("loading");
       window.clearTimeout(saveShareLevelTimeout.current);
@@ -156,9 +158,13 @@ export default function ReportMetaInfo({
     setSaveShareLevelStatus,
     apiCall,
     showEditControls,
+    isAdmin,
+    isOwner,
   ]);
 
   useEffect(() => {
+    if (!(isAdmin || isOwner)) return;
+
     if (report.editLevel !== editLevel) {
       setSaveEditLevelStatus("loading");
       window.clearTimeout(saveEditLevelTimeout.current);
@@ -196,6 +202,8 @@ export default function ReportMetaInfo({
     setSaveEditLevelStatus,
     apiCall,
     showEditControls,
+    isAdmin,
+    isOwner,
   ]);
 
   const shareLinkButton =
@@ -394,6 +402,8 @@ export default function ReportMetaInfo({
             setGeneralModalOpen(false);
           }}
           submit={generalForm.handleSubmit(async (value) => {
+            if (!canEdit) return;
+
             const { updatedReport } = await apiCall<{
               updatedReport: ExperimentSnapshotReportInterface;
             }>(`/report/${report.id}`, {

--- a/packages/front-end/pages/_app.tsx
+++ b/packages/front-end/pages/_app.tsx
@@ -47,6 +47,7 @@ type ModAppProps = AppProps & {
     progressiveAuth?: boolean;
     progressiveAuthTopNav?: boolean;
     noLoadingOverlay?: boolean;
+    mainClassName?: string;
   };
 };
 
@@ -59,7 +60,9 @@ function App({
   const [error, setError] = useState("");
 
   // hacky:
-  const parts = router.route.substr(1).split("/");
+  const parts = Component.mainClassName
+    ? [Component.mainClassName]
+    : router.route.substr(1).split("/");
 
   const organizationRequired = !Component.noOrganization;
   const preAuth = Component.preAuth || false;

--- a/packages/front-end/pages/public/e/[e].tsx
+++ b/packages/front-end/pages/public/e/[e].tsx
@@ -269,3 +269,4 @@ PublicExperimentPage.preAuth = true;
 PublicExperimentPage.progressiveAuth = true;
 PublicExperimentPage.progressiveAuthTopNav = true;
 PublicExperimentPage.noLoadingOverlay = true;
+PublicExperimentPage.mainClassName = "public experiment";

--- a/packages/front-end/pages/public/r/[r].tsx
+++ b/packages/front-end/pages/public/r/[r].tsx
@@ -141,3 +141,4 @@ ReportPage.preAuth = true;
 ReportPage.progressiveAuth = true;
 ReportPage.progressiveAuthTopNav = true;
 ReportPage.noLoadingOverlay = true;
+ReportPage.mainClassName = "public report";

--- a/packages/front-end/pages/report/[rid].tsx
+++ b/packages/front-end/pages/report/[rid].tsx
@@ -87,8 +87,11 @@ export default function ReportPage() {
     ? permissionsUtil.canViewReportModal(experiment.project)
     : false;
   const isOwner = userId === report?.userId || !report?.userId;
-  const canEdit = isOwner || canUpdateReport;
   const isAdmin = permissionsUtil.canSuperDeleteReport();
+  const canEdit =
+    isOwner ||
+    isAdmin ||
+    (report.editLevel === "organization" && canUpdateReport);
   const canDelete = isOwner || isAdmin;
 
   const isBandit = experiment?.type === "multi-armed-bandit";

--- a/packages/front-end/styles/global.scss
+++ b/packages/front-end/styles/global.scss
@@ -787,21 +787,15 @@ pre {
     transform: translate(0.5px, -0.5px);
   }
 }
-main.main.report {
-  .experiment-results {
-    th {
-      &.axis-col {
-        top: 50px;
-      }
+main.main {
+  &.report {
+    .experiment-results th.axis-col {
+      top: 55px;
     }
   }
-}
-main.main.public {
-  .experiment-results {
-    th {
-      &.axis-col {
-        top: 95px;
-      }
+  &.public.experiment {
+    .experiment-results th.axis-col {
+      top: 95px;
     }
   }
 }


### PR DESCRIPTION
- was not respecting `editLevel` for edit permissions
- more BE gating
- prevent useEffect from PUTting share updates when permissions are invalid

also fixes a small UI bug with floating table headers having too much top offset