### PR TITLE
Add frontend entrypoint for environment inheritance

### DIFF
--- a/packages/back-end/src/routers/environment/environment.controller.ts
+++ b/packages/back-end/src/routers/environment/environment.controller.ts
@@ -1,6 +1,7 @@
 import type { Response } from "express";
 import z from "zod";
 import { isEqual } from "lodash";
+import { DEFAULT_ENVIRONMENT_IDS } from "shared/util";
 import { findSDKConnectionsByOrganization } from "back-end/src/models/SdkConnectionModel";
 import { triggerSingleSDKWebhookJobs } from "back-end/src/jobs/updateAllJobs";
 import {
@@ -268,6 +269,14 @@ export const postEnvironment = async (
       status: 400,
       message: `Environment ${environment.id} already exists`,
     });
+  }
+
+  if (environment.parent && !DEFAULT_ENVIRONMENT_IDS.includes(environment.id)) {
+    throw new Error(
+      `Manual environment inheritance only valid for environments ${DEFAULT_ENVIRONMENT_IDS.join(
+        ", "
+      )}. For programmatic control use the API endpoint instead.`
+    );
   }
 
   const updatedEnvironments = addEnvironmentToOrganizationEnvironments(

--- a/packages/front-end/components/DocLink.tsx
+++ b/packages/front-end/components/DocLink.tsx
@@ -73,6 +73,7 @@ const docSections = {
   customMarkdown: "/using/growthbook-best-practices#custom-markdown",
   savedGroups: "/features/targeting#saved-groups",
   ga4BigQuery: "/guide/GA4-google-analytics",
+  apiPostEnvironment: "/api#tag/environments/operation/postEnvironment",
 };
 
 export type DocSection = keyof typeof docSections;

--- a/packages/front-end/components/Forms/SelectField.tsx
+++ b/packages/front-end/components/Forms/SelectField.tsx
@@ -27,6 +27,7 @@ export type SelectFieldProps = Omit<
   onChange: (value: string) => void;
   sort?: boolean;
   createable?: boolean;
+  formatCreateLabel?: (value: string) => string;
   formatOptionLabel?: (
     value: SingleValue,
     meta: FormatOptionLabelMeta<SingleValue>
@@ -147,6 +148,7 @@ const SelectField: FC<SelectFieldProps> = ({
   style,
   className,
   createable = false,
+  formatCreateLabel,
   formatOptionLabel,
   formatGroupLabel,
   isSearchable = true,
@@ -214,6 +216,11 @@ const SelectField: FC<SelectFieldProps> = ({
                 placeholder={placeholder}
                 inputValue={inputValue}
                 options={sorted}
+                formatCreateLabel={formatCreateLabel}
+                isValidNewOption={(value) => {
+                  if (!otherProps.pattern) return true;
+                  return new RegExp(otherProps.pattern).test(value);
+                }}
                 autoFocus={autoFocus}
                 onChange={(selected: { value: string }) => {
                   onChange(selected?.value || "");

--- a/packages/front-end/components/Settings/EnvironmentModal.tsx
+++ b/packages/front-end/components/Settings/EnvironmentModal.tsx
@@ -177,11 +177,8 @@ export default function EnvironmentModal({
               form.setValue("parent", value || undefined);
             }}
             options={environments.map((e) => ({ label: e.id, value: e.id }))}
-            isClearable={true}
-            disabled={
-              !!existing.id ||
-              !DEFAULT_ENVIRONMENT_IDS.includes(form.watch("id") || "")
-            }
+            isClearable
+            disabled={!DEFAULT_ENVIRONMENT_IDS.includes(form.watch("id") || "")}
             helpText={
               <>
                 <div>

--- a/packages/front-end/components/Settings/EnvironmentModal.tsx
+++ b/packages/front-end/components/Settings/EnvironmentModal.tsx
@@ -2,6 +2,7 @@ import { useForm } from "react-hook-form";
 import { Environment } from "back-end/types/organization";
 import React, { useMemo } from "react";
 import { FaExclamationTriangle } from "react-icons/fa";
+import { DEFAULT_ENVIRONMENT_IDS } from "shared/util";
 import { useAuth } from "@/services/auth";
 import { useEnvironments } from "@/services/features";
 import { useUser } from "@/services/UserContext";
@@ -11,6 +12,8 @@ import useSDKConnections from "@/hooks/useSDKConnections";
 import Modal from "@/components/Modal";
 import Field from "@/components/Forms/Field";
 import Toggle from "@/components/Forms/Toggle";
+import SelectField from "@/components/Forms/SelectField";
+import { DocLink } from "../DocLink";
 
 export default function EnvironmentModal({
   existing,
@@ -28,6 +31,7 @@ export default function EnvironmentModal({
       toggleOnList: existing.toggleOnList || false,
       defaultState: existing.defaultState ?? true,
       projects: existing.projects || [],
+      parent: existing.parent,
     },
   });
   const { apiCall } = useAuth();
@@ -104,6 +108,7 @@ export default function EnvironmentModal({
             toggleOnList: value.toggleOnList,
             defaultState: value.defaultState,
             projects: value.projects,
+            parent: value.parent,
           };
           await apiCall(`/environment`, {
             method: "POST",
@@ -120,12 +125,28 @@ export default function EnvironmentModal({
       })}
     >
       {!existing.id && (
-        <Field
+        <SelectField
+          value={form.watch("id") || ""}
+          options={DEFAULT_ENVIRONMENT_IDS.map((id) => ({
+            label: id,
+            value: id,
+          }))}
+          sort={false}
+          createable
+          isClearable
+          formatCreateLabel={(value) =>
+            `Use custom environment name "${value}"`
+          }
+          onChange={(value) => {
+            form.setValue("id", value);
+            if (!DEFAULT_ENVIRONMENT_IDS.includes(value)) {
+              form.setValue("parent", undefined);
+            }
+          }}
           maxLength={30}
           required
           pattern="^[A-Za-z][A-Za-z0-9_-]*$"
           title="Must start with a letter. Can only contain letters, numbers, hyphens, and underscores. No spaces or special characters."
-          {...form.register("id")}
           label="Id"
           helpText={
             <>
@@ -147,6 +168,37 @@ export default function EnvironmentModal({
         placeholder=""
         textarea
       />
+      {!existing.id && (
+        <div className="mb-3">
+          <SelectField
+            label="Parent"
+            value={form.watch("parent") || ""}
+            onChange={(value) => {
+              form.setValue("parent", value || undefined);
+            }}
+            options={environments.map((e) => ({ label: e.id, value: e.id }))}
+            isClearable={true}
+            disabled={
+              !!existing.id ||
+              !DEFAULT_ENVIRONMENT_IDS.includes(form.watch("id") || "")
+            }
+            helpText={
+              <>
+                <div>
+                  Environment to inherit Feature Rules from.{" "}
+                  {`Only allowed when creating one of the default environments.`}
+                </div>
+                <div>
+                  For programmatic control of environment inheritance, use the{" "}
+                  <DocLink docSection="apiPostEnvironment">
+                    API endpoint instead
+                  </DocLink>
+                </div>
+              </>
+            }
+          />
+        </div>
+      )}
       <div className="mb-4">
         <MultiSelectField
           label="Projects"

--- a/packages/shared/src/util/index.ts
+++ b/packages/shared/src/util/index.ts
@@ -21,6 +21,8 @@ import { featureHasEnvironment } from "./features";
 export * from "./features";
 export * from "./saved-groups";
 
+export const DEFAULT_ENVIRONMENT_IDS = ["production", "dev", "staging", "test"];
+
 export function getAffectedEnvsForExperiment({
   experiment,
   orgEnvironments,


### PR DESCRIPTION
### Features and Changes

* Defines a set of default environment ids: production, dev, staging, and test
* Changes the Create Environment modal's ID input to a select field which allows creating custom entries
* Adds a new field to the Create Environment modal for specifying a parent environment
* Disables manual parent inheritance for custom environment ids; still allows API to use arbitrary environment IDs (with enterprise license)

### Testing

On the [environments page](http://localhost:3000/environments) click to Add Environment and test the behavior of the ID and Parent fields. Try creating a custom ID that follows the required pattern and one that doesn't, and see that the parent field is only enabled for the 4 default environments

### Screenshots

Empty state when opening modal
<img src="https://github.com/user-attachments/assets/aa6aba13-fa38-4f99-b7ce-e0b76ca1cf19" width="400px"/>

Allowed inheritance for default environment
<img src="https://github.com/user-attachments/assets/8a24db44-ea9a-4f40-a0fa-75ce65ee93eb" width="400px"/>


Controller enforces inheritance only working for default environments
<img src="https://github.com/user-attachments/assets/c6e26296-2832-437d-b608-c1d012af88a4" width="400px"/>
