### PR TITLE
Fixes broken glossary links

### DIFF
--- a/docs/docs/kb/glossary.mdx
+++ b/docs/docs/kb/glossary.mdx
@@ -46,11 +46,11 @@ hide_table_of_contents: true
 
 [Custom API Usage Limits](https://www.growthbook.io/pricing): Allow purchasing additional API calls above the included 10M/month on GrowthBook Cloud.
 
-[Custom Fields](/using/growthbook-best-practices#custom-fields): Allows enterprise organizations to create custom fields that can be added to features and experiments. 
+[Custom Fields](/using/growthbook-best-practices#custom-fields): Allows enterprise organizations to create custom fields that can be added to features and experiments.
 
 [Custom Page Markdown](/using/growthbook-best-practices#custom-markdown): Inject custom content onto specific pages to help enforce company standards and processes. For example, add a link to internal best practices at the top of all feature flag pages.
 
-[Custom Pre-Launch Experiment Checklist](/app/pre-launch-checklist): Create custom checklists that have to be completed before starting an experiment.  For example, require users to add a hypothesis.
+[Custom Pre-Launch Experiment Checklist](/app/pre-launch-checklist): Create custom checklists that have to be completed before starting an experiment. For example, require users to add a hypothesis.
 
 [Custom Roles](/account/user-permissions#custom-roles): Define your own user roles with custom sets of permissions
 
@@ -64,7 +64,7 @@ hide_table_of_contents: true
 
 [Dimension](/app/dimensions): A Dimension in GrowthBook is a way to slice and dice your data, allowing you to drill down into your results by different user attributes or experiment characteristics for deeper analysis.
 
-[Discover Metrics / Auto Generate Metrics](/app/metrics/legacy#auto-generate-metrics): Allows organizations using GA4, Segment, Rudderstack, or Amplitude for event tracking to automatically generate count and binomial metrics for each  unique tracked event.
+[Discover Metrics / Auto Generate Metrics](/app/metrics/legacy#auto-generate-metrics): Allows organizations using GA4, Segment, Rudderstack, or Amplitude for event tracking to automatically generate count and binomial metrics for each unique tracked event.
 
 [Duration Metric](/using/experimenting#test-duration): A duration metric in GrowthBook is a type of metric that measures the time it takes to do something (like page load time or time on site), where the value of each event is summed together at the user level before taking an average per variation.
 
@@ -132,23 +132,23 @@ hide_table_of_contents: true
 
 [Metric Groups](/app/metrics#metric-groups): Group related metrics together and easily add them in bulk to experiments. Great for company-wide guardrail metrics.
 
-[Metric Overrides](/app/metrics#bayesian-priors): 
+[Metric Overrides](/app/metrics#bayesian-priors):
 
 [Metric Query](/app/metrics/legacy#query-settings): A Metric Query in GrowthBook is a SQL or simple query that defines how to fetch data for a specific metric from your data source, returning one row per "conversion event" and supporting various types of identifiers.
 
 [Multi-Arm Bandits](/bandits/overview): Optimize experimentation by dynamically adjusting traffic to the best-performing variations in real-time.
 
-[Multi-Org Deployments](/self-host/env#multi-org): For self-hosted deployments, configure multiple top-level organizations with complete data isolation.  Users can be centrally managed and assigned to multiple orgs.
+[Multi-Org Deployments](/self-host/env#multi-org): For self-hosted deployments, configure multiple top-level organizations with complete data isolation. Users can be centrally managed and assigned to multiple orgs.
 
 [Multiple Exposures](/using/experimenting#multiple-exposures): Multiple Exposures in GrowthBook refers to a situation where a substantial number of users in an experiment have been exposed to multiple variations, indicating a potential issue with the experiment assignment or tracking implementation.
 
-[Multiple SDK Webhooks](/webhooks#global-sdk-webhooks): The ability to fire multiple webhooks when an SDK payload changes. This enables complex integrations and workflows.
+[Multiple SDK Webhooks](/app/webhooks/global-sdk-webhooks): The ability to fire multiple webhooks when an SDK payload changes. This enables complex integrations and workflows.
 
 **N**
 
 [Namespace](/feature-flag-experiments#namespaces): A Namespace in GrowthBook is a feature that allows you to make multiple experiments mutually exclusive, ensuring that users are only part of one experiment within the same namespace at a time, useful for avoiding conflicts between experiments.
 
-[No Access Role](/account/user-permissions#how-does-the-no-access-role-work): A base role with zero permissions (not even read access).  Combine with project-scoped roles for fine-grained access control.
+[No Access Role](/account/user-permissions#how-does-the-no-access-role-work): A base role with zero permissions (not even read access). Combine with project-scoped roles for fine-grained access control.
 
 **O**
 
@@ -168,10 +168,9 @@ hide_table_of_contents: true
 
 [Project](/using/growthbook-best-practices#projects): A Project in GrowthBook is a way to organizationally separate features, metrics, experiments, and data sources by team or product feature within an organization, allowing for focused views and management of specific sections of GrowthBook.
 
-[Project-Scoped Roles](account/user-permissions#project-specific-permissions): Assign a user different roles based on project.  For example, read-only access globally, but full write access to specific projects.
+[Project-Scoped Roles](/account/user-permissions#project-specific-permissions): Assign a user different roles based on project. For example, read-only access globally, but full write access to specific projects.
 
 [Proportion Metric](/app/metrics#proportion-metrics): A Proportion Metric in GrowthBook is a type of metric that measures the percent of experiment users who match a specific criteria (like the percent of users who purchased something).
-
 
 **Q**
 


### PR DESCRIPTION
### Features and Changes

There were two broken links in a recent docs-only pr that got merged in, resulting the in Vercel docs build to fail. This corrects those broken links.

In the future, we can ignore the broken links by using the `[onBrokenLinks](https://docusaurus.io/docs/api/docusaurus-config#onBrokenLinks)` option in the Docusarus configuration, but idk if that's a great idea.
