### PR TITLE
Quick fix to help Mixpanel experiments not get confused by the assignment

### DIFF
--- a/packages/front-end/components/Experiment/TabbedPage/AnalysisSettingsSummary.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/AnalysisSettingsSummary.tsx
@@ -223,7 +223,7 @@ export default function AnalysisSettingsSummary({
     tooltip: ds ? "Data Source" : "",
   });
 
-  if (assignmentQuery) {
+  if (assignmentQuery && ds?.type !== "mixpanel") {
     items.push({
       value: assignmentQuery.name,
       icon: <FaTable className="mr-1" />,


### PR DESCRIPTION
Since Mixpanel only supports Distinct ID via the JQL, this field is misleading. This fix hides it for mixpanel data source.  