### PR TITLE
[Bugfix] Fix setting stats engine in new reports

### DIFF
--- a/packages/back-end/src/controllers/reports.ts
+++ b/packages/back-end/src/controllers/reports.ts
@@ -91,6 +91,7 @@ export async function postReportFromSnapshot(
   const phaseIndex = snapshot.phase ?? (experiment.phases?.length || 1) - 1;
   const _experimentAnalysisSettings: ExperimentReportAnalysisSettings = {
     ...pick(experiment, Object.keys(experimentAnalysisSettings.shape)),
+    statsEngine: analysis.settings.statsEngine,
     trackingKey: experiment.trackingKey || experiment.id,
     ...pick(reportArgs, [
       "userIdType",

--- a/packages/front-end/components/Experiment/Public/PublicExperimentAnalysisSettingsBar.tsx
+++ b/packages/front-end/components/Experiment/Public/PublicExperimentAnalysisSettingsBar.tsx
@@ -58,16 +58,16 @@ export default function PublicExperimentAnalysisSettingsBar({
                   : "Disabled"
               }
             />
-            {analysis?.settings?.statsEngine ===
-                "frequentist" && (
-            <Metadata
-              label="Sequential"
-              value={
-                analysis?.settings?.sequentialTesting
-                  ? "Enabled"
-                  : "Disabled"
-              }
-            />)}
+            {analysis?.settings?.statsEngine === "frequentist" && (
+              <Metadata
+                label="Sequential"
+                value={
+                  analysis?.settings?.sequentialTesting
+                    ? "Enabled"
+                    : "Disabled"
+                }
+              />
+            )}
             {snapshot.runStarted && (
               <div className="text-right mt-3">
                 <Metadata

--- a/packages/front-end/components/Experiment/Public/PublicExperimentAnalysisSettingsBar.tsx
+++ b/packages/front-end/components/Experiment/Public/PublicExperimentAnalysisSettingsBar.tsx
@@ -58,6 +58,8 @@ export default function PublicExperimentAnalysisSettingsBar({
                   : "Disabled"
               }
             />
+            {analysis?.settings?.statsEngine ===
+                "frequentist" && (
             <Metadata
               label="Sequential"
               value={
@@ -65,7 +67,7 @@ export default function PublicExperimentAnalysisSettingsBar({
                   ? "Enabled"
                   : "Disabled"
               }
-            />
+            />)}
             {snapshot.runStarted && (
               <div className="text-right mt-3">
                 <Metadata

--- a/packages/front-end/components/Report/ReportAnalysisSettingsBar.tsx
+++ b/packages/front-end/components/Report/ReportAnalysisSettingsBar.tsx
@@ -81,8 +81,7 @@ export default function ReportAnalysisSettingsBar({
             <Metadata
               label="Engine"
               value={
-                report?.experimentAnalysisSettings?.statsEngine ===
-                "frequentist"
+                analysis?.settings?.statsEngine === "frequentist"
                   ? "Frequentist"
                   : "Bayesian"
               }
@@ -90,19 +89,17 @@ export default function ReportAnalysisSettingsBar({
             <Metadata
               label="CUPED"
               value={
-                report?.experimentAnalysisSettings?.regressionAdjustmentEnabled
-                  ? "Enabled"
-                  : "Disabled"
+                analysis?.settings?.regressionAdjusted ? "Enabled" : "Disabled"
               }
             />
-            <Metadata
-              label="Sequential"
-              value={
-                report?.experimentAnalysisSettings?.sequentialTestingEnabled
-                  ? "Enabled"
-                  : "Disabled"
-              }
-            />
+            {analysis?.settings?.statsEngine === "frequentist" && (
+              <Metadata
+                label="Sequential"
+                value={
+                  analysis?.settings?.sequentialTesting ? "Enabled" : "Disabled"
+                }
+              />
+            )}
             {snapshot.runStarted && (
               <div className="text-right mt-3">
                 <Metadata


### PR DESCRIPTION
### Features and Changes

New report flow wouldn't properly capture stats engine in the report metadata if experiment was using the org default. This fixes that and also relies on the analysis as the source of truth for the tooltip on the report page.

Closes #3517 

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

<!--
  Please describe how to test these changes.
 -->

### Screenshots

https://www.loom.com/share/dbc3cd6725004c2282242e33f2af69f6