### PR TITLE
Improve saved group reference checks

### DIFF
--- a/packages/front-end/pages/saved-groups/index.tsx
+++ b/packages/front-end/pages/saved-groups/index.tsx
@@ -3,6 +3,11 @@ import Link from "next/link";
 import { SavedGroupInterface } from "shared/src/types";
 import { FaExternalLinkAlt } from "react-icons/fa";
 import { FeatureInterface } from "back-end/types/feature";
+import {
+  ExperimentInterface,
+  ExperimentInterfaceStringDates,
+} from "back-end/types/experiment";
+import { isEmpty } from "lodash";
 import IdLists from "@/components/SavedGroups/IdLists";
 import ConditionGroups from "@/components/SavedGroups/ConditionGroups";
 import { useUser } from "@/services/UserContext";
@@ -21,23 +26,32 @@ import {
 } from "@/components/Radix/Tabs";
 
 export const getSavedGroupMessage = (
-  featuresUsingSavedGroups: FeatureInterface[]
+  featuresUsingSavedGroups?: FeatureInterface[],
+  experimentsUsingSavedGroups?: Array<
+    ExperimentInterface | ExperimentInterfaceStringDates
+  >
 ) => {
   return async () => {
-    if (featuresUsingSavedGroups.length > 0) {
+    if (
+      !isEmpty(featuresUsingSavedGroups) ||
+      !isEmpty(experimentsUsingSavedGroups)
+    ) {
       return (
         <div>
           <p className="alert alert-danger">
             <strong>Whoops!</strong> Before you can delete this saved group, you
-            will need to update the feature
-            {featuresUsingSavedGroups.length > 1 && "s"} listed below by
-            removing any targeting conditions that rely on this saved group.
+            will need to update the item
+            {(featuresUsingSavedGroups?.length || 0) +
+              (experimentsUsingSavedGroups?.length || 0) >
+              1 && "s"}{" "}
+            listed below by removing any targeting conditions that rely on this
+            saved group.
           </p>
           <ul
             className="border rounded bg-light pt-3 pb-3 overflow-auto"
             style={{ maxHeight: "200px" }}
           >
-            {featuresUsingSavedGroups.map((feature) => {
+            {(featuresUsingSavedGroups || []).map((feature) => {
               return (
                 <li key={feature.id}>
                   <div className="d-flex">
@@ -46,6 +60,21 @@ export const getSavedGroupMessage = (
                       className="btn btn-link pt-1 pb-1"
                     >
                       {feature.id}
+                    </Link>
+                  </div>
+                </li>
+              );
+            })}
+
+            {(experimentsUsingSavedGroups || []).map((experiment) => {
+              return (
+                <li key={experiment.id}>
+                  <div className="d-flex">
+                    <Link
+                      href={`/experiment/${experiment.id}`}
+                      className="btn btn-link pt-1 pb-1"
+                    >
+                      {experiment.name}
                     </Link>
                   </div>
                 </li>

--- a/packages/front-end/pages/saved-groups/index.tsx
+++ b/packages/front-end/pages/saved-groups/index.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { SavedGroupInterface } from "shared/src/types";
 import { FaExternalLinkAlt } from "react-icons/fa";
+import { FeatureInterface } from "back-end/types/feature";
 import IdLists from "@/components/SavedGroups/IdLists";
 import ConditionGroups from "@/components/SavedGroups/ConditionGroups";
 import { useUser } from "@/services/UserContext";
@@ -20,31 +21,31 @@ import {
 } from "@/components/Radix/Tabs";
 
 export const getSavedGroupMessage = (
-  featuresUsingSavedGroups: Set<string> | undefined
+  featuresUsingSavedGroups: FeatureInterface[]
 ) => {
   return async () => {
-    if (featuresUsingSavedGroups && featuresUsingSavedGroups?.size > 0) {
+    if (featuresUsingSavedGroups.length > 0) {
       return (
         <div>
           <p className="alert alert-danger">
             <strong>Whoops!</strong> Before you can delete this saved group, you
             will need to update the feature
-            {featuresUsingSavedGroups.size > 1 && "s"} listed below by removing
-            any targeting conditions that rely on this saved group.
+            {featuresUsingSavedGroups.length > 1 && "s"} listed below by
+            removing any targeting conditions that rely on this saved group.
           </p>
           <ul
             className="border rounded bg-light pt-3 pb-3 overflow-auto"
             style={{ maxHeight: "200px" }}
           >
-            {[...featuresUsingSavedGroups].map((feature) => {
+            {featuresUsingSavedGroups.map((feature) => {
               return (
-                <li key={feature}>
+                <li key={feature.id}>
                   <div className="d-flex">
                     <Link
-                      href={`/features/${feature}`}
+                      href={`/features/${feature.id}`}
                       className="btn btn-link pt-1 pb-1"
                     >
-                      {feature}
+                      {feature.id}
                     </Link>
                   </div>
                 </li>

--- a/packages/shared/src/util/index.ts
+++ b/packages/shared/src/util/index.ts
@@ -16,6 +16,7 @@ import { ExperimentReportVariation } from "back-end/types/report";
 import { VisualChange } from "back-end/types/visual-changeset";
 import { FeatureRevisionInterface } from "back-end/types/feature-revision";
 import { Environment } from "back-end/types/organization";
+import { SavedGroupInterface } from "../types";
 import { featureHasEnvironment } from "./features";
 
 export * from "./features";
@@ -335,4 +336,34 @@ export function formatByteSizeString(numBytes: number, decimalPlaces = 1) {
     " " +
     sizes[i]
   );
+}
+
+export function featuresReferencingSavedGroups({
+  savedGroups,
+  features,
+  environments,
+}: {
+  savedGroups: SavedGroupInterface[];
+  features: FeatureInterface[];
+  environments: Environment[];
+}): Record<string, FeatureInterface[]> {
+  const referenceMap: Record<string, FeatureInterface[]> = {};
+  features.forEach((feature) => {
+    savedGroups.forEach((savedGroup) => {
+      const matches = getMatchingRules(
+        feature,
+        (rule) =>
+          rule.condition?.includes(savedGroup.id) ||
+          rule.savedGroups?.some((g) => g.ids.includes(savedGroup.id)) ||
+          false,
+        environments.map((e) => e.id)
+      );
+
+      if (matches.length > 0) {
+        referenceMap[savedGroup.id] ||= [];
+        referenceMap[savedGroup.id].push(feature);
+      }
+    });
+  });
+  return referenceMap;
 }

--- a/packages/shared/src/util/index.ts
+++ b/packages/shared/src/util/index.ts
@@ -367,3 +367,32 @@ export function featuresReferencingSavedGroups({
   });
   return referenceMap;
 }
+
+export function experimentsReferencingSavedGroups({
+  savedGroups,
+  experiments,
+}: {
+  savedGroups: SavedGroupInterface[];
+  experiments: Array<ExperimentInterface | ExperimentInterfaceStringDates>;
+}) {
+  const referenceMap: Record<
+    string,
+    Array<ExperimentInterface | ExperimentInterfaceStringDates>
+  > = {};
+  savedGroups.forEach((savedGroup) => {
+    experiments.forEach((experiment) => {
+      const matchingPhases = experiment.phases.filter(
+        (phase) =>
+          phase.condition?.includes(savedGroup.id) ||
+          phase.savedGroups?.some((g) => g.ids.includes(savedGroup.id)) ||
+          false
+      );
+
+      if (matchingPhases.length > 0) {
+        referenceMap[savedGroup.id] ||= [];
+        referenceMap[savedGroup.id].push(experiment);
+      }
+    });
+  });
+  return referenceMap;
+}


### PR DESCRIPTION
### Features and Changes

Currently when deleting saved groups we check for any referencing features before allowing the deletion. This PR refactors the existing checks into a shared helper for consistency and adds a second helper to also check for experiment references.

### Testing

Manually tested the delete flows from the three entrypoints: condition groups view, id lists view, and [sgid] per-group page
* Delete button should be disabled if at least one reference exists
* Delete button should be enabled if no references exist
* Links should appear for all referencing features and experiments
* Links should direct to the proper pages for those features/experiments

### Screenshots
<img src="https://github.com/user-attachments/assets/1a65082b-21f2-4c2e-8cff-4c069e59e72c" width="400px"/>
