### PR TITLE
Templates hotfix for creating an experiment from a template

### DIFF
--- a/packages/front-end/components/Experiment/NewExperimentForm.tsx
+++ b/packages/front-end/components/Experiment/NewExperimentForm.tsx
@@ -451,13 +451,7 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
 
   // If a template id is provided as an initial value, load the template and convert it to an experiment
   useEffect(() => {
-    if (
-      initialValue?.templateId &&
-      initialValue?.templateId !== form.watch("templateId") &&
-      isNewExperiment &&
-      !isImport &&
-      !isBandit
-    ) {
+    if (initialValue?.templateId && isNewExperiment && !isImport && !isBandit) {
       const template = templatesMap.get(initialValue.templateId);
       if (!template) return;
       const templateAsExperiment = convertTemplateToExperiment(template);


### PR DESCRIPTION
### Features and Changes

Fixes a bug where clicking `Create Experiment` from a template detail page doesn't properly fill out the `NewExperimentForm`. 
