### PR TITLE
updating docs so links go to specific troubleshooting sections

### DIFF
--- a/docs/docs/kb/experiments/troubleshooting-experiments.mdx
+++ b/docs/docs/kb/experiments/troubleshooting-experiments.mdx
@@ -5,7 +5,7 @@ sidebar_label: Troubleshooting Experiments
 slug: troubleshooting-experiments
 ---
 
-## Problem 1: No traffic flowing into the experiment
+## Problem 1: No or little traffic flowing into the experiment
 
 There are a few common reasons why there may not be any data showing in the Results tab of your experiment's detail page, first among them is a lack of experiment traffic. You'll likely see a banner like this:
 

--- a/docs/docs/using/experimenting.mdx
+++ b/docs/docs/using/experimenting.mdx
@@ -168,6 +168,10 @@ GrowthBook automatically does data quality checks on all experiments and shows t
 
 This page shows experiment exposure over time, and also all the other health checks we do.
 
+### Little traffic in experiment
+
+Experiment Traffic Over Time shows how many users are in the experiment at a given timepoint. If traffic is too low, please see our [troubleshooting guide](/kb/experiments/troubleshooting-experiments#problem-1-no-or-little-traffic-flowing-into-the-experiment).
+
 ### Sample Ratio Mismatch (SRM)
 
 Every experiment automatically checks for a Sample Ratio Mismatch and will warn you if found.
@@ -182,13 +186,13 @@ experiment health page.
 
 Like the warning says, you shouldn't trust the results since they are likely misleading. Instead, find and
 fix the source of the bug and restart the experiment. You can find more information about potential sources
-of the problems in our [troubleshooting guide](/kb/experiments/troubleshooting-experiments).
+of the problems in our [troubleshooting guide](/kb/experiments/troubleshooting-experiments#problem-2-srm-errors-traffic-imbalance-in-the-experiment).
 
 ### Multiple Exposures
 
 We also automatically check each experiment to make sure that too many users have not been
 exposed to multiple variations of a single experiment. This can happen if the hashing attribute is
-different from the assignment id used in the report, or for implementation problems.
+different from the assignment id used in the report, or for implementation problems. Please see our [troubleshooting guide](/kb/experiments/troubleshooting-experiments#problem-3-multiple-exposures).
 
 ### Minimum Data Thresholds
 


### PR DESCRIPTION
currently our customer has to scroll through the Troubleshooting section after being sent there for SRM errors.  Now the docs link to the appropriate Troubleshooting section for SRM, multiple exposures, and low data. 