### PR TITLE
Enable mistakenly disabled validations

### DIFF
--- a/packages/front-end/components/Features/FixConflictsModal.tsx
+++ b/packages/front-end/components/Features/FixConflictsModal.tsx
@@ -219,6 +219,7 @@ export default function FixConflictsModal({
     >
       <Page
         display="Fix Conflicts"
+        enabled
         validate={async () => {
           if (!mergeResult?.success) {
             throw new Error("Please resolve all conflicts first");

--- a/packages/front-end/components/Metrics/MetricForm/index.tsx
+++ b/packages/front-end/components/Metrics/MetricForm/index.tsx
@@ -654,6 +654,7 @@ const MetricForm: FC<MetricFormProps> = ({
       >
         <Page
           display="Basic Info"
+          enabled
           validate={async () => {
             validateBasicInfo(form.getValues());
             if (allowAutomaticSqlReset) {
@@ -795,6 +796,7 @@ const MetricForm: FC<MetricFormProps> = ({
         </Page>
         <Page
           display="Query Settings"
+          enabled
           validate={async () => {
             validateQuerySettings(
               datasourceSettingsSupport,

--- a/packages/front-end/components/Settings/RestoreConfigYamlButton.tsx
+++ b/packages/front-end/components/Settings/RestoreConfigYamlButton.tsx
@@ -269,6 +269,7 @@ export default function RestoreConfigYamlButton({
         >
           <Page
             display="Select File"
+            enabled
             validate={async () => {
               const { config } = form.getValues();
               const json = load(config);


### PR DESCRIPTION
### Features and Changes

Re-enables a few mistakenly disabled validations within paged modals
- Closes #3428 

### Testing

Try each impacted modal and see if the validation is triggerable now

### Screenshots
![image](https://github.com/user-attachments/assets/c36c3cde-2843-4a6e-8b2e-6be444559993)

![image](https://github.com/user-attachments/assets/64d10533-c6e2-4a23-b62d-8d02e0c4c62a)

![image](https://github.com/user-attachments/assets/db303a7d-0039-43e9-91d8-e59756cb3f79)

![image](https://github.com/user-attachments/assets/8c793249-4ccf-49f8-bcb1-59f8dd2331f7)
