### PR TITLE
Fix feature environment selector not showing all envs

### DIFF
--- a/packages/front-end/components/Features/FeatureRules.tsx
+++ b/packages/front-end/components/Features/FeatureRules.tsx
@@ -6,6 +6,7 @@ import {
   FeatureRule,
 } from "back-end/src/validators/features";
 import { Environment } from "back-end/types/organization";
+import { Flex } from "@radix-ui/themes";
 import RuleModal from "@/components/Features/RuleModal/index";
 import RuleList from "@/components/Features/RuleList";
 import track from "@/services/track";
@@ -75,17 +76,19 @@ export default function FeatureRules({
     <>
       <Tabs value={env} onValueChange={setEnv}>
         <TabsList>
-          {environments.map((e) => (
-            <TabsTrigger value={e.id} key={e.id}>
-              <span className="mr-2">{e.id}</span>
-              <Badge
-                label={rulesByEnv[e.id].length.toString()}
-                radius="full"
-                variant="solid"
-                color="violet"
-              ></Badge>
-            </TabsTrigger>
-          ))}
+          <Flex overflow="scroll">
+            {environments.map((e) => (
+              <TabsTrigger value={e.id} key={e.id}>
+                <span className="mr-2">{e.id}</span>
+                <Badge
+                  label={rulesByEnv[e.id].length.toString()}
+                  radius="full"
+                  variant="solid"
+                  color="violet"
+                ></Badge>
+              </TabsTrigger>
+            ))}
+          </Flex>
         </TabsList>
         {environments.map((e) => {
           return (


### PR DESCRIPTION
### Features and Changes

The changes in #3485 made the tabs start hiding any overflowing environments because of Radix styling. This PR explicitly enables horizontal overflow on a flex so there's a visible scrollbar if necessary.

- Closes #3543 

### Testing

Load the feature page with many environments, scrollbar should be visible if and only if there is overflow

### Screenshots
![image](https://github.com/user-attachments/assets/47505616-cd0e-47a6-aa5b-23b5e39baeb1)

![image](https://github.com/user-attachments/assets/02b92a8e-495d-47e2-a1a3-f73945414d8a)

