### PR TITLE
Add plan level to premium tooltip

### DIFF
--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -750,7 +750,10 @@ export async function getOrganization(req: AuthRequest, res: Response) {
     licenseError: getLicenseError(org),
     commercialFeatures: [...accountFeatures[getEffectiveAccountPlan(org)]],
     fullCommercialFeaturesMap: Object.fromEntries(
-      Object.entries(accountFeatures).map(([plan, features]) => [plan, Array.from(features)])
+      Object.entries(accountFeatures).map(([plan, features]) => [
+        plan,
+        Array.from(features),
+      ])
     ),
     roles: getRoles(org),
     members: expandedMembers,

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -7,6 +7,7 @@ import {
   getEffectiveAccountPlan,
   getLicense,
   getLicenseError,
+  getLowestPlanPerFeature,
   licenseInit,
 } from "enterprise";
 import { experimentHasLinkedChanges } from "shared/util";
@@ -741,6 +742,8 @@ export async function getOrganization(req: AuthRequest, res: Response) {
 
   const watch = await getWatchedByUser(org.id, userId);
 
+  const commercialFeatureLowestPlan = getLowestPlanPerFeature(accountFeatures);
+
   return res.status(200).json({
     status: 200,
     apiKeys,
@@ -749,12 +752,7 @@ export async function getOrganization(req: AuthRequest, res: Response) {
     effectiveAccountPlan: getEffectiveAccountPlan(org),
     licenseError: getLicenseError(org),
     commercialFeatures: [...accountFeatures[getEffectiveAccountPlan(org)]],
-    fullCommercialFeaturesMap: Object.fromEntries(
-      Object.entries(accountFeatures).map(([plan, features]) => [
-        plan,
-        Array.from(features),
-      ])
-    ),
+    commercialFeatureLowestPlan: commercialFeatureLowestPlan,
     roles: getRoles(org),
     members: expandedMembers,
     currentUserPermissions,

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -749,6 +749,9 @@ export async function getOrganization(req: AuthRequest, res: Response) {
     effectiveAccountPlan: getEffectiveAccountPlan(org),
     licenseError: getLicenseError(org),
     commercialFeatures: [...accountFeatures[getEffectiveAccountPlan(org)]],
+    fullCommercialFeaturesMap: Object.fromEntries(
+      Object.entries(accountFeatures).map(([plan, features]) => [plan, Array.from(features)])
+    ),
     roles: getRoles(org),
     members: expandedMembers,
     currentUserPermissions,

--- a/packages/enterprise/src/license.ts
+++ b/packages/enterprise/src/license.ts
@@ -261,20 +261,29 @@ type MinimalOrganization = {
   };
 };
 
-export function getLowestPlanPerFeature(accountFeatures: CommercialFeaturesMap): Partial<Record<CommercialFeature, AccountPlan>> {
-  const lowestPlanPerFeature: Partial<Record<CommercialFeature, AccountPlan>> = {};
-  
+export function getLowestPlanPerFeature(
+  accountFeatures: CommercialFeaturesMap
+): Partial<Record<CommercialFeature, AccountPlan>> {
+  const lowestPlanPerFeature: Partial<
+    Record<CommercialFeature, AccountPlan>
+  > = {};
+
   // evaluate in order from highest to lowest plan
-  const plansFromHighToLow: AccountPlan[] = ["enterprise", "pro_sso", "pro", "starter", "oss"];
+  const plansFromHighToLow: AccountPlan[] = [
+    "enterprise",
+    "pro_sso",
+    "pro",
+    "starter",
+    "oss",
+  ];
   plansFromHighToLow.forEach((accountPlan) => {
     accountFeatures[accountPlan].forEach((feature) => {
-      lowestPlanPerFeature[feature] = accountPlan
-    }
-  )});
+      lowestPlanPerFeature[feature] = accountPlan;
+    });
+  });
 
   return lowestPlanPerFeature;
 }
-
 
 export function isActiveSubscriptionStatus(
   status?: Stripe.Subscription.Status

--- a/packages/enterprise/src/license.ts
+++ b/packages/enterprise/src/license.ts
@@ -261,6 +261,21 @@ type MinimalOrganization = {
   };
 };
 
+export function getLowestPlanPerFeature(accountFeatures: CommercialFeaturesMap): Partial<Record<CommercialFeature, AccountPlan>> {
+  const lowestPlanPerFeature: Partial<Record<CommercialFeature, AccountPlan>> = {};
+  
+  // evaluate in order from highest to lowest plan
+  const plansFromHighToLow: AccountPlan[] = ["enterprise", "pro_sso", "pro", "starter", "oss"];
+  plansFromHighToLow.forEach((accountPlan) => {
+    accountFeatures[accountPlan].forEach((feature) => {
+      lowestPlanPerFeature[feature] = accountPlan
+    }
+  )});
+
+  return lowestPlanPerFeature;
+}
+
+
 export function isActiveSubscriptionStatus(
   status?: Stripe.Subscription.Status
 ) {

--- a/packages/front-end/components/Archetype/ArchetypeList.tsx
+++ b/packages/front-end/components/Archetype/ArchetypeList.tsx
@@ -27,7 +27,11 @@ export const ArchetypeList: FC<{
   ] = useState<Partial<ArchetypeInterface> | null>(null);
   const permissionsUtil = usePermissionsUtil();
   const { project, getProjectById } = useDefinitions();
-  const { getUserDisplay, hasCommercialFeature, commercialFeatureLowestPlan} = useUser();
+  const {
+    getUserDisplay,
+    hasCommercialFeature,
+    commercialFeatureLowestPlan,
+  } = useUser();
   const [showUpgradeModal, setShowUpgradeModal] = useState(false);
 
   const hasArchetypeFeature = hasCommercialFeature("archetypes");
@@ -35,7 +39,7 @@ export const ArchetypeList: FC<{
     projects: [project],
   });
 
-  const archetypePlanLevel = commercialFeatureLowestPlan?.['archetypes'];
+  const archetypePlanLevel = commercialFeatureLowestPlan?.["archetypes"];
 
   const { apiCall } = useAuth();
 
@@ -55,7 +59,8 @@ export const ArchetypeList: FC<{
             <h2>Create Reusable Archetypes</h2>
             <p>
               Archetypes are named sets of attributes that help you test your
-              features. Archetypes are a {planNameFromAccountPlan(archetypePlanLevel)} feature.
+              features. Archetypes are a{" "}
+              {planNameFromAccountPlan(archetypePlanLevel)} feature.
             </p>
             <div className="mt-3">
               <LinkButton
@@ -71,7 +76,7 @@ export const ArchetypeList: FC<{
                   setShowUpgradeModal(true);
                 }}
               >
-                Upgrade to Pro
+                Upgrade to {planNameFromAccountPlan(archetypePlanLevel)}
               </Button>
             </div>
           </div>

--- a/packages/front-end/components/Archetype/ArchetypeList.tsx
+++ b/packages/front-end/components/Archetype/ArchetypeList.tsx
@@ -52,7 +52,7 @@ export const ArchetypeList: FC<{
             <h2>Create Reusable Archetypes</h2>
             <p>
               Archetypes are named sets of attributes that help you test your
-              features. Archetypes are a premium feature.
+              features. Archetypes are a Pro feature.
             </p>
             <div className="mt-3">
               <LinkButton
@@ -68,7 +68,7 @@ export const ArchetypeList: FC<{
                   setShowUpgradeModal(true);
                 }}
               >
-                Upgrade Plan
+                Upgrade to Pro
               </Button>
             </div>
           </div>

--- a/packages/front-end/components/Archetype/ArchetypeList.tsx
+++ b/packages/front-end/components/Archetype/ArchetypeList.tsx
@@ -14,6 +14,7 @@ import Button from "@/components/Radix/Button";
 import { useUser } from "@/services/UserContext";
 import LinkButton from "@/components/Radix/LinkButton";
 import UpgradeModal from "@/components/Settings/UpgradeModal";
+import { planNameFromAccountPlan } from "@/services/utils";
 
 export const ArchetypeList: FC<{
   archetypes: ArchetypeInterface[];
@@ -26,13 +27,15 @@ export const ArchetypeList: FC<{
   ] = useState<Partial<ArchetypeInterface> | null>(null);
   const permissionsUtil = usePermissionsUtil();
   const { project, getProjectById } = useDefinitions();
-  const { getUserDisplay, hasCommercialFeature } = useUser();
+  const { getUserDisplay, hasCommercialFeature, commercialFeatureLowestPlan} = useUser();
   const [showUpgradeModal, setShowUpgradeModal] = useState(false);
 
   const hasArchetypeFeature = hasCommercialFeature("archetypes");
   const canCreateGlobal = permissionsUtil.canCreateArchetype({
     projects: [project],
   });
+
+  const archetypePlanLevel = commercialFeatureLowestPlan?.['archetypes'];
 
   const { apiCall } = useAuth();
 
@@ -52,7 +55,7 @@ export const ArchetypeList: FC<{
             <h2>Create Reusable Archetypes</h2>
             <p>
               Archetypes are named sets of attributes that help you test your
-              features. Archetypes are a Pro feature.
+              features. Archetypes are a {planNameFromAccountPlan(archetypePlanLevel)} feature.
             </p>
             <div className="mt-3">
               <LinkButton

--- a/packages/front-end/components/GetStarted/DocumentationSidebar.tsx
+++ b/packages/front-end/components/GetStarted/DocumentationSidebar.tsx
@@ -134,15 +134,15 @@ function getLinksFor(type: Props["type"]): JSX.Element {
           </LinkItem>
           <LinkItem href="https://docs.growthbook.io/app/sticky-bucketing">
             Sticky Bucketing
-            <PaidFeatureBadge type="pro" />
+            <PaidFeatureBadge commercialFeature="sticky-bucketing" />
           </LinkItem>
           <LinkItem href="https://docs.growthbook.io/app/visual">
             Visual Editor
-            <PaidFeatureBadge type="pro" />
+            <PaidFeatureBadge commercialFeature="visual-editor" />
           </LinkItem>
           <LinkItem href="https://docs.growthbook.io/app/url-redirects">
             URL Redirects
-            <PaidFeatureBadge type="pro" />
+            <PaidFeatureBadge commercialFeature="redirects" />
           </LinkItem>
         </>
       );
@@ -158,7 +158,7 @@ function getLinksFor(type: Props["type"]): JSX.Element {
           </LinkItem>
           <LinkItem href="https://docs.growthbook.io/app/data-pipeline">
             Data Pipeline Mode
-            <PaidFeatureBadge type="enterprise" />
+            <PaidFeatureBadge commercialFeature="pipeline-mode" />
           </LinkItem>
           <LinkItem href="https://docs.growthbook.io/app/experiment-results">
             Experiment Results

--- a/packages/front-end/components/GetStarted/PaidFeatureBadge.tsx
+++ b/packages/front-end/components/GetStarted/PaidFeatureBadge.tsx
@@ -1,10 +1,15 @@
+import { CommercialFeature } from "enterprise";
 import Tooltip from "@/components/Tooltip/Tooltip";
 import { useUser } from "@/services/UserContext";
 import { planNameFromAccountPlan } from "@/services/utils";
-import { CommercialFeature } from "enterprise";
 
-const PaidFeatureBadge = ({ commercialFeature, premiumText }: { commercialFeature?: CommercialFeature, premiumText?: string }) => {
-
+const PaidFeatureBadge = ({
+  commercialFeature,
+  premiumText,
+}: {
+  commercialFeature?: CommercialFeature;
+  premiumText?: string;
+}) => {
   const { hasCommercialFeature, commercialFeatureLowestPlan } = useUser();
   const hasFeature = commercialFeature
     ? hasCommercialFeature(commercialFeature)
@@ -14,20 +19,24 @@ const PaidFeatureBadge = ({ commercialFeature, premiumText }: { commercialFeatur
     return null;
   }
 
-  const lowestPlanLevel = commercialFeature ? commercialFeatureLowestPlan?.[commercialFeature] : undefined;
-  const planLevelText = `${lowestPlanLevel === "enterprise" ? "an" : "a"} ${planNameFromAccountPlan(lowestPlanLevel)}`
+  const lowestPlanLevel = commercialFeature
+    ? commercialFeatureLowestPlan?.[commercialFeature]
+    : undefined;
+  const planLevelText = `${
+    lowestPlanLevel === "enterprise" ? "an" : "a"
+  } ${planNameFromAccountPlan(lowestPlanLevel)}`;
 
   const tooltipText = premiumText ?? `This is ${planLevelText} feature`;
 
   return (
-    <Tooltip
-      body={tooltipText}
-      tipPosition="top"
-    >
+    <Tooltip body={tooltipText} tipPosition="top">
       <span
         className="badge ml-2"
         style={{
-          backgroundColor: lowestPlanLevel === "pro" || lowestPlanLevel === "pro_sso" ? "#978365" : "#050549",
+          backgroundColor:
+            lowestPlanLevel === "pro" || lowestPlanLevel === "pro_sso"
+              ? "#978365"
+              : "#050549",
           color: "#FFFFFF",
         }}
       >

--- a/packages/front-end/components/GetStarted/PaidFeatureBadge.tsx
+++ b/packages/front-end/components/GetStarted/PaidFeatureBadge.tsx
@@ -1,22 +1,33 @@
 import Tooltip from "@/components/Tooltip/Tooltip";
 import { useUser } from "@/services/UserContext";
+import { planNameFromAccountPlan } from "@/services/utils";
+import { CommercialFeature } from "enterprise";
 
-const PaidFeatureBadge = ({ type }: { type: "pro" | "enterprise" }) => {
-  const { accountPlan } = useUser();
+const PaidFeatureBadge = ({ commercialFeature, premiumText }: { commercialFeature?: CommercialFeature, premiumText?: string }) => {
 
-  if (accountPlan !== "oss" && accountPlan !== "starter") {
+  const { hasCommercialFeature, commercialFeatureLowestPlan } = useUser();
+  const hasFeature = commercialFeature
+    ? hasCommercialFeature(commercialFeature)
+    : true;
+
+  if (hasFeature) {
     return null;
   }
 
+  const lowestPlanLevel = commercialFeature ? commercialFeatureLowestPlan?.[commercialFeature] : undefined;
+  const planLevelText = `${lowestPlanLevel === "enterprise" ? "an" : "a"} ${planNameFromAccountPlan(lowestPlanLevel)}`
+
+  const tooltipText = premiumText ?? `This is ${planLevelText} feature`;
+
   return (
     <Tooltip
-      body={`This is ${type === "pro" ? "a Pro" : "an Enterprise"} feature`}
+      body={tooltipText}
       tipPosition="top"
     >
       <span
         className="badge ml-2"
         style={{
-          backgroundColor: type === "pro" ? "#978365" : "#050549",
+          backgroundColor: lowestPlanLevel === "pro" || lowestPlanLevel === "pro_sso" ? "#978365" : "#050549",
           color: "#FFFFFF",
         }}
       >

--- a/packages/front-end/components/Marketing/PremiumTooltip.tsx
+++ b/packages/front-end/components/Marketing/PremiumTooltip.tsx
@@ -22,7 +22,7 @@ export default function PremiumTooltip({
   commercialFeature,
   children,
   body = null,
-  premiumText = "This is a premium feature",
+  premiumText,
   tipMinWidth,
   tipPosition = "top",
   className = "",
@@ -31,11 +31,19 @@ export default function PremiumTooltip({
   usePortal,
   ...otherProps
 }: Props) {
-  const { hasCommercialFeature } = useUser();
+  const { accountFeaturesMap, hasCommercialFeature } = useUser();
   const hasFeature = commercialFeature
     ? hasCommercialFeature(commercialFeature)
     : true;
 
+  const planLevelText = !commercialFeature
+    ? undefined
+    : accountFeaturesMap["pro"].has(commercialFeature)
+    ? "a Pro"
+    : accountFeaturesMap["enterprise"].has(commercialFeature)
+    ? "an Enterprise"
+    : "a Premium";
+  const tooltipText = premiumText ?? `This is a ${planLevelText} feature`;
   return (
     <Tooltip
       shouldDisplay={!!body || !hasFeature}
@@ -49,7 +57,7 @@ export default function PremiumTooltip({
               )}
             >
               <GBPremiumBadge className="mr-1" />
-              {premiumText}
+              {tooltipText}
             </p>
           )}
           {body}

--- a/packages/front-end/components/Marketing/PremiumTooltip.tsx
+++ b/packages/front-end/components/Marketing/PremiumTooltip.tsx
@@ -37,14 +37,15 @@ export default function PremiumTooltip({
     : true;
   console.log(fullCommercialFeaturesMap);
 
-  const planLevelText = !commercialFeature || !fullCommercialFeaturesMap
-    ? undefined
-    : fullCommercialFeaturesMap["pro"].includes(commercialFeature)
-    ? "a Pro"
-    : fullCommercialFeaturesMap["enterprise"].includes(commercialFeature)
-    ? "an Enterprise"
-    : "a Premium";
-  const tooltipText = premiumText ?? `This is a ${planLevelText} feature`;
+  const planLevelText =
+    !commercialFeature || !fullCommercialFeaturesMap
+      ? undefined
+      : fullCommercialFeaturesMap["pro"].includes(commercialFeature)
+      ? "a Pro"
+      : fullCommercialFeaturesMap["enterprise"].includes(commercialFeature)
+      ? "an Enterprise"
+      : "a Premium";
+  const tooltipText = premiumText ?? `This is ${planLevelText} feature`;
   return (
     <Tooltip
       shouldDisplay={!!body || !hasFeature}

--- a/packages/front-end/components/Marketing/PremiumTooltip.tsx
+++ b/packages/front-end/components/Marketing/PremiumTooltip.tsx
@@ -4,6 +4,7 @@ import clsx from "clsx";
 import { useUser } from "@/services/UserContext";
 import Tooltip from "@/components/Tooltip/Tooltip";
 import { GBPremiumBadge } from "@/components/Icons";
+import { planNameFromAccountPlan } from "@/services/utils";
 
 interface Props extends HTMLAttributes<HTMLDivElement> {
   commercialFeature?: CommercialFeature;
@@ -31,21 +32,16 @@ export default function PremiumTooltip({
   usePortal,
   ...otherProps
 }: Props) {
-  const { hasCommercialFeature, fullCommercialFeaturesMap } = useUser();
+  const { hasCommercialFeature, commercialFeatureLowestPlan } = useUser();
   const hasFeature = commercialFeature
     ? hasCommercialFeature(commercialFeature)
     : true;
-  console.log(fullCommercialFeaturesMap);
 
-  const planLevelText =
-    !commercialFeature || !fullCommercialFeaturesMap
-      ? undefined
-      : fullCommercialFeaturesMap["pro"].includes(commercialFeature)
-      ? "a Pro"
-      : fullCommercialFeaturesMap["enterprise"].includes(commercialFeature)
-      ? "an Enterprise"
-      : "a Premium";
+  const lowestPlanLevel = commercialFeature ? commercialFeatureLowestPlan?.[commercialFeature] : undefined;
+  const planLevelText = `${lowestPlanLevel === "enterprise" ? "an" : "a"} ${planNameFromAccountPlan(lowestPlanLevel)}`
+
   const tooltipText = premiumText ?? `This is ${planLevelText} feature`;
+  
   return (
     <Tooltip
       shouldDisplay={!!body || !hasFeature}

--- a/packages/front-end/components/Marketing/PremiumTooltip.tsx
+++ b/packages/front-end/components/Marketing/PremiumTooltip.tsx
@@ -31,16 +31,17 @@ export default function PremiumTooltip({
   usePortal,
   ...otherProps
 }: Props) {
-  const { accountFeaturesMap, hasCommercialFeature } = useUser();
+  const { hasCommercialFeature, fullCommercialFeaturesMap } = useUser();
   const hasFeature = commercialFeature
     ? hasCommercialFeature(commercialFeature)
     : true;
+  console.log(fullCommercialFeaturesMap);
 
-  const planLevelText = !commercialFeature
+  const planLevelText = !commercialFeature || !fullCommercialFeaturesMap
     ? undefined
-    : accountFeaturesMap["pro"].has(commercialFeature)
+    : fullCommercialFeaturesMap["pro"].includes(commercialFeature)
     ? "a Pro"
-    : accountFeaturesMap["enterprise"].has(commercialFeature)
+    : fullCommercialFeaturesMap["enterprise"].includes(commercialFeature)
     ? "an Enterprise"
     : "a Premium";
   const tooltipText = premiumText ?? `This is a ${planLevelText} feature`;

--- a/packages/front-end/components/Marketing/PremiumTooltip.tsx
+++ b/packages/front-end/components/Marketing/PremiumTooltip.tsx
@@ -37,11 +37,15 @@ export default function PremiumTooltip({
     ? hasCommercialFeature(commercialFeature)
     : true;
 
-  const lowestPlanLevel = commercialFeature ? commercialFeatureLowestPlan?.[commercialFeature] : undefined;
-  const planLevelText = `${lowestPlanLevel === "enterprise" ? "an" : "a"} ${planNameFromAccountPlan(lowestPlanLevel)}`
+  const lowestPlanLevel = commercialFeature
+    ? commercialFeatureLowestPlan?.[commercialFeature]
+    : undefined;
+  const planLevelText = `${
+    lowestPlanLevel === "enterprise" ? "an" : "a"
+  } ${planNameFromAccountPlan(lowestPlanLevel)}`;
 
   const tooltipText = premiumText ?? `This is ${planLevelText} feature`;
-  
+
   return (
     <Tooltip
       shouldDisplay={!!body || !hasFeature}

--- a/packages/front-end/pages/bandits/index.tsx
+++ b/packages/front-end/pages/bandits/index.tsx
@@ -261,7 +261,6 @@ const ExperimentsPage = (): React.ReactElement => {
               <div className="col-auto">
                 <PremiumTooltip
                   tipPosition="left"
-                  popperStyle={{ top: 15 }}
                   body={
                     hasStickyBucketFeature && !orgStickyBucketing
                       ? "Enable Sticky Bucketing in your organization settings to run a Bandit"

--- a/packages/front-end/pages/experiments/index.tsx
+++ b/packages/front-end/pages/experiments/index.tsx
@@ -421,7 +421,7 @@ const ExperimentsPage = (): React.ReactElement => {
               <TabsList>
                 <TabsTrigger value="experiments">Experiments</TabsTrigger>
                 <TabsTrigger value="templates">
-                  Templates <PaidFeatureBadge type="enterprise" />
+                  Templates <PaidFeatureBadge commercialFeature="templates" />
                 </TabsTrigger>
               </TabsList>
             </Box>

--- a/packages/front-end/services/UserContext.tsx
+++ b/packages/front-end/services/UserContext.tsx
@@ -56,6 +56,7 @@ type OrgSettingsResponse = {
   enterpriseSSO: SSOConnectionInterface | null;
   accountPlan: AccountPlan;
   effectiveAccountPlan: AccountPlan;
+  fullCommercialFeaturesMap: Record<AccountPlan, CommercialFeature[]>;
   licenseError: string;
   commercialFeatures: CommercialFeature[];
   license: LicenseInterface;
@@ -131,6 +132,7 @@ export interface UserContextValue {
   teams?: Team[];
   error?: string;
   hasCommercialFeature: (feature: CommercialFeature) => boolean;
+  fullCommercialFeaturesMap?: Record<AccountPlan, CommercialFeature[]>;
   permissionsUtil: Permissions;
   quote: SubscriptionQuote | null;
   watching: {
@@ -481,6 +483,7 @@ export function UserContextProvider({ children }: { children: ReactNode }) {
         enterpriseSSO: currentOrg?.enterpriseSSO || undefined,
         accountPlan: currentOrg?.accountPlan,
         effectiveAccountPlan: currentOrg?.effectiveAccountPlan,
+        fullCommercialFeaturesMap: currentOrg?.fullCommercialFeaturesMap,
         licenseError: currentOrg?.licenseError || "",
         commercialFeatures: currentOrg?.commercialFeatures || [],
         apiKeys: currentOrg?.apiKeys || [],

--- a/packages/front-end/services/UserContext.tsx
+++ b/packages/front-end/services/UserContext.tsx
@@ -56,7 +56,7 @@ type OrgSettingsResponse = {
   enterpriseSSO: SSOConnectionInterface | null;
   accountPlan: AccountPlan;
   effectiveAccountPlan: AccountPlan;
-  fullCommercialFeaturesMap: Record<AccountPlan, CommercialFeature[]>;
+  commercialFeatureLowestPlan?: Partial<Record<CommercialFeature, AccountPlan>>;
   licenseError: string;
   commercialFeatures: CommercialFeature[];
   license: LicenseInterface;
@@ -132,7 +132,7 @@ export interface UserContextValue {
   teams?: Team[];
   error?: string;
   hasCommercialFeature: (feature: CommercialFeature) => boolean;
-  fullCommercialFeaturesMap?: Record<AccountPlan, CommercialFeature[]>;
+  commercialFeatureLowestPlan?: Partial<Record<CommercialFeature, AccountPlan>>;
   permissionsUtil: Permissions;
   quote: SubscriptionQuote | null;
   watching: {
@@ -483,7 +483,7 @@ export function UserContextProvider({ children }: { children: ReactNode }) {
         enterpriseSSO: currentOrg?.enterpriseSSO || undefined,
         accountPlan: currentOrg?.accountPlan,
         effectiveAccountPlan: currentOrg?.effectiveAccountPlan,
-        fullCommercialFeaturesMap: currentOrg?.fullCommercialFeaturesMap,
+        commercialFeatureLowestPlan: currentOrg?.commercialFeatureLowestPlan,
         licenseError: currentOrg?.licenseError || "",
         commercialFeatures: currentOrg?.commercialFeatures || [],
         apiKeys: currentOrg?.apiKeys || [],

--- a/packages/front-end/services/utils.tsx
+++ b/packages/front-end/services/utils.tsx
@@ -8,6 +8,7 @@ import {
   GrowthBook,
 } from "@growthbook/growthbook-react";
 import Cookies from "js-cookie";
+import { AccountPlan } from "enterprise";
 import { AppFeatures } from "@/types/app-features";
 import track from "@/services/track";
 
@@ -204,4 +205,25 @@ export function capitalizeWords(string): string {
     .split(" ")
     .map((word) => capitalizeFirstLetter(word))
     .join(" ");
+}
+
+// Used to describe account plan in text
+export function planNameFromAccountPlan(accountPlan?: AccountPlan) {
+  if (!accountPlan) {
+    return "Premium";
+  }
+
+  if (accountPlan === "pro_sso" || accountPlan === "pro") {
+    return "Pro";
+  }
+
+  if (accountPlan === "oss" || accountPlan === "starter") {
+    return "Starter";
+  }
+
+  if (accountPlan === "enterprise") {
+    return "Enterprise";
+  }
+
+  return capitalizeFirstLetter(accountPlan);
 }


### PR DESCRIPTION
### Features and Changes

Passes the `accountFeatures` map via userContext to the front-end to easily look-up commercial feature <-> account plan lookup.

Use this to improve the tooltip language and be more precise. When you add `commercialFeature` to a `PremiumTooltip` it always tries to say "Pro" if that's the lowest plan needed or "Enterprise" if enterprise is needed.

Also fixes some premium language elsewhere.

### Screenshots
**Before** it just said "This is a premium feature." 
![Screenshot 2025-01-16 at 12 27 08 PM](https://github.com/user-attachments/assets/0b41f65f-8cdc-462f-9211-4535caf5241f)


**Now** it says...

![Screenshot 2025-01-16 at 12 25 07 PM](https://github.com/user-attachments/assets/b77c8911-3bcc-4155-8375-25d34e645125)
![Screenshot 2025-01-16 at 12 24 52 PM](https://github.com/user-attachments/assets/f26d87fd-072a-4797-bbbf-a9f8c369d73c)


Other fix
![Screenshot 2025-01-16 at 12 21 38 PM](https://github.com/user-attachments/assets/6874c0d4-ae33-439d-ad5d-568dd4ba0262)

