### PR TITLE
Style fixes for feature rules component

### DIFF
--- a/packages/front-end/components/Features/FeatureRules.tsx
+++ b/packages/front-end/components/Features/FeatureRules.tsx
@@ -89,7 +89,7 @@ export default function FeatureRules({
     <>
       <Tabs value={env} onValueChange={setEnv}>
         {environments.length < 6 ? (
-          <Container>
+          <Container maxWidth="100%">
             <Flex align="center" justify="between">
               <TabsList>
                 <Flex overflow="scroll">
@@ -115,7 +115,7 @@ export default function FeatureRules({
             </Flex>
           </Container>
         ) : (
-          <Container mb={"4"}>
+          <Container mb={"4"} maxWidth="100%">
             <Flex align="center">
               <Container flexGrow="0" width="270px" mr="4">
                 <EnvironmentDropdown
@@ -160,7 +160,7 @@ export default function FeatureRules({
                     experimentsMap={experimentsMap}
                   />
                 ) : (
-                  <div className="p-3 bg-white border-bottom">
+                  <div className="p-3 bg-white border-bottom border-top">
                     <em>No rules for this environment yet</em>
                   </div>
                 )}


### PR DESCRIPTION
### Features and Changes

Minor fixes for two weird visual behaviors
1. On large screens, the environment tab selection was width-constrained and adding unwanted padding
2. The empty state for rules was missing a top border and blended into the tab row

### Testing

Load the features page and then zoom way out to ensure the environment selector stays full width (both tabs for <6 envs and dropdown for 6+)
Use an environment with no rules to check the top border

### Screenshots

![image](https://github.com/user-attachments/assets/3b1539e6-df4b-4c1f-8479-58e3fb739ff0)

![image](https://github.com/user-attachments/assets/b4204f3d-5659-4b8b-8605-bc91685e3752)

