### PR TITLE
add markdown location, organize guides, add yt video to strapi

### DIFF
--- a/docs/docs/guide/index.mdx
+++ b/docs/docs/guide/index.mdx
@@ -12,8 +12,20 @@ This list isn't complete! If you have a specific technology stack you'd like to 
 
 ## Tutorials
 
+### Content Management Systems
+
 - [GrowthBook with Strapi](/guide/strapi)
 - [GrowthBook with Contentful](/guide/contentful)
+- [GrowthBook with Wordpress](/integrations/wordpress)
+
+### No-Code/Low-Code Platforms
+
+- [GrowthBook with Google Tag Manager (GTM)](/guide/google-tag-manager-and-growthbook)
+- [GrowthBook with Shopify](/integrations/shopify)
+- [GrowthBook with Webflow](/integrations/webflow)
+
+### JavaScript Frameworks
+
 - [GrowthBook with Deno and Hono](/guide/deno-hono)
 - [GrowthBook with Express.js](/guide/express-js)
 - [GrowthBook with Next.js, Vercel Edge Config, and Vercel Feature Flags API](/guide/nextjs-and-vercel-feature-flags)
@@ -21,10 +33,9 @@ This list isn't complete! If you have a specific technology stack you'd like to 
 - [GrowthBook with Next.js (Pages Router)](/guide/nextjs-and-growthbook)
 - [GrowthBook with Create React App](/guide/create-react-app-and-growthbook)
 - [GrowthBook with Next.js and Rudderstack](/guide/rudderstack-and-nextjs-with-growthbook)
-- [GrowthBook with Google Tag Manager](/guide/google-tag-manager-and-growthbook)
-- [GrowthBook with Webflow](/integrations/webflow)
-- [GrowthBook with Shopify](/integrations/shopify)
-- [GrowthBook with Wordpress](/integrations/wordpress)
+
+### Migration Guides
+
 - [How to Migrate from LaunchDarkly](/guide/importing)
 
 ## A/B Testing Guide

--- a/docs/docs/guide/strapi.mdx
+++ b/docs/docs/guide/strapi.mdx
@@ -6,6 +6,8 @@ slug: strapi
 
 # How to Feature Flag and A/B Test with GrowthBook and Strapi
 
+<iframe style={{aspectRatio: "16/9", width: "100%", height: "auto", marginBlockEnd: "1rem"}} width="560" height="315" src="https://www.youtube.com/embed/grYlfKNFHCk?si=iJZzVFYzdGuUE5er" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
 Want to A/B test your content without changing code for every experiment? This tutorial shows you how to integrate [Strapi](https://strapi.io/) with [GrowthBook](https://growthbook.io), enabling you to feature flag and A/B test your content directly from your CMS.
 
 <video src="/videos/guides/strapi-demo.mp4" loop autoPlay muted style={{width: "100%", aspectRatio: "16/9", marginBlockEnd: "1rem"}}></video>

--- a/docs/docs/using/growthbook-best-practices.mdx
+++ b/docs/docs/using/growthbook-best-practices.mdx
@@ -143,7 +143,7 @@ before your team is able to start an experiment.
 
 Enterprise users can add custom fields to features and experiments. For example, these custom fields can be
 used to require links to Jira tickets, or to capture additional information that is important to your process
-or organization. Custom fields can be added from the Settings → Custom Fields page. Custom fields can be set to
+or organization. Custom fields can be added from the **Settings** → **Custom Fields** page. Custom fields can be set to
 required or optional, and scoped to specific projects. Currently, custom fields has support for URL, text,
 textarea (larger text), markdown, number, enum, multiselect, date, and boolean types.
 
@@ -174,6 +174,8 @@ in markdown for the Experiment page becomes `Guidance for experiments with tags.
 | Feature          | `user` `orgName` `featureKey` `featureType` `tags`                   |
 | Metrics List     | `user` `orgName`                                                     |
 | Metric           | `user` `orgName` `metricName` `metricType` `metricDatasource` `tags` |
+
+To view and edit custom markdown, go to **Settings** → **General** → **Custom Markdown** → **View Custom Markdown Settings**.
 
 ## Searching
 


### PR DESCRIPTION
- Add clear location for custom markdown
- Add subheading to tutorials page
- Add YT video to Strapi tutorial