### PR TITLE
Allow specifying environments when adding experiment to existing rule

### DIFF
--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -1242,13 +1242,16 @@ export async function postFeatureSync(
 }
 
 export async function postFeatureExperimentRefRule(
-  req: AuthRequest<{ rule: ExperimentRefRule }, { id: string }>,
+  req: AuthRequest<
+    { rule: ExperimentRefRule; appliedEnvironments: string[] },
+    { id: string }
+  >,
   res: Response<{ status: 200; version: number }, EventUserForResponseLocals>
 ) {
   const context = getContextFromReq(req);
   const { environments, org } = context;
   const { id } = req.params;
-  const { rule } = req.body;
+  const { rule, appliedEnvironments } = req.body;
 
   if (
     rule.type !== "experiment-ref" ||
@@ -1295,6 +1298,8 @@ export async function postFeatureExperimentRefRule(
     rules: {},
   };
   environments.forEach((env) => {
+    if (!appliedEnvironments.includes(env)) return;
+
     const envRule = {
       ...rule,
       id: generateRuleId(),

--- a/packages/front-end/components/Features/FeatureModal/EnvironmentSelect.tsx
+++ b/packages/front-end/components/Features/FeatureModal/EnvironmentSelect.tsx
@@ -1,4 +1,4 @@
-import { FC, useMemo } from "react";
+import { FC, ReactNode, useMemo } from "react";
 import { Environment } from "back-end/types/organization";
 import { FeatureEnvironment } from "back-end/types/feature";
 import { Container, Grid, Text } from "@radix-ui/themes";

--- a/packages/front-end/components/Features/FeatureModal/EnvironmentSelect.tsx
+++ b/packages/front-end/components/Features/FeatureModal/EnvironmentSelect.tsx
@@ -7,10 +7,16 @@ import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 import Checkbox from "@/components/Radix/Checkbox";
 
 const EnvironmentSelect: FC<{
+  label?: string | ReactNode;
   environmentSettings: Record<string, FeatureEnvironment>;
   environments: Environment[];
   setValue: (env: Environment, enabled: boolean) => void;
-}> = ({ environmentSettings, environments, setValue }) => {
+}> = ({
+  label = "Enabled Environments",
+  environmentSettings,
+  environments,
+  setValue,
+}) => {
   const permissionsUtil = usePermissionsUtil();
   const { project } = useDefinitions();
   const environmentsUserCanAccess = useMemo(() => {
@@ -29,14 +35,16 @@ const EnvironmentSelect: FC<{
   return (
     <div className="form-group">
       <Container
-        p="5"
+        px="4"
+        pt="4"
+        pb="3"
         style={{
           background: "var(--color-background)",
           borderRadius: "var(--radius-2)",
         }}
       >
         <Text as="label" weight="bold" mb="4">
-          Enabled Environments
+          {label}
         </Text>
         <div>
           <Checkbox
@@ -54,7 +62,7 @@ const EnvironmentSelect: FC<{
             }
             label="Select All"
             weight="bold"
-            mb="5"
+            mb="4"
           />
         </div>
         <Grid
@@ -74,7 +82,6 @@ const EnvironmentSelect: FC<{
               label={env.id}
               key={env.id}
               weight="regular"
-              mb="4"
               mr="2"
             />
           ))}

--- a/packages/front-end/components/Features/FeatureValueField.tsx
+++ b/packages/front-end/components/Features/FeatureValueField.tsx
@@ -22,7 +22,7 @@ import RadioGroup from "@/components/Radix/RadioGroup";
 
 export interface Props {
   valueType?: FeatureValueType;
-  label?: string;
+  label?: string | ReactNode;
   value: string;
   setValue: (v: string) => void;
   id: string;
@@ -340,7 +340,7 @@ function SimpleSchemaEditor({
   value: string;
   setValue: (value: string) => void;
   renderInline?: boolean;
-  label?: string;
+  label?: string | ReactNode;
   placeholder?: string;
 }) {
   const [open, setOpen] = useState(false);
@@ -493,7 +493,7 @@ function JSONTextEditor({
   helpText,
   placeholder,
 }: {
-  label?: string;
+  label?: string | ReactNode;
   editAsForm?: () => void;
   value: string;
   setValue: (value: string) => void;
@@ -576,7 +576,7 @@ function SimpleSchemaObjectArrayEditor({
   value: string;
   setValue: (value: string) => void;
   fields: SchemaField[];
-  label?: string;
+  label?: string | ReactNode;
   placeholder?: string;
 }) {
   let valueParsed: unknown;

--- a/packages/front-end/components/Features/RuleModal/ExperimentRefNewFields.tsx
+++ b/packages/front-end/components/Features/RuleModal/ExperimentRefNewFields.tsx
@@ -366,7 +366,7 @@ export default function ExperimentRefNewFields({
             </div>
           )}
 
-          {!isTemplate && (
+          {!isTemplate && source === "rule" ? (
             <>
               <hr />
               <div className="mt-4 mb-3">
@@ -405,7 +405,7 @@ export default function ExperimentRefNewFields({
                 ) : null}
               </div>
             </>
-          )}
+          ) : null}
         </>
       ) : null}
       {step === 3 ? (


### PR DESCRIPTION
- Allow user to specify environment(s) when adding an experiment-ref rule from an experiment page
- Clean up UI

<img width="857" alt="image" src="https://github.com/user-attachments/assets/5bb4acc8-9d22-401b-9b08-f64a980a2cab" />


### Features and Changes

<!--
  Include a description of your changes.
  If there are any new tools, API's, etc. that devs can leverage, it may be helpful to include usage info.
-->

<!--
  Indicate which issue this will close, if applicable
  For multiple issues, add a new `- Closes` or `- Fixes` line
-->

- Closes **(add link to issue here)**

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

<!--
  Please describe how to test these changes.
 -->

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
