### PR TITLE
Better truncate environment names to prevent scrolling

### DIFF
--- a/packages/front-end/components/Features/CompareEnvironmentsModal.tsx
+++ b/packages/front-end/components/Features/CompareEnvironmentsModal.tsx
@@ -1,7 +1,7 @@
 import { FeatureInterface } from "back-end/types/feature";
-import { filterEnvironmentsByFeature, truncateString } from "shared/util";
+import { filterEnvironmentsByFeature } from "shared/util";
 import ReactDiffViewer, { DiffMethod } from "react-diff-viewer";
-import { Flex, useThemeContext } from "@radix-ui/themes";
+import { Flex, useThemeContext, Text } from "@radix-ui/themes";
 import { getRules, useEnvironments } from "@/services/features";
 import Modal from "@/components/Modal";
 import { useAuth } from "@/services/auth";
@@ -90,11 +90,14 @@ export default function CompareEnvironmentsModal({
         environments={environments}
         formatOptionLabel={({ value }) => (
           <Flex justify="between" align="center">
-            <span>{truncateString(value, 50)}</span>
+            <Flex maxWidth="calc(100% - 130px)">
+              <Text truncate>{value}</Text>
+            </Flex>
             <Badge
               label={`${rulesByEnv[value].length} Rule${
                 rulesByEnv[value].length === 1 ? "" : "s"
               } applied`}
+              ml="2"
             />
           </Flex>
         )}
@@ -106,11 +109,14 @@ export default function CompareEnvironmentsModal({
         environments={environments.filter((env) => env.id !== sourceEnv)}
         formatOptionLabel={({ value }) => (
           <Flex justify="between" align="center">
-            <span>{value}</span>
+            <Flex maxWidth="calc(100% - 130px)">
+              <Text truncate>{value}</Text>
+            </Flex>
             <Badge
               label={`${rulesByEnv[value].length} Rule${
                 rulesByEnv[value].length === 1 ? "" : "s"
               } applied`}
+              ml="2"
             />
           </Flex>
         )}

--- a/packages/front-end/components/Features/FeatureRules.tsx
+++ b/packages/front-end/components/Features/FeatureRules.tsx
@@ -6,8 +6,7 @@ import {
   FeatureRule,
 } from "back-end/src/validators/features";
 import { Environment } from "back-end/types/organization";
-import { Container, Flex } from "@radix-ui/themes";
-import { truncateString } from "shared/util";
+import { Container, Flex, Text } from "@radix-ui/themes";
 import RuleModal from "@/components/Features/RuleModal/index";
 import RuleList from "@/components/Features/RuleList";
 import track from "@/services/track";
@@ -92,11 +91,14 @@ export default function FeatureRules({
           <Container maxWidth="100%">
             <Flex align="center" justify="between">
               <TabsList>
-                <Flex overflow="scroll">
+                <Flex wrap="wrap" overflow="hidden">
                   {environments.map((e) => (
                     <TabsTrigger value={e.id} key={e.id}>
-                      <span className="mr-2">{e.id}</span>
+                      <Flex maxWidth="220px">
+                        <Text truncate>{e.id}</Text>
+                      </Flex>
                       <Badge
+                        ml="2"
                         label={rulesByEnv[e.id].length.toString()}
                         radius="full"
                         variant="solid"
@@ -107,8 +109,10 @@ export default function FeatureRules({
                 </Flex>
               </TabsList>
               <Link
+                ml="2"
                 onClick={() => setCompareEnvModal({ sourceEnv: env })}
                 underline="none"
+                wrap="nowrap"
               >
                 Compare environments
               </Link>
@@ -124,11 +128,14 @@ export default function FeatureRules({
                   environments={environments}
                   formatOptionLabel={({ value }) => (
                     <Flex justify="between" align="center">
-                      <span>{truncateString(value, 50)}</span>
+                      <Flex maxWidth="270px">
+                        <Text truncate>{value}</Text>
+                      </Flex>
                       <Badge
                         label={`${rulesByEnv[value].length} Rule${
                           rulesByEnv[value].length === 1 ? "" : "s"
                         } applied`}
+                        ml="2"
                       />
                     </Flex>
                   )}


### PR DESCRIPTION
### Features and Changes

Environment names are still causing some awkward UI behaviors on certain resolutions and browsers, so this PR removes the scrolling and adds extra safeguards to prevent elements growing unexpectedly.

### Testing

Check each of these cases to make sure the spacing looks correct
* 5 or fewer small environment names (extra whitespace)
* 5 or fewer large environment names (truncation/wrapping)
* 6+ small environment names (dropdown with whitespace)
* 6+ large environment names (dropdown truncation)
* Compare environments modal with a mix of small & large env names

### Screenshots

#### Short names
![image](https://github.com/user-attachments/assets/31f6722e-f691-42d0-9466-be5dacdb77a4)

#### Short names + zoomed out (no weird whitespace)
![image](https://github.com/user-attachments/assets/1eb96bbe-c19e-4f21-9559-5da27cd63665)

#### Truncation
![image](https://github.com/user-attachments/assets/f6fbad36-beb2-4908-914d-9b76cfa997d9)


#### Truncation + wrapping
![image](https://github.com/user-attachments/assets/7c80212a-c34d-4bf6-81b8-a74b50ff3155)

#### Modal
![image](https://github.com/user-attachments/assets/1dfab260-ab9f-4ed1-afc6-e1ee86c784f0)

