### PR TITLE
Fixes Add Experiment Template DropdownMenuItem

### DIFF
--- a/packages/front-end/pages/experiments/index.tsx
+++ b/packages/front-end/pages/experiments/index.tsx
@@ -375,14 +375,14 @@ const ExperimentsPage = (): React.ReactElement => {
         </DropdownMenuItem>
       )}
       {canAddTemplate && (
-        <PremiumTooltip commercialFeature="templates">
-          <DropdownMenuItem
-            onClick={() => setOpenTemplateModal({})}
-            disabled={!hasTemplatesFeature}
-          >
+        <DropdownMenuItem
+          onClick={() => setOpenTemplateModal({})}
+          disabled={!hasTemplatesFeature}
+        >
+          <PremiumTooltip commercialFeature="templates">
             Create Template
-          </DropdownMenuItem>
-        </PremiumTooltip>
+          </PremiumTooltip>
+        </DropdownMenuItem>
       )}
       {canAddExperiment && (
         <>


### PR DESCRIPTION
### Features and Changes

The "Create Template" button had the `PremiumTooltip` component wrapping the `DropdownMenuItem` was affected the styling of the `DropdownMenuItem`. Specifically, on-hover, the background color wasn't full width.

Before
<img width="290" alt="Screenshot 2025-01-24 at 12 01 54 PM" src="https://github.com/user-attachments/assets/ef83f86f-c4c4-43d7-8e76-de268cbdf7d5" />

This PR moves the `PremiumTooltip` as a child component of the `DropdownMenuItem` so the Radix styling is retained.

After (No hover - free org)
<img width="280" alt="Screenshot 2025-01-24 at 11 59 50 AM" src="https://github.com/user-attachments/assets/4cc074cf-3bcb-404c-aed3-25197588aa89" />

After (hover - free org)
<img width="295" alt="Screenshot 2025-01-24 at 11 59 55 AM" src="https://github.com/user-attachments/assets/17dbac00-a550-4f0c-b5ac-cce58d35f1d0" />

After (Hover - enterprise org)
<img width="286" alt="Screenshot 2025-01-24 at 12 00 42 PM" src="https://github.com/user-attachments/assets/8dee5c5a-2134-45cb-a43e-47fc1373841b" />

