### PR TITLE
Add API endpoints for Archetypes

### DIFF
--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -108,6 +108,12 @@ tags:
   - name: code-references
     x-displayName: Code References
     description: 'Intended for use with our code reference CI utility, [`gb-find-code-refs`](https://github.com/growthbook/gb-find-code-refs).'
+  - name: archetypes
+    x-displayName: Archetypes
+    description: Archetypes allow you to simulate the result of targeting rules on pre-set user attributes
+  - name: Archetype_model
+    x-displayName: Archetype
+    description: <SchemaDefinition schemaRef="#/components/schemas/Archetype" />
   - name: Attribute_model
     x-displayName: Attribute
     description: <SchemaDefinition schemaRef="#/components/schemas/Attribute" />
@@ -1189,6 +1195,35 @@ paths:
                 properties:
                   deletedId:
                     type: string
+  '/sdk-connections/lookup/{key}':
+    get:
+      parameters:
+        - in: path
+          name: key
+          required: true
+          description: The key of the requested sdkConnection
+          schema:
+            type: string
+      summary: Find a single sdk connection by its key
+      tags:
+        - sdk-connections
+      operationId: lookupSdkConnectionByKey
+      x-codeSamples:
+        - lang: cURL
+          source: |
+            curl https://api.growthbook.io/api/v1/sdk-connections/lookup/sdk-123abc \
+              -u secret_abc123DEF456:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - sdkConnection
+                properties:
+                  sdkConnection:
+                    $ref: '#/components/schemas/SdkConnection'
   /data-sources:
     get:
       summary: Get all data sources
@@ -3144,6 +3179,102 @@ paths:
                 properties:
                   deletedProperty:
                     type: string
+  /archetypes:
+    get:
+      summary: Get the organization's archetypes
+      tags:
+        - archetypes
+      operationId: listArchetypes
+      x-codeSamples:
+        - lang: cURL
+          source: |
+            curl https://api.growthbook.io/api/v1/archetypes \
+              -u secret_abc123DEF456:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - type: object
+                    required:
+                      - archetypes
+                    properties:
+                      archetypes:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/Archetype'
+    post:
+      parameters: []
+      tags:
+        - archetypes
+      summary: Create a single archetype
+      operationId: postArchetype
+      x-codeSamples:
+        - lang: cURL
+          source: |
+            curl -X POST https://api.growthbook.io/api/v1/archetypes \
+              -d '{ "name": "Mobile user", attributes: "{\"deviceType\": \"mobile\"}", isPublic: true, ... }'
+              -u secret_abc123DEF456:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+                - isPublic
+              properties:
+                name:
+                  type: string
+                description:
+                  type: string
+                isPublic:
+                  type: boolean
+                  description: Whether to make this Archetype available to other team members
+                attributes:
+                  type: string
+                  description: A valid JSON string of the attributes for this Archetype
+                projects:
+                  type: array
+                  items:
+                    type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - archetype
+                properties:
+                  archetype:
+                    $ref: '#/components/schemas/Archetype'
+  '/archetypes/${id}':
+    get:
+      parameters:
+        - $ref: '#/components/parameters/id'
+      summary: Get a single archetype
+      tags:
+        - archetypes
+      operationId: getArchetype
+      x-codeSamples:
+        - lang: cURL
+          source: |
+            curl https://api.growthbook.io/api/v1/archetypes/sam_123abc \
+              -u secret_abc123DEF456:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - archetype
+                properties:
+                  archetype:
+                    $ref: '#/components/schemas/Archetype'
   /members:
     get:
       summary: Get all organization members
@@ -6557,6 +6688,38 @@ components:
         dateUpdated:
           type: string
           format: date-time
+    Archetype:
+      type: object
+      required:
+        - id
+        - dateCreated
+        - dateUpdated
+        - name
+        - owner
+        - isPublic
+        - attributes
+      properties:
+        id:
+          type: string
+        dateCreated:
+          type: string
+        dateUpdated:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        owner:
+          type: string
+        isPublic:
+          type: boolean
+        attributes:
+          type: string
+          description: A valid JSON string of the attributes for this Archetype
+        projects:
+          type: array
+          items:
+            type: string
   securitySchemes:
     bearerAuth:
       type: http
@@ -6610,8 +6773,10 @@ x-tagGroups:
       - fact-tables
       - fact-metrics
       - code-references
+      - archetypes
   - name: Models
     tags:
+      - Archetype_model
       - Attribute_model
       - DataSource_model
       - Dimension_model

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -3275,6 +3275,74 @@ paths:
                 properties:
                   archetype:
                     $ref: '#/components/schemas/Archetype'
+    put:
+      parameters:
+        - $ref: '#/components/parameters/id'
+      tags:
+        - archetypes
+      summary: Update a single archetype
+      operationId: putArchetype
+      x-codeSamples:
+        - lang: cURL
+          source: |
+            curl -X PUT https://api.growthbook.io/api/v1/archetypes/sam_abc123 \
+              -d '{ "description": "New description" }'
+              -u secret_abc123DEF456:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                description:
+                  type: string
+                isPublic:
+                  type: boolean
+                  description: Whether to make this Archetype available to other team members
+                attributes:
+                  type: string
+                  description: A valid JSON string of the attributes for this Archetype
+                projects:
+                  type: array
+                  items:
+                    type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - archetype
+                properties:
+                  archetype:
+                    $ref: '#/components/schemas/Archetype'
+    delete:
+      parameters:
+        - $ref: '#/components/parameters/id'
+      tags:
+        - archetypes
+      summary: Deletes a single archetype
+      operationId: deleteArchetype
+      x-codeSamples:
+        - lang: cURL
+          source: |
+            curl -X DELETE https://api.growthbook.io/api/v1/archetypes/sam_abc123 \
+              -u secret_abc123DEF456:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - deletedId
+                properties:
+                  deletedId:
+                    type: string
   /members:
     get:
       summary: Get all organization members

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -3234,8 +3234,8 @@ paths:
                   type: boolean
                   description: Whether to make this Archetype available to other team members
                 attributes:
-                  type: string
-                  description: A valid JSON string of the attributes for this Archetype
+                  type: object
+                  description: The attributes to set when using this Archetype
                 projects:
                   type: array
                   items:
@@ -3303,8 +3303,8 @@ paths:
                   type: boolean
                   description: Whether to make this Archetype available to other team members
                 attributes:
-                  type: string
-                  description: A valid JSON string of the attributes for this Archetype
+                  type: object
+                  description: The attributes to set when using this Archetype
                 projects:
                   type: array
                   items:
@@ -6782,8 +6782,8 @@ components:
         isPublic:
           type: boolean
         attributes:
-          type: string
-          description: A valid JSON string of the attributes for this Archetype
+          type: object
+          description: The attributes to set when using this Archetype
         projects:
           type: array
           items:

--- a/packages/back-end/src/api/api.router.ts
+++ b/packages/back-end/src/api/api.router.ts
@@ -29,6 +29,7 @@ import membersRouter from "./members/members.router";
 import { postCopyTransform } from "./openai/postCopyTransform";
 import { getFeatureKeys } from "./features/getFeatureKeys";
 import ingestionRouter from "./ingestion/ingestion.router";
+import archetypesRouter from "./archetypes/archetypes.router";
 
 const router = Router();
 let openapiSpec: string;
@@ -102,6 +103,7 @@ router.use("/bulk-import", bulkImportRouter);
 router.use("/code-refs", codeRefsRouter);
 router.use("/members", membersRouter);
 router.use("/ingestion", ingestionRouter);
+router.use("/archetypes", archetypesRouter);
 
 router.post("/transform-copy", postCopyTransform);
 

--- a/packages/back-end/src/api/archetypes/archetypes.router.ts
+++ b/packages/back-end/src/api/archetypes/archetypes.router.ts
@@ -1,8 +1,16 @@
 import { Router } from "express";
 import { listArchetypes } from "./listArchetypes";
+import { postArchetype } from "./postArchetype";
+import { getArchetype } from "./getArchetype";
+import { putArchetype } from "./putArchetype";
+import { deleteArchetype } from "./deleteArchetype";
 
 const router = Router();
 
 router.get("/", listArchetypes);
+router.post("/", postArchetype);
+router.get("/:id", getArchetype);
+router.put("/:id", putArchetype);
+router.delete("/:id", deleteArchetype);
 
 export default router;

--- a/packages/back-end/src/api/archetypes/archetypes.router.ts
+++ b/packages/back-end/src/api/archetypes/archetypes.router.ts
@@ -1,0 +1,8 @@
+import { Router } from "express";
+import { listArchetypes } from "./listArchetypes";
+
+const router = Router();
+
+router.get("/", listArchetypes);
+
+export default router;

--- a/packages/back-end/src/api/archetypes/deleteArchetype.ts
+++ b/packages/back-end/src/api/archetypes/deleteArchetype.ts
@@ -1,0 +1,38 @@
+import { DeleteArchetypeResponse } from "back-end/types/openapi";
+import { createApiRequestHandler } from "back-end/src/util/handler";
+import { deleteArchetypeValidator } from "back-end/src/validators/openapi";
+import {
+  deleteArchetypeById,
+  getArchetypeById,
+} from "back-end/src/models/ArchetypeModel";
+import { auditDetailsDelete } from "back-end/src/services/audit";
+
+export const deleteArchetype = createApiRequestHandler(
+  deleteArchetypeValidator
+)(
+  async (req): Promise<DeleteArchetypeResponse> => {
+    const { id } = req.params;
+    const orgId = req.organization.id;
+    const archetype = await getArchetypeById(id, orgId);
+    if (!archetype) {
+      throw new Error(`An archetype with id ${id} does not exist`);
+    }
+
+    if (!req.context.permissions.canDeleteArchetype(archetype))
+      req.context.permissions.throwPermissionError();
+
+    await deleteArchetypeById(id, orgId);
+    await req.audit({
+      event: "archetype.deleted",
+      entity: {
+        object: "archetype",
+        id: archetype.id,
+      },
+      details: auditDetailsDelete(archetype),
+    });
+
+    return {
+      deletedId: archetype.id,
+    };
+  }
+);

--- a/packages/back-end/src/api/archetypes/getArchetype.ts
+++ b/packages/back-end/src/api/archetypes/getArchetype.ts
@@ -1,0 +1,27 @@
+import { GetArchetypeResponse } from "back-end/types/openapi";
+import { createApiRequestHandler } from "back-end/src/util/handler";
+import { getArchetypeValidator } from "back-end/src/validators/openapi";
+import {
+  getArchetypeById,
+  toArchetypeApiInterface,
+} from "back-end/src/models/ArchetypeModel";
+
+export const getArchetype = createApiRequestHandler(getArchetypeValidator)(
+  async (req): Promise<GetArchetypeResponse> => {
+    const { id } = req.params;
+    const orgId = req.organization.id;
+    const archetype = await getArchetypeById(id, orgId);
+    if (!archetype) {
+      throw new Error(`An archetype with id ${id} does not exist`);
+    }
+
+    if (
+      !req.context.permissions.canReadMultiProjectResource(archetype.projects)
+    )
+      req.context.permissions.throwPermissionError();
+
+    return {
+      archetype: toArchetypeApiInterface(archetype),
+    };
+  }
+);

--- a/packages/back-end/src/api/archetypes/listArchetypes.ts
+++ b/packages/back-end/src/api/archetypes/listArchetypes.ts
@@ -12,8 +12,12 @@ export const listArchetypes = createApiRequestHandler(listArchetypesValidator)(
       req.context.org.id,
       req.context.userId
     );
+    const filteredArchetypes = archetypes.filter((archetype) => {
+      req.context.permissions.canReadMultiProjectResource(archetype.projects);
+    });
+
     return {
-      archetypes: archetypes.map((archetype) =>
+      archetypes: filteredArchetypes.map((archetype) =>
         toArchetypeApiInterface(archetype)
       ),
     };

--- a/packages/back-end/src/api/archetypes/listArchetypes.ts
+++ b/packages/back-end/src/api/archetypes/listArchetypes.ts
@@ -1,0 +1,21 @@
+import { ListArchetypesResponse } from "back-end/types/openapi";
+import { createApiRequestHandler } from "back-end/src/util/handler";
+import { listArchetypesValidator } from "back-end/src/validators/openapi";
+import {
+  getAllArchetypes,
+  toArchetypeApiInterface,
+} from "back-end/src/models/ArchetypeModel";
+
+export const listArchetypes = createApiRequestHandler(listArchetypesValidator)(
+  async (req): Promise<ListArchetypesResponse> => {
+    const archetypes = await getAllArchetypes(
+      req.context.org.id,
+      req.context.userId
+    );
+    return {
+      archetypes: archetypes.map((archetype) =>
+        toArchetypeApiInterface(archetype)
+      ),
+    };
+  }
+);

--- a/packages/back-end/src/api/archetypes/listArchetypes.ts
+++ b/packages/back-end/src/api/archetypes/listArchetypes.ts
@@ -12,9 +12,9 @@ export const listArchetypes = createApiRequestHandler(listArchetypesValidator)(
       req.context.org.id,
       req.context.userId
     );
-    const filteredArchetypes = archetypes.filter((archetype) => {
-      req.context.permissions.canReadMultiProjectResource(archetype.projects);
-    });
+    const filteredArchetypes = archetypes.filter((archetype) =>
+      req.context.permissions.canReadMultiProjectResource(archetype.projects)
+    );
 
     return {
       archetypes: filteredArchetypes.map((archetype) =>

--- a/packages/back-end/src/api/archetypes/postArchetype.ts
+++ b/packages/back-end/src/api/archetypes/postArchetype.ts
@@ -10,10 +10,7 @@ import { validatePayload } from "./validations";
 
 export const postArchetype = createApiRequestHandler(postArchetypeValidator)(
   async (req): Promise<PostArchetypeResponse> => {
-    const payload = {
-      ...(await validatePayload(req.context, req.body)),
-      organization: req.organization.id,
-    };
+    const payload = await validatePayload(req.context, req.body);
     const archetype = await createArchetype(payload);
 
     await req.audit({

--- a/packages/back-end/src/api/archetypes/postArchetype.ts
+++ b/packages/back-end/src/api/archetypes/postArchetype.ts
@@ -1,0 +1,31 @@
+import { PostArchetypeResponse } from "back-end/types/openapi";
+import { createApiRequestHandler } from "back-end/src/util/handler";
+import { postArchetypeValidator } from "back-end/src/validators/openapi";
+import {
+  createArchetype,
+  toArchetypeApiInterface,
+} from "back-end/src/models/ArchetypeModel";
+import { auditDetailsCreate } from "back-end/src/services/audit";
+import { validatePayload } from "./validations";
+
+export const postArchetype = createApiRequestHandler(postArchetypeValidator)(
+  async (req): Promise<PostArchetypeResponse> => {
+    const payload = {
+      ...(await validatePayload(req.context, req.body)),
+      organization: req.organization.id,
+    };
+    const archetype = await createArchetype(payload);
+
+    await req.audit({
+      event: "archetype.created",
+      entity: {
+        object: "archetype",
+        id: archetype.id,
+      },
+      details: auditDetailsCreate(archetype),
+    });
+    return {
+      archetype: toArchetypeApiInterface(archetype),
+    };
+  }
+);

--- a/packages/back-end/src/api/archetypes/putArchetype.ts
+++ b/packages/back-end/src/api/archetypes/putArchetype.ts
@@ -1,0 +1,46 @@
+import { PutArchetypeResponse } from "back-end/types/openapi";
+import { createApiRequestHandler } from "back-end/src/util/handler";
+import { putArchetypeValidator } from "back-end/src/validators/openapi";
+import {
+  getArchetypeById,
+  toArchetypeApiInterface,
+  updateArchetypeById,
+} from "back-end/src/models/ArchetypeModel";
+import { auditDetailsUpdate } from "back-end/src/services/audit";
+import { validatePayload } from "./validations";
+
+export const putArchetype = createApiRequestHandler(putArchetypeValidator)(
+  async (req): Promise<PutArchetypeResponse> => {
+    const { id } = req.params;
+    const orgId = req.organization.id;
+    const archetype = await getArchetypeById(id, orgId);
+    if (!archetype) {
+      throw new Error(`An archetype with id ${id} does not exist`);
+    }
+
+    const rawUpdatedArchetype = { ...archetype, ...req.body };
+
+    const updatedArchetype = {
+      ...rawUpdatedArchetype,
+      ...(await validatePayload(req.context, rawUpdatedArchetype)),
+    };
+    if (
+      !req.context.permissions.canUpdateArchetype(archetype, updatedArchetype)
+    )
+      req.context.permissions.throwPermissionError();
+
+    await updateArchetypeById(id, orgId, updatedArchetype);
+    await req.audit({
+      event: "archetype.updated",
+      entity: {
+        object: "archetype",
+        id: archetype.id,
+      },
+      details: auditDetailsUpdate(archetype, updatedArchetype),
+    });
+
+    return {
+      archetype: toArchetypeApiInterface(updatedArchetype),
+    };
+  }
+);

--- a/packages/back-end/src/api/archetypes/validations.ts
+++ b/packages/back-end/src/api/archetypes/validations.ts
@@ -6,13 +6,14 @@ export async function validatePayload(
     name,
     isPublic,
     description = "",
-    attributes = "{}",
+    attributes,
     projects = [],
   }: {
     name: string;
     isPublic: boolean;
     description?: string;
-    attributes?: string;
+    // eslint-disable-next-line
+    attributes?: Record<string, any> | string; // Attributes from the payload will be an object but from an existing model will be a string
     projects?: string[];
   }
 ) {
@@ -30,10 +31,8 @@ export async function validatePayload(
       );
   }
 
-  try {
-    JSON.parse(attributes);
-  } catch {
-    throw new Error("Attributes is not a valid JSON string");
+  if (typeof attributes !== "string") {
+    attributes = JSON.stringify(attributes || {});
   }
 
   return {

--- a/packages/back-end/src/api/archetypes/validations.ts
+++ b/packages/back-end/src/api/archetypes/validations.ts
@@ -30,6 +30,12 @@ export async function validatePayload(
       );
   }
 
+  try {
+    JSON.parse(attributes);
+  } catch {
+    throw new Error("Attributes is not a valid JSON string");
+  }
+
   return {
     name,
     attributes,
@@ -37,5 +43,6 @@ export async function validatePayload(
     projects,
     isPublic,
     owner: context.userId,
+    organization: context.org.id,
   };
 }

--- a/packages/back-end/src/api/archetypes/validations.ts
+++ b/packages/back-end/src/api/archetypes/validations.ts
@@ -1,0 +1,41 @@
+import { ApiReqContext } from "back-end/types/api";
+
+export async function validatePayload(
+  context: ApiReqContext,
+  {
+    name,
+    isPublic,
+    description = "",
+    attributes = "{}",
+    projects = [],
+  }: {
+    name: string;
+    isPublic: boolean;
+    description?: string;
+    attributes?: string;
+    projects?: string[];
+  }
+) {
+  if (name === "") throw Error("Archetype name cannot empty!");
+
+  if (projects.length) {
+    const allProjects = await context.models.projects.getAll();
+    const nonexistentProjects = projects.filter(
+      (p) => !allProjects.some(({ id }) => p === id)
+    );
+
+    if (nonexistentProjects.length)
+      throw new Error(
+        `The following projects do not exist: ${nonexistentProjects.join(", ")}`
+      );
+  }
+
+  return {
+    name,
+    attributes,
+    description,
+    projects,
+    isPublic,
+    owner: context.userId,
+  };
+}

--- a/packages/back-end/src/api/openapi/openapi.yaml
+++ b/packages/back-end/src/api/openapi/openapi.yaml
@@ -111,6 +111,9 @@ tags:
   - name: code-references
     x-displayName: Code References
     description: Intended for use with our code reference CI utility, [`gb-find-code-refs`](https://github.com/growthbook/gb-find-code-refs).
+  - name: archetypes
+    x-displayName: Archetypes
+    description: Archetypes allow you to simulate the result of targeting rules on pre-set user attributes
 paths:
   /features:
     get:
@@ -161,6 +164,9 @@ paths:
       $ref: "./paths/putSdkConnection.yaml"
     delete:
       $ref: "./paths/deleteSdkConnection.yaml"
+  /sdk-connections/lookup/{key}:
+    get:
+      $ref: "./paths/lookupSdkConnectionByKey.yaml"
   /data-sources:
     $ref: "./paths/listDataSources.yaml"
   /data-sources/{id}:
@@ -234,6 +240,14 @@ paths:
       $ref: "./paths/putAttribute.yaml"
     delete:
       $ref: "./paths/deleteAttribute.yaml"
+  /archetypes:
+    get:
+      $ref: "./paths/listArchetypes.yaml"
+    post:
+      $ref: "./paths/postArchetype.yaml"
+  /archetypes/${id}:
+    get:
+      $ref: "./paths/getArchetype.yaml"
   /members:
     get:
       $ref: "./paths/listMembers.yaml"

--- a/packages/back-end/src/api/openapi/openapi.yaml
+++ b/packages/back-end/src/api/openapi/openapi.yaml
@@ -248,6 +248,10 @@ paths:
   /archetypes/${id}:
     get:
       $ref: "./paths/getArchetype.yaml"
+    put:
+      $ref: "./paths/putArchetype.yaml"
+    delete:
+      $ref: "./paths/deleteArchetype.yaml"
   /members:
     get:
       $ref: "./paths/listMembers.yaml"

--- a/packages/back-end/src/api/openapi/paths/deleteArchetype.yaml
+++ b/packages/back-end/src/api/openapi/paths/deleteArchetype.yaml
@@ -1,0 +1,22 @@
+parameters:
+  - $ref: "../parameters.yaml#/id"
+tags:
+  - archetypes
+summary: Deletes a single archetype
+operationId: deleteArchetype
+x-codeSamples:
+  - lang: "cURL"
+    source: |
+      curl -X DELETE https://api.growthbook.io/api/v1/archetypes/sam_abc123 \
+        -u secret_abc123DEF456:
+responses:
+  "200":
+    content:
+      application/json:
+        schema:
+          type: object
+          required:
+            - deletedId
+          properties:
+            deletedId:
+              type: string

--- a/packages/back-end/src/api/openapi/paths/getArchetype.yaml
+++ b/packages/back-end/src/api/openapi/paths/getArchetype.yaml
@@ -1,0 +1,22 @@
+parameters:
+  - $ref: "../parameters.yaml#/id"
+summary: Get a single archetype
+tags:
+  - archetypes
+operationId: getArchetype
+x-codeSamples:
+  - lang: "cURL"
+    source: |
+      curl https://api.growthbook.io/api/v1/archetypes/sam_123abc \
+        -u secret_abc123DEF456:
+responses:
+  "200":
+    content:
+      application/json:
+        schema:
+          type: object
+          required:
+            - archetype
+          properties:
+            archetype:
+              $ref: "../schemas/Archetype.yaml"

--- a/packages/back-end/src/api/openapi/paths/listArchetypes.yaml
+++ b/packages/back-end/src/api/openapi/paths/listArchetypes.yaml
@@ -1,0 +1,23 @@
+summary: Get the organization's archetypes
+tags:
+  - archetypes
+operationId: listArchetypes
+x-codeSamples:
+  - lang: "cURL"
+    source: |
+      curl https://api.growthbook.io/api/v1/archetypes \
+        -u secret_abc123DEF456:
+responses:
+  "200":
+    content:
+      application/json:
+        schema:
+          allOf:
+            - type: object
+              required:
+                - archetypes
+              properties:
+                archetypes:
+                  type: array
+                  items:
+                    $ref: "../schemas/Archetype.yaml"

--- a/packages/back-end/src/api/openapi/paths/lookupSdkConnectionByKey.yaml
+++ b/packages/back-end/src/api/openapi/paths/lookupSdkConnectionByKey.yaml
@@ -1,0 +1,27 @@
+parameters:
+  - in: path
+    name: key
+    required: true
+    description: The key of the requested sdkConnection
+    schema:
+      type: string
+summary: Find a single sdk connection by its key
+tags:
+  - sdk-connections
+operationId: lookupSdkConnectionByKey
+x-codeSamples:
+  - lang: "cURL"
+    source: |
+      curl https://api.growthbook.io/api/v1/sdk-connections/lookup/sdk-123abc \
+        -u secret_abc123DEF456:
+responses:
+  "200":
+    content:
+      application/json:
+        schema:
+          type: object
+          required:
+            - sdkConnection
+          properties:
+            sdkConnection:
+              $ref: "../schemas/SdkConnection.yaml"

--- a/packages/back-end/src/api/openapi/paths/postArchetype.yaml
+++ b/packages/back-end/src/api/openapi/paths/postArchetype.yaml
@@ -1,0 +1,28 @@
+parameters: []
+tags:
+  - archetypes
+summary: Create a single archetype
+operationId: postArchetype
+x-codeSamples:
+  - lang: "cURL"
+    source: |
+      curl -X POST https://api.growthbook.io/api/v1/archetypes \
+        -d '{ "name": "Mobile user", attributes: "{\"deviceType\": \"mobile\"}", isPublic: true, ... }'
+        -u secret_abc123DEF456:
+requestBody:
+  required: true
+  content:
+    application/json:
+      schema:
+        $ref: "../payload-schemas/PostArchetypePayload.yaml"
+responses:
+  "200":
+    content:
+      application/json:
+        schema:
+          type: object
+          required:
+            - archetype
+          properties:
+            archetype:
+              $ref: "../schemas/Archetype.yaml"

--- a/packages/back-end/src/api/openapi/paths/putArchetype.yaml
+++ b/packages/back-end/src/api/openapi/paths/putArchetype.yaml
@@ -1,0 +1,29 @@
+parameters:
+  - $ref: "../parameters.yaml#/id"
+tags:
+  - archetypes
+summary: Update a single archetype
+operationId: putArchetype
+x-codeSamples:
+  - lang: "cURL"
+    source: |
+      curl -X PUT https://api.growthbook.io/api/v1/archetypes/sam_abc123 \
+        -d '{ "description": "New description" }'
+        -u secret_abc123DEF456:
+requestBody:
+  required: true
+  content:
+    application/json:
+      schema:
+        $ref: "../payload-schemas/PutArchetypePayload.yaml"
+responses:
+  "200":
+    content:
+      application/json:
+        schema:
+          type: object
+          required:
+            - archetype
+          properties:
+            archetype:
+              $ref: "../schemas/Archetype.yaml"

--- a/packages/back-end/src/api/openapi/payload-schemas/PostArchetypePayload.yaml
+++ b/packages/back-end/src/api/openapi/payload-schemas/PostArchetypePayload.yaml
@@ -1,0 +1,19 @@
+type: object
+required:
+  - name
+  - isPublic
+properties:
+  name:
+    type: string
+  description:
+    type: string
+  isPublic:
+    type: boolean
+    description: Whether to make this Archetype available to other team members
+  attributes:
+    type: string
+    description: A valid JSON string of the attributes for this Archetype
+  projects:
+    type: array
+    items:
+      type: string

--- a/packages/back-end/src/api/openapi/payload-schemas/PostArchetypePayload.yaml
+++ b/packages/back-end/src/api/openapi/payload-schemas/PostArchetypePayload.yaml
@@ -11,8 +11,8 @@ properties:
     type: boolean
     description: Whether to make this Archetype available to other team members
   attributes:
-    type: string
-    description: A valid JSON string of the attributes for this Archetype
+    type: object
+    description: The attributes to set when using this Archetype
   projects:
     type: array
     items:

--- a/packages/back-end/src/api/openapi/payload-schemas/PutArchetypePayload.yaml
+++ b/packages/back-end/src/api/openapi/payload-schemas/PutArchetypePayload.yaml
@@ -1,0 +1,16 @@
+type: object
+properties:
+  name:
+    type: string
+  description:
+    type: string
+  isPublic:
+    type: boolean
+    description: Whether to make this Archetype available to other team members
+  attributes:
+    type: string
+    description: A valid JSON string of the attributes for this Archetype
+  projects:
+    type: array
+    items:
+      type: string

--- a/packages/back-end/src/api/openapi/payload-schemas/PutArchetypePayload.yaml
+++ b/packages/back-end/src/api/openapi/payload-schemas/PutArchetypePayload.yaml
@@ -8,8 +8,8 @@ properties:
     type: boolean
     description: Whether to make this Archetype available to other team members
   attributes:
-    type: string
-    description: A valid JSON string of the attributes for this Archetype
+    type: object
+    description: The attributes to set when using this Archetype
   projects:
     type: array
     items:

--- a/packages/back-end/src/api/openapi/schemas/Archetype.yaml
+++ b/packages/back-end/src/api/openapi/schemas/Archetype.yaml
@@ -23,8 +23,8 @@ properties:
   isPublic:
     type: boolean
   attributes:
-    type: string
-    description: A valid JSON string of the attributes for this Archetype
+    type: object
+    description: The attributes to set when using this Archetype
   projects:
     type: array
     items:

--- a/packages/back-end/src/api/openapi/schemas/Archetype.yaml
+++ b/packages/back-end/src/api/openapi/schemas/Archetype.yaml
@@ -1,0 +1,31 @@
+type: object
+required:
+  - id
+  - dateCreated
+  - dateUpdated
+  - name
+  - owner
+  - isPublic
+  - attributes
+properties:
+  id:
+    type: string
+  dateCreated:
+    type: string
+  dateUpdated:
+    type: string
+  name:
+    type: string
+  description:
+    type: string
+  owner:
+    type: string
+  isPublic:
+    type: boolean
+  attributes:
+    type: string
+    description: A valid JSON string of the attributes for this Archetype
+  projects:
+    type: array
+    items:
+      type: string

--- a/packages/back-end/src/api/openapi/schemas/_index.yaml
+++ b/packages/back-end/src/api/openapi/schemas/_index.yaml
@@ -58,3 +58,5 @@ FactMetric:
   $ref: "./FactMetric.yaml"
 Member:
   $ref: "./Member.yaml"
+Archetype:
+  $ref: "./Archetype.yaml"

--- a/packages/back-end/src/api/sdk-connections/lookupSdkConnectionByKey.ts
+++ b/packages/back-end/src/api/sdk-connections/lookupSdkConnectionByKey.ts
@@ -1,0 +1,28 @@
+import { GetSdkConnectionResponse } from "back-end/types/openapi";
+import {
+  findSDKConnectionByKey,
+  toApiSDKConnectionInterface,
+} from "back-end/src/models/SdkConnectionModel";
+import { createApiRequestHandler } from "back-end/src/util/handler";
+import { lookupSdkConnectionByKeyValidator } from "back-end/src/validators/openapi";
+
+export const lookupSdkConnectionByKey = createApiRequestHandler(
+  lookupSdkConnectionByKeyValidator
+)(
+  async (req): Promise<GetSdkConnectionResponse> => {
+    const sdkConnection = await findSDKConnectionByKey(req.params.key);
+    if (!sdkConnection) {
+      throw new Error("Could not find sdkConnection with that key");
+    }
+    if (
+      !req.context.permissions.canReadMultiProjectResource(
+        sdkConnection.projects
+      )
+    )
+      req.context.permissions.throwPermissionError();
+
+    return {
+      sdkConnection: toApiSDKConnectionInterface(sdkConnection),
+    };
+  }
+);

--- a/packages/back-end/src/api/sdk-connections/sdk-connections.router.ts
+++ b/packages/back-end/src/api/sdk-connections/sdk-connections.router.ts
@@ -4,6 +4,7 @@ import { listSdkConnections } from "./listSdkConnections";
 import { postSdkConnection } from "./postSdkConnection";
 import { putSdkConnection } from "./putSdkConnection";
 import { deleteSdkConnection } from "./deleteSdkConnection";
+import { lookupSdkConnectionByKey } from "./lookupSdkConnectionByKey";
 
 const router = Router();
 
@@ -13,5 +14,6 @@ router.post("/", postSdkConnection);
 router.get("/:id", getSdkConnection);
 router.put("/:id", putSdkConnection);
 router.delete("/:id", deleteSdkConnection);
+router.get("/lookup/:key", lookupSdkConnectionByKey);
 
 export default router;

--- a/packages/back-end/src/models/ArchetypeModel.ts
+++ b/packages/back-end/src/models/ArchetypeModel.ts
@@ -2,6 +2,7 @@ import mongoose, { FilterQuery } from "mongoose";
 import uniqid from "uniqid";
 import { omit } from "lodash";
 import { ArchetypeInterface } from "back-end/types/archetype";
+import { ApiArchetype } from "back-end/types/openapi";
 
 const archetypeSchema = new mongoose.Schema({
   id: {
@@ -134,4 +135,20 @@ export async function deleteArchetypeById(id: string, organization: string) {
     id,
     organization,
   });
+}
+
+export function toArchetypeApiInterface(
+  archetype: ArchetypeInterface
+): ApiArchetype {
+  return {
+    id: archetype.id,
+    dateCreated: archetype.dateCreated?.toISOString() || "",
+    dateUpdated: archetype.dateUpdated?.toISOString() || "",
+    name: archetype.name,
+    description: archetype.description,
+    owner: archetype.owner || "",
+    isPublic: archetype.isPublic,
+    attributes: archetype.attributes,
+    projects: archetype.projects || [],
+  };
 }

--- a/packages/back-end/src/models/ArchetypeModel.ts
+++ b/packages/back-end/src/models/ArchetypeModel.ts
@@ -3,6 +3,7 @@ import uniqid from "uniqid";
 import { omit } from "lodash";
 import { ArchetypeInterface } from "back-end/types/archetype";
 import { ApiArchetype } from "back-end/types/openapi";
+import { logger } from "back-end/src/util/logger";
 
 const archetypeSchema = new mongoose.Schema({
   id: {
@@ -140,6 +141,14 @@ export async function deleteArchetypeById(id: string, organization: string) {
 export function toArchetypeApiInterface(
   archetype: ArchetypeInterface
 ): ApiArchetype {
+  let parsedAttributes = {};
+  try {
+    parsedAttributes = JSON.parse(archetype.attributes);
+  } catch {
+    logger.error("Failed to parse archetype attributes json", {
+      archetypeId: archetype.id,
+    });
+  }
   return {
     id: archetype.id,
     dateCreated: archetype.dateCreated?.toISOString() || "",
@@ -148,7 +157,7 @@ export function toArchetypeApiInterface(
     description: archetype.description,
     owner: archetype.owner || "",
     isPublic: archetype.isPublic,
-    attributes: archetype.attributes,
+    attributes: parsedAttributes,
     projects: archetype.projects || [],
   };
 }

--- a/packages/back-end/src/validators/openapi.ts
+++ b/packages/back-end/src/validators/openapi.ts
@@ -66,6 +66,8 @@ export const apiFactMetricValidator = z.object({ "id": z.string(), "name": z.str
 
 export const apiMemberValidator = z.object({ "id": z.string(), "name": z.string().optional(), "email": z.string(), "globalRole": z.string(), "environments": z.array(z.string()).optional(), "limitAccessByEnvironment": z.boolean().optional(), "managedbyIdp": z.boolean().optional(), "teams": z.array(z.string()).optional(), "projectRoles": z.array(z.object({ "project": z.string(), "role": z.string(), "limitAccessByEnvironment": z.boolean(), "environments": z.array(z.string()) })).optional(), "lastLoginDate": z.string().optional(), "dateCreated": z.string().optional(), "dateUpdated": z.string().optional() }).strict()
 
+export const apiArchetypeValidator = z.object({ "id": z.string(), "dateCreated": z.string(), "dateUpdated": z.string(), "name": z.string(), "description": z.string().optional(), "owner": z.string(), "isPublic": z.boolean(), "attributes": z.string().describe("A valid JSON string of the attributes for this Archetype"), "projects": z.array(z.string()).optional() }).strict()
+
 export const listFeaturesValidator = {
   bodySchema: z.never(),
   querySchema: z.object({ "limit": z.coerce.number().int().default(10), "offset": z.coerce.number().int().default(0), "projectId": z.string().optional() }).strict(),
@@ -190,6 +192,12 @@ export const deleteSdkConnectionValidator = {
   bodySchema: z.never(),
   querySchema: z.never(),
   paramsSchema: z.object({ "id": z.string() }).strict(),
+};
+
+export const lookupSdkConnectionByKeyValidator = {
+  bodySchema: z.never(),
+  querySchema: z.never(),
+  paramsSchema: z.object({ "key": z.string() }).strict(),
 };
 
 export const listDataSourcesValidator = {
@@ -376,6 +384,24 @@ export const deleteAttributeValidator = {
   bodySchema: z.never(),
   querySchema: z.never(),
   paramsSchema: z.object({ "property": z.string() }).strict(),
+};
+
+export const listArchetypesValidator = {
+  bodySchema: z.never(),
+  querySchema: z.never(),
+  paramsSchema: z.never(),
+};
+
+export const postArchetypeValidator = {
+  bodySchema: z.object({ "name": z.string(), "description": z.string().optional(), "isPublic": z.boolean().describe("Whether to make this Archetype available to other team members"), "attributes": z.string().describe("A valid JSON string of the attributes for this Archetype").optional(), "projects": z.array(z.string()).optional() }).strict(),
+  querySchema: z.never(),
+  paramsSchema: z.never(),
+};
+
+export const getArchetypeValidator = {
+  bodySchema: z.never(),
+  querySchema: z.never(),
+  paramsSchema: z.object({ "id": z.string() }).strict(),
 };
 
 export const listMembersValidator = {

--- a/packages/back-end/src/validators/openapi.ts
+++ b/packages/back-end/src/validators/openapi.ts
@@ -404,6 +404,18 @@ export const getArchetypeValidator = {
   paramsSchema: z.object({ "id": z.string() }).strict(),
 };
 
+export const putArchetypeValidator = {
+  bodySchema: z.object({ "name": z.string().optional(), "description": z.string().optional(), "isPublic": z.boolean().describe("Whether to make this Archetype available to other team members").optional(), "attributes": z.string().describe("A valid JSON string of the attributes for this Archetype").optional(), "projects": z.array(z.string()).optional() }).strict(),
+  querySchema: z.never(),
+  paramsSchema: z.object({ "id": z.string() }).strict(),
+};
+
+export const deleteArchetypeValidator = {
+  bodySchema: z.never(),
+  querySchema: z.never(),
+  paramsSchema: z.object({ "id": z.string() }).strict(),
+};
+
 export const listMembersValidator = {
   bodySchema: z.never(),
   querySchema: z.object({ "limit": z.coerce.number().int().default(10), "offset": z.coerce.number().int().default(0), "userName": z.string().optional(), "userEmail": z.string().optional(), "globalRole": z.string().optional() }).strict(),

--- a/packages/back-end/src/validators/openapi.ts
+++ b/packages/back-end/src/validators/openapi.ts
@@ -66,7 +66,7 @@ export const apiFactMetricValidator = z.object({ "id": z.string(), "name": z.str
 
 export const apiMemberValidator = z.object({ "id": z.string(), "name": z.string().optional(), "email": z.string(), "globalRole": z.string(), "environments": z.array(z.string()).optional(), "limitAccessByEnvironment": z.boolean().optional(), "managedbyIdp": z.boolean().optional(), "teams": z.array(z.string()).optional(), "projectRoles": z.array(z.object({ "project": z.string(), "role": z.string(), "limitAccessByEnvironment": z.boolean(), "environments": z.array(z.string()) })).optional(), "lastLoginDate": z.string().optional(), "dateCreated": z.string().optional(), "dateUpdated": z.string().optional() }).strict()
 
-export const apiArchetypeValidator = z.object({ "id": z.string(), "dateCreated": z.string(), "dateUpdated": z.string(), "name": z.string(), "description": z.string().optional(), "owner": z.string(), "isPublic": z.boolean(), "attributes": z.string().describe("A valid JSON string of the attributes for this Archetype"), "projects": z.array(z.string()).optional() }).strict()
+export const apiArchetypeValidator = z.object({ "id": z.string(), "dateCreated": z.string(), "dateUpdated": z.string(), "name": z.string(), "description": z.string().optional(), "owner": z.string(), "isPublic": z.boolean(), "attributes": z.record(z.any()).describe("The attributes to set when using this Archetype"), "projects": z.array(z.string()).optional() }).strict()
 
 export const listFeaturesValidator = {
   bodySchema: z.never(),
@@ -393,7 +393,7 @@ export const listArchetypesValidator = {
 };
 
 export const postArchetypeValidator = {
-  bodySchema: z.object({ "name": z.string(), "description": z.string().optional(), "isPublic": z.boolean().describe("Whether to make this Archetype available to other team members"), "attributes": z.string().describe("A valid JSON string of the attributes for this Archetype").optional(), "projects": z.array(z.string()).optional() }).strict(),
+  bodySchema: z.object({ "name": z.string(), "description": z.string().optional(), "isPublic": z.boolean().describe("Whether to make this Archetype available to other team members"), "attributes": z.record(z.any()).describe("The attributes to set when using this Archetype").optional(), "projects": z.array(z.string()).optional() }).strict(),
   querySchema: z.never(),
   paramsSchema: z.never(),
 };
@@ -405,7 +405,7 @@ export const getArchetypeValidator = {
 };
 
 export const putArchetypeValidator = {
-  bodySchema: z.object({ "name": z.string().optional(), "description": z.string().optional(), "isPublic": z.boolean().describe("Whether to make this Archetype available to other team members").optional(), "attributes": z.string().describe("A valid JSON string of the attributes for this Archetype").optional(), "projects": z.array(z.string()).optional() }).strict(),
+  bodySchema: z.object({ "name": z.string().optional(), "description": z.string().optional(), "isPublic": z.boolean().describe("Whether to make this Archetype available to other team members").optional(), "attributes": z.record(z.any()).describe("The attributes to set when using this Archetype").optional(), "projects": z.array(z.string()).optional() }).strict(),
   querySchema: z.never(),
   paramsSchema: z.object({ "id": z.string() }).strict(),
 };

--- a/packages/back-end/types/openapi.d.ts
+++ b/packages/back-end/types/openapi.d.ts
@@ -95,6 +95,10 @@ export interface paths {
     /** Deletes a single SDK connection */
     delete: operations["deleteSdkConnection"];
   };
+  "/sdk-connections/lookup/{key}": {
+    /** Find a single sdk connection by its key */
+    get: operations["lookupSdkConnectionByKey"];
+  };
   "/data-sources": {
     /** Get all data sources */
     get: operations["listDataSources"];
@@ -232,6 +236,16 @@ export interface paths {
     put: operations["putAttribute"];
     /** Deletes a single attribute */
     delete: operations["deleteAttribute"];
+  };
+  "/archetypes": {
+    /** Get the organization's archetypes */
+    get: operations["listArchetypes"];
+    /** Create a single archetype */
+    post: operations["postArchetype"];
+  };
+  "/archetypes/${id}": {
+    /** Get a single archetype */
+    get: operations["getArchetype"];
   };
   "/members": {
     /** Get all organization members */
@@ -1517,6 +1531,18 @@ export interface components {
       dateCreated?: string;
       /** Format: date-time */
       dateUpdated?: string;
+    };
+    Archetype: {
+      id: string;
+      dateCreated: string;
+      dateUpdated: string;
+      name: string;
+      description?: string;
+      owner: string;
+      isPublic: boolean;
+      /** @description A valid JSON string of the attributes for this Archetype */
+      attributes: string;
+      projects?: (string)[];
     };
   };
   responses: {
@@ -3476,6 +3502,52 @@ export interface operations {
         content: {
           "application/json": {
             deletedId: string;
+          };
+        };
+      };
+    };
+  };
+  lookupSdkConnectionByKey: {
+    /** Find a single sdk connection by its key */
+    parameters: {
+        /** @description The key of the requested sdkConnection */
+      path: {
+        key: string;
+      };
+    };
+    responses: {
+      200: {
+        content: {
+          "application/json": {
+            sdkConnection: {
+              id: string;
+              /** Format: date-time */
+              dateCreated: string;
+              /** Format: date-time */
+              dateUpdated: string;
+              name: string;
+              organization: string;
+              languages: (string)[];
+              sdkVersion?: string;
+              environment: string;
+              /** @description Use 'projects' instead. This is only for backwards compatibility and contains the first project only. */
+              project: string;
+              projects?: (string)[];
+              encryptPayload: boolean;
+              encryptionKey: string;
+              includeVisualExperiments?: boolean;
+              includeDraftExperiments?: boolean;
+              includeExperimentNames?: boolean;
+              includeRedirectExperiments?: boolean;
+              key: string;
+              proxyEnabled: boolean;
+              proxyHost: string;
+              proxySigningKey: string;
+              sseEnabled?: boolean;
+              hashSecureAttributes?: boolean;
+              remoteEvalEnabled?: boolean;
+              savedGroupReferencesEnabled?: boolean;
+            };
           };
         };
       };
@@ -5915,6 +5987,94 @@ export interface operations {
       };
     };
   };
+  listArchetypes: {
+    /** Get the organization's archetypes */
+    responses: {
+      200: {
+        content: {
+          "application/json": {
+            archetypes: ({
+                id: string;
+                dateCreated: string;
+                dateUpdated: string;
+                name: string;
+                description?: string;
+                owner: string;
+                isPublic: boolean;
+                /** @description A valid JSON string of the attributes for this Archetype */
+                attributes: string;
+                projects?: (string)[];
+              })[];
+          };
+        };
+      };
+    };
+  };
+  postArchetype: {
+    /** Create a single archetype */
+    requestBody: {
+      content: {
+        "application/json": {
+          name: string;
+          description?: string;
+          /** @description Whether to make this Archetype available to other team members */
+          isPublic: boolean;
+          /** @description A valid JSON string of the attributes for this Archetype */
+          attributes?: string;
+          projects?: (string)[];
+        };
+      };
+    };
+    responses: {
+      200: {
+        content: {
+          "application/json": {
+            archetype: {
+              id: string;
+              dateCreated: string;
+              dateUpdated: string;
+              name: string;
+              description?: string;
+              owner: string;
+              isPublic: boolean;
+              /** @description A valid JSON string of the attributes for this Archetype */
+              attributes: string;
+              projects?: (string)[];
+            };
+          };
+        };
+      };
+    };
+  };
+  getArchetype: {
+    /** Get a single archetype */
+    parameters: {
+        /** @description The id of the requested resource */
+      path: {
+        id: string;
+      };
+    };
+    responses: {
+      200: {
+        content: {
+          "application/json": {
+            archetype: {
+              id: string;
+              dateCreated: string;
+              dateUpdated: string;
+              name: string;
+              description?: string;
+              owner: string;
+              isPublic: boolean;
+              /** @description A valid JSON string of the attributes for this Archetype */
+              attributes: string;
+              projects?: (string)[];
+            };
+          };
+        };
+      };
+    };
+  };
   listMembers: {
     /** Get all organization members */
     parameters: {
@@ -7479,6 +7639,7 @@ export type ApiFactTable = z.infer<typeof openApiValidators.apiFactTableValidato
 export type ApiFactTableFilter = z.infer<typeof openApiValidators.apiFactTableFilterValidator>;
 export type ApiFactMetric = z.infer<typeof openApiValidators.apiFactMetricValidator>;
 export type ApiMember = z.infer<typeof openApiValidators.apiMemberValidator>;
+export type ApiArchetype = z.infer<typeof openApiValidators.apiArchetypeValidator>;
 
 // Operations
 export type ListFeaturesResponse = operations["listFeatures"]["responses"]["200"]["content"]["application/json"];
@@ -7502,6 +7663,7 @@ export type PostSdkConnectionResponse = operations["postSdkConnection"]["respons
 export type GetSdkConnectionResponse = operations["getSdkConnection"]["responses"]["200"]["content"]["application/json"];
 export type PutSdkConnectionResponse = operations["putSdkConnection"]["responses"]["200"]["content"]["application/json"];
 export type DeleteSdkConnectionResponse = operations["deleteSdkConnection"]["responses"]["200"]["content"]["application/json"];
+export type LookupSdkConnectionByKeyResponse = operations["lookupSdkConnectionByKey"]["responses"]["200"]["content"]["application/json"];
 export type ListDataSourcesResponse = operations["listDataSources"]["responses"]["200"]["content"]["application/json"];
 export type GetDataSourceResponse = operations["getDataSource"]["responses"]["200"]["content"]["application/json"];
 export type ListExperimentsResponse = operations["listExperiments"]["responses"]["200"]["content"]["application/json"];
@@ -7533,6 +7695,9 @@ export type ListAttributesResponse = operations["listAttributes"]["responses"]["
 export type PostAttributeResponse = operations["postAttribute"]["responses"]["200"]["content"]["application/json"];
 export type PutAttributeResponse = operations["putAttribute"]["responses"]["200"]["content"]["application/json"];
 export type DeleteAttributeResponse = operations["deleteAttribute"]["responses"]["200"]["content"]["application/json"];
+export type ListArchetypesResponse = operations["listArchetypes"]["responses"]["200"]["content"]["application/json"];
+export type PostArchetypeResponse = operations["postArchetype"]["responses"]["200"]["content"]["application/json"];
+export type GetArchetypeResponse = operations["getArchetype"]["responses"]["200"]["content"]["application/json"];
 export type ListMembersResponse = operations["listMembers"]["responses"]["200"]["content"]["application/json"];
 export type DeleteMemberResponse = operations["deleteMember"]["responses"]["200"]["content"]["application/json"];
 export type UpdateMemberRoleResponse = operations["updateMemberRole"]["responses"]["200"]["content"]["application/json"];

--- a/packages/back-end/types/openapi.d.ts
+++ b/packages/back-end/types/openapi.d.ts
@@ -1544,8 +1544,8 @@ export interface components {
       description?: string;
       owner: string;
       isPublic: boolean;
-      /** @description A valid JSON string of the attributes for this Archetype */
-      attributes: string;
+      /** @description The attributes to set when using this Archetype */
+      attributes: any;
       projects?: (string)[];
     };
   };
@@ -6005,8 +6005,8 @@ export interface operations {
                 description?: string;
                 owner: string;
                 isPublic: boolean;
-                /** @description A valid JSON string of the attributes for this Archetype */
-                attributes: string;
+                /** @description The attributes to set when using this Archetype */
+                attributes: any;
                 projects?: (string)[];
               })[];
           };
@@ -6023,8 +6023,8 @@ export interface operations {
           description?: string;
           /** @description Whether to make this Archetype available to other team members */
           isPublic: boolean;
-          /** @description A valid JSON string of the attributes for this Archetype */
-          attributes?: string;
+          /** @description The attributes to set when using this Archetype */
+          attributes?: any;
           projects?: (string)[];
         };
       };
@@ -6041,8 +6041,8 @@ export interface operations {
               description?: string;
               owner: string;
               isPublic: boolean;
-              /** @description A valid JSON string of the attributes for this Archetype */
-              attributes: string;
+              /** @description The attributes to set when using this Archetype */
+              attributes: any;
               projects?: (string)[];
             };
           };
@@ -6070,8 +6070,8 @@ export interface operations {
               description?: string;
               owner: string;
               isPublic: boolean;
-              /** @description A valid JSON string of the attributes for this Archetype */
-              attributes: string;
+              /** @description The attributes to set when using this Archetype */
+              attributes: any;
               projects?: (string)[];
             };
           };
@@ -6094,8 +6094,8 @@ export interface operations {
           description?: string;
           /** @description Whether to make this Archetype available to other team members */
           isPublic?: boolean;
-          /** @description A valid JSON string of the attributes for this Archetype */
-          attributes?: string;
+          /** @description The attributes to set when using this Archetype */
+          attributes?: any;
           projects?: (string)[];
         };
       };
@@ -6112,8 +6112,8 @@ export interface operations {
               description?: string;
               owner: string;
               isPublic: boolean;
-              /** @description A valid JSON string of the attributes for this Archetype */
-              attributes: string;
+              /** @description The attributes to set when using this Archetype */
+              attributes: any;
               projects?: (string)[];
             };
           };

--- a/packages/back-end/types/openapi.d.ts
+++ b/packages/back-end/types/openapi.d.ts
@@ -246,6 +246,10 @@ export interface paths {
   "/archetypes/${id}": {
     /** Get a single archetype */
     get: operations["getArchetype"];
+    /** Update a single archetype */
+    put: operations["putArchetype"];
+    /** Deletes a single archetype */
+    delete: operations["deleteArchetype"];
   };
   "/members": {
     /** Get all organization members */
@@ -6075,6 +6079,66 @@ export interface operations {
       };
     };
   };
+  putArchetype: {
+    /** Update a single archetype */
+    parameters: {
+        /** @description The id of the requested resource */
+      path: {
+        id: string;
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          name?: string;
+          description?: string;
+          /** @description Whether to make this Archetype available to other team members */
+          isPublic?: boolean;
+          /** @description A valid JSON string of the attributes for this Archetype */
+          attributes?: string;
+          projects?: (string)[];
+        };
+      };
+    };
+    responses: {
+      200: {
+        content: {
+          "application/json": {
+            archetype: {
+              id: string;
+              dateCreated: string;
+              dateUpdated: string;
+              name: string;
+              description?: string;
+              owner: string;
+              isPublic: boolean;
+              /** @description A valid JSON string of the attributes for this Archetype */
+              attributes: string;
+              projects?: (string)[];
+            };
+          };
+        };
+      };
+    };
+  };
+  deleteArchetype: {
+    /** Deletes a single archetype */
+    parameters: {
+        /** @description The id of the requested resource */
+      path: {
+        id: string;
+      };
+    };
+    responses: {
+      200: {
+        content: {
+          "application/json": {
+            deletedId: string;
+          };
+        };
+      };
+    };
+  };
   listMembers: {
     /** Get all organization members */
     parameters: {
@@ -7698,6 +7762,8 @@ export type DeleteAttributeResponse = operations["deleteAttribute"]["responses"]
 export type ListArchetypesResponse = operations["listArchetypes"]["responses"]["200"]["content"]["application/json"];
 export type PostArchetypeResponse = operations["postArchetype"]["responses"]["200"]["content"]["application/json"];
 export type GetArchetypeResponse = operations["getArchetype"]["responses"]["200"]["content"]["application/json"];
+export type PutArchetypeResponse = operations["putArchetype"]["responses"]["200"]["content"]["application/json"];
+export type DeleteArchetypeResponse = operations["deleteArchetype"]["responses"]["200"]["content"]["application/json"];
 export type ListMembersResponse = operations["listMembers"]["responses"]["200"]["content"]["application/json"];
 export type DeleteMemberResponse = operations["deleteMember"]["responses"]["200"]["content"]["application/json"];
 export type UpdateMemberRoleResponse = operations["updateMemberRole"]["responses"]["200"]["content"]["application/json"];

--- a/packages/front-end/components/Archetype/ArchetypeList.tsx
+++ b/packages/front-end/components/Archetype/ArchetypeList.tsx
@@ -112,6 +112,15 @@ export const ArchetypeList: FC<{
                   archetype,
                   {}
                 );
+                let parsedAttributes = {};
+                try {
+                  parsedAttributes = JSON.parse(archetype.attributes);
+                } catch {
+                  console.error(
+                    "Failed to parse attributes. Invalid JSON string: " +
+                      archetype.attributes
+                  );
+                }
                 const canDelete = permissionsUtil.canDeleteArchetype(archetype);
                 return (
                   <tr key={archetype.id} className={``}>
@@ -120,11 +129,7 @@ export const ArchetypeList: FC<{
                         body={
                           <>
                             <Code
-                              code={JSON.stringify(
-                                JSON.parse(archetype.attributes || "{}"),
-                                null,
-                                2
-                              )}
+                              code={JSON.stringify(parsedAttributes, null, 2)}
                               language="json"
                             />
                           </>

--- a/packages/front-end/components/Archetype/ArchetypeList.tsx
+++ b/packages/front-end/components/Archetype/ArchetypeList.tsx
@@ -121,7 +121,7 @@ export const ArchetypeList: FC<{
                           <>
                             <Code
                               code={JSON.stringify(
-                                JSON.parse(archetype.attributes),
+                                JSON.parse(archetype.attributes || "{}"),
                                 null,
                                 2
                               )}


### PR DESCRIPTION
### Features and Changes

Adds CRUD endpoints for archetypes to the API, along with an endpoint for finding an sdkConnection by the sdk key.
These endpoints will be consumed by the new devtools but could also be used for general programmatic control of Archetypes

### Testing
Hit the various endpoints to check behavior & see the changes reflected on the Archetypes page

### Screenshots
![image](https://github.com/user-attachments/assets/144d51da-8c5e-46e4-a287-9ce2713ad0f4)

