### PR TITLE
fix: Make Experiment tabs sticky again

### DIFF
--- a/packages/front-end/pages/_app.tsx
+++ b/packages/front-end/pages/_app.tsx
@@ -186,8 +186,7 @@ function App({
           --font-weight-medium: 600;
         }
         .radix-themes[data-is-root-theme="true"] {
-          min-height: 100%;
-          height: 100vh;
+          min-height: 100vh;
         }
       `}</style>
       <Head>

--- a/packages/front-end/pages/_app.tsx
+++ b/packages/front-end/pages/_app.tsx
@@ -185,9 +185,6 @@ function App({
           --default-font-family: ${inter.style.fontFamily};
           --font-weight-medium: 600;
         }
-        .radix-themes[data-is-root-theme="true"] {
-          min-height: 100vh;
-        }
       `}</style>
       <Head>
         <title>GrowthBook</title>

--- a/packages/front-end/styles/global.scss
+++ b/packages/front-end/styles/global.scss
@@ -9,12 +9,6 @@
 // Bootstrap theme overrides must be loaded AFTER Bootstrap
 @import "_bootstrap-theme-overrides";
 
-html,
-body,
-#__next,
-main {
-  min-height: 100vh;
-}
 main {
   padding-top: 56px;
 }

--- a/packages/front-end/styles/global.scss
+++ b/packages/front-end/styles/global.scss
@@ -13,8 +13,7 @@ html,
 body,
 #__next,
 main {
-  min-height: 100%;
-  height: 100vh;
+  min-height: 100vh;
 }
 main {
   padding-top: 56px;


### PR DESCRIPTION
### Features and Changes

To make sure we always have a background color we should use only `min-height` instead of also setting `height`, otherwise it'll always be only the viewport height which breaks the sticky header when we scroll.

We could set `min-height: 100vh` or rely on Radix as they do the proper checks for `dvh` as well, which is the option I chose to go with here.

### Demo

https://www.loom.com/share/43b7fcf364ca4f7c879a281a4b6fd2ad
