### PR TITLE
Move Impact on Dashboard (pseudo a/a test)

### DIFF
--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -237,8 +237,9 @@ export async function getExperimentsFrequencyMonth(
         // I can do this because the indexes will represent the same month
         dataByStatus[e.status][i].numExp++;
 
-        // experiments without a project, are included in the 'all projects'
-        if (e.project) {
+        // experiments without a project or with a deleted project
+        // are included in the 'all projects'
+        if (e.project && dataByProject[e.project]) {
           dataByProject[e.project][i].numExp++;
         } else {
           dataByProject["all"][i].numExp++;

--- a/packages/front-end/components/HomePage/Dashboard.tsx
+++ b/packages/front-end/components/HomePage/Dashboard.tsx
@@ -26,7 +26,7 @@ export default function Dashboard({ experiments }: Props) {
     nameMap.set(e.id, e.name);
   });
 
-  const experimentImpactWidget = () => (
+  const experimentImpactWidget = (
     <div className="col-xl-13 mb-4">
       <div className="list-group activity-box overflow-auto pt-1">
         {hasCommercialFeature("experiment-impact") ? (
@@ -60,7 +60,7 @@ export default function Dashboard({ experiments }: Props) {
           </div>
         </div>
 
-        {showImpactNearTop ? experimentImpactWidget() : null}
+        {showImpactNearTop ? experimentImpactWidget : null}
         <div className="row">
           <div className="col-lg-12 col-md-12 col-xl-8 mb-3">
             <div className="list-group activity-box">
@@ -110,7 +110,7 @@ export default function Dashboard({ experiments }: Props) {
             </div>
           </div>
         </div>
-        {!showImpactNearTop ? experimentImpactWidget() : null}
+        {!showImpactNearTop ? experimentImpactWidget : null}
       </div>
     </>
   );

--- a/packages/front-end/components/HomePage/Dashboard.tsx
+++ b/packages/front-end/components/HomePage/Dashboard.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import Link from "next/link";
+import { useGrowthBook } from "@growthbook/growthbook-react";
 import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
+import { AppFeatures } from "@/types/app-features";
 import { useUser } from "@/services/UserContext";
 import ActivityList from "@/components/ActivityList";
 import ExperimentList from "@/components/Experiment/ExperimentList";
@@ -17,11 +19,36 @@ export interface Props {
 
 export default function Dashboard({ experiments }: Props) {
   const { name, hasCommercialFeature } = useUser();
+  const growthbook = useGrowthBook<AppFeatures>();
 
   const nameMap = new Map<string, string>();
   experiments.forEach((e) => {
     nameMap.set(e.id, e.name);
   });
+
+  const experimentImpactWidget = () => (
+    <div className="col-xl-13 mb-4">
+      <div className="list-group activity-box overflow-auto pt-1">
+        {hasCommercialFeature("experiment-impact") ? (
+          <ExperimentImpact experiments={experiments} />
+        ) : (
+          <div className="pt-2">
+            <div className="row align-items-start mb-4">
+              <div className="col-lg-auto">
+                <h3 className="mt-2">Experiment Impact</h3>
+              </div>
+            </div>
+
+            <PremiumTooltip commercialFeature="experiment-impact">
+              Experiment Impact is available to Enterprise customers
+            </PremiumTooltip>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+
+  const showImpactNearTop = growthbook.isOn("show-impact-near-top");
 
   return (
     <>
@@ -43,6 +70,7 @@ export default function Dashboard({ experiments }: Props) {
               />
             </div>
           </div>
+          {showImpactNearTop ? experimentImpactWidget() : null}
           <div className="col-md-4 mb-3">
             <div className="list-group activity-box fixed-height overflow-auto">
               <h4 className="">
@@ -81,25 +109,7 @@ export default function Dashboard({ experiments }: Props) {
             </div>
           </div>
         </div>
-        <div className="col-xl-13 mb-4">
-          <div className="list-group activity-box overflow-auto pt-1">
-            {hasCommercialFeature("experiment-impact") ? (
-              <ExperimentImpact experiments={experiments} />
-            ) : (
-              <div className="pt-2">
-                <div className="row align-items-start mb-4">
-                  <div className="col-lg-auto">
-                    <h3 className="mt-2">Experiment Impact</h3>
-                  </div>
-                </div>
-
-                <PremiumTooltip commercialFeature="experiment-impact">
-                  Experiment Impact is available to Enterprise customers
-                </PremiumTooltip>
-              </div>
-            )}
-          </div>
-        </div>
+        {!showImpactNearTop ? experimentImpactWidget() : null}
       </div>
     </>
   );

--- a/packages/front-end/components/HomePage/Dashboard.tsx
+++ b/packages/front-end/components/HomePage/Dashboard.tsx
@@ -59,6 +59,8 @@ export default function Dashboard({ experiments }: Props) {
             <NorthStar experiments={experiments} />
           </div>
         </div>
+
+        {showImpactNearTop ? experimentImpactWidget() : null}
         <div className="row">
           <div className="col-lg-12 col-md-12 col-xl-8 mb-3">
             <div className="list-group activity-box">
@@ -70,7 +72,6 @@ export default function Dashboard({ experiments }: Props) {
               />
             </div>
           </div>
-          {showImpactNearTop ? experimentImpactWidget() : null}
           <div className="col-md-4 mb-3">
             <div className="list-group activity-box fixed-height overflow-auto">
               <h4 className="">

--- a/packages/front-end/types/app-features.ts
+++ b/packages/front-end/types/app-features.ts
@@ -53,4 +53,5 @@ export type AppFeatures = {
   "gb-ax10-bandit": boolean;
   "fact-metric-sql-preview": boolean;
   "inbuilt-data-warehouse": boolean;
+  "show-impact-near-top": boolean;
 };


### PR DESCRIPTION
### Features and Changes

This PR introduces a feature flag to move the experiment impact just below the top-line graphs on the Dashboard. This change is a test on a low risk surface that acts as a pseudo a/a test of our Cluster Experiment recommended flow.

Rather than create a totally artificial test, I prefer to do something that has a reasonable goal, even though our power will be very limited.

FF off
<img width="1462" alt="Screenshot 2025-01-28 at 4 19 13 PM" src="https://github.com/user-attachments/assets/e7cbbd09-2328-4aea-bf9c-d32f50b7140f" />


FF on
<img width="1466" alt="Screenshot 2025-01-28 at 4 19 17 PM" src="https://github.com/user-attachments/assets/1d0d871a-6970-4baf-9485-efbf63e3e985" />
