### PR TITLE
Extra padding for environment dropdown

### DIFF
--- a/packages/front-end/components/Features/FeatureRules.tsx
+++ b/packages/front-end/components/Features/FeatureRules.tsx
@@ -136,15 +136,15 @@ export default function FeatureRules({
           </Container>
         ) : (
           <Container mb={"4"} maxWidth="100%">
-            <Flex align="center">
-              <Container flexGrow="0" width="270px" mr="4">
+            <Flex align="center" mb="3">
+              <Container flexGrow="0" width="310px" mr="4">
                 <EnvironmentDropdown
                   env={env}
                   setEnv={setEnv}
                   environments={environments}
                   formatOptionLabel={({ value }) => (
                     <Flex justify="between" align="center">
-                      <Flex maxWidth="270px">
+                      <Flex maxWidth="310px">
                         <Text truncate>{value}</Text>
                       </Flex>
                       <Badge


### PR DESCRIPTION
### Features and Changes

Adds a bit of extra padding to make the environment dropdown more visually distinct from the surrounding components

### Screenshots

#### Before
![image](https://github.com/user-attachments/assets/010c7a2b-6402-4b4b-956d-8d6cf6ec0916)

#### After
![image](https://github.com/user-attachments/assets/84cea1d7-ecad-4225-bfe2-0dd02083590e)

#### Tabbed environments unaffected
![image](https://github.com/user-attachments/assets/305a9dba-5fd2-4b4e-b5d1-8a4d7c470e46)
