### PR TITLE
fix: Experiment Status Indicator says SRM is unhealthy for Bandit but it is not

### DIFF
--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -25,6 +25,7 @@ import {
   MatchingRule,
   validateCondition,
 } from "shared/util";
+import { getSRMValue } from "shared/health";
 import {
   expandMetricGroups,
   ExperimentMetricInterface,
@@ -2733,9 +2734,11 @@ export async function updateExperimentAnalysisSummary({
     0
   );
 
-  if (overallTraffic && totalUsers) {
+  const srm = getSRMValue(experiment.type ?? "standard", experimentSnapshot);
+
+  if (overallTraffic && totalUsers && srm) {
     analysisSummary.health = {
-      srm: overallTraffic.srm,
+      srm,
       multipleExposures: experimentSnapshot.multipleExposures,
       totalUsers,
     };

--- a/packages/shared/src/health/health.ts
+++ b/packages/shared/src/health/health.ts
@@ -1,3 +1,6 @@
+import { ExperimentType } from "back-end/src/validators/experiments";
+import { ExperimentSnapshotInterface } from "back-end/types/experiment-snapshot";
+
 type MultipleExposureHealthStatus =
   | "not-enough-traffic"
   | "healthy"
@@ -18,7 +21,7 @@ type MultipleExposureHealthData = {
  * @param minCountThreshold - Minimum number of multiple exposures required to be considered significant
  * @param minPercentThreshold - Minimum percentage of multiple exposures required to be considered unhealthy
  */
-export const getMultipleExposureHealthData = ({
+export function getMultipleExposureHealthData({
   multipleExposuresCount,
   totalUsersCount,
   minCountThreshold,
@@ -28,7 +31,7 @@ export const getMultipleExposureHealthData = ({
   totalUsersCount: number;
   minCountThreshold: number;
   minPercentThreshold: number;
-}): MultipleExposureHealthData => {
+}): MultipleExposureHealthData {
   const multipleExposureDecimal = multipleExposuresCount / totalUsersCount;
 
   const hasEnoughData = multipleExposuresCount >= minCountThreshold;
@@ -55,7 +58,7 @@ export const getMultipleExposureHealthData = ({
       ...data,
     };
   }
-};
+}
 
 /**
  * Returns the health status for Sample Ratio Mismatch (SRM) in an experiment
@@ -67,7 +70,7 @@ export const getMultipleExposureHealthData = ({
  * @param minUsersPerVariation - Minimum number of users required per variation
  * @returns SRMHealthStatus - The health status: 'healthy', 'unhealthy', or 'not-enough-traffic'
  */
-export const getSRMHealthData = ({
+export function getSRMHealthData({
   srm,
   numOfVariations,
   totalUsersCount,
@@ -79,7 +82,7 @@ export const getSRMHealthData = ({
   totalUsersCount: number;
   srmThreshold: number;
   minUsersPerVariation: number;
-}): SRMHealthStatus => {
+}): SRMHealthStatus {
   const minUsersCount = numOfVariations * minUsersPerVariation;
 
   if (totalUsersCount < minUsersCount) {
@@ -89,4 +92,22 @@ export const getSRMHealthData = ({
   } else {
     return "healthy";
   }
-};
+}
+
+export function getSRMValue(
+  experimentType: ExperimentType,
+  snapshot: ExperimentSnapshotInterface
+): number | undefined {
+  switch (experimentType) {
+    case "multi-armed-bandit":
+      return snapshot.banditResult?.srm;
+
+    case "standard":
+      return snapshot.health?.traffic?.overall?.srm;
+
+    default: {
+      const _exhaustiveCheck: never = experimentType;
+      throw new Error(`Unknown experiment type: ${_exhaustiveCheck}`);
+    }
+  }
+}

--- a/packages/shared/src/health/health.ts
+++ b/packages/shared/src/health/health.ts
@@ -1,4 +1,3 @@
-import { logger } from "back-end/src/util/logger";
 import { ExperimentType } from "back-end/src/validators/experiments";
 import { ExperimentSnapshotInterface } from "back-end/types/experiment-snapshot";
 
@@ -108,8 +107,9 @@ export function getSRMValue(
 
     default: {
       const _exhaustiveCheck: never = experimentType;
-      logger.error(
-        `Unknown experiment type for SRM: ${_exhaustiveCheck}. Snapshot id: ${snapshot.id}`
+      // eslint-disable-next-line no-console
+      console.error(
+        `Unknown experiment type for SRM: ${_exhaustiveCheck}. snapshotId: ${snapshot.id}`
       );
       return undefined;
     }

--- a/packages/shared/src/health/health.ts
+++ b/packages/shared/src/health/health.ts
@@ -1,3 +1,4 @@
+import { logger } from "back-end/src/util/logger";
 import { ExperimentType } from "back-end/src/validators/experiments";
 import { ExperimentSnapshotInterface } from "back-end/types/experiment-snapshot";
 
@@ -107,7 +108,10 @@ export function getSRMValue(
 
     default: {
       const _exhaustiveCheck: never = experimentType;
-      throw new Error(`Unknown experiment type: ${_exhaustiveCheck}`);
+      logger.error(
+        `Unknown experiment type for SRM: ${_exhaustiveCheck}. Snapshot id: ${snapshot.id}`
+      );
+      return undefined;
     }
   }
 }


### PR DESCRIPTION
### Features and Changes

An issue was reported where the Experiment had a badge saying `Unhealthy (SRM)` but when opening the `Health Tab` no error was reported.

This happened because we were using `health.traffic.overall.srm` for Bandit experiments, which is not the correct source. So now we are getting it from `snapshot.banditResult.srm` instead for Bandit experiments.

This means that `experiment.analysisSummary` will have the appropriate SRM value, which then we will use to check against the defined threshold to consider healthy/unhealthy.

### Future Improvements

The logic from BanditSRMCard should be the shared with the one we are using to set AnalysisSummary, so we can ensure ExperimentStatusIndicator & Health Tab are looking at the same set of data, to prevent inconsistencies.
