### PR TITLE
Fix front-end enterprise check

### DIFF
--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -772,6 +772,7 @@ export async function getOrganization(req: AuthRequest, res: Response) {
       subscription,
       licenseKey,
       freeSeats,
+      enterprise: org.enterprise,
       disableSelfServeBilling,
       freeTrialDate: org.freeTrialDate,
       discountCode: org.discountCode || "",


### PR DESCRIPTION
### Features and Changes

Some enterprise organizations on GrowthBook Cloud were being prompted to upgrade when inviting members.  The upgrade modal has an extra sanity check to make sure it never shows to enterprise orgs.  So the net result is that it looked like the "Invite" button was not doing anything.

This happened because the back-end was not properly sending down the `enterprise: true` flag to the front-end.