### PR TITLE
Add api endpoints for serving Audit Logs

### DIFF
--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -111,12 +111,18 @@ tags:
   - name: archetypes
     x-displayName: Archetypes
     description: Archetypes allow you to simulate the result of targeting rules on pre-set user attributes
+  - name: audit-logs
+    x-displayName: Audit Logs
+    description: The events logged when changes are made to various objects
   - name: Archetype_model
     x-displayName: Archetype
     description: <SchemaDefinition schemaRef="#/components/schemas/Archetype" />
   - name: Attribute_model
     x-displayName: Attribute
     description: <SchemaDefinition schemaRef="#/components/schemas/Attribute" />
+  - name: AuditLog_model
+    x-displayName: AuditLog
+    description: <SchemaDefinition schemaRef="#/components/schemas/AuditLog" />
   - name: DataSource_model
     x-displayName: DataSource
     description: <SchemaDefinition schemaRef="#/components/schemas/DataSource" />
@@ -4749,6 +4755,71 @@ paths:
                     type: array
                     items:
                       type: string
+  '/history/{type}':
+    get:
+      parameters:
+        - type: null
+          name: type
+          in: path
+          required: true
+          description: 'The type of entity, e.g. "experiment" or "feature"'
+          schema:
+            type: string
+      summary: Get the Audit Logs for all entities of specified type
+      tags:
+        - audit-logs
+      operationId: getAllHistory
+      x-codeSamples:
+        - lang: cURL
+          source: |
+            curl https://api.growthbook.io/api/v1/getHistory/feature \
+              -u secret_abc123DEF456:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - events
+                properties:
+                  events:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/AuditLog'
+  '/history/{type}/{id}':
+    get:
+      parameters:
+        - $ref: '#/components/parameters/id'
+        - type: null
+          name: type
+          in: path
+          required: true
+          description: 'The type of entity, e.g. "experiment" or "feature"'
+          schema:
+            type: string
+      summary: Get the Audit Logs for a single entity
+      tags:
+        - audit-logs
+      operationId: getHistory
+      x-codeSamples:
+        - lang: cURL
+          source: |
+            curl https://api.growthbook.io/api/v1/getHistory/feature/my_feature \
+              -u secret_abc123DEF456:
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - events
+                properties:
+                  events:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/AuditLog'
 components:
   parameters:
     id:
@@ -6788,6 +6859,71 @@ components:
           type: array
           items:
             type: string
+    AuditLog:
+      type: object
+      required:
+        - id
+        - user
+        - event
+        - entity
+        - dateCreated
+      properties:
+        id:
+          type: string
+        user:
+          anyOf:
+            - type: object
+              required:
+                - apiKey
+              properties:
+                apiKey:
+                  type: string
+            - type: object
+              required:
+                - id
+                - email
+                - name
+              properties:
+                id:
+                  type: string
+                email:
+                  type: string
+                name:
+                  type: string
+        event:
+          type: string
+          pattern: ^\w+\.\w+$
+          description: The event being audited contains the Entity and the Action separated by a '.'
+        entity:
+          type: object
+          required:
+            - object
+            - id
+          properties:
+            object:
+              type: string
+              description: 'The type of Entity being acted on, e.g. "experiment" or "feature"'
+            id:
+              type: string
+            name:
+              type: string
+        parent:
+          type: object
+          required:
+            - object
+            - id
+          properties:
+            object:
+              type: string
+              description: 'The type of Entity being acted on, e.g. "experiment" or "feature"'
+            id:
+              type: string
+        reason:
+          type: string
+        details:
+          type: string
+        dateCreated:
+          type: string
   securitySchemes:
     bearerAuth:
       type: http
@@ -6842,10 +6978,12 @@ x-tagGroups:
       - fact-metrics
       - code-references
       - archetypes
+      - audit-logs
   - name: Models
     tags:
       - Archetype_model
       - Attribute_model
+      - AuditLog_model
       - DataSource_model
       - Dimension_model
       - Environment_model

--- a/packages/back-end/src/api/api.router.ts
+++ b/packages/back-end/src/api/api.router.ts
@@ -30,6 +30,7 @@ import { postCopyTransform } from "./openai/postCopyTransform";
 import { getFeatureKeys } from "./features/getFeatureKeys";
 import ingestionRouter from "./ingestion/ingestion.router";
 import archetypesRouter from "./archetypes/archetypes.router";
+import auditLogsRouter from "./audit-logs/audit-logs.router";
 
 const router = Router();
 let openapiSpec: string;
@@ -104,6 +105,7 @@ router.use("/code-refs", codeRefsRouter);
 router.use("/members", membersRouter);
 router.use("/ingestion", ingestionRouter);
 router.use("/archetypes", archetypesRouter);
+router.use("/history", auditLogsRouter);
 
 router.post("/transform-copy", postCopyTransform);
 

--- a/packages/back-end/src/api/audit-logs/audit-logs.router.ts
+++ b/packages/back-end/src/api/audit-logs/audit-logs.router.ts
@@ -1,0 +1,10 @@
+import { Router } from "express";
+import { getAllHistory } from "./getAllHistory";
+import { getHistory } from "./getHistory";
+
+const router = Router();
+
+router.get("/:type", getAllHistory);
+router.get("/:type/:id", getHistory);
+
+export default router;

--- a/packages/back-end/src/api/audit-logs/getAllHistory.ts
+++ b/packages/back-end/src/api/audit-logs/getAllHistory.ts
@@ -1,0 +1,34 @@
+import { GetAllHistoryResponse } from "back-end/types/openapi";
+import { createApiRequestHandler } from "back-end/src/util/handler";
+import { getAllHistoryValidator } from "back-end/src/validators/openapi";
+import {
+  findAllAuditsAndChildrenByEntityType,
+  toApiAuditLog,
+} from "back-end/src/models/AuditModel";
+import { isValidAuditEntityType } from "back-end/src/services/audit";
+import { EntityType } from "back-end/src/types/Audit";
+
+export const getAllHistory = createApiRequestHandler(getAllHistoryValidator)(
+  async (req): Promise<GetAllHistoryResponse> => {
+    const { org } = req.context;
+    const { type } = req.params;
+
+    if (!isValidAuditEntityType(type)) {
+      throw new Error(
+        `${type} is not a valid entity type. Possible entity types are: ${EntityType}`
+      );
+    }
+
+    const rawEvents = await findAllAuditsAndChildrenByEntityType(org.id, type);
+
+    if (rawEvents.find((e) => e.organization !== org.id)) {
+      req.context.permissions.throwPermissionError();
+    }
+
+    const auditEvents = rawEvents.map(toApiAuditLog);
+
+    return {
+      events: auditEvents,
+    };
+  }
+);

--- a/packages/back-end/src/api/audit-logs/getHistory.ts
+++ b/packages/back-end/src/api/audit-logs/getHistory.ts
@@ -1,0 +1,34 @@
+import { GetHistoryResponse } from "back-end/types/openapi";
+import { createApiRequestHandler } from "back-end/src/util/handler";
+import { getHistoryValidator } from "back-end/src/validators/openapi";
+import {
+  findAuditAndChildrenByEntity,
+  toApiAuditLog,
+} from "back-end/src/models/AuditModel";
+import { isValidAuditEntityType } from "back-end/src/services/audit";
+import { EntityType } from "back-end/src/types/Audit";
+
+export const getHistory = createApiRequestHandler(getHistoryValidator)(
+  async (req): Promise<GetHistoryResponse> => {
+    const { org } = req.context;
+    const { type, id } = req.params;
+
+    if (!isValidAuditEntityType(type)) {
+      throw new Error(
+        `${type} is not a valid entity type. Possible entity types are: ${EntityType}`
+      );
+    }
+
+    const rawEvents = await findAuditAndChildrenByEntity(org.id, type, id);
+
+    if (rawEvents.find((e) => e.organization !== org.id)) {
+      req.context.permissions.throwPermissionError();
+    }
+
+    const auditEvents = rawEvents.map(toApiAuditLog);
+
+    return {
+      events: auditEvents,
+    };
+  }
+);

--- a/packages/back-end/src/api/openapi/openapi.yaml
+++ b/packages/back-end/src/api/openapi/openapi.yaml
@@ -114,6 +114,9 @@ tags:
   - name: archetypes
     x-displayName: Archetypes
     description: Archetypes allow you to simulate the result of targeting rules on pre-set user attributes
+  - name: audit-logs
+    x-displayName: Audit Logs
+    description: The events logged when changes are made to various objects
 paths:
   /features:
     get:
@@ -313,6 +316,12 @@ paths:
   /code-refs:
     post:
       $ref: "./paths/postCodeRefs.yaml"
+  /history/{type}:
+    get:
+      $ref: "./paths/getAllHistory.yaml"
+  /history/{type}/{id}:
+    get:
+      $ref: "./paths/getHistory.yaml"
   # PLOP_INSERT_PATHS_HERE
 components:
   parameters:

--- a/packages/back-end/src/api/openapi/paths/getAllHistory.yaml
+++ b/packages/back-end/src/api/openapi/paths/getAllHistory.yaml
@@ -1,0 +1,30 @@
+parameters:
+  - type:
+    name: type
+    in: path
+    required: true
+    description: The type of entity, e.g. "experiment" or "feature"
+    schema:
+      type: string
+summary: Get the Audit Logs for all entities of specified type
+tags:
+  - audit-logs
+operationId: getAllHistory
+x-codeSamples:
+  - lang: "cURL"
+    source: |
+      curl https://api.growthbook.io/api/v1/getHistory/feature \
+        -u secret_abc123DEF456:
+responses:
+  "200":
+    content:
+      application/json:
+        schema:
+          type: object
+          required:
+            - events
+          properties:
+            events:
+              type: array
+              items:
+                $ref: "../schemas/AuditLog.yaml"

--- a/packages/back-end/src/api/openapi/paths/getHistory.yaml
+++ b/packages/back-end/src/api/openapi/paths/getHistory.yaml
@@ -1,0 +1,31 @@
+parameters:
+  - $ref: "../parameters.yaml#/id"
+  - type:
+    name: type
+    in: path
+    required: true
+    description: The type of entity, e.g. "experiment" or "feature"
+    schema:
+      type: string
+summary: Get the Audit Logs for a single entity
+tags:
+  - audit-logs
+operationId: getHistory
+x-codeSamples:
+  - lang: "cURL"
+    source: |
+      curl https://api.growthbook.io/api/v1/getHistory/feature/my_feature \
+        -u secret_abc123DEF456:
+responses:
+  "200":
+    content:
+      application/json:
+        schema:
+          type: object
+          required:
+            - events
+          properties:
+            events:
+              type: array
+              items:
+                $ref: "../schemas/AuditLog.yaml"

--- a/packages/back-end/src/api/openapi/schemas/AuditLog.yaml
+++ b/packages/back-end/src/api/openapi/schemas/AuditLog.yaml
@@ -1,0 +1,64 @@
+type: object
+required:
+  - id
+  - user
+  - event
+  - entity
+  - dateCreated
+properties:
+  id:
+    type: string
+  user:
+    anyOf:
+      - type: object
+        required:
+          - apiKey
+        properties:
+          apiKey:
+            type: string
+      - type: object
+        required:
+          - id
+          - email
+          - name
+        properties:
+          id:
+            type: string
+          email:
+            type: string
+          name:
+            type: string
+  event:
+    type: string
+    pattern: '^\w+\.\w+$'
+    description: The event being audited contains the Entity and the Action separated by a '.'
+  entity:
+    type: object
+    required:
+      - object
+      - id
+    properties:
+      object:
+        type: string
+        description: The type of Entity being acted on, e.g. "experiment" or "feature"
+      id:
+        type: string
+      name:
+        type: string
+  parent:
+    type: object
+    required:
+      - object
+      - id
+    properties:
+      object:
+        type: string
+        description: The type of Entity being acted on, e.g. "experiment" or "feature"
+      id:
+        type: string
+  reason:
+    type: string
+  details:
+    type: string
+  dateCreated:
+    type: string

--- a/packages/back-end/src/api/openapi/schemas/_index.yaml
+++ b/packages/back-end/src/api/openapi/schemas/_index.yaml
@@ -60,3 +60,5 @@ Member:
   $ref: "./Member.yaml"
 Archetype:
   $ref: "./Archetype.yaml"
+AuditLog:
+  $ref: "./AuditLog.yaml"

--- a/packages/back-end/src/validators/openapi.ts
+++ b/packages/back-end/src/validators/openapi.ts
@@ -68,6 +68,8 @@ export const apiMemberValidator = z.object({ "id": z.string(), "name": z.string(
 
 export const apiArchetypeValidator = z.object({ "id": z.string(), "dateCreated": z.string(), "dateUpdated": z.string(), "name": z.string(), "description": z.string().optional(), "owner": z.string(), "isPublic": z.boolean(), "attributes": z.record(z.any()).describe("The attributes to set when using this Archetype"), "projects": z.array(z.string()).optional() }).strict()
 
+export const apiAuditLogValidator = z.object({ "id": z.string(), "user": z.union([z.object({ "apiKey": z.string() }), z.object({ "id": z.string(), "email": z.string(), "name": z.string() })]), "event": z.string().regex(new RegExp("^\\w+\\.\\w+$")).describe("The event being audited contains the Entity and the Action separated by a '.'"), "entity": z.object({ "object": z.string().describe("The type of Entity being acted on, e.g. \"experiment\" or \"feature\""), "id": z.string(), "name": z.string().optional() }), "parent": z.object({ "object": z.string().describe("The type of Entity being acted on, e.g. \"experiment\" or \"feature\""), "id": z.string() }).optional(), "reason": z.string().optional(), "details": z.string().optional(), "dateCreated": z.string() }).strict()
+
 export const listFeaturesValidator = {
   bodySchema: z.never(),
   querySchema: z.object({ "limit": z.coerce.number().int().default(10), "offset": z.coerce.number().int().default(0), "projectId": z.string().optional() }).strict(),
@@ -558,4 +560,16 @@ export const postCodeRefsValidator = {
   bodySchema: z.object({ "branch": z.string(), "repoName": z.string(), "refs": z.array(z.object({ "filePath": z.string(), "startingLineNumber": z.number().int(), "lines": z.string(), "flagKey": z.string(), "contentHash": z.string() })) }).strict(),
   querySchema: z.never(),
   paramsSchema: z.never(),
+};
+
+export const getAllHistoryValidator = {
+  bodySchema: z.never(),
+  querySchema: z.never(),
+  paramsSchema: z.object({ "type": z.string() }).strict(),
+};
+
+export const getHistoryValidator = {
+  bodySchema: z.never(),
+  querySchema: z.never(),
+  paramsSchema: z.object({ "id": z.string(), "type": z.string() }).strict(),
 };

--- a/packages/back-end/types/openapi.d.ts
+++ b/packages/back-end/types/openapi.d.ts
@@ -325,6 +325,14 @@ export interface paths {
     /** Submit list of code references */
     post: operations["postCodeRefs"];
   };
+  "/history/{type}": {
+    /** Get the Audit Logs for all entities of specified type */
+    get: operations["getAllHistory"];
+  };
+  "/history/{type}/{id}": {
+    /** Get the Audit Logs for a single entity */
+    get: operations["getHistory"];
+  };
 }
 
 export type webhooks = Record<string, never>;
@@ -1547,6 +1555,32 @@ export interface components {
       /** @description The attributes to set when using this Archetype */
       attributes: any;
       projects?: (string)[];
+    };
+    AuditLog: {
+      id: string;
+      user: {
+        apiKey: string;
+      } | {
+        id: string;
+        email: string;
+        name: string;
+      };
+      /** @description The event being audited contains the Entity and the Action separated by a '.' */
+      event: string;
+      entity: {
+        /** @description The type of Entity being acted on, e.g. "experiment" or "feature" */
+        object: string;
+        id: string;
+        name?: string;
+      };
+      parent?: {
+        /** @description The type of Entity being acted on, e.g. "experiment" or "feature" */
+        object: string;
+        id: string;
+      };
+      reason?: string;
+      details?: string;
+      dateCreated: string;
     };
   };
   responses: {
@@ -7668,6 +7702,94 @@ export interface operations {
       };
     };
   };
+  getAllHistory: {
+    /** Get the Audit Logs for all entities of specified type */
+    parameters: {
+        /** @description The type of entity, e.g. "experiment" or "feature" */
+      path: {
+        type: string;
+      };
+    };
+    responses: {
+      200: {
+        content: {
+          "application/json": {
+            events: ({
+                id: string;
+                user: {
+                  apiKey: string;
+                } | {
+                  id: string;
+                  email: string;
+                  name: string;
+                };
+                /** @description The event being audited contains the Entity and the Action separated by a '.' */
+                event: string;
+                entity: {
+                  /** @description The type of Entity being acted on, e.g. "experiment" or "feature" */
+                  object: string;
+                  id: string;
+                  name?: string;
+                };
+                parent?: {
+                  /** @description The type of Entity being acted on, e.g. "experiment" or "feature" */
+                  object: string;
+                  id: string;
+                };
+                reason?: string;
+                details?: string;
+                dateCreated: string;
+              })[];
+          };
+        };
+      };
+    };
+  };
+  getHistory: {
+    /** Get the Audit Logs for a single entity */
+    parameters: {
+        /** @description The id of the requested resource */
+        /** @description The type of entity, e.g. "experiment" or "feature" */
+      path: {
+        id: string;
+        type: string;
+      };
+    };
+    responses: {
+      200: {
+        content: {
+          "application/json": {
+            events: ({
+                id: string;
+                user: {
+                  apiKey: string;
+                } | {
+                  id: string;
+                  email: string;
+                  name: string;
+                };
+                /** @description The event being audited contains the Entity and the Action separated by a '.' */
+                event: string;
+                entity: {
+                  /** @description The type of Entity being acted on, e.g. "experiment" or "feature" */
+                  object: string;
+                  id: string;
+                  name?: string;
+                };
+                parent?: {
+                  /** @description The type of Entity being acted on, e.g. "experiment" or "feature" */
+                  object: string;
+                  id: string;
+                };
+                reason?: string;
+                details?: string;
+                dateCreated: string;
+              })[];
+          };
+        };
+      };
+    };
+  };
 }
 import { z } from "zod";
 import * as openApiValidators from "back-end/src/validators/openapi";
@@ -7704,6 +7826,7 @@ export type ApiFactTableFilter = z.infer<typeof openApiValidators.apiFactTableFi
 export type ApiFactMetric = z.infer<typeof openApiValidators.apiFactMetricValidator>;
 export type ApiMember = z.infer<typeof openApiValidators.apiMemberValidator>;
 export type ApiArchetype = z.infer<typeof openApiValidators.apiArchetypeValidator>;
+export type ApiAuditLog = z.infer<typeof openApiValidators.apiAuditLogValidator>;
 
 // Operations
 export type ListFeaturesResponse = operations["listFeatures"]["responses"]["200"]["content"]["application/json"];
@@ -7788,3 +7911,5 @@ export type UpdateFactMetricResponse = operations["updateFactMetric"]["responses
 export type DeleteFactMetricResponse = operations["deleteFactMetric"]["responses"]["200"]["content"]["application/json"];
 export type PostBulkImportFactsResponse = operations["postBulkImportFacts"]["responses"]["200"]["content"]["application/json"];
 export type PostCodeRefsResponse = operations["postCodeRefs"]["responses"]["200"]["content"]["application/json"];
+export type GetAllHistoryResponse = operations["getAllHistory"]["responses"]["200"]["content"]["application/json"];
+export type GetHistoryResponse = operations["getHistory"]["responses"]["200"]["content"]["application/json"];


### PR DESCRIPTION
### Features and Changes

Adds endpoints for fetching both the per-entity and per-entity-type audit logs

### Testing

GET requests to `/api/v1/history/<entity_type>/<entity_id>` and `/api/v1/history/<entity_type>`

### Screenshots

![image](https://github.com/user-attachments/assets/cdeef7cf-74fb-4bb6-984a-7dbe163fa758)

![image](https://github.com/user-attachments/assets/51d4aa21-93ee-490a-a3b5-39eb4f4c0058)
