### PR TITLE
Add banner to draft/locked feature revisions

### DIFF
--- a/packages/front-end/components/Features/FeaturesOverview.tsx
+++ b/packages/front-end/components/Features/FeaturesOverview.tsx
@@ -966,14 +966,28 @@ export default function FeaturesOverview({
               </Grid>
             </Box>
             <Box className="appbox nobg" mt="4" p="4">
-              {isPendingReview && (
+              {isPendingReview ? (
                 <Box>
-                  <Callout status="info" mb="3">
-                    This draft is pending approval. Review and approve changes
-                    to enable publishing.
+                  <Callout status="warning" mb="3">
+                    You are viewing a <strong>draft</strong>. The changes below
+                    will not go live until they are approved and published.
                   </Callout>
                 </Box>
-              )}
+              ) : isDraft ? (
+                <Box>
+                  <Callout status="warning" mb="3">
+                    You are viewing a <strong>draft</strong>. The changes below
+                    will not go live until you review and publish them.
+                  </Callout>
+                </Box>
+              ) : isLocked && !isLive ? (
+                <Box>
+                  <Callout status="info" mb="3">
+                    This revision has been <strong>locked</strong>. It is no
+                    longer live and cannot be modified.
+                  </Callout>
+                </Box>
+              ) : null}
 
               {renderRevisionInfo()}
 


### PR DESCRIPTION
### Features and Changes

The status of the currently selected feature revision was very subtle.  It was hard to know at a glance whether you were viewing something that was live or still in a draft state.  This PR adds a banner whenever the revision you are viewing is not live.

Live revision (not changing, just for reference):

![Screenshot from 2025-01-31 17-28-00](https://github.com/user-attachments/assets/0c65c90a-a522-476c-aa8a-b7fa44feab4e)

Drafts before:

![Screenshot from 2025-01-31 17-27-55](https://github.com/user-attachments/assets/03ca2070-5d0c-45a6-bf18-a8adb6052d44)

Drafts after:

![Screenshot from 2025-01-31 17-43-51](https://github.com/user-attachments/assets/1d173bdd-9f59-4aca-bb18-c5cce5acf04d)

Locked revision before:

![Screenshot from 2025-01-31 17-27-48](https://github.com/user-attachments/assets/c48e335e-184b-4cac-91d6-890cc01073de)

Locked revision after:

![Screenshot from 2025-01-31 17-43-40](https://github.com/user-attachments/assets/94b6611e-9c7e-4073-8e70-03ffd3905544)
