### PR TITLE
Fixed responsive display of the top of features

### DIFF
--- a/packages/front-end/components/Features/FeaturesOverview.tsx
+++ b/packages/front-end/components/Features/FeaturesOverview.tsx
@@ -19,7 +19,7 @@ import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
 import Link from "next/link";
 import { BsClock } from "react-icons/bs";
 import { PiCheckCircleFill, PiCircleDuotone, PiFileX } from "react-icons/pi";
-import { Box, Card, Flex, Grid, Heading, Switch } from "@radix-ui/themes";
+import { Box, Card, Flex, Heading, Switch } from "@radix-ui/themes";
 import { RxListBullet } from "react-icons/rx";
 import Button from "@/components/Radix/Button";
 import { GBAddCircle, GBEdit } from "@/components/Icons";
@@ -450,9 +450,7 @@ export default function FeaturesOverview({
     return (
       <>
         {actions.map((el, i) => (
-          <Box key={"cta-" + i} ml="5">
-            {el}
-          </Box>
+          <Box key={"cta-" + i}>{el}</Box>
         ))}
       </>
     );
@@ -921,12 +919,16 @@ export default function FeaturesOverview({
               <Heading as="h3" size="5" mb="3">
                 Rules &amp; Values
               </Heading>
-              <Grid columns="2" gap="4">
+              <Flex
+                gap="4"
+                align={{ initial: "center", xs: "start" }}
+                direction={{ initial: "column", xs: "row" }}
+                justify="between"
+              >
                 <Flex
                   align="center"
-                  flexGrow="1"
-                  width="100%"
                   justify="between"
+                  width={{ initial: "95%", sm: "70%", md: "60%", lg: "50%" }}
                 >
                   <Box width="100%">
                     <RevisionDropdown
@@ -960,10 +962,18 @@ export default function FeaturesOverview({
                     </a>
                   </Box>
                 </Flex>
-                <Flex align="center" justify="end">
+                <Flex
+                  align={{ initial: "center", xs: "center", sm: "start" }}
+                  justify="end"
+                  flexShrink="0"
+                  direction={{ initial: "row", xs: "column", sm: "row" }}
+                  // @ts-expect-error text wrap is not valid for some reason, but it is
+                  style={{ textWrap: "nowrap" }}
+                  gap="4"
+                >
                   {renderRevisionCTA()}
                 </Flex>
-              </Grid>
+              </Flex>
             </Box>
             <Box className="appbox nobg" mt="4" p="4">
               {isPendingReview ? (

--- a/packages/front-end/components/Features/FeaturesOverview.tsx
+++ b/packages/front-end/components/Features/FeaturesOverview.tsx
@@ -921,14 +921,14 @@ export default function FeaturesOverview({
               </Heading>
               <Flex
                 gap="4"
-                align={{ initial: "center", xs: "start" }}
+                align={{ initial: "center" }}
                 direction={{ initial: "column", xs: "row" }}
                 justify="between"
               >
                 <Flex
                   align="center"
                   justify="between"
-                  width={{ initial: "95%", sm: "70%", md: "60%", lg: "50%" }}
+                  width={{ initial: "98%", sm: "70%", md: "60%", lg: "50%" }}
                 >
                   <Box width="100%">
                     <RevisionDropdown

--- a/packages/front-end/components/Features/FeaturesOverview.tsx
+++ b/packages/front-end/components/Features/FeaturesOverview.tsx
@@ -967,8 +967,7 @@ export default function FeaturesOverview({
                   justify="end"
                   flexShrink="0"
                   direction={{ initial: "row", xs: "column", sm: "row" }}
-                  // @ts-expect-error text wrap is not valid for some reason, but it is
-                  style={{ textWrap: "nowrap" }}
+                  style={{ whiteSpace: "nowrap" }}
                   gap="4"
                 >
                   {renderRevisionCTA()}

--- a/packages/front-end/components/Features/RevisionDropdown.tsx
+++ b/packages/front-end/components/Features/RevisionDropdown.tsx
@@ -53,7 +53,11 @@ export default function RevisionDropdown({
               Revision {value}
             </Heading>
             <Box flexGrow="1" />
-            <Box flexShrink="1" overflow="hidden">
+            <Box
+              flexShrink="1"
+              overflow="hidden"
+              style={{ textOverflow: "ellipsis" }}
+            >
               {date && (
                 <Text size="1" color="gray">
                   Created {datetime(date)} by{" "}

--- a/packages/front-end/components/Features/RevisionDropdown.tsx
+++ b/packages/front-end/components/Features/RevisionDropdown.tsx
@@ -1,7 +1,7 @@
 import { FeatureInterface } from "back-end/types/feature";
 import { FeatureRevisionInterface } from "back-end/types/feature-revision";
 import { datetime } from "shared/dates";
-import { Flex, Heading, Text } from "@radix-ui/themes";
+import { Box, Flex, Heading, Text } from "@radix-ui/themes";
 import SelectField from "@/components/Forms/SelectField";
 import EventUser from "@/components/Avatar/EventUser";
 import Badge from "@/components/Radix/Badge";
@@ -52,13 +52,16 @@ export default function RevisionDropdown({
             <Heading size="2" mb="0">
               Revision {value}
             </Heading>
-            <Flex align="center" gap="3">
+            <Box flexGrow="1" />
+            <Box flexShrink="1" overflow="hidden">
               {date && (
                 <Text size="1" color="gray">
                   Created {datetime(date)} by{" "}
                   <EventUser user={revision?.createdBy} display="name" />
                 </Text>
               )}
+            </Box>
+            <Box flexShrink="0">
               {revision?.version === liveVersion ? (
                 <Badge label="Live" radius="full" color="teal" />
               ) : revision?.status === "draft" ? (
@@ -68,9 +71,7 @@ export default function RevisionDropdown({
               ) : revision?.status === "discarded" ? (
                 <Badge label="Discarded" radius="full" color="red" />
               ) : null}
-
-              <div className="ml-auto"></div>
-            </Flex>
+            </Box>
           </Flex>
         );
       }}


### PR DESCRIPTION
<img width="890" alt="Screenshot 2025-01-31 at 10 27 29 PM" src="https://github.com/user-attachments/assets/4b4e0715-46c0-48ad-9615-9852fb03cf43" />
<img width="660" alt="Screenshot 2025-01-31 at 10 27 19 PM" src="https://github.com/user-attachments/assets/0c34676f-f944-4f2a-84b1-1b0425e19493" />
<img width="457" alt="Screenshot 2025-01-31 at 10 27 11 PM" src="https://github.com/user-attachments/assets/c59155a2-54d2-46c0-8d6c-711974e947fc" />
