### PR TITLE
Fix presentations page error card margin

### DIFF
--- a/packages/front-end/components/Share/ShareModal.tsx
+++ b/packages/front-end/components/Share/ShareModal.tsx
@@ -281,7 +281,7 @@ const ShareModal = ({
 
   if (experiments.length === 0) {
     return (
-      <div className="alert alert-danger">
+      <div className="alert alert-danger" style={{ marginTop: "1rem" }}>
         You need some experiments to share first.
       </div>
     );


### PR DESCRIPTION
### Features and Changes

Added `marginTop: 1rem` to the card.

### Screenshots

Before: 
![1738424476_TzGraYIw5a](https://github.com/user-attachments/assets/461ea2ad-0e0e-46cb-a69f-7156263f58a8)
After:
![image](https://github.com/user-attachments/assets/0d68156d-761d-4989-a319-21f61c277001)
