### PR TITLE
Smith/cuped variance update

### DIFF
--- a/docs/docs/statistics/cuped-technical.mdx
+++ b/docs/docs/statistics/cuped-technical.mdx
@@ -41,11 +41,12 @@ $$
 Under a superpopulation framework and independence of random assignment, the adjusted means $\left(\bar{Y}_{T} - \theta\bar{X}_{T}\right)$ and $\left(\bar{Y}_{C} - \theta\bar{X}_{C}\right)$ are statistically independent.  
 Therefore, the variance of the difference in adjusted means is the sum of the variances of the adjusted means.  
 We denote these variances as $V_{adj, C}$ and $V_{adj, T}$, respectively, and they are defined as
+Define the control (treatment) population covariance between post-exposure and pre-exposure revenue as $\sigma_{XY,C}$ ($\sigma_{XY,T}$).
 
 $$
 \begin{align}
-V_{adj, C} &= \frac{\sigma^{2}_{YC} + \theta^{2}\sigma^{2}_{XC} - 2\theta\text{Cov}\left(Y_{C}, X_{C} \right)}{N_{C}}\\
-V_{adj, T} &= \frac{\sigma^{2}_{YT} + \theta^{2}\sigma^{2}_{XT} - 2\theta\text{Cov}\left(Y_{T}, X_{T} \right)}{N_{T}}.
+V_{adj, C} &= \frac{\sigma^{2}_{YC} + \theta^{2}\sigma^{2}_{XC} - 2\theta\sigma_{XY,C}}{N_{C}}\\
+V_{adj, T} &= \frac{\sigma^{2}_{YT} + \theta^{2}\sigma^{2}_{XT} - 2\theta\sigma_{XY,T}}{N_{T}}.
 \end{align}
 $$
 
@@ -73,18 +74,17 @@ To derive $\hat{\sigma}^{2}_{\Delta_{R}}$, the estimated variance of $\hat{\Delt
 
 1. Define the control (treatment) population post-exposure variance as $\sigma^{2}_{YC}$ ($\sigma^{2}_{YT}$).
 2. Define the control (treatment) population pre-exposure variance as $\sigma^{2}_{XC}$ ($\sigma^{2}_{XT}$).
-3. Define the control (treatment) population covariance between post-exposure and pre-exposure revenue as $\text{Cov}\left(Y_{C}, X_{C} \right)$ ($\text{Cov}\left(Y_{T}, X_{T} \right)$).
-4. Define the covariance of the sample control means $$ \boldsymbol{\Lambda}_{C} = \text{Cov}\left[\bar{Y}_{C}, \bar{X}_{C}\right] =\begin{pmatrix}
+3. Define the covariance of the sample control means $$ \boldsymbol{\Lambda}_{C} = \text{Cov}\left[\bar{Y}_{C}, \bar{X}_{C}\right] =\begin{pmatrix}
    \sigma^{2}_{Y,C} & \sigma*{XY,C}\\
    \sigma*{XY,C} & \sigma^{2}_{X,C}
    \end{pmatrix}/ N_{C}$$.
-5. Define the covariance of the sample treatment means $$ \boldsymbol{\Lambda}_{T} = \text{Cov}\left[\bar{Y}_{T}, \bar{X}_{T}\right] =\begin{pmatrix}
+4. Define the covariance of the sample treatment means $$ \boldsymbol{\Lambda}_{T} = \text{Cov}\left[\bar{Y}_{T}, \bar{X}_{T}\right] =\begin{pmatrix}
    \sigma^{2}_{Y,T} & \sigma*{XY,T}\\
    \sigma*{XY,T} & \sigma^{2}_{X,T}
    \end{pmatrix}/ N_{T}$$.
-6. Define the vector of population means $\boldsymbol{\beta}_{0} = \left[\mu_{YT}, \mu_{XT}, \mu_{YC}, \mu_{XC} \right].$
-7. Define their sample counterparts as $\hat{\boldsymbol{\beta}} = \left[\bar{Y}_{T}, \bar{X}_{T}, \bar{Y}_{C}, \bar{X}_{C} \right].$
-8. Define $$\boldsymbol{\Lambda} = \text{Cov}\left(\hat{\boldsymbol{\beta}}\right) = \begin{pmatrix}
+5. Define the vector of population means $\boldsymbol{\beta}_{0} = \left[\mu_{YT}, \mu_{XT}, \mu_{YC}, \mu_{XC} \right].$
+6. Define their sample counterparts as $\hat{\boldsymbol{\beta}} = \left[\bar{Y}_{T}, \bar{X}_{T}, \bar{Y}_{C}, \bar{X}_{C} \right].$
+7. Define $$\boldsymbol{\Lambda} = \text{Cov}\left(\hat{\boldsymbol{\beta}}\right) = \begin{pmatrix}
 \boldsymbol{\Lambda}_{T} & \textbf{0}\\
 \textbf{0} & \boldsymbol{\Lambda}_{C}
 \end{pmatrix},$$
@@ -180,7 +180,7 @@ $$
 \nonumber\\&=\frac{
 \sigma^{2}_{Y,T}
 +\theta^{2}\sigma^{2}_{X,T}
--2\text{Cov}\left(\sigma_{XY,T} \right)
+-2\sigma_{XY,T}
 }{N_{T}\boldsymbol{\beta}[3]^{2}}
 \nonumber\\&+
 \frac{1}{N_{C}\boldsymbol{\beta}[3]^{2}}
@@ -203,7 +203,7 @@ $$
 \nonumber\\&=\frac{
 \sigma^{2}_{Y,T}
 +\theta^{2}\sigma^{2}_{X,T}
--2\text{Cov}\left(\sigma_{XY,T} \right)
+-2\sigma_{XY,T}
 }{N_{T}\boldsymbol{\beta}[3]^{2}}
 \nonumber\\&+
 \frac{1}{N_{C}\boldsymbol{\beta}[3]^{2}}
@@ -218,7 +218,7 @@ $$
 \nonumber\\&=\frac{
 \sigma^{2}_{Y,T}
 +\theta^{2}\sigma^{2}_{X,T}
--2\text{Cov}\left(\sigma_{XY,T} \right)
+-2\sigma_{XY,T}
 }{N_{T}\bar{Y}_{C}^{2}}
 \nonumber\\&+
 \frac{1}{N_{C}\bar{Y}_{C}^{2}}

--- a/docs/docs/statistics/cuped-technical.mdx
+++ b/docs/docs/statistics/cuped-technical.mdx
@@ -1,0 +1,260 @@
+---
+title: Cuped Estimated Variance Technical Details
+description: Technical details of CUPED variance estimates
+sidebar_label: CUPED Technical
+slug: cuped-technical
+---
+
+# Technical CUPED details
+
+Here we document the technical details behind GrowthBook CUPED variance estimates.
+
+We use the notation below. We describe our approach in terms of revenue, but any binomial or count metric can be substituted.
+
+1. Define $Y_{C}$ $\left(Y_{T}\right)$ as the observed post-exposure revenue for a user exposed to control (treatment).
+2. Define $X_{C}$ $\left(X_{T}\right)$ as the observed pre-exposure revenue for a user exposed to control (treatment).
+3. Define $Y$ ($X$) as the post-exposure (pre-exposure) revenue for all users collectively in the experiment.
+4. Define $\bar{Y}_{C}$ $\left(\bar{Y}_{T}\right)$ as the sample average post-exposure revenue for users exposed to control (treatment).
+5. Define $\mu_{C}$ $\left(\mu_{T}\right)$ as the population average post-exposure revenue for users exposed to control (treatment).
+6. Define $N_{C}$ $\left(N_{T}\right)$ as the number of users exposed to control (treatment).
+
+## Absolute case
+
+For absolute inference, our target parameter is
+
+$$
+\begin{align}
+\Delta_{A}&=\mu_{Y}-\mu_{YC}.
+\end{align}
+$$
+
+As described in Equation 4 of ([Deng et al. 2013](https://exp-platform.com/Documents/2013-02-CUPED-ImprovingSensitivityOfControlledExperiments.pdf)), we find the optimal $\theta$ using user data across both control and treatment:
+$$\theta = cov(Y, X) / var(X).$$
+Our estimate of $\Delta_{A}$ is the difference in adjusted means
+
+$$
+\begin{align}
+\hat{\Delta}_{A} &= \left(\bar{Y}_{T} - \theta\bar{X}_{T}\right)  - \left(\bar{Y}_{C} - \theta\bar{X}_{C}\right).
+\end{align}
+$$
+
+Under a superpopulation framework and independence of random assignment, the adjusted means $\left(\bar{Y}_{T} - \theta\bar{X}_{T}\right)$ and $\left(\bar{Y}_{C} - \theta\bar{X}_{C}\right)$ are statistically independent.  
+Therefore, the variance of the difference in adjusted means is the sum of the variances of the adjusted means.  
+We denote these variances as $V_{adj, C}$ and $V_{adj, T}$, respectively, and they are defined as
+
+$$
+\begin{align}
+V_{adj, C} &= \frac{\sigma^{2}_{YC} + \theta^{2}\sigma^{2}_{XC} - 2\theta\text{Cov}\left(Y_{C}, X_{C} \right)}{N_{C}}\\
+V_{adj, T} &= \frac{\sigma^{2}_{YT} + \theta^{2}\sigma^{2}_{XT} - 2\theta\text{Cov}\left(Y_{T}, X_{T} \right)}{N_{T}}.
+\end{align}
+$$
+
+Our estimated variance of $\hat{\Delta}_{A}$ is $\hat{\sigma}^{2}_{\Delta_{A}} = V_{adj, C} + V_{adj, T}$.
+
+## Relative case
+
+For relative inference (i.e., estimating lift), the parameter of interest is
+
+$$
+\begin{align}
+\Delta_{R}&=\frac{\mu_{T}-\mu_{C}}{\mu_{C}}.
+\end{align}
+$$
+
+Our estimate of $\Delta_{R}$ is the difference in adjusted means divided by the control mean:
+
+$$
+\begin{align}
+\hat{\Delta}_{R} = \frac{\left(\bar{Y}_{T} - \theta\bar{X}_{T}\right)  - \left(\bar{Y}_{C} - \theta\bar{X}_{C}\right)}{\bar{Y}_{C}}.
+\end{align}
+$$
+
+To derive $\hat{\sigma}^{2}_{\Delta_{R}}$, the estimated variance of $\hat{\Delta}_{R}$, we use the delta method.
+
+1. Define the control (treatment) population post-exposure variance as $\sigma^{2}_{YC}$ ($\sigma^{2}_{YT}$).
+2. Define the control (treatment) population pre-exposure variance as $\sigma^{2}_{XC}$ ($\sigma^{2}_{XT}$).
+3. Define the control (treatment) population covariance between post-exposure and pre-exposure revenue as $\text{Cov}\left(Y_{C}, X_{C} \right)$ ($\text{Cov}\left(Y_{T}, X_{T} \right)$).
+4. Define the covariance of the sample control means $$ \boldsymbol{\Lambda}_{C} = \text{Cov}\left[\bar{Y}_{C}, \bar{X}_{C}\right] =\begin{pmatrix}
+   \sigma^{2}_{Y,C} & \sigma*{XY,C}\\
+   \sigma*{XY,C} & \sigma^{2}_{X,C}
+   \end{pmatrix}/ N_{C}$$.
+5. Define the covariance of the sample treatment means $$ \boldsymbol{\Lambda}_{T} = \text{Cov}\left[\bar{Y}_{T}, \bar{X}_{T}\right] =\begin{pmatrix}
+   \sigma^{2}_{Y,T} & \sigma*{XY,T}\\
+   \sigma*{XY,T} & \sigma^{2}_{X,T}
+   \end{pmatrix}/ N_{T}$$.
+6. Define the vector of population means $\boldsymbol{\beta}_{0} = \left[\mu_{YT}, \mu_{XT}, \mu_{YC}, \mu_{XC} \right].$
+7. Define their sample counterparts as $\hat{\boldsymbol{\beta}} = \left[\bar{Y}_{T}, \bar{X}_{T}, \bar{Y}_{C}, \bar{X}_{C} \right].$
+8. Define $$\boldsymbol{\Lambda} = \text{Cov}\left(\hat{\boldsymbol{\beta}}\right) = \begin{pmatrix}
+\boldsymbol{\Lambda}_{T} & \textbf{0}\\
+\textbf{0} & \boldsymbol{\Lambda}_{C}
+\end{pmatrix},$$
+   where $\textbf{0}$ is a $2 \times 2$ matrix of zeros.
+
+By the multivariate central limit theorem:
+
+$$
+\begin{align}
+\hat{\boldsymbol{\beta}}
+\stackrel{}{\sim}\mathcal{MVN}\left(\boldsymbol{\beta}_{0},\boldsymbol{\Lambda}\right).
+\end{align}
+$$
+
+For vector $\boldsymbol{\beta}$, define its $k^{\text{th}}$ element as $\beta[k]$.  
+Define the function
+$$g(\boldsymbol{\beta}; \theta) = \frac{\left(\beta[1] - \theta\beta[2]\right)  - \left(\beta[3] - \theta\beta[4]\right)}{\beta[3]}.$$
+
+Define the vector of partial derivatives as $\boldsymbol{\nabla}_{r} = \frac{\partial g(\boldsymbol{\beta})}{\partial\boldsymbol{\beta}}$, where the individual elements are
+
+$$
+\begin{align*}
+\boldsymbol{\nabla}[1] &= \frac{1}{\boldsymbol{\beta}[3]}
+\\\boldsymbol{\nabla}[2] &= \frac{-\theta}{\boldsymbol{\beta}[3]}
+\\\boldsymbol{\nabla}[3] &= \frac{-\boldsymbol{\beta}[3]
+-
+\left(\boldsymbol{\beta}[1] - \theta\boldsymbol{\beta}[2] - \boldsymbol{\beta}[3] + \theta\boldsymbol{\beta}[4]\right)
+}{\boldsymbol{\beta}[3]^{2}}
+= \frac{
+-\boldsymbol{\beta}[1] + \theta\boldsymbol{\beta}[2]  - \theta\boldsymbol{\beta}[4]
+}{\boldsymbol{\beta}[3]^{2}}
+\\\boldsymbol{\nabla}[4] &= \frac{\theta}{\boldsymbol{\beta}[3]}.
+\end{align*}
+$$
+
+By the delta method,
+$$\hat{\Delta}_{r} = g(\hat{\boldsymbol{\beta}}) \stackrel{}{\sim}\mathcal{N}\left(\Delta_{r} = g\left(\boldsymbol{\beta}\right), \boldsymbol{\nabla}_{r}^{\top}\Lambda\boldsymbol{\nabla}_{r} \right)$$.
+
+Decompose $\boldsymbol{\nabla}_{r}$ into $\boldsymbol{\nabla}_{r} = \left[
+\boldsymbol{\nabla}_{r}[1:2], \boldsymbol{\nabla}_{r}[3:4]
+\right].$
+
+Then the final variance
+
+$$
+\begin{align}
+\boldsymbol{\nabla}_{r}^{\top}\Lambda\boldsymbol{\nabla}_{r} &=
+\boldsymbol{\nabla}_{r}[1:2]^{\top}
+\boldsymbol{\Lambda}_{T}
+\boldsymbol{\nabla}_{r}[1:2]
++
+\boldsymbol{\nabla}_{r}[3:4]^{\top}
+\boldsymbol{\Lambda}_{C}
+\boldsymbol{\nabla}_{r}[3:4]
+\nonumber\\&=
+\left[\frac{1}{\boldsymbol{\beta}[3]}, \frac{-\theta}{\boldsymbol{\beta}[3]}\right]
+^{\top}
+\begin{pmatrix}
+\sigma^{2}_{Y,T}  & \sigma_{XY,T} \\
+\sigma_{XY,T} & \sigma^{2}_{X,T}
+\end{pmatrix}/ N_{T}
+\left[\frac{1}{\boldsymbol{\beta}[3]}, \frac{-\theta}{\boldsymbol{\beta}[3]}\right]
+\nonumber\\&+ \left[\frac{
+-\boldsymbol{\beta}[1] + \theta\boldsymbol{\beta}[2]  - \theta\boldsymbol{\beta}[4]
+}{\boldsymbol{\beta}[3]^{2}},  \frac{\theta}{\boldsymbol{\beta}[3]}\right]
+\begin{pmatrix}
+\sigma^{2}_{Y,C}  & \sigma_{XY,C} \\
+\sigma_{XY,C} & \sigma^{2}_{X,C}
+\end{pmatrix}/ N_{C}
+\left[\frac{
+-\boldsymbol{\beta}[1] + \theta\boldsymbol{\beta}[2]  - \theta\boldsymbol{\beta}[4]
+}{\boldsymbol{\beta}[3]^{2}},  \frac{\theta}{\boldsymbol{\beta}[3]}\right]
+\nonumber\\&=
+\frac{1}{N_{T}\boldsymbol{\beta}[3]^{2}}\left[1, -\theta\right]
+^{\top}
+\begin{pmatrix}
+\sigma^{2}_{Y,T}  & \sigma_{XY,T} \\
+\sigma_{XY,T} & \sigma^{2}_{X,T}
+\end{pmatrix}
+\left[1, -\theta\right]
+\nonumber\\&+
+\frac{1}{N_{C}\boldsymbol{\beta}[3]^{2}}
+\left[\frac{
+-\boldsymbol{\beta}[1] + \theta\boldsymbol{\beta}[2]  - \theta\boldsymbol{\beta}[4]
+}{\boldsymbol{\beta}[3]},  \theta\right]
+\begin{pmatrix}
+\sigma^{2}_{Y,C}  & \sigma_{XY,C} \\
+\sigma_{XY,C} & \sigma^{2}_{X,C}
+\end{pmatrix}
+\left[\frac{
+-\boldsymbol{\beta}[1] + \theta\boldsymbol{\beta}[2]  - \theta\boldsymbol{\beta}[4]
+}{\boldsymbol{\beta}[3]},  \theta\right]
+\nonumber\\&=\frac{
+\sigma^{2}_{Y,T}
++\theta^{2}\sigma^{2}_{X,T}
+-2\text{Cov}\left(\sigma_{XY,T} \right)
+}{N_{T}\boldsymbol{\beta}[3]^{2}}
+\nonumber\\&+
+\frac{1}{N_{C}\boldsymbol{\beta}[3]^{2}}
+\left[\frac{
+-\boldsymbol{\beta}[1] + \theta\boldsymbol{\beta}[2]  - \theta\boldsymbol{\beta}[4]
+}{\boldsymbol{\beta}[3]},  \theta\right]
+\begin{pmatrix}
+\frac{\sigma^{2}_{Y,C}  \left(
+-\boldsymbol{\beta}[1] + \theta\boldsymbol{\beta}[2]  - \theta\boldsymbol{\beta}[4]
+\right)}{
+\boldsymbol{\beta}[3]
+}
++ \theta\sigma_{XY,C} \\
+\frac{\sigma_{XY,C}
+\left(
+-\boldsymbol{\beta}[1] + \theta\boldsymbol{\beta}[2]  - \theta\boldsymbol{\beta}[4]
+\right)}{\boldsymbol{\beta}[3]}
++\theta\sigma^{2}_{X,C}
+\end{pmatrix}
+\nonumber\\&=\frac{
+\sigma^{2}_{Y,T}
++\theta^{2}\sigma^{2}_{X,T}
+-2\text{Cov}\left(\sigma_{XY,T} \right)
+}{N_{T}\boldsymbol{\beta}[3]^{2}}
+\nonumber\\&+
+\frac{1}{N_{C}\boldsymbol{\beta}[3]^{2}}
+\left(
+\frac{\sigma^{2}_{Y,C}  \left(
+-\boldsymbol{\beta}[1] + \theta\boldsymbol{\beta}[2]  - \theta\boldsymbol{\beta}[4]
+\right)^{2}}{\boldsymbol{\beta}[3]^{2}}
++2\frac{\theta\sigma_{XY,C}
+\left(-\boldsymbol{\beta}[1] + \theta\boldsymbol{\beta}[2]  - \theta\boldsymbol{\beta}[4]\right)}{\boldsymbol{\beta}[3]}
++\theta^{2}\sigma^{2}_{X,C}
+\right)
+\nonumber\\&=\frac{
+\sigma^{2}_{Y,T}
++\theta^{2}\sigma^{2}_{X,T}
+-2\text{Cov}\left(\sigma_{XY,T} \right)
+}{N_{T}\bar{Y}_{C}^{2}}
+\nonumber\\&+
+\frac{1}{N_{C}\bar{Y}_{C}^{2}}
+\left(
+\frac{\sigma^{2}_{Y,C}  \left(
+-\bar{Y}_{T} + \theta\bar{X}_{T}  - \theta\bar{X}_{C}
+\right)^{2}}{\bar{Y}_{C}^{2}}
++2\frac{\theta\sigma_{XY,C}
+\left(-\bar{Y}_{T} + \theta\bar{X}_{T}  - \theta\bar{X}_{C}\right)}{\bar{Y}_{C}}
++\theta^{2}\sigma^{2}_{X,C}
+\right),
+\end{align}
+$$
+
+where in the last step we move away from $\boldsymbol{\beta}$ notation and use sample mean notation.
+
+For estimating uncertainty in production, we use
+
+$$
+\begin{align}
+\hat{\sigma}^{2}_{\Delta_{R}}&=\frac{
+\sigma^{2}_{Y,T}
++\theta^{2}\sigma^{2}_{X,T}
+-2\sigma_{XY,T}
+}{N_{T}\bar{Y}_{C}^{2}}
+\nonumber\\&+
+\frac{1}{N_{C}\bar{Y}_{C}^{2}}
+\left(
+\frac{\sigma^{2}_{Y,C}  \left(
+-\bar{Y}_{T}
+\right)^{2}}{\bar{Y}_{C}^{2}}
++2\frac{\theta\sigma_{XY,C}
+\left(-\bar{Y}_{T}\right)}{\bar{Y}_{C}}
++\theta^{2}\sigma^{2}_{X,C}
+\right),
+\end{align}
+$$
+
+which leverages the fact that the pre-exposure revenue population means are equal due to randomization.

--- a/docs/docs/statistics/cuped.mdx
+++ b/docs/docs/statistics/cuped.mdx
@@ -47,12 +47,12 @@ For each metric you analyze, we use the metric itself from the pre-exposure peri
 We then use the standard CUPED estimator for each variation mean,
 
 $$
-\bar{Y}_{adjusted} = \bar{Y}_{post} - \theta * \bar{Y}_{pre}
+\bar{Y}_{adjusted} = \bar{Y} - \theta * \bar{X}
 $$
 
-where $\bar{Y}_{post}$ is the post-exposure metric average, $\bar{Y}_{pre}$ is the pre-exposure metric average, and $\theta$ is essentially a regression coefficient from a regression of the post-experiment data on the pre-experiment data (pooled across both the control and treatment variation of interest), $\theta = \text{Cov}(Y_{pre}, Y_{post}) / \text{Var}(Y_{pre})$.
+where $\bar{Y}$ is the post-exposure metric average, $\bar{X}$ is the pre-exposure metric average, and $\theta$ is essentially a regression coefficient from a regression of the post-experiment data on the pre-experiment data (pooled across both the control and treatment variation of interest), $\theta = \text{Cov}(Y, X) / \text{Var}(X)$. We describe how to estimate uncertainty [here](/statistics/cuped-technical).
 
-As discussed above, we could use any correlated data instead of $Y_{pre}$. For example, we could use some model that includes all pre-exposure metrics added to your experiment, or auxiliary dimension information you have configured per user. However, one downside of these approaches is that your results for metric A will depend on whether or not you add a metric B to your experiment and our analysis pipeline would lose its modularity, where each metric can be processed in parallel. Nonetheless, we anticipate continuing to build methods that leverage additional data to improve variance reduction from CUPED.
+As discussed above, we could use any correlated data instead of $X$. For example, we could use some model that includes all pre-exposure metrics added to your experiment, or auxiliary dimension information you have configured per user. However, one downside of these approaches is that your results for metric A will depend on whether or not you add a metric B to your experiment and our analysis pipeline would lose its modularity, where each metric can be processed in parallel. Nonetheless, we anticipate continuing to build methods that leverage additional data to improve variance reduction from CUPED.
 
 ### Regression Adjustment lookback window
 

--- a/packages/stats/gbstats/bayesian/tests.py
+++ b/packages/stats/gbstats/bayesian/tests.py
@@ -22,6 +22,7 @@ from gbstats.models.statistics import (
 from gbstats.frequentist.tests import (
     frequentist_diff,
     frequentist_variance,
+    frequentist_variance_relative_cuped,
 )
 from gbstats.utils import (
     truncated_normal_mean,
@@ -175,16 +176,24 @@ class EffectBayesianABTest(BayesianABTest):
                 self.config.prior_effect.variance * pow(self.stat_a.unadjusted_mean, 2),
                 self.config.prior_effect.proper,
             )
-
-        data_variance = frequentist_variance(
-            self.stat_a.variance,
-            self.stat_a.unadjusted_mean,
-            self.stat_a.n,
-            self.stat_b.variance,
-            self.stat_b.unadjusted_mean,
-            self.stat_b.n,
-            self.relative,
-        )
+        if (
+            isinstance(self.stat_a, RegressionAdjustedStatistic)
+            and isinstance(self.stat_b, RegressionAdjustedStatistic)
+            and self.relative
+        ):
+            data_variance = frequentist_variance_relative_cuped(
+                self.stat_a, self.stat_b
+            )
+        else:
+            data_variance = frequentist_variance(
+                self.stat_a.variance,
+                self.stat_a.unadjusted_mean,
+                self.stat_a.n,
+                self.stat_b.variance,
+                self.stat_b.unadjusted_mean,
+                self.stat_b.n,
+                self.relative,
+            )
         data_mean = frequentist_diff(
             self.stat_a.mean,
             self.stat_b.mean,

--- a/packages/stats/gbstats/frequentist/tests.py
+++ b/packages/stats/gbstats/frequentist/tests.py
@@ -56,6 +56,30 @@ def frequentist_variance(var_a, mean_a, n_a, var_b, mean_b, n_b, relative) -> fl
         return var_b / n_b + var_a / n_a
 
 
+def frequentist_variance_relative_cuped(
+    stat_a: RegressionAdjustedStatistic, stat_b: RegressionAdjustedStatistic
+) -> float:
+    den_trt = stat_b.n * stat_a.unadjusted_mean**2
+    den_ctrl = stat_a.n * stat_a.unadjusted_mean**2
+    if den_trt == 0 or den_ctrl == 0:
+        return 0  # avoid division by zero
+    theta = stat_a.theta if stat_a.theta else 0
+    num_trt = (
+        stat_b.post_statistic.variance
+        + theta**2 * stat_b.pre_statistic.variance
+        - 2 * theta * stat_b.covariance
+    )
+    v_trt = num_trt / den_trt
+    const = -stat_b.post_statistic.mean
+    num_a = (
+        stat_a.post_statistic.variance * const**2 / (stat_a.post_statistic.mean**2)
+    )
+    num_b = 2 * theta * stat_a.covariance * const / stat_a.post_statistic.mean
+    num_c = theta**2 * stat_a.pre_statistic.variance
+    v_ctrl = (num_a + num_b + num_c) / den_ctrl
+    return v_trt + v_ctrl
+
+
 class TTest(BaseABTest):
     def __init__(
         self,
@@ -88,33 +112,7 @@ class TTest(BaseABTest):
             and isinstance(self.stat_b, RegressionAdjustedStatistic)
             and self.relative
         ):
-            den_trt = self.stat_b.n * self.stat_a.unadjusted_mean**2
-            den_ctrl = self.stat_a.n * self.stat_a.unadjusted_mean**2
-            if den_trt == 0 or den_ctrl == 0:
-                return 0  # avoid division by zero
-            theta = self.stat_a.theta if self.stat_a.theta else 0
-            num_trt = (
-                self.stat_b.post_statistic.variance
-                + theta**2 * self.stat_b.pre_statistic.variance
-                - 2 * theta * self.stat_b.covariance
-            )
-            v_trt = num_trt / den_trt
-            const = -self.stat_b.post_statistic.mean
-            num_a = (
-                self.stat_a.post_statistic.variance
-                * const**2
-                / (self.stat_a.post_statistic.mean**2)
-            )
-            num_b = (
-                2
-                * theta
-                * self.stat_a.covariance
-                * const
-                / self.stat_a.post_statistic.mean
-            )
-            num_c = theta**2 * self.stat_a.pre_statistic.variance
-            v_ctrl = (num_a + num_b + num_c) / den_ctrl
-            return v_trt + v_ctrl
+            return frequentist_variance_relative_cuped(self.stat_a, self.stat_b)
         else:
             return frequentist_variance(
                 self.stat_a.variance,

--- a/packages/stats/gbstats/models/tests.py
+++ b/packages/stats/gbstats/models/tests.py
@@ -46,7 +46,16 @@ class BaseABTest(ABC):
     ):
         self.stat_a = stat_a
         self.stat_b = stat_b
-
+        if isinstance(stat_a, RegressionAdjustedStatistic):
+            if not isinstance(stat_b, RegressionAdjustedStatistic):
+                raise ValueError(
+                    "If stat_a is a RegressionAdjustedStatistic, stat_b must be as well"
+                )
+        if isinstance(stat_b, RegressionAdjustedStatistic):
+            if not isinstance(stat_a, RegressionAdjustedStatistic):
+                raise ValueError(
+                    "If stat_b is a RegressionAdjustedStatistic, stat_a must be as well"
+                )
         # Ensure theta is set for regression adjusted statistics
         if (
             isinstance(self.stat_b, RegressionAdjustedStatistic)

--- a/packages/stats/tests/test_gbstats.py
+++ b/packages/stats/tests/test_gbstats.py
@@ -730,7 +730,7 @@ class TestAnalyzeMetricDfRegressionAdjustment(TestCase):
         self.assertEqual(result.at[0, "v1_risk"], None)
         self.assertEqual(round_(result.at[0, "v1_expected"]), -0.281707154)
         self.assertEqual(result.at[0, "v1_prob_beat_baseline"], None)
-        self.assertEqual(round_(result.at[0, "v1_p_value"]), 0.003736297)
+        self.assertEqual(round_(result.at[0, "v1_p_value"]), 0.003732549)
         # But difference is not just DIM / control mean, like it used to be
         self.assertNotEqual(
             np.round(result.at[0, "v1_expected"], 3),
@@ -763,7 +763,7 @@ class TestAnalyzeMetricDfRegressionAdjustment(TestCase):
         self.assertEqual(result.at[0, "v1_risk"], None)
         self.assertEqual(round_(result.at[0, "v1_expected"]), -0.316211568)
         self.assertEqual(result.at[0, "v1_prob_beat_baseline"], None)
-        self.assertEqual(round_(result.at[0, "v1_p_value"]), 0.00000035)
+        self.assertEqual(round_(result.at[0, "v1_p_value"]), 0.000000352)
 
 
 class TestAnalyzeMetricDfSequential(TestCase):


### PR DESCRIPTION
### Features and Changes

Currently the in-production CUPED estimate of variance is wrong for relative case.  While numerically it is close to the true value in many cases, when the variance of the post-exposure metric is small, in-production variance estimates are too small, resulting in undercoverage (i.e., 95% confidence intervals do not capture the true lift 95% of the time).  

This change produces accurate variance estimates, and updates the docs with a derivation from first principles.  


### Testing

tested offline using notebook in simulation study

### Screenshots
for demo experiment, lift confidence intervals on the UI were unchanged for revenue


<img width="1728" alt="cuped_update" src="https://github.com/user-attachments/assets/49acded5-8932-4d4e-b31a-2bed6eb0d1ff" />

<img width="1728" alt="cuped_main" src="https://github.com/user-attachments/assets/68169393-0bcd-4565-aa15-80aee3f9d80c" />
