### PR TITLE
Remove upper bound on pagination offset

### DIFF
--- a/packages/back-end/src/util/handler.ts
+++ b/packages/back-end/src/util/handler.ts
@@ -237,7 +237,7 @@ export function applyPagination<T>(
   if (isNaN(limit) || limit < 1 || limit > 100) {
     throw new Error("Pagination limit must be between 1 and 100");
   }
-  if (isNaN(offset) || offset < 0 || (offset > 0 && offset >= items.length)) {
+  if (isNaN(offset) || offset < 0) {
     throw new Error("Invalid pagination offset");
   }
 


### PR DESCRIPTION
### Features and Changes

Removes the pagination check that `offset` is below the total number of items being paginated so that automated API requests don't fail when trying to pull the next page if `totalCount % limit === 0`

Example:
Imagine the API requests made to list a collection `items` with 10 members and a page limit of 10:
1. `/items?limit=10&offset=0` returns all items (and `hasMore: false` but this may be ignored)
2. `/items?limit=10&offset=10` throws an error currently

### Testing

Sanity checked a list endpoint and passed `offset` > the number of items

### Screenshots

![image](https://github.com/user-attachments/assets/4845d9db-8439-4e15-9882-46e1bd9a4746)
