### PR TITLE
only show the setup flow/hide the add feature button, in the empty state

### DIFF
--- a/packages/front-end/pages/features/index.tsx
+++ b/packages/front-end/pages/features/index.tsx
@@ -507,7 +507,7 @@ export default function FeaturesPage() {
     return <LoadingOverlay />;
   }
 
-  // If "All Projects" is selected is selected and some experiments are in a project, show the project column
+  // If "All Projects" is selected and some experiments are in a project, show the project column
   const showProjectColumn = !project && allFeatures.some((f) => f.project);
 
   // Ignore the demo datasource
@@ -528,6 +528,7 @@ export default function FeaturesPage() {
     });
 
   const showSetUpFlow =
+    !hasFeatures &&
     canUseSetupFlow &&
     sdkConnectionData &&
     (sdkConnectionData.connections.length === 0 ||


### PR DESCRIPTION
### Features and Changes

If someone's sdk connection has "connected": "false" then we were hiding the "Add Feature" thinking that they should be shown the setup button.  I'm not sure why people have a production sdk that they have been using for years with a connected: false state, but at any rate we only show the setup flow button in the empty state.  So we should only hide the add feature button in the empty state as well.

### Testing

Create a new org
Create an sdk connection
Create a feature
Delete the sdk connection
Go to the features page and see the add feature button still.
