### PR TITLE
Fix telemetry race condition and de-duping logic

### DIFF
--- a/packages/sdk-js/src/plugins/growthbook-tracking.ts
+++ b/packages/sdk-js/src/plugins/growthbook-tracking.ts
@@ -5,6 +5,7 @@ import type {
   GrowthBookClient,
   UserScopedGrowthBook,
 } from "../GrowthBookClient";
+import { EVENT_EXPERIMENT_VIEWED, EVENT_FEATURE_EVALUATED } from "../core";
 
 const SDK_VERSION = loadSDKVersion();
 
@@ -138,15 +139,19 @@ async function track({
   const body = JSON.stringify(events);
 
   try {
-    await fetch(endpoint, {
-      method: "POST",
-      body,
-      headers: {
-        Accept: "application/json",
-        "Content-Type": "text/plain",
-      },
-      credentials: "omit",
-    });
+    if (typeof navigator !== "undefined" && "sendBeacon" in navigator) {
+      navigator.sendBeacon(endpoint, body);
+    } else {
+      await fetch(endpoint, {
+        method: "POST",
+        body,
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "text/plain",
+        },
+        credentials: "omit",
+      });
+    }
   } catch (e) {
     console.error("Failed to track event", e);
   }
@@ -185,9 +190,9 @@ export function growthbookTrackingPlugin({
       const flush = async () => {
         const events = _q;
         _q = [];
-        events.length && (await track({ clientKey, events, ingestorHost }));
         timer && clearTimeout(timer);
         timer = null;
+        events.length && (await track({ clientKey, events, ingestorHost }));
       };
 
       let promise: Promise<void> | null = null;
@@ -204,27 +209,34 @@ export function growthbookTrackingPlugin({
           return;
         }
 
-        // Build the key for de-duping
-        const dedupeKeyData: Record<string, unknown> = {
-          eventName,
-          properties,
-        };
-        for (const key of dedupeKeyAttributes) {
-          dedupeKeyData["attr:" + key] = data.attributes[key];
-        }
+        // De-dupe Feature Evaluated and Experiment Viewed events
+        if (
+          eventName === EVENT_FEATURE_EVALUATED ||
+          eventName === EVENT_EXPERIMENT_VIEWED
+        ) {
+          // Build the key for de-duping
+          const dedupeKeyData: Record<string, unknown> = {
+            eventName,
+            properties,
+          };
+          for (const key of dedupeKeyAttributes) {
+            dedupeKeyData["attr:" + key] = data.attributes[key];
+          }
 
-        const k = JSON.stringify(dedupeKeyData);
-        // Duplicate event fired recently, move to end of LRU cache and skip
-        if (eventCache.has(k)) {
-          eventCache.delete(k);
+          const k = JSON.stringify(dedupeKeyData);
+          // Duplicate event fired recently, move to end of LRU cache and skip
+          if (eventCache.has(k)) {
+            eventCache.delete(k);
+            eventCache.add(k);
+            return;
+          }
           eventCache.add(k);
-          return;
-        }
-        eventCache.add(k);
-        // If the cache is too big, remove the oldest item
-        if (eventCache.size > dedupeCacheSize) {
-          const oldest = eventCache.values().next().value;
-          oldest && eventCache.delete(oldest);
+
+          // If the cache is too big, remove the oldest item
+          if (eventCache.size > dedupeCacheSize) {
+            const oldest = eventCache.values().next().value;
+            oldest && eventCache.delete(oldest);
+          }
         }
 
         const payload = getEventPayload(data);

--- a/packages/sdk-js/test/plugins/growthbook-tracking.test.ts
+++ b/packages/sdk-js/test/plugins/growthbook-tracking.test.ts
@@ -1,5 +1,10 @@
 import { growthbookTrackingPlugin } from "../../src/plugins/growthbook-tracking";
-import { GrowthBook, GrowthBookClient } from "../../src";
+import {
+  EVENT_EXPERIMENT_VIEWED,
+  EVENT_FEATURE_EVALUATED,
+  GrowthBook,
+  GrowthBookClient,
+} from "../../src";
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -84,6 +89,34 @@ describe("growthbookTrackingPlugin", () => {
     gb.destroy();
   });
 
+  it("Can track multiple events without a race condition", async () => {
+    // Make the fetch call take 100ms
+    fetchMock.mockImplementation(async () => {
+      await sleep(100);
+    });
+
+    const plugin = growthbookTrackingPlugin({
+      queueFlushInterval: 100,
+    });
+    const gb = new GrowthBook({
+      clientKey: "test",
+      plugins: [plugin],
+    });
+
+    gb.logEvent("test");
+    await sleep(150);
+
+    // By now, the first fetch should be in-flight
+    // New events should get queued for the next fetch
+    gb.logEvent("test2");
+
+    // Wait for both fetches to finish
+    await sleep(225);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    gb.destroy();
+  });
+
   it("Can be disabled and debugged", async () => {
     const plugin = growthbookTrackingPlugin({
       debug: true,
@@ -126,7 +159,7 @@ describe("growthbookTrackingPlugin", () => {
     gb.destroy();
   });
 
-  it("Skips logging duplicate events", async () => {
+  it("Skips logging duplicate Feature Evaluted events", async () => {
     const plugin = growthbookTrackingPlugin();
 
     const gb = new GrowthBook({
@@ -138,38 +171,37 @@ describe("growthbookTrackingPlugin", () => {
       },
     });
 
-    gb.logEvent("test");
-    gb.logEvent("test");
-    gb.logEvent("test2");
+    // Skips feature evalutead events with the same properties
+    gb.logEvent(EVENT_FEATURE_EVALUATED, { foo: "bar" });
+    gb.logEvent(EVENT_FEATURE_EVALUATED, { foo: "bar" });
+    gb.logEvent(EVENT_FEATURE_EVALUATED, { foo: "baz" });
 
     await sleep(150);
     let body = JSON.parse(fetchMock.mock.calls[0][1].body);
     expect(body.length).toBe(2);
-    expect(body[0].event_name).toBe("test");
-    expect(body[1].event_name).toBe("test2");
+    expect(body[0].properties_json).toEqual({ foo: "bar" });
+    expect(body[1].properties_json).toEqual({ foo: "baz" });
 
-    // Also skips events with duplicate properties
-    gb.logEvent("test", { foo: "bar" });
-    gb.logEvent("test", { foo: "bar" });
-    gb.logEvent("test", { foo: "baz" });
+    // Also skips experiment viewed events with the same properties
+    gb.logEvent(EVENT_EXPERIMENT_VIEWED, { foo: "bar" });
+    gb.logEvent(EVENT_EXPERIMENT_VIEWED, { foo: "bar" });
+    gb.logEvent(EVENT_EXPERIMENT_VIEWED, { foo: "baz" });
 
     await sleep(150);
     body = JSON.parse(fetchMock.mock.calls[1][1].body);
     expect(body.length).toBe(2);
-    expect(body[0].event_name).toBe("test");
     expect(body[0].properties_json).toEqual({ foo: "bar" });
-    expect(body[1].event_name).toBe("test");
     expect(body[1].properties_json).toEqual({ foo: "baz" });
 
     // Skips the fetch entirely if there are no new events to log
-    gb.logEvent("test");
+    gb.logEvent(EVENT_FEATURE_EVALUATED, { foo: "bar" });
     await sleep(150);
     expect(fetchMock).toHaveBeenCalledTimes(2);
 
     // De-dupe ignores url and attribute changes by default
     gb.updateAttributes({ foo: "baz" });
     gb.setURL("http://localhost:3001");
-    gb.logEvent("test");
+    gb.logEvent(EVENT_FEATURE_EVALUATED, { foo: "bar" });
     await sleep(150);
     expect(fetchMock).toHaveBeenCalledTimes(2);
 
@@ -191,25 +223,25 @@ describe("growthbookTrackingPlugin", () => {
       },
     });
 
-    gb.logEvent("test");
+    gb.logEvent(EVENT_FEATURE_EVALUATED);
     await sleep(150);
     expect(fetchMock).toHaveBeenCalledTimes(1);
 
     // If a key attribute changes, it should not be considered a duplicate
     gb.updateAttributes({ foo: "baz" });
-    gb.logEvent("test");
+    gb.logEvent(EVENT_FEATURE_EVALUATED);
     await sleep(150);
     expect(fetchMock).toHaveBeenCalledTimes(2);
 
     // If a non-key attribute changes, it should be considered a duplicate
     gb.updateAttributes({ bar: "qux" });
-    gb.logEvent("test");
+    gb.logEvent(EVENT_FEATURE_EVALUATED);
     await sleep(150);
     expect(fetchMock).toHaveBeenCalledTimes(2);
 
     // If a key attribute changes back, it should be considered a duplicate again
     gb.updateAttributes({ foo: "bar" });
-    gb.logEvent("test");
+    gb.logEvent(EVENT_FEATURE_EVALUATED);
     await sleep(150);
     expect(fetchMock).toHaveBeenCalledTimes(2);
 
@@ -279,6 +311,30 @@ describe("growthbookTrackingPlugin", () => {
     gb2.destroy();
   });
 
+  it("does not de-dupe custom events", async () => {
+    const plugin = growthbookTrackingPlugin();
+
+    const gb = new GrowthBook({
+      clientKey: "test",
+      plugins: [plugin],
+      url: "http://localhost:3000",
+      attributes: {
+        foo: "bar",
+      },
+    });
+
+    gb.logEvent("custom");
+    gb.logEvent("custom");
+    gb.logEvent("custom", { foo: "bar" });
+    gb.logEvent("custom", { foo: "bar" });
+
+    await sleep(150);
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.length).toBe(4);
+
+    gb.destroy();
+  });
+
   it("works for GrowthBookClient and user-scoped instances", async () => {
     const plugin = growthbookTrackingPlugin({
       dedupeKeyAttributes: ["id"],
@@ -292,25 +348,25 @@ describe("growthbookTrackingPlugin", () => {
     const userContext = { attributes: { id: "123" } };
 
     // Global logged event with user context
-    gb.logEvent("test", {}, userContext);
+    gb.logEvent(EVENT_FEATURE_EVALUATED, {}, userContext);
 
     await sleep(150);
     expect(fetchMock).toHaveBeenCalledTimes(1);
 
     // De-dupe
-    gb.logEvent("test", {}, userContext);
+    gb.logEvent(EVENT_FEATURE_EVALUATED, {}, userContext);
     await sleep(150);
     expect(fetchMock).toHaveBeenCalledTimes(1);
 
     // User-scoped logged event
     const gb2 = gb.createScopedInstance({ attributes: { id: "456" } });
-    gb2.logEvent("test");
+    gb2.logEvent(EVENT_FEATURE_EVALUATED);
 
     await sleep(150);
     expect(fetchMock).toHaveBeenCalledTimes(2);
 
     // De-dupe
-    gb2.logEvent("test");
+    gb2.logEvent(EVENT_FEATURE_EVALUATED);
     await sleep(150);
     expect(fetchMock).toHaveBeenCalledTimes(2);
 


### PR DESCRIPTION
### Features and Changes

- Revert the change in #3625 since that was not the issue
- Fix a race condition with multiple events logged in close proximity
- Changed de-duping to only happen for built-in events (`Feature Evaluted` and `Experiment Viewed`)