### PR TITLE
Switch back to fetch again

### DIFF
--- a/packages/sdk-js/src/plugins/growthbook-tracking.ts
+++ b/packages/sdk-js/src/plugins/growthbook-tracking.ts
@@ -139,19 +139,15 @@ async function track({
   const body = JSON.stringify(events);
 
   try {
-    if (typeof navigator !== "undefined" && "sendBeacon" in navigator) {
-      navigator.sendBeacon(endpoint, body);
-    } else {
-      await fetch(endpoint, {
-        method: "POST",
-        body,
-        headers: {
-          Accept: "application/json",
-          "Content-Type": "text/plain",
-        },
-        credentials: "omit",
-      });
-    }
+    await fetch(endpoint, {
+      method: "POST",
+      body,
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "text/plain",
+      },
+      credentials: "omit",
+    });
   } catch (e) {
     console.error("Failed to track event", e);
   }


### PR DESCRIPTION
### Features and Changes

Once again switch from `navigator.sendBeacon` to `fetch` to try and reduce the number of failed network calls