### PR TITLE
Still allow adding a feature when there are no connected SDKs

### DIFF
--- a/packages/front-end/pages/features/index.tsx
+++ b/packages/front-end/pages/features/index.tsx
@@ -531,8 +531,7 @@ export default function FeaturesPage() {
     !hasFeatures &&
     canUseSetupFlow &&
     sdkConnectionData &&
-    (sdkConnectionData.connections.length === 0 ||
-      !sdkConnectionData.connections[0].connected);
+    !sdkConnectionData.connections.length;
 
   const toggleEnvs = environments.filter((en) => en.toggleOnList);
   const showArchivedToggle = hasArchived;

--- a/packages/front-end/pages/getstarted.tsx
+++ b/packages/front-end/pages/getstarted.tsx
@@ -50,8 +50,7 @@ const GetStartedPage = (): React.ReactElement => {
   const showSetUpFlow =
     canUseSetupFlow &&
     sdkConnectionData &&
-    (sdkConnectionData.connections.length === 0 ||
-      !sdkConnectionData.connections[0].connected);
+    !sdkConnectionData.connections.some((c) => c.connected);
 
   // If they view the guide, clear the current step
   useEffect(() => {


### PR DESCRIPTION
### Features and Changes

Two fixes:
1. Don't take into account the `conntected` status of SDKs when determining whether or not to show the "Add Feature" button.  As long as there's at least 1 SDK, allow it whether or not it's been verified to be connected.
2. Fix logic bug on Get Started page that was showing the setup callout even after an org has completed the setup.