### PR TITLE
Fix css on rule dropdown

### DIFF
--- a/packages/front-end/components/Features/Rule.tsx
+++ b/packages/front-end/components/Features/Rule.tsx
@@ -288,7 +288,7 @@ export const Rule = forwardRef<HTMLDivElement, RuleProps>(
                   )}
                 </Box>
               </Box>
-              <Box>
+              <Flex>
                 {featureUsage && (
                   <div className="ml-auto">
                     <FeatureUsageGraph
@@ -395,7 +395,7 @@ export const Rule = forwardRef<HTMLDivElement, RuleProps>(
                     />
                   </MoreMenu>
                 )}
-              </Box>
+              </Flex>
             </Flex>
           </Card>
         </Box>


### PR DESCRIPTION
### Features and Changes

The three dot menu was appearing in the wrong place when there was a feature usage graph showing.

### Screenshots

Before:
![Screenshot 2025-02-10 at 3 53 09 PM](https://github.com/user-attachments/assets/f4c3ee53-6b35-45ac-bdba-ca5d76d0dadd)

After:
![Screenshot 2025-02-10 at 3 52 53 PM](https://github.com/user-attachments/assets/c95bb575-6d97-467e-beb4-2919ceaacef4)

