### PR TITLE
Fix styling bugs on experiment setup tab

### DIFF
--- a/packages/front-end/components/Experiment/PreLaunchChecklist.tsx
+++ b/packages/front-end/components/Experiment/PreLaunchChecklist.tsx
@@ -117,7 +117,7 @@ export function getChecklistItems({
           {openSetupTab &&
           ((isBandit && !hasLiveLinkedChanges) ||
             (!isBandit && hasLinkedChanges)) ? (
-            <a className="a" role="button" onClick={openSetupTab}>
+            <a className="a link-purple" role="button" onClick={openSetupTab}>
               Linked Feature or Visual Editor change
             </a>
           ) : (
@@ -140,7 +140,7 @@ export function getChecklistItems({
           <>
             {setAnalysisModal ? (
               <a
-                className="a"
+                className="a link-purple"
                 role="button"
                 onClick={() => setAnalysisModal(true)}
               >
@@ -175,7 +175,7 @@ export function getChecklistItems({
           <>
             Publish and enable all{" "}
             {openSetupTab ? (
-              <a className="a" role="button" onClick={openSetupTab}>
+              <a className="a link-purple" role="button" onClick={openSetupTab}>
                 Linked Feature
               </a>
             ) : (
@@ -198,7 +198,7 @@ export function getChecklistItems({
           <>
             Add changes in the{" "}
             {openSetupTab ? (
-              <a className="a" role="button" onClick={openSetupTab}>
+              <a className="a link-purple" role="button" onClick={openSetupTab}>
                 Visual Editor
               </a>
             ) : (
@@ -222,7 +222,7 @@ export function getChecklistItems({
       <>
         {editTargeting ? (
           <a
-            className="a"
+            className="a link-purple"
             role="button"
             onClick={() => {
               editTargeting();
@@ -253,7 +253,11 @@ export function getChecklistItems({
         {!setShowSdkForm && !verifiedConnections ? (
           <Link href="/sdks">Manage SDK Connections</Link>
         ) : connections.length === 0 && setShowSdkForm ? (
-          <a className="a" role="button" onClick={() => setShowSdkForm(true)}>
+          <a
+            className="a link-purple"
+            role="button"
+            onClick={() => setShowSdkForm(true)}
+          >
             Add SDK Connection
           </a>
         ) : null}
@@ -441,7 +445,7 @@ export function PreLaunchChecklistUI({
   const contents = !data ? (
     <LoadingSpinner />
   ) : (
-    <div>
+    <div className="pt-2">
       {checklist.map((item, i) => (
         <div key={i} className="mb-2">
           <Checkbox
@@ -487,7 +491,7 @@ export function PreLaunchChecklistUI({
 
   const header = (
     <div className="d-flex flex-row align-items-center justify-content-between text-dark">
-      <h4>
+      <h4 className="mb-0">
         {title}{" "}
         {data && checklistItemsRemaining !== null ? (
           <span

--- a/packages/front-end/components/Experiment/TabbedPage/SetupTabOverview.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/SetupTabOverview.tsx
@@ -109,12 +109,7 @@ export default function SetupTabOverview({
                   cursor: `${experiment.description ? "pointer" : "default"}`,
                 }}
               >
-                <Flex
-                  align="center"
-                  justify="between"
-                  pb="2"
-                  className="text-dark"
-                >
+                <Flex align="center" justify="between" className="text-dark">
                   <h4 className="m-0">Description</h4>
                   <Flex align="center">
                     {canEditExperiment ? (


### PR DESCRIPTION
### Features and Changes

There have been some sweeping UI changes, and I beleive as a result there were a few small padding/margin issues on the Experiment Setup Tab's `Pre-Launch Checklist` and `Experiment Description` sections.

This PR addresses those, while also updates the `<a>` tags within the `Pre-Launch Checklist` to use the `purple-link` utility class.

Before: (Notice the misalignment of the title and the open/close carrot when closed)
![Screenshot 2025-02-10 at 11 15 26 AM](https://github.com/user-attachments/assets/aad2fa1c-9bf1-45fd-9704-01f6a5ca51b6)
![Screenshot 2025-02-10 at 11 15 34 AM](https://github.com/user-attachments/assets/e7b5bc7f-caab-4ad1-a11d-e15bae987cc5)


After:
![Screenshot 2025-02-10 at 11 09 28 AM](https://github.com/user-attachments/assets/ddb3b7b4-5e0f-4cf8-a3af-f2b45ac47422)
![Screenshot 2025-02-10 at 11 09 21 AM](https://github.com/user-attachments/assets/7c98c660-5cf1-40fe-b797-96ab97279c12)


### Testing

- See screenshots above
