### PR TITLE
Add CUPED statistics for ratio metrics to gbstats

### DIFF
--- a/packages/stats/gbstats/bayesian/tests.py
+++ b/packages/stats/gbstats/bayesian/tests.py
@@ -18,11 +18,13 @@ from gbstats.models.statistics import (
     ProportionStatistic,
     SampleMeanStatistic,
     RegressionAdjustedStatistic,
+    RegressionAdjustedRatioStatistic,
 )
 from gbstats.frequentist.tests import (
     frequentist_diff,
     frequentist_variance,
     frequentist_variance_relative_cuped,
+    frequentist_variance_relative_cuped_ratio,
 )
 from gbstats.utils import (
     truncated_normal_mean,
@@ -182,6 +184,14 @@ class EffectBayesianABTest(BayesianABTest):
             and self.relative
         ):
             data_variance = frequentist_variance_relative_cuped(
+                self.stat_a, self.stat_b
+            )
+        elif (
+            isinstance(self.stat_a, RegressionAdjustedRatioStatistic)
+            and isinstance(self.stat_b, RegressionAdjustedRatioStatistic)
+            and self.relative
+        ):
+            data_variance = frequentist_variance_relative_cuped_ratio(
                 self.stat_a, self.stat_b
             )
         else:

--- a/packages/stats/gbstats/frequentist/tests.py
+++ b/packages/stats/gbstats/frequentist/tests.py
@@ -16,6 +16,7 @@ from gbstats.models.statistics import (
     TestStatistic,
     ScaledImpactStatistic,
     RegressionAdjustedStatistic,
+    RegressionAdjustedRatioStatistic,
 )
 from gbstats.models.tests import BaseABTest, BaseConfig, TestResult, Uplift
 from gbstats.utils import variance_of_ratios, isinstance_union
@@ -80,6 +81,37 @@ def frequentist_variance_relative_cuped(
     return v_trt + v_ctrl
 
 
+def frequentist_variance_relative_cuped_ratio(
+    stat_a: RegressionAdjustedRatioStatistic, stat_b: RegressionAdjustedRatioStatistic
+) -> float:
+    if stat_a.unadjusted_mean == 0 or stat_a.d_statistic_post.mean == 0:
+        return 0  # avoid division by zero
+    g_abs = stat_b.mean - stat_a.mean
+    g_rel_den = np.abs(stat_a.unadjusted_mean)
+    nabla_ctrl_0_num = -(g_rel_den + g_abs) / stat_a.d_statistic_post.mean
+    nabla_ctrl_0_den = g_rel_den**2
+    nabla_ctrl_0 = nabla_ctrl_0_num / nabla_ctrl_0_den
+    nabla_ctrl_1_num = (
+        stat_a.m_statistic_post.mean * g_rel_den / stat_a.d_statistic_post.mean**2
+        + stat_a.m_statistic_post.mean * g_abs / stat_a.d_statistic_post.mean**2
+    )
+    nabla_ctrl_1_den = g_rel_den**2
+    nabla_ctrl_1 = nabla_ctrl_1_num / nabla_ctrl_1_den
+    nabla_a = np.array(
+        [
+            nabla_ctrl_0,
+            nabla_ctrl_1,
+            -stat_a.nabla[2] / g_rel_den,
+            -stat_a.nabla[3] / g_rel_den,
+        ]
+    )
+    nabla_b = stat_b.nabla / g_rel_den
+    return (
+        nabla_a.T.dot(stat_a.lambda_matrix).dot(nabla_a) / stat_a.n
+        + nabla_b.T.dot(stat_b.lambda_matrix).dot(nabla_b) / stat_b.n
+    )
+
+
 class TTest(BaseABTest):
     def __init__(
         self,
@@ -113,6 +145,12 @@ class TTest(BaseABTest):
             and self.relative
         ):
             return frequentist_variance_relative_cuped(self.stat_a, self.stat_b)
+        elif (
+            isinstance(self.stat_a, RegressionAdjustedRatioStatistic)
+            and isinstance(self.stat_b, RegressionAdjustedRatioStatistic)
+            and self.relative
+        ):
+            return frequentist_variance_relative_cuped_ratio(self.stat_a, self.stat_b)
         else:
             return frequentist_variance(
                 self.stat_a.variance,

--- a/packages/stats/gbstats/models/statistics.py
+++ b/packages/stats/gbstats/models/statistics.py
@@ -282,7 +282,7 @@ class RegressionAdjustedRatioStatistic(Statistic):
         return self.nabla[2:4].T.dot(self.lambda_matrix[2:4, 2:4]).dot(self.nabla[2:4])
 
     @property
-    def covariance(self):
+    def covariance(self) -> float:
         if self.n <= 1:
             return 0
         return self.nabla[2:4].T.dot(self.lambda_matrix[2:4, 0:2]).dot(self.nabla[0:2])

--- a/packages/stats/gbstats/models/statistics.py
+++ b/packages/stats/gbstats/models/statistics.py
@@ -273,10 +273,10 @@ class RegressionAdjustedRatioStatistic(Statistic):
             return 0
         return variance_of_ratios(
             self.mean_m_y,
-            self.var_m_y / self.n,
+            self.var_m_y,
             self.mean_d_y,
-            self.var_d_y / self.n,
-            self.cov_m_y_d_y / self.n,
+            self.var_d_y,
+            self.cov_m_y_d_y,
         )
 
     @property
@@ -285,10 +285,10 @@ class RegressionAdjustedRatioStatistic(Statistic):
             return 0
         return variance_of_ratios(
             self.mean_m_x,
-            self.var_m_x / self.n,
+            self.var_m_x,
             self.mean_d_x,
-            self.var_d_x / self.n,
-            self.cov_m_x_d_x / self.n,
+            self.var_d_x,
+            self.cov_m_x_d_x,
         )
 
     # take cross_cov here
@@ -373,36 +373,33 @@ class RegressionAdjustedRatioStatistic(Statistic):
 
     @property
     def lambda_full(self):
-        return (
-            np.array(
+        return np.array(
+            [
                 [
-                    [
-                        self.var_m_y,
-                        self.cov_m_y_d_y,
-                        self.cov_m_y_m_x,
-                        self.cov_m_y_d_x,
-                    ],
-                    [
-                        self.cov_m_y_d_y,
-                        self.var_d_y,
-                        self.cov_d_y_m_x,
-                        self.cov_d_y_d_x,
-                    ],
-                    [
-                        self.cov_m_y_m_x,
-                        self.cov_d_y_m_x,
-                        self.var_m_x,
-                        self.cov_m_x_d_x,
-                    ],
-                    [
-                        self.cov_m_y_d_x,
-                        self.cov_d_y_d_x,
-                        self.cov_m_x_d_x,
-                        self.var_d_x,
-                    ],
-                ]
-            )
-            / self.n
+                    self.var_m_y,
+                    self.cov_m_y_d_y,
+                    self.cov_m_y_m_x,
+                    self.cov_m_y_d_x,
+                ],
+                [
+                    self.cov_m_y_d_y,
+                    self.var_d_y,
+                    self.cov_d_y_m_x,
+                    self.cov_d_y_d_x,
+                ],
+                [
+                    self.cov_m_y_m_x,
+                    self.cov_d_y_m_x,
+                    self.var_m_x,
+                    self.cov_m_x_d_x,
+                ],
+                [
+                    self.cov_m_y_d_x,
+                    self.cov_d_y_d_x,
+                    self.cov_m_x_d_x,
+                    self.var_d_x,
+                ],
+            ]
         )
 
     @property

--- a/packages/stats/gbstats/models/statistics.py
+++ b/packages/stats/gbstats/models/statistics.py
@@ -224,8 +224,8 @@ def create_joint_statistic(
 @dataclass
 class RegressionAdjustedRatioStatistic(Statistic):
     m_statistic_post: Union[SampleMeanStatistic, ProportionStatistic]
-    m_statistic_pre: Union[SampleMeanStatistic, ProportionStatistic]
     d_statistic_post: Union[SampleMeanStatistic, ProportionStatistic]
+    m_statistic_pre: Union[SampleMeanStatistic, ProportionStatistic]
     d_statistic_pre: Union[SampleMeanStatistic, ProportionStatistic]
     m_post_m_pre_sum_of_products: float
     d_post_d_pre_sum_of_products: float
@@ -376,10 +376,10 @@ class RegressionAdjustedRatioStatistic(Statistic):
             ]
         )
 
+    # vector of partial derivatives for the absolute case
     @property
     def nabla(self):
         theta = self.theta if self.theta else 0
-        # later figure out best place for check that not dividing by 0
         return np.array(
             [
                 1 / self.betahat[1],
@@ -425,9 +425,12 @@ class RegressionAdjustedRatioStatistic(Statistic):
 def compute_theta_regression_adjusted_ratio(
     a: RegressionAdjustedRatioStatistic, b: RegressionAdjustedRatioStatistic
 ) -> float:
+    # set theta equal to 1, so the partial derivatives are unaffected by theta
+    a.theta = 1
+    b.theta = 1
     if a.var_x + b.var_x == 0:
         return 0
-    return (a.covariance + b.covariance) / (a.var_x + b.var_x)
+    return -(a.covariance + b.covariance) / (a.var_x + b.var_x)
 
 
 @dataclass

--- a/packages/stats/gbstats/models/tests.py
+++ b/packages/stats/gbstats/models/tests.py
@@ -5,8 +5,11 @@ from pydantic.dataclasses import dataclass
 
 from gbstats.models.statistics import (
     RegressionAdjustedStatistic,
+    RegressionAdjustedRatioStatistic,
+    RatioStatistic,
     TestStatistic,
     compute_theta,
+    compute_theta_regression_adjusted_ratio,
 )
 from gbstats.models.settings import DifferenceType
 
@@ -67,6 +70,30 @@ class BaseABTest(ABC):
                 # revert to non-RA under the hood if no variance in a time period
                 self.stat_a = self.stat_a.post_statistic
                 self.stat_b = self.stat_b.post_statistic
+            else:
+                self.stat_a.theta = theta
+                self.stat_b.theta = theta
+
+        if (
+            isinstance(self.stat_b, RegressionAdjustedRatioStatistic)
+            and isinstance(self.stat_a, RegressionAdjustedRatioStatistic)
+            and (self.stat_a.theta is None or self.stat_b.theta is None)
+        ):
+            theta = compute_theta_regression_adjusted_ratio(self.stat_a, self.stat_b)
+            if theta == 0:
+                # revert to non-RA under the hood if no variance in a time period
+                self.stat_a = RatioStatistic(
+                    n=self.stat_a.n,
+                    m_statistic=self.stat_a.m_statistic_post,
+                    d_statistic=self.stat_a.d_statistic_post,
+                    m_d_sum_of_products=self.stat_a.m_post_d_post_sum_of_products,
+                )
+                self.stat_b = RatioStatistic(
+                    n=self.stat_b.n,
+                    m_statistic=self.stat_b.m_statistic_post,
+                    d_statistic=self.stat_b.d_statistic_post,
+                    m_d_sum_of_products=self.stat_b.m_post_d_post_sum_of_products,
+                )
             else:
                 self.stat_a.theta = theta
                 self.stat_b.theta = theta


### PR DESCRIPTION
### Features and Changes

Currently CUPED is unavailable for ratio metrics.  This PR adds the functionality.  

### Dependencies

None
### Testing

Unit tests still need to be added, interval coverage and mean squared error improvements were assessed via simulation study.  

TODO:
1. update SQL
2. update gbstats.py to permit ratio CUPED
3. update BE to enable ratio CUPED