### PR TITLE
[bugfix] Allow undefined project stats engine to inherit org default

### DIFF
--- a/packages/back-end/src/models/ProjectModel.ts
+++ b/packages/back-end/src/models/ProjectModel.ts
@@ -1,13 +1,11 @@
-import { DEFAULT_STATS_ENGINE } from "shared/constants";
 import { z } from "zod";
 import { ApiProject } from "back-end/types/openapi";
 import { statsEngines } from "back-end/src/util/constants";
 import { baseSchema, MakeModelClass } from "./BaseModel";
-
 export const statsEnginesValidator = z.enum(statsEngines);
 
 export const projectSettingsValidator = z.object({
-  statsEngine: statsEnginesValidator.default(DEFAULT_STATS_ENGINE).optional(),
+  statsEngine: statsEnginesValidator.optional(),
 });
 
 export const projectValidator = baseSchema
@@ -64,7 +62,6 @@ export class ProjectModel extends BaseClass {
 
   protected migrate(doc: MigratedProject) {
     const settings = {
-      statsEngine: DEFAULT_STATS_ENGINE,
       ...(doc.settings || {}),
     };
 
@@ -98,7 +95,7 @@ export class ProjectModel extends BaseClass {
       dateCreated: project.dateCreated.toISOString(),
       dateUpdated: project.dateUpdated.toISOString(),
       settings: {
-        statsEngine: project.settings?.statsEngine || DEFAULT_STATS_ENGINE,
+        statsEngine: project.settings?.statsEngine,
       },
     };
   }

--- a/packages/front-end/pages/project/[pid].tsx
+++ b/packages/front-end/pages/project/[pid].tsx
@@ -181,7 +181,7 @@ const ProjectPage: FC = () => {
               <StatsEngineSelect
                 value={form.watch("statsEngine")}
                 onChange={(v) => {
-                  form.setValue("statsEngine", v);
+                  form.setValue("statsEngine", v || undefined);
                 }}
                 label="Default Statistics Engine"
                 parentSettings={parentSettings}


### PR DESCRIPTION
### Features and Changes

Allows project setting for stats engine to be undefined, so it will inherit the org setting properly.

**warning:** any org that has saved "Frequentist" as their org setting, and has created projects and not changed the project stats engine to frequentist, may have experiments analyzed with the bayesian engine switched automatically to "Frequentist". This is the desired behavior, but it could cause a change in some prod experiment analyses

https://www.loom.com/share/d0229a1c14c64af78ca368bfb7950b4d
