### PR TITLE
[bugfix] Fix remote evaluation by adding missing await (#3654)

### DIFF
--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -381,7 +381,7 @@ export async function getEvaluatedFeaturesPublic(req: Request, res: Response) {
     res.set("Cache-control", "no-store");
 
     // todo: don't use link. investigate why clicking through returns the stub only.
-    const payload = evaluateFeatures({
+    const payload = await evaluateFeatures({
       payload: defs,
       attributes,
       forcedVariations,


### PR DESCRIPTION
### Features and Changes

Fixed remote feature evaluation in self-hosted backend by adding missing `await` keyword to `evaluateFeatures `call in `getEvaluatedFeaturesPublic` controller. Previously, the function was returning a raw `Promise` instead of waiting for the evaluation results, causing incorrect behavior in remote feature evaluation.

Fixes #3654
