### PR TITLE
[Bugfix] Dazzling condition group tooltip 😵

### DIFF
--- a/packages/front-end/components/Features/ConditionDisplay/ConditionDisplay.module.scss
+++ b/packages/front-end/components/Features/ConditionDisplay/ConditionDisplay.module.scss
@@ -1,0 +1,10 @@
+.Tooltip {
+  &:first-child {
+    margin-left: 0;
+  }
+
+  &:not(:last-child)::after {
+    display: inline-block;
+    content: ",";
+  }
+}

--- a/packages/front-end/components/Features/ConditionDisplay/index.tsx
+++ b/packages/front-end/components/Features/ConditionDisplay/index.tsx
@@ -12,7 +12,8 @@ import { useDefinitions } from "@/services/DefinitionsContext";
 import { Condition, jsonToConds, useAttributeMap } from "@/services/features";
 import Tooltip from "@/components/Tooltip/Tooltip";
 import InlineCode from "@/components/SyntaxHighlighting/InlineCode";
-import SavedGroupTargetingDisplay from "./SavedGroupTargetingDisplay";
+import SavedGroupTargetingDisplay from "../SavedGroupTargetingDisplay";
+import styles from "./ConditionDisplay.module.scss";
 
 type ConditionWithParentId = Condition & { parentId?: string };
 
@@ -106,12 +107,13 @@ export function MultiValuesDisplay({ values }: { values: string[] }) {
           body={
             <div>
               {values.slice(MULTI_VALUE_LIMIT).map((v, i) => (
-                <span key={i} className="mr-1 border px-2 bg-light rounded">
+                <span key={i} className={`${styles.Tooltip} ml-1`}>
                   {v}
                 </span>
               ))}
             </div>
           }
+          usePortal
         >
           <span className="mr-1">
             <em>+ {values.length - MULTI_VALUE_LIMIT} more</em>


### PR DESCRIPTION
### Features

I visited my company's GrowthBook console today and accidentally encountered this serious UI bug when I tried to check a long list of specified conditional groups.

😵 The UI of this tooltip is literally **UNREADABLE**, no matter the light or dark mode.

|Light Mode|Dark Mode|
|:---:|:---:|
|![image](https://github.com/user-attachments/assets/e094b53c-b058-4fe9-86aa-3c1111c18d6f)|![image](https://github.com/user-attachments/assets/3316066b-167c-4494-8de8-a9520654cef0)|

### Changes

1. I dropped off all tooltip chip designs, borders and background colors. Instead, I use **plain text** which looks much better (Unless you still want a cut-off chip UI which looks so weird👇).

|Light Mode|Dark Mode|
|:---:|:---:|
|![image](https://github.com/user-attachments/assets/eb6e7992-274d-4a59-b75b-44bdac93772c)|![image](https://github.com/user-attachments/assets/64011e9d-b4dc-4ab9-96e9-16e2fe2f4bb7)|

3. I fixed the issue with the tooltip position on the feature rule card, which was causing it to be cut off.

### Dependencies

None

### Testing

- Create a long list of a condition group under `SDK Configuration > Saved Groups`.
- Or set a targeting rule which contains a list of names under `Features`.

### Screenshots

||Before|After|
|:--:|:---:|:---:|
|Condition Group|![image](https://github.com/user-attachments/assets/d6b4da8a-02d6-42f0-bb4a-6615f4545a66)|![image](https://github.com/user-attachments/assets/841c7b6c-8ac8-4b41-8fd2-42c165c2a7f9)|
|Feature|![image](https://github.com/user-attachments/assets/5dd85527-1dc5-449e-a1c4-d184146f6b83)|![image](https://github.com/user-attachments/assets/3537e138-4de0-4067-bebf-b84df74b5f80)|