### PR TITLE
Show pro upgrade still to pro trial

### DIFF
--- a/packages/front-end/components/Settings/UpgradeModal/index.tsx
+++ b/packages/front-end/components/Settings/UpgradeModal/index.tsx
@@ -425,7 +425,7 @@ export default function UpgradeModal({ close, source }: Props) {
                 <div
                   className={clsx(
                     "col-lg-6 mb-4",
-                    isAtLeastPro ? "disabled-opacity" : ""
+                    isAtLeastPro && !license?.isTrial ? "disabled-opacity" : ""
                   )}
                 >
                   <div className="pr-lg-2 border rounded p-0 d-flex flex-column">
@@ -464,7 +464,7 @@ export default function UpgradeModal({ close, source }: Props) {
                         <button
                           className="btn btn-primary m-3 w-100"
                           onClick={startPro}
-                          disabled={isAtLeastPro}
+                          disabled={isAtLeastPro && !license?.isTrial}
                         >
                           Upgrade Now
                         </button>


### PR DESCRIPTION
### Features and Changes

If someone is on a pro trial they should still be able to click upgrade in the modal.

### Testing
start to dev license server
set `LICENSE_SERVER_URL=http://localhost:3004/api/v1/`
Delete any licenseKey on org or LICENSE_KEY in env var.
Click upgrade.
Click start pro trial.
Click upgrade.
See that you can still upgrade to pro.
