### PR TITLE
remove price for enterprise

### DIFF
--- a/packages/front-end/components/Settings/Team/InviteModalSubscriptionInfo.tsx
+++ b/packages/front-end/components/Settings/Team/InviteModalSubscriptionInfo.tsx
@@ -14,9 +14,9 @@ export default function InviteModalSubscriptionInfo() {
     quote,
     loading,
   } = useStripeSubscription();
-  const { license } = useUser();
+  const { license, effectiveAccountPlan } = useUser();
   if (loading) return null;
-
+  if (effectiveAccountPlan === "enterprise") return null;
   if (!hasActiveSubscription) return null;
   if (activeAndInvitedUsers < freeSeats) return null;
 


### PR DESCRIPTION
### Features and Changes

We were showing price increases for old style enterprise orgs that also had a subscription.


### Testing

Set an org with the properties in mongo: 
```
  "enterprise": "true",
  "freeSeats": {
    "$numberLong": "1"
  },
  "stripeCustomerId": "cus_RkqnZGpCsdiNzO",
  "subscription": {
    "id": "sub_1QrL6DIjx52TO6icTAmUEpGh",
    "qty": 2,
    "trialEnd": {
      "$date": "2025-02-25T15:10:09.000Z"
    },
    "status": "trialing",
    "current_period_end": 1740496209,
    "cancel_at": null,
    "canceled_at": null,
    "cancel_at_period_end": false,
    "planNickname": "GrowthBook Cloud",
    "priceId": "price_1LT7j0Ijx52TO6icXtvMq12s",
    "price": 20,
    "discountAmount": {
      "$numberDouble": "-0.0"
    },
    "discountMessage": "",
    "hasPaymentMethod": true
  }
```
Add a user.  See no price warning.