### PR TITLE
Added structured DOM mutation fields

### DIFF
--- a/packages/front-end/components/Experiment/EditDOMMutationsModal.tsx
+++ b/packages/front-end/components/Experiment/EditDOMMutationsModal.tsx
@@ -6,6 +6,7 @@ import Modal from "@/components/Modal";
 import Field from "@/components/Forms/Field";
 import SelectField from "@/components/Forms/SelectField";
 import Button from "@/components/Radix/Button";
+import Tooltip from "@/components/Tooltip/Tooltip";
 
 const actionValues = ["append", "set", "remove"];
 
@@ -193,6 +194,12 @@ const EditDOMMutationsModal: FC<{
                       label="Attribute"
                       labelClassName="mb-1"
                       value={domChanges?.attribute}
+                      helpText={
+                        <>
+                          DOM attribute to modify{" "}
+                          <Tooltip body="Use 'html' to set the contents of this DOM element" />
+                        </>
+                      }
                       onChange={(e) => {
                         const newMutation = {
                           ...domChanges,

--- a/packages/front-end/components/Experiment/EditDOMMutationsModal.tsx
+++ b/packages/front-end/components/Experiment/EditDOMMutationsModal.tsx
@@ -64,12 +64,12 @@ const EditDOMMutationsModal: FC<{
 
   const addDOMMutation = useCallback(
     (updates: DOMMutation) => {
-      setNewVisualChange({
-        ...newVisualChange,
-        domMutations: [...newVisualChange.domMutations, updates],
-      });
+      setNewVisualChange((prevVisualChange) => ({
+        ...prevVisualChange,
+        domMutations: [...prevVisualChange.domMutations, updates],
+      }));
     },
-    [newVisualChange, setNewVisualChange]
+    [setNewVisualChange]
   );
 
   const setDOMMutationErrors = useCallback(
@@ -166,7 +166,6 @@ const EditDOMMutationsModal: FC<{
                           selector: e.target.value,
                         };
                         setDOMMutation(i, newMutation);
-                        //validateDOMMutations(i, newMutation);
                       }}
                     />
                   </Box>
@@ -186,7 +185,6 @@ const EditDOMMutationsModal: FC<{
                         }
                         const newMutation = { ...domChanges, action: val };
                         setDOMMutation(i, newMutation);
-                        //validateDOMMutations(i, newMutation);
                       }}
                     />
                   </Box>
@@ -201,7 +199,6 @@ const EditDOMMutationsModal: FC<{
                           attribute: e.target.value,
                         };
                         setDOMMutation(i, newMutation);
-                        //validateDOMMutations(i, newMutation);
                       }}
                     />
                   </Box>
@@ -217,7 +214,6 @@ const EditDOMMutationsModal: FC<{
                       value: e.target.value,
                     };
                     setDOMMutation(i, newMutation);
-                    //validateDOMMutations(i, newMutation);
                   }}
                 />
                 <Flex justify="end">
@@ -248,20 +244,17 @@ const EditDOMMutationsModal: FC<{
                         onChange={(e) => {
                           if (!e.target.value) {
                             // remove the key if it's empty
-                            const {
-                              // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                              insertBeforeSelector,
-                              ...newMutation
-                            } = domChanges;
+                            const newMutation = domChanges;
+                            if (newMutation?.insertBeforeSelector) {
+                              delete newMutation.insertBeforeSelector;
+                            }
                             setDOMMutation(i, newMutation);
-                            //validateDOMMutations(i, newMutation);
                           } else {
                             const newMutation = {
                               ...domChanges,
                               insertBeforeSelector: e.target.value,
                             };
                             setDOMMutation(i, newMutation);
-                            //validateDOMMutations(i, newMutation);
                           }
                         }}
                       />
@@ -274,20 +267,17 @@ const EditDOMMutationsModal: FC<{
                         onChange={(e) => {
                           if (!e.target.value) {
                             // remove the key if it's empty
-                            const {
-                              // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                              parentSelector,
-                              ...newMutation
-                            } = domChanges;
+                            const newMutation = domChanges;
+                            if (newMutation?.parentSelector) {
+                              delete newMutation.parentSelector;
+                            }
                             setDOMMutation(i, newMutation);
-                            //validateDOMMutations(i, newMutation);
                           } else {
                             const newMutation = {
                               ...domChanges,
                               parentSelector: e.target.value,
                             };
                             setDOMMutation(i, newMutation);
-                            //validateDOMMutations(i, newMutation);
                           }
                         }}
                       />

--- a/packages/front-end/components/Experiment/EditDOMMutationsModal.tsx
+++ b/packages/front-end/components/Experiment/EditDOMMutationsModal.tsx
@@ -1,10 +1,15 @@
 import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
-import { VisualChange } from "back-end/types/visual-changeset";
-import { FC, useCallback, useEffect, useState } from "react";
+import { DOMMutation, VisualChange } from "back-end/types/visual-changeset";
+import React, { FC, useCallback, useState } from "react";
+import { Box, Flex } from "@radix-ui/themes";
 import Modal from "@/components/Modal";
 import Field from "@/components/Forms/Field";
+import SelectField from "@/components/Forms/SelectField";
+import Button from "@/components/Radix/Button";
 
-const EditDOMMutatonsModal: FC<{
+const actionValues = ["append", "set", "remove"];
+
+const EditDOMMutationsModal: FC<{
   experiment: ExperimentInterfaceStringDates;
   visualChange: VisualChange;
   close: () => void;
@@ -13,19 +18,11 @@ const EditDOMMutatonsModal: FC<{
   const [newVisualChange, setNewVisualChange] = useState<VisualChange>(
     visualChange
   );
+  const [useAdvanced, setUseAdvanced] = useState(false);
 
-  const [newDOMMutationStr, setNewDOMMutationStr] = useState(
-    visualChange.domMutations.map((m) => JSON.stringify(m))
-  );
   const [newDOMMutationErrors, setNewDOMMutationErrors] = useState<string[]>(
     []
   );
-  //update Dom mutations when visualChange changes
-  useEffect(() => {
-    setNewDOMMutationStr(
-      newVisualChange.domMutations.map((m) => JSON.stringify(m))
-    );
-  }, [newVisualChange]);
 
   const deleteCustomJS = useCallback(() => {
     setNewVisualChange({
@@ -54,26 +51,25 @@ const EditDOMMutatonsModal: FC<{
   );
 
   const setDOMMutation = useCallback(
-    (index: number, updates) => {
-      setNewVisualChange({
-        ...newVisualChange,
-        domMutations: newVisualChange.domMutations.map((m, i) =>
+    (index: number, updates: DOMMutation) => {
+      setNewVisualChange((prevVisualChange) => ({
+        ...prevVisualChange,
+        domMutations: prevVisualChange.domMutations.map((m, i) =>
           i === index ? updates : m
         ),
+      }));
+    },
+    [setNewVisualChange]
+  );
+
+  const addDOMMutation = useCallback(
+    (updates: DOMMutation) => {
+      setNewVisualChange({
+        ...newVisualChange,
+        domMutations: [...newVisualChange.domMutations, updates],
       });
     },
     [newVisualChange, setNewVisualChange]
-  );
-
-  const setDOMMutationStr = useCallback(
-    (index: number, str: string) => {
-      setNewDOMMutationStr((strs) => {
-        const newStrs = [...strs];
-        newStrs[index] = str;
-        return newStrs;
-      });
-    },
-    [setNewDOMMutationStr]
   );
 
   const setDOMMutationErrors = useCallback(
@@ -88,9 +84,8 @@ const EditDOMMutatonsModal: FC<{
   );
 
   const validateDOMMutations = useCallback(
-    (index: number, mutation: string) => {
+    (index: number, mutations) => {
       try {
-        const m = JSON.parse(mutation);
         /*
         valid DOM mutation object. No other keys are allowed:
           selector: string;
@@ -100,21 +95,21 @@ const EditDOMMutatonsModal: FC<{
           parentSelector?: string;
           insertBeforeSelector?: string;
          */
-        if (m.selector === undefined) {
+        if (mutations.selector === undefined) {
           throw new Error("selector key is required");
         }
-        if (m.attribute === undefined) {
+        if (mutations.attribute === undefined) {
           throw new Error("attribute key is required");
         }
-        if (m.action === undefined) {
+        if (mutations.action === undefined) {
           throw new Error("action key is required");
         }
-        if (!["append", "set", "remove"].includes(m.action)) {
+        if (!["append", "set", "remove"].includes(mutations.action)) {
           throw new Error("action must be one of 'append', 'set', or 'remove'");
         }
         // check to make sure the object has no non-defined keys
-        if (Object.keys(m).length > 3) {
-          Object.keys(m).forEach((key) => {
+        if (Object.keys(mutations).length > 3) {
+          Object.keys(mutations).forEach((key) => {
             if (
               ![
                 "selector",
@@ -130,7 +125,7 @@ const EditDOMMutatonsModal: FC<{
           });
         }
 
-        setDOMMutation(index, m);
+        setDOMMutation(index, mutations);
         setDOMMutationErrors(index, "");
         return true;
       } catch (e) {
@@ -143,13 +138,191 @@ const EditDOMMutatonsModal: FC<{
 
   const checkValidDOMMutations = useCallback(() => {
     let valid = true;
-    newDOMMutationStr.forEach((m, i) => {
+    newVisualChange?.domMutations.forEach((m, i) => {
       if (!validateDOMMutations(i, m)) {
         valid = false;
       }
     });
     return valid;
-  }, [newDOMMutationStr, validateDOMMutations]);
+  }, [newVisualChange?.domMutations, validateDOMMutations]);
+
+  const editableDomEditFields = useCallback(
+    (i: number, domChanges: DOMMutation) => {
+      try {
+        return (
+          <Box p="3" px="4" className="appbox">
+            <Flex justify="between" gap="4" align="start" mb="2">
+              <Box flexGrow="1">
+                <Flex justify="start" gap="6">
+                  <Box flexBasis="50%">
+                    <Field
+                      label="Selector"
+                      labelClassName="mb-1"
+                      helpText="CSS selector for the element to modify"
+                      value={domChanges?.selector || ""}
+                      onChange={(e) => {
+                        const newMutation = {
+                          ...domChanges,
+                          selector: e.target.value,
+                        };
+                        setDOMMutation(i, newMutation);
+                        //validateDOMMutations(i, newMutation);
+                      }}
+                    />
+                  </Box>
+                  <Box flexBasis="25%">
+                    <SelectField
+                      label="Action"
+                      labelClassName="mb-1"
+                      options={[
+                        { value: "append", label: "Append" },
+                        { value: "set", label: "Set" },
+                        { value: "remove", label: "Remove" },
+                      ]}
+                      value={domChanges?.action}
+                      onChange={(val: "append" | "set" | "remove") => {
+                        if (!actionValues.includes(val)) {
+                          return;
+                        }
+                        const newMutation = { ...domChanges, action: val };
+                        setDOMMutation(i, newMutation);
+                        //validateDOMMutations(i, newMutation);
+                      }}
+                    />
+                  </Box>
+                  <Box flexBasis="25%">
+                    <Field
+                      label="Attribute"
+                      labelClassName="mb-1"
+                      value={domChanges?.attribute}
+                      onChange={(e) => {
+                        const newMutation = {
+                          ...domChanges,
+                          attribute: e.target.value,
+                        };
+                        setDOMMutation(i, newMutation);
+                        //validateDOMMutations(i, newMutation);
+                      }}
+                    />
+                  </Box>
+                </Flex>
+                <Field
+                  label="Value"
+                  labelClassName="mb-1"
+                  textarea
+                  value={domChanges?.value}
+                  onChange={(e) => {
+                    const newMutation = {
+                      ...domChanges,
+                      value: e.target.value,
+                    };
+                    setDOMMutation(i, newMutation);
+                    //validateDOMMutations(i, newMutation);
+                  }}
+                />
+                <Flex justify="end">
+                  <a
+                    className="small"
+                    href="#"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      setUseAdvanced(!useAdvanced);
+                    }}
+                  >
+                    {useAdvanced ||
+                    domChanges?.insertBeforeSelector ||
+                    domChanges?.parentSelector
+                      ? "Hide advanced"
+                      : "Show advanced"}
+                  </a>
+                </Flex>
+                {(useAdvanced ||
+                  domChanges?.insertBeforeSelector ||
+                  domChanges?.parentSelector) && (
+                  <Flex gap="6">
+                    <Box flexBasis="50%">
+                      <Field
+                        label="Insert Before Selector"
+                        labelClassName="mb-1"
+                        value={domChanges?.insertBeforeSelector || ""}
+                        onChange={(e) => {
+                          if (!e.target.value) {
+                            // remove the key if it's empty
+                            const {
+                              // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                              insertBeforeSelector,
+                              ...newMutation
+                            } = domChanges;
+                            setDOMMutation(i, newMutation);
+                            //validateDOMMutations(i, newMutation);
+                          } else {
+                            const newMutation = {
+                              ...domChanges,
+                              insertBeforeSelector: e.target.value,
+                            };
+                            setDOMMutation(i, newMutation);
+                            //validateDOMMutations(i, newMutation);
+                          }
+                        }}
+                      />
+                    </Box>
+                    <Box flexBasis="50%">
+                      <Field
+                        label="Parent Selector"
+                        labelClassName="mb-1"
+                        value={domChanges?.parentSelector || ""}
+                        onChange={(e) => {
+                          if (!e.target.value) {
+                            // remove the key if it's empty
+                            const {
+                              // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                              parentSelector,
+                              ...newMutation
+                            } = domChanges;
+                            setDOMMutation(i, newMutation);
+                            //validateDOMMutations(i, newMutation);
+                          } else {
+                            const newMutation = {
+                              ...domChanges,
+                              parentSelector: e.target.value,
+                            };
+                            setDOMMutation(i, newMutation);
+                            //validateDOMMutations(i, newMutation);
+                          }
+                        }}
+                      />
+                    </Box>
+                  </Flex>
+                )}
+              </Box>
+              <Button
+                variant="ghost"
+                color="red"
+                onClick={() => {
+                  deleteDOMMutation(i);
+                }}
+              >
+                Delete
+              </Button>
+            </Flex>
+
+            {newDOMMutationErrors[i] && (
+              <div className="text-danger">
+                <small>{newDOMMutationErrors[i]}</small>
+              </div>
+            )}
+          </Box>
+        );
+      } catch (e) {
+        return (
+          <div className="text-danger">
+            <small>Invalid JSON</small>
+          </div>
+        );
+      }
+    },
+    [deleteDOMMutation, newDOMMutationErrors, setDOMMutation, useAdvanced]
+  );
 
   const onSubmit = () => {
     // make sure all DOM mutations are valid
@@ -235,43 +408,29 @@ const EditDOMMutatonsModal: FC<{
 
         <div className="mb-4">
           <h4>DOM Mutations</h4>
-          {newVisualChange.domMutations.length ? (
-            newDOMMutationStr.map((m, i) => (
-              <div key={i} className="my-3">
-                <a
-                  className="text-danger float-right"
-                  href="#"
-                  onClick={() => deleteDOMMutation(i)}
-                  style={{ fontSize: "0.75rem" }}
-                >
-                  delete
-                </a>
-                <Field
-                  textarea
-                  minRows={2}
-                  value={m}
-                  className="w-100"
-                  onChange={(e) => {
-                    setDOMMutationStr(i, e.target.value);
-                    validateDOMMutations(i, e.target.value);
-                  }}
-                />
-                <div>
-                  {newDOMMutationErrors[i] ? (
-                    <div className="text-danger">
-                      <small>{newDOMMutationErrors[i]}</small>
-                    </div>
-                  ) : null}
-                </div>
-              </div>
-            ))
-          ) : (
-            <div className="text-muted font-italic">(None)</div>
-          )}
+          <Box>
+            <Box>
+              {newVisualChange?.domMutations.length ? (
+                newVisualChange.domMutations.map((dm, i) => (
+                  <Box key={i}>{editableDomEditFields(i, dm)}</Box>
+                ))
+              ) : (
+                <div className="text-muted">No DOM mutations</div>
+              )}
+            </Box>
+            <Button
+              variant="soft"
+              onClick={() => {
+                addDOMMutation({ selector: "", action: "set", attribute: "" });
+              }}
+            >
+              Add DOM Mutation
+            </Button>
+          </Box>
         </div>
       </div>
     </Modal>
   );
 };
 
-export default EditDOMMutatonsModal;
+export default EditDOMMutationsModal;

--- a/packages/front-end/components/Experiment/VisualChangesetTable.tsx
+++ b/packages/front-end/components/Experiment/VisualChangesetTable.tsx
@@ -15,7 +15,7 @@ import track from "@/services/track";
 import { appendQueryParamsToURL } from "@/services/utils";
 import { useAuth } from "@/services/auth";
 import VisualChangesetModal from "@/components/Experiment/VisualChangesetModal";
-import EditDOMMutatonsModal from "@/components/Experiment/EditDOMMutationsModal";
+import EditDOMMutationsModal from "@/components/Experiment/EditDOMMutationsModal";
 import LinkedChange from "@/components/Experiment/LinkedChange";
 import Badge from "@/components/Radix/Badge";
 import Button from "@/components/Radix/Button";
@@ -397,7 +397,7 @@ export const VisualChangesetTable: FC<Props> = ({
       ) : null}
 
       {editingVisualChange ? (
-        <EditDOMMutatonsModal
+        <EditDOMMutationsModal
           experiment={experiment}
           visualChange={editingVisualChange.visualChange}
           close={() => setEditingVisualChange(null)}


### PR DESCRIPTION
Removes the quite unhelpful JSON text field for DOM mutations and replaces it with a form:

<img width="786" alt="Screenshot 2025-02-20 at 3 17 32 AM" src="https://github.com/user-attachments/assets/e0c80da0-2d67-4c6a-a4a2-3d4607a28bf9" />
