### PR TITLE
Switch Avatar Dropdown to Controlled Component

### DIFF
--- a/packages/front-end/components/Layout/TopNav.tsx
+++ b/packages/front-end/components/Layout/TopNav.tsx
@@ -61,6 +61,7 @@ const TopNav: FC<{
     enableCelebrations,
     setEnableCelebrations,
   ] = useCelebrationLocalStorage();
+  const [dropdownOpen, setDropdownOpen] = useState(false);
 
   const { breadcrumb } = usePageHead();
 
@@ -154,6 +155,7 @@ const TopNav: FC<{
       <DropdownMenuItem
         key="edit-profile"
         onClick={() => {
+          setDropdownOpen(false);
           setEditUserOpen(true);
         }}
       >
@@ -184,6 +186,7 @@ const TopNav: FC<{
       <DropdownMenuItem
         className={styles.dropdownItemIconColor}
         onClick={() => {
+          setDropdownOpen(false);
           router.push("/account/personal-access-tokens");
         }}
       >
@@ -199,6 +202,7 @@ const TopNav: FC<{
       <DropdownMenuItem
         className={styles.dropdownItemIconColor}
         onClick={() => {
+          setDropdownOpen(false);
           router.push("/reports");
         }}
       >
@@ -214,6 +218,7 @@ const TopNav: FC<{
       <DropdownMenuItem
         className={styles.dropdownItemIconColor}
         onClick={() => {
+          setDropdownOpen(false);
           router.push("/activity");
         }}
       >
@@ -235,6 +240,7 @@ const TopNav: FC<{
           className={styles.dropdownItemIconColor}
           key="system"
           onClick={() => {
+            setDropdownOpen(false);
             setTheme("system");
           }}
         >
@@ -247,6 +253,7 @@ const TopNav: FC<{
           className={styles.dropdownItemIconColor}
           key="light"
           onClick={() => {
+            setDropdownOpen(false);
             setTheme("light");
           }}
         >
@@ -259,6 +266,7 @@ const TopNav: FC<{
           className={styles.dropdownItemIconColor}
           key="dark"
           onClick={() => {
+            setDropdownOpen(false);
             setTheme("dark");
           }}
         >
@@ -381,7 +389,12 @@ const TopNav: FC<{
   const renderChangePassword = () => {
     if (!usingSSO()) {
       return (
-        <DropdownMenuItem onClick={() => setChangePasswordOpen(true)}>
+        <DropdownMenuItem
+          onClick={() => {
+            setDropdownOpen(false);
+            setChangePasswordOpen(true);
+          }}
+        >
           Change Password
         </DropdownMenuItem>
       );
@@ -465,6 +478,10 @@ const TopNav: FC<{
           {renderOrganizationDropDown()}
           <DropdownMenu
             variant="solid"
+            open={dropdownOpen}
+            onOpenChange={(o) => {
+              setDropdownOpen(!!o);
+            }}
             trigger={
               <div className="nav-link d-flex">
                 <Avatar


### PR DESCRIPTION
### Features and Changes

When we switched to using Radix's `DropdownMenu` for the Avatar dropdown menu (the menu in the top-right corner) of the app, when clicking on a dropdown menu's item, the dropdown menu wasn't auto closing. I've now switched the `DropdownMenu` to a controlled component and I'm handling the open/closed state rather than relying the Radix's magic.

### Dependencies

None

### Testing

- [x] Ensure that the dropdown menu closes whenever a menu item is clicked
- [x] Ensure the dropdown is closed by default
- [x] Ensure this works whether or not the item selected is a direct child, or a sub-menu item (e.g. theme)
