### PR TITLE
Add env var customization for default log event properties

### DIFF
--- a/packages/back-end/.env.example
+++ b/packages/back-end/.env.example
@@ -33,3 +33,9 @@ EXPRESS_TRUST_PROXY_OPTS=
 CACHE_CONTROL_MAX_AGE=
 CACHE_CONTROL_STALE_WHILE_REVALIDATE=
 CACHE_CONTROL_STALE_IF_ERROR=
+
+# Logging
+# key/value pairs that should be included in all log events: https://getpino.io/#/docs/api?id=base-object
+# must be valid JSON e.g. {"hostname":"MY_HOST"}, or the string `null` to remove default log properties
+# if not present or JSON is invalid, Pino's defaults will be used
+LOG_BASE=

--- a/packages/back-end/src/util/logger.ts
+++ b/packages/back-end/src/util/logger.ts
@@ -4,7 +4,7 @@ import { Request } from "express";
 import { BaseLogger, Level } from "pino";
 import { ApiRequestLocals } from "back-end/types/api";
 import { AuthRequest } from "back-end/src/types/AuthRequest";
-import { ENVIRONMENT, IS_CLOUD, LOG_LEVEL } from "./secrets";
+import { ENVIRONMENT, IS_CLOUD, LOG_BASE, LOG_LEVEL } from "./secrets";
 
 const redactPaths = [
   "req.headers.authorization",
@@ -69,6 +69,14 @@ const isValidLevel = (input: unknown): input is Level => {
   ] as const).includes(input as Level);
 };
 
+// Only pass `base` if defined or null
+const logBase =
+  typeof LOG_BASE === "undefined"
+    ? {}
+    : {
+        base: LOG_BASE,
+      };
+
 export const httpLogger = pinoHttp({
   autoLogging: ENVIRONMENT === "production",
   level: isValidLevel(LOG_LEVEL) ? LOG_LEVEL : "info",
@@ -77,6 +85,7 @@ export const httpLogger = pinoHttp({
     remove: true,
   },
   customProps: getCustomLogProps,
+  ...logBase,
 });
 
 /**

--- a/packages/back-end/src/util/secrets.ts
+++ b/packages/back-end/src/util/secrets.ts
@@ -27,7 +27,7 @@ try {
   } else if (process.env.LOG_BASE) {
     parsedLogBase = JSON.parse(process.env.LOG_BASE);
   }
-} catch (e) {
+} catch {
   // Empty catch - don't pass a LOG_BASE
 }
 export const LOG_BASE = parsedLogBase;

--- a/packages/back-end/src/util/secrets.ts
+++ b/packages/back-end/src/util/secrets.ts
@@ -14,6 +14,24 @@ if (fs.existsSync(".env.local")) {
 
 export const LOG_LEVEL = process.env.LOG_LEVEL;
 
+let parsedLogBase:
+  | {
+      // eslint-disable-next-line
+      [key: string]: any;
+    }
+  | null
+  | undefined = undefined;
+try {
+  if (process.env.LOG_BASE === "null") {
+    parsedLogBase = null;
+  } else if (process.env.LOG_BASE) {
+    parsedLogBase = JSON.parse(process.env.LOG_BASE);
+  }
+} catch (e) {
+  // Empty catch - don't pass a LOG_BASE
+}
+export const LOG_BASE = parsedLogBase;
+
 export const IS_CLOUD = stringToBoolean(process.env.IS_CLOUD);
 export const IS_MULTI_ORG = stringToBoolean(process.env.IS_MULTI_ORG);
 


### PR DESCRIPTION
### Features and Changes

Adds a new environment variable for configuring or disabling the default properties (e.g. `hostname`) that our back-end logger includes. See [Pino's docs](https://getpino.io/#/docs/api?id=base-object) for more details

### Testing

1. Create `packages/back-end/.env.local`
2. Provide a `LOG_BASE=` variable with the relevant values
  a. Empty value
  b. `null`
  c. valid json e.g. `{"foo":"bar"}`
  d. invalid json e.g. `{foo:"bar"}`

### Screenshots
Results from adding the log:
```javascript
console.log("Parsed log base of", parsedLogBase);
```

#### Empty/not present variable
![image](https://github.com/user-attachments/assets/4990ee0a-27ba-4b1f-8d49-da3beda3c1ce)

#### Null
![image](https://github.com/user-attachments/assets/4ecdfa1b-49fd-4811-81d4-2fc8bce63fa2)

#### Valid json
![image](https://github.com/user-attachments/assets/8c9bb2d8-8f8e-4527-9061-fbc0708cf59f)

Log output includes the key:
```
 | [1] [12:03:55.241] INFO: Back-end is running at http://localhost:3100 in development mode. Press CTRL-C to stop
 | [1]     defaultIncludedLogKey: "defaultValue"
 | [1] [12:03:55.349] INFO: Deleted 0 old agenda jobs in 6ms
 | [1]     defaultIncludedLogKey: "defaultValue"
```

#### Invaild json
![image](https://github.com/user-attachments/assets/e11198d9-5729-46a6-bb7f-3f5e4d6b5216)
