### PR TITLE
Fix filters not working with segment FTs that have WHERE clauses

### DIFF
--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -4650,9 +4650,10 @@ ${this.selectStarLimit("__topValues ORDER BY count DESC", limit)}
       ${userIdCol} as ${baseIdType},
       ${timestampDateTimeColumn} as date
     FROM(
-        ${sql} ${where.length ? `WHERE ${where.join(" AND ")}` : ""}
+        ${sql}
       ) m
       ${join}
+      ${where.length ? `WHERE ${where.join(" AND ")}` : ""}
   `;
     return sqlVars ? compileSqlTemplate(baseSql, sqlVars) : baseSql;
   }


### PR DESCRIPTION
Moves where clause outside of sub-select on fact table for segments to prevent colliding with where clause that may already exist on fact table.