### PR TITLE
Updates archetype docs

### DIFF
--- a/docs/docs/features/rules.mdx
+++ b/docs/docs/features/rules.mdx
@@ -112,12 +112,16 @@ results to see more debug information about why each rule was or wasn't applied.
 Archetypes are a way you can save preset user attributes to see how your if the rules will apply to them. This is useful
 if you have specific sets of users who you frequently want to target features to. They are automatically shown along with
 the feature values at the top of the test rules form. Mouse over any value to see more debug information about why that
-value was returned. Archetypes are part of the GrowthBook Enterprise plan.
+value was returned.
 
 ![Archetypes](/images/features/feature-archetypes.png)
 
 You can create and manage archetypes in the _Archetypes_ page under the SDK Configuration. You will need a paid plan to
 use Archetypes.
+
+:::note
+**Archetypes** are a GrowthBook Pro and Enterprise feature.
+:::
 
 ### Simulation
 


### PR DESCRIPTION
### Features and Changes

Updates docs to correctly reflect that `Archetypes` are available for both Pro and Enterprise plans, not just Enterprise.

### Screenshots

Before:
<img width="886" alt="Screenshot 2025-02-24 at 6 42 51 AM" src="https://github.com/user-attachments/assets/e850e818-2083-415c-b60c-261426750b88" />

After:
<img width="896" alt="Screenshot 2025-02-24 at 6 54 34 AM" src="https://github.com/user-attachments/assets/04baa2ec-a790-4840-9faf-f3d14320b0b0" />
