### PR TITLE
fix(LinkedChanges): Allow changes to be deleted

### DIFF
--- a/packages/front-end/components/Experiment/LinkedChanges/AddLinkedChanges.tsx
+++ b/packages/front-end/components/Experiment/LinkedChanges/AddLinkedChanges.tsx
@@ -117,12 +117,14 @@ const AddLinkedChangeRow = ({
               <div className="btn btn-link p-0 disabled">{cta}</div>
             </PremiumTooltip>
           ) : (
-            <Tooltip
-              body={`The SDKs in this project don't support ${header}. Upgrade your SDK(s) or add a supported SDK.`}
-              tipPosition="top"
-            >
-              <div className="btn btn-link disabled p-0">{cta}</div>
-            </Tooltip>
+            <div>
+              <Tooltip
+                body={`The SDKs in this project don't support ${header}. Upgrade your SDK(s) or add a supported SDK.`}
+                tipPosition="top"
+              >
+                <div className="btn btn-link disabled p-0">{cta}</div>
+              </Tooltip>
+            </div>
           )}
         </div>
         <p className="mt-2 mb-1">{description}</p>

--- a/packages/front-end/components/Modal.tsx
+++ b/packages/front-end/components/Modal.tsx
@@ -374,6 +374,9 @@ const Modal: FC<ModalProps> = ({
         position: inline ? "relative" : undefined,
         zIndex: inline ? 1 : increasedElevation ? 1550 : undefined,
       }}
+      onClick={(e) => {
+        e.stopPropagation();
+      }}
     >
       <div
         className={`modal-dialog modal-${size}`}


### PR DESCRIPTION
Fixes #3701 

### Features and Changes

- We are unable to delete Visual Changes because the event is being propagated up via the `onClick` listener before the `submit` from the button is triggered
  - So for a Modal we are stopping the propagation of events for things outside the Modal, as this is a scenario that should not happen often.
- Small UI fix for Tooltip for disabled changes

https://www.loom.com/share/565ac203e5334e2b8be6540530269f6b
