### PR TITLE
fix(UI): Dropdown theme was not matching user's theme

### DIFF
--- a/packages/front-end/components/Dropdown/MoreMenu.tsx
+++ b/packages/front-end/components/Dropdown/MoreMenu.tsx
@@ -90,8 +90,8 @@ const MoreMenu: FC<{
           <BsThreeDotsVertical />
         </a>
       )}
-      <RadixTheme>
-        <FloatingPortal>
+      <FloatingPortal>
+        <RadixTheme>
           <div
             className={`dropdown-menu ${open ? "show" : ""}`}
             onClick={() => {
@@ -104,8 +104,8 @@ const MoreMenu: FC<{
           >
             {children}
           </div>
-        </FloatingPortal>
-      </RadixTheme>
+        </RadixTheme>
+      </FloatingPortal>
     </div>
   );
 };


### PR DESCRIPTION
### Features and Changes

On #3689 we started to make use of more Radix CSS variables in the dropdown menus which are usually rendered via Portal. As the Radix variables are set within the root of the React application, the dropdowns did not have the proper variables set. 

The fix is simple, and changing the order makes sure we have the proper `div.radix-themes` element within the Portal, setting the correct variables.

One mystery is why did this manifest only in prod and not in dev.