### PR TITLE
fix(UI): Tooltip on getting started cards

### DIFF
--- a/packages/front-end/components/GetStarted/FeaturedCards.tsx
+++ b/packages/front-end/components/GetStarted/FeaturedCards.tsx
@@ -66,6 +66,7 @@ export function LaunchDarklyImportFeatureCard() {
           ? ""
           : "You do not have permission to complete this action"
       }
+      usePortal={true}
     >
       <CardLink
         href="/importing/launchdarkly"


### PR DESCRIPTION
I noticed a UI bug when the user does not have permission to import from Launch Darkly in the Getting Started page.

### Before

<img width="800" alt="Screenshot 2025-02-24 at 8 00 04 PM" src="https://github.com/user-attachments/assets/321b683c-9b9a-41b4-a950-3aa6919e9fd1" />

### After

<img width="775" alt="Screenshot 2025-02-24 at 7 58 55 PM" src="https://github.com/user-attachments/assets/c13d4027-2035-4a16-8f1f-845d8c2c326b" />
