### PR TITLE
Change visual treatment of statuses on experiment list

### DIFF
--- a/packages/front-end/components/Experiment/TabbedPage/ExperimentStatusIndicator.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/ExperimentStatusIndicator.tsx
@@ -11,7 +11,7 @@ export type StatusIndicatorData = {
   color: React.ComponentProps<typeof Badge>["color"];
   status: string;
   detailedStatus?: string;
-  important?: boolean;
+  needsAttention?: boolean;
   tooltip?: string;
 };
 
@@ -38,11 +38,16 @@ export function ExperimentStatusDetailsWithDot({
 }: {
   statusIndicatorData: StatusIndicatorData;
 }) {
-  const { color, detailedStatus, important, tooltip } = statusIndicatorData;
+  const {
+    color,
+    detailedStatus,
+    needsAttention,
+    tooltip,
+  } = statusIndicatorData;
 
   if (!detailedStatus) return null;
 
-  const contents = important ? (
+  const contents = needsAttention ? (
     <Flex gap="1" align="center">
       <div
         style={{

--- a/packages/front-end/components/Experiment/TabbedPage/ExperimentStatusIndicator.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/ExperimentStatusIndicator.tsx
@@ -1,4 +1,4 @@
-import { Tooltip } from "@radix-ui/themes";
+import { Flex, Tooltip } from "@radix-ui/themes";
 import Badge from "@/components/Radix/Badge";
 import {
   ExperimentData,
@@ -9,9 +9,9 @@ type LabelFormat = "full" | "status-only" | "detail-only";
 
 export type StatusIndicatorData = {
   color: React.ComponentProps<typeof Badge>["color"];
-  variant: React.ComponentProps<typeof Badge>["variant"];
   status: string;
   detailedStatus?: string;
+  important?: boolean;
   tooltip?: string;
 };
 
@@ -33,6 +33,34 @@ export default function ExperimentStatusIndicator({
   );
 }
 
+export function ExperimentStatusDetailsWithDot({
+  statusIndicatorData,
+}: {
+  statusIndicatorData: StatusIndicatorData;
+}) {
+  const { color, detailedStatus, important, tooltip } = statusIndicatorData;
+
+  if (!detailedStatus) return null;
+
+  const contents = important ? (
+    <Flex gap="1" align="center">
+      <div
+        style={{
+          width: 8,
+          height: 8,
+          borderRadius: 8,
+          backgroundColor: `var(--${color}-9)`,
+        }}
+      ></div>
+      {detailedStatus}
+    </Flex>
+  ) : (
+    <>{detailedStatus}</>
+  );
+
+  return tooltip ? <Tooltip content={tooltip}>{contents}</Tooltip> : contents;
+}
+
 export function RawExperimentStatusIndicator({
   statusIndicatorData,
   labelFormat = "full",
@@ -40,19 +68,13 @@ export function RawExperimentStatusIndicator({
   statusIndicatorData: StatusIndicatorData;
   labelFormat?: LabelFormat;
 }) {
-  const {
-    color,
-    variant,
-    status,
-    detailedStatus,
-    tooltip,
-  } = statusIndicatorData;
+  const { color, status, detailedStatus, tooltip } = statusIndicatorData;
   const label = getFormattedLabel(labelFormat, status, detailedStatus);
 
   const badge = (
     <Badge
       color={color}
-      variant={variant}
+      variant={"soft"}
       radius="full"
       label={label}
       style={{

--- a/packages/front-end/components/Experiment/TabbedPage/ExperimentStatusIndicator.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/ExperimentStatusIndicator.tsx
@@ -2,18 +2,11 @@ import { Flex, Tooltip } from "@radix-ui/themes";
 import Badge from "@/components/Radix/Badge";
 import {
   ExperimentData,
+  StatusIndicatorData,
   useExperimentStatusIndicator,
 } from "@/hooks/useExperimentStatusIndicator";
 
 type LabelFormat = "full" | "status-only" | "detail-only";
-
-export type StatusIndicatorData = {
-  color: React.ComponentProps<typeof Badge>["color"];
-  status: string;
-  detailedStatus?: string;
-  needsAttention?: boolean;
-  tooltip?: string;
-};
 
 export default function ExperimentStatusIndicator({
   experimentData,
@@ -40,6 +33,7 @@ export function ExperimentStatusDetailsWithDot({
 }) {
   const {
     color,
+    status,
     detailedStatus,
     needsAttention,
     tooltip,
@@ -47,21 +41,22 @@ export function ExperimentStatusDetailsWithDot({
 
   if (!detailedStatus) return null;
 
-  const contents = needsAttention ? (
-    <Flex gap="1" align="center">
-      <div
-        style={{
-          width: 8,
-          height: 8,
-          borderRadius: 8,
-          backgroundColor: `var(--${color}-9)`,
-        }}
-      ></div>
-      {detailedStatus}
-    </Flex>
-  ) : (
-    <>{detailedStatus}</>
-  );
+  const contents =
+    needsAttention || status === "Stopped" ? (
+      <Flex gap="1" align="center">
+        <div
+          style={{
+            width: 8,
+            height: 8,
+            borderRadius: 8,
+            backgroundColor: `var(--${color}-9)`,
+          }}
+        ></div>
+        {detailedStatus}
+      </Flex>
+    ) : (
+      <>{detailedStatus}</>
+    );
 
   return tooltip ? <Tooltip content={tooltip}>{contents}</Tooltip> : contents;
 }

--- a/packages/front-end/components/Experiment/TabbedPage/ExperimentStatusIndicator.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/ExperimentStatusIndicator.tsx
@@ -55,7 +55,7 @@ export function ExperimentStatusDetailsWithDot({
         {detailedStatus}
       </Flex>
     ) : (
-      <>{detailedStatus}</>
+      <div>{detailedStatus}</div>
     );
 
   return tooltip ? <Tooltip content={tooltip}>{contents}</Tooltip> : contents;

--- a/packages/front-end/components/Experiment/TabbedPage/ExperimentStatusIndicator.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/ExperimentStatusIndicator.tsx
@@ -74,7 +74,7 @@ export function RawExperimentStatusIndicator({
   const badge = (
     <Badge
       color={color}
-      variant={"soft"}
+      variant={"solid"}
       radius="full"
       label={label}
       style={{

--- a/packages/front-end/components/MetricExperiments/MetricExperiments.tsx
+++ b/packages/front-end/components/MetricExperiments/MetricExperiments.tsx
@@ -65,6 +65,8 @@ interface MetricExperimentData {
   phases: ExperimentPhaseStringDates[];
   guardrailMetrics: string[];
   goalMetrics: string[];
+  secondaryMetrics: string[];
+  datasource: string;
 }
 
 const NUM_PER_PAGE = 50;
@@ -112,6 +114,8 @@ function MetricExperimentResultTab({
         phases: e.phases,
         goalMetrics: e.goalMetrics,
         guardrailMetrics: e.guardrailMetrics,
+        secondaryMetrics: e.secondaryMetrics,
+        datasource: e.datasource,
       };
       if (!bandits && baseline && variationResults[i]) {
         const {

--- a/packages/front-end/hooks/useExperimentStatusIndicator.ts
+++ b/packages/front-end/hooks/useExperimentStatusIndicator.ts
@@ -165,7 +165,7 @@ function getStatusIndicatorData(
         status: "Running",
         detailedStatus: "Unhealthy",
         tooltip: unhealthyStatuses.join(", "),
-        important: true,
+        needsAttention: true,
       };
     }
 
@@ -185,7 +185,7 @@ function getStatusIndicatorData(
         status: "Running",
         detailedStatus: "No data",
         tooltip: "No data source configured for experiment",
-        important: true,
+        needsAttention: true,
       };
     }
 
@@ -200,7 +200,7 @@ function getStatusIndicatorData(
         status: "Running",
         detailedStatus: "No data",
         tooltip: "No metrics configured for experiment yet",
-        important: true,
+        needsAttention: true,
       };
     }
 
@@ -239,14 +239,14 @@ function getStatusIndicatorData(
           color: "green",
           status: "Stopped",
           detailedStatus: "Won",
-          important: true,
+          needsAttention: true,
         };
       case "lost":
         return {
           color: "red",
           status: "Stopped",
           detailedStatus: "Lost",
-          important: true,
+          needsAttention: true,
         };
       case "inconclusive":
         return {
@@ -265,7 +265,7 @@ function getStatusIndicatorData(
           color: "amber",
           status: "Stopped",
           detailedStatus: "Awaiting decision",
-          important: true,
+          needsAttention: true,
         };
     }
   }
@@ -288,7 +288,7 @@ function getDetailedStatusIndicatorData(
       status: "Running",
       detailedStatus: "Roll back now",
       tooltip: decisionData.tooltip,
-      important: true,
+      needsAttention: true,
     };
   }
 
@@ -298,7 +298,7 @@ function getDetailedStatusIndicatorData(
       status: "Running",
       detailedStatus: "Ship now",
       tooltip: decisionData.tooltip,
-      important: true,
+      needsAttention: true,
     };
   }
 
@@ -322,7 +322,7 @@ function getDetailedStatusIndicatorData(
       status: "Running",
       detailedStatus: "Ready for review",
       tooltip: decisionData.tooltip,
-      important: true,
+      needsAttention: true,
     };
   }
 }

--- a/packages/front-end/hooks/useExperimentStatusIndicator.ts
+++ b/packages/front-end/hooks/useExperimentStatusIndicator.ts
@@ -17,7 +17,16 @@ import {
 } from "back-end/types/experiment";
 import useOrgSettings from "@/hooks/useOrgSettings";
 import { useUser } from "@/services/UserContext";
-import { StatusIndicatorData } from "@/components/Experiment/TabbedPage/ExperimentStatusIndicator";
+
+export type StatusIndicatorData = {
+  color: "amber" | "green" | "red" | "gold" | "indigo" | "gray";
+  status: "Running" | "Stopped" | "Draft" | "Archived";
+  detailedStatus?: string;
+  needsAttention?: boolean;
+  tooltip?: string;
+  // Most actionable status have higher numbers
+  sortOrder: number;
+};
 
 export type ExperimentData = Pick<
   ExperimentInterfaceStringDates,
@@ -71,6 +80,7 @@ function getStatusIndicatorData(
     return {
       color: "gold",
       status: "Archived",
+      sortOrder: 0,
     };
   }
 
@@ -78,6 +88,7 @@ function getStatusIndicatorData(
     return {
       color: "indigo",
       status: "Draft",
+      sortOrder: 6,
     };
   }
 
@@ -166,6 +177,7 @@ function getStatusIndicatorData(
         detailedStatus: "Unhealthy",
         tooltip: unhealthyStatuses.join(", "),
         needsAttention: true,
+        sortOrder: 9,
       };
     }
 
@@ -175,6 +187,7 @@ function getStatusIndicatorData(
         color: "indigo",
         status: "Running",
         detailedStatus: "No data",
+        sortOrder: 10,
       };
     }
 
@@ -186,6 +199,7 @@ function getStatusIndicatorData(
         detailedStatus: "No data",
         tooltip: "No data source configured for experiment",
         needsAttention: true,
+        sortOrder: 10,
       };
     }
 
@@ -201,6 +215,7 @@ function getStatusIndicatorData(
         detailedStatus: "No data",
         tooltip: "No metrics configured for experiment yet",
         needsAttention: true,
+        sortOrder: 10,
       };
     }
 
@@ -210,6 +225,7 @@ function getStatusIndicatorData(
         color: "indigo",
         status: "Running",
         tooltip: `Estimated days left or decision recommendations will appear after the minimum experiment duration of ${healthSettings.experimentMinLengthDays} is reached.`,
+        sortOrder: 7,
       };
     }
 
@@ -229,6 +245,7 @@ function getStatusIndicatorData(
     return {
       color: "indigo",
       status: "Running",
+      sortOrder: 7,
     };
   }
 
@@ -239,26 +256,28 @@ function getStatusIndicatorData(
           color: "green",
           status: "Stopped",
           detailedStatus: "Won",
-          needsAttention: true,
+          sortOrder: 4,
         };
       case "lost":
         return {
           color: "red",
           status: "Stopped",
           detailedStatus: "Lost",
-          needsAttention: true,
+          sortOrder: 3,
         };
       case "inconclusive":
         return {
           color: "gray",
           status: "Stopped",
           detailedStatus: "Inconclusive",
+          sortOrder: 2,
         };
       case "dnf":
         return {
           color: "gray",
           status: "Stopped",
           detailedStatus: "Didn't finish",
+          sortOrder: 1,
         };
       default:
         return {
@@ -266,6 +285,7 @@ function getStatusIndicatorData(
           status: "Stopped",
           detailedStatus: "Awaiting decision",
           needsAttention: true,
+          sortOrder: 5,
         };
     }
   }
@@ -289,6 +309,7 @@ function getDetailedStatusIndicatorData(
       detailedStatus: "Roll back now",
       tooltip: decisionData.tooltip,
       needsAttention: true,
+      sortOrder: 13,
     };
   }
 
@@ -299,6 +320,7 @@ function getDetailedStatusIndicatorData(
       detailedStatus: "Ship now",
       tooltip: decisionData.tooltip,
       needsAttention: true,
+      sortOrder: 12,
     };
   }
 
@@ -313,6 +335,7 @@ function getDetailedStatusIndicatorData(
       tooltip: decisionData.tooltip
         ? decisionData.tooltip
         : `The experiment needs more data to reliably detect the target minimum detectable effect for all goal metrics. At recent traffic levels, the experiment will take ~${decisionData.daysLeft} more days to collect enough data.`,
+      sortOrder: 8,
     };
   }
 
@@ -323,6 +346,7 @@ function getDetailedStatusIndicatorData(
       detailedStatus: "Ready for review",
       tooltip: decisionData.tooltip,
       needsAttention: true,
+      sortOrder: 11,
     };
   }
 }

--- a/packages/front-end/hooks/useExperimentStatusIndicator.ts
+++ b/packages/front-end/hooks/useExperimentStatusIndicator.ts
@@ -19,7 +19,7 @@ import useOrgSettings from "@/hooks/useOrgSettings";
 import { useUser } from "@/services/UserContext";
 
 export type StatusIndicatorData = {
-  color: "amber" | "green" | "red" | "gold" | "indigo" | "gray";
+  color: "amber" | "green" | "red" | "gold" | "indigo" | "gray" | "pink";
   status: "Running" | "Stopped" | "Draft" | "Archived";
   detailedStatus?: string;
   needsAttention?: boolean;
@@ -86,7 +86,7 @@ function getStatusIndicatorData(
 
   if (experimentData.status === "draft") {
     return {
-      color: "indigo",
+      color: "pink",
       status: "Draft",
       sortOrder: 6,
     };

--- a/packages/front-end/hooks/useExperimentStatusIndicator.ts
+++ b/packages/front-end/hooks/useExperimentStatusIndicator.ts
@@ -30,7 +30,9 @@ export type ExperimentData = Pick<
   | "phases"
   | "dismissedWarnings"
   | "goalMetrics"
+  | "secondaryMetrics"
   | "guardrailMetrics"
+  | "datasource"
 >;
 
 export function useExperimentStatusIndicator() {
@@ -68,7 +70,6 @@ function getStatusIndicatorData(
   if (!skipArchived && experimentData.archived) {
     return {
       color: "gold",
-      variant: "soft",
       status: "Archived",
     };
   }
@@ -76,7 +77,6 @@ function getStatusIndicatorData(
   if (experimentData.status === "draft") {
     return {
       color: "indigo",
-      variant: "soft",
       status: "Draft",
     };
   }
@@ -162,10 +162,10 @@ function getStatusIndicatorData(
     if (unhealthyStatuses.length > 0) {
       return {
         color: "amber",
-        variant: "solid",
         status: "Running",
         detailedStatus: "Unhealthy",
         tooltip: unhealthyStatuses.join(", "),
+        important: true,
       };
     }
 
@@ -173,9 +173,34 @@ function getStatusIndicatorData(
     if (healthSummary?.totalUsers === 0) {
       return {
         color: "indigo",
-        variant: "solid",
         status: "Running",
         detailedStatus: "No data",
+      };
+    }
+
+    // 2.5 - No data source configured for experiment
+    if (!experimentData.datasource) {
+      return {
+        color: "amber",
+        status: "Running",
+        detailedStatus: "No data",
+        tooltip: "No data source configured for experiment",
+        important: true,
+      };
+    }
+
+    // 2.6 - No metrics configured for experiment
+    if (
+      !experimentData.goalMetrics?.length &&
+      !experimentData.secondaryMetrics?.length &&
+      !experimentData.guardrailMetrics?.length
+    ) {
+      return {
+        color: "amber",
+        status: "Running",
+        detailedStatus: "No data",
+        tooltip: "No metrics configured for experiment yet",
+        important: true,
       };
     }
 
@@ -183,7 +208,6 @@ function getStatusIndicatorData(
     if (beforeMinDuration) {
       return {
         color: "indigo",
-        variant: "solid",
         status: "Running",
         tooltip: `Estimated days left or decision recommendations will appear after the minimum experiment duration of ${healthSettings.experimentMinLengthDays} is reached.`,
       };
@@ -204,7 +228,6 @@ function getStatusIndicatorData(
     // 6. Otherwise, show running status
     return {
       color: "indigo",
-      variant: "solid",
       status: "Running",
     };
   }
@@ -213,38 +236,36 @@ function getStatusIndicatorData(
     switch (experimentData.results) {
       case "won":
         return {
-          color: "gray",
-          variant: "soft",
+          color: "green",
           status: "Stopped",
           detailedStatus: "Won",
+          important: true,
         };
       case "lost":
         return {
-          color: "gray",
-          variant: "soft",
+          color: "red",
           status: "Stopped",
           detailedStatus: "Lost",
+          important: true,
         };
       case "inconclusive":
         return {
           color: "gray",
-          variant: "soft",
           status: "Stopped",
           detailedStatus: "Inconclusive",
         };
       case "dnf":
         return {
           color: "gray",
-          variant: "soft",
           status: "Stopped",
           detailedStatus: "Didn't finish",
         };
       default:
         return {
-          color: "gray",
-          variant: "soft",
+          color: "amber",
           status: "Stopped",
           detailedStatus: "Awaiting decision",
+          important: true,
         };
     }
   }
@@ -263,21 +284,21 @@ function getDetailedStatusIndicatorData(
 
   if (decisionData.status === "rollback-now") {
     return {
-      color: "red",
-      variant: "solid",
+      color: "amber",
       status: "Running",
-      detailedStatus: "Roll Back Now",
+      detailedStatus: "Roll back now",
       tooltip: decisionData.tooltip,
+      important: true,
     };
   }
 
   if (decisionData.status === "ship-now") {
     return {
-      color: "green",
-      variant: "solid",
+      color: "amber",
       status: "Running",
-      detailedStatus: "Ship Now",
+      detailedStatus: "Ship now",
       tooltip: decisionData.tooltip,
+      important: true,
     };
   }
 
@@ -285,7 +306,6 @@ function getDetailedStatusIndicatorData(
     const cappedPowerAdditionalDaysNeeded = Math.min(decisionData.daysLeft, 90);
     return {
       color: "indigo",
-      variant: "solid",
       status: "Running",
       detailedStatus: `${
         decisionData.daysLeft !== cappedPowerAdditionalDaysNeeded ? ">" : ""
@@ -299,10 +319,10 @@ function getDetailedStatusIndicatorData(
   if (decisionData.status === "ready-for-review") {
     return {
       color: "amber",
-      variant: "soft",
       status: "Running",
-      detailedStatus: "Ready for Review",
+      detailedStatus: "Ready for review",
       tooltip: decisionData.tooltip,
+      important: true,
     };
   }
 }

--- a/packages/front-end/pages/design-system/index.tsx
+++ b/packages/front-end/pages/design-system/index.tsx
@@ -747,6 +747,8 @@ export default function DesignSystemPage() {
               phases: [],
               goalMetrics: [],
               guardrailMetrics: [],
+              secondaryMetrics: [],
+              datasource: "ds_abc123",
             }}
           />
           <ExperimentStatusIndicator
@@ -757,6 +759,8 @@ export default function DesignSystemPage() {
               phases: [],
               goalMetrics: [],
               guardrailMetrics: [],
+              secondaryMetrics: [],
+              datasource: "ds_abc123",
             }}
           />
           <ExperimentStatusIndicator
@@ -767,6 +771,8 @@ export default function DesignSystemPage() {
               phases: [],
               goalMetrics: [],
               guardrailMetrics: [],
+              secondaryMetrics: [],
+              datasource: "ds_abc123",
             }}
           />
           <ExperimentStatusIndicator
@@ -778,6 +784,8 @@ export default function DesignSystemPage() {
               phases: [],
               goalMetrics: [],
               guardrailMetrics: [],
+              secondaryMetrics: [],
+              datasource: "ds_abc123",
             }}
           />
           <ExperimentStatusIndicator
@@ -789,6 +797,8 @@ export default function DesignSystemPage() {
               phases: [],
               goalMetrics: [],
               guardrailMetrics: [],
+              secondaryMetrics: [],
+              datasource: "ds_abc123",
             }}
           />
           <ExperimentStatusIndicator
@@ -800,6 +810,8 @@ export default function DesignSystemPage() {
               phases: [],
               goalMetrics: [],
               guardrailMetrics: [],
+              secondaryMetrics: [],
+              datasource: "ds_abc123",
             }}
           />
           <ExperimentStatusIndicator
@@ -811,6 +823,8 @@ export default function DesignSystemPage() {
               phases: [],
               goalMetrics: [],
               guardrailMetrics: [],
+              secondaryMetrics: [],
+              datasource: "ds_abc123",
             }}
           />
           <ExperimentStatusIndicator
@@ -821,6 +835,8 @@ export default function DesignSystemPage() {
               phases: [],
               goalMetrics: [],
               guardrailMetrics: [],
+              secondaryMetrics: [],
+              datasource: "ds_abc123",
             }}
           />
         </Flex>

--- a/packages/front-end/pages/experiments/index.tsx
+++ b/packages/front-end/pages/experiments/index.tsx
@@ -584,7 +584,7 @@ const ExperimentsPage = (): React.ReactElement => {
                               <SortableTH field="statusSortOrder">
                                 Status
                               </SortableTH>
-                              <td></td>
+                              <th></th>
                             </>
                           ) : needsStatusColumn || needsResultColumn ? (
                             <SortableTH field="statusSortOrder">

--- a/packages/front-end/pages/experiments/index.tsx
+++ b/packages/front-end/pages/experiments/index.tsx
@@ -29,10 +29,7 @@ import TagsFilter, {
   useTagsFilter,
 } from "@/components/Tags/TagsFilter";
 import { useWatching } from "@/services/WatchProvider";
-import {
-  ExperimentStatusDetailsWithDot,
-  StatusIndicatorData,
-} from "@/components/Experiment/TabbedPage/ExperimentStatusIndicator";
+import { ExperimentStatusDetailsWithDot } from "@/components/Experiment/TabbedPage/ExperimentStatusIndicator";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 import CustomMarkdown from "@/components/Markdown/CustomMarkdown";
@@ -60,31 +57,6 @@ import Callout from "@/components/Radix/Callout";
 import { useExperimentStatusIndicator } from "@/hooks/useExperimentStatusIndicator";
 
 const NUM_PER_PAGE = 20;
-
-// Most actionable status have higher numbers
-function getExperimentStatusSortOrder(
-  statusIndicator: StatusIndicatorData
-): number {
-  if (statusIndicator.status === "Archived") return 0;
-  if (statusIndicator.status === "Stopped") {
-    if (statusIndicator.detailedStatus === "Didn't finish") return 1;
-    if (statusIndicator.detailedStatus === "Inconclusive") return 2;
-    if (statusIndicator.detailedStatus === "Lost") return 3;
-    if (statusIndicator.detailedStatus === "Won") return 4;
-    return 5;
-  }
-  if (statusIndicator.status === "Draft") return 6;
-  if (statusIndicator.status === "Running") {
-    if (statusIndicator.detailedStatus?.includes("days left")) return 8;
-    if (statusIndicator.detailedStatus === "Unhealthy") return 9;
-    if (statusIndicator.detailedStatus === "No data") return 10;
-    if (statusIndicator.detailedStatus === "Ready for Review") return 11;
-    if (statusIndicator.detailedStatus === "Ship Now") return 12;
-    if (statusIndicator.detailedStatus === "Roll Back Now") return 13;
-    return 7;
-  }
-  return 14;
-}
 
 export function experimentDate(exp: ExperimentInterfaceStringDates): string {
   return (
@@ -147,7 +119,7 @@ const ExperimentsPage = (): React.ReactElement => {
       const projectName = projectId ? getProjectById(projectId)?.name : "";
       const projectIsDeReferenced = projectId && !projectName;
       const statusIndicator = getExperimentStatusIndicator(exp);
-      const statusSortOrder = getExperimentStatusSortOrder(statusIndicator);
+      const statusSortOrder = statusIndicator.sortOrder;
       const lastPhase = exp.phases?.[exp.phases?.length - 1] || {};
       const rawSavedGroup = lastPhase?.savedGroups || [];
       const savedGroupIds = rawSavedGroup.map((g) => g.ids).flat();
@@ -607,14 +579,16 @@ const ExperimentsPage = (): React.ReactElement => {
                           <SortableTH field="tags">Tags</SortableTH>
                           <SortableTH field="ownerName">Owner</SortableTH>
                           <SortableTH field="date">Date</SortableTH>
-                          {needsStatusColumn ? (
+                          {needsStatusColumn && needsResultColumn ? (
+                            <>
+                              <SortableTH field="statusSortOrder">
+                                Status
+                              </SortableTH>
+                              <td></td>
+                            </>
+                          ) : needsStatusColumn || needsResultColumn ? (
                             <SortableTH field="statusSortOrder">
                               Status
-                            </SortableTH>
-                          ) : null}
-                          {needsResultColumn ? (
-                            <SortableTH field="statusSortOrder">
-                              Result
                             </SortableTH>
                           ) : null}
                         </tr>
@@ -721,7 +695,14 @@ const ExperimentsPage = (): React.ReactElement => {
                               </td>
                               {needsStatusColumn ? (
                                 <td className="nowrap" data-title="Status:">
-                                  {e.statusIndicator.status}
+                                  {e.statusIndicator.tooltip &&
+                                  !e.statusIndicator.detailedStatus ? (
+                                    <Tooltip body={e.statusIndicator.tooltip}>
+                                      {e.statusIndicator.status}
+                                    </Tooltip>
+                                  ) : (
+                                    e.statusIndicator.status
+                                  )}
                                 </td>
                               ) : null}
                               {needsResultColumn ? (

--- a/packages/front-end/pages/experiments/index.tsx
+++ b/packages/front-end/pages/experiments/index.tsx
@@ -30,7 +30,7 @@ import TagsFilter, {
 } from "@/components/Tags/TagsFilter";
 import { useWatching } from "@/services/WatchProvider";
 import {
-  RawExperimentStatusIndicator,
+  ExperimentStatusDetailsWithDot,
   StatusIndicatorData,
 } from "@/components/Experiment/TabbedPage/ExperimentStatusIndicator";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
@@ -380,6 +380,10 @@ const ExperimentsPage = (): React.ReactElement => {
     };
   }
 
+  const needsStatusColumn = tabs.length != 1;
+  const needsResultColumn =
+    !tabs.length || tabs.includes("stopped") || tabs.includes("running");
+
   const addExperimentDropdownButton = (
     <DropdownMenu
       trigger={
@@ -603,12 +607,16 @@ const ExperimentsPage = (): React.ReactElement => {
                           <SortableTH field="tags">Tags</SortableTH>
                           <SortableTH field="ownerName">Owner</SortableTH>
                           <SortableTH field="date">Date</SortableTH>
-                          <SortableTH
-                            field="statusSortOrder"
-                            style={{ minWidth: "150px" }}
-                          >
-                            Status
-                          </SortableTH>
+                          {needsStatusColumn ? (
+                            <SortableTH field="statusSortOrder">
+                              Status
+                            </SortableTH>
+                          ) : null}
+                          {needsResultColumn ? (
+                            <SortableTH field="statusSortOrder">
+                              Result
+                            </SortableTH>
+                          ) : null}
                         </tr>
                       </thead>
                       <tbody>
@@ -711,11 +719,18 @@ const ExperimentsPage = (): React.ReactElement => {
                                   : ""}{" "}
                                 {date(e.date)}
                               </td>
-                              <td className="nowrap" data-title="Status:">
-                                <RawExperimentStatusIndicator
-                                  statusIndicatorData={e.statusIndicator}
-                                />
-                              </td>
+                              {needsStatusColumn ? (
+                                <td className="nowrap" data-title="Status:">
+                                  {e.statusIndicator.status}
+                                </td>
+                              ) : null}
+                              {needsResultColumn ? (
+                                <td className="nowrap" data-title="Details:">
+                                  <ExperimentStatusDetailsWithDot
+                                    statusIndicatorData={e.statusIndicator}
+                                  />
+                                </td>
+                              ) : null}
                             </tr>
                           );
                         })}


### PR DESCRIPTION
### Features and Changes

Experiment list page:
- Split the status column into two: `Status` and results (no column header)
- Only show the status column (running, stopped, etc.) when multiple status tabs are active.  Otherwise hide it.
- Only show the result column when running and/or stopped tabs are selected.  Otherwise hide it.
- Render the status and result as plain text instead of badges
- Add an indicator dot for tests that need your attention (amber) or stopped tests (gray, red, or green)
- Define sort order as part of `StatusIndicatorData` instead of in a separate function

Other pages:
- Switch all status badges to be the `solid` variant instead of mixing and matching soft and solid
- Switch "Ship now" and "Roll back now" to use amber color instead of green/red
- Switch "Won" and "Lost" to use green/red instead of gray
- Switch "Draft" to be pink instead of indigo (to differentiate from running)

General changes to the decision framework logic:
- Add additional `No data` states for when an experiment is missing a data source or has no metrics selected
- Change all badges to use sentence case instead of title case

![image](https://github.com/user-attachments/assets/7f674556-1855-4f69-955f-b42a65e0a154)
