### PR TITLE
Fix feature usage graph position for default values

### DIFF
--- a/packages/front-end/components/Features/FeatureUsageGraph.tsx
+++ b/packages/front-end/components/Features/FeatureUsageGraph.tsx
@@ -181,9 +181,6 @@ export default function FeatureUsageGraph({
       )}
       {showLabel && (
         <div className="d-flex text-secondary">
-          <div>
-            <small></small>
-          </div>
           <div className="ml-auto">
             <small>
               used <strong>{formatter.format(data?.total || 0)}</strong> times

--- a/packages/front-end/components/Features/FeaturesOverview.tsx
+++ b/packages/front-end/components/Features/FeaturesOverview.tsx
@@ -1102,7 +1102,7 @@ export default function FeaturesOverview({
                       />
                     </Box>
                     {featureUsage && (
-                      <Box className="ml-auto" flexGrow="1">
+                      <Box className="ml-auto">
                         <FeatureUsageGraph data={featureUsage?.defaultValue} />
                       </Box>
                     )}


### PR DESCRIPTION
### Features and Changes
The position of the feature usage graph was half way across the screen instead of right aligned as it's containing box was allowed to grow.

Also removed an empty div and small tag that was doing nothing.

### Screenshots

![Screenshot 2025-02-25 at 3 05 22 PM](https://github.com/user-attachments/assets/45062444-406e-465f-850f-8be0b9f25950)
