### PR TITLE
dont allow deleting and sanity checks 

### DIFF
--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -1671,6 +1671,13 @@ export async function deleteExperimentPhase(
   if (!context.permissions.canUpdateExperiment(experiment, changes)) {
     context.permissions.throwPermissionError();
   }
+  //dont delete phase if it is the only phase
+  if (experiment.phases.length === 1) {
+    res.status(400).json({
+      status: 400,
+      message: "Cannot delete the only phase",
+    });
+  }
 
   const linkedFeatureIds = experiment.linkedFeatures || [];
 

--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -1671,7 +1671,7 @@ export async function deleteExperimentPhase(
   if (!context.permissions.canUpdateExperiment(experiment, changes)) {
     context.permissions.throwPermissionError();
   }
-  //dont delete phase if it is the only phase
+
   if (experiment.phases.length === 1) {
     res.status(400).json({
       status: 400,

--- a/packages/front-end/components/Experiment/EditPhaseModal.tsx
+++ b/packages/front-end/components/Experiment/EditPhaseModal.tsx
@@ -32,10 +32,10 @@ export default function EditPhaseModal({
   const form = useForm<ExperimentPhaseStringDates>({
     defaultValues: {
       ...experiment.phases[i],
-      seed: experiment.phases[i].seed ?? experiment.trackingKey,
-      dateStarted: (experiment.phases[i].dateStarted ?? "").substr(0, 16),
-      dateEnded: experiment.phases[i].dateEnded
-        ? (experiment.phases[i].dateEnded ?? "").substr(0, 16)
+      seed: experiment.phases[i]?.seed ?? experiment.trackingKey,
+      dateStarted: (experiment.phases[i]?.dateStarted ?? "").substr(0, 16),
+      dateEnded: experiment.phases[i]?.dateEnded
+        ? (experiment.phases[i]?.dateEnded ?? "").substr(0, 16)
         : "",
     },
   });

--- a/packages/front-end/components/Experiment/EditPhasesModal.tsx
+++ b/packages/front-end/components/Experiment/EditPhasesModal.tsx
@@ -73,7 +73,7 @@ export default function EditPhasesModal({
       />
     );
   }
-
+  console.log(experiment.phases.length, "phase length");
   return (
     <Modal
       trackingEventModalType="edit-phases-modal"
@@ -131,23 +131,22 @@ export default function EditPhasesModal({
                 >
                   Edit
                 </button>
-                {(experiment.status !== "running" || !hasLinkedChanges) && (
-                  <DeleteButton
-                    className="ml-2"
-                    displayName="phase"
-                    additionalMessage={
-                      experiment.phases.length === 1
-                        ? "This is the only phase. Deleting this will revert the experiment to a draft."
-                        : ""
-                    }
-                    onClick={async () => {
-                      await apiCall(`/experiment/${experiment.id}/phase/${i}`, {
-                        method: "DELETE",
-                      });
-                      mutateExperiment();
-                    }}
-                  />
-                )}
+                {(experiment.status !== "running" || !hasLinkedChanges) &&
+                  experiment.phases.length > 1 && (
+                    <DeleteButton
+                      className="ml-2"
+                      displayName="phase"
+                      onClick={async () => {
+                        await apiCall(
+                          `/experiment/${experiment.id}/phase/${i}`,
+                          {
+                            method: "DELETE",
+                          }
+                        );
+                        mutateExperiment();
+                      }}
+                    />
+                  )}
               </td>
             </tr>
           ))}

--- a/packages/front-end/components/Experiment/EditPhasesModal.tsx
+++ b/packages/front-end/components/Experiment/EditPhasesModal.tsx
@@ -73,7 +73,6 @@ export default function EditPhasesModal({
       />
     );
   }
-  console.log(experiment.phases.length, "phase length");
   return (
     <Modal
       trackingEventModalType="edit-phases-modal"


### PR DESCRIPTION

### Features and Changes
prevents the user from deleting the only phase. it also does sanity checks if there are no phases so that the app doesn't crash when opening up the phases modal (backwards compatibility for users in that state)
<!--
  Include a description of your changes.
  If there are any new tools, API's, etc. that devs can leverage, it may be helpful to include usage info.
-->

<!--
  Indicate which issue this will close, if applicable
  For multiple issues, add a new `- Closes` or `- Fixes` line
-->

- Closes https://github.com/growthbook/growthbook/issues/3640#event-16465633512

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

<!--
  Please describe how to test these changes.
 -->

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
