### PR TITLE
Improve UX for environment selector in feature rules

### DIFF
--- a/packages/front-end/components/Environments/EnvironmentDropdown.tsx
+++ b/packages/front-end/components/Environments/EnvironmentDropdown.tsx
@@ -9,23 +9,35 @@ export default function EnvironmentDropdown({
   setEnv,
   environments,
   formatOptionLabel,
+  placeholder,
+  containerClassName,
 }: {
   label?: string;
   env?: string;
   setEnv: (env: string) => void;
   environments: Environment[];
   formatOptionLabel: FormatOptionLabelType;
+  placeholder?: string;
+  containerClassName?: string;
 }) {
   return (
     <SelectField
+      containerClassName={containerClassName}
       label={label}
       value={env || ""}
       onChange={setEnv}
-      options={environments.map((e) => ({
-        label: e.id,
-        value: e.id,
-      }))}
+      options={[
+        {
+          label: "Type to search",
+          options: environments.map((e) => ({
+            label: e.id,
+            value: e.id,
+          })),
+        },
+      ]}
       formatOptionLabel={formatOptionLabel}
+      placeholder={placeholder}
+      forceUndefinedValueToNull
     />
   );
 }

--- a/packages/front-end/components/Features/FeatureRules.tsx
+++ b/packages/front-end/components/Features/FeatureRules.tsx
@@ -124,7 +124,6 @@ export default function FeatureRules({
                 ))}
                 <Flex
                   px="1"
-                  height="100%"
                   direction="column"
                   justify="center"
                   align="center"
@@ -151,6 +150,7 @@ export default function FeatureRules({
                           </Flex>
                           <Badge
                             ml="2"
+                            mr="3"
                             label={rulesByEnv[value].length.toString()}
                             radius="full"
                             variant="solid"

--- a/packages/front-end/components/Features/FeatureRules.tsx
+++ b/packages/front-end/components/Features/FeatureRules.tsx
@@ -1,5 +1,5 @@
 import { FeatureInterface } from "back-end/types/feature";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
 import {
   FeatureRevisionInterface,
@@ -7,6 +7,7 @@ import {
 } from "back-end/src/validators/features";
 import { Environment } from "back-end/types/organization";
 import { Box, Container, Flex, Text } from "@radix-ui/themes";
+import clsx from "clsx";
 import RuleModal from "@/components/Features/RuleModal/index";
 import RuleList from "@/components/Features/RuleList";
 import track from "@/services/track";
@@ -81,79 +82,98 @@ export default function FeatureRules({
     })
   );
 
+  const [tabEnvs, dropdownEnvs] = useMemo(() => {
+    const tabEnvs: Environment[] = [];
+    const dropdownEnvs: Environment[] = [];
+    environments.forEach((env) => {
+      if (env.toggleOnList) {
+        tabEnvs.push(env);
+      } else {
+        dropdownEnvs.push(env);
+      }
+    });
+    return [tabEnvs, dropdownEnvs];
+  }, [environments]);
+
+  const selectedDropdownEnv = dropdownEnvs.find((e) => e.id === env)?.id;
+
   return (
     <>
       <Tabs value={env} onValueChange={setEnv}>
-        {environments.length < 6 ? (
-          <Container maxWidth="100%">
-            <Flex
-              align="center"
-              justify="between"
-              style={{ boxShadow: "inset 0 -1px 0 0 var(--slate-a3)" }}
-            >
-              <TabsList className="w-100" style={{ boxShadow: "none" }}>
-                <Flex wrap="wrap" overflow="hidden">
-                  {environments.map((e) => (
-                    <TabsTrigger value={e.id} key={e.id}>
-                      <Flex maxWidth="220px">
-                        <Text truncate>{e.id}</Text>
-                      </Flex>
-                      <Badge
-                        ml="2"
-                        label={rulesByEnv[e.id].length.toString()}
-                        radius="full"
-                        variant="solid"
-                        color="violet"
-                      ></Badge>
-                    </TabsTrigger>
-                  ))}
-                </Flex>
-              </TabsList>
-              <Link
-                ml="2"
-                onClick={() => setCompareEnvModal({ sourceEnv: env })}
-                underline="none"
-                wrap="nowrap"
-                size="1"
-              >
-                Compare environments
-              </Link>
-            </Flex>
-          </Container>
-        ) : (
-          <Container mb={"4"} maxWidth="100%">
-            <Flex align="center" mb="3">
-              <Container flexGrow="0" width="310px" mr="4">
-                <EnvironmentDropdown
-                  env={env}
-                  setEnv={setEnv}
-                  environments={environments}
-                  formatOptionLabel={({ value }) => (
-                    <Flex justify="between" align="center">
-                      <Flex maxWidth="310px">
-                        <Text weight="medium" truncate>
-                          {value}
-                        </Text>
-                      </Flex>
-                      <Badge
-                        label={`${rulesByEnv[value].length} Rule${
-                          rulesByEnv[value].length === 1 ? "" : "s"
-                        } applied`}
-                        ml="2"
-                      />
+        <Container maxWidth="100%">
+          <Flex
+            align="center"
+            justify="between"
+            style={{ boxShadow: "inset 0 -1px 0 0 var(--slate-a3)" }}
+          >
+            <TabsList className="w-full" style={{ boxShadow: "none" }}>
+              <Flex wrap="wrap" overflow="hidden">
+                {tabEnvs.map((e) => (
+                  <TabsTrigger value={e.id} key={e.id}>
+                    <Flex maxWidth="220px">
+                      <Text truncate>{e.id}</Text>
                     </Flex>
-                  )}
-                />
-              </Container>
-              <Link
-                onClick={() => setCompareEnvModal({ sourceEnv: env })}
-                underline="none"
-              >
-                Compare environments
-              </Link>
-            </Flex>
-          </Container>
-        )}
+                    <Badge
+                      ml="2"
+                      label={rulesByEnv[e.id].length.toString()}
+                      radius="full"
+                      variant="solid"
+                      color="violet"
+                    ></Badge>
+                  </TabsTrigger>
+                ))}
+                <Flex
+                  px="1"
+                  height="100%"
+                  direction="column"
+                  justify="center"
+                  align="center"
+                  className={clsx("tab-trigger-container", {
+                    active: !!selectedDropdownEnv,
+                  })}
+                >
+                  <Container
+                    flexGrow="0"
+                    minWidth={selectedDropdownEnv ? undefined : "100px"}
+                  >
+                    <EnvironmentDropdown
+                      containerClassName={"select-dropdown-no-underline"}
+                      env={selectedDropdownEnv}
+                      setEnv={setEnv}
+                      environments={dropdownEnvs}
+                      placeholder="Other...    "
+                      formatOptionLabel={({ value }) => (
+                        <Flex align="center">
+                          <Flex maxWidth="150px">
+                            <Text weight="medium" truncate>
+                              {value}
+                            </Text>
+                          </Flex>
+                          <Badge
+                            ml="2"
+                            label={rulesByEnv[value].length.toString()}
+                            radius="full"
+                            variant="solid"
+                            color="violet"
+                          ></Badge>
+                        </Flex>
+                      )}
+                    />
+                  </Container>
+                </Flex>
+              </Flex>
+            </TabsList>
+            <Link
+              ml="2"
+              onClick={() => setCompareEnvModal({ sourceEnv: env })}
+              underline="none"
+              wrap="nowrap"
+              size="1"
+            >
+              Compare environments
+            </Link>
+          </Flex>
+        </Container>
         {environments.map((e) => {
           return (
             <TabsContent key={e.id} value={e.id}>

--- a/packages/front-end/components/Features/FeatureRules.tsx
+++ b/packages/front-end/components/Features/FeatureRules.tsx
@@ -1,5 +1,5 @@
 import { FeatureInterface } from "back-end/types/feature";
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
 import {
   FeatureRevisionInterface,
@@ -82,19 +82,8 @@ export default function FeatureRules({
     })
   );
 
-  const [tabEnvs, dropdownEnvs] = useMemo(() => {
-    const tabEnvs: Environment[] = [];
-    const dropdownEnvs: Environment[] = [];
-    environments.forEach((env) => {
-      if (env.toggleOnList) {
-        tabEnvs.push(env);
-      } else {
-        dropdownEnvs.push(env);
-      }
-    });
-    return [tabEnvs, dropdownEnvs];
-  }, [environments]);
-
+  const tabEnvs = environments.slice(0, 4);
+  const dropdownEnvs = environments.slice(4);
   const selectedDropdownEnv = dropdownEnvs.find((e) => e.id === env)?.id;
 
   return (
@@ -122,45 +111,61 @@ export default function FeatureRules({
                     ></Badge>
                   </TabsTrigger>
                 ))}
-                <Flex
-                  px="1"
-                  direction="column"
-                  justify="center"
-                  align="center"
-                  className={clsx("tab-trigger-container", {
-                    active: !!selectedDropdownEnv,
-                  })}
-                >
-                  <Container
-                    flexGrow="0"
-                    minWidth={selectedDropdownEnv ? undefined : "100px"}
+                {dropdownEnvs.length === 1 && (
+                  <TabsTrigger value={dropdownEnvs[0].id}>
+                    <Flex maxWidth="220px">
+                      <Text truncate>{dropdownEnvs[0].id}</Text>
+                    </Flex>
+                    <Badge
+                      ml="2"
+                      label={rulesByEnv[dropdownEnvs[0].id].length.toString()}
+                      radius="full"
+                      variant="solid"
+                      color="violet"
+                    ></Badge>
+                  </TabsTrigger>
+                )}
+                {dropdownEnvs.length > 1 && (
+                  <Flex
+                    px="1"
+                    direction="column"
+                    justify="center"
+                    align="center"
+                    className={clsx("tab-trigger-container", {
+                      active: !!selectedDropdownEnv,
+                    })}
                   >
-                    <EnvironmentDropdown
-                      containerClassName={"select-dropdown-no-underline"}
-                      env={selectedDropdownEnv}
-                      setEnv={setEnv}
-                      environments={dropdownEnvs}
-                      placeholder="Other..."
-                      formatOptionLabel={({ value }) => (
-                        <Flex align="center">
-                          <Flex maxWidth="150px">
-                            <Text weight="medium" truncate>
-                              {value}
-                            </Text>
+                    <Container
+                      flexGrow="0"
+                      minWidth={selectedDropdownEnv ? undefined : "100px"}
+                    >
+                      <EnvironmentDropdown
+                        containerClassName={"select-dropdown-no-underline"}
+                        env={selectedDropdownEnv}
+                        setEnv={setEnv}
+                        environments={dropdownEnvs}
+                        placeholder="Other..."
+                        formatOptionLabel={({ value }) => (
+                          <Flex align="center">
+                            <Flex maxWidth="150px">
+                              <Text weight="medium" truncate>
+                                {value}
+                              </Text>
+                            </Flex>
+                            <Badge
+                              ml="2"
+                              mr="3"
+                              label={rulesByEnv[value].length.toString()}
+                              radius="full"
+                              variant="solid"
+                              color="violet"
+                            ></Badge>
                           </Flex>
-                          <Badge
-                            ml="2"
-                            mr="3"
-                            label={rulesByEnv[value].length.toString()}
-                            radius="full"
-                            variant="solid"
-                            color="violet"
-                          ></Badge>
-                        </Flex>
-                      )}
-                    />
-                  </Container>
-                </Flex>
+                        )}
+                      />
+                    </Container>
+                  </Flex>
+                )}
               </Flex>
             </TabsList>
             <Link

--- a/packages/front-end/components/Features/FeatureRules.tsx
+++ b/packages/front-end/components/Features/FeatureRules.tsx
@@ -141,7 +141,7 @@ export default function FeatureRules({
                       env={selectedDropdownEnv}
                       setEnv={setEnv}
                       environments={dropdownEnvs}
-                      placeholder="Other...    "
+                      placeholder="Other..."
                       formatOptionLabel={({ value }) => (
                         <Flex align="center">
                           <Flex maxWidth="150px">

--- a/packages/front-end/styles/global.scss
+++ b/packages/front-end/styles/global.scss
@@ -2702,7 +2702,8 @@ html {
     font-size: 10px;
   }
 }
-.select-dropdown-underline {
+.select-dropdown-underline,
+.select-dropdown-no-underline {
   position: relative !important;
   top: 1px !important;
 
@@ -2774,6 +2775,18 @@ html {
     }
   }
 }
+.select-dropdown-no-underline {
+  .gb-select__control {
+    border-radius: 0 !important;
+    border: 0 transparent !important;
+    border-bottom: 0 transparent !important;
+
+    &:hover {
+      border-bottom: 0 transparent !important;
+    }
+  }
+}
+
 .phase-selector {
   .gb-select__control {
     background-color: transparent !important;
@@ -3497,4 +3510,19 @@ input:disabled {
 
 .disabled-opacity {
   opacity: 0.65;
+}
+
+// CSS style alternative to <TabsTrigger> for when a custom container is necessary
+.tab-trigger-container {
+  position: relative !important;
+  &.active::before {
+    box-sizing: border-box;
+    content: "";
+    height: 2px;
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background-color: var(--accent-indicator);
+  }
 }

--- a/packages/front-end/styles/global.scss
+++ b/packages/front-end/styles/global.scss
@@ -2777,8 +2777,6 @@ html {
 }
 .select-dropdown-no-underline {
   .gb-select__control {
-    border-radius: 0 !important;
-    border: 0 transparent !important;
     border-bottom: 0 transparent !important;
 
     &:hover {


### PR DESCRIPTION
### Features and Changes

Changes the UX for environment selection to always show the first 4 environments as separate tabs, and the remaining environments in a dropdown.
Style updates to make the dropdown fit in alongside the tabs

- Closes #3574 

### Screenshots

#### <=5 environments
![image](https://github.com/user-attachments/assets/b7aa4371-a916-4a29-aeb3-9c038c7c86f0)
![image](https://github.com/user-attachments/assets/35ab489e-7d01-44eb-babf-996ec43ea81d)


#### >5 environments
![image](https://github.com/user-attachments/assets/07362c06-caaf-4a46-8b2c-1d55d9d67a6b)

![env-selector](https://github.com/user-attachments/assets/673ba9e5-1c38-4de2-8ebc-bb308b661065)

The only remaining UI weirdness (visible in the above gif) is that typing in the dropdown will sometimes cause the caret to clip with the text. This is a general issue with our select containers rather than specific to this component so I've left it be for now.
