### PR TITLE
Allow empty lists for feature $in and $nin conditions

### DIFF
--- a/packages/front-end/services/features.ts
+++ b/packages/front-end/services/features.ts
@@ -1055,10 +1055,15 @@ export function condToJson(
     } else if (operator === "$notEmpty") {
       obj[field]["$size"] = { $gt: 0 };
     } else if (operator === "$in" || operator === "$nin") {
-      obj[field][operator] = value
-        .split(",")
-        .map((x) => x.trim())
-        .map((x) => parseValue(x, attributes.get(field)?.datatype));
+      // Allow for the empty list
+      if (value === "") {
+        obj[field][operator] = [];
+      } else {
+        obj[field][operator] = value
+          .split(",")
+          .map((x) => x.trim())
+          .map((x) => parseValue(x, attributes.get(field)?.datatype));
+      }
     } else if (operator === "$inGroup" || operator === "$notInGroup") {
       obj[field][operator] = value;
     } else {


### PR DESCRIPTION
### Features and Changes

Currently, leaving the text field empty when creating an "in the list" targeting condition leads not to an empty list but to the list `[""]`. This then results in the opposite of desired behavior when checking membership of an attribute that is only sometimes set.

- Closes #3657

### Testing

Create a feature with an empty list condition without these changes and inspect the SDK payload to see it rendered as `$in: [""]`.
Then, with the changes in place, create a second condition (or update the first), and observe `$in: []`

### Screenshots

### Incorrect `main` behavior
![image](https://github.com/user-attachments/assets/0a119e03-f929-48cb-87ef-439a5df3cb70)


### Correct behavior
![image](https://github.com/user-attachments/assets/1f26b103-8953-45af-81ce-434e4b3700d8)
