### PR TITLE
Use correct reference for VE status check

### DIFF
--- a/packages/front-end/components/OpenVisualEditorLink.tsx
+++ b/packages/front-end/components/OpenVisualEditorLink.tsx
@@ -65,7 +65,7 @@ export async function openVisualEditor(
 
     try {
       const res = await fetch(
-        "chrome-extension://opemhndcehfgipokneipaafbglcecjia/js/logo192.png",
+        "chrome-extension://opemhndcehfgipokneipaafbglcecjia/js/logo128.png",
         { method: "HEAD" }
       );
       if (!res.ok) {
@@ -106,7 +106,6 @@ export async function openVisualEditor(
     source: "visual-editor-ui",
     status: "success",
   });
-  window.location.href = url;
   return null;
 }
 


### PR DESCRIPTION
Hardcoded icon path changed, which we are using for status checks. Update path so VE opens without a warning message.