### PR TITLE
don't show account plan notice for expired notices older than 30 days

### DIFF
--- a/packages/front-end/components/Layout/AccountPlanNotices.tsx
+++ b/packages/front-end/components/Layout/AccountPlanNotices.tsx
@@ -128,29 +128,34 @@ export default function AccountPlanNotices() {
             </Tooltip>
           );
         case "License expired":
-          return (
-            <Tooltip
-              body={
-                license.plan === "enterprise" ? (
-                  <>
-                    Your license expired on{" "}
-                    <strong>{date(license.dateExpires || "")}</strong>. Contact
-                    sales@growthbook.io to renew.
-                  </>
-                ) : (
-                  <>
-                    Your license expired on{" "}
-                    <strong>{date(license.dateExpires || "")}</strong>. Go to
-                    your settings &gt; billing page to renew.
-                  </>
-                )
-              }
-            >
-              <div className="alert alert-danger py-1 px-2 d-none d-md-block mb-0 mr-1">
-                <FaExclamationTriangle /> license expired
-              </div>
-            </Tooltip>
-          );
+          // if the license expired more than 30 days ago, we don't show the notice
+          if (daysLeft(license.dateExpires || "") < -30) {
+            return null;
+          } else {
+            return (
+              <Tooltip
+                body={
+                  license.plan === "enterprise" ? (
+                    <>
+                      Your license expired on{" "}
+                      <strong>{date(license.dateExpires || "")}</strong>.
+                      Contact sales@growthbook.io to renew.
+                    </>
+                  ) : (
+                    <>
+                      Your license expired on{" "}
+                      <strong>{date(license.dateExpires || "")}</strong>. Go to
+                      your settings &gt; billing page to renew.
+                    </>
+                  )
+                }
+              >
+                <div className="alert alert-danger py-1 px-2 d-none d-md-block mb-0 mr-1">
+                  <FaExclamationTriangle /> license expired
+                </div>
+              </Tooltip>
+            );
+          }
         case "Email not verified":
           return (
             <Tooltip


### PR DESCRIPTION
### Features and Changes

One difference between stripe subscriptions on the organization vs on the license is that for licenses we show the `AccountPlanNotice` that it is cancelled.  While this can be useful for recently expired licenses, but if no one renewed in the month since they lost their pro access they probably won't reactivate it soon and they are probably well aware they are not on pro anymore, so no need to show the message indefinitely.

Also as we migrate we don't want people suddenly seeing the message even though they went off pro over a year ago or something.

### Testing

Update an org's license to expiring a week ago and still see the message.  Then updated it to 2 months ago and don't see the message any more.  Still see no Pro/Enterprise tag, and see that the upgrade modal still opens.