### PR TITLE
[bugfix] Block CUPED for non-optimized fact ratio metrics

### DIFF
--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -1203,8 +1203,6 @@ export default abstract class SqlIntegration
       "main_covariate_sum_product",
       "quantile",
       "theta",
-      "main_denominator_sum_product",
-      "main_covariate_sum_product",
       "main_post_denominator_pre_sum_product",
       "main_pre_denominator_post_sum_product",
       "main_pre_denominator_pre_sum_product",
@@ -3022,7 +3020,9 @@ export default abstract class SqlIntegration
     // where RA is actually possible
     const regressionAdjusted =
       settings.regressionAdjustmentEnabled &&
-      isRegressionAdjusted(metric, denominator);
+      isRegressionAdjusted(metric, denominator) &&
+      // and block RA for cuped for experiment metric query only, only works for optimized queries
+      !isRatioMetric(metric, denominator);
 
     const regressionAdjustmentHours = regressionAdjusted
       ? (metric.regressionAdjustmentDays ?? 0) * 24

--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -3021,7 +3021,7 @@ export default abstract class SqlIntegration
     const regressionAdjusted =
       settings.regressionAdjustmentEnabled &&
       isRegressionAdjusted(metric, denominator) &&
-      // and block RA for cuped for experiment metric query only, only works for optimized queries
+      // and block RA for experiment metric query only, only works for optimized queries
       !isRatioMetric(metric, denominator);
 
     const regressionAdjustmentHours = regressionAdjusted


### PR DESCRIPTION
This blocks weird SQL from being run for non-optimized fact metrics which was causing some bugs.

We should probably also block it upstream somehow or in the return object so we can explain in the UI that CUPED was not applied, but we should launch this bugfix ASAP to resolve some issues with customer data.

### Testing

Without this fix, you get a `main_covariate_sum_product` on its own which is meaningless for Ratio CUPED and was causing one customer's queries to fail.

With this fix, we only get the standard SQL fields for a ratio metric and the stats engine knows to treat it just as a ratio metric.