### PR TITLE
Remove add implementation when no options remain

### DIFF
--- a/packages/front-end/components/Experiment/LinkedChanges/AddLinkedChanges.tsx
+++ b/packages/front-end/components/Experiment/LinkedChanges/AddLinkedChanges.tsx
@@ -174,8 +174,8 @@ export default function AddLinkedChanges({
   };
 
   const possibleSections = Object.keys(sections);
-
   const sectionsToRender = possibleSections.filter((s) => sections[s].render);
+  if (!sectionsToRender.length) return null;
 
   return (
     <div className="appbox px-4 py-3 my-4">


### PR DESCRIPTION
Removes this empty section from experiment page:

<img width="1359" alt="image" src="https://github.com/user-attachments/assets/9547714c-f07b-4909-805f-512528ec3666" />
