### PR TITLE
Filter /reports by project

### DIFF
--- a/packages/front-end/pages/reports.tsx
+++ b/packages/front-end/pages/reports.tsx
@@ -12,14 +12,16 @@ import Toggle from "@/components/Forms/Toggle";
 import { useUser } from "@/services/UserContext";
 import Field from "@/components/Forms/Field";
 import ShareStatusBadge from "@/components/Report/ShareStatusBadge";
+import { useDefinitions } from "@/services/DefinitionsContext";
 
 const ReportsPage = (): React.ReactElement => {
   const router = useRouter();
+  const { project } = useDefinitions();
 
   const { data, error } = useApi<{
     reports: ReportInterface[];
     experiments: ExperimentInterface[];
-  }>(`/reports`);
+  }>(`/reports?project=${project || ""}`);
   const [onlyMyReports, setOnlyMyReports] = useState(true);
 
   const { userId, getUserDisplay } = useUser();


### PR DESCRIPTION
### Features and Changes

Previously, the `/reports` page was returning all reports, regardless of the current project selected. The endpoint this page was hitting is capable of filtering based on a projects URL param - this PR adds that URL param to take advantage of it.

- Closes - https://github.com/growthbook/growthbook/issues/927

### Dependencies

None

### Testing

- [x] Ensure that when `All Projects` is selected, the endpoint returns reports for all projects
- [x] Ensure that when a project is selected, only the reports for that project

