### PR TITLE
Add Ctrl-F Functionality to CodeTextArea

### DIFF
--- a/packages/front-end/components/Forms/CodeTextArea.tsx
+++ b/packages/front-end/components/Forms/CodeTextArea.tsx
@@ -16,6 +16,7 @@ const AceEditor = dynamic(
     await import("ace-builds/src-noconflict/mode-json");
     await import("ace-builds/src-noconflict/theme-textmate");
     await import("ace-builds/src-noconflict/theme-tomorrow_night");
+    await import("ace-builds/src-noconflict/ext-searchbox");
 
     return reactAce;
   },


### PR DESCRIPTION
### Features and Changes

This PR resolves https://github.com/growthbook/growthbook/issues/3723. When using `Ctrl+F` errors were being thrown in the console (and no search functionality was working).

I located this [GH issue](https://github.com/securingsincity/react-ace/issues/178) from the React Ace authors that outlines how to resolve this and support `Crtl+F`.

- Closes [**(add link to issue here)**](https://github.com/growthbook/growthbook/issues/3723)

### Dependencies

N/A

### Testing

- [x] Ensure you can use the `Crtl+F` (or `Cmd+F` for Mac) and it opens the search and find dialog and doesn't throw any errors in the console.

### Screenshots
![Screenshot 2025-02-27 at 1 39 45 PM](https://github.com/user-attachments/assets/7cd5040e-f51c-488e-b5f8-025bbd6ad395)
