### PR TITLE
Rename form input to get LastPass/other password managers to ignore it

### DIFF
--- a/packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentifierTypes/EditIdentifierType.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentifierTypes/EditIdentifierType.tsx
@@ -27,21 +27,21 @@ export const EditIdentifierType: FC<EditIdentifierTypeProps> = ({
 
   const form = useForm({
     defaultValues: {
-      userIdType: userIdType,
+      idType: userIdType,
       description: description,
     },
   });
 
   const handleSubmit = form.handleSubmit(async (value) => {
-    await onSave(value.userIdType, value.description);
+    await onSave(value.idType, value.description);
 
     form.reset({
-      userIdType: "",
+      idType: "",
       description: "",
     });
   });
 
-  const userEnteredUserIdType = form.watch("userIdType");
+  const userEnteredUserIdType = form.watch("idType");
 
   const isDuplicate = useMemo(() => {
     return mode === "add" && existingIds.includes(userEnteredUserIdType);
@@ -82,7 +82,7 @@ export const EditIdentifierType: FC<EditIdentifierTypeProps> = ({
 
         <Field
           label="Identifier Type"
-          {...form.register("userIdType")}
+          {...form.register("idType")}
           pattern="^[a-z_]+$"
           title="Only lowercase letters and underscores allowed"
           readOnly={mode === "edit"}


### PR DESCRIPTION
### Features and Changes

LastPass, and perhaps other password managers will try and autofill an input that has "userId" within it's name.  We could alternatively added `autocomple="off"` to the input, but LastPass only respects that if users click a button in their setting, while having a different name for the input the user doesn't need to do anything.

### Testing

Add an identifier type.
See that it saved and is named correctly.
Click on it to edit it.
See that the name you gave it is correctly pre-populated in the identifier type field in order to edit it.
