### PR TITLE
[api] Allow update fact metric to go from ratio to non-ratio

### DIFF
--- a/packages/back-end/src/api/fact-metrics/updateFactMetric.ts
+++ b/packages/back-end/src/api/fact-metrics/updateFactMetric.ts
@@ -52,6 +52,10 @@ export async function getUpdateFactMetricPropsFromBody(
       factTable: factTable,
     });
   }
+  // remove denominator for non-ratio metrics
+  if (metricType !== "ratio") {
+    updates.denominator = undefined;
+  }
   if (denominator) {
     updates.denominator = {
       filters: [],


### PR DESCRIPTION
### Features and Changes

In the REST API, deletes `denominator` from `ratio` Fact Metrics when updating it to a non-ratio fact metric type.

### Testing

Previously, an update payload like:
```
{
  "metricType": "mean",
  "numerator": {
      "factTableId": "ftb_2s1bx837m4bs22a6",
      "column": "clerk",
      "aggregation": "count distinct",
      "filters": []
  } 
}
```

Would return
```
{
  "message": "Denominator not allowed for non-ratio metric"
}
```

Because the update would try to set the `metricType` to `"mean"` but the `denominator` still existed in the fact metric. Now, when updating to a non-fact metric, we make sure the denominator in the existing model is deleted, but we still validate the payload if the denominator is in the payload and throw the requisite errors.

Now, the above payload works as expected and returns a `"mean"` metric with no `denominator`.

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
