### PR TITLE
Linking tooltip for risk thresholds being violated to docs

### DIFF
--- a/docs/docs/statistics/details.mdx
+++ b/docs/docs/statistics/details.mdx
@@ -100,6 +100,10 @@ where $\Phi_{posterior}$ is the CDF of the distribution $N(\Delta_{posterior}, \
 ### Risk
 
 Risk is the expected loss, where loss is considered to be 0 if the variation is beneficial.
+Define $p$ as the probability that treatment is worse than the control (i.e., 1 - Chance to Win).
+Define $L$ as the average loss under the scenario where treatment is worse than control.
+Then the risk is $p \cdot L$.
+We model the loss $L$ as the mean of a truncated normal distribution with mean $\Delta_{posterior}$, variance $\sigma^2_{posterior}$, and boundaries at $-\infty$ and 0 for a variation, and 0 and $\infty$ for baseline.
 
 ### Confidence Interval
 

--- a/docs/docs/statistics/details.mdx
+++ b/docs/docs/statistics/details.mdx
@@ -97,6 +97,10 @@ $$
 
 where $\Phi_{posterior}$ is the CDF of the distribution $N(\Delta_{posterior}, \sigma^2_{posterior})$.
 
+### Risk
+
+Risk is the expected loss, where loss is considered to be 0 if the variation is beneficial.
+
 ### Confidence Interval
 
 Our “confidence interval” in the Bayesian engine is an interval from the 2.5th to the 97.5th percentile of the posterior distribution (e.g. $\Phi^{-1}_{posterior}(0.025)$ and $\Phi^{-1}_{posterior}(0.975)$). We plot the posterior between these two points in the GrowthBook UI.

--- a/docs/docs/statistics/overview.mdx
+++ b/docs/docs/statistics/overview.mdx
@@ -72,12 +72,11 @@ We have found this tends to lead to more accurate interpretations. For example, 
 just reading the above as _"it’s 17% better"_, people tend to factor in the error bars (_"it’s
 about 17% better, but there’s a lot of uncertainty still"_).
 
-**Risk** (or expected loss) can be interpreted as If I stop the test now and choose X _“and X is actually worse_, how
-much am I expected to lose?”. This is shown as a relative percent change - so if your baseline metric value is \$5/user,
-a 10% risk equates to losing \$0.50/user. You can specify your risk tolerance thresholds on a per-metric basis within GrowthBook.
+**Risk** (or expected loss) can be interpreted as, "If I stop the test now and choose variation X, under the scenarios where variation X is worse, how much am I expected to lose?"
+This is shown as a relative percent change - so if your baseline metric value is \$5/user, a 10% risk equates to losing \$0.50/user.
+You can specify your risk tolerance thresholds on a per-metric basis within GrowthBook.
 
-GrowthBook gives the human decision maker everything they need to weigh the results against
-external factors to determine when to stop an experiment and which variation to declare the winner.
+GrowthBook gives the human decision maker everything they need to weigh the results against external factors to determine when to stop an experiment and which variation to declare the winner.
 
 ## Frequentist Statistics
 

--- a/docs/docs/statistics/overview.mdx
+++ b/docs/docs/statistics/overview.mdx
@@ -72,8 +72,8 @@ We have found this tends to lead to more accurate interpretations. For example, 
 just reading the above as _"it’s 17% better"_, people tend to factor in the error bars (_"it’s
 about 17% better, but there’s a lot of uncertainty still"_).
 
-**Risk** (or expected loss) can be interpreted as _“If I stop the test now and choose X and it’s actually worse, how
-much am I expected to lose?”_. This is shown as a relative percent change - so if your baseline metric value is \$5/user,
+**Risk** (or expected loss) can be interpreted as If I stop the test now and choose X _“and X is actually worse_, how
+much am I expected to lose?”. This is shown as a relative percent change - so if your baseline metric value is \$5/user,
 a 10% risk equates to losing \$0.50/user. You can specify your risk tolerance thresholds on a per-metric basis within GrowthBook.
 
 GrowthBook gives the human decision maker everything they need to weigh the results against

--- a/docs/docs/statistics/overview.mdx
+++ b/docs/docs/statistics/overview.mdx
@@ -74,7 +74,7 @@ about 17% better, but there’s a lot of uncertainty still"_).
 
 **Risk** (or expected loss) can be interpreted as, "If I stop the test now and choose variation X, under the scenarios where variation X is worse, how much am I expected to lose?"
 This is shown as a relative percent change - so if your baseline metric value is \$5/user, a 10% risk equates to losing \$0.50/user.
-You can specify your risk tolerance thresholds on a per-metric basis within GrowthBook.
+You can specify your risk tolerance thresholds on a per-metric basis.
 
 GrowthBook gives the human decision maker everything they need to weigh the results against external factors to determine when to stop an experiment and which variation to declare the winner.
 

--- a/docs/docs/using/experimenting.mdx
+++ b/docs/docs/using/experimenting.mdx
@@ -115,7 +115,7 @@ see the full data, including 'risk', mouse over any of the results.
 
 ![GrowthBook Results](/images/using/experiment-results-bayesian-details2.png)
 
-Risk tells you how much you are predicted to lose if you choose the selected variation as the winner
+**Risk** tells you how much you are predicted to lose if you choose the selected variation as the winner
 and you are wrong. You can specify upper risk thresholds (designed to flag high-risk outcomes) and lower risk thresholds (designed to flag low-risk outcomes) in Behavior on the Metrics tab. Red indicates that the treatment variation has risk above the high-risk threshold.
 Yellow indicates that your risk is between the two thresholds. You can use the dropdown to see the risk of choosing a different winner if you have multiple variations.
 

--- a/packages/front-end/components/Experiment/ResultsTableTooltip/ResultsTableTooltip.tsx
+++ b/packages/front-end/components/Experiment/ResultsTableTooltip/ResultsTableTooltip.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import React, { DetailedHTMLProps, HTMLAttributes, useEffect } from "react";
 import {
   ExperimentReportVariationWithIndex,
@@ -15,7 +16,7 @@ import {
   BsArrowReturnRight,
 } from "react-icons/bs";
 import clsx from "clsx";
-import { FaArrowDown, FaArrowUp } from "react-icons/fa";
+import { FaArrowDown, FaArrowUp, FaQuestionCircle } from "react-icons/fa";
 import { HiOutlineExclamationCircle } from "react-icons/hi";
 import { RxInfoCircled } from "react-icons/rx";
 import { MdSwapCalls } from "react-icons/md";
@@ -595,10 +596,15 @@ export default function ResultsTableTooltip({
                         data.rowResults.riskMeta.riskStatus
                       )}
                     >
-                      <HiOutlineExclamationCircle
-                        size={18}
-                        className="flag-icon"
-                      />
+                      <Link
+                        href="https://docs.growthbook.io/using/experimenting#bayesian-results"
+                        target="_blank"
+                      >
+                        <FaQuestionCircle
+                          size={12}
+                          style={{ marginRight: "8px" }}
+                        />
+                      </Link>
                       <div className="risk">
                         <div className="risk-value">
                           risk: {data.rowResults.riskMeta.relativeRiskFormatted}


### PR DESCRIPTION
### Features and Changes

Linking tooltip for risk thresholds being violated to docs.  After discussion, linking the question mark icon was decided to be the first approach, rather than providing standalone link to docs in risk TT.  

Closes **https://github.com/growthbook/growthbook/issues/3706**

<img width="1728" alt="Screenshot 2025-02-28 at 4 21 28 PM" src="https://github.com/user-attachments/assets/46f9ca86-a8ef-44d9-83ae-b1bbfec0721d" />
