### PR TITLE
Awaits upgrade call

### DIFF
--- a/packages/front-end/components/Settings/UpgradeModal/index.tsx
+++ b/packages/front-end/components/Settings/UpgradeModal/index.tsx
@@ -101,7 +101,6 @@ export default function UpgradeModal({
     isCloud() && freeTrialAvailable && lowestPlan !== "enterprise"
       ? growthbook.getFeatureValue("pro-upgrade-modal", "OFF")
       : "OFF";
-
   const daysToGo = license?.dateExpires ? daysLeft(license.dateExpires) : 0;
 
   const hasCanceledSubscription =
@@ -435,14 +434,14 @@ export default function UpgradeModal({
     );
   }
 
-  function onSubmit() {
+  async function onSubmit() {
     if (
       featureFlagValue === "UPGRADE-ONLY" ||
       trialAndUpgradePreference === "upgrade"
     ) {
-      startPro();
+      await startPro();
     } else {
-      startProTrial(name, email);
+      await startProTrial(name, email);
     }
   }
 
@@ -530,7 +529,11 @@ export default function UpgradeModal({
               <PiCaretRight />
             </>
           }
-          submit={featureFlagValue !== "OFF" ? () => onSubmit() : undefined}
+          submit={
+            featureFlagValue !== "OFF"
+              ? async () => await onSubmit()
+              : undefined
+          }
         >
           {!permissionsUtil.canManageBilling() ? (
             <div className="text-center mt-4 mb-5">

--- a/packages/front-end/components/Settings/UpgradeModal/index.tsx
+++ b/packages/front-end/components/Settings/UpgradeModal/index.tsx
@@ -529,11 +529,7 @@ export default function UpgradeModal({
               <PiCaretRight />
             </>
           }
-          submit={
-            featureFlagValue !== "OFF"
-              ? async () => await onSubmit()
-              : undefined
-          }
+          submit={featureFlagValue !== "OFF" ? onSubmit : undefined}
         >
           {!permissionsUtil.canManageBilling() ? (
             <div className="text-center mt-4 mb-5">


### PR DESCRIPTION
### Features and Changes

Previously, we weren't awaiting the `startPro` trial, so the loading state wasn't being displayed properly.

### Testing

- [x] Ensure the loading state is displayed when `Upgrade Now` is selected
- [x] Ensure no regressions are introduced as a result of this update
