### PR TITLE
[Bug] Phase date not updating when starting an experiment

### DIFF
--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -1450,7 +1450,11 @@ export async function postExperimentStatus(
     status === "running" &&
     phases?.length > 0
   ) {
-    Object.assign(changes, getChangesToStartExperiment(context, experiment));
+    const additionalChanges: Changeset = await getChangesToStartExperiment(
+      context,
+      experiment
+    );
+    Object.assign(changes, additionalChanges);
   }
   // If starting or drafting a stopped experiment, clear the phase end date
   // and perform any needed bandit cleanup


### PR DESCRIPTION
### Features and Changes

When going from `draft` -> `running`, we're supposed to update the analysis start date to now.  This code was being skipped because of a missing `await`.