### PR TITLE
Fix unhealthy status badges for exps with no traffic query

### DIFF
--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -2814,17 +2814,18 @@ export async function updateExperimentAnalysisSummary({
 
   const standardSnapshot =
     experimentSnapshot.type === "standard" &&
-    experimentSnapshot.analyses?.[0].results.length === 1;
-  const totalUsers = overallTraffic?.variationUnits.length
-    ? overallTraffic.variationUnits.reduce((acc, a) => acc + a, 0)
-    : standardSnapshot
-    ? // fall back to first result for standard snapshots if overall traffic
-      // is missing
-      experimentSnapshot?.analyses?.[0]?.results?.[0]?.variations?.reduce(
-        (acc, a) => acc + a.users,
-        0
-      )
-    : null;
+    experimentSnapshot.analyses?.[0]?.results?.length === 1;
+  const totalUsers =
+    (overallTraffic?.variationUnits.length
+      ? overallTraffic.variationUnits.reduce((acc, a) => acc + a, 0)
+      : standardSnapshot
+      ? // fall back to first result for standard snapshots if overall traffic
+        // is missing
+        experimentSnapshot?.analyses?.[0]?.results?.[0]?.variations?.reduce(
+          (acc, a) => acc + a.users,
+          0
+        )
+      : null) ?? null;
 
   const srm = getSRMValue(experiment.type ?? "standard", experimentSnapshot);
 

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -2812,14 +2812,23 @@ export async function updateExperimentAnalysisSummary({
   const overallTraffic = experimentSnapshot.health?.traffic?.overall;
   const snapshotHealthPower = experimentSnapshot.health?.power;
 
-  const totalUsers = overallTraffic?.variationUnits?.reduce(
-    (acc, a) => acc + a,
-    0
-  );
+  const standardSnapshot =
+    experimentSnapshot.type === "standard" &&
+    experimentSnapshot.analyses?.[0].results.length === 1;
+  const totalUsers = overallTraffic?.variationUnits.length
+    ? overallTraffic.variationUnits.reduce((acc, a) => acc + a, 0)
+    : standardSnapshot
+    ? // fall back to first result for standard snapshots if overall traffic
+      // is missing
+      experimentSnapshot?.analyses?.[0]?.results?.[0]?.variations?.reduce(
+        (acc, a) => acc + a.users,
+        0
+      )
+    : null;
 
   const srm = getSRMValue(experiment.type ?? "standard", experimentSnapshot);
 
-  if (overallTraffic && totalUsers !== undefined && srm !== undefined) {
+  if (overallTraffic && srm !== undefined) {
     analysisSummary.health = {
       srm,
       multipleExposures: experimentSnapshot.multipleExposures,

--- a/packages/back-end/src/validators/experiments.ts
+++ b/packages/back-end/src/validators/experiments.ts
@@ -161,7 +161,7 @@ export type ExperimentAnalysisSettings = z.infer<
 export const experimentAnalysisSummaryHealth = z.object({
   srm: z.number(),
   multipleExposures: z.number(),
-  totalUsers: z.number(),
+  totalUsers: z.number().nullable(),
   power: z
     .discriminatedUnion("type", [
       z.object({

--- a/packages/front-end/hooks/useExperimentStatusIndicator.ts
+++ b/packages/front-end/hooks/useExperimentStatusIndicator.ts
@@ -132,7 +132,7 @@ function getStatusIndicatorData(
       ? getDetailedStatusIndicatorData(getDaysLeftStatus({ daysNeeded }))
       : undefined;
 
-    if (healthSummary) {
+    if (healthSummary?.totalUsers) {
       const srmHealthData = getSRMHealthData({
         srm: healthSummary.srm,
         srmThreshold: healthSettings.srmThreshold,

--- a/packages/shared/src/health/health.ts
+++ b/packages/shared/src/health/health.ts
@@ -102,8 +102,23 @@ export function getSRMValue(
     case "multi-armed-bandit":
       return snapshot.banditResult?.srm;
 
-    case "standard":
-      return snapshot.health?.traffic?.overall?.srm;
+    case "standard": {
+      const healthQuerySRM = snapshot.health?.traffic?.overall?.srm;
+
+      if (healthQuerySRM !== undefined) {
+        return healthQuerySRM;
+      }
+      // fall back to main results SRM for no dimension split snapshots
+      // and without health query SRM
+      // if no dimension && only one overall result (e.g. no dim splits)
+      if (
+        snapshot.type === "standard" &&
+        snapshot.analyses?.[0].results.length === 1
+      ) {
+        return snapshot.analyses?.[0]?.results?.[0]?.srm;
+      }
+      return undefined;
+    }
 
     default: {
       const _exhaustiveCheck: never = experimentType;

--- a/packages/shared/src/health/health.ts
+++ b/packages/shared/src/health/health.ts
@@ -113,7 +113,7 @@ export function getSRMValue(
       // if no dimension && only one overall result (e.g. no dim splits)
       if (
         snapshot.type === "standard" &&
-        snapshot.analyses?.[0].results.length === 1
+        snapshot.analyses?.[0]?.results?.length === 1
       ) {
         return snapshot.analyses?.[0]?.results?.[0]?.srm;
       }


### PR DESCRIPTION
This PR adds a fallback for `totalUsers` and `srm` in the `analysisSummary` to populate them even when the health query is off. 

This enables the top-level unhealthy status for users even if they don't have the health query activated.  Previously, those users were not getting their `analysisSummary` set so we would show them unhealthy banners on their results tab but no top-level status on the experiments list.

This also solves a bug where bandit users with the health query off were getting a "No data" warning even if they did have data. This was happening because `analysisSummary` was getting set for these cases because (1) `totalUsers` was 0 owing to the fact that the experiment snapshot units array wasn't missing but rather of length 0 and (2) bandit gets SRM from a different place than non-bandits. Item (2) is not true for standard experiments, so this bug was limited to bandits only.

### Testing

https://www.loom.com/share/892ea9dcc7004ac296cec8fd958f343c