### PR TITLE
Enable 'Edit status' escape hatch for drafts with data

### DIFF
--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -2749,12 +2749,14 @@ export async function getChangesToStartExperiment(
 
   const changes: Changeset = {};
 
-  // use the current date as the phase start date
-  phases[lastIndex] = {
-    ...phases[lastIndex],
-    dateStarted: new Date(),
-  };
-  changes.phases = phases;
+  // If the experiment doesn't have any results yet, reset the phase start date to now
+  if (!experiment.analysisSummary?.snapshotId) {
+    phases[lastIndex] = {
+      ...phases[lastIndex],
+      dateStarted: new Date(),
+    };
+    changes.phases = phases;
+  }
 
   // Bandit-specific changes
   if (experiment.type === "multi-armed-bandit") {

--- a/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
@@ -800,7 +800,7 @@ export default function ExperimentHeader({
               <DropdownMenuGroup>
                 {canRunExperiment &&
                   !isBandit &&
-                  experiment.status !== "draft" && (
+                  (experiment.status !== "draft" || hasResults) && (
                     <DropdownMenuItem
                       onClick={() => {
                         setStatusModal(true);


### PR DESCRIPTION
### Features and Changes

Allow editing an experiment draft status directly (without going through the "Start Experiment" flow), but only if it already has results.  Also, when going from `draft` -> `running` for an experiment, only reset the phase start date if there are no results yet.  

This enables a common workflow, where you need to quickly revert back to a draft to make a tweak to the implementation settings.