### PR TITLE
Only refresh fact table columns when needed

### DIFF
--- a/packages/back-end/src/api/bulk-import/postBulkImportFacts.ts
+++ b/packages/back-end/src/api/bulk-import/postBulkImportFacts.ts
@@ -17,6 +17,7 @@ import { createApiRequestHandler } from "back-end/src/util/handler";
 import { postBulkImportFactsValidator } from "back-end/src/validators/openapi";
 import { getCreateMetricPropsFromBody } from "back-end/src/api/fact-metrics/postFactMetric";
 import { getUpdateFactMetricPropsFromBody } from "back-end/src/api/fact-metrics/updateFactMetric";
+import { needsColumnRefresh } from "back-end/src/api/fact-tables/updateFactTable";
 
 export const postBulkImportFacts = createApiRequestHandler(
   postBulkImportFactsValidator
@@ -102,7 +103,9 @@ export const postBulkImportFacts = createApiRequestHandler(
           }
 
           await updateFactTable(req.context, existing, data);
-          await queueFactTableColumnsRefresh(existing);
+          if (needsColumnRefresh(data)) {
+            await queueFactTableColumnsRefresh(existing);
+          }
           factTableMap.set(existing.id, {
             ...existing,
             ...data,

--- a/packages/back-end/src/api/fact-tables/updateFactTable.ts
+++ b/packages/back-end/src/api/fact-tables/updateFactTable.ts
@@ -58,7 +58,9 @@ export const updateFactTable = createApiRequestHandler(
     const data: UpdateFactTableProps = { ...req.body };
 
     await updateFactTableInDb(req.context, factTable, data);
-    await queueFactTableColumnsRefresh(factTable);
+    if (needsColumnRefresh(data)) {
+      await queueFactTableColumnsRefresh(factTable);
+    }
 
     if (data.tags) {
       await addTagsDiff(req.organization.id, factTable.tags, data.tags);
@@ -69,3 +71,7 @@ export const updateFactTable = createApiRequestHandler(
     };
   }
 );
+
+export function needsColumnRefresh(changes: UpdateFactTableProps): boolean {
+  return !!(changes.sql || changes.eventName);
+}

--- a/packages/back-end/src/routers/fact-table/fact-table.controller.ts
+++ b/packages/back-end/src/routers/fact-table/fact-table.controller.ts
@@ -34,6 +34,7 @@ import {
   runColumnTopValuesQuery,
 } from "back-end/src/jobs/refreshFactTableColumns";
 import { logger } from "back-end/src/util/logger";
+import { needsColumnRefresh } from "back-end/src/api/fact-tables/updateFactTable";
 
 export const getFactTables = async (
   req: AuthRequest,
@@ -154,14 +155,16 @@ export const putFactTable = async (
   }
 
   // Update the columns
-  data.columns = await runRefreshColumnsQuery(context, datasource, {
-    ...factTable,
-    ...data,
-  } as FactTableInterface);
-  data.columnsError = null;
+  if (needsColumnRefresh(data)) {
+    data.columns = await runRefreshColumnsQuery(context, datasource, {
+      ...factTable,
+      ...data,
+    } as FactTableInterface);
+    data.columnsError = null;
 
-  if (!data.columns.some((col) => !col.deleted)) {
-    throw new Error("SQL did not return any rows");
+    if (!data.columns.some((col) => !col.deleted)) {
+      throw new Error("SQL did not return any rows");
+    }
   }
 
   await updateFactTable(context, factTable, data);

--- a/packages/back-end/src/routers/fact-table/fact-table.controller.ts
+++ b/packages/back-end/src/routers/fact-table/fact-table.controller.ts
@@ -134,7 +134,11 @@ export const postFactTable = async (
 };
 
 export const putFactTable = async (
-  req: AuthRequest<UpdateFactTableProps, { id: string }>,
+  req: AuthRequest<
+    UpdateFactTableProps,
+    { id: string },
+    { forceColumnRefresh?: string }
+  >,
   res: Response<{ status: 200 }>
 ) => {
   const data = req.body;
@@ -155,7 +159,7 @@ export const putFactTable = async (
   }
 
   // Update the columns
-  if (needsColumnRefresh(data)) {
+  if (req.query?.forceColumnRefresh || needsColumnRefresh(data)) {
     data.columns = await runRefreshColumnsQuery(context, datasource, {
       ...factTable,
       ...data,

--- a/packages/front-end/components/FactTables/ColumnList.tsx
+++ b/packages/front-end/components/FactTables/ColumnList.tsx
@@ -94,10 +94,13 @@ export default function ColumnList({ factTable }: Props) {
           <Button
             color="link"
             onClick={async () => {
-              await apiCall(`/fact-tables/${factTable.id}`, {
-                method: "PUT",
-                body: JSON.stringify({}),
-              });
+              await apiCall(
+                `/fact-tables/${factTable.id}?forceColumnRefresh=1`,
+                {
+                  method: "PUT",
+                  body: JSON.stringify({}),
+                }
+              );
               mutateDefinitions();
             }}
           >


### PR DESCRIPTION
### Features and Changes

Updating anything on a fact table was triggering a full refresh, which ran a SQL query to check if any columns have changed.  This is not necessary when just changing things like `tags` or `projects`. 

This PR changes the logic to only run a full refresh if the SQL definition changes.