### PR TITLE
Include Experiments using hashAttribute in attr references

### DIFF
--- a/packages/front-end/pages/attributes.tsx
+++ b/packages/front-end/pages/attributes.tsx
@@ -69,6 +69,8 @@ const FeatureAttributesPage = (): React.ReactElement => {
 
     for (const experiment of experiments) {
       try {
+        attributeExperimentIds[experiment.hashAttribute] ||= new Set<string>();
+        attributeExperimentIds[experiment.hashAttribute].add(experiment.id);
         const phase = experiment.phases?.[experiment.phases.length - 1];
         const parsedCondition = JSON.parse(phase?.condition ?? "{}");
         recursiveWalk(parsedCondition, (node) => {
@@ -163,7 +165,7 @@ const FeatureAttributesPage = (): React.ReactElement => {
           <Tooltip
             tipPosition="bottom"
             state={showReferences === i}
-            popperStyle={{ marginLeft: 50 }}
+            popperStyle={{ marginLeft: 50, marginTop: 15 }}
             body={
               <div
                 className="px-3 py-2"
@@ -172,7 +174,7 @@ const FeatureAttributesPage = (): React.ReactElement => {
                 <a
                   role="button"
                   style={{ top: 3, right: 5 }}
-                  className="position-absolute text-gray cursor-pointer"
+                  className="position-absolute text-dark-gray cursor-pointer"
                   onClick={(e) => {
                     e.preventDefault();
                     setShowReferences(null);


### PR DESCRIPTION
### Features and Changes
Adds the `hashAttribute` of experiments to the sources of attribute references on the `/attributes` page 
Plus two minor style tweaks to improve the tooltip's usability

- Closes #3642


### Screenshots

#### Light mode
![image](https://github.com/user-attachments/assets/6d2b2e6b-383f-43fc-a3da-54662644e408)

#### Dark mode
![image](https://github.com/user-attachments/assets/796bb3d4-5566-4655-ae40-b8f79a0a3cf3)
