### PR TITLE
CUPED ratio bug fixes

### DIFF
--- a/packages/stats/gbstats/bayesian/tests.py
+++ b/packages/stats/gbstats/bayesian/tests.py
@@ -148,8 +148,6 @@ class EffectBayesianABTest(BayesianABTest):
         config: EffectBayesianConfig = EffectBayesianConfig(),
     ):
         super().__init__(stat_a, stat_b, config)
-        self.stat_a = stat_a
-        self.stat_b = stat_b
         self.config = config
 
     def compute_result(self):

--- a/packages/stats/gbstats/models/tests.py
+++ b/packages/stats/gbstats/models/tests.py
@@ -75,6 +75,16 @@ class BaseABTest(ABC):
                 self.stat_a.theta = theta
                 self.stat_b.theta = theta
 
+        if isinstance(stat_a, RegressionAdjustedRatioStatistic):
+            if not isinstance(stat_b, RegressionAdjustedRatioStatistic):
+                raise ValueError(
+                    "If stat_a is a RegressionAdjustedRatioStatistic, stat_b must be as well"
+                )
+        if isinstance(stat_b, RegressionAdjustedRatioStatistic):
+            if not isinstance(stat_a, RegressionAdjustedRatioStatistic):
+                raise ValueError(
+                    "If stat_b is a RegressionAdjustedRatioStatistic, stat_a must be as well"
+                )
         if (
             isinstance(self.stat_b, RegressionAdjustedRatioStatistic)
             and isinstance(self.stat_a, RegressionAdjustedRatioStatistic)

--- a/packages/stats/gbstats/models/tests.py
+++ b/packages/stats/gbstats/models/tests.py
@@ -74,17 +74,6 @@ class BaseABTest(ABC):
             else:
                 self.stat_a.theta = theta
                 self.stat_b.theta = theta
-
-        if isinstance(stat_a, RegressionAdjustedRatioStatistic):
-            if not isinstance(stat_b, RegressionAdjustedRatioStatistic):
-                raise ValueError(
-                    "If stat_a is a RegressionAdjustedRatioStatistic, stat_b must be as well"
-                )
-        if isinstance(stat_b, RegressionAdjustedRatioStatistic):
-            if not isinstance(stat_a, RegressionAdjustedRatioStatistic):
-                raise ValueError(
-                    "If stat_b is a RegressionAdjustedRatioStatistic, stat_a must be as well"
-                )
         if (
             isinstance(self.stat_b, RegressionAdjustedRatioStatistic)
             and isinstance(self.stat_a, RegressionAdjustedRatioStatistic)


### PR DESCRIPTION
### Features and Changes
This PR addresses two minor bugs w/r/t CUPED for ratio metrics:
1. we now currently assert that if one test statistic in `BaseABTest` is of type `RegressionAdjustedRatioStatistic`, the other also is
2. when baseline variance was 0, we were not correctly propagating through `RatioStatistics`, but were rather using the `RegressionAdjustedRatioStatistics` in the test (issue only in Bayesian engine).  

Below is example where baseline values are missing and CUPED is turned on: 

### Screenshots
Results without CUPED are showing:
<img width="1728" alt="bayesian_standard_after_fix" src="https://github.com/user-attachments/assets/02701302-1e6b-4a0d-9a87-38b6ff753481" />

Results with CUPED were not showing due to `ZERO_NEGATIVE_VARIANCE` error
<img width="1728" alt="bayesian_cuped_before_fix" src="https://github.com/user-attachments/assets/7625841a-7422-4e46-ac5f-f2aac7e6ee54" />

After the fix, results with CUPED are showing and identical to the non-CUPED case:
<img width="1728" alt="bayesian_cuped_after_fix" src="https://github.com/user-attachments/assets/cf55ffda-cd83-4988-ad17-826f0a8bd65c" />
 

