### PR TITLE
Add heartbeat update when starting query execution

### DIFF
--- a/packages/back-end/src/queryRunners/QueryRunner.ts
+++ b/packages/back-end/src/queryRunners/QueryRunner.ts
@@ -533,6 +533,7 @@ export abstract class QueryRunner<
       await updateQuery(doc, {
         startedAt: new Date(),
         status: "running",
+        heartbeat: new Date(),
       });
     }
 


### PR DESCRIPTION
### Features and Changes

#3291 has an example of a query that was able to run successfully, but still got the "Query execution interupted" error message. Since that error is based on the `expireOldQueries` job marking a running query as stale, I think what's happening is that the cron job is picking up queries that were in the queue for too long and their initial heartbeat became stale before the 30s interval had a chance to kick in.
This adds an update to the heartbeat immediately when the query is actually started to give the `setInterval` some time to work before `getStaleQueries` will mark it as failed.

### Testing

This is fairly hard to test manually, but since it's a one-liner my plan was to ship it and see if it solves the customer's issue. @jdorn lmk if you disagree