### PR TITLE
Gets stripe publishable key at build time

### DIFF
--- a/packages/front-end/enterprise/components/Billing/StripeProvider.tsx
+++ b/packages/front-end/enterprise/components/Billing/StripeProvider.tsx
@@ -12,6 +12,7 @@ import { useUser } from "@/services/UserContext";
 import { useAppearanceUITheme } from "@/services/AppearanceUIThemeProvider";
 import Callout from "@/components/Radix/Callout";
 import LoadingOverlay from "@/components/LoadingOverlay";
+import { getStripePublishableKey } from "@/services/env";
 
 interface StripeContextProps {
   clientSecret: string | null;
@@ -30,8 +31,7 @@ export function StripeProvider({ children }) {
   const [clientSecret, setClientSecret] = useState<string | null>(null);
   const [error, setError] = useState<string | undefined>(undefined);
 
-  const stripePublishableKey =
-    process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY || "";
+  const stripePublishableKey = getStripePublishableKey();
 
   const stripePromise = useMemo(
     () => (stripePublishableKey ? loadStripe(stripePublishableKey) : null),
@@ -68,7 +68,8 @@ export function StripeProvider({ children }) {
     if (stripePublishableKey) setupStripe();
   }, [setupStripe, stripePublishableKey]);
 
-  if (!stripePublishableKey) return null;
+  if (!stripePublishableKey)
+    return <Callout status="error">Missing Stripe Publishable Key</Callout>;
   if (error) return <Callout status="error">{error}</Callout>;
   if (!clientSecret || !stripePromise) return <LoadingOverlay />;
 

--- a/packages/front-end/pages/api/init.ts
+++ b/packages/front-end/pages/api/init.ts
@@ -28,6 +28,7 @@ export interface EnvironmentInitValue {
   usingFileProxy: boolean;
   superadminDefaultRole: string;
   ingestorOverride: string;
+  stripePublishableKey: string;
 }
 
 // Get env variables at runtime on the front-end while still using SSG
@@ -53,6 +54,7 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
     ALLOW_CREATE_METRICS,
     USE_FILE_PROXY: USING_FILE_PROXY,
     SUPERADMIN_DEFAULT_ROLE,
+    NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY,
   } = process.env;
 
   const rootPath = path.join(__dirname, "..", "..", "..", "..", "..", "..");
@@ -126,6 +128,7 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
     usingFileProxy: stringToBoolean(USING_FILE_PROXY),
     superadminDefaultRole: SUPERADMIN_DEFAULT_ROLE || "readonly",
     ingestorOverride: INGESTOR_HOST || "",
+    stripePublishableKey: NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY || "",
   };
 
   res.setHeader("Cache-Control", "max-age=3600").status(200).json(body);

--- a/packages/front-end/services/env.ts
+++ b/packages/front-end/services/env.ts
@@ -21,6 +21,7 @@ const env: EnvironmentInitValue = {
   usingFileProxy: false,
   superadminDefaultRole: "readonly",
   ingestorOverride: "",
+  stripePublishableKey: "",
 };
 
 export async function initEnv() {
@@ -102,4 +103,8 @@ export function getSuperadminDefaultRole() {
 }
 export function getIngestorHost() {
   return env.ingestorOverride || "https://us1.gb-ingest.com";
+}
+
+export function getStripePublishableKey() {
+  return env.stripePublishableKey;
 }


### PR DESCRIPTION
### Features and Changes

Fetches the `stripePublishableKey` at build time.

### Dependencies

NA

### Testing

- [x] Ensure the key is set and available on the frontend
- [x] Ensure an in-app error is displayed if no publishableKey is set
