### PR TITLE
Fix spacing for bandits empty state buttons

### DIFF
--- a/packages/front-end/pages/bandits/index.tsx
+++ b/packages/front-end/pages/bandits/index.tsx
@@ -304,13 +304,11 @@ const ExperimentsPage = (): React.ReactElement => {
                 <h1>Adaptively experiment with bandits.</h1>
                 <p className="">Run adaptive experiments with Bandits.</p>
               </div>
-              <div
-                className="d-flex justify-content-center pt-2"
-                style={{ gap: "1rem" }}
-              >
+              <div className="d-flex justify-content-center pt-2">
                 <LinkButton
                   href="/getstarted/experiment-guide"
                   variant="outline"
+                  mr="4"
                 >
                   Setup Instructions
                 </LinkButton>


### PR DESCRIPTION
### Features and Changes

Fixes one of the buttons moving around by changing from `gap` on the parent flex to a margin-right on the first button

### Testing

Check the empty state on http://localhost:3000/bandits

### Screenshots

![image](https://github.com/user-attachments/assets/ca6a3d65-faed-4ef2-baf5-6bf43d071ad5)

![image](https://github.com/user-attachments/assets/0b8e0d0e-95a5-4652-9b6a-891bdaf73958)
