### PR TITLE
getting the correct attribute for SampleSize

### DIFF
--- a/packages/shared/src/experiments.ts
+++ b/packages/shared/src/experiments.ts
@@ -542,7 +542,7 @@ export function getMetricSampleSize(
         baselineValue: baseline?.stats?.count,
         variationValue: stats?.stats?.count,
       }
-    : { baselineValue: baseline.value, variationValue: stats.value };
+    : { baselineValue: baseline.users, variationValue: stats.users };
 }
 
 export function hasEnoughData(


### PR DESCRIPTION
### Features and Changes

Currently inside of the `getMetricSampleSize` method we return the `value` attribute for the sample size.  We want to return the `users` attribute.  This PR addresses this issue.  

### Screenshots

Example where our app currently inappropriately returns a sample size error for having fewer than 150 users, even though the number of users per variation is 200.  
<img width="1728" alt="WrongSampleSizes" src="https://github.com/user-attachments/assets/f669109d-c455-4801-91d5-ec4eae4f569a" />

After the fix, the app appropriately displays results.  
<img width="1728" alt="RightSampleSizes" src="https://github.com/user-attachments/assets/dc96c3e4-0826-4251-b85f-cfc039c7aff4" />

