### PR TITLE
[Draft] React 19 support

### DIFF
--- a/packages/sdk-react/package.json
+++ b/packages/sdk-react/package.json
@@ -35,7 +35,7 @@
   },
   "author": "Jeremy Dorn",
   "peerDependencies": {
-    "react": "^16.8.0-0 || ^17.0.0-0 || ^18.0.0-0"
+    "react": "^16.8.0-0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
   },
   "dependencies": {
     "@growthbook/growthbook": "^1.4.1"
@@ -51,8 +51,8 @@
     "@rollup/plugin-replace": "^3.0.0",
     "@testing-library/react": "^14.0.0",
     "@types/jest": "^27.0.1",
-    "@types/react": "^18.0.15",
-    "@types/react-dom": "^18.0.6",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
     "gzip-size-cli": "^5.0.0",
     "jest": "^27.1.1",
     "npm-run-all": "^4.1.5",

--- a/packages/sdk-react/src/GrowthBookReact.tsx
+++ b/packages/sdk-react/src/GrowthBookReact.tsx
@@ -154,9 +154,9 @@ export const withRunExperiment = <P extends WithRunExperimentProps>(
   Component: React.ComponentType<P>
 ): React.ComponentType<Omit<P, keyof WithRunExperimentProps>> => {
   // eslint-disable-next-line
-  const withRunExperimentWrapper = (props: any): React.ReactNode => (
+  const withRunExperimentWrapper = (props: any): React.JSX.Element => (
     <GrowthBookContext.Consumer>
-      {({ growthbook }): React.ReactNode => {
+      {({ growthbook }): React.JSX.Element => {
         return (
           <Component
             {...(props as P)}
@@ -170,14 +170,13 @@ export const withRunExperiment = <P extends WithRunExperimentProps>(
 };
 withRunExperiment.displayName = "WithRunExperiment";
 
-export type GBProviderType = (
-  props: React.PropsWithChildren<{ growthbook: GrowthBook }>
-) => React.ReactNode;
-
-export const GrowthBookProvider: GBProviderType = ({
+export function GrowthBookProvider({
   children,
   growthbook,
-}) => {
+}: {
+  children: React.ReactNode | React.JSX.Element;
+  growthbook: GrowthBook;
+}): React.JSX.Element {
   // Tell growthbook how to re-render our app (for dev mode integration)
   // eslint-disable-next-line
   const [_, setRenderCount] = React.useState(0);
@@ -203,4 +202,4 @@ export const GrowthBookProvider: GBProviderType = ({
       {children}
     </GrowthBookContext.Provider>
   );
-};
+}

--- a/packages/sdk-react/src/GrowthBookReact.tsx
+++ b/packages/sdk-react/src/GrowthBookReact.tsx
@@ -154,9 +154,9 @@ export const withRunExperiment = <P extends WithRunExperimentProps>(
   Component: React.ComponentType<P>
 ): React.ComponentType<Omit<P, keyof WithRunExperimentProps>> => {
   // eslint-disable-next-line
-  const withRunExperimentWrapper = (props: any): JSX.Element => (
+  const withRunExperimentWrapper = (props: any): React.ReactNode => (
     <GrowthBookContext.Consumer>
-      {({ growthbook }): JSX.Element => {
+      {({ growthbook }): React.ReactNode => {
         return (
           <Component
             {...(props as P)}
@@ -170,11 +170,14 @@ export const withRunExperiment = <P extends WithRunExperimentProps>(
 };
 withRunExperiment.displayName = "WithRunExperiment";
 
-export const GrowthBookProvider: React.FC<
-  React.PropsWithChildren<{
-    growthbook: GrowthBook;
-  }>
-> = ({ children, growthbook }) => {
+export type GBProviderType = (
+  props: React.PropsWithChildren<{ growthbook: GrowthBook }>
+) => React.ReactNode;
+
+export const GrowthBookProvider: GBProviderType = ({
+  children,
+  growthbook,
+}) => {
   // Tell growthbook how to re-render our app (for dev mode integration)
   // eslint-disable-next-line
   const [_, setRenderCount] = React.useState(0);

--- a/yarn.lock
+++ b/yarn.lock
@@ -8605,6 +8605,11 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-dom@^19.0.0":
+  version "19.0.4"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-19.0.4.tgz#bedba97f9346bd4c0fe5d39e689713804ec9ac89"
+  integrity sha512-4fSQ8vWFkg+TGhePfUzVmat3eC14TXYSsiiDSLI0dVLsrm9gZFABjPy/Qu6TKgl1tq1Bu1yDsuQgY3A3DOjCcg==
+
 "@types/react-paginate@^7.1.1":
   version "7.1.1"
   resolved "https://registry.npmjs.org/@types/react-paginate/-/react-paginate-7.1.1.tgz"
@@ -8657,6 +8662,13 @@
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/react@^19.0.0":
+  version "19.0.10"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-19.0.10.tgz#d0c66dafd862474190fe95ce11a68de69ed2b0eb"
+  integrity sha512-JuRQ9KXLEjaUNjTWpzuR231Z2WpIwczOkBEIvbHNCzQefFIT0L8IqE6NV6ULLyC1SI/i234JnDoMkfg+RjQj2g==
+  dependencies:
     csstype "^3.0.2"
 
 "@types/readable-stream@^4.0.0":
@@ -20407,7 +20419,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -20424,6 +20436,15 @@ string-width@^3.0.0, string-width@^3.1.0:
     emoji-regex "^7.0.1"
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
+
+string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -20545,7 +20566,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -20558,6 +20579,13 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.0.1"
@@ -22201,7 +22229,7 @@ wordwrapjs@^5.1.0:
   resolved "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.0.tgz"
   integrity sha512-JNjcULU2e4KJwUNv6CHgI46UvDGitb6dGryHajXTDiLgg1/RiGoPSDw4kZfYnwGtEXf2ZMeIewDQgFGzkCB2Sg==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -22223,6 +22251,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
### Features and Changes

[WIP] adds support for React 19

To reproduce the issue:

1. Create a blank Next 15 / React 19 project: `npx create-next-app@15`
2. Create a blank Next 14 / React 18 project: `npx create-next-app@14`
3. In both projects, do `npm install @growthbook/growthbook-react` to install the latest published version (1.4.1)
4. In both projects, create a new page with the following contents:
```tsx
"use client";
import {
  GrowthBook,
  GrowthBookProvider,
  useFeatureValue,
} from "@growthbook/growthbook-react";

const gb = new GrowthBook({
  enableDevMode: true,
}).initSync({
  payload: {
    features: {
      "test-feature": { defaultValue: "value" },
    },
  },
});

export default function Page() {
  return (
    <GrowthBookProvider growthbook={gb}>
      <FeatureValue feature="test-feature" defaultValue={"default"} />
    </GrowthBookProvider>
  );
}

function FeatureValue({
  feature,
  defaultValue,
}: {
  feature: string;
  defaultValue: string;
}) {
  const featureValue = useFeatureValue(feature, defaultValue);
  return (
    <p>
      Inside GrowthBookProvider. Value for {feature} is{" "}
      <span>{featureValue}</span>
    </p>
  );
}
```
5.  In both projects, run `npm run dev` and load the page.  It should show the feature value as `value`.
5.  In both projects, run `tsc --noEmit`.  There should be no errors.

With the latest published SDK version, the Next 15 / React 19 version has a type error.

To use a local SDK build for testing instead, use `npm link` (or `yarn link`).