### PR TITLE
Add percentile language to quantile docs

### DIFF
--- a/docs/docs/metrics/metrics.mdx
+++ b/docs/docs/metrics/metrics.mdx
@@ -109,7 +109,7 @@ For example, to create a **Session Duration** metric, you would do the following
 
 ### Quantile Metrics
 
-Quantile Metrics are useful when you care about comparing variations at a quantile (e.g. latency at P99) rather than the mean. Learn more about when to use Quantile Metrics [here](/statistics/quantile).
+Quantile Metrics are useful when you care about comparing variations at a quantile (e.g. latency at P99) rather than the mean. These are also called percentile metrics. Learn more about when to use Quantile Metrics [here](/statistics/quantile).
 
 One key consideration is `Group by Experiment User before taking quantile?`. In short, if you often think about your metric at the user level, you should aggregate. If you think about your metric at the event level, do not aggregate.
 

--- a/docs/docs/statistics/quantile.mdx
+++ b/docs/docs/statistics/quantile.mdx
@@ -13,7 +13,9 @@ Quantile Testing is a GrowthBook Pro and Enterprise feature. It is incompatible 
 
 ## What is a quantile test?
 
-Quantile tests compare quantiles across variations. In contrast, standard GrowthBook A/B tests compare means across variations. For example, suppose that treatment increases user spend. Suppose that 90% of users in control spend at most \$50 per visit, and 90% of users in treatment spend at most \$55 per visit. Then the quantile treatment effect at the 90th percentile (i.e., P90) is \$55 - \$50 = \$5. Quantiles are commonly used in many applications where very large or small values are of interest (webpage latency, birth weight, blood pressure).
+Quantile tests, also known as percentile tests, compare quantiles across variations. In contrast, standard GrowthBook A/B tests compare means across variations. For example, suppose that treatment increases user spend. Suppose that 90% of users in control spend at most \$50 per visit, and 90% of users in treatment spend at most \$55 per visit. Then the quantile treatment effect at the 90th percentile (i.e., P90) is \$55 - \$50 = \$5. Quantiles are commonly used in many applications where very large or small values are of interest (webpage latency, birth weight, blood pressure).
+
+Quantile m
 
 ## When should I run quantile tests?
 


### PR DESCRIPTION
Adds "percentile" near "quantile" in the docs to improve discoverability.