### PR TITLE
Add note about consistent hash attribute in namespace experiments

### DIFF
--- a/docs/docs/experiments.mdx
+++ b/docs/docs/experiments.mdx
@@ -161,7 +161,7 @@ two tests will meaningfully interact, and many will run the tests in serial in a
 However, meaningful interactions are actually quite rare, and keeping a higher rate of experimentation
 is usually more beneficial. You can run analysis after the experiments to see if there were any
 interaction effects which would change your conclusions. If you need to run mutually exclusive tests,
-you can use GrowthBook’s namespace feature.
+you can use GrowthBook’s namespace feature. Ensure all experiments within the namespace use the same hash attribute (assignment attribute).
 
 ### Experimentation Frequency
 

--- a/docs/docs/faq.mdx
+++ b/docs/docs/faq.mdx
@@ -77,7 +77,7 @@ So that means if you do 50 orders per week and that's the metric you are trying 
 
 Yes! In fact, we recommend running many experiments in parallel in your application. Most A/B tests fail, so the more shots-on-goal you take, the more likely you are to get a winner. Running tests in parallel is a great way to increase your velocity.
 
-Now it's possible your experiments might have interaction effects, but these are actually pretty rare in practice. One example is if one test is changing the text color on a page and another test is changing the background color. Some users might see end up seeing black text on a black background, which is obviously not ideal. For these rare cases, you can use [Namespaces](/features/rules#namespaces) to run mutually exclusive experiments.
+Now it's possible your experiments might have interaction effects, but these are actually pretty rare in practice. One example is if one test is changing the text color on a page and another test is changing the background color. Some users might see end up seeing black text on a black background, which is obviously not ideal. For these rare cases, you can use [Namespaces](/features/rules#namespaces) to run mutually exclusive experiments. Make sure all experiments within the same Namespace are using the same hash attribute (assignment attribute).
 
 As long as you apply a little common sense to avoid situations like the above, running multiple experiments has low risk and really high reward.
 

--- a/docs/docs/feature-flag-experiments.mdx
+++ b/docs/docs/feature-flag-experiments.mdx
@@ -79,12 +79,12 @@ If you have multiple experiments that may conflict with each other (e.g. backgro
 use **namespaces** to make the conflicting experiments mutually exclusive.
 
 Users are randomly assigned a value from 0 to 1 for each namespace. Each experiment in a namespace has a range of values
-that it includes. Users are only part of an experiment if their value falls within the experiment's range. So as long
+that it includes. Users are only part of an experiment if their value falls within the experiment's range. As long
 as two experiment ranges do not overlap, users will only ever be in at most one of them.
 
 ![Namespaces](/images/namespaces.png)
 
-Before you can use namespaces, you must configure them under _SDK Configuration → Namespaces_.
+Before you can use namespaces, you must configure them under _SDK Configuration → Namespaces_. It's essential to ensure that all experiments within a given namespace use the same hash attribute (assignment attribute).
 
 ## Experiment Results
 

--- a/docs/docs/features/rules.mdx
+++ b/docs/docs/features/rules.mdx
@@ -94,7 +94,7 @@ as two experiment ranges do not overlap, users will only ever be in at most one 
     ![Namespaces](/images/namespaces.png)
 </MaxWidthImage>
 
-In order to use namespaces, simply create a new namespace or modify an existing one in _SDK Configuration → Namespaces_ in the GrowthBook UI's left navigation bar.
+In order to use namespaces, simply create a new namespace or modify an existing one in _SDK Configuration → Namespaces_ in the GrowthBook UI's left navigation bar. It's essential to ensure that all experiments within the namespace use the same hash attribute (assignment attribute).
 
 ## Testing Rules
 


### PR DESCRIPTION
Adds a note about using a consistent hash attribute across all experiments within a namespace to avoid unexpected behavior.