### PR TITLE
changing condition for theta == 0 to theta < 1e-8

### DIFF
--- a/packages/stats/gbstats/models/tests.py
+++ b/packages/stats/gbstats/models/tests.py
@@ -1,6 +1,5 @@
 from abc import ABC, abstractmethod
 from typing import List, Optional
-import numpy as np
 from pydantic.dataclasses import dataclass
 
 from gbstats.models.statistics import (
@@ -80,7 +79,7 @@ class BaseABTest(ABC):
             and (self.stat_a.theta is None or self.stat_b.theta is None)
         ):
             theta = compute_theta_regression_adjusted_ratio(self.stat_a, self.stat_b)
-            if np.abs(theta) < 1e-8:
+            if abs(theta) < 1e-8:
                 # revert to non-RA under the hood if no variance in a time period
                 self.stat_a = RatioStatistic(
                     n=self.stat_a.n,

--- a/packages/stats/gbstats/models/tests.py
+++ b/packages/stats/gbstats/models/tests.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from typing import List, Optional
-
+import numpy as np
 from pydantic.dataclasses import dataclass
 
 from gbstats.models.statistics import (
@@ -80,7 +80,7 @@ class BaseABTest(ABC):
             and (self.stat_a.theta is None or self.stat_b.theta is None)
         ):
             theta = compute_theta_regression_adjusted_ratio(self.stat_a, self.stat_b)
-            if theta == 0:
+            if np.abs(theta) < 1e-8:
                 # revert to non-RA under the hood if no variance in a time period
                 self.stat_a = RatioStatistic(
                     n=self.stat_a.n,


### PR DESCRIPTION
currently we default to using unadjusted `RatioStatistic`s when `theta = 0`.  This can cause the variance of the statistic to be very small but not quite 0, so we do not throw `ZERO_NEGATIVE_VARIANCE` error, even though we should.  

This PR instead checks if the absolute value of `theta` is less than 1e-8.  So now if `theta` is 0 except for numerical rounding, we should appropriately revert to unadjusted `RatioStatistic`s.  