### PR TITLE
fix: js sdk plugin - Trackers type and default values to use 'ga4' instead of 'gtag'

### DIFF
--- a/packages/sdk-js/src/plugins/third-party-tracking.ts
+++ b/packages/sdk-js/src/plugins/third-party-tracking.ts
@@ -5,11 +5,11 @@ import type {
   UserScopedGrowthBook,
 } from "../GrowthBookClient";
 
-export type Trackers = "gtag" | "gtm" | "segment";
+export type Trackers = "ga4" | "gtm" | "segment";
 
 export function thirdPartyTrackingPlugin({
   additionalCallback,
-  trackers = ["gtag", "gtm", "segment"],
+  trackers = ["ga4", "gtm", "segment"],
 }: {
   additionalCallback?: TrackingCallback;
   trackers?: Trackers[];
@@ -29,7 +29,7 @@ export function thirdPartyTrackingPlugin({
       }
 
       // GA4 - gtag
-      if (trackers.includes("gtag") && window.gtag) {
+      if (trackers.includes("ga4") && window.gtag) {
         let gtagResolve;
         const gtagPromise = new Promise((resolve) => {
           gtagResolve = resolve;

--- a/packages/sdk-js/test/plugins/third-party-tracking.test.ts
+++ b/packages/sdk-js/test/plugins/third-party-tracking.test.ts
@@ -38,7 +38,7 @@ describe("thirdPartyTrackingPlugin", () => {
   });
   it("should call gtag if enabled", async () => {
     const plugin = thirdPartyTrackingPlugin({
-      trackers: ["gtag"],
+      trackers: ["ga4"],
     });
 
     window.gtag = jest.fn();
@@ -67,7 +67,7 @@ describe("thirdPartyTrackingPlugin", () => {
   });
   it("should call gtm if enabled", async () => {
     const plugin = thirdPartyTrackingPlugin({
-      trackers: ["gtag", "gtm"],
+      trackers: ["ga4", "gtm"],
     });
 
     window.dataLayer = [];


### PR DESCRIPTION
### Features and Changes

- Corrected code mismatch between implementation (`gtag`) and documentation (`ga4`)
- Updated `Trackers` type definitions and default values to match official guides
  - https://docs.growthbook.io/lib/js#third-party-tracking
  - https://docs.growthbook.io/lib/react#third-party-tracking

### Testing

`yarn test` in `packages/sdk-js` directory

```sh
$ yarn test 
yarn run v1.22.22
$ jest

 PASS  test/multi-user.test.ts
 PASS  test/features.test.ts
 PASS  test/visual-changes.test.ts (5.247 s)
 PASS  test/experiments.test.ts (5.66 s)
 PASS  test/url-redirects.test.ts
 PASS  test/plugins/third-party-tracking.test.ts
 PASS  test/plugins/auto-attributes.test.ts
 PASS  test/typed-features.test.ts
 PASS  test/preview-links.test.ts
 PASS  test/mongrule.test.ts
 PASS  test/json.test.ts
 PASS  test/plugins/growthbook-tracking.test.ts
 PASS  test/remote-eval.test.ts (8.61 s)
 PASS  test/sticky-buckets.test.ts (8.769 s)
 PASS  test/feature-repo.test.ts (9.707 s)

Test Suites: 15 passed, 15 total
Tests:       638 passed, 638 total
Snapshots:   0 total
Time:        10.356 s
Ran all test suites.
✨  Done in 11.45s.
```