### PR TITLE
Add new Query Optimization docs and updates to "View Docs" link

### DIFF
--- a/docs/docs/experimentation-analysis/query-optimization.mdx
+++ b/docs/docs/experimentation-analysis/query-optimization.mdx
@@ -9,18 +9,11 @@ slug: /app/query-optimization
 
 GrowthBook is designed to run efficient database queries out-of-the-box, but for large datasets or complex metrics, there are a few settings and techniques you can use to optimize your queries.
 
-1. Use SQL template variables to take advantage of date partitioning
-2. Use Fact Tables to define metrics
-3. Enable Fact Table Query Optimization (Enterprise only)
-4. Enable Data Pipeline Mode (Enterprise only)
-5. Utilize materialized views
-6. Pre-aggregated your data
-
 ## SQL Template Variables
 
 GrowthBook always includes a date filter in the SQL queries it generates, but because the queries are complex with multiple nested subqueries, database engines are not always able to fully take advantage of these filters.
 
-If you have a date-partitioned table, you can use template variables within the SQL you enter in GrowthBook to provide better hints to your database.
+If you have a date-partitioned table, you can use template variables within the SQL you enter in GrowthBook to provide better hints to your database. This applies to metrics, fact table, and experiment assignment queries.
 
 Here's an example of a simple Fact Table definition that uses template variables:
 

--- a/docs/docs/experimentation-analysis/query-optimization.mdx
+++ b/docs/docs/experimentation-analysis/query-optimization.mdx
@@ -13,7 +13,7 @@ GrowthBook is designed to run efficient database queries out-of-the-box, but for
 
 GrowthBook always includes a date filter in the SQL queries it generates, but because the queries are complex with multiple nested subqueries, database engines are not always able to fully take advantage of these filters.
 
-If you have a date-partitioned table, you can use template variables within the SQL you enter in GrowthBook to provide better hints to your database. This applies to metrics, fact table, and experiment assignment queries.
+If you have a date-partitioned table, you can use template variables within the SQL you enter in GrowthBook to provide better hints to your database. This applies to metrics, fact tables, and experiment assignment queries.
 
 Here's an example of a simple Fact Table definition that uses template variables:
 

--- a/docs/docs/experimentation-analysis/query-optimization.mdx
+++ b/docs/docs/experimentation-analysis/query-optimization.mdx
@@ -1,0 +1,126 @@
+---
+title: Query Optimization
+description: Learn about different techniques and settings to optimize SQL queries in GrowthBook
+sidebar_label: Query Optimization
+slug: /app/query-optimization
+---
+
+# Query Optimization
+
+GrowthBook is designed to run efficient database queries out-of-the-box, but for large datasets or complex metrics, there are a few settings and techniques you can use to optimize your queries.
+
+1. Use SQL template variables to take advantage of date partitioning
+2. Use Fact Tables to define metrics
+3. Enable Fact Table Query Optimization (Enterprise only)
+4. Enable Data Pipeline Mode (Enterprise only)
+5. Utilize materialized views
+6. Pre-aggregated your data
+
+## SQL Template Variables
+
+GrowthBook always includes a date filter in the SQL queries it generates, but because the queries are complex with multiple nested subqueries, database engines are not always able to fully take advantage of these filters.
+
+If you have a date-partitioned table, you can use template variables within the SQL you enter in GrowthBook to provide better hints to your database.
+
+Here's an example of a simple Fact Table definition that uses template variables:
+
+```sql
+SELECT
+  timestamp,
+  user_id,
+  amount
+FROM purchases
+WHERE
+  timestamp BETWEEN '{{startDate}}' AND '{{endDate}}'
+```
+
+The following variables are available:
+
+- **startDate** - `yyyy-MM-dd HH:mm:ss` of the earliest data that needs to be included
+- **startDateISO** - `yyyy-MM-dd'T'HH:mm:ss.SSS'Z'` of the startDate in ISO format
+- **endDate** - `yyyy-MM-dd HH:mm:ss` of the latest data that needs to be included
+- **endDateISO** - `yyyy-MM-dd'T'HH:mm:ss.SSS'Z'` of the endDate in ISO format
+
+There is also a `date` helper you can use with the ISO variables to format the date exactly how you need it. For example `{{date endDateISO "yyyyMMdd"}}`
+
+| code | meaning   |
+| ---- | --------- |
+| yyyy | year      |
+| MM   | month     |
+| dd   | day       |
+| HH   | hour      |
+| mm   | minutes   |
+| ss   | seconds   |
+| t    | timestamp |
+
+Here's a full example of this being used:
+
+```sql
+SELECT
+  user_id as user_id,
+  received_at as timestamp
+FROM
+  orders
+WHERE
+  partition_key BETWEEN
+    '{{date startDateISO "yyyyMMdd"}}' AND '{{date endDateISO "yyyyMMdd"}}'
+```
+
+:::note
+
+The inserted values do not have surrounding quotes, so you must add those yourself (e.g. use `'{{ startDate }}'` instead of `{{ startDate }}`).
+
+:::
+
+## Fact Tables
+
+Fact Tables are a shared SQL definition that can be re-used across multiple metrics. For example, a "Purchases" fact table could be used for both a "Total Revenue" metric and a "Items per Order" metric.
+
+If you are still using legacy metrics (where each metric has its own separate SQL definition), you are missing out on important query optimizations and the newest features in GrowthBook.
+
+Read more about [Fact Tables](/app/metrics) and how to [convert legacy metrics to Fact Tables](/app/metrics/legacy#migrating-legacy-metrics-to-fact-tables).
+
+## Fact Table Query Optimization
+
+GrowthBook Enterprise customers can enable Fact Table Query Optimization for faster, more efficient queries.
+
+If multiple metrics from the same Fact Table are added to an experiment, they will be combined into a single SQL query. For data sourcees with usage-based billing, this can result in dramatic cost savings.
+
+There are some restrictions that limit when this optimization can be performed:
+
+- Ratio metrics where the numerator and denominator are part of different Fact Tables are always excluded from this optimization
+- If `Exclude In-Progress Conversions` is set for an experiment, optimization is disabled for all metrics
+- If you are using MySQL and a metric has percentile capping, it will be excluded from optimization
+
+In all other cases, this optimization is enabled by default for all Enterprise customers. It can be disabled under **Settings → General → Experiment Settings**. When disabled, a separate SQL query will always be run for every individual metric.
+
+## Data Pipeline Mode
+
+GrowthBook Enterprise customers can enable Data Pipeline Mode to reduce the amount of duplicate data your warehouse needs to scan.
+
+When enabled, GrowthBook will write some intermediate tables back to your warehouse with short retention and re-use those across all of the metric queries in an experiment.
+
+Currently, this is limited to BigQuery, Snowflake, and Databricks, but we are working on adding support for other data sources soon.
+
+Read more about [Data Pipeline Mode](/app/data-pipeline).
+
+## Materialized Views
+
+If your metric definitions are complex and involve multiple joins or subqueries, you may want to consider creating a materialized view in your warehouse.
+
+Setting up materialized views differs by warehouse, so consult the documentation for your specific warehouse for more information.
+
+You can also use a tool like [dbt](https://www.getdbt.com/) to create computed tables that are automatically refreshed on a schedule.
+
+## Pre-Aggregated Tables
+
+Pre-aggregated tables include a GROUP BY in the data pipeline to compress raw event-level data down to fewer rows. This is usually done when querying raw data directly is prohibitively expensive.
+
+GrowthBook supports pre-aggregated tables as long as they satisfy two requirements:
+
+- Must be grouped by both user and date
+- Pre-aggregated columns can only be basic sums or counts. No averages, percentiles, count distinct, or complex derived formulas that break statistical assumptions.
+
+Using pre-aggregated tables for experimentation comes with additional complexities and downsides, so we highly recommend sticking with event-level data whenever possible.
+
+Read more about this approach with some [examples and best practices](/app/metrics/examples#pre-aggregated-tables).

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -281,6 +281,11 @@ const sidebars = {
         },
         {
           type: "doc",
+          id: "experimentation-analysis/query-optimization",
+          label: "Query Optimization",
+        },
+        {
+          type: "doc",
           id: "experimentation-analysis/data-pipeline",
           label: "Data Pipeline",
         },

--- a/packages/front-end/components/DocLink.tsx
+++ b/packages/front-end/components/DocLink.tsx
@@ -18,6 +18,12 @@ const docSections = {
   eventWebhooks: "/app/webhooks/event-webhooks",
   sdkWebhooks: "/app/webhooks/sdk-webhooks",
   "sdkWebhooks#payload-format": "/app/webhooks/sdk-webhooks#payload-format",
+  bandits: "/bandits/overview",
+  targeting: "/features/targeting",
+  namespaces: "/features/rules#namespaces",
+  environments: "/features/environments",
+  archetypes: "/features/rules#archetype",
+  team: "/account/user-permissions",
   //DataSourceType
   athena: "/app/datasources#aws-athena",
   mixpanel: "/guide/mixpanel",
@@ -81,6 +87,7 @@ const docSections = {
     "/guide/google-tag-manager-and-growthbook#4-tracking-via-datalayer-and-gtm",
   apiPostEnvironment: "/api#tag/environments/operation/postEnvironment",
   idLists: "/features/targeting#id-lists",
+  queryOptimization: "/app/query-optimization",
 };
 
 export type DocSection = keyof typeof docSections;
@@ -88,18 +95,29 @@ export type DocSection = keyof typeof docSections;
 const urlPathMapping: Record<string, DocSection> = {
   "/": "home",
   "/features": "features",
+  "/bandits": "bandits",
+  "/bandit": "bandits",
   "/experiment": "experimentResults",
   "/experiments": "experimentConfiguration",
   "/metric": "metrics",
   "/metrics": "metrics",
+  "/fact-tables": "factTables",
+  "/fact-metrics": "metrics",
   "/power-calculator": "powerCalculator",
   "/segments": "datasources",
   "/dimensions": "dimensions",
   "/datasources": "datasources",
   "/dashboard": "experimentConfiguration",
   "/settings/keys": "api",
-  "/environments": "api",
+  "/account/personal-access-tokens": "api",
+  "/environments": "environments",
   "/settings/webhooks": "eventWebhooks",
+  "/sdks": "sdks",
+  "/attributes": "targeting",
+  "/namespaces": "namespaces",
+  "/saved-groups": "savedGroups",
+  "/archetypes": "archetypes",
+  "/settings/team": "team",
 };
 
 //for testing use "http://localhost:3200"


### PR DESCRIPTION
New docs page on database query optimization.  Previously this info was scattered across multiple pages in the docs and were hard to find.

Also, the "View Docs" link in the left nav of the app is contextual depending on the page you are viewing.  However, only a small subset of pages were taking advantage of this behavior.  This PR adds this contextual behavior to all major pages of the app.