### PR TITLE
Force auto-updates for bandits

### DIFF
--- a/packages/back-end/src/jobs/updateExperimentResults.ts
+++ b/packages/back-end/src/jobs/updateExperimentResults.ts
@@ -122,9 +122,11 @@ async function updateSingleExperiment(job: UpdateSingleExpJob) {
     project: project ?? undefined,
   });
 
-  if (organization?.settings?.updateSchedule?.type === "never") {
-    // Disable auto snapshots for the experiment so it doesn't keep trying to update (non-bandits only)
-    if (experiment.type === "multi-armed-bandit") return;
+  // Disable auto snapshots for the experiment so it doesn't keep trying to update if schedule is off (non-bandits only)
+  if (
+    organization?.settings?.updateSchedule?.type === "never" &&
+    experiment.type !== "multi-armed-bandit"
+  ) {
     await updateExperiment({
       context,
       experiment,

--- a/packages/back-end/src/jobs/updateExperimentResults.ts
+++ b/packages/back-end/src/jobs/updateExperimentResults.ts
@@ -123,7 +123,8 @@ async function updateSingleExperiment(job: UpdateSingleExpJob) {
   });
 
   if (organization?.settings?.updateSchedule?.type === "never") {
-    // Disable auto snapshots for the experiment so it doesn't keep trying to update
+    // Disable auto snapshots for the experiment so it doesn't keep trying to update (non-bandits only)
+    if (experiment.type === "multi-armed-bandit") return;
     await updateExperiment({
       context,
       experiment,


### PR DESCRIPTION
When updates are turned off, bandits may not update as expected. This fixes that to only set `autoSnapshots` to `false`  when auto-updates is off for non-bandits.