### PR TITLE
Renew license directly when there is a default payment

### DIFF
--- a/packages/back-end/src/controllers/stripe.ts
+++ b/packages/back-end/src/controllers/stripe.ts
@@ -116,6 +116,16 @@ export const postNewProSubscription = withLicenseServerErrorHandling(
     );
     await updateOrganization(org.id, { licenseKey: result.license.id });
 
+    if (result.created) {
+      // update license info from the license server as the new subscription should be added.
+      await licenseInit(
+        req.organization,
+        getUserCodesForOrg,
+        getLicenseMetaData,
+        true
+      );
+    }
+
     res.status(200).json(result);
   }
 );

--- a/packages/front-end/components/Settings/UpgradeModal/index.tsx
+++ b/packages/front-end/components/Settings/UpgradeModal/index.tsx
@@ -155,6 +155,7 @@ export default function UpgradeModal({
         const resp = await apiCall<{
           status: number;
           session?: { url?: string };
+          created?: boolean;
         }>(`/subscription/new`, {
           method: "POST",
           body: JSON.stringify({
@@ -169,6 +170,14 @@ export default function UpgradeModal({
             trackContext
           );
           await redirectWithTimeout(resp.session.url);
+        } else if (resp.created) {
+          track(
+            "Created new subscription with existing default payment method",
+            trackContext
+          );
+          await redirectWithTimeout(
+            "/settings/team?subscription-success-session=true"
+          );
         } else {
           setError("Failed to start checkout");
         }


### PR DESCRIPTION
### Features and Changes
When a license expired but there is already a default payment, then if we take them to the session checkout page on stripe it will force them to reenter their payment details, which then creates a new payment option.  But if they already have a default payment we can just create the subscription directly.  

### Testing
On an org in mongo remove it's licenseKey, and delete that license from licenses.newlicenses.
Then click "upgrade" and choose trial.
Then go to the billing page and click "View Plan Details" and add the payment method.
Then go back to growthbook and click upgrade.  
Click on pro.
Should immeditately take you to the team page saying their subscription is a success. 
