### PR TITLE
Add log_base to shared utils and use in license logger

### DIFF
--- a/packages/back-end/src/util/logger.ts
+++ b/packages/back-end/src/util/logger.ts
@@ -2,9 +2,10 @@ import pinoHttp from "pino-http";
 import * as Sentry from "@sentry/node";
 import { Request } from "express";
 import { BaseLogger, Level } from "pino";
+import { parseProcessLogBase } from "shared/util";
 import { ApiRequestLocals } from "back-end/types/api";
 import { AuthRequest } from "back-end/src/types/AuthRequest";
-import { ENVIRONMENT, IS_CLOUD, LOG_BASE, LOG_LEVEL } from "./secrets";
+import { ENVIRONMENT, IS_CLOUD, LOG_LEVEL } from "./secrets";
 
 const redactPaths = [
   "req.headers.authorization",
@@ -69,13 +70,7 @@ const isValidLevel = (input: unknown): input is Level => {
   ] as const).includes(input as Level);
 };
 
-// Only pass `base` if defined or null
-const logBase =
-  typeof LOG_BASE === "undefined"
-    ? {}
-    : {
-        base: LOG_BASE,
-      };
+const logBase = parseProcessLogBase();
 
 export const httpLogger = pinoHttp({
   autoLogging: ENVIRONMENT === "production",

--- a/packages/back-end/src/util/secrets.ts
+++ b/packages/back-end/src/util/secrets.ts
@@ -14,24 +14,6 @@ if (fs.existsSync(".env.local")) {
 
 export const LOG_LEVEL = process.env.LOG_LEVEL;
 
-let parsedLogBase:
-  | {
-      // eslint-disable-next-line
-      [key: string]: any;
-    }
-  | null
-  | undefined = undefined;
-try {
-  if (process.env.LOG_BASE === "null") {
-    parsedLogBase = null;
-  } else if (process.env.LOG_BASE) {
-    parsedLogBase = JSON.parse(process.env.LOG_BASE);
-  }
-} catch {
-  // Empty catch - don't pass a LOG_BASE
-}
-export const LOG_BASE = parsedLogBase;
-
 export const IS_CLOUD = stringToBoolean(process.env.IS_CLOUD);
 export const IS_MULTI_ORG = stringToBoolean(process.env.IS_MULTI_ORG);
 

--- a/packages/shared/src/enterprise/licenseUtil.ts
+++ b/packages/shared/src/enterprise/licenseUtil.ts
@@ -4,7 +4,7 @@ import type Stripe from "stripe";
 import pino from "pino";
 import { pick, sortBy } from "lodash";
 import AsyncLock from "async-lock";
-import { stringToBoolean } from "shared/util";
+import { parseProcessLogBase, stringToBoolean } from "shared/util";
 import { ProxyAgent } from "proxy-agent";
 import cloneDeep from "lodash/cloneDeep";
 import { getLicenseByKey, LicenseModel } from "./models/licenseModel";
@@ -17,7 +17,11 @@ export const LICENSE_SERVER_URL =
 // mimic behavior in back-end/src/util/secrets.ts
 const APP_ORIGIN = process.env.APP_ORIGIN || "http://localhost:3000";
 
-const logger = pino();
+const logBase = parseProcessLogBase();
+
+const logger = pino({
+  ...logBase,
+});
 
 export type AccountPlan = "oss" | "starter" | "pro" | "pro_sso" | "enterprise";
 const accountPlans: Set<AccountPlan> = new Set([

--- a/packages/shared/src/util/index.ts
+++ b/packages/shared/src/util/index.ts
@@ -452,3 +452,29 @@ export function experimentsReferencingSavedGroups({
   });
   return referenceMap;
 }
+
+export function parseProcessLogBase() {
+  let parsedLogBase:
+    | {
+        // eslint-disable-next-line
+        [key: string]: any;
+      }
+    | null
+    | undefined = undefined;
+  try {
+    if (process.env.LOG_BASE === "null") {
+      parsedLogBase = null;
+    } else if (process.env.LOG_BASE) {
+      parsedLogBase = JSON.parse(process.env.LOG_BASE);
+    }
+  } catch {
+    // Empty catch - don't pass a LOG_BASE
+  }
+
+  // Only pass `base` if defined or null
+  return typeof parsedLogBase === "undefined"
+    ? {}
+    : {
+        base: parsedLogBase,
+      };
+}


### PR DESCRIPTION
### Features and Changes

We added control of the log base used by Pino in #3694, but missed that there's a standalone logger (previously in the Enterprise package, now shared) that wasn't inheriting that logbase.
A customer wrote in asking if we could also fix the logs emitted for "Verifying license data: ..." which seems to be the only usage of a separate Pino instance.

This PR moves the processing out of back-end/secrets (as it's not really a secret anyway) and into shared/utils so it can be imported from anywhere we use Pino

### Testing

Define a `LOG_BASE` in your `.env.local` or similar with example value
```
LOG_BASE={"defaultIncludedLogKey":"defaultValue"}
```
Starting the server should prompt the license server message

### Screenshots

![image](https://github.com/user-attachments/assets/5c87371c-9c6c-4418-a6ca-8746c93dbdd7)