### PR TITLE
Fixes to experimentTimeSeries

### DIFF
--- a/packages/back-end/src/services/experimentTimeSeries.ts
+++ b/packages/back-end/src/services/experimentTimeSeries.ts
@@ -141,7 +141,7 @@ export async function updateExperimentTimeSeries({
         metricId,
         experimentSnapshot.settings.metricSettings.find(
           (it) => it.id === metricId
-        )!,
+        ),
         factMetrics,
         factTableMap
       ),
@@ -214,13 +214,13 @@ function getExperimentSettingsHash(
 
 function getMetricSettingsHash(
   metricId: string,
-  metricSettings: MetricForSnapshot,
+  metricSettings?: MetricForSnapshot,
   factMetrics?: FactMetricInterface[],
   factTableMap?: Map<string, FactTableInterface>
 ): string {
   const factMetric = factMetrics?.find((metric) => metric.id === metricId);
   if (!factMetric) {
-    return hashObject(metricSettings);
+    return hashObject(metricSettings ?? { id: metricId });
   } else {
     const numeratorFactTableId = factMetric.numerator.factTableId;
     const numeratorFactTable = numeratorFactTableId
@@ -275,12 +275,22 @@ function getHasSignificantDifference(
 
   const parseToMap = (results: ExperimentAnalysisSummaryResultsStatus) => {
     return new Map(
-      results.variations.flatMap((variation) =>
-        Object.entries(variation.guardrailMetrics).map(([metricId, metric]) => [
-          `${variation.variationId}-${metricId}`,
-          metric.status,
-        ])
-      )
+      results.variations.flatMap((variation) => ({
+        ...(variation?.goalMetrics
+          ? Object.entries(variation.goalMetrics).map(([metricId, metric]) => [
+              `${variation.variationId}-${metricId}`,
+              metric.status,
+            ])
+          : []),
+        ...(variation?.guardrailMetrics
+          ? Object.entries(
+              variation.guardrailMetrics
+            ).map(([metricId, metric]) => [
+              `${variation.variationId}-${metricId}`,
+              metric.status,
+            ])
+          : []),
+      }))
     );
   };
 

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -2983,10 +2983,16 @@ async function computeResultsStatus({
           } else if (resultsStatus.resultsStatus === "lost") {
             metricStatus.superStatSigStatus = "lost";
           }
+          if (!variationStatus.goalMetrics) {
+            variationStatus.goalMetrics = {};
+          }
           variationStatus.goalMetrics[metric.id] = metricStatus;
         }
 
         if (guardrailMetric) {
+          if (!variationStatus.guardrailMetrics) {
+            variationStatus.guardrailMetrics = {};
+          }
           variationStatus.guardrailMetrics[metric.id] = {
             status: resultsStatus.resultsStatus === "lost" ? "lost" : "neutral",
           };

--- a/packages/back-end/src/validators/experiments.ts
+++ b/packages/back-end/src/validators/experiments.ts
@@ -194,11 +194,10 @@ export type GoalMetricResult = z.infer<typeof goalMetricResult>;
 
 export const experimentAnalysisSummaryVariationStatus = z.object({
   variationId: z.string(),
-  goalMetrics: z.record(z.string(), goalMetricResult),
-  guardrailMetrics: z.record(
-    z.string(),
-    z.object({ status: z.enum(guardrailMetricStatus) })
-  ),
+  goalMetrics: z.record(z.string(), goalMetricResult).optional(),
+  guardrailMetrics: z
+    .record(z.string(), z.object({ status: z.enum(guardrailMetricStatus) }))
+    .optional(),
 });
 export type ExperimentAnalysisSummaryVariationStatus = z.infer<
   typeof experimentAnalysisSummaryVariationStatus


### PR DESCRIPTION
Two things:
- We might have invalid references pointing to metric settings that don't exist, so we are handling that now
- `goalMetrics` and `guardrailMetrics` for `resultsStatus` are not saved in the db, so it is not a guarantee that the objects exist. Handling that as well by updating the types & fixing how we iterate over the metrics
  - Additional fix to include `goalMetrics` here that I forgot before.
