### PR TITLE
fixing bug in degrees of freedom for bandits srm

### DIFF
--- a/packages/stats/gbstats/bayesian/bandits.py
+++ b/packages/stats/gbstats/bayesian/bandits.py
@@ -155,7 +155,7 @@ class Bandits(ABC):
                 resid_squared[positive_expected]
                 / self.counts_expected[positive_expected]
             )
-            df = self.num_variations - 1
+            df = self.num_periods_historical * (self.num_variations - 1)
             return float(1 - chi2.cdf(test_stat, df=df))
         else:
             return 1


### PR DESCRIPTION
currently we use (`num_variations` - 1) for our degrees of freedom in our Bandits SRM chi-squared test.  This should be `num_periods` * (`num_variations`-1).  

The proposed value was found to be the right degrees of freedom in simulation study.  

