### PR TITLE
Fix notification text bug for multiple exposures

### DIFF
--- a/packages/back-end/src/services/experimentNotifications.ts
+++ b/packages/back-end/src/services/experimentNotifications.ts
@@ -155,7 +155,7 @@ export const notifyMultipleExposures = async ({
             type: "multiple-exposures",
             experimentId: experiment.id,
             experimentName: experiment.name,
-            usersCount: multipleExposureData.totalUsers,
+            usersCount: multipleExposureData.multipleExposedUsers,
             percent: multipleExposureData.rawDecimal,
           },
         },

--- a/packages/back-end/test/events/experiment.test.ts
+++ b/packages/back-end/test/events/experiment.test.ts
@@ -721,7 +721,7 @@ describe("experiments events", () => {
         unhealthyData: {
           multipleExposures: {
             rawDecimal: 0.1,
-            totalUsers: 10,
+            multipleExposedUsers: 10,
           },
         },
       },

--- a/packages/back-end/types/experiment.d.ts
+++ b/packages/back-end/types/experiment.d.ts
@@ -39,7 +39,10 @@ export type DecisionFrameworkExperimentRecommendationStatus =
 export type ExperimentUnhealthyData = {
   // if key exists, the status is unhealthy
   srm?: boolean;
-  multipleExposures?: { rawDecimal: number; totalUsers: number };
+  multipleExposures?: {
+    rawDecimal: number;
+    multipleExposedUsers: number;
+  };
   lowPowered?: boolean;
 };
 

--- a/packages/shared/src/experiments.ts
+++ b/packages/shared/src/experiments.ts
@@ -1127,7 +1127,7 @@ export function getExperimentResultStatus({
     if (multipleExposuresHealthData.status === "unhealthy") {
       unhealthyData.multipleExposures = {
         rawDecimal: multipleExposuresHealthData.rawDecimal,
-        totalUsers: healthSummary.totalUsers,
+        multipleExposedUsers: healthSummary.multipleExposures,
       };
     }
 

--- a/packages/shared/src/health/health.ts
+++ b/packages/shared/src/health/health.ts
@@ -40,6 +40,8 @@ export function getMultipleExposureHealthData({
 
   const data = {
     rawDecimal: multipleExposureDecimal,
+    multipleExposedUsers: multipleExposuresCount,
+    totalUsers: totalUsersCount,
   };
 
   if (!hasEnoughData) {

--- a/packages/shared/src/health/health.ts
+++ b/packages/shared/src/health/health.ts
@@ -40,8 +40,6 @@ export function getMultipleExposureHealthData({
 
   const data = {
     rawDecimal: multipleExposureDecimal,
-    multipleExposedUsers: multipleExposuresCount,
-    totalUsers: totalUsersCount,
   };
 
   if (!hasEnoughData) {


### PR DESCRIPTION
We were returning total users instead of the multiply exposed users which is what the slack notification text needed. This fixes that bug. The data model used here is always used on demand so no need for any migration.

Open question: should we do more to use the `analysisSummary` itself on the health page?