### PR TITLE
Enrich metrics with project names for project search

### DIFF
--- a/packages/front-end/components/Metrics/MetricsList.tsx
+++ b/packages/front-end/components/Metrics/MetricsList.tsx
@@ -224,6 +224,7 @@ const MetricsList = (): React.ReactElement => {
   const {
     getDatasourceById,
     mutateDefinitions,
+    getProjectById,
     project,
     ready,
   } = useDefinitions();
@@ -253,6 +254,7 @@ const MetricsList = (): React.ReactElement => {
   const metrics = useAddComputedFields(
     combinedMetrics,
     (m) => ({
+      projectNames: m.projects.map((p) => getProjectById(p)?.name || p),
       datasourceName: m.datasource
         ? getDatasourceById(m.datasource)?.name || "Unknown"
         : "None",
@@ -323,7 +325,7 @@ const MetricsList = (): React.ReactElement => {
         return item.type;
       },
       tag: (item) => item.tags,
-      project: (item) => item.projects,
+      project: (item) => item.projectNames,
       datasource: (item) => [item.datasource, item.datasourceName],
     },
     filterResults,

--- a/packages/front-end/pages/features/index.tsx
+++ b/packages/front-end/pages/features/index.tsx
@@ -154,7 +154,7 @@ export default function FeaturesPage() {
                 href="https://docs.growthbook.io/using/growthbook-best-practices#syntax-search"
                 target="_blank"
               >
-                <Tooltip body={searchTermFilterExplainations}></Tooltip>
+                <Tooltip body={searchTermFilterExplanations}></Tooltip>
               </Link>
             </div>
             <div className="col-auto">
@@ -433,7 +433,7 @@ export default function FeaturesPage() {
     environments,
   });
 
-  const searchTermFilterExplainations = (
+  const searchTermFilterExplanations = (
     <>
       <p>This search field supports advanced syntax search, including:</p>
       <ul>


### PR DESCRIPTION
### Features and Changes

Previously the `project:` advanced filter would only look for the project id which was not useful. Now we enrich the metrics with project name and search on that (is this too slow???)

### Testing

Tested on local and it works as advertised now
