### PR TITLE
Fix difference type usage in reports

### DIFF
--- a/packages/back-end/src/controllers/reports.ts
+++ b/packages/back-end/src/controllers/reports.ts
@@ -83,7 +83,12 @@ export async function postReportFromSnapshot(
     throw new Error("Unknown experiment phase");
   }
 
-  const analysis = getSnapshotAnalysis(snapshot);
+  const analysis = getSnapshotAnalysis(
+    snapshot,
+    snapshot.analyses.find(
+      (a) => a.settings.differenceType === reportArgs.differenceType
+    )?.settings
+  );
   if (!analysis) {
     throw new Error("Missing analysis settings");
   }

--- a/packages/back-end/src/services/reports.ts
+++ b/packages/back-end/src/services/reports.ts
@@ -364,13 +364,19 @@ export async function createReportSnapshot({
     hasRegressionAdjustmentFeature: true,
   });
 
-  const analysisSettings = getDefaultExperimentAnalysisSettings(
+  const defaultAnalysisSettings = getDefaultExperimentAnalysisSettings(
     statsEngine,
     report.experimentAnalysisSettings,
     organization,
     regressionAdjustmentEnabled,
     report.experimentAnalysisSettings.dimension
   );
+
+  const analysisSettings: ExperimentSnapshotAnalysisSettings = {
+    ...defaultAnalysisSettings,
+    differenceType:
+      report.experimentAnalysisSettings.differenceType ?? "relative",
+  };
 
   const snapshotSettings = getReportSnapshotSettings({
     report,

--- a/packages/front-end/components/Report/ReportResults.tsx
+++ b/packages/front-end/components/Report/ReportResults.tsx
@@ -57,8 +57,16 @@ export default function ReportResults({
         1 / (report.experimentMetadata?.variations?.length || 2),
     })
   );
+  // find analysis matching the difference type
   const analysis = snapshot
-    ? getSnapshotAnalysis(snapshot) ?? undefined
+    ? getSnapshotAnalysis(
+        snapshot,
+        snapshot.analyses.find(
+          (a) =>
+            a.settings.differenceType ===
+            report.experimentAnalysisSettings.differenceType
+        )?.settings
+      ) ?? undefined
     : undefined;
   const queryStatusData = getQueryStatus(
     snapshot?.queries || [],


### PR DESCRIPTION
### Features and Changes

Difference types in reports had two bugs:
* We weren't finding the right `analysis` inside the copied over snapshot when we made a report from a snapshot, so there was a misalignment between the results and the settings
* If you refreshed a report and changed the difference type, this also was not being passed down correctly.

https://www.loom.com/share/77cd6ab26c204827bbcb0aa2397971f5