### PR TITLE
Initialize import aliases in Open Telemetry tracing

### DIFF
--- a/packages/back-end/src/tracing.ts
+++ b/packages/back-end/src/tracing.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import "./init/aliases";
 import * as opentelemetry from "@opentelemetry/sdk-node";
 import { PinoInstrumentation } from "@opentelemetry/instrumentation-pino";
 import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-http";


### PR DESCRIPTION
### Features and Changes

#3848 was reverted due to a runtime import error (failed to find module "back-end/src/enterprise"). It turns out that it's due to the difference between `yarn dev` and `yarn start:with-tracing` where the former uses swc which is configured to define local path aliases (see .swcrc) and the latter directly calls node. This isn't a problem for yarn start as our `server.ts` has a helper to initialize the aliases as its first import, but `tracing.ts` didn't. Adding that same alias initializer fixes the root issue.

### Testing

This change shouldn't make a difference on its own, but we can verify the codepath doesn't break by running
```
yarn workspace back-end build
yarn workspace back-end start:with-tracing
```