### PR TITLE
fix(BaseModel): Ensure index exists before dropping

### DIFF
--- a/packages/back-end/src/models/BaseModel.ts
+++ b/packages/back-end/src/models/BaseModel.ts
@@ -761,16 +761,22 @@ export abstract class BaseModel<
     }
 
     // Remove any explicitly defined indexes that are no longer needed
-    this.config.indexesToRemove?.forEach((indexName) => {
-      this._dangerousGetCollection()
-        .dropIndex(indexName)
-        .catch((err) => {
-          logger.error(
-            `Error dropping index ${indexName} for ${this.config.collectionName}`,
-            err
-          );
-        });
-    });
+    const indexesToRemove = this.config.indexesToRemove;
+    if (indexesToRemove) {
+      const existingIndexes = this._dangerousGetCollection().listIndexes();
+      existingIndexes.forEach((index) => {
+        if (!indexesToRemove.includes(index.name)) return;
+
+        this._dangerousGetCollection()
+          .dropIndex(index.name)
+          .catch((err) => {
+            logger.error(
+              `Error dropping index ${index.name} for ${this.config.collectionName}`,
+              err
+            );
+          });
+      });
+    }
 
     // Create any additional indexes
     this.config.additionalIndexes?.forEach((index) => {


### PR DESCRIPTION
### Features and Changes

On #3867 I added the ability to drop indexes, but every deployment this is creating errors as we attempt to drop an index that does not exist.

This behavior is different than creating an index which does not throw an error if the index already exists.

#### Note

Due to our deployment strategy there is still a chance that this will error out if we have a race condition between multiple servers, so I'll keep monitoring.

Note: The error is just logging-wise as the index is properly dropped and the error is handled.