### PR TITLE
Fix date in Health Tab graph being always interpreted as UTC

### DIFF
--- a/packages/front-end/components/HealthTab/TrafficCard.tsx
+++ b/packages/front-end/components/HealthTab/TrafficCard.tsx
@@ -6,6 +6,7 @@ import { ExperimentReportVariation } from "back-end/types/report";
 import { useEffect, useMemo, useState } from "react";
 import { getValidDate } from "shared/dates";
 import { FaCircle } from "react-icons/fa6";
+import { parseISO } from "date-fns";
 import { DEFAULT_SRM_THRESHOLD } from "shared/constants";
 import { useUser } from "@/services/UserContext";
 import track from "@/services/track";
@@ -71,14 +72,13 @@ export default function TrafficCard({
   const usersPerDate = useMemo<ExperimentDateGraphDataPoint[]>(() => {
     // Keep track of total users per variation for when cumulative is true
     const total: number[] = [];
-    const sortedTraffic = [...trafficByDate];
-    sortedTraffic.sort((a, b) => {
+    const sortedTraffic = [...trafficByDate].sort((a, b) => {
       return getValidDate(a.name).getTime() - getValidDate(b.name).getTime();
     });
 
     return sortedTraffic.map((d) => {
       return {
-        d: getValidDate(d.name),
+        d: getValidDate(parseISO(d.name)),
         variations: variations.map((variation, i) => {
           const users = d.variationUnits[i] || 0;
           total[i] = total[i] || 0;


### PR DESCRIPTION
Fixes #3871 

### Features and Changes

The dates returned from `dim_exposure_date` query follow the format of `yyyy-MM-dd` and they are aggregated in the SQL layer, so for the UI we should use the Data as-is and not do any timezone conversion.

The issue was that the date was being interpreted as UTC and depending on the user timezone then final graph date would be off by 1 day.

Now we interpret the date as midnight on the local time, fixing the graph.

### Screenshots

Note how the date for the last point is properly set to March 28th now.

#### Before

<img width="992" alt="Screenshot 2025-03-28 at 12 17 14 PM" src="https://github.com/user-attachments/assets/bc71fb86-2b93-4f1d-81e3-f5fe687e745f" />

#### After

<img width="997" alt="Screenshot 2025-03-28 at 12 16 50 PM" src="https://github.com/user-attachments/assets/9ba1cffd-0181-457b-8876-dd644547bbbe" />
