### PR TITLE
Allow metric overrides for bandit reports

### DIFF
--- a/packages/front-end/components/Report/ConfigureReport.tsx
+++ b/packages/front-end/components/Report/ConfigureReport.tsx
@@ -481,7 +481,7 @@ export default function ConfigureReport({
                 ]}
               />
             )}
-            {hasMetrics && !isBandit && experiment && (
+            {hasMetrics && experiment && (
               <div className="form-group mt-4 mb-2">
                 <PremiumTooltip commercialFeature="override-metrics">
                   <label className="font-weight-bold mb-0">


### PR DESCRIPTION
Bandit reports should allow overrides since they won't affect the main results at all.