### PR TITLE
Remove subscription/update call to use licenseInit instead

### DIFF
--- a/packages/back-end/src/enterprise/licenseUtil.ts
+++ b/packages/back-end/src/enterprise/licenseUtil.ts
@@ -451,23 +451,6 @@ export async function postCreateBillingSessionToLicenseServer(
   });
 }
 
-export async function postSubscriptionUpdateToLicenseServer(
-  licenseId: string,
-  seats: number
-): Promise<LicenseInterface> {
-  const url = `${LICENSE_SERVER_URL}subscription/update`;
-  const license = await callLicenseServer({
-    url,
-    body: JSON.stringify({
-      licenseId,
-      seats,
-    }),
-  });
-
-  verifyAndSetServerLicenseData(license);
-  return license;
-}
-
 export async function postCreateTrialEnterpriseLicenseToLicenseServer(
   email: string,
   name: string,

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -1090,6 +1090,7 @@ export async function postInviteAccept(
       throw new Error("Must be logged in");
     }
     const org = await acceptInvite(key, req.userId);
+    await licenseInit(org, getUserCodesForOrg, getLicenseMetaData, true);
 
     return res.status(200).json({
       status: 200,


### PR DESCRIPTION
### Features and Changes

Previously, the license server had a `subscription/update` endpoint that would take in seat qty updates and push those to the subscription provider Stripe (and also Orb).

However, due to some recent changes outlined in the companion PR [here](https://github.com/growthbook/central-license-server/pull/50) - we've removed the `/subscription/update` endpoint entirely and are instead just calling `licenseInit` with `forceRefresh = true`.

Companion PR: https://github.com/growthbook/central-license-server/pull/50 (The main repo PR will need to be merged in first)

### Testing

- [x] Ensure that the full subscription life cycle works for Stripe subscriptions (signing up, inviting, removing, accepting an invite, etc) all syncs the correct quantities to Stripe. (For stripe, when a user is invited, the subscription qty should be updated)
- [x] Ensure that the full subscription life cycle works for Orb subscriptions (signing up, inviting, removing, accepting an invite, etc) all syncs the correct quantities to Orb. (For Orb, only when a user accepts an invite is the subscription qty to be updated)