### PR TITLE
experiment overview: fix attribute targeting wrapping

### DIFF
--- a/packages/front-end/components/Features/ConditionDisplay/index.tsx
+++ b/packages/front-end/components/Features/ConditionDisplay/index.tsx
@@ -340,5 +340,9 @@ export default function ConditionDisplay({
     parts.push(...prereqParts);
   }
 
-  return <Flex gap="3">{parts}</Flex>;
+  return (
+    <Flex gapX="3" gapY="2" wrap="wrap">
+      {parts}
+    </Flex>
+  );
 }


### PR DESCRIPTION
before
<img width="414" alt="image" src="https://github.com/user-attachments/assets/94b63e9c-4b29-4280-9d30-ffa0ac8ad94d" />

after
<img width="421" alt="image" src="https://github.com/user-attachments/assets/176313ea-3e40-4f2a-bb7b-0850f736ca49" />
