### PR TITLE
 Fix API permissions check for updating features

### DIFF
--- a/packages/back-end/src/api/features/updateFeature.ts
+++ b/packages/back-end/src/api/features/updateFeature.ts
@@ -35,7 +35,8 @@ export const updateFeature = createApiRequestHandler(updateFeatureValidator)(
 
     const { owner, archived, description, project, tags } = req.body;
 
-    const effectiveProject = project === null ? feature.project : project;
+    const effectiveProject =
+      typeof project === "undefined" ? feature.project : project;
 
     const orgEnvs = getEnvironmentIdsFromOrg(req.organization);
 

--- a/packages/back-end/src/api/features/updateFeature.ts
+++ b/packages/back-end/src/api/features/updateFeature.ts
@@ -35,6 +35,8 @@ export const updateFeature = createApiRequestHandler(updateFeatureValidator)(
 
     const { owner, archived, description, project, tags } = req.body;
 
+    const effectiveProject = project === null ? feature.project : project;
+
     const orgEnvs = getEnvironmentIdsFromOrg(req.organization);
 
     if (!req.context.permissions.canUpdateFeature(feature, req.body)) {
@@ -109,7 +111,7 @@ export const updateFeature = createApiRequestHandler(updateFeatureValidator)(
     ) {
       if (
         !req.context.permissions.canPublishFeature(
-          updates,
+          { project: effectiveProject },
           Array.from(
             getEnabledEnvironments(
               {


### PR DESCRIPTION
### Features and Changes

For users with project roles, the update feature endpoint throws a permission error when making most types of changes. This fixes the check by defaulting to the feature's project rather than checking permissions as if the user is removing the project.

### Testing

Setup:
1. Create a feature (value type string) in a project
2. Add a user to the organization with readonly access but the Experimenter role in that project
3. Generate a PAT for that user

Run the following curl request, substituting the two needed variables
```
curl --request POST \
  --url localhost:3100/api/v1/features/<FEATURE_NAME> \
  --header 'Authorization: Bearer <USER_PAT>' \
  --header 'content-type: application/json' \
  --data '{"environments":{"dev":{"enabled":true,"rules":[{"type":"force","description":"Once a day at 5am UTC for TEST12","value":"0 0 5 * * *","enabled":true,"condition":"{\"id\":\"TEST12\"}"}]}}}'
```

### Screenshots
With the fix
![image](https://github.com/user-attachments/assets/d387b54b-1c44-42a1-a5e4-30185735e3c8)

On main
![image](https://github.com/user-attachments/assets/200366f3-e117-4ebd-8b1c-d12296931b8f)

