### PR TITLE
Fix usage dropdown label for past months

### DIFF
--- a/packages/front-end/components/Settings/Usage/CloudUsage.tsx
+++ b/packages/front-end/components/Settings/Usage/CloudUsage.tsx
@@ -73,12 +73,12 @@ export default function CloudUsage() {
   };
 
   const startDate = new Date();
-  startDate.setUTCMonth(startDate.getUTCMonth() - monthsAgo);
   startDate.setUTCDate(1);
   startDate.setUTCHours(0, 0, 0, 0);
+  startDate.setUTCMonth(startDate.getUTCMonth() - monthsAgo);
 
-  const endDate = new Date();
-  endDate.setUTCMonth(endDate.getUTCMonth() - monthsAgo + 1);
+  const endDate = new Date(startDate);
+  endDate.setUTCMonth(endDate.getUTCMonth() + 1);
   endDate.setUTCDate(0);
   endDate.setUTCHours(23, 59, 59, 999);
 

--- a/packages/front-end/components/Settings/Usage/CloudUsage.tsx
+++ b/packages/front-end/components/Settings/Usage/CloudUsage.tsx
@@ -109,10 +109,11 @@ export default function CloudUsage() {
   const monthOptions: { value: string; label: string }[] = [];
   for (let i = 0; i < 12; i++) {
     const date = new Date();
+    date.setUTCDate(1);
     date.setUTCMonth(date.getUTCMonth() - i);
 
     // Skip months before Feb 2025
-    if (date < new Date("2025-02-01")) continue;
+    if (date.toISOString() < "2025-02-01") continue;
 
     const month = date.toLocaleString("default", {
       month: "short",


### PR DESCRIPTION
Fixes a few edge cases (e.g. label for Feb shows up as Mar if today is the 30th of the month)