### PR TITLE
Address race condition letting queries ignore concurrency limit

### DIFF
--- a/packages/back-end/src/queryRunners/QueryRunner.ts
+++ b/packages/back-end/src/queryRunners/QueryRunner.ts
@@ -342,13 +342,7 @@ export abstract class QueryRunner<
           this.onQueryFinish();
         } else {
           if (await this.concurrencyLimitReached()) {
-            this.queuedQueryTimers[query.id] = setTimeout(() => {
-              this.executeQueryWhenReady(
-                query,
-                runCallbacks.run,
-                runCallbacks.process
-              );
-            }, INITIAL_CONCURRENCY_TIMEOUT);
+            this.queueQueryExecution(query);
           } else {
             await this.executeQuery(
               query,
@@ -479,33 +473,46 @@ export abstract class QueryRunner<
     }
   }
 
-  public async executeQueryWhenReady<
-    Rows extends RowsType,
-    ProcessedRows extends ProcessedRowsType
-  >(
+  public queueQueryExecution(
+    query: QueryInterface,
+    timeout: number = INITIAL_CONCURRENCY_TIMEOUT
+  ) {
+    // Queue query randomly within the window [timeout, timeout*2) to reduce race conditions
+    const jitter = Math.floor(Math.random() * timeout);
+    logger.debug(
+      `${query.id}: Query concurrency limit reached, waiting ${
+        timeout + jitter
+      } before retrying`
+    );
+    this.queuedQueryTimers[query.id] = setTimeout(() => {
+      this.executeQueryWhenReady(query, timeout);
+    }, timeout + jitter);
+  }
+
+  public async executeQueryWhenReady(
     doc: QueryInterface,
-    run: (
-      query: string,
-      setExternalId: ExternalIdCallback
-    ) => Promise<QueryResponse<Rows>>,
-    process: (rows: Rows) => ProcessedRows,
     currentTimeout: number = INITIAL_CONCURRENCY_TIMEOUT
   ): Promise<void> {
     // If too many queries are running against the datastore, use capped exponential backoff to wait until they've finished
     const concurrencyLimitReached = await this.concurrencyLimitReached();
     if (concurrencyLimitReached) {
-      logger.debug(
-        `${doc.id}: Query concurrency limit reached, waiting ${currentTimeout} before retrying`
-      );
-      this.runCallbacks[doc.id] = { run, process };
       const nextTimeout = Math.min(currentTimeout * 2, MAX_CONCURRENCY_TIMEOUT);
-      this.queuedQueryTimers[doc.id] = setTimeout(() => {
-        this.executeQueryWhenReady(doc, run, process, nextTimeout);
-      }, currentTimeout);
+      this.queueQueryExecution(doc, nextTimeout);
       return;
     }
+
     delete this.queuedQueryTimers[doc.id];
-    return this.executeQuery(doc, run, process);
+    const runCallbacks = this.runCallbacks[doc.id];
+    if (runCallbacks === undefined) {
+      logger.debug(`${doc.id}: Run callbacks not found..`);
+      await updateQuery(doc, {
+        finishedAt: new Date(),
+        status: "failed",
+        error: `Run callbacks not found`,
+      });
+      return this.onQueryFinish();
+    }
+    return this.executeQuery(doc, runCallbacks.run, runCallbacks.process);
   }
 
   public async executeQuery<
@@ -674,9 +681,8 @@ export abstract class QueryRunner<
     if (readyToRun) {
       this.executeQuery(doc, run, process);
     } else if (dependenciesComplete && !runAtEnd) {
-      this.queuedQueryTimers[doc.id] = setTimeout(() => {
-        this.executeQueryWhenReady(doc, run, process);
-      }, INITIAL_CONCURRENCY_TIMEOUT);
+      this.runCallbacks[doc.id] = { run, process };
+      this.queueQueryExecution(doc);
     } else {
       // save callback methods for execution later
       this.runCallbacks[doc.id] = { run, process };


### PR DESCRIPTION
### Features and Changes

Adds a random "jitter" to the delay when queuing queries due to the concurrency limit. This should alleviate the race condition observed in #3291 where many queries will execute at once despite a low concurrency limit.

Also refactors some of the queuing logic/helpers to make the codepath simpler

### Testing

Set up a datasource with a low concurrency limit & at least one experiment with multiple queries; the sample datasource works well for this.

Update the experiment analysis (hamburger menu -> re-run all queries to force an update) and view the queries to watch them come out of the queue.

<details>
<summary>Optionally, apply this diff to inspect the logic directly</summary>

```diff
diff --git a/packages/back-end/src/queryRunners/QueryRunner.ts b/packages/back-end/src/queryRunners/QueryRunner.ts
index f9f01aaee..14ed0709a 100644
--- a/packages/back-end/src/queryRunners/QueryRunner.ts
+++ b/packages/back-end/src/queryRunners/QueryRunner.ts
@@ -484,6 +484,7 @@ export abstract class QueryRunner<
         timeout + jitter
       } before retrying`
     );
+    console.log("Query queued for", timeout + jitter);
     this.queuedQueryTimers[query.id] = setTimeout(() => {
       this.executeQueryWhenReady(query, timeout);
     }, timeout + jitter);
@@ -493,14 +494,17 @@ export abstract class QueryRunner<
     doc: QueryInterface,
     currentTimeout: number = INITIAL_CONCURRENCY_TIMEOUT
   ): Promise<void> {
+    console.log("Checking concurrency");
     // If too many queries are running against the datastore, use capped exponential backoff to wait until they've finished
     const concurrencyLimitReached = await this.concurrencyLimitReached();
     if (concurrencyLimitReached) {
+      console.log("Concurrency limit reached. Doubling timeout");
       const nextTimeout = Math.min(currentTimeout * 2, MAX_CONCURRENCY_TIMEOUT);
       this.queueQueryExecution(doc, nextTimeout);
       return;
     }
 
+    console.log("Below concurrency limit. Executing query");
     delete this.queuedQueryTimers[doc.id];
     const runCallbacks = this.runCallbacks[doc.id];
     if (runCallbacks === undefined) {
```
</details>

Log results for 6 queries with a concurrency limit of 2:
```
 | [1] Query queued for 316
 | [1] Query queued for 353
 | [1] Query queued for 361
 | [1] Query queued for 457
 | [1] Checking concurrency
 | [1] Concurrency limit reached. Doubling timeout
 | [1] Query queued for 593
 | [1] Checking concurrency
 | [1] Concurrency limit reached. Doubling timeout
 | [1] Query queued for 728
 | [1] Checking concurrency
 | [1] Concurrency limit reached. Doubling timeout
 | [1] Query queued for 743
 | [1] Checking concurrency
 | [1] Concurrency limit reached. Doubling timeout
 | [1] Query queued for 774
 | [1] Checking concurrency
 | [1] Concurrency limit reached. Doubling timeout
 | [1] Query queued for 1036
 | [1] Checking concurrency
 | [1] Concurrency limit reached. Doubling timeout
 | [1] Query queued for 1009
 | [1] Checking concurrency
 | [1] Concurrency limit reached. Doubling timeout
 | [1] Query queued for 1247
 | [1] Checking concurrency
 | [1] Concurrency limit reached. Doubling timeout
 | [1] Query queued for 1098
 | [1] Checking concurrency
 | [1] Below concurrency limit. Executing query
 | [1] Checking concurrency
 | [1] Below concurrency limit. Executing query
 | [1] Checking concurrency
 | [1] Concurrency limit reached. Doubling timeout
 | [1] Query queued for 2024
 | [1] Checking concurrency
 | [1] Concurrency limit reached. Doubling timeout
 | [1] Query queued for 2972
 | [1] Checking concurrency
 | [1] Below concurrency limit. Executing query
 | [1] Checking concurrency
 | [1] Below concurrency limit. Executing query
```

### Screenshots

![image](https://github.com/user-attachments/assets/ce4566ad-bbaf-402c-bf4a-92e0193f3ddc)

![image](https://github.com/user-attachments/assets/beed1db5-11ac-4226-b256-8132d4411618)
