### PR TITLE
Fix live sql preview to show >= exposure timestamp

### DIFF
--- a/packages/front-end/components/FactTables/FactMetricModal.tsx
+++ b/packages/front-end/components/FactTables/FactMetricModal.tsx
@@ -838,23 +838,23 @@ function getWHERE({
 
   if (type === "retention") {
     whereParts.push(
-      `-- Only after seeing the experiment + retention delay\ntimestamp > (exposure_timestamp + '${
+      `-- Only after seeing the experiment + retention delay\ntimestamp >= (exposure_timestamp + '${
         windowSettings.delayValue
       } ${windowSettings.delayUnit ?? "days"}')`
     );
   } else if (windowSettings.delayValue) {
     whereParts.push(
-      `-- Only after seeing the experiment + delay\ntimestamp > (exposure_timestamp + '${windowSettings.delayValue} ${windowSettings.delayUnit}')`
+      `-- Only after seeing the experiment + delay\ntimestamp >= (exposure_timestamp + '${windowSettings.delayValue} ${windowSettings.delayUnit}')`
     );
   } else {
     whereParts.push(
-      `-- Only after seeing the experiment\ntimestamp > exposure_timestamp`
+      `-- Only after seeing the experiment\ntimestamp >= exposure_timestamp`
     );
   }
 
   if (windowSettings.type === "lookback") {
     whereParts.push(
-      `-- Lookback Metric Window\ntimestamp > (NOW() - '${windowSettings.windowValue} ${windowSettings.windowUnit}')`
+      `-- Lookback Metric Window\ntimestamp >= (NOW() - '${windowSettings.windowValue} ${windowSettings.windowUnit}')`
     );
   } else if (windowSettings.type === "conversion") {
     if (type === "retention") {


### PR DESCRIPTION
We use `>=` for our comparison of metric timestamp and exposure timestamp and our Live SQL preview should reflect that.