### PR TITLE
Render abs. differences in proportion metrics with pp notation

### DIFF
--- a/packages/front-end/components/Experiment/ChangeColumn.tsx
+++ b/packages/front-end/components/Experiment/ChangeColumn.tsx
@@ -57,7 +57,11 @@ export default function ChangeColumn({
   const formatter =
     differenceType === "relative"
       ? formatPercent
-      : getExperimentMetricFormatter(metric, getFactTableById, true);
+      : getExperimentMetricFormatter(
+          metric,
+          getFactTableById,
+          differenceType === "absolute" ? "percentagePoints" : "number"
+        );
   const formatterOptions: Intl.NumberFormatOptions = {
     currency: displayCurrency,
     ...(differenceType === "relative" ? { maximumFractionDigits: 1 } : {}),

--- a/packages/front-end/components/Experiment/DateResults.tsx
+++ b/packages/front-end/components/Experiment/DateResults.tsx
@@ -390,7 +390,7 @@ const DateResults: FC<{
               formatter={
                 differenceType === "relative"
                   ? formatPercent
-                  : getExperimentMetricFormatter(metric, getFactTableById, true)
+                  : getExperimentMetricFormatter(metric, getFactTableById, differenceType === "absolute" ? "percentagePoints" : "number")
               }
               formatterOptions={metricFormatterOptions}
               variationNames={variations.map((v) => v.name)}

--- a/packages/front-end/components/Experiment/DateResults.tsx
+++ b/packages/front-end/components/Experiment/DateResults.tsx
@@ -390,7 +390,13 @@ const DateResults: FC<{
               formatter={
                 differenceType === "relative"
                   ? formatPercent
-                  : getExperimentMetricFormatter(metric, getFactTableById, differenceType === "absolute" ? "percentagePoints" : "number")
+                  : getExperimentMetricFormatter(
+                      metric,
+                      getFactTableById,
+                      differenceType === "absolute"
+                        ? "percentagePoints"
+                        : "number"
+                    )
               }
               formatterOptions={metricFormatterOptions}
               variationNames={variations.map((v) => v.name)}

--- a/packages/front-end/components/Experiment/ResultsTable.tsx
+++ b/packages/front-end/components/Experiment/ResultsTable.tsx
@@ -968,7 +968,7 @@ function getChangeTooltip(
     "The uplift comparing the variation to the baseline, in percent change from the baseline value.";
   if (differenceType == "absolute") {
     changeText =
-      "The absolute difference between the average values in the variation and the baseline. For non-ratio metrics, this is average difference between users in the variation and the baseline.";
+      "The absolute difference between the average values in the variation and the baseline. For non-ratio metrics, this is average difference between users in the variation and the baseline. Differences in proportion metrics are shown in percentage points (pp).";
   } else if (differenceType == "scaled") {
     changeText =
       "The total change in the metric per day if 100% of traffic were to have gone to the variation.";

--- a/packages/front-end/components/Experiment/ResultsTableTooltip/ResultsTableTooltip.tsx
+++ b/packages/front-end/components/Experiment/ResultsTableTooltip/ResultsTableTooltip.tsx
@@ -747,7 +747,7 @@ export default function ResultsTableTooltip({
                           {getExperimentMetricFormatter(
                             data.metric,
                             ssrPolyfills?.getFactTableById || getFactTableById,
-                            true
+                            "number"
                           )(row.value, { currency: displayCurrency })}
                         </td>
                       ) : null}

--- a/packages/front-end/components/Experiment/ResultsTableTooltip/ResultsTableTooltip.tsx
+++ b/packages/front-end/components/Experiment/ResultsTableTooltip/ResultsTableTooltip.tsx
@@ -146,7 +146,7 @@ export default function ResultsTableTooltip({
       : getExperimentMetricFormatter(
           data.metric,
           ssrPolyfills?.getFactTableById || getFactTableById,
-          true
+          differenceType === "absolute" ? "percentagePoints" : "number"
         );
   const deltaFormatterOptions = {
     currency: displayCurrency,

--- a/packages/front-end/components/HomePage/ExperimentImpact/index.tsx
+++ b/packages/front-end/components/HomePage/ExperimentImpact/index.tsx
@@ -344,7 +344,7 @@ export default function ExperimentImpact({
 
   const metricInterface = metrics.find((m) => m.id === metric);
   const formatter = metricInterface
-    ? getExperimentMetricFormatter(metricInterface, getFactTableById, true)
+    ? getExperimentMetricFormatter(metricInterface, getFactTableById, "number")
     : formatNumber;
 
   const formatterOptions: Intl.NumberFormatOptions = {

--- a/packages/front-end/pages/fact-metrics/[fmid].tsx
+++ b/packages/front-end/pages/fact-metrics/[fmid].tsx
@@ -719,7 +719,7 @@ export default function FactMetricPage() {
                         : getExperimentMetricFormatter(
                             factMetric,
                             getFactTableById,
-                            true
+                            "number"
                           )(getMinSampleSizeForMetric(factMetric), {
                             currency: displayCurrency,
                           })}

--- a/packages/front-end/services/metrics.tsx
+++ b/packages/front-end/services/metrics.tsx
@@ -253,8 +253,7 @@ export function formatPercent(
 export function formatPercentagePoints(value: number) {
   const ppValue = 100 * value;
   const absValue = Math.abs(ppValue);
-  const digits =
-    absValue > 100 ? 0 : absValue > 10 ? 1 : absValue > 1 ? 2 : 3;
+  const digits = absValue > 100 ? 0 : absValue > 10 ? 1 : absValue > 1 ? 2 : 3;
   // Show fewer fractional digits for bigger numbers
   const formatter = new Intl.NumberFormat(undefined, {
     maximumFractionDigits: digits,

--- a/packages/front-end/services/metrics.tsx
+++ b/packages/front-end/services/metrics.tsx
@@ -250,6 +250,20 @@ export function formatPercent(
   return percentFormatter.format(Math.round(value * 100000) / 100000);
 }
 
+export function formatPercentagePoints(value: number) {
+  const ppValue = 100 * value;
+  const absValue = Math.abs(ppValue);
+  const digits =
+    absValue > 100 ? 0 : absValue > 10 ? 1 : absValue > 1 ? 2 : 3;
+  // Show fewer fractional digits for bigger numbers
+  const formatter = new Intl.NumberFormat(undefined, {
+    maximumFractionDigits: digits,
+    minimumFractionDigits: 0,
+  });
+  const number = formatter.format(ppValue);
+  return `${number} pp`;
+}
+
 export function getColumnFormatter(
   column: ColumnInterface
 ): (value: number, options?: Intl.NumberFormatOptions) => string {
@@ -285,23 +299,28 @@ export function getColumnRefFormatter(
 export function getExperimentMetricFormatter(
   metric: ExperimentMetricInterface,
   getFactTableById: (id: string) => FactTableInterface | null,
-  formatProportionAsNumber: boolean = false
+  proportionFormat: "number" | "percentagePoints" | "percentage" = "percentage"
 ): (value: number, options?: Intl.NumberFormatOptions) => string {
   // Old metric
   if ("type" in metric) {
-    return getMetricFormatter(
-      metric.type === "binomial" && formatProportionAsNumber
-        ? "count"
-        : metric.type
-    );
+    if (metric.type === "binomial" && proportionFormat === "number") {
+      return getMetricFormatter("count");
+    }
+    if (metric.type === "binomial" && proportionFormat === "percentagePoints") {
+      return formatPercentagePoints;
+    }
+    return getMetricFormatter(metric.type);
   }
 
   // Fact metric
   switch (metric.metricType) {
     case "proportion":
     case "retention":
-      if (formatProportionAsNumber) {
+      if (proportionFormat === "number") {
         return formatNumber;
+      }
+      if (proportionFormat === "percentagePoints") {
+        return formatPercentagePoints;
       }
       return formatPercent;
     case "ratio":


### PR DESCRIPTION
### Features and Changes

Use "percentage point" notation to make absolute changes for proportion metrics more consistent with the variation values we show in percent terms rather than proportion terms.

- Closes #3865 

### Screenshots

After
<img width="744" alt="Screenshot 2025-04-01 at 4 55 20 PM" src="https://github.com/user-attachments/assets/982b8d87-ad77-408c-997b-bcecbeda702e" />
<img width="495" alt="Screenshot 2025-04-01 at 4 52 38 PM" src="https://github.com/user-attachments/assets/5de688b4-c20c-410b-9d91-c4654feaaf18" />
<img width="1436" alt="Screenshot 2025-04-01 at 4 52 31 PM" src="https://github.com/user-attachments/assets/b01cf13d-4268-41e8-bc36-bb26471d12da" />

Before
<img width="850" alt="Screenshot 2025-04-01 at 4 57 10 PM" src="https://github.com/user-attachments/assets/0dc410b3-ba04-470b-9ddd-0885948e5aeb" />
<img width="545" alt="Screenshot 2025-04-01 at 4 56 54 PM" src="https://github.com/user-attachments/assets/97da17aa-b6c5-40ad-bccc-69fabcf9f60f" />
