### PR TITLE
Adds IS_CLOUD check to getUsage

### DIFF
--- a/packages/back-end/src/app.ts
+++ b/packages/back-end/src/app.ts
@@ -406,6 +406,7 @@ if (IS_CLOUD) {
   );
   app.post("/subscription/cancel", subscriptionController.cancelSubscription);
   app.get("/subscription/portal-url", subscriptionController.getPortalUrl);
+  app.get("/billing/usage", subscriptionController.getUsage);
 }
 app.post("/subscription/new", subscriptionController.postNewProSubscription);
 app.post(
@@ -416,8 +417,6 @@ app.post(
   "/subscription/success",
   subscriptionController.postSubscriptionSuccess
 );
-
-app.get("/billing/usage", subscriptionController.getUsage);
 
 app.get("/queries/:ids", datasourcesController.getQueries);
 app.post("/query/test", datasourcesController.testLimitedQuery);

--- a/packages/back-end/src/controllers/subscription.ts
+++ b/packages/back-end/src/controllers/subscription.ts
@@ -34,6 +34,7 @@ import {
   updateDefaultPaymentMethod,
   getPaymentMethodsByLicenseKey,
 } from "back-end/src/enterprise/billing/index";
+import { IS_CLOUD } from "back-end/src/util/secrets";
 
 function withLicenseServerErrorHandling<T>(
   fn: (req: AuthRequest<T>, res: Response) => Promise<void>
@@ -397,6 +398,9 @@ export async function getUsage(
   req: AuthRequest<unknown, unknown, { monthsAgo?: number }>,
   res: Response<{ status: 200; cdnUsage: DailyUsage[]; limits: UsageLimits }>
 ) {
+  if (!IS_CLOUD) {
+    throw new Error("Usage data is only available on GrowthBook Cloud.");
+  }
   const context = getContextFromReq(req);
 
   if (!context.permissions.canViewUsage()) {

--- a/packages/back-end/src/controllers/subscription.ts
+++ b/packages/back-end/src/controllers/subscription.ts
@@ -34,7 +34,6 @@ import {
   updateDefaultPaymentMethod,
   getPaymentMethodsByLicenseKey,
 } from "back-end/src/enterprise/billing/index";
-import { IS_CLOUD } from "back-end/src/util/secrets";
 
 function withLicenseServerErrorHandling<T>(
   fn: (req: AuthRequest<T>, res: Response) => Promise<void>
@@ -398,9 +397,6 @@ export async function getUsage(
   req: AuthRequest<unknown, unknown, { monthsAgo?: number }>,
   res: Response<{ status: 200; cdnUsage: DailyUsage[]; limits: UsageLimits }>
 ) {
-  if (!IS_CLOUD) {
-    throw new Error("Usage data is only available on GrowthBook Cloud.");
-  }
   const context = getContextFromReq(req);
 
   if (!context.permissions.canViewUsage()) {

--- a/packages/back-end/src/enterprise/billing/index.ts
+++ b/packages/back-end/src/enterprise/billing/index.ts
@@ -9,6 +9,7 @@ import {
   OrganizationUsage,
 } from "back-end/types/organization";
 import { getEffectiveAccountPlan } from "back-end/src/enterprise";
+import { IS_CLOUD } from "back-end/src/util/secrets";
 
 const PLANS_WITH_UNLIMITED_USAGE: AccountPlan[] = [
   "pro",
@@ -106,6 +107,9 @@ type StoredUsage = {
 const keyToUsageData: Record<string, StoredUsage> = {};
 
 export async function getUsage(organization: OrganizationInterface) {
+  if (!IS_CLOUD) {
+    return UNLIMITED_USAGE;
+  }
   const plan = getEffectiveAccountPlan(organization);
 
   if (PLANS_WITH_UNLIMITED_USAGE.includes(plan)) return UNLIMITED_USAGE;


### PR DESCRIPTION
### Features and Changes

Adds `IS_CLOUD` check to the `getUsage` controller method and returns an error if the visitor isn't a cloud org.

Opted to do it this way, instead of updating app.ts and including the endpoint within the `IS_CLOUD` check, as this way we can return a 400 error with a message, as opposed to a 404 error which could get confusing.

If anyone feels strongly, I can update the return type of the endpoint so as to return a 200 with a message, so we don't have an error, but I feel like this is probably fine and makes the code clean on the front end.

### Dependencies

None

### Testing

- [x] Ensure that if an org isn't a cloud org, we don't actually hit the license server from the `getUsage` endpoint, but the controller function throws an error.
