### PR TITLE
Remove free trial language from in-app-help upgrade.

### DIFF
--- a/packages/front-end/components/Auth/InAppHelp.tsx
+++ b/packages/front-end/components/Auth/InAppHelp.tsx
@@ -103,7 +103,7 @@ export default function InAppHelp() {
                   className="btn btn-premium font-weight-normal my-2 w-100"
                   onClick={() => setUpgradeModal(true)}
                 >
-                  Start Free Trial <GBPremiumBadge />
+                  Upgrade Now <GBPremiumBadge />
                 </button>
               </div>
             )}

--- a/packages/front-end/components/Settings/UpgradeModal/index.tsx
+++ b/packages/front-end/components/Settings/UpgradeModal/index.tsx
@@ -531,7 +531,6 @@ export default function UpgradeModal({
         <StripeProvider initialClientSecret={cloudProUpgradeSetup.clientSecret}>
           <CloudProUpgradeModal
             close={() => setCloudProUpgradeSetup(null)}
-            numOfCurrentMembers={numOfCurrentMembers}
             closeParent={close}
           />
         </StripeProvider>

--- a/packages/front-end/enterprise/components/Billing/CloudProUpgradeModal.tsx
+++ b/packages/front-end/enterprise/components/Billing/CloudProUpgradeModal.tsx
@@ -12,14 +12,9 @@ import { useUser } from "@/services/UserContext";
 interface Props {
   close: () => void;
   closeParent: () => void;
-  numOfCurrentMembers: number;
 }
 
-export default function CloudProUpgradeModal({
-  close,
-  numOfCurrentMembers,
-  closeParent,
-}: Props) {
+export default function CloudProUpgradeModal({ close, closeParent }: Props) {
   const [success, setSuccess] = useState(false);
   const [loading, setLoading] = useState(false);
   const { clientSecret } = useStripeContext();
@@ -91,14 +86,10 @@ export default function CloudProUpgradeModal({
         ) : (
           <>
             <p>
-              Pro accounts cost <strong>$20/month per user</strong>. After
-              upgrading, an amount of{" "}
-              <strong>
-                ${numOfCurrentMembers * 20} ({numOfCurrentMembers} seat
-                {numOfCurrentMembers === 1 ? "" : "s"} x $20/month)
-              </strong>{" "}
-              will be added this month&apos;s invoice and your credit card will
-              be charged immediately.
+              The cost is <strong>$20 per seat per month</strong>. You will be
+              charged a pro-rated amount immediately for the remainder of the
+              current month and it will renew automatically on the 1st of each
+              subsequent month. Cancel anytime.
             </p>
             <PaymentElement />
           </>


### PR DESCRIPTION
### Features and Changes

Removes the `Free Trial` language from the `In-App Help` widget.

### Dependencies

N/A

### Testing

- [x] Confirm the CTA says "Upgrade Now" when the in-app help widget is shown for Cloud users on the `Starter` plan.

### Screenshots

<img width="364" alt="Screenshot 2025-04-03 at 6 49 05 AM" src="https://github.com/user-attachments/assets/dd30b97d-0640-44af-82f4-3c65dabde572" />

