### PR TITLE
Fix table query header opacity

### DIFF
--- a/packages/front-end/components/Queries/ExpandableQuery.tsx
+++ b/packages/front-end/components/Queries/ExpandableQuery.tsx
@@ -91,16 +91,19 @@ const ExpandableQuery: FC<{
         <>
           {query.rawResult?.[0] ? (
             <div style={{ maxHeight: 300, overflowY: "auto" }}>
-              <table className="table table-bordered table-sm">
+              <table className="table table-bordered table-sm query-table">
                 <thead>
                   <tr
-                    style={{ position: "sticky", top: 0 }}
+                    style={{
+                      position: "sticky",
+                      top: -1,
+                    }}
                     className="bg-light"
                   >
                     <th></th>
-                    {Object.keys(query.rawResult[0]).map((k) => {
-                      return <th key={k}>{k}</th>;
-                    })}
+                    {Object.keys(query.rawResult[0]).map((k) => (
+                      <th key={k}>{k}</th>
+                    ))}
                   </tr>
                 </thead>
                 <tbody>

--- a/packages/front-end/styles/global.scss
+++ b/packages/front-end/styles/global.scss
@@ -1021,6 +1021,24 @@ main.main {
   }
 }
 
+.query-table {
+  thead {
+    th {
+      background-color: var(--slate-2);
+    }
+  }
+}
+
+.dark .query-table {
+  thead {
+    th {
+      // hard coded to match slate-a2 on the background color
+      // opaque to prevent table header from showing through
+      background-color: rgba(36, 43, 61, 1);
+    }
+  }
+}
+
 @media only screen and (max-width: 760px),
   (min-device-width: 768px) and (max-device-width: 1024px) {
   .responsive-table {


### PR DESCRIPTION
Table header on query results was showing through. Couldn't fix it with z-index so just set header BG to be opaque instead.

https://www.loom.com/share/6e3d53aa2bd9439090bf218d17da1647

After
<img width="1545" alt="Screenshot 2025-04-03 at 8 35 05 AM" src="https://github.com/user-attachments/assets/111744a8-9a6a-4b37-980b-e72acb012a8d" />

<img width="1523" alt="Screenshot 2025-04-03 at 8 34 53 AM" src="https://github.com/user-attachments/assets/5a1617c4-a61a-4284-92b0-42ac95d5bbb2" />


Before
<img width="1528" alt="Screenshot 2025-04-03 at 8 32 19 AM" src="https://github.com/user-attachments/assets/f183e054-e0be-41c3-b17b-510cd6c54695" />

<img width="1567" alt="Screenshot 2025-04-03 at 8 32 29 AM" src="https://github.com/user-attachments/assets/a8f93b08-cd0e-43d0-bbd3-d001ead58b1b" />
