### PR TITLE
Move visual editor / redirect paywall to publish step

### DIFF
--- a/packages/back-end/src/api/sdk-connections/validations.ts
+++ b/packages/back-end/src/api/sdk-connections/validations.ts
@@ -26,10 +26,10 @@ type CapabilitiesParams = { [k in CapabilitiesParamKey]?: boolean };
 
 const premiumFeatures = [
   ["encrypt-features-endpoint", "encryptPayload"],
-  ["visual-editor", "includeVisualExperiments"],
+  // ["visual-editor", "includeVisualExperiments"],
   ["hash-secure-attributes", "hashSecureAttributes"],
   ["remote-evaluation", "remoteEvalEnabled"],
-  ["redirects", "includeRedirectExperiments"],
+  // ["redirects", "includeRedirectExperiments"],
   ["cloud-proxy", "proxyEnabled"],
 ] as const;
 

--- a/packages/front-end/components/Archetype/ArchetypeList.tsx
+++ b/packages/front-end/components/Archetype/ArchetypeList.tsx
@@ -48,7 +48,6 @@ export const ArchetypeList: FC<{
           title="Create Reusable Archetypes"
           description="Archetypes are named sets of attributes that help you test your features."
           commercialFeature="archetypes"
-          reason="Archetypes landing page no access"
           learnMoreLink="https://docs.growthbook.io/features/rules#archetype"
         />
       </div>

--- a/packages/front-end/components/Archetype/SimulateFeatureValues.tsx
+++ b/packages/front-end/components/Archetype/SimulateFeatureValues.tsx
@@ -456,7 +456,6 @@ export const SimulateFeatureValues: FC<{
               values they have or would receive. Simulation is a premium
               feature."
           commercialFeature="simulate"
-          reason="Simulate landing page no access"
           learnMoreLink="https://docs.growthbook.io/features/rules#simulation"
         />
       </div>

--- a/packages/front-end/components/Auth/InAppHelp.tsx
+++ b/packages/front-end/components/Auth/InAppHelp.tsx
@@ -40,7 +40,6 @@ export default function InAppHelp() {
       {upgradeModal && (
         <UpgradeModal
           close={() => setUpgradeModal(false)}
-          reason="To get access to live chat support,"
           source="in-app-help"
           commercialFeature="livechat"
         />

--- a/packages/front-end/components/Experiment/AnalysisForm.tsx
+++ b/packages/front-end/components/Experiment/AnalysisForm.tsx
@@ -223,7 +223,6 @@ const AnalysisForm: FC<{
     return (
       <UpgradeModal
         close={() => setUpgradeModal(false)}
-        reason="To override metric conversion windows,"
         source="override-metrics"
         commercialFeature="override-metrics"
       />

--- a/packages/front-end/components/Experiment/EditMetricsForm.tsx
+++ b/packages/front-end/components/Experiment/EditMetricsForm.tsx
@@ -166,7 +166,6 @@ const EditMetricsForm: FC<{
     return (
       <UpgradeModal
         close={() => setUpgradeModal(false)}
-        reason="To override metric conversion windows,"
         source="override-metrics"
         commercialFeature="override-metrics"
       />

--- a/packages/front-end/components/Experiment/LinkedChange.tsx
+++ b/packages/front-end/components/Experiment/LinkedChange.tsx
@@ -10,7 +10,6 @@ import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
 import Callout from "@/components/Radix/Callout";
 import Button from "@/components/Radix/Button";
 import OpenVisualEditorLink from "@/components/OpenVisualEditorLink";
-import { useUser } from "@/services/UserContext";
 import DeleteButton from "@/components/DeleteButton/DeleteButton";
 
 type Props = {
@@ -55,8 +54,6 @@ export default function LinkedChange({
   state,
 }: Props) {
   const [expanded, setExpanded] = React.useState(open);
-  const { hasCommercialFeature } = useUser();
-  const hasVisualEditorFeature = hasCommercialFeature("visual-editor");
   //if (changeType === "visual" && !vc && !experiment) return null;
 
   return (
@@ -104,7 +101,6 @@ export default function LinkedChange({
                     <Flex gap="3">
                       {canEditVisualChangesets &&
                         experiment?.status === "draft" &&
-                        hasVisualEditorFeature &&
                         vc && (
                           <Box onClick={(e) => e.stopPropagation()}>
                             <OpenVisualEditorLink

--- a/packages/front-end/components/Experiment/LinkedChanges/AddLinkedChanges.tsx
+++ b/packages/front-end/components/Experiment/LinkedChanges/AddLinkedChanges.tsx
@@ -5,19 +5,28 @@ import {
   getConnectionsSDKCapabilities,
 } from "shared/sdk-versioning";
 import PremiumTooltip from "@/components/Marketing/PremiumTooltip";
-import { useUser } from "@/services/UserContext";
 import useSDKConnections from "@/hooks/useSDKConnections";
 import Tooltip from "@/components/Tooltip/Tooltip";
 import styles from "@/components/Experiment/LinkedChanges/AddLinkedChanges.module.scss";
+import { useUser } from "@/services/UserContext";
 import { ICON_PROPERTIES, LinkedChange } from "./constants";
 
-const LINKED_CHANGES = {
+const LINKED_CHANGES: Record<
+  LinkedChange,
+  {
+    header: string;
+    cta: string;
+    description: string;
+    commercialFeature: CommercialFeature | "";
+    sdkCapabilityKey: SDKCapability | "";
+  }
+> = {
   "feature-flag": {
     header: "Feature Flag",
     cta: "Link Feature Flag",
     description:
       "Use feature flags and SDKs to make changes in your front-end, back-end or mobile application code.",
-    commercialFeature: false,
+    commercialFeature: "",
     sdkCapabilityKey: "",
   },
   "visual-editor": {
@@ -25,7 +34,7 @@ const LINKED_CHANGES = {
     cta: "Launch Visual Editor",
     description:
       "Use our no-code browser extension to A/B test minor changes, such as headings or button text.",
-    commercialFeature: true,
+    commercialFeature: "visual-editor",
     sdkCapabilityKey: "visualEditor",
   },
   redirects: {
@@ -33,7 +42,7 @@ const LINKED_CHANGES = {
     cta: "Add URL Redirects",
     description:
       "Use our no-code tool to A/B test URL redirects for whole pages, or to test parts of a URL.",
-    commercialFeature: true,
+    commercialFeature: "redirects",
     sdkCapabilityKey: "redirects",
   },
 };
@@ -41,12 +50,10 @@ const LINKED_CHANGES = {
 const AddLinkedChangeRow = ({
   type,
   setModal,
-  hasFeature,
   experiment,
 }: {
   type: LinkedChange;
   setModal: (boolean) => void;
-  hasFeature: boolean;
   experiment: ExperimentInterfaceStringDates;
 }) => {
   const {
@@ -59,6 +66,11 @@ const AddLinkedChangeRow = ({
   const { component: Icon, color } = ICON_PROPERTIES[type];
   const { data: sdkConnectionsData } = useSDKConnections();
 
+  const { hasCommercialFeature } = useUser();
+  const hasFeature = commercialFeature
+    ? hasCommercialFeature(commercialFeature)
+    : true;
+
   const hasSDKWithFeature =
     type === "feature-flag" ||
     getConnectionsSDKCapabilities({
@@ -66,8 +78,7 @@ const AddLinkedChangeRow = ({
       project: experiment.project ?? "",
     }).includes(sdkCapabilityKey as SDKCapability);
 
-  const isCTAClickable =
-    (!commercialFeature || hasFeature) && hasSDKWithFeature;
+  const isCTAClickable = hasSDKWithFeature;
 
   return (
     <div className="d-flex">
@@ -104,18 +115,32 @@ const AddLinkedChangeRow = ({
             {header}
           </b>
           {isCTAClickable ? (
-            <div
-              className="btn btn-link link-purple p-0"
-              onClick={() => {
-                setModal(true);
-              }}
-            >
-              {cta}
-            </div>
-          ) : commercialFeature && !hasFeature ? (
-            <PremiumTooltip commercialFeature={type as CommercialFeature}>
-              <div className="btn btn-link p-0 disabled">{cta}</div>
-            </PremiumTooltip>
+            commercialFeature && !hasFeature ? (
+              <PremiumTooltip
+                commercialFeature={commercialFeature}
+                body={
+                  "You can add this to your draft, but you will not be able to start the experiment until upgrading."
+                }
+              >
+                <div
+                  className="btn btn-link link-purple p-0"
+                  onClick={() => {
+                    setModal(true);
+                  }}
+                >
+                  {cta}
+                </div>
+              </PremiumTooltip>
+            ) : (
+              <div>
+                <Tooltip
+                  body={`The SDKs in this project don't support ${header}. Upgrade your SDK(s) or add a supported SDK.`}
+                  tipPosition="top"
+                >
+                  <div className="btn btn-link disabled p-0">{cta}</div>
+                </Tooltip>
+              </div>
+            )
           ) : (
             <div>
               <Tooltip
@@ -148,11 +173,6 @@ export default function AddLinkedChanges({
   setFeatureModal: (state: boolean) => unknown;
   setUrlRedirectModal: (state: boolean) => unknown;
 }) {
-  const { hasCommercialFeature } = useUser();
-
-  const hasVisualEditorFeature = hasCommercialFeature("visual-editor");
-  const hasURLRedirectsFeature = hasCommercialFeature("redirects");
-
   if (experiment.status !== "draft") return null;
   if (experiment.archived) return null;
   // Already has linked changes
@@ -196,13 +216,6 @@ export default function AddLinkedChanges({
               <AddLinkedChangeRow
                 type={s as LinkedChange}
                 setModal={sections[s].setModal}
-                hasFeature={
-                  s === "visual-editor"
-                    ? hasVisualEditorFeature
-                    : s === "redirects"
-                    ? hasURLRedirectsFeature
-                    : true
-                }
                 experiment={experiment}
               />
               {i < sectionsToRender.length - 1 && <hr />}

--- a/packages/front-end/components/Experiment/LinkedChanges/LinkedChangesContainer.tsx
+++ b/packages/front-end/components/Experiment/LinkedChanges/LinkedChangesContainer.tsx
@@ -79,11 +79,17 @@ export default function LinkedChangesContainer({
                     {addButtonCopy}
                   </Button>
                 ) : (
-                  <PremiumTooltip commercialFeature={type}>
-                    <div className="btn btn-link disabled">
-                      <FaPlusCircle className="mr-1" />
+                  <PremiumTooltip
+                    commercialFeature={type}
+                    body="You can add this to your draft, but you will not be able to start the experiment until upgrading."
+                  >
+                    <Button variant="ghost" onClick={() => onAddChange()}>
+                      <FaPlusCircle
+                        className="mr-2"
+                        style={{ position: "relative", top: "-2px" }}
+                      />
                       {addButtonCopy}
-                    </div>
+                    </Button>
                   </PremiumTooltip>
                 )}
               </div>

--- a/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
@@ -10,8 +10,6 @@ import React, { ReactNode, useEffect, useRef, useState } from "react";
 import { date, daysBetween } from "shared/dates";
 import { MdRocketLaunch } from "react-icons/md";
 import clsx from "clsx";
-import { SDKConnectionInterface } from "back-end/types/sdk-connection";
-import Link from "next/link";
 import Collapsible from "react-collapsible";
 import { useGrowthBook } from "@growthbook/growthbook-react";
 import { BsThreeDotsVertical } from "react-icons/bs";
@@ -31,7 +29,6 @@ import Tooltip from "@/components/Tooltip/Tooltip";
 import track from "@/services/track";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import { useCelebration } from "@/hooks/useCelebration";
-import useSDKConnections from "@/hooks/useSDKConnections";
 import InitialSDKConnectionForm from "@/components/Features/SDKConnections/InitialSDKConnectionForm";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 import { useUser } from "@/services/UserContext";
@@ -54,6 +51,7 @@ import Callout from "@/components/Radix/Callout";
 import SelectField from "@/components/Forms/SelectField";
 import LoadingSpinner from "@/components/LoadingSpinner";
 import HelperText from "@/components/Radix/HelperText";
+import StartExperimentModal from "@/components/Experiment/TabbedPage/StartExperimentModal";
 import TemplateForm from "../Templates/TemplateForm";
 import ProjectTagBar from "./ProjectTagBar";
 import EditExperimentInfoModal, {
@@ -83,7 +81,6 @@ export interface Props {
   editPhases?: (() => void) | null;
   editTags?: (() => void) | null;
   healthNotificationCount: number;
-  verifiedConnections: SDKConnectionInterface[];
   linkedFeatures: LinkedFeatureInfo[];
 }
 
@@ -135,7 +132,6 @@ export default function ExperimentHeader({
   editPhases,
   editTags,
   healthNotificationCount,
-  verifiedConnections,
   linkedFeatures,
 }: Props) {
   const growthbook = useGrowthBook<AppFeatures>();
@@ -148,9 +144,7 @@ export default function ExperimentHeader({
   const { getDatasourceById } = useDefinitions();
   const dataSource = getDatasourceById(experiment.datasource);
   const startCelebration = useCelebration();
-  const { data: sdkConnections } = useSDKConnections();
   const { snapshot, phase, analysis } = useSnapshot();
-  const connections = sdkConnections?.connections || [];
 
   const [showSdkForm, setShowSdkForm] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
@@ -241,8 +235,6 @@ export default function ExperimentHeader({
   const canCreateTemplate =
     permissionsUtil.canViewExperimentTemplateModal() &&
     hasCommercialFeature("templates");
-  const checklistIncomplete =
-    checklistItemsRemaining !== null && checklistItemsRemaining > 0;
 
   const isUsingHealthUnsupportDatasource =
     !dataSource || datasourcesWithoutHealthData.has(dataSource.type);
@@ -566,96 +558,12 @@ export default function ExperimentHeader({
         </Modal>
       ) : null}
       {showStartExperiment && experiment.status === "draft" && (
-        <Modal
-          trackingEventModalType="start-experiment"
-          trackingEventModalSource={
-            checklistIncomplete || !verifiedConnections.length
-              ? "incomplete-checklist"
-              : "complete-checklist"
-          }
-          open={true}
-          size="md"
-          closeCta={
-            checklistIncomplete || !verifiedConnections.length
-              ? "Close"
-              : "Start Immediately"
-          }
-          closeCtaClassName="btn btn-primary"
-          onClickCloseCta={
-            checklistIncomplete || !verifiedConnections.length
-              ? () => setShowStartExperiment(false)
-              : async () => startExperiment()
-          }
-          secondaryCTA={
-            checklistIncomplete || !verifiedConnections.length ? (
-              <button
-                className="btn btn-link text-decoration-none"
-                onClick={async () => startExperiment()}
-              >
-                <span
-                  style={{
-                    color: "var(--text-color-primary)",
-                  }}
-                >
-                  Start Anyway
-                </span>
-              </button>
-            ) : (
-              <button
-                className="btn btn-link text-decoration-none"
-                onClick={() => setShowStartExperiment(false)}
-              >
-                <span
-                  style={{
-                    color: "var(--text-color-primary)",
-                  }}
-                >
-                  Cancel
-                </span>
-              </button>
-            )
-          }
+        <StartExperimentModal
+          experiment={experiment}
           close={() => setShowStartExperiment(false)}
-          header="Start Experiment"
-        >
-          <div className="p-2">
-            {checklistIncomplete ? (
-              <div className="alert alert-warning">
-                You have{" "}
-                <strong>
-                  {checklistItemsRemaining} task
-                  {checklistItemsRemaining > 1 ? "s " : " "}
-                </strong>
-                left to complete. Review the Pre-Launch Checklist before
-                starting this experiment.
-              </div>
-            ) : null}
-            {!verifiedConnections.length ? (
-              <div className="alert alert-warning">
-                You haven&apos;t integrated GrowthBook into your app.{" "}
-                {connections.length > 0 ? (
-                  <Link href="/sdks">Manage SDK Connections</Link>
-                ) : (
-                  <a
-                    href="#"
-                    onClick={(e) => {
-                      e.preventDefault();
-                      setShowStartExperiment(false);
-                      setShowSdkForm(true);
-                    }}
-                  >
-                    Add SDK Connection
-                  </a>
-                )}
-              </div>
-            ) : null}
-            <div>
-              Once started, linked changes will be activated and users will
-              begin to see your experiment variations{" "}
-              <strong>immediately</strong>.
-            </div>
-          </div>
-        </Modal>
+          startExperiment={startExperiment}
+          checklistItemsRemaining={checklistItemsRemaining || 0}
+        />
       )}
       {showTemplateForm && (
         <TemplateForm

--- a/packages/front-end/components/Experiment/TabbedPage/StartExperimentModal.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/StartExperimentModal.tsx
@@ -1,0 +1,116 @@
+import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
+import { useState } from "react";
+import Modal from "@/components/Modal";
+import { useUser } from "@/services/UserContext";
+import UpgradeModal from "@/components/Settings/UpgradeModal";
+import PremiumCallout from "@/components/Radix/PremiumCallout";
+
+export interface Props {
+  experiment: ExperimentInterfaceStringDates;
+  close: () => void;
+  startExperiment: () => Promise<void>;
+  checklistItemsRemaining: number;
+}
+
+export default function StartExperimentModal({
+  experiment,
+  close,
+  startExperiment,
+  checklistItemsRemaining,
+}: Props) {
+  const checklistIncomplete = checklistItemsRemaining > 0;
+
+  const [upgradeModal, setUpgradeModal] = useState(false);
+
+  const { hasCommercialFeature } = useUser();
+
+  const needsVisualEditorUpgrade =
+    experiment.hasVisualChangesets && !hasCommercialFeature("visual-editor");
+
+  const needsRedirectUpgrade =
+    experiment.hasURLRedirects && !hasCommercialFeature("redirects");
+
+  const needsUpgrade = needsVisualEditorUpgrade || needsRedirectUpgrade;
+
+  if (needsUpgrade && upgradeModal) {
+    return (
+      <UpgradeModal
+        close={() => setUpgradeModal(false)}
+        commercialFeature={
+          needsVisualEditorUpgrade ? "visual-editor" : "redirects"
+        }
+        source="start-experiment-modal"
+      />
+    );
+  }
+
+  return (
+    <Modal
+      trackingEventModalType="start-experiment"
+      trackingEventModalSource={
+        checklistIncomplete ? "incomplete-checklist" : "complete-checklist"
+      }
+      open={true}
+      size="md"
+      submit={startExperiment}
+      cta="Start Now"
+      ctaEnabled={!checklistIncomplete && !needsUpgrade}
+      close={close}
+      secondaryCTA={
+        checklistIncomplete && !needsUpgrade ? (
+          <button
+            className="btn btn-link text-decoration-none"
+            onClick={async () => startExperiment()}
+          >
+            <span
+              style={{
+                color: "var(--text-color-danger)",
+              }}
+            >
+              Start Anyway
+            </span>
+          </button>
+        ) : null
+      }
+      header="Start Experiment"
+    >
+      <div className="p-2">
+        {checklistIncomplete ? (
+          <div className="alert alert-warning">
+            You have{" "}
+            <strong>
+              {checklistItemsRemaining} task
+              {checklistItemsRemaining > 1 ? "s " : " "}
+            </strong>
+            left to complete. Review the Pre-Launch Checklist before starting
+            this experiment.
+          </div>
+        ) : null}
+
+        {needsVisualEditorUpgrade ? (
+          <PremiumCallout
+            commercialFeature="visual-editor"
+            id="start-experiment-modal"
+            mb="3"
+          >
+            This experiment contains visual editor changes, which require a paid
+            plan.
+          </PremiumCallout>
+        ) : needsRedirectUpgrade ? (
+          <PremiumCallout
+            commercialFeature="redirects"
+            id="start-experiment-modal"
+            mb="3"
+          >
+            This experiment contains URL redirects, which require a paid plan.
+          </PremiumCallout>
+        ) : (
+          <div>
+            Once started, linked changes will be activated and users will begin
+            to see your experiment variations <strong>immediately</strong>.
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/packages/front-end/components/Experiment/TabbedPage/index.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/index.tsx
@@ -173,9 +173,6 @@ export default function TabbedPage({
     (connection) =>
       !visualChangesets.length || connection.includeVisualExperiments
   );
-  const verifiedConnections = matchingConnections.filter(
-    (connection) => connection.connected
-  );
 
   const { data, mutate: mutateWatchers } = useApi<{
     userIds: string[];
@@ -292,7 +289,6 @@ export default function TabbedPage({
         editPhases={editPhases}
         healthNotificationCount={healthNotificationCount}
         checklistItemsRemaining={checklistItemsRemaining}
-        verifiedConnections={verifiedConnections}
         linkedFeatures={linkedFeatures}
       />
 

--- a/packages/front-end/components/Experiment/Templates/TemplatesPage.tsx
+++ b/packages/front-end/components/Experiment/Templates/TemplatesPage.tsx
@@ -106,7 +106,6 @@ export const TemplatesPage = ({
           description="Save time configuring experiment details, and ensure consistency
             across your team and projects."
           commercialFeature="templates"
-          reason="Experiment Templates No Access"
           learnMoreLink="https://docs.growthbook.io/running-experiments/experiment-templates"
         />
       </>
@@ -220,7 +219,6 @@ export const TemplatesPage = ({
         <UpgradeModal
           close={() => setShowUpgradeModal(false)}
           source="templates"
-          reason="Create reusable experiment templates"
           commercialFeature="templates"
         />
       )}

--- a/packages/front-end/components/FactTables/CreateMetricFromTemplate.tsx
+++ b/packages/front-end/components/FactTables/CreateMetricFromTemplate.tsx
@@ -46,7 +46,6 @@ export default function CreateMetricFromTemplate() {
   const [upgradeModal, setUpgradeModal] = useState<null | {
     source: string;
     commercialFeature: CommercialFeature;
-    reason: string;
   }>(null);
 
   const QUERY_KEY = "addMetric";
@@ -95,7 +94,6 @@ export default function CreateMetricFromTemplate() {
                 showUpgradeModal={() =>
                   setUpgradeModal({
                     source: "metric-template-quantile",
-                    reason: "To create quantile metrics,",
                     commercialFeature: "quantile-metrics",
                   })
                 }
@@ -116,7 +114,6 @@ export default function CreateMetricFromTemplate() {
                 showUpgradeModal={() =>
                   setUpgradeModal({
                     source: "metric-template-retention",
-                    reason: "To create retention metrics,",
                     commercialFeature: "retention-metrics",
                   })
                 }
@@ -165,7 +162,6 @@ export default function CreateMetricFromTemplate() {
       {upgradeModal ? (
         <UpgradeModal
           close={() => setUpgradeModal(null)}
-          reason={upgradeModal.reason}
           source={upgradeModal.source}
           commercialFeature={upgradeModal.commercialFeature}
         />

--- a/packages/front-end/components/Features/FeatureTest.tsx
+++ b/packages/front-end/components/Features/FeatureTest.tsx
@@ -41,7 +41,6 @@ export default function FeatureTest({
           description={
             "Feature allows you to see how your rules will apply to users based on their attributes. Upgrade to unlock this feature."
           }
-          reason={"No Access Feature Testing Tab"}
           learnMoreLink="https://docs.growthbook.io/features/rules#testing-rules"
         />
       </Box>

--- a/packages/front-end/components/Features/FeaturesStats.tsx
+++ b/packages/front-end/components/Features/FeaturesStats.tsx
@@ -56,7 +56,6 @@ export default function FeaturesStats({
               codebase, with direct links from GrowthBook to the platform of
               your choice."
             commercialFeature="code-references"
-            reason="Code ref on features no access"
             learnMoreLink="https://docs.growthbook.io/features/code-references"
           />
         </div>

--- a/packages/front-end/components/Features/JSONValidation.tsx
+++ b/packages/front-end/components/Features/JSONValidation.tsx
@@ -57,7 +57,6 @@ export default function JSONValidation({ feature, mutate }: Props) {
       {upgradeModal && (
         <UpgradeModal
           close={() => setUpgradeModal(false)}
-          reason="To get access to JSON Validation,"
           source="json-validation"
           commercialFeature="json-validation"
         />

--- a/packages/front-end/components/Layout/Layout.tsx
+++ b/packages/front-end/components/Layout/Layout.tsx
@@ -405,7 +405,6 @@ const Layout = (): React.ReactElement => {
       {upgradeModal && (
         <UpgradeModal
           close={() => setUpgradeModal(false)}
-          reason=""
           source="layout"
           commercialFeature={null}
         />

--- a/packages/front-end/components/License/ShowLicenseInfo.tsx
+++ b/packages/front-end/components/License/ShowLicenseInfo.tsx
@@ -39,7 +39,6 @@ const ShowLicenseInfo: FC<{
       {upgradeModal && (
         <UpgradeModal
           close={() => setUpgradeModal(false)}
-          reason=""
           source="settings"
           commercialFeature={null}
         />

--- a/packages/front-end/components/Metrics/MetricGroupsList.tsx
+++ b/packages/front-end/components/Metrics/MetricGroupsList.tsx
@@ -57,7 +57,6 @@ const MetricGroupsList: FC = () => {
           title="Organize Your Experiment Metrics"
           description="Create reusable groups of metrics that can be ordered and added to experiments"
           commercialFeature="metric-groups"
-          reason="No Access Metric Groups"
           learnMoreLink="https://docs.growthbook.io/app/metrics#metric-groups"
           image="/images/empty-states/metric_groups.png"
         />

--- a/packages/front-end/components/PremiumEmptyState.tsx
+++ b/packages/front-end/components/PremiumEmptyState.tsx
@@ -12,7 +12,6 @@ interface Props {
   description: string;
   learnMoreLink?: string;
   commercialFeature: CommercialFeature;
-  reason: string;
   image?: string;
 }
 
@@ -22,7 +21,6 @@ const PremiumEmptyState: FC<Props> = ({
   h1 = "",
   learnMoreLink,
   commercialFeature,
-  reason,
   image,
 }) => {
   const [upgradeModal, setUpgradeModal] = useState(false);
@@ -91,7 +89,6 @@ const PremiumEmptyState: FC<Props> = ({
           {upgradeModal && (
             <UpgradeModal
               close={() => setUpgradeModal(false)}
-              reason={reason}
               source={commercialFeature}
               commercialFeature={commercialFeature}
             />

--- a/packages/front-end/components/Radix/PremiumCallout.tsx
+++ b/packages/front-end/components/Radix/PremiumCallout.tsx
@@ -1,0 +1,120 @@
+import { CommercialFeature } from "shared/enterprise";
+import { Flex, IconButton, Callout as RadixCallout } from "@radix-ui/themes";
+import { MarginProps } from "@radix-ui/themes/dist/esm/props/margin.props.js";
+import { useState } from "react";
+import { PiArrowSquareOut, PiLightbulb } from "react-icons/pi";
+import { useUser } from "@/services/UserContext";
+import { DocLink, DocSection } from "@/components/DocLink";
+import PaidFeatureBadge from "@/components/GetStarted/PaidFeatureBadge";
+import { useLocalStorage } from "@/hooks/useLocalStorage";
+import UpgradeModal from "@/components/Settings/UpgradeModal";
+import styles from "./RadixOverrides.module.scss";
+
+export type Props = {
+  commercialFeature: CommercialFeature;
+  id: string;
+  dismissable?: boolean;
+  children: React.ReactNode;
+  docSection?: DocSection;
+} & MarginProps;
+
+export default function PremiumCallout({
+  commercialFeature,
+  id,
+  dismissable = false,
+  children,
+  docSection,
+  ...containerProps
+}: Props) {
+  const { hasCommercialFeature, commercialFeatureLowestPlan } = useUser();
+  const hasFeature = hasCommercialFeature(commercialFeature);
+
+  const [dismissed, setDismissed] = useLocalStorage(
+    `premium-callout-${id}`,
+    false
+  );
+
+  const [upgradeModal, setUpgradeModal] = useState(false);
+
+  if (hasFeature && !docSection) return null;
+  if (dismissed) return null;
+
+  const lowestPlanLevel =
+    commercialFeatureLowestPlan?.[commercialFeature] || "";
+
+  const enterprise = lowestPlanLevel === "enterprise";
+  const pro = lowestPlanLevel === "pro";
+
+  // Some unknown plan, skip showing the callout
+  if (!enterprise && !pro) {
+    return null;
+  }
+
+  if (upgradeModal) {
+    return (
+      <UpgradeModal
+        commercialFeature={commercialFeature}
+        close={() => setUpgradeModal(false)}
+        source={`premium-callout-${id}`}
+      />
+    );
+  }
+
+  const color = hasFeature ? "violet" : pro ? "gold" : "indigo";
+  const icon = hasFeature ? (
+    <PiLightbulb size={15} />
+  ) : (
+    <PaidFeatureBadge commercialFeature={commercialFeature} useTip={false} />
+  );
+
+  const link =
+    hasFeature && docSection ? (
+      <DocLink docSection={docSection}>
+        View docs <PiArrowSquareOut size={15} />
+      </DocLink>
+    ) : pro ? (
+      <a
+        href="#"
+        onClick={(e) => {
+          e.preventDefault();
+          setUpgradeModal(true);
+        }}
+      >
+        Upgrade Now
+      </a>
+    ) : (
+      <a href="https://www.growthbook.io/demo" target="_blank" rel="noreferrer">
+        Talk to Sales <PiArrowSquareOut size={15} />
+      </a>
+    );
+
+  return (
+    <RadixCallout.Root
+      className={styles.callout}
+      color={color}
+      role="alert"
+      size="2"
+      {...containerProps}
+    >
+      <RadixCallout.Icon>{icon}</RadixCallout.Icon>
+      <RadixCallout.Text size="2">
+        <Flex align="center" gap="1">
+          <div>{children}</div>
+          <div>{link}</div>
+          {dismissable ? (
+            <IconButton
+              variant="ghost"
+              color="gray"
+              size="1"
+              onClick={() => setDismissed(true)}
+              aria-label="Dismiss"
+              ml="auto"
+            >
+              x
+            </IconButton>
+          ) : null}
+        </Flex>
+      </RadixCallout.Text>
+    </RadixCallout.Root>
+  );
+}

--- a/packages/front-end/components/Report/ConfigureReport.tsx
+++ b/packages/front-end/components/Report/ConfigureReport.tsx
@@ -166,7 +166,6 @@ export default function ConfigureReport({
     return (
       <UpgradeModal
         close={() => setUpgradeModal(false)}
-        reason="To override metric conversion windows,"
         source="override-metrics"
         commercialFeature="override-metrics"
       />

--- a/packages/front-end/components/SavedGroups/IdLists.tsx
+++ b/packages/front-end/components/SavedGroups/IdLists.tsx
@@ -106,7 +106,6 @@ export default function IdLists({ groups, mutate }: Props) {
       {upgradeModal && (
         <UpgradeModal
           close={() => setUpgradeModal(false)}
-          reason=""
           source="large-saved-groups"
           commercialFeature="large-saved-groups"
         />

--- a/packages/front-end/components/SavedGroups/SavedGroupForm.tsx
+++ b/packages/front-end/components/SavedGroups/SavedGroupForm.tsx
@@ -77,7 +77,6 @@ const SavedGroupForm: FC<{
   return upgradeModal ? (
     <UpgradeModal
       close={() => setUpgradeModal(false)}
-      reason=""
       source="large-saved-groups"
       commercialFeature="large-saved-groups"
     />

--- a/packages/front-end/components/Settings/SubscriptionInfo.tsx
+++ b/packages/front-end/components/Settings/SubscriptionInfo.tsx
@@ -38,7 +38,6 @@ export default function SubscriptionInfo() {
       {upgradeModal && (
         <UpgradeModal
           close={() => setUpgradeModal(false)}
-          reason="Your subscription has expired."
           source="billing-renew"
           commercialFeature={null}
         />

--- a/packages/front-end/components/Settings/Team/AddOrphanedUserModal.tsx
+++ b/packages/front-end/components/Settings/Team/AddOrphanedUserModal.tsx
@@ -30,7 +30,6 @@ const AddOrphanedUserModal: FC<{
       <UpgradeModal
         close={close}
         source="add orphaned user"
-        reason={"To enable advanced permissioning,"}
         commercialFeature="advanced-permissions"
       />
     );

--- a/packages/front-end/components/Settings/Team/ChangeRoleModal.tsx
+++ b/packages/front-end/components/Settings/Team/ChangeRoleModal.tsx
@@ -18,7 +18,6 @@ const ChangeRoleModal: FC<{
     return (
       <UpgradeModal
         close={() => setUpgradeModal(false)}
-        reason="To enable advanced permissioning,"
         source="advanced-permissions"
         commercialFeature="advanced-permissions"
       />

--- a/packages/front-end/components/Settings/Team/InviteModal.tsx
+++ b/packages/front-end/components/Settings/Team/InviteModal.tsx
@@ -55,8 +55,6 @@ const InviteModal = ({ mutate, close, defaultRole }: Props) => {
   const { apiCall } = useAuth();
   const [showUpgradeModal, setShowUpgradeModal] = useState(
     isCloud() && canSubscribe && seatsInUse >= freeSeats
-      ? "Whoops! You reached your free seat limit."
-      : ""
   );
 
   const [showContactSupport, setShowContactSupport] = useState(
@@ -72,7 +70,6 @@ const InviteModal = ({ mutate, close, defaultRole }: Props) => {
       <UpgradeModal
         close={close}
         source="invite team"
-        reason={showUpgradeModal}
         commercialFeature={null}
       />
     );
@@ -108,7 +105,7 @@ const InviteModal = ({ mutate, close, defaultRole }: Props) => {
       canSubscribe &&
       seatsInUse + value.email.length > freeSeats
     ) {
-      setShowUpgradeModal("Whoops! You reached your free seat limit.");
+      setShowUpgradeModal(true);
       return;
     }
 
@@ -262,9 +259,7 @@ const InviteModal = ({ mutate, close, defaultRole }: Props) => {
           <RoleSelector
             value={form.watch("roleInfo")}
             setValue={(value) => form.setValue("roleInfo", value)}
-            showUpgradeModal={() =>
-              setShowUpgradeModal("To enable advanced permissioning,")
-            }
+            showUpgradeModal={() => setShowUpgradeModal(true)}
           />
         </>
       )}

--- a/packages/front-end/components/Settings/UpgradeModal/VerifyingEmailModal.tsx
+++ b/packages/front-end/components/Settings/UpgradeModal/VerifyingEmailModal.tsx
@@ -61,7 +61,6 @@ export default function VerifyingEmailModal() {
     return (
       <UpgradeModal
         close={() => setShowUpgradeModal(false)}
-        reason="To fix an error verifying email."
         source="verify email"
         commercialFeature={null}
       />

--- a/packages/front-end/components/Settings/UpgradeModal/index.tsx
+++ b/packages/front-end/components/Settings/UpgradeModal/index.tsx
@@ -26,7 +26,6 @@ import SelfHostedTrialConfirmationModal from "./SelfHostedTrialConfirmationModal
 export interface Props {
   close: () => void;
   source: string;
-  reason: string;
   commercialFeature: CommercialFeature | null;
 }
 

--- a/packages/front-end/pages/bandits/index.tsx
+++ b/packages/front-end/pages/bandits/index.tsx
@@ -254,7 +254,6 @@ const ExperimentsPage = (): React.ReactElement => {
           title="Run Adaptive Experiments with Bandits"
           description="Bandits automatically guide more traffic to better variants."
           commercialFeature="multi-armed-bandits"
-          reason="Bandit Experiments No Access"
           learnMoreLink="https://docs.growthbook.io/bandits/overview"
         />
       </div>

--- a/packages/front-end/pages/experiments/template/[tid].tsx
+++ b/packages/front-end/pages/experiments/template/[tid].tsx
@@ -145,7 +145,6 @@ const TemplatePage: FC = () => {
               <UpgradeModal
                 close={() => setShowUpgradeModal(false)}
                 source="templates"
-                reason="Create experiments from templates"
                 commercialFeature="templates"
               />
             )}

--- a/packages/front-end/pages/getstarted.tsx
+++ b/packages/front-end/pages/getstarted.tsx
@@ -65,7 +65,6 @@ const GetStartedPage = (): React.ReactElement => {
       {upgradeModal && (
         <UpgradeModal
           close={() => setUpgradeModal(false)}
-          reason=""
           source="get-started"
           commercialFeature={null}
         />

--- a/packages/front-end/pages/getstarted/experiment-guide.tsx
+++ b/packages/front-end/pages/getstarted/experiment-guide.tsx
@@ -125,7 +125,6 @@ const ExperimentGuide = (): React.ReactElement => {
       {upgradeModal && (
         <UpgradeModal
           close={() => setUpgradeModal(false)}
-          reason=""
           source="get-started-experiment-guide"
           commercialFeature={null}
         />

--- a/packages/front-end/pages/getstarted/feature-flag-guide.tsx
+++ b/packages/front-end/pages/getstarted/feature-flag-guide.tsx
@@ -60,7 +60,6 @@ const CreateFeatureFlagsGuide = (): React.ReactElement => {
       {upgradeModal && (
         <UpgradeModal
           close={() => setUpgradeModal(false)}
-          reason=""
           source="get-started"
           commercialFeature={null}
         />

--- a/packages/front-end/pages/getstarted/imported-experiment-guide.tsx
+++ b/packages/front-end/pages/getstarted/imported-experiment-guide.tsx
@@ -67,7 +67,6 @@ const ImportedExperimentGuide = (): React.ReactElement => {
       {upgradeModal && (
         <UpgradeModal
           close={() => setUpgradeModal(false)}
-          reason=""
           source="get-started-experiment-guide"
           commercialFeature={null}
         />

--- a/packages/front-end/pages/saved-groups/[sgid].tsx
+++ b/packages/front-end/pages/saved-groups/[sgid].tsx
@@ -154,7 +154,6 @@ export default function EditSavedGroupPage() {
       {upgradeModal && (
         <UpgradeModal
           close={() => setUpgradeModal(false)}
-          reason=""
           source="large-saved-groups"
           commercialFeature="large-saved-groups"
         />

--- a/packages/front-end/pages/settings/billing.tsx
+++ b/packages/front-end/pages/settings/billing.tsx
@@ -69,7 +69,6 @@ const BillingPage: FC = () => {
       {upgradeModal && (
         <UpgradeModal
           close={() => setUpgradeModal(false)}
-          reason=""
           source="billing-free"
           commercialFeature={null}
         />

--- a/packages/front-end/pages/settings/customfields.tsx
+++ b/packages/front-end/pages/settings/customfields.tsx
@@ -16,7 +16,6 @@ const CustomFieldsPage = (): React.ReactElement => {
                   experiments and feature flags that can be required or
                   optional."
           commercialFeature="custom-metadata"
-          reason="Custom Fields landing page no access"
           learnMoreLink="https://docs.growthbook.io/using/growthbook-best-practices#custom-fields"
         />
       </div>

--- a/packages/front-end/pages/settings/team.tsx
+++ b/packages/front-end/pages/settings/team.tsx
@@ -89,7 +89,6 @@ const TeamPage: FC = () => {
                 title="Teams"
                 description="Create groups of GrowthBook users to organize and manage permissions centrally"
                 commercialFeature="teams"
-                reason="Teams no access"
                 learnMoreLink="https://docs.growthbook.io/account/user-permissions#teams"
               />
             )}
@@ -128,7 +127,6 @@ const TeamPage: FC = () => {
                 title="Custom Roles"
                 description="Custom roles allows you to adjust permissions and assign those roles to members or teams"
                 commercialFeature="custom-roles"
-                reason="Custom Roles no access"
                 learnMoreLink="https://docs.growthbook.io/account/user-permissions#custom-roles"
               />
             )}

--- a/packages/front-end/pages/setup/index.tsx
+++ b/packages/front-end/pages/setup/index.tsx
@@ -181,13 +181,11 @@ export default function SetupFlow() {
 
             const sdkCapabilities = getSDKCapabilities(value.languages[0]);
 
-            const canUseVisualEditor =
-              hasCommercialFeature("visual-editor") &&
-              sdkCapabilities.includes("visualEditorJS");
+            const canUseVisualEditor = sdkCapabilities.includes(
+              "visualEditorJS"
+            );
 
-            const canUseUrlRedirects =
-              hasCommercialFeature("redirects") &&
-              sdkCapabilities.includes("redirects");
+            const canUseUrlRedirects = sdkCapabilities.includes("redirects");
 
             const canUseSecureConnection =
               hasCommercialFeature("hash-secure-attributes") &&


### PR DESCRIPTION
### Features and Changes

Instead of blocking free accounts from creating Visual Editor or URL Redirect experiments entirely, allow creating drafts and only block when trying to start the experiment.

This will let free users try these premium features before deciding whether or not to upgrade.

TODO:
- [ ] Testing
- [ ] Add screenshots to PR
- [ ] Document new `PremiumCallout` component in the design system