### PR TITLE
Add number field for rollouts (allow fractional percentages)

### DIFF
--- a/packages/front-end/components/Features/RolloutPercentInput.tsx
+++ b/packages/front-end/components/Features/RolloutPercentInput.tsx
@@ -37,9 +37,7 @@ export default function RolloutPercentInput({
             <Field
               style={{ width: 95 }}
               value={isNaN(value ?? 0) ? "" : decimalToPercent(value ?? 0)}
-              min={0}
-              max={1}
-              step={0.01}
+              step={1}
               onChange={(e) => {
                 let decimal = percentToDecimal(e.target.value);
                 if (decimal > 1) decimal = 1;

--- a/packages/front-end/components/Features/RolloutPercentInput.tsx
+++ b/packages/front-end/components/Features/RolloutPercentInput.tsx
@@ -1,9 +1,8 @@
 import { Slider } from "@radix-ui/themes";
-
-const percentFormatter = new Intl.NumberFormat(undefined, {
-  style: "percent",
-  maximumFractionDigits: 2,
-});
+import React from "react";
+import styles from "@/components/Features/VariationsInput.module.scss";
+import Field from "@/components/Forms/Field";
+import { decimalToPercent, percentToDecimal } from "@/services/utils";
 
 export interface Props {
   value: number;
@@ -33,8 +32,24 @@ export default function RolloutPercentInput({
             }}
           />
         </div>
-        <div className="col-auto" style={{ fontSize: "1.3em", width: "4em" }}>
-          {percentFormatter.format(value)}
+        <div className="col-auto">
+          <div className={`position-relative ${styles.percentInputWrap}`}>
+            <Field
+              style={{ width: 95 }}
+              value={isNaN(value ?? 0) ? "" : decimalToPercent(value ?? 0)}
+              min={0}
+              max={1}
+              step={0.01}
+              onChange={(e) => {
+                let decimal = percentToDecimal(e.target.value);
+                if (decimal > 1) decimal = 1;
+                if (decimal < 0) decimal = 0;
+                setValue(decimal);
+              }}
+              type="number"
+            />
+            <span>%</span>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Fix: cannot add less than 1% of users to a rollout without hackery (stacking rollouts, REST API).

<img width="855" alt="image" src="https://github.com/user-attachments/assets/f5813a6b-f582-41f3-aed2-ea62e504b858" />

before:
<img width="770" alt="image" src="https://github.com/user-attachments/assets/436c9a33-0179-4f2e-93fe-357a4acdc34a" />
