### PR TITLE
including __add__ for statistics that are not quantile

### DIFF
--- a/packages/stats/gbstats/models/statistics.py
+++ b/packages/stats/gbstats/models/statistics.py
@@ -133,6 +133,16 @@ class RatioStatistic(Statistic):
             - self.m_statistic.sum * self.d_statistic.sum / self.n
         ) / (self.n - 1)
 
+    def __add__(self, other):
+        if not isinstance(other, RatioStatistic):
+            raise TypeError("Can add only another RatioStatistic instance")
+        return RatioStatistic(
+            n=self.n + other.n,
+            m_statistic=self.m_statistic + other.m_statistic,
+            d_statistic=self.d_statistic + other.d_statistic,
+            m_d_sum_of_products=self.m_d_sum_of_products + other.m_d_sum_of_products,
+        )
+
 
 @dataclass
 class RegressionAdjustedStatistic(Statistic):
@@ -180,45 +190,26 @@ class RegressionAdjustedStatistic(Statistic):
             - self.post_statistic.sum * self.pre_statistic.sum / self.n
         ) / (self.n - 1)
 
+    def __add__(self, other):
+        if not isinstance(other, RegressionAdjustedStatistic):
+            raise TypeError("Can add only another RegressionAdjustedStatistic instance")
+        return RegressionAdjustedStatistic(
+            n=self.n + other.n,
+            post_statistic=self.post_statistic + other.post_statistic,
+            pre_statistic=self.pre_statistic + other.pre_statistic,
+            post_pre_sum_of_products=self.post_pre_sum_of_products
+            + other.post_pre_sum_of_products,
+            theta=None,
+        )
+
 
 def compute_theta(
     a: RegressionAdjustedStatistic, b: RegressionAdjustedStatistic
 ) -> float:
-    n = a.n + b.n
-    joint_post_statistic = create_joint_statistic(
-        a=a.post_statistic, b=b.post_statistic, n=n
-    )
-    joint_pre_statistic = create_joint_statistic(
-        a=a.pre_statistic, b=b.pre_statistic, n=n
-    )
-    if joint_pre_statistic.variance == 0 or joint_post_statistic.variance == 0:
+    joint = a + b
+    if joint.pre_statistic.variance == 0 or joint.post_statistic.variance == 0:
         return 0
-
-    joint = RegressionAdjustedStatistic(
-        n=n,
-        post_statistic=joint_post_statistic,
-        pre_statistic=joint_pre_statistic,
-        post_pre_sum_of_products=a.post_pre_sum_of_products
-        + b.post_pre_sum_of_products,
-        theta=0,
-    )
     return joint.covariance / joint.pre_statistic.variance
-
-
-def create_joint_statistic(
-    a: Union[ProportionStatistic, SampleMeanStatistic],
-    b: Union[ProportionStatistic, SampleMeanStatistic],
-    n: int,
-) -> Union[ProportionStatistic, SampleMeanStatistic]:
-    if isinstance(a, ProportionStatistic) and isinstance(b, ProportionStatistic):
-        return ProportionStatistic(n=n, sum=a.sum + b.sum)
-    elif isinstance(a, SampleMeanStatistic) and isinstance(b, SampleMeanStatistic):
-        return SampleMeanStatistic(
-            n=n, sum=a.sum + b.sum, sum_squares=a.sum_squares + b.sum_squares
-        )
-    raise ValueError(
-        "Statistic types for a metric must not be different types across variations."
-    )
 
 
 @dataclass
@@ -419,6 +410,32 @@ class RegressionAdjustedRatioStatistic(Statistic):
     def var_d_pre(self) -> float:
         return self.d_statistic_pre.variance
 
+    def __add__(self, other):
+        if not isinstance(other, RegressionAdjustedRatioStatistic):
+            raise TypeError(
+                "Can add only another RegressionAdjustedRatioStatistic instance"
+            )
+        return RegressionAdjustedRatioStatistic(
+            n=self.n + other.n,
+            m_statistic_post=self.m_statistic_post + other.m_statistic_post,
+            d_statistic_post=self.d_statistic_post + other.d_statistic_post,
+            m_statistic_pre=self.m_statistic_pre + other.m_statistic_pre,
+            d_statistic_pre=self.d_statistic_pre + other.d_statistic_pre,
+            m_post_m_pre_sum_of_products=self.m_post_m_pre_sum_of_products
+            + other.m_post_m_pre_sum_of_products,
+            d_post_d_pre_sum_of_products=self.d_post_d_pre_sum_of_products
+            + other.d_post_d_pre_sum_of_products,
+            m_pre_d_pre_sum_of_products=self.m_pre_d_pre_sum_of_products
+            + other.m_pre_d_pre_sum_of_products,
+            m_post_d_post_sum_of_products=self.m_post_d_post_sum_of_products
+            + other.m_post_d_post_sum_of_products,
+            m_post_d_pre_sum_of_products=self.m_post_d_pre_sum_of_products
+            + other.m_post_d_pre_sum_of_products,
+            m_pre_d_post_sum_of_products=self.m_pre_d_post_sum_of_products
+            + other.m_pre_d_post_sum_of_products,
+            theta=None,
+        )
+
 
 def compute_theta_regression_adjusted_ratio(
     a: RegressionAdjustedRatioStatistic, b: RegressionAdjustedRatioStatistic
@@ -517,7 +534,9 @@ class QuantileClusteredStatistic(QuantileStatistic):
             * self.n_clusters
             / (self.n_clusters - 1)
         )
-        num = sigma_2_s - 2 * mu_s * sigma_s_n / mu_n + mu_s**2 * sigma_2_n / mu_n**2
+        num = (
+            sigma_2_s - 2 * mu_s * sigma_s_n / mu_n + mu_s**2 * sigma_2_n / mu_n**2
+        )
         den = self.n_clusters * mu_n**2
         return num / den
 

--- a/packages/stats/tests/test_gbstats.py
+++ b/packages/stats/tests/test_gbstats.py
@@ -788,6 +788,9 @@ class TestAnalyzeMetricDfRegressionAdjustment(TestCase):
         rows["main_sum_squares"] = None
         rows["covariate_sum_squares"] = None
         df = get_metric_df(rows, {"zero": 0, "one": 1}, ["zero", "one"])
+        print("brenda")
+        print(rows["main_sum_squares"])
+        print(rows["covariate_sum_squares"])
         result = analyze_metric_df(
             df,
             metric=dataclasses.replace(
@@ -796,9 +799,7 @@ class TestAnalyzeMetricDfRegressionAdjustment(TestCase):
                 covariate_metric_type="binomial",
             ),
             analysis=dataclasses.replace(DEFAULT_ANALYSIS, stats_engine="frequentist"),
-        )
-
-        # Test that metric mean is unadjusted
+        )  # Test that metric mean is unadjusted
         self.assertEqual(len(result.index), 1)
         self.assertEqual(result.at[0, "dimension"], "All")
         self.assertEqual(round_(result.at[0, "baseline_cr"]), 0.099966678)
@@ -806,7 +807,7 @@ class TestAnalyzeMetricDfRegressionAdjustment(TestCase):
         self.assertEqual(round_(result.at[0, "v1_cr"]), 0.074)
         self.assertEqual(round_(result.at[0, "v1_mean"]), 0.074)
         self.assertEqual(result.at[0, "v1_risk"], None)
-        self.assertEqual(round_(result.at[0, "v1_expected"]), -0.316211568)
+        self.assertEqual(round_(result.at[0, "v1_expected"]), -0.31620216)
         self.assertEqual(result.at[0, "v1_prob_beat_baseline"], None)
         self.assertEqual(round_(result.at[0, "v1_p_value"]), 0.000000352)
 


### PR DESCRIPTION
including an __add__ method makes it easier to combine Statistics when appropriate.  

The only way this can affect production results is if two ProportionStatistics are combined when estimating theta in CUPED.  Currently we inappropriately combine the proportion statistics, which results in incorrect variance estimates unless the statistics have the same proportion parameter `p`.  If instead the resultant sum of two `ProportionStatistics` is a`SampleMeanStatistic` (as we do in Bandits) we will get the correct variance.  This had a small impact on one result in the test file.  