### PR TITLE
feature(timeseries): Add error + loading states & remove button for old experiments

### DIFF
--- a/packages/front-end/components/Experiment/BreakDownResults.tsx
+++ b/packages/front-end/components/Experiment/BreakDownResults.tsx
@@ -71,6 +71,7 @@ const BreakDownResults: FC<{
   dimensionId: string;
   isLatestPhase: boolean;
   startDate: string;
+  endDate: string;
   reportDate: Date;
   activationMetric?: string;
   status: ExperimentStatus;
@@ -98,6 +99,7 @@ const BreakDownResults: FC<{
   guardrailMetrics,
   isLatestPhase,
   startDate,
+  endDate,
   activationMetric,
   status,
   reportDate,
@@ -345,6 +347,7 @@ const BreakDownResults: FC<{
               dateCreated={reportDate}
               isLatestPhase={isLatestPhase}
               startDate={startDate}
+              endDate={endDate}
               status={status}
               queryStatusData={queryStatusData}
               variations={variations}

--- a/packages/front-end/components/Experiment/CompactResults.tsx
+++ b/packages/front-end/components/Experiment/CompactResults.tsx
@@ -62,6 +62,7 @@ const CompactResults: FC<{
   queryStatusData?: QueryStatusData;
   reportDate: Date;
   startDate: string;
+  endDate: string;
   isLatestPhase: boolean;
   status: ExperimentStatus;
   goalMetrics: string[];
@@ -95,6 +96,7 @@ const CompactResults: FC<{
   queryStatusData,
   reportDate,
   startDate,
+  endDate,
   isLatestPhase,
   status,
   goalMetrics,
@@ -344,6 +346,7 @@ const CompactResults: FC<{
           dateCreated={reportDate}
           isLatestPhase={isLatestPhase}
           startDate={startDate}
+          endDate={endDate}
           status={status}
           queryStatusData={queryStatusData}
           variations={variations}
@@ -394,6 +397,7 @@ const CompactResults: FC<{
             dateCreated={reportDate}
             isLatestPhase={isLatestPhase}
             startDate={startDate}
+            endDate={endDate}
             status={status}
             queryStatusData={queryStatusData}
             variations={variations}
@@ -432,6 +436,7 @@ const CompactResults: FC<{
             dateCreated={reportDate}
             isLatestPhase={isLatestPhase}
             startDate={startDate}
+            endDate={endDate}
             status={status}
             queryStatusData={queryStatusData}
             variations={variations}

--- a/packages/front-end/components/Experiment/ExperimentMetricTimeSeriesGraphWrapper.tsx
+++ b/packages/front-end/components/Experiment/ExperimentMetricTimeSeriesGraphWrapper.tsx
@@ -1,3 +1,4 @@
+import { Flex } from "@radix-ui/themes";
 import { DifferenceType, StatsEngine } from "back-end/types/stats";
 import { ExperimentStatus } from "back-end/src/validators/experiments";
 import { MetricTimeSeries } from "back-end/src/validators/metric-time-series";
@@ -48,12 +49,25 @@ export default function ExperimentMetricTimeSeriesGraphWrapper({
     getFactTableById
   );
 
-  const { data } = useApi<{ timeSeries: MetricTimeSeries[] }>(
+  const { data, isLoading, error } = useApi<{ timeSeries: MetricTimeSeries[] }>(
     `/experiments/${experimentId}/time-series?phase=${phase}&metricIds[]=${metric.id}`
   );
 
-  if (!data || !data.timeSeries || data.timeSeries.length === 0) {
-    return null;
+  if (error) {
+    return (
+      <Message>
+        An error occurred while loading the time series data. Please try again
+        later.
+      </Message>
+    );
+  }
+
+  if (isLoading) {
+    return <Message>Loading...</Message>;
+  }
+
+  if (!data || data.timeSeries.length === 0) {
+    return <Message>No time series data available for this metric.</Message>;
   }
 
   // Ensure we always render at least 7 days in case we have less than 7 days worth of data
@@ -169,5 +183,20 @@ export default function ExperimentMetricTimeSeriesGraphWrapper({
       statsEngine={statsEngine}
       usesPValueAdjustment={pValueAdjustmentEnabled}
     />
+  );
+}
+
+function Message({ children }: { children: React.ReactNode }) {
+  return (
+    <Flex
+      align="center"
+      height="220px"
+      justify="center"
+      pb="1rem"
+      position="relative"
+      width="100%"
+    >
+      {children}
+    </Flex>
   );
 }

--- a/packages/front-end/components/Experiment/ExperimentTimeSeriesGraph.tsx
+++ b/packages/front-end/components/Experiment/ExperimentTimeSeriesGraph.tsx
@@ -141,7 +141,7 @@ const getTooltipContents = (
             const variationColor = getVariationColor(i, true);
             return (
               <TableRow
-                key={i}
+                key={`tooltip_row_${i}`}
                 style={{
                   color: "var(--color-text-high)",
                   fontWeight: 500,
@@ -570,7 +570,7 @@ const ExperimentTimeSeriesGraph: FC<ExperimentTimeSeriesGraphProps> = ({
                     // Render a dot at the current x location for each variation
                     return (
                       <div
-                        key={i}
+                        key={`tooltip_dot_open_${i}`}
                         className={styles.positionIndicator}
                         style={{
                           transform: `translate(${tooltipLeft}px, ${

--- a/packages/front-end/components/Experiment/Public/PublicExperimentResults.tsx
+++ b/packages/front-end/components/Experiment/Public/PublicExperimentResults.tsx
@@ -145,6 +145,7 @@ export default function PublicExperimentResults({
                 dimensionId={snapshot.dimension ?? ""}
                 isLatestPhase={phase === experiment.phases.length - 1}
                 startDate={phaseObj?.dateStarted ?? ""}
+                endDate={phaseObj?.dateEnded ?? ""}
                 reportDate={snapshot.dateCreated}
                 activationMetric={experiment.activationMetric}
                 status={experiment.status}
@@ -166,6 +167,7 @@ export default function PublicExperimentResults({
                 queryStatusData={queryStatusData}
                 reportDate={snapshot.dateCreated}
                 startDate={phaseObj?.dateStarted ?? ""}
+                endDate={phaseObj?.dateEnded ?? ""}
                 isLatestPhase={phase === experiment.phases.length - 1}
                 status={experiment.status}
                 goalMetrics={experiment.goalMetrics}

--- a/packages/front-end/components/Experiment/Results.tsx
+++ b/packages/front-end/components/Experiment/Results.tsx
@@ -340,6 +340,7 @@ const Results: FC<{
           dimensionId={snapshot.dimension ?? ""}
           isLatestPhase={phase === experiment.phases.length - 1}
           startDate={phaseObj?.dateStarted ?? ""}
+          endDate={phaseObj?.dateEnded ?? ""}
           reportDate={snapshot.dateCreated}
           activationMetric={experiment.activationMetric}
           status={experiment.status}
@@ -374,6 +375,7 @@ const Results: FC<{
             queryStatusData={queryStatusData}
             reportDate={snapshot.dateCreated}
             startDate={phaseObj?.dateStarted ?? ""}
+            endDate={phaseObj?.dateEnded ?? ""}
             isLatestPhase={phase === experiment.phases.length - 1}
             status={experiment.status}
             goalMetrics={experiment.goalMetrics}

--- a/packages/front-end/components/Experiment/ResultsTable.tsx
+++ b/packages/front-end/components/Experiment/ResultsTable.tsx
@@ -180,8 +180,6 @@ export default function ResultsTable({
     !disableTimeSeriesButton &&
     gb.isOn("experiment-results-timeseries");
 
-  console.log(endDate);
-
   // Disable time series button for stopped experiments before we added this feature (& therefore data)
   if (status === "stopped" && endDate <= "2025-04-03") {
     showTimeSeriesButton = false;

--- a/packages/front-end/components/Experiment/ResultsTable.tsx
+++ b/packages/front-end/components/Experiment/ResultsTable.tsx
@@ -72,6 +72,7 @@ export type ResultsTableProps = {
   queryStatusData?: QueryStatusData;
   isLatestPhase: boolean;
   startDate: string;
+  endDate: string;
   rows: ExperimentTableRow[];
   dimension?: string;
   tableRowAxis: "metric" | "dimension";
@@ -124,6 +125,7 @@ export default function ResultsTable({
   variationFilter,
   baselineRow = 0,
   startDate,
+  endDate,
   renderLabelColumn,
   dateCreated,
   hasRisk,
@@ -172,11 +174,18 @@ export default function ResultsTable({
   const [tableCellScale, setTableCellScale] = useState(1);
 
   const gb = useGrowthBook<AppFeatures>();
-  const showTimeSeriesButton =
+  let showTimeSeriesButton =
     baselineRow === 0 &&
     tableRowAxis === "metric" &&
     !disableTimeSeriesButton &&
     gb.isOn("experiment-results-timeseries");
+
+  console.log(endDate);
+
+  // Disable time series button for stopped experiments before we added this feature (& therefore data)
+  if (status === "stopped" && endDate <= "2025-04-03") {
+    showTimeSeriesButton = false;
+  }
 
   const [visibleTimeSeriesMetricIds, setVisibleTimeSeriesMetricIds] = useState<
     string[]

--- a/packages/front-end/components/Report/LegacyReportPage.tsx
+++ b/packages/front-end/components/Report/LegacyReportPage.tsx
@@ -509,6 +509,7 @@ export default function LegacyReportPage({
                     startDate={getValidDate(
                       report.args.startDate
                     ).toISOString()}
+                    endDate={getValidDate(report.args.endDate).toISOString()}
                     dimensionId={report.args.dimension}
                     activationMetric={report.args.activationMetric}
                     variations={variations}
@@ -575,6 +576,7 @@ export default function LegacyReportPage({
                       startDate={getValidDate(
                         report.args.startDate
                       ).toISOString()}
+                      endDate={getValidDate(report.args.endDate).toISOString()}
                       isLatestPhase={true}
                       status={"stopped"}
                       goalMetrics={report.args.goalMetrics}

--- a/packages/front-end/components/Report/ReportResults.tsx
+++ b/packages/front-end/components/Report/ReportResults.tsx
@@ -203,6 +203,7 @@ export default function ReportResults({
                 }
                 dimensionId={snapshot.dimension ?? ""}
                 startDate={getValidDate(phaseObj.dateStarted).toISOString()}
+                endDate={getValidDate(phaseObj.dateEnded).toISOString()}
                 isLatestPhase={phase === phases.length - 1}
                 reportDate={snapshot.dateCreated}
                 status={"stopped"}
@@ -230,6 +231,7 @@ export default function ReportResults({
                 queryStatusData={queryStatusData}
                 reportDate={snapshot.dateCreated}
                 startDate={getValidDate(phaseObj.dateStarted).toISOString()}
+                endDate={getValidDate(phaseObj.dateEnded).toISOString()}
                 isLatestPhase={phase === phases.length - 1}
                 status={"stopped"}
                 goalMetrics={report.experimentAnalysisSettings.goalMetrics}

--- a/packages/front-end/components/Share/Presentation.tsx
+++ b/packages/front-end/components/Share/Presentation.tsx
@@ -292,6 +292,7 @@ const Presentation = ({
               results={snapshot?.analyses[0]?.results?.[0]}
               reportDate={snapshot.dateCreated}
               startDate={phase?.dateStarted ?? ""}
+              endDate={phase?.dateEnded ?? ""}
               isLatestPhase={snapshot.phase === experiment.phases.length - 1}
               status={experiment.status}
               goalMetrics={experiment.goalMetrics}


### PR DESCRIPTION
### Features and Changes

- If the experiment has been stopped before Apr 4, we will not show the Time Series button for the metrics.
- Added messages to loading, error and no data states.

### Screenshots

<img width="1043" alt="Screenshot 2025-04-08 at 4 21 12 PM" src="https://github.com/user-attachments/assets/d9ad6f1a-3944-4b50-822f-9a45708ddbb5" />
<img width="1047" alt="Screenshot 2025-04-08 at 4 21 01 PM" src="https://github.com/user-attachments/assets/bce6ca57-c6ce-4c8b-93b0-644f4d9ba7f9" />
<img width="1041" alt="Screenshot 2025-04-08 at 4 21 23 PM" src="https://github.com/user-attachments/assets/98b01c10-cdc4-4fde-b37a-0969394ad162" />
