### PR TITLE
Disable time series button for reports

### DIFF
--- a/packages/front-end/components/Experiment/CompactResults.tsx
+++ b/packages/front-end/components/Experiment/CompactResults.tsx
@@ -86,6 +86,7 @@ const CompactResults: FC<{
   experimentType?: ExperimentType;
   ssrPolyfills?: SSRPolyfills;
   hideDetails?: boolean;
+  disableTimeSeriesButton?: boolean;
 }> = ({
   editMetrics,
   variations,
@@ -120,6 +121,7 @@ const CompactResults: FC<{
   experimentType,
   ssrPolyfills,
   hideDetails,
+  disableTimeSeriesButton,
 }) => {
   const { getExperimentMetricById, metricGroups, ready } = useDefinitions();
 
@@ -388,6 +390,7 @@ const CompactResults: FC<{
           isBandit={isBandit}
           isGoalMetrics={true}
           ssrPolyfills={ssrPolyfills}
+          disableTimeSeriesButton={disableTimeSeriesButton}
         />
       ) : null}
 
@@ -426,6 +429,7 @@ const CompactResults: FC<{
             noTooltip={noTooltip}
             isBandit={isBandit}
             ssrPolyfills={ssrPolyfills}
+            disableTimeSeriesButton={disableTimeSeriesButton}
           />
         </div>
       ) : null}
@@ -465,6 +469,7 @@ const CompactResults: FC<{
             noTooltip={noTooltip}
             isBandit={isBandit}
             ssrPolyfills={ssrPolyfills}
+            disableTimeSeriesButton={disableTimeSeriesButton}
           />
         </div>
       ) : (

--- a/packages/front-end/components/Report/LegacyReportPage.tsx
+++ b/packages/front-end/components/Report/LegacyReportPage.tsx
@@ -595,6 +595,7 @@ export default function LegacyReportPage({
                       sequentialTestingEnabled={sequentialTestingEnabled}
                       differenceType={differenceType}
                       isTabActive={true}
+                      disableTimeSeriesButton={true}
                     />
                   </div>
                 )}

--- a/packages/front-end/components/Report/ReportResults.tsx
+++ b/packages/front-end/components/Report/ReportResults.tsx
@@ -260,6 +260,7 @@ export default function ReportResults({
                 experimentType={report.experimentMetadata.type}
                 ssrPolyfills={ssrPolyfills}
                 hideDetails={!showDetails}
+                disableTimeSeriesButton={true}
               />
             ) : (
               <div className="mx-3 mb-3">


### PR DESCRIPTION
### Features and Changes

Disabling time series button for Reports as they don't pass in the experiment.id, instead they send the report.id -- we might be able to add it back by either handling reports differently or duplicating the data when reports are generated.

But at the moment it does not work as expected ([see error here](https://growthbook.sentry.io/issues/6532219443/?alert_rule_id=12426543&alert_type=issue&notification_uuid=abc847fe-523f-40b8-8154-cc080bbf37a6&project=4503942935216128&referrer=slack)).