### PR TITLE
Ji/get usage cache

### DIFF
--- a/packages/back-end/src/controllers/subscription.ts
+++ b/packages/back-end/src/controllers/subscription.ts
@@ -34,6 +34,7 @@ import {
   updateDefaultPaymentMethod,
   getPaymentMethodsByLicenseKey,
 } from "back-end/src/enterprise/billing/index";
+import { getUsage as getOrgUsage } from "back-end/src/enterprise/billing/index";
 
 function withLicenseServerErrorHandling<T>(
   fn: (req: AuthRequest<T>, res: Response) => Promise<void>
@@ -426,7 +427,7 @@ export async function getUsage(
 
   const {
     limits: { requests: cdnRequests, bandwidth: cdnBandwidth },
-  } = await context.usage();
+  } = await getOrgUsage(org, true);
 
   res.json({ status: 200, cdnUsage, limits: { cdnRequests, cdnBandwidth } });
 }

--- a/packages/back-end/src/controllers/subscription.ts
+++ b/packages/back-end/src/controllers/subscription.ts
@@ -33,8 +33,8 @@ import {
   deletePaymentMethodById,
   updateDefaultPaymentMethod,
   getPaymentMethodsByLicenseKey,
+  getUsage as getOrgUsage,
 } from "back-end/src/enterprise/billing/index";
-import { getUsage as getOrgUsage } from "back-end/src/enterprise/billing/index";
 
 function withLicenseServerErrorHandling<T>(
   fn: (req: AuthRequest<T>, res: Response) => Promise<void>

--- a/packages/back-end/src/enterprise/billing/index.ts
+++ b/packages/back-end/src/enterprise/billing/index.ts
@@ -82,19 +82,13 @@ export async function deletePaymentMethodById(
   return res;
 }
 
-export async function updateUsageDataFromServer(organization: string) {
+export async function updateUsageDataFromServer(orgId: string) {
   try {
-    const url = `${LICENSE_SERVER_URL}cdn/${organization}/usage`;
+    const url = `${LICENSE_SERVER_URL}cdn/${orgId}/usage`;
 
     const usage = await callLicenseServer({ url, method: "GET" });
 
-    keyToUsageData[organization] = {
-      timestamp: new Date(),
-      usage: {
-        ...usage,
-        cdn: { ...usage.cdn, lastUpdated: new Date(usage.cdn.lastUpdated) },
-      },
-    };
+    setUsageInCache(orgId, usage);
   } catch (err) {
     Sentry.captureException(err);
   }
@@ -107,18 +101,30 @@ type StoredUsage = {
 
 const keyToUsageData: Record<string, StoredUsage> = {};
 
-export function getUsageFromCache(organization: OrganizationInterface) {
-  if (keyToUsageData[organization.id]?.usage) {
-    return keyToUsageData[organization.id].usage;
-  }
-  // Update the usage data in the background
-  updateUsageDataFromServer(organization.id).catch((err) => {
-    logger.error(`Error getting usage data from server`, err);
+export const setUsageInCache = (orgId: string, usage: OrganizationUsage) => {
+  keyToUsageData[orgId] = {
+    timestamp: new Date(),
+    usage: {
+      ...usage,
+      cdn: { ...usage.cdn, lastUpdated: new Date(usage.cdn.lastUpdated) },
+    },
+  };
+};
+
+export const resetUsageCache = () => {
+  Object.keys(keyToUsageData).forEach((key) => {
+    delete keyToUsageData[key];
   });
-  return UNLIMITED_USAGE;
+};
+
+export function getUsageFromCache(organization: OrganizationInterface) {
+  return getUsage(organization, false);
 }
 
-export async function getUsage(organization: OrganizationInterface) {
+export async function getUsage(
+  organization: OrganizationInterface,
+  wait: boolean = true
+) {
   if (!IS_CLOUD) {
     return UNLIMITED_USAGE;
   }
@@ -129,21 +135,22 @@ export async function getUsage(organization: OrganizationInterface) {
   const cacheCutOff = new Date();
   cacheCutOff.setHours(cacheCutOff.getHours() - 1);
 
-  if (keyToUsageData[organization.id]?.timestamp <= cacheCutOff) {
-    // Don't await for the result, we will just keep showing out of date cached version
+  if (!keyToUsageData[organization.id] && wait) {
+    await updateUsageDataFromServer(organization.id);
+  } else if (
+    !keyToUsageData[organization.id] ||
+    keyToUsageData[organization.id]?.timestamp <= cacheCutOff
+  ) {
+    // Don't await for the result, we will just keep showing out of date cached version or the fallback
     updateUsageDataFromServer(organization.id).catch((err) => {
       logger.error(`Error getting usage data from server`, err);
     });
-  }
-
-  if (!keyToUsageData[organization.id]) {
-    await updateUsageDataFromServer(organization.id);
   }
 
   if (keyToUsageData[organization.id]) {
     return keyToUsageData[organization.id].usage;
   }
 
-  // If the updateUsageDataFromServer failed to set the cache we return the unlimited usage
+  // If the updateUsageDataFromServer failed or if `wait` was `false` we fall back to unlimited usage
   return UNLIMITED_USAGE;
 }

--- a/packages/back-end/src/enterprise/billing/index.ts
+++ b/packages/back-end/src/enterprise/billing/index.ts
@@ -120,7 +120,14 @@ export const resetUsageCache = () => {
 };
 
 export function getUsageFromCache(organization: OrganizationInterface) {
-  return getUsage(organization, false);
+  if (keyToUsageData[organization.id]) {
+    return keyToUsageData[organization.id].usage;
+  } else {
+    getUsage(organization, false).catch((err) => {
+      logger.error(`Error getting usage data from server`, err);
+    });
+    return UNLIMITED_USAGE;
+  }
 }
 
 export async function getUsage(

--- a/packages/back-end/src/enterprise/billing/index.ts
+++ b/packages/back-end/src/enterprise/billing/index.ts
@@ -94,6 +94,8 @@ export async function updateUsageDataFromServer(orgId: string) {
   }
 }
 
+export let backgroundUpdateUsageDataFromServerForTests: Promise<void>;
+
 type StoredUsage = {
   timestamp: Date;
   usage: OrganizationUsage;
@@ -142,7 +144,9 @@ export async function getUsage(
     keyToUsageData[organization.id]?.timestamp <= cacheCutOff
   ) {
     // Don't await for the result, we will just keep showing out of date cached version or the fallback
-    updateUsageDataFromServer(organization.id).catch((err) => {
+    backgroundUpdateUsageDataFromServerForTests = updateUsageDataFromServer(
+      organization.id
+    ).catch((err) => {
       logger.error(`Error getting usage data from server`, err);
     });
   }

--- a/packages/back-end/src/middleware/authenticateApiRequestMiddleware.ts
+++ b/packages/back-end/src/middleware/authenticateApiRequestMiddleware.ts
@@ -21,7 +21,6 @@ import {
   getUserCodesForOrg,
 } from "back-end/src/services/licenseData";
 import { ReqContextClass } from "back-end/src/services/context";
-import { getUsage } from "back-end/src/enterprise/billing";
 
 export default function authenticateApiRequestMiddleware(
   req: Request & ApiRequestLocals,
@@ -124,7 +123,6 @@ export default function authenticateApiRequestMiddleware(
 
       req.context = new ReqContextClass({
         org,
-        usage: () => getUsage(org),
         auditUser: eventAudit,
         teams,
         user: req.user,

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -142,6 +142,7 @@ import {
   getLicenseError,
   getSubscriptionFromLicense,
 } from "back-end/src/enterprise";
+import { getUsageFromCache } from "back-end/src/enterprise/billing";
 
 export async function getDefinitions(req: AuthRequest, res: Response) {
   const context = getContextFromReq(req);
@@ -795,7 +796,7 @@ export async function getOrganization(
       dateCreated: org.dateCreated,
     },
     seatsInUse,
-    usage: await context.usage(),
+    usage: getUsageFromCache(org),
   });
 }
 

--- a/packages/back-end/src/services/context.ts
+++ b/packages/back-end/src/services/context.ts
@@ -9,7 +9,6 @@ import { CustomFieldModel } from "back-end/src/models/CustomFieldModel";
 import { MetricAnalysisModel } from "back-end/src/models/MetricAnalysisModel";
 import {
   OrganizationInterface,
-  OrganizationUsage,
   Permission,
   UserPermissions,
 } from "back-end/types/organization";
@@ -78,7 +77,6 @@ export class ReqContextClass {
   }
 
   public org: OrganizationInterface;
-  public usage: OrganizationUsage;
   public userId = "";
   public email = "";
   public userName = "";

--- a/packages/back-end/src/services/context.ts
+++ b/packages/back-end/src/services/context.ts
@@ -78,7 +78,7 @@ export class ReqContextClass {
   }
 
   public org: OrganizationInterface;
-  public usage: () => Promise<OrganizationUsage>;
+  public usage: OrganizationUsage;
   public userId = "";
   public email = "";
   public userName = "";
@@ -106,7 +106,6 @@ export class ReqContextClass {
     req,
   }: {
     org: OrganizationInterface;
-    usage: () => Promise<OrganizationUsage>;
     user?: {
       id: string;
       email: string;

--- a/packages/back-end/src/services/context.ts
+++ b/packages/back-end/src/services/context.ts
@@ -118,7 +118,6 @@ export class ReqContextClass {
     req?: Request;
   }) {
     this.org = org;
-    this.usage = usage;
     this.auditUser = auditUser;
     this.teams = teams || [];
 

--- a/packages/back-end/src/services/context.ts
+++ b/packages/back-end/src/services/context.ts
@@ -97,7 +97,6 @@ export class ReqContextClass {
 
   public constructor({
     org,
-    usage,
     auditUser,
     teams,
     user,

--- a/packages/back-end/src/services/organizations.ts
+++ b/packages/back-end/src/services/organizations.ts
@@ -20,7 +20,6 @@ import {
   DEFAULT_PROPER_PRIOR_STDDEV,
   DEFAULT_TARGET_MDE,
 } from "shared/constants";
-import { getUsage } from "back-end/src/enterprise/billing";
 import {
   MetricCappingSettings,
   MetricPriorSettings,
@@ -135,11 +134,8 @@ export function getContextFromReq(req: AuthRequest): ReqContext {
     throw new Error("Must be logged in");
   }
 
-  const { organization } = req;
-
   return new ReqContextClass({
     org: req.organization,
-    usage: () => getUsage(organization),
     auditUser: {
       type: "dashboard",
       id: req.userId,
@@ -1121,7 +1117,6 @@ export function getContextForAgendaJobByOrgObject(
 ): ApiReqContext {
   return new ReqContextClass({
     org: organization,
-    usage: () => getUsage(organization),
     auditUser: null,
     // TODO: Limit background job permissions to the user who created the job
     role: "admin",

--- a/packages/back-end/test/billing.test.ts
+++ b/packages/back-end/test/billing.test.ts
@@ -1,0 +1,225 @@
+import fetch, { Response } from "node-fetch";
+import * as Sentry from "@sentry/node";
+import {
+  backgroundUpdateUsageDataFromServerForTests,
+  getUsage,
+  getUsageFromCache,
+  resetUsageCache,
+  UNLIMITED_USAGE,
+} from "back-end/src/enterprise/billing";
+import * as licenseUtil from "back-end/src/enterprise/licenseUtil";
+import { OrganizationInterface } from "back-end/types/organization";
+
+jest.mock("@sentry/node", () => ({
+  ...jest.requireActual("@sentry/node"),
+  captureException: jest.fn(),
+}));
+
+jest.mock("back-end/src/enterprise/licenseUtil", () => ({
+  ...jest.requireActual("back-end/src/enterprise/licenseUtil"),
+  getEffectiveAccountPlan: jest.fn(),
+}));
+
+jest.mock("back-end/src/util/logger", () => ({
+  logger: {
+    error: jest.fn(),
+  },
+}));
+
+let isCloud = false;
+
+jest.mock("back-end/src/util/secrets", () => ({
+  ...jest.requireActual("back-end/src/util/secrets"),
+  get IS_CLOUD() {
+    return isCloud; // Use a getter to dynamically return the value of isCloud
+  },
+}));
+jest.mock("node-fetch");
+
+const mockedFetch = fetch as jest.MockedFunction<typeof fetch>;
+
+const mockOrganization: OrganizationInterface = {
+  id: "org_123",
+  name: "Test Organization",
+  dateCreated: new Date(),
+  members: [],
+  invites: [],
+  url: "",
+  ownerEmail: "",
+};
+
+describe("getUsage", () => {
+  const env = process.env;
+  const now = new Date("2023-11-21T12:08:12.610Z");
+  const twoHoursFromNow = new Date("2023-11-21T14:08:12.610Z");
+
+  beforeEach(() => {
+    resetUsageCache();
+    jest.clearAllMocks();
+    jest.useFakeTimers("modern");
+    jest.setSystemTime(now);
+    process.env = { ...env };
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    mockedFetch.mockReset();
+    process.env = env;
+  });
+
+  describe("IS_CLOUD = false", () => {
+    beforeEach(() => {
+      isCloud = false;
+    });
+
+    it("should return UNLIMITED_USAGE if not in cloud mode", async () => {
+      const usage = await getUsage(mockOrganization);
+
+      expect(usage).toEqual(UNLIMITED_USAGE);
+      expect(mockedFetch).toHaveBeenCalledTimes(0);
+    });
+
+    it("should return UNLIMITED_USAGE getUsageFromCache", async () => {
+      const mockResponse = {
+        limits: { requests: "1000", bandwidth: "10GB" },
+        cdn: { lastUpdated: new Date(), status: "under" },
+      };
+      mockedFetch.mockResolvedValueOnce(({
+        ok: true,
+        json: jest.fn().mockResolvedValueOnce(mockResponse),
+      } as unknown) as Response);
+
+      const usage = await getUsageFromCache(mockOrganization);
+      expect(usage).toEqual(UNLIMITED_USAGE);
+
+      await backgroundUpdateUsageDataFromServerForTests;
+      expect(mockedFetch).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe("IS_CLOUD = true", () => {
+    beforeEach(() => {
+      isCloud = true;
+    });
+
+    describe("pro plan", () => {
+      beforeEach(() => {
+        (licenseUtil.getEffectiveAccountPlan as jest.Mock).mockReturnValue(
+          "pro"
+        );
+      });
+
+      it("should return UNLIMITED_USAGE for plans with unlimited usage", async () => {
+        const usage = await getUsage(mockOrganization);
+
+        expect(usage).toEqual(UNLIMITED_USAGE);
+        expect(mockedFetch).toHaveBeenCalledTimes(0);
+      });
+    });
+
+    describe("starter plan", () => {
+      beforeEach(() => {
+        (licenseUtil.getEffectiveAccountPlan as jest.Mock).mockReturnValue(
+          "starter"
+        );
+      });
+
+      it("should return UNLIMITED_USAGE if no usage data is available and license server errors", async () => {
+        mockedFetch.mockRejectedValueOnce(new Error("Network error"));
+
+        const usage = await getUsage(mockOrganization);
+
+        expect(usage).toEqual(UNLIMITED_USAGE);
+        expect(Sentry.captureException).toHaveBeenCalled();
+        expect(mockedFetch).toHaveBeenCalledTimes(1);
+      });
+
+      it("should fetch usage data from the server if cache is empty and wait is true", async () => {
+        const mockResponse = {
+          limits: { requests: "1000", bandwidth: "10GB" },
+          cdn: { lastUpdated: new Date(), status: "under" },
+        };
+        mockedFetch.mockResolvedValueOnce(({
+          ok: true,
+          json: jest.fn().mockResolvedValueOnce(mockResponse),
+        } as unknown) as Response);
+
+        const usage = await getUsage(mockOrganization);
+        expect(usage).toEqual(mockResponse);
+        expect(mockedFetch).toHaveBeenCalledTimes(1);
+      });
+
+      it("should return cached usage data if available and not expired", async () => {
+        const mockResponse = {
+          limits: { requests: "1000", bandwidth: "10GB" },
+          cdn: { lastUpdated: new Date(), status: "under" },
+        };
+        mockedFetch.mockResolvedValueOnce(({
+          ok: true,
+          json: jest.fn().mockResolvedValueOnce(mockResponse),
+        } as unknown) as Response);
+
+        const usage = await getUsage(mockOrganization);
+        const usage2 = await getUsage(mockOrganization);
+
+        expect(mockedFetch).toHaveBeenCalledTimes(1);
+        expect(usage).toEqual(mockResponse);
+        expect(usage2).toEqual(mockResponse);
+      });
+
+      it("should return cached usage data if available and expired, and refetch in the background", async () => {
+        const mockResponse = {
+          limits: { requests: "1000", bandwidth: "10GB" },
+          cdn: { lastUpdated: new Date(), status: "under" },
+        };
+        const mockResponse2 = {
+          limits: { requests: "2000", bandwidth: "20GB" },
+          cdn: { lastUpdated: new Date(), status: "over" },
+        };
+        mockedFetch.mockResolvedValueOnce(({
+          ok: true,
+          json: jest.fn().mockResolvedValueOnce(mockResponse),
+        } as unknown) as Response);
+        mockedFetch.mockResolvedValueOnce(({
+          ok: true,
+          json: jest.fn().mockResolvedValueOnce(mockResponse2),
+        } as unknown) as Response);
+
+        const usage = await getUsage(mockOrganization);
+        expect(usage).toEqual(mockResponse);
+
+        jest.setSystemTime(twoHoursFromNow);
+        const usage2 = await getUsage(mockOrganization);
+        expect(usage2).toEqual(mockResponse);
+
+        // Once the background job is done
+        await backgroundUpdateUsageDataFromServerForTests;
+        expect(mockedFetch).toHaveBeenCalledTimes(2);
+
+        // Following calls should return the new data
+        const usage3 = await getUsage(mockOrganization);
+        expect(usage3).toEqual(mockResponse2);
+      });
+
+      it("should not wait for the server response if getUsageFromCache is called, but subsequent request should have it", async () => {
+        const mockResponse = {
+          limits: { requests: "1000", bandwidth: "10GB" },
+          cdn: { lastUpdated: new Date(), status: "under" },
+        };
+        mockedFetch.mockResolvedValueOnce(({
+          ok: true,
+          json: jest.fn().mockResolvedValueOnce(mockResponse),
+        } as unknown) as Response);
+
+        const usage = await getUsageFromCache(mockOrganization);
+        expect(usage).toEqual(UNLIMITED_USAGE);
+
+        await backgroundUpdateUsageDataFromServerForTests;
+        expect(mockedFetch).toHaveBeenCalledTimes(1);
+
+        const usage2 = await getUsageFromCache(mockOrganization);
+        expect(usage2).toEqual(mockResponse);
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Features and Changes
On some endpoints like the getUsage() endpoint we will definitely want the actual usage data and are willing to wait for it.  On other endpoints like the getOrganization endpoint, and getFeature endpoint get called often we will not want to be dependent upon the license server as new deploys might kick off a torrent of requests to the license server and could slow the license server down.  In those cases it is ok to have it be unlimited usage if it is not in the cache.

1. Removes the usage from the request context as sometime we will want to wait for it and sometimes not.  Since the organization is in the request we can call the `getUsage` function when we want to wait and the `getUsageFromCache` function when we don't want to wait.
2. If the cache has expired we will now keep using the old value but update the cache in the background.

### Testing

In env vars set it to use the dev license server
Set the usage for the organization in the usage.organization_usage to over:
```
{
  "_id": {
    "$oid": "67d80ec029c16b8a82b52554"
  },
  "organization": "org_4posg1kwim7kjjcrr",
  "usage": {
    "limits": {
      "requests": 10000000,
      "bandwidth": "unlimited"
    },
    "cdn": {
      "lastUpdated": {
        "$date": "2025-03-17T12:00:00.687Z"
      },
      "status": "approaching"
    }
  }
}
```
Restart the dev server
Don't see the over limit message.
Click out of the window and then in it again (this will make the front end code call /organization endpoint again)
See the over the limit message.

Run `yarn test`