### PR TITLE
Limit number of revisions returned in feature API endpoint

### DIFF
--- a/packages/back-end/src/models/FeatureRevisionModel.ts
+++ b/packages/back-end/src/models/FeatureRevisionModel.ts
@@ -128,17 +128,21 @@ export async function getFeatureRevisionsByStatus({
   organization,
   featureId,
   status,
+  limit = 10,
 }: {
   context: ReqContext;
   organization: string;
   featureId: string;
   status?: string;
+  limit?: number;
 }): Promise<FeatureRevisionInterface[]> {
   const docs = await FeatureRevisionModel.find({
     organization,
     featureId,
     ...(status ? { status } : {}),
-  });
+  })
+    .sort({ version: -1 })
+    .limit(limit);
   return docs.map((m) => toInterface(m, context));
 }
 

--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -20,6 +20,7 @@ import {
   getSavedGroupsValuesFromInterfaces,
   NodeHandler,
   recursiveWalk,
+  filterEnvironmentsByFeature,
 } from "shared/util";
 import {
   scrubExperiments,
@@ -103,6 +104,7 @@ import { getRevision } from "back-end/src/models/FeatureRevisionModel";
 import {
   getContextForAgendaJobByOrgObject,
   getEnvironmentIdsFromOrg,
+  getEnvironments,
 } from "./organizations";
 
 export type AttributeMap = Map<string, string>;
@@ -1216,7 +1218,13 @@ export function getApiFeatureObj({
 }): ApiFeatureWithRevisions {
   const defaultValue = feature.defaultValue;
   const featureEnvironments: Record<string, ApiFeatureEnvironment> = {};
-  const environments = getEnvironmentIdsFromOrg(organization);
+
+  // Only get environments that are relevant for this feature (based on the feature's project)
+  const environments = filterEnvironmentsByFeature(
+    getEnvironments(organization),
+    feature
+  ).map((e) => e.id);
+
   environments.forEach((env) => {
     const envSettings = feature.environmentSettings?.[env];
     const enabled = !!envSettings?.enabled;

--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -20,7 +20,6 @@ import {
   getSavedGroupsValuesFromInterfaces,
   NodeHandler,
   recursiveWalk,
-  filterEnvironmentsByFeature,
 } from "shared/util";
 import {
   scrubExperiments,
@@ -104,7 +103,6 @@ import { getRevision } from "back-end/src/models/FeatureRevisionModel";
 import {
   getContextForAgendaJobByOrgObject,
   getEnvironmentIdsFromOrg,
-  getEnvironments,
 } from "./organizations";
 
 export type AttributeMap = Map<string, string>;
@@ -1218,13 +1216,7 @@ export function getApiFeatureObj({
 }): ApiFeatureWithRevisions {
   const defaultValue = feature.defaultValue;
   const featureEnvironments: Record<string, ApiFeatureEnvironment> = {};
-
-  // Only get environments that are relevant for this feature (based on the feature's project)
-  const environments = filterEnvironmentsByFeature(
-    getEnvironments(organization),
-    feature
-  ).map((e) => e.id);
-
+  const environments = getEnvironmentIdsFromOrg(organization);
   environments.forEach((env) => {
     const envSettings = feature.environmentSettings?.[env];
     const enabled = !!envSettings?.enabled;


### PR DESCRIPTION
When getting a feature definition from the REST api with the `withRevisions` flag, no limit was being applied.  Some features have thousands of revisions and this endpoint was causing performance issues.

This PR limits this endpoint to only return the most recent 10 revisions that match the query.