### PR TITLE
fix(public-reports): Ensure GrowthbookProvider exists to fix 500 errors

### DIFF
--- a/packages/front-end/components/Experiment/ResultsTable.tsx
+++ b/packages/front-end/components/Experiment/ResultsTable.tsx
@@ -29,6 +29,7 @@ import { getValidDate } from "shared/dates";
 import { FaExclamationTriangle } from "react-icons/fa";
 import { Flex } from "@radix-ui/themes";
 import { ExperimentMetricInterface, isFactMetric } from "shared/experiments";
+import { useAuth } from "@/services/auth";
 import {
   ExperimentTableRow,
   getEffectLabel,
@@ -174,7 +175,9 @@ export default function ResultsTable({
   const [tableCellScale, setTableCellScale] = useState(1);
 
   const gb = useGrowthBook<AppFeatures>();
+  const { isAuthenticated } = useAuth();
   let showTimeSeriesButton =
+    isAuthenticated &&
     baselineRow === 0 &&
     tableRowAxis === "metric" &&
     !disableTimeSeriesButton &&

--- a/packages/front-end/pages/_app.tsx
+++ b/packages/front-end/pages/_app.tsx
@@ -134,24 +134,22 @@ function App({
 
     return (
       <AuthProvider exitOnNoAuth={!(preAuth || progressiveAuth)}>
-        <GrowthBookProvider growthbook={growthbook}>
-          <UserContextProvider key={orgId}>
-            <DefinitionsProvider>
-              <PageHeadProvider>
-                {preAuthTopNav || progressiveAuthTopNav ? (
-                  <>
-                    <TopNavLite />
-                    <main className={`main lite ${parts[0]}`}>
-                      <Component {...{ ...pageProps, envReady: ready }} />
-                    </main>
-                  </>
-                ) : (
-                  <Component {...{ ...pageProps, envReady: ready }} />
-                )}
-              </PageHeadProvider>
-            </DefinitionsProvider>
-          </UserContextProvider>
-        </GrowthBookProvider>
+        <UserContextProvider key={orgId}>
+          <DefinitionsProvider>
+            <PageHeadProvider>
+              {preAuthTopNav || progressiveAuthTopNav ? (
+                <>
+                  <TopNavLite />
+                  <main className={`main lite ${parts[0]}`}>
+                    <Component {...{ ...pageProps, envReady: ready }} />
+                  </main>
+                </>
+              ) : (
+                <Component {...{ ...pageProps, envReady: ready }} />
+              )}
+            </PageHeadProvider>
+          </DefinitionsProvider>
+        </UserContextProvider>
       </AuthProvider>
     );
   };

--- a/packages/front-end/pages/_app.tsx
+++ b/packages/front-end/pages/_app.tsx
@@ -178,13 +178,13 @@ function App({
       {ready || noLoadingOverlay ? (
         <AppearanceUIThemeProvider>
           <RadixTheme>
-            <div id="portal-root" />
-            {preAuth || progressiveAuth ? (
-              renderPreAuth()
-            ) : (
-              <PageHeadProvider>
-                <AuthProvider>
-                  <GrowthBookProvider growthbook={growthbook}>
+            <GrowthBookProvider growthbook={growthbook}>
+              <div id="portal-root" />
+              {preAuth || progressiveAuth ? (
+                renderPreAuth()
+              ) : (
+                <PageHeadProvider>
+                  <AuthProvider>
                     <ProtectedPage organizationRequired={organizationRequired}>
                       {organizationRequired ? (
                         <GetStartedProvider>
@@ -211,10 +211,10 @@ function App({
                         </div>
                       )}
                     </ProtectedPage>
-                  </GrowthBookProvider>
-                </AuthProvider>
-              </PageHeadProvider>
-            )}
+                  </AuthProvider>
+                </PageHeadProvider>
+              )}
+            </GrowthBookProvider>
           </RadixTheme>
         </AppearanceUIThemeProvider>
       ) : error ? (


### PR DESCRIPTION
### Features and Changes

For TimeSeries we added a check behind a feature flag and it broke the public experiment page because GrowthbookProvider was not set in that context.

So to fix it we moved it up in the tree.

Additionally, the API for TimeSeries requires the user to be authenticated (at the moment), so we are adding one additional check for now (disabling timeseries from public pages if the user is not logged in) while we work on a proper fix.