### PR TITLE
Fix redirect checkbox state for nodejs sdk connections

### DIFF
--- a/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
+++ b/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
@@ -269,10 +269,16 @@ export default function SDKConnectionForm({
       form.setValue("includeVisualExperiments", showVisualEditorSettings);
       form.setValue("includeDraftExperiments", showVisualEditorSettings);
       form.setValue("includeRedirectExperiments", showRedirectSettings);
-    } else if (!showVisualEditorSettings) {
-      form.setValue("includeVisualExperiments", false);
-      form.setValue("includeDraftExperiments", false);
-      form.setValue("includeRedirectExperiments", false);
+    } else {
+      if (!showVisualEditorSettings) {
+        form.setValue("includeVisualExperiments", false);
+      }
+      if (!showRedirectSettings) {
+        form.setValue("includeRedirectExperiments", false);
+      }
+      if (!showVisualEditorSettings && !showRedirectSettings) {
+        form.setValue("includeDraftExperiments", false);
+      }
     }
   }, [showVisualEditorSettings, form, edit, showRedirectSettings]);
 


### PR DESCRIPTION
We were forcing redirects to be turned off whenever the sdk did not support the visual editor. This is not correct logic for environments like nodejs that do support redirects without the VE.