### PR TITLE
Adds archetype in-app promo to feature flag page

### DIFF
--- a/packages/front-end/components/Features/FeaturesOverview.tsx
+++ b/packages/front-end/components/Features/FeaturesOverview.tsx
@@ -27,6 +27,7 @@ import {
 import { FeatureUsageLookback } from "back-end/src/types/Integration";
 import { Box, Flex, Heading, Switch, Text } from "@radix-ui/themes";
 import { RxListBullet } from "react-icons/rx";
+import { ArchetypeInterface } from "back-end/types/archetype";
 import Button from "@/components/Radix/Button";
 import { GBAddCircle, GBEdit } from "@/components/Icons";
 import LoadingOverlay from "@/components/LoadingOverlay";
@@ -72,6 +73,8 @@ import Badge from "@/components/Radix/Badge";
 import Frame from "@/components/Radix/Frame";
 import LoadingSpinner from "@/components/LoadingSpinner";
 import JSONValidation from "@/components/Features/JSONValidation";
+import useApi from "@/hooks/useApi";
+import PremiumCallout from "../Radix/PremiumCallout";
 import PrerequisiteStatusRow, {
   PrerequisiteStatesCols,
 } from "./PrerequisiteStatusRow";
@@ -112,6 +115,12 @@ export default function FeaturesOverview({
 }) {
   const router = useRouter();
   const { fid } = router.query;
+
+  const { data } = useApi<{
+    archetype: ArchetypeInterface[];
+  }>("/archetype");
+
+  const archetypes = data?.archetype || [];
 
   const settings = useOrgSettings();
   const [edit, setEdit] = useState(false);
@@ -1073,6 +1082,18 @@ export default function FeaturesOverview({
                         Default Value.
                       </p>
                     )}
+                    {!archetypes.length ? (
+                      <PremiumCallout
+                        commercialFeature="archetypes"
+                        dismissable={true}
+                        id="feature-archetypes-promo"
+                        mb="4"
+                        docSection="archetypes"
+                      >
+                        Use Archetypes to save sets of user attributes and
+                        simulate the feature flag value assigned.
+                      </PremiumCallout>
+                    ) : null}
 
                     <FeatureRules
                       environments={environments}


### PR DESCRIPTION
### Features and Changes

This PR introduces an in-app promo via the `PremiumCallout` for Archetypes within the [fid].tsx page.

In the event an organization does not have any archetypes, we'll render the promo callout. This is a dismiss-able callout. If the org has access to the feature (e.g they're pro or enterprise) it'll like out to the docs. Otherwise, it'll prompt the org to upgrade.



### Dependencies

N/A

### Testing

- [x] Ensure that the correct CTA/icon is used depending on whether or not the org has access to archetypes
- [x] Ensure that the styling looks correct for both light and dark modes
- [x] Ensure that the callout isn't rendered if the org has previously created at least 1 archetype.
- [x] Ensure that when a callout is dismissed, it remains dismissed for the duration of the browser session

### Screenshots
`Starter` Org Experience
![Screenshot 2025-04-21 at 10 30 49 AM](https://github.com/user-attachments/assets/b67f82c9-02a2-42af-ba35-8818111afc43)
![Screenshot 2025-04-21 at 10 30 58 AM](https://github.com/user-attachments/assets/dbf348b6-fbf7-4efb-bb7b-290273081610)

`Pro` & `Enterprise` Org Experience
![Screenshot 2025-04-21 at 10 33 30 AM](https://github.com/user-attachments/assets/fcba8711-47a8-4b8f-9753-239337117c6e)
![Screenshot 2025-04-21 at 10 33 38 AM](https://github.com/user-attachments/assets/643186f4-bdf1-4e07-9980-46859a665549)


