### PR TITLE
Ignore cache for recently upgrade to pro accounts

### DIFF
--- a/packages/back-end/src/enterprise/billing/index.ts
+++ b/packages/back-end/src/enterprise/billing/index.ts
@@ -120,6 +120,13 @@ export const resetUsageCache = () => {
 };
 
 export function getUsageFromCache(organization: OrganizationInterface) {
+  if (!IS_CLOUD) {
+    return UNLIMITED_USAGE;
+  }
+  const plan = getEffectiveAccountPlan(organization);
+
+  if (PLANS_WITH_UNLIMITED_USAGE.includes(plan)) return UNLIMITED_USAGE;
+
   if (keyToUsageData[organization.id]) {
     return keyToUsageData[organization.id].usage;
   } else {


### PR DESCRIPTION
### Features and Changes

During testing, I realized that working with a free org that has usage set to `over` when they upgrade to pro, we will still be getting the value from the cache rather than unlimited.  This PR fixes that.

### Testing

Remove any licenseKey from the main org in mongo that you log in to.
Set a usage object in `usage.organization_usages` along the lines of:
```
{
  "_id": {
    "$oid": "67d80ec029c16b8a82b52554"
  },
  "organization": "YOUR_ORG_ID",
  "usage": {
    "limits": {
      "requests": 10000000,
      "bandwidth": "unlimited"
    },
    "cdn": {
      "lastUpdated": {
        "$date": "2025-03-17T12:00:00.687Z"
      },
      "status": "over"
    }
  }
}
```
Replacing YOUR_ORG_ID.  See the over the limit message.  Upgrade to pro.  See the message disappear and only see the pro tag.