### PR TITLE
Accounts with disableSelfServeBilling should have UNLIMITED cdn usage

### DIFF
--- a/packages/back-end/src/enterprise/billing/index.ts
+++ b/packages/back-end/src/enterprise/billing/index.ts
@@ -125,6 +125,14 @@ function getCachedUsageIfValid(
   if (!IS_CLOUD) {
     return UNLIMITED_USAGE;
   }
+
+  // An old manual flag that gives orgs the starter plan, but with unlimited members
+  // and blocks them from upgrading to a paid plan. For now we will just give them
+  // unlimited cdn usage
+  if (organization.disableSelfServeBilling) {
+    return UNLIMITED_USAGE;
+  }
+
   const plan = getEffectiveAccountPlan(organization);
 
   if (PLANS_WITH_UNLIMITED_USAGE.includes(plan)) return UNLIMITED_USAGE;

--- a/packages/back-end/test/billing.test.ts
+++ b/packages/back-end/test/billing.test.ts
@@ -135,6 +135,15 @@ describe("getUsage", () => {
         );
       });
 
+      it("should return UNLIMITED_USAGE if disableSelfServeBilling is true", async () => {
+        const mockOrganization2 = { ...mockOrganization };
+        mockOrganization2.disableSelfServeBilling = true;
+        const usage = await getUsage(mockOrganization2);
+
+        expect(usage).toEqual(UNLIMITED_USAGE);
+        expect(mockedFetch).toHaveBeenCalledTimes(0);
+      });
+
       it("should return UNLIMITED_USAGE if no usage data is available and license server errors", async () => {
         mockedFetch.mockRejectedValueOnce(new Error("Network error"));
 


### PR DESCRIPTION
### Features and Changes

`organization.disableSelfServeBilling is an old manual flag that gives orgs the starter plan, but with unlimited members
 and blocks them from upgrading to a paid plan. For now we will just give them unlimited cdn usage

### Testing

yarn test

Remove any licenseKey from the main org in mongo that you log in to.
Set a usage object in usage.organization_usages along the lines of:
```
{
  "_id": {
    "$oid": "67d80ec029c16b8a82b52554"
  },
  "organization": "YOUR_ORG_ID",
  "usage": {
    "limits": {
      "requests": 10000000,
      "bandwidth": "unlimited"
    },
    "cdn": {
      "lastUpdated": {
        "$date": "2025-03-17T12:00:00.687Z"
      },
      "status": "over"
    }
  }
}
```
See the usage notification.
Set disableSelfServeBilling on the org.
Reboot the server to clear the cache
See no usage notification.
