### PR TITLE
[safe rollouts] Enable adding events to webhook

### DIFF
--- a/packages/front-end/components/EventWebHooks/utils.tsx
+++ b/packages/front-end/components/EventWebHooks/utils.tsx
@@ -43,6 +43,10 @@ export const notificationEventNames = [
   "feature.created",
   "feature.updated",
   "feature.deleted",
+  // Safe Rollouts
+  "feature.saferollout.ship",
+  "feature.saferollout.rollback",
+  "feature.saferollout.unhealthy",
   // Experiments
   "experiment.created",
   "experiment.updated",


### PR DESCRIPTION
Fix being able to select safe rollout notifications in event webhook modal.