### PR TITLE
Filter out Safe Rollout from Experiment Import SQL

### DIFF
--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -12,6 +12,7 @@ import {
   resetReviewOnChange,
   getAffectedEnvsForExperiment,
 } from "shared/util";
+import { SAFE_ROLLOUT_TRACKING_KEY_PREFIX } from "shared/constants";
 import {
   getConnectionSDKCapabilities,
   SDKCapability,
@@ -1193,7 +1194,8 @@ export async function postFeatureRule(
     // Set default status for safe rollout rule
     rule.status = "running";
     rule.seed = rule.seed || uuidv4();
-    rule.trackingKey = rule.trackingKey || `srk_${uuidv4()}`;
+    rule.trackingKey =
+      rule.trackingKey || `${SAFE_ROLLOUT_TRACKING_KEY_PREFIX}${uuidv4()}`;
 
     const safeRollout = await context.models.safeRollout.create({
       ...validatedSafeRolloutFields,

--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -23,6 +23,7 @@ import {
   DEFAULT_TEST_QUERY_DAYS,
   DEFAULT_METRIC_HISTOGRAM_BINS,
   BANDIT_SRM_DIMENSION_NAME,
+  SAFE_ROLLOUT_TRACKING_KEY_PREFIX,
 } from "shared/constants";
 import { MetricAnalysisSettings } from "back-end/types/metric-analysis";
 import { UNITS_TABLE_PREFIX } from "back-end/src/queryRunners/ExperimentResultsQueryRunner";
@@ -407,6 +408,9 @@ export default abstract class SqlIntegration
           WHERE
             timestamp > ${this.toTimestamp(params.from)}
             AND timestamp <= ${this.toTimestamp(end)}
+            AND SUBSTRING(experiment_id, 1, ${
+              SAFE_ROLLOUT_TRACKING_KEY_PREFIX.length
+            }) != '${SAFE_ROLLOUT_TRACKING_KEY_PREFIX}'
           GROUP BY
             experiment_id,
             variation_id,

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -72,3 +72,6 @@ export const DEFAULT_DECISION_FRAMEWORK_ENABLED = false;
 export const DEFAULT_EXPERIMENT_MIN_LENGTH_DAYS = 3;
 export const DEFAULT_EXPERIMENT_MAX_LENGTH_DAYS = undefined; // undefined means no limit
 export const FALLBACK_EXPERIMENT_MAX_LENGTH_DAYS = 180;
+
+// Safe Rollout
+export const SAFE_ROLLOUT_TRACKING_KEY_PREFIX = "srk_";


### PR DESCRIPTION
### Features and Changes

When importing experiments, we want to now show Safe Rollouts that are managed internally by GrowthBook, so we are now filtering them out.

<img width="436" alt="Screenshot 2025-04-24 at 3 28 39 PM" src="https://github.com/user-attachments/assets/2c3078f6-f278-451b-9dd5-871b1a2344a9" />