### PR TITLE
ignore CR character for group csv import

### DIFF
--- a/packages/front-end/components/SavedGroups/IdListItemInput.tsx
+++ b/packages/front-end/components/SavedGroups/IdListItemInput.tsx
@@ -123,6 +123,8 @@ export const IdListItemInput: FC<{
                         .replaceAll(/,,/g, ",")
                         // Remove trailing delimiters to prevent adding an empty value
                         .replace(/,$/, "")
+                        // Remove Windows carriage return
+                        .replaceAll(/\r/g, "")
                         .split(",");
                       setFileName(file.name);
                       setValues(newValues);


### PR DESCRIPTION
Otherwise extra `\r` can be inserted into saved groups (Windows)