### PR TITLE
[fix] Mutate safe rollout when mutating a safe rollout snapshot

### DIFF
--- a/packages/front-end/components/Features/Rule.tsx
+++ b/packages/front-end/components/Features/Rule.tsx
@@ -487,7 +487,11 @@ export const Rule = forwardRef<HTMLDivElement, RuleProps>(
       </Box>
     );
     return safeRollout ? (
-      <SafeRolloutSnapshotProvider safeRollout={safeRollout} feature={feature}>
+      <SafeRolloutSnapshotProvider
+        safeRollout={safeRollout}
+        feature={feature}
+        mutateSafeRollout={mutate}
+      >
         {contents}
       </SafeRolloutSnapshotProvider>
     ) : (

--- a/packages/front-end/components/SafeRollout/AnalysisSettingsSummary.tsx
+++ b/packages/front-end/components/SafeRollout/AnalysisSettingsSummary.tsx
@@ -86,7 +86,7 @@ export default function SafeRolloutAnalysisSettingsSummary({
           <h4>Guardrail Metrics</h4>
           <div>
             <Metadata
-              label="Total users"
+              label="Total units"
               value={numberFormatter.format(
                 safeRollout.analysisSummary?.health?.totalUsers ?? 0
               )}


### PR DESCRIPTION
### Features and Changes

Always mutate safe rollout when mutating a safe rollout snapshot to update total unit count immediately.
Rename total users on safe rollout rule results to total units to be more accurate
