### PR TITLE
show license invalidated error message for invalidatd airgapped licenses

### DIFF
--- a/packages/back-end/src/enterprise/licenseUtil.ts
+++ b/packages/back-end/src/enterprise/licenseUtil.ts
@@ -141,6 +141,19 @@ function getPublicKey(): Buffer {
   return Buffer.from(LICENSE_PUBLIC_KEY);
 }
 
+// The end of the key is base64 encoding of the sha256 hash and is random
+// comparing the last 10 characters is random enough for 1/2^60 which is good enough
+const forbiddenAirGappedLicenseKeyEndings = ["JenaAbOBsY"];
+
+function isForbiddenAirGappedLicenseKey(key?: string): boolean {
+  if (!key) {
+    return false;
+  }
+  return forbiddenAirGappedLicenseKeyEndings.some((ending) =>
+    key.endsWith(ending)
+  );
+}
+
 function getVerifiedLicenseData(key: string): Partial<LicenseInterface> {
   const [license, signature] = key
     .split(".")
@@ -838,7 +851,10 @@ export function getLicenseError(org: MinimalOrganization): string {
     return "Invalid license";
   }
 
-  if (licenseData?.remoteDowngrade) {
+  if (
+    licenseData?.remoteDowngrade ||
+    (isAirGappedLicenseKey(key) && isForbiddenAirGappedLicenseKey(key))
+  ) {
     return "License invalidated";
   }
 

--- a/packages/back-end/src/enterprise/licenseUtil.ts
+++ b/packages/back-end/src/enterprise/licenseUtil.ts
@@ -142,7 +142,7 @@ function getPublicKey(): Buffer {
 }
 
 // The end of the key is base64 encoding of the sha256 hash and is random
-// comparing the last 10 characters is random enough for 1/2^60 which is good enough
+// comparing the last 10 characters is enough that a chance of a collision is 1/2^60
 const forbiddenAirGappedLicenseKeyEndings = ["JenaAbOBsY"];
 
 function isForbiddenAirGappedLicenseKey(key?: string): boolean {


### PR DESCRIPTION
### Features and Changes

We accidentally made an air-gapped license key that lasted too long.  We don't want it to work for future versions of growthbook.

### Testing

set LICENSE_KEY to be the bad license.
Make sure no org in mongo has `licenseKey` set.
start the server.  See the license invalidate error message.
![Screenshot 2025-04-28 at 9 53 23 PM](https://github.com/user-attachments/assets/875a8010-b6b9-4be8-9c6c-d767abadca70)

