### PR TITLE
React SDK: Update peer dependencies for react 19

### DIFF
--- a/packages/sdk-react/package.json
+++ b/packages/sdk-react/package.json
@@ -35,7 +35,7 @@
   },
   "author": "Jeremy Dorn",
   "peerDependencies": {
-    "react": "^16.8.0-0 || ^17.0.0-0 || ^18.0.0-0"
+    "react": "^16.8.0-0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
   },
   "dependencies": {
     "@growthbook/growthbook": "^1.4.1"


### PR DESCRIPTION
prevents `warning " > @growthbook/growthbook-react@1.4.1" has incorrect peer dependency "react@^16.8.0-0 || ^17.0.0-0 || ^18.0.0-0".`