### PR TITLE
Enable duplicating metrics from details page

### DIFF
--- a/packages/front-end/pages/metric/[mid].tsx
+++ b/packages/front-end/pages/metric/[mid].tsx
@@ -68,6 +68,7 @@ import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 import MetricPriorRightRailSectionGroup from "@/components/Metrics/MetricPriorRightRailSectionGroup";
 import CustomMarkdown from "@/components/Markdown/CustomMarkdown";
 import MetricExperiments from "@/components/MetricExperiments/MetricExperiments";
+import { MetricModal } from "@/components/FactTables/NewMetricModal";
 
 const MetricPage: FC = () => {
   const router = useRouter();
@@ -87,6 +88,7 @@ const MetricPage: FC = () => {
   const { organization } = useUser();
 
   const [editModalOpen, setEditModalOpen] = useState<boolean | number>(false);
+  const [duplicateModalOpen, setDuplicateModalOpen] = useState<boolean>(false);
   const [editTags, setEditTags] = useState(false);
   const [editProjects, setEditProjects] = useState(false);
   const [editOwnerModal, setEditOwnerModal] = useState(false);
@@ -136,6 +138,7 @@ const MetricPage: FC = () => {
   }
 
   const metric = data.metric;
+  const canDuplicateMetric = permissionsUtil.canCreateMetric(metric);
   const canEditMetric =
     permissionsUtil.canUpdateMetric(metric, {}) && !metric.managedBy;
   const canDeleteMetric =
@@ -307,6 +310,17 @@ const MetricPage: FC = () => {
           }}
         />
       )}
+      {duplicateModalOpen && (
+        <MetricModal
+          mode="duplicate"
+          currentMetric={{
+            ...metric,
+            name: metric.name + " (copy)",
+          }}
+          close={() => setDuplicateModalOpen(false)}
+          source="metrics-detail"
+        />
+      )}
       {editTags && (
         <EditTagsForm
           cancel={() => setEditTags(false)}
@@ -435,6 +449,15 @@ const MetricPage: FC = () => {
                 onClick={() => setEditModalOpen(true)}
               >
                 Edit metric
+              </Button>
+            ) : null}
+            {canDuplicateMetric ? (
+              <Button
+                className="btn dropdown-item py-2"
+                color=""
+                onClick={() => setDuplicateModalOpen(true)}
+              >
+                Duplicate metric
               </Button>
             ) : null}
             {canDeleteMetric ? (


### PR DESCRIPTION
### Features and Changes

Adds a Duplicate action to the dropdown menu on the `[mid]` page for duplicating existing metrics 

- Closes #3996

### Testing

Visit the page for a metric, then use the top right hamburger menu to open the duplicate modal

### Screenshots

![image](https://github.com/user-attachments/assets/ff858f69-cc69-4d2a-a27a-c1ecbe7622fc)


![image](https://github.com/user-attachments/assets/e4ce06a8-40bd-4ffa-a458-6dc596929845)
