### PR TITLE
Fix reason and metadata for not enough data for safe rollouts

### DIFF
--- a/packages/front-end/components/Experiment/NotEnoughData.tsx
+++ b/packages/front-end/components/Experiment/NotEnoughData.tsx
@@ -28,8 +28,7 @@ export default function NotEnoughData({
   style?: CSSProperties;
   showBaselineZero?: boolean;
 }) {
-  const numerator = rowResults.enoughDataMeta.percentCompleteNumerator;
-  const denominator = rowResults.enoughDataMeta.percentCompleteDenominator;
+  const enoughDataMeta = rowResults.enoughDataMeta;
   return (
     <div className="not-enough-data" style={style}>
       <div>
@@ -40,43 +39,40 @@ export default function NotEnoughData({
           not enough data
         </div>
       </div>
-      {showTimeRemaining && rowResults.enoughDataMeta.showTimeRemaining && (
-        <div
-          className={clsx("text-muted time-remaining", { small: !noStyle })}
-          style={noStyle ? {} : { fontSize: "10.5px", lineHeight: "12px" }}
-        >
-          {(rowResults.enoughDataMeta.timeRemainingMs ?? 0) > 0 ? (
-            <>
-              <span className="nowrap">
-                {formatDistance(
-                  0,
-                  rowResults.enoughDataMeta.timeRemainingMs ?? 0
-                )}
-              </span>{" "}
-              left
-            </>
-          ) : showBaselineZero ? (
-            "0 value in baseline"
-          ) : (
-            "try updating now"
-          )}
-        </div>
-      )}
-      {showPercentComplete ? (
+      {showTimeRemaining &&
+        enoughDataMeta.reason === "notEnoughData" &&
+        enoughDataMeta.showTimeRemaining && (
+          <div
+            className={clsx("text-muted time-remaining", { small: !noStyle })}
+            style={noStyle ? {} : { fontSize: "10.5px", lineHeight: "12px" }}
+          >
+            {(enoughDataMeta.timeRemainingMs ?? 0) > 0 ? (
+              <>
+                <span className="nowrap">
+                  {formatDistance(0, enoughDataMeta.timeRemainingMs ?? 0)}
+                </span>{" "}
+                left
+              </>
+            ) : showBaselineZero ? (
+              "0 value in baseline"
+            ) : (
+              "try updating now"
+            )}
+          </div>
+        )}
+      {showPercentComplete && enoughDataMeta.reason === "notEnoughData" ? (
         <div
           className={clsx("text-muted percent-complete", { small: !noStyle })}
         >
           <span className="percent-complete-numerator">
-            {numberFormatter.format(numerator)}
+            {numberFormatter.format(enoughDataMeta.percentCompleteNumerator)}
           </span>{" "}
           /&nbsp;
           <span className="percent-complete-denominator">
-            {numberFormatter.format(denominator)}
+            {numberFormatter.format(enoughDataMeta.percentCompleteDenominator)}
           </span>
           <span className="percent-complete-percent ml-1">
-            (
-            {percentFormatter.format(rowResults.enoughDataMeta.percentComplete)}
-            )
+            ({percentFormatter.format(enoughDataMeta.percentComplete)})
           </span>
         </div>
       ) : null}

--- a/packages/front-end/components/Experiment/ResultsTableTooltip/ResultsTableTooltip.tsx
+++ b/packages/front-end/components/Experiment/ResultsTableTooltip/ResultsTableTooltip.tsx
@@ -579,7 +579,7 @@ export default function ResultsTableTooltip({
                 {!data.rowResults.enoughData ? (
                   <Tooltip
                     className="cursor-pointer"
-                    body={data.rowResults.enoughDataMeta.reason}
+                    body={data.rowResults.enoughDataMeta.reasonText}
                   >
                     <div className="flagged d-flex border rounded p-1 flagged-not-enough-data">
                       <BsHourglassSplit

--- a/packages/front-end/components/FlagCard/FlagCard.tsx
+++ b/packages/front-end/components/FlagCard/FlagCard.tsx
@@ -233,7 +233,7 @@ export default function FlagCard({
             style={{ color: "var(--color-text-mid)" }}
           >
             <i>Not enough data</i>{" "}
-            <Tooltip content={enoughDataMeta.reason}>
+            <Tooltip content={enoughDataMeta.reasonText}>
               <span>
                 <PiInfo />
               </span>

--- a/packages/front-end/components/FlagCard/FlagCard.tsx
+++ b/packages/front-end/components/FlagCard/FlagCard.tsx
@@ -223,11 +223,8 @@ export default function FlagCard({
   );
 
   const renderContent = () => {
-    const numerator = data.rowResults.enoughDataMeta.percentCompleteNumerator;
-    const denominator =
-      data.rowResults.enoughDataMeta.percentCompleteDenominator;
-
     if (!data.rowResults.enoughData) {
+      const enoughDataMeta = data.rowResults.enoughDataMeta;
       return (
         <Flex direction="column" gap="1" p="3">
           <Text
@@ -236,21 +233,22 @@ export default function FlagCard({
             style={{ color: "var(--color-text-mid)" }}
           >
             <i>Not enough data</i>{" "}
-            <Tooltip content={data.rowResults.enoughDataMeta.reason}>
+            <Tooltip content={enoughDataMeta.reason}>
               <span>
                 <PiInfo />
               </span>
             </Tooltip>
           </Text>
-
-          <Text size="1" weight="medium">
-            {numberFormatter.format(numerator)} /{" "}
-            {numberFormatter.format(denominator)} (
-            {percentFormatter.format(
-              data.rowResults.enoughDataMeta.percentComplete
-            )}
-            )
-          </Text>
+          {enoughDataMeta.reason === "notEnoughData" ? (
+            <Text size="1" weight="medium">
+              {numberFormatter.format(enoughDataMeta.percentCompleteNumerator)}{" "}
+              /{" "}
+              {numberFormatter.format(
+                enoughDataMeta.percentCompleteDenominator
+              )}{" "}
+              ({percentFormatter.format(enoughDataMeta.percentComplete)})
+            </Text>
+          ) : null}
         </Flex>
       );
     } else {


### PR DESCRIPTION
In safe rollouts, when either the variation or baseline are 0, we now reveal "not enough data" instead of "NO DATA" which also hides tooltips. This is more informative, but our old metadata about "not enough data" did not properly cover this case, and now it does.