### PR TITLE
Add format as a percentage for ratio metrics

### DIFF
--- a/packages/back-end/src/api/openapi/payload-schemas/PostFactMetricPayload.yaml
+++ b/packages/back-end/src/api/openapi/payload-schemas/PostFactMetricPayload.yaml
@@ -206,6 +206,9 @@ properties:
     type: number
     description: Threshold for Risk to be considered too high, as a proportion (e.g. put 0.0125 for 1.25%). <br/> Must be a non-negative number.
     minimum: 0
+  displayAsPercentage:
+    type: boolean
+    description: If true and the metric is a ratio metric, variation means will be displayed as a percentage
   minPercentChange:
     type: number
     description: Minimum percent change to consider uplift significant, as a proportion (e.g. put 0.005 for 0.5%)

--- a/packages/back-end/src/api/openapi/payload-schemas/UpdateFactMetricPayload.yaml
+++ b/packages/back-end/src/api/openapi/payload-schemas/UpdateFactMetricPayload.yaml
@@ -201,6 +201,9 @@ properties:
     type: number
     description: Threshold for Risk to be considered too high, as a proportion (e.g. put 0.0125 for 1.25%). <br/> Must be a non-negative number.
     minimum: 0
+  displayAsPercentage:
+    type: boolean
+    description: If true and the metric is a ratio metric, variation means will be displayed as a percentage
   minPercentChange:
     type: number
     description: Minimum percent change to consider uplift significant, as a proportion (e.g. put 0.005 for 0.5%)

--- a/packages/back-end/src/api/openapi/schemas/FactMetric.yaml
+++ b/packages/back-end/src/api/openapi/schemas/FactMetric.yaml
@@ -209,6 +209,9 @@ properties:
     type: number
   riskThresholdDanger:
     type: number
+  displayAsPercentage:
+    type: boolean
+    description: If true and the metric is a ratio metric, variation means will be displayed as a percentage
   minPercentChange:
     type: number
   maxPercentChange:

--- a/packages/back-end/src/routers/fact-table/fact-table.validators.ts
+++ b/packages/back-end/src/routers/fact-table/fact-table.validators.ts
@@ -177,6 +177,7 @@ export const factMetricValidator = z
     minPercentChange: z.number(),
     minSampleSize: z.number(),
     targetMDE: z.number(),
+    displayAsPercentage: z.boolean().optional(),
 
     winRisk: z.number(),
     loseRisk: z.number(),

--- a/packages/front-end/components/Experiment/ResultsTableTooltip/ResultsTableTooltip.tsx
+++ b/packages/front-end/components/Experiment/ResultsTableTooltip/ResultsTableTooltip.tsx
@@ -41,6 +41,7 @@ import {
   formatPercent,
   getColumnRefFormatter,
   getExperimentMetricFormatter,
+  getMetricFormatter,
   getPercentileLabel,
 } from "@/services/metrics";
 import { useCurrency } from "@/hooks/useCurrency";
@@ -754,11 +755,17 @@ export default function ResultsTableTooltip({
 
                       {!quantileMetric ? (
                         <td>
-                          {getExperimentMetricFormatter(
-                            data.metric,
-                            ssrPolyfills?.getFactTableById || getFactTableById,
-                            "number"
-                          )(row.value, { currency: displayCurrency })}
+                          {isFactMetric(data.metric)
+                            ? getColumnRefFormatter(
+                                data.metric.numerator,
+                                ssrPolyfills?.getFactTableById ||
+                                  getFactTableById
+                              )(row.value, { currency: displayCurrency })
+                            : getMetricFormatter(
+                                data.metric.type === "binomial"
+                                  ? "count"
+                                  : data.metric.type
+                              )(row.value, { currency: displayCurrency })}
                         </td>
                       ) : null}
                       {hasCustomDenominator ? (

--- a/packages/front-end/components/FactTables/FactMetricModal.tsx
+++ b/packages/front-end/components/FactTables/FactMetricModal.tsx
@@ -1612,6 +1612,11 @@ export default function FactMetricModal({
           values.denominator = null;
         }
 
+        // reset displayAsPercentage for non-ratio metrics
+        if (values.metricType !== "ratio" && values.displayAsPercentage) {
+          values.displayAsPercentage = undefined;
+        }
+
         // reset numerator for proportion/retention metrics
         if (
           (values.metricType === "proportion" ||
@@ -2204,8 +2209,8 @@ export default function FactMetricModal({
               {advancedOpen && (
                 <Tabs defaultValue="query">
                   <TabsList>
-                    <TabsTrigger value="query">Query Settings</TabsTrigger>
-                    <TabsTrigger value="display">Analysis Settings</TabsTrigger>
+                    <TabsTrigger value="query">Analysis Settings</TabsTrigger>
+                    <TabsTrigger value="display">Display Settings</TabsTrigger>
                     <div className="ml-auto">
                       <a
                         href="#"
@@ -2236,6 +2241,19 @@ export default function FactMetricModal({
                         />
                       ) : null}
 
+                      <Field
+                        label="Target MDE"
+                        type="number"
+                        step="any"
+                        append="%"
+                        {...form.register("targetMDE", {
+                          valueAsNumber: true,
+                        })}
+                        helpText={`The percentage change that you want to reliably detect before ending your experiment. This is used to estimate the "Days Left" for running experiments. (default ${
+                          metricDefaults.targetMDE * 100
+                        }%)`}
+                      />
+
                       <MetricPriorSettingsForm
                         priorSettings={form.watch("priorSettings")}
                         setPriorSettings={(priorSettings) =>
@@ -2252,17 +2270,21 @@ export default function FactMetricModal({
                       <div className="px-3 py-2 pb-0 mb-2 border rounded">
                         {regressionAdjustmentAvailableForMetric ? (
                           <>
-                            <Checkbox
-                              label="Override organization-level settings"
-                              value={form.watch("regressionAdjustmentOverride")}
-                              setValue={(v) =>
-                                form.setValue(
-                                  "regressionAdjustmentOverride",
-                                  v === true
-                                )
-                              }
-                              disabled={!hasRegressionAdjustmentFeature}
-                            />
+                            <Box mt="1">
+                              <Checkbox
+                                label="Override organization-level settings"
+                                value={form.watch(
+                                  "regressionAdjustmentOverride"
+                                )}
+                                setValue={(v) =>
+                                  form.setValue(
+                                    "regressionAdjustmentOverride",
+                                    v === true
+                                  )
+                                }
+                                disabled={!hasRegressionAdjustmentFeature}
+                              />
+                            </Box>
                             <div
                               style={{
                                 display: form.watch(
@@ -2371,19 +2393,6 @@ export default function FactMetricModal({
                     </TabsContent>
 
                     <TabsContent value="display">
-                      <Field
-                        label="Target MDE"
-                        type="number"
-                        step="any"
-                        append="%"
-                        {...form.register("targetMDE", {
-                          valueAsNumber: true,
-                        })}
-                        helpText={`The percentage change that you want to reliably detect before ending your experiment. This is used to estimate the "Days Left" for running experiments. (default ${
-                          metricDefaults.targetMDE * 100
-                        }%)`}
-                      />
-
                       <div className="form-group">
                         <label>{`Minimum ${
                           quantileMetricType
@@ -2452,6 +2461,21 @@ export default function FactMetricModal({
                         loseRiskRegisterField={form.register("loseRisk")}
                         riskError={riskError}
                       />
+                      {type === "ratio" ? (
+                        <Box mb="1">
+                          <Checkbox
+                            label="Format ratio as a percentage"
+                            value={form.watch("displayAsPercentage") ?? false}
+                            setValue={(v) =>
+                              form.setValue("displayAsPercentage", v === true)
+                            }
+                          />
+                          <Box className="text-muted small">
+                            Will render variation means as a percentage rather
+                            than a proportion (e.g. 34% instead of 0.34).
+                          </Box>
+                        </Box>
+                      ) : null}
                     </TabsContent>
                   </Box>
                 </Tabs>

--- a/packages/front-end/components/Metrics/MetricForm/MetricPriorSettingsForm.tsx
+++ b/packages/front-end/components/Metrics/MetricForm/MetricPriorSettingsForm.tsx
@@ -2,8 +2,10 @@ import { MetricPriorSettings } from "back-end/types/fact-table";
 import { MetricDefaults } from "back-end/types/organization";
 import { DEFAULT_PROPER_PRIOR_STDDEV } from "shared/constants";
 import { useState } from "react";
+import { Box } from "@radix-ui/themes";
 import Toggle from "@/components/Forms/Toggle";
 import Field from "@/components/Forms/Field";
+import Checkbox from "@/components/Radix/Checkbox";
 
 const percentFormatter = new Intl.NumberFormat(undefined, {
   style: "percent",
@@ -29,28 +31,15 @@ export function MetricPriorSettingsForm({
         Only applicable to Bayesian analyses
       </small>
       <div className="px-3 py-2 pb-0 mb-2 border rounded">
-        <div className="form-group mb-0 mr-0 form-inline">
-          <div className="form-inline my-1">
-            <input
-              type="checkbox"
-              className="form-check-input"
-              id={"toggle-properPriorOverride"}
-              checked={priorSettings.override}
-              onChange={(v) =>
-                setPriorSettings({
-                  ...priorSettings,
-                  override: v.target.checked,
-                })
-              }
-            />
-            <label
-              className="mr-1 cursor-pointer"
-              htmlFor="toggle-properPriorOverride"
-            >
-              Override organization-level settings
-            </label>
-          </div>
-        </div>
+        <Box mt="1">
+          <Checkbox
+            label="Override organization-level settings"
+            value={priorSettings.override}
+            setValue={(v) =>
+              setPriorSettings({ ...priorSettings, override: v })
+            }
+          />
+        </Box>
         <div
           style={{
             display: priorSettings.override ? "block" : "none",

--- a/packages/front-end/pages/fact-metrics/[fmid].tsx
+++ b/packages/front-end/pages/fact-metrics/[fmid].tsx
@@ -702,6 +702,22 @@ export default function FactMetricPage() {
                 <ul className="right-rail-subsection list-unstyled mb-4">
                   <li className="mt-3 mb-1">
                     <span className="uppercase-title lg">
+                      Experiment Decision Framework
+                    </span>
+                  </li>
+                  <li className="mb-2">
+                    <span className="text-gray">Target MDE:</span>{" "}
+                    <span className="font-weight-bold">
+                      {getTargetMDEForMetric(factMetric) * 100}%
+                    </span>
+                  </li>
+                </ul>
+              </RightRailSectionGroup>
+
+              <RightRailSectionGroup type="custom" empty="">
+                <ul className="right-rail-subsection list-unstyled mb-4">
+                  <li className="mt-3 mb-1">
+                    <span className="uppercase-title lg">
                       Display Thresholds
                     </span>
                   </li>
@@ -735,12 +751,6 @@ export default function FactMetricPage() {
                     <span className="text-gray">Min percent change:</span>{" "}
                     <span className="font-weight-bold">
                       {getMinPercentageChangeForMetric(factMetric) * 100}%
-                    </span>
-                  </li>
-                  <li className="mb-2">
-                    <span className="text-gray">Target MDE:</span>{" "}
-                    <span className="font-weight-bold">
-                      {getTargetMDEForMetric(factMetric) * 100}%
                     </span>
                   </li>
                 </ul>

--- a/packages/front-end/pages/metric/[mid].tsx
+++ b/packages/front-end/pages/metric/[mid].tsx
@@ -1254,6 +1254,22 @@ const MetricPage: FC = () => {
                 <ul className="right-rail-subsection list-unstyled mb-4">
                   <li className="mt-3 mb-1">
                     <span className="uppercase-title lg">
+                      Experiment Decision Framework
+                    </span>
+                  </li>
+                  <li className="mb-2">
+                    <span className="text-gray">Target MDE:</span>{" "}
+                    <span className="font-weight-bold">
+                      {getTargetMDEForMetric(metric) * 100}%
+                    </span>
+                  </li>
+                </ul>
+              </RightRailSectionGroup>
+
+              <RightRailSectionGroup type="custom" empty="">
+                <ul className="right-rail-subsection list-unstyled mb-4">
+                  <li className="mt-3 mb-1">
+                    <span className="uppercase-title lg">
                       Display Thresholds
                     </span>
                   </li>
@@ -1278,12 +1294,6 @@ const MetricPage: FC = () => {
                     <span className="text-gray">Min percent change:</span>{" "}
                     <span className="font-weight-bold">
                       {getMinPercentageChangeForMetric(metric) * 100}%
-                    </span>
-                  </li>
-                  <li className="mb-2">
-                    <span className="text-gray">Target MDE:</span>{" "}
-                    <span className="font-weight-bold">
-                      {getTargetMDEForMetric(metric) * 100}%
                     </span>
                   </li>
                 </ul>

--- a/packages/front-end/services/metrics.tsx
+++ b/packages/front-end/services/metrics.tsx
@@ -108,6 +108,7 @@ export function getDefaultFactMetricProps({
       DEFAULT_MIN_PERCENT_CHANGE,
     targetMDE:
       existing?.targetMDE ?? metricDefaults.targetMDE ?? DEFAULT_TARGET_MDE,
+    displayAsPercentage: existing?.displayAsPercentage,
     maxPercentChange:
       existing?.maxPercentChange ??
       metricDefaults.maxPercentageChange ??
@@ -326,6 +327,11 @@ export function getExperimentMetricFormatter(
       return formatPercent;
     case "ratio":
       return (() => {
+        // If user has set displayAsPercentage to true, format as a percentage
+        if (metric.displayAsPercentage) {
+          return formatPercent;
+        }
+
         // If the metric is ratio of the same unit, they cancel out
         // For example: profit/revenue = $/$ = plain number
         const numerator = getFactTableById(


### PR DESCRIPTION
### Features and Changes

Allows ratio metrics to be formatted as percentages in tooltips, metric variation columns, and in metric analyses. This only applies to Fact Metric Ratio metrics, and not legacy Ratio metrics.

Makes other minor cosmetic changes.

- Closes #2249 


### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

- [ ] Test REST API

### Screenshots

#### New setting
<img width="1466" alt="Screenshot 2025-04-30 at 1 11 17 PM" src="https://github.com/user-attachments/assets/75d1ea2e-ad04-4b47-bb62-e59ccc8679d3" />


#### After

<img width="1385" alt="Screenshot 2025-04-30 at 1 17 55 PM" src="https://github.com/user-attachments/assets/a3b7889c-6882-4c9b-ada9-f960306afde2" />
<img width="1380" alt="Screenshot 2025-04-30 at 1 28 54 PM" src="https://github.com/user-attachments/assets/260b005c-3357-48d6-96af-bb079da195e2" />

#### Before

<img width="1406" alt="Screenshot 2025-04-30 at 1 14 23 PM" src="https://github.com/user-attachments/assets/7abc0be4-ca4b-4dab-ba92-1da8f0f658e9" />
<img width="1397" alt="Screenshot 2025-04-30 at 1 29 05 PM" src="https://github.com/user-attachments/assets/5a2a796d-a893-467e-8b5b-aa0b488ef4ff" />
