### PR TITLE
Fix signing key not showing for json event webhooks

### DIFF
--- a/packages/front-end/components/EventWebHooks/EventWebHookDetail/EventWebHookDetail.tsx
+++ b/packages/front-end/components/EventWebHooks/EventWebHookDetail/EventWebHookDetail.tsx
@@ -228,7 +228,7 @@ export const EventWebHookDetail: FC<EventWebHookDetailProps> = ({
           )}
         </div>
 
-        {payloadType === "raw" && (
+        {["raw", "json"].includes(payloadType) && (
           <div className="ml-2 d-flex align-items-center">
             <div className="text-main">
               <b>Secret:</b>


### PR DESCRIPTION
### Features and Changes

Event webhooks were only showing the signing key for "raw" payload types, which are now deprecated. This adds JSON to the types of webhooks for which we show signing keys.

### Testing

Create a JSON event webhook, then visit the details page
Discord/Slack webhooks should still not show the key

### Screenshots

![image](https://github.com/user-attachments/assets/dc647d02-4128-4554-852e-d1d5e1ad553d)
