### PR TITLE
Hide metric groups help text in Edit Metrics form

### DIFF
--- a/packages/front-end/components/Experiment/MetricsSelector.tsx
+++ b/packages/front-end/components/Experiment/MetricsSelector.tsx
@@ -213,11 +213,15 @@ const MetricsSelector: FC<{
     }
   });
 
-  const showMetricGroupHelper =
+  let showMetricGroupHelper =
     hasCommercialFeature("metric-groups") &&
     selected.length >= 2 &&
     !metricListContainsGroup &&
     datasource;
+
+  // Disable this for now since it is making the UI too cluttered
+  // We will revisit when we re-design the metric selector
+  showMetricGroupHelper = false;
 
   const selector = !forceSingleMetric ? (
     <MultiSelectField
@@ -291,7 +295,7 @@ const MetricsSelector: FC<{
       helpText={
         <>
           {helpText}
-          {showMetricGroupHelper ? (
+          {showMetricGroupHelper && datasource ? (
             <Flex align="center">
               {createMetricGroup ? (
                 <MetricGroupInlineForm


### PR DESCRIPTION
### Features and Changes

The Metric Selector is already cluttered, so adding more help text and another CTA was too much.  Removing for now until we get a chance to re-design this component.

Before:

![image](https://github.com/user-attachments/assets/b7fe7621-1c10-4635-91be-df1c639082d2)

After:

![image](https://github.com/user-attachments/assets/b7b0aa0b-101c-48d0-a93a-f15ffbc46116)

