### PR TITLE
Automatically open upgrade modal if query param is set

### DIFF
--- a/packages/front-end/pages/settings/billing.tsx
+++ b/packages/front-end/pages/settings/billing.tsx
@@ -1,4 +1,5 @@
 import { FC, useEffect, useState } from "react";
+import { useRouter } from "next/router";
 import { LicenseInterface } from "shared/enterprise";
 import SubscriptionInfo from "@/components/Settings/SubscriptionInfo";
 import UpgradeModal from "@/components/Settings/UpgradeModal";
@@ -18,6 +19,8 @@ const BillingPage: FC = () => {
 
   const { apiCall } = useAuth();
   const { refreshOrganization } = useUser();
+
+  const router = useRouter();
 
   useEffect(() => {
     const refreshLicense = async () => {
@@ -40,8 +43,15 @@ const BillingPage: FC = () => {
       if (urlParams.get("refreshLicense") || urlParams.get("org")) {
         refreshLicense();
       }
+
+      if (urlParams.get("openUpgradeModal")) {
+        setUpgradeModal(true);
+
+        // Remove the query param from the URL
+        router.replace(router.pathname, undefined, { shallow: true });
+      }
     }
-  }, [apiCall, refreshOrganization]);
+  }, [apiCall, refreshOrganization, router]);
 
   if (accountPlan === "enterprise") {
     return (


### PR DESCRIPTION
### Features and Changes

From emails we want to link people to the billing page with the upgrade modal already open.  This query parameter allows it.

### Testing

Go to localhost:3000/settings/billing?openUpgradeModal=1 
see that the upgradeModal is open and that the query parameter has been removed from the url.