### PR TITLE
Fix plugins import for JS SDK on webpack

### DIFF
--- a/packages/sdk-js/package.json
+++ b/packages/sdk-js/package.json
@@ -31,6 +31,7 @@
   },
   "files": [
     "dist",
+    "plugins",
     "src"
   ],
   "engines": {

--- a/packages/sdk-js/plugins/index.js
+++ b/packages/sdk-js/plugins/index.js
@@ -1,0 +1,1 @@
+module.exports = require("../dist/cjs/plugins/index.js");

--- a/packages/sdk-js/plugins/package.json
+++ b/packages/sdk-js/plugins/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "../dist/cjs/plugins/index.js",
+  "types": "../dist/plugins/index.d.ts"
+}


### PR DESCRIPTION
### Features and Changes

In the Javascript SDK, we tell people to import from `@growthbook/growthbook/plugins`.  We make this work via subpaths in the package.json `exports` field.  This works for modern bundlers and systems, but older tools like Webpack don't know how to find the file to import.

This PR adds a new `plugins` directory with stub files so all systems, old and new, should understand imports properly.