### PR TITLE
fix: Pass coverage to EditVariationsForm

### DIFF
--- a/packages/front-end/components/Experiment/EditVariationsForm.tsx
+++ b/packages/front-end/components/Experiment/EditVariationsForm.tsx
@@ -139,8 +139,7 @@ const EditVariationsForm: FC<{
           );
         }}
         showPreview={false}
-        coverage={lastPhase.coverage}
-        disableCoverage
+        hideCoverage
         onlySafeToEditVariationMetadata={onlySafeToEditVariationMetadata}
       />
     </Modal>

--- a/packages/front-end/components/Experiment/EditVariationsForm.tsx
+++ b/packages/front-end/components/Experiment/EditVariationsForm.tsx
@@ -139,6 +139,7 @@ const EditVariationsForm: FC<{
           );
         }}
         showPreview={false}
+        coverage={lastPhase.coverage}
         disableCoverage
         onlySafeToEditVariationMetadata={onlySafeToEditVariationMetadata}
       />


### PR DESCRIPTION
### Features and Changes

When Editing Variations in an Experiment, the Coverage % is not editable but right now it is showing as 0%, so this fixes it by hiding it.

#### Before

<img width="828" alt="Screenshot 2025-05-09 at 9 15 35 AM" src="https://github.com/user-attachments/assets/395acecc-73fa-4714-b4fe-dc7041476f92" />

#### After

<img width="808" alt="Screenshot 2025-05-13 at 2 43 17 PM" src="https://github.com/user-attachments/assets/116d480b-c693-40f7-8eee-d2969922bda4" />
