### PR TITLE
Limit feature revisions fetched when loading experiment

### DIFF
--- a/packages/back-end/src/models/FeatureRevisionModel.ts
+++ b/packages/back-end/src/models/FeatureRevisionModel.ts
@@ -545,7 +545,9 @@ export async function getFeatureRevisionsByFeatureIds(
     const revisions = await FeatureRevisionModel.find({
       organization,
       featureId: { $in: featureIds },
-    });
+    })
+      .sort({ version: -1 })
+      .limit(10);
     revisions.forEach((revision) => {
       const featureId = revision.featureId;
       revisionsByFeatureId[featureId] = revisionsByFeatureId[featureId] || [];


### PR DESCRIPTION
### Features and Changes

When fetching an experiment, we get all linked features.  For each feature, we get the revision history to cover the edge case when an experiment is no longer linked to a feature, but was in the past.  This query to get feature revisions did not have a limit and was causing performance issues.  In one instance, a feature had 700+ revisions and each one had 100+kb of data.

This PR adds a limit, so we only fetch the most recent 10 revisions from each linked feature.  This is a temporary fix.  In the future, we will instead only fetch draft revisions.  If the experiment does not exist in the live revision or any draft, then we can safely assume it is from an old locked revision.
