### PR TITLE
Fix zod error in doc fact metrics

### DIFF
--- a/packages/front-end/components/FactTables/FactMetricModal.tsx
+++ b/packages/front-end/components/FactTables/FactMetricModal.tsx
@@ -1612,6 +1612,11 @@ export default function FactMetricModal({
           values.denominator = null;
         }
 
+        // if denominator is undefined, set to null instead
+        if (values.denominator === undefined) {
+          values.denominator = null;
+        }
+
         // reset displayAsPercentage for non-ratio metrics
         if (values.metricType !== "ratio" && values.displayAsPercentage) {
           values.displayAsPercentage = undefined;


### PR DESCRIPTION
Non-ratio metrics created from Docs Templates (from this link: https://docs.growthbook.io/app/metrics/examples) were resulting in zod errors as `denominator` was `undefined` instead of `null`. This fixes this by just casting undefined denominators to null, which seems like a safe escape hatch that resolves this issue and could hide other minor bugs.

We could try instead to resolve it in the template metric modal so that other bugs that cause `denominator` to unexpectedly be `undefined` are caught, but that doesn't seem necessary.

Old bug that no longer exists:
<img width="1113" alt="Screenshot 2025-05-12 at 1 05 58 PM" src="https://github.com/user-attachments/assets/48bd0b40-9aac-46bc-b964-6f4e97e5d608" />
