### PR TITLE
feat(Features): Add requireProjectForFeatures setting + add validation of Projects when creating & updating features

### DIFF
--- a/packages/back-end/src/api/features/postFeature.ts
+++ b/packages/back-end/src/api/features/postFeature.ts
@@ -91,6 +91,13 @@ export const postFeature = createApiRequestHandler(postFeatureValidator)(
       Object.keys(req.body.environments ?? {})
     );
 
+    if (
+      req.context.org.settings?.requireProjectForFeatures &&
+      !req.body.project
+    ) {
+      throw new Error("Must specify a project for new features");
+    }
+
     // Validate projects - We can remove this validation when FeatureModel is migrated to BaseModel
     if (req.body.project) {
       const projects = await req.context.getProjects();

--- a/packages/back-end/src/api/features/updateFeature.ts
+++ b/packages/back-end/src/api/features/updateFeature.ts
@@ -38,10 +38,17 @@ export const updateFeature = createApiRequestHandler(updateFeatureValidator)(
     const effectiveProject =
       typeof project === "undefined" ? feature.project : project;
 
-    const orgEnvs = getEnvironmentIdsFromOrg(req.organization);
+    const orgEnvs = getEnvironmentIdsFromOrg(req.context.org);
 
     if (!req.context.permissions.canUpdateFeature(feature, req.body)) {
       req.context.permissions.throwPermissionError();
+    }
+    if (
+      req.context.org.settings?.requireProjectForFeatures &&
+      feature.project &&
+      (effectiveProject == null || effectiveProject === "")
+    ) {
+      throw new Error("Must specify a project");
     }
 
     if (project != null) {
@@ -209,7 +216,7 @@ export const updateFeature = createApiRequestHandler(updateFeatureValidator)(
     );
 
     await addTagsDiff(
-      req.organization.id,
+      req.context.org.id,
       feature.tags || [],
       updates.tags || []
     );

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -459,6 +459,15 @@ export async function postFeatures(
       "Feature keys can only include letters, numbers, hyphens, and underscores."
     );
   }
+
+  if (org.settings?.requireProjectForFeatures && !otherProps.project) {
+    throw new Error("Must specify a project for new features");
+  }
+  // Validate projects - We can remove this validation when FeatureModel is migrated to BaseModel
+  if (otherProps.project) {
+    await context.models.projects.ensureProjectsExist([otherProps.project]);
+  }
+
   const existing = await getFeature(context, id);
   if (existing) {
     throw new Error(
@@ -2112,6 +2121,19 @@ export async function putFeature(
   const updates = req.body;
   if (!context.permissions.canUpdateFeature(feature, updates)) {
     context.permissions.throwPermissionError();
+  }
+
+  // For a feature created before requireProjectForFeatures was enabled, allow updates to happen until the feature is associated with a project
+  if (
+    org.settings?.requireProjectForFeatures &&
+    feature.project &&
+    updates.project === ""
+  ) {
+    throw new Error("Must specify a project");
+  }
+  // Validate projects - We can remove this validation when FeatureModel is migrated to BaseModel
+  if (updates.project) {
+    await context.models.projects.ensureProjectsExist([updates.project]);
   }
 
   // Changing the project can affect whether or not it's published if using project-scoped api keys

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -2132,7 +2132,7 @@ export async function putFeature(
     throw new Error("Must specify a project");
   }
   // Validate projects - We can remove this validation when FeatureModel is migrated to BaseModel
-  if (updates.project) {
+  if (updates.project && feature.project !== updates.project) {
     await context.models.projects.ensureProjectsExist([updates.project]);
   }
 

--- a/packages/back-end/test/api/features.test.ts
+++ b/packages/back-end/test/api/features.test.ts
@@ -1,5 +1,10 @@
 import request from "supertest";
-import { createFeature, getFeature } from "back-end/src/models/FeatureModel";
+import { FeatureInterface } from "back-end/types/feature";
+import {
+  createFeature,
+  getFeature,
+  updateFeature,
+} from "back-end/src/models/FeatureModel";
 import { addTags } from "back-end/src/models/TagModel";
 import {
   getSavedGroupMap,
@@ -11,10 +16,12 @@ import { setupApp } from "./api.setup";
 jest.mock("back-end/src/models/FeatureModel", () => ({
   getFeature: jest.fn(),
   createFeature: jest.fn(),
+  updateFeature: jest.fn(),
 }));
 
 jest.mock("back-end/src/models/TagModel", () => ({
   addTags: jest.fn(),
+  addTagsDiff: jest.fn(),
 }));
 
 jest.mock("back-end/src/services/features", () => ({
@@ -31,7 +38,7 @@ describe("features API", () => {
     jest.clearAllMocks();
   });
 
-  const org = { id: "org", environments: [{ id: "production" }] };
+  const org = { id: "org", settings: { environments: [{ id: "production" }] } };
 
   it("can create new features", async () => {
     setReqContext({
@@ -106,6 +113,188 @@ describe("features API", () => {
       details: `{"post":{"defaultValue":"defaultValue","valueType":"string","owner":"owner","description":"description","project":"project","dateCreated":"${response.body.feature.feature.dateCreated}","dateUpdated":"${response.body.feature.feature.dateUpdated}","organization":"org","id":"id","archived":true,"version":1,"environmentSettings":"createInterfaceEnvSettingsFromApiEnvSettings","prerequisites":[],"tags":["tag"],"jsonSchema":{"schemaType":"schema","schema":"","simple":{"type":"object","fields":[]},"date":"${response.body.feature.feature.jsonSchema.date}","enabled":false}},"context":{}}`,
       entity: { id: "id", object: "feature" },
       event: "feature.create",
+    });
+  });
+
+  describe("requireProjectForFeatures enabled", () => {
+    it("fails to create new features without a project", async () => {
+      setReqContext({
+        org: {
+          ...org,
+          settings: {
+            requireProjectForFeatures: true,
+          },
+        },
+        permissions: {
+          canPublishFeature: () => true,
+          canCreateFeature: () => true,
+        },
+        getProjects: async () => [{ id: "project" }],
+      });
+
+      const feature = {
+        defaultValue: "defaultValue",
+        valueType: "string",
+        owner: "owner",
+        description: "description",
+        project: "",
+        id: "id",
+        archived: true,
+        tags: ["tag"],
+      };
+
+      const response = await request(app)
+        .post("/api/v1/features")
+        .send(feature);
+
+      expect(response.status).toBe(400);
+      expect(response.body).toEqual({
+        message: "Must specify a project for new features",
+      });
+    });
+
+    it("fails to update existing features if removing a project", async () => {
+      setReqContext({
+        org: {
+          ...org,
+          settings: {
+            requireProjectForFeatures: true,
+          },
+        },
+        permissions: {
+          canPublishFeature: () => true,
+          canCreateFeature: () => true,
+          canUpdateFeature: () => true,
+        },
+        getProjects: async () => [{ id: "project" }],
+      });
+
+      const existingFeature: FeatureInterface = {
+        organization: org.id,
+        defaultValue: "defaultValue",
+        valueType: "string",
+        owner: "owner",
+        description: "description",
+        project: "project",
+        id: "myexistingfeature",
+        archived: true,
+        tags: ["tag"],
+        dateCreated: new Date(),
+        dateUpdated: new Date(),
+        version: 1,
+        environmentSettings: {},
+        prerequisites: [],
+      };
+
+      getFeature.mockImplementation((ctx, id) => {
+        if (id === existingFeature.id) {
+          return Promise.resolve(existingFeature);
+        }
+        return Promise.resolve(null);
+      });
+
+      updateFeature.mockImplementation((ctx, feature, updates) => {
+        if (feature.id === existingFeature.id) {
+          return Promise.resolve({ ...existingFeature, ...updates });
+        }
+        return Promise.resolve(null);
+      });
+
+      const updates = {
+        project: "",
+      };
+
+      const response = await request(app)
+        .post(`/api/v1/features/${existingFeature.id}`)
+        .send(updates);
+
+      expect(response.status).toBe(400);
+      expect(response.body).toEqual({
+        message: "Must specify a project",
+      });
+    });
+
+    it("allows updating existing features if originally not associated with a project", async () => {
+      setReqContext({
+        org: {
+          ...org,
+          settings: {
+            requireProjectForFeatures: true,
+          },
+        },
+        permissions: {
+          canPublishFeature: () => true,
+          canCreateFeature: () => true,
+          canUpdateFeature: () => true,
+        },
+        getProjects: async () => [{ id: "project" }],
+      });
+
+      const existingFeature: FeatureInterface = {
+        organization: org.id,
+        defaultValue: "defaultValue",
+        valueType: "string",
+        owner: "owner",
+        description: "description",
+        project: "",
+        id: "myexistingfeature",
+        archived: true,
+        tags: ["tag"],
+        dateCreated: new Date(),
+        dateUpdated: new Date(),
+        version: 1,
+        environmentSettings: {},
+        prerequisites: [],
+      };
+
+      getFeature.mockImplementation((ctx, id) => {
+        if (id === existingFeature.id) {
+          return Promise.resolve(existingFeature);
+        }
+        return Promise.resolve(null);
+      });
+
+      updateFeature.mockImplementation((ctx, feature, updates) => {
+        if (feature.id === existingFeature.id) {
+          return Promise.resolve({ ...existingFeature, ...updates });
+        }
+        return Promise.resolve(null);
+      });
+
+      const newDescription = "This is an updated description";
+      const updates = {
+        description: newDescription,
+      };
+
+      const response = await request(app)
+        .post(`/api/v1/features/${existingFeature.id}`)
+        .send(updates);
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual(
+        expect.objectContaining({
+          feature: expect.objectContaining({
+            experimentMap: {},
+            feature: expect.objectContaining({
+              archived: true,
+              dateCreated: expect.any(String),
+              dateUpdated: expect.any(String),
+              defaultValue: "defaultValue",
+              description: newDescription,
+              environmentSettings: {},
+              prerequisites: [],
+              id: "myexistingfeature",
+              organization: "org",
+              owner: "owner",
+              project: "", // Still empty
+              tags: ["tag"],
+              valueType: "string",
+              version: 1,
+            }),
+            groupMap: "savedGroupMap",
+          }),
+        })
+      );
     });
   });
 });

--- a/packages/back-end/types/organization.d.ts
+++ b/packages/back-end/types/organization.d.ts
@@ -230,6 +230,7 @@ export interface OrganizationSettings {
   codeRefsPlatformUrl?: string;
   featureKeyExample?: string; // Example Key of feature flag (e.g. "feature-20240201-name")
   featureRegexValidator?: string; // Regex to validate feature flag name (e.g. ^.+-\d{8}-.+$)
+  requireProjectForFeatures?: boolean;
   featureListMarkdown?: string;
   featurePageMarkdown?: string;
   experimentListMarkdown?: string;

--- a/packages/front-end/components/Features/EditFeatureInfoModal.tsx
+++ b/packages/front-end/components/Features/EditFeatureInfoModal.tsx
@@ -86,7 +86,7 @@ const EditFeatureInfoModal: FC<{
             value={form.watch("project")}
             onChange={(v) => {
               form.setValue("project", v);
-              setShowProjectWarningMsg(true);
+              setShowProjectWarningMsg(v !== feature.project);
             }}
             options={useProjectOptions(
               permissionRequired,

--- a/packages/front-end/components/Features/EditFeatureInfoModal.tsx
+++ b/packages/front-end/components/Features/EditFeatureInfoModal.tsx
@@ -11,6 +11,7 @@ import SelectField from "@/components/Forms/SelectField";
 import Callout from "@/components/Radix/Callout";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 import Tooltip from "@/components/Tooltip/Tooltip";
+import useOrgSettings from "@/hooks/useOrgSettings";
 
 const EditFeatureInfoModal: FC<{
   feature: FeatureInterface;
@@ -34,10 +35,12 @@ const EditFeatureInfoModal: FC<{
   });
   const permissionsUtil = usePermissionsUtil();
   const [showProjectWarningMsg, setShowProjectWarningMsg] = useState(false);
+  const { requireProjectForFeatures } = useOrgSettings();
 
   const permissionRequired = (project) =>
     permissionsUtil.canUpdateFeature(feature, { project });
-  const initialOption = permissionRequired("") ? "None" : "";
+  const initialOption =
+    permissionRequired("") && !requireProjectForFeatures ? "None" : "";
 
   return (
     <Modal

--- a/packages/front-end/components/Features/FeatureModal/index.tsx
+++ b/packages/front-end/components/Features/FeatureModal/index.tsx
@@ -31,6 +31,7 @@ import { useUser } from "@/services/UserContext";
 import FeatureValueField from "@/components/Features/FeatureValueField";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 import useProjectOptions from "@/hooks/useProjectOptions";
+import useOrgSettings from "@/hooks/useOrgSettings";
 import SelectField from "@/components/Forms/SelectField";
 import FeatureKeyField from "./FeatureKeyField";
 import EnvironmentSelect from "./EnvironmentSelect";
@@ -169,6 +170,7 @@ export default function FeatureModal({
   const permissionsUtil = usePermissionsUtil();
   const { refreshWatching } = useWatching();
   const { hasCommercialFeature } = useUser();
+  const { requireProjectForFeatures } = useOrgSettings();
 
   const customFields = filterCustomFieldsForSectionAndProject(
     useCustomFields(),
@@ -357,8 +359,9 @@ export default function FeatureModal({
             onChange={(v) => {
               form.setValue("project", v);
             }}
-            initialOption="None"
+            initialOption={requireProjectForFeatures ? undefined : "None"}
             options={projectOptions}
+            required={requireProjectForFeatures}
           />
         </>
       )}

--- a/packages/front-end/components/GeneralSettings/FeaturesSettings.tsx
+++ b/packages/front-end/components/GeneralSettings/FeaturesSettings.tsx
@@ -180,6 +180,48 @@ export default function FeaturesSettings() {
               </Flex>
             </Flex>
           </Box>
+
+          {/* Require project for features */}
+          <Box mb="6" width="100%">
+            <Flex align="start" justify="start" gap="3">
+              <Box>
+                <Checkbox
+                  id="toggle-requireProjectForFeatures"
+                  value={!!form.watch("requireProjectForFeatures")}
+                  setValue={(value) => {
+                    form.setValue("requireProjectForFeatures", value, {
+                      shouldDirty: true,
+                    });
+                  }}
+                  mt="1"
+                />
+              </Box>
+              <Flex
+                direction="column"
+                justify="start"
+                style={{ marginTop: "1px" }}
+              >
+                <Box>
+                  <Text
+                    size="3"
+                    className="font-weight-semibold"
+                    htmlFor="toggle-requireProjectForFeatures"
+                    as="label"
+                    mb="2"
+                  >
+                    Require Project for all new Features
+                  </Text>
+                </Box>
+                <Box>
+                  <Text size="2" color="gray">
+                    If enabled, users will be required to select a project when
+                    creating a feature flag.
+                  </Text>
+                </Box>
+              </Flex>
+            </Flex>
+          </Box>
+
           {hasRequireApprovals && (
             <>
               <Box mb="6" width="100%">

--- a/packages/front-end/components/GeneralSettings/FeaturesSettings.tsx
+++ b/packages/front-end/components/GeneralSettings/FeaturesSettings.tsx
@@ -182,45 +182,47 @@ export default function FeaturesSettings() {
           </Box>
 
           {/* Require project for features */}
-          <Box mb="6" width="100%">
-            <Flex align="start" justify="start" gap="3">
-              <Box>
-                <Checkbox
-                  id="toggle-requireProjectForFeatures"
-                  value={!!form.watch("requireProjectForFeatures")}
-                  setValue={(value) => {
-                    form.setValue("requireProjectForFeatures", value, {
-                      shouldDirty: true,
-                    });
-                  }}
-                  mt="1"
-                />
-              </Box>
-              <Flex
-                direction="column"
-                justify="start"
-                style={{ marginTop: "1px" }}
-              >
+          {hasCommercialFeature("require-project-for-features-setting") && (
+            <Box mb="6" width="100%">
+              <Flex align="start" justify="start" gap="3">
                 <Box>
-                  <Text
-                    size="3"
-                    className="font-weight-semibold"
-                    htmlFor="toggle-requireProjectForFeatures"
-                    as="label"
-                    mb="2"
-                  >
-                    Require Project for all new Features
-                  </Text>
+                  <Checkbox
+                    id="toggle-requireProjectForFeatures"
+                    value={!!form.watch("requireProjectForFeatures")}
+                    setValue={(value) => {
+                      form.setValue("requireProjectForFeatures", value, {
+                        shouldDirty: true,
+                      });
+                    }}
+                    mt="1"
+                  />
                 </Box>
-                <Box>
-                  <Text size="2" color="gray">
-                    If enabled, users will be required to select a project when
-                    creating a feature flag.
-                  </Text>
-                </Box>
+                <Flex
+                  direction="column"
+                  justify="start"
+                  style={{ marginTop: "1px" }}
+                >
+                  <Box>
+                    <Text
+                      size="3"
+                      className="font-weight-semibold"
+                      htmlFor="toggle-requireProjectForFeatures"
+                      as="label"
+                      mb="2"
+                    >
+                      Require Project for all new Features
+                    </Text>
+                  </Box>
+                  <Box>
+                    <Text size="2" color="gray">
+                      If enabled, users will be required to select a project
+                      when creating a feature flag.
+                    </Text>
+                  </Box>
+                </Flex>
               </Flex>
-            </Flex>
-          </Box>
+            </Box>
+          )}
 
           {hasRequireApprovals && (
             <>

--- a/packages/front-end/pages/settings/index.tsx
+++ b/packages/front-end/pages/settings/index.tsx
@@ -13,6 +13,7 @@ import {
   DEFAULT_EXPERIMENT_MIN_LENGTH_DAYS,
   DEFAULT_EXPERIMENT_MAX_LENGTH_DAYS,
   DEFAULT_DECISION_FRAMEWORK_ENABLED,
+  DEFAULT_REQUIRE_PROJECT_FOR_FEATURES,
 } from "shared/constants";
 import { OrganizationSettings } from "back-end/types/organization";
 import Link from "next/link";
@@ -166,6 +167,9 @@ const GeneralSettingsPage = (): React.ReactElement => {
         settings.decisionFrameworkEnabled ?? DEFAULT_DECISION_FRAMEWORK_ENABLED,
       defaultDecisionCriteriaId:
         settings.defaultDecisionCriteriaId ?? PRESET_DECISION_CRITERIA.id,
+      requireProjectForFeatures:
+        settings.requireProjectForFeatures ??
+        DEFAULT_REQUIRE_PROJECT_FOR_FEATURES,
     },
   });
   const { apiCall } = useAuth();

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -75,3 +75,5 @@ export const FALLBACK_EXPERIMENT_MAX_LENGTH_DAYS = 180;
 
 // Safe Rollout
 export const SAFE_ROLLOUT_TRACKING_KEY_PREFIX = "srk_";
+
+export const DEFAULT_REQUIRE_PROJECT_FOR_FEATURES = false;

--- a/packages/shared/src/enterprise/license-consts.ts
+++ b/packages/shared/src/enterprise/license-consts.ts
@@ -55,7 +55,8 @@ export type CommercialFeature =
   | "historical-power"
   | "decision-framework"
   | "unlimited-cdn-usage"
-  | "safe-rollout";
+  | "safe-rollout"
+  | "require-project-for-features-setting";
 
 export type CommercialFeaturesMap = Record<AccountPlan, Set<CommercialFeature>>;
 
@@ -269,6 +270,7 @@ export const accountFeatures: CommercialFeaturesMap = {
     "historical-power",
     "decision-framework",
     "safe-rollout",
+    "require-project-for-features-setting",
   ]),
 };
 


### PR DESCRIPTION
### Features and Changes

Closes #3427

We're introducing a new organization setting called requireProjectForFeatures.

- This setting is turned off by default.
- When Enabled: If you turn this setting on, every new feature must be linked to a project.
  - UI: The "None" option for selecting a project will be hidden when creating or editing features.
  - API: If you try to create a new feature without specifying a project, an error will be returned.
  - Updating a feature
    - Features without a project: If a feature doesn't currently have a project assigned, you can still update its other details without assigning a project.
    - Features with a project: Once a feature is linked to a project, it follows the same rules as creation and will throw an error if we attempt to remove the project.


### Testing

Unit tests added
Manual testing UI
- Enable setting
  - See how Project is now required when creating a Feature
  - When editing a Feature information, observe how we cannot select `None` as the project

### Screenshots

<img width="829" alt="Screenshot 2025-05-13 at 2 14 07 PM" src="https://github.com/user-attachments/assets/7a670dcb-9a47-44fd-b6b1-b68e247b0062" />