### PR TITLE
REST API: implement SDK clientKey filter for listFeatures

### DIFF
--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -5072,7 +5072,7 @@ components:
     platform:
       name: platform
       in: query
-      description: Name of versino control platform like GitHub or Gitlab.
+      description: Name of version control platform like GitHub or Gitlab.
       schema:
         type: string
         enum:
@@ -5100,7 +5100,7 @@ components:
     clientKey:
       name: clientKey
       in: query
-      description: Optionally filter features by a SDK connection's client key
+      description: Filter by a SDK connection's client key
       schema:
         type: string
   schemas:

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -223,6 +223,7 @@ paths:
         - $ref: '#/components/parameters/limit'
         - $ref: '#/components/parameters/offset'
         - $ref: '#/components/parameters/projectId'
+        - $ref: '#/components/parameters/clientKey'
       operationId: listFeatures
       x-codeSamples:
         - lang: cURL
@@ -5094,6 +5095,12 @@ components:
       name: globalRole
       in: query
       description: Name of the global role
+      schema:
+        type: string
+    clientKey:
+      name: clientKey
+      in: query
+      description: Optionally filter features by a SDK connection's client key
       schema:
         type: string
   schemas:

--- a/packages/back-end/src/api/features/listFeatures.ts
+++ b/packages/back-end/src/api/features/listFeatures.ts
@@ -1,3 +1,4 @@
+import { getConnectionSDKCapabilities } from "shared/sdk-versioning";
 import { getFeatureRevisionsByFeaturesCurrentVersion } from "back-end/src/models/FeatureRevisionModel";
 import { ListFeaturesResponse } from "back-end/types/openapi";
 import { getAllPayloadExperiments } from "back-end/src/models/ExperimentModel";
@@ -5,12 +6,14 @@ import { getAllFeatures } from "back-end/src/models/FeatureModel";
 import {
   getApiFeatureObj,
   getSavedGroupMap,
+  getFeatureDefinitions,
 } from "back-end/src/services/features";
 import {
   applyPagination,
   createApiRequestHandler,
 } from "back-end/src/util/handler";
 import { listFeaturesValidator } from "back-end/src/validators/openapi";
+import { findSDKConnectionByKey } from "back-end/src/models/SdkConnectionModel";
 
 export const listFeatures = createApiRequestHandler(listFeaturesValidator)(
   async (req): Promise<ListFeaturesResponse> => {
@@ -24,13 +27,44 @@ export const listFeatures = createApiRequestHandler(listFeaturesValidator)(
       req.query.projectId
     );
 
+    // If SDK clientKey is provided, get the SDK connection and use its projects/environment
+    let filteredFeatures = features;
+    if (req.query.clientKey) {
+      const sdkConnection = await findSDKConnectionByKey(req.query.clientKey);
+      if (!sdkConnection) {
+        throw new Error("Invalid SDK connection key");
+      }
+
+      const payload = await getFeatureDefinitions({
+        context: req.context,
+        capabilities: getConnectionSDKCapabilities(sdkConnection),
+        environment: sdkConnection.environment,
+        projects: sdkConnection.projects,
+        encryptionKey: sdkConnection.encryptPayload
+          ? sdkConnection.encryptionKey
+          : "",
+        includeVisualExperiments: sdkConnection.includeVisualExperiments,
+        includeDraftExperiments: sdkConnection.includeDraftExperiments,
+        includeExperimentNames: sdkConnection.includeExperimentNames,
+        includeRedirectExperiments: sdkConnection.includeRedirectExperiments,
+        includeRuleIds: sdkConnection.includeRuleIds,
+        hashSecureAttributes: sdkConnection.hashSecureAttributes,
+        savedGroupReferencesEnabled: sdkConnection.savedGroupReferencesEnabled,
+      });
+
+      filteredFeatures = features.filter(
+        (feature) => feature.id in payload.features
+      );
+    }
+
     // TODO: Move sorting/limiting to the database query for better performance
     const { filtered, returnFields } = applyPagination(
-      features.sort(
+      filteredFeatures.sort(
         (a, b) => a.dateCreated.getTime() - b.dateCreated.getTime()
       ),
       req.query
     );
+
     //get all feature ids and there version
     const revisions = await getFeatureRevisionsByFeaturesCurrentVersion(
       req.context,

--- a/packages/back-end/src/api/features/listFeatures.ts
+++ b/packages/back-end/src/api/features/listFeatures.ts
@@ -31,7 +31,10 @@ export const listFeatures = createApiRequestHandler(listFeaturesValidator)(
     let filteredFeatures = features;
     if (req.query.clientKey) {
       const sdkConnection = await findSDKConnectionByKey(req.query.clientKey);
-      if (!sdkConnection || sdkConnection.organization !== req.organization) {
+      if (
+        !sdkConnection ||
+        sdkConnection.organization !== req.organization.id
+      ) {
         throw new Error("Invalid SDK connection key");
       }
 

--- a/packages/back-end/src/api/features/listFeatures.ts
+++ b/packages/back-end/src/api/features/listFeatures.ts
@@ -31,7 +31,7 @@ export const listFeatures = createApiRequestHandler(listFeaturesValidator)(
     let filteredFeatures = features;
     if (req.query.clientKey) {
       const sdkConnection = await findSDKConnectionByKey(req.query.clientKey);
-      if (!sdkConnection) {
+      if (!sdkConnection || sdkConnection.organization !== req.organization) {
         throw new Error("Invalid SDK connection key");
       }
 
@@ -40,15 +40,10 @@ export const listFeatures = createApiRequestHandler(listFeaturesValidator)(
         capabilities: getConnectionSDKCapabilities(sdkConnection),
         environment: sdkConnection.environment,
         projects: sdkConnection.projects,
-        encryptionKey: sdkConnection.encryptPayload
-          ? sdkConnection.encryptionKey
-          : "",
         includeVisualExperiments: sdkConnection.includeVisualExperiments,
         includeDraftExperiments: sdkConnection.includeDraftExperiments,
         includeExperimentNames: sdkConnection.includeExperimentNames,
         includeRedirectExperiments: sdkConnection.includeRedirectExperiments,
-        includeRuleIds: sdkConnection.includeRuleIds,
-        hashSecureAttributes: sdkConnection.hashSecureAttributes,
         savedGroupReferencesEnabled: sdkConnection.savedGroupReferencesEnabled,
       });
 

--- a/packages/back-end/src/api/openapi/parameters.yaml
+++ b/packages/back-end/src/api/openapi/parameters.yaml
@@ -90,3 +90,9 @@ globalRole:
   description: Name of the global role
   schema:
     type: string
+clientKey:
+  name: clientKey
+  in: query
+  description: Optionally filter features by a SDK connection's client key
+  schema:
+    type: string

--- a/packages/back-end/src/api/openapi/parameters.yaml
+++ b/packages/back-end/src/api/openapi/parameters.yaml
@@ -65,7 +65,7 @@ branch:
 platform:
   name: platform
   in: query
-  description: Name of versino control platform like GitHub or Gitlab.
+  description: Name of version control platform like GitHub or Gitlab.
   schema:
     type: string
     enum:
@@ -93,6 +93,6 @@ globalRole:
 clientKey:
   name: clientKey
   in: query
-  description: Optionally filter features by a SDK connection's client key
+  description: Filter by a SDK connection's client key
   schema:
     type: string

--- a/packages/back-end/src/api/openapi/paths/listFeatures.yaml
+++ b/packages/back-end/src/api/openapi/paths/listFeatures.yaml
@@ -5,6 +5,7 @@ parameters:
   - $ref: "../parameters.yaml#/limit"
   - $ref: "../parameters.yaml#/offset"
   - $ref: "../parameters.yaml#/projectId"
+  - $ref: "../parameters.yaml#/clientKey"
 operationId: listFeatures
 x-codeSamples:
   - lang: "cURL"

--- a/packages/back-end/src/validators/openapi.ts
+++ b/packages/back-end/src/validators/openapi.ts
@@ -76,7 +76,7 @@ export const apiArchetypeValidator = z.object({ "id": z.string(), "dateCreated":
 
 export const listFeaturesValidator = {
   bodySchema: z.never(),
-  querySchema: z.object({ "limit": z.coerce.number().int().default(10), "offset": z.coerce.number().int().default(0), "projectId": z.string().optional() }).strict(),
+  querySchema: z.object({ "limit": z.coerce.number().int().default(10), "offset": z.coerce.number().int().default(0), "projectId": z.string().optional(), "clientKey": z.string().optional() }).strict(),
   paramsSchema: z.never(),
 };
 

--- a/packages/back-end/types/openapi.d.ts
+++ b/packages/back-end/types/openapi.d.ts
@@ -2264,7 +2264,7 @@ export interface components {
     repo: string;
     /** @description Name of branch for git repo. */
     branch: string;
-    /** @description Name of versino control platform like GitHub or Gitlab. */
+    /** @description Name of version control platform like GitHub or Gitlab. */
     platform: "github" | "gitlab" | "bitbucket";
     /** @description Name of the user. */
     userName: string;
@@ -2272,7 +2272,7 @@ export interface components {
     userEmail: string;
     /** @description Name of the global role */
     globalRole: string;
-    /** @description Optionally filter features by a SDK connection's client key */
+    /** @description Filter by a SDK connection's client key */
     clientKey: string;
   };
   requestBodies: never;
@@ -2290,7 +2290,7 @@ export interface operations {
         /** @description The number of items to return */
         /** @description How many items to skip (use in conjunction with limit for pagination) */
         /** @description Filter by project id */
-        /** @description Optionally filter features by a SDK connection's client key */
+        /** @description Filter by a SDK connection's client key */
       query: {
         limit?: number;
         offset?: number;

--- a/packages/back-end/types/openapi.d.ts
+++ b/packages/back-end/types/openapi.d.ts
@@ -2272,6 +2272,8 @@ export interface components {
     userEmail: string;
     /** @description Name of the global role */
     globalRole: string;
+    /** @description Optionally filter features by a SDK connection's client key */
+    clientKey: string;
   };
   requestBodies: never;
   headers: never;
@@ -2288,10 +2290,12 @@ export interface operations {
         /** @description The number of items to return */
         /** @description How many items to skip (use in conjunction with limit for pagination) */
         /** @description Filter by project id */
+        /** @description Optionally filter features by a SDK connection's client key */
       query: {
         limit?: number;
         offset?: number;
         projectId?: string;
+        clientKey?: string;
       };
     };
     responses: {


### PR DESCRIPTION
Pass in an optional `?clientKey=sdk-abc123` to filter responses by what is in the SDK payload. Useful for 3rd party integrations like Vercel's flag explorer toolbar