### PR TITLE
[fix] Reordering project-scoped environments is unpredictable

### DIFF
--- a/packages/back-end/src/routers/environment/environment.controller.ts
+++ b/packages/back-end/src/routers/environment/environment.controller.ts
@@ -48,7 +48,7 @@ export const putEnvironmentOrder = async (
 ) => {
   const context = getContextFromReq(req);
   const { org } = context;
-  const { envId, direction } = req.body;
+  const { envId, newIndex } = req.body;
   const existingEnvs = org.settings?.environments;
 
   if (!existingEnvs) {
@@ -77,16 +77,15 @@ export const putEnvironmentOrder = async (
   }
 
   const updatedEnvs = [...existingEnvs];
-  const newEnvIndex = envIndex + direction;
 
-  if (newEnvIndex < 0 || newEnvIndex >= existingEnvs.length) {
+  if (newIndex < 0 || newIndex >= existingEnvs.length) {
     return res.status(400).json({
       status: 400,
-      message: `Invalid direction: ${direction}`,
+      message: `Invalid new index: ${newIndex}`,
     });
   }
   updatedEnvs.splice(envIndex, 1);
-  updatedEnvs.splice(newEnvIndex, 0, updatedEnvs[envIndex]);
+  updatedEnvs.splice(newIndex, 0, updatedEnvs[envIndex]);
 
   try {
     await updateOrganization(org.id, {

--- a/packages/back-end/src/routers/environment/environment.controller.ts
+++ b/packages/back-end/src/routers/environment/environment.controller.ts
@@ -85,7 +85,7 @@ export const putEnvironmentOrder = async (
     });
   }
   updatedEnvs.splice(envIndex, 1);
-  updatedEnvs.splice(newIndex, 0, updatedEnvs[envIndex]);
+  updatedEnvs.splice(newIndex, 0, existingEnvs[envIndex]);
 
   try {
     await updateOrganization(org.id, {

--- a/packages/back-end/src/routers/environment/environment.validators.ts
+++ b/packages/back-end/src/routers/environment/environment.validators.ts
@@ -2,7 +2,8 @@ import z from "zod";
 
 export const updateEnvOrderValidator = z
   .object({
-    environments: z.array(z.string()),
+    envId: z.string(),
+    direction: z.number(),
   })
   .strict();
 

--- a/packages/back-end/src/routers/environment/environment.validators.ts
+++ b/packages/back-end/src/routers/environment/environment.validators.ts
@@ -3,7 +3,7 @@ import z from "zod";
 export const updateEnvOrderValidator = z
   .object({
     envId: z.string(),
-    direction: z.number(),
+    newIndex: z.number(),
   })
   .strict();
 

--- a/packages/front-end/pages/environments.tsx
+++ b/packages/front-end/pages/environments.tsx
@@ -207,13 +207,11 @@ const EnvironmentsPage: FC = () => {
                               color=""
                               className="dropdown-item"
                               onClick={async () => {
-                                const newEnvs = [...environments];
-                                newEnvs.splice(i, 1);
-                                newEnvs.splice(i - 1, 0, e);
                                 await apiCall(`/environment/order`, {
                                   method: "PUT",
                                   body: JSON.stringify({
-                                    environments: newEnvs.map((env) => env.id),
+                                    envId: e.id,
+                                    direction: 1,
                                   }),
                                 });
                                 refreshOrganization();
@@ -227,13 +225,11 @@ const EnvironmentsPage: FC = () => {
                               color=""
                               className="dropdown-item"
                               onClick={async () => {
-                                const newEnvs = [...environments];
-                                newEnvs.splice(i, 1);
-                                newEnvs.splice(i + 1, 0, e);
                                 await apiCall(`/environment/order`, {
                                   method: "PUT",
                                   body: JSON.stringify({
-                                    environments: newEnvs.map((env) => env.id),
+                                    envId: e.id,
+                                    direction: -1,
                                   }),
                                 });
                                 refreshOrganization();

--- a/packages/front-end/pages/environments.tsx
+++ b/packages/front-end/pages/environments.tsx
@@ -207,11 +207,14 @@ const EnvironmentsPage: FC = () => {
                               color=""
                               className="dropdown-item"
                               onClick={async () => {
+                                const newIndex = environments.findIndex(
+                                  (env) => env.id === e.id
+                                );
                                 await apiCall(`/environment/order`, {
                                   method: "PUT",
                                   body: JSON.stringify({
                                     envId: e.id,
-                                    direction: 1,
+                                    newIndex: newIndex - 1,
                                   }),
                                 });
                                 refreshOrganization();
@@ -225,11 +228,14 @@ const EnvironmentsPage: FC = () => {
                               color=""
                               className="dropdown-item"
                               onClick={async () => {
+                                const index = environments.findIndex(
+                                  (env) => env.id === e.id
+                                );
                                 await apiCall(`/environment/order`, {
                                   method: "PUT",
                                   body: JSON.stringify({
                                     envId: e.id,
-                                    direction: -1,
+                                    newIndex: index + 1,
                                   }),
                                 });
                                 refreshOrganization();

--- a/packages/front-end/pages/environments.tsx
+++ b/packages/front-end/pages/environments.tsx
@@ -220,7 +220,7 @@ const EnvironmentsPage: FC = () => {
                               Move up
                             </OldButton>
                           )}
-                          {i < environments.length - 1 && (
+                          {i < filteredEnvironments.length - 1 && (
                             <OldButton
                               color=""
                               className="dropdown-item"

--- a/packages/front-end/pages/environments.tsx
+++ b/packages/front-end/pages/environments.tsx
@@ -207,14 +207,11 @@ const EnvironmentsPage: FC = () => {
                               color=""
                               className="dropdown-item"
                               onClick={async () => {
-                                const newIndex = environments.findIndex(
-                                  (env) => env.id === e.id
-                                );
                                 await apiCall(`/environment/order`, {
                                   method: "PUT",
                                   body: JSON.stringify({
                                     envId: e.id,
-                                    newIndex: newIndex - 1,
+                                    newIndex: i - 1, // this is the filteredEnvironments index  we are moving it on
                                   }),
                                 });
                                 refreshOrganization();
@@ -228,14 +225,11 @@ const EnvironmentsPage: FC = () => {
                               color=""
                               className="dropdown-item"
                               onClick={async () => {
-                                const index = environments.findIndex(
-                                  (env) => env.id === e.id
-                                );
                                 await apiCall(`/environment/order`, {
                                   method: "PUT",
                                   body: JSON.stringify({
                                     envId: e.id,
-                                    newIndex: index + 1,
+                                    newIndex: i + 1, // this is the filteredEnvironments index  we are moving it on
                                   }),
                                 });
                                 refreshOrganization();

--- a/packages/front-end/pages/environments.tsx
+++ b/packages/front-end/pages/environments.tsx
@@ -207,11 +207,15 @@ const EnvironmentsPage: FC = () => {
                               color=""
                               className="dropdown-item"
                               onClick={async () => {
+                                const targetEnv = filteredEnvironments[i - 1];
+                                const newIndex = environments.findIndex(
+                                  (env) => targetEnv.id === env.id
+                                );
                                 await apiCall(`/environment/order`, {
                                   method: "PUT",
                                   body: JSON.stringify({
                                     envId: e.id,
-                                    newIndex: i - 1, // this is the filteredEnvironments index  we are moving it on
+                                    newIndex, // this is the filteredEnvironments index  we are moving it on
                                   }),
                                 });
                                 refreshOrganization();
@@ -225,11 +229,15 @@ const EnvironmentsPage: FC = () => {
                               color=""
                               className="dropdown-item"
                               onClick={async () => {
+                                const targetEnv = filteredEnvironments[i + 1];
+                                const newIndex = environments.findIndex(
+                                  (env) => targetEnv.id === env.id
+                                );
                                 await apiCall(`/environment/order`, {
                                   method: "PUT",
                                   body: JSON.stringify({
                                     envId: e.id,
-                                    newIndex: i + 1, // this is the filteredEnvironments index  we are moving it on
+                                    newIndex, // this is the filteredEnvironments index  we are moving it on
                                   }),
                                 });
                                 refreshOrganization();


### PR DESCRIPTION
### Features and Changes

When re-ordering environments, the local array index within the UI was being used instead of the global index in the organization's full environment list.  Normally, these are identical so there are no issues, but if some environments are project-scoped AND the UI is filtered to a single project, the array indexes could get out of sync.

Out-of-sync indexes could cause one of three potential bugs (depending on multiple factors):
- Duplicate environment ids
- Deleted environment ids
- Incorrect ordering

Luckily, all of these outcomes are fully reversible without data loss (even a deleted environment can just be recreated with the same name and it picks up where it left off).  However, this bug can cause serious disruption to an organization's work flow.

This PR fixes the root problem of mismatched indexes and adds multiple safety nets to avoid similar issues in the future.  Even if another front-end bug with indexes is introduced in the future (hopefully not!), the back-end will now reject the request if something doesn't look right.