### PR TITLE
Support any random string as secret.

### DIFF
--- a/packages/back-end/src/events/handlers/webhooks/EventWebHookNotifier.ts
+++ b/packages/back-end/src/events/handlers/webhooks/EventWebHookNotifier.ts
@@ -21,6 +21,7 @@ import { getLegacyMessageForNotificationEvent } from "back-end/src/events/handle
 import { LegacyNotificationEvent } from "back-end/src/events/notification-events";
 import { NotificationEventName } from "back-end/types/event";
 import { getContextForAgendaJobByOrgObject } from "back-end/src/services/organizations";
+import { SecretsReplacer } from "back-end/src/util/secrets";
 import {
   EventWebHookErrorResult,
   EventWebHookResult,
@@ -214,7 +215,7 @@ export class EventWebHookNotifier implements Notifier {
     payload: DataType;
     eventWebHook: EventWebHookInterface;
     method: EventWebHookMethod;
-    applySecrets: (s: string) => string;
+    applySecrets: SecretsReplacer;
   }): Promise<EventWebHookResult> {
     const requestTimeout = 30000;
     const maxContentSize = 1000;
@@ -231,7 +232,7 @@ export class EventWebHookNotifier implements Notifier {
         applySecrets(url),
         {
           headers: {
-            ...JSON.parse(applySecrets(JSON.stringify(headers))),
+            ...applySecrets(headers),
             "Content-Type": "application/json",
             "User-Agent": "GrowthBook Webhook",
             "X-GrowthBook-Signature": signature,

--- a/packages/back-end/src/events/handlers/webhooks/EventWebHookNotifier.ts
+++ b/packages/back-end/src/events/handlers/webhooks/EventWebHookNotifier.ts
@@ -229,7 +229,7 @@ export class EventWebHookNotifier implements Notifier {
       });
 
       const result = await cancellableFetch(
-        applySecrets(url),
+        applySecrets(url, { encode: encodeURIComponent }),
         {
           headers: {
             ...applySecrets(headers),

--- a/packages/back-end/src/jobs/sdkWebhooks.ts
+++ b/packages/back-end/src/jobs/sdkWebhooks.ts
@@ -247,7 +247,7 @@ async function runWebhookFetch({
     let customHeaders: Record<string, string> | undefined;
     if (headers) {
       try {
-        customHeaders = JSON.parse(applySecrets(headers));
+        customHeaders = applySecrets(JSON.parse(headers));
       } catch (error) {
         throw new Error("Failed to parse custom headers: " + error.message);
       }

--- a/packages/back-end/src/jobs/sdkWebhooks.ts
+++ b/packages/back-end/src/jobs/sdkWebhooks.ts
@@ -254,7 +254,7 @@ async function runWebhookFetch({
     }
 
     res = await cancellableFetch(
-      applySecrets(url),
+      applySecrets(url, { encode: encodeURIComponent }),
       {
         headers: {
           ...customHeaders,

--- a/packages/back-end/src/models/WebhookSecretModel.ts
+++ b/packages/back-end/src/models/WebhookSecretModel.ts
@@ -4,6 +4,7 @@ import {
   WebhookSecretFrontEndInterface,
   webhookSecretSchema,
 } from "back-end/src/validators/webhook-secrets";
+import { secretsReplacer } from "back-end/src/util/secrets";
 import { MakeModelClass } from "./BaseModel";
 
 const BaseClass = MakeModelClass({
@@ -47,18 +48,21 @@ export class WebhookSecretDataModel extends BaseClass {
     });
   }
 
-  public async getBackEndSecretsReplacer(): Promise<(s: string) => string> {
+  public async getBackEndSecretsReplacer() {
     const secrets = await this.getAll();
     const replacements: Record<string, string> = {};
     for (const secret of secrets) {
       replacements[secret.key] = secret.value;
     }
-    return (s) => {
+
+    const stringReplacer = (s: string) => {
       const template = Handlebars.compile(s, {
         noEscape: true,
         strict: true,
       });
       return template(replacements);
     };
+
+    return secretsReplacer(stringReplacer);
   }
 }

--- a/packages/back-end/src/models/WebhookSecretModel.ts
+++ b/packages/back-end/src/models/WebhookSecretModel.ts
@@ -1,5 +1,4 @@
 import { omit } from "lodash";
-import Handlebars from "handlebars";
 import {
   WebhookSecretFrontEndInterface,
   webhookSecretSchema,
@@ -55,14 +54,6 @@ export class WebhookSecretDataModel extends BaseClass {
       replacements[secret.key] = secret.value;
     }
 
-    const stringReplacer = (s: string) => {
-      const template = Handlebars.compile(s, {
-        noEscape: true,
-        strict: true,
-      });
-      return template(replacements);
-    };
-
-    return secretsReplacer(stringReplacer);
+    return secretsReplacer(replacements);
   }
 }

--- a/packages/back-end/src/util/secrets.ts
+++ b/packages/back-end/src/util/secrets.ts
@@ -1,4 +1,5 @@
 import fs from "fs";
+import Handlebars from "handlebars";
 import dotenv from "dotenv";
 import trimEnd from "lodash/trimEnd";
 import { stringToBoolean } from "shared/util";
@@ -272,14 +273,35 @@ export const CLICKHOUSE_DATABASE = process.env.CLICKHOUSE_DATABASE || "";
 export const CLICKHOUSE_MAIN_TABLE = process.env.CLICKHOUSE_MAIN_TABLE || "";
 
 export type SecretsReplacer = <T extends string | Record<string, string>>(
-  s: T
+  s: T,
+  options?: {
+    encode?: (s: string) => string;
+  }
 ) => T;
 
 export const secretsReplacer = (
-  stringReplacer: (_: string) => string
+  secrets: Record<string, string>
 ): SecretsReplacer => {
-  return <T extends string | Record<string, string>>(s: T): T => {
-    if (typeof s === "string") return stringReplacer(s) as T;
+  return ((s, options) => {
+    const encode = options?.encode || ((s: string) => s);
+
+    const encodedSecrets = Object.keys(secrets).reduce<Record<string, string>>(
+      (encoded, key) => ({
+        ...encoded,
+        [key]: encode(secrets[key]),
+      }),
+      {}
+    );
+
+    const stringReplacer = (s: string) => {
+      const template = Handlebars.compile(s, {
+        noEscape: true,
+        strict: true,
+      });
+      return template(encodedSecrets);
+    };
+
+    if (typeof s === "string") return stringReplacer(s);
 
     return Object.keys(s).reduce<Record<string, string>>(
       (obj, key) => ({
@@ -287,6 +309,6 @@ export const secretsReplacer = (
         [stringReplacer(key)]: stringReplacer(s[key]),
       }),
       {}
-    ) as T;
-  };
+    );
+  }) as SecretsReplacer;
 };

--- a/packages/back-end/src/util/secrets.ts
+++ b/packages/back-end/src/util/secrets.ts
@@ -270,3 +270,23 @@ export const CLICKHOUSE_ADMIN_PASSWORD =
   process.env.CLICKHOUSE_ADMIN_PASSWORD || "";
 export const CLICKHOUSE_DATABASE = process.env.CLICKHOUSE_DATABASE || "";
 export const CLICKHOUSE_MAIN_TABLE = process.env.CLICKHOUSE_MAIN_TABLE || "";
+
+export type SecretsReplacer = <T extends string | Record<string, string>>(
+  s: T
+) => T;
+
+export const secretsReplacer = (
+  stringReplacer: (_: string) => string
+): SecretsReplacer => {
+  return <T extends string | Record<string, string>>(s: T): T => {
+    if (typeof s === "string") return stringReplacer(s) as T;
+
+    return Object.keys(s).reduce<Record<string, string>>(
+      (obj, key) => ({
+        ...obj,
+        [stringReplacer(key)]: stringReplacer(s[key]),
+      }),
+      {}
+    ) as T;
+  };
+};

--- a/packages/back-end/test/events/EventWebHookNotifier.test.ts
+++ b/packages/back-end/test/events/EventWebHookNotifier.test.ts
@@ -1,6 +1,7 @@
 import { EventWebHookNotifier } from "back-end/src/events/handlers/webhooks/EventWebHookNotifier";
 import { getEventWebHookSignatureForPayload } from "back-end/src/events/handlers/webhooks/event-webhooks-utils";
 import { cancellableFetch } from "back-end/src/util/http.util";
+import { secretsReplacer } from "back-end/src/util/secrets";
 
 jest.mock("back-end/src/events/handlers/webhooks/event-webhooks-utils", () => ({
   getEventWebHookSignatureForPayload: jest.fn(),
@@ -10,7 +11,7 @@ jest.mock("back-end/src/util/http.util", () => ({
   cancellableFetch: jest.fn(),
 }));
 
-const applySecrets = (s: string) => s;
+const applySecrets = secretsReplacer((s: string) => s);
 
 describe("EventWebHookNotifier", () => {
   beforeEach(() => {
@@ -186,7 +187,9 @@ describe("EventWebHookNotifier", () => {
         signingKey: "the signing key",
       },
       method: "POST",
-      applySecrets: (s) => s.replace("{{secret}}", "my-secret"),
+      applySecrets: secretsReplacer((s) =>
+        s.replace("{{secret}}", "my-secret")
+      ),
     });
     expect(result).toEqual({
       responseBody: "the response body",
@@ -202,6 +205,46 @@ describe("EventWebHookNotifier", () => {
           "User-Agent": "GrowthBook Webhook",
           "X-GrowthBook-Signature": "some-signature",
           foo: "barmy-secret",
+        },
+        method: "POST",
+      },
+      { maxContentSize: 1000, maxTimeMs: 30000 }
+    );
+  });
+
+  it("supports custom headers with secrets containing quotation marks", async () => {
+    getEventWebHookSignatureForPayload.mockReturnValueOnce("some-signature");
+    cancellableFetch.mockReturnValueOnce({
+      responseWithoutBody: { ok: true, status: "all's good" },
+      stringBody: "the response body",
+    });
+
+    const result = await EventWebHookNotifier.sendDataToWebHook({
+      payload: "the payload",
+      eventWebHook: {
+        url: "http://foo.com/bla?secret={{secret}}",
+        headers: { foo: "bar{{secret}}" },
+        signingKey: "the signing key",
+      },
+      method: "POST",
+      applySecrets: secretsReplacer((s) =>
+        s.replace("{{secret}}", 'my "secret"')
+      ),
+    });
+    expect(result).toEqual({
+      responseBody: "the response body",
+      result: "success",
+      statusCode: "all's good",
+    });
+    expect(cancellableFetch).toHaveBeenCalledWith(
+      'http://foo.com/bla?secret=my "secret"',
+      {
+        body: '"the payload"',
+        headers: {
+          "Content-Type": "application/json",
+          "User-Agent": "GrowthBook Webhook",
+          "X-GrowthBook-Signature": "some-signature",
+          foo: 'barmy "secret"',
         },
         method: "POST",
       },

--- a/packages/back-end/test/events/EventWebHookNotifier.test.ts
+++ b/packages/back-end/test/events/EventWebHookNotifier.test.ts
@@ -11,7 +11,7 @@ jest.mock("back-end/src/util/http.util", () => ({
   cancellableFetch: jest.fn(),
 }));
 
-const applySecrets = secretsReplacer((s: string) => s);
+const applySecrets = secretsReplacer({});
 
 describe("EventWebHookNotifier", () => {
   beforeEach(() => {
@@ -187,9 +187,7 @@ describe("EventWebHookNotifier", () => {
         signingKey: "the signing key",
       },
       method: "POST",
-      applySecrets: secretsReplacer((s) =>
-        s.replace("{{secret}}", "my-secret")
-      ),
+      applySecrets: secretsReplacer({ secret: "my-secret" }),
     });
     expect(result).toEqual({
       responseBody: "the response body",
@@ -227,9 +225,7 @@ describe("EventWebHookNotifier", () => {
         signingKey: "the signing key",
       },
       method: "POST",
-      applySecrets: secretsReplacer((s) =>
-        s.replace("{{secret}}", 'my "secret"')
-      ),
+      applySecrets: secretsReplacer({ secret: 'my "secret"' }),
     });
     expect(result).toEqual({
       responseBody: "the response body",
@@ -237,7 +233,7 @@ describe("EventWebHookNotifier", () => {
       statusCode: "all's good",
     });
     expect(cancellableFetch).toHaveBeenCalledWith(
-      'http://foo.com/bla?secret=my "secret"',
+      "http://foo.com/bla?secret=my%20%22secret%22",
       {
         body: '"the payload"',
         headers: {


### PR DESCRIPTION
Given that secrets are meant to contain any random string, we should make sure that we support `"` in secrets.

This PR expands the previous one by making the secret replace support either `string` or `Record<string, string>`.

In the latter case, the replacement is done at the object level.