### PR TITLE
Move feature revision logs to their own model

### DIFF
--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -2495,7 +2495,7 @@ export async function getRevisionLog(
     }
   );
 
-  // Then we merge them.  The front end will sort them as needed
+  // We merge old logs on revisions with revisionLogs. The front end will sort them as needed
   const log = [...(revision.log || []), ...revisionLogs];
 
   res.json({

--- a/packages/back-end/src/enterprise/saferollouts/safeRolloutUtils.ts
+++ b/packages/back-end/src/enterprise/saferollouts/safeRolloutUtils.ts
@@ -108,6 +108,7 @@ export async function checkAndRollbackSafeRollout({
       org: context.org,
     });
     await editFeatureRule(
+      context,
       revision,
       updatedSafeRollout.environment,
       ruleIndex,

--- a/packages/back-end/src/models/BaseModel.ts
+++ b/packages/back-end/src/models/BaseModel.ts
@@ -260,6 +260,11 @@ export abstract class BaseModel<
       keys.metric = metric;
     }
 
+    const feature = this.detectForeignKey(doc, ["feature", "featureId"]);
+    if (feature) {
+      keys.feature = feature;
+    }
+
     return keys;
   }
 

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -357,6 +357,7 @@ export async function deleteFeature(
     id: feature.id,
   });
   await deleteAllRevisionsForFeature(context.org.id, feature.id);
+  await context.models.featureRevisionLogs.deleteAllByFeature(feature);
 
   if (feature.linkedExperiments) {
     await Promise.all(

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -750,6 +750,7 @@ export async function toggleFeatureEnvironment(
 }
 
 export async function addFeatureRule(
+  context: ReqContext | ApiReqContext,
   revision: FeatureRevisionInterface,
   env: string,
   rule: FeatureRule,
@@ -767,6 +768,7 @@ export async function addFeatureRule(
   changes.rules[env] = changes.rules[env] || [];
   changes.rules[env].push(rule);
   await updateRevision(
+    context,
     revision,
     changes,
     {
@@ -780,6 +782,7 @@ export async function addFeatureRule(
 }
 
 export async function editFeatureRule(
+  context: ReqContext | ApiReqContext,
   revision: FeatureRevisionInterface,
   environment: string,
   i: number,
@@ -799,6 +802,7 @@ export async function editFeatureRule(
     ...updates,
   } as FeatureRule;
   await updateRevision(
+    context,
     revision,
     changes,
     {
@@ -812,6 +816,7 @@ export async function editFeatureRule(
 }
 
 export async function copyFeatureEnvironmentRules(
+  context: ReqContext | ApiReqContext,
   revision: FeatureRevisionInterface,
   sourceEnv: string,
   targetEnv: string,
@@ -824,6 +829,7 @@ export async function copyFeatureEnvironmentRules(
   };
   changes.rules[targetEnv] = changes.rules[sourceEnv] || [];
   await updateRevision(
+    context,
     revision,
     changes,
     {
@@ -885,12 +891,14 @@ export async function removeProjectFromFeatures(
 }
 
 export async function setDefaultValue(
+  context: ReqContext | ApiReqContext,
   revision: FeatureRevisionInterface,
   defaultValue: string,
   user: EventUser,
   requireReview: boolean
 ) {
   await updateRevision(
+    context,
     revision,
     { defaultValue },
     {
@@ -1041,7 +1049,7 @@ export async function publishRevision(
     result
   );
 
-  await markRevisionAsPublished(revision, context.auditUser, comment);
+  await markRevisionAsPublished(context, revision, context.auditUser, comment);
 
   return updatedFeature;
 }

--- a/packages/back-end/src/models/FeatureRevisionLogModel.ts
+++ b/packages/back-end/src/models/FeatureRevisionLogModel.ts
@@ -1,4 +1,7 @@
-import { featureRevisionLogValidator } from "back-end/src/validators/feature-revision-log";
+import {
+  FeatureRevisionLogInterface,
+  featureRevisionLogValidator,
+} from "back-end/src/validators/feature-revision-log";
 import { MakeModelClass } from "./BaseModel";
 
 export const COLLECTION_NAME = "featurerevisionlog";
@@ -25,18 +28,43 @@ const BaseClass = MakeModelClass({
 });
 
 export class FeatureRevisionLogModel extends BaseClass {
-  // TODO: fix permissions
-  protected canRead() {
-    return true;
+  protected canRead(doc: FeatureRevisionLogInterface): boolean {
+    const { feature } = this.getForeignRefs(doc);
+
+    return this.context.permissions.canReadSingleProjectResource(
+      feature?.project
+    );
   }
-  protected canCreate() {
-    return true;
+  protected canCreate(doc: FeatureRevisionLogInterface): boolean {
+    const { feature } = this.getForeignRefs(doc);
+    if (!feature) {
+      throw new Error("Feature not found for FeatureRevisionLog");
+    }
+    return (
+      this.context.permissions.canCreateFeature(feature) ||
+      this.context.permissions.canManageFeatureDrafts(feature)
+    );
   }
-  protected canUpdate() {
-    return true;
+  protected canUpdate(existing: FeatureRevisionLogInterface): boolean {
+    const { feature } = this.getForeignRefs(existing);
+    if (!feature) {
+      throw new Error("Feature not found for FeatureRevisionLog");
+    }
+    return (
+      this.context.permissions.canUpdateFeature(feature, {}) ||
+      this.context.permissions.canManageFeatureDrafts(feature)
+    );
   }
-  protected canDelete() {
-    return true;
+
+  protected canDelete(doc: FeatureRevisionLogInterface): boolean {
+    const { feature } = this.getForeignRefs(doc);
+    if (!feature) {
+      throw new Error("Feature not found for FeatureRevisionLog");
+    }
+    return (
+      this.context.permissions.canDeleteFeature(feature) ||
+      this.context.permissions.canManageFeatureDrafts(feature)
+    );
   }
 
   public async getAllByFeatureIdAndVersion({

--- a/packages/back-end/src/models/FeatureRevisionLogModel.ts
+++ b/packages/back-end/src/models/FeatureRevisionLogModel.ts
@@ -1,0 +1,54 @@
+import { featureRevisionLogValidator } from "back-end/src/validators/feature-revision-log";
+import { MakeModelClass } from "./BaseModel";
+
+export const COLLECTION_NAME = "featurerevisionlog";
+
+const BaseClass = MakeModelClass({
+  schema: featureRevisionLogValidator,
+  collectionName: COLLECTION_NAME,
+  idPrefix: "frl_",
+  auditLog: {
+    entity: "featureRevisionLog",
+    createEvent: "featureRevisionLog.create",
+    updateEvent: "featureRevisionLog.update",
+    deleteEvent: "featureRevisionLog.delete",
+  },
+  globallyUniqueIds: true,
+  additionalIndexes: [
+    {
+      fields: {
+        featureId: 1,
+        version: 1,
+      },
+    },
+  ],
+});
+
+export class FeatureRevisionLogModel extends BaseClass {
+  // TODO: fix permissions
+  protected canRead() {
+    return true;
+  }
+  protected canCreate() {
+    return true;
+  }
+  protected canUpdate() {
+    return true;
+  }
+  protected canDelete() {
+    return true;
+  }
+
+  public async getAllByFeatureIdAndVersion({
+    featureId,
+    version,
+  }: {
+    featureId: string;
+    version: number;
+  }) {
+    return await this._find(
+      { featureId, version },
+      { sort: { timestamp: -1 } }
+    );
+  }
+}

--- a/packages/back-end/src/models/FeatureRevisionLogModel.ts
+++ b/packages/back-end/src/models/FeatureRevisionLogModel.ts
@@ -46,9 +46,6 @@ export class FeatureRevisionLogModel extends BaseClass {
     featureId: string;
     version: number;
   }) {
-    return await this._find(
-      { featureId, version },
-      { sort: { timestamp: -1 } }
-    );
+    return await this._find({ featureId, version });
   }
 }

--- a/packages/back-end/src/models/FeatureRevisionModel.ts
+++ b/packages/back-end/src/models/FeatureRevisionModel.ts
@@ -273,18 +273,6 @@ export async function createRevision({
     }
   });
 
-  const log: RevisionLog = {
-    action: "new revision",
-    subject: `based on revision #${baseVersion || feature.version}`,
-    timestamp: new Date(),
-    user,
-    value: JSON.stringify({
-      status: publish ? "published" : "draft",
-      comment: comment || "",
-      defaultValue,
-      rules,
-    }),
-  };
   if (!baseVersion) baseVersion = lastRevision?.version;
   const baseRevision =
     lastRevision?.version === baseVersion
@@ -314,7 +302,6 @@ export async function createRevision({
     comment: comment || "",
     defaultValue,
     rules,
-    log: [log],
   } as FeatureRevisionInterface;
   const requiresReview = checkIfRevisionNeedsReview({
     feature,
@@ -332,6 +319,25 @@ export async function createRevision({
   }
 
   const doc = await FeatureRevisionModel.create(revision);
+
+  // Fire and forget - no route that creates the revision expects the log to be there immediately
+  context.models.featureRevisionLogs
+    .create({
+      featureId: revision.featureId,
+      version: revision.version,
+      action: "new revision",
+      subject: `based on revision #${baseVersion || feature.version}`,
+      user,
+      value: JSON.stringify({
+        status: publish ? "published" : "draft",
+        comment: comment || "",
+        defaultValue,
+        rules,
+      }),
+    })
+    .catch((e) => {
+      logger.error("Error creating revisionlog", e);
+    });
 
   return toInterface(doc, context);
 }
@@ -382,17 +388,16 @@ export async function updateRevision(
     }
   );
 
-  try {
-    // Fire and forget - no route that updates the revision expects the log to be there immediately
-    context.models.featureRevisionLogs.create({
+  // Fire and forget - no route that updates the revision expects the log to be there immediately
+  context.models.featureRevisionLogs
+    .create({
       ...log,
       featureId: revision.featureId,
       version: revision.version,
-      timestamp: new Date(),
+    })
+    .catch((e) => {
+      logger.error("Error creating revisionlog", e);
     });
-  } catch (e) {
-    logger.error("Error creating revisionlog", e);
-  }
 }
 
 export async function markRevisionAsPublished(
@@ -421,20 +426,19 @@ export async function markRevisionAsPublished(
     }
   );
 
-  try {
-    // Fire and forget - no route that marks the revision as published expects the log to be there immediately
-    context.models.featureRevisionLogs.create({
+  // Fire and forget - no route that marks the revision as published expects the log to be there immediately
+  context.models.featureRevisionLogs
+    .create({
       featureId: revision.featureId,
       version: revision.version,
       action,
       subject: "",
-      timestamp: new Date(),
       user,
       value: JSON.stringify(comment ? { comment } : {}),
+    })
+    .catch((e) => {
+      logger.error("Error creating revisionlog", e);
     });
-  } catch (e) {
-    logger.error("Error creating revisionlog", e);
-  }
 }
 
 export async function markRevisionAsReviewRequested(
@@ -461,20 +465,19 @@ export async function markRevisionAsReviewRequested(
     }
   );
 
-  try {
-    // Fire and forget - no route that marks the revision as Review Requested expects the log to be there immediately
-    context.models.featureRevisionLogs.create({
+  // Fire and forget - no route that marks the revision as Review Requested expects the log to be there immediately
+  context.models.featureRevisionLogs
+    .create({
       featureId: revision.featureId,
       version: revision.version,
       action,
       subject: "",
-      timestamp: new Date(),
       user,
       value: JSON.stringify(comment ? { comment } : {}),
+    })
+    .catch((e) => {
+      logger.error("Error creating revisionlog", e);
     });
-  } catch (e) {
-    logger.error("Error creating revisionlog", e);
-  }
 }
 
 export async function submitReviewAndComments(
@@ -513,20 +516,19 @@ export async function submitReviewAndComments(
     }
   );
 
-  try {
-    // Fire and forget - no route that submits the review and comments expects the log to be there immediately
-    context.models.featureRevisionLogs.create({
+  // Fire and forget - no route that submits the review and comments expects the log to be there immediately
+  context.models.featureRevisionLogs
+    .create({
       featureId: revision.featureId,
       version: revision.version,
       action,
       subject: "",
-      timestamp: new Date(),
       user,
       value: JSON.stringify(comment ? { comment } : {}),
+    })
+    .catch((e) => {
+      logger.error("Error creating revisionlog", e);
     });
-  } catch (e) {
-    logger.error("Error creating revisionlog", e);
-  }
 }
 
 export async function discardRevision(
@@ -549,20 +551,19 @@ export async function discardRevision(
     }
   );
 
-  try {
-    // Fire and forget - no route that discards the revision expects the log to be there immediately
-    context.models.featureRevisionLogs.create({
+  // Fire and forget - no route that discards the revision expects the log to be there immediately
+  context.models.featureRevisionLogs
+    .create({
       featureId: revision.featureId,
       version: revision.version,
       action: "discard",
       subject: "",
-      timestamp: new Date(),
       user,
       value: JSON.stringify({}),
+    })
+    .catch((e) => {
+      logger.error("Error creating revisionlog", e);
     });
-  } catch (e) {
-    logger.error("Error creating revisionlog", e);
-  }
 }
 
 export async function getFeatureRevisionsByFeatureIds(

--- a/packages/back-end/src/models/FeatureRevisionModel.ts
+++ b/packages/back-end/src/models/FeatureRevisionModel.ts
@@ -33,7 +33,6 @@ const featureRevisionSchema = new mongoose.Schema({
     {
       _id: false,
       user: {},
-      approvedBy: {},
       timestamp: Date,
       action: String,
       subject: String,

--- a/packages/back-end/src/services/context.ts
+++ b/packages/back-end/src/services/context.ts
@@ -40,6 +40,7 @@ import { SafeRolloutSnapshotModel } from "back-end/src/models/SafeRolloutSnapsho
 import { DecisionCriteriaModel } from "back-end/src/enterprise/models/DecisionCriteriaModel";
 import { MetricTimeSeriesModel } from "back-end/src/models/MetricTimeSeriesModel";
 import { WebhookSecretDataModel } from "back-end/src/models/WebhookSecretModel";
+import { FeatureRevisionLogModel } from "back-end/src/models/FeatureRevisionLogModel";
 import { getExperimentMetricsByIds } from "./experiments";
 
 export type ForeignRefTypes = {
@@ -53,6 +54,7 @@ export class ReqContextClass {
   public models!: {
     customFields: CustomFieldModel;
     factMetrics: FactMetricModel;
+    featureRevisionLogs: FeatureRevisionLogModel;
     projects: ProjectModel;
     urlRedirects: UrlRedirectModel;
     metricAnalysis: MetricAnalysisModel;
@@ -70,6 +72,7 @@ export class ReqContextClass {
     this.models = {
       customFields: new CustomFieldModel(this),
       factMetrics: new FactMetricModel(this),
+      featureRevisionLogs: new FeatureRevisionLogModel(this),
       projects: new ProjectModel(this),
       urlRedirects: new UrlRedirectModel(this),
       metricAnalysis: new MetricAnalysisModel(this),

--- a/packages/back-end/src/services/context.ts
+++ b/packages/back-end/src/services/context.ts
@@ -41,12 +41,15 @@ import { DecisionCriteriaModel } from "back-end/src/enterprise/models/DecisionCr
 import { MetricTimeSeriesModel } from "back-end/src/models/MetricTimeSeriesModel";
 import { WebhookSecretDataModel } from "back-end/src/models/WebhookSecretModel";
 import { FeatureRevisionLogModel } from "back-end/src/models/FeatureRevisionLogModel";
+import { FeatureInterface } from "back-end/types/feature";
+import { getFeaturesByIds } from "back-end/src/models/FeatureModel";
 import { getExperimentMetricsByIds } from "./experiments";
 
 export type ForeignRefTypes = {
   experiment: ExperimentInterface;
   datasource: DataSourceInterface;
   metric: ExperimentMetricInterface;
+  feature: FeatureInterface;
 };
 
 export class ReqContextClass {
@@ -233,11 +236,13 @@ export class ReqContextClass {
     experiment: new Map(),
     datasource: new Map(),
     metric: new Map(),
+    feature: new Map(),
   };
   public async populateForeignRefs({
     experiment,
     datasource,
     metric,
+    feature,
   }: ForeignRefsCacheKeys) {
     await this.addMissingForeignRefs("experiment", experiment, (ids) =>
       getExperimentsByIds(this, ids)
@@ -248,6 +253,9 @@ export class ReqContextClass {
     );
     await this.addMissingForeignRefs("metric", metric, (ids) =>
       getExperimentMetricsByIds(this, ids)
+    );
+    await this.addMissingForeignRefs("feature", feature, (ids) =>
+      getFeaturesByIds(this, ids)
     );
   }
   private async addMissingForeignRefs<K extends keyof ForeignRefsCache>(

--- a/packages/back-end/src/types/Audit.ts
+++ b/packages/back-end/src/types/Audit.ts
@@ -32,6 +32,7 @@ export const entityEvents = {
     "archive",
     "delete",
   ],
+  featureRevisionLog: ["create", "update", "delete"],
   urlRedirect: ["create", "update", "delete"],
   metric: ["autocreate", "create", "update", "delete", "analysis"],
   metricAnalysis: ["create", "update", "delete"],

--- a/packages/back-end/src/validators/feature-revision-log.ts
+++ b/packages/back-end/src/validators/feature-revision-log.ts
@@ -8,7 +8,6 @@ export const featureRevisionLog = z
     version: z.number(),
     user: eventUser,
     approvedBy: eventUser.optional(),
-    timestamp: z.date(),
     action: z.string(),
     subject: z.string(),
     value: z.string(),

--- a/packages/back-end/src/validators/feature-revision-log.ts
+++ b/packages/back-end/src/validators/feature-revision-log.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+import { baseSchema } from "back-end/src/models/BaseModel";
+import { eventUser } from "./events";
+
+export const featureRevisionLog = z
+  .object({
+    featureId: z.string(),
+    version: z.number(),
+    user: eventUser,
+    approvedBy: eventUser.optional(),
+    timestamp: z.date(),
+    action: z.string(),
+    subject: z.string(),
+    value: z.string(),
+  })
+  .strict();
+
+export const featureRevisionLogValidator = baseSchema
+  .extend(featureRevisionLog.shape)
+  .strict();
+
+export type FeatureRevisionLogInterface = z.infer<
+  typeof featureRevisionLogValidator
+>;

--- a/packages/back-end/src/validators/feature-revision-log.ts
+++ b/packages/back-end/src/validators/feature-revision-log.ts
@@ -7,7 +7,6 @@ export const featureRevisionLog = z
     featureId: z.string(),
     version: z.number(),
     user: eventUser,
-    approvedBy: eventUser.optional(),
     action: z.string(),
     subject: z.string(),
     value: z.string(),

--- a/packages/back-end/src/validators/features.ts
+++ b/packages/back-end/src/validators/features.ts
@@ -193,7 +193,6 @@ export const JSONSchemaDef = z
 const revisionLog = z
   .object({
     user: eventUser,
-    approvedBy: eventUser.optional(),
     timestamp: z.date(),
     action: z.string(),
     subject: z.string(),

--- a/packages/back-end/src/validators/features.ts
+++ b/packages/back-end/src/validators/features.ts
@@ -228,7 +228,7 @@ const featureRevisionInterface = z
     ]),
     defaultValue: z.string(),
     rules: revisionRulesSchema,
-    log: z.array(revisionLog).optional(),
+    log: z.array(revisionLog).optional(), // This is deprecated in favor of using FeatureRevisionLog due to it being too large
   })
   .strict();
 


### PR DESCRIPTION
### Features and Changes
Feature Revision logs can be up to 10 times the size of the rest of the revision.   This creates the danger of revisions becoming larger than the maximum document size for Mongo.  So this moves future revision logs over to their own model.  Revision.log is filtered out from most queries and are only sent when specifically loading the logs.  Since this is a rare event, and it will be even rarer to do it for old versions we won't bother moving over old revision.logs to the new model.

### Testing
On main branch.
Load a feature.
Make changes.
View logs.
Change to this branch.
Make changes.
View logs.
See that the logs are the merged `revision.log` and `FeatureRevisionLogModels`.
Check Mongo to see that the `FeatureRevision` has the old logs and `FeatureRevisionLogModels` have the new logs.
