### PR TITLE
Allow restricting webhook secrets by origin

### DIFF
--- a/docs/docs/webhooks/overview.mdx
+++ b/docs/docs/webhooks/overview.mdx
@@ -74,6 +74,10 @@ https://api.example.com/webhook?secret={{SECRET_TOKEN}}
 
 The secret value will be swapped in right before sending the request and will never be visible within the GrowthBook UI or logs.
 
+### Restricted Origins
+
+For better security, you can restrict the origins where a webhook secret can be used. When enabled, the secret will only be available for webhooks where the destination URL matches one of the allowed origins.
+
 ## Notable Mentions
 
 Less common or soon-to-be-deprecated webhooks:

--- a/packages/back-end/src/events/handlers/webhooks/EventWebHookNotifier.ts
+++ b/packages/back-end/src/events/handlers/webhooks/EventWebHookNotifier.ts
@@ -166,7 +166,11 @@ export class EventWebHookNotifier implements Notifier {
 
     const context = getContextForAgendaJobByOrgObject(organization);
 
-    const applySecrets = await context.models.webhookSecrets.getBackEndSecretsReplacer();
+    const origin = new URL(eventWebHook.url).origin;
+
+    const applySecrets = await context.models.webhookSecrets.getBackEndSecretsReplacer(
+      origin
+    );
 
     const webHookResult = await EventWebHookNotifier.sendDataToWebHook({
       payload,

--- a/packages/back-end/src/jobs/sdkWebhooks.ts
+++ b/packages/back-end/src/jobs/sdkWebhooks.ts
@@ -242,7 +242,10 @@ async function runWebhookFetch({
   let res: CancellableFetchReturn | undefined = undefined;
 
   try {
-    const applySecrets = await context.models.webhookSecrets.getBackEndSecretsReplacer();
+    const origin = new URL(url).origin;
+    const applySecrets = await context.models.webhookSecrets.getBackEndSecretsReplacer(
+      origin
+    );
 
     let customHeaders: Record<string, string> | undefined;
     if (headers) {

--- a/packages/back-end/src/models/WebhookSecretModel.ts
+++ b/packages/back-end/src/models/WebhookSecretModel.ts
@@ -47,11 +47,17 @@ export class WebhookSecretDataModel extends BaseClass {
     });
   }
 
-  public async getBackEndSecretsReplacer() {
+  public async getBackEndSecretsReplacer(origin: string) {
     const secrets = await this.getAll();
     const replacements: Record<string, string> = {};
     for (const secret of secrets) {
-      replacements[secret.key] = secret.value;
+      if (
+        !secret.allowedOrigins ||
+        !secret.allowedOrigins.length ||
+        secret.allowedOrigins.includes(origin)
+      ) {
+        replacements[secret.key] = secret.value;
+      }
     }
 
     return secretsReplacer(replacements);

--- a/packages/back-end/src/validators/webhook-secrets.ts
+++ b/packages/back-end/src/validators/webhook-secrets.ts
@@ -9,6 +9,7 @@ export const webhookSecretSchema = z
     dateUpdated: z.date(),
     key: z.string(),
     value: z.string(),
+    allowedOrigins: z.array(z.string()).optional(),
     description: z.string().optional(),
   })
   .strict();

--- a/packages/front-end/components/EventWebHooks/WebhookSecretModal.tsx
+++ b/packages/front-end/components/EventWebHooks/WebhookSecretModal.tsx
@@ -40,6 +40,7 @@ export default function WebhookSecretModal({
         if (existingId) {
           const body: UpdateWebhookSecretProps = {
             description: data.description,
+            allowedOrigins: data.allowedOrigins,
           };
           // Don't update the value if it's empty
           if (data.value) {

--- a/packages/front-end/components/EventWebHooks/WebhookSecretModal.tsx
+++ b/packages/front-end/components/EventWebHooks/WebhookSecretModal.tsx
@@ -37,6 +37,21 @@ export default function WebhookSecretModal({
       trackingEventModalType={`webhook_secret_${existingId ? "edit" : "add"}`}
       header={existingId ? "Edit Secret" : "Add Secret"}
       submit={form.handleSubmit(async (data) => {
+        // Validation for allowed origins
+        if (data.allowedOrigins?.length) {
+          if (!data.allowedOrigins.every((o) => o.startsWith("http"))) {
+            throw new Error("All origins must start with http or https");
+          }
+
+          // Make sure all origins are valid and normalized
+          data.allowedOrigins = data.allowedOrigins.map(
+            (origin) => new URL(origin).origin
+          );
+
+          // Remove duplicates
+          data.allowedOrigins = [...new Set(data.allowedOrigins)];
+        }
+
         if (existingId) {
           const body: UpdateWebhookSecretProps = {
             description: data.description,

--- a/packages/front-end/components/EventWebHooks/WebhookSecretModal.tsx
+++ b/packages/front-end/components/EventWebHooks/WebhookSecretModal.tsx
@@ -4,6 +4,7 @@ import Modal from "@/components/Modal";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import Field from "@/components/Forms/Field";
 import { useAuth } from "@/services/auth";
+import StringArrayField from "../Forms/StringArrayField";
 
 export default function WebhookSecretModal({
   existingId,
@@ -24,6 +25,7 @@ export default function WebhookSecretModal({
     defaultValues: {
       key: existing?.key || "",
       description: existing?.description || "",
+      allowedOrigins: existing?.allowedOrigins || [],
       value: "",
     },
   });
@@ -78,6 +80,12 @@ export default function WebhookSecretModal({
         label="Description"
         textarea
         placeholder="(optional)"
+      />
+      <StringArrayField
+        value={form.watch("allowedOrigins")}
+        onChange={(value) => form.setValue("allowedOrigins", value)}
+        label="Restrict to Specific Origins"
+        helpText="Only allow using this secret in requests to the specified origins. Leave empty for no origin restrictions."
       />
     </Modal>
   );

--- a/packages/front-end/pages/settings/webhooks/index.tsx
+++ b/packages/front-end/pages/settings/webhooks/index.tsx
@@ -52,6 +52,7 @@ const WebhooksPage: FC = () => {
               <tr>
                 <th>Key</th>
                 <th>Description</th>
+                <th>Allowed Origins</th>
                 <th>Created</th>
                 <th>Updated</th>
                 <th></th>
@@ -64,6 +65,13 @@ const WebhooksPage: FC = () => {
                     <ClickToCopy>{secret.key}</ClickToCopy>
                   </td>
                   <td>{secret.description}</td>
+                  <td>
+                    {secret.allowedOrigins?.length ? (
+                      secret.allowedOrigins.join(", ")
+                    ) : (
+                      <em>Any</em>
+                    )}
+                  </td>
                   <td>{datetime(secret.dateCreated)}</td>
                   <td>{datetime(secret.dateUpdated)}</td>
                   <td>


### PR DESCRIPTION
### Features and Changes

Webhook secrets are never revealed in the GrowthBook app, but it's still possible for any user in the organization to reveal them by adding a new webhook to a server they control (or something local like ngrok).  Then, they just need to fire a test event and inspect the request headers as it is received.

This PR lets you specify an allowlist of webhook origins for each secret.  When configured, the secret can only be used when sent to one of these origins.

![image](https://github.com/user-attachments/assets/fa4682f4-1638-4c5d-be6e-d66e69024c29)