### PR TITLE
Add fact metric audit history to fact metric page

### DIFF
--- a/packages/front-end/pages/fact-metrics/[fmid].tsx
+++ b/packages/front-end/pages/fact-metrics/[fmid].tsx
@@ -54,6 +54,7 @@ import DataList, { DataListItem } from "@/components/Radix/DataList";
 import useOrgSettings from "@/hooks/useOrgSettings";
 import { AppFeatures } from "@/types/app-features";
 import { useCurrency } from "@/hooks/useCurrency";
+import HistoryTable from "@/components/HistoryTable";
 
 function FactTableLink({ id }: { id?: string }) {
   const { getFactTableById } = useDefinitions();
@@ -876,6 +877,7 @@ export default function FactMetricPage() {
               Bandits
             </TabsTrigger>
           )}
+          <TabsTrigger value="history">History</TabsTrigger>
         </TabsList>
 
         <TabsContent value="analysis">
@@ -897,6 +899,14 @@ export default function FactMetricPage() {
             <MetricExperiments metric={factMetric} bandits={true} />
           </TabsContent>
         )}
+
+        <TabsContent value="history">
+          <div className="appbox p-3 mb-3">
+            <div className="mt-1" style={{ maxHeight: 800, overflowY: "auto" }}>
+              <HistoryTable type="metric" id={factMetric.id} />
+            </div>
+          </div>
+        </TabsContent>
       </Tabs>
     </div>
   );

--- a/packages/front-end/pages/fact-metrics/[fmid].tsx
+++ b/packages/front-end/pages/fact-metrics/[fmid].tsx
@@ -61,7 +61,6 @@ import {
   DropdownMenuItem,
   DropdownMenuSeparator,
 } from "@/components/Radix/DropdownMenu";
-import ConfirmModal from "@/components/ConfirmModal";
 
 function FactTableLink({ id }: { id?: string }) {
   const { getFactTableById } = useDefinitions();
@@ -380,14 +379,14 @@ export default function FactMetricPage() {
         </Modal>
       )}
       {showDeleteModal && (
-        <ConfirmModal
-          title="Delete Metric"
-          subtitle="Are you sure you want to delete this metric? This action cannot be undone."
-          yesText="Delete"
-          noText="Cancel"
-          modalState={showDeleteModal}
-          setModalState={setShowDeleteModal}
-          onConfirm={async () => {
+        <Modal
+          trackingEventModalType=""
+          header={`Delete Metric`}
+          close={() => setShowDeleteModal(false)}
+          open={true}
+          cta="Delete"
+          submitColor="danger"
+          submit={async () => {
             await apiCall(`/fact-metrics/${factMetric.id}`, {
               method: "DELETE",
             });
@@ -395,7 +394,14 @@ export default function FactMetricPage() {
             setShowDeleteModal(false);
             router.push("/metrics");
           }}
-        />
+          ctaEnabled={canDelete}
+          increasedElevation={true}
+        >
+          <p>
+            Are you sure you want to delete this metric? This action cannot be
+            undone.
+          </p>
+        </Modal>
       )}
       {editOpen !== "closed" && (
         <FactMetricModal


### PR DESCRIPTION
Adds audit history as a modal you can open from the fact metric dropdown (similar to experiments and features) and uses radix + styling/ordering similar to the experiment dropdown for consistency.

<img width="657" alt="Screenshot 2025-06-03 at 12 02 39 PM" src="https://github.com/user-attachments/assets/a347efbb-aeba-418d-a69e-44dbadf69b9b" />
<img width="311" alt="Screenshot 2025-06-03 at 12 02 36 PM" src="https://github.com/user-attachments/assets/0455d82c-d424-4d6b-9ae3-7ff47f2de3f1" />
