### PR TITLE
When creating feature from experiment, use control as defaultValue

### DIFF
--- a/packages/front-end/services/features.ts
+++ b/packages/front-end/services/features.ts
@@ -489,7 +489,7 @@ export function useAttributeSchema(
 
 export function validateFeatureRule(
   rule: FeatureRule,
-  feature: FeatureInterface
+  feature: Pick<FeatureInterface, "valueType" | "jsonSchema">
 ): null | FeatureRule {
   let hasChanges = false;
   const ruleCopy = cloneDeep(rule);

--- a/packages/shared/src/util/features.ts
+++ b/packages/shared/src/util/features.ts
@@ -32,7 +32,7 @@ export const DRAFT_REVISION_STATUSES = [
   "pending-review",
 ];
 
-export function getValidation(feature: FeatureInterface) {
+export function getValidation(feature: Pick<FeatureInterface, "jsonSchema">) {
   try {
     if (!feature?.jsonSchema) {
       return {
@@ -100,7 +100,7 @@ export function getJSONValidator() {
 export function validateJSONFeatureValue(
   // eslint-disable-next-line
   value: any,
-  feature: FeatureInterface
+  feature: Pick<FeatureInterface, "jsonSchema">
 ) {
   const { jsonSchema, validationEnabled } = getValidation(feature);
   if (!validationEnabled) {
@@ -154,7 +154,7 @@ export function validateJSONFeatureValue(
 }
 
 export function validateFeatureValue(
-  feature: FeatureInterface,
+  feature: Pick<FeatureInterface, "valueType" | "jsonSchema">,
   value: string,
   label?: string
 ): string {


### PR DESCRIPTION
### Features and Changes

When creating a new feature flag from an experiment page, here is the existing UI.  The default "fallback" value is `"false"` for string features. 99% of the time, you want it to equal the control value, but with this UI as you edit the control, the fallback value doesn't stay in sync.  This means you either have to copy/paste it or (as happens frequently) forget and then have to go fix it later.

![image](https://github.com/user-attachments/assets/fcd01b14-3d78-4641-b78e-dcbd9dc6f05b)

This PR removes the "fallback" field entirely.  Whatever you enter as the control value will also be used as the default value when creating the feature.  For those super rare cases where you want them to be different, you can easily just edit the feature after and change the default.

This will reduce mistakes and streamline the feature creation flow from experiments.