### PR TITLE
Adds licenseId to licenseModel

### DIFF
--- a/packages/back-end/src/enterprise/models/licenseModel.ts
+++ b/packages/back-end/src/enterprise/models/licenseModel.ts
@@ -23,6 +23,7 @@ const licenseSchema = new mongoose.Schema({
     tooltipText: String, // The text to show in the tooltip
     showAllUsers: Boolean, // True if all users should see the notice rather than just the admins
   },
+  vercelInstallationId: String, // The Vercel installation ID
   orbSubscription: {},
   stripeSubscription: {},
   price: Number, // The price of the license


### PR DESCRIPTION
### Features and Changes

While we had updated the `LicenseInterface` to have the new id field, we didn't update the model, so it wasn't being persisted in Mongo

- Closes **(add link to issue here)**

### Dependencies
 - none

### Testing

- Create a new license with the id field and ensure the growthbook.license collection has the property.

