### PR TITLE
Load only minimal versions of the features.

### DIFF
--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -75,8 +75,9 @@ import {
   createInitialRevision,
   createRevision,
   discardRevision,
+  getMinimalRevisions,
   getRevision,
-  getRevisions,
+  getLatestRevisions,
   getRevisionsByStatus,
   hasDraft,
   markRevisionAsPublished,
@@ -2486,13 +2487,15 @@ export async function getFeatureById(
     throw new Error("Could not find feature");
   }
 
-  let revisions = await getRevisions(context, org.id, id);
+  let minimalRevisions = await getMinimalRevisions(context, org.id, id);
+
+  let fullRevisions = await getLatestRevisions(context, org.id, id);
 
   // The above only fetches the most recent revisions
   // If we're requesting a specific version that's older than that, fetch it directly
   if (req.query.v) {
     const version = parseInt(req.query.v);
-    if (!revisions.some((r) => r.version === version)) {
+    if (!fullRevisions.some((r) => r.version === version)) {
       const revision = await getRevision({
         context,
         organization: org.id,
@@ -2500,13 +2503,13 @@ export async function getFeatureById(
         version,
       });
       if (revision) {
-        revisions.push(revision);
+        fullRevisions.push(revision);
       }
     }
   }
 
   // Make sure we always select the live version, even if it's not one of the most recent revisions
-  if (!revisions.some((r) => r.version === feature.version)) {
+  if (!fullRevisions.some((r) => r.version === feature.version)) {
     const revision = await getRevision({
       context,
       organization: org.id,
@@ -2514,23 +2517,25 @@ export async function getFeatureById(
       version: feature.version,
     });
     if (revision) {
-      revisions.push(revision);
+      fullRevisions.push(revision);
     }
   }
 
   // Historically, we haven't properly cleared revision history when deleting a feature
   // So if you create a feature with the same name as a previously deleted one, it would inherit the revision history
   // This can seriously mess up the feature page, so if we detect any old revisions, delete them
-  if (revisions.some((r) => r.dateCreated < feature.dateCreated)) {
+  if (fullRevisions.some((r) => r.dateCreated < feature.dateCreated)) {
     await cleanUpPreviousRevisions(org.id, feature.id, feature.dateCreated);
-    revisions = revisions.filter((r) => r.dateCreated >= feature.dateCreated);
+    fullRevisions = fullRevisions.filter(
+      (r) => r.dateCreated >= feature.dateCreated
+    );
   }
 
   // If feature doesn't have any revisions, add revision 1 automatically
   // We haven't always created revisions when creating a feature, so this lets us backfill
-  if (!revisions.length) {
+  if (!fullRevisions.length) {
     try {
-      revisions.push(
+      fullRevisions.push(
         await createInitialRevision(
           context,
           feature,
@@ -2549,7 +2554,7 @@ export async function getFeatureById(
   if (feature.legacyDraft) {
     const draft = await migrateDraft(context, feature);
     if (draft) {
-      revisions.push(draft);
+      fullRevisions.push(draft);
     }
   }
 
@@ -2557,7 +2562,7 @@ export async function getFeatureById(
   const experimentIds = new Set<string>();
   const trackingKeys = new Set<string>();
   let hasSafeRollout = false;
-  revisions.forEach((revision) => {
+  fullRevisions.forEach((revision) => {
     environments.forEach((env) => {
       const rules = revision.rules[env];
       if (!rules) return;
@@ -2600,7 +2605,7 @@ export async function getFeatureById(
   }
 
   // Sanity check to make sure the published revision values and rules match what's stored in the feature
-  const live = revisions.find((r) => r.version === feature.version);
+  const live = fullRevisions.find((r) => r.version === feature.version);
   if (live) {
     try {
       if (live.defaultValue !== feature.defaultValue) {
@@ -2630,7 +2635,8 @@ export async function getFeatureById(
   res.status(200).json({
     status: 200,
     feature,
-    revisions,
+    revisionList: minimalRevisions,
+    revisions: fullRevisions,
     experiments: [...experimentsMap.values()],
     safeRollouts: [...safeRolloutMap.values()],
     codeRefs,

--- a/packages/back-end/src/models/FeatureRevisionModel.ts
+++ b/packages/back-end/src/models/FeatureRevisionModel.ts
@@ -10,6 +10,7 @@ import { EventUser, EventUserLoggedIn } from "back-end/src/events/event-types";
 import { OrganizationInterface, ReqContext } from "back-end/types/organization";
 import { ApiReqContext } from "back-end/types/api";
 import { applyEnvironmentInheritance } from "back-end/src/util/features";
+import { MinimalFeatureRevisionInterface } from "back-end/src/validators/features";
 
 export type ReviewSubmittedType = "Comment" | "Approved" | "Requested Changes";
 
@@ -87,7 +88,23 @@ function toInterface(
   return revision;
 }
 
-export async function getRevisions(
+export async function getMinimalRevisions(
+  context: ReqContext | ApiReqContext,
+  organization: string,
+  featureId: string
+): Promise<MinimalFeatureRevisionInterface[]> {
+  const docs: FeatureRevisionDocument[] = await FeatureRevisionModel.find({
+    organization,
+    featureId,
+  })
+    .select("version datePublished dateUpdated createdBy status")
+    .sort({ version: -1 })
+    .limit(25);
+
+  return docs.map((m) => toInterface(m, context));
+}
+
+export async function getLatestRevisions(
   context: ReqContext | ApiReqContext,
   organization: string,
   featureId: string
@@ -98,7 +115,7 @@ export async function getRevisions(
   })
     .select("-log") // Remove the log when fetching all revisions since it can be large to send over the network
     .sort({ version: -1 })
-    .limit(25);
+    .limit(5);
 
   return docs.map((m) => toInterface(m, context));
 }

--- a/packages/back-end/src/validators/features.ts
+++ b/packages/back-end/src/validators/features.ts
@@ -206,18 +206,12 @@ export type RevisionLog = z.infer<typeof revisionLog>;
 const revisionRulesSchema = z.record(z.string(), z.array(featureRule));
 export type RevisionRules = z.infer<typeof revisionRulesSchema>;
 
-const featureRevisionInterface = z
+const minimalFeatureRevisionInterface = z
   .object({
-    featureId: z.string(),
-    organization: z.string(),
-    baseVersion: z.number(),
     version: z.number(),
-    dateCreated: z.date(),
-    dateUpdated: z.date(),
     datePublished: z.union([z.null(), z.date()]),
-    publishedBy: z.union([z.null(), eventUser]),
+    dateUpdated: z.date(),
     createdBy: eventUser,
-    comment: z.string(),
     status: z.enum([
       "draft",
       "published",
@@ -226,6 +220,21 @@ const featureRevisionInterface = z
       "changes-requested",
       "pending-review",
     ]),
+  })
+  .strict();
+
+export type MinimalFeatureRevisionInterface = z.infer<
+  typeof minimalFeatureRevisionInterface
+>;
+
+const featureRevisionInterface = minimalFeatureRevisionInterface
+  .extend({
+    featureId: z.string(),
+    organization: z.string(),
+    baseVersion: z.number(),
+    dateCreated: z.date(),
+    publishedBy: z.union([z.null(), eventUser]),
+    comment: z.string(),
     defaultValue: z.string(),
     rules: revisionRulesSchema,
     log: z.array(revisionLog).optional(),

--- a/packages/back-end/types/feature-revision.d.ts
+++ b/packages/back-end/types/feature-revision.d.ts
@@ -1,4 +1,5 @@
 export {
   RevisionLog,
   FeatureRevisionInterface,
+  MinimalFeatureRevisionInterface,
 } from "back-end/src/validators/features";

--- a/packages/front-end/components/Features/FeaturesOverview.tsx
+++ b/packages/front-end/components/Features/FeaturesOverview.tsx
@@ -28,6 +28,7 @@ import { FeatureUsageLookback } from "back-end/src/types/Integration";
 import { Box, Flex, Heading, Switch, Text } from "@radix-ui/themes";
 import { RxListBullet } from "react-icons/rx";
 import { SafeRolloutInterface } from "back-end/src/validators/safe-rollout";
+import { MinimalFeatureRevisionInterface } from "back-end/src/validators/features";
 import Button from "@/components/Radix/Button";
 import { GBAddCircle, GBEdit } from "@/components/Icons";
 import LoadingOverlay from "@/components/LoadingOverlay";
@@ -86,6 +87,7 @@ export default function FeaturesOverview({
   baseFeature,
   feature,
   revision,
+  revisionList,
   revisions,
   experiments,
   mutate,
@@ -101,6 +103,7 @@ export default function FeaturesOverview({
   baseFeature: FeatureInterface;
   feature: FeatureInterface;
   revision: FeatureRevisionInterface | null;
+  revisionList: MinimalFeatureRevisionInterface[];
   revisions: FeatureRevisionInterface[];
   experiments: ExperimentInterfaceStringDates[] | undefined;
   safeRollouts: SafeRolloutInterface[] | undefined;
@@ -954,7 +957,7 @@ export default function FeaturesOverview({
                       feature={feature}
                       version={currentVersion}
                       setVersion={setVersion}
-                      revisions={revisions || []}
+                      revisions={revisionList || []}
                     />
                   </Box>
                   <Box mx="6">

--- a/packages/front-end/components/Features/RevisionDropdown.tsx
+++ b/packages/front-end/components/Features/RevisionDropdown.tsx
@@ -1,5 +1,5 @@
 import { FeatureInterface } from "back-end/types/feature";
-import { FeatureRevisionInterface } from "back-end/types/feature-revision";
+import { MinimalFeatureRevisionInterface } from "back-end/types/feature-revision";
 import { datetime } from "shared/dates";
 import { Box, Flex, Heading, Text } from "@radix-ui/themes";
 import SelectField from "@/components/Forms/SelectField";
@@ -8,7 +8,7 @@ import Badge from "@/components/Radix/Badge";
 
 export interface Props {
   feature: FeatureInterface;
-  revisions: FeatureRevisionInterface[];
+  revisions: MinimalFeatureRevisionInterface[];
   version: number;
   setVersion: (version: number) => void;
 }


### PR DESCRIPTION
### Features and Changes
Features including their rules and default values can get large.  We had been loading the 25 most recent revisions.  Now we still load 25 revisions, but only the minimal information needed to display the drop down.

We load the past 5 full revisions.  If people select something older than that, we will now make a new request that will include ?v=missing version and then merges that.

Theoretically we only really need to load the most recent version, instead of the most recent 5, as we now lazy load the rest, but to have the best user experience with no waiting for the request to finish for the most common use cases we still load 5.

I don't have a loading spinner when we are fetching more, but just keep displaying the previous revision.  I could add a loading spinner, but since it loads quickly the brief spinner might look a bit janky, so it is probably not worth it.

### Testing

Put in console.logs.
Put in a delay in the fetch endpoint
Make a bunch of versions.
See the we only fetch the most recent 5 on page load.
See that we fetch older revisions once, but not again if re-selected later.

### Screenshots
https://www.loom.com/share/823ec64ebd7345dda97637d7bc92bdbf
