### PR TITLE
Vercel Native Integration Docs

### DIFF
--- a/docs/docs/integrations/vercel.mdx
+++ b/docs/docs/integrations/vercel.mdx
@@ -1,0 +1,43 @@
+---
+title: Vercel Native Integration
+description: Integrate GrowthBook with Vercel to manage feature flags and experiments directly from your Vercel dashboard.
+sidebar_label: Vercel
+unlisted: true
+---
+
+GrowthBook is now available as a Native Integration in Vercel, allowing you to manage feature flags and experiments directly from your Vercel dashboard. This integration also integrates with Edge Config, enabling you to use GrowthBook's SDKs with near-zero latency.
+
+## What's Included
+
+- View all of your feature flags and experiments in Vercel with links to GrowthBook for more details.
+- Login to GrowthBook directly from Vercel without needing to manage separate credentials.
+- Sync your feature flags to Vercel Edge Config to bootstrap our SDKs with near-zero latency.
+- Install into multiple Vercel projects - each one will get their own corresponding team and project in GrowthBook.
+- Seamlessly integrate with Vercel's Flags SDK with zero-configuration - ideal for Next.js applications.
+
+## Installation
+
+Installation is done entirely through the Vercel dashboard:
+
+1. Go to your Vercel dashboard and navigate to the **Integrations** section.
+2. Click on **Browse Marketplace**
+3. Search for "GrowthBook" and select the GrowthBook integration.
+4. Click **Install** and follow the prompts
+
+:::note
+This integration creates a brand new GrowthBook organization and cannot be used to connect to an existing GrowthBook organization.
+:::
+
+## Billing
+
+When configuring the integration, you can choose either our free Starter plan or our Pro plan.
+
+The Pro plan includes a per-seat fee as well as usage-based billing (if you happen to go above our generous free tier). You are only charged for seats for users who log into GrowthBook through Vercel. Users who only ever use the Vercel dashboard to view feature flags and experiments will not be charged for a seat.
+
+When using the Pro plan, you will be billed directly through Vercel. You can manage your billing info, view current usage, download past invoices, and cancel your subscription directly from the Vercel dashboard.
+
+## User Management
+
+Any user in your Vercel team can log into GrowthBook by clicking the "Open in Provider" button in Vercel. This will automatically create a GrowthBook user for them if they don't already have one and grant them the necessary permissions to view feature flags and experiments.
+
+Admins within GrowthBook can manage user roles and permissions, allowing you to control who can create or modify feature flags and experiments. Only the first user who installs the integration will be an admin by default, but you can change this later in GrowthBook settings.

--- a/docs/docs/integrations/vercel.mdx
+++ b/docs/docs/integrations/vercel.mdx
@@ -32,12 +32,18 @@ This integration creates a brand new GrowthBook organization and cannot be used 
 
 When configuring the integration, you can choose either our free Starter plan or our Pro plan.
 
-The Pro plan includes a per-seat fee as well as usage-based billing (if you happen to go above our generous free tier). You are only charged for seats for users who log into GrowthBook through Vercel. Users who only ever use the Vercel dashboard to view feature flags and experiments will not be charged for a seat.
-
 When using the Pro plan, you will be billed directly through Vercel. You can manage your billing info, view current usage, download past invoices, and cancel your subscription directly from the Vercel dashboard.
+
+The Pro plan includes a per-seat fee. You are only charged for members on your team who log into the GrowthBook application. Viewing flags and experiments directly within the Vercel dashboard is always 100% free. If you no longer need a seat (e.g. someone leaves your organization), you can remove them from GrowthBook's settings and they will no longer be charged.
 
 ## User Management
 
 Any user in your Vercel team can log into GrowthBook by clicking the "Open in Provider" button in Vercel. This will automatically create a GrowthBook user for them if they don't already have one and grant them the necessary permissions to view feature flags and experiments.
 
 Admins within GrowthBook can manage user roles and permissions, allowing you to control who can create or modify feature flags and experiments. Only the first user who installs the integration will be an admin by default, but you can change this later in GrowthBook settings.
+
+## Edge Config and SDK Integration
+
+You can optionally enable Edge Config syncing during the installation process. When enabled, GrowthBook will automatically sync your feature flags to Vercel Edge Config.
+
+You can use this Edge Config data with any of our [SDKs](/lib), but the most seamless integration is with Next.js using Vercel's Flags SDK. View the docs for the [Next.js SDK](/lib/nextjs) for more details.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -598,6 +598,14 @@ const sidebars = {
           label: "MCP Server",
           className: "pill-new",
         },
+        /*
+        {
+          type: "doc",
+          id: "integrations/vercel",
+          label: "Vercel",
+          className: "pill-new",
+        },
+        */
         {
           type: "doc",
           id: "integrations/framer",


### PR DESCRIPTION
Add docs for new Vercel Native Integration.  The page will remain unlisted (and not part of the sidebar) until the integration is approved and published by Vercel.