### PR TITLE
Add memory (btye, kB) formatting for fact metrics

### DIFF
--- a/docs/docs/metrics/metrics.mdx
+++ b/docs/docs/metrics/metrics.mdx
@@ -53,7 +53,7 @@ Any column can be used to create filters, but only numeric columns can be used a
 
 #### Number Formats
 
-For numeric columns, you can also specify a number format, which controls how the metric is displayed on the front-end. Possible values are `currency` and `time:seconds`.
+For numeric columns, you can also specify a number format, which controls how the metric is displayed on the front-end. Possible values are `currency`, `time:seconds`, `memory:bytes`, and `memory:kilobytes`.
 
 :::note
 The default display currency is USD, but you can change it under **Settings** → **General** → **Metric Settings**

--- a/packages/back-end/src/routers/fact-table/fact-table.validators.ts
+++ b/packages/back-end/src/routers/fact-table/fact-table.validators.ts
@@ -9,7 +9,13 @@ export const factTableColumnTypeValidator = z.enum([
   "",
 ]);
 
-export const numberFormatValidator = z.enum(["", "currency", "time:seconds"]);
+export const numberFormatValidator = z.enum([
+  "",
+  "currency",
+  "time:seconds",
+  "memory:bytes",
+  "memory:kilobytes",
+]);
 
 export const jsonColumnFieldsValidator = z.record(
   z.object({ datatype: factTableColumnTypeValidator })

--- a/packages/front-end/components/FactTables/ColumnModal.tsx
+++ b/packages/front-end/components/FactTables/ColumnModal.tsx
@@ -201,6 +201,14 @@ export default function ColumnModal({ existing, factTable, close }: Props) {
               label: "Time (seconds)",
               value: "time:seconds",
             },
+            {
+              label: "Memory (bytes)",
+              value: "memory:bytes",
+            },
+            {
+              label: "Memory (kilobytes)",
+              value: "memory:kilobytes",
+            },
           ]}
         />
       )}

--- a/packages/front-end/services/metrics.tsx
+++ b/packages/front-end/services/metrics.tsx
@@ -226,6 +226,50 @@ export function formatDurationSeconds(value: number) {
 
   return f;
 }
+
+export function formatMemoryBytes(value: number) {
+  if (value < 1000 * 1000) {
+    return formatNumber(value, {
+      style: "unit",
+      unit: "byte",
+    });
+  } else if (value < 1000 * 1000 * 1000) {
+    return formatNumber(value / 1000, {
+      style: "unit",
+      unit: "kilobyte",
+    });
+  } else if (value < 1000 * 1000 * 1000 * 1000) {
+    return formatNumber(value / 1000 / 1000, {
+      style: "unit",
+      unit: "megabyte",
+    });
+  } else {
+    return formatNumber(value / 1000 / 1000 / 1000, {
+      style: "unit",
+      unit: "gigabyte",
+    });
+  }
+}
+
+export function formatMemoryKilobytes(value: number) {
+  if (value < 1000 * 1000) {
+    return formatNumber(value, {
+      style: "unit",
+      unit: "kilobyte",
+    });
+  } else if (value < 1000 * 1000 * 1000) {
+    return formatNumber(value / 1000, {
+      style: "unit",
+      unit: "megabyte",
+    });
+  } else {
+    return formatNumber(value / 1000 / 1000, {
+      style: "unit",
+      unit: "gigabyte",
+    });
+  }
+}
+
 export function formatNumber(
   value: number,
   options?: Intl.NumberFormatOptions
@@ -276,6 +320,10 @@ export function getColumnFormatter(
       return formatCurrency;
     case "time:seconds":
       return formatDurationSeconds;
+    case "memory:bytes":
+      return formatMemoryBytes;
+    case "memory:kilobytes":
+      return formatMemoryKilobytes;
   }
 }
 

--- a/packages/front-end/services/metrics.tsx
+++ b/packages/front-end/services/metrics.tsx
@@ -271,7 +271,7 @@ export function formatBytes(value: number) {
 }
 
 export function formatKilobytes(value: number) {
-  return formatByteSizeString(value * 1000, true);
+  return formatByteSizeString(value / 1000, true);
 }
 
 export function getColumnFormatter(

--- a/packages/front-end/services/metrics.tsx
+++ b/packages/front-end/services/metrics.tsx
@@ -271,7 +271,7 @@ export function formatBytes(value: number) {
 }
 
 export function formatKilobytes(value: number) {
-  return formatByteSizeString(value / 1000, true);
+  return formatByteSizeString(value / 1024, true);
 }
 
 export function getColumnFormatter(

--- a/packages/front-end/services/metrics.tsx
+++ b/packages/front-end/services/metrics.tsx
@@ -271,7 +271,7 @@ export function formatBytes(value: number) {
 }
 
 export function formatKilobytes(value: number) {
-  return formatByteSizeString(value / 1024, true);
+  return formatByteSizeString(value * 1024, true);
 }
 
 export function getColumnFormatter(

--- a/packages/front-end/services/metrics.tsx
+++ b/packages/front-end/services/metrics.tsx
@@ -28,6 +28,7 @@ import {
   OrganizationSettings,
 } from "back-end/types/organization";
 import { DataSourceInterfaceWithParams } from "back-end/types/datasource";
+import { formatByteSizeString, getNumberFormatDigits } from "shared/util";
 import { decimalToPercent } from "@/services/utils";
 import { getNewExperimentDatasourceDefaults } from "@/components/Experiment/NewExperimentForm";
 
@@ -227,56 +228,11 @@ export function formatDurationSeconds(value: number) {
   return f;
 }
 
-export function formatMemoryBytes(value: number) {
-  if (value < 1000 * 1000) {
-    return formatNumber(value, {
-      style: "unit",
-      unit: "byte",
-    });
-  } else if (value < 1000 * 1000 * 1000) {
-    return formatNumber(value / 1000, {
-      style: "unit",
-      unit: "kilobyte",
-    });
-  } else if (value < 1000 * 1000 * 1000 * 1000) {
-    return formatNumber(value / 1000 / 1000, {
-      style: "unit",
-      unit: "megabyte",
-    });
-  } else {
-    return formatNumber(value / 1000 / 1000 / 1000, {
-      style: "unit",
-      unit: "gigabyte",
-    });
-  }
-}
-
-export function formatMemoryKilobytes(value: number) {
-  if (value < 1000 * 1000) {
-    return formatNumber(value, {
-      style: "unit",
-      unit: "kilobyte",
-    });
-  } else if (value < 1000 * 1000 * 1000) {
-    return formatNumber(value / 1000, {
-      style: "unit",
-      unit: "megabyte",
-    });
-  } else {
-    return formatNumber(value / 1000 / 1000, {
-      style: "unit",
-      unit: "gigabyte",
-    });
-  }
-}
-
 export function formatNumber(
   value: number,
   options?: Intl.NumberFormatOptions
 ) {
-  const absValue = Math.abs(value);
-  const digits =
-    absValue > 1000 ? 0 : absValue > 100 ? 1 : absValue > 10 ? 2 : 3;
+  const digits = getNumberFormatDigits(value);
   // Show fewer fractional digits for bigger numbers
   const formatter = new Intl.NumberFormat(undefined, {
     maximumFractionDigits: digits,
@@ -310,6 +266,14 @@ export function formatPercentagePoints(value: number) {
   return `${number} pp`;
 }
 
+export function formatBytes(value: number) {
+  return formatByteSizeString(value, true);
+}
+
+export function formatKilobytes(value: number) {
+  return formatByteSizeString(value * 1000, true);
+}
+
 export function getColumnFormatter(
   column: ColumnInterface
 ): (value: number, options?: Intl.NumberFormatOptions) => string {
@@ -321,9 +285,9 @@ export function getColumnFormatter(
     case "time:seconds":
       return formatDurationSeconds;
     case "memory:bytes":
-      return formatMemoryBytes;
+      return formatBytes;
     case "memory:kilobytes":
-      return formatMemoryKilobytes;
+      return formatKilobytes;
   }
 }
 

--- a/packages/shared/src/util/index.ts
+++ b/packages/shared/src/util/index.ts
@@ -341,16 +341,26 @@ export function truncateString(s: string, numChars: number) {
   return s;
 }
 
-export function formatByteSizeString(numBytes: number, decimalPlaces = 1) {
+export function getNumberFormatDigits(value: number) {
+  const absValue = Math.abs(value);
+  const digits =
+    absValue > 1000 ? 0 : absValue > 100 ? 1 : absValue > 10 ? 2 : 3;
+  return digits;
+}
+
+export function formatByteSizeString(numBytes: number, inferDigits = false) {
   if (numBytes == 0) return "0 Bytes";
   const k = 1024,
     sizes = ["Bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"],
     i = Math.floor(Math.log(numBytes) / Math.log(k));
-  return (
-    parseFloat((numBytes / Math.pow(k, i)).toFixed(decimalPlaces)) +
-    " " +
-    sizes[i]
-  );
+  const value = numBytes / Math.pow(k, i);
+
+  const options = {
+    maximumFractionDigits: inferDigits ? getNumberFormatDigits(value) : 1,
+    minimumFractionDigits: 0,
+  };
+
+  return Intl.NumberFormat(undefined, options).format(value) + " " + sizes[i];
 }
 
 export function meanVarianceFromSums(


### PR DESCRIPTION
### Features and Changes

Adds Memory (byte or kilobyte) formatting for fact table columns to improve formatting.

### Testing

Created fact metrics with both formatting and ran them in an analysis.

### Screenshots

<img width="759" alt="Screenshot 2025-06-09 at 4 29 58 PM" src="https://github.com/user-attachments/assets/eb10a59b-3b01-4c36-a008-e38bcaf0e556" />
<img width="645" alt="Screenshot 2025-06-09 at 4 30 01 PM" src="https://github.com/user-attachments/assets/60ac1cb5-bc0f-4668-9a00-808c04914b81" />


<img width="1402" alt="Screenshot 2025-06-09 at 5 07 43 PM" src="https://github.com/user-attachments/assets/df6abc77-702a-4361-89f0-d9b0fd334856" />
<img width="1352" alt="Screenshot 2025-06-09 at 5 08 04 PM" src="https://github.com/user-attachments/assets/f682e603-743c-4401-91d2-91ab7caff978" />
