### PR TITLE
Fix exec dashboard bugs

### DIFF
--- a/packages/front-end/components/ExecReports/ExperimentWinRateByProject.tsx
+++ b/packages/front-end/components/ExecReports/ExperimentWinRateByProject.tsx
@@ -71,6 +71,9 @@ const ExperimentWinRateByProject: React.FC<ExperimentWinRateByProjectProps> = ({
           if (exp.results === "won") {
             allWins += 1;
           }
+          if (exp.results === "lost") {
+            allLosses += 1;
+          }
         }
       }
     });


### PR DESCRIPTION
Fixes two bugs with the new exec dashboard.

1. Ensures impact reloads when `allExperiments` reloads, as determined by the filters.

Before, you would need to refresh to get the impact data to update: https://www.loom.com/share/3239c946a1554a89b60ad5e5e9297b9c

After, it works automatically and dynamically: https://www.loom.com/share/1f4871271d534f1d9e4118cc35324c93

2. Fixes loss count being pushed into "Other" counter for project specific win rate

Before:
<img width="692" alt="Screenshot 2025-06-10 at 10 41 14 AM" src="https://github.com/user-attachments/assets/0e1b6a09-08c3-4311-8245-9208893d027b" />

After:
<img width="712" alt="Screenshot 2025-06-10 at 10 44 10 AM" src="https://github.com/user-attachments/assets/e5c69c37-ed43-45a7-81a5-1527b23e98cb" />
