### PR TITLE
fix(timeseries): Render CI if it exists + Filter out invalid data points

### DIFF
--- a/packages/back-end/src/models/MetricTimeSeriesModel.ts
+++ b/packages/back-end/src/models/MetricTimeSeriesModel.ts
@@ -53,7 +53,7 @@ export class MetricTimeSeriesModel extends BaseClass {
     sourceId: MetricTimeSeries["sourceId"];
     sourcePhase: MetricTimeSeries["sourcePhase"];
     metricIds: Array<MetricTimeSeries["metricId"]>;
-  }) {
+  }): Promise<MetricTimeSeries[]> {
     const query: FilterQuery<MetricTimeSeries> = {
       source,
       sourceId,
@@ -72,7 +72,34 @@ export class MetricTimeSeriesModel extends BaseClass {
       query.sourcePhase = sourcePhase;
     }
 
-    return this._find(query);
+    const results = await this._find(query);
+
+    const filteredResults = results.map((ts) => {
+      const filteredDataPoints = ts.dataPoints.filter((dp) => {
+        if (!dp.variations || dp.variations.length <= 1) return true;
+
+        // Check variations from index 1 onwards (skip control)
+        for (let i = 1; i < dp.variations.length; i++) {
+          const variation = dp.variations[i];
+          if (
+            variation.absolute?.ci &&
+            variation.absolute.ci[0] === 0 &&
+            variation.absolute.ci[1] === 0
+          ) {
+            return false;
+          }
+        }
+
+        return true;
+      });
+
+      return {
+        ...ts,
+        dataPoints: filteredDataPoints,
+      };
+    });
+
+    return filteredResults;
   }
 
   public async deleteAllBySource(

--- a/packages/back-end/src/routers/safe-rollout/safe-rollout.controller.ts
+++ b/packages/back-end/src/routers/safe-rollout/safe-rollout.controller.ts
@@ -253,20 +253,9 @@ export const getSafeRolloutTimeSeries = async (
     }
   );
 
-  // If the rollout variation has a CI of 0,0, remove the data point as it is invalid
-  const filteredTimeSeries = timeSeries.filter((ts) => {
-    return ts.dataPoints.some((dp) => {
-      return (
-        dp.variations[1].absolute?.ci &&
-        dp.variations[1].absolute.ci[0] !== 0 &&
-        dp.variations[1].absolute.ci[1] !== 0
-      );
-    });
-  });
-
   res.status(200).json({
     status: 200,
-    timeSeries: filteredTimeSeries,
+    timeSeries,
   });
 };
 // endregion GET /safe-rollout/:id/time-series

--- a/packages/front-end/components/Experiment/ExperimentTimeSeriesGraph.tsx
+++ b/packages/front-end/components/Experiment/ExperimentTimeSeriesGraph.tsx
@@ -465,6 +465,13 @@ const ExperimentTimeSeriesGraph: FC<ExperimentTimeSeriesGraphProps> = ({
     (it) => it.helperText
   );
 
+  // If any point or variation has a valid CI we should render it
+  const variationsWithCI = useMemo(() => {
+    return variationNames.map((_, i) =>
+      sortedDatesWithData.some((d) => d.variations?.[i]?.ci !== undefined)
+    );
+  }, [sortedDatesWithData, variationNames]);
+
   const hasDataForDay = useMemo(() => {
     const firstDateWithData =
       sortedDatesWithData[lastDataPointIndexWithHelperText + 1].d;
@@ -640,8 +647,7 @@ const ExperimentTimeSeriesGraph: FC<ExperimentTimeSeriesGraphProps> = ({
                     }
                     // Render a shaded area for error bars for each variation if defined
                     return (
-                      typeof sortedDatesWithData[0]?.variations?.[i]?.ci !==
-                        "undefined" && (
+                      variationsWithCI[i] && (
                         <AreaClosed
                           key={`ci_${i}`}
                           yScale={yScale}


### PR DESCRIPTION
### Features and Changes

##### Render CI if it exists

Before we were checking the first data point to make an assumption if we should render or not CI, which is incorrect and we should check if any data point has a valid CI.

##### Filter out invalid data points

Temporary fix to not render data points that do not have a valid value. Ideally this would be done before we save the data point which is the future improvement we will make.
