### PR TITLE
Tweak event-type edit instructions

### DIFF
--- a/docs/docs/metrics/metric-examples.mdx
+++ b/docs/docs/metrics/metric-examples.mdx
@@ -29,7 +29,7 @@ Fact Tables in GrowthBook work really well with raw events. When defining your F
 3. Event Type - What action was performed (page view, start checkout, add friend, etc.)
 4. Context - Any helpful user or app context (geo-location, current url, account plan, etc.)
 
-When creating metrics, you will almost always want to filter on the Event Type. To make this easier, after creating your Fact Table, you can edit that column check the “Prompt all metrics” box. This helps GrowthBook better streamline the UI when creating metrics.
+When creating metrics, you will almost always want to filter on the Event Type. To make this easier, you can edit the column representing Event Type and check the “Prompt all metrics” box (after creating your Fact Table). This helps GrowthBook better streamline the UI when creating metrics.
 
 ![Event Type Filter](/images/metrics/inline-filter.png)
 


### PR DESCRIPTION
A small documentation change: Fix typo and possibly clearer description of "prompt all metrics" for event-type column.
