### PR TITLE
Fix typo in stats documentation

### DIFF
--- a/docs/docs/statistics/details.mdx
+++ b/docs/docs/statistics/details.mdx
@@ -189,7 +189,7 @@ In these cases, we have
 $$
 \begin{align}
 \hat\mu_C &= \frac{\sum^{n_C}_{i=1} {M_{i}}}{\sum^{n_C}_{i=1} {D_{i}}} \\
-\hat\sigma^2_C &= \frac{1}{n_{C}\hat\mu^2_D}\left(\hat\sigma^2_M - 2 \frac{\hat\mu_M}{\hat\mu_D}\hat\sigma_{MD} +  \hat\sigma^2_D\frac{\hat\mu^2_M}{\hat\mu^2_D} \right)
+\hat\sigma^2_C &= \frac{1}{\hat\mu^2_D}\left(\hat\sigma^2_M - 2 \frac{\hat\mu_M}{\hat\mu_D}\hat\sigma_{MD} +  \hat\sigma^2_D\frac{\hat\mu^2_M}{\hat\mu^2_D} \right)
 \end{align}
 $$
 


### PR DESCRIPTION
Fixes a typo (in docs only) in the variance for ratio metrics.

- Closes #4167 