### PR TITLE
Better BigQuery date handling

### DIFF
--- a/packages/back-end/src/integrations/BigQuery.ts
+++ b/packages/back-end/src/integrations/BigQuery.ts
@@ -1,6 +1,5 @@
 import * as bq from "@google-cloud/bigquery";
 import { bigQueryCreateTableOptions } from "shared/enterprise";
-import { getValidDate } from "shared/dates";
 import { FormatDialect } from "shared/src/types";
 import { format } from "shared/sql";
 import { decryptDataSourceParams } from "back-end/src/services/datasource";
@@ -93,6 +92,22 @@ export default class BigQuery extends SqlIntegration {
           ? metadata.statistics.query.totalPartitionsProcessed > 0
           : undefined,
     };
+
+    // BigQuery dates are stored nested in an object, so need to extract the value
+    for (const row of rows) {
+      for (const key in row) {
+        const value = row[key];
+        if (value instanceof bq.BigQueryDatetime) {
+          row[key] = value.value + "Z"; // Convert to ISO date
+        } else if (
+          value instanceof bq.BigQueryTimestamp ||
+          value instanceof bq.BigQueryDate
+        ) {
+          row[key] = value.value; // Already in ISO format
+        }
+      }
+    }
+
     return { rows, statistics };
   }
 
@@ -111,27 +126,6 @@ export default class BigQuery extends SqlIntegration {
     return `DATETIME_${
       sign === "+" ? "ADD" : "SUB"
     }(${col}, INTERVAL ${amount} ${unit.toUpperCase()})`;
-  }
-
-  // BigQueryDateTime: ISO Date string in UTC (Z at end)
-  // BigQueryDatetime: ISO Date string with no timezone
-  // BigQueryDate: YYYY-MM-DD
-  convertDate(
-    fromDB:
-      | bq.BigQueryDatetime
-      | bq.BigQueryTimestamp
-      | bq.BigQueryDate
-      | undefined
-  ) {
-    if (!fromDB?.value) return getValidDate(null);
-
-    // BigQueryTimestamp already has `Z` at the end, but the others don't
-    let value = fromDB.value;
-    if (!value.endsWith("Z")) {
-      value += "Z";
-    }
-
-    return getValidDate(value);
   }
   dateTrunc(col: string) {
     return `date_trunc(${col}, DAY)`;

--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -284,10 +284,6 @@ export default abstract class SqlIntegration
   dateDiff(startCol: string, endCol: string) {
     return `datediff(day, ${startCol}, ${endCol})`;
   }
-  // eslint-disable-next-line
-  convertDate(fromDB: any): Date {
-    return getValidDate(fromDB);
-  }
   formatDate(col: string): string {
     return col;
   }
@@ -490,9 +486,9 @@ export default abstract class SqlIntegration
           variation_id: row.variation_id ?? "",
           variation_name: row.variation_name,
           users: parseInt(row.users) || 0,
-          end_date: this.convertDate(row.end_date).toISOString(),
-          start_date: this.convertDate(row.start_date).toISOString(),
-          latest_data: this.convertDate(row.latest_data).toISOString(),
+          end_date: getValidDate(row.end_date).toISOString(),
+          start_date: getValidDate(row.start_date).toISOString(),
+          latest_data: getValidDate(row.latest_data).toISOString(),
         };
       }),
       statistics: statistics,
@@ -1131,7 +1127,7 @@ export default abstract class SqlIntegration
         } = row;
 
         const ret: MetricAnalysisQueryResponseRow = {
-          date: date ? this.convertDate(date).toISOString() : "",
+          date: date ? getValidDate(date).toISOString() : "",
           data_type: data_type ?? "",
           capped: (capped ?? "uncapped") == "capped",
           units: parseFloat(units) || 0,
@@ -1386,7 +1382,7 @@ export default abstract class SqlIntegration
         const { date, count, main_sum, main_sum_squares } = row;
 
         const ret: MetricValueQueryResponseRow = {
-          date: date ? this.convertDate(date).toISOString() : "",
+          date: date ? getValidDate(date).toISOString() : "",
           count: parseFloat(count) || 0,
           main_sum: parseFloat(main_sum) || 0,
           main_sum_squares: parseFloat(main_sum_squares) || 0,
@@ -1445,7 +1441,7 @@ export default abstract class SqlIntegration
       results.rows.forEach((row) => {
         timestampCols.forEach((col) => {
           if (row[col]) {
-            row[col] = this.convertDate(row[col]);
+            row[col] = getValidDate(row[col]);
           }
         });
       });


### PR DESCRIPTION
### Features and Changes

When selecting date columns in BigQuery from Node.js, custom objects are returned instead of actual date strings.  We had special handling in the code to deal with this, but only for known column names.  So we would fix date values in a column named `timestamp`, but not a column named `other_timestamp`:

![image](https://github.com/user-attachments/assets/9d72cf6b-a5fe-4892-b4eb-ac38d570e541)

This PR changes the logic to automatically look for (and fix) dates across all returned columns of all rows.

![image](https://github.com/user-attachments/assets/873ddd1f-41c1-4f2e-b416-1ae963cd2efe)
