### PR TITLE
Fix for ability to delete users via API

### DIFF
--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -3668,7 +3668,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/id'
       tags:
-        - member
+        - members
       operationId: deleteMember
       x-codeSamples:
         - lang: cURL

--- a/packages/back-end/src/api/openapi/paths/deleteMember.yaml
+++ b/packages/back-end/src/api/openapi/paths/deleteMember.yaml
@@ -2,7 +2,7 @@ summary: Removes a single user from an organization
 parameters:
   - $ref: "../parameters.yaml#/id"
 tags:
-  - member
+  - members
 operationId: deleteMember
 x-codeSamples:
   - lang: "cURL"


### PR DESCRIPTION
### Features and Changes
- The delete member API was already present, but it was not visible in the docs due to the wrong tag in openapi spec.
- Have updated the tag to list it in the members accordion in docs for discoverability.
- Closes #3458 


### Screenshots
![image](https://github.com/user-attachments/assets/73ff132d-1a38-4966-b838-7cd1a802161f)
![image](https://github.com/user-attachments/assets/f297e71d-5beb-4d97-8836-3fcd0714f124)

