### PR TITLE
Show "starter" badge for externally managed orgs with restricted login methods

### DIFF
--- a/packages/back-end/src/enterprise/licenseUtil.ts
+++ b/packages/back-end/src/enterprise/licenseUtil.ts
@@ -73,6 +73,7 @@ type MinimalOrganization = {
   enterprise?: boolean;
   restrictAuthSubPrefix?: string;
   restrictLoginMethod?: string;
+  isVercelIntegration?: boolean;
   subscription?: {
     status: Stripe.Subscription.Status;
   };
@@ -116,6 +117,8 @@ export function getAccountPlan(org: MinimalOrganization): AccountPlan {
     if (org.licenseKey) {
       return getLicense(org.licenseKey)?.plan || "starter";
     }
+    // Vercel starter orgs have the `restrictLoginMethod` set, but they're not pro_sso
+    if (org.isVercelIntegration) return "starter";
     if (org.enterprise) return "enterprise";
     if (org.restrictAuthSubPrefix || org.restrictLoginMethod) return "pro_sso";
     return "starter";


### PR DESCRIPTION
### Features and Changes

This PR fixes a bug where an externally managed cloud org with restricted login methods was getting the `Pro SSO` plan badge in the top nav. 

The code that determines the plan first checks if there is a license key, and if not, then checks if the org has restricted login methods.

Now, before we get to that check, we're looking at if the org is externally managed and if so, returning `starter` instead of of `Pro SSO`.


### Dependencies

- None

### Testing

- [x] Validate that the fix works as expected
