### PR TITLE
fix(timeseries): Accessing undefined index when datapoints do not match current variations

### DIFF
--- a/packages/front-end/components/Experiment/ExperimentTimeSeriesGraph.tsx
+++ b/packages/front-end/components/Experiment/ExperimentTimeSeriesGraph.tsx
@@ -42,7 +42,7 @@ export interface DataPointVariation {
 
 export interface ExperimentTimeSeriesGraphDataPoint {
   d: Date;
-  variations?: DataPointVariation[]; // undefined === missing date
+  variations?: Array<DataPointVariation | null>; // undefined === missing date, null === variation not present
   helperText?: string;
 }
 
@@ -89,8 +89,8 @@ const getTooltipContents = (
 ) => {
   const { d, yaxis } = data;
 
-  const bayesian = d.variations?.some((v) => v.ctw !== undefined);
-  const frequentist = d.variations?.some((v) => v.p !== undefined);
+  const bayesian = d.variations?.some((v) => v?.ctw !== undefined);
+  const frequentist = d.variations?.some((v) => v?.p !== undefined);
   const usedStatsEngine = bayesian
     ? "bayesian"
     : frequentist
@@ -138,6 +138,7 @@ const getTooltipContents = (
             if (!d.variations) return null;
             if (!showVariations[i]) return null;
             const variation = d.variations[i];
+            if (!variation) return null;
             const variationColor = getVariationColor(i, true);
             return (
               <TableRow
@@ -173,11 +174,9 @@ const getTooltipContents = (
                 </TableRowHeaderCell>
                 {yaxis === "effect" && (
                   <>
+                    <TableCell justify="center">{variation.users}</TableCell>
                     <TableCell justify="center">
-                      {d.variations[i].users}
-                    </TableCell>
-                    <TableCell justify="center">
-                      {d.variations[i].v_formatted}
+                      {variation.v_formatted}
                     </TableCell>
                     <TableCell justify="center">
                       {i > 0 && (
@@ -268,7 +267,7 @@ const getTooltipData = (
   const x = xCoords[closestIndex];
   const y = d.variations
     ? d.variations.map(
-        (variation) => yScale(getYVal(variation, yaxis) ?? 0) ?? 0
+        (variation) => yScale(getYVal(variation ?? undefined, yaxis) ?? 0) ?? 0
       )
     : undefined;
   return { x, y, d, yaxis };
@@ -363,7 +362,7 @@ const ExperimentTimeSeriesGraph: FC<ExperimentTimeSeriesGraphProps> = ({
           ? Math.min(
               ...d.variations
                 .filter((_, i) => showVariations[i])
-                .map((variation) => getYVal(variation, yaxis) ?? 0)
+                .map((variation) => getYVal(variation ?? undefined, yaxis) ?? 0)
             )
           : 0
       )
@@ -374,7 +373,7 @@ const ExperimentTimeSeriesGraph: FC<ExperimentTimeSeriesGraphProps> = ({
           ? Math.max(
               ...d.variations
                 .filter((_, i) => showVariations[i])
-                .map((variation) => getYVal(variation, yaxis) ?? 0)
+                .map((variation) => getYVal(variation ?? undefined, yaxis) ?? 0)
             )
           : 0
       )
@@ -386,9 +385,9 @@ const ExperimentTimeSeriesGraph: FC<ExperimentTimeSeriesGraphProps> = ({
               ...d.variations
                 .filter((_, i) => showVariations[i])
                 .map((variation) =>
-                  variation.ci?.[0]
+                  variation?.ci?.[0]
                     ? variation.ci[0]
-                    : getYVal(variation, yaxis) ?? 0
+                    : getYVal(variation ?? undefined, yaxis) ?? 0
                 )
             )
           : 0
@@ -401,9 +400,9 @@ const ExperimentTimeSeriesGraph: FC<ExperimentTimeSeriesGraphProps> = ({
               ...d.variations
                 .filter((_, i) => showVariations[i])
                 .map((variation) =>
-                  variation.ci?.[1]
+                  variation?.ci?.[1]
                     ? variation.ci[1]
-                    : getYVal(variation, yaxis) ?? 0
+                    : getYVal(variation ?? undefined, yaxis) ?? 0
                 )
             )
           : 0
@@ -419,7 +418,10 @@ const ExperimentTimeSeriesGraph: FC<ExperimentTimeSeriesGraphProps> = ({
           ...lastDataPointWithData.variations
             .filter((_, i) => showVariations[i])
             .map(
-              (variation) => variation.ci?.[0] ?? getYVal(variation, yaxis) ?? 0
+              (variation) =>
+                variation?.ci?.[0] ??
+                getYVal(variation ?? undefined, yaxis) ??
+                0
             )
         )
       : 0;
@@ -429,7 +431,10 @@ const ExperimentTimeSeriesGraph: FC<ExperimentTimeSeriesGraphProps> = ({
           ...lastDataPointWithData.variations
             .filter((_, i) => showVariations[i])
             .map(
-              (variation) => variation.ci?.[1] ?? getYVal(variation, yaxis) ?? 0
+              (variation) =>
+                variation?.ci?.[1] ??
+                getYVal(variation ?? undefined, yaxis) ??
+                0
             )
         )
       : 0;
@@ -522,6 +527,21 @@ const ExperimentTimeSeriesGraph: FC<ExperimentTimeSeriesGraphProps> = ({
             hideTooltip();
             return;
           }
+
+          // Check if there are any non-control variations with data at this specific point
+          const hasNonControlVariations = data.d.variations?.some((v, i) => {
+            if (i === 0) return false; // Skip control for effect axis
+            return showVariations[i] && v !== null && v !== undefined;
+          });
+
+          if (!hasNonControlVariations) {
+            hideTooltip();
+            return;
+          }
+
+          // const validYValues = data.y.filter(
+          //   (v): v is number => v !== undefined
+          // );
           showTooltip({
             tooltipLeft: data.x,
             tooltipTop: Math.max(Math.min(...data.y), 150),
@@ -569,11 +589,12 @@ const ExperimentTimeSeriesGraph: FC<ExperimentTimeSeriesGraphProps> = ({
             >
               {tooltipOpen && (
                 <>
-                  {variationNames.map((v, i) => {
+                  {variationNames.map((variationName, i) => {
                     if (!showVariations[i]) return null;
                     if (yaxis === "effect" && i === 0) {
                       return;
                     }
+                    if (!tooltipData?.d.variations?.[i]) return null;
                     // Render a dot at the current x location for each variation
                     return (
                       <div
@@ -593,18 +614,20 @@ const ExperimentTimeSeriesGraph: FC<ExperimentTimeSeriesGraphProps> = ({
 
               {sortedDatesWithData.map((d) => {
                 // Render a dot at the current x location for each variation
-                return d.variations?.map((v, i) => {
+                return variationNames.map((_, i) => {
                   if (yaxis === "effect" && i === 0) {
                     return;
                   }
                   if (!showVariations[i]) return null;
+                  const variation = d.variations?.[i];
+                  if (!variation) return null;
                   return (
                     <div
                       key={`${d.d.getTime()}_${i}`}
                       className={timeSeriesStyles.positionWithData}
                       style={{
                         transform: `translate(${xScale(d.d)}px, ${
-                          yScale(getYVal(v, yaxis) ?? 0) ?? 0
+                          yScale(getYVal(variation, yaxis) ?? 0) ?? 0
                         }px)`,
                         background: getVariationColor(i, true),
                       }}
@@ -640,25 +663,37 @@ const ExperimentTimeSeriesGraph: FC<ExperimentTimeSeriesGraphProps> = ({
                 />
 
                 <Group clipPath="url(#experiment-date-graph-clip)">
-                  {variationNames.map((v, i) => {
+                  {variationNames.map((_, i) => {
                     if (!showVariations[i]) return null;
                     if (yaxis === "effect" && i === 0) {
                       return <></>;
                     }
-                    // Render a shaded area for error bars for each variation if defined
+
+                    const sortedDataForVariation = sortedDatesWithData
+                      .map((d) => ({
+                        d: d.d,
+                        variation: d.variations?.[i],
+                        helperText: d.helperText,
+                      }))
+                      .filter(
+                        (item) =>
+                          item.variation !== null &&
+                          item.variation !== undefined
+                      );
+
                     return (
                       variationsWithCI[i] && (
                         <AreaClosed
                           key={`ci_${i}`}
                           yScale={yScale}
-                          data={sortedDatesWithData}
+                          data={sortedDataForVariation}
                           x={(d) => xScale(d.d) ?? 0}
-                          y0={(d) =>
-                            yScale(d?.variations?.[i]?.ci?.[0] ?? 0) ?? 0
-                          }
-                          y1={(d) =>
-                            yScale(d?.variations?.[i]?.ci?.[1] ?? 0) ?? 0
-                          }
+                          y0={(d) => {
+                            return yScale(d?.variation?.ci?.[0] ?? 0) ?? 0;
+                          }}
+                          y1={(d) => {
+                            return yScale(d?.variation?.ci?.[1] ?? 0) ?? 0;
+                          }}
                           fill={getVariationColor(i, true)}
                           opacity={0.12}
                           curve={curveMonotoneX}
@@ -675,10 +710,22 @@ const ExperimentTimeSeriesGraph: FC<ExperimentTimeSeriesGraphProps> = ({
 
                     // NB: We include the last index in both arrays as we need
                     // to draw the dashed line to it, and the solid line from it onwards
-                    const previousSettingsDataPoints = sortedDatesWithData.filter(
+                    const sortedDataForVariation = sortedDatesWithData
+                      .map((d) => ({
+                        d: d.d,
+                        variation: d.variations?.[i],
+                        helperText: d.helperText,
+                      }))
+                      .filter(
+                        (item) =>
+                          item.variation !== null &&
+                          item.variation !== undefined
+                      );
+
+                    const previousSettingsDataPoints = sortedDataForVariation.filter(
                       (_, idx) => idx <= lastDataPointIndexWithHelperText
                     );
-                    const currentSettingsDataPoints = sortedDatesWithData.filter(
+                    const currentSettingsDataPoints = sortedDataForVariation.filter(
                       (_, idx) => idx >= lastDataPointIndexWithHelperText
                     );
 
@@ -689,9 +736,11 @@ const ExperimentTimeSeriesGraph: FC<ExperimentTimeSeriesGraphProps> = ({
                           key={`linepath_dashed_${i}`}
                           data={previousSettingsDataPoints}
                           x={(d) => xScale(d.d)}
-                          y={(d) =>
-                            yScale(getYVal(d?.variations?.[i], yaxis) ?? 0)
-                          }
+                          y={(d) => {
+                            return yScale(
+                              getYVal(d.variation ?? undefined, yaxis) ?? 0
+                            );
+                          }}
                           stroke={getVariationColor(i, true)}
                           strokeWidth={2}
                           strokeDasharray={3}
@@ -703,9 +752,11 @@ const ExperimentTimeSeriesGraph: FC<ExperimentTimeSeriesGraphProps> = ({
                           key={`linepath_solid_${i}`}
                           data={currentSettingsDataPoints}
                           x={(d) => xScale(d.d)}
-                          y={(d) =>
-                            yScale(getYVal(d?.variations?.[i], yaxis) ?? 0)
-                          }
+                          y={(d) => {
+                            return yScale(
+                              getYVal(d.variation ?? undefined, yaxis) ?? 0
+                            );
+                          }}
                           stroke={getVariationColor(i, true)}
                           strokeWidth={2}
                           curve={curveLinear}

--- a/packages/front-end/components/Experiment/ResultsTable.tsx
+++ b/packages/front-end/components/Experiment/ResultsTable.tsx
@@ -965,6 +965,9 @@ export default function ResultsTable({
                               experimentStatus={status}
                               metric={row.metric}
                               differenceType={differenceType}
+                              variationNames={orderedVariations.map(
+                                (v) => v.name
+                              )}
                               showVariations={showVariations}
                               statsEngine={statsEngine}
                               pValueAdjustmentEnabled={


### PR DESCRIPTION
Resolves #4137

### Features and Changes

In certain scenarios, adding a new variation after we already had partial data in the MetricTimeSeries would lead to a client-side exception because the code assumed that all datapoints had the same variations, which is not true in this case.

So to fix this we:
- Only render the lines for the variations that are still associated with the Experiment
  - This ensures we only show the data we are already showing in the page, and that the colors also match for the expected variations
- Pre-process the datapoints based on Experiment Variations
- Adjusted rendering to handle missing data (for points and CI shaded area)

### Screenshots

#### Before

Note: This would crash when hovering certain data points

<img width="1043" alt="Screenshot 2025-06-18 at 2 31 59 PM" src="https://github.com/user-attachments/assets/48d093ba-d776-4fe8-a5ff-d9e7ebdf2579" />

#### After

<img width="1045" alt="Screenshot 2025-06-18 at 2 32 17 PM" src="https://github.com/user-attachments/assets/6979fff7-1775-4976-9189-14b6ba88a268" />

