### PR TITLE
Add table with filtering ability to correlations page

### DIFF
--- a/packages/front-end/components/MetricExperiments/MetricExperiments.tsx
+++ b/packages/front-end/components/MetricExperiments/MetricExperiments.tsx
@@ -45,7 +45,7 @@ interface MetricAnalysisProps {
 
 interface Props {
   experimentsWithSnapshot: ExperimentWithSnapshot[];
-  metrics: ExperimentMetricInterface[];
+  metric: ExperimentMetricInterface;
   bandits?: boolean;
   numPerPage?: number;
   differenceType?: DifferenceType;
@@ -79,9 +79,9 @@ export interface MetricExperimentData {
 
 const NUM_PER_PAGE = 50;
 
-export function MetricExperimentResultTab({
+function MetricExperimentResultTab({
   experimentsWithSnapshot,
-  metrics,
+  metric,
   bandits,
   numPerPage = NUM_PER_PAGE,
   differenceType = "relative",

--- a/packages/front-end/enterprise/components/Insights/MetricCorrelations.tsx
+++ b/packages/front-end/enterprise/components/Insights/MetricCorrelations.tsx
@@ -440,7 +440,7 @@ const MetricCorrelationCard = ({
         setMetricData({
           correlationData: newCorrelationData,
         });
-        setFilteredExperiments(filteredExperimentsWithSnapshot);
+        setFilteredExperiments(Object.values(filteredExperimentsWithSnapshot));
       } else {
         setMetricData({
           correlationData: [],


### PR DESCRIPTION
### Features and Changes

Adds a table to the metric correlations table that allows you to select rows to filter down the graph view, saving the excluded experiments in the URL.

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

<!--
  Please describe how to test these changes.
 -->

### Screenshots
https://www.loom.com/share/3d0ce05dfb284ddfb11b203cda60eee4
