### PR TITLE
Do not allow anonymous user tracking by docs widget

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -38,7 +38,7 @@ const config = {
     {
       src: "https://widget.kapa.ai/kapa-widget.bundle.js",
       "data-website-id": "c4406b9f-35c5-43ca-b0c1-e7c0e261831f", // Safe to expose publicly
-      "data-user-analytics-cookie-enabled="false",
+      "data-user-analytics-cookie-enabled": "false",
       "data-project-name": "GrowthBook",
       "data-project-color": "#7817d3",
       "data-modal-example-questions":

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -38,6 +38,7 @@ const config = {
     {
       src: "https://widget.kapa.ai/kapa-widget.bundle.js",
       "data-website-id": "c4406b9f-35c5-43ca-b0c1-e7c0e261831f", // Safe to expose publicly
+      "data-user-analytics-cookie-enabled="false",
       "data-project-name": "GrowthBook",
       "data-project-color": "#7817d3",
       "data-modal-example-questions":


### PR DESCRIPTION
Our AI docs widget service provider is releasing a 1st party cookie to allow their users to track anonymized user behavior. This one-line change will prevent such tracking.