### PR TITLE
fix(bandits): Fix integer division in redshift

### DIFF
--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -3728,7 +3728,7 @@ export default abstract class SqlIntegration
       m.variation AS variation
       , m.dimension AS dimension
       , m.bandit_period AS bandit_period
-      , COUNT(*) AS users
+      , ${this.ensureFloat(`COUNT(*)`)} AS users
       ${metricData
         .map((data) => {
           const alias = data.alias + (factMetrics ? "_" : "");
@@ -3738,8 +3738,12 @@ export default abstract class SqlIntegration
             ? `, MAX(COALESCE(cap.${alias}value_cap, 0)) AS ${alias}main_cap_value`
             : ""
         }
-        , SUM(${data.capCoalesceMetric}) AS ${alias}main_sum
-        , SUM(POWER(${data.capCoalesceMetric}, 2)) AS ${alias}main_sum_squares
+        , ${this.ensureFloat(
+          `SUM(${data.capCoalesceMetric})`
+        )} AS ${alias}main_sum
+        , ${this.ensureFloat(
+          `SUM(POWER(${data.capCoalesceMetric}, 2))`
+        )} AS ${alias}main_sum_squares
         ${
           data.ratioMetric
             ? `
@@ -3749,22 +3753,30 @@ export default abstract class SqlIntegration
               ? `, MAX(COALESCE(capd.${alias}value_cap, 0)) as ${alias}denominator_cap_value`
               : ""
           }
-          , SUM(${data.capCoalesceDenominator}) AS ${alias}denominator_sum
-          , SUM(POWER(${
-            data.capCoalesceDenominator
-          }, 2)) AS ${alias}denominator_sum_squares
-          , SUM(${data.capCoalesceDenominator} * ${
-                data.capCoalesceMetric
-              }) AS ${alias}main_denominator_sum_product
+          , ${this.ensureFloat(
+            `SUM(${data.capCoalesceDenominator})`
+          )} AS ${alias}denominator_sum
+          , ${this.ensureFloat(
+            `SUM(POWER(${data.capCoalesceDenominator}, 2))`
+          )} AS ${alias}denominator_sum_squares
+          , ${this.ensureFloat(
+            `SUM(${data.capCoalesceDenominator} * ${data.capCoalesceMetric})`
+          )} AS ${alias}main_denominator_sum_product
         `
             : ""
         }
         ${
           data.regressionAdjusted
             ? `
-          , SUM(${data.capCoalesceCovariate}) AS ${alias}covariate_sum
-          , SUM(POWER(${data.capCoalesceCovariate}, 2)) AS ${alias}covariate_sum_squares
-          , SUM(${data.capCoalesceMetric} * ${data.capCoalesceCovariate}) AS ${alias}main_covariate_sum_product
+          , ${this.ensureFloat(
+            `SUM(${data.capCoalesceCovariate})`
+          )} AS ${alias}covariate_sum
+          , ${this.ensureFloat(
+            `SUM(POWER(${data.capCoalesceCovariate}, 2))`
+          )} AS ${alias}covariate_sum_squares
+          , ${this.ensureFloat(
+            `SUM(${data.capCoalesceMetric} * ${data.capCoalesceCovariate})`
+          )} AS ${alias}main_covariate_sum_product
           `
             : ""
         }`;
@@ -3802,7 +3814,7 @@ export default abstract class SqlIntegration
   __dimensionTotals AS (
     SELECT
       dimension
-      , SUM(users) AS total_users
+      , ${this.ensureFloat(`SUM(users)`)} AS total_users
     FROM 
       __banditPeriodStatistics
     GROUP BY


### PR DESCRIPTION
### Features and Changes

In Redshift (and possibly others), some divisions in the more complex bandit SQL were using integer division instead of float division, causing issues with the in-SQL weighting approach. This PR fixes that by ensuring all upstream statistics are float instead of integer. 

### Testing

WIP
