### PR TITLE
REST api endpoint for reverting a feature to a specific revision

### DIFF
--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -825,6 +825,44 @@ paths:
                 properties:
                   feature:
                     $ref: '#/components/schemas/Feature'
+  '/features/{id}/revert':
+    parameters:
+      - $ref: '#/components/parameters/id'
+    post:
+      summary: Revert a feature to a specific revision
+      tags:
+        - features
+      operationId: revertFeature
+      x-codeSamples:
+        - lang: cURL
+          source: |
+            curl -X POST https://api.growthbook.io/api/v1/features/my-feature/revert \
+              -d '{ "revision": 3, "comment": "Bug found" }' \
+              -u secret_abc123DEF456:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - revision
+              properties:
+                revision:
+                  type: number
+                comment:
+                  type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - feature
+                properties:
+                  feature:
+                    $ref: '#/components/schemas/Feature'
   /feature-keys:
     get:
       summary: Get list of feature keys

--- a/packages/back-end/src/api/features/features.router.ts
+++ b/packages/back-end/src/api/features/features.router.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { listFeatures } from "./listFeatures";
 import { toggleFeature } from "./toggleFeature";
+import { revertFeature } from "./revertFeature";
 import { getFeature } from "./getFeature";
 import { postFeature } from "./postFeature";
 import { updateFeature } from "./updateFeature";
@@ -16,5 +17,6 @@ router.get("/:id", getFeature);
 router.post("/:id", updateFeature);
 router.delete("/:id", deleteFeatureById);
 router.post("/:id/toggle", toggleFeature);
+router.post("/:id/revert", revertFeature);
 
 export default router;

--- a/packages/back-end/src/api/features/revertFeature.ts
+++ b/packages/back-end/src/api/features/revertFeature.ts
@@ -1,0 +1,131 @@
+import { filterEnvironmentsByFeature, MergeResultChanges } from "shared/util";
+import { isEqual } from "lodash";
+import {
+  getRevision,
+  markRevisionAsPublished,
+} from "back-end/src/models/FeatureRevisionModel";
+import { ToggleFeatureResponse } from "back-end/types/openapi";
+import { getExperimentMapForFeature } from "back-end/src/models/ExperimentModel";
+import {
+  applyRevisionChanges,
+  getFeature,
+} from "back-end/src/models/FeatureModel";
+import { auditDetailsUpdate } from "back-end/src/services/audit";
+import {
+  getApiFeatureObj,
+  getSavedGroupMap,
+} from "back-end/src/services/features";
+import { getEnvironments } from "back-end/src/services/organizations";
+import { createApiRequestHandler } from "back-end/src/util/handler";
+import { revertFeatureValidator } from "back-end/src/validators/openapi";
+import { getEnabledEnvironments } from "back-end/src/util/features";
+
+export const revertFeature = createApiRequestHandler(revertFeatureValidator)(
+  async (req): Promise<ToggleFeatureResponse> => {
+    const context = req.context;
+
+    const feature = await getFeature(context, req.params.id);
+    if (!feature) {
+      throw new Error("Could not find a feature with that key");
+    }
+
+    const allEnvironments = getEnvironments(context.org);
+    const environments = filterEnvironmentsByFeature(allEnvironments, feature);
+    const environmentIds = environments.map((e) => e.id);
+
+    if (!req.context.permissions.canUpdateFeature(feature, {})) {
+      req.context.permissions.throwPermissionError();
+    }
+
+    const { revision: version, comment } = req.body;
+
+    const revision = await getRevision({
+      context,
+      organization: context.org.id,
+      featureId: feature.id,
+      version: version,
+    });
+    if (!revision) {
+      throw new Error("Could not find feature revision");
+    }
+
+    if (
+      revision.version === feature.version ||
+      revision.status !== "published"
+    ) {
+      throw new Error("Can only revert to previously published revisions");
+    }
+
+    const changes: MergeResultChanges = {};
+
+    if (revision.defaultValue !== feature.defaultValue) {
+      if (
+        !context.permissions.canPublishFeature(
+          feature,
+          Array.from(getEnabledEnvironments(feature, environmentIds))
+        )
+      ) {
+        context.permissions.throwPermissionError();
+      }
+      changes.defaultValue = revision.defaultValue;
+    }
+
+    const changedEnvs: string[] = [];
+    environmentIds.forEach((env) => {
+      if (
+        revision.rules[env] &&
+        !isEqual(
+          revision.rules[env],
+          feature.environmentSettings?.[env]?.rules || []
+        )
+      ) {
+        changedEnvs.push(env);
+        changes.rules = changes.rules || {};
+        changes.rules[env] = revision.rules[env];
+      }
+    });
+    if (changedEnvs.length > 0) {
+      if (!context.permissions.canPublishFeature(feature, changedEnvs)) {
+        context.permissions.throwPermissionError();
+      }
+    }
+
+    const updatedFeature = await applyRevisionChanges(
+      context,
+      feature,
+      revision,
+      changes
+    );
+
+    await markRevisionAsPublished(context, revision, req.eventAudit, comment);
+
+    await req.audit({
+      event: "feature.revert",
+      entity: {
+        object: "feature",
+        id: feature.id,
+      },
+      details: auditDetailsUpdate(feature, updatedFeature, {
+        revision: revision.version,
+      }),
+    });
+
+    const groupMap = await getSavedGroupMap(req.organization);
+    const experimentMap = await getExperimentMapForFeature(
+      req.context,
+      feature.id
+    );
+    const safeRolloutMap = await req.context.models.safeRollout.getAllPayloadSafeRollouts();
+
+    return {
+      feature: getApiFeatureObj({
+        feature: updatedFeature,
+        organization: req.organization,
+        groupMap,
+        experimentMap,
+        revision,
+        safeRolloutMap,
+      }),
+    };
+  }
+);

--- a/packages/back-end/src/api/openapi/openapi.yaml
+++ b/packages/back-end/src/api/openapi/openapi.yaml
@@ -132,6 +132,8 @@ paths:
       $ref: "./paths/deleteFeature.yaml"
   /features/{id}/toggle:
     $ref: "./paths/toggleFeature.yaml"
+  /features/{id}/revert:
+    $ref: "./paths/revertFeature.yaml"
   /feature-keys:
     get:
       $ref: "./paths/getFeatureKeys.yaml"

--- a/packages/back-end/src/api/openapi/paths/revertFeature.yaml
+++ b/packages/back-end/src/api/openapi/paths/revertFeature.yaml
@@ -1,0 +1,37 @@
+parameters:
+  - $ref: "../parameters.yaml#/id"
+post:
+  summary: Revert a feature to a specific revision
+  tags:
+    - features
+  operationId: revertFeature
+  x-codeSamples:
+    - lang: 'cURL'
+      source: |
+        curl -X POST https://api.growthbook.io/api/v1/features/my-feature/revert \
+          -d '{ "revision": 3, "comment": "Bug found" }' \
+          -u secret_abc123DEF456:
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          required:
+            - revision
+          properties:
+            revision:
+              type: number
+            comment:
+              type: string
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - feature
+            properties:
+              feature:
+                $ref: "../schemas/Feature.yaml"

--- a/packages/back-end/src/validators/openapi.ts
+++ b/packages/back-end/src/validators/openapi.ts
@@ -112,6 +112,12 @@ export const toggleFeatureValidator = {
   paramsSchema: z.object({ "id": z.string() }).strict(),
 };
 
+export const revertFeatureValidator = {
+  bodySchema: z.object({ "revision": z.number(), "comment": z.string().optional() }).strict(),
+  querySchema: z.never(),
+  paramsSchema: z.object({ "id": z.string() }).strict(),
+};
+
 export const getFeatureKeysValidator = {
   bodySchema: z.never(),
   querySchema: z.object({ "projectId": z.string().optional() }).strict(),

--- a/packages/back-end/types/openapi.d.ts
+++ b/packages/back-end/types/openapi.d.ts
@@ -35,6 +35,16 @@ export interface paths {
       };
     };
   };
+  "/features/{id}/revert": {
+    /** Revert a feature to a specific revision */
+    post: operations["revertFeature"];
+    parameters: {
+        /** @description The id of the requested resource */
+      path: {
+        id: string;
+      };
+    };
+  };
   "/feature-keys": {
     /** Get list of feature keys */
     get: operations["getFeatureKeys"];
@@ -4260,6 +4270,286 @@ export interface operations {
           environments: {
             [key: string]: (true | "" | "true" | "false" | "1" | "0" | 1 | "" | "") | undefined;
           };
+        };
+      };
+    };
+    responses: {
+      200: {
+        content: {
+          "application/json": {
+            feature: {
+              id: string;
+              /** Format: date-time */
+              dateCreated: string;
+              /** Format: date-time */
+              dateUpdated: string;
+              archived: boolean;
+              description: string;
+              owner: string;
+              project: string;
+              /** @enum {string} */
+              valueType: "boolean" | "string" | "number" | "json";
+              defaultValue: string;
+              tags: (string)[];
+              environments: {
+                [key: string]: ({
+                  enabled: boolean;
+                  defaultValue: string;
+                  rules: (({
+                      description: string;
+                      condition: string;
+                      savedGroupTargeting?: ({
+                          /** @enum {string} */
+                          matchType: "all" | "any" | "none";
+                          savedGroups: (string)[];
+                        })[];
+                      prerequisites?: ({
+                          /** @description Feature ID */
+                          id: string;
+                          condition: string;
+                        })[];
+                      scheduleRules?: ({
+                          enabled: boolean;
+                          timestamp: string | null;
+                        })[];
+                      id: string;
+                      enabled: boolean;
+                      /** @enum {string} */
+                      type: "force";
+                      value: string;
+                    }) | ({
+                      description: string;
+                      condition: string;
+                      savedGroupTargeting?: ({
+                          /** @enum {string} */
+                          matchType: "all" | "any" | "none";
+                          savedGroups: (string)[];
+                        })[];
+                      scheduleRules?: ({
+                          enabled: boolean;
+                          timestamp: string | null;
+                        })[];
+                      id: string;
+                      enabled: boolean;
+                      /** @enum {string} */
+                      type: "rollout";
+                      value: string;
+                      coverage: number;
+                      hashAttribute: string;
+                    }) | ({
+                      description: string;
+                      condition: string;
+                      id: string;
+                      enabled: boolean;
+                      /** @enum {string} */
+                      type: "experiment";
+                      trackingKey?: string;
+                      hashAttribute?: string;
+                      fallbackAttribute?: string;
+                      disableStickyBucketing?: boolean;
+                      bucketVersion?: number;
+                      minBucketVersion?: number;
+                      namespace?: {
+                        enabled: boolean;
+                        name: string;
+                        range: (number)[];
+                      };
+                      coverage?: number;
+                      scheduleRules?: ({
+                          enabled: boolean;
+                          timestamp: string | null;
+                        })[];
+                      value?: ({
+                          value: string;
+                          weight: number;
+                          name?: string;
+                        })[];
+                    }) | ({
+                      description: string;
+                      id: string;
+                      enabled: boolean;
+                      /** @enum {string} */
+                      type: "experiment-ref";
+                      condition?: string;
+                      scheduleRules?: ({
+                          enabled: boolean;
+                          timestamp: string | null;
+                        })[];
+                      variations: ({
+                          value: string;
+                          variationId: string;
+                        })[];
+                      experimentId: string;
+                    }) | ({
+                      condition: string;
+                      savedGroupTargeting?: ({
+                          /** @enum {string} */
+                          matchType: "all" | "any" | "none";
+                          savedGroups: (string)[];
+                        })[];
+                      prerequisites?: ({
+                          /** @description Feature ID */
+                          id: string;
+                          condition: string;
+                        })[];
+                      id: string;
+                      trackingKey?: string;
+                      enabled: boolean;
+                      /** @enum {string} */
+                      type: "safe-rollout";
+                      controlValue: string;
+                      variationValue: string;
+                      seed?: string;
+                      hashAttribute?: string;
+                      safeRolloutId?: string;
+                      /** @enum {string} */
+                      status?: "running" | "released" | "rolled-back" | "stopped";
+                    }))[];
+                  /** @description A JSON stringified [FeatureDefinition](#tag/FeatureDefinition_model) */
+                  definition?: string;
+                  draft?: {
+                    enabled: boolean;
+                    defaultValue: string;
+                    rules: (({
+                        description: string;
+                        condition: string;
+                        savedGroupTargeting?: ({
+                            /** @enum {string} */
+                            matchType: "all" | "any" | "none";
+                            savedGroups: (string)[];
+                          })[];
+                        prerequisites?: ({
+                            /** @description Feature ID */
+                            id: string;
+                            condition: string;
+                          })[];
+                        scheduleRules?: ({
+                            enabled: boolean;
+                            timestamp: string | null;
+                          })[];
+                        id: string;
+                        enabled: boolean;
+                        /** @enum {string} */
+                        type: "force";
+                        value: string;
+                      }) | ({
+                        description: string;
+                        condition: string;
+                        savedGroupTargeting?: ({
+                            /** @enum {string} */
+                            matchType: "all" | "any" | "none";
+                            savedGroups: (string)[];
+                          })[];
+                        scheduleRules?: ({
+                            enabled: boolean;
+                            timestamp: string | null;
+                          })[];
+                        id: string;
+                        enabled: boolean;
+                        /** @enum {string} */
+                        type: "rollout";
+                        value: string;
+                        coverage: number;
+                        hashAttribute: string;
+                      }) | ({
+                        description: string;
+                        condition: string;
+                        id: string;
+                        enabled: boolean;
+                        /** @enum {string} */
+                        type: "experiment";
+                        trackingKey?: string;
+                        hashAttribute?: string;
+                        fallbackAttribute?: string;
+                        disableStickyBucketing?: boolean;
+                        bucketVersion?: number;
+                        minBucketVersion?: number;
+                        namespace?: {
+                          enabled: boolean;
+                          name: string;
+                          range: (number)[];
+                        };
+                        coverage?: number;
+                        scheduleRules?: ({
+                            enabled: boolean;
+                            timestamp: string | null;
+                          })[];
+                        value?: ({
+                            value: string;
+                            weight: number;
+                            name?: string;
+                          })[];
+                      }) | ({
+                        description: string;
+                        id: string;
+                        enabled: boolean;
+                        /** @enum {string} */
+                        type: "experiment-ref";
+                        condition?: string;
+                        scheduleRules?: ({
+                            enabled: boolean;
+                            timestamp: string | null;
+                          })[];
+                        variations: ({
+                            value: string;
+                            variationId: string;
+                          })[];
+                        experimentId: string;
+                      }) | ({
+                        condition: string;
+                        savedGroupTargeting?: ({
+                            /** @enum {string} */
+                            matchType: "all" | "any" | "none";
+                            savedGroups: (string)[];
+                          })[];
+                        prerequisites?: ({
+                            /** @description Feature ID */
+                            id: string;
+                            condition: string;
+                          })[];
+                        id: string;
+                        trackingKey?: string;
+                        enabled: boolean;
+                        /** @enum {string} */
+                        type: "safe-rollout";
+                        controlValue: string;
+                        variationValue: string;
+                        seed?: string;
+                        hashAttribute?: string;
+                        safeRolloutId?: string;
+                        /** @enum {string} */
+                        status?: "running" | "released" | "rolled-back" | "stopped";
+                      }))[];
+                    /** @description A JSON stringified [FeatureDefinition](#tag/FeatureDefinition_model) */
+                    definition?: string;
+                  };
+                }) | undefined;
+              };
+              /** @description Feature IDs. Each feature must evaluate to `true` */
+              prerequisites?: (string)[];
+              revision: {
+                version: number;
+                comment: string;
+                /** Format: date-time */
+                date: string;
+                publishedBy: string;
+              };
+              customFields?: {
+                [key: string]: unknown | undefined;
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+  revertFeature: {
+    /** Revert a feature to a specific revision */
+    requestBody: {
+      content: {
+        "application/json": {
+          revision: number;
+          comment?: string;
         };
       };
     };
@@ -9596,6 +9886,7 @@ export type GetFeatureResponse = operations["getFeature"]["responses"]["200"]["c
 export type UpdateFeatureResponse = operations["updateFeature"]["responses"]["200"]["content"]["application/json"];
 export type DeleteFeatureResponse = operations["deleteFeature"]["responses"]["200"]["content"]["application/json"];
 export type ToggleFeatureResponse = operations["toggleFeature"]["responses"]["200"]["content"]["application/json"];
+export type RevertFeatureResponse = operations["revertFeature"]["responses"]["200"]["content"]["application/json"];
 export type GetFeatureKeysResponse = operations["getFeatureKeys"]["responses"]["200"]["content"]["application/json"];
 export type ListProjectsResponse = operations["listProjects"]["responses"]["200"]["content"]["application/json"];
 export type PostProjectResponse = operations["postProject"]["responses"]["200"]["content"]["application/json"];


### PR DESCRIPTION
### Features and Changes

New REST endpoint for reverting a feature to a specific revision. Acts exactly the same as the "revert" action in the front-end.