### PR TITLE
Targeting attribute option to disable equality comparisons

### DIFF
--- a/packages/back-end/src/routers/attributes/attributes.controller.ts
+++ b/packages/back-end/src/routers/attributes/attributes.controller.ts
@@ -17,6 +17,7 @@ export const postAttribute = async (
     format,
     enum: enumValue,
     hashAttribute,
+    disableEqualityConditions,
   } = req.body;
   const context = getContextFromReq(req);
 
@@ -31,21 +32,21 @@ export const postAttribute = async (
     throw new Error("An attribute with that name already exists");
   }
 
+  const newAttribute: SDKAttribute = {
+    property,
+    description,
+    datatype,
+    projects,
+    format,
+    enum: enumValue,
+    hashAttribute,
+    disableEqualityConditions,
+  };
+
   await updateOrganization(org.id, {
     settings: {
       ...org.settings,
-      attributeSchema: [
-        ...attributeSchema,
-        {
-          property,
-          description,
-          datatype,
-          projects,
-          format,
-          enum: enumValue,
-          hashAttribute,
-        },
-      ],
+      attributeSchema: [...attributeSchema, newAttribute],
     },
   });
 
@@ -59,18 +60,7 @@ export const postAttribute = async (
       { settings: { attributeSchema } },
       {
         settings: {
-          attributeSchema: [
-            ...attributeSchema,
-            {
-              property,
-              description,
-              datatype,
-              projects,
-              format,
-              enum: enumValue,
-              hashAttribute,
-            },
-          ],
+          attributeSchema: [...attributeSchema, newAttribute],
         },
       }
     ),
@@ -93,6 +83,7 @@ export const putAttribute = async (
     enum: enumValue,
     hashAttribute,
     archived,
+    disableEqualityConditions,
     previousName,
   } = req.body;
   const context = getContextFromReq(req);
@@ -134,6 +125,7 @@ export const putAttribute = async (
     enum: enumValue,
     hashAttribute,
     archived,
+    disableEqualityConditions,
   };
 
   await updateOrganization(org.id, {

--- a/packages/back-end/types/organization.d.ts
+++ b/packages/back-end/types/organization.d.ts
@@ -171,6 +171,7 @@ export type SDKAttribute = {
   archived?: boolean;
   format?: SDKAttributeFormat;
   projects?: string[];
+  disableEqualityConditions?: boolean;
 };
 
 export type SDKAttributeSchema = SDKAttribute[];

--- a/packages/front-end/components/Features/AttributeModal.tsx
+++ b/packages/front-end/components/Features/AttributeModal.tsx
@@ -12,13 +12,13 @@ import Modal from "@/components/Modal";
 import Field from "@/components/Forms/Field";
 import SelectField from "@/components/Forms/SelectField";
 import PremiumTooltip from "@/components/Marketing/PremiumTooltip";
-import Toggle from "@/components/Forms/Toggle";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import MultiSelectField from "@/components/Forms/MultiSelectField";
 import { useUser } from "@/services/UserContext";
 import Tooltip from "@/components/Tooltip/Tooltip";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 import useProjectOptions from "@/hooks/useProjectOptions";
+import Checkbox from "@/components/Radix/Checkbox";
 import MinSDKVersionsList from "./MinSDKVersionsList";
 
 export interface Props {
@@ -52,9 +52,12 @@ export default function AttributeModal({ close, attribute }: Props) {
       description: current?.description || "",
       datatype: current?.datatype || "string",
       projects: attribute ? current?.projects || [] : project ? [project] : [],
-      format: current?.format || "",
+      format: ((current?.format as unknown) !== "none"
+        ? current?.format || ""
+        : "") as SDKAttributeFormat,
       enum: current?.enum || "",
       hashAttribute: !!current?.hashAttribute,
+      disableEqualityConditions: current?.disableEqualityConditions || false,
     },
   });
 
@@ -89,12 +92,17 @@ export default function AttributeModal({ close, attribute }: Props) {
       submit={form.handleSubmit(async (value) => {
         if (value.datatype !== "string") {
           value.format = "";
+          value.disableEqualityConditions = false;
         }
         if (value.datatype !== "enum") {
           value.enum = "";
         }
         if (!hashAttributeDataTypes.includes(value.datatype)) {
           value.hashAttribute = false;
+        }
+
+        if (value.format) {
+          value.disableEqualityConditions = false;
         }
 
         if (
@@ -114,6 +122,7 @@ export default function AttributeModal({ close, attribute }: Props) {
           format: value.format,
           enum: value.enum,
           hashAttribute: value.hashAttribute,
+          disableEqualityConditions: value.disableEqualityConditions,
         };
 
         // If the attribute name is changed, we need to pass in the original name
@@ -255,7 +264,7 @@ export default function AttributeModal({ close, attribute }: Props) {
         <>
           <SelectField
             label="String Format"
-            value={form.watch(`format`) || "none"}
+            value={form.watch(`format`) || ""}
             onChange={(v) => form.setValue(`format`, v as SDKAttributeFormat)}
             initialOption="None"
             options={[
@@ -279,6 +288,18 @@ export default function AttributeModal({ close, attribute }: Props) {
               it will break any filtering based on the attribute.
             </div>
           )}
+
+          {!form.watch("format") && (
+            <Checkbox
+              label="Disable Equality Comparisons"
+              description="This prevents users from targeting with exact string matches. Only regex and less than/greater than will be allowed. Useful for PII."
+              value={!!form.watch(`disableEqualityConditions`)}
+              setValue={(value) =>
+                form.setValue(`disableEqualityConditions`, value)
+              }
+              mb="4"
+            />
+          )}
         </>
       )}
       {datatype === "enum" && (
@@ -292,26 +313,12 @@ export default function AttributeModal({ close, attribute }: Props) {
         />
       )}
       {hashAttributeDataTypes.includes(datatype) && (
-        <div className="form-group">
-          <label>Unique Identifier</label>
-          <div className="row align-items-center">
-            <div className="col-auto">
-              <Toggle
-                id={"hashAttributeToggle"}
-                value={!!form.watch(`hashAttribute`)}
-                setValue={(value) => {
-                  form.setValue(`hashAttribute`, value);
-                }}
-              />
-            </div>
-            <div className="col px-0 text-muted" style={{ lineHeight: "1rem" }}>
-              <div>Attribute can be used for user assignment</div>
-              <small>
-                For example, <code>email</code> or <code>id</code>
-              </small>
-            </div>
-          </div>
-        </div>
+        <Checkbox
+          label="Unique Identifier"
+          description="Allow attribute to be used for experiment assignment."
+          value={!!form.watch(`hashAttribute`)}
+          setValue={(value) => form.setValue(`hashAttribute`, value)}
+        />
       )}
     </Modal>
   );

--- a/packages/front-end/components/Features/ConditionInput.tsx
+++ b/packages/front-end/components/Features/ConditionInput.tsx
@@ -147,7 +147,12 @@ export default function ConditionInput(props: Props) {
               setConds([
                 {
                   field: prop?.property || "",
-                  operator: prop?.datatype === "boolean" ? "$true" : "$eq",
+                  operator:
+                    prop?.datatype === "boolean"
+                      ? "$true"
+                      : prop?.disableEqualityConditions
+                      ? "$regex"
+                      : "$eq",
                   value: "",
                 },
               ]);
@@ -210,7 +215,7 @@ export default function ConditionInput(props: Props) {
               handleCondsChange(value, name);
             };
 
-            const operatorOptions =
+            let operatorOptions =
               attribute.datatype === "boolean"
                 ? [
                     { label: "is true", value: "$true" },
@@ -314,6 +319,13 @@ export default function ConditionInput(props: Props) {
                   ]
                 : [];
 
+            if (attribute.disableEqualityConditions) {
+              // Remove equality operators if the attribute has them disabled
+              operatorOptions = operatorOptions.filter(
+                (o) => !["$eq", "$ne", "$in", "$nin"].includes(o.value)
+              );
+            }
+
             let displayType:
               | "select-only"
               | "array-field"
@@ -378,7 +390,10 @@ export default function ConditionInput(props: Props) {
                         const newAttribute = attributes.get(value);
                         const hasAttrChanged =
                           newAttribute?.datatype !== attribute.datatype ||
-                          newAttribute?.array !== attribute.array;
+                          newAttribute?.array !== attribute.array ||
+                          !!newAttribute.disableEqualityConditions !==
+                            !!attribute.disableEqualityConditions;
+
                         if (hasAttrChanged && newAttribute) {
                           newConds[i]["operator"] = getDefaultOperator(
                             newAttribute

--- a/packages/front-end/components/Features/ConditionInput.tsx
+++ b/packages/front-end/components/Features/ConditionInput.tsx
@@ -27,6 +27,7 @@ import CountrySelector, {
 } from "@/components/Forms/CountrySelector";
 import MultiSelectField from "@/components/Forms/MultiSelectField";
 import DatePicker from "@/components/DatePicker";
+import Callout from "@/components/Radix/Callout";
 import styles from "./ConditionInput.module.scss";
 
 interface Props {
@@ -58,6 +59,10 @@ export default function ConditionInput(props: Props) {
   const [rawTextMode, setRawTextMode] = useState(false);
 
   const attributeSchema = useAttributeSchema(false, props.project);
+
+  const usingDisabledEqualityAttributes = conds.some(
+    (cond) => !!attributes.get(cond.field)?.disableEqualityConditions
+  );
 
   useEffect(() => {
     if (advanced) return;
@@ -624,6 +629,12 @@ export default function ConditionInput(props: Props) {
             <RxLoop /> Advanced mode
           </span>
         </div>
+        {usingDisabledEqualityAttributes && (
+          <Callout status="warning" mt="4">
+            Be careful not to include Personally Identifiable Information (PII)
+            in your targeting conditions.
+          </Callout>
+        )}
       </div>
     </div>
   );

--- a/packages/front-end/components/SavedGroups/SavedGroupForm.tsx
+++ b/packages/front-end/components/SavedGroups/SavedGroupForm.tsx
@@ -5,7 +5,7 @@ import {
 } from "back-end/types/saved-group";
 import { useForm } from "react-hook-form";
 import {
-  isIdListSupportedDatatype,
+  isIdListSupportedAttribute,
   validateAndFixCondition,
 } from "shared/util";
 import { FaPlusCircle } from "react-icons/fa";
@@ -222,14 +222,15 @@ const SavedGroupForm: FC<{
                 (attr) => attr.property === label
               );
               if (!attr) return false;
-              return !isIdListSupportedDatatype(attr.datatype);
+              return !isIdListSupportedAttribute(attr);
             }}
+            sort={false}
             formatOptionLabel={({ label }) => {
               const attr = attributeSchema.find(
                 (attr) => attr.property === label
               );
               if (!attr) return label;
-              const unsupported = !isIdListSupportedDatatype(attr.datatype);
+              const unsupported = !isIdListSupportedAttribute(attr);
               return (
                 <div className={clsx(unsupported ? "disabled" : "")}>
                   {label}

--- a/packages/front-end/pages/saved-groups/[sgid].tsx
+++ b/packages/front-end/pages/saved-groups/[sgid].tsx
@@ -7,7 +7,7 @@ import { PiArrowsDownUp, PiWarningFill } from "react-icons/pi";
 import {
   experimentsReferencingSavedGroups,
   featuresReferencingSavedGroups,
-  isIdListSupportedDatatype,
+  isIdListSupportedAttribute,
 } from "shared/util";
 import Link from "next/link";
 import { FeatureInterface } from "back-end/types/feature";
@@ -124,7 +124,6 @@ export default function EditSavedGroupPage() {
   const attr = (attributeSchema || []).find(
     (attr) => attr.property === savedGroup?.attributeKey
   );
-  const dataType = attr?.datatype;
 
   if (!data || !savedGroup) {
     return <LoadingOverlay />;
@@ -287,7 +286,7 @@ export default function EditSavedGroupPage() {
           </div>
         </div>
         <div>{savedGroup.description}</div>
-        {!isIdListSupportedDatatype(dataType) && (
+        {!isIdListSupportedAttribute(attr) && (
           <div className="alert alert-danger">
             <PiWarningFill style={{ marginTop: "-2px" }} />
             The attribute for this saved group has an unsupported datatype. It

--- a/packages/front-end/services/features.ts
+++ b/packages/front-end/services/features.ts
@@ -69,6 +69,7 @@ export interface AttributeData {
   enum: string[];
   archived: boolean;
   format?: SDKAttributeFormat;
+  disableEqualityConditions?: boolean;
 }
 
 export type NewExperimentRefRule = {
@@ -1196,6 +1197,7 @@ export function useAttributeMap(
         identifier: !!schema.hashAttribute,
         archived: !!schema.archived,
         format: schema.format || "",
+        disableEqualityConditions: !!schema.disableEqualityConditions,
       });
     });
 
@@ -1315,6 +1317,8 @@ export function getDefaultOperator(attribute: AttributeData) {
     return "$true";
   } else if (attribute.array) {
     return "$includes";
+  } else if (attribute.disableEqualityConditions) {
+    return "$regex";
   }
   return "$eq";
 }

--- a/packages/shared/src/util/saved-groups.ts
+++ b/packages/shared/src/util/saved-groups.ts
@@ -1,6 +1,7 @@
 import {
   SDKAttributeType,
   OrganizationInterface,
+  SDKAttribute,
 } from "back-end/types/organization";
 import { AttributeMap } from "back-end/src/services/features";
 import { GroupMap, SavedGroupsValues, SavedGroupInterface } from "../types";
@@ -12,9 +13,11 @@ export const ID_LIST_DATATYPES: SDKAttributeType[] = [
   "string",
   "secureString",
 ] as const;
-export function isIdListSupportedDatatype(
-  datatype?: SDKAttributeType
-): datatype is "number" | "string" | "secureString" {
+export function isIdListSupportedAttribute(
+  attribute?: Pick<SDKAttribute, "datatype" | "disableEqualityConditions">
+): boolean {
+  if (attribute?.disableEqualityConditions) return false;
+  const datatype = attribute?.datatype;
   return !!datatype && ID_LIST_DATATYPES.includes(datatype);
 }
 


### PR DESCRIPTION
### Features and Changes

Sometimes you need to use PII targeting attributes like `email`.  The `secureString` attribute type is great when you want to target only individual values safely.  However, there was no way to do pattern matching on the value (like `*@example.com`).  The only option is to use a regular `string` attribute, which makes it way easier to accidentally include PII.

This PR adds a new option to disable equality comparisons.  When checked, the attribute cannot be used in a saved group id list and only regex and less than/greater than operators are allowed in the targeting condition form.

This solution is not foolproof and can by bypassed in the following ways.
1. Use the regex match as an equality operator (e.g. `^sensitive@example\.com$`)
2. Use the REST API to set a custom targeting condition with JSON
3. Use "advanced" mode and enter a targeting condition with JSON instead of the condition builder UI
4. Uncheck this attribute option (any engineer with permissions to manage attributes will be able to do this)

![Screenshot from 2025-06-27 10-17-26](https://github.com/user-attachments/assets/5e4bc301-5139-4003-b095-bdcd2e24022f)

As an added precaution, if you do target on this attribute, we show a warning in the UI to avoid entering PII.

![image](https://github.com/user-attachments/assets/9d041eae-876b-4a26-82c0-43fbc3c21b46)

