### PR TITLE
feat(dimensions): Update dimension editor to add priority and custom slices

### DIFF
--- a/packages/back-end/src/app.ts
+++ b/packages/back-end/src/app.ts
@@ -461,11 +461,6 @@ app.post(
   datasourcesController.cancelDimensionSlices
 );
 
-app.get(
-  "/dimension-slices/datasource/:datasourceId/:exposureQueryId",
-  datasourcesController.getLatestDimensionSlicesForDatasource
-);
-
 app.use("/tag", tagRouter);
 
 app.use("/saved-groups", savedGroupRouter);

--- a/packages/back-end/src/controllers/datasources.ts
+++ b/packages/back-end/src/controllers/datasources.ts
@@ -47,7 +47,6 @@ import { getUserById } from "back-end/src/models/UserModel";
 import { AuditUserLoggedIn } from "back-end/types/audit";
 import {
   createDimensionSlices,
-  getLatestDimensionSlices,
   getDimensionSlicesById,
 } from "back-end/src/models/DimensionSlicesModel";
 import { DimensionSlicesQueryRunner } from "back-end/src/queryRunners/DimensionSlicesQueryRunner";
@@ -761,25 +760,6 @@ export async function getDimensionSlices(
   const { id } = req.params;
 
   const dimensionSlices = await getDimensionSlicesById(org.id, id);
-
-  res.status(200).json({
-    status: 200,
-    dimensionSlices,
-  });
-}
-
-export async function getLatestDimensionSlicesForDatasource(
-  req: AuthRequest<null, { datasourceId: string; exposureQueryId: string }>,
-  res: Response
-) {
-  const { org } = getContextFromReq(req);
-  const { datasourceId, exposureQueryId } = req.params;
-
-  const dimensionSlices = await getLatestDimensionSlices(
-    org.id,
-    datasourceId,
-    exposureQueryId
-  );
 
   res.status(200).json({
     status: 200,

--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -2302,7 +2302,7 @@ export default abstract class SqlIntegration
     const startDate = subDays(new Date(), params.lookbackDays);
     const timestampColumn = "e.timestamp";
     return format(
-      `-- Suggest Dimension Slices
+      `-- Dimension Traffic Query
     WITH
       __rawExperiment AS (
         ${compileSqlTemplate(exposureQuery.query, {

--- a/packages/back-end/src/models/DimensionSlicesModel.ts
+++ b/packages/back-end/src/models/DimensionSlicesModel.ts
@@ -74,25 +74,6 @@ export async function getDimensionSlicesById(
   return doc ? toInterface(doc) : null;
 }
 
-export async function getLatestDimensionSlices(
-  organization: string,
-  datasource: string,
-  exposureQueryId: string
-): Promise<DimensionSlicesInterface | null> {
-  const doc = await DimensionSlicesModel.find(
-    { organization, datasource, exposureQueryId },
-    null,
-    {
-      sort: { runStarted: -1 },
-      limit: 1,
-    }
-  ).exec();
-  if (doc[0]) {
-    return toInterface(doc[0]);
-  }
-  return null;
-}
-
 export async function createDimensionSlices({
   organization,
   dataSourceId,

--- a/packages/back-end/types/datasource.d.ts
+++ b/packages/back-end/types/datasource.d.ts
@@ -154,6 +154,7 @@ export type IdentityJoinQuery = {
 export interface ExperimentDimensionMetadata {
   dimension: string;
   specifiedSlices: string[];
+  customSlices?: boolean;
 }
 
 export interface ExposureQuery {

--- a/packages/front-end/components/Experiment/TabbedPage/HealthTabOnboardingModal.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/HealthTabOnboardingModal.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactElement, useEffect, useState } from "react";
+import React, { FC, ReactElement, useState } from "react";
 import { DimensionSlicesInterface } from "back-end/types/dimension";
 import {
   DataSourceInterfaceWithParams,
@@ -13,12 +13,12 @@ import { useAuth } from "@/services/auth";
 import useApi from "@/hooks/useApi";
 import { getQueryStatus } from "@/components/Queries/RunQueriesButton";
 import Modal from "@/components/Modal";
-import {
-  DimensionSlicesRunner,
-  getLatestDimensionSlices,
-} from "@/components/Settings/EditDataSource/DimensionMetadata/UpdateDimensionMetadata";
 import track, { trackSnapshot } from "@/services/track";
 import RadioGroup from "@/components/Radix/RadioGroup";
+import {
+  CustomDimensionMetadata,
+  DimensionSlicesRunner,
+} from "@/components/Settings/EditDataSource/DimensionMetadata/DimensionSlicesRunner";
 
 type HealthTabOnboardingModalProps = {
   open: boolean;
@@ -68,6 +68,24 @@ export const HealthTabOnboardingModal: FC<HealthTabOnboardingModalProps> = ({
   const [step, setStep] = useState(startingStep);
   const [lastStep, setLastStep] = useState(startingStep);
 
+  // track custom slices + priority locally
+  const [customDimensionMetadata, setCustomDimensionMetadata] = useState<
+    CustomDimensionMetadata[]
+  >(
+    exposureQuery.dimensions?.map((d, i) => {
+      const existingMetadata = exposureQuery.dimensionMetadata?.find(
+        (m) => m.dimension === d
+      );
+      return {
+        dimension: d,
+        customSlicesArray: existingMetadata?.customSlices
+          ? existingMetadata.specifiedSlices
+          : undefined,
+        priority: i + 1,
+      };
+    }) ?? []
+  );
+
   const source = "health-tab-onboarding";
 
   const metadataId = exposureQuery.dimensionSlicesId;
@@ -92,12 +110,29 @@ export const HealthTabOnboardingModal: FC<HealthTabOnboardingModalProps> = ({
       data?.dimensionSlices?.results &&
       data.dimensionSlices.results.length > 0
     ) {
-      track("Save Dimension Metadata", { source });
+      const orderedDimensions = exposureQuery.dimensions.sort((a, b) => {
+        const aMetadata = customDimensionMetadata.find(
+          (m) => m.dimension === a
+        );
+        const bMetadata = customDimensionMetadata.find(
+          (m) => m.dimension === b
+        );
+        // if missing metadata, put it at the end
+        if (!aMetadata) return 1;
+        if (!bMetadata) return -1;
+        return aMetadata.priority - bMetadata.priority;
+      });
+
       const updates: Partial<ExposureQuery> = {
         dimensionSlicesId: id,
-        dimensionMetadata: data.dimensionSlices.results.map((r) => ({
-          dimension: r.dimension,
-          specifiedSlices: r.dimensionSlices.map((dv) => dv.name),
+        dimensions: orderedDimensions,
+        dimensionMetadata: customDimensionMetadata.map((d) => ({
+          dimension: d.dimension,
+          specifiedSlices: d.customSlicesArray?.length
+            ? d.customSlicesArray
+            : data.dimensionSlices.results
+                .find((r) => r.dimension === d.dimension)
+                ?.dimensionSlices.map((s) => s.name) ?? [],
         })),
       };
       await apiCall(
@@ -138,19 +173,6 @@ export const HealthTabOnboardingModal: FC<HealthTabOnboardingModalProps> = ({
     close();
     refreshOrganization();
   };
-
-  useEffect(
-    () =>
-      getLatestDimensionSlices(
-        dataSourceId,
-        exposureQueryId,
-        metadataId,
-        apiCall,
-        setId,
-        mutate
-      ),
-    [dataSourceId, exposureQueryId, metadataId, setId, apiCall, mutate]
-  );
 
   if (error) {
     return <div className="alert alert-error">{error?.message}</div>;
@@ -245,14 +267,13 @@ export const HealthTabOnboardingModal: FC<HealthTabOnboardingModalProps> = ({
             </div>
             <div className="row">
               <DimensionSlicesRunner
+                exposureQueryId={exposureQueryId}
+                datasourceId={dataSourceId}
+                customDimensionMetadata={customDimensionMetadata}
+                setCustomDimensionMetadata={setCustomDimensionMetadata}
                 dimensionSlices={data?.dimensionSlices}
-                status={status}
-                id={id}
-                setId={setId}
-                mutate={mutate}
-                dataSource={dataSource}
-                exposureQuery={exposureQuery}
-                source={source}
+                mutateDimensionSlices={mutate}
+                setDimensionSlicesId={setId}
               />
             </div>
           </div>

--- a/packages/front-end/components/Settings/EditDataSource/DimensionMetadata/DimensionSlicesRunner.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/DimensionMetadata/DimensionSlicesRunner.tsx
@@ -203,23 +203,23 @@ const RefreshData = ({
             </Text>
           </Flex>
         ) : null}
-          <RunQueriesButton
-            cta={`${dimensionSlices ? "Refresh" : "Query"} Traffic Data`}
-            icon={dimensionSlices ? "refresh" : "run"}
-            mutate={mutate}
-            model={dimensionSlices ?? { queries: [], runStarted: undefined }}
-            cancelEndpoint={`/dimension-slices/${dimensionSlices?.id}/cancel`}
-            color={`${dimensionSlices ? "outline-" : ""}primary`}
-            onSubmit={async () => {
-              try {
-                setError("");
-                await refreshDimensionSlices();
-              } catch (e) {
-                setError(e.message);
-                console.error(e);
-              }
-            }}
-          />
+        <RunQueriesButton
+          cta={`${dimensionSlices ? "Refresh" : "Query"} Traffic Data`}
+          icon={dimensionSlices ? "refresh" : "run"}
+          mutate={mutate}
+          model={dimensionSlices ?? { queries: [], runStarted: undefined }}
+          cancelEndpoint={`/dimension-slices/${dimensionSlices?.id}/cancel`}
+          color={`${dimensionSlices ? "outline-" : ""}primary`}
+          onSubmit={async () => {
+            try {
+              setError("");
+              await refreshDimensionSlices();
+            } catch (e) {
+              setError(e.message);
+              console.error(e);
+            }
+          }}
+        />
       </Flex>
     </Flex>
   );

--- a/packages/front-end/components/Settings/EditDataSource/DimensionMetadata/DimensionSlicesRunner.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/DimensionMetadata/DimensionSlicesRunner.tsx
@@ -203,18 +203,6 @@ const RefreshData = ({
             </Text>
           </Flex>
         ) : null}
-        <form
-          onSubmit={async (e) => {
-            e.preventDefault();
-            try {
-              setError("");
-              await refreshDimensionSlices();
-            } catch (e) {
-              setError(e.message);
-              console.error(e);
-            }
-          }}
-        >
           <RunQueriesButton
             cta={`${dimensionSlices ? "Refresh" : "Query"} Traffic Data`}
             icon={dimensionSlices ? "refresh" : "run"}
@@ -222,8 +210,16 @@ const RefreshData = ({
             model={dimensionSlices ?? { queries: [], runStarted: undefined }}
             cancelEndpoint={`/dimension-slices/${dimensionSlices?.id}/cancel`}
             color={`${dimensionSlices ? "outline-" : ""}primary`}
+            onSubmit={async () => {
+              try {
+                setError("");
+                await refreshDimensionSlices();
+              } catch (e) {
+                setError(e.message);
+                console.error(e);
+              }
+            }}
           />
-        </form>
       </Flex>
     </Flex>
   );

--- a/packages/front-end/components/Settings/EditDataSource/DimensionMetadata/DimensionSlicesRunner.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/DimensionMetadata/DimensionSlicesRunner.tsx
@@ -1,0 +1,473 @@
+import React, { FC, Fragment, useState } from "react";
+import { ago } from "shared/dates";
+import { DimensionSlicesInterface } from "back-end/types/dimension";
+import { BsGear } from "react-icons/bs";
+import { useForm } from "react-hook-form";
+import { Box, Flex, Text } from "@radix-ui/themes";
+import { useGrowthBook } from "@growthbook/growthbook-react";
+import { QueryStatus } from "back-end/types/query";
+import RunQueriesButton, {
+  getQueryStatus,
+} from "@/components/Queries/RunQueriesButton";
+import ViewAsyncQueriesButton from "@/components/Queries/ViewAsyncQueriesButton";
+import Field from "@/components/Forms/Field";
+import MultiSelectField from "@/components/Forms/MultiSelectField";
+import Tooltip from "@/components/Tooltip/Tooltip";
+import SelectField from "@/components/Forms/SelectField";
+import { AppFeatures } from "@/types/app-features";
+import Link from "@/components/Radix/Link";
+import { useAuth } from "@/services/auth";
+
+const smallPercentFormatter = new Intl.NumberFormat(undefined, {
+  style: "percent",
+  maximumFractionDigits: 0,
+});
+
+export type CustomDimensionMetadata = {
+  dimension: string;
+  customSlicesArray?: string[];
+  priority: number;
+};
+
+type DimensionSlicesRunnerProps = {
+  exposureQueryId: string;
+  datasourceId: string;
+  customDimensionMetadata: CustomDimensionMetadata[];
+  setCustomDimensionMetadata: (
+    customDimensionMetadata: CustomDimensionMetadata[]
+  ) => void;
+  dimensionSlices?: DimensionSlicesInterface;
+  mutateDimensionSlices: () => void;
+  setDimensionSlicesId: (dimensionSlicesId: string) => void;
+};
+
+export const DimensionSlicesRunner: FC<DimensionSlicesRunnerProps> = ({
+  exposureQueryId,
+  datasourceId,
+  customDimensionMetadata,
+  setCustomDimensionMetadata,
+  dimensionSlices,
+  mutateDimensionSlices,
+  setDimensionSlicesId,
+}) => {
+  const { apiCall } = useAuth();
+  const [error, setError] = useState<string>("");
+  const [openLookbackField, setOpenLookbackField] = useState<boolean>(false);
+  const form = useForm({
+    defaultValues: {
+      lookbackDays: 30,
+    },
+  });
+
+  const { status } = getQueryStatus(
+    dimensionSlices?.queries ?? [],
+    dimensionSlices?.error ?? ""
+  );
+
+  const asyncQueriesButton = dimensionSlices?.queries ? (
+    <ViewAsyncQueriesButton
+      queries={
+        dimensionSlices.queries?.length > 0
+          ? dimensionSlices.queries.map((q) => q.query)
+          : []
+      }
+      error={dimensionSlices.error}
+      inline={true}
+      status={status}
+    />
+  ) : null;
+
+  const refreshDimensionSlices = async () => {
+    apiCall<{
+      dimensionSlices: DimensionSlicesInterface;
+    }>("/dimension-slices", {
+      method: "POST",
+      body: JSON.stringify({
+        dataSourceId: datasourceId,
+        queryId: exposureQueryId,
+        lookbackDays: form.watch("lookbackDays"),
+      }),
+    })
+      .then((res) => {
+        setDimensionSlicesId(res.dimensionSlices.id);
+      })
+      .catch((e) => {
+        console.error(e.message);
+      });
+  };
+
+  const lookbackField = openLookbackField ? (
+    <div className="d-inline-flex align-items-center mt-1">
+      <label className="mb-0 mr-2 small">Days to look back</label>
+      <Field
+        type="number"
+        style={{ width: 70 }}
+        {...form.register("lookbackDays", {
+          valueAsNumber: true,
+          min: 1,
+        })}
+      />
+    </div>
+  ) : (
+    <span className="mt-1 small">
+      <a
+        role="button"
+        className="a"
+        onClick={(e) => {
+          e.preventDefault();
+          setOpenLookbackField(!openLookbackField);
+        }}
+      >
+        <BsGear />
+      </a>{" "}
+      {form.getValues("lookbackDays")} days to look back
+    </span>
+  );
+
+  const ErrorBox = (
+    <>
+      {(status === "failed" || error !== "") && dimensionSlices ? (
+        <div className="alert alert-danger mt-2">
+          <Flex direction="column" gap="1">
+            <Box>
+              <strong>Error updating data</strong>
+              {error ? `: ${error}` : null}
+            </Box>
+            <Box>{lookbackField}</Box>
+            <Box>{asyncQueriesButton}</Box>
+          </Flex>
+        </div>
+      ) : null}
+      {status === "succeeded" && dimensionSlices?.results.length === 0 ? (
+        <div className="alert alert-warning mt-2">
+          <p className="mb-0">
+            <strong>No experiment assignment rows found in data source.</strong>{" "}
+          </p>{" "}
+          <p className="mb-0">
+            Ensure that your Experiment Assignment Query is correctly specified
+            or increase the lookback window.
+          </p>
+          {lookbackField}
+          {asyncQueriesButton}
+        </div>
+      ) : null}
+    </>
+  );
+
+  return (
+    <>
+      <div className="col-12">
+        <Flex direction="row" gap="1" mb="2" justify="end">
+          <RefreshData
+            dimensionSlices={dimensionSlices}
+            refreshDimensionSlices={refreshDimensionSlices}
+            mutate={mutateDimensionSlices}
+            setError={setError}
+          />
+        </Flex>
+        {ErrorBox ? (
+          <Flex direction="column" gap="1" mt="2">
+            {ErrorBox}
+          </Flex>
+        ) : null}
+        <DimensionSlicesResults
+          customDimensionMetadata={customDimensionMetadata}
+          setCustomDimensionMetadata={setCustomDimensionMetadata}
+          status={status}
+          dimensionSlices={dimensionSlices}
+        />
+      </div>
+    </>
+  );
+};
+
+const RefreshData = ({
+  dimensionSlices,
+  refreshDimensionSlices,
+  mutate,
+  setError,
+}: {
+  dimensionSlices: DimensionSlicesInterface | undefined;
+  refreshDimensionSlices: () => Promise<void>;
+  mutate: () => void;
+  setError: (error: string) => void;
+}) => {
+  return (
+    <Flex direction="column" gap="1">
+      <Flex direction="row" gap="1">
+        {dimensionSlices?.runStarted ? (
+          <Flex mr="2" direction="column" gap="">
+            <Text className="small text-muted">Last updated</Text>
+            <Text className="small text-muted">
+              {ago(dimensionSlices.runStarted)}
+            </Text>
+          </Flex>
+        ) : null}
+        <form
+          onSubmit={async (e) => {
+            e.preventDefault();
+            try {
+              setError("");
+              await refreshDimensionSlices();
+            } catch (e) {
+              setError(e.message);
+              console.error(e);
+            }
+          }}
+        >
+          <RunQueriesButton
+            cta={`${dimensionSlices ? "Refresh" : "Query"} Traffic Data`}
+            icon={dimensionSlices ? "refresh" : "run"}
+            mutate={mutate}
+            model={dimensionSlices ?? { queries: [], runStarted: undefined }}
+            cancelEndpoint={`/dimension-slices/${dimensionSlices?.id}/cancel`}
+            color={`${dimensionSlices ? "outline-" : ""}primary`}
+          />
+        </form>
+      </Flex>
+    </Flex>
+  );
+};
+
+export const DimensionSlicesResults: FC<{
+  customDimensionMetadata: CustomDimensionMetadata[];
+  setCustomDimensionMetadata: (
+    customDimensionMetadata: CustomDimensionMetadata[]
+  ) => void;
+  dimensionSlices?: DimensionSlicesInterface;
+  status: QueryStatus;
+}> = ({
+  customDimensionMetadata,
+  setCustomDimensionMetadata,
+  dimensionSlices,
+  status,
+}) => {
+  const growthbook = useGrowthBook<AppFeatures>();
+
+  const updateCustomSelectedSlices = (dimension: string, values: string[]) => {
+    const newCustomDimensionMetadata: CustomDimensionMetadata[] = [];
+    customDimensionMetadata.forEach((v) => {
+      if (v.dimension === dimension) {
+        newCustomDimensionMetadata.push({
+          dimension,
+          customSlicesArray: values,
+          priority: v.priority,
+        });
+      } else {
+        newCustomDimensionMetadata.push(v);
+      }
+    });
+    setCustomDimensionMetadata(newCustomDimensionMetadata);
+  };
+
+  const updatePriority = (dimension: string, priority: number) => {
+    const oldPriority = customDimensionMetadata.find(
+      (v) => v.dimension === dimension
+    )?.priority;
+
+    const newCustomDimensionMetadata: CustomDimensionMetadata[] = [];
+    customDimensionMetadata.forEach((v) => {
+      if (v.dimension === dimension) {
+        newCustomDimensionMetadata.push({
+          dimension,
+          customSlicesArray: v.customSlicesArray,
+          priority: priority,
+        });
+      } else if (v.priority >= priority && v.priority < (oldPriority ?? 0)) {
+        newCustomDimensionMetadata.push({
+          ...v,
+          priority: v.priority + 1,
+        });
+      } else if (v.priority > (oldPriority ?? 0) && v.priority <= priority) {
+        newCustomDimensionMetadata.push({
+          ...v,
+          priority: v.priority - 1,
+        });
+      } else {
+        newCustomDimensionMetadata.push(v);
+      }
+    });
+    setCustomDimensionMetadata(newCustomDimensionMetadata);
+  };
+
+  const toggleCustomDimension = (dimension: string) => {
+    const trafficValues =
+      dimensionSlices?.results
+        .find((d) => d.dimension === dimension)
+        ?.dimensionSlices.map((s) => s.name) || [];
+
+    const newMetadata: CustomDimensionMetadata[] = [];
+    customDimensionMetadata.forEach((v) => {
+      if (v.dimension === dimension) {
+        newMetadata.push({
+          dimension,
+          customSlicesArray: trafficValues,
+          priority: v.priority,
+        });
+      } else {
+        newMetadata.push(v);
+      }
+    });
+
+    setCustomDimensionMetadata(newMetadata);
+  };
+
+  return (
+    <>
+      <table className="table appbox gbtable mt-2 mb-0">
+        <thead>
+          <tr>
+            <th>Dimension</th>
+            <th>% of Traffic</th>
+            <th>
+              Dimension Values{" "}
+              <Tooltip body="Dimension values are the levels of a dimension used for pre-computed dimension analysis (currently only used on the Experiment Health Tab). Values not in this list will be grouped into the '__Other__' bucket."></Tooltip>
+            </th>
+            {growthbook.isOn("pre-computed-dimensions") ? (
+              <th>
+                Priority{" "}
+                <Tooltip body="Higher priority dimensions are used first when choosing which dimensions to pre-compute for fast slicing and dicing."></Tooltip>
+              </th>
+            ) : null}
+          </tr>
+        </thead>
+        <tbody>
+          {customDimensionMetadata.map((metadata) => {
+            const dimensionValueResult = dimensionSlices?.results.find(
+              (d) => d.dimension === metadata.dimension
+            );
+            let totalPercent = 0;
+            return (
+              <tr key={metadata.dimension}>
+                <td>{metadata.dimension}</td>
+                <td>
+                  {dimensionValueResult ? (
+                    <>
+                      <div>
+                        {dimensionValueResult.dimensionSlices.map((d, i) => {
+                          totalPercent += d.percent;
+                          return (
+                            <>
+                              <Fragment key={`${metadata.dimension}-${i}`}>
+                                {i ? ", " : ""}
+                                <code
+                                  key={`${metadata.dimension}-code-${d.name}`}
+                                >
+                                  {d.name}
+                                </code>
+                              </Fragment>
+                              <span>{` (${smallPercentFormatter.format(
+                                d.percent / 100.0
+                              )})`}</span>
+                            </>
+                          );
+                        })}
+                      </div>
+                      <div>
+                        {" "}
+                        All other values:
+                        <Fragment key={`${metadata.dimension}--1`}>
+                          {" "}
+                          <code key={`${metadata.dimension}-code-_other_`}>
+                            __Other__
+                          </code>
+                        </Fragment>
+                        <span>{` (${smallPercentFormatter.format(
+                          (100.0 - totalPercent) / 100.0
+                        )})`}</span>
+                      </div>
+                    </>
+                  ) : (
+                    <div className="text-muted">
+                      {status !== "running" &&
+                      (!dimensionSlices || !dimensionValueResult)
+                        ? "Run dimension slices query to populate"
+                        : status === "succeeded" &&
+                          dimensionSlices?.results?.length === 0
+                        ? "No data found"
+                        : status === "running"
+                        ? "Updating data"
+                        : ""}
+                    </div>
+                  )}
+                </td>
+                <td>
+                  <div className="d-flex flex-column">
+                    {metadata?.customSlicesArray ? (
+                      <>
+                        <MultiSelectField
+                          value={metadata?.customSlicesArray || []}
+                          onChange={(values) =>
+                            updateCustomSelectedSlices(
+                              metadata.dimension,
+                              values
+                            )
+                          }
+                          options={(
+                            dimensionValueResult?.dimensionSlices.map(
+                              (d) => d.name
+                            ) ?? []
+                          )
+                            .concat(metadata?.customSlicesArray || [])
+                            .map((v) => ({
+                              value: v,
+                              label: v,
+                            }))}
+                          max={20}
+                          placeholder="Select dimension values..."
+                          creatable={true}
+                          closeMenuOnSelect={false}
+                        />
+                        <Text className="text-muted">
+                          {metadata?.customSlicesArray?.length === 20
+                            ? "20 values max"
+                            : ""}
+                        </Text>
+                        <Link
+                          className="mt-1 small"
+                          onClick={() =>
+                            toggleCustomDimension(metadata.dimension)
+                          }
+                        >
+                          Use traffic values
+                        </Link>
+                      </>
+                    ) : (
+                      <Flex direction="column" gap="1">
+                        <Text>Using values found in traffic</Text>
+                        <Link
+                          className="small"
+                          onClick={() =>
+                            toggleCustomDimension(metadata.dimension)
+                          }
+                        >
+                          Customize values
+                        </Link>
+                      </Flex>
+                    )}
+                  </div>
+                </td>
+                {growthbook.isOn("pre-computed-dimensions") ? (
+                  <td>
+                    <SelectField
+                      value={metadata.priority?.toString() ?? "0"}
+                      onChange={(value) =>
+                        updatePriority(metadata.dimension, parseInt(value))
+                      }
+                      options={Object.values(customDimensionMetadata).map(
+                        (_, i) => ({
+                          value: (i + 1).toString(),
+                          label: (i + 1).toString(),
+                        })
+                      )}
+                    />
+                  </td>
+                ) : null}
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </>
+  );
+};

--- a/packages/front-end/components/Settings/EditDataSource/DimensionMetadata/UpdateDimensionMetadata.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/DimensionMetadata/UpdateDimensionMetadata.tsx
@@ -1,140 +1,80 @@
-import React, { FC, Fragment, useCallback, useEffect, useState } from "react";
-import {
-  DataSourceInterfaceWithParams,
-  ExposureQuery,
-} from "back-end/types/datasource";
-import cloneDeep from "lodash/cloneDeep";
-import { ago, datetime } from "shared/dates";
-import { QueryStatus } from "back-end/types/query";
+import React, { FC, useState } from "react";
+import { ExposureQuery } from "back-end/types/datasource";
 import { DimensionSlicesInterface } from "back-end/types/dimension";
-import { BsGear } from "react-icons/bs";
-import { useForm } from "react-hook-form";
-import { useAuth } from "@/services/auth";
+import { Flex, Text } from "@radix-ui/themes";
 import useApi from "@/hooks/useApi";
-import RunQueriesButton, {
-  getQueryStatus,
-} from "@/components/Queries/RunQueriesButton";
-import ViewAsyncQueriesButton from "@/components/Queries/ViewAsyncQueriesButton";
 import Modal from "@/components/Modal";
-import Field from "@/components/Forms/Field";
-import track from "@/services/track";
-import usePermissionsUtil from "@/hooks/usePermissionsUtils";
-
-const smallPercentFormatter = new Intl.NumberFormat(undefined, {
-  style: "percent",
-  maximumFractionDigits: 0,
-});
-
-export function getLatestDimensionSlices(
-  dataSourceId: string,
-  exposureQueryId: string,
-  metadataId: string | undefined,
-  apiCall: <T>(
-    url: string | null,
-    options?: RequestInit | undefined
-  ) => Promise<T>,
-  setId: (id: string) => void,
-  mutate: () => void
-): void {
-  if (!dataSourceId || !exposureQueryId) return;
-  if (metadataId) {
-    setId(metadataId);
-    mutate();
-    return;
-  } else {
-    apiCall<{ dimensionSlices: DimensionSlicesInterface }>(
-      `/dimension-slices/datasource/${dataSourceId}/${exposureQueryId}`
-    )
-      .then((res) => {
-        if (res?.dimensionSlices?.id) {
-          setId(res.dimensionSlices.id);
-          mutate();
-        }
-      })
-      .catch((e) => {
-        console.error(e);
-      });
-  }
-}
+import {
+  CustomDimensionMetadata,
+  DimensionSlicesRunner,
+} from "@/components/Settings/EditDataSource/DimensionMetadata/DimensionSlicesRunner";
 
 type UpdateDimensionMetadataModalProps = {
-  exposureQuery: ExposureQuery;
-  dataSource: DataSourceInterfaceWithParams;
+  exposureQuery: Pick<
+    ExposureQuery,
+    "id" | "dimensions" | "dimensionMetadata" | "dimensionSlicesId"
+  >;
+  datasourceId: string;
   close: () => void;
-  onSave: (exposureQuery: ExposureQuery) => void;
+  onSave: (
+    customDimensionMetadata: CustomDimensionMetadata[],
+    dimensionSlices?: DimensionSlicesInterface
+  ) => void;
 };
 
 export const UpdateDimensionMetadataModal: FC<UpdateDimensionMetadataModalProps> = ({
   exposureQuery,
-  dataSource,
+  datasourceId,
   close,
   onSave,
 }) => {
-  const { apiCall } = useAuth();
-  const [id, setId] = useState<string | null>(
-    exposureQuery.dimensionSlicesId || null
-  );
-  const { data, error, mutate } = useApi<{
+  const [dimensionSlicesId, setDimensionSlicesId] = useState<
+    string | undefined
+  >(exposureQuery.dimensionSlicesId);
+  const { data, mutate: mutateDimensionSlices } = useApi<{
     dimensionSlices: DimensionSlicesInterface;
-  }>(`/dimension-slices/${id}`);
+  }>(`/dimension-slices/${dimensionSlicesId}`, {
+    shouldRun: () => !!dimensionSlicesId,
+  });
+  const dimensionSlices = data?.dimensionSlices;
 
-  const dataSourceId = dataSource.id;
-  const exposureQueryId = exposureQuery.id;
-  const metadataId = exposureQuery.dimensionSlicesId;
-  const source = "datasource-modal";
-
-  useEffect(
-    () =>
-      getLatestDimensionSlices(
-        dataSourceId,
-        exposureQueryId,
-        metadataId,
-        apiCall,
-        setId,
-        mutate
-      ),
-    [dataSourceId, exposureQueryId, metadataId, setId, apiCall, mutate]
+  // track custom slices + priority locally
+  const [customDimensionMetadata, setCustomDimensionMetadata] = useState<
+    CustomDimensionMetadata[]
+  >(
+    exposureQuery.dimensions?.map((d, i) => {
+      const existingMetadata = exposureQuery.dimensionMetadata?.find(
+        (m) => m.dimension === d
+      );
+      return {
+        dimension: d,
+        customSlicesArray: existingMetadata?.customSlices
+          ? existingMetadata.specifiedSlices
+          : undefined,
+        priority: i + 1,
+      };
+    }) ?? []
   );
 
-  if (error) {
-    return <div className="alert alert-error">{error?.message}</div>;
-  }
-  const { status } = getQueryStatus(
-    data?.dimensionSlices?.queries || [],
-    data?.dimensionSlices?.error
-  );
-
-  const saveEnabled =
-    id &&
-    status === "succeeded" &&
-    data?.dimensionSlices?.results &&
-    data.dimensionSlices.results.length > 0;
   const secondaryCTA = (
     <button
       className={`btn btn-primary`}
       type="submit"
-      disabled={!saveEnabled}
       onClick={async () => {
-        if (
-          id &&
-          data?.dimensionSlices?.results &&
-          data.dimensionSlices.results.length > 0
-        ) {
-          track("Save Dimension Metadata", { source });
-          const value = cloneDeep<ExposureQuery>(exposureQuery);
-          value.dimensionSlicesId = id;
-          value.dimensionMetadata = data.dimensionSlices.results.map((r) => ({
-            dimension: r.dimension,
-            specifiedSlices: r.dimensionSlices.map((dv) => dv.name),
-          }));
-          await onSave(value);
-          close();
-        }
+        await onSave(customDimensionMetadata, dimensionSlices);
+        close();
       }}
     >
-      Save Dimension Slices
+      Save Dimension Values
     </button>
   );
+
+  if (!exposureQuery) {
+    console.error(
+      "ImplementationError: exposureQuery is required for Edit mode"
+    );
+    return null;
+  }
 
   return (
     <>
@@ -143,310 +83,28 @@ export const UpdateDimensionMetadataModal: FC<UpdateDimensionMetadataModalProps>
         open={true}
         close={close}
         secondaryCTA={secondaryCTA}
-        size="lg"
+        size="max"
         header={"Configure Experiment Dimensions"}
       >
-        <div className="my-2 ml-3 mr-3">
-          <div className="row mb-1">
-            Experiment Dimensions can be configured to have up to 20 pre-defined
-            slices per dimension.
-          </div>
-          <div className="row mb-1">
-            <strong>Why?</strong>
-            Pre-defining dimension slices allows us to automatically run traffic
-            and health checks on your experiment for all bins whenever you
-            update experiment results.
-          </div>
-          <div className="row mb-3">
-            <strong>How?</strong>
-            Running the query on this page will load data using your experiment
-            assignment query to determine the 20 most popular dimension slices.
-          </div>
-          <div className="row">
-            <DimensionSlicesRunner
-              dimensionSlices={data?.dimensionSlices}
-              status={status}
-              id={id}
-              setId={setId}
-              mutate={mutate}
-              dataSource={dataSource}
-              exposureQuery={exposureQuery}
-              source={source}
-            />
-          </div>
-        </div>
+        <Flex direction="column" gap="2">
+          <Text>
+            Experiment Dimensions are additional columns made available in the
+            Experiment Assignment Query. These columns can be used for
+            dimension-based analysis without additional joins. Dimension values
+            can be defined in this modal to ensure consistency, reliability, and
+            query performance.
+          </Text>
+          <DimensionSlicesRunner
+            exposureQueryId={exposureQuery.id}
+            datasourceId={datasourceId}
+            customDimensionMetadata={customDimensionMetadata}
+            setCustomDimensionMetadata={setCustomDimensionMetadata}
+            dimensionSlices={dimensionSlices}
+            mutateDimensionSlices={mutateDimensionSlices}
+            setDimensionSlicesId={setDimensionSlicesId}
+          />
+        </Flex>
       </Modal>
-    </>
-  );
-};
-
-type DimensionSlicesRunnerProps = {
-  dimensionSlices?: DimensionSlicesInterface;
-  status: QueryStatus;
-  id: string | null;
-  setId: (id: string) => void;
-  mutate: () => void;
-  dataSource: DataSourceInterfaceWithParams;
-  exposureQuery: ExposureQuery;
-  source: string;
-};
-
-export const DimensionSlicesRunner: FC<DimensionSlicesRunnerProps> = ({
-  dimensionSlices,
-  status,
-  id,
-  setId,
-  mutate,
-  dataSource,
-  exposureQuery,
-  source,
-}) => {
-  const { apiCall } = useAuth();
-  const [error, setError] = useState<string>("");
-  const permissionsUtil = usePermissionsUtil();
-  const [openLookbackField, setOpenLookbackField] = useState<boolean>(false);
-  const form = useForm({
-    defaultValues: {
-      lookbackDays: 30,
-    },
-  });
-
-  const refreshDimension = useCallback(async () => {
-    track("Refresh Dimension Slices - click", { source });
-    apiCall<{
-      dimensionSlices: DimensionSlicesInterface;
-    }>("/dimension-slices", {
-      method: "POST",
-      body: JSON.stringify({
-        dataSourceId: dataSource.id,
-        queryId: exposureQuery.id,
-        lookbackDays: form.getValues("lookbackDays"),
-      }),
-    })
-      .then((res) => {
-        track("Refresh Dimension Slices - success", { source });
-        setId(res.dimensionSlices.id);
-        mutate();
-      })
-      .catch((e) => {
-        track("Refresh Dimension Slices - error", {
-          source,
-          error: e.message.substr(0, 32) + "...",
-        });
-        setError(e.message);
-        console.error(e.message);
-      });
-  }, [dataSource.id, exposureQuery.id, form, source, mutate, apiCall, setId]);
-
-  return (
-    <>
-      <div className="col-12">
-        <div className="col-auto ml-auto">
-          <div className="row align-items-center mb-3">
-            {permissionsUtil.canRunHealthQueries(dataSource) ? (
-              <div className="mr-2">
-                <form
-                  onSubmit={async (e) => {
-                    e.preventDefault();
-                    try {
-                      setError("");
-                      refreshDimension();
-                    } catch (e) {
-                      setError(e.message);
-                      console.error(e);
-                    }
-                  }}
-                >
-                  <RunQueriesButton
-                    cta={`${
-                      dimensionSlices ? "Refresh" : "Query"
-                    } Dimension Slices`}
-                    icon={dimensionSlices ? "refresh" : "run"}
-                    position={"left"}
-                    mutate={mutate}
-                    model={
-                      dimensionSlices ?? { queries: [], runStarted: undefined }
-                    }
-                    cancelEndpoint={`/dimension-slices/${id}/cancel`}
-                    color={`${dimensionSlices ? "outline-" : ""}primary`}
-                  />
-                </form>
-              </div>
-            ) : null}
-            {dimensionSlices?.runStarted ? (
-              <div className="pt-2 mr-2">
-                <div
-                  className="text-right text-muted"
-                  style={{ fontSize: "0.7em" }}
-                  title={datetime(dimensionSlices.runStarted)}
-                >
-                  last updated {ago(dimensionSlices.runStarted)}
-                </div>
-              </div>
-            ) : null}
-            <div className="flex-1" />
-            <div>
-              <div className="text-right text-muted">
-                {openLookbackField ? (
-                  <div className="d-inline-flex align-items-center mt-1">
-                    <label className="mb-0 mr-2 small">Days to look back</label>
-                    <Field
-                      type="number"
-                      style={{ width: 70 }}
-                      {...form.register("lookbackDays", {
-                        valueAsNumber: true,
-                        min: 1,
-                      })}
-                    />
-                  </div>
-                ) : (
-                  <span className="mt-1 small">
-                    <a
-                      role="button"
-                      className="a"
-                      onClick={(e) => {
-                        e.preventDefault();
-                        setOpenLookbackField(!openLookbackField);
-                      }}
-                    >
-                      <BsGear />
-                    </a>{" "}
-                    {form.getValues("lookbackDays")} days to look back
-                  </span>
-                )}
-              </div>
-            </div>
-          </div>
-        </div>
-        {(status === "failed" || error !== "") && dimensionSlices ? (
-          <div className="alert alert-danger mt-2">
-            <strong>Error updating data</strong>
-            {error ? `: ${error}` : null}
-          </div>
-        ) : null}
-        {status === "succeeded" && dimensionSlices?.results.length === 0 ? (
-          <div className="alert alert-warning mt-2">
-            <p className="mb-0">
-              <strong>
-                No experiment assignment rows found in data source.
-              </strong>{" "}
-            </p>{" "}
-            <p className="mb-0">
-              Either increase the number of days to look back or ensure that
-              your Experiment Assignment Query is correctly specified.
-            </p>
-          </div>
-        ) : null}
-
-        <div className="row align-items-center mb-2">
-          <strong>Dimension Slices to Display on Health Tab:</strong>
-        </div>
-        <DimensionSlicesResults
-          status={status}
-          dimensions={exposureQuery.dimensions}
-          dimensionSlices={dimensionSlices}
-        />
-
-        {dimensionSlices?.queries && (
-          <div>
-            <ViewAsyncQueriesButton
-              queries={
-                dimensionSlices.queries?.length > 0
-                  ? dimensionSlices.queries.map((q) => q.query)
-                  : []
-              }
-              error={dimensionSlices.error}
-              inline={true}
-              status={status}
-            />
-          </div>
-        )}
-      </div>
-    </>
-  );
-};
-
-type DimensionSlicesProps = {
-  status: string;
-  dimensions: string[];
-  dimensionSlices?: DimensionSlicesInterface;
-};
-
-export const DimensionSlicesResults: FC<DimensionSlicesProps> = ({
-  dimensions,
-  dimensionSlices,
-  status,
-}) => {
-  return (
-    <>
-      <table className="table appbox gbtable mt-2 mb-0">
-        <thead>
-          <tr>
-            <th>Dimension</th>
-            <th>Pre-defined Slices (% of Units)</th>
-          </tr>
-        </thead>
-        <tbody>
-          {dimensions.map((r) => {
-            const dimensionValueResult = dimensionSlices?.results.find(
-              (d) => d.dimension === r
-            );
-            let totalPercent = 0;
-            return (
-              <tr key={r}>
-                <td>{r}</td>
-                <td>
-                  {dimensionValueResult ? (
-                    <>
-                      <div>
-                        {dimensionValueResult.dimensionSlices.map((d, i) => {
-                          totalPercent += d.percent;
-                          return (
-                            <>
-                              <Fragment key={`${r}-${i}`}>
-                                {i ? ", " : ""}
-                                <code key={`${r}-code-${d.name}`}>
-                                  {d.name}
-                                </code>
-                              </Fragment>
-                              <span>{` (${smallPercentFormatter.format(
-                                d.percent / 100.0
-                              )})`}</span>
-                            </>
-                          );
-                        })}
-                      </div>
-                      <div>
-                        {" "}
-                        All other values:
-                        <Fragment key={`${r}--1`}>
-                          {" "}
-                          <code key={`${r}-code-_other_`}>__Other__</code>
-                        </Fragment>
-                        <span>{` (${smallPercentFormatter.format(
-                          (100.0 - totalPercent) / 100.0
-                        )})`}</span>
-                      </div>
-                    </>
-                  ) : (
-                    <div className="text-muted">
-                      {status !== "running" &&
-                      (!dimensionSlices || !dimensionValueResult)
-                        ? "Run dimension slices query to populate"
-                        : status === "succeeded" &&
-                          dimensionSlices?.results?.length === 0
-                        ? "No data found"
-                        : status === "running"
-                        ? "Updating data"
-                        : ""}
-                    </div>
-                  )}
-                </td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
     </>
   );
 };

--- a/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/ExperimentAssignmentQueries.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/ExperimentAssignmentQueries.tsx
@@ -7,6 +7,7 @@ import cloneDeep from "lodash/cloneDeep";
 import { FaChevronRight, FaPlus } from "react-icons/fa";
 import { useRouter } from "next/router";
 import { Box, Card, Flex, Heading } from "@radix-ui/themes";
+import { DimensionSlicesInterface } from "back-end/types/dimension";
 import { DataSourceQueryEditingModalBaseProps } from "@/components/Settings/EditDataSource/types";
 import DeleteButton from "@/components/DeleteButton/DeleteButton";
 import Code from "@/components/SyntaxHighlighting/Code";
@@ -17,6 +18,7 @@ import { UpdateDimensionMetadataModal } from "@/components/Settings/EditDataSour
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 import Badge from "@/components/Radix/Badge";
 import Callout from "@/components/Radix/Callout";
+import { CustomDimensionMetadata } from "@/components/Settings/EditDataSource/DimensionMetadata/DimensionSlicesRunner";
 
 type ExperimentAssignmentQueriesProps = DataSourceQueryEditingModalBaseProps;
 type UIMode = "view" | "edit" | "add" | "dimension";
@@ -27,6 +29,7 @@ export const ExperimentAssignmentQueries: FC<ExperimentAssignmentQueriesProps> =
   canEdit = true,
 }) => {
   const router = useRouter();
+
   let intitialOpenIndexes: boolean[] = [];
   if (router.query.openAll === "1") {
     intitialOpenIndexes = Array.from(
@@ -242,7 +245,7 @@ export const ExperimentAssignmentQueries: FC<ExperimentAssignmentQueriesProps> =
                         className="dropdown-item py-2"
                         onClick={handleActionClicked(idx, "dimension")}
                       >
-                        Configure Dimensions
+                        Edit Dimensions
                       </button>
                     ) : null}
 
@@ -305,13 +308,68 @@ export const ExperimentAssignmentQueries: FC<ExperimentAssignmentQueriesProps> =
       {uiMode === "dimension" ? (
         <UpdateDimensionMetadataModal
           exposureQuery={experimentExposureQueries[editingIndex]}
-          dataSource={dataSource}
+          datasourceId={dataSource.id}
           close={() => setUiMode("view")}
-          onSave={handleSave(editingIndex)}
+          onSave={handleSaveDimensionMetadata(editingIndex, dataSource, onSave)}
         />
       ) : null}
 
       {/* endregion Add/Edit modal */}
     </Box>
   );
+};
+
+const handleSaveDimensionMetadata = (
+  editingIndex: number,
+  dataSource: DataSourceInterfaceWithParams,
+  onSave: (dataSource: DataSourceInterfaceWithParams) => void
+) => async (
+  customDimensionMetadata: CustomDimensionMetadata[],
+  dimensionSlices?: DimensionSlicesInterface
+) => {
+  const copy = cloneDeep<DataSourceInterfaceWithParams>(dataSource);
+  const exposureQuery = copy.settings?.queries?.exposure?.[editingIndex];
+
+  if (exposureQuery) {
+    exposureQuery.dimensionMetadata = exposureQuery.dimensions.map((d) => {
+      const existingMetadata = exposureQuery.dimensionMetadata?.find(
+        (m) => m.dimension === d
+      ) ?? {
+        dimension: d,
+        specifiedSlices: [],
+      };
+
+      const trafficSlices = dimensionSlices?.results
+        .find((r) => r.dimension === d)
+        ?.dimensionSlices.map((s) => s.name);
+
+      const customDimension = customDimensionMetadata?.find(
+        (m) => m.dimension === d
+      );
+
+      // if custom slices are defined, use them, otherwise use the traffic slices.
+      // If neither are defined, use fall back to the existing values.
+      const specifiedSlices = customDimension?.customSlicesArray?.length
+        ? customDimension.customSlicesArray
+        : trafficSlices ?? existingMetadata.specifiedSlices;
+
+      return {
+        ...existingMetadata,
+        specifiedSlices,
+        customSlices: !!customDimension?.customSlicesArray?.length,
+      };
+    });
+
+    // re-order the dimensions array based on the priority
+    exposureQuery.dimensions = exposureQuery.dimensions.sort((a, b) => {
+      const aMetadata = customDimensionMetadata?.find((m) => m.dimension === a);
+      const bMetadata = customDimensionMetadata?.find((m) => m.dimension === b);
+      // if missing metadata, put it at the end
+      if (!aMetadata) return 1;
+      if (!bMetadata) return -1;
+      return aMetadata.priority - bMetadata.priority;
+    });
+
+    await onSave(copy);
+  }
 };

--- a/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/ExperimentAssignmentQueries.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/ExperimentAssignmentQueries.tsx
@@ -330,7 +330,10 @@ const handleSaveDimensionMetadata = (
   const copy = cloneDeep<DataSourceInterfaceWithParams>(dataSource);
   const exposureQuery = copy.settings?.queries?.exposure?.[editingIndex];
 
-  if (exposureQuery) {
+  if (!exposureQuery) {
+    throw new Error("Exposure queries out of sync. Refresh the page and try again.");
+  }
+
     exposureQuery.dimensionMetadata = exposureQuery.dimensions.map((d) => {
       const existingMetadata = exposureQuery.dimensionMetadata?.find(
         (m) => m.dimension === d
@@ -370,6 +373,5 @@ const handleSaveDimensionMetadata = (
       return aMetadata.priority - bMetadata.priority;
     });
 
-    await onSave(copy);
-  }
+  await onSave(copy);
 };

--- a/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/ExperimentAssignmentQueries.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/ExperimentAssignmentQueries.tsx
@@ -331,47 +331,50 @@ const handleSaveDimensionMetadata = (
   const exposureQuery = copy.settings?.queries?.exposure?.[editingIndex];
 
   if (!exposureQuery) {
-    throw new Error("Exposure queries out of sync. Refresh the page and try again.");
+    console.error(
+      "Exposure queries out of sync. Refresh the page and try again."
+    );
+    return;
   }
 
-    exposureQuery.dimensionMetadata = exposureQuery.dimensions.map((d) => {
-      const existingMetadata = exposureQuery.dimensionMetadata?.find(
-        (m) => m.dimension === d
-      ) ?? {
-        dimension: d,
-        specifiedSlices: [],
-      };
+  exposureQuery.dimensionMetadata = exposureQuery.dimensions.map((d) => {
+    const existingMetadata = exposureQuery.dimensionMetadata?.find(
+      (m) => m.dimension === d
+    ) ?? {
+      dimension: d,
+      specifiedSlices: [],
+    };
 
-      const trafficSlices = dimensionSlices?.results
-        .find((r) => r.dimension === d)
-        ?.dimensionSlices.map((s) => s.name);
+    const trafficSlices = dimensionSlices?.results
+      .find((r) => r.dimension === d)
+      ?.dimensionSlices.map((s) => s.name);
 
-      const customDimension = customDimensionMetadata?.find(
-        (m) => m.dimension === d
-      );
+    const customDimension = customDimensionMetadata?.find(
+      (m) => m.dimension === d
+    );
 
-      // if custom slices are defined, use them, otherwise use the traffic slices.
-      // If neither are defined, use fall back to the existing values.
-      const specifiedSlices = customDimension?.customSlicesArray?.length
-        ? customDimension.customSlicesArray
-        : trafficSlices ?? existingMetadata.specifiedSlices;
+    // if custom slices are defined, use them, otherwise use the traffic slices.
+    // If neither are defined, use fall back to the existing values.
+    const specifiedSlices = customDimension?.customSlicesArray?.length
+      ? customDimension.customSlicesArray
+      : trafficSlices ?? existingMetadata.specifiedSlices;
 
-      return {
-        ...existingMetadata,
-        specifiedSlices,
-        customSlices: !!customDimension?.customSlicesArray?.length,
-      };
-    });
+    return {
+      ...existingMetadata,
+      specifiedSlices,
+      customSlices: !!customDimension?.customSlicesArray?.length,
+    };
+  });
 
-    // re-order the dimensions array based on the priority
-    exposureQuery.dimensions = exposureQuery.dimensions.sort((a, b) => {
-      const aMetadata = customDimensionMetadata?.find((m) => m.dimension === a);
-      const bMetadata = customDimensionMetadata?.find((m) => m.dimension === b);
-      // if missing metadata, put it at the end
-      if (!aMetadata) return 1;
-      if (!bMetadata) return -1;
-      return aMetadata.priority - bMetadata.priority;
-    });
+  // re-order the dimensions array based on the priority
+  exposureQuery.dimensions = exposureQuery.dimensions.sort((a, b) => {
+    const aMetadata = customDimensionMetadata?.find((m) => m.dimension === a);
+    const bMetadata = customDimensionMetadata?.find((m) => m.dimension === b);
+    // if missing metadata, put it at the end
+    if (!aMetadata) return 1;
+    if (!bMetadata) return -1;
+    return aMetadata.priority - bMetadata.priority;
+  });
 
   await onSave(copy);
 };

--- a/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/ExperimentAssignmentQueries.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/ExperimentAssignmentQueries.tsx
@@ -331,10 +331,9 @@ const handleSaveDimensionMetadata = (
   const exposureQuery = copy.settings?.queries?.exposure?.[editingIndex];
 
   if (!exposureQuery) {
-    console.error(
+    throw new Error(
       "Exposure queries out of sync. Refresh the page and try again."
     );
-    return;
   }
 
   exposureQuery.dimensionMetadata = exposureQuery.dimensions.map((d) => {

--- a/packages/front-end/pages/datasources/[did].tsx
+++ b/packages/front-end/pages/datasources/[did].tsx
@@ -42,6 +42,8 @@ function quotePropertyName(name: string) {
   return JSON.stringify(name);
 }
 
+export const EAQ_ANCHOR_ID = "experiment-assignment-queries";
+
 const DataSourcePage: FC = () => {
   const permissionsUtil = usePermissionsUtil();
   const [editConn, setEditConn] = useState(false);
@@ -56,6 +58,7 @@ const DataSourcePage: FC = () => {
   } = useDefinitions();
   const { did } = router.query as { did: string };
   const d = getDatasourceById(did);
+
   const { apiCall } = useAuth();
   const { organization, hasCommercialFeature } = useUser();
 
@@ -379,7 +382,7 @@ mixpanel.init('YOUR PROJECT TOKEN', {
                   </Frame>
                 ) : null}
 
-                <Frame>
+                <Frame id={EAQ_ANCHOR_ID}>
                   <ExperimentAssignmentQueries
                     dataSource={d}
                     onSave={updateDataSourceSettings}

--- a/packages/front-end/pages/dimensions/index.tsx
+++ b/packages/front-end/pages/dimensions/index.tsx
@@ -5,7 +5,6 @@ import clsx from "clsx";
 import Link from "next/link";
 import { ago } from "shared/dates";
 import { Box, Flex } from "@radix-ui/themes";
-import router from "next/router";
 import { DataSourceInterfaceWithParams } from "back-end/types/datasource";
 import LoadingOverlay from "@/components/LoadingOverlay";
 import Button from "@/components/Radix/Button";
@@ -196,18 +195,12 @@ const DimensionsPage: FC = () => {
                   </TableCell>
                   <TableCell>
                     <MoreMenu useRadix={true}>
-                      <a
+                      <Link
                         className="dropdown-item"
                         href={`/datasources/${item.datasourceId}#${EAQ_ANCHOR_ID}`}
-                        onClick={(e) => {
-                          e.preventDefault();
-                          router.push(
-                            `/datasources/${item.datasourceId}#${EAQ_ANCHOR_ID}`
-                          );
-                        }}
                       >
                         Manage via Data Source
-                      </a>
+                      </Link>
                     </MoreMenu>
                   </TableCell>
                 </TableRow>

--- a/packages/front-end/pages/dimensions/index.tsx
+++ b/packages/front-end/pages/dimensions/index.tsx
@@ -4,6 +4,9 @@ import { DimensionInterface } from "back-end/types/dimension";
 import clsx from "clsx";
 import Link from "next/link";
 import { ago } from "shared/dates";
+import { Box, Flex } from "@radix-ui/themes";
+import router from "next/router";
+import { DataSourceInterfaceWithParams } from "back-end/types/datasource";
 import LoadingOverlay from "@/components/LoadingOverlay";
 import Button from "@/components/Radix/Button";
 import DimensionForm from "@/components/Dimensions/DimensionForm";
@@ -15,6 +18,58 @@ import { DocLink } from "@/components/DocLink";
 import Code, { Language } from "@/components/SyntaxHighlighting/Code";
 import Tooltip from "@/components/Tooltip/Tooltip";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
+import { useSearch } from "@/services/search";
+import Table, {
+  TableBody,
+  TableCell,
+  TableHeader,
+  TableRow,
+} from "@/components/Radix/Table";
+import MoreMenu from "@/components/Dropdown/MoreMenu";
+import { EAQ_ANCHOR_ID } from "@/pages/datasources/[did]";
+
+type ExperimentDimensionItem = {
+  dimension: string;
+  datasourceName: string;
+  datasourceId: string;
+  identifierTypes: string[];
+};
+
+function getExperimentDimensions(
+  datasources: DataSourceInterfaceWithParams[]
+): ExperimentDimensionItem[] {
+  const collapsedExperimentDimensions: Record<
+    string,
+    ExperimentDimensionItem
+  > = {};
+
+  datasources.forEach((ds) => {
+    ds.settings.queries?.exposure?.forEach((eq) => {
+      eq.dimensions.forEach((d) => {
+        const key = `${d}-${ds.id}`;
+        if (!collapsedExperimentDimensions[key]) {
+          collapsedExperimentDimensions[key] = {
+            dimension: d,
+            datasourceName: ds.name,
+            datasourceId: ds.id,
+            identifierTypes: [eq.userIdType],
+          };
+        } else if (
+          !collapsedExperimentDimensions[key].identifierTypes.includes(
+            eq.userIdType
+          )
+        ) {
+          collapsedExperimentDimensions[key].identifierTypes.push(
+            eq.userIdType
+          );
+        }
+      });
+    });
+  });
+
+  const experimentDimensions = Object.values(collapsedExperimentDimensions);
+  return experimentDimensions;
+}
 
 const DimensionsPage: FC = () => {
   const {
@@ -37,6 +92,22 @@ const DimensionsPage: FC = () => {
   ] = useState<null | Partial<DimensionInterface>>(null);
 
   const { apiCall } = useAuth();
+
+  const experimentDimensions = getExperimentDimensions(datasources);
+
+  const { items, SortableTH, pagination } = useSearch({
+    items: experimentDimensions,
+    localStorageKey: "dimensions",
+    defaultSortField: "dimension",
+    defaultSortDir: 1,
+    searchFields: [
+      "dimension",
+      "datasourceName",
+      "datasourceId",
+      "identifierTypes",
+    ],
+    pageSize: 10,
+  });
 
   if (!error && !ready) {
     return <LoadingOverlay />;
@@ -86,15 +157,69 @@ const DimensionsPage: FC = () => {
           current={dimensionForm}
         />
       )}
+      <Flex mb="3" direction="column">
+        <Box>
+          <h1>Experiment Dimensions</h1>
+        </Box>
+        <Box mb="3">
+          Experiment Dimensions are specific to the point-in-time that a unit is
+          put into an experiment - for example, &quot;browser&quot; or
+          &quot;referrer&quot;. They are defined via the experiment assignment
+          queries and are the preferred way to specify dimensions.
+        </Box>
+        <Table className="appbox table gbtable responsive-table">
+          <TableHeader>
+            <TableRow>
+              <SortableTH field="dimension">Name</SortableTH>
+              <SortableTH field="datasourceName">Data Source</SortableTH>
+              <SortableTH field="identifierTypes">Identifier Types</SortableTH>
+              <th></th>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {items.map((item) => {
+              return (
+                <TableRow
+                  key={`${item.dimension}-${item.datasourceId}`}
+                  className="hover-highlight"
+                >
+                  <TableCell>{item.dimension}</TableCell>
+                  <TableCell>
+                    <Link href={`/datasources/${item.datasourceId}`}>
+                      {item.datasourceName ?? item.datasourceId}
+                    </Link>
+                  </TableCell>
+                  <TableCell
+                    style={{ maxWidth: "20ch", wordWrap: "break-word" }}
+                  >
+                    {item.identifierTypes.join(", ")}
+                  </TableCell>
+                  <TableCell>
+                    <MoreMenu useRadix={true}>
+                      <a
+                        className="dropdown-item"
+                        href={`/datasources/${item.datasourceId}#${EAQ_ANCHOR_ID}`}
+                        onClick={(e) => {
+                          e.preventDefault();
+                          router.push(
+                            `/datasources/${item.datasourceId}#${EAQ_ANCHOR_ID}`
+                          );
+                        }}
+                      >
+                        Manage via Data Source
+                      </a>
+                    </MoreMenu>
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+        {pagination}
+      </Flex>
       <div className="row mb-3">
         <div className="col-auto d-flex">
-          <h1>User Dimensions</h1>
-          <DocLink
-            docSection="dimensions"
-            className="align-self-center ml-2 pb-1"
-          >
-            View Documentation
-          </DocLink>
+          <h1>Unit Dimensions</h1>
         </div>
         <div style={{ flex: 1 }}></div>
         {!hasFileConfig() && canCreateDimension && (
@@ -104,7 +229,7 @@ const DimensionsPage: FC = () => {
                 setDimensionForm({});
               }}
             >
-              Add User Dimension
+              Add Unit Dimension
             </Button>
           </div>
         )}
@@ -113,9 +238,10 @@ const DimensionsPage: FC = () => {
         <div className="row mb-4">
           <div className="col-12">
             <p>
-              User Dimensions are attributes of your users - for example,
-              &quot;subscription plan&quot; or &quot;age group&quot;. In Growth
-              Book, you can use these to drill down into experiment results.
+              Unit Dimensions are attributes of your units - for example,
+              &quot;subscription plan&quot; or &quot;age group&quot;. GrowthBook
+              will join these dimensions to your units in the exposure query to
+              let you drill down into experiment results.
             </p>
             <table
               className={clsx("table appbox gbtable", {
@@ -232,20 +358,6 @@ const DimensionsPage: FC = () => {
           <DocLink docSection="config_yml">View Documentation</DocLink>
         </div>
       )}
-
-      <div>
-        <h3>Experiment Dimensions</h3>
-        <p>
-          Experiment Dimensions are specific to the point-in-time that a user is
-          put into an experiment - for example, &quot;browser&quot; or
-          &quot;referrer&quot;. These are defined as part of your data source
-          settings.
-        </p>
-
-        <Link href="/datasources" className="btn btn-outline-primary">
-          View Data Sources
-        </Link>
-      </div>
     </div>
   );
 };

--- a/packages/front-end/types/app-features.ts
+++ b/packages/front-end/types/app-features.ts
@@ -73,6 +73,7 @@ export type AppFeatures = {
   "safe-rollout-auto-rollback": boolean;
   "aa-test-holdout": boolean;
   "new-exec-reports": boolean;
+  "pre-computed-dimensions": boolean;
   insights: boolean;
   "sql-explorer": boolean;
 };


### PR DESCRIPTION
### Features and Changes

Allow customers to set custom dimension values as well as dimension priorities (priorities are behind a feature flag for now). It currently only has an effect on the dimension levels used in the health tab, but will eventually be used for auto-dimensions and post-stratification.

This required changes to:

1. The `ExposureQuery` model to save whether custom slices were used and what those values are.

```
export interface ExperimentDimensionMetadata {
  dimension: string;
  specifiedSlices: string[];
  customSlices?: boolean;
}
```
Here the custom slices are saved as the specified slices if they are set, otherwise it falls back to the traffic derived slices. We also store `customSlices` to keep the FE aware of when custom slices have been used as well as keep the specified slices from being overwritten by future "auto updating" slices that are updated via agenda job.

2. The *Update Dimension* modal now lets you specify slices + the priority (which gets saved as the order of the `dimensions` array in the `ExposureQuery`.
![image](https://github.com/user-attachments/assets/c39ac860-cf20-4a5e-8644-63dab81d294e)

3. The `Dimension` landing page has also been updated for more visibility of experiment dimensions
![image](https://github.com/user-attachments/assets/bd456226-45b3-4e2b-a4ce-d1e5948c62cf)

### Testing

- [X] Specific slices and order are saved in exposure query
- [X] Custom slices appear in health tab
- [X] Health tab onboarding still works

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
