### PR TITLE
Add python process pool to reduce CPU and startup costs

### DIFF
--- a/packages/back-end/scripts/stats_server.py
+++ b/packages/back-end/scripts/stats_server.py
@@ -1,0 +1,30 @@
+from dataclasses import asdict
+import json
+import time
+import sys
+from gbstats.gbstats import process_multiple_experiment_results
+
+for line in sys.stdin:
+    start = time.time()
+
+    # Read from stdin
+    input = json.loads(line, strict=False)
+
+    id = input["id"]
+
+    # cast asdict because dataclasses are not serializable
+    results = [asdict(analysis) for analysis in process_multiple_experiment_results(input["data"])]
+    try:
+        sys.stdout.write(json.dumps({
+            'id': id,
+            'results': results,
+            'time': time.time() - start
+        }, allow_nan=False) + "\n")
+    except Exception as e:
+        sys.stdout.write(json.dumps({
+            'id': id,
+            'error': str(e),
+            'time': time.time() - start
+        }, allow_nan=False) + "\n")
+
+    sys.stdout.flush()

--- a/packages/back-end/scripts/stats_server.py
+++ b/packages/back-end/scripts/stats_server.py
@@ -2,6 +2,7 @@ from dataclasses import asdict
 import json
 import time
 import sys
+import traceback
 from gbstats.gbstats import process_multiple_experiment_results
 
 for line in sys.stdin:
@@ -48,7 +49,9 @@ for line in sys.stdin:
     except Exception as e:
         sys.stdout.write(json.dumps({
             'id': id,
-            'error': f"Processing error: {str(e)}",
+            'error': str(e),
+            # Include formatted stack trace
+            'stack_trace': traceback.format_exc(),
             'time': time.time() - start
         }, allow_nan=False) + "\n")
         sys.stdout.flush()

--- a/packages/back-end/scripts/stats_server.py
+++ b/packages/back-end/scripts/stats_server.py
@@ -7,24 +7,48 @@ from gbstats.gbstats import process_multiple_experiment_results
 for line in sys.stdin:
     start = time.time()
 
-    # Read from stdin
-    input = json.loads(line, strict=False)
-
-    id = input["id"]
-
-    # cast asdict because dataclasses are not serializable
-    results = [asdict(analysis) for analysis in process_multiple_experiment_results(input["data"])]
+    # Read from stdin and parse JSON
     try:
+        input = json.loads(line, strict=False)
+    except json.JSONDecodeError as e:
+        sys.stderr.write(f"Invalid JSON input: {str(e)}\n")
+        sys.stderr.flush()
+        continue
+    except Exception as e:
+        sys.stderr.write(f"Unexpected error parsing input: {str(e)}\n")
+        sys.stderr.flush()
+        continue
+
+    # Extract required fields
+    try:
+        id = input["id"]
+        data = input["data"]
+    except KeyError as e:
+        sys.stderr.write(f"Missing required field: {str(e)}\n")
+        sys.stderr.flush()
+        continue
+    except TypeError as e:
+        sys.stderr.write(f"Input is not a valid object: {str(e)}\n")
+        sys.stderr.flush()
+        continue
+    except Exception as e:
+        sys.stderr.write(f"Error extracting fields from input: {str(e)}\n")
+        sys.stderr.flush()
+        continue
+
+    # Process experiment results
+    try:
+        results = [asdict(analysis) for analysis in process_multiple_experiment_results(data)]
         sys.stdout.write(json.dumps({
             'id': id,
             'results': results,
             'time': time.time() - start
         }, allow_nan=False) + "\n")
+        sys.stdout.flush()
     except Exception as e:
         sys.stdout.write(json.dumps({
             'id': id,
-            'error': str(e),
+            'error': f"Processing error: {str(e)}",
             'time': time.time() - start
         }, allow_nan=False) + "\n")
-
-    sys.stdout.flush()
+        sys.stdout.flush()

--- a/packages/back-end/src/services/python.ts
+++ b/packages/back-end/src/services/python.ts
@@ -169,8 +169,8 @@ function getAvgCPU(pre: os.CpuInfo[], post: os.CpuInfo[]) {
     user += postTimes.user - preTimes.user;
     system += postTimes.sys - preTimes.sys;
     total +=
-      Object.values(postTimes).reduce((n, sum) => n + sum, 0) -
-      Object.values(preTimes).reduce((n, sum) => n + sum, 0);
+      Object.values(postTimes).reduce((sum, n) => sum + n, 0) -
+      Object.values(preTimes).reduce((sum, n) => sum + n, 0);
   });
 
   return { user: user / total, system: system / total };

--- a/packages/back-end/src/services/python.ts
+++ b/packages/back-end/src/services/python.ts
@@ -24,7 +24,11 @@ class PythonStatsServer<Input, Output> {
   >;
 
   constructor(script: string) {
-    this.python = spawn("python3", ["-u", script], {
+    const [command, ...pythonArgs] = process.env.GB_ENABLE_PYTHON_DD_PROFILING
+      ? ["ddtrace-run", "python3"]
+      : ["python3"];
+
+    this.python = spawn(command, [...pythonArgs, "-u", script], {
       stdio: ["pipe", "pipe", "pipe"],
     });
     logger.info("Started Python stats server, pid " + this.python.pid);
@@ -153,7 +157,7 @@ export const statsServerPool = createPool(
   }
 );
 
-export function getAvgCPU(pre: os.CpuInfo[], post: os.CpuInfo[]) {
+function getAvgCPU(pre: os.CpuInfo[], post: os.CpuInfo[]) {
   let user = 0;
   let system = 0;
   let total = 0;

--- a/packages/back-end/src/services/python.ts
+++ b/packages/back-end/src/services/python.ts
@@ -1,0 +1,173 @@
+import { ChildProcess, spawn } from "child_process";
+import os from "os";
+import path from "path";
+import { randomUUID } from "crypto";
+import { createPool } from "generic-pool";
+import { MultipleExperimentMetricAnalysis } from "back-end/types/stats";
+import { logger } from "back-end/src/util/logger";
+import { ExperimentDataForStatsEngine } from "back-end/src/services/stats";
+
+type PythonServerResponse<T> = {
+  id: string;
+  time: number;
+  results: T;
+};
+
+class PythonStatsServer<Input, Output> {
+  private python: ChildProcess;
+  private promises: Map<
+    string,
+    {
+      resolve: (value: PythonServerResponse<Output>) => void;
+      reject: (reason?: Error) => void;
+    }
+  >;
+
+  constructor(script: string) {
+    this.python = spawn("python3", ["-u", script], {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    logger.info("Started Python stats server, pid " + this.python.pid);
+    this.promises = new Map();
+
+    this.python.stdout?.on("data", (data) => {
+      const output = data.toString().trim();
+      if (!output) return;
+
+      try {
+        const parsed:
+          | PythonServerResponse<Output>
+          | { id: string; error: string } = JSON.parse(output);
+
+        if (!parsed.id) {
+          logger.error("Python stats server output missing 'id':", parsed);
+          return;
+        }
+
+        const promise = this.promises.get(parsed.id);
+        if (!promise) {
+          logger.error(
+            `Python stats server returned result for unknown id: ${parsed.id}`,
+            parsed
+          );
+          return;
+        }
+
+        if ("error" in parsed) {
+          promise.reject(new Error(parsed.error || "Unknown error"));
+        } else {
+          promise.resolve(parsed);
+        }
+
+        // Delete promise
+        this.promises.delete(parsed.id);
+      } catch (e) {
+        logger.error("Failed to parse Python stats server output:", e);
+        return;
+      }
+    });
+
+    this.python.stderr?.on("data", (data) => {
+      logger.error("Python stats server stderr:", data.toString().trim());
+    });
+
+    // When the process dies
+    this.python.on("close", (code, signal) => {
+      logger.info(
+        `Python stats server exited with code ${code} ${signal}. Destroying server.`
+      );
+      this.destroy();
+    });
+  }
+
+  destroy() {
+    if (this.isRunning()) {
+      this.python.kill();
+    }
+    this.promises.forEach((promise) =>
+      promise.reject(new Error("Stats server killed"))
+    );
+    this.promises = new Map();
+  }
+
+  isRunning() {
+    return this.python.exitCode === null;
+  }
+
+  async call(data: Input) {
+    return new Promise<Output>((resolve, reject) => {
+      const id = randomUUID();
+      const start = Date.now();
+      const cpus = os.cpus();
+
+      // Timeout if the server doesn't respond within 20 seconds
+      // It usually finishes in under 1 second, so this is overly conservative
+      const timer = setTimeout(() => {
+        logger.error(`StatsEngine: Python call timed out for id ${id}`);
+        this.promises.delete(id);
+        reject(new Error("Python stats server call timed out"));
+      }, 20000);
+
+      this.promises.set(id, {
+        resolve: ({ results, time }) => {
+          logger.debug(`StatsEngine: Python time: ${time}`);
+          logger.debug(
+            `StatsEngine: Typescript time: ${(Date.now() - start) / 1000}`
+          );
+          logger.debug(
+            `StatsEngine: Average CPU: ${JSON.stringify(
+              getAvgCPU(cpus, os.cpus())
+            )}`
+          );
+          clearTimeout(timer);
+          resolve(results);
+        },
+        reject: (reason?: Error) => {
+          logger.error(`StatsEngine: Python call failed for id ${id}`, reason);
+          clearTimeout(timer);
+          reject(reason || new Error("Unknown error from Python stats server"));
+        },
+      });
+      this.python.stdin?.write(JSON.stringify({ id, data }) + "\n");
+    });
+  }
+}
+
+export const statsServerPool = createPool(
+  {
+    create: async () => {
+      return new PythonStatsServer<
+        ExperimentDataForStatsEngine[],
+        MultipleExperimentMetricAnalysis[]
+      >(path.join(__dirname, "..", "..", "scripts", "stats_server.py"));
+    },
+    destroy: async (server) => server.destroy(),
+    validate: async (server) => server.isRunning(),
+  },
+  {
+    min: 1,
+    max: 10,
+    testOnBorrow: true,
+    evictionRunIntervalMillis: 60000,
+    numTestsPerEvictionRun: 3,
+  }
+);
+
+export function getAvgCPU(pre: os.CpuInfo[], post: os.CpuInfo[]) {
+  let user = 0;
+  let system = 0;
+  let total = 0;
+
+  post.forEach((cpu, i) => {
+    const preTimes = pre[i]?.times || { user: 0, sys: 0 };
+    const postTimes = cpu.times;
+
+    user += postTimes.user - preTimes.user;
+    system += postTimes.sys - preTimes.sys;
+    total +=
+      Object.values(postTimes).reduce((n, sum) => n + sum, 0) -
+      Object.values(preTimes).reduce((n, sum) => n + sum, 0);
+  });
+
+  return { user: user / total, system: system / total };
+}

--- a/packages/back-end/src/services/stats.ts
+++ b/packages/back-end/src/services/stats.ts
@@ -1,6 +1,3 @@
-import { promisify } from "util";
-import os from "os";
-import { PythonShell } from "python-shell";
 import cloneDeep from "lodash/cloneDeep";
 import {
   BANDIT_SRM_DIMENSION_NAME,
@@ -53,6 +50,7 @@ import { updateSnapshotAnalysis } from "back-end/src/models/ExperimentSnapshotMo
 import { MAX_ROWS_UNIT_AGGREGATE_QUERY } from "back-end/src/integrations/SqlIntegration";
 import { applyMetricOverrides } from "back-end/src/util/integration";
 import { BanditResult } from "back-end/types/experiment";
+import { statsServerPool } from "back-end/src/services/python";
 
 // Keep these interfaces in sync with gbstats
 export interface AnalysisSettingsForStatsEngine {
@@ -138,25 +136,6 @@ export interface ExperimentDataForStatsEngine {
 
 export const MAX_DIMENSIONS = 20;
 
-export function getAvgCPU(pre: os.CpuInfo[], post: os.CpuInfo[]) {
-  let user = 0;
-  let system = 0;
-  let total = 0;
-
-  post.forEach((cpu, i) => {
-    const preTimes = pre[i]?.times || { user: 0, sys: 0 };
-    const postTimes = cpu.times;
-
-    user += postTimes.user - preTimes.user;
-    system += postTimes.sys - preTimes.sys;
-    total +=
-      Object.values(postTimes).reduce((n, sum) => n + sum, 0) -
-      Object.values(preTimes).reduce((n, sum) => n + sum, 0);
-  });
-
-  return { user: user / total, system: system / total };
-}
-
 export function getAnalysisSettingsForStatsEngine(
   settings: ExperimentSnapshotAnalysisSettings,
   variations: ExperimentReportVariation[],
@@ -226,55 +205,14 @@ export function getBanditSettingsForStatsEngine(
 async function runStatsEngine(
   statsData: ExperimentDataForStatsEngine[]
 ): Promise<MultipleExperimentMetricAnalysis[]> {
-  const escapedStatsData = JSON.stringify(statsData).replace(/\\/g, "\\\\");
-  const start = Date.now();
-  const cpus = os.cpus();
-  const options = process.env.GB_ENABLE_PYTHON_DD_PROFILING
-    ? {
-        pythonPath: "ddtrace-run",
-        pythonOptions: ["python3"],
-      }
-    : {};
-  const result = await promisify(PythonShell.runString)(
-    `
-
-from dataclasses import asdict
-import json
-import time
-
-from gbstats.gbstats import process_multiple_experiment_results
-
-start = time.time()
-
-data = json.loads("""${escapedStatsData}""", strict=False)
-
-# cast asdict because dataclasses are not serializable
-results = [asdict(analysis) for analysis in process_multiple_experiment_results(data)]
-
-print(json.dumps({
-  'results': results,
-  'time': time.time() - start
-}, allow_nan=False))`,
-    options
-  );
+  const server = await statsServerPool.acquire();
   try {
-    const parsed: {
-      results: MultipleExperimentMetricAnalysis[];
-      time: number;
-    } = JSON.parse(result?.[0]);
-
-    logger.debug(`StatsEngine: Python time: ${parsed.time}`);
-    logger.debug(
-      `StatsEngine: Typescript time: ${(Date.now() - start) / 1000}`
-    );
-    logger.debug(
-      `StatsEngine: Average CPU: ${JSON.stringify(getAvgCPU(cpus, os.cpus()))}`
-    );
-
-    return parsed.results;
+    return await server.call(statsData);
   } catch (e) {
-    logger.error(e, "Failed to run stats model: " + result);
+    logger.error(e, "Failed to run stats engine");
     throw e;
+  } finally {
+    statsServerPool.release(server);
   }
 }
 

--- a/packages/back-end/src/services/stats.ts
+++ b/packages/back-end/src/services/stats.ts
@@ -208,9 +208,6 @@ async function runStatsEngine(
   const server = await statsServerPool.acquire();
   try {
     return await server.call(statsData);
-  } catch (e) {
-    logger.error(e, "Failed to run stats engine");
-    throw e;
   } finally {
     statsServerPool.release(server);
   }


### PR DESCRIPTION
There are two huge performance problems with our stats engine today:
1. We generate a temporary `.py` file, write it to the file system, and instantiate a new Python shell every time. This is wildly inefficient.
2. We have no concurrency limits, so too many calls to the stats engine at once can overload the server's CPU and impact other parts of the app.

This PR fixes the above problems:
1. We use a long running Python process and stdin/stdout to pass data between Node and Python.
2. We create a pool of Python processes with a max size.  Requests are queued until a process becomes available.

Quick benchmarking on my laptop:
* Single call time went from 2.8s down to 0.8s.  CPU load decreased from 0.18 to 0.10
* With a pool size of 5, CPU maxed out at ~0.45 no matter how many calls were made in parallel.  Before, CPU would grow unbounded and eventually freeze the computer.

TODO:
- [x] Test within docker build
- [x] Test error handling and edge cases
  - [x] Python service gets killed while stats are running
  - [x] Python service times out processing request
  - [x] Python analysis code throws exception
  - [x] Node passes invalid JSON to stats engine
  - [x] Node passes JSON to stats engine that's missing required fields
  - [x] Python outputs invalid JSON in response (e.g. using Infinity or NaN)
  - [x] Python outputs JSON that is missing expected fields
  - [x] Pool / locking behavior with many parallel calls
- [x] Benchmarch CPU usage when calls are happening in parallel.  Is 10 the right concurrency limit to start? (answer: no, we should match # of CPUs, so 4 in prod)