### PR TITLE
Add defaultMappings for useSearch, use it to define a default value for last login

### DIFF
--- a/packages/front-end/components/Settings/Team/MemberList.tsx
+++ b/packages/front-end/components/Settings/Team/MemberList.tsx
@@ -79,7 +79,7 @@ const MemberList: FC<{
     localStorageKey: "members",
     defaultSortField: "name",
     searchFields: ["name", "email"],
-    pageSize: 2,
+    pageSize: 20,
     defaultMappings: {
       lastLoginDate: new Date(0).toISOString(),
     },

--- a/packages/front-end/components/Settings/Team/MemberList.tsx
+++ b/packages/front-end/components/Settings/Team/MemberList.tsx
@@ -79,7 +79,10 @@ const MemberList: FC<{
     localStorageKey: "members",
     defaultSortField: "name",
     searchFields: ["name", "email"],
-    pageSize: 20,
+    pageSize: 2,
+    defaultMappings: {
+      lastLoginDate: new Date(0).toISOString(),
+    },
   });
   return (
     <>

--- a/packages/front-end/services/search.tsx
+++ b/packages/front-end/services/search.tsx
@@ -49,6 +49,7 @@ export interface SearchProps<T> {
   defaultSortField: keyof T;
   defaultSortDir?: number;
   undefinedLast?: boolean;
+  defaultMappings?: Partial<Record<keyof T, unknown>>;
   searchTermFilters?: {
     [key: string]: (
       item: T
@@ -97,6 +98,7 @@ export function useSearch<T>({
   defaultSortField,
   defaultSortDir,
   undefinedLast,
+  defaultMappings = {},
   searchTermFilters,
   updateSearchQueryOnChange,
   pageSize,
@@ -200,8 +202,8 @@ export function useSearch<T>({
     const sorted = [...filtered];
 
     sorted.sort((a, b) => {
-      const comp1 = a[sort.field];
-      const comp2 = b[sort.field];
+      const comp1 = a[sort.field] || defaultMappings[sort.field];
+      const comp2 = b[sort.field] || defaultMappings[sort.field];
       if (undefinedLast) {
         if (comp1 === undefined && comp2 !== undefined) return 1;
         if (comp2 === undefined && comp1 !== undefined) return -1;


### PR DESCRIPTION
Slack reference: https://growthbookapp.slack.com/archives/C05QYS2UFRD/p1751060561841959

This PR addresses an issue when sorting users but last login.

The problem being that the default sorting algorithm is not able to properly account for `undefined` values.

There is an existing `undefinedLast` option but it places entries with undefined value last which is not consistent here.

If a user does not have a last login date, it is expected to be sorted last when sorting by descending last login date and first when sorting by ascending last login date.

This PR achieves that by adding a `defaultMapping` which makes it possible to assign a meaningful default value when sorting items that do not have an entry for the sorting key.

## Screenshots:

### Last login, sorted by descending value:
![Screenshot 2025-07-01 at 4 57 38 PM](https://github.com/user-attachments/assets/3446b08c-01a8-4b97-b0e4-8f68662b1d4d)

### Last login, sorted by ascending value:
![Screenshot 2025-07-01 at 4 57 34 PM](https://github.com/user-attachments/assets/6a2ba333-2ff3-4b5c-b973-c0b1cc50a983)

### Last login, sorted by descending value with 2 entries per page:
![Screenshot 2025-07-01 at 4 56 36 PM](https://github.com/user-attachments/assets/68eefaa0-3909-42b6-a76c-9ee217990b53)

![Screenshot 2025-07-01 at 4 59 05 PM](https://github.com/user-attachments/assets/2bd98f28-d940-46dc-adac-e5fb5ab59c30)

### Last login, sorted by ascending value with 2 entries per page:
![Screenshot 2025-07-01 at 4 57 03 PM](https://github.com/user-attachments/assets/75499998-8e48-43d2-8d4b-c165a3d41053)
![Screenshot 2025-07-01 at 4 59 50 PM](https://github.com/user-attachments/assets/931d7c04-06ae-4ba8-a1e4-42a75c8a6292)
