### PR TITLE
Fix envs with parents

### DIFF
--- a/packages/back-end/src/models/FeatureRevisionModel.ts
+++ b/packages/back-end/src/models/FeatureRevisionModel.ts
@@ -101,7 +101,16 @@ export async function getMinimalRevisions(
     .sort({ version: -1 })
     .limit(25);
 
-  return docs.map((m) => toInterface(m, context));
+  return docs.map(
+    (m) =>
+      ({
+        version: m.version,
+        datePublished: m.datePublished,
+        dateUpdated: m.dateUpdated,
+        createdBy: m.createdBy,
+        status: m.status,
+      } as MinimalFeatureRevisionInterface)
+  );
 }
 
 export async function getLatestRevisions(

--- a/packages/back-end/src/models/FeatureRevisionModel.ts
+++ b/packages/back-end/src/models/FeatureRevisionModel.ts
@@ -101,16 +101,13 @@ export async function getMinimalRevisions(
     .sort({ version: -1 })
     .limit(25);
 
-  return docs.map(
-    (m) =>
-      ({
-        version: m.version,
-        datePublished: m.datePublished,
-        dateUpdated: m.dateUpdated,
-        createdBy: m.createdBy,
-        status: m.status,
-      } as MinimalFeatureRevisionInterface)
-  );
+  return docs.map((m) => ({
+    version: m.version,
+    datePublished: m.datePublished,
+    dateUpdated: m.dateUpdated,
+    createdBy: m.createdBy,
+    status: m.status,
+  }));
 }
 
 export async function getLatestRevisions(


### PR DESCRIPTION
### Features and Changes

toInterface expects rules to exist, and errored for those orgs with envs that had a "parent" env.  We shouldn't have been calling toInterface because we just wanted a minimal interface.

### Testing

Loaded a feature page on an org with a parent env saw no error.

