### PR TITLE
updating covariance calculation for binomial metrics in CUPED

### DIFF
--- a/docs/docs/statistics/cuped-technical.mdx
+++ b/docs/docs/statistics/cuped-technical.mdx
@@ -54,6 +54,26 @@ $$
 
 Our estimated variance of $\hat{\Delta}_{A}$ is $\hat{\sigma}^{2}_{\Delta_{A}} = V_{adj, C} + V_{adj, T}$.
 
+Formulae for variances of the statistics can be found in our sections on [proportion metrics](/statistics/details#proportion-metrics) and [mean metrics](/statistics/details#mean-metrics).
+When estimating the covariance between two binomial variables $X$ and $Y$, we use the following formula:
+
+$$
+\begin{align*}
+\sigma_{XY} &= E(XY) - E(X)E(Y)
+\\ &= P(X=1, Y=1) - P(X=1)P(Y=1)
+\\ &= P(X=1) * P(Y=1|X=1) - P(X=1)P(Y=1)
+\\ &= P(X=1) * (P(Y=1|X=1) - P(Y=1)).
+\end{align*}
+$$
+
+For mean metrics, we use the usual covariance formula:
+
+$$
+\begin{align*}
+\sigma_{XY} &= \frac{1}{N-1} \sum_{i=1}^{N} (X_i - \bar{X})(Y_i - \bar{Y}).
+\end{align*}
+$$
+
 ## Mean or Binomial Metric, Relative case
 
 For relative inference (i.e., estimating lift), the parameter of interest is

--- a/packages/stats/gbstats/models/statistics.py
+++ b/packages/stats/gbstats/models/statistics.py
@@ -141,6 +141,10 @@ class RegressionAdjustedStatistic(Statistic):
     post_pre_sum_of_products: float
     theta: Optional[float]
 
+    def __post_init__(self) -> None:
+        if not isinstance(self.post_statistic, type(self.pre_statistic)):
+            raise TypeError("post_statistic and pre_statistic must be of the same type")
+
     def __add__(self, other):
         if not isinstance(other, RegressionAdjustedStatistic):
             raise TypeError("Can add only another RegressionAdjustedStatistic instance")
@@ -187,10 +191,31 @@ class RegressionAdjustedStatistic(Statistic):
     def covariance(self) -> float:
         if self.n <= 1:
             return 0
+        if isinstance(self.post_statistic, ProportionStatistic) and isinstance(
+            self.pre_statistic, ProportionStatistic
+        ):
+            return binomial_covariance(
+                self.n,
+                self.post_statistic,
+                self.pre_statistic,
+                self.post_pre_sum_of_products,
+            )
         return (
             self.post_pre_sum_of_products
             - self.post_statistic.sum * self.pre_statistic.sum / self.n
         ) / (self.n - 1)
+
+
+# return the covariance of two proportion statistics
+def binomial_covariance(
+    n: int,
+    a: ProportionStatistic,
+    b: ProportionStatistic,
+    cross_statistic_sum_of_products: float,
+):
+    if n == 0:
+        return 0
+    return cross_statistic_sum_of_products / n - a.mean * b.mean
 
 
 def compute_theta(
@@ -246,6 +271,20 @@ class RegressionAdjustedRatioStatistic(Statistic):
     m_post_d_pre_sum_of_products: float
     m_pre_d_post_sum_of_products: float
     theta: Optional[float]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.m_statistic_post, type(self.d_statistic_post)):
+            raise TypeError(
+                "m_statistic_post and d_statistic_post must be of the same type"
+            )
+        if not isinstance(self.m_statistic_post, type(self.m_statistic_pre)):
+            raise TypeError(
+                "m_statistic_post and m_statistic_pre must be of the same type"
+            )
+        if not isinstance(self.m_statistic_post, type(self.d_statistic_pre)):
+            raise TypeError(
+                "m_statistic_post and d_statistic_pre must be of the same type"
+            )
 
     def __add__(self, other):
         if not isinstance(other, RegressionAdjustedRatioStatistic):
@@ -323,6 +362,15 @@ class RegressionAdjustedRatioStatistic(Statistic):
     def cov_m_pre_d_pre(self) -> float:
         if self.n <= 1:
             return 0
+        if isinstance(self.m_statistic_pre, ProportionStatistic) and isinstance(
+            self.d_statistic_pre, ProportionStatistic
+        ):
+            return binomial_covariance(
+                self.n,
+                self.m_statistic_pre,
+                self.d_statistic_pre,
+                self.m_pre_d_pre_sum_of_products,
+            )
         return (
             self.m_pre_d_pre_sum_of_products
             - self.m_statistic_pre.sum * self.d_statistic_pre.sum / self.n
@@ -332,6 +380,15 @@ class RegressionAdjustedRatioStatistic(Statistic):
     def cov_m_post_d_post(self) -> float:
         if self.n <= 1:
             return 0
+        if isinstance(self.m_statistic_post, ProportionStatistic) and isinstance(
+            self.d_statistic_post, ProportionStatistic
+        ):
+            return binomial_covariance(
+                self.n,
+                self.m_statistic_post,
+                self.d_statistic_post,
+                self.m_post_d_post_sum_of_products,
+            )
         return (
             self.m_post_d_post_sum_of_products
             - self.m_statistic_post.sum * self.d_statistic_post.sum / self.n
@@ -341,6 +398,15 @@ class RegressionAdjustedRatioStatistic(Statistic):
     def cov_m_post_m_pre(self) -> float:
         if self.n <= 1:
             return 0
+        if isinstance(self.m_statistic_post, ProportionStatistic) and isinstance(
+            self.m_statistic_pre, ProportionStatistic
+        ):
+            return binomial_covariance(
+                self.n,
+                self.m_statistic_post,
+                self.m_statistic_pre,
+                self.m_post_m_pre_sum_of_products,
+            )
         return (
             self.m_post_m_pre_sum_of_products
             - self.m_statistic_post.sum * self.m_statistic_pre.sum / self.n
@@ -350,6 +416,15 @@ class RegressionAdjustedRatioStatistic(Statistic):
     def cov_d_post_d_pre(self) -> float:
         if self.n <= 1:
             return 0
+        if isinstance(self.d_statistic_post, ProportionStatistic) and isinstance(
+            self.d_statistic_pre, ProportionStatistic
+        ):
+            return binomial_covariance(
+                self.n,
+                self.d_statistic_post,
+                self.d_statistic_pre,
+                self.d_post_d_pre_sum_of_products,
+            )
         return (
             self.d_post_d_pre_sum_of_products
             - self.d_statistic_post.sum * self.d_statistic_pre.sum / self.n
@@ -359,6 +434,15 @@ class RegressionAdjustedRatioStatistic(Statistic):
     def cov_m_post_d_pre(self) -> float:
         if self.n <= 1:
             return 0
+        if isinstance(self.m_statistic_post, ProportionStatistic) and isinstance(
+            self.d_statistic_pre, ProportionStatistic
+        ):
+            return binomial_covariance(
+                self.n,
+                self.m_statistic_post,
+                self.d_statistic_pre,
+                self.m_post_d_pre_sum_of_products,
+            )
         return (
             self.m_post_d_pre_sum_of_products
             - self.m_statistic_post.sum * self.d_statistic_pre.sum / self.n
@@ -368,6 +452,15 @@ class RegressionAdjustedRatioStatistic(Statistic):
     def cov_d_post_m_pre(self) -> float:
         if self.n <= 1:
             return 0
+        if isinstance(self.d_statistic_post, ProportionStatistic) and isinstance(
+            self.m_statistic_pre, ProportionStatistic
+        ):
+            return binomial_covariance(
+                self.n,
+                self.d_statistic_post,
+                self.m_statistic_pre,
+                self.m_pre_d_post_sum_of_products,
+            )
         return (
             self.m_pre_d_post_sum_of_products
             - self.m_statistic_pre.sum * self.d_statistic_post.sum / self.n
@@ -555,7 +648,9 @@ class QuantileClusteredStatistic(QuantileStatistic):
             * self.n_clusters
             / (self.n_clusters - 1)
         )
-        num = sigma_2_s - 2 * mu_s * sigma_s_n / mu_n + mu_s**2 * sigma_2_n / mu_n**2
+        num = (
+            sigma_2_s - 2 * mu_s * sigma_s_n / mu_n + mu_s**2 * sigma_2_n / mu_n**2
+        )
         den = self.n_clusters * mu_n**2
         return num / den
 

--- a/packages/stats/gbstats/models/statistics.py
+++ b/packages/stats/gbstats/models/statistics.py
@@ -126,12 +126,12 @@ class RatioStatistic(Statistic):
 
     @property
     def covariance(self):
-        return SampleCovariance(
+        return compute_covariance(
             n=self.n,
             stat_a=self.m_statistic,
             stat_b=self.d_statistic,
             sum_of_products=self.m_d_sum_of_products,
-        ).compute_covariance()
+        )
 
 
 @dataclass
@@ -189,67 +189,32 @@ class RegressionAdjustedStatistic(Statistic):
 
     @property
     def covariance(self) -> float:
-        return SampleCovariance(
+        return compute_covariance(
             n=self.n,
             stat_a=self.post_statistic,
             stat_b=self.pre_statistic,
             sum_of_products=self.post_pre_sum_of_products,
-        ).compute_covariance()
-
-
-class SampleCovariance:
-    def __init__(
-        self,
-        n: int,
-        stat_a: Union[SampleMeanStatistic, ProportionStatistic],
-        stat_b: Union[SampleMeanStatistic, ProportionStatistic],
-        sum_of_products: float,
-    ):
-        self.n = n
-        self.stat_a = stat_a
-        self.stat_b = stat_b
-        self.sum_of_products = sum_of_products
-        if not isinstance(self.stat_a, type(self.stat_b)):
-            raise TypeError("stat_a and stat_b must be of the same type")
-
-    def compute_covariance(self) -> float:
-        if isinstance(self.stat_a, ProportionStatistic) and isinstance(
-            self.stat_b, ProportionStatistic
-        ):
-            return self.binomial_covariance(
-                self.n,
-                self.stat_a.sum,
-                self.stat_b.sum,
-                self.sum_of_products,
-            )
-        return self.mean_covariance(
-            self.n,
-            self.stat_a.sum,
-            self.stat_b.sum,
-            self.sum_of_products,
         )
 
-    @staticmethod
-    def mean_covariance(
-        n: int,
-        sum_a: float,
-        sum_b: float,
-        cross_statistic_sum_of_products: float,
-    ):
-        if n <= 1:
-            return 0
-        return (cross_statistic_sum_of_products - sum_a * sum_b / n) / (n - 1)
 
-    @staticmethod
-    def binomial_covariance(
-        n: int,
-        sum_a: float,
-        sum_b: float,
-        cross_statistic_sum_of_products: float,
+def compute_covariance(
+    n: int,
+    stat_a: Union[SampleMeanStatistic, ProportionStatistic],
+    stat_b: Union[SampleMeanStatistic, ProportionStatistic],
+    sum_of_products: float,
+) -> float:
+    if not isinstance(stat_a, type(stat_b)):
+        raise TypeError("stat_a and stat_b must be of the same type")
+
+    if n <= 1:
+        return 0
+
+    if isinstance(stat_a, ProportionStatistic) and isinstance(
+        stat_b, ProportionStatistic
     ):
-        if n == 0:
-            return 0
-        return cross_statistic_sum_of_products / n - sum_a * sum_b / n**2
+        return sum_of_products / n - stat_a.sum * stat_b.sum / n**2
+    else:
+        return (sum_of_products - stat_a.sum * stat_b.sum / n) / (n - 1)
 
 
 def compute_theta(
@@ -394,57 +359,57 @@ class RegressionAdjustedRatioStatistic(Statistic):
 
     @property
     def cov_m_pre_d_pre(self) -> float:
-        return SampleCovariance(
+        return compute_covariance(
             n=self.n,
             stat_a=self.m_statistic_pre,
             stat_b=self.d_statistic_pre,
             sum_of_products=self.m_pre_d_pre_sum_of_products,
-        ).compute_covariance()
+        )
 
     @property
     def cov_m_post_d_post(self) -> float:
-        return SampleCovariance(
+        return compute_covariance(
             n=self.n,
             stat_a=self.m_statistic_post,
             stat_b=self.d_statistic_post,
             sum_of_products=self.m_post_d_post_sum_of_products,
-        ).compute_covariance()
+        )
 
     @property
     def cov_m_post_m_pre(self) -> float:
-        return SampleCovariance(
+        return compute_covariance(
             n=self.n,
             stat_a=self.m_statistic_post,
             stat_b=self.m_statistic_pre,
             sum_of_products=self.m_post_m_pre_sum_of_products,
-        ).compute_covariance()
+        )
 
     @property
     def cov_d_post_d_pre(self) -> float:
-        return SampleCovariance(
+        return compute_covariance(
             n=self.n,
             stat_a=self.d_statistic_post,
             stat_b=self.d_statistic_pre,
             sum_of_products=self.d_post_d_pre_sum_of_products,
-        ).compute_covariance()
+        )
 
     @property
     def cov_m_post_d_pre(self) -> float:
-        return SampleCovariance(
+        return compute_covariance(
             n=self.n,
             stat_a=self.m_statistic_post,
             stat_b=self.d_statistic_pre,
             sum_of_products=self.m_post_d_pre_sum_of_products,
-        ).compute_covariance()
+        )
 
     @property
     def cov_d_post_m_pre(self) -> float:
-        return SampleCovariance(
+        return compute_covariance(
             n=self.n,
             stat_a=self.d_statistic_post,
             stat_b=self.m_statistic_pre,
             sum_of_products=self.m_pre_d_post_sum_of_products,
-        ).compute_covariance()
+        )
 
     @property
     def betahat(self) -> np.ndarray:

--- a/packages/stats/gbstats/models/statistics.py
+++ b/packages/stats/gbstats/models/statistics.py
@@ -593,9 +593,7 @@ class QuantileClusteredStatistic(QuantileStatistic):
             * self.n_clusters
             / (self.n_clusters - 1)
         )
-        num = (
-            sigma_2_s - 2 * mu_s * sigma_s_n / mu_n + mu_s**2 * sigma_2_n / mu_n**2
-        )
+        num = sigma_2_s - 2 * mu_s * sigma_s_n / mu_n + mu_s**2 * sigma_2_n / mu_n**2
         den = self.n_clusters * mu_n**2
         return num / den
 

--- a/packages/stats/tests/test_gbstats.py
+++ b/packages/stats/tests/test_gbstats.py
@@ -807,9 +807,9 @@ class TestAnalyzeMetricDfRegressionAdjustment(TestCase):
         self.assertEqual(round_(result.at[0, "v1_cr"]), 0.074)
         self.assertEqual(round_(result.at[0, "v1_mean"]), 0.074)
         self.assertEqual(result.at[0, "v1_risk"], None)
-        self.assertEqual(round_(result.at[0, "v1_expected"]), -0.316211568)
+        self.assertEqual(round_(result.at[0, "v1_expected"]), -0.31620216)
         self.assertEqual(result.at[0, "v1_prob_beat_baseline"], None)
-        self.assertEqual(round_(result.at[0, "v1_p_value"]), 0.000000352)
+        self.assertEqual(round_(result.at[0, "v1_p_value"]), 0.000000353)
 
     def test_analyze_metric_df_ratio_ra(self):
         rows = RATIO_RA_STATISTICS_DF

--- a/packages/stats/tests/test_shared_models.py
+++ b/packages/stats/tests/test_shared_models.py
@@ -262,8 +262,8 @@ class TestEffectMomentsResult(TestCase):
         moments = EffectMoments(
             [(stat_a, stat_b)], config=EffectMomentsConfig(difference_type="absolute")
         )
-        self.assertEqual(moments.stat_a.theta, 0.9722222222222223)  # type: ignore
-        self.assertEqual(moments.stat_b.theta, 0.9722222222222223)  # type: ignore
+        self.assertEqual(moments.stat_a.theta, 0.8333333333333334)  # type: ignore
+        self.assertEqual(moments.stat_b.theta, 0.8333333333333334)  # type: ignore
 
     def test_negative_variance(self):
         stat_a = RASTAT_A
@@ -271,10 +271,8 @@ class TestEffectMomentsResult(TestCase):
         moments = EffectMoments(
             [(stat_a, stat_b)], config=EffectMomentsConfig(difference_type="absolute")
         )
-        self.assertEqual(moments.variance, -0.025084304983996344)
-        self.assertEqual(
-            moments.compute_result().error_message, ZERO_NEGATIVE_VARIANCE_MESSAGE
-        )
+        self.assertEqual(moments.variance, 0.04893261316872429)
+        self.assertEqual(moments.compute_result().error_message, None)
 
 
 if __name__ == "__main__":

--- a/packages/stats/tests/test_shared_models.py
+++ b/packages/stats/tests/test_shared_models.py
@@ -3,7 +3,7 @@
 2. Demonstrating equivalence to numpy methods that take raw data"""
 
 from unittest import TestCase, main as unittest_main
-
+import copy
 import numpy as np
 
 from gbstats.messages import ZERO_NEGATIVE_VARIANCE_MESSAGE
@@ -266,13 +266,16 @@ class TestEffectMomentsResult(TestCase):
         self.assertEqual(moments.stat_b.theta, 0.8333333333333334)  # type: ignore
 
     def test_negative_variance(self):
-        stat_a = RASTAT_A
+        stat_a = copy.deepcopy(RASTAT_A)
         stat_b = RASTAT_B
+        stat_a.post_statistic.sum = -7
         moments = EffectMoments(
             [(stat_a, stat_b)], config=EffectMomentsConfig(difference_type="absolute")
         )
-        self.assertEqual(moments.variance, 0.04893261316872429)
-        self.assertEqual(moments.compute_result().error_message, None)
+        self.assertEqual(moments.variance, -1.2010673868312758)
+        self.assertEqual(
+            moments.compute_result().error_message, ZERO_NEGATIVE_VARIANCE_MESSAGE
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
currently the covariance calculation used in regression adjusted statistics that have binomial metric components for the pre- and post- statistics is wrong in that it does not leverage the fact that these are binomial random variables.  Because our variance calculations do make this assumption, this can lead to a covariance matrix that is negative definite, potentially leading to negative variance estimates, pre-post correlations bigger than 1, etc.  

Practically speaking, this issue surfaces only when sample sizes are small in CUPED analyses of binomial metrics, as the standard sample variance and the binomial variance estimation becomes close as n increases.  

This PR changes adds a check for binomial statistics in our covariance calculation to obviate future errors at small sample sizes.   