### PR TITLE
Ignore python stderr open telemetry warnings

### DIFF
--- a/packages/back-end/src/services/python.ts
+++ b/packages/back-end/src/services/python.ts
@@ -91,11 +91,12 @@ class PythonStatsServer<Input, Output> {
     });
 
     this.python.stderr?.on("data", (data) => {
-      logger.error(
-        `Python stats server (pid: ${
-          this.pid
-        }) stderr: ${data.toString().trim()}`
-      );
+      const err = data.toString().trim();
+      // Ignore OpenTelemetry warnings from ddtrace-run
+      // They are just informational and there's no easy way to disable them
+      if (err.match(/OTEL_/)) return;
+
+      logger.error(`Python stats server (pid: ${this.pid}) stderr: ${err}`);
     });
 
     // When the process dies


### PR DESCRIPTION
When running Python with `ddtrace-run`, it outputs warnings to stderr about `OTEL_` env vars not being supported and ignored.  This has no effect on anything and is just noise.  This PR skips logging for these warnings to keep the error logs clean.