### PR TITLE
Bump react types to v19

### DIFF
--- a/packages/sdk-react/src/GrowthBookReact.tsx
+++ b/packages/sdk-react/src/GrowthBookReact.tsx
@@ -110,7 +110,7 @@ export function FeaturesReady({
   children: React.ReactNode;
   timeout?: number;
   fallback?: React.ReactNode;
-}) {
+}): React.ReactElement {
   const gb = useGrowthBook();
   const [hitTimeout, setHitTimeout] = React.useState(false);
   const ready = gb ? gb.ready : false;
@@ -136,11 +136,14 @@ export function IfFeatureEnabled({
 }: {
   children: React.ReactNode;
   feature: string;
-}) {
+}): React.ReactElement | null {
   return useFeature(feature).on ? <>{children}</> : null;
 }
 
-export function FeatureString(props: { default: string; feature: string }) {
+export function FeatureString(props: {
+  default: string;
+  feature: string;
+}): React.ReactElement {
   const value = useFeature(props.feature).value;
 
   if (value !== null) {
@@ -154,9 +157,9 @@ export const withRunExperiment = <P extends WithRunExperimentProps>(
   Component: React.ComponentType<P>
 ): React.ComponentType<Omit<P, keyof WithRunExperimentProps>> => {
   // eslint-disable-next-line
-  const withRunExperimentWrapper = (props: any): JSX.Element => (
+  const withRunExperimentWrapper = (props: any): React.ReactElement => (
     <GrowthBookContext.Consumer>
-      {({ growthbook }): JSX.Element => {
+      {({ growthbook }): React.ReactElement => {
         return (
           <Component
             {...(props as P)}


### PR DESCRIPTION
### Features and Changes

Updates `@types/react` and `@types/react-dom` from v18 to v19. This should solve typescript build errors for react@19 applications.

- Closes #4204

### Testing

Create a react@19 app with typescript, add dependency to growthbook-react sdk and run tsc build.