### PR TITLE
removing check blocking results

### DIFF
--- a/packages/stats/gbstats/models/statistics.py
+++ b/packages/stats/gbstats/models/statistics.py
@@ -203,8 +203,6 @@ def compute_covariance(
     stat_b: Union[SampleMeanStatistic, ProportionStatistic],
     sum_of_products: float,
 ) -> float:
-    if not isinstance(stat_a, type(stat_b)):
-        raise TypeError("stat_a and stat_b must be of the same type")
 
     if n <= 1:
         return 0
@@ -593,7 +591,9 @@ class QuantileClusteredStatistic(QuantileStatistic):
             * self.n_clusters
             / (self.n_clusters - 1)
         )
-        num = sigma_2_s - 2 * mu_s * sigma_s_n / mu_n + mu_s**2 * sigma_2_n / mu_n**2
+        num = (
+            sigma_2_s - 2 * mu_s * sigma_s_n / mu_n + mu_s**2 * sigma_2_n / mu_n**2
+        )
         den = self.n_clusters * mu_n**2
         return num / den
 


### PR DESCRIPTION
removing a type check causing a results run to fail.  

if the type check should truly fail, then the statistics are of different types, in which case we will use standard moment-based estimation for the `theta` parameter in CUPED.  For large sample sizes, the moment-based estimation and binomial estimation give similar `theta`, so it's not worth blocking results.  