### PR TITLE
updating type checks in RegressionAdjustedRatioStatistic

### DIFF
--- a/packages/stats/gbstats/models/statistics.py
+++ b/packages/stats/gbstats/models/statistics.py
@@ -270,17 +270,13 @@ class RegressionAdjustedRatioStatistic(Statistic):
     theta: Optional[float]
 
     def __post_init__(self) -> None:
-        if not isinstance(self.m_statistic_post, type(self.d_statistic_post)):
-            raise TypeError(
-                "m_statistic_post and d_statistic_post must be of the same type"
-            )
         if not isinstance(self.m_statistic_post, type(self.m_statistic_pre)):
             raise TypeError(
                 "m_statistic_post and m_statistic_pre must be of the same type"
             )
-        if not isinstance(self.m_statistic_post, type(self.d_statistic_pre)):
+        if not isinstance(self.d_statistic_post, type(self.d_statistic_pre)):
             raise TypeError(
-                "m_statistic_post and d_statistic_pre must be of the same type"
+                "d_statistic_post and d_statistic_pre must be of the same type"
             )
 
     def __add__(self, other):


### PR DESCRIPTION
we should allow `SampleMeanStatistic` in numerator and `ProportionStatistic` in denominator.  Currently our `RegressionAdjustedRatioStatistic` does not permit this.  

changing checks for `RegressionAdjustedRatioStatistic` so that now we check for only:
1. the numerator post-statistic and numerator pre-statistic are of the same type
2. the denominator post-statistic and denominator pre-statistic are of the same type

