### PR TITLE
deploy new image to prod-api-jobs cluster and service as well

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: "20"
 
       - name: Generate sentry sourcemaps
         run: |
@@ -98,8 +98,8 @@ jobs:
       - name: Create Sentry release
         uses: getsentry/action-release@v1
         with:
-          environment: 'production'
-          sourcemaps: './back-end-dist'
+          environment: "production"
+          sourcemaps: "./back-end-dist"
           version: ${{ github.sha }}
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -108,3 +108,6 @@ jobs:
 
       - name: Deploy docker image to ECS for GrowthBook Cloud API
         run: aws ecs update-service --cluster prod-api --service prod-api --force-new-deployment --region us-east-1
+
+      - name: Deploy docker image to ECS for GrowthBook Cloud Jobs
+        run: aws ecs update-service --cluster prod-api-jobs --service prod-api-jobs --force-new-deployment --region us-east-1


### PR DESCRIPTION
### Features and Changes
What the title says.  We want the new cluster so that jobs can run on their own machines and not affect users.

### Dependencies

[infra needs to be there](https://github.com/growthbook/terraform/pull/104)

