### PR TITLE
Fix CRON_DISABLED to only disable running of cron, not queueing

### DIFF
--- a/packages/back-end/src/init/queue.ts
+++ b/packages/back-end/src/init/queue.ts
@@ -20,7 +20,6 @@ import { logger } from "back-end/src/util/logger";
 import addSafeRolloutSnapshotJob from "back-end/src/jobs/addSafeRolloutSnapshotJob";
 
 export async function queueInit() {
-  if (!CRON_ENABLED) return;
   const agenda = getAgendaInstance();
 
   addExperimentResultsJob(agenda);
@@ -46,7 +45,9 @@ export async function queueInit() {
     });
   deleteOldAgendaJobs(agenda);
 
-  await agenda.start();
+  if (CRON_ENABLED) {
+    await agenda.start();
+  }
 
   if (!IS_CLOUD) {
     await queueUpdateLicense();

--- a/packages/back-end/src/jobs/proxyUpdate.ts
+++ b/packages/back-end/src/jobs/proxyUpdate.ts
@@ -3,7 +3,7 @@ import Agenda, { Job } from "agenda";
 import { getConnectionSDKCapabilities } from "shared/sdk-versioning";
 import { filterProjectsByEnvironmentWithNull } from "shared/util";
 import { getFeatureDefinitions } from "back-end/src/services/features";
-import { CRON_ENABLED, IS_CLOUD } from "back-end/src/util/secrets";
+import { IS_CLOUD } from "back-end/src/util/secrets";
 import { SDKPayloadKey } from "back-end/types/sdk-payload";
 import {
   clearProxyError,
@@ -176,7 +176,6 @@ export async function queueProxyUpdate(
   context: ReqContext | ApiReqContext,
   payloadKeys: SDKPayloadKey[]
 ) {
-  if (!CRON_ENABLED) return;
   if (!payloadKeys.length) return;
 
   const connections = await findSDKConnectionsByOrganization(context);

--- a/packages/back-end/src/jobs/sdkWebhooks.ts
+++ b/packages/back-end/src/jobs/sdkWebhooks.ts
@@ -5,7 +5,7 @@ import { getConnectionSDKCapabilities } from "shared/sdk-versioning";
 import { filterProjectsByEnvironmentWithNull } from "shared/util";
 import { Promise as BluebirdPromise } from "bluebird";
 import { getFeatureDefinitions } from "back-end/src/services/features";
-import { CRON_ENABLED, WEBHOOKS } from "back-end/src/util/secrets";
+import { WEBHOOKS } from "back-end/src/util/secrets";
 import { SDKPayloadKey } from "back-end/types/sdk-payload";
 import {
   findSDKConnectionsByIds,
@@ -127,7 +127,6 @@ export async function queueWebhooksBySdkPayloadKeys(
   context: ReqContext | ApiReqContext,
   payloadKeys: SDKPayloadKey[]
 ) {
-  if (!CRON_ENABLED) return;
   if (!payloadKeys.length) return;
   const connections = await findSDKConnectionsByOrganization(context);
 

--- a/packages/back-end/src/jobs/webhooks.ts
+++ b/packages/back-end/src/jobs/webhooks.ts
@@ -6,7 +6,6 @@ import {
   getExperimentOverrides,
 } from "back-end/src/services/organizations";
 import { getFeatureDefinitions } from "back-end/src/services/features";
-import { CRON_ENABLED } from "back-end/src/util/secrets";
 import { SDKPayloadKey } from "back-end/types/sdk-payload";
 import {
   findAllLegacySdkWebhooks,
@@ -127,7 +126,6 @@ export async function queueLegacySdkWebhooks(
   payloadKeys: SDKPayloadKey[],
   isFeature?: boolean
 ) {
-  if (!CRON_ENABLED) return;
   if (!payloadKeys.length) return;
 
   const webhooks = await findAllLegacySdkWebhooks(context);


### PR DESCRIPTION
### Features and Changes

On the `api` cluster we no longer want to run jobs.  However we still want the jobs to be queued correctly.  CRON_DISABLED was also stopping jobs being queued.  It is unlikely then that anyone was actually using it.

### Testing
`yarn dev`
See no job messages appear in logs.


