### PR TITLE
Adds disabled limit checkbox to SQL Explorer

### DIFF
--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -25,7 +25,7 @@ import {
   BANDIT_SRM_DIMENSION_NAME,
   SAFE_ROLLOUT_TRACKING_KEY_PREFIX,
 } from "shared/constants";
-import { ensureLimit, format } from "shared/sql";
+import { ensureLimit, format, SQL_EXPLORER_LIMIT } from "shared/sql";
 import { FormatDialect } from "shared/src/types";
 import { MetricAnalysisSettings } from "back-end/types/metric-analysis";
 import { UNITS_TABLE_PREFIX } from "back-end/src/queryRunners/ExperimentResultsQueryRunner";
@@ -1413,7 +1413,7 @@ export default abstract class SqlIntegration
   }
 
   getFreeFormQuery(sql: string, limit?: number): string {
-    const limitedQuery = this.ensureMaxLimit(sql, limit ?? 1000);
+    const limitedQuery = this.ensureMaxLimit(sql, limit ?? SQL_EXPLORER_LIMIT);
     return format(limitedQuery, this.getFormatDialect());
   }
 

--- a/packages/front-end/components/SchemaBrowser/SqlExplorerModal.tsx
+++ b/packages/front-end/components/SchemaBrowser/SqlExplorerModal.tsx
@@ -14,7 +14,7 @@ import {
 } from "back-end/src/validators/saved-queries";
 import { Box, Flex, Text } from "@radix-ui/themes";
 import { getValidDate } from "shared/dates";
-import { isReadOnlySQL } from "shared/sql";
+import { isReadOnlySQL, SQL_EXPLORER_LIMIT } from "shared/sql";
 import { useAuth } from "@/services/auth";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import { useUser } from "@/services/UserContext";
@@ -160,7 +160,7 @@ export default function SqlExplorerModal({
         body: JSON.stringify({
           query: sql,
           datasourceId: form.watch("datasourceId"),
-          limit: 1000,
+          limit: SQL_EXPLORER_LIMIT,
         }),
       });
       return res;
@@ -531,6 +531,23 @@ export default function SqlExplorerModal({
                           </Text>
                           {!readOnlyMode ? (
                             <Flex gap="3">
+                              <Tooltip body="The SQL Explorer automatically applies a 1000 row limit to ensure optimal performance.">
+                                <input
+                                  type="checkbox"
+                                  className="form-check-input"
+                                  id={`limit-toggle`}
+                                  checked={true}
+                                  disabled={true}
+                                />
+                                <Text
+                                  size="1"
+                                  weight="medium"
+                                  style={{ color: "var(--gray-8)" }}
+                                  className="cursor-pointer"
+                                >
+                                  Limit to {SQL_EXPLORER_LIMIT} rows
+                                </Text>
+                              </Tooltip>
                               {formatError && (
                                 <Tooltip body={formatError}>
                                   <span>

--- a/packages/shared/src/sql.ts
+++ b/packages/shared/src/sql.ts
@@ -1,6 +1,8 @@
 import { format as sqlFormat } from "sql-formatter";
 import { FormatDialect, FormatError } from "./types";
 
+export const SQL_EXPLORER_LIMIT = 1000;
+
 export function format(
   sql: string,
   dialect?: FormatDialect,


### PR DESCRIPTION
### Features and Changes

This PR adds an always-disabled checkbox to the SQL Explorer to communicate to users that there is a 1000 row limit imposed on all queries ran via the SQL Explorer. I've wrapped the checkbox with a tooltip to add context about why this is the case.

Additionally, I've defined a shared const `SQL_EXPLORER_LIMIT` in the shared directory so we can reference the same limit everywhere.

In the future, we may change the limit and possibly even make it an org-level or project-level setting, but for now its defined via the const.

### Dependencies

None

### Testing

- [x] Ensure the checkbox is always disabled and the state can't be changed
- [x] Ensure the the tooltip renders to add context for the user

### Screenshots

![Screenshot 2025-07-07 at 2 17 33 PM](https://github.com/user-attachments/assets/749901bd-649d-4599-84f2-05f9e7f159f4)

