### PR TITLE
Mobile styling for /experiment

### DIFF
--- a/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
@@ -647,7 +647,7 @@ export default function ExperimentHeader({
 
       <div className="container-fluid pagecontents position-relative experiment-header px-3 pt-3">
         <div className="d-flex align-items-center flex-wrap">
-          <Flex direction="row" wrap="wrap" align="center" overflow="auto">
+          <Flex direction="row" align="center" wrap="wrap" overflow="auto">
             <h1 className="mb-0">{experiment.name}</h1>
             <Box ml="2">
               <ExperimentStatusIndicator experimentData={experiment} />

--- a/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
@@ -646,8 +646,8 @@ export default function ExperimentHeader({
       )}
 
       <div className="container-fluid pagecontents position-relative experiment-header px-3 pt-3">
-        <div className="d-flex align-items-center">
-          <Flex direction="row" align="center">
+        <div className="d-flex align-items-center flex-wrap">
+          <Flex direction="row" wrap="wrap" align="center" overflow="auto">
             <h1 className="mb-0">{experiment.name}</h1>
             <Box ml="2">
               <ExperimentStatusIndicator experimentData={experiment} />

--- a/packages/front-end/components/Experiment/TabbedPage/ProjectTagBar.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/ProjectTagBar.tsx
@@ -146,7 +146,7 @@ export default function ProjectTagBar({
   };
   return (
     <div className="pb-3">
-      <Flex gap="3" mt="2" mb="1">
+      <Flex gap="3" mt="2" mb="1" wrap="wrap">
         {renderProject()}
         <Metadata label="Experiment Key" value={trackingKey || "None"} />
         <Metadata label="Created" value={createdDate} />


### PR DESCRIPTION
### Features and Changes

Improves mobile styling for `/experiment` by wrapping long content on smaller screens. Notice header sections cause analysis section below to have shrinked width.

### Dependencies

n/a

### Testing

Confirm no UI regressions on mobile and desktop

### Screenshots

#### Without changes
<img height="300" alt="Screenshot 2025-07-07 at 21 28 59" src="https://github.com/user-attachments/assets/2c3b86f1-9e1f-4ce8-8073-c2d650ec013e" /><img height="300" alt="Screenshot 2025-07-07 at 21 06 10" src="https://github.com/user-attachments/assets/7d35a117-6abc-454a-8a4e-cb0095c6edcd" /><img height="300" alt="Screenshot 2025-07-07 at 21 06 05" src="https://github.com/user-attachments/assets/d2a31c50-f993-44bc-aa96-ec6f52fb06b8" />

#### With changes
<img height="300" alt="Screenshot 2025-07-07 at 21 05 05" src="https://github.com/user-attachments/assets/988eb072-5615-4fbe-a916-c20c33c8a783" /><img height="300" alt="Screenshot 2025-07-07 at 21 04 54" src="https://github.com/user-attachments/assets/ad889f5d-e41a-4316-bf16-3bc7ab4a801d" /><img height="300" alt="Screenshot 2025-07-07 at 21 04 44" src="https://github.com/user-attachments/assets/a6d47ac9-f05f-4fa3-ba14-cf13e9cca297" />

