### PR TITLE
fix(dimensions): fix saving dimension slices ID when updated

### DIFF
--- a/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/ExperimentAssignmentQueries.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/ExperimentAssignmentQueries.tsx
@@ -375,5 +375,10 @@ const handleSaveDimensionMetadata = (
     return aMetadata.priority - bMetadata.priority;
   });
 
+  // if dimension slices updated, update the dimension slices id
+  if (dimensionSlices) {
+    exposureQuery.dimensionSlicesId = dimensionSlices.id;
+  }
+
   await onSave(copy);
 };


### PR DESCRIPTION
Bugfix to save dimension slices id to pull in latest traffic data when viewing dimensions modal.

https://www.loom.com/share/b633569df14f45d186a117505f32543d