### PR TITLE
computing MDE for midexperiment power

### DIFF
--- a/packages/back-end/types/stats.d.ts
+++ b/packages/back-end/types/stats.d.ts
@@ -49,7 +49,7 @@ interface FrequentistVariationResponse extends BaseVariationResponse {
 // Keep in sync with gbstats PowerResponse
 export interface MetricPowerResponseFromStatsEngine {
   status: string;
-  errorMessage?: string;
+  scalingFactorErrorMessage?: string;
   firstPeriodPairwiseSampleSize?: number;
   targetMDE: number;
   sigmahat2Delta?: number;
@@ -58,6 +58,9 @@ export interface MetricPowerResponseFromStatsEngine {
   priorLiftVariance?: number;
   upperBoundAchieved?: boolean;
   scalingFactor?: number;
+  mde?: number;
+  mdeConverged?: boolean;
+  mdeErrorMessage?: string;
 }
 
 interface BaseDimensionResponse {

--- a/packages/shared/src/enterprise/power.ts
+++ b/packages/shared/src/enterprise/power.ts
@@ -138,11 +138,11 @@ export function calculateMidExperimentPowerSingle(
     );
   }
   const response = params.variation;
-  if (response?.errorMessage) {
+  if (response?.scalingFactorErrorMessage) {
     return calculateMidExperimentPowerSingleError(
       metricId,
       variation,
-      response.errorMessage
+      response.scalingFactorErrorMessage
     );
   }
   if (response.firstPeriodPairwiseSampleSize === undefined) {
@@ -374,7 +374,7 @@ export function calculateMidExperimentPower(
           variation: variation,
           power: undefined,
           effectSize: variationMetricData.targetMDE,
-          errorMessage: variationMetricData.errorMessage,
+          errorMessage: variationMetricData.scalingFactorErrorMessage,
         });
       } else {
         const powerParams: MidExperimentPowerParamsSingle = {

--- a/packages/stats/gbstats/gbstats.py
+++ b/packages/stats/gbstats/gbstats.py
@@ -326,9 +326,12 @@ def analyze_metric_df(
             df[f"v{i}_prior_lift_mean"] = None
             df[f"v{i}_prior_lift_variance"] = None
             df[f"v{i}_power_status"] = None
-            df[f"v{i}_power_error_message"] = None
+            df[f"v{i}_scaling_factor_error_message"] = None
             df[f"v{i}_power_upper_bound_acheieved"] = None
             df[f"v{i}_scaling_factor"] = None
+            df[f"v{i}_mde"] = None
+            df[f"v{i}_mde_converged"] = None
+            df[f"v{i}_mde_error_message"] = None
 
     def analyze_row(s: pd.Series) -> pd.Series:
         s = s.copy()
@@ -373,26 +376,32 @@ def analyze_metric_df(
                     test.stat_a, test.stat_b, res, config, power_config
                 )
 
-                s[f"v{i}_first_period_pairwise_users"] = (
-                    mid_experiment_power.pairwise_sample_size
-                )
+                s[
+                    f"v{i}_first_period_pairwise_users"
+                ] = mid_experiment_power.pairwise_sample_size
                 s[f"v{i}_target_mde"] = metric.target_mde
                 s[f"v{i}_sigmahat_2_delta"] = mid_experiment_power.sigmahat_2_delta
                 if mid_experiment_power.prior_effect:
                     s[f"v{i}_prior_proper"] = mid_experiment_power.prior_effect.proper
                     s[f"v{i}_prior_lift_mean"] = mid_experiment_power.prior_effect.mean
-                    s[f"v{i}_prior_lift_variance"] = (
-                        mid_experiment_power.prior_effect.variance
-                    )
+                    s[
+                        f"v{i}_prior_lift_variance"
+                    ] = mid_experiment_power.prior_effect.variance
                 mid_experiment_power_result = (
                     mid_experiment_power.calculate_sample_size()
                 )
                 s[f"v{i}_power_status"] = mid_experiment_power_result.update_message
-                s[f"v{i}_power_error_message"] = mid_experiment_power_result.error
-                s[f"v{i}_power_upper_bound_achieved"] = (
-                    mid_experiment_power_result.upper_bound_achieved
-                )
+                s[
+                    f"v{i}_scaling_factor_error_message"
+                ] = mid_experiment_power_result.error
+                s[
+                    f"v{i}_power_upper_bound_achieved"
+                ] = mid_experiment_power_result.upper_bound_achieved
                 s[f"v{i}_scaling_factor"] = mid_experiment_power_result.scaling_factor
+                mde_result = mid_experiment_power.calculate_mde()
+                s[f"v{i}_mde"] = mde_result.mde
+                s[f"v{i}_mde_converged"] = mde_result.converged
+                s[f"v{i}_mde_error_message"] = mde_result.error
 
             s["baseline_cr"] = test.stat_a.unadjusted_mean
             s["baseline_mean"] = test.stat_a.unadjusted_mean
@@ -492,7 +501,7 @@ def format_variation_result(
         if row[f"{prefix}_decision_making_conditions"]:
             power_response = PowerResponse(
                 status=row[f"{prefix}_power_status"],
-                errorMessage=row[f"{prefix}_power_error_message"],
+                scalingFactorErrorMessage=row[f"{prefix}_scaling_factor_error_message"],
                 firstPeriodPairwiseSampleSize=row[
                     f"{prefix}_first_period_pairwise_users"
                 ],
@@ -503,6 +512,9 @@ def format_variation_result(
                 priorLiftVariance=row[f"{prefix}_prior_lift_variance"],
                 upperBoundAchieved=row[f"{prefix}_power_upper_bound_achieved"],
                 scalingFactor=row[f"{prefix}_scaling_factor"],
+                mde=row[f"{prefix}_mde"],
+                mdeConverged=row[f"{prefix}_mde_converged"],
+                mdeErrorMessage=row[f"{prefix}_mde_error_message"],
             )
         else:
             power_response = None

--- a/packages/stats/gbstats/models/results.py
+++ b/packages/stats/gbstats/models/results.py
@@ -48,7 +48,7 @@ class BaselineResponse:
 @dataclass
 class PowerResponse:
     status: str
-    errorMessage: Optional[str]
+    scalingFactorErrorMessage: Optional[str]
     firstPeriodPairwiseSampleSize: Optional[float]
     targetMDE: float
     sigmahat2Delta: Optional[float]
@@ -57,6 +57,9 @@ class PowerResponse:
     priorLiftVariance: Optional[float]
     upperBoundAchieved: Optional[bool]
     scalingFactor: Optional[float]
+    mde: Optional[float]
+    mdeConverged: Optional[bool]
+    mdeErrorMessage: Optional[str]
 
 
 ResponseCI = Tuple[Optional[float], Optional[float]]

--- a/packages/stats/tests/test_midexperimentpower.py
+++ b/packages/stats/tests/test_midexperimentpower.py
@@ -89,39 +89,67 @@ class TestMidExperimentPower(TestCase):
         self.result_freq = self.m_freq.calculate_scaling_factor()
         self.result_seq = self.m_seq.calculate_scaling_factor()
         self.result_bayes = self.m_bayes.calculate_scaling_factor()
+        self.mde_freq = self.m_freq.calculate_mde().mde
+        self.mde_seq = self.m_seq.calculate_mde().mde
+        self.mde_bayes = self.m_bayes.calculate_mde().mde
 
     def test_calculate_midexperiment_power_freq(self):
         scaling_factor_true = 25.45703125
+        mde_true = 0.25717773437500885
         if self.result_freq.scaling_factor:
             self.assertAlmostEqual(
-                self.m_freq.power(self.result_freq.scaling_factor), 0.8, places=4
+                self.m_freq.power(
+                    self.result_freq.scaling_factor, self.m_freq.target_mde
+                ),
+                0.8,
+                places=4,
             )
             self.assertAlmostEqual(
                 self.result_freq.scaling_factor, scaling_factor_true, places=4
             )
         else:
             raise ValueError("scaling_factor_freq is None")
+        if self.mde_freq:
+            self.assertAlmostEqual(self.mde_freq, mde_true, places=4)
+        else:
+            raise ValueError("mde_freq is None")
 
     def test_calculate_midexperiment_power_seq(self):
         scaling_factor_true = 55.66796875
+        mde_true = 0.38605957031251326
         if self.result_seq.scaling_factor:
             self.assertAlmostEqual(
-                self.m_seq.power(self.result_seq.scaling_factor), 0.8, places=4
+                self.m_seq.power(self.result_seq.scaling_factor, self.m_seq.target_mde),
+                0.8,
+                places=4,
             )
             self.assertAlmostEqual(
                 self.result_seq.scaling_factor, scaling_factor_true, places=4
             )
         else:
             raise ValueError("scaling_factor_seq is None")
+        if self.mde_seq:
+            self.assertAlmostEqual(self.mde_seq, mde_true, places=4)
+        else:
+            raise ValueError("mde_seq is None")
 
     def test_calculate_midexperiment_power_bayesian(self):
         scaling_factor_true = 13.9404296875
+        mde_true = 0.20833129882812576
         if self.result_bayes.scaling_factor:
             self.assertAlmostEqual(
-                self.m_bayes.power(self.result_bayes.scaling_factor), 0.8, places=4
+                self.m_bayes.power(
+                    self.result_bayes.scaling_factor, self.m_bayes.target_mde
+                ),
+                0.8,
+                places=4,
             )
             self.assertAlmostEqual(
                 self.result_bayes.scaling_factor, scaling_factor_true, places=4
             )
         else:
             raise ValueError("scaling_factor_bayes is None")
+        if self.mde_bayes:
+            self.assertAlmostEqual(self.mde_bayes, mde_true, places=4)
+        else:
+            raise ValueError("mde_bayes is None")


### PR DESCRIPTION
Currently GrowthBook customers do not have a mechanism for easily determining whether their target MDE is too large.  This PR calculates the MDE during the middle of the experiment.  By comparing the outputted MDE to the target MDE, the customer can see if their target MDE is much too big.  

TODO: 
align on how and when to surface the target MDE
all front end work
