### PR TITLE
Revert "Revert "add a jobQueue monitoring job (#4262)""

### DIFF
--- a/packages/back-end/src/init/queue.ts
+++ b/packages/back-end/src/init/queue.ts
@@ -18,6 +18,7 @@ import updateLicenseJob, {
 import deleteOldAgendaJobs from "back-end/src/jobs/deleteOldAgendaJobs";
 import { logger } from "back-end/src/util/logger";
 import addSafeRolloutSnapshotJob from "back-end/src/jobs/addSafeRolloutSnapshotJob";
+import addMonitorJobQueueJob from "back-end/src/jobs/monitorJobQueueJob";
 
 export async function queueInit() {
   const agenda = getAgendaInstance();
@@ -36,6 +37,7 @@ export async function queueInit() {
   addSdkWebhooksJob(agenda);
   updateLicenseJob(agenda);
   addSafeRolloutSnapshotJob(agenda);
+  addMonitorJobQueueJob(agenda);
 
   // Make sure we have index needed to delete efficiently
   agenda._collection

--- a/packages/back-end/src/jobs/monitorJobQueueJob.ts
+++ b/packages/back-end/src/jobs/monitorJobQueueJob.ts
@@ -1,0 +1,62 @@
+import Agenda from "agenda";
+import { getAgendaInstance } from "back-end/src/services/queueing";
+import { trackJob } from "back-end/src/services/tracing";
+import { logger } from "back-end/src/util/logger";
+import { Gauge, metrics } from "back-end/src/util/metrics";
+
+const MONITOR_JOB_QUEUE_NAME = "monitorJobQueue";
+
+const addMonitorJobQueueJob = trackJob(MONITOR_JOB_QUEUE_NAME, async () => {
+  const agenda = getAgendaInstance();
+
+  const now = new Date();
+
+  try {
+    // Query the AgendaJobs collection
+    const jobsCollection = agenda._collection;
+
+    // Find jobs waiting to be run ASAP (nextRunAt <= now and lockedAt is null)
+    const waitingJobs = await jobsCollection
+      .find({
+        nextRunAt: { $lte: now }, // Jobs that should have already started
+        lockedAt: null, // Jobs that are not locked yet
+      })
+      .toArray();
+
+    const waitingCount = waitingJobs.length;
+
+    // Calculate the average waiting time
+    const totalWaitingTime = waitingJobs.reduce((sum, job) => {
+      const waitingTime = now.getTime() - new Date(job.nextRunAt).getTime();
+      return sum + waitingTime;
+    }, 0);
+
+    const averageWaitingTime =
+      waitingCount > 0 ? totalWaitingTime / waitingCount : 0;
+
+    const waitingGauge: Gauge = metrics.getGauge("jobs.waiting_count");
+    const averageWaitingTimeGauge: Gauge = metrics.getGauge(
+      "jobs.average_waiting_time"
+    );
+
+    // Post metrics to Datadog
+    waitingGauge.record(waitingCount, {
+      job_name: MONITOR_JOB_QUEUE_NAME,
+    });
+    averageWaitingTimeGauge.record(averageWaitingTime, {
+      job_name: MONITOR_JOB_QUEUE_NAME,
+    });
+  } catch (error) {
+    logger.error("Error monitoring job queue:", error);
+  }
+});
+
+export default async function (agenda: Agenda) {
+  agenda.define(MONITOR_JOB_QUEUE_NAME, addMonitorJobQueueJob);
+
+  const job = agenda.create(MONITOR_JOB_QUEUE_NAME, {});
+  job.unique({});
+  job.repeatEvery("60 seconds");
+  job.priority("low");
+  await job.save();
+}

--- a/packages/back-end/src/tracing.datadog.ts
+++ b/packages/back-end/src/tracing.datadog.ts
@@ -34,7 +34,20 @@ class Histogram {
   }
 }
 
+class Gauge {
+  name: string;
+
+  constructor(name: string) {
+    this.name = name;
+  }
+
+  record(v: number, attributes?: Attributes) {
+    tracer.dogstatsd.gauge(this.name, v, attributes);
+  }
+}
+
 setMetrics({
   getCounter: (name: string) => new Counter(name),
   getHistogram: (name: string) => new Histogram(name),
+  getGauge: (name: string) => new Gauge(name),
 });

--- a/packages/back-end/src/tracing.opentelemetry.ts
+++ b/packages/back-end/src/tracing.opentelemetry.ts
@@ -87,8 +87,21 @@ const getCounter = (name: string) => {
   };
 };
 
+const getGauge = (name: string) => {
+  const gauge = otlMetrics.getMeter(name).createObservableGauge(name);
+
+  return {
+    record: (value: number, attributes?: Attributes) => {
+      gauge.addCallback((observableResult) => {
+        observableResult.observe(value, attributes);
+      });
+    },
+  };
+};
+
 setMetrics({
   getCounter,
   getHistogram: (name: string) =>
     otlMetrics.getMeter(name).createHistogram(name),
+  getGauge,
 });

--- a/packages/back-end/src/util/metrics.ts
+++ b/packages/back-end/src/util/metrics.ts
@@ -9,9 +9,14 @@ export type Histogram = {
   record: (value: number, attributes?: Attributes) => void;
 };
 
+export type Gauge = {
+  record: (value: number, attributes?: Attributes) => void;
+};
+
 type Metrics = {
   getCounter: (_: string) => Counter;
   getHistogram: (_: string) => Histogram;
+  getGauge: (_: string) => Gauge;
 };
 
 export const metrics: Metrics = {
@@ -20,6 +25,9 @@ export const metrics: Metrics = {
     decrement: () => undefined,
   }),
   getHistogram: (_: string) => ({
+    record: () => undefined,
+  }),
+  getGauge: (_: string) => ({
     record: () => undefined,
   }),
 };


### PR DESCRIPTION
This reverts commit 0e3a4ef6cc29a523cefd4ce340952b909c13c86b.

That means it is putting the monitoring back in.  I don't think it is impacting the jobs servers that badly, and we need the insight in how the queue is doing in order to manually scale the jobs servers.
