### PR TITLE
Updates SQL Explorer front end

### DIFF
--- a/packages/front-end/components/SchemaBrowser/SqlExplorerModal.tsx
+++ b/packages/front-end/components/SchemaBrowser/SqlExplorerModal.tsx
@@ -307,6 +307,18 @@ export default function SqlExplorerModal({
     }
   };
 
+  const getTruncatedTitle = (
+    title: string,
+    totalVisualizationCount: number
+  ): string => {
+    // Only truncate if there are 4 or more visualizations
+    if (totalVisualizationCount < 4) return title;
+
+    const maxLength = 20;
+    if (title.length <= maxLength) return title;
+    return title.substring(0, maxLength) + "...";
+  };
+
   // Filter datasources to only those that support SQL queries
   // Also only show datasources that the user has permission to query
   const validDatasources = datasources.filter(
@@ -451,7 +463,14 @@ export default function SqlExplorerModal({
                     style={{ paddingRight: "0px" }}
                   >
                     <Flex align="center" gap="2">
-                      {config.title || `Visualization ${index + 1}`}
+                      <span
+                        title={config.title || `Visualization ${index + 1}`}
+                      >
+                        {getTruncatedTitle(
+                          config.title || `Visualization ${index + 1}`,
+                          dataVizConfig.length
+                        )}
+                      </span>
                       {!readOnlyMode && tab === `visualization-${index}` ? (
                         <DropdownMenu
                           trigger={

--- a/packages/front-end/components/SchemaBrowser/SqlExplorerModal.tsx
+++ b/packages/front-end/components/SchemaBrowser/SqlExplorerModal.tsx
@@ -1,12 +1,13 @@
 import { useCallback, useState } from "react";
 import { useForm } from "react-hook-form";
+import { FaPlay, FaExclamationTriangle } from "react-icons/fa";
 import {
-  FaPlay,
-  FaExclamationTriangle,
-  FaCheck,
-  FaTimes,
-} from "react-icons/fa";
-import { PiCaretDoubleRight, PiPencilSimpleFill } from "react-icons/pi";
+  PiCaretDoubleRight,
+  PiCheck,
+  PiFileSql,
+  PiPencilSimpleFill,
+  PiX,
+} from "react-icons/pi";
 import {
   DataVizConfig,
   SavedQuery,
@@ -43,11 +44,7 @@ import { SqlExplorerDataVisualization } from "../DataViz/SqlExplorerDataVisualiz
 import Modal from "../Modal";
 import SelectField from "../Forms/SelectField";
 import Tooltip from "../Tooltip/Tooltip";
-import {
-  DropdownMenu,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-} from "../Radix/DropdownMenu";
+import { DropdownMenu, DropdownMenuItem } from "../Radix/DropdownMenu";
 import SchemaBrowser from "./SchemaBrowser";
 import styles from "./EditSqlModal.module.scss";
 
@@ -384,7 +381,6 @@ export default function SqlExplorerModal({
                       <Flex align="center" gap="2">
                         <input
                           type="text"
-                          className="form-control"
                           value={tempName}
                           placeholder="Enter a name..."
                           onChange={(e) => setTempName(e.target.value)}
@@ -399,32 +395,37 @@ export default function SqlExplorerModal({
                               setIsEditingName(false);
                             }
                           }}
+                          style={{
+                            border: "none",
+                            outline: "none",
+                          }}
                         />
                         <Button
-                          variant="ghost"
-                          size="sm"
-                          onClick={() => {
-                            setTempName(form.watch("name"));
-                            setIsEditingName(false);
-                          }}
-                        >
-                          <FaTimes color="var(--gray-11)" />
-                        </Button>
-                        <Button
-                          variant="ghost"
-                          size="sm"
+                          variant="outline"
+                          size="xs"
                           onClick={() => {
                             setDirty(true);
                             form.setValue("name", tempName);
                             setIsEditingName(false);
                           }}
                         >
-                          <FaCheck color="var(--accent-11)" />
+                          <PiCheck />
+                        </Button>
+                        <Button
+                          color="red"
+                          variant="outline"
+                          size="xs"
+                          onClick={() => {
+                            setTempName(form.watch("name"));
+                            setIsEditingName(false);
+                          }}
+                        >
+                          <PiX />
                         </Button>
                       </Flex>
                     ) : (
                       <>
-                        <strong>SQL :</strong>{" "}
+                        <PiFileSql size={20} />
                         {form.watch("name") || "Untitled Query..."}
                         {!readOnlyMode && tab === "sql" ? (
                           <Button
@@ -450,31 +451,39 @@ export default function SqlExplorerModal({
                       {!readOnlyMode && tab === `visualization-${index}` ? (
                         <DropdownMenu
                           trigger={
-                            <Button variant="ghost" size="sm">
+                            <Button size="sm" variant="ghost">
                               <BsThreeDotsVertical />
                             </Button>
                           }
                         >
-                          <DropdownMenuItem
-                            onClick={() => {
-                              setDirty(true);
-                              const newDataVizConfig = [
-                                ...dataVizConfig,
-                                {
-                                  ...config,
-                                  title: `${
-                                    config.title || `Visualization ${index + 1}`
-                                  } (Copy)`,
-                                },
-                              ];
-                              form.setValue("dataVizConfig", newDataVizConfig);
-                              setTab(`visualization-${dataVizConfig.length}`);
-                            }}
-                            disabled={dataVizConfig.length >= 5}
+                          <Tooltip
+                            body="You can only add up to 5 visualizations to a query."
+                            shouldDisplay={dataVizConfig.length >= 5}
                           >
-                            Duplicate
-                          </DropdownMenuItem>
-                          <DropdownMenuSeparator />
+                            <DropdownMenuItem
+                              onClick={() => {
+                                setDirty(true);
+                                const newDataVizConfig = [
+                                  ...dataVizConfig,
+                                  {
+                                    ...config,
+                                    title: `${
+                                      config.title ||
+                                      `Visualization ${index + 1}`
+                                    } (Copy)`,
+                                  },
+                                ];
+                                form.setValue(
+                                  "dataVizConfig",
+                                  newDataVizConfig
+                                );
+                                setTab(`visualization-${dataVizConfig.length}`);
+                              }}
+                              disabled={dataVizConfig.length >= 5}
+                            >
+                              Duplicate
+                            </DropdownMenuItem>
+                          </Tooltip>
                           <DropdownMenuItem
                             color="red"
                             onClick={() => {
@@ -502,7 +511,7 @@ export default function SqlExplorerModal({
               {!readOnlyMode ? (
                 <Tooltip
                   shouldDisplay={dataVizConfig.length >= 5}
-                  body="You can only add up to 5 visualizations to a query from this modal."
+                  body="You can only add up to 5 visualizations to a query."
                 >
                   <Button
                     variant="ghost"

--- a/packages/front-end/components/SchemaBrowser/SqlExplorerModal.tsx
+++ b/packages/front-end/components/SchemaBrowser/SqlExplorerModal.tsx
@@ -445,15 +445,19 @@ export default function SqlExplorerModal({
                   </Flex>
                 </TabsTrigger>
                 {dataVizConfig.map((config, index) => (
-                  <TabsTrigger value={`visualization-${index}`} key={index}>
+                  <TabsTrigger
+                    value={`visualization-${index}`}
+                    key={index}
+                    style={{ paddingRight: "0px" }}
+                  >
                     <Flex align="center" gap="2">
                       {config.title || `Visualization ${index + 1}`}
                       {!readOnlyMode && tab === `visualization-${index}` ? (
                         <DropdownMenu
                           trigger={
-                            <Button size="sm" variant="ghost">
-                              <BsThreeDotsVertical />
-                            </Button>
+                            <button className="btn btn-link pr-0">
+                              <BsThreeDotsVertical color="black" />
+                            </button>
                           }
                         >
                           <Tooltip

--- a/packages/front-end/components/SchemaBrowser/SqlExplorerModal.tsx
+++ b/packages/front-end/components/SchemaBrowser/SqlExplorerModal.tsx
@@ -457,8 +457,8 @@ export default function SqlExplorerModal({
                           }
                         >
                           <Tooltip
-                            body="You can only add up to 5 visualizations to a query."
-                            shouldDisplay={dataVizConfig.length >= 5}
+                            body="You can only add up to 10 visualizations to a query."
+                            shouldDisplay={dataVizConfig.length >= 10}
                           >
                             <DropdownMenuItem
                               onClick={() => {
@@ -479,7 +479,7 @@ export default function SqlExplorerModal({
                                 );
                                 setTab(`visualization-${dataVizConfig.length}`);
                               }}
-                              disabled={dataVizConfig.length >= 5}
+                              disabled={dataVizConfig.length >= 10}
                             >
                               Duplicate
                             </DropdownMenuItem>
@@ -510,8 +510,8 @@ export default function SqlExplorerModal({
               </TabsList>
               {!readOnlyMode ? (
                 <Tooltip
-                  shouldDisplay={dataVizConfig.length >= 5}
-                  body="You can only add up to 5 visualizations to a query."
+                  shouldDisplay={dataVizConfig.length >= 10}
+                  body="You can only add up to 10 visualizations to a query."
                 >
                   <Button
                     variant="ghost"
@@ -526,11 +526,13 @@ export default function SqlExplorerModal({
                       setTab(`visualization-${currentConfig.length}`);
                       setSidePanel(true);
                     }}
-                    title={dataVizConfig.length >= 5 ? "" : "Add Visualization"}
+                    title={
+                      dataVizConfig.length >= 10 ? "" : "Add Visualization"
+                    }
                     disabled={
                       !form.watch("results").results ||
                       form.watch("results").results.length === 0 ||
-                      dataVizConfig.length >= 5
+                      dataVizConfig.length >= 10
                     }
                   >
                     <VisualizationAddIcon />{" "}

--- a/packages/front-end/components/SchemaBrowser/SqlExplorerModal.tsx
+++ b/packages/front-end/components/SchemaBrowser/SqlExplorerModal.tsx
@@ -456,7 +456,7 @@ export default function SqlExplorerModal({
                         <DropdownMenu
                           trigger={
                             <button className="btn btn-link pr-0">
-                              <BsThreeDotsVertical color="black" />
+                              <BsThreeDotsVertical color="var(--text-color-main" />
                             </button>
                           }
                         >


### PR DESCRIPTION
### Features and Changes

This PR introduces a few new changes:

- A user can now duplicate a visualization
- We've updated the tab to use a dropdown so users can now choose to duplicate or delete a visualization
- I've also updated the sql tab so the edit icon is only rendered when that tab is focused, to be more consistent with the other tabs
- I've also updated the max number of visualizations from 3 to 10
- I've also added a SQL icon to the sql tab to differentiate that tab vs the visualization tabs
- We've also added logic so that if there are more than 3 variations, we start to truncate the visualization tab names to save space.

### Dependencies

- None

### Testing

- [x] Ensure this works for both light and dark modes
- [x] Ensure that you can add up to 10 visualizations
- [x] Ensure that the sql tab only shows the edit icon when the tab is focused
- [x] Ensure that the saved query input field is rendered in a way that matches the mock and uses the correct buttons
- [x] Ensure that the horizontal scroll works well when a saved query has a high number of visualizations or if the visualizations have long names
- [x] Ensure the duplicate visualization button is only enabled when there are less than 10 visualizations - and if not, a tooltip is rendered
- [x] Ensure that if there are 10 visualizations, the add visualization button is still rendered, but it's disabled with a tooltip explaining why
- [x] Ensure the duplicate viz functionality works correctly

### Screenshots
<img width="1420" height="902" alt="Screenshot 2025-07-14 at 1 37 22 PM" src="https://github.com/user-attachments/assets/f9d2b6ea-fd23-4af9-bdcb-61dc339841cd" />
<img width="1419" height="902" alt="Screenshot 2025-07-14 at 1 37 33 PM" src="https://github.com/user-attachments/assets/af47aa26-5b6a-47bf-bfbf-0dfb228f8f85" />
<img width="1417" height="897" alt="Screenshot 2025-07-14 at 1 37 52 PM" src="https://github.com/user-attachments/assets/98b89923-c14d-4e70-9b79-fa2ed41cd436" />
<img width="1411" height="899" alt="Screenshot 2025-07-14 at 1 37 58 PM" src="https://github.com/user-attachments/assets/6041944d-e9a5-426a-9fc2-5a2003fd6617" />
<img width="1414" height="900" alt="Screenshot 2025-07-14 at 1 38 04 PM" src="https://github.com/user-attachments/assets/146ae1e2-816a-49f4-a98d-23cf43e4cd7c" />
<img width="1416" height="900" alt="Screenshot 2025-07-14 at 1 38 24 PM" src="https://github.com/user-attachments/assets/32dbc258-1bb0-422e-b191-073963822ba9" />
<img width="1417" height="903" alt="Screenshot 2025-07-14 at 1 40 35 PM" src="https://github.com/user-attachments/assets/b316a35d-f5ea-4031-9fba-2c80c79fc92c" />


