### PR TITLE
Don't send orgs with trackingDisabled:true to data-enrichment endpoint

### DIFF
--- a/packages/back-end/src/api/ingestion/ingestion.router.ts
+++ b/packages/back-end/src/api/ingestion/ingestion.router.ts
@@ -50,10 +50,12 @@ export const getDataEnrichment = createApiRequestHandler({
       orgIds
     );
 
-    const validOrgs = orgIds.filter((x) => !orgIdsWithTrackingDisabled.has(x));
+    const orgIdsWiithTrackingEnabled = orgIds.filter(
+      (x) => !orgIdsWithTrackingDisabled.has(x)
+    );
 
     const sdkConnections = await _dangerousGetSdkConnectionsAcrossMultipleOrgs(
-      validOrgs
+      orgIdsWiithTrackingEnabled
     );
 
     const sdkData = Object.fromEntries(

--- a/packages/back-end/src/api/ingestion/ingestion.router.ts
+++ b/packages/back-end/src/api/ingestion/ingestion.router.ts
@@ -50,12 +50,12 @@ export const getDataEnrichment = createApiRequestHandler({
       orgIds
     );
 
-    const orgIdsWiithTrackingEnabled = orgIds.filter(
+    const orgIdsWithTrackingEnabled = orgIds.filter(
       (x) => !orgIdsWithTrackingDisabled.has(x)
     );
 
     const sdkConnections = await _dangerousGetSdkConnectionsAcrossMultipleOrgs(
-      orgIdsWiithTrackingEnabled
+      orgIdsWithTrackingEnabled
     );
 
     const sdkData = Object.fromEntries(

--- a/packages/back-end/src/models/OrganizationModel.ts
+++ b/packages/back-end/src/models/OrganizationModel.ts
@@ -143,6 +143,7 @@ const organizationSchema = new mongoose.Schema({
   deactivatedRoles: [],
   disabled: Boolean,
   setupEventTracker: String,
+  trackingDisabled: Boolean,
 });
 
 organizationSchema.index({ "members.id": 1 });
@@ -232,6 +233,19 @@ export async function createOrganization({
     ...(restrictLoginMethod ? { restrictLoginMethod } : {}),
   });
   return toInterface(doc);
+}
+
+export async function getOrganizationIdsWithTrackingDisabled(
+  organizationIds: string[]
+) {
+  const orgs = await OrganizationModel.find(
+    {
+      id: { $in: organizationIds },
+      trackingDisabled: true,
+    },
+    { id: 1, _id: 0 }
+  );
+  return new Set(orgs.map((org) => org.id));
 }
 
 export async function findAllOrganizations(


### PR DESCRIPTION
### Features and Changes
Pro orgs that stop paying may continue to have a growthbook clickhouse datasource even though they are free.  We will be nice and in general let them continue to track events up to a limit.  But if any org is costing us too much money we may want to hard cut them off quickly.  This PR sets a new property on OrganizationModel that will always be undefined unless set by hand to be true.  If `trackingDisabled:true` for an org, then we won't send it to the Ingestor and the Ingestor will return ClientKeyInvalid 400 error.

Notes:
- Although the query is grabbing across multiple orgs, this doesn't seem to warrant the "_dangerous" prefix like the other functions in the ingestor as all it returns is a subset of the already know orgIds passed in.  
- Filtering by orgIds is necessary as we don't want to create an index for trackingDisabled as we don't want to slow down writes.

### Testing

In Mongo set an org with an sdk key being the growthbook sdk key. 
Have .env.local:
```
IS_CLOUD=true
IS_MULTI_ORG=true
```
Make sure the env var TRACKING_DISABLED is not set. 
Start the ingestor.
Login to the org with growthbook sdk key.  
Hit localhost:3000.
In the ingestor logs see 200 returned.
In Mongo set `trackingDisabled:true`
Go to two different pages.
In the ingestor logs see 200 returned for the first one (it will still be in cache, fetch done in the backgroun)
See 400 InvalidClientKey returned for the second one.