### PR TITLE
Add BACKEND_PORT env var

### DIFF
--- a/docs/docs/self-host/env.mdx
+++ b/docs/docs/self-host/env.mdx
@@ -63,6 +63,9 @@ growthbook:
     - API_HOST=http://<my ip or url>:4100
 ```
 
+If you for some reason have a **PORT** environment variable set,
+you need to set the **BACKEND_PORT** variable to `3100` to avoid port conflicts. 
+
 ### Production Settings
 
 - **NODE_ENV** - Set to "production" to turn on additional optimizations and API request logging

--- a/packages/back-end/src/app.ts
+++ b/packages/back-end/src/app.ts
@@ -137,7 +137,9 @@ if (!process.env.NO_INIT && process.env.NODE_ENV !== "test") {
   init();
 }
 
-app.set("port", process.env.PORT || 3100);
+// Some platforms set the PORT env var, causing the back-end and front-end to both try to listen on the same port.
+// BACKEND_PORT allows specifying a different port for the back-end to mitigate this conflict.
+app.set("port", process.env.BACKEND_PORT || process.env.PORT || 3100);
 app.set("trust proxy", EXPRESS_TRUST_PROXY_OPTS);
 
 // Pretty print on dev


### PR DESCRIPTION
### Features and Changes

- Add support for setting the port for the back-end using env vars. If the `PORT` env var is set, it sets the port for the back-end and front-end, causing a conflict.

Made this change due to the fact [Railway](https://railway.com) [always sets the `PORT` env var](https://docs.railway.com/guides/public-networking#railway-provided-port), and are unable to deploy GrowthBook because of this.