### PR TITLE
Add several fixes for a job that runs forever

### DIFF
--- a/packages/back-end/src/jobs/updateExperimentResults.ts
+++ b/packages/back-end/src/jobs/updateExperimentResults.ts
@@ -17,7 +17,10 @@ import {
 import { getContextForAgendaJobByOrgId } from "back-end/src/services/organizations";
 import { getMetricMap } from "back-end/src/models/MetricModel";
 import { notifyAutoUpdate } from "back-end/src/services/experimentNotifications";
-import { EXPERIMENT_REFRESH_FREQUENCY } from "back-end/src/util/secrets";
+import {
+  EXPERIMENT_REFRESH_FREQUENCY,
+  MAX_QUERY_TIMEOUT_MS,
+} from "back-end/src/util/secrets";
 import { logger } from "back-end/src/util/logger";
 import { getFactTableMap } from "back-end/src/models/FactTableModel";
 
@@ -125,138 +128,160 @@ async function updateSingleExperiment(job: UpdateSingleExpJob) {
 
   startTouch();
 
+  const TIMEOUT = MAX_QUERY_TIMEOUT_MS + 1000; // Allow some buffer for the query client to close properly after it timesout
+  let timeoutHandle: NodeJS.Timeout | null = null;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeoutHandle = setTimeout(() => {
+      const errorMsg = `updateSingleExperiment exceeded timeout of ${TIMEOUT}ms for experiment ${experimentId}`;
+      logger.error(new Error(errorMsg));
+      stopTouch();
+      reject(new Error(errorMsg));
+    }, TIMEOUT);
+  });
+
   try {
-    const context = await getContextForAgendaJobByOrgId(orgId);
+    await Promise.race([
+      (async () => {
+        const context = await getContextForAgendaJobByOrgId(orgId);
 
-    const { org: organization } = context;
+        const { org: organization } = context;
 
-    const experiment = await getExperimentById(context, experimentId);
-    if (!experiment) return;
+        const experiment = await getExperimentById(context, experimentId);
+        if (!experiment) return;
 
-    let project = null;
-    if (experiment.project) {
-      project = await context.models.projects.getById(experiment.project);
-    }
-    const { settings: scopedSettings } = getScopedSettings({
-      organization: context.org,
-      project: project ?? undefined,
-    });
-
-    // Disable auto snapshots for the experiment so it doesn't keep trying to update if schedule is off (non-bandits only)
-    if (
-      organization?.settings?.updateSchedule?.type === "never" &&
-      experiment.type !== "multi-armed-bandit"
-    ) {
-      await updateExperiment({
-        context,
-        experiment,
-        changes: {
-          autoSnapshots: false,
-        },
-      });
-      return;
-    }
-
-    try {
-      logger.info("Start Refreshing Results for experiment " + experimentId);
-      const datasource = await getDataSourceById(
-        context,
-        experiment.datasource || ""
-      );
-      if (!datasource) {
-        throw new Error(
-          "Error refreshing experiment, could not find datasource"
-        );
-      }
-
-      const {
-        regressionAdjustmentEnabled,
-        settingsForSnapshotMetrics,
-      } = await getSettingsForSnapshotMetrics(context, experiment);
-
-      const analysisSettings = getDefaultExperimentAnalysisSettings(
-        experiment.statsEngine || scopedSettings.statsEngine.value,
-        experiment,
-        organization,
-        regressionAdjustmentEnabled
-      );
-
-      const metricMap = await getMetricMap(context);
-      const factTableMap = await getFactTableMap(context);
-
-      let reweight =
-        experiment.type === "multi-armed-bandit" &&
-        experiment.banditStage === "exploit";
-
-      if (experiment.type === "multi-armed-bandit" && !reweight) {
-        // Quick check to see if we're about to enter "exploit" stage and will need to reweight
-        const tempChanges = updateExperimentBanditSettings({
-          experiment,
-          isScheduled: true,
-        });
-        if (tempChanges.banditStage === "exploit") {
-          reweight = true;
+        let project = null;
+        if (experiment.project) {
+          project = await context.models.projects.getById(experiment.project);
         }
-      }
-
-      const queryRunner = await createSnapshot({
-        experiment,
-        context,
-        phaseIndex: experiment.phases.length - 1,
-        defaultAnalysisSettings: analysisSettings,
-        additionalAnalysisSettings: getAdditionalExperimentAnalysisSettings(
-          analysisSettings
-        ),
-        settingsForSnapshotMetrics: settingsForSnapshotMetrics || [],
-        metricMap,
-        factTableMap,
-        useCache: true,
-        type: "standard",
-        triggeredBy: "schedule",
-        reweight,
-      });
-      await queryRunner.waitForResults();
-      const currentSnapshot = queryRunner.model;
-
-      logger.info(
-        "Successfully Refreshed Results for experiment " + experimentId
-      );
-
-      if (experiment.type === "multi-armed-bandit") {
-        const changes = updateExperimentBanditSettings({
-          experiment,
-          snapshot: currentSnapshot,
-          reweight:
-            currentSnapshot?.banditResult?.reweight &&
-            experiment.banditStage === "exploit",
-          isScheduled: true,
-        });
-        await updateExperiment({
-          context,
-          experiment,
-          changes,
-        });
-      }
-    } catch (e) {
-      logger.error(e, "Failed to update experiment: " + experimentId);
-      // If we failed to update the experiment, turn off auto-updating for the future (non-bandits only)
-      if (experiment.type === "multi-armed-bandit") return;
-      try {
-        await updateExperiment({
-          context,
-          experiment,
-          changes: {
-            autoSnapshots: false,
-          },
+        const { settings: scopedSettings } = getScopedSettings({
+          organization: context.org,
+          project: project ?? undefined,
         });
 
-        await notifyAutoUpdate({ context, experiment, success: true });
-      } catch (e) {
-        logger.error(e, "Failed to turn off autoSnapshots: " + experimentId);
-        await notifyAutoUpdate({ context, experiment, success: false });
-      }
-    }
+        // Disable auto snapshots for the experiment so it doesn't keep trying to update if schedule is off (non-bandits only)
+        if (
+          organization?.settings?.updateSchedule?.type === "never" &&
+          experiment.type !== "multi-armed-bandit"
+        ) {
+          await updateExperiment({
+            context,
+            experiment,
+            changes: {
+              autoSnapshots: false,
+            },
+          });
+          return;
+        }
+
+        try {
+          logger.info(
+            "Start Refreshing Results for experiment " + experimentId
+          );
+          const datasource = await getDataSourceById(
+            context,
+            experiment.datasource || ""
+          );
+          if (!datasource) {
+            throw new Error(
+              "Error refreshing experiment, could not find datasource"
+            );
+          }
+
+          const {
+            regressionAdjustmentEnabled,
+            settingsForSnapshotMetrics,
+          } = await getSettingsForSnapshotMetrics(context, experiment);
+
+          const analysisSettings = getDefaultExperimentAnalysisSettings(
+            experiment.statsEngine || scopedSettings.statsEngine.value,
+            experiment,
+            organization,
+            regressionAdjustmentEnabled
+          );
+
+          const metricMap = await getMetricMap(context);
+          const factTableMap = await getFactTableMap(context);
+
+          let reweight =
+            experiment.type === "multi-armed-bandit" &&
+            experiment.banditStage === "exploit";
+
+          if (experiment.type === "multi-armed-bandit" && !reweight) {
+            // Quick check to see if we're about to enter "exploit" stage and will need to reweight
+            const tempChanges = updateExperimentBanditSettings({
+              experiment,
+              isScheduled: true,
+            });
+            if (tempChanges.banditStage === "exploit") {
+              reweight = true;
+            }
+          }
+
+          const queryRunner = await createSnapshot({
+            experiment,
+            context,
+            phaseIndex: experiment.phases.length - 1,
+            defaultAnalysisSettings: analysisSettings,
+            additionalAnalysisSettings: getAdditionalExperimentAnalysisSettings(
+              analysisSettings
+            ),
+            settingsForSnapshotMetrics: settingsForSnapshotMetrics || [],
+            metricMap,
+            factTableMap,
+            useCache: true,
+            type: "standard",
+            triggeredBy: "schedule",
+            reweight,
+          });
+          await queryRunner.waitForResults();
+          const currentSnapshot = queryRunner.model;
+
+          logger.info(
+            "Successfully Refreshed Results for experiment " + experimentId
+          );
+
+          if (experiment.type === "multi-armed-bandit") {
+            const changes = updateExperimentBanditSettings({
+              experiment,
+              snapshot: currentSnapshot,
+              reweight:
+                currentSnapshot?.banditResult?.reweight &&
+                experiment.banditStage === "exploit",
+              isScheduled: true,
+            });
+            await updateExperiment({
+              context,
+              experiment,
+              changes,
+            });
+          }
+        } catch (e) {
+          logger.error(e, "Failed to update experiment: " + experimentId);
+          // If we failed to update the experiment, turn off auto-updating for the future (non-bandits only)
+          if (experiment.type === "multi-armed-bandit") return;
+          try {
+            await updateExperiment({
+              context,
+              experiment,
+              changes: {
+                autoSnapshots: false,
+              },
+            });
+
+            await notifyAutoUpdate({ context, experiment, success: true });
+          } catch (e) {
+            logger.error(
+              e,
+              "Failed to turn off autoSnapshots: " + experimentId
+            );
+            await notifyAutoUpdate({ context, experiment, success: false });
+          }
+        }
+      })(),
+      timeoutPromise,
+    ]);
   } finally {
     stopTouch();
+    if (timeoutHandle) clearTimeout(timeoutHandle);
   }
 }

--- a/packages/back-end/src/jobs/updateExperimentResults.ts
+++ b/packages/back-end/src/jobs/updateExperimentResults.ts
@@ -49,12 +49,7 @@ export default async function (agenda: Agenda) {
     }
   });
 
-  agenda.define(
-    UPDATE_SINGLE_EXP,
-    // This job queries a datasource, which may be slow. Give it 30 minutes to complete.
-    { lockLifetime: 30 * 60 * 1000 },
-    updateSingleExperiment
-  );
+  agenda.define(UPDATE_SINGLE_EXP, updateSingleExperiment);
 
   // Update experiment results
   await startUpdateJob();
@@ -106,120 +101,52 @@ async function updateSingleExperiment(job: UpdateSingleExpJob) {
 
   if (!experimentId || !orgId) return;
 
-  const context = await getContextForAgendaJobByOrgId(orgId);
+  // This job may take a while to run,
+  // so to ensure another server doesn't pick it up we
+  // Start a timer to call job.touch() every 3 minutes which will update the job's lock time.
+  const TOUCH_INTERVAL = 3 * 60 * 1000;
+  let touchTimer: NodeJS.Timeout | null = null;
+  let finished = false;
 
-  const { org: organization } = context;
-
-  const experiment = await getExperimentById(context, experimentId);
-  if (!experiment) return;
-
-  let project = null;
-  if (experiment.project) {
-    project = await context.models.projects.getById(experiment.project);
+  function startTouch() {
+    touchTimer = setInterval(() => {
+      if (!finished) {
+        job.touch().catch((e) => {
+          logger.error(e, "Failed to touch Agenda job");
+        });
+      }
+    }, TOUCH_INTERVAL);
   }
-  const { settings: scopedSettings } = getScopedSettings({
-    organization: context.org,
-    project: project ?? undefined,
-  });
 
-  // Disable auto snapshots for the experiment so it doesn't keep trying to update if schedule is off (non-bandits only)
-  if (
-    organization?.settings?.updateSchedule?.type === "never" &&
-    experiment.type !== "multi-armed-bandit"
-  ) {
-    await updateExperiment({
-      context,
-      experiment,
-      changes: {
-        autoSnapshots: false,
-      },
-    });
-    return;
+  function stopTouch() {
+    finished = true;
+    if (touchTimer) clearInterval(touchTimer);
   }
+
+  startTouch();
 
   try {
-    logger.info("Start Refreshing Results for experiment " + experimentId);
-    const datasource = await getDataSourceById(
-      context,
-      experiment.datasource || ""
-    );
-    if (!datasource) {
-      throw new Error("Error refreshing experiment, could not find datasource");
+    const context = await getContextForAgendaJobByOrgId(orgId);
+
+    const { org: organization } = context;
+
+    const experiment = await getExperimentById(context, experimentId);
+    if (!experiment) return;
+
+    let project = null;
+    if (experiment.project) {
+      project = await context.models.projects.getById(experiment.project);
     }
-
-    const {
-      regressionAdjustmentEnabled,
-      settingsForSnapshotMetrics,
-    } = await getSettingsForSnapshotMetrics(context, experiment);
-
-    const analysisSettings = getDefaultExperimentAnalysisSettings(
-      experiment.statsEngine || scopedSettings.statsEngine.value,
-      experiment,
-      organization,
-      regressionAdjustmentEnabled
-    );
-
-    const metricMap = await getMetricMap(context);
-    const factTableMap = await getFactTableMap(context);
-
-    let reweight =
-      experiment.type === "multi-armed-bandit" &&
-      experiment.banditStage === "exploit";
-
-    if (experiment.type === "multi-armed-bandit" && !reweight) {
-      // Quick check to see if we're about to enter "exploit" stage and will need to reweight
-      const tempChanges = updateExperimentBanditSettings({
-        experiment,
-        isScheduled: true,
-      });
-      if (tempChanges.banditStage === "exploit") {
-        reweight = true;
-      }
-    }
-
-    const queryRunner = await createSnapshot({
-      experiment,
-      context,
-      phaseIndex: experiment.phases.length - 1,
-      defaultAnalysisSettings: analysisSettings,
-      additionalAnalysisSettings: getAdditionalExperimentAnalysisSettings(
-        analysisSettings
-      ),
-      settingsForSnapshotMetrics: settingsForSnapshotMetrics || [],
-      metricMap,
-      factTableMap,
-      useCache: true,
-      type: "standard",
-      triggeredBy: "schedule",
-      reweight,
+    const { settings: scopedSettings } = getScopedSettings({
+      organization: context.org,
+      project: project ?? undefined,
     });
-    await queryRunner.waitForResults();
-    const currentSnapshot = queryRunner.model;
 
-    logger.info(
-      "Successfully Refreshed Results for experiment " + experimentId
-    );
-
-    if (experiment.type === "multi-armed-bandit") {
-      const changes = updateExperimentBanditSettings({
-        experiment,
-        snapshot: currentSnapshot,
-        reweight:
-          currentSnapshot?.banditResult?.reweight &&
-          experiment.banditStage === "exploit",
-        isScheduled: true,
-      });
-      await updateExperiment({
-        context,
-        experiment,
-        changes,
-      });
-    }
-  } catch (e) {
-    logger.error(e, "Failed to update experiment: " + experimentId);
-    // If we failed to update the experiment, turn off auto-updating for the future (non-bandits only)
-    if (experiment.type === "multi-armed-bandit") return;
-    try {
+    // Disable auto snapshots for the experiment so it doesn't keep trying to update if schedule is off (non-bandits only)
+    if (
+      organization?.settings?.updateSchedule?.type === "never" &&
+      experiment.type !== "multi-armed-bandit"
+    ) {
       await updateExperiment({
         context,
         experiment,
@@ -227,11 +154,109 @@ async function updateSingleExperiment(job: UpdateSingleExpJob) {
           autoSnapshots: false,
         },
       });
-
-      await notifyAutoUpdate({ context, experiment, success: true });
-    } catch (e) {
-      logger.error(e, "Failed to turn off autoSnapshots: " + experimentId);
-      await notifyAutoUpdate({ context, experiment, success: false });
+      return;
     }
+
+    try {
+      logger.info("Start Refreshing Results for experiment " + experimentId);
+      const datasource = await getDataSourceById(
+        context,
+        experiment.datasource || ""
+      );
+      if (!datasource) {
+        throw new Error(
+          "Error refreshing experiment, could not find datasource"
+        );
+      }
+
+      const {
+        regressionAdjustmentEnabled,
+        settingsForSnapshotMetrics,
+      } = await getSettingsForSnapshotMetrics(context, experiment);
+
+      const analysisSettings = getDefaultExperimentAnalysisSettings(
+        experiment.statsEngine || scopedSettings.statsEngine.value,
+        experiment,
+        organization,
+        regressionAdjustmentEnabled
+      );
+
+      const metricMap = await getMetricMap(context);
+      const factTableMap = await getFactTableMap(context);
+
+      let reweight =
+        experiment.type === "multi-armed-bandit" &&
+        experiment.banditStage === "exploit";
+
+      if (experiment.type === "multi-armed-bandit" && !reweight) {
+        // Quick check to see if we're about to enter "exploit" stage and will need to reweight
+        const tempChanges = updateExperimentBanditSettings({
+          experiment,
+          isScheduled: true,
+        });
+        if (tempChanges.banditStage === "exploit") {
+          reweight = true;
+        }
+      }
+
+      const queryRunner = await createSnapshot({
+        experiment,
+        context,
+        phaseIndex: experiment.phases.length - 1,
+        defaultAnalysisSettings: analysisSettings,
+        additionalAnalysisSettings: getAdditionalExperimentAnalysisSettings(
+          analysisSettings
+        ),
+        settingsForSnapshotMetrics: settingsForSnapshotMetrics || [],
+        metricMap,
+        factTableMap,
+        useCache: true,
+        type: "standard",
+        triggeredBy: "schedule",
+        reweight,
+      });
+      await queryRunner.waitForResults();
+      const currentSnapshot = queryRunner.model;
+
+      logger.info(
+        "Successfully Refreshed Results for experiment " + experimentId
+      );
+
+      if (experiment.type === "multi-armed-bandit") {
+        const changes = updateExperimentBanditSettings({
+          experiment,
+          snapshot: currentSnapshot,
+          reweight:
+            currentSnapshot?.banditResult?.reweight &&
+            experiment.banditStage === "exploit",
+          isScheduled: true,
+        });
+        await updateExperiment({
+          context,
+          experiment,
+          changes,
+        });
+      }
+    } catch (e) {
+      logger.error(e, "Failed to update experiment: " + experimentId);
+      // If we failed to update the experiment, turn off auto-updating for the future (non-bandits only)
+      if (experiment.type === "multi-armed-bandit") return;
+      try {
+        await updateExperiment({
+          context,
+          experiment,
+          changes: {
+            autoSnapshots: false,
+          },
+        });
+
+        await notifyAutoUpdate({ context, experiment, success: true });
+      } catch (e) {
+        logger.error(e, "Failed to turn off autoSnapshots: " + experimentId);
+        await notifyAutoUpdate({ context, experiment, success: false });
+      }
+    }
+  } finally {
+    stopTouch();
   }
 }

--- a/packages/back-end/src/services/postgres.ts
+++ b/packages/back-end/src/services/postgres.ts
@@ -2,7 +2,7 @@ import { Client, ClientConfig } from "pg";
 import { PostgresConnectionParams } from "back-end/types/integrations/postgres";
 import { logger } from "back-end/src/util/logger";
 import { QueryResponse } from "back-end/src/types/Integration";
-import { MAX_QUERY_TIMEOUT } from "back-end/src/util/secrets";
+import { MAX_QUERY_TIMEOUT_MS } from "back-end/src/util/secrets";
 
 export function runPostgresQuery(
   conn: PostgresConnectionParams,
@@ -31,7 +31,7 @@ export function runPostgresQuery(
       ...conn,
       ssl,
       connectionTimeoutMillis: 10000,
-      query_timeout: MAX_QUERY_TIMEOUT,
+      query_timeout: MAX_QUERY_TIMEOUT_MS,
     };
 
     const client = new Client(settings);
@@ -41,10 +41,10 @@ export function runPostgresQuery(
       client.end().catch(() => {});
       reject(
         new Error(
-          `Postgres query exceeded timeout of ${MAX_QUERY_TIMEOUT + 1000}ms`
+          `Postgres query exceeded timeout of ${MAX_QUERY_TIMEOUT_MS + 1000}ms`
         )
       );
-    }, MAX_QUERY_TIMEOUT + 1000); // Add a buffer to the timeout to ensure client has time to timeout first
+    }, MAX_QUERY_TIMEOUT_MS + 1000); // Add a buffer to the timeout to ensure client has time to timeout first
 
     client
       .on("error", (err) => {

--- a/packages/back-end/src/util/secrets.ts
+++ b/packages/back-end/src/util/secrets.ts
@@ -115,6 +115,9 @@ export const SLACK_SIGNING_SECRET = process.env.SLACK_SIGNING_SECRET || "";
 const testConn = process.env.POSTGRES_TEST_CONN;
 export const POSTGRES_TEST_CONN = testConn ? JSON.parse(testConn) : {};
 
+export const MAX_QUERY_TIMEOUT =
+  parseInt(process.env.MAX_QUERY_TIMEOUT_MS || "") || 3600000; // Default to 1 hour
+
 export const FASTLY_API_TOKEN = process.env.FASTLY_API_TOKEN || "";
 export const FASTLY_SERVICE_ID = process.env.FASTLY_SERVICE_ID || "";
 

--- a/packages/back-end/src/util/secrets.ts
+++ b/packages/back-end/src/util/secrets.ts
@@ -115,7 +115,7 @@ export const SLACK_SIGNING_SECRET = process.env.SLACK_SIGNING_SECRET || "";
 const testConn = process.env.POSTGRES_TEST_CONN;
 export const POSTGRES_TEST_CONN = testConn ? JSON.parse(testConn) : {};
 
-export const MAX_QUERY_TIMEOUT =
+export const MAX_QUERY_TIMEOUT_MS =
   parseInt(process.env.MAX_QUERY_TIMEOUT_MS || "") || 3600000; // Default to 1 hour
 
 export const FASTLY_API_TOKEN = process.env.FASTLY_API_TOKEN || "";


### PR DESCRIPTION
### Features and Changes

There was a client that started a query to a postgres client that never resolved it's promise (either successfully or rejecting).  Once the lockLifetime was reached another server picked it up.  Eventually all jobs servers were running this one job leaving no room for other jobs to run.

This change:

1. Gets rid of lockLifetimeout of 30 minutes (will default back to 10 minutes)
2. Calls touch() every 3 minutes, to make sure that another job doesn't pick it up.  If the server dies, then another server should pick it up 10 minutes from the last touch().
3. Adds a `query_timeout` to the postgres client call. 
4. Adds a timeout to `runPostgresQuery` (in case the postgres client still doesn't reject when the timeout is reached)
5. Adds a timeout to the updateSingleExperimentJob (in case some other client also doesn't timeout promptly).

### Testing
...