### PR TITLE
feat(experiment-list): Add is:watched to Experiment list filters

### DIFF
--- a/packages/back-end/types/experiment.d.ts
+++ b/packages/back-end/types/experiment.d.ts
@@ -192,6 +192,7 @@ export type ComputedExperimentInterface = ExperimentInterfaceStringDates & {
   date: string;
   statusSortOrder: number;
   statusIndicator: StatusIndicatorData;
+  isWatched?: boolean;
 };
 
 export type Changeset = Partial<ExperimentInterface>;

--- a/packages/front-end/pages/experiments/index.tsx
+++ b/packages/front-end/pages/experiments/index.tsx
@@ -23,6 +23,7 @@ import ViewSampleDataButton from "@/components/GetStarted/ViewSampleDataButton";
 import EmptyState from "@/components/EmptyState";
 import Callout from "@/components/Radix/Callout";
 import { useExperimentSearch } from "@/services/experiments";
+import { useWatching } from "@/services/WatchProvider";
 import ExperimentSearchFilters from "@/components/Search/ExperimentSearchFilters";
 import {
   Tabs,
@@ -56,6 +57,7 @@ const ExperimentsPage = (): React.ReactElement => {
     loading,
     hasArchived,
   } = useExperiments(project, tab === "archived", "standard");
+  const { watchedExperiments } = useWatching();
 
   const [openNewExperimentModal, setOpenNewExperimentModal] = useState(false);
   const [openImportExperimentModal, setOpenImportExperimentModal] = useState(
@@ -73,6 +75,7 @@ const ExperimentsPage = (): React.ReactElement => {
     setSearchValue,
   } = useExperimentSearch({
     allExperiments,
+    watchedExperimentIds: watchedExperiments,
   });
 
   const tabCounts = useMemo(() => {

--- a/packages/front-end/services/experiments.ts
+++ b/packages/front-end/services/experiments.ts
@@ -280,6 +280,7 @@ export function useExperimentSearch({
   defaultSortDir = -1,
   filterResults,
   localStorageKey = "experiments",
+  watchedExperimentIds,
 }: {
   allExperiments: ExperimentInterfaceStringDates[];
   defaultSortField?: keyof ComputedExperimentInterface;
@@ -288,6 +289,7 @@ export function useExperimentSearch({
     items: ComputedExperimentInterface[]
   ) => ComputedExperimentInterface[];
   localStorageKey?: string;
+  watchedExperimentIds?: string[];
 }) {
   const {
     getExperimentMetricById,
@@ -309,6 +311,7 @@ export function useExperimentSearch({
       const lastPhase = exp.phases?.[exp.phases?.length - 1] || {};
       const rawSavedGroup = lastPhase?.savedGroups || [];
       const savedGroupIds = rawSavedGroup.map((g) => g.ids).flat();
+      const isWatched = watchedExperimentIds?.includes(exp.id) ?? false;
 
       return {
         ownerName: getUserDisplay(exp.owner, false) || "",
@@ -330,6 +333,7 @@ export function useExperimentSearch({
         date: experimentDate(exp),
         statusIndicator,
         statusSortOrder,
+        isWatched,
       };
     },
     [getExperimentMetricById, getProjectById, getUserDisplay]
@@ -353,6 +357,7 @@ export function useExperimentSearch({
       "metricNames",
       "results",
       "analysis",
+      "isWatched",
     ],
     searchTermFilters: {
       is: (item) => {
@@ -373,6 +378,7 @@ export function useExperimentSearch({
         if (item.results === "dnf") is.push("dnf");
         if (item.hasVisualChangesets) is.push("visual");
         if (item.hasURLRedirects) is.push("redirect");
+        if (item.isWatched) is.push("watched");
         return is;
       },
       has: (item) => {


### PR DESCRIPTION
### Features and Changes

With the consolidation of filters in the Experiment Lists page we ended up removing the filter by `Watched` status.
This adds it back via the search query field only by typing `is:watched` while we figure out the best solution for the UI.