### PR TITLE
feat(experiment list search): Add `Other` option to filter by watched

### DIFF
--- a/packages/back-end/types/experiment.d.ts
+++ b/packages/back-end/types/experiment.d.ts
@@ -192,6 +192,7 @@ export type ComputedExperimentInterface = ExperimentInterfaceStringDates & {
   date: string;
   statusSortOrder: number;
   statusIndicator: StatusIndicatorData;
+  isWatched?: boolean;
 };
 
 export type Changeset = Partial<ExperimentInterface>;

--- a/packages/front-end/components/Search/ExperimentSearchFilters.tsx
+++ b/packages/front-end/components/Search/ExperimentSearchFilters.tsx
@@ -1,15 +1,23 @@
 import React, { FC, useMemo } from "react";
-import { Flex } from "@radix-ui/themes";
+import { Box, Flex } from "@radix-ui/themes";
 import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
 import Tag from "@/components/Tags/Tag";
 import {
   BaseSearchFiltersProps,
+  doesFilterExistInSearch,
   FilterDropdown,
+  FilterHeading,
+  FilterItem,
   SearchFiltersItem,
   useSearchFiltersBase,
 } from "@/components/Search/SearchFilters";
+import {
+  DropdownMenu,
+  DropdownMenuItem,
+} from "@/components/Radix/DropdownMenu";
 import { useCombinedMetrics } from "@/components/Metrics/MetricsList";
 import { useUser } from "@/services/UserContext";
+import { SyntaxFilter } from "@/services/search";
 
 const ExperimentSearchFilters: FC<
   BaseSearchFiltersProps & {
@@ -250,6 +258,37 @@ const ExperimentSearchFilters: FC<
         items={allExperimentTypes}
         updateQuery={updateQuery}
       />
+      <DropdownMenu
+        trigger={FilterHeading({
+          heading: "Other",
+          open: false,
+        })}
+      >
+        <Box overflow="auto" style={{ maxHeight: "300px", maxWidth: "250px" }}>
+          <DropdownMenuItem
+            onClick={() => {
+              const f: SyntaxFilter = {
+                field: "is",
+                values: ["watched"],
+                operator: "",
+                negated: false,
+              };
+              updateQuery(f);
+            }}
+          >
+            <FilterItem
+              item="Watched"
+              exists={doesFilterExistInSearch({
+                syntaxFilters,
+                field: "is",
+                value: "watched",
+                operator: "",
+                negated: false,
+              })}
+            />
+          </DropdownMenuItem>
+        </Box>
+      </DropdownMenu>
       {/*<DropdownMenu*/}
       {/*  trigger={FilterHeading({*/}
       {/*    heading: "created",*/}

--- a/packages/front-end/components/Search/SearchFilters.tsx
+++ b/packages/front-end/components/Search/SearchFilters.tsx
@@ -196,7 +196,7 @@ export const FilterDropdown: FC<{
 };
 
 // Helper function for checking if a filter exists in the syntax filters
-function doesFilterExistInSearch({
+export function doesFilterExistInSearch({
   syntaxFilters,
   field,
   value,

--- a/packages/front-end/pages/experiments/index.tsx
+++ b/packages/front-end/pages/experiments/index.tsx
@@ -23,6 +23,7 @@ import ViewSampleDataButton from "@/components/GetStarted/ViewSampleDataButton";
 import EmptyState from "@/components/EmptyState";
 import Callout from "@/components/Radix/Callout";
 import { useExperimentSearch } from "@/services/experiments";
+import { useWatching } from "@/services/WatchProvider";
 import ExperimentSearchFilters from "@/components/Search/ExperimentSearchFilters";
 import {
   Tabs,
@@ -56,6 +57,7 @@ const ExperimentsPage = (): React.ReactElement => {
     loading,
     hasArchived,
   } = useExperiments(project, tab === "archived", "standard");
+  const { watchedExperiments } = useWatching();
 
   const [openNewExperimentModal, setOpenNewExperimentModal] = useState(false);
   const [openImportExperimentModal, setOpenImportExperimentModal] = useState(
@@ -73,6 +75,7 @@ const ExperimentsPage = (): React.ReactElement => {
     setSearchValue,
   } = useExperimentSearch({
     allExperiments,
+    watchedExperimentIds: watchedExperiments,
   });
 
   const tabCounts = useMemo(() => {

--- a/packages/front-end/services/experiments.ts
+++ b/packages/front-end/services/experiments.ts
@@ -280,6 +280,7 @@ export function useExperimentSearch({
   defaultSortDir = -1,
   filterResults,
   localStorageKey = "experiments",
+  watchedExperimentIds,
 }: {
   allExperiments: ExperimentInterfaceStringDates[];
   defaultSortField?: keyof ComputedExperimentInterface;
@@ -288,6 +289,7 @@ export function useExperimentSearch({
     items: ComputedExperimentInterface[]
   ) => ComputedExperimentInterface[];
   localStorageKey?: string;
+  watchedExperimentIds?: string[];
 }) {
   const {
     getExperimentMetricById,
@@ -309,6 +311,7 @@ export function useExperimentSearch({
       const lastPhase = exp.phases?.[exp.phases?.length - 1] || {};
       const rawSavedGroup = lastPhase?.savedGroups || [];
       const savedGroupIds = rawSavedGroup.map((g) => g.ids).flat();
+      const isWatched = watchedExperimentIds?.includes(exp.id) ?? false;
 
       return {
         ownerName: getUserDisplay(exp.owner, false) || "",
@@ -330,6 +333,7 @@ export function useExperimentSearch({
         date: experimentDate(exp),
         statusIndicator,
         statusSortOrder,
+        isWatched,
       };
     },
     [getExperimentMetricById, getProjectById, getUserDisplay]
@@ -353,6 +357,7 @@ export function useExperimentSearch({
       "metricNames",
       "results",
       "analysis",
+      "isWatched",
     ],
     searchTermFilters: {
       is: (item) => {
@@ -373,6 +378,7 @@ export function useExperimentSearch({
         if (item.results === "dnf") is.push("dnf");
         if (item.hasVisualChangesets) is.push("visual");
         if (item.hasURLRedirects) is.push("redirect");
+        if (item.isWatched) is.push("watched");
         return is;
       },
       has: (item) => {


### PR DESCRIPTION
### Features and Changes

Add `Other` option in Experiment search filters for one-offs

#### Before

<img width="1068" height="221" alt="Screenshot 2025-07-15 at 3 58 42 PM" src="https://github.com/user-attachments/assets/0045a6b7-70f8-45df-bef2-828cdf0dc0a6" />

#### After

<img width="1067" height="257" alt="Screenshot 2025-07-15 at 3 58 21 PM" src="https://github.com/user-attachments/assets/0de6924c-8283-4211-8dff-d9e89fcd1fab" />
