### PR TITLE
feat(http): Add User-Agent header to fetch requests

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -205,6 +205,27 @@
         "./packages/back-end/src/scripts/**/*",
         "./packages/back-end/**/*.test.{ts,tsx,js,jsx}"
       ]
+    },
+    {
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "paths": [
+              {
+                "name": "node-fetch",
+                "message": "Use `import { fetch } from \"back-end/src/util/http.util\";` instead.",
+                "importNames": ["default"]
+              }
+            ]
+          }
+        ]
+      },
+      "files": ["./packages/back-end/**/*"],
+      "excludedFiles": [
+        "./packages/back-end/src/util/http.util.ts",
+        "./packages/back-end/**/*.test.{ts,tsx,js,jsx}"
+      ]
     }
   ]
 }

--- a/packages/back-end/src/enterprise/licenseUtil.ts
+++ b/packages/back-end/src/enterprise/licenseUtil.ts
@@ -1,5 +1,4 @@
 import crypto from "crypto";
-import fetch from "node-fetch";
 import type Stripe from "stripe";
 import pino from "pino";
 import { pick, sortBy } from "lodash";
@@ -20,6 +19,7 @@ import {
   SubscriptionInfo,
 } from "shared/enterprise";
 import { StripeAddress, TaxIdType } from "shared/src/types";
+import { fetch } from "back-end/src/util/http.util";
 import { OrganizationInterface } from "back-end/types/organization";
 import { getLicenseByKey, LicenseModel } from "./models/licenseModel";
 import { LICENSE_PUBLIC_KEY } from "./public-key";

--- a/packages/back-end/src/models/SdkConnectionModel.ts
+++ b/packages/back-end/src/models/SdkConnectionModel.ts
@@ -478,9 +478,6 @@ export async function testProxyConnection(
       url,
       {
         method: "GET",
-        headers: {
-          "User-Agent": "GrowthBook Backend",
-        },
       },
       {
         maxTimeMs: 5000,

--- a/packages/back-end/src/models/SdkConnectionModel.ts
+++ b/packages/back-end/src/models/SdkConnectionModel.ts
@@ -478,6 +478,9 @@ export async function testProxyConnection(
       url,
       {
         method: "GET",
+        headers: {
+          "User-Agent": "GrowthBook Backend",
+        },
       },
       {
         maxTimeMs: 5000,

--- a/packages/back-end/src/routers/event-webhooks/event-webhooks.controller.ts
+++ b/packages/back-end/src/routers/event-webhooks/event-webhooks.controller.ts
@@ -1,5 +1,4 @@
 import type { Response } from "express";
-import fetch from "node-fetch";
 import { PrivateApiErrorResponse } from "back-end/types/api";
 import {
   EventWebHookInterface,

--- a/packages/back-end/src/services/mixpanel.ts
+++ b/packages/back-end/src/services/mixpanel.ts
@@ -1,5 +1,5 @@
 import { URLSearchParams } from "url";
-import fetch from "node-fetch";
+import { fetch } from "back-end/src/util/http.util";
 import { MixpanelConnectionParams } from "back-end/types/integrations/mixpanel";
 
 const encodedParams = new URLSearchParams();

--- a/packages/back-end/src/util/cdn.util.ts
+++ b/packages/back-end/src/util/cdn.util.ts
@@ -1,4 +1,4 @@
-import fetch from "node-fetch";
+import { fetch } from "back-end/src/util/http.util";
 import { logger } from "./logger";
 import { FASTLY_API_TOKEN, FASTLY_SERVICE_ID } from "./secrets";
 

--- a/packages/back-end/src/util/http.util.ts
+++ b/packages/back-end/src/util/http.util.ts
@@ -5,9 +5,11 @@ import { IS_CLOUD, USE_PROXY, WEBHOOK_PROXY } from "./secrets";
 
 let useWebhookProxy = true;
 
-const USER_AGENT = IS_CLOUD
-  ? "GrowthBook Cloud (https://app.growthbook.io)"
-  : "GrowthBook";
+function getUserAgent() {
+  return IS_CLOUD
+    ? "GrowthBook Cloud (https://app.growthbook.io)"
+    : "GrowthBook";
+}
 
 export type CancellableFetchCriteria = {
   maxContentSize: number;
@@ -23,7 +25,7 @@ export type CancellableFetchReturn = {
 export function fetch(url: string, init?: RequestInit) {
   return nodeFetch(url, {
     ...init,
-    headers: { ...init?.headers, "User-Agent": USER_AGENT },
+    headers: { ...init?.headers, "User-Agent": getUserAgent() },
   });
 }
 

--- a/packages/back-end/src/util/http.util.ts
+++ b/packages/back-end/src/util/http.util.ts
@@ -47,7 +47,6 @@ export function getHttpOptions(url?: string) {
   }
   return {};
 }
-
 export const cancellableFetch = async (
   url: string,
   fetchOptions: RequestInit,
@@ -80,11 +79,17 @@ export const cancellableFetch = async (
   let response: Response | null = null;
   let stringBody = "";
 
+  const headers = {
+    "User-Agent": "GrowthBook",
+    ...fetchOptions.headers,
+  };
+
   try {
     response = await fetch(url, {
       signal: abortController.signal,
       ...getHttpOptions(url),
       ...fetchOptions,
+      headers,
     });
 
     stringBody = await readResponseBody(response);

--- a/packages/back-end/src/util/http.util.ts
+++ b/packages/back-end/src/util/http.util.ts
@@ -1,11 +1,13 @@
 import nodeFetch, { RequestInit, Response } from "node-fetch";
 import { ProxyAgent } from "proxy-agent";
 import { logger } from "./logger";
-import { USE_PROXY, WEBHOOK_PROXY } from "./secrets";
+import { IS_CLOUD, USE_PROXY, WEBHOOK_PROXY } from "./secrets";
 
 let useWebhookProxy = true;
 
-const USER_AGENT = "GrowthBook";
+const USER_AGENT = IS_CLOUD
+  ? "GrowthBook Cloud (https://app.growthbook.io)"
+  : "GrowthBook";
 
 export type CancellableFetchCriteria = {
   maxContentSize: number;
@@ -88,17 +90,11 @@ export const cancellableFetch = async (
   let response: Response | null = null;
   let stringBody = "";
 
-  const headers = {
-    "User-Agent": "GrowthBook",
-    ...fetchOptions.headers,
-  };
-
   try {
     response = await fetch(url, {
       signal: abortController.signal,
       ...getHttpOptions(url),
       ...fetchOptions,
-      headers,
     });
 
     stringBody = await readResponseBody(response);

--- a/packages/back-end/src/util/http.util.ts
+++ b/packages/back-end/src/util/http.util.ts
@@ -1,15 +1,9 @@
 import nodeFetch, { RequestInit, Response } from "node-fetch";
 import { ProxyAgent } from "proxy-agent";
 import { logger } from "./logger";
-import { IS_CLOUD, USE_PROXY, WEBHOOK_PROXY } from "./secrets";
+import { API_USER_AGENT, USE_PROXY, WEBHOOK_PROXY } from "./secrets";
 
 let useWebhookProxy = true;
-
-function getUserAgent() {
-  return IS_CLOUD
-    ? "GrowthBook Cloud (https://app.growthbook.io)"
-    : "GrowthBook";
-}
 
 export type CancellableFetchCriteria = {
   maxContentSize: number;
@@ -25,7 +19,7 @@ export type CancellableFetchReturn = {
 export function fetch(url: string, init?: RequestInit) {
   return nodeFetch(url, {
     ...init,
-    headers: { ...init?.headers, "User-Agent": getUserAgent() },
+    headers: { ...init?.headers, "User-Agent": API_USER_AGENT },
   });
 }
 

--- a/packages/back-end/src/util/http.util.ts
+++ b/packages/back-end/src/util/http.util.ts
@@ -1,9 +1,11 @@
-import fetch, { RequestInit, Response } from "node-fetch";
+import nodeFetch, { RequestInit, Response } from "node-fetch";
 import { ProxyAgent } from "proxy-agent";
 import { logger } from "./logger";
 import { USE_PROXY, WEBHOOK_PROXY } from "./secrets";
 
 let useWebhookProxy = true;
+
+const USER_AGENT = "GrowthBook";
 
 export type CancellableFetchCriteria = {
   maxContentSize: number;
@@ -15,6 +17,13 @@ export type CancellableFetchReturn = {
   responseWithoutBody: Response;
   stringBody: string;
 };
+
+export function fetch(url: string, init?: RequestInit) {
+  return nodeFetch(url, {
+    ...init,
+    headers: { ...init?.headers, "User-Agent": USER_AGENT },
+  });
+}
 
 export function getHttpOptions(url?: string) {
   // if there is a ?proxy argument in the url, use that as the proxy

--- a/packages/back-end/src/util/secrets.ts
+++ b/packages/back-end/src/util/secrets.ts
@@ -165,6 +165,11 @@ export const ALLOW_CREATE_METRICS = stringToBoolean(
   process.env.ALLOW_CREATE_METRICS
 );
 
+// Defines the User-Agent header for all requests made by the API
+export const API_USER_AGENT =
+  process.env.API_USER_AGENT ||
+  (IS_CLOUD ? "GrowthBook Cloud (https://app.growthbook.io)" : "GrowthBook");
+
 // Add a default secret access key via an environment variable
 // Only allowed while self-hosting and not multi org
 let secretAPIKey = IS_MULTI_ORG ? "" : process.env.SECRET_API_KEY || "";

--- a/packages/back-end/test/license.test.ts
+++ b/packages/back-end/test/license.test.ts
@@ -605,6 +605,7 @@ describe("src/license", () => {
               method: "PUT",
               headers: {
                 "Content-Type": "application/json",
+                "User-Agent": "GrowthBook",
               },
               body: JSON.stringify({
                 licenseUserCodes: userLicenseCodes,
@@ -636,6 +637,7 @@ describe("src/license", () => {
               method: "PUT",
               headers: {
                 "Content-Type": "application/json",
+                "User-Agent": "GrowthBook",
               },
               body: JSON.stringify({
                 licenseUserCodes: userLicenseCodes,
@@ -674,6 +676,7 @@ describe("src/license", () => {
               method: "PUT",
               headers: {
                 "Content-Type": "application/json",
+                "User-Agent": "GrowthBook",
               },
               body: JSON.stringify({
                 licenseUserCodes: userLicenseCodes,
@@ -778,6 +781,7 @@ describe("src/license", () => {
               method: "PUT",
               headers: {
                 "Content-Type": "application/json",
+                "User-Agent": "GrowthBook",
               },
               body: JSON.stringify({
                 licenseUserCodes: userLicenseCodes,


### PR DESCRIPTION
### Features and Changes
As an enterprise user of GrowthBook, we need the User-Agent header in each request. This is a requirement that we cannot work around. The User-Agent header has been added to all outgoing requests made by the backend, ensuring compliance with enterprise standards.


- Added User-Agent header to all requests in the backend, specifically in the testProxyConnection function.
- Closes https://github.com/growthbook/growthbook/issues/2096

### Dependencies

None

### Testing

- Verify that all outgoing requests from the backend include the User-Agent header.
- Test the testProxyConnection function to ensure the header is correctly set and does not interfere with the request functionality.
- Run integration tests to confirm no regressions in proxy connection handling.

### Screenshots
None
