### PR TITLE
Add query_timeout to Postgres

### DIFF
--- a/packages/back-end/src/util/secrets.ts
+++ b/packages/back-end/src/util/secrets.ts
@@ -116,7 +116,7 @@ const testConn = process.env.POSTGRES_TEST_CONN;
 export const POSTGRES_TEST_CONN = testConn ? JSON.parse(testConn) : {};
 
 export const QUERY_TIMEOUT_MS =
-  parseInt(process.env.QUERY_TIMEOUT_MS || "") || 3600000; // Defaults to 1 hour
+  parseInt(process.env.QUERY_TIMEOUT_MS || "") || 1 * 60 * 60 * 1000; // Defaults to 1 hour
 export const JOB_TIMEOUT_MS =
   parseInt(process.env.JOB_TIMEOUT_MS || "") || 2 * 60 * 60 * 1000; // Defaults to 2 hours
 


### PR DESCRIPTION
### Features and Changes

We are adding a 1 hour default timeout for Postgres queries -- with a fallback that will release the client in case the server does not respect the timeout.