### PR TITLE
Enables SDK Payload Security section for Backend SDKs

### DIFF
--- a/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
+++ b/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
@@ -60,10 +60,8 @@ function shouldShowPayloadSecurity(
   // Next.js should always use plain text
   if (languages.includes("nextjs")) return false;
 
-  // Only show for frontend, mobile, nocode, edge, and other types
-  return ["frontend", "mobile", "nocode", "edge", "other"].includes(
-    languageType
-  );
+  // all languages support encryption and secure attributes.
+  return true;
 }
 
 function getSecurityTabState(

--- a/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
+++ b/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
@@ -12,7 +12,7 @@ import {
   FaExclamationTriangle,
   FaInfoCircle,
 } from "react-icons/fa";
-import { clsx } from "clsx";
+import clsx from "clsx";
 import {
   getConnectionSDKCapabilities,
   getDefaultSDKVersion,
@@ -61,7 +61,7 @@ function shouldShowPayloadSecurity(
   if (languages.includes("nextjs")) return false;
 
   // Only show for frontend, mobile, nocode, edge, and other types
-  return ["frontend", "mobile", "nocode", "edge", "other", "backend"].includes(
+  return ["frontend", "mobile", "nocode", "edge", "other"].includes(
     languageType
   );
 }
@@ -203,8 +203,9 @@ export default function SDKConnectionForm({
     form.getValues(),
     "min-ver-intersection"
   );
-  const showVisualEditorSettings =
-    latestSdkCapabilities.includes("visualEditor");
+  const showVisualEditorSettings = latestSdkCapabilities.includes(
+    "visualEditor"
+  );
   const showRedirectSettings = latestSdkCapabilities.includes("redirects");
   const showEncryption = currentSdkCapabilities.includes("encryption");
   const showRemoteEval = currentSdkCapabilities.includes("remoteEval");
@@ -476,9 +477,9 @@ export default function SDKConnectionForm({
                       placeholder="0.0.0"
                       autoComplete="off"
                       sort={false}
-                      options={getSDKVersions(form.watch("languages")[0]).map(
-                        (ver) => ({ label: ver, value: ver })
-                      )}
+                      options={getSDKVersions(
+                        form.watch("languages")[0]
+                      ).map((ver) => ({ label: ver, value: ver }))}
                       createable={true}
                       isClearable={false}
                       value={

--- a/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
+++ b/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
@@ -12,7 +12,7 @@ import {
   FaExclamationTriangle,
   FaInfoCircle,
 } from "react-icons/fa";
-import clsx from "clsx";
+import { clsx } from "clsx";
 import {
   getConnectionSDKCapabilities,
   getDefaultSDKVersion,
@@ -61,7 +61,7 @@ function shouldShowPayloadSecurity(
   if (languages.includes("nextjs")) return false;
 
   // Only show for frontend, mobile, nocode, edge, and other types
-  return ["frontend", "mobile", "nocode", "edge", "other"].includes(
+  return ["frontend", "mobile", "nocode", "edge", "other", "backend"].includes(
     languageType
   );
 }
@@ -203,9 +203,8 @@ export default function SDKConnectionForm({
     form.getValues(),
     "min-ver-intersection"
   );
-  const showVisualEditorSettings = latestSdkCapabilities.includes(
-    "visualEditor"
-  );
+  const showVisualEditorSettings =
+    latestSdkCapabilities.includes("visualEditor");
   const showRedirectSettings = latestSdkCapabilities.includes("redirects");
   const showEncryption = currentSdkCapabilities.includes("encryption");
   const showRemoteEval = currentSdkCapabilities.includes("remoteEval");
@@ -477,9 +476,9 @@ export default function SDKConnectionForm({
                       placeholder="0.0.0"
                       autoComplete="off"
                       sort={false}
-                      options={getSDKVersions(
-                        form.watch("languages")[0]
-                      ).map((ver) => ({ label: ver, value: ver }))}
+                      options={getSDKVersions(form.watch("languages")[0]).map(
+                        (ver) => ({ label: ver, value: ver })
+                      )}
                       createable={true}
                       isClearable={false}
                       value={

--- a/packages/shared/src/sdk-versioning/sdk-versions/flutter.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/flutter.json
@@ -1,6 +1,9 @@
 {
   "versions": [
     {
+      "version": "3.9.11"
+    },
+    {
       "version": "3.9.9"
     },
     {

--- a/packages/shared/src/sdk-versioning/sdk-versions/go.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/go.json
@@ -1,6 +1,9 @@
 {
   "versions": [
     {
+      "version": "0.2.4"
+    },
+    {
       "version": "0.2.3",
       "capabilities": ["stickyBucketing"]
     },

--- a/packages/shared/src/sdk-versioning/sdk-versions/kotlin.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/kotlin.json
@@ -1,5 +1,6 @@
 {
   "versions": [
+    { "version": "5.0.1" },
     { "version": "2.0.0" },
     { "version": "1.1.60" },
     { "version": "1.1.59" },

--- a/packages/shared/src/sdk-versioning/sdk-versions/python.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/python.json
@@ -1,6 +1,9 @@
 {
   "versions": [
     {
+      "version": "1.3.1"
+    },
+    {
       "version": "1.2.1",
       "capabilities": ["savedGroupReferences"]
     },

--- a/packages/shared/src/sdk-versioning/sdk-versions/swift.json
+++ b/packages/shared/src/sdk-versioning/sdk-versions/swift.json
@@ -1,6 +1,9 @@
 {
   "versions": [
     {
+      "version": "1.0.73"
+    },
+    {
       "version": "1.0.68"
     },
     {


### PR DESCRIPTION
### Features and Changes

Enables "SDK Payload Security section" in the SDK connection model for all language types including backend. 

<img width="796" height="871" alt="Screenshot 2025-07-15 at 6 12 27 PM" src="https://github.com/user-attachments/assets/41427405-5c34-48e0-b21e-f25279384ec7" />


### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

<!--
  Please describe how to test these changes.
 -->

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
