### PR TITLE
Add datadog and cloudwatch metrics for python server

### DIFF
--- a/packages/back-end/src/services/python.ts
+++ b/packages/back-end/src/services/python.ts
@@ -177,7 +177,6 @@ class PythonStatsServer<Input, Output> {
           );
           clearTimeout(timer);
 
-          // Datadog metrics
           metrics.getCounter("python.stats_calls_resolved").increment();
           metrics
             .getHistogram("python.stats_call_duration_ms")
@@ -192,7 +191,6 @@ class PythonStatsServer<Input, Output> {
           );
           clearTimeout(timer);
 
-          // Datadog metrics
           metrics.getCounter("python.stats_calls_rejected").increment();
           metrics
             .getHistogram("python.stats_call_duration_ms")

--- a/packages/back-end/src/services/python.ts
+++ b/packages/back-end/src/services/python.ts
@@ -2,11 +2,13 @@ import { ChildProcess, spawn } from "child_process";
 import os from "os";
 import path from "path";
 import { randomUUID } from "crypto";
+import { CloudWatch } from "aws-sdk";
 import { createPool } from "generic-pool";
 import { MultipleExperimentMetricAnalysis } from "back-end/types/stats";
 import { logger } from "back-end/src/util/logger";
 import { ExperimentDataForStatsEngine } from "back-end/src/services/stats";
-import { ENVIRONMENT } from "back-end/src/util/secrets";
+import { ENVIRONMENT, IS_CLOUD } from "back-end/src/util/secrets";
+import { metrics } from "back-end/src/util/metrics";
 
 type PythonServerResponse<T> = {
   id: string;
@@ -18,6 +20,11 @@ type PythonServerResponse<T> = {
 // We use an overly conservative timeout to account for high load
 const STATS_ENGINE_TIMEOUT_MS = 60_000;
 const MAX_POOL_SIZE = 4;
+
+let cloudWatch: CloudWatch | null = null;
+if (IS_CLOUD) {
+  cloudWatch = new CloudWatch();
+}
 
 class PythonStatsServer<Input, Output> {
   private python: ChildProcess;
@@ -149,6 +156,7 @@ class PythonStatsServer<Input, Output> {
           `Python stats server (pid: ${this.pid}) call timed out for id ${id}`
         );
         this.promises.delete(id);
+        metrics.getCounter("python.stats_calls_rejected").increment();
         reject(new Error("Python stats server call timed out"));
       }, STATS_ENGINE_TIMEOUT_MS);
 
@@ -168,6 +176,13 @@ class PythonStatsServer<Input, Output> {
             }) Average CPU: ${JSON.stringify(getAvgCPU(cpus, os.cpus()))}`
           );
           clearTimeout(timer);
+
+          // Datadog metrics
+          metrics.getCounter("python.stats_calls_resolved").increment();
+          metrics
+            .getHistogram("python.stats_call_duration_ms")
+            .record(Date.now() - start);
+
           resolve(results);
         },
         reject: (reason?: Error) => {
@@ -176,6 +191,13 @@ class PythonStatsServer<Input, Output> {
             reason
           );
           clearTimeout(timer);
+
+          // Datadog metrics
+          metrics.getCounter("python.stats_calls_rejected").increment();
+          metrics
+            .getHistogram("python.stats_call_duration_ms")
+            .record(Date.now() - start);
+
           reject(reason || new Error("Unknown error from Python stats server"));
         },
       });
@@ -206,6 +228,67 @@ export const statsServerPool = createPool(
     numTestsPerEvictionRun: 2,
   }
 );
+
+function publishPoolSizeToCloudWatch(value: number) {
+  if (!cloudWatch) return;
+  try {
+    cloudWatch.putMetricData({
+      Namespace: "GrowthBook/PythonStatsPool",
+      MetricData: [
+        {
+          MetricName: "PoolSize",
+          Timestamp: new Date(),
+          Value: value,
+          Unit: "Count",
+          Dimensions: [
+            { Name: "TaskId", Value: process.env.ECS_TASK_ID || "local" },
+          ],
+        },
+      ],
+    });
+  } catch (error) {
+    // When not running on AWS, no need to publish to cloudwatch or warn us every ten seconds.
+  }
+}
+
+function monitorServicePool() {
+  // If pool is exhausted it will emit this event
+  statsServerPool.on("factoryCreateError", () => {
+    metrics.getCounter("python.stats_pool_create_error").increment();
+  });
+  statsServerPool.on("factoryCreateSuccess", () => {
+    metrics.getCounter("python.stats_pool_created").increment();
+  });
+  statsServerPool.on("factoryDestroySuccess", () => {
+    metrics.getCounter("python.stats_pool_destroyed").increment();
+  });
+  statsServerPool.on("factoryValidateError", () => {
+    metrics.getCounter("python.stats_pool_validate_error").increment();
+  });
+  statsServerPool.on("evict", () => {
+    metrics.getCounter("python.stats_pool_evicted").increment();
+  });
+
+  setInterval(() => {
+    metrics.getGauge("python.stats_pool_size").record(statsServerPool.size);
+    metrics
+      .getGauge("python.stats_pool_idle")
+      .record(statsServerPool.available);
+    metrics.getGauge("python.stats_pool_busy").record(statsServerPool.borrowed);
+
+    // Publish to CloudWatch in order to be able to scale the python service
+    // Since generic-pool will only increase the pool size when all others are busy
+    // and we only decrease it once a minute if left idle.  The size will show
+    // the maximum pool size that was needed in the last minute.
+    if (IS_CLOUD) {
+      publishPoolSizeToCloudWatch(statsServerPool.size);
+    }
+  }, 60 * 1000);
+}
+
+if (!process.env.EXTERNAL_PYTHON_SERVER_URL) {
+  monitorServicePool();
+}
 
 function getAvgCPU(pre: os.CpuInfo[], post: os.CpuInfo[]) {
   let user = 0;


### PR DESCRIPTION
### Features and Changes

As we plan to break out python to its own microservice, it would be good to have accurate sense of how the python servers are doing.  This PR adds datadog metrics for how individual python calls go, and also on the pool size.  It also, if on cloud, will send cloudwatch the pool_size metric that we can use to autoscale the python servers.

pool_size is used instead of pool_busy because we only send the metric once a minute, and there is a good chance that there are no python processes running at that instant, but were in the recent past.  generic-pool will automatically increase the pool size if needed, and only decreases it if it has been idle for a minute so pool_busy should show the maximum number of busy servers in the last minute.  We would then be able to scale if the pool_size >= MAXIMUM_POOL_SIZE *0.75.

### Testing

`yarn build`
`. $(cd packages/stats && poetry env info --path)/bin/activate && yarn start:with-datadog`
Kick off a number of experiment results processings.
See the values in [datadog](https://us5.datadoghq.com/metric/explorer?fromUser=true&start=1752750383288&end=1752751152262&paused=true#N4Ig7glgJg5gpgFxALlAGwIYE8D2BXJVEADxQEYAaELcqyKBAC1pEbghkcLIF8qo4AMwgA7CAgg4RKUAiwAHOChASAtnADOcAE4RNIKtrgBHPJoQaUAbVBGN8qVoD6gnNtUZCKiOq279VKY6epbINiAiGOrKQdpYZAYgUJ4YThr42gDGSsgg6gi6mZaBZnHKGABuMMjyWExSAHQaCJ4aTpkYaGhtdjhoFXBQwABUPAAEAEZYY8CMOM08DRhtmfgiCAAUAJQgfKCR0bmxWABMicktaRnZyvmFxSDH5VU1dXMiTS0W7Z1oTlB4bSeSQiJyqDRLKojcZTGZzBa7Cj7KI5R6lLAAZnOKSugJuuTuECKiSeuUq1Vq9Q+zVaTgcfTSEAAXnBoZNprN5ggeIjkYc0TosAAWbGXdJ41GE4klQXPClvRo0770v4TPAaLBs2GchE8AC6VFc7jwmFC4SNqhNGBi6ISexAFqtNsFZ3tjswzriWLdbktHqO6JF+qozSwaByoHknUQCFRUBwMHapo0RMSaFEcCcckUynS6agaYzTnoTGUIl9nURSQg9kwWCzClR6ZESn1PD4IFr4gAwlJhDAUCITWgeEA).

