### PR TITLE
Updates SqlExplorer validation

### DIFF
--- a/packages/back-end/src/services/datasource.ts
+++ b/packages/back-end/src/services/datasource.ts
@@ -1,5 +1,4 @@
 import { AES, enc } from "crypto-js";
-import { isReadOnlySQL } from "shared/sql";
 import { ENCRYPTION_KEY } from "back-end/src/util/secrets";
 import GoogleAnalytics from "back-end/src/integrations/GoogleAnalytics";
 import Athena from "back-end/src/integrations/Athena";
@@ -155,10 +154,6 @@ export async function runFreeFormQuery(
 }> {
   if (!context.permissions.canRunSqlExplorerQueries(datasource)) {
     throw new Error("Permission denied");
-  }
-
-  if (!isReadOnlySQL(query)) {
-    throw new Error("Only SELECT queries are allowed.");
   }
 
   const integration = getSourceIntegrationObject(context, datasource);

--- a/packages/front-end/components/SchemaBrowser/SqlExplorerModal.tsx
+++ b/packages/front-end/components/SchemaBrowser/SqlExplorerModal.tsx
@@ -15,7 +15,7 @@ import {
 } from "back-end/src/validators/saved-queries";
 import { Box, Flex, Text } from "@radix-ui/themes";
 import { getValidDate } from "shared/dates";
-import { isReadOnlySQL, SQL_EXPLORER_LIMIT } from "shared/sql";
+import { SQL_EXPLORER_LIMIT } from "shared/sql";
 import { BsThreeDotsVertical } from "react-icons/bs";
 import { useAuth } from "@/services/auth";
 import { useDefinitions } from "@/services/DefinitionsContext";
@@ -40,6 +40,7 @@ import {
 } from "@/components/ResizablePanels";
 import useOrgSettings from "@/hooks/useOrgSettings";
 import { VisualizationAddIcon } from "@/components/Icons";
+import { validateSQL } from "@/services/datasources";
 import { SqlExplorerDataVisualization } from "../DataViz/SqlExplorerDataVisualization";
 import Modal from "../Modal";
 import SelectField from "../Forms/SelectField";
@@ -153,10 +154,7 @@ export default function SqlExplorerModal({
 
   const runQuery = useCallback(
     async (sql: string) => {
-      if (!isReadOnlySQL(sql)) {
-        throw new Error("Only SELECT queries are allowed.");
-      }
-
+      validateSQL(sql, []);
       form.setValue("dateLastRan", new Date());
       const res = await apiCall<QueryExecutionResult>("/query/run", {
         method: "POST",

--- a/packages/shared/src/sql.ts
+++ b/packages/shared/src/sql.ts
@@ -68,19 +68,3 @@ export function ensureLimit(sql: string, limit: number): string {
   // Add a newline in case there's a line comment at the end
   return `${sql}\nLIMIT ${limit}`;
 }
-
-export function isReadOnlySQL(sql: string) {
-  const normalized = sql
-    .trim()
-    .replace(/--.*$/gm, "") // remove line comments
-    .replace(/\/\*[\s\S]*?\*\//g, "") // remove block comments
-    .toLowerCase();
-
-  // Check the first keyword (e.g. "select", "with", etc.)
-  const match = normalized.match(
-    /^\s*(with|select|explain|show|describe|desc)\b/
-  );
-  if (!match) return false;
-
-  return true;
-}


### PR DESCRIPTION
### Features and Changes

While debugging a recent user issue, I noticed that we were using different validation for the `EditSqlModal` and the `SqlExplorerModal`.

In the `EditSqlModal` we were using the `validateSql` function, whereas in `SqlExplorerModal` we were using a one-off `isReadOnlyQuery` helper.

I originally noticed this as within `EditSqlModal` we have a check to throw an error if the query contains a trailing comma, but that was missing in the `SqlExplorerModal`.

As a result, I've currently opted to align both modals so they use the same `validateSql` helper. `validateSql` is much more restrictive than `isReadOnlyQuery` as `isReadOnlyQuery` accepts queries like `EXPLAIN`.  

If we think orgs will want and benefit from the less restrictive `isReadOnlyQuery` check, I can simply update it to also check for the trailing comma, otherwise we can align both modals on the `validateSql` helper.

The tertiary benefit of using `validateSql` is if we eventually want to support required columns in the `EditSqlModal`, `validateSql` has that logic built in.

### Dependencies

None

### Testing

- [x] Ensure an error is thrown if the query doesn't start with `SELECT`
- [x] Ensure an error is thrown if the query contains a trailing comma

