### PR TITLE
Some fixes for python monitoring stats

### DIFF
--- a/packages/back-end/src/services/python.ts
+++ b/packages/back-end/src/services/python.ts
@@ -235,17 +235,19 @@ function publishPoolSizeToCloudWatch(value: number) {
       MetricData: [
         {
           MetricName: "PoolSize",
-          Timestamp: new Date(),
           Value: value,
           Unit: "Count",
-          Dimensions: [
-            { Name: "TaskId", Value: process.env.ECS_TASK_ID || "local" },
-          ],
         },
       ],
     });
   } catch (error) {
-    // When not running on AWS, no need to publish to cloudwatch or warn us every ten seconds.
+    // When not running on AWS, no need to publish to cloudwatch or warn us every minute.
+    if (ENVIRONMENT === "production") {
+      logger.error(
+        "Failed to publish Python stats pool size to CloudWatch: " +
+          error.message
+      );
+    }
   }
 }
 
@@ -254,17 +256,8 @@ function monitorServicePool() {
   statsServerPool.on("factoryCreateError", () => {
     metrics.getCounter("python.stats_pool_create_error").increment();
   });
-  statsServerPool.on("factoryCreateSuccess", () => {
-    metrics.getCounter("python.stats_pool_created").increment();
-  });
-  statsServerPool.on("factoryDestroySuccess", () => {
-    metrics.getCounter("python.stats_pool_destroyed").increment();
-  });
-  statsServerPool.on("factoryValidateError", () => {
-    metrics.getCounter("python.stats_pool_validate_error").increment();
-  });
-  statsServerPool.on("evict", () => {
-    metrics.getCounter("python.stats_pool_evicted").increment();
+  statsServerPool.on("factoryDestroyError", () => {
+    metrics.getCounter("python.stats_pool_destroy_error").increment();
   });
 
   setInterval(() => {


### PR DESCRIPTION
### Features and Changes

A few of the events were hallucinations by Copilot.  There are just two that are emitted according to https://www.npmjs.com/package/generic-pool.

The cloudwatch metric doesn't seem to be populated yet.  Also the env var for the task doesn't exist - we could get it by making a fetch, but I don't think it is necessary for our purposes.  Will output the error on prod in order to debug.