### PR TITLE
DOCS, Grammar updates on faq.mdx

### DIFF
--- a/docs/docs/faq.mdx
+++ b/docs/docs/faq.mdx
@@ -62,7 +62,7 @@ So that means if you do 50 orders per week and that's the metric you are trying 
 
 Yes! In fact, we recommend running many experiments in parallel in your application. Most A/B tests fail, so the more shots-on-goal you take, the more likely you are to get a winner. Running tests in parallel is a great way to increase your velocity.
 
-Now it's possible your experiments might have interaction effects, but these are actually pretty rare in practice. One example is if one test is changing the text color on a page and another test is changing the background color. Some users might see end up seeing black text on a black background, which is obviously not ideal. For these rare cases, you can use [Namespaces](/features/rules#namespaces) to run mutually exclusive experiments. Make sure all experiments within the same Namespace are using the same hash attribute (assignment attribute).
+Now it's possible your experiments might have interaction effects, but these are actually pretty rare in practice. One example is if one test is changing the text color on a page and another test is changing the background color. Some users might end up seeing black text on a black background, which is obviously not ideal. For these rare cases, you can use [Namespaces](/features/rules#namespaces) to run mutually exclusive experiments. Make sure all experiments within the same Namespace are using the same hash attribute (assignment attribute).
 
 As long as you apply a little common sense to avoid situations like the above, running multiple experiments has low risk and really high reward.
 
@@ -132,7 +132,7 @@ The `trackingCallback` only fires when a user is included in an experiment. If y
 - The experiment has reduced coverage. For example, if it's only running for 10% of users and you are in the 90% that are excluded.
 - There is another feature rule that is taking precedence over the experiment.
 
-If you are using the Javascript or React SDK in a browser environment, you can install the GrowthBook DevTools Browser Extension for [Chrome](https://chrome.google.com/webstore/detail/growthbook-devtools/opemhndcehfgipokneipaafbglcecjia) or [Firefox](https://addons.mozilla.org/en-US/firefox/addon/growthbook-devtools/) to help you debug.
+If you are using the JavaScript or React SDK in a browser environment, you can install the GrowthBook DevTools Browser Extension for [Chrome](https://chrome.google.com/webstore/detail/growthbook-devtools/opemhndcehfgipokneipaafbglcecjia) or [Firefox](https://addons.mozilla.org/en-US/firefox/addon/growthbook-devtools/) to help you debug.
 
 **Note**: To use the plugin, you will need to pass `enableDevMode: true` when creating your GrowthBook instance.
 
@@ -144,7 +144,7 @@ const growthbook = new GrowthBook({
 
 ### How do I use the DevTools browser extension?
 
-- Make sure you are using the React or Javascript SDK
+- Make sure you are using the React or JavaScript SDK
 - Install the [Chrome](https://chrome.google.com/webstore/detail/growthbook-devtools/opemhndcehfgipokneipaafbglcecjia) or [Firefox](https://addons.mozilla.org/en-US/firefox/addon/growthbook-devtools/) DevTools Browser Extension
 - Pass the `enableDevMode: true` option into the GrowthBook constructor
 


### PR DESCRIPTION
Quick fix for typos:
- `users might see end up seeing` > `users might end up seeing`
- `Javascript` > `JavaScript` [Humorous notes on spelling](https://dev.to/gypsydave5/how-to-spell-javascript-107d)