### PR TITLE
fix(logs): Be more conservative on logging for Jobs

### DIFF
--- a/packages/back-end/src/services/jobLifecycle.ts
+++ b/packages/back-end/src/services/jobLifecycle.ts
@@ -18,9 +18,8 @@ export const addJobLifecycleChecks = <T extends JobAttributesData>(
       if (!finished) {
         job.touch().catch((e) => {
           logger.error(
-            `job=${JSON.stringify(
-              job.attrs
-            )} Error while trying to touch Agenda job ${job.attrs.name}: ${e}`
+            { jobId: job.attrs._id, err: e },
+            `Error while trying to touch Agenda job ${job.attrs.name}`
           );
         });
       }
@@ -36,12 +35,9 @@ export const addJobLifecycleChecks = <T extends JobAttributesData>(
 
   const timeoutPromise = new Promise<never>((_, reject) => {
     timeoutTimer = setTimeout(() => {
-      const errorMsg = `job=${JSON.stringify(job.attrs)} Agenda job ${
-        job.attrs.name
-      } timed out after ${JOB_TIMEOUT_MS}ms`;
-
+      const errorMsg = `Agenda job ${job.attrs.name} timed out after ${JOB_TIMEOUT_MS}ms`;
       stopTouch();
-      logger.error(new Error(errorMsg));
+      logger.error({ jobId: job.attrs._id, err: new Error(errorMsg) });
       reject(new Error(errorMsg));
     }, JOB_TIMEOUT_MS);
   });

--- a/packages/back-end/src/services/tracing.ts
+++ b/packages/back-end/src/services/tracing.ts
@@ -57,7 +57,7 @@ export const trackJob = <T extends JobAttributesData>(
   // run job
   let res;
   try {
-    logger.info(`job=${JSON.stringify(job)}; starting job ${jobName}`);
+    logger.info({ jobId: job.attrs._id }, `starting job ${jobName}`);
     res = await fn(job);
   } catch (e) {
     logger.error(`error running job: ${jobName}: ${e}`);
@@ -71,9 +71,7 @@ export const trackJob = <T extends JobAttributesData>(
   }
 
   // on successful job
-  logger.info(
-    `job=${JSON.stringify(job)}; successfully finished job ${jobName}`
-  );
+  logger.info({ jobId: job.attrs._id }, `successfully finished job ${jobName}`);
   try {
     wrapUpMetrics();
     metrics.getCounter(`jobs.successes`).increment(attributes);


### PR DESCRIPTION
### Features and Changes

Logging the whole job is creating a circular reference and keeps increasing the size of the object as it keeps failing and retrying; so we are being more conservative and logging only the job id which will give us enough information to debug problems.