### PR TITLE
Fix date format used in feature flag simulator

### DIFF
--- a/packages/front-end/components/Archetype/AttributeForm.tsx
+++ b/packages/front-end/components/Archetype/AttributeForm.tsx
@@ -1,9 +1,9 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { SDKAttribute, SDKAttributeSchema } from "back-end/types/organization";
 import { ArchetypeAttributeValues } from "back-end/types/archetype";
-import { datetime } from "shared/dates";
 import isEqual from "lodash/isEqual";
 import { Switch } from "@radix-ui/themes";
+import format from "date-fns/format";
 import { useAttributeSchema } from "@/services/features";
 import Field from "@/components/Forms/Field";
 import {
@@ -193,12 +193,12 @@ export default function AttributeForm({
               <>
                 {attribute.format === "date" ? (
                   <DatePicker
-                    precision="date"
+                    precision="datetime"
                     date={dateValue ? new Date(dateValue) : undefined}
                     setDate={(v) => {
                       attributeFormValues.set(
                         attribute.property,
-                        v ? datetime(v) : ""
+                        v ? format(v, "yyyy-MM-dd'T'HH:mm") : ""
                       );
                       updateFormValues();
                     }}

--- a/packages/front-end/components/Features/AttributeModal.tsx
+++ b/packages/front-end/components/Features/AttributeModal.tsx
@@ -269,7 +269,7 @@ export default function AttributeModal({ close, attribute }: Props) {
             initialOption="None"
             options={[
               { value: "version", label: "Version string" },
-              { value: "date", label: "Date string" },
+              { value: "date", label: "Date string (ISO)" },
               { value: "isoCountryCode", label: "ISO Country Code (2 digit)" },
             ]}
             sort={false}


### PR DESCRIPTION
Force the attribute form to use ISO formatted dates for strings that are formatted as dates. Affects the simulator and archetype editor.

<img width="538" height="715" alt="Screenshot 2025-07-21 at 2 12 43 PM" src="https://github.com/user-attachments/assets/8c196605-fd8f-4c04-b46f-ee849674957c" />
=