### PR TITLE
Set the default lock limit as an env var

### DIFF
--- a/packages/back-end/src/services/queueing.ts
+++ b/packages/back-end/src/services/queueing.ts
@@ -10,7 +10,7 @@ export const getAgendaInstance = (): Agenda => {
     const config: AgendaConfig = {
       // @ts-expect-error - For some reason the Mongoose MongoDB instance does not match (missing 5 properties)
       mongo: mongoose.connection.db,
-      defaultLockLimit: 5,
+      defaultLockLimit: Number(process.env.GB_DEFAULT_LOCK_LIMIT) || 5,
       defaultLockLifetime: 10 * 60 * 1000, // 10 minutes
     };
 


### PR DESCRIPTION
### Features and Changes
Our jobs servers run nothing else, so they can have a higher limit.