### PR TITLE
Fix back-end unable to boot under certain scenarios

### DIFF
--- a/packages/back-end/src/server.ts
+++ b/packages/back-end/src/server.ts
@@ -1,5 +1,6 @@
-import "./instrumentation";
 import "./init/aliases";
+
+import "./instrumentation";
 import app from "./app";
 import { logger } from "./util/logger";
 import { getAgendaInstance } from "./services/queueing";


### PR DESCRIPTION
Closes #4345

### Features and Changes

Depending on the build and the runtime the aliases needs to be configured in a different way (as described in #3863).

When I merged #4321 I added my file before init aliases by mistake, so this fixes it. 