### PR TITLE
fix(mysql-datasource): Ensure we close the connection after the query

### DIFF
--- a/packages/back-end/src/integrations/Mysql.ts
+++ b/packages/back-end/src/integrations/Mysql.ts
@@ -39,6 +39,7 @@ export default class Mysql extends SqlIntegration {
     const conn = await mysql.createConnection(config);
 
     const [rows] = await conn.query(sql);
+    conn.end();
     return { rows: rows as RowDataPacket[] };
   }
   dateDiff(startCol: string, endCol: string) {


### PR DESCRIPTION
Closes #1825

### Features and Changes

As reported in the issue, when querying a MySQL data source we would open a connection but never close it.
The DB configuration might close the connection depending on the idle configuration, but we can also close it on our end as soon as we are done with the query.