### PR TITLE
ClickHouse: Refactor extractJSONField to handle JSON type checks for better extraction logic

### DIFF
--- a/packages/back-end/src/integrations/ClickHouse.ts
+++ b/packages/back-end/src/integrations/ClickHouse.ts
@@ -118,9 +118,21 @@ export default class ClickHouse extends SqlIntegration {
   }
   extractJSONField(jsonCol: string, path: string, isNumeric: boolean): string {
     if (isNumeric) {
-      return `simpleJSONExtractFloat(${jsonCol}, '${path}')`;
+      return `
+if(
+  toTypeName(${jsonCol}) = 'JSON', 
+  toFloat64(${jsonCol}.${path}),
+  JSONExtractFloat(${jsonCol}, '${path}')
+)
+      `;
     } else {
-      return `simpleJSONExtractString(${jsonCol}, '${path}')`;
+      return `
+if(
+  toTypeName(${jsonCol}) = 'JSON',
+  ${jsonCol}.${path}.:String,
+  JSONExtractString(${jsonCol}, '${path}')
+)
+      `;
     }
   }
 


### PR DESCRIPTION
### Features and Changes

Added logic to determine the type of JSON column before retrieving values by key.

If JSON is stored as a string, the functions have been changed from `simpleJSONExtract*` to `JSONExtract`, which allows you to get the correct float value if an integer is requested.

- Closes #4130 

### Testing

1. Create fact table from simple query:

```
SELECT 
    '{"float": 1.0, "string": "string", "int": 123}' as json_string,
    json_string::JSON as json
```

2. Set both column types to JSON

3. Try to extract values.
