### PR TITLE
fix(sdk-webhooks): Use webhook secrets

### DIFF
--- a/packages/front-end/components/EventWebHooks/WebhookSecretModal.tsx
+++ b/packages/front-end/components/EventWebHooks/WebhookSecretModal.tsx
@@ -9,9 +9,13 @@ import StringArrayField from "../Forms/StringArrayField";
 export default function WebhookSecretModal({
   existingId,
   close,
+  onSuccess,
+  increasedElevation = false,
 }: {
   existingId?: string;
   close: () => void;
+  onSuccess?: (webhookSecretKey: string) => void;
+  increasedElevation?: boolean;
 }) {
   const { webhookSecrets, mutateDefinitions } = useDefinitions();
 
@@ -34,6 +38,7 @@ export default function WebhookSecretModal({
     <Modal
       open={true}
       close={close}
+      increasedElevation={increasedElevation}
       trackingEventModalType={`webhook_secret_${existingId ? "edit" : "add"}`}
       header={existingId ? "Edit Secret" : "Add Secret"}
       submit={form.handleSubmit(async (data) => {
@@ -74,6 +79,9 @@ export default function WebhookSecretModal({
           });
         }
         await mutateDefinitions();
+        if (onSuccess) {
+          onSuccess(data.key);
+        }
       })}
     >
       <Field

--- a/packages/front-end/pages/settings/webhooks/index.tsx
+++ b/packages/front-end/pages/settings/webhooks/index.tsx
@@ -23,7 +23,11 @@ const WebhooksPage: FC = () => {
   const { webhookSecrets, mutateDefinitions } = useDefinitions();
 
   const [editSecretId, setEditSecretId] = useState<string | null>(null);
-  const [newSecretOpen, setNewSecretOpen] = useState(false);
+
+  const queryParams = new URLSearchParams(window.location.search);
+  const [newSecretOpen, setNewSecretOpen] = useState<boolean>(
+    queryParams.has("newSecret") || false
+  );
 
   if (!canManageWebhooks) {
     return (


### PR DESCRIPTION
### Features and Changes

The recommended way of authenticating webhooks is via Webhook Secrets, but our SDK Connection flow was still hard-coding keys in the headers, meaning it could be seen by users of the platform after it had been set.

This fixes the flow by requiring the user to select an Existing Webhook Secret and injecting it into the headers automatically.

#### Before

It was a string field.

<img width="795" height="93" alt="Screenshot 2025-07-28 at 4 34 52 PM" src="https://github.com/user-attachments/assets/1d5addc5-fbdb-4d93-8609-81dfebeb4306" />

#### After

<img width="816" height="135" alt="Screenshot 2025-07-28 at 4 34 38 PM" src="https://github.com/user-attachments/assets/19a195d2-925c-484f-8995-9814756bff34" />