### PR TITLE
load secrets first

### DIFF
--- a/packages/back-end/src/api/api.router.ts
+++ b/packages/back-end/src/api/api.router.ts
@@ -5,7 +5,7 @@ import rateLimit from "express-rate-limit";
 import bodyParser from "body-parser";
 import * as Sentry from "@sentry/node";
 import authenticateApiRequestMiddleware from "back-end/src/middleware/authenticateApiRequestMiddleware";
-import { getBuild } from "back-end/src/util/handler";
+import { getBuild } from "back-end/src/util/build";
 import { ApiRequestLocals } from "back-end/types/api";
 import { SENTRY_DSN } from "../util/secrets";
 import featuresRouter from "./features/features.router";

--- a/packages/back-end/src/app.ts
+++ b/packages/back-end/src/app.ts
@@ -28,7 +28,7 @@ import { getAuthConnection, processJWT, usingOpenId } from "./services/auth";
 import { wrapController } from "./routers/wrapController";
 import apiRouter from "./api/api.router";
 import scimRouter from "./scim/scim.router";
-import { getBuild } from "./util/handler";
+import { getBuild } from "./util/build";
 
 // Begin Controllers
 import * as authControllerRaw from "./controllers/auth";

--- a/packages/back-end/src/init/dotenv.ts
+++ b/packages/back-end/src/init/dotenv.ts
@@ -1,0 +1,6 @@
+import fs from "fs";
+import dotenv from "dotenv";
+
+if (fs.existsSync(".env.local")) {
+  dotenv.config({ path: ".env.local" });
+}

--- a/packages/back-end/src/instrumentation.ts
+++ b/packages/back-end/src/instrumentation.ts
@@ -1,5 +1,6 @@
+// Warning: Careful importing other modules, as they and any dependencies they import won't be instrumented.
 import * as Sentry from "@sentry/node";
-import { getBuild } from "./util/handler";
+import { getBuild } from "./util/build";
 
 const SENTRY_DSN = process.env.SENTRY_DSN;
 if (SENTRY_DSN) {

--- a/packages/back-end/src/server.ts
+++ b/packages/back-end/src/server.ts
@@ -1,5 +1,5 @@
 import "./init/aliases";
-import "./util/secrets";
+import "./init/dotenv";
 import "./instrumentation";
 import app from "./app";
 import { logger } from "./util/logger";

--- a/packages/back-end/src/tracing.opentelemetry.ts
+++ b/packages/back-end/src/tracing.opentelemetry.ts
@@ -31,7 +31,7 @@ import { Resource } from "@opentelemetry/resources";
 import { SemanticResourceAttributes } from "@opentelemetry/semantic-conventions";
 import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-proto";
 import { PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
-import { getBuild } from "./util/handler";
+import { getBuild } from "./util/build";
 import { setMetrics, Attributes } from "./util/metrics";
 
 diag.setLogger(

--- a/packages/back-end/src/util/build.ts
+++ b/packages/back-end/src/util/build.ts
@@ -1,0 +1,45 @@
+// Warning: This is called from init/instrumentation.ts.
+// Careful importing other modules, as they and any dependencies they import won't be instrumented.
+import path from "path";
+import fs from "fs";
+
+let build: { sha: string; date: string; lastVersion: string };
+export function getBuild() {
+  if (!build) {
+    build = {
+      sha: "",
+      date: "",
+      lastVersion: "",
+    };
+    const rootPath = path.join(__dirname, "..", "..", "..", "..", "buildinfo");
+    if (fs.existsSync(path.join(rootPath, "SHA"))) {
+      build.sha = fs.readFileSync(path.join(rootPath, "SHA")).toString().trim();
+    }
+    if (fs.existsSync(path.join(rootPath, "DATE"))) {
+      build.date = fs
+        .readFileSync(path.join(rootPath, "DATE"))
+        .toString()
+        .trim();
+    }
+
+    // Read version from package.json
+    try {
+      const packageJSONPath = path.join(
+        __dirname,
+        "..",
+        "..",
+        "..",
+        "..",
+        "package.json"
+      );
+      if (fs.existsSync(packageJSONPath)) {
+        const json = JSON.parse(fs.readFileSync(packageJSONPath).toString());
+        build.lastVersion = json.version;
+      }
+    } catch (e) {
+      // Ignore errors here, not important
+    }
+  }
+
+  return build;
+}

--- a/packages/back-end/src/util/handler.ts
+++ b/packages/back-end/src/util/handler.ts
@@ -1,5 +1,3 @@
-import path from "path";
-import fs from "fs";
 import { Request, RequestHandler } from "express";
 import z, { Schema, ZodNever } from "zod";
 import { orgHasPremiumFeature } from "back-end/src/enterprise";
@@ -127,47 +125,6 @@ export function createApiRequestHandler<
     };
     return wrappedHandler;
   };
-}
-
-let build: { sha: string; date: string; lastVersion: string };
-export function getBuild() {
-  if (!build) {
-    build = {
-      sha: "",
-      date: "",
-      lastVersion: "",
-    };
-    const rootPath = path.join(__dirname, "..", "..", "..", "..", "buildinfo");
-    if (fs.existsSync(path.join(rootPath, "SHA"))) {
-      build.sha = fs.readFileSync(path.join(rootPath, "SHA")).toString().trim();
-    }
-    if (fs.existsSync(path.join(rootPath, "DATE"))) {
-      build.date = fs
-        .readFileSync(path.join(rootPath, "DATE"))
-        .toString()
-        .trim();
-    }
-
-    // Read version from package.json
-    try {
-      const packageJSONPath = path.join(
-        __dirname,
-        "..",
-        "..",
-        "..",
-        "..",
-        "package.json"
-      );
-      if (fs.existsSync(packageJSONPath)) {
-        const json = JSON.parse(fs.readFileSync(packageJSONPath).toString());
-        build.lastVersion = json.version;
-      }
-    } catch (e) {
-      // Ignore errors here, not important
-    }
-  }
-
-  return build;
 }
 
 export async function validateIsSuperUserRequest(req: {

--- a/packages/back-end/src/util/secrets.ts
+++ b/packages/back-end/src/util/secrets.ts
@@ -1,6 +1,4 @@
-import fs from "fs";
 import Handlebars from "handlebars";
-import dotenv from "dotenv";
 import trimEnd from "lodash/trimEnd";
 import { stringToBoolean } from "shared/util";
 import { DEFAULT_METRIC_WINDOW_HOURS } from "shared/constants";
@@ -8,10 +6,6 @@ import { z } from "zod";
 
 export const ENVIRONMENT = process.env.NODE_ENV;
 const prod = ENVIRONMENT === "production";
-
-if (fs.existsSync(".env.local")) {
-  dotenv.config({ path: ".env.local" });
-}
 
 export const LOG_LEVEL = process.env.LOG_LEVEL;
 


### PR DESCRIPTION
### Features and Changes

if IS_CLOUD=true and SSO_CONFIG={} in .env.local `yarn dev` will end up saying "No SSO Connection Configured" which is not true.  That is because the "./instrumentation" import in server.ts kicked off a series of imports that ended up loading secrets.ts after sso.ts, but secrets.ts needs to be loaded first to get `dotenv` loaded. 

### Testing
Set IS_CLOUD=true and SSO_CONFIG={} in .env.local
`yarn dev`
localhost:3000
See no error msg, but get taken to the SSO login page.
