### PR TITLE
log request starts on cloud

### DIFF
--- a/packages/back-end/src/util/logger.ts
+++ b/packages/back-end/src/util/logger.ts
@@ -93,6 +93,11 @@ export const httpLogger = pinoHttp({
     remove: true,
   },
   customProps: getCustomLogProps,
+  ...(IS_CLOUD
+    ? {
+        customReceivedMessage: () => "Request started",
+      }
+    : {}),
   ...logBase,
 });
 


### PR DESCRIPTION
### Features and Changes

Very occasionally on cloud there is a request that uses so much memory and CPU that the server crashes.  It is unclear if the "request aborted" message even gets sent for those routes, hence on cloud we will output a "Request started" log that we can use to match up and see which requests never finished. 

It is unlikely other self-hosted production environments would need this extra log.

Without `autoLogging:true` no "Request started" logs get printed.

### Testing
`yarn dev`
hit localhost:3000
See no logs in the console.
Ctrl-C

set IS_CLOUD=false in .env.local
`yarn dev`
replace the `autologging` line to `autoLogging:true`
hit localhost:3000
See only "Request completed" logs
Ctrl-C

set IS_CLOUD=true in .env.local
`yarn dev`
hit localhost:3000
See both "Request started" and "Request completed" logs
 

