### PR TITLE
fix(SQL): Add parentheses around user-defined filters

### DIFF
--- a/packages/front-end/components/FactTables/FactMetricModal.tsx
+++ b/packages/front-end/components/FactTables/FactMetricModal.tsx
@@ -559,7 +559,13 @@ function ColumnRefSelector({
                       key={f}
                     >
                       <Tooltip
-                        body={<InlineCode language="sql" code={filter.value} />}
+                        body={
+                          <InlineCode
+                            language="sql"
+                            code={filter.value}
+                            inTooltip
+                          />
+                        }
                       >
                         <span className="cursor-default">{filter.name}</span>
                       </Tooltip>

--- a/packages/front-end/components/SyntaxHighlighting/InlineCode.tsx
+++ b/packages/front-end/components/SyntaxHighlighting/InlineCode.tsx
@@ -19,12 +19,20 @@ export interface Props {
   code: string;
   language: Language;
   className?: string;
+  inTooltip?: boolean;
 }
 
-export default function InlineCode({ code, language, className }: Props) {
+export default function InlineCode({
+  code,
+  language,
+  className,
+  inTooltip,
+}: Props) {
   const { theme } = useAppearanceUITheme();
 
-  const style = cloneDeep(theme === "light" ? light : dark);
+  const style = cloneDeep(
+    theme === "light" ? (inTooltip ? dark : light) : inTooltip ? light : dark
+  );
   style['code[class*="language-"]'].fontSize = "0.85rem";
   style['code[class*="language-"]'].lineHeight = 1.5;
   style['code[class*="language-"]'].fontWeight = 600;

--- a/packages/shared/src/experiments.ts
+++ b/packages/shared/src/experiments.ts
@@ -139,7 +139,7 @@ export function getColumnRefWhereClause(
     const filter = factTable.filters.find((f) => f.id === filterId);
     if (filter) {
       const comment = showSourceComment ? `-- Filter: ${filter.name}\n` : "";
-      where.add(comment + filter.value);
+      where.add(comment + `(${filter.value})`);
     }
   });
 


### PR DESCRIPTION
### Features and Changes

If you had 2+ filters for a fact metric, and one of them had an OR statement, there was a chance it would evaluate incorrectly. This PR adds more parentheses in the fact metric preview and in the actual fact metric SQL by updating the shared logic that returns the filters.

I also fixed some inline code styling within tooltips in a hacky way.

### Testing

* Fact Metric preview fixed
* Experiment Fact Metric query now adds parentheses (double parentheses if you add manual parentheses work fine in postgres, at least)
* Fact Metric standalone analysis query also works

### Screenshots

| | Before | After |
| - | - | - |
|Preview | <img width="1429" height="715" alt="Screenshot 2025-07-31 at 3 46 11 PM" src="https://github.com/user-attachments/assets/1d444c79-e178-4fe1-ac00-b2fa0dd24b7e" /> | <img width="1389" height="695" alt="Screenshot 2025-07-31 at 10 09 07 AM" src="https://github.com/user-attachments/assets/682deee7-a706-4b65-9721-1fa2f4589351" /> |
| In experiment SQL |  <img width="1430" height="552" alt="Screenshot 2025-07-31 at 3 38 50 PM" src="https://github.com/user-attachments/assets/b240d0ac-4e22-4509-a75e-c4e8cb5a5d4c" /> | 
<img width="646" height="459" alt="Screenshot 2025-07-31 at 3 37 41 PM" src="https://github.com/user-attachments/assets/b83cef7f-3174-489c-ba85-652e8a44946f" /> |

