### PR TITLE
fix(stats): Fix another rare div by 0 error

### DIFF
--- a/packages/stats/gbstats/utils.py
+++ b/packages/stats/gbstats/utils.py
@@ -45,6 +45,8 @@ def truncated_normal_mean(mu, sigma, a, b) -> float:
 # denominator random variable D (mean = mean_d, var = var_d),
 # and covariance cov_m_d, what is the variance of M / D?
 def variance_of_ratios(mean_m, var_m, mean_d, var_d, cov_m_d) -> float:
+    if mean_d == 0:
+        return 0
     return (
         var_m / mean_d**2
         + var_d * mean_m**2 / mean_d**4


### PR DESCRIPTION
### Features and Changes

Hopefully, fixes another rare division by zero error (seen here: https://growthbook.sentry.io/issues/6775367950/?project=4503942935216128&query=is%3Aunresolved%20python&referrer=issue-stream)

This must occur somehow when there is a ratio metric that is regression adjusted and only the unadjusted mean is zero? Otherwise I don't see how this error would occur.

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

Did not do any.

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
