### PR TITLE
Fix dashboards throwing permission error when updating snapshot

### DIFF
--- a/packages/back-end/src/models/ExperimentSnapshotModel.ts
+++ b/packages/back-end/src/models/ExperimentSnapshotModel.ts
@@ -306,7 +306,10 @@ export async function updateSnapshot({
           ? { ...block, snapshotId: experimentSnapshotModel.id }
           : block
       );
-      await context.models.dashboards.updateById(dashboard.id, { blocks });
+      await context.models.dashboards.dangerousUpdateBypassPermission(
+        dashboard,
+        { blocks }
+      );
     }
   }
 }


### PR DESCRIPTION
### Features and Changes

The permissions checks for updating dashboards were interfering with the automatic snapshot updates. This bypasses the permissions because the codepath isn't initiated by a user