### PR TITLE
fix(time-series): Avoid going over array boundary

### DIFF
--- a/packages/back-end/src/models/MetricTimeSeriesModel.ts
+++ b/packages/back-end/src/models/MetricTimeSeriesModel.ts
@@ -284,7 +284,7 @@ export class MetricTimeSeriesModel extends BaseClass {
         (a, b) =>
           getValidDate(a.date).getTime() - getValidDate(b.date).getTime()
       )
-      .reduce((acc, dataPoint) => {
+      .reduceRight((acc, dataPoint) => {
         if (!isValidDataPoint(dataPoint)) {
           return acc;
         }

--- a/packages/front-end/components/Experiment/ExperimentTimeSeriesGraph.tsx
+++ b/packages/front-end/components/Experiment/ExperimentTimeSeriesGraph.tsx
@@ -479,7 +479,13 @@ const ExperimentTimeSeriesGraph: FC<ExperimentTimeSeriesGraphProps> = ({
 
   const hasDataForDay = useMemo(() => {
     const firstDateWithData =
-      sortedDatesWithData[lastDataPointIndexWithHelperText + 1].d;
+      sortedDatesWithData[
+        // Ensure we don't go past the end of the array
+        Math.min(
+          lastDataPointIndexWithHelperText + 1,
+          sortedDatesWithData.length - 1
+        )
+      ].d;
     const lastDateWithData =
       sortedDatesWithData[sortedDatesWithData.length - 1].d;
 


### PR DESCRIPTION
### Features and Changes

With #4365 I changed `reduceRight` to `reduce` by mistake and did notice it, so I am undoing this change to fix a bug.
Also adding additional checks to ensure we don't go over the array boundary.