### PR TITLE
fix(sql): presto connection form missing fields

### DIFF
--- a/packages/front-end/components/Settings/PrestoForm.tsx
+++ b/packages/front-end/components/Settings/PrestoForm.tsx
@@ -86,7 +86,7 @@ const PrestoForm: FC<{
           onChange={onParamChange}
         />
       </div>
-      {params.authType === "basicAuth" && (
+      {(params.authType ?? "basicAuth") === "basicAuth" && (
         <>
           <div className="form-group col-md-12">
             <label>Username</label>


### PR DESCRIPTION
Presto/trino wasn't showing username/password by default since `authType` was undefined. Under the hood we default to "basicAuth" so having the fields show up properly but keeping the authType undefined is a fine fix.

https://www.loom.com/share/287903a51c47482bb79eeaa6eba3ea12