### PR TITLE
Make sure jest doesn't warn on open handles

### DIFF
--- a/packages/back-end/package.json
+++ b/packages/back-end/package.json
@@ -16,7 +16,7 @@
     "start:with-tracing": "node --require ./dist/tracing.opentelemetry.js dist/server.js",
     "start:with-datadog": "node --require ./dist/tracing.datadog.js dist/server.js",
     "repl": "node --require ts-node/register/transpile-only --experimental-repl-await repl",
-    "test": "jest --forceExit --verbose --detectOpenHandles",
+    "test": "DISABLE_PYTHON_MONITOR=true GB_STATS_ENGINE_MIN_POOL_SIZE=0 jest --forceExit --verbose --detectOpenHandles",
     "type-check": "tsc --pretty --noEmit",
     "unused-export-check": "npx ts-unused-exports tsconfig.json --findCompletelyUnusedFiles --allowUnusedTypes --showLineNumber",
     "generate-dummy-data": "ts-node ./test/data-generator/new-generator.ts",

--- a/packages/back-end/src/services/python.ts
+++ b/packages/back-end/src/services/python.ts
@@ -4,6 +4,7 @@ import path from "path";
 import { randomUUID } from "crypto";
 import { CloudWatch } from "aws-sdk";
 import { createPool } from "generic-pool";
+import { stringToBoolean } from "shared/util";
 import { MultipleExperimentMetricAnalysis } from "back-end/types/stats";
 import { logger } from "back-end/src/util/logger";
 import { ExperimentDataForStatsEngine } from "back-end/src/services/stats";
@@ -21,8 +22,9 @@ function parseEnvInt(
   defaultValue: number,
   opts?: { min?: number; max?: number; name?: string }
 ): number {
-  const num = parseInt(value || "") || defaultValue;
+  const num = value === undefined ? defaultValue : parseInt(value);
   if (
+    isNaN(num) ||
     (opts?.min !== undefined && num < opts.min) ||
     (opts?.max !== undefined && num > opts.max)
   ) {
@@ -323,7 +325,10 @@ function monitorServicePool() {
   }, 60 * 1000);
 }
 
-if (!process.env.EXTERNAL_PYTHON_SERVER_URL) {
+if (
+  !process.env.EXTERNAL_PYTHON_SERVER_URL &&
+  !stringToBoolean(process.env.DISABLE_PYTHON_MONITOR)
+) {
   monitorServicePool();
 }
 


### PR DESCRIPTION
### Features and Changes

This makes sure that jest doesn't complain about open handles.  There were two, one from python and the other from the python monitor's setInterval.  Since we are not testing this logic anywhere I disable both globally by setting the env var.
This also fixes a bug when setting the GB_STATS_ENGINE_MIN_POOL_SIZE=0.

The alternative is to make a cleanup Handler.  I tried that with a globalTeardown, but it didn't work. 
The only other way is to make sure each test has an afterAll, but since there is no wrapper around all tests, this would have been a pain.

### Testing
`yarn test` see no complaints about open handles

