### PR TITLE
Updates auto complete logic to better handle lowercase FROM clause

### DIFF
--- a/packages/front-end/services/sqlAutoComplete.ts
+++ b/packages/front-end/services/sqlAutoComplete.ts
@@ -567,7 +567,8 @@ export async function getAutoCompletions(
       // Isolate the text after the "FROM" or "from" SQL keyword
       // This allows us to identify if the FROM clause already has certain tables or schemas
       // for more accurate completions. e.g. if the FROM clause references a schema, only show tables in that schema
-      const textAfterFrom = textUpToCursor.split(/from/i)[1]?.trim() || "";
+      const textAfterFrom =
+        textUpToCursor.toLowerCase().split("from")[1]?.trim() || "";
 
       return handleFromClauseCompletions(
         textAfterFrom,


### PR DESCRIPTION
### Features and Changes

Previously, the logic to isolate the text after the `FROM` Sql keyword was a bit too limiting and was case sensitive. I.E the logic wouldn't return the correct value for the clause `from `my_schema`.`my_table``, but it would work correctly for `FROM `my_schema`.`my_table``.

Now, I normalize the input to lowecase before splitting on the `FROM` keyword.

- Closes **(add link to issue here)**

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

- [x] Ensure that the query `SELECT * FROM ` returns all of the dbs, schemas, tables, and sql keywords
- [x] Ensure that the query `select * from ` returns all of the dbs, schemas, tables, and sql keywords
- [x] Ensure that the query `select * From ` returns all of the dbs, schemas, tables, and sql keywords
