### PR TITLE
Adds managedBy field to segments

### DIFF
--- a/docs/docs/self-host/config.mdx
+++ b/docs/docs/self-host/config.mdx
@@ -518,7 +518,7 @@ sql: SELECT user_id, timestamp as date FROM pages WHERE country='US'
 ```
 
 Segment support for the config.yml was added in February 2023. If you are using the config.yml file and have previously created segments stored in MongoDB, in order to access,
-you will need to add the environment variable `STORE_SEGMENTS_IN_MONGO` or update your config.yml file to include these segments.
+you will need to add the environment variable `STORE_SEGMENTS_IN_MONGO` or update your config.yml file to include these segments. Likewise, if you'd like to create new segments via the UI in addition to those in the config.yml, you'll want to set this environment variable to `TRUE`.
 
 ### Organization Settings
 

--- a/packages/back-end/src/init/config.ts
+++ b/packages/back-end/src/init/config.ts
@@ -237,6 +237,7 @@ export function getConfigSegments(organization: string): SegmentInterface[] {
       organization,
       dateCreated: new Date(),
       dateUpdated: new Date(),
+      managedBy: "config",
     };
   });
 }

--- a/packages/back-end/src/models/SegmentModel.ts
+++ b/packages/back-end/src/models/SegmentModel.ts
@@ -82,26 +82,20 @@ export class SegmentModel extends BaseClass {
     // Special case: If using config file AND STORE_SEGMENTS_IN_MONGO is true,
     // we want to pull from both sources
     if (usingFileConfig() && STORE_SEGMENTS_IN_MONGO) {
-      const segments: SegmentInterface[] = [];
-      const segmentIds = new Set<string>();
+      const segmentSet = new Set<SegmentInterface>();
 
       // Get config documents first
       const configSegments = getConfigSegments(this.context.org.id);
       configSegments.forEach((segment) => {
-        segments.push(segment);
-        segmentIds.add(segment.id);
+        segmentSet.add(segment);
       });
 
-      // Get MongoDB documents (excluding those already in config)
       const mongoSegments = await super.getAll();
       mongoSegments.forEach((segment) => {
-        if (!segmentIds.has(segment.id)) {
-          segments.push(segment);
-          segmentIds.add(segment.id);
-        }
+        segmentSet.add(segment);
       });
 
-      return segments;
+      return Array.from(segmentSet);
     } else {
       // Use the default BaseModel logic
       return super.getAll();
@@ -139,27 +133,21 @@ export class SegmentModel extends BaseClass {
     // Special case: If using config file AND STORE_SEGMENTS_IN_MONGO is true,
     // we want to pull from both sources
     if (usingFileConfig() && STORE_SEGMENTS_IN_MONGO) {
-      const segments: SegmentInterface[] = [];
-      const segmentIds = new Set<string>();
+      const segmentSet = new Set<SegmentInterface>();
 
       // Get config documents first
       const configSegments = getConfigSegments(this.context.org.id).filter(
         (segment) => segment.datasource === datasourceId
       );
       configSegments.forEach((segment) => {
-        segments.push(segment);
-        segmentIds.add(segment.id);
+        segmentSet.add(segment);
       });
 
-      // Get MongoDB documents (excluding those already in config)
       const mongoSegments = await super._find({ datasource: datasourceId });
       mongoSegments.forEach((segment) => {
-        if (!segmentIds.has(segment.id)) {
-          segments.push(segment);
-          segmentIds.add(segment.id);
-        }
+        segmentSet.add(segment);
       });
-      return segments;
+      return Array.from(segmentSet);
     } else {
       return await this._find({ datasource: datasourceId });
     }
@@ -171,28 +159,22 @@ export class SegmentModel extends BaseClass {
     // Special case: If using config file AND STORE_SEGMENTS_IN_MONGO is true,
     // we want to pull from both sources
     if (usingFileConfig() && STORE_SEGMENTS_IN_MONGO) {
-      const segments: SegmentInterface[] = [];
-      const segmentIds = new Set<string>();
+      const segmentSet = new Set<SegmentInterface>();
 
       // Get config documents first
       const configSegments = getConfigSegments(this.context.org.id).filter(
         (segment) => segment.factTableId === factTableId
       );
       configSegments.forEach((segment) => {
-        segments.push(segment);
-        segmentIds.add(segment.id);
+        segmentSet.add(segment);
       });
 
-      // Get MongoDB documents (excluding those already in config)
       const mongoSegments = await super._find({ factTableId });
       mongoSegments.forEach((segment) => {
-        if (!segmentIds.has(segment.id)) {
-          segments.push(segment);
-          segmentIds.add(segment.id);
-        }
+        segmentSet.add(segment);
       });
 
-      return segments;
+      return Array.from(segmentSet);
     } else {
       return await this._find({ factTableId });
     }

--- a/packages/back-end/src/models/SegmentModel.ts
+++ b/packages/back-end/src/models/SegmentModel.ts
@@ -82,20 +82,12 @@ export class SegmentModel extends BaseClass {
     // Special case: If using config file AND STORE_SEGMENTS_IN_MONGO is true,
     // we want to pull from both sources
     if (usingFileConfig() && STORE_SEGMENTS_IN_MONGO) {
-      const segmentSet = new Set<SegmentInterface>();
-
       // Get config documents first
       const configSegments = getConfigSegments(this.context.org.id);
-      configSegments.forEach((segment) => {
-        segmentSet.add(segment);
-      });
 
       const mongoSegments = await super.getAll();
-      mongoSegments.forEach((segment) => {
-        segmentSet.add(segment);
-      });
 
-      return Array.from(segmentSet);
+      return [...configSegments, ...mongoSegments];
     } else {
       // Use the default BaseModel logic
       return super.getAll();
@@ -133,21 +125,13 @@ export class SegmentModel extends BaseClass {
     // Special case: If using config file AND STORE_SEGMENTS_IN_MONGO is true,
     // we want to pull from both sources
     if (usingFileConfig() && STORE_SEGMENTS_IN_MONGO) {
-      const segmentSet = new Set<SegmentInterface>();
-
       // Get config documents first
       const configSegments = getConfigSegments(this.context.org.id).filter(
         (segment) => segment.datasource === datasourceId
       );
-      configSegments.forEach((segment) => {
-        segmentSet.add(segment);
-      });
 
       const mongoSegments = await super._find({ datasource: datasourceId });
-      mongoSegments.forEach((segment) => {
-        segmentSet.add(segment);
-      });
-      return Array.from(segmentSet);
+      return [...configSegments, ...mongoSegments];
     } else {
       return await this._find({ datasource: datasourceId });
     }
@@ -159,22 +143,14 @@ export class SegmentModel extends BaseClass {
     // Special case: If using config file AND STORE_SEGMENTS_IN_MONGO is true,
     // we want to pull from both sources
     if (usingFileConfig() && STORE_SEGMENTS_IN_MONGO) {
-      const segmentSet = new Set<SegmentInterface>();
-
       // Get config documents first
       const configSegments = getConfigSegments(this.context.org.id).filter(
         (segment) => segment.factTableId === factTableId
       );
-      configSegments.forEach((segment) => {
-        segmentSet.add(segment);
-      });
 
       const mongoSegments = await super._find({ factTableId });
-      mongoSegments.forEach((segment) => {
-        segmentSet.add(segment);
-      });
 
-      return Array.from(segmentSet);
+      return [...configSegments, ...mongoSegments];
     } else {
       return await this._find({ factTableId });
     }

--- a/packages/back-end/src/models/SegmentModel.ts
+++ b/packages/back-end/src/models/SegmentModel.ts
@@ -38,6 +38,33 @@ export class SegmentModel extends BaseClass {
   protected canDelete(doc: SegmentInterface): boolean {
     return this.context.permissions.canDeleteSegment(doc);
   }
+
+  protected async beforeCreate(doc: SegmentInterface) {
+    if (doc.managedBy === "api" && !this.context.isApiRequest) {
+      throw new Error("Cannot create segment managed by API");
+    }
+  }
+
+  protected async beforeUpdate(existing: SegmentInterface) {
+    if (existing.managedBy === "config") {
+      throw new Error("Cannot update segment managed by config");
+    }
+
+    if (existing.managedBy === "api" && !this.context.isApiRequest) {
+      throw new Error("Cannot update segment managed by API");
+    }
+  }
+
+  protected async beforeDelete(existing: SegmentInterface) {
+    if (existing.managedBy === "config") {
+      throw new Error("Cannot delete segment managed by config");
+    }
+
+    if (existing.managedBy === "api" && !this.context.isApiRequest) {
+      throw new Error("Cannot delete segment managed by API");
+    }
+  }
+
   protected useConfigFile(): boolean {
     if (usingFileConfig() && !STORE_SEGMENTS_IN_MONGO) {
       return true;

--- a/packages/back-end/src/routers/segment/segment.validators.ts
+++ b/packages/back-end/src/routers/segment/segment.validators.ts
@@ -14,6 +14,7 @@ export const segmentValidator = z
     description: z.string(),
     userIdType: z.string(),
     type: z.enum(TYPES),
+    managedBy: z.enum(["", "api", "config"]).optional(),
     sql: z.string().optional(),
     factTableId: z.string().optional(),
     filters: z.array(z.string()).optional(),

--- a/packages/front-end/components/Owner/SelectOwner.tsx
+++ b/packages/front-end/components/Owner/SelectOwner.tsx
@@ -19,6 +19,7 @@ interface Props {
     | "archetype"
     | "factTable";
   placeholder?: string;
+  disabled?: boolean;
 }
 
 export default function SelectOwner({
@@ -26,6 +27,7 @@ export default function SelectOwner({
   onChange,
   placeholder = "",
   resourceType,
+  disabled = false,
 }: Props) {
   const { memberUsernameOptions, memberUserNameAndIdOptions } = useMembers();
 
@@ -53,6 +55,7 @@ export default function SelectOwner({
         label: member.display,
       }))}
       value={value}
+      disabled={disabled}
       placeholder={placeholder}
       onChange={(v) => onChange(v)}
       formatOptionLabel={({ label }) => {

--- a/packages/front-end/components/Segments/SegmentForm.tsx
+++ b/packages/front-end/components/Segments/SegmentForm.tsx
@@ -40,6 +40,20 @@ const SegmentForm: FC<{
     factTables,
   } = useDefinitions();
   const permissionsUtil = usePermissionsUtil();
+
+  // If the segment is externally managed, automatically set it as read-only, even if the user has create/update permissions
+  let isReadOnly = !!current?.managedBy;
+
+  // If the segment is not externally managed, check the user's permissions
+  if (isReadOnly === false) {
+    if (current?.id) {
+      // if the current segment has an id, this is an update
+      isReadOnly = !permissionsUtil.canUpdateSegment(current, {});
+    } else {
+      // otherwise, the user is trying to create a new segment
+      isReadOnly = !permissionsUtil.canCreateSegment({ projects: [project] });
+    }
+  }
   const filteredDatasources = datasources
     .filter((d) => d.properties?.segments)
     .filter(
@@ -127,6 +141,7 @@ const SegmentForm: FC<{
         close={close}
         open={true}
         size={"lg"}
+        ctaEnabled={!isReadOnly}
         cta={current.id ? "Update Segment" : "Create Segment"}
         header={current.id ? "Edit Segment" : "New Segment"}
         submit={form.handleSubmit(async (value) => {
@@ -181,18 +196,29 @@ const SegmentForm: FC<{
             </a>
           </div>
         ) : null}
-        <Field label="Name" required {...form.register("name")} />
+        <Field
+          label="Name"
+          required
+          {...form.register("name")}
+          disabled={isReadOnly}
+        />
         <SelectOwner
           resourceType="segment"
+          disabled={isReadOnly}
           value={form.watch("owner")}
           onChange={(v) => form.setValue("owner", v)}
         />
-        <Field label="Description" {...form.register("description")} textarea />
+        <Field
+          label="Description"
+          {...form.register("description")}
+          textarea
+          disabled={isReadOnly}
+        />
         <SelectField
           label="Data Source"
           required
           value={form.watch("datasource")}
-          disabled={!!current.id}
+          disabled={!!current.id || isReadOnly}
           onChange={(v) => {
             form.setValue("datasource", v);
             // When a new data source is selected, update the projects so they equal the data source's project list
@@ -210,6 +236,7 @@ const SegmentForm: FC<{
           <SelectField
             label="Identifier Type"
             required
+            disabled={isReadOnly}
             value={userIdType}
             onChange={(v) => form.setValue("userIdType", v)}
             options={(datasource?.settings?.userIdTypes || []).map((t) => {
@@ -235,6 +262,7 @@ const SegmentForm: FC<{
               }
               placeholder="All projects"
               value={form.watch("projects")}
+              disabled={isReadOnly}
               options={projectOptions}
               onChange={(v) => form.setValue("projects", v)}
               customClassName="label-overflow-ellipsis"
@@ -250,6 +278,7 @@ const SegmentForm: FC<{
               <button
                 className="btn btn-outline-primary"
                 type="button"
+                disabled={isReadOnly}
                 onClick={(e) => {
                   e.preventDefault();
                   setSqlOpen(true);
@@ -266,6 +295,7 @@ const SegmentForm: FC<{
             {...form.register("sql")}
             textarea
             minRows={3}
+            disabled={isReadOnly}
             placeholder={"event.properties.$browser === 'Chrome'"}
             helpText={
               <>

--- a/packages/front-end/pages/segments/index.tsx
+++ b/packages/front-end/pages/segments/index.tsx
@@ -18,6 +18,7 @@ import Tooltip from "@/components/Tooltip/Tooltip";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 import MoreMenu from "@/components/Dropdown/MoreMenu";
 import ProjectBadges from "@/components/ProjectBadges";
+import { OfficialBadge } from "@/components/Metrics/MetricName";
 
 const SegmentPage: FC = () => {
   const {
@@ -248,7 +249,7 @@ const SegmentPage: FC = () => {
                   <th>Projects</th>
                   <th className="d-none d-sm-table-cell">Data Source</th>
                   <th className="d-none d-md-table-cell">Identifier Type</th>
-                  {canStoreSegmentsInMongo ? <th>Date Updated</th> : null}
+                  <th>Date Updated</th>
                   <th></th>
                 </tr>
               </thead>
@@ -262,6 +263,10 @@ const SegmentPage: FC = () => {
                     <tr key={s.id}>
                       <td>
                         <>
+                          <OfficialBadge
+                            type="Segment"
+                            managedBy={s.managedBy}
+                          />{" "}
                           {s.name}{" "}
                           {s.description ? (
                             <Tooltip body={s.description} />
@@ -299,25 +304,38 @@ const SegmentPage: FC = () => {
                           {userIdType}
                         </span>
                       </td>
-                      {canStoreSegmentsInMongo ? (
-                        <td>{ago(s.dateUpdated)}</td>
-                      ) : null}
+                      <td>
+                        {s.managedBy !== "config" ? (
+                          <>{ago(s.dateUpdated)}</>
+                        ) : (
+                          <>-</>
+                        )}
+                      </td>
                       <td>
                         <MoreMenu>
-                          {permissionsUtil.canUpdateSegment(s, {}) &&
-                          canStoreSegmentsInMongo ? (
-                            <button
-                              className="dropdown-item"
-                              onClick={(e) => {
-                                e.preventDefault();
-                                setSegmentForm(s);
-                              }}
-                            >
-                              <FaPencilAlt /> Edit
-                            </button>
-                          ) : null}
+                          {/* If the user has permission & the segment isn't externally managed, show edit icon,
+                          otherwise the cta should be `View Details`. This is because Segment's don't have an id page,
+                         in order for the user to see the sql that powers the segment, we need to show the edit form, but in read only mode */}
+                          <button
+                            className="dropdown-item"
+                            onClick={(e) => {
+                              e.preventDefault();
+                              setSegmentForm(s);
+                            }}
+                          >
+                            {permissionsUtil.canUpdateSegment(s, {}) &&
+                            !s.managedBy ? (
+                              <>
+                                <FaPencilAlt /> Edit
+                              </>
+                            ) : (
+                              <>View Details</>
+                            )}
+                          </button>
                           {permissionsUtil.canDeleteSegment(s) &&
-                          canStoreSegmentsInMongo ? (
+                          canStoreSegmentsInMongo &&
+                          // if the segment has a managedBy value, it can't be deleted in the UI
+                          !s.managedBy ? (
                             <DeleteButton
                               className="dropdown-item"
                               displayName={s.name}


### PR DESCRIPTION
### Features and Changes

This PR picks up the work left off here (https://github.com/growthbook/growthbook/pull/4374) and adds the `managedBy` field to Segments. Now, when self-hosted orgs create Segments via the `config.yml` file, the segment will have a `managedBy: "config"` property, which will surface the `OfficialBadge` in the UI.

As a fast-follow to this PR, I'll update the Segment REST API endpoints to support the `managedBy` field, so orgs can create/update segments and optionally pass in a `managedBy: "api"` property. If set, the Segment will then only be editable via the Rest API, and not the UI.

This matches the pattern of [Official Dimensions](https://github.com/growthbook/growthbook/pull/4374) and [Official Metrics](https://github.com/growthbook/growthbook/pull/2007). 

One noticable difference between this PR and the Official Dimension/Official Metrics pr is that we've now introduced a `readOnly` mode for the Segment Modals. Given that Segment's are sql or Fact table based resources and they don't have a dedicated /segment/id page, if we were to hide the `Edit` CTA like we do for Metrics/Dimensions, no user would be able to view the actual sql that powers the Segment.

So I've introduced a readOnly mode for the two Segment Modals that goes into effect IF the Segment is an Official Segment (ie. it was created via the config file or via the API). This allows users to view the actual definition of the Segment.

Likewise, this readOnly mode also impacts non-official Segments by taking into consideration the user's permissions. Even if the Segment isn't an official Segment, if the user doesn't have create/edit permissions, we're still allowing them to open the modal, but it'll open in readonly mode so they can't make changes, but they can view the details of the Segment.

### Dependencies

- None

### Testing

- [x] Ensure if a Segment is Official (e.g. managedBy equals "config" or "api") - the modal always opens in `readOnly` mode
- [x] Ensure if a Segment is Official (e.g. managedBy equals "config" or "api") - the Official Segment badge is rendered
- [x] Ensure if a Segment isn't an Official Segment, if the user has permission to create/update, readOnly mode is not set
- [x] Ensure if a Segment isn't an Official Segment, if the user doesn't have create/update permissions, readOnly mode is set
- [x] Ensure that the `GET` requests for Segments on `/segments` correctly returns both Config segments and mongo segments if `STORE_SEGMENTS_IN_MONGO` is true
- [x] Ensure that the `GET` requests for Segments on `/segments` correctly returns ONLY Config segments and no mongo segments if `STORE_SEGMENTS_IN_MONGO` is false
- [x] Ensure that the `GET` requests for Segments on `/segments` only returns Mongo segments if no config.yml is set

### Screenshots
<img width="1497" height="389" alt="Screenshot 2025-08-12 at 3 04 34 PM" src="https://github.com/user-attachments/assets/24b69d98-10cd-471c-b8e8-0f509aeffb2c" />

Read-Only mode for API managed Segment
<img width="822" height="810" alt="Screenshot 2025-08-12 at 3 04 45 PM" src="https://github.com/user-attachments/assets/24a14005-02c4-44f3-a450-5be52f90d183" />

