### PR TITLE
Implement new experiment results popover UI

### DIFF
--- a/packages/back-end/src/enterprise/validators/dashboard-block.ts
+++ b/packages/back-end/src/enterprise/validators/dashboard-block.ts
@@ -240,7 +240,7 @@ export const dashboardBlockPartial = z.discriminatedUnion("type", [
 
 export type DashboardBlockData<
   T extends DashboardBlockInterface
-> = DistributiveOmit<T, "uid" | "organization">;
+> = DistributiveOmit<T, "id" | "uid" | "organization">;
 
 export type DashboardBlockInterfaceOrData<T extends DashboardBlockInterface> =
   | T

--- a/packages/back-end/src/enterprise/validators/dashboard-block.ts
+++ b/packages/back-end/src/enterprise/validators/dashboard-block.ts
@@ -240,7 +240,7 @@ export const dashboardBlockPartial = z.discriminatedUnion("type", [
 
 export type DashboardBlockData<
   T extends DashboardBlockInterface
-> = DistributiveOmit<T, "id" | "uid" | "organization">;
+> = DistributiveOmit<T, "uid" | "organization">;
 
 export type DashboardBlockInterfaceOrData<T extends DashboardBlockInterface> =
   | T

--- a/packages/front-end/components/AnalysisResultPopover/AnalysisResultPopover.tsx
+++ b/packages/front-end/components/AnalysisResultPopover/AnalysisResultPopover.tsx
@@ -149,7 +149,7 @@ export default function AnalysisResultPopover({
         ) : priorUsed ? (
           <>Bayesian Priors affect results</>
         ) : (
-          <>CUPED affect results</>
+          <>CUPED affects results</>
         )}{" "}
         <Tooltip
           content={

--- a/packages/front-end/components/Experiment/BreakDownResults.tsx
+++ b/packages/front-end/components/Experiment/BreakDownResults.tsx
@@ -81,7 +81,7 @@ const BreakDownResults: FC<{
   secondaryMetrics: string[];
   guardrailMetrics: string[];
   metricOverrides: MetricOverride[];
-  id?: string;
+  idPrefix?: string;
   dimensionId: string;
   dimensionValuesFilter?: string[];
   isLatestPhase: boolean;
@@ -117,7 +117,7 @@ const BreakDownResults: FC<{
   goalMetrics,
   secondaryMetrics,
   metricOverrides,
-  id,
+  idPrefix,
   guardrailMetrics,
   isLatestPhase,
   phase,
@@ -387,7 +387,7 @@ const BreakDownResults: FC<{
               columnsFilter={columnsFilter}
               rows={table.rows}
               dimension={dimension}
-              id={(id ? `${id}_` : "") + table.metric.id}
+              id={(idPrefix ? `${idPrefix}_` : "") + table.metric.id}
               hasRisk={_hasRisk}
               tableRowAxis="dimension" // todo: dynamic grouping?
               labelHeader={

--- a/packages/front-end/components/Experiment/BreakDownResults.tsx
+++ b/packages/front-end/components/Experiment/BreakDownResults.tsx
@@ -81,6 +81,7 @@ const BreakDownResults: FC<{
   secondaryMetrics: string[];
   guardrailMetrics: string[];
   metricOverrides: MetricOverride[];
+  id?: string;
   dimensionId: string;
   dimensionValuesFilter?: string[];
   isLatestPhase: boolean;
@@ -116,6 +117,7 @@ const BreakDownResults: FC<{
   goalMetrics,
   secondaryMetrics,
   metricOverrides,
+  id,
   guardrailMetrics,
   isLatestPhase,
   phase,
@@ -385,7 +387,7 @@ const BreakDownResults: FC<{
               columnsFilter={columnsFilter}
               rows={table.rows}
               dimension={dimension}
-              id={table.metric.id}
+              id={(id ? `${id}_` : "") + table.metric.id}
               hasRisk={_hasRisk}
               tableRowAxis="dimension" // todo: dynamic grouping?
               labelHeader={

--- a/packages/front-end/components/Experiment/ExperimentDateGraph.tsx
+++ b/packages/front-end/components/Experiment/ExperimentDateGraph.tsx
@@ -199,7 +199,7 @@ const getTooltipData = (
 
   const d = datapoints[closestIndex];
   const x = xCoords[closestIndex];
-  const y = d.variations
+  const y = d?.variations
     ? d.variations.map(
         (variation) => yScale(getYVal(variation, yaxis) ?? 0) ?? 0
       )

--- a/packages/front-end/components/Experiment/MetricValueColumn.tsx
+++ b/packages/front-end/components/Experiment/MetricValueColumn.tsx
@@ -17,6 +17,7 @@ import {
   getExperimentMetricFormatter,
   getMetricFormatter,
 } from "@/services/metrics";
+import ConditionalWrapper from "@/components/ConditionalWrapper";
 
 const numberFormatter = Intl.NumberFormat("en-US", {
   notation: "compact",
@@ -39,6 +40,7 @@ interface Props
   displayCurrency: string;
   getExperimentMetricById: (id: string) => null | ExperimentMetricInterface;
   getFactTableById: (id: string) => null | FactTableInterface;
+  asTd?: boolean;
 }
 
 export default function MetricValueColumn({
@@ -53,6 +55,7 @@ export default function MetricValueColumn({
   displayCurrency,
   getExperimentMetricById,
   getFactTableById,
+  asTd = true,
   ...otherProps
 }: Props) {
   const formatterOptions = { currency: displayCurrency };
@@ -98,7 +101,17 @@ export default function MetricValueColumn({
   }
 
   return (
-    <td className={className} style={style} rowSpan={rowSpan} {...otherProps}>
+    <ConditionalWrapper
+      condition={asTd}
+      wrapper={
+        <td
+          className={className}
+          style={style}
+          rowSpan={rowSpan}
+          {...otherProps}
+        />
+      }
+    >
       {metric && stats.users ? (
         <>
           <div className="result-number">{overall}</div>
@@ -126,6 +139,6 @@ export default function MetricValueColumn({
       ) : (
         <em className="text-muted">{noDataMessage}</em>
       )}
-    </td>
+    </ConditionalWrapper>
   );
 }

--- a/packages/front-end/components/Experiment/ResultsTableTooltip/ResultsTableTooltip.tsx
+++ b/packages/front-end/components/Experiment/ResultsTableTooltip/ResultsTableTooltip.tsx
@@ -9,7 +9,7 @@ import {
   PValueCorrection,
   StatsEngine,
 } from "back-end/types/stats";
-import { BsXCircle, BsArrowReturnRight } from "react-icons/bs";
+import { BsX, BsArrowReturnRight } from "react-icons/bs";
 import clsx from "clsx";
 import { MdSwapCalls } from "react-icons/md";
 import {
@@ -243,7 +243,7 @@ export default function ResultsTableTooltip({
           className="position-absolute text-gray cursor-pointer"
           onClick={close}
         >
-          <BsXCircle size={16} />
+          <BsX size={16} />
         </a>
 
         {/*tooltip contents*/}
@@ -322,10 +322,7 @@ export default function ResultsTableTooltip({
             </Flex>
           </Flex>
 
-          <Box
-            mb="3"
-            className={clsx("results-overview", data.rowResults.resultsStatus)}
-          >
+          <Box mb="3">
             <FlagCard
               effectLabel={effectLabel}
               deltaFormatter={deltaFormatter}
@@ -406,7 +403,6 @@ export default function ResultsTableTooltip({
                               alignItems: "center",
                               justifyContent: "center",
                               flexShrink: 0,
-                              marginTop: 2,
                             }}
                           >
                             {rowNumber}
@@ -488,7 +484,7 @@ export default function ResultsTableTooltip({
 
           <Flex direction="column" gap="2">
             {addLiftWarning && data.rowResults.enoughData ? (
-              <Callout size="sm" status="info" mt="2" mb="1">
+              <Callout size="sm" status="info" icon={null} mt="2" mb="1">
                 {priorUsed && cupedUsed ? (
                   <>CUPED and Bayesian Priors affect results</>
                 ) : priorUsed ? (
@@ -524,20 +520,6 @@ export default function ResultsTableTooltip({
                       </div>
                     </>
                   }
-                >
-                  <span>
-                    <PiInfo size={16} />
-                  </span>
-                </Tooltip>
-              </Callout>
-            ) : null}
-
-            {data.rowResults.guardrailWarning ? (
-              <Callout size="sm" status="warning" mt="2" mb="1">
-                bad guardrail trend{" "}
-                <Tooltip
-                  className="cursor-pointer"
-                  body={data.rowResults.guardrailWarning}
                 >
                   <span>
                     <PiInfo size={16} />

--- a/packages/front-end/components/Experiment/ResultsTableTooltip/ResultsTableTooltip.tsx
+++ b/packages/front-end/components/Experiment/ResultsTableTooltip/ResultsTableTooltip.tsx
@@ -20,6 +20,7 @@ import {
 import { DEFAULT_PROPER_PRIOR_STDDEV } from "shared/constants";
 import { Box, Flex, Text } from "@radix-ui/themes";
 import { PiInfo } from "react-icons/pi";
+import { upperFirst } from "lodash";
 import { getEffectLabel, RowResults } from "@/services/experiments";
 import Tooltip from "@/components/Tooltip/Tooltip";
 import MetricValueColumn from "@/components/Experiment/MetricValueColumn";
@@ -267,13 +268,15 @@ export default function ResultsTableTooltip({
                 {data.metric.name}
               </Text>
               <PercentileLabel metric={data.metric} />
-              <span className="small text-muted ml-2">
+              <Text weight="regular" size="2" color="gray" ml="2">
                 (
-                {isFactMetric(data.metric)
-                  ? data.metric.metricType
-                  : data.metric.type}
+                {upperFirst(
+                  isFactMetric(data.metric)
+                    ? data.metric.metricType
+                    : data.metric.type
+                )}
                 )
-              </span>
+              </Text>
               {metricInverseIconDisplay}
             </Flex>
 

--- a/packages/front-end/components/Experiment/ResultsTableTooltip/ResultsTableTooltip.tsx
+++ b/packages/front-end/components/Experiment/ResultsTableTooltip/ResultsTableTooltip.tsx
@@ -332,70 +332,9 @@ export default function ResultsTableTooltip({
             />
           </Box>
 
-          <Flex direction="column" gap="2">
-            {addLiftWarning && data.rowResults.enoughData ? (
-              <Callout size="sm" status="info">
-                {priorUsed && cupedUsed ? (
-                  <>CUPED and Bayesian Priors affect results</>
-                ) : priorUsed ? (
-                  <>Bayesian Priors affect results</>
-                ) : (
-                  <>CUPED affects results</>
-                )}{" "}
-                <Tooltip
-                  className="cursor-pointer"
-                  body={
-                    <>
-                      {priorUsed ? (
-                        <div className="mb-1">
-                          {`This metric was analyzed with a prior that is normally distributed with mean ${
-                            data.metricSnapshotSettings?.properPriorMean ?? 0
-                          } and standard deviation ${
-                            data.metricSnapshotSettings?.properPriorStdDev ??
-                            DEFAULT_PROPER_PRIOR_STDDEV
-                          }.`}
-                        </div>
-                      ) : null}
-                      {cupedUsed ? (
-                        <div className="mb-1">
-                          {`This metric was analyzed with CUPED, which adjusts for covariates.`}
-                        </div>
-                      ) : null}
-                      <div>
-                        {`This affects metrics results (e.g., lift, ${
-                          data.statsEngine === "bayesian"
-                            ? "chance to win, credible intervals"
-                            : "p-values, confidence intervals"
-                        }), and estimated lift will often differ from the raw difference between variation and baseline.`}
-                      </div>
-                    </>
-                  }
-                >
-                  <span>
-                    <PiInfo size={16} />
-                  </span>
-                </Tooltip>
-              </Callout>
-            ) : null}
-
-            {data.rowResults.guardrailWarning ? (
-              <Callout size="sm" status="warning">
-                bad guardrail trend{" "}
-                <Tooltip
-                  className="cursor-pointer"
-                  body={data.rowResults.guardrailWarning}
-                >
-                  <span>
-                    <PiInfo size={16} />
-                  </span>
-                </Tooltip>
-              </Callout>
-            ) : null}
-          </Flex>
-
-          <Box mt="3" mb="2" className="results">
+          <Box className="results">
             <Table size="1">
-              <TableHeader>
+              <TableHeader style={{ fontSize: "12px" }}>
                 <TableRow style={{ color: "var(--color-text-mid)" }}>
                   <TableColumnHeader pl="0" style={{ width: 130 }}>
                     Variation
@@ -445,6 +384,7 @@ export default function ResultsTableTooltip({
                       style={{
                         color: "var(--color-text-high)",
                         fontWeight: 500,
+                        fontSize: "12px",
                       }}
                     >
                       <TableCell pl="0">
@@ -542,6 +482,67 @@ export default function ResultsTableTooltip({
               </TableBody>
             </Table>
           </Box>
+
+          <Flex direction="column" gap="2">
+            {addLiftWarning && data.rowResults.enoughData ? (
+              <Callout size="sm" status="info" mt="2" mb="1">
+                {priorUsed && cupedUsed ? (
+                  <>CUPED and Bayesian Priors affect results</>
+                ) : priorUsed ? (
+                  <>Bayesian Priors affect results</>
+                ) : (
+                  <>CUPED affects results</>
+                )}{" "}
+                <Tooltip
+                  className="cursor-pointer"
+                  body={
+                    <>
+                      {priorUsed ? (
+                        <div className="mb-1">
+                          {`This metric was analyzed with a prior that is normally distributed with mean ${
+                            data.metricSnapshotSettings?.properPriorMean ?? 0
+                          } and standard deviation ${
+                            data.metricSnapshotSettings?.properPriorStdDev ??
+                            DEFAULT_PROPER_PRIOR_STDDEV
+                          }.`}
+                        </div>
+                      ) : null}
+                      {cupedUsed ? (
+                        <div className="mb-1">
+                          {`This metric was analyzed with CUPED, which adjusts for covariates.`}
+                        </div>
+                      ) : null}
+                      <div>
+                        {`This affects metrics results (e.g., lift, ${
+                          data.statsEngine === "bayesian"
+                            ? "chance to win, credible intervals"
+                            : "p-values, confidence intervals"
+                        }), and estimated lift will often differ from the raw difference between variation and baseline.`}
+                      </div>
+                    </>
+                  }
+                >
+                  <span>
+                    <PiInfo size={16} />
+                  </span>
+                </Tooltip>
+              </Callout>
+            ) : null}
+
+            {data.rowResults.guardrailWarning ? (
+              <Callout size="sm" status="warning" mt="2" mb="1">
+                bad guardrail trend{" "}
+                <Tooltip
+                  className="cursor-pointer"
+                  body={data.rowResults.guardrailWarning}
+                >
+                  <span>
+                    <PiInfo size={16} />
+                  </span>
+                </Tooltip>
+              </Callout>
+            ) : null}
+          </Flex>
         </Box>
       </div>
     </div>

--- a/packages/front-end/components/Experiment/ResultsTableTooltip/ResultsTableTooltip.tsx
+++ b/packages/front-end/components/Experiment/ResultsTableTooltip/ResultsTableTooltip.tsx
@@ -403,6 +403,7 @@ export default function ResultsTableTooltip({
                               alignItems: "center",
                               justifyContent: "center",
                               flexShrink: 0,
+                              marginTop: 1,
                             }}
                           >
                             {rowNumber}

--- a/packages/front-end/components/FlagCard/FlagCard.tsx
+++ b/packages/front-end/components/FlagCard/FlagCard.tsx
@@ -11,6 +11,7 @@ import {
 } from "back-end/types/report";
 import { pValueFormatter, RowResults } from "@/services/experiments";
 import styles from "./FlagCard.module.scss";
+import React from "react";
 
 const numberFormatter = Intl.NumberFormat(undefined, {
   notation: "compact",
@@ -214,6 +215,18 @@ export default function FlagCard({
                 {data.rowResults.riskMeta.riskFormatted ? (
                   <>, {data.rowResults.riskMeta.riskFormatted}</>
                 ) : null}
+              </span>
+            }
+          />
+        ) : null}
+
+        {!data?.isGuardrail && data.rowResults.suspiciousChange ? (
+          <CardItem
+            label="Suspicious"
+            tooltip={data.rowResults.suspiciousChangeReason}
+            value={
+              <span style={{ color: "var(--violet-a11)" }}>
+                suspicious
               </span>
             }
           />

--- a/packages/front-end/components/FlagCard/FlagCard.tsx
+++ b/packages/front-end/components/FlagCard/FlagCard.tsx
@@ -138,12 +138,9 @@ export default function FlagCard({
               gap="1"
               style={{
                 color:
-                  (data.rowResults.directionalStatus === "winning" &&
-                    !data.metric.inverse) ||
-                  (data.rowResults.directionalStatus === "losing" &&
-                    data.metric.inverse)
+                  data.rowResults.directionalStatus === "winning"
                     ? "var(--green-11)"
-                    : "var(--red-a11)",
+                    : "var(--red-a12)",
               }}
             >
               {deltaFormatter(data.stats.expected ?? 0, deltaFormatterOptions)}
@@ -205,9 +202,9 @@ export default function FlagCard({
                 style={{
                   color:
                     data.rowResults.riskMeta.riskStatus === "danger"
-                      ? "var(--red-a11)"
+                      ? "var(--red-a12)"
                       : data.rowResults.riskMeta.riskStatus === "warning"
-                      ? "var(--amber-a11)"
+                      ? "var(--amber-a12)"
                       : undefined,
                 }}
               >
@@ -224,8 +221,18 @@ export default function FlagCard({
           <CardItem
             label="Suspicious"
             tooltip={data.rowResults.suspiciousChangeReason}
+            value={<span style={{ color: "var(--pink-a11)" }}>suspicious</span>}
+          />
+        ) : null}
+
+        {data.rowResults.guardrailWarning ? (
+          <CardItem
+            label="Guardrail trend"
+            tooltip={data.rowResults.guardrailWarning}
             value={
-              <span style={{ color: "var(--violet-a11)" }}>suspicious</span>
+              <span style={{ color: "var(--red-a12)" }}>
+                Bad guardrail trend
+              </span>
             }
           />
         ) : null}

--- a/packages/front-end/components/FlagCard/FlagCard.tsx
+++ b/packages/front-end/components/FlagCard/FlagCard.tsx
@@ -9,9 +9,9 @@ import {
   MetricSnapshotSettings,
   ExperimentReportVariationWithIndex,
 } from "back-end/types/report";
+import React from "react";
 import { pValueFormatter, RowResults } from "@/services/experiments";
 import styles from "./FlagCard.module.scss";
-import React from "react";
 
 const numberFormatter = Intl.NumberFormat(undefined, {
   notation: "compact",
@@ -225,9 +225,7 @@ export default function FlagCard({
             label="Suspicious"
             tooltip={data.rowResults.suspiciousChangeReason}
             value={
-              <span style={{ color: "var(--violet-a11)" }}>
-                suspicious
-              </span>
+              <span style={{ color: "var(--violet-a11)" }}>suspicious</span>
             }
           />
         ) : null}

--- a/packages/front-end/components/FlagCard/FlagCard.tsx
+++ b/packages/front-end/components/FlagCard/FlagCard.tsx
@@ -137,10 +137,11 @@ export default function FlagCard({
               align="center"
               gap="1"
               style={{
-                color:
-                  data.rowResults.directionalStatus === "winning"
-                    ? "var(--green-11)"
-                    : "var(--red-a12)",
+                color: !data.rowResults.significant
+                  ? undefined
+                  : data.rowResults.directionalStatus === "winning"
+                  ? "var(--green-11)"
+                  : "var(--red-a12)",
               }}
             >
               {deltaFormatter(data.stats.expected ?? 0, deltaFormatterOptions)}
@@ -202,9 +203,9 @@ export default function FlagCard({
                 style={{
                   color:
                     data.rowResults.riskMeta.riskStatus === "danger"
-                      ? "var(--red-a12)"
+                      ? "var(--red-a11)"
                       : data.rowResults.riskMeta.riskStatus === "warning"
-                      ? "var(--amber-a12)"
+                      ? "var(--amber-a11)"
                       : undefined,
                 }}
               >

--- a/packages/front-end/components/FlagCard/FlagCard.tsx
+++ b/packages/front-end/components/FlagCard/FlagCard.tsx
@@ -222,7 +222,12 @@ export default function FlagCard({
           <CardItem
             label="Suspicious"
             tooltip={data.rowResults.suspiciousChangeReason}
-            value={<span style={{ color: "var(--pink-a11)" }}>suspicious</span>}
+            value={
+              <span style={{ color: "var(--pink-a11)" }}>
+                % change &gt;{" "}
+                {percentFormatter.format(data.rowResults.suspiciousThreshold)}
+              </span>
+            }
           />
         ) : null}
 

--- a/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardBlock/ExperimentDimensionBlock.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardBlock/ExperimentDimensionBlock.tsx
@@ -27,7 +27,7 @@ export default function ExperimentDimensionBlock({
   snapshot,
   analysis,
   ssrPolyfills,
-}: BlockProps<ExperimentDimensionBlockInterface>) {
+}: BlockProps<ExperimentDimensionBlockInterface> & { block: { id: string } }) {
   const { pValueCorrection: hookPValueCorrection } = useOrgSettings();
   const { metricGroups } = useDefinitions();
   const expandedMetricIds = expandMetricGroups(metricIds, metricGroups);
@@ -103,7 +103,7 @@ export default function ExperimentDimensionBlock({
 
   return (
     <BreakDownResults
-      id={id}
+      idPrefix={id}
       key={snapshot.dimension}
       results={analysis.results}
       queryStatusData={queryStatusData}

--- a/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardBlock/ExperimentDimensionBlock.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardBlock/ExperimentDimensionBlock.tsx
@@ -27,7 +27,10 @@ export default function ExperimentDimensionBlock({
   snapshot,
   analysis,
   ssrPolyfills,
-}: BlockProps<ExperimentDimensionBlockInterface> & { block: { id: string } }) {
+}: BlockProps<ExperimentDimensionBlockInterface> & { block: { id?: string } }) {
+  // todo?: assign stable temp ID when creating new block
+  id = id || Math.floor(Math.random() * 10000);
+
   const { pValueCorrection: hookPValueCorrection } = useOrgSettings();
   const { metricGroups } = useDefinitions();
   const expandedMetricIds = expandMetricGroups(metricIds, metricGroups);

--- a/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardBlock/ExperimentDimensionBlock.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardBlock/ExperimentDimensionBlock.tsx
@@ -14,6 +14,7 @@ import { BlockProps } from ".";
 
 export default function ExperimentDimensionBlock({
   block: {
+    id,
     metricIds,
     baselineRow,
     columnsFilter,
@@ -102,6 +103,7 @@ export default function ExperimentDimensionBlock({
 
   return (
     <BreakDownResults
+      id={id}
       key={snapshot.dimension}
       results={analysis.results}
       queryStatusData={queryStatusData}

--- a/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardBlock/ExperimentDimensionBlock.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardBlock/ExperimentDimensionBlock.tsx
@@ -29,7 +29,7 @@ export default function ExperimentDimensionBlock({
   ssrPolyfills,
 }: BlockProps<ExperimentDimensionBlockInterface> & { block: { id?: string } }) {
   // todo?: assign stable temp ID when creating new block
-  id = id || Math.floor(Math.random() * 10000);
+  id = id || "" + Math.floor(Math.random() * 10000);
 
   const { pValueCorrection: hookPValueCorrection } = useOrgSettings();
   const { metricGroups } = useDefinitions();

--- a/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardBlock/ExperimentMetricBlock.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardBlock/ExperimentMetricBlock.tsx
@@ -18,7 +18,10 @@ export default function ExperimentMetricBlock({
   analysis,
   ssrPolyfills,
   metrics,
-}: BlockProps<ExperimentMetricBlockInterface> & { block: { id: string } }) {
+}: BlockProps<ExperimentMetricBlockInterface> & { block: { id?: string } }) {
+  // todo?: assign stable temp ID when creating new block
+  id = id || Math.floor(Math.random() * 10000);
+
   const { pValueCorrection: hookPValueCorrection } = useOrgSettings();
   const { metricGroups } = useDefinitions();
   const goalMetrics = useMemo(

--- a/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardBlock/ExperimentMetricBlock.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardBlock/ExperimentMetricBlock.tsx
@@ -18,7 +18,7 @@ export default function ExperimentMetricBlock({
   analysis,
   ssrPolyfills,
   metrics,
-}: BlockProps<ExperimentMetricBlockInterface>) {
+}: BlockProps<ExperimentMetricBlockInterface> & { block: { id: string } }) {
   const { pValueCorrection: hookPValueCorrection } = useOrgSettings();
   const { metricGroups } = useDefinitions();
   const goalMetrics = useMemo(

--- a/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardBlock/ExperimentMetricBlock.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardBlock/ExperimentMetricBlock.tsx
@@ -20,7 +20,7 @@ export default function ExperimentMetricBlock({
   metrics,
 }: BlockProps<ExperimentMetricBlockInterface> & { block: { id?: string } }) {
   // todo?: assign stable temp ID when creating new block
-  id = id || Math.floor(Math.random() * 10000);
+  id = id || "" + Math.floor(Math.random() * 10000);
 
   const { pValueCorrection: hookPValueCorrection } = useOrgSettings();
   const { metricGroups } = useDefinitions();

--- a/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardBlock/ExperimentMetricBlock.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardBlock/ExperimentMetricBlock.tsx
@@ -13,16 +13,13 @@ import { getMetricResultGroup } from "@/components/Experiment/BreakDownResults";
 import { BlockProps } from ".";
 
 export default function ExperimentMetricBlock({
-  block: { baselineRow, columnsFilter, variationIds },
+  block: { id, baselineRow, columnsFilter, variationIds },
   experiment,
   analysis,
   ssrPolyfills,
   metrics,
 }: BlockProps<ExperimentMetricBlockInterface>) {
-  const {
-    pValueCorrection: hookPValueCorrection,
-    statsEngine: hookStatsEngine,
-  } = useOrgSettings();
+  const { pValueCorrection: hookPValueCorrection } = useOrgSettings();
   const { metricGroups } = useDefinitions();
   const goalMetrics = useMemo(
     () => expandMetricGroups(experiment.goalMetrics, metricGroups),
@@ -37,10 +34,7 @@ export default function ExperimentMetricBlock({
     [experiment, metricGroups]
   );
 
-  const statsEngine =
-    ssrPolyfills?.useOrgSettings()?.statsEngine ||
-    hookStatsEngine ||
-    "frequentist";
+  const statsEngine = analysis.settings.statsEngine;
 
   const pValueCorrection =
     ssrPolyfills?.useOrgSettings()?.pValueCorrection || hookPValueCorrection;
@@ -120,7 +114,7 @@ export default function ExperimentMetricBlock({
       {Object.entries(rowGroups).map(([resultGroup, rows]) => (
         <ResultsTable
           key={resultGroup}
-          id={experiment.id}
+          id={id}
           phase={experiment.phases.length - 1}
           variations={variations}
           variationFilter={variationFilter}

--- a/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardBlock/ExperimentTimeSeriesBlock.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardBlock/ExperimentTimeSeriesBlock.tsx
@@ -14,7 +14,7 @@ export default function ExperimentTimeSeriesBlock({
   ssrPolyfills,
   metric,
 }: BlockProps<ExperimentTimeSeriesBlockInterface>) {
-  const { pValueCorrection, statsEngine: hookStatsEngine } = useOrgSettings();
+  const { pValueCorrection } = useOrgSettings();
   const { metricGroups } = useDefinitions();
   const goalMetrics = expandMetricGroups(experiment.goalMetrics, metricGroups);
   const secondaryMetrics = expandMetricGroups(
@@ -22,10 +22,7 @@ export default function ExperimentTimeSeriesBlock({
     metricGroups
   );
 
-  const statsEngine =
-    ssrPolyfills?.useOrgSettings()?.statsEngine ||
-    hookStatsEngine ||
-    "frequentist";
+  const statsEngine = analysis.settings.statsEngine;
 
   const resultGroup = getMetricResultGroup(
     metric.id,

--- a/packages/front-end/services/experiments.ts
+++ b/packages/front-end/services/experiments.ts
@@ -455,6 +455,7 @@ export type RowResults = {
   significantUnadjusted: boolean;
   significantReason: string;
   suspiciousChange: boolean;
+  suspiciousThreshold: number;
   suspiciousChangeReason: string;
   belowMinChange: boolean;
   risk: number;
@@ -620,9 +621,11 @@ export function getRowResults({
     metricDefaults,
     differenceType
   );
+  const suspiciousThreshold =
+    metric.maxPercentChange ?? metricDefaults?.maxPercentageChange ?? 0;
   const suspiciousChangeReason = suspiciousChange
     ? `A suspicious result occurs when the percent change exceeds your maximum percent change (${percentFormatter.format(
-        metric.maxPercentChange ?? metricDefaults?.maxPercentageChange ?? 0
+        suspiciousThreshold
       )}).`
     : "";
 
@@ -754,6 +757,7 @@ export function getRowResults({
     significantUnadjusted,
     significantReason,
     suspiciousChange,
+    suspiciousThreshold,
     suspiciousChangeReason,
     belowMinChange,
     risk,


### PR DESCRIPTION
- Update results tooltip to new style guide
- Fix bugs with dashboard results tables (stats engine locked to org default, Bayesian violin plots broken)

<img width="527" height="386" alt="image" src="https://github.com/user-attachments/assets/470a748f-77bc-4cad-90c9-4e0b8602956e" />

<img width="472" height="364" alt="image" src="https://github.com/user-attachments/assets/95635726-320b-450a-b97b-ab8ffd329782" />

<img width="496" height="425" alt="image" src="https://github.com/user-attachments/assets/0ce3acf4-01bb-4e1c-88e2-45b0b746052a" />
