### PR TITLE
Add Minimum once an hour notice.

### DIFF
--- a/packages/front-end/components/GeneralSettings/ExperimentSettings/index.tsx
+++ b/packages/front-end/components/GeneralSettings/ExperimentSettings/index.tsx
@@ -271,7 +271,8 @@ export default function ExperimentSettings({
                       description: (
                         <>
                           <Text mb="2" as="p">
-                            Enter cron string to specify frequency
+                            Enter cron string to specify frequency. Minimum once
+                            an hour.
                           </Text>
                           <Field
                             disabled={


### PR DESCRIPTION
### Features and Changes

Adds a minor improvement in messaging.

Some people were trying to get their cron running once every 5 minutes.  However we have code in services/experiments.ts to make sure it is at least an hour apart.

We could theoretically try and get early validation there.  I don't mention that the maximum separation for the jobs is 7 days.  There are other nuances too, like that we kind of disregard the minutes or seconds in the cron definition, and schedule it to the closest hour from the time it gets scheduled.  Then, we only check every 10 minutes and if there are more than 100 that need to be scheduled it could get scheduled later. 


