### PR TITLE
chore(notify-on-failure): Use html_url instead of API url

### DIFF
--- a/.github/workflows/notify-on-failure.yml
+++ b/.github/workflows/notify-on-failure.yml
@@ -29,4 +29,4 @@ jobs:
           webhook-type: webhook-trigger
           payload: |
             workflow_name: "${{ github.event.workflow_run.name }}"
-            workflow_url: "${{ github.event.workflow_run.url }}"
+            workflow_url: "${{ github.event.workflow_run.html_url }}"


### PR DESCRIPTION
### Features and Changes

The Slack message that is sent at the moment contains the API URL which is a JSON which is not the goal.

So we are using html_url now so we can get to the proper page in a single click.