### PR TITLE
Improves SideNav upgrade button render logic

### DIFF
--- a/packages/front-end/components/Layout/Layout.tsx
+++ b/packages/front-end/components/Layout/Layout.tsx
@@ -18,6 +18,7 @@ import { inferDocUrl } from "@/components/DocLink";
 import UpgradeModal from "@/components/Settings/UpgradeModal";
 import { AppFeatures } from "@/types/app-features";
 import { WhiteButton } from "@/components/Radix/Button";
+import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 import ProjectSelector from "./ProjectSelector";
 import SidebarLink, { SidebarLinkProps } from "./SidebarLink";
 import TopNav from "./TopNav";
@@ -399,7 +400,8 @@ const backgroundShade = (color: string) => {
 const Layout = (): React.ReactElement => {
   const { open, setOpen } = useSidebarOpen();
   const settings = useOrgSettings();
-  const { accountPlan, license, subscription } = useUser();
+  const permissionsUtil = usePermissionsUtil();
+  const { organization, canSubscribe } = useUser();
   const growthbook = useGrowthBook<AppFeatures>();
 
   // holdout aa-test, dogfooding
@@ -409,10 +411,9 @@ const Layout = (): React.ReactElement => {
 
   const [upgradeModal, setUpgradeModal] = useState(false);
   const showUpgradeButton =
-    ["oss", "starter"].includes(accountPlan || "") ||
-    (license?.isTrial && !subscription?.hasPaymentMethod) ||
-    (["pro", "pro_sso"].includes(accountPlan || "") &&
-      subscription?.status === "canceled");
+    canSubscribe &&
+    permissionsUtil.canManageBilling() &&
+    !organization.isVercelIntegration;
 
   // hacky:
   const router = useRouter();

--- a/packages/front-end/components/Settings/UpgradeModal/index.tsx
+++ b/packages/front-end/components/Settings/UpgradeModal/index.tsx
@@ -131,15 +131,6 @@ export default function UpgradeModal({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  useEffect(() => {
-    if (
-      ["enterprise"].includes(effectiveAccountPlan || "") &&
-      !license?.isTrial
-    ) {
-      close();
-    }
-  }, [effectiveAccountPlan, license, close]);
-
   const startPro = async () => {
     setError("");
     setLoading(true);
@@ -684,6 +675,28 @@ export default function UpgradeModal({
         await startProTrial(name, email);
       }
     }
+  }
+
+  // Safety check in case an Enterprise org found themselves here
+  if (accountPlan === "enterprise") {
+    return (
+      <Modal
+        trackingEventModalType="upgrade-modal"
+        allowlistedTrackingEventProps={trackContext}
+        open={true}
+        includeCloseCta={true}
+        closeCta="Close"
+        close={close}
+        size="lg"
+        header={null}
+        showHeaderCloseButton={false}
+        ctaEnabled={permissionsUtil.canManageBilling()}
+      >
+        <Callout status="info" mr="5" mb="2">
+          Your organization is already on GrowthBook&apos;s highest plan.
+        </Callout>
+      </Modal>
+    );
   }
 
   return (


### PR DESCRIPTION
### Features and Changes

We came across an issue with the SideNav's `Upgrade` button logic. In this case, it was an Enterprise organization that was on a trial. The logic to determine whether to render the `Upgrade` button was outdated given our new trial policy.

Given this, the Enterprise trial organization was seeing the `Upgrade` button and was confused. Ultimately, the button was rendering because the org was in a trial and didn't have a card on file. Again, this is based on previous trial logic. 

Now, if an organization has a plan, we hide the CTA on the SideNav. This does mean that `Pro` orgs won't see the upgrade, so if they want to upgrade to Enterprise, the path to do so will be through an enterprise-only feature, which feels natural, IMO.

Additionally, this PR updates the `Upgrade Modal` logic. Previously, if the org was an enterprise org, we had a useEffect snippet that was automatically calling `close()`. I found this un-intuitive and felt like it behaved like a bug. As such, I've added an early return (well, as early as I can return it) that renders a callout letting the org know they're already in GrowthBook's highest plan. (Screenshot below).

While an org shouldn't get here, having this safety net is a good idea, IMO.

- Closes **(add link to issue here)**

### Dependencies

- None

### Testing

- [x] Ensure that paid plans (pro or enterprise) don't see the upgrade modal cta on the sidenav
- [ ] Ensure that if an enterprise plan DOES get to the Upgrade Modal, the callout renders
- [ ] Ensure that if a pro or free org clicks on a CTA for a premium feature, we show the Enterprise treatment
- [ ] Ensure that if a free org clicks the CTA for a non-enterprise feature, we show the Pro treatment

### Screenshots

<img width="821" height="192" alt="Screenshot 2025-08-14 at 12 17 07 PM" src="https://github.com/user-attachments/assets/73a4e8d3-4c81-404f-94f9-67db9e40872e" />


