### PR TITLE
Removes duplicate namespace sidenav link

### DIFF
--- a/packages/front-end/components/Layout/Layout.tsx
+++ b/packages/front-end/components/Layout/Layout.tsx
@@ -207,11 +207,6 @@ const navlinks: SidebarLinkProps[] = [
         path: /^attributes/,
       },
       {
-        name: "Namespaces",
-        href: "/namespaces",
-        path: /^namespaces/,
-      },
-      {
         name: "Environments",
         href: "/environments",
         path: /^environments/,


### PR DESCRIPTION
### Features and Changes

Removes duplicate sidenav link for `Namespaces`

### Dependencies

- none

### Testing

- [x] Ensure namespaces only renders under the `Experiments` section
