### PR TITLE
fix(experiment-header): Fixes wrapping of long experiment names

### DIFF
--- a/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
@@ -645,64 +645,72 @@ export default function ExperimentHeader({
         </Modal>
       )}
 
-      <div className="container-fluid pagecontents position-relative experiment-header px-3 pt-3">
-        <div className="d-flex align-items-center flex-wrap">
-          <Flex direction="row" align="center" wrap="wrap" overflow="auto">
-            <h1 className="mb-0">{experiment.name}</h1>
-            <Box ml="2">
+      <div className="container-fluid pagecontents position-relative px-3 pt-3">
+        <Flex direction="row" align="start" justify="between" gap="5">
+          <Box>
+            <h1
+              className="mb-0"
+              style={{ display: "inline", verticalAlign: "middle" }}
+            >
+              {experiment.name}
+            </h1>
+            <Box ml="2" mt="1" display="inline-block">
               <ExperimentStatusIndicator experimentData={experiment} />
             </Box>
-          </Flex>
-          <div className="ml-auto flex-1"></div>
-          {canRunExperiment ? (
-            <div className="ml-2 flex-shrink-0">
-              {experiment.status === "running" ? (
-                <ExperimentActionButtons
-                  editResult={editResult}
-                  editTargeting={editTargeting}
-                  isBandit={isBandit}
-                  runningExperimentStatus={runningExperimentStatus}
-                />
-              ) : experiment.status === "draft" ? (
-                <Tooltip
-                  shouldDisplay={
-                    isBandit &&
-                    !experimentHasLiveLinkedChanges(experiment, linkedFeatures)
-                  }
-                  body="Add at least one live Linked Feature, Visual Editor change, or URL Redirect before starting."
-                >
-                  <button
-                    className="btn btn-teal"
-                    onClick={(e) => {
-                      e.preventDefault();
-                      setShowStartExperiment(true);
-                    }}
-                    disabled={
+          </Box>
+
+          <Flex direction="row" align="center" gap="2" flexShrink="0">
+            {canRunExperiment ? (
+              <div>
+                {experiment.status === "running" ? (
+                  <ExperimentActionButtons
+                    editResult={editResult}
+                    editTargeting={editTargeting}
+                    isBandit={isBandit}
+                    runningExperimentStatus={runningExperimentStatus}
+                  />
+                ) : experiment.status === "draft" ? (
+                  <Tooltip
+                    shouldDisplay={
                       isBandit &&
                       !experimentHasLiveLinkedChanges(
                         experiment,
                         linkedFeatures
                       )
                     }
+                    body="Add at least one live Linked Feature, Visual Editor change, or URL Redirect before starting."
                   >
-                    Start Experiment <MdRocketLaunch />
-                  </button>
-                </Tooltip>
-              ) : null}
-              {experiment.status === "stopped" && experiment.results ? (
-                <>
-                  {canEditExperiment ? (
-                    <Button onClick={() => setShareModalOpen(true)}>
-                      Share...
-                    </Button>
-                  ) : shareLevel === "public" ? (
-                    shareLinkButton
-                  ) : null}
-                </>
-              ) : null}
-            </div>
-          ) : null}
-          <div className="ml-2">
+                    <button
+                      className="btn btn-teal"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        setShowStartExperiment(true);
+                      }}
+                      disabled={
+                        isBandit &&
+                        !experimentHasLiveLinkedChanges(
+                          experiment,
+                          linkedFeatures
+                        )
+                      }
+                    >
+                      Start Experiment <MdRocketLaunch />
+                    </button>
+                  </Tooltip>
+                ) : null}
+                {experiment.status === "stopped" && experiment.results ? (
+                  <>
+                    {canEditExperiment ? (
+                      <Button onClick={() => setShareModalOpen(true)}>
+                        Share...
+                      </Button>
+                    ) : shareLevel === "public" ? (
+                      shareLinkButton
+                    ) : null}
+                  </>
+                ) : null}
+              </div>
+            ) : null}
             <DropdownMenu
               trigger={
                 <IconButton
@@ -711,6 +719,7 @@ export default function ExperimentHeader({
                   radius="full"
                   size="3"
                   highContrast
+                  ml="2"
                 >
                   <BsThreeDotsVertical size={18} />
                 </IconButton>
@@ -927,8 +936,8 @@ export default function ExperimentHeader({
                 )}
               </DropdownMenuGroup>
             </DropdownMenu>
-          </div>
-        </div>
+          </Flex>
+        </Flex>
         <ProjectTagBar
           experiment={experiment}
           setShowEditInfoModal={setShowEditInfoModal}

--- a/packages/front-end/styles/global.scss
+++ b/packages/front-end/styles/global.scss
@@ -551,11 +551,6 @@ pre {
 .main.bandit,
 .public.experiment,
 .public.bandit {
-  .experiment-header {
-    .border {
-      border-bottom: 1px solid var(--border-color-200);
-    }
-  }
   .experiment-tabs {
     background-color: var(--color-background);
     // NB: Keep top property in sync with TABS_HEADER_HEIGHT_PX in ExperimentHeader.tsx


### PR DESCRIPTION
### Features and Changes

CSS updates to improve the handling of long experiment names.

| Before | After |
|--------|--------|
| <img width="1613" height="610" alt="Screenshot 2025-08-14 at 10 41 41 AM" src="https://github.com/user-attachments/assets/51f3c53f-2ea2-4980-9b1a-2f9397de7f47" /> | <img width="1613" height="580" alt="Screenshot 2025-08-14 at 10 42 33 AM" src="https://github.com/user-attachments/assets/04500bb8-8b0e-4cd2-ba7b-97af58bcb9f1" /> |
| <img width="1611" height="462" alt="Screenshot 2025-08-14 at 10 41 02 AM" src="https://github.com/user-attachments/assets/28e9a9d2-b0f9-4cbb-83b0-4a6a22414a0f" /> | <img width="1613" height="466" alt="Screenshot 2025-08-14 at 10 42 23 AM" src="https://github.com/user-attachments/assets/95db545e-0417-4965-b367-facc2f9cddc1" /> |
| <img width="1610" height="661" alt="Screenshot 2025-08-14 at 10 41 55 AM" src="https://github.com/user-attachments/assets/4ec4a4f4-8b5f-49ff-b596-b906dc327a02" /> | <img width="1614" height="662" alt="Screenshot 2025-08-14 at 10 42 45 AM" src="https://github.com/user-attachments/assets/54341882-a79f-4ff9-9f12-5a327440b07e" /> |