### PR TITLE
chore(docs): Update tsconfig exclude for docs

### DIFF
--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "baseUrl": "."
   },
-  "exclude": ["./scripts/*.ts"],
+  "exclude": ["./scripts/*.ts", "build", ".docusaurus"],
   "ts-node": {
     "compilerOptions": {
       "module": "commonjs"


### PR DESCRIPTION
### Features and Changes

I got a warning from VSCode that we were scanning too many files so I checked some tsconfigs and saw that for `docs` we were iterating over build files if they existed.

Updated config to ignore it.

Tested via `yarn tsc --showConfig`