### PR TITLE
Add info about ID tokens for MS Azure AD

### DIFF
--- a/docs/docs/sso.mdx
+++ b/docs/docs/sso.mdx
@@ -203,7 +203,7 @@ When setting up Auth0, please ensure that you've enabled offline access, and che
 
 :::note
 
-In Azure, register an Application, instead of Enterprise, as we use OpenID Connect, not SAML.
+In Azure, register an Application, instead of Enterprise, as we use OpenID Connect, not SAML. Ensure the Application has ID tokens enabled.
 
 :::
 
@@ -212,7 +212,7 @@ In Azure, register an Application, instead of Enterprise, as we use OpenID Conne
   <div>
     <ol>
       <li>
-        Register an Application (we use OpenID Connect, so choose regular app, not Enterprise)
+        Register an Application (we use OpenID Connect, so choose regular app, not Enterprise). Because GrowthBook uses OIDC, ensure ID tokens are enabled, as the Microsoft Graph permission `User.read` does not work with OIDC.
         <MaxWidthImage>![Register an Application](/images/guides/SSO-Azure-1.png)</MaxWidthImage>
       </li>
       <li>


### PR DESCRIPTION
An Enterprise customer reported that the `User.read` permission associated with MS Graph does not work, since GrowthBook uses OIDC which is not compatible with MS Graph. Thus, ID tokens need to be enabled.