### PR TITLE
Add Prettier upgrade to git blame ignore

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Ignore Prettier 2 -> 3 upgrade
+4136239a48e7169832b22f93f0aae0bd7164a632


### PR DESCRIPTION
### Features and Changes

On #4418 we reformatted a lot of files because of the Prettier upgrade.

Now we are adding it to `.git-blame-ignore-revs` to make it be ignored by Git Blame as it is just formatting changes and not the commit we want to surface when trying to understand 'why is this line here?'