### PR TITLE
Add a db prefix for dev

### DIFF
--- a/packages/back-end/src/services/clickhouse.ts
+++ b/packages/back-end/src/services/clickhouse.ts
@@ -92,7 +92,7 @@ function ensureClickhouseEnvVars() {
     !CLICKHOUSE_MAIN_TABLE
   ) {
     throw new Error(
-      "Must specify necessary environment variables to interact with clickhouse."
+      "Must specify necessary environment variables to interact with clickhouse.",
     );
   }
 }
@@ -113,7 +113,7 @@ function createAdminClickhouseClient() {
 }
 
 function getClickhouseDatatype(
-  columnType: FactTableColumnType
+  columnType: FactTableColumnType,
 ): ClickHouseDataType {
   switch (columnType) {
     case "date":
@@ -129,7 +129,7 @@ function getClickhouseDatatype(
 
 function getClickhouseExtractClause(
   sourceField: string,
-  columnType: FactTableColumnType
+  columnType: FactTableColumnType,
 ) {
   // Some fields will eventually be inside attributes instead of top-level
   // This is a temp workaround until then
@@ -166,7 +166,7 @@ export function getReservedColumnNames(): Set<string> {
       "experiment_id",
       "variation_id",
       ...Object.keys(REMAINING_COLUMNS_SCHEMA),
-    ].map((col) => col.toLowerCase())
+    ].map((col) => col.toLowerCase()),
   );
 }
 
@@ -178,13 +178,13 @@ type ColumnDef = {
 
 function getCreateTableColumnList(columns: ColumnDef[]): string[] {
   return columns.map(
-    ({ source, alias, datatype }) => `${alias || source} ${datatype}`
+    ({ source, alias, datatype }) => `${alias || source} ${datatype}`,
   );
 }
 function getSelectColumnList(columns: ColumnDef[]): string[] {
   return columns.map(
     ({ source, alias }) =>
-      `${source}${alias && alias !== source ? ` as ${alias}` : ""}`
+      `${source}${alias && alias !== source ? ` as ${alias}` : ""}`,
   );
 }
 
@@ -196,7 +196,7 @@ function getRemainingColumnDefs(): ColumnDef[] {
 }
 
 function getMaterializedColumnDefs(
-  materializedColumns: MaterializedColumn[]
+  materializedColumns: MaterializedColumn[],
 ): ColumnDef[] {
   return materializedColumns.map(({ columnName, datatype, sourceField }) => ({
     source: getClickhouseExtractClause(sourceField, datatype),
@@ -255,7 +255,7 @@ AS ${select}`;
 
 function getEventsSQL(
   orgId: string,
-  materializedColumns: MaterializedColumn[]
+  materializedColumns: MaterializedColumn[],
 ) {
   return getMaterializedViewSQL({
     orgId,
@@ -276,7 +276,7 @@ function getEventsSQL(
 
 function getExperimentViewSQL(
   orgId: string,
-  materializedColumns: MaterializedColumn[]
+  materializedColumns: MaterializedColumn[],
 ) {
   return getMaterializedViewSQL({
     orgId,
@@ -351,7 +351,7 @@ function getFeatureusageSQL(orgId: string) {
 
 async function runCommand(
   client: ReturnType<typeof createClickhouseClient>,
-  query: string
+  query: string,
 ): Promise<void> {
   await client.command({ query });
 }
@@ -364,7 +364,7 @@ function getTableName(orgId: string, name: string) {
 
 export async function createClickhouseUser(
   context: ReqContext,
-  materializedColumns: MaterializedColumn[] = []
+  materializedColumns: MaterializedColumn[] = [],
 ): Promise<DataSourceParams> {
   const client = createAdminClickhouseClient();
 
@@ -387,18 +387,18 @@ export async function createClickhouseUser(
   logger.info(`Creating Clickhouse user ${user}`);
   await runCommand(
     client,
-    `CREATE USER ${user} IDENTIFIED WITH sha256_hash BY '${hashedPassword}' DEFAULT DATABASE ${database}`
+    `CREATE USER ${user} IDENTIFIED WITH sha256_hash BY '${hashedPassword}' DEFAULT DATABASE ${database}`,
   );
 
   await createClickhouseTables(client, orgId, materializedColumns);
 
   logger.info(
-    `Granting select permissions on information_schema.columns to ${user}`
+    `Granting select permissions on information_schema.columns to ${user}`,
   );
   // For schema browser.  They can only see info on tables that they have select permissions on.
   await runCommand(
     client,
-    `GRANT SELECT(data_type, table_name, table_catalog, table_schema, column_name) ON information_schema.columns TO ${user}`
+    `GRANT SELECT(data_type, table_name, table_catalog, table_schema, column_name) ON information_schema.columns TO ${user}`,
   );
 
   const url = new URL(CLICKHOUSE_HOST);
@@ -417,7 +417,7 @@ export async function createClickhouseUser(
 export async function createClickhouseTables(
   client: ReturnType<typeof createAdminClickhouseClient>,
   orgId: string,
-  materializedColumns: MaterializedColumn[] = []
+  materializedColumns: MaterializedColumn[] = [],
 ): Promise<void> {
   const user = clickhouseUserId(orgId);
   const database = user;
@@ -455,7 +455,7 @@ export async function createClickhouseTables(
 
 export async function _dangerousRecreateClickhouseTables(
   context: ReqContext,
-  datasource: GrowthbookClickhouseDataSource
+  datasource: GrowthbookClickhouseDataSource,
 ): Promise<void> {
   const client = createAdminClickhouseClient();
 
@@ -477,7 +477,7 @@ export async function _dangerousRecreateClickhouseTables(
     await createClickhouseTables(
       client,
       orgId,
-      datasource.settings.materializedColumns || []
+      datasource.settings.materializedColumns || [],
     );
   } finally {
     await unlockDataSource(context, datasource);
@@ -510,7 +510,7 @@ export async function addCloudSDKMapping(connection: SDKConnectionInterface) {
   } catch (e) {
     logger.error(
       e,
-      `Error inserting sdk key mapping (${key} -> ${organization})`
+      `Error inserting sdk key mapping (${key} -> ${organization})`,
     );
   }
 }
@@ -567,7 +567,7 @@ export async function logCloudAIUsage({
 export async function getDailyCDNUsageForOrg(
   orgId: string,
   start: Date,
-  end: Date
+  end: Date,
 ): Promise<DailyUsage[]> {
   const client = createAdminClickhouseClient();
 
@@ -652,8 +652,8 @@ export async function updateMaterializedColumns({
       .map(
         ({ columnName, datatype }) =>
           `ADD COLUMN IF NOT EXISTS ${columnName} ${getClickhouseDatatype(
-            datatype
-          )}`
+            datatype,
+          )}`,
       )
       .join(", ");
     const dropClauses = columnsToDelete
@@ -675,12 +675,10 @@ export async function updateMaterializedColumns({
     let viewColumns = originalColumns;
 
     // First update the main events table
-    const {
-      tableName: eventsTableName,
-      viewName: eventsViewName,
-    } = getEventsSQL(orgId, []);
+    const { tableName: eventsTableName, viewName: eventsViewName } =
+      getEventsSQL(orgId, []);
     logger.info(
-      `Updating materialized columns; dropping view ${eventsViewName}`
+      `Updating materialized columns; dropping view ${eventsViewName}`,
     );
     await runCommand(client, `DROP VIEW IF EXISTS ${eventsViewName}`);
     let err = undefined;
@@ -701,12 +699,10 @@ export async function updateMaterializedColumns({
     }
 
     // Now update the experiment views table
-    const {
-      tableName: exposureTableName,
-      viewName: exposureViewName,
-    } = getExperimentViewSQL(orgId, []);
+    const { tableName: exposureTableName, viewName: exposureViewName } =
+      getExperimentViewSQL(orgId, []);
     logger.info(
-      `Updating materialized columns; dropping view ${exposureViewName}`
+      `Updating materialized columns; dropping view ${exposureViewName}`,
     );
     await runCommand(client, `DROP VIEW IF EXISTS ${exposureViewName}`);
     err = undefined;
@@ -776,7 +772,7 @@ export async function updateMaterializedColumns({
         { columns: newColumns },
         {
           bypassManagedByCheck: true,
-        }
+        },
       );
     }
   } finally {

--- a/packages/back-end/src/util/secrets.ts
+++ b/packages/back-end/src/util/secrets.ts
@@ -15,7 +15,7 @@ export const IS_MULTI_ORG = stringToBoolean(process.env.IS_MULTI_ORG);
 // Default to true
 export const ALLOW_SELF_ORG_CREATION = stringToBoolean(
   process.env.ALLOW_SELF_ORG_CREATION,
-  true,
+  true
 );
 
 export const UPLOAD_METHOD = (() => {
@@ -48,7 +48,7 @@ if (!MONGODB_URI) {
 if (!MONGODB_URI) {
   if (prod) {
     throw new Error(
-      "Missing MONGODB_URI or required alternate environment variables to generate it",
+      "Missing MONGODB_URI or required alternate environment variables to generate it"
     );
   }
   MONGODB_URI = "mongodb://root:password@localhost:27017/test?authSource=admin";
@@ -80,7 +80,7 @@ export const S3_DOMAIN =
 export const ENCRYPTION_KEY = process.env.ENCRYPTION_KEY || "dev";
 if (prod && ENCRYPTION_KEY === "dev") {
   throw new Error(
-    "Cannot use ENCRYPTION_KEY=dev in production. Please set to a long random string.",
+    "Cannot use ENCRYPTION_KEY=dev in production. Please set to a long random string."
   );
 }
 
@@ -92,7 +92,7 @@ export const GCS_DOMAIN =
 export const JWT_SECRET = process.env.JWT_SECRET || "dev";
 if ((prod || !isLocalhost) && !IS_CLOUD && JWT_SECRET === "dev") {
   throw new Error(
-    "Cannot use JWT_SECRET=dev in production. Please set to a long random string.",
+    "Cannot use JWT_SECRET=dev in production. Please set to a long random string."
   );
 }
 
@@ -154,17 +154,17 @@ export const CRON_ENABLED = !stringToBoolean(process.env.CRON_DISABLED);
 export const SENTRY_DSN = process.env.SENTRY_DSN || "";
 
 export const STORE_SEGMENTS_IN_MONGO = stringToBoolean(
-  process.env.STORE_SEGMENTS_IN_MONGO,
+  process.env.STORE_SEGMENTS_IN_MONGO
 );
 
 // If set to false AND using a config file, don't allow creating metric via the UI
 export const ALLOW_CREATE_METRICS = stringToBoolean(
-  process.env.ALLOW_CREATE_METRICS,
+  process.env.ALLOW_CREATE_METRICS
 );
 
 // If set to false AND using a config file, don't allow creating dimension via the UI
 export const ALLOW_CREATE_DIMENSIONS = stringToBoolean(
-  process.env.ALLOW_CREATE_DIMENSIONS,
+  process.env.ALLOW_CREATE_DIMENSIONS
 );
 
 // Defines the User-Agent header for all requests made by the API
@@ -180,7 +180,7 @@ if ((prod || !isLocalhost) && secretAPIKey === "dev") {
   secretAPIKey = "";
   // eslint-disable-next-line
   console.error(
-    "SECRET_API_KEY must be set to a secure value in production. Disabling access.",
+    "SECRET_API_KEY must be set to a secure value in production. Disabling access."
   );
 }
 export const SECRET_API_KEY = secretAPIKey;
@@ -215,7 +215,7 @@ const webhooksValidator = z.array(
         .optional(),
       payloadKey: z.string().optional(),
     })
-    .strict(),
+    .strict()
 );
 let webhooks: z.infer<typeof webhooksValidator> = [];
 try {
@@ -276,16 +276,18 @@ export const CLICKHOUSE_ADMIN_PASSWORD =
   process.env.CLICKHOUSE_ADMIN_PASSWORD || "";
 export const CLICKHOUSE_DATABASE = process.env.CLICKHOUSE_DATABASE || "";
 export const CLICKHOUSE_MAIN_TABLE = process.env.CLICKHOUSE_MAIN_TABLE || "";
+export const CLICKHOUSE_DEV_PREFIX =
+  process.env.CLICKHOUSE_DEV_PREFIX || "test_";
 
 export type SecretsReplacer = <T extends string | Record<string, string>>(
   s: T,
   options?: {
     encode?: (s: string) => string;
-  },
+  }
 ) => T;
 
 export const secretsReplacer = (
-  secrets: Record<string, string>,
+  secrets: Record<string, string>
 ): SecretsReplacer => {
   return ((s, options) => {
     const encode = options?.encode || ((s: string) => s);
@@ -295,7 +297,7 @@ export const secretsReplacer = (
         ...encoded,
         [key]: encode(secrets[key]),
       }),
-      {},
+      {}
     );
 
     const stringReplacer = (s: string) => {
@@ -313,7 +315,7 @@ export const secretsReplacer = (
         ...obj,
         [stringReplacer(key)]: stringReplacer(s[key]),
       }),
-      {},
+      {}
     );
   }) as SecretsReplacer;
 };

--- a/packages/back-end/src/util/secrets.ts
+++ b/packages/back-end/src/util/secrets.ts
@@ -15,7 +15,7 @@ export const IS_MULTI_ORG = stringToBoolean(process.env.IS_MULTI_ORG);
 // Default to true
 export const ALLOW_SELF_ORG_CREATION = stringToBoolean(
   process.env.ALLOW_SELF_ORG_CREATION,
-  true
+  true,
 );
 
 export const UPLOAD_METHOD = (() => {
@@ -48,7 +48,7 @@ if (!MONGODB_URI) {
 if (!MONGODB_URI) {
   if (prod) {
     throw new Error(
-      "Missing MONGODB_URI or required alternate environment variables to generate it"
+      "Missing MONGODB_URI or required alternate environment variables to generate it",
     );
   }
   MONGODB_URI = "mongodb://root:password@localhost:27017/test?authSource=admin";
@@ -80,7 +80,7 @@ export const S3_DOMAIN =
 export const ENCRYPTION_KEY = process.env.ENCRYPTION_KEY || "dev";
 if (prod && ENCRYPTION_KEY === "dev") {
   throw new Error(
-    "Cannot use ENCRYPTION_KEY=dev in production. Please set to a long random string."
+    "Cannot use ENCRYPTION_KEY=dev in production. Please set to a long random string.",
   );
 }
 
@@ -92,7 +92,7 @@ export const GCS_DOMAIN =
 export const JWT_SECRET = process.env.JWT_SECRET || "dev";
 if ((prod || !isLocalhost) && !IS_CLOUD && JWT_SECRET === "dev") {
   throw new Error(
-    "Cannot use JWT_SECRET=dev in production. Please set to a long random string."
+    "Cannot use JWT_SECRET=dev in production. Please set to a long random string.",
   );
 }
 
@@ -154,17 +154,17 @@ export const CRON_ENABLED = !stringToBoolean(process.env.CRON_DISABLED);
 export const SENTRY_DSN = process.env.SENTRY_DSN || "";
 
 export const STORE_SEGMENTS_IN_MONGO = stringToBoolean(
-  process.env.STORE_SEGMENTS_IN_MONGO
+  process.env.STORE_SEGMENTS_IN_MONGO,
 );
 
 // If set to false AND using a config file, don't allow creating metric via the UI
 export const ALLOW_CREATE_METRICS = stringToBoolean(
-  process.env.ALLOW_CREATE_METRICS
+  process.env.ALLOW_CREATE_METRICS,
 );
 
 // If set to false AND using a config file, don't allow creating dimension via the UI
 export const ALLOW_CREATE_DIMENSIONS = stringToBoolean(
-  process.env.ALLOW_CREATE_DIMENSIONS
+  process.env.ALLOW_CREATE_DIMENSIONS,
 );
 
 // Defines the User-Agent header for all requests made by the API
@@ -180,7 +180,7 @@ if ((prod || !isLocalhost) && secretAPIKey === "dev") {
   secretAPIKey = "";
   // eslint-disable-next-line
   console.error(
-    "SECRET_API_KEY must be set to a secure value in production. Disabling access."
+    "SECRET_API_KEY must be set to a secure value in production. Disabling access.",
   );
 }
 export const SECRET_API_KEY = secretAPIKey;
@@ -215,7 +215,7 @@ const webhooksValidator = z.array(
         .optional(),
       payloadKey: z.string().optional(),
     })
-    .strict()
+    .strict(),
 );
 let webhooks: z.infer<typeof webhooksValidator> = [];
 try {
@@ -283,11 +283,11 @@ export type SecretsReplacer = <T extends string | Record<string, string>>(
   s: T,
   options?: {
     encode?: (s: string) => string;
-  }
+  },
 ) => T;
 
 export const secretsReplacer = (
-  secrets: Record<string, string>
+  secrets: Record<string, string>,
 ): SecretsReplacer => {
   return ((s, options) => {
     const encode = options?.encode || ((s: string) => s);
@@ -297,7 +297,7 @@ export const secretsReplacer = (
         ...encoded,
         [key]: encode(secrets[key]),
       }),
-      {}
+      {},
     );
 
     const stringReplacer = (s: string) => {
@@ -315,7 +315,7 @@ export const secretsReplacer = (
         ...obj,
         [stringReplacer(key)]: stringReplacer(s[key]),
       }),
-      {}
+      {},
     );
   }) as SecretsReplacer;
 };


### PR DESCRIPTION
### Features and Changes

Adds an env var that gets used as a prefix instead of "test_".  The permissions for the dev admin role are the same as prod, which only give permission for dbs that start with "org_".  We could theoretically give more permissions but it is nice to keep them in sync.  The idea is that each dev can add a prefix with their name such as "org_james", and hence it is clearer whose db is whose when in Clickhouse console.  Since dev has it's own service, it is no longer import to prefix it with "test_" to separate it from prod dbs.

### Testing

Go to: localhost:3000/admin.  
Click on the down arrow by an org.
Click Create Database.
Click "Yes"
See it Created.
