### PR TITLE
fix(stats): Allow SRM to throw error even with 0 users

### DIFF
--- a/packages/back-end/src/services/stats.ts
+++ b/packages/back-end/src/services/stats.ts
@@ -773,6 +773,8 @@ export function analyzeExperimentTraffic({
       banditSrmSet = true;
     }
     const variationIndex = variationIdMap[r.variation];
+    // skip if variation is not found (this happens if variation is __multiple__)
+    if (variationIndex === undefined) return;
     const dimTraffic: Map<string, ExperimentSnapshotTrafficDimension> =
       dimTrafficResults.get(r.dimension_name) ?? new Map();
     const dimValueTraffic: ExperimentSnapshotTrafficDimension = dimTraffic.get(

--- a/packages/back-end/src/util/stats.ts
+++ b/packages/back-end/src/util/stats.ts
@@ -2,12 +2,12 @@ import chisquare from "@stdlib/stats/base/dists/chisquare";
 import { returnZeroIfNotFinite } from "shared/util";
 
 export function checkSrm(users: number[], weights: number[]) {
-  // Skip variations with weight=0 or users=0
+  // Skip variations with weight=0 or a missing user count
   const data: [number, number][] = [];
   let totalUsers = 0;
   let totalWeight = 0;
   for (let i = 0; i < weights.length; i++) {
-    if (!weights[i] || !users[i]) continue;
+    if (!weights[i] || users[i] === undefined) continue;
     data.push([users[i], weights[i]]);
     totalUsers += users[i];
     totalWeight += weights[i];
@@ -15,6 +15,11 @@ export function checkSrm(users: number[], weights: number[]) {
 
   // Skip SRM calculation if there aren't enough valid variations
   if (data.length < 2) {
+    return 1;
+  }
+
+  // if no data, no need to calculate SRM
+  if (totalUsers === 0) {
     return 1;
   }
 

--- a/packages/back-end/test/stats.test.ts
+++ b/packages/back-end/test/stats.test.ts
@@ -12,7 +12,7 @@ describe("backend", () => {
     expect(+checkSrm([310, 98], [0.75, 0.25]).toFixed(9)).toEqual(0.647434186);
 
     // Not enough valid variations
-    expect(+checkSrm([1000, 0], [0.5, 0.5])).toEqual(1);
+    expect(+checkSrm([1000], [0.5, 0.5])).toEqual(1);
 
     // Not enough valid weights
     expect(+checkSrm([1000, 900, 800], [1, 0, 0])).toEqual(1);
@@ -22,9 +22,12 @@ describe("backend", () => {
       0.000020079,
     );
 
-    // Skip empty users
-    expect(+checkSrm([0, 505, 500], [0.34, 0.33, 0.33]).toFixed(9)).toEqual(
-      0.874677381,
+    // Skip if all users are 0
+    expect(+checkSrm([0, 0, 0], [0.34, 0.33, 0.33])).toEqual(1);
+
+    // Use empty users in the test
+    expect(+checkSrm([0, 10, 10], [0.34, 0.33, 0.33]).toFixed(9)).toEqual(
+      0.005790624,
     );
 
     // More than 2 variations


### PR DESCRIPTION
### Features and Changes

Allows variations with no traffic to pass through to SRM test if they have some expected weight. 

While we could consider a special warning about "Missing data in one variation", in general the SRM warning with 0 units in one variation is correct and uses our existing warning infrastructure to raise that there is a problem. Then it is easy to see that one variation is missing all traffic from the health tab. We could consider additional diagnostics/explanations about what is going wrong to improve debugging.

Furthermore, this solution scales better with n variations than some arbitrary `n` threshold.

- Closes #4427

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

Fixed and added unit tests.

Tested in dev that 0 unit variations before could keep SRM from throwing, but now it throws as I would expect.

### Screenshots

**Before**, balance in variations 2 and 3 made it seem safe as we ignored variation 1, but even the table looks odd:
<img width="885" height="418" alt="Screenshot 2025-08-20 at 2 29 38 PM" src="https://github.com/user-attachments/assets/41d071ad-71fd-4a44-bf42-ec203faa7eb6" />


**After**, throwing SRM as expected:

<img width="910" height="455" alt="Screenshot 2025-08-20 at 2 28 40 PM" src="https://github.com/user-attachments/assets/9d47c488-2e80-4ce9-b945-120d219079f0" />

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
