### PR TITLE
Ji/free managed warehouse

### DIFF
--- a/packages/back-end/src/api/ingestion/ingestion.router.ts
+++ b/packages/back-end/src/api/ingestion/ingestion.router.ts
@@ -7,13 +7,18 @@ import {
 import { SDKConnectionInterface } from "back-end/types/sdk-connection";
 import { _dangerousGetSdkConnectionsAcrossMultipleOrgs } from "back-end/src/models/SdkConnectionModel";
 import { _dangerousGetAllGrowthbookClickhouseDataSources } from "back-end/src/models/DataSourceModel";
-import { getOrganizationIdsWithTrackingDisabled } from "back-end/src/models/OrganizationModel";
+import {
+  _dangerouslyFindAllOrganizationsByIds,
+  getOrganizationIdsWithTrackingDisabled,
+} from "back-end/src/models/OrganizationModel";
+import { getUsages } from "back-end/src/enterprise/billing";
 
 interface SdkInfo {
   organization: string;
   client_key: string;
   datasource: string;
   environment: string;
+  overLimit: boolean;
 }
 
 interface GetDataEnrichmentResponse {
@@ -22,12 +27,17 @@ interface GetDataEnrichmentResponse {
   };
 }
 
-function sdkInfo(conn: SDKConnectionInterface, datasource: string): SdkInfo {
+function sdkInfo(
+  conn: SDKConnectionInterface,
+  datasource: string,
+  overLimit: boolean,
+): SdkInfo {
   return {
     organization: conn.organization,
     client_key: conn.key,
     environment: conn.environment,
     datasource,
+    overLimit,
   };
 }
 
@@ -56,10 +66,23 @@ export const getDataEnrichment = createApiRequestHandler({
     orgIdsWithTrackingEnabled,
   );
 
+  // TODO: Organizations can be large.  We only really need the fields that are used to determine effectivePlan.
+  // If this endpoint becomes too slow or use too much memory we can project just those fields and the
+  // downstream types.  Alternatively we can batch.
+  const organizations = await _dangerouslyFindAllOrganizationsByIds(
+    orgIdsWithTrackingEnabled,
+  );
+
+  const usages = await getUsages(organizations);
+
   const sdkData = Object.fromEntries(
     sdkConnections.map((conn) => [
       conn.key,
-      sdkInfo(conn, dataSourcesByOrgId[conn.organization]),
+      sdkInfo(
+        conn,
+        dataSourcesByOrgId[conn.organization],
+        usages[conn.organization]?.managedClickhouse.status === "over" || false,
+      ),
     ]),
   );
 

--- a/packages/back-end/src/controllers/subscription.ts
+++ b/packages/back-end/src/controllers/subscription.ts
@@ -30,7 +30,10 @@ import {
   getLicenseMetaData,
   getUserCodesForOrg,
 } from "back-end/src/services/licenseData";
-import { getDailyCDNUsageForOrg } from "back-end/src/services/clickhouse";
+import {
+  getDailyUsageForOrg,
+  migrateOverageEventsForOrgId,
+} from "back-end/src/services/clickhouse";
 import {
   createSetupIntent,
   deletePaymentMethodById,
@@ -38,6 +41,7 @@ import {
   getPaymentMethodsByLicenseKey,
   getUsage as getOrgUsage,
 } from "back-end/src/enterprise/billing/index";
+import { getGrowthbookDatasource } from "back-end/src/models/DataSourceModel";
 
 function withLicenseServerErrorHandling<T>(
   fn: (req: AuthRequest<T>, res: Response) => Promise<void>,
@@ -185,6 +189,14 @@ export const postInlineProSubscription = withLicenseServerErrorHandling(
       req.body.address,
       req.body.taxConfig,
     );
+
+    const managedWarehouseDatasource = await getGrowthbookDatasource(context);
+    if (managedWarehouseDatasource) {
+      // new pro users might have events in the overage_events table if they had
+      // use more than 1M events.  This moves those events over to the main table,
+      // so that they can see them.
+      await migrateOverageEventsForOrgId(org.id);
+    }
 
     res.status(200).json(result);
   },
@@ -413,7 +425,11 @@ export async function deletePaymentMethod(
 
 export async function getUsage(
   req: AuthRequest<unknown, unknown, { monthsAgo?: number }>,
-  res: Response<{ status: 200; cdnUsage: DailyUsage[]; limits: UsageLimits }>,
+  res: Response<{
+    status: 200;
+    usage: DailyUsage[];
+    limits: UsageLimits;
+  }>,
 ) {
   const context = getContextFromReq(req);
 
@@ -440,13 +456,25 @@ export async function getUsage(
   end.setUTCDate(0);
   end.setUTCHours(23, 59, 59, 999);
 
-  const cdnUsage = await getDailyCDNUsageForOrg(org.id, start, end);
+  const usage = await getDailyUsageForOrg(org.id, start, end);
 
   const {
-    limits: { requests: cdnRequests, bandwidth: cdnBandwidth },
+    limits: {
+      requests: cdnRequests,
+      bandwidth: cdnBandwidth,
+      managedClickhouseEvents,
+    },
   } = await getOrgUsage(org);
 
-  res.json({ status: 200, cdnUsage, limits: { cdnRequests, cdnBandwidth } });
+  res.json({
+    status: 200,
+    usage,
+    limits: {
+      cdnRequests,
+      cdnBandwidth,
+      managedClickhouseEvents,
+    },
+  });
 }
 
 export async function getCustomerData(

--- a/packages/back-end/src/enterprise/billing/index.ts
+++ b/packages/back-end/src/enterprise/billing/index.ts
@@ -19,8 +19,16 @@ const PLANS_WITH_UNLIMITED_USAGE: AccountPlan[] = [
 ];
 
 export const UNLIMITED_USAGE: OrganizationUsage = {
-  limits: { requests: "unlimited", bandwidth: "unlimited" },
+  limits: {
+    requests: "unlimited",
+    bandwidth: "unlimited",
+    managedClickhouseEvents: "unlimited",
+  },
   cdn: {
+    lastUpdated: new Date(),
+    status: "under",
+  },
+  managedClickhouse: {
     lastUpdated: new Date(),
     status: "under",
   },
@@ -82,13 +90,20 @@ export async function deletePaymentMethodById(
   return res;
 }
 
-export async function updateUsageDataFromServer(orgId: string) {
+export async function updateUsagesFromServer(organizationIds: string[]) {
   try {
-    const url = `${LICENSE_SERVER_URL}cdn/${orgId}/usage`;
+    const url = `${LICENSE_SERVER_URL}subscription/usages`;
 
-    const usage = await callLicenseServer({ url, method: "GET" });
-
-    setUsageInCache(orgId, usage);
+    const usages = await callLicenseServer({
+      url,
+      body: JSON.stringify({
+        organizationIds: organizationIds,
+        cloudSecret: process.env.CLOUD_SECRET,
+      }),
+    });
+    organizationIds.forEach((orgId) => {
+      setUsageInCache(orgId, usages[orgId]);
+    });
   } catch (err) {
     Sentry.captureException(err);
   }
@@ -148,9 +163,9 @@ export function getUsageFromCache(organization: OrganizationInterface) {
   }
 
   // Don't await for the result, we will just keep showing out of date cached version or the fallback
-  backgroundUpdateUsageDataFromServerForTests = updateUsageDataFromServer(
+  backgroundUpdateUsageDataFromServerForTests = updateUsagesFromServer([
     organization.id,
-  ).catch((err) => {
+  ]).catch((err) => {
     logger.error(err, `Error getting usage data from server`);
   });
 
@@ -165,15 +180,38 @@ export async function getUsage(organization: OrganizationInterface) {
 
   if (keyToUsageData[organization.id]) {
     // If we have a cached version, but it's invalid, we will update it in the background
-    backgroundUpdateUsageDataFromServerForTests = updateUsageDataFromServer(
+    backgroundUpdateUsageDataFromServerForTests = updateUsagesFromServer([
       organization.id,
-    ).catch((err) => {
+    ]).catch((err) => {
       logger.error(err, `Error getting usage data from server`);
     });
   } else {
-    await updateUsageDataFromServer(organization.id);
+    await updateUsagesFromServer([organization.id]);
   }
 
   // If the updateUsageDataFromServer failed we fall back to unlimited usage
   return keyToUsageData[organization.id]?.usage || UNLIMITED_USAGE;
+}
+
+export async function getUsages(organizations: OrganizationInterface[]) {
+  const orgUsageMap: Record<string, OrganizationUsage> = {};
+
+  const orgsNotInCache: string[] = [];
+  organizations.forEach((org) => {
+    const cachedUsage = getCachedUsageIfValid(org);
+    if (cachedUsage) {
+      orgUsageMap[org.id] = cachedUsage;
+    } else {
+      orgsNotInCache.push(org.id);
+    }
+  });
+
+  if (orgsNotInCache.length > 0) {
+    await updateUsagesFromServer(orgsNotInCache);
+    orgsNotInCache.forEach((orgId) => {
+      orgUsageMap[orgId] = keyToUsageData[orgId]?.usage || UNLIMITED_USAGE;
+    });
+  }
+
+  return orgUsageMap;
 }

--- a/packages/back-end/src/models/OrganizationModel.ts
+++ b/packages/back-end/src/models/OrganizationModel.ts
@@ -280,6 +280,13 @@ export async function findAllOrganizations(
   return { organizations: docs.map(toInterface), total };
 }
 
+export async function _dangerouslyFindAllOrganizationsByIds(orgIds: string[]) {
+  const docs = await OrganizationModel.find({
+    id: { $in: orgIds },
+  });
+  return docs.map(toInterface);
+}
+
 export async function findOrganizationById(id: string) {
   const doc = await getCollection(COLLECTION).findOne({ id });
   return doc ? toInterface(doc) : null;

--- a/packages/back-end/src/services/clickhouse.ts
+++ b/packages/back-end/src/services/clickhouse.ts
@@ -11,6 +11,7 @@ import {
   ENVIRONMENT,
   IS_CLOUD,
   CLICKHOUSE_DEV_PREFIX,
+  CLICKHOUSE_OVERAGE_TABLE,
 } from "back-end/src/util/secrets";
 import {
   GrowthbookClickhouseDataSource,
@@ -515,6 +516,18 @@ export async function addCloudSDKMapping(connection: SDKConnectionInterface) {
   }
 }
 
+export async function migrateOverageEventsForOrgId(orgId: string) {
+  const client = createAdminClickhouseClient();
+  await runCommand(
+    client,
+    `INSERT INTO ${CLICKHOUSE_MAIN_TABLE} SELECT * FROM ${CLICKHOUSE_OVERAGE_TABLE} WHERE organization = '${orgId}'`,
+  );
+  await runCommand(
+    client,
+    `ALTER TABLE ${CLICKHOUSE_OVERAGE_TABLE} DELETE WHERE organization = '${orgId}'`,
+  );
+}
+
 // In order to monitor usage and quality of AI responses on cloud we log each request to AI agents
 export async function logCloudAIUsage({
   organization,
@@ -564,7 +577,7 @@ export async function logCloudAIUsage({
   }
 }
 
-export async function getDailyCDNUsageForOrg(
+export async function getDailyUsageForOrg(
   orgId: string,
   start: Date,
   end: Date,
@@ -586,13 +599,48 @@ export async function getDailyCDNUsageForOrg(
 
   const sql = `
 select
-  toStartOfDay(hour) as date,
+  date,
   sum(requests) as requests,
-  sum(bandwidth) as bandwidth
-from usage.cdn_hourly
-where
-  organization = '${sanitizedOrgId}'
-  AND date BETWEEN '${startString}' AND '${endString}'
+  sum(bandwidth) as bandwidth,
+  sum(managedClickhouseEvents) as managedClickhouseEvents
+from (
+  select
+    toStartOfDay(hour) as date,
+    sum(requests) as requests,
+    sum(bandwidth) as bandwidth,
+    0 as managedClickhouseEvents
+  from usage.cdn_hourly
+  where
+    organization = '${sanitizedOrgId}'
+    AND date BETWEEN '${startString}' AND '${endString}'
+  group by date
+  
+  union all
+  
+  select
+    toStartOfDay(received_at) as date,
+    0 as requests,
+    0 as bandwidth,
+    count(1) as managedClickhouseEvents
+  from ${CLICKHOUSE_MAIN_TABLE}
+  where
+    organization = '${sanitizedOrgId}'
+    AND received_at BETWEEN '${startString}' AND '${endString}'
+  group by date
+  
+  union all
+  
+  select
+    toStartOfDay(received_at) as date,
+    0 as requests,
+    0 as bandwidth,
+    count(1) as managedClickhouseEvents
+  from ${CLICKHOUSE_OVERAGE_TABLE}
+  where
+    organization = '${sanitizedOrgId}'
+    AND received_at BETWEEN '${startString}' AND '${endString}'
+  group by date
+)
 group by date
 order by date ASC
 WITH FILL
@@ -612,13 +660,15 @@ WITH FILL
     // That is very unlikely, and even if it happens it will still be approximately correct
     requests: string;
     bandwidth: string;
+    managedClickhouseEvents: string;
   }[] = await res.json();
 
-  // Convert strings to numbers for requests/bandwidth
+  // Convert strings to numbers for all metrics
   return data.map((d) => ({
     date: d.date,
     requests: parseInt(d.requests) || 0,
     bandwidth: parseInt(d.bandwidth) || 0,
+    managedClickhouseEvents: parseInt(d.managedClickhouseEvents) || 0,
   }));
 }
 

--- a/packages/back-end/src/util/secrets.ts
+++ b/packages/back-end/src/util/secrets.ts
@@ -276,6 +276,8 @@ export const CLICKHOUSE_ADMIN_PASSWORD =
   process.env.CLICKHOUSE_ADMIN_PASSWORD || "";
 export const CLICKHOUSE_DATABASE = process.env.CLICKHOUSE_DATABASE || "";
 export const CLICKHOUSE_MAIN_TABLE = process.env.CLICKHOUSE_MAIN_TABLE || "";
+export const CLICKHOUSE_OVERAGE_TABLE =
+  process.env.CLICKHOUSE_OVERAGE_TABLE || "overage_events";
 export const CLICKHOUSE_DEV_PREFIX =
   process.env.CLICKHOUSE_DEV_PREFIX || "test_";
 

--- a/packages/back-end/types/organization.d.ts
+++ b/packages/back-end/types/organization.d.ts
@@ -384,6 +384,7 @@ export type DailyUsage = {
   date: string;
   requests: number;
   bandwidth: number;
+  managedClickhouseEvents: number;
 };
 
 type UsageLimit = number | "unlimited";
@@ -391,14 +392,20 @@ type UsageLimit = number | "unlimited";
 export type UsageLimits = {
   cdnRequests: UsageLimit;
   cdnBandwidth: UsageLimit;
+  managedClickhouseEvents: UsageLimit;
 };
 
 export type OrganizationUsage = {
   limits: {
     requests: UsageLimit;
     bandwidth: UsageLimit;
+    managedClickhouseEvents: UsageLimit;
   };
   cdn: {
+    lastUpdated: Date;
+    status: "under" | "approaching" | "over";
+  };
+  managedClickhouse: {
     lastUpdated: Date;
     status: "under" | "approaching" | "over";
   };

--- a/packages/back-end/types/organization.d.ts
+++ b/packages/back-end/types/organization.d.ts
@@ -399,13 +399,13 @@ export type OrganizationUsage = {
   limits: {
     requests: UsageLimit;
     bandwidth: UsageLimit;
-    managedClickhouseEvents: UsageLimit;
+    managedClickhouseEvents?: UsageLimit;
   };
   cdn: {
     lastUpdated: Date;
     status: "under" | "approaching" | "over";
   };
-  managedClickhouse: {
+  managedClickhouse?: {
     lastUpdated: Date;
     status: "under" | "approaching" | "over";
   };

--- a/packages/front-end/components/InitialSetup/ManagedWarehouseModal.tsx
+++ b/packages/front-end/components/InitialSetup/ManagedWarehouseModal.tsx
@@ -17,7 +17,6 @@ import Modal from "@/components/Modal";
 import Badge from "@/components/Radix/Badge";
 import SelectField from "@/components/Forms/SelectField";
 import Checkbox from "@/components/Radix/Checkbox";
-import Button from "@/components/Radix/Button";
 
 export default function ManagedWarehouseModal({
   close,
@@ -28,8 +27,8 @@ export default function ManagedWarehouseModal({
   const { mutateDefinitions } = useDefinitions();
   const router = useRouter();
 
-  const { hasCommercialFeature } = useUser();
-  const hasAccess = hasCommercialFeature("managed-warehouse");
+  const { effectiveAccountPlan } = useUser();
+
   const [agree, setAgree] = useState(false);
   const [upgradeOpen, setUpgradeOpen] = useState(false);
 
@@ -44,7 +43,7 @@ export default function ManagedWarehouseModal({
     return (
       <UpgradeModal
         close={() => setUpgradeOpen(false)}
-        commercialFeature="managed-warehouse"
+        commercialFeature="unlimited-managed-warehouse-usage"
         source="datasource-list"
       />
     );
@@ -99,9 +98,6 @@ export default function ManagedWarehouseModal({
       trackingEventModalType="managed-warehouse"
       close={close}
       submit={async () => {
-        if (!hasAccess) {
-          throw new Error("You must upgrade to use this feature");
-        }
         if (!agree) {
           throw new Error("You must agree to the terms and conditions");
         }
@@ -122,7 +118,6 @@ export default function ManagedWarehouseModal({
         }
       }}
       cta="Create"
-      ctaEnabled={hasAccess}
     >
       <p>
         GrowthBook Cloud offers a fully-managed version of ClickHouse, an
@@ -158,50 +153,49 @@ export default function ManagedWarehouseModal({
         <div className="mb-1">
           <strong>Pricing</strong>
         </div>
-        <p>
-          2 million events included per month, then <strong>$0.03</strong> per
-          1K events
-        </p>
+        {effectiveAccountPlan === "starter" ? (
+          <p>
+            1 million events included per month. Afterwards you would need to
+            upgrade to Pro or Enterprise. The Pro plan has 2 million events
+            included free per month, then <strong>$0.03</strong> per 1K events
+          </p>
+        ) : (
+          <p>
+            2 million events included per month, then <strong>$0.03</strong> per
+            1K events
+          </p>
+        )}
       </div>
 
-      {hasAccess ? (
-        <>
-          <Separator size="4" my="4" />
-          <Box>
-            <Checkbox
-              value={agree}
-              setValue={setAgree}
-              label={
-                <>
-                  I agree to the{" "}
-                  <a
-                    href="https://www.growthbook.io/legal"
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    terms and conditions
-                  </a>
-                </>
-              }
-              required
-            />
-            <Box mt="2">
-              <Text size="1" mb="2">
-                Do not include any sensitive or regulated personal data in your
-                analytics events unless it is properly de-identified in
-                accordance with applicable legal standards.
-              </Text>
-            </Box>
+      <>
+        <Separator size="4" my="4" />
+        <Box>
+          <Checkbox
+            value={agree}
+            setValue={setAgree}
+            label={
+              <>
+                I agree to the{" "}
+                <a
+                  href="https://www.growthbook.io/legal"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  terms and conditions
+                </a>
+              </>
+            }
+            required
+          />
+          <Box mt="2">
+            <Text size="1" mb="2">
+              Do not include any sensitive or regulated personal data in your
+              analytics events unless it is properly de-identified in accordance
+              with applicable legal standards.
+            </Text>
           </Box>
-        </>
-      ) : (
-        <div className="appbox bg-light p-3 text-center">
-          <Text>You must upgrade to Pro to access this feature.</Text>
-          <Button variant="solid" mt="3" onClick={() => setUpgradeOpen(true)}>
-            Upgrade to Pro
-          </Button>
-        </div>
-      )}
+        </Box>
+      </>
       {creatingResources ? (
         <div className="mt-2">
           <p>Creating some metrics to get you started.</p>

--- a/packages/front-end/components/Layout/AccountPlanNotices.tsx
+++ b/packages/front-end/components/Layout/AccountPlanNotices.tsx
@@ -111,7 +111,7 @@ export default function AccountPlanNotices() {
   );
 
   let managedWarehouseUsageMessage: JSX.Element | null = null;
-  if (usage?.managedClickhouse.status === "approaching") {
+  if (usage?.managedClickhouse?.status === "approaching") {
     managedWarehouseUsageMessage = (
       <>
         {upgradeModal && (
@@ -133,7 +133,7 @@ export default function AccountPlanNotices() {
         </Tooltip>
       </>
     );
-  } else if (usage?.managedClickhouse.status === "over") {
+  } else if (usage?.managedClickhouse?.status === "over") {
     managedWarehouseUsageMessage = (
       <>
         {upgradeModal && (

--- a/packages/front-end/components/Layout/AccountPlanNotices.tsx
+++ b/packages/front-end/components/Layout/AccountPlanNotices.tsx
@@ -41,9 +41,9 @@ export default function AccountPlanNotices() {
     </Box>
   );
 
-  let usageMessage: JSX.Element | null = null;
+  let cdnUsageMessage: JSX.Element | null = null;
   if (usage?.cdn.status === "approaching") {
-    usageMessage = (
+    cdnUsageMessage = (
       <>
         {upgradeModal && (
           <div>
@@ -65,7 +65,7 @@ export default function AccountPlanNotices() {
       </>
     );
   } else if (usage?.cdn.status === "over") {
-    usageMessage = (
+    cdnUsageMessage = (
       <>
         {upgradeModal && (
           <div>
@@ -88,6 +88,76 @@ export default function AccountPlanNotices() {
     );
   }
 
+  const managedWarehouseUsageTooltipBody = permissionsUtil.canViewUsage() ? (
+    <Box className={styles["notice-tooltip"]}>
+      Click to upgrade, or go to{" "}
+      <Link href="/settings/usage">Settings &gt; Usage</Link> to learn more
+    </Box>
+  ) : (
+    <Box className={styles["notice-tooltip"]}>
+      Click to upgrade, or visit{" "}
+      <a
+        href="https://docs.growthbook.io/app/managed-warehouse#limits"
+        className="text-decoration-none"
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={() => {
+          track("Clicked Read About Managed Warehouse Limits Link in Tooltip");
+        }}
+      >
+        Growthbook Docs &gt; FAQ
+      </a>
+    </Box>
+  );
+
+  let managedWarehouseUsageMessage: JSX.Element | null = null;
+  if (usage?.managedClickhouse.status === "approaching") {
+    managedWarehouseUsageMessage = (
+      <>
+        {upgradeModal && (
+          <div>
+            <UpgradeModal
+              close={() => setUpgradeModal(false)}
+              source={"managed-warehouse-usage-approaching-topnav-notification"}
+              commercialFeature="unlimited-managed-warehouse-usage"
+            />
+          </div>
+        )}
+        <Tooltip body={managedWarehouseUsageTooltipBody}>
+          <Box className={styles["warning-notification"]}>
+            Approaching Managed Warehouse event limit.{" "}
+            <a href="#" onClick={() => setUpgradeModal(true)}>
+              Upgrade license.
+            </a>{" "}
+          </Box>
+        </Tooltip>
+      </>
+    );
+  } else if (usage?.managedClickhouse.status === "over") {
+    managedWarehouseUsageMessage = (
+      <>
+        {upgradeModal && (
+          <div>
+            <UpgradeModal
+              close={() => setUpgradeModal(false)}
+              source={"managed-warehouse-usage-exceeded-topnav-notification"}
+              commercialFeature="unlimited-managed-warehouse-usage"
+            />
+          </div>
+        )}
+        <Tooltip body={managedWarehouseUsageTooltipBody}>
+          <Box className={styles["error-notification"]}>
+            Managed Warehouse event limit exceeded.{" "}
+            <a href="#" onClick={() => setUpgradeModal(true)}>
+              Upgrade license.
+            </a>{" "}
+          </Box>
+        </Tooltip>
+      </>
+    );
+  }
+
+  const usageMessage = cdnUsageMessage || managedWarehouseUsageMessage;
   if (license?.message && (license.message.showAllUsers || canManageBilling)) {
     return (
       <>

--- a/packages/front-end/components/Settings/UpgradeModal/index.tsx
+++ b/packages/front-end/components/Settings/UpgradeModal/index.tsx
@@ -326,8 +326,8 @@ export default function UpgradeModal({
     "require-approvals":
       "Reduce errors by requiring approval flows when changing feature flag values",
     "audit-logging": "Easily export historical audit logs",
-    "managed-warehouse":
-      "Fully managed data warehouse and event tracking pipeline in GrowthBook Cloud",
+    "unlimited-managed-warehouse-usage":
+      "Access to all your tracked events in the Managed Warehouse",
     saveSqlExplorerQueries:
       "Save query results and visualizations from the SQL Explorer.",
   };
@@ -548,7 +548,8 @@ export default function UpgradeModal({
                   </tr>
                 </thead>
                 <tbody>
-                  {commercialFeature === "managed-warehouse" && (
+                  {commercialFeature ===
+                    "unlimited-managed-warehouse-usage" && (
                     <tr>
                       <td>
                         Managed Warehouse{" "}

--- a/packages/front-end/components/Settings/Usage/CloudUsage.tsx
+++ b/packages/front-end/components/Settings/Usage/CloudUsage.tsx
@@ -45,7 +45,7 @@ export default function CloudUsage() {
   const useDummyData = !isCloud() && !!router.query.dummy;
 
   const { data, error } = useApi<{
-    cdnUsage: DailyUsage[];
+    usage: DailyUsage[];
     limits: UsageLimits;
   }>(`/billing/usage?monthsAgo=${monthsAgo}`, {
     shouldRun: () => !useDummyData,
@@ -67,10 +67,11 @@ export default function CloudUsage() {
     );
   }
 
-  const usage = data?.cdnUsage || [];
+  const usage = data?.usage || [];
   const limits: UsageLimits = data?.limits || {
     cdnRequests: "unlimited",
     cdnBandwidth: "unlimited",
+    managedClickhouseEvents: "unlimited",
   };
 
   const startDate = new Date();
@@ -96,6 +97,7 @@ export default function CloudUsage() {
         date: new Date(current).toISOString(),
         requests: Math.floor(Math.random() * 1000000),
         bandwidth: Math.floor(Math.random() * 2000000000),
+        managedClickhouseEvents: Math.floor(Math.random() * 1000000),
       });
       current.setUTCDate(current.getUTCDate() + 1);
     }
@@ -106,6 +108,10 @@ export default function CloudUsage() {
 
   const totalRequests = usage.reduce((sum, u) => sum + u.requests, 0);
   const totalBandwidth = usage.reduce((sum, u) => sum + u.bandwidth, 0);
+  const totalManagedClickhouseEvents = usage.reduce(
+    (sum, u) => sum + u.managedClickhouseEvents,
+    0,
+  );
 
   const monthOptions: { value: string; label: string }[] = [];
   for (let i = 0; i < 12; i++) {
@@ -150,6 +156,10 @@ export default function CloudUsage() {
         <div>
           <strong>Total bandwidth: </strong>
           <span>{formatBytes(totalBandwidth)}</span>
+        </div>
+        <div>
+          <strong>Total managed Clickhouse events: </strong>
+          <span>{requestsFormatter.format(totalManagedClickhouseEvents)}</span>
         </div>
         {useDummyData && <Badge label="Dummy Data" color="amber" />}
         <Flex className="ml-auto" gap="2">
@@ -206,6 +216,25 @@ export default function CloudUsage() {
             end={endDate}
             limitLine={
               limits.cdnBandwidth === "unlimited" ? null : limits.cdnBandwidth
+            }
+          />
+        </Box>
+      )}
+      {totalManagedClickhouseEvents > 0 && (
+        <Box>
+          <h3>Managed Clickhouse Events</h3>
+          <DailyGraph
+            data={usage.map((u) => ({
+              ts: new Date(u.date),
+              v: u.managedClickhouseEvents,
+            }))}
+            formatValue={(v) => requestsFormatter.format(v)}
+            start={startDate}
+            end={endDate}
+            limitLine={
+              limits.managedClickhouseEvents === "unlimited"
+                ? null
+                : limits.managedClickhouseEvents
             }
           />
         </Box>

--- a/packages/front-end/pages/datasources/index.tsx
+++ b/packages/front-end/pages/datasources/index.tsx
@@ -23,13 +23,10 @@ import DataSourceDiagram from "@/components/InitialSetup/DataSourceDiagram";
 import DataSourceTypeSelector from "@/components/Settings/DataSourceTypeSelector";
 import Badge from "@/components/Radix/Badge";
 import { useUser } from "@/services/UserContext";
-import PaidFeatureBadge from "@/components/GetStarted/PaidFeatureBadge";
 import ManagedWarehouseModal from "@/components/InitialSetup/ManagedWarehouseModal";
 
 function ManagedWarehouseDriver() {
-  const { hasCommercialFeature } = useUser();
   const [open, setOpen] = useState(false);
-  const hasAccess = hasCommercialFeature("managed-warehouse");
 
   const cursors: {
     top: number;
@@ -104,11 +101,8 @@ function ManagedWarehouseDriver() {
           })}
         </div>
         <div className="text-center">
-          {hasAccess ? (
-            <Badge label="New!" color="violet" variant="soft" />
-          ) : (
-            <PaidFeatureBadge commercialFeature="managed-warehouse" />
-          )}
+          <Badge label="New!" color="violet" variant="soft" />
+
           <h3 className="mb-3 mt-2">
             Use GrowthBook Cloud&apos;s fully-managed warehouse to get started
             quickly
@@ -149,14 +143,14 @@ const DataSourcesPage: FC = () => {
     useState<null | Partial<DataSourceInterfaceWithParams>>(null);
 
   const permissionsUtil = usePermissionsUtil();
-  const { hasCommercialFeature, license } = useUser();
+  const { effectiveAccountPlan, license } = useUser();
 
   // Cloud, no data sources yet, has permissions, and is either free OR on a usage-based paid plan, or is on a trial
   const showManagedWarehouse =
     isCloud() &&
     filteredDatasources.length === 0 &&
     permissionsUtil.canViewCreateDataSourceModal(project) &&
-    (!hasCommercialFeature("managed-warehouse") ||
+    (effectiveAccountPlan === "starter" ||
       license?.isTrial ||
       !!license?.orbSubscription) &&
     gb.isOn("inbuilt-data-warehouse");

--- a/packages/shared/src/enterprise/license-consts.ts
+++ b/packages/shared/src/enterprise/license-consts.ts
@@ -57,7 +57,7 @@ export type CommercialFeature =
   | "historical-power"
   | "decision-framework"
   | "unlimited-cdn-usage"
-  | "managed-warehouse"
+  | "unlimited-managed-warehouse-usage"
   | "safe-rollout"
   | "require-project-for-features-setting"
   | "holdouts"
@@ -206,7 +206,7 @@ export const accountFeatures: CommercialFeaturesMap = {
     "historical-power",
     "decision-framework",
     "safe-rollout",
-    "managed-warehouse",
+    "unlimited-managed-warehouse-usage",
     "saveSqlExplorerQueries",
     "precomputed-dimensions",
   ]),
@@ -237,7 +237,7 @@ export const accountFeatures: CommercialFeaturesMap = {
     "historical-power",
     "decision-framework",
     "safe-rollout",
-    "managed-warehouse",
+    "unlimited-managed-warehouse-usage",
     "saveSqlExplorerQueries",
     "precomputed-dimensions",
   ]),
@@ -288,7 +288,7 @@ export const accountFeatures: CommercialFeaturesMap = {
     "historical-power",
     "decision-framework",
     "safe-rollout",
-    "managed-warehouse",
+    "unlimited-managed-warehouse-usage",
     "require-project-for-features-setting",
     "holdouts",
     "saveSqlExplorerQueries",


### PR DESCRIPTION
### Features and Changes

This is part of a 3 PR set, with a change in the [license server](https://github.com/growthbook/central-license-server/pull/80) and in the [ingestor](https://github.com/growthbook/growthbook-ingestor/pull/47).  The overall goal is to allow free orgs to also use the managed warehouse.  If they use more than 1M events per month those events will now go into a `overage_events` table instead of the main `enriched_events` table.  We show them a warning that they are over and prompt them to upgrade to pro.  If they do we copy over the events from the `overage_events` table and put it into the `enriched_events` table which will then load it into their materialized views.  

1. Adds `managedClickhouseEvents` as an optional limit and usage in `OrganizationUsage` type.
2. Uses the new /subscription/usages endpoint instead of the cdn/:id/usages endpoint when calling the license server
3. Modifies the data-enrichment endpoint such that all free orgs who are over the usage limit will have an `overLimit:true` property added to their `SdkInfo`.
4. Adds an AccountPlanNotice to let them know about the managedWarehouse overages.
5. Displays a Managed Warehouse Events graph on the /settings/usage page that combines the events in the `enriched_events` table and the `overage_events` table.
6. Modifies the add Growthbook Managed Warehouse modal to allow free orgs to sign up.
7. Modifies the upgrade modal to show pricing info for the managed warehouse.

### Dependencies
Both of the following need to land first:
- [ ] https://github.com/growthbook/central-license-server/pull/80 ... to get the new /subscription/usages endpoint
- [ ] https://github.com/growthbook/growthbook-ingestor/pull/47 ... so the ingestor can handle the new property.
- [ ] The overage_events clickpipe on production needs to be set up.

### Testing

1. https://www.notion.so/growthbook/Dev-Managed-Data-Warehouse-251a857e74a080eda450d70045cb3770
2. Do Test plan from [the license server PR](https://github.com/growthbook/central-license-server/pull/80) 
3. Set IS_CLOUD=true locally with a valid SSO_CONFIG.
4. Remove the license_key from the organization in Mongo.
5. Delete the Managed Warehouse from the organization.
6. See the overage AcountPlanNotice.
7. See in Clickhouse new events going into the overage_events table
8. Go to the datasource page
9. Click to create the Growthbook Managed Warehouse
10. Click on the Upgrade button in the AccountPlanNotice.
11. See the note about being able to Access all your Managed Warehouse Events
12. Upgrade to Pro.
13. See the events removed from the overage_events table.
14. See the events that had been in the overage_events table now visible in the organization's db. 

### Screenshots

<img width="509" height="671" alt="Screenshot 2025-08-22 at 5 01 11 PM" src="https://github.com/user-attachments/assets/9ace8d84-2a04-4859-a6d2-6be69ec43f4e" />

<img width="943" height="646" alt="Screenshot 2025-08-22 at 4 31 44 PM" src="https://github.com/user-attachments/assets/a54008d0-37a7-4db9-9ce6-f5b2a9865c43" />
