### PR TITLE
fix(power): Use right date column computing units

### DIFF
--- a/packages/back-end/src/queryRunners/PopulationDataQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/PopulationDataQueryRunner.ts
@@ -238,9 +238,9 @@ function readMetricData({
   // count units to get max
   const histogram: { [week: string]: number } = {};
   rows.forEach((r) => {
-    if (r.dimension) {
+    if (r.dim_pre_date) {
       const users = (r.users as number) ?? 0;
-      const week = lastMondayString(r.dimension as string);
+      const week = lastMondayString(r.dim_pre_date as string);
       if (!histogram[week]) {
         histogram[week] = users;
       }


### PR DESCRIPTION
### Features and Changes

Bugfix. The auto-compute dimensions query broke the unit calculation in our power calculator when based on fact tables or segments as it changed the column name in the returned object. This fixes that.

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

https://www.loom.com/share/82bd946ae10a4a5db3b06d166b6214ea

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
