### PR TITLE
Renders org id on settings page for all orgs

### DIFF
--- a/packages/front-end/components/GeneralSettings/OrganizationAndLicenseSettings.tsx
+++ b/packages/front-end/components/GeneralSettings/OrganizationAndLicenseSettings.tsx
@@ -65,11 +65,9 @@ export default function OrganizationAndLicenseSettings({
                     </a>
                   )}
                 </Box>
-                {!isCloud() && !isMultiOrg() && (
-                  <Box>
-                    <Text weight="medium">Organization Id: </Text> {org.id}
-                  </Box>
-                )}
+                <Box>
+                  <Text weight="medium">Organization Id: </Text> {org.id}
+                </Box>
               </Flex>
               {canEdit && (
                 <Button


### PR DESCRIPTION
### Features and Changes

Previously, in the `General Settings` section of an org's `/settings` page, we were only rendering the organization's id for self hosted org's that didn't have multiple organizations.

This PR removes that logic so all orgs, regardless of if they're self-hosted or using our cloud platform, and regardless of how many orgs they have, will see their org id listed below the org owner's email. 

Unlike the organization name and email, this field is read-only.

I have a self-hosted instance with multiple orgs and I can confirm that switching between them does work correctly, where the org id is updating correctly.

- Closes **(https://github.com/growthbook/growthbook/issues/4318)**

### Dependencies

- None

### Testing

- [x] Ensure that the org id renders for cloud and self-hosted orgs
- [x] Ensure that if self-hosted and the user is a member of multiple organizations, switching between the orgs updates the UI correctly.

### Screenshots

Before:
<img width="581" height="299" alt="Screenshot 2025-08-25 at 2 34 23 PM" src="https://github.com/user-attachments/assets/1a0a3465-b38e-484f-80f8-3bfc730ae7da" />

After:
<img width="617" height="342" alt="Screenshot 2025-08-25 at 2 33 23 PM" src="https://github.com/user-attachments/assets/426efbd1-6400-403e-94b7-dcd8fbc43faa" />


