### PR TITLE
fix(sql): Fix proportion metrics from applying capping

### DIFF
--- a/packages/back-end/src/models/FactMetricModel.ts
+++ b/packages/back-end/src/models/FactMetricModel.ts
@@ -49,10 +49,14 @@ function validateUserFilter({
     );
   }
 
-  // error if metric type is not retention or proportion
-  if (metricType !== "retention" && metricType !== "proportion") {
+  // error if metric type is not retention, proportion, or ratio
+  if (
+    metricType !== "retention" &&
+    metricType !== "proportion" &&
+    metricType !== "ratio"
+  ) {
     throw new Error(
-      `Aggregate filter is only supported for retention and proportion metrics.`,
+      `Aggregate filter is only supported for retention, proportion, and ratio metrics.`,
     );
   }
 

--- a/packages/front-end/components/FactTables/FactMetricModal.tsx
+++ b/packages/front-end/components/FactTables/FactMetricModal.tsx
@@ -1663,7 +1663,8 @@ export default function FactMetricModal({
         // reset aggregate filter for certain metrics
         if (
           values.metricType !== "proportion" &&
-          values.metricType !== "retention"
+          values.metricType !== "retention" &&
+          values.metricType !== "ratio"
         ) {
           values.numerator.aggregateFilterColumn = undefined;
           values.numerator.aggregateFilter = undefined;
@@ -1677,6 +1678,18 @@ export default function FactMetricModal({
           if (!values.cappingSettings.value) {
             throw new Error("Capped Value cannot be 0");
           }
+        }
+
+        // reset capping that may be carried over to uncappable metrics
+        if (
+          values.metricType === "quantile" ||
+          values.metricType === "proportion" ||
+          values.metricType === "retention"
+        ) {
+          values.cappingSettings = {
+            type: "",
+            value: 0,
+          };
         }
 
         if (

--- a/packages/shared/src/experiments.ts
+++ b/packages/shared/src/experiments.ts
@@ -208,6 +208,10 @@ export function getMetricTemplateVariables(
   return m.templateVariables || {};
 }
 
+export function isCappableMetricType(m: ExperimentMetricInterface) {
+  return !quantileMetricType(m) && !isBinomialMetric(m);
+}
+
 export function isBinomialMetric(m: ExperimentMetricInterface) {
   if (isFactMetric(m))
     return ["proportion", "retention"].includes(m.metricType);


### PR DESCRIPTION
### Features and Changes

If a metric is not cappable (e.g. is retention, proportion, or quantile) we should not try to apply capping. We were before if there was `cappingSettings` attached to a metric because somehow the validation didn't occur to prevent capping from being saved. We now ignore those settings if the metric is one of the three types above, which also happens to be when aggregate filters are an option.

`capCoalesceValue` also only works for capping *or* aggregate filters, but not both, so this adds more validation to ensure that we are only doing one or the other, but we could probably do a better job validating the metric config before passing it to the query builder.

This PR also fixes some validation in the fact metric modal.

### Testing

See the loom below.

Also, was able to recreate the situation where a proportion metric with aggregate filter was not applying the aggregate filter because the erroneously saved capping was taking precedence. Now, that capping is being ignored so the aggregate filter is passing through.

Furthermore, new metrics are now stripping the capping when saved as a proportion metric, as shown in the loom below.

### Screenshots

https://www.loom.com/share/e46c662c98864ae199539a95277b4707