### PR TITLE
fix(sql): Improve handling of unit quantiles with ignore zero

### DIFF
--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -5162,7 +5162,7 @@ ${this.selectStarLimit("__topValues ORDER BY count DESC", limit)}
         endDate,
         overrideConversionWindows,
       )}
-        ${metricQuantileSettings?.ignoreZeros ? `AND ${col} != 0` : ""}
+        ${metricQuantileSettings?.ignoreZeros && metricQuantileSettings?.type === "event" ? `AND ${col} != 0` : ""}
       `,
       `${col}`,
       `NULL`,
@@ -5197,13 +5197,18 @@ ${this.selectStarLimit("__topValues ORDER BY count DESC", limit)}
         ? columnRef?.aggregateFilterColumn
         : columnRef?.column;
 
+      const nullIfZero =
+        metric.quantileSettings?.ignoreZeros &&
+        metric.quantileSettings?.type === "unit";
+
       if (
         !hasAggregateFilter &&
         (isBinomialMetric(metric) || column === "$$distinctUsers")
       ) {
         return `COALESCE(MAX(${valueColumn}), 0)`;
       } else if (column === "$$count") {
-        return `COUNT(${valueColumn})`;
+        const aggColumn = `COUNT(${valueColumn})`;
+        return nullIfZero ? `NULLIF(${aggColumn}, 0)` : aggColumn;
       } else if (
         metric.metricType === "quantile" &&
         metric.quantileSettings?.type === "event"
@@ -5214,26 +5219,23 @@ ${this.selectStarLimit("__topValues ORDER BY count DESC", limit)}
           "0",
         )})`;
       } else if (
-        metric.metricType === "quantile" &&
-        metric.quantileSettings?.type === "unit" &&
-        metric.quantileSettings?.ignoreZeros
-      ) {
-        return `SUM(${valueColumn})`;
-      } else if (
         !columnRef?.column.startsWith("$$") &&
         columnRef?.aggregation === "count distinct"
       ) {
         if (willReaggregate) {
           return this.hllAggregate(valueColumn);
         }
-        return this.hllCardinality(this.hllAggregate(valueColumn));
+        const aggColumn = this.hllCardinality(this.hllAggregate(valueColumn));
+        return nullIfZero ? `NULLIF(${aggColumn}, 0)` : aggColumn;
       } else if (
         !columnRef?.column.startsWith("$$") &&
         columnRef?.aggregation === "max"
       ) {
-        return `COALESCE(MAX(${valueColumn}), 0)`;
+        const aggColumn = `COALESCE(MAX(${valueColumn}), 0)`;
+        return nullIfZero ? `NULLIF(${aggColumn}, 0)` : aggColumn;
       } else {
-        return `SUM(COALESCE(${valueColumn}, 0))`;
+        const aggColumn = `SUM(COALESCE(${valueColumn}, 0))`;
+        return nullIfZero ? `NULLIF(${aggColumn}, 0)` : aggColumn;
       }
     }
 

--- a/packages/front-end/components/FactTables/FactMetricModal.tsx
+++ b/packages/front-end/components/FactTables/FactMetricModal.tsx
@@ -2101,7 +2101,9 @@ export default function FactMetricModal({
                       <>
                         {form
                           .watch("numerator")
-                          ?.column?.startsWith("$$") ? undefined : (
+                          ?.column?.startsWith(
+                            "$$distinctUsers",
+                          ) ? undefined : (
                           <div className="col-auto">
                             <div className="form-group">
                               <label htmlFor="quantileIgnoreZeros">


### PR DESCRIPTION
### Features and Changes

Ignore zeros for unit quantiles was not updated to work with COUNT DISTINCT aggregations (and was a bit unsafe in implementation before anyways).

This fixes that by relying on `NULLIF({unit_aggregation}, 0)` in the user aggregation step so that the percentile methods will ignore 0 aggregate values as they will be null.

- Closes #4477 

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

See Loom below.

### Screenshots

https://www.loom.com/share/2a25b676f8164f8e9b53f7ebea736b27