### PR TITLE
fix(phases-dates): Format phase start/end time in UTC

### DIFF
--- a/packages/front-end/components/DataViz/SqlExplorerDataVisualization.tsx
+++ b/packages/front-end/components/DataViz/SqlExplorerDataVisualization.tsx
@@ -464,12 +464,6 @@ export function DataVisualizationDisplay({
                 color: textColor,
               },
               top: "bottom",
-              formatter: (name: string) => {
-                return name.length > 20 ? name.substring(0, 18) + "..." : name;
-              },
-              tooltip: {
-                show: true,
-              },
             },
           }
         : null),

--- a/packages/front-end/components/DataViz/SqlExplorerDataVisualization.tsx
+++ b/packages/front-end/components/DataViz/SqlExplorerDataVisualization.tsx
@@ -464,6 +464,12 @@ export function DataVisualizationDisplay({
                 color: textColor,
               },
               top: "bottom",
+              formatter: (name: string) => {
+                return name.length > 20 ? name.substring(0, 18) + "..." : name;
+              },
+              tooltip: {
+                show: true,
+              },
             },
           }
         : null),

--- a/packages/front-end/components/Experiment/EditPhasesModal.tsx
+++ b/packages/front-end/components/Experiment/EditPhasesModal.tsx
@@ -101,12 +101,12 @@ export default function EditPhasesModal({
               <td>{i + 1}</td>
               <td>{phase.name}</td>
               <td>
-                <strong title={datetime(phase.dateStarted ?? "")}>
-                  {date(phase.dateStarted ?? "")}
+                <strong title={datetime(phase.dateStarted ?? "", "UTC")}>
+                  {date(phase.dateStarted ?? "", "UTC")}
                 </strong>{" "}
                 to{" "}
-                <strong title={datetime(phase.dateEnded ?? "")}>
-                  {phase.dateEnded ? date(phase.dateEnded) : "now"}
+                <strong title={datetime(phase.dateEnded ?? "", "UTC")}>
+                  {phase.dateEnded ? date(phase.dateEnded, "UTC") : "now"}
                 </strong>
               </td>
               {!isHoldout ? (

--- a/packages/front-end/components/Experiment/ExpandablePhaseSummary.tsx
+++ b/packages/front-end/components/Experiment/ExpandablePhaseSummary.tsx
@@ -39,8 +39,10 @@ export default function ExpandablePhaseSummary({ i, phase, editPhase }: Props) {
         <div className="small">
           <div style={{ fontSize: "1.2em" }}>{phase.name}</div>
           <div>
-            <strong>{date(phase.dateStarted ?? "")}</strong> to{" "}
-            <strong>{phase.dateEnded ? date(phase.dateEnded) : "now"}</strong>
+            <strong>{date(phase.dateStarted ?? "", "UTC")}</strong> to{" "}
+            <strong>
+              {phase.dateEnded ? date(phase.dateEnded, "UTC") : "now"}
+            </strong>
           </div>
         </div>
         <div className="ml-auto">

--- a/packages/front-end/components/Experiment/FilterSummary.tsx
+++ b/packages/front-end/components/Experiment/FilterSummary.tsx
@@ -81,10 +81,10 @@ const FilterSummary: FC<{
                 <strong className="text-gray">Date range:</strong>
               </div>
               <div className="col">
-                <strong>{datetime(phase.dateStarted ?? "")}</strong> to
+                <strong>{datetime(phase.dateStarted ?? "", "UTC")}</strong> to
                 <br />
                 <strong>
-                  {datetime(phase.dateEnded || snapshot.dateCreated)}
+                  {datetime(phase.dateEnded || snapshot.dateCreated, "UTC")}
                 </strong>
                 {!phase.dateEnded && " (last update)"}
               </div>

--- a/packages/front-end/components/Experiment/PhaseSelector.tsx
+++ b/packages/front-end/components/Experiment/PhaseSelector.tsx
@@ -69,8 +69,8 @@ export default function PhaseSelector({
               <span className="font-weight-bold">{phaseIndex + 1}: </span>
             )}
             <span className="date-label">
-              {date(phase.dateStarted ?? "")} —{" "}
-              {phase.dateEnded ? date(phase.dateEnded) : "now"}
+              {date(phase.dateStarted ?? "", "UTC")} —{" "}
+              {phase.dateEnded ? date(phase.dateEnded, "UTC") : "now"}
             </span>
           </>
         </Tooltip>
@@ -79,8 +79,8 @@ export default function PhaseSelector({
           <span className="phase-label font-weight-bold">{phase.name}</span>
           <div className="break mt-1" />
           <span className="date-label mt-1">
-            {date(phase.dateStarted ?? "")} —{" "}
-            {phase.dateEnded ? date(phase.dateEnded) : "now"}
+            {date(phase.dateStarted ?? "", "UTC")} —{" "}
+            {phase.dateEnded ? date(phase.dateEnded, "UTC") : "now"}
           </span>
           {!isHoldout && (
             <div className="phase-summary text-muted small">

--- a/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
@@ -212,12 +212,12 @@ export default function ExperimentHeader({
     | undefined
     | ExperimentPhaseStringDates;
   const startDate = phases?.[0]?.dateStarted
-    ? date(phases[0].dateStarted)
+    ? date(phases[0].dateStarted, "UTC")
     : null;
   const endDate =
     phases.length > 0
       ? lastPhase?.dateEnded
-        ? date(lastPhase.dateEnded ?? "")
+        ? date(lastPhase.dateEnded, "UTC")
         : "now"
       : date(new Date());
   const viewingOldPhase = phases.length > 0 && phase < phases.length - 1;

--- a/packages/front-end/components/Experiment/holdout/HoldoutTimeline.tsx
+++ b/packages/front-end/components/Experiment/holdout/HoldoutTimeline.tsx
@@ -454,7 +454,7 @@ const HoldoutTimeline: React.FC<{
                       </Text>
                       <Text size="2" ml="2">
                         {tooltipData.phase.dateStarted
-                          ? date(tooltipData.phase.dateStarted)
+                          ? date(tooltipData.phase.dateStarted, "UTC")
                           : "-"}
                       </Text>
                     </span>
@@ -465,7 +465,7 @@ const HoldoutTimeline: React.FC<{
                         </Text>
                         <Text size="2" ml="2">
                           {tooltipData.phase.dateEnded
-                            ? date(tooltipData.phase.dateEnded)
+                            ? date(tooltipData.phase.dateEnded, "UTC")
                             : "-"}
                         </Text>
                       </span>

--- a/packages/front-end/enterprise/components/Insights/ExperimentTimeline.tsx
+++ b/packages/front-end/enterprise/components/Insights/ExperimentTimeline.tsx
@@ -249,14 +249,14 @@ const ExperimentTimeline: React.FC<{
                 <Box>
                   <strong>Started:</strong>{" "}
                   {tooltipData.phase.dateStarted
-                    ? date(tooltipData.phase.dateStarted)
+                    ? date(tooltipData.phase.dateStarted, "UTC")
                     : "-"}
                 </Box>
                 {tooltipData.status === "stopped" && (
                   <Box>
                     <strong>Ended:</strong>{" "}
                     {tooltipData.phase.dateEnded
-                      ? date(tooltipData.phase.dateEnded)
+                      ? date(tooltipData.phase.dateEnded, "UTC")
                       : "-"}
                   </Box>
                 )}

--- a/packages/front-end/pages/public/e/[e].tsx
+++ b/packages/front-end/pages/public/e/[e].tsx
@@ -106,17 +106,17 @@ export default function PublicExperimentPage(props: PublicExperimentPageProps) {
     | undefined
     | ExperimentPhaseStringDates;
   const startDate = phases?.[0]?.dateStarted
-    ? date(phases[0].dateStarted)
+    ? date(phases[0].dateStarted, "UTC")
     : null;
   const endDate =
     phases.length > 0
       ? lastPhase?.dateEnded
-        ? date(lastPhase.dateEnded ?? "")
+        ? date(lastPhase.dateEnded, "UTC")
         : "now"
       : date(new Date());
   const dateRangeLabel = startDate
-    ? `${date(startDate)} — ${
-      endDate ? date(endDate) : "now"
+    ? `${startDate} — ${
+      endDate ? endDate : "now"
     }`
     : "";
 

--- a/packages/shared/src/dates.ts
+++ b/packages/shared/src/dates.ts
@@ -5,14 +5,23 @@ import differenceInHours from "date-fns/differenceInHours";
 import addMonths from "date-fns/addMonths";
 import formatRelative from "date-fns/formatRelative";
 import previousMonday from "date-fns/previousMonday";
+import { formatInTimeZone } from "date-fns-tz";
 
-export function date(date: string | Date): string {
+export function date(date: string | Date, inTimezone?: string): string {
   if (!date) return "";
-  return format(getValidDate(date), "PP");
+  const d = getValidDate(date);
+  const formatStr = "PP";
+  return inTimezone
+    ? formatInTimeZone(d, inTimezone, formatStr)
+    : format(d, formatStr);
 }
-export function datetime(date: string | Date): string {
+export function datetime(date: string | Date, inTimezone?: string): string {
   if (!date) return "";
-  return format(getValidDate(date), "PPp");
+  const d = getValidDate(date);
+  const formatStr = "PPp";
+  return inTimezone
+    ? formatInTimeZone(d, inTimezone, formatStr)
+    : format(d, formatStr);
 }
 export function relativeDate(date: string | Date): string {
   if (!date) return "";


### PR DESCRIPTION
### Features and Changes

Fixes #4478

When editing the phase, the datepicker correctly shows the time in UTC and it gets saved in Mongo also in UTC.
But when showing in the UI we are converting from UTC to the user's local time, leading to confusion.

So now we format the timestamp in the UTC timezone as well to ensure the values match.

https://www.loom.com/share/8e3b4dd171ad487eaf3b4e84a9e48879