### PR TITLE
fix(power): ensure threshold passes through to power calc

### DIFF
--- a/packages/front-end/components/PowerCalculation/PowerCalculationContent.tsx
+++ b/packages/front-end/components/PowerCalculation/PowerCalculationContent.tsx
@@ -106,9 +106,10 @@ const AnalysisSettings = ({
                 params.statsEngineSettings.sequentialTesting
                   ? "enabled"
                   : "disabled"
-              })
+              }; ${params.alpha} p-value threshold)
               `
-                : ""}{" "}
+                : ` (${100 * (1 - params.alpha)}% chance to win threshold)
+              `}{" "}
               ·{" "}
               <Link
                 href="#"

--- a/packages/front-end/components/PowerCalculation/PowerCalculationContent.tsx
+++ b/packages/front-end/components/PowerCalculation/PowerCalculationContent.tsx
@@ -27,7 +27,9 @@ import Callout from "@/components/Radix/Callout";
 import { ensureAndReturn } from "@/types/utils";
 import { GBHeadingArrowLeft } from "@/components/Icons";
 import Frame from "@/components/Radix/Frame";
-import PowerCalculationStatsEngineSettingsModal from "./PowerCalculationStatsEngineSettingsModal";
+import PowerCalculationStatsEngineSettingsModal, {
+  alphaToChanceToWin,
+} from "./PowerCalculationStatsEngineSettingsModal";
 
 const engineType = {
   frequentist: "Frequentist",
@@ -108,7 +110,7 @@ const AnalysisSettings = ({
                   : "disabled"
               }; ${params.alpha} p-value threshold)
               `
-                : ` (${100 * (1 - params.alpha)}% chance to win threshold)
+                : ` (${alphaToChanceToWin(params.alpha)}% chance to win threshold)
               `}{" "}
               ·{" "}
               <Link

--- a/packages/front-end/components/PowerCalculation/PowerCalculationContent.tsx
+++ b/packages/front-end/components/PowerCalculation/PowerCalculationContent.tsx
@@ -5,7 +5,6 @@ import {
   PowerCalculationParams,
   PowerCalculationResults,
   PowerCalculationSuccessResults,
-  StatsEngineSettings,
 } from "shared/power";
 import { Box } from "@radix-ui/themes";
 import { LinePath } from "@visx/shape";
@@ -29,6 +28,7 @@ import { GBHeadingArrowLeft } from "@/components/Icons";
 import Frame from "@/components/Radix/Frame";
 import PowerCalculationStatsEngineSettingsModal, {
   alphaToChanceToWin,
+  StatsEngineSettingsWithAlpha,
 } from "./PowerCalculationStatsEngineSettingsModal";
 
 const engineType = {
@@ -65,12 +65,12 @@ const AnalysisSettings = ({
   params,
   results,
   updateVariations,
-  updateStatsEngineSettings,
+  updateStatsEngineSettingsWithAlpha,
 }: {
   params: PowerCalculationParams;
   results: PowerCalculationResults;
   updateVariations: (_: number) => void;
-  updateStatsEngineSettings: (_: StatsEngineSettings) => void;
+  updateStatsEngineSettingsWithAlpha: (_: StatsEngineSettingsWithAlpha) => void;
 }) => {
   const [currentVariations, setCurrentVariations] = useState<
     number | undefined
@@ -89,9 +89,12 @@ const AnalysisSettings = ({
       {showStatsEngineSettingsModal && (
         <PowerCalculationStatsEngineSettingsModal
           close={() => setShowStatsEngineSettingsModal(false)}
-          params={params.statsEngineSettings}
+          params={{
+            ...params.statsEngineSettings,
+            alpha: params.alpha,
+          }}
           onSubmit={(v) => {
-            updateStatsEngineSettings(v);
+            updateStatsEngineSettingsWithAlpha(v);
             setShowStatsEngineSettingsModal(false);
           }}
         />
@@ -585,14 +588,14 @@ export default function PowerCalculationContent({
   results,
   params,
   updateVariations,
-  updateStatsEngineSettings,
+  updateStatsEngineSettingsWithAlpha,
   edit,
   newCalculation,
 }: {
   results: PowerCalculationResults;
   params: PowerCalculationParams;
   updateVariations: (_: number) => void;
-  updateStatsEngineSettings: (_: StatsEngineSettings) => void;
+  updateStatsEngineSettingsWithAlpha: (_: StatsEngineSettingsWithAlpha) => void;
   edit: () => void;
   newCalculation: () => void;
 }) {
@@ -629,7 +632,7 @@ export default function PowerCalculationContent({
         params={params}
         results={results}
         updateVariations={updateVariations}
-        updateStatsEngineSettings={updateStatsEngineSettings}
+        updateStatsEngineSettingsWithAlpha={updateStatsEngineSettingsWithAlpha}
       />
       {results.type !== "error" ? (
         <>

--- a/packages/front-end/components/PowerCalculation/PowerCalculationStatsEngineSettingsModal.tsx
+++ b/packages/front-end/components/PowerCalculation/PowerCalculationStatsEngineSettingsModal.tsx
@@ -1,11 +1,24 @@
 import { useState } from "react";
 import { DEFAULT_SEQUENTIAL_TESTING_TUNING_PARAMETER } from "shared/constants";
 import { StatsEngineSettings } from "shared/power";
+import Collapsible from "react-collapsible";
+import { PiCaretRightFill } from "react-icons/pi";
 import useOrgSettings from "@/hooks/useOrgSettings";
 import Modal from "@/components/Modal";
 import RadioGroup from "@/components/Radix/RadioGroup";
+import Field from "@/components/Forms/Field";
+import useConfidenceLevels from "@/hooks/useConfidenceLevels";
+import usePValueThreshold from "@/hooks/usePValueThreshold";
 
 type StatsEngineWithSequential = "bayesian" | "frequentist" | "sequential";
+
+export function alphaToChanceToWin(alpha: number): number {
+  return parseFloat((100 * (1 - alpha)).toFixed(6));
+}
+
+export function chanceToWinToAlpha(chanceToWin: number): number {
+  return parseFloat(((100 - chanceToWin) / 100).toFixed(6));
+}
 
 export type Props = {
   close: () => void;
@@ -19,10 +32,20 @@ export default function PowerCalculationStatsEngineSettingsModal({
   onSubmit,
 }: Props) {
   const orgSettings = useOrgSettings();
+  const pValueThresholdOrgDefault = usePValueThreshold();
+  const { ciUpper: ciUpperOrgDefault } = useConfidenceLevels();
+
   const sequentialTestingTuningParameter =
     orgSettings.sequentialTestingTuningParameter ||
     DEFAULT_SEQUENTIAL_TESTING_TUNING_PARAMETER;
   const [currentParams, setCurrentParams] = useState(params);
+  // separate state to deal with 100% formatting, only show if
+  // different from default
+  const [ciUpperPercent, setCiUpperPercent] = useState<number | undefined>(
+    params.customAlpha && params.customAlpha !== 1 - ciUpperOrgDefault
+      ? alphaToChanceToWin(params.customAlpha)
+      : undefined,
+  );
   const currentEngine =
     currentParams.type === "bayesian"
       ? "bayesian"
@@ -84,17 +107,101 @@ export default function PowerCalculationStatsEngineSettingsModal({
             },
           ]}
           setValue={(type: StatsEngineWithSequential) => {
+            const unsetThreshold =
+              (type === "bayesian" && currentParams.type === "frequentist") ||
+              (type !== "bayesian" && currentParams.type === "bayesian");
+            // reset threshold if changing engine
+            if (unsetThreshold) {
+              setCiUpperPercent(undefined);
+            }
             setCurrentParams({
               type: type === "sequential" ? "frequentist" : type,
               sequentialTesting:
                 type === "sequential"
                   ? sequentialTestingTuningParameter
                   : false,
+              customAlpha: unsetThreshold
+                ? undefined
+                : currentParams.customAlpha,
             });
           }}
           mt="3"
         />
       </div>
+      <Collapsible
+        trigger={
+          <div className="link-purple font-weight-bold mt-4 mb-2">
+            <PiCaretRightFill className="chevron mr-1" />
+            Advanced Settings
+          </div>
+        }
+        transitionTime={100}
+      >
+        <div className="rounded px-3 pt-3 pb-1 bg-highlight">
+          {currentParams.type === "frequentist" ? (
+            <Field
+              label="P-value threshold"
+              type="number"
+              step="0.001"
+              max="0.5"
+              min="0.001"
+              className="ml-2"
+              containerClassName="mb-3"
+              value={currentParams.customAlpha?.toString() || ""}
+              placeholder={pValueThresholdOrgDefault.toString()}
+              onChange={(e) => {
+                const value =
+                  e.target.value === ""
+                    ? undefined
+                    : parseFloat(e.target.value);
+                setCurrentParams({
+                  ...currentParams,
+                  customAlpha: value,
+                });
+              }}
+              helpText={
+                <span className="ml-2">
+                  ({pValueThresholdOrgDefault} is your organization default)
+                </span>
+              }
+            />
+          ) : null}
+          {currentParams.type === "bayesian" ? (
+            <Field
+              label="Chance to win threshold"
+              type="number"
+              step="any"
+              min="70"
+              max="99.999999"
+              className="ml-2"
+              containerClassName="mb-3"
+              append="%"
+              value={ciUpperPercent?.toString() || ""}
+              placeholder={(100 * ciUpperOrgDefault).toString()}
+              onChange={(e) => {
+                const value =
+                  e.target.value === ""
+                    ? undefined
+                    : parseFloat(e.target.value);
+                setCiUpperPercent(value);
+                // convert to alpha
+                const customAlpha = value
+                  ? chanceToWinToAlpha(value)
+                  : undefined;
+                setCurrentParams({
+                  ...currentParams,
+                  customAlpha: customAlpha,
+                });
+              }}
+              helpText={
+                <span className="ml-2">
+                  ({100 * ciUpperOrgDefault}% is your organization default)
+                </span>
+              }
+            />
+          ) : null}
+        </div>
+      </Collapsible>
     </Modal>
   );
 }

--- a/packages/front-end/components/PowerCalculation/PowerCalculationStatsEngineSettingsModal.tsx
+++ b/packages/front-end/components/PowerCalculation/PowerCalculationStatsEngineSettingsModal.tsx
@@ -37,17 +37,25 @@ export default function PowerCalculationStatsEngineSettingsModal({
 }: Props) {
   const orgSettings = useOrgSettings();
   const pValueThresholdOrgDefault = usePValueThreshold();
-  const { ciLower: ciLowerOrgDefault, ciUpper: ciUpperOrgDefault } = useConfidenceLevels();
+  const { ciLower: ciLowerOrgDefault, ciUpper: ciUpperOrgDefault } =
+    useConfidenceLevels();
 
   const sequentialTestingTuningParameter =
     orgSettings.sequentialTestingTuningParameter ||
     DEFAULT_SEQUENTIAL_TESTING_TUNING_PARAMETER;
   const [currentParams, setCurrentParams] = useState(params);
   // separate state to handle undefined value better and for formatting
-  const [pValueThreshold, setPValueThreshold] = useState<number | undefined>(params.alpha);
-  const [ciUpperPercent, setCiUpperPercent] = useState<number | undefined>(alphaToChanceToWin(params.alpha));
+  const [pValueThreshold, setPValueThreshold] = useState<number | undefined>(
+    params.alpha,
+  );
+  const [ciUpperPercent, setCiUpperPercent] = useState<number | undefined>(
+    alphaToChanceToWin(params.alpha),
+  );
 
-  const defaultAlpha = params.type === "frequentist" ? pValueThresholdOrgDefault : ciLowerOrgDefault;
+  const defaultAlpha =
+    params.type === "frequentist"
+      ? pValueThresholdOrgDefault
+      : ciLowerOrgDefault;
   const currentEngine =
     currentParams.type === "bayesian"
       ? "bayesian"

--- a/packages/front-end/pages/power-calculator/index.tsx
+++ b/packages/front-end/pages/power-calculator/index.tsx
@@ -111,13 +111,11 @@ const PowerCalculationPage = (): React.ReactElement => {
     pValueThreshold,
     ciLower,
   ]);
-  console.log(finalParams);
 
   const results: PowerCalculationResults | undefined = useMemo(() => {
     if (!finalParams) return;
     return powerMetricWeeks(finalParams);
   }, [finalParams]);
-  console.log(results);
   return (
     <div className="contents power-calculator container-fluid pagecontents">
       {showModal && (

--- a/packages/front-end/pages/power-calculator/index.tsx
+++ b/packages/front-end/pages/power-calculator/index.tsx
@@ -15,6 +15,8 @@ import EmptyPowerCalculation from "@/components/PowerCalculation/EmptyPowerCalcu
 import useOrgSettings from "@/hooks/useOrgSettings";
 import PowerCalculationContent from "@/components/PowerCalculation/PowerCalculationContent";
 import track from "@/services/track";
+import usePValueThreshold from "@/hooks/usePValueThreshold";
+import useConfidenceLevels from "@/hooks/useConfidenceLevels";
 
 const WEEKS = 9;
 const INITIAL_FORM_PARAMS = { metrics: {} } as const;
@@ -34,6 +36,9 @@ const INITIAL_PAGE_SETTINGS: PageSettings = {
 
 const PowerCalculationPage = (): React.ReactElement => {
   const orgSettings = useOrgSettings();
+
+  const pValueThreshold = usePValueThreshold();
+  const { ciLower } = useConfidenceLevels();
 
   const initialJSONParams = localStorage.getItem(LOCAL_STORAGE_KEY);
 
@@ -93,9 +98,16 @@ const PowerCalculationPage = (): React.ReactElement => {
       nVariations: variations,
       nWeeks: WEEKS,
       targetPower: 0.8,
-      alpha: 0.05,
+      alpha:
+        statsEngineSettings.type === "frequentist" ? pValueThreshold : ciLower,
     };
-  }, [powerCalculationParams, variations, statsEngineSettings]);
+  }, [
+    powerCalculationParams,
+    variations,
+    statsEngineSettings,
+    pValueThreshold,
+    ciLower,
+  ]);
 
   const results: PowerCalculationResults | undefined = useMemo(() => {
     if (!finalParams) return;

--- a/packages/front-end/pages/power-calculator/index.tsx
+++ b/packages/front-end/pages/power-calculator/index.tsx
@@ -98,8 +98,7 @@ const PowerCalculationPage = (): React.ReactElement => {
       nVariations: variations,
       nWeeks: WEEKS,
       targetPower: 0.8,
-      alpha:
-        statsEngineSettings.customAlpha ??
+      alpha: powerCalculationParams.alpha ||
         (statsEngineSettings.type === "frequentist"
           ? pValueThreshold
           : ciLower),
@@ -157,7 +156,15 @@ const PowerCalculationPage = (): React.ReactElement => {
             setShowModal("set-params");
           }}
           updateVariations={setVariations}
-          updateStatsEngineSettings={setStatsEngineSettings}
+          updateStatsEngineSettingsWithAlpha={(v) => {
+            setPowerCalculationParams(
+              {
+                ...powerCalculationParams,
+                alpha: v.alpha,
+              }
+            );
+            setStatsEngineSettings(v);
+          }}
           newCalculation={() => {
             setModalStatsEngineSettings(defaultStatsEngineSettings);
             setSettingsModalParams(INITIAL_FORM_PARAMS);

--- a/packages/front-end/pages/power-calculator/index.tsx
+++ b/packages/front-end/pages/power-calculator/index.tsx
@@ -98,7 +98,8 @@ const PowerCalculationPage = (): React.ReactElement => {
       nVariations: variations,
       nWeeks: WEEKS,
       targetPower: 0.8,
-      alpha: powerCalculationParams.alpha ||
+      alpha:
+        powerCalculationParams.alpha ||
         (statsEngineSettings.type === "frequentist"
           ? pValueThreshold
           : ciLower),
@@ -157,12 +158,10 @@ const PowerCalculationPage = (): React.ReactElement => {
           }}
           updateVariations={setVariations}
           updateStatsEngineSettingsWithAlpha={(v) => {
-            setPowerCalculationParams(
-              {
-                ...powerCalculationParams,
-                alpha: v.alpha,
-              }
-            );
+            setPowerCalculationParams({
+              ...powerCalculationParams,
+              alpha: v.alpha,
+            });
             setStatsEngineSettings(v);
           }}
           newCalculation={() => {

--- a/packages/front-end/pages/power-calculator/index.tsx
+++ b/packages/front-end/pages/power-calculator/index.tsx
@@ -99,7 +99,10 @@ const PowerCalculationPage = (): React.ReactElement => {
       nWeeks: WEEKS,
       targetPower: 0.8,
       alpha:
-        statsEngineSettings.type === "frequentist" ? pValueThreshold : ciLower,
+        statsEngineSettings.customAlpha ??
+        (statsEngineSettings.type === "frequentist"
+          ? pValueThreshold
+          : ciLower),
     };
   }, [
     powerCalculationParams,
@@ -108,11 +111,13 @@ const PowerCalculationPage = (): React.ReactElement => {
     pValueThreshold,
     ciLower,
   ]);
+  console.log(finalParams);
 
   const results: PowerCalculationResults | undefined = useMemo(() => {
     if (!finalParams) return;
     return powerMetricWeeks(finalParams);
   }, [finalParams]);
+  console.log(results);
   return (
     <div className="contents power-calculator container-fluid pagecontents">
       {showModal && (

--- a/packages/shared/src/power/power.ts
+++ b/packages/shared/src/power/power.ts
@@ -31,6 +31,7 @@ export type MetricParams = MetricParamsMean | MetricParamsBinomial;
 export interface StatsEngineSettings {
   type: "frequentist" | "bayesian";
   sequentialTesting: false | number;
+  customAlpha?: number;
 }
 
 export interface PowerCalculationParams {

--- a/packages/shared/src/power/power.ts
+++ b/packages/shared/src/power/power.ts
@@ -31,7 +31,6 @@ export type MetricParams = MetricParamsMean | MetricParamsBinomial;
 export interface StatsEngineSettings {
   type: "frequentist" | "bayesian";
   sequentialTesting: false | number;
-  customAlpha?: number;
 }
 
 export interface PowerCalculationParams {


### PR DESCRIPTION
### Features and Changes

We previously weren't properly passing through the bayesian and frequentist org threshold settings if they were different from the default.

Also added information to the stats engine settings section and provided you with a UI to override, thereby partly addressing #4505.

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

Changed organization thresholds and observed directionally correct updates to power calculation.

<img width="1337" height="806" alt="Screenshot 2025-09-02 at 10 54 20 AM" src="https://github.com/user-attachments/assets/7510b8f9-36f9-40fe-b426-0bd33a42b70e" />

<img width="1353" height="798" alt="Screenshot 2025-09-02 at 10 54 03 AM" src="https://github.com/user-attachments/assets/950847d1-ff58-4695-9b15-0cf2e2c67e50" />

Also seem loom for evidence the override is working: 
https://www.loom.com/share/d8963d9c18a54f26a166af3a90eb6031

Ignore how similar the %ages are to your threshold in that loom, this is correct with these thresholds and I tested it again with more reasonable data and all was well.

