### PR TITLE
chore(clickhouse): Update property that was deprecated

### DIFF
--- a/packages/back-end/src/integrations/ClickHouse.ts
+++ b/packages/back-end/src/integrations/ClickHouse.ts
@@ -33,7 +33,7 @@ export default class ClickHouse extends SqlIntegration {
 
   async runQuery(sql: string): Promise<QueryResponse> {
     const client = createClient({
-      host: getHost(this.params.url, this.params.port),
+      url: getHost(this.params.url, this.params.port),
       username: this.params.username,
       password: this.params.password,
       database: this.params.database,


### PR DESCRIPTION
### Features and Changes

While looking over some server logs I noticed the following line:

```
[2025-09-03T22:50:57.042Z][WARN][@clickhouse/client][Config] "host" is deprecated. Use "url" instead.
```

So I am doing that.