### PR TITLE
Add baseSetting fallback to metric value resolution

### DIFF
--- a/packages/shared/src/settings/resolvers/genMetricOverrideResolver.ts
+++ b/packages/shared/src/settings/resolvers/genMetricOverrideResolver.ts
@@ -13,6 +13,7 @@ export default function genMetricOverrideResolver(
   fieldName: keyof Omit<
     MetricOverride,
     | "id"
+    | "regressionAdjustmentOverride"
     | "regressionAdjustmentEnabled"
     | "regressionAdjustmentDays"
     | "properPriorOverride"
@@ -46,7 +47,7 @@ export default function genMetricOverrideResolver(
       metricValue = ctx.scopes?.metric?.[fieldName];
     }
 
-    const baseSetting = ctx.baseSettings[fieldName as keyof Settings]?.value;
+    const baseSetting = ctx.baseSettings[fieldName]?.value;
     const value =
       metricOverride?.[fieldName] ?? metricValue ?? baseSetting ?? null;
 


### PR DESCRIPTION
When the settings API is called, the metric settings fields `delayHours`, `windowType`, `windowHours`, `winRisk`, `loseRisk` are being resolved by `genMetricOverrideResolver`, which:

Checks experiment-level metric overrides -> checks metric-level values -> falls back to `null` if neither exist

This should probably fall back to the organization's base settings (from `ctx.baseSettings`) like the `genDefaultResolver` does, not to `null`.

The OpenAPI spec shows these fields as required - but nullable, leading to issues when attempting to validate responses via something like pydantic