### PR TITLE
New design for modal errors

### DIFF
--- a/packages/front-end/components/Modal.tsx
+++ b/packages/front-end/components/Modal.tsx
@@ -255,7 +255,7 @@ const Modal: FC<ModalProps> = ({
         ) : (
           <>
             {aboveBodyContent}
-            {error && <ErrorDisplay error={error} mb="3" expandable />}
+            {error && <ErrorDisplay error={error} mb="3" />}
             {children}
           </>
         )}

--- a/packages/front-end/components/Modal.tsx
+++ b/packages/front-end/components/Modal.tsx
@@ -14,6 +14,7 @@ import { Flex, Text } from "@radix-ui/themes";
 import track, { TrackEventProps } from "@/services/track";
 import ConditionalWrapper from "@/components/ConditionalWrapper";
 import Button from "@/components/Radix/Button";
+import ErrorDisplay from "@/components/Radix/ErrorDisplay";
 import LoadingOverlay from "./LoadingOverlay";
 import Portal from "./Modal/Portal";
 import Tooltip from "./Tooltip/Tooltip";
@@ -67,6 +68,7 @@ type ModalProps = {
   customValidation?: () => Promise<boolean> | boolean;
   increasedElevation?: boolean;
   stickyFooter?: boolean;
+  aboveBodyContent?: ReactNode;
   useRadixButton?: boolean;
   borderlessHeader?: boolean;
   borderlessFooter?: boolean;
@@ -116,6 +118,7 @@ const Modal: FC<ModalProps> = ({
   modalUuid: _modalUuid,
   trackOnSubmit = true,
   useRadixButton,
+  aboveBodyContent = null,
   borderlessHeader = false,
   borderlessFooter = false,
 }) => {
@@ -124,19 +127,29 @@ const Modal: FC<ModalProps> = ({
   const [error, setError] = useState<string | null>(null);
   const [isSuccess, setIsSuccess] = useState(false);
 
+  const bodyRef = useRef<HTMLDivElement>(null);
+
+  const scrollToTop = () => {
+    setTimeout(() => {
+      if (bodyRef.current) {
+        bodyRef.current.scrollTo({ top: 0, behavior: "smooth" });
+      }
+    }, 50);
+  };
+
   if (inline) {
     size = "fill";
   }
 
   useEffect(() => {
     setError(externalError || null);
+    externalError && scrollToTop();
   }, [externalError]);
 
   useEffect(() => {
     setLoading(externalLoading || false);
   }, [externalLoading]);
 
-  const bodyRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     setTimeout(() => {
       if (!autoFocusSelector) return;
@@ -240,7 +253,11 @@ const Modal: FC<ModalProps> = ({
         {isSuccess ? (
           <div className="alert alert-success">{successMessage}</div>
         ) : (
-          children
+          <>
+            {aboveBodyContent}
+            {error && <ErrorDisplay error={error} mb="3" expandable />}
+            {children}
+          </>
         )}
       </div>
       {!hideCta &&
@@ -258,19 +275,6 @@ const Modal: FC<ModalProps> = ({
               <div className="flex-1" />
             </>
           ) : null}
-          {error && (
-            <div
-              className="alert alert-danger mr-auto"
-              style={{ maxWidth: "65%" }}
-            >
-              {error
-                .split("\n")
-                .filter((v) => !!v.trim())
-                .map((s, i) => (
-                  <div key={i}>{s}</div>
-                ))}
-            </div>
-          )}
           <ConditionalWrapper
             condition={stickyFooter}
             wrapper={
@@ -431,6 +435,7 @@ const Modal: FC<ModalProps> = ({
                 }
               } catch (e) {
                 setError(e.message);
+                scrollToTop();
                 setLoading(false);
                 if (trackOnSubmit) {
                   sendTrackingEvent("modal-submit-error", {

--- a/packages/front-end/components/Modal/PagedModal.tsx
+++ b/packages/front-end/components/Modal/PagedModal.tsx
@@ -183,6 +183,86 @@ const PagedModal: FC<Props> = (props) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [step]);
 
+  const stepper = !hideNav ? (
+    <nav
+      className={`nav mb-3 justify-content-start ${navStyleClass} ${navFillClass} ${
+        style === "default" && "paged-modal-default"
+      }`}
+    >
+      {steps.map(({ display, enabled }, i) => {
+        if (navStyleClass === "nav-default") {
+          return (
+            <div
+              className={clsx(
+                "step d-flex align-items-center justify-content-between",
+                {
+                  active: step === i,
+                  completed: i < step && !skipped?.has(i),
+                  disabled: !enabled,
+                },
+              )}
+              key={i}
+            >
+              <a
+                key={i}
+                role="button"
+                className="nav-link d-flex align-items-center"
+                onClick={async (e) => {
+                  e.preventDefault();
+                  setError("");
+                  try {
+                    await validateSteps(i);
+                    setStep(i);
+                  } catch (e) {
+                    setError(e.message);
+                  }
+                }}
+              >
+                <span className="step-number rounded-circle">
+                  {i < step ? (
+                    skipped?.has(i) ? (
+                      <PiCircleDashed />
+                    ) : (
+                      <MdCheck />
+                    )
+                  ) : (
+                    i + 1
+                  )}
+                </span>
+                <div className="step-title ml-1" style={{ lineHeight: "18px" }}>
+                  {display}
+                </div>
+              </a>
+            </div>
+          );
+        } else {
+          return (
+            <a
+              key={i}
+              role="button"
+              className={clsx("w-md-100 nav-item nav-link", {
+                active: step === i,
+                disabled: !enabled,
+              })}
+              onClick={async (e) => {
+                e.preventDefault();
+                setError("");
+                try {
+                  await validateSteps(i);
+                  setStep(i);
+                } catch (e) {
+                  setError(e.message);
+                }
+              }}
+            >
+              {i + 1}. {display}
+            </a>
+          );
+        }
+      })}
+    </nav>
+  ) : null;
+
   return (
     <Modal
       inline={inline}
@@ -261,90 +341,9 @@ const PagedModal: FC<Props> = (props) => {
       trackingEventModalSource={trackingEventModalSource}
       allowlistedTrackingEventProps={allowlistedTrackingEventProps}
       modalUuid={modalUuid}
+      aboveBodyContent={stepper}
     >
-      {!hideNav ? (
-        <nav
-          className={`nav mb-4 justify-content-start ${navStyleClass} ${navFillClass} ${
-            style === "default" && "paged-modal-default"
-          }`}
-        >
-          {steps.map(({ display, enabled }, i) => {
-            if (navStyleClass === "nav-default") {
-              return (
-                <div
-                  className={clsx(
-                    "step d-flex align-items-center justify-content-between",
-                    {
-                      active: step === i,
-                      completed: i < step && !skipped?.has(i),
-                      disabled: !enabled,
-                    },
-                  )}
-                  key={i}
-                >
-                  <a
-                    key={i}
-                    role="button"
-                    className="nav-link d-flex align-items-center"
-                    onClick={async (e) => {
-                      e.preventDefault();
-                      setError("");
-                      try {
-                        await validateSteps(i);
-                        setStep(i);
-                      } catch (e) {
-                        setError(e.message);
-                      }
-                    }}
-                  >
-                    <span className="step-number rounded-circle">
-                      {i < step ? (
-                        skipped?.has(i) ? (
-                          <PiCircleDashed />
-                        ) : (
-                          <MdCheck />
-                        )
-                      ) : (
-                        i + 1
-                      )}
-                    </span>
-                    <div
-                      className="step-title ml-1"
-                      style={{ lineHeight: "18px" }}
-                    >
-                      {display}
-                    </div>
-                  </a>
-                </div>
-              );
-            } else {
-              return (
-                <a
-                  key={i}
-                  role="button"
-                  className={clsx("w-md-100 nav-item nav-link", {
-                    active: step === i,
-                    disabled: !enabled,
-                  })}
-                  onClick={async (e) => {
-                    e.preventDefault();
-                    setError("");
-                    try {
-                      await validateSteps(i);
-                      setStep(i);
-                    } catch (e) {
-                      setError(e.message);
-                    }
-                  }}
-                >
-                  {i + 1}. {display}
-                </a>
-              );
-            }
-          })}
-        </nav>
-      ) : null}
-      {content}
+      <div className="mt-2">{content}</div>
     </Modal>
   );
 };

--- a/packages/front-end/components/Radix/ErrorDisplay.tsx
+++ b/packages/front-end/components/Radix/ErrorDisplay.tsx
@@ -1,0 +1,93 @@
+import { Box, Flex, Text } from "@radix-ui/themes";
+import { useState } from "react";
+import { PiCaretDown, PiCaretRight } from "react-icons/pi";
+import type { MarginProps } from "@radix-ui/themes/dist/esm/props/margin.props.js";
+import { RadixStatusIcon } from "./HelperText";
+
+export default function ErrorDisplay({
+  error,
+  expandable = false,
+  ...containerProps
+}: {
+  error: string;
+  expandable?: boolean;
+} & MarginProps) {
+  // Split error into lines
+  const errorLines = error.split("\n").filter((line) => line.trim() !== "");
+
+  const [expanded, setExpanded] = useState(false);
+
+  if (!errorLines.length) return null;
+
+  return (
+    <Box
+      style={{
+        backgroundColor: "var(--red-a3)",
+        borderRadius: "var(--radius-3)",
+      }}
+      role={"alert"}
+      py="2"
+      px="3"
+      {...containerProps}
+    >
+      <Flex align="start" gap="2" style={{ width: "100%" }}>
+        <Text color="red">
+          <RadixStatusIcon status={"error"} size={"sm"} />
+        </Text>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          {expanded || !expandable ? (
+            <>
+              <Text size="1" color="red">
+                {errorLines[0]}
+              </Text>
+              {errorLines.length > 1 && (
+                <pre>
+                  <Text size="1" color="red">
+                    {errorLines.slice(1).join("\n")}
+                  </Text>
+                </pre>
+              )}
+            </>
+          ) : (
+            <Text
+              style={{
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                display: "inline-block",
+                whiteSpace: "nowrap",
+                verticalAlign: "middle",
+                cursor: "pointer",
+                maxWidth: "100%",
+              }}
+              onClick={(e) => {
+                e.preventDefault();
+                setExpanded(true);
+              }}
+              size="1"
+              color="red"
+            >
+              {errorLines[0]}
+            </Text>
+          )}
+        </div>
+        {expandable && (expanded || errorLines.length > 1) ? (
+          <Text color="red">
+            <a
+              href="#"
+              onClick={(e) => {
+                e.preventDefault();
+                setExpanded(!expanded);
+              }}
+              style={{
+                color: "inherit",
+                textDecoration: "none",
+              }}
+            >
+              {expanded ? <PiCaretDown /> : <PiCaretRight />}
+            </a>
+          </Text>
+        ) : null}
+      </Flex>
+    </Box>
+  );
+}

--- a/packages/front-end/components/Radix/ErrorDisplay.tsx
+++ b/packages/front-end/components/Radix/ErrorDisplay.tsx
@@ -1,23 +1,16 @@
 import { Box, Flex, Text } from "@radix-ui/themes";
-import { useState } from "react";
-import { PiCaretDown, PiCaretRight } from "react-icons/pi";
 import type { MarginProps } from "@radix-ui/themes/dist/esm/props/margin.props.js";
 import { RadixStatusIcon } from "./HelperText";
 
 export default function ErrorDisplay({
   error,
-  expandable = false,
+  maxLines = 4,
   ...containerProps
 }: {
   error: string;
-  expandable?: boolean;
+  maxLines?: number;
 } & MarginProps) {
-  // Split error into lines
-  const errorLines = error.split("\n").filter((line) => line.trim() !== "");
-
-  const [expanded, setExpanded] = useState(false);
-
-  if (!errorLines.length) return null;
+  if (!error || !error.trim()) return null;
 
   return (
     <Box
@@ -31,62 +24,21 @@ export default function ErrorDisplay({
       {...containerProps}
     >
       <Flex align="start" gap="2" style={{ width: "100%" }}>
-        <Text color="red">
-          <RadixStatusIcon status={"error"} size={"sm"} />
+        <Text color="red" style={{ marginTop: -2 }}>
+          <RadixStatusIcon status={"error"} size={"md"} />
         </Text>
-        <div style={{ flex: 1, minWidth: 0 }}>
-          {expanded || !expandable ? (
-            <>
-              <Text size="1" color="red">
-                {errorLines[0]}
-              </Text>
-              {errorLines.length > 1 && (
-                <pre>
-                  <Text size="1" color="red">
-                    {errorLines.slice(1).join("\n")}
-                  </Text>
-                </pre>
-              )}
-            </>
-          ) : (
-            <Text
-              style={{
-                overflow: "hidden",
-                textOverflow: "ellipsis",
-                display: "inline-block",
-                whiteSpace: "nowrap",
-                verticalAlign: "middle",
-                cursor: "pointer",
-                maxWidth: "100%",
-              }}
-              onClick={(e) => {
-                e.preventDefault();
-                setExpanded(true);
-              }}
-              size="1"
-              color="red"
-            >
-              {errorLines[0]}
-            </Text>
-          )}
-        </div>
-        {expandable && (expanded || errorLines.length > 1) ? (
-          <Text color="red">
-            <a
-              href="#"
-              onClick={(e) => {
-                e.preventDefault();
-                setExpanded(!expanded);
-              }}
-              style={{
-                color: "inherit",
-                textDecoration: "none",
-              }}
-            >
-              {expanded ? <PiCaretDown /> : <PiCaretRight />}
-            </a>
+        <Box
+          style={{
+            flex: 1,
+            maxHeight: 21 * maxLines,
+            overflowY: "auto",
+            whiteSpace: "pre-wrap",
+          }}
+        >
+          <Text size="2" color="red">
+            {error}
           </Text>
-        ) : null}
+        </Box>
       </Flex>
     </Box>
   );


### PR DESCRIPTION
### Features and Changes

Revamped errors within modals:

* Instead of rendering the error message in the modal footer, it is now rendered at the top of the modal body (beneath the stepper for paged modals).  
* If the error is longer than 4 lines, it will overflow with scroll
* The error now renders with `white-space: pre-wrap`, so indented lines will show up properly (e.g. JSON)
* When an error occurs in a long modal, it will scroll the modal content back to the top.
* Converted error styles from bootstrap to Radix.

### Before

<img width="247" height="125" alt="image" src="https://github.com/user-attachments/assets/1411fcc8-a852-46c5-8b68-98ab5b913a71" />

<img width="247" height="188" alt="image" src="https://github.com/user-attachments/assets/aed20741-4ebe-4962-bcd8-290527aa70a6" />

<img width="700" height="361" alt="image" src="https://github.com/user-attachments/assets/29a7b599-8d59-4ec3-940e-be5f5717a333" />

<img width="397" height="361" alt="image" src="https://github.com/user-attachments/assets/8cc05269-d11a-44f5-8c19-e9fffd7ed8f5" />

### After

<img width="250" height="145" alt="image" src="https://github.com/user-attachments/assets/6589f98f-3a54-4dd5-9d7f-f477d262b8cf" />

<img width="250" height="176" alt="image" src="https://github.com/user-attachments/assets/ae3de2c4-ceac-4b61-9f2f-b1861d902e04" />

<img width="700" height="380" alt="image" src="https://github.com/user-attachments/assets/795b6a7d-ddf6-4e40-b7b2-f30690bd62b6" />

<img width="397" height="376" alt="image" src="https://github.com/user-attachments/assets/4ffed9d2-98ac-4ff2-82c4-584f20553cc2" />


