### PR TITLE
Optionally disable api root path or hide sensitive info

### DIFF
--- a/packages/back-end/src/app.ts
+++ b/packages/back-end/src/app.ts
@@ -13,8 +13,12 @@ import decisionCriteriaRouter from "back-end/src/enterprise/routers/decision-cri
 import { usingFileConfig } from "./init/config";
 import { AuthRequest } from "./types/AuthRequest";
 import {
+  API_ROOT_HIDE_API_HOST,
+  API_ROOT_HIDE_APP_ORIGIN,
+  API_ROOT_HIDE_BUILD_INFO,
   APP_ORIGIN,
   CORS_ORIGIN_REGEX,
+  DISABLE_API_ROOT_PATH,
   ENVIRONMENT,
   EXPRESS_TRUST_PROXY_OPTS,
   IS_CLOUD,
@@ -197,19 +201,33 @@ app.get("/robots.txt", (_req, res) => {
 
 app.use(compression());
 
-app.get("/", (req, res) => {
-  res.json({
-    name: "GrowthBook API",
-    production: ENVIRONMENT === "production",
-    api_host:
-      process.env.API_HOST ||
-      req.protocol + "://" + req.hostname + ":" + app.get("port"),
-    app_origin: APP_ORIGIN,
-    config_source: usingFileConfig() ? "file" : "db",
-    email_enabled: isEmailEnabled(),
-    build: getBuild(),
+if (!DISABLE_API_ROOT_PATH) {
+  app.get("/", (req, res) => {
+    res.json({
+      name: "GrowthBook API",
+      production: ENVIRONMENT === "production",
+      ...(API_ROOT_HIDE_API_HOST
+        ? {}
+        : {
+            api_host:
+              process.env.API_HOST ||
+              req.protocol + "://" + req.hostname + ":" + app.get("port"),
+          }),
+      ...(API_ROOT_HIDE_APP_ORIGIN
+        ? {}
+        : {
+            app_origin: APP_ORIGIN,
+          }),
+      config_source: usingFileConfig() ? "file" : "db",
+      email_enabled: isEmailEnabled(),
+      ...(API_ROOT_HIDE_BUILD_INFO
+        ? {}
+        : {
+            build: getBuild(),
+          }),
+    });
   });
-});
+}
 
 app.use(httpLogger);
 

--- a/packages/back-end/src/util/secrets.ts
+++ b/packages/back-end/src/util/secrets.ts
@@ -279,6 +279,21 @@ export const CLICKHOUSE_MAIN_TABLE = process.env.CLICKHOUSE_MAIN_TABLE || "";
 export const CLICKHOUSE_DEV_PREFIX =
   process.env.CLICKHOUSE_DEV_PREFIX || "test_";
 
+// Enable fully disabling the root api path or controlling which fields should be removed from the response
+// Note: the Visual Editor relies on the information in this path, so disabling it will prevent some features from working correctly.
+export const DISABLE_API_ROOT_PATH = stringToBoolean(
+  process.env.DISABLE_API_ROOT_PATH,
+);
+export const API_ROOT_HIDE_API_HOST = stringToBoolean(
+  process.env.API_ROOT_HIDE_API_HOST,
+);
+export const API_ROOT_HIDE_APP_ORIGIN = stringToBoolean(
+  process.env.API_ROOT_HIDE_APP_ORIGIN,
+);
+export const API_ROOT_HIDE_BUILD_INFO = stringToBoolean(
+  process.env.API_ROOT_HIDE_BUILD_INFO,
+);
+
 export type SecretsReplacer = <T extends string | Record<string, string>>(
   s: T,
   options?: {


### PR DESCRIPTION
### Features and Changes

Adds four optional environment variables for self-hosted instances to fully disable or partially omit the information exposed on the `/` root path of the api.

- Closes #4073 

### Testing

Add the following variables to your `packages/back-end/.env.local` and toggle them on individually to observe their effects
```
DISABLE_API_ROOT_PATH=false
API_ROOT_HIDE_API_HOST=false
API_ROOT_HIDE_APP_ORIGIN=false
API_ROOT_HIDE_BUILD_INFO=false
```

### Screenshots

#### Without anything disabled

<img width="351" height="247" alt="image" src="https://github.com/user-attachments/assets/6438b07c-e01c-401b-8b54-f53953213014" />

#### Fully disabled

<img width="395" height="76" alt="image" src="https://github.com/user-attachments/assets/f851e738-5182-40e2-b41b-808c1811498e" />

#### Enabled but hiding all optional fields

<img width="293" height="110" alt="image" src="https://github.com/user-attachments/assets/18553151-d6b5-4b1c-81ac-3f3282685669" />
