### PR TITLE
fix: Cache job metrics + Use default export interval for OTEL

### DIFF
--- a/packages/back-end/src/services/tracing.ts
+++ b/packages/back-end/src/services/tracing.ts
@@ -66,7 +66,7 @@ export const trackJob =
     let res;
     try {
       if (!disableJobLogs) {
-        logger.info({ job: job.attrs }, `Starting job ${jobName}`);
+        logger.debug({ job: job.attrs }, `Starting job ${jobName}`);
       }
       res = await fn(job);
     } catch (e) {
@@ -85,7 +85,7 @@ export const trackJob =
 
     // on successful job
     if (!disableJobLogs) {
-      logger.info({ job: job.attrs }, `Successfully finished job ${jobName}`);
+      logger.debug({ job: job.attrs }, `Successfully finished job ${jobName}`);
     }
     try {
       wrapUpMetrics();

--- a/packages/back-end/src/services/tracing.ts
+++ b/packages/back-end/src/services/tracing.ts
@@ -1,6 +1,9 @@
+import { performance } from "node:perf_hooks";
 import { Job, JobAttributesData } from "agenda";
 import { logger } from "back-end/src/util/logger";
 import { metrics, Counter, Histogram } from "back-end/src/util/metrics";
+
+const disableJobLogs = process.env.GB_DISABLE_JOB_LOGS === "1";
 
 // Datadog downcases tag values, so it is best to use snake case
 const normalizeJobName = (jobName: string) => {
@@ -10,94 +13,121 @@ const normalizeJobName = (jobName: string) => {
     .toLowerCase();
 };
 
-export const trackJob =
-  <T extends JobAttributesData>(
-    jobNameRaw: string,
-    fn: (job: Job<T>) => Promise<void>,
-  ) =>
-  async (job: Job<T>) => {
-    let counter: Counter;
-    let histogram: Histogram;
-    let hasMetricsStarted = false;
+export const trackJob = <T extends JobAttributesData>(
+  jobNameRaw: string,
+  fn: (job: Job<T>) => Promise<void>
+) => async (job: Job<T>) => {
+  let hasMetricsStarted = false;
 
-    const jobName = normalizeJobName(jobNameRaw);
+  const jobName = normalizeJobName(jobNameRaw);
 
-    // DataDog downcases tag names, so converting to snakecase here
-    const attributes = { job_name: jobName };
+  // DataDog downcases tag names, so converting to snakecase here
+  const attributes = { job_name: jobName };
 
-    const startTime = new Date().getTime();
+  const startTime = performance.now();
 
-    // init metrics
+  // init metrics
+  try {
+    getJobsRunningCounter().increment(attributes);
+    hasMetricsStarted = true;
+  } catch (e) {
+    logger.error(
+      { err: e, job: job.attrs },
+      `Error incrementing jobs.running_count`
+    );
+  }
+
+  // wrap up metrics function, to be called at the end of the job
+  const wrapUpMetrics = () => {
     try {
-      counter = metrics.getCounter(`jobs.running_count`);
-      counter.increment(attributes);
-      hasMetricsStarted = true;
+      const end = performance.now();
+      const elapsed = end - startTime;
+      getJobsDurationHistogram().record(elapsed, attributes);
     } catch (e) {
       logger.error(
         { err: e, job: job.attrs },
-        `Error initializing counter for job`,
+        `Error recording duration metric for job`
       );
     }
+    if (!hasMetricsStarted) return;
     try {
-      histogram = metrics.getHistogram(`jobs.duration`);
+      getJobsRunningCounter().decrement(attributes);
     } catch (e) {
       logger.error(
         { err: e, job: job.attrs },
-        `Error initializing histogram for job`,
+        `Error decrementing jobs.running_count`
       );
     }
+  };
 
-    // wrap up metrics function, to be called at the end of the job
-    const wrapUpMetrics = () => {
-      try {
-        histogram?.record(new Date().getTime() - startTime, attributes);
-      } catch (e) {
-        logger.error(
-          { err: e, job: job.attrs },
-          `Error recording duration metric for job`,
-        );
-      }
-      if (!hasMetricsStarted) return;
-      try {
-        counter.decrement(attributes);
-      } catch (e) {
-        logger.error(
-          { err: e, job: job.attrs },
-          `Error decrementing count metric for job`,
-        );
-      }
-    };
-
-    // run job
-    let res;
-    try {
-      logger.debug({ job: job.attrs }, `Starting job ${jobName}`);
-      res = await fn(job);
-    } catch (e) {
-      logger.error({ err: e, job: job.attrs }, `Error running job: ${jobName}`);
-      try {
-        wrapUpMetrics();
-        metrics.getCounter(`jobs.errors`).increment(attributes);
-      } catch (e) {
-        logger.error(
-          { err: e, job: job.attrs },
-          `Error wrapping up metrics: ${jobName}`,
-        );
-      }
-      throw e;
+  // run job
+  let res;
+  try {
+    if (!disableJobLogs) {
+      logger.info({ job: job.attrs }, `Starting job ${jobName}`);
     }
-
-    // on successful job
-    logger.debug({ job: job.attrs }, `Successfully finished job ${jobName}`);
+    res = await fn(job);
+  } catch (e) {
+    logger.error({ err: e, job: job.attrs }, `Error running job: ${jobName}`);
     try {
       wrapUpMetrics();
-      metrics.getCounter(`jobs.successes`).increment(attributes);
+      getJobsErrorsCounter().increment(attributes);
     } catch (e) {
       logger.error(
         { err: e, job: job.attrs },
-        `Error wrapping up metrics: ${jobName}`,
+        `Error wrapping up metrics: ${jobName}`
       );
     }
+    throw e;
+  }
 
-    return res;
-  };
+  // on successful job
+  if (!disableJobLogs) {
+    logger.info({ job: job.attrs }, `Successfully finished job ${jobName}`);
+  }
+  try {
+    wrapUpMetrics();
+    getJobsSuccessesCounter().increment(attributes);
+  } catch (e) {
+    logger.error(
+      { err: e, job: job.attrs },
+      `Error wrapping up metrics: ${jobName}`
+    );
+  }
+
+  return res;
+};
+
+// Cache metric handles
+let jobsRunningCounter: Counter | null = null;
+let jobsDurationHistogram: Histogram | null = null;
+let jobsSuccessesCounter: Counter | null = null;
+let jobsErrorsCounter: Counter | null = null;
+
+function getJobsRunningCounter() {
+  if (!jobsRunningCounter) {
+    jobsRunningCounter = metrics.getCounter("jobs.running_count");
+  }
+  return jobsRunningCounter;
+}
+
+function getJobsDurationHistogram() {
+  if (!jobsDurationHistogram) {
+    jobsDurationHistogram = metrics.getHistogram("jobs.duration");
+  }
+  return jobsDurationHistogram;
+}
+
+function getJobsSuccessesCounter() {
+  if (!jobsSuccessesCounter) {
+    jobsSuccessesCounter = metrics.getCounter("jobs.successes");
+  }
+  return jobsSuccessesCounter;
+}
+
+function getJobsErrorsCounter() {
+  if (!jobsErrorsCounter) {
+    jobsErrorsCounter = metrics.getCounter("jobs.errors");
+  }
+  return jobsErrorsCounter;
+}

--- a/packages/back-end/src/tracing.opentelemetry.ts
+++ b/packages/back-end/src/tracing.opentelemetry.ts
@@ -41,7 +41,6 @@ diag.setLogger(
 
 const metricReader = new PeriodicExportingMetricReader({
   exporter: new OTLPMetricExporter(),
-  exportIntervalMillis: 1000,
 });
 
 const sdk = new opentelemetry.NodeSDK({


### PR DESCRIPTION
### Features and Changes

While investigating increased CPU usage when running backend `with-tracing`, which enables OTEL, we have 2 changes that reduce CPU usage.

- Caching metric handler for jobs (as these are now shared by all jobs we expect memory usage to be lower in a scenario where many jobs are running in parallel)
- Use default value for `exportIntervalMillis` (60s) instead of 1s
  - The previously configured value is too aggressive and means we will be spending CPU cycles serializing the data, and sending it to the collector.
- Added `GB_DISABLE_JOB_LOGS` env, to keep OTEL metrics but disabled logs if needed.