### PR TITLE
Enable "/" in AI search without launching Algolia search

### DIFF
--- a/docs/src/theme/SearchBar/index.tsx
+++ b/docs/src/theme/SearchBar/index.tsx
@@ -1,0 +1,34 @@
+import { ReactNode, useEffect } from "react";
+// eslint-disable-next-line import/no-unresolved
+import SearchBar from "@theme-original/SearchBar";
+import type SearchBarType from "@theme/SearchBar";
+import type { WrapperProps } from "@docusaurus/types";
+
+type Props = WrapperProps<typeof SearchBarType>;
+
+export default function SearchBarWrapper(props: Props): ReactNode {
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (
+        e.key === "/" &&
+        e.target instanceof Element &&
+        e.target.tagName !== "INPUT" &&
+        e.target.tagName !== "TEXTAREA"
+      ) {
+        e.stopImmediatePropagation();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown, true);
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown, true);
+    };
+  }, []);
+
+  return (
+    <>
+      <SearchBar {...props} />
+    </>
+  );
+}


### PR DESCRIPTION
Ref #4049 

Problem:
When using Kapa AI search, writing "A/B" would trigger Algolia search with the "/" keyboard shortcut. Unfortunately, there isn't a straightforward way to disable this behavior.

Solution:
Capture "/" input and prevent Algolia `searchbar` from launching when conditions are met.