### PR TITLE
Rename Helm Chart github action

### DIFF
--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -1,9 +1,10 @@
+name: Helm Chart
 on:
   push:
   workflow_dispatch:
     inputs:
       publish:
-        description: "Publish chart to OCI registry"
+        description: "Build and maybe publish Helm Chart to OCI registry"
         required: false
         default: false
         type: boolean


### PR DESCRIPTION
### Features and Changes

Name the helm chart github action.  Previously it was just the path.

### Testing

See it called Helm Charts in [Github Actions](helm upgrade --install growthbook oci://ghcr.io/growthbook/charts/growthbook -f values-minikube.yaml).
