### PR TITLE
feat: Allow unsetting of license key

### DIFF
--- a/packages/back-end/src/controllers/admin.ts
+++ b/packages/back-end/src/controllers/admin.ts
@@ -113,7 +113,7 @@ export async function putOrganization(
     updates.externalId = externalId;
     orig.externalId = org.externalId;
   }
-  if (licenseKey && licenseKey.trim() !== org.licenseKey) {
+  if (licenseKey !== undefined && licenseKey.trim() !== org.licenseKey) {
     updates.licenseKey = licenseKey.trim();
     orig.licenseKey = org.licenseKey;
     await setLicenseKey(org, updates.licenseKey);


### PR DESCRIPTION
### Features and Changes

Enterprise trial clients that want to downgrade to pro need their license key unset so that they can sign up for pro like normal. This PR allows them to do it.

### Testing

Go to /admin.  
Select an org with a license key.
Click edit pencil.
Delete the license key and save.
Click on the org again and edit.
See the license key is gone. 
