### PR TITLE
Add separate entrypoint for editing dashboard metadata

### DIFF
--- a/packages/back-end/src/routers/dashboards/dashboards.controller.ts
+++ b/packages/back-end/src/routers/dashboards/dashboards.controller.ts
@@ -132,7 +132,7 @@ export async function updateDashboard(
         "enableAutoUpdates" in updates) &&
       !canManage
     ) {
-      context.permissions.throwPermissionError();
+      return context.permissions.throwPermissionError();
     }
 
     const createdBlocks = await Promise.all(

--- a/packages/front-end/enterprise/components/Dashboards/DashboardEditor/index.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardEditor/index.tsx
@@ -4,7 +4,6 @@ import {
   PiCaretDownFill,
   PiPlus,
   PiTableDuotone,
-  PiPencilSimpleFill,
   PiChartLineDuotone,
   PiFileSqlDuotone,
   PiListDashesDuotone,
@@ -28,7 +27,6 @@ import {
   DropdownMenuSeparator,
 } from "@/ui/DropdownMenu";
 import Callout from "@/ui/Callout";
-import Field from "@/components/Forms/Field";
 import DashboardBlock from "./DashboardBlock";
 import DashboardUpdateDisplay from "./DashboardUpdateDisplay";
 
@@ -144,7 +142,6 @@ interface Props {
     index: number,
     block: DashboardBlockInterfaceOrData<DashboardBlockInterface>,
   ) => void;
-  setTitle?: (title: string) => Promise<void>;
   moveBlock: (index: number, direction: -1 | 1) => void;
   addBlockType: (bType: DashboardBlockType, i?: number) => void;
   editBlock: (index: number) => void;
@@ -165,7 +162,6 @@ function DashboardEditor({
   stagedBlockIndex,
   scrollAreaRef,
   setBlock,
-  setTitle,
   moveBlock,
   addBlockType,
   editBlock,
@@ -173,8 +169,6 @@ function DashboardEditor({
   deleteBlock,
   mutate,
 }: Props) {
-  const [editingTitle, setEditingTitle] = useState(false);
-
   const renderSingleBlock = ({
     i,
     key,
@@ -273,8 +267,6 @@ function DashboardEditor({
     );
   };
 
-  const canEditTitle = isEditing && !!setTitle;
-
   return (
     <div>
       <Flex
@@ -283,69 +275,19 @@ function DashboardEditor({
         className="mb-3"
         gap="1"
       >
-        {canEditTitle && editingTitle ? (
-          <Field
-            autoFocus
-            defaultValue={title}
-            placeholder="Title"
-            onFocus={(e) => {
-              e.target.select();
-            }}
-            onBlur={(e) => {
-              setEditingTitle(false);
-              const newTitle = e.target.value;
-              if (newTitle !== title) {
-                setTitle(newTitle);
-              }
-            }}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") {
-                (e.target as HTMLInputElement).blur();
-              } else if (e.key === "Escape") {
-                setEditingTitle(false);
-              }
-            }}
-            containerClassName="flex-1"
-          />
-        ) : (
-          <>
-            <Text
-              weight="medium"
-              size="5"
-              onDoubleClick={
-                canEditTitle
-                  ? (e) => {
-                      e.preventDefault();
-                      setEditingTitle(true);
-                    }
-                  : undefined
-              }
-              style={{
-                overflow: "hidden",
-                textOverflow: "ellipsis",
-                whiteSpace: "nowrap",
-                flexShrink: 1,
-              }}
-            >
-              {title}
-            </Text>
-            {canEditTitle && (
-              <a
-                href="#"
-                onClick={(e) => {
-                  e.preventDefault();
-                  setEditingTitle(true);
-                }}
-                className="ml-2"
-                style={{ color: "var(--violet-9)", paddingBottom: 5 }}
-                title="Edit Title"
-              >
-                <PiPencilSimpleFill />
-              </a>
-            )}
-            <div style={{ flexGrow: 1 }} />
-          </>
-        )}
+        <Text
+          weight="medium"
+          size="5"
+          style={{
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+            flexShrink: 1,
+          }}
+        >
+          {title}
+        </Text>
+        <div style={{ flexGrow: 1 }} />
         <DashboardUpdateDisplay
           blocks={blocks}
           enableAutoUpdates={enableAutoUpdates}

--- a/packages/front-end/enterprise/components/Dashboards/DashboardWorkspace.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardWorkspace.tsx
@@ -1,11 +1,5 @@
 import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { DashboardInterface } from "back-end/src/enterprise/validators/dashboard";
 import {
   DashboardBlockInterfaceOrData,
@@ -107,22 +101,6 @@ export default function DashboardWorkspace({
       });
     };
   }, [setBlocks, submit, dashboard.id]);
-
-  const [title, setTitleState] = useState(dashboard.title);
-  const setTitle = useCallback(
-    async (title: string) => {
-      setTitleState(title);
-      setHasMadeChanges(true);
-      await submit({
-        method: "PUT",
-        dashboardId: dashboard.id,
-        data: {
-          title,
-        },
-      });
-    },
-    [dashboard.id, submit],
-  );
 
   const [editSidebarExpanded, setEditSidebarExpanded] = useState(true);
   const [editSidebarDirty, setEditSidebarDirty] = useState(false);
@@ -301,7 +279,7 @@ export default function DashboardWorkspace({
           <DashboardEditor
             isTabActive={isTabActive}
             experiment={experiment}
-            title={title}
+            title={dashboard.title}
             blocks={effectiveBlocks}
             isEditing={true}
             enableAutoUpdates={dashboard.enableAutoUpdates}
@@ -322,7 +300,6 @@ export default function DashboardWorkspace({
                 ]);
               }
             }}
-            setTitle={setTitle}
             moveBlock={(i, direction) => {
               if (isDefined(addBlockIndex) || isDefined(editingBlockIndex))
                 return;

--- a/packages/front-end/enterprise/components/Dashboards/DashboardsTab.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardsTab.tsx
@@ -107,6 +107,7 @@ export default function DashboardsTab({
   const [isEditing, setIsEditing] = useState(false);
   const [showUpgradeModal, setShowUpgradeModal] = useState(false);
   const [showCreateModal, setShowCreateModal] = useState(false);
+  const [showEditModal, setShowEditModal] = useState(false);
   const [showDuplicateModal, setShowDuplicateModal] = useState(false);
   const { apiCall } = useAuth();
   const [blocks, setBlocks] = useState<
@@ -128,11 +129,9 @@ export default function DashboardsTab({
     : true;
   const isOwner = userId === dashboard?.userId || !dashboard?.userId;
   const isAdmin = permissionsUtil.canSuperDeleteReport();
-  const canEdit =
-    isOwner ||
-    isAdmin ||
-    (dashboard.editLevel === "organization" && canUpdateDashboard);
   const canManage = isOwner || isAdmin;
+  const canEdit =
+    canManage || (dashboard.editLevel === "organization" && canUpdateDashboard);
 
   useEffect(() => {
     if (dashboard) {
@@ -220,6 +219,25 @@ export default function DashboardsTab({
               submit={async (data) => {
                 await submitDashboard({ method: "POST", data });
                 setIsEditing(true);
+              }}
+            />
+          )}
+          {dashboard && showEditModal && (
+            <DashboardModal
+              mode="edit"
+              close={() => setShowEditModal(false)}
+              initial={{
+                editLevel: dashboard.editLevel,
+                enableAutoUpdates: dashboard.enableAutoUpdates,
+                title: dashboard.title,
+              }}
+              disableAutoUpdate={autoUpdateDisabled}
+              submit={async (data) => {
+                await submitDashboard({
+                  method: "PUT",
+                  dashboardId: dashboard.id,
+                  data,
+                });
               }}
             />
           )}
@@ -366,6 +384,17 @@ export default function DashboardsTab({
                                   setIsEditing(true);
                                 }}
                               />
+                              {canManage && (
+                                <Button
+                                  className="dropdown-item"
+                                  onClick={() => setShowEditModal(true)}
+                                >
+                                  <Text weight="regular">
+                                    Edit Dashboard Details
+                                  </Text>
+                                </Button>
+                              )}
+
                               <Container px="5">
                                 <DropdownMenuSeparator />
                               </Container>


### PR DESCRIPTION
### Features and Changes

Removes the in-line title editing for dashboards in favor of a separate item in the moremenu. This new item pops the standard dashboard modal so users can toggle the "allow organization members to edit" setting after dashboard creation.

This also fixes an issue where title editing wasn't checking for the `canManage` permission, which would lead to permission errors being thrown

### Testing

Create two user accounts, one who owns the dashboard and a second in the same organization.
Check that the observed behavior matches expectations for the following states
| User Role / Dashboard Org Editing | Read-only | Experimenter | Admin |
|- | - | - | - |
| Org editing Disabled | No access | No access | Full access |
| Org editing Enabled | No access | Can edit blocks but not metadata | Full access |

### Screenshots


