### PR TITLE
Show chart of seat usage per installation for self-hosted enterprise …

### DIFF
--- a/packages/back-end/src/enterprise/models/licenseModel.ts
+++ b/packages/back-end/src/enterprise/models/licenseModel.ts
@@ -34,6 +34,7 @@ const licenseSchema = new mongoose.Schema({
     of: {
       _id: false,
       date: Date,
+      installationName: String,
       userHashes: [String],
       licenseUserCodes: {
         invites: [String],

--- a/packages/back-end/src/models/InstallationModel.ts
+++ b/packages/back-end/src/models/InstallationModel.ts
@@ -2,30 +2,46 @@
  * This file is used to store the installation ID of the app.
  * Each installation (dev, prod, etc.) has a unique ID.
  * This is used as a singleton to identify the installation when registering licenses.
+ * The installation name is a user-settable friendly name for the installation
+ * for multi-org installations where we can't use the org name.
  */
 import { randomUUID } from "crypto";
 import mongoose from "mongoose";
+import { InstallationInterface } from "back-end/types/installation";
 
 const InstallationSchema = new mongoose.Schema({
   id: String,
+  name: String,
 });
 
-export type InstallationDocument = mongoose.Document & {
-  id: string;
-};
+export type InstallationDocument = mongoose.Document & InstallationInterface;
 
-export const InstallationModel = mongoose.model<InstallationDocument>(
+export const InstallationModel = mongoose.model<InstallationInterface>(
   "Installation",
   InstallationSchema,
 );
 
-export async function getInstallationId(): Promise<string> {
+function toInterface(doc: InstallationDocument): InstallationInterface {
+  return doc.toJSON();
+}
+
+export async function getInstallation(): Promise<InstallationInterface> {
   const installation = await InstallationModel.findOne({});
   if (installation) {
-    return installation.id;
+    return toInterface(installation);
   } else {
     const installationId = `installation-${randomUUID()}`;
-    await InstallationModel.create({ id: installationId });
-    return installationId;
+    return toInterface(await InstallationModel.create({ id: installationId }));
+  }
+}
+
+export async function setInstallationName(name: string): Promise<void> {
+  const installation = await InstallationModel.findOne({});
+  if (installation) {
+    installation.name = name;
+    await installation.save();
+  } else {
+    const installationId = `installation-${randomUUID()}`;
+    await InstallationModel.create({ id: installationId, name });
   }
 }

--- a/packages/back-end/src/types/Audit.ts
+++ b/packages/back-end/src/types/Audit.ts
@@ -45,6 +45,7 @@ export const entityEvents = {
   "sdk-connection": ["create", "update", "delete"],
   user: ["create", "update", "delete", "invite"],
   organization: ["create", "update", "delete", "disable", "enable"],
+  installation: ["update"],
   savedGroup: ["created", "deleted", "updated"],
   segment: ["create", "delete", "update"],
   archetype: ["created", "deleted", "updated"],

--- a/packages/back-end/types/installation.d.ts
+++ b/packages/back-end/types/installation.d.ts
@@ -1,0 +1,4 @@
+export interface InstallationInterface {
+  id: string;
+  name?: string;
+}

--- a/packages/back-end/types/organization.d.ts
+++ b/packages/back-end/types/organization.d.ts
@@ -325,6 +325,7 @@ export interface OrganizationInterface {
     hasPaymentMethod?: boolean;
   };
   licenseKey?: string;
+  installationName?: string;
   autoApproveMembers?: boolean;
   members: Member[];
   invites: Invite[];
@@ -369,6 +370,7 @@ export type GetOrganizationResponse = {
   licenseError: string;
   commercialFeatures: CommercialFeature[];
   license: Partial<LicenseInterface> | null;
+  installationName: string | null;
   subscription: SubscriptionInfo | null;
   licenseKey?: string;
   currentUserPermissions: UserPermissions;

--- a/packages/front-end/components/GeneralSettings/OrganizationAndLicenseSettings.tsx
+++ b/packages/front-end/components/GeneralSettings/OrganizationAndLicenseSettings.tsx
@@ -16,6 +16,7 @@ export default function OrganizationAndLicenseSettings({
   org: Partial<OrganizationInterface>;
   refreshOrg: () => Promise<void>;
 }) {
+  const { installationName, license } = useUser();
   const [editOpen, setEditOpen] = useState(false);
   const permissions = usePermissions();
   // this check isn't strictly necessary, as we check permissions accessing the settings page, but it's a good to be safe
@@ -24,12 +25,15 @@ export default function OrganizationAndLicenseSettings({
   const ownerEmailExists = !!Array.from(users).find(
     (e) => e[1].email === org.ownerEmail,
   );
+  const showInstallationName =
+    license?.plan === "enterprise" && !isCloud() && isMultiOrg();
 
   return (
     <>
       {editOpen && (
         <EditOrganizationModal
           name={org.name || ""}
+          installationName={installationName || ""}
           ownerEmail={org.ownerEmail || ""}
           close={() => setEditOpen(false)}
           mutate={refreshOrg}
@@ -68,6 +72,12 @@ export default function OrganizationAndLicenseSettings({
                 <Box>
                   <Text weight="medium">Organization Id: </Text> {org.id}
                 </Box>
+                {showInstallationName && (
+                  <Box>
+                    <Text weight="medium">Installation Name: </Text>{" "}
+                    {installationName}
+                  </Box>
+                )}
               </Flex>
               {canEdit && (
                 <Button

--- a/packages/front-end/components/License/ShowLicenseInfo.tsx
+++ b/packages/front-end/components/License/ShowLicenseInfo.tsx
@@ -8,6 +8,7 @@ import UpgradeModal from "@/components/Settings/UpgradeModal";
 import AccountPlanNotices from "@/components/Layout/AccountPlanNotices";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 import Button from "@/ui/Button";
+import { isCloud } from "@/services/env";
 import RefreshLicenseButton from "./RefreshLicenseButton";
 import DownloadLicenseUsageButton from "./DownloadLicenseUsageButton";
 
@@ -33,6 +34,14 @@ const ShowLicenseInfo: FC<{
         : actualPlan === "pro_sso"
           ? "Pro + SSO"
           : "Starter") + (license && license.isTrial ? " (trial)" : "");
+
+  const showInstallationChart =
+    !isCloud() &&
+    license?.plan === "enterprise" &&
+    Object.keys(license?.installationUsers || {}).length > 1;
+
+  const showSeatUsage =
+    license?.plan === "enterprise" && !showInstallationChart;
 
   return (
     <Box>
@@ -149,6 +158,14 @@ const ShowLicenseInfo: FC<{
                           <div>Seats:</div>
                           <span className="text-muted">{license.seats}</span>
                         </div>
+                        {license.id?.startsWith("license") && showSeatUsage && (
+                          <div className="col-sm-2">
+                            <div>Seats in use:</div>
+                            <span className="text-muted">
+                              {license.seatsInUse}
+                            </span>
+                          </div>
+                        )}
                       </>
                     )}
                   {license && (
@@ -166,6 +183,37 @@ const ShowLicenseInfo: FC<{
                       )}
                     </>
                   )}
+                </div>
+              )}
+              {showInstallationChart && (
+                <div className="form-group row mt-4">
+                  <div className="col-sm-12">
+                    <Text className="font-weight-semibold mb-3">
+                      Seats in Use:
+                    </Text>
+                    <table className="table gbtable appbox table-sm">
+                      <thead>
+                        <tr>
+                          <th>Installation</th>
+                          <th>Seats Used</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {Object.entries(license?.installationUsers || {}).map(
+                          ([id, { installationName, userHashes }]) => (
+                            <tr key={id}>
+                              <td>{installationName || id}</td>
+                              <td>{userHashes.length}</td>
+                            </tr>
+                          ),
+                        )}
+                        <tr key="total" className="font-weight-bold">
+                          <td>Total Distinct Users</td>
+                          <td>{license?.seatsInUse || 0}</td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
                 </div>
               )}
             </Box>

--- a/packages/front-end/services/UserContext.tsx
+++ b/packages/front-end/services/UserContext.tsx
@@ -96,6 +96,7 @@ export interface UserContextValue {
   email?: string;
   superAdmin?: boolean;
   license?: Partial<LicenseInterface> | null;
+  installationName?: string;
   subscription: SubscriptionInfo | null;
   user?: ExpandedMember;
   users: Map<string, ExpandedMember>;
@@ -509,6 +510,7 @@ export function UserContextProvider({ children }: { children: ReactNode }) {
         permissionsUtil,
         settings: currentOrg?.organization?.settings || {},
         license,
+        installationName: currentOrg?.installationName || undefined,
         subscription,
         enterpriseSSO: currentOrg?.enterpriseSSO || undefined,
         accountPlan: currentOrg?.accountPlan,

--- a/packages/shared/src/enterprise/license-consts.ts
+++ b/packages/shared/src/enterprise/license-consts.ts
@@ -137,6 +137,7 @@ export interface LicenseInterface {
   installationUsers: {
     [installationId: string]: {
       date: string;
+      installationName?: string;
       userHashes: string[];
       licenseUserCodes?: LicenseUserCodes;
     };
@@ -313,6 +314,7 @@ export interface LicenseUserCodes {
 
 export interface LicenseMetaData {
   installationId: string;
+  installationName?: string;
   gitSha: string;
   gitCommitDate: string;
   sdkLanguages: string[];


### PR DESCRIPTION
### Features and Changes

Some organizations have different departments using their own infrastructure, and sharing the org wide license.  As the different departments need to communicate how many seats each are using it would be nice if they could see a chart of which department is using how many seats.  We have all that data already on the license, however only with an installationId identifying the installation.  That is not very user friendly.

This PR defaults to using the organization name as the installation name.  For IS_MULTI_ORG installations we need a new field, so we allow them to set an installationName that gets set to the installation object itself.  If it is not set we default to the installationId which at least is a unique identifier.

This PR shows "seats in use" on the license info if there is just one installation.  If there is more than one it shows a chart with the number of seats used in each installation.  

### Dependencies

The license server PR needs to land in order to start seeing the installation names in the chart instead of just the installation ids.

### Testing

#### Single Installation
These should show a "Seats in use" field in the license section.
1. Go to http://localhost:3000/settings and see a "Seats in use" field.
<img width="1328" height="344" alt="Screenshot 2025-09-18 at 4 26 05 PM" src="https://github.com/user-attachments/assets/ea86e1b8-6858-4f15-abf0-2a0f7cc1d289" />

#### Setup for multi-orgs
1. manually change the installation id on the one document in installation collection in mongo.  
2. Click refresh license on http://localhost:3000/settings

#### Airgapped
These are rare.  While we could calculate the number of seats being used, it is not on the license and no need to support this, so we just hide the field.
1. Set `IS_CLOUD=false` `LICENSE_KEY=<airgapped license key>` `MULTI_ORG=false`.  
2. Restart the server.
3. Go to http://localhost:3000/settings and see no Seats in use, chart, on installation name field. 
4. Click on Edit Organization and see no installation name setting.

#### Existing multi- installation
Existing multi installations won't have installationName set.  So if an org upgrades growthbook, but is using an existing license from the cache it may not have installationName set.  In this case we should show the installationId.
1. Set `IS_CLOUD=false` `LICENSE_KEY=<dev license key to dev server>` `MULTI_ORG=false`.  
2. Restart the server.
3. In mongo growthbook.licenses delete the installationName's that are set in the cache.
5. Go to http://localhost:3000/settings and see that the chart defaults to the installationIds.
6. Click on Edit Organization and see no installation name setting.

#### remote license multi- installation
1. click Refresh button in the license section.  This will send the org name as the installation to the license server and then return it.
2. see the chart with the current installation showing the current org name.
3. Click "Edit" in Organization settings.
4. Change the name of the current org.
5. See the chart get immediately updated with the new organization name for the current installation
6. In Mongo see that no default installation.name got save on the installation object. (this doesn't really matter now but early versions of the code defaulted to this value even if `IS_MULTI_ORG` was `false`)

#### remote license multi- installation with multi-org at an installation.
The license information is on the /admin page for multi-org installations.  It uses the installation.name for installationName and installation.id as the default.
1. Set `IS_CLOUD=false` `LICENSE_KEY=<dev license key to dev server>` `MULTI_ORG=true`.
2. Restart the server.  
3.  Go to http://localhost:3000/admin
4. Click the Refresh license button.
5. See the installation id for the name of the current installation.
7. Go to http://localhost:3000/settings
8. See installation name in the organization settings, having the default being the installationId.
9. Click "Edit" in Organization settings.
10. Change the installation name of the current org.
11.  Go to http://localhost:3000/admin
12. See the installation name in the chart updated to what was entered in the form.


### Screenshots
Single installation && cloud data:
<img width="1328" height="344" alt="Screenshot 2025-09-18 at 4 26 05 PM" src="https://github.com/user-attachments/assets/c237ec56-f3ef-453c-9cbf-b999f1251632" />

Multi installation chart:
<img width="1356" height="525" alt="Screenshot 2025-09-18 at 4 24 55 PM" src="https://github.com/user-attachments/assets/9d89f530-eac0-4830-a468-be73ec18c077" />

Multi-org multi-installation:
Organization settings with installation name
<img width="1360" height="258" alt="Screenshot 2025-09-18 at 5 22 47 PM" src="https://github.com/user-attachments/assets/e971f1e4-a0f2-45e1-8574-3b3f950ddffd" />
Edit org settings with installation name
<img width="526" height="419" alt="Screenshot 2025-09-18 at 5 22 54 PM" src="https://github.com/user-attachments/assets/9072e38d-3ec8-4826-9ca8-60d981617343" />
Admin page showing license info
<img width="1394" height="403" alt="Screenshot 2025-09-18 at 4 52 44 PM" src="https://github.com/user-attachments/assets/54b6429d-f924-4692-befd-20d428b357ea" />
