### PR TITLE
fix(api): Fix incorrect Fact Metric window defaults

### DIFF
--- a/packages/back-end/src/api/fact-metrics/postFactMetric.ts
+++ b/packages/back-end/src/api/fact-metrics/postFactMetric.ts
@@ -121,15 +121,13 @@ export async function getCreateMetricPropsFromBody(
     inverse: false,
     quantileSettings: quantileSettings ?? null,
     windowSettings: {
-      type: scopedSettings.windowType.value ?? DEFAULT_FACT_METRIC_WINDOW,
+      type: DEFAULT_FACT_METRIC_WINDOW,
       delayValue:
         windowSettings?.delayValue ??
         windowSettings?.delayHours ??
-        scopedSettings.delayHours.value ??
         DEFAULT_METRIC_WINDOW_DELAY_HOURS,
       delayUnit: windowSettings?.delayUnit ?? "hours",
-      windowValue:
-        scopedSettings.windowHours.value ?? DEFAULT_METRIC_WINDOW_HOURS,
+      windowValue: DEFAULT_METRIC_WINDOW_HOURS,
       windowUnit: "hours",
     },
     cappingSettings: {


### PR DESCRIPTION
### Features and Changes

We were inappropriately using `scopedSettings` for a few of our fact metric creation API defaults. This made no sense since scopedSettings window fields are for resolving metric overrides, not org defaults.

In any case, there is no such thing as a org or project level default for window type or window, only our hard coded GrowthBook defaults. If we change those defaults then we'll need to update these endpoints again, but for now we should just rely on the hardcoded defaults if there is nothing in the payload.

- Closes #4589 

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

Via Hoppscotch created metrics with all different window types (including no field) and window values and all were created as expected.

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
