### PR TITLE
Minor fixes to styles on home page and presentations

### DIFF
--- a/packages/front-end/components/Features/FeaturesHeader.tsx
+++ b/packages/front-end/components/Features/FeaturesHeader.tsx
@@ -127,8 +127,8 @@ export default function FeaturesHeader({
           )}
 
           <Flex align="center" justify="between">
-            <Flex align="center">
-              <Heading size="7" as="h1">
+            <Flex align="center" mb="2">
+              <Heading size="7" as="h1" mb="0">
                 {feature.id}
               </Heading>
               {stale && (

--- a/packages/front-end/components/GetStarted/NeedingAttention.module.scss
+++ b/packages/front-end/components/GetStarted/NeedingAttention.module.scss
@@ -26,12 +26,3 @@
     max-width: 150px;
   }
 }
-
-.needs-attentions-table {
-  thead th {
-    font-weight: 600;
-  }
-  tbody td {
-    font-weight: 400;
-  }
-}

--- a/packages/front-end/components/GetStarted/NeedingAttention.tsx
+++ b/packages/front-end/components/GetStarted/NeedingAttention.tsx
@@ -369,7 +369,7 @@ const NeedingAttention = (): React.ReactElement | null => {
           />
         </Flex>
         {experimentsNeedingAttention.length > 0 ? (
-          <table className="table gbtable needs-attentions-table mt-3">
+          <table className="table gbtable needs-attentions-table mt-3 rounded-table">
             <thead>
               <tr>
                 <SortableTHExperiments field="name">Name</SortableTHExperiments>
@@ -493,7 +493,7 @@ const NeedingAttention = (): React.ReactElement | null => {
         </Flex>
         {featureFlagsNeedingAttention.length > 0 ? (
           <table
-            className={`table gbtable mt-3 ${styles.needsAttentionsTable}`}
+            className={`table gbtable mt-3 needs-attentions-table rounded-table`}
           >
             <thead>
               <tr>

--- a/packages/front-end/pages/presentations.tsx
+++ b/packages/front-end/pages/presentations.tsx
@@ -137,7 +137,7 @@ const PresentationPage = (): React.ReactElement => {
     presList = [];
     p.presentations.map((pres, i) => {
       presList.push(
-        <Card className="card" key={`pres-exp-${i}`} mb="3">
+        <Card key={`pres-exp-${i}`} mb="3">
           <Flex p="2" gap="2">
             <div className="col flex-grow-1">
               <h4 className="mb-0">{pres.title}</h4>

--- a/packages/front-end/styles/global.scss
+++ b/packages/front-end/styles/global.scss
@@ -1407,7 +1407,7 @@ main.main {
 // Required for the collapsible component to work correctly with lazyRender={true} - https://github.com/glennflanagan/react-collapsible/issues/36
 .Collapsible__contentInner {
   border: 1px solid transparent;
-  }
+}
 
 .Collapsible__trigger {
   &:hover {
@@ -3713,7 +3713,13 @@ input:disabled {
     font-weight: 400;
   }
 }
-
+.rounded-table {
+  border-radius: 0.33rem;
+  overflow: hidden;
+  border-spacing: 0;
+  border-collapse: separate;
+  border: 1px solid var(--slate-a6);
+}
 .border-violet {
   border-color: var(--violet-a7);
 }


### PR DESCRIPTION
Adds a subtle border around the home page tables. Fixes the double border around the presentations. Aligned the icons heading on the feature details page correctly. 