### PR TITLE
fix: scripts with broken imports

### DIFF
--- a/packages/back-end/src/scripts/generate-openapi.mjs
+++ b/packages/back-end/src/scripts/generate-openapi.mjs
@@ -36,14 +36,14 @@ async function run() {
   // Step 3: Add additional named types for easier access
   // Export each schema as a named type
   output += `import { z } from "zod";\n`;
-  output += `import * as openApiValidators from "back-end/src/validators/openapi";\n`;
+  output += `import * as openApiValidators from "../src/validators/openapi";\n`;
   output += "\n// Schemas\n";
   Object.keys(api.components.schemas).forEach((k) => {
     // Zod validator for response body
     validators.push(
       `export const api${k}Validator = ${generateZodSchema(
-        api.components.schemas[k]
-      )}`
+        api.components.schemas[k],
+      )}`,
     );
 
     output += `export type Api${k} = z.infer<typeof openApiValidators.api${k}Validator>;\n`;
@@ -72,7 +72,7 @@ async function run() {
   bodySchema: ${generateZodSchema(requestSchema, false)},
   querySchema: ${generateZodSchema(querySchema)},
   paramsSchema: ${generateZodSchema(pathSchema)},
-};`
+};`,
         );
       }
     });
@@ -81,13 +81,13 @@ async function run() {
   // Step 4: Persist specs and generated files to file system
   fs.writeFileSync(
     path.join(__dirname, "..", "..", "types", "openapi.d.ts"),
-    output
+    output,
   );
   fs.writeFileSync(
     path.join(__dirname, "..", "..", "src", "validators", "openapi.ts"),
     generatedFileHeader +
       `import { z } from "zod";\n\n` +
-      validators.join("\n\n")
+      validators.join("\n\n"),
   );
 }
 

--- a/packages/back-end/src/scripts/migrate-encryption-key.ts
+++ b/packages/back-end/src/scripts/migrate-encryption-key.ts
@@ -2,12 +2,12 @@ import { AES, enc } from "crypto-js";
 import {
   updateDataSource,
   _dangerousGetAllDatasources,
-} from "back-end/src/models/DataSourceModel";
-import { usingFileConfig } from "back-end/src/init/config";
-import { ENCRYPTION_KEY, IS_CLOUD } from "back-end/src/util/secrets";
-import { init } from "back-end/src/init";
-import { encryptParams } from "back-end/src/services/datasource";
-import { getContextForAgendaJobByOrgId } from "back-end/src/services/organizations";
+} from "../models/DataSourceModel";
+import { usingFileConfig } from "../init/config";
+import { ENCRYPTION_KEY, IS_CLOUD } from "../util/secrets";
+import { init } from "../init";
+import { encryptParams } from "../services/datasource";
+import { getContextForAgendaJobByOrgId } from "../services/organizations";
 
 const [oldEncryptionKey] = process.argv.slice(2);
 if (IS_CLOUD) {


### PR DESCRIPTION
### Features and Changes

In [3032](https://github.com/growthbook/growthbook/pull/3032/files#diff-aced234513c165040ff4f4379947036186aeef52210bfbfa71d1a3cd1d2369d9) we wholesale moved from relative imports to absolute. That kills scripts when called from docker.

- Closes 
https://github.com/growthbook/growthbook/issues/3986

### Testing
a bit annoying to test as I'd have to rebuild docker image, but this just reverts changes in 3032 so this should be safe.
