### PR TITLE
fix: prevent datasources with null UserIdType from killing the UI

### DIFF
--- a/packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentifierTypes/DataSourceInlineEditIdentifierTypes.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentifierTypes/DataSourceInlineEditIdentifierTypes.tsx
@@ -26,7 +26,8 @@ export const DataSourceInlineEditIdentifierTypes: FC<
   canEdit = canEdit && permissionsUtil.canUpdateDataSourceSettings(dataSource);
 
   const userIdTypes = useMemo(
-    () => dataSource.settings?.userIdTypes || [],
+    () =>
+      (dataSource.settings?.userIdTypes || []).filter((type) => type != null),
     [dataSource.settings?.userIdTypes],
   );
 


### PR DESCRIPTION
### Features and Changes

Somehow a [user](https://growthbookapp.slack.com/archives/C05QYS2UFRD/p1758540063742019) got into the state with a userIdType of null.  It crashed the UI so they couldn't delete the datasource.  They shouldn't get into that state, but this at least shows it.  

### Testing

Create a datasource and manually set a userIdType to null. See the datasource page load.
