### PR TITLE
Fix dashboard metric timeseries

### DIFF
--- a/packages/front-end/components/Experiment/BreakDownResults.tsx
+++ b/packages/front-end/components/Experiment/BreakDownResults.tsx
@@ -76,6 +76,7 @@ type TableDef = {
 };
 
 const BreakDownResults: FC<{
+  experimentId: string;
   results: ExperimentReportResultDimension[];
   queryStatusData?: QueryStatusData;
   variations: ExperimentReportVariation[];
@@ -113,6 +114,7 @@ const BreakDownResults: FC<{
   ) => React.ReactElement | string;
   noStickyHeader?: boolean;
 }> = ({
+  experimentId,
   dimensionId,
   dimensionValuesFilter,
   results,
@@ -394,6 +396,7 @@ const BreakDownResults: FC<{
             </h5>
             <ResultsTable
               key={i}
+              experimentId={experimentId}
               dateCreated={reportDate}
               isLatestPhase={isLatestPhase}
               phase={phase}

--- a/packages/front-end/components/Experiment/CompactResults.tsx
+++ b/packages/front-end/components/Experiment/CompactResults.tsx
@@ -54,6 +54,7 @@ import { ExperimentTab } from "./TabbedPage";
 const numberFormatter = Intl.NumberFormat();
 
 const CompactResults: FC<{
+  experimentId: string;
   editMetrics?: () => void;
   variations: ExperimentReportVariation[];
   variationFilter?: number[];
@@ -90,6 +91,7 @@ const CompactResults: FC<{
   hideDetails?: boolean;
   disableTimeSeriesButton?: boolean;
 }> = ({
+  experimentId,
   editMetrics,
   variations,
   variationFilter,
@@ -345,6 +347,7 @@ const CompactResults: FC<{
 
       {expandedGoals.length ? (
         <ResultsTable
+          experimentId={experimentId}
           dateCreated={reportDate}
           isLatestPhase={isLatestPhase}
           phase={phase}
@@ -399,6 +402,7 @@ const CompactResults: FC<{
       {!mainTableOnly && expandedSecondaries.length ? (
         <div className="mt-4">
           <ResultsTable
+            experimentId={experimentId}
             dateCreated={reportDate}
             isLatestPhase={isLatestPhase}
             phase={phase}
@@ -440,6 +444,7 @@ const CompactResults: FC<{
       {!mainTableOnly && expandedGuardrails.length ? (
         <div className="mt-4">
           <ResultsTable
+            experimentId={experimentId}
             dateCreated={reportDate}
             isLatestPhase={isLatestPhase}
             phase={phase}

--- a/packages/front-end/components/Experiment/Public/PublicExperimentResults.tsx
+++ b/packages/front-end/components/Experiment/Public/PublicExperimentResults.tsx
@@ -132,6 +132,7 @@ export default function PublicExperimentResults({
               />
             ) : showBreakDownResults ? (
               <BreakDownResults
+                experimentId={experiment.id}
                 key={snapshot.dimension}
                 results={analysis?.results ?? []}
                 queryStatusData={queryStatusData}
@@ -160,6 +161,7 @@ export default function PublicExperimentResults({
               />
             ) : showCompactResults ? (
               <CompactResults
+                experimentId={experiment.id}
                 variations={variations}
                 multipleExposures={snapshot.multipleExposures || 0}
                 results={analysis.results[0]}

--- a/packages/front-end/components/Experiment/Results.tsx
+++ b/packages/front-end/components/Experiment/Results.tsx
@@ -331,6 +331,7 @@ const Results: FC<{
         />
       ) : showBreakDownResults && snapshot ? (
         <BreakDownResults
+          experimentId={experiment.id}
           key={analysis?.settings?.dimensions?.[0] ?? snapshot.dimension}
           results={analysis?.results ?? []}
           queryStatusData={queryStatusData}
@@ -374,6 +375,7 @@ const Results: FC<{
             </div>
           )}
           <CompactResults
+            experimentId={experiment.id}
             editMetrics={editMetrics}
             variations={variations}
             variationFilter={analysisBarSettings.variationFilter}

--- a/packages/front-end/components/Experiment/ResultsTable.tsx
+++ b/packages/front-end/components/Experiment/ResultsTable.tsx
@@ -67,6 +67,7 @@ import styles from "./ResultsTable.module.scss";
 
 export type ResultsTableProps = {
   id: string;
+  experimentId: string;
   variations: ExperimentReportVariation[];
   variationFilter?: number[];
   baselineRow?: number;
@@ -130,6 +131,7 @@ const percentFormatter = new Intl.NumberFormat(undefined, {
 
 export default function ResultsTable({
   id,
+  experimentId,
   isLatestPhase,
   phase,
   status,
@@ -1115,7 +1117,7 @@ export default function ResultsTable({
                         <div className={styles.expandAnimation}>
                           <div className={styles.timeSeriesCell}>
                             <ExperimentMetricTimeSeriesGraphWrapper
-                              experimentId={id}
+                              experimentId={experimentId}
                               phase={phase}
                               experimentStatus={status}
                               metric={row.metric}

--- a/packages/front-end/components/Report/LegacyReportPage.tsx
+++ b/packages/front-end/components/Report/LegacyReportPage.tsx
@@ -494,6 +494,7 @@ export default function LegacyReportPage({
                   />
                 ) : (
                   <BreakDownResults
+                    experimentId={report.experimentId ?? ""}
                     isLatestPhase={true}
                     phase={
                       (experimentData?.experiment?.phases?.length ?? 1) - 1
@@ -568,6 +569,7 @@ export default function LegacyReportPage({
                 report.results?.dimensions?.[0] !== undefined && (
                   <div className="mt-0 mb-3">
                     <CompactResults
+                      experimentId={report.experimentId ?? ""}
                       variations={variations}
                       multipleExposures={report.results?.multipleExposures || 0}
                       results={report.results?.dimensions?.[0]}

--- a/packages/front-end/components/Report/ReportResults.tsx
+++ b/packages/front-end/components/Report/ReportResults.tsx
@@ -182,6 +182,7 @@ export default function ReportResults({
               />
             ) : showBreakDownResults ? (
               <BreakDownResults
+                experimentId={snapshot.experiment}
                 key={snapshot.dimension}
                 results={analysis?.results ?? []}
                 queryStatusData={queryStatusData}
@@ -226,6 +227,7 @@ export default function ReportResults({
               />
             ) : showCompactResults ? (
               <CompactResults
+                experimentId={snapshot.experiment}
                 variations={variations}
                 multipleExposures={snapshot.multipleExposures || 0}
                 results={analysis.results[0]}

--- a/packages/front-end/components/Share/Presentation.tsx
+++ b/packages/front-end/components/Share/Presentation.tsx
@@ -281,6 +281,7 @@ const Presentation = ({
             }}
           >
             <CompactResults
+              experimentId={experiment.id}
               variations={experiment.variations.map((v, i) => {
                 return {
                   id: v.key || i + "",

--- a/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardBlock/ExperimentDimensionBlock.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardBlock/ExperimentDimensionBlock.tsx
@@ -110,6 +110,7 @@ export default function ExperimentDimensionBlock({
 
   return (
     <BreakDownResults
+      experimentId={experiment.id}
       noStickyHeader
       idPrefix={blockId}
       key={snapshot.dimension}

--- a/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardBlock/ExperimentMetricBlock.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardBlock/ExperimentMetricBlock.tsx
@@ -158,6 +158,7 @@ export default function ExperimentMetricBlock({
           noStickyHeader
           key={resultGroup}
           id={blockId}
+          experimentId={experiment.id}
           phase={experiment.phases.length - 1}
           variations={variations}
           variationFilter={variationFilter}


### PR DESCRIPTION
### Features and Changes

Fixes the timeseries button within dashboard metric blocks by explicitly passing the experiment ID through all of the result table components.

### Testing

Create a dashboard with a metric block and make sure that the timeseries can render
Also check the timeseries block type and the results tab to make sure they're unaffected

### Screenshots

<img width="1968" height="787" alt="image" src="https://github.com/user-attachments/assets/bd8e160b-9af7-42fc-a7fd-ebdcf8dbe8d9" />
