### PR TITLE
fix(holdouts): Use correct holdoutId when redirecting holdouts that land on experiments path

### DIFF
--- a/packages/front-end/hooks/useHoldouts.ts
+++ b/packages/front-end/hooks/useHoldouts.ts
@@ -30,12 +30,18 @@ export function useHoldouts(
     [experiments],
   );
 
+  const experimentToHoldoutsMap = useMemo(
+    () => new Map(holdouts.map((h) => [h.experimentId, h])),
+    [holdouts],
+  );
+
   return {
     loading: !error && !data,
     holdouts: holdouts,
     holdoutsMap,
     experiments,
     experimentsMap,
+    experimentToHoldoutsMap,
     error: error,
     mutateHoldouts: mutate,
     hasArchived: data?.hasArchived || false,

--- a/packages/front-end/pages/experiment/[eid].tsx
+++ b/packages/front-end/pages/experiment/[eid].tsx
@@ -26,6 +26,7 @@ import TabbedPage from "@/components/Experiment/TabbedPage";
 import PageHead from "@/components/Layout/PageHead";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 import { useRunningExperimentStatus } from "@/hooks/useExperimentStatusIndicator";
+import { useHoldouts } from "@/hooks/useHoldouts";
 
 const ExperimentPage = (): ReactElement => {
   const permissionsUtil = usePermissionsUtil();
@@ -65,19 +66,22 @@ const ExperimentPage = (): ReactElement => {
 
   const { apiCall } = useAuth();
 
+  const { experimentToHoldoutsMap } = useHoldouts();
+
   useEffect(() => {
     if (data?.experiment?.type === "multi-armed-bandit") {
       router.replace(window.location.href.replace("experiment/", "bandit/"));
     }
     if (data?.experiment?.type === "holdout") {
+      const holdoutId = experimentToHoldoutsMap.get(data?.experiment?.id)?.id;
       let url = window.location.href.replace(
         /(.*)\/experiment\/.*/,
         "$1/holdout/",
       );
-      url += data?.experiment?.holdoutId;
+      url += holdoutId;
       router.replace(url);
     }
-  }, [data, router]);
+  }, [data, experimentToHoldoutsMap, router]);
 
   if (error) {
     return <div>There was a problem loading the experiment</div>;


### PR DESCRIPTION
### Features and Changes

When redirecting holdouts that land on `/experiment/${id}` we were using `holdoutId` from the `ExperimentInterface` which corresponds to the id of the holdout an experiment belongs to (if applicable). Instead we should find the experiment's parent holdout object and use its id for the redirect.

