### PR TITLE
Org setting to block all file uploads

### DIFF
--- a/packages/back-end/src/routers/upload/upload.controller.ts
+++ b/packages/back-end/src/routers/upload/upload.controller.ts
@@ -45,6 +45,10 @@ export async function putUpload(
   const contentType = req.headers["content-type"] as string;
   const context = getContextFromReq(req);
 
+  if (context.org.settings?.blockFileUploads) {
+    throw new Error("File uploads are disabled for this organization");
+  }
+
   // The user can upload images if they have permission to add comments globally, or in atleast 1 project
   if (!context.permissions.canAddComment([])) {
     context.permissions.throwPermissionError();
@@ -59,10 +63,9 @@ export async function putUpload(
   }
 
   const ext = mimetypes[contentType];
-  const { org } = getContextFromReq(req);
 
   const now = new Date();
-  const pathPrefix = `${org.id}/${now.toISOString().substr(0, 7)}/`;
+  const pathPrefix = `${context.org.id}/${now.toISOString().substr(0, 7)}/`;
   const fileName = "img_" + uuidv4();
   const filePath = `${pathPrefix}${fileName}.${ext}`;
   const fileURL = await uploadFile(filePath, contentType, req.body);
@@ -75,6 +78,10 @@ export async function putUpload(
 
 export function getImage(req: AuthRequest<{ path: string }>, res: Response) {
   const { org } = getContextFromReq(req);
+
+  if (org.settings?.blockFileUploads) {
+    throw new Error("File uploads are disabled for this organization");
+  }
 
   const path = req.path[0] === "/" ? req.path.substr(1) : req.path;
 
@@ -102,6 +109,10 @@ export async function getSignedImageToken(
 ) {
   const { org } = getContextFromReq(req);
 
+  if (org.settings?.blockFileUploads) {
+    throw new Error("File uploads are disabled for this organization");
+  }
+
   const fullPath = req.path.substring("/signed-url/".length);
 
   const orgFromPath = fullPath.split("/")[0];
@@ -128,6 +139,10 @@ export async function getSignedUploadToken(
 ) {
   const context = getContextFromReq(req);
   const { org } = getContextFromReq(req);
+
+  if (org.settings?.blockFileUploads) {
+    throw new Error("File uploads are disabled for this organization");
+  }
 
   // The user can upload images if they have permission to add comments globally, or in at least 1 project
   if (!context.permissions.canAddComment([])) {

--- a/packages/back-end/types/organization.d.ts
+++ b/packages/back-end/types/organization.d.ts
@@ -253,6 +253,7 @@ export interface OrganizationSettings {
   experimentMaxLengthDays?: number;
   decisionFrameworkEnabled?: boolean;
   defaultDecisionCriteriaId?: string;
+  blockFileUploads?: boolean;
 }
 
 export interface OrganizationConnections {

--- a/packages/front-end/components/Experiment/VariationsTable.tsx
+++ b/packages/front-end/components/Experiment/VariationsTable.tsx
@@ -12,6 +12,7 @@ import ScreenshotUpload from "@/components/EditExperiment/ScreenshotUpload";
 import AuthorizedImage from "@/components/AuthorizedImage";
 import Button from "@/ui/Button";
 import ExperimentCarouselModal from "@/components/Experiment/ExperimentCarouselModal";
+import useOrgSettings from "@/hooks/useOrgSettings";
 
 const imageCache = {};
 
@@ -132,6 +133,8 @@ export function VariationBox({
   percent?: number;
   minWidth?: string | number;
 }) {
+  const { blockFileUploads } = useOrgSettings();
+
   return (
     <Box
       key={i}
@@ -178,7 +181,7 @@ export function VariationBox({
                 />
               ) : (
                 <>
-                  {canEdit ? (
+                  {canEdit && !blockFileUploads ? (
                     <>
                       <ScreenshotUpload
                         variation={i}
@@ -214,7 +217,7 @@ export function VariationBox({
                     {v.screenshots.length > 1 ? "s" : ""}
                   </Text>
                 ) : null}
-                {canEdit && (
+                {canEdit && !blockFileUploads && (
                   <div>
                     <ScreenshotUpload
                       variation={i}

--- a/packages/front-end/components/Markdown/MarkdownInput.tsx
+++ b/packages/front-end/components/Markdown/MarkdownInput.tsx
@@ -17,7 +17,7 @@ import { useAuth } from "@/services/auth";
 import { uploadFile } from "@/services/files";
 import LoadingOverlay from "@/components/LoadingOverlay";
 import Button from "@/ui/Button";
-import { useAISettings } from "@/hooks/useOrgSettings";
+import useOrgSettings, { useAISettings } from "@/hooks/useOrgSettings";
 import OptInModal from "@/components/License/OptInModal";
 import Tooltip from "@/components/Tooltip/Tooltip";
 import { useUser } from "@/services/UserContext";
@@ -74,6 +74,7 @@ const MarkdownInput: FC<{
   const [revertValue, setRevertValue] = useState<string | null>(null);
   const { hasCommercialFeature } = useUser();
   const hasAISuggestions = hasCommercialFeature("ai-suggestions");
+  const { blockFileUploads } = useOrgSettings();
 
   const [aiAgreementModal, setAiAgreementModal] = useState(false);
   useEffect(() => {
@@ -83,6 +84,8 @@ const MarkdownInput: FC<{
   }, [autofocus, textareaRef.current]);
 
   const onDrop = (files: File[]) => {
+    if (blockFileUploads) return;
+
     setUploading(true);
     const toAdd: string[] = [];
     const promises = Promise.all(
@@ -208,8 +211,9 @@ const MarkdownInput: FC<{
                   },
                 }}
               />
+
               {uploading && <LoadingOverlay />}
-              <input {...getInputProps()} />
+              {!blockFileUploads && <input {...getInputProps()} />}
               <div className="cursor-pointer py-1 px-2 border rounded-bottom mb-2 bg-light">
                 <a
                   href="https://guides.github.com/features/mastering-markdown/"
@@ -224,9 +228,12 @@ const MarkdownInput: FC<{
                 >
                   <FaMarkdown />
                 </a>
-                <div className="small text-muted" onClick={open}>
-                  Upload images by dragging &amp; dropping or clicking here{" "}
-                </div>
+                {!blockFileUploads && (
+                  <div className="small text-muted" onClick={open}>
+                    Upload images by dragging &amp; dropping or clicking
+                    here{" "}
+                  </div>
+                )}
               </div>
             </div>
             {showButtons && (

--- a/packages/front-end/components/Markdown/MarkdownInput.tsx
+++ b/packages/front-end/components/Markdown/MarkdownInput.tsx
@@ -213,28 +213,30 @@ const MarkdownInput: FC<{
               />
 
               {uploading && <LoadingOverlay />}
-              {!blockFileUploads && <input {...getInputProps()} />}
-              <div className="cursor-pointer py-1 px-2 border rounded-bottom mb-2 bg-light">
-                <a
-                  href="https://guides.github.com/features/mastering-markdown/"
-                  target="_blank"
-                  rel="noreferrer"
-                  className="text-dark float-right"
-                  style={{
-                    fontSize: "1.2em",
-                    lineHeight: "1em",
-                  }}
-                  title="Github-flavored Markdown is supported"
-                >
-                  <FaMarkdown />
-                </a>
-                {!blockFileUploads && (
-                  <div className="small text-muted" onClick={open}>
-                    Upload images by dragging &amp; dropping or clicking
-                    here{" "}
+              {!blockFileUploads && (
+                <>
+                  <input {...getInputProps()} />
+                  <div className="cursor-pointer py-1 px-2 border rounded-bottom mb-2 bg-light">
+                    <a
+                      href="https://guides.github.com/features/mastering-markdown/"
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-dark float-right"
+                      style={{
+                        fontSize: "1.2em",
+                        lineHeight: "1em",
+                      }}
+                      title="Github-flavored Markdown is supported"
+                    >
+                      <FaMarkdown />
+                    </a>
+                    <div className="small text-muted" onClick={open}>
+                      Upload images by dragging &amp; dropping or clicking
+                      here{" "}
+                    </div>
                   </div>
-                )}
-              </div>
+                </>
+              )}
             </div>
             {showButtons && (
               <div className="row">

--- a/packages/front-end/pages/settings/index.tsx
+++ b/packages/front-end/pages/settings/index.tsx
@@ -162,6 +162,7 @@ const GeneralSettingsPage = (): React.ReactElement => {
         settings.decisionFrameworkEnabled ?? DEFAULT_DECISION_FRAMEWORK_ENABLED,
       defaultDecisionCriteriaId:
         settings.defaultDecisionCriteriaId ?? PRESET_DECISION_CRITERIA.id,
+      blockFileUploads: settings.blockFileUploads ?? false,
       requireProjectForFeatures:
         settings.requireProjectForFeatures ??
         DEFAULT_REQUIRE_PROJECT_FOR_FEATURES,


### PR DESCRIPTION
### Features and Changes

Some organizations may want to prevent all file uploads within GrowthBook (e.g. adding screenshots to experiments).  This PR adds an organization setting for this.

There is no way to enable this in the UI, so it must be turned on directly in the database (or via config.yml when self-hosting).