### PR TITLE
feat(dimensions): Add job to refresh precomputed dimensions traffic data

### DIFF
--- a/packages/back-end/src/init/queue.ts
+++ b/packages/back-end/src/init/queue.ts
@@ -18,6 +18,7 @@ import updateLicenseJob, {
 import deleteOldAgendaJobs from "back-end/src/jobs/deleteOldAgendaJobs";
 import { logger } from "back-end/src/util/logger";
 import addSafeRolloutSnapshotJob from "back-end/src/jobs/addSafeRolloutSnapshotJob";
+import updateExposureQueriesDimensionSlicesJob from "back-end/src/jobs/updateExposureQueriesDimensionSlices";
 
 export async function queueInit() {
   const agenda = getAgendaInstance();
@@ -36,6 +37,7 @@ export async function queueInit() {
   addSdkWebhooksJob(agenda);
   updateLicenseJob(agenda);
   addSafeRolloutSnapshotJob(agenda);
+  updateExposureQueriesDimensionSlicesJob(agenda);
 
   // Make sure we have index needed to delete efficiently
   agenda._collection

--- a/packages/back-end/src/jobs/updateExposureQueriesDimensionSlices.ts
+++ b/packages/back-end/src/jobs/updateExposureQueriesDimensionSlices.ts
@@ -1,0 +1,266 @@
+import Agenda, { Job } from "agenda";
+import { subDays } from "date-fns";
+import { logger } from "back-end/src/util/logger";
+import { getContextForAgendaJobByOrgId } from "back-end/src/services/organizations";
+import {
+  _dangerousGetAllDatasourcesWithExposureQueriesWithAutomaticDimensionSlices,
+  getDataSourceById,
+  updateDataSource,
+} from "back-end/src/models/DataSourceModel";
+import { usingFileConfig } from "back-end/src/init/config";
+import { getIntegrationFromDatasourceId } from "back-end/src/services/datasource";
+import {
+  createDimensionSlices,
+  _dangerousGetAllDimensionSlicesByIds,
+} from "back-end/src/models/DimensionSlicesModel";
+import { DimensionSlicesQueryRunner } from "back-end/src/queryRunners/DimensionSlicesQueryRunner";
+
+const QUEUE_EXPOSURE_QUERIES_DIMENSION_SLICES_UPDATES =
+  "queueExposureQueriesDimensionSlicesUpdates";
+
+const UPDATE_SINGLE_DATASOURCE_EXPOSURE_QUERIES_DIMENSION_SLICES =
+  "updateSingleExposureQueryDimensionSlices";
+
+const DEFAULT_LOOKBACK_DAYS = 30;
+
+type UpdateSingleJobParams = {
+  organizationId: string;
+  dataSourceId: string;
+  exposureQueryIds: string[];
+};
+
+export default async function (agenda: Agenda) {
+  agenda.define(QUEUE_EXPOSURE_QUERIES_DIMENSION_SLICES_UPDATES, async () => {
+    const exposureQueriesToUpdate =
+      await getDataSourcesWithExposureQueriesToUpdate();
+
+    for (const jobParams of exposureQueriesToUpdate) {
+      await queueExposureQueriesDimensionSlicesUpdate(jobParams);
+    }
+  });
+
+  agenda.define(
+    UPDATE_SINGLE_DATASOURCE_EXPOSURE_QUERIES_DIMENSION_SLICES,
+    updateSingleDatasourceExposureQueriesDimensionSlices,
+  );
+
+  // Don't schedule automatic updates if using file config
+  if (usingFileConfig()) return;
+
+  await startUpdateJob();
+
+  async function startUpdateJob() {
+    const job = agenda.create(
+      QUEUE_EXPOSURE_QUERIES_DIMENSION_SLICES_UPDATES,
+      {},
+    );
+    job.unique({});
+    job.repeatEvery("1 day");
+    await job.save();
+  }
+
+  async function queueExposureQueriesDimensionSlicesUpdate(
+    jobParams: UpdateSingleJobParams,
+  ) {
+    logger.info(
+      {
+        dataSourceId: jobParams.dataSourceId,
+        exposureQueryIds: jobParams.exposureQueryIds,
+      },
+      "Queuing dimension slices update",
+    );
+
+    const job = agenda.create(
+      UPDATE_SINGLE_DATASOURCE_EXPOSURE_QUERIES_DIMENSION_SLICES,
+      jobParams,
+    );
+    job.unique({
+      organizationId: jobParams.organizationId,
+      dataSourceId: jobParams.dataSourceId,
+    });
+    job.schedule(new Date());
+    await job.save();
+  }
+}
+
+async function getDataSourcesWithExposureQueriesToUpdate(): Promise<
+  UpdateSingleJobParams[]
+> {
+  try {
+    const potentialDataSourcesToUpdate =
+      await _dangerousGetAllDatasourcesWithExposureQueriesWithAutomaticDimensionSlices();
+
+    // Include only exposure queries that have at least one non-custom slice
+    const dataSourcesAndExposureQueries = potentialDataSourcesToUpdate
+      .map((ds) => {
+        const exposureQueries = ds.settings?.queries?.exposure || [];
+        const queriesWithAutomaticDimensionSlices = exposureQueries.filter(
+          (eq) => eq.dimensionMetadata?.some((m) => m.customSlices === false),
+        );
+
+        if (queriesWithAutomaticDimensionSlices.length > 0) {
+          return {
+            dataSource: ds,
+            exposureQueries: queriesWithAutomaticDimensionSlices,
+          };
+        }
+      })
+      .filter((x) => x !== undefined);
+
+    const existingDimensionSlicesIds = dataSourcesAndExposureQueries
+      .flatMap((x) => x.exposureQueries.map((eq) => eq.dimensionSlicesId))
+      .filter((id) => id !== undefined);
+
+    const dimensionSlices = await _dangerousGetAllDimensionSlicesByIds(
+      existingDimensionSlicesIds,
+      subDays(new Date(), 7),
+    );
+    const dimensionSlicesMap = new Map(
+      dimensionSlices.map((ds) => [ds.id, ds]),
+    );
+
+    // Filter exposure queries based on dimension slices criteria
+    const dataSourcesAndExposureQueryIdsMap = dataSourcesAndExposureQueries
+      .map(({ dataSource, exposureQueries }) => {
+        const filteredExposureQueries = exposureQueries.filter((eq) => {
+          // If the exposureQuery does not have a dimensionSlicesId defined, it should be included
+          if (!eq.dimensionSlicesId) {
+            return true;
+          }
+
+          // If it does have a dimensionSliceId but no dimensionSlice was returned from _dangerousGetAllDimensionSlicesByIds,
+          // it should be skipped as the Date filter makes it ineligible for the automatic update
+          return dimensionSlicesMap.has(eq.dimensionSlicesId);
+        });
+
+        // If we filter out all exposureQueries for a given data source then we should also not even return the data source
+        if (filteredExposureQueries.length === 0) {
+          return null;
+        }
+
+        return {
+          organizationId: dataSource.organization,
+          dataSourceId: dataSource.id,
+          exposureQueryIds: filteredExposureQueries.map((eq) => eq.id),
+        };
+      })
+      .filter((x) => x !== null);
+
+    return dataSourcesAndExposureQueryIdsMap;
+  } catch (e) {
+    // Silently fail as this is not critical -- but log it so we can fix it
+    logger.error(e, "Failed to queue dimension slices updates");
+    return [];
+  }
+}
+
+const updateSingleDatasourceExposureQueriesDimensionSlices = async (
+  job: Job<{
+    organizationId: string;
+    dataSourceId: string;
+    exposureQueryIds: string[];
+  }>,
+) => {
+  const organizationId = job.attrs.data?.organizationId;
+  const dataSourceId = job.attrs.data?.dataSourceId;
+  const exposureQueryIds = job.attrs.data?.exposureQueryIds;
+
+  if (
+    !organizationId ||
+    !dataSourceId ||
+    !exposureQueryIds ||
+    !exposureQueryIds.length
+  ) {
+    logger.warn(
+      {
+        organizationId,
+        dataSourceId,
+        exposureQueryIds,
+      },
+      "Invalid job parameters for dimension slices update",
+    );
+    return;
+  }
+
+  const context = await getContextForAgendaJobByOrgId(organizationId);
+  const dataSource = await getDataSourceById(context, dataSourceId);
+  if (!dataSource) {
+    logger.warn(
+      `Data source ${dataSourceId} not found for dimension slices update`,
+      {
+        organizationId,
+        dataSourceId,
+      },
+    );
+    return;
+  }
+
+  const integration = await getIntegrationFromDatasourceId(
+    context,
+    dataSourceId,
+    true,
+  );
+
+  // We need to keep track of all queries, even the ones we are not changing, so we can update the data source
+  const allExposureQueries = new Map(
+    dataSource.settings.queries?.exposure?.map((q) => [q.id, { ...q }]),
+  );
+
+  for (const queryId of exposureQueryIds) {
+    const exposureQuery = allExposureQueries.get(queryId);
+    if (!exposureQuery) {
+      logger.warn(
+        {
+          organizationId,
+          dataSourceId,
+          exposureQueryId: queryId,
+        },
+        `Exposure query not found in data source`,
+      );
+      continue;
+    }
+
+    const model = await createDimensionSlices({
+      organization: organizationId,
+      dataSourceId,
+      queryId,
+    });
+
+    const queryRunner = new DimensionSlicesQueryRunner(
+      context,
+      model,
+      integration,
+    );
+
+    queryRunner.startAnalysis({
+      exposureQueryId: queryId,
+      lookbackDays: DEFAULT_LOOKBACK_DAYS,
+    });
+
+    await queryRunner.waitForResults();
+    const outputModel = queryRunner.model;
+
+    exposureQuery.dimensionSlicesId = outputModel.id;
+    exposureQuery.dimensionMetadata = exposureQuery.dimensions.map((d) => ({
+      dimension: d,
+      specifiedSlices:
+        outputModel.results
+          .find((r) => r.dimension === d)
+          ?.dimensionSlices.map((s) => s.name) ?? [],
+      customSlices: false,
+    }));
+
+    allExposureQueries.set(queryId, exposureQuery);
+  }
+
+  await updateDataSource(context, dataSource, {
+    ...dataSource,
+    settings: {
+      ...dataSource.settings,
+      queries: {
+        ...dataSource.settings.queries,
+        exposure: Array.from(allExposureQueries.values()),
+      },
+    },
+  });
+};

--- a/packages/back-end/src/models/DataSourceModel.ts
+++ b/packages/back-end/src/models/DataSourceModel.ts
@@ -49,6 +49,11 @@ const dataSourceSchema = new mongoose.Schema<DataSourceDocument>({
   lockUntil: Date,
 });
 dataSourceSchema.index({ id: 1, organization: 1 }, { unique: true });
+dataSourceSchema.index({
+  "settings.queries.exposure.dimensionSlicesId": 1,
+  "settings.queries.exposure.dimensionMetadata.customSlices": 1,
+});
+
 type DataSourceDocument = mongoose.Document & DataSourceInterface;
 
 const DataSourceModel = mongoose.model<DataSourceInterface>(
@@ -108,6 +113,21 @@ export async function _dangerourslyGetAllDatasourcesByOrganizations(
 export async function _dangerousGetAllGrowthbookClickhouseDataSources() {
   const docs: DataSourceDocument[] = await DataSourceModel.find({
     type: "growthbook_clickhouse",
+  });
+  return docs.map(toInterface);
+}
+
+export async function _dangerousGetAllDatasourcesWithExposureQueriesWithAutomaticDimensionSlices() {
+  const docs: Array<DataSourceDocument> = await DataSourceModel.find({
+    "settings.queries.exposure.dimensionMetadata": {
+      $elemMatch: {
+        customSlices: false,
+      },
+    },
+    "settings.queries.exposure.dimensionSlicesId": {
+      $exists: true,
+      $ne: "",
+    },
   });
   return docs.map(toInterface);
 }

--- a/packages/back-end/src/models/DimensionSlicesModel.ts
+++ b/packages/back-end/src/models/DimensionSlicesModel.ts
@@ -8,6 +8,7 @@ const dimensionSlicesSchema = new mongoose.Schema({
   id: {
     type: String,
     unique: true,
+    index: true,
   },
   organization: String,
   runStarted: Date,
@@ -32,6 +33,7 @@ const dimensionSlicesSchema = new mongoose.Schema({
   ],
   error: String,
 });
+dimensionSlicesSchema.index({ organization: 1, id: 1 }, { unique: true });
 
 type DimensionSlicesDocument = mongoose.Document & DimensionSlicesInterface;
 
@@ -65,6 +67,18 @@ export async function updateDimensionSlices(
     ...updates,
   };
 }
+
+export async function _dangerousGetAllDimensionSlicesByIds(
+  ids: string[],
+  runStartedLt?: Date,
+): Promise<DimensionSlicesInterface[]> {
+  const docs = await DimensionSlicesModel.find({
+    id: { $in: ids },
+    ...(runStartedLt ? { runStarted: { $lt: runStartedLt } } : {}),
+  });
+  return docs.map(toInterface);
+}
+
 export async function getDimensionSlicesById(
   organization: string,
   id: string,

--- a/packages/back-end/tsconfig.test.json
+++ b/packages/back-end/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["jest", "node"],
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true
+  },
+  "include": ["src/**/*", "test/**/*", "types/**/*.d.ts", "typings/**/*.d.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
### Features and Changes

- Add new job to refresh precomputed dimensions data based on traffic
  - Target only exposure queries where there are dimensions, and one of them is not custom (so it is based on traffic data)
  - Skip updates if they were refreshed in the last 7 days (we can add a config for this in the near future), making it per-EAQ or DataSource if we want