### PR TITLE
use ts-node for migrate-encryption-key script

### DIFF
--- a/packages/back-end/package.json
+++ b/packages/back-end/package.json
@@ -23,7 +23,7 @@
     "test-integration-queries": "./test/integrations/integration-query-test.sh",
     "watch-compile": "swc src -w --out-dir dist",
     "watch-dev": "delay 1 && nodemon --exec 'node --enable-source-maps' --watch dist --watch '../shared/dist' -e js ./dist/server.js",
-    "migrate-encryption-key": "node dist/scripts/migrate-encryption-key.js",
+    "migrate-encryption-key": "ts-node src/scripts/migrate-encryption-key.ts",
     "generate-api-models": "node src/scripts/generate-doc-models-for-openapi-schemas.mjs",
     "generate-api-types": "yarn generate-api-models && swagger-cli bundle -t yaml src/api/openapi/openapi.tmp.yaml -o generated/spec.yaml && node src/scripts/generate-openapi.mjs"
   },

--- a/packages/back-end/src/scripts/migrate-encryption-key.ts
+++ b/packages/back-end/src/scripts/migrate-encryption-key.ts
@@ -2,12 +2,12 @@ import { AES, enc } from "crypto-js";
 import {
   updateDataSource,
   _dangerousGetAllDatasources,
-} from "../models/DataSourceModel";
-import { usingFileConfig } from "../init/config";
-import { ENCRYPTION_KEY, IS_CLOUD } from "../util/secrets";
-import { init } from "../init";
-import { encryptParams } from "../services/datasource";
-import { getContextForAgendaJobByOrgId } from "../services/organizations";
+} from "back-end/src/models/DataSourceModel";
+import { usingFileConfig } from "back-end/src/init/config";
+import { ENCRYPTION_KEY, IS_CLOUD } from "back-end/src/util/secrets";
+import { init } from "back-end/src/init";
+import { encryptParams } from "back-end/src/services/datasource";
+import { getContextForAgendaJobByOrgId } from "back-end/src/services/organizations";
 
 const [oldEncryptionKey] = process.argv.slice(2);
 if (IS_CLOUD) {


### PR DESCRIPTION
### Features and Changes

In [3032](https://github.com/growthbook/growthbook/pull/3032/files#diff-aced234513c165040ff4f4379947036186aeef52210bfbfa71d1a3cd1d2369d9) we wholesale moved from relative imports to absolute. That kills scripts when called from docker.
This [PR](https://github.com/growthbook/growthbook/pull/4602) tried to fix it, but since it imports other files it fails. 
It turns out using ts-node instead will make it work.  So this PR does that and undoes the relative imports in the previous fix.

### Testing
`yarn migrate-encryption-key dev`
See no import errors thrown.
