### PR TITLE
Metric Explorer

### DIFF
--- a/packages/back-end/src/models/MetricAnalysisModel.ts
+++ b/packages/back-end/src/models/MetricAnalysisModel.ts
@@ -1,4 +1,7 @@
-import { MetricAnalysisInterface } from "back-end/types/metric-analysis";
+import {
+  MetricAnalysisInterface,
+  MetricAnalysisSettings,
+} from "back-end/types/metric-analysis";
 import { metricAnalysisInterfaceValidator } from "back-end/src/routers/metric-analysis/metric-analysis.validators";
 import { MakeModelClass } from "./BaseModel";
 
@@ -42,6 +45,51 @@ export class MetricAnalysisModel extends BaseClass {
   }
   protected canDelete(doc: MetricAnalysisInterface): boolean {
     return this.canCreate(doc);
+  }
+
+  public async findLatestBySettings(
+    metricId: string,
+    settings: MetricAnalysisSettings,
+  ) {
+    // 1. Get all possible matches (ignoring date ranges for now)
+    const matches = await this._find(
+      {
+        metric: metricId,
+        "settings.userIdType": settings.userIdType,
+        "settings.populationType": settings.populationType,
+        "settings.populationId": settings.populationId,
+      },
+      { sort: { dateCreated: -1 }, limit: 10 },
+    );
+
+    // 2. Find the analysis that covers the most of the requested date range
+    const maxOverlapAnalysis = matches.reduce(
+      (max, current) => {
+        const maxStart = Math.max(
+          settings.startDate.getTime(),
+          current.settings.startDate.getTime(),
+        );
+        const minEnd = Math.min(
+          settings.endDate.getTime(),
+          current.settings.endDate.getTime(),
+        );
+        const currentOverlap =
+          Math.max(0, minEnd - maxStart) /
+          (settings.endDate.getTime() - settings.startDate.getTime());
+
+        return currentOverlap > max.overlap
+          ? { analysis: current, overlap: currentOverlap }
+          : max;
+      },
+      { analysis: null, overlap: 0 },
+    );
+
+    // 3. Return if at least 75% of the requested date range is covered
+    if (maxOverlapAnalysis.overlap >= 0.75) {
+      return maxOverlapAnalysis.analysis;
+    }
+
+    return null;
   }
 
   public async findLatestByMetric(metric: string, includeNorthStar?: boolean) {

--- a/packages/back-end/src/routers/metric-analysis/metric-analysis.controller.ts
+++ b/packages/back-end/src/routers/metric-analysis/metric-analysis.controller.ts
@@ -12,6 +12,7 @@ import { getExperimentMetricById } from "back-end/src/services/experiments";
 import { getIntegrationFromDatasourceId } from "back-end/src/services/datasource";
 import { getContextFromReq } from "back-end/src/services/organizations";
 import { AuthRequest } from "back-end/src/types/AuthRequest";
+import { metricAnalysisSettingsValidator } from "./metric-analysis.validators";
 
 export const postMetricAnalysis = async (
   req: AuthRequest<CreateMetricAnalysisProps>,
@@ -129,7 +130,7 @@ export async function cancelMetricAnalysis(
 }
 
 export async function getLatestMetricAnalysis(
-  req: AuthRequest<null, { metricid: string }>,
+  req: AuthRequest<null, { metricid: string }, { settings?: string }>,
   res: Response<{
     status: 200;
     metricAnalysis: MetricAnalysisInterface | null;
@@ -137,9 +138,54 @@ export async function getLatestMetricAnalysis(
 ) {
   const context = getContextFromReq(req);
 
+  // If we're trying to match specific analysis settings
+  if (req.query.settings) {
+    const rawSettings = JSON.parse(req.query.settings || "{}");
+    // Fix dates
+    rawSettings.startDate = getValidDate(rawSettings.startDate);
+    rawSettings.endDate = getValidDate(rawSettings.endDate);
+
+    const settings = metricAnalysisSettingsValidator.parse(rawSettings);
+
+    const metricAnalysis =
+      await context.models.metricAnalysis.findLatestBySettings(
+        req.params.metricid,
+        settings,
+      );
+    res.status(200).json({
+      status: 200,
+      metricAnalysis,
+    });
+    return;
+  }
+
+  // Otherwise, just find the latest one, regardless of settings
   const metricAnalysis = await context.models.metricAnalysis.findLatestByMetric(
     req.params.metricid,
   );
+
+  res.status(200).json({
+    status: 200,
+    metricAnalysis,
+  });
+}
+
+export async function getMetricAnalysisById(
+  req: AuthRequest<null, { id: string }>,
+  res: Response<{
+    status: 200;
+    metricAnalysis: MetricAnalysisInterface | null;
+  }>,
+) {
+  const context = getContextFromReq(req);
+
+  const metricAnalysis = await context.models.metricAnalysis.getById(
+    req.params.id,
+  );
+
+  if (!metricAnalysis) {
+    throw new Error("Metric analysis not found");
+  }
 
   res.status(200).json({
     status: 200,

--- a/packages/back-end/src/routers/metric-analysis/metric-analysis.router.ts
+++ b/packages/back-end/src/routers/metric-analysis/metric-analysis.router.ts
@@ -29,8 +29,17 @@ router.get(
   "/metric-analysis/metric/:metricid/",
   validateRequestMiddleware({
     params: z.object({ metricid: z.string() }).strict(),
+    query: z.object({ settings: z.string().optional() }).strict(),
   }),
   metricAnalysisController.getLatestMetricAnalysis,
+);
+
+router.get(
+  "/metric-analysis/:id",
+  validateRequestMiddleware({
+    params: z.object({ id: z.string() }).strict(),
+  }),
+  metricAnalysisController.getMetricAnalysisById,
 );
 
 export { router as metricAnalysisRouter };

--- a/packages/front-end/components/DataViz/MetricExplorer.tsx
+++ b/packages/front-end/components/DataViz/MetricExplorer.tsx
@@ -1,0 +1,529 @@
+import {
+  CreateMetricAnalysisProps,
+  MetricAnalysisInterface,
+  MetricAnalysisSettings,
+} from "back-end/types/metric-analysis";
+import { Box, Flex, Text } from "@radix-ui/themes";
+import { useForm } from "react-hook-form";
+import { useEffect, useMemo, useState } from "react";
+import { PiWrench } from "react-icons/pi";
+import EChartsReact from "echarts-for-react";
+import { getValidDate } from "shared/dates";
+import { useAuth } from "@/services/auth";
+import { useDefinitions } from "@/services/DefinitionsContext";
+import { Select, SelectItem } from "@/ui/Select";
+import Callout from "@/ui/Callout";
+import LoadingOverlay from "@/components/LoadingOverlay";
+import Button from "@/ui/Button";
+import { useAppearanceUITheme } from "@/services/AppearanceUIThemeProvider";
+import ViewAsyncQueriesButton from "@/components/Queries/ViewAsyncQueriesButton";
+import { AreaWithHeader } from "../SchemaBrowser/SqlExplorerModal";
+import { Panel, PanelGroup, PanelResizeHandle } from "../ResizablePanels";
+import BigValueChart from "../SqlExplorer/BigValueChart";
+import MetricSelector from "../Experiment/MetricSelector";
+import PopulationChooser from "../MetricAnalysis/PopulationChooser";
+
+type MetricExplorerSettings = {
+  metricId: string;
+  analysisSettings: MetricAnalysisSettings;
+  visualizationType: "bigNumber" | "timeseries" | "histogram";
+  valueType: "sum" | "avg";
+};
+
+export function MetricExplorer() {
+  const defaultStart = new Date();
+  defaultStart.setDate(defaultStart.getDate() - 30);
+  const form = useForm<MetricExplorerSettings>({
+    defaultValues: {
+      analysisSettings: {
+        lookbackDays: 30,
+        startDate: defaultStart,
+        endDate: new Date(),
+        populationId: "",
+        populationType: "factTable",
+        userIdType: "",
+      },
+      metricId: "",
+      visualizationType: "timeseries",
+      valueType: "avg",
+    },
+  });
+
+  const { theme } = useAppearanceUITheme();
+  const textColor = theme === "dark" ? "#FFFFFF" : "#1F2D5C";
+
+  const { apiCall } = useAuth();
+
+  const [results, setResults] = useState<MetricAnalysisInterface | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState<boolean>(false);
+
+  const [analysisId, setAnalysisId] = useState<string | null>(null);
+
+  const { getFactMetricById, getFactTableById, project } = useDefinitions();
+
+  const updateResults = async () => {
+    const { metricId, analysisSettings } = form.getValues();
+
+    setError(null);
+
+    if (!metricId || !analysisSettings.userIdType) return;
+
+    setLoading(true);
+    try {
+      const response = await apiCall<{
+        metricAnalysis: MetricAnalysisInterface | null;
+      }>(
+        `/metric-analysis/metric/${metricId}?settings=${encodeURIComponent(JSON.stringify(analysisSettings))}`,
+        {
+          method: "GET",
+        },
+      );
+
+      setResults(response.metricAnalysis);
+      setAnalysisId(response.metricAnalysis?.id || null);
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (
+      analysisId &&
+      (results?.status === "running" || results?.status === "queued")
+    ) {
+      const timeout = setInterval(async () => {
+        const res = await apiCall<{
+          metricAnalysis: MetricAnalysisInterface;
+        }>(`/metric-analysis/${analysisId}`, {
+          method: "GET",
+        });
+        setResults(res.metricAnalysis);
+      }, 3000);
+      return () => clearInterval(timeout);
+    }
+  }, [analysisId, results?.status, apiCall]);
+
+  const refreshResults = async () => {
+    const { metricId, analysisSettings } = form.getValues();
+    if (!metricId || !analysisSettings.userIdType) return;
+
+    const body: CreateMetricAnalysisProps = {
+      id: metricId,
+      userIdType: analysisSettings.userIdType,
+      lookbackDays: analysisSettings.lookbackDays,
+      startDate: analysisSettings.startDate.toISOString(),
+      endDate: analysisSettings.endDate.toISOString(),
+      populationType: analysisSettings.populationType,
+      populationId: analysisSettings.populationId || null,
+      source: "metric",
+    };
+
+    setError(null);
+    setLoading(true);
+    try {
+      const response = await apiCall<{
+        metricAnalysis: MetricAnalysisInterface;
+      }>(`/metric-analysis`, {
+        method: "POST",
+        body: JSON.stringify(body),
+      });
+
+      setResults(response.metricAnalysis);
+      setAnalysisId(response.metricAnalysis.id);
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const analysisSettings = form.watch("analysisSettings");
+  const visualizationType = form.watch("visualizationType");
+  const valueType = form.watch("valueType");
+
+  const metric = getFactMetricById(form.watch("metricId"));
+  const factTable = getFactTableById(metric?.numerator?.factTableId || "");
+
+  const chartData = useMemo(() => {
+    if (!metric) return null;
+    if (!results) return null;
+
+    const data: { x: string | number | Date; y: number }[] = [];
+
+    if (visualizationType === "bigNumber") {
+      const sum = (results.result?.dates || []).reduce((acc, curr) => {
+        const value =
+          valueType === "avg" ? curr.mean || 0 : curr.mean * (curr.units || 0);
+        return acc + value;
+      }, 0);
+
+      return {
+        value:
+          valueType === "sum"
+            ? sum
+            : sum / (results.result?.dates?.length || 1),
+        format:
+          metric.metricType === "proportion" && valueType === "avg"
+            ? "percentage"
+            : metric.metricType === "proportion"
+              ? "shortNumber"
+              : "longNumber",
+      };
+    } else if (
+      visualizationType === "histogram" &&
+      metric.metricType === "mean"
+    ) {
+      results.result?.histogram?.forEach((row) => {
+        data.push({ x: `${row.start} - ${row.end}`, y: row.units });
+      });
+    } else if (visualizationType === "timeseries") {
+      results.result?.dates?.forEach((row) => {
+        const d = getValidDate(row.date);
+        if (d < analysisSettings.startDate) return;
+        if (d > analysisSettings.endDate) return;
+
+        if (valueType === "sum" && metric.metricType !== "ratio") {
+          data.push({ x: d, y: (row.mean || 0) * (row.units || 0) });
+        } else {
+          data.push({
+            x: d,
+            y: row.mean || 0,
+          });
+        }
+      });
+    }
+
+    const option = {
+      title: {
+        text: `${metric.name}`,
+        left: "center",
+        textStyle: {
+          color: textColor,
+          fontSize: 20,
+          fontWeight: "bold",
+        },
+      },
+      tooltip: {
+        appendTo: "body",
+        trigger: "axis",
+        axisPointer: {
+          type: "shadow",
+        },
+      },
+      xAxis: {
+        type: visualizationType === "timeseries" ? "time" : "category",
+        nameLocation: "middle",
+        nameTextStyle: {
+          fontSize: 14,
+          fontWeight: "bold",
+          padding: [10, 0],
+          color: textColor,
+        },
+        axisLabel: {
+          color: textColor,
+        },
+      },
+      yAxis: {
+        type: "value",
+        nameLocation: "middle",
+        nameTextStyle: {
+          fontSize: 14,
+          fontWeight: "bold",
+          padding: [40, 0],
+          color: textColor,
+        },
+        axisLabel: {
+          color: textColor,
+        },
+      },
+      dataset: [
+        {
+          source: data,
+        },
+      ],
+      series: [
+        {
+          type: visualizationType === "histogram" ? "bar" : "line",
+          encode: {
+            x: "x",
+            y: "y",
+          },
+        },
+      ],
+    };
+    return option;
+  }, [
+    metric,
+    valueType,
+    visualizationType,
+    results,
+    analysisSettings.startDate,
+    analysisSettings.endDate,
+    textColor,
+  ]);
+
+  return (
+    <PanelGroup direction="horizontal">
+      <Panel
+        id="graph"
+        order={1}
+        defaultSize={75}
+        minSize={55}
+        style={{ position: "relative" }}
+      >
+        <AreaWithHeader
+          header={
+            <Flex align="center" width="100%">
+              <Text style={{ color: "var(--color-text-mid)", fontWeight: 500 }}>
+                Results
+              </Text>
+              <Box flexGrow={"1"} />
+              {results?.queries?.length ? (
+                <ViewAsyncQueriesButton
+                  queries={results.queries.map((q) => q.query)}
+                />
+              ) : null}
+              <Button
+                onClick={refreshResults}
+                ml="4"
+                loading={
+                  loading ||
+                  ["running", "queued"].includes(results?.status || "")
+                }
+              >
+                Refresh
+              </Button>
+            </Flex>
+          }
+        >
+          <Box p="4">
+            {error ? (
+              <Callout status="error">{error}</Callout>
+            ) : loading ? (
+              <LoadingOverlay />
+            ) : !results ? (
+              <Text style={{ color: "var(--color-text-mid)", fontWeight: 500 }}>
+                No data available
+              </Text>
+            ) : results.status === "error" ? (
+              <Callout status="error">
+                {results.error || "There was an error with the analysis"}
+              </Callout>
+            ) : ["running", "queued"].includes(results.status || "") ? (
+              <LoadingOverlay />
+            ) : visualizationType === "bigNumber" ? (
+              <BigValueChart
+                value={
+                  (chartData && "value" in chartData && chartData.value) || 0
+                }
+                label={"Value"}
+                format={
+                  ((chartData &&
+                    "format" in chartData &&
+                    chartData.format) as "shortNumber") || "shortNumber"
+                }
+              />
+            ) : (
+              <EChartsReact
+                key={JSON.stringify(chartData)}
+                option={chartData}
+                style={{ width: "100%", minHeight: "350px", height: "80%" }}
+              />
+            )}
+          </Box>
+        </AreaWithHeader>
+      </Panel>
+      <PanelResizeHandle />
+      <Panel id="graph-config" order={2} defaultSize={25} minSize={20}>
+        <Box style={{ overflow: "auto", height: "100%" }}>
+          <Flex direction="column" gap="4">
+            <AreaWithHeader
+              header={
+                <Text
+                  style={{ color: "var(--color-text-mid)", fontWeight: 500 }}
+                >
+                  <Flex align="center" gap="1">
+                    <PiWrench style={{ color: "var(--violet-11)" }} size={20} />
+                    Configuration
+                  </Flex>
+                </Text>
+              }
+            >
+              <Box p="4" height="fit-content">
+                <Flex direction="column" gap="4">
+                  <MetricSelector
+                    label="Metric"
+                    labelClassName="font-weight-bold"
+                    value={form.watch("metricId")}
+                    project={project}
+                    includeFacts={true}
+                    containerClassName="mb-0"
+                    filterMetrics={(m) => {
+                      // Only fact metrics
+                      const metric = getFactMetricById(m.id);
+                      if (!metric) return false;
+
+                      // Skip quantile and retention metrics
+                      if (
+                        metric.metricType === "quantile" ||
+                        metric.metricType === "retention"
+                      ) {
+                        return false;
+                      }
+
+                      return true;
+                    }}
+                    onChange={(value) => {
+                      const metric = getFactMetricById(value);
+
+                      if (!metric) return;
+
+                      form.setValue("metricId", value);
+
+                      // Only mean metric support histogram views
+                      if (
+                        metric.metricType !== "mean" &&
+                        visualizationType === "histogram"
+                      ) {
+                        form.setValue("visualizationType", "timeseries");
+                      }
+
+                      if (
+                        metric.metricType === "ratio" &&
+                        valueType === "sum"
+                      ) {
+                        form.setValue("valueType", "avg");
+                      }
+
+                      updateResults();
+                    }}
+                  />
+
+                  {metric && factTable && (
+                    <Select
+                      label="Unit"
+                      size="2"
+                      value={analysisSettings.userIdType}
+                      placeholder="Select unit"
+                      setValue={(v) => {
+                        form.setValue("analysisSettings", {
+                          ...analysisSettings,
+                          userIdType: v,
+                          populationType: "factTable",
+                          populationId: "",
+                        });
+
+                        updateResults();
+                      }}
+                    >
+                      {factTable.userIdTypes.map((type) => (
+                        <SelectItem key={type} value={type}>
+                          {type}
+                        </SelectItem>
+                      ))}
+                    </Select>
+                  )}
+
+                  {metric && factTable && (
+                    <PopulationChooser
+                      datasourceId={factTable.datasource}
+                      value={analysisSettings.populationType ?? "factTable"}
+                      setValue={(v, populationId) => {
+                        form.setValue("analysisSettings", {
+                          ...analysisSettings,
+                          populationId,
+                          populationType: v,
+                        });
+
+                        updateResults();
+                      }}
+                      userIdType={analysisSettings.userIdType}
+                      newStyle
+                    />
+                  )}
+
+                  {metric && metric?.metricType !== "ratio" && (
+                    <Select
+                      label="Metric Value"
+                      size="2"
+                      value={valueType}
+                      placeholder="Select value"
+                      setValue={(v) => {
+                        form.setValue("valueType", v as "sum" | "avg");
+                      }}
+                    >
+                      <SelectItem value="avg">
+                        {metric?.metricType === "proportion"
+                          ? "Proportion"
+                          : "Average"}
+                      </SelectItem>
+                      <SelectItem value="sum">
+                        {metric?.metricType === "proportion"
+                          ? "Unit Count"
+                          : "Sum"}
+                      </SelectItem>
+                    </Select>
+                  )}
+
+                  <Select
+                    label="Date Range"
+                    size="2"
+                    value={analysisSettings.lookbackDays + ""}
+                    placeholder="Select value"
+                    setValue={(v) => {
+                      const days = parseInt(v);
+
+                      // Calculate start/end
+                      const start = new Date();
+                      const end = new Date();
+                      start.setDate(end.getDate() - days);
+
+                      form.setValue("analysisSettings", {
+                        ...analysisSettings,
+                        lookbackDays: days,
+                        startDate: start,
+                        endDate: end,
+                      });
+
+                      updateResults();
+                    }}
+                  >
+                    <SelectItem value="7">Last 7 Days</SelectItem>
+                    <SelectItem value="14">Last 14 Days</SelectItem>
+                    <SelectItem value="30">Last 30 Days</SelectItem>
+                    <SelectItem value="90">Last 90 Days</SelectItem>
+                    <SelectItem value="180">Last 180 Days</SelectItem>
+                    <SelectItem value="365">Last 365 Days</SelectItem>
+                    <SelectItem value="9999">Last 9999 Days</SelectItem>
+                  </Select>
+
+                  <Select
+                    label="Graph Type"
+                    size="2"
+                    value={visualizationType}
+                    placeholder="Select value"
+                    setValue={(v) => {
+                      form.setValue(
+                        "visualizationType",
+                        v as "bigNumber" | "timeseries" | "histogram",
+                      );
+                    }}
+                  >
+                    <SelectItem value="bigNumber">Big Number</SelectItem>
+                    <SelectItem value="timeseries">Timeseries</SelectItem>
+                    {metric?.metricType === "mean" && (
+                      <SelectItem value="histogram">Histogram</SelectItem>
+                    )}
+                  </Select>
+                </Flex>
+              </Box>
+            </AreaWithHeader>
+          </Flex>
+        </Box>
+      </Panel>
+    </PanelGroup>
+  );
+}

--- a/packages/front-end/components/MetricAnalysis/MetricAnalysis.tsx
+++ b/packages/front-end/components/MetricAnalysis/MetricAnalysis.tsx
@@ -383,13 +383,13 @@ const MetricAnalysis: FC<MetricAnalysisProps> = ({
               <div className="col-auto form-inline pr-5">
                 <PopulationChooser
                   value={populationValue ?? "factTable"}
-                  setValue={(v) =>
+                  setValue={(v, populationId) => {
                     setValue(
                       "populationType",
                       v as MetricAnalysisPopulationType,
-                    )
-                  }
-                  setPopulationValue={(v) => setValue("populationId", v)}
+                    );
+                    setValue("populationId", populationId);
+                  }}
                   userIdType={watch("userIdType")}
                   datasourceId={factMetric.datasource}
                 />

--- a/packages/front-end/components/MetricAnalysis/PopulationChooser.tsx
+++ b/packages/front-end/components/MetricAnalysis/PopulationChooser.tsx
@@ -9,19 +9,21 @@ import Tooltip from "@/components/Tooltip/Tooltip";
 
 export interface Props {
   value: string;
-  setValue: (value: MetricAnalysisPopulationType) => void;
-  setPopulationValue: (value: string | null) => void;
-
+  setValue: (
+    value: MetricAnalysisPopulationType,
+    populationId: string | null,
+  ) => void;
   userIdType: string;
   datasourceId: string;
+  newStyle?: boolean;
 }
 
 export default function PopulationChooser({
   value,
   setValue,
-  setPopulationValue,
   userIdType,
   datasourceId,
+  newStyle,
 }: Props) {
   const { getDatasourceById, segments } = useDefinitions();
   const { hasCommercialFeature } = useUser();
@@ -53,18 +55,22 @@ export default function PopulationChooser({
 
   return (
     <div>
-      <div className="uppercase-title text-muted">
-        Population{" "}
-        <Tooltip
-          body={`The metric values will only come from units in this population. 
+      {!newStyle && (
+        <div className="uppercase-title text-muted">
+          Population{" "}
+          <Tooltip
+            body={`The metric values will only come from units in this population.
             For experiment assignment tables, any unit exposed to an
             experiment in the selected date window is in the population.`}
-        >
-          <FaQuestionCircle />
-        </Tooltip>
-      </div>
+          >
+            <FaQuestionCircle />
+          </Tooltip>
+        </div>
+      )}
       <SelectField
-        containerClassName={"select-dropdown-underline"}
+        label={newStyle ? "Population" : undefined}
+        labelClassName="font-weight-bold"
+        containerClassName={newStyle ? "mb-0" : "select-dropdown-underline"}
         options={[
           {
             label: "Fact Table",
@@ -100,16 +106,13 @@ export default function PopulationChooser({
         onChange={(v) => {
           if (v === value) return;
           if (v.startsWith("experiment")) {
-            setValue("exposureQuery");
             const exposureQueryId = v.match(/experiment_(.*)/)?.[1];
-            setPopulationValue(exposureQueryId ?? null);
+            setValue("exposureQuery", exposureQueryId ?? null);
           } else if (v.startsWith("segment")) {
-            setValue("segment");
             const segmentId = v.match(/segment_(.*)/)?.[1];
-            setPopulationValue(segmentId ?? null);
+            setValue("segment", segmentId ?? null);
           } else {
-            setValue(v as MetricAnalysisPopulationType);
-            setPopulationValue(null);
+            setValue(v as MetricAnalysisPopulationType, null);
           }
         }}
       />

--- a/packages/front-end/pages/metric-explorer.tsx
+++ b/packages/front-end/pages/metric-explorer.tsx
@@ -1,0 +1,13 @@
+import { Box } from "@radix-ui/themes";
+import { MetricExplorer } from "@/components/DataViz/MetricExplorer";
+
+export default function MetricExplorerPage() {
+  return (
+    <div className="container pagecontents">
+      <h1>Metric Explorer</h1>
+      <Box mt="4">
+        <MetricExplorer />
+      </Box>
+    </div>
+  );
+}


### PR DESCRIPTION
### Features and Changes

Lightweight Metric Explorer.  Part of our upcoming Product Analytics suite.

This MVP is very bare bones.  Future improvements:

- Ability to group by a metric dimension
    - + new Bar Chart visualization for this
- Ability to select multiple metrics and graph them together
- Ability to add filters to individual metrics (applies to both numerator and denominator)
- Ability to add filters globally (that also applies to the population when applicable)
- More time granularity (weekly, hourly options in addition to daily)
- Smarter caching (switching from 90 days to 30 days should re-use the results when possible)
- Include all identifier types in the SQL (currently requires a new query when changing the identifier)
- Add support for Quantile metrics
