### PR TITLE
Sql Explorer bug fixes - unable to remove dimension count & unable to remove long tag names

### DIFF
--- a/packages/front-end/components/DataViz/DataVizDimensionPanel.tsx
+++ b/packages/front-end/components/DataViz/DataVizDimensionPanel.tsx
@@ -220,12 +220,11 @@ export default function DataVizDimensionPanel({
                                   step="1"
                                   type="number"
                                   value={dimension.maxValues?.toString() || "5"}
-                                  onBlur={(e) => {
+                                  onChange={(e) => {
                                     const maxValues = parseInt(
                                       e.target.value,
                                       10,
                                     );
-                                    if (isNaN(maxValues)) return;
                                     if (
                                       !supportsDimension(dataVizConfig) ||
                                       !dataVizConfig.dimension
@@ -240,33 +239,6 @@ export default function DataVizDimensionPanel({
                                         },
                                       ],
                                     });
-                                  }}
-                                  onKeyDown={(e) => {
-                                    // Ignore enter
-                                    if (e.key === "Enter") {
-                                      e.stopPropagation();
-                                      e.preventDefault();
-
-                                      const maxValues = parseInt(
-                                        e.target.value,
-                                        10,
-                                      );
-                                      if (isNaN(maxValues)) return;
-                                      if (
-                                        !supportsDimension(dataVizConfig) ||
-                                        !dataVizConfig.dimension
-                                      )
-                                        return;
-                                      onDataVizConfigChange({
-                                        ...dataVizConfig,
-                                        dimension: [
-                                          {
-                                            ...dimension,
-                                            maxValues,
-                                          },
-                                        ],
-                                      });
-                                    }
                                   }}
                                 />
                               </Flex>

--- a/packages/front-end/components/Forms/MultiSelectField.tsx
+++ b/packages/front-end/components/Forms/MultiSelectField.tsx
@@ -46,7 +46,14 @@ const SortableMultiValue = SortableElement(
 const SortableMultiValueLabel = SortableHandle<any>(
   (props: MultiValueGenericProps) => {
     const label = <components.MultiValueLabel {...props} />;
-    return <div title={props.data?.tooltip}>{label}</div>;
+    return (
+      <div
+        title={props.data?.tooltip}
+        style={{ maxWidth: "calc(100% - 22px)" }}
+      >
+        {label}
+      </div>
+    );
   },
 );
 

--- a/packages/front-end/components/Forms/MultiSelectField.tsx
+++ b/packages/front-end/components/Forms/MultiSelectField.tsx
@@ -49,6 +49,7 @@ const SortableMultiValueLabel = SortableHandle<any>(
     return (
       <div
         title={props.data?.tooltip}
+        // Constrain width to save room for x button
         style={{ maxWidth: "calc(100% - 22px)" }}
       >
         {label}


### PR DESCRIPTION
### Features and Changes

Two Sql Explorer bug fixes.

1) When trying to change the number of dimensions, we had some validation in the onKeyDown handler that was preventing a user from removing a value (to then enter a new value) - this PR simplifies that and removes that logic to allow this, and also simplifies from using both `onBlur` and `onKeyDown` listeners to just using an `onChange` listener.

2) Long tag names were hiding the `X` icon to delete it. This was a result of a PR I did [here](https://github.com/growthbook/growthbook/pull/4592#issuecomment-3319754113)  (See comments [here](https://github.com/growthbook/growthbook/pull/4592#issuecomment-3318999406)) - I thought I tested in enough places, but didn't test here and broke it. This PR adds back one of the two `style` tags and does so in a way where it fixes the issue that I was addressing in the other PR, without breaking it here.

Loom walkthrough video - https://www.loom.com/share/fd63b2e10b56469680f9584dd17dc2d2

### Dependencies
None

### Testing
See video above

### Future Work
- We should make the error message better if the user tries to submit the form without a value for the `Dimensions.maxValues` field.
- We shouldn't truncate the text of a tag if the parent modal is wide enough to show the whole thing. We may also want to add a tooltip (I know) - that shows the full value of the tag if truncated.
