### PR TITLE
Ensure OfficialBadge renders when metric.managedBy isn't an empty str…

### DIFF
--- a/packages/front-end/components/Experiment/MetricsSelector.tsx
+++ b/packages/front-end/components/Experiment/MetricsSelector.tsx
@@ -336,7 +336,6 @@ const MetricsSelector: FC<{
               context !== "value" ? "var(--blue-11)" : "var(--violet-11)"
             }
             officialBadgePosition="left"
-            officialBadgeLeftGap={context !== "value"}
           />
         ) : (
           label

--- a/packages/front-end/components/Metrics/MetricName.tsx
+++ b/packages/front-end/components/Metrics/MetricName.tsx
@@ -124,7 +124,7 @@ export default function MetricName({
   metrics,
   showLink,
   badgeColor,
-  officialBadgePosition,
+  officialBadgePosition = "left",
   officialBadgeLeftGap,
 }: {
   id?: string;
@@ -258,15 +258,14 @@ export default function MetricName({
           />
         ) : null}
         {metric.name}
-        {officialBadgePosition === "right" && metric.managedBy ? (
-          <HiBadgeCheck
-            style={{
-              fontSize: "1em",
-              lineHeight: "1em",
-              marginTop: "-2px",
-              marginLeft: "4px",
-              color: "var(--blue-11)",
-            }}
+        {officialBadgePosition === "right" ? (
+          <OfficialBadge
+            type="metric"
+            managedBy={metric.managedBy || ""}
+            disableTooltip={disableTooltip}
+            showOfficialLabel={showOfficialLabel}
+            color={badgeColor}
+            leftGap={officialBadgeLeftGap}
           />
         ) : null}
       </span>

--- a/packages/front-end/components/Metrics/MetricName.tsx
+++ b/packages/front-end/components/Metrics/MetricName.tsx
@@ -99,9 +99,10 @@ export function OfficialBadge({
       >
         <HiBadgeCheck
           style={{
-            fontSize: "1.2em",
+            fontSize: "1em",
             lineHeight: "1em",
             marginTop: "-2px",
+            marginLeft: leftGap ? "4px" : "0px",
             color: color || "var(--blue-11)",
           }}
         />
@@ -124,8 +125,7 @@ export default function MetricName({
   metrics,
   showLink,
   badgeColor,
-  officialBadgePosition = "left",
-  officialBadgeLeftGap,
+  officialBadgePosition = "right",
 }: {
   id?: string;
   metric?: ExperimentMetricInterface;
@@ -138,7 +138,6 @@ export default function MetricName({
   showLink?: boolean;
   badgeColor?: string;
   officialBadgePosition?: "left" | "right";
-  officialBadgeLeftGap?: boolean;
 }) {
   const { getExperimentMetricById, getMetricGroupById } = useDefinitions();
   const metric = _metric ?? getExperimentMetricById(id ?? "");
@@ -254,7 +253,6 @@ export default function MetricName({
             disableTooltip={disableTooltip}
             showOfficialLabel={showOfficialLabel}
             color={badgeColor}
-            leftGap={officialBadgeLeftGap}
           />
         ) : null}
         {metric.name}
@@ -265,7 +263,7 @@ export default function MetricName({
             disableTooltip={disableTooltip}
             showOfficialLabel={showOfficialLabel}
             color={badgeColor}
-            leftGap={officialBadgeLeftGap}
+            leftGap={true}
           />
         ) : null}
       </span>

--- a/packages/front-end/components/Metrics/MetricsList.tsx
+++ b/packages/front-end/components/Metrics/MetricsList.tsx
@@ -551,7 +551,7 @@ const MetricsList = (): React.ReactElement => {
                       metric.archived ? "text-muted" : "text-dark"
                     } font-weight-bold`}
                   >
-                    <MetricName id={metric.id} />
+                    <MetricName id={metric.id} officialBadgePosition="left" />
                   </Link>
                 </td>
                 <td>{metric.type}</td>

--- a/packages/front-end/pages/dimensions/index.tsx
+++ b/packages/front-end/pages/dimensions/index.tsx
@@ -260,7 +260,7 @@ const DimensionsPage: FC = () => {
                           <OfficialBadge
                             type="Dimension"
                             managedBy={s.managedBy}
-                          />{" "}
+                          />
                           {s.name}{" "}
                           {s.description ? (
                             <Tooltip body={s.description} />

--- a/packages/front-end/pages/fact-metrics/[fmid].tsx
+++ b/packages/front-end/pages/fact-metrics/[fmid].tsx
@@ -488,7 +488,7 @@ export default function FactMetricPage() {
       <div className="row mb-3">
         <div className="col-auto">
           <h1 className="mb-0">
-            <MetricName id={factMetric.id} />
+            <MetricName id={factMetric.id} officialBadgePosition="right" />
           </h1>
         </div>
         <div className="ml-auto mr-2">

--- a/packages/front-end/pages/fact-tables/index.tsx
+++ b/packages/front-end/pages/fact-tables/index.tsx
@@ -419,7 +419,11 @@ export default function FactTablesPage() {
                 >
                   <td>
                     <Link href={`/fact-tables/${f.id}`}>{f.name}</Link>
-                    <OfficialBadge type="fact table" managedBy={f.managedBy} />
+                    <OfficialBadge
+                      type="fact table"
+                      managedBy={f.managedBy}
+                      leftGap={true}
+                    />
                   </td>
                   <td>{f.datasourceName}</td>
                   <td>

--- a/packages/front-end/pages/segments/index.tsx
+++ b/packages/front-end/pages/segments/index.tsx
@@ -264,7 +264,7 @@ const SegmentPage: FC = () => {
                           <OfficialBadge
                             type="Segment"
                             managedBy={s.managedBy}
-                          />{" "}
+                          />
                           {s.name}{" "}
                           {s.description ? (
                             <Tooltip body={s.description} />


### PR DESCRIPTION
### Features and Changes

There was a bug where if `officialBadgePosition` was undefined, the badge wouldn't render. Now, we've specified a default value, so if the Metric is official, it will show on the right by default, but that can be overridden.

- Closes **(add link to issue here)**

### Dependencies

- None

### Testing

- [x] Ensure that the official badge renders as expected for all resource types that support `official` status - legacy metrics, fact metrics, fact tables, fact filters, segments, and dimensions on both the list page and the individual page
- [x] Ensure the spacing looks correct when the badge is placed on the right
