### PR TITLE
fix(sdk-connection): Don't automatically focus on first input

### DIFF
--- a/packages/front-end/components/Features/CodeSnippetModal.tsx
+++ b/packages/front-end/components/Features/CodeSnippetModal.tsx
@@ -211,6 +211,7 @@ export default function CodeSnippetModal({
         inline={inline}
         size={"max"}
         header="Implementation Instructions"
+        autoFocusSelector=""
         autoCloseOnSubmit={false}
         submit={
           includeCheck


### PR DESCRIPTION
### Features and Changes

For the Code Snippet instructions we were automatically focusing on the `Event Tracking System` picker and that caused the page to scroll down, which is not intentional.

So now we don't auto focus on the input anymore.

https://www.loom.com/share/9b2e70ebd959480eb9433d1f0f75e40c