### PR TITLE
Fix SCIM sync when displayName or userName are not mapped

### DIFF
--- a/packages/back-end/src/scim/users/putUser.ts
+++ b/packages/back-end/src/scim/users/putUser.ts
@@ -61,7 +61,7 @@ export async function putUser(
     });
   }
 
-  if (currentMemberName !== displayName) {
+  if (displayName && currentMemberName !== displayName) {
     return res.status(400).json({
       schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],
       status: "400",
@@ -69,7 +69,7 @@ export async function putUser(
     });
   }
 
-  if (currentMemberEmail !== userName) {
+  if (userName && currentMemberEmail !== userName) {
     return res.status(400).json({
       schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"],
       status: "400",


### PR DESCRIPTION
### Features and Changes

Fix bug when updating users via SCIM.  If displayName or userName was empty (i.e. not mapped), we would return an error.  We should instead just ignore those fields if they are empty.