### PR TITLE
Add 'See References' button to Saved Groups page

### DIFF
--- a/packages/front-end/pages/saved-groups/[sgid].tsx
+++ b/packages/front-end/pages/saved-groups/[sgid].tsx
@@ -3,17 +3,18 @@ import { useRouter } from "next/router";
 import { SavedGroupInterface } from "shared/src/types";
 import { ago } from "shared/dates";
 import { FaPlusCircle } from "react-icons/fa";
+import { BiShow } from "react-icons/bi";
 import { PiArrowsDownUp, PiWarningFill } from "react-icons/pi";
 import {
   experimentsReferencingSavedGroups,
   featuresReferencingSavedGroups,
   isIdListSupportedAttribute,
 } from "shared/util";
-import Link from "next/link";
 import { FeatureInterface } from "back-end/types/feature";
 import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
 import { isEmpty } from "lodash";
-import { Container, Flex } from "@radix-ui/themes";
+import { Container, Flex, Text } from "@radix-ui/themes";
+import Link from "@/ui/Link";
 import Field from "@/components/Forms/Field";
 import PageHead from "@/components/Layout/PageHead";
 import Pagination from "@/components/Pagination";
@@ -22,7 +23,10 @@ import { useAuth } from "@/services/auth";
 import SavedGroupForm from "@/components/SavedGroups/SavedGroupForm";
 import DeleteButton from "@/components/DeleteButton/DeleteButton";
 import { useEnvironments, useFeaturesList } from "@/services/features";
-import { getSavedGroupMessage } from "@/pages/saved-groups";
+import {
+  getSavedGroupMessage,
+  getListOfReferences,
+} from "@/pages/saved-groups";
 import EditButton from "@/components/EditButton/EditButton";
 import Modal from "@/components/Modal";
 import LoadingOverlay from "@/components/LoadingOverlay";
@@ -38,6 +42,7 @@ import { DocLink } from "@/components/DocLink";
 import Callout from "@/ui/Callout";
 import { useExperiments } from "@/hooks/useExperiments";
 import Button from "@/ui/Button";
+import Tooltip from "@/ui/Tooltip";
 
 const NUM_PER_PAGE = 10;
 
@@ -55,6 +60,8 @@ export default function EditSavedGroupPage() {
   const [addItems, setAddItems] = useState<boolean>(false);
   const [itemsToAdd, setItemsToAdd] = useState<string[]>([]);
   const [upgradeModal, setUpgradeModal] = useState<boolean>(false);
+  const [showReferencesModal, setShowReferencesModal] =
+    useState<boolean>(false);
 
   const values = savedGroup?.values || [];
   const [currentPage, setCurrentPage] = useState(1);
@@ -98,19 +105,23 @@ export default function EditSavedGroupPage() {
 
   const referencingFeatures = useMemo(() => {
     if (!savedGroup) return [] as FeatureInterface[];
-    return featuresReferencingSavedGroups({
-      savedGroups: [savedGroup],
-      features,
-      environments,
-    })[savedGroup.id];
+    return (
+      featuresReferencingSavedGroups({
+        savedGroups: [savedGroup],
+        features,
+        environments,
+      })[savedGroup.id] || []
+    );
   }, [savedGroup, features, environments]);
 
   const referencingExperiments = useMemo(() => {
     if (!savedGroup) return [] as ExperimentInterfaceStringDates[];
-    return experimentsReferencingSavedGroups({
-      savedGroups: [savedGroup],
-      experiments,
-    })[savedGroup.id];
+    return (
+      experimentsReferencingSavedGroups({
+        savedGroups: [savedGroup],
+        experiments,
+      })[savedGroup.id] || []
+    );
   }, [savedGroup, experiments]);
 
   const getConfirmationContent = useMemo(() => {
@@ -215,6 +226,22 @@ export default function EditSavedGroupPage() {
           type="list"
         />
       )}
+      {showReferencesModal && (
+        <Modal
+          header={`'${savedGroup.groupName}' References`}
+          trackingEventModalType="show-saved-group-references"
+          close={() => setShowReferencesModal(false)}
+          open={showReferencesModal}
+          useRadixButton={true}
+          closeCta="Close"
+        >
+          <Text as="p" mb="3">
+            This saved group is referenced by the following features and
+            experiments.
+          </Text>
+          {getListOfReferences(referencingFeatures, referencingExperiments)}
+        </Modal>
+      )}
       <PageHead
         breadcrumb={[
           { display: "Saved Groups", href: "/saved-groups" },
@@ -312,6 +339,30 @@ export default function EditSavedGroupPage() {
             />
           </div>
           <Flex>
+            <Tooltip
+              content="Currently, no active features or experiments reference this Saved Group."
+              enabled={
+                referencingFeatures.length === 0 &&
+                referencingExperiments.length === 0
+              }
+            >
+              <Button
+                variant="ghost"
+                disabled={
+                  referencingFeatures.length === 0 &&
+                  referencingExperiments.length === 0
+                }
+                onClick={() => {
+                  setShowReferencesModal(true);
+                }}
+              >
+                <BiShow />{" "}
+                {referencingFeatures.length + referencingExperiments.length}{" "}
+                reference
+                {referencingFeatures.length + referencingExperiments.length !==
+                  1 && "s"}
+              </Button>
+            </Tooltip>
             <Container mr="4">
               <Button
                 variant="ghost"

--- a/packages/front-end/pages/saved-groups/index.tsx
+++ b/packages/front-end/pages/saved-groups/index.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useMemo, useState } from "react";
-import Link from "next/link";
 import { SavedGroupInterface } from "shared/src/types";
 import { FaExternalLinkAlt } from "react-icons/fa";
 import { FeatureInterface } from "back-end/types/feature";
@@ -19,6 +18,7 @@ import Modal from "@/components/Modal";
 import HistoryTable from "@/components/HistoryTable";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/ui/Tabs";
+import Link from "@/ui/Link";
 
 export const getSavedGroupMessage = (
   featuresUsingSavedGroups?: FeatureInterface[],
@@ -28,59 +28,75 @@ export const getSavedGroupMessage = (
 ) => {
   return async () => {
     if (
-      !isEmpty(featuresUsingSavedGroups) ||
-      !isEmpty(experimentsUsingSavedGroups)
+      isEmpty(featuresUsingSavedGroups) &&
+      isEmpty(experimentsUsingSavedGroups)
     ) {
-      return (
-        <div>
-          <p className="alert alert-danger">
-            <strong>Whoops!</strong> Before you can delete this saved group, you
-            will need to update the item
-            {(featuresUsingSavedGroups?.length || 0) +
-              (experimentsUsingSavedGroups?.length || 0) >
-              1 && "s"}{" "}
-            listed below by removing any targeting conditions that rely on this
-            saved group.
-          </p>
-          <ul
-            className="border rounded bg-light pt-3 pb-3 overflow-auto"
-            style={{ maxHeight: "200px" }}
-          >
-            {(featuresUsingSavedGroups || []).map((feature) => {
-              return (
-                <li key={feature.id}>
-                  <div className="d-flex">
-                    <Link
-                      href={`/features/${feature.id}`}
-                      className="btn btn-link pt-1 pb-1"
-                    >
-                      {feature.id}
-                    </Link>
-                  </div>
-                </li>
-              );
-            })}
-
-            {(experimentsUsingSavedGroups || []).map((experiment) => {
-              return (
-                <li key={experiment.id}>
-                  <div className="d-flex">
-                    <Link
-                      href={`/experiment/${experiment.id}`}
-                      className="btn btn-link pt-1 pb-1"
-                    >
-                      {experiment.name}
-                    </Link>
-                  </div>
-                </li>
-              );
-            })}
-          </ul>
-        </div>
-      );
+      return null;
     }
-    return null;
+
+    return (
+      <div>
+        <p className="alert alert-danger">
+          <strong>Whoops!</strong> Before you can delete this saved group, you
+          will need to update the item
+          {(featuresUsingSavedGroups?.length || 0) +
+            (experimentsUsingSavedGroups?.length || 0) >
+            1 && "s"}{" "}
+          listed below by removing any targeting conditions that rely on this
+          saved group.
+        </p>
+        {getListOfReferences(
+          featuresUsingSavedGroups,
+          experimentsUsingSavedGroups,
+        )}
+      </div>
+    );
   };
+};
+
+export const getListOfReferences = (
+  featuresUsingSavedGroups?: FeatureInterface[],
+  experimentsUsingSavedGroups?: Array<
+    ExperimentInterface | ExperimentInterfaceStringDates
+  >,
+) => {
+  if (
+    isEmpty(featuresUsingSavedGroups) &&
+    isEmpty(experimentsUsingSavedGroups)
+  ) {
+    return null;
+  }
+
+  return (
+    <ul
+      className="border rounded bg-light pt-3 pb-3 overflow-auto"
+      style={{ maxHeight: "200px" }}
+    >
+      {(featuresUsingSavedGroups || []).map((feature) => {
+        return (
+          <li key={feature.id}>
+            <div className="d-flex">
+              <Link href={`/features/${feature.id}`} className="pt-1 pb-1">
+                {feature.id}
+              </Link>
+            </div>
+          </li>
+        );
+      })}
+
+      {(experimentsUsingSavedGroups || []).map((experiment) => {
+        return (
+          <li key={experiment.id}>
+            <div className="d-flex">
+              <Link href={`/experiment/${experiment.id}`} className="pt-1 pb-1">
+                {experiment.name}
+              </Link>
+            </div>
+          </li>
+        );
+      })}
+    </ul>
+  );
 };
 
 export default function SavedGroupsPage() {

--- a/packages/front-end/ui/Tooltip.tsx
+++ b/packages/front-end/ui/Tooltip.tsx
@@ -1,0 +1,26 @@
+import { forwardRef } from "react";
+import {
+  Tooltip as RadixTooltip,
+  TooltipProps as RadixTooltipProps,
+} from "@radix-ui/themes";
+
+type TooltipProps = RadixTooltipProps & {
+  enabled: boolean;
+};
+
+const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
+  ({ children, enabled, ...props }, ref) => {
+    if (!enabled) {
+      return <>{children}</>;
+    }
+
+    return (
+      <RadixTooltip {...props} ref={ref}>
+        {children}
+      </RadixTooltip>
+    );
+  },
+);
+
+Tooltip.displayName = "Tooltip";
+export default Tooltip;


### PR DESCRIPTION
### Features and Changes

In the Saved Groups page now we have a `See References` button that will show all active Features & Experiments that are using the Saved Group.

<img width="1061" height="244" alt="Screenshot 2025-09-30 at 4 36 19 PM" src="https://github.com/user-attachments/assets/61506614-bcf5-4a46-96f9-7e1210d12862" />
<img width="1066" height="396" alt="Screenshot 2025-09-30 at 4 35 57 PM" src="https://github.com/user-attachments/assets/270c574a-a63c-4999-bdc3-9c56d4a9659e" />
<img width="1079" height="430" alt="Screenshot 2025-09-30 at 4 36 03 PM" src="https://github.com/user-attachments/assets/222dd5e6-9371-43fe-b665-054e2cc7a913" />
