### PR TITLE
Hide Segments sidenav link

### DIFF
--- a/docs/docs/faq.mdx
+++ b/docs/docs/faq.mdx
@@ -230,6 +230,12 @@ A dimension is a user attribute that can have multiple values. Some examples are
 
 A segment is a specific group of users. Some examples are `visitors in the US`, `premium users`, and `chrome users`.
 
+:::info
+
+We have begun the process of phasing out Segments in favor of `Dimensions`.
+
+:::
+
 Dimensions are used to explore experiment results. For example, you can use a `country` dimension to see which countries had the highest conversion rates. Or an `account_type` dimension to see if there was a significant difference in how free vs paid users behaved. Or a `browser` dimension to detect any browser-specific bugs in your implementation.
 
 Segments can apply a filter to results, usually to compensate for bad data. For example, if your experiment was only visible to premium users, but your database inaccurately shows that free users were also included, you could apply a `premium users` segment to only include those who were actually exposed to the test. Ideally, you could just fix the underlying data, but that's often not feasible so segments provide a quick and dirty alternative.

--- a/docs/docs/faq.mdx
+++ b/docs/docs/faq.mdx
@@ -228,7 +228,7 @@ const getUUID=()=>{const a=(a,b)=>{var c=new Date;c.setTime(c.getTime()+86400000
 
 :::info
 
-We have begun phasing out Segments as we recommend using `Dimensions` instead. Segments are still supported, but we will be deprecating them in the future.
+We recommend using Dimensions instead of Segments for new implementations. While Segments remain fully supported, we plan to deprecate them in a future release.
 
 :::
 

--- a/docs/docs/faq.mdx
+++ b/docs/docs/faq.mdx
@@ -226,15 +226,15 @@ const getUUID=()=>{const a=(a,b)=>{var c=new Date;c.setTime(c.getTime()+86400000
 
 ### What is the difference between a Dimension and a Segment?
 
+:::info
+
+We have begun phasing out Segments as we recommend using `Dimensions` instead. Segments are still supported, but we will be deprecating them in the future.
+
+:::
+
 A dimension is a user attribute that can have multiple values. Some examples are `country`, `account_type`, and `browser`.
 
 A segment is a specific group of users. Some examples are `visitors in the US`, `premium users`, and `chrome users`.
-
-:::info
-
-We have begun the process of phasing out Segments in favor of `Dimensions`.
-
-:::
 
 Dimensions are used to explore experiment results. For example, you can use a `country` dimension to see which countries had the highest conversion rates. Or an `account_type` dimension to see if there was a significant difference in how free vs paid users behaved. Or a `browser` dimension to detect any browser-specific bugs in your implementation.
 

--- a/docs/docs/self-host/config.mdx
+++ b/docs/docs/self-host/config.mdx
@@ -503,6 +503,12 @@ This will let you create new dimensions via the UI. Dimensions defined in `confi
 
 ### Segments
 
+:::info
+
+We have begun the process of phasing out Segments in favor of `Dimensions`.
+
+:::
+
 Segments define important groups of users - for example, "annual subscribers" or "left-handed people from France." They are currently only supported for SQL data sources.
 
 Segments only have 4 properties: name, datasource, userIdType, and SQL. The SQL query must return two columns: the identifier type and `date`.

--- a/docs/docs/self-host/config.mdx
+++ b/docs/docs/self-host/config.mdx
@@ -505,7 +505,7 @@ This will let you create new dimensions via the UI. Dimensions defined in `confi
 
 :::info
 
-We have begun the process of phasing out Segments in favor of `Dimensions`.
+We have begun phasing out Segments as we recommend using `Dimensions` instead. Segments are still supported, but we will be deprecating them in the future.
 
 :::
 

--- a/docs/docs/self-host/config.mdx
+++ b/docs/docs/self-host/config.mdx
@@ -505,7 +505,7 @@ This will let you create new dimensions via the UI. Dimensions defined in `confi
 
 :::info
 
-We have begun phasing out Segments as we recommend using `Dimensions` instead. Segments are still supported, but we will be deprecating them in the future.
+We recommend using Dimensions instead of Segments for new implementations. While Segments remain fully supported, we plan to deprecate them in a future release.
 
 :::
 

--- a/packages/front-end/components/Layout/Layout.tsx
+++ b/packages/front-end/components/Layout/Layout.tsx
@@ -108,6 +108,7 @@ const navlinks: SidebarLinkProps[] = [
         name: "Segments",
         href: "/segments",
         path: /^segment/,
+        filter: ({ segments }) => segments.length > 0,
       },
       {
         name: "Dimensions",

--- a/packages/front-end/components/Layout/SidebarLink.tsx
+++ b/packages/front-end/components/Layout/SidebarLink.tsx
@@ -7,6 +7,7 @@ import { FiChevronRight } from "react-icons/fi";
 import { GrowthBook, useGrowthBook } from "@growthbook/growthbook-react";
 import { GlobalPermission } from "back-end/types/organization";
 import { Permissions } from "shared/permissions";
+import { SegmentInterface } from "back-end/types/segment";
 import { AppFeatures } from "@/types/app-features";
 import { isCloud, isMultiOrg } from "@/services/env";
 import { PermissionFunctions, useUser } from "@/services/UserContext";
@@ -27,6 +28,7 @@ export type SidebarLinkProps = {
   navigateOnExpand?: boolean;
   filter?: (props: {
     permissionsUtils: Permissions;
+    segments: SegmentInterface[];
     permissions: Record<GlobalPermission, boolean> & PermissionFunctions;
     superAdmin: boolean;
     isCloud: boolean;
@@ -40,7 +42,7 @@ export type SidebarLinkProps = {
 
 const SidebarLink: FC<SidebarLinkProps> = (props) => {
   const { permissions, superAdmin } = useUser();
-  const { project } = useDefinitions();
+  const { project, segments } = useDefinitions();
   const router = useRouter();
 
   const path = router.route.substr(1);
@@ -67,6 +69,7 @@ const SidebarLink: FC<SidebarLinkProps> = (props) => {
     isMultiOrg: isMultiOrg(),
     gb: growthbook,
     project,
+    segments,
   };
 
   if (props.filter && !props.filter(filterProps)) {


### PR DESCRIPTION
### Features and Changes

This PR hides the `Segments` side-nav link for organizations that don't have any Segments, but leaves it for orgs with existing Segments. It also introduces a few lightweight notes in the docs that outlines we've begun to phase out Segments in favor of Dimensions. 

- Closes https://github.com/growthbook/growthbook/issues/4651

### Dependencies

- None

### Testing

- [x] Log in as an org that has existing Segments, and ensure that the `Segments` link under the `Metrics and Data` tab is rendered.
- [x] Log in as an org that doesn't have any existing Segments, and ensure that the `Segments` link under the `Metrics and Data` tab is NOT rendered.
