### PR TITLE
fix(dimensions): Drop deleted pre-computed dimension metadata

### DIFF
--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -518,7 +518,9 @@ export function getSnapshotSettings({
   if (precomputeDimensions) {
     // if standard snapshot with no dimension set, we should pre-compute dimensions
     const predefinedDimensions = getPredefinedDimensionSlicesByExperiment(
-      exposureQuery.dimensionMetadata ?? [],
+      (exposureQuery.dimensionMetadata ?? []).filter((d) =>
+        exposureQuery.dimensions.includes(d.dimension),
+      ),
       experiment.variations.length,
     );
     dimensions =


### PR DESCRIPTION
### Features and Changes

Sometimes the dimension metadata used for post-strat and pre-computed dimensions can get out of sync with the exposure query and cause errors when running an analysis if you don't update the dimension metadata. This fix ensures the dimension exists in both `dimensions` and `dimensionMetadata` on an exposure query before sending it to the snapshot for computation.

- Closes **(add link to issue here)**

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

<!--
  Please describe how to test these changes.
 -->

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
