### PR TITLE
 fix: replace react-beautiful-dnd with @hello-pangea/dnd for React 18  compatibility

### DIFF
--- a/packages/front-end/components/Share/ShareModal.tsx
+++ b/packages/front-end/components/Share/ShareModal.tsx
@@ -11,7 +11,7 @@ import {
   DragDropContext,
   Droppable,
   Draggable,
-} from "react-beautiful-dnd";
+} from "@hello-pangea/dnd";
 import { GrDrag } from "react-icons/gr";
 import { FaCheck, FaRegTrashAlt } from "react-icons/fa";
 import { FiAlertTriangle } from "react-icons/fi";

--- a/packages/front-end/package.json
+++ b/packages/front-end/package.json
@@ -16,7 +16,7 @@
     "type-gen": "growthbook features generate-types --output ./types --profile growthbook"
   },
   "dependencies": {
-    "@dnd-kit/core": "^5.0.0",
+    "@dnd-kit/core": "^6.3.0",
     "@dnd-kit/sortable": "^10.0.0",
     "@floating-ui/react": "^0.25.4",
     "@growthbook/growthbook-react": "^1.6.1",
@@ -74,7 +74,7 @@
     "query-string": "^7.1.3",
     "react": "^18.2.0",
     "react-ace": "^10.1.0",
-    "react-beautiful-dnd": "^13.1.0",
+    "@hello-pangea/dnd": "^16.6.0",
     "react-collapsible": "^2.10.0",
     "react-colorful": "^5.3.0",
     "react-day-picker": "^9.3.1",


### PR DESCRIPTION
Features and Changes

  This PR fixes a critical React 18 compatibility issue where the application crashes with TypeError: Cannot set properties of undefined (setting  'AsyncMode') at runtime. The error occurs because react-beautiful-dnd library tries to access React.AsyncMode which was deprecated and removed in
   React 18.

  Changes made:
  - Replaced react-beautiful-dnd@^13.1.0 with @hello-pangea/dnd@^16.6.0 (official React 18-compatible successor)
  - Updated @dnd-kit/core from ^5.0.0 to ^6.3.0 to resolve peer dependency conflicts
  - Updated import statement in ShareModal.tsx to use the new library

  @hello-pangea/dnd is a drop-in replacement that maintains the exact same API while providing full React 18 and Strict Mode compatibility.

  - Closes #4621

  Dependencies

  None - this is a direct library replacement with identical API. No breaking changes to existing functionality.

  Testing

  1. Install dependencies: yarn install
  2. Start the front-end application: yarn workspace front-end dev
  3. Navigate to any page that uses the ShareModal component
  4. Verify no AsyncMode errors appear in browser console
  5. Test drag and drop functionality in presentation sharing to ensure it works correctly
  6. Confirm the application loads without runtime errors

  Before: Application crashes with TypeError: Cannot set properties of undefined (setting 'AsyncMode')
  After: Application loads successfully with working drag and drop functionality

  Screenshots

  No UI changes - this is an internal dependency replacement that maintains identical visual behavior and functionality.