### PR TITLE
feat(auth): add 'Remember me' checkbox with email persistence on login

### DIFF
--- a/packages/front-end/components/Auth/ChangePasswordModal.tsx
+++ b/packages/front-end/components/Auth/ChangePasswordModal.tsx
@@ -1,19 +1,28 @@
 import { FC } from "react";
 import { useForm } from "react-hook-form";
 import { useAuth } from "@/services/auth";
-import Field from "@/components/Forms/Field";
 import Modal from "@/components/Modal";
+import PasswordInput from "./PasswordInput";
 
-const ChangePasswordModal: FC<{
-  close: () => void;
-}> = ({ close }) => {
-  const form = useForm({
+type FormValues = {
+  currentPassword: string;
+  newPassword: string;
+};
+
+const ChangePasswordModal: FC<{ close: () => void }> = ({ close }) => {
+  const form = useForm<FormValues>({
     defaultValues: {
       currentPassword: "",
       newPassword: "",
     },
   });
+
   const { apiCall } = useAuth();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = form;
 
   return (
     <Modal
@@ -24,36 +33,50 @@ const ChangePasswordModal: FC<{
       close={close}
       cta="Change Password"
       successMessage="Password successfully changed"
-      submit={form.handleSubmit(async (data) => {
+      submit={handleSubmit(async (data) => {
         await apiCall("/auth/change-password", {
           method: "POST",
           body: JSON.stringify(data),
         });
       })}
     >
-      <Field
-        label="Current Password"
-        type="password"
-        required
-        minLength={8}
-        autoComplete="current-password"
-        {...form.register("currentPassword")}
-        helpText={
-          <>
-            Can&apos;t remember your current password? Log out and click on{" "}
-            <strong>Forgot&nbsp;Password</strong> to reset it.
-          </>
-        }
-      />
-      <Field
-        label="New Password"
-        type="password"
-        required
-        minLength={8}
-        autoComplete="new-password"
-        {...form.register("newPassword")}
-      />
+      {/* Current Password */}
+      <div className="mb-3">
+        <label className="form-label">Current Password</label>
+        <PasswordInput
+          {...register("currentPassword", { required: true, minLength: 8 })}
+          autoComplete="current-password"
+          className={`form-control ${errors.currentPassword ? "is-invalid" : ""}`}
+          placeholder="Enter current password"
+          error={
+            errors.currentPassword
+              ? "Current password must be at least 8 characters"
+              : null
+          }
+        />
+        <div className="form-text mt-1">
+          Can&apos;t remember your current password? Log out and click{" "}
+          <strong>Forgot&nbsp;Password</strong> to reset it.
+        </div>
+      </div>
+
+      {/* New Password */}
+      <div className="mb-3">
+        <label className="form-label">New Password</label>
+        <PasswordInput
+          {...register("newPassword", { required: true, minLength: 8 })}
+          autoComplete="new-password"
+          className={`form-control ${errors.newPassword ? "is-invalid" : ""}`}
+          placeholder="Create a new password"
+          error={
+            errors.newPassword
+              ? "New password must be at least 8 characters"
+              : null
+          }
+        />
+      </div>
     </Modal>
   );
 };
+
 export default ChangePasswordModal;

--- a/packages/front-end/components/Auth/PasswordInput.tsx
+++ b/packages/front-end/components/Auth/PasswordInput.tsx
@@ -1,0 +1,114 @@
+// packages/front-end/components/PasswordInput.tsx
+"use client";
+
+import * as React from "react";
+
+type Props = React.InputHTMLAttributes<HTMLInputElement> & {
+  error?: string | null;
+};
+
+/** SVG icons (no extra dependency) */
+const Eye = () => (
+  <svg
+    width="20"
+    height="20"
+    viewBox="0 0 24 24"
+    fill="none"
+    aria-hidden="true"
+    className="text-gray-500"
+  >
+    <path
+      d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7S1 12 1 12Z"
+      stroke="currentColor"
+      strokeWidth="2"
+    />
+    <circle cx="12" cy="12" r="3" stroke="currentColor" strokeWidth="2" />
+  </svg>
+);
+
+const EyeOff = () => (
+  <svg
+    width="20"
+    height="20"
+    viewBox="0 0 24 24"
+    fill="none"
+    aria-hidden="true"
+    className="text-gray-500"
+  >
+    <path d="M3 3l18 18" stroke="currentColor" strokeWidth="2" />
+    <path
+      d="M10.6 6.2A10.9 10.9 0 0 1 12 5c7 0 11 7 11 7a18.2 18.2 0 0 1-5.1 5.4"
+      stroke="currentColor"
+      strokeWidth="2"
+    />
+    <path
+      d="M6.2 10.7A12 12 0 0 0 1 12s4 7 11 7c1.3 0 2.6-.3 3.8-.7"
+      stroke="currentColor"
+      strokeWidth="2"
+    />
+    <circle cx="12" cy="12" r="3" stroke="currentColor" strokeWidth="2" />
+  </svg>
+);
+
+/**
+ * Password input with show/hide toggle — polished version
+ * Responsive + visually aligned with GrowthBook form fields
+ */
+const PasswordInput = React.forwardRef<HTMLInputElement, Props>(
+  function PasswordInput({ className, error, style, ...rest }, ref) {
+    const [visible, setVisible] = React.useState(false);
+
+    return (
+      <div style={{ position: "relative" }}>
+        <input
+          {...rest}
+          ref={ref}
+          type={visible ? "text" : "password"}
+          className={`form-control ${
+            error ? "is-invalid" : ""
+          } ${className || ""}`}
+          style={{
+            paddingRight: "42px",
+            fontSize: "0.95rem",
+            height: "42px",
+            ...style,
+          }}
+        />
+
+        <button
+          type="button"
+          aria-label={visible ? "Hide password" : "Show password"}
+          onClick={() => setVisible((v) => !v)}
+          tabIndex={-1}
+          className="toggle-password-btn"
+          style={{
+            background: "transparent",
+            border: "none",
+            position: "absolute",
+            top: "50%",
+            right: "12px",
+            transform: "translateY(-50%)",
+            padding: 0,
+            cursor: "pointer",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          {visible ? <Eye /> : <EyeOff />}
+        </button>
+
+        {error ? (
+          <div
+            className="invalid-feedback d-block"
+            style={{ fontSize: "0.8rem", marginTop: "4px" }}
+          >
+            {error}
+          </div>
+        ) : null}
+      </div>
+    );
+  },
+);
+
+export default PasswordInput;

--- a/packages/front-end/components/Auth/Welcome.tsx
+++ b/packages/front-end/components/Auth/Welcome.tsx
@@ -5,6 +5,7 @@ import track from "@/services/track";
 import { getApiHost } from "@/services/env";
 import Field from "@/components/Forms/Field";
 import WelcomeFrame from "./WelcomeFrame";
+import PasswordInput from "./PasswordInput";
 
 export default function Welcome({
   onSuccess,
@@ -16,6 +17,7 @@ export default function Welcome({
   const [state, setState] = useState<
     "login" | "register" | "forgot" | "forgotSuccess" | "firsttime"
   >(firstTime ? "firsttime" : "login");
+
   const form = useForm({
     defaultValues: {
       companyname: "",
@@ -24,8 +26,9 @@ export default function Welcome({
       password: "",
     },
   });
+
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState(null);
+  const [error, setError] = useState<string | null>(null);
   const [welcomeMsgIndex] = useState(Math.floor(Math.random() * 4));
   const { pathname } = useRouter();
 
@@ -41,6 +44,7 @@ export default function Welcome({
     "Hello there, Welcome!",
     "Hey there!",
   ];
+
   const cta =
     state === "login"
       ? "Log in"
@@ -58,9 +62,7 @@ export default function Welcome({
       : form.handleSubmit(async (data) => {
           const res = await fetch(getApiHost() + "/auth/" + state, {
             method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-            },
+            headers: { "Content-Type": "application/json" },
             credentials: "include",
             body: JSON.stringify(data),
           });
@@ -70,18 +72,16 @@ export default function Welcome({
             message?: string;
             projectId?: string;
           } = await res.json();
+
           if (json.status > 200) {
             throw new Error(
               json.message || "An error occurred. Please try again.",
             );
           }
 
-          if (state === "register") {
-            track("Register");
-          }
-          if (state === "firsttime") {
-            track("Register-first");
-          }
+          if (state === "register") track("Register");
+          if (state === "firsttime") track("Register-first");
+
           if (state === "forgot") {
             setState("forgotSuccess");
           } else {
@@ -134,7 +134,8 @@ export default function Welcome({
             try {
               await submit?.();
             } catch (e) {
-              setError(e.message);
+              const msg = e instanceof Error ? e.message : String(e);
+              setError(msg);
             }
             setLoading(false);
           }}
@@ -156,6 +157,7 @@ export default function Welcome({
               </p>
             </div>
           )}
+
           {state === "firsttime" && (
             <div>
               <h3 className="h2">Set up your first account</h3>
@@ -166,6 +168,7 @@ export default function Welcome({
               </p>
             </div>
           )}
+
           {state === "login" && (
             <div>
               <h3 className="h2">Log In</h3>
@@ -183,6 +186,7 @@ export default function Welcome({
               </p>
             </div>
           )}
+
           {state === "forgot" && (
             <div>
               <h3 className="h2">Forgot Password</h3>
@@ -199,6 +203,7 @@ export default function Welcome({
               </p>
             </div>
           )}
+
           {state === "forgotSuccess" && (
             <div>
               <h3 className="h2">Forgot Password</h3>
@@ -220,6 +225,7 @@ export default function Welcome({
               </p>
             </div>
           )}
+
           {state === "firsttime" && (
             <Field
               label="Company name"
@@ -229,6 +235,7 @@ export default function Welcome({
               {...form.register("companyname")}
             />
           )}
+
           {(state === "register" || state === "firsttime") && (
             <Field
               label="Name"
@@ -239,6 +246,7 @@ export default function Welcome({
               minLength={2}
             />
           )}
+
           {(state === "login" ||
             state === "register" ||
             state === "forgot" ||
@@ -252,20 +260,24 @@ export default function Welcome({
               autoComplete="username"
             />
           )}
+
           {(state === "login" ||
             state === "register" ||
             state === "firsttime") && (
-            <Field
-              label="Password"
-              required
-              type="password"
-              {...form.register("password")}
-              autoComplete={
-                state === "login" ? "current-password" : "new-password"
-              }
-              minLength={8}
-              helpText={
-                state === "login" ? (
+            <div className="mb-3">
+              <label className="form-label">Password</label>
+
+              <PasswordInput
+                {...form.register("password", { required: true, minLength: 8 })}
+                autoComplete={
+                  state === "login" ? "current-password" : "new-password"
+                }
+                className="form-control"
+                placeholder={state === "login" ? "Password" : "Create password"}
+              />
+
+              {state === "login" && (
+                <div className="mt-1">
                   <a
                     href="#"
                     onClick={(e) => {
@@ -275,12 +287,18 @@ export default function Welcome({
                   >
                     Forgot Password?
                   </a>
-                ) : null
-              }
-            />
+                </div>
+              )}
+            </div>
           )}
+
           {error && <div className="alert alert-danger mr-auto">{error}</div>}
-          <button className={`btn btn-primary btn-block btn-lg`} type="submit">
+
+          <button
+            className="btn btn-primary btn-block btn-lg"
+            type="submit"
+            disabled={loading}
+          >
             {cta}
           </button>
         </form>

--- a/packages/front-end/components/Auth/Welcome.tsx
+++ b/packages/front-end/components/Auth/Welcome.tsx
@@ -32,6 +32,21 @@ export default function Welcome({
   const [welcomeMsgIndex] = useState(Math.floor(Math.random() * 4));
   const { pathname } = useRouter();
 
+  // -------------------------------
+  // Remember-me logic
+  // -------------------------------
+  const [rememberMe, setRememberMe] = useState(false);
+
+  // Prefill saved email if available
+  useEffect(() => {
+    const savedEmail = localStorage.getItem("gb_saved_email");
+    if (savedEmail) {
+      form.setValue("email", savedEmail);
+      setRememberMe(true);
+    }
+  }, [form]);
+  // -------------------------------
+
   useEffect(() => {
     if (pathname === "/invitation") {
       setState("register");
@@ -85,6 +100,15 @@ export default function Welcome({
           if (state === "forgot") {
             setState("forgotSuccess");
           } else {
+            // Save or clear remembered email
+            if (state === "login") {
+              if (rememberMe) {
+                localStorage.setItem("gb_saved_email", data.email);
+              } else {
+                localStorage.removeItem("gb_saved_email");
+              }
+            }
+
             onSuccess(json.token, json.projectId);
           }
         });
@@ -266,7 +290,6 @@ export default function Welcome({
             state === "firsttime") && (
             <div className="mb-3">
               <label className="form-label">Password</label>
-
               <PasswordInput
                 {...form.register("password", { required: true, minLength: 8 })}
                 autoComplete={
@@ -289,6 +312,22 @@ export default function Welcome({
                   </a>
                 </div>
               )}
+            </div>
+          )}
+
+          {/* Remember Me (login only) */}
+          {state === "login" && (
+            <div className="form-check mt-2 mb-3">
+              <input
+                className="form-check-input"
+                type="checkbox"
+                id="rememberMe"
+                checked={rememberMe}
+                onChange={(e) => setRememberMe(e.target.checked)}
+              />
+              <label className="form-check-label" htmlFor="rememberMe">
+                Remember me
+              </label>
             </div>
           )}
 


### PR DESCRIPTION
### Summary
Adds a “Remember me” checkbox on the login form that stores the user’s email in localStorage when checked.
On subsequent visits, the email auto-fills for a smoother login experience.

### Details
- Introduces `rememberMe` state in Welcome.tsx
- Persists email in localStorage as "gb_saved_email"
- Automatically restores email on mount
- No backend changes; fully client-side

### Why
Improves UX by reducing friction for returning users.

### Screenshots
<img width="1901" height="885" alt="Remember_Me" src="https://github.com/user-attachments/assets/b15bc275-9723-473e-bb56-f33db03375d5" />

