### PR TITLE
Bug fix: Allows orgs to auto-generate fact tables for managed warehou…

### DIFF
--- a/packages/back-end/src/models/FactTableModel.ts
+++ b/packages/back-end/src/models/FactTableModel.ts
@@ -203,7 +203,12 @@ export async function createFactTable(
   context: ReqContext | ApiReqContext,
   data: CreateFactTableProps,
 ) {
-  if (data.managedBy === "api" && !context.isApiRequest) {
+  if (
+    data.managedBy === "api" &&
+    !context.isApiRequest &&
+    // For managed warehouses, we allow managedBy to be set to "api" when we're creating them for the org
+    data.id !== "ch_events"
+  ) {
     throw new Error(
       "Cannot create fact table managed by API if the request isn't from the API.",
     );

--- a/packages/back-end/src/models/FactTableModel.ts
+++ b/packages/back-end/src/models/FactTableModel.ts
@@ -204,17 +204,6 @@ export async function createFactTable(
   data: CreateFactTableProps,
 ) {
   if (
-    data.managedBy === "api" &&
-    !context.isApiRequest &&
-    // For managed warehouses, we allow managedBy to be set to "api" when we're creating them for the org
-    data.id !== "ch_events"
-  ) {
-    throw new Error(
-      "Cannot create fact table managed by API if the request isn't from the API.",
-    );
-  }
-
-  if (
     data.managedBy === "admin" &&
     !context.hasPremiumFeature("manage-official-resources")
   ) {


### PR DESCRIPTION
### Features and Changes

For fact tables created via the `Managed Warehouse` Data Source, the code is setting the `managedBy` field to `api` in order to prevent users from editing the Fact Tables via the UI.

This caused an issue as the `Fact Table` model is now checking that api calls are coming from the rest API if `managedBy` is being set to `api`, to prevent an org from creating a resource and marking it as managed by the API when its not being created via the API.

This PR removes that check. It shouldn't be possible for an org to set `managedBy: "api"` for a new fact table via the UI, so this check could be seen as too strict.

There is likely a much larger fix here, in that we need to customize the UI for Managed Warehouse metrics, but that is too big of a lift to do at the moment. This PR will fix the bug the user is experiencing.

- Closes **(add link to issue here)**

### Dependencies

- None

### Testing

I don't have my env set up to easily test managed warehouse stuff, but I'm confident in the fix.

