### PR TITLE
feat(sql): Use BigQuery query result types for Fact Tables

### DIFF
--- a/packages/back-end/src/integrations/BigQuery.ts
+++ b/packages/back-end/src/integrations/BigQuery.ts
@@ -1,4 +1,5 @@
 import * as bq from "@google-cloud/bigquery";
+import { QueryResultsResponse } from "@google-cloud/bigquery/build/src/bigquery";
 import { bigQueryCreateTableOptions } from "shared/enterprise";
 import { FormatDialect } from "shared/src/types";
 import { format } from "shared/sql";
@@ -11,9 +12,14 @@ import {
   QueryResponse,
   RawInformationSchema,
   DataType,
+  QueryResponseColumnData,
 } from "back-end/src/types/Integration";
 import { formatInformationSchema } from "back-end/src/util/informationSchemas";
 import { logger } from "back-end/src/util/logger";
+import {
+  BigQueryDataType,
+  getFactTableTypeFromBigQueryType,
+} from "../services/bigquery";
 import SqlIntegration from "./SqlIntegration";
 
 export default class BigQuery extends SqlIntegration {
@@ -94,9 +100,9 @@ export default class BigQuery extends SqlIntegration {
           : undefined,
     };
 
-    const columns = queryResultsResponse?.schema?.fields
-      ?.map((field) => field.name?.toLowerCase())
-      .filter((field) => field !== undefined);
+    const columns = queryResultsResponse
+      ? this.getQueryResultResponseColumns(queryResultsResponse)
+      : undefined;
 
     // BigQuery dates are stored nested in an object, so need to extract the value
     for (const row of rows) {
@@ -272,5 +278,32 @@ export default class BigQuery extends SqlIntegration {
         throw new Error(`Unsupported data type: ${dataType}`);
       }
     }
+  }
+
+  getQueryResultResponseColumns(
+    bqQueryResultsResponse: QueryResultsResponse,
+  ): QueryResponseColumnData[] | undefined {
+    const mapField = (field: bq.TableField): QueryResponseColumnData => {
+      let childFields = undefined;
+      if (field.type === "RECORD" || field.type === "STRUCT") {
+        childFields = field.fields
+          ?.filter((f) => f.name !== undefined)
+          .map((f) => mapField(f));
+      }
+
+      const dataType = field.type
+        ? getFactTableTypeFromBigQueryType(field.type as BigQueryDataType)
+        : undefined;
+
+      return {
+        name: field.name!.toLowerCase(),
+        ...(dataType && { dataType }),
+        ...(childFields && { fields: childFields }),
+      };
+    };
+
+    return bqQueryResultsResponse.schema?.fields
+      ?.filter((field) => field.name !== undefined)
+      .map((field) => mapField(field));
   }
 }

--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -1463,7 +1463,7 @@ export default abstract class SqlIntegration
       });
     }
 
-    return { results: results.rows, duration };
+    return { results: results.rows, columns: results.columns, duration };
   }
 
   getDropUnitsTableQuery(params: DropTableQueryParams): string {

--- a/packages/back-end/src/jobs/refreshFactTableColumns.ts
+++ b/packages/back-end/src/jobs/refreshFactTableColumns.ts
@@ -138,7 +138,48 @@ export async function runRefreshColumnsQuery(
 
   const typeMap = new Map<string, FactTableColumnType>();
   const jsonMap = new Map<string, JSONColumnFields>();
-  determineColumnTypes(result.results).forEach((col) => {
+
+  result.columns?.forEach((col) => {
+    // If the underlying SQL engine returned the datatype, use it
+    if (col.dataType !== undefined) {
+      // For JSON, only return if we have the field information, otherwise skip
+      // so we can infer from the returned data
+      if (
+        col.dataType === "json" &&
+        col.fields !== undefined &&
+        col.fields.length > 0
+      ) {
+        typeMap.set(col.name, "json");
+        jsonMap.set(
+          col.name,
+          col.fields.reduce(
+            (acc, field) => ({
+              ...acc,
+              [field.name]: {
+                datatype: field.dataType,
+              },
+            }),
+            {},
+          ),
+        );
+      } else if (col.dataType !== "json") {
+        typeMap.set(col.name, col.dataType);
+      }
+    }
+  });
+
+  // Remove columns that we already know the type of from the first result
+  // so we can determine the types of the remaining columns
+  const resultWithoutKnownColumns = result.results?.[0];
+  if (resultWithoutKnownColumns) {
+    for (const col of Object.keys(resultWithoutKnownColumns)) {
+      if (typeMap.has(col)) {
+        delete resultWithoutKnownColumns[col];
+      }
+    }
+  }
+
+  determineColumnTypes([resultWithoutKnownColumns]).forEach((col) => {
     typeMap.set(col.column, col.datatype);
     if (col.jsonFields) {
       jsonMap.set(col.column, col.jsonFields);

--- a/packages/back-end/src/services/bigquery.ts
+++ b/packages/back-end/src/services/bigquery.ts
@@ -1,0 +1,66 @@
+import { FactTableColumnType } from "back-end/types/fact-table";
+import { logger } from "back-end/src/util/logger";
+
+export type BigQueryDataType =
+  | "STRING"
+  | "BYTES"
+  | "INTEGER"
+  | "INT64"
+  | "FLOAT"
+  | "FLOAT64"
+  | "BOOLEAN"
+  | "BOOL"
+  | "TIMESTAMP"
+  | "DATE"
+  | "TIME"
+  | "DATETIME"
+  | "GEOGRAPHY"
+  | "NUMERIC"
+  | "BIGNUMERIC"
+  | "JSON"
+  | "RECORD"
+  | "STRUCT"
+  | "RANGE";
+
+export function getFactTableTypeFromBigQueryType(
+  dataType: BigQueryDataType,
+): FactTableColumnType | undefined {
+  switch (dataType) {
+    case "STRING":
+      return "string";
+
+    case "BOOL":
+    case "BOOLEAN":
+      return "boolean";
+
+    case "NUMERIC":
+    case "BIGNUMERIC":
+    case "INTEGER":
+    case "INT64":
+    case "FLOAT":
+    case "FLOAT64":
+      return "number";
+
+    case "DATE":
+    case "TIME":
+    case "DATETIME":
+    case "TIMESTAMP":
+      return "date";
+
+    case "JSON":
+    case "RECORD":
+    case "STRUCT":
+      return "json";
+
+    case "RANGE":
+    case "GEOGRAPHY":
+    case "BYTES":
+      return "other";
+
+    default: {
+      const _: never = dataType;
+      logger.warn(`Unsupported BigQuery data type: ${dataType}`);
+      return undefined;
+    }
+  }
+}

--- a/packages/back-end/src/types/Integration.ts
+++ b/packages/back-end/src/types/Integration.ts
@@ -19,6 +19,7 @@ import { FactTableMap } from "back-end/src/models/FactTableModel";
 import {
   ColumnInterface,
   FactMetricInterface,
+  FactTableColumnType,
   FactTableInterface,
   MetricQuantileSettings,
 } from "back-end/types/fact-table";
@@ -444,10 +445,16 @@ export type UserExperimentExposuresQueryResponseRows = {
   [key: string]: string | null;
 }[];
 
+export type QueryResponseColumnData = {
+  name: string;
+  dataType?: FactTableColumnType;
+  fields?: QueryResponseColumnData[];
+};
+
 // eslint-disable-next-line
 export type QueryResponse<Rows = Record<string, any>[]> = {
   rows: Rows;
-  columns?: string[];
+  columns?: QueryResponseColumnData[];
   statistics?: QueryStatistics;
 };
 
@@ -481,6 +488,7 @@ export interface TestQueryRow {
 
 export interface TestQueryResult {
   results: TestQueryRow[];
+  columns?: QueryResponseColumnData[];
   duration: number;
 }
 


### PR DESCRIPTION
### Features and Changes

This changes our logic for BigQuery to use the information returned by the Query to determined the types of columns on our end, instead of always testing against the returned values to infer what type it is.