### PR TITLE
Update cloud rate limit warning

### DIFF
--- a/packages/back-end/src/api/api.router.ts
+++ b/packages/back-end/src/api/api.router.ts
@@ -7,7 +7,7 @@ import * as Sentry from "@sentry/node";
 import authenticateApiRequestMiddleware from "back-end/src/middleware/authenticateApiRequestMiddleware";
 import { getBuild } from "back-end/src/util/build";
 import { ApiRequestLocals } from "back-end/types/api";
-import { SENTRY_DSN } from "../util/secrets";
+import { IS_CLOUD, SENTRY_DSN } from "../util/secrets";
 import featuresRouter from "./features/features.router";
 import experimentsRouter from "./experiments/experiments.router";
 import snapshotsRouter from "./snapshots/snapshots.router";
@@ -79,6 +79,7 @@ if (SENTRY_DSN) {
 }
 
 const API_RATE_LIMIT_MAX = Number(process.env.API_RATE_LIMIT_MAX) || 60;
+const overallRateLimit = IS_CLOUD ? 60 : API_RATE_LIMIT_MAX;
 // Rate limit API keys to 60 requests per minute
 router.use(
   rateLimit({
@@ -88,7 +89,7 @@ router.use(
     legacyHeaders: false,
     keyGenerator: (req: Request & ApiRequestLocals) => req.apiKey,
     message: {
-      message: `Too many requests, limit to ${API_RATE_LIMIT_MAX} per minute`,
+      message: `Too many requests, limit to ${overallRateLimit} per minute`,
     },
   }),
 );


### PR DESCRIPTION
### Features and Changes
Now that we set a lower rate limit per server the error message says an incorrect too low limit.  So we hard code the error message for cloud.  

### Testing
cross-fingers
