### PR TITLE
Create feature rules in multiple environments at once

### DIFF
--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -1250,7 +1250,11 @@ export async function postFeatureRule(
   const context = getContextFromReq(req);
   const { org } = context;
   const { id, version } = req.params;
-  const { environment, rule, safeRolloutFields } = req.body;
+  const {
+    environments: selectedEnvironments,
+    rule,
+    safeRolloutFields,
+  } = req.body;
 
   const feature = await getFeature(context, id);
   if (!feature) {
@@ -1261,8 +1265,14 @@ export async function postFeatureRule(
   const environments = filterEnvironmentsByFeature(allEnvironments, feature);
   const environmentIds = environments.map((e) => e.id);
 
-  if (!environmentIds.includes(environment)) {
-    throw new Error("Invalid environment");
+  selectedEnvironments.forEach((env) => {
+    if (!environmentIds.includes(env)) {
+      throw new Error("Invalid environment");
+    }
+  });
+
+  if (!selectedEnvironments.length) {
+    throw new Error("Must select at least one environment");
   }
 
   if (
@@ -1273,6 +1283,13 @@ export async function postFeatureRule(
   }
 
   if (rule.type === "safe-rollout") {
+    const environment = selectedEnvironments[0];
+    if (selectedEnvironments.length > 1) {
+      throw new Error(
+        "Safe Rollout rules can only be applied to a single environment",
+      );
+    }
+
     if (!context.hasPremiumFeature("safe-rollout")) {
       throw new Error(`Safe Rollout rules is a premium feature.`);
     }
@@ -1359,14 +1376,14 @@ export async function postFeatureRule(
   const revision = await getDraftRevision(context, feature, parseInt(version));
   const resetReview = resetReviewOnChange({
     feature,
-    changedEnvironments: [environment],
+    changedEnvironments: selectedEnvironments,
     defaultValueChanged: false,
     settings: org?.settings,
   });
   await addFeatureRule(
     context,
     revision,
-    environment,
+    selectedEnvironments,
     rule,
     res.locals.eventAudit,
     resetReview,

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -806,7 +806,7 @@ export async function toggleFeatureEnvironment(
 export async function addFeatureRule(
   context: ReqContext | ApiReqContext,
   revision: FeatureRevisionInterface,
-  env: string,
+  envs: string[],
   rule: FeatureRule,
   user: EventUser,
   resetReview: boolean,
@@ -819,8 +819,10 @@ export async function addFeatureRule(
     rules: revision.rules || {},
     status: revision.status,
   };
-  changes.rules[env] = changes.rules[env] || [];
-  changes.rules[env].push(rule);
+  envs.forEach((env) => {
+    changes.rules[env] = changes.rules[env] || [];
+    changes.rules[env].push(rule);
+  });
   await updateRevision(
     context,
     revision,
@@ -828,7 +830,7 @@ export async function addFeatureRule(
     {
       user,
       action: "add rule",
-      subject: `to ${env}`,
+      subject: `to ${envs.join(", ")}`,
       value: JSON.stringify(rule),
     },
     resetReview,

--- a/packages/back-end/types/feature-rule.d.ts
+++ b/packages/back-end/types/feature-rule.d.ts
@@ -3,7 +3,7 @@ import { CreateSafeRolloutInterface } from "back-end/src/validators/safe-rollout
 
 export type PostFeatureRuleBody = {
   rule: FeatureRule;
-  environment: string;
+  environments: string[];
   safeRolloutFields?: CreateSafeRolloutInterface;
 };
 

--- a/packages/back-end/types/organization.d.ts
+++ b/packages/back-end/types/organization.d.ts
@@ -255,6 +255,7 @@ export interface OrganizationSettings {
   defaultDecisionCriteriaId?: string;
   disableLegacyMetricCreation?: boolean;
   blockFileUploads?: boolean;
+  defaultFeatureRulesInAllEnvs?: boolean;
 }
 
 export interface OrganizationConnections {

--- a/packages/front-end/components/Features/FeatureModal/EnvironmentSelect.tsx
+++ b/packages/front-end/components/Features/FeatureModal/EnvironmentSelect.tsx
@@ -7,10 +7,11 @@ import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 import Checkbox from "@/ui/Checkbox";
 
 const EnvironmentSelect: FC<{
-  environmentSettings: Record<string, FeatureEnvironment>;
+  environmentSettings: Record<string, Pick<FeatureEnvironment, "enabled">>;
   environments: Environment[];
   setValue: (env: Environment, enabled: boolean) => void;
-}> = ({ environmentSettings, environments, setValue }) => {
+  label?: string;
+}> = ({ environmentSettings, environments, setValue, label }) => {
   const permissionsUtil = usePermissionsUtil();
   const { project } = useDefinitions();
   const environmentsUserCanAccess = useMemo(() => {
@@ -29,7 +30,7 @@ const EnvironmentSelect: FC<{
   return (
     <div className="form-group">
       <Text as="label" weight="bold" mb="2">
-        Enabled Environments
+        {label || "Enabled Environments"}
       </Text>
       <Box
         className="box"

--- a/packages/front-end/components/GeneralSettings/FeaturesSettings.tsx
+++ b/packages/front-end/components/GeneralSettings/FeaturesSettings.tsx
@@ -222,6 +222,46 @@ export default function FeaturesSettings() {
             </Box>
           )}
 
+          <Box mb="6" width="100%">
+            <Flex align="start" justify="start" gap="3">
+              <Box>
+                <Checkbox
+                  id="toggle-defaultFeatureRulesInAllEnvs"
+                  value={!!form.watch("defaultFeatureRulesInAllEnvs")}
+                  setValue={(value) => {
+                    form.setValue("defaultFeatureRulesInAllEnvs", value, {
+                      shouldDirty: true,
+                    });
+                  }}
+                  mt="1"
+                />
+              </Box>
+              <Flex
+                direction="column"
+                justify="start"
+                style={{ marginTop: "1px" }}
+              >
+                <Box>
+                  <Text
+                    size="3"
+                    className="font-weight-semibold"
+                    htmlFor="toggle-defaultFeatureRulesInAllEnvs"
+                    as="label"
+                    mb="2"
+                  >
+                    Create rules in all environments by default
+                  </Text>
+                </Box>
+                <Box>
+                  <Text size="2" color="gray">
+                    If enabled, new feature rules will be created in all
+                    environments by default.
+                  </Text>
+                </Box>
+              </Flex>
+            </Flex>
+          </Box>
+
           {hasRequireApprovals && (
             <>
               <Box mb="6" width="100%">

--- a/packages/front-end/pages/settings/index.tsx
+++ b/packages/front-end/pages/settings/index.tsx
@@ -170,6 +170,8 @@ const GeneralSettingsPage = (): React.ReactElement => {
       openAIDefaultModel: settings.openAIDefaultModel || "gpt-4o-mini",
       disableLegacyMetricCreation:
         settings.disableLegacyMetricCreation ?? false,
+      defaultFeatureRulesInAllEnvs:
+        settings.defaultFeatureRulesInAllEnvs ?? false,
     },
   });
   const { apiCall } = useAuth();
@@ -217,6 +219,7 @@ const GeneralSettingsPage = (): React.ReactElement => {
     aiEnabled: form.watch("aiEnabled"),
     openAIDefaultModel: form.watch("openAIDefaultModel"),
     disableLegacyMetricCreation: form.watch("disableLegacyMetricCreation"),
+    defaultFeatureRulesInAllEnvs: form.watch("defaultFeatureRulesInAllEnvs"),
   };
   function updateCronString(cron?: string) {
     cron = cron || value.updateSchedule?.cron || "";


### PR DESCRIPTION
### Features and Changes

When adding a rule to a feature, it's common to want to add the same rule to multiple environments at once.  This PR adds a new field when creating a rule where you can select which environments to create it in.

<img width="801" height="927" alt="Screenshot from 2025-10-07 18-08-41" src="https://github.com/user-attachments/assets/92007d87-8878-4d23-8a16-f40cc7f5fe4e" />


By default, only the current environment tab is checked (just like how it works today).  However, you can change this default behavior in General Settings on the Features tab:

<img width="717" height="79" alt="Screenshot from 2025-10-07 18-11-43" src="https://github.com/user-attachments/assets/724ab981-4cee-461f-9b8c-dd4f5a473561" />
