### PR TITLE
Use removeMongooseFields for code-refs

### DIFF
--- a/packages/back-end/src/models/FeatureCodeRefs.ts
+++ b/packages/back-end/src/models/FeatureCodeRefs.ts
@@ -2,6 +2,7 @@ import mongoose from "mongoose";
 import { FeatureCodeRefsInterface } from "back-end/types/code-refs";
 import {
   ToInterface,
+  getCollection,
   removeMongooseFields,
 } from "back-end/src/util/mongo.util";
 import { ApiCodeRef } from "back-end/types/openapi";
@@ -43,6 +44,8 @@ const FeatureCodeRefsModel = mongoose.model<FeatureCodeRefsInterface>(
   "FeatureCodeRefs",
   featureCodeRefsSchema,
 );
+
+const COLLECTION = "featurecoderefs";
 
 const toInterface: ToInterface<FeatureCodeRefsInterface> = (doc) =>
   removeMongooseFields(doc);
@@ -94,12 +97,16 @@ export const upsertFeatureCodeRefs = async ({
     { upsert: true },
   );
 
-  return await FeatureCodeRefsModel.find({
-    feature,
-    repo,
-    branch,
-    organization: organization.id,
-  }).then((docs) => docs.map(toInterface));
+  const docs = await getCollection(COLLECTION)
+    .find({
+      feature,
+      repo,
+      branch,
+      organization: organization.id,
+    })
+    .toArray();
+
+  return docs.map((d) => toInterface(d));
 };
 
 export const getFeatureCodeRefsByFeatures = async ({
@@ -113,12 +120,16 @@ export const getFeatureCodeRefsByFeatures = async ({
   features: string[];
   organization: OrganizationInterface;
 }): Promise<FeatureCodeRefsInterface[]> => {
-  return await FeatureCodeRefsModel.find({
-    repo,
-    branch,
-    feature: { $in: features },
-    organization: organization.id,
-  }).then((docs) => docs.map(toInterface));
+  const docs = await getCollection(COLLECTION)
+    .find({
+      repo,
+      branch,
+      feature: { $in: features },
+      organization: organization.id,
+    })
+    .toArray();
+
+  return docs.map((d) => toInterface(d));
 };
 
 export const getAllCodeRefsForFeature = async ({
@@ -128,10 +139,14 @@ export const getAllCodeRefsForFeature = async ({
   feature: string;
   organization: OrganizationInterface;
 }): Promise<FeatureCodeRefsInterface[]> => {
-  return await FeatureCodeRefsModel.find({
-    feature,
-    organization: organization.id,
-  }).then((docs) => docs.map(toInterface));
+  const docs = await getCollection(COLLECTION)
+    .find({
+      feature,
+      organization: organization.id,
+    })
+    .toArray();
+
+  return docs.map((d) => toInterface(d));
 };
 
 export const getAllCodeRefsForOrg = async ({
@@ -139,7 +154,11 @@ export const getAllCodeRefsForOrg = async ({
 }: {
   context: ReqContext | ApiReqContext;
 }): Promise<FeatureCodeRefsInterface[]> => {
-  return await FeatureCodeRefsModel.find({
-    organization: context.org.id,
-  }).then((docs) => docs.map(toInterface));
+  const docs = await getCollection(COLLECTION)
+    .find({
+      organization: context.org.id,
+    })
+    .toArray();
+
+  return docs.map((d) => toInterface(d));
 };

--- a/packages/back-end/src/models/FeatureCodeRefs.ts
+++ b/packages/back-end/src/models/FeatureCodeRefs.ts
@@ -1,6 +1,9 @@
 import mongoose from "mongoose";
-import { omit } from "lodash";
 import { FeatureCodeRefsInterface } from "back-end/types/code-refs";
+import {
+  ToInterface,
+  removeMongooseFields,
+} from "back-end/src/util/mongo.util";
 import { ApiCodeRef } from "back-end/types/openapi";
 import { OrganizationInterface, ReqContext } from "back-end/types/organization";
 import { ApiReqContext } from "back-end/types/api";
@@ -41,10 +44,8 @@ const FeatureCodeRefsModel = mongoose.model<FeatureCodeRefsInterface>(
   featureCodeRefsSchema,
 );
 
-function toInterface(doc: FeatureCodeRefsDocument): FeatureCodeRefsInterface {
-  const ret = doc.toJSON<FeatureCodeRefsDocument>();
-  return omit(ret, ["__v", "_id"]);
-}
+const toInterface: ToInterface<FeatureCodeRefsInterface> = (doc) =>
+  removeMongooseFields(doc);
 
 export function toApiInterface(doc: FeatureCodeRefsDocument): ApiCodeRef {
   return {


### PR DESCRIPTION
### Features and Changes

Our servers are often becoming unresponsive because lodash.omit is slow in code_refs. 

### Testing

Create a Personal Access Token.

GROWTHBOOK_API_KEY=<PAT>
GROWTHBOOK_API_HOST=http://localhost:3100
curl -H "Authorization: Bearer $GROWTHBOOK_API_KEY" "$GROWTHBOOK_API_HOST/api/v1/feature-keys" -o flags.json
./gb-find-code-refs -d ../growthbook -f ./flags.json -n growthbook/growthbook
curl -XPOST -H "Authorization: Bearer $GROWTHBOOK_API_KEY" -H "Content-Type: application/json" -d @coderefs_ji_code-ref.json "$GROWTHBOOK_API_HOST/api/v1/code-refs?deleteMissing=false"
See that it finishes, go to the feature and see the code refs (Make sure to enable Code-refs in settings first).  For example make a feature called: `aa-test-holdout` and after the post go to http://localhost:3000/features/aa-test-holdout
