### PR TITLE
Api Rate Limit Per Org

### DIFF
--- a/packages/back-end/src/api/api.router.ts
+++ b/packages/back-end/src/api/api.router.ts
@@ -7,7 +7,7 @@ import * as Sentry from "@sentry/node";
 import authenticateApiRequestMiddleware from "back-end/src/middleware/authenticateApiRequestMiddleware";
 import { getBuild } from "back-end/src/util/build";
 import { ApiRequestLocals } from "back-end/types/api";
-import { IS_CLOUD, SENTRY_DSN } from "../util/secrets";
+import { SENTRY_DSN } from "../util/secrets";
 import featuresRouter from "./features/features.router";
 import experimentsRouter from "./experiments/experiments.router";
 import snapshotsRouter from "./snapshots/snapshots.router";
@@ -91,16 +91,7 @@ router.use(
     standardHeaders: true,
     legacyHeaders: false,
     keyGenerator: (req: Request & ApiRequestLocals) => req.apiKey,
-    message: (req: Request & ApiRequestLocals) => {
-      const rateLimitForWarning = IS_CLOUD
-        ? 60
-        : req.context.org?.apiRateLimit ||
-          Number(process.env.API_RATE_LIMIT_MAX) ||
-          60;
-      return {
-        message: `Too many requests, limit to ${rateLimitForWarning} per minute`,
-      };
-    },
+    message: { message: `Too many requests per minute` },
   }),
 );
 

--- a/packages/back-end/src/api/api.router.ts
+++ b/packages/back-end/src/api/api.router.ts
@@ -83,7 +83,7 @@ router.use(
     windowMs: 60 * 1000, // 1 minute window
     max: (req: Request & ApiRequestLocals) => {
       return (
-        req.context.org.apiRateLimit ||
+        req.context.org?.apiRateLimit ||
         Number(process.env.API_RATE_LIMIT_MAX) ||
         60
       );
@@ -94,7 +94,7 @@ router.use(
     message: (req: Request & ApiRequestLocals) => {
       const rateLimitForWarning = IS_CLOUD
         ? 60
-        : req.context.org.apiRateLimit ||
+        : req.context.org?.apiRateLimit ||
           Number(process.env.API_RATE_LIMIT_MAX) ||
           60;
       return {

--- a/packages/back-end/types/organization.d.ts
+++ b/packages/back-end/types/organization.d.ts
@@ -339,6 +339,7 @@ export interface OrganizationInterface {
   deactivatedRoles?: string[];
   disabled?: boolean;
   setupEventTracker?: string;
+  apiRateLimit?: number;
 }
 
 export type NamespaceUsage = Record<


### PR DESCRIPTION
### Features and Changes
Have a unique api limit that can be set on a per org basis.

### Testing

Create a personal API token <PAT>
```
for i in {1..65}; do
  echo "Request $i:"
  curl -H "Authorization: Bearer <PAT>" \
       -H "Content-Type: application/json" \
       -w "HTTP Status: %{http_code}, Time: %{time_total}s\n" \
       -s \
       http://localhost:3100/api/v1/
  echo "---"
done
```
See that the first 60 succeed, then the last 5 return 429.

Then set `apiRateLimit: 5` on the org in Mongo
Do the same command and see the first 5 succeed and then next 60 fail.