### PR TITLE
Have SavedGroups use Mongo Utils for Perf Gains

### DIFF
--- a/packages/back-end/src/models/SavedGroupModel.ts
+++ b/packages/back-end/src/models/SavedGroupModel.ts
@@ -1,6 +1,5 @@
 import mongoose from "mongoose";
 import uniqid from "uniqid";
-import { omit } from "lodash";
 import { SavedGroupInterface } from "shared/src/types";
 import { ApiSavedGroup } from "back-end/types/openapi";
 import {
@@ -8,6 +7,11 @@ import {
   LegacySavedGroupInterface,
   UpdateSavedGroupProps,
 } from "back-end/types/saved-group";
+import {
+  ToInterface,
+  getCollection,
+  removeMongooseFields,
+} from "back-end/src/util/mongo.util";
 import { migrateSavedGroup } from "back-end/src/util/migrations";
 
 const savedGroupSchema = new mongoose.Schema({
@@ -36,18 +40,15 @@ const savedGroupSchema = new mongoose.Schema({
   useEmptyListGroup: Boolean,
 });
 
-type SavedGroupDocument = mongoose.Document & LegacySavedGroupInterface;
-
 const SavedGroupModel = mongoose.model<LegacySavedGroupInterface>(
   "savedGroup",
   savedGroupSchema,
 );
 
-const toInterface = (doc: SavedGroupDocument): SavedGroupInterface => {
-  const legacy = omit(doc.toJSON<SavedGroupDocument>({ flattenMaps: true }), [
-    "__v",
-    "_id",
-  ]);
+const COLLECTION = "savedgroups";
+
+const toInterface: ToInterface<SavedGroupInterface> = (doc) => {
+  const legacy = removeMongooseFields(doc);
 
   return migrateSavedGroup(legacy);
 };
@@ -79,9 +80,12 @@ export async function createSavedGroup(
 export async function getAllSavedGroups(
   organization: string,
 ): Promise<SavedGroupInterface[]> {
-  const savedGroups: SavedGroupDocument[] = await SavedGroupModel.find({
-    organization,
-  });
+  const savedGroups = await getCollection(COLLECTION)
+    .find({
+      organization,
+    })
+    .toArray();
+
   return savedGroups.map(toInterface);
 }
 
@@ -89,7 +93,7 @@ export async function getSavedGroupById(
   savedGroupId: string,
   organization: string,
 ): Promise<SavedGroupInterface | null> {
-  const savedGroup = await SavedGroupModel.findOne({
+  const savedGroup = await getCollection(COLLECTION).findOne({
     id: savedGroupId,
     organization: organization,
   });
@@ -101,10 +105,12 @@ export async function getSavedGroupsById(
   savedGroupIds: string[],
   organization: string,
 ): Promise<SavedGroupInterface[]> {
-  const savedGroups = await SavedGroupModel.find({
-    id: savedGroupIds,
-    organization: organization,
-  });
+  const savedGroups = await getCollection(COLLECTION)
+    .find({
+      id: savedGroupIds,
+      organization: organization,
+    })
+    .toArray();
 
   return savedGroups ? savedGroups.map((group) => toInterface(group)) : [];
 }


### PR DESCRIPTION
### Features and Changes

Saved Groups are not BaseModel and it was using the inefficient lodash `omit`. This causes some requests for `organization/definitions` to lock up CPU which slows down other requests as well for example in [this request](https://us5.datadoghq.com/profiling/profile/AZnHiatVAABfQq3BNAXMzgAA?event=AwAAAZnHiaolGeU9eAAAABhBWm5IaWF0VkFBQmZRcTNCTkFYTXpnQUEAAAAkMDE5OWM3OGUtMGNlNS00ODI2LTk3ZTktNWI2MTE4MjU2NWZkAAAAIQ&filterBy=spanChild&localRootSpanID=1874516341563339515&my_code=enabled&p_tl_tb=1759989246857000000&p_tl_tf_f_0=0&p_tl_tf_f_1=65180000000&p_tl_tf_s_0=3769001728&p_tl_tf_s_1=10833972919&p_tl_tf_us_0=3769001728&p_tl_tf_us_1=10833972919&profileViz=timeline&profiling-timeline__stack_order=top-down&profiling-timeline__summary_tab=flame-graph&spanID=1874516341563339515&timeHint=1759989257.69&trace-to-profile__filter_by=spanChild&traceID=68e74e02000000001a039eae588c32fb
).  By moving it over to using mongo utils cpu bottleneck should go away. 

- Closes **(add link to issue here)**

### Testing

Create Saved Groups on http://localhost:3000/saved-groups (calls `getAllSavedGroups`). 
See the items in the list.

Edit a saved Group (calls `getSavedGroupById`)
See the updated saved group's definition in the list.

Add the saved group to a feature.
Create a Personal Access Token.
Call ```
 curl -H "Authorization: Bearer <PAT>" \
       -H "Content-Type: application/json" \
       -w "HTTP Status: %{http_code}, Time: %{time_total}s\n" \
       -s \
       "http://localhost:3100/api/v1/features?clientKey=<SDK KEY FOR ENV THAT HAS THAT FEATURE ENABLED>"
``` (calls `getSavedGroupsById`)
See savedGroups in the output.

