### PR TITLE
adjust graph domain based on row hidden/expanded status

### DIFF
--- a/packages/front-end/services/experiments.ts
+++ b/packages/front-end/services/experiments.ts
@@ -279,7 +279,7 @@ export function useDomain(
   let upperBound = 0;
   rows.forEach((row) => {
     // Skip metric slice rows that are hidden (not expanded or pinned)
-    if (row.isSliceRow && row.isHiddenByFilter) {
+    if (row.isHiddenByFilter) {
       return;
     }
 


### PR DESCRIPTION
### Features and Changes

Adjust results table graph range (x-axis) based on whether the rows are shown/hidden. Previously it was including all rows (even hidden)

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

<!--
  Please describe how to test these changes.
 -->

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
