### PR TITLE
rollback future v4 updates

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -29,11 +29,6 @@ const config = {
     locales: ["en"], // Ensure only 'en' is listed if it's single-language
   },
 
-  // Enable v4 features
-  future: {
-    v4: true,
-  },
-
   // Markdown
   markdown: {
     hooks: {


### PR DESCRIPTION
The v4 future updates introduced some bugs (like broken dark mode), so we'll restrict features to the latest version.