### PR TITLE
Fix dashboard permission errors

### DIFF
--- a/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardBlock/index.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardBlock/index.tsx
@@ -76,7 +76,7 @@ type ObjectProps<Block> = {
 export type BlockProps<T extends DashboardBlockInterface> = {
   isTabActive: boolean;
   block: DashboardBlockInterfaceOrData<T>;
-  setBlock: React.Dispatch<DashboardBlockInterfaceOrData<T>>;
+  setBlock: undefined | React.Dispatch<DashboardBlockInterfaceOrData<T>>;
   snapshot: ExperimentSnapshotInterface;
   analysis: ExperimentSnapshotAnalysis;
   mutate: () => void;
@@ -95,7 +95,9 @@ interface Props<DashboardBlock extends DashboardBlockInterface> {
   isFirstBlock: boolean;
   isLastBlock: boolean;
   scrollAreaRef: null | React.MutableRefObject<HTMLDivElement | null>;
-  setBlock: React.Dispatch<DashboardBlockInterfaceOrData<DashboardBlock>>;
+  setBlock:
+    | undefined
+    | React.Dispatch<DashboardBlockInterfaceOrData<DashboardBlock>>;
   editBlock: () => void;
   duplicateBlock: () => void;
   deleteBlock: () => void;
@@ -336,7 +338,7 @@ export default function DashboardBlock<T extends DashboardBlockInterface>({
         </DropdownMenu>
       )}
       <Flex align="center" mb="2" mr="3">
-        {canEditTitle && editTitle ? (
+        {canEditTitle && editTitle && setBlock ? (
           <Field
             autoFocus
             defaultValue={block.title || BLOCK_TYPE_INFO[block.type].name}

--- a/packages/front-end/enterprise/components/Dashboards/DashboardEditor/index.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardEditor/index.tsx
@@ -139,10 +139,12 @@ interface Props {
   focusedBlockIndex: number | undefined;
   stagedBlockIndex: number | undefined;
   scrollAreaRef: null | React.MutableRefObject<HTMLDivElement | null>;
-  setBlock: (
-    index: number,
-    block: DashboardBlockInterfaceOrData<DashboardBlockInterface>,
-  ) => void;
+  setBlock:
+    | undefined
+    | ((
+        index: number,
+        block: DashboardBlockInterfaceOrData<DashboardBlockInterface>,
+      ) => void);
   moveBlock: (index: number, direction: -1 | 1) => void;
   addBlockType: (bType: DashboardBlockType, i?: number) => void;
   editBlock: (index: number) => void;
@@ -186,9 +188,9 @@ function DashboardEditor({
     key: number | string;
     block: DashboardBlockInterfaceOrData<DashboardBlockInterface>;
     isFocused: boolean;
-    setBlock: React.Dispatch<
-      DashboardBlockInterfaceOrData<DashboardBlockInterface>
-    >;
+    setBlock:
+      | undefined
+      | React.Dispatch<DashboardBlockInterfaceOrData<DashboardBlockInterface>>;
     isEditingBlock: boolean;
     isLastBlock: boolean;
   }) => {
@@ -346,7 +348,7 @@ function DashboardEditor({
                   : `${block.type}-${i}`,
                 block: block,
                 isFocused: focusedBlockIndex === i,
-                setBlock: (block) => setBlock(i, block),
+                setBlock: setBlock ? (block) => setBlock(i, block) : undefined,
                 isEditingBlock: stagedBlockIndex === i,
                 isLastBlock: i === blocks.length - 1,
               }),

--- a/packages/front-end/enterprise/components/Dashboards/DashboardsTab.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardsTab.tsx
@@ -574,21 +574,25 @@ function DashboardsTab({
                         scrollAreaRef={null}
                         enableAutoUpdates={dashboard.enableAutoUpdates}
                         nextUpdate={experiment.nextSnapshotAttempt}
-                        setBlock={(i, block) => {
-                          const newBlocks = [
-                            ...blocks.slice(0, i),
-                            block,
-                            ...blocks.slice(i + 1),
-                          ];
-                          setBlocks(newBlocks);
-                          submitDashboard({
-                            method: "PUT",
-                            dashboardId,
-                            data: {
-                              blocks: newBlocks,
-                            },
-                          });
-                        }}
+                        setBlock={
+                          canEdit
+                            ? (i, block) => {
+                                const newBlocks = [
+                                  ...blocks.slice(0, i),
+                                  block,
+                                  ...blocks.slice(i + 1),
+                                ];
+                                setBlocks(newBlocks);
+                                submitDashboard({
+                                  method: "PUT",
+                                  dashboardId,
+                                  data: {
+                                    blocks: newBlocks,
+                                  },
+                                });
+                              }
+                            : undefined
+                        }
                         // TODO: reduce unnecessary props
                         stagedBlockIndex={undefined}
                         editSidebarDirty={false}


### PR DESCRIPTION
### Features and Changes

Dashboards were repeatedly throwing permission errors which seems to have come from the snapshot management in the frontend. This PR removes the `setBlock` helper which was the source of these errors from the relevant components if the user doesn't have edit permission.

### Testing

I'm not sure how users got into this behavior in the wild, but it involves having a dashboard where the dimension results were never loaded by a user with permission. Here's what I did locally that ended up reproducing the issue

1. Set up precomputed dimensions and create a dashboard using a precomputed dimension's results
2. Disable precomputed results in the org settings and refresh the experiment results
3. Change the dimension for the dashboard from the precomputed to the on-demand version of the same dimension
4. Observe that the dashboard refreshes infinitely (this is broken behavior that will need to be addressed separately)
5. Create a user with read-only permissions and load the broken dashboard

### Screenshots

Behavior on main
<img width="862" height="970" alt="image" src="https://github.com/user-attachments/assets/c082575f-5e4e-4329-b27f-e9c8ce29c27d" />

Behavior on this branch
<img width="2559" height="1087" alt="image" src="https://github.com/user-attachments/assets/b8543d39-f032-465d-a811-7fe4d870772c" />


