### PR TITLE
Make permission errors status 403

### DIFF
--- a/packages/shared/src/permissions/permissionsClass.ts
+++ b/packages/shared/src/permissions/permissionsClass.ts
@@ -30,6 +30,7 @@ import { HoldoutInterface } from "back-end/src/routers/holdout/holdout.validator
 import { SavedGroupInterface } from "../types";
 import { READ_ONLY_PERMISSIONS } from "./permissions.constants";
 class PermissionError extends Error {
+  status = 403;
   constructor(message: string) {
     super(message);
     this.name = "PermissionError";


### PR DESCRIPTION
### Features and Changes

The `context.permissions.throwPermissionError()` helper was previously sending a status of `400` rather than the expected `403`. We already have an error-handler configured in Express so a quick one-liner lets us match proper behavior.

### Screenshots

Behavior on main
<img width="1277" height="321" alt="image" src="https://github.com/user-attachments/assets/7673e692-31ca-4608-a97f-64fcc0c2c90c" />


With this change
<img width="1178" height="435" alt="image" src="https://github.com/user-attachments/assets/209ea04d-9d8e-430f-bed2-7bfd614ee742" />
