### PR TITLE
Hide dashboard update button based on permissions

### DIFF
--- a/packages/front-end/enterprise/components/Dashboards/DashboardSnapshotProvider.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardSnapshotProvider.tsx
@@ -27,6 +27,7 @@ import { getQueryStatus } from "@/components/Queries/RunQueriesButton";
 
 export const DashboardSnapshotContext = React.createContext<{
   experiment?: ExperimentInterfaceStringDates;
+  projects?: string[];
   defaultSnapshot?: ExperimentSnapshotInterface;
   dimensionless?: ExperimentSnapshotInterface;
   snapshotsMap: Map<string, ExperimentSnapshotInterface>;
@@ -164,6 +165,7 @@ export default function DashboardSnapshotProvider({
     <DashboardSnapshotContext.Provider
       value={{
         experiment,
+        projects: experiment?.project ? [experiment.project] : undefined,
         defaultSnapshot: snapshotData?.snapshot,
         dimensionless: snapshotData?.dimensionless,
         snapshotsMap,

--- a/packages/shared/src/permissions/permissionsClass.ts
+++ b/packages/shared/src/permissions/permissionsClass.ts
@@ -528,6 +528,15 @@ export class Permissions {
     );
   };
 
+  public canCreateAnalyses = (projects?: string[]): boolean => {
+    return this.checkProjectFilterPermission(
+      {
+        projects: projects ? projects : [],
+      },
+      "createAnalyses",
+    );
+  };
+
   // This is a helper method to use on the frontend to determine whether or not to show certain UI elements
   public canViewIdeaModal = (project?: string): boolean => {
     return this.canCreateIdea({ project });


### PR DESCRIPTION
### Features and Changes

While debugging dashboard permission errors I noticed that the update button is rendering even for users without permissions. This PR adds the appropriate checks based on the experiment/dashboard projects as well as the saved queries referenced.

### Testing

Create a dashboard on an experiment in a project, and a user with read-only access to that project.
The user should be able to load the dashboard but the update button should be hidden

### Screenshots

User with permissions
<img width="1488" height="80" alt="image" src="https://github.com/user-attachments/assets/57e5f354-085a-4b7f-84d1-8f98a2d3f90a" />

<img width="2080" height="650" alt="image" src="https://github.com/user-attachments/assets/9c2bc609-bc68-48d9-85bb-ef9d5fdae423" />

Read-only user

<img width="2020" height="728" alt="image" src="https://github.com/user-attachments/assets/5d95ccc8-39d5-426e-9879-1c24332e94b8" />

