### PR TITLE
Prevent looping fetches for snapshots in dashboards

### DIFF
--- a/packages/front-end/enterprise/components/Dashboards/DashboardSnapshotProvider.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardSnapshotProvider.tsx
@@ -206,6 +206,7 @@ export function useDashboardSnapshot(
   const [postSnapshotAnalysisLoading, setPostSnapshotAnalysisLoading] =
     useState(false);
   const [fetchingSnapshot, setFetchingSnapshot] = useState(false);
+  const [fetchingSnapshotFailed, setFetchingSnapshotFailed] = useState(false);
 
   const blockSnapshotId = block?.snapshotId;
   const blockSnapshot = snapshotsMap.get(blockSnapshotId ?? "");
@@ -242,7 +243,8 @@ export function useDashboardSnapshot(
       !experiment ||
       !snapshot ||
       snapshotSettingsMatch ||
-      fetchingSnapshot
+      fetchingSnapshot ||
+      fetchingSnapshotFailed
     )
       return;
     const getNewSnapshot = async () => {
@@ -255,7 +257,11 @@ export function useDashboardSnapshot(
           experiment.phases.length - 1
         }/${dimension}`,
       );
-      setBlock({ ...block, snapshotId: res.snapshot?.id ?? "" });
+      if (!res.snapshot) {
+        setFetchingSnapshotFailed(true);
+      } else {
+        setBlock({ ...block, snapshotId: res.snapshot.id });
+      }
       setFetchingSnapshot(false);
     };
     getNewSnapshot();
@@ -264,6 +270,7 @@ export function useDashboardSnapshot(
     snapshot,
     snapshotSettingsMatch,
     fetchingSnapshot,
+    fetchingSnapshotFailed,
     apiCall,
     block,
     setBlock,

--- a/packages/front-end/enterprise/components/Dashboards/DashboardsTab.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardsTab.tsx
@@ -190,6 +190,21 @@ function DashboardsTab({
     [apiCall, experiment.id, mutateDashboards],
   );
 
+  const memoizedSetBlock = useCallback(
+    (i: number, block: (typeof blocks)[number]) => {
+      const newBlocks = [...blocks.slice(0, i), block, ...blocks.slice(i + 1)];
+      setBlocks(newBlocks);
+      submitDashboard({
+        method: "PUT",
+        dashboardId,
+        data: {
+          blocks: newBlocks,
+        },
+      });
+    },
+    [blocks, submitDashboard, dashboardId],
+  );
+
   if (loadingDashboards || !dashboardMounted) return <LoadingSpinner />;
   return (
     <DashboardSnapshotProvider
@@ -574,25 +589,7 @@ function DashboardsTab({
                         scrollAreaRef={null}
                         enableAutoUpdates={dashboard.enableAutoUpdates}
                         nextUpdate={experiment.nextSnapshotAttempt}
-                        setBlock={
-                          canEdit
-                            ? (i, block) => {
-                                const newBlocks = [
-                                  ...blocks.slice(0, i),
-                                  block,
-                                  ...blocks.slice(i + 1),
-                                ];
-                                setBlocks(newBlocks);
-                                submitDashboard({
-                                  method: "PUT",
-                                  dashboardId,
-                                  data: {
-                                    blocks: newBlocks,
-                                  },
-                                });
-                              }
-                            : undefined
-                        }
+                        setBlock={canEdit ? memoizedSetBlock : undefined}
                         // TODO: reduce unnecessary props
                         stagedBlockIndex={undefined}
                         editSidebarDirty={false}


### PR DESCRIPTION
### Features and Changes

#4710 didn't solve the root problem, so this PR adds a safety net to prevent re-fetching the same snapshot repeatedly which leads to an infinite loop of failures (or errors if the user doesn't have permissions)

### Testing

1. Start on `main` to see the behavior without this fix
2. Set up precomputed dimensions and create a dashboard using a dimension results block
3. Disable precomputed results in the org settings and refresh the experiment results
4. Change the dimension for the dashboard from the precomputed to the on-demand version of the same dimension
5. The dashboard should refresh infinitely as it fails to find a snapshot via the GET endpoint
6. Checkout to this branch and observe the refreshing stops until the user manually updates, which fixes the missing data

### Screenshots

Before the fix
<img width="850" height="1009" alt="image" src="https://github.com/user-attachments/assets/340b71a9-89f6-41e4-9991-5dfae62802e9" />

After the fix
<img width="2549" height="562" alt="image" src="https://github.com/user-attachments/assets/b1feaf70-3564-42d1-8dde-120fefd77212" />
