### PR TITLE
fix(metrics): Allow use of space in row filters

### DIFF
--- a/packages/front-end/components/FactTables/FactMetricModal.tsx
+++ b/packages/front-end/components/FactTables/FactMetricModal.tsx
@@ -714,6 +714,7 @@ function ColumnRefSelector({
                           value={v}
                           onChange={onValuesChange}
                           placeholder="Any"
+                          delimiters={["Enter", "Tab"]}
                           autoFocus
                         />
                       )}


### PR DESCRIPTION
### Features and Changes

When adding a Fact Metric, we can specify Row Filters, but the current experience is that typing a Space is treated as finishing the input so every word is treated independently instead of a single value with multiple words.

So now we accept spaces as part of the value when typing.

#### Before

Notice how every space that I type it gets treated as a separate value.

<img width="678" height="207" alt="Screenshot 2025-10-17 at 11 12 00 AM" src="https://github.com/user-attachments/assets/b4c3f565-5a88-479c-a692-9d29faada5d1" />


#### After

Now I need to either press Enter or Tab to finish inserting my value.

<img width="656" height="212" alt="Screenshot 2025-10-17 at 11 11 37 AM" src="https://github.com/user-attachments/assets/42b2d3e0-23e7-4442-beb0-a5b5c523d491" />

