### PR TITLE
Prevent background flashing if user has dark mode

### DIFF
--- a/packages/front-end/pages/_document.tsx
+++ b/packages/front-end/pages/_document.tsx
@@ -1,0 +1,30 @@
+import { Html, Head, Main, NextScript } from "next/document";
+import { AppearanceUISnippet } from "@/services/AppearanceUIThemeProvider";
+
+export default function Document() {
+  return (
+    <Html>
+      <Head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: AppearanceUISnippet,
+          }}
+        />
+        <style>
+          {`
+            html.light-theme {
+              background-color: #faf8ff;
+            }
+            html.dark-theme {
+              background-color: #10172e;
+            }
+          `}
+        </style>
+      </Head>
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
+}

--- a/packages/front-end/styles/_colors.scss
+++ b/packages/front-end/styles/_colors.scss
@@ -40,7 +40,7 @@ $gray4: #e0e2eb;
 $gray5: #f0f1f5;
 $gray6: #f6f7f9;
 
-$main-background: #f5f7fa;
+$main-background: #faf8ff;
 $main-background-dark: #10172e;
 $surface-background-dark: #212529;
 $dark-purple: #391c6d;

--- a/packages/front-end/styles/theme.scss
+++ b/packages/front-end/styles/theme.scss
@@ -254,20 +254,16 @@
   --step-color: #baa7ff;
 }
 
-.theme--light,
 .light-theme {
   @include light-theme();
 }
 
-.theme--dark,
 .dark-theme {
   @include dark-theme();
 }
 
 // OS default
-:root:not(.theme--light):not(.theme--dark):not(.dark-theme):not(.light-theme) {
-  @include light-theme();
-
+:root:not(.dark-theme):not(.light-theme) {
   @media (prefers-color-scheme: light) {
     @include light-theme();
   }


### PR DESCRIPTION
### Features and Changes

If you are on dark mode, regardless if forced or system setting, when loading GrowthBook we would default to a white background, which creates a bad experience.

So now we inject the theme in `head` so the background is properly set.

While doing it I also simplified some of the logic in the UIThemeProvider and removed `theme--`, keeping only `-theme` classes.

https://www.loom.com/share/5e516c89f46a473f81e5a2f8a3ff2fa7