### PR TITLE
Add AWS_ASSUME_ROLE environment variable description

### DIFF
--- a/docs/docs/self-host/env.mdx
+++ b/docs/docs/self-host/env.mdx
@@ -131,6 +131,7 @@ Store uploads in an AWS S3 bucket.
 - **S3_DOMAIN** (defaults to `https://${S3_BUCKET}.s3.amazonaws.com/`)
 - **AWS_ACCESS_KEY_ID** (not required when deployed to AWS with an instance role)
 - **AWS_SECRET_ACCESS_KEY** (not required when deployed to AWS with an instance role)
+- **AWS_ASSUME_ROLE** (optional role to assume, that has `s3:PutObject` and `s3:GetObject` to the bucket)
 
 ### google-cloud
 


### PR DESCRIPTION
In https://github.com/growthbook/growthbook/pull/4701/files we added AWS_ASSUME_ROLE as an optional role to assume while copying the files.