### PR TITLE
fix(OpenAPI): Include attributes in list of APIs

### DIFF
--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -119,7 +119,7 @@ tags:
     description: Get the organization settings.
   - name: attributes
     x-displayName: Attributes
-    description: Used when targetting feature flags and experiments.
+    description: Used when targeting feature flags and experiments.
   - name: Archetype_model
     x-displayName: Archetype
     description: <SchemaDefinition schemaRef="#/components/schemas/Archetype" />

--- a/packages/back-end/src/api/openapi/openapi.yaml
+++ b/packages/back-end/src/api/openapi/openapi.yaml
@@ -122,7 +122,7 @@ tags:
     description: Get the organization settings.
   - name: attributes
     x-displayName: Attributes
-    description: Used when targetting feature flags and experiments.
+    description: Used when targeting feature flags and experiments.
 paths:
   /features:
     get:


### PR DESCRIPTION
### Features and Changes

Attributes were missing from tags in the `openapi.yaml` which was causing attributes to not show up in the API list