### PR TITLE
Allow NaN values from Python

### DIFF
--- a/packages/back-end/package.json
+++ b/packages/back-end/package.json
@@ -76,6 +76,7 @@
     "googleapis": "^59.0.0",
     "handlebars": "^4.7.8",
     "js-yaml": "^4.1.0",
+    "json5": "^2.2.3",
     "jsonwebtoken": "^8.5.1",
     "jwks-rsa": "^1.8.0",
     "lodash": "^4.17.21",

--- a/packages/back-end/scripts/stats_server.py
+++ b/packages/back-end/scripts/stats_server.py
@@ -44,7 +44,7 @@ for line in sys.stdin:
             'id': id,
             'results': results,
             'time': time.time() - start
-        }, allow_nan=False) + "\n")
+        }, allow_nan=True) + "\n")
         sys.stdout.flush()
     except Exception as e:
         sys.stdout.write(json.dumps({
@@ -53,5 +53,5 @@ for line in sys.stdin:
             # Include formatted stack trace
             'stack_trace': traceback.format_exc(),
             'time': time.time() - start
-        }, allow_nan=False) + "\n")
+        }, allow_nan=True) + "\n")
         sys.stdout.flush()

--- a/packages/back-end/src/services/python.ts
+++ b/packages/back-end/src/services/python.ts
@@ -5,6 +5,7 @@ import { randomUUID } from "crypto";
 import { CloudWatch } from "aws-sdk";
 import { createPool } from "generic-pool";
 import { stringToBoolean } from "shared/util";
+import JSON5 from "json5";
 import { MultipleExperimentMetricAnalysis } from "back-end/types/stats";
 import { logger } from "back-end/src/util/logger";
 import { ExperimentDataForStatsEngine } from "back-end/src/services/stats";
@@ -102,7 +103,7 @@ class PythonStatsServer<Input, Output> {
           const parsed:
             | PythonServerResponse<Output>
             | { id: string; error: string; stack_trace?: string } =
-            JSON.parse(output);
+            JSON5.parse(output);
 
           if (!parsed.id) {
             logger.error(

--- a/yarn.lock
+++ b/yarn.lock
@@ -16779,7 +16779,7 @@ json5@^1.0.2:
 
 json5@^2.2.3:
   version "2.2.3"
-  resolved "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
 jsonc-parser@^3.2.0:


### PR DESCRIPTION
### Features and Changes

There are some edge cases in Python that result in NaN or Infinity.  This threw an error during JSON serialization, which prevented the entire experiment results from rendering.  This PR allows NaN to flow through to the back-end.  Now, only the specific metric / cell of the results table will be broken, not the entire results.