### PR TITLE
Reverts SQL Explorer SideNav filter logic for now

### DIFF
--- a/packages/front-end/components/Layout/Layout.tsx
+++ b/packages/front-end/components/Layout/Layout.tsx
@@ -125,10 +125,7 @@ const navlinks: SidebarLinkProps[] = [
         name: "SQL Explorer",
         href: "/sql-explorer",
         path: /^sql-explorer/,
-        filter: ({ gb, savedQueries }) =>
-          !!gb?.isOn("sql-explorer") &&
-          // Only show SQL Explorer for orgs with saved queries that weren't created by dashboards
-          savedQueries.some((sq) => (sq.linkedDashboardIds ?? []).length === 0),
+        filter: ({ gb }) => !!gb?.isOn("sql-explorer"),
       },
     ],
   },


### PR DESCRIPTION
### Features and Changes

When we released the PA Dashboards PR, I thought I had removed all of the changes to the SQL Explorer, but this Side Nav change slipped through. This reverts the change.
