### PR TITLE
chore(url): Update page title format

### DIFF
--- a/packages/front-end/components/Layout/Layout.tsx
+++ b/packages/front-end/components/Layout/Layout.tsx
@@ -439,7 +439,10 @@ const Layout = (): React.ReactElement => {
     return null;
   }
 
-  let pageTitle = breadcrumb.map((b) => b.display).join(" > ");
+  let pageTitle = [...breadcrumb]
+    .reverse()
+    .map((b) => b.display)
+    .join(" - ");
 
   // If no breadcrumb provided, try to figure out a page name based on the path
   otherPageTitles.forEach((o) => {

--- a/packages/front-end/components/Layout/TopNav.tsx
+++ b/packages/front-end/components/Layout/TopNav.tsx
@@ -401,7 +401,7 @@ const TopNav: FC<{
   return (
     <>
       <Head>
-        <title>GrowthBook &gt; {pageTitle}</title>
+        <title>{pageTitle ? `${pageTitle} | GrowthBook` : "GrowthBook"}</title>
       </Head>
       {editUserOpen && (
         <Modal

--- a/packages/front-end/pages/dashboard.tsx
+++ b/packages/front-end/pages/dashboard.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import Head from "next/head";
 import { useExperiments } from "@/hooks/useExperiments";
 import Dashboard from "@/components/HomePage/Dashboard";
 import LoadingOverlay from "@/components/LoadingOverlay";
@@ -32,11 +31,6 @@ export default function Analysis(): React.ReactElement {
 
   return (
     <>
-      <Head>
-        <title>GrowthBook</title>
-        <link rel="icon" href="/favicon.ico" />
-      </Head>
-
       <div className="container pagecontents position-relative">
         {hasExperiments ? (
           <Dashboard experiments={experiments} />

--- a/packages/front-end/pages/public/e/[e].tsx
+++ b/packages/front-end/pages/public/e/[e].tsx
@@ -130,10 +130,10 @@ export default function PublicExperimentPage(props: PublicExperimentPageProps) {
   return (
     <div className={`public pb-2 ${isBandit ? "bandit" : "experiment"}`}>
       <Head>
-        <title>{experiment?.name || "Experiment not found"}</title>
+        <title>{experiment?.name ? `${experiment.name} | GrowthBook` : "Experiment not found | GrowthBook"}</title>
         <meta
           property="og:title"
-          content={experiment?.name ? (`${isBandit ? "Bandit" : "Experiment"}: ${experiment?.name}`) : "Experiment not found"}
+          content={experiment?.name ? (`${isBandit ? "Bandit" : "Experiment"}: ${experiment?.name} | GrowthBook`) : "Experiment not found | GrowthBook"}
         />
         <meta
           property="og:description"

--- a/packages/front-end/pages/public/r/[r].tsx
+++ b/packages/front-end/pages/public/r/[r].tsx
@@ -82,10 +82,18 @@ export default function ReportPage(props: ReportPageProps) {
   return (
     <div className="pagecontents container-fluid">
       <Head>
-        <title>{report?.title || "Report not found"}</title>
+        <title>
+          {report?.title
+            ? `${report.title} | GrowthBook`
+            : "Report not found | GrowthBook"}
+        </title>
         <meta
           property="og:title"
-          content={report?.title ? `Report: ${report.title}` : "Report not found"}
+          content={
+            report?.title
+              ? `Report: ${report.title} | GrowthBook`
+              : "Report not found | GrowthBook"
+          }
         />
         <meta
           property="og:description"


### PR DESCRIPTION
### Features and Changes

For a feature flag named `show-experiment-groups` our page title would be `GrowthBook > Features > show-experiment-groups` which is correct but it makes hard to differentiate between multiple GrowthBook tabs as the browser tab size is reduced.

So now we show the most relevant information first: `show-experiment-groups - Features | GrowthBook`.