### PR TITLE
chore(precommit): Don't run script if we don't need to

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -27,7 +27,7 @@ fi
 echo "#### Linting typescript, scss, and markdown files"
 yarn lint-staged
 
-docchanged=$(git status --porcelain | grep '^[MADRC]' | grep "back-end/src\|docs/scripts" || true)
+docchanged=$(git status --porcelain | grep '^[MADRC]' | grep "back-end/src/events/\|docs/scripts/gen-event-webhook-doc.ts" || true)
 
 if [ -n "$docchanged" ]
   then


### PR DESCRIPTION
### Features and Changes

The pre-commit hook to run `gen-event-webhook-doc.ts` was too broad, running if any file in the back-end package changed.

Now we are more conservative and run it only if the script or if any file in `back-end/events` is updated.