### PR TITLE
Throw error early for large Athena queries

### DIFF
--- a/packages/back-end/src/services/athena.ts
+++ b/packages/back-end/src/services/athena.ts
@@ -78,7 +78,7 @@ export async function runAthenaQuery(
   const MAX_QUERY_LENGTH = 262144;
   if (sql.length > MAX_QUERY_LENGTH) {
     throw new Error(
-      `Query string length (${sql.length} characters) exceeds Athena's maximum allowed length of ${MAX_QUERY_LENGTH} characters. Please simplify your query or reduce the date range.`,
+      `Query string length (${sql.length} characters) exceeds Athena's maximum allowed length of ${MAX_QUERY_LENGTH} characters. Please simplify your query.`,
     );
   }
 


### PR DESCRIPTION
### Features and Changes

There is a long running bandit experiment that is consistently failing due to the query being too large.  It also seems to cause [CPU and memory issues](https://growthbookapp.slack.com/archives/C07NK4F016Z/p1755619066928549) as Athena SDK doesn't seem to handle the validation error.  This doesn't fix the underlying issue of the excessively large bandit queries, but it does fail the query early to hopefully avoid the athena SDK locking our servers up.

