### PR TITLE
feat(incremental): Add experiment-level enable/disable

### DIFF
--- a/packages/back-end/src/services/dataPipeline.ts
+++ b/packages/back-end/src/services/dataPipeline.ts
@@ -1,0 +1,163 @@
+import {
+  ExperimentMetricInterface,
+  isFactMetric,
+  isRatioMetric,
+  quantileMetricType,
+} from "shared/experiments";
+import { ExperimentSnapshotSettings } from "back-end/types/experiment-snapshot";
+import { FactTableMap } from "back-end/src/models/FactTableModel";
+import { IncrementalRefreshInterface } from "back-end/src/validators/incremental-refresh";
+import { OrganizationInterface } from "back-end/types/organization";
+import { orgHasPremiumFeature } from "back-end/src/enterprise";
+import { SourceIntegrationInterface } from "back-end/src/types/Integration";
+import { ExperimentInterface } from "back-end/types/experiment";
+import {
+  getExperimentSettingsHashForIncrementalRefresh,
+  getMetricSettingsHashForIncrementalRefresh,
+} from "./experimentTimeSeries";
+
+// If the given settings / experiment is not compatible with incremental refresh, throw an error.
+// Otherwise, return void.
+export async function validateIncrementalPipeline({
+  org,
+  integration,
+  snapshotSettings,
+  metricMap,
+  factTableMap,
+  experiment,
+  incrementalRefreshModel,
+  fullRefresh,
+}: {
+  org: OrganizationInterface;
+  integration: SourceIntegrationInterface;
+  snapshotSettings: ExperimentSnapshotSettings;
+  metricMap: Map<string, ExperimentMetricInterface>;
+  factTableMap: FactTableMap;
+  experiment: ExperimentInterface;
+  incrementalRefreshModel: IncrementalRefreshInterface | null;
+  fullRefresh: boolean;
+}): Promise<void> {
+  if (snapshotSettings.skipPartialData) {
+    throw new Error(
+      "'Exclude In-Progress Conversions' is not supported for incremental refresh queries while in beta. Please select 'Include' in the Analysis Settings for Metric Conversion Windows.",
+    );
+  }
+
+  if (!integration.getSourceProperties().hasIncrementalRefresh) {
+    throw new Error("Integration does not support incremental refresh queries");
+  }
+
+  // Check if organization has the incremental refresh feature
+  const hasIncrementalRefreshFeature = orgHasPremiumFeature(
+    org,
+    "incremental-refresh",
+  );
+  if (!hasIncrementalRefreshFeature) {
+    throw new Error(
+      "Organization does not have access to incremental refresh feature",
+    );
+  }
+
+  // Check if pipeline mode is set to incremental
+  const settings = integration.datasource.settings;
+  const canRunIncrementalRefreshQueries =
+    settings.pipelineSettings?.mode === "incremental";
+  if (!canRunIncrementalRefreshQueries) {
+    throw new Error("Integration does not have Pipeline Incremental enabled");
+  }
+
+  if (experiment.activationMetric) {
+    throw new Error(
+      "Activation metrics are not supported for incremental refresh while in beta.",
+    );
+  }
+
+  if (
+    (settings.pipelineSettings?.includedExperimentIds !== undefined &&
+      !settings.pipelineSettings?.includedExperimentIds.includes(
+        experiment.id,
+      )) ||
+    (settings.pipelineSettings?.excludedExperimentIds !== undefined &&
+      settings.pipelineSettings?.excludedExperimentIds.includes(experiment.id))
+  ) {
+    throw new Error(
+      "Experiment is not included in the Pipeline Incremental scope",
+    );
+  }
+
+  // Get selected metrics
+  const selectedMetrics = snapshotSettings.metricSettings
+    .map((m) => metricMap.get(m.id))
+    .filter((m) => m !== undefined);
+
+  if (!selectedMetrics.length) {
+    throw new Error("Experiment must have at least 1 metric selected.");
+  }
+  if (selectedMetrics.some((m) => !isFactMetric(m))) {
+    throw new Error(
+      "Only fact metrics are supported with incremental refresh.",
+    );
+  }
+
+  selectedMetrics.filter(isFactMetric).forEach((metric) => {
+    if (
+      isRatioMetric(metric) &&
+      metric.numerator.factTableId !== metric.denominator?.factTableId
+    ) {
+      throw new Error(
+        "Ratio metrics must have the same numerator and denominator fact table with incremental refresh.",
+      );
+    }
+
+    if (quantileMetricType(metric)) {
+      throw new Error(
+        "Quantile metrics are not supported with incremental refresh.",
+      );
+    }
+  });
+
+  // If not forcing a full refresh and we have a previous run, ensure the
+  // current configuration matches what the incremental pipeline was built with.
+  if (!fullRefresh && incrementalRefreshModel) {
+    const currentSettingsHash =
+      getExperimentSettingsHashForIncrementalRefresh(snapshotSettings);
+    if (
+      incrementalRefreshModel.experimentSettingsHash &&
+      currentSettingsHash !== incrementalRefreshModel.experimentSettingsHash
+    ) {
+      throw new Error(
+        "The experiment configuration is outdated. Please run a Full Refresh.",
+      );
+    }
+
+    // Validate metric settings hashes for existing metric sources
+    if (incrementalRefreshModel.metricSources?.length) {
+      const existingMetricHashMap = new Map<string, string>();
+      incrementalRefreshModel.metricSources.forEach((source) => {
+        source.metrics.forEach((metric) => {
+          existingMetricHashMap.set(metric.id, metric.settingsHash);
+        });
+      });
+
+      selectedMetrics.filter(isFactMetric).forEach((m) => {
+        const storedHash = existingMetricHashMap.get(m.id);
+        if (!storedHash) return;
+
+        const currentHash = getMetricSettingsHashForIncrementalRefresh({
+          factMetric: m,
+          factTableMap: factTableMap,
+          metricSettings: snapshotSettings.metricSettings.find(
+            (ms) => ms.id === m.id,
+          ),
+        });
+
+        if (currentHash !== storedHash) {
+          const metricName = m.name ?? m.id;
+          throw new Error(
+            `The metric "${metricName}" configuration is outdated. Please run a Full Refresh.`,
+          );
+        }
+      });
+    }
+  }
+}

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -154,6 +154,7 @@ import { ExperimentQueryMetadata } from "back-end/types/query";
 
 import { updateExperimentDashboards } from "back-end/src/enterprise/services/dashboards";
 import { getReportVariations, getMetricForSnapshot } from "./reports";
+import { validateIncrementalPipeline } from "./dataPipeline";
 import {
   getIntegrationFromDatasourceId,
   getSourceIntegrationObject,
@@ -1265,14 +1266,40 @@ export async function createSnapshot({
 
   const snapshot = await createExperimentSnapshotModel({ data });
   const integration = getSourceIntegrationObject(context, datasource, true);
+  const incrementalRefreshModel =
+    await context.models.incrementalRefresh.getByExperimentId(experiment.id);
+  const fullRefresh = !useCache || !incrementalRefreshModel;
 
   const isIncrementalRefreshEnabledForExperiment =
     datasource.settings.pipelineSettings?.mode === "incremental" &&
+    !datasource.settings.pipelineSettings?.excludedExperimentIds?.includes(
+      experiment.id,
+    ) &&
     (datasource.settings.pipelineSettings?.includedExperimentIds ===
       undefined ||
       datasource.settings.pipelineSettings?.includedExperimentIds.includes(
         experiment.id,
       ));
+
+  let isExperimentCompatibleWithIncrementalRefresh;
+  try {
+    await validateIncrementalPipeline({
+      org: organization,
+      integration,
+      snapshotSettings: data.settings,
+      metricMap,
+      factTableMap,
+      experiment,
+      incrementalRefreshModel,
+      fullRefresh,
+    });
+    isExperimentCompatibleWithIncrementalRefresh = true;
+  } catch (error) {
+    isExperimentCompatibleWithIncrementalRefresh = false;
+    logger.info(
+      `Experiment ${experiment.id} does not support incremental refresh: ${"message" in error ? error.message : error}`,
+    );
+  }
 
   let queryRunner:
     | ExperimentResultsQueryRunner
@@ -1281,7 +1308,8 @@ export async function createSnapshot({
   if (
     isIncrementalRefreshEnabledForExperiment &&
     (experiment.type === undefined || experiment.type === "standard") &&
-    snapshot.type === "standard"
+    snapshot.type === "standard" &&
+    isExperimentCompatibleWithIncrementalRefresh
   ) {
     queryRunner = new ExperimentIncrementalRefreshQueryRunner(
       context,

--- a/packages/back-end/types/datasource.d.ts
+++ b/packages/back-end/types/datasource.d.ts
@@ -218,6 +218,11 @@ export type DataSourcePipelineSettings = {
    * If not specified, we will use the configured pipeline mode for all experiments.
    */
   includedExperimentIds?: string[];
+  /**
+   * If specified, these experiment IDs will NOT use incremental refresh
+   * even when mode is "incremental". They will fall back to standard queries.
+   */
+  excludedExperimentIds?: string[];
 };
 
 export type MaterializedColumnType = "" | "identifier" | "dimension";

--- a/packages/front-end/components/Experiment/RefreshSnapshotButton.tsx
+++ b/packages/front-end/components/Experiment/RefreshSnapshotButton.tsx
@@ -22,6 +22,7 @@ const RefreshSnapshotButton: FC<{
     settings: ExperimentSnapshotAnalysisSettings | null,
   ) => void;
   resetFilters?: () => void;
+  setError: (e: string | undefined) => void;
 }> = ({
   mutate,
   experiment,
@@ -30,6 +31,7 @@ const RefreshSnapshotButton: FC<{
   dimension,
   setAnalysisSettings,
   resetFilters,
+  setError,
 }) => {
   const [open, setOpen] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -83,6 +85,7 @@ const RefreshSnapshotButton: FC<{
       )}
       <Button
         color="outline-primary"
+        setErrorText={setError}
         onClick={async () => {
           resetFilters?.();
           setLoading(true);

--- a/packages/front-end/components/Experiment/TabbedPage/AnalysisSettingsSummary.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/AnalysisSettingsSummary.tsx
@@ -12,6 +12,7 @@ import { HiCursorClick } from "react-icons/hi";
 import { ExperimentSnapshotInterface } from "back-end/types/experiment-snapshot";
 import { DifferenceType, StatsEngine } from "back-end/types/stats";
 import clsx from "clsx";
+import { Box, Text } from "@radix-ui/themes";
 import {
   expandMetricGroups,
   getAllMetricIdsFromExperiment,
@@ -44,6 +45,8 @@ import AnalysisForm from "@/components/Experiment/AnalysisForm";
 import Link from "@/ui/Link";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 import { useExperimentDashboards } from "@/hooks/useDashboards";
+import Callout from "@/ui/Callout";
+import { getIsExperimentIncludedInIncrementalRefresh } from "@/services/experiments";
 import OverflowText from "./OverflowText";
 
 export interface Props {
@@ -79,6 +82,7 @@ export default function AnalysisSettingsSummary({
     metricGroups,
     factMetrics,
     metrics,
+    mutateDefinitions,
   } = useDefinitions();
 
   const datasourceSettings = experiment.datasource
@@ -136,6 +140,35 @@ export default function AnalysisSettingsSummary({
   const { status } = getQueryStatus(latest?.queries || [], latest?.error);
 
   const [analysisModal, setAnalysisModal] = useState(false);
+
+  const isExperimentIncludedInIncrementalRefresh =
+    getIsExperimentIncludedInIncrementalRefresh(
+      datasource ?? undefined,
+      experiment.id,
+    );
+
+  const handleDisableIncrementalRefresh = async () => {
+    if (!datasource || !isExperimentIncludedInIncrementalRefresh) return;
+
+    await apiCall(`/datasource/${datasource.id}`, {
+      method: "PUT",
+      body: JSON.stringify({
+        settings: {
+          ...datasource.settings,
+          pipelineSettings: {
+            ...datasource.settings.pipelineSettings,
+            excludedExperimentIds: [
+              ...(datasource.settings?.pipelineSettings
+                ?.excludedExperimentIds ?? []),
+              experiment.id,
+            ],
+          },
+        },
+      }),
+    });
+    setRefreshError("");
+    mutateDefinitions();
+  };
 
   const allExpandedMetrics = Array.from(
     new Set(
@@ -481,6 +514,7 @@ export default function AnalysisSettingsSummary({
                       experiment={experiment}
                       lastAnalysis={analysis}
                       dimension={dimension}
+                      setError={(error) => setRefreshError(error ?? "")}
                       setAnalysisSettings={setAnalysisSettings}
                       resetFilters={() => {
                         if (baselineRow !== 0) {
@@ -635,9 +669,23 @@ export default function AnalysisSettingsSummary({
         </div>
       </div>
       {refreshError && (
-        <div className="alert alert-danger mt-2">
-          <strong>Error updating data: </strong> {refreshError}
-        </div>
+        <>
+          <Callout status="error" mt="2">
+            <strong>Error updating data: </strong> {refreshError}
+          </Callout>
+          {isExperimentIncludedInIncrementalRefresh && (
+            <Box mt="2" mb="2" style={{ color: "var(--color-text-low)" }}>
+              <Text size="1">
+                If this error persists, you can try disabling Incremental
+                Refresh for this experiment by{" "}
+                <Link onClick={handleDisableIncrementalRefresh}>
+                  clicking here
+                </Link>
+                .
+              </Text>
+            </Box>
+          )}
+        </>
       )}
     </div>
   );

--- a/packages/front-end/services/experiments.ts
+++ b/packages/front-end/services/experiments.ts
@@ -993,6 +993,12 @@ export function getIsExperimentIncludedInIncrementalRefresh(
 
   const includedExperimentIds =
     datasource?.settings.pipelineSettings?.includedExperimentIds;
+  const excludedExperimentIds =
+    datasource?.settings.pipelineSettings?.excludedExperimentIds;
+
+  if (experimentId && excludedExperimentIds?.includes(experimentId)) {
+    return false;
+  }
 
   // If no specific experiment IDs are set, all experiments are included
   // If experimentId is not provided, consider it included for the New Experiment form


### PR DESCRIPTION
### Features and Changes

To facilitate onboarding with IncrementalRefresh, we want to ensure older experiments keep working as expected. So instead of throwing if they use any settings that are not supported by Incremental Refresh, we will automatically fallback to the regular ExperimentResultsQueryRunner.

Additionally, if an error is thrown for an Experiment in the Incremental Refresh pipeline, we provide an easy way to exclude the experiment (and re-enable it if wanted) from incremental, so we don't block users.

### Screenshots

<img width="1208" height="206" alt="Screenshot 2025-11-05 at 1 43 51 PM" src="https://github.com/user-attachments/assets/adacc231-8fe7-48ac-893d-e3c8ef20ec30" />

<img width="421" height="374" alt="Screenshot 2025-11-05 at 1 52 38 PM" src="https://github.com/user-attachments/assets/978f6847-ae4d-4644-9a06-44ea7905d5c4" />
