### PR TITLE
Use authorized images in presentations

### DIFF
--- a/packages/front-end/components/Share/Presentation.tsx
+++ b/packages/front-end/components/Share/Presentation.tsx
@@ -22,6 +22,7 @@ import { useDefinitions } from "@/services/DefinitionsContext";
 import Markdown from "@/components/Markdown/Markdown";
 import useOrgSettings from "@/hooks/useOrgSettings";
 import CompactResults from "@/components/Experiment/CompactResults";
+import AuthorizedImage from "@/components/AuthorizedImage";
 import { presentationThemes, defaultTheme } from "./ShareModal";
 
 export interface Props {
@@ -53,6 +54,11 @@ const Presentation = ({
 }: Props): ReactElement => {
   const { getExperimentMetricById } = useDefinitions();
   const orgSettings = useOrgSettings();
+
+  // Image cache for AuthorizedImage component
+  const [imageCache] = React.useState<
+    Record<string, { url: string; expiresAt: string }>
+  >({});
 
   // Interval to force the results table to redraw (currently needed for window-size-based rendering)
   // - ideally would have rerendered on slide number, but spectacle doesn't seem to expose this
@@ -198,10 +204,11 @@ const Presentation = ({
               >
                 <h4>{v.name}</h4>
                 {v?.screenshots[0]?.path && (
-                  <img
+                  <AuthorizedImage
                     className="expimage border"
                     src={v.screenshots[0].path}
                     alt={v.name}
+                    imageCache={imageCache}
                   />
                 )}
                 {v.description && (


### PR DESCRIPTION
### Features and Changes

Images don't work when loaded directly since the s3 bucket is private.  It needs to be an authorized image to work correctly.

### Testing
Use valid s3 env vars to a locked down s3 bucket.
Create a presentation for an experiment with images.  
Go to the second page and see the image loaded correctly.
