### PR TITLE
Add migrate link to main tutorials page

### DIFF
--- a/docs/docs/guide/index.mdx
+++ b/docs/docs/guide/index.mdx
@@ -37,7 +37,7 @@ This list isn't complete! If you have a specific technology stack you'd like to 
 
 ### Migration Guides
 
-- [How to Migrate from StatSig](/guide/migrate-from-statsig)
+- [How to Migrate from Statsig](/guide/migrate-from-statsig)
 - [How to Migrate from LaunchDarkly](/guide/importing)
 
 ## A/B Testing Guide


### PR DESCRIPTION
- Add link to Statsig migration guide.