### PR TITLE
Update to use Callout + spacing

### DIFF
--- a/packages/front-end/components/Experiment/CompactResults.tsx
+++ b/packages/front-end/components/Experiment/CompactResults.tsx
@@ -1,4 +1,5 @@
 import { FC, ReactElement, useMemo, useState } from "react";
+import { Flex } from "@radix-ui/themes";
 import {
   ExperimentReportResultDimension,
   ExperimentReportVariation,
@@ -257,7 +258,7 @@ const CompactResults: FC<{
             </div>
           )}
 
-          <div className="mx-3">
+          <Flex direction="column" gap="2" mx="3">
             {experimentType !== "multi-armed-bandit" && (
               <DataQualityWarning
                 results={results}
@@ -271,7 +272,7 @@ const CompactResults: FC<{
               totalUsers={totalUsers}
               multipleExposures={multipleExposures}
             />
-          </div>
+          </Flex>
         </>
       )}
 

--- a/packages/front-end/components/Experiment/MultipleExposureWarning.tsx
+++ b/packages/front-end/components/Experiment/MultipleExposureWarning.tsx
@@ -4,6 +4,7 @@ import {
 } from "shared/constants";
 import { getMultipleExposureHealthData } from "shared/health";
 import useOrgSettings from "@/hooks/useOrgSettings";
+import Callout from "@/ui/Callout";
 
 const percentFormatter = new Intl.NumberFormat(undefined, {
   style: "percent",
@@ -34,12 +35,12 @@ export default function MultipleExposureWarning({
   }
 
   return (
-    <div className="alert alert-warning">
+    <Callout status="warning">
       <strong>Multiple Exposures Warning</strong>.{" "}
       {numberFormatter.format(multipleExposures)} users (
       {percentFormatter.format(multipleExposureHealth.rawDecimal)}) saw multiple
       variations and were automatically removed from results. Check for bugs in
       your implementation, event tracking, or data pipeline.
-    </div>
+    </Callout>
   );
 }

--- a/packages/front-end/components/Experiment/TabbedPage/BanditSummaryResultsTab.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/BanditSummaryResultsTab.tsx
@@ -1,5 +1,6 @@
 import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
 import React, { useEffect, useState } from "react";
+import { Flex } from "@radix-ui/themes";
 import { LiaChartLineSolid } from "react-icons/lia";
 import { TbChartAreaLineFilled } from "react-icons/tb";
 import { BanditEvent } from "back-end/src/validators/experiments";
@@ -131,7 +132,7 @@ export default function BanditSummaryResultsTab({
         ) : null}
 
         {!isPublic && (
-          <div className="mx-3">
+          <Flex direction="column" gap="2" mx="3">
             <SRMWarning
               srm={
                 latest
@@ -146,7 +147,7 @@ export default function BanditSummaryResultsTab({
               totalUsers={totalUsers}
               multipleExposures={multipleExposures ?? 0}
             />
-          </div>
+          </Flex>
         )}
 
         {showVisualizations && (


### PR DESCRIPTION
### Features and Changes

We noticed the `Multiple Exposure Warnings` was using an old style and it could be rendered with the SRM warning which uses the new one, which creates a bad UI experience.

#### Before

<img width="1238" height="406" alt="Screenshot 2025-11-06 at 12 46 56 PM" src="https://github.com/user-attachments/assets/3b99bf53-e5f9-4a41-9994-847b944fdd96" />

#### After

<img width="1235" height="415" alt="Screenshot 2025-11-06 at 12 46 43 PM" src="https://github.com/user-attachments/assets/3afe249e-13c4-4d84-9127-e42409ef4849" />

