### PR TITLE
fix new test

### DIFF
--- a/packages/back-end/test/api/experiments.test.ts
+++ b/packages/back-end/test/api/experiments.test.ts
@@ -741,6 +741,11 @@ describe("experiments API", () => {
     it("returns experiment results", async () => {
       setReqContext({
         org,
+        models: {
+          metricGroups: {
+            getAll: jest.fn().mockResolvedValue([]),
+          },
+        },
         permissions: {
           canViewExperiment: () => true,
         },


### PR DESCRIPTION
### Features and Changes

New experiment tests were added.  In the meantime a route was changed to access the MetricGroups model, that the test hadn't mocked.  This PR mocks it.

### Testing

`yarn test`
