### PR TITLE
Mk/pa dashboard tweaks

### DIFF
--- a/packages/back-end/src/routers/saved-queries/saved-queries.controller.ts
+++ b/packages/back-end/src/routers/saved-queries/saved-queries.controller.ts
@@ -157,7 +157,7 @@ export async function postSavedQuery(
   res.status(200).json({
     status: 200,
     id: savedQuery.id,
-    savedQueryIds: savedQuery.dataVizConfig?.map((viz) => viz.id) || [],
+    savedQuery,
   });
 }
 
@@ -182,13 +182,13 @@ export async function putSavedQuery(
       : undefined,
   };
 
-  const updatedSavedQuery = await context.models.savedQueries.updateById(
+  const savedQuery = await context.models.savedQueries.updateById(
     id,
     updateData,
   );
   res.status(200).json({
     status: 200,
-    savedQueryIds: updatedSavedQuery.dataVizConfig?.map((viz) => viz.id) || [],
+    savedQuery,
   });
 }
 

--- a/packages/front-end/components/Layout/Layout.tsx
+++ b/packages/front-end/components/Layout/Layout.tsx
@@ -89,6 +89,13 @@ const navlinks: SidebarLinkProps[] = [
     ],
   },
   {
+    name: "Product Analytics",
+    href: "/product-analytics/dashboards",
+    path: /^(product-analytics\/dashboards)/,
+    Icon: GBProductAnalytics,
+    filter: ({ gb }) => !!gb?.isOn("general-dashboards"),
+  },
+  {
     name: "Metrics and Data",
     href: "/metrics",
     path: /^(metric\/|metrics|segment|dimension|datasources|fact-|metric-group|sql-explorer)/,
@@ -128,13 +135,6 @@ const navlinks: SidebarLinkProps[] = [
         filter: ({ gb }) => !!gb?.isOn("sql-explorer"),
       },
     ],
-  },
-  {
-    name: "Product Analytics",
-    href: "/product-analytics/dashboards",
-    path: /^(product-analytics\/dashboards)/,
-    Icon: GBProductAnalytics,
-    filter: ({ gb }) => !!gb?.isOn("general-dashboards"),
   },
   {
     name: "Insights",

--- a/packages/front-end/hooks/useIncrementalRefresh.ts
+++ b/packages/front-end/hooks/useIncrementalRefresh.ts
@@ -4,7 +4,9 @@ import useApi from "./useApi";
 export function useIncrementalRefresh(experimentId: string) {
   const { data, error, mutate } = useApi<{
     incrementalRefresh: IncrementalRefreshInterface | null;
-  }>(`/experiment/${experimentId}/incremental-refresh`);
+  }>(`/experiment/${experimentId}/incremental-refresh`, {
+    shouldRun: () => !!experimentId,
+  });
 
   return {
     loading: !error && !data,

--- a/packages/front-end/pages/product-analytics/dashboards/index.tsx
+++ b/packages/front-end/pages/product-analytics/dashboards/index.tsx
@@ -261,14 +261,14 @@ export default function DashboardsPage() {
           <div className="mt-4">
             {!hasCommercialFeature("product-analytics-dashboards") ? (
               <PremiumEmptyState
-                title="Explore & Share Custom Analyses"
-                description="Create curated dashboards to visualize key metrics and track performance."
+                title="Explore Your Data"
+                description="Turn your data and metrics into actionable product insights, share with your team, and make smarter decisions about what to build next."
                 commercialFeature="product-analytics-dashboards"
               />
             ) : (
               <EmptyState
-                title="Explore & Share Custom Analyses"
-                description="Create curated dashboards to visualize key metrics and track performance."
+                title="Explore Your Data"
+                description="Turn your data and metrics into actionable product insights, share with your team, and make smarter decisions about what to build next."
                 leftButton={
                   <Button
                     onClick={() =>

--- a/packages/shared/src/enterprise/dashboards/utils.ts
+++ b/packages/shared/src/enterprise/dashboards/utils.ts
@@ -232,7 +232,7 @@ export const CREATE_BLOCK_TYPE: {
     title: "",
     description: "",
     savedQueryId: "",
-    blockConfig: [BLOCK_CONFIG_ITEM_TYPES.RESULTS_TABLE],
+    blockConfig: [],
     ...(initialValues || {}),
   }),
   "metric-explorer": ({ initialValues }) => ({


### PR DESCRIPTION
### Features and Changes

This PR does a few things:
1. It adds a `Beta` badge on the dashboards landing page
2. When a user goes to add their first SQL block to a dashboard, we're auto-opening the SqlExplorerModal, rather than making the user click the edit button
3. We're giving the queries a default `New Query` name
4. Visualizations are automatically added to the block
5. The results table is not shown by default unless there are no visualizations
6. We don't let you save the SQL modal until you run the query and get results back
7. Move Product Analytics in the left nav above Metrics & Data
8. Update the empty state copy for Product Analytics