### PR TITLE
Don't format large sql for perf reasons

### DIFF
--- a/packages/shared/src/sql.ts
+++ b/packages/shared/src/sql.ts
@@ -1,12 +1,10 @@
 import { format as sqlFormat } from "sql-formatter";
 import { FormatDialect, FormatError } from "./types";
-import { stringToBoolean } from "./util";
 
 export const SQL_ROW_LIMIT = 1000;
 
 export const MAX_SQL_LENGTH_TO_FORMAT = parseInt(
-  process.env.MAX_SQL_LENGTH_TO_FORMAT ||
-    (stringToBoolean(process.env.IS_CLOUD) ? "15000" : "0"),
+  process.env.MAX_SQL_LENGTH_TO_FORMAT || "15000",
 );
 
 export function format(


### PR DESCRIPTION
### Features and Changes
sql-formatter is slow and during experiment snapshots for experiments with large queries has been shown to have a [performance impact on cloud](https://growthbookapp.slack.com/archives/C055GKYGT26/p1762782130000269).  

This PR limits the damage it can do by only formatting normal size queries. An analysis of the 10k most recent queries showed:
```
count 10000
avgLength 6786.52
median 4540
percentile90 9274
percentile95 13374
percentile99 57511
```
So 15k will effect only 4% of queries or so.

As we provide already mostly formatted sql, there is a good chance people won't notice. However we also use the formatter to format user provided queries. Usually those will probably be small.  If it does turn out to be an issue, not limiting user provided queries is perhaps not as bad as they will happen rarely, and probably not all at once.

Other alternatives considered:
- @sqltools/formatter is 2-3x faster though it doesn't have most dialects and falls back to basic sql. 
- stop formatting queries we generate, since they tend to be formatted anyway but continue to format elsewhere. The downside here is that we might end up still getting perf issues in other places.
- roll our own basic formatting for large strings (too much to maintain)
- move sql formatting to python/external expensive CPU server like we do for python script.
