### PR TITLE
Togglable code editor for JSON feature values, default to off when too large

### DIFF
--- a/packages/front-end/components/Features/FeatureValueField.tsx
+++ b/packages/front-end/components/Features/FeatureValueField.tsx
@@ -140,23 +140,6 @@ export default function FeatureValueField({
   }
 
   if (valueType === "json") {
-    // If useCodeInput is false, always use the legacy editor with no toggle
-    if (!useCodeInput) {
-      return (
-        <JSONTextEditor
-          label={label}
-          value={value}
-          setValue={setValue}
-          helpText={helpText}
-          placeholder={placeholder}
-          disabled={disabled}
-          showCopyButton={true}
-          performCopy={performCopy}
-          copySuccess={copySuccess}
-        />
-      );
-    }
-
     let formatted;
     try {
       const parsed = dJSON.parse(value);
@@ -165,7 +148,7 @@ export default function FeatureValueField({
       // Ignore
     }
 
-    const codeEditorToggleButton = (
+    const codeEditorToggleButton = useCodeInput ? (
       <a
         href="#"
         className="text-purple"
@@ -178,7 +161,7 @@ export default function FeatureValueField({
         <PiBracketsCurly />{" "}
         {codeEditorToggledOn ? "Use text editor" : "Use code editor"}
       </a>
-    );
+    ) : null;
 
     const formatJSONButton = (
       <a
@@ -214,7 +197,7 @@ export default function FeatureValueField({
       </Flex>
     );
 
-    if (codeEditorToggledOn) {
+    if (useCodeInput && codeEditorToggledOn) {
       return (
         <CodeTextArea
           label={label}


### PR DESCRIPTION
- make code editor togglable
- default to off when value.length is too large
- add missing "copy to clipboard" button for JSON text editor

<img width="828" height="671" alt="image" src="https://github.com/user-attachments/assets/05d96a76-72c1-498e-a233-2342f33c959f" />

<img width="814" height="396" alt="image" src="https://github.com/user-attachments/assets/b2bb9b3a-027b-4b8e-a0f0-587f91bd1415" />


### Features and Changes

<!--
  Include a description of your changes.
  If there are any new tools, API's, etc. that devs can leverage, it may be helpful to include usage info.
-->

<!--
  Indicate which issue this will close, if applicable
  For multiple issues, add a new `- Closes` or `- Fixes` line
-->

- Closes **(add link to issue here)**

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

<!--
  Please describe how to test these changes.
 -->

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
