### PR TITLE
fix(datasource): Remove invalid values from userIdTypes

### DIFF
--- a/packages/back-end/src/util/migrations.ts
+++ b/packages/back-end/src/util/migrations.ts
@@ -208,6 +208,11 @@ export function upgradeDatasourceObject(
     ];
   }
 
+  // Sanity check as somehow this ended up with null value in the array
+  if (settings.userIdTypes) {
+    settings.userIdTypes = settings.userIdTypes?.filter((it) => !!it);
+  }
+
   // Upgrade old docs to the new exposure queries format
   if (settings && !settings?.queries?.exposure) {
     const isSQL = !["google_analytics", "mixpanel"].includes(datasource.type);


### PR DESCRIPTION
### Features and Changes

We have a scenario where `null` has ended up inside of `dataSource.settings.userIdTypes` -- while I am still investigating how that was possible, we can use the migration to ensure it does not happen again, and this automatically heals DataSources with this issue too.