### PR TITLE
Add confirmation to deleting PA dashboard

### DIFF
--- a/packages/front-end/pages/product-analytics/dashboards/index.tsx
+++ b/packages/front-end/pages/product-analytics/dashboards/index.tsx
@@ -468,7 +468,6 @@ export default function DashboardsPage() {
                                             </span>
                                           ),
                                           cta: "Delete",
-                                          submitColor: "danger",
                                           submit: async () => {
                                             await apiCall(
                                               `/dashboards/${d.id}`,

--- a/packages/front-end/ui/DropdownMenu.tsx
+++ b/packages/front-end/ui/DropdownMenu.tsx
@@ -111,7 +111,7 @@ type DropdownItemProps = {
     getConfirmationContent?: () => Promise<string | ReactElement | null>;
     confirmationTitle: string | ReactElement;
     cta: string;
-    submitColor: string;
+    submitColor?: string;
   };
 } & MarginProps;
 
@@ -151,7 +151,7 @@ export function DropdownMenuItem({
           close={() => setConfirming(false)}
           open={true}
           cta={confirmation.cta}
-          submitColor={confirmation.submitColor}
+          submitColor={confirmation.submitColor ?? "danger"}
           submit={confirmation.submit}
           increasedElevation={true}
         >


### PR DESCRIPTION
### Features and Changes

Adds a confirmation modal before allowing deletion of Product Analytics Dashboards.

The implementation is a general confirmation step for `DropdownMenuItem` since the existing `DeleteButton` doesn't play nicely with Radix dropdowns.

### Testing

Create and then delete a dashboard

### Screenshots

<img width="2107" height="973" alt="image" src="https://github.com/user-attachments/assets/450d7629-380a-476d-88a1-e7091555f4ca" />
