### PR TITLE
Upgrade mongodb helm chart

### DIFF
--- a/charts/growthbook/Chart.lock
+++ b/charts/growthbook/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: mongodb
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 16.5.1
+  version: 18.1.9
 - name: server
   repository: ""
   version: 0.0.0
 - name: server
   repository: ""
   version: 0.0.0
-digest: sha256:4d1eabf4f8723300ab9bc325ae11fe395cc1de97e3cf32c6c7540a3af3a70ace
-generated: "2025-04-17T11:49:04.396553326+02:00"
+digest: sha256:81fec7a9e7863e315f4347e877ef61d7a8af8a94d8d2f3549dce0810d79ac4ce
+generated: "2025-11-14T10:32:04.916227+01:00"

--- a/charts/growthbook/Chart.yaml
+++ b/charts/growthbook/Chart.yaml
@@ -22,7 +22,7 @@ appVersion: "4.1.0"
 dependencies:
   - name: mongodb
     repository: oci://registry-1.docker.io/bitnamicharts
-    version: "^17.0.0"
+    version: "^18.0.0"
     condition: mongodb.enabled
   - name: server
     version: "0.0.0"


### PR DESCRIPTION
### Features and Changes

CI was throwing:
```
 Run helm lint --strict --with-subcharts .
Error: 3 chart(s) linted, 1 chart(s) failed
==> Linting .
==> Linting charts/mongodb-16.5.1.tgz
Warning: templates/standalone/pdb.yaml: policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+; use policy/v1 PodDisruptionBudget
```
The newer version of the chart doesn't use that.

In our docker-compose.yml we always use mongo:latest so should be safe here too. 

### Testing

See ci pass.

