### PR TITLE
Fix duplicate IDs in saved query visualizations

### DIFF
--- a/packages/front-end/components/SchemaBrowser/SqlExplorerModal.tsx
+++ b/packages/front-end/components/SchemaBrowser/SqlExplorerModal.tsx
@@ -877,6 +877,7 @@ export default function SqlExplorerModal({
                                     ...dataVizConfig,
                                     {
                                       ...config,
+                                      id: undefined, // Generate a new ID once the request hits the backend
                                       title: `${
                                         config.title ||
                                         `Visualization ${index + 1}`


### PR DESCRIPTION
### Features and Changes

Currently if you duplicate a visualization that's already been saved (has had an ID generated for it), the duplicate will inherit the same ID. This leads to broken behavior when toggling which visualizations to display in the dashboard sql explorer block.

### Testing

1. Create a new (or use an existing) saved query in a dashboard
2. Create and save a visualization
3. Using the hamburger menu, duplicate that visualization and then save the query
4. Attempt to toggle the duplicated visualization. Without this fix, it toggles both the original and the duplicate at the same time

