### PR TITLE
Deploy to ECR as well

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Configure AWS credentials for ECR
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -87,7 +87,7 @@ jobs:
           fetch-depth: 0
 
       - name: Configure AWS credentials for GrowthBook Cloud
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       sha:
-        description: 'The first 7 characters of the commit SHA to be rolled back to'
+        description: "The first 7 characters of the commit SHA to be rolled back to"
         required: true
         type: string
 jobs:
@@ -35,7 +35,7 @@ jobs:
     if: ${{ github.repository == 'growthbook/growthbook' }}
     steps:
       - name: Configure AWS credentials for GrowthBook Cloud
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
### Features and Changes
To lower the time of Fargate to download and start up images we will instruct fargate to load from ecr instead of DockerHub. This also avoids any issue of DockerHub rate limiting us. This second step sends the image to ECR as well as DockerHub.  We also update the step to push the built images to s3 to pull from ECR instead of DockerHub.

The last step will actually update the container image to read from ECR instead of dockerhub.

### Dependencies
https://github.com/growthbook/terraform/pull/116

### Testing
See deploy succeeds.
Login to AWS and see image updated.
