### PR TITLE
Add runtime Metrics to datadog

### DIFF
--- a/packages/back-end/src/tracing.datadog.ts
+++ b/packages/back-end/src/tracing.datadog.ts
@@ -4,6 +4,7 @@ import { Attributes, setMetrics } from "./util/metrics";
 
 tracer.init({
   logInjection: true,
+  runtimeMetrics: true,
 });
 
 class Counter {


### PR DESCRIPTION
### Features and Changes

We have certain routes that seem CPU bound.  Adding runtimeMetrics should help keep us on time of whether requests are getting delayed because another request is hogging the CPU the whole time. https://docs.datadoghq.com/tracing/metrics/runtime_metrics/?tab=nodejs

The downside might be a few more custom metrics that cost us in datadog usage, but it doesn't seem like all that many, if it is per service.