### PR TITLE
add break-all to diff viewer

### DIFF
--- a/packages/front-end/components/Features/CompareEnvironmentsModal.tsx
+++ b/packages/front-end/components/Features/CompareEnvironmentsModal.tsx
@@ -128,6 +128,11 @@ export default function CompareEnvironmentsModal({
           newValue={JSON.stringify(rulesByEnv[sourceEnv], null, 2)}
           compareMethod={DiffMethod.LINES}
           useDarkTheme={appearance === "dark"}
+          styles={{
+            contentText: {
+              wordBreak: "break-all",
+            },
+          }}
         />
       )}
     </Modal>

--- a/packages/front-end/components/Features/DraftModal.tsx
+++ b/packages/front-end/components/Features/DraftModal.tsx
@@ -68,6 +68,11 @@ export function ExpandableDiff({
             oldValue={a}
             newValue={b}
             compareMethod={DiffMethod.LINES}
+            styles={{
+              contentText: {
+                wordBreak: "break-all",
+              },
+            }}
           />
         </div>
       )}

--- a/packages/front-end/components/Features/FixConflictsModal.tsx
+++ b/packages/front-end/components/Features/FixConflictsModal.tsx
@@ -101,6 +101,11 @@ export function ExpandableConflict({
                 oldValue={conflict.base}
                 newValue={conflict.live}
                 compareMethod={DiffMethod.LINES}
+                styles={{
+                  contentText: {
+                    wordBreak: "break-all",
+                  },
+                }}
               />
             </div>
             <div className="col pt-2 pb-3">
@@ -112,6 +117,11 @@ export function ExpandableConflict({
                 oldValue={conflict.base}
                 newValue={conflict.revision}
                 compareMethod={DiffMethod.LINES}
+                styles={{
+                  contentText: {
+                    wordBreak: "break-all",
+                  },
+                }}
               />
             </div>
           </div>

--- a/packages/front-end/components/HistoryTable.tsx
+++ b/packages/front-end/components/HistoryTable.tsx
@@ -59,6 +59,11 @@ function EventDetails({
           oldValue={JSON.stringify(json.pre || {}, null, 2)}
           newValue={JSON.stringify(json.post || {}, null, 2)}
           compareMethod={DiffMethod.LINES}
+          styles={{
+            contentText: {
+              wordBreak: "break-all",
+            },
+          }}
         />
       </div>
     );

--- a/packages/front-end/components/importing/ImportFromLaunchDarkly/ImportFromLaunchDarkly.tsx
+++ b/packages/front-end/components/importing/ImportFromLaunchDarkly/ImportFromLaunchDarkly.tsx
@@ -133,6 +133,11 @@ function FeatureDiff({
       oldValue={a}
       newValue={b}
       compareMethod={DiffMethod.LINES}
+      styles={{
+        contentText: {
+          wordBreak: "break-all",
+        },
+      }}
     />
   );
 }


### PR DESCRIPTION
before (was causing confusion with nested structures / JSON):
<img width="1373" height="306" alt="image" src="https://github.com/user-attachments/assets/d4b9fbf6-8636-4596-8ee5-40eda0f39639" />

after:
<img width="1364" height="292" alt="image" src="https://github.com/user-attachments/assets/4c3f8856-2ef4-45cf-9c0b-0ab625daf06d" />
