### PR TITLE
Fix dashboard timeseries validation error

### DIFF
--- a/packages/back-end/src/enterprise/models/DashboardModel.ts
+++ b/packages/back-end/src/enterprise/models/DashboardModel.ts
@@ -332,7 +332,7 @@ export function migrateBlock(
     case "experiment-time-series":
       return {
         ...doc,
-        metricIds: doc.metricId ? [doc.metricId] : doc.metricIds,
+        metricIds: doc.metricId ? [doc.metricId] : (doc.metricIds ?? undefined),
         metricId: undefined,
         metricSelector: doc.metricSelector || "custom",
         pinSource: doc.pinSource || "experiment",


### PR DESCRIPTION
### Features and Changes

There's a bug with zod validation of dashboard timeseries blocks which currently prevents managing dashboards that include a timeseries block. This is due to mongo storing a `null` which wasn't being correctly handled by `migrate`

### Testing

- [x] Create a dashboard with a timeseries block (all goal metrics) on `main`. After saving it initially and refreshing once, a second refresh should fail.
- [x] After switching to this branch, refreshing should work again
- [x] Set the timeseries metric selection to custom selection but don't select any metrics. The block shouldn't interfere with updating (but won't have any results)
- [x] Select a custom metric; results should now be visible and refreshing should still work
- [x] Verify that regular metric blocks still work and can refresh with a default metric selection
- [x] Verify that regular metric blocks still work and can refresh with a custom metric selection
- [x] Verify that dimension blocks still work and can refresh with a default metric selection
- [x] Verify that dimension blocks still work and can refresh with a custom metric selection

(These last few tests aren't related to the fix, but to make sure the bug didn't also apply to those blocks. That said, the data in mongo is different so it makes sense why it's only affecting timeseries)

<details>
<summary>Mongo data screenshots</summary>


`experiment-metric` and `experiment-dimension` blocks don't have a `metricIds` field until "custom selection" is chosen, so there's no `null` to cause validation issues
<img width="890" height="666" alt="image" src="https://github.com/user-attachments/assets/188d6f37-8663-416e-9950-b48c62edab9f" />

<img width="1027" height="665" alt="image" src="https://github.com/user-attachments/assets/5c3182e6-568a-4544-b2eb-2085667cc994" />

`experiment-time-series` has `metricIds: null` from the start, which is why this error is happening
<img width="823" height="630" alt="image" src="https://github.com/user-attachments/assets/b49791e3-5a67-48f8-9f83-8bfadaffcf75" />


</details>