### PR TITLE
Fix migration from legacy sql explorer blocks

### DIFF
--- a/packages/back-end/src/enterprise/models/DashboardModel.ts
+++ b/packages/back-end/src/enterprise/models/DashboardModel.ts
@@ -376,6 +376,12 @@ export function migrateBlock(
         showTable: true,
         showTimeseries: false,
       };
+    case "sql-explorer": {
+      return {
+        ...doc,
+        blockConfig: doc.blockConfig ?? [],
+      };
+    }
     default:
       return doc;
   }

--- a/packages/back-end/src/enterprise/validators/dashboard-block.ts
+++ b/packages/back-end/src/enterprise/validators/dashboard-block.ts
@@ -43,18 +43,12 @@ const legacyExperimentDescriptionBlockInterface = baseBlockInterface
     experimentId: z.string(),
   })
   .strict();
-export type LegacyExperimentDescriptionBlockInterface = z.infer<
-  typeof legacyExperimentDescriptionBlockInterface
->;
 const legacyExperimentHypothesisBlockInterface = baseBlockInterface
   .extend({
     type: z.literal("experiment-hypothesis"),
     experimentId: z.string(),
   })
   .strict();
-export type LegacyExperimentHypothesisBlockInterface = z.infer<
-  typeof legacyExperimentHypothesisBlockInterface
->;
 const legacyExperimentVariationImageBlockInterface = baseBlockInterface
   .extend({
     type: z.literal("experiment-variation-image"),
@@ -62,9 +56,6 @@ const legacyExperimentVariationImageBlockInterface = baseBlockInterface
     variationIds: z.array(z.string()),
   })
   .strict();
-export type LegacyExperimentVariationImageBlockInterface = z.infer<
-  typeof legacyExperimentVariationImageBlockInterface
->;
 const legacyExperimentTrafficTableBlockInterface = baseBlockInterface
   .extend({
     type: z.literal("experiment-traffic-table"),
@@ -72,9 +63,6 @@ const legacyExperimentTrafficTableBlockInterface = baseBlockInterface
   })
   .strict();
 
-export type LegacyExperimentTrafficTableBlockInterface = z.infer<
-  typeof legacyExperimentTrafficTableBlockInterface
->;
 const legacyExperimentTrafficGraphBlockInterface = baseBlockInterface
   .extend({
     type: z.literal("experiment-traffic-graph"),
@@ -82,9 +70,6 @@ const legacyExperimentTrafficGraphBlockInterface = baseBlockInterface
   })
   .strict();
 
-export type LegacyExperimentTrafficGraphBlockInterface = z.infer<
-  typeof legacyExperimentTrafficGraphBlockInterface
->;
 // End deprecated block types
 
 const experimentMetadataBlockInterface = baseBlockInterface
@@ -146,9 +131,6 @@ const legacyExperimentMetricBlockInterface = experimentMetricBlockInterface
     metricSelector: z.enum(metricSelectors).optional(),
   })
   .merge(metricSliceSettingsInterface.partial());
-export type LegacyExperimentMetricBlockInterface = z.infer<
-  typeof legacyExperimentMetricBlockInterface
->;
 
 const experimentDimensionBlockInterface = baseBlockInterface
   .extend({
@@ -182,9 +164,6 @@ const legacyExperimentDimensionBlockInterface =
   experimentDimensionBlockInterface.omit({ metricSelector: true }).extend({
     metricSelector: z.enum(metricSelectors).optional(),
   });
-export type LegacyExperimentDimensionBlockInterface = z.infer<
-  typeof legacyExperimentDimensionBlockInterface
->;
 
 const experimentTimeSeriesBlockInterface = baseBlockInterface
   .extend({
@@ -209,18 +188,21 @@ const legacyExperimentTimeSeriesBlockInterface =
       metricSelector: z.enum(metricSelectors).optional(),
     })
     .merge(metricSliceSettingsInterface.partial());
-export type LegacyExperimentTimeSeriesBlockInterface = z.infer<
-  typeof legacyExperimentTimeSeriesBlockInterface
->;
 
 const sqlExplorerBlockInterface = baseBlockInterface
   .extend({
     type: z.literal("sql-explorer"),
     savedQueryId: z.string(),
     dataVizConfigIndex: z.number().optional(), // Deprecated with the release of product analytics dashboards as we now allow users to show multiple visualizations
-    blockConfig: z.array(z.string()).optional(),
+    blockConfig: z.array(z.string()),
   })
   .strict();
+
+const legacySqlExplorerBlockInterface = sqlExplorerBlockInterface
+  .omit({ blockConfig: true })
+  .extend({
+    blockConfig: z.array(z.string()).optional(),
+  });
 
 export type SqlExplorerBlockInterface = z.infer<
   typeof sqlExplorerBlockInterface
@@ -263,6 +245,7 @@ export const legacyDashboardBlockInterface = z.discriminatedUnion("type", [
   legacyExperimentTimeSeriesBlockInterface,
   legacyExperimentTrafficGraphBlockInterface,
   legacyExperimentTrafficTableBlockInterface,
+  legacySqlExplorerBlockInterface,
 ]);
 
 export type DashboardBlockInterface = z.infer<typeof dashboardBlockInterface>;

--- a/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardEditorSidebar/EditSingleBlock.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardEditorSidebar/EditSingleBlock.tsx
@@ -117,13 +117,15 @@ function toggleBlockConfigItem(
   // Type guard to ensure we have a sql-explorer block with blockConfig
   if (!("blockConfig" in block)) return;
 
-  const currentBlockConfig = block.blockConfig || [];
+  const currentBlockConfig = block.blockConfig;
+  // Remove dataVizConfigIndex from legacy blocks so the new config format takes effect
+  const { dataVizConfigIndex: _, ...blockToSet } = block;
 
   if (value) {
     // Add item to blockConfig
     const newBlockConfig = [...currentBlockConfig, itemId];
     setBlock({
-      ...block,
+      ...blockToSet,
       blockConfig: newBlockConfig,
     });
   } else {
@@ -132,7 +134,7 @@ function toggleBlockConfigItem(
       (id: string) => id !== itemId,
     );
     setBlock({
-      ...block,
+      ...blockToSet,
       blockConfig: filteredBlockConfig,
     });
   }


### PR DESCRIPTION
### Features and Changes

With the release of Product Analytics dashboards we changed the format for `sql-explorer` blocks, but missed a migration helper for the legacy blocks. This means that while the old blocks still display correctly, they can't be edited with the new `blockConfig` field. This PR adds the missing case to `migrate` and makes the new config field required as it can now be relied on.

### Testing

Setup:
1. Switch to main and create a dashboard with a single sql-explorer block (make sure the query has at least one visualization)
2. Using a mongo shell, update it to match the legacy interface
```
db.dashboards.updateOne({id:"<YOUR_ID_HERE>"}, {$set: {"blocks.0.dataVizConfigIndex": 0}, $unset: {"blocks.0.blockConfig": ""}})
```
- [x] On main the block should still render, but editing and trying to toggle the visualization/results table checkboxes shouldn't work
- [x] On this branch, the display should also render, but toggling the checkboxes should work and display the appropriate visualizations
- [x] Inspecting the block in mongo should show it dropped the `dataVizConfigIndex`

### Screenshots

Legacy block behavior
<img width="733" height="419" alt="image" src="https://github.com/user-attachments/assets/c33e402c-c6df-422b-8836-5d9feefa323c" />

<img width="2560" height="840" alt="image" src="https://github.com/user-attachments/assets/2eeb962e-cfa0-4d6d-af4d-d1c163352750" />

With migration
<img width="1130" height="429" alt="image" src="https://github.com/user-attachments/assets/f1b0cd63-ae59-44ff-8aff-46cee0bee6a2" />

<img width="2560" height="1000" alt="image" src="https://github.com/user-attachments/assets/55a28f33-f638-444c-83d3-38e3770bff6c" />
