### PR TITLE
pin form-data to avoid security vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,10 @@
     "overrides": {
       "@growthbook/growthbook": "1.6.2",
       "vite": "^6.0.0",
-      "execa": "^5.0.0"
+      "execa": "^5.0.0",
+      "form-data@2": "2.5.5",
+      "form-data@3": "3.0.4",
+      "form-data@4": "4.0.5"
     },
     "patchedDependencies": {
       "@types/presto-client@1.0.2": "patches/@types__presto-client@1.0.2.patch",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ overrides:
   '@growthbook/growthbook': 1.6.2
   vite: ^6.0.0
   execa: ^5.0.0
+  form-data@2: 2.5.5
+  form-data@3: 3.0.4
+  form-data@4: 4.0.5
 
 patchedDependencies:
   '@ephys/zod-to-ts@2.3.2':
@@ -8955,16 +8958,16 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
-  form-data@2.5.1:
-    resolution: {integrity: sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==}
+  form-data@2.5.5:
+    resolution: {integrity: sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==}
     engines: {node: '>= 0.12'}
 
-  form-data@3.0.1:
-    resolution: {integrity: sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==}
+  form-data@3.0.4:
+    resolution: {integrity: sha512-f0cRzm6dkyVYV3nPoooP8XlccPQukegwhAnpoLcXy+X+A8KfpGOoXwDr9FLZd3wzgLaBGQBE3lY93Zm/i1JvIQ==}
     engines: {node: '>= 6'}
 
-  form-data@4.0.4:
-    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
 
   format@0.2.2:
@@ -21700,7 +21703,7 @@ snapshots:
   '@types/node-fetch@2.6.2':
     dependencies:
       '@types/node': 22.8.6
-      form-data: 3.0.1
+      form-data: 3.0.4
 
   '@types/node-int64@0.4.29':
     dependencies:
@@ -21818,7 +21821,7 @@ snapshots:
       '@types/caseless': 0.12.2
       '@types/node': 22.8.6
       '@types/tough-cookie': 4.0.0
-      form-data: 2.5.1
+      form-data: 2.5.5
 
   '@types/resolve@1.20.2': {}
 
@@ -22620,7 +22623,7 @@ snapshots:
   axios@1.12.2:
     dependencies:
       follow-redirects: 1.15.6(debug@4.4.3)
-      form-data: 4.0.4
+      form-data: 4.0.5
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
@@ -24697,19 +24700,24 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  form-data@2.5.1:
+  form-data@2.5.5:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
       mime-types: 2.1.35
+      safe-buffer: 5.2.1
 
-  form-data@3.0.1:
+  form-data@3.0.4:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
       mime-types: 2.1.35
 
-  form-data@4.0.4:
+  form-data@4.0.5:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
@@ -26309,7 +26317,7 @@ snapshots:
       decimal.js: 10.5.0
       domexception: 2.0.1
       escodegen: 2.1.0
-      form-data: 3.0.1
+      form-data: 3.0.4
       html-encoding-sniffer: 2.0.1
       http-proxy-agent: 4.0.1
       https-proxy-agent: 5.0.1
@@ -29799,7 +29807,7 @@ snapshots:
       cookiejar: 2.1.4
       debug: 4.4.3(supports-color@5.5.0)
       fast-safe-stringify: 2.1.1
-      form-data: 4.0.4
+      form-data: 4.0.5
       formidable: 3.5.1
       methods: 1.1.2
       mime: 2.6.0


### PR DESCRIPTION
### Features and Changes

Form-data has some [security vulnerabilities](https://us-east-1.console.aws.amazon.com/inspector/v2/home?region=us-east-1#/findings/container-image/arn%3Aaws%3Aecr%3Aus-east-1%3A476680172222%3Arepository%2Fgrowthbook%2Fsha256%3A0f76c288cbd3ae08c97783bf756706a267c5a9e0be929760e7230790910120e7).  We pin it to the most recent major version for versions 2,3,and 4.  This is deemed safe because the [change log](https://github.com/form-data/form-data/blob/master/CHANGELOG.md) doesn't show any breaking changes within major versions.  The modules relying on older major versions are either from testing or from @types.

This is the output of `pnpm why -r --prod form-data` after pinning in `overrides`:
```
pnpm why -r --prod form-data
Legend: production dependency, optional only, dev only

back-end@0.0.1 /Users/james/growthbook/growthbook/packages/back-end (PRIVATE)

dependencies:
snowflake-sdk 2.3.3
├─┬ @google-cloud/storage 7.10.0
│ └─┬ retry-request 7.0.2
│   └─┬ @types/request 2.48.12
│     └── form-data 2.5.5
└─┬ axios 1.12.2
  └── form-data 4.0.5
```
Note ECR was complaining about version 3.0.1 and 4.0.0 being mentioned in /usr/local/src/app/node_modules/.pnpm/tedious@16.7.1/node_modules/tedious/benchmarks/package-lock.json however `pnpm why -r --prod form-data` doesn't show that, I think because they are not actually installed.   Hopefully ECR won't still mention it after this change.
