### PR TITLE
Fix UI bug in custom hooks modal

### DIFF
--- a/packages/front-end/pages/settings/custom-hooks.tsx
+++ b/packages/front-end/pages/settings/custom-hooks.tsx
@@ -123,6 +123,7 @@ function CustomHooksModal({
       code: current?.code || "",
       projects: current?.projects || [],
       enabled: current?.enabled ?? true,
+      incrementalChangesOnly: current?.incrementalChangesOnly || false,
     },
   });
 


### PR DESCRIPTION
### Features and Changes

The checkbox for "Incremental Changes Only" was being saved to the database correctly, but would always be unchecked when opening the edit modal.  Was just missing a default value in the form state.  One line fix.
