### PR TITLE
fix(incremental): Ensure variation is type string

### DIFF
--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -6730,7 +6730,7 @@ ${this.selectStarLimit("__topValues ORDER BY count DESC", limit)}
         , __filteredNewExposures AS (
           SELECT 
             ${this.castToString(`${baseIdType}`)} AS ${baseIdType}
-            , variation_id AS variation
+            , ${this.castToString(`variation_id`)} AS variation
             , timestamp AS timestamp
             ${activationMetric ? `, NULL AS activation_timestamp` : ""}
             ${experimentDimensions


### PR DESCRIPTION
Variation IDs can sometimes be non-string, but we expect them to be string as part of incremental refresh. This just always casts variation to string.

The other column this may apply to is `timestamp`, where we expect type Timestamp but maybe it is actually DATETIME or the like. I am not going to make that change until it is an issue, however, since that's a bit riskier.