### PR TITLE
(HOTFIX) Add fallback to AnalysisSettingsSummary units if health query not available

### DIFF
--- a/packages/front-end/components/Experiment/TabbedPage/AnalysisSettingsSummary.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/AnalysisSettingsSummary.tsx
@@ -127,10 +127,20 @@ export default function AnalysisSettingsSummary({
       weight: phaseObj?.variationWeights?.[i] || 0,
     };
   });
-  const totalUnits = snapshot?.health?.traffic?.overall?.variationUnits?.reduce(
-    (acc, a) => acc + a,
-    0,
-  );
+
+  const totalUnits = useMemo(() => {
+    const healthVariationUnits =
+      snapshot?.health?.traffic?.overall?.variationUnits;
+    if (healthVariationUnits && healthVariationUnits.length > 0) {
+      return healthVariationUnits.reduce((acc, a) => acc + a, 0);
+    }
+    // Fallback to using results for total units if health units not available
+    let totalUsers = 0;
+    analysis?.results?.[0]?.variations?.forEach((v) => {
+      totalUsers += v.users;
+    });
+    return totalUsers;
+  }, [analysis?.results, snapshot?.health?.traffic?.overall?.variationUnits]);
 
   // Convert userIdType to display name (e.g. "user_id" -> "User Ids")
   const unitDisplayName = userIdType


### PR DESCRIPTION
### Features and Changes

The experiment results units count was switched over to use the health query for the units count but if the health query is disabled the count will always be zero. Adds a fallback to use the the analysis unit counts if the health query is unavailable and memoizes the value.

### Testing

- [x] Test with an experiment when health query is available and make sure the health query value is used
- [x] Test with an experiment when health query is not available and make sure the analysis value is used