### PR TITLE
fix(diffs): Consolidate diff generation + ensure it is parsed as JSON

### DIFF
--- a/packages/front-end/components/Features/DraftModal.tsx
+++ b/packages/front-end/components/Features/DraftModal.tsx
@@ -1,4 +1,4 @@
-import { FeatureInterface, FeatureRule } from "back-end/types/feature";
+import { FeatureInterface } from "back-end/types/feature";
 import ReactDiffViewer, { DiffMethod } from "react-diff-viewer";
 import { useState, useMemo } from "react";
 import { FaAngleDown, FaAngleRight, FaArrowLeft } from "react-icons/fa";
@@ -20,6 +20,10 @@ import Modal from "@/components/Modal";
 import Button from "@/components/Button";
 import Field from "@/components/Forms/Field";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
+import {
+  useFeatureRevisionDiff,
+  featureToFeatureRevisionDiffInput,
+} from "@/hooks/useFeatureRevisionDiff";
 import Callout from "@/ui/Callout";
 import Checkbox from "@/ui/Checkbox";
 import { PreLaunchChecklistFeatureExpRule } from "@/components/Experiment/PreLaunchChecklist";
@@ -101,16 +105,11 @@ export default function DraftModal({
   );
   const liveRevision = revisions.find((r) => r.version === feature.version);
 
+  const envIds = environments.map((e) => e.id);
   const mergeResult = useMemo(() => {
     if (!revision || !baseRevision || !liveRevision) return null;
-    return autoMerge(
-      liveRevision,
-      baseRevision,
-      revision,
-      environments.map((e) => e.id),
-      {},
-    );
-  }, [revision, baseRevision, liveRevision]);
+    return autoMerge(liveRevision, baseRevision, revision, envIds, {});
+  }, [revision, baseRevision, liveRevision, envIds]);
 
   const [comment, setComment] = useState(revision?.comment || "");
 
@@ -125,91 +124,18 @@ export default function DraftModal({
   );
   const [experimentsStep, setExperimentsStep] = useState(false);
 
-  // Parse JSON strings that look like JSON
-  const parseIfJson = (str: string | undefined): string | unknown => {
-    if (!str || typeof str !== "string") return str || "";
-    if (str.trim().startsWith("{") && str.trim().endsWith("}")) {
-      try {
-        const parsed = JSON.parse(str);
-        return parsed;
-      } catch (e) {
-        return str;
-      }
-    }
-
-    return str;
-  };
-
-  // Process rules for diff with special formatting for a few fields
-  const processRulesForDiff = (rules: FeatureRule[]): FeatureRule[] => {
-    if (!Array.isArray(rules)) return rules;
-
-    return rules.map((rule) => {
-      const processedRule = { ...rule };
-
-      if ("value" in processedRule && typeof processedRule.value === "string") {
-        (processedRule as { value: unknown }).value = parseIfJson(
-          processedRule.value as string,
-        );
-      }
-
-      if (
-        "variations" in processedRule &&
-        Array.isArray(processedRule.variations)
-      ) {
-        type Variation = { value: string | unknown; [key: string]: unknown };
-        (processedRule as unknown as { variations: Variation[] }).variations = (
-          processedRule.variations as Variation[]
-        ).map((variation) => {
-          if (typeof variation.value === "string") {
-            return { ...variation, value: parseIfJson(variation.value) };
-          }
-          return variation;
-        });
-      }
-
-      return processedRule as FeatureRule;
-    });
-  };
-
-  const resultDiffs = useMemo(() => {
-    const diffs: { a: string; b: string; title: string }[] = [];
-
-    if (!mergeResult) return diffs;
-    if (!mergeResult.success) return diffs;
-
-    const result = mergeResult.result;
-
-    if (result.defaultValue !== undefined) {
-      const aValue = parseIfJson(feature.defaultValue);
-      const bValue = parseIfJson(result.defaultValue);
-      diffs.push({
-        title: "Default Value",
-        a:
-          typeof aValue === "string" ? aValue : JSON.stringify(aValue, null, 2),
-        b:
-          typeof bValue === "string" ? bValue : JSON.stringify(bValue, null, 2),
-      });
-    }
-    if (result.rules) {
-      environments.forEach((env) => {
-        const liveRules = feature.environmentSettings?.[env.id]?.rules || [];
-        const processedLiveRules = processRulesForDiff(liveRules);
-        const resultRules = result.rules?.[env.id];
-        const processedResultRules = processRulesForDiff(resultRules || []);
-
-        if (resultRules) {
-          diffs.push({
-            title: `Rules - ${env.id}`,
-            a: JSON.stringify(processedLiveRules, null, 2),
-            b: JSON.stringify(processedResultRules, null, 2),
-          });
+  const currentRevisionData = featureToFeatureRevisionDiffInput(feature);
+  const resultDiffs = useFeatureRevisionDiff({
+    current: currentRevisionData,
+    draft: mergeResult?.success
+      ? {
+          // Use current values as fallback when merge result doesn't have changes
+          defaultValue:
+            mergeResult.result.defaultValue ?? currentRevisionData.defaultValue,
+          rules: mergeResult.result.rules ?? currentRevisionData.rules,
         }
-      });
-    }
-
-    return diffs;
-  }, [mergeResult]);
+      : currentRevisionData,
+  });
 
   if (!revision || !mergeResult) return null;
 

--- a/packages/front-end/components/Features/FixConflictsModal.tsx
+++ b/packages/front-end/components/Features/FixConflictsModal.tsx
@@ -15,6 +15,10 @@ import { useEnvironments } from "@/services/features";
 import { useAuth } from "@/services/auth";
 import PagedModal from "@/components/Modal/PagedModal";
 import Page from "@/components/Modal/Page";
+import {
+  useFeatureRevisionDiff,
+  featureToFeatureRevisionDiffInput,
+} from "@/hooks/useFeatureRevisionDiff";
 import { ExpandableDiff } from "./DraftModal";
 
 export interface Props {
@@ -165,36 +169,18 @@ export default function FixConflictsModal({
     );
   }, [revision, baseRevision, liveRevision, environments, strategies]);
 
-  const resultDiffs = useMemo(() => {
-    const diffs: { a: string; b: string; title: string }[] = [];
-
-    if (!mergeResult) return diffs;
-    if (!mergeResult.success) return diffs;
-
-    const result = mergeResult.result;
-
-    if (result.defaultValue !== undefined) {
-      diffs.push({
-        title: "Default Value",
-        a: feature.defaultValue,
-        b: result.defaultValue,
-      });
-    }
-    if (result.rules) {
-      environments.forEach((env) => {
-        const liveRules = feature.environmentSettings?.[env.id]?.rules || [];
-        if (result.rules && result.rules[env.id]) {
-          diffs.push({
-            title: `Rules - ${env.id}`,
-            a: JSON.stringify(liveRules, null, 2),
-            b: JSON.stringify(result.rules[env.id], null, 2),
-          });
+  const currentRevisionData = featureToFeatureRevisionDiffInput(feature);
+  const resultDiffs = useFeatureRevisionDiff({
+    current: currentRevisionData,
+    draft: mergeResult?.success
+      ? {
+          // Use current values as fallback when merge result doesn't have changes
+          defaultValue:
+            mergeResult.result.defaultValue ?? currentRevisionData.defaultValue,
+          rules: mergeResult.result.rules ?? currentRevisionData.rules,
         }
-      });
-    }
-
-    return diffs;
-  }, [mergeResult, feature, environments]);
+      : currentRevisionData,
+  });
 
   if (!revision || !mergeResult || !mergeResult.conflicts.length) return null;
 

--- a/packages/front-end/components/Features/RequestReviewModal.tsx
+++ b/packages/front-end/components/Features/RequestReviewModal.tsx
@@ -23,6 +23,10 @@ import Button from "@/components/Button";
 import { ExpandableDiff } from "@/components/Features/DraftModal";
 import Revisionlog, { MutateLog } from "@/components/Features/RevisionLog";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
+import {
+  useFeatureRevisionDiff,
+  featureToFeatureRevisionDiffInput,
+} from "@/hooks/useFeatureRevisionDiff";
 import RadioGroup from "@/ui/RadioGroup";
 import Callout from "@/ui/Callout";
 import { PreLaunchChecklistFeatureExpRule } from "@/components/Experiment/PreLaunchChecklist";
@@ -96,6 +100,19 @@ export default function RequestReviewModal({
   );
   const [experimentsStep, setExperimentsStep] = useState(false);
 
+  const currentRevisionData = featureToFeatureRevisionDiffInput(feature);
+  const resultDiffs = useFeatureRevisionDiff({
+    current: currentRevisionData,
+    draft: mergeResult?.success
+      ? {
+          // Use current values as fallback when merge result doesn't have changes
+          defaultValue:
+            mergeResult.result.defaultValue ?? currentRevisionData.defaultValue,
+          rules: mergeResult.result.rules ?? currentRevisionData.rules,
+        }
+      : currentRevisionData,
+  });
+
   let submitEnabled = true;
   if (experimentsStep && experimentData.some((d) => d.failedRequired)) {
     submitEnabled = false;
@@ -156,42 +173,6 @@ export default function RequestReviewModal({
       close();
     }
   };
-
-  const resultDiffs = useMemo(() => {
-    const diffs: { a: string; b: string; title: string }[] = [];
-
-    if (!mergeResult) return diffs;
-    if (!mergeResult.success) return diffs;
-
-    const result = mergeResult.result;
-
-    if (result.defaultValue !== undefined) {
-      diffs.push({
-        title: "Default Value",
-        a: feature.defaultValue,
-        b: result.defaultValue,
-      });
-    }
-    if (result.rules) {
-      environments.forEach((env) => {
-        const liveRules = feature.environmentSettings?.[env.id]?.rules || [];
-        if (result.rules && result.rules[env.id]) {
-          diffs.push({
-            title: `Rules - ${env.id}`,
-            a: JSON.stringify(liveRules, null, 2),
-            b: JSON.stringify(result.rules[env.id], null, 2),
-          });
-        }
-      });
-    }
-
-    return diffs;
-  }, [
-    environments,
-    feature.defaultValue,
-    feature.environmentSettings,
-    mergeResult,
-  ]);
 
   if (!revision || !mergeResult) return null;
 

--- a/packages/front-end/components/Features/RevertModal.tsx
+++ b/packages/front-end/components/Features/RevertModal.tsx
@@ -1,12 +1,15 @@
 import { FeatureInterface } from "back-end/types/feature";
-import { useState, useMemo } from "react";
+import { useState } from "react";
 import { FeatureRevisionInterface } from "back-end/types/feature-revision";
-import isEqual from "lodash/isEqual";
 import { filterEnvironmentsByFeature } from "shared/util";
 import { getAffectedRevisionEnvs, useEnvironments } from "@/services/features";
 import { useAuth } from "@/services/auth";
 import Modal from "@/components/Modal";
 import Field from "@/components/Forms/Field";
+import {
+  useFeatureRevisionDiff,
+  featureToFeatureRevisionDiffInput,
+} from "@/hooks/useFeatureRevisionDiff";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 import { ExpandableDiff } from "./DraftModal";
 
@@ -35,31 +38,10 @@ export default function RevertModal({
     revision.comment || `Revert from #${feature.version}`,
   );
 
-  const diffs = useMemo(() => {
-    const diffs: { a: string; b: string; title: string }[] = [];
-
-    if (revision.defaultValue !== feature.defaultValue) {
-      diffs.push({
-        title: "Default Value",
-        a: feature.defaultValue,
-        b: revision.defaultValue,
-      });
-    }
-    environments.forEach((env) => {
-      const liveRules = feature.environmentSettings?.[env.id]?.rules || [];
-      const draftRules = revision.rules?.[env.id] || [];
-
-      if (!isEqual(liveRules, draftRules)) {
-        diffs.push({
-          title: `Rules - ${env.id}`,
-          a: JSON.stringify(liveRules, null, 2),
-          b: JSON.stringify(draftRules, null, 2),
-        });
-      }
-    });
-
-    return diffs;
-  }, [feature, revision, environments]);
+  const diffs = useFeatureRevisionDiff({
+    current: featureToFeatureRevisionDiffInput(feature),
+    draft: revision,
+  });
 
   const hasPermission = permissionsUtil.canPublishFeature(
     feature,

--- a/packages/front-end/hooks/useFeatureRevisionDiff.ts
+++ b/packages/front-end/hooks/useFeatureRevisionDiff.ts
@@ -1,0 +1,145 @@
+import { useMemo } from "react";
+import isEqual from "lodash/isEqual";
+import { FeatureRule, FeatureInterface } from "back-end/types/feature";
+import { FeatureRevisionInterface } from "../../back-end/types/feature-revision";
+
+// Helper
+export const featureToFeatureRevisionDiffInput = (
+  feature: FeatureInterface,
+): FeatureRevisionDiffInput => {
+  return {
+    defaultValue: feature.defaultValue,
+    rules: Object.fromEntries(
+      Object.entries(feature.environmentSettings).map(([envId, env]) => [
+        envId,
+        env.rules,
+      ]),
+    ),
+  };
+};
+
+// Parse JSON strings that look like JSON objects or arrays
+const parseIfJson = (str: string | undefined): string => {
+  if (!str || typeof str !== "string") return str || "";
+  const trimmed = str.trim();
+  const isJsonObject = trimmed.startsWith("{") && trimmed.endsWith("}");
+  const isJsonArray = trimmed.startsWith("[") && trimmed.endsWith("]");
+  if (isJsonObject || isJsonArray) {
+    try {
+      return JSON.parse(str);
+    } catch (e) {
+      return str;
+    }
+  }
+
+  return str;
+};
+
+// Process rules for diff with special formatting for a few fields
+const processRulesForDiff = (rules: FeatureRule[]): FeatureRule[] => {
+  if (!Array.isArray(rules)) return rules;
+
+  return rules.map((rule) => {
+    const processedRule = { ...rule };
+
+    if (
+      "condition" in processedRule &&
+      typeof processedRule.condition === "string"
+    ) {
+      processedRule.condition = parseIfJson(processedRule.condition);
+    }
+
+    if ("value" in processedRule && typeof processedRule.value === "string") {
+      processedRule.value = parseIfJson(processedRule.value);
+    }
+
+    // Safe rollout
+    if (
+      "controlValue" in processedRule &&
+      typeof processedRule.controlValue === "string"
+    ) {
+      processedRule.controlValue = parseIfJson(processedRule.controlValue);
+    }
+    if (
+      "variationValue" in processedRule &&
+      typeof processedRule.variationValue === "string"
+    ) {
+      processedRule.variationValue = parseIfJson(processedRule.variationValue);
+    }
+
+    // Parse variations values (experiment rules, experiment-ref rules)
+    if (
+      "variations" in processedRule &&
+      Array.isArray(processedRule.variations)
+    ) {
+      processedRule.variations = processedRule.variations.map((variation) => {
+        if (typeof variation.value === "string") {
+          return { ...variation, value: parseIfJson(variation.value) };
+        }
+        return variation;
+      });
+    }
+
+    return processedRule;
+  });
+};
+
+type FeatureRevisionDiffInput = Pick<
+  FeatureRevisionInterface,
+  "defaultValue" | "rules"
+>;
+
+type FeatureRevisionDiff = {
+  title: string;
+  a: string;
+  b: string;
+};
+
+export function useFeatureRevisionDiff({
+  current,
+  draft,
+}: {
+  current: FeatureRevisionDiffInput;
+  draft: FeatureRevisionDiffInput;
+}): FeatureRevisionDiff[] {
+  return useMemo(() => {
+    const diffs: FeatureRevisionDiff[] = [];
+
+    // Compare default values
+    if (current.defaultValue !== draft.defaultValue) {
+      const aValue = parseIfJson(current.defaultValue);
+      const bValue = parseIfJson(draft.defaultValue);
+      diffs.push({
+        title: "Default Value",
+        a:
+          typeof aValue === "string" ? aValue : JSON.stringify(aValue, null, 2),
+        b:
+          typeof bValue === "string" ? bValue : JSON.stringify(bValue, null, 2),
+      });
+    }
+
+    // Get all unique environment IDs from both current and draft
+    const allEnvironments = new Set([
+      ...Object.keys(current.rules || {}),
+      ...Object.keys(draft.rules || {}),
+    ]);
+
+    // Compare rules per environment
+    allEnvironments.forEach((envId) => {
+      const currentRules = current.rules?.[envId] || [];
+      const draftRules = draft.rules?.[envId] || [];
+
+      if (!isEqual(currentRules, draftRules)) {
+        const processedCurrentRules = processRulesForDiff(currentRules);
+        const processedDraftRules = processRulesForDiff(draftRules);
+        diffs.push({
+          title: `Rules - ${envId}`,
+          a: JSON.stringify(processedCurrentRules, null, 2),
+          b: JSON.stringify(processedDraftRules, null, 2),
+        });
+      }
+    });
+
+    return diffs;
+  }, [current, draft]);
+}


### PR DESCRIPTION
### Features and Changes

- Consolidate all diff generation in a hook
  - Based from DraftModal which is the one with most fixes / most up to date
- Ensure we parse Condition as a JSON too, to improve readability of diff

| Before | After |
|--------|--------|
| <img width="826" height="863" alt="Screenshot 2025-12-03 at 4 35 32 PM" src="https://github.com/user-attachments/assets/9b274f98-f9ed-47f7-a2a0-93b007bd9ca9" /> | <img width="814" height="857" alt="Screenshot 2025-12-03 at 4 36 01 PM" src="https://github.com/user-attachments/assets/3fb9affb-97b2-4870-bd23-bf3bce03fd7a" /> |
| <img width="809" height="855" alt="Screenshot 2025-12-03 at 4 36 47 PM" src="https://github.com/user-attachments/assets/aee707f1-33a8-44cc-8771-3071c035753f" /> | <img width="811" height="854" alt="Screenshot 2025-12-03 at 4 36 23 PM" src="https://github.com/user-attachments/assets/1fadf76e-f605-4034-893c-e068d0f02e91" /> |
| <img width="1217" height="849" alt="Screenshot 2025-12-03 at 4 37 57 PM" src="https://github.com/user-attachments/assets/0f2f5907-9350-43f3-a082-90d551a89262" /> | <img width="1228" height="854" alt="Screenshot 2025-12-03 at 4 37 26 PM" src="https://github.com/user-attachments/assets/cbdc2834-a3d6-444b-93d4-3e32f3c29675" /> | 