### PR TITLE
fix(diff): Ensure we don't render diffs for unchanged envs

### DIFF
--- a/packages/front-end/hooks/useFeatureRevisionDiff.ts
+++ b/packages/front-end/hooks/useFeatureRevisionDiff.ts
@@ -84,7 +84,7 @@ const processRulesForDiff = (rules: FeatureRule[]): FeatureRule[] => {
   });
 };
 
-type FeatureRevisionDiffInput = Pick<
+export type FeatureRevisionDiffInput = Pick<
   FeatureRevisionInterface,
   "defaultValue" | "rules"
 >;
@@ -118,14 +118,12 @@ export function useFeatureRevisionDiff({
       });
     }
 
-    // Get all unique environment IDs from both current and draft
-    const allEnvironments = new Set([
-      ...Object.keys(current.rules || {}),
-      ...Object.keys(draft.rules || {}),
-    ]);
+    // Only iterate over environments present in draft
+    // (environments not in draft weren't modified and shouldn't show a diff)
+    const draftEnvironments = Object.keys(draft.rules || {});
 
     // Compare rules per environment
-    allEnvironments.forEach((envId) => {
+    draftEnvironments.forEach((envId) => {
       const currentRules = current.rules?.[envId] || [];
       const draftRules = draft.rules?.[envId] || [];
 

--- a/packages/front-end/test/hooks/useFeatureRevisionDiff.test.ts
+++ b/packages/front-end/test/hooks/useFeatureRevisionDiff.test.ts
@@ -1,0 +1,42 @@
+import { renderHook } from "@testing-library/react";
+import {
+  FeatureRevisionDiffInput,
+  useFeatureRevisionDiff,
+} from "@/hooks/useFeatureRevisionDiff";
+
+describe("useFeatureRevisionDiff", () => {
+  it("should not show diff for unmodified environments when only one environment is changed", () => {
+    const current: FeatureRevisionDiffInput = {
+      defaultValue: "false",
+      rules: {
+        production: [
+          { id: "rule1", description: "test", type: "force", value: "true" },
+        ],
+        staging: [
+          { id: "rule2", description: "test", type: "force", value: "false" },
+        ],
+      },
+    };
+
+    const draft: FeatureRevisionDiffInput = {
+      defaultValue: "false",
+      rules: {
+        production: [
+          { id: "rule1", description: "test", type: "force", value: "changed" },
+        ],
+      },
+    };
+
+    const { result } = renderHook(() =>
+      useFeatureRevisionDiff({ current, draft }),
+    );
+
+    // Should only show diff for production, not staging
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0].title).toBe("Rules - production");
+
+    // Verify staging is NOT in the diffs (the bug would have shown staging going from rules to [])
+    const stagingDiff = result.current.find((d) => d.title.includes("staging"));
+    expect(stagingDiff).toBeUndefined();
+  });
+});


### PR DESCRIPTION
### Features and Changes

With #4941 I introduced a new bug that rendered the diff for unchanged environment from the full rule to an empty array `[]`.

This fixes it.