### PR TITLE
Make sure that the back-end server file exists

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ RUN yarn postinstall
 COPY packages ./packages
 RUN \
   yarn build \
+  && test -f packages/back-end/dist/server.js || (echo "ERROR: packages/back-end/dist/server.js is missing after build!" && exit 1) \
   && rm -rf node_modules \
   && rm -rf packages/back-end/node_modules \
   && rm -rf packages/front-end/node_modules \


### PR DESCRIPTION
### Features and Changes
A misconfigured tsconfig might make our app not start if dist/server.js does not exist.  Now we exit the build in case it is missing.

### Testing
Add 
```
    "../shared/src/validators/**/*",
    "../shared/types/**/*.d.ts"
```
to the "include" in tsconfig.json

Run `docker build -t growthbook .`
See it fail.
Remove the changes in tsconfig.json.
Run `docker build -t growthbook .`
See it succeed.