### PR TITLE
Refator remaining outside references of types and validators

### DIFF
--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -123,7 +123,8 @@ import {
   upsertWatch,
 } from "back-end/src/models/WatchModel";
 import { getFactTableMap } from "back-end/src/models/FactTableModel";
-import { OrganizationSettings, ReqContext } from "back-end/types/organization";
+import { OrganizationSettings } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 import { CreateURLRedirectProps } from "back-end/types/url-redirect";
 import { logger } from "back-end/src/util/logger";
 import { getFeaturesByIds } from "back-end/src/models/FeatureModel";

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -88,7 +88,8 @@ import {
   updateRevision,
 } from "back-end/src/models/FeatureRevisionModel";
 import { getEnabledEnvironments } from "back-end/src/util/features";
-import { Environment, ReqContext } from "back-end/types/organization";
+import { Environment } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 import {
   findSDKConnectionByKey,
   markSDKConnectionUsed,

--- a/packages/back-end/src/enterprise/saferollouts/safeRolloutUtils.ts
+++ b/packages/back-end/src/enterprise/saferollouts/safeRolloutUtils.ts
@@ -9,7 +9,8 @@ import {
   SafeRolloutSnapshotInterface,
 } from "back-end/types/safe-rollout";
 import { SafeRolloutStatus } from "back-end/src/validators/safe-rollout";
-import { OrganizationInterface, ReqContext } from "back-end/types/organization";
+import { OrganizationInterface } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 import { ApiReqContext } from "back-end/types/api";
 import { orgHasPremiumFeature } from "back-end/src/enterprise/licenseUtil";
 import {

--- a/packages/back-end/src/enterprise/services/dashboards.ts
+++ b/packages/back-end/src/enterprise/services/dashboards.ts
@@ -17,7 +17,7 @@ import {
 import { findSnapshotsByIds } from "back-end/src/models/ExperimentSnapshotModel";
 
 import { ExperimentInterface } from "back-end/types/experiment";
-import { ReqContext } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 
 import { MetricSnapshotSettings } from "back-end/types/report";
 

--- a/packages/back-end/src/enterprise/services/openai.ts
+++ b/packages/back-end/src/enterprise/services/openai.ts
@@ -13,7 +13,8 @@ import { AIPromptType } from "shared/ai";
 import { z, ZodObject, ZodRawShape } from "zod";
 import { zodResponseFormat } from "openai/helpers/zod";
 import { logger } from "back-end/src/util/logger";
-import { OrganizationInterface, ReqContext } from "back-end/types/organization";
+import { OrganizationInterface } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 import {
   getTokensUsedByOrganization,
   updateTokenUsage,

--- a/packages/back-end/src/init/config.ts
+++ b/packages/back-end/src/init/config.ts
@@ -20,7 +20,8 @@ import {
 import { MetricInterface } from "back-end/types/metric";
 import { DimensionInterface } from "back-end/types/dimension";
 import { encryptParams } from "back-end/src/services/datasource";
-import { OrganizationSettings, ReqContext } from "back-end/types/organization";
+import { OrganizationSettings } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 import {
   upgradeMetricDoc,
   upgradeDatasourceObject,

--- a/packages/back-end/src/integrations/GoogleAnalytics.ts
+++ b/packages/back-end/src/integrations/GoogleAnalytics.ts
@@ -1,6 +1,6 @@
 import { analyticsreporting_v4, google } from "googleapis";
 import cloneDeep from "lodash/cloneDeep";
-import { ReqContext } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 import {
   SourceIntegrationInterface,
   MetricValueParams,

--- a/packages/back-end/src/integrations/Mixpanel.ts
+++ b/packages/back-end/src/integrations/Mixpanel.ts
@@ -3,7 +3,7 @@ import {
   getConversionWindowHours,
   getDelayWindowHours,
 } from "shared/experiments";
-import { ReqContext } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 import {
   DataSourceInterface,
   DataSourceProperties,

--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -45,7 +45,7 @@ import {
 import { SegmentInterface } from "shared/types/segment";
 import { MetricAnalysisSettings } from "back-end/types/metric-analysis";
 import { UNITS_TABLE_PREFIX } from "back-end/src/queryRunners/ExperimentResultsQueryRunner";
-import { ReqContext } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 import { MetricInterface, MetricType } from "back-end/types/metric";
 import {
   DataSourceSettings,
@@ -148,7 +148,7 @@ import {
 } from "back-end/types/fact-table";
 import { applyMetricOverrides } from "back-end/src/util/integration";
 import { ReqContextClass } from "back-end/src/services/context";
-import { PopulationDataQuerySettings } from "back-end/src/queryRunners/PopulationDataQueryRunner";
+import type { PopulationDataQuerySettings } from "back-end/types/query";
 import { INCREMENTAL_UNITS_TABLE_PREFIX } from "back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner";
 import { AdditionalQueryMetadata, QueryMetadata } from "back-end/types/query";
 

--- a/packages/back-end/src/jobs/proxyUpdate.ts
+++ b/packages/back-end/src/jobs/proxyUpdate.ts
@@ -15,7 +15,7 @@ import {
 import { cancellableFetch } from "back-end/src/util/http.util";
 import { logger } from "back-end/src/util/logger";
 import { ApiReqContext } from "back-end/types/api";
-import { ReqContext } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 import { getContextForAgendaJobByOrgId } from "back-end/src/services/organizations";
 
 const PROXY_UPDATE_JOB_NAME = "proxyUpdate";

--- a/packages/back-end/src/jobs/refreshFactTableColumns.ts
+++ b/packages/back-end/src/jobs/refreshFactTableColumns.ts
@@ -1,7 +1,7 @@
 import Agenda, { Job } from "agenda";
 import { canInlineFilterColumn } from "shared/experiments";
 import { DEFAULT_MAX_METRIC_SLICE_LEVELS } from "shared/constants";
-import { ReqContext } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 import {
   getFactTable,
   updateFactTableColumns,

--- a/packages/back-end/src/jobs/sdkWebhooks.ts
+++ b/packages/back-end/src/jobs/sdkWebhooks.ts
@@ -29,7 +29,7 @@ import {
   getContextForAgendaJobByOrgId,
   getContextForAgendaJobByOrgObject,
 } from "back-end/src/services/organizations";
-import { ReqContext } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 import { ApiReqContext } from "back-end/types/api";
 
 const SDK_WEBHOOKS_JOB_NAME = "fireWebhooks";

--- a/packages/back-end/src/jobs/updateAllJobs.ts
+++ b/packages/back-end/src/jobs/updateAllJobs.ts
@@ -3,7 +3,7 @@ import {
   SDKConnectionInterface,
 } from "shared/types/sdk-connection";
 import { ApiReqContext } from "back-end/types/api";
-import { ReqContext } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 import { SDKPayloadKey } from "back-end/types/sdk-payload";
 import {
   getSurrogateKeysFromEnvironments,

--- a/packages/back-end/src/jobs/webhooks.ts
+++ b/packages/back-end/src/jobs/webhooks.ts
@@ -1,6 +1,6 @@
 import { createHmac } from "crypto";
 import Agenda, { Job } from "agenda";
-import { ReqContext } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 import {
   getContextForAgendaJobByOrgId,
   getExperimentOverrides,

--- a/packages/back-end/src/models/ApiKeyModel.ts
+++ b/packages/back-end/src/models/ApiKeyModel.ts
@@ -9,7 +9,7 @@ import {
   SECRET_API_KEY_ROLE,
 } from "back-end/src/util/secrets";
 import { roleForApiKey } from "back-end/src/util/api-key.util";
-import { ReqContext } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 import { ApiReqContext } from "back-end/types/api";
 import {
   ToInterface,

--- a/packages/back-end/src/models/BaseModel.ts
+++ b/packages/back-end/src/models/BaseModel.ts
@@ -10,7 +10,7 @@ import { evalCondition } from "@growthbook/growthbook";
 import { baseSchema } from "shared/validators";
 import { CreateProps, UpdateProps } from "shared/types/base-model";
 import { ApiReqContext } from "back-end/types/api";
-import { ReqContext } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 import { logger } from "back-end/src/util/logger";
 import { EntityType, EventTypes, EventType } from "back-end/src/types/Audit";
 import { AuditInterfaceTemplate } from "back-end/types/audit";

--- a/packages/back-end/src/models/DataSourceModel.ts
+++ b/packages/back-end/src/models/DataSourceModel.ts
@@ -23,7 +23,7 @@ import { upgradeDatasourceObject } from "back-end/src/util/migrations";
 import { ApiDataSource } from "back-end/types/openapi";
 import { queueCreateInformationSchema } from "back-end/src/jobs/createInformationSchema";
 import { IS_CLOUD } from "back-end/src/util/secrets";
-import { ReqContext } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 import { ApiReqContext } from "back-end/types/api";
 import { logger } from "back-end/src/util/logger";
 import { deleteClickhouseUser } from "back-end/src/services/clickhouse";

--- a/packages/back-end/src/models/DimensionModel.ts
+++ b/packages/back-end/src/models/DimensionModel.ts
@@ -3,7 +3,7 @@ import { ApiDimension } from "back-end/types/openapi";
 import { DimensionInterface } from "back-end/types/dimension";
 import { getConfigDimensions, usingFileConfig } from "back-end/src/init/config";
 import { ApiReqContext } from "back-end/types/api";
-import { ReqContext } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 import { ALLOW_CREATE_DIMENSIONS } from "../util/secrets";
 
 const dimensionSchema = new mongoose.Schema({

--- a/packages/back-end/src/models/EventModel.ts
+++ b/packages/back-end/src/models/EventModel.ts
@@ -23,7 +23,7 @@ import {
 } from "back-end/types/events/event";
 import { errorStringFromZodResult } from "back-end/src/util/validation";
 import { logger } from "back-end/src/util/logger";
-import { ReqContext } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 import { EventNotifier } from "back-end/src/events/notifiers/EventNotifier";
 import { DiffResult } from "back-end/types/events/diff";
 

--- a/packages/back-end/src/models/EventWebhookModel.ts
+++ b/packages/back-end/src/models/EventWebhookModel.ts
@@ -15,7 +15,7 @@ import {
   eventWebHookMethods,
   EventWebHookMethod,
 } from "back-end/src/validators/event-webhook";
-import { ReqContext } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 import { createEvent } from "./EventModel";
 
 const eventWebHookSchema = new mongoose.Schema({

--- a/packages/back-end/src/models/ExperimentLaunchChecklistModel.ts
+++ b/packages/back-end/src/models/ExperimentLaunchChecklistModel.ts
@@ -5,7 +5,7 @@ import {
   ChecklistTask,
   ExperimentLaunchChecklistInterface,
 } from "back-end/types/experimentLaunchChecklist";
-import { ReqContext } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 import { ApiReqContext } from "back-end/types/api";
 
 const experimentLaunchChecklistSchema = new mongoose.Schema({

--- a/packages/back-end/src/models/ExperimentModel.ts
+++ b/packages/back-end/src/models/ExperimentModel.ts
@@ -14,7 +14,7 @@ import {
   LegacyExperimentInterface,
   Variation,
 } from "back-end/types/experiment";
-import { ReqContext } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 import {
   determineNextDate,
   toExperimentApiInterface,

--- a/packages/back-end/src/models/ExperimentSnapshotModel.ts
+++ b/packages/back-end/src/models/ExperimentSnapshotModel.ts
@@ -13,7 +13,7 @@ import { migrateSnapshot } from "back-end/src/util/migrations";
 import { notifyExperimentChange } from "back-end/src/services/experimentNotifications";
 import { updateExperimentAnalysisSummary } from "back-end/src/services/experiments";
 import { updateExperimentTimeSeries } from "back-end/src/services/experimentTimeSeries";
-import { ReqContext } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 import { ApiReqContext } from "back-end/types/api";
 import { DashboardInterface } from "../enterprise/validators/dashboard";
 import { queriesSchema } from "./QueryModel";

--- a/packages/back-end/src/models/FactTableModel.ts
+++ b/packages/back-end/src/models/FactTableModel.ts
@@ -12,7 +12,7 @@ import {
   ColumnInterface,
 } from "back-end/types/fact-table";
 import { ApiFactTable, ApiFactTableFilter } from "back-end/types/openapi";
-import { ReqContext } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 import { ApiReqContext } from "back-end/types/api";
 import { promiseAllChunks } from "../util/promise";
 

--- a/packages/back-end/src/models/FeatureCodeRefs.ts
+++ b/packages/back-end/src/models/FeatureCodeRefs.ts
@@ -6,7 +6,8 @@ import {
   removeMongooseFields,
 } from "back-end/src/util/mongo.util";
 import { ApiCodeRef } from "back-end/types/openapi";
-import { OrganizationInterface, ReqContext } from "back-end/types/organization";
+import { OrganizationInterface } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 import { ApiReqContext } from "back-end/types/api";
 
 const featureCodeRefsSchema = new mongoose.Schema({

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -19,7 +19,7 @@ import {
   refreshSDKPayloadCache,
 } from "back-end/src/services/features";
 import { upgradeFeatureInterface } from "back-end/src/util/migrations";
-import { ReqContext } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 import {
   applyEnvironmentInheritance,
   getAffectedSDKPayloadKeys,

--- a/packages/back-end/src/models/FeatureRevisionModel.ts
+++ b/packages/back-end/src/models/FeatureRevisionModel.ts
@@ -10,7 +10,8 @@ import {
   EventUser,
   EventUserLoggedIn,
 } from "back-end/types/events/event-types";
-import { OrganizationInterface, ReqContext } from "back-end/types/organization";
+import { OrganizationInterface } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 import { ApiReqContext } from "back-end/types/api";
 import { applyEnvironmentInheritance } from "back-end/src/util/features";
 import { MinimalFeatureRevisionInterface } from "back-end/src/validators/features";

--- a/packages/back-end/src/models/GeneratedHypothesis.ts
+++ b/packages/back-end/src/models/GeneratedHypothesis.ts
@@ -1,7 +1,7 @@
 import { omit } from "lodash";
 import mongoose from "mongoose";
 import uniqid from "uniqid";
-import { ReqContext } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 import { GeneratedHypothesisInterface } from "back-end/types/generated-hypothesis";
 import { ExperimentInterface } from "back-end/types/experiment";
 import { createExperiment } from "./ExperimentModel";

--- a/packages/back-end/src/models/ImpactEstimateModel.ts
+++ b/packages/back-end/src/models/ImpactEstimateModel.ts
@@ -7,7 +7,7 @@ import { getMetricById } from "back-end/src/models/MetricModel";
 import { getIntegrationFromDatasourceId } from "back-end/src/services/datasource";
 import { DEFAULT_CONVERSION_WINDOW_HOURS } from "back-end/src/util/secrets";
 import { processMetricValueQueryResponse } from "back-end/src/queryRunners/LegacyMetricAnalysisQueryRunner";
-import { ReqContext } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 import { ApiReqContext } from "back-end/types/api";
 import { getFactTableMap } from "./FactTableModel";
 

--- a/packages/back-end/src/models/MetricModel.ts
+++ b/packages/back-end/src/models/MetricModel.ts
@@ -8,7 +8,7 @@ import {
 import { getConfigMetrics, usingFileConfig } from "back-end/src/init/config";
 import { upgradeMetricDoc } from "back-end/src/util/migrations";
 import { ALLOW_CREATE_METRICS } from "back-end/src/util/secrets";
-import { ReqContext } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 import { ApiReqContext } from "back-end/types/api";
 import {
   ToInterface,

--- a/packages/back-end/src/models/ProjectModel.ts
+++ b/packages/back-end/src/models/ProjectModel.ts
@@ -1,26 +1,11 @@
-import { z } from "zod";
-import { statsEngines } from "shared/constants";
-import { managedByValidator, ManagedBy, baseSchema } from "shared/validators";
+import { ManagedBy } from "shared/validators";
 import { ApiProject } from "back-end/types/openapi";
+import {
+  ProjectInterface,
+  ProjectSettings,
+  projectValidator,
+} from "back-end/src/validators/projects";
 import { MakeModelClass } from "./BaseModel";
-export const statsEnginesValidator = z.enum(statsEngines);
-
-export const projectSettingsValidator = z.object({
-  statsEngine: statsEnginesValidator.optional(),
-});
-
-export const projectValidator = baseSchema
-  .extend({
-    name: z.string(),
-    description: z.string().default("").optional(),
-    settings: projectSettingsValidator.default({}).optional(),
-    managedBy: managedByValidator.optional(),
-  })
-  .strict();
-
-export type StatsEngine = z.infer<typeof statsEnginesValidator>;
-export type ProjectSettings = z.infer<typeof projectSettingsValidator>;
-export type ProjectInterface = z.infer<typeof projectValidator>;
 
 type MigratedProject = Omit<ProjectInterface, "settings"> & {
   settings: Partial<ProjectInterface["settings"]>;

--- a/packages/back-end/src/models/QueryModel.ts
+++ b/packages/back-end/src/models/QueryModel.ts
@@ -5,7 +5,7 @@ import { QueryInterface, QueryType } from "back-end/types/query";
 import { QUERY_CACHE_TTL_MINS } from "back-end/src/util/secrets";
 import { QueryLanguage } from "back-end/types/datasource";
 import { ApiQuery } from "back-end/types/openapi";
-import type { ReqContext } from "back-end/types/organization";
+import type { ReqContext } from "back-end/types/request";
 import type { ApiReqContext } from "back-end/types/api";
 
 export const queriesSchema = [

--- a/packages/back-end/src/models/ReportModel.ts
+++ b/packages/back-end/src/models/ReportModel.ts
@@ -8,7 +8,7 @@ import {
   ExperimentSnapshotReportInterface,
   ReportInterface,
 } from "back-end/types/report";
-import { ReqContext } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 import { ApiReqContext } from "back-end/types/api";
 import { logger } from "back-end/src/util/logger";
 import { getAllExperiments } from "./ExperimentModel";

--- a/packages/back-end/src/models/SdkConnectionModel.ts
+++ b/packages/back-end/src/models/SdkConnectionModel.ts
@@ -22,7 +22,7 @@ import {
 import { errorStringFromZodResult } from "back-end/src/util/validation";
 import { triggerSingleSDKWebhookJobs } from "back-end/src/jobs/updateAllJobs";
 import { ApiReqContext } from "back-end/types/api";
-import { ReqContext } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 import { addCloudSDKMapping } from "back-end/src/services/clickhouse";
 import { generateEncryptionKey, generateSigningKey } from "./ApiKeyModel";
 

--- a/packages/back-end/src/models/VisualChangesetModel.ts
+++ b/packages/back-end/src/models/VisualChangesetModel.ts
@@ -10,7 +10,7 @@ import {
 } from "shared/types/visual-changeset";
 import { ExperimentInterface, Variation } from "back-end/types/experiment";
 import { ApiVisualChangeset } from "back-end/types/openapi";
-import { ReqContext } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 import { refreshSDKPayloadCache } from "back-end/src/services/features";
 import { visualChangesetsHaveChanges } from "back-end/src/services/experiments";
 import { ApiReqContext } from "back-end/types/api";

--- a/packages/back-end/src/models/WebhookModel.ts
+++ b/packages/back-end/src/models/WebhookModel.ts
@@ -5,7 +5,7 @@ import md5 from "md5";
 import { z } from "zod";
 import { managedByValidator } from "shared/validators";
 import { WebhookInterface } from "shared/types/webhook";
-import { ReqContext } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 import { migrateWebhookModel } from "back-end/src/util/migrations";
 
 const payloadFormatValidator = z.enum([

--- a/packages/back-end/src/queryRunners/PopulationDataQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/PopulationDataQueryRunner.ts
@@ -8,7 +8,12 @@ import { lastMondayString } from "shared/dates";
 import { SegmentInterface } from "shared/types/segment";
 import { ApiReqContext } from "back-end/types/api";
 import { MetricInterface } from "back-end/types/metric";
-import { Queries, QueryPointer, QueryStatus } from "back-end/types/query";
+import {
+  Queries,
+  QueryPointer,
+  QueryStatus,
+  PopulationDataQuerySettings,
+} from "back-end/types/query";
 import {
   Dimension,
   ExperimentFactMetricsQueryResponseRows,
@@ -34,10 +39,6 @@ import {
   StartQueryParams,
 } from "./QueryRunner";
 
-export type PopulationDataQuerySettings = Pick<
-  PopulationDataInterface,
-  "startDate" | "endDate" | "sourceId" | "sourceType" | "userIdType"
->;
 export interface PopulationDataQueryParams {
   populationSettings: PopulationDataQuerySettings;
   snapshotSettings: ExperimentSnapshotSettings;

--- a/packages/back-end/src/queryRunners/QueryRunner.ts
+++ b/packages/back-end/src/queryRunners/QueryRunner.ts
@@ -21,7 +21,7 @@ import {
 } from "back-end/src/types/Integration";
 import { logger } from "back-end/src/util/logger";
 import { promiseAllChunks } from "back-end/src/util/promise";
-import { ReqContext } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 import { ApiReqContext } from "back-end/types/api";
 
 export type QueryMap = Map<string, QueryInterface>;

--- a/packages/back-end/src/routers/attributes/attributes.router.ts
+++ b/packages/back-end/src/routers/attributes/attributes.router.ts
@@ -1,8 +1,8 @@
 import express from "express";
 import { z } from "zod";
+import { attributeDataTypes } from "shared/constants";
 import { wrapController } from "back-end/src/routers/wrapController";
 import { validateRequestMiddleware } from "back-end/src/routers/utils/validateRequestMiddleware";
-import { attributeDataTypes } from "back-end/src/util/organization.util";
 import * as rawAttributesController from "./attributes.controller";
 
 const router = express.Router();

--- a/packages/back-end/src/routers/fact-table/fact-table.controller.ts
+++ b/packages/back-end/src/routers/fact-table/fact-table.controller.ts
@@ -2,7 +2,7 @@ import type { Response } from "express";
 import { canInlineFilterColumn } from "shared/experiments";
 import { DEFAULT_MAX_METRIC_SLICE_LEVELS } from "shared/settings";
 import { cloneDeep } from "lodash";
-import { ReqContext } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 import { AuthRequest } from "back-end/src/types/AuthRequest";
 import { getContextFromReq } from "back-end/src/services/organizations";
 import {

--- a/packages/back-end/src/routers/population-data/population-data.controller.ts
+++ b/packages/back-end/src/routers/population-data/population-data.controller.ts
@@ -8,10 +8,8 @@ import { getContextFromReq } from "back-end/src/services/organizations";
 import { AuthRequest } from "back-end/src/types/AuthRequest";
 import { ExperimentSnapshotSettings } from "back-end/types/experiment-snapshot";
 import { PopulationDataInterface } from "back-end/types/population-data";
-import {
-  PopulationDataQueryRunner,
-  PopulationDataQuerySettings,
-} from "back-end/src/queryRunners/PopulationDataQueryRunner";
+import { PopulationDataQueryRunner } from "back-end/src/queryRunners/PopulationDataQueryRunner";
+import type { PopulationDataQuerySettings } from "back-end/types/query";
 import { getDataSourceById } from "back-end/src/models/DataSourceModel";
 import { getMetricMap } from "back-end/src/models/MetricModel";
 import { getFactTableMap } from "back-end/src/models/FactTableModel";

--- a/packages/back-end/src/routers/saved-queries/saved-queries.controller.ts
+++ b/packages/back-end/src/routers/saved-queries/saved-queries.controller.ts
@@ -34,7 +34,7 @@ import {
   getInformationSchemaTableById,
 } from "back-end/src/models/InformationSchemaTablesModel";
 import { fetchTableData } from "back-end/src/services/informationSchema";
-import { ReqContext } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 import { DataSourceInterface } from "back-end/types/datasource";
 import { ApiReqContext } from "back-end/types/api";
 

--- a/packages/back-end/src/routers/vercel-native-integration/vercel-native-integration.controller.ts
+++ b/packages/back-end/src/routers/vercel-native-integration/vercel-native-integration.controller.ts
@@ -21,7 +21,8 @@ import {
 } from "back-end/src/models/OrganizationModel";
 import { createUser, getUserByEmail } from "back-end/src/models/UserModel";
 import { ReqContextClass } from "back-end/src/services/context";
-import { ReqContext, OrganizationInterface } from "back-end/types/organization";
+import { OrganizationInterface } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 import {
   getVercelSSOToken,
   syncVercelSdkConnection,

--- a/packages/back-end/src/services/clickhouse.ts
+++ b/packages/back-end/src/services/clickhouse.ts
@@ -18,7 +18,8 @@ import {
   DataSourceParams,
   MaterializedColumn,
 } from "back-end/types/datasource";
-import { DailyUsage, ReqContext } from "back-end/types/organization";
+import { DailyUsage } from "back-end/types/organization";
+import type { ReqContext } from "back-end/types/request";
 import { logger } from "back-end/src/util/logger";
 import { FactTableColumnType } from "back-end/types/fact-table";
 import {

--- a/packages/back-end/src/services/datasource.ts
+++ b/packages/back-end/src/services/datasource.ts
@@ -26,7 +26,7 @@ import {
 import Mysql from "back-end/src/integrations/Mysql";
 import Mssql from "back-end/src/integrations/Mssql";
 import { getDataSourceById } from "back-end/src/models/DataSourceModel";
-import { ReqContext } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 import { ApiReqContext } from "back-end/types/api";
 import { QueryStatistics } from "back-end/types/query";
 

--- a/packages/back-end/src/services/discussions.ts
+++ b/packages/back-end/src/services/discussions.ts
@@ -4,7 +4,7 @@ import { DiscussionModel } from "back-end/src/models/DiscussionModel";
 import { getExperimentById } from "back-end/src/models/ExperimentModel";
 import { getFeature } from "back-end/src/models/FeatureModel";
 import { getMetricById } from "back-end/src/models/MetricModel";
-import { ReqContext } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 import { getIdeaById } from "./ideas";
 
 export async function getDiscussionByParent(

--- a/packages/back-end/src/services/experimentTimeSeries.ts
+++ b/packages/back-end/src/services/experimentTimeSeries.ts
@@ -15,7 +15,7 @@ import {
   GoalMetricStatus,
   GuardrailMetricStatus,
 } from "shared/validators";
-import { ReqContext } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 import {
   ExperimentSnapshotAnalysisSettings,
   ExperimentSnapshotInterface,

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -112,8 +112,8 @@ import {
 import {
   ExperimentUpdateSchedule,
   OrganizationInterface,
-  ReqContext,
 } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 import { logger } from "back-end/src/util/logger";
 import { DataSourceInterface, ExposureQuery } from "back-end/types/datasource";
 import {
@@ -139,7 +139,11 @@ import {
   FactTableMap,
   getFactTableMap,
 } from "back-end/src/models/FactTableModel";
-import { StatsEngine } from "back-end/types/stats";
+import {
+  StatsEngine,
+  MetricSettingsForStatsEngine,
+  QueryResultsForStatsEngine,
+} from "back-end/types/stats";
 import { getFeaturesByIds } from "back-end/src/models/FeatureModel";
 import { getFeatureRevisionsByFeatureIds } from "back-end/src/models/FeatureRevisionModel";
 import { ExperimentRefRule, FeatureRule } from "back-end/types/feature";
@@ -164,8 +168,6 @@ import {
   analyzeExperimentResults,
   getMetricsAndQueryDataForStatsEngine,
   getMetricSettingsForStatsEngine,
-  MetricSettingsForStatsEngine,
-  QueryResultsForStatsEngine,
   runSnapshotAnalyses,
   runSnapshotAnalysis,
   writeSnapshotAnalyses,

--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -76,10 +76,10 @@ import {
 import {
   Environment,
   OrganizationInterface,
-  ReqContext,
   SDKAttribute,
   SDKAttributeSchema,
 } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 import {
   getSDKPayload,
   getSDKPayloadCacheLocation,

--- a/packages/back-end/src/services/informationSchema.ts
+++ b/packages/back-end/src/services/informationSchema.ts
@@ -13,7 +13,7 @@ import { removeDeletedInformationSchemaTables } from "back-end/src/models/Inform
 import { queueUpdateStaleInformationSchemaTable } from "back-end/src/jobs/updateStaleInformationSchemaTable";
 import { promiseAllChunks } from "back-end/src/util/promise";
 import { ApiReqContext } from "back-end/types/api";
-import { ReqContext } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 import { usingFileConfig } from "../init/config";
 import { getSourceIntegrationObject } from "./datasource";
 

--- a/packages/back-end/src/services/notebook.ts
+++ b/packages/back-end/src/services/notebook.ts
@@ -13,16 +13,16 @@ import { getReportById } from "back-end/src/models/ReportModel";
 import { Queries } from "back-end/types/query";
 import { QueryMap } from "back-end/src/queryRunners/QueryRunner";
 import { getQueriesByIds } from "back-end/src/models/QueryModel";
-import { ReqContext } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 import { ApiReqContext } from "back-end/types/api";
 import {
   ExperimentSnapshotAnalysisSettings,
   ExperimentSnapshotSettings,
 } from "back-end/types/experiment-snapshot";
 import { ExperimentInterface } from "back-end/types/experiment";
+import type { DataForStatsEngine } from "back-end/types/stats";
 import { getSnapshotSettingsFromReportArgs } from "./reports";
 import {
-  DataForStatsEngine,
   getAnalysisSettingsForStatsEngine,
   getMetricsAndQueryDataForStatsEngine,
 } from "./stats";

--- a/packages/back-end/src/services/organizations.ts
+++ b/packages/back-end/src/services/organizations.ts
@@ -49,8 +49,8 @@ import {
   OrganizationInterface,
   PendingMember,
   ProjectMemberRole,
-  ReqContext,
 } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 import { ApiReqContext, ExperimentOverride } from "back-end/types/api";
 import { ConfigFile } from "back-end/src/init/config";
 import {

--- a/packages/back-end/src/services/presentations.ts
+++ b/packages/back-end/src/services/presentations.ts
@@ -8,7 +8,7 @@ import { getExperimentsByIds } from "back-end/src/models/ExperimentModel";
 import { ExperimentInterface } from "back-end/types/experiment";
 import { ExperimentSnapshotInterface } from "back-end/types/experiment-snapshot";
 import { getLatestSnapshot } from "back-end/src/models/ExperimentSnapshotModel";
-import { ReqContext } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 import { ApiReqContext } from "back-end/types/api";
 
 //import {query} from "back-end/src/config/postgres";

--- a/packages/back-end/src/services/python.ts
+++ b/packages/back-end/src/services/python.ts
@@ -8,7 +8,7 @@ import { stringToBoolean } from "shared/util";
 import JSON5 from "json5";
 import { MultipleExperimentMetricAnalysis } from "back-end/types/stats";
 import { logger } from "back-end/src/util/logger";
-import { ExperimentDataForStatsEngine } from "back-end/src/services/stats";
+import type { ExperimentDataForStatsEngine } from "back-end/types/stats";
 import { ENVIRONMENT, IS_CLOUD } from "back-end/src/util/secrets";
 import { metrics } from "back-end/src/util/metrics";
 

--- a/packages/back-end/src/services/reports.ts
+++ b/packages/back-end/src/services/reports.ts
@@ -44,7 +44,8 @@ import {
   ExperimentSnapshotSettings,
   MetricForSnapshot,
 } from "back-end/types/experiment-snapshot";
-import { OrganizationSettings, ReqContext } from "back-end/types/organization";
+import { OrganizationSettings } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 import { ApiReqContext } from "back-end/types/api";
 import {
   FactTableMap,

--- a/packages/back-end/src/services/safeRolloutSnapshots.ts
+++ b/packages/back-end/src/services/safeRolloutSnapshots.ts
@@ -37,7 +37,8 @@ import {
   ExperimentSnapshotSettings,
 } from "back-end/types/experiment-snapshot";
 import { ApiReqContext } from "back-end/types/api";
-import { OrganizationInterface, ReqContext } from "back-end/types/organization";
+import { OrganizationInterface } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 import { MetricSnapshotSettings } from "back-end/types/report";
 import { MetricInterface } from "back-end/types/metric";
 import { getMetricMap } from "back-end/src/models/MetricModel";

--- a/packages/back-end/src/services/safeRolloutTimeSeries.ts
+++ b/packages/back-end/src/services/safeRolloutTimeSeries.ts
@@ -6,7 +6,7 @@ import {
   MetricTimeSeriesValue,
   MetricTimeSeriesVariation,
 } from "shared/validators";
-import { ReqContext } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 import {
   FactMetricInterface,
   FactTableInterface,

--- a/packages/back-end/src/services/savedGroups.ts
+++ b/packages/back-end/src/services/savedGroups.ts
@@ -1,5 +1,5 @@
 import { includeExperimentInPayload } from "shared/util";
-import { ReqContext } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 import {
   getAllPayloadExperiments,
   getPayloadKeysForAllEnvs,

--- a/packages/back-end/src/services/stats.ts
+++ b/packages/back-end/src/services/stats.ts
@@ -19,8 +19,15 @@ import {
 import { hoursBetween } from "shared/dates";
 import chunk from "lodash/chunk";
 import {
+  AnalysisSettingsForStatsEngine,
+  BanditSettingsForStatsEngine,
+  BusinessMetricTypeForStatsEngine,
+  DataForStatsEngine,
+  ExperimentDataForStatsEngine,
   ExperimentMetricAnalysis,
+  MetricSettingsForStatsEngine,
   MultipleExperimentMetricAnalysis,
+  QueryResultsForStatsEngine,
 } from "back-end/types/stats";
 import {
   ExperimentAggregateUnitsQueryResponseRows,
@@ -53,89 +60,6 @@ import { applyMetricOverrides } from "back-end/src/util/integration";
 import { BanditResult } from "back-end/types/experiment";
 import { statsServerPool } from "back-end/src/services/python";
 import { metrics } from "back-end/src/util/metrics";
-
-// Keep these interfaces in sync with gbstats
-export interface AnalysisSettingsForStatsEngine {
-  var_names: string[];
-  var_ids: string[];
-  weights: number[];
-  baseline_index: number;
-  dimension: string;
-  stats_engine: string;
-  p_value_corrected: boolean;
-  sequential_testing_enabled: boolean;
-  sequential_tuning_parameter: number;
-  difference_type: string;
-  phase_length_days: number;
-  alpha: number;
-  max_dimensions: number;
-  traffic_percentage: number;
-  num_goal_metrics: number;
-  one_sided_intervals?: boolean;
-  post_stratification_enabled?: boolean;
-}
-
-export interface BanditSettingsForStatsEngine {
-  var_names: string[];
-  var_ids: string[];
-  historical_weights?: {
-    date: Date;
-    weights: number[];
-    total_users: number;
-  }[];
-  current_weights: number[];
-  reweight: boolean;
-  decision_metric: string;
-  bandit_weights_seed: number;
-}
-
-export type BusinessMetricTypeForStatsEngine =
-  | "goal"
-  | "secondary"
-  | "guardrail";
-
-export interface MetricSettingsForStatsEngine {
-  id: string;
-  name: string;
-  inverse: boolean;
-  statistic_type:
-    | "mean"
-    | "ratio"
-    | "ratio_ra"
-    | "mean_ra"
-    | "quantile_event"
-    | "quantile_unit";
-  main_metric_type: "count" | "binomial" | "quantile";
-  denominator_metric_type?: "count" | "binomial" | "quantile";
-  covariate_metric_type?: "count" | "binomial" | "quantile";
-  keep_theta?: boolean;
-  quantile_value?: number;
-  prior_proper?: boolean;
-  prior_mean?: number;
-  prior_stddev?: number;
-  target_mde: number;
-  business_metric_type: BusinessMetricTypeForStatsEngine[];
-}
-
-export interface QueryResultsForStatsEngine {
-  rows:
-    | ExperimentMetricQueryResponseRows
-    | ExperimentFactMetricsQueryResponseRows;
-  metrics: (string | null)[];
-  sql?: string;
-}
-
-export interface DataForStatsEngine {
-  analyses: AnalysisSettingsForStatsEngine[];
-  metrics: Record<string, MetricSettingsForStatsEngine>;
-  query_results: QueryResultsForStatsEngine[];
-  bandit_settings?: BanditSettingsForStatsEngine;
-}
-
-export interface ExperimentDataForStatsEngine {
-  id: string;
-  data: DataForStatsEngine;
-}
 
 export const MAX_DIMENSIONS = 20;
 

--- a/packages/back-end/src/types/Integration.ts
+++ b/packages/back-end/src/types/Integration.ts
@@ -3,7 +3,7 @@ import { ExperimentMetricInterface } from "shared/experiments";
 import { TemplateVariables, FormatDialect } from "shared/types/sql";
 import { SegmentInterface } from "shared/types/segment";
 import { MetricAnalysisSettings } from "back-end/types/metric-analysis";
-import { ReqContext } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 import {
   AutoFactTableSchemas,
   DataSourceInterface,
@@ -14,15 +14,15 @@ import { DimensionInterface } from "back-end/types/dimension";
 import { ExperimentSnapshotSettings } from "back-end/types/experiment-snapshot";
 import { MetricInterface, MetricType } from "back-end/types/metric";
 import { AdditionalQueryMetadata, QueryStatistics } from "back-end/types/query";
-import { FactTableMap } from "back-end/src/models/FactTableModel";
 import {
+  FactTableMap,
   ColumnInterface,
   FactMetricInterface,
   FactTableColumnType,
   FactTableInterface,
   MetricQuantileSettings,
 } from "back-end/types/fact-table";
-import { PopulationDataQuerySettings } from "back-end/src/queryRunners/PopulationDataQueryRunner";
+import type { PopulationDataQuerySettings } from "back-end/types/query";
 
 export type ExternalIdCallback = (id: string) => Promise<void>;
 

--- a/packages/back-end/src/util/environments.ts
+++ b/packages/back-end/src/util/environments.ts
@@ -1,5 +1,6 @@
 import cloneDeep from "lodash/cloneDeep";
-import { Environment, ReqContext } from "back-end/types/organization";
+import { Environment } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 
 /**
  * util for adding an environment to the existing organization environments.

--- a/packages/back-end/src/util/organization.util.ts
+++ b/packages/back-end/src/util/organization.util.ts
@@ -297,14 +297,3 @@ export function getUserPermissions(
 
   return userPermissions;
 }
-
-export const attributeDataTypes = [
-  "boolean",
-  "string",
-  "number",
-  "secureString",
-  "enum",
-  "string[]",
-  "number[]",
-  "secureString[]",
-] as const;

--- a/packages/back-end/src/validators/projects.ts
+++ b/packages/back-end/src/validators/projects.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+import { statsEngines } from "shared/constants";
+import { managedByValidator, baseSchema } from "shared/validators";
+
+export const statsEnginesValidator = z.enum(statsEngines);
+
+export const projectSettingsValidator = z.object({
+  statsEngine: statsEnginesValidator.optional(),
+});
+
+export const projectValidator = baseSchema
+  .extend({
+    name: z.string(),
+    description: z.string().default("").optional(),
+    settings: projectSettingsValidator.default({}).optional(),
+    managedBy: managedByValidator.optional(),
+  })
+  .strict();
+
+export type StatsEngine = z.infer<typeof statsEnginesValidator>;
+export type ProjectSettings = z.infer<typeof projectSettingsValidator>;
+export type ProjectInterface = z.infer<typeof projectValidator>;

--- a/packages/back-end/src/validators/safe-rollout-snapshot.ts
+++ b/packages/back-end/src/validators/safe-rollout-snapshot.ts
@@ -6,7 +6,7 @@ import {
   priorSettingsValidator,
   windowSettingsValidator,
 } from "shared/validators";
-import { statsEnginesValidator } from "back-end/src/models/ProjectModel";
+import { statsEnginesValidator } from "back-end/src/validators/projects";
 
 const metricStatsObject = z.object({
   users: z.number(),

--- a/packages/back-end/src/validators/safe-rollout.ts
+++ b/packages/back-end/src/validators/safe-rollout.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { experimentAnalysisSummary, baseSchema } from "shared/validators";
 import { getMetricMap } from "back-end/src/models/MetricModel";
 import { ApiReqContext } from "back-end/types/api";
-import { ReqContext } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 
 export const safeRolloutStatusArray = [
   "running",

--- a/packages/back-end/types/api.d.ts
+++ b/packages/back-end/types/api.d.ts
@@ -6,7 +6,8 @@ import { EventUser } from "back-end/types/events/event-types";
 import { PermissionFunctions } from "back-end/src/types/AuthRequest";
 import { AuditInterfaceInput } from "./audit";
 import { ExperimentStatus } from "./experiment";
-import { OrganizationInterface, ReqContext } from "./organization";
+import { OrganizationInterface } from "./organization";
+import { ReqContext } from "./request";
 import { UserInterface } from "./user";
 
 export interface ExperimentOverride {

--- a/packages/back-end/types/experiment-snapshot.d.ts
+++ b/packages/back-end/types/experiment-snapshot.d.ts
@@ -4,15 +4,13 @@ import { BanditResult } from "shared/validators";
 import {
   MetricSettingsForStatsEngine,
   QueryResultsForStatsEngine,
-} from "back-end/src/services/stats";
-import { QueryLanguage } from "./datasource";
-import { MetricInterface, MetricStats } from "./metric";
-import {
   DifferenceType,
   RiskType,
   StatsEngine,
   MetricPowerResponseFromStatsEngine,
-} from "./stats";
+} from "back-end/types/stats";
+import { QueryLanguage } from "./datasource";
+import { MetricInterface, MetricStats } from "./metric";
 import { Queries } from "./query";
 import {
   ExperimentReportResultDimension,

--- a/packages/back-end/types/organization.d.ts
+++ b/packages/back-end/types/organization.d.ts
@@ -1,5 +1,9 @@
 import Stripe from "stripe";
-import { OWNER_JOB_TITLES, USAGE_INTENTS } from "shared/constants";
+import {
+  OWNER_JOB_TITLES,
+  USAGE_INTENTS,
+  attributeDataTypes,
+} from "shared/constants";
 import {
   ENV_SCOPED_PERMISSIONS,
   GLOBAL_PERMISSIONS,
@@ -17,8 +21,6 @@ import { TiktokenModel } from "@dqbd/tiktoken";
 import { SSOConnectionInterface } from "shared/types/sso-connection";
 import { AgreementType } from "shared/validators";
 import { environment } from "back-end/src/routers/environment/environment.validators";
-import type { ReqContextClass } from "back-end/src/services/context";
-import { attributeDataTypes } from "back-end/src/util/organization.util";
 import { ApiKeyInterface } from "back-end/types/apikey";
 import { TeamInterface } from "back-end/types/team";
 import { AttributionModel, ImplementationType } from "./experiment";
@@ -359,8 +361,6 @@ export type NamespaceUsage = Record<
     end: number;
   }[]
 >;
-
-export type ReqContext = ReqContextClass;
 
 export type GetOrganizationResponse = {
   status: 200;

--- a/packages/back-end/types/project.d.ts
+++ b/packages/back-end/types/project.d.ts
@@ -1,4 +1,4 @@
 export {
   ProjectInterface,
   ProjectSettings,
-} from "back-end/src/models/ProjectModel";
+} from "back-end/src/validators/projects";

--- a/packages/back-end/types/query.d.ts
+++ b/packages/back-end/types/query.d.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { queryPointerValidator, queryStatusValidator } from "shared/validators";
+import type { PopulationDataInterface } from "back-end/types/population-data";
 import { QueryLanguage } from "./datasource";
 
 export type QueryStatus = z.infer<typeof queryStatusValidator>;
@@ -84,3 +85,7 @@ export interface QueryInterface {
   statistics?: QueryStatistics;
   externalId?: string;
 }
+export type PopulationDataQuerySettings = Pick<
+  PopulationDataInterface,
+  "startDate" | "endDate" | "sourceId" | "sourceType" | "userIdType"
+>;

--- a/packages/back-end/types/report.d.ts
+++ b/packages/back-end/types/report.d.ts
@@ -3,7 +3,7 @@ import { ExperimentDecisionFrameworkSettings } from "shared/validators";
 import { OrganizationSettings } from "back-end/types/organization";
 import { MetricGroupInterface } from "back-end/types/metric-groups";
 import { DimensionInterface } from "back-end/types/dimension";
-import { ProjectInterface } from "back-end/src/models/ProjectModel";
+import { ProjectInterface } from "back-end/src/validators/projects";
 import { FactTableInterface, MetricPriorSettings } from "./fact-table";
 import {
   AttributionModel,

--- a/packages/back-end/types/request.d.ts
+++ b/packages/back-end/types/request.d.ts
@@ -1,0 +1,3 @@
+import type { ReqContextClass } from "back-end/src/services/context";
+
+export type ReqContext = ReqContextClass;

--- a/packages/back-end/types/stats.d.ts
+++ b/packages/back-end/types/stats.d.ts
@@ -1,6 +1,10 @@
-export { StatsEngine } from "back-end/src/models/ProjectModel";
+export { StatsEngine } from "back-end/src/validators/projects";
 
 import { BanditResult } from "shared/validators";
+import {
+  ExperimentFactMetricsQueryResponseRows,
+  ExperimentMetricQueryResponseRows,
+} from "back-end/src/types/Integration";
 import type { MetricStats } from "./metric";
 
 export type PValueCorrection = null | "benjamini-hochberg" | "holm-bonferroni";
@@ -100,3 +104,86 @@ export type MultipleExperimentMetricAnalysis = {
   error?: string;
   traceback?: string;
 };
+
+// Keep these interfaces in sync with gbstats
+export interface AnalysisSettingsForStatsEngine {
+  var_names: string[];
+  var_ids: string[];
+  weights: number[];
+  baseline_index: number;
+  dimension: string;
+  stats_engine: string;
+  p_value_corrected: boolean;
+  sequential_testing_enabled: boolean;
+  sequential_tuning_parameter: number;
+  difference_type: string;
+  phase_length_days: number;
+  alpha: number;
+  max_dimensions: number;
+  traffic_percentage: number;
+  num_goal_metrics: number;
+  one_sided_intervals?: boolean;
+  post_stratification_enabled?: boolean;
+}
+
+export interface BanditSettingsForStatsEngine {
+  var_names: string[];
+  var_ids: string[];
+  historical_weights?: {
+    date: Date;
+    weights: number[];
+    total_users: number;
+  }[];
+  current_weights: number[];
+  reweight: boolean;
+  decision_metric: string;
+  bandit_weights_seed: number;
+}
+
+export type BusinessMetricTypeForStatsEngine =
+  | "goal"
+  | "secondary"
+  | "guardrail";
+
+export interface MetricSettingsForStatsEngine {
+  id: string;
+  name: string;
+  inverse: boolean;
+  statistic_type:
+    | "mean"
+    | "ratio"
+    | "ratio_ra"
+    | "mean_ra"
+    | "quantile_event"
+    | "quantile_unit";
+  main_metric_type: "count" | "binomial" | "quantile";
+  denominator_metric_type?: "count" | "binomial" | "quantile";
+  covariate_metric_type?: "count" | "binomial" | "quantile";
+  keep_theta?: boolean;
+  quantile_value?: number;
+  prior_proper?: boolean;
+  prior_mean?: number;
+  prior_stddev?: number;
+  target_mde: number;
+  business_metric_type: BusinessMetricTypeForStatsEngine[];
+}
+
+export interface QueryResultsForStatsEngine {
+  rows:
+    | ExperimentMetricQueryResponseRows
+    | ExperimentFactMetricsQueryResponseRows;
+  metrics: (string | null)[];
+  sql?: string;
+}
+
+export interface DataForStatsEngine {
+  analyses: AnalysisSettingsForStatsEngine[];
+  metrics: Record<string, MetricSettingsForStatsEngine>;
+  query_results: QueryResultsForStatsEngine[];
+  bandit_settings?: BanditSettingsForStatsEngine;
+}
+
+export interface ExperimentDataForStatsEngine {
+  id: string;
+  data: DataForStatsEngine;
+}

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -122,3 +122,14 @@ export const sdkLanguages = [
 ] as const;
 
 export const statsEngines = ["bayesian", "frequentist"] as const;
+
+export const attributeDataTypes = [
+  "boolean",
+  "string",
+  "number",
+  "secureString",
+  "enum",
+  "string[]",
+  "number[]",
+  "secureString[]",
+] as const;


### PR DESCRIPTION
### Features and Changes

This is another refactor aimed at making it easier to move types and validators to shared en-mass. It takes care of moving the remaining types/validations/and constatns out of other back-end/src files and move them into types/validators/shared. Here is a list of the external references, what was referenced, where it was imported from, and -> what I did/plan to do with them.

 packages/back-end/src/models/FactTableModel
    Imports: FactTableMap
    Imported by (1 files):
      - packages/back-end/src/types/Integration
->FactTableMap was imported from FatcTableModel when a copy of it seems to be in back-end/types/fact-table.d.ts so I switched the import to there.

  packages/back-end/src/models/MetricModel
    Imports: getMetricMap
    Imported by (1 files):
      - packages/back-end/src/validators/safe-rollout
-> The function validateCreateSafeRolloutFields that uses getMetricMap is only used on the back-end.  It obviously has to be.  So one safe-rollout validator will be in shared and the other will remain in back-end with that function.  Will do that when moving all the other files.  Nothing is done to it in this PR.

 packages/back-end/src/models/ProjectModel
    Imports: ProjectInterface, statsEnginesValidator
    Imported by (2 files):
      - packages/back-end/src/validators/safe-rollout-snapshot
      - packages/back-end/types/report
-> Moved those imports to a new back-end/src/validators/project.ts (will then move it to shared with the others)

 packages/back-end/src/queryRunners/PopulationDataQueryRunner
    Imports: PopulationDataQuerySettings
    Imported by (1 files):
      - packages/back-end/src/types/Integration
-> Moved the type to existing back-end/types/query.d.ts

 packages/back-end/src/services/context
    Imports: ReqContextClass
    Imported by (1 files):
      - packages/back-end/types/organization
-> it uses this to make ReqContext type.  That type is only used on the back-end.  I have made a new back-end/types/request.d.ts file as organization.d.ts doesn't really have anything to do with requests.  It will stay on the back-end.

 packages/back-end/src/services/stats
    Imports: MetricSettingsForStatsEngine, QueryResultsForStatsEngine
    Imported by (1 files):
      - packages/back-end/types/experiment-snapshot
-> moved these (and others to keep them together to back-end/types/stats.d.ts). This will move in the grand migration to shared.

packages/back-end/src/util/organization.util
    Imports: attributeDataTypes
    Imported by (1 files):
      - packages/back-end/types/organization
-> move this to /shared/src/constants.ts
 
### Testing

`yarn build`
click around the preview environment.

