### PR TITLE
Move roleToPermissionMap to shared

### DIFF
--- a/packages/back-end/src/middleware/authenticateApiRequestMiddleware.ts
+++ b/packages/back-end/src/middleware/authenticateApiRequestMiddleware.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from "express";
-import { hasPermission } from "shared/permissions";
+import { hasPermission, roleToPermissionMap } from "shared/permissions";
 import { licenseInit } from "back-end/src/enterprise";
 import { ApiRequestLocals } from "back-end/types/api";
 import { lookupOrganizationByApiKey } from "back-end/src/models/ApiKeyModel";
@@ -8,10 +8,7 @@ import { getCustomLogProps } from "back-end/src/util/logger";
 import { EventUserApiKey } from "back-end/types/events/event-types";
 import { isApiKeyForUserInOrganization } from "back-end/src/util/api-key.util";
 import { OrganizationInterface, Permission } from "back-end/types/organization";
-import {
-  getUserPermissions,
-  roleToPermissionMap,
-} from "back-end/src/util/organization.util";
+import { getUserPermissions } from "back-end/src/util/organization.util";
 import { ApiKeyInterface } from "back-end/types/apikey";
 import { getTeamsForOrganization } from "back-end/src/models/TeamModel";
 import { TeamInterface } from "back-end/types/team";

--- a/packages/back-end/src/services/context.ts
+++ b/packages/back-end/src/services/context.ts
@@ -1,4 +1,8 @@
-import { Permissions, userHasPermission } from "shared/permissions";
+import {
+  Permissions,
+  userHasPermission,
+  roleToPermissionMap,
+} from "shared/permissions";
 import { uniq } from "lodash";
 import type pino from "pino";
 import type { Request } from "express";
@@ -16,7 +20,6 @@ import {
 import { EventUser } from "back-end/types/events/event-types";
 import {
   getUserPermissions,
-  roleToPermissionMap,
   getEnvironmentIdsFromOrg,
 } from "back-end/src/util/organization.util";
 import { TeamInterface } from "back-end/types/team";

--- a/packages/back-end/src/util/organization.util.ts
+++ b/packages/back-end/src/util/organization.util.ts
@@ -2,9 +2,8 @@ import { cloneDeep } from "lodash";
 import {
   ALL_PERMISSIONS,
   ENV_SCOPED_PERMISSIONS,
-  getPermissionsObjectByPolicies,
-  getRoleById,
   roleSupportsEnvLimit,
+  roleToPermissionMap,
 } from "shared/permissions";
 import {
   OrganizationInterface,
@@ -50,15 +49,6 @@ export function getEnvironments(org: OrganizationInterface) {
     ];
   }
   return org.settings.environments;
-}
-
-export function roleToPermissionMap(
-  roleId: string,
-  org: OrganizationInterface,
-): PermissionsObject {
-  const role = getRoleById(roleId || "readonly", org);
-  const policies = role?.policies || [];
-  return getPermissionsObjectByPolicies(policies);
 }
 
 function isValidPermission(permission: string): permission is Permission {

--- a/packages/back-end/test/models/dataSourceModel.test.ts
+++ b/packages/back-end/test/models/dataSourceModel.test.ts
@@ -1,4 +1,4 @@
-import { Permissions } from "shared/permissions";
+import { Permissions, roleToPermissionMap } from "shared/permissions";
 import {
   updateDataSource,
   validateExposureQueriesAndAddMissingIds,
@@ -10,8 +10,8 @@ import {
 } from "back-end/types/datasource";
 import { testQueryValidity } from "back-end/src/services/datasource";
 import { usingFileConfig } from "back-end/src/init/config";
-import { OrganizationInterface, ReqContext } from "back-end/types/organization";
-import { roleToPermissionMap } from "back-end/src/util/organization.util";
+import { OrganizationInterface } from "back-end/types/organization";
+import { ReqContext } from "back-end/types/request";
 
 jest.mock("back-end/src/services/datasource");
 jest.mock("back-end/src/init/config");

--- a/packages/back-end/test/permissions.test.ts
+++ b/packages/back-end/test/permissions.test.ts
@@ -1,8 +1,5 @@
-import { Permissions } from "shared/permissions";
-import {
-  getUserPermissions,
-  roleToPermissionMap,
-} from "back-end/src/util/organization.util";
+import { Permissions, roleToPermissionMap } from "shared/permissions";
+import { getUserPermissions } from "back-end/src/util/organization.util";
 import { OrganizationInterface } from "back-end/types/organization";
 import { TeamInterface } from "back-end/types/team";
 import { FeatureInterface } from "back-end/types/feature";

--- a/packages/shared/src/permissions/permissions.utils.ts
+++ b/packages/shared/src/permissions/permissions.utils.ts
@@ -173,3 +173,12 @@ export function roleSupportsEnvLimit(
 
   return policiesSupportEnvLimit(role?.policies || []);
 }
+
+export function roleToPermissionMap(
+  roleId: string,
+  org: OrganizationInterface,
+): PermissionsObject {
+  const role = getRoleById(roleId || "readonly", org);
+  const policies = role?.policies || [];
+  return getPermissionsObjectByPolicies(policies);
+}

--- a/packages/shared/test/permissions.test.ts
+++ b/packages/shared/test/permissions.test.ts
@@ -1,6 +1,5 @@
-import { roleToPermissionMap } from "back-end/src/util/organization.util";
 import { OrganizationInterface } from "back-end/types/organization";
-import { Permissions } from "../permissions";
+import { roleToPermissionMap, Permissions } from "../permissions";
 
 describe("Role permissions", () => {
   const testOrg: OrganizationInterface = {


### PR DESCRIPTION
### Features and Changes

There is one test in shared that was using roleToPermissionMap in packages/back-end/src/util/organization.util.ts. I moved the function to packages/shared/src/permissions/permissions.utils.ts instead.

### Testing

`yarn build`
Click around preview env
