### PR TITLE
fix(incremental-refresh): Add alter to query dependencies

### DIFF
--- a/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner.ts
@@ -539,9 +539,10 @@ const startExperimentIncrementalRefreshQueries = async (
       name: `insert_metrics_source_data_${group.groupId}`,
       displayTitle: `Update Metrics Source ${sourceName}`,
       query: integration.getInsertMetricSourceDataQuery(metricParams),
-      dependencies: createMetricsSourceQuery
-        ? [createMetricsSourceQuery.query]
-        : [alterUnitsTableQuery.query],
+      dependencies: [
+        ...(createMetricsSourceQuery ? [createMetricsSourceQuery.query] : []),
+        alterUnitsTableQuery.query,
+      ],
       run: (query, setExternalId) =>
         integration.runIncrementalWithNoOutputQuery(query, setExternalId),
       process: (rows) => rows,


### PR DESCRIPTION
### Features and Changes

We were missing the `alter` query statement as a dependency for the update query, which means that sometimes depending on how fast the queries got executed we would get a `table does not exists` error.

Now we are properly awaiting for the alter statement before proceeding.