### PR TITLE
fix(incremental-refresh): Drop covariate table if creating a new one

### DIFF
--- a/packages/back-end/src/integrations/GoogleAnalytics.ts
+++ b/packages/back-end/src/integrations/GoogleAnalytics.ts
@@ -32,6 +32,7 @@ import {
   MetricAnalysisParams,
   ExperimentFactMetricsQueryResponse,
   UserExperimentExposuresQueryResponse,
+  DropMetricSourceCovariateTableQueryParams,
   InsertMetricSourceCovariateDataQueryParams,
   CreateMetricSourceCovariateTableQueryParams,
 } from "shared/types/integrations";
@@ -216,6 +217,11 @@ export default class GoogleAnalytics implements SourceIntegrationInterface {
     _query: string,
     _setExternalId: ExternalIdCallback,
   ): Promise<IncrementalWithNoOutputQueryResponse> {
+    throw new Error("Method not implemented.");
+  }
+  getDropMetricSourceCovariateTableQuery(
+    _params: DropMetricSourceCovariateTableQueryParams,
+  ): string {
     throw new Error("Method not implemented.");
   }
   getCreateMetricSourceCovariateTableQuery(

--- a/packages/back-end/src/integrations/Mixpanel.ts
+++ b/packages/back-end/src/integrations/Mixpanel.ts
@@ -35,6 +35,7 @@ import {
   MetricAnalysisParams,
   ExperimentFactMetricsQueryResponse,
   UserExperimentExposuresQueryResponse,
+  DropMetricSourceCovariateTableQueryParams,
   CreateMetricSourceCovariateTableQueryParams,
   InsertMetricSourceCovariateDataQueryParams,
 } from "shared/types/integrations";
@@ -176,6 +177,11 @@ export default class Mixpanel implements SourceIntegrationInterface {
   }
   getInsertMetricSourceDataQuery(
     _params: InsertMetricSourceDataQueryParams,
+  ): string {
+    throw new Error("Method not implemented.");
+  }
+  getDropMetricSourceCovariateTableQuery(
+    _params: DropMetricSourceCovariateTableQueryParams,
   ): string {
     throw new Error("Method not implemented.");
   }

--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -97,6 +97,7 @@ import {
   CreateMetricSourceTableQueryParams,
   InsertMetricSourceDataQueryParams,
   DimensionColumnData,
+  DropMetricSourceCovariateTableQueryParams,
   MaxTimestampQueryResponse,
   ExperimentFactMetricsQueryResponseRows,
   IncrementalRefreshStatisticsQueryParams,
@@ -152,7 +153,10 @@ import {
 import { applyMetricOverrides } from "back-end/src/util/integration";
 import { ReqContextClass } from "back-end/src/services/context";
 import type { PopulationDataQuerySettings } from "back-end/types/query";
-import { INCREMENTAL_UNITS_TABLE_PREFIX } from "back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner";
+import {
+  INCREMENTAL_METRICS_TABLE_PREFIX,
+  INCREMENTAL_UNITS_TABLE_PREFIX,
+} from "back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner";
 import { AdditionalQueryMetadata, QueryMetadata } from "back-end/types/query";
 
 export const MAX_ROWS_UNIT_AGGREGATE_QUERY = 3000;
@@ -6866,6 +6870,27 @@ ${this.selectStarLimit("__topValues ORDER BY count DESC", limit)}
     return format(
       `
       SELECT MAX(max_timestamp) AS max_timestamp FROM ${params.metricSourceTableFullName}
+      `,
+      this.getFormatDialect(),
+    );
+  }
+
+  getDropMetricSourceCovariateTableQuery(
+    params: DropMetricSourceCovariateTableQueryParams,
+  ): string {
+    if (
+      !params.metricSourceCovariateTableFullName.includes(`_covariate`) ||
+      !params.metricSourceCovariateTableFullName.includes(
+        INCREMENTAL_METRICS_TABLE_PREFIX,
+      )
+    ) {
+      throw new Error(
+        "Unable to drop table that is not an incremental refresh covariate table.",
+      );
+    }
+    return format(
+      `
+      DROP TABLE IF EXISTS ${params.metricSourceCovariateTableFullName}
       `,
       this.getFormatDialect(),
     );

--- a/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner.ts
@@ -577,6 +577,21 @@ const startExperimentIncrementalRefreshQueries = async (
     let insertMetricCovariateDataQuery: QueryPointer | null = null;
     if (anyMetricHasCuped) {
       if (!existingCovariateSource) {
+        // Safety net in case our data model is out of sync with the database
+        const dropMetricCovariateTableQuery = await startQuery({
+          name: `drop_metrics_covariate_table_${group.groupId}`,
+          displayTitle: `Drop Old Metric Covariate Table ${sourceName}`,
+          query: integration.getDropMetricSourceCovariateTableQuery({
+            metricSourceCovariateTableFullName,
+          }),
+          dependencies: [updateUnitsTableQuery.query],
+          run: (query, setExternalId) =>
+            integration.runDropTableQuery(query, setExternalId),
+          process: (rows) => rows,
+          queryType: "experimentIncrementalRefreshDropMetricsCovariateTable",
+        });
+        queries.push(dropMetricCovariateTableQuery);
+
         createMetricCovariateTableQuery = await startQuery({
           name: `create_metrics_covariate_table_${group.groupId}`,
           displayTitle: `Create Metric Covariate Table ${sourceName}`,
@@ -585,7 +600,7 @@ const startExperimentIncrementalRefreshQueries = async (
             metrics: group.metrics,
             metricSourceCovariateTableFullName,
           }),
-          dependencies: [updateUnitsTableQuery.query],
+          dependencies: [dropMetricCovariateTableQuery.query],
           run: (query, setExternalId) =>
             integration.runIncrementalWithNoOutputQuery(query, setExternalId),
           process: (rows) => rows,

--- a/packages/back-end/src/types/Integration.ts
+++ b/packages/back-end/src/types/Integration.ts
@@ -10,6 +10,7 @@ import {
   CreateMetricSourceTableQueryParams,
   DimensionSlicesQueryParams,
   DimensionSlicesQueryResponse,
+  DropMetricSourceCovariateTableQueryParams,
   DropOldIncrementalUnitsQueryParams,
   DropTableQueryParams,
   DropTableQueryResponse,
@@ -169,6 +170,9 @@ export interface SourceIntegrationInterface {
   ): string;
   getInsertMetricSourceDataQuery(
     params: InsertMetricSourceDataQueryParams,
+  ): string;
+  getDropMetricSourceCovariateTableQuery(
+    params: DropMetricSourceCovariateTableQueryParams,
   ): string;
   getCreateMetricSourceCovariateTableQuery(
     params: CreateMetricSourceCovariateTableQueryParams,

--- a/packages/back-end/types/query.d.ts
+++ b/packages/back-end/types/query.d.ts
@@ -56,6 +56,7 @@ export type QueryType =
   | "experimentIncrementalRefreshCreateMetricsSourceTable"
   | "experimentIncrementalRefreshInsertMetricsSourceData"
   | "experimentIncrementalRefreshMaxTimestampMetricsSource"
+  | "experimentIncrementalRefreshDropMetricsCovariateTable"
   | "experimentIncrementalRefreshCreateMetricsCovariateTable"
   | "experimentIncrementalRefreshInsertMetricsCovariateData"
   | "experimentIncrementalRefreshStatistics"

--- a/packages/shared/types/integrations.d.ts
+++ b/packages/shared/types/integrations.d.ts
@@ -317,6 +317,10 @@ export interface InsertMetricSourceDataQueryParams {
   lastMaxTimestamp: Date | null;
 }
 
+export interface DropMetricSourceCovariateTableQueryParams {
+  metricSourceCovariateTableFullName: string;
+}
+
 export interface CreateMetricSourceCovariateTableQueryParams {
   settings: ExperimentSnapshotSettings;
   metrics: FactMetricInterface[];


### PR DESCRIPTION
### Features and Changes

In case our data model gets out of sync with the database, the currently pipeline would error with `Table ..._covariate already exists`.

So now we are making sure to drop the table if it exists before attempting to recreate it.