### PR TITLE
Fix handling of 'autoRefresh' setting in experiment REST endpoints

### DIFF
--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -2784,7 +2784,7 @@ export function postExperimentApiPayloadToInterface(
     ...(payload.minBucketVersion !== undefined
       ? { minBucketVersion: payload.minBucketVersion }
       : {}),
-    autoSnapshots: true,
+    autoSnapshots: payload.autoRefresh ?? true,
     project: payload.project,
     owner: payload.owner || "",
     trackingKey: payload.trackingKey || "",
@@ -2909,6 +2909,7 @@ export function updateExperimentApiPayloadToInterface(
     pinnedMetricSlices,
     customMetricSlices,
     customFields,
+    autoRefresh,
   } = payload;
   let changes: ExperimentInterface = {
     ...(trackingKey ? { trackingKey } : {}),
@@ -3008,6 +3009,7 @@ export function updateExperimentApiPayloadToInterface(
     ...(pinnedMetricSlices !== undefined ? { pinnedMetricSlices } : {}),
     ...(customMetricSlices !== undefined ? { customMetricSlices } : {}),
     ...(customFields !== undefined ? { customFields } : {}),
+    ...(autoRefresh !== undefined ? { autoSnapshots: !!autoRefresh } : {}),
     dateUpdated: new Date(),
   } as ExperimentInterface;
 


### PR DESCRIPTION
### Features and Changes

The `autoRefresh` parameter in the experiment create/update REST endpoints was being ignored.  This PR correctly maps it to the internal `autoSnapshots` property instead.