### PR TITLE
fix(incremental-refresh): Handle health query with many rows properly

### DIFF
--- a/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner.ts
@@ -297,6 +297,17 @@ const startExperimentIncrementalRefreshQueries = async (
     throw new Error("Exposure query not found");
   }
 
+  let dimensionsForTraffic: ExperimentDimension[] = [];
+  if (exposureQuery?.dimensionMetadata) {
+    dimensionsForTraffic = exposureQuery.dimensionMetadata
+      .filter((dm) => exposureQuery.dimensions.includes(dm.dimension))
+      .map((dm) => ({
+        type: "experiment",
+        id: dm.dimension,
+        specifiedSlices: dm.specifiedSlices,
+      }));
+  }
+
   const experimentDimensions: ExperimentDimension[] =
     params.fullRefresh || !incrementalRefreshModel
       ? exposureQuery.dimensions.map((d) => {
@@ -759,7 +770,7 @@ const startExperimentIncrementalRefreshQueries = async (
       name: TRAFFIC_QUERY_NAME,
       query: integration.getExperimentAggregateUnitsQuery({
         ...unitQueryParams,
-        dimensions: experimentDimensions,
+        dimensions: dimensionsForTraffic,
         useUnitsTable: true,
       }),
       dependencies: [alterUnitsTableQuery.query],


### PR DESCRIPTION
### Features and Changes

Pass `specificSlices` for the health query to limit the cardinality of the results so we don't hit the 3k rows limit.