### PR TITLE
Move validators and types out of WebhookModel.

### DIFF
--- a/packages/back-end/src/models/WebhookModel.ts
+++ b/packages/back-end/src/models/WebhookModel.ts
@@ -2,24 +2,17 @@ import mongoose from "mongoose";
 import { omit } from "lodash";
 import uniqid from "uniqid";
 import md5 from "md5";
-import { z } from "zod";
-import { managedByValidator } from "shared/validators";
-import { WebhookInterface } from "shared/types/webhook";
+import {
+  WebhookInterface,
+  UpdateSdkWebhookProps,
+  CreateSdkWebhookProps,
+} from "shared/types/webhook";
+import {
+  updateSdkWebhookValidator,
+  createSdkWebhookValidator,
+} from "shared/validators";
 import { ReqContext } from "back-end/types/request";
 import { migrateWebhookModel } from "back-end/src/util/migrations";
-
-const payloadFormatValidator = z.enum([
-  "standard",
-
-  "standard-no-payload",
-  "sdkPayload",
-  "edgeConfig",
-  "edgeConfigUnescaped",
-  "vercelNativeIntegration",
-  "none",
-]);
-
-export type PayloadFormat = z.infer<typeof payloadFormatValidator>;
 
 const webhookSchema = new mongoose.Schema({
   id: {
@@ -150,22 +143,6 @@ export async function setLastSdkWebhookError(
   );
 }
 
-export const updateSdkWebhookValidator = z
-  .object({
-    name: z.string().optional(),
-    endpoint: z.string().optional(),
-    payloadFormat: payloadFormatValidator.optional(),
-    payloadKey: z.string().optional(),
-    sdks: z.array(z.string()).optional(),
-    httpMethod: z
-      .enum(["GET", "POST", "PUT", "DELETE", "PATCH", "PURGE"])
-      .optional(),
-    headers: z.string().optional(),
-  })
-  .strict();
-
-export type UpdateSdkWebhookProps = z.infer<typeof updateSdkWebhookValidator>;
-
 export async function updateSdkWebhook(
   context: ReqContext,
   existing: WebhookInterface,
@@ -191,19 +168,6 @@ export async function updateSdkWebhook(
     ...updates,
   };
 }
-
-const createSdkWebhookValidator = z
-  .object({
-    name: z.string(),
-    endpoint: z.string(),
-    payloadFormat: payloadFormatValidator.optional(),
-    payloadKey: z.string().optional(),
-    httpMethod: z.enum(["GET", "POST", "PUT", "DELETE", "PATCH", "PURGE"]),
-    headers: z.string(),
-    managedBy: managedByValidator.optional(),
-  })
-  .strict();
-export type CreateSdkWebhookProps = z.infer<typeof createSdkWebhookValidator>;
 
 export async function createSdkWebhook(
   context: ReqContext,

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -12,9 +12,9 @@ import uniqid from "uniqid";
 import { LicenseInterface, accountFeatures } from "shared/enterprise";
 import { AgreementType } from "shared/validators";
 import { entityTypes } from "shared/constants";
+import { UpdateSdkWebhookProps } from "shared/types/webhook";
 import { getWatchedByUser } from "back-end/src/models/WatchModel";
 import {
-  UpdateSdkWebhookProps,
   deleteLegacySdkWebhookById,
   deleteSdkWebhookById,
   findAllLegacySdkWebhooks,

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -13,3 +13,4 @@ export * from "./saved-queries";
 export * from "./segment";
 export * from "./shared";
 export * from "./webhook-secrets";
+export * from "./webhooks";

--- a/packages/shared/src/validators/webhooks.ts
+++ b/packages/shared/src/validators/webhooks.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+import { managedByValidator } from "./managed-by";
+
+export const payloadFormatValidator = z.enum([
+  "standard",
+  "standard-no-payload",
+  "sdkPayload",
+  "edgeConfig",
+  "edgeConfigUnescaped",
+  "vercelNativeIntegration",
+  "none",
+]);
+
+export type WebhookPayloadFormat = z.infer<typeof payloadFormatValidator>;
+
+export const updateSdkWebhookValidator = z
+  .object({
+    name: z.string().optional(),
+    endpoint: z.string().optional(),
+    payloadFormat: payloadFormatValidator.optional(),
+    payloadKey: z.string().optional(),
+    sdks: z.array(z.string()).optional(),
+    httpMethod: z
+      .enum(["GET", "POST", "PUT", "DELETE", "PATCH", "PURGE"])
+      .optional(),
+    headers: z.string().optional(),
+  })
+  .strict();
+
+export type UpdateSdkWebhookProps = z.infer<typeof updateSdkWebhookValidator>;
+
+export const createSdkWebhookValidator = z
+  .object({
+    name: z.string(),
+    endpoint: z.string(),
+    payloadFormat: payloadFormatValidator.optional(),
+    payloadKey: z.string().optional(),
+    httpMethod: z.enum(["GET", "POST", "PUT", "DELETE", "PATCH", "PURGE"]),
+    headers: z.string(),
+    managedBy: managedByValidator.optional(),
+  })
+  .strict();
+
+export type CreateSdkWebhookProps = z.infer<typeof createSdkWebhookValidator>;

--- a/packages/shared/types/webhook.d.ts
+++ b/packages/shared/types/webhook.d.ts
@@ -1,4 +1,4 @@
-import { ManagedBy } from "shared/validators";
+import { ManagedBy, WebhookPayloadFormat } from "shared/validators";
 
 export interface WebhookInterface {
   id: string;
@@ -36,16 +36,8 @@ export type WebhookMethod =
   | "PURGE"
   | "PATCH";
 
-export type WebhookPayloadFormat =
-  | "standard"
-  | "standard-no-payload"
-  | "sdkPayload"
-  | "edgeConfig"
-  | "edgeConfigUnescaped"
-  | "vercelNativeIntegration"
-  | "none";
-
 export type {
   UpdateSdkWebhookProps,
   CreateSdkWebhookProps,
-} from "back-end/src/models/WebhookModel";
+  WebhookPayloadFormat,
+} from "shared/validators";


### PR DESCRIPTION
### Features and Changes

There were two remaining imports from WebhooksModel.  

- I've moved the validators to a new shared/src/validators/webhooks.ts file 
- updated the type file to import from there.  
- I've also removed a duplicate definition for WebhookPayloadFormat.

### Testing

`yarn build`
click around Preview environment.