### PR TITLE
Add eslint rule to make sure imports in shared are done right

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -136,22 +136,6 @@
       },
     },
     {
-      "files": ["./packages/shared/src/validators/**/*.ts"],
-      "rules": {
-        "no-restricted-imports": [
-          "error",
-          {
-            "patterns": [
-              {
-                "group": ["shared/validators/*", "shared/src/validators/*"],
-                "message": "Use relative imports (e.g., './file-name') when importing from other files within the validators directory",
-              },
-            ],
-          },
-        ],
-      },
-    },
-    {
       "files": ["./packages/front-end/**/*.ts*"],
       "excludedFiles": ["./packages/front-end/ui/**/*.ts*"],
       "rules": {

--- a/.eslintrc
+++ b/.eslintrc
@@ -2,22 +2,22 @@
   "env": {
     "node": true,
     "browser": true,
-    "es6": true
+    "es6": true,
   },
   "settings": {
     "react": {
-      "version": "detect"
+      "version": "detect",
     },
     "import/parsers": {
-      "@typescript-eslint/parser": [".ts", ".tsx"]
+      "@typescript-eslint/parser": [".ts", ".tsx"],
     },
     "import/resolver": {
       "node": true,
       "typescript": {
         "alwaysTryTypes": true,
-        "project": ["packages/*/tsconfig.json"]
-      }
-    }
+        "project": ["packages/*/tsconfig.json"],
+      },
+    },
   },
   "parser": "@typescript-eslint/parser",
   "plugins": [
@@ -25,7 +25,8 @@
     "@typescript-eslint",
     "prettier",
     "@next/eslint-plugin-next",
-    "no-async-foreach"
+    "no-async-foreach",
+    "eslint-plugin-local-rules",
   ],
   "extends": [
     "eslint:recommended",
@@ -36,18 +37,18 @@
     "plugin:@typescript-eslint/recommended",
     "plugin:prettier/recommended",
     "plugin:@next/eslint-plugin-next/recommended",
-    "plugin:react-hooks/recommended"
+    "plugin:react-hooks/recommended",
   ],
   "parserOptions": {
     "ecmaFeatures": {
-      "jsx": true
+      "jsx": true,
     },
     "ecmaVersion": 2018,
-    "sourceType": "module"
+    "sourceType": "module",
   },
   "globals": {
     "Atomics": "readonly",
-    "SharedArrayBuffer": "readonly"
+    "SharedArrayBuffer": "readonly",
   },
   "rules": {
     "no-unused-expressions": [
@@ -55,8 +56,8 @@
       {
         "allowShortCircuit": true,
         "enforceForJSX": true,
-        "allowTernary": true
-      }
+        "allowTernary": true,
+      },
     ],
     "no-async-foreach/no-async-foreach": 2,
     "@next/next/no-html-link-for-pages": ["warn", "./packages/front-end/pages"],
@@ -67,15 +68,15 @@
     "@typescript-eslint/no-inferrable-types": [
       "warn",
       {
-        "ignoreParameters": true
-      }
+        "ignoreParameters": true,
+      },
     ],
     "@typescript-eslint/no-unused-vars": [
       "warn",
       {
         "argsIgnorePattern": "^_",
-        "varsIgnorePattern": "^_"
-      }
+        "varsIgnorePattern": "^_",
+      },
     ],
     "no-console": ["warn"],
     "no-restricted-imports": "off",
@@ -93,31 +94,62 @@
           "parent",
           "sibling",
           "index",
-          "unknown"
-        ]
-      }
+          "unknown",
+        ],
+      },
     ],
-    "@typescript-eslint/prefer-ts-expect-error": "error"
+    "@typescript-eslint/prefer-ts-expect-error": "error",
+    "local-rules/no-internal-shared-imports": "error",
   },
   "overrides": [
     {
       "files": [
         "./packages/sdk-js/rollup.config.js",
-        "./packages/sdk-react/rollup.config.js"
+        "./packages/sdk-react/rollup.config.js",
       ],
       "rules": {
-        "import/no-named-as-default": "off"
-      }
+        "import/no-named-as-default": "off",
+      },
     },
     {
       "files": [
         "./packages/back-end/src/**/*.ts*",
         "./packages/back-end/types/**/*.ts*",
-        "./packages/front-end/**/*.ts*"
+        "./packages/front-end/**/*.ts*",
       ],
       "rules": {
-        "no-restricted-imports": ["error", { "patterns": ["..*"] }]
-      }
+        "no-restricted-imports": [
+          "error",
+          {
+            "patterns": [
+              {
+                "group": ["..*"],
+                "message": "Use absolute imports instead of parent directory imports",
+              },
+              {
+                "group": ["shared/src/**"],
+                "message": "Import from entry points (shared/validators, shared/enterprise, shared/types/*) instead of shared/src/*",
+              },
+            ],
+          },
+        ],
+      },
+    },
+    {
+      "files": ["./packages/shared/src/validators/**/*.ts"],
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "patterns": [
+              {
+                "group": ["shared/validators/*", "shared/src/validators/*"],
+                "message": "Use relative imports (e.g., './file-name') when importing from other files within the validators directory",
+              },
+            ],
+          },
+        ],
+      },
     },
     {
       "files": ["./packages/front-end/**/*.ts*"],
@@ -144,13 +176,19 @@
                   "Select",
                   "Switch",
                   "Table",
-                  "Tabs"
-                ]
-              }
-            ]
-          }
-        ]
-      }
+                  "Tabs",
+                ],
+              },
+            ],
+            "patterns": [
+              {
+                "group": ["shared/src/**"],
+                "message": "Import from entry points (shared/validators, shared/enterprise, shared/types/*) instead of shared/src/*",
+              },
+            ],
+          },
+        ],
+      },
     },
     {
       "files": [
@@ -190,23 +228,23 @@
         "./packages/front-end/services/features.ts",
         "./packages/front-end/services/search.tsx",
         "./packages/front-end/services/useGlobalMenu.ts",
-        "./packages/front-end/services/useSwitchOrg.ts"
+        "./packages/front-end/services/useSwitchOrg.ts",
       ],
       "rules": {
-        "react-hooks/exhaustive-deps": "off"
-      }
+        "react-hooks/exhaustive-deps": "off",
+      },
     },
     {
       "rules": {
-        "no-console": "off"
+        "no-console": "off",
       },
       "files": [
         "./packages/sdk-js/**/*",
         "./packages/front-end/**/*",
         "./packages/back-end/test/**/*",
         "./packages/back-end/src/scripts/**/*",
-        "./packages/back-end/**/*.test.{ts,tsx,js,jsx}"
-      ]
+        "./packages/back-end/**/*.test.{ts,tsx,js,jsx}",
+      ],
     },
     {
       "rules": {
@@ -217,17 +255,23 @@
               {
                 "name": "node-fetch",
                 "message": "Use `import { fetch } from \"back-end/src/util/http.util\";` instead.",
-                "importNames": ["default"]
-              }
-            ]
-          }
-        ]
+                "importNames": ["default"],
+              },
+            ],
+            "patterns": [
+              {
+                "group": ["shared/src/**"],
+                "message": "Import from entry points (shared/validators, shared/enterprise, shared/types/*) instead of shared/src/*",
+              },
+            ],
+          },
+        ],
       },
       "files": ["./packages/back-end/**/*"],
       "excludedFiles": [
         "./packages/back-end/src/util/http.util.ts",
-        "./packages/back-end/**/*.test.{ts,tsx,js,jsx}"
-      ]
-    }
-  ]
+        "./packages/back-end/**/*.test.{ts,tsx,js,jsx}",
+      ],
+    },
+  ],
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -126,10 +126,6 @@
                 "group": ["..*"],
                 "message": "Use absolute imports instead of parent directory imports",
               },
-              {
-                "group": ["shared/src/**"],
-                "message": "Import from entry points (shared/validators, shared/enterprise, shared/types/*) instead of shared/src/*",
-              },
             ],
           },
         ],
@@ -162,12 +158,6 @@
                   "Table",
                   "Tabs",
                 ],
-              },
-            ],
-            "patterns": [
-              {
-                "group": ["shared/src/**"],
-                "message": "Import from entry points (shared/validators, shared/enterprise, shared/types/*) instead of shared/src/*",
               },
             ],
           },
@@ -240,12 +230,6 @@
                 "name": "node-fetch",
                 "message": "Use `import { fetch } from \"back-end/src/util/http.util\";` instead.",
                 "importNames": ["default"],
-              },
-            ],
-            "patterns": [
-              {
-                "group": ["shared/src/**"],
-                "message": "Import from entry points (shared/validators, shared/enterprise, shared/types/*) instead of shared/src/*",
               },
             ],
           },

--- a/docs/scripts/gen-sdk-resources.ts
+++ b/docs/scripts/gen-sdk-resources.ts
@@ -6,7 +6,7 @@ import {
   getSDKCapabilities,
   getSDKCapabilityVersion,
   SDKCapability,
-} from "shared/src/sdk-versioning";
+} from "shared/sdk-versioning";
 import type { SDKLanguage } from "shared/types/sdk-connection";
 
 function defineSDKCapabilityVersion(sdk: string, capabilities: string[]) {

--- a/eslint-local-rules.js
+++ b/eslint-local-rules.js
@@ -1,0 +1,59 @@
+// Custom ESLint rules for GrowthBook
+module.exports = {
+  "no-internal-shared-imports": {
+    meta: {
+      type: "problem",
+      docs: {
+        description:
+          "Enforce using entry points instead of internal shared paths",
+        category: "Best Practices",
+        recommended: true,
+      },
+      fixable: "code",
+      messages: {
+        useEntryPoint:
+          'Import from entry point "{{suggestedPath}}" instead of "{{importPath}}"',
+      },
+      schema: [],
+    },
+    create(context) {
+      return {
+        ImportDeclaration(node) {
+          const importPath = node.source.value;
+
+          // Check if it's importing from shared/src
+          if (
+            typeof importPath === "string" &&
+            importPath.startsWith("shared/src/")
+          ) {
+            // Extract the first directory after shared/src/
+            // e.g., "shared/src/validators/foo" -> "validators"
+            // e.g., "shared/src/enterprise/validators/bar" -> "enterprise"
+            const match = importPath.match(/^shared\/src\/([^/]+)/);
+            if (match) {
+              const entryPoint = match[1];
+              const suggestedPath = `shared/${entryPoint}`;
+
+              context.report({
+                node: node.source,
+                messageId: "useEntryPoint",
+                data: {
+                  importPath: importPath,
+                  suggestedPath: suggestedPath,
+                },
+                fix(fixer) {
+                  // Replace the import path, keeping the quotes
+                  const quote = node.source.raw[0];
+                  return fixer.replaceText(
+                    node.source,
+                    `${quote}${suggestedPath}${quote}`,
+                  );
+                },
+              });
+            }
+          }
+        },
+      };
+    },
+  },
+};

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "eslint-config-prettier": "^6.11.0",
     "eslint-import-resolver-typescript": "^3.5.1",
     "eslint-plugin-import": "^2.26.0",
+    "eslint-plugin-local-rules": "^3.0.2",
     "eslint-plugin-no-async-foreach": "^0.1.1",
     "eslint-plugin-prettier": "^5.5.4",
     "eslint-plugin-react": "^7.30.1",

--- a/packages/front-end/components/Dimensions/DimensionChooser.tsx
+++ b/packages/front-end/components/Dimensions/DimensionChooser.tsx
@@ -5,7 +5,7 @@ import {
   ExperimentSnapshotInterface,
 } from "back-end/types/experiment-snapshot";
 import { Flex } from "@radix-ui/themes";
-import { getSnapshotAnalysis } from "shared/src/util";
+import { getSnapshotAnalysis } from "shared/util";
 import { DataSourceInterfaceWithParams } from "back-end/types/datasource";
 import { DimensionInterface } from "back-end/types/dimension";
 import { IncrementalRefreshInterface } from "shared/validators";

--- a/packages/front-end/components/GetStarted/AdvancedFeaturesCard.tsx
+++ b/packages/front-end/components/GetStarted/AdvancedFeaturesCard.tsx
@@ -1,5 +1,5 @@
 import { AspectRatio, Box, Text } from "@radix-ui/themes";
-import { CommercialFeature } from "shared/src/enterprise/license-consts";
+import { CommercialFeature } from "shared/enterprise";
 import PaidFeatureBadge from "@/components/GetStarted/PaidFeatureBadge";
 import { DocSection, DocLink } from "@/components/DocLink";
 import Link from "@/ui/Link";

--- a/packages/front-end/components/GetStarted/index.tsx
+++ b/packages/front-end/components/GetStarted/index.tsx
@@ -10,7 +10,7 @@ import {
 } from "@radix-ui/themes";
 import { PiArrowSquareOut, PiCaretDownFill } from "react-icons/pi";
 import { getDemoDatasourceProjectIdForOrganization } from "shared/demo-datasource";
-import { CommercialFeature } from "shared/src/enterprise/license-consts";
+import { CommercialFeature } from "shared/enterprise";
 import router from "next/router";
 import { useGrowthBook } from "@growthbook/growthbook-react";
 import UpgradeModal from "@/components/Settings/UpgradeModal";

--- a/yarn.lock
+++ b/yarn.lock
@@ -14198,6 +14198,11 @@ eslint-plugin-jsx-a11y@^6.7.1:
     object.entries "^1.1.7"
     object.fromentries "^2.0.7"
 
+eslint-plugin-local-rules@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-local-rules/-/eslint-plugin-local-rules-3.0.2.tgz#84c02ea1d604ecb00970779ad27f00738ff361ae"
+  integrity sha512-IWME7GIYHXogTkFsToLdBCQVJ0U4kbSuVyDT+nKoR4UgtnVrrVeNWuAZkdEu1nxkvi9nsPccGehEEF6dgA28IQ==
+
 eslint-plugin-no-async-foreach@^0.1.1:
   version "0.1.1"
   resolved "https://registry.npmjs.org/eslint-plugin-no-async-foreach/-/eslint-plugin-no-async-foreach-0.1.1.tgz"
@@ -22832,7 +22837,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -22849,6 +22854,15 @@ string-width@^3.0.0, string-width@^3.1.0:
     emoji-regex "^7.0.1"
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
+
+string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -22970,7 +22984,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -22983,6 +22997,13 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.0.1"
@@ -24781,7 +24802,7 @@ wordwrapjs@^5.1.0:
   resolved "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.0.tgz"
   integrity sha512-JNjcULU2e4KJwUNv6CHgI46UvDGitb6dGryHajXTDiLgg1/RiGoPSDw4kZfYnwGtEXf2ZMeIewDQgFGzkCB2Sg==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -24803,6 +24824,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
### Features and Changes

Within the shared package file, if you try and import from another file within the same entry point there will be a circular reference unless it is a relative import.  The build would succeed, but there is a runtime error on the page.

Outside of the shared package it worked fine to load from a full /shared/src/xxx/xxx path, but when building the front-end there were errors.

By adding a custom build rule both types are autofixable.  To make a custom build rule I had to:
-  add the `"eslint-plugin-local-rules": "^3.0.2",` package, 
- this to .eslintrc: `"local-rules/no-internal-shared-imports": "error",`
- eslint-local-rules.js file.

### Alternatives considered
I couldn't quite make a "no-restricted-import-rule" for the relative imports as it is fine to import from other entry-points within shared non-relatively.  Also there was no way to get it to be autofixable.

### Testing
Have these settings in vscode:
```
{
  "eslint.validate": [
    "javascript",
    "javascriptreact",
    "typescript",
    "typescriptreact"
  ],
  "editor.codeActionsOnSave": {
    "source.fixAll.eslint": "explicit"
  },
  "eslint.options": {
    "rulePaths": ["./"]
  }
}
```
In /shared/src/settings/index.ts put in: 
`import genDefaultResolver from "shared/src/settings/resolvers/genDefaultResolver";` 
see it complain.
save and see it say `import genDefaultResolver from "./resolvers/genDefaultResolver";` 
In shared/src/constants.ts see no erros for importing from shared/types/audit.
In a back-end file:
`import { ExperimentInterfaceExcludingHoldouts } from "shared/src/validators/experiments";`
see it complain.
save and see it rewritten:
`import { ExperimentInterfaceExcludingHoldouts } from "shared/validators";`
