### PR TITLE
Import stripe from pure directory to limit side effects

### DIFF
--- a/packages/front-end/enterprise/components/Billing/StripeProvider.tsx
+++ b/packages/front-end/enterprise/components/Billing/StripeProvider.tsx
@@ -7,7 +7,7 @@ import {
   ReactNode,
 } from "react";
 import { Elements } from "@stripe/react-stripe-js";
-import { loadStripe } from "@stripe/stripe-js";
+import { loadStripe } from "@stripe/stripe-js/pure";
 import { useAuth } from "@/services/auth";
 import { useAppearanceUITheme } from "@/services/AppearanceUIThemeProvider";
 import Callout from "@/ui/Callout";


### PR DESCRIPTION
### Features and Changes

While we were calling `loadStripe` conditionally, the way that we were importing `loadStripe` resulted in loading the stripe.js script. This PR switches to using Stripe's `pure` module, that defers loading the stripe.js script until loadstripe is first called.

This results in no calls made out to Stripe for self-hosted organizations that don't have a stripe key set.

By default, Stripe makes some calls to m.stripe.com for fraud detection. The current implementation retains that logic, but only for cloud organizations. (As we're not calling `loadStripe` for self-hosted orgs without a stripe key, so the stripe.js script is never loaded.

### Dependencies

- None

### Testing

- [x] Ensure that cloud orgs can still manage their cards and manage subscriptions without issue.
- [x] Ensure that in a self-hosted instance without any stripe publishable keys, no calls to m.stripe.com are made
- [x] Ensure that IF a stripe publishable key is present, calls to m.stripe.com are made, but only after stripe is loaded
