### PR TITLE
feat(fact-tables): Add daily aggregation toggle and use to cast in BQ

### DIFF
--- a/packages/back-end/src/integrations/BigQuery.ts
+++ b/packages/back-end/src/integrations/BigQuery.ts
@@ -176,6 +176,9 @@ export default class BigQuery extends SqlIntegration {
   castUserDateCol(column: string): string {
     return `CAST(${column} as DATETIME)`;
   }
+  castDailyAggregatedTimestampToTimestampCol(column: string): string {
+    return this.castToTimestamp(column);
+  }
   hasCountDistinctHLL(): boolean {
     return true;
   }

--- a/packages/back-end/src/models/FactTableModel.ts
+++ b/packages/back-end/src/models/FactTableModel.ts
@@ -51,6 +51,7 @@ const factTableSchema = new mongoose.Schema({
     },
   ],
   columnsError: String,
+  timestampAggregatedDaily: Boolean,
   filters: [
     {
       _id: false,
@@ -124,6 +125,7 @@ function createPropsToInterface(
     columns,
     columnsError: null,
     managedBy: props.managedBy || "",
+    timestampAggregatedDaily: props.timestampAggregatedDaily || false,
   };
 }
 

--- a/packages/back-end/types/fact-table.d.ts
+++ b/packages/back-end/types/fact-table.d.ts
@@ -73,6 +73,7 @@ export interface FactTableInterface {
   sql: string;
   eventName: string;
   columns: ColumnInterface[];
+  timestampAggregatedDaily?: boolean;
   columnsError?: string | null;
   filters: FactFilterInterface[];
   archived?: boolean;

--- a/packages/front-end/components/FactTables/FactTableModal.tsx
+++ b/packages/front-end/components/FactTables/FactTableModal.tsx
@@ -68,6 +68,7 @@ export default function FactTableModal({
       eventName: existing?.eventName || "",
       managedBy: existing?.managedBy || "",
       projects: existing?.projects || [],
+      timestampAggregatedDaily: existing?.timestampAggregatedDaily || false,
     },
   });
 
@@ -143,6 +144,7 @@ export default function FactTableModal({
               eventName: value.eventName,
               managedBy: value.managedBy,
               projects: value.projects,
+              timestampAggregatedDaily: value.timestampAggregatedDaily,
             };
             await apiCall(`/fact-tables/${existing.id}`, {
               method: "PUT",
@@ -272,6 +274,19 @@ export default function FactTableModal({
               </div>
             )}
           </>
+        )}
+
+        {selectedDataSource && (
+          <div className="mt-2">
+            <Checkbox
+              label="Mark timestamp column as aggregated daily"
+              value={form.watch("timestampAggregatedDaily") || false}
+              description="If the fact table is pre-aggregated at the day level, checking this box ensures that the timestamp column is handled correctly by GrowthBook."
+              setValue={(value) => {
+                form.setValue("timestampAggregatedDaily", value);
+              }}
+            />
+          </div>
         )}
 
         {permissionsUtil.canCreateOfficialResources({

--- a/packages/shared/src/validators/fact-table.ts
+++ b/packages/shared/src/validators/fact-table.ts
@@ -81,6 +81,7 @@ export const createFactTablePropsValidator = z
     eventName: z.string(),
     columns: z.array(createColumnPropsValidator).optional(),
     managedBy: z.enum(["", "api", "admin"]).optional(),
+    timestampAggregatedDaily: z.boolean().optional(),
   })
   .strict();
 
@@ -98,6 +99,7 @@ export const updateFactTablePropsValidator = z
     managedBy: z.enum(["", "api", "admin"]).optional(),
     columnsError: z.string().nullable().optional(),
     archived: z.boolean().optional(),
+    timestampAggregatedDaily: z.boolean().optional(),
   })
   .strict();
 


### PR DESCRIPTION
### Features and Changes

Daily aggregated data works in GrowthBook, especially ensure that the timestamp for a date is the end of the day that it was collected (or the start of the next day). However, if the `timestamp` column used in a Fact Table is of type `DATE` then BigQuery will throw an error when trying to compare that to our timestamps that determine the eligible range of data.

This PR introduces a Fact Table level flag indicating the data is aggregated at the daily level, and uses that flag to cast the `timestamp` column to `TIMESTAMP` in BigQuery to make sure the WHERE clause works. This should work even if the column is already a TIMESTAMP or a DATETIME, or even if the data isn't actually aggregated daily.

In the future we may use this toggle to restrict certain metric types to be ensure that all analyses with daily aggregated data make sense.

- Closes **(add link to issue here)**

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

* [X] - New cast fixes issue when timestamp is a DATE (see screenshots below)
* [X] - Date partitions are still pruned correctly

### Screenshots

All the below are with this test branch enabled...

Failure when `timestamp` is type `DATE`
<img width="647" height="625" alt="Screenshot 2025-12-09 at 12 10 03 PM" src="https://github.com/user-attachments/assets/5416d266-88a6-4e9b-8c37-31c09fc8b5cb" />

Setting timestamp as daily on the Fact Table (editing and new fact table)
<img width="549" height="489" alt="Screenshot 2025-12-09 at 12 12 15 PM" src="https://github.com/user-attachments/assets/625f27e8-dfaa-4eb1-b9df-483d8ef6e759" />

<img width="534" height="867" alt="Screenshot 2025-12-09 at 12 12 25 PM" src="https://github.com/user-attachments/assets/ff46f1b9-b496-4b3b-8ea6-56fdb645c1b3" />


Fixed query when the toggle is on
<img width="632" height="687" alt="Screenshot 2025-12-09 at 12 24 17 PM" src="https://github.com/user-attachments/assets/c8406729-6586-44f8-a34b-235611b51517" />
