### PR TITLE
fix(ui): Properly handle multiple visual editor changes

### DIFF
--- a/packages/front-end/components/Experiment/LinkedChange.tsx
+++ b/packages/front-end/components/Experiment/LinkedChange.tsx
@@ -121,9 +121,9 @@ export default function LinkedChange({
                                 </>
                               }
                             />
-                            <Box>&middot;</Box>
                           </Box>
                         )}
+                      <Box>&middot;</Box>
                       <Box className="text-muted">
                         {(changes?.length || 0) > 0
                           ? joinWithOxfordComma(changes) + " changes"

--- a/packages/front-end/components/Experiment/VisualChangesetTable.tsx
+++ b/packages/front-end/components/Experiment/VisualChangesetTable.tsx
@@ -55,8 +55,8 @@ const drawChange = ({
   }) => void;
   simpleUrlPatterns: VisualChangesetURLPattern[];
   regexUrlPatterns: VisualChangesetURLPattern[];
-  showChangeset: number[];
-  setShowChangeset: (value: number[]) => void;
+  showChangeset: string[];
+  setShowChangeset: (value: string[]) => void;
 }) => {
   return (
     <>
@@ -132,6 +132,7 @@ const drawChange = ({
           </Flex>
           <Box>
             {variations.map((v, j) => {
+              const key = `${i}-${j}`;
               const changes = vc.visualChanges[j];
               const numChanges =
                 (changes?.css ? 1 : 0) +
@@ -168,7 +169,7 @@ const drawChange = ({
                           className="label mt-1"
                           style={{ width: 20, height: 20 }}
                         >
-                          {i}
+                          {j}
                         </span>
                         <Flex direction="column">
                           <span
@@ -182,9 +183,9 @@ const drawChange = ({
                             onClick={(e) => {
                               e.preventDefault();
                               setShowChangeset(
-                                showChangeset.includes(j)
-                                  ? showChangeset.filter((item) => item !== j)
-                                  : [...showChangeset, j],
+                                showChangeset.includes(key)
+                                  ? showChangeset.filter((item) => item !== key)
+                                  : [...showChangeset, key],
                               );
                             }}
                           >
@@ -199,7 +200,9 @@ const drawChange = ({
                                 className="chevron"
                                 style={{
                                   transform: `rotate(${
-                                    showChangeset.includes(j) ? "90deg" : "0deg"
+                                    showChangeset.includes(key)
+                                      ? "90deg"
+                                      : "0deg"
                                   })`,
                                 }}
                               />
@@ -233,7 +236,7 @@ const drawChange = ({
                         )}
                       </Flex>
                     </Flex>
-                    {showChangeset.includes(j) && (
+                    {showChangeset.includes(key) && (
                       <Box>
                         <Code
                           language="json"
@@ -271,7 +274,7 @@ export const VisualChangesetTable: FC<Props> = ({
 }: Props) => {
   const { variations } = experiment;
   const { apiCall } = useAuth();
-  const [showChangeset, setShowChangeset] = useState<number[]>([]);
+  const [showChangeset, setShowChangeset] = useState<string[]>([]);
 
   const [editingVisualChangeset, setEditingVisualChangeset] =
     useState<VisualChangesetInterface | null>(null);


### PR DESCRIPTION
### Features and Changes

- Ensure each visual editor change is individual
  - Before this meant we would open the changes for all Visual Editor changes when clicking on a single one
- Ensure variation number is rendered properly
- Small UI fix to have middot in the right place

#### Before

<img width="959" height="824" alt="Screenshot 2025-12-10 at 1 54 31 PM" src="https://github.com/user-attachments/assets/8836c7b8-1bec-41cb-b934-6dc88a7702f1" />

#### After

<img width="961" height="825" alt="Screenshot 2025-12-10 at 1 56 31 PM" src="https://github.com/user-attachments/assets/bae6131b-be08-494b-9fc9-893e33d9c0c9" />
