### PR TITLE
fix(incremental): Remove filter to account for microsecond vs millisecond precision

### DIFF
--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -6759,7 +6759,6 @@ ${this.selectStarLimit("__topValues ORDER BY count DESC", limit)}
             }
             ${experimentDimensions.map((d) => `, dim_exp_${d.id}`).join("\n")}
           FROM ${params.unitsTableFullName}
-          ${params.lastMaxTimestamp ? `WHERE max_timestamp <= ${this.toTimestampWithMs(params.lastMaxTimestamp)}` : ""}
         )
         ${
           segment


### PR DESCRIPTION
### Features and Changes

BigQuery has microsecond precision, while JS Date is only milliseconds. So using the value of `2025-12-10T23:04:21.427743000Z` as an example:
- We would get it as a string from BQ
- Casting to Date means it becomes `2025-12-10T23:04:21.427`
- We use it to filter `max_timestamp <= ${Date}`
- So the left column (max_timestamp) still references the microsecond value while the right side only has the millisecond precision
- This drops all previous units because `.4277432` is bigger than `.427`.

For units we don't need to have this filter at all, so we are removing it.