### PR TITLE
fix: use correct dateUpdated field in sdk-connection delete test

### DIFF
--- a/packages/back-end/test/api/sdk-connections.test.ts
+++ b/packages/back-end/test/api/sdk-connections.test.ts
@@ -514,7 +514,7 @@ describe("sdk-connections API", () => {
     expect(auditMock).toHaveBeenCalledWith({
       details: `{"pre":{"id":"${
         existing.id
-      }","name":"my-connection","dateCreated":"${existing.dateCreated.toISOString()}","dateUpdated":"${existing.dateCreated.toISOString()}","languages":["javascript"],"environment":"production","projects":[],"encryptPayload":false,"encryptionKey":"","key":"${
+      }","name":"my-connection","dateCreated":"${existing.dateCreated.toISOString()}","dateUpdated":"${existing.dateUpdated.toISOString()}","languages":["javascript"],"environment":"production","projects":[],"encryptPayload":false,"encryptionKey":"","key":"${
         existing.key
       }","connected":false,"proxy":{"enabled":false,"host":"","signingKey":"","connected":false,"version":"","error":"","lastError":null},"language":"javascript"},"context":{}}`,
       entity: { id: existing.id, object: "sdk-connection" },


### PR DESCRIPTION
### Features and Changes

Fixes a flaky test by using the correct `dateUpdated` field in the SDK connection delete audit log assertion. The test was incorrectly using `existing.dateCreated` for both `dateCreated` and `dateUpdated`, causing failures when the factory's two separate `new Date()` calls returned timestamps differing by a millisecond.

### Testing

This test was flaky on CI and failed intermittently. The fix ensures the audit log assertion matches whatever timestamps the factory actually generates by using the correct field reference.