### PR TITLE
Disable audit log for SQL result chunks

### DIFF
--- a/packages/back-end/src/models/SqlResultChunkModel.ts
+++ b/packages/back-end/src/models/SqlResultChunkModel.ts
@@ -9,12 +9,6 @@ const BaseClass = MakeModelClass({
   schema: sqlResultChunkValidator,
   collectionName: "sqlresultchunks",
   idPrefix: "sqlres_",
-  auditLog: {
-    entity: "sqlResultChunk",
-    createEvent: "sqlResultChunk.create",
-    updateEvent: "sqlResultChunk.update",
-    deleteEvent: "sqlResultChunk.delete",
-  },
   globallyUniqueIds: true,
   additionalIndexes: [
     { fields: { organization: 1, queryId: 1, chunkNumber: 1 }, unique: true },


### PR DESCRIPTION
### Features and Changes

Audit log is not necessary for SQL result chunks and it just causes unnecessary load and data in MongoDB.
