### PR TITLE
Add filter value tooltip to fmid

### DIFF
--- a/packages/front-end/pages/fact-metrics/[fmid].tsx
+++ b/packages/front-end/pages/fact-metrics/[fmid].tsx
@@ -65,6 +65,7 @@ import PaidFeatureBadge from "@/components/GetStarted/PaidFeatureBadge";
 import { DocLink } from "@/components/DocLink";
 import Callout from "@/ui/Callout";
 import { DeleteDemoDatasourceButton } from "@/components/DemoDataSourcePage/DemoDataSourcePage";
+import InlineCode from "@/components/SyntaxHighlighting/InlineCode";
 
 function FactTableLink({ id }: { id?: string }) {
   const { getFactTableById } = useDefinitions();
@@ -95,7 +96,11 @@ function FilterBadges({
         if (!filter) return null;
         return (
           <span className="badge badge-secondary mr-2" key={filter.id}>
-            {filter.name}
+            <Tooltip
+              body={<InlineCode language="sql" code={filter.value} inTooltip />}
+            >
+              <span className="cursor-default">{filter.name}</span>
+            </Tooltip>
           </span>
         );
       })}


### PR DESCRIPTION
Tiny PR to replicate the hover tooltip that takes a saved filter and renders it on [fmid] (copied logic from FactMetricModal where we do this).

May be redundant due to Jeremy's new Filters PR.

<img width="386" height="276" alt="Screenshot 2025-12-15 at 10 28 22 AM" src="https://github.com/user-attachments/assets/bd7b6767-4e55-462a-a7e7-8ede6fec137c" />
<img width="656" height="351" alt="Screenshot 2025-12-15 at 10 28 11 AM" src="https://github.com/user-attachments/assets/70ca75ce-3a13-4647-a6e2-cf68e109278a" />
