### PR TITLE
fix(metrics): handle orphaned denominator columns in JIT migration

### DIFF
--- a/packages/back-end/src/models/FactMetricModel.ts
+++ b/packages/back-end/src/models/FactMetricModel.ts
@@ -86,6 +86,20 @@ function validateUserFilter({
   }
 }
 
+// Ensure that that
+function denominatorRequiredByMetricType(metricType: FactMetricType): boolean {
+  switch (metricType) {
+    case "mean":
+    case "dailyParticipation":
+    case "quantile":
+    case "retention":
+    case "proportion":
+      return false;
+    case "ratio":
+      return true;
+  }
+}
+
 export class FactMetricModel extends BaseClass {
   protected canRead(doc: FactMetricInterface): boolean {
     return this.context.hasPermission("readData", doc.projects || []);
@@ -140,6 +154,11 @@ export class FactMetricModel extends BaseClass {
         mean: 0,
         stddev: DEFAULT_PROPER_PRIOR_STDDEV,
       };
+    }
+
+    // Clean up orphaned denominators that should not exist
+    if (!denominatorRequiredByMetricType(newDoc.metricType)) {
+      newDoc.denominator = null;
     }
 
     return newDoc as FactMetricInterface;


### PR DESCRIPTION
### Features and Changes

There are some records in our fact metric collection where `denominator` in a `factmetrics` is non-null, but isn't well formed according to our internal types, perhaps due to faulty validation in the past. This is causing other errors when users run queries, thanks to us sometimes relying on this column being well-formed.

To resolve this, we can just add a JIT migration to clean up this column when it isn't needed (as per the metric type).

This is somewhat risky in that if we are wrong that other metric types require denominators somehow (they shouldn't...) then this deletes those columns.

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

Error on main with similar data to customer
<img width="1259" height="458" alt="Screenshot 2025-12-17 at 11 22 27 AM" src="https://github.com/user-attachments/assets/e5955c8d-bdf4-457c-aa91-d6f2db8d5e10" />

Resolved with fix
<img width="1267" height="472" alt="Screenshot 2025-12-17 at 11 23 44 AM" src="https://github.com/user-attachments/assets/f462aade-302d-4e0f-8233-b5b4d24f2aad" />


Other metrics working, but definitely not exhaustive. Relying partially on suite of sql generation jobs in the snapshot test.

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
