### PR TITLE
Fix SDK payload undefined bug

### DIFF
--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -835,7 +835,7 @@ export async function getFeatureDefinitions({
         cached.contents;
       const allSavedGroups = await getAllSavedGroups(context.org.id);
       const usedSavedGroups = allSavedGroups.filter((sg) =>
-        savedGroupsInUse.includes(sg.id),
+        savedGroupsInUse?.includes(sg.id),
       );
       if (hashSecureAttributes) {
         // Note: We don't check for whether the org has the hash-secure-attributes premium feature here because


### PR DESCRIPTION
### Features and Changes

A variable on the back-end is sometimes undefined when generating SDK payloads.  Add safety check around that.
