### PR TITLE
Re-enable saved groups front-end JSON validation

### DIFF
--- a/packages/back-end/types/sdk-payload.d.ts
+++ b/packages/back-end/types/sdk-payload.d.ts
@@ -6,7 +6,7 @@ export type SDKPayloadContents = {
   features: Record<string, FeatureDefinition>;
   holdouts?: Record<string, FeatureDefinition>;
   experiments: AutoExperiment[];
-  savedGroupsInUse: string[]; // The ids of saved groups to be pulled from Mongo before returning the SDK payload
+  savedGroupsInUse?: string[]; // The ids of saved groups to be pulled from Mongo before returning the SDK payload
 };
 
 interface DOMMutation {

--- a/packages/front-end/components/SavedGroups/SavedGroupForm.tsx
+++ b/packages/front-end/components/SavedGroups/SavedGroupForm.tsx
@@ -112,7 +112,7 @@ const SavedGroupForm: FC<{
               form.setValue("condition", c);
               forceConditionRender();
             },
-            false,
+            true,
             groupMap,
           );
           if (conditionRes.empty) {


### PR DESCRIPTION
### Features and Changes

In #4990 we accidentally disabled front-end JSON validation on the Saved Groups condition input.  Back-end validation was still in place, so not a huge deal - the error message and UX were just not as good.

Also correcting an invalid typescript type that led to the bug in #5023 just to avoid any future problems.