### PR TITLE
up memory for running tests

### DIFF
--- a/packages/back-end/package.json
+++ b/packages/back-end/package.json
@@ -16,7 +16,7 @@
     "start:with-tracing": "node --require ./dist/tracing.opentelemetry.js dist/server.js",
     "start:with-datadog": "node --require ./dist/tracing.datadog.js dist/server.js",
     "repl": "node --require ts-node/register/transpile-only --experimental-repl-await repl",
-    "test": "DISABLE_PYTHON_MONITOR=true GB_STATS_ENGINE_MIN_POOL_SIZE=0 NODE_OPTIONS='--no-node-snapshot' jest --forceExit --verbose --detectOpenHandles",
+    "test": "DISABLE_PYTHON_MONITOR=true GB_STATS_ENGINE_MIN_POOL_SIZE=0 NODE_OPTIONS='--no-node-snapshot --max-old-space-size=8192' jest --forceExit --verbose --detectOpenHandles",
     "type-check": "tsc --pretty --noEmit",
     "unused-export-check": "npx ts-unused-exports tsconfig.json --findCompletelyUnusedFiles --allowUnusedTypes --showLineNumber",
     "generate-dummy-data": "ts-node ./test/data-generator/new-generator.ts",


### PR DESCRIPTION
### Features and Changes
We are sometimes running out of memory in tests.  Running the yarn test command with  `--logHeapUsage` doesn't show any one test being a main cause, and heap usage increases after every test run, and ends up being around 4GB.  

### Testing
Se `yarn test` succeed.

