### PR TITLE
Fix (Add a Presentation Modal): add back button and clickable tabs/navs

### DIFF
--- a/packages/front-end/components/Share/ShareModal.tsx
+++ b/packages/front-end/components/Share/ShareModal.tsx
@@ -488,14 +488,14 @@ const ShareModal = ({
       submit={submitForm}
       cta="Save"
       closeCta="Cancel"
-      navStyle="underlined"
-      navFill={true}
+      navStyle="default"
       size="max"
       step={step}
       setStep={setStep}
+      backButton={true}
     >
       <Page display="Select Experiments">
-        <div className="row new-share">
+        <div className="row new-share mt-4">
           <div className="col-sm-12 col-md-4 mb-5">
             <h4>Selected experiments to share</h4>
             <div className="selected-area h-100">
@@ -681,7 +681,7 @@ const ShareModal = ({
           </div>
         </Page> */}
       <Page display="Presentation Options">
-        <div className="row new-share">
+        <div className="row new-share mt-4">
           <div className="col-sm-12 col-md-6">
             <div className="form-group row">
               <label


### PR DESCRIPTION
### Features and Changes

 "**Add a Presentation**" modal have few fixes regarding going back and switching navs/tabs (Bad User Experience).

- When user select **no experiment** moving to next nav **(2. Presentation Options)** but can't go back to previous nav **"(1. Select Experiments)"** no back button even navs also non-clickable. After closing modal and reopen same nav selected still can't go back to select experiment. 
- Improvements: **Back Button** + **Clickable Navs** + **Spacing above Tab Content** (For better user experience and consistency through app)

### Screenshots
**Before**
<img width="1575" height="741" alt="new presentation modal consistency for back or previous page - before" src="https://github.com/user-attachments/assets/f9a0ffe2-0a2d-4f7d-8807-a133ee866f67" />

**After**
<img width="1586" height="739" alt="new presentation modal consistency for back or previous page - after" src="https://github.com/user-attachments/assets/6ca2eb5b-9acd-4800-91e7-4296019b3b3d" />

