### PR TITLE
fix(mixpanel): issue with negative metric delays applying to wrong metrics

### DIFF
--- a/packages/back-end/src/integrations/Mixpanel.ts
+++ b/packages/back-end/src/integrations/Mixpanel.ts
@@ -292,7 +292,6 @@ export default class Mixpanel implements SourceIntegrationInterface {
                 : "",
             )
             .join("\n")}
-            : ""
         });
         state.queuedEvents = [];`
             : ""


### PR DESCRIPTION
### Features and Changes

This fix addresses a bug in the Mixpanel integration where metrics with negative delays (pre-exposure windows) were incorrectly affecting other metrics in the same experiment analysis.

Only if there are negative metric delays does the issue occur: for negative metric delays, we were filtering a list before using indices in that list to refer to metrics, instead we need to use the original index from the unfiltered list.

For proportion metrics, this would only have overcounted some events incorrectly, but it could have had other errors for non-proportion metrics.

- Closes **(add link to issue here)**

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

<!--
  Please describe how to test these changes.
 -->

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
