### PR TITLE
Fix cached payload encryption

### DIFF
--- a/packages/back-end/src/services/features.ts
+++ b/packages/back-end/src/services/features.ts
@@ -659,7 +659,9 @@ export async function refreshSDKPayloadCache({
           experiments: experimentsDefinitions || [],
           holdouts: holdoutFeatureDefinitions || {},
           dateUpdated: new Date(),
-          encryptionKey: connection.encryptionKey,
+          encryptionKey: connection.encryptPayload
+            ? connection.encryptionKey
+            : undefined,
           includeVisualExperiments: connection.includeVisualExperiments,
           includeDraftExperiments: connection.includeDraftExperiments,
           includeExperimentNames: connection.includeExperimentNames,


### PR DESCRIPTION
### Features and Changes

In the new SDK payload cache (not being used yet), all payloads are being encrypted even when `encryptPayload` is set to false.