### PR TITLE
[performance] Have Definitions Context load Saved Groups without Values.

### DIFF
--- a/packages/back-end/src/models/SavedGroupModel.ts
+++ b/packages/back-end/src/models/SavedGroupModel.ts
@@ -1,6 +1,9 @@
 import mongoose from "mongoose";
 import uniqid from "uniqid";
-import { SavedGroupInterface } from "shared/types/groups";
+import {
+  SavedGroupInterface,
+  SavedGroupWithoutValues,
+} from "shared/types/groups";
 import { ApiSavedGroup } from "shared/types/openapi";
 import {
   CreateSavedGroupProps,
@@ -87,6 +90,25 @@ export async function getAllSavedGroups(
     .toArray();
 
   return savedGroups.map(toInterface);
+}
+
+export async function getAllSavedGroupsWithoutValues(
+  organization: string,
+): Promise<SavedGroupWithoutValues[]> {
+  const savedGroups = await getCollection(COLLECTION)
+    .find(
+      {
+        organization,
+      },
+      {
+        projection: {
+          values: 0,
+        },
+      },
+    )
+    .toArray();
+
+  return savedGroups.map(toInterface) as SavedGroupWithoutValues[];
 }
 
 export async function getSavedGroupById(

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -82,7 +82,7 @@ import {
   sendOwnerEmailChangeEmail,
 } from "back-end/src/services/email";
 import { getDataSourcesByOrganization } from "back-end/src/models/DataSourceModel";
-import { getAllSavedGroups } from "back-end/src/models/SavedGroupModel";
+import { getAllSavedGroupsWithoutValues } from "back-end/src/models/SavedGroupModel";
 import { getMetricsByOrganization } from "back-end/src/models/MetricModel";
 import {
   createOrganization,
@@ -183,7 +183,7 @@ export async function getDefinitions(req: AuthRequest, res: Response) {
     context.models.segments.getAll(),
     context.models.metricGroups.getAll(),
     getAllTags(orgId),
-    getAllSavedGroups(orgId),
+    getAllSavedGroupsWithoutValues(orgId),
     context.models.customFields.getCustomFields(),
     context.models.projects.getAll(),
     getAllFactTablesForOrganization(context),

--- a/packages/front-end/components/Features/ConditionDisplay/index.tsx
+++ b/packages/front-end/components/Features/ConditionDisplay/index.tsx
@@ -2,7 +2,7 @@ import stringify from "json-stringify-pretty-compact";
 import { ReactNode, useMemo } from "react";
 import { FeaturePrerequisite, SavedGroupTargeting } from "shared/types/feature";
 import { isDefined } from "shared/util";
-import { SavedGroupInterface } from "shared/types/groups";
+import { SavedGroupWithoutValues } from "shared/types/groups";
 import { Flex, Text } from "@radix-ui/themes";
 import { PiArrowSquareOut } from "react-icons/pi";
 import { useDefinitions } from "@/services/DefinitionsContext";
@@ -85,7 +85,7 @@ function hasMultiValues(operator: string) {
 function getValue(
   operator: string,
   value: string,
-  savedGroups?: SavedGroupInterface[],
+  savedGroups?: SavedGroupWithoutValues[],
 ): string {
   if (operator === "$true") return "TRUE";
   if (operator === "$false") return "FALSE";
@@ -214,7 +214,7 @@ function getConditionParts({
   keyPrefix = "",
 }: {
   conditions: ConditionWithParentId[];
-  savedGroups?: SavedGroupInterface[];
+  savedGroups?: SavedGroupWithoutValues[];
   initialAnd?: boolean;
   renderPrerequisite?: boolean;
   keyPrefix?: string;

--- a/packages/front-end/components/SavedGroups/ConditionGroups.tsx
+++ b/packages/front-end/components/SavedGroups/ConditionGroups.tsx
@@ -1,7 +1,10 @@
 import { useMemo, useState } from "react";
 import Link from "next/link";
 import { ago } from "shared/dates";
-import { SavedGroupInterface } from "shared/types/groups";
+import {
+  SavedGroupInterface,
+  SavedGroupWithoutValues,
+} from "shared/types/groups";
 import {
   experimentsReferencingSavedGroups,
   featuresReferencingSavedGroups,
@@ -28,7 +31,7 @@ import TruncatedConditionDisplay from "./TruncatedConditionDisplay";
 import SavedGroupForm from "./SavedGroupForm";
 
 export interface Props {
-  groups: SavedGroupInterface[];
+  groups: SavedGroupWithoutValues[];
   mutate: () => void;
 }
 
@@ -80,7 +83,7 @@ export default function ConditionGroups({ groups, mutate }: Props) {
   );
 
   const referencingSavedGroupsByGroup = useMemo(() => {
-    const result: Record<string, SavedGroupInterface[]> = {};
+    const result: Record<string, SavedGroupWithoutValues[]> = {};
     filteredConditionGroups.forEach((targetGroup) => {
       result[targetGroup.id] = conditionGroups.filter((sg) => {
         if (sg.id === targetGroup.id) return false;

--- a/packages/front-end/components/SavedGroups/IdLists.tsx
+++ b/packages/front-end/components/SavedGroups/IdLists.tsx
@@ -7,7 +7,10 @@ import {
   truncateString,
 } from "shared/util";
 import Link from "next/link";
-import { SavedGroupInterface } from "shared/types/groups";
+import {
+  SavedGroupInterface,
+  SavedGroupWithoutValues,
+} from "shared/types/groups";
 import { FaMagnifyingGlass } from "react-icons/fa6";
 import { isEmpty } from "lodash";
 import { Box } from "@radix-ui/themes";
@@ -31,7 +34,7 @@ import { useExperiments } from "@/hooks/useExperiments";
 import SavedGroupForm from "./SavedGroupForm";
 
 export interface Props {
-  groups: SavedGroupInterface[];
+  groups: SavedGroupWithoutValues[];
   mutate: () => void;
 }
 
@@ -91,7 +94,7 @@ export default function IdLists({ groups, mutate }: Props) {
   );
 
   const referencingSavedGroupsByGroup = useMemo(() => {
-    const result: Record<string, SavedGroupInterface[]> = {};
+    const result: Record<string, SavedGroupWithoutValues[]> = {};
     filteredIdLists.forEach((targetGroup) => {
       result[targetGroup.id] = conditionGroups.filter((sg) => {
         if (!sg.condition) return false;

--- a/packages/front-end/components/SavedGroups/SavedGroupReferencesList.tsx
+++ b/packages/front-end/components/SavedGroups/SavedGroupReferencesList.tsx
@@ -4,7 +4,7 @@ import {
   ExperimentInterface,
   ExperimentInterfaceStringDates,
 } from "shared/types/experiment";
-import { SavedGroupInterface } from "shared/types/groups";
+import { SavedGroupWithoutValues } from "shared/types/groups";
 import { Box, Flex, Heading } from "@radix-ui/themes";
 import { PiCaretRightFill } from "react-icons/pi";
 import Collapsible from "react-collapsible";
@@ -14,7 +14,7 @@ import Badge from "@/ui/Badge";
 interface SavedGroupReferencesListProps {
   features?: FeatureInterface[];
   experiments?: Array<ExperimentInterface | ExperimentInterfaceStringDates>;
-  savedGroups?: SavedGroupInterface[];
+  savedGroups?: SavedGroupWithoutValues[];
 }
 
 const SavedGroupReferencesList: FC<SavedGroupReferencesListProps> = ({

--- a/packages/front-end/pages/attributes.tsx
+++ b/packages/front-end/pages/attributes.tsx
@@ -6,7 +6,7 @@ import { BiHide, BiShow } from "react-icons/bi";
 import { BsXCircle } from "react-icons/bs";
 import { FeatureInterface } from "shared/validators";
 import { ExperimentInterfaceStringDates } from "shared/types/experiment";
-import { SavedGroupInterface } from "shared/types/groups";
+import { SavedGroupWithoutValues } from "shared/types/groups";
 import Tooltip from "@/components/Tooltip/Tooltip";
 import MoreMenu from "@/components/Dropdown/MoreMenu";
 import { useAuth } from "@/services/auth";
@@ -104,7 +104,7 @@ const FeatureAttributesPage = (): React.ReactElement => {
         string,
         ExperimentInterfaceStringDates[]
       > = {};
-      const attributeGroups: Record<string, SavedGroupInterface[]> = {};
+      const attributeGroups: Record<string, SavedGroupWithoutValues[]> = {};
 
       attributeKeys.forEach((a) => {
         attributeFeatures[a] = [...(attributeFeatureIds?.[a] ?? [])]
@@ -115,7 +115,7 @@ const FeatureAttributesPage = (): React.ReactElement => {
           .filter(Boolean) as ExperimentInterfaceStringDates[];
         attributeGroups[a] = [...(attributeGroupIds?.[a] ?? [])]
           .map((gid) => savedGroups.find((group) => group.id === gid))
-          .filter(Boolean) as SavedGroupInterface[];
+          .filter(Boolean) as SavedGroupWithoutValues[];
       });
 
       return { attributeFeatures, attributeExperiments, attributeGroups };

--- a/packages/front-end/pages/saved-groups/index.tsx
+++ b/packages/front-end/pages/saved-groups/index.tsx
@@ -1,6 +1,9 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/router";
-import { SavedGroupInterface } from "shared/types/groups";
+import {
+  SavedGroupInterface,
+  SavedGroupWithoutValues,
+} from "shared/types/groups";
 import { PiArrowSquareOut } from "react-icons/pi";
 import { FeatureInterface } from "shared/types/feature";
 import {
@@ -104,8 +107,8 @@ export default function SavedGroupsPage() {
   const { apiCall } = useAuth();
   const attributeSchema = useAttributeSchema();
   const [idLists, conditionGroups] = useMemo(() => {
-    const idLists: SavedGroupInterface[] = [];
-    const conditionGroups: SavedGroupInterface[] = [];
+    const idLists: SavedGroupWithoutValues[] = [];
+    const conditionGroups: SavedGroupWithoutValues[] = [];
     savedGroups.forEach((savedGroup) => {
       if (savedGroup.type === "condition") {
         conditionGroups.push(savedGroup);

--- a/packages/front-end/services/DefinitionsContext.tsx
+++ b/packages/front-end/services/DefinitionsContext.tsx
@@ -19,7 +19,7 @@ import {
   FactTableInterface,
 } from "shared/types/fact-table";
 import { ExperimentMetricInterface, isFactMetricId } from "shared/experiments";
-import { SavedGroupInterface } from "shared/types/groups";
+import { SavedGroupWithoutValues } from "shared/types/groups";
 import { MetricGroupInterface } from "shared/types/metric-groups";
 import { CustomField } from "shared/types/custom-fields";
 import { DecisionCriteriaInterface } from "shared/types/experiment";
@@ -37,7 +37,7 @@ type Definitions = {
   dimensions: DimensionInterface[];
   segments: SegmentInterface[];
   projects: ProjectInterface[];
-  savedGroups: SavedGroupInterface[];
+  savedGroups: SavedGroupWithoutValues[];
   metricGroups: MetricGroupInterface[];
   customFields: CustomField[];
   tags: TagInterface[];
@@ -61,7 +61,7 @@ type DefinitionContextValue = Definitions & {
   getDimensionById: (id: string) => null | DimensionInterface;
   getSegmentById: (id: string) => null | SegmentInterface;
   getProjectById: (id: string) => null | ProjectInterface;
-  getSavedGroupById: (id: string) => null | SavedGroupInterface;
+  getSavedGroupById: (id: string) => null | SavedGroupWithoutValues;
   getTagById: (id: string) => null | TagInterface;
   getFactTableById: (id: string) => null | FactTableInterface;
   getFactMetricById: (id: string) => null | FactMetricInterface;

--- a/packages/shared/types/groups.d.ts
+++ b/packages/shared/types/groups.d.ts
@@ -27,3 +27,6 @@ export interface SavedGroupInterface {
   useEmptyListGroup?: boolean;
 }
 export type SavedGroupType = "condition" | "list";
+
+// Omit large values array for performance on the front-end
+export type SavedGroupWithoutValues = Omit<SavedGroupInterface, "values">;


### PR DESCRIPTION
### Features and Changes

Some Saved Groups values are > 1MB.  The front-end doesn't use them on the list page.  

### Testing

- Add a saved group
- Add a saved group dependent on the first
- Edit the first to try and make it dependent on the second and see the cyclical detection warning.
