### PR TITLE
hotfix: Only save prompts if the form is dirty

### DIFF
--- a/packages/front-end/pages/settings/index.tsx
+++ b/packages/front-end/pages/settings/index.tsx
@@ -523,7 +523,10 @@ const GeneralSettingsPage = (): React.ReactElement => {
                 setSubmitError(null);
                 if (!ctaEnabled) return;
                 await saveSettings();
-                await savePrompts();
+                // Only save prompts if the prompt form has changes
+                if (promptForm.formState.isDirty) {
+                  await savePrompts();
+                }
               }}
               setError={setSubmitError}
             >


### PR DESCRIPTION
### Features and Changes

On the general settings page it was trying to save the prompts when the ai tab hadn't loaded and set the prompt values.  That ended up throwing an error.  That is now done only if the prompts form is dirty.

### Testing
Go to any non-ai testing tab of the page.
Refresh the page.
Click save all.
See success.
