### PR TITLE
Add proxy configuration explicitly for calls to jwksUri.

### DIFF
--- a/packages/back-end/src/services/auth/OpenIdAuthConnection.ts
+++ b/packages/back-end/src/services/auth/OpenIdAuthConnection.ts
@@ -33,7 +33,6 @@ import {
   VERCEL_CLIENT_SECRET,
 } from "back-end/src/services/vercel-native-integration.service";
 import { AuthConnection, TokensResponse } from "./AuthConnection";
-import { HttpsProxyAgent } from 'https-proxy-agent';
 
 type AuthChecks = {
   connection_id: string;
@@ -182,7 +181,6 @@ export class OpenIdAuthConnection implements AuthConnection {
 
       let middleware = jwksMiddlewareCache[cacheKey];
       if (!middleware) {
-        const proxy = process.env.HTTPS_PROXY;
         middleware = jwtExpress({
           secret: jwks.expressJwtSecret({
             cache: true,
@@ -191,7 +189,7 @@ export class OpenIdAuthConnection implements AuthConnection {
             rateLimit: false,
             jwksRequestsPerMinute: 10,
             jwksUri,
-            requestAgent: proxy ? new HttpsProxyAgent(proxy) : undefined,
+            requestAgent: getHttpOptions().agent,
           }),
           audience: connection.clientId,
           issuer,


### PR DESCRIPTION


### Features and Changes

Commit 8c00ce4418d13e0bd1fb550416851f692d9eb5d6 upgraded jwks-rsa from 1.8.0 to 2.1.5.

This update empirically removed automatic support for respecting proxy configurations specified through the env var HTTP_PROXY.

The release notes for v2.0.0 mention how to specify a proxy explicitly.

https://github.com/auth0/node-jwks-rsa/releases/tag/v2.0.0

This commit updates growthbook to respect proxies again, restoring the functionality that was lost during the upgrade.

### Testing

This change was tested by attempting to deploy in an environment where a proxy is necessary for `OpenIdAuthConnection`.
In such an environment, Growthbook outputs the error `read ECONNRESET` at the tip of master and fails to load.
With this change, Growthbook loads normally.