### PR TITLE
Bump snowflake-sdk to 2.3.3.

### DIFF
--- a/packages/back-end/package.json
+++ b/packages/back-end/package.json
@@ -115,7 +115,7 @@
     "saslprep": "^1.0.0",
     "scim2-parse-filter": "^0.2.8",
     "shared": "0.0.1",
-    "snowflake-sdk": "2.3.1",
+    "snowflake-sdk": "2.3.3",
     "ssrf-req-filter": "^1.1.1",
     "string-env-interpolation": "^1.0.1",
     "stripe": "^17.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16345,7 +16345,7 @@ glob@7.1.7:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^10.0.0, glob@^10.2.2, glob@^10.3.10, glob@^10.4.1:
+glob@^10.2.2, glob@^10.3.10, glob@^10.4.1:
   version "10.5.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-10.5.0.tgz#8ec0355919cd3338c28428a23d4f24ecc5fe738c"
   integrity sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==
@@ -23455,10 +23455,10 @@ snake-case@^3.0.4:
     dot-case "^3.0.4"
     tslib "^2.0.3"
 
-snowflake-sdk@2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/snowflake-sdk/-/snowflake-sdk-2.3.1.tgz#6921bb9bf1d7d4c3794f99230cbdc8f0abb5571c"
-  integrity sha512-4XRwiazsq35DLRy737er2/Q5revfH+PAw56ClS1X3cbYGWI2koCfcHQ8FYQ4gn/utMObQ8fQRsbICBMw7LpO5g==
+snowflake-sdk@2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/snowflake-sdk/-/snowflake-sdk-2.3.3.tgz#611b559ce19ab994af8e103c71d1b626aa10ea0f"
+  integrity sha512-ILuI762MUjbWZ2COzdCewtrU5ANKVWQWfJnz2UNhwgLVpbl/rHZg4ZfMTiSkcS6Qqos7qSD4FK6gORaOaCQNSQ==
   dependencies:
     "@aws-crypto/sha256-js" "^5.2.0"
     "@aws-sdk/client-s3" "^3.726.0"
@@ -23483,7 +23483,6 @@ snowflake-sdk@2.3.1:
     fast-xml-parser "^4.2.5"
     fastest-levenshtein "^1.0.16"
     generic-pool "^3.8.2"
-    glob "^10.0.0"
     google-auth-library "^10.1.0"
     https-proxy-agent "^7.0.2"
     jsonwebtoken "^9.0.0"


### PR DESCRIPTION
### Features and Changes

Commit f270ed3072e8b737cfbd83b33f20d0cf42d8b554 moved to snowflake-sdk to 2.3.1 which includes a broken SnowflakeHttpsProxyAgent constructor call.

This commit bumps snowflake-sdk to 2.3.3, which fixes that bug.
