### PR TITLE
Ls/only use original queries for cache

### DIFF
--- a/packages/back-end/src/models/QueryModel.ts
+++ b/packages/back-end/src/models/QueryModel.ts
@@ -153,6 +153,7 @@ export async function getRecentQuery(
   organization: string,
   datasource: string,
   query: string,
+  onlyOriginalQueries: boolean = true,
 ) {
   // Only re-use queries that were run recently
   const earliestDate = new Date();
@@ -166,6 +167,8 @@ export async function getRecentQuery(
       $gt: earliestDate,
     },
     status: { $in: ["succeeded", "running"] },
+    // Exclude documents that were created from cache - they shouldn't reset the TTL
+    ...(onlyOriginalQueries && { cachedQueryUsed: { $exists: false } }),
   })
     .sort({ createdAt: -1 })
     .limit(1);


### PR DESCRIPTION
### Features and Changes

When creating a new query document that used the cache for results, we effectively we re-setting the TTL on the cache. If you clicked the update button within the TTL and the query was unchanged, you never would get new data.

This changes that by only pulling in "original" (e.g. queries that didnt use the cache) documents when trying to use the cache, effectively preserving the TTL.

I think this is fine for still retrieving the old results because even though we now skip the intermediate documents that hit the cache, we previously had to ensure that `cachedQueryUsed` passed forward from the original query. This should, I think, negate the need for that feature of `cachedQueryUsed`, but it's fine to keep it around to mark whether or not a query doc was original or pulled from the cache.

- Closes **(add link to issue here)**

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

TODO

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
