### PR TITLE
chore(app): Add robots.txt

### DIFF
--- a/packages/front-end/public/robots.txt
+++ b/packages/front-end/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
### Features and Changes

While we want our main website `www.growthbook.io` and `docs` to be indexed, `app.growthbook.io` is more private focused and we want to make sure that if public report links get shared they are not unintentionally indexed by search engines.

So disallowing all robots for the subdomain `app` for now.