### PR TITLE
Add missing index for safe rollout snapshots

### DIFF
--- a/packages/back-end/src/models/SafeRolloutSnapshotModel.ts
+++ b/packages/back-end/src/models/SafeRolloutSnapshotModel.ts
@@ -20,6 +20,17 @@ const BaseClass = MakeModelClass({
   collectionName: "saferolloutsnapshots",
   idPrefix: "srsnp_",
   globallyUniqueIds: true,
+  additionalIndexes: [
+    {
+      fields: {
+        organization: 1,
+        safeRolloutId: 1,
+        dimension: 1,
+        status: 1,
+        dateCreated: -1,
+      },
+    },
+  ],
 });
 
 export class SafeRolloutSnapshotModel extends BaseClass {


### PR DESCRIPTION
### Features and Changes

Safe rollouts do a complicated Mongo query to look up the latest snapshot.  This PR adds a Mongo index for this.  It will help with performance, but most importantly, this should also fix errors from CosmosDB and other mongo-compatible databases that require indexes on all query/sort fields.