### PR TITLE
Fix tests locally

### DIFF
--- a/packages/back-end/test/api/api.setup.ts
+++ b/packages/back-end/test/api/api.setup.ts
@@ -51,8 +51,9 @@ export const setupApp = () => {
 
       await mongoInit();
       await queueInit();
+
       // This seems to help:
-      setTimeout(resolve, 100);
+      setTimeout(resolve, 400);
     }, 60000); // Increase timeout to 60s for CI environment
 
     afterAll(async () => {

--- a/packages/back-end/test/jest.setup.ts
+++ b/packages/back-end/test/jest.setup.ts
@@ -1,3 +1,9 @@
 // Polyfill web streams for Node.js test environment
 import { TransformStream } from "node:stream/web";
 global.TransformStream = TransformStream as typeof globalThis.TransformStream;
+
+// Mock snowflake-sdk to prevent open handles from CustomGC
+jest.mock("snowflake-sdk", () => ({
+  createConnection: jest.fn(),
+  configure: jest.fn(),
+}));


### PR DESCRIPTION
### Features and Changes

After pnpm change landed setting up api seemed to take longer.  In ci increasing the test timeout seemed to work, but locally it gave this error:

```
AIL  test/api/environments.test.ts
  ● environements API › can update environments
MongoServerError: ns does not exist: test.metrictimeseries
  at Connection.onMessage (../../node_modules/.pnpm/mongodb@4.17.2/node_modules/mongodb/src/cmap/connection.ts:449:20)
  at MessageStream.<anonymous> (../../node_modules/.pnpm/mongodb@4.17.2/node_modules/mongodb/src/cmap/connection.ts:241:56)
  at processIncomingData (../../node_modules/.pnpm/mongodb@4.17.2/node_modules/mongodb/src/cmap/message_stream.ts:188:12)
  at MessageStream._write (../../node_modules/.pnpm/mongodb@4.17.2/node_modules/mongodb/src/cmap/message_stream.ts:69:5)
```

Furthermore jest complained about an open handle from within the snowflake-sdk package.  By mocking createConnection and configure it fixes that issue.  

### Testing
`yarn test` locally
