### PR TITLE
Remove benchmarks directories from docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,8 @@ RUN \
   && find node_modules -name "*.map" -delete \
   && find node_modules -name "CHANGELOG*" -delete \
   && find node_modules -name "LICENSE*" -delete \
-  && find node_modules -name "README*" -delete
+  && find node_modules -name "README*" -delete \
+  && find node_modules -type d -name benchmarks -prune -exec rm -rf {} +
 RUN pnpm postinstall
 
 


### PR DESCRIPTION
### Features and Changes
[AWS security scan](https://us-east-1.console.aws.amazon.com/inspector/v2/home?region=us-east-1#/findings?by=all&findingArn=arn:aws:inspector2:us-east-1:476680172222:finding/6c0875bb5eff231de5a786d833cc4aba) still complained about form-data even though we pinned it because it was looking at /usr/local/src/app/node_modules/.pnpm/tedious@16.7.1/node_modules/tedious/benchmarks/package-lock.json.  The form-data versions there don't get installed, so it is an incorrect warning.

To get rid of it we delete all "benchmarks" directories from node-modules.  This seems safe enough.  I can't image a benchmarks directory having a production use case.

### Test Plan
Ran the command locally
`ls node_modules/.pnpm/tedious@16.7.1/node_modules/tedious/benchmarks/package-lock.json`  showed no results afterwards