### PR TITLE
refactor: Extract SQL generation modules from SqlIntegration.ts

### DIFF
--- a/packages/back-end/src/integrations/sql-builders/cte-builders/identities.ts
+++ b/packages/back-end/src/integrations/sql-builders/cte-builders/identities.ts
@@ -1,0 +1,251 @@
+/**
+ * Identity CTE Builder
+ *
+ * Pure functions for generating identity join SQL CTEs.
+ * Extracted from SqlIntegration.ts for better testability and reuse.
+ *
+ * Identity CTEs are used to join different user ID types together
+ * (e.g., user_id to anonymous_id) when queries need data from tables
+ * that use different identifier types.
+ */
+
+import { DataSourceSettings } from "shared/types/datasource";
+import { getBaseIdTypeAndJoins, compileSqlTemplate } from "back-end/src/util/sql";
+
+/**
+ * Interface for SQL generation methods needed by identity CTE builder.
+ * This allows the function to be pure while still using dialect-specific SQL.
+ */
+export interface IdentitiesCTEDialect {
+  /**
+   * Generate an identity join query between two user ID types.
+   * @param settings - Datasource settings with identity join configuration
+   * @param id1 - First user ID type (typically the base ID type)
+   * @param id2 - Second user ID type to join to
+   * @param from - Start date for the query
+   * @param to - End date for the query (optional)
+   * @param experimentId - Optional experiment ID for template variables
+   * @returns SQL query string for the identity join
+   */
+  getIdentitiesQuery(
+    settings: DataSourceSettings,
+    id1: string,
+    id2: string,
+    from: Date,
+    to: Date | undefined,
+    experimentId?: string
+  ): string;
+}
+
+/**
+ * Parameters for building the identities CTE.
+ */
+export interface IdentitiesCTEParams {
+  /**
+   * Arrays of user ID types needed by different objects (metrics, segments, etc.)
+   * Each inner array represents the user ID types supported by one object.
+   */
+  objects: string[][];
+
+  /** Start date for the identity join query */
+  from: Date;
+
+  /** End date for the identity join query (optional) */
+  to?: Date;
+
+  /**
+   * Force a specific base ID type instead of auto-detecting.
+   * Useful when the exposure query already determines the user ID type.
+   */
+  forcedBaseIdType?: string;
+
+  /** Optional experiment ID for template variable substitution */
+  experimentId?: string;
+}
+
+/**
+ * Result of building the identities CTE.
+ */
+export interface IdentitiesCTEResult {
+  /**
+   * The base user ID type that all other IDs will be joined to.
+   * Either the forced type or the most commonly used type across objects.
+   */
+  baseIdType: string;
+
+  /**
+   * SQL string containing the CTE definitions for identity joins.
+   * Format: `__identities_<idtype> as (...), ...`
+   */
+  idJoinSQL: string;
+
+  /**
+   * Map from user ID type to the CTE table name that provides the join.
+   * Example: { "anonymous_id": "__identities_anonymous_id" }
+   */
+  idJoinMap: Record<string, string>;
+}
+
+/**
+ * Build identity join CTEs for matching different user ID types.
+ *
+ * When a query needs to join data from multiple sources that use different
+ * user ID types (e.g., metrics using user_id and exposures using anonymous_id),
+ * this function generates the necessary identity join CTEs.
+ *
+ * The algorithm:
+ * 1. Determine the base ID type (most common or forced)
+ * 2. Find which ID types need joins (objects that don't support base type)
+ * 3. Generate a CTE for each required join
+ *
+ * @param dialect - SQL dialect implementation with identity query generation
+ * @param settings - Datasource settings with identity join configuration
+ * @param params - Parameters including objects, date range, and optional forcing
+ * @returns Result with baseIdType, SQL string, and join table mapping
+ *
+ * @example
+ * const result = buildIdentitiesCTE(dialect, settings, {
+ *   objects: [
+ *     ["user_id"],           // Exposure query uses user_id
+ *     ["anonymous_id"],       // Metric uses anonymous_id
+ *   ],
+ *   from: new Date("2023-01-01"),
+ *   to: new Date("2023-01-31"),
+ * });
+ * // result.baseIdType = "user_id"
+ * // result.idJoinMap = { "anonymous_id": "__identities_anonymous_id" }
+ * // result.idJoinSQL = "__identities_anonymous_id as (SELECT user_id, anonymous_id FROM ...),"
+ */
+export function buildIdentitiesCTE(
+  dialect: IdentitiesCTEDialect,
+  settings: DataSourceSettings,
+  params: IdentitiesCTEParams
+): IdentitiesCTEResult {
+  const { objects, from, to, forcedBaseIdType, experimentId } = params;
+
+  // Determine base ID type and which joins are needed
+  const { baseIdType, joinsRequired } = getBaseIdTypeAndJoins(
+    objects,
+    forcedBaseIdType
+  );
+
+  // Build join CTEs for each required ID type
+  const joins: string[] = [];
+  const idJoinMap: Record<string, string> = {};
+
+  joinsRequired.forEach((idType) => {
+    // Sanitize the ID type for use in SQL table names
+    const sanitizedIdType = idType.replace(/[^a-zA-Z0-9_]/g, "");
+    const table = `__identities_${sanitizedIdType}`;
+    idJoinMap[idType] = table;
+
+    // Generate the CTE using the dialect's identity query method
+    const identityQuery = dialect.getIdentitiesQuery(
+      settings,
+      baseIdType,
+      idType,
+      from,
+      to,
+      experimentId
+    );
+
+    joins.push(
+      `${table} as (
+        ${identityQuery}
+      ),`
+    );
+  });
+
+  return {
+    baseIdType,
+    idJoinSQL: joins.join("\n"),
+    idJoinMap,
+  };
+}
+
+/**
+ * Generate an identity join query between two user ID types.
+ *
+ * This is the core logic extracted from SqlIntegration.getIdentitiesQuery.
+ * It looks for a matching identity join query in the datasource settings,
+ * or falls back to using the pageviews query if available.
+ *
+ * @param settings - Datasource settings with query configuration
+ * @param id1 - First user ID type (typically the base ID type)
+ * @param id2 - Second user ID type to join to
+ * @param from - Start date for the query
+ * @param to - End date for the query (optional)
+ * @param experimentId - Optional experiment ID for template variables
+ * @param timestampFilter - Function to generate timestamp filter SQL
+ * @returns SQL query string for the identity join
+ */
+export function generateIdentitiesQuery(
+  settings: DataSourceSettings,
+  id1: string,
+  id2: string,
+  from: Date,
+  to: Date | undefined,
+  experimentId: string | undefined,
+  timestampFilter: (col: string, from: Date, to: Date | undefined) => string
+): string {
+  // Check for configured identity join queries
+  if (settings?.queries?.identityJoins) {
+    for (let i = 0; i < settings.queries.identityJoins.length; i++) {
+      const join = settings?.queries?.identityJoins[i];
+      if (
+        join.query.length > 6 &&
+        join.ids.includes(id1) &&
+        join.ids.includes(id2)
+      ) {
+        return `
+          SELECT
+            ${id1},
+            ${id2}
+          FROM
+            (
+              ${compileSqlTemplate(join.query, {
+                startDate: from,
+                endDate: to,
+                experimentId,
+              })}
+            ) i
+          GROUP BY
+            ${id1}, ${id2}
+          `;
+      }
+    }
+  }
+
+  // Fallback to pageviews query for user_id/anonymous_id joins
+  if (settings?.queries?.pageviewsQuery) {
+    const timestampColumn = "i.timestamp";
+
+    if (
+      ["user_id", "anonymous_id"].includes(id1) &&
+      ["user_id", "anonymous_id"].includes(id2)
+    ) {
+      return `
+        SELECT
+          user_id,
+          anonymous_id
+        FROM
+          (${compileSqlTemplate(settings.queries.pageviewsQuery, {
+            startDate: from,
+            endDate: to,
+            experimentId,
+          })}) i
+        WHERE
+          ${timestampFilter(timestampColumn, from, to)}
+        GROUP BY
+          user_id, anonymous_id
+        `;
+    }
+  }
+
+  // If no matching query configuration found, return empty result
+  // The original implementation would throw or return incomplete SQL
+  throw new Error(
+    `No identity join query found for ${id1} and ${id2}. ` +
+      `Configure an identity join in your data source settings.`
+  );
+}

--- a/packages/back-end/src/integrations/sql-builders/cte-builders/index.ts
+++ b/packages/back-end/src/integrations/sql-builders/cte-builders/index.ts
@@ -1,0 +1,64 @@
+/**
+ * CTE Builders Module
+ *
+ * This module provides pure functions for generating SQL Common Table Expressions (CTEs)
+ * used in experiment analysis queries. These functions have been extracted from
+ * SqlIntegration.ts for better testability, reuse, and maintainability.
+ *
+ * Each CTE builder:
+ * - Takes a dialect object for database-specific SQL generation
+ * - Returns a SQL string fragment (the CTE body, without the "name AS (...)" wrapper)
+ * - Is pure (no side effects, deterministic output)
+ *
+ * CTE Types:
+ * - Identities: Join different user ID types together
+ * - Segments: Filter users to specific groups
+ * - Metrics: Calculate metric values from raw data
+ * - Statistics: Aggregate metric data for statistical analysis
+ */
+
+// ============================================================
+// Identities CTE Builder
+// ============================================================
+
+export {
+  buildIdentitiesCTE,
+  generateIdentitiesQuery,
+  type IdentitiesCTEDialect,
+  type IdentitiesCTEParams,
+  type IdentitiesCTEResult,
+} from "./identities";
+
+// ============================================================
+// Segments CTE Builder
+// ============================================================
+
+export {
+  buildSegmentCTE,
+  buildFactSegmentCTE,
+  type SegmentCTEDialect,
+  type FactSegmentCTEDialect,
+  type SegmentCTEParams,
+} from "./segments";
+
+// ============================================================
+// Metrics CTE Builder
+// ============================================================
+
+export {
+  buildMetricCTE,
+  buildFactMetricCTE,
+  type MetricCTEDialect,
+  type MetricCTEParams,
+  type FactMetricCTEParams,
+} from "./metrics";
+
+// ============================================================
+// Statistics CTE Builder
+// ============================================================
+
+export {
+  buildExperimentFactMetricStatisticsCTE,
+  type StatisticsCTEDialect,
+  type StatisticsCTEParams,
+} from "./statistics";

--- a/packages/back-end/src/integrations/sql-builders/cte-builders/metrics.ts
+++ b/packages/back-end/src/integrations/sql-builders/cte-builders/metrics.ts
@@ -1,0 +1,512 @@
+/**
+ * Metric CTE Builder
+ *
+ * Pure functions for generating metric SQL CTEs.
+ * Extracted from SqlIntegration.ts for better testability and reuse.
+ *
+ * Metrics are used to measure the impact of experiments. They can be:
+ * - Legacy metrics (SQL-based or query builder)
+ * - Fact metrics (based on fact tables with filters)
+ *
+ * The CTE builders handle:
+ * - SQL generation for different metric types
+ * - Identity joins when metric uses different user ID type
+ * - Date filtering and template variable substitution
+ * - Fact table filters and column expressions
+ */
+
+import {
+  ExperimentMetricInterface,
+  isFactMetric,
+  getUserIdTypes,
+  getMetricTemplateVariables,
+  getColumnRefWhereClause,
+  parseSliceMetricId,
+  isRatioMetric,
+} from "shared/experiments";
+import {
+  FactMetricInterface,
+  FactTableInterface,
+} from "shared/types/fact-table";
+import { PhaseSQLVar } from "shared/types/sql";
+import { FactTableMap } from "back-end/src/models/FactTableModel";
+import { compileSqlTemplate } from "back-end/src/util/sql";
+
+/**
+ * Interface for SQL generation methods needed by metric CTE builder.
+ */
+export interface MetricCTEDialect {
+  /** Cast a user-provided date column to the appropriate datetime type */
+  castUserDateCol(column: string): string;
+
+  /** Convert a Date to a SQL timestamp expression */
+  toTimestamp(date: Date): string;
+
+  /** Convert a Date to a SQL timestamp with millisecond precision */
+  toTimestampWithMs(date: Date): string;
+
+  /** Get the database schema prefix (if any) */
+  getSchema(): string;
+
+  /** Escape a string literal for SQL */
+  escapeStringLiteral(value: string): string;
+
+  /** Extract a field from a JSON column */
+  extractJSONField(jsonCol: string, path: string, isNumeric: boolean): string;
+
+  /** Evaluate a boolean expression in SQL */
+  evalBoolean(value: boolean): string;
+
+  /** Get metric query format ('sql', 'builder', or 'fact') */
+  getMetricQueryFormat(metric: ExperimentMetricInterface): "sql" | "builder";
+
+  /** Get metric columns (userIds, timestamp, value) */
+  getMetricColumns(
+    metric: ExperimentMetricInterface,
+    factTableMap: FactTableMap,
+    alias: string,
+    useDenominator?: boolean
+  ): {
+    userIds: Record<string, string>;
+    timestamp: string;
+    value: string;
+  };
+
+  /** Get fact metric column expression */
+  getFactMetricColumn(
+    metric: FactMetricInterface,
+    columnRef: FactMetricInterface["numerator"],
+    factTable: FactTableInterface,
+    alias: string
+  ): { value: string };
+}
+
+/**
+ * Parameters for building a metric CTE.
+ */
+export interface MetricCTEParams {
+  /** The metric to build a CTE for */
+  metric: ExperimentMetricInterface;
+
+  /** The base user ID type for the query */
+  baseIdType: string;
+
+  /** Map from user ID types to their identity join table names */
+  idJoinMap: Record<string, string>;
+
+  /** Start date for metric data */
+  startDate: Date;
+
+  /** End date for metric data (null means no upper bound) */
+  endDate: Date | null;
+
+  /** Optional experiment ID for template variables */
+  experimentId?: string;
+
+  /** Map of fact tables by ID */
+  factTableMap: FactTableMap;
+
+  /** Whether to use denominator for ratio metrics */
+  useDenominator?: boolean;
+
+  /** Optional phase information for template variables */
+  phase?: PhaseSQLVar;
+
+  /** Optional custom fields for template variables */
+  customFields?: Record<string, unknown>;
+}
+
+/**
+ * Parameters for building a fact metric CTE.
+ */
+export interface FactMetricCTEParams {
+  /** Array of metrics with their indices for column naming */
+  metricsWithIndices: { metric: FactMetricInterface; index: number }[];
+
+  /** The fact table to query */
+  factTable: FactTableInterface;
+
+  /** The base user ID type for the query */
+  baseIdType: string;
+
+  /** Map from user ID types to their identity join table names */
+  idJoinMap: Record<string, string>;
+
+  /** Start date for metric data */
+  startDate: Date;
+
+  /** End date for metric data (null means no upper bound) */
+  endDate: Date | null;
+
+  /** Optional experiment ID for template variables */
+  experimentId?: string;
+
+  /** Whether to add metric filters to WHERE clause */
+  addFiltersToWhere?: boolean;
+
+  /** Optional phase information for template variables */
+  phase?: PhaseSQLVar;
+
+  /** Optional custom fields for template variables */
+  customFields?: Record<string, unknown>;
+
+  /** Use exclusive (>) start date filter instead of inclusive (>=) */
+  exclusiveStartDateFilter?: boolean;
+
+  /** Use exclusive (<) end date filter instead of inclusive (<=) */
+  exclusiveEndDateFilter?: boolean;
+
+  /** Cast ID column to string */
+  castIdToString?: boolean;
+}
+
+/**
+ * Build a metric CTE for calculating metric values.
+ *
+ * This function generates SQL for querying metric data, handling:
+ * - Different metric formats (SQL, builder, fact)
+ * - Identity joins when needed
+ * - Date filtering
+ * - Template variable substitution
+ *
+ * @param dialect - SQL dialect implementation
+ * @param params - Parameters including metric, dates, and fact tables
+ * @returns SQL string for the metric CTE body
+ */
+export function buildMetricCTE(
+  dialect: MetricCTEDialect,
+  params: MetricCTEParams
+): string {
+  const {
+    metric,
+    baseIdType,
+    idJoinMap,
+    startDate,
+    endDate,
+    experimentId,
+    factTableMap,
+    useDenominator,
+    phase,
+    customFields,
+  } = params;
+
+  const cols = dialect.getMetricColumns(
+    metric,
+    factTableMap,
+    "m",
+    useDenominator
+  );
+
+  // Determine the identifier column to select from
+  let userIdCol = cols.userIds[baseIdType] || "user_id";
+  let join = "";
+
+  const userIdTypes = getUserIdTypes(metric, factTableMap, useDenominator);
+
+  const isFact = isFactMetric(metric);
+  const queryFormat = isFact ? "fact" : dialect.getMetricQueryFormat(metric);
+  const columnRef = isFact
+    ? useDenominator
+      ? metric.denominator
+      : metric.numerator
+    : null;
+
+  // For fact metrics with a WHERE clause
+  const factTable = isFact
+    ? factTableMap.get(columnRef?.factTableId || "")
+    : undefined;
+
+  if (isFact && !factTable) {
+    throw new Error("Could not find fact table");
+  }
+
+  // Query builder does not use a sub-query to get the userId column to
+  // equal the userIdType, so when using the query builder, continue to
+  // use the actual input column name rather than the id type
+  if (userIdTypes.includes(baseIdType)) {
+    userIdCol = queryFormat === "builder" ? userIdCol : baseIdType;
+  } else if (userIdTypes.length > 0) {
+    for (let i = 0; i < userIdTypes.length; i++) {
+      const userIdType: string = userIdTypes[i];
+      if (userIdType in idJoinMap) {
+        const metricUserIdCol =
+          queryFormat === "builder"
+            ? cols.userIds[userIdType]
+            : `m.${userIdType}`;
+        join = `JOIN ${idJoinMap[userIdType]} i ON (i.${userIdType} = ${metricUserIdCol})`;
+        userIdCol = `i.${baseIdType}`;
+        break;
+      }
+    }
+  }
+
+  // BQ datetime cast for SELECT statements (do not use for where)
+  const timestampDateTimeColumn = dialect.castUserDateCol(cols.timestamp);
+
+  const schema = dialect.getSchema();
+
+  const where: string[] = [];
+  let sql = "";
+
+  // From old, deprecated query builder UI
+  if (queryFormat === "builder" && !isFact && metric.conditions?.length) {
+    metric.conditions.forEach((c) => {
+      where.push(`m.${c.column} ${c.operator} '${c.value}'`);
+    });
+  }
+
+  // Add filters from the Metric
+  if (isFact && factTable && columnRef) {
+    const sliceInfo = parseSliceMetricId(metric.id);
+    getColumnRefWhereClause({
+      factTable,
+      columnRef,
+      escapeStringLiteral: dialect.escapeStringLiteral.bind(dialect),
+      jsonExtract: dialect.extractJSONField.bind(dialect),
+      evalBoolean: dialect.evalBoolean.bind(dialect),
+      sliceInfo,
+    }).forEach((filterSQL) => {
+      where.push(filterSQL);
+    });
+
+    sql = factTable.sql;
+  }
+
+  if (!isFact && queryFormat === "sql") {
+    sql = metric.sql || "";
+  }
+
+  // Add date filter
+  if (startDate) {
+    where.push(`${cols.timestamp} >= ${dialect.toTimestamp(startDate)}`);
+  }
+  if (endDate) {
+    where.push(`${cols.timestamp} <= ${dialect.toTimestamp(endDate)}`);
+  }
+
+  return compileSqlTemplate(
+    `-- Metric (${metric.name})
+      SELECT
+        ${userIdCol} as ${baseIdType},
+        ${cols.value} as value,
+        ${timestampDateTimeColumn} as timestamp
+      FROM
+        ${
+          queryFormat === "sql" || queryFormat === "fact"
+            ? `(
+              ${sql}
+            )`
+            : !isFact
+              ? (schema && !metric.table?.match(/\./) ? schema + "." : "") +
+                (metric.table || "")
+              : ""
+        } m
+        ${join}
+        ${where.length ? `WHERE ${where.join(" AND ")}` : ""}
+    `,
+    {
+      startDate,
+      endDate: endDate || undefined,
+      experimentId,
+      phase,
+      customFields,
+      templateVariables: getMetricTemplateVariables(
+        metric,
+        factTableMap,
+        useDenominator
+      ),
+    }
+  );
+}
+
+/**
+ * Build a fact metric CTE for calculating fact-based metric values.
+ *
+ * This function generates SQL for querying fact table data with:
+ * - Multiple metrics from the same fact table
+ * - Per-metric filters as CASE WHEN expressions
+ * - Identity joins when needed
+ * - Date filtering with inclusive/exclusive options
+ *
+ * @param dialect - SQL dialect implementation
+ * @param params - Parameters including metrics, fact table, and dates
+ * @returns SQL string for the fact metric CTE body
+ */
+export function buildFactMetricCTE(
+  dialect: MetricCTEDialect,
+  params: FactMetricCTEParams
+): string {
+  const {
+    metricsWithIndices,
+    factTable,
+    baseIdType,
+    idJoinMap,
+    startDate,
+    endDate,
+    experimentId,
+    addFiltersToWhere,
+    phase,
+    customFields,
+    exclusiveStartDateFilter,
+    exclusiveEndDateFilter,
+    castIdToString,
+  } = params;
+
+  // Determine if a join is required to match up id types
+  let join = "";
+  let userIdCol = "";
+  const userIdTypes = factTable.userIdTypes;
+
+  if (userIdTypes.includes(baseIdType)) {
+    userIdCol = baseIdType;
+  } else if (userIdTypes.length > 0) {
+    for (let i = 0; i < userIdTypes.length; i++) {
+      const userIdType: string = userIdTypes[i];
+      if (userIdType in idJoinMap) {
+        const metricUserIdCol = `m.${userIdType}`;
+        join = `JOIN ${idJoinMap[userIdType]} i ON (i.${userIdType} = ${metricUserIdCol})`;
+        userIdCol = `i.${baseIdType}`;
+        break;
+      }
+    }
+  }
+
+  // BQ datetime cast for SELECT statements (do not use for where)
+  const timestampDateTimeColumn = dialect.castUserDateCol("m.timestamp");
+
+  const sql = factTable.sql;
+  const where: string[] = [];
+
+  if (startDate) {
+    const operator = exclusiveStartDateFilter ? ">" : ">=";
+    const timestampFn = exclusiveStartDateFilter
+      ? dialect.toTimestampWithMs
+      : dialect.toTimestamp;
+    where.push(`m.timestamp ${operator} ${timestampFn(startDate)}`);
+  }
+  if (endDate) {
+    const operator = exclusiveEndDateFilter ? "<" : "<=";
+    const timestampFn = exclusiveEndDateFilter
+      ? dialect.toTimestampWithMs
+      : dialect.toTimestamp;
+    where.push(`m.timestamp ${operator} ${timestampFn(endDate)}`);
+  }
+
+  const metricCols: string[] = [];
+  const filterWhere: Set<string> = new Set();
+
+  let numberOfNumeratorsOrDenominatorsWithoutFilters = 0;
+
+  metricsWithIndices.forEach((metricWithIndex) => {
+    const m = metricWithIndex.metric;
+    const index = metricWithIndex.index;
+
+    // Get numerator if it matches the fact table
+    if (m.numerator?.factTableId === factTable.id) {
+      const value = dialect.getFactMetricColumn(
+        m,
+        m.numerator,
+        factTable,
+        "m"
+      ).value;
+
+      const sliceInfo = parseSliceMetricId(m.id, {
+        [factTable.id]: factTable,
+      });
+      const filters = getColumnRefWhereClause({
+        factTable,
+        columnRef: m.numerator,
+        escapeStringLiteral: dialect.escapeStringLiteral.bind(dialect),
+        jsonExtract: dialect.extractJSONField.bind(dialect),
+        evalBoolean: dialect.evalBoolean.bind(dialect),
+        sliceInfo,
+      });
+
+      const column =
+        filters.length > 0
+          ? `CASE WHEN (${filters.join("\n AND ")}) THEN ${value} ELSE NULL END`
+          : value;
+
+      metricCols.push(`-- ${m.name}
+        ${column} as m${index}_value`);
+
+      if (!filters.length) {
+        numberOfNumeratorsOrDenominatorsWithoutFilters++;
+      }
+      if (addFiltersToWhere && filters.length) {
+        filterWhere.add(`(${filters.join("\n AND ")})`);
+      }
+    }
+
+    // Add denominator column if there is one
+    if (isRatioMetric(m) && m.denominator) {
+      if (m.denominator.factTableId !== factTable.id) {
+        return;
+      }
+
+      const value = dialect.getFactMetricColumn(
+        m,
+        m.denominator,
+        factTable,
+        "m"
+      ).value;
+
+      const sliceInfo = parseSliceMetricId(m.id, {
+        [factTable.id]: factTable,
+      });
+      const filters = getColumnRefWhereClause({
+        factTable,
+        columnRef: m.denominator,
+        escapeStringLiteral: dialect.escapeStringLiteral.bind(dialect),
+        jsonExtract: dialect.extractJSONField.bind(dialect),
+        evalBoolean: dialect.evalBoolean.bind(dialect),
+        sliceInfo,
+      });
+
+      const column =
+        filters.length > 0
+          ? `CASE WHEN (${filters.join(" AND ")}) THEN ${value} ELSE NULL END`
+          : value;
+
+      metricCols.push(`-- ${m.name} (denominator)
+        ${column} as m${index}_denominator`);
+
+      if (!filters.length) {
+        numberOfNumeratorsOrDenominatorsWithoutFilters++;
+      }
+      if (addFiltersToWhere && filters.length) {
+        filterWhere.add(`(${filters.join("\n AND ")})`);
+      }
+    }
+  });
+
+  // Only add filter WHERE clause if all metrics have filters
+  if (
+    addFiltersToWhere &&
+    filterWhere.size > 0 &&
+    numberOfNumeratorsOrDenominatorsWithoutFilters === 0
+  ) {
+    where.push(`(${Array.from(filterWhere).join("\n OR ")})`);
+  }
+
+  return compileSqlTemplate(
+    `-- Fact Table (${factTable.name})
+      SELECT
+        ${castIdToString ? `CAST(${userIdCol} AS STRING)` : userIdCol} as ${baseIdType},
+        ${timestampDateTimeColumn} as timestamp,
+        ${metricCols.join(",\n")}
+      FROM(
+          ${sql}
+        ) m
+        ${join}
+        ${where.length ? `WHERE ${where.join(" AND ")}` : ""}
+    `,
+    {
+      startDate,
+      endDate: endDate || undefined,
+      experimentId,
+      phase,
+      customFields,
+    }
+  );
+}

--- a/packages/back-end/src/integrations/sql-builders/cte-builders/segments.ts
+++ b/packages/back-end/src/integrations/sql-builders/cte-builders/segments.ts
@@ -1,0 +1,256 @@
+/**
+ * Segment CTE Builder
+ *
+ * Pure functions for generating segment SQL CTEs.
+ * Extracted from SqlIntegration.ts for better testability and reuse.
+ *
+ * Segments are used to filter experiment analysis to specific groups of users
+ * (e.g., "premium users", "users from US"). They can be defined via SQL queries
+ * or based on fact tables with filters.
+ */
+
+import { SegmentInterface } from "shared/types/segment";
+import { FactTableInterface } from "shared/types/fact-table";
+import { SQLVars } from "shared/types/sql";
+import { compileSqlTemplate } from "back-end/src/util/sql";
+import { FactTableMap } from "back-end/src/models/FactTableModel";
+
+/**
+ * Interface for SQL generation methods needed by segment CTE builder.
+ * This allows the function to be pure while still using dialect-specific SQL.
+ */
+export interface SegmentCTEDialect {
+  /**
+   * Cast a user-provided date column to the appropriate datetime type.
+   * @param column - The column expression to cast
+   * @returns SQL expression with appropriate date casting
+   */
+  castUserDateCol(column: string): string;
+}
+
+/**
+ * Interface for fact segment CTE generation.
+ * Used when a segment is based on a fact table rather than raw SQL.
+ */
+export interface FactSegmentCTEDialect extends SegmentCTEDialect {
+  /**
+   * Generate a fact segment CTE.
+   * @param params - Parameters for fact segment generation
+   * @returns SQL CTE string for the fact segment
+   */
+  getFactSegmentCTE(params: {
+    factTable: FactTableInterface;
+    baseIdType: string;
+    idJoinMap: Record<string, string>;
+    filters?: string[];
+    sqlVars?: SQLVars;
+  }): string;
+}
+
+/**
+ * Parameters for building a segment CTE.
+ */
+export interface SegmentCTEParams {
+  /** The segment to build a CTE for */
+  segment: SegmentInterface;
+
+  /** The base user ID type for the query */
+  baseIdType: string;
+
+  /** Map from user ID types to their identity join table names */
+  idJoinMap: Record<string, string>;
+
+  /** Map of fact tables by ID */
+  factTableMap: FactTableMap;
+
+  /** Optional SQL variables for template substitution */
+  sqlVars?: SQLVars;
+}
+
+/**
+ * Build a segment CTE for filtering users.
+ *
+ * Segments can be:
+ * 1. SQL-based: User provides a SQL query returning (user_id, date)
+ * 2. Fact-based: Segment is defined by filters on a fact table
+ *
+ * The function handles:
+ * - Template variable substitution
+ * - Date column casting (for dialect compatibility)
+ * - Identity joins when segment uses different user ID type than base
+ *
+ * @param dialect - SQL dialect implementation with date casting
+ * @param params - Parameters including segment, ID types, and fact tables
+ * @returns SQL string for the segment CTE body (without the CTE name)
+ *
+ * @example
+ * const segmentSql = buildSegmentCTE(dialect, {
+ *   segment: premiumUsersSegment,
+ *   baseIdType: "user_id",
+ *   idJoinMap: {},
+ *   factTableMap: new Map(),
+ * });
+ * // Returns: "-- Segment (Premium Users)\nSELECT user_id, date FROM (...) s"
+ */
+export function buildSegmentCTE(
+  dialect: SegmentCTEDialect | FactSegmentCTEDialect,
+  params: SegmentCTEParams
+): string {
+  const { segment, baseIdType, idJoinMap, factTableMap, sqlVars } = params;
+
+  let segmentSql = "";
+
+  // Handle SQL-based segments
+  if (segment.type === "SQL") {
+    if (!segment.sql) {
+      throw new Error(
+        `Segment ${segment.name} is a SQL Segment but has no SQL value`
+      );
+    }
+    segmentSql = sqlVars
+      ? compileSqlTemplate(segment.sql, sqlVars)
+      : segment.sql;
+  } else {
+    // Handle fact-based segments
+    if (!segment.factTableId) {
+      throw new Error(
+        `Segment ${segment.name} is a FACT Segment, but has no factTableId set`
+      );
+    }
+    const factTable = factTableMap.get(segment.factTableId);
+
+    if (!factTable) {
+      throw new Error(`Unknown fact table: ${segment.factTableId}`);
+    }
+
+    // Type guard to check if dialect supports fact segments
+    if (!("getFactSegmentCTE" in dialect)) {
+      throw new Error(
+        "Dialect does not support fact-based segments. Use a dialect that implements FactSegmentCTEDialect."
+      );
+    }
+
+    const factDialect = dialect as FactSegmentCTEDialect;
+    segmentSql = factDialect.getFactSegmentCTE({
+      baseIdType,
+      idJoinMap,
+      factTable,
+      filters: segment.filters,
+      sqlVars,
+    });
+
+    return `-- Segment (${segment.name})
+        SELECT * FROM (\n${segmentSql}\n) s `;
+  }
+
+  // Handle date column casting
+  const dateCol = dialect.castUserDateCol("s.date");
+  const userIdType = segment.userIdType || "user_id";
+
+  // Need to use an identity join table when segment uses different ID type
+  if (userIdType !== baseIdType) {
+    return `-- Segment (${segment.name})
+      SELECT
+        i.${baseIdType},
+        ${dateCol} as date
+      FROM
+        (
+          ${segmentSql}
+        ) s
+        JOIN ${idJoinMap[userIdType]} i ON ( i.${userIdType} = s.${userIdType} )
+      `;
+  }
+
+  // If date column needs casting, wrap the SQL
+  if (dateCol !== "s.date") {
+    return `-- Segment (${segment.name})
+      SELECT
+        s.${userIdType},
+        ${dateCol} as date
+      FROM
+        (
+          ${segmentSql}
+        ) s`;
+  }
+
+  // Simple case: no casting or joins needed
+  return `-- Segment (${segment.name})
+    ${segmentSql}
+    `;
+}
+
+/**
+ * Build a fact segment CTE for filtering users based on a fact table.
+ *
+ * This is the core logic extracted from SqlIntegration.getFactSegmentCTE.
+ * It generates SQL to select users from a fact table, optionally applying
+ * filters and joining to identity tables when needed.
+ *
+ * @param dialect - SQL dialect implementation with date casting
+ * @param params - Parameters for fact segment generation
+ * @returns SQL string for the fact segment
+ */
+export function buildFactSegmentCTE(
+  dialect: SegmentCTEDialect,
+  params: {
+    factTable: FactTableInterface;
+    baseIdType: string;
+    idJoinMap: Record<string, string>;
+    filters?: string[];
+    sqlVars?: SQLVars;
+  }
+): string {
+  const { factTable, baseIdType, idJoinMap, filters, sqlVars } = params;
+
+  // Determine if a join is required to match up ID types
+  let join = "";
+  let userIdCol = "";
+  const userIdTypes = factTable.userIdTypes;
+
+  if (userIdTypes.includes(baseIdType)) {
+    userIdCol = baseIdType;
+  } else if (userIdTypes.length > 0) {
+    for (let i = 0; i < userIdTypes.length; i++) {
+      const userIdType: string = userIdTypes[i];
+      if (userIdType in idJoinMap) {
+        const metricUserIdCol = `m.${userIdType}`;
+        join = `JOIN ${idJoinMap[userIdType]} i ON (i.${userIdType} = ${metricUserIdCol})`;
+        userIdCol = `i.${baseIdType}`;
+        break;
+      }
+    }
+  }
+
+  // BQ datetime cast for SELECT statements (do not use for WHERE)
+  const timestampDateTimeColumn = dialect.castUserDateCol("m.timestamp");
+
+  const sql = factTable.sql;
+
+  const where: string[] = [];
+
+  // Apply filters from the segment
+  if (filters?.length) {
+    filters.forEach((filter) => {
+      const filterObj = factTable.filters.find(
+        (factFilter) => factFilter.id === filter
+      );
+
+      if (filterObj) {
+        where.push(filterObj.value);
+      }
+    });
+  }
+
+  const baseSql = `-- Fact Table (${factTable.name})
+    SELECT
+      ${userIdCol} as ${baseIdType},
+      ${timestampDateTimeColumn} as date
+    FROM(
+        ${sql}
+      ) m
+      ${join}
+      ${where.length ? `WHERE ${where.join(" AND ")}` : ""}
+  `;
+
+  return sqlVars ? compileSqlTemplate(baseSql, sqlVars) : baseSql;
+}

--- a/packages/back-end/src/integrations/sql-builders/cte-builders/statistics.ts
+++ b/packages/back-end/src/integrations/sql-builders/cte-builders/statistics.ts
@@ -1,0 +1,334 @@
+/**
+ * Statistics CTE Builder
+ *
+ * Pure functions for generating experiment statistics SQL CTEs.
+ * Extracted from SqlIntegration.ts for better testability and reuse.
+ *
+ * The statistics CTE aggregates metric data per variation and dimension
+ * to calculate:
+ * - User counts
+ * - Sum and sum of squares (for mean calculations)
+ * - Denominator data (for ratio metrics)
+ * - Covariate data (for CUPED regression adjustment)
+ * - Quantile data (for percentile metrics)
+ */
+
+import {
+  DimensionColumnData,
+  FactMetricData,
+  FactMetricQuantileData,
+} from "shared/types/integrations";
+import { FactTableInterface } from "shared/types/fact-table";
+import { MetricQuantileSettings } from "shared/types/fact-table";
+import { N_STAR_VALUES } from "back-end/src/services/experimentQueries/constants";
+
+/**
+ * Interface for SQL generation methods needed by statistics CTE builder.
+ */
+export interface StatisticsCTEDialect {
+  /** Cast a value to a string type */
+  castToString(col: string): string;
+
+  /** Get quantile grid columns for percentile metrics */
+  getQuantileGridColumns(
+    quantileSettings: MetricQuantileSettings | undefined,
+    prefix: string
+  ): string;
+}
+
+/**
+ * Parameters for building the experiment statistics CTE.
+ */
+export interface StatisticsCTEParams {
+  /** Dimension columns for GROUP BY */
+  dimensionCols: DimensionColumnData[];
+
+  /** Metric data with aggregation expressions */
+  metricData: FactMetricData[];
+
+  /** Event-level quantile data for quantile metrics */
+  eventQuantileData: FactMetricQuantileData[];
+
+  /** Base user ID type */
+  baseIdType: string;
+
+  /** Name of the joined metric table CTE */
+  joinedMetricTableName: string;
+
+  /** Name of the event quantile table CTE */
+  eventQuantileTableName: string;
+
+  /** Name of the CUPED covariate table CTE */
+  cupedMetricTableName: string;
+
+  /** Name of the cap value table CTE */
+  capValueTableName: string;
+
+  /** Fact tables with their indices */
+  factTablesWithIndices: { factTable: FactTableInterface; index: number }[];
+
+  /** Set of table indices that use regression adjustment */
+  regressionAdjustedTableIndices: Set<number>;
+
+  /** Set of table indices that use percentile capping */
+  percentileTableIndices: Set<number>;
+}
+
+/**
+ * Build the experiment fact metric statistics CTE.
+ *
+ * This generates the final aggregation SQL that:
+ * 1. Joins metric data with optional quantile, covariate, and cap value tables
+ * 2. Groups by variation and dimension columns
+ * 3. Calculates sum, sum_squares for each metric
+ * 4. Handles ratio metrics with denominator calculations
+ * 5. Handles CUPED regression adjustment with covariate products
+ * 6. Handles quantile metrics with grid columns or event-level quantiles
+ *
+ * @param dialect - SQL dialect implementation
+ * @param params - Parameters including metric data, tables, and indices
+ * @returns SQL string for the statistics CTE body
+ */
+export function buildExperimentFactMetricStatisticsCTE(
+  dialect: StatisticsCTEDialect,
+  params: StatisticsCTEParams
+): string {
+  const {
+    dimensionCols,
+    metricData,
+    eventQuantileData,
+    baseIdType,
+    joinedMetricTableName,
+    eventQuantileTableName,
+    cupedMetricTableName,
+    capValueTableName,
+    factTablesWithIndices,
+    regressionAdjustedTableIndices,
+    percentileTableIndices,
+  } = params;
+
+  // Generate metric column SELECT expressions
+  const metricColumns = metricData.map((data) => {
+    const numeratorSuffix = `${data.numeratorSourceIndex === 0 ? "" : data.numeratorSourceIndex}`;
+
+    return buildMetricSelectColumns(
+      dialect,
+      data,
+      numeratorSuffix,
+      eventQuantileData.length > 0
+    );
+  });
+
+  // Generate JOIN clauses for additional tables
+  const tableJoins = factTablesWithIndices.map(({ index }) => {
+    const suffix = `${index === 0 ? "" : index}`;
+
+    return buildTableJoins(
+      index,
+      suffix,
+      baseIdType,
+      joinedMetricTableName,
+      cupedMetricTableName,
+      capValueTableName,
+      regressionAdjustedTableIndices,
+      percentileTableIndices
+    );
+  });
+
+  return `SELECT
+        m.variation AS variation
+        ${dimensionCols.map((c) => `, m.${c.alias} AS ${c.alias}`).join("")}
+        , COUNT(*) AS users
+        ${metricColumns.join("\n")}
+      FROM
+        ${joinedMetricTableName} m
+        ${
+          eventQuantileData.length
+            ? `LEFT JOIN ${eventQuantileTableName} qm ON (
+          qm.variation = m.variation
+          ${dimensionCols
+            .map((c) => `AND qm.${c.alias} = m.${c.alias}`)
+            .join("\n")}
+            )`
+            : ""
+        }
+      ${tableJoins.join("\n")}
+      GROUP BY
+        m.variation
+        ${dimensionCols.map((c) => `, m.${c.alias}`).join("")}
+    `;
+}
+
+/**
+ * Build SELECT columns for a single metric.
+ */
+function buildMetricSelectColumns(
+  dialect: StatisticsCTEDialect,
+  data: FactMetricData,
+  numeratorSuffix: string,
+  hasEventQuantiles: boolean
+): string {
+  const columns: string[] = [];
+
+  // Metric ID column
+  columns.push(`, ${dialect.castToString(`'${data.id}'`)} as ${data.alias}_id`);
+
+  // Cap value for percentile-capped metrics
+  if (data.isPercentileCapped) {
+    columns.push(
+      `, MAX(COALESCE(cap${numeratorSuffix}.${data.alias}_value_cap, 0)) as ${data.alias}_main_cap_value`
+    );
+  }
+
+  // Main sum and sum_squares
+  columns.push(
+    `, SUM(${data.capCoalesceMetric}) AS ${data.alias}_main_sum`,
+    `, SUM(POWER(${data.capCoalesceMetric}, 2)) AS ${data.alias}_main_sum_squares`
+  );
+
+  // Event-level quantile columns
+  if (data.quantileMetric === "event") {
+    columns.push(buildEventQuantileColumns(data, hasEventQuantiles));
+  }
+
+  // Unit-level quantile columns
+  if (data.quantileMetric === "unit") {
+    columns.push(
+      dialect.getQuantileGridColumns(
+        data.metricQuantileSettings,
+        `${data.alias}_`
+      ),
+      `, COUNT(m.${data.alias}_value) AS ${data.alias}_quantile_n`
+    );
+  }
+
+  // Ratio metric columns
+  if (data.ratioMetric) {
+    columns.push(
+      buildRatioMetricColumns(data)
+    );
+  } else if (data.regressionAdjusted) {
+    // Non-ratio metric with regression adjustment
+    columns.push(
+      `, SUM(${data.capCoalesceCovariate}) AS ${data.alias}_covariate_sum`,
+      `, SUM(POWER(${data.capCoalesceCovariate}, 2)) AS ${data.alias}_covariate_sum_squares`,
+      `, SUM(${data.capCoalesceMetric} * ${data.capCoalesceCovariate}) AS ${data.alias}_main_covariate_sum_product`
+    );
+  }
+
+  return columns.join("\n            ");
+}
+
+/**
+ * Build event quantile columns.
+ */
+function buildEventQuantileColumns(
+  data: FactMetricData,
+  hasEventQuantiles: boolean
+): string {
+  const columns: string[] = [
+    `, SUM(COALESCE(m.${data.alias}_n_events, 0)) AS ${data.alias}_denominator_sum`,
+    `, SUM(POWER(COALESCE(m.${data.alias}_n_events, 0), 2)) AS ${data.alias}_denominator_sum_squares`,
+    `, SUM(COALESCE(m.${data.alias}_n_events, 0) * ${data.capCoalesceMetric}) AS ${data.alias}_main_denominator_sum_product`,
+    `, SUM(COALESCE(m.${data.alias}_n_events, 0)) AS ${data.alias}_quantile_n`,
+  ];
+
+  if (hasEventQuantiles) {
+    columns.push(`, MAX(qm.${data.alias}_quantile) AS ${data.alias}_quantile`);
+
+    // Add N-star value columns
+    N_STAR_VALUES.forEach((n) => {
+      columns.push(
+        `, MAX(qm.${data.alias}_quantile_lower_${n}) AS ${data.alias}_quantile_lower_${n}`,
+        `, MAX(qm.${data.alias}_quantile_upper_${n}) AS ${data.alias}_quantile_upper_${n}`
+      );
+    });
+  }
+
+  return columns.join("\n              ");
+}
+
+/**
+ * Build ratio metric columns.
+ */
+function buildRatioMetricColumns(data: FactMetricData): string {
+  const columns: string[] = [];
+
+  // Denominator cap value for percentile-capped metrics
+  if (data.isPercentileCapped) {
+    const denomSuffix = data.denominatorSourceIndex === 0 ? "" : data.denominatorSourceIndex;
+    columns.push(
+      `, MAX(COALESCE(cap${denomSuffix}.${data.alias}_denominator_cap, 0)) as ${data.alias}_denominator_cap_value`
+    );
+  }
+
+  // Denominator sum and sum_squares
+  columns.push(
+    `, SUM(${data.capCoalesceDenominator}) AS ${data.alias}_denominator_sum`,
+    `, SUM(POWER(${data.capCoalesceDenominator}, 2)) AS ${data.alias}_denominator_sum_squares`
+  );
+
+  if (data.regressionAdjusted) {
+    // Full CUPED columns for ratio metrics
+    columns.push(
+      `, SUM(${data.capCoalesceCovariate}) AS ${data.alias}_covariate_sum`,
+      `, SUM(POWER(${data.capCoalesceCovariate}, 2)) AS ${data.alias}_covariate_sum_squares`,
+      `, SUM(${data.capCoalesceDenominatorCovariate}) AS ${data.alias}_denominator_pre_sum`,
+      `, SUM(POWER(${data.capCoalesceDenominatorCovariate}, 2)) AS ${data.alias}_denominator_pre_sum_squares`,
+      `, SUM(${data.capCoalesceMetric} * ${data.capCoalesceDenominator}) AS ${data.alias}_main_denominator_sum_product`,
+      `, SUM(${data.capCoalesceMetric} * ${data.capCoalesceCovariate}) AS ${data.alias}_main_covariate_sum_product`,
+      `, SUM(${data.capCoalesceMetric} * ${data.capCoalesceDenominatorCovariate}) AS ${data.alias}_main_post_denominator_pre_sum_product`,
+      `, SUM(${data.capCoalesceCovariate} * ${data.capCoalesceDenominator}) AS ${data.alias}_main_pre_denominator_post_sum_product`,
+      `, SUM(${data.capCoalesceCovariate} * ${data.capCoalesceDenominatorCovariate}) AS ${data.alias}_main_pre_denominator_pre_sum_product`,
+      `, SUM(${data.capCoalesceDenominator} * ${data.capCoalesceDenominatorCovariate}) AS ${data.alias}_denominator_post_denominator_pre_sum_product`
+    );
+  } else {
+    // Simple ratio without CUPED
+    columns.push(
+      `, SUM(${data.capCoalesceDenominator} * ${data.capCoalesceMetric}) AS ${data.alias}_main_denominator_sum_product`
+    );
+  }
+
+  return columns.join("\n                ");
+}
+
+/**
+ * Build JOIN clauses for fact tables.
+ */
+function buildTableJoins(
+  index: number,
+  suffix: string,
+  baseIdType: string,
+  joinedMetricTableName: string,
+  cupedMetricTableName: string,
+  capValueTableName: string,
+  regressionAdjustedTableIndices: Set<number>,
+  percentileTableIndices: Set<number>
+): string {
+  const joins: string[] = [];
+
+  // JOIN for non-first tables
+  if (index !== 0) {
+    joins.push(
+      `LEFT JOIN ${joinedMetricTableName}${suffix} m${suffix} ON (
+          m${suffix}.${baseIdType} = m.${baseIdType}
+        )`
+    );
+  }
+
+  // CUPED covariate JOIN
+  if (regressionAdjustedTableIndices.has(index)) {
+    joins.push(
+      `LEFT JOIN ${cupedMetricTableName}${suffix} c${suffix} ON (
+            c${suffix}.${baseIdType} = m${suffix}.${baseIdType}
+          )`
+    );
+  }
+
+  // Percentile cap value CROSS JOIN
+  if (percentileTableIndices.has(index)) {
+    joins.push(`CROSS JOIN ${capValueTableName}${suffix} cap${suffix}`);
+  }
+
+  return joins.join("\n        ");
+}

--- a/packages/back-end/src/integrations/sql-builders/query-generators/experiment-metrics.ts
+++ b/packages/back-end/src/integrations/sql-builders/query-generators/experiment-metrics.ts
@@ -1,0 +1,483 @@
+/**
+ * Experiment Metrics Query Generators
+ *
+ * Generates SQL queries for analyzing experiment metrics. This module provides
+ * utilities for both legacy metric queries and fact-based metric queries.
+ *
+ * Query Structure (getExperimentFactMetricsQuery):
+ * 1. Identity CTEs (join different user ID types)
+ * 2. Experiment Units CTE (get users exposed to experiment)
+ * 3. Distinct Users CTE (apply filters, add dimensions)
+ * 4. Fact Table CTEs (one per fact table used by metrics)
+ * 5. User Metric Join CTEs (join users with metric events, apply conversion windows)
+ * 6. Event Quantile Metric CTEs (for quantile metrics)
+ * 7. User Metric Aggregate CTEs (aggregate per user)
+ * 8. Cap Value CTEs (for percentile capping)
+ * 9. User Covariate Metric CTEs (for CUPED/regression adjustment)
+ * 10. Statistics CTE (final aggregation by variation/dimension)
+ *
+ * This is the most complex query type in GrowthBook. The full implementation
+ * relies heavily on CTE builders from Phase 4 and internal SqlIntegration methods.
+ */
+
+import { format, FormatDialect } from "sql-formatter";
+import { SqlDialect } from "../../sql-dialects";
+
+/**
+ * Dimension column data for grouping results
+ */
+export interface DimensionColumnData {
+  /** SQL expression for the dimension value */
+  value: string;
+  /** Column alias in the output */
+  alias: string;
+}
+
+/**
+ * Parameters for building the __distinctUsers CTE
+ */
+export interface DistinctUsersParams {
+  /** Base user ID type (e.g., "user_id") */
+  baseIdType: string;
+  /** Dimension columns to include */
+  dimensionCols: DimensionColumnData[];
+  /** Column to use for user timestamp */
+  timestampColumn: string;
+  /** Source table for units (exposure table or CTE) */
+  sourceTable: string;
+  /** Additional WHERE conditions */
+  whereConditions: string[];
+  /** Whether to include bandit period column */
+  includeBanditPeriod: boolean;
+  /** Bandit period case-when expression */
+  banditCaseWhen?: string;
+  /** Regression adjustment settings for pre-exposure windows */
+  raMetricSettings?: Array<{
+    alias: string;
+    hours: number;
+    minDelay: number;
+  }>;
+}
+
+/**
+ * Generate the __distinctUsers CTE body.
+ *
+ * This CTE filters experiment units and adds dimension columns.
+ *
+ * @param params CTE parameters
+ * @param dialect SQL dialect for date functions
+ * @returns SQL CTE body
+ */
+export function generateDistinctUsersCTE(
+  params: DistinctUsersParams,
+  dialect: SqlDialect
+): string {
+  const {
+    baseIdType,
+    dimensionCols,
+    timestampColumn,
+    sourceTable,
+    whereConditions,
+    includeBanditPeriod,
+    banditCaseWhen,
+    raMetricSettings,
+  } = params;
+
+  const dimensionSelects = dimensionCols
+    .map((c) => `, ${c.value} AS ${c.alias}`)
+    .join("");
+
+  const banditColumn = includeBanditPeriod && banditCaseWhen ? banditCaseWhen : "";
+
+  // Pre-exposure window columns for regression adjustment
+  let raColumns = "";
+  if (raMetricSettings && raMetricSettings.length > 0) {
+    const minPreStart = Math.min(
+      ...raMetricSettings.map((s) => s.minDelay - s.hours)
+    );
+    const maxPreEnd = Math.max(...raMetricSettings.map((s) => s.minDelay));
+
+    raColumns = `
+    , ${dialect.addHours("first_exposure_timestamp", minPreStart)} as min_preexposure_start
+    , ${dialect.addHours("first_exposure_timestamp", maxPreEnd)} as max_preexposure_end
+    ${raMetricSettings
+      .map(
+        ({ alias, hours, minDelay }) => `
+    , ${dialect.addHours("first_exposure_timestamp", minDelay)} AS ${alias}_preexposure_end
+    , ${dialect.addHours("first_exposure_timestamp", minDelay - hours)} AS ${alias}_preexposure_start`
+      )
+      .join("")}`;
+  }
+
+  const whereClause =
+    whereConditions.length > 0
+      ? `WHERE ${whereConditions.join(" AND ")}`
+      : "";
+
+  return `
+SELECT
+  ${baseIdType}
+  ${dimensionSelects}
+  , variation
+  , ${timestampColumn} AS timestamp
+  , ${dialect.dateTrunc("first_exposure_timestamp")} AS first_exposure_date
+  ${banditColumn}
+  ${raColumns}
+FROM ${sourceTable}
+${whereClause}`;
+}
+
+/**
+ * Statistics output columns for a single metric
+ */
+export interface MetricStatisticsColumns {
+  /** Metric ID column */
+  idColumn: string;
+  /** Whether metric uses percentile capping */
+  isPercentileCapped: boolean;
+  /** Expression for main cap value (if capped) */
+  capValueExpression?: string;
+  /** Expression for main sum */
+  mainSumExpression: string;
+  /** Expression for main sum of squares */
+  mainSumSquaresExpression: string;
+  /** Whether this is a ratio metric */
+  isRatioMetric: boolean;
+  /** Denominator expressions (for ratio metrics) */
+  denominatorSumExpression?: string;
+  denominatorSumSquaresExpression?: string;
+  denominatorCapValueExpression?: string;
+  mainDenominatorSumProductExpression?: string;
+  /** Whether regression adjustment is enabled */
+  isRegressionAdjusted: boolean;
+  /** Covariate expressions (for CUPED) */
+  covariateSumExpression?: string;
+  covariateSumSquaresExpression?: string;
+  mainCovariateSumProductExpression?: string;
+  /** Whether this is a quantile metric */
+  isQuantileMetric: boolean;
+  quantileType?: "event" | "unit";
+  /** Alias prefix for output columns */
+  alias: string;
+}
+
+/**
+ * Generate statistics columns for a single metric.
+ *
+ * @param metric Metric statistics configuration
+ * @param dialect SQL dialect for casting
+ * @returns SQL fragment with metric statistics columns
+ */
+export function generateMetricStatisticsColumns(
+  metric: MetricStatisticsColumns,
+  dialect: SqlDialect
+): string {
+  const { alias, isPercentileCapped, isRatioMetric, isRegressionAdjusted } =
+    metric;
+
+  let columns = `
+  , ${dialect.castToString(`'${metric.idColumn}'`)} as ${alias}_id`;
+
+  // Cap value (for percentile capping)
+  if (isPercentileCapped && metric.capValueExpression) {
+    columns += `
+  , MAX(${metric.capValueExpression}) as ${alias}_main_cap_value`;
+  }
+
+  // Main sum and sum of squares
+  columns += `
+  , SUM(${metric.mainSumExpression}) AS ${alias}_main_sum
+  , SUM(POWER(${metric.mainSumExpression}, 2)) AS ${alias}_main_sum_squares`;
+
+  // Ratio metric columns
+  if (isRatioMetric) {
+    if (isPercentileCapped && metric.denominatorCapValueExpression) {
+      columns += `
+  , MAX(${metric.denominatorCapValueExpression}) as ${alias}_denominator_cap_value`;
+    }
+
+    columns += `
+  , SUM(${metric.denominatorSumExpression}) AS ${alias}_denominator_sum
+  , SUM(POWER(${metric.denominatorSumExpression}, 2)) AS ${alias}_denominator_sum_squares`;
+
+    if (isRegressionAdjusted) {
+      columns += `
+  , SUM(${metric.covariateSumExpression}) AS ${alias}_covariate_sum
+  , SUM(POWER(${metric.covariateSumExpression}, 2)) AS ${alias}_covariate_sum_squares
+  , SUM(${metric.mainSumExpression} * ${metric.denominatorSumExpression}) AS ${alias}_main_denominator_sum_product
+  , SUM(${metric.mainSumExpression} * ${metric.covariateSumExpression}) AS ${alias}_main_covariate_sum_product`;
+    } else {
+      columns += `
+  , SUM(${metric.denominatorSumExpression} * ${metric.mainSumExpression}) AS ${alias}_main_denominator_sum_product`;
+    }
+  } else {
+    // Non-ratio metric
+    if (isRegressionAdjusted) {
+      columns += `
+  , SUM(${metric.covariateSumExpression}) AS ${alias}_covariate_sum
+  , SUM(POWER(${metric.covariateSumExpression}, 2)) AS ${alias}_covariate_sum_squares
+  , SUM(${metric.mainSumExpression} * ${metric.covariateSumExpression}) AS ${alias}_main_covariate_sum_product`;
+    }
+  }
+
+  return columns;
+}
+
+/**
+ * Parameters for building the final statistics CTE
+ */
+export interface ExperimentStatisticsParams {
+  /** Dimension columns */
+  dimensionCols: DimensionColumnData[];
+  /** Metric statistics configurations */
+  metrics: MetricStatisticsColumns[];
+  /** Base user ID type */
+  baseIdType: string;
+  /** Name of the joined metric table */
+  joinedMetricTableName: string;
+  /** Additional table joins */
+  additionalJoins: string[];
+}
+
+/**
+ * Generate the final statistics SELECT.
+ *
+ * This produces the final aggregated results by variation and dimension.
+ *
+ * @param params Statistics parameters
+ * @param dialect SQL dialect
+ * @returns SQL SELECT statement
+ */
+export function generateExperimentStatisticsSelect(
+  params: ExperimentStatisticsParams,
+  dialect: SqlDialect
+): string {
+  const { dimensionCols, metrics, joinedMetricTableName, additionalJoins } =
+    params;
+
+  const dimensionSelects = dimensionCols
+    .map((c) => `, m.${c.alias} AS ${c.alias}`)
+    .join("");
+
+  const dimensionGroupBy = dimensionCols
+    .map((c) => `, m.${c.alias}`)
+    .join("");
+
+  const metricColumns = metrics
+    .map((m) => generateMetricStatisticsColumns(m, dialect))
+    .join("");
+
+  const joins = additionalJoins.length > 0 ? additionalJoins.join("\n") : "";
+
+  return `
+SELECT
+  m.variation AS variation
+  ${dimensionSelects}
+  , COUNT(*) AS users
+  ${metricColumns}
+FROM
+  ${joinedMetricTableName} m
+  ${joins}
+GROUP BY
+  m.variation
+  ${dimensionGroupBy}`;
+}
+
+/**
+ * Conversion window filter parameters
+ */
+export interface ConversionWindowFilter {
+  /** Column containing the metric value */
+  valueColumn: string;
+  /** Column containing the metric timestamp */
+  metricTimestampColumn: string;
+  /** Column containing the exposure timestamp */
+  exposureTimestampColumn: string;
+  /** Conversion window start (hours after exposure) */
+  conversionWindowStart?: number;
+  /** Conversion window end (hours after exposure) */
+  conversionWindowEnd?: number;
+  /** Whether to override conversion windows */
+  overrideConversionWindows: boolean;
+  /** Analysis end date */
+  endDate: Date;
+}
+
+/**
+ * Generate a CASE WHEN expression for conversion window filtering.
+ *
+ * This wraps a metric value column with time-based filtering to only include
+ * conversions that happened within the specified window.
+ *
+ * @param params Conversion window parameters
+ * @param dialect SQL dialect
+ * @returns SQL CASE WHEN expression
+ */
+export function generateConversionWindowFilter(
+  params: ConversionWindowFilter,
+  dialect: SqlDialect
+): string {
+  const {
+    valueColumn,
+    metricTimestampColumn,
+    exposureTimestampColumn,
+    conversionWindowStart,
+    conversionWindowEnd,
+    overrideConversionWindows,
+    endDate,
+  } = params;
+
+  // If overriding windows, just check against end date
+  if (overrideConversionWindows) {
+    return `CASE WHEN ${metricTimestampColumn} <= ${dialect.toTimestamp(
+      endDate
+    )} THEN ${valueColumn} ELSE NULL END`;
+  }
+
+  const conditions: string[] = [];
+
+  // Start condition
+  if (conversionWindowStart !== undefined && conversionWindowStart > 0) {
+    conditions.push(
+      `${metricTimestampColumn} >= ${dialect.addHours(
+        exposureTimestampColumn,
+        conversionWindowStart
+      )}`
+    );
+  }
+
+  // End condition
+  if (conversionWindowEnd !== undefined && conversionWindowEnd > 0) {
+    conditions.push(
+      `${metricTimestampColumn} <= ${dialect.addHours(
+        exposureTimestampColumn,
+        conversionWindowEnd
+      )}`
+    );
+  }
+
+  // End date condition
+  conditions.push(
+    `${metricTimestampColumn} <= ${dialect.toTimestamp(endDate)}`
+  );
+
+  if (conditions.length === 0) {
+    return valueColumn;
+  }
+
+  return `CASE WHEN ${conditions.join(" AND ")} THEN ${valueColumn} ELSE NULL END`;
+}
+
+/**
+ * Build a formatted comment for experiment metric queries.
+ *
+ * @param factTableNames Names of fact tables used in the query
+ * @returns SQL comment
+ */
+export function generateQueryComment(factTableNames: string[]): string {
+  if (factTableNames.length === 1) {
+    return `-- Fact Table: ${factTableNames[0]}`;
+  }
+  return `-- Cross-Fact Table Metrics: ${factTableNames.join(" & ")}`;
+}
+
+/**
+ * Parameters for the experiment fact metrics query structure.
+ *
+ * This interface defines the pre-computed values needed to assemble
+ * the full experiment fact metrics query. The actual CTE contents are
+ * generated by the CTE builders (Phase 4).
+ */
+export interface ExperimentFactMetricsQueryParams {
+  /** Query comment (fact table names) */
+  queryComment: string;
+
+  /** Format dialect for sql-formatter */
+  formatDialect: FormatDialect;
+
+  /** SQL for identity joins */
+  identitiesCTESQL: string;
+
+  /** SQL for experiment units */
+  experimentUnitsCTESQL?: string;
+
+  /** SQL for distinct users CTE */
+  distinctUsersCTESQL: string;
+
+  /** SQL for fact table CTEs (array for multi-table queries) */
+  factTableCTESQLs: string[];
+
+  /** SQL for user metric join CTEs */
+  userMetricJoinCTESQLs: string[];
+
+  /** SQL for user metric aggregate CTEs */
+  userMetricAggCTESQLs: string[];
+
+  /** SQL for cap value CTEs (optional) */
+  capValueCTESQLs?: string[];
+
+  /** SQL for covariate metric CTEs (optional) */
+  covariateCTESQLs?: string[];
+
+  /** SQL for final statistics */
+  statisticsSQL: string;
+}
+
+/**
+ * Assemble the full experiment fact metrics query from pre-computed parts.
+ *
+ * This function takes the outputs of CTE builders and combines them
+ * into the complete experiment metrics query.
+ *
+ * @param params Query parameters with pre-computed CTE SQL
+ * @returns Formatted SQL query string
+ */
+export function assembleExperimentFactMetricsQuery(
+  params: ExperimentFactMetricsQueryParams
+): string {
+  const {
+    queryComment,
+    formatDialect,
+    identitiesCTESQL,
+    experimentUnitsCTESQL,
+    distinctUsersCTESQL,
+    factTableCTESQLs,
+    userMetricJoinCTESQLs,
+    userMetricAggCTESQLs,
+    capValueCTESQLs,
+    covariateCTESQLs,
+    statisticsSQL,
+  } = params;
+
+  // Build the CTE chain
+  const cteParts: string[] = [identitiesCTESQL];
+
+  if (experimentUnitsCTESQL) {
+    cteParts.push(experimentUnitsCTESQL);
+  }
+
+  cteParts.push(`__distinctUsers AS (${distinctUsersCTESQL})`);
+
+  // Add fact table and join CTEs
+  for (let i = 0; i < factTableCTESQLs.length; i++) {
+    const suffix = i === 0 ? "" : String(i);
+    cteParts.push(`__factTable${suffix} AS (${factTableCTESQLs[i]})`);
+    cteParts.push(`__userMetricJoin${suffix} AS (${userMetricJoinCTESQLs[i]})`);
+    cteParts.push(`__userMetricAgg${suffix} AS (${userMetricAggCTESQLs[i]})`);
+
+    if (capValueCTESQLs && capValueCTESQLs[i]) {
+      cteParts.push(`__capValue${suffix} AS (${capValueCTESQLs[i]})`);
+    }
+
+    if (covariateCTESQLs && covariateCTESQLs[i]) {
+      cteParts.push(`__userCovariateMetric${suffix} AS (${covariateCTESQLs[i]})`);
+    }
+  }
+
+  const query = `${queryComment}
+WITH
+  ${cteParts.join(",\n  ")}
+${statisticsSQL}`;
+
+  return format(query, formatDialect);
+}

--- a/packages/back-end/src/integrations/sql-builders/query-generators/index.ts
+++ b/packages/back-end/src/integrations/sql-builders/query-generators/index.ts
@@ -1,0 +1,107 @@
+/**
+ * Query Generators Module
+ *
+ * This module provides pure functions for generating complete SQL queries
+ * used in GrowthBook's experiment analysis and data discovery features.
+ *
+ * Query generators compose CTE builders (from Phase 4) into full SQL queries.
+ * They take database-agnostic parameters and a dialect for DB-specific syntax.
+ *
+ * Query Types:
+ *
+ * 1. Past Experiments Query
+ *    - Discovers past experiments from exposure data
+ *    - Simplest query type, good for understanding the pattern
+ *
+ * 2. Schema Discovery Queries
+ *    - Information schema queries for table/column discovery
+ *    - Database-specific metadata table handling
+ *
+ * 3. Metric Analysis Query
+ *    - Analyzes a single metric over time
+ *    - Returns daily and overall statistics with optional histogram
+ *
+ * 4. Experiment Metrics Queries
+ *    - The most complex queries - analyze experiment metrics
+ *    - Legacy (SQL-based) and Fact-based variants
+ *    - Composes many CTEs: identities, units, metrics, statistics
+ *
+ * Usage:
+ *
+ * ```typescript
+ * import { generatePastExperimentsQuery, bigQueryDialect } from '...';
+ *
+ * const query = generatePastExperimentsQuery({
+ *   from: new Date('2024-01-01'),
+ *   exposureQueries: [...]
+ * }, bigQueryDialect);
+ * ```
+ *
+ * Architecture Notes:
+ *
+ * - Query generators are pure functions (no side effects, deterministic)
+ * - They take a dialect object for database-specific SQL syntax
+ * - Complex queries may accept pre-computed CTE SQL from CTE builders
+ * - All functions return formatted SQL strings
+ *
+ * @module query-generators
+ */
+
+// ============================================================
+// Past Experiments Query Generator
+// ============================================================
+
+export {
+  generatePastExperimentsQuery,
+  MAX_ROWS_PAST_EXPERIMENTS_QUERY,
+  type PastExperimentsQueryParams,
+} from "./past-experiments";
+
+// ============================================================
+// Schema Discovery Query Generators
+// ============================================================
+
+export {
+  generateInformationSchemaQuery,
+  generateTableDataQuery,
+  generateTablePath,
+  defaultInformationSchemaConfigs,
+  type InformationSchemaConfig,
+  type TableDataQueryParams,
+} from "./schema-discovery";
+
+// ============================================================
+// Metric Analysis Query Generator
+// ============================================================
+
+export {
+  generateMetricAnalysisStatisticClauses,
+  generateHistogramBins,
+  generateHistogramPlaceholders,
+  generateDailyStatisticsCTE,
+  generateOverallStatisticsCTE,
+  generateHistogramCTE,
+  assembleMetricAnalysisQuery,
+  DEFAULT_METRIC_HISTOGRAM_BINS,
+  type MetricAnalysisStatisticsConfig,
+  type MetricAnalysisQueryParams,
+} from "./metric-analysis";
+
+// ============================================================
+// Experiment Metrics Query Generators
+// ============================================================
+
+export {
+  generateDistinctUsersCTE,
+  generateMetricStatisticsColumns,
+  generateExperimentStatisticsSelect,
+  generateConversionWindowFilter,
+  generateQueryComment,
+  assembleExperimentFactMetricsQuery,
+  type DimensionColumnData,
+  type DistinctUsersParams,
+  type MetricStatisticsColumns,
+  type ConversionWindowFilter,
+  type ExperimentStatisticsParams,
+  type ExperimentFactMetricsQueryParams,
+} from "./experiment-metrics";

--- a/packages/back-end/src/integrations/sql-builders/query-generators/metric-analysis.ts
+++ b/packages/back-end/src/integrations/sql-builders/query-generators/metric-analysis.ts
@@ -1,0 +1,421 @@
+/**
+ * Metric Analysis Query Generator
+ *
+ * Generates SQL queries for analyzing metrics over time periods.
+ * This provides both overall statistics and daily breakdown for a single metric.
+ *
+ * Query Structure:
+ * 1. Identity CTEs (join different user ID types)
+ * 2. Population CTEs (optional - filter to specific user segment)
+ * 3. Fact Table CTE (get raw metric events)
+ * 4. User Metric Daily CTE (aggregate per user per day)
+ * 5. User Metric Overall CTE (aggregate across all days)
+ * 6. Cap Value CTE (optional - for percentile capping)
+ * 7. Statistics Daily CTE (statistics per day)
+ * 8. Statistics Overall CTE (overall statistics)
+ * 9. Histogram CTE (optional - for mean metrics)
+ *
+ * This module provides the query assembly logic while delegating
+ * CTE generation to the CTE builders from Phase 4.
+ */
+
+import { format, FormatDialect } from "sql-formatter";
+import { SqlDialect } from "../../sql-dialects";
+
+/**
+ * Default number of histogram bins for metric analysis
+ */
+export const DEFAULT_METRIC_HISTOGRAM_BINS = 20;
+
+/**
+ * Configuration for metric analysis statistics
+ */
+export interface MetricAnalysisStatisticsConfig {
+  /** Whether the metric uses ratio (numerator/denominator) */
+  isRatioMetric: boolean;
+  /** Column expression for the metric value (with optional capping) */
+  valueColumn: string;
+  /** Column expression for the denominator (for ratio metrics) */
+  denominatorColumn?: string;
+  /** Whether to create histogram bins */
+  createHistogram: boolean;
+  /** Whether the metric is capped */
+  isCapped: boolean;
+}
+
+/**
+ * Generate the statistic clauses for metric analysis.
+ *
+ * These clauses calculate count, sum, sum of squares, etc. for
+ * both the numerator and (optionally) denominator.
+ *
+ * @param config Statistics configuration
+ * @returns SQL fragment with statistic columns
+ */
+export function generateMetricAnalysisStatisticClauses(
+  config: MetricAnalysisStatisticsConfig
+): string {
+  const { isRatioMetric, valueColumn, denominatorColumn } = config;
+
+  let clauses = `
+    , COUNT(*) as count
+    , SUM(${valueColumn}) as main_sum
+    , SUM(POWER(${valueColumn}, 2)) as main_sum_squares`;
+
+  if (isRatioMetric && denominatorColumn) {
+    clauses += `
+    , SUM(${denominatorColumn}) as denominator_sum
+    , SUM(POWER(${denominatorColumn}, 2)) as denominator_sum_squares
+    , SUM(${denominatorColumn} * ${valueColumn}) as main_denominator_sum_product`;
+  }
+
+  return clauses;
+}
+
+/**
+ * Generate histogram bin expressions for a given number of bins.
+ *
+ * Creates SQL expressions that count values falling into each bin,
+ * based on value_min and bin_width from the statistics table.
+ *
+ * @param dialect SQL dialect for conditional expressions
+ * @param numBins Number of histogram bins
+ * @returns SQL fragment with histogram bin columns
+ */
+export function generateHistogramBins(
+  dialect: SqlDialect,
+  numBins: number = DEFAULT_METRIC_HISTOGRAM_BINS
+): string {
+  const bins: string[] = [];
+
+  // First bin: value < value_min + bin_width
+  bins.push(
+    `SUM(${dialect.ifElse("m.value < (s.value_min + s.bin_width)", "1", "0")}) as units_bin_0`
+  );
+
+  // Middle bins
+  for (let i = 0; i < numBins - 2; i++) {
+    bins.push(
+      `SUM(${dialect.ifElse(
+        `m.value >= (s.value_min + s.bin_width*${i + 1}.0) AND m.value < (s.value_min + s.bin_width*${i + 2}.0)`,
+        "1",
+        "0"
+      )}) as units_bin_${i + 1}`
+    );
+  }
+
+  // Last bin: value >= value_min + bin_width * (numBins - 1)
+  bins.push(
+    `SUM(${dialect.ifElse(
+      `m.value >= (s.value_min + s.bin_width*${numBins - 1}.0)`,
+      "1",
+      "0"
+    )}) as units_bin_${numBins - 1}`
+  );
+
+  return bins.join("\n      , ");
+}
+
+/**
+ * Generate placeholder histogram columns for daily statistics.
+ *
+ * Daily statistics don't have histogram data, so we generate NULL placeholders.
+ *
+ * @param dialect SQL dialect for type casting
+ * @param numBins Number of histogram bins
+ * @returns SQL fragment with NULL histogram columns
+ */
+export function generateHistogramPlaceholders(
+  dialect: SqlDialect,
+  numBins: number = DEFAULT_METRIC_HISTOGRAM_BINS
+): string {
+  const placeholders: string[] = [];
+
+  for (let i = 0; i < numBins; i++) {
+    placeholders.push(`${dialect.ensureFloat("NULL")} AS units_bin_${i}`);
+  }
+
+  return placeholders.join("\n      , ");
+}
+
+/**
+ * Generate the __statisticsDaily CTE body.
+ *
+ * Calculates per-day statistics for the metric.
+ *
+ * @param config Statistics configuration
+ * @param dialect SQL dialect
+ * @param options Additional options
+ * @returns SQL CTE body
+ */
+export function generateDailyStatisticsCTE(
+  config: MetricAnalysisStatisticsConfig,
+  dialect: SqlDialect,
+  options: {
+    sourceTable: string;
+    useCapTable: boolean;
+  }
+): string {
+  const { createHistogram, isCapped, valueColumn, denominatorColumn } = config;
+
+  const cappedString = dialect.castToString(`'${isCapped ? "capped" : "uncapped"}'`);
+  const dataTypeString = dialect.castToString("'date'");
+
+  let histogramCols = "";
+  if (createHistogram) {
+    histogramCols = `
+    , MIN(${valueColumn}) as value_min
+    , MAX(${valueColumn}) as value_max
+    , ${dialect.ensureFloat("NULL")} AS bin_width
+    , ${generateHistogramPlaceholders(dialect)}`;
+  }
+
+  return `
+SELECT
+  date
+  , MAX(${dataTypeString}) AS data_type
+  , ${cappedString} AS capped
+  ${generateMetricAnalysisStatisticClauses(config)}
+  ${histogramCols}
+FROM ${options.sourceTable}
+${options.useCapTable ? "CROSS JOIN __capValue cap" : ""}
+GROUP BY date`;
+}
+
+/**
+ * Generate the __statisticsOverall CTE body.
+ *
+ * Calculates overall statistics for the metric across all days.
+ *
+ * @param config Statistics configuration
+ * @param dialect SQL dialect
+ * @param options Additional options
+ * @returns SQL CTE body
+ */
+export function generateOverallStatisticsCTE(
+  config: MetricAnalysisStatisticsConfig,
+  dialect: SqlDialect,
+  options: {
+    sourceTable: string;
+    useCapTable: boolean;
+  }
+): string {
+  const { createHistogram, isCapped, valueColumn } = config;
+
+  const cappedString = dialect.castToString(`'${isCapped ? "capped" : "uncapped"}'`);
+  const dataTypeString = dialect.castToString("'overall'");
+  const numBins = DEFAULT_METRIC_HISTOGRAM_BINS;
+
+  let histogramCols = "";
+  if (createHistogram) {
+    histogramCols = `
+    , MIN(${valueColumn}) as value_min
+    , MAX(${valueColumn}) as value_max
+    , (MAX(${valueColumn}) - MIN(${valueColumn})) / ${numBins}.0 as bin_width`;
+  }
+
+  return `
+SELECT
+  ${dialect.castToDate("NULL")} AS date
+  , MAX(${dataTypeString}) AS data_type
+  , ${cappedString} AS capped
+  ${generateMetricAnalysisStatisticClauses(config)}
+  ${histogramCols}
+FROM ${options.sourceTable}
+${options.useCapTable ? "CROSS JOIN __capValue cap" : ""}`;
+}
+
+/**
+ * Generate the __histogram CTE body.
+ *
+ * Calculates histogram bin counts for the overall metric distribution.
+ *
+ * @param dialect SQL dialect
+ * @param options Additional options
+ * @returns SQL CTE body
+ */
+export function generateHistogramCTE(
+  dialect: SqlDialect,
+  options: {
+    sourceTable: string;
+    statisticsTable: string;
+  }
+): string {
+  return `
+SELECT
+  ${generateHistogramBins(dialect)}
+FROM
+  ${options.sourceTable} m
+CROSS JOIN
+  ${options.statisticsTable} s`;
+}
+
+/**
+ * Parameters for the metric analysis query structure.
+ *
+ * This interface defines the pre-computed values needed to assemble
+ * the full metric analysis query. The actual CTE contents are generated
+ * by the CTE builders (Phase 4).
+ */
+export interface MetricAnalysisQueryParams {
+  /** Name of the metric (for query comment) */
+  metricName: string;
+
+  /** The base user ID type */
+  baseIdType: string;
+
+  /** SQL for identity joins (from buildIdentitiesCTE) */
+  identitiesCTESQL: string;
+
+  /** SQL for population CTEs (optional) */
+  populationCTESQL: string;
+
+  /** SQL for fact table CTE (from buildFactMetricCTE) */
+  factTableCTESQL: string;
+
+  /** Metric statistics configuration */
+  statisticsConfig: MetricAnalysisStatisticsConfig;
+
+  /** SQL dialect for formatting */
+  dialect: SqlDialect;
+
+  /** Format dialect string */
+  formatDialect: FormatDialect;
+
+  /** Numerator aggregation functions */
+  numeratorAggFns: {
+    fullAggregationFunction: (col: string) => string;
+    partialAggregationFunction: (col: string) => string;
+    reAggregationFunction: (col: string) => string;
+  };
+
+  /** Denominator aggregation functions (for ratio metrics) */
+  denominatorAggFns?: {
+    fullAggregationFunction: (col: string) => string;
+    partialAggregationFunction: (col: string) => string;
+    reAggregationFunction: (col: string) => string;
+  };
+
+  /** Value transformation function */
+  aggregatedValueTransformation: (params: {
+    column: string;
+    initialTimestampColumn: string;
+    analysisEndDate?: Date;
+  }) => string;
+
+  /** Column alias for the metric */
+  metricAlias: string;
+
+  /** Whether percentile capping is used */
+  isPercentileCapped: boolean;
+
+  /** Percentile cap CTE SQL (if capping is used) */
+  percentileCapCTESQL?: string;
+}
+
+/**
+ * Assemble the full metric analysis query from pre-computed parts.
+ *
+ * This function takes the outputs of CTE builders and combines them
+ * into the complete metric analysis query.
+ *
+ * @param params Query parameters with pre-computed CTE SQL
+ * @returns Formatted SQL query string
+ */
+export function assembleMetricAnalysisQuery(
+  params: MetricAnalysisQueryParams
+): string {
+  const {
+    metricName,
+    baseIdType,
+    identitiesCTESQL,
+    populationCTESQL,
+    factTableCTESQL,
+    statisticsConfig,
+    dialect,
+    formatDialect,
+    numeratorAggFns,
+    denominatorAggFns,
+    aggregatedValueTransformation,
+    metricAlias,
+    isPercentileCapped,
+    percentileCapCTESQL,
+  } = params;
+
+  const hasPopulation = !!populationCTESQL;
+  const tablePrefix = hasPopulation ? "p" : "f";
+
+  // Build __userMetricDaily CTE
+  const denominatorDailyCols = statisticsConfig.isRatioMetric && denominatorAggFns
+    ? `, ${denominatorAggFns.fullAggregationFunction(`f.${metricAlias}_denominator`)} AS denominator
+    , ${denominatorAggFns.partialAggregationFunction(`f.${metricAlias}_denominator`)} AS denominator_for_reaggregation`
+    : "";
+
+  const userMetricDailyFrom = hasPopulation
+    ? `FROM __population p
+      LEFT JOIN __factTable f ON (f.${baseIdType} = p.${baseIdType})`
+    : `FROM __factTable f`;
+
+  const userMetricDailyCTE = `
+SELECT
+  ${tablePrefix}.${baseIdType} AS ${baseIdType}
+  , ${dialect.dateTrunc("timestamp")} AS date
+  , ${numeratorAggFns.fullAggregationFunction(`f.${metricAlias}_value`)} AS value
+  , ${numeratorAggFns.partialAggregationFunction(`f.${metricAlias}_value`)} AS value_for_reaggregation
+  ${denominatorDailyCols}
+${userMetricDailyFrom}
+GROUP BY
+  ${dialect.dateTrunc("f.timestamp")}
+  , ${tablePrefix}.${baseIdType}`;
+
+  // Build __userMetricOverall CTE
+  // Note: This uses a simplified version - the actual implementation has more complex transformation
+  const denominatorOverallCol = statisticsConfig.isRatioMetric && denominatorAggFns
+    ? `, ${denominatorAggFns.reAggregationFunction("denominator_for_reaggregation")} AS denominator`
+    : "";
+
+  const userMetricOverallCTE = `
+SELECT
+  ${baseIdType}
+  , ${numeratorAggFns.reAggregationFunction("value_for_reaggregation")} AS value
+  ${denominatorOverallCol}
+FROM
+  __userMetricDaily
+GROUP BY
+  ${baseIdType}`;
+
+  // Assemble the full query
+  const query = `-- ${metricName} Metric Analysis
+WITH
+  ${identitiesCTESQL}
+  ${populationCTESQL}
+  __factTable AS (${factTableCTESQL})
+  , __userMetricDaily AS (
+    -- Get aggregated metric per user by day
+    ${userMetricDailyCTE}
+  )
+  , __userMetricOverall AS (${userMetricOverallCTE})
+  ${isPercentileCapped && percentileCapCTESQL ? `, __capValue AS (${percentileCapCTESQL})` : ""}
+  , __statisticsDaily AS (${generateDailyStatisticsCTE(
+    statisticsConfig,
+    dialect,
+    { sourceTable: "__userMetricDaily", useCapTable: isPercentileCapped }
+  )})
+  , __statisticsOverall AS (${generateOverallStatisticsCTE(
+    statisticsConfig,
+    dialect,
+    { sourceTable: "__userMetricOverall", useCapTable: isPercentileCapped }
+  )})
+  ${statisticsConfig.createHistogram ? `, __histogram AS (${generateHistogramCTE(
+    dialect,
+    { sourceTable: "__userMetricOverall", statisticsTable: "__statisticsOverall" }
+  )})` : ""}
+SELECT *
+FROM __statisticsOverall
+${statisticsConfig.createHistogram ? "CROSS JOIN __histogram" : ""}
+UNION ALL
+SELECT *
+FROM __statisticsDaily`;
+
+  return format(query, formatDialect);
+}

--- a/packages/back-end/src/integrations/sql-builders/query-generators/past-experiments.ts
+++ b/packages/back-end/src/integrations/sql-builders/query-generators/past-experiments.ts
@@ -1,0 +1,160 @@
+/**
+ * Past Experiments Query Generator
+ *
+ * Generates SQL queries to discover past experiments from exposure data.
+ * This is the simplest query generator, extracting experiment and variation
+ * information from exposure queries over a date range.
+ */
+
+import { format } from "sql-formatter";
+import { SAFE_ROLLOUT_TRACKING_KEY_PREFIX } from "shared/constants";
+import { ExposureQuery } from "shared/types/datasource";
+import { SqlDialect, hasHllSupport } from "../../sql-dialects";
+import { compileSqlTemplate } from "back-end/src/util/sql";
+
+/**
+ * Maximum number of rows to return from past experiments query.
+ * This prevents overly large result sets.
+ */
+export const MAX_ROWS_PAST_EXPERIMENTS_QUERY = 3000;
+
+/**
+ * Parameters for generating past experiments query
+ */
+export interface PastExperimentsQueryParams {
+  /** Start date for the query range */
+  from: Date;
+  /** End date for the query range (optional, defaults to now) */
+  to?: Date;
+  /** List of exposure queries to scan for experiments */
+  exposureQueries: ExposureQuery[];
+}
+
+/**
+ * Generate a SQL query to discover past experiments from exposure data.
+ *
+ * This function scans exposure queries and aggregates experiment/variation data
+ * to identify past experiments based on user traffic patterns.
+ *
+ * Key features:
+ * - Unions multiple exposure queries together
+ * - Groups by experiment_id, variation_id, and date
+ * - Filters out safe rollout tracking keys
+ * - Uses user thresholds to filter out low-traffic variations
+ * - Returns top N results ordered by start_date DESC
+ *
+ * @param params Query parameters
+ * @param dialect SQL dialect for database-specific syntax
+ * @returns Formatted SQL query string
+ */
+export function generatePastExperimentsQuery(
+  params: PastExperimentsQueryParams,
+  dialect: SqlDialect
+): string {
+  const { from, exposureQueries } = params;
+  const end = params.to ?? new Date();
+
+  if (exposureQueries.length === 0) {
+    throw new Error("At least one exposure query is required");
+  }
+
+  // Build individual exposure CTEs
+  const exposureCTEs = exposureQueries.map((q, i) => {
+    const hasNameCol = q.hasNameCol || false;
+
+    // Use HLL for user count if available, otherwise COUNT DISTINCT
+    const userCountColumn = hasHllSupport(dialect)
+      ? dialect.hllCardinality(dialect.hllAggregate(q.userIdType))
+      : `COUNT(distinct ${q.userIdType})`;
+
+    return `
+    __exposures${i} as (
+      SELECT
+        ${dialect.castToString(`'${q.id}'`)} as exposure_query,
+        experiment_id,
+        ${hasNameCol ? "MIN(experiment_name)" : "experiment_id"} as experiment_name,
+        ${dialect.castToString("variation_id")} as variation_id,
+        ${hasNameCol ? "MIN(variation_name)" : dialect.castToString("variation_id")} as variation_name,
+        ${dialect.dateTrunc(dialect.castUserDateCol("timestamp"))} as date,
+        ${userCountColumn} as users,
+        MAX(${dialect.castUserDateCol("timestamp")}) as latest_data
+      FROM
+        (
+          ${compileSqlTemplate(q.query, { startDate: from })}
+        ) e${i}
+      WHERE
+        timestamp > ${dialect.toTimestamp(from)}
+        AND timestamp <= ${dialect.toTimestamp(end)}
+        AND SUBSTRING(experiment_id, 1, ${SAFE_ROLLOUT_TRACKING_KEY_PREFIX.length}) != '${SAFE_ROLLOUT_TRACKING_KEY_PREFIX}'
+        AND experiment_id IS NOT NULL
+        AND variation_id IS NOT NULL
+      GROUP BY
+        experiment_id,
+        variation_id,
+        ${dialect.dateTrunc(dialect.castUserDateCol("timestamp"))}
+    )`;
+  });
+
+  // Union all exposure CTEs
+  const experimentsUnion = exposureQueries
+    .map((_, i) => `SELECT * FROM __exposures${i}`)
+    .join("\nUNION ALL\n");
+
+  const query = `-- Past Experiments
+WITH
+  ${exposureCTEs.join(",\n")}
+  , __experiments as (
+    ${experimentsUnion}
+  ),
+  __userThresholds as (
+    SELECT
+      exposure_query,
+      experiment_id,
+      MIN(experiment_name) as experiment_name,
+      variation_id,
+      MIN(variation_name) as variation_name,
+      -- It's common for a small number of tracking events to continue coming in
+      -- long after an experiment ends, so limit to days with enough traffic
+      max(users)*0.05 as threshold
+    FROM
+      __experiments
+    WHERE
+      -- Skip days where a variation got 5 or fewer visitors since it's probably not real traffic
+      users > 5
+    GROUP BY
+    exposure_query, experiment_id, variation_id
+  ),
+  __variations as (
+    SELECT
+      d.exposure_query,
+      d.experiment_id,
+      MIN(d.experiment_name) as experiment_name,
+      d.variation_id,
+      MIN(d.variation_name) as variation_name,
+      MIN(d.date) as start_date,
+      MAX(d.date) as end_date,
+      SUM(d.users) as users,
+      MAX(latest_data) as latest_data
+    FROM
+      __experiments d
+      JOIN __userThresholds u ON (
+        d.exposure_query = u.exposure_query
+        AND d.experiment_id = u.experiment_id
+        AND d.variation_id = u.variation_id
+      )
+    WHERE
+      d.users > u.threshold
+    GROUP BY
+      d.exposure_query, d.experiment_id, d.variation_id
+  )
+${dialect.selectStarLimit(
+  `
+  __variations
+ORDER BY
+  start_date DESC, experiment_id ASC, variation_id ASC
+  `,
+  MAX_ROWS_PAST_EXPERIMENTS_QUERY
+)}`;
+
+  return format(query, dialect.formatDialect);
+}

--- a/packages/back-end/src/integrations/sql-builders/query-generators/schema-discovery.ts
+++ b/packages/back-end/src/integrations/sql-builders/query-generators/schema-discovery.ts
@@ -1,0 +1,231 @@
+/**
+ * Schema Discovery Query Generator
+ *
+ * Generates SQL queries to discover database schema information from
+ * the information_schema or equivalent system tables.
+ *
+ * Note: Schema discovery is highly database-specific. Different databases
+ * have different metadata tables and structures. This module provides
+ * common patterns that work with most SQL databases.
+ */
+
+import { format, FormatDialect } from "sql-formatter";
+
+/**
+ * Configuration for information schema table discovery
+ */
+export interface InformationSchemaConfig {
+  /** The table path to query (e.g., "information_schema.columns") */
+  tablePath: string;
+  /** WHERE clause to filter schemas (e.g., "table_schema NOT IN ('information_schema')") */
+  whereClause: string;
+  /** The format dialect for sql-formatter */
+  formatDialect: FormatDialect;
+  /** Override table_catalog with a fixed value (for databases like Vertica) */
+  fixedCatalog?: string;
+}
+
+/**
+ * Parameters for generating table data query
+ */
+export interface TableDataQueryParams {
+  /** The database/catalog name */
+  databaseName: string;
+  /** The schema name */
+  tableSchema: string;
+  /** The table name to get column info for */
+  tableName: string;
+}
+
+/**
+ * Generate SQL query to list all tables in the information schema.
+ *
+ * Returns columns:
+ * - table_name: Name of the table
+ * - table_catalog: Database/catalog name
+ * - table_schema: Schema name
+ * - column_count: Number of columns in the table
+ *
+ * @param config Information schema configuration
+ * @returns Formatted SQL query string
+ */
+export function generateInformationSchemaQuery(
+  config: InformationSchemaConfig
+): string {
+  const { tablePath, whereClause, formatDialect, fixedCatalog } = config;
+
+  const catalogColumn = fixedCatalog
+    ? `'${fixedCatalog}' as table_catalog`
+    : "table_catalog as table_catalog";
+
+  const groupByColumns = fixedCatalog
+    ? `table_name, table_schema, '${fixedCatalog}'`
+    : "table_name, table_schema, table_catalog";
+
+  const sql = `
+SELECT
+  table_name as table_name,
+  ${catalogColumn},
+  table_schema as table_schema,
+  count(column_name) as column_count
+FROM
+  ${tablePath}
+WHERE ${whereClause}
+GROUP BY ${groupByColumns}`;
+
+  return format(sql, formatDialect);
+}
+
+/**
+ * Generate SQL query to get column information for a specific table.
+ *
+ * Returns columns:
+ * - data_type: The column data type
+ * - column_name: Name of the column
+ *
+ * @param config Information schema configuration
+ * @param params Query parameters with table identifiers
+ * @returns Formatted SQL query string
+ */
+export function generateTableDataQuery(
+  config: InformationSchemaConfig,
+  params: TableDataQueryParams
+): string {
+  const { tablePath, formatDialect } = config;
+  const { databaseName, tableSchema, tableName } = params;
+
+  // Basic SQL injection prevention for table/schema/database names
+  const safeDatabaseName = databaseName.replace(/'/g, "''");
+  const safeTableSchema = tableSchema.replace(/'/g, "''");
+  const safeTableName = tableName.replace(/'/g, "''");
+
+  const sql = `
+SELECT
+  data_type as data_type,
+  column_name as column_name
+FROM
+  ${tablePath}
+WHERE
+  table_name = '${safeTableName}'
+  AND table_schema = '${safeTableSchema}'
+  AND table_catalog = '${safeDatabaseName}'`;
+
+  return format(sql, formatDialect);
+}
+
+/**
+ * Default information schema configurations for common databases.
+ * These can be used as starting points or directly for databases
+ * that follow standard patterns.
+ */
+export const defaultInformationSchemaConfigs = {
+  /**
+   * Standard SQL configuration - works for most databases
+   */
+  standard: {
+    tablePath: "information_schema.columns",
+    whereClause: "table_schema NOT IN ('information_schema')",
+  },
+
+  /**
+   * BigQuery configuration
+   * Note: BigQuery requires querying per-dataset, so the tablePath
+   * should be constructed with the dataset name included.
+   */
+  bigquery: {
+    tablePath: "INFORMATION_SCHEMA.COLUMNS", // Needs dataset prefix
+    whereClause: "table_schema NOT IN ('information_schema')",
+  },
+
+  /**
+   * Redshift configuration - uses SVV_COLUMNS view
+   */
+  redshift: {
+    tablePath: "SVV_COLUMNS",
+    whereClause: "table_schema NOT IN ('information_schema')",
+  },
+
+  /**
+   * Vertica configuration - uses v_catalog.columns
+   */
+  vertica: {
+    tablePath: "v_catalog.columns",
+    whereClause:
+      "table_schema NOT IN ('v_catalog', 'v_monitor', 'v_license') AND NOT is_system_table",
+  },
+
+  /**
+   * MySQL configuration
+   */
+  mysql: {
+    tablePath: "information_schema.columns",
+    whereClause: "table_schema NOT IN ('information_schema', 'mysql', 'performance_schema', 'sys')",
+  },
+
+  /**
+   * Postgres configuration
+   */
+  postgres: {
+    tablePath: "information_schema.columns",
+    whereClause: "table_schema NOT IN ('information_schema', 'pg_catalog')",
+  },
+
+  /**
+   * Snowflake configuration
+   */
+  snowflake: {
+    tablePath: "information_schema.columns",
+    whereClause: "table_schema NOT IN ('INFORMATION_SCHEMA')",
+  },
+
+  /**
+   * ClickHouse configuration
+   */
+  clickhouse: {
+    tablePath: "system.columns",
+    whereClause: "database NOT IN ('system', 'INFORMATION_SCHEMA', 'information_schema')",
+  },
+} as const;
+
+/**
+ * Helper to generate table path with database and schema prefixes.
+ *
+ * This mimics the generateTablePath logic from SqlIntegration.ts
+ * but as a pure function.
+ *
+ * @param tableName The table name (can include schema like "information_schema.columns")
+ * @param schema Optional schema prefix
+ * @param database Optional database prefix
+ * @param escapeChar Optional character to escape the path (e.g., backticks)
+ * @returns Fully qualified table path
+ */
+export function generateTablePath(
+  tableName: string,
+  options: {
+    schema?: string;
+    database?: string;
+    escapeChar?: string;
+    requiresDatabase?: boolean;
+    requiresSchema?: boolean;
+  } = {}
+): string {
+  const { schema, database, escapeChar, requiresDatabase, requiresSchema } =
+    options;
+
+  let path = "";
+
+  // Add database if required
+  if (requiresDatabase && database) {
+    path += database + ".";
+  }
+
+  // Add schema if required
+  if (requiresSchema && schema) {
+    path += schema + ".";
+  }
+
+  // Add table name
+  path += tableName;
+
+  return escapeChar ? `${escapeChar}${path}${escapeChar}` : path;
+}

--- a/packages/back-end/src/integrations/sql-builders/time-window/index.ts
+++ b/packages/back-end/src/integrations/sql-builders/time-window/index.ts
@@ -1,0 +1,253 @@
+/**
+ * Time Window Utilities
+ *
+ * Pure functions for calculating experiment metric time windows.
+ * Extracted from SqlIntegration.ts for better testability and reuse.
+ *
+ * These functions calculate:
+ * - When to start querying metric data (accounting for lookback delays)
+ * - When to stop querying metric data (accounting for conversion windows)
+ * - Maximum hours needed for users to convert (for skipPartialData)
+ */
+
+import { ExperimentMetricInterface } from "shared/experiments";
+import {
+  getDelayWindowHours,
+  getMetricWindowHours,
+} from "shared/experiments";
+import { ExperimentSnapshotSettings } from "shared/types/experiment-snapshot";
+
+/**
+ * Calculate the minimum delay across a set of metrics.
+ *
+ * Used to determine how far back before the experiment start we need
+ * to query metric data. A negative delay means we need to look at
+ * events that happened BEFORE the user was exposed to the experiment.
+ *
+ * For funnel metrics where windows cascade, the delays accumulate.
+ *
+ * @param metrics - Array of experiment metrics
+ * @returns Minimum (most negative) delay in hours
+ *
+ * @example
+ * // Metric with -24 hour delay (lookback)
+ * getMetricMinDelay([metricWithLookback]) // -24
+ *
+ * // Two metrics with cascading delays
+ * getMetricMinDelay([m1WithDelay24, m2WithDelayNeg48]) // -72 (24 + -48)
+ */
+export function getMetricMinDelay(
+  metrics: ExperimentMetricInterface[]
+): number {
+  let runningDelay = 0;
+  let minDelay = 0;
+
+  metrics.forEach((m) => {
+    const delay = getDelayWindowHours(m.windowSettings);
+    if (delay) {
+      const totalDelay = runningDelay + delay;
+      if (totalDelay < minDelay) {
+        minDelay = totalDelay;
+      }
+      runningDelay = totalDelay;
+    }
+  });
+
+  return minDelay;
+}
+
+/**
+ * Calculate the start date for querying metric data.
+ *
+ * The start date may be earlier than the experiment start if:
+ * - Metrics have negative delays (lookback windows)
+ * - Regression adjustment is enabled (need pre-experiment data)
+ *
+ * @param initial - The experiment start date
+ * @param minDelay - Minimum delay from getMetricMinDelay (negative for lookback)
+ * @param regressionAdjustmentHours - Hours of pre-experiment data for CUPED
+ * @returns Adjusted start date for metric queries
+ *
+ * @example
+ * // No adjustments needed
+ * getMetricStart(expStart, 0, 0) // expStart
+ *
+ * // 24 hour lookback
+ * getMetricStart(expStart, -24, 0) // expStart - 24 hours
+ *
+ * // 48 hour regression adjustment
+ * getMetricStart(expStart, 0, 48) // expStart - 48 hours
+ */
+export function getMetricStart(
+  initial: Date,
+  minDelay: number,
+  regressionAdjustmentHours: number
+): Date {
+  const metricStart = new Date(initial);
+
+  // If minDelay is negative, we need to look back before the experiment started
+  if (minDelay < 0) {
+    metricStart.setHours(metricStart.getHours() + minDelay);
+  }
+
+  // Regression adjustment requires pre-experiment data
+  if (regressionAdjustmentHours > 0) {
+    metricStart.setHours(metricStart.getHours() - regressionAdjustmentHours);
+  }
+
+  return metricStart;
+}
+
+/**
+ * Calculate the end date for querying metric data.
+ *
+ * The end date is extended beyond the experiment end to account for
+ * conversion windows - users need time after exposure to convert.
+ *
+ * For funnel metrics where windows cascade, the hours accumulate.
+ *
+ * @param metrics - Array of experiment metrics
+ * @param initial - The experiment end date (optional)
+ * @param overrideConversionWindows - If true, return initial without extending
+ * @returns Extended end date, or null if initial is undefined
+ *
+ * @example
+ * // 72 hour conversion window
+ * getMetricEnd([metric72h], expEnd) // expEnd + 72 hours
+ *
+ * // Multiple metrics with cascading windows
+ * getMetricEnd([m1_48h, m2_72h], expEnd) // expEnd + max(48, 48+72+delay)
+ */
+export function getMetricEnd(
+  metrics: ExperimentMetricInterface[],
+  initial?: Date,
+  overrideConversionWindows?: boolean
+): Date | null {
+  if (!initial) return null;
+  if (overrideConversionWindows) return initial;
+
+  const metricEnd = new Date(initial);
+  let runningHours = 0;
+  let maxHours = 0;
+
+  metrics.forEach((m) => {
+    if (m.windowSettings.type === "conversion") {
+      const hours =
+        runningHours +
+        getMetricWindowHours(m.windowSettings) +
+        getDelayWindowHours(m.windowSettings);
+      if (hours > maxHours) {
+        maxHours = hours;
+      }
+      runningHours = hours;
+    }
+  });
+
+  if (maxHours > 0) {
+    metricEnd.setHours(metricEnd.getHours() + maxHours);
+  }
+
+  return metricEnd;
+}
+
+/**
+ * Calculate maximum hours needed for a user to fully convert.
+ *
+ * Used with skipPartialData to exclude users who haven't had enough
+ * time to complete their conversion journey.
+ *
+ * For funnel metrics, windows cascade (sum together).
+ * For non-funnel metrics, we take the maximum window.
+ * Activation metrics always add to the total.
+ *
+ * @param funnelMetric - Whether this is a funnel metric (windows cascade)
+ * @param metricAndDenominatorMetrics - Primary metric and any denominator metrics
+ * @param activationMetric - Optional activation metric (always adds to total)
+ * @returns Maximum hours needed for conversion
+ *
+ * @example
+ * // Single metric with 72h window + 24h delay
+ * getMaxHoursToConvert(false, [metric], null) // 96
+ *
+ * // Funnel metric: windows cascade
+ * getMaxHoursToConvert(true, [m1_48h, m2_72h], null) // 48 + 72 = 120
+ *
+ * // With activation metric
+ * getMaxHoursToConvert(false, [metric_48h], activation_24h) // 48 + 24 = 72
+ */
+export function getMaxHoursToConvert(
+  funnelMetric: boolean,
+  metricAndDenominatorMetrics: ExperimentMetricInterface[],
+  activationMetric: ExperimentMetricInterface | null
+): number {
+  let neededHoursForConversion = 0;
+
+  metricAndDenominatorMetrics.forEach((m) => {
+    if (m.windowSettings.type === "conversion") {
+      const metricHours =
+        getDelayWindowHours(m.windowSettings) +
+        getMetricWindowHours(m.windowSettings);
+
+      if (funnelMetric) {
+        // Funnel metric windows cascade, so sum each metric's hours
+        neededHoursForConversion += metricHours;
+      } else if (metricHours > neededHoursForConversion) {
+        // Non-funnel: take the maximum
+        neededHoursForConversion = metricHours;
+      }
+    }
+  });
+
+  // Activation metrics always cascade (add to total)
+  if (
+    activationMetric &&
+    activationMetric.windowSettings.type === "conversion"
+  ) {
+    neededHoursForConversion +=
+      getDelayWindowHours(activationMetric.windowSettings) +
+      getMetricWindowHours(activationMetric.windowSettings);
+  }
+
+  return neededHoursForConversion;
+}
+
+/**
+ * Calculate the effective experiment end date for filtering users.
+ *
+ * When skipPartialData is enabled, we exclude users who haven't had
+ * enough time to fully convert. This returns the earlier of:
+ * - The actual experiment end date
+ * - The current time minus the conversion window
+ *
+ * @param settings - Experiment snapshot settings
+ * @param conversionWindowHours - Hours needed for conversion (from getMaxHoursToConvert)
+ * @returns Effective end date for filtering experiment users
+ *
+ * @example
+ * // skipPartialData = false: use actual end date
+ * getExperimentEndDate(settings, 72) // settings.endDate
+ *
+ * // skipPartialData = true, experiment still running
+ * // Returns (now - 72 hours) so users have time to convert
+ * getExperimentEndDate(settings, 72) // now - 72h
+ */
+export function getExperimentEndDate(
+  settings: ExperimentSnapshotSettings,
+  conversionWindowHours: number
+): Date {
+  // If we don't need to skip partial data, use the actual end date
+  if (!settings.skipPartialData) {
+    return settings.endDate;
+  }
+
+  // Calculate the last date that gives users enough time to convert
+  const conversionWindowEndDate = new Date();
+  conversionWindowEndDate.setHours(
+    conversionWindowEndDate.getHours() - conversionWindowHours
+  );
+
+  // Use the earlier of the experiment end date or conversion window end
+  return new Date(
+    Math.min(settings.endDate.getTime(), conversionWindowEndDate.getTime())
+  );
+}

--- a/packages/back-end/src/integrations/sql-dialects/athena-dialect.ts
+++ b/packages/back-end/src/integrations/sql-dialects/athena-dialect.ts
@@ -1,0 +1,105 @@
+/**
+ * Amazon Athena SQL Dialect
+ *
+ * Implements Athena-specific SQL generation methods including:
+ * - from_iso8601_timestamp for timestamp parsing
+ * - to_iso8601 for date formatting
+ * - date_diff for date differences
+ * - HyperLogLog (APPROX_SET, MERGE, CARDINALITY)
+ */
+
+import { FullSqlDialect } from "./index";
+import { baseDialect } from "./base-dialect";
+
+/**
+ * Athena dialect implementation.
+ *
+ * Extracted from Athena.ts to enable:
+ * - Unit testing of SQL generation without Athena client
+ * - Reuse in SQL builders without class instantiation
+ * - Clear separation of concerns
+ *
+ * Note: Athena uses Presto/Trino syntax.
+ */
+export const athenaDialect: FullSqlDialect = {
+  ...baseDialect,
+
+  formatDialect: "trino",
+
+  // ============================================================
+  // Date/Time Functions (Athena-specific)
+  // ============================================================
+
+  toTimestamp(date: Date): string {
+    return `from_iso8601_timestamp('${date.toISOString()}')`;
+  },
+
+  addTime(
+    col: string,
+    unit: "hour" | "minute",
+    sign: "+" | "-",
+    amount: number
+  ): string {
+    return `${col} ${sign} INTERVAL '${amount}' ${unit}`;
+  },
+
+  dateDiff(startCol: string, endCol: string): string {
+    return `date_diff('day', ${startCol}, ${endCol})`;
+  },
+
+  formatDate(col: string): string {
+    return `substr(to_iso8601(${col}),1,10)`;
+  },
+
+  formatDateTimeString(col: string): string {
+    return `to_iso8601(${col})`;
+  },
+
+  // ============================================================
+  // Type Casting (Athena-specific)
+  // ============================================================
+
+  ensureFloat(col: string): string {
+    return `CAST(${col} AS double)`;
+  },
+
+  // ============================================================
+  // HyperLogLog (Athena/Presto APPROX_SET)
+  // ============================================================
+
+  hasCountDistinctHLL(): boolean {
+    return true;
+  },
+
+  hllAggregate(col: string): string {
+    return `APPROX_SET(${col})`;
+  },
+
+  hllReaggregate(col: string): string {
+    return `MERGE(${col})`;
+  },
+
+  hllCardinality(col: string): string {
+    return `CARDINALITY(${col})`;
+  },
+
+  castToHllDataType(col: string): string {
+    return `CAST(${col} AS HyperLogLog)`;
+  },
+
+  // ============================================================
+  // Quantile (Athena uses standard APPROX_PERCENTILE)
+  // ============================================================
+
+  hasEfficientPercentile(): boolean {
+    return true;
+  },
+
+  hasQuantileTesting(): boolean {
+    return true;
+  },
+
+  approxQuantile(value: string, quantile: string | number): string {
+    return `APPROX_PERCENTILE(${value}, ${quantile})`;
+  },
+};

--- a/packages/back-end/src/integrations/sql-dialects/base-dialect.ts
+++ b/packages/back-end/src/integrations/sql-dialects/base-dialect.ts
@@ -1,0 +1,201 @@
+/**
+ * Base SQL Dialect Implementation
+ *
+ * Provides default implementations for SQL generation methods.
+ * These defaults match the original SqlIntegration.ts base class methods
+ * and work with standard SQL syntax.
+ *
+ * Database-specific dialects should extend or override these methods.
+ */
+
+import { DataType } from "shared/types/integrations";
+import { SqlDialect, QuantileDialect } from "./index";
+
+/**
+ * Base dialect with standard SQL implementations.
+ * This matches the original SqlIntegration defaults.
+ */
+export const baseDialect: SqlDialect & Partial<QuantileDialect> = {
+  formatDialect: "",
+
+  // ============================================================
+  // Date/Time Functions
+  // ============================================================
+
+  toTimestamp(date: Date): string {
+    return `'${date.toISOString().substr(0, 19).replace("T", " ")}'`;
+  },
+
+  toTimestampWithMs(date: Date): string {
+    return `'${date.toISOString().substring(0, 23).replace("T", " ")}'`;
+  },
+
+  addHours(col: string, hours: number): string {
+    if (!hours) return col;
+
+    let unit: "hour" | "minute" = "hour";
+    const sign = hours > 0 ? "+" : "-";
+    hours = Math.abs(hours);
+
+    const roundedHours = Math.round(hours);
+    const roundedMinutes = Math.round(hours * 60);
+
+    let amount = roundedHours;
+
+    // If minutes are needed, use them
+    if (roundedMinutes % 60 > 0) {
+      unit = "minute";
+      amount = roundedMinutes;
+    }
+
+    if (amount === 0) {
+      return col;
+    }
+
+    return this.addTime(col, unit, sign, amount);
+  },
+
+  addTime(
+    col: string,
+    unit: "hour" | "minute",
+    sign: "+" | "-",
+    amount: number
+  ): string {
+    return `${col} ${sign} INTERVAL '${amount} ${unit}s'`;
+  },
+
+  dateTrunc(col: string): string {
+    return `date_trunc('day', ${col})`;
+  },
+
+  dateDiff(startCol: string, endCol: string): string {
+    return `datediff(day, ${startCol}, ${endCol})`;
+  },
+
+  formatDate(col: string): string {
+    return col;
+  },
+
+  formatDateTimeString(col: string): string {
+    return this.castToString(col);
+  },
+
+  // ============================================================
+  // Type Casting
+  // ============================================================
+
+  castToString(col: string): string {
+    return `cast(${col} as varchar)`;
+  },
+
+  castToDate(col: string): string {
+    return `CAST(${col} AS DATE)`;
+  },
+
+  castToTimestamp(col: string): string {
+    return `CAST(${col} AS TIMESTAMP)`;
+  },
+
+  castUserDateCol(col: string): string {
+    return col;
+  },
+
+  ensureFloat(col: string): string {
+    return col;
+  },
+
+  // ============================================================
+  // String Functions
+  // ============================================================
+
+  escapeStringLiteral(value: string): string {
+    return value.replace(/'/g, `''`);
+  },
+
+  // ============================================================
+  // Control Flow
+  // ============================================================
+
+  ifElse(condition: string, ifTrue: string, ifFalse: string): string {
+    return `(CASE WHEN ${condition} THEN ${ifTrue} ELSE ${ifFalse} END)`;
+  },
+
+  evalBoolean(col: string, value: boolean): string {
+    return `${col} IS ${value ? "TRUE" : "FALSE"}`;
+  },
+
+  // ============================================================
+  // Query Structure
+  // ============================================================
+
+  selectStarLimit(table: string, limit: number): string {
+    return `SELECT * FROM ${table} LIMIT ${limit}`;
+  },
+
+  // ============================================================
+  // JSON Functions
+  // ============================================================
+
+  extractJSONField(jsonCol: string, path: string, isNumeric: boolean): string {
+    const raw = `json_extract_scalar(${jsonCol}, '$.${path}')`;
+    return isNumeric ? this.ensureFloat(raw) : raw;
+  },
+
+  // ============================================================
+  // Data Types
+  // ============================================================
+
+  getDataType(dataType: DataType): string {
+    switch (dataType) {
+      case "string":
+        return "VARCHAR";
+      case "integer":
+        return "INTEGER";
+      case "float":
+        return "FLOAT";
+      case "boolean":
+        return "BOOLEAN";
+      case "date":
+        return "DATE";
+      case "timestamp":
+        return "TIMESTAMP";
+      case "hll":
+        return "BINARY";
+      default: {
+        const _: never = dataType;
+        throw new Error(`Unsupported data type: ${dataType}`);
+      }
+    }
+  },
+
+  // ============================================================
+  // Quantile (optional - not all DBs support this)
+  // ============================================================
+
+  hasEfficientPercentile(): boolean {
+    return true;
+  },
+
+  hasQuantileTesting(): boolean {
+    return true;
+  },
+};
+
+/**
+ * Create a custom dialect by merging overrides with the base dialect.
+ * This is a helper for creating database-specific dialects.
+ *
+ * @example
+ * const myDialect = createDialect({
+ *   formatDialect: "postgresql",
+ *   dateDiff: (start, end) => `${end}::DATE - ${start}::DATE`,
+ * });
+ */
+export function createDialect<T extends Partial<SqlDialect>>(
+  overrides: T
+): SqlDialect & T {
+  return {
+    ...baseDialect,
+    ...overrides,
+  } as SqlDialect & T;
+}

--- a/packages/back-end/src/integrations/sql-dialects/bigquery-dialect.ts
+++ b/packages/back-end/src/integrations/sql-dialects/bigquery-dialect.ts
@@ -1,0 +1,159 @@
+/**
+ * BigQuery SQL Dialect
+ *
+ * Implements BigQuery-specific SQL generation methods including:
+ * - DATETIME functions (DATETIME_ADD, DATETIME_SUB)
+ * - HyperLogLog (HLL_COUNT.*)
+ * - APPROX_QUANTILES
+ * - BigQuery data types (STRING, INT64, FLOAT64, etc.)
+ */
+
+import { DataType } from "shared/types/integrations";
+import { FullSqlDialect } from "./index";
+import { baseDialect } from "./base-dialect";
+
+/**
+ * BigQuery dialect implementation.
+ *
+ * Extracted from BigQuery.ts to enable:
+ * - Unit testing of SQL generation without BigQuery client
+ * - Reuse in SQL builders without class instantiation
+ * - Clear separation of concerns
+ */
+export const bigQueryDialect: FullSqlDialect = {
+  ...baseDialect,
+
+  formatDialect: "bigquery",
+
+  // ============================================================
+  // Date/Time Functions (BigQuery-specific)
+  // ============================================================
+
+  addTime(
+    col: string,
+    unit: "hour" | "minute",
+    sign: "+" | "-",
+    amount: number
+  ): string {
+    return `DATETIME_${
+      sign === "+" ? "ADD" : "SUB"
+    }(${col}, INTERVAL ${amount} ${unit.toUpperCase()})`;
+  },
+
+  dateTrunc(col: string): string {
+    return `date_trunc(${col}, DAY)`;
+  },
+
+  dateDiff(startCol: string, endCol: string): string {
+    return `date_diff(${endCol}, ${startCol}, DAY)`;
+  },
+
+  formatDate(col: string): string {
+    return `format_date("%F", ${col})`;
+  },
+
+  formatDateTimeString(col: string): string {
+    return `format_datetime("%F %T", ${col})`;
+  },
+
+  // ============================================================
+  // Type Casting (BigQuery-specific)
+  // ============================================================
+
+  castToString(col: string): string {
+    return `cast(${col} as string)`;
+  },
+
+  castUserDateCol(col: string): string {
+    return `CAST(${col} as DATETIME)`;
+  },
+
+  // ============================================================
+  // String Functions (BigQuery-specific)
+  // ============================================================
+
+  escapeStringLiteral(value: string): string {
+    // BigQuery uses backslash escaping
+    return value.replace(/(['\\])/g, "\\$1");
+  },
+
+  // ============================================================
+  // JSON Functions (BigQuery-specific)
+  // ============================================================
+
+  extractJSONField(jsonCol: string, path: string, isNumeric: boolean): string {
+    const raw = `JSON_VALUE(${jsonCol}, '$.${path}')`;
+    return isNumeric ? `CAST(${raw} AS FLOAT64)` : raw;
+  },
+
+  // ============================================================
+  // Data Types (BigQuery-specific)
+  // ============================================================
+
+  getDataType(dataType: DataType): string {
+    switch (dataType) {
+      case "string":
+        return "STRING";
+      case "integer":
+        return "INT64";
+      case "float":
+        return "FLOAT64";
+      case "boolean":
+        return "BOOL";
+      case "date":
+        return "DATE";
+      case "timestamp":
+        return "TIMESTAMP";
+      case "hll":
+        return "BYTES";
+      default: {
+        const _: never = dataType;
+        throw new Error(`Unsupported data type: ${dataType}`);
+      }
+    }
+  },
+
+  // ============================================================
+  // HyperLogLog (BigQuery HLL_COUNT.*)
+  // ============================================================
+
+  hasCountDistinctHLL(): boolean {
+    return true;
+  },
+
+  hllAggregate(col: string): string {
+    return `HLL_COUNT.INIT(${col})`;
+  },
+
+  hllReaggregate(col: string): string {
+    return `HLL_COUNT.MERGE_PARTIAL(${col})`;
+  },
+
+  hllCardinality(col: string): string {
+    return `HLL_COUNT.EXTRACT(${col})`;
+  },
+
+  castToHllDataType(col: string): string {
+    return `CAST(${col} AS BYTES)`;
+  },
+
+  // ============================================================
+  // Quantile (BigQuery APPROX_QUANTILES)
+  // ============================================================
+
+  hasEfficientPercentile(): boolean {
+    return true;
+  },
+
+  hasQuantileTesting(): boolean {
+    return true;
+  },
+
+  approxQuantile(value: string, quantile: string | number): string {
+    const multiplier = 10000;
+    const quantileVal = Number(quantile)
+      ? Math.trunc(multiplier * Number(quantile))
+      : `${multiplier} * ${quantile}`;
+    return `APPROX_QUANTILES(${value}, ${multiplier} IGNORE NULLS)[OFFSET(CAST(${quantileVal} AS INT64))]`;
+  },
+};

--- a/packages/back-end/src/integrations/sql-dialects/clickhouse-dialect.ts
+++ b/packages/back-end/src/integrations/sql-dialects/clickhouse-dialect.ts
@@ -1,0 +1,159 @@
+/**
+ * ClickHouse SQL Dialect
+ *
+ * Implements ClickHouse-specific SQL generation methods including:
+ * - toDateTime for timestamp creation
+ * - dateAdd/dateSub for adding time
+ * - dateTrunc/dateDiff with lowercase names
+ * - formatDateTime for date formatting
+ * - if() function instead of CASE WHEN
+ * - HyperLogLog (uniqState, uniqMergeState, finalizeAggregation)
+ * - quantile() for approximate percentiles
+ * - JSON extraction with JSONExtract functions
+ */
+
+import { FullSqlDialect } from "./index";
+import { baseDialect } from "./base-dialect";
+
+/**
+ * ClickHouse dialect implementation.
+ *
+ * Extracted from ClickHouse.ts to enable:
+ * - Unit testing of SQL generation without ClickHouse client
+ * - Reuse in SQL builders without class instantiation
+ * - Clear separation of concerns
+ */
+export const clickhouseDialect: FullSqlDialect = {
+  ...baseDialect,
+
+  // sql-formatter doesn't have a dedicated ClickHouse dialect
+  formatDialect: "",
+
+  // ============================================================
+  // Date/Time Functions (ClickHouse-specific)
+  // ============================================================
+
+  toTimestamp(date: Date): string {
+    return `toDateTime('${date.toISOString().substr(0, 19).replace("T", " ")}', 'UTC')`;
+  },
+
+  addTime(
+    col: string,
+    unit: "hour" | "minute",
+    sign: "+" | "-",
+    amount: number
+  ): string {
+    return `date${sign === "+" ? "Add" : "Sub"}(${unit}, ${amount}, ${col})`;
+  },
+
+  dateTrunc(col: string): string {
+    return `dateTrunc('day', ${col})`;
+  },
+
+  dateDiff(startCol: string, endCol: string): string {
+    return `dateDiff('day', ${startCol}, ${endCol})`;
+  },
+
+  formatDate(col: string): string {
+    return `formatDateTime(${col}, '%F')`;
+  },
+
+  formatDateTimeString(col: string): string {
+    return `formatDateTime(${col}, '%Y-%m-%d %H:%i:%S.%f')`;
+  },
+
+  // ============================================================
+  // Type Casting (ClickHouse-specific)
+  // ============================================================
+
+  castToDate(col: string): string {
+    const columType = col === "NULL" ? "Nullable(DATE)" : "DATE";
+    return `CAST(${col} AS ${columType})`;
+  },
+
+  castToString(col: string): string {
+    return `toString(${col})`;
+  },
+
+  ensureFloat(col: string): string {
+    return `toFloat64(${col})`;
+  },
+
+  // ============================================================
+  // Control Flow (ClickHouse-specific)
+  // ============================================================
+
+  ifElse(condition: string, ifTrue: string, ifFalse: string): string {
+    return `if(${condition}, ${ifTrue}, ${ifFalse})`;
+  },
+
+  evalBoolean(col: string, value: boolean): string {
+    // ClickHouse does not support `IS TRUE` / `IS FALSE`
+    return `${col} = ${value ? "true" : "false"}`;
+  },
+
+  // ============================================================
+  // JSON Functions (ClickHouse-specific)
+  // ============================================================
+
+  extractJSONField(jsonCol: string, path: string, isNumeric: boolean): string {
+    if (isNumeric) {
+      return `
+if(
+  toTypeName(${jsonCol}) = 'JSON',
+  toFloat64(${jsonCol}.${path}),
+  JSONExtractFloat(${jsonCol}, '${path}')
+)
+      `.trim();
+    } else {
+      return `
+if(
+  toTypeName(${jsonCol}) = 'JSON',
+  ${jsonCol}.${path}.:String,
+  JSONExtractString(${jsonCol}, '${path}')
+)
+      `.trim();
+    }
+  },
+
+  // ============================================================
+  // HyperLogLog (ClickHouse uniq*)
+  // ============================================================
+
+  hasCountDistinctHLL(): boolean {
+    return true;
+  },
+
+  hllAggregate(col: string): string {
+    return `uniqState(${col})`;
+  },
+
+  hllReaggregate(col: string): string {
+    return `uniqMergeState(${col})`;
+  },
+
+  hllCardinality(col: string): string {
+    return `finalizeAggregation(${col})`;
+  },
+
+  castToHllDataType(col: string): string {
+    // ClickHouse uses AggregateFunction type, but for casting purposes BINARY works
+    return `CAST(${col} AS String)`;
+  },
+
+  // ============================================================
+  // Quantile (ClickHouse quantile)
+  // ============================================================
+
+  hasEfficientPercentile(): boolean {
+    return true;
+  },
+
+  hasQuantileTesting(): boolean {
+    return true;
+  },
+
+  approxQuantile(value: string, quantile: string | number): string {
+    return `quantile(${quantile})(${value})`;
+  },
+};

--- a/packages/back-end/src/integrations/sql-dialects/databricks-dialect.ts
+++ b/packages/back-end/src/integrations/sql-dialects/databricks-dialect.ts
@@ -1,0 +1,152 @@
+/**
+ * Databricks SQL Dialect
+ *
+ * Implements Databricks-specific SQL generation methods including:
+ * - TIMESTAMP'...' for timestamp literals
+ * - timestampadd for adding time
+ * - date_format for formatting
+ * - HyperLogLog (HLL_SKETCH_AGG, HLL_UNION_AGG, HLL_SKETCH_ESTIMATE)
+ * - JSON extraction with :path:: syntax
+ */
+
+import { DataType } from "shared/types/integrations";
+import { FullSqlDialect } from "./index";
+import { baseDialect } from "./base-dialect";
+
+/**
+ * Databricks dialect implementation.
+ *
+ * Extracted from Databricks.ts to enable:
+ * - Unit testing of SQL generation without Databricks client
+ * - Reuse in SQL builders without class instantiation
+ * - Clear separation of concerns
+ */
+export const databricksDialect: FullSqlDialect = {
+  ...baseDialect,
+
+  // sql-formatter doesn't support databricks explicitly yet
+  formatDialect: "sql",
+
+  // ============================================================
+  // Date/Time Functions (Databricks-specific)
+  // ============================================================
+
+  toTimestamp(date: Date): string {
+    return `TIMESTAMP'${date.toISOString()}'`;
+  },
+
+  addTime(
+    col: string,
+    unit: "hour" | "minute",
+    sign: "+" | "-",
+    amount: number
+  ): string {
+    return `timestampadd(${unit},${sign === "-" ? "-" : ""}${amount},${col})`;
+  },
+
+  formatDate(col: string): string {
+    return `date_format(${col}, 'y-MM-dd')`;
+  },
+
+  formatDateTimeString(col: string): string {
+    return `date_format(${col}, 'y-MM-dd HH:mm:ss.SSS')`;
+  },
+
+  // ============================================================
+  // Type Casting (Databricks-specific)
+  // ============================================================
+
+  castToString(col: string): string {
+    return `cast(${col} as string)`;
+  },
+
+  ensureFloat(col: string): string {
+    return `cast(${col} as double)`;
+  },
+
+  // ============================================================
+  // String Functions (Databricks-specific)
+  // ============================================================
+
+  escapeStringLiteral(value: string): string {
+    // Databricks uses backslash escaping like BigQuery
+    return value.replace(/(['\\])/g, "\\$1");
+  },
+
+  // ============================================================
+  // JSON Functions (Databricks-specific)
+  // ============================================================
+
+  extractJSONField(jsonCol: string, path: string, isNumeric: boolean): string {
+    const raw = `${jsonCol}:${path}`;
+    return isNumeric ? `cast(${raw} as double)` : raw;
+  },
+
+  // ============================================================
+  // Data Types (Databricks-specific)
+  // ============================================================
+
+  getDataType(dataType: DataType): string {
+    switch (dataType) {
+      case "string":
+        return "STRING";
+      case "integer":
+        return "INT";
+      case "float":
+        return "DOUBLE";
+      case "boolean":
+        return "BOOLEAN";
+      case "date":
+        return "DATE";
+      case "timestamp":
+        return "TIMESTAMP";
+      case "hll":
+        return "BINARY";
+      default: {
+        const _: never = dataType;
+        throw new Error(`Unsupported data type: ${dataType}`);
+      }
+    }
+  },
+
+  // ============================================================
+  // HyperLogLog (Databricks HLL_SKETCH_*)
+  // ============================================================
+
+  hasCountDistinctHLL(): boolean {
+    return true;
+  },
+
+  hllAggregate(col: string): string {
+    // Databricks requires string input for HLL_SKETCH_AGG
+    return `HLL_SKETCH_AGG(cast(${col} as string))`;
+  },
+
+  hllReaggregate(col: string): string {
+    return `HLL_UNION_AGG(${col})`;
+  },
+
+  hllCardinality(col: string): string {
+    return `HLL_SKETCH_ESTIMATE(${col})`;
+  },
+
+  castToHllDataType(col: string): string {
+    return `CAST(${col} AS BINARY)`;
+  },
+
+  // ============================================================
+  // Quantile (Databricks uses APPROX_PERCENTILE)
+  // ============================================================
+
+  hasEfficientPercentile(): boolean {
+    return true;
+  },
+
+  hasQuantileTesting(): boolean {
+    return true;
+  },
+
+  approxQuantile(value: string, quantile: string | number): string {
+    return `APPROX_PERCENTILE(${value}, ${quantile})`;
+  },
+};

--- a/packages/back-end/src/integrations/sql-dialects/index.ts
+++ b/packages/back-end/src/integrations/sql-dialects/index.ts
@@ -1,0 +1,280 @@
+/**
+ * SQL Dialect Interface
+ *
+ * This module provides a dialect abstraction for SQL generation across different
+ * database systems (BigQuery, Snowflake, Postgres, etc.). Each database has its
+ * own syntax for dates, casting, aggregations, etc.
+ *
+ * The goal is to extract these dialect-specific methods from SqlIntegration.ts
+ * into composable, testable units that can be used independently.
+ */
+
+import { FormatDialect } from "shared/types/sql";
+import { DataType } from "shared/types/integrations";
+
+/**
+ * Core SQL dialect interface for database-specific SQL generation.
+ *
+ * All methods are pure functions that return SQL fragments. They do not
+ * execute queries or have side effects.
+ */
+export interface SqlDialect {
+  /**
+   * The format dialect used by sql-formatter library.
+   * E.g., "bigquery", "snowflake", "postgresql", "mysql", "trino", "tsql"
+   */
+  readonly formatDialect: FormatDialect;
+
+  // ============================================================
+  // Date/Time Functions
+  // ============================================================
+
+  /**
+   * Convert a JavaScript Date to a SQL timestamp literal (without milliseconds).
+   * @example toTimestamp(new Date('2023-01-15T12:30:45Z')) => "'2023-01-15 12:30:45'"
+   */
+  toTimestamp(date: Date): string;
+
+  /**
+   * Convert a JavaScript Date to a SQL timestamp literal (with milliseconds).
+   * @example toTimestampWithMs(new Date('2023-01-15T12:30:45.123Z')) => "'2023-01-15 12:30:45.123'"
+   */
+  toTimestampWithMs(date: Date): string;
+
+  /**
+   * Add hours to a datetime column.
+   * @example addHours('timestamp', 24) => "DATETIME_ADD(timestamp, INTERVAL 24 HOUR)"
+   */
+  addHours(col: string, hours: number): string;
+
+  /**
+   * Add time to a datetime column with specified unit and sign.
+   * @example addTime('timestamp', 'hour', '+', 24) => "timestamp + INTERVAL '24 hours'"
+   */
+  addTime(
+    col: string,
+    unit: "hour" | "minute",
+    sign: "+" | "-",
+    amount: number
+  ): string;
+
+  /**
+   * Truncate a timestamp/datetime to day granularity.
+   * @example dateTrunc('timestamp') => "date_trunc('day', timestamp)"
+   */
+  dateTrunc(col: string): string;
+
+  /**
+   * Calculate the difference in days between two date columns.
+   * @example dateDiff('start_date', 'end_date') => "datediff(day, start_date, end_date)"
+   */
+  dateDiff(startCol: string, endCol: string): string;
+
+  /**
+   * Format a date column as a string in YYYY-MM-DD format.
+   * @example formatDate('date_col') => "format_date('%F', date_col)"
+   */
+  formatDate(col: string): string;
+
+  /**
+   * Format a datetime column as a string in YYYY-MM-DD HH:MI:SS format.
+   * @example formatDateTimeString('datetime_col') => "format_datetime('%F %T', datetime_col)"
+   */
+  formatDateTimeString(col: string): string;
+
+  // ============================================================
+  // Type Casting
+  // ============================================================
+
+  /**
+   * Cast a column to a string type.
+   * @example castToString('numeric_col') => "cast(numeric_col as string)"
+   */
+  castToString(col: string): string;
+
+  /**
+   * Cast a column to a date type.
+   * @example castToDate('string_col') => "CAST(string_col AS DATE)"
+   */
+  castToDate(col: string): string;
+
+  /**
+   * Cast a column to a timestamp type.
+   * @example castToTimestamp('string_col') => "CAST(string_col AS TIMESTAMP)"
+   */
+  castToTimestamp(col: string): string;
+
+  /**
+   * Cast a user-provided date column (may need special handling).
+   * BigQuery needs DATETIME, others may differ.
+   * @example castUserDateCol('user_date') => "CAST(user_date as DATETIME)"
+   */
+  castUserDateCol(col: string): string;
+
+  /**
+   * Ensure a column is a float type (for arithmetic operations).
+   * @example ensureFloat('int_col') => "int_col::float"
+   */
+  ensureFloat(col: string): string;
+
+  // ============================================================
+  // String Functions
+  // ============================================================
+
+  /**
+   * Escape a string value for use in a SQL literal.
+   * @example escapeStringLiteral("it's") => "it''s" or "it\'s"
+   */
+  escapeStringLiteral(value: string): string;
+
+  // ============================================================
+  // Control Flow
+  // ============================================================
+
+  /**
+   * Generate a CASE WHEN expression.
+   * @example ifElse('x > 0', '1', '0') => "(CASE WHEN x > 0 THEN 1 ELSE 0 END)"
+   */
+  ifElse(condition: string, ifTrue: string, ifFalse: string): string;
+
+  /**
+   * Generate a boolean evaluation expression.
+   * @example evalBoolean('active', true) => "active IS TRUE"
+   */
+  evalBoolean(col: string, value: boolean): string;
+
+  // ============================================================
+  // Query Structure
+  // ============================================================
+
+  /**
+   * Generate a SELECT * with LIMIT statement.
+   * @example selectStarLimit('users', 10) => "SELECT * FROM users LIMIT 10"
+   */
+  selectStarLimit(table: string, limit: number): string;
+
+  // ============================================================
+  // JSON Functions
+  // ============================================================
+
+  /**
+   * Extract a field from a JSON column.
+   * @example extractJSONField('json_col', 'user.name', false) => "JSON_VALUE(json_col, '$.user.name')"
+   */
+  extractJSONField(jsonCol: string, path: string, isNumeric: boolean): string;
+
+  // ============================================================
+  // Data Types
+  // ============================================================
+
+  /**
+   * Map a logical DataType to the database-specific SQL type name.
+   * @example getDataType('string') => "STRING" (BigQuery) or "VARCHAR" (Snowflake)
+   */
+  getDataType(dataType: DataType): string;
+}
+
+/**
+ * Extended dialect interface for databases that support HyperLogLog
+ * (approximate count distinct).
+ */
+export interface HllDialect {
+  /**
+   * Check if HLL count distinct is supported.
+   */
+  hasCountDistinctHLL(): boolean;
+
+  /**
+   * Aggregate values into an HLL sketch.
+   * @example hllAggregate('user_id') => "HLL_COUNT.INIT(user_id)"
+   */
+  hllAggregate(col: string): string;
+
+  /**
+   * Merge HLL sketches (for reaggregation).
+   * @example hllReaggregate('hll_col') => "HLL_COUNT.MERGE_PARTIAL(hll_col)"
+   */
+  hllReaggregate(col: string): string;
+
+  /**
+   * Extract cardinality from an HLL sketch.
+   * @example hllCardinality('hll_col') => "HLL_COUNT.EXTRACT(hll_col)"
+   */
+  hllCardinality(col: string): string;
+
+  /**
+   * Cast a column to the HLL data type.
+   * @example castToHllDataType('col') => "CAST(col AS BYTES)"
+   */
+  castToHllDataType(col: string): string;
+}
+
+/**
+ * Extended dialect interface for databases that support quantile/percentile functions.
+ */
+export interface QuantileDialect {
+  /**
+   * Check if the database has efficient percentile/quantile support.
+   * Some databases (like MySQL) have limited support.
+   */
+  hasEfficientPercentile(): boolean;
+
+  /**
+   * Check if quantile testing is supported.
+   */
+  hasQuantileTesting(): boolean;
+
+  /**
+   * Generate an approximate quantile expression.
+   * @example approxQuantile('value', 0.5) => "APPROX_QUANTILES(value, 10000)[OFFSET(5000)]"
+   */
+  approxQuantile(value: string, quantile: string | number): string;
+}
+
+/**
+ * Full dialect interface combining core, HLL, and quantile capabilities.
+ */
+export interface FullSqlDialect extends SqlDialect, HllDialect, QuantileDialect {}
+
+/**
+ * Type guard to check if a dialect supports HLL operations.
+ */
+export function hasHllSupport(
+  dialect: SqlDialect
+): dialect is SqlDialect & HllDialect {
+  const d = dialect as unknown as Partial<HllDialect>;
+  return (
+    typeof d.hasCountDistinctHLL === "function" &&
+    typeof d.hllAggregate === "function" &&
+    typeof d.hllReaggregate === "function" &&
+    typeof d.hllCardinality === "function" &&
+    d.hasCountDistinctHLL()
+  );
+}
+
+/**
+ * Type guard to check if a dialect supports quantile operations.
+ */
+export function hasQuantileSupport(
+  dialect: SqlDialect
+): dialect is SqlDialect & QuantileDialect {
+  const d = dialect as unknown as Partial<QuantileDialect>;
+  return (
+    typeof d.approxQuantile === "function" &&
+    typeof d.hasEfficientPercentile === "function" &&
+    typeof d.hasQuantileTesting === "function"
+  );
+}
+
+// Re-export implementations
+export { baseDialect } from "./base-dialect";
+export { bigQueryDialect } from "./bigquery-dialect";
+export { snowflakeDialect } from "./snowflake-dialect";
+export { postgresDialect } from "./postgres-dialect";
+export { redshiftDialect } from "./redshift-dialect";
+export { athenaDialect } from "./athena-dialect";
+export { prestoDialect } from "./presto-dialect";
+export { databricksDialect } from "./databricks-dialect";
+export { clickhouseDialect } from "./clickhouse-dialect";
+export { mysqlDialect } from "./mysql-dialect";
+export { mssqlDialect } from "./mssql-dialect";

--- a/packages/back-end/src/integrations/sql-dialects/mssql-dialect.ts
+++ b/packages/back-end/src/integrations/sql-dialects/mssql-dialect.ts
@@ -1,0 +1,137 @@
+/**
+ * Microsoft SQL Server (MSSQL) SQL Dialect
+ *
+ * Implements MSSQL-specific SQL generation methods including:
+ * - DATEADD for adding time
+ * - cast(col as DATE) for date truncation (DATETRUNC is SQL Server 2022+)
+ * - FORMAT for date formatting
+ * - SELECT TOP instead of LIMIT
+ * - CONVERT for datetime strings
+ * - JSON_VALUE for JSON extraction
+ * - Boolean comparison using = 1/0 instead of IS TRUE/FALSE
+ * - No HLL support
+ * - APPROX_PERCENTILE_CONT for quantiles
+ */
+
+import { FullSqlDialect } from "./index";
+import { baseDialect } from "./base-dialect";
+
+/**
+ * MSSQL dialect implementation.
+ *
+ * Extracted from Mssql.ts to enable:
+ * - Unit testing of SQL generation without MSSQL client
+ * - Reuse in SQL builders without class instantiation
+ * - Clear separation of concerns
+ */
+export const mssqlDialect: FullSqlDialect = {
+  ...baseDialect,
+
+  formatDialect: "tsql",
+
+  // ============================================================
+  // Date/Time Functions (MSSQL-specific)
+  // ============================================================
+
+  addTime(
+    col: string,
+    unit: "hour" | "minute",
+    sign: "+" | "-",
+    amount: number
+  ): string {
+    return `DATEADD(${unit}, ${sign === "-" ? "-" : ""}${amount}, ${col})`;
+  },
+
+  dateTrunc(col: string): string {
+    // DATETRUNC is only supported in SQL Server 2022 preview
+    return `cast(${col} as DATE)`;
+  },
+
+  formatDate(col: string): string {
+    return `FORMAT(${col}, 'yyyy-MM-dd')`;
+  },
+
+  formatDateTimeString(col: string): string {
+    // CONVERT with style 121 gives: yyyy-mm-dd hh:mi:ss.mmm
+    return `CONVERT(VARCHAR(25), ${col}, 121)`;
+  },
+
+  // ============================================================
+  // Type Casting (MSSQL-specific)
+  // ============================================================
+
+  castToString(col: string): string {
+    return `cast(${col} as varchar(256))`;
+  },
+
+  ensureFloat(col: string): string {
+    return `CAST(${col} as FLOAT)`;
+  },
+
+  // ============================================================
+  // Query Structure (MSSQL-specific)
+  // ============================================================
+
+  selectStarLimit(table: string, limit: number): string {
+    // MSSQL doesn't support LIMIT, uses TOP instead
+    return `SELECT TOP ${limit} * FROM ${table}`;
+  },
+
+  // ============================================================
+  // Control Flow (MSSQL-specific)
+  // ============================================================
+
+  evalBoolean(col: string, value: boolean): string {
+    // MS SQL does not support `IS TRUE` / `IS FALSE`
+    return `${col} = ${value ? "1" : "0"}`;
+  },
+
+  // ============================================================
+  // JSON Functions (MSSQL-specific)
+  // ============================================================
+
+  extractJSONField(jsonCol: string, path: string, isNumeric: boolean): string {
+    const raw = `JSON_VALUE(${jsonCol}, '$.${path}')`;
+    return isNumeric ? `CAST(${raw} as FLOAT)` : raw;
+  },
+
+  // ============================================================
+  // HyperLogLog (MSSQL does not support HLL)
+  // ============================================================
+
+  hasCountDistinctHLL(): boolean {
+    return false;
+  },
+
+  hllAggregate(_col: string): string {
+    throw new Error("MSSQL does not support HyperLogLog");
+  },
+
+  hllReaggregate(_col: string): string {
+    throw new Error("MSSQL does not support HyperLogLog");
+  },
+
+  hllCardinality(_col: string): string {
+    throw new Error("MSSQL does not support HyperLogLog");
+  },
+
+  castToHllDataType(_col: string): string {
+    throw new Error("MSSQL does not support HyperLogLog");
+  },
+
+  // ============================================================
+  // Quantile (MSSQL APPROX_PERCENTILE_CONT)
+  // ============================================================
+
+  hasEfficientPercentile(): boolean {
+    return true;
+  },
+
+  hasQuantileTesting(): boolean {
+    return true;
+  },
+
+  approxQuantile(value: string, quantile: string | number): string {
+    return `APPROX_PERCENTILE_CONT(${quantile}) WITHIN GROUP (ORDER BY ${value})`;
+  },
+};

--- a/packages/back-end/src/integrations/sql-dialects/mysql-dialect.ts
+++ b/packages/back-end/src/integrations/sql-dialects/mysql-dialect.ts
@@ -1,0 +1,124 @@
+/**
+ * MySQL SQL Dialect
+ *
+ * Implements MySQL-specific SQL generation methods including:
+ * - DATE_ADD/DATE_SUB for adding time
+ * - DATE() for date truncation
+ * - DATE_FORMAT for formatting
+ * - DATEDIFF with reversed order
+ * - JSON_EXTRACT for JSON extraction
+ * - No HLL support
+ * - Limited percentile support
+ */
+
+import { FullSqlDialect } from "./index";
+import { baseDialect } from "./base-dialect";
+
+/**
+ * MySQL dialect implementation.
+ *
+ * Extracted from Mysql.ts to enable:
+ * - Unit testing of SQL generation without MySQL client
+ * - Reuse in SQL builders without class instantiation
+ * - Clear separation of concerns
+ */
+export const mysqlDialect: FullSqlDialect = {
+  ...baseDialect,
+
+  formatDialect: "mysql",
+
+  // ============================================================
+  // Date/Time Functions (MySQL-specific)
+  // ============================================================
+
+  addTime(
+    col: string,
+    unit: "hour" | "minute",
+    sign: "+" | "-",
+    amount: number
+  ): string {
+    return `DATE_${sign === "+" ? "ADD" : "SUB"}(${col}, INTERVAL ${amount} ${unit.toUpperCase()})`;
+  },
+
+  dateTrunc(col: string): string {
+    return `DATE(${col})`;
+  },
+
+  dateDiff(startCol: string, endCol: string): string {
+    // MySQL DATEDIFF takes (end, start), returns end - start
+    return `DATEDIFF(${endCol}, ${startCol})`;
+  },
+
+  formatDate(col: string): string {
+    return `DATE_FORMAT(${col}, "%Y-%m-%d")`;
+  },
+
+  formatDateTimeString(col: string): string {
+    return `DATE_FORMAT(${col}, "%Y-%m-%d %H:%i:%S")`;
+  },
+
+  // ============================================================
+  // Type Casting (MySQL-specific)
+  // ============================================================
+
+  castToString(col: string): string {
+    return `cast(${col} as char)`;
+  },
+
+  ensureFloat(col: string): string {
+    return `CAST(${col} AS DOUBLE)`;
+  },
+
+  // ============================================================
+  // JSON Functions (MySQL-specific)
+  // ============================================================
+
+  extractJSONField(jsonCol: string, path: string, isNumeric: boolean): string {
+    const raw = `JSON_EXTRACT(${jsonCol}, '$.${path}')`;
+    return isNumeric ? `CAST(${raw} AS DOUBLE)` : raw;
+  },
+
+  // ============================================================
+  // HyperLogLog (MySQL does not support HLL)
+  // ============================================================
+
+  hasCountDistinctHLL(): boolean {
+    return false;
+  },
+
+  hllAggregate(_col: string): string {
+    throw new Error("MySQL does not support HyperLogLog");
+  },
+
+  hllReaggregate(_col: string): string {
+    throw new Error("MySQL does not support HyperLogLog");
+  },
+
+  hllCardinality(_col: string): string {
+    throw new Error("MySQL does not support HyperLogLog");
+  },
+
+  castToHllDataType(_col: string): string {
+    throw new Error("MySQL does not support HyperLogLog");
+  },
+
+  // ============================================================
+  // Quantile (MySQL has limited support)
+  // ============================================================
+
+  hasEfficientPercentile(): boolean {
+    return false;
+  },
+
+  hasQuantileTesting(): boolean {
+    return false;
+  },
+
+  approxQuantile(_value: string, _quantile: string | number): string {
+    // MySQL doesn't have a built-in percentile function
+    // The actual implementation in Mysql.ts uses a complex workaround
+    throw new Error(
+      "MySQL does not have a built-in approximate percentile function"
+    );
+  },
+};

--- a/packages/back-end/src/integrations/sql-dialects/postgres-dialect.ts
+++ b/packages/back-end/src/integrations/sql-dialects/postgres-dialect.ts
@@ -1,0 +1,106 @@
+/**
+ * PostgreSQL SQL Dialect
+ *
+ * Implements PostgreSQL-specific SQL generation methods including:
+ * - to_char for date formatting
+ * - :: cast syntax
+ * - JSON_EXTRACT_PATH_TEXT for JSON extraction
+ * - PERCENTILE_CONT for quantiles (no approx)
+ */
+
+import { FullSqlDialect } from "./index";
+import { baseDialect } from "./base-dialect";
+
+/**
+ * PostgreSQL dialect implementation.
+ *
+ * Extracted from Postgres.ts to enable:
+ * - Unit testing of SQL generation without Postgres client
+ * - Reuse in SQL builders without class instantiation
+ * - Clear separation of concerns
+ */
+export const postgresDialect: FullSqlDialect = {
+  ...baseDialect,
+
+  formatDialect: "postgresql",
+
+  // ============================================================
+  // Date/Time Functions (PostgreSQL-specific)
+  // ============================================================
+
+  dateDiff(startCol: string, endCol: string): string {
+    // Postgres doesn't have a DATEDIFF function, use subtraction
+    return `${endCol}::DATE - ${startCol}::DATE`;
+  },
+
+  formatDate(col: string): string {
+    return `to_char(${col}, 'YYYY-MM-DD')`;
+  },
+
+  formatDateTimeString(col: string): string {
+    return `to_char(${col}, 'YYYY-MM-DD HH24:MI:SS.MS')`;
+  },
+
+  // ============================================================
+  // Type Casting (PostgreSQL-specific)
+  // ============================================================
+
+  ensureFloat(col: string): string {
+    return `${col}::float`;
+  },
+
+  // ============================================================
+  // JSON Functions (PostgreSQL-specific)
+  // ============================================================
+
+  extractJSONField(jsonCol: string, path: string, isNumeric: boolean): string {
+    // Split path by '.' and wrap each part in quotes
+    const pathParts = path
+      .split(".")
+      .map((p) => `'${p}'`)
+      .join(", ");
+    const raw = `JSON_EXTRACT_PATH_TEXT(${jsonCol}::json, ${pathParts})`;
+    return isNumeric ? `${raw}::float` : raw;
+  },
+
+  // ============================================================
+  // HyperLogLog (PostgreSQL does not have native HLL)
+  // ============================================================
+
+  hasCountDistinctHLL(): boolean {
+    return false;
+  },
+
+  hllAggregate(_col: string): string {
+    throw new Error("PostgreSQL does not support HyperLogLog natively");
+  },
+
+  hllReaggregate(_col: string): string {
+    throw new Error("PostgreSQL does not support HyperLogLog natively");
+  },
+
+  hllCardinality(_col: string): string {
+    throw new Error("PostgreSQL does not support HyperLogLog natively");
+  },
+
+  castToHllDataType(_col: string): string {
+    throw new Error("PostgreSQL does not support HyperLogLog natively");
+  },
+
+  // ============================================================
+  // Quantile (PostgreSQL PERCENTILE_CONT - no approx)
+  // ============================================================
+
+  hasEfficientPercentile(): boolean {
+    return true;
+  },
+
+  hasQuantileTesting(): boolean {
+    return true;
+  },
+
+  approxQuantile(value: string, quantile: string | number): string {
+    // PostgreSQL doesn't have approx quantile, use exact
+    return `PERCENTILE_CONT(${quantile}) WITHIN GROUP (ORDER BY ${value})`;
+  },
+};

--- a/packages/back-end/src/integrations/sql-dialects/presto-dialect.ts
+++ b/packages/back-end/src/integrations/sql-dialects/presto-dialect.ts
@@ -1,0 +1,106 @@
+/**
+ * Presto/Trino SQL Dialect
+ *
+ * Implements Presto-specific SQL generation methods including:
+ * - from_iso8601_timestamp for timestamp parsing
+ * - to_iso8601 for date formatting
+ * - date_diff for date differences
+ * - HyperLogLog (APPROX_SET, MERGE with HyperLogLog cast, CARDINALITY)
+ *
+ * Note: Very similar to Athena, but with slight differences in HLL handling.
+ */
+
+import { FullSqlDialect } from "./index";
+import { baseDialect } from "./base-dialect";
+
+/**
+ * Presto/Trino dialect implementation.
+ *
+ * Extracted from Presto.ts to enable:
+ * - Unit testing of SQL generation without Presto client
+ * - Reuse in SQL builders without class instantiation
+ * - Clear separation of concerns
+ */
+export const prestoDialect: FullSqlDialect = {
+  ...baseDialect,
+
+  formatDialect: "trino",
+
+  // ============================================================
+  // Date/Time Functions (Presto-specific)
+  // ============================================================
+
+  toTimestamp(date: Date): string {
+    return `from_iso8601_timestamp('${date.toISOString()}')`;
+  },
+
+  addTime(
+    col: string,
+    unit: "hour" | "minute",
+    sign: "+" | "-",
+    amount: number
+  ): string {
+    return `${col} ${sign} INTERVAL '${amount}' ${unit}`;
+  },
+
+  dateDiff(startCol: string, endCol: string): string {
+    return `date_diff('day', ${startCol}, ${endCol})`;
+  },
+
+  formatDate(col: string): string {
+    return `substr(to_iso8601(${col}),1,10)`;
+  },
+
+  formatDateTimeString(col: string): string {
+    return `to_iso8601(${col})`;
+  },
+
+  // ============================================================
+  // Type Casting (Presto-specific)
+  // ============================================================
+
+  ensureFloat(col: string): string {
+    return `CAST(${col} AS DOUBLE)`;
+  },
+
+  // ============================================================
+  // HyperLogLog (Presto APPROX_SET with explicit HyperLogLog cast for merge)
+  // ============================================================
+
+  hasCountDistinctHLL(): boolean {
+    return true;
+  },
+
+  hllAggregate(col: string): string {
+    return `APPROX_SET(${col})`;
+  },
+
+  hllReaggregate(col: string): string {
+    // Presto requires explicit cast to HyperLogLog for MERGE
+    return `MERGE(CAST(${col} AS HyperLogLog))`;
+  },
+
+  hllCardinality(col: string): string {
+    return `CARDINALITY(${col})`;
+  },
+
+  castToHllDataType(col: string): string {
+    return `CAST(${col} AS HyperLogLog)`;
+  },
+
+  // ============================================================
+  // Quantile (Presto uses APPROX_PERCENTILE)
+  // ============================================================
+
+  hasEfficientPercentile(): boolean {
+    return true;
+  },
+
+  hasQuantileTesting(): boolean {
+    return true;
+  },
+
+  approxQuantile(value: string, quantile: string | number): string {
+    return `APPROX_PERCENTILE(${value}, ${quantile})`;
+  },
+};

--- a/packages/back-end/src/integrations/sql-dialects/redshift-dialect.ts
+++ b/packages/back-end/src/integrations/sql-dialects/redshift-dialect.ts
@@ -1,0 +1,106 @@
+/**
+ * Amazon Redshift SQL Dialect
+ *
+ * Implements Redshift-specific SQL generation methods including:
+ * - to_char for date formatting (like Postgres)
+ * - :: cast syntax
+ * - JSON_EXTRACT_PATH_TEXT for JSON extraction (with TRUE for null handling)
+ * - HyperLogLog (HLL_CREATE_SKETCH, HLL_COMBINE, HLL_CARDINALITY)
+ * - PERCENTILE_CONT for quantiles (no efficient approx)
+ */
+
+import { FullSqlDialect } from "./index";
+import { baseDialect } from "./base-dialect";
+
+/**
+ * Redshift dialect implementation.
+ *
+ * Extracted from Redshift.ts to enable:
+ * - Unit testing of SQL generation without Redshift client
+ * - Reuse in SQL builders without class instantiation
+ * - Clear separation of concerns
+ *
+ * Note: Redshift is similar to PostgreSQL but has some differences,
+ * particularly around HLL support and JSON handling.
+ */
+export const redshiftDialect: FullSqlDialect = {
+  ...baseDialect,
+
+  formatDialect: "redshift",
+
+  // ============================================================
+  // Date/Time Functions (Redshift-specific, similar to Postgres)
+  // ============================================================
+
+  formatDate(col: string): string {
+    return `to_char(${col}, 'YYYY-MM-DD')`;
+  },
+
+  formatDateTimeString(col: string): string {
+    return `to_char(${col}, 'YYYY-MM-DD HH24:MI:SS.MS')`;
+  },
+
+  // ============================================================
+  // Type Casting (Redshift-specific)
+  // ============================================================
+
+  ensureFloat(col: string): string {
+    return `${col}::float`;
+  },
+
+  // ============================================================
+  // JSON Functions (Redshift-specific)
+  // ============================================================
+
+  extractJSONField(jsonCol: string, path: string, isNumeric: boolean): string {
+    // Redshift's JSON_EXTRACT_PATH_TEXT takes TRUE as final param for null handling
+    const pathParts = path
+      .split(".")
+      .map((p) => `'${p}'`)
+      .join(", ");
+    const raw = `JSON_EXTRACT_PATH_TEXT(${jsonCol}, ${pathParts}, TRUE)`;
+    return isNumeric ? `${raw}::float` : raw;
+  },
+
+  // ============================================================
+  // HyperLogLog (Redshift HLL_*)
+  // ============================================================
+
+  hasCountDistinctHLL(): boolean {
+    return true;
+  },
+
+  hllAggregate(col: string): string {
+    return `HLL_CREATE_SKETCH(${col})`;
+  },
+
+  hllReaggregate(col: string): string {
+    return `HLL_COMBINE(${col})`;
+  },
+
+  hllCardinality(col: string): string {
+    return `HLL_CARDINALITY(${col})`;
+  },
+
+  castToHllDataType(col: string): string {
+    return `CAST(${col} AS HLLSKETCH)`;
+  },
+
+  // ============================================================
+  // Quantile (Redshift - no efficient approx percentile)
+  // ============================================================
+
+  hasEfficientPercentile(): boolean {
+    // Redshift's approx behaves differently, so we mark as not efficient
+    return false;
+  },
+
+  hasQuantileTesting(): boolean {
+    return true;
+  },
+
+  approxQuantile(value: string, quantile: string | number): string {
+    // Use exact percentile since approx behaves differently in Redshift
+    return `PERCENTILE_CONT(${quantile}) WITHIN GROUP (ORDER BY ${value})`;
+  },
+};

--- a/packages/back-end/src/integrations/sql-dialects/snowflake-dialect.ts
+++ b/packages/back-end/src/integrations/sql-dialects/snowflake-dialect.ts
@@ -1,0 +1,128 @@
+/**
+ * Snowflake SQL Dialect
+ *
+ * Implements Snowflake-specific SQL generation methods including:
+ * - TO_VARCHAR for casting/formatting
+ * - HyperLogLog (HLL_ACCUMULATE, HLL_COMBINE, HLL_ESTIMATE)
+ * - PARSE_JSON for JSON extraction
+ * - Snowflake data types (VARCHAR, DOUBLE, etc.)
+ */
+
+import { DataType } from "shared/types/integrations";
+import { FullSqlDialect } from "./index";
+import { baseDialect } from "./base-dialect";
+
+/**
+ * Snowflake dialect implementation.
+ *
+ * Extracted from Snowflake.ts to enable:
+ * - Unit testing of SQL generation without Snowflake client
+ * - Reuse in SQL builders without class instantiation
+ * - Clear separation of concerns
+ */
+export const snowflakeDialect: FullSqlDialect = {
+  ...baseDialect,
+
+  formatDialect: "snowflake",
+
+  // ============================================================
+  // Date/Time Functions (Snowflake-specific)
+  // ============================================================
+
+  formatDate(col: string): string {
+    return `TO_VARCHAR(${col}, 'YYYY-MM-DD')`;
+  },
+
+  formatDateTimeString(col: string): string {
+    return `TO_VARCHAR(${col}, 'YYYY-MM-DD HH24:MI:SS.MS')`;
+  },
+
+  // ============================================================
+  // Type Casting (Snowflake-specific)
+  // ============================================================
+
+  castToString(col: string): string {
+    return `TO_VARCHAR(${col})`;
+  },
+
+  ensureFloat(col: string): string {
+    return `CAST(${col} AS DOUBLE)`;
+  },
+
+  // ============================================================
+  // JSON Functions (Snowflake-specific)
+  // ============================================================
+
+  extractJSONField(jsonCol: string, path: string, isNumeric: boolean): string {
+    const floatType = "float";
+    const stringType = "string";
+    return `PARSE_JSON(${jsonCol}):${path}::${isNumeric ? floatType : stringType}`;
+  },
+
+  // ============================================================
+  // Data Types (Snowflake-specific)
+  // ============================================================
+
+  getDataType(dataType: DataType): string {
+    switch (dataType) {
+      case "string":
+        return "VARCHAR";
+      case "integer":
+        return "INTEGER";
+      case "float":
+        return "DOUBLE";
+      case "boolean":
+        return "BOOLEAN";
+      case "date":
+        return "DATE";
+      case "timestamp":
+        return "TIMESTAMP";
+      case "hll":
+        return "BINARY";
+      default: {
+        const _: never = dataType;
+        throw new Error(`Unsupported data type: ${dataType}`);
+      }
+    }
+  },
+
+  // ============================================================
+  // HyperLogLog (Snowflake HLL_*)
+  // ============================================================
+
+  hasCountDistinctHLL(): boolean {
+    return true;
+  },
+
+  hllAggregate(col: string): string {
+    return `HLL_ACCUMULATE(${col})`;
+  },
+
+  hllReaggregate(col: string): string {
+    return `HLL_COMBINE(${col})`;
+  },
+
+  hllCardinality(col: string): string {
+    return `HLL_ESTIMATE(${col})`;
+  },
+
+  castToHllDataType(col: string): string {
+    return `CAST(${col} AS BINARY)`;
+  },
+
+  // ============================================================
+  // Quantile (Snowflake uses standard APPROX_PERCENTILE)
+  // ============================================================
+
+  hasEfficientPercentile(): boolean {
+    return true;
+  },
+
+  hasQuantileTesting(): boolean {
+    return true;
+  },
+
+  approxQuantile(value: string, quantile: string | number): string {
+    return `APPROX_PERCENTILE(${value}, ${quantile})`;
+  },
+};

--- a/packages/back-end/test/integrations/sql-builders/cte-builders/identities.test.ts
+++ b/packages/back-end/test/integrations/sql-builders/cte-builders/identities.test.ts
@@ -1,0 +1,474 @@
+/**
+ * Identity CTE Builder Tests
+ *
+ * These tests verify:
+ * 1. The extracted buildIdentitiesCTE function works correctly
+ * 2. The extracted function produces IDENTICAL results to the original
+ *    SqlIntegration.getIdentitiesCTE private method (parity tests)
+ *
+ * The identity CTE builder is responsible for:
+ * - Determining the base user ID type from multiple sources
+ * - Generating SQL CTEs for joining different user ID types together
+ */
+
+import BigQuery from "../../../../src/integrations/BigQuery";
+import { DataSourceSettings } from "shared/types/datasource";
+import {
+  buildIdentitiesCTE,
+  IdentitiesCTEDialect,
+  IdentitiesCTEParams,
+  IdentitiesCTEResult,
+} from "../../../../src/integrations/sql-builders/cte-builders/identities";
+
+// ============================================================
+// Test Setup
+// ============================================================
+
+// Create BigQuery instance for testing original private methods
+// @ts-expect-error - context not needed for method testing
+const bqInstance = new BigQuery("", {
+  settings: {
+    queries: {
+      identityJoins: [
+        {
+          ids: ["user_id", "anonymous_id"],
+          query: "SELECT user_id, anonymous_id FROM identity_table",
+        },
+      ],
+    },
+  },
+});
+
+// Helper to access private methods from original implementation
+function getPrivateMethod<T>(methodName: string): T {
+  return (bqInstance as unknown as Record<string, T>)[methodName].bind(
+    bqInstance
+  );
+}
+
+// Get reference to ORIGINAL private method (for parity testing)
+const originalGetIdentitiesCTE = getPrivateMethod<
+  (params: IdentitiesCTEParams) => IdentitiesCTEResult
+>("getIdentitiesCTE");
+
+// Create a dialect adapter that wraps the BigQuery instance for use with extracted function
+function createBigQueryDialectAdapter(): IdentitiesCTEDialect {
+  const getIdentitiesQuery = getPrivateMethod<
+    (
+      settings: DataSourceSettings,
+      id1: string,
+      id2: string,
+      from: Date,
+      to: Date | undefined,
+      experimentId?: string
+    ) => string
+  >("getIdentitiesQuery");
+
+  return {
+    getIdentitiesQuery: (settings, id1, id2, from, to, experimentId) => {
+      return getIdentitiesQuery(settings, id1, id2, from, to, experimentId);
+    },
+  };
+}
+
+// ============================================================
+// Test Fixtures
+// ============================================================
+
+const testDatasourceSettings: DataSourceSettings = {
+  queries: {
+    identityJoins: [
+      {
+        ids: ["user_id", "anonymous_id"],
+        query: "SELECT user_id, anonymous_id FROM identity_table",
+      },
+      {
+        ids: ["user_id", "device_id"],
+        query: "SELECT user_id, device_id FROM device_identity_table",
+      },
+    ],
+  },
+};
+
+const baseDate = new Date("2023-01-01T00:00:00Z");
+const endDate = new Date("2023-01-31T00:00:00Z");
+
+// ============================================================
+// Unit Tests for buildIdentitiesCTE
+// ============================================================
+
+describe("buildIdentitiesCTE", () => {
+  const dialect = createBigQueryDialectAdapter();
+
+  describe("base ID type selection", () => {
+    it("returns empty idJoinSQL when all objects use the same ID type", () => {
+      const result = buildIdentitiesCTE(dialect, testDatasourceSettings, {
+        objects: [["user_id"], ["user_id"], ["user_id"]],
+        from: baseDate,
+        to: endDate,
+      });
+
+      expect(result.baseIdType).toBe("user_id");
+      expect(result.idJoinSQL).toBe("");
+      expect(result.idJoinMap).toEqual({});
+    });
+
+    it("selects the most common ID type as base", () => {
+      const result = buildIdentitiesCTE(dialect, testDatasourceSettings, {
+        objects: [
+          ["user_id"],
+          ["user_id"],
+          ["anonymous_id"],
+        ],
+        from: baseDate,
+        to: endDate,
+      });
+
+      expect(result.baseIdType).toBe("user_id");
+    });
+
+    it("uses forcedBaseIdType when provided", () => {
+      const result = buildIdentitiesCTE(dialect, testDatasourceSettings, {
+        objects: [
+          ["user_id"],
+          ["anonymous_id"],
+        ],
+        from: baseDate,
+        to: endDate,
+        forcedBaseIdType: "anonymous_id",
+      });
+
+      expect(result.baseIdType).toBe("anonymous_id");
+    });
+
+    it("handles empty objects array", () => {
+      const result = buildIdentitiesCTE(dialect, testDatasourceSettings, {
+        objects: [],
+        from: baseDate,
+        to: endDate,
+      });
+
+      expect(result.baseIdType).toBe("");
+      expect(result.idJoinSQL).toBe("");
+      expect(result.idJoinMap).toEqual({});
+    });
+  });
+
+  describe("identity join generation", () => {
+    it("generates join CTE for objects that need different ID type", () => {
+      const result = buildIdentitiesCTE(dialect, testDatasourceSettings, {
+        objects: [
+          ["user_id"],       // Exposure uses user_id
+          ["anonymous_id"],  // Metric uses anonymous_id
+        ],
+        from: baseDate,
+        to: endDate,
+      });
+
+      expect(result.baseIdType).toBe("user_id");
+      expect(result.idJoinMap).toHaveProperty("anonymous_id");
+      expect(result.idJoinMap["anonymous_id"]).toBe("__identities_anonymous_id");
+      expect(result.idJoinSQL).toContain("__identities_anonymous_id as");
+      expect(result.idJoinSQL).toContain("SELECT");
+    });
+
+    it("generates multiple join CTEs when needed", () => {
+      const result = buildIdentitiesCTE(dialect, testDatasourceSettings, {
+        objects: [
+          ["user_id"],       // Base type
+          ["anonymous_id"],  // Needs join
+          ["device_id"],     // Needs join
+        ],
+        from: baseDate,
+        to: endDate,
+      });
+
+      expect(result.baseIdType).toBe("user_id");
+      expect(Object.keys(result.idJoinMap).length).toBe(2);
+      expect(result.idJoinMap).toHaveProperty("anonymous_id");
+      expect(result.idJoinMap).toHaveProperty("device_id");
+      expect(result.idJoinSQL).toContain("__identities_anonymous_id");
+      expect(result.idJoinSQL).toContain("__identities_device_id");
+    });
+
+    it("does not create duplicate joins for same ID type", () => {
+      // Force user_id as base so that anonymous_id objects need joins
+      const result = buildIdentitiesCTE(dialect, testDatasourceSettings, {
+        objects: [
+          ["user_id"],
+          ["anonymous_id"],  // First object needing anonymous_id
+          ["anonymous_id"],  // Second object needing anonymous_id
+        ],
+        from: baseDate,
+        to: endDate,
+        forcedBaseIdType: "user_id",
+      });
+
+      // Should only have one join entry for anonymous_id
+      expect(Object.keys(result.idJoinMap).length).toBe(1);
+      expect(result.idJoinMap).toHaveProperty("anonymous_id");
+      // Count occurrences of the join CTE name
+      const matches = result.idJoinSQL.match(/__identities_anonymous_id as/g);
+      expect(matches?.length).toBe(1);
+    });
+
+    it("skips objects that support the base ID type", () => {
+      const result = buildIdentitiesCTE(dialect, testDatasourceSettings, {
+        objects: [
+          ["user_id", "anonymous_id"], // Supports both
+          ["user_id"],                 // Supports base
+          ["anonymous_id"],            // Only supports anonymous_id
+        ],
+        from: baseDate,
+        to: endDate,
+      });
+
+      // With user_id as base, only the third object needs a join
+      expect(result.baseIdType).toBe("user_id");
+      expect(Object.keys(result.idJoinMap).length).toBe(1);
+    });
+  });
+
+  describe("ID type sanitization", () => {
+    it("sanitizes ID types with special characters", () => {
+      // Create mock dialect that accepts any ID types
+      const mockDialect: IdentitiesCTEDialect = {
+        getIdentitiesQuery: (_settings, id1, id2, _from, _to, _experimentId) => {
+          return `SELECT ${id1}, ${id2} FROM mock_table`;
+        },
+      };
+
+      const result = buildIdentitiesCTE(mockDialect, testDatasourceSettings, {
+        objects: [
+          ["user_id"],
+          ["special-id.type"], // Contains dash and dot
+        ],
+        from: baseDate,
+        to: endDate,
+      });
+
+      // The table name should be sanitized
+      expect(result.idJoinMap["special-id.type"]).toBe("__identities_specialidtype");
+    });
+  });
+
+  describe("date range handling", () => {
+    it("passes date range to dialect", () => {
+      let capturedFrom: Date | undefined;
+      let capturedTo: Date | undefined;
+
+      const mockDialect: IdentitiesCTEDialect = {
+        getIdentitiesQuery: (_settings, _id1, _id2, from, to, _experimentId) => {
+          capturedFrom = from;
+          capturedTo = to;
+          return "SELECT user_id, anonymous_id FROM mock_table";
+        },
+      };
+
+      buildIdentitiesCTE(mockDialect, testDatasourceSettings, {
+        objects: [["user_id"], ["anonymous_id"]],
+        from: baseDate,
+        to: endDate,
+      });
+
+      expect(capturedFrom).toEqual(baseDate);
+      expect(capturedTo).toEqual(endDate);
+    });
+
+    it("handles undefined end date", () => {
+      let capturedTo: Date | undefined = new Date();
+
+      const mockDialect: IdentitiesCTEDialect = {
+        getIdentitiesQuery: (_settings, _id1, _id2, _from, to, _experimentId) => {
+          capturedTo = to;
+          return "SELECT user_id, anonymous_id FROM mock_table";
+        },
+      };
+
+      buildIdentitiesCTE(mockDialect, testDatasourceSettings, {
+        objects: [["user_id"], ["anonymous_id"]],
+        from: baseDate,
+        // No 'to' date
+      });
+
+      expect(capturedTo).toBeUndefined();
+    });
+  });
+
+  describe("experiment ID handling", () => {
+    it("passes experiment ID to dialect", () => {
+      let capturedExperimentId: string | undefined;
+
+      const mockDialect: IdentitiesCTEDialect = {
+        getIdentitiesQuery: (_settings, _id1, _id2, _from, _to, experimentId) => {
+          capturedExperimentId = experimentId;
+          return "SELECT user_id, anonymous_id FROM mock_table";
+        },
+      };
+
+      buildIdentitiesCTE(mockDialect, testDatasourceSettings, {
+        objects: [["user_id"], ["anonymous_id"]],
+        from: baseDate,
+        to: endDate,
+        experimentId: "exp-123",
+      });
+
+      expect(capturedExperimentId).toBe("exp-123");
+    });
+  });
+});
+
+// ============================================================
+// PARITY TESTS: Verify extracted code matches original
+// ============================================================
+
+describe("Parity Tests: buildIdentitiesCTE vs Original getIdentitiesCTE", () => {
+  const dialect = createBigQueryDialectAdapter();
+
+  // Helper to normalize SQL for comparison (remove extra whitespace)
+  function normalizeSQL(sql: string): string {
+    return sql.replace(/\s+/g, " ").trim();
+  }
+
+  const parityTestCases = [
+    {
+      name: "single ID type - no joins needed",
+      params: {
+        objects: [["user_id"], ["user_id"]],
+        from: baseDate,
+        to: endDate,
+      },
+    },
+    {
+      name: "two ID types - one join needed",
+      params: {
+        objects: [["user_id"], ["anonymous_id"]],
+        from: baseDate,
+        to: endDate,
+      },
+    },
+    {
+      name: "forced base ID type",
+      params: {
+        objects: [["user_id"], ["anonymous_id"]],
+        from: baseDate,
+        to: endDate,
+        forcedBaseIdType: "user_id",
+      },
+    },
+    {
+      name: "with experiment ID",
+      params: {
+        objects: [["user_id"], ["anonymous_id"]],
+        from: baseDate,
+        to: endDate,
+        experimentId: "test-experiment",
+      },
+    },
+    {
+      name: "empty objects array",
+      params: {
+        objects: [],
+        from: baseDate,
+        to: endDate,
+      },
+    },
+    {
+      name: "objects with multiple ID type support",
+      params: {
+        objects: [
+          ["user_id", "anonymous_id"],
+          ["user_id"],
+          ["anonymous_id"],
+        ],
+        from: baseDate,
+        to: endDate,
+      },
+    },
+    {
+      name: "without end date",
+      params: {
+        objects: [["user_id"], ["anonymous_id"]],
+        from: baseDate,
+      },
+    },
+  ];
+
+  parityTestCases.forEach(({ name, params }) => {
+    it(`matches original for: ${name}`, () => {
+      // Get result from original implementation
+      const originalResult = originalGetIdentitiesCTE(params);
+
+      // Get result from extracted implementation
+      const extractedResult = buildIdentitiesCTE(
+        dialect,
+        testDatasourceSettings,
+        params
+      );
+
+      // Compare results
+      expect(extractedResult.baseIdType).toBe(originalResult.baseIdType);
+      expect(extractedResult.idJoinMap).toEqual(originalResult.idJoinMap);
+      expect(normalizeSQL(extractedResult.idJoinSQL)).toBe(
+        normalizeSQL(originalResult.idJoinSQL)
+      );
+    });
+  });
+});
+
+// ============================================================
+// Edge Case Tests
+// ============================================================
+
+describe("Edge Cases", () => {
+  const dialect = createBigQueryDialectAdapter();
+
+  it("handles deeply nested objects array", () => {
+    const result = buildIdentitiesCTE(dialect, testDatasourceSettings, {
+      objects: [
+        ["user_id"],
+        [],  // Empty inner array
+        ["user_id"],
+      ],
+      from: baseDate,
+      to: endDate,
+    });
+
+    expect(result.baseIdType).toBe("user_id");
+    expect(result.idJoinSQL).toBe("");
+  });
+
+  it("handles objects with empty strings", () => {
+    const result = buildIdentitiesCTE(dialect, testDatasourceSettings, {
+      objects: [
+        ["user_id", ""],  // Contains empty string
+        ["user_id"],
+      ],
+      from: baseDate,
+      to: endDate,
+    });
+
+    expect(result.baseIdType).toBe("user_id");
+    expect(result.idJoinSQL).toBe("");
+  });
+
+  it("throws when identity join query is not configured", () => {
+    const emptySettings: DataSourceSettings = {
+      queries: {},
+    };
+
+    const mockDialect: IdentitiesCTEDialect = {
+      getIdentitiesQuery: () => {
+        throw new Error("No identity join configured");
+      },
+    };
+
+    expect(() => {
+      buildIdentitiesCTE(mockDialect, emptySettings, {
+        objects: [["user_id"], ["anonymous_id"]],
+        from: baseDate,
+        to: endDate,
+      });
+    }).toThrow();
+  });
+});

--- a/packages/back-end/test/integrations/sql-builders/cte-builders/metrics.test.ts
+++ b/packages/back-end/test/integrations/sql-builders/cte-builders/metrics.test.ts
@@ -1,0 +1,519 @@
+/**
+ * Metric CTE Builder Tests
+ *
+ * These tests verify:
+ * 1. The extracted buildMetricCTE function works correctly
+ * 2. The extracted buildFactMetricCTE function works correctly
+ * 3. The extracted functions produce IDENTICAL results to the original
+ *    SqlIntegration private methods (parity tests)
+ *
+ * The metric CTE builders are responsible for:
+ * - Generating SQL CTEs for metric calculations
+ * - Handling SQL-based, builder-based, and fact-based metrics
+ * - Applying identity joins when needed
+ * - Date filtering and template variable substitution
+ */
+
+import BigQuery from "../../../../src/integrations/BigQuery";
+import { ExperimentMetricInterface } from "shared/experiments";
+import {
+  FactMetricInterface,
+  FactTableInterface,
+} from "shared/types/fact-table";
+import { PhaseSQLVar } from "shared/types/sql";
+import { FactTableMap } from "../../../../src/models/FactTableModel";
+import {
+  buildMetricCTE,
+  buildFactMetricCTE,
+  MetricCTEDialect,
+  MetricCTEParams,
+  FactMetricCTEParams,
+} from "../../../../src/integrations/sql-builders/cte-builders/metrics";
+
+// ============================================================
+// Test Setup
+// ============================================================
+
+// Create BigQuery instance for testing original private methods
+// @ts-expect-error - context not needed for method testing
+const bqInstance = new BigQuery("", {
+  settings: {
+    queries: {
+      identityJoins: [
+        {
+          ids: ["user_id", "anonymous_id"],
+          query: "SELECT user_id, anonymous_id FROM identity_table",
+        },
+      ],
+    },
+  },
+});
+
+// Helper to access private methods from original implementation
+function getPrivateMethod<T>(methodName: string): T {
+  return (bqInstance as unknown as Record<string, T>)[methodName].bind(
+    bqInstance
+  );
+}
+
+// Get references to ORIGINAL private methods (for parity testing)
+const originalGetMetricCTE = getPrivateMethod<
+  (params: {
+    metric: ExperimentMetricInterface;
+    baseIdType: string;
+    idJoinMap: Record<string, string>;
+    startDate: Date;
+    endDate: Date | null;
+    experimentId?: string;
+    factTableMap: FactTableMap;
+    useDenominator?: boolean;
+    phase?: PhaseSQLVar;
+    customFields?: Record<string, unknown>;
+  }) => string
+>("getMetricCTE");
+
+const originalGetFactMetricCTE = getPrivateMethod<
+  (params: {
+    metricsWithIndices: { metric: FactMetricInterface; index: number }[];
+    factTable: FactTableInterface;
+    baseIdType: string;
+    idJoinMap: Record<string, string>;
+    startDate: Date;
+    endDate: Date | null;
+    experimentId?: string;
+    addFiltersToWhere?: boolean;
+    phase?: PhaseSQLVar;
+    customFields?: Record<string, unknown>;
+    exclusiveStartDateFilter?: boolean;
+    exclusiveEndDateFilter?: boolean;
+    castIdToString?: boolean;
+  }) => string
+>("getFactMetricCTE");
+
+// Create a dialect adapter that wraps the BigQuery instance
+function createBigQueryDialectAdapter(): MetricCTEDialect {
+  return {
+    castUserDateCol: getPrivateMethod<(column: string) => string>("castUserDateCol"),
+    toTimestamp: getPrivateMethod<(date: Date) => string>("toTimestamp"),
+    toTimestampWithMs: getPrivateMethod<(date: Date) => string>("toTimestampWithMs"),
+    getSchema: getPrivateMethod<() => string>("getSchema"),
+    escapeStringLiteral: getPrivateMethod<(value: string) => string>("escapeStringLiteral"),
+    extractJSONField: getPrivateMethod<(jsonCol: string, path: string, isNumeric: boolean) => string>("extractJSONField"),
+    evalBoolean: getPrivateMethod<(value: boolean) => string>("evalBoolean"),
+    getMetricQueryFormat: getPrivateMethod<(metric: ExperimentMetricInterface) => "sql" | "builder">("getMetricQueryFormat"),
+    getMetricColumns: getPrivateMethod<(
+      metric: ExperimentMetricInterface,
+      factTableMap: FactTableMap,
+      alias: string,
+      useDenominator?: boolean
+    ) => { userIds: Record<string, string>; timestamp: string; value: string }>("getMetricColumns"),
+    getFactMetricColumn: getPrivateMethod<(
+      metric: FactMetricInterface,
+      columnRef: FactMetricInterface["numerator"],
+      factTable: FactTableInterface,
+      alias: string
+    ) => { value: string }>("getFactMetricColumn"),
+  };
+}
+
+// ============================================================
+// Test Fixtures
+// ============================================================
+
+const startDate = new Date("2023-01-01T00:00:00Z");
+const endDate = new Date("2023-01-31T00:00:00Z");
+
+function createLegacyMetric(
+  overrides: Partial<ExperimentMetricInterface> = {}
+): ExperimentMetricInterface {
+  return {
+    id: "met-1",
+    name: "Test Metric",
+    type: "binomial",
+    sql: "SELECT user_id, timestamp FROM events WHERE converted = true",
+    userIdTypes: ["user_id"],
+    windowSettings: {
+      type: "conversion",
+      windowUnit: "hours",
+      windowValue: 72,
+      delayUnit: "hours",
+      delayValue: 0,
+    },
+    ...overrides,
+  } as ExperimentMetricInterface;
+}
+
+function createFactMetric(
+  overrides: Partial<FactMetricInterface> = {}
+): FactMetricInterface {
+  return {
+    id: "fmet-1",
+    name: "Fact Metric",
+    metricType: "proportion",
+    numerator: {
+      factTableId: "ft-1",
+      column: "$$count",
+      filters: [],
+    },
+    windowSettings: {
+      type: "conversion",
+      windowUnit: "hours",
+      windowValue: 72,
+      delayUnit: "hours",
+      delayValue: 0,
+    },
+    ...overrides,
+  } as FactMetricInterface;
+}
+
+function createFactTable(
+  overrides: Partial<FactTableInterface> = {}
+): FactTableInterface {
+  return {
+    id: "ft-1",
+    name: "Events",
+    description: "Event fact table",
+    organization: "org-1",
+    datasource: "ds-1",
+    userIdTypes: ["user_id"],
+    sql: "SELECT user_id, timestamp, value FROM events",
+    dateCreated: new Date("2023-01-01"),
+    dateUpdated: new Date("2023-01-01"),
+    columns: [
+      { name: "value", column: "value", datatype: "number", numberFormat: "", deleted: false },
+    ],
+    filters: [],
+    ...overrides,
+  } as FactTableInterface;
+}
+
+// ============================================================
+// Unit Tests for buildMetricCTE
+// ============================================================
+
+describe("buildMetricCTE", () => {
+  const dialect = createBigQueryDialectAdapter();
+
+  describe("SQL-based metrics", () => {
+    it("generates metric CTE for SQL metric", () => {
+      const metric = createLegacyMetric();
+      const factTableMap: FactTableMap = new Map();
+
+      const result = buildMetricCTE(dialect, {
+        metric,
+        baseIdType: "user_id",
+        idJoinMap: {},
+        startDate,
+        endDate,
+        factTableMap,
+      });
+
+      expect(result).toContain("-- Metric (Test Metric)");
+      expect(result).toContain("user_id");
+      expect(result).toContain("timestamp");
+    });
+
+    it("adds date filters", () => {
+      const metric = createLegacyMetric();
+      const factTableMap: FactTableMap = new Map();
+
+      const result = buildMetricCTE(dialect, {
+        metric,
+        baseIdType: "user_id",
+        idJoinMap: {},
+        startDate,
+        endDate,
+        factTableMap,
+      });
+
+      expect(result).toContain(">=");
+      expect(result).toContain("<=");
+    });
+
+    it("handles null end date", () => {
+      const metric = createLegacyMetric();
+      const factTableMap: FactTableMap = new Map();
+
+      const result = buildMetricCTE(dialect, {
+        metric,
+        baseIdType: "user_id",
+        idJoinMap: {},
+        startDate,
+        endDate: null,
+        factTableMap,
+      });
+
+      expect(result).toContain(">=");
+      expect(result).not.toContain("<=");
+    });
+
+    it("adds identity join when metric uses different ID type", () => {
+      const metric = createLegacyMetric({
+        userIdTypes: ["anonymous_id"],
+      });
+      const factTableMap: FactTableMap = new Map();
+      const idJoinMap = { anonymous_id: "__identities_anonymous_id" };
+
+      const result = buildMetricCTE(dialect, {
+        metric,
+        baseIdType: "user_id",
+        idJoinMap,
+        startDate,
+        endDate,
+        factTableMap,
+      });
+
+      expect(result).toContain("i.user_id");
+      expect(result).toContain("JOIN __identities_anonymous_id");
+    });
+  });
+
+  describe("Fact metrics", () => {
+    it("generates metric CTE for fact metric", () => {
+      const metric = createFactMetric();
+      const factTable = createFactTable();
+      const factTableMap: FactTableMap = new Map([["ft-1", factTable]]);
+
+      const result = buildMetricCTE(dialect, {
+        metric: metric as ExperimentMetricInterface,
+        baseIdType: "user_id",
+        idJoinMap: {},
+        startDate,
+        endDate,
+        factTableMap,
+      });
+
+      expect(result).toContain("-- Metric (Fact Metric)");
+    });
+
+    it("throws when fact table not found", () => {
+      const metric = createFactMetric();
+      const factTableMap: FactTableMap = new Map();
+
+      expect(() =>
+        buildMetricCTE(dialect, {
+          metric: metric as ExperimentMetricInterface,
+          baseIdType: "user_id",
+          idJoinMap: {},
+          startDate,
+          endDate,
+          factTableMap,
+        })
+      ).toThrow("Could not find fact table");
+    });
+  });
+});
+
+// ============================================================
+// Unit Tests for buildFactMetricCTE
+// ============================================================
+
+describe("buildFactMetricCTE", () => {
+  const dialect = createBigQueryDialectAdapter();
+
+  it("generates fact metric CTE", () => {
+    const metric = createFactMetric();
+    const factTable = createFactTable();
+
+    const result = buildFactMetricCTE(dialect, {
+      metricsWithIndices: [{ metric, index: 0 }],
+      factTable,
+      baseIdType: "user_id",
+      idJoinMap: {},
+      startDate,
+      endDate,
+    });
+
+    expect(result).toContain("-- Fact Table (Events)");
+    expect(result).toContain("user_id");
+    expect(result).toContain("timestamp");
+  });
+
+  it("generates multiple metric columns", () => {
+    const metric1 = createFactMetric({ id: "m1", name: "Metric 1" });
+    const metric2 = createFactMetric({ id: "m2", name: "Metric 2" });
+    const factTable = createFactTable();
+
+    const result = buildFactMetricCTE(dialect, {
+      metricsWithIndices: [
+        { metric: metric1, index: 0 },
+        { metric: metric2, index: 1 },
+      ],
+      factTable,
+      baseIdType: "user_id",
+      idJoinMap: {},
+      startDate,
+      endDate,
+    });
+
+    expect(result).toContain("m0_value");
+    expect(result).toContain("m1_value");
+  });
+
+  it("adds identity join when fact table uses different ID type", () => {
+    const metric = createFactMetric();
+    const factTable = createFactTable({
+      userIdTypes: ["anonymous_id"],
+    });
+    const idJoinMap = { anonymous_id: "__identities_anonymous_id" };
+
+    const result = buildFactMetricCTE(dialect, {
+      metricsWithIndices: [{ metric, index: 0 }],
+      factTable,
+      baseIdType: "user_id",
+      idJoinMap,
+      startDate,
+      endDate,
+    });
+
+    expect(result).toContain("i.user_id");
+    expect(result).toContain("JOIN __identities_anonymous_id");
+  });
+
+  it("handles exclusive date filters", () => {
+    const metric = createFactMetric();
+    const factTable = createFactTable();
+
+    const result = buildFactMetricCTE(dialect, {
+      metricsWithIndices: [{ metric, index: 0 }],
+      factTable,
+      baseIdType: "user_id",
+      idJoinMap: {},
+      startDate,
+      endDate,
+      exclusiveStartDateFilter: true,
+      exclusiveEndDateFilter: true,
+    });
+
+    expect(result).toContain(">");
+    expect(result).toContain("<");
+  });
+
+  it("casts ID to string when requested", () => {
+    const metric = createFactMetric();
+    const factTable = createFactTable();
+
+    const result = buildFactMetricCTE(dialect, {
+      metricsWithIndices: [{ metric, index: 0 }],
+      factTable,
+      baseIdType: "user_id",
+      idJoinMap: {},
+      startDate,
+      endDate,
+      castIdToString: true,
+    });
+
+    expect(result).toContain("CAST(");
+    expect(result).toContain("AS STRING)");
+  });
+});
+
+// ============================================================
+// PARITY TESTS: Verify extracted code matches original
+// ============================================================
+
+describe("Parity Tests: buildMetricCTE vs Original getMetricCTE", () => {
+  const dialect = createBigQueryDialectAdapter();
+
+  // Helper to normalize SQL for comparison
+  function normalizeSQL(sql: string): string {
+    return sql.replace(/\s+/g, " ").trim();
+  }
+
+  const parityTestCases = [
+    {
+      name: "SQL metric - same ID type",
+      params: {
+        metric: createLegacyMetric(),
+        baseIdType: "user_id",
+        idJoinMap: {},
+        startDate,
+        endDate,
+        factTableMap: new Map() as FactTableMap,
+      },
+    },
+    {
+      name: "SQL metric - null end date",
+      params: {
+        metric: createLegacyMetric(),
+        baseIdType: "user_id",
+        idJoinMap: {},
+        startDate,
+        endDate: null,
+        factTableMap: new Map() as FactTableMap,
+      },
+    },
+  ];
+
+  parityTestCases.forEach(({ name, params }) => {
+    it(`matches original for: ${name}`, () => {
+      // Get result from original implementation
+      const originalResult = originalGetMetricCTE(params);
+
+      // Get result from extracted implementation
+      const extractedResult = buildMetricCTE(dialect, params);
+
+      // Compare normalized SQL
+      expect(normalizeSQL(extractedResult)).toBe(normalizeSQL(originalResult));
+    });
+  });
+});
+
+describe("Parity Tests: buildFactMetricCTE vs Original getFactMetricCTE", () => {
+  const dialect = createBigQueryDialectAdapter();
+
+  function normalizeSQL(sql: string): string {
+    return sql.replace(/\s+/g, " ").trim();
+  }
+
+  const parityTestCases = [
+    {
+      name: "basic fact metric",
+      params: {
+        metricsWithIndices: [{ metric: createFactMetric(), index: 0 }],
+        factTable: createFactTable(),
+        baseIdType: "user_id",
+        idJoinMap: {},
+        startDate,
+        endDate,
+      },
+    },
+    {
+      name: "fact metric with exclusive filters",
+      params: {
+        metricsWithIndices: [{ metric: createFactMetric(), index: 0 }],
+        factTable: createFactTable(),
+        baseIdType: "user_id",
+        idJoinMap: {},
+        startDate,
+        endDate,
+        exclusiveStartDateFilter: true,
+        exclusiveEndDateFilter: true,
+      },
+    },
+    {
+      name: "fact metric with identity join",
+      params: {
+        metricsWithIndices: [{ metric: createFactMetric(), index: 0 }],
+        factTable: createFactTable({ userIdTypes: ["anonymous_id"] }),
+        baseIdType: "user_id",
+        idJoinMap: { anonymous_id: "__identities_anonymous_id" },
+        startDate,
+        endDate,
+      },
+    },
+  ];
+
+  parityTestCases.forEach(({ name, params }) => {
+    it(`matches original for: ${name}`, () => {
+      // Get result from original implementation
+      const originalResult = originalGetFactMetricCTE(params);
+
+      // Get result from extracted implementation
+      const extractedResult = buildFactMetricCTE(dialect, params);
+
+      // Compare normalized SQL
+      expect(normalizeSQL(extractedResult)).toBe(normalizeSQL(originalResult));
+    });
+  });
+});

--- a/packages/back-end/test/integrations/sql-builders/cte-builders/segments.test.ts
+++ b/packages/back-end/test/integrations/sql-builders/cte-builders/segments.test.ts
@@ -1,0 +1,547 @@
+/**
+ * Segment CTE Builder Tests
+ *
+ * These tests verify:
+ * 1. The extracted buildSegmentCTE function works correctly
+ * 2. The extracted function produces IDENTICAL results to the original
+ *    SqlIntegration.getSegmentCTE private method (parity tests)
+ *
+ * The segment CTE builder is responsible for:
+ * - Generating SQL CTEs for user segments
+ * - Handling SQL-based and fact-table-based segments
+ * - Applying identity joins when needed
+ */
+
+import BigQuery from "../../../../src/integrations/BigQuery";
+import { SegmentInterface } from "shared/types/segment";
+import { FactTableInterface } from "shared/types/fact-table";
+import { SQLVars } from "shared/types/sql";
+import { FactTableMap } from "../../../../src/models/FactTableModel";
+import {
+  buildSegmentCTE,
+  buildFactSegmentCTE,
+  SegmentCTEDialect,
+  FactSegmentCTEDialect,
+  SegmentCTEParams,
+} from "../../../../src/integrations/sql-builders/cte-builders/segments";
+
+// ============================================================
+// Test Setup
+// ============================================================
+
+// Create BigQuery instance for testing original private methods
+// @ts-expect-error - context not needed for method testing
+const bqInstance = new BigQuery("", {
+  settings: {
+    queries: {
+      identityJoins: [
+        {
+          ids: ["user_id", "anonymous_id"],
+          query: "SELECT user_id, anonymous_id FROM identity_table",
+        },
+      ],
+    },
+  },
+});
+
+// Helper to access private methods from original implementation
+function getPrivateMethod<T>(methodName: string): T {
+  return (bqInstance as unknown as Record<string, T>)[methodName].bind(
+    bqInstance
+  );
+}
+
+// Get reference to ORIGINAL private methods (for parity testing)
+const originalGetSegmentCTE = getPrivateMethod<
+  (
+    segment: SegmentInterface,
+    baseIdType: string,
+    idJoinMap: Record<string, string>,
+    factTableMap: FactTableMap,
+    sqlVars?: SQLVars
+  ) => string
+>("getSegmentCTE");
+
+const originalGetFactSegmentCTE = getPrivateMethod<
+  (params: {
+    factTable: FactTableInterface;
+    baseIdType: string;
+    idJoinMap: Record<string, string>;
+    filters?: string[];
+    sqlVars?: SQLVars;
+  }) => string
+>("getFactSegmentCTE");
+
+// Create a dialect adapter that wraps the BigQuery instance
+function createBigQueryDialectAdapter(): FactSegmentCTEDialect {
+  const castUserDateCol = getPrivateMethod<(column: string) => string>(
+    "castUserDateCol"
+  );
+
+  return {
+    castUserDateCol: (column) => castUserDateCol(column),
+    getFactSegmentCTE: (params) => originalGetFactSegmentCTE(params),
+  };
+}
+
+// ============================================================
+// Test Fixtures
+// ============================================================
+
+function createSqlSegment(
+  overrides: Partial<SegmentInterface> = {}
+): SegmentInterface {
+  return {
+    id: "seg-1",
+    name: "Test Segment",
+    type: "SQL",
+    sql: "SELECT user_id, date FROM users WHERE is_active = true",
+    userIdType: "user_id",
+    owner: "test-owner",
+    datasource: "ds-1",
+    dateCreated: new Date("2023-01-01"),
+    dateUpdated: new Date("2023-01-01"),
+    organization: "org-1",
+    ...overrides,
+  } as SegmentInterface;
+}
+
+function createFactSegment(
+  overrides: Partial<SegmentInterface> = {}
+): SegmentInterface {
+  return {
+    id: "seg-2",
+    name: "Fact Segment",
+    type: "FACT",
+    factTableId: "ft-1",
+    filters: [],
+    userIdType: "user_id",
+    owner: "test-owner",
+    datasource: "ds-1",
+    dateCreated: new Date("2023-01-01"),
+    dateUpdated: new Date("2023-01-01"),
+    organization: "org-1",
+    ...overrides,
+  } as SegmentInterface;
+}
+
+function createFactTable(
+  overrides: Partial<FactTableInterface> = {}
+): FactTableInterface {
+  return {
+    id: "ft-1",
+    name: "Events",
+    description: "Event fact table",
+    organization: "org-1",
+    datasource: "ds-1",
+    userIdTypes: ["user_id"],
+    sql: "SELECT user_id, timestamp FROM events",
+    dateCreated: new Date("2023-01-01"),
+    dateUpdated: new Date("2023-01-01"),
+    columns: [],
+    filters: [
+      {
+        id: "filter-1",
+        name: "Active Users",
+        value: "is_active = true",
+        description: "",
+      },
+    ],
+    ...overrides,
+  } as FactTableInterface;
+}
+
+// ============================================================
+// Unit Tests for buildSegmentCTE
+// ============================================================
+
+describe("buildSegmentCTE", () => {
+  const dialect = createBigQueryDialectAdapter();
+
+  describe("SQL-based segments", () => {
+    it("generates simple segment CTE when no joins needed", () => {
+      const segment = createSqlSegment();
+      const result = buildSegmentCTE(dialect, {
+        segment,
+        baseIdType: "user_id",
+        idJoinMap: {},
+        factTableMap: new Map(),
+      });
+
+      expect(result).toContain("-- Segment (Test Segment)");
+      expect(result).toContain("SELECT user_id, date FROM users");
+    });
+
+    it("throws error when SQL segment has no sql value", () => {
+      const segment = createSqlSegment({ sql: "" });
+
+      expect(() =>
+        buildSegmentCTE(dialect, {
+          segment,
+          baseIdType: "user_id",
+          idJoinMap: {},
+          factTableMap: new Map(),
+        })
+      ).toThrow("is a SQL Segment but has no SQL value");
+    });
+
+    it("applies template variables when provided", () => {
+      const segment = createSqlSegment({
+        sql: "SELECT user_id, date FROM users WHERE date >= {{ startDate }}",
+      });
+      const sqlVars: SQLVars = {
+        startDate: new Date("2023-01-01"),
+        endDate: new Date("2023-01-31"),
+      };
+
+      const result = buildSegmentCTE(dialect, {
+        segment,
+        baseIdType: "user_id",
+        idJoinMap: {},
+        factTableMap: new Map(),
+        sqlVars,
+      });
+
+      expect(result).toContain("-- Segment (Test Segment)");
+      // The template should be compiled
+      expect(result).not.toContain("{{ startDate }}");
+    });
+
+    it("adds identity join when segment uses different ID type", () => {
+      const segment = createSqlSegment({ userIdType: "anonymous_id" });
+      const idJoinMap = { anonymous_id: "__identities_anonymous_id" };
+
+      const result = buildSegmentCTE(dialect, {
+        segment,
+        baseIdType: "user_id",
+        idJoinMap,
+        factTableMap: new Map(),
+      });
+
+      expect(result).toContain("i.user_id");
+      expect(result).toContain("JOIN __identities_anonymous_id i");
+      expect(result).toContain("i.anonymous_id = s.anonymous_id");
+    });
+
+    it("casts date column when dialect requires it", () => {
+      const segment = createSqlSegment();
+
+      const result = buildSegmentCTE(dialect, {
+        segment,
+        baseIdType: "user_id",
+        idJoinMap: {},
+        factTableMap: new Map(),
+      });
+
+      // BigQuery casts to DATETIME
+      expect(result).toContain("CAST(s.date as DATETIME)");
+    });
+
+    it("defaults userIdType to user_id when not specified", () => {
+      const segment = createSqlSegment({ userIdType: undefined });
+
+      const result = buildSegmentCTE(dialect, {
+        segment,
+        baseIdType: "user_id",
+        idJoinMap: {},
+        factTableMap: new Map(),
+      });
+
+      // Should work without needing a join
+      expect(result).not.toContain("JOIN");
+    });
+  });
+
+  describe("Fact-based segments", () => {
+    it("generates fact segment CTE", () => {
+      const segment = createFactSegment();
+      const factTable = createFactTable();
+      const factTableMap: FactTableMap = new Map([["ft-1", factTable]]);
+
+      const result = buildSegmentCTE(dialect, {
+        segment,
+        baseIdType: "user_id",
+        idJoinMap: {},
+        factTableMap,
+      });
+
+      expect(result).toContain("-- Segment (Fact Segment)");
+      expect(result).toContain("SELECT * FROM");
+    });
+
+    it("throws error when fact segment has no factTableId", () => {
+      const segment = createFactSegment({ factTableId: undefined });
+
+      expect(() =>
+        buildSegmentCTE(dialect, {
+          segment,
+          baseIdType: "user_id",
+          idJoinMap: {},
+          factTableMap: new Map(),
+        })
+      ).toThrow("is a FACT Segment, but has no factTableId set");
+    });
+
+    it("throws error when fact table not found", () => {
+      const segment = createFactSegment({ factTableId: "unknown-ft" });
+
+      expect(() =>
+        buildSegmentCTE(dialect, {
+          segment,
+          baseIdType: "user_id",
+          idJoinMap: {},
+          factTableMap: new Map(),
+        })
+      ).toThrow("Unknown fact table: unknown-ft");
+    });
+  });
+});
+
+// ============================================================
+// Unit Tests for buildFactSegmentCTE
+// ============================================================
+
+describe("buildFactSegmentCTE", () => {
+  // Create simple dialect for testing
+  const simpleDialect: SegmentCTEDialect = {
+    castUserDateCol: (column) => `CAST(${column} as DATETIME)`,
+  };
+
+  it("generates basic fact segment CTE", () => {
+    const factTable = createFactTable();
+
+    const result = buildFactSegmentCTE(simpleDialect, {
+      factTable,
+      baseIdType: "user_id",
+      idJoinMap: {},
+    });
+
+    expect(result).toContain("-- Fact Table (Events)");
+    expect(result).toContain("user_id as user_id");
+    expect(result).toContain("CAST(m.timestamp as DATETIME) as date");
+    expect(result).toContain("FROM(");
+  });
+
+  it("applies filters from fact table", () => {
+    const factTable = createFactTable({
+      filters: [
+        { id: "filter-1", name: "Active", value: "is_active = true", description: "" },
+        { id: "filter-2", name: "Paid", value: "is_paid = true", description: "" },
+      ],
+    });
+
+    const result = buildFactSegmentCTE(simpleDialect, {
+      factTable,
+      baseIdType: "user_id",
+      idJoinMap: {},
+      filters: ["filter-1", "filter-2"],
+    });
+
+    expect(result).toContain("WHERE is_active = true AND is_paid = true");
+  });
+
+  it("ignores non-matching filters", () => {
+    const factTable = createFactTable({
+      filters: [
+        { id: "filter-1", name: "Active", value: "is_active = true", description: "" },
+      ],
+    });
+
+    const result = buildFactSegmentCTE(simpleDialect, {
+      factTable,
+      baseIdType: "user_id",
+      idJoinMap: {},
+      filters: ["filter-1", "non-existent-filter"],
+    });
+
+    expect(result).toContain("WHERE is_active = true");
+    expect(result).not.toContain("non-existent");
+  });
+
+  it("adds identity join when fact table uses different ID type", () => {
+    const factTable = createFactTable({
+      userIdTypes: ["anonymous_id"],
+    });
+    const idJoinMap = { anonymous_id: "__identities_anonymous_id" };
+
+    const result = buildFactSegmentCTE(simpleDialect, {
+      factTable,
+      baseIdType: "user_id",
+      idJoinMap,
+    });
+
+    expect(result).toContain("i.user_id as user_id");
+    expect(result).toContain("JOIN __identities_anonymous_id i");
+    expect(result).toContain("i.anonymous_id = m.anonymous_id");
+  });
+
+  it("applies template variables when provided", () => {
+    const factTable = createFactTable({
+      sql: "SELECT user_id, timestamp FROM events WHERE date >= {{ startDate }}",
+    });
+    const sqlVars: SQLVars = {
+      startDate: new Date("2023-01-01"),
+      endDate: new Date("2023-01-31"),
+    };
+
+    const result = buildFactSegmentCTE(simpleDialect, {
+      factTable,
+      baseIdType: "user_id",
+      idJoinMap: {},
+      sqlVars,
+    });
+
+    expect(result).not.toContain("{{ startDate }}");
+  });
+});
+
+// ============================================================
+// PARITY TESTS: Verify extracted code matches original
+// ============================================================
+
+describe("Parity Tests: buildSegmentCTE vs Original getSegmentCTE", () => {
+  const dialect = createBigQueryDialectAdapter();
+
+  // Helper to normalize SQL for comparison (remove extra whitespace)
+  function normalizeSQL(sql: string): string {
+    return sql.replace(/\s+/g, " ").trim();
+  }
+
+  describe("SQL segments", () => {
+    const parityTestCases = [
+      {
+        name: "simple SQL segment - same ID type",
+        segment: createSqlSegment(),
+        baseIdType: "user_id",
+        idJoinMap: {},
+      },
+      {
+        name: "SQL segment with identity join",
+        segment: createSqlSegment({ userIdType: "anonymous_id" }),
+        baseIdType: "user_id",
+        idJoinMap: { anonymous_id: "__identities_anonymous_id" },
+      },
+      {
+        name: "SQL segment with default userIdType",
+        segment: createSqlSegment({ userIdType: undefined }),
+        baseIdType: "user_id",
+        idJoinMap: {},
+      },
+    ];
+
+    parityTestCases.forEach(({ name, segment, baseIdType, idJoinMap }) => {
+      it(`matches original for: ${name}`, () => {
+        const factTableMap: FactTableMap = new Map();
+
+        // Get result from original implementation
+        const originalResult = originalGetSegmentCTE(
+          segment,
+          baseIdType,
+          idJoinMap,
+          factTableMap,
+          undefined
+        );
+
+        // Get result from extracted implementation
+        const extractedResult = buildSegmentCTE(dialect, {
+          segment,
+          baseIdType,
+          idJoinMap,
+          factTableMap,
+        });
+
+        // Compare normalized SQL
+        expect(normalizeSQL(extractedResult)).toBe(
+          normalizeSQL(originalResult)
+        );
+      });
+    });
+  });
+
+  describe("Fact segments", () => {
+    it("matches original for fact segment", () => {
+      const segment = createFactSegment();
+      const factTable = createFactTable();
+      const factTableMap: FactTableMap = new Map([["ft-1", factTable]]);
+
+      // Get result from original implementation
+      const originalResult = originalGetSegmentCTE(
+        segment,
+        "user_id",
+        {},
+        factTableMap,
+        undefined
+      );
+
+      // Get result from extracted implementation
+      const extractedResult = buildSegmentCTE(dialect, {
+        segment,
+        baseIdType: "user_id",
+        idJoinMap: {},
+        factTableMap,
+      });
+
+      // Compare normalized SQL
+      expect(normalizeSQL(extractedResult)).toBe(normalizeSQL(originalResult));
+    });
+  });
+});
+
+describe("Parity Tests: buildFactSegmentCTE vs Original getFactSegmentCTE", () => {
+  const dialect = createBigQueryDialectAdapter();
+
+  function normalizeSQL(sql: string): string {
+    return sql.replace(/\s+/g, " ").trim();
+  }
+
+  const parityTestCases = [
+    {
+      name: "basic fact table",
+      factTable: createFactTable(),
+      baseIdType: "user_id",
+      idJoinMap: {},
+      filters: undefined,
+    },
+    {
+      name: "fact table with filters",
+      factTable: createFactTable({
+        filters: [
+          { id: "f1", name: "Test", value: "active = true", description: "" },
+        ],
+      }),
+      baseIdType: "user_id",
+      idJoinMap: {},
+      filters: ["f1"],
+    },
+    {
+      name: "fact table with identity join",
+      factTable: createFactTable({ userIdTypes: ["anonymous_id"] }),
+      baseIdType: "user_id",
+      idJoinMap: { anonymous_id: "__identities_anonymous_id" },
+      filters: undefined,
+    },
+  ];
+
+  parityTestCases.forEach(({ name, factTable, baseIdType, idJoinMap, filters }) => {
+    it(`matches original for: ${name}`, () => {
+      // Get result from original implementation
+      const originalResult = originalGetFactSegmentCTE({
+        factTable,
+        baseIdType,
+        idJoinMap,
+        filters,
+      });
+
+      // Get result from extracted implementation
+      const extractedResult = buildFactSegmentCTE(dialect, {
+        factTable,
+        baseIdType,
+        idJoinMap,
+        filters,
+      });
+
+      // Compare normalized SQL
+      expect(normalizeSQL(extractedResult)).toBe(normalizeSQL(originalResult));
+    });
+  });
+});

--- a/packages/back-end/test/integrations/sql-builders/cte-builders/statistics.test.ts
+++ b/packages/back-end/test/integrations/sql-builders/cte-builders/statistics.test.ts
@@ -1,0 +1,374 @@
+/**
+ * Statistics CTE Builder Tests
+ *
+ * These tests verify:
+ * 1. The extracted buildExperimentFactMetricStatisticsCTE function works correctly
+ * 2. The extracted function produces IDENTICAL results to the original
+ *    SqlIntegration.getExperimentFactMetricStatisticsCTE method (parity tests)
+ *
+ * The statistics CTE builder is responsible for:
+ * - Aggregating metric data per variation and dimension
+ * - Calculating sum, sum_squares for statistical analysis
+ * - Handling ratio metrics with denominator data
+ * - Handling CUPED regression adjustment
+ * - Handling quantile/percentile metrics
+ */
+
+import BigQuery from "../../../../src/integrations/BigQuery";
+import {
+  DimensionColumnData,
+  FactMetricData,
+  FactMetricQuantileData,
+} from "shared/types/integrations";
+import { FactTableInterface, MetricQuantileSettings } from "shared/types/fact-table";
+import {
+  buildExperimentFactMetricStatisticsCTE,
+  StatisticsCTEDialect,
+  StatisticsCTEParams,
+} from "../../../../src/integrations/sql-builders/cte-builders/statistics";
+
+// ============================================================
+// Test Setup
+// ============================================================
+
+// Create BigQuery instance for testing original private methods
+// @ts-expect-error - context not needed for method testing
+const bqInstance = new BigQuery("", {
+  settings: {},
+});
+
+// Helper to access private methods from original implementation
+function getPrivateMethod<T>(methodName: string): T {
+  return (bqInstance as unknown as Record<string, T>)[methodName].bind(
+    bqInstance
+  );
+}
+
+// Get reference to ORIGINAL method (for parity testing)
+// Note: This is a public method in SqlIntegration
+const originalGetExperimentFactMetricStatisticsCTE = getPrivateMethod<
+  (params: StatisticsCTEParams) => string
+>("getExperimentFactMetricStatisticsCTE");
+
+// Create a dialect adapter that wraps the BigQuery instance
+function createBigQueryDialectAdapter(): StatisticsCTEDialect {
+  return {
+    castToString: getPrivateMethod<(col: string) => string>("castToString"),
+    getQuantileGridColumns: getPrivateMethod<
+      (quantileSettings: MetricQuantileSettings | undefined, prefix: string) => string
+    >("getQuantileGridColumns"),
+  };
+}
+
+// ============================================================
+// Test Fixtures
+// ============================================================
+
+function createDimensionColumn(alias: string): DimensionColumnData {
+  return {
+    alias,
+    expression: `d.${alias}`,
+  } as DimensionColumnData;
+}
+
+function createFactMetricData(
+  overrides: Partial<FactMetricData> = {}
+): FactMetricData {
+  return {
+    id: "metric_1",
+    alias: "m0",
+    numeratorSourceIndex: 0,
+    denominatorSourceIndex: 0,
+    capCoalesceMetric: "COALESCE(m.m0_value, 0)",
+    capCoalesceCovariate: "COALESCE(c0.m0_covariate, 0)",
+    capCoalesceDenominator: "COALESCE(m.m0_denominator, 0)",
+    capCoalesceDenominatorCovariate: "COALESCE(c0.m0_denominator_covariate, 0)",
+    ratioMetric: false,
+    regressionAdjusted: false,
+    isPercentileCapped: false,
+    quantileMetric: undefined,
+    metricQuantileSettings: undefined,
+    ...overrides,
+  } as FactMetricData;
+}
+
+function createFactTable(): FactTableInterface {
+  return {
+    id: "ft-1",
+    name: "Events",
+    description: "",
+    organization: "org-1",
+    datasource: "ds-1",
+    userIdTypes: ["user_id"],
+    sql: "SELECT user_id, timestamp, value FROM events",
+    dateCreated: new Date(),
+    dateUpdated: new Date(),
+    columns: [],
+    filters: [],
+  } as FactTableInterface;
+}
+
+// ============================================================
+// Unit Tests for buildExperimentFactMetricStatisticsCTE
+// ============================================================
+
+describe("buildExperimentFactMetricStatisticsCTE", () => {
+  const dialect = createBigQueryDialectAdapter();
+
+  describe("basic aggregation", () => {
+    it("generates statistics CTE with basic metric", () => {
+      const result = buildExperimentFactMetricStatisticsCTE(dialect, {
+        dimensionCols: [],
+        metricData: [createFactMetricData()],
+        eventQuantileData: [],
+        baseIdType: "user_id",
+        joinedMetricTableName: "__userMetricAgg",
+        eventQuantileTableName: "__eventQuantileMetric",
+        cupedMetricTableName: "__userCovariateMetric",
+        capValueTableName: "__capValue",
+        factTablesWithIndices: [{ factTable: createFactTable(), index: 0 }],
+        regressionAdjustedTableIndices: new Set(),
+        percentileTableIndices: new Set(),
+      });
+
+      expect(result).toContain("SELECT");
+      expect(result).toContain("m.variation AS variation");
+      expect(result).toContain("COUNT(*) AS users");
+      expect(result).toContain("m0_main_sum");
+      expect(result).toContain("m0_main_sum_squares");
+      expect(result).toContain("FROM");
+      expect(result).toContain("__userMetricAgg m");
+      expect(result).toContain("GROUP BY");
+    });
+
+    it("includes dimension columns", () => {
+      const result = buildExperimentFactMetricStatisticsCTE(dialect, {
+        dimensionCols: [createDimensionColumn("dim_experiment")],
+        metricData: [createFactMetricData()],
+        eventQuantileData: [],
+        baseIdType: "user_id",
+        joinedMetricTableName: "__userMetricAgg",
+        eventQuantileTableName: "__eventQuantileMetric",
+        cupedMetricTableName: "__userCovariateMetric",
+        capValueTableName: "__capValue",
+        factTablesWithIndices: [{ factTable: createFactTable(), index: 0 }],
+        regressionAdjustedTableIndices: new Set(),
+        percentileTableIndices: new Set(),
+      });
+
+      expect(result).toContain("m.dim_experiment AS dim_experiment");
+      expect(result).toContain("GROUP BY");
+      expect(result).toContain(", m.dim_experiment");
+    });
+
+    it("generates metric ID column", () => {
+      const result = buildExperimentFactMetricStatisticsCTE(dialect, {
+        dimensionCols: [],
+        metricData: [createFactMetricData({ id: "test_metric" })],
+        eventQuantileData: [],
+        baseIdType: "user_id",
+        joinedMetricTableName: "__userMetricAgg",
+        eventQuantileTableName: "__eventQuantileMetric",
+        cupedMetricTableName: "__userCovariateMetric",
+        capValueTableName: "__capValue",
+        factTablesWithIndices: [{ factTable: createFactTable(), index: 0 }],
+        regressionAdjustedTableIndices: new Set(),
+        percentileTableIndices: new Set(),
+      });
+
+      expect(result).toContain("'test_metric'");
+      expect(result).toContain("m0_id");
+    });
+  });
+
+  describe("ratio metrics", () => {
+    it("includes denominator columns for ratio metrics", () => {
+      const result = buildExperimentFactMetricStatisticsCTE(dialect, {
+        dimensionCols: [],
+        metricData: [createFactMetricData({ ratioMetric: true })],
+        eventQuantileData: [],
+        baseIdType: "user_id",
+        joinedMetricTableName: "__userMetricAgg",
+        eventQuantileTableName: "__eventQuantileMetric",
+        cupedMetricTableName: "__userCovariateMetric",
+        capValueTableName: "__capValue",
+        factTablesWithIndices: [{ factTable: createFactTable(), index: 0 }],
+        regressionAdjustedTableIndices: new Set(),
+        percentileTableIndices: new Set(),
+      });
+
+      expect(result).toContain("m0_denominator_sum");
+      expect(result).toContain("m0_denominator_sum_squares");
+      expect(result).toContain("m0_main_denominator_sum_product");
+    });
+  });
+
+  describe("regression adjustment (CUPED)", () => {
+    it("includes covariate columns for CUPED", () => {
+      const result = buildExperimentFactMetricStatisticsCTE(dialect, {
+        dimensionCols: [],
+        metricData: [createFactMetricData({ regressionAdjusted: true })],
+        eventQuantileData: [],
+        baseIdType: "user_id",
+        joinedMetricTableName: "__userMetricAgg",
+        eventQuantileTableName: "__eventQuantileMetric",
+        cupedMetricTableName: "__userCovariateMetric",
+        capValueTableName: "__capValue",
+        factTablesWithIndices: [{ factTable: createFactTable(), index: 0 }],
+        regressionAdjustedTableIndices: new Set([0]),
+        percentileTableIndices: new Set(),
+      });
+
+      expect(result).toContain("m0_covariate_sum");
+      expect(result).toContain("m0_covariate_sum_squares");
+      expect(result).toContain("m0_main_covariate_sum_product");
+      // For index 0, suffix is empty, so it's "c" not "c0"
+      expect(result).toContain("LEFT JOIN __userCovariateMetric c ON");
+    });
+
+    it("includes full CUPED columns for ratio metrics", () => {
+      const result = buildExperimentFactMetricStatisticsCTE(dialect, {
+        dimensionCols: [],
+        metricData: [
+          createFactMetricData({ ratioMetric: true, regressionAdjusted: true }),
+        ],
+        eventQuantileData: [],
+        baseIdType: "user_id",
+        joinedMetricTableName: "__userMetricAgg",
+        eventQuantileTableName: "__eventQuantileMetric",
+        cupedMetricTableName: "__userCovariateMetric",
+        capValueTableName: "__capValue",
+        factTablesWithIndices: [{ factTable: createFactTable(), index: 0 }],
+        regressionAdjustedTableIndices: new Set([0]),
+        percentileTableIndices: new Set(),
+      });
+
+      expect(result).toContain("m0_denominator_pre_sum");
+      expect(result).toContain("m0_main_pre_denominator_post_sum_product");
+    });
+  });
+
+  describe("percentile capping", () => {
+    it("includes cap value columns for percentile-capped metrics", () => {
+      const result = buildExperimentFactMetricStatisticsCTE(dialect, {
+        dimensionCols: [],
+        metricData: [createFactMetricData({ isPercentileCapped: true })],
+        eventQuantileData: [],
+        baseIdType: "user_id",
+        joinedMetricTableName: "__userMetricAgg",
+        eventQuantileTableName: "__eventQuantileMetric",
+        cupedMetricTableName: "__userCovariateMetric",
+        capValueTableName: "__capValue",
+        factTablesWithIndices: [{ factTable: createFactTable(), index: 0 }],
+        regressionAdjustedTableIndices: new Set(),
+        percentileTableIndices: new Set([0]),
+      });
+
+      expect(result).toContain("m0_main_cap_value");
+      expect(result).toContain("CROSS JOIN __capValue cap");
+    });
+  });
+
+  describe("multiple fact tables", () => {
+    it("joins additional fact tables", () => {
+      const result = buildExperimentFactMetricStatisticsCTE(dialect, {
+        dimensionCols: [],
+        metricData: [createFactMetricData()],
+        eventQuantileData: [],
+        baseIdType: "user_id",
+        joinedMetricTableName: "__userMetricAgg",
+        eventQuantileTableName: "__eventQuantileMetric",
+        cupedMetricTableName: "__userCovariateMetric",
+        capValueTableName: "__capValue",
+        factTablesWithIndices: [
+          { factTable: createFactTable(), index: 0 },
+          { factTable: createFactTable(), index: 1 },
+        ],
+        regressionAdjustedTableIndices: new Set(),
+        percentileTableIndices: new Set(),
+      });
+
+      expect(result).toContain("LEFT JOIN __userMetricAgg1 m1");
+    });
+  });
+});
+
+// ============================================================
+// PARITY TESTS: Verify extracted code matches original
+// ============================================================
+
+describe("Parity Tests: buildExperimentFactMetricStatisticsCTE vs Original", () => {
+  const dialect = createBigQueryDialectAdapter();
+
+  // Helper to normalize SQL for comparison
+  function normalizeSQL(sql: string): string {
+    return sql.replace(/\s+/g, " ").trim();
+  }
+
+  const parityTestCases = [
+    {
+      name: "basic metric without dimensions",
+      params: {
+        dimensionCols: [],
+        metricData: [createFactMetricData()],
+        eventQuantileData: [],
+        baseIdType: "user_id",
+        joinedMetricTableName: "__userMetricAgg",
+        eventQuantileTableName: "__eventQuantileMetric",
+        cupedMetricTableName: "__userCovariateMetric",
+        capValueTableName: "__capValue",
+        factTablesWithIndices: [{ factTable: createFactTable(), index: 0 }],
+        regressionAdjustedTableIndices: new Set<number>(),
+        percentileTableIndices: new Set<number>(),
+      },
+    },
+    {
+      name: "metric with dimension",
+      params: {
+        dimensionCols: [createDimensionColumn("dim_exp")],
+        metricData: [createFactMetricData()],
+        eventQuantileData: [],
+        baseIdType: "user_id",
+        joinedMetricTableName: "__userMetricAgg",
+        eventQuantileTableName: "__eventQuantileMetric",
+        cupedMetricTableName: "__userCovariateMetric",
+        capValueTableName: "__capValue",
+        factTablesWithIndices: [{ factTable: createFactTable(), index: 0 }],
+        regressionAdjustedTableIndices: new Set<number>(),
+        percentileTableIndices: new Set<number>(),
+      },
+    },
+    {
+      name: "ratio metric",
+      params: {
+        dimensionCols: [],
+        metricData: [createFactMetricData({ ratioMetric: true })],
+        eventQuantileData: [],
+        baseIdType: "user_id",
+        joinedMetricTableName: "__userMetricAgg",
+        eventQuantileTableName: "__eventQuantileMetric",
+        cupedMetricTableName: "__userCovariateMetric",
+        capValueTableName: "__capValue",
+        factTablesWithIndices: [{ factTable: createFactTable(), index: 0 }],
+        regressionAdjustedTableIndices: new Set<number>(),
+        percentileTableIndices: new Set<number>(),
+      },
+    },
+  ];
+
+  parityTestCases.forEach(({ name, params }) => {
+    it(`matches original for: ${name}`, () => {
+      // Get result from original implementation
+      const originalResult = originalGetExperimentFactMetricStatisticsCTE(params);
+
+      // Get result from extracted implementation
+      const extractedResult = buildExperimentFactMetricStatisticsCTE(
+        dialect,
+        params
+      );
+
+      // Compare normalized SQL
+      expect(normalizeSQL(extractedResult)).toBe(normalizeSQL(originalResult));
+    });
+  });
+});

--- a/packages/back-end/test/integrations/sql-builders/query-generators/experiment-metrics.test.ts
+++ b/packages/back-end/test/integrations/sql-builders/query-generators/experiment-metrics.test.ts
@@ -1,0 +1,409 @@
+/**
+ * Tests for Experiment Metrics Query Generator
+ *
+ * Tests the experiment metrics query structure and helper functions.
+ */
+
+import {
+  generateDistinctUsersCTE,
+  generateMetricStatisticsColumns,
+  generateExperimentStatisticsSelect,
+  generateConversionWindowFilter,
+  generateQueryComment,
+  DimensionColumnData,
+  DistinctUsersParams,
+  MetricStatisticsColumns,
+  ConversionWindowFilter,
+} from "../../../../src/integrations/sql-builders/query-generators/experiment-metrics";
+import { bigQueryDialect } from "../../../../src/integrations/sql-dialects";
+import { postgresDialect } from "../../../../src/integrations/sql-dialects/postgres-dialect";
+
+describe("Experiment Metrics Query Generator", () => {
+  describe("generateDistinctUsersCTE", () => {
+    const baseParams: DistinctUsersParams = {
+      baseIdType: "user_id",
+      dimensionCols: [],
+      timestampColumn: "first_exposure_timestamp",
+      sourceTable: "__experimentUnits",
+      whereConditions: [],
+      includeBanditPeriod: false,
+    };
+
+    it("should generate basic distinct users CTE", () => {
+      const cte = generateDistinctUsersCTE(baseParams, bigQueryDialect);
+
+      expect(cte).toContain("SELECT");
+      expect(cte).toContain("user_id");
+      expect(cte).toContain("variation");
+      expect(cte).toContain("timestamp");
+      expect(cte).toContain("first_exposure_date");
+      expect(cte).toContain("FROM __experimentUnits");
+    });
+
+    it("should include dimension columns", () => {
+      const params: DistinctUsersParams = {
+        ...baseParams,
+        dimensionCols: [
+          { value: "country", alias: "dim_country" },
+          { value: "platform", alias: "dim_platform" },
+        ],
+      };
+
+      const cte = generateDistinctUsersCTE(params, bigQueryDialect);
+
+      expect(cte).toContain("country AS dim_country");
+      expect(cte).toContain("platform AS dim_platform");
+    });
+
+    it("should include WHERE conditions", () => {
+      const params: DistinctUsersParams = {
+        ...baseParams,
+        whereConditions: [
+          "first_activation_timestamp IS NOT NULL",
+          "timestamp <= '2024-01-31'",
+        ],
+      };
+
+      const cte = generateDistinctUsersCTE(params, bigQueryDialect);
+
+      expect(cte).toContain("WHERE");
+      expect(cte).toContain("first_activation_timestamp IS NOT NULL");
+      expect(cte).toContain("AND");
+      expect(cte).toContain("timestamp <= '2024-01-31'");
+    });
+
+    it("should include bandit case-when when specified", () => {
+      const params: DistinctUsersParams = {
+        ...baseParams,
+        includeBanditPeriod: true,
+        banditCaseWhen: ", CASE WHEN timestamp < '2024-01-15' THEN 0 ELSE 1 END AS bandit_period",
+      };
+
+      const cte = generateDistinctUsersCTE(params, bigQueryDialect);
+
+      expect(cte).toContain("bandit_period");
+    });
+
+    it("should include regression adjustment columns", () => {
+      const params: DistinctUsersParams = {
+        ...baseParams,
+        raMetricSettings: [
+          { alias: "m0", hours: 24, minDelay: 0 },
+          { alias: "m1", hours: 48, minDelay: -24 },
+        ],
+      };
+
+      const cte = generateDistinctUsersCTE(params, bigQueryDialect);
+
+      expect(cte).toContain("min_preexposure_start");
+      expect(cte).toContain("max_preexposure_end");
+      expect(cte).toContain("m0_preexposure_end");
+      expect(cte).toContain("m0_preexposure_start");
+      expect(cte).toContain("m1_preexposure_end");
+      expect(cte).toContain("m1_preexposure_start");
+    });
+
+    it("should use correct timestamp column", () => {
+      const params: DistinctUsersParams = {
+        ...baseParams,
+        timestampColumn: "first_activation_timestamp",
+      };
+
+      const cte = generateDistinctUsersCTE(params, bigQueryDialect);
+
+      expect(cte).toContain("first_activation_timestamp AS timestamp");
+    });
+
+    it("should use correct source table", () => {
+      const params: DistinctUsersParams = {
+        ...baseParams,
+        sourceTable: "my_experiment_units_table",
+      };
+
+      const cte = generateDistinctUsersCTE(params, bigQueryDialect);
+
+      expect(cte).toContain("FROM my_experiment_units_table");
+    });
+  });
+
+  describe("generateMetricStatisticsColumns", () => {
+    const baseMetric: MetricStatisticsColumns = {
+      idColumn: "metric_123",
+      isPercentileCapped: false,
+      mainSumExpression: "m.m0_value",
+      mainSumSquaresExpression: "m.m0_value",
+      isRatioMetric: false,
+      isRegressionAdjusted: false,
+      isQuantileMetric: false,
+      alias: "m0",
+    };
+
+    it("should generate basic metric statistics columns", () => {
+      const columns = generateMetricStatisticsColumns(
+        baseMetric,
+        bigQueryDialect
+      );
+
+      expect(columns).toContain("m0_id");
+      expect(columns).toContain("m0_main_sum");
+      expect(columns).toContain("m0_main_sum_squares");
+      expect(columns).toContain("SUM(m.m0_value)");
+      expect(columns).toContain("SUM(POWER(m.m0_value, 2))");
+    });
+
+    it("should include cap value for percentile-capped metrics", () => {
+      const metric: MetricStatisticsColumns = {
+        ...baseMetric,
+        isPercentileCapped: true,
+        capValueExpression: "COALESCE(cap.m0_value_cap, 0)",
+      };
+
+      const columns = generateMetricStatisticsColumns(metric, bigQueryDialect);
+
+      expect(columns).toContain("m0_main_cap_value");
+      expect(columns).toContain("MAX(COALESCE(cap.m0_value_cap, 0))");
+    });
+
+    it("should include denominator columns for ratio metrics", () => {
+      const metric: MetricStatisticsColumns = {
+        ...baseMetric,
+        isRatioMetric: true,
+        denominatorSumExpression: "m.m0_denominator",
+        denominatorSumSquaresExpression: "m.m0_denominator",
+        mainDenominatorSumProductExpression: "m.m0_value * m.m0_denominator",
+      };
+
+      const columns = generateMetricStatisticsColumns(metric, bigQueryDialect);
+
+      expect(columns).toContain("m0_denominator_sum");
+      expect(columns).toContain("m0_denominator_sum_squares");
+      expect(columns).toContain("m0_main_denominator_sum_product");
+    });
+
+    it("should include covariate columns for regression-adjusted metrics", () => {
+      const metric: MetricStatisticsColumns = {
+        ...baseMetric,
+        isRegressionAdjusted: true,
+        covariateSumExpression: "c.m0_value",
+        covariateSumSquaresExpression: "c.m0_value",
+        mainCovariateSumProductExpression: "m.m0_value * c.m0_value",
+      };
+
+      const columns = generateMetricStatisticsColumns(metric, bigQueryDialect);
+
+      expect(columns).toContain("m0_covariate_sum");
+      expect(columns).toContain("m0_covariate_sum_squares");
+      expect(columns).toContain("m0_main_covariate_sum_product");
+    });
+
+    it("should include all columns for capped ratio metrics with CUPED", () => {
+      const metric: MetricStatisticsColumns = {
+        ...baseMetric,
+        isPercentileCapped: true,
+        capValueExpression: "COALESCE(cap.m0_value_cap, 0)",
+        isRatioMetric: true,
+        denominatorSumExpression: "m.m0_denominator",
+        denominatorSumSquaresExpression: "m.m0_denominator",
+        denominatorCapValueExpression: "COALESCE(cap.m0_denominator_cap, 0)",
+        isRegressionAdjusted: true,
+        covariateSumExpression: "c.m0_value",
+        covariateSumSquaresExpression: "c.m0_value",
+      };
+
+      const columns = generateMetricStatisticsColumns(metric, bigQueryDialect);
+
+      expect(columns).toContain("m0_main_cap_value");
+      expect(columns).toContain("m0_denominator_cap_value");
+      expect(columns).toContain("m0_covariate_sum");
+    });
+  });
+
+  describe("generateExperimentStatisticsSelect", () => {
+    it("should generate statistics select with COUNT", () => {
+      const select = generateExperimentStatisticsSelect(
+        {
+          dimensionCols: [],
+          metrics: [
+            {
+              idColumn: "m1",
+              isPercentileCapped: false,
+              mainSumExpression: "m.m0_value",
+              mainSumSquaresExpression: "m.m0_value",
+              isRatioMetric: false,
+              isRegressionAdjusted: false,
+              isQuantileMetric: false,
+              alias: "m0",
+            },
+          ],
+          baseIdType: "user_id",
+          joinedMetricTableName: "__userMetricAgg",
+          additionalJoins: [],
+        },
+        bigQueryDialect
+      );
+
+      expect(select).toContain("SELECT");
+      expect(select).toContain("m.variation AS variation");
+      expect(select).toContain("COUNT(*) AS users");
+      expect(select).toContain("FROM");
+      expect(select).toContain("__userMetricAgg m");
+      expect(select).toContain("GROUP BY");
+      expect(select).toContain("m.variation");
+    });
+
+    it("should include dimension columns in SELECT and GROUP BY", () => {
+      const dimensionCols: DimensionColumnData[] = [
+        { value: "country", alias: "dim_country" },
+      ];
+
+      const select = generateExperimentStatisticsSelect(
+        {
+          dimensionCols,
+          metrics: [],
+          baseIdType: "user_id",
+          joinedMetricTableName: "__userMetricAgg",
+          additionalJoins: [],
+        },
+        bigQueryDialect
+      );
+
+      expect(select).toContain("m.dim_country AS dim_country");
+      expect(select).toContain(", m.dim_country");
+    });
+
+    it("should include additional joins", () => {
+      const select = generateExperimentStatisticsSelect(
+        {
+          dimensionCols: [],
+          metrics: [],
+          baseIdType: "user_id",
+          joinedMetricTableName: "__userMetricAgg",
+          additionalJoins: [
+            "LEFT JOIN __capValue cap ON (cap.user_id = m.user_id)",
+          ],
+        },
+        bigQueryDialect
+      );
+
+      expect(select).toContain("LEFT JOIN __capValue cap");
+    });
+  });
+
+  describe("generateConversionWindowFilter", () => {
+    const baseParams: ConversionWindowFilter = {
+      valueColumn: "m.value",
+      metricTimestampColumn: "m.timestamp",
+      exposureTimestampColumn: "d.timestamp",
+      overrideConversionWindows: false,
+      endDate: new Date("2024-01-31T23:59:59Z"),
+    };
+
+    it("should return simple end date filter when overriding windows", () => {
+      const params: ConversionWindowFilter = {
+        ...baseParams,
+        overrideConversionWindows: true,
+      };
+
+      const filter = generateConversionWindowFilter(params, bigQueryDialect);
+
+      expect(filter).toContain("CASE WHEN");
+      expect(filter).toContain("m.timestamp <=");
+      expect(filter).toContain("2024-01-31");
+      expect(filter).toContain("THEN m.value ELSE NULL END");
+    });
+
+    it("should include conversion window start condition", () => {
+      const params: ConversionWindowFilter = {
+        ...baseParams,
+        conversionWindowStart: 1, // 1 hour after exposure
+      };
+
+      const filter = generateConversionWindowFilter(params, bigQueryDialect);
+
+      expect(filter).toContain("m.timestamp >=");
+      expect(filter).toContain("d.timestamp");
+    });
+
+    it("should include conversion window end condition", () => {
+      const params: ConversionWindowFilter = {
+        ...baseParams,
+        conversionWindowEnd: 24, // 24 hours after exposure
+      };
+
+      const filter = generateConversionWindowFilter(params, bigQueryDialect);
+
+      expect(filter).toContain("m.timestamp <=");
+      expect(filter).toContain("d.timestamp");
+    });
+
+    it("should combine multiple conditions with AND", () => {
+      const params: ConversionWindowFilter = {
+        ...baseParams,
+        conversionWindowStart: 1,
+        conversionWindowEnd: 72,
+      };
+
+      const filter = generateConversionWindowFilter(params, bigQueryDialect);
+
+      expect(filter).toContain("AND");
+      expect(filter).toContain("m.timestamp >=");
+      expect(filter).toContain("m.timestamp <=");
+    });
+
+    it("should always include end date condition", () => {
+      const filter = generateConversionWindowFilter(baseParams, bigQueryDialect);
+
+      expect(filter).toContain("2024-01-31");
+    });
+  });
+
+  describe("generateQueryComment", () => {
+    it("should generate comment for single fact table", () => {
+      const comment = generateQueryComment(["events"]);
+
+      expect(comment).toBe("-- Fact Table: events");
+    });
+
+    it("should generate comment for multiple fact tables", () => {
+      const comment = generateQueryComment(["events", "purchases", "sessions"]);
+
+      expect(comment).toBe("-- Cross-Fact Table Metrics: events & purchases & sessions");
+    });
+  });
+
+  describe("Cross-dialect support", () => {
+    it("should work with BigQuery dialect", () => {
+      const cte = generateDistinctUsersCTE(
+        {
+          baseIdType: "user_id",
+          dimensionCols: [],
+          timestampColumn: "timestamp",
+          sourceTable: "__units",
+          whereConditions: [],
+          includeBanditPeriod: false,
+        },
+        bigQueryDialect
+      );
+
+      expect(cte).toContain("user_id");
+      expect(cte).toContain("FROM __units");
+    });
+
+    it("should work with Postgres dialect", () => {
+      const cte = generateDistinctUsersCTE(
+        {
+          baseIdType: "user_id",
+          dimensionCols: [],
+          timestampColumn: "timestamp",
+          sourceTable: "__units",
+          whereConditions: [],
+          includeBanditPeriod: false,
+        },
+        postgresDialect
+      );
+
+      expect(cte).toContain("user_id");
+      expect(cte).toContain("FROM __units");
+    });
+  });
+});

--- a/packages/back-end/test/integrations/sql-builders/query-generators/metric-analysis.test.ts
+++ b/packages/back-end/test/integrations/sql-builders/query-generators/metric-analysis.test.ts
@@ -1,0 +1,344 @@
+/**
+ * Tests for Metric Analysis Query Generator
+ *
+ * Tests the metric analysis query structure and helper functions.
+ */
+
+import {
+  generateMetricAnalysisStatisticClauses,
+  generateHistogramBins,
+  generateHistogramPlaceholders,
+  generateDailyStatisticsCTE,
+  generateOverallStatisticsCTE,
+  generateHistogramCTE,
+  DEFAULT_METRIC_HISTOGRAM_BINS,
+  MetricAnalysisStatisticsConfig,
+} from "../../../../src/integrations/sql-builders/query-generators/metric-analysis";
+import { bigQueryDialect } from "../../../../src/integrations/sql-dialects";
+import { postgresDialect } from "../../../../src/integrations/sql-dialects/postgres-dialect";
+
+describe("Metric Analysis Query Generator", () => {
+  describe("Constants", () => {
+    it("should have DEFAULT_METRIC_HISTOGRAM_BINS = 20", () => {
+      expect(DEFAULT_METRIC_HISTOGRAM_BINS).toBe(20);
+    });
+  });
+
+  describe("generateMetricAnalysisStatisticClauses", () => {
+    it("should generate basic statistics for non-ratio metrics", () => {
+      const config: MetricAnalysisStatisticsConfig = {
+        isRatioMetric: false,
+        valueColumn: "value",
+        createHistogram: false,
+        isCapped: false,
+      };
+
+      const clauses = generateMetricAnalysisStatisticClauses(config);
+
+      expect(clauses).toContain("COUNT(*)");
+      expect(clauses).toContain("SUM(value)");
+      expect(clauses).toContain("SUM(POWER(value, 2))");
+      expect(clauses).toContain("main_sum");
+      expect(clauses).toContain("main_sum_squares");
+    });
+
+    it("should include denominator statistics for ratio metrics", () => {
+      const config: MetricAnalysisStatisticsConfig = {
+        isRatioMetric: true,
+        valueColumn: "value",
+        denominatorColumn: "denominator",
+        createHistogram: false,
+        isCapped: false,
+      };
+
+      const clauses = generateMetricAnalysisStatisticClauses(config);
+
+      expect(clauses).toContain("SUM(denominator)");
+      expect(clauses).toContain("SUM(POWER(denominator, 2))");
+      expect(clauses).toContain("denominator_sum");
+      expect(clauses).toContain("denominator_sum_squares");
+      expect(clauses).toContain("main_denominator_sum_product");
+    });
+
+    it("should handle capped value columns", () => {
+      const config: MetricAnalysisStatisticsConfig = {
+        isRatioMetric: false,
+        valueColumn: "COALESCE(cap.value_capped, value)",
+        createHistogram: false,
+        isCapped: true,
+      };
+
+      const clauses = generateMetricAnalysisStatisticClauses(config);
+
+      expect(clauses).toContain("COALESCE(cap.value_capped, value)");
+    });
+  });
+
+  describe("generateHistogramBins", () => {
+    it("should generate the correct number of bins", () => {
+      const bins = generateHistogramBins(bigQueryDialect, 10);
+
+      // Should have all 10 bin columns
+      for (let i = 0; i < 10; i++) {
+        expect(bins).toContain(`units_bin_${i}`);
+      }
+    });
+
+    it("should use dialect ifElse for bin conditions", () => {
+      const bins = generateHistogramBins(bigQueryDialect, 5);
+
+      // BigQuery uses CASE WHEN
+      expect(bins).toContain("CASE WHEN");
+      expect(bins).toContain("THEN");
+      expect(bins).toContain("ELSE");
+    });
+
+    it("should use default bin count when not specified", () => {
+      const bins = generateHistogramBins(bigQueryDialect);
+
+      // Should have 20 bins by default
+      expect(bins).toContain("units_bin_0");
+      expect(bins).toContain(`units_bin_${DEFAULT_METRIC_HISTOGRAM_BINS - 1}`);
+    });
+
+    it("should create first bin for values less than min + width", () => {
+      const bins = generateHistogramBins(bigQueryDialect, 5);
+
+      expect(bins).toContain("m.value < (s.value_min + s.bin_width)");
+      expect(bins).toContain("units_bin_0");
+    });
+
+    it("should create last bin for values >= final threshold", () => {
+      const bins = generateHistogramBins(bigQueryDialect, 5);
+
+      expect(bins).toContain("m.value >= (s.value_min + s.bin_width*4.0)");
+      expect(bins).toContain("units_bin_4");
+    });
+  });
+
+  describe("generateHistogramPlaceholders", () => {
+    it("should generate NULL placeholders for all bins", () => {
+      const placeholders = generateHistogramPlaceholders(bigQueryDialect, 5);
+
+      for (let i = 0; i < 5; i++) {
+        expect(placeholders).toContain(`units_bin_${i}`);
+      }
+    });
+
+    it("should use dialect ensureFloat for NULL values", () => {
+      const placeholders = generateHistogramPlaceholders(bigQueryDialect, 3);
+
+      // BigQuery ensureFloat on NULL returns NULL (unchanged)
+      expect(placeholders).toContain("NULL");
+    });
+
+    it("should use default bin count when not specified", () => {
+      const placeholders = generateHistogramPlaceholders(bigQueryDialect);
+
+      expect(placeholders).toContain("units_bin_0");
+      expect(placeholders).toContain(`units_bin_${DEFAULT_METRIC_HISTOGRAM_BINS - 1}`);
+    });
+  });
+
+  describe("generateDailyStatisticsCTE", () => {
+    const baseConfig: MetricAnalysisStatisticsConfig = {
+      isRatioMetric: false,
+      valueColumn: "value",
+      createHistogram: false,
+      isCapped: false,
+    };
+
+    it("should generate daily statistics CTE", () => {
+      const cte = generateDailyStatisticsCTE(baseConfig, bigQueryDialect, {
+        sourceTable: "__userMetricDaily",
+        useCapTable: false,
+      });
+
+      expect(cte).toContain("SELECT");
+      expect(cte).toContain("date");
+      expect(cte).toContain("data_type");
+      expect(cte).toContain("capped");
+      expect(cte).toContain("GROUP BY date");
+      expect(cte).toContain("__userMetricDaily");
+    });
+
+    it("should include histogram placeholders when createHistogram is true", () => {
+      const config: MetricAnalysisStatisticsConfig = {
+        ...baseConfig,
+        createHistogram: true,
+      };
+
+      const cte = generateDailyStatisticsCTE(config, bigQueryDialect, {
+        sourceTable: "__userMetricDaily",
+        useCapTable: false,
+      });
+
+      expect(cte).toContain("value_min");
+      expect(cte).toContain("value_max");
+      expect(cte).toContain("bin_width");
+      expect(cte).toContain("units_bin_0");
+    });
+
+    it("should add CROSS JOIN when cap table is used", () => {
+      const cte = generateDailyStatisticsCTE(baseConfig, bigQueryDialect, {
+        sourceTable: "__userMetricDaily",
+        useCapTable: true,
+      });
+
+      expect(cte).toContain("CROSS JOIN __capValue cap");
+    });
+
+    it("should set capped status correctly", () => {
+      const cappedConfig: MetricAnalysisStatisticsConfig = {
+        ...baseConfig,
+        isCapped: true,
+      };
+
+      const cte = generateDailyStatisticsCTE(cappedConfig, bigQueryDialect, {
+        sourceTable: "__userMetricDaily",
+        useCapTable: false,
+      });
+
+      expect(cte).toContain("'capped'");
+    });
+  });
+
+  describe("generateOverallStatisticsCTE", () => {
+    const baseConfig: MetricAnalysisStatisticsConfig = {
+      isRatioMetric: false,
+      valueColumn: "value",
+      createHistogram: false,
+      isCapped: false,
+    };
+
+    it("should generate overall statistics CTE with NULL date", () => {
+      const cte = generateOverallStatisticsCTE(baseConfig, bigQueryDialect, {
+        sourceTable: "__userMetricOverall",
+        useCapTable: false,
+      });
+
+      expect(cte).toContain("SELECT");
+      expect(cte).toContain("NULL");
+      expect(cte).toContain("date");
+      expect(cte).toContain("data_type");
+      expect(cte).toContain("'overall'");
+    });
+
+    it("should include bin_width calculation when createHistogram is true", () => {
+      const config: MetricAnalysisStatisticsConfig = {
+        ...baseConfig,
+        createHistogram: true,
+      };
+
+      const cte = generateOverallStatisticsCTE(config, bigQueryDialect, {
+        sourceTable: "__userMetricOverall",
+        useCapTable: false,
+      });
+
+      expect(cte).toContain("value_min");
+      expect(cte).toContain("value_max");
+      expect(cte).toContain("bin_width");
+      // Should calculate bin_width, not use NULL
+      expect(cte).toContain("(MAX");
+      expect(cte).toContain("MIN");
+    });
+
+    it("should add CROSS JOIN when cap table is used", () => {
+      const cte = generateOverallStatisticsCTE(baseConfig, bigQueryDialect, {
+        sourceTable: "__userMetricOverall",
+        useCapTable: true,
+      });
+
+      expect(cte).toContain("CROSS JOIN __capValue cap");
+    });
+  });
+
+  describe("generateHistogramCTE", () => {
+    it("should generate histogram CTE with CROSS JOIN", () => {
+      const cte = generateHistogramCTE(bigQueryDialect, {
+        sourceTable: "__userMetricOverall",
+        statisticsTable: "__statisticsOverall",
+      });
+
+      expect(cte).toContain("SELECT");
+      expect(cte).toContain("FROM");
+      expect(cte).toContain("__userMetricOverall");
+      expect(cte).toContain("CROSS JOIN");
+      expect(cte).toContain("__statisticsOverall");
+    });
+
+    it("should include histogram bin calculations", () => {
+      const cte = generateHistogramCTE(bigQueryDialect, {
+        sourceTable: "__userMetricOverall",
+        statisticsTable: "__statisticsOverall",
+      });
+
+      expect(cte).toContain("units_bin_0");
+      expect(cte).toContain("m.value");
+      expect(cte).toContain("s.value_min");
+      expect(cte).toContain("s.bin_width");
+    });
+  });
+
+  describe("Cross-dialect support", () => {
+    const baseConfig: MetricAnalysisStatisticsConfig = {
+      isRatioMetric: false,
+      valueColumn: "value",
+      createHistogram: true,
+      isCapped: false,
+    };
+
+    it("should work with Postgres dialect", () => {
+      const cte = generateDailyStatisticsCTE(baseConfig, postgresDialect, {
+        sourceTable: "__userMetricDaily",
+        useCapTable: false,
+      });
+
+      expect(cte).toContain("SELECT");
+      expect(cte).toContain("date");
+    });
+
+    it("should use dialect-specific casting", () => {
+      const bigqueryCte = generateOverallStatisticsCTE(
+        baseConfig,
+        bigQueryDialect,
+        { sourceTable: "__test", useCapTable: false }
+      );
+
+      const postgresCte = generateOverallStatisticsCTE(
+        baseConfig,
+        postgresDialect,
+        { sourceTable: "__test", useCapTable: false }
+      );
+
+      // Both should have the basic structure
+      expect(bigqueryCte).toContain("date");
+      expect(postgresCte).toContain("date");
+
+      // BigQuery uses cast(... as string), Postgres uses cast(... as varchar)
+      expect(bigqueryCte).toContain("cast");
+      expect(postgresCte).toContain("cast");
+    });
+  });
+
+  describe("Ratio metrics", () => {
+    it("should include denominator in daily statistics for ratio metrics", () => {
+      const config: MetricAnalysisStatisticsConfig = {
+        isRatioMetric: true,
+        valueColumn: "value",
+        denominatorColumn: "denominator",
+        createHistogram: false,
+        isCapped: false,
+      };
+
+      const cte = generateDailyStatisticsCTE(config, bigQueryDialect, {
+        sourceTable: "__userMetricDaily",
+        useCapTable: false,
+      });
+
+      expect(cte).toContain("denominator_sum");
+      expect(cte).toContain("denominator_sum_squares");
+      expect(cte).toContain("main_denominator_sum_product");
+    });
+  });
+});

--- a/packages/back-end/test/integrations/sql-builders/query-generators/past-experiments.test.ts
+++ b/packages/back-end/test/integrations/sql-builders/query-generators/past-experiments.test.ts
@@ -1,0 +1,402 @@
+/**
+ * Tests for Past Experiments Query Generator
+ *
+ * Tests the extraction of past experiments query generation from SqlIntegration.
+ * Verifies that the extracted pure function produces equivalent SQL to the original.
+ */
+
+import { ExposureQuery } from "shared/types/datasource";
+import {
+  generatePastExperimentsQuery,
+  MAX_ROWS_PAST_EXPERIMENTS_QUERY,
+} from "../../../../src/integrations/sql-builders/query-generators/past-experiments";
+import { bigQueryDialect } from "../../../../src/integrations/sql-dialects";
+import { snowflakeDialect } from "../../../../src/integrations/sql-dialects/snowflake-dialect";
+import { postgresDialect } from "../../../../src/integrations/sql-dialects/postgres-dialect";
+
+describe("Past Experiments Query Generator", () => {
+  // Sample exposure queries for testing
+  const sampleExposureQueries: ExposureQuery[] = [
+    {
+      id: "user_id",
+      name: "User ID Exposures",
+      userIdType: "user_id",
+      query: "SELECT user_id, experiment_id, variation_id, timestamp FROM experiment_viewed WHERE timestamp >= '{{startDate}}'",
+      dimensions: [],
+      hasNameCol: false,
+    },
+  ];
+
+  const exposureQueryWithNames: ExposureQuery[] = [
+    {
+      id: "user_id_with_names",
+      name: "User ID Exposures with Names",
+      userIdType: "user_id",
+      query: "SELECT user_id, experiment_id, experiment_name, variation_id, variation_name, timestamp FROM experiment_viewed",
+      dimensions: [],
+      hasNameCol: true,
+    },
+  ];
+
+  const multipleExposureQueries: ExposureQuery[] = [
+    {
+      id: "user_id",
+      name: "User Exposures",
+      userIdType: "user_id",
+      query: "SELECT user_id, experiment_id, variation_id, timestamp FROM user_experiment_viewed",
+      dimensions: [],
+      hasNameCol: false,
+    },
+    {
+      id: "anonymous_id",
+      name: "Anonymous Exposures",
+      userIdType: "anonymous_id",
+      query: "SELECT anonymous_id, experiment_id, variation_id, timestamp FROM anon_experiment_viewed",
+      dimensions: [],
+      hasNameCol: false,
+    },
+  ];
+
+  const fromDate = new Date("2024-01-01T00:00:00Z");
+  const toDate = new Date("2024-03-01T00:00:00Z");
+
+  describe("Basic Query Generation", () => {
+    it("should generate a valid SQL query for BigQuery dialect", () => {
+      const query = generatePastExperimentsQuery(
+        {
+          from: fromDate,
+          to: toDate,
+          exposureQueries: sampleExposureQueries,
+        },
+        bigQueryDialect
+      );
+
+      // Check query structure
+      expect(query).toContain("-- Past Experiments");
+      expect(query).toContain("__exposures0");
+      expect(query).toContain("__experiments");
+      expect(query).toContain("__userThresholds");
+      expect(query).toContain("__variations");
+
+      // Check BigQuery-specific syntax
+      expect(query).toContain("cast(");
+      expect(query).toContain("DATETIME"); // BigQuery uses DATETIME for castUserDateCol
+    });
+
+    it("should generate a valid SQL query for Snowflake dialect", () => {
+      const query = generatePastExperimentsQuery(
+        {
+          from: fromDate,
+          to: toDate,
+          exposureQueries: sampleExposureQueries,
+        },
+        snowflakeDialect
+      );
+
+      expect(query).toContain("-- Past Experiments");
+      expect(query).toContain("__exposures0");
+    });
+
+    it("should generate a valid SQL query for Postgres dialect", () => {
+      const query = generatePastExperimentsQuery(
+        {
+          from: fromDate,
+          to: toDate,
+          exposureQueries: sampleExposureQueries,
+        },
+        postgresDialect
+      );
+
+      expect(query).toContain("-- Past Experiments");
+      expect(query).toContain("__exposures0");
+    });
+  });
+
+  describe("Exposure Query Handling", () => {
+    it("should handle exposure queries with hasNameCol=true", () => {
+      const query = generatePastExperimentsQuery(
+        {
+          from: fromDate,
+          to: toDate,
+          exposureQueries: exposureQueryWithNames,
+        },
+        bigQueryDialect
+      );
+
+      // When hasNameCol is true, it should use MIN(experiment_name) and MIN(variation_name)
+      expect(query).toContain("MIN(experiment_name)");
+      expect(query).toContain("MIN(variation_name)");
+    });
+
+    it("should handle exposure queries with hasNameCol=false", () => {
+      const query = generatePastExperimentsQuery(
+        {
+          from: fromDate,
+          to: toDate,
+          exposureQueries: sampleExposureQueries,
+        },
+        bigQueryDialect
+      );
+
+      // When hasNameCol is false, experiment_name should fall back to experiment_id
+      // and variation_name to cast(variation_id as string)
+      expect(query).toContain("experiment_id as experiment_name");
+    });
+
+    it("should handle multiple exposure queries with UNION ALL", () => {
+      const query = generatePastExperimentsQuery(
+        {
+          from: fromDate,
+          to: toDate,
+          exposureQueries: multipleExposureQueries,
+        },
+        bigQueryDialect
+      );
+
+      // Check for multiple exposure CTEs
+      expect(query).toContain("__exposures0");
+      expect(query).toContain("__exposures1");
+
+      // Check for UNION ALL
+      expect(query).toContain("UNION ALL");
+
+      // Check for both user types
+      expect(query).toContain("user_id");
+      expect(query).toContain("anonymous_id");
+    });
+
+    it("should throw error when no exposure queries provided", () => {
+      expect(() => {
+        generatePastExperimentsQuery(
+          {
+            from: fromDate,
+            to: toDate,
+            exposureQueries: [],
+          },
+          bigQueryDialect
+        );
+      }).toThrow("At least one exposure query is required");
+    });
+  });
+
+  describe("Date Handling", () => {
+    it("should use provided from date in query", () => {
+      const query = generatePastExperimentsQuery(
+        {
+          from: fromDate,
+          to: toDate,
+          exposureQueries: sampleExposureQueries,
+        },
+        bigQueryDialect
+      );
+
+      // Check that the from date is used in the WHERE clause
+      expect(query).toContain("2024-01-01");
+    });
+
+    it("should use provided to date in query", () => {
+      const query = generatePastExperimentsQuery(
+        {
+          from: fromDate,
+          to: toDate,
+          exposureQueries: sampleExposureQueries,
+        },
+        bigQueryDialect
+      );
+
+      // Check that the to date is used
+      expect(query).toContain("2024-03-01");
+    });
+
+    it("should default to current time when to date is not provided", () => {
+      const now = new Date();
+      const query = generatePastExperimentsQuery(
+        {
+          from: fromDate,
+          exposureQueries: sampleExposureQueries,
+        },
+        bigQueryDialect
+      );
+
+      // Query should still be valid
+      expect(query).toContain("-- Past Experiments");
+      // The current date should be in the query (in some format)
+      expect(query).toContain(now.getFullYear().toString());
+    });
+  });
+
+  describe("Safe Rollout Filtering", () => {
+    it("should filter out safe rollout tracking keys", () => {
+      const query = generatePastExperimentsQuery(
+        {
+          from: fromDate,
+          to: toDate,
+          exposureQueries: sampleExposureQueries,
+        },
+        bigQueryDialect
+      );
+
+      // Check for safe rollout filter using the "srk_" prefix
+      expect(query).toContain("srk_");
+      expect(query).toContain("SUBSTRING");
+    });
+  });
+
+  describe("Result Limiting", () => {
+    it("should include LIMIT clause with MAX_ROWS_PAST_EXPERIMENTS_QUERY", () => {
+      const query = generatePastExperimentsQuery(
+        {
+          from: fromDate,
+          to: toDate,
+          exposureQueries: sampleExposureQueries,
+        },
+        bigQueryDialect
+      );
+
+      // Check for LIMIT clause (may be formatted on separate lines)
+      expect(query).toContain("LIMIT");
+      expect(query).toContain(MAX_ROWS_PAST_EXPERIMENTS_QUERY.toString());
+    });
+  });
+
+  describe("Ordering", () => {
+    it("should order results by start_date DESC, experiment_id ASC, variation_id ASC", () => {
+      const query = generatePastExperimentsQuery(
+        {
+          from: fromDate,
+          to: toDate,
+          exposureQueries: sampleExposureQueries,
+        },
+        bigQueryDialect
+      );
+
+      expect(query).toContain("ORDER BY");
+      expect(query).toContain("start_date DESC");
+      expect(query).toContain("experiment_id ASC");
+      expect(query).toContain("variation_id ASC");
+    });
+  });
+
+  describe("User Threshold Logic", () => {
+    it("should include user threshold calculation with 5% max users filter", () => {
+      const query = generatePastExperimentsQuery(
+        {
+          from: fromDate,
+          to: toDate,
+          exposureQueries: sampleExposureQueries,
+        },
+        bigQueryDialect
+      );
+
+      // Check for threshold calculation
+      expect(query).toContain("threshold");
+      expect(query).toContain("max(users)");
+      expect(query).toContain("0.05");
+
+      // Check for minimum users filter
+      expect(query).toContain("users > 5");
+    });
+
+    it("should join variations with thresholds to filter low-traffic variations", () => {
+      const query = generatePastExperimentsQuery(
+        {
+          from: fromDate,
+          to: toDate,
+          exposureQueries: sampleExposureQueries,
+        },
+        bigQueryDialect
+      );
+
+      // Check for join between experiments and thresholds
+      expect(query).toContain("JOIN __userThresholds");
+      expect(query).toContain("d.users > u.threshold");
+    });
+  });
+
+  describe("Output Columns", () => {
+    it("should select correct output columns", () => {
+      const query = generatePastExperimentsQuery(
+        {
+          from: fromDate,
+          to: toDate,
+          exposureQueries: sampleExposureQueries,
+        },
+        bigQueryDialect
+      );
+
+      // Check for expected output columns
+      expect(query).toContain("exposure_query");
+      expect(query).toContain("experiment_id");
+      expect(query).toContain("experiment_name");
+      expect(query).toContain("variation_id");
+      expect(query).toContain("variation_name");
+      expect(query).toContain("start_date");
+      expect(query).toContain("end_date");
+      expect(query).toContain("users");
+      expect(query).toContain("latest_data");
+    });
+  });
+
+  describe("HLL Support", () => {
+    it("should use HLL aggregate for BigQuery (which supports HLL)", () => {
+      const query = generatePastExperimentsQuery(
+        {
+          from: fromDate,
+          to: toDate,
+          exposureQueries: sampleExposureQueries,
+        },
+        bigQueryDialect
+      );
+
+      // BigQuery supports HLL, so should use HLL functions
+      expect(query).toContain("HLL_COUNT");
+    });
+
+    it("should use COUNT DISTINCT for dialects without HLL", () => {
+      const query = generatePastExperimentsQuery(
+        {
+          from: fromDate,
+          to: toDate,
+          exposureQueries: sampleExposureQueries,
+        },
+        postgresDialect
+      );
+
+      // Postgres doesn't have HLL by default, should use COUNT DISTINCT
+      expect(query).toContain("COUNT(distinct");
+    });
+  });
+
+  describe("SQL Template Compilation", () => {
+    it("should compile SQL template with startDate variable", () => {
+      const exposureWithTemplate: ExposureQuery[] = [
+        {
+          id: "user_id",
+          name: "User ID Exposures",
+          userIdType: "user_id",
+          query: "SELECT * FROM events WHERE timestamp >= '{{startDate}}'",
+          dimensions: [],
+          hasNameCol: false,
+        },
+      ];
+
+      const query = generatePastExperimentsQuery(
+        {
+          from: new Date("2024-06-15T00:00:00Z"),
+          to: toDate,
+          exposureQueries: exposureWithTemplate,
+        },
+        bigQueryDialect
+      );
+
+      // The template variable should be replaced with the actual date
+      expect(query).toContain("2024-06-15");
+    });
+  });
+});
+
+describe("MAX_ROWS_PAST_EXPERIMENTS_QUERY constant", () => {
+  it("should be 3000", () => {
+    expect(MAX_ROWS_PAST_EXPERIMENTS_QUERY).toBe(3000);
+  });
+});

--- a/packages/back-end/test/integrations/sql-builders/query-generators/schema-discovery.test.ts
+++ b/packages/back-end/test/integrations/sql-builders/query-generators/schema-discovery.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Tests for Schema Discovery Query Generator
+ *
+ * Tests the extraction of information schema query generation from SqlIntegration.
+ */
+
+import {
+  generateInformationSchemaQuery,
+  generateTableDataQuery,
+  generateTablePath,
+  defaultInformationSchemaConfigs,
+  InformationSchemaConfig,
+} from "../../../../src/integrations/sql-builders/query-generators/schema-discovery";
+
+describe("Schema Discovery Query Generator", () => {
+  describe("generateInformationSchemaQuery", () => {
+    const standardConfig: InformationSchemaConfig = {
+      tablePath: "information_schema.columns",
+      whereClause: "table_schema NOT IN ('information_schema')",
+      formatDialect: "",
+    };
+
+    it("should generate a valid information schema query", () => {
+      const query = generateInformationSchemaQuery(standardConfig);
+
+      // Check for expected columns
+      expect(query).toContain("table_name as table_name");
+      expect(query).toContain("table_catalog as table_catalog");
+      expect(query).toContain("table_schema as table_schema");
+      expect(query).toContain("count(column_name) as column_count");
+
+      // Check for table source
+      expect(query).toContain("information_schema.columns");
+
+      // Check for WHERE clause
+      expect(query).toContain("table_schema NOT IN ('information_schema')");
+
+      // Check for GROUP BY
+      expect(query).toContain("GROUP BY");
+      expect(query).toContain("table_name");
+      expect(query).toContain("table_schema");
+      expect(query).toContain("table_catalog");
+    });
+
+    it("should handle fixed catalog (like Vertica)", () => {
+      const verticaConfig: InformationSchemaConfig = {
+        ...standardConfig,
+        tablePath: "v_catalog.columns",
+        fixedCatalog: "my_database",
+      };
+
+      const query = generateInformationSchemaQuery(verticaConfig);
+
+      // Should use the fixed catalog value
+      expect(query).toContain("'my_database' as table_catalog");
+
+      // Should group by the literal value
+      expect(query).toContain("'my_database'");
+    });
+
+    it("should use the correct table path for BigQuery", () => {
+      const bigqueryConfig: InformationSchemaConfig = {
+        tablePath: "my_dataset.INFORMATION_SCHEMA.COLUMNS",
+        whereClause: "table_schema NOT IN ('information_schema')",
+        formatDialect: "bigquery",
+      };
+
+      const query = generateInformationSchemaQuery(bigqueryConfig);
+
+      expect(query).toContain("my_dataset.INFORMATION_SCHEMA.COLUMNS");
+    });
+
+    it("should use the correct table path for Redshift", () => {
+      const redshiftConfig: InformationSchemaConfig = {
+        tablePath: "SVV_COLUMNS",
+        whereClause: "table_schema NOT IN ('information_schema')",
+        formatDialect: "postgresql",
+      };
+
+      const query = generateInformationSchemaQuery(redshiftConfig);
+
+      expect(query).toContain("SVV_COLUMNS");
+    });
+
+    it("should apply format dialect correctly", () => {
+      const postgresConfig: InformationSchemaConfig = {
+        ...standardConfig,
+        formatDialect: "postgresql",
+      };
+
+      const query = generateInformationSchemaQuery(postgresConfig);
+
+      // Query should be formatted
+      expect(query).toContain("SELECT");
+      expect(query).toContain("FROM");
+      expect(query).toContain("WHERE");
+    });
+  });
+
+  describe("generateTableDataQuery", () => {
+    const standardConfig: InformationSchemaConfig = {
+      tablePath: "information_schema.columns",
+      whereClause: "",
+      formatDialect: "",
+    };
+
+    it("should generate a valid table data query", () => {
+      const query = generateTableDataQuery(standardConfig, {
+        databaseName: "my_database",
+        tableSchema: "public",
+        tableName: "users",
+      });
+
+      // Check for expected columns
+      expect(query).toContain("data_type as data_type");
+      expect(query).toContain("column_name as column_name");
+
+      // Check for table source
+      expect(query).toContain("information_schema.columns");
+
+      // Check for WHERE conditions
+      expect(query).toContain("table_name = 'users'");
+      expect(query).toContain("table_schema = 'public'");
+      expect(query).toContain("table_catalog = 'my_database'");
+    });
+
+    it("should escape single quotes in identifiers", () => {
+      const query = generateTableDataQuery(standardConfig, {
+        databaseName: "my_db's",
+        tableSchema: "schema'test",
+        tableName: "table's_name",
+      });
+
+      // Single quotes should be escaped
+      expect(query).toContain("my_db''s");
+      expect(query).toContain("schema''test");
+      expect(query).toContain("table''s_name");
+    });
+
+    it("should use the provided table path", () => {
+      const redshiftConfig: InformationSchemaConfig = {
+        tablePath: "SVV_COLUMNS",
+        whereClause: "",
+        formatDialect: "",
+      };
+
+      const query = generateTableDataQuery(redshiftConfig, {
+        databaseName: "db",
+        tableSchema: "public",
+        tableName: "users",
+      });
+
+      expect(query).toContain("SVV_COLUMNS");
+    });
+  });
+
+  describe("generateTablePath", () => {
+    it("should return just the table name with no options", () => {
+      const path = generateTablePath("my_table");
+      expect(path).toBe("my_table");
+    });
+
+    it("should add database prefix when required", () => {
+      const path = generateTablePath("my_table", {
+        database: "my_db",
+        requiresDatabase: true,
+      });
+      expect(path).toBe("my_db.my_table");
+    });
+
+    it("should add schema prefix when required", () => {
+      const path = generateTablePath("my_table", {
+        schema: "my_schema",
+        requiresSchema: true,
+      });
+      expect(path).toBe("my_schema.my_table");
+    });
+
+    it("should add both database and schema prefixes", () => {
+      const path = generateTablePath("my_table", {
+        database: "my_db",
+        schema: "my_schema",
+        requiresDatabase: true,
+        requiresSchema: true,
+      });
+      expect(path).toBe("my_db.my_schema.my_table");
+    });
+
+    it("should not add prefix if not required", () => {
+      const path = generateTablePath("my_table", {
+        database: "my_db",
+        schema: "my_schema",
+        requiresDatabase: false,
+        requiresSchema: false,
+      });
+      expect(path).toBe("my_table");
+    });
+
+    it("should add escape characters when specified", () => {
+      const path = generateTablePath("my_table", {
+        database: "my_db",
+        requiresDatabase: true,
+        escapeChar: "`",
+      });
+      expect(path).toBe("`my_db.my_table`");
+    });
+
+    it("should handle complex table names with dots", () => {
+      const path = generateTablePath("information_schema.columns");
+      expect(path).toBe("information_schema.columns");
+    });
+  });
+
+  describe("defaultInformationSchemaConfigs", () => {
+    it("should have standard config", () => {
+      expect(defaultInformationSchemaConfigs.standard.tablePath).toBe(
+        "information_schema.columns"
+      );
+    });
+
+    it("should have bigquery config", () => {
+      expect(defaultInformationSchemaConfigs.bigquery.tablePath).toBe(
+        "INFORMATION_SCHEMA.COLUMNS"
+      );
+    });
+
+    it("should have redshift config with SVV_COLUMNS", () => {
+      expect(defaultInformationSchemaConfigs.redshift.tablePath).toBe(
+        "SVV_COLUMNS"
+      );
+    });
+
+    it("should have vertica config with v_catalog.columns", () => {
+      expect(defaultInformationSchemaConfigs.vertica.tablePath).toBe(
+        "v_catalog.columns"
+      );
+      expect(defaultInformationSchemaConfigs.vertica.whereClause).toContain(
+        "v_catalog"
+      );
+      expect(defaultInformationSchemaConfigs.vertica.whereClause).toContain(
+        "NOT is_system_table"
+      );
+    });
+
+    it("should have mysql config", () => {
+      expect(defaultInformationSchemaConfigs.mysql.whereClause).toContain(
+        "mysql"
+      );
+      expect(defaultInformationSchemaConfigs.mysql.whereClause).toContain(
+        "performance_schema"
+      );
+    });
+
+    it("should have postgres config", () => {
+      expect(defaultInformationSchemaConfigs.postgres.whereClause).toContain(
+        "pg_catalog"
+      );
+    });
+
+    it("should have snowflake config", () => {
+      expect(defaultInformationSchemaConfigs.snowflake.whereClause).toContain(
+        "INFORMATION_SCHEMA"
+      );
+    });
+
+    it("should have clickhouse config with system.columns", () => {
+      expect(defaultInformationSchemaConfigs.clickhouse.tablePath).toBe(
+        "system.columns"
+      );
+    });
+  });
+
+  describe("Query formatting", () => {
+    it("should produce formatted SQL", () => {
+      const config: InformationSchemaConfig = {
+        tablePath: "information_schema.columns",
+        whereClause: "table_schema NOT IN ('information_schema')",
+        formatDialect: "",
+      };
+
+      const query = generateInformationSchemaQuery(config);
+
+      // Check that query is formatted with proper structure
+      expect(query).toMatch(/SELECT/);
+      expect(query).toMatch(/FROM/);
+      expect(query).toMatch(/WHERE/);
+      expect(query).toMatch(/GROUP BY/);
+    });
+  });
+});

--- a/packages/back-end/test/integrations/sql-builders/time-window/time-window.test.ts
+++ b/packages/back-end/test/integrations/sql-builders/time-window/time-window.test.ts
@@ -1,0 +1,913 @@
+/**
+ * Time Window Utilities Tests
+ *
+ * These tests verify:
+ * 1. The extracted time window utilities work correctly
+ * 2. The extracted utilities produce IDENTICAL results to the original
+ *    SqlIntegration private methods (parity tests)
+ *
+ * Methods tested:
+ * - getMetricMinDelay: Calculate minimum delay for a set of metrics
+ * - getMetricStart: Calculate query start date based on delays
+ * - getMetricEnd: Calculate query end date based on conversion windows
+ * - getMaxHoursToConvert: Calculate max hours needed for conversion
+ * - getExperimentEndDate: Calculate experiment end date with skipPartialData
+ */
+
+import BigQuery from "../../../../src/integrations/BigQuery";
+import { ExperimentMetricInterface } from "shared/experiments";
+import { ExperimentSnapshotSettings } from "shared/types/experiment-snapshot";
+
+// Import the EXTRACTED utilities
+import * as extracted from "../../../../src/integrations/sql-builders/time-window";
+
+// Create BigQuery instance for testing original private methods
+// @ts-expect-error - context not needed for method testing
+const bqInstance = new BigQuery("", {});
+
+// Helper to access private methods from original implementation
+function getPrivateMethod<T>(methodName: string): T {
+  return (bqInstance as unknown as Record<string, T>)[methodName].bind(
+    bqInstance
+  );
+}
+
+// Get references to ORIGINAL private methods (for parity testing)
+const originalGetMetricMinDelay = getPrivateMethod<
+  (metrics: ExperimentMetricInterface[]) => number
+>("getMetricMinDelay");
+
+const originalGetMetricStart = getPrivateMethod<
+  (initial: Date, minDelay: number, regressionAdjustmentHours: number) => Date
+>("getMetricStart");
+
+const originalGetMetricEnd = getPrivateMethod<
+  (
+    metrics: ExperimentMetricInterface[],
+    initial?: Date,
+    overrideConversionWindows?: boolean
+  ) => Date | null
+>("getMetricEnd");
+
+const originalGetMaxHoursToConvert = getPrivateMethod<
+  (
+    funnelMetric: boolean,
+    metricAndDenominatorMetrics: ExperimentMetricInterface[],
+    activationMetric: ExperimentMetricInterface | null
+  ) => number
+>("getMaxHoursToConvert");
+
+const originalGetExperimentEndDate = getPrivateMethod<
+  (settings: ExperimentSnapshotSettings, conversionWindowHours: number) => Date
+>("getExperimentEndDate");
+
+// Use EXTRACTED utilities for all tests (same behavior expected)
+const getMetricMinDelay = extracted.getMetricMinDelay;
+const getMetricStart = extracted.getMetricStart;
+const getMetricEnd = extracted.getMetricEnd;
+const getMaxHoursToConvert = extracted.getMaxHoursToConvert;
+const getExperimentEndDate = extracted.getExperimentEndDate;
+
+// ============================================================
+// Test Fixtures
+// ============================================================
+
+function createMetric(
+  overrides: Partial<ExperimentMetricInterface> = {}
+): ExperimentMetricInterface {
+  return {
+    id: "metric-1",
+    windowSettings: {
+      type: "conversion",
+      windowUnit: "hours",
+      windowValue: 72,
+      delayUnit: "hours",
+      delayValue: 0,
+    },
+    ...overrides,
+  } as ExperimentMetricInterface;
+}
+
+function createSettings(
+  overrides: Partial<ExperimentSnapshotSettings> = {}
+): ExperimentSnapshotSettings {
+  return {
+    startDate: new Date("2023-01-01T00:00:00Z"),
+    endDate: new Date("2023-01-31T00:00:00Z"),
+    skipPartialData: false,
+    experimentId: "exp-1",
+    manual: false,
+    regressionAdjustmentEnabled: false,
+    dimensions: [],
+    statsEngine: "frequentist" as const,
+    pValueThreshold: 0.05,
+    defaultMetricPriorSettings: {
+      override: false,
+      proper: false,
+      mean: 0,
+      stddev: 0.3,
+    },
+    ...overrides,
+  } as ExperimentSnapshotSettings;
+}
+
+// ============================================================
+// Tests for getMetricMinDelay
+// ============================================================
+
+describe("getMetricMinDelay", () => {
+  it("returns 0 for metrics with no delay", () => {
+    const metrics = [
+      createMetric({
+        windowSettings: {
+          type: "conversion",
+          windowUnit: "hours",
+          windowValue: 72,
+          delayUnit: "hours",
+          delayValue: 0,
+        },
+      }),
+    ];
+    expect(getMetricMinDelay(metrics)).toBe(0);
+  });
+
+  it("returns 0 for empty metrics array", () => {
+    expect(getMetricMinDelay([])).toBe(0);
+  });
+
+  it("returns negative delay for lookback metrics", () => {
+    const metrics = [
+      createMetric({
+        windowSettings: {
+          type: "conversion",
+          windowUnit: "hours",
+          windowValue: 72,
+          delayUnit: "hours",
+          delayValue: -24,
+        },
+      }),
+    ];
+    expect(getMetricMinDelay(metrics)).toBe(-24);
+  });
+
+  it("returns minimum (most negative) delay across multiple metrics", () => {
+    const metrics = [
+      createMetric({
+        id: "m1",
+        windowSettings: {
+          type: "conversion",
+          windowUnit: "hours",
+          windowValue: 72,
+          delayUnit: "hours",
+          delayValue: -24,
+        },
+      }),
+      createMetric({
+        id: "m2",
+        windowSettings: {
+          type: "conversion",
+          windowUnit: "hours",
+          windowValue: 48,
+          delayUnit: "hours",
+          delayValue: -48,
+        },
+      }),
+    ];
+    // Running total: -24, then -24 + -48 = -72
+    expect(getMetricMinDelay(metrics)).toBe(-72);
+  });
+
+  it("handles mixed positive and negative delays", () => {
+    const metrics = [
+      createMetric({
+        id: "m1",
+        windowSettings: {
+          type: "conversion",
+          windowUnit: "hours",
+          windowValue: 72,
+          delayUnit: "hours",
+          delayValue: 24, // positive delay
+        },
+      }),
+      createMetric({
+        id: "m2",
+        windowSettings: {
+          type: "conversion",
+          windowUnit: "hours",
+          windowValue: 48,
+          delayUnit: "hours",
+          delayValue: -100, // large negative delay
+        },
+      }),
+    ];
+    // Running: 24, then 24 + -100 = -76
+    expect(getMetricMinDelay(metrics)).toBe(-76);
+  });
+
+  it("ignores metrics with lookback window type", () => {
+    const metrics = [
+      createMetric({
+        windowSettings: {
+          type: "lookback",
+          windowUnit: "days",
+          windowValue: 7,
+          delayUnit: "hours",
+          delayValue: 0,
+        },
+      }),
+    ];
+    // Lookback windows don't use delay in the same way
+    expect(getMetricMinDelay(metrics)).toBe(0);
+  });
+});
+
+// ============================================================
+// Tests for getMetricStart
+// ============================================================
+
+describe("getMetricStart", () => {
+  const baseDate = new Date("2023-01-15T12:00:00Z");
+
+  it("returns initial date when minDelay is 0 and no regression adjustment", () => {
+    const result = getMetricStart(baseDate, 0, 0);
+    expect(result.getTime()).toBe(baseDate.getTime());
+  });
+
+  it("does not modify date for positive delay", () => {
+    const result = getMetricStart(baseDate, 24, 0);
+    // Positive delay doesn't affect start date
+    expect(result.getTime()).toBe(baseDate.getTime());
+  });
+
+  it("subtracts negative delay from start date", () => {
+    const result = getMetricStart(baseDate, -24, 0);
+    const expected = new Date(baseDate);
+    expected.setHours(expected.getHours() - 24);
+    expect(result.getTime()).toBe(expected.getTime());
+  });
+
+  it("subtracts regression adjustment hours", () => {
+    const result = getMetricStart(baseDate, 0, 48);
+    const expected = new Date(baseDate);
+    expected.setHours(expected.getHours() - 48);
+    expect(result.getTime()).toBe(expected.getTime());
+  });
+
+  it("combines negative delay and regression adjustment", () => {
+    const result = getMetricStart(baseDate, -24, 48);
+    const expected = new Date(baseDate);
+    expected.setHours(expected.getHours() - 24 - 48); // Both subtract
+    expect(result.getTime()).toBe(expected.getTime());
+  });
+
+  it("does not mutate the input date", () => {
+    const original = new Date(baseDate);
+    getMetricStart(baseDate, -24, 48);
+    expect(baseDate.getTime()).toBe(original.getTime());
+  });
+});
+
+// ============================================================
+// Tests for getMetricEnd
+// ============================================================
+
+describe("getMetricEnd", () => {
+  const baseDate = new Date("2023-01-31T00:00:00Z");
+
+  it("returns null when initial date is undefined", () => {
+    const metrics = [createMetric()];
+    expect(getMetricEnd(metrics, undefined)).toBeNull();
+  });
+
+  it("returns initial date when overrideConversionWindows is true", () => {
+    const metrics = [
+      createMetric({
+        windowSettings: {
+          type: "conversion",
+          windowUnit: "hours",
+          windowValue: 72,
+          delayUnit: "hours",
+          delayValue: 0,
+        },
+      }),
+    ];
+    const result = getMetricEnd(metrics, baseDate, true);
+    expect(result?.getTime()).toBe(baseDate.getTime());
+  });
+
+  it("extends end date by conversion window hours", () => {
+    const metrics = [
+      createMetric({
+        windowSettings: {
+          type: "conversion",
+          windowUnit: "hours",
+          windowValue: 72, // 72 hours
+          delayUnit: "hours",
+          delayValue: 0,
+        },
+      }),
+    ];
+    const result = getMetricEnd(metrics, baseDate);
+    const expected = new Date(baseDate);
+    expected.setHours(expected.getHours() + 72);
+    expect(result?.getTime()).toBe(expected.getTime());
+  });
+
+  it("includes delay in end date calculation", () => {
+    const metrics = [
+      createMetric({
+        windowSettings: {
+          type: "conversion",
+          windowUnit: "hours",
+          windowValue: 72,
+          delayUnit: "hours",
+          delayValue: 24,
+        },
+      }),
+    ];
+    const result = getMetricEnd(metrics, baseDate);
+    const expected = new Date(baseDate);
+    expected.setHours(expected.getHours() + 72 + 24); // window + delay
+    expect(result?.getTime()).toBe(expected.getTime());
+  });
+
+  it("uses max hours across multiple metrics", () => {
+    const metrics = [
+      createMetric({
+        id: "m1",
+        windowSettings: {
+          type: "conversion",
+          windowUnit: "hours",
+          windowValue: 48,
+          delayUnit: "hours",
+          delayValue: 0,
+        },
+      }),
+      createMetric({
+        id: "m2",
+        windowSettings: {
+          type: "conversion",
+          windowUnit: "hours",
+          windowValue: 72,
+          delayUnit: "hours",
+          delayValue: 24,
+        },
+      }),
+    ];
+    // First: 48, Running: 48
+    // Second: 48 + 72 + 24 = 144, Running: 144
+    const result = getMetricEnd(metrics, baseDate);
+    const expected = new Date(baseDate);
+    expected.setHours(expected.getHours() + 144);
+    expect(result?.getTime()).toBe(expected.getTime());
+  });
+
+  it("ignores non-conversion window types", () => {
+    const metrics = [
+      createMetric({
+        windowSettings: {
+          type: "lookback",
+          windowUnit: "days",
+          windowValue: 7,
+          delayUnit: "hours",
+          delayValue: 0,
+        },
+      }),
+    ];
+    const result = getMetricEnd(metrics, baseDate);
+    // No conversion window, so no extension
+    expect(result?.getTime()).toBe(baseDate.getTime());
+  });
+
+  it("does not mutate the input date", () => {
+    const original = new Date(baseDate);
+    const metrics = [createMetric()];
+    getMetricEnd(metrics, baseDate);
+    expect(baseDate.getTime()).toBe(original.getTime());
+  });
+});
+
+// ============================================================
+// Tests for getMaxHoursToConvert
+// ============================================================
+
+describe("getMaxHoursToConvert", () => {
+  it("returns 0 for metrics with no conversion window", () => {
+    const metrics = [
+      createMetric({
+        windowSettings: {
+          type: "lookback",
+          windowUnit: "days",
+          windowValue: 7,
+          delayUnit: "hours",
+          delayValue: 0,
+        },
+      }),
+    ];
+    expect(getMaxHoursToConvert(false, metrics, null)).toBe(0);
+  });
+
+  it("returns conversion window + delay for single metric", () => {
+    const metrics = [
+      createMetric({
+        windowSettings: {
+          type: "conversion",
+          windowUnit: "hours",
+          windowValue: 72,
+          delayUnit: "hours",
+          delayValue: 24,
+        },
+      }),
+    ];
+    expect(getMaxHoursToConvert(false, metrics, null)).toBe(96);
+  });
+
+  it("takes max for non-funnel metrics", () => {
+    const metrics = [
+      createMetric({
+        id: "m1",
+        windowSettings: {
+          type: "conversion",
+          windowUnit: "hours",
+          windowValue: 48,
+          delayUnit: "hours",
+          delayValue: 0,
+        },
+      }),
+      createMetric({
+        id: "m2",
+        windowSettings: {
+          type: "conversion",
+          windowUnit: "hours",
+          windowValue: 72,
+          delayUnit: "hours",
+          delayValue: 24,
+        },
+      }),
+    ];
+    // Non-funnel: max of (48+0, 72+24) = max(48, 96) = 96
+    expect(getMaxHoursToConvert(false, metrics, null)).toBe(96);
+  });
+
+  it("sums windows for funnel metrics", () => {
+    const metrics = [
+      createMetric({
+        id: "m1",
+        windowSettings: {
+          type: "conversion",
+          windowUnit: "hours",
+          windowValue: 48,
+          delayUnit: "hours",
+          delayValue: 0,
+        },
+      }),
+      createMetric({
+        id: "m2",
+        windowSettings: {
+          type: "conversion",
+          windowUnit: "hours",
+          windowValue: 72,
+          delayUnit: "hours",
+          delayValue: 24,
+        },
+      }),
+    ];
+    // Funnel: sum of (48+0) + (72+24) = 48 + 96 = 144
+    expect(getMaxHoursToConvert(true, metrics, null)).toBe(144);
+  });
+
+  it("adds activation metric window", () => {
+    const metrics = [
+      createMetric({
+        windowSettings: {
+          type: "conversion",
+          windowUnit: "hours",
+          windowValue: 48,
+          delayUnit: "hours",
+          delayValue: 0,
+        },
+      }),
+    ];
+    const activation = createMetric({
+      id: "activation",
+      windowSettings: {
+        type: "conversion",
+        windowUnit: "hours",
+        windowValue: 24,
+        delayUnit: "hours",
+        delayValue: 12,
+      },
+    });
+    // Metric: 48, Activation: 24+12=36, Total: 48+36=84
+    expect(getMaxHoursToConvert(false, metrics, activation)).toBe(84);
+  });
+
+  it("ignores activation metric with non-conversion window", () => {
+    const metrics = [
+      createMetric({
+        windowSettings: {
+          type: "conversion",
+          windowUnit: "hours",
+          windowValue: 48,
+          delayUnit: "hours",
+          delayValue: 0,
+        },
+      }),
+    ];
+    const activation = createMetric({
+      id: "activation",
+      windowSettings: {
+        type: "lookback",
+        windowUnit: "days",
+        windowValue: 7,
+        delayUnit: "hours",
+        delayValue: 0,
+      },
+    });
+    expect(getMaxHoursToConvert(false, metrics, activation)).toBe(48);
+  });
+});
+
+// ============================================================
+// Tests for getExperimentEndDate
+// ============================================================
+
+describe("getExperimentEndDate", () => {
+  // Mock the Date constructor to control "now"
+  const RealDate = global.Date;
+  const mockNow = new RealDate("2023-02-15T00:00:00Z").getTime();
+
+  beforeAll(() => {
+    // Override Date to use a fixed "now" for new Date() calls
+    global.Date = class extends RealDate {
+      constructor(...args: ConstructorParameters<typeof RealDate>) {
+        if (args.length === 0) {
+          super(mockNow);
+        } else {
+          // @ts-expect-error - spread args to parent constructor
+          super(...args);
+        }
+      }
+
+      static now() {
+        return mockNow;
+      }
+    } as typeof Date;
+  });
+
+  afterAll(() => {
+    global.Date = RealDate;
+  });
+
+  it("returns endDate when skipPartialData is false", () => {
+    const settings = createSettings({
+      endDate: new RealDate("2023-01-31T00:00:00Z"),
+      skipPartialData: false,
+    });
+    const result = getExperimentEndDate(settings, 72);
+    expect(result.getTime()).toBe(settings.endDate.getTime());
+  });
+
+  it("returns endDate when skipPartialData is true but endDate is before conversion window", () => {
+    const settings = createSettings({
+      endDate: new RealDate("2023-01-15T00:00:00Z"), // Well before "now"
+      skipPartialData: true,
+    });
+    // Now is 2023-02-15, conversion window is 72 hours
+    // Conversion window end would be 2023-02-12
+    // endDate (Jan 15) is before that, so use endDate
+    const result = getExperimentEndDate(settings, 72);
+    expect(result.getTime()).toBe(settings.endDate.getTime());
+  });
+
+  it("returns conversion window end date when it's before endDate", () => {
+    const settings = createSettings({
+      endDate: new RealDate("2023-03-01T00:00:00Z"), // After "now"
+      skipPartialData: true,
+    });
+    // Now is 2023-02-15T00:00:00Z, conversion window is 72 hours
+    // Conversion window end = 2023-02-15 - 72 hours = 2023-02-12T00:00:00Z
+    const result = getExperimentEndDate(settings, 72);
+    const expected = new RealDate(mockNow - 72 * 60 * 60 * 1000);
+    expect(result.getTime()).toBe(expected.getTime());
+  });
+
+  it("handles 0 conversion window hours", () => {
+    const settings = createSettings({
+      endDate: new RealDate("2023-03-01T00:00:00Z"),
+      skipPartialData: true,
+    });
+    // With 0 conversion window, uses "now" as the end date
+    const result = getExperimentEndDate(settings, 0);
+    // Should be min of (endDate, now) = now since endDate is in future
+    expect(result.getTime()).toBe(mockNow);
+  });
+
+  it("handles large conversion window", () => {
+    const settings = createSettings({
+      endDate: new RealDate("2023-03-01T00:00:00Z"),
+      skipPartialData: true,
+    });
+    // 30 days = 720 hours
+    const result = getExperimentEndDate(settings, 720);
+    const expected = new RealDate(mockNow - 720 * 60 * 60 * 1000);
+    expect(result.getTime()).toBe(expected.getTime());
+  });
+});
+
+// ============================================================
+// Integration-style tests
+// ============================================================
+
+describe("Time Window Integration", () => {
+  it("calculates consistent windows for a typical experiment", () => {
+    const startDate = new Date("2023-01-01T00:00:00Z");
+    const endDate = new Date("2023-01-31T00:00:00Z");
+
+    const metric = createMetric({
+      windowSettings: {
+        type: "conversion",
+        windowUnit: "hours",
+        windowValue: 72,
+        delayUnit: "hours",
+        delayValue: 0,
+      },
+    });
+
+    const minDelay = getMetricMinDelay([metric]);
+    const metricStart = getMetricStart(startDate, minDelay, 0);
+    const metricEnd = getMetricEnd([metric], endDate);
+    const maxHours = getMaxHoursToConvert(false, [metric], null);
+
+    expect(minDelay).toBe(0);
+    expect(metricStart.getTime()).toBe(startDate.getTime());
+    expect(metricEnd?.getTime()).toBe(
+      new Date("2023-02-03T00:00:00Z").getTime() // +72 hours
+    );
+    expect(maxHours).toBe(72);
+  });
+
+  it("handles complex metric with lookback delay", () => {
+    const startDate = new Date("2023-01-15T00:00:00Z");
+    const endDate = new Date("2023-01-31T00:00:00Z");
+
+    const metric = createMetric({
+      windowSettings: {
+        type: "conversion",
+        windowUnit: "hours",
+        windowValue: 48,
+        delayUnit: "hours",
+        delayValue: -24, // Lookback 24 hours before exposure
+      },
+    });
+
+    const minDelay = getMetricMinDelay([metric]);
+    const metricStart = getMetricStart(startDate, minDelay, 0);
+    const metricEnd = getMetricEnd([metric], endDate);
+
+    expect(minDelay).toBe(-24);
+    // Start date moves back by 24 hours
+    expect(metricStart.getTime()).toBe(
+      new Date("2023-01-14T00:00:00Z").getTime()
+    );
+    // End date extends by window + delay (48 + (-24) = 24 hours)
+    expect(metricEnd?.getTime()).toBe(
+      new Date("2023-01-31T00:00:00Z").getTime() + 24 * 60 * 60 * 1000
+    );
+  });
+});
+
+// ============================================================
+// PARITY TESTS: Verify extracted code matches original
+// ============================================================
+
+describe("Parity Tests: Extracted vs Original", () => {
+  describe("getMetricMinDelay parity", () => {
+    const testCases = [
+      { name: "empty array", metrics: [] },
+      {
+        name: "single metric no delay",
+        metrics: [
+          createMetric({
+            windowSettings: {
+              type: "conversion",
+              windowUnit: "hours",
+              windowValue: 72,
+              delayUnit: "hours",
+              delayValue: 0,
+            },
+          }),
+        ],
+      },
+      {
+        name: "single metric with negative delay",
+        metrics: [
+          createMetric({
+            windowSettings: {
+              type: "conversion",
+              windowUnit: "hours",
+              windowValue: 72,
+              delayUnit: "hours",
+              delayValue: -24,
+            },
+          }),
+        ],
+      },
+      {
+        name: "multiple metrics cascading delays",
+        metrics: [
+          createMetric({
+            id: "m1",
+            windowSettings: {
+              type: "conversion",
+              windowUnit: "hours",
+              windowValue: 48,
+              delayUnit: "hours",
+              delayValue: -24,
+            },
+          }),
+          createMetric({
+            id: "m2",
+            windowSettings: {
+              type: "conversion",
+              windowUnit: "hours",
+              windowValue: 72,
+              delayUnit: "hours",
+              delayValue: -48,
+            },
+          }),
+        ],
+      },
+    ];
+
+    testCases.forEach(({ name, metrics }) => {
+      it(`matches original for ${name}`, () => {
+        expect(extracted.getMetricMinDelay(metrics)).toBe(
+          originalGetMetricMinDelay(metrics)
+        );
+      });
+    });
+  });
+
+  describe("getMetricStart parity", () => {
+    const baseDate = new Date("2023-01-15T12:00:00Z");
+    const testCases = [
+      { name: "no adjustments", minDelay: 0, regression: 0 },
+      { name: "negative delay", minDelay: -24, regression: 0 },
+      { name: "regression adjustment", minDelay: 0, regression: 48 },
+      { name: "both adjustments", minDelay: -24, regression: 48 },
+      { name: "positive delay (ignored)", minDelay: 24, regression: 0 },
+    ];
+
+    testCases.forEach(({ name, minDelay, regression }) => {
+      it(`matches original for ${name}`, () => {
+        expect(
+          extracted.getMetricStart(baseDate, minDelay, regression).getTime()
+        ).toBe(originalGetMetricStart(baseDate, minDelay, regression).getTime());
+      });
+    });
+  });
+
+  describe("getMetricEnd parity", () => {
+    const baseDate = new Date("2023-01-31T00:00:00Z");
+
+    it("matches original for undefined initial", () => {
+      const metrics = [createMetric()];
+      expect(extracted.getMetricEnd(metrics, undefined)).toBe(
+        originalGetMetricEnd(metrics, undefined)
+      );
+    });
+
+    it("matches original for override=true", () => {
+      const metrics = [createMetric()];
+      expect(extracted.getMetricEnd(metrics, baseDate, true)?.getTime()).toBe(
+        originalGetMetricEnd(metrics, baseDate, true)?.getTime()
+      );
+    });
+
+    const metricCases = [
+      {
+        name: "single conversion metric",
+        metrics: [
+          createMetric({
+            windowSettings: {
+              type: "conversion",
+              windowUnit: "hours",
+              windowValue: 72,
+              delayUnit: "hours",
+              delayValue: 0,
+            },
+          }),
+        ],
+      },
+      {
+        name: "metric with delay",
+        metrics: [
+          createMetric({
+            windowSettings: {
+              type: "conversion",
+              windowUnit: "hours",
+              windowValue: 72,
+              delayUnit: "hours",
+              delayValue: 24,
+            },
+          }),
+        ],
+      },
+      {
+        name: "lookback metric",
+        metrics: [
+          createMetric({
+            windowSettings: {
+              type: "lookback",
+              windowUnit: "days",
+              windowValue: 7,
+              delayUnit: "hours",
+              delayValue: 0,
+            },
+          }),
+        ],
+      },
+    ];
+
+    metricCases.forEach(({ name, metrics }) => {
+      it(`matches original for ${name}`, () => {
+        expect(extracted.getMetricEnd(metrics, baseDate)?.getTime()).toBe(
+          originalGetMetricEnd(metrics, baseDate)?.getTime()
+        );
+      });
+    });
+  });
+
+  describe("getMaxHoursToConvert parity", () => {
+    const metric72h = createMetric({
+      windowSettings: {
+        type: "conversion",
+        windowUnit: "hours",
+        windowValue: 72,
+        delayUnit: "hours",
+        delayValue: 24,
+      },
+    });
+
+    const metric48h = createMetric({
+      id: "m2",
+      windowSettings: {
+        type: "conversion",
+        windowUnit: "hours",
+        windowValue: 48,
+        delayUnit: "hours",
+        delayValue: 0,
+      },
+    });
+
+    const activation = createMetric({
+      id: "activation",
+      windowSettings: {
+        type: "conversion",
+        windowUnit: "hours",
+        windowValue: 24,
+        delayUnit: "hours",
+        delayValue: 12,
+      },
+    });
+
+    const testCases = [
+      { name: "single metric, no funnel", funnel: false, metrics: [metric72h], activation: null },
+      { name: "single metric, funnel", funnel: true, metrics: [metric72h], activation: null },
+      { name: "multiple metrics, no funnel", funnel: false, metrics: [metric48h, metric72h], activation: null },
+      { name: "multiple metrics, funnel", funnel: true, metrics: [metric48h, metric72h], activation: null },
+      { name: "with activation", funnel: false, metrics: [metric48h], activation },
+    ];
+
+    testCases.forEach(({ name, funnel, metrics, activation: act }) => {
+      it(`matches original for ${name}`, () => {
+        expect(extracted.getMaxHoursToConvert(funnel, metrics, act)).toBe(
+          originalGetMaxHoursToConvert(funnel, metrics, act)
+        );
+      });
+    });
+  });
+
+  describe("getExperimentEndDate parity", () => {
+    it("matches original when skipPartialData=false", () => {
+      const settings = createSettings({
+        endDate: new Date("2023-01-31T00:00:00Z"),
+        skipPartialData: false,
+      });
+      expect(extracted.getExperimentEndDate(settings, 72).getTime()).toBe(
+        originalGetExperimentEndDate(settings, 72).getTime()
+      );
+    });
+
+    it("matches original when endDate is before conversion window", () => {
+      const settings = createSettings({
+        endDate: new Date("2023-01-15T00:00:00Z"),
+        skipPartialData: true,
+      });
+      expect(extracted.getExperimentEndDate(settings, 72).getTime()).toBe(
+        originalGetExperimentEndDate(settings, 72).getTime()
+      );
+    });
+  });
+});

--- a/packages/back-end/test/integrations/sql-dialects/athena-dialect.test.ts
+++ b/packages/back-end/test/integrations/sql-dialects/athena-dialect.test.ts
@@ -1,0 +1,193 @@
+import {
+  athenaDialect,
+  hasHllSupport,
+  hasQuantileSupport,
+} from "../../../src/integrations/sql-dialects";
+
+describe("Athena Dialect", () => {
+  describe("formatDialect", () => {
+    it("returns trino", () => {
+      expect(athenaDialect.formatDialect).toBe("trino");
+    });
+  });
+
+  describe("toTimestamp", () => {
+    it("formats date using from_iso8601_timestamp", () => {
+      const date = new Date("2023-01-15T12:30:45.123Z");
+      expect(athenaDialect.toTimestamp(date)).toBe(
+        "from_iso8601_timestamp('2023-01-15T12:30:45.123Z')"
+      );
+    });
+
+    it("handles midnight correctly", () => {
+      const date = new Date("2023-01-01T00:00:00.000Z");
+      expect(athenaDialect.toTimestamp(date)).toBe(
+        "from_iso8601_timestamp('2023-01-01T00:00:00.000Z')"
+      );
+    });
+  });
+
+  describe("addHours", () => {
+    it("returns column unchanged when hours is 0", () => {
+      expect(athenaDialect.addHours("timestamp", 0)).toBe("timestamp");
+    });
+
+    it("adds positive hours using INTERVAL syntax without s", () => {
+      expect(athenaDialect.addHours("timestamp", 24)).toBe(
+        "timestamp + INTERVAL '24' hour"
+      );
+    });
+
+    it("subtracts negative hours", () => {
+      expect(athenaDialect.addHours("timestamp", -12)).toBe(
+        "timestamp - INTERVAL '12' hour"
+      );
+    });
+
+    it("uses minutes for fractional hours", () => {
+      expect(athenaDialect.addHours("timestamp", 1.5)).toBe(
+        "timestamp + INTERVAL '90' minute"
+      );
+    });
+  });
+
+  describe("addTime", () => {
+    it("adds hours with INTERVAL syntax (no s on unit)", () => {
+      expect(athenaDialect.addTime("col", "hour", "+", 5)).toBe(
+        "col + INTERVAL '5' hour"
+      );
+    });
+
+    it("subtracts minutes with INTERVAL syntax", () => {
+      expect(athenaDialect.addTime("col", "minute", "-", 30)).toBe(
+        "col - INTERVAL '30' minute"
+      );
+    });
+  });
+
+  describe("dateTrunc", () => {
+    it("truncates to day using date_trunc (inherited from base)", () => {
+      expect(athenaDialect.dateTrunc("timestamp")).toBe(
+        "date_trunc('day', timestamp)"
+      );
+    });
+  });
+
+  describe("dateDiff", () => {
+    it("uses date_diff function with day unit", () => {
+      expect(athenaDialect.dateDiff("start_date", "end_date")).toBe(
+        "date_diff('day', start_date, end_date)"
+      );
+    });
+  });
+
+  describe("formatDate", () => {
+    it("formats date using to_iso8601 and substr", () => {
+      expect(athenaDialect.formatDate("date_col")).toBe(
+        "substr(to_iso8601(date_col),1,10)"
+      );
+    });
+  });
+
+  describe("formatDateTimeString", () => {
+    it("formats datetime using to_iso8601", () => {
+      expect(athenaDialect.formatDateTimeString("datetime_col")).toBe(
+        "to_iso8601(datetime_col)"
+      );
+    });
+  });
+
+  describe("ensureFloat", () => {
+    it("casts to double", () => {
+      expect(athenaDialect.ensureFloat("int_col")).toBe(
+        "CAST(int_col AS double)"
+      );
+    });
+  });
+
+  describe("escapeStringLiteral", () => {
+    it("escapes single quotes by doubling (inherited from base)", () => {
+      expect(athenaDialect.escapeStringLiteral("it's")).toBe("it''s");
+    });
+  });
+
+  describe("selectStarLimit", () => {
+    it("generates SELECT with LIMIT", () => {
+      expect(athenaDialect.selectStarLimit("users", 10)).toBe(
+        "SELECT * FROM users LIMIT 10"
+      );
+    });
+  });
+
+  describe("extractJSONField", () => {
+    it("extracts field using json_extract_scalar (inherited from base)", () => {
+      expect(
+        athenaDialect.extractJSONField("json_col", "user.name", false)
+      ).toBe("json_extract_scalar(json_col, '$.user.name')");
+    });
+
+    it("extracts numeric field with ensureFloat", () => {
+      expect(
+        athenaDialect.extractJSONField("json_col", "user.age", true)
+      ).toBe("CAST(json_extract_scalar(json_col, '$.user.age') AS double)");
+    });
+  });
+
+  describe("HLL functions", () => {
+    it("supports HLL", () => {
+      expect(athenaDialect.hasCountDistinctHLL()).toBe(true);
+    });
+
+    it("aggregates with APPROX_SET", () => {
+      expect(athenaDialect.hllAggregate("user_id")).toBe("APPROX_SET(user_id)");
+    });
+
+    it("reaggregates with MERGE", () => {
+      expect(athenaDialect.hllReaggregate("hll_col")).toBe("MERGE(hll_col)");
+    });
+
+    it("extracts cardinality with CARDINALITY", () => {
+      expect(athenaDialect.hllCardinality("hll_col")).toBe(
+        "CARDINALITY(hll_col)"
+      );
+    });
+
+    it("casts to HLL data type (HyperLogLog)", () => {
+      expect(athenaDialect.castToHllDataType("col")).toBe(
+        "CAST(col AS HyperLogLog)"
+      );
+    });
+  });
+
+  describe("Quantile functions", () => {
+    it("has efficient percentile", () => {
+      expect(athenaDialect.hasEfficientPercentile()).toBe(true);
+    });
+
+    it("has quantile testing", () => {
+      expect(athenaDialect.hasQuantileTesting()).toBe(true);
+    });
+
+    it("generates APPROX_PERCENTILE for numeric quantile", () => {
+      expect(athenaDialect.approxQuantile("value", 0.5)).toBe(
+        "APPROX_PERCENTILE(value, 0.5)"
+      );
+    });
+
+    it("generates APPROX_PERCENTILE for string quantile expression", () => {
+      expect(athenaDialect.approxQuantile("value", "q")).toBe(
+        "APPROX_PERCENTILE(value, q)"
+      );
+    });
+  });
+
+  describe("Type guards", () => {
+    it("hasHllSupport returns true for Athena", () => {
+      expect(hasHllSupport(athenaDialect)).toBe(true);
+    });
+
+    it("hasQuantileSupport returns true for Athena", () => {
+      expect(hasQuantileSupport(athenaDialect)).toBe(true);
+    });
+  });
+});

--- a/packages/back-end/test/integrations/sql-dialects/bigquery-dialect.test.ts
+++ b/packages/back-end/test/integrations/sql-dialects/bigquery-dialect.test.ts
@@ -1,0 +1,356 @@
+import {
+  bigQueryDialect,
+  baseDialect,
+  hasHllSupport,
+  hasQuantileSupport,
+} from "../../../src/integrations/sql-dialects";
+
+describe("BigQuery Dialect", () => {
+  describe("formatDialect", () => {
+    it("returns bigquery", () => {
+      expect(bigQueryDialect.formatDialect).toBe("bigquery");
+    });
+  });
+
+  describe("toTimestamp", () => {
+    it("formats date without milliseconds", () => {
+      const date = new Date("2023-01-15T12:30:45.123Z");
+      expect(bigQueryDialect.toTimestamp(date)).toBe("'2023-01-15 12:30:45'");
+    });
+
+    it("handles midnight correctly", () => {
+      const date = new Date("2023-01-01T00:00:00Z");
+      expect(bigQueryDialect.toTimestamp(date)).toBe("'2023-01-01 00:00:00'");
+    });
+  });
+
+  describe("toTimestampWithMs", () => {
+    it("formats date with milliseconds", () => {
+      const date = new Date("2023-01-15T12:30:45.123Z");
+      expect(bigQueryDialect.toTimestampWithMs(date)).toBe(
+        "'2023-01-15 12:30:45.123'"
+      );
+    });
+  });
+
+  describe("addHours", () => {
+    it("returns column unchanged when hours is 0", () => {
+      expect(bigQueryDialect.addHours("timestamp", 0)).toBe("timestamp");
+    });
+
+    it("adds positive hours using DATETIME_ADD", () => {
+      expect(bigQueryDialect.addHours("timestamp", 24)).toBe(
+        "DATETIME_ADD(timestamp, INTERVAL 24 HOUR)"
+      );
+    });
+
+    it("subtracts negative hours using DATETIME_SUB", () => {
+      expect(bigQueryDialect.addHours("timestamp", -12)).toBe(
+        "DATETIME_SUB(timestamp, INTERVAL 12 HOUR)"
+      );
+    });
+
+    it("uses minutes for fractional hours", () => {
+      expect(bigQueryDialect.addHours("timestamp", 1.5)).toBe(
+        "DATETIME_ADD(timestamp, INTERVAL 90 MINUTE)"
+      );
+    });
+  });
+
+  describe("addTime", () => {
+    it("adds hours with DATETIME_ADD", () => {
+      expect(bigQueryDialect.addTime("col", "hour", "+", 5)).toBe(
+        "DATETIME_ADD(col, INTERVAL 5 HOUR)"
+      );
+    });
+
+    it("subtracts minutes with DATETIME_SUB", () => {
+      expect(bigQueryDialect.addTime("col", "minute", "-", 30)).toBe(
+        "DATETIME_SUB(col, INTERVAL 30 MINUTE)"
+      );
+    });
+  });
+
+  describe("dateTrunc", () => {
+    it("truncates to day", () => {
+      expect(bigQueryDialect.dateTrunc("timestamp")).toBe(
+        "date_trunc(timestamp, DAY)"
+      );
+    });
+  });
+
+  describe("dateDiff", () => {
+    it("calculates difference in days", () => {
+      expect(bigQueryDialect.dateDiff("start_date", "end_date")).toBe(
+        "date_diff(end_date, start_date, DAY)"
+      );
+    });
+  });
+
+  describe("formatDate", () => {
+    it("formats date with %F", () => {
+      expect(bigQueryDialect.formatDate("date_col")).toBe(
+        'format_date("%F", date_col)'
+      );
+    });
+  });
+
+  describe("formatDateTimeString", () => {
+    it("formats datetime with %F %T", () => {
+      expect(bigQueryDialect.formatDateTimeString("datetime_col")).toBe(
+        'format_datetime("%F %T", datetime_col)'
+      );
+    });
+  });
+
+  describe("castToString", () => {
+    it("casts to string type", () => {
+      expect(bigQueryDialect.castToString("numeric_col")).toBe(
+        "cast(numeric_col as string)"
+      );
+    });
+  });
+
+  describe("castUserDateCol", () => {
+    it("casts to DATETIME", () => {
+      expect(bigQueryDialect.castUserDateCol("user_date")).toBe(
+        "CAST(user_date as DATETIME)"
+      );
+    });
+  });
+
+  describe("escapeStringLiteral", () => {
+    it("escapes single quotes with backslash", () => {
+      expect(bigQueryDialect.escapeStringLiteral("it's")).toBe("it\\'s");
+    });
+
+    it("escapes backslashes", () => {
+      expect(bigQueryDialect.escapeStringLiteral("path\\to\\file")).toBe(
+        "path\\\\to\\\\file"
+      );
+    });
+
+    it("handles strings without special characters", () => {
+      expect(bigQueryDialect.escapeStringLiteral("hello world")).toBe(
+        "hello world"
+      );
+    });
+  });
+
+  describe("ifElse", () => {
+    it("generates CASE WHEN expression", () => {
+      expect(bigQueryDialect.ifElse("x > 0", "1", "0")).toBe(
+        "(CASE WHEN x > 0 THEN 1 ELSE 0 END)"
+      );
+    });
+  });
+
+  describe("evalBoolean", () => {
+    it("evaluates true", () => {
+      expect(bigQueryDialect.evalBoolean("active", true)).toBe("active IS TRUE");
+    });
+
+    it("evaluates false", () => {
+      expect(bigQueryDialect.evalBoolean("active", false)).toBe(
+        "active IS FALSE"
+      );
+    });
+  });
+
+  describe("selectStarLimit", () => {
+    it("generates SELECT with LIMIT", () => {
+      expect(bigQueryDialect.selectStarLimit("users", 10)).toBe(
+        "SELECT * FROM users LIMIT 10"
+      );
+    });
+  });
+
+  describe("extractJSONField", () => {
+    it("extracts string field with JSON_VALUE", () => {
+      expect(bigQueryDialect.extractJSONField("json_col", "user.name", false)).toBe(
+        "JSON_VALUE(json_col, '$.user.name')"
+      );
+    });
+
+    it("extracts numeric field with CAST to FLOAT64", () => {
+      expect(bigQueryDialect.extractJSONField("json_col", "user.age", true)).toBe(
+        "CAST(JSON_VALUE(json_col, '$.user.age') AS FLOAT64)"
+      );
+    });
+  });
+
+  describe("getDataType", () => {
+    it("maps string to STRING", () => {
+      expect(bigQueryDialect.getDataType("string")).toBe("STRING");
+    });
+
+    it("maps integer to INT64", () => {
+      expect(bigQueryDialect.getDataType("integer")).toBe("INT64");
+    });
+
+    it("maps float to FLOAT64", () => {
+      expect(bigQueryDialect.getDataType("float")).toBe("FLOAT64");
+    });
+
+    it("maps boolean to BOOL", () => {
+      expect(bigQueryDialect.getDataType("boolean")).toBe("BOOL");
+    });
+
+    it("maps date to DATE", () => {
+      expect(bigQueryDialect.getDataType("date")).toBe("DATE");
+    });
+
+    it("maps timestamp to TIMESTAMP", () => {
+      expect(bigQueryDialect.getDataType("timestamp")).toBe("TIMESTAMP");
+    });
+
+    it("maps hll to BYTES", () => {
+      expect(bigQueryDialect.getDataType("hll")).toBe("BYTES");
+    });
+  });
+
+  describe("HLL functions", () => {
+    it("supports HLL", () => {
+      expect(bigQueryDialect.hasCountDistinctHLL()).toBe(true);
+    });
+
+    it("aggregates with HLL_COUNT.INIT", () => {
+      expect(bigQueryDialect.hllAggregate("user_id")).toBe(
+        "HLL_COUNT.INIT(user_id)"
+      );
+    });
+
+    it("reaggregates with HLL_COUNT.MERGE_PARTIAL", () => {
+      expect(bigQueryDialect.hllReaggregate("hll_col")).toBe(
+        "HLL_COUNT.MERGE_PARTIAL(hll_col)"
+      );
+    });
+
+    it("extracts cardinality with HLL_COUNT.EXTRACT", () => {
+      expect(bigQueryDialect.hllCardinality("hll_col")).toBe(
+        "HLL_COUNT.EXTRACT(hll_col)"
+      );
+    });
+
+    it("casts to HLL data type (BYTES)", () => {
+      expect(bigQueryDialect.castToHllDataType("col")).toBe("CAST(col AS BYTES)");
+    });
+  });
+
+  describe("Quantile functions", () => {
+    it("has efficient percentile", () => {
+      expect(bigQueryDialect.hasEfficientPercentile()).toBe(true);
+    });
+
+    it("has quantile testing", () => {
+      expect(bigQueryDialect.hasQuantileTesting()).toBe(true);
+    });
+
+    it("generates APPROX_QUANTILES for numeric quantile", () => {
+      expect(bigQueryDialect.approxQuantile("value", 0.5)).toBe(
+        "APPROX_QUANTILES(value, 10000 IGNORE NULLS)[OFFSET(CAST(5000 AS INT64))]"
+      );
+    });
+
+    it("generates APPROX_QUANTILES for string quantile expression", () => {
+      expect(bigQueryDialect.approxQuantile("value", "q")).toBe(
+        "APPROX_QUANTILES(value, 10000 IGNORE NULLS)[OFFSET(CAST(10000 * q AS INT64))]"
+      );
+    });
+
+    it("handles edge quantile values", () => {
+      // Note: 0 is falsy in JS, so it uses the string path (still valid SQL)
+      expect(bigQueryDialect.approxQuantile("value", 0)).toBe(
+        "APPROX_QUANTILES(value, 10000 IGNORE NULLS)[OFFSET(CAST(10000 * 0 AS INT64))]"
+      );
+      expect(bigQueryDialect.approxQuantile("value", 1)).toBe(
+        "APPROX_QUANTILES(value, 10000 IGNORE NULLS)[OFFSET(CAST(10000 AS INT64))]"
+      );
+    });
+  });
+
+  describe("Type guards", () => {
+    it("hasHllSupport returns true for BigQuery", () => {
+      expect(hasHllSupport(bigQueryDialect)).toBe(true);
+    });
+
+    it("hasHllSupport returns false for base dialect", () => {
+      expect(hasHllSupport(baseDialect)).toBe(false);
+    });
+
+    it("hasQuantileSupport returns true for BigQuery", () => {
+      expect(hasQuantileSupport(bigQueryDialect)).toBe(true);
+    });
+
+    it("hasQuantileSupport returns false for base dialect", () => {
+      expect(hasQuantileSupport(baseDialect)).toBe(false);
+    });
+  });
+});
+
+describe("Base Dialect", () => {
+  describe("formatDialect", () => {
+    it("returns empty string", () => {
+      expect(baseDialect.formatDialect).toBe("");
+    });
+  });
+
+  describe("toTimestamp", () => {
+    it("formats date in ISO-like format", () => {
+      const date = new Date("2023-01-15T12:30:45.123Z");
+      expect(baseDialect.toTimestamp(date)).toBe("'2023-01-15 12:30:45'");
+    });
+  });
+
+  describe("addTime", () => {
+    it("uses INTERVAL syntax", () => {
+      expect(baseDialect.addTime("col", "hour", "+", 5)).toBe(
+        "col + INTERVAL '5 hours'"
+      );
+    });
+
+    it("uses negative INTERVAL for subtraction", () => {
+      expect(baseDialect.addTime("col", "minute", "-", 30)).toBe(
+        "col - INTERVAL '30 minutes'"
+      );
+    });
+  });
+
+  describe("dateTrunc", () => {
+    it("uses date_trunc function", () => {
+      expect(baseDialect.dateTrunc("timestamp")).toBe(
+        "date_trunc('day', timestamp)"
+      );
+    });
+  });
+
+  describe("dateDiff", () => {
+    it("uses datediff function", () => {
+      expect(baseDialect.dateDiff("start", "end")).toBe(
+        "datediff(day, start, end)"
+      );
+    });
+  });
+
+  describe("castToString", () => {
+    it("casts to varchar", () => {
+      expect(baseDialect.castToString("col")).toBe("cast(col as varchar)");
+    });
+  });
+
+  describe("escapeStringLiteral", () => {
+    it("escapes single quotes by doubling", () => {
+      expect(baseDialect.escapeStringLiteral("it's")).toBe("it''s");
+    });
+  });
+
+  describe("getDataType", () => {
+    it("maps string to VARCHAR", () => {
+      expect(baseDialect.getDataType("string")).toBe("VARCHAR");
+    });
+
+    it("maps float to FLOAT", () => {
+      expect(baseDialect.getDataType("float")).toBe("FLOAT");
+    });
+  });
+});

--- a/packages/back-end/test/integrations/sql-dialects/clickhouse-dialect.test.ts
+++ b/packages/back-end/test/integrations/sql-dialects/clickhouse-dialect.test.ts
@@ -1,0 +1,235 @@
+import {
+  clickhouseDialect,
+  hasHllSupport,
+  hasQuantileSupport,
+} from "../../../src/integrations/sql-dialects";
+
+describe("ClickHouse Dialect", () => {
+  describe("formatDialect", () => {
+    it("returns empty string (no dedicated formatter)", () => {
+      expect(clickhouseDialect.formatDialect).toBe("");
+    });
+  });
+
+  describe("toTimestamp", () => {
+    it("formats date using toDateTime with UTC", () => {
+      const date = new Date("2023-01-15T12:30:45.123Z");
+      expect(clickhouseDialect.toTimestamp(date)).toBe(
+        "toDateTime('2023-01-15 12:30:45', 'UTC')"
+      );
+    });
+
+    it("handles midnight correctly", () => {
+      const date = new Date("2023-01-01T00:00:00.000Z");
+      expect(clickhouseDialect.toTimestamp(date)).toBe(
+        "toDateTime('2023-01-01 00:00:00', 'UTC')"
+      );
+    });
+  });
+
+  describe("addHours", () => {
+    it("returns column unchanged when hours is 0", () => {
+      expect(clickhouseDialect.addHours("timestamp", 0)).toBe("timestamp");
+    });
+
+    it("adds positive hours using dateAdd", () => {
+      expect(clickhouseDialect.addHours("timestamp", 24)).toBe(
+        "dateAdd(hour, 24, timestamp)"
+      );
+    });
+
+    it("subtracts negative hours using dateSub", () => {
+      expect(clickhouseDialect.addHours("timestamp", -12)).toBe(
+        "dateSub(hour, 12, timestamp)"
+      );
+    });
+
+    it("uses minutes for fractional hours", () => {
+      expect(clickhouseDialect.addHours("timestamp", 1.5)).toBe(
+        "dateAdd(minute, 90, timestamp)"
+      );
+    });
+  });
+
+  describe("addTime", () => {
+    it("adds hours with dateAdd", () => {
+      expect(clickhouseDialect.addTime("col", "hour", "+", 5)).toBe(
+        "dateAdd(hour, 5, col)"
+      );
+    });
+
+    it("subtracts minutes with dateSub", () => {
+      expect(clickhouseDialect.addTime("col", "minute", "-", 30)).toBe(
+        "dateSub(minute, 30, col)"
+      );
+    });
+  });
+
+  describe("dateTrunc", () => {
+    it("truncates to day using dateTrunc (lowercase)", () => {
+      expect(clickhouseDialect.dateTrunc("timestamp")).toBe(
+        "dateTrunc('day', timestamp)"
+      );
+    });
+  });
+
+  describe("dateDiff", () => {
+    it("uses dateDiff function with day unit", () => {
+      expect(clickhouseDialect.dateDiff("start_date", "end_date")).toBe(
+        "dateDiff('day', start_date, end_date)"
+      );
+    });
+  });
+
+  describe("formatDate", () => {
+    it("formats date using formatDateTime with %F", () => {
+      expect(clickhouseDialect.formatDate("date_col")).toBe(
+        "formatDateTime(date_col, '%F')"
+      );
+    });
+  });
+
+  describe("formatDateTimeString", () => {
+    it("formats datetime using formatDateTime with full format", () => {
+      expect(clickhouseDialect.formatDateTimeString("datetime_col")).toBe(
+        "formatDateTime(datetime_col, '%Y-%m-%d %H:%i:%S.%f')"
+      );
+    });
+  });
+
+  describe("castToDate", () => {
+    it("casts to DATE", () => {
+      expect(clickhouseDialect.castToDate("col")).toBe("CAST(col AS DATE)");
+    });
+
+    it("uses Nullable(DATE) for NULL", () => {
+      expect(clickhouseDialect.castToDate("NULL")).toBe(
+        "CAST(NULL AS Nullable(DATE))"
+      );
+    });
+  });
+
+  describe("castToString", () => {
+    it("casts using toString", () => {
+      expect(clickhouseDialect.castToString("numeric_col")).toBe(
+        "toString(numeric_col)"
+      );
+    });
+  });
+
+  describe("ensureFloat", () => {
+    it("casts using toFloat64", () => {
+      expect(clickhouseDialect.ensureFloat("int_col")).toBe(
+        "toFloat64(int_col)"
+      );
+    });
+  });
+
+  describe("ifElse", () => {
+    it("generates if() expression instead of CASE WHEN", () => {
+      expect(clickhouseDialect.ifElse("x > 0", "1", "0")).toBe(
+        "if(x > 0, 1, 0)"
+      );
+    });
+  });
+
+  describe("evalBoolean", () => {
+    it("evaluates true using equality", () => {
+      expect(clickhouseDialect.evalBoolean("active", true)).toBe(
+        "active = true"
+      );
+    });
+
+    it("evaluates false using equality", () => {
+      expect(clickhouseDialect.evalBoolean("active", false)).toBe(
+        "active = false"
+      );
+    });
+  });
+
+  describe("selectStarLimit", () => {
+    it("generates SELECT with LIMIT", () => {
+      expect(clickhouseDialect.selectStarLimit("users", 10)).toBe(
+        "SELECT * FROM users LIMIT 10"
+      );
+    });
+  });
+
+  describe("extractJSONField", () => {
+    it("extracts numeric field with if/JSONExtractFloat", () => {
+      const result = clickhouseDialect.extractJSONField(
+        "json_col",
+        "user.age",
+        true
+      );
+      expect(result).toContain("JSONExtractFloat");
+      expect(result).toContain("toFloat64");
+    });
+
+    it("extracts string field with if/JSONExtractString", () => {
+      const result = clickhouseDialect.extractJSONField(
+        "json_col",
+        "user.name",
+        false
+      );
+      expect(result).toContain("JSONExtractString");
+      expect(result).toContain(":String");
+    });
+  });
+
+  describe("HLL functions", () => {
+    it("supports HLL", () => {
+      expect(clickhouseDialect.hasCountDistinctHLL()).toBe(true);
+    });
+
+    it("aggregates with uniqState", () => {
+      expect(clickhouseDialect.hllAggregate("user_id")).toBe(
+        "uniqState(user_id)"
+      );
+    });
+
+    it("reaggregates with uniqMergeState", () => {
+      expect(clickhouseDialect.hllReaggregate("hll_col")).toBe(
+        "uniqMergeState(hll_col)"
+      );
+    });
+
+    it("extracts cardinality with finalizeAggregation", () => {
+      expect(clickhouseDialect.hllCardinality("hll_col")).toBe(
+        "finalizeAggregation(hll_col)"
+      );
+    });
+  });
+
+  describe("Quantile functions", () => {
+    it("has efficient percentile", () => {
+      expect(clickhouseDialect.hasEfficientPercentile()).toBe(true);
+    });
+
+    it("has quantile testing", () => {
+      expect(clickhouseDialect.hasQuantileTesting()).toBe(true);
+    });
+
+    it("generates quantile() for numeric quantile", () => {
+      expect(clickhouseDialect.approxQuantile("value", 0.5)).toBe(
+        "quantile(0.5)(value)"
+      );
+    });
+
+    it("generates quantile() for string quantile expression", () => {
+      expect(clickhouseDialect.approxQuantile("value", "q")).toBe(
+        "quantile(q)(value)"
+      );
+    });
+  });
+
+  describe("Type guards", () => {
+    it("hasHllSupport returns true for ClickHouse", () => {
+      expect(hasHllSupport(clickhouseDialect)).toBe(true);
+    });
+
+    it("hasQuantileSupport returns true for ClickHouse", () => {
+      expect(hasQuantileSupport(clickhouseDialect)).toBe(true);
+    });
+  });
+});

--- a/packages/back-end/test/integrations/sql-dialects/databricks-dialect.test.ts
+++ b/packages/back-end/test/integrations/sql-dialects/databricks-dialect.test.ts
@@ -1,0 +1,216 @@
+import {
+  databricksDialect,
+  hasHllSupport,
+  hasQuantileSupport,
+} from "../../../src/integrations/sql-dialects";
+
+describe("Databricks Dialect", () => {
+  describe("formatDialect", () => {
+    it("returns sql (generic formatter)", () => {
+      expect(databricksDialect.formatDialect).toBe("sql");
+    });
+  });
+
+  describe("toTimestamp", () => {
+    it("formats date using TIMESTAMP literal", () => {
+      const date = new Date("2023-01-15T12:30:45.123Z");
+      expect(databricksDialect.toTimestamp(date)).toBe(
+        "TIMESTAMP'2023-01-15T12:30:45.123Z'"
+      );
+    });
+  });
+
+  describe("addHours", () => {
+    it("returns column unchanged when hours is 0", () => {
+      expect(databricksDialect.addHours("timestamp", 0)).toBe("timestamp");
+    });
+
+    it("adds positive hours using timestampadd", () => {
+      expect(databricksDialect.addHours("timestamp", 24)).toBe(
+        "timestampadd(hour,24,timestamp)"
+      );
+    });
+
+    it("subtracts negative hours using timestampadd with negative", () => {
+      expect(databricksDialect.addHours("timestamp", -12)).toBe(
+        "timestampadd(hour,-12,timestamp)"
+      );
+    });
+
+    it("uses minutes for fractional hours", () => {
+      expect(databricksDialect.addHours("timestamp", 1.5)).toBe(
+        "timestampadd(minute,90,timestamp)"
+      );
+    });
+  });
+
+  describe("addTime", () => {
+    it("adds hours with timestampadd", () => {
+      expect(databricksDialect.addTime("col", "hour", "+", 5)).toBe(
+        "timestampadd(hour,5,col)"
+      );
+    });
+
+    it("subtracts minutes with timestampadd", () => {
+      expect(databricksDialect.addTime("col", "minute", "-", 30)).toBe(
+        "timestampadd(minute,-30,col)"
+      );
+    });
+  });
+
+  describe("dateTrunc", () => {
+    it("truncates to day using date_trunc (inherited from base)", () => {
+      expect(databricksDialect.dateTrunc("timestamp")).toBe(
+        "date_trunc('day', timestamp)"
+      );
+    });
+  });
+
+  describe("dateDiff", () => {
+    it("uses datediff function (inherited from base)", () => {
+      expect(databricksDialect.dateDiff("start_date", "end_date")).toBe(
+        "datediff(day, start_date, end_date)"
+      );
+    });
+  });
+
+  describe("formatDate", () => {
+    it("formats date using date_format", () => {
+      expect(databricksDialect.formatDate("date_col")).toBe(
+        "date_format(date_col, 'y-MM-dd')"
+      );
+    });
+  });
+
+  describe("formatDateTimeString", () => {
+    it("formats datetime using date_format with milliseconds", () => {
+      expect(databricksDialect.formatDateTimeString("datetime_col")).toBe(
+        "date_format(datetime_col, 'y-MM-dd HH:mm:ss.SSS')"
+      );
+    });
+  });
+
+  describe("castToString", () => {
+    it("casts using string type", () => {
+      expect(databricksDialect.castToString("numeric_col")).toBe(
+        "cast(numeric_col as string)"
+      );
+    });
+  });
+
+  describe("ensureFloat", () => {
+    it("casts to double", () => {
+      expect(databricksDialect.ensureFloat("int_col")).toBe(
+        "cast(int_col as double)"
+      );
+    });
+  });
+
+  describe("escapeStringLiteral", () => {
+    it("escapes single quotes with backslash", () => {
+      expect(databricksDialect.escapeStringLiteral("it's")).toBe("it\\'s");
+    });
+
+    it("escapes backslashes", () => {
+      expect(databricksDialect.escapeStringLiteral("path\\to\\file")).toBe(
+        "path\\\\to\\\\file"
+      );
+    });
+  });
+
+  describe("selectStarLimit", () => {
+    it("generates SELECT with LIMIT", () => {
+      expect(databricksDialect.selectStarLimit("users", 10)).toBe(
+        "SELECT * FROM users LIMIT 10"
+      );
+    });
+  });
+
+  describe("extractJSONField", () => {
+    it("extracts string field with :path syntax", () => {
+      expect(
+        databricksDialect.extractJSONField("json_col", "user.name", false)
+      ).toBe("json_col:user.name");
+    });
+
+    it("extracts numeric field with double cast", () => {
+      expect(
+        databricksDialect.extractJSONField("json_col", "user.age", true)
+      ).toBe("cast(json_col:user.age as double)");
+    });
+  });
+
+  describe("getDataType", () => {
+    it("maps string to STRING", () => {
+      expect(databricksDialect.getDataType("string")).toBe("STRING");
+    });
+
+    it("maps integer to INT", () => {
+      expect(databricksDialect.getDataType("integer")).toBe("INT");
+    });
+
+    it("maps float to DOUBLE", () => {
+      expect(databricksDialect.getDataType("float")).toBe("DOUBLE");
+    });
+
+    it("maps hll to BINARY", () => {
+      expect(databricksDialect.getDataType("hll")).toBe("BINARY");
+    });
+  });
+
+  describe("HLL functions", () => {
+    it("supports HLL", () => {
+      expect(databricksDialect.hasCountDistinctHLL()).toBe(true);
+    });
+
+    it("aggregates with HLL_SKETCH_AGG and string cast", () => {
+      expect(databricksDialect.hllAggregate("user_id")).toBe(
+        "HLL_SKETCH_AGG(cast(user_id as string))"
+      );
+    });
+
+    it("reaggregates with HLL_UNION_AGG", () => {
+      expect(databricksDialect.hllReaggregate("hll_col")).toBe(
+        "HLL_UNION_AGG(hll_col)"
+      );
+    });
+
+    it("extracts cardinality with HLL_SKETCH_ESTIMATE", () => {
+      expect(databricksDialect.hllCardinality("hll_col")).toBe(
+        "HLL_SKETCH_ESTIMATE(hll_col)"
+      );
+    });
+
+    it("casts to HLL data type (BINARY)", () => {
+      expect(databricksDialect.castToHllDataType("col")).toBe(
+        "CAST(col AS BINARY)"
+      );
+    });
+  });
+
+  describe("Quantile functions", () => {
+    it("has efficient percentile", () => {
+      expect(databricksDialect.hasEfficientPercentile()).toBe(true);
+    });
+
+    it("has quantile testing", () => {
+      expect(databricksDialect.hasQuantileTesting()).toBe(true);
+    });
+
+    it("generates APPROX_PERCENTILE for numeric quantile", () => {
+      expect(databricksDialect.approxQuantile("value", 0.5)).toBe(
+        "APPROX_PERCENTILE(value, 0.5)"
+      );
+    });
+  });
+
+  describe("Type guards", () => {
+    it("hasHllSupport returns true for Databricks", () => {
+      expect(hasHllSupport(databricksDialect)).toBe(true);
+    });
+
+    it("hasQuantileSupport returns true for Databricks", () => {
+      expect(hasQuantileSupport(databricksDialect)).toBe(true);
+    });
+  });
+});

--- a/packages/back-end/test/integrations/sql-dialects/dialect-parity.test.ts
+++ b/packages/back-end/test/integrations/sql-dialects/dialect-parity.test.ts
@@ -1,0 +1,611 @@
+/**
+ * Dialect Parity Tests
+ *
+ * These tests verify that the extracted dialect modules produce IDENTICAL
+ * output to the original SqlIntegration/BigQuery class methods.
+ *
+ * IMPORTANT: These tests require the full build to be working (yarn build:deps).
+ * They compare the output of the extracted dialect modules against the original
+ * class methods to ensure the refactoring doesn't change behavior.
+ *
+ * To run these tests:
+ * 1. Run `yarn build:deps` from the root directory
+ * 2. Run `yarn workspace back-end test test/integrations/sql-dialects/dialect-parity.test.ts`
+ *
+ * If you see "@growthbook/growthbook not found" errors, the SDK hasn't been built.
+ * Run `yarn` from the root first.
+ */
+
+import { bigQueryDialect } from "../../../src/integrations/sql-dialects/bigquery-dialect";
+import { baseDialect } from "../../../src/integrations/sql-dialects/base-dialect";
+
+/**
+ * These tests verify the extracted dialects match the EXPECTED behavior
+ * documented in the original SqlIntegration.ts and BigQuery.ts files.
+ *
+ * The expected values are copied directly from the original source code
+ * to ensure parity.
+ */
+describe("BigQuery Dialect - Expected Behavior Parity", () => {
+  describe("Date/Time Functions", () => {
+    describe("toTimestamp - matches SqlIntegration.toTimestamp", () => {
+      // Original: return `'${date.toISOString().substr(0, 19).replace("T", " ")}'`;
+      it("formats 2023-01-15T12:30:45.123Z", () => {
+        const date = new Date("2023-01-15T12:30:45.123Z");
+        const expected = "'2023-01-15 12:30:45'"; // From SqlIntegration.ts line 334
+        expect(bigQueryDialect.toTimestamp(date)).toBe(expected);
+      });
+
+      it("formats 2023-01-01T00:00:00.000Z", () => {
+        const date = new Date("2023-01-01T00:00:00.000Z");
+        const expected = "'2023-01-01 00:00:00'";
+        expect(bigQueryDialect.toTimestamp(date)).toBe(expected);
+      });
+    });
+
+    describe("toTimestampWithMs - matches SqlIntegration.toTimestampWithMs", () => {
+      // Original: return `'${date.toISOString().substring(0, 23).replace("T", " ")}'`;
+      it("formats with milliseconds", () => {
+        const date = new Date("2023-01-15T12:30:45.123Z");
+        const expected = "'2023-01-15 12:30:45.123'"; // From SqlIntegration.ts line 337
+        expect(bigQueryDialect.toTimestampWithMs(date)).toBe(expected);
+      });
+    });
+
+    describe("addTime - matches BigQuery.addTime", () => {
+      // Original BigQuery.ts line 156-164:
+      // return `DATETIME_${sign === "+" ? "ADD" : "SUB"}(${col}, INTERVAL ${amount} ${unit.toUpperCase()})`;
+      it("adds hours", () => {
+        expect(bigQueryDialect.addTime("col", "hour", "+", 5)).toBe(
+          "DATETIME_ADD(col, INTERVAL 5 HOUR)"
+        );
+      });
+
+      it("subtracts minutes", () => {
+        expect(bigQueryDialect.addTime("col", "minute", "-", 30)).toBe(
+          "DATETIME_SUB(col, INTERVAL 30 MINUTE)"
+        );
+      });
+    });
+
+    describe("dateTrunc - matches BigQuery.dateTrunc", () => {
+      // Original BigQuery.ts line 166-167: return `date_trunc(${col}, DAY)`;
+      it("truncates to day", () => {
+        expect(bigQueryDialect.dateTrunc("timestamp")).toBe(
+          "date_trunc(timestamp, DAY)"
+        );
+      });
+    });
+
+    describe("dateDiff - matches BigQuery.dateDiff", () => {
+      // Original BigQuery.ts line 169-170: return `date_diff(${endCol}, ${startCol}, DAY)`;
+      it("calculates difference in days", () => {
+        expect(bigQueryDialect.dateDiff("start", "end")).toBe(
+          "date_diff(end, start, DAY)"
+        );
+      });
+    });
+
+    describe("formatDate - matches BigQuery.formatDate", () => {
+      // Original BigQuery.ts line 172-173: return `format_date("%F", ${col})`;
+      it("formats with %F", () => {
+        expect(bigQueryDialect.formatDate("date_col")).toBe(
+          'format_date("%F", date_col)'
+        );
+      });
+    });
+
+    describe("formatDateTimeString - matches BigQuery.formatDateTimeString", () => {
+      // Original BigQuery.ts line 175-176: return `format_datetime("%F %T", ${col})`;
+      it("formats with %F %T", () => {
+        expect(bigQueryDialect.formatDateTimeString("datetime_col")).toBe(
+          'format_datetime("%F %T", datetime_col)'
+        );
+      });
+    });
+  });
+
+  describe("Type Casting", () => {
+    describe("castToString - matches BigQuery.castToString", () => {
+      // Original BigQuery.ts line 178-179: return `cast(${col} as string)`;
+      it("casts to string", () => {
+        expect(bigQueryDialect.castToString("col")).toBe("cast(col as string)");
+      });
+    });
+
+    describe("castUserDateCol - matches BigQuery.castUserDateCol", () => {
+      // Original BigQuery.ts line 184-185: return `CAST(${column} as DATETIME)`;
+      it("casts to DATETIME", () => {
+        expect(bigQueryDialect.castUserDateCol("user_date")).toBe(
+          "CAST(user_date as DATETIME)"
+        );
+      });
+    });
+
+    describe("castToDate - matches SqlIntegration.castToDate", () => {
+      // Original SqlIntegration.ts line 385-386: return `CAST(${col} AS DATE)`;
+      it("casts to DATE", () => {
+        expect(bigQueryDialect.castToDate("col")).toBe("CAST(col AS DATE)");
+      });
+    });
+
+    describe("castToTimestamp - matches SqlIntegration.castToTimestamp", () => {
+      // Original SqlIntegration.ts line 388-389: return `CAST(${col} AS TIMESTAMP)`;
+      it("casts to TIMESTAMP", () => {
+        expect(bigQueryDialect.castToTimestamp("col")).toBe(
+          "CAST(col AS TIMESTAMP)"
+        );
+      });
+    });
+  });
+
+  describe("String Functions", () => {
+    describe("escapeStringLiteral - matches BigQuery.escapeStringLiteral", () => {
+      // Original BigQuery.ts line 181-182: return value.replace(/(['\\])/g, "\\$1");
+      it("escapes single quotes with backslash", () => {
+        expect(bigQueryDialect.escapeStringLiteral("it's")).toBe("it\\'s");
+      });
+
+      it("escapes backslashes", () => {
+        expect(bigQueryDialect.escapeStringLiteral("path\\to")).toBe(
+          "path\\\\to"
+        );
+      });
+    });
+  });
+
+  describe("Control Flow", () => {
+    describe("ifElse - matches SqlIntegration.ifElse", () => {
+      // Original SqlIntegration.ts line 379-380:
+      // return `(CASE WHEN ${condition} THEN ${ifTrue} ELSE ${ifFalse} END)`;
+      it("generates CASE WHEN", () => {
+        expect(bigQueryDialect.ifElse("x > 0", "1", "0")).toBe(
+          "(CASE WHEN x > 0 THEN 1 ELSE 0 END)"
+        );
+      });
+    });
+
+    describe("evalBoolean - matches SqlIntegration.evalBoolean", () => {
+      // Original SqlIntegration.ts line 447-448:
+      // return `${col} IS ${value ? "TRUE" : "FALSE"}`;
+      it("evaluates true", () => {
+        expect(bigQueryDialect.evalBoolean("active", true)).toBe(
+          "active IS TRUE"
+        );
+      });
+
+      it("evaluates false", () => {
+        expect(bigQueryDialect.evalBoolean("active", false)).toBe(
+          "active IS FALSE"
+        );
+      });
+    });
+  });
+
+  describe("Query Structure", () => {
+    describe("selectStarLimit - matches SqlIntegration.selectStarLimit", () => {
+      // Original SqlIntegration.ts line 406-407:
+      // return `SELECT * FROM ${table} LIMIT ${limit}`;
+      it("generates SELECT with LIMIT", () => {
+        expect(bigQueryDialect.selectStarLimit("users", 10)).toBe(
+          "SELECT * FROM users LIMIT 10"
+        );
+      });
+    });
+  });
+
+  describe("JSON Functions", () => {
+    describe("extractJSONField - matches BigQuery.extractJSONField", () => {
+      // Original BigQuery.ts line 206-208:
+      // const raw = `JSON_VALUE(${jsonCol}, '$.${path}')`;
+      // return isNumeric ? `CAST(${raw} AS FLOAT64)` : raw;
+      it("extracts string field", () => {
+        expect(
+          bigQueryDialect.extractJSONField("json_col", "user.name", false)
+        ).toBe("JSON_VALUE(json_col, '$.user.name')");
+      });
+
+      it("extracts numeric field with CAST", () => {
+        expect(
+          bigQueryDialect.extractJSONField("json_col", "user.age", true)
+        ).toBe("CAST(JSON_VALUE(json_col, '$.user.age') AS FLOAT64)");
+      });
+    });
+  });
+
+  describe("Data Types", () => {
+    describe("getDataType - matches BigQuery.getDataType", () => {
+      // Original BigQuery.ts lines 280-299
+      it("maps string to STRING", () => {
+        expect(bigQueryDialect.getDataType("string")).toBe("STRING");
+      });
+
+      it("maps integer to INT64", () => {
+        expect(bigQueryDialect.getDataType("integer")).toBe("INT64");
+      });
+
+      it("maps float to FLOAT64", () => {
+        expect(bigQueryDialect.getDataType("float")).toBe("FLOAT64");
+      });
+
+      it("maps boolean to BOOL", () => {
+        expect(bigQueryDialect.getDataType("boolean")).toBe("BOOL");
+      });
+
+      it("maps date to DATE", () => {
+        expect(bigQueryDialect.getDataType("date")).toBe("DATE");
+      });
+
+      it("maps timestamp to TIMESTAMP", () => {
+        expect(bigQueryDialect.getDataType("timestamp")).toBe("TIMESTAMP");
+      });
+
+      it("maps hll to BYTES", () => {
+        expect(bigQueryDialect.getDataType("hll")).toBe("BYTES");
+      });
+    });
+  });
+
+  describe("HLL Functions", () => {
+    describe("hasCountDistinctHLL - matches BigQuery.hasCountDistinctHLL", () => {
+      // Original BigQuery.ts line 187-188: return true;
+      it("returns true", () => {
+        expect(bigQueryDialect.hasCountDistinctHLL()).toBe(true);
+      });
+    });
+
+    describe("hllAggregate - matches BigQuery.hllAggregate", () => {
+      // Original BigQuery.ts line 190-191: return `HLL_COUNT.INIT(${col})`;
+      it("uses HLL_COUNT.INIT", () => {
+        expect(bigQueryDialect.hllAggregate("user_id")).toBe(
+          "HLL_COUNT.INIT(user_id)"
+        );
+      });
+    });
+
+    describe("hllReaggregate - matches BigQuery.hllReaggregate", () => {
+      // Original BigQuery.ts line 193-194: return `HLL_COUNT.MERGE_PARTIAL(${col})`;
+      it("uses HLL_COUNT.MERGE_PARTIAL", () => {
+        expect(bigQueryDialect.hllReaggregate("hll_col")).toBe(
+          "HLL_COUNT.MERGE_PARTIAL(hll_col)"
+        );
+      });
+    });
+
+    describe("hllCardinality - matches BigQuery.hllCardinality", () => {
+      // Original BigQuery.ts line 196-197: return `HLL_COUNT.EXTRACT(${col})`;
+      it("uses HLL_COUNT.EXTRACT", () => {
+        expect(bigQueryDialect.hllCardinality("hll_col")).toBe(
+          "HLL_COUNT.EXTRACT(hll_col)"
+        );
+      });
+    });
+
+    describe("castToHllDataType - matches BigQuery behavior", () => {
+      // Uses getDataType("hll") which returns BYTES in BigQuery
+      it("casts to BYTES", () => {
+        expect(bigQueryDialect.castToHllDataType("col")).toBe(
+          "CAST(col AS BYTES)"
+        );
+      });
+    });
+  });
+
+  describe("Quantile Functions", () => {
+    describe("approxQuantile - matches BigQuery.approxQuantile", () => {
+      // Original BigQuery.ts line 199-204:
+      // const multiplier = 10000;
+      // const quantileVal = Number(quantile) ? Math.trunc(multiplier * Number(quantile)) : `${multiplier} * ${quantile}`;
+      // return `APPROX_QUANTILES(${value}, ${multiplier} IGNORE NULLS)[OFFSET(CAST(${quantileVal} AS INT64))]`;
+      it("handles numeric quantile 0.5", () => {
+        expect(bigQueryDialect.approxQuantile("value", 0.5)).toBe(
+          "APPROX_QUANTILES(value, 10000 IGNORE NULLS)[OFFSET(CAST(5000 AS INT64))]"
+        );
+      });
+
+      it("handles numeric quantile 0.25", () => {
+        expect(bigQueryDialect.approxQuantile("value", 0.25)).toBe(
+          "APPROX_QUANTILES(value, 10000 IGNORE NULLS)[OFFSET(CAST(2500 AS INT64))]"
+        );
+      });
+
+      it("handles string quantile expression", () => {
+        expect(bigQueryDialect.approxQuantile("value", "q")).toBe(
+          "APPROX_QUANTILES(value, 10000 IGNORE NULLS)[OFFSET(CAST(10000 * q AS INT64))]"
+        );
+      });
+    });
+  });
+});
+
+describe("Base Dialect - Expected Behavior Parity with SqlIntegration", () => {
+  describe("toTimestamp", () => {
+    // Original SqlIntegration.ts line 333-334:
+    // return `'${date.toISOString().substr(0, 19).replace("T", " ")}'`;
+    it("matches SqlIntegration default", () => {
+      const date = new Date("2023-01-15T12:30:45.123Z");
+      expect(baseDialect.toTimestamp(date)).toBe("'2023-01-15 12:30:45'");
+    });
+  });
+
+  describe("addTime", () => {
+    // Original SqlIntegration.ts line 362-368:
+    // return `${col} ${sign} INTERVAL '${amount} ${unit}s'`;
+    it("matches SqlIntegration default", () => {
+      expect(baseDialect.addTime("col", "hour", "+", 5)).toBe(
+        "col + INTERVAL '5 hours'"
+      );
+    });
+  });
+
+  describe("dateTrunc", () => {
+    // Original SqlIntegration.ts line 370-371:
+    // return `date_trunc('day', ${col})`;
+    it("matches SqlIntegration default", () => {
+      expect(baseDialect.dateTrunc("timestamp")).toBe(
+        "date_trunc('day', timestamp)"
+      );
+    });
+  });
+
+  describe("dateDiff", () => {
+    // Original SqlIntegration.ts line 373-374:
+    // return `datediff(day, ${startCol}, ${endCol})`;
+    it("matches SqlIntegration default", () => {
+      expect(baseDialect.dateDiff("start", "end")).toBe(
+        "datediff(day, start, end)"
+      );
+    });
+  });
+
+  describe("castToString", () => {
+    // Original SqlIntegration.ts line 382-383:
+    // return `cast(${col} as varchar)`;
+    it("matches SqlIntegration default", () => {
+      expect(baseDialect.castToString("col")).toBe("cast(col as varchar)");
+    });
+  });
+
+  describe("escapeStringLiteral", () => {
+    // Original SqlIntegration.ts line 397-398:
+    // return value.replace(/'/g, `''`);
+    it("matches SqlIntegration default (double single quotes)", () => {
+      expect(baseDialect.escapeStringLiteral("it's")).toBe("it''s");
+    });
+  });
+
+  describe("getDataType", () => {
+    // Base dialect uses standard SQL types
+    it("maps string to VARCHAR", () => {
+      expect(baseDialect.getDataType("string")).toBe("VARCHAR");
+    });
+
+    it("maps float to FLOAT", () => {
+      expect(baseDialect.getDataType("float")).toBe("FLOAT");
+    });
+  });
+});
+
+/**
+ * Runtime parity tests - compare actual BigQuery class output vs extracted dialects.
+ * These tests directly instantiate BigQuery and compare method outputs.
+ */
+describe("Runtime Parity Tests", () => {
+  // Lazy import to avoid issues if build isn't ready
+  let BigQuery: typeof import("../../../src/integrations/BigQuery").default;
+  let bqInstance: InstanceType<typeof BigQuery>;
+
+  beforeAll(async () => {
+    const module = await import("../../../src/integrations/BigQuery");
+    BigQuery = module.default;
+    // @ts-expect-error - context not needed for dialect method testing
+    bqInstance = new BigQuery("", {});
+  });
+
+  describe("Date/Time Functions", () => {
+    const testDates = [
+      new Date("2023-01-15T12:30:45.123Z"),
+      new Date("2023-01-01T00:00:00.000Z"),
+      new Date("2023-12-31T23:59:59.999Z"),
+    ];
+
+    describe("toTimestamp", () => {
+      testDates.forEach((date) => {
+        it(`matches BigQuery class for ${date.toISOString()}`, () => {
+          expect(bigQueryDialect.toTimestamp(date)).toBe(
+            bqInstance.toTimestamp(date)
+          );
+        });
+      });
+    });
+
+    describe("toTimestampWithMs", () => {
+      testDates.forEach((date) => {
+        it(`matches BigQuery class for ${date.toISOString()}`, () => {
+          expect(bigQueryDialect.toTimestampWithMs(date)).toBe(
+            bqInstance.toTimestampWithMs(date)
+          );
+        });
+      });
+    });
+
+    describe("addTime", () => {
+      const cases: Array<{
+        col: string;
+        unit: "hour" | "minute";
+        sign: "+" | "-";
+        amount: number;
+      }> = [
+        { col: "ts", unit: "hour", sign: "+", amount: 5 },
+        { col: "ts", unit: "hour", sign: "-", amount: 10 },
+        { col: "ts", unit: "minute", sign: "+", amount: 30 },
+        { col: "ts", unit: "minute", sign: "-", amount: 90 },
+      ];
+
+      cases.forEach(({ col, unit, sign, amount }) => {
+        it(`matches BigQuery class for addTime('${col}', '${unit}', '${sign}', ${amount})`, () => {
+          expect(bigQueryDialect.addTime(col, unit, sign, amount)).toBe(
+            bqInstance.addTime(col, unit, sign, amount)
+          );
+        });
+      });
+    });
+
+    describe("addHours", () => {
+      const cases = [0, 1, 24, -12, 1.5, 0.25];
+      cases.forEach((hours) => {
+        it(`matches BigQuery class for addHours('col', ${hours})`, () => {
+          expect(bigQueryDialect.addHours("col", hours)).toBe(
+            bqInstance.addHours("col", hours)
+          );
+        });
+      });
+    });
+
+    describe("dateTrunc", () => {
+      it("matches BigQuery class", () => {
+        expect(bigQueryDialect.dateTrunc("timestamp")).toBe(
+          bqInstance.dateTrunc("timestamp")
+        );
+      });
+    });
+
+    describe("dateDiff", () => {
+      it("matches BigQuery class", () => {
+        expect(bigQueryDialect.dateDiff("start", "end")).toBe(
+          bqInstance.dateDiff("start", "end")
+        );
+      });
+    });
+
+    describe("formatDate", () => {
+      it("matches BigQuery class", () => {
+        expect(bigQueryDialect.formatDate("date_col")).toBe(
+          bqInstance.formatDate("date_col")
+        );
+      });
+    });
+
+    describe("formatDateTimeString", () => {
+      it("matches BigQuery class", () => {
+        expect(bigQueryDialect.formatDateTimeString("datetime_col")).toBe(
+          bqInstance.formatDateTimeString("datetime_col")
+        );
+      });
+    });
+  });
+
+  describe("Type Casting", () => {
+    describe("castToString", () => {
+      it("matches BigQuery class", () => {
+        expect(bigQueryDialect.castToString("col")).toBe(
+          bqInstance.castToString("col")
+        );
+      });
+    });
+
+    describe("castUserDateCol", () => {
+      it("matches BigQuery class", () => {
+        expect(bigQueryDialect.castUserDateCol("user_date")).toBe(
+          bqInstance.castUserDateCol("user_date")
+        );
+      });
+    });
+
+    describe("castToDate", () => {
+      it("matches BigQuery class", () => {
+        expect(bigQueryDialect.castToDate("col")).toBe(
+          bqInstance.castToDate("col")
+        );
+      });
+    });
+
+    describe("castToTimestamp", () => {
+      it("matches BigQuery class", () => {
+        expect(bigQueryDialect.castToTimestamp("col")).toBe(
+          bqInstance.castToTimestamp("col")
+        );
+      });
+    });
+  });
+
+  describe("String Functions", () => {
+    describe("escapeStringLiteral", () => {
+      const cases = ["simple", "it's", "path\\to", "both 'and' \\"];
+      cases.forEach((str) => {
+        it(`matches BigQuery class for '${str}'`, () => {
+          expect(bigQueryDialect.escapeStringLiteral(str)).toBe(
+            bqInstance.escapeStringLiteral(str)
+          );
+        });
+      });
+    });
+  });
+
+  describe("JSON Functions", () => {
+    describe("extractJSONField", () => {
+      it("matches BigQuery class for string field", () => {
+        expect(
+          bigQueryDialect.extractJSONField("json_col", "user.name", false)
+        ).toBe(bqInstance.extractJSONField("json_col", "user.name", false));
+      });
+
+      it("matches BigQuery class for numeric field", () => {
+        expect(
+          bigQueryDialect.extractJSONField("json_col", "user.age", true)
+        ).toBe(bqInstance.extractJSONField("json_col", "user.age", true));
+      });
+    });
+  });
+
+  describe("Data Types", () => {
+    const types: Array<
+      "string" | "integer" | "float" | "boolean" | "date" | "timestamp" | "hll"
+    > = ["string", "integer", "float", "boolean", "date", "timestamp", "hll"];
+
+    types.forEach((type) => {
+      it(`matches BigQuery class for getDataType('${type}')`, () => {
+        expect(bigQueryDialect.getDataType(type)).toBe(
+          bqInstance.getDataType(type)
+        );
+      });
+    });
+  });
+
+  describe("HLL Functions", () => {
+    it("hasCountDistinctHLL matches", () => {
+      expect(bigQueryDialect.hasCountDistinctHLL()).toBe(
+        bqInstance.hasCountDistinctHLL()
+      );
+    });
+
+    it("hllAggregate matches", () => {
+      expect(bigQueryDialect.hllAggregate("user_id")).toBe(
+        bqInstance.hllAggregate("user_id")
+      );
+    });
+
+    it("hllReaggregate matches", () => {
+      expect(bigQueryDialect.hllReaggregate("hll_col")).toBe(
+        bqInstance.hllReaggregate("hll_col")
+      );
+    });
+
+    it("hllCardinality matches", () => {
+      expect(bigQueryDialect.hllCardinality("hll_col")).toBe(
+        bqInstance.hllCardinality("hll_col")
+      );
+    });
+  });
+
+  describe("Quantile Functions", () => {
+    const quantiles = [0.25, 0.5, 0.75, 0.99, "q"];
+    quantiles.forEach((q) => {
+      it(`matches BigQuery class for approxQuantile('value', ${q})`, () => {
+        expect(bigQueryDialect.approxQuantile("value", q)).toBe(
+          bqInstance.approxQuantile("value", q)
+        );
+      });
+    });
+  });
+});

--- a/packages/back-end/test/integrations/sql-dialects/mssql-dialect.test.ts
+++ b/packages/back-end/test/integrations/sql-dialects/mssql-dialect.test.ts
@@ -1,0 +1,204 @@
+import {
+  mssqlDialect,
+  hasHllSupport,
+  hasQuantileSupport,
+} from "../../../src/integrations/sql-dialects";
+
+describe("MSSQL Dialect", () => {
+  describe("formatDialect", () => {
+    it("returns tsql", () => {
+      expect(mssqlDialect.formatDialect).toBe("tsql");
+    });
+  });
+
+  describe("toTimestamp", () => {
+    it("formats date without milliseconds (inherited from base)", () => {
+      const date = new Date("2023-01-15T12:30:45.123Z");
+      expect(mssqlDialect.toTimestamp(date)).toBe("'2023-01-15 12:30:45'");
+    });
+  });
+
+  describe("addHours", () => {
+    it("returns column unchanged when hours is 0", () => {
+      expect(mssqlDialect.addHours("timestamp", 0)).toBe("timestamp");
+    });
+
+    it("adds positive hours using DATEADD", () => {
+      expect(mssqlDialect.addHours("timestamp", 24)).toBe(
+        "DATEADD(hour, 24, timestamp)"
+      );
+    });
+
+    it("subtracts negative hours using DATEADD with negative", () => {
+      expect(mssqlDialect.addHours("timestamp", -12)).toBe(
+        "DATEADD(hour, -12, timestamp)"
+      );
+    });
+
+    it("uses minutes for fractional hours", () => {
+      expect(mssqlDialect.addHours("timestamp", 1.5)).toBe(
+        "DATEADD(minute, 90, timestamp)"
+      );
+    });
+  });
+
+  describe("addTime", () => {
+    it("adds hours with DATEADD", () => {
+      expect(mssqlDialect.addTime("col", "hour", "+", 5)).toBe(
+        "DATEADD(hour, 5, col)"
+      );
+    });
+
+    it("subtracts minutes with DATEADD and negative", () => {
+      expect(mssqlDialect.addTime("col", "minute", "-", 30)).toBe(
+        "DATEADD(minute, -30, col)"
+      );
+    });
+  });
+
+  describe("dateTrunc", () => {
+    it("truncates to day using cast as DATE", () => {
+      expect(mssqlDialect.dateTrunc("timestamp")).toBe("cast(timestamp as DATE)");
+    });
+  });
+
+  describe("dateDiff", () => {
+    it("uses datediff function (inherited from base)", () => {
+      expect(mssqlDialect.dateDiff("start_date", "end_date")).toBe(
+        "datediff(day, start_date, end_date)"
+      );
+    });
+  });
+
+  describe("formatDate", () => {
+    it("formats date using FORMAT", () => {
+      expect(mssqlDialect.formatDate("date_col")).toBe(
+        "FORMAT(date_col, 'yyyy-MM-dd')"
+      );
+    });
+  });
+
+  describe("formatDateTimeString", () => {
+    it("formats datetime using CONVERT with style 121", () => {
+      expect(mssqlDialect.formatDateTimeString("datetime_col")).toBe(
+        "CONVERT(VARCHAR(25), datetime_col, 121)"
+      );
+    });
+  });
+
+  describe("castToString", () => {
+    it("casts using varchar(256)", () => {
+      expect(mssqlDialect.castToString("numeric_col")).toBe(
+        "cast(numeric_col as varchar(256))"
+      );
+    });
+  });
+
+  describe("ensureFloat", () => {
+    it("casts to FLOAT", () => {
+      expect(mssqlDialect.ensureFloat("int_col")).toBe("CAST(int_col as FLOAT)");
+    });
+  });
+
+  describe("escapeStringLiteral", () => {
+    it("escapes single quotes by doubling (inherited from base)", () => {
+      expect(mssqlDialect.escapeStringLiteral("it's")).toBe("it''s");
+    });
+  });
+
+  describe("ifElse", () => {
+    it("generates CASE WHEN expression (inherited from base)", () => {
+      expect(mssqlDialect.ifElse("x > 0", "1", "0")).toBe(
+        "(CASE WHEN x > 0 THEN 1 ELSE 0 END)"
+      );
+    });
+  });
+
+  describe("evalBoolean", () => {
+    it("evaluates true using = 1", () => {
+      expect(mssqlDialect.evalBoolean("active", true)).toBe("active = 1");
+    });
+
+    it("evaluates false using = 0", () => {
+      expect(mssqlDialect.evalBoolean("active", false)).toBe("active = 0");
+    });
+  });
+
+  describe("selectStarLimit", () => {
+    it("generates SELECT TOP instead of LIMIT", () => {
+      expect(mssqlDialect.selectStarLimit("users", 10)).toBe(
+        "SELECT TOP 10 * FROM users"
+      );
+    });
+  });
+
+  describe("extractJSONField", () => {
+    it("extracts string field with JSON_VALUE", () => {
+      expect(
+        mssqlDialect.extractJSONField("json_col", "user.name", false)
+      ).toBe("JSON_VALUE(json_col, '$.user.name')");
+    });
+
+    it("extracts numeric field with FLOAT cast", () => {
+      expect(mssqlDialect.extractJSONField("json_col", "user.age", true)).toBe(
+        "CAST(JSON_VALUE(json_col, '$.user.age') as FLOAT)"
+      );
+    });
+  });
+
+  describe("HLL functions", () => {
+    it("does not support HLL", () => {
+      expect(mssqlDialect.hasCountDistinctHLL()).toBe(false);
+    });
+
+    it("throws error for hllAggregate", () => {
+      expect(() => mssqlDialect.hllAggregate("user_id")).toThrow(
+        "MSSQL does not support HyperLogLog"
+      );
+    });
+
+    it("throws error for hllReaggregate", () => {
+      expect(() => mssqlDialect.hllReaggregate("hll_col")).toThrow(
+        "MSSQL does not support HyperLogLog"
+      );
+    });
+
+    it("throws error for hllCardinality", () => {
+      expect(() => mssqlDialect.hllCardinality("hll_col")).toThrow(
+        "MSSQL does not support HyperLogLog"
+      );
+    });
+  });
+
+  describe("Quantile functions", () => {
+    it("has efficient percentile", () => {
+      expect(mssqlDialect.hasEfficientPercentile()).toBe(true);
+    });
+
+    it("has quantile testing", () => {
+      expect(mssqlDialect.hasQuantileTesting()).toBe(true);
+    });
+
+    it("generates APPROX_PERCENTILE_CONT for numeric quantile", () => {
+      expect(mssqlDialect.approxQuantile("value", 0.5)).toBe(
+        "APPROX_PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY value)"
+      );
+    });
+
+    it("generates APPROX_PERCENTILE_CONT for string quantile expression", () => {
+      expect(mssqlDialect.approxQuantile("value", "q")).toBe(
+        "APPROX_PERCENTILE_CONT(q) WITHIN GROUP (ORDER BY value)"
+      );
+    });
+  });
+
+  describe("Type guards", () => {
+    it("hasHllSupport returns false for MSSQL", () => {
+      expect(hasHllSupport(mssqlDialect)).toBe(false);
+    });
+
+    it("hasQuantileSupport returns true for MSSQL", () => {
+      expect(hasQuantileSupport(mssqlDialect)).toBe(true);
+    });
+  });
+});

--- a/packages/back-end/test/integrations/sql-dialects/mysql-dialect.test.ts
+++ b/packages/back-end/test/integrations/sql-dialects/mysql-dialect.test.ts
@@ -1,0 +1,192 @@
+import {
+  mysqlDialect,
+  hasHllSupport,
+  hasQuantileSupport,
+} from "../../../src/integrations/sql-dialects";
+
+describe("MySQL Dialect", () => {
+  describe("formatDialect", () => {
+    it("returns mysql", () => {
+      expect(mysqlDialect.formatDialect).toBe("mysql");
+    });
+  });
+
+  describe("toTimestamp", () => {
+    it("formats date without milliseconds (inherited from base)", () => {
+      const date = new Date("2023-01-15T12:30:45.123Z");
+      expect(mysqlDialect.toTimestamp(date)).toBe("'2023-01-15 12:30:45'");
+    });
+  });
+
+  describe("addHours", () => {
+    it("returns column unchanged when hours is 0", () => {
+      expect(mysqlDialect.addHours("timestamp", 0)).toBe("timestamp");
+    });
+
+    it("adds positive hours using DATE_ADD", () => {
+      expect(mysqlDialect.addHours("timestamp", 24)).toBe(
+        "DATE_ADD(timestamp, INTERVAL 24 HOUR)"
+      );
+    });
+
+    it("subtracts negative hours using DATE_SUB", () => {
+      expect(mysqlDialect.addHours("timestamp", -12)).toBe(
+        "DATE_SUB(timestamp, INTERVAL 12 HOUR)"
+      );
+    });
+
+    it("uses minutes for fractional hours", () => {
+      expect(mysqlDialect.addHours("timestamp", 1.5)).toBe(
+        "DATE_ADD(timestamp, INTERVAL 90 MINUTE)"
+      );
+    });
+  });
+
+  describe("addTime", () => {
+    it("adds hours with DATE_ADD", () => {
+      expect(mysqlDialect.addTime("col", "hour", "+", 5)).toBe(
+        "DATE_ADD(col, INTERVAL 5 HOUR)"
+      );
+    });
+
+    it("subtracts minutes with DATE_SUB", () => {
+      expect(mysqlDialect.addTime("col", "minute", "-", 30)).toBe(
+        "DATE_SUB(col, INTERVAL 30 MINUTE)"
+      );
+    });
+  });
+
+  describe("dateTrunc", () => {
+    it("truncates to day using DATE()", () => {
+      expect(mysqlDialect.dateTrunc("timestamp")).toBe("DATE(timestamp)");
+    });
+  });
+
+  describe("dateDiff", () => {
+    it("uses DATEDIFF with reversed order (end, start)", () => {
+      expect(mysqlDialect.dateDiff("start_date", "end_date")).toBe(
+        "DATEDIFF(end_date, start_date)"
+      );
+    });
+  });
+
+  describe("formatDate", () => {
+    it("formats date using DATE_FORMAT", () => {
+      expect(mysqlDialect.formatDate("date_col")).toBe(
+        'DATE_FORMAT(date_col, "%Y-%m-%d")'
+      );
+    });
+  });
+
+  describe("formatDateTimeString", () => {
+    it("formats datetime using DATE_FORMAT", () => {
+      expect(mysqlDialect.formatDateTimeString("datetime_col")).toBe(
+        'DATE_FORMAT(datetime_col, "%Y-%m-%d %H:%i:%S")'
+      );
+    });
+  });
+
+  describe("castToString", () => {
+    it("casts using char type", () => {
+      expect(mysqlDialect.castToString("numeric_col")).toBe(
+        "cast(numeric_col as char)"
+      );
+    });
+  });
+
+  describe("ensureFloat", () => {
+    it("casts to DOUBLE", () => {
+      expect(mysqlDialect.ensureFloat("int_col")).toBe(
+        "CAST(int_col AS DOUBLE)"
+      );
+    });
+  });
+
+  describe("escapeStringLiteral", () => {
+    it("escapes single quotes by doubling (inherited from base)", () => {
+      expect(mysqlDialect.escapeStringLiteral("it's")).toBe("it''s");
+    });
+  });
+
+  describe("ifElse", () => {
+    it("generates CASE WHEN expression (inherited from base)", () => {
+      expect(mysqlDialect.ifElse("x > 0", "1", "0")).toBe(
+        "(CASE WHEN x > 0 THEN 1 ELSE 0 END)"
+      );
+    });
+  });
+
+  describe("selectStarLimit", () => {
+    it("generates SELECT with LIMIT", () => {
+      expect(mysqlDialect.selectStarLimit("users", 10)).toBe(
+        "SELECT * FROM users LIMIT 10"
+      );
+    });
+  });
+
+  describe("extractJSONField", () => {
+    it("extracts string field with JSON_EXTRACT", () => {
+      expect(
+        mysqlDialect.extractJSONField("json_col", "user.name", false)
+      ).toBe("JSON_EXTRACT(json_col, '$.user.name')");
+    });
+
+    it("extracts numeric field with DOUBLE cast", () => {
+      expect(mysqlDialect.extractJSONField("json_col", "user.age", true)).toBe(
+        "CAST(JSON_EXTRACT(json_col, '$.user.age') AS DOUBLE)"
+      );
+    });
+  });
+
+  describe("HLL functions", () => {
+    it("does not support HLL", () => {
+      expect(mysqlDialect.hasCountDistinctHLL()).toBe(false);
+    });
+
+    it("throws error for hllAggregate", () => {
+      expect(() => mysqlDialect.hllAggregate("user_id")).toThrow(
+        "MySQL does not support HyperLogLog"
+      );
+    });
+
+    it("throws error for hllReaggregate", () => {
+      expect(() => mysqlDialect.hllReaggregate("hll_col")).toThrow(
+        "MySQL does not support HyperLogLog"
+      );
+    });
+
+    it("throws error for hllCardinality", () => {
+      expect(() => mysqlDialect.hllCardinality("hll_col")).toThrow(
+        "MySQL does not support HyperLogLog"
+      );
+    });
+  });
+
+  describe("Quantile functions", () => {
+    it("does not have efficient percentile", () => {
+      expect(mysqlDialect.hasEfficientPercentile()).toBe(false);
+    });
+
+    it("does not have quantile testing", () => {
+      expect(mysqlDialect.hasQuantileTesting()).toBe(false);
+    });
+
+    it("throws error for approxQuantile", () => {
+      expect(() => mysqlDialect.approxQuantile("value", 0.5)).toThrow(
+        "MySQL does not have a built-in approximate percentile function"
+      );
+    });
+  });
+
+  describe("Type guards", () => {
+    it("hasHllSupport returns false for MySQL", () => {
+      expect(hasHllSupport(mysqlDialect)).toBe(false);
+    });
+
+    it("hasQuantileSupport returns true for MySQL (methods exist but throw)", () => {
+      // The type guard checks for method presence, not whether they work
+      // MySQL has the methods but they throw when called
+      expect(hasQuantileSupport(mysqlDialect)).toBe(true);
+    });
+  });
+});

--- a/packages/back-end/test/integrations/sql-dialects/postgres-dialect.test.ts
+++ b/packages/back-end/test/integrations/sql-dialects/postgres-dialect.test.ts
@@ -1,0 +1,220 @@
+import {
+  postgresDialect,
+  hasHllSupport,
+  hasQuantileSupport,
+} from "../../../src/integrations/sql-dialects";
+
+describe("PostgreSQL Dialect", () => {
+  describe("formatDialect", () => {
+    it("returns postgresql", () => {
+      expect(postgresDialect.formatDialect).toBe("postgresql");
+    });
+  });
+
+  describe("toTimestamp", () => {
+    it("formats date without milliseconds (inherited from base)", () => {
+      const date = new Date("2023-01-15T12:30:45.123Z");
+      expect(postgresDialect.toTimestamp(date)).toBe("'2023-01-15 12:30:45'");
+    });
+  });
+
+  describe("addHours", () => {
+    it("returns column unchanged when hours is 0", () => {
+      expect(postgresDialect.addHours("timestamp", 0)).toBe("timestamp");
+    });
+
+    it("adds positive hours using INTERVAL syntax", () => {
+      expect(postgresDialect.addHours("timestamp", 24)).toBe(
+        "timestamp + INTERVAL '24 hours'"
+      );
+    });
+
+    it("subtracts negative hours", () => {
+      expect(postgresDialect.addHours("timestamp", -12)).toBe(
+        "timestamp - INTERVAL '12 hours'"
+      );
+    });
+  });
+
+  describe("addTime", () => {
+    it("adds hours with INTERVAL syntax", () => {
+      expect(postgresDialect.addTime("col", "hour", "+", 5)).toBe(
+        "col + INTERVAL '5 hours'"
+      );
+    });
+
+    it("subtracts minutes with INTERVAL syntax", () => {
+      expect(postgresDialect.addTime("col", "minute", "-", 30)).toBe(
+        "col - INTERVAL '30 minutes'"
+      );
+    });
+  });
+
+  describe("dateTrunc", () => {
+    it("truncates to day using date_trunc", () => {
+      expect(postgresDialect.dateTrunc("timestamp")).toBe(
+        "date_trunc('day', timestamp)"
+      );
+    });
+  });
+
+  describe("dateDiff", () => {
+    it("calculates difference using subtraction with ::DATE cast", () => {
+      expect(postgresDialect.dateDiff("start_date", "end_date")).toBe(
+        "end_date::DATE - start_date::DATE"
+      );
+    });
+  });
+
+  describe("formatDate", () => {
+    it("formats date with to_char YYYY-MM-DD", () => {
+      expect(postgresDialect.formatDate("date_col")).toBe(
+        "to_char(date_col, 'YYYY-MM-DD')"
+      );
+    });
+  });
+
+  describe("formatDateTimeString", () => {
+    it("formats datetime with to_char including milliseconds", () => {
+      expect(postgresDialect.formatDateTimeString("datetime_col")).toBe(
+        "to_char(datetime_col, 'YYYY-MM-DD HH24:MI:SS.MS')"
+      );
+    });
+  });
+
+  describe("castToString", () => {
+    it("casts using varchar (inherited from base)", () => {
+      expect(postgresDialect.castToString("numeric_col")).toBe(
+        "cast(numeric_col as varchar)"
+      );
+    });
+  });
+
+  describe("ensureFloat", () => {
+    it("casts using :: syntax", () => {
+      expect(postgresDialect.ensureFloat("int_col")).toBe("int_col::float");
+    });
+  });
+
+  describe("escapeStringLiteral", () => {
+    it("escapes single quotes by doubling", () => {
+      expect(postgresDialect.escapeStringLiteral("it's")).toBe("it''s");
+    });
+  });
+
+  describe("ifElse", () => {
+    it("generates CASE WHEN expression", () => {
+      expect(postgresDialect.ifElse("x > 0", "1", "0")).toBe(
+        "(CASE WHEN x > 0 THEN 1 ELSE 0 END)"
+      );
+    });
+  });
+
+  describe("evalBoolean", () => {
+    it("evaluates true", () => {
+      expect(postgresDialect.evalBoolean("active", true)).toBe(
+        "active IS TRUE"
+      );
+    });
+
+    it("evaluates false", () => {
+      expect(postgresDialect.evalBoolean("active", false)).toBe(
+        "active IS FALSE"
+      );
+    });
+  });
+
+  describe("selectStarLimit", () => {
+    it("generates SELECT with LIMIT", () => {
+      expect(postgresDialect.selectStarLimit("users", 10)).toBe(
+        "SELECT * FROM users LIMIT 10"
+      );
+    });
+  });
+
+  describe("extractJSONField", () => {
+    it("extracts string field with JSON_EXTRACT_PATH_TEXT", () => {
+      expect(
+        postgresDialect.extractJSONField("json_col", "user.name", false)
+      ).toBe("JSON_EXTRACT_PATH_TEXT(json_col::json, 'user', 'name')");
+    });
+
+    it("extracts numeric field with float cast", () => {
+      expect(
+        postgresDialect.extractJSONField("json_col", "user.age", true)
+      ).toBe("JSON_EXTRACT_PATH_TEXT(json_col::json, 'user', 'age')::float");
+    });
+
+    it("handles single-level paths", () => {
+      expect(postgresDialect.extractJSONField("json_col", "name", false)).toBe(
+        "JSON_EXTRACT_PATH_TEXT(json_col::json, 'name')"
+      );
+    });
+  });
+
+  describe("getDataType", () => {
+    it("maps string to VARCHAR (inherited from base)", () => {
+      expect(postgresDialect.getDataType("string")).toBe("VARCHAR");
+    });
+
+    it("maps float to FLOAT (inherited from base)", () => {
+      expect(postgresDialect.getDataType("float")).toBe("FLOAT");
+    });
+  });
+
+  describe("HLL functions", () => {
+    it("does not support HLL", () => {
+      expect(postgresDialect.hasCountDistinctHLL()).toBe(false);
+    });
+
+    it("throws error for hllAggregate", () => {
+      expect(() => postgresDialect.hllAggregate("user_id")).toThrow(
+        "PostgreSQL does not support HyperLogLog natively"
+      );
+    });
+
+    it("throws error for hllReaggregate", () => {
+      expect(() => postgresDialect.hllReaggregate("hll_col")).toThrow(
+        "PostgreSQL does not support HyperLogLog natively"
+      );
+    });
+
+    it("throws error for hllCardinality", () => {
+      expect(() => postgresDialect.hllCardinality("hll_col")).toThrow(
+        "PostgreSQL does not support HyperLogLog natively"
+      );
+    });
+  });
+
+  describe("Quantile functions", () => {
+    it("has efficient percentile", () => {
+      expect(postgresDialect.hasEfficientPercentile()).toBe(true);
+    });
+
+    it("has quantile testing", () => {
+      expect(postgresDialect.hasQuantileTesting()).toBe(true);
+    });
+
+    it("generates PERCENTILE_CONT for numeric quantile", () => {
+      expect(postgresDialect.approxQuantile("value", 0.5)).toBe(
+        "PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY value)"
+      );
+    });
+
+    it("generates PERCENTILE_CONT for string quantile expression", () => {
+      expect(postgresDialect.approxQuantile("value", "q")).toBe(
+        "PERCENTILE_CONT(q) WITHIN GROUP (ORDER BY value)"
+      );
+    });
+  });
+
+  describe("Type guards", () => {
+    it("hasHllSupport returns false for PostgreSQL", () => {
+      expect(hasHllSupport(postgresDialect)).toBe(false);
+    });
+
+    it("hasQuantileSupport returns true for PostgreSQL", () => {
+      expect(hasQuantileSupport(postgresDialect)).toBe(true);
+    });
+  });
+});

--- a/packages/back-end/test/integrations/sql-dialects/presto-dialect.test.ts
+++ b/packages/back-end/test/integrations/sql-dialects/presto-dialect.test.ts
@@ -1,0 +1,150 @@
+import {
+  prestoDialect,
+  hasHllSupport,
+  hasQuantileSupport,
+} from "../../../src/integrations/sql-dialects";
+
+describe("Presto Dialect", () => {
+  describe("formatDialect", () => {
+    it("returns trino", () => {
+      expect(prestoDialect.formatDialect).toBe("trino");
+    });
+  });
+
+  describe("toTimestamp", () => {
+    it("formats date using from_iso8601_timestamp", () => {
+      const date = new Date("2023-01-15T12:30:45.123Z");
+      expect(prestoDialect.toTimestamp(date)).toBe(
+        "from_iso8601_timestamp('2023-01-15T12:30:45.123Z')"
+      );
+    });
+  });
+
+  describe("addHours", () => {
+    it("returns column unchanged when hours is 0", () => {
+      expect(prestoDialect.addHours("timestamp", 0)).toBe("timestamp");
+    });
+
+    it("adds positive hours using INTERVAL syntax without s", () => {
+      expect(prestoDialect.addHours("timestamp", 24)).toBe(
+        "timestamp + INTERVAL '24' hour"
+      );
+    });
+  });
+
+  describe("addTime", () => {
+    it("adds hours with INTERVAL syntax (no s on unit)", () => {
+      expect(prestoDialect.addTime("col", "hour", "+", 5)).toBe(
+        "col + INTERVAL '5' hour"
+      );
+    });
+
+    it("subtracts minutes with INTERVAL syntax", () => {
+      expect(prestoDialect.addTime("col", "minute", "-", 30)).toBe(
+        "col - INTERVAL '30' minute"
+      );
+    });
+  });
+
+  describe("dateTrunc", () => {
+    it("truncates to day using date_trunc (inherited from base)", () => {
+      expect(prestoDialect.dateTrunc("timestamp")).toBe(
+        "date_trunc('day', timestamp)"
+      );
+    });
+  });
+
+  describe("dateDiff", () => {
+    it("uses date_diff function with day unit", () => {
+      expect(prestoDialect.dateDiff("start_date", "end_date")).toBe(
+        "date_diff('day', start_date, end_date)"
+      );
+    });
+  });
+
+  describe("formatDate", () => {
+    it("formats date using to_iso8601 and substr", () => {
+      expect(prestoDialect.formatDate("date_col")).toBe(
+        "substr(to_iso8601(date_col),1,10)"
+      );
+    });
+  });
+
+  describe("formatDateTimeString", () => {
+    it("formats datetime using to_iso8601", () => {
+      expect(prestoDialect.formatDateTimeString("datetime_col")).toBe(
+        "to_iso8601(datetime_col)"
+      );
+    });
+  });
+
+  describe("ensureFloat", () => {
+    it("casts to DOUBLE", () => {
+      expect(prestoDialect.ensureFloat("int_col")).toBe(
+        "CAST(int_col AS DOUBLE)"
+      );
+    });
+  });
+
+  describe("selectStarLimit", () => {
+    it("generates SELECT with LIMIT", () => {
+      expect(prestoDialect.selectStarLimit("users", 10)).toBe(
+        "SELECT * FROM users LIMIT 10"
+      );
+    });
+  });
+
+  describe("HLL functions", () => {
+    it("supports HLL", () => {
+      expect(prestoDialect.hasCountDistinctHLL()).toBe(true);
+    });
+
+    it("aggregates with APPROX_SET", () => {
+      expect(prestoDialect.hllAggregate("user_id")).toBe("APPROX_SET(user_id)");
+    });
+
+    it("reaggregates with MERGE and HyperLogLog cast", () => {
+      expect(prestoDialect.hllReaggregate("hll_col")).toBe(
+        "MERGE(CAST(hll_col AS HyperLogLog))"
+      );
+    });
+
+    it("extracts cardinality with CARDINALITY", () => {
+      expect(prestoDialect.hllCardinality("hll_col")).toBe(
+        "CARDINALITY(hll_col)"
+      );
+    });
+
+    it("casts to HLL data type (HyperLogLog)", () => {
+      expect(prestoDialect.castToHllDataType("col")).toBe(
+        "CAST(col AS HyperLogLog)"
+      );
+    });
+  });
+
+  describe("Quantile functions", () => {
+    it("has efficient percentile", () => {
+      expect(prestoDialect.hasEfficientPercentile()).toBe(true);
+    });
+
+    it("has quantile testing", () => {
+      expect(prestoDialect.hasQuantileTesting()).toBe(true);
+    });
+
+    it("generates APPROX_PERCENTILE for numeric quantile", () => {
+      expect(prestoDialect.approxQuantile("value", 0.5)).toBe(
+        "APPROX_PERCENTILE(value, 0.5)"
+      );
+    });
+  });
+
+  describe("Type guards", () => {
+    it("hasHllSupport returns true for Presto", () => {
+      expect(hasHllSupport(prestoDialect)).toBe(true);
+    });
+
+    it("hasQuantileSupport returns true for Presto", () => {
+      expect(hasQuantileSupport(prestoDialect)).toBe(true);
+    });
+  });
+});

--- a/packages/back-end/test/integrations/sql-dialects/redshift-dialect.test.ts
+++ b/packages/back-end/test/integrations/sql-dialects/redshift-dialect.test.ts
@@ -1,0 +1,180 @@
+import {
+  redshiftDialect,
+  hasHllSupport,
+  hasQuantileSupport,
+} from "../../../src/integrations/sql-dialects";
+
+describe("Redshift Dialect", () => {
+  describe("formatDialect", () => {
+    it("returns redshift", () => {
+      expect(redshiftDialect.formatDialect).toBe("redshift");
+    });
+  });
+
+  describe("toTimestamp", () => {
+    it("formats date without milliseconds (inherited from base)", () => {
+      const date = new Date("2023-01-15T12:30:45.123Z");
+      expect(redshiftDialect.toTimestamp(date)).toBe("'2023-01-15 12:30:45'");
+    });
+  });
+
+  describe("addHours", () => {
+    it("returns column unchanged when hours is 0", () => {
+      expect(redshiftDialect.addHours("timestamp", 0)).toBe("timestamp");
+    });
+
+    it("adds positive hours using INTERVAL syntax", () => {
+      expect(redshiftDialect.addHours("timestamp", 24)).toBe(
+        "timestamp + INTERVAL '24 hours'"
+      );
+    });
+  });
+
+  describe("addTime", () => {
+    it("adds hours with INTERVAL syntax", () => {
+      expect(redshiftDialect.addTime("col", "hour", "+", 5)).toBe(
+        "col + INTERVAL '5 hours'"
+      );
+    });
+
+    it("subtracts minutes with INTERVAL syntax", () => {
+      expect(redshiftDialect.addTime("col", "minute", "-", 30)).toBe(
+        "col - INTERVAL '30 minutes'"
+      );
+    });
+  });
+
+  describe("dateTrunc", () => {
+    it("truncates to day using date_trunc", () => {
+      expect(redshiftDialect.dateTrunc("timestamp")).toBe(
+        "date_trunc('day', timestamp)"
+      );
+    });
+  });
+
+  describe("dateDiff", () => {
+    it("uses datediff function (inherited from base)", () => {
+      expect(redshiftDialect.dateDiff("start_date", "end_date")).toBe(
+        "datediff(day, start_date, end_date)"
+      );
+    });
+  });
+
+  describe("formatDate", () => {
+    it("formats date with to_char YYYY-MM-DD", () => {
+      expect(redshiftDialect.formatDate("date_col")).toBe(
+        "to_char(date_col, 'YYYY-MM-DD')"
+      );
+    });
+  });
+
+  describe("formatDateTimeString", () => {
+    it("formats datetime with to_char including milliseconds", () => {
+      expect(redshiftDialect.formatDateTimeString("datetime_col")).toBe(
+        "to_char(datetime_col, 'YYYY-MM-DD HH24:MI:SS.MS')"
+      );
+    });
+  });
+
+  describe("ensureFloat", () => {
+    it("casts using :: syntax", () => {
+      expect(redshiftDialect.ensureFloat("int_col")).toBe("int_col::float");
+    });
+  });
+
+  describe("escapeStringLiteral", () => {
+    it("escapes single quotes by doubling", () => {
+      expect(redshiftDialect.escapeStringLiteral("it's")).toBe("it''s");
+    });
+  });
+
+  describe("selectStarLimit", () => {
+    it("generates SELECT with LIMIT", () => {
+      expect(redshiftDialect.selectStarLimit("users", 10)).toBe(
+        "SELECT * FROM users LIMIT 10"
+      );
+    });
+  });
+
+  describe("extractJSONField", () => {
+    it("extracts string field with JSON_EXTRACT_PATH_TEXT and TRUE", () => {
+      expect(
+        redshiftDialect.extractJSONField("json_col", "user.name", false)
+      ).toBe("JSON_EXTRACT_PATH_TEXT(json_col, 'user', 'name', TRUE)");
+    });
+
+    it("extracts numeric field with float cast", () => {
+      expect(
+        redshiftDialect.extractJSONField("json_col", "user.age", true)
+      ).toBe("JSON_EXTRACT_PATH_TEXT(json_col, 'user', 'age', TRUE)::float");
+    });
+
+    it("handles single-level paths", () => {
+      expect(redshiftDialect.extractJSONField("json_col", "name", false)).toBe(
+        "JSON_EXTRACT_PATH_TEXT(json_col, 'name', TRUE)"
+      );
+    });
+  });
+
+  describe("HLL functions", () => {
+    it("supports HLL", () => {
+      expect(redshiftDialect.hasCountDistinctHLL()).toBe(true);
+    });
+
+    it("aggregates with HLL_CREATE_SKETCH", () => {
+      expect(redshiftDialect.hllAggregate("user_id")).toBe(
+        "HLL_CREATE_SKETCH(user_id)"
+      );
+    });
+
+    it("reaggregates with HLL_COMBINE", () => {
+      expect(redshiftDialect.hllReaggregate("hll_col")).toBe(
+        "HLL_COMBINE(hll_col)"
+      );
+    });
+
+    it("extracts cardinality with HLL_CARDINALITY", () => {
+      expect(redshiftDialect.hllCardinality("hll_col")).toBe(
+        "HLL_CARDINALITY(hll_col)"
+      );
+    });
+
+    it("casts to HLL data type (HLLSKETCH)", () => {
+      expect(redshiftDialect.castToHllDataType("col")).toBe(
+        "CAST(col AS HLLSKETCH)"
+      );
+    });
+  });
+
+  describe("Quantile functions", () => {
+    it("does not have efficient percentile", () => {
+      expect(redshiftDialect.hasEfficientPercentile()).toBe(false);
+    });
+
+    it("has quantile testing", () => {
+      expect(redshiftDialect.hasQuantileTesting()).toBe(true);
+    });
+
+    it("generates PERCENTILE_CONT for numeric quantile", () => {
+      expect(redshiftDialect.approxQuantile("value", 0.5)).toBe(
+        "PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY value)"
+      );
+    });
+
+    it("generates PERCENTILE_CONT for string quantile expression", () => {
+      expect(redshiftDialect.approxQuantile("value", "q")).toBe(
+        "PERCENTILE_CONT(q) WITHIN GROUP (ORDER BY value)"
+      );
+    });
+  });
+
+  describe("Type guards", () => {
+    it("hasHllSupport returns true for Redshift", () => {
+      expect(hasHllSupport(redshiftDialect)).toBe(true);
+    });
+
+    it("hasQuantileSupport returns true for Redshift", () => {
+      expect(hasQuantileSupport(redshiftDialect)).toBe(true);
+    });
+  });
+});

--- a/packages/back-end/test/integrations/sql-dialects/snowflake-dialect.test.ts
+++ b/packages/back-end/test/integrations/sql-dialects/snowflake-dialect.test.ts
@@ -1,0 +1,274 @@
+import {
+  snowflakeDialect,
+  hasHllSupport,
+  hasQuantileSupport,
+} from "../../../src/integrations/sql-dialects";
+
+describe("Snowflake Dialect", () => {
+  describe("formatDialect", () => {
+    it("returns snowflake", () => {
+      expect(snowflakeDialect.formatDialect).toBe("snowflake");
+    });
+  });
+
+  describe("toTimestamp", () => {
+    it("formats date without milliseconds (inherited from base)", () => {
+      const date = new Date("2023-01-15T12:30:45.123Z");
+      expect(snowflakeDialect.toTimestamp(date)).toBe("'2023-01-15 12:30:45'");
+    });
+
+    it("handles midnight correctly", () => {
+      const date = new Date("2023-01-01T00:00:00Z");
+      expect(snowflakeDialect.toTimestamp(date)).toBe("'2023-01-01 00:00:00'");
+    });
+  });
+
+  describe("toTimestampWithMs", () => {
+    it("formats date with milliseconds (inherited from base)", () => {
+      const date = new Date("2023-01-15T12:30:45.123Z");
+      expect(snowflakeDialect.toTimestampWithMs(date)).toBe(
+        "'2023-01-15 12:30:45.123'"
+      );
+    });
+  });
+
+  describe("addHours", () => {
+    it("returns column unchanged when hours is 0", () => {
+      expect(snowflakeDialect.addHours("timestamp", 0)).toBe("timestamp");
+    });
+
+    it("adds positive hours using INTERVAL syntax", () => {
+      expect(snowflakeDialect.addHours("timestamp", 24)).toBe(
+        "timestamp + INTERVAL '24 hours'"
+      );
+    });
+
+    it("subtracts negative hours", () => {
+      expect(snowflakeDialect.addHours("timestamp", -12)).toBe(
+        "timestamp - INTERVAL '12 hours'"
+      );
+    });
+
+    it("uses minutes for fractional hours", () => {
+      expect(snowflakeDialect.addHours("timestamp", 1.5)).toBe(
+        "timestamp + INTERVAL '90 minutes'"
+      );
+    });
+  });
+
+  describe("addTime", () => {
+    it("adds hours with INTERVAL syntax", () => {
+      expect(snowflakeDialect.addTime("col", "hour", "+", 5)).toBe(
+        "col + INTERVAL '5 hours'"
+      );
+    });
+
+    it("subtracts minutes with INTERVAL syntax", () => {
+      expect(snowflakeDialect.addTime("col", "minute", "-", 30)).toBe(
+        "col - INTERVAL '30 minutes'"
+      );
+    });
+  });
+
+  describe("dateTrunc", () => {
+    it("truncates to day using date_trunc", () => {
+      expect(snowflakeDialect.dateTrunc("timestamp")).toBe(
+        "date_trunc('day', timestamp)"
+      );
+    });
+  });
+
+  describe("dateDiff", () => {
+    it("calculates difference in days", () => {
+      expect(snowflakeDialect.dateDiff("start_date", "end_date")).toBe(
+        "datediff(day, start_date, end_date)"
+      );
+    });
+  });
+
+  describe("formatDate", () => {
+    it("formats date with TO_VARCHAR YYYY-MM-DD", () => {
+      expect(snowflakeDialect.formatDate("date_col")).toBe(
+        "TO_VARCHAR(date_col, 'YYYY-MM-DD')"
+      );
+    });
+  });
+
+  describe("formatDateTimeString", () => {
+    it("formats datetime with TO_VARCHAR including milliseconds", () => {
+      expect(snowflakeDialect.formatDateTimeString("datetime_col")).toBe(
+        "TO_VARCHAR(datetime_col, 'YYYY-MM-DD HH24:MI:SS.MS')"
+      );
+    });
+  });
+
+  describe("castToString", () => {
+    it("casts using TO_VARCHAR", () => {
+      expect(snowflakeDialect.castToString("numeric_col")).toBe(
+        "TO_VARCHAR(numeric_col)"
+      );
+    });
+  });
+
+  describe("ensureFloat", () => {
+    it("casts to DOUBLE", () => {
+      expect(snowflakeDialect.ensureFloat("int_col")).toBe(
+        "CAST(int_col AS DOUBLE)"
+      );
+    });
+  });
+
+  describe("castUserDateCol", () => {
+    it("returns column unchanged (inherited from base)", () => {
+      expect(snowflakeDialect.castUserDateCol("user_date")).toBe("user_date");
+    });
+  });
+
+  describe("escapeStringLiteral", () => {
+    it("escapes single quotes by doubling (inherited from base)", () => {
+      expect(snowflakeDialect.escapeStringLiteral("it's")).toBe("it''s");
+    });
+
+    it("handles strings without special characters", () => {
+      expect(snowflakeDialect.escapeStringLiteral("hello world")).toBe(
+        "hello world"
+      );
+    });
+  });
+
+  describe("ifElse", () => {
+    it("generates CASE WHEN expression", () => {
+      expect(snowflakeDialect.ifElse("x > 0", "1", "0")).toBe(
+        "(CASE WHEN x > 0 THEN 1 ELSE 0 END)"
+      );
+    });
+  });
+
+  describe("evalBoolean", () => {
+    it("evaluates true", () => {
+      expect(snowflakeDialect.evalBoolean("active", true)).toBe(
+        "active IS TRUE"
+      );
+    });
+
+    it("evaluates false", () => {
+      expect(snowflakeDialect.evalBoolean("active", false)).toBe(
+        "active IS FALSE"
+      );
+    });
+  });
+
+  describe("selectStarLimit", () => {
+    it("generates SELECT with LIMIT", () => {
+      expect(snowflakeDialect.selectStarLimit("users", 10)).toBe(
+        "SELECT * FROM users LIMIT 10"
+      );
+    });
+  });
+
+  describe("extractJSONField", () => {
+    it("extracts string field with PARSE_JSON", () => {
+      expect(
+        snowflakeDialect.extractJSONField("json_col", "user.name", false)
+      ).toBe("PARSE_JSON(json_col):user.name::string");
+    });
+
+    it("extracts numeric field with float cast", () => {
+      expect(
+        snowflakeDialect.extractJSONField("json_col", "user.age", true)
+      ).toBe("PARSE_JSON(json_col):user.age::float");
+    });
+  });
+
+  describe("getDataType", () => {
+    it("maps string to VARCHAR", () => {
+      expect(snowflakeDialect.getDataType("string")).toBe("VARCHAR");
+    });
+
+    it("maps integer to INTEGER", () => {
+      expect(snowflakeDialect.getDataType("integer")).toBe("INTEGER");
+    });
+
+    it("maps float to DOUBLE", () => {
+      expect(snowflakeDialect.getDataType("float")).toBe("DOUBLE");
+    });
+
+    it("maps boolean to BOOLEAN", () => {
+      expect(snowflakeDialect.getDataType("boolean")).toBe("BOOLEAN");
+    });
+
+    it("maps date to DATE", () => {
+      expect(snowflakeDialect.getDataType("date")).toBe("DATE");
+    });
+
+    it("maps timestamp to TIMESTAMP", () => {
+      expect(snowflakeDialect.getDataType("timestamp")).toBe("TIMESTAMP");
+    });
+
+    it("maps hll to BINARY", () => {
+      expect(snowflakeDialect.getDataType("hll")).toBe("BINARY");
+    });
+  });
+
+  describe("HLL functions", () => {
+    it("supports HLL", () => {
+      expect(snowflakeDialect.hasCountDistinctHLL()).toBe(true);
+    });
+
+    it("aggregates with HLL_ACCUMULATE", () => {
+      expect(snowflakeDialect.hllAggregate("user_id")).toBe(
+        "HLL_ACCUMULATE(user_id)"
+      );
+    });
+
+    it("reaggregates with HLL_COMBINE", () => {
+      expect(snowflakeDialect.hllReaggregate("hll_col")).toBe(
+        "HLL_COMBINE(hll_col)"
+      );
+    });
+
+    it("extracts cardinality with HLL_ESTIMATE", () => {
+      expect(snowflakeDialect.hllCardinality("hll_col")).toBe(
+        "HLL_ESTIMATE(hll_col)"
+      );
+    });
+
+    it("casts to HLL data type (BINARY)", () => {
+      expect(snowflakeDialect.castToHllDataType("col")).toBe(
+        "CAST(col AS BINARY)"
+      );
+    });
+  });
+
+  describe("Quantile functions", () => {
+    it("has efficient percentile", () => {
+      expect(snowflakeDialect.hasEfficientPercentile()).toBe(true);
+    });
+
+    it("has quantile testing", () => {
+      expect(snowflakeDialect.hasQuantileTesting()).toBe(true);
+    });
+
+    it("generates APPROX_PERCENTILE for numeric quantile", () => {
+      expect(snowflakeDialect.approxQuantile("value", 0.5)).toBe(
+        "APPROX_PERCENTILE(value, 0.5)"
+      );
+    });
+
+    it("generates APPROX_PERCENTILE for string quantile expression", () => {
+      expect(snowflakeDialect.approxQuantile("value", "q")).toBe(
+        "APPROX_PERCENTILE(value, q)"
+      );
+    });
+  });
+
+  describe("Type guards", () => {
+    it("hasHllSupport returns true for Snowflake", () => {
+      expect(hasHllSupport(snowflakeDialect)).toBe(true);
+    });
+
+    it("hasQuantileSupport returns true for Snowflake", () => {
+      expect(hasQuantileSupport(snowflakeDialect)).toBe(true);
+    });
+  });
+});

--- a/packages/back-end/test/jest.setup.ts
+++ b/packages/back-end/test/jest.setup.ts
@@ -1,3 +1,9 @@
+// Mock kerberos module to avoid native library issues in tests
+jest.mock("kerberos", () => ({
+  initializeClient: jest.fn(),
+  initializeServer: jest.fn(),
+}));
+
 // Polyfill web streams for Node.js test environment
 import { TransformStream } from "node:stream/web";
 global.TransformStream = TransformStream as typeof globalThis.TransformStream;


### PR DESCRIPTION
### Context
Our team has some changes on top of SqlIntegration.ts. Rebasing these whenever changes are made are by far the most tedious & error-prone parts of bringing in updates. Additionally, general debugging of SQL generation is difficult and time consuming.

This is meant to be a (working) proposal PR to start a discussion about refactoring SqlIntegration to something that's more testable, maintainable, debuggable, and extensible.

### Features and Changes
Extract testable, pure functions from the monolithic SqlIntegration.ts (8,122 lines).

New modules:
- sql-dialects/: Database-specific SQL syntax (11 databases)
- sql-builders/time-window/: Date/time calculation utilities
- sql-builders/cte-builders/: CTE generation (identities, segments, metrics, statistics)
- sql-builders/query-generators/: Full query assembly functions

Key improvements:
- 642 new tests with parity verification against original implementations
- Pure functions that can be unit tested in isolation
- Dialect pattern for database-specific SQL without inheritance
- No changes to SqlIntegration.ts - new code runs in parallel. More validation could be done until confidence is built and we're ready to switch over.

This is groundwork for gradually migrating SqlIntegration to use these extracted modules while maintaining backwards compatibility.

### Testing
Tests were created to validate new functions against existing (and unmodified) SqlIntegration.ts functions, giving confidence that new implementations do not break existing functionality.

### Not Yet (Fully) Implemented
- getMetricValueQuery
- getExperimentUnitsQuery (partially - generateDistinctUsersCTE exists but not full implementation)
- getMetricAnalysisQuery (partially - building blocks exist)
- getExperimentFactMetricsQuery (partially - assembleExperimentFactMetricsQuery exists but many internal CTEs not fully implemented)