### PR TITLE
Add decryption_key on the ruby setup code snippet even if it is not set

### DIFF
--- a/packages/front-end/components/SyntaxHighlighting/Snippets/GrowthBookSetupCodeSnippet.tsx
+++ b/packages/front-end/components/SyntaxHighlighting/Snippets/GrowthBookSetupCodeSnippet.tsx
@@ -583,12 +583,8 @@ require 'growthbook'
 # Fetch features from a GrowthBook instance
 # You should cache this in Redis or similar in production
 features_repository = Growthbook::FeatureRepository.new(
-  endpoint: '${featuresEndpoint}'${
-    encryptionKey
-      ? `,
-  decryption_key: '${encryptionKey}'`
-      : ""
-  }
+  endpoint: '${featuresEndpoint}',
+  decryption_key: ${encryptionKey ? `'${encryptionKey}'` : "nil"}
 )
 features = features_repository.fetch
             `.trim()}


### PR DESCRIPTION
### Features and Changes

Add decryption_key on the setup instructions for ruby. Fixes `missing keyword: :decryption_key (ArgumentError)` when running the current code.
This uses the same code on the docs https://docs.growthbook.io/lib/ruby#quick-start

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
<img width="952" height="336" alt="decryption_key_nil" src="https://github.com/user-attachments/assets/36701582-7df7-498d-a94b-bce63e29e9c2" />
