### PR TITLE
fix: Update import assertion syntax for Node.js 22 compatibility

### DIFF
--- a/packages/sdk-js/rollup.config.mjs
+++ b/packages/sdk-js/rollup.config.mjs
@@ -2,7 +2,7 @@ import babel from "@rollup/plugin-babel";
 import resolve from "@rollup/plugin-node-resolve";
 import { terser } from "rollup-plugin-terser";
 import replace from "@rollup/plugin-replace";
-import packageJson from "./package.json" assert { type: "json" };
+import packageJson from "./package.json" with { type: "json" };
 
 const { version } = packageJson;
 


### PR DESCRIPTION
### Features and Changes

Node 22 removed `assert` syntax and supports `with` instead. So we are updating it to be compatible with Node 22+.
This also works for Node 20 as `with` was already supported and `assert` is deprecated.

### Testing

`pnpm build:deps` runs successfully with node 22.