### PR TITLE
Upgrade fast-xml-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,9 +72,10 @@
       "@growthbook/growthbook": "1.6.2",
       "vite": "^6.0.0",
       "execa": "^5.0.0",
-      "form-data@2": "2.5.5",
-      "form-data@3": "3.0.4",
-      "form-data@4": "4.0.5"
+      "form-data@2": "^2.5.5",
+      "form-data@3": "^3.0.4",
+      "form-data@4": "^4.0.5",
+      "fast-xml-parser@4": "^4.4.1"
     },
     "patchedDependencies": {
       "@types/presto-client@1.0.2": "patches/@types__presto-client@1.0.2.patch",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,10 @@ overrides:
   '@growthbook/growthbook': 1.6.2
   vite: ^6.0.0
   execa: ^5.0.0
-  form-data@2: 2.5.5
-  form-data@3: 3.0.4
-  form-data@4: 4.0.5
+  form-data@2: ^2.5.5
+  form-data@3: ^3.0.4
+  form-data@4: ^4.0.5
+  fast-xml-parser@4: ^4.4.1
 
 patchedDependencies:
   '@ephys/zod-to-ts@2.3.2':
@@ -8834,16 +8835,8 @@ packages:
   fast-text-encoding@1.0.4:
     resolution: {integrity: sha512-x6lDDm/tBAzX9kmsPcZsNbvDs3Zey3+scsxaZElS8xWLgUMAg/oFLeewfUz0mu1CblHhhsu15jGkraldkFh8KQ==}
 
-  fast-xml-parser@4.0.11:
-    resolution: {integrity: sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==}
-    hasBin: true
-
-  fast-xml-parser@4.2.5:
-    resolution: {integrity: sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==}
-    hasBin: true
-
-  fast-xml-parser@4.3.6:
-    resolution: {integrity: sha512-M2SovcRxD4+vC493Uc2GZVcZaj66CCJhWurC4viynVSTvrpErCShNcDz1lAho6n9REQKvL/ll4A4/fw6Y9z8nw==}
+  fast-xml-parser@4.5.3:
+    resolution: {integrity: sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==}
     hasBin: true
 
   fast-xml-parser@5.2.5:
@@ -12860,8 +12853,8 @@ packages:
     resolution: {integrity: sha512-aT2BU9KkizY9SATf14WhhYVv2uOapBWX0OFWF4xvcj1mPaNotlSc2CsxpS4DS46ZueSppmCF5BX1sNYBtwBvfw==}
     engines: {node: '>=12.*'}
 
-  strnum@1.0.5:
-    resolution: {integrity: sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==}
+  strnum@1.1.2:
+    resolution: {integrity: sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==}
 
   strnum@2.1.1:
     resolution: {integrity: sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==}
@@ -14661,7 +14654,7 @@ snapshots:
       '@aws-sdk/util-user-agent-node': 3.212.0
       '@aws-sdk/util-utf8-browser': 3.188.0
       '@aws-sdk/util-utf8-node': 3.208.0
-      fast-xml-parser: 4.0.11
+      fast-xml-parser: 4.5.3
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -14726,7 +14719,7 @@ snapshots:
       '@smithy/signature-v4': 2.3.0
       '@smithy/smithy-client': 2.5.1
       '@smithy/types': 2.12.0
-      fast-xml-parser: 4.2.5
+      fast-xml-parser: 4.5.3
       tslib: 2.8.1
 
   '@aws-sdk/core@3.914.0':
@@ -17348,7 +17341,7 @@ snapshots:
       async-retry: 1.3.3
       duplexify: 4.1.3
       ent: 2.2.0
-      fast-xml-parser: 4.3.6
+      fast-xml-parser: 4.5.3
       gaxios: 6.5.0(encoding@0.1.13)
       google-auth-library: 9.8.0(encoding@0.1.13)
       mime: 3.0.0
@@ -24600,18 +24593,9 @@ snapshots:
 
   fast-text-encoding@1.0.4: {}
 
-  fast-xml-parser@4.0.11:
+  fast-xml-parser@4.5.3:
     dependencies:
-      strnum: 1.0.5
-    optional: true
-
-  fast-xml-parser@4.2.5:
-    dependencies:
-      strnum: 1.0.5
-
-  fast-xml-parser@4.3.6:
-    dependencies:
-      strnum: 1.0.5
+      strnum: 1.1.2
 
   fast-xml-parser@5.2.5:
     dependencies:
@@ -29526,7 +29510,7 @@ snapshots:
       bn.js: 5.2.1
       browser-request: 0.3.3
       expand-tilde: 2.0.2
-      fast-xml-parser: 4.3.6
+      fast-xml-parser: 4.5.3
       fastest-levenshtein: 1.0.16
       generic-pool: 3.9.0
       google-auth-library: 10.4.1
@@ -29823,7 +29807,7 @@ snapshots:
       '@types/node': 22.8.6
       qs: 6.14.0
 
-  strnum@1.0.5: {}
+  strnum@1.1.2: {}
 
   strnum@2.1.1: {}
 


### PR DESCRIPTION
### Features and Changes
There is a security vulnerability in fast-xml-parser:
https://nvd.nist.gov/vuln/detail/cve-2024-41818

It is a very common transitive dependency, so we just override it here.
Based upon https://github.com/NaturalIntelligence/fast-xml-parser/releases there should be no breaking changes within the major version 4. 
