### PR TITLE
fix(metric-group): Add missing owner field to payload

### DIFF
--- a/packages/front-end/components/Metrics/MetricGroupModal.tsx
+++ b/packages/front-end/components/Metrics/MetricGroupModal.tsx
@@ -77,6 +77,7 @@ const MetricGroupModal: FC<{
                 datasource: value.datasource,
                 projects: value.projects,
                 metrics: value.metrics,
+                owner: "",
               }),
             },
           );


### PR DESCRIPTION
### Features and Changes

By default the owner is the person creating the resource and our validation expected an empty string on the back-end.

So we are adding `owner: ""` to keep the same pattern and behavior we have with other resources.