### PR TITLE
fix(sql): fix boolean row filter in snowflake

### DIFF
--- a/packages/back-end/src/integrations/Snowflake.ts
+++ b/packages/back-end/src/integrations/Snowflake.ts
@@ -69,6 +69,10 @@ export default class Snowflake extends SqlIntegration {
   extractJSONField(jsonCol: string, path: string, isNumeric: boolean): string {
     return `PARSE_JSON(${jsonCol}):${path}::${isNumeric ? "float" : "string"}`;
   }
+  evalBoolean(col: string, value: boolean): string {
+    // Snowflake does not support `IS TRUE` / `IS FALSE`
+    return `${col} = ${value ? "true" : "false"}`;
+  }
   getInformationSchemaWhereClause(): string {
     return "table_schema NOT IN ('INFORMATION_SCHEMA')";
   }


### PR DESCRIPTION
### Features and Changes

Snowflake does not like `IS TRUE` type operators, so have to use equality instead. Cursory search says all other engines using base syntax support it.

This fixes bugs with using the fact table row filter `is true`.

- Closes **(add link to issue here)**

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

Row filter works in metric on local dev with sample snowflake data
<img width="1405" height="762" alt="Screenshot 2026-01-23 at 6 34 04 PM" src="https://github.com/user-attachments/assets/02398abb-9f5c-4fe8-92f5-4a3a82900e91" />

<!--
  Please describe how to test these changes.
 -->

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
