### PR TITLE
Batch project lookups in listExperiments API

### DIFF
--- a/packages/back-end/src/api/experiments/listExperiments.ts
+++ b/packages/back-end/src/api/experiments/listExperiments.ts
@@ -3,6 +3,7 @@ import {
   listExperimentsValidator,
 } from "shared/validators";
 import { ListExperimentsResponse } from "shared/types/openapi";
+import { ProjectInterface } from "shared/types/project";
 import { getAllExperiments } from "back-end/src/models/ExperimentModel";
 import { toExperimentApiInterface } from "back-end/src/services/experiments";
 import {
@@ -32,10 +33,24 @@ export const listExperiments = createApiRequestHandler(
     req.query,
   );
 
+  // Batch-load all projects for the filtered experiments to avoid N+1 queries
+  const projectIds = [
+    ...new Set(
+      filtered.map((exp) => exp.project).filter((p): p is string => !!p),
+    ),
+  ];
+  const projects = projectIds.length
+    ? await req.context.models.projects.getByIds(projectIds)
+    : [];
+  const projectMap = new Map<string, ProjectInterface>(
+    projects.map((p) => [p.id, p]),
+  );
+
   const promises = filtered.map((experiment) =>
     toExperimentApiInterface(
       req.context,
       experiment as ExperimentInterfaceExcludingHoldouts,
+      projectMap,
     ),
   );
   const apiExperiments = await Promise.all(promises);

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -1485,13 +1485,17 @@ function getExperimentMetric(
 export async function toExperimentApiInterface(
   context: ReqContext | ApiReqContext,
   experiment: ExperimentInterfaceExcludingHoldouts,
+  projectMap?: Map<string, ProjectInterface>,
 ): Promise<ApiExperiment> {
   const appOrigin = (APP_ORIGIN ?? "").replace(/\/$/, "");
 
   let project: ProjectInterface | null = null;
   const organization = context.org;
   if (experiment.project) {
-    project = await context.models.projects.getById(experiment.project);
+    // Use pre-loaded project from map if available, otherwise fetch individually
+    project =
+      projectMap?.get(experiment.project) ??
+      (await context.models.projects.getById(experiment.project));
   }
   const { settings: scopedSettings } = getScopedSettings({
     organization,

--- a/packages/back-end/test/api/experiments.test.ts
+++ b/packages/back-end/test/api/experiments.test.ts
@@ -59,6 +59,7 @@ describe("experiments API", () => {
         },
         projects: {
           getById: jest.fn().mockResolvedValue(null),
+          getByIds: jest.fn().mockResolvedValue([]),
           ensureProjectsExist: jest.fn().mockResolvedValue(undefined),
         },
         dataSources: {


### PR DESCRIPTION
Avoid N+1 queries by pre-loading all projects for the filtered experiments in a single batch query, then passing the project map to toExperimentApiInterface.

This significantly reduces the number of database queries when listing many experiments, as each experiment previously triggered an individual project lookup. In our case we only have one project, and use the API to list all experiments pretty frequently.