### PR TITLE
docs(react): add Testing section documenting setPolyfills

### DIFF
--- a/docs/docs/lib/react.mdx
+++ b/docs/docs/lib/react.mdx
@@ -1123,6 +1123,110 @@ import { useFeatureIsOn } from "@/src/utils/growthbook"
 const isDarkModeOn = useFeatureIsOn("dark_mode");
 ```
 
+## Testing
+
+When writing unit tests for React components that use GrowthBook, you may need to polyfill certain browser APIs that aren't available in test environments like Jest or Vitest.
+
+### Polyfilling fetch
+
+Test runners like Jest don't provide a native `fetch` implementation. If your tests initialize GrowthBook with `apiHost` and `clientKey` (which triggers network requests), you'll need to either mock `fetch` or provide a polyfill.
+
+#### Jest Setup Example
+
+Create a setup file (e.g., `jest.setup.js`) and configure it in your Jest config:
+
+```js
+// jest.setup.js
+import { setPolyfills } from "@growthbook/growthbook";
+
+// Option 1: Use a mock function
+setPolyfills({
+  fetch: jest.fn(() =>
+    Promise.resolve({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          features: {},
+        }),
+    })
+  ),
+});
+
+// Option 2: Use a real polyfill like cross-fetch
+// import fetch from "cross-fetch";
+// setPolyfills({ fetch });
+```
+
+```js
+// jest.config.js
+module.exports = {
+  setupFilesAfterEnv: ["./jest.setup.js"],
+};
+```
+
+#### Vitest Setup Example
+
+```ts
+// vitest.setup.ts
+import { setPolyfills } from "@growthbook/growthbook";
+import { vi } from "vitest";
+
+setPolyfills({
+  fetch: vi.fn(() =>
+    Promise.resolve({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          features: {},
+        }),
+    })
+  ),
+});
+```
+
+### Resetting Polyfills Between Tests
+
+If you need to customize the mock behavior for specific tests, you can reset the polyfill in `beforeEach` or `afterEach`:
+
+```js
+import { setPolyfills } from "@growthbook/growthbook";
+
+afterEach(() => {
+  // Reset to default mock
+  setPolyfills({ fetch: jest.fn() });
+});
+```
+
+### Testing Without Network Requests
+
+The simplest approach for testing is to bypass network requests entirely by passing features directly:
+
+```tsx
+import { GrowthBook, GrowthBookProvider } from "@growthbook/growthbook-react";
+import { render } from "@testing-library/react";
+
+test("renders with feature flag on", () => {
+  const gb = new GrowthBook();
+  gb.initSync({
+    payload: {
+      features: {
+        "my-feature": { defaultValue: true },
+      },
+    },
+  });
+
+  render(
+    <GrowthBookProvider growthbook={gb}>
+      <MyComponent />
+    </GrowthBookProvider>
+  );
+
+  // Your assertions here
+});
+```
+
+This approach doesn't require any polyfills since no network requests are made.
+
 ## Examples
 
 - [Next.js <ExternalLink />](https://github.com/growthbook/examples/tree/main/next-js)


### PR DESCRIPTION
## Summary
- Adds a new **Testing** section to the React SDK documentation
- Documents how to use `setPolyfills` to mock `fetch` in Jest and Vitest
- Shows the recommended approach of using `initSync` with a payload to avoid network requests entirely

## Context
When writing unit tests for React components that use GrowthBook, users need to polyfill `fetch` because Jest/Vitest don't provide it natively. This wasn't documented anywhere, so users had to look at the source code to figure it out.

Fixes #1690

## Test plan
- [ ] Verify the documentation renders correctly on the docs site
- [ ] Verify code examples are syntactically correct