### PR TITLE
Docs: Fix Claude Code command structure in MCP integration documentation

### DIFF
--- a/docs/docs/integrations/mcp.mdx
+++ b/docs/docs/integrations/mcp.mdx
@@ -240,7 +240,7 @@ In CoPilot Chat, you'll see a tool icon, indicating the server is connected succ
 Claude Code uses command-line commands to add MCP servers. Run the following command in your terminal:
 
 ```bash
-claude mcp add --transport stdio --env GB_API_KEY=YOUR_API_KEY --env GB_API_URL=YOUR_API_URL --env GB_APP_ORIGIN=YOUR_APP_ORIGIN --env GB_EMAIL=YOUR_EMAIL growthbook -- npx -y @growthbook/mcp@latest
+claude mcp add growthbook --transport stdio --env GB_API_KEY=YOUR_API_KEY --env GB_API_URL=YOUR_API_URL --env GB_APP_ORIGIN=YOUR_APP_ORIGIN --env GB_EMAIL=YOUR_EMAIL -- npx -y @growthbook/mcp@latest
 ```
 
 :::tip Command structure


### PR DESCRIPTION
### Features and Changes

The current command for adding Growthbook MCP to Claude Code returns the following error:
```
Invalid environment variable format: growthbook, environment variables should be added as: -e KEY1=value1 -e KEY2=value2
```
This commit fixes that by putting the MCP name argument in the correct position.

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

- Try running the command from the current docs and confirm it fails:
   ```bash
   claude mcp add --transport stdio --env GB_API_KEY=YOUR_API_KEY --env GB_API_URL=YOUR_API_URL --env GB_APP_ORIGIN=YOUR_APP_ORIGIN --env GB_EMAIL=YOUR_EMAIL growthbook -- npx -y @growthbook/mcp@latest
   ```
- Try running the updated command from this PR and confirm it works:
   ```bash
   claude mcp add growthbook --transport stdio --env GB_API_KEY=YOUR_API_KEY --env GB_API_URL=YOUR_API_URL --env GB_APP_ORIGIN=YOUR_APP_ORIGIN --env GB_EMAIL=YOUR_EMAIL -- npx -y @growthbook/mcp@latest
   ```

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
