### PR TITLE
fix s3 uploading with regional urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,11 @@
       "@octokit/request-error@5": "^5.1.1",
       "prismjs@1": "^1.30.0"
     },
+    "peerDependencyRules": {
+      "ignoreMissing": [
+        "react-native"
+      ]
+    },
     "patchedDependencies": {
       "@types/presto-client@1.0.2": "patches/@types__presto-client@1.0.2.patch",
       "presto-client@1.1.0": "patches/presto-client@1.1.0.patch",

--- a/packages/front-end/services/files.ts
+++ b/packages/front-end/services/files.ts
@@ -44,7 +44,11 @@ export async function uploadFile(
       let uploadResponse: Response;
 
       // Determine upload method based on URL and fields
-      const isS3Post = signedUrl.includes("s3.amazonaws.com");
+      // Detect S3 URLs (virtual-hosted, path-style, regional, legacy)
+      const isS3Post =
+        /https?:\/\/(?:[\w-]+\.)?s3(?:[.-][a-z0-9-]+)?\.amazonaws\.com/.test(
+          signedUrl,
+        );
 
       if (isS3Post && fields) {
         // S3 POST-based upload with policy enforcement


### PR DESCRIPTION
### Features and Changes
s3 uploading was broken when their were regions as part of the url.  This PR fixes that.

- Closes https://github.com/growthbook/growthbook/issues/5164

### Testing
In the console, try this:
```
const s3Regex = /https?:\/\/(?:[\w-]+\.)?s3(?:[.-][a-z0-9-]+)?\.amazonaws\.com/;

const testCases = [
  // Virtual-hosted style - us-east-1 (no region)
  { url: "https://bucket.s3.amazonaws.com", expected: true, description: "Virtual-hosted us-east-1" },
  { url: "https://my-bucket.s3.amazonaws.com/path/to/file.jpg", expected: true, description: "Virtual-hosted us-east-1 with path" },
  
  // Virtual-hosted style - with region (dot format)
  { url: "https://bucket.s3.us-west-2.amazonaws.com", expected: true, description: "Virtual-hosted with region (dot)" },
  { url: "https://my-bucket.s3.eu-west-1.amazonaws.com/file.png", expected: true, description: "Virtual-hosted EU region (dot)" },
  { url: "https://test-bucket.s3.ap-southeast-1.amazonaws.com", expected: true, description: "Virtual-hosted APAC region (dot)" },
  
  // Virtual-hosted style - with region (dash format - legacy)
  { url: "https://bucket.s3-us-west-2.amazonaws.com", expected: true, description: "Virtual-hosted with region (dash)" },
  { url: "https://my-bucket.s3-eu-central-1.amazonaws.com/data.csv", expected: true, description: "Virtual-hosted EU region (dash)" },
  
  // Path style - us-east-1
  { url: "https://s3.amazonaws.com/bucket/file.txt", expected: true, description: "Path style us-east-1" },
  
  // Path style - with region (dot format)
  { url: "https://s3.us-west-2.amazonaws.com/bucket/file.txt", expected: true, description: "Path style with region (dot)" },
  { url: "https://s3.eu-west-1.amazonaws.com/my-bucket", expected: true, description: "Path style EU region (dot)" },
  
  // Path style - with region (dash format - legacy)
  { url: "https://s3-us-west-2.amazonaws.com/bucket/file.txt", expected: true, description: "Path style with region (dash)" },
  { url: "https://s3-ap-northeast-1.amazonaws.com/bucket", expected: true, description: "Path style APAC region (dash)" },
  
  // HTTP (not HTTPS)
  { url: "http://bucket.s3.amazonaws.com", expected: true, description: "HTTP instead of HTTPS" },
  
  // With query params and fragments
  { url: "https://bucket.s3.us-west-2.amazonaws.com/file.jpg?X-Amz-Algorithm=AWS4-HMAC-SHA256", expected: true, description: "With query parameters" },
  
  // Non-S3 URLs (should be false)
  { url: "https://storage.googleapis.com/bucket/file", expected: false, description: "Google Cloud Storage" },
  { url: "https://example.com", expected: false, description: "Random domain" },
  { url: "https://s3.notaws.com/bucket", expected: false, description: "Fake S3 domain" },
  { url: "https://amazonaws.com", expected: false, description: "AWS domain without s3" },
  { url: "ftp://bucket.s3.amazonaws.com", expected: false, description: "FTP protocol" },
];

console.log("S3 URL Regex Test Results:\n");
let passed = 0;
let failed = 0;

testCases.forEach(({ url, expected, description }) => {
  const result = s3Regex.test(url);
  const status = result === expected ? "✅ PASS" : "❌ FAIL";
  
  if (result === expected) {
    passed++;
  } else {
    failed++;
  }
  
  console.log(`${status} - ${description}`);
  console.log(`  URL: ${url}`);
  console.log(`  Expected: ${expected}, Got: ${result}\n`);
});

console.log(`\nSummary: ${passed} passed, ${failed} failed out of ${testCases.length} tests`);
```
