### PR TITLE
Remove filter on getAll

### DIFF
--- a/packages/back-end/src/enterprise/models/DashboardModel.ts
+++ b/packages/back-end/src/enterprise/models/DashboardModel.ts
@@ -112,6 +112,10 @@ export class DashboardModel extends BaseClass {
     return this._find({ experimentId, ...additionalFilter });
   }
 
+  public async getAllNonExperimentDashboards(): Promise<DashboardInterface[]> {
+    return this._find({ experimentId: null });
+  }
+
   public static async getDashboardsToUpdate(): Promise<
     Array<{
       id: string;

--- a/packages/back-end/src/models/BaseModel.ts
+++ b/packages/back-end/src/models/BaseModel.ts
@@ -376,8 +376,8 @@ export abstract class BaseModel<
 
     return this._find({ id: { $in: ids } });
   }
-  public getAll(filter?: ScopedFilterQuery<T>) {
-    return this._find(filter);
+  public getAll() {
+    return this._find();
   }
   public create(
     props: CreateProps<z.infer<T>>,

--- a/packages/back-end/src/models/MetricGroupModel.ts
+++ b/packages/back-end/src/models/MetricGroupModel.ts
@@ -41,7 +41,7 @@ export class MetricGroupModel extends BaseClass {
   }
 
   findByMetric(metricId: string): Promise<MetricGroupInterface[]> {
-    return this.getAll({
+    return this._find({
       metrics: metricId,
     });
   }

--- a/packages/back-end/src/models/WebhookModel.ts
+++ b/packages/back-end/src/models/WebhookModel.ts
@@ -69,7 +69,7 @@ export class SdkWebhookModel extends BaseClass {
   public async findAllSdkWebhooksByConnectionIds(
     sdkConnectionIds: string[],
   ): Promise<WebhookInterface[]> {
-    return await this.getAll({
+    return await this._find({
       sdks: { $in: sdkConnectionIds },
     });
   }
@@ -77,7 +77,7 @@ export class SdkWebhookModel extends BaseClass {
   public async findAllSdkWebhooksByPayloadFormat(
     payloadFormat: string,
   ): Promise<WebhookInterface[]> {
-    return await this.getAll({
+    return await this._find({
       payloadFormat,
     });
   }
@@ -85,13 +85,13 @@ export class SdkWebhookModel extends BaseClass {
   public async findAllSdkWebhooksByConnection(
     sdkConnectionId: string,
   ): Promise<WebhookInterface[]> {
-    return await this.getAll({
+    return await this._find({
       sdks: sdkConnectionId,
     });
   }
 
   public async findAllLegacySdkWebhooks(): Promise<WebhookInterface[]> {
-    return await this.getAll({
+    return await this._find({
       useSdkMode: { $ne: true },
     });
   }

--- a/packages/back-end/src/routers/dashboards/dashboards.controller.ts
+++ b/packages/back-end/src/routers/dashboards/dashboards.controller.ts
@@ -54,11 +54,9 @@ export async function getAllDashboards(
 ) {
   const context = getContextFromReq(req);
 
-  const dashboards = await context.models.dashboards.getAll(
-    stringToBoolean(req.query.includeExperimentDashboards)
-      ? {}
-      : { experimentId: null },
-  );
+  const dashboards = stringToBoolean(req.query.includeExperimentDashboards)
+    ? await context.models.dashboards.getAll()
+    : await context.models.dashboards.getAllNonExperimentDashboards();
   return res.status(200).json({ status: 200, dashboards });
 }
 


### PR DESCRIPTION
### Features and Changes

The base model added a filter argument to getAll()  at some point.  This encourages bad practices like having Mongo queries scattered throughout the code base instead of localized within the model.

Previously:
`context.foo.getAll({ bar: "baz" })`

With this PR we require adding helper functions to the model if you want to query on specific fields

```
class FooModel extends BaseModel {
  // ...

  public getAllByBar(bar: string) {
    return this._find({ bar });
  }
}

// Usage
context.foo.getAllbyBar("baz")
```

### Testing
`pnpm test`
- Go to localhost:3000/product-analytics/dashboards
- Create dashboards
- See the dashboards in the list.
- Edit packages/front-end/pages/product-analytics/dashboards/index.tsx to have `useDashboards(true)` instead of `useDashboards(false)`.
- See the dashboards in the list.
