### PR TITLE
remove optional packages from docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ RUN \
   && rm -rf packages/shared/node_modules \
   && rm -rf packages/sdk-js/node_modules \
   && rm -rf packages/sdk-react/node_modules \
-  && pnpm install --frozen-lockfile --prod \
+  && pnpm install --frozen-lockfile --prod --no-optional \
   && pnpm store prune \
   && find node_modules -name "*.md" -delete \
   && find node_modules -name "*.ts" ! -name "*.d.ts" -delete \


### PR DESCRIPTION
### Features and Changes

When switching from yarn to pnpm we stopped removing optional packages in the docker image.  This PR once again ignores those packages.
