### PR TITLE
fix(user-avatar): Handle potential undefined owner

### DIFF
--- a/packages/front-end/components/Avatar/UserAvatar.tsx
+++ b/packages/front-end/components/Avatar/UserAvatar.tsx
@@ -11,9 +11,10 @@ const getUserAvatar = (
   icon?: ReactElement,
 ): string | ReactElement => {
   if (icon) return icon;
+  if (!name) return "";
 
-  const firstNameLetter = name?.charAt(0);
-  const lastNameLetter = name?.split(" ")[1]?.charAt(0) || "";
+  const firstNameLetter = name.charAt(0);
+  const lastNameLetter = name.split(" ")[1]?.charAt(0) || "";
   const userInitials =
     name.toLowerCase() === "api"
       ? name.toUpperCase()

--- a/packages/front-end/components/MetricDrilldown/MetricDrilldownOwnerTags.tsx
+++ b/packages/front-end/components/MetricDrilldown/MetricDrilldownOwnerTags.tsx
@@ -14,11 +14,11 @@ export function MetricDrilldownOwnerTags({ row }: { row: ExperimentTableRow }) {
         label="Owner"
         value={
           <Flex align="center" gap="1">
-            {metric.owner !== "" && (
+            {metric.owner && (
               <UserAvatar name={metric.owner} size="sm" variant="soft" />
             )}
             <Text weight="regular" className={metaDataStyles.valueColor}>
-              {metric.owner === "" ? "None" : metric.owner}
+              {metric.owner || "None"}
             </Text>
           </Flex>
         }


### PR DESCRIPTION
### Features and Changes

For very old metrics there is a chance that `owner` is `undefined`.
Our code was handling `empty string` correctly, but would fail to handle `undefined`, leading to a client side exception.

Now it works as we expect.