### PR TITLE
Upgrade pip in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,6 +84,7 @@ RUN apt-get update && \
   npm install -g pnpm@9.15.0 && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
+RUN pip install --upgrade pip
 COPY --from=pybuild /usr/local/src/app/requirements.txt /usr/local/src/requirements.txt
 RUN pip3 install -r /usr/local/src/requirements.txt && rm -rf /root/.cache/pip
 


### PR DESCRIPTION
### Features and Changes

Pip 24 has a security vulnerability, so we should prompt it to upgrade when building our docker image

### Testing

`docker build -t growthbook . --no-cache`

Note: My local env fails the build on both `main` and this branch, but I think the error is due to my docker version given the comment in the dockerfile about the wildcard. The actual build steps before this including the pip upgrade work fine
```
Step 41/52 : COPY buildinfo* ./buildinfo
COPY failed: no source files were specified
```