### PR TITLE
Do apt-get upgrade for openssl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,8 +70,10 @@ RUN pnpm postinstall
 FROM python:${PYTHON_MAJOR}-slim
 ARG NODE_MAJOR
 WORKDIR /usr/local/src/app
+# TODO: Remove openssl upgrade once base image has version >3.5.4-1~deb13u2
+# Check with: `docker run --rm python:3.11-slim dpkg -l | grep openssl`
 RUN apt-get update && \
-  apt-get upgrade -y && \
+  apt-get install --only-upgrade -y openssl && \
   apt-get install -y wget gnupg2 build-essential ca-certificates libkrb5-dev && \
   mkdir -p /etc/apt/keyrings && \
   wget -qO- https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \


### PR DESCRIPTION
### Features and Changes
Do apt-get upgrade to get the latest security patches into the final image.  This fixes a [critical security vulnerability](https://us-east-1.console.aws.amazon.com/inspector/v2/home?region=us-east-1#/findings?by=all&findingArn=arn:aws:inspector2:us-east-1:476680172222:finding/9309f50e65fdfe40d087088f9a88cace) in openssl.

### Testing
See build complete
