### PR TITLE
fix auto-slice enablement top values query

### DIFF
--- a/packages/front-end/components/FactTables/ColumnModal.tsx
+++ b/packages/front-end/components/FactTables/ColumnModal.tsx
@@ -81,8 +81,14 @@ export default function ColumnModal({ existing, factTable, close }: Props) {
     setRefreshingTopValues(true);
     setShouldForceOverwriteSlices(true); // Flag to force overwrite slices
     try {
+      // If the column is newly added as an auto slice, the endpoint below
+      // will not run the top values query since the column in the DB is not
+      // set as a auto slice column. We need to tell the backend to proceed with the query.
+      const forceAutoSlice =
+        (form.watch("isAutoSliceColumn") && !existing.isAutoSliceColumn) ||
+        form.watch("datatype") !== existing.datatype;
       await apiCall(
-        `/fact-tables/${factTable.id}/column/${existing.column}/top-values`,
+        `/fact-tables/${factTable.id}/column/${existing.column}/top-values${forceAutoSlice ? "?forceAutoSlice=true" : ""}`,
         {
           method: "POST",
         },


### PR DESCRIPTION
### Features and Changes

The happy path for enabling auto-slices is now broken because the query fails as the database version of the column doesn't have auto-slices enabled. This spoofs the new column status when fetching top values so that it will work even if the mongo version of the column hasn't been updated yet.

- Closes #5212 

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

<!--
  Please describe how to test these changes.
 -->

### Screenshots

https://www.loom.com/share/ebde3638a6534981ba1dc9d09a33f002
