### PR TITLE
Revert default text color change

### DIFF
--- a/packages/front-end/styles/radix-config.css
+++ b/packages/front-end/styles/radix-config.css
@@ -1,7 +1,6 @@
 /* Shared styles for light & dark themes */
 .radix-themes {
   font-size: 14px !important; /* radix should start at 16px as standard but that messes with all our em and rem */
-  color: var(--color-text-mid);
 
   --default-line-height: var(
     --line-height-2


### PR DESCRIPTION
- Reverts the `color: var(--color-text-mid)` default added to `.radix-themes` in #5223 
- While we want to have `color-mid` as our default Text color, we have more prep work to do before proceeding with it