### PR TITLE
Remove special handling for openssl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,10 +87,7 @@ FROM python:${PYTHON_MAJOR}-slim
 ARG NODE_MAJOR
 ARG PYPI_MIRROR_URL
 WORKDIR /usr/local/src/app
-# TODO: Remove openssl upgrade once base image has version >3.5.4-1~deb13u2
-# Check with: `docker run --rm python:3.11-slim dpkg -l | grep openssl`
 RUN apt-get update && \
-  apt-get install --only-upgrade -y openssl && \
   apt-get install -y wget gnupg2 build-essential ca-certificates libkrb5-dev && \
   mkdir -p /etc/apt/keyrings && \
   wget -qO- https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \


### PR DESCRIPTION
### Features and Changes
The upgrade is now in the base image

### Test Plan
```
docker pull python:3.11-slim
docker run --rm python:3.11-slim dpkg -l | grep openssl
```
See 
```
ii  openssl                 3.5.4-1~deb13u2             arm64        Secure Sockets Layer toolkit - cryptographic utility
ii  openssl-provider-legacy 3.5.4-1~deb13u2             arm64        Secure Sockets Layer toolkit - cryptographic utility
```