### PR TITLE
Don't copy python lock file to prod image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,8 @@ RUN \
   && find node_modules -type f -name "CHANGELOG*" -delete \
   && find node_modules -type f -name "LICENSE*" -delete \
   && find node_modules -type f -name "README*" -delete \
-  && find node_modules -type d -name benchmarks -prune -exec rm -rf {} +
+  && find node_modules -type d -name benchmarks -prune -exec rm -rf {} + \
+  && rm -f packages/stats/poetry.lock
 RUN pnpm postinstall
 
 


### PR DESCRIPTION
### Features and Changes
Vanta and AWS security scan look at the poetry.lock file and [complain](https://github.com/growthbook/growthbook/pull/5245) about it.  The issue is that the lock file also has dev dependencies that don't make it to prod.  The security scanners should still look at the actual installed packages, so I don't think we are losing any protection by doing that.