### PR TITLE
Docs: update to reflect hashing uses seed rather than tracking key

### DIFF
--- a/docs/docs/experiments.mdx
+++ b/docs/docs/experiments.mdx
@@ -82,7 +82,7 @@ within your data warehouse, you can use GrowthBook to analyse the results of you
 
 ## How GrowthBook Assigns Users to Experiments
 
-GrowthBook uses a consistent hashing algorithm to assign users to experiments, ensuring that the same user will always receive the same variation as long as the experiment settings (experiment key and user hashing ID) remain unchanged. This makes it possible to run experiments across multiple pages or applications while maintaining consistent user experiences without storing any state or using additional cookies.
+GrowthBook uses a consistent hashing algorithm to assign users to experiments, ensuring that the same user will always receive the same variation as long as the experiment settings (experiment seed and user hashing ID) remain unchanged. This makes it possible to run experiments across multiple pages or applications while maintaining consistent user experiences without storing any state or using additional cookies.
 
 In cases where experiment settings do change but consistent assignment is still required, GrowthBook offers a feature called [sticky bucketing](/app/sticky-bucketing), which requires additional configuration.
 

--- a/docs/docs/faq.mdx
+++ b/docs/docs/faq.mdx
@@ -15,7 +15,7 @@ Below are some frequently asked questions about GrowthBook.
 
 GrowthBook SDKs use deterministic hashing to ensure the same user always gets assigned the same variation in an experiment.
 
-In a nutshell, GrowthBook hashes together the `hashAttribute` (the user attribute used to assign a variation, ex: user id) and the experiment `trackingKey` which produces a decimal between 0 and 1. Each variation is assigned a range of values (e.g. `0 to 0.5` and `0.5 to 1.0`) and the user is assigned to whichever one their hash falls into.
+In a nutshell, GrowthBook hashes together the `hashAttribute` (the user attribute used to assign a variation, ex: user id) and the experiment `seed` which produces a decimal between 0 and 1. Each variation is assigned a range of values (e.g. `0 to 0.5` and `0.5 to 1.0`) and the user is assigned to whichever one their hash falls into.
 
 This does mean, if you change the experiment configuration, some users may switch their assigned variation. For example, if someone has the hash `0.49` and you adjust the weights to a 40/60 experiment, the variation ranges become `0 to 0.4` and `0.4 to 1.0`. In this case, the user was previously in the control group, but will now be in the variation.
 

--- a/docs/docs/feature-flag-experiments.mdx
+++ b/docs/docs/feature-flag-experiments.mdx
@@ -39,13 +39,11 @@ about [targeting](/features/targeting). By default, all users will be included.
 The tracking key used to identify this experiment in the SDK. It is used, along with the user hashing attribute in the
 persistent hashing algorithm to ensure the users always get randomized into the same treatment group. It is also what is
 passed to the tracking callback to be tracked in your data warehouse. By default, the tracking key is the same as the
-feature name, but can be any string. If you change the experiment tracking key users will re-bucketed. The tracking key
-can be set to the same values in different features or experiment rules to allow for one experiment to have multiple
-features.
+feature name, but can be any string. We used to use the tracking key as part of the hashing value, but we now instead use a random seed that is generated for each experiment.
 
 ### Assign Variations Based on Attribute
 
-The value you select here will be hashed along with tracking key to determine which variation the user will be assigned.
+The value you select here will be hashed along with experiment seed (set randomly for each experiment but fixed for each phase of the experiment) to determine which variation the user will be assigned.
 Only attributes marked as **identifiers** can be used here. In the vast majority of cases, you want to split traffic based
 on either a logged-in user id or some sort of anonymous identifier like a device id or session cookie. As long as the user
 has the same value for this attribute, they will always get assigned the same variation.
@@ -68,7 +66,7 @@ Multiple variations can be added to an experiment from this section as well, as 
 
 The bar at the bottom shows the traffic allocation for this experiment.
 
-Each user will have the **tracking key** and **hashing attribute** hashed together to determine which variation they
+Each user will have the experiment's **seed** and **hashing attribute** hashed together to determine which variation they
 will be assigned. The algorithm is deterministic, and always returns the same value (a number from 0 to 1) as long as
 the inputs are the same. Changing the split percentages mid-experiment risks having a user switch variations, and could
 cause multiple exposure warnings. Changing the overall exposure percentage is completely safe.

--- a/docs/docs/kb/experiments/aa-tests.mdx
+++ b/docs/docs/kb/experiments/aa-tests.mdx
@@ -83,7 +83,7 @@ You have two options:
 
 Use the "Make Changes" flow in the A/A experiment page.
 
-Use this flow to "Start a New Phase" and make sure you "re-randomize traffic" to ensure that users returning to your test will be re-randomized into variations.
+Use this flow to "Start a New Phase" and make sure you "re-randomize traffic" to ensure that users returning to your test will be re-randomized into variations (this will re-set the seed for the experiment, causing users to get randomly re-assigned).
 
 ![New Phase](/images/new-phase.png)
 ![New Phase, Re-Randomize](/images/new-phase-rerandomize.png)


### PR DESCRIPTION
We don't hash using the tracking key any more (and haven't for a while). We instead use the seed (a property of an experiment phase, technically, but it gives us more randomness and more control over when the experiment should re-randomize and when it shouldn't).

This updates the docs to reflect that.