### PR TITLE
Ignore open telemetry warning from sentry

### DIFF
--- a/packages/front-end/next.config.js
+++ b/packages/front-end/next.config.js
@@ -41,16 +41,17 @@ const nextConfig = {
       test: /ace-builds.*\/worker-.*$/,
       type: "asset/resource",
     });
-    
+
     // Suppress OpenTelemetry dynamic require warnings from Sentry
     config.ignoreWarnings = [
       ...(config.ignoreWarnings || []),
       {
         module: /@opentelemetry\/instrumentation/,
-        message: /Critical dependency: the request of a dependency is an expression/,
+        message:
+          /Critical dependency: the request of a dependency is an expression/,
       },
     ];
-    
+
     return config;
   },
   productionBrowserSourceMaps: true,


### PR DESCRIPTION
### Features and Changes

Since we upgraded Sentry open telemetry, we started getting warnings in dev output:
```
packages/front-end dev:  ⚠ ../../node_modules/.pnpm/@opentelemetry+instrumentation@0.210.0_@opentelemetry+api@1.9.0/node_modules/@opentelemetry/instrumentation/build/src/platform/node/instrumentation.js
packages/front-end dev: Critical dependency: the request of a dependency is an expression
packages/front-end dev: Import trace for requested module:
packages/front-end dev: ../../node_modules/.pnpm/@opentelemetry+instrumentation@0.210.0_@opentelemetry+api@1.9.0/node_modules/@opentelemetry/instrumentation/build/src/platform/node/instrumentation.js
packages/front-end dev: ../../node_modules/.pnpm/@opentelemetry+instrumentation@0.210.0_@opentelemetry+api@1.9.0/node_modules/@opentelemetry/instrumentation/build/src/platform/node/index.js
packages/front-end dev: ../../node_modules/.pnpm/@opentelemetry+instrumentation@0.210.0_@opentelemetry+api@1.9.0/node_modules/@opentelemetry/instrumentation/build/src/platform/index.js
packages/front-end dev: ../../node_modules/.pnpm/@opentelemetry+instrumentation@0.210.0_@opentelemetry+api@1.9.0/node_modules/@opentelemetry/instrumentation/build/src/index.js
packages/front-end dev: ../../node_modules/.pnpm/@sentry+node@10.36.0/node_modules/@sentry/node/build/cjs/integrations/tracing/postgresjs.js
packages/front-end dev: ../../node_modules/.pnpm/@sentry+node@10.36.0/node_modules/@sentry/node/build/cjs/index.js
packages/front-end dev: ../../node_modules/.pnpm/@sentry+nextjs@10.36.0_@opentelemetry+context-async-hooks@2.5.0_@opentelemetry+api@1.9._35d5e0467b75a4a464e61e81637ef87c/node_modules/@sentry/nextjs/build/cjs/index.server.js
```
This is fine.  Open telemetry should not be trying to instrument postgres and the like on the front-end.  I suppress it here because it is annoying clouding dev output.

### Testing
`pnpm dev`
Don't see such warnings.
