### PR TITLE
Build before generating SDKInfo + fix EdgeUtils

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -54,7 +54,6 @@ fi
 sdkchanged=$(has_changes "shared/src/sdk-versioning|shared/scripts/gen-sdk-resources.ts")
 if [ -n "$sdkchanged" ]; then
   echo "#### sdk-versioning or gen-sdk-resources.ts changed, running gen-sdk-resources"
-  pnpm --filter shared build
   pnpm --filter shared gen-sdk-resources-for-docs
   git add docs
 fi

--- a/docs/src/data/SDKInfo.ts
+++ b/docs/src/data/SDKInfo.ts
@@ -1000,7 +1000,7 @@ export default {
   },
   edgeUtils: {
     name: "Edge Utils",
-    version: "0.2.5",
+    version: "0.2.7",
     github:
       "https://github.com/growthbook/growthbook-proxy/tree/main/packages/lib/edge-utils",
     examples: [],

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -17,7 +17,7 @@
     "type-check": "tsc --pretty --noEmit",
     "generate-sdk-report": "node -r @swc-node/register ./src/sdk-versioning/sdk-report.ts ./src/sdk-versioning/CAPABILITIES.md",
     "gen-event-webhook-for-docs": "pnpm exec tsx ./scripts/gen-event-webhook-doc.ts",
-    "gen-sdk-resources-for-docs": "pnpm exec tsx ./scripts/gen-sdk-resources.ts"
+    "gen-sdk-resources-for-docs": "pnpm build && pnpm exec tsx ./scripts/gen-sdk-resources.ts"
   },
   "dependencies": {
     "@dqbd/tiktoken": "^1.0.21",

--- a/packages/shared/scripts/gen-sdk-resources.ts
+++ b/packages/shared/scripts/gen-sdk-resources.ts
@@ -464,7 +464,7 @@ const baseSDKInfo = {
   },
   edgeUtils: {
     name: "Edge Utils",
-    version: "0.2.5",
+    version: getLatestSDKVersion("edge-other"),
     github:
       "https://github.com/growthbook/growthbook-proxy/tree/main/packages/lib/edge-utils",
     examples: [],


### PR DESCRIPTION
### Features and Changes

`pnpm build` needs to run before running `pnpm gen-sdk-resources-for-docs`. We had been doing as part of the pre-commit hook, but if someone ran it outside of that, it would use whatever state their shared build was in, which might have been out of date.

Furthermore the version for edgeUtils was hard coded in the script before.  Presumably a hand edit was done to SDKInfo before to get it into that state.  I have fixed the hard coded version in the script and now it should show the correct data.
