### PR TITLE
WatchModel to BaseModel using generic primary keys

### DIFF
--- a/packages/back-end/src/api/experiments/postExperiment.ts
+++ b/packages/back-end/src/api/experiments/postExperiment.ts
@@ -16,7 +16,6 @@ import {
 } from "back-end/src/services/experiments";
 import { createApiRequestHandler } from "back-end/src/util/handler";
 import { getUserByEmail } from "back-end/src/models/UserModel";
-import { upsertWatch } from "back-end/src/models/WatchModel";
 import { getMetricMap } from "back-end/src/models/MetricModel";
 import { validateVariationIds } from "back-end/src/controllers/experiments";
 import { validateCustomFields } from "./validations";
@@ -170,9 +169,8 @@ export const postExperiment = createApiRequestHandler(postExperimentValidator)(
 
     if (ownerId) {
       // add owner as watcher
-      await upsertWatch({
+      await req.context.models.watch.upsertWatch({
         userId: ownerId,
-        organization: req.organization.id,
         item: experiment.id,
         type: "experiments",
       });

--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -120,10 +120,6 @@ import {
   getVisualEditorApiKey,
 } from "back-end/src/models/ApiKeyModel";
 
-import {
-  getExperimentWatchers,
-  upsertWatch,
-} from "back-end/src/models/WatchModel";
 import { getFactTableMap } from "back-end/src/models/FactTableModel";
 import { ReqContext } from "back-end/types/request";
 import { logger } from "back-end/src/util/logger";
@@ -1319,9 +1315,8 @@ export async function postExperiments(
       details: auditDetailsCreate(experiment),
     });
 
-    await upsertWatch({
+    await context.models.watch.upsertWatch({
       userId,
-      organization: org.id,
       item: experiment.id,
       type: "experiments",
     });
@@ -1842,9 +1837,8 @@ export async function postExperiment(
   // If there are new tags to add
   await addTagsDiff(org.id, experiment.tags || [], data.tags || []);
 
-  await upsertWatch({
+  await context.models.watch.upsertWatch({
     userId,
-    organization: org.id,
     item: experiment.id,
     type: "experiments",
   });
@@ -2615,9 +2609,8 @@ export async function postExperimentTargeting(
       details: auditDetailsUpdate(experiment, updated),
     });
 
-    await upsertWatch({
+    await context.models.watch.upsertWatch({
       userId,
-      organization: org.id,
       item: experiment.id,
       type: "experiments",
     });
@@ -2729,9 +2722,8 @@ export async function postExperimentPhase(
       details: auditDetailsUpdate(experiment, updated),
     });
 
-    await upsertWatch({
+    await context.models.watch.upsertWatch({
       userId,
-      organization: org.id,
       item: experiment.id,
       type: "experiments",
     });
@@ -2751,9 +2743,9 @@ export async function getWatchingUsers(
   req: AuthRequest<null, { id: string }>,
   res: Response,
 ) {
-  const { org } = getContextFromReq(req);
+  const context = getContextFromReq(req);
   const { id } = req.params;
-  const watchers = await getExperimentWatchers(id, org.id);
+  const watchers = await context.models.watch.getExperimentWatchers(id);
   res.status(200).json({
     status: 200,
     userIds: watchers,
@@ -3514,9 +3506,8 @@ export async function addScreenshot(
     }),
   });
 
-  await upsertWatch({
+  await context.models.watch.upsertWatch({
     userId,
-    organization: org.id,
     item: experiment.id,
     type: "experiments",
   });

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -141,7 +141,6 @@ import {
   CACHE_CONTROL_STALE_WHILE_REVALIDATE,
   FASTLY_SERVICE_ID,
 } from "back-end/src/util/secrets";
-import { upsertWatch } from "back-end/src/models/WatchModel";
 import { getSurrogateKeysFromEnvironments } from "back-end/src/util/cdn.util";
 import {
   addLinkedFeatureToExperiment,
@@ -607,9 +606,8 @@ export async function postFeatures(
   addIdsToRules(feature.environmentSettings, feature.id);
 
   await createFeature(context, feature);
-  await upsertWatch({
+  await context.models.watch.upsertWatch({
     userId,
-    organization: org.id,
     item: feature.id,
     type: "features",
   });

--- a/packages/back-end/src/models/GeneratedHypothesis.ts
+++ b/packages/back-end/src/models/GeneratedHypothesis.ts
@@ -5,7 +5,6 @@ import { GeneratedHypothesisInterface } from "shared/types/generated-hypothesis"
 import { ExperimentInterface } from "shared/types/experiment";
 import { ReqContext } from "back-end/types/request";
 import { createExperiment } from "./ExperimentModel";
-import { upsertWatch } from "./WatchModel";
 import { createVisualChangeset } from "./VisualChangesetModel";
 import { createFeature } from "./FeatureModel";
 
@@ -125,9 +124,8 @@ export const findOrCreateGeneratedHypothesis = async (
     context,
   });
 
-  await upsertWatch({
+  await context.models.watch.upsertWatch({
     userId,
-    organization: org.id,
     item: createdExperiment.id,
     type: "experiments",
   });
@@ -206,9 +204,8 @@ export const findOrCreateGeneratedHypothesis = async (
       },
       linkedExperiments: [createdExperiment.id],
     });
-    await upsertWatch({
+    await context.models.watch.upsertWatch({
       userId,
-      organization: org.id,
       item: featureId,
       type: "features",
     });

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -27,7 +27,6 @@ import {
 } from "shared/types/organization";
 import { ExperimentRule, NamespaceValue } from "shared/types/feature";
 import { TeamInterface } from "shared/types/team";
-import { getWatchedByUser } from "back-end/src/models/WatchModel";
 import { validateRoleAndEnvs } from "back-end/src/api/members/updateMemberRole";
 import {
   AuthRequest,
@@ -225,9 +224,9 @@ export async function getDefinitions(req: AuthRequest, res: Response) {
 
 export async function getActivityFeed(req: AuthRequest, res: Response) {
   const context = getContextFromReq(req);
-  const { org, userId } = context;
+  const { userId } = context;
   try {
-    const docs = await getRecentWatchedAudits(userId, org.id);
+    const docs = await getRecentWatchedAudits(context, userId);
 
     if (!docs.length) {
       return res.status(200).json({
@@ -931,7 +930,7 @@ export async function getOrganization(
   );
   const seatsInUse = getNumberOfUniqueMembersAndInvites(org);
 
-  const watch = await getWatchedByUser(org.id, userId);
+  const watch = await context.models.watch.getWatchedByUser(userId);
 
   const commercialFeatureLowestPlan = getLowestPlanPerFeature(accountFeatures);
 

--- a/packages/back-end/src/routers/users/users.controller.ts
+++ b/packages/back-end/src/routers/users/users.controller.ts
@@ -16,10 +16,6 @@ import {
   getUserByEmail,
   updateUser,
 } from "back-end/src/models/UserModel";
-import {
-  deleteWatchedByEntity,
-  upsertWatch,
-} from "back-end/src/models/WatchModel";
 import { getFeature } from "back-end/src/models/FeatureModel";
 import { getExperimentById } from "back-end/src/models/ExperimentModel";
 import { findRecentAuditByUserIdAndOrganization } from "back-end/src/models/AuditModel";
@@ -173,9 +169,8 @@ export async function postWatchItem(
     throw new Error(`Could not find ${item}`);
   }
 
-  await upsertWatch({
+  await context.models.watch.upsertWatch({
     userId,
-    organization: org.id,
     item: id,
     type: type === "experiment" ? "experiments" : "features", // Pluralizes entity type for the Watch model,
   });
@@ -189,7 +184,8 @@ export async function postUnwatchItem(
   req: AuthRequest<null, { type: string; id: string }>,
   res: Response,
 ) {
-  const { org, userId } = getContextFromReq(req);
+  const context = getContextFromReq(req);
+  const { userId } = context;
   const { type, id } = req.params;
 
   if (!isValidWatchEntityType(type)) {
@@ -201,8 +197,7 @@ export async function postUnwatchItem(
   }
 
   try {
-    await deleteWatchedByEntity({
-      organization: org.id,
+    await context.models.watch.deleteWatchedByEntity({
       userId,
       type: type === "experiment" ? "experiments" : "features", // Pluralizes entity type for the Watch model
       item: id,

--- a/packages/back-end/src/services/audit.ts
+++ b/packages/back-end/src/services/audit.ts
@@ -6,7 +6,6 @@ import {
 } from "shared/types/audit";
 import { entityTypes } from "shared/constants";
 import { findAuditByEntityList } from "back-end/src/models/AuditModel";
-import { getWatchedByUser } from "back-end/src/models/WatchModel";
 import { ApiReqContext } from "back-end/types/api";
 import { ReqContext } from "back-end/types/request";
 
@@ -15,10 +14,11 @@ export function isValidAuditEntityType(type: string): type is EntityType {
 }
 
 export async function getRecentWatchedAudits(
+  context: ReqContext,
   userId: string,
-  organization: string,
 ) {
-  const userWatches = await getWatchedByUser(organization, userId);
+  const organization = context.org.id;
+  const userWatches = await context.models.watch.getWatchedByUser(userId);
 
   if (!userWatches) {
     return [];

--- a/packages/back-end/src/services/context.ts
+++ b/packages/back-end/src/services/context.ts
@@ -68,6 +68,7 @@ import { SdkWebhookModel } from "back-end/src/models/WebhookModel";
 import { TeamModel } from "back-end/src/models/TeamModel";
 import { AnalyticsExplorationModel } from "back-end/src/models/AnalyticsExplorationModel";
 import { PresentationThemeModel } from "back-end/src/models/PresentationThemeModel";
+import { WatchModel } from "back-end/src/models/WatchModel";
 import { getExperimentMetricsByIds } from "./experiments";
 
 export type ForeignRefTypes = {
@@ -107,7 +108,8 @@ export type ModelName =
   | "savedGroups"
   | "teams"
   | "analyticsExplorations"
-  | "presentationThemes";
+  | "presentationThemes"
+  | "watch";
 
 export const modelClasses = {
   agreements: AgreementModel,
@@ -140,6 +142,7 @@ export const modelClasses = {
   teams: TeamModel,
   analyticsExplorations: AnalyticsExplorationModel,
   presentationThemes: PresentationThemeModel,
+  watch: WatchModel,
 };
 export type ModelClass = (typeof modelClasses)[ModelName];
 type ModelInstances = {
@@ -181,6 +184,7 @@ export class ReqContextClass {
       teams: new TeamModel(this),
       analyticsExplorations: new AnalyticsExplorationModel(this),
       presentationThemes: new PresentationThemeModel(this),
+      watch: new WatchModel(this),
     };
   }
 

--- a/packages/back-end/src/services/experimentNotifications.ts
+++ b/packages/back-end/src/services/experimentNotifications.ts
@@ -29,7 +29,6 @@ import { orgHasPremiumFeature } from "back-end/src/enterprise";
 import { Context } from "back-end/src/models/BaseModel";
 import { createEvent, CreateEventData } from "back-end/src/models/EventModel";
 import { updateExperiment } from "back-end/src/models/ExperimentModel";
-import { getExperimentWatchers } from "back-end/src/models/WatchModel";
 import { logger } from "back-end/src/util/logger";
 import {
   ExperimentSnapshotDocument,
@@ -233,6 +232,7 @@ type ExperimentSignificanceChange = {
 };
 
 const sendSignificanceEmail = async (
+  context: Context,
   experiment: ExperimentInterface,
   experimentChanges: ExperimentSignificanceChange[],
 ) => {
@@ -253,9 +253,8 @@ const sendSignificanceEmail = async (
 
   try {
     // send an email to any subscribers on this test:
-    const watchers = await getExperimentWatchers(
+    const watchers = await context.models.watch.getExperimentWatchers(
       experiment.id,
-      experiment.organization,
     );
 
     await sendExperimentChangesEmail(
@@ -437,7 +436,7 @@ export const notifySignificance = async ({
     snapshot.triggeredBy === "schedule" &&
     snapshot.type === "standard"
   ) {
-    await sendSignificanceEmail(experiment, experimentChanges);
+    await sendSignificanceEmail(context, experiment, experimentChanges);
   }
 
   await Promise.all(

--- a/packages/back-end/types/watch.d.ts
+++ b/packages/back-end/types/watch.d.ts
@@ -1,6 +1,0 @@
-export interface WatchInterface {
-  userId: string;
-  organization: string;
-  experiments: string[];
-  features: string[];
-}

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -40,3 +40,4 @@ export * from "./metric-group";
 export * from "./product-analytics";
 export * from "./organization";
 export * from "./team";
+export * from "./watch";

--- a/packages/shared/src/validators/watch.ts
+++ b/packages/shared/src/validators/watch.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+import { createBaseSchemaWithPrimaryKey } from "./base-model";
+
+export const watchSchema = createBaseSchemaWithPrimaryKey({
+  userId: z.string(),
+  organization: z.string(),
+}).safeExtend({
+  experiments: z.array(z.string()),
+  features: z.array(z.string()),
+});
+
+export type WatchInterface = z.infer<typeof watchSchema>;
+
+export const updateWatchSchema = z.strictObject({
+  userId: z.string(),
+  type: z.enum(["experiments", "features"]),
+  item: z.string(),
+});
+
+export type UpdateWatchOptions = z.infer<typeof updateWatchSchema>;


### PR DESCRIPTION
### Features and Changes

Fork of #5244 using the new generic primary key options

### Dependencies

This PR is based off #5293 not `main` so we should wait until that's merged and then review this against `main`

### Testing

If you've previously run #5244 locally, you'll need to delete any indices referencing ID
```
db.watches.getIndexes()
// db.watches.dropIndex("id_1_organization_1")
```
and then remove the IDs from the documents
```
db.watches.updateMany({}, {$unset: {id: true}})
```

After starting the server, check that watches work in the frontend:
- Add a new experiment to see that you're automatically enabled as a watcher
- Check that you can remove and re-add watching for it
- Same for a new feature within the organization
- Create a second user within the org and have them watch an existing feature/experiment

And then verify that the watch for the new user was created correctly + doesn't have an ID
```
db.watches.find({id: {$ne: null}})
```

The watch model already had an index on `userId/organization`, but we can verify that it would've been created automatically by dropping it and then restarting the server
```
db.watches.dropIndex("id_1_organization_1")
db.watches.getIndexes()
```