### PR TITLE
fix the generate-api-types/models command

### DIFF
--- a/packages/back-end/package.json
+++ b/packages/back-end/package.json
@@ -24,7 +24,7 @@
     "watch-compile": "swc src -w --out-dir dist",
     "watch-dev": "delay 1 && nodemon --exec 'node --enable-source-maps --no-node-snapshot' --watch dist --watch '../shared/dist' -e js ./dist/server.js",
     "migrate-encryption-key": "GB_STATS_ENGINE_MIN_POOL_SIZE=0 CRON_ENABLED=false ./src/scripts/migrate-encryption-key.sh",
-    "generate-api-models": "ts-node src/scripts/generate-doc-models-for-openapi-schemas.ts",
+    "generate-api-models": "DISABLE_PYTHON_MONITOR=1 GB_STATS_ENGINE_MIN_POOL_SIZE=0 ts-node src/scripts/generate-doc-models-for-openapi-schemas.ts",
     "generate-api-types": "pnpm generate-api-models && swagger-cli bundle -t yaml src/api/openapi/openapi.tmp.yaml -o generated/spec.yaml && node src/scripts/generate-openapi.mjs"
   },
   "dependencies": {


### PR DESCRIPTION
Fixes the rogue python runner that is crashing the command.

importing ApiModel sets of a chain of imports which ultimately imports python and starts the workers.