### PR TITLE
Fix alias bug in metric analysis query

### DIFF
--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -1738,7 +1738,7 @@ export default abstract class SqlIntegration
           )
         ),
         20, 
-      99999
+        99999
       )`;
     }
 


### PR DESCRIPTION
Presto fails if a GROUP BY includes a statement with an alias but the matching select statement doesn't. It's possible other engines do as well, but not many we test regularly as we would have noticed this before.

e.g.

```
SELECT
  f.id AS id,
  date_trunc('day', timestamp) AS date,
  COALESCE(MAX(f.m0_value), 0) AS value,
  COALESCE(MAX(f.m0_value), 0) AS value_for_reaggregation
FROM
  __factTable f
GROUP BY
  date_trunc('day', f.timestamp),
  f.subject_id
  ```
  
  Fails since the date_trunc in the GROUP BY and in the SELECT statement differ.