### PR TITLE
fix(jobs): Add OTEL span for each job

### DIFF
--- a/packages/back-end/src/jobs/createInformationSchema.ts
+++ b/packages/back-end/src/jobs/createInformationSchema.ts
@@ -15,15 +15,15 @@ import { getContextForAgendaJobByOrgId } from "back-end/src/services/organizatio
 const CREATE_INFORMATION_SCHEMA_JOB_NAME = "createInformationSchema";
 type CreateInformationSchemaJob = Job<{
   datasourceId: string;
-  organization: string;
+  organizationId: string;
 }>;
 
 const createInformationSchema = async (job: CreateInformationSchemaJob) => {
-  const { datasourceId, organization } = job.attrs.data;
+  const { datasourceId, organizationId } = job.attrs.data;
 
-  if (!datasourceId || !organization) return;
+  if (!datasourceId || !organizationId) return;
 
-  const context = await getContextForAgendaJobByOrgId(organization);
+  const context = await getContextForAgendaJobByOrgId(organizationId);
 
   const datasource = await getDataSourceById(context, datasourceId);
 
@@ -44,10 +44,10 @@ const createInformationSchema = async (job: CreateInformationSchemaJob) => {
     }
     const informationSchema = await getInformationSchemaByDatasourceId(
       datasource.id,
-      organization,
+      organizationId,
     );
     if (informationSchema) {
-      await updateInformationSchemaById(organization, informationSchema.id, {
+      await updateInformationSchemaById(organizationId, informationSchema.id, {
         ...informationSchema,
         status: "COMPLETE",
         error,
@@ -64,15 +64,15 @@ export default function (ag: Agenda) {
 
 export async function queueCreateInformationSchema(
   datasourceId: string,
-  organization: string,
+  organizationId: string,
 ) {
-  if (!datasourceId || !organization) return;
+  if (!datasourceId || !organizationId) return;
 
   const job = agenda.create(CREATE_INFORMATION_SCHEMA_JOB_NAME, {
     datasourceId,
-    organization,
+    organizationId,
   }) as CreateInformationSchemaJob;
-  job.unique({ datasource: datasourceId, organization });
+  job.unique({ datasource: datasourceId, organization: organizationId });
   job.schedule(new Date());
   await job.save();
 }

--- a/packages/back-end/src/jobs/proxyUpdate.ts
+++ b/packages/back-end/src/jobs/proxyUpdate.ts
@@ -18,7 +18,7 @@ import { getContextForAgendaJobByOrgId } from "back-end/src/services/organizatio
 
 const PROXY_UPDATE_JOB_NAME = "proxyUpdate";
 type ProxyUpdateJob = Job<{
-  orgId: string;
+  organizationId: string;
   connectionId: string;
   useCloudProxy: boolean;
   retryCount: number;
@@ -26,7 +26,7 @@ type ProxyUpdateJob = Job<{
 
 const proxyUpdate = async (job: ProxyUpdateJob) => {
   const connectionId = job.attrs.data?.connectionId;
-  const orgId = job.attrs.data?.orgId;
+  const organizationId = job.attrs.data?.organizationId;
   const useCloudProxy = job.attrs.data?.useCloudProxy;
   if (!connectionId) {
     logger.error(
@@ -39,18 +39,18 @@ const proxyUpdate = async (job: ProxyUpdateJob) => {
     return;
   }
 
-  if (!orgId) {
+  if (!organizationId) {
     logger.error(
       {
         connectionId,
         useCloudProxy,
       },
-      "proxyUpdate: No orgId provided for proxy update job",
+      "proxyUpdate: No organizationId provided for proxy update job",
     );
     return;
   }
 
-  const context = await getContextForAgendaJobByOrgId(orgId);
+  const context = await getContextForAgendaJobByOrgId(organizationId);
 
   const connection = await findSDKConnectionById(context, connectionId);
   if (!connection) {
@@ -158,14 +158,14 @@ export default function addProxyUpdateJob(ag: Agenda) {
 }
 
 export async function queueSingleProxyUpdate(
-  orgId: string,
+  organizationId: string,
   connection: SDKConnectionInterface,
   useCloudProxy: boolean = false,
 ) {
   if (!connectionSupportsProxyUpdate(connection, useCloudProxy)) return;
 
   const job = agenda.create(PROXY_UPDATE_JOB_NAME, {
-    orgId,
+    organizationId,
     connectionId: connection.id,
     retryCount: 0,
     useCloudProxy,

--- a/packages/back-end/src/jobs/refreshFactTableColumns.ts
+++ b/packages/back-end/src/jobs/refreshFactTableColumns.ts
@@ -22,16 +22,16 @@ import { logger } from "back-end/src/util/logger";
 
 const JOB_NAME = "refreshFactTableColumns";
 type RefreshFactTableColumnsJob = Job<{
-  organization: string;
+  organizationId: string;
   factTableId: string;
 }>;
 
 const refreshFactTableColumns = async (job: RefreshFactTableColumnsJob) => {
-  const { organization, factTableId } = job.attrs.data;
+  const { organizationId, factTableId } = job.attrs.data;
 
-  if (!factTableId || !organization) return;
+  if (!factTableId || !organizationId) return;
 
-  const context = await getContextForAgendaJobByOrgId(organization);
+  const context = await getContextForAgendaJobByOrgId(organizationId);
 
   const factTable = await getFactTable(context, factTableId);
   if (!factTable) return;
@@ -331,7 +331,7 @@ export async function queueFactTableColumnsRefresh(
   factTable: FactTableInterface,
 ) {
   const job = agenda.create(JOB_NAME, {
-    organization: factTable.organization,
+    organizationId: factTable.organization,
     factTableId: factTable.id,
   }) as RefreshFactTableColumnsJob;
   job.unique({

--- a/packages/back-end/src/jobs/updateAutoSlices.ts
+++ b/packages/back-end/src/jobs/updateAutoSlices.ts
@@ -20,7 +20,7 @@ const QUEUE_AUTO_SLICE_UPDATES = "queueAutoSliceUpdates";
 const UPDATE_SINGLE_FACT_TABLE_AUTO_SLICES = "updateSingleFactTableAutoSlices";
 
 type UpdateSingleFactTableAutoSlicesJob = Job<{
-  organization: string;
+  organizationId: string;
   factTableId: string;
 }>;
 
@@ -49,7 +49,7 @@ export default async function (agenda: Agenda) {
 
   async function queueAutoSliceUpdate(factTable: FactTableInterface) {
     const job = agenda.create(UPDATE_SINGLE_FACT_TABLE_AUTO_SLICES, {
-      organization: factTable.organization,
+      organizationId: factTable.organization,
       factTableId: factTable.id,
     });
     job.unique({
@@ -64,11 +64,11 @@ export default async function (agenda: Agenda) {
 const updateSingleFactTableAutoSlices = async (
   job: UpdateSingleFactTableAutoSlicesJob,
 ) => {
-  const { organization, factTableId } = job.attrs.data;
+  const { organizationId, factTableId } = job.attrs.data;
 
-  if (!factTableId || !organization) return;
+  if (!factTableId || !organizationId) return;
 
-  const context = await getContextForAgendaJobByOrgId(organization);
+  const context = await getContextForAgendaJobByOrgId(organizationId);
 
   if (!context.hasPremiumFeature("metric-slices")) return;
 
@@ -95,13 +95,13 @@ const updateSingleFactTableAutoSlices = async (
         context,
       );
       logger.info(
-        `Updated auto-slices for fact table ${factTableId} in organization ${organization}`,
+        `Updated auto-slices for fact table ${factTableId} in organization ${organizationId}`,
       );
     }
   } catch (e) {
     logger.error(e, "Failed to update auto-slices", {
       factTableId,
-      organization,
+      organizationId,
     });
   }
 };

--- a/packages/back-end/src/jobs/updateDashboards.ts
+++ b/packages/back-end/src/jobs/updateDashboards.ts
@@ -8,7 +8,7 @@ const QUEUE_DASHBOARD_UPDATES = "queueDashboardUpdates";
 
 const UPDATE_SINGLE_DASH = "updateSingleDashboard";
 type UpdateSingleDashJob = Job<{
-  organization: string;
+  organizationId: string;
   dashboardId: string;
 }>;
 
@@ -33,17 +33,17 @@ export default async function (agenda: Agenda) {
   }
 
   async function queueDashboardUpdate(
-    organization: string,
+    organizationId: string,
     dashboardId: string,
   ) {
     const job = agenda.create(UPDATE_SINGLE_DASH, {
-      organization,
+      organizationId,
       dashboardId,
     }) as UpdateSingleDashJob;
 
     job.unique({
       dashboardId,
-      organization,
+      organization: organizationId,
     });
     job.schedule(new Date());
     await job.save();
@@ -52,11 +52,11 @@ export default async function (agenda: Agenda) {
 
 const updateSingleDashboard = async (job: UpdateSingleDashJob) => {
   const dashboardId = job.attrs.data?.dashboardId;
-  const orgId = job.attrs.data?.organization;
+  const organizationId = job.attrs.data?.organizationId;
 
-  if (!dashboardId || !orgId) return;
+  if (!dashboardId || !organizationId) return;
 
-  const context = await getContextForAgendaJobByOrgId(orgId);
+  const context = await getContextForAgendaJobByOrgId(organizationId);
 
   const dashboard = await context.models.dashboards.getById(dashboardId);
   if (!dashboard) return;

--- a/packages/back-end/src/jobs/updateExperimentResults.ts
+++ b/packages/back-end/src/jobs/updateExperimentResults.ts
@@ -28,7 +28,7 @@ const QUEUE_EXPERIMENT_UPDATES = "queueExperimentUpdates";
 
 const UPDATE_SINGLE_EXP = "updateSingleExperiment";
 type UpdateSingleExpJob = Job<{
-  organization: string;
+  organizationId: string;
   experimentId: string;
 }>;
 
@@ -78,17 +78,17 @@ export default async function (agenda: Agenda) {
   }
 
   async function queueExperimentUpdate(
-    organization: string,
+    organizationId: string,
     experimentId: string,
   ) {
     const job = agenda.create(UPDATE_SINGLE_EXP, {
-      organization,
+      organizationId,
       experimentId,
     }) as UpdateSingleExpJob;
 
     job.unique({
       experimentId,
-      organization,
+      organization: organizationId,
     });
     job.schedule(new Date());
     await job.save();
@@ -97,11 +97,11 @@ export default async function (agenda: Agenda) {
 
 const updateSingleExperiment = async (job: UpdateSingleExpJob) => {
   const experimentId = job.attrs.data?.experimentId;
-  const orgId = job.attrs.data?.organization;
+  const organizationId = job.attrs.data?.organizationId;
 
-  if (!experimentId || !orgId) return;
+  if (!experimentId || !organizationId) return;
 
-  const context = await getContextForAgendaJobByOrgId(orgId);
+  const context = await getContextForAgendaJobByOrgId(organizationId);
 
   const { org: organization } = context;
 

--- a/packages/back-end/src/jobs/updateInformationSchema.ts
+++ b/packages/back-end/src/jobs/updateInformationSchema.ts
@@ -15,19 +15,19 @@ import { getContextForAgendaJobByOrgId } from "back-end/src/services/organizatio
 const UPDATE_INFORMATION_SCHEMA_JOB_NAME = "updateInformationSchema";
 type UpdateInformationSchemaJob = Job<{
   datasourceId: string;
-  organization: string;
+  organizationId: string;
   informationSchemaId: string;
 }>;
 
 const updateInformationSchema = async (job: UpdateInformationSchemaJob) => {
-  const { datasourceId, organization, informationSchemaId } = job.attrs.data;
+  const { datasourceId, organizationId, informationSchemaId } = job.attrs.data;
 
-  const context = await getContextForAgendaJobByOrgId(organization);
+  const context = await getContextForAgendaJobByOrgId(organizationId);
 
   const datasource = await getDataSourceById(context, datasourceId);
 
   const informationSchema = await getInformationSchemaById(
-    organization,
+    organizationId,
     informationSchemaId,
   );
 
@@ -50,7 +50,7 @@ const updateInformationSchema = async (job: UpdateInformationSchemaJob) => {
     if (e instanceof MissingDatasourceParamsError) {
       error.errorType = "missing_params";
     }
-    await updateInformationSchemaById(organization, informationSchemaId, {
+    await updateInformationSchemaById(organizationId, informationSchemaId, {
       status: "COMPLETE",
       error,
     });
@@ -65,17 +65,17 @@ export default function (ag: Agenda) {
 
 export async function queueUpdateInformationSchema(
   datasourceId: string,
-  organization: string,
+  organizationId: string,
   informationSchemaId: string,
 ) {
-  if (!datasourceId || !organization) return;
+  if (!datasourceId || !organizationId) return;
 
   const job = agenda.create(UPDATE_INFORMATION_SCHEMA_JOB_NAME, {
     datasourceId,
-    organization,
+    organizationId,
     informationSchemaId,
   }) as UpdateInformationSchemaJob;
-  job.unique({ datasource: datasourceId, organization });
+  job.unique({ datasource: datasourceId, organization: organizationId });
   job.schedule(new Date());
   await job.save();
 }

--- a/packages/back-end/src/jobs/updateStaleInformationSchemaTable.ts
+++ b/packages/back-end/src/jobs/updateStaleInformationSchemaTable.ts
@@ -13,20 +13,19 @@ import { getContextForAgendaJobByOrgId } from "back-end/src/services/organizatio
 const UPDATE_STALE_INFORMATION_SCHEMA_TABLE_JOB_NAME =
   "updateStaleInformationSchemaTable";
 type UpdateStaleInformationSchemaTableJob = Job<{
-  organization: string;
+  organizationId: string;
   informationSchemaTableId: string;
 }>;
 
 const updateStaleInformationSchemaTable = async (
   job: UpdateStaleInformationSchemaTableJob,
 ) => {
-  // console.log("starting the job!");
-  const { organization, informationSchemaTableId } = job.attrs.data;
+  const { organizationId, informationSchemaTableId } = job.attrs.data;
 
-  if (!informationSchemaTableId || !organization) return;
+  if (!informationSchemaTableId || !organizationId) return;
 
   const informationSchemaTable = await getInformationSchemaTableById(
-    organization,
+    organizationId,
     informationSchemaTableId,
   );
 
@@ -38,7 +37,7 @@ const updateStaleInformationSchemaTable = async (
     return;
   }
 
-  const context = await getContextForAgendaJobByOrgId(organization);
+  const context = await getContextForAgendaJobByOrgId(organizationId);
 
   const datasource = await getDataSourceById(
     context,
@@ -46,7 +45,7 @@ const updateStaleInformationSchemaTable = async (
   );
 
   const informationSchema = await getInformationSchemaById(
-    organization,
+    organizationId,
     informationSchemaTable.informationSchemaId,
   );
 
@@ -85,7 +84,7 @@ const updateStaleInformationSchemaTable = async (
 
     // update the information schema table
     await updateInformationSchemaTableById(
-      organization,
+      organizationId,
       informationSchemaTableId,
       {
         columns,
@@ -112,16 +111,16 @@ export default function (ag: Agenda) {
 }
 
 export async function queueUpdateStaleInformationSchemaTable(
-  organization: string,
+  organizationId: string,
   informationSchemaTableId: string,
 ) {
-  if (!informationSchemaTableId || !organization) return;
+  if (!informationSchemaTableId || !organizationId) return;
 
   const job = agenda.create(UPDATE_STALE_INFORMATION_SCHEMA_TABLE_JOB_NAME, {
-    organization,
+    organizationId,
     informationSchemaTableId,
   }) as UpdateStaleInformationSchemaTableJob;
-  job.unique({ informationSchemaTableId, organization });
+  job.unique({ informationSchemaTableId, organization: organizationId });
   job.schedule(new Date());
   await job.save();
 }

--- a/packages/back-end/src/services/tracing.ts
+++ b/packages/back-end/src/services/tracing.ts
@@ -1,9 +1,19 @@
 import { performance } from "node:perf_hooks";
 import { Job, JobAttributesData } from "agenda";
+import {
+  trace,
+  context,
+  ROOT_CONTEXT,
+  SpanKind,
+  SpanStatusCode,
+} from "@opentelemetry/api";
 import { logger } from "back-end/src/util/logger";
 import { metrics, Counter, Histogram } from "back-end/src/util/metrics";
 
 const disableJobLogs = process.env.GB_DISABLE_JOB_LOGS === "1";
+
+// Shared tracer instance for all jobs
+const tracer = trace.getTracer("growthbook-jobs");
 
 // Datadog downcases tag values, so it is best to use snake case
 const normalizeJobName = (jobName: string) => {
@@ -19,16 +29,18 @@ export const trackJob =
     fn: (job: Job<T>) => Promise<void>,
   ) =>
   async (job: Job<T>) => {
-    let hasMetricsStarted = false;
-
     const jobName = normalizeJobName(jobNameRaw);
-
-    // DataDog downcases tag names, so converting to snakecase here
     const attributes = { job_name: jobName };
-
     const startTime = performance.now();
 
-    // init metrics
+    migrateJobData(job.attrs.data);
+
+    const spanAttributes: Record<string, string> = {
+      "job.name": jobNameRaw,
+      ...extractJobAttributesForSpan(job.attrs.data),
+    };
+
+    let hasMetricsStarted = false;
     try {
       getJobsRunningCounter().increment(attributes);
       hasMetricsStarted = true;
@@ -40,10 +52,9 @@ export const trackJob =
     }
 
     // wrap up metrics function, to be called at the end of the job
-    const wrapUpMetrics = () => {
+    const wrapUpMetrics = (success: boolean) => {
       try {
-        const end = performance.now();
-        const elapsed = end - startTime;
+        const elapsed = performance.now() - startTime;
         getJobsDurationHistogram().record(elapsed, attributes);
       } catch (e) {
         logger.error(
@@ -51,53 +62,82 @@ export const trackJob =
           `Error recording duration metric for job`,
         );
       }
-      if (!hasMetricsStarted) return;
-      try {
-        getJobsRunningCounter().decrement(attributes);
-      } catch (e) {
-        logger.error(
-          { err: e, job: job.attrs },
-          `Error decrementing jobs.running_count`,
-        );
-      }
-    };
 
-    // run job
-    let res;
-    try {
-      if (!disableJobLogs) {
-        logger.debug({ job: job.attrs }, `Starting job ${jobName}`);
+      if (hasMetricsStarted) {
+        try {
+          getJobsRunningCounter().decrement(attributes);
+        } catch (e) {
+          logger.error(
+            { err: e, job: job.attrs },
+            `Error decrementing jobs.running_count`,
+          );
+        }
       }
-      res = await fn(job);
-    } catch (e) {
-      logger.error({ err: e, job: job.attrs }, `Error running job: ${jobName}`);
+
       try {
-        wrapUpMetrics();
-        getJobsErrorsCounter().increment(attributes);
+        if (success) {
+          getJobsSuccessesCounter().increment(attributes);
+        } else {
+          getJobsErrorsCounter().increment(attributes);
+        }
       } catch (e) {
         logger.error(
           { err: e, job: job.attrs },
           `Error wrapping up metrics: ${jobName}`,
         );
       }
-      throw e;
-    }
+    };
 
-    // on successful job
-    if (!disableJobLogs) {
-      logger.debug({ job: job.attrs }, `Successfully finished job ${jobName}`);
-    }
-    try {
-      wrapUpMetrics();
-      getJobsSuccessesCounter().increment(attributes);
-    } catch (e) {
-      logger.error(
-        { err: e, job: job.attrs },
-        `Error wrapping up metrics: ${jobName}`,
-      );
-    }
+    return context.with(ROOT_CONTEXT, () =>
+      tracer.startActiveSpan(
+        `job.${jobNameRaw}`,
+        {
+          kind: SpanKind.CONSUMER,
+          attributes: spanAttributes,
+        },
+        async (span) => {
+          try {
+            if (!disableJobLogs) {
+              logger.debug({ job: job.attrs }, `Starting job ${jobName}`);
+            }
 
-    return res;
+            const result = await fn(job);
+
+            if (!disableJobLogs) {
+              logger.debug(
+                { job: job.attrs },
+                `Successfully finished job ${jobName}`,
+              );
+            }
+
+            span.setStatus({ code: SpanStatusCode.OK });
+            wrapUpMetrics(true);
+            return result;
+          } catch (error) {
+            logger.error(
+              { err: error, job: job.attrs },
+              `Error running job: ${jobName}`,
+            );
+
+            // Attach job.id only on errors so it's available
+            // without adding high-cardinality tags to every span
+            span.setAttribute("job.id", job.attrs._id?.toString() || "unknown");
+            span.recordException(error);
+            span.setStatus({
+              code: SpanStatusCode.ERROR,
+              message:
+                error instanceof Error
+                  ? error.message
+                  : String(error || "Job failed"),
+            });
+            wrapUpMetrics(false);
+            throw error;
+          } finally {
+            span.end();
+          }
+        },
+      ),
+    );
   };
 
 // Cache metric handles
@@ -132,4 +172,49 @@ function getJobsErrorsCounter() {
     jobsErrorsCounter = metrics.getCounter("jobs.errors");
   }
   return jobsErrorsCounter;
+}
+
+/**
+ * We migrated to a canonical organizationId for example, but we
+ * want to ensure we are not dropping any old queued jobs when updating.
+ * So this handles old field names to the new field names.
+ */
+const LEGACY_JOB_DATA_FIELDS: Record<string, string> = {
+  organization: "organizationId",
+  orgId: "organizationId",
+};
+
+/**
+ * Migrates & normalizes job data to ensure we
+ * only need to handle the latest format.
+ *
+ * NB: It modifies the original data object in place.
+ */
+function migrateJobData(data: Record<string, unknown> | undefined): void {
+  if (!data) return;
+  for (const [legacy, updated] of Object.entries(LEGACY_JOB_DATA_FIELDS)) {
+    if (data[legacy] !== undefined && data[updated] === undefined) {
+      data[updated] = data[legacy];
+    }
+  }
+}
+
+/**
+ * Extracts contextual attributes from job data for trace spans.
+ * Captures any string field ending in "Id" (organizationId, experimentId, etc.)
+ */
+function extractJobAttributesForSpan(
+  data: Record<string, unknown> | undefined,
+): Record<string, string> {
+  const attributes: Record<string, string> = {};
+  if (!data) return attributes;
+
+  for (const [key, value] of Object.entries(data)) {
+    if (typeof value === "string" && key.toLowerCase().endsWith("id")) {
+      const attrName = key.slice(0, -2).toLowerCase() + ".id";
+      attributes[attrName] = value;
+    }
+  }
+
+  return attributes;
 }


### PR DESCRIPTION
### Features and Changes

For exceptions that happen in our Jobs (managed by Agenda), our error tracking is treating all of them as a single trace because this is a long-running process.

This fixes it by manually creating spans for the job execution context.

- [x] Create span for each job execution
- [x] Add organizationId for all jobs that are associated with an organization
- [x] Add additional information to the span based on jobs attributes

### Screenshots

#### Before

Note how the time is up to 6 minutes, showing how multiple jobs executions (this one is scheduled for every 5 minutes) are being aggregated on the same trace, making it hard to understand a per-job issues/errors.

<img width="618" height="240" alt="Screenshot 2026-02-13 at 10 30 20 AM" src="https://github.com/user-attachments/assets/09b337a4-f726-401c-abcd-6c89d23de546" />

#### After

See how we have 2 separate Trace IDs and they end in milliseconds.

<img width="617" height="125" alt="Screenshot 2026-02-13 at 10 31 16 AM" src="https://github.com/user-attachments/assets/13f3338b-20c6-4a3e-8273-b12106889e50" />
<img width="609" height="131" alt="Screenshot 2026-02-13 at 10 31 03 AM" src="https://github.com/user-attachments/assets/7ea0d334-1084-43cd-9880-f29087e4bc50" />