### PR TITLE
add custom styling to limit max width on smaller viewports

### DIFF
--- a/docs/src/styles/custom.scss
+++ b/docs/src/styles/custom.scss
@@ -275,6 +275,28 @@
   display: none;
 }
 
+// Custom widths — shared max-width and centering so navbar and main content align
+$content-max-width: 92rem;
+
+.navbar__inner,
+.main-wrapper {
+  margin-inline: auto;
+  max-width: $content-max-width;
+  width: 100%;
+}
+
+@media (min-width: $content-max-width) {
+  .navbar {
+    padding-inline: max(0px, (100vw - $content-max-width) / 2);
+  }
+
+  .navbar__inner {
+    padding-inline-start: calc(
+      var(--ifm-menu-link-padding-horizontal) + 0.5rem
+    );
+  }
+}
+
 [class^="docItemContainer"] {
   max-width: 688px;
 }


### PR DESCRIPTION
On large viewports, our docs stretched across the whole screen, making the sidebar hang out awkwardly alone on the side:

<img width="3422" height="965" alt="CleanShot 2026-02-13 at 17 05 31" src="https://github.com/user-attachments/assets/3a789043-ba9d-4fef-90d1-b4d8a2fee43c" />

This update restrains max width so that the content is kept together:
<img width="3422" height="965" alt="CleanShot 2026-02-13 at 17 05 56" src="https://github.com/user-attachments/assets/333f07be-88b7-48dc-8c14-3317f819fc71" />
