### PR TITLE
[HOTFIX] Filter out invalid metrics from experiment create/update

### DIFF
--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -1083,7 +1083,7 @@ export async function postExperiments(
   const experimentType = data.type ?? "standard";
   const holdoutId = data.holdoutId;
 
-  // TODO: Added as a hotfix. Remove when issue is resolved.
+  // TODO: Added as a hotfix. Remove when issue #5316 is fixed.
   // Filter out invalid metric ids from the data
   if (invalidMetricIds.length) {
     data.goalMetrics = data.goalMetrics?.filter(
@@ -1420,7 +1420,7 @@ export async function postExperiment(
         } else {
           // new metric that's not recognized...
           invalidMetricIds.push(newMetricIds[i]);
-          // TODO: Commented out as a hotfix. Remove when we figure out why this is happening from the UI
+          // TODO: Commented out as a hotfix. Remove when issue #5316 is fixed.
           // res.status(403).json({
           //   status: 403,
           //   message: "Unknown metric: " + newMetricIds[i],
@@ -1430,7 +1430,7 @@ export async function postExperiment(
       }
     }
 
-    // TODO: Added as a hotfix. Remove when issue is resolved.
+    // TODO: Added as a hotfix. Remove when issue #5316 is fixed.
     // Filter out invalid metric ids from the data
     if (invalidMetricIds.length) {
       data.goalMetrics = data.goalMetrics?.filter(

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -3425,7 +3425,7 @@ export async function validateExperimentData(
         } else {
           // new metric that's not recognized...
           invalidMetricIds.push(metricIds[i]);
-          // TODO: Commented out as a hotfix. Remove when we figure out why this is happening from the UI
+          // TODO: Commented out as a hotfix. Remove when issue #5316 is fixed.
           // throw new Error("Unknown metric: " + metricIds[i]);
         }
       }


### PR DESCRIPTION
### Features and Changes

#5316 

Hotfix to temporarily not throw an error when an unknown metric is passed in to experiment update/create while we figure out the underlying issue.
See https://growthbookapp.slack.com/archives/C05QYS2UFRD/p1770905452163769

### Testing

- [x] Create/Update an experiment with valid metrics. Should persist all metrics
- [x] Make a create/update request with a mix of valid/invalid metrics. Invalid metrics should be removed

