### PR TITLE
fix(safe-rollouts): Fix blocked Safe Rollout update after starting

### DIFF
--- a/packages/back-end/src/models/SafeRolloutModel.ts
+++ b/packages/back-end/src/models/SafeRolloutModel.ts
@@ -114,6 +114,7 @@ export class SafeRolloutModel extends BaseClass {
         "analysisSummary",
         "pastNotifications",
         "rampUpSchedule",
+        "dateUpdated",
       ];
 
       // Check for disallowed field updates


### PR DESCRIPTION
### Features and Changes

Attempting to edit a safe rollout after starting it was throwing:
`Cannot update field 'dateUpdated' after the Safe Rollout has started.`
We have a `beforeUpdate` base model validator in place for safe rollouts that was blocking `dateUpdated` from being changed, but the base model updates `dateUpdated` before calling `beforeUpdate`.

### Testing

- [x] Edit a running safe rollout and the request should succeed

