### PR TITLE
Scope refresh token cookie to /auth path

### DIFF
--- a/packages/back-end/src/util/cookie.ts
+++ b/packages/back-end/src/util/cookie.ts
@@ -3,22 +3,38 @@ import { Request, Response } from "express";
 class Cookie {
   private key: string;
   private expires: number;
-  constructor(key: string, expires: number) {
+  private path?: string;
+  constructor(key: string, expires: number, path?: string) {
     this.key = key;
     this.expires = expires;
+    this.path = path;
   }
 
   setValue(value: string, req: Request, res: Response, maxAge: number = 0) {
+    const opts: {
+      httpOnly: boolean;
+      maxAge: number;
+      secure: boolean;
+      path?: string;
+    } = {
+      httpOnly: true,
+      maxAge: maxAge || this.expires,
+      secure: req.secure,
+    };
+    if (this.path) {
+      opts.path = this.path;
+    }
+
     if (!value) {
+      res.clearCookie(this.key, opts);
+    } else {
+      res.cookie(this.key, value, opts);
+    }
+
+    // Clear any legacy cookie at the default path during transition
+    if (this.path) {
       res.clearCookie(this.key, {
         httpOnly: true,
-        maxAge: maxAge || this.expires,
-        secure: req.secure,
-      });
-    } else {
-      res.cookie(this.key, value, {
-        httpOnly: true,
-        maxAge: maxAge || this.expires,
         secure: req.secure,
       });
     }
@@ -38,6 +54,10 @@ function minutes(n: number) {
   return n * 60 * 1000;
 }
 export const SSOConnectionIdCookie = new Cookie("SSO_CONNECTION_ID", days(30));
-export const RefreshTokenCookie = new Cookie("AUTH_REFRESH_TOKEN", days(30));
+export const RefreshTokenCookie = new Cookie(
+  "AUTH_REFRESH_TOKEN",
+  days(30),
+  "/auth",
+);
 export const IdTokenCookie = new Cookie("AUTH_ID_TOKEN", minutes(15));
 export const AuthChecksCookie = new Cookie("AUTH_CHECKS", minutes(10));


### PR DESCRIPTION
### Features and Changes

Courtesy of @R167 in #5307, but forked locally to fix the linter errors

### Dependencies

The exact `path` for this cookie will likely need to be changed to be able to run back-end and front-end from the same domain, but that can be punted until we decide on an approach

### Testing

- [x] On `main`, inspecting the cookie shows `path: "/"`
- [x] Swapping to this branch, initial pageload doesn't force a new login
- [x] Inspecting the cookie shows the path updated to `/auth`
- [x] Logout clears the cookie
- [x] Logging in sets it again and has no issues