### PR TITLE
delete npm from docker image and uninstall python build tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN \
     && poetry export -f requirements.txt --output requirements.txt \
     && pip install --no-cache-dir -r requirements.txt \
     && pip install --no-cache-dir dist/*.whl ddtrace==4.3.2 \
-    && pip uninstall -y poetry poetry-core poetry-plugin-export keyring jaraco.classes jaraco.context jaraco.functools setuptools wheel; \
+    && pip uninstall -y poetry poetry-core poetry-plugin-export keyring jaraco.classes setuptools wheel; \
   else \
     pip install --no-cache-dir poetry==1.8.5 \
     && poetry install --no-root --without dev --no-interaction --no-ansi \
@@ -40,7 +40,7 @@ RUN \
     && poetry export -f requirements.txt --output requirements.txt \
     && pip install --no-cache-dir -r requirements.txt \
     && pip install --no-cache-dir dist/*.whl ddtrace==4.3.2 \
-    && pip uninstall -y poetry poetry-core poetry-plugin-export keyring jaraco.classes jaraco.context jaraco.functools setuptools wheel;\
+    && pip uninstall -y poetry poetry-core poetry-plugin-export keyring jaraco.classes setuptools wheel;\
   fi
 
 # Build the nodejs app


### PR DESCRIPTION
### Features and Changes
There are often security vulnerabilities in our build tools. As the build tools are not actually used in the image, they are not true security vulnerabilities.  By deleting our build tools when we are done with them, we avoid having to track down these issues in the future.

### Testing
In preview env refresh the example experiment stats.
