### PR TITLE
fix(features): Recalculate nextScheduledUpdate for API updates

### DIFF
--- a/packages/back-end/src/api/features/updateFeature.ts
+++ b/packages/back-end/src/api/features/updateFeature.ts
@@ -4,7 +4,7 @@ import {
   validateScheduleRules,
 } from "shared/util";
 import { isEqual } from "lodash";
-import { UpdateFeatureResponse } from "shared/types/openapi";
+import type { UpdateFeatureResponse } from "shared/types/openapi";
 import { updateFeatureValidator, RevisionRules } from "shared/validators";
 import { FeatureInterface } from "shared/types/feature";
 import { FeatureRevisionInterface } from "shared/types/feature-revision";
@@ -17,6 +17,7 @@ import { getExperimentMapForFeature } from "back-end/src/models/ExperimentModel"
 import {
   addIdsToRules,
   getApiFeatureObj,
+  getNextScheduledUpdate,
   getSavedGroupMap,
   updateInterfaceEnvSettingsFromApiEnvSettings,
 } from "back-end/src/services/features";
@@ -184,6 +185,13 @@ export const updateFeature = createApiRequestHandler(updateFeatureValidator)(
         req.context.permissions.throwPermissionError();
       }
       addIdsToRules(updates.environmentSettings, feature.id);
+    }
+
+    if (updates.environmentSettings) {
+      updates.nextScheduledUpdate = getNextScheduledUpdate(
+        updates.environmentSettings,
+        orgEnvs,
+      );
     }
 
     // Create a revision for the changes and publish them immediately

--- a/packages/back-end/test/api/features.test.ts
+++ b/packages/back-end/test/api/features.test.ts
@@ -5,11 +5,18 @@ import {
   getFeature,
   updateFeature,
 } from "back-end/src/models/FeatureModel";
+import {
+  createRevision,
+  getRevision,
+} from "back-end/src/models/FeatureRevisionModel";
+import { getExperimentMapForFeature } from "back-end/src/models/ExperimentModel";
 import { addTags } from "back-end/src/models/TagModel";
 import {
   getSavedGroupMap,
   getApiFeatureObj,
   createInterfaceEnvSettingsFromApiEnvSettings,
+  updateInterfaceEnvSettingsFromApiEnvSettings,
+  getNextScheduledUpdate,
 } from "back-end/src/services/features";
 import { setupApp } from "./api.setup";
 
@@ -24,21 +31,39 @@ jest.mock("back-end/src/models/TagModel", () => ({
   addTagsDiff: jest.fn(),
 }));
 
+jest.mock("back-end/src/models/ExperimentModel", () => ({
+  getExperimentMapForFeature: jest.fn(),
+}));
+
+jest.mock("back-end/src/models/FeatureRevisionModel", () => ({
+  createRevision: jest.fn(),
+  getRevision: jest.fn(),
+}));
+
 jest.mock("back-end/src/services/features", () => ({
   getApiFeatureObj: jest.fn(),
   getSavedGroupMap: jest.fn(),
+  getNextScheduledUpdate: jest.fn(),
   addIdsToRules: jest.fn(),
   createInterfaceEnvSettingsFromApiEnvSettings: jest.fn(),
+  updateInterfaceEnvSettingsFromApiEnvSettings: jest.fn(),
 }));
 
 describe("features API", () => {
   const { app, auditMock, setReqContext } = setupApp();
+  const org = { id: "org", settings: { environments: [{ id: "production" }] } };
+
+  beforeEach(() => {
+    (getApiFeatureObj as jest.Mock).mockImplementation((v) => v);
+    (getSavedGroupMap as jest.Mock).mockResolvedValue("savedGroupMap");
+    (getExperimentMapForFeature as jest.Mock).mockResolvedValue(new Map());
+    (getRevision as jest.Mock).mockResolvedValue(null);
+    (getNextScheduledUpdate as jest.Mock).mockReturnValue(null);
+  });
 
   afterEach(() => {
     jest.clearAllMocks();
   });
-
-  const org = { id: "org", settings: { environments: [{ id: "production" }] } };
 
   it("can create new features", async () => {
     setReqContext({
@@ -313,6 +338,201 @@ describe("features API", () => {
             groupMap: "savedGroupMap",
           }),
         }),
+      );
+    });
+  });
+
+  describe("nextScheduledUpdate", () => {
+    it("writes nextScheduledUpdate when scheduleRules are updated via API", async () => {
+      setReqContext({
+        org,
+        models: {
+          safeRollout: {
+            getAllPayloadSafeRollouts: jest.fn().mockResolvedValue(new Map()),
+          },
+        },
+        permissions: {
+          canPublishFeature: () => true,
+          canUpdateFeature: () => true,
+          canBypassApprovalChecks: () => true,
+        },
+        hasPremiumFeature: () => true,
+        getProjects: async () => [{ id: "project_1" }],
+      });
+
+      const existingFeature: FeatureInterface = {
+        organization: org.id,
+        defaultValue: "false",
+        valueType: "boolean",
+        owner: "owner",
+        description: "description",
+        project: "project_1",
+        id: "myexistingfeature",
+        archived: false,
+        tags: [],
+        dateCreated: new Date(),
+        dateUpdated: new Date(),
+        version: 10,
+        environmentSettings: {
+          production: {
+            enabled: true,
+            rules: [],
+          },
+        },
+        prerequisites: [],
+      };
+
+      const startTs = "2026-02-20T08:00:00.000Z";
+      const endTs = "2026-02-25T08:00:00.000Z";
+      const nextScheduledUpdate = new Date(startTs);
+      const updatedEnvironmentSettings = {
+        production: {
+          enabled: true,
+          rules: [
+            {
+              id: "fr_test",
+              type: "force",
+              description: "scheduled force",
+              condition: "",
+              value: "true",
+              enabled: true,
+              savedGroups: [],
+              scheduleRules: [
+                {
+                  enabled: true,
+                  timestamp: startTs,
+                },
+                {
+                  enabled: false,
+                  timestamp: endTs,
+                },
+              ],
+            },
+          ],
+        },
+      };
+
+      (getFeature as jest.Mock).mockResolvedValue(existingFeature);
+      (
+        updateInterfaceEnvSettingsFromApiEnvSettings as jest.Mock
+      ).mockReturnValue(updatedEnvironmentSettings);
+      (getNextScheduledUpdate as jest.Mock).mockReturnValue(
+        nextScheduledUpdate,
+      );
+      (createRevision as jest.Mock).mockResolvedValue({ version: 11 });
+      (updateFeature as jest.Mock).mockImplementation((ctx, feature, updates) =>
+        Promise.resolve({ ...feature, ...updates }),
+      );
+
+      const response = await request(app)
+        .post(`/api/v1/features/${existingFeature.id}`)
+        .send({
+          environments: {
+            production: {
+              enabled: true,
+              rules: [
+                {
+                  id: "fr_test",
+                  type: "force",
+                  description: "scheduled force",
+                  condition: "",
+                  value: "true",
+                  enabled: true,
+                  scheduleRules: [
+                    { enabled: true, timestamp: startTs },
+                    { enabled: false, timestamp: endTs },
+                  ],
+                },
+              ],
+            },
+          },
+        });
+
+      expect(response.status).toBe(200);
+      expect(updateFeature).toHaveBeenCalledWith(
+        expect.anything(),
+        existingFeature,
+        expect.objectContaining({
+          environmentSettings: updatedEnvironmentSettings,
+          nextScheduledUpdate,
+        }),
+      );
+    });
+
+    it("does not modify nextScheduledUpdate if there are no environment updates", async () => {
+      setReqContext({
+        org,
+        models: {
+          safeRollout: {
+            getAllPayloadSafeRollouts: jest.fn().mockResolvedValue(new Map()),
+          },
+        },
+        permissions: {
+          canPublishFeature: () => true,
+          canUpdateFeature: () => true,
+        },
+        getProjects: async () => [{ id: "project_1" }, { id: "project_2" }],
+      });
+
+      const existingFeature: FeatureInterface = {
+        organization: org.id,
+        defaultValue: "false",
+        valueType: "boolean",
+        owner: "owner",
+        description: "description",
+        project: "project_1",
+        id: "myexistingfeature",
+        archived: false,
+        tags: [],
+        dateCreated: new Date(),
+        dateUpdated: new Date(),
+        version: 10,
+        environmentSettings: {
+          production: {
+            enabled: true,
+            rules: [
+              {
+                id: "fr_schedule",
+                type: "force",
+                condition: "",
+                value: "true",
+                savedGroups: [],
+                scheduleRules: [
+                  {
+                    enabled: true,
+                    timestamp: "2026-02-20T08:00:00.000Z",
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        prerequisites: [],
+      };
+
+      const preservedNextScheduledUpdate = new Date("2026-02-20T08:00:00.000Z");
+
+      (getFeature as jest.Mock).mockResolvedValue(existingFeature);
+      (getNextScheduledUpdate as jest.Mock).mockImplementation((envSettings) =>
+        envSettings ? preservedNextScheduledUpdate : null,
+      );
+      (updateFeature as jest.Mock).mockImplementation((ctx, feature, updates) =>
+        Promise.resolve({ ...feature, ...updates }),
+      );
+
+      const response = await request(app)
+        .post(`/api/v1/features/${existingFeature.id}`)
+        .send({
+          project: "project_2",
+        });
+
+      expect(response.status).toBe(200);
+      expect(updateFeature).toHaveBeenCalledWith(
+        expect.anything(),
+        existingFeature,
+        {
+          project: "project_2",
+        },
       );
     });
   });


### PR DESCRIPTION
### Features and Changes

We use `nextScheduledUpdate` to control when feature should be updated, and that is what powers our `Scheduled Features` functionality, allowing users to defined when a rule should be automatically turned on/off.

While our UI flow works correctly via `applyRevision`, the public API bypasses that and requires the revision to be published immediately.

In this latter case we were not recalculating `nextScheduledUpdate`, meaning that if we added Scheduled Rules via the API, they would not be honored unless a manual change was applied via the UI later.

This is now fixed.