### PR TITLE
Improves permission check on teams

### DIFF
--- a/packages/back-end/src/models/TeamModel.ts
+++ b/packages/back-end/src/models/TeamModel.ts
@@ -102,7 +102,7 @@ export class TeamModel extends BaseClass {
   protected canCreate(): boolean {
     return this.context.permissions.canManageTeam();
   }
-  protected canRead(team: TeamInterface): boolean {
+  protected canRead(): boolean {
     // Teams aren't project-scoped and they're used to build a user's permissions, so the `readData` check doesn't work
     return true;
   }


### PR DESCRIPTION
### Features and Changes
This PR fixes a bug that ultimately lead to some permission errors.

In the `TeamModel`, we have a `canRead` function that is called when someone uses the `getAll` method of the `BaseModel` that filters out any resources the user doesn't have read access for.

In this case, `canRead` was checking the `canManageTeam` permission, so unless someone was an admin, the `teams` array being returned from the `getAll` call was an empty array.

And when building a user's permissions for the front-end, we require the data included in the `teams` array so we know if a user is a member of a team, and should inherit any of the team's roles/permissions.

So in this case, since the `teams` array was an empty array, when we were building a user's permissions for the front-end, we were ignoring any permissions the user should've inherited from the team or teams they were a part of.

Teams are a bit different from other resources in GrowthBook in that they're not project-scoped - instead, a team can have multiple project roles. So we can't just check and see if the user has read access for atleast 1 of a team's projects.

So in the `canRead` helper, we're not filtering out any teams if the user has the `canManageTeam` permission globally, OR if the current user is a member of a particular team. This way, we return only the minimal amount of teams needed to correctly build a user's permissions for the front-end. This prevents us from leaking ALL teams in an organization to a member who might only have readAccess for a singular project.

And, there is still the `bypassReadPermissionChecks` we can use for other use cases.

### Dependencies

- None

### Testing

- [x] Log in as a user who's global role is `noAccess` and is a member of a team that also has a global role of `noaccess` but has an 'experimenter' role for a single project in the app - ensure that when you log in as that user, you can only view the single project and you have the correct experimenter permissions
- [x] Log in as an admin and ensure you can see ALL teams via the UserContext
