### PR TITLE
Fix: preserve ignore zeros on fact metric REST API create

### DIFF
--- a/packages/back-end/src/api/fact-metrics/postFactMetric.ts
+++ b/packages/back-end/src/api/fact-metrics/postFactMetric.ts
@@ -172,6 +172,7 @@ export async function getCreateMetricPropsFromBody(
   if (cappingSettings?.type && cappingSettings?.type !== "none") {
     data.cappingSettings.type = cappingSettings.type;
     data.cappingSettings.value = cappingSettings.value || 0;
+    data.cappingSettings.ignoreZeros = cappingSettings.ignoreZeros || false;
   }
 
   if (windowSettings?.type && windowSettings?.type !== "none") {


### PR DESCRIPTION
We were not persisting the `ignoreZeros` setting and typescript wasn't complaining since it is "optional". Probably a more robust fix here would be good, but this patches the current behavior.

Tested the post endpoint:
```
curl -s -X POST http://localhost:3100/api/v1/fact-metrics \
  -H "Content-Type: application/json" \
  -u MY_KEY: \
  -d '{
    "name": "Test Ignore Zeros",
    "metricType": "mean",
    "numerator": {
      "factTableId": "MY_FACT_TABLE_ID",
      "column": "$$distinctUsers"
    },
    "cappingSettings": {
      "type": "percentile",
      "value": 0.995,
      "ignoreZeros": true
    }
  }'
```

Closes #5342 