### PR TITLE
Migrate AuditModel to BaseModel

### DIFF
--- a/packages/back-end/src/models/AuditModel.ts
+++ b/packages/back-end/src/models/AuditModel.ts
@@ -1,233 +1,176 @@
-import mongoose, { FilterQuery, QueryOptions } from "mongoose";
-import uniqid from "uniqid";
 import { AuditInterface, EntityType } from "shared/types/audit";
-import {
-  removeMongooseFields,
-  ToInterface,
-} from "back-end/src/util/mongo.util";
+import { auditSchema } from "shared/validators";
+import { CreateProps } from "shared/types/base-model";
+import { getCollection } from "back-end/src/util/mongo.util";
+import { FindOptions, MakeModelClass, ScopedFilterQuery } from "./BaseModel";
 
-const auditSchema = new mongoose.Schema({
-  id: {
-    type: String,
-    unique: true,
-  },
-  organization: {
-    type: String,
-    index: true,
-  },
-  user: {
-    _id: false,
-    id: String,
-    email: String,
-    name: String,
-    apiKey: String,
-  },
-  reason: String,
-  event: String,
-  entity: {
-    _id: false,
-    object: String,
-    id: String,
-    name: String,
-  },
-  parent: {
-    _id: false,
-    object: String,
-    id: String,
-  },
-  details: String,
-  dateCreated: Date,
+const COLLECTION_NAME = "audits";
+const BaseClass = MakeModelClass({
+  schema: auditSchema,
+  collectionName: COLLECTION_NAME,
+  idPrefix: "aud_",
+  globallyUniqueIds: false,
+  readonlyFields: [],
+  additionalIndexes: [
+    {
+      fields: { "user.id": 1, organization: 1 },
+    },
+    { fields: { organization: 1, "entity.object": 1, "entity.id": 1 } },
+    { fields: { organization: 1, "parent.object": 1, "parent.id": 1 } },
+  ],
 });
 
-type AuditDocument = mongoose.Document & AuditInterface;
+export class AuditModel extends BaseClass {
+  protected canCreate(): boolean {
+    return true;
+  }
+  protected canRead(): boolean {
+    return true;
+  }
+  protected canUpdate(): boolean {
+    return true;
+  }
+  protected canDelete(): boolean {
+    return true;
+  }
 
-const AuditModel = mongoose.model<AuditInterface>("Audit", auditSchema);
+  public async findRecentAuditByUserId(userId: string) {
+    return await this._find(
+      {
+        "user.id": userId,
+      },
+      {
+        limit: 10,
+        projection: {
+          details: 0,
+        },
+        sort: { dateCreated: -1 },
+      },
+    );
+  }
 
-const toInterface: ToInterface<AuditInterface> = (doc: AuditDocument) => {
-  return removeMongooseFields(doc);
-};
+  public async findAuditByEntity(
+    type: EntityType,
+    id: string,
+    options?: FindOptions<AuditInterface>,
+    customFilter?: ScopedFilterQuery<typeof auditSchema>,
+  ): Promise<AuditInterface[]> {
+    return await this._find(
+      {
+        "entity.object": type,
+        "entity.id": id,
+        ...customFilter,
+      },
+      options,
+    );
+  }
 
-export async function insertAudit(
-  data: Omit<AuditInterface, "id">,
-): Promise<AuditInterface> {
-  const auditDoc = await AuditModel.create({
-    ...data,
-    id: uniqid("aud_"),
-  });
-  return toInterface(auditDoc);
-}
+  public async findAuditByEntityList(
+    type: EntityType,
+    ids: string[],
+    customFilter?: ScopedFilterQuery<typeof auditSchema>,
+    options?: FindOptions<AuditInterface>,
+  ): Promise<AuditInterface[]> {
+    return await this._find(
+      {
+        "entity.object": type,
+        "entity.id": {
+          $in: ids,
+        },
+        ...customFilter,
+      },
+      options,
+    );
+  }
 
-/**
- * find all audits by user id and organization
- * @param userId
- * @param organization
- */
-export async function findRecentAuditByUserIdAndOrganization(
-  userId: string,
-  organization: string,
-): Promise<Omit<AuditInterface, "details">[]> {
-  const userAudits = await AuditModel.find({
-    "user.id": userId,
-    organization,
-  })
-    .select("-details")
-    .limit(10)
-    .sort({ dateCreated: -1 });
-  const transformed = userAudits.map((doc) => toInterface(doc));
-  return transformed;
-}
+  public async findAuditByEntityParent(
+    type: EntityType,
+    id: string,
+    options?: FindOptions<AuditInterface>,
+    customFilter?: ScopedFilterQuery<typeof auditSchema>,
+  ): Promise<AuditInterface[]> {
+    return await this._find(
+      {
+        "parent.object": type,
+        "parent.id": id,
+        ...customFilter,
+      },
+      options,
+    );
+  }
 
-export async function findAuditByOrganization(
-  organization: string,
-  options?: QueryOptions,
-): Promise<AuditInterface[]> {
-  const auditDocs = await AuditModel.find(
-    {
-      organization,
-    },
-    options,
-  );
-  return auditDocs.map((doc) => toInterface(doc));
-}
+  public async findAllAuditsByEntityType(
+    type: EntityType,
+    options?: FindOptions<AuditInterface>,
+    customFilter?: ScopedFilterQuery<typeof auditSchema>,
+  ): Promise<AuditInterface[]> {
+    return await this._find(
+      {
+        "entity.object": type,
+        ...customFilter,
+      },
+      options,
+    );
+  }
 
-export async function findAuditByEntity(
-  organization: string,
-  type: EntityType,
-  id: string,
-  options?: QueryOptions,
-  customFilter?: FilterQuery<AuditDocument>,
-): Promise<AuditInterface[]> {
-  const auditDocs = await AuditModel.find(
-    {
-      organization,
+  public async findAllAuditsByEntityTypeParent(
+    type: EntityType,
+    options?: FindOptions<AuditInterface>,
+    customFilter?: ScopedFilterQuery<typeof auditSchema>,
+  ): Promise<AuditInterface[]> {
+    return await this._find(
+      {
+        "parent.object": type,
+        ...customFilter,
+      },
+      options,
+    );
+  }
+
+  public async countAuditByEntity(
+    type: EntityType,
+    id: string,
+  ): Promise<number> {
+    return await this._countDocuments({
       "entity.object": type,
       "entity.id": id,
-      ...customFilter,
-    },
-    null,
-    options,
-  );
-  return auditDocs.map((doc) => toInterface(doc));
-}
+    });
+  }
 
-export async function findAuditByEntityList(
-  organization: string,
-  type: EntityType,
-  ids: string[],
-  customFilter?: FilterQuery<AuditDocument>,
-  options?: QueryOptions,
-): Promise<AuditInterface[]> {
-  const auditDocs = await AuditModel.find(
-    {
-      organization,
-      "entity.object": type,
-      "entity.id": {
-        $in: ids,
-      },
-      ...customFilter,
-    },
-    null,
-    options,
-  );
-  return auditDocs.map((doc) => toInterface(doc));
-}
-
-export async function findAuditByEntityParent(
-  organization: string,
-  type: EntityType,
-  id: string,
-  options?: QueryOptions,
-  customFilter?: FilterQuery<AuditDocument>,
-): Promise<AuditInterface[]> {
-  const auditDocs = await AuditModel.find(
-    {
-      organization,
+  public async countAuditByEntityParent(
+    type: EntityType,
+    id: string,
+  ): Promise<number> {
+    return await this._countDocuments({
       "parent.object": type,
       "parent.id": id,
-      ...customFilter,
-    },
-    null,
-    options,
-  );
-  return auditDocs.map((doc) => toInterface(doc));
-}
+    });
+  }
 
-export async function findAllAuditsByEntityType(
-  organization: string,
-  type: EntityType,
-  options?: QueryOptions,
-  customFilter?: FilterQuery<AuditDocument>,
-): Promise<AuditInterface[]> {
-  const auditDocs = await AuditModel.find(
-    {
-      organization,
+  public async countAllAuditsByEntityType(type: EntityType): Promise<number> {
+    return await this._countDocuments({
       "entity.object": type,
-      ...customFilter,
-    },
-    null,
-    options,
-  );
-  return auditDocs.map((doc) => toInterface(doc));
-}
+    });
+  }
 
-export async function findAllAuditsByEntityTypeParent(
-  organization: string,
-  type: EntityType,
-  options?: QueryOptions,
-  customFilter?: FilterQuery<AuditDocument>,
-): Promise<AuditInterface[]> {
-  const auditDocs = await AuditModel.find(
-    {
-      organization,
+  public async countAllAuditsByEntityTypeParent(
+    type: EntityType,
+  ): Promise<number> {
+    return await this._countDocuments({
       "parent.object": type,
-      ...customFilter,
-    },
-    null,
-    options,
-  );
-  return auditDocs.map((doc) => toInterface(doc));
-}
+    });
+  }
 
-export async function countAuditByEntity(
-  organization: string,
-  type: EntityType,
-  id: string,
-): Promise<number> {
-  return await AuditModel.countDocuments({
-    organization,
-    "entity.object": type,
-    "entity.id": id,
-  });
-}
-
-export async function countAuditByEntityParent(
-  organization: string,
-  type: EntityType,
-  id: string,
-): Promise<number> {
-  return await AuditModel.countDocuments({
-    organization,
-    "parent.object": type,
-    "parent.id": id,
-  });
-}
-
-export async function countAllAuditsByEntityType(
-  organization: string,
-  type: EntityType,
-): Promise<number> {
-  return await AuditModel.countDocuments({
-    organization,
-    "entity.object": type,
-  });
-}
-
-export async function countAllAuditsByEntityTypeParent(
-  organization: string,
-  type: EntityType,
-): Promise<number> {
-  return await AuditModel.countDocuments({
-    organization,
-    "parent.object": type,
-  });
+  public static async dangerousInsertRawAuditForOrg(
+    orgId: string,
+    data: CreateProps<AuditInterface>,
+  ) {
+    const docToInsert = {
+      ...data,
+      organization: orgId,
+      dateCreated: new Date(),
+      dateUpdated: new Date(),
+    };
+    await getCollection(COLLECTION_NAME).insertOne(docToInsert);
+  }
 }

--- a/packages/back-end/src/models/BaseModel.ts
+++ b/packages/back-end/src/models/BaseModel.ts
@@ -91,6 +91,18 @@ export type IndexableFieldPath<T> = T extends object
     : keyof T
   : never;
 
+export type FindOptions<T> = {
+  sort?: Partial<{
+    [key in keyof Omit<z.infer<T>, "organization">]: 1 | -1;
+  }>;
+  limit?: number;
+  skip?: number;
+  bypassReadPermissionChecks?: boolean;
+  // Note: projection does not work when using config.yml
+  projection?: Partial<Record<keyof z.infer<T>, 0 | 1>>;
+  dangerousCrossOrganization?: boolean;
+};
+
 export interface ModelConfig<
   T extends BaseSchema,
   Entity extends EntityType,
@@ -514,17 +526,7 @@ export abstract class BaseModel<
       bypassReadPermissionChecks,
       projection,
       dangerousCrossOrganization,
-    }: {
-      sort?: Partial<{
-        [key in keyof Omit<z.infer<T>, "organization">]: 1 | -1;
-      }>;
-      limit?: number;
-      skip?: number;
-      bypassReadPermissionChecks?: boolean;
-      // Note: projection does not work when using config.yml
-      projection?: Partial<Record<keyof z.infer<T>, 0 | 1>>;
-      dangerousCrossOrganization?: boolean;
-    } = {},
+    }: FindOptions<T> = {},
   ) {
     const fullQuery = this.applyBaseQuery(query, dangerousCrossOrganization);
     let rawDocs;

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -255,7 +255,9 @@ export async function getAllHistory(
   const { org } = context;
   const { type } = req.params;
   const limit = Math.min(parseInt(req.query.limit || "50"), 100); // Max 100 per page
-  const cursor = req.query.cursor ? new Date(req.query.cursor) : null;
+  const maxDateCreated = req.query.cursor
+    ? new Date(req.query.cursor)
+    : undefined;
 
   if (!isValidAuditEntityType(type)) {
     return res.status(400).json({
@@ -271,26 +273,19 @@ export async function getAllHistory(
   ]);
   const total = entityCount + parentCount;
 
-  const cursorFilter = cursor ? { dateCreated: { $lt: cursor } } : undefined;
   const fetchLimit = limit;
 
   const events = await Promise.all([
-    context.models.audits.findAllAuditsByEntityType(
+    context.models.audits.findAllAuditsByEntityType({
       type,
-      {
-        limit: fetchLimit,
-        sort: { dateCreated: -1 },
-      },
-      cursorFilter,
-    ),
-    context.models.audits.findAllAuditsByEntityTypeParent(
+      limit: fetchLimit,
+      maxDateCreated,
+    }),
+    context.models.audits.findAllAuditsByEntityTypeParent({
       type,
-      {
-        limit: fetchLimit,
-        sort: { dateCreated: -1 },
-      },
-      cursorFilter,
-    ),
+      limit: fetchLimit,
+      maxDateCreated,
+    }),
   ]);
 
   // Merge and sort by dateCreated descending
@@ -337,7 +332,9 @@ export async function getHistory(
   const { org } = context;
   const { type, id } = req.params;
   const limit = Math.min(parseInt(req.query.limit || "50"), 100); // Max 100 per page
-  const cursor = req.query.cursor ? new Date(req.query.cursor) : null;
+  const maxDateCreated = req.query.cursor
+    ? new Date(req.query.cursor)
+    : undefined;
 
   if (!isValidAuditEntityType(type)) {
     return res.status(400).json({
@@ -353,29 +350,21 @@ export async function getHistory(
   ]);
   const total = entityCount + parentCount;
 
-  const cursorFilter = cursor ? { dateCreated: { $lt: cursor } } : undefined;
-
   const fetchLimit = limit;
 
   const events = await Promise.all([
-    context.models.audits.findAuditByEntity(
+    context.models.audits.findAuditByEntity({
       type,
       id,
-      {
-        limit: fetchLimit,
-        sort: { dateCreated: -1 },
-      },
-      cursorFilter,
-    ),
-    context.models.audits.findAuditByEntityParent(
+      limit: fetchLimit,
+      maxDateCreated,
+    }),
+    context.models.audits.findAuditByEntityParent({
       type,
       id,
-      {
-        limit: fetchLimit,
-        sort: { dateCreated: -1 },
-      },
-      cursorFilter,
-    ),
+      limit: fetchLimit,
+      maxDateCreated,
+    }),
   ]);
 
   // Merge and sort by dateCreated descending

--- a/packages/back-end/src/routers/users/users.controller.ts
+++ b/packages/back-end/src/routers/users/users.controller.ts
@@ -22,7 +22,6 @@ import {
 } from "back-end/src/models/WatchModel";
 import { getFeature } from "back-end/src/models/FeatureModel";
 import { getExperimentById } from "back-end/src/models/ExperimentModel";
-import { findRecentAuditByUserIdAndOrganization } from "back-end/src/models/AuditModel";
 
 function isValidWatchEntityType(type: string): boolean {
   if (type === "experiment" || type === "feature") {
@@ -32,8 +31,9 @@ function isValidWatchEntityType(type: string): boolean {
   }
 }
 export async function getHistoryByUser(req: AuthRequest<null>, res: Response) {
-  const { org, userId } = getContextFromReq(req);
-  const events = await findRecentAuditByUserIdAndOrganization(userId, org.id);
+  const context = getContextFromReq(req);
+  const { userId } = context;
+  const events = await context.models.audits.findRecentAuditByUserId(userId);
   res.status(200).json({
     status: 200,
     events,

--- a/packages/back-end/src/services/audit.ts
+++ b/packages/back-end/src/services/audit.ts
@@ -20,46 +20,30 @@ export async function getRecentWatchedAudits(
   const startTime = new Date();
   startTime.setDate(startTime.getDate() - 7);
 
-  const experimentsFilter = {
-    event: {
-      $in: [
-        "experiment.start",
-        "experiment.stop",
-        "experiment.phase",
-        "experiment.results",
-      ],
-    },
-    dateCreated: {
-      $gte: startTime,
-    },
-  };
+  const experiments = await context.models.audits.findAuditByEntityList({
+    type: "experiment",
+    ids: userWatches.experiments,
+    minDateCreated: startTime,
+    eventList: [
+      "experiment.start",
+      "experiment.stop",
+      "experiment.phase",
+      "experiment.results",
+    ],
+  });
 
-  const featuresFilter = {
-    event: {
-      $in: [
-        "feature.publish",
-        "feature.update",
-        "feature.toggle",
-        "feature.create",
-        "feature.delete",
-      ],
-    },
-    dateCreated: {
-      $gte: startTime,
-    },
-  };
-
-  const experiments = await context.models.audits.findAuditByEntityList(
-    "experiment",
-    userWatches.experiments,
-    experimentsFilter,
-  );
-
-  const features = await context.models.audits.findAuditByEntityList(
-    "feature",
-    userWatches.features,
-    featuresFilter,
-  );
+  const features = await context.models.audits.findAuditByEntityList({
+    type: "feature",
+    ids: userWatches.features,
+    minDateCreated: startTime,
+    eventList: [
+      "feature.publish",
+      "feature.update",
+      "feature.toggle",
+      "feature.create",
+      "feature.delete",
+    ],
+  });
 
   const all = experiments
     .concat(features)

--- a/packages/back-end/src/services/auth/index.ts
+++ b/packages/back-end/src/services/auth/index.ts
@@ -17,6 +17,7 @@ import {
   getUserByEmail,
 } from "back-end/src/models/UserModel";
 import {
+  getContextFromReq,
   getOrganizationById,
   validateLoginMethod,
 } from "back-end/src/services/organizations";
@@ -31,7 +32,6 @@ import {
   SSOConnectionIdCookie,
 } from "back-end/src/util/cookie";
 import { getUserPermissions } from "back-end/src/util/organization.util";
-import { insertAudit } from "back-end/src/models/AuditModel";
 import {
   getLicenseMetaData,
   getUserCodesForOrg,
@@ -266,15 +266,14 @@ export async function processJWT(
         "user" | "organization" | "dateCreated" | "id"
       >,
     ) => {
-      await insertAudit({
+      const context = getContextFromReq(req);
+      await context.models.audits.create({
         ...data,
         user: {
           id: user.id,
           email: user.email,
           name: user.name || "",
         },
-        organization: req.organization?.id || "",
-        dateCreated: new Date(),
       });
     };
   } else {

--- a/packages/back-end/src/types/AuthRequest.ts
+++ b/packages/back-end/src/types/AuthRequest.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from "express";
 import { SSOConnectionInterface } from "shared/types/sso-connection";
-import { AuditInterface } from "shared/types/audit";
+import { AuditInputData } from "shared/types/audit";
 import {
   EnvScopedPermission,
   GlobalPermission,
@@ -42,9 +42,7 @@ export type AuthRequest<
   superAdmin?: boolean;
   organization?: OrganizationInterface;
   teams: TeamInterface[];
-  audit: (
-    data: Omit<AuditInterface, "organization" | "id" | "user" | "dateCreated">,
-  ) => Promise<void>;
+  audit: (data: AuditInputData) => Promise<void>;
 } & PermissionFunctions;
 
 export type ResponseWithStatusAndError<T = unknown> = Response<

--- a/packages/back-end/types/api.d.ts
+++ b/packages/back-end/types/api.d.ts
@@ -2,11 +2,11 @@ import {
   AutoExperiment,
   FeatureRule as FeatureDefinitionRule,
 } from "@growthbook/growthbook";
-import { AuditInterfaceInput } from "shared/types/audit";
 import { EventUser } from "shared/types/events/event-types";
 import { ExperimentStatus } from "shared/types/experiment";
 import { OrganizationInterface } from "shared/types/organization";
 import { UserInterface } from "shared/types/user";
+import { AuditInputData } from "shared/types/audit";
 import { PermissionFunctions } from "back-end/src/types/AuthRequest";
 import { ReqContext } from "./request";
 
@@ -53,7 +53,7 @@ export type ApiRequestLocals = PermissionFunctions & {
   user?: UserInterface;
   organization: OrganizationInterface;
   eventAudit: EventUser;
-  audit: (data: AuditInterfaceInput) => Promise<void>;
+  audit: (data: AuditInputData) => Promise<void>;
   context: ApiReqContext;
 };
 

--- a/packages/shared/src/validators/audit.ts
+++ b/packages/shared/src/validators/audit.ts
@@ -1,0 +1,72 @@
+import { z } from "zod";
+import { entityEvents, entityTypes } from "shared/constants";
+import type { EventType } from "shared/types/audit";
+import { baseSchema } from "./base-model";
+
+export const auditUserLoggedIn = z.strictObject({
+  id: z.string(),
+  email: z.string(),
+  name: z.string(),
+});
+export const auditUserApiKey = z.strictObject({
+  apiKey: z.string(),
+});
+export const auditUserSystem = z.strictObject({
+  system: z.literal(true),
+});
+
+const auditUser = z.union([
+  auditUserLoggedIn,
+  auditUserApiKey,
+  auditUserSystem,
+]);
+
+const auditEntity = z.strictObject({
+  object: z.enum(entityTypes),
+  id: z.string(),
+  name: z.string().optional(),
+});
+
+const auditParent = z.strictObject({
+  object: z.enum(entityTypes),
+  id: z.string(),
+});
+
+const auditEvent: z.ZodType<EventType> = z.string() as z.ZodType<EventType>;
+
+export const auditSchema = baseSchema
+  .safeExtend({
+    user: auditUser,
+    reason: z.string().optional(),
+    event: auditEvent,
+    entity: auditEntity,
+    parent: auditParent.optional(),
+    details: z.string().optional(),
+  })
+  .superRefine((data, ctx) => {
+    const entity = data.entity.object;
+    if (data.parent && data.parent.object !== entity) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["parent", "object"],
+        message:
+          "parent.object must be of the same entity type as entity.object",
+      });
+    }
+    if (!data.event.startsWith(`${entity}.`)) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["event"],
+        message: `event must correspond to entity.object \`${entity}\``,
+      });
+    } else if (
+      // This case should be unreachable due to the original zod enum validation
+      !entityEvents[entity].some((event) => data.event === `${entity}.${event}`)
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["event"],
+        message: `event must be a valid event of format \`${entity}.{eventType}\``,
+      });
+    }
+  });

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -37,3 +37,4 @@ export * from "./sdk-connection-cache";
 export * from "./metric-group";
 export * from "./organization";
 export * from "./team";
+export * from "./audit";


### PR DESCRIPTION
### Features and Changes

Moves AuditModel to inherit from BaseModel and updates its usage across the app

The Zod schema was rather tricky due to Audits being a generic type, so it relies on `superRefine` for runtime validation and typecasting for simplicity at compile-time


### Testing

WIP