### PR TITLE
[fix] Not able to delete teams via SCIM

### DIFF
--- a/packages/back-end/src/models/TeamModel.ts
+++ b/packages/back-end/src/models/TeamModel.ts
@@ -132,7 +132,7 @@ export class TeamModel extends BaseClass {
       );
     }
 
-    if (team?.managedByIdp) {
+    if (team?.managedByIdp && !this.context.isApiRequest) {
       return this.context.throwBadRequestError(
         "Cannot delete a team that is being managed by an idP. Please delete the team through your idP.",
       );


### PR DESCRIPTION
### Features and Changes

Fix bug that was blocking teams from being deleted via SCIM (and other) API calls.