### PR TITLE
feat(cmd+k): Improve fuzzy matching

### DIFF
--- a/packages/front-end/components/CommandPalette/CommandPalette.tsx
+++ b/packages/front-end/components/CommandPalette/CommandPalette.tsx
@@ -1,6 +1,5 @@
 import { FC, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/router";
-import MiniSearch from "minisearch";
 import {
   BsSearch,
   BsToggleOn,
@@ -14,6 +13,7 @@ import { useDefinitions } from "@/services/DefinitionsContext";
 import { useFeaturesNames } from "@/hooks/useFeaturesNames";
 import { useExperiments } from "@/hooks/useExperiments";
 import { useDashboards } from "@/hooks/useDashboards";
+import { buildCommandPaletteIndex, combinedSearch } from "./searchUtils";
 import styles from "./CommandPalette.module.scss";
 
 type CommandPaletteItemType =
@@ -221,30 +221,13 @@ const CommandPalette: FC<{ onClose: () => void }> = ({ onClose }) => {
   ]);
 
   // MiniSearch index
-  const miniSearch = useMemo(() => {
-    const ms = new MiniSearch<CommandPaletteItem>({
-      fields: ["name", "description", "tags"],
-      storeFields: ["name"],
-      searchOptions: {
-        boost: { name: 3, description: 1 },
-        fuzzy: 0.2,
-        prefix: true,
-      },
-    });
-    try {
-      ms.addAll(items);
-    } catch (e) {
-      console.error("CommandPalette: error building search index", e);
-    }
-    return ms;
-  }, [items]);
+  const miniSearch = useMemo(() => buildCommandPaletteIndex(items), [items]);
 
   // Search results grouped by section
   const groupedResults = useMemo(() => {
     if (!query.trim()) return null;
 
-    const raw = miniSearch.search(query.trim());
-    const itemMap = new Map(items.map((i) => [i.id, i]));
+    const ordered = combinedSearch(miniSearch, items, query.trim());
     const groups: Record<CommandPaletteItemType, CommandPaletteItem[]> = {
       feature: [],
       experiment: [],
@@ -253,9 +236,7 @@ const CommandPalette: FC<{ onClose: () => void }> = ({ onClose }) => {
       dashboard: [],
     };
 
-    for (const r of raw) {
-      const item = itemMap.get(r.id);
-      if (!item) continue;
+    for (const item of ordered) {
       if (groups[item.type].length < MAX_PER_SECTION) {
         groups[item.type].push(item);
       }

--- a/packages/front-end/components/CommandPalette/searchUtils.ts
+++ b/packages/front-end/components/CommandPalette/searchUtils.ts
@@ -1,0 +1,101 @@
+import MiniSearch from "minisearch";
+import { fuzzyMatch } from "@nozbe/microfuzz";
+
+/**
+ * Splits text on non-alphanumeric boundaries AND camelCase/PascalCase boundaries so
+ * that identifiers like "myFeatureFlag" or "my-feature-flag" are indexed and searched
+ * as individual tokens: ["my", "feature", "flag"].
+ */
+export function tokenize(str: string): string[] {
+  return str
+    .replace(/([a-z])([A-Z])/g, "$1 $2")
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2")
+    .split(/[^a-zA-Z0-9]+/)
+    .map((t) => t.toLowerCase())
+    .filter((t) => t.length > 0);
+}
+
+/**
+ * Runs microfuzz on the tokenized+joined form of an item name.
+ * Returns a numeric score (lower = better match) or null if no match.
+ *
+ * Tokenizing before matching ensures word-boundary bonuses apply to
+ * camelCase/kebab/snake separators, e.g. "abc" scoring well against
+ * "alpha bravo charlie" (from "alpha_bravo_charlie").
+ */
+export function fuzzyMatchName(query: string, name: string): number | null {
+  const searchText = tokenize(name).join(" ");
+  const result = fuzzyMatch(searchText, query);
+  return result ? result.score : null;
+}
+
+export interface SearchableItem {
+  id: string;
+  name: string;
+  description: string;
+  tags: string;
+}
+
+/**
+ * Two-tier search: MiniSearch (prefix + fuzzy per token) followed by a
+ * microfuzz fallback for cross-token subsequence abbreviations like
+ * "albrcha" → "alpha_bravo_charlie".
+ *
+ * Returns items in priority order: MiniSearch matches first (exact/prefix/typo),
+ * then microfuzz matches sorted ascending by score (lower = better).
+ */
+export function combinedSearch<T extends SearchableItem>(
+  index: MiniSearch<T>,
+  items: T[],
+  query: string,
+): T[] {
+  const raw = index.search(query);
+  const matchedIds = new Set(raw.map((r) => r.id));
+  const itemMap = new Map(items.map((i) => [i.id, i]));
+
+  const results: T[] = raw
+    .map((r) => itemMap.get(r.id))
+    .filter((item) => item !== undefined);
+
+  items
+    .filter((item) => !matchedIds.has(item.id))
+    .map((item) => {
+      const score = fuzzyMatchName(query, item.name);
+      return score !== null ? { item, score } : null;
+    })
+    .filter((m) => m !== null)
+    .sort((a, b) => a.score - b.score)
+    .forEach(({ item }) => results.push(item));
+
+  return results;
+}
+
+/**
+ * Builds a MiniSearch index with the CommandPalette configuration.
+ */
+export function buildCommandPaletteIndex<T extends SearchableItem>(
+  items: T[],
+): MiniSearch<T> {
+  const ms = new MiniSearch<T>({
+    fields: ["name", "description", "tags"],
+    storeFields: ["name"],
+    tokenize,
+    searchOptions: {
+      boost: { name: 3, description: 1 },
+      // Scale allowed edits with term length
+      fuzzy: (term) => {
+        if (term.length <= 2) return 0;
+        if (term.length <= 4) return 1;
+        return 2;
+      },
+      prefix: true,
+      tokenize,
+    },
+  });
+  try {
+    ms.addAll(items);
+  } catch (e) {
+    console.error("CommandPalette: error building search index", e);
+  }
+  return ms;
+}

--- a/packages/front-end/package.json
+++ b/packages/front-end/package.json
@@ -24,6 +24,7 @@
     "@jitsu/sdk-js": "^2.2.0",
     "@jukben/emoji-search": "^2.0.1",
     "@next/bundle-analyzer": "^16.1.6",
+    "@nozbe/microfuzz": "^1.0.0",
     "@popperjs/core": "^2.11.5",
     "@radix-ui/colors": "^3.0.0",
     "@radix-ui/react-popover": "1.1.1",

--- a/packages/front-end/test/components/CommandPalette/searchUtils.test.ts
+++ b/packages/front-end/test/components/CommandPalette/searchUtils.test.ts
@@ -1,0 +1,217 @@
+import {
+  tokenize,
+  fuzzyMatchName,
+  buildCommandPaletteIndex,
+  combinedSearch,
+} from "@/components/CommandPalette/searchUtils";
+
+const ITEMS = [
+  {
+    id: "f1",
+    name: "alpha_bravo_charlie",
+    description: "",
+    tags: "",
+  },
+  {
+    id: "f2",
+    name: "foo_bar",
+    description: "",
+    tags: "",
+  },
+  {
+    id: "f3",
+    name: "myToggleFlag",
+    description: "Controls the widget rollout",
+    tags: "widget rollout",
+  },
+  {
+    id: "e1",
+    name: "enable-flow-v2",
+    description: "",
+    tags: "",
+  },
+  {
+    id: "e2",
+    name: "beta_test_experiment",
+    description: "",
+    tags: "",
+  },
+  {
+    id: "m1",
+    name: "ValuePerSession",
+    description: "Average value per session",
+    tags: "value sessions",
+  },
+  {
+    id: "x1",
+    name: "able_body",
+    description: "",
+    tags: "",
+  },
+];
+
+function search(query: string): string[] {
+  const index = buildCommandPaletteIndex(ITEMS);
+  return combinedSearch(index, ITEMS, query.trim()).map((item) => item.name);
+}
+
+describe("tokenize", () => {
+  it("lowercases everything", () => {
+    expect(tokenize("HELLO")).toEqual(["hello"]);
+  });
+
+  it("splits on hyphens", () => {
+    expect(tokenize("foo-bar-baz")).toEqual(["foo", "bar", "baz"]);
+  });
+
+  it("splits on underscores", () => {
+    expect(tokenize("foo_bar")).toEqual(["foo", "bar"]);
+  });
+
+  it("splits on dots", () => {
+    expect(tokenize("one.two.three")).toEqual(["one", "two", "three"]);
+  });
+
+  it("splits camelCase", () => {
+    expect(tokenize("fooBarBaz")).toEqual(["foo", "bar", "baz"]);
+  });
+
+  it("splits PascalCase", () => {
+    expect(tokenize("FooBarBaz")).toEqual(["foo", "bar", "baz"]);
+  });
+
+  it("splits consecutive uppercase (ABCDef style)", () => {
+    expect(tokenize("ABCDef")).toEqual(["abc", "def"]);
+  });
+
+  it("handles multiple underscore-separated tokens", () => {
+    expect(tokenize("one_two_three")).toEqual(["one", "two", "three"]);
+  });
+
+  it("drops empty segments from repeated delimiters", () => {
+    expect(tokenize("--double--dash--")).toEqual(["double", "dash"]);
+  });
+});
+
+describe("fuzzyMatchName", () => {
+  it("matches a query whose chars appear in order across tokens", () => {
+    expect(fuzzyMatchName("abc", "alpha_bravo_charlie")).not.toBeNull();
+  });
+
+  it("returns null when a query character is absent from the name", () => {
+    expect(fuzzyMatchName("xyz", "foo_bar")).toBeNull();
+  });
+
+  it("returns null when query characters appear in the wrong order", () => {
+    expect(fuzzyMatchName("bo", "foo_bar")).toBeNull();
+  });
+
+  it("gives a better (lower) score to a closer match", () => {
+    const closeScore = fuzzyMatchName("foo", "foo_bar");
+    const abbrevScore = fuzzyMatchName("fb", "foo_bar");
+    expect(closeScore).not.toBeNull();
+    expect(abbrevScore).not.toBeNull();
+    expect(closeScore!).toBeLessThan(abbrevScore!);
+  });
+
+  it("matches first-letter abbreviations across tokens", () => {
+    expect(fuzzyMatchName("fb", "foo_bar")).not.toBeNull();
+  });
+
+  it("is case-insensitive", () => {
+    expect(fuzzyMatchName("FB", "foo_bar")).not.toBeNull();
+    expect(fuzzyMatchName("fb", "Foo_Bar")).not.toBeNull();
+  });
+});
+
+describe("search — prefix matching", () => {
+  it("finds an item by an exact token", () => {
+    expect(search("bravo")).toContain("alpha_bravo_charlie");
+  });
+
+  it("finds an item by a partial token prefix", () => {
+    expect(search("brav")).toContain("alpha_bravo_charlie");
+  });
+
+  it("finds an item by a token produced by camelCase splitting", () => {
+    expect(search("toggle")).toContain("myToggleFlag");
+  });
+
+  it("finds an item by a description word", () => {
+    expect(search("widget")).toContain("myToggleFlag");
+  });
+
+  it("finds an item by a tag word", () => {
+    expect(search("rollout")).toContain("myToggleFlag");
+  });
+});
+
+describe("search — fuzzy matching (typo tolerance)", () => {
+  it("tolerates a single extra character (insertion)", () => {
+    expect(search("bravoo")).toContain("alpha_bravo_charlie");
+  });
+
+  it("tolerates a single missing character (deletion)", () => {
+    expect(search("enble")).toContain("enable-flow-v2");
+  });
+
+  it("tolerates a single substitution", () => {
+    expect(search("togxle")).toContain("myToggleFlag");
+  });
+
+  it("does not fuzzy-match very short terms (≤3 chars require exact prefix)", () => {
+    expect(search("xy")).toHaveLength(0);
+  });
+});
+
+describe("search — microfuzz (abbreviated multi-token queries)", () => {
+  it("matches leading chars from each token: abc → alpha_bravo_charlie", () => {
+    expect(search("abc")).toEqual(["alpha_bravo_charlie"]);
+  });
+
+  it("matches first-letter abbreviations across two tokens: fb → foo_bar", () => {
+    // "fb" → f(oo) b(ar)
+    expect(search("fb")).toEqual(["foo_bar"]);
+  });
+
+  it("matches albrcha (partial chars spanning all three tokens)", () => {
+    expect(search("albrcha")).toEqual(["alpha_bravo_charlie"]);
+  });
+
+  it("matches brcha (starting from the second token, skipping alpha)", () => {
+    expect(search("brcha")).toEqual(["alpha_bravo_charlie"]);
+  });
+
+  it("does not return false positives for random strings", () => {
+    expect(search("zzz")).toHaveLength(0);
+  });
+});
+
+describe("search — result ordering", () => {
+  it("returns MiniSearch prefix results before microfuzz results", () => {
+    const results = search("ab");
+    expect(results).toContain("able_body");
+    expect(results).toContain("alpha_bravo_charlie");
+    expect(results.indexOf("able_body")).toBeLessThan(
+      results.indexOf("alpha_bravo_charlie"),
+    );
+  });
+
+  it("within microfuzz tier, ranks closer matches (lower score) first", () => {
+    // "foo" scores ~0.5 (startsWith) against "foo_bar" while "fb" scores ~2.8
+    // (word-boundary subsequence). Both land in microfuzz when the other item
+    // is already matched by MiniSearch. We verify the score relationship via
+    // fuzzyMatchName directly since constructing two microfuzz-only items with
+    // the same query is fixture-dependent.
+    const closeScore = fuzzyMatchName("foo", "foo_bar");
+    const distantScore = fuzzyMatchName("fb", "foo_bar");
+    expect(closeScore!).toBeLessThan(distantScore!);
+  });
+
+  it("exact token match ranks first within MiniSearch results", () => {
+    // "bravo" matches "alpha_bravo_charlie" as an exact token.
+    // It should be the first result (or at least present and ranked highly).
+    const results = search("bravo");
+    expect(results[0]).toBe("alpha_bravo_charlie");
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -626,6 +626,9 @@ importers:
       '@next/bundle-analyzer':
         specifier: ^16.1.6
         version: 16.1.6
+      '@nozbe/microfuzz':
+        specifier: ^1.0.0
+        version: 1.0.0
       '@popperjs/core':
         specifier: ^2.11.5
         version: 2.11.5
@@ -1057,7 +1060,7 @@ importers:
         version: 7.0.2(rollup@4.53.3)
       ts-jest:
         specifier: ^27.0.5
-        version: 27.1.5(@babel/core@7.28.5)(@types/jest@27.0.1)(babel-jest@27.5.1(@babel/core@7.28.5))(jest@27.5.1)(typescript@5.7.3)
+        version: 27.1.5(@babel/core@7.28.5)(@types/jest@27.0.1)(babel-jest@27.5.1(@babel/core@7.28.5))(jest@27.5.1(ts-node@10.9.1(@swc/core@1.3.4)(@swc/wasm@1.2.130)(@types/node@22.8.6)(typescript@5.7.3)))(typescript@5.7.3)
       typescript:
         specifier: 5.7.3
         version: 5.7.3
@@ -1124,7 +1127,7 @@ importers:
         version: 4.53.3
       ts-jest:
         specifier: ^27.0.5
-        version: 27.1.5(@babel/core@7.28.5)(@types/jest@27.0.1)(babel-jest@27.5.1(@babel/core@7.28.5))(jest@27.5.1)(typescript@5.7.3)
+        version: 27.1.5(@babel/core@7.28.5)(@types/jest@27.0.1)(babel-jest@27.5.1(@babel/core@7.28.5))(jest@27.5.1(ts-node@10.9.1(@swc/core@1.3.4)(@swc/wasm@1.2.130)(@types/node@22.8.6)(typescript@5.7.3)))(typescript@5.7.3)
       typescript:
         specifier: 5.7.3
         version: 5.7.3
@@ -3663,6 +3666,9 @@ packages:
   '@nodelib/fs.walk@1.2.6':
     resolution: {integrity: sha512-8Broas6vTtW4GIXTAHDoE32hnN2M5ykgCpWGbuXHQ15vEMqr23pB76e/GZcYsZCHALv50ktd24qhEyKr6wBtow==}
     engines: {node: '>= 8'}
+
+  '@nozbe/microfuzz@1.0.0':
+    resolution: {integrity: sha512-XKIg/guk+s1tkPTkHch9hfGOWgsKojT7BqSQddXTppOfVr3SWQhhTCqbgQaPTbppf9gc2kFeG0gpBZZ612UXHA==}
 
   '@npmcli/agent@4.0.0':
     resolution: {integrity: sha512-kAQTcEN9E8ERLVg5AsGwLNoFb+oEG6engbqAU2P43gD4JEIkNGMHdVQ096FsOAAYpZPB0RSt0zgInKIAS1l5QA==}
@@ -17918,6 +17924,8 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.4
       fastq: 1.13.0
 
+  '@nozbe/microfuzz@1.0.0': {}
+
   '@npmcli/agent@4.0.0':
     dependencies:
       agent-base: 7.1.3
@@ -22785,7 +22793,7 @@ snapshots:
 
   axios@1.12.2:
     dependencies:
-      follow-redirects: 1.15.6(debug@4.3.4)
+      follow-redirects: 1.15.6(debug@4.4.3)
       form-data: 4.0.5
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -28313,7 +28321,7 @@ snapshots:
 
   presto-client@1.1.0(patch_hash=9fd1f0ac9c8a83e477d0fbea5a3b9c67665121c24b78fa4d5af0cf112c3d1efb):
     dependencies:
-      follow-redirects: 1.15.6(debug@4.3.4)
+      follow-redirects: 1.15.6(debug@4.4.3)
     transitivePeerDependencies:
       - debug
 
@@ -30176,7 +30184,7 @@ snapshots:
     dependencies:
       typescript: 5.7.3
 
-  ts-jest@27.1.5(@babel/core@7.28.5)(@types/jest@27.0.1)(babel-jest@27.5.1(@babel/core@7.28.5))(jest@27.5.1)(typescript@5.7.3):
+  ts-jest@27.1.5(@babel/core@7.28.5)(@types/jest@27.0.1)(babel-jest@27.5.1(@babel/core@7.28.5))(jest@27.5.1(ts-node@10.9.1(@swc/core@1.3.4)(@swc/wasm@1.2.130)(@types/node@22.8.6)(typescript@5.7.3)))(typescript@5.7.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0


### PR DESCRIPTION
### Features and Changes

We use `minisearch` for which the `fuzzy` param controls the levenshtein distance accepted for a given word. Now we use `minifuzz` to expand on that and provide abbreviation-style matching that provides better results.

### Dependencies

- Adds `@nozbe/microfuzz` to `front-end`

### Testing

New unit tests added

### Screenshots

| Before | After |
|--------|--------|
| <img width="621" height="189" alt="Screenshot 2026-02-24 at 1 43 33 PM" src="https://github.com/user-attachments/assets/786580b2-ccdd-4b28-a1c2-0956f521258b" /> | <img width="741" height="268" alt="Screenshot 2026-02-24 at 1 42 42 PM" src="https://github.com/user-attachments/assets/942a5a9f-61b1-4d50-b001-ee077a6715a4" /> |
| <img width="622" height="333" alt="Screenshot 2026-02-24 at 1 43 39 PM" src="https://github.com/user-attachments/assets/def0d875-52d2-4db2-b7bd-6b54d3e393ea" /> | <img width="638" height="389" alt="Screenshot 2026-02-24 at 1 43 00 PM" src="https://github.com/user-attachments/assets/7cc73b3d-8ea8-4a08-8a1d-e45529d114e9" /> |
| <img width="619" height="214" alt="Screenshot 2026-02-24 at 1 44 00 PM" src="https://github.com/user-attachments/assets/923b40f0-8e1c-449e-8e85-b1a2e8f67cf5" /> | <img width="623" height="191" alt="Screenshot 2026-02-24 at 1 44 15 PM" src="https://github.com/user-attachments/assets/404e542a-d22b-45d1-adfe-519fbd5e2a55" /> |