### PR TITLE
Api init build info

### DIFF
--- a/packages/front-end/pages/api/init.ts
+++ b/packages/front-end/pages/api/init.ts
@@ -75,7 +75,9 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
     UPLOAD_METHOD,
   } = process.env;
 
-  const rootPath = path.join(__dirname, "..", "..", "..", "..", "..", "..");
+  // Use process.cwd() which returns the front-end directory (set via ecosystem.config.js cwd)
+  // Go 2 levels up to reach the workspace/app root where buildinfo and config directories live
+  const rootPath = path.join(process.cwd(), "..", "..");
 
   const hasConfigFile = fs.existsSync(
     path.join(rootPath, "config", "config.yml"),
@@ -89,12 +91,14 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
   if (fs.existsSync(path.join(rootPath, "buildinfo", "SHA"))) {
     build.sha = fs
       .readFileSync(path.join(rootPath, "buildinfo", "SHA"))
-      .toString();
+      .toString()
+      .trim();
   }
   if (fs.existsSync(path.join(rootPath, "buildinfo", "DATE"))) {
     build.date = fs
       .readFileSync(path.join(rootPath, "buildinfo", "DATE"))
-      .toString();
+      .toString()
+      .trim();
   }
 
   // Read version from package.json


### PR DESCRIPTION
### Features and Changes

Fixes an issue where the `/api/init` route in the front-end failed to read `buildinfo` and `config` files. This was due to `__dirname` resolving incorrectly in Next.js 16 with Turbopack, leading to an invalid path calculation.

The fix involves:
- Replacing `__dirname` with `process.cwd()` for path resolution. `process.cwd()` reliably returns the front-end directory, allowing for a correct relative path to the workspace root.
- Adjusting the relative path from 6 levels up to 2 levels up.
- Adding `.trim()` to the read file contents to remove trailing newlines, consistent with back-end implementation.

- Closes **(add link to issue here)**

### Dependencies

None

### Testing

- Verified the `/api/init` endpoint correctly reads `buildinfo/SHA`, `buildinfo/DATE`, and detects `config/config.yml` by starting the dev server and making requests.
- Confirmed the `build` object in the response contained the correct and trimmed SHA and date.
- Type-check passed.

### Screenshots

N/A

---
[Slack Thread](https://growthbookapp.slack.com/archives/D0AH34812MC/p1772051201043059?thread_ts=1772051201.043059&cid=D0AH34812MC)

<p><a href="https://cursor.com/agents/bc-b9467116-ef09-5ad8-92bb-23c871609d24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b9467116-ef09-5ad8-92bb-23c871609d24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

