### PR TITLE
fix(custom-reports): Don't use health traffic for calculating custom report unit counts

### DIFF
--- a/packages/front-end/components/Features/RuleModal/BanditRefNewFields.tsx
+++ b/packages/front-end/components/Features/RuleModal/BanditRefNewFields.tsx
@@ -305,6 +305,7 @@ export default function BanditRefNewFields({
               />
             ) : null}
           </div>
+
           <ExperimentMetricsSelector
             datasource={datasource?.id}
             exposureQueryId={exposureQueryId}
@@ -318,10 +319,11 @@ export default function BanditRefNewFields({
               form.setValue("goalMetrics", goalMetrics)
             }
           />
-          r
+
           <div className="mt-2 mb-3">
             <BanditSettings page="experiment-settings" />
           </div>
+
           <ExperimentMetricsSelector
             datasource={datasource?.id}
             exposureQueryId={exposureQueryId}
@@ -338,6 +340,7 @@ export default function BanditRefNewFields({
             collapseSecondary={true}
             collapseGuardrail={true}
           />
+
           <CustomMetricSlicesSelector
             goalMetrics={form.watch("goalMetrics") ?? []}
             secondaryMetrics={form.watch("secondaryMetrics") ?? []}
@@ -347,7 +350,9 @@ export default function BanditRefNewFields({
               form.setValue("customMetricSlices", slices)
             }
           />
+
           <hr className="mt-4" />
+
           <Collapsible
             trigger={
               <div className="link-purple font-weight-bold mt-4 mb-2">


### PR DESCRIPTION
### Features and Changes

We had previously switched to using health traffic by default to calculate unit counts for experiments and custom reports, but we can't use health traffic for custom reports because if you specify a custom date range the health traffic is not re-calculated. This PR switches to just using analysis results to calculate the unit counts for reports.

### Testing

- [x] Create a custom report and edit the analysis date range to be shorter than the experiments total runtime. Verify that the total units are updated and look correct.
