### PR TITLE
fix: show anchor y-axis to zero checkbox for bar charts

### DIFF
--- a/packages/front-end/components/DataViz/DisplaySettingsPanel/AnchorYAxisToZeroCheckbox.tsx
+++ b/packages/front-end/components/DataViz/DisplaySettingsPanel/AnchorYAxisToZeroCheckbox.tsx
@@ -1,4 +1,4 @@
-import { DataVizConfig, LineChart, ScatterChart } from "shared/validators";
+import { BarChart, DataVizConfig, LineChart, ScatterChart } from "shared/validators";
 import { chartTypeSupportsAnchorYAxisToZero } from "shared/enterprise";
 import Checkbox from "@/ui/Checkbox";
 
@@ -18,7 +18,7 @@ export default function AnchorYAxisToZeroCheckbox({
 
   // We know the chart type supports anchorYAxisToZero, so we can cast the dataVizConfig to the appropriate type.
   const configWithDisplaySettings = dataVizConfig as Partial<
-    LineChart | ScatterChart
+    BarChart | LineChart | ScatterChart
   >;
   return (
     <Checkbox

--- a/packages/shared/src/enterprise/dashboards/utils.ts
+++ b/packages/shared/src/enterprise/dashboards/utils.ts
@@ -377,7 +377,7 @@ export function convertPinnedSlicesToSliceTags(
 export function chartTypeSupportsAnchorYAxisToZero(
   chartType: DataVizConfig["chartType"],
 ): boolean {
-  return ["line", "scatter"].includes(chartType);
+  return ["line", "scatter", "bar"].includes(chartType);
 }
 
 export function chartTypeHasDisplaySettings(

--- a/packages/shared/src/validators/saved-queries.ts
+++ b/packages/shared/src/validators/saved-queries.ts
@@ -181,7 +181,12 @@ const withFormat = z.object({
 const barChartValidator = baseChartConfig
   .merge(z.object({ chartType: z.literal("bar") }))
   .merge(withXAxis)
-  .merge(withExtendedDimensions);
+  .merge(withExtendedDimensions)
+  .extend({
+    displaySettings: z.object({
+      anchorYAxisToZero: z.boolean(),
+    }).optional(),
+  });
 
 const lineChartValidator = baseChartConfig
   .merge(z.object({ chartType: z.literal("line") }))


### PR DESCRIPTION
## Summary

Fixes #4950

The \"Anchor y-axis to zero\" checkbox was not appearing for bar charts because `chartTypeSupportsAnchorYAxisToZero` only included `line` and `scatter`. The rendering layer already defaults `anchorYAxisToZero` to `true` when `displaySettings` is absent, so bar charts were already anchoring to zero — users just had no way to toggle it off.

Changes:
- Add `"bar"` to `chartTypeSupportsAnchorYAxisToZero` so the checkbox appears for bar charts
- Add optional `displaySettings.anchorYAxisToZero` to `barChartValidator` so the setting can be persisted
- Update `AnchorYAxisToZeroCheckbox` type cast to include `BarChart`

## Test plan
- [ ] Create a bar chart in SQL Explorer
- [ ] Confirm the "Anchor y-axis to zero" checkbox now appears in Display Settings
- [ ] Toggle it off — confirm y-axis zooms in to data range
- [ ] Toggle it on — confirm y-axis starts at zero
- [ ] Confirm line and scatter charts are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)