### PR TITLE
Fix the add Feature button when no projects exist at all.

### DIFF
--- a/packages/front-end/pages/features/index.tsx
+++ b/packages/front-end/pages/features/index.tsx
@@ -430,8 +430,13 @@ export default function FeaturesPage() {
     if (project) {
       return permissionsUtil.canViewFeatureModal(project);
     }
-    // If "All Projects" is selected, check if user has permissions for at least one project
-    return projects.some((p) => permissionsUtil.canViewFeatureModal(p.id));
+    if (projects?.length) {
+      // If "All Projects" is selected, check if user has permissions for at least one project
+
+      return projects.some((p) => permissionsUtil.canViewFeatureModal(p.id));
+    }
+    // No projects - fall back to global permission check (e.g. admin in new org)
+    return permissionsUtil.canViewFeatureModal();
   }, [project, projects, permissionsUtil]);
 
   const canCreateFeatures = useMemo(() => {
@@ -439,11 +444,19 @@ export default function FeaturesPage() {
     if (project) {
       return permissionsUtil.canManageFeatureDrafts({ project });
     }
-    // If "All Projects" is selected, check if user has permissions for at least one project
-    return projects.some(
-      (p) =>
-        permissionsUtil.canCreateFeature({ project: p.id }) &&
-        permissionsUtil.canManageFeatureDrafts({ project: p.id }),
+    if (projects?.length) {
+      // If "All Projects" is selected, check if user has permissions for at least one project
+
+      return projects.some(
+        (p) =>
+          permissionsUtil.canCreateFeature({ project: p.id }) &&
+          permissionsUtil.canManageFeatureDrafts({ project: p.id }),
+      );
+    }
+    // No projects - fall back to global permission check (e.g. admin in new org)
+    return (
+      permissionsUtil.canCreateFeature({ project: "" }) &&
+      permissionsUtil.canManageFeatureDrafts({ project: "" })
     );
   }, [project, projects, permissionsUtil]);
 


### PR DESCRIPTION
### Features and Changes
A bug was recently introduced in https://github.com/growthbook/growthbook/pull/5370 where when they had no projects at all that we didn't show the add Feature button.  This fixes that case.

### Testing
Delete all projects. See the "Add feature" button on the /features page