### PR TITLE
Redshift percentile capping

### DIFF
--- a/packages/back-end/src/integrations/Mysql.ts
+++ b/packages/back-end/src/integrations/Mysql.ts
@@ -123,6 +123,9 @@ export default class Mysql extends SqlIntegration {
   hasEfficientPercentile(): boolean {
     return false;
   }
+  canGroupPercentileCappedMetrics(): boolean {
+    return false;
+  }
   getInformationSchemaWhereClause(): string {
     if (!this.params.database)
       throw new Error(

--- a/packages/back-end/src/integrations/Redshift.ts
+++ b/packages/back-end/src/integrations/Redshift.ts
@@ -17,6 +17,9 @@ export default class Redshift extends SqlIntegration {
   getSensitiveParamKeys(): string[] {
     return ["password", "caCert", "clientCert", "clientKey"];
   }
+  hasEfficientPercentile(): boolean {
+    return false;
+  }
   runQuery(sql: string): Promise<QueryResponse> {
     return runPostgresQuery(this.params, sql);
   }

--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -270,6 +270,7 @@ export default abstract class SqlIntegration
       dropUnitsTable: this.dropUnitsTable(),
       hasQuantileTesting: this.hasQuantileTesting(),
       hasEfficientPercentiles: this.hasEfficientPercentile(),
+      canGroupPercentileCappedMetrics: this.canGroupPercentileCappedMetrics(),
       hasCountDistinctHLL: this.hasCountDistinctHLL(),
       hasIncrementalRefresh: this.canRunIncrementalRefreshQueries(),
       maxColumns: 1000,
@@ -415,6 +416,9 @@ export default abstract class SqlIntegration
     return true;
   }
   hasEfficientPercentile(): boolean {
+    return true;
+  }
+  canGroupPercentileCappedMetrics(): boolean {
     return true;
   }
   hasCountDistinctHLL(): boolean {

--- a/packages/back-end/src/services/experimentQueries/experimentQueries.ts
+++ b/packages/back-end/src/services/experimentQueries/experimentQueries.ts
@@ -290,9 +290,17 @@ export function getFactMetricGroups(
   // Group fact metrics into efficient groups (primarily if they share a fact table)
   const groups: Record<string, FactMetricInterface[]> = {};
   factMetrics.forEach((m) => {
-    // Skip grouping metrics with percentile caps or quantile metrics if there's not an efficient implementation
+    // Skip grouping metrics with percentile caps if they cannot be grouped at all
     if (
-      (m.cappingSettings.type === "percentile" || quantileMetricType(m)) &&
+      m.cappingSettings.type === "percentile" &&
+      !integration.getSourceProperties().canGroupPercentileCappedMetrics
+    ) {
+      return;
+    }
+
+    // Skip grouping quantile metrics if there's not an efficient implementation
+    if (
+      quantileMetricType(m) &&
       !integration.getSourceProperties().hasEfficientPercentiles
     ) {
       return;

--- a/packages/shared/types/datasource.d.ts
+++ b/packages/shared/types/datasource.d.ts
@@ -137,6 +137,7 @@ export interface DataSourceProperties {
   dropUnitsTable?: boolean;
   hasQuantileTesting?: boolean;
   hasEfficientPercentiles?: boolean;
+  canGroupPercentileCappedMetrics?: boolean;
   hasCountDistinctHLL?: boolean;
   hasIncrementalRefresh?: boolean;
   maxColumns: number;


### PR DESCRIPTION
### Features and Changes

Overrides `percentileCapSelectClause` in `Redshift.ts` to use scalar subqueries for each `PERCENTILE_CONT` function. This resolves an issue where Redshift errors when multiple `PERCENTILE_CONT` functions with different `ORDER BY` clauses are used in the same `SELECT` statement, which occurs with percentile capped ratio metrics.

Also allowed capped metrics in redshift to be optimized by creating separate logic for percentiles and quantiles, allowing percentile capped metrics to be grouped in Redshift but not quantiles. We could implement a similar fix for quantiles but the value isn't as great and the fix would be more complex.

Note this implementation is inefficient since we scan the user metric agg table for each percentile, but there isn't a better solution in the Redshift docs. Furthermore, joining two queries with two `(SELECT PERCENTILE_CONT(...) FROM __userMetricAgg)` statements that are somewhat redundant is probably better than the status quo of just running them in fully separate queries.

### Dependencies

None

### Testing

-   Type-check passed.
-   All existing SQL integration tests pass.
-   Verified generated SQL output for single value, multiple values, and `ignoreZeros` cases.

### Human testing

- Ratio capped now works
- Joining multiple capped metrics via query optimization now allowed and works
- Quantile metrics are still in individual queries

### Screenshots

---
[Slack Thread](https://growthbookapp.slack.com/archives/C05QYS2UFRD/p1764713398053599?thread_ts=1764713398.053599&cid=C05QYS2UFRD)

<p><a href="https://cursor.com/agents/bc-9eee236c-d2c9-5ead-8799-cee14e06af57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9eee236c-d2c9-5ead-8799-cee14e06af57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

