### PR TITLE
Custom field runtime permissions

### DIFF
--- a/packages/front-end/components/Features/FeaturesOverview.tsx
+++ b/packages/front-end/components/Features/FeaturesOverview.tsx
@@ -289,8 +289,6 @@ export default function FeaturesOverview({
   const revisionHasChanges =
     !!mergeResult && mergeResultHasChanges(mergeResult);
 
-  const canManageCustomFields = permissionsUtil.canManageCustomFields();
-
   const projectId = feature.project;
 
   const hasDraftPublishPermission =
@@ -600,7 +598,7 @@ export default function FeaturesOverview({
         <Box>
           <CustomFieldDisplay
             target={feature}
-            canEdit={canManageCustomFields}
+            canEdit={canEdit}
             mutate={mutate}
             section={"feature"}
           />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Features and Changes

Previously, editing custom field values on features incorrectly required the "Manage Custom Fields" permission. This permission is intended for creating/editing custom field *definitions*, not for updating values on existing features.

This change updates the permission check in `FeaturesOverview.tsx` to use the feature editing permission (`canEdit`, derived from `canViewFeatureModal`) instead of `canManageCustomFields` when rendering the `CustomFieldDisplay` component. This ensures that users with permission to edit features can also edit their custom field values, aligning with how custom fields are handled on experiments.

- Users with `manageFeatures` permission can now edit custom field values on features.
- The `manageCustomFields` permission is now solely for managing custom field definitions.

### Dependencies

None

### Testing

- Ran `npm run typecheck`
- Ran `npm run lint`

### Screenshots

N/A (Permission logic change)

---
[Slack Thread](https://growthbookapp.slack.com/archives/C07NK4F016Z/p1772570595779919?thread_ts=1772570595.779919&cid=C07NK4F016Z)

<p><a href="https://cursor.com/agents/bc-7ba9b956-b0e9-5760-a499-9be5f7f3f109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ba9b956-b0e9-5760-a499-9be5f7f3f109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->