### PR TITLE
Fix -Infinity when refreshing safe rollout results

### DIFF
--- a/packages/back-end/src/services/stats.ts
+++ b/packages/back-end/src/services/stats.ts
@@ -473,6 +473,7 @@ function parseStatsEngineResult({
   const experimentReportResults: ExperimentReportResults[] = [];
   // TODO fix for dimension slices and move to health query
   const multipleExposures = Math.max(
+    0,
     ...queryResults.map(
       (q) =>
         q.rows.filter((r) => r.variation === "__multiple__")?.[0]?.users || 0,


### PR DESCRIPTION
### Features and Changes

`Math.max()` with no arguments results in `-Infinity`. This breaks Zod validation with `z.number()`.  Added a baseline of `0` to the Math.max call so the value will always be finite and non-negative (which makes sense for multiple exposures).

There's a separate question of why `queryResults` is empty that we should look into, but we can do that later.