### PR TITLE
Ensure full refresh is false if model is missing

### DIFF
--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -1079,13 +1079,13 @@ export async function createSnapshot({
     throw new Error("Could not load data source");
   }
 
-  // TODO(incremental-refresh): use other signal other than useCache
-  // to determine full refresh
-  const fullRefresh = !useCache;
+  const incrementalRefreshModel = useCache
+    ? await context.models.incrementalRefresh.getByExperimentId(experiment.id)
+    : null;
 
-  const incrementalRefreshModel = fullRefresh
-    ? null
-    : await context.models.incrementalRefresh.getByExperimentId(experiment.id);
+  // Full refresh when explicitly requested (!useCache) or when no prior
+  // incremental state exists (e.g. newly imported experiment)
+  const fullRefresh = !useCache || !incrementalRefreshModel;
 
   const snapshotSettings = getSnapshotSettings({
     experiment,
@@ -1256,7 +1256,8 @@ export async function createSnapshot({
       queryRunner instanceof ExperimentIncrementalRefreshQueryRunner ||
       queryRunner instanceof ExperimentIncrementalRefreshExploratoryQueryRunner
     ) {
-      const fullRefresh = !useCache && snapshot.type === "standard";
+      const fullRefresh =
+        (!useCache || !incrementalRefreshModel) && snapshot.type === "standard";
 
       await queryRunner.startAnalysis({
         ...analysisProps,


### PR DESCRIPTION
### Features and Changes

On import, we set `useCache = true` and this means if you have incremental refresh on and go to import, we tried to do a temp refresh. We need to ensure that we use a full refresh.

The easiest way to do this is just to check if the incremental fresh model exists and rely on that, otherwise just start anew. This fix should catch more edge cases anyways.

- Closes **(add link to issue here)**

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

Still need to test.

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
