### PR TITLE
chore(preview): Increase memory for preview environment

### DIFF
--- a/preview-pr-fly.toml
+++ b/preview-pr-fly.toml
@@ -50,6 +50,6 @@ primary_region = 'sjc'
     handlers = ['tls', 'http']
 
 [[vm]]
-  memory = '1gb'
+  memory = '2gb'
   cpu_kind = 'shared'
-  cpus = 4
+  cpus = 1


### PR DESCRIPTION
## Summary

Having multiple people accessing the preview environment is not working as it is very slow; so increasing the memory to see if this makes it more usable.