### PR TITLE
Symlink .claude/rules to .cursor/rules

### DIFF
--- a/.claude/rules
+++ b/.claude/rules
@@ -1,0 +1,1 @@
+../.cursor/rules


### PR DESCRIPTION
### Features and Changes

Creates a symlink from `.claude/rules` to `.cursor/rules` so Claude also benefits from the added context.
:warning: Cursor uses `globs` to determine when to apply the rules, while Claude uses `paths`. This means that all of these rule files will be loaded as part of every conversation, bloating the context and consuming extra tokens.

I considered a transpiler that copies the rules back and forth and updates the metadata appropriately, but that's rather cumbersome, and I tend to agree with this response that Claude provided when asking about the downsides of a simple symlink

<details>

<summary>AI response</summary>

> The main downsides are:
Context consumption — every rule file is loaded on every request, consuming tokens that could be used for actual code context
Noise — frontend React patterns being loaded when you're deep in backend model work (and vice versa) adds irrelevant instructions
However, looking at the actual content of your rule files, I'd lean toward not building the transpiler, for a few reasons:
The rules are relatively concise — they don't appear to consume an alarming amount of context
Many of them are genuinely cross-cutting (e.g. permissions, package boundaries, project overview) and would match broad globs anyway
The frontend/backend split rules are useful to have available even when crossing boundaries, since tasks often touch both sides
Building and maintaining a transpiler adds real complexity for marginal gain given your specific rule content
The calculus would change if you had many large, highly specialized rule files that are only relevant in narrow contexts. But with what you have, the "load everything" approach seems fine in practice — as your testing confirmed it works correctly.

</details>