### PR TITLE
Trim trim from the overrides. Trim.

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,6 @@
       "node-forge@1": "^1.3.2",
       "prismjs@1": "^1.30.0",
       "qs@6": "^6.15.0",
-      "trim": "^0.0.3",
       "vite": "^6.0.0"
     },
     "peerDependencyRules": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,7 +30,6 @@ overrides:
   node-forge@1: ^1.3.2
   prismjs@1: ^1.30.0
   qs@6: ^6.15.0
-  trim: ^0.0.3
   vite: ^6.0.0
 
 patchedDependencies:


### PR DESCRIPTION
### Features and Changes
With spectacle removed one of the security package overrides had referenced a package that was only there.  We no longer have to override it.

### Testing
Nothing else changed in pnpm.lock

