### PR TITLE
Disabling confirmation when changing datasources w/ empty PA explore config

### DIFF
--- a/packages/front-end/enterprise/components/ProductAnalytics/MainSection/Toolbar/DataSourceDropdown.tsx
+++ b/packages/front-end/enterprise/components/ProductAnalytics/MainSection/Toolbar/DataSourceDropdown.tsx
@@ -9,7 +9,8 @@ import Link from "@/ui/Link";
 
 export default function DataSourceDropdown() {
   const [dropdownOpen, setDropdownOpen] = useState(false);
-  const { draftExploreState, clearAllDatasets } = useExplorerContext();
+  const { draftExploreState, clearAllDatasets, isSubmittable } =
+    useExplorerContext();
   const { datasources } = useDefinitions();
 
   const triggerLabel =
@@ -45,14 +46,26 @@ export default function DataSourceDropdown() {
         ) : (
           <DropdownMenuItem
             key={ds.id}
-            confirmation={{
-              confirmationTitle: "Change data source",
-              cta: "Change",
-              submitColor: "primary",
-              submit: () => clearAllDatasets(ds.id),
-              getConfirmationContent: async () =>
-                `Changing the data source will clear your current exploration. Are you sure you want to switch to "${ds.name}"?`,
-            }}
+            onClick={
+              isSubmittable
+                ? undefined
+                : () => {
+                    clearAllDatasets(ds.id);
+                    setDropdownOpen(false);
+                  }
+            }
+            confirmation={
+              isSubmittable
+                ? {
+                    confirmationTitle: "Change data source",
+                    cta: "Change",
+                    submitColor: "primary",
+                    submit: () => clearAllDatasets(ds.id),
+                    getConfirmationContent: async () =>
+                      `Changing the data source will clear your current exploration. Are you sure you want to switch to "${ds.name}"?`,
+                  }
+                : undefined
+            }
           >
             <Flex align="center" justify="between" gap="2">
               <Flex align="center" width="20px" />


### PR DESCRIPTION
### Features and Changes

No longer prompting for confirmation on datasource change in Product Analytics Explore if the config is still empty. 

### Testing

1. Go to Product Analytics -> Explore -> Metrics 
2. Do not make any changes to the configuration
3.  Select a different data source than is already selected
4.  Ensure no confirmation pop up appears

5. Repeat above steps but with a config change before datasource change
6. Ensure a confirmation appears
