### PR TITLE
Fix linked feature showing Discarded instead of Draft with approval flows

### DIFF
--- a/packages/back-end/src/models/FeatureRevisionModel.ts
+++ b/packages/back-end/src/models/FeatureRevisionModel.ts
@@ -697,7 +697,7 @@ export async function getFeatureRevisionsByFeatureIds(
   if (featureIds.length) {
     const revisions = await FeatureRevisionModel.find({
       organization,
-      status: "draft",
+      status: { $in: ACTIVE_DRAFT_STATUSES },
       featureId: { $in: featureIds },
     })
       .select("-log") // Remove the log when fetching all revisions since it can be large to send over the network


### PR DESCRIPTION
## Summary

- Fixes a bug where linking an experiment to a feature that requires approval flows incorrectly shows the feature as "Discarded" on the experiment implementation page.
- Root cause: `getFeatureRevisionsByFeatureIds` only queried for revisions with `status: "draft"`, missing revisions in `"pending-review"`, `"approved"`, or `"changes-requested"` states that arise from approval flows.
- Fix: changed the MongoDB query to use `ACTIVE_DRAFT_STATUSES` (which includes all four active draft statuses) so these revisions are fetched and correctly resolve to the "Draft" state.

## Test plan

- [x] Link an experiment to a feature that has approval flows enabled
- [x] Verify the linked feature shows "Draft" (not "Discarded") on the experiment implementation page
- [x] Verify features without approval flows still show correct states (Live, Draft, Locked, Discarded)


Made with [Cursor](https://cursor.com)