### PR TITLE
Sorting PA chart/table based on cumulative group values

### DIFF
--- a/packages/front-end/enterprise/components/ProductAnalytics/MainSection/ExplorerChart.tsx
+++ b/packages/front-end/enterprise/components/ProductAnalytics/MainSection/ExplorerChart.tsx
@@ -5,7 +5,11 @@ import type {
   ExplorationConfig,
   ProductAnalyticsExploration,
 } from "shared/validators";
-import { shouldChartSectionShow } from "@/enterprise/components/ProductAnalytics/util";
+import {
+  shouldChartSectionShow,
+  getEffectiveMetricValue,
+  computeDimensionTotals,
+} from "@/enterprise/components/ProductAnalytics/util";
 import { useAppearanceUITheme } from "@/services/AppearanceUIThemeProvider";
 import { useDashboardCharts } from "@/enterprise/components/Dashboards/DashboardChartsContext";
 import BigValueChart from "@/components/SqlExplorer/BigValueChart";
@@ -135,20 +139,47 @@ export default function ExplorerChart({
           };
         }
 
-        dataMap[seriesKey][xValue] = v.numerator ?? 0;
-        if (v.denominator) {
-          dataMap[seriesKey][xValue] /= v.denominator;
-        }
+        dataMap[seriesKey][xValue] = getEffectiveMetricValue(v);
       });
     });
 
-    // 2. Sort X-axis values
-    const sortedXValues = Array.from(uniqueXValues).sort();
+    // 2. Compute cumulative totals for sorting
+    const seriesTotals: Record<string, number> = {};
+    for (const [seriesKey, seriesData] of Object.entries(dataMap)) {
+      seriesTotals[seriesKey] = Object.values(seriesData).reduce(
+        (sum, v) => sum + v,
+        0,
+      );
+    }
+    const sortedSeriesKeys = Object.keys(dataMap).sort(
+      (a, b) => seriesTotals[b] - seriesTotals[a],
+    );
 
-    // 3. Build Series
+    const isBarType = [
+      "bar",
+      "stackedBar",
+      "stackedHorizontalBar",
+      "horizontalBar",
+    ].includes(chartType);
+
+    // Bar charts: sort categories by total value; timeseries: chronological
+    let sortedXValues: string[];
+    if (isBarType) {
+      const xValueTotals = computeDimensionTotals(rows, 0);
+      // Horizontal bars render bottom-to-top, so sort ascending for largest on top
+      sortedXValues = Array.from(uniqueXValues).sort((a, b) =>
+        isHorizontalBar
+          ? xValueTotals[a] - xValueTotals[b]
+          : xValueTotals[b] - xValueTotals[a],
+      );
+    } else {
+      sortedXValues = Array.from(uniqueXValues).sort();
+    }
+
+    // 3. Build Series (ordered by cumulative total, highest first)
     const seriesColor = (i: number) => CHART_COLORS[i % CHART_COLORS.length];
 
-    const seriesConfigs = Object.keys(dataMap).map((seriesKey, idx) => {
+    const seriesConfigs = sortedSeriesKeys.map((seriesKey, idx) => {
       const { name } = seriesMeta[seriesKey];
       const seriesDataMap = dataMap[seriesKey];
 

--- a/packages/front-end/enterprise/components/ProductAnalytics/MainSection/ExplorerDataTable.tsx
+++ b/packages/front-end/enterprise/components/ProductAnalytics/MainSection/ExplorerDataTable.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { useExplorerContext } from "@/enterprise/components/ProductAnalytics/ExplorerContext";
+import { sortExplorationRows } from "@/enterprise/components/ProductAnalytics/util";
 import DisplayTestQueryResults from "@/components/Settings/DisplayTestQueryResults";
 
 type ColumnSlot =
@@ -219,14 +220,7 @@ export default function ExplorerDataTable({ hasChart }: { hasChart: boolean }) {
     const isTimeseries =
       submittedExploreState?.dimensions?.[0]?.dimensionType === "date";
 
-    const rowsToProcess = isTimeseries
-      ? [...rawRows].sort((a, b) => {
-          const dateA = a.dimensions[0] || "";
-          const dateB = b.dimensions[0] || "";
-          if (!dateA || !dateB) return 0;
-          return new Date(dateA).getTime() - new Date(dateB).getTime();
-        })
-      : rawRows;
+    const rowsToProcess = sortExplorationRows(rawRows, isTimeseries);
 
     const context = {
       dimensionColumnHeaders,

--- a/packages/front-end/enterprise/components/ProductAnalytics/util.ts
+++ b/packages/front-end/enterprise/components/ProductAnalytics/util.ts
@@ -12,6 +12,7 @@ import type {
   DatasetType,
   ExplorationDataset,
   ExplorationConfig,
+  ProductAnalyticsResultRow,
 } from "shared/validators";
 import { isEqual } from "lodash";
 import { dateGranularity } from "shared/validators";
@@ -500,4 +501,74 @@ export function shouldChartSectionShow(params: {
   }
 
   return true;
+}
+
+// --- Shared sorting helpers for chart & table ---
+
+export function getEffectiveMetricValue(v: {
+  numerator: number | null;
+  denominator: number | null;
+}): number {
+  const num = v.numerator ?? 0;
+  return v.denominator ? num / v.denominator : num;
+}
+
+function getRowTotal(row: ProductAnalyticsResultRow): number {
+  return row.values.reduce((sum, v) => sum + getEffectiveMetricValue(v), 0);
+}
+
+/** Compute the sum of all metric values grouped by a specific dimension index. */
+export function computeDimensionTotals(
+  rows: ProductAnalyticsResultRow[],
+  dimIndex: number,
+): Record<string, number> {
+  const totals: Record<string, number> = {};
+  for (const row of rows) {
+    const key = row.dimensions[dimIndex] ?? "";
+    totals[key] = (totals[key] ?? 0) + getRowTotal(row);
+  }
+  return totals;
+}
+
+/** Compute the sum of all metric values grouped by the "group key" (all dimensions after the first). */
+export function computeGroupTotals(
+  rows: ProductAnalyticsResultRow[],
+): Record<string, number> {
+  const totals: Record<string, number> = {};
+  for (const row of rows) {
+    const key = row.dimensions.slice(1).join(" - ");
+    totals[key] = (totals[key] ?? 0) + getRowTotal(row);
+  }
+  return totals;
+}
+
+/**
+ * Sort exploration result rows to match the visual ordering of the chart.
+ * - Timeseries: chronological by first dimension (date), then by group total descending.
+ * - Bar/cumulative: by first-dimension total descending, then by group total descending.
+ */
+export function sortExplorationRows(
+  rows: ProductAnalyticsResultRow[],
+  isTimeseries: boolean,
+): ProductAnalyticsResultRow[] {
+  if (rows.length === 0) return rows;
+
+  const dim0Totals = computeDimensionTotals(rows, 0);
+  const groupTotals = computeGroupTotals(rows);
+
+  return [...rows].sort((a, b) => {
+    const dim0A = a.dimensions[0] ?? "";
+    const dim0B = b.dimensions[0] ?? "";
+
+    if (dim0A !== dim0B) {
+      if (isTimeseries) {
+        return new Date(dim0A).getTime() - new Date(dim0B).getTime();
+      }
+      return (dim0Totals[dim0B] ?? 0) - (dim0Totals[dim0A] ?? 0);
+    }
+
+    const groupA = a.dimensions.slice(1).join(" - ");
+    const groupB = b.dimensions.slice(1).join(" - ");
+    return (groupTotals[groupB] ?? 0) - (groupTotals[groupA] ?? 0);
+  });
 }


### PR DESCRIPTION
### Features and Changes

- Sorted chart series and bar chart categories by cumulative metric value so the highest-contributing groups appear first
- Timeseries x-axis remains chronological; bar chart categories are sorted by total value
- Aligned data table row ordering with the chart's visual order
- Extracted shared sorting helpers into util.ts to keep chart and table logic consistent


### Testing

- Bar charts: Create an exploration with a non-date dimension. Verify x-axis categories are ordered by total value (highest-left for vertical, highest-top for horizontal). Legend/stacked segments should also be ordered by total.
- Timeseries: Create an exploration with a date dimension + group-by. Verify x-axis stays chronological and legend series are sorted by cumulative value.
- Table: For both chart types, confirm the table row ordering matches the chart (value-descending for bars, chronological for timeseries, groups sorted by total within each dimension).

### Screenshots

#### Timeseries
<img width="1706" height="1325" alt="image" src="https://github.com/user-attachments/assets/a4e99834-5b2c-4ec1-a82a-0894f5d0727c" />

#### Bar
<img width="1706" height="1325" alt="image" src="https://github.com/user-attachments/assets/593bf940-a559-4b69-9f70-aa9132489181" />
