### PR TITLE
Experiment linking approval message

### DIFF
--- a/packages/front-end/components/Features/FeatureModal/FeatureFromExperimentModal.tsx
+++ b/packages/front-end/components/Features/FeatureModal/FeatureFromExperimentModal.tsx
@@ -27,6 +27,7 @@ import MarkdownInput from "@/components/Markdown/MarkdownInput";
 import SelectField from "@/components/Forms/SelectField";
 import FeatureValueField from "@/components/Features/FeatureValueField";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
+import useOrgSettings from "@/hooks/useOrgSettings";
 import FeatureKeyField from "./FeatureKeyField";
 import EnvironmentSelect from "./EnvironmentSelect";
 import TagsField from "./TagsField";
@@ -124,6 +125,17 @@ export default function FeatureFromExperimentModal({
   );
   const permissionsUtil = usePermissionsUtil();
   const { refreshWatching } = useWatching();
+  const settings = useOrgSettings();
+
+  const hasApprovalFlowsEnabled = (() => {
+    const requireReviews = settings?.requireReviews;
+    if (!requireReviews) return false;
+    if (requireReviews === true) return true;
+    if (Array.isArray(requireReviews)) {
+      return requireReviews.some((r) => r.requireReviewOn);
+    }
+    return false;
+  })();
 
   const defaultValues = genFormDefaultValues({
     environments,
@@ -414,14 +426,30 @@ export default function FeatureFromExperimentModal({
 
       {existing && (
         <div className="alert alert-info">
-          A rule will be added to the bottom of every environment in a new draft
-          revision. For more control over placement, you can add Experiment
-          rules directly from the{" "}
-          <Link href={`/features/${existing}`}>
-            Feature page
-            <FaExternalLinkAlt />
-          </Link>{" "}
-          instead.
+          {hasApprovalFlowsEnabled ? (
+            <>
+              A rule will be added to the bottom of every environment in a new
+              draft revision. For more control over placement, you can add
+              Experiment rules directly from the{" "}
+              <Link href={`/features/${existing}`}>
+                Feature page
+                <FaExternalLinkAlt />
+              </Link>{" "}
+              instead.
+            </>
+          ) : (
+            <>
+              A rule will be added to the bottom of every environment and the
+              revision will go live. This rule will be skipped until the
+              experiment is started. For more control over placement, you can
+              add Experiment rules directly from the{" "}
+              <Link href={`/features/${existing}`}>
+                Feature page
+                <FaExternalLinkAlt />
+              </Link>{" "}
+              instead.
+            </>
+          )}
         </div>
       )}
 

--- a/packages/front-end/components/Features/FeatureModal/FeatureFromExperimentModal.tsx
+++ b/packages/front-end/components/Features/FeatureModal/FeatureFromExperimentModal.tsx
@@ -10,7 +10,10 @@ import { ReactElement, useState } from "react";
 import { ExperimentInterfaceStringDates } from "shared/types/experiment";
 import Link from "next/link";
 import { FaExternalLinkAlt } from "react-icons/fa";
-import { filterEnvironmentsByExperiment } from "shared/util";
+import {
+  filterEnvironmentsByExperiment,
+  featureRequiresReview,
+} from "shared/util";
 import { useAuth } from "@/services/auth";
 import Modal from "@/components/Modal";
 import { useDefinitions } from "@/services/DefinitionsContext";
@@ -127,16 +130,6 @@ export default function FeatureFromExperimentModal({
   const { refreshWatching } = useWatching();
   const settings = useOrgSettings();
 
-  const hasApprovalFlowsEnabled = (() => {
-    const requireReviews = settings?.requireReviews;
-    if (!requireReviews) return false;
-    if (requireReviews === true) return true;
-    if (Array.isArray(requireReviews)) {
-      return requireReviews.some((r) => r.requireReviewOn);
-    }
-    return false;
-  })();
-
   const defaultValues = genFormDefaultValues({
     environments,
     permissions: permissionsUtil,
@@ -183,6 +176,19 @@ export default function FeatureFromExperimentModal({
   }
 
   const existing = form.watch("existing");
+
+  const selectedFeature = existing
+    ? validFeatures.find((f) => f.id === existing)
+    : undefined;
+
+  const requiresReviewForSelectedFeature = selectedFeature
+    ? featureRequiresReview(
+        { project: selectedFeature.project } as FeatureInterface,
+        environments.map((e) => e.id),
+        false,
+        settings,
+      )
+    : false;
 
   function updateValuesOnTypeChange(val: FeatureValueType) {
     // If existing value already matches, do nothing
@@ -426,7 +432,7 @@ export default function FeatureFromExperimentModal({
 
       {existing && (
         <div className="alert alert-info">
-          {hasApprovalFlowsEnabled ? (
+          {requiresReviewForSelectedFeature ? (
             <>
               A rule will be added to the bottom of every environment in a new
               draft revision. For more control over placement, you can add


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Features and Changes

Corrected the informational message displayed when linking an existing feature flag to an experiment. Previously, it always stated a "draft revision" would be created, even when approval flows were disabled and the revision would go live immediately.

The message now dynamically updates based on the organization's approval flow settings:
*   **Approval flows OFF**: "A rule will be added to the bottom of every environment and the revision will go live. This rule will be skipped until the experiment is started."
*   **Approval flows ON**: Retains the original message about creating a "draft revision".

This ensures the user is accurately informed about the immediate impact of linking a feature flag when approval flows are not required.

- Closes **(add link to issue here)**

### Dependencies

None

### Testing

1.  **With Approval Flows OFF**:
    *   Disable approval flows in organization settings.
    *   Navigate to an experiment and attempt to link an existing feature flag.
    *   Verify the modal displays the message: "A rule will be added to the bottom of every environment and the revision will go live. This rule will be skipped until the experiment is started."
2.  **With Approval Flows ON**:
    *   Enable approval flows in organization settings.
    *   Navigate to an experiment and attempt to link an existing feature flag.
    *   Verify the modal displays the message: "A draft revision will be created for this feature flag. Once approved, a rule will be added to the bottom of every environment. This rule will be skipped until the experiment is started."

### Screenshots

![Modal showing corrected message](modal_corrected_message.webp)

[Video: linking_feature_flag_corrected_message.mp4]

---
[Slack Thread](https://growthbookapp.slack.com/archives/C07NK4F016Z/p1772747388589369?thread_ts=1772747388.589369&cid=C07NK4F016Z)

<p><a href="https://cursor.com/agents/bc-40c73448-a7e6-539c-b1b3-0f0991a80e2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-40c73448-a7e6-539c-b1b3-0f0991a80e2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->