### PR TITLE
fix(results): render abs effects on % DAU as pp

### DIFF
--- a/packages/front-end/services/metrics.tsx
+++ b/packages/front-end/services/metrics.tsx
@@ -343,7 +343,12 @@ export function getExperimentMetricFormatter(
   // Fact metric
   switch (metric.metricType) {
     case "dailyParticipation":
-      return metric.displayAsPercentage ? formatPercent : formatNumber;
+      if (metric.displayAsPercentage) {
+        return proportionFormat === "percentagePoints"
+          ? formatPercentagePoints
+          : formatPercent;
+      }
+      return formatNumber;
     case "proportion":
     case "retention":
       if (proportionFormat === "number") {


### PR DESCRIPTION
### Features and Changes

DAU types should render absolute changes as `pp` not as `%`, just like Proportion metrics do.

Before
<img width="997" height="65" alt="Screenshot 2026-03-06 at 10 53 12 AM" src="https://github.com/user-attachments/assets/21ecd659-401e-4192-8eca-53f9ec09ac1a" />

After
<img width="989" height="57" alt="Screenshot 2026-03-06 at 10 53 04 AM" src="https://github.com/user-attachments/assets/5e4cae50-c076-41ea-b3d9-dd86bbe277e5" />

- Closes **(add link to issue here)**

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

<!--
  Please describe how to test these changes.
 -->

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
