### PR TITLE
fix(incremental): coerce unit dimension id type to string

### DIFF
--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -7891,7 +7891,7 @@ ORDER BY column_name, count DESC
               (
                 d,
               ) => `LEFT JOIN __dim_unit_${d.dimension.id} __dim_unit_${d.dimension.id} ON (
-            __dim_unit_${d.dimension.id}.${baseIdType} = e.${baseIdType}
+            ${this.castToString(`__dim_unit_${d.dimension.id}.${baseIdType}`)} = e.${baseIdType}
           )`,
             )
             .join("\n")}


### PR DESCRIPTION
### Features and Changes

We need to cast unit dimension user types to string to work with incremental refresh in case it is INT or some other unit type, since we don't validate on unit dimension creation.

- Closes **(add link to issue here)**

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

<!--
  Please describe how to test these changes.
 -->

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
