### PR TITLE
Prevent accidental deletion and archiving of active features

### DIFF
--- a/packages/front-end/components/Features/FeatureArchiveModal.tsx
+++ b/packages/front-end/components/Features/FeatureArchiveModal.tsx
@@ -1,6 +1,7 @@
 import { FeatureInterface } from "shared/types/feature";
 import { Text } from "@radix-ui/themes";
 import { useFeatureDependents } from "@/hooks/useFeatureDependents";
+import { getEnabledEnvironments, useEnvironments } from "@/services/features";
 import Callout from "@/ui/Callout";
 import LoadingSpinner from "@/components/LoadingSpinner";
 import Modal from "@/components/Modal";
@@ -22,6 +23,12 @@ export default function FeatureArchiveModal({
     (dependents?.features.length ?? 0) + (dependents?.experiments.length ?? 0);
   const isArchived = feature.archived;
 
+  const environments = useEnvironments();
+  const enabledEnvs = isArchived
+    ? []
+    : getEnabledEnvironments(feature, environments);
+  const hasActiveEnvs = enabledEnvs.length > 0;
+
   return (
     <Modal
       trackingEventModalType=""
@@ -34,13 +41,21 @@ export default function FeatureArchiveModal({
         await onArchive();
         close();
       }}
-      ctaEnabled={!loading && totalDependents === 0}
+      ctaEnabled={!loading && totalDependents === 0 && !hasActiveEnvs}
       useRadixButton={true}
     >
       {loading ? (
         <Text color="gray">
           <LoadingSpinner /> Checking feature dependencies...
         </Text>
+      ) : hasActiveEnvs ? (
+        <Callout status="warning" mb="4">
+          <Text as="p" mb="0">
+            This feature is still active in the following environments:{" "}
+            <strong>{enabledEnvs.join(", ")}</strong>. Please disable those
+            environments first before archiving.
+          </Text>
+        </Callout>
       ) : totalDependents > 0 ? (
         <>
           <Callout status="error" mb="4">

--- a/packages/front-end/components/Features/FeaturesHeader.tsx
+++ b/packages/front-end/components/Features/FeaturesHeader.tsx
@@ -263,18 +263,22 @@ export default function FeaturesHeader({
                       {isArchived ? "Unarchive" : "Archive"}
                     </DropdownMenuItem>
                   </DropdownMenuGroup>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuGroup>
-                    <DropdownMenuItem
-                      color="red"
-                      onClick={() => {
-                        setDeleteModal(true);
-                        setDropdownOpen(false);
-                      }}
-                    >
-                      Delete
-                    </DropdownMenuItem>
-                  </DropdownMenuGroup>
+                  {isArchived && (
+                    <>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuGroup>
+                        <DropdownMenuItem
+                          color="red"
+                          onClick={() => {
+                            setDeleteModal(true);
+                            setDropdownOpen(false);
+                          }}
+                        >
+                          Delete
+                        </DropdownMenuItem>
+                      </DropdownMenuGroup>
+                    </>
+                  )}
                 </>
               )}
             </DropdownMenu>


### PR DESCRIPTION
This PR adds friction to the deletion process and helps ensure that features that are actively being used are not removed accidentally.

1. Require archiving a feature first before doing a hard delete
2. Disable archiving if the feature is active in any environments

Both of these restrictions are only enforced on the front-end, meaning API calls can bypass them. This is intentional to prevent breaking existing automated workflows.