### PR TITLE
Updates teams.update call to fix SCIM bug

### DIFF
--- a/packages/back-end/src/scim/groups/patchGroup.ts
+++ b/packages/back-end/src/scim/groups/patchGroup.ts
@@ -105,10 +105,9 @@ export async function patchGroup(
           }
         }
         await req.context.models.teams.update(team, {
-          ...team,
           name: (value as BasicScimGroup).displayName,
           managedByIdp: true,
-          role,
+          role: role || team.role,
         });
       } else {
         return res.status(400).json({


### PR DESCRIPTION
### Features and Changes

An organization using our SCIM service reported a bug as they were having trouble removing/updating a group in Okta. They were receiving an `Unable to perform replace operation` error.

It looks like the issue was with the `await req.context.models.teams.update()` call inside of the `patchGroup.ts` file - we were spreading in the `...team` to the update call, which resulted in an error.

Removing the spread and just passing in the content of the `value` remedied the issue.

I am a little concerned that the linter didn't catch this, but I'm not super familiar with the BaseModel. will sync with the infra team to see if there is something we can do to prevent this in the future.

### Dependencies
 None

### Testing

- [x] Ensure you can correctly push, deactivate, and unlink a push group from Okta
- [x] Ensure that you can still provision groups via Okta
- [x] Ensure that if a user is provisioned, and in a push group, when the push group is added, we correctly create the `team` in GrowthBook, add the user to the team
- [x] Ensure that if you unlink a group and choose to delete the team, we correctly delete the team in growthbook
