### PR TITLE
fixes s3 credentials refresh

### DIFF
--- a/packages/back-end/src/services/files.ts
+++ b/packages/back-end/src/services/files.ts
@@ -15,6 +15,30 @@ import {
 let s3: AWS.S3;
 let awsTempCredentials: AWS.TemporaryCredentials | null = null;
 
+function shouldRefreshCredentials(): boolean {
+  if (!awsTempCredentials) return false;
+
+  // Check if credentials need refresh using the SDK's built-in method
+  if (awsTempCredentials.needsRefresh()) return true;
+
+  // Additional safety check: if expireTime is not set, credentials may not have been loaded
+  if (!awsTempCredentials.expireTime) return true;
+
+  // Proactively refresh if credentials expire within 5 minutes to avoid edge cases
+  const bufferMs = 5 * 60 * 1000; // 5 minutes
+  return awsTempCredentials.expireTime.getTime() - Date.now() < bufferMs;
+}
+
+async function refreshCredentials(): Promise<void> {
+  if (!awsTempCredentials) return;
+  return new Promise<void>((resolve, reject) => {
+    awsTempCredentials!.refresh((err) => {
+      if (err) reject(err);
+      else resolve();
+    });
+  });
+}
+
 async function getS3(): Promise<AWS.S3> {
   if (!s3) {
     AWS.config.update({ region: S3_REGION });
@@ -26,6 +50,11 @@ async function getS3(): Promise<AWS.S3> {
         RoleSessionName: "growthbook-uploads",
       });
 
+      // Eagerly load credentials for the first time so that masterCredentials
+      // is populated before any synchronous SDK operations (e.g. getSignedUrl,
+      // createPresignedPost) attempt to access it.
+      await refreshCredentials();
+
       s3 = new AWS.S3({
         signatureVersion: "v4",
         credentials: awsTempCredentials,
@@ -36,13 +65,8 @@ async function getS3(): Promise<AWS.S3> {
   }
   // Eagerly refresh expired/expiring credentials before returning the client.
   // This ensures even synchronous operations like getSignedUrl use valid creds.
-  if (awsTempCredentials && awsTempCredentials.needsRefresh()) {
-    await new Promise<void>((resolve, reject) => {
-      awsTempCredentials!.refresh((err) => {
-        if (err) reject(err);
-        else resolve();
-      });
-    });
+  if (shouldRefreshCredentials()) {
+    await refreshCredentials();
   }
   return s3;
 }


### PR DESCRIPTION
## Features and Changes
Fix Cannot read properties of null (reading 'masterCredentials') error when uploading files via S3 pre-signed URLs with an assumed IAM role (`AWS_ASSUME_ROLE`).
The AWS SDK v2 TemporaryCredentials constructor does not eagerly resolve `masterCredentials` — it only does so on the first call to `refresh()`. Synchronous SDK operations such as getSignedUrl and `createPresignedPost` attempt to access masterCredentials before it is populated, causing a null reference error.
The fix explicitly calls `refresh()` immediately after constructing `TemporaryCredentials`, ensuring credentials are fully initialized before the S3 client is used for any operation.
Closes [#5458](https://github.com/growthbook/growthbook/issues/5458)
## Dependencies
None
## Testing
Configure the app with `AWS_ASSUME_ROLE` set to a valid IAM role ARN and `UPLOAD_METHOD=s3`.
Attempt to upload a file through the UI.
Verify the upload completes successfully without the `masterCredentials` error.
## Screenshots
N/A — backend-only change, no UI impact.