### PR TITLE
Increase the size limit for just the screenshot upload endpoint

### DIFF
--- a/packages/back-end/src/app.ts
+++ b/packages/back-end/src/app.ts
@@ -241,8 +241,19 @@ app.use(async (req, res, next) => {
 // Visual Designer js file (does not require JWT or cors)
 app.get("/js/:key.js", getExperimentsScript);
 
-// increase max payload json size to 2mb
-app.use(bodyParser.json({ limit: "2mb" }));
+// increase max payload json size to 2mb (10mb for the api screenshot upload)
+app.use((req, res, next) => {
+  const isScreenshotUpload =
+    req.method === "POST" &&
+    /^\/api\/v1\/experiments\/[^/]+\/variation\/[^/]+\/screenshot\/upload$/.test(
+      req.path,
+    );
+  bodyParser.json({ limit: isScreenshotUpload ? "10mb" : "2mb" })(
+    req,
+    res,
+    next,
+  );
+});
 
 // Public API routes (does not require JWT, does require cors with origin = *)
 app.get(


### PR DESCRIPTION
### Features and Changes
Increase the size limit for just the screenshot upload endpoint

### Testing
`base64 -i bigfile.png -o bigfile_base64.png`
run the following with a user Personal Access Token, or API key, and an experimentId in your db
```
curl -X GET http://localhost:3100/api/v1/experiments/exp_rh6351nbkmmj2brom \
  -H "Authorization: Bearer secret_user_VyRx63NRXzVjGZixxHHOrDkpv8A3EirZEWSV0Rz3MM" 
```
See the variationId.  Then run:
```
jq -n --rawfile screenshot ~/growthbook/growthbook/bigimage_base64.txt '{screenshot: $screenshot, contentType: "image/png"}' | \
curl -X POST "http://localhost:3100/api/v1/experiments/exp_rh6351nbkmmj2brom/variation/var_mmj2bj1c/screenshot/upload" \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer secret_user_VyRx63NRXzVjGZixxHHOrDkpv8A3EirZEWSV0Rz3MM" \
  -d @-
```
Load the experiment and see the new big image there.
