### PR TITLE
Add API endpoint for listing experiment templates

### DIFF
--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -264,6 +264,9 @@ tags:
   - name: Team_model
     x-displayName: Team
     description: <SchemaDefinition schemaRef="#/components/schemas/Team" />
+  - name: ExperimentTemplate_model
+    x-displayName: ExperimentTemplate
+    description: <SchemaDefinition schemaRef="#/components/schemas/ExperimentTemplate" />
 paths:
   /features:
     get:
@@ -17702,6 +17705,190 @@ paths:
                 required:
                   - deletedId
                 additionalProperties: false
+  /experiment-templates:
+    get:
+      $skipValidatorGeneration: true
+      parameters:
+        - name: projectId
+          in: query
+          required: false
+          schema:
+            type: string
+      tags:
+        - ExperimentTemplates
+      summary: Get all experimentTemplates
+      operationId: listExperimentTemplates
+      x-codeSamples:
+        - lang: cURL
+          source: 'curl -X GET https://api.growthbook.io/api/v1/experiment-templates -u secret_abc123DEF456'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - experimentTemplates
+                properties:
+                  experimentTemplates:
+                    $schema: 'https://json-schema.org/draft/2020-12/schema'
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        dateCreated:
+                          type: string
+                          format: date-time
+                          pattern: '^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$'
+                        dateUpdated:
+                          type: string
+                          format: date-time
+                          pattern: '^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$'
+                        project:
+                          type: string
+                        owner:
+                          type: string
+                        templateMetadata:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            description:
+                              type: string
+                          required:
+                            - name
+                          additionalProperties: false
+                        type:
+                          type: string
+                          enum:
+                            - standard
+                        hypothesis:
+                          type: string
+                        description:
+                          type: string
+                        tags:
+                          type: array
+                          items:
+                            type: string
+                        customFields:
+                          type: object
+                          propertyNames:
+                            type: string
+                          additionalProperties:
+                            type: string
+                        datasource:
+                          type: string
+                        exposureQueryId:
+                          type: string
+                        hashAttribute:
+                          type: string
+                        fallbackAttribute:
+                          type: string
+                        disableStickyBucketing:
+                          type: boolean
+                        goalMetrics:
+                          type: array
+                          items:
+                            type: string
+                        secondaryMetrics:
+                          type: array
+                          items:
+                            type: string
+                        guardrailMetrics:
+                          type: array
+                          items:
+                            type: string
+                        activationMetric:
+                          type: string
+                        statsEngine:
+                          type: string
+                          enum:
+                            - bayesian
+                            - frequentist
+                        segment:
+                          type: string
+                        skipPartialData:
+                          type: boolean
+                        targeting:
+                          type: object
+                          properties:
+                            coverage:
+                              type: number
+                            savedGroups:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  match:
+                                    type: string
+                                    enum:
+                                      - all
+                                      - none
+                                      - any
+                                  ids:
+                                    type: array
+                                    items:
+                                      type: string
+                                required:
+                                  - match
+                                  - ids
+                                additionalProperties: false
+                            prerequisites:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  id:
+                                    type: string
+                                  condition:
+                                    type: string
+                                required:
+                                  - id
+                                  - condition
+                                additionalProperties: false
+                            condition:
+                              type: string
+                          required:
+                            - coverage
+                            - condition
+                          additionalProperties: false
+                        customMetricSlices:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              slices:
+                                type: array
+                                items:
+                                  type: object
+                                  properties:
+                                    column:
+                                      type: string
+                                    levels:
+                                      type: array
+                                      items:
+                                        type: string
+                                  required:
+                                    - column
+                                    - levels
+                                  additionalProperties: false
+                            required:
+                              - slices
+                            additionalProperties: false
+                      required:
+                        - id
+                        - dateCreated
+                        - dateUpdated
+                        - owner
+                        - templateMetadata
+                        - type
+                        - datasource
+                        - exposureQueryId
+                        - statsEngine
+                        - targeting
+                      additionalProperties: false
 components:
   parameters:
     id:
@@ -19505,6 +19692,164 @@ components:
         - environments
         - members
         - managedByIdp
+      additionalProperties: false
+      $skipValidatorGeneration: true
+    ExperimentTemplate:
+      $schema: 'https://json-schema.org/draft/2020-12/schema'
+      type: object
+      properties:
+        id:
+          type: string
+        dateCreated:
+          type: string
+          format: date-time
+          pattern: '^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$'
+        dateUpdated:
+          type: string
+          format: date-time
+          pattern: '^(?:(?:\d\d[2468][048]|\d\d[13579][26]|\d\d0[48]|[02468][048]00|[13579][26]00)-02-29|\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\d|30)|(?:02)-(?:0[1-9]|1\d|2[0-8])))T(?:(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?(?:Z))$'
+        project:
+          type: string
+        owner:
+          type: string
+        templateMetadata:
+          type: object
+          properties:
+            name:
+              type: string
+            description:
+              type: string
+          required:
+            - name
+          additionalProperties: false
+        type:
+          type: string
+          enum:
+            - standard
+        hypothesis:
+          type: string
+        description:
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+        customFields:
+          type: object
+          propertyNames:
+            type: string
+          additionalProperties:
+            type: string
+        datasource:
+          type: string
+        exposureQueryId:
+          type: string
+        hashAttribute:
+          type: string
+        fallbackAttribute:
+          type: string
+        disableStickyBucketing:
+          type: boolean
+        goalMetrics:
+          type: array
+          items:
+            type: string
+        secondaryMetrics:
+          type: array
+          items:
+            type: string
+        guardrailMetrics:
+          type: array
+          items:
+            type: string
+        activationMetric:
+          type: string
+        statsEngine:
+          type: string
+          enum:
+            - bayesian
+            - frequentist
+        segment:
+          type: string
+        skipPartialData:
+          type: boolean
+        targeting:
+          type: object
+          properties:
+            coverage:
+              type: number
+            savedGroups:
+              type: array
+              items:
+                type: object
+                properties:
+                  match:
+                    type: string
+                    enum:
+                      - all
+                      - none
+                      - any
+                  ids:
+                    type: array
+                    items:
+                      type: string
+                required:
+                  - match
+                  - ids
+                additionalProperties: false
+            prerequisites:
+              type: array
+              items:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  condition:
+                    type: string
+                required:
+                  - id
+                  - condition
+                additionalProperties: false
+            condition:
+              type: string
+          required:
+            - coverage
+            - condition
+          additionalProperties: false
+        customMetricSlices:
+          type: array
+          items:
+            type: object
+            properties:
+              slices:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    column:
+                      type: string
+                    levels:
+                      type: array
+                      items:
+                        type: string
+                  required:
+                    - column
+                    - levels
+                  additionalProperties: false
+            required:
+              - slices
+            additionalProperties: false
+      required:
+        - id
+        - dateCreated
+        - dateUpdated
+        - owner
+        - templateMetadata
+        - type
+        - datasource
+        - exposureQueryId
+        - statsEngine
+        - targeting
       additionalProperties: false
       $skipValidatorGeneration: true
     PaginationFields:
@@ -22423,6 +22768,7 @@ x-tagGroups:
       - CustomFields
       - MetricGroups
       - Teams
+      - ExperimentTemplates
   - name: Models
     tags:
       - Archetype_model
@@ -22472,3 +22818,4 @@ x-tagGroups:
       - CustomField_model
       - MetricGroup_model
       - Team_model
+      - ExperimentTemplate_model

--- a/packages/back-end/src/api/ApiModel.ts
+++ b/packages/back-end/src/api/ApiModel.ts
@@ -11,6 +11,7 @@ import {
 } from "back-end/src/util/handler";
 import { MetricGroupModel } from "back-end/src/models/MetricGroupModel";
 import { TeamModel } from "back-end/src/models/TeamModel";
+import { ExperimentTemplatesModel } from "back-end/src/models/ExperimentTemplateModel";
 import {
   CustomApiHandler,
   CrudAction,
@@ -24,6 +25,7 @@ export const API_MODELS: ModelClass[] = [
   CustomFieldModel,
   MetricGroupModel,
   TeamModel,
+  ExperimentTemplatesModel,
 ];
 
 export type ApiBaseSchema = typeof apiBaseSchema;
@@ -41,7 +43,7 @@ type CrudValidatorShapes<T extends ApiBaseSchema> = {
     z.ZodNever
   >;
   get: ApiRequestValidator<z.ZodType<{ id: string }>, z.ZodNever, z.ZodNever>;
-  list: ApiRequestValidator<z.ZodNever, z.ZodNever, z.ZodNever>;
+  list: ApiRequestValidator<z.ZodNever, z.ZodNever, z.ZodTypeAny>;
   update: ApiRequestValidator<
     z.ZodType<{ id: string }>,
     ApiUpdateZodObject<T>,

--- a/packages/back-end/src/models/ExperimentTemplateModel.ts
+++ b/packages/back-end/src/models/ExperimentTemplateModel.ts
@@ -1,7 +1,12 @@
+import { z } from "zod";
 import {
+  ApiExperimentTemplateInterface,
+  apiExperimentTemplateValidator,
+  apiListExperimentTemplatesValidator,
   experimentTemplateInterface,
   ExperimentTemplateInterface,
 } from "shared/validators";
+import { ApiRequest } from "back-end/src/util/handler";
 import { MakeModelClass } from "./BaseModel";
 
 const BaseClass = MakeModelClass({
@@ -18,6 +23,21 @@ const BaseClass = MakeModelClass({
   defaultValues: {
     targeting: {
       condition: "{}",
+    },
+  },
+  apiConfig: {
+    modelKey: "experimentTemplates",
+    modelSingular: "experimentTemplate",
+    modelPlural: "experimentTemplates",
+    apiInterface: apiExperimentTemplateValidator,
+    schemas: {
+      createBody: z.never(),
+      updateBody: z.never(),
+    },
+    pathBase: "/experiment-templates",
+    crudActions: ["list"],
+    crudValidatorOverrides: {
+      list: apiListExperimentTemplatesValidator,
     },
   },
 });
@@ -47,11 +67,16 @@ export class ExperimentTemplatesModel extends BaseClass {
     return this.context.hasPremiumFeature("templates");
   }
 
-  // TODO: Implement this for OpenAPI
-  //   public toApiInterface(project: ProjectInterface): ApiProject {
-  //     return {
-  //       id: project.id,
-  //       name: project.name,
-  //     };
-  //   }
+  public async handleApiList(
+    req: ApiRequest<unknown, z.ZodTypeAny, z.ZodTypeAny, z.ZodTypeAny>,
+  ): Promise<ApiExperimentTemplateInterface[]> {
+    // Typecast due to the method signature using ZodTypeAnys since a narrower type breaks ApiModel
+    const { projectId } = req.query as z.infer<
+      (typeof apiListExperimentTemplatesValidator)["querySchema"]
+    >;
+    const docs = await (projectId
+      ? this._find({ project: projectId })
+      : this.getAll());
+    return docs.map(this.toApiInterface.bind(this));
+  }
 }

--- a/packages/shared/src/validators/experiment-template.ts
+++ b/packages/shared/src/validators/experiment-template.ts
@@ -2,15 +2,12 @@ import { z } from "zod";
 import { statsEngines } from "shared/constants";
 import { customMetricSlice } from "./experiments";
 import { featurePrerequisite, savedGroupTargeting } from "./shared";
+import { apiBaseSchema, baseSchema } from "./base-model";
 
-export const experimentTemplateInterface = z
-  .object({
-    id: z.string(),
-    organization: z.string(),
+export const experimentTemplateInterface = baseSchema
+  .safeExtend({
     project: z.string().optional(),
     owner: z.string(),
-    dateCreated: z.date(),
-    dateUpdated: z.date(),
 
     templateMetadata: z.object({
       name: z.string(),
@@ -52,6 +49,57 @@ export const experimentTemplateInterface = z
 export type ExperimentTemplateInterface = z.infer<
   typeof experimentTemplateInterface
 >;
+
+export const apiExperimentTemplateValidator = apiBaseSchema.safeExtend({
+  project: z.string().optional(),
+  owner: z.string(),
+
+  templateMetadata: z.object({
+    name: z.string(),
+    description: z.string().optional(),
+  }),
+
+  type: z.enum(["standard"]),
+  hypothesis: z.string().optional(),
+  description: z.string().optional(),
+  tags: z.array(z.string()).optional(),
+  customFields: z.record(z.string(), z.string()).optional(),
+
+  datasource: z.string(),
+  exposureQueryId: z.string(),
+
+  hashAttribute: z.string().optional(),
+  fallbackAttribute: z.string().optional(),
+  disableStickyBucketing: z.boolean().optional(),
+
+  goalMetrics: z.array(z.string()).optional(),
+  secondaryMetrics: z.array(z.string()).optional(),
+  guardrailMetrics: z.array(z.string()).optional(),
+  activationMetric: z.string().optional(),
+  statsEngine: z.enum(statsEngines),
+  segment: z.string().optional(),
+  skipPartialData: z.boolean().optional(),
+
+  // Located in phases array for ExperimentInterface
+  targeting: z.object({
+    coverage: z.number(),
+    savedGroups: z.array(savedGroupTargeting).optional(),
+    prerequisites: z.array(featurePrerequisite).optional(),
+    condition: z.string(),
+  }),
+
+  customMetricSlices: z.array(customMetricSlice).optional(),
+});
+
+export type ApiExperimentTemplateInterface = z.infer<
+  typeof apiExperimentTemplateValidator
+>;
+
+export const apiListExperimentTemplatesValidator = {
+  bodySchema: z.never(),
+  querySchema: z.strictObject({ projectId: z.string().optional() }),
+  paramsSchema: z.never(),
+};
 
 export const createTemplateValidator = experimentTemplateInterface.omit({
   id: true,

--- a/packages/shared/types/experiment.d.ts
+++ b/packages/shared/types/experiment.d.ts
@@ -36,6 +36,7 @@ export {
 
 export {
   ExperimentTemplateInterface,
+  ApiExperimentTemplateInterface,
   CreateTemplateProps,
   UpdateTemplateProps,
 } from "shared/validators";

--- a/packages/shared/types/openapi.d.ts
+++ b/packages/shared/types/openapi.d.ts
@@ -470,6 +470,10 @@ export interface paths {
     /** Delete a single team */
     delete: operations["deleteTeam"];
   };
+  "/experiment-templates": {
+    /** Get all experimentTemplates */
+    get: operations["listExperimentTemplates"];
+  };
 }
 
 export type webhooks = Record<string, never>;
@@ -932,6 +936,59 @@ export interface components {
         resourceId: string;
       };
       defaultProject?: string;
+    };
+    ExperimentTemplate: {
+      id: string;
+      /** Format: date-time */
+      dateCreated: string;
+      /** Format: date-time */
+      dateUpdated: string;
+      project?: string;
+      owner: string;
+      templateMetadata: {
+        name: string;
+        description?: string;
+      };
+      /** @enum {string} */
+      type: "standard";
+      hypothesis?: string;
+      description?: string;
+      tags?: (string)[];
+      customFields?: {
+        [key: string]: string | undefined;
+      };
+      datasource: string;
+      exposureQueryId: string;
+      hashAttribute?: string;
+      fallbackAttribute?: string;
+      disableStickyBucketing?: boolean;
+      goalMetrics?: (string)[];
+      secondaryMetrics?: (string)[];
+      guardrailMetrics?: (string)[];
+      activationMetric?: string;
+      /** @enum {string} */
+      statsEngine: "bayesian" | "frequentist";
+      segment?: string;
+      skipPartialData?: boolean;
+      targeting: {
+        coverage: number;
+        savedGroups?: ({
+            /** @enum {string} */
+            match: "all" | "none" | "any";
+            ids: (string)[];
+          })[];
+        prerequisites?: ({
+            id: string;
+            condition: string;
+          })[];
+        condition: string;
+      };
+      customMetricSlices?: ({
+          slices: ({
+              column: string;
+              levels: (string)[];
+            })[];
+        })[];
     };
     PaginationFields: {
       limit: number;
@@ -18473,6 +18530,75 @@ export interface operations {
         content: {
           "application/json": {
             deletedId: string;
+          };
+        };
+      };
+    };
+  };
+  listExperimentTemplates: {
+    /** Get all experimentTemplates */
+    parameters: {
+      query: {
+        projectId?: string;
+      };
+    };
+    responses: {
+      200: {
+        content: {
+          "application/json": {
+            experimentTemplates: ({
+                id: string;
+                /** Format: date-time */
+                dateCreated: string;
+                /** Format: date-time */
+                dateUpdated: string;
+                project?: string;
+                owner: string;
+                templateMetadata: {
+                  name: string;
+                  description?: string;
+                };
+                /** @enum {string} */
+                type: "standard";
+                hypothesis?: string;
+                description?: string;
+                tags?: (string)[];
+                customFields?: {
+                  [key: string]: string | undefined;
+                };
+                datasource: string;
+                exposureQueryId: string;
+                hashAttribute?: string;
+                fallbackAttribute?: string;
+                disableStickyBucketing?: boolean;
+                goalMetrics?: (string)[];
+                secondaryMetrics?: (string)[];
+                guardrailMetrics?: (string)[];
+                activationMetric?: string;
+                /** @enum {string} */
+                statsEngine: "bayesian" | "frequentist";
+                segment?: string;
+                skipPartialData?: boolean;
+                targeting: {
+                  coverage: number;
+                  savedGroups?: ({
+                      /** @enum {string} */
+                      match: "all" | "none" | "any";
+                      ids: (string)[];
+                    })[];
+                  prerequisites?: ({
+                      id: string;
+                      condition: string;
+                    })[];
+                  condition: string;
+                };
+                customMetricSlices?: ({
+                    slices: ({
+                        column: string;
+                        levels: (string)[];
+                      })[];
+                  })[];
+              })[];
           };
         };
       };


### PR DESCRIPTION
### Features and Changes

Adds a rest endpoint for listing experiment templates (filtered by `projectId`)
Started in #5462 by @dannylin-ant

Also has a minor improvement to `apiConfig` to make overriding query params for list endpoints easier in the future

### Testing

- [x] Hit the new endpoint with and without `projectId=` to check that the filtering works appropriately
- [x] Check that the docs generated properly with the new param format

### Screenshots

<img width="1046" height="982" alt="image" src="https://github.com/user-attachments/assets/cd6ba9b6-5c8b-41c0-8ae5-68ee8ae0abcc" />

<img width="1745" height="845" alt="image" src="https://github.com/user-attachments/assets/62d56922-8f44-46bf-8952-5503cbe99dd5" />

