### PR TITLE
Ji/docs api self hosted fix

### DIFF
--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -51,7 +51,7 @@ info:
 servers:
   - url: 'https://api.growthbook.io/api/v1'
     description: GrowthBook Cloud
-  - url: 'http://{domain}/api/v1'
+  - url: 'https://{domain}/api/v1'
     description: Self-hosted GrowthBook
 tags:
   - name: projects

--- a/packages/back-end/src/api/openapi/openapi.yaml
+++ b/packages/back-end/src/api/openapi/openapi.yaml
@@ -51,7 +51,7 @@ info:
 servers:
   - url: "https://api.growthbook.io/api/v1"
     description: GrowthBook Cloud
-  - url: "http://{domain}/api/v1"
+  - url: "https://{domain}/api/v1"
     description: Self-hosted GrowthBook
 tags:
   - name: projects


### PR DESCRIPTION
### Features and Changes

Docusaurus was interpreting 
  `- url: {domain}/api/v1"` as a relative url and inserting `docs.growthbook.io/redocusaurus/` before it.  By making it an absolute path, it displays as intended.

It also removes the variable: domain, as it wasn't be properly replaced, and there was no place to set it even for docs.growthbook.io that I am aware of.

### Screenshots

Before:
<img width="403" height="253" alt="Screenshot 2026-03-11 at 5 52 34 PM" src="https://github.com/user-attachments/assets/975ae621-2c46-436a-9f6f-93571c739283" />

After:
<img width="403" height="249" alt="Screenshot 2026-03-11 at 6 01 24 PM" src="https://github.com/user-attachments/assets/cb8dbc85-1b38-4c6b-8643-3c0be94ad07d" />
