### PR TITLE
Fix other AI provider usage in frontend

### DIFF
--- a/packages/front-end/hooks/useOrgSettings.ts
+++ b/packages/front-end/hooks/useOrgSettings.ts
@@ -1,6 +1,6 @@
 import { AGREEMENT_TYPE_AI } from "shared/validators";
 import { useUser } from "@/services/UserContext";
-import { hasAnthropicKey, isCloud, hasOpenAIKey } from "@/services/env";
+import { isCloud, hasAnyAIKey } from "@/services/env";
 
 export default function useOrgSettings() {
   const { settings } = useUser();
@@ -16,7 +16,7 @@ export const useAISettings = (): {
 
   const aiEnabled = isCloud()
     ? !!settings?.aiEnabled && !!agreements?.includes(AGREEMENT_TYPE_AI)
-    : !!(settings?.aiEnabled && (hasOpenAIKey() || hasAnthropicKey()));
+    : !!(settings?.aiEnabled && hasAnyAIKey());
   const aiAgreedTo = isCloud()
     ? !!agreements?.includes(AGREEMENT_TYPE_AI)
     : true;

--- a/packages/front-end/services/env.ts
+++ b/packages/front-end/services/env.ts
@@ -140,6 +140,16 @@ export function hasGoogleAIKey() {
   return env.hasGoogleAIKey || false;
 }
 
+export function hasAnyAIKey() {
+  return (
+    hasOpenAIKey() ||
+    hasAnthropicKey() ||
+    hasXaiKey() ||
+    hasMistralKey() ||
+    hasGoogleAIKey()
+  );
+}
+
 export function getExperimentRefreshFrequency() {
   return env.experimentRefreshFrequency;
 }


### PR DESCRIPTION
### Features and Changes

When we added xAI/Gemini/Mistral in #5058, they were added in most places but `useOrgSettings` was still hardcoded to check for OpenAI/Anthropic. This led to a number of the AI-enabled frontend components showing error messages that AI was disabled for the organization despite a valid setup.

### Testing

1. Remove all openai/anthropic api keys from the environment
2. Check in the org AI settings that the gemini/xai/mistral api key is configured correctly
3.  Open a modal with a markdown input (e.g. Stop Experiment) and verify that the AI analysis generation succeeds