### PR TITLE
Make deploy action run sequentially

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,11 @@ on:
       - "pnpm-lock.yaml"
       - "Dockerfile"
       - ".dockerignore"
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
 jobs:
   # Build and publish the commit to docker
   docker:


### PR DESCRIPTION
### Features and Changes

Earlier today I merged two PRs at the same time which launched the deploy action twice. Because the first run took longer, it pushed to ECR later which led to the second PR's changes not being deployed on cloud.
If we change the deploy config to use a concurrency group it should only execute one at a time, and will cancel intermediate jobs in the queue if we merge many PRs at a time (reducing the total number of deploys)

[Github docs](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency)
