### PR TITLE
Managed warehouse defaults

### DIFF
--- a/packages/back-end/src/controllers/datasources.ts
+++ b/packages/back-end/src/controllers/datasources.ts
@@ -300,7 +300,7 @@ export async function postManagedWarehouse(
 
   // Start out with some default materialized columns
   // These can be changed by the user later
-  const identifiers = ["device_id", "user_id"];
+  const identifiers = ["device_id"];
   const dimensions = [
     "geo_country",
     "ua_browser",
@@ -1601,22 +1601,13 @@ function generateManagedWarehouseExposureQueries(
     .map((c) => c.columnName);
 
   return identifiers.map((identifier) => {
-    const cols = [
-      identifier,
-      "timestamp",
-      "experiment_id",
-      "variation_id",
-      ...dimensions,
-    ];
-
     return {
       id: identifier,
       dimensions,
       name: identifier,
       userIdType: identifier,
       query: `
-SELECT 
-  ${cols.join(",\n  ")}
+SELECT *
 FROM experiment_views
 WHERE
   experiment_id LIKE '{{ experimentId }}'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Features and Changes

- Updated `postManagedWarehouse` to default identifiers to `device_id` only, addressing common setups where `user_id` tracking is not configured.
- Modified `generateManagedWarehouseExposureQueries` to use `SELECT *` instead of explicitly listing columns, providing more flexibility for referencing additional columns.

- Closes **(add link to issue here)**

### Dependencies

None

### Testing

- `pnpm --filter back-end type-check`
- `pnpm --filter back-end test test/services/datasource.test.ts` (8/8 passing)

### Screenshots

[Slack Thread](https://growthbookapp.slack.com/archives/D0AH34812MC/p1773376368895059?thread_ts=1773376368.895059&cid=D0AH34812MC)

<div><a href="https://cursor.com/agents/bc-da34ada4-91cf-59b1-9937-bb7c516cdeb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-da34ada4-91cf-59b1-9937-bb7c516cdeb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->