### PR TITLE
Dimension query metric slices

### DIFF
--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -520,15 +520,12 @@ export function getSnapshotSettings({
   const currentDate = new Date();
 
   // Expand all slice metrics (auto and custom) and add them to the metricMap
-  // Skip slice expansion for dimension snapshots
-  if (!dimension) {
-    expandAllSliceMetricsInMap({
-      metricMap,
-      factTableMap,
-      experiment,
-      metricGroups,
-    });
-  }
+  expandAllSliceMetricsInMap({
+    metricMap,
+    factTableMap,
+    experiment,
+    metricGroups,
+  });
 
   const phaseEndDate = phase.dateEnded || currentDate;
   const lookbackOverride = getEffectiveLookbackOverride(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Features and Changes

Previously, metric slice expansion was explicitly skipped in `getSnapshotSettings` when a dimension was set, preventing slice data from being computed for dimension queries. This resulted in the metric drilldown modal's "Slices" tab showing no data when viewing dimension breakdown results.

This is probably because when we built slices, we had no convenient location to store dimension slice data. Now we do via the metric drilldown.

This PR expands slices in the metric map even when dimensions are selected.

The existing front-end warning "Slice filters are ignored when a unit dimension is set" remains accurate as it refers to a separate filtering functionality in the main results table, not the metric drilldown modal.


### Dependencies

None

### Human Testing
On main, there is no data populating drilldown slices when a unit dimension is applied
<img width="538" height="608" alt="Screenshot 2026-03-13 at 7 27 26 AM" src="https://github.com/user-attachments/assets/3c6e4e78-ee7e-4b51-85a9-3b879cb325a9" />

On this branch, there is!
<img width="556" height="748" alt="Screenshot 2026-03-13 at 7 27 00 AM" src="https://github.com/user-attachments/assets/7cad27f6-b96e-4e3f-892e-ff309b9ce6db" />


### Testing

- All back-end tests passed.
- All shared package tests passed.
- TypeScript type-checking passed.

### Screenshots

N/A (Backend change enabling UI functionality)

[Slack Thread](https://growthbookapp.slack.com/archives/C07NK4F016Z/p1773410745357919?thread_ts=1773410745.357919&cid=C07NK4F016Z)

<div><a href="https://cursor.com/agents/bc-decfa880-43d9-520e-8189-7cc03a179aac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-decfa880-43d9-520e-8189-7cc03a179aac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->