### PR TITLE
Breakdown results slice UI

### DIFF
--- a/packages/front-end/components/Experiment/BreakDownResults.tsx
+++ b/packages/front-end/components/Experiment/BreakDownResults.tsx
@@ -1,4 +1,4 @@
-import { FC } from "react";
+import { FC, useState, useEffect, useRef } from "react";
 import {
   ExperimentReportResultDimension,
   ExperimentReportVariation,
@@ -24,6 +24,7 @@ import {
   ExperimentSortBy,
   SetExperimentSortBy,
   formatDimensionValueForDisplay,
+  expandMetricGroups,
 } from "shared/experiments";
 import { NULL_DIMENSION_VALUE } from "shared/constants";
 import { FaCaretRight } from "react-icons/fa";
@@ -84,6 +85,13 @@ const BreakDownResults: FC<{
   differenceType: DifferenceType;
   metricTagFilter?: string[];
   metricsFilter?: string[];
+  sliceTagsFilter?: string[];
+  customMetricSlices?: Array<{
+    slices: Array<{
+      column: string;
+      levels: string[];
+    }>;
+  }>;
   experimentType?: ExperimentType;
   ssrPolyfills?: SSRPolyfills;
   renderMetricName?: (
@@ -137,6 +145,8 @@ const BreakDownResults: FC<{
   differenceType,
   metricTagFilter,
   metricsFilter,
+  sliceTagsFilter,
+  customMetricSlices,
   experimentType,
   ssrPolyfills,
   renderMetricName,
@@ -154,7 +164,15 @@ const BreakDownResults: FC<{
   mutate,
   setDifferenceType,
 }) => {
-  const { getDimensionById, getExperimentMetricById } = useDefinitions();
+  const {
+    getDimensionById,
+    getExperimentMetricById,
+    getFactTableById,
+    metricGroups: _metricGroups,
+  } = useDefinitions();
+
+  const getFactTableByIdFn = ssrPolyfills?.getFactTableById || getFactTableById;
+  const metricGroupsFn = ssrPolyfills?.metricGroups || _metricGroups;
 
   const _settings = useOrgSettings();
   const settings = ssrPolyfills?.useOrgSettings?.() || _settings;
@@ -168,7 +186,84 @@ const BreakDownResults: FC<{
     dimensionId?.split(":")?.[1] ||
     "Dimension";
 
-  const { tables } = useExperimentDimensionRows({
+  // Expanded state for metric slices
+  const [expandedMetrics, setExpandedMetrics] = useState<
+    Record<string, boolean>
+  >({});
+  const toggleExpandedMetric = (
+    metricId: string,
+    resultGroup: "goal" | "secondary" | "guardrail",
+  ) => {
+    const key = `${metricId}:${resultGroup}`;
+    setExpandedMetrics((prev) => ({
+      ...prev,
+      [key]: !prev[key],
+    }));
+  };
+
+  // Compute expanded metrics
+  const expandedGoals = expandMetricGroups(goalMetrics, metricGroupsFn);
+  const expandedSecondaries = expandMetricGroups(
+    secondaryMetrics,
+    metricGroupsFn,
+  );
+  const expandedGuardrails = expandMetricGroups(
+    guardrailMetrics,
+    metricGroupsFn,
+  );
+
+  // Track previous sliceTagsFilter to detect when it goes from non-empty to empty
+  const prevSliceTagsFilterRef = useRef<string[] | undefined>(sliceTagsFilter);
+
+  // Auto-expand all metrics when slice tags are selected, collapse when slice filters are cleared
+  useEffect(() => {
+    const allMetricIds = [
+      ...expandedGoals,
+      ...expandedSecondaries,
+      ...expandedGuardrails,
+    ];
+
+    const prevHadSliceFilters =
+      prevSliceTagsFilterRef.current &&
+      prevSliceTagsFilterRef.current.length > 0;
+    const currentHasSliceFilters =
+      sliceTagsFilter && sliceTagsFilter.length > 0;
+
+    if (currentHasSliceFilters) {
+      // Expand all metrics for all result groups when slice filter is active
+      const newExpandedMetrics: Record<string, boolean> = {};
+      allMetricIds.forEach((metricId) => {
+        ["goal", "secondary", "guardrail"].forEach((resultGroup) => {
+          const key = `${metricId}:${resultGroup}`;
+          newExpandedMetrics[key] = true;
+        });
+      });
+
+      setExpandedMetrics((prev) => ({
+        ...prev,
+        ...newExpandedMetrics,
+      }));
+    } else if (prevHadSliceFilters && !currentHasSliceFilters) {
+      // Collapse all metrics when slice filters go from non-empty to empty
+      const collapsedMetrics: Record<string, boolean> = {};
+      allMetricIds.forEach((metricId) => {
+        ["goal", "secondary", "guardrail"].forEach((resultGroup) => {
+          const key = `${metricId}:${resultGroup}`;
+          collapsedMetrics[key] = false;
+        });
+      });
+
+      setExpandedMetrics((prev) => ({
+        ...prev,
+        ...collapsedMetrics,
+      }));
+    }
+
+    // Update ref for next render
+    prevSliceTagsFilterRef.current = sliceTagsFilter;
+  }, [sliceTagsFilter, expandedGoals, expandedSecondaries, expandedGuardrails]);
+
+  const { tables, getChildRowCounts } = useExperimentDimensionRows({
     results,
     goalMetrics,
     secondaryMetrics,
@@ -177,6 +272,8 @@ const BreakDownResults: FC<{
     ssrPolyfills,
     metricTagFilter,
     metricsFilter,
+    sliceTagsFilter,
+    customMetricSlices,
     sortBy,
     sortDirection,
     customMetricOrder,
@@ -186,6 +283,8 @@ const BreakDownResults: FC<{
     settingsForSnapshotMetrics,
     dimensionValuesFilter,
     showErrorsOnQuantileMetrics,
+    shouldShowMetricSlices: true,
+    expandedMetrics,
   });
 
   const activationMetricObj = activationMetric
@@ -195,6 +294,9 @@ const BreakDownResults: FC<{
 
   const isBandit = experimentType === "multi-armed-bandit";
   const isHoldout = experimentType === "holdout";
+
+  // Filter slice rows based on expansion state when there's no slice filter
+  const hasSliceFilter = sliceTagsFilter && sliceTagsFilter.length > 0;
 
   // Wrap drilldown to include dimension info
   const handleRowClick = drilldownContext
@@ -244,6 +346,20 @@ const BreakDownResults: FC<{
       </div>
 
       {tables.map((table, i) => {
+        // Filter slice rows based on expansion state
+        const filteredSliceRows = hasSliceFilter
+          ? table.sliceRows
+          : table.sliceRows.filter((row) => {
+              if (row.parentRowId) {
+                const expandedKey = `${row.parentRowId}:${row.resultGroup}`;
+                return !!expandedMetrics?.[expandedKey];
+              }
+              return true;
+            });
+
+        // Combine dimension rows with slice rows for display
+        const allRows = [...filteredSliceRows, ...table.rows];
+
         return (
           <>
             <h4
@@ -273,20 +389,31 @@ const BreakDownResults: FC<{
               setVariationFilter={setVariationFilter}
               baselineRow={baselineRow}
               columnsFilter={columnsFilter}
-              rows={table.rows}
+              rows={allRows}
               onRowClick={handleRowClick}
               dimension={dimension}
               id={(idPrefix ? `${idPrefix}_` : "") + table.metric.id}
-              tableRowAxis="dimension" // todo: dynamic grouping?
+              tableRowAxis="dimension"
               labelHeader={
                 renderMetricName ? (
                   renderMetricName(table.metric)
                 ) : (
                   <div style={{ marginBottom: 2 }}>
-                    {getRenderLabelColumn({})({
+                    {getRenderLabelColumn({
+                      expandedMetrics,
+                      toggleExpandedMetric,
+                      getExperimentMetricById:
+                        ssrPolyfills?.getExperimentMetricById ||
+                        getExperimentMetricById,
+                      getFactTableById: getFactTableByIdFn,
+                      shouldShowMetricSlices: true,
+                      getChildRowCounts,
+                      sliceTagsFilter,
+                    })({
                       label: table.metric.name,
                       metric: table.metric,
-                      row: table.rows[0],
+                      row: { ...table.rows[0], numSlices: table.numSlices },
+                      location: table.rows[0]?.resultGroup,
                     })}
                   </div>
                 )
@@ -297,28 +424,41 @@ const BreakDownResults: FC<{
               pValueCorrection={pValueCorrection}
               differenceType={differenceType}
               setDifferenceType={setDifferenceType}
-              renderLabelColumn={({ label }) => (
-                <div
-                  className="pl-3 font-weight-bold"
-                  style={{
-                    display: "-webkit-box",
-                    WebkitLineClamp: 1,
-                    WebkitBoxOrient: "vertical",
-                    overflow: "hidden",
-                    color: "var(--color-text-mid)",
-                  }}
-                >
-                  {label ? (
-                    label === NULL_DIMENSION_VALUE ? (
-                      <em>{formatDimensionValueForDisplay(label)}</em>
+              renderLabelColumn={({ label, row }) => {
+                // For slice rows, use the slice row rendering
+                if (row?.isSliceRow) {
+                  return getRenderLabelColumn({})({
+                    label: label as string,
+                    metric: row.metric,
+                    row,
+                  });
+                }
+                // For dimension value rows, use the original dimension value rendering
+                return (
+                  <div
+                    className="pl-3 font-weight-bold"
+                    style={{
+                      display: "-webkit-box",
+                      WebkitLineClamp: 1,
+                      WebkitBoxOrient: "vertical",
+                      overflow: "hidden",
+                      color: "var(--color-text-mid)",
+                    }}
+                  >
+                    {label ? (
+                      label === NULL_DIMENSION_VALUE ? (
+                        <em>
+                          {formatDimensionValueForDisplay(label as string)}
+                        </em>
+                      ) : (
+                        label
+                      )
                     ) : (
-                      label
-                    )
-                  ) : (
-                    <em>unknown</em>
-                  )}
-                </div>
-              )}
+                      <em>unknown</em>
+                    )}
+                  </div>
+                );
+              }}
               isTabActive={true}
               isBandit={isBandit}
               ssrPolyfills={ssrPolyfills}

--- a/packages/front-end/components/Experiment/BreakDownResults.tsx
+++ b/packages/front-end/components/Experiment/BreakDownResults.tsx
@@ -1,4 +1,5 @@
-import { FC, useState, useEffect, useRef } from "react";
+import { FC, useState, ReactElement } from "react";
+import { IconButton } from "@radix-ui/themes";
 import {
   ExperimentReportResultDimension,
   ExperimentReportVariation,
@@ -24,10 +25,10 @@ import {
   ExperimentSortBy,
   SetExperimentSortBy,
   formatDimensionValueForDisplay,
-  expandMetricGroups,
 } from "shared/experiments";
 import { NULL_DIMENSION_VALUE } from "shared/constants";
 import { FaCaretRight } from "react-icons/fa";
+import { PiCaretCircleRight, PiCaretCircleDown } from "react-icons/pi";
 import Collapsible from "react-collapsible";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import { ExperimentTableRow } from "@/services/experiments";
@@ -41,6 +42,7 @@ import { useExperimentDimensionRows } from "@/hooks/useExperimentDimensionRows";
 import useOrgSettings from "@/hooks/useOrgSettings";
 import { useMetricDrilldownContext } from "@/components/MetricDrilldown/useMetricDrilldownContext";
 import Link from "@/ui/Link";
+import Tooltip from "@/components/Tooltip/Tooltip";
 import UsersTable from "./UsersTable";
 
 export const includeVariation = (
@@ -164,15 +166,7 @@ const BreakDownResults: FC<{
   mutate,
   setDifferenceType,
 }) => {
-  const {
-    getDimensionById,
-    getExperimentMetricById,
-    getFactTableById,
-    metricGroups: _metricGroups,
-  } = useDefinitions();
-
-  const getFactTableByIdFn = ssrPolyfills?.getFactTableById || getFactTableById;
-  const metricGroupsFn = ssrPolyfills?.metricGroups || _metricGroups;
+  const { getDimensionById, getExperimentMetricById } = useDefinitions();
 
   const _settings = useOrgSettings();
   const settings = ssrPolyfills?.useOrgSettings?.() || _settings;
@@ -186,84 +180,23 @@ const BreakDownResults: FC<{
     dimensionId?.split(":")?.[1] ||
     "Dimension";
 
-  // Expanded state for metric slices
-  const [expandedMetrics, setExpandedMetrics] = useState<
+  // Expanded state for dimension value rows (to show slices underneath)
+  const [expandedDimensionRows, setExpandedDimensionRows] = useState<
     Record<string, boolean>
   >({});
-  const toggleExpandedMetric = (
+  const toggleExpandedDimensionRow = (
     metricId: string,
+    dimensionValue: string,
     resultGroup: "goal" | "secondary" | "guardrail",
   ) => {
-    const key = `${metricId}:${resultGroup}`;
-    setExpandedMetrics((prev) => ({
+    const key = `${metricId}:${dimensionValue}:${resultGroup}`;
+    setExpandedDimensionRows((prev) => ({
       ...prev,
       [key]: !prev[key],
     }));
   };
 
-  // Compute expanded metrics
-  const expandedGoals = expandMetricGroups(goalMetrics, metricGroupsFn);
-  const expandedSecondaries = expandMetricGroups(
-    secondaryMetrics,
-    metricGroupsFn,
-  );
-  const expandedGuardrails = expandMetricGroups(
-    guardrailMetrics,
-    metricGroupsFn,
-  );
-
-  // Track previous sliceTagsFilter to detect when it goes from non-empty to empty
-  const prevSliceTagsFilterRef = useRef<string[] | undefined>(sliceTagsFilter);
-
-  // Auto-expand all metrics when slice tags are selected, collapse when slice filters are cleared
-  useEffect(() => {
-    const allMetricIds = [
-      ...expandedGoals,
-      ...expandedSecondaries,
-      ...expandedGuardrails,
-    ];
-
-    const prevHadSliceFilters =
-      prevSliceTagsFilterRef.current &&
-      prevSliceTagsFilterRef.current.length > 0;
-    const currentHasSliceFilters =
-      sliceTagsFilter && sliceTagsFilter.length > 0;
-
-    if (currentHasSliceFilters) {
-      // Expand all metrics for all result groups when slice filter is active
-      const newExpandedMetrics: Record<string, boolean> = {};
-      allMetricIds.forEach((metricId) => {
-        ["goal", "secondary", "guardrail"].forEach((resultGroup) => {
-          const key = `${metricId}:${resultGroup}`;
-          newExpandedMetrics[key] = true;
-        });
-      });
-
-      setExpandedMetrics((prev) => ({
-        ...prev,
-        ...newExpandedMetrics,
-      }));
-    } else if (prevHadSliceFilters && !currentHasSliceFilters) {
-      // Collapse all metrics when slice filters go from non-empty to empty
-      const collapsedMetrics: Record<string, boolean> = {};
-      allMetricIds.forEach((metricId) => {
-        ["goal", "secondary", "guardrail"].forEach((resultGroup) => {
-          const key = `${metricId}:${resultGroup}`;
-          collapsedMetrics[key] = false;
-        });
-      });
-
-      setExpandedMetrics((prev) => ({
-        ...prev,
-        ...collapsedMetrics,
-      }));
-    }
-
-    // Update ref for next render
-    prevSliceTagsFilterRef.current = sliceTagsFilter;
-  }, [sliceTagsFilter, expandedGoals, expandedSecondaries, expandedGuardrails]);
-
-  const { tables, getChildRowCounts } = useExperimentDimensionRows({
+  const { tables, getSliceCountForDimensionRow } = useExperimentDimensionRows({
     results,
     goalMetrics,
     secondaryMetrics,
@@ -284,7 +217,7 @@ const BreakDownResults: FC<{
     dimensionValuesFilter,
     showErrorsOnQuantileMetrics,
     shouldShowMetricSlices: true,
-    expandedMetrics,
+    expandedDimensionRows,
   });
 
   const activationMetricObj = activationMetric
@@ -346,19 +279,8 @@ const BreakDownResults: FC<{
       </div>
 
       {tables.map((table, i) => {
-        // Filter slice rows based on expansion state
-        const filteredSliceRows = hasSliceFilter
-          ? table.sliceRows
-          : table.sliceRows.filter((row) => {
-              if (row.parentRowId) {
-                const expandedKey = `${row.parentRowId}:${row.resultGroup}`;
-                return !!expandedMetrics?.[expandedKey];
-              }
-              return true;
-            });
-
-        // Combine dimension rows with slice rows for display
-        const allRows = [...filteredSliceRows, ...table.rows];
+        // Filter out hidden slice rows
+        const visibleRows = table.rows.filter((row) => !row.isHiddenByFilter);
 
         return (
           <>
@@ -389,7 +311,7 @@ const BreakDownResults: FC<{
               setVariationFilter={setVariationFilter}
               baselineRow={baselineRow}
               columnsFilter={columnsFilter}
-              rows={allRows}
+              rows={visibleRows}
               onRowClick={handleRowClick}
               dimension={dimension}
               id={(idPrefix ? `${idPrefix}_` : "") + table.metric.id}
@@ -399,21 +321,10 @@ const BreakDownResults: FC<{
                   renderMetricName(table.metric)
                 ) : (
                   <div style={{ marginBottom: 2 }}>
-                    {getRenderLabelColumn({
-                      expandedMetrics,
-                      toggleExpandedMetric,
-                      getExperimentMetricById:
-                        ssrPolyfills?.getExperimentMetricById ||
-                        getExperimentMetricById,
-                      getFactTableById: getFactTableByIdFn,
-                      shouldShowMetricSlices: true,
-                      getChildRowCounts,
-                      sliceTagsFilter,
-                    })({
+                    {getRenderLabelColumn({})({
                       label: table.metric.name,
                       metric: table.metric,
-                      row: { ...table.rows[0], numSlices: table.numSlices },
-                      location: table.rows[0]?.resultGroup,
+                      row: table.rows[0],
                     })}
                   </div>
                 )
@@ -424,41 +335,13 @@ const BreakDownResults: FC<{
               pValueCorrection={pValueCorrection}
               differenceType={differenceType}
               setDifferenceType={setDifferenceType}
-              renderLabelColumn={({ label, row }) => {
-                // For slice rows, use the slice row rendering
-                if (row?.isSliceRow) {
-                  return getRenderLabelColumn({})({
-                    label: label as string,
-                    metric: row.metric,
-                    row,
-                  });
-                }
-                // For dimension value rows, use the original dimension value rendering
-                return (
-                  <div
-                    className="pl-3 font-weight-bold"
-                    style={{
-                      display: "-webkit-box",
-                      WebkitLineClamp: 1,
-                      WebkitBoxOrient: "vertical",
-                      overflow: "hidden",
-                      color: "var(--color-text-mid)",
-                    }}
-                  >
-                    {label ? (
-                      label === NULL_DIMENSION_VALUE ? (
-                        <em>
-                          {formatDimensionValueForDisplay(label as string)}
-                        </em>
-                      ) : (
-                        label
-                      )
-                    ) : (
-                      <em>unknown</em>
-                    )}
-                  </div>
-                );
-              }}
+              renderLabelColumn={renderDimensionLabelColumn({
+                hasSliceFilter: hasSliceFilter ?? false,
+                sliceTagsFilter,
+                expandedDimensionRows,
+                toggleExpandedDimensionRow,
+                getSliceCountForDimensionRow,
+              })}
               isTabActive={true}
               isBandit={isBandit}
               ssrPolyfills={ssrPolyfills}
@@ -482,3 +365,108 @@ const BreakDownResults: FC<{
   );
 };
 export default BreakDownResults;
+
+// Helper function to render dimension value labels with expand/collapse for slices
+function renderDimensionLabelColumn({
+  hasSliceFilter,
+  sliceTagsFilter: _sliceTagsFilter,
+  expandedDimensionRows,
+  toggleExpandedDimensionRow,
+  getSliceCountForDimensionRow: _getSliceCountForDimensionRow,
+}: {
+  hasSliceFilter: boolean;
+  sliceTagsFilter?: string[];
+  expandedDimensionRows: Record<string, boolean>;
+  toggleExpandedDimensionRow: (
+    metricId: string,
+    dimensionValue: string,
+    resultGroup: "goal" | "secondary" | "guardrail",
+  ) => void;
+  getSliceCountForDimensionRow: (
+    metricId: string,
+    dimensionValue: string,
+  ) => number;
+}) {
+  return function renderLabelColumn({
+    label,
+    row,
+  }: {
+    label: string | ReactElement;
+    row?: ExperimentTableRow;
+  }) {
+    // For slice rows, use the slice row rendering from getRenderLabelColumn
+    if (row?.isSliceRow) {
+      return getRenderLabelColumn({})({
+        label: label as string,
+        metric: row.metric,
+        row,
+      });
+    }
+
+    // For dimension value rows, show expand/collapse if there are slices
+    const dimensionValue = row?.dimensionValue || (label as string);
+    const metricId = row?.metric?.id || "";
+    const resultGroup = row?.resultGroup || "goal";
+    const expandedKey = `${metricId}:${dimensionValue}:${resultGroup}`;
+    const isExpanded = !!expandedDimensionRows?.[expandedKey];
+
+    const numSlices = row?.numSlices || 0;
+    const hasSlices = numSlices > 0;
+    const shouldShowExpandButton =
+      hasSlices && !row?.labelOnly && !hasSliceFilter;
+
+    return (
+      <div className="pl-3" style={{ position: "relative" }}>
+        {shouldShowExpandButton && (
+          <div style={{ position: "absolute", left: 7, marginTop: 3 }}>
+            <Tooltip
+              body={
+                isExpanded ? "Collapse metric slices" : "Expand metric slices"
+              }
+              tipPosition="top"
+            >
+              <IconButton
+                size="1"
+                variant="ghost"
+                radius="full"
+                onClick={() =>
+                  toggleExpandedDimensionRow(
+                    metricId,
+                    dimensionValue,
+                    resultGroup,
+                  )
+                }
+              >
+                {isExpanded ? (
+                  <PiCaretCircleDown size={16} />
+                ) : (
+                  <PiCaretCircleRight size={16} />
+                )}
+              </IconButton>
+            </Tooltip>
+          </div>
+        )}
+        <span
+          className="ml-2 font-weight-bold"
+          style={{
+            display: "-webkit-box",
+            WebkitLineClamp: 1,
+            WebkitBoxOrient: "vertical",
+            overflow: "hidden",
+            color: "var(--color-text-mid)",
+          }}
+        >
+          {label ? (
+            label === NULL_DIMENSION_VALUE ? (
+              <em>{formatDimensionValueForDisplay(label as string)}</em>
+            ) : (
+              label
+            )
+          ) : (
+            <em>unknown</em>
+          )}
+        </span>
+      </div>
+    );
+  };
+}

--- a/packages/front-end/components/Experiment/Results.tsx
+++ b/packages/front-end/components/Experiment/Results.tsx
@@ -421,6 +421,8 @@ const Results: FC<{
               }
               metricTagFilter={metricTagFilter}
               metricsFilter={metricsFilter}
+              sliceTagsFilter={sliceTagsFilter}
+              customMetricSlices={experiment.customMetricSlices}
               experimentType={experiment.type}
               sortBy={sortBy}
               setSortBy={setSortBy}

--- a/packages/front-end/components/Experiment/ResultsFilter/ResultsFilter.tsx
+++ b/packages/front-end/components/Experiment/ResultsFilter/ResultsFilter.tsx
@@ -18,8 +18,6 @@ import { Popover } from "@/ui/Popover";
 import Button from "@/ui/Button";
 import Badge from "@/ui/Badge";
 import Link from "@/ui/Link";
-import Tooltip from "@/components/Tooltip/Tooltip";
-import HelperText from "@/ui/HelperText";
 import { useUser } from "@/services/UserContext";
 import MetricName from "@/components/Metrics/MetricName";
 import { useDefinitions } from "@/services/DefinitionsContext";
@@ -328,7 +326,7 @@ export default function ResultsFilter({
   setSliceTagsFilter,
   showMetricFilter,
   setShowMetricFilter,
-  dimension,
+  dimension: _dimension,
 }: {
   availableMetricTags?: string[];
   metricTagFilter?: string[];
@@ -476,13 +474,7 @@ export default function ResultsFilter({
                 >
                   <Box style={{ width: 80 }}>
                     <Heading size="2" weight="medium" mb="0">
-                      {dimension && (sliceTagsFilter?.length || 0) > 0 ? (
-                        <Tooltip body="Slice filters are ignored when a unit dimension is set">
-                          <HelperText status="warning">Slices</HelperText>
-                        </Tooltip>
-                      ) : (
-                        "Slices"
-                      )}
+                      Slices
                     </Heading>
                   </Box>
                   <MultiSelectField

--- a/packages/front-end/hooks/useExperimentDimensionRows.ts
+++ b/packages/front-end/hooks/useExperimentDimensionRows.ts
@@ -6,6 +6,10 @@ import {
 import { MetricOverride } from "shared/types/experiment";
 import { PValueCorrection, StatsEngine } from "shared/types/stats";
 import {
+  FactMetricInterface,
+  FactTableInterface,
+} from "shared/types/fact-table";
+import {
   expandMetricGroups,
   ExperimentMetricInterface,
   ExperimentSortBy,
@@ -13,6 +17,13 @@ import {
   setAdjustedCIs,
   setAdjustedPValuesOnResults,
   isMetricGroupId,
+  createAutoSliceDataForMetric,
+  createCustomSliceDataForMetric,
+  dedupeSliceMetrics,
+  SliceDataForMetric,
+  isFactMetric,
+  generateSliceString,
+  generateSelectAllSliceString,
 } from "shared/experiments";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import {
@@ -39,6 +50,13 @@ export interface UseExperimentDimensionRowsParams {
   ssrPolyfills?: SSRPolyfills;
   metricTagFilter?: string[];
   metricsFilter?: string[];
+  sliceTagsFilter?: string[];
+  customMetricSlices?: Array<{
+    slices: Array<{
+      column: string;
+      levels: string[];
+    }>;
+  }>;
   sortBy?: ExperimentSortBy;
   sortDirection?: "asc" | "desc" | null;
   customMetricOrder?: string[];
@@ -50,6 +68,8 @@ export interface UseExperimentDimensionRowsParams {
   settingsForSnapshotMetrics?: MetricSnapshotSettings[];
   dimensionValuesFilter?: string[];
   showErrorsOnQuantileMetrics?: boolean;
+  shouldShowMetricSlices?: boolean;
+  expandedMetrics?: Record<string, boolean>;
 }
 
 export interface UseExperimentDimensionRowsReturn {
@@ -57,7 +77,10 @@ export interface UseExperimentDimensionRowsReturn {
     metric: ExperimentMetricInterface;
     isGuardrail: boolean;
     rows: ExperimentTableRow[];
+    sliceRows: ExperimentTableRow[];
+    numSlices: number;
   }>;
+  getChildRowCounts: (metricId: string) => number;
 }
 
 export function useExperimentDimensionRows({
@@ -69,6 +92,8 @@ export function useExperimentDimensionRows({
   ssrPolyfills,
   metricTagFilter,
   metricsFilter,
+  sliceTagsFilter,
+  customMetricSlices,
   sortBy,
   sortDirection,
   customMetricOrder,
@@ -78,8 +103,16 @@ export function useExperimentDimensionRows({
   settingsForSnapshotMetrics,
   dimensionValuesFilter,
   showErrorsOnQuantileMetrics = false,
+  shouldShowMetricSlices = false,
+  expandedMetrics,
 }: UseExperimentDimensionRowsParams): UseExperimentDimensionRowsReturn {
-  const { getExperimentMetricById, metricGroups, ready } = useDefinitions();
+  const {
+    getExperimentMetricById,
+    getFactTableById: _getFactTableById,
+    metricGroups,
+    ready,
+  } = useDefinitions();
+  const getFactTableById = ssrPolyfills?.getFactTableById || _getFactTableById;
   const { metricDefaults } = useOrganizationMetricDefaults();
 
   const _pValueThreshold = usePValueThreshold();
@@ -365,16 +398,150 @@ export function useExperimentDimensionRows({
             newMetric,
           });
 
+          // Generate slice rows if enabled
+          const sliceRows: ExperimentTableRow[] = [];
+          let numSlices = 0;
+
+          if (shouldShowMetricSlices && isFactMetric(metric)) {
+            const sliceData = generateSliceDataForMetric({
+              metricId,
+              metric,
+              newMetric,
+              customMetricSlices,
+              getExperimentMetricById:
+                ssrPolyfills?.getExperimentMetricById ||
+                getExperimentMetricById,
+              getFactTableById,
+            });
+
+            numSlices = sliceData.length;
+
+            sliceData.forEach((slice) => {
+              // Check if slice matches filter
+              let sliceMatches = true;
+
+              if (sliceTagsFilter && sliceTagsFilter.length > 0) {
+                const hasSelectAllFilter = slice.sliceLevels.some(
+                  (sliceLevel) => {
+                    const selectAllTag = generateSelectAllSliceString(
+                      sliceLevel.column,
+                    );
+                    return sliceTagsFilter.includes(selectAllTag);
+                  },
+                );
+
+                if (hasSelectAllFilter) {
+                  sliceMatches = true;
+                } else {
+                  const sliceTags: string[] = [];
+                  slice.sliceLevels.forEach((sliceLevel) => {
+                    const value = sliceLevel.levels[0] || "";
+                    const tag = generateSliceString({
+                      [sliceLevel.column]: value,
+                    });
+                    sliceTags.push(tag);
+                  });
+                  if (slice.sliceLevels.length > 1) {
+                    const slices: Record<string, string> = {};
+                    slice.sliceLevels.forEach((sl) => {
+                      slices[sl.column] = sl.levels[0] || "";
+                    });
+                    const comboTag = generateSliceString(slices);
+                    sliceTags.push(comboTag);
+                  }
+                  sliceMatches = sliceTags.some((tag) =>
+                    sliceTagsFilter.includes(tag),
+                  );
+                }
+              }
+
+              // Check expansion state
+              const expandedKey = `${metricId}:${resultGroup}`;
+              const hasFilter = sliceTagsFilter && sliceTagsFilter.length > 0;
+              const isExpanded = hasFilter
+                ? true
+                : !!expandedMetrics?.[expandedKey];
+
+              const shouldShowLevel = hasFilter
+                ? isExpanded && sliceMatches
+                : isExpanded;
+
+              const label = slice.sliceLevels
+                .map((dl) => {
+                  if (dl.levels.length === 0) {
+                    const emptyValue =
+                      dl.datatype === "string" ? "other" : "null";
+                    return `${dl.column}: ${emptyValue}`;
+                  }
+                  const value = dl.levels[0];
+                  if (dl.datatype === "boolean") {
+                    return `${dl.column}: ${value}`;
+                  }
+                  return value;
+                })
+                .join(" + ");
+
+              // Get slice data from the first result (overall)
+              const sliceRow: ExperimentTableRow = {
+                label,
+                metric: {
+                  ...newMetric,
+                  name: slice.name,
+                },
+                metricOverrideFields: overrideFields,
+                rowClass: `${newMetric?.inverse ? "inverse" : ""} slice-row`,
+                sliceId: slice.id,
+                variations:
+                  results[0]?.variations.map((v) => {
+                    return (
+                      v.metrics?.[slice.id] || {
+                        users: 0,
+                        value: 0,
+                        cr: 0,
+                        errorMessage: "No data",
+                      }
+                    );
+                  }) || [],
+                metricSnapshotSettings: _metricSnapshotSettings,
+                resultGroup,
+                numSlices: 0,
+                isSliceRow: true,
+                parentRowId: metricId,
+                sliceLevels: slice.sliceLevels.map((dl) => ({
+                  column: dl.column,
+                  datatype: dl.datatype,
+                  levels: dl.levels,
+                })),
+                allSliceLevels: slice.allSliceLevels,
+                isHiddenByFilter: hasFilter ? !shouldShowLevel : false,
+              };
+
+              // Skip "other" slice rows with no data
+              if (
+                slice.sliceLevels.every((dl) => dl.levels.length === 0) &&
+                sliceRow.variations.every((v) => v.value === 0)
+              ) {
+                return;
+              }
+
+              sliceRows.push(sliceRow);
+            });
+          }
+
           return {
             metric: newMetric,
             isGuardrail: resultGroup === "guardrail",
             rows,
+            sliceRows,
+            numSlices,
           };
         })
         .filter((table) => table?.metric) as Array<{
         metric: ExperimentMetricInterface;
         isGuardrail: boolean;
         rows: ExperimentTableRow[];
+        sliceRows: ExperimentTableRow[];
+        numSlices: number;
       }>;
     }
 
@@ -406,6 +573,8 @@ export function useExperimentDimensionRows({
     metricOverrides,
     ssrPolyfills,
     metricTagFilter,
+    sliceTagsFilter,
+    customMetricSlices,
     sortBy,
     sortDirection,
     customMetricOrder,
@@ -415,6 +584,7 @@ export function useExperimentDimensionRows({
     settingsForSnapshotMetrics,
     dimensionValuesFilter,
     getExperimentMetricById,
+    getFactTableById,
     ready,
     metricDefaults,
     pValueThreshold,
@@ -422,10 +592,19 @@ export function useExperimentDimensionRows({
     expandedSecondaries,
     expandedGuardrails,
     showErrorsOnQuantileMetrics,
+    shouldShowMetricSlices,
+    expandedMetrics,
   ]);
+
+  const getChildRowCounts = (metricId: string) => {
+    const table = tables.find((t) => t.metric.id === metricId);
+    if (!table) return 0;
+    return table.sliceRows.filter((row) => !row.isHiddenByFilter).length;
+  };
 
   return {
     tables,
+    getChildRowCounts,
   };
 }
 
@@ -500,4 +679,46 @@ export function generateDimensionRowsForMetric({
   });
 
   return rows;
+}
+
+// Helper function to generate slice data for a metric
+function generateSliceDataForMetric({
+  metricId,
+  metric,
+  newMetric,
+  customMetricSlices,
+  getExperimentMetricById,
+  getFactTableById,
+}: {
+  metricId: string;
+  metric: ExperimentMetricInterface;
+  newMetric: ExperimentMetricInterface;
+  customMetricSlices?: Array<{
+    slices: Array<{
+      column: string;
+      levels: string[];
+    }>;
+  }>;
+  getExperimentMetricById: (id: string) => ExperimentMetricInterface | null;
+  getFactTableById: (id: string) => FactTableInterface | null;
+}): SliceDataForMetric[] {
+  const standardSliceData = createAutoSliceDataForMetric({
+    parentMetric: getExperimentMetricById(metricId),
+    factTable: getFactTableById(
+      (getExperimentMetricById(metricId) as FactMetricInterface)?.numerator
+        ?.factTableId || "",
+    ),
+    includeOther: true,
+  });
+
+  const customSliceData = createCustomSliceDataForMetric({
+    metricId,
+    metricName: newMetric?.name || "",
+    customMetricSlices: customMetricSlices || [],
+    factTable: getFactTableById(
+      (metric as FactMetricInterface)?.numerator?.factTableId || "",
+    ),
+  });
+
+  return dedupeSliceMetrics([...standardSliceData, ...customSliceData]);
 }

--- a/packages/front-end/hooks/useExperimentDimensionRows.ts
+++ b/packages/front-end/hooks/useExperimentDimensionRows.ts
@@ -69,7 +69,7 @@ export interface UseExperimentDimensionRowsParams {
   dimensionValuesFilter?: string[];
   showErrorsOnQuantileMetrics?: boolean;
   shouldShowMetricSlices?: boolean;
-  expandedMetrics?: Record<string, boolean>;
+  expandedDimensionRows?: Record<string, boolean>;
 }
 
 export interface UseExperimentDimensionRowsReturn {
@@ -77,10 +77,11 @@ export interface UseExperimentDimensionRowsReturn {
     metric: ExperimentMetricInterface;
     isGuardrail: boolean;
     rows: ExperimentTableRow[];
-    sliceRows: ExperimentTableRow[];
-    numSlices: number;
   }>;
-  getChildRowCounts: (metricId: string) => number;
+  getSliceCountForDimensionRow: (
+    metricId: string,
+    dimensionValue: string,
+  ) => number;
 }
 
 export function useExperimentDimensionRows({
@@ -104,7 +105,7 @@ export function useExperimentDimensionRows({
   dimensionValuesFilter,
   showErrorsOnQuantileMetrics = false,
   shouldShowMetricSlices = false,
-  expandedMetrics,
+  expandedDimensionRows,
 }: UseExperimentDimensionRowsParams): UseExperimentDimensionRowsReturn {
   const {
     getExperimentMetricById,
@@ -388,22 +389,10 @@ export function useExperimentDimensionRows({
             };
           }
 
-          const rows = generateDimensionRowsForMetric({
-            metricId,
-            resultGroup,
-            results,
-            dimensionValuesFilter,
-            overrideFields,
-            metricSnapshotSettings: _metricSnapshotSettings,
-            newMetric,
-          });
-
-          // Generate slice rows if enabled
-          const sliceRows: ExperimentTableRow[] = [];
-          let numSlices = 0;
-
+          // Generate slice data for the metric (if applicable)
+          let sliceData: SliceDataForMetric[] = [];
           if (shouldShowMetricSlices && isFactMetric(metric)) {
-            const sliceData = generateSliceDataForMetric({
+            sliceData = generateSliceDataForMetric({
               metricId,
               metric,
               newMetric,
@@ -413,135 +402,31 @@ export function useExperimentDimensionRows({
                 getExperimentMetricById,
               getFactTableById,
             });
-
-            numSlices = sliceData.length;
-
-            sliceData.forEach((slice) => {
-              // Check if slice matches filter
-              let sliceMatches = true;
-
-              if (sliceTagsFilter && sliceTagsFilter.length > 0) {
-                const hasSelectAllFilter = slice.sliceLevels.some(
-                  (sliceLevel) => {
-                    const selectAllTag = generateSelectAllSliceString(
-                      sliceLevel.column,
-                    );
-                    return sliceTagsFilter.includes(selectAllTag);
-                  },
-                );
-
-                if (hasSelectAllFilter) {
-                  sliceMatches = true;
-                } else {
-                  const sliceTags: string[] = [];
-                  slice.sliceLevels.forEach((sliceLevel) => {
-                    const value = sliceLevel.levels[0] || "";
-                    const tag = generateSliceString({
-                      [sliceLevel.column]: value,
-                    });
-                    sliceTags.push(tag);
-                  });
-                  if (slice.sliceLevels.length > 1) {
-                    const slices: Record<string, string> = {};
-                    slice.sliceLevels.forEach((sl) => {
-                      slices[sl.column] = sl.levels[0] || "";
-                    });
-                    const comboTag = generateSliceString(slices);
-                    sliceTags.push(comboTag);
-                  }
-                  sliceMatches = sliceTags.some((tag) =>
-                    sliceTagsFilter.includes(tag),
-                  );
-                }
-              }
-
-              // Check expansion state
-              const expandedKey = `${metricId}:${resultGroup}`;
-              const hasFilter = sliceTagsFilter && sliceTagsFilter.length > 0;
-              const isExpanded = hasFilter
-                ? true
-                : !!expandedMetrics?.[expandedKey];
-
-              const shouldShowLevel = hasFilter
-                ? isExpanded && sliceMatches
-                : isExpanded;
-
-              const label = slice.sliceLevels
-                .map((dl) => {
-                  if (dl.levels.length === 0) {
-                    const emptyValue =
-                      dl.datatype === "string" ? "other" : "null";
-                    return `${dl.column}: ${emptyValue}`;
-                  }
-                  const value = dl.levels[0];
-                  if (dl.datatype === "boolean") {
-                    return `${dl.column}: ${value}`;
-                  }
-                  return value;
-                })
-                .join(" + ");
-
-              // Get slice data from the first result (overall)
-              const sliceRow: ExperimentTableRow = {
-                label,
-                metric: {
-                  ...newMetric,
-                  name: slice.name,
-                },
-                metricOverrideFields: overrideFields,
-                rowClass: `${newMetric?.inverse ? "inverse" : ""} slice-row`,
-                sliceId: slice.id,
-                variations:
-                  results[0]?.variations.map((v) => {
-                    return (
-                      v.metrics?.[slice.id] || {
-                        users: 0,
-                        value: 0,
-                        cr: 0,
-                        errorMessage: "No data",
-                      }
-                    );
-                  }) || [],
-                metricSnapshotSettings: _metricSnapshotSettings,
-                resultGroup,
-                numSlices: 0,
-                isSliceRow: true,
-                parentRowId: metricId,
-                sliceLevels: slice.sliceLevels.map((dl) => ({
-                  column: dl.column,
-                  datatype: dl.datatype,
-                  levels: dl.levels,
-                })),
-                allSliceLevels: slice.allSliceLevels,
-                isHiddenByFilter: hasFilter ? !shouldShowLevel : false,
-              };
-
-              // Skip "other" slice rows with no data
-              if (
-                slice.sliceLevels.every((dl) => dl.levels.length === 0) &&
-                sliceRow.variations.every((v) => v.value === 0)
-              ) {
-                return;
-              }
-
-              sliceRows.push(sliceRow);
-            });
           }
+
+          const rows = generateDimensionRowsWithSlices({
+            metricId,
+            resultGroup,
+            results,
+            dimensionValuesFilter,
+            overrideFields,
+            metricSnapshotSettings: _metricSnapshotSettings,
+            newMetric,
+            sliceData,
+            sliceTagsFilter,
+            expandedDimensionRows,
+          });
 
           return {
             metric: newMetric,
             isGuardrail: resultGroup === "guardrail",
             rows,
-            sliceRows,
-            numSlices,
           };
         })
         .filter((table) => table?.metric) as Array<{
         metric: ExperimentMetricInterface;
         isGuardrail: boolean;
         rows: ExperimentTableRow[];
-        sliceRows: ExperimentTableRow[];
-        numSlices: number;
       }>;
     }
 
@@ -593,18 +478,27 @@ export function useExperimentDimensionRows({
     expandedGuardrails,
     showErrorsOnQuantileMetrics,
     shouldShowMetricSlices,
-    expandedMetrics,
+    expandedDimensionRows,
   ]);
 
-  const getChildRowCounts = (metricId: string) => {
+  const getSliceCountForDimensionRow = (
+    metricId: string,
+    dimensionValue: string,
+  ) => {
     const table = tables.find((t) => t.metric.id === metricId);
     if (!table) return 0;
-    return table.sliceRows.filter((row) => !row.isHiddenByFilter).length;
+    // Count the slice rows that are children of this dimension row
+    return table.rows.filter(
+      (row) =>
+        row.isSliceRow &&
+        row.parentRowId === `${metricId}:${dimensionValue}` &&
+        !row.isHiddenByFilter,
+    ).length;
   };
 
   return {
     tables,
-    getChildRowCounts,
+    getSliceCountForDimensionRow,
   };
 }
 
@@ -633,7 +527,8 @@ function includeVariation(
 }
 
 // Specialized row generation for dimension mode - creates one row per dimension result
-export function generateDimensionRowsForMetric({
+// with slice rows underneath when expanded
+function generateDimensionRowsWithSlices({
   metricId,
   resultGroup,
   results,
@@ -641,6 +536,9 @@ export function generateDimensionRowsForMetric({
   overrideFields,
   metricSnapshotSettings,
   newMetric,
+  sliceData,
+  sliceTagsFilter,
+  expandedDimensionRows,
 }: {
   metricId: string;
   resultGroup: "goal" | "secondary" | "guardrail";
@@ -649,33 +547,160 @@ export function generateDimensionRowsForMetric({
   overrideFields: string[];
   metricSnapshotSettings: MetricSnapshotSettings | undefined;
   newMetric: ExperimentMetricInterface;
+  sliceData: SliceDataForMetric[];
+  sliceTagsFilter?: string[];
+  expandedDimensionRows?: Record<string, boolean>;
 }): ExperimentTableRow[] {
   const filteredResults = includeVariation(results, dimensionValuesFilter);
 
   const rows: ExperimentTableRow[] = [];
+  const numSlices = sliceData.length;
+  const hasFilter = sliceTagsFilter && sliceTagsFilter.length > 0;
 
   // Create a row for each dimension result
   filteredResults.forEach((dimensionResult) => {
-    const row: ExperimentTableRow = {
-      label: dimensionResult.name,
+    const dimensionValue = dimensionResult.name;
+    const expandedKey = `${metricId}:${dimensionValue}:${resultGroup}`;
+    const isExpanded = hasFilter
+      ? true
+      : !!expandedDimensionRows?.[expandedKey];
+
+    // Determine if this dimension row should show as label-only when filter is active
+    const isLabelOnly =
+      hasFilter && numSlices > 0 && !sliceTagsFilter.includes("overall");
+
+    const dimensionRow: ExperimentTableRow = {
+      label: dimensionValue,
       metric: newMetric,
       metricOverrideFields: overrideFields,
       rowClass: newMetric?.inverse ? "inverse" : "",
-      variations: dimensionResult.variations.map((v) => {
-        return (
-          v.metrics?.[metricId] || {
+      variations: isLabelOnly
+        ? dimensionResult.variations.map(() => ({
             users: 0,
             value: 0,
             cr: 0,
             errorMessage: "No data",
-          }
-        );
-      }),
+          }))
+        : dimensionResult.variations.map((v) => {
+            return (
+              v.metrics?.[metricId] || {
+                users: 0,
+                value: 0,
+                cr: 0,
+                errorMessage: "No data",
+              }
+            );
+          }),
       metricSnapshotSettings,
       resultGroup,
+      numSlices,
+      labelOnly: isLabelOnly,
+      dimensionValue,
     };
 
-    rows.push(row);
+    rows.push(dimensionRow);
+
+    // Generate slice rows for this dimension value if expanded
+    if (numSlices > 0) {
+      sliceData.forEach((slice) => {
+        // Check if slice matches filter
+        let sliceMatches = true;
+
+        if (hasFilter) {
+          const hasSelectAllFilter = slice.sliceLevels.some((sliceLevel) => {
+            const selectAllTag = generateSelectAllSliceString(
+              sliceLevel.column,
+            );
+            return sliceTagsFilter.includes(selectAllTag);
+          });
+
+          if (hasSelectAllFilter) {
+            sliceMatches = true;
+          } else {
+            const sliceTags: string[] = [];
+            slice.sliceLevels.forEach((sliceLevel) => {
+              const value = sliceLevel.levels[0] || "";
+              const tag = generateSliceString({ [sliceLevel.column]: value });
+              sliceTags.push(tag);
+            });
+            if (slice.sliceLevels.length > 1) {
+              const slices: Record<string, string> = {};
+              slice.sliceLevels.forEach((sl) => {
+                slices[sl.column] = sl.levels[0] || "";
+              });
+              const comboTag = generateSliceString(slices);
+              sliceTags.push(comboTag);
+            }
+            sliceMatches = sliceTags.some((tag) =>
+              sliceTagsFilter.includes(tag),
+            );
+          }
+        }
+
+        const shouldShowLevel = hasFilter
+          ? isExpanded && sliceMatches
+          : isExpanded;
+
+        const label = slice.sliceLevels
+          .map((dl) => {
+            if (dl.levels.length === 0) {
+              const emptyValue = dl.datatype === "string" ? "other" : "null";
+              return `${dl.column}: ${emptyValue}`;
+            }
+            const value = dl.levels[0];
+            if (dl.datatype === "boolean") {
+              return `${dl.column}: ${value}`;
+            }
+            return value;
+          })
+          .join(" + ");
+
+        // Get slice data from this specific dimension result
+        const sliceRow: ExperimentTableRow = {
+          label,
+          metric: {
+            ...newMetric,
+            name: slice.name,
+          },
+          metricOverrideFields: overrideFields,
+          rowClass: `${newMetric?.inverse ? "inverse" : ""} slice-row`,
+          sliceId: slice.id,
+          variations: dimensionResult.variations.map((v) => {
+            return (
+              v.metrics?.[slice.id] || {
+                users: 0,
+                value: 0,
+                cr: 0,
+                errorMessage: "No data",
+              }
+            );
+          }),
+          metricSnapshotSettings,
+          resultGroup,
+          numSlices: 0,
+          isSliceRow: true,
+          parentRowId: `${metricId}:${dimensionValue}`,
+          sliceLevels: slice.sliceLevels.map((dl) => ({
+            column: dl.column,
+            datatype: dl.datatype,
+            levels: dl.levels,
+          })),
+          allSliceLevels: slice.allSliceLevels,
+          isHiddenByFilter: hasFilter ? !shouldShowLevel : !isExpanded,
+          dimensionValue,
+        };
+
+        // Skip "other" slice rows with no data
+        if (
+          slice.sliceLevels.every((dl) => dl.levels.length === 0) &&
+          sliceRow.variations.every((v) => v.value === 0)
+        ) {
+          return;
+        }
+
+        rows.push(sliceRow);
+      });
+    }
   });
 
   return rows;

--- a/packages/front-end/services/experiments.ts
+++ b/packages/front-end/services/experiments.ts
@@ -185,6 +185,8 @@ export type ExperimentTableRow = {
   allSliceLevels?: string[];
   isHiddenByFilter?: boolean;
   labelOnly?: boolean;
+  // Dimension breakdown properties
+  dimensionValue?: string;
 };
 
 export function useDomain(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Features and Changes

-   Introduces the ability to expand and collapse slices for individual metrics within `BreakdownResults`, mirroring the functionality found in `CompactResults`.
-   Enables the `ResultsFilter` to correctly apply slice filters when a dimension is selected in `BreakdownResults`.
-   Removes the "Slice filters are ignored when a unit dimension is set" warning from `ResultsFilter`, as this is no longer the case.

- Closes **(add link to issue here)**

### Dependencies

None

### Testing

-   Ran `npm run type-check`
-   Ran `npm test`
-   Ran `npm run lint`

### Screenshots

(Screenshots showing the expanded slices in BreakdownResults and the ResultsFilter with active slice filters would be beneficial here.)

[Slack Thread](https://growthbookapp.slack.com/archives/C07NK4F016Z/p1773410745357919?thread_ts=1773410745.357919&cid=C07NK4F016Z)

<div><a href="https://cursor.com/agents/bc-6d7e6ebc-e1ec-5219-a281-07c7b181f59c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d7e6ebc-e1ec-5219-a281-07c7b181f59c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->