### PR TITLE
Fixes auto-complete background CSS bug

### DIFF
--- a/packages/front-end/styles/global.scss
+++ b/packages/front-end/styles/global.scss
@@ -3620,6 +3620,15 @@ input:disabled {
   background-color: var(--color-surface-solid) !important;
 }
 
+// Ace autocomplete is appended to body (outside .radix-themes), so it doesn't
+// see theme variables. Set explicit backgrounds by theme so the list is readable.
+.light-theme .ace_editor.ace_autocomplete {
+  background-color: #ffffff !important;
+}
+.dark-theme .ace_editor.ace_autocomplete {
+  background-color: #0c1122 !important;
+}
+
 /* Radix-style pagination for ReactPaginate */
 .pagination-radix-container {
   display: flex;


### PR DESCRIPTION
### Features and Changes

Quick bugfix - recently when I was using our SQL explorer with auto-complete enabled, I ran into an issue where the background CSS had broken - and it was transparent. This PR adds some background colors to our `global.scss` file.

### Dependencies

- None

### Testing

- [x] Ensure the background looks good on light and dark mode
- [x] Ensure this doesn't introduce any regressions

### Screenshots

### Light Mode

#### Before
<img width="536" height="227" alt="Screenshot 2026-03-13 at 3 51 27 PM" src="https://github.com/user-attachments/assets/4bba0d62-d503-4448-ab1c-c11e6f2fbce1" />

#### After
<img width="537" height="238" alt="Screenshot 2026-03-13 at 3 51 44 PM" src="https://github.com/user-attachments/assets/982cb540-79f1-4f0c-8464-177b48c31c31" />

### Dark Mode

#### Before
<img width="549" height="178" alt="Screenshot 2026-03-13 at 3 51 12 PM" src="https://github.com/user-attachments/assets/a068a337-6c19-42da-969e-8c3f18621419" />

#### After
<img width="542" height="225" alt="Screenshot 2026-03-13 at 3 50 54 PM" src="https://github.com/user-attachments/assets/534e59a4-cc58-40e6-b32c-381336991b1e" />
