### PR TITLE
Scaled impact namespace coverage

### DIFF
--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -57,6 +57,7 @@ import {
   getAdditionalExperimentAnalysisSettings,
   getChangesToStartExperiment,
   getDefaultExperimentAnalysisSettings,
+  getEffectiveCoverage,
   getLinkedFeatureInfo,
   PlannedExperimentSnapshot,
   planSnapshot,
@@ -3365,8 +3366,10 @@ function addCoverageToSnapshotIfMissing(
 ): ExperimentSnapshotInterface {
   if (snapshot.settings.coverage === undefined) {
     const latestPhase = experiment.phases.length - 1;
-    snapshot.settings.coverage =
-      experiment.phases[phase ?? latestPhase]?.coverage ?? 1;
+    const experimentPhase = experiment.phases[phase ?? latestPhase];
+    snapshot.settings.coverage = experimentPhase
+      ? getEffectiveCoverage(experimentPhase)
+      : 1;
   }
   return snapshot;
 }

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -388,6 +388,20 @@ export function isJoinableMetric({
   return isMetricJoinable(metricIdTypes, experimentIdType, datasource.settings);
 }
 
+/**
+ * Calculates the effective coverage for an experiment phase, accounting for
+ * both the traffic percentage coverage and the namespace range (if enabled).
+ * This is used for scaled impact calculations in the stats engine.
+ */
+export function getEffectiveCoverage(phase: ExperimentPhase): number {
+  const phaseCoverage = phase.coverage ?? 1;
+  const hasNamespace = phase.namespace && phase.namespace.enabled;
+  const namespaceRange = hasNamespace
+    ? phase.namespace!.range[1] - phase.namespace!.range[0]
+    : 1;
+  return namespaceRange * phaseCoverage;
+}
+
 export function getSnapshotSettings({
   experiment,
   phaseIndex,
@@ -681,7 +695,7 @@ export function getSnapshotSettings({
       id: v.key || i + "",
       weight: phase.variationWeights[i] || 0,
     })),
-    coverage: phase.coverage ?? 1,
+    coverage: getEffectiveCoverage(phase),
     banditSettings,
   };
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Features and Changes

Updates the `coverage` parameter sent to the stats engine for scaled impact calculations. The `coverage` now represents the effective proportion of traffic, calculated as a multiple of the experiment's namespace range and its traffic percentage coverage.

-   Introduced a new helper function `getEffectiveCoverage` in `packages/back-end/src/services/experiments.ts` to compute this value.
-   Modified `getSnapshotSettings` (experiments service) and `addCoverageToSnapshotIfMissing` (experiments controller) to utilize `getEffectiveCoverage`.

**Example:** If an experiment uses 40% of a namespace (range `[0, 0.4]`) and has 30% traffic coverage, the effective coverage will be `0.4 * 0.3 = 0.12`.

- Closes **(add link to issue here)**

### Dependencies

None

### Testing

-   Ran `npm run type-check`
-   Ran `npm run test` (all tests passed)

### Screenshots

N/A

[Slack Thread](https://growthbookapp.slack.com/archives/C07NK4F016Z/p1773675205709789?thread_ts=1773675205.709789&cid=C07NK4F016Z)

<div><a href="https://cursor.com/agents/bc-40d5f62a-2073-5511-8cea-6d2fb5e592c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-40d5f62a-2073-5511-8cea-6d2fb5e592c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->