### PR TITLE
Variations in Phases 1b: use variation index in graphs

### DIFF
--- a/packages/front-end/components/Experiment/BanditDateGraph.tsx
+++ b/packages/front-end/components/Experiment/BanditDateGraph.tsx
@@ -89,9 +89,11 @@ type TooltipData = {
 const height = 300;
 const margin = [15, 30, 50, 80];
 
+type GraphVariation = { name: string; index: number };
+
 const getTooltipContents = (
   data: TooltipData,
-  variationNames: string[],
+  variations: GraphVariation[],
   mode: "values" | "probabilities" | "weights",
   metric: ExperimentMetricInterface | null,
   getFactTableById: any,
@@ -119,7 +121,7 @@ const getTooltipContents = (
             </tr>
           </thead>
           <tbody>
-            {variationNames.map((v, i) => {
+            {variations.map((v, i) => {
               if (!showVariations[i]) return null;
               const val = d[i];
               const meta = d.meta;
@@ -130,12 +132,12 @@ const getTooltipContents = (
                   )
                 : val;
               return (
-                <tr key={i}>
+                <tr key={v.index}>
                   <td
                     className="text-ellipsis"
-                    style={{ color: getVariationColor(i, true) }}
+                    style={{ color: getVariationColor(v.index, true) }}
                   >
-                    {v}
+                    {v.name}
                   </td>
                   <td>
                     {mode === "values" && crFormatted !== undefined
@@ -289,8 +291,8 @@ const BanditDateGraph: FC<BanditDateGraphProps> = ({
   const displayCurrency = ssrPolyfills?.useCurrency() || _displayCurrency;
   const metricFormatterOptions = { currency: displayCurrency };
 
-  const variationNames = getLatestPhaseVariations(experiment).map(
-    (v) => v.name,
+  const variations: GraphVariation[] = getLatestPhaseVariations(experiment).map(
+    (v) => ({ name: v.name, index: v.index }),
   );
   const { containerRef, containerBounds } = useTooltipInPortal({
     scroll: true,
@@ -304,7 +306,7 @@ const BanditDateGraph: FC<BanditDateGraphProps> = ({
   });
   const filterVariations = form.watch("filterVariations");
   const [showVariations, setShowVariations] = useState<boolean[]>(
-    variationNames.map(() => true),
+    variations.map(() => true),
   );
 
   const {
@@ -322,18 +324,18 @@ const BanditDateGraph: FC<BanditDateGraphProps> = ({
 
     const stackedData: any[] = [];
 
-    let lastVal = variationNames.map(() => 1 / (variationNames.length || 2));
+    let lastVal = variations.map(() => 1 / (variations.length || 2));
     events.forEach((event, eventNo) => {
       const bestArmProbabilities =
         event.banditResult?.bestArmProbabilities ?? [];
 
       const weights = event.banditResult.updatedWeights;
 
-      const users = variationNames.map(
+      const users = variations.map(
         (_, i) => event.banditResult?.singleVariationResults?.[i]?.users ?? 0,
       );
 
-      const crs = variationNames.map(
+      const crs = variations.map(
         (_, i) => event.banditResult?.singleVariationResults?.[i]?.cr ?? 0,
       );
 
@@ -359,7 +361,7 @@ const BanditDateGraph: FC<BanditDateGraphProps> = ({
       };
 
       let allEmpty = true;
-      variationNames.forEach((_, i) => {
+      variations.forEach((_, i) => {
         let val = 0;
         if (mode === "values") {
           val = crs[i];
@@ -382,12 +384,12 @@ const BanditDateGraph: FC<BanditDateGraphProps> = ({
         };
       });
       if (allEmpty) {
-        variationNames.forEach((_, i) => {
+        variations.forEach((_, i) => {
           dataPoint[i] = lastVal[i];
         });
         dataPoint.empty = true;
       } else {
-        lastVal = variationNames.map((_, i) => dataPoint[i]);
+        lastVal = variations.map((_, i) => dataPoint[i]);
       }
 
       stackedData.push(dataPoint);
@@ -400,7 +402,7 @@ const BanditDateGraph: FC<BanditDateGraphProps> = ({
       now > stackedData[stackedData.length - 1].date
     ) {
       const dataPoint: BanditDateGraphDataPoint = { date: now, meta: {} };
-      variationNames.forEach((_, i) => {
+      variations.forEach((_, i) => {
         dataPoint[i] = stackedData[stackedData.length - 1][i];
       });
       dataPoint.initial = stackedData[stackedData.length - 1].initial;
@@ -411,7 +413,7 @@ const BanditDateGraph: FC<BanditDateGraphProps> = ({
     }
 
     return stackedData;
-  }, [experiment, phase, mode, variationNames]);
+  }, [experiment, phase, mode, variations]);
 
   const filteredStackedData: BanditDateGraphDataPoint[] = useMemo(() => {
     const filtered = cloneDeep(stackedData);
@@ -428,7 +430,7 @@ const BanditDateGraph: FC<BanditDateGraphProps> = ({
     () => {
       let sv = [...showVariations];
       if (filterVariations === "all") {
-        sv = variationNames.map(() => true);
+        sv = variations.map(() => true);
         setShowVariations(sv);
         return;
       }
@@ -436,9 +438,9 @@ const BanditDateGraph: FC<BanditDateGraphProps> = ({
       const probabilities = (() => {
         let probs: number[] = [];
         let totalUsers = 0;
-        for (let i = 0; i < variationNames.length; i++) {
+        for (let i = 0; i < variations.length; i++) {
           let prob =
-            latestMeta?.[i]?.probability ?? 1 / (variationNames.length || 2);
+            latestMeta?.[i]?.probability ?? 1 / (variations.length || 2);
           const users = latestMeta?.[i]?.users ?? 0;
           totalUsers += users;
           if (users < 100) {
@@ -447,8 +449,8 @@ const BanditDateGraph: FC<BanditDateGraphProps> = ({
 
           probs.push(prob);
         }
-        if (totalUsers < 100 * variationNames.length) {
-          probs = probs.map(() => 1 / (variationNames.length || 2));
+        if (totalUsers < 100 * variations.length) {
+          probs = probs.map(() => 1 / (variations.length || 2));
         }
         return probs;
       })();
@@ -468,11 +470,11 @@ const BanditDateGraph: FC<BanditDateGraphProps> = ({
       const variationRanks = rankArray(probabilities);
 
       if (filterVariations === "5") {
-        sv = variationNames.map((_, i) => variationRanks[i] <= 5);
+        sv = variations.map((_, i) => variationRanks[i] <= 5);
       } else if (filterVariations === "3") {
-        sv = variationNames.map((_, i) => variationRanks[i] <= 3);
+        sv = variations.map((_, i) => variationRanks[i] <= 3);
       } else if (filterVariations === "1") {
-        sv = variationNames.map((_, i) => variationRanks[i] <= 1);
+        sv = variations.map((_, i) => variationRanks[i] <= 1);
       }
       setShowVariations(sv);
     },
@@ -490,7 +492,7 @@ const BanditDateGraph: FC<BanditDateGraphProps> = ({
               Math.min(
                 ...stackedData.map((d) =>
                   Math.min(
-                    ...variationNames
+                    ...variations
                       .map((_, i) => d?.meta?.[i]?.ci?.[0] ?? 0)
                       .filter(
                         (_, i) =>
@@ -507,7 +509,7 @@ const BanditDateGraph: FC<BanditDateGraphProps> = ({
               Math.max(
                 ...stackedData.map((d) =>
                   Math.max(
-                    ...variationNames
+                    ...variations
                       .map((_, i) => d?.meta?.[i]?.ci?.[1] ?? 0)
                       .filter(
                         (_, i) =>
@@ -529,7 +531,7 @@ const BanditDateGraph: FC<BanditDateGraphProps> = ({
             domain: [0, 1],
             range: [yMax, 0],
           }),
-    [variationNames, mode, stackedData, yMax, showVariations],
+    [variations, mode, stackedData, yMax, showVariations],
   );
 
   // Get x-axis domain
@@ -542,10 +544,10 @@ const BanditDateGraph: FC<BanditDateGraphProps> = ({
       ? Math.max(...stackedData.map((d) => d.date.getTime()))
       : 0;
 
-  const gradients = variationNames.map((_, i) => (
+  const gradients = variations.map((v) => (
     <linearGradient
-      key={`gradient-${i}`}
-      id={`gradient-${i}`}
+      key={`gradient-${v.index}`}
+      id={`gradient-${v.index}`}
       x1="0%"
       y1="0%"
       x2="0%"
@@ -553,12 +555,12 @@ const BanditDateGraph: FC<BanditDateGraphProps> = ({
     >
       <stop
         offset="0%"
-        stopColor={getVariationColor(i, true)}
+        stopColor={getVariationColor(v.index, true)}
         stopOpacity={0.75}
       />
       <stop
         offset="100%"
-        stopColor={getVariationColor(i, true)}
+        stopColor={getVariationColor(v.index, true)}
         stopOpacity={0.65}
       />
     </linearGradient>
@@ -668,7 +670,7 @@ const BanditDateGraph: FC<BanditDateGraphProps> = ({
               >
                 {getTooltipContents(
                   tooltipData,
-                  variationNames,
+                  variations,
                   mode,
                   metric,
                   getFactTableById,
@@ -693,7 +695,7 @@ const BanditDateGraph: FC<BanditDateGraphProps> = ({
                       label: "All variations",
                       value: "all",
                     },
-                    ...(variationNames.length > 5
+                    ...(variations.length > 5
                       ? [
                           {
                             label: "Top 5",
@@ -701,7 +703,7 @@ const BanditDateGraph: FC<BanditDateGraphProps> = ({
                           },
                         ]
                       : []),
-                    ...(variationNames.length > 3
+                    ...(variations.length > 3
                       ? [
                           {
                             label: "Top 3",
@@ -734,20 +736,20 @@ const BanditDateGraph: FC<BanditDateGraphProps> = ({
                 className="d-flex flex-wrap px-3 mb-2"
                 style={{ gap: "0.25rem 1rem" }}
               >
-                {variationNames.map((v, i) => {
+                {variations.map((v, i) => {
                   return (
                     <div
-                      key={i}
+                      key={v.index}
                       className="nowrap text-ellipsis cursor-pointer hover-highlight py-1 pr-1 rounded user-select-none"
                       style={{
                         maxWidth: 200,
-                        color: getVariationColor(i, true),
+                        color: getVariationColor(v.index, true),
                       }}
                       onClick={() => {
                         let sv = [...showVariations];
                         sv[i] = !sv[i];
                         if (sv.every((v) => !v)) {
-                          sv = variationNames.map((_, j) => i !== j);
+                          sv = variations.map((_, j) => i !== j);
                         }
                         setShowVariations(sv);
                         if (sv.every((v) => v)) {
@@ -762,7 +764,7 @@ const BanditDateGraph: FC<BanditDateGraphProps> = ({
                       ) : (
                         <BiCheckbox size={24} />
                       )}
-                      {v}
+                      {v.name}
                     </div>
                   );
                 })}
@@ -783,8 +785,7 @@ const BanditDateGraph: FC<BanditDateGraphProps> = ({
               {tooltipOpen && (
                 <>
                   {type === "line" &&
-                    variationNames.map((_, i) => {
-                      // Render a dot at the current x location for each variation
+                    variations.map((v, i) => {
                       if (!showVariations[i]) return null;
                       const y = tooltipData?.d?.[i];
                       if (y === undefined) return;
@@ -792,13 +793,13 @@ const BanditDateGraph: FC<BanditDateGraphProps> = ({
                       if (users === 0 && mode === "values") return;
                       return (
                         <div
-                          key={i}
+                          key={v.index}
                           className={styles.positionIndicator}
                           style={{
                             transform: `translate(${tooltipLeft}px, ${yScale(
                               y,
                             )}px)`,
-                            background: getVariationColor(i, true),
+                            background: getVariationColor(v.index, true),
                           }}
                         />
                       );
@@ -854,7 +855,7 @@ const BanditDateGraph: FC<BanditDateGraphProps> = ({
                 <Group clipPath="url(#bandit-date-graph-clip)">
                   {type === "area" && (
                     <AreaStack
-                      keys={variationNames.map((_, i) => i)}
+                      keys={variations.map((_, i) => i)}
                       data={filteredStackedData}
                       x={(d) => xScale(d.data.date)}
                       y0={(d) => yScale(d[0])}
@@ -874,12 +875,13 @@ const BanditDateGraph: FC<BanditDateGraphProps> = ({
                       {({ stacks, path }) =>
                         stacks.map((stack, i) => {
                           if (!showVariations[i]) return null;
+                          const vIndex = variations[i]?.index ?? i;
                           return (
                             <path
                               key={`stack-${stack.key}`}
                               d={path(stack) || ""}
-                              stroke={getVariationColor(i, true)}
-                              fill={`url(#gradient-${i})`}
+                              stroke={getVariationColor(vIndex, true)}
+                              fill={`url(#gradient-${vIndex})`}
                               mask="url(#stripe-mask)"
                             />
                           );
@@ -889,17 +891,17 @@ const BanditDateGraph: FC<BanditDateGraphProps> = ({
                   )}
 
                   {mode === "values" &&
-                    variationNames.map((_, i) => {
+                    variations.map((v, i) => {
                       if (!showVariations[i]) return null;
                       return (
                         <AreaClosed
-                          key={`ci_${i}`}
+                          key={`ci_${v.index}`}
                           yScale={yScale}
                           data={stackedData}
                           x={(d) => xScale(d.date)}
                           y0={(d) => yScale(d?.meta?.[i]?.ci?.[0] ?? 0) ?? 0}
                           y1={(d) => yScale(d?.meta?.[i]?.ci?.[1] ?? 0) ?? 0}
-                          fill={getVariationColor(i, true)}
+                          fill={getVariationColor(v.index, true)}
                           opacity={0.12}
                           curve={curveMonotoneX}
                           defined={(d) =>
@@ -911,15 +913,15 @@ const BanditDateGraph: FC<BanditDateGraphProps> = ({
                     })}
 
                   {type === "line" &&
-                    variationNames.map((_, i) => {
+                    variations.map((v, i) => {
                       if (!showVariations[i]) return null;
                       return (
                         <LinePath
-                          key={`linepath-${i}`}
+                          key={`linepath-${v.index}`}
                           data={stackedData}
                           x={(d) => xScale(d.date)}
                           y={(d) => yScale(d[i])}
-                          stroke={getVariationColor(i, true)}
+                          stroke={getVariationColor(v.index, true)}
                           strokeWidth={2}
                           curve={
                             mode === "values"

--- a/packages/front-end/components/Experiment/DateResults.tsx
+++ b/packages/front-end/components/Experiment/DateResults.tsx
@@ -343,7 +343,7 @@ const DateResults: FC<{
         <h2>Units</h2>
         <ExperimentDateGraph
           yaxis="users"
-          variationNames={variations.map((v) => v.name)}
+          variations={variations}
           label="Units"
           datapoints={users}
           formatter={formatNumber}
@@ -391,7 +391,7 @@ const DateResults: FC<{
                     )
               }
               formatterOptions={metricFormatterOptions}
-              variationNames={variations.map((v) => v.name)}
+              variations={variations}
               statsEngine={statsEngine}
               hasStats={!cumulative}
             />

--- a/packages/front-end/components/Experiment/ExperimentDateGraph.tsx
+++ b/packages/front-end/components/Experiment/ExperimentDateGraph.tsx
@@ -34,9 +34,11 @@ export interface ExperimentDateGraphDataPoint {
   d: Date;
   variations?: DataPointVariation[]; // undefined === missing date
 }
+export type GraphVariation = { name: string; index: number };
+
 export interface ExperimentDateGraphProps {
   yaxis: "users" | "effect";
-  variationNames: string[];
+  variations: GraphVariation[];
   label: string;
   datapoints: ExperimentDateGraphDataPoint[];
   formatter: (value: number, options?: Intl.NumberFormatOptions) => string;
@@ -65,7 +67,7 @@ const margin = [15, 15, 30, 80];
 // Render the contents of a tooltip
 const getTooltipContents = (
   data: TooltipData,
-  variationNames: string[],
+  variations: GraphVariation[],
   showVariations: boolean[],
   statsEngine: StatsEngine,
   formatter: (value: number, options?: Intl.NumberFormatOptions) => string,
@@ -104,17 +106,17 @@ const getTooltipContents = (
           </tr>
         </thead>
         <tbody>
-          {variationNames.map((v, i) => {
+          {variations.map((v, i) => {
             if (!d.variations) return null;
             if (!showVariations[i]) return null;
             const variation = d.variations[i];
             return (
-              <tr key={i}>
+              <tr key={v.index}>
                 <td
                   className="text-ellipsis"
-                  style={{ color: getVariationColor(i, true) }}
+                  style={{ color: getVariationColor(v.index, true) }}
                 >
-                  {v}
+                  {v.name}
                 </td>
                 {yaxis === "users" && <td>{d.variations[i].v_formatted}</td>}
                 {yaxis === "effect" && (
@@ -225,7 +227,7 @@ const getYVal = (
 const ExperimentDateGraph: FC<ExperimentDateGraphProps> = ({
   yaxis,
   datapoints: _datapoints,
-  variationNames,
+  variations,
   label,
   formatter,
   formatterOptions,
@@ -241,7 +243,7 @@ const ExperimentDateGraph: FC<ExperimentDateGraphProps> = ({
   });
 
   const [showVariations, setShowVariations] = useState<boolean[]>(
-    variationNames.map(() => true),
+    variations.map(() => true),
   );
 
   const {
@@ -409,7 +411,7 @@ const ExperimentDateGraph: FC<ExperimentDateGraphProps> = ({
               >
                 {getTooltipContents(
                   tooltipData,
-                  variationNames,
+                  variations,
                   showVariations,
                   statsEngine,
                   formatter,
@@ -428,10 +430,10 @@ const ExperimentDateGraph: FC<ExperimentDateGraphProps> = ({
                   className="nowrap cursor-pointer hover-highlight py-1 pr-1 rounded user-select-none"
                   onClick={() => {
                     if (!showVariations.every((sv) => sv)) {
-                      setShowVariations(variationNames.map(() => true));
+                      setShowVariations(variations.map(() => true));
                     } else {
                       setShowVariations(
-                        variationNames.map((_, i) => (i === 0 ? true : false)),
+                        variations.map((_, i) => (i === 0 ? true : false)),
                       );
                     }
                   }}
@@ -443,21 +445,21 @@ const ExperimentDateGraph: FC<ExperimentDateGraphProps> = ({
                   )}
                   Show all
                 </div>
-                {variationNames.map((v, i) => {
+                {variations.map((v, i) => {
                   if (i === 0 && yaxis === "effect") return null;
                   return (
                     <div
-                      key={i}
+                      key={v.index}
                       className="nowrap text-ellipsis cursor-pointer hover-highlight py-1 pr-1 rounded user-select-none"
                       style={{
                         maxWidth: 200,
-                        color: getVariationColor(i, true),
+                        color: getVariationColor(v.index, true),
                       }}
                       onClick={() => {
                         let sv = [...showVariations];
                         sv[i] = !sv[i];
                         if (sv.every((v) => !v)) {
-                          sv = variationNames.map((_, j) => i !== j);
+                          sv = variations.map((_, j) => i !== j);
                         }
                         setShowVariations(sv);
                       }}
@@ -467,7 +469,7 @@ const ExperimentDateGraph: FC<ExperimentDateGraphProps> = ({
                       ) : (
                         <BiCheckbox size={24} />
                       )}
-                      {v}
+                      {v.name}
                     </div>
                   );
                 })}
@@ -487,7 +489,7 @@ const ExperimentDateGraph: FC<ExperimentDateGraphProps> = ({
             >
               {tooltipOpen && (
                 <>
-                  {variationNames.map((v, i) => {
+                  {variations.map((v, i) => {
                     if (!showVariations[i]) return null;
                     if (yaxis === "effect" && i === 0) {
                       return;
@@ -495,13 +497,13 @@ const ExperimentDateGraph: FC<ExperimentDateGraphProps> = ({
                     // Render a dot at the current x location for each variation
                     return (
                       <div
-                        key={i}
+                        key={v.index}
                         className={styles.positionIndicator}
                         style={{
                           transform: `translate(${tooltipLeft}px, ${
                             tooltipData?.y?.[i] ?? 0
                           }px)`,
-                          background: getVariationColor(i, true),
+                          background: getVariationColor(v.index, true),
                         }}
                       />
                     );
@@ -540,7 +542,7 @@ const ExperimentDateGraph: FC<ExperimentDateGraphProps> = ({
                 />
 
                 <Group clipPath="url(#experiment-date-graph-clip)">
-                  {variationNames.map((v, i) => {
+                  {variations.map((v, i) => {
                     if (!showVariations[i]) return null;
                     if (yaxis === "effect" && i === 0) {
                       return <></>;
@@ -550,7 +552,7 @@ const ExperimentDateGraph: FC<ExperimentDateGraphProps> = ({
                       typeof datapoints[0]?.variations?.[i]?.ci !==
                         "undefined" && (
                         <AreaClosed
-                          key={`ci_${i}`}
+                          key={`ci_${v.index}`}
                           yScale={yScale}
                           data={datapoints}
                           x={(d) => xScale(d.d) ?? 0}
@@ -560,7 +562,7 @@ const ExperimentDateGraph: FC<ExperimentDateGraphProps> = ({
                           y1={(d) =>
                             yScale(d?.variations?.[i]?.ci?.[1] ?? 0) ?? 0
                           }
-                          fill={getVariationColor(i, true)}
+                          fill={getVariationColor(v.index, true)}
                           opacity={0.12}
                           curve={curveMonotoneX}
                         />
@@ -568,7 +570,7 @@ const ExperimentDateGraph: FC<ExperimentDateGraphProps> = ({
                     );
                   })}
 
-                  {variationNames.map((_, i) => {
+                  {variations.map((v, i) => {
                     if (!showVariations[i]) return null;
                     if (yaxis === "effect" && i === 0) {
                       return null;
@@ -576,13 +578,13 @@ const ExperimentDateGraph: FC<ExperimentDateGraphProps> = ({
                     // Render the actual line chart for each variation
                     return (
                       <LinePath
-                        key={`linepath_${i}`}
+                        key={`linepath_${v.index}`}
                         data={datapoints}
                         x={(d) => xScale(d.d)}
                         y={(d) =>
                           yScale(getYVal(d?.variations?.[i], yaxis) ?? 0)
                         }
-                        stroke={getVariationColor(i, true)}
+                        stroke={getVariationColor(v.index, true)}
                         strokeWidth={2}
                         curve={curveMonotoneX}
                         defined={(d) =>

--- a/packages/front-end/components/Experiment/ExperimentMetricTimeSeriesGraphWrapper.tsx
+++ b/packages/front-end/components/Experiment/ExperimentMetricTimeSeriesGraphWrapper.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/services/metrics";
 import usePValueThreshold from "@/hooks/usePValueThreshold";
 import { useCurrency } from "@/hooks/useCurrency";
+import { GraphVariation } from "./ExperimentDateGraph";
 import ExperimentTimeSeriesGraph, {
   ExperimentTimeSeriesGraphDataPoint,
 } from "./ExperimentTimeSeriesGraph";
@@ -25,7 +26,7 @@ interface ExperimentMetricTimeSeriesGraphWrapperProps {
   phase: number;
   metric: ExperimentMetricInterface;
   differenceType: DifferenceType;
-  variationNames: string[];
+  variations: GraphVariation[];
   showVariations: boolean[];
   statsEngine: StatsEngine;
   pValueAdjustmentEnabled: boolean;
@@ -57,7 +58,7 @@ function ExperimentMetricTimeSeriesGraphWrapper({
   phase,
   metric,
   differenceType,
-  variationNames,
+  variations,
   showVariations,
   statsEngine,
   pValueAdjustmentEnabled,
@@ -150,9 +151,8 @@ function ExperimentMetricTimeSeriesGraphWrapper({
 
   const dataPoints = [
     ...timeSeries.dataPoints.map((point, idx) => {
-      // Preprocess variations to match variationNames order exactly with indices
-      const variations = variationNames.map((vName) => {
-        const variation = point.variations.find((v) => v.name === vName);
+      const pointVariations = variations.map((gv) => {
+        const variation = point.variations.find((v) => v.name === gv.name);
         if (!variation) return null;
 
         // compute adjusted CI if we have all the data and adjustment exists
@@ -188,7 +188,7 @@ function ExperimentMetricTimeSeriesGraphWrapper({
 
       const parsedPoint: ExperimentTimeSeriesGraphDataPoint = {
         d: new Date(point.date),
-        variations,
+        variations: pointVariations,
         helperText:
           idx < lastIndexInvalidConfiguration
             ? "Analysis or metric settings do not match current version"
@@ -214,7 +214,7 @@ function ExperimentMetricTimeSeriesGraphWrapper({
   return (
     <ExperimentTimeSeriesGraph
       yaxis="effect"
-      variationNames={variationNames}
+      variations={variations}
       label={labelText}
       datapoints={dataPoints}
       showVariations={showVariations}

--- a/packages/front-end/components/Experiment/ExperimentTimeSeriesGraph.tsx
+++ b/packages/front-end/components/Experiment/ExperimentTimeSeriesGraph.tsx
@@ -46,9 +46,11 @@ export interface ExperimentTimeSeriesGraphDataPoint {
   helperText?: string;
 }
 
+import { GraphVariation } from "./ExperimentDateGraph";
+
 export interface ExperimentTimeSeriesGraphProps {
   yaxis: AxisType;
-  variationNames: string[];
+  variations: GraphVariation[];
   label: string;
   datapoints: ExperimentTimeSeriesGraphDataPoint[];
   formatter: (value: number, options?: Intl.NumberFormatOptions) => string;
@@ -79,7 +81,7 @@ const margin = [15, 30, 30, 80];
 // Render the contents of a tooltip
 const getTooltipContents = (
   data: TooltipData,
-  variationNames: string[],
+  variations: GraphVariation[],
   showVariations: boolean[],
   statsEngine: StatsEngine,
   usesPValueAdjustment: boolean,
@@ -134,15 +136,15 @@ const getTooltipContents = (
         </TableHeader>
 
         <TableBody style={{ fontSize: "12px" }}>
-          {variationNames.map((v, i) => {
+          {variations.map((v, i) => {
             if (!d.variations) return null;
             if (!showVariations[i]) return null;
             const variation = d.variations[i];
             if (!variation) return null;
-            const variationColor = getVariationColor(i, true);
+            const variationColor = getVariationColor(v.index, true);
             return (
               <TableRow
-                key={`tooltip_row_${i}`}
+                key={`tooltip_row_${v.index}`}
                 style={{
                   color: "var(--color-text-high)",
                   fontWeight: 500,
@@ -167,9 +169,9 @@ const getTooltipContents = (
                         flexShrink: 0,
                       }}
                     >
-                      {i}
+                      {v.index}
                     </span>
-                    <Text weight="bold">{v}</Text>
+                    <Text weight="bold">{v.name}</Text>
                   </Flex>
                 </TableRowHeaderCell>
                 {yaxis === "effect" && (
@@ -295,7 +297,7 @@ const getYVal = (variation?: DataPointVariation, yaxis?: AxisType) => {
 const ExperimentTimeSeriesGraph: FC<ExperimentTimeSeriesGraphProps> = ({
   yaxis,
   datapoints: _datapoints,
-  variationNames,
+  variations,
   label,
   formatter,
   formatterOptions,
@@ -487,10 +489,10 @@ const ExperimentTimeSeriesGraph: FC<ExperimentTimeSeriesGraphProps> = ({
 
   // If any point or variation has a valid CI we should render it
   const variationsWithCI = useMemo(() => {
-    return variationNames.map((_, i) =>
+    return variations.map((_, i) =>
       sortedDatesWithData.some((d) => d.variations?.[i]?.ci !== undefined),
     );
-  }, [sortedDatesWithData, variationNames]);
+  }, [sortedDatesWithData, variations]);
 
   const hasDataForDay = useMemo(() => {
     const firstDateWithData =
@@ -584,7 +586,7 @@ const ExperimentTimeSeriesGraph: FC<ExperimentTimeSeriesGraphProps> = ({
                   <div className={timeSeriesStyles.tooltipContent}>
                     {getTooltipContents(
                       tooltipData,
-                      variationNames,
+                      variations,
                       showVariations,
                       statsEngine,
                       usesPValueAdjustment,
@@ -610,22 +612,21 @@ const ExperimentTimeSeriesGraph: FC<ExperimentTimeSeriesGraphProps> = ({
             >
               {tooltipOpen && (
                 <>
-                  {variationNames.map((variationName, i) => {
+                  {variations.map((v, i) => {
                     if (!showVariations[i]) return null;
                     if (yaxis === "effect" && i === 0) {
                       return null;
                     }
                     if (!tooltipData?.d.variations?.[i]) return null;
-                    // Render a dot at the current x location for each variation
                     return (
                       <div
-                        key={`tooltip_dot_open_${i}`}
+                        key={`tooltip_dot_open_${v.index}`}
                         className={styles.positionIndicator}
                         style={{
                           transform: `translate(${tooltipLeft}px, ${
                             tooltipData?.y?.[i] ?? 0
                           }px)`,
-                          background: getVariationColor(i, true),
+                          background: getVariationColor(v.index, true),
                         }}
                       />
                     );
@@ -637,7 +638,7 @@ const ExperimentTimeSeriesGraph: FC<ExperimentTimeSeriesGraphProps> = ({
                 // Render a dot at the current x location for each variation
                 return (
                   <React.Fragment key={`date_${d.d.getTime()}`}>
-                    {variationNames.map((_, i) => {
+                    {variations.map((v, i) => {
                       if (yaxis === "effect" && i === 0) {
                         return null;
                       }
@@ -646,13 +647,13 @@ const ExperimentTimeSeriesGraph: FC<ExperimentTimeSeriesGraphProps> = ({
                       if (!variation) return null;
                       return (
                         <div
-                          key={`${d.d.getTime()}_${i}`}
+                          key={`${d.d.getTime()}_${v.index}`}
                           className={timeSeriesStyles.positionWithData}
                           style={{
                             transform: `translate(${xScale(d.d)}px, ${
                               yScale(getYVal(variation, yaxis) ?? 0) ?? 0
                             }px)`,
-                            background: getVariationColor(i, true),
+                            background: getVariationColor(v.index, true),
                           }}
                         />
                       );
@@ -688,11 +689,13 @@ const ExperimentTimeSeriesGraph: FC<ExperimentTimeSeriesGraphProps> = ({
                 />
 
                 <Group clipPath="url(#experiment-date-graph-clip)">
-                  {variationNames.map((_, i) => {
+                  {variations.map((v, i) => {
                     if (!showVariations[i]) return null;
                     if (yaxis === "effect" && i === 0) {
                       return (
-                        <React.Fragment key={`empty_${i}`}></React.Fragment>
+                        <React.Fragment
+                          key={`empty_${v.index}`}
+                        ></React.Fragment>
                       );
                     }
 
@@ -711,7 +714,7 @@ const ExperimentTimeSeriesGraph: FC<ExperimentTimeSeriesGraphProps> = ({
                     return (
                       variationsWithCI[i] && (
                         <AreaClosed
-                          key={`ci_${i}`}
+                          key={`ci_${v.index}`}
                           yScale={yScale}
                           data={sortedDataForVariation}
                           x={(d) => xScale(d.d) ?? 0}
@@ -721,7 +724,7 @@ const ExperimentTimeSeriesGraph: FC<ExperimentTimeSeriesGraphProps> = ({
                           y1={(d) => {
                             return yScale(d?.variation?.ci?.[1] ?? 0) ?? 0;
                           }}
-                          fill={getVariationColor(i, true)}
+                          fill={getVariationColor(v.index, true)}
                           opacity={0.12}
                           curve={curveMonotoneX}
                         />
@@ -729,14 +732,12 @@ const ExperimentTimeSeriesGraph: FC<ExperimentTimeSeriesGraphProps> = ({
                     );
                   })}
 
-                  {variationNames.map((_, i) => {
+                  {variations.map((v, i) => {
                     if (!showVariations[i]) return null;
                     if (yaxis === "effect" && i === 0) {
                       return null;
                     }
 
-                    // NB: We include the last index in both arrays as we need
-                    // to draw the dashed line to it, and the solid line from it onwards
                     const sortedDataForVariation = sortedDatesWithData
                       .map((d) => ({
                         d: d.d,
@@ -759,10 +760,9 @@ const ExperimentTimeSeriesGraph: FC<ExperimentTimeSeriesGraphProps> = ({
                       );
 
                     return (
-                      <React.Fragment key={`linepaths_${i}`}>
-                        {/* Render a dotted line for the previous settings data points */}
+                      <React.Fragment key={`linepaths_${v.index}`}>
                         <LinePath
-                          key={`linepath_dashed_${i}`}
+                          key={`linepath_dashed_${v.index}`}
                           data={previousSettingsDataPoints}
                           x={(d) => xScale(d.d)}
                           y={(d) => {
@@ -770,15 +770,14 @@ const ExperimentTimeSeriesGraph: FC<ExperimentTimeSeriesGraphProps> = ({
                               getYVal(d.variation ?? undefined, yaxis) ?? 0,
                             );
                           }}
-                          stroke={getVariationColor(i, true)}
+                          stroke={getVariationColor(v.index, true)}
                           strokeWidth={2}
                           strokeDasharray={3}
                           strokeLinecap="butt"
                           curve={curveLinear}
                         />
-                        {/* Render a solid line for the current settings data points */}
                         <LinePath
-                          key={`linepath_solid_${i}`}
+                          key={`linepath_solid_${v.index}`}
                           data={currentSettingsDataPoints}
                           x={(d) => xScale(d.d)}
                           y={(d) => {
@@ -786,7 +785,7 @@ const ExperimentTimeSeriesGraph: FC<ExperimentTimeSeriesGraphProps> = ({
                               getYVal(d.variation ?? undefined, yaxis) ?? 0,
                             );
                           }}
-                          stroke={getVariationColor(i, true)}
+                          stroke={getVariationColor(v.index, true)}
                           strokeWidth={2}
                           curve={curveLinear}
                         />

--- a/packages/front-end/components/Experiment/ResultsTable.tsx
+++ b/packages/front-end/components/Experiment/ResultsTable.tsx
@@ -1290,9 +1290,7 @@ export default function ResultsTable({
                                           phase={phase}
                                           metric={row.metric}
                                           differenceType={differenceType}
-                                          variationNames={orderedVariations.map(
-                                            (v) => v.name,
-                                          )}
+                                          variations={orderedVariations}
                                           showVariations={showVariations}
                                           statsEngine={statsEngine}
                                           pValueAdjustmentEnabled={

--- a/packages/front-end/components/HealthTab/BanditSRMGraph.tsx
+++ b/packages/front-end/components/HealthTab/BanditSRMGraph.tsx
@@ -61,9 +61,11 @@ type TooltipData = {
 const height = 300;
 const margin = [15, 25, 50, 70];
 
+type GraphVariation = { name: string; index: number };
+
 const getTooltipContents = (
   data: TooltipData,
-  variationNames: string[],
+  variations: GraphVariation[],
   mode: "users" | "weights",
   showVariations: boolean[],
 ) => {
@@ -86,19 +88,19 @@ const getTooltipContents = (
           </tr>
         </thead>
         <tbody>
-          {variationNames.map((v, i) => {
+          {variations.map((v, i) => {
             if (!showVariations[i]) return null;
             const expectedUsers = data?.d?.expectedUsers?.[i] ?? 0;
             const users = data?.d?.users?.[i] ?? 0;
             const weight = data?.d?.weights?.[i] ?? 0;
             const userRatio = data?.d?.userRatios?.[i];
             return (
-              <tr key={i}>
+              <tr key={v.index}>
                 <td
                   className="text-ellipsis"
-                  style={{ color: getVariationColor(i, true) }}
+                  style={{ color: getVariationColor(v.index, true) }}
                 >
-                  {v}
+                  {v.name}
                 </td>
                 <td>
                   {mode === "users"
@@ -169,8 +171,8 @@ const BanditSRMGraph: FC<BanditSRMGraphProps> = ({
 }) => {
   const formatter = formatNumber;
 
-  const variationNames = getLatestPhaseVariations(experiment).map(
-    (v) => v.name,
+  const variations: GraphVariation[] = getLatestPhaseVariations(experiment).map(
+    (v) => ({ name: v.name, index: v.index }),
   );
   const { containerRef, containerBounds } = useTooltipInPortal({
     scroll: true,
@@ -178,7 +180,7 @@ const BanditSRMGraph: FC<BanditSRMGraphProps> = ({
   });
 
   const [showVariations, setShowVariations] = useState<boolean[]>(
-    variationNames.map(() => true),
+    variations.map(() => true),
   );
 
   const {
@@ -195,29 +197,28 @@ const BanditSRMGraph: FC<BanditSRMGraphProps> = ({
 
     const data: any[] = [];
 
-    let previousUsers = variationNames.map(() => 0);
+    let previousUsers = variations.map(() => 0);
 
     events.forEach((event, i) => {
-      // only use reweighted events + the latest event
       if (!event.banditResult.reweight && i !== events.length - 1) {
         return;
       }
       const weights = event.banditResult.currentWeights;
 
-      const users = variationNames.map(
+      const users = variations.map(
         (_, i) =>
           (event.banditResult?.singleVariationResults?.[i]?.users ?? 0) -
           (previousUsers?.[i] ?? 0),
       );
-      previousUsers = variationNames.map(
+      previousUsers = variations.map(
         (_, i) => event.banditResult?.singleVariationResults?.[i]?.users ?? 0,
       );
       const totalUsers = users.reduce((sum, val) => sum + val, 0);
-      const expectedUsers = variationNames.map(
+      const expectedUsers = variations.map(
         (_, i) => (weights[i] ?? 0) * totalUsers,
       );
 
-      const userRatios = variationNames.map((_, i) =>
+      const userRatios = variations.map((_, i) =>
         totalUsers ? (users[i] ?? 0) / totalUsers : undefined,
       );
 
@@ -236,7 +237,7 @@ const BanditSRMGraph: FC<BanditSRMGraphProps> = ({
     });
 
     return data;
-  }, [phase, variationNames]);
+  }, [phase, variations]);
 
   const yMax = height - margin[0] - margin[2];
 
@@ -248,10 +249,10 @@ const BanditSRMGraph: FC<BanditSRMGraphProps> = ({
               Math.min(
                 ...data.map((d) =>
                   Math.min(
-                    ...variationNames
+                    ...variations
                       .map((_, i) => d?.users?.[i] ?? 0)
                       .filter((_, i) => showVariations[i]),
-                    ...variationNames
+                    ...variations
                       .map((_, i) => d?.expectedUsers?.[i] ?? 0)
                       .filter((_, i) => showVariations[i]),
                   ),
@@ -260,10 +261,10 @@ const BanditSRMGraph: FC<BanditSRMGraphProps> = ({
               Math.max(
                 ...data.map((d) =>
                   Math.max(
-                    ...variationNames
+                    ...variations
                       .map((_, i) => d?.users?.[i] ?? 0)
                       .filter((_, i) => showVariations[i]),
-                    ...variationNames
+                    ...variations
                       .map((_, i) => d?.expectedUsers?.[i] ?? 0)
                       .filter((_, i) => showVariations[i]),
                   ),
@@ -277,7 +278,7 @@ const BanditSRMGraph: FC<BanditSRMGraphProps> = ({
             domain: [0, 1],
             range: [yMax, 0],
           }),
-    [variationNames, mode, data, yMax, showVariations],
+    [variations, mode, data, yMax, showVariations],
   );
 
   // Get x-axis domain
@@ -332,7 +333,7 @@ const BanditSRMGraph: FC<BanditSRMGraphProps> = ({
               >
                 {getTooltipContents(
                   tooltipData,
-                  variationNames,
+                  variations,
                   mode,
                   showVariations,
                 )}
@@ -352,7 +353,7 @@ const BanditSRMGraph: FC<BanditSRMGraphProps> = ({
                   key={"all"}
                   className="nowrap cursor-pointer hover-highlight py-1 pr-1 rounded user-select-none"
                   onClick={() => {
-                    setShowVariations(variationNames.map(() => true));
+                    setShowVariations(variations.map(() => true));
                   }}
                 >
                   {showVariations.every((sv) => sv) ? (
@@ -362,19 +363,17 @@ const BanditSRMGraph: FC<BanditSRMGraphProps> = ({
                   )}
                   Show all
                 </div>
-                {variationNames.map((v, i) => {
+                {variations.map((v, i) => {
                   return (
                     <div
-                      key={i}
+                      key={v.index}
                       className="nowrap text-ellipsis cursor-pointer hover-highlight py-1 pr-1 rounded user-select-none"
                       style={{
                         maxWidth: 200,
-                        color: getVariationColor(i, true),
+                        color: getVariationColor(v.index, true),
                       }}
                       onClick={() => {
-                        setShowVariations(
-                          variationNames.map((_, j) => i === j),
-                        );
+                        setShowVariations(variations.map((_, j) => i === j));
                       }}
                     >
                       {showVariations[i] &&
@@ -383,7 +382,7 @@ const BanditSRMGraph: FC<BanditSRMGraphProps> = ({
                       ) : (
                         <BiRadioCircle size={24} />
                       )}
-                      {v}
+                      {v.name}
                     </div>
                   );
                 })}
@@ -473,37 +472,37 @@ const BanditSRMGraph: FC<BanditSRMGraphProps> = ({
 
                 <Group clipPath="url(#bandit-srm-graph-clip)">
                   {mode === "users"
-                    ? variationNames.map((_, i) => {
+                    ? variations.map((v, i) => {
                         if (!showVariations[i]) return null;
                         return (
-                          <Fragment key={`users-group-${i}`}>
+                          <Fragment key={`users-group-${v.index}`}>
                             <LinePath
-                              key={`linepath-expectedUsers-${i}`}
+                              key={`linepath-expectedUsers-${v.index}`}
                               data={data}
                               x={(d) => xScale(d.date)}
                               y={(d) => yScale(d.expectedUsers?.[i] ?? 0)}
-                              stroke={getVariationColor(i, true)}
+                              stroke={getVariationColor(v.index, true)}
                               strokeWidth={2}
                               strokeDasharray={"2,5"}
                               curve={curveMonotoneX}
                             />
                             <LinePath
-                              key={`linepath-users-${i}`}
+                              key={`linepath-users-${v.index}`}
                               data={data}
                               x={(d) => xScale(d.date)}
                               y={(d) => yScale(d.users?.[i] ?? 0)}
-                              stroke={getVariationColor(i, true)}
+                              stroke={getVariationColor(v.index, true)}
                               strokeWidth={2}
                               curve={curveMonotoneX}
                             />
                             <AreaClosed
-                              key={`users-delta-${i}`}
+                              key={`users-delta-${v.index}`}
                               yScale={yScale}
                               data={data}
                               x={(d) => xScale(d.date)}
                               y0={(d) => yScale(d.expectedUsers?.[i] ?? 0)}
                               y1={(d) => yScale(d.users?.[i] ?? 0)}
-                              fill={getVariationColor(i, true)}
+                              fill={getVariationColor(v.index, true)}
                               opacity={0.12}
                               curve={curveMonotoneX}
                             />
@@ -513,38 +512,38 @@ const BanditSRMGraph: FC<BanditSRMGraphProps> = ({
                     : null}
 
                   {mode === "weights"
-                    ? variationNames.map((_, i) => {
+                    ? variations.map((v, i) => {
                         if (!showVariations[i]) return null;
                         return (
-                          <Fragment key={`weights-group-${i}`}>
+                          <Fragment key={`weights-group-${v.index}`}>
                             <LinePath
-                              key={`linepath-weights-${i}`}
+                              key={`linepath-weights-${v.index}`}
                               data={data}
                               x={(d) => xScale(d.date)}
                               y={(d) => yScale(d.weights?.[i] ?? 0)}
-                              stroke={getVariationColor(i, true)}
+                              stroke={getVariationColor(v.index, true)}
                               strokeWidth={2}
                               curve={curveStepAfter}
                             />
                             <LinePath
-                              key={`linepath-userRatios-${i}`}
+                              key={`linepath-userRatios-${v.index}`}
                               data={data}
                               x={(d) => xScale(d.date)}
                               y={(d) => yScale(d.userRatios?.[i] ?? 0)}
-                              stroke={getVariationColor(i, true)}
+                              stroke={getVariationColor(v.index, true)}
                               strokeWidth={2}
                               strokeDasharray={"2,5"}
                               curve={curveStepAfter}
                               defined={(d) => d.userRatios?.[i] !== undefined}
                             />
                             <AreaClosed
-                              key={`weights-delta-${i}`}
+                              key={`weights-delta-${v.index}`}
                               yScale={yScale}
                               data={data}
                               x={(d) => xScale(d.date)}
                               y0={(d) => yScale(d.weights?.[i] ?? 0)}
                               y1={(d) => yScale(d.userRatios?.[i] ?? 0)}
-                              fill={getVariationColor(i, true)}
+                              fill={getVariationColor(v.index, true)}
                               opacity={0.12}
                               curve={curveStepAfter}
                               defined={(d) => d.userRatios?.[i] !== undefined}

--- a/packages/front-end/components/HealthTab/TrafficCard.tsx
+++ b/packages/front-end/components/HealthTab/TrafficCard.tsx
@@ -251,7 +251,7 @@ export default function TrafficCard({
         <div className="mt-2 mb-2">
           <ExperimentDateGraph
             yaxis="users"
-            variationNames={variations.map((v) => v.name)}
+            variations={variations}
             label="Units"
             datapoints={usersPerDate}
             formatter={formatNumber}

--- a/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardBlock/ExperimentTimeSeriesBlock.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardBlock/ExperimentTimeSeriesBlock.tsx
@@ -152,7 +152,6 @@ export default function ExperimentTimeSeriesBlock({
               const showVariations = variations.map(
                 (v) => variationIds.length === 0 || variationIds.includes(v.id),
               );
-              const variationNames = variations.map(({ name }) => name);
 
               // Check if this metric has slices and if it's expanded
               const expandedKey = `${metric.id}:${resultGroup}`;
@@ -197,7 +196,7 @@ export default function ExperimentTimeSeriesBlock({
                           analysis?.settings.differenceType || "relative"
                         }
                         showVariations={showVariations}
-                        variationNames={variationNames}
+                        variations={variations}
                         statsEngine={statsEngine}
                         pValueAdjustmentEnabled={!!appliedPValueCorrection}
                         firstDateToRender={phaseStartDate}
@@ -242,7 +241,7 @@ export default function ExperimentTimeSeriesBlock({
                               analysis?.settings.differenceType || "relative"
                             }
                             showVariations={showVariations}
-                            variationNames={variationNames}
+                            variations={variations}
                             statsEngine={statsEngine}
                             pValueAdjustmentEnabled={!!appliedPValueCorrection}
                             firstDateToRender={phaseStartDate}


### PR DESCRIPTION
### Features and Changes

Recently we ensured all variations returned from an experiment have the index from the main `experiment.variations` object using helpers like `getLatestPhaseVariations`. This means we can sometimes delete the 1st variation and only have the 0th and 2nd. To compensate for this, we need to build the index and pass it to our graph components instead of relying on an array of variation names alone.

This PR achieves that with the main components.

This shouldn't affect any users, as none of them have "disabled" variations yet.

- Closes **(add link to issue here)**

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

<!--
  Please describe how to test these changes.
 -->

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
