### PR TITLE
Fix experiment import search when tracking keys are duplicated

### DIFF
--- a/packages/front-end/services/search.tsx
+++ b/packages/front-end/services/search.tsx
@@ -121,7 +121,7 @@ export function useSearch<T extends { id: string }>({
   // We only want to re-create the MiniSearch instance if the fields actually changed
   // It's really easy to forget to add `useMemo` around the fields declaration
   // So, we turn it into a string here to use in the dependency array
-  const { miniSearch, indexedItemMap } = useMemo(() => {
+  const { miniSearch, itemMap } = useMemo(() => {
     const keys: Record<string, number> = Object.fromEntries(
       searchFields.map((f) => {
         const [key, weight] = (f as string).split("^");
@@ -135,10 +135,10 @@ export function useSearch<T extends { id: string }>({
     // Some lists can contain duplicate business IDs (e.g. experiment tracking keys),
     // so we store a separate internal ID only for indexing.
     const internalSearchIdField = "__gb_search_id";
-    const indexedItemMap = new Map<string, T>();
+    const itemMap = new Map<string, T>();
     const indexedItems = items.map((item, index) => {
       const indexedId = `${item.id}::${index}`;
-      indexedItemMap.set(indexedId, item);
+      itemMap.set(indexedId, item);
       return {
         ...item,
         [internalSearchIdField]: indexedId,
@@ -162,7 +162,7 @@ export function useSearch<T extends { id: string }>({
       console.error("Error adding items to search index:", error);
     }
 
-    return { miniSearch: miniSearchInstance, indexedItemMap };
+    return { miniSearch: miniSearchInstance, itemMap };
   }, [items, JSON.stringify(searchFields)]);
 
   const { filtered, syntaxFilters, searchTerm } = useMemo(() => {
@@ -175,7 +175,7 @@ export function useSearch<T extends { id: string }>({
     if (searchTerm.length > 0) {
       const searchResults = miniSearch.search(searchTerm);
       filtered = searchResults
-        .map((result) => indexedItemMap.get(result.id + ""))
+        .map((result) => itemMap.get(result.id + ""))
         .filter((item): item is T => !!item);
     }
     if (updateSearchQueryOnChange) {

--- a/packages/front-end/test/services/search.test.ts
+++ b/packages/front-end/test/services/search.test.ts
@@ -362,9 +362,9 @@ describe("useSearch", () => {
 
     it("searches all rows even when ids are duplicated", () => {
       const items: SearchItem[] = [
-        { id: "dup", name: "firstrowtoken" },
-        { id: "dup", name: "secondrowtoken" },
-        { id: "unique", name: "othertoken" },
+        { id: "dup", name: "first row token" },
+        { id: "dup", name: "second row token" },
+        { id: "unique", name: "other token" },
       ];
 
       const { result } = renderHook(() =>
@@ -377,19 +377,45 @@ describe("useSearch", () => {
       );
 
       act(() => {
-        result.current.setSearchValue("secondrowtoken");
+        result.current.setSearchValue("second row token");
       });
-      expect(
-        result.current.unpaginatedItems.map((item) => item.name),
-      ).toContain("secondrowtoken");
+      expect(result.current.filteredItems.length).toBe(3);
+      expect(result.current.filteredItems.map((i) => i.name)).toStrictEqual([
+        "second row token",
+        "first row token",
+        "other token",
+      ]);
+      expect(result.current.filteredItems.map((i) => i.id)).toStrictEqual([
+        "dup",
+        "dup",
+        "unique",
+      ]);
 
       act(() => {
         result.current.setSearchValue("second");
       });
-      expect(
-        result.current.unpaginatedItems.map((item) => item.name),
-      ).toContain("secondrowtoken");
-      expect(result.current.unpaginatedItems[0]?.id).toBe("dup");
+      expect(result.current.filteredItems.length).toBe(1);
+      expect(result.current.filteredItems[0]?.id).toBe("dup");
+      expect(result.current.filteredItems[0]?.name).toBe("second row token");
+
+      act(() => {
+        result.current.setSearchValue("row");
+      });
+      expect(result.current.filteredItems.length).toBe(2);
+      expect(result.current.filteredItems.map((i) => i.name)).toStrictEqual([
+        "first row token",
+        "second row token",
+      ]);
+
+      act(() => {
+        result.current.setSearchValue("token");
+      });
+      expect(result.current.filteredItems.length).toBe(3);
+      expect(result.current.filteredItems.map((i) => i.name)).toStrictEqual([
+        "other token",
+        "first row token",
+        "second row token",
+      ]);
     });
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Features and Changes

- Fixes `useSearch` indexing to avoid MiniSearch duplicate-ID collisions when list items share the same business `id`.
- Uses an internal per-row indexed ID (`${id}::${index}`) for the search index while preserving original item objects in results.
- Uses MiniSearch `idField` with a dedicated internal field (`__gb_search_id`) so item `id` is never overwritten in indexed docs.
- Adds a regression test proving both exact-token and partial-token searches still return rows when duplicate IDs are present.
- Adds a regression assertion confirming returned results preserve original item IDs (safe for link construction).
- Applies CI-requested Prettier formatting to the new duplicate-ID test assertions.

- Closes **(add link to issue here)**

### Dependencies

None.

### Testing

- Ran focused front-end test suite:
  - `pnpm --filter front-end test test/services/search.test.ts`
- Ran Prettier check on updated file:
  - `pnpm --filter front-end exec prettier --check test/services/search.test.ts`

### Screenshots

N/A (no UI changes).
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://growthbookapp.slack.com/archives/C07NK4F016Z/p1774303478876219?thread_ts=1774303478.876219&cid=C07NK4F016Z)

<div><a href="https://cursor.com/agents/bc-87477bcb-90f8-5785-ac09-945d977024cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-87477bcb-90f8-5785-ac09-945d977024cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

