### PR TITLE
chore(eslint): Prevent import from controllers

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -343,6 +343,59 @@ export default defineConfig([
     },
   },
   {
+    files: [
+      "./packages/back-end/src/controllers/**/*.ts",
+      "./packages/back-end/src/routers/**/*.controller.ts",
+      "./packages/back-end/src/enterprise/routers/**/*.controller.ts",
+    ],
+
+    rules: {
+      "import/no-restricted-paths": [
+        "error",
+        {
+          zones: [
+            {
+              target: "./packages/back-end/src/controllers/**/*.ts",
+              from: "./packages/back-end/src/controllers",
+              message:
+                "Controllers must not import other controllers. Move shared logic into services/, models/, or util/.",
+            },
+            {
+              target: "./packages/back-end/src/controllers/**/*.ts",
+              from: [
+                "./packages/back-end/src/routers/**/*.controller.ts",
+                "./packages/back-end/src/enterprise/routers/**/*.controller.ts",
+              ],
+              message:
+                "Controllers must not import other controllers. Move shared logic into services/, models/, or util/.",
+            },
+            {
+              target: [
+                "./packages/back-end/src/routers/**/*.controller.ts",
+                "./packages/back-end/src/enterprise/routers/**/*.controller.ts",
+              ],
+              from: "./packages/back-end/src/controllers",
+              message:
+                "Controllers must not import other controllers. Move shared logic into services/, models/, or util/.",
+            },
+            {
+              target: [
+                "./packages/back-end/src/routers/**/*.controller.ts",
+                "./packages/back-end/src/enterprise/routers/**/*.controller.ts",
+              ],
+              from: [
+                "./packages/back-end/src/routers/**/*.controller.ts",
+                "./packages/back-end/src/enterprise/routers/**/*.controller.ts",
+              ],
+              message:
+                "Controllers must not import other controllers. Move shared logic into services/, models/, or util/.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
     files: ["./packages/shared/**/*"],
 
     rules: {

--- a/packages/back-end/src/api/experiments/postExperiment.ts
+++ b/packages/back-end/src/api/experiments/postExperiment.ts
@@ -15,11 +15,11 @@ import { getDataSourceById } from "back-end/src/models/DataSourceModel";
 import {
   postExperimentApiPayloadToInterface,
   toExperimentApiInterface,
+  validateVariationIds,
 } from "back-end/src/services/experiments";
 import { createApiRequestHandler } from "back-end/src/util/handler";
 import { getUserByEmail } from "back-end/src/models/UserModel";
 import { getMetricMap } from "back-end/src/models/MetricModel";
-import { validateVariationIds } from "back-end/src/controllers/experiments";
 import { validateCustomFields } from "./validations";
 
 const TEMPLATE_FIELDS_TO_OMIT = [

--- a/packages/back-end/src/api/experiments/postExperimentSnapshot.ts
+++ b/packages/back-end/src/api/experiments/postExperimentSnapshot.ts
@@ -1,9 +1,9 @@
 import { postExperimentSnapshotValidator } from "shared/validators";
 import { PostExperimentSnapshotResponse } from "shared/types/openapi";
-import { createExperimentSnapshot } from "back-end/src/controllers/experiments";
 import { getDataSourceById } from "back-end/src/models/DataSourceModel";
 import { getExperimentById } from "back-end/src/models/ExperimentModel";
 import { auditDetailsCreate } from "back-end/src/services/audit";
+import { createExperimentSnapshot } from "back-end/src/services/experiments";
 import { createApiRequestHandler } from "back-end/src/util/handler";
 
 // TODO update params (add phase, useCache)

--- a/packages/back-end/src/api/experiments/updateExperiment.ts
+++ b/packages/back-end/src/api/experiments/updateExperiment.ts
@@ -14,12 +14,12 @@ import {
 import {
   toExperimentApiInterface,
   updateExperimentApiPayloadToInterface,
+  validateVariationIds,
 } from "back-end/src/services/experiments";
 import { auditDetailsUpdate } from "back-end/src/services/audit";
 import { createApiRequestHandler } from "back-end/src/util/handler";
 import { shouldValidateCustomFieldsOnUpdate } from "back-end/src/util/custom-fields";
 import { getMetricMap } from "back-end/src/models/MetricModel";
-import { validateVariationIds } from "back-end/src/controllers/experiments";
 import { validateCustomFields } from "./validations";
 
 export const updateExperiment = createApiRequestHandler(

--- a/packages/back-end/src/controllers/admin.ts
+++ b/packages/back-end/src/controllers/admin.ts
@@ -24,8 +24,8 @@ import {
 import {
   getContextFromReq,
   getOrganizationById,
+  setLicenseKey,
 } from "back-end/src/services/organizations";
-import { setLicenseKey } from "back-end/src/routers/organizations/organizations.controller";
 import {
   auditDetailsCreate,
   auditDetailsUpdate,

--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -1,5 +1,4 @@
 import { Response } from "express";
-import uniqid from "uniqid";
 import format from "date-fns/format";
 import cloneDeep from "lodash/cloneDeep";
 import { DEFAULT_SEQUENTIAL_TESTING_TUNING_PARAMETER } from "shared/constants";
@@ -13,16 +12,14 @@ import {
   expandAllSliceMetricsInMap,
   expandMetricGroups,
   getAllMetricIdsFromExperiment,
-  getAllMetricSettingsForSnapshot,
   getAllVariations,
 } from "shared/experiments";
 import { getScopedSettings } from "shared/settings";
 import { v4 as uuidv4 } from "uuid";
-import uniq from "lodash/uniq";
 import { IdeaInterface } from "shared/types/idea";
 import { VisualChangesetInterface } from "shared/types/visual-changeset";
 import { DataSourceInterface } from "shared/types/datasource";
-import { MetricInterface, MetricStats } from "shared/types/metric";
+import { MetricStats } from "shared/types/metric";
 import {
   Changeset,
   ExperimentInterface,
@@ -31,16 +28,13 @@ import {
   ExperimentStatus,
   ExperimentTargetingData,
   ExperimentType,
-  Variation,
 } from "shared/types/experiment";
 import {
   ExperimentSnapshotAnalysisSettings,
   ExperimentSnapshotInterface,
-  SnapshotTriggeredBy,
   SnapshotType,
 } from "shared/types/experiment-snapshot";
 import { EventUserForResponseLocals } from "shared/types/events/event-types";
-import { OrganizationSettings } from "shared/types/organization";
 import { CreateURLRedirectProps } from "shared/types/url-redirect";
 import { getMetricMap } from "back-end/src/models/MetricModel";
 import {
@@ -49,20 +43,16 @@ import {
 } from "back-end/src/types/AuthRequest";
 import {
   _getSnapshots,
-  createSnapshotFromPlan,
   createSnapshotAnalyses,
   createSnapshotAnalysis,
   determineNextBanditSchedule,
-  ExperimentSnapshotQueryRunner,
-  getAdditionalExperimentAnalysisSettings,
   getChangesToStartExperiment,
-  getDefaultExperimentAnalysisSettings,
   getLinkedFeatureInfo,
-  PlannedExperimentSnapshot,
-  planSnapshot,
   resetExperimentBanditSettings,
   SnapshotAnalysisParams,
+  createExperimentSnapshot,
   updateExperimentBanditSettings,
+  validateVariationIds,
   validateExperimentData,
 } from "back-end/src/services/experiments";
 import {
@@ -1021,21 +1011,6 @@ export async function getSnapshots(
     snapshots: snapshots,
   });
   return;
-}
-
-export function validateVariationIds(variations: Variation[]) {
-  variations.forEach((variation, i) => {
-    if (!variation.id) {
-      variation.id = uniqid("var_");
-    }
-    if (!variation.key) {
-      variation.key = i + "";
-    }
-  });
-  const keys = variations.map((v) => v.key);
-  if (keys.length !== new Set(keys).size) {
-    throw new Error("Variation keys must be unique");
-  }
 }
 
 /**
@@ -2876,222 +2851,6 @@ export async function cancelSnapshot(
     );
 
   res.status(200).json({ status: 200 });
-}
-
-function getSnapshotType({
-  experiment,
-  dimension,
-  phaseIndex,
-}: {
-  experiment: ExperimentInterface;
-  dimension: string | undefined;
-  phaseIndex: number;
-}): SnapshotType {
-  // dimension analyses are ad-hoc
-  if (dimension) {
-    return "exploratory";
-  }
-
-  // analyses of old phases are ad-hoc
-  if (phaseIndex !== experiment.phases.length - 1) {
-    return "exploratory";
-  }
-
-  return "standard";
-}
-
-export async function createExperimentSnapshot({
-  context,
-  experiment,
-  datasource,
-  dimension,
-  phase,
-  useCache = true,
-  triggeredBy,
-  type,
-  reweight,
-  allowIncrementalRefresh = true,
-}: {
-  context: ReqContext;
-  experiment: ExperimentInterface;
-  datasource: DataSourceInterface;
-  dimension: string | undefined;
-  phase: number;
-  useCache?: boolean;
-  triggeredBy?: SnapshotTriggeredBy;
-  type?: SnapshotType;
-  reweight?: boolean;
-  allowIncrementalRefresh?: boolean;
-}): Promise<{
-  snapshot: ExperimentSnapshotInterface;
-  queryRunner: ExperimentSnapshotQueryRunner;
-}> {
-  const plan = await planExperimentSnapshot({
-    context,
-    experiment,
-    datasource,
-    dimension,
-    phase,
-    useCache,
-    triggeredBy,
-    type,
-    reweight,
-    allowIncrementalRefresh,
-  });
-
-  return createExperimentSnapshotFromPlan({
-    plan,
-    context,
-    experiment,
-  });
-}
-
-export async function createExperimentSnapshotFromPlan({
-  plan,
-  context,
-  experiment,
-}: {
-  plan: PlannedExperimentSnapshot;
-  context: ReqContext;
-  experiment: ExperimentInterface;
-}): Promise<{
-  snapshot: ExperimentSnapshotInterface;
-  queryRunner: ExperimentSnapshotQueryRunner;
-}> {
-  const metricMap = await getMetricMap(context);
-  const factTableMap = await getFactTableMap(context);
-  const metricGroups = await context.models.metricGroups.getAll();
-
-  expandAllSliceMetricsInMap({
-    metricMap,
-    factTableMap,
-    experiment,
-    metricGroups,
-  });
-
-  const queryRunner = await createSnapshotFromPlan({
-    plan,
-    context,
-    experiment,
-    metricMap,
-    factTableMap,
-  });
-  return { snapshot: queryRunner.model, queryRunner };
-}
-
-export async function planExperimentSnapshot({
-  context,
-  experiment,
-  datasource,
-  dimension,
-  phase,
-  useCache = true,
-  triggeredBy,
-  type,
-  reweight,
-  allowIncrementalRefresh = true,
-}: {
-  context: ReqContext;
-  experiment: ExperimentInterface;
-  datasource: DataSourceInterface;
-  dimension: string | undefined;
-  phase: number;
-  useCache?: boolean;
-  triggeredBy?: SnapshotTriggeredBy;
-  type?: SnapshotType;
-  reweight?: boolean;
-  allowIncrementalRefresh?: boolean;
-}): Promise<PlannedExperimentSnapshot> {
-  const snapshotType =
-    type ??
-    getSnapshotType({
-      experiment,
-      dimension,
-      phaseIndex: phase,
-    });
-
-  let project = null;
-  if (experiment.project) {
-    project = await context.models.projects.getById(experiment.project);
-  }
-
-  const { org } = context;
-  const orgSettings: OrganizationSettings =
-    org.settings as OrganizationSettings;
-  const { settings } = getScopedSettings({
-    organization: org,
-    project: project ?? undefined,
-    experiment,
-  });
-  const statsEngine = settings.statsEngine.value;
-  const postStratificationEnabled = settings.postStratificationEnabled.value;
-  const metricMap = await getMetricMap(context);
-  const factTableMap = await getFactTableMap(context);
-
-  const metricGroups = await context.models.metricGroups.getAll();
-  const metricIds = getAllMetricIdsFromExperiment(
-    experiment,
-    false,
-    metricGroups,
-  );
-
-  const allExperimentMetrics = metricIds.map((m) => metricMap.get(m) || null);
-
-  const denominatorMetricIds = uniq<string>(
-    allExperimentMetrics
-      .map((m) => m?.denominator)
-      .filter((d) => d && typeof d === "string") as string[],
-  );
-  const denominatorMetrics = denominatorMetricIds
-    .map((m) => metricMap.get(m) || null)
-    .filter(isDefined) as MetricInterface[];
-
-  const { settingsForSnapshotMetrics, regressionAdjustmentEnabled } =
-    getAllMetricSettingsForSnapshot({
-      allExperimentMetrics,
-      denominatorMetrics,
-      orgSettings,
-      experimentRegressionAdjustmentEnabled:
-        experiment.regressionAdjustmentEnabled,
-      experimentMetricOverrides: experiment.metricOverrides,
-      datasourceType: datasource?.type,
-      hasRegressionAdjustmentFeature: true,
-      ...(experiment.type === "multi-armed-bandit"
-        ? {
-            banditConversionWindowValue:
-              experiment.banditConversionWindowValue ?? undefined,
-            banditConversionWindowUnit:
-              experiment.banditConversionWindowUnit ?? undefined,
-          }
-        : {}),
-    });
-
-  const analysisSettings = getDefaultExperimentAnalysisSettings({
-    statsEngine,
-    experiment,
-    organization: org,
-    regressionAdjustmentEnabled,
-    postStratificationEnabled,
-    dimension,
-  });
-
-  const plan = await planSnapshot({
-    experiment,
-    context,
-    phaseIndex: phase,
-    useCache,
-    defaultAnalysisSettings: analysisSettings,
-    additionalAnalysisSettings:
-      getAdditionalExperimentAnalysisSettings(analysisSettings),
-    settingsForSnapshotMetrics,
-    metricMap,
-    factTableMap,
-    reweight,
-    type: snapshotType,
-    triggeredBy: triggeredBy ?? "manual",
-    allowIncrementalRefresh,
-  });
-  return plan;
 }
 
 export async function postSnapshot(

--- a/packages/back-end/src/routers/attributes/attributes.controller.ts
+++ b/packages/back-end/src/routers/attributes/attributes.controller.ts
@@ -6,7 +6,6 @@ import { getContextFromReq } from "back-end/src/services/organizations";
 import { updateOrganization } from "back-end/src/models/OrganizationModel";
 import { auditDetailsUpdate } from "back-end/src/services/audit";
 import { addTags, addTagsDiff } from "back-end/src/models/TagModel";
-import { ReqContext } from "back-end/types/request";
 import { getAllFeatures } from "back-end/src/models/FeatureModel";
 import { getAllExperiments } from "back-end/src/models/ExperimentModel";
 
@@ -349,26 +348,3 @@ export const getAttributeReferences = async (
 
   return res.status(200).json({ status: 200, references });
 };
-
-export async function removeTagInAttribute(
-  context: ReqContext,
-  tag: string,
-): Promise<void> {
-  const { org } = context;
-  const attributeSchema = org.settings?.attributeSchema || [];
-
-  const hasTag = attributeSchema.some((a) => (a.tags || []).includes(tag));
-  if (!hasTag) return;
-
-  const updatedAttributeSchema = attributeSchema.map((attr) => ({
-    ...attr,
-    tags: (attr.tags || []).filter((t) => t !== tag),
-  }));
-
-  await updateOrganization(org.id, {
-    settings: {
-      ...org.settings,
-      attributeSchema: updatedAttributeSchema,
-    },
-  });
-}

--- a/packages/back-end/src/routers/dashboards/dashboards.controller.ts
+++ b/packages/back-end/src/routers/dashboards/dashboards.controller.ts
@@ -21,7 +21,7 @@ import {
   createExperimentSnapshot,
   createExperimentSnapshotFromPlan,
   planExperimentSnapshot,
-} from "back-end/src/controllers/experiments";
+} from "back-end/src/services/experiments";
 import { getExperimentById } from "back-end/src/models/ExperimentModel";
 import { getDataSourceById } from "back-end/src/models/DataSourceModel";
 import { findSnapshotsByIds } from "back-end/src/models/ExperimentSnapshotModel";

--- a/packages/back-end/src/routers/holdout/holdout.controller.ts
+++ b/packages/back-end/src/routers/holdout/holdout.controller.ts
@@ -39,11 +39,9 @@ import {
 import { logger } from "back-end/src/util/logger";
 import {
   createExperimentSnapshot,
-  validateVariationIds,
-} from "back-end/src/controllers/experiments";
-import {
   getChangesToStartExperiment,
   validateExperimentData,
+  validateVariationIds,
 } from "back-end/src/services/experiments";
 import { auditDetailsCreate } from "back-end/src/services/audit";
 import { PrivateApiErrorResponse } from "back-end/types/api";

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -47,6 +47,7 @@ import {
   isEnterpriseSSO,
   removeMember,
   revokeInvite,
+  setLicenseKey,
 } from "back-end/src/services/organizations";
 import {
   getNonSensitiveParams,
@@ -2170,20 +2171,6 @@ export async function putAdminResetUserPassword(
   res.status(200).json({
     status: 200,
   });
-}
-
-export async function setLicenseKey(
-  org: OrganizationInterface,
-  licenseKey: string,
-) {
-  if (!IS_CLOUD && IS_MULTI_ORG) {
-    throw new Error(
-      "You must use the LICENSE_KEY environmental variable on multi org sites.",
-    );
-  }
-
-  org.licenseKey = licenseKey;
-  await licenseInit(org, getUserCodesForOrg, getLicenseMetaData, true);
 }
 
 export async function putLicenseKey(

--- a/packages/back-end/src/routers/tag/tag.controller.ts
+++ b/packages/back-end/src/routers/tag/tag.controller.ts
@@ -8,7 +8,7 @@ import { addTag, removeTag } from "back-end/src/models/TagModel";
 import { removeTagInMetrics } from "back-end/src/models/MetricModel";
 import { removeTagInFeature } from "back-end/src/models/FeatureModel";
 import { removeTagFromSlackIntegration } from "back-end/src/models/SlackIntegrationModel";
-import { removeTagInAttribute } from "back-end/src/routers/attributes/attributes.controller";
+import { removeTagInAttribute } from "back-end/src/services/attributes";
 import { removeTagFromExperiments } from "back-end/src/models/ExperimentModel";
 
 // region POST /tag

--- a/packages/back-end/src/services/attributes.ts
+++ b/packages/back-end/src/services/attributes.ts
@@ -1,0 +1,25 @@
+import { updateOrganization } from "back-end/src/models/OrganizationModel";
+import { ReqContext } from "back-end/types/request";
+
+export async function removeTagInAttribute(
+  context: ReqContext,
+  tag: string,
+): Promise<void> {
+  const { org } = context;
+  const attributeSchema = org.settings?.attributeSchema || [];
+
+  const hasTag = attributeSchema.some((a) => (a.tags || []).includes(tag));
+  if (!hasTag) return;
+
+  const updatedAttributeSchema = attributeSchema.map((attr) => ({
+    ...attr,
+    tags: (attr.tags || []).filter((t) => t !== tag),
+  }));
+
+  await updateOrganization(org.id, {
+    settings: {
+      ...org.settings,
+      attributeSchema: updatedAttributeSchema,
+    },
+  });
+}

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -2,6 +2,7 @@ import uniqid from "uniqid";
 import cronParser from "cron-parser";
 import { z } from "zod";
 import { isEqual } from "lodash";
+import uniq from "lodash/uniq";
 import cloneDeep from "lodash/cloneDeep";
 import {
   DEFAULT_LOOKBACK_OVERRIDE_VALUE_UNIT,
@@ -34,6 +35,7 @@ import {
   ExperimentMetricInterface,
   getAllMetricIdsFromExperiment,
   getAllExpandedMetricIdsFromExperiment,
+  getAllMetricSettingsForSnapshot,
   expandAllSliceMetricsInMap,
   getEqualWeights,
   getEffectiveLookbackOverride,
@@ -101,10 +103,12 @@ import {
   LinkedFeatureEnvState,
   LinkedFeatureInfo,
   LinkedFeatureState,
+  Variation,
 } from "shared/types/experiment";
 import {
   ExperimentUpdateSchedule,
   OrganizationInterface,
+  OrganizationSettings,
 } from "shared/types/organization";
 import { DataSourceInterface, ExposureQuery } from "shared/types/datasource";
 import {
@@ -1530,6 +1534,237 @@ export async function createSnapshot({
     metricMap,
     factTableMap,
   });
+}
+
+export function validateVariationIds(variations: Variation[]) {
+  variations.forEach((variation, i) => {
+    if (!variation.id) {
+      variation.id = uniqid("var_");
+    }
+    if (!variation.key) {
+      variation.key = i + "";
+    }
+  });
+  const keys = variations.map((v) => v.key);
+  if (keys.length !== new Set(keys).size) {
+    throw new Error("Variation keys must be unique");
+  }
+}
+
+function getSnapshotType({
+  experiment,
+  dimension,
+  phaseIndex,
+}: {
+  experiment: ExperimentInterface;
+  dimension: string | undefined;
+  phaseIndex: number;
+}): SnapshotType {
+  // dimension analyses are ad-hoc
+  if (dimension) {
+    return "exploratory";
+  }
+
+  // analyses of old phases are ad-hoc
+  if (phaseIndex !== experiment.phases.length - 1) {
+    return "exploratory";
+  }
+
+  return "standard";
+}
+
+export async function createExperimentSnapshot({
+  context,
+  experiment,
+  datasource,
+  dimension,
+  phase,
+  useCache = true,
+  triggeredBy,
+  type,
+  reweight,
+  allowIncrementalRefresh = true,
+}: {
+  context: ReqContext;
+  experiment: ExperimentInterface;
+  datasource: DataSourceInterface;
+  dimension: string | undefined;
+  phase: number;
+  useCache?: boolean;
+  triggeredBy?: SnapshotTriggeredBy;
+  type?: SnapshotType;
+  reweight?: boolean;
+  allowIncrementalRefresh?: boolean;
+}): Promise<{
+  snapshot: ExperimentSnapshotInterface;
+  queryRunner: ExperimentSnapshotQueryRunner;
+}> {
+  const plan = await planExperimentSnapshot({
+    context,
+    experiment,
+    datasource,
+    dimension,
+    phase,
+    useCache,
+    triggeredBy,
+    type,
+    reweight,
+    allowIncrementalRefresh,
+  });
+
+  return createExperimentSnapshotFromPlan({
+    plan,
+    context,
+    experiment,
+  });
+}
+
+export async function createExperimentSnapshotFromPlan({
+  plan,
+  context,
+  experiment,
+}: {
+  plan: PlannedExperimentSnapshot;
+  context: ReqContext;
+  experiment: ExperimentInterface;
+}): Promise<{
+  snapshot: ExperimentSnapshotInterface;
+  queryRunner: ExperimentSnapshotQueryRunner;
+}> {
+  const metricMap = await getMetricMap(context);
+  const factTableMap = await getFactTableMap(context);
+  const metricGroups = await context.models.metricGroups.getAll();
+
+  expandAllSliceMetricsInMap({
+    metricMap,
+    factTableMap,
+    experiment,
+    metricGroups,
+  });
+
+  const queryRunner = await createSnapshotFromPlan({
+    plan,
+    context,
+    experiment,
+    metricMap,
+    factTableMap,
+  });
+  return { snapshot: queryRunner.model, queryRunner };
+}
+
+export async function planExperimentSnapshot({
+  context,
+  experiment,
+  datasource,
+  dimension,
+  phase,
+  useCache = true,
+  triggeredBy,
+  type,
+  reweight,
+  allowIncrementalRefresh = true,
+}: {
+  context: ReqContext;
+  experiment: ExperimentInterface;
+  datasource: DataSourceInterface;
+  dimension: string | undefined;
+  phase: number;
+  useCache?: boolean;
+  triggeredBy?: SnapshotTriggeredBy;
+  type?: SnapshotType;
+  reweight?: boolean;
+  allowIncrementalRefresh?: boolean;
+}): Promise<PlannedExperimentSnapshot> {
+  const snapshotType =
+    type ??
+    getSnapshotType({
+      experiment,
+      dimension,
+      phaseIndex: phase,
+    });
+
+  let project = null;
+  if (experiment.project) {
+    project = await context.models.projects.getById(experiment.project);
+  }
+
+  const { org } = context;
+  const orgSettings: OrganizationSettings =
+    org.settings as OrganizationSettings;
+  const { settings } = getScopedSettings({
+    organization: org,
+    project: project ?? undefined,
+    experiment,
+  });
+  const statsEngine = settings.statsEngine.value;
+  const postStratificationEnabled = settings.postStratificationEnabled.value;
+  const metricMap = await getMetricMap(context);
+  const factTableMap = await getFactTableMap(context);
+
+  const metricGroups = await context.models.metricGroups.getAll();
+  const metricIds = getAllMetricIdsFromExperiment(
+    experiment,
+    false,
+    metricGroups,
+  );
+
+  const allExperimentMetrics = metricIds.map((m) => metricMap.get(m) || null);
+
+  const denominatorMetricIds = uniq<string>(
+    allExperimentMetrics
+      .map((m) => m?.denominator)
+      .filter((d) => d && typeof d === "string") as string[],
+  );
+  const denominatorMetrics = denominatorMetricIds
+    .map((m) => metricMap.get(m) || null)
+    .filter(isDefined) as MetricInterface[];
+
+  const { settingsForSnapshotMetrics, regressionAdjustmentEnabled } =
+    getAllMetricSettingsForSnapshot({
+      allExperimentMetrics,
+      denominatorMetrics,
+      orgSettings,
+      experimentRegressionAdjustmentEnabled:
+        experiment.regressionAdjustmentEnabled,
+      experimentMetricOverrides: experiment.metricOverrides,
+      datasourceType: datasource?.type,
+      hasRegressionAdjustmentFeature: true,
+      ...(experiment.type === "multi-armed-bandit"
+        ? {
+            banditConversionWindowValue:
+              experiment.banditConversionWindowValue ?? undefined,
+            banditConversionWindowUnit:
+              experiment.banditConversionWindowUnit ?? undefined,
+          }
+        : {}),
+    });
+
+  const analysisSettings = getDefaultExperimentAnalysisSettings({
+    statsEngine,
+    experiment,
+    organization: org,
+    regressionAdjustmentEnabled,
+    postStratificationEnabled,
+    dimension,
+  });
+
+  const plan = await planSnapshot({
+    experiment,
+    context,
+    phaseIndex: phase,
+    useCache,
+    defaultAnalysisSettings: analysisSettings,
+    additionalAnalysisSettings:
+      getAdditionalExperimentAnalysisSettings(analysisSettings),
+    settingsForSnapshotMetrics,
+    metricMap,
+    factTableMap,
+    reweight,
+    type: snapshotType,
+    triggeredBy: triggeredBy ?? "manual",
+    allowIncrementalRefresh,
+  });
+  return plan;
 }
 
 export type SnapshotAnalysisParams = {

--- a/packages/back-end/src/services/organizations.ts
+++ b/packages/back-end/src/services/organizations.ts
@@ -53,7 +53,7 @@ import {
   findOrganizationsByDomain,
   updateOrganization,
 } from "back-end/src/models/OrganizationModel";
-import { APP_ORIGIN, IS_CLOUD } from "back-end/src/util/secrets";
+import { APP_ORIGIN, IS_CLOUD, IS_MULTI_ORG } from "back-end/src/util/secrets";
 import { AuthRequest } from "back-end/src/types/AuthRequest";
 import { ReqContext } from "back-end/types/request";
 import { ApiReqContext, ExperimentOverride } from "back-end/types/api";
@@ -99,6 +99,20 @@ export {
 
 export async function getOrganizationById(id: string) {
   return findOrganizationById(id);
+}
+
+export async function setLicenseKey(
+  org: OrganizationInterface,
+  licenseKey: string,
+) {
+  if (!IS_CLOUD && IS_MULTI_ORG) {
+    throw new Error(
+      "You must use the LICENSE_KEY environmental variable on multi org sites.",
+    );
+  }
+
+  org.licenseKey = licenseKey;
+  await licenseInit(org, getUserCodesForOrg, getLicenseMetaData, true);
 }
 
 export function validateLoginMethod(


### PR DESCRIPTION
### Features and Changes

Sometimes TypeScript suggests imports from controllers for functions we need, but that can create a bad type of coupling between disparate controllers, when ideally our controllers are thin and just take input and pass it into model/utils/services that contain the core business logic.

So now we have a ESLint rule to prevent this from happening again.