### PR TITLE
fix(api): Match previous behavior with assignmentQueryId

### DIFF
--- a/packages/back-end/src/api/experiments/postExperiment.ts
+++ b/packages/back-end/src/api/experiments/postExperiment.ts
@@ -107,7 +107,7 @@ export const postExperiment = createApiRequestHandler(postExperimentValidator)(
       };
     }
 
-    if (!payload.assignmentQueryId) {
+    if (payload.assignmentQueryId === undefined) {
       throw new Error(
         "assignmentQueryId is required unless provided by the template",
       );


### PR DESCRIPTION
### Features and Changes

A previous PR adding template support to `postExperiment` unintentionally made it required that `assignmentQueryId` be a truthy value. This PR changes the check to only throw an error if the value is undefined.
