### PR TITLE
Fix EnvironmentSelect permission check using wrong project

### DIFF
--- a/packages/front-end/components/Features/FeatureModal/EnvironmentSelect.tsx
+++ b/packages/front-end/components/Features/FeatureModal/EnvironmentSelect.tsx
@@ -11,9 +11,17 @@ const EnvironmentSelect: FC<{
   environments: Environment[];
   setValue: (env: Environment, enabled: boolean) => void;
   label?: string;
-}> = ({ environmentSettings, environments, setValue, label }) => {
+  project?: string;
+}> = ({
+  environmentSettings,
+  environments,
+  setValue,
+  label,
+  project: projectProp,
+}) => {
   const permissionsUtil = usePermissionsUtil();
-  const { project } = useDefinitions();
+  const { project: globalProject } = useDefinitions();
+  const project = projectProp ?? globalProject;
   const environmentsUserCanAccess = useMemo(() => {
     return environments.filter((env) => {
       return permissionsUtil.canPublishFeature({ project }, [env.id]);

--- a/packages/front-end/components/Features/FeatureModal/FeatureFromExperimentModal.tsx
+++ b/packages/front-end/components/Features/FeatureModal/FeatureFromExperimentModal.tsx
@@ -404,6 +404,7 @@ export default function FeatureFromExperimentModal({
           />
 
           <EnvironmentSelect
+            project={experiment.project}
             environmentSettings={environmentSettings}
             environments={environments}
             setValue={(env, on) => {

--- a/packages/front-end/components/Features/FeatureModal/index.tsx
+++ b/packages/front-end/components/Features/FeatureModal/index.tsx
@@ -376,6 +376,7 @@ export default function FeatureModal({
         )}
 
         <EnvironmentSelect
+          project={selectedProject}
           environmentSettings={environmentSettings}
           environments={environments}
           setValue={(env, on) => {

--- a/packages/front-end/components/Features/RuleModal/index.tsx
+++ b/packages/front-end/components/Features/RuleModal/index.tsx
@@ -939,6 +939,7 @@ export default function RuleModal({
 
         {environments.length > 1 && overviewRuleType !== "safe-rollout" && (
           <EnvironmentSelect
+            project={feature.project}
             environments={environments}
             environmentSettings={Object.fromEntries(
               environments.map((env) => [


### PR DESCRIPTION
## Problem

Users with project-scoped `publishFeatures` permission see all environment checkboxes disabled in the "Create Rule in Environments" selector. "Select All" appears force-checked but does nothing, with tooltip "You don't have permission to create features in this environment."

## Root cause

`EnvironmentSelect` reads `project` from `useDefinitions()` — the global nav project selector (localStorage `gb_current_project`), not the feature's own project.

When the global selector is "All Projects" (`""`) or a different project than the feature, `canPublishFeature({ project: "" }, [env])` checks global permissions, which fails for users with only project-scoped access.

The "Select All" checkbox appears force-checked because `[].every()` returns `true` when the accessible-environments array is empty.

## Fix

Add an optional `project` prop to `EnvironmentSelect` so callers pass the resource's own project. Falls back to the global selector when not provided (preserves existing behavior for holdout callers, which use multi-project and would need a separate fix).

Updated callers:
- `RuleModal` → `feature.project`
- `FeatureModal` → `selectedProject` (form value)
- `FeatureFromExperimentModal` → `experiment.project`