### PR TITLE
fix: copy jsonSchema when duplicating a feature

### DIFF
--- a/packages/front-end/components/Features/FeatureModal/index.tsx
+++ b/packages/front-end/components/Features/FeatureModal/index.tsx
@@ -101,6 +101,7 @@ const genFormDefaultValues = ({
   | "environmentSettings"
   | "customFields"
   | "holdout"
+  | "jsonSchema"
 > => {
   const environmentSettings = genEnvironmentSettings({
     environments,
@@ -130,6 +131,7 @@ const genFormDefaultValues = ({
         holdout: featureToDuplicate.holdout?.id
           ? featureToDuplicate.holdout
           : undefined,
+        jsonSchema: featureToDuplicate.jsonSchema,
       }
     : {
         valueType: "" as FeatureValueType,


### PR DESCRIPTION
## Summary
When duplicating a feature, the validation params (jsonSchema) were not being copied to the new feature, requiring users to manually recreate validation settings.

## Issue
Fixes #5407

## Changes
- Include `jsonSchema` in the duplicated feature properties within `genFormDefaultValues`

## Testing
- Duplicate a feature that has validation (jsonSchema) configured
- Verify the new feature preserves the validation settings