### PR TITLE
Fix feature requiresReview check when switching projects

### DIFF
--- a/packages/front-end/components/Features/FeaturesOverview.tsx
+++ b/packages/front-end/components/Features/FeaturesOverview.tsx
@@ -477,7 +477,7 @@ export default function FeaturesOverview({
     }
 
     requireReviews = checkIfRevisionNeedsReview({
-      feature,
+      feature: baseFeature,
       baseRevision: effectiveBase,
       revision: effectiveRevision,
       allEnvironments: environments.map((e) => e.id),


### PR DESCRIPTION
### Features and Changes

The bug: `checkIfRevisionNeedsReview` at FeaturesOverview.tsx:480 was being called with `feature`, the merged preview that already has the draft's project change applied. The function uses the feature's project field to look up which review rules apply via getReviewSetting().
                                                                                                                                                                                                                                                         
When a draft changes the project from "A" to "B":
  - The merged feature has project: "B", so getReviewSetting() looks for review rules matching project "B", which may not exist or may not require reviews
  - The back-end correctly uses the live feature (project: "A"), finds the review rule for project "A", and detects the metadata change

The fix: Pass baseFeature (the current live feature) instead of feature (the merged preview), matching the back-end's behavior.