### PR TITLE
Fix prerequisite targeting empty state styling

### DIFF
--- a/packages/front-end/components/Features/PrerequisiteInput.tsx
+++ b/packages/front-end/components/Features/PrerequisiteInput.tsx
@@ -901,7 +901,10 @@ export default function PrerequisiteInput({
                 : "not-allowed",
             }}
           >
-            <PiPlusCircleBold /> Add prerequisite targeting
+            <Text weight="bold">
+              <PiPlusCircleBold className="mr-1" />
+              Add prerequisite targeting
+            </Text>
           </Link>
         </PremiumTooltip>
       )}

--- a/packages/front-end/test/components/Features/PrerequisiteInput.test.tsx
+++ b/packages/front-end/test/components/Features/PrerequisiteInput.test.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { TooltipProvider } from "@radix-ui/react-tooltip";
+import { describe, it, beforeEach, vi, expect } from "vitest";
+import PrerequisiteInput from "@/components/Features/PrerequisiteInput";
+import { useFeatureMetaInfo } from "@/hooks/useFeatureMetaInfo";
+import { useDefinitions } from "@/services/DefinitionsContext";
+import { useUser } from "@/services/UserContext";
+import useSDKConnections from "@/hooks/useSDKConnections";
+import { useBatchPrerequisiteStates } from "@/hooks/usePrerequisiteStates";
+import { RadixTheme } from "@/services/RadixTheme";
+
+vi.mock("@/hooks/useFeatureMetaInfo", () => ({
+  useFeatureMetaInfo: vi.fn(),
+}));
+
+vi.mock("@/services/DefinitionsContext", () => ({
+  useDefinitions: vi.fn(),
+}));
+
+vi.mock("@/services/UserContext", () => ({
+  useUser: vi.fn(),
+}));
+
+vi.mock("@/hooks/useSDKConnections", () => ({
+  default: vi.fn(),
+}));
+
+vi.mock("@/hooks/usePrerequisiteStates", () => ({
+  useBatchPrerequisiteStates: vi.fn(),
+}));
+
+describe("PrerequisiteInput", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // @ts-expect-error partial test mock
+    vi.mocked(useFeatureMetaInfo).mockReturnValue({
+      features: [],
+    });
+
+    // @ts-expect-error partial test mock
+    vi.mocked(useDefinitions).mockReturnValue({
+      projects: [],
+    });
+
+    // @ts-expect-error partial test mock
+    vi.mocked(useUser).mockReturnValue({
+      hasCommercialFeature: () => true,
+    });
+
+    vi.mocked(useSDKConnections).mockReturnValue({
+      data: {
+        connections: [],
+      },
+    });
+
+    vi.mocked(useBatchPrerequisiteStates).mockReturnValue([]);
+  });
+
+  it("renders the empty-state add action with bold text and adds a prerequisite", () => {
+    const setValue = vi.fn();
+
+    render(
+      <RadixTheme>
+        <TooltipProvider>
+          <PrerequisiteInput
+            value={[]}
+            setValue={setValue}
+            environments={[]}
+            setPrerequisiteTargetingSdkIssues={vi.fn()}
+          />
+        </TooltipProvider>
+      </RadixTheme>,
+    );
+
+    const addAction = screen.getByText("Add prerequisite targeting");
+    expect(addAction).toBeInTheDocument();
+    expect(addAction).toHaveAttribute("data-accent-color", "gray");
+    expect(addAction.tagName).toBe("SPAN");
+
+    fireEvent.click(addAction);
+
+    expect(setValue).toHaveBeenCalledWith([{ id: "", condition: "{}" }]);
+  });
+});

--- a/packages/front-end/test/components/Features/PrerequisiteInput.test.tsx
+++ b/packages/front-end/test/components/Features/PrerequisiteInput.test.tsx
@@ -7,7 +7,10 @@ import { useFeatureMetaInfo } from "@/hooks/useFeatureMetaInfo";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import { useUser } from "@/services/UserContext";
 import useSDKConnections from "@/hooks/useSDKConnections";
-import { useBatchPrerequisiteStates } from "@/hooks/usePrerequisiteStates";
+import {
+  useBatchPrerequisiteStates,
+  type UseBatchPrerequisiteStatesReturn,
+} from "@/hooks/usePrerequisiteStates";
 import { RadixTheme } from "@/services/RadixTheme";
 
 vi.mock("shared/util", () => ({
@@ -93,9 +96,18 @@ describe("PrerequisiteInput", () => {
       data: {
         connections: [],
       },
+      error: undefined,
+      mutate: vi.fn(),
+      isValidating: false,
+      isLoading: false,
     });
 
-    vi.mocked(useBatchPrerequisiteStates).mockReturnValue([]);
+    vi.mocked(useBatchPrerequisiteStates).mockReturnValue({
+      results: null,
+      loading: false,
+      error: undefined,
+      mutate: vi.fn(),
+    } satisfies UseBatchPrerequisiteStatesReturn);
   });
 
   it("renders the empty-state add action with bold text and adds a prerequisite", () => {

--- a/packages/front-end/test/components/Features/PrerequisiteInput.test.tsx
+++ b/packages/front-end/test/components/Features/PrerequisiteInput.test.tsx
@@ -10,6 +10,32 @@ import useSDKConnections from "@/hooks/useSDKConnections";
 import { useBatchPrerequisiteStates } from "@/hooks/usePrerequisiteStates";
 import { RadixTheme } from "@/services/RadixTheme";
 
+vi.mock("shared/util", () => ({
+  getDefaultPrerequisiteCondition: vi.fn(() => "{}"),
+}));
+
+vi.mock("shared/sdk-versioning", () => ({
+  getConnectionsSDKCapabilities: vi.fn(() => []),
+}));
+
+vi.mock("@/services/features", () => ({
+  condToJson: vi.fn(() => "{}"),
+  jsonToConds: vi.fn(() => []),
+}));
+
+vi.mock("@/components/Marketing/PremiumTooltip", () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/Features/ConditionInput", () => ({
+  datatypeSupportsCaseInsensitive: vi.fn(() => false),
+  getDisplayOperator: vi.fn(() => ""),
+  isCaseInsensitiveOperator: vi.fn(() => false),
+  operatorSupportsCaseInsensitive: vi.fn(() => false),
+  withOperatorCaseInsensitivity: vi.fn((operator: string) => operator),
+}));
+
 vi.mock("@/hooks/useFeatureMetaInfo", () => ({
   useFeatureMetaInfo: vi.fn(),
 }));
@@ -28,6 +54,20 @@ vi.mock("@/hooks/useSDKConnections", () => ({
 
 vi.mock("@/hooks/usePrerequisiteStates", () => ({
   useBatchPrerequisiteStates: vi.fn(),
+}));
+
+vi.mock("@/components/Features/PrerequisiteFeatureSelector", () => ({
+  default: () => <div data-testid="prerequisite-feature-selector" />,
+}));
+
+vi.mock("@/components/Features/PrerequisiteStatesTable", () => ({
+  __esModule: true,
+  default: () => <div data-testid="prerequisite-states-table" />,
+}));
+
+vi.mock("@/components/Features/PrerequisiteAlerts", () => ({
+  __esModule: true,
+  default: () => <div data-testid="prerequisite-alerts" />,
 }));
 
 describe("PrerequisiteInput", () => {
@@ -76,8 +116,8 @@ describe("PrerequisiteInput", () => {
 
     const addAction = screen.getByText("Add prerequisite targeting");
     expect(addAction).toBeInTheDocument();
-    expect(addAction).toHaveAttribute("data-accent-color", "gray");
     expect(addAction.tagName).toBe("SPAN");
+    expect(addAction.parentElement?.querySelector("svg")).toBeTruthy();
 
     fireEvent.click(addAction);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Features and Changes

- Update the empty-state prerequisite targeting action to use the same bold text wrapper strategy as the saved group and attribute targeting actions.
- Add a focused front-end regression test covering the prerequisite empty-state CTA render/click behavior.
- Fix the regression test mock typing so front-end type-check passes in CI.

- Closes **(add link to issue here)**

### Dependencies

- None

### Testing

- `pnpm --filter front-end type-check`
- `pnpm --filter front-end exec vitest run test/components/Features/PrerequisiteInput.test.tsx`
- Manual verification in the GrowthBook UI at `http://localhost:3000` by opening **Add New Experiment -> Targeting** and confirming visual parity between the targeting CTAs.

### Screenshots

- Screenshot artifact: `<img alt="Experiment targeting step CTA parity" src="/opt/cursor/artifacts/experiment_targeting_targeting_step.png" />`
- Video artifact: `<video src="/opt/cursor/artifacts/experiment_targeting_prerequisite_cta_parity.mp4"></video>`

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://growthbookapp.slack.com/archives/C07NK4F016Z/p1774538232848799?thread_ts=1774538232.848799&cid=C07NK4F016Z)

<div><a href="https://cursor.com/agents/bc-ed1785fd-86ea-51a1-b0b6-919fa5c44f9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed1785fd-86ea-51a1-b0b6-919fa5c44f9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

