### PR TITLE
fix: use reset() instead of setValue() in AISettings to properly trac…

### DIFF
--- a/packages/front-end/components/GeneralSettings/AISettings.tsx
+++ b/packages/front-end/components/GeneralSettings/AISettings.tsx
@@ -325,13 +325,12 @@ export default function AISettings({
   useEffect(() => {
     if (data) {
       const prompts = getPrompts(data);
+      const values: Record<string, string> = {};
       prompts.forEach((prompt) => {
-        promptForm.setValue(prompt.promptType, prompt.promptValue);
-        promptForm.setValue(
-          `${prompt.promptType}-model`,
-          prompt.overrideModel || "",
-        );
+        values[prompt.promptType] = prompt.promptValue;
+        values[`${prompt.promptType}-model`] = prompt.overrideModel || "";
       });
+      promptForm.reset(values);
     }
   }, [data, promptForm]);
 


### PR DESCRIPTION
### Features and Changes

Fix root cause of AI Settings prompt form validation error. PR #5070 added a guard to only call `savePrompts()` when the form is dirty, but the underlying issue remained: `setValue()` was used to populate the prompt form which doesn't update `defaultValues`, causing `isDirty` to stay `true` after visiting AI Settings even without making changes.

Replace `setValue()` calls with `promptForm.reset()` which properly sets both the form values and `defaultValues`, ensuring `isDirty` is only `true` when the user actually modifies a prompt.

- Fixes https://github.com/growthbook/growthbook/issues/5053

### Testing

1. Hard refresh `localhost:3000/settings` — stay on Experiment Settings — make any change — click Save All → no prompt validation error
2. Visit AI Settings tab — navigate to Experiment Settings — click Save All → prompts POST not called (form not dirty)
3. Visit AI Settings tab — edit a prompt — navigate to Experiment Settings — click Save All → prompts POST called and succeeds with 200
