### PR TITLE
Clear nested timeout in Tooltip to fix flaky test behavior

### DIFF
--- a/packages/front-end/components/Tooltip/Tooltip.tsx
+++ b/packages/front-end/components/Tooltip/Tooltip.tsx
@@ -58,28 +58,39 @@ const Tooltip: FC<Props> = ({
   const [alreadyHovered, setAlreadyHovered] = useState(false);
 
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const nestedTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   const clearTimeouts = useCallback(() => {
     if (timeoutRef.current) {
       clearTimeout(timeoutRef.current);
       timeoutRef.current = null;
     }
-  }, [timeoutRef]);
+    if (nestedTimeoutRef.current) {
+      clearTimeout(nestedTimeoutRef.current);
+      nestedTimeoutRef.current = null;
+    }
+  }, []);
 
   const handleMouseEnter = useCallback(() => {
     clearTimeouts();
     timeoutRef.current = setTimeout(() => {
       setOpen(true);
-      setTimeout(() => setFadeIn(true), 50);
+      nestedTimeoutRef.current = setTimeout(() => setFadeIn(true), 50);
     }, delay);
-  }, [clearTimeouts, timeoutRef, setOpen, setFadeIn, delay]);
+  }, [clearTimeouts, delay]);
 
   const handleMouseLeave = useCallback(() => {
     clearTimeouts();
     timeoutRef.current = setTimeout(() => {
       setFadeIn(false);
-      setTimeout(() => setOpen(false), 300);
+      nestedTimeoutRef.current = setTimeout(() => setOpen(false), 300);
     }, 200);
+  }, [clearTimeouts]);
+
+  useEffect(() => {
+    return () => {
+      clearTimeouts();
+    };
   }, [clearTimeouts]);
 
   useEffect(() => {


### PR DESCRIPTION
### Features and Changes
There was a random error in a test run due to a timeout not being cleared: https://github.com/growthbook/growthbook/actions/runs/23651232328/job/68896357417?pr=5520

This clears the nested timeout as well

### Testing
See tests pass 

