### PR TITLE
fix(custom-fields): Ensure custom fields are rendered when creating Feature from Experiment

### DIFF
--- a/packages/front-end/components/Features/FeatureModal/FeatureFromExperimentModal.tsx
+++ b/packages/front-end/components/Features/FeatureModal/FeatureFromExperimentModal.tsx
@@ -25,9 +25,15 @@ import {
 import { useFeatureMetaInfo } from "@/hooks/useFeatureMetaInfo";
 import { useWatching } from "@/services/WatchProvider";
 import MarkdownInput from "@/components/Markdown/MarkdownInput";
+import CustomFieldInput from "@/components/CustomFields/CustomFieldInput";
 import SelectField from "@/components/Forms/SelectField";
 import FeatureValueField from "@/components/Features/FeatureValueField";
+import {
+  filterCustomFieldsForSectionAndProject,
+  useCustomFields,
+} from "@/hooks/useCustomFields";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
+import { useUser } from "@/services/UserContext";
 import FeatureKeyField from "./FeatureKeyField";
 import EnvironmentSelect from "./EnvironmentSelect";
 import TagsField from "./TagsField";
@@ -70,23 +76,35 @@ const genFormDefaultValues = ({
   permissions,
   project,
   experiment,
+  customFields,
 }: {
   environments: ReturnType<typeof useEnvironments>;
   permissions: ReturnType<typeof usePermissionsUtil>;
   project: string;
   experiment: ExperimentInterfaceStringDates;
+  customFields?: ReturnType<typeof useCustomFields>;
 }): Omit<
   FeatureInterface,
-  "organization" | "dateCreated" | "dateUpdated" | "defaultValue"
+  | "organization"
+  | "dateCreated"
+  | "dateUpdated"
+  | "defaultValue"
+  | "customFields"
 > & {
   variations: ExperimentRefVariation[];
   existing: string;
+  customFields: Record<string, string>;
 } => {
   const environmentSettings = genEnvironmentSettings({
     environments,
     permissions,
     project,
   });
+  const customFieldValues = customFields
+    ? Object.fromEntries(
+        customFields.map((field) => [field.id, field.defaultValue ?? ""]),
+      )
+    : {};
   const type =
     getLatestPhaseVariations(experiment).length > 2 ? "string" : "boolean";
   const defaultValue = getDefaultValue(type);
@@ -100,6 +118,7 @@ const genFormDefaultValues = ({
     project,
     tags: experiment.tags || [],
     environmentSettings,
+    customFields: customFieldValues,
     variations: getLatestPhaseVariations(experiment).map((v, i) => {
       return {
         value: i ? getDefaultVariationValue(defaultValue) : defaultValue,
@@ -119,6 +138,7 @@ export default function FeatureFromExperimentModal({
   source,
 }: Props) {
   const { project, refreshTags } = useDefinitions();
+  const selectedProject = experiment.project ?? project;
   const allEnvironments = useEnvironments();
   const environments = filterEnvironmentsByExperiment(
     allEnvironments,
@@ -126,12 +146,22 @@ export default function FeatureFromExperimentModal({
   );
   const permissionsUtil = usePermissionsUtil();
   const { refreshWatching } = useWatching();
+  const { hasCommercialFeature } = useUser();
+  const allCustomFields = useCustomFields();
+  const customFields = filterCustomFieldsForSectionAndProject(
+    allCustomFields,
+    "feature",
+    selectedProject,
+  );
 
   const defaultValues = genFormDefaultValues({
     environments,
     permissions: permissionsUtil,
     experiment,
-    project,
+    project: selectedProject,
+    customFields: hasCommercialFeature("custom-metadata")
+      ? customFields
+      : undefined,
   });
 
   // Scope features to the experiment's project (or all features if experiment has no project)
@@ -164,7 +194,7 @@ export default function FeatureFromExperimentModal({
 
   if (
     !permissionsUtil.canManageFeatureDrafts({
-      project: experiment.project ?? project,
+      project: selectedProject,
     })
   ) {
     ctaEnabled = false;
@@ -411,6 +441,22 @@ export default function FeatureFromExperimentModal({
               form.setValue("environmentSettings", environmentSettings);
             }}
           />
+
+          {hasCommercialFeature("custom-metadata") &&
+            customFields &&
+            customFields.length > 0 && (
+              <div>
+                <CustomFieldInput
+                  customFields={customFields}
+                  setCustomFields={(value) => {
+                    form.setValue("customFields", value);
+                  }}
+                  currentCustomFields={form.watch("customFields") || {}}
+                  section={"feature"}
+                  project={selectedProject}
+                />
+              </div>
+            )}
         </>
       )}
 


### PR DESCRIPTION
### Features and Changes

When creating a feature from the Experiment page we were not rendering the Custom Fields (if any are configured) for users, potentially blocking the creation if they had custom fields marked as required.

This fixes it by rendering custom fields inputs.

### Screenshots

#### Before

Note the error message but there's no place in the UI to fix it, making the user unable to proceed.

<img width="624" height="874" alt="Screenshot 2026-03-27 at 5 37 49 PM" src="https://github.com/user-attachments/assets/9ddc394d-b1ac-462e-a582-202defd2b6bb" />

#### After

Now we have the custom fields in the UI, and the required field is handled properly by the browser.

<img width="629" height="883" alt="Screenshot 2026-03-27 at 5 38 04 PM" src="https://github.com/user-attachments/assets/ea0d1d3c-ea08-41f1-9553-9a412b45f5bd" />
