### PR TITLE
fix: use ISO 8601 week start (Monday) for week granularity in data visualization

### DIFF
--- a/packages/front-end/components/DataViz/SqlExplorerDataVisualization.tsx
+++ b/packages/front-end/components/DataViz/SqlExplorerDataVisualization.tsx
@@ -124,9 +124,11 @@ function roundDate(date: Date, unit: xAxisDateAggregationUnit): Date {
       return d;
     }
     case "week": {
-      const day = d.getUTCDay(); // Sunday = 0
+      // Use ISO 8601 week start (Monday) instead of US convention (Sunday)
+      const day = d.getUTCDay(); // Sunday = 0, Monday = 1, ...
+      const diff = (day + 6) % 7; // Monday = 0, Tuesday = 1, ..., Sunday = 6
       const startOfWeek = new Date(
-        Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() - day),
+        Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() - diff),
       );
       startOfWeek.setUTCHours(0, 0, 0, 0); // Round to the start of the week
       return startOfWeek;


### PR DESCRIPTION
## Summary

Fixes #4978

The "Week" granularity in SQL Explorer data visualization uses US week convention (Sunday start), causing a 1-day mismatch when the underlying SQL query uses ISO week aggregation (`DATE_TRUNC(col, ISOWEEK)`).

### Root Cause

In `SqlExplorerDataVisualization.tsx`, `roundDate()` computes the start of the week by subtracting `d.getUTCDay()` days, where `getUTCDay()` returns 0 for Sunday. This rounds to Sunday (US convention).

### Fix

Use `(day + 6) % 7` to compute the offset from **Monday** instead of Sunday, aligning with ISO 8601:

| Day       | getUTCDay() | (day+6)%7 |
|-----------|-------------|-----------|
| Monday    | 1           | 0         |
| Tuesday   | 2           | 1         |
| Wednesday | 3           | 2         |
| Thursday  | 4           | 3         |
| Friday    | 5           | 4         |
| Saturday  | 6           | 5         |
| Sunday    | 0           | 6         |

**Before:** data for `2025-12-01` (Monday) → displayed as `2025-11-30` (Sunday)  
**After:** data for `2025-12-01` (Monday) → displayed as `2025-12-01` (Monday) ✅

## Changes

- `packages/front-end/components/DataViz/SqlExplorerDataVisualization.tsx` — 1 file, 4 lines changed

## Test Plan

- [ ] Create a SQL query with `DATE_TRUNC(date_col, ISOWEEK)` 
- [ ] Select "Week" granularity in the visualization config
- [ ] Verify week start dates align with Monday (ISO 8601)
- [ ] Verify non-week granularities (day, month, year) are unaffected