### PR TITLE
feat: allow customize cookie attributes in auto-attribute plugin

### DIFF
--- a/packages/sdk-js/src/plugins/auto-attributes.ts
+++ b/packages/sdk-js/src/plugins/auto-attributes.ts
@@ -4,8 +4,19 @@ import type {
   GrowthBookClient,
 } from "../GrowthBookClient";
 
+export type uuidCookieSettings = {
+  domain?: string;
+  path?: string;
+  maxAge?: number;
+  expires?: number;
+  secure?: boolean;
+  sameSite?: "lax" | "strict" | "none";
+  partitioned?: boolean;
+};
+
 export type AutoAttributeSettings = {
   uuidCookieName?: string;
+  uuidCookieSettings?: uuidCookieSettings;
   uuidKey?: string;
   uuid?: string;
   uuidAutoPersist?: boolean;
@@ -47,7 +58,7 @@ export function autoAttributesPlugin(settings: AutoAttributeSettings = {}) {
   const uuidKey = settings.uuidKey || "id";
   let uuid = settings.uuid || "";
   function persistUUID() {
-    setCookie(COOKIE_NAME, uuid);
+    setCookie(COOKIE_NAME, uuid, settings.uuidCookieSettings);
   }
   function getUUID() {
     // Already stored in memory, return
@@ -129,11 +140,33 @@ export function autoAttributesPlugin(settings: AutoAttributeSettings = {}) {
   };
 }
 
-function setCookie(name: string, value: string) {
+function getDefaultExpireOTCString() {
   const d = new Date();
   const COOKIE_DAYS = 400; // 400 days is the max cookie duration for chrome
   d.setTime(d.getTime() + 24 * 60 * 60 * 1000 * COOKIE_DAYS);
-  document.cookie = name + "=" + value + ";path=/;expires=" + d.toUTCString();
+  return d.toUTCString();
+}
+
+function setCookie(
+  name: string,
+  value: string,
+  settings: uuidCookieSettings = {},
+) {
+  document.cookie = [
+    `${name}=${value}`,
+    "maxAge" in settings
+      ? `max-age=${settings.maxAge}`
+      : `expires=${settings.expires ?? getDefaultExpireOTCString()}`,
+    `path=${settings.path ?? "/"}`,
+    settings.domain ? `domain=${settings.domain}` : "",
+    settings.sameSite ? `sameSite=${settings.sameSite}` : "",
+    settings.secure || settings.sameSite === "none" || settings.partitioned
+      ? "secure"
+      : "",
+    settings.partitioned ? "partitioned" : "",
+  ]
+    .filter(Boolean)
+    .join("; ");
 }
 
 function getCookie(name: string): string {

--- a/packages/sdk-js/src/plugins/auto-attributes.ts
+++ b/packages/sdk-js/src/plugins/auto-attributes.ts
@@ -8,7 +8,7 @@ export type uuidCookieSettings = {
   domain?: string;
   path?: string;
   maxAge?: number;
-  expires?: number;
+  expires?: string;
   secure?: boolean;
   sameSite?: "lax" | "strict" | "none";
   partitioned?: boolean;
@@ -154,7 +154,7 @@ function setCookie(
 ) {
   document.cookie = [
     `${name}=${value}`,
-    "maxAge" in settings
+    settings.maxAge !== undefined && settings.maxAge !== null
       ? `max-age=${settings.maxAge}`
       : `expires=${settings.expires ?? getDefaultExpireOTCString()}`,
     `path=${settings.path ?? "/"}`,

--- a/packages/sdk-js/test/plugins/auto-attributes.test.ts
+++ b/packages/sdk-js/test/plugins/auto-attributes.test.ts
@@ -342,4 +342,239 @@ describe("autoAttributesPlugin", () => {
 
     gb.destroy();
   });
+
+  describe("uuidCookieSettings", () => {
+    let cookieSetCalls: string[] = [];
+    let originalCookieDescriptor: PropertyDescriptor | undefined;
+
+    beforeAll(() => {
+      originalCookieDescriptor = Object.getOwnPropertyDescriptor(
+        document,
+        "cookie",
+      );
+      Object.defineProperty(document, "cookie", {
+        get: () => "",
+        set: (value: string) => {
+          cookieSetCalls.push(value);
+        },
+        configurable: true,
+      });
+    });
+
+    beforeEach(() => {
+      cookieSetCalls = [];
+    });
+
+    it("passes domain setting to cookie setter", () => {
+      const plugin = autoAttributesPlugin({
+        uuidCookieSettings: { domain: "example.com" },
+      });
+      const gb = new GrowthBook({
+        plugins: [plugin],
+      });
+
+      expect(cookieSetCalls.length).toBeGreaterThan(0);
+      expect(cookieSetCalls[0]).toContain("domain=example.com");
+
+      gb.destroy();
+    });
+
+    it("passes path setting to cookie setter", () => {
+      const plugin = autoAttributesPlugin({
+        uuidCookieSettings: { path: "/app" },
+      });
+      const gb = new GrowthBook({
+        plugins: [plugin],
+      });
+
+      expect(cookieSetCalls.length).toBeGreaterThan(0);
+      expect(cookieSetCalls[0]).toContain("path=/app");
+
+      gb.destroy();
+    });
+
+    it("passes maxAge setting to cookie setter", () => {
+      const plugin = autoAttributesPlugin({
+        uuidCookieSettings: { maxAge: 86400 },
+      });
+      const gb = new GrowthBook({
+        plugins: [plugin],
+      });
+
+      expect(cookieSetCalls.length).toBeGreaterThan(0);
+      expect(cookieSetCalls[0]).toContain("max-age=86400");
+
+      gb.destroy();
+    });
+
+    it("passes expires setting to cookie setter", () => {
+      const expirationTime = 1735689600;
+      const plugin = autoAttributesPlugin({
+        uuidCookieSettings: { expires: expirationTime },
+      });
+      const gb = new GrowthBook({
+        plugins: [plugin],
+      });
+
+      expect(cookieSetCalls.length).toBeGreaterThan(0);
+      expect(cookieSetCalls[0]).toContain("expires=");
+
+      gb.destroy();
+    });
+
+    it("passes sameSite=strict setting to cookie setter", () => {
+      const plugin = autoAttributesPlugin({
+        uuidCookieSettings: { sameSite: "strict" },
+      });
+      const gb = new GrowthBook({
+        plugins: [plugin],
+      });
+
+      expect(cookieSetCalls.length).toBeGreaterThan(0);
+      expect(cookieSetCalls[0]).toContain("sameSite=strict");
+
+      gb.destroy();
+    });
+
+    it("passes sameSite=lax setting to cookie setter", () => {
+      const plugin = autoAttributesPlugin({
+        uuidCookieSettings: { sameSite: "lax" },
+      });
+      const gb = new GrowthBook({
+        plugins: [plugin],
+      });
+
+      expect(cookieSetCalls.length).toBeGreaterThan(0);
+      expect(cookieSetCalls[0]).toContain("sameSite=lax");
+
+      gb.destroy();
+    });
+
+    it("passes sameSite=none with secure flag to cookie setter", () => {
+      const plugin = autoAttributesPlugin({
+        uuidCookieSettings: { sameSite: "none" },
+      });
+      const gb = new GrowthBook({
+        plugins: [plugin],
+      });
+
+      expect(cookieSetCalls.length).toBeGreaterThan(0);
+      expect(cookieSetCalls[0]).toContain("sameSite=none");
+      expect(cookieSetCalls[0]).toContain("secure");
+
+      gb.destroy();
+    });
+
+    it("passes secure setting to cookie setter", () => {
+      const plugin = autoAttributesPlugin({
+        uuidCookieSettings: { secure: true },
+      });
+      const gb = new GrowthBook({
+        plugins: [plugin],
+      });
+
+      expect(cookieSetCalls.length).toBeGreaterThan(0);
+      expect(cookieSetCalls[0]).toContain("secure");
+
+      gb.destroy();
+    });
+
+    it("passes partitioned setting with secure flag to cookie setter", () => {
+      const plugin = autoAttributesPlugin({
+        uuidCookieSettings: { partitioned: true },
+      });
+      const gb = new GrowthBook({
+        plugins: [plugin],
+      });
+
+      expect(cookieSetCalls.length).toBeGreaterThan(0);
+      expect(cookieSetCalls[0]).toContain("secure");
+      expect(cookieSetCalls[0]).toContain("partitioned");
+
+      gb.destroy();
+    });
+
+    it("combines multiple cookie settings correctly", () => {
+      const plugin = autoAttributesPlugin({
+        uuidCookieSettings: {
+          domain: "example.com",
+          path: "/app",
+          maxAge: 604800,
+          sameSite: "lax",
+          secure: true,
+        },
+      });
+      const gb = new GrowthBook({
+        plugins: [plugin],
+      });
+
+      expect(cookieSetCalls.length).toBeGreaterThan(0);
+      const cookieString = cookieSetCalls[0];
+      expect(cookieString).toContain("domain=example.com");
+      expect(cookieString).toContain("path=/app");
+      expect(cookieString).toContain("max-age=604800");
+      expect(cookieString).toContain("sameSite=lax");
+      expect(cookieString).toContain("secure");
+
+      gb.destroy();
+    });
+
+    it("uses default path when uuidCookieSettings not provided", () => {
+      const plugin = autoAttributesPlugin();
+      const gb = new GrowthBook({
+        plugins: [plugin],
+      });
+
+      expect(cookieSetCalls.length).toBeGreaterThan(0);
+      expect(cookieSetCalls[0]).toContain("path=/");
+      expect(cookieSetCalls[0]).toContain("expires=");
+
+      gb.destroy();
+    });
+
+    it("respects cookie settings when persisting via growthbookpersist event", () => {
+      let localCookieSetCalls: string[] = [];
+      const originalCookieDescriptor = Object.getOwnPropertyDescriptor(
+        document,
+        "cookie",
+      );
+      Object.defineProperty(document, "cookie", {
+        get: () => "",
+        set: (value: string) => {
+          localCookieSetCalls.push(value);
+        },
+        configurable: true,
+      });
+
+      try {
+        const plugin = autoAttributesPlugin({
+          uuidAutoPersist: false,
+          uuidCookieSettings: { path: "/test", maxAge: 3600 },
+        });
+        const gb = new GrowthBook({
+          plugins: [plugin],
+        });
+
+        // No cookie set initially
+        expect(localCookieSetCalls.length).toBe(0);
+
+        // Trigger persist event
+        document.dispatchEvent(new Event("growthbookpersist"));
+
+        // Cookie should now be set with custom settings
+        expect(localCookieSetCalls.length).toBeGreaterThan(0);
+        // Verify that our custom cookie settings were passed
+        const cookieString = localCookieSetCalls.find((c) =>
+          c.includes("path=/test"),
+        );
+        expect(cookieString).toBeTruthy();
+
+        gb.destroy();
+      } finally {
+        if (originalCookieDescriptor) {
+          Object.defineProperty(document, "cookie", originalCookieDescriptor);
+        }
+      }
+    });
+  });
 });

--- a/packages/sdk-js/test/plugins/auto-attributes.test.ts
+++ b/packages/sdk-js/test/plugins/auto-attributes.test.ts
@@ -408,7 +408,7 @@ describe("autoAttributesPlugin", () => {
     });
 
     it("passes expires setting to cookie setter", () => {
-      const expirationTime = 1735689600;
+      const expirationTime = new Date().toISOString();
       const plugin = autoAttributesPlugin({
         uuidCookieSettings: { expires: expirationTime },
       });

--- a/packages/sdk-js/test/plugins/auto-attributes.test.ts
+++ b/packages/sdk-js/test/plugins/auto-attributes.test.ts
@@ -361,6 +361,12 @@ describe("autoAttributesPlugin", () => {
       });
     });
 
+    afterAll(() => {
+      if (originalCookieDescriptor) {
+        Object.defineProperty(document, "cookie", originalCookieDescriptor);
+      }
+    });
+
     beforeEach(() => {
       cookieSetCalls = [];
     });
@@ -533,7 +539,7 @@ describe("autoAttributesPlugin", () => {
     });
 
     it("respects cookie settings when persisting via growthbookpersist event", () => {
-      let localCookieSetCalls: string[] = [];
+      const localCookieSetCalls: string[] = [];
       const originalCookieDescriptor = Object.getOwnPropertyDescriptor(
         document,
         "cookie",


### PR DESCRIPTION
## Problem                                                                                                                   

The autoAttribute Plugin hardcoded cookie attributes (path=/; expires=...) with no way to customize them. This is a problem for apps that need to:                                                                                            
- Share the UUID across subdomains requires setting domain                                          
- Control cookie lifetime — the hardcoded 400-day expiry isn't always appropriate                                         
- Meet security requirements — many apps need Secure, SameSite=Strict, or Partitioned flags                               
- Comply with privacy regulations — consent-gated flows may need specific cookie scoping                                  
                                                                                                                            
## Solution
Adds a new uuidCookieSettings option to AutoAttributeSettings that lets callers configure all standard cookie attributes: 

```TypeScript
  autoAttributesPlugin({                                                                                                    
    uuidCookieSettings: {                                                                                                   
      domain: '.example.com',                                                                                           
      path: '/app',                                                                                                         
      maxAge: 604800,                                                                                                       
      sameSite: 'lax',                                                                                                      
      secure: true,                                                                                                         
      partitioned: true,                                                                                                    
    },                                                                                                                      
  }); 
```

## Backward compatible                                                                                                       
- All new options are optional. Without uuidCookieSettings, behavior is identical to the current implementation — path=/, with a 400-day expiry.