### PR TITLE
Ensure explorationUrl contains correct chartType

### DIFF
--- a/packages/back-end/src/models/AnalyticsExplorationModel.ts
+++ b/packages/back-end/src/models/AnalyticsExplorationModel.ts
@@ -75,7 +75,7 @@ function makeExplorationHandler<
       return {
         exploration: toApiInterface(exploration),
         query: queryDoc ? toQueryApiInterface(queryDoc) : null,
-        explorationUrl: getProductAnalyticsExplorationUrl(exploration.config),
+        explorationUrl: getProductAnalyticsExplorationUrl(req.body),
       };
     },
   });


### PR DESCRIPTION
### Features and Changes

When the external API returns an `explorationUrl`, it now generates the URL from the caller's request config (`req.body`) instead of the cached exploration's config (`exploration.config`).

Since `chartType` is intentionally excluded from the cache hash (to maximize cache hit rates without affecting query results), a cache hit can return an exploration originally created with a different chart type. Previously, the `explorationUrl` was built from the cached exploration's config, meaning the link could open the explorer with the wrong chart type (e.g., `bar` instead of the caller's intended `line`). This ensures the URL always reflects the caller's intended display settings.

### Dependencies

None

### Testing

- [x] Create a metric exploration via the API with `chartType: "line"` and note the `explorationUrl`
- [x] Create another exploration with the same metric/dimensions/date range but `chartType: "bar"` — it should hit the cache but the `explorationUrl` should reflect `bar`, not `line`
- [x] Click the `explorationUrl` and verify the explorer opens with the correct chart type from the request

### Screenshots
