### PR TITLE
update default central license server name

### DIFF
--- a/packages/back-end/src/enterprise/licenseUtil.ts
+++ b/packages/back-end/src/enterprise/licenseUtil.ts
@@ -30,7 +30,7 @@ import { LICENSE_PUBLIC_KEY } from "./public-key";
 
 export const LICENSE_SERVER_URL =
   process.env.LICENSE_SERVER_URL ||
-  "https://central_license_server.growthbook.io/api/v1/";
+  "https://central-license-server.growthbook.io/api/v1/";
 
 // mimic behavior in back-end/src/util/secrets.ts
 const APP_ORIGIN = process.env.APP_ORIGIN || "http://localhost:3000";


### PR DESCRIPTION
### Features and Changes
RFC 1035 says domain names cannot have underscores. So I made a new alias in Route 53.

### Testing
Make a small change in Retool.
On settings, refresh the license server from prod and see new values.


