### PR TITLE
fix(front-end): align experiment runtime dates and timezone display

### DIFF
--- a/packages/front-end/components/Experiment/PhaseSelector.tsx
+++ b/packages/front-end/components/Experiment/PhaseSelector.tsx
@@ -1,9 +1,12 @@
-import { date } from "shared/dates";
 import { parseIntWithDefault } from "shared/util";
 import { ExperimentPhaseStringDates } from "shared/types/experiment";
 import { Flex } from "@radix-ui/themes";
 import { HoldoutInterfaceStringDates } from "shared/validators";
 import { phaseSummary } from "@/services/utils";
+import {
+  formatDateRangeForDisplay,
+  getPhaseDateRangeForDisplay,
+} from "@/services/experimentDateRanges";
 import Tooltip from "@/components/Tooltip/Tooltip";
 import SelectField from "@/components/Forms/SelectField";
 import Text from "@/ui/Text";
@@ -57,6 +60,14 @@ export default function PhaseSelector({
     const phaseIndex = parseIntWithDefault(value, 0);
     const phase = (phases ?? experiment?.phases)?.[phaseIndex];
     if (!phase) return value;
+    const phaseRange = getPhaseDateRangeForDisplay({
+      phase,
+      isHoldout,
+      holdoutAnalysisStartDate: holdout?.analysisStartDate,
+    });
+    const phaseDateRangeText = phaseRange
+      ? formatDateRangeForDisplay(phaseRange)
+      : "not started - now";
 
     const isValueContext = meta?.context === "value";
 
@@ -90,15 +101,7 @@ export default function PhaseSelector({
             {!isHoldout && (
               <span className="font-weight-bold">{phaseIndex + 1}: </span>
             )}
-            <span className="date-label">
-              {phase.lookbackStartDate && isHoldout
-                ? date(
-                    holdout?.analysisStartDate ?? phase.lookbackStartDate,
-                    "UTC",
-                  )
-                : date(phase.dateStarted ?? "", "UTC")}{" "}
-              - {phase.dateEnded ? date(phase.dateEnded, "UTC") : "now"}
-            </span>
+            <span className="date-label">{phaseDateRangeText}</span>
           </>
         </Tooltip>
       );
@@ -111,10 +114,9 @@ export default function PhaseSelector({
         <span className="font-weight-bold">{phase.name}</span>
         <div className="break mt-1" />
         <span className="date-label mt-1">
-          {phase.lookbackStartDate && isHoldout
-            ? date(phase.lookbackStartDate, "UTC")
-            : date(phase.dateStarted ?? "", "UTC")}{" "}
-          — {phase.dateEnded ? date(phase.dateEnded, "UTC") : "now"}
+          {phaseRange
+            ? formatDateRangeForDisplay(phaseRange, { delimiter: " — " })
+            : "not started — now"}
         </span>
         {!isHoldout && (
           <div className="small">{phaseSummary(phase, isBandit)}</div>

--- a/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
@@ -1104,6 +1104,7 @@ export default function ExperimentHeader({
         <ProjectTagBar
           experiment={experiment}
           holdout={holdout}
+          selectedPhase={phase}
           setShowEditInfoModal={setShowEditInfoModal}
           setEditInfoFocusSelector={setEditInfoFocusSelector}
           editTags={editTags}

--- a/packages/front-end/components/Experiment/TabbedPage/ProjectTagBar.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/ProjectTagBar.tsx
@@ -250,7 +250,11 @@ export default function ProjectTagBar({
                 ? "Phase Runtime"
                 : "Runtime"
             }
-            value={runtimeRange ? formatDateRangeForDisplay(runtimeRange) : "not started"}
+            value={
+              runtimeRange
+                ? formatDateRangeForDisplay(runtimeRange)
+                : "not started"
+            }
           />
         </Tooltip>
       </Flex>

--- a/packages/front-end/components/Experiment/TabbedPage/ProjectTagBar.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/ProjectTagBar.tsx
@@ -1,6 +1,6 @@
 import { ExperimentInterfaceStringDates } from "shared/types/experiment";
 import { Flex, Text } from "@radix-ui/themes";
-import { date, daysBetween } from "shared/dates";
+import { date } from "shared/dates";
 import { PiWarning } from "react-icons/pi";
 import React from "react";
 import { HoldoutInterfaceStringDates } from "shared/validators";
@@ -15,11 +15,18 @@ import Link from "@/ui/Link";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 import { useHoldouts } from "@/hooks/useHoldouts";
 import ProjectBadges from "@/components/ProjectBadges";
+import {
+  formatDateRangeForDisplay,
+  getDateRangeDurationInDays,
+  getRuntimeRangeForSelectedPhase,
+  getTotalRuntimeRange,
+} from "@/services/experimentDateRanges";
 import { FocusSelector } from "./EditExperimentInfoModal";
 
 export interface Props {
   experiment: ExperimentInterfaceStringDates;
   holdout?: HoldoutInterfaceStringDates;
+  selectedPhase?: number;
   setShowEditInfoModal: (value: boolean) => void;
   setEditInfoFocusSelector: (value: FocusSelector) => void;
   editTags?: (() => void) | null;
@@ -28,6 +35,7 @@ export interface Props {
 export default function ProjectTagBar({
   experiment,
   holdout,
+  selectedPhase,
   setShowEditInfoModal,
   setEditInfoFocusSelector,
   editTags,
@@ -60,85 +68,27 @@ export default function ProjectTagBar({
   const ownerName = getOwnerDisplay(experiment.owner);
 
   const hasMultiplePhases = (experiment.phases?.length ?? 0) > 1;
-
-  const renderRuntime = () => {
-    const phases = experiment.phases || [];
-    const numPhases = phases.length;
-
-    // If no phases: If experiment start date ? `experiment start date - now` : "not started"
-    if (numPhases === 0) {
-      return "not started";
-    }
-
-    // If 1 phase: phase start date - {phase end date || now}
-    if (numPhases === 1) {
-      const phase = phases[0];
-      const startDate = date(phase?.dateStarted ?? "", "UTC");
-      const endDate = phase?.dateEnded ? date(phase.dateEnded, "UTC") : "now";
-
-      if (!startDate) {
-        return "not started";
-      }
-
-      return `${startDate} - ${endDate}`;
-    }
-
-    // If multiple phases, phase[0] start date - {phase[last] end date || now}
-    const firstPhase = phases[0];
-    const lastPhase = phases[phases.length - 1];
-    const startDate = date(firstPhase?.dateStarted ?? "", "UTC");
-    const endDate = lastPhase?.dateEnded
-      ? date(lastPhase.dateEnded, "UTC")
-      : "now";
-
-    if (!startDate) {
-      return "not started";
-    }
-
-    return `${startDate} - ${endDate}`;
-  };
+  const runtimeRange = getRuntimeRangeForSelectedPhase({
+    experiment,
+    selectedPhase,
+    holdoutAnalysisStartDate: holdout?.analysisStartDate,
+  });
+  const totalRuntimeRange = getTotalRuntimeRange({
+    experiment,
+    holdoutAnalysisStartDate: holdout?.analysisStartDate,
+  });
 
   const renderTotalRuntimeTooltip = (): JSX.Element | string => {
-    const phases = experiment.phases || [];
-    const numPhases = phases.length;
-    const isHoldout = experiment.type === "holdout";
-
-    if (numPhases === 0) {
+    if (!totalRuntimeRange) {
       return "";
     }
-
-    const firstPhase = phases[0];
-    const lastPhase = phases[phases.length - 1];
-
-    // Get the actual start date (not formatted)
-    const startDateStr =
-      firstPhase?.lookbackStartDate && isHoldout
-        ? firstPhase.lookbackStartDate
-        : firstPhase?.dateStarted;
-
-    if (!startDateStr) {
-      return "";
-    }
-
-    // Get the end date (or use now)
-    const endDateStr = lastPhase?.dateEnded || new Date().toISOString();
-
-    const days = daysBetween(startDateStr, endDateStr);
-
-    // Format the date range
-    const startDateFormatted =
-      firstPhase?.lookbackStartDate && isHoldout
-        ? date(firstPhase.lookbackStartDate, "UTC")
-        : date(firstPhase?.dateStarted ?? "", "UTC");
-    const endDateFormatted = lastPhase?.dateEnded
-      ? date(lastPhase.dateEnded, "UTC")
-      : "now";
+    const days = getDateRangeDurationInDays(totalRuntimeRange);
 
     return (
       <>
         <strong>Total runtime</strong>
         <br />
-        {startDateFormatted} - {endDateFormatted} ({days}{" "}
+        {formatDateRangeForDisplay(totalRuntimeRange)} ({days}{" "}
         {days === 1 ? "day" : "days"})
       </>
     );
@@ -297,10 +247,10 @@ export default function ProjectTagBar({
           <Metadata
             label={
               hasMultiplePhases && experiment.type !== "holdout"
-                ? "Latest Phase"
+                ? "Phase Runtime"
                 : "Runtime"
             }
-            value={renderRuntime()}
+            value={runtimeRange ? formatDateRangeForDisplay(runtimeRange) : "not started"}
           />
         </Tooltip>
       </Flex>

--- a/packages/front-end/services/experimentDateRanges.ts
+++ b/packages/front-end/services/experimentDateRanges.ts
@@ -122,5 +122,8 @@ export function getTotalRuntimeRange({
 }
 
 export function getDateRangeDurationInDays(range: DateRange): number {
-  return daysBetween(range.startDate, range.endDate ?? new Date().toISOString());
+  return daysBetween(
+    range.startDate,
+    range.endDate ?? new Date().toISOString(),
+  );
 }

--- a/packages/front-end/services/experimentDateRanges.ts
+++ b/packages/front-end/services/experimentDateRanges.ts
@@ -5,21 +5,21 @@ import {
 } from "shared/types/experiment";
 
 export type DateRange = {
-  startDate: string;
-  endDate?: string;
+  startDate: string | Date;
+  endDate?: string | Date;
 };
 
 type PhaseDateRangeOptions = {
   phase?: ExperimentPhaseStringDates;
   isHoldout?: boolean;
-  holdoutAnalysisStartDate?: string;
+  holdoutAnalysisStartDate?: string | Date;
 };
 
 export function getPhaseStartDateForDisplay({
   phase,
   isHoldout,
   holdoutAnalysisStartDate,
-}: PhaseDateRangeOptions): string | undefined {
+}: PhaseDateRangeOptions): string | Date | undefined {
   if (!phase) return undefined;
 
   if (isHoldout && phase.lookbackStartDate) {

--- a/packages/front-end/services/experimentDateRanges.ts
+++ b/packages/front-end/services/experimentDateRanges.ts
@@ -1,0 +1,126 @@
+import { date, daysBetween } from "shared/dates";
+import {
+  ExperimentInterfaceStringDates,
+  ExperimentPhaseStringDates,
+} from "shared/types/experiment";
+
+export type DateRange = {
+  startDate: string;
+  endDate?: string;
+};
+
+type PhaseDateRangeOptions = {
+  phase?: ExperimentPhaseStringDates;
+  isHoldout?: boolean;
+  holdoutAnalysisStartDate?: string;
+};
+
+export function getPhaseStartDateForDisplay({
+  phase,
+  isHoldout,
+  holdoutAnalysisStartDate,
+}: PhaseDateRangeOptions): string | undefined {
+  if (!phase) return undefined;
+
+  if (isHoldout && phase.lookbackStartDate) {
+    return holdoutAnalysisStartDate ?? phase.lookbackStartDate;
+  }
+
+  return phase.dateStarted;
+}
+
+export function getPhaseDateRangeForDisplay({
+  phase,
+  isHoldout,
+  holdoutAnalysisStartDate,
+}: PhaseDateRangeOptions): DateRange | null {
+  const startDate = getPhaseStartDateForDisplay({
+    phase,
+    isHoldout,
+    holdoutAnalysisStartDate,
+  });
+  if (!startDate) return null;
+
+  return {
+    startDate,
+    endDate: phase?.dateEnded,
+  };
+}
+
+export function formatDateRangeForDisplay(
+  range: DateRange,
+  {
+    delimiter = " - ",
+    inTimezone,
+  }: {
+    delimiter?: string;
+    inTimezone?: string;
+  } = {},
+): string {
+  return `${date(range.startDate, inTimezone)}${delimiter}${
+    range.endDate ? date(range.endDate, inTimezone) : "now"
+  }`;
+}
+
+export function getRuntimeRangeForSelectedPhase({
+  experiment,
+  selectedPhase,
+  holdoutAnalysisStartDate,
+}: {
+  experiment: ExperimentInterfaceStringDates;
+  selectedPhase?: number;
+  holdoutAnalysisStartDate?: string;
+}): DateRange | null {
+  // Draft experiments have planned phase dates, but runtime should only be shown
+  // once an experiment has actually started.
+  if (experiment.status === "draft") return null;
+
+  const phases = experiment.phases ?? [];
+  if (!phases.length) return null;
+
+  const normalizedPhase = Math.max(
+    0,
+    Math.min(selectedPhase ?? phases.length - 1, phases.length - 1),
+  );
+
+  const selectedRange = getPhaseDateRangeForDisplay({
+    phase: phases[normalizedPhase],
+    isHoldout: experiment.type === "holdout",
+    holdoutAnalysisStartDate,
+  });
+  return selectedRange;
+}
+
+export function getTotalRuntimeRange({
+  experiment,
+  holdoutAnalysisStartDate,
+}: {
+  experiment: ExperimentInterfaceStringDates;
+  holdoutAnalysisStartDate?: string;
+}): DateRange | null {
+  if (experiment.status === "draft") return null;
+
+  const phaseRanges = (experiment.phases ?? [])
+    .map((phase) =>
+      getPhaseDateRangeForDisplay({
+        phase,
+        isHoldout: experiment.type === "holdout",
+        holdoutAnalysisStartDate,
+      }),
+    )
+    .filter((range): range is DateRange => !!range);
+
+  if (!phaseRanges.length) return null;
+
+  const firstRange = phaseRanges[0];
+  const lastRange = phaseRanges[phaseRanges.length - 1];
+
+  return {
+    startDate: firstRange.startDate,
+    endDate: lastRange.endDate,
+  };
+}
+
+export function getDateRangeDurationInDays(range: DateRange): number {
+  return daysBetween(range.startDate, range.endDate ?? new Date().toISOString());
+}

--- a/packages/front-end/test/services/experimentDateRanges.test.ts
+++ b/packages/front-end/test/services/experimentDateRanges.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest";
+import { ExperimentInterfaceStringDates } from "shared/types/experiment";
+import {
+  formatDateRangeForDisplay,
+  getDateRangeDurationInDays,
+  getPhaseDateRangeForDisplay,
+  getRuntimeRangeForSelectedPhase,
+  getTotalRuntimeRange,
+} from "@/services/experimentDateRanges";
+
+const baseExperiment: ExperimentInterfaceStringDates = {
+  id: "exp_1",
+  organization: "org_1",
+  owner: "user_1",
+  dateCreated: "2026-02-26T10:00:00.000Z",
+  dateUpdated: "2026-02-26T10:00:00.000Z",
+  project: "",
+  datasource: "",
+  userIdType: "user",
+  status: "draft",
+  archived: false,
+  type: "standard",
+  name: "Test Experiment",
+  hypothesis: "",
+  description: "",
+  variations: [
+    { id: "0", key: "0", name: "Control" },
+    { id: "1", key: "1", name: "Variation" },
+  ],
+  phases: [],
+  metrics: [],
+  goalMetrics: [],
+  secondaryMetrics: [],
+  guardrailMetrics: [],
+  tags: [],
+  results: "inconclusive",
+};
+
+describe("experimentDateRanges", () => {
+  it("does not show runtime for draft experiments", () => {
+    const experiment: ExperimentInterfaceStringDates = {
+      ...baseExperiment,
+      status: "draft",
+      phases: [
+        {
+          name: "Main",
+          dateStarted: "2026-02-26T10:00:00.000Z",
+          coverage: 1,
+          variationWeights: [0.5, 0.5],
+          condition: "",
+          savedGroups: [],
+          prerequisites: [],
+          variations: [
+            { id: "0", status: "active" },
+            { id: "1", status: "active" },
+          ],
+        },
+      ],
+    };
+
+    expect(
+      getRuntimeRangeForSelectedPhase({
+        experiment,
+      }),
+    ).toBeNull();
+    expect(
+      getTotalRuntimeRange({
+        experiment,
+      }),
+    ).toBeNull();
+  });
+
+  it("returns selected phase runtime range when experiment has started", () => {
+    const experiment: ExperimentInterfaceStringDates = {
+      ...baseExperiment,
+      status: "running",
+      phases: [
+        {
+          name: "Main",
+          dateStarted: "2026-02-26T10:00:00.000Z",
+          dateEnded: "2026-03-01T10:00:00.000Z",
+          coverage: 1,
+          variationWeights: [0.5, 0.5],
+          condition: "",
+          savedGroups: [],
+          prerequisites: [],
+          variations: [
+            { id: "0", status: "active" },
+            { id: "1", status: "active" },
+          ],
+        },
+        {
+          name: "Phase 2",
+          dateStarted: "2026-03-01T10:00:00.000Z",
+          coverage: 1,
+          variationWeights: [0.5, 0.5],
+          condition: "",
+          savedGroups: [],
+          prerequisites: [],
+          variations: [
+            { id: "0", status: "active" },
+            { id: "1", status: "active" },
+          ],
+        },
+      ],
+    };
+
+    const selectedRange = getRuntimeRangeForSelectedPhase({
+      experiment,
+      selectedPhase: 0,
+    });
+
+    expect(selectedRange).toEqual({
+      startDate: "2026-02-26T10:00:00.000Z",
+      endDate: "2026-03-01T10:00:00.000Z",
+    });
+  });
+
+  it("uses holdout analysis start date for holdout phase display", () => {
+    const range = getPhaseDateRangeForDisplay({
+      phase: {
+        name: "Analysis",
+        lookbackStartDate: "2026-02-20T00:00:00.000Z",
+        dateStarted: "2026-02-26T00:00:00.000Z",
+        dateEnded: "2026-03-03T00:00:00.000Z",
+        coverage: 1,
+        variationWeights: [0.5, 0.5],
+        condition: "",
+        savedGroups: [],
+        prerequisites: [],
+        variations: [
+          { id: "0", status: "active" },
+          { id: "1", status: "active" },
+        ],
+      },
+      isHoldout: true,
+      holdoutAnalysisStartDate: "2026-02-24T00:00:00.000Z",
+    });
+
+    expect(range).toEqual({
+      startDate: "2026-02-24T00:00:00.000Z",
+      endDate: "2026-03-03T00:00:00.000Z",
+    });
+  });
+
+  it("formats date ranges and computes duration", () => {
+    const range = {
+      startDate: "2026-02-01T00:00:00.000Z",
+      endDate: "2026-02-03T00:00:00.000Z",
+    };
+
+    expect(formatDateRangeForDisplay(range)).toContain("2026");
+    expect(getDateRangeDurationInDays(range)).toBe(2);
+  });
+});

--- a/packages/front-end/test/services/experimentDateRanges.test.ts
+++ b/packages/front-end/test/services/experimentDateRanges.test.ts
@@ -8,55 +8,45 @@ import {
   getTotalRuntimeRange,
 } from "@/services/experimentDateRanges";
 
-const baseExperiment: ExperimentInterfaceStringDates = {
-  id: "exp_1",
-  organization: "org_1",
-  owner: "user_1",
-  dateCreated: "2026-02-26T10:00:00.000Z",
-  dateUpdated: "2026-02-26T10:00:00.000Z",
-  project: "",
-  datasource: "",
-  userIdType: "user",
-  status: "draft",
-  archived: false,
-  type: "standard",
-  name: "Test Experiment",
-  hypothesis: "",
-  description: "",
-  variations: [
-    { id: "0", key: "0", name: "Control" },
-    { id: "1", key: "1", name: "Variation" },
-  ],
-  phases: [],
-  metrics: [],
-  goalMetrics: [],
-  secondaryMetrics: [],
-  guardrailMetrics: [],
-  tags: [],
-  results: "inconclusive",
+const phaseVariationPair = [
+  { id: "0", status: "active" as const },
+  { id: "1", status: "active" as const },
+];
+
+const variationPair = [
+  { id: "0", key: "0", name: "Control", screenshots: [] },
+  { id: "1", key: "1", name: "Variation", screenshots: [] },
+];
+
+const makeExperiment = (
+  overrides: Partial<ExperimentInterfaceStringDates>,
+): ExperimentInterfaceStringDates => {
+  return {
+    status: "draft",
+    type: "standard",
+    phases: [],
+    ...overrides,
+  } as unknown as ExperimentInterfaceStringDates;
 };
 
 describe("experimentDateRanges", () => {
   it("does not show runtime for draft experiments", () => {
-    const experiment: ExperimentInterfaceStringDates = {
-      ...baseExperiment,
+    const experiment = makeExperiment({
       status: "draft",
       phases: [
         {
           name: "Main",
           dateStarted: "2026-02-26T10:00:00.000Z",
+          reason: "",
           coverage: 1,
           variationWeights: [0.5, 0.5],
           condition: "",
           savedGroups: [],
           prerequisites: [],
-          variations: [
-            { id: "0", status: "active" },
-            { id: "1", status: "active" },
-          ],
+          variations: phaseVariationPair,
         },
       ],
-    };
+    });
 
     expect(
       getRuntimeRangeForSelectedPhase({
@@ -71,39 +61,34 @@ describe("experimentDateRanges", () => {
   });
 
   it("returns selected phase runtime range when experiment has started", () => {
-    const experiment: ExperimentInterfaceStringDates = {
-      ...baseExperiment,
+    const experiment = makeExperiment({
       status: "running",
       phases: [
         {
           name: "Main",
           dateStarted: "2026-02-26T10:00:00.000Z",
           dateEnded: "2026-03-01T10:00:00.000Z",
+          reason: "",
           coverage: 1,
           variationWeights: [0.5, 0.5],
           condition: "",
           savedGroups: [],
           prerequisites: [],
-          variations: [
-            { id: "0", status: "active" },
-            { id: "1", status: "active" },
-          ],
+          variations: phaseVariationPair,
         },
         {
           name: "Phase 2",
           dateStarted: "2026-03-01T10:00:00.000Z",
+          reason: "",
           coverage: 1,
           variationWeights: [0.5, 0.5],
           condition: "",
           savedGroups: [],
           prerequisites: [],
-          variations: [
-            { id: "0", status: "active" },
-            { id: "1", status: "active" },
-          ],
+          variations: phaseVariationPair,
         },
       ],
-    };
+    });
 
     const selectedRange = getRuntimeRangeForSelectedPhase({
       experiment,
@@ -120,7 +105,8 @@ describe("experimentDateRanges", () => {
     const range = getPhaseDateRangeForDisplay({
       phase: {
         name: "Analysis",
-        lookbackStartDate: "2026-02-20T00:00:00.000Z",
+        reason: "",
+        lookbackStartDate: new Date("2026-02-20T00:00:00.000Z"),
         dateStarted: "2026-02-26T00:00:00.000Z",
         dateEnded: "2026-03-03T00:00:00.000Z",
         coverage: 1,
@@ -128,10 +114,7 @@ describe("experimentDateRanges", () => {
         condition: "",
         savedGroups: [],
         prerequisites: [],
-        variations: [
-          { id: "0", status: "active" },
-          { id: "1", status: "active" },
-        ],
+        variations: phaseVariationPair,
       },
       isHoldout: true,
       holdoutAnalysisStartDate: "2026-02-24T00:00:00.000Z",

--- a/packages/front-end/test/services/experimentDateRanges.test.ts
+++ b/packages/front-end/test/services/experimentDateRanges.test.ts
@@ -13,11 +13,6 @@ const phaseVariationPair = [
   { id: "1", status: "active" as const },
 ];
 
-const variationPair = [
-  { id: "0", key: "0", name: "Control", screenshots: [] },
-  { id: "1", key: "1", name: "Variation", screenshots: [] },
-];
-
 const makeExperiment = (
   overrides: Partial<ExperimentInterfaceStringDates>,
 ): ExperimentInterfaceStringDates => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Features and Changes

- Added a new front-end date range helper (`packages/front-end/services/experimentDateRanges.ts`) to centralize phase/runtime range computation and date-range display formatting.
- Updated experiment header metadata runtime rendering to:
  - use local timezone formatting consistently,
  - show `not started` for draft/unrun experiments,
  - align runtime with the currently selected phase (fixes phase-selector/date mismatch),
  - keep total-runtime details in tooltip.
- Updated `PhaseSelector` to use the shared helper for phase date ranges and removed hardcoded UTC formatting so displayed phase dates match local-time behavior.
- Added focused unit tests in `packages/front-end/test/services/experimentDateRanges.test.ts` for draft behavior, selected phase runtime, holdout start-date handling, and runtime duration/date formatting.
- Follow-up CI fix: resolved lint formatting/warning issues reported in CI.
- New fix in this iteration: updated `VariationUsersTable` (Experiment Balance Check) to prevent long variation names from overflowing into adjacent columns by using fixed table layout and truncation (`text-ellipsis`) in the variation-name cell.

- Closes **(add link to issue here)**

### Dependencies

None

### Testing

- `pnpm lint`
- `pnpm --filter front-end test test/services/experimentDateRanges.test.ts`
- `pnpm --filter front-end type-check`

Manual verification note:
- I attempted to validate the new Balance Check overflow fix in-browser, but local app manual testing was blocked by an environment/runtime issue (backend process repeatedly failed with native module version mismatch and app served an Internal Server Error). I attempted multiple remediations (Node version switching, rebuilding native module, restarting services) before stopping.

### Screenshots

- [Running experiment date formatting consistency](https://cursor.com/agents/bc-9b0f4cae-8fca-560b-8a96-10b2c973e242/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fexperiment_header_running_dates_consistent.webp)
- [Draft experiment runtime not started](https://cursor.com/agents/bc-9b0f4cae-8fca-560b-8a96-10b2c973e242/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fexperiment_header_draft_not_started.webp)
- [Phase 2 runtime in header](https://cursor.com/agents/bc-9b0f4cae-8fca-560b-8a96-10b2c973e242/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fexperiment_phase2_runtime.webp)
- [Phase 1 runtime in header](https://cursor.com/agents/bc-9b0f4cae-8fca-560b-8a96-10b2c973e242/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fexperiment_phase1_runtime.webp)
- [experiment_phase_runtime_timezone_walkthrough.mp4](https://cursor.com/agents/bc-9b0f4cae-8fca-560b-8a96-10b2c973e242/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fexperiment_phase_runtime_timezone_walkthrough.mp4)
- [Manual verification blocker internal server error](https://cursor.com/agents/bc-9b0f4cae-8fca-560b-8a96-10b2c973e242/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmanual_test_blocker_internal_server_error.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://growthbookapp.slack.com/archives/D0ANTLUD22J/p1774465571901549?thread_ts=1774465571.901549&cid=D0ANTLUD22J)

<div><a href="https://cursor.com/agents/bc-9b0f4cae-8fca-560b-8a96-10b2c973e242"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b0f4cae-8fca-560b-8a96-10b2c973e242"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

