### PR TITLE
fix(experiments): Consistently use UTC dates for experiment metadata and phases

### DIFF
--- a/packages/front-end/components/Experiment/TabbedPage/ProjectTagBar.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/ProjectTagBar.tsx
@@ -2,7 +2,6 @@ import { ExperimentInterfaceStringDates } from "shared/types/experiment";
 import { Flex } from "@radix-ui/themes";
 import { date, daysBetween } from "shared/dates";
 import { PiWarning } from "react-icons/pi";
-import React from "react";
 import { HoldoutInterfaceStringDates } from "shared/validators";
 import Text from "@/ui/Text";
 import SortedTags from "@/components/Tags/SortedTags";
@@ -53,9 +52,20 @@ export default function ProjectTagBar({
 
   const trackingKey = experiment.trackingKey;
 
-  const createdDate = date(experiment.dateCreated);
+  const toUTCDate = (dateValue: string | Date) => date(dateValue, "UTC");
+
+  const createdDate = toUTCDate(experiment.dateCreated);
+
+  const isHoldout = experiment.type === "holdout";
 
   const hasMultiplePhases = (experiment.phases?.length ?? 0) > 1;
+
+  const latestPhase = experiment.phases?.[experiment.phases.length - 1];
+
+  const showRuntime =
+    experiment.phases?.length > 0 &&
+    experiment.status !== "draft" &&
+    latestPhase?.dateStarted;
 
   const renderRuntime = () => {
     const phases = experiment.phases || [];
@@ -66,25 +76,15 @@ export default function ProjectTagBar({
       return "not started";
     }
 
-    // If 1 phase: phase start date - {phase end date || now}
-    if (numPhases === 1) {
-      const phase = phases[0];
-      const startDate = date(phase?.dateStarted ?? "", "UTC");
-      const endDate = phase?.dateEnded ? date(phase.dateEnded, "UTC") : "now";
-
-      if (!startDate) {
-        return "not started";
-      }
-
-      return `${startDate} - ${endDate}`;
-    }
-
-    // If multiple phases, phase[0] start date - {phase[last] end date || now}
+    // If holdout, total runtime from first phase to latest phase
+    // If not holdout, latest phase runtime
     const firstPhase = phases[0];
     const lastPhase = phases[phases.length - 1];
-    const startDate = date(firstPhase?.dateStarted ?? "", "UTC");
+    const startDate = isHoldout
+      ? toUTCDate(firstPhase?.dateStarted ?? "")
+      : toUTCDate(lastPhase?.dateStarted ?? "");
     const endDate = lastPhase?.dateEnded
-      ? date(lastPhase.dateEnded, "UTC")
+      ? toUTCDate(lastPhase.dateEnded)
       : "now";
 
     if (!startDate) {
@@ -97,7 +97,6 @@ export default function ProjectTagBar({
   const renderTotalRuntimeTooltip = (): JSX.Element | string => {
     const phases = experiment.phases || [];
     const numPhases = phases.length;
-    const isHoldout = experiment.type === "holdout";
 
     if (numPhases === 0) {
       return "";
@@ -107,10 +106,9 @@ export default function ProjectTagBar({
     const lastPhase = phases[phases.length - 1];
 
     // Get the actual start date (not formatted)
-    const startDateStr =
-      firstPhase?.lookbackStartDate && isHoldout
-        ? firstPhase.lookbackStartDate
-        : firstPhase?.dateStarted;
+    const startDateStr = isHoldout
+      ? firstPhase.dateStarted
+      : lastPhase.dateStarted;
 
     if (!startDateStr) {
       return "";
@@ -122,12 +120,9 @@ export default function ProjectTagBar({
     const days = daysBetween(startDateStr, endDateStr);
 
     // Format the date range
-    const startDateFormatted =
-      firstPhase?.lookbackStartDate && isHoldout
-        ? date(firstPhase.lookbackStartDate, "UTC")
-        : date(firstPhase?.dateStarted ?? "", "UTC");
+    const startDateFormatted = toUTCDate(startDateStr);
     const endDateFormatted = lastPhase?.dateEnded
-      ? date(lastPhase.dateEnded, "UTC")
+      ? toUTCDate(lastPhase.dateEnded)
       : "now";
 
     return (
@@ -278,16 +273,18 @@ export default function ProjectTagBar({
         )}
         <Metadata label="Owner" value={renderOwner()} />
         <Metadata label="Created" value={createdDate} />
-        <Tooltip body={renderTotalRuntimeTooltip()}>
-          <Metadata
-            label={
-              hasMultiplePhases && experiment.type !== "holdout"
-                ? "Latest Phase"
-                : "Runtime"
-            }
-            value={renderRuntime()}
-          />
-        </Tooltip>
+        {showRuntime && (
+          <Tooltip body={renderTotalRuntimeTooltip()}>
+            <Metadata
+              label={
+                hasMultiplePhases && experiment.type !== "holdout"
+                  ? "Latest Phase"
+                  : "Runtime"
+              }
+              value={renderRuntime()}
+            />
+          </Tooltip>
+        )}
       </Flex>
       <div className="row mt-2">
         <div className="col-auto">


### PR DESCRIPTION
### Features and Changes

- UTC helper: toUTCDate() wraps date(..., "UTC") and is used for Created, runtime strings, and tooltip formatting.
Created date: Uses UTC so it matches the runtime line (previously Created could read as local time while runtime was UTC).
- Runtime range: For holdouts, the range runs from the first phase’s start to the last phase’s end; for standard experiments it reflects the latest phase (start of last phase → end or “now”). Removed the redundant single-phase branch; one-phase experiments use the same first/last logic.
- Tooltip: Total-runtime tooltip uses the same start/end selection as the visible runtime; holdout tooltip start date no longer depends on lookbackStartDate for picking the range start (uses first phase start for holdouts).
- Visibility: Runtime metadata (and its tooltip) only renders when there is at least one phase, the experiment is not draft, and the latest phase has a start date (showRuntime).

### Testing

- Open a running experiment with phases: confirm Created and Runtime look consistent (UTC calendar dates).
   - Draft experiments: runtime block should be hidden.
- Holdout vs standard with multiple phases: confirm runtime range matches intent (first→last vs latest phase).
- Hover Runtime / Latest Phase: tooltip total days and date range should match the label behavior.

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
