### PR TITLE
fix: preserve feature validation schema in duplicate flow (#5407)

### DIFF
--- a/packages/back-end/src/api/features/postFeature.ts
+++ b/packages/back-end/src/api/features/postFeature.ts
@@ -2,9 +2,7 @@ import { z } from "zod";
 import { validateFeatureValue, validateScheduleRules } from "shared/util";
 import { PostFeatureResponse } from "shared/types/openapi";
 import { postFeatureValidator } from "shared/validators";
-import { FeatureInterface, JSONSchemaDef } from "shared/types/feature";
-import { OrganizationInterface } from "shared/types/organization";
-import { orgHasPremiumFeature } from "back-end/src/enterprise";
+import { FeatureInterface } from "shared/types/feature";
 import { createApiRequestHandler } from "back-end/src/util/handler";
 import { createFeature, getFeature } from "back-end/src/models/FeatureModel";
 import { getExperimentMapForFeature } from "back-end/src/models/ExperimentModel";
@@ -19,7 +17,7 @@ import { auditDetailsCreate } from "back-end/src/services/audit";
 import { getEnvironments } from "back-end/src/services/organizations";
 import { getRevision } from "back-end/src/models/FeatureRevisionModel";
 import { addTags } from "back-end/src/models/TagModel";
-import { logger } from "back-end/src/util/logger";
+import { parseApiJsonSchema } from "back-end/src/util/feature-json-schema";
 import { validateCustomFields } from "./validations";
 
 export type ApiFeatureEnvSettings = NonNullable<
@@ -41,30 +39,6 @@ export const validateEnvKeys = (
         "', '",
       )}' not recognized. Please create the environment or remove it from your environment settings and try again.`,
     );
-  }
-};
-
-export const parseJsonSchemaForEnterprise = (
-  org: OrganizationInterface,
-  jsonSchema: string | undefined,
-) => {
-  const jsonSchemaWrapper: JSONSchemaDef = {
-    schemaType: "schema",
-    schema: "",
-    simple: { type: "object", fields: [] },
-    date: new Date(),
-    enabled: false,
-  };
-  if (!jsonSchema) return jsonSchemaWrapper;
-  if (!orgHasPremiumFeature(org, "json-validation")) return jsonSchemaWrapper;
-  try {
-    // ensure the schema is valid JSON
-    jsonSchemaWrapper.schema = JSON.stringify(JSON.parse(jsonSchema));
-    jsonSchemaWrapper.enabled = true;
-    return jsonSchemaWrapper;
-  } catch (e) {
-    logger.error(e, "Failed to parse feature json schema");
-    return jsonSchemaWrapper;
   }
 };
 
@@ -177,10 +151,7 @@ export const postFeature = createApiRequestHandler(postFeatureValidator)(async (
 
   feature.environmentSettings = environmentSettings;
 
-  const jsonSchema = parseJsonSchemaForEnterprise(
-    req.context.org,
-    req.body.jsonSchema,
-  );
+  const jsonSchema = parseApiJsonSchema(req.context.org, req.body.jsonSchema);
 
   feature.jsonSchema = jsonSchema;
 

--- a/packages/back-end/src/api/features/updateFeature.ts
+++ b/packages/back-end/src/api/features/updateFeature.ts
@@ -24,7 +24,8 @@ import { auditDetailsUpdate } from "back-end/src/services/audit";
 import { getRevision } from "back-end/src/models/FeatureRevisionModel";
 import { getEnvironmentIdsFromOrg } from "back-end/src/services/organizations";
 import { shouldValidateCustomFieldsOnUpdate } from "back-end/src/util/custom-fields";
-import { parseJsonSchemaForEnterprise, validateEnvKeys } from "./postFeature";
+import { parseApiJsonSchema } from "back-end/src/util/feature-json-schema";
+import { validateEnvKeys } from "./postFeature";
 import { validateCustomFields } from "./validations";
 
 export const updateFeature = createApiRequestHandler(updateFeatureValidator)(
@@ -161,7 +162,7 @@ export const updateFeature = createApiRequestHandler(updateFeatureValidator)(
 
     const jsonSchema =
       feature.valueType === "json" && req.body.jsonSchema != null
-        ? parseJsonSchemaForEnterprise(req.organization, req.body.jsonSchema)
+        ? parseApiJsonSchema(req.organization, req.body.jsonSchema)
         : null;
 
     const updates: Partial<FeatureInterface> = {

--- a/packages/back-end/src/controllers/features.ts
+++ b/packages/back-end/src/controllers/features.ts
@@ -167,6 +167,7 @@ import {
   shouldValidateCustomFieldsOnUpdate,
   validateCustomFieldsForSection,
 } from "back-end/src/util/custom-fields";
+import { getInitialFeatureJsonSchema } from "back-end/src/util/feature-json-schema";
 
 /**
  * Routes an envelope change through the revision system.
@@ -607,8 +608,14 @@ export async function postFeatures(
 ) {
   const context = getContextFromReq(req);
   const { org, userId } = context;
-  const { id, environmentSettings, holdout, customFields, ...otherProps } =
-    req.body;
+  const {
+    id,
+    environmentSettings,
+    holdout,
+    customFields,
+    jsonSchema,
+    ...otherProps
+  } = req.body;
 
   if (
     !context.permissions.canCreateFeature(req.body) ||
@@ -662,6 +669,8 @@ export async function postFeatures(
     );
   }
 
+  const initialJsonSchema = getInitialFeatureJsonSchema(jsonSchema);
+
   const feature: FeatureInterface = {
     defaultValue: "",
     valueType: "boolean",
@@ -678,16 +687,7 @@ export async function postFeatures(
     archived: false,
     version: 1,
     holdout: holdout?.id ? holdout : undefined,
-    jsonSchema: {
-      schemaType: "schema",
-      simple: {
-        type: "object",
-        fields: [],
-      },
-      schema: "",
-      date: new Date(),
-      enabled: false,
-    },
+    jsonSchema: initialJsonSchema,
   };
 
   const allEnvironments = getEnvironments(org);

--- a/packages/back-end/src/util/feature-json-schema.ts
+++ b/packages/back-end/src/util/feature-json-schema.ts
@@ -8,8 +8,13 @@ import { FeatureInterface, JSONSchemaDef } from "shared/types/feature";
 export function getInitialFeatureJsonSchema(
   jsonSchema?: FeatureInterface["jsonSchema"],
 ): JSONSchemaDef {
+  const schemaType =
+    jsonSchema?.schemaType === "schema" || jsonSchema?.schemaType === "simple"
+      ? jsonSchema.schemaType
+      : "schema";
+
   return {
-    schemaType: jsonSchema?.schemaType ?? "schema",
+    schemaType,
     simple: jsonSchema?.simple ?? {
       type: "object",
       fields: [],

--- a/packages/back-end/src/util/feature-json-schema.ts
+++ b/packages/back-end/src/util/feature-json-schema.ts
@@ -1,0 +1,21 @@
+import { FeatureInterface, JSONSchemaDef } from "shared/types/feature";
+
+/**
+ * Creates the JSON schema payload for a newly-created feature.
+ * If source schema settings are provided (e.g. duplicate flow), preserve them.
+ * Always refresh the `date` field at creation time.
+ */
+export function getInitialFeatureJsonSchema(
+  jsonSchema?: FeatureInterface["jsonSchema"],
+): JSONSchemaDef {
+  return {
+    schemaType: jsonSchema?.schemaType ?? "schema",
+    simple: jsonSchema?.simple ?? {
+      type: "object",
+      fields: [],
+    },
+    schema: jsonSchema?.schema ?? "",
+    date: new Date(),
+    enabled: jsonSchema?.enabled ?? false,
+  };
+}

--- a/packages/back-end/src/util/feature-json-schema.ts
+++ b/packages/back-end/src/util/feature-json-schema.ts
@@ -3,13 +3,15 @@ import { OrganizationInterface } from "shared/types/organization";
 import { orgHasPremiumFeature } from "back-end/src/enterprise";
 import { logger } from "back-end/src/util/logger";
 
-const DEFAULT_JSON_SCHEMA: JSONSchemaDef = {
-  schemaType: "schema",
-  schema: "",
-  simple: { type: "object", fields: [] },
-  date: new Date(),
-  enabled: false,
-};
+function getDefaultJsonSchema(date: Date): JSONSchemaDef {
+  return {
+    schemaType: "schema",
+    schema: "",
+    simple: { type: "object", fields: [] },
+    date,
+    enabled: false,
+  };
+}
 
 /**
  * Creates the JSON schema payload for a newly-created feature.
@@ -24,12 +26,13 @@ export function getInitialFeatureJsonSchema(
       ? jsonSchema.schemaType
       : "schema";
 
+  const defaultSchema = getDefaultJsonSchema(new Date());
   return {
     schemaType,
-    simple: jsonSchema?.simple ?? DEFAULT_JSON_SCHEMA.simple,
-    schema: jsonSchema?.schema ?? DEFAULT_JSON_SCHEMA.schema,
-    date: new Date(),
-    enabled: jsonSchema?.enabled ?? DEFAULT_JSON_SCHEMA.enabled,
+    simple: jsonSchema?.simple ?? defaultSchema.simple,
+    schema: jsonSchema?.schema ?? defaultSchema.schema,
+    date: defaultSchema.date,
+    enabled: jsonSchema?.enabled ?? defaultSchema.enabled,
   };
 }
 
@@ -41,10 +44,7 @@ export function parseApiJsonSchema(
   org: OrganizationInterface,
   jsonSchema: string | undefined,
 ): JSONSchemaDef {
-  const jsonSchemaWrapper: JSONSchemaDef = {
-    ...DEFAULT_JSON_SCHEMA,
-    date: new Date(),
-  };
+  const jsonSchemaWrapper = getDefaultJsonSchema(new Date());
   if (!jsonSchema) return jsonSchemaWrapper;
   if (!orgHasPremiumFeature(org, "json-validation")) return jsonSchemaWrapper;
   try {

--- a/packages/back-end/src/util/feature-json-schema.ts
+++ b/packages/back-end/src/util/feature-json-schema.ts
@@ -1,4 +1,15 @@
 import { FeatureInterface, JSONSchemaDef } from "shared/types/feature";
+import { OrganizationInterface } from "shared/types/organization";
+import { orgHasPremiumFeature } from "back-end/src/enterprise";
+import { logger } from "back-end/src/util/logger";
+
+const DEFAULT_JSON_SCHEMA: JSONSchemaDef = {
+  schemaType: "schema",
+  schema: "",
+  simple: { type: "object", fields: [] },
+  date: new Date(),
+  enabled: false,
+};
 
 /**
  * Creates the JSON schema payload for a newly-created feature.
@@ -15,12 +26,33 @@ export function getInitialFeatureJsonSchema(
 
   return {
     schemaType,
-    simple: jsonSchema?.simple ?? {
-      type: "object",
-      fields: [],
-    },
-    schema: jsonSchema?.schema ?? "",
+    simple: jsonSchema?.simple ?? DEFAULT_JSON_SCHEMA.simple,
+    schema: jsonSchema?.schema ?? DEFAULT_JSON_SCHEMA.schema,
     date: new Date(),
-    enabled: jsonSchema?.enabled ?? false,
+    enabled: jsonSchema?.enabled ?? DEFAULT_JSON_SCHEMA.enabled,
   };
+}
+
+/**
+ * Builds a JSONSchemaDef for the external REST API.
+ * Gates on the `json-validation` premium feature and validates the raw JSON string.
+ */
+export function parseApiJsonSchema(
+  org: OrganizationInterface,
+  jsonSchema: string | undefined,
+): JSONSchemaDef {
+  const jsonSchemaWrapper: JSONSchemaDef = {
+    ...DEFAULT_JSON_SCHEMA,
+    date: new Date(),
+  };
+  if (!jsonSchema) return jsonSchemaWrapper;
+  if (!orgHasPremiumFeature(org, "json-validation")) return jsonSchemaWrapper;
+  try {
+    jsonSchemaWrapper.schema = JSON.stringify(JSON.parse(jsonSchema));
+    jsonSchemaWrapper.enabled = true;
+    return jsonSchemaWrapper;
+  } catch (e) {
+    logger.error(e, "Failed to parse feature json schema");
+    return jsonSchemaWrapper;
+  }
 }

--- a/packages/back-end/test/util/feature-json-schema.test.ts
+++ b/packages/back-end/test/util/feature-json-schema.test.ts
@@ -48,4 +48,23 @@ describe("getInitialFeatureJsonSchema", () => {
     );
     expect(schema.date).toBeInstanceOf(Date);
   });
+
+  it("falls back to schema mode when schemaType is invalid at runtime", () => {
+    const sourceSchema = {
+      schemaType: "custom",
+      schema: '{"type":"object"}',
+      simple: {
+        type: "object",
+        fields: [],
+      },
+      date: new Date("2025-01-01T00:00:00.000Z"),
+      enabled: true,
+    } as unknown as FeatureInterface["jsonSchema"];
+
+    const schema = getInitialFeatureJsonSchema(sourceSchema);
+
+    expect(schema.schemaType).toBe("schema");
+    expect(schema.schema).toBe('{"type":"object"}');
+    expect(schema.enabled).toBe(true);
+  });
 });

--- a/packages/back-end/test/util/feature-json-schema.test.ts
+++ b/packages/back-end/test/util/feature-json-schema.test.ts
@@ -29,7 +29,7 @@ describe("getInitialFeatureJsonSchema", () => {
       }),
     );
     expect(schema.date).toBeInstanceOf(Date);
-    expect(schema.date).not.toBe(sourceDate);
+    expect(schema.date.getTime()).toBeGreaterThan(sourceDate.getTime());
   });
 
   it("uses a disabled default schema when no source schema is provided", () => {

--- a/packages/back-end/test/util/feature-json-schema.test.ts
+++ b/packages/back-end/test/util/feature-json-schema.test.ts
@@ -1,0 +1,51 @@
+import { FeatureInterface } from "shared/types/feature";
+import { getInitialFeatureJsonSchema } from "back-end/src/util/feature-json-schema";
+
+describe("getInitialFeatureJsonSchema", () => {
+  it("preserves provided schema settings for duplicated features", () => {
+    const sourceDate = new Date("2025-01-01T00:00:00.000Z");
+    const sourceSchema: FeatureInterface["jsonSchema"] = {
+      schemaType: "simple",
+      schema: '{"type":"object"}',
+      simple: {
+        type: "object",
+        fields: [],
+      },
+      date: sourceDate,
+      enabled: true,
+    };
+
+    const schema = getInitialFeatureJsonSchema(sourceSchema);
+
+    expect(schema).toEqual(
+      expect.objectContaining({
+        schemaType: "simple",
+        schema: '{"type":"object"}',
+        simple: {
+          type: "object",
+          fields: [],
+        },
+        enabled: true,
+      }),
+    );
+    expect(schema.date).toBeInstanceOf(Date);
+    expect(schema.date).not.toBe(sourceDate);
+  });
+
+  it("uses a disabled default schema when no source schema is provided", () => {
+    const schema = getInitialFeatureJsonSchema(undefined);
+
+    expect(schema).toEqual(
+      expect.objectContaining({
+        schemaType: "schema",
+        schema: "",
+        simple: {
+          type: "object",
+          fields: [],
+        },
+        enabled: false,
+      }),
+    );
+    expect(schema.date).toBeInstanceOf(Date);
+  });
+});


### PR DESCRIPTION
## Summary
- preserve an existing feature's JSON validation schema when duplicating a feature
- add a helper util to initialize schema defaults consistently
- add regression tests for preserved schema behavior and missing-schema defaults

## Testing
- `corepack pnpm --filter back-end exec jest test/util/feature-json-schema.test.ts`
