### PR TITLE
fix(settings): restore CDN usage graph on Usage page for Orb billing

### DIFF
--- a/packages/front-end/pages/settings/usage.tsx
+++ b/packages/front-end/pages/settings/usage.tsx
@@ -1,7 +1,6 @@
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 import CloudUsage from "@/components/Settings/Usage/CloudUsage";
 import { useUser } from "@/services/UserContext";
-import OrbPortal from "@/enterprise/components/Billing/OrbPortal";
 
 export default function UsagePage() {
   const permissionsUtil = usePermissionsUtil();
@@ -31,7 +30,7 @@ export default function UsagePage() {
 
   return (
     <div className="container-fluid pagecontents">
-      {subscription?.billingPlatform === "orb" ? <OrbPortal /> : <CloudUsage />}
+      <CloudUsage />
     </div>
   );
 }

--- a/packages/front-end/test/components/settings/UsagePage.test.tsx
+++ b/packages/front-end/test/components/settings/UsagePage.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, beforeEach, expect, vi } from "vitest";
+import UsagePage from "@/pages/settings/usage";
+import usePermissionsUtil from "@/hooks/usePermissionsUtils";
+import { useUser } from "@/services/UserContext";
+
+vi.mock("@/hooks/usePermissionsUtils");
+vi.mock("@/services/UserContext");
+vi.mock("@/components/Settings/Usage/CloudUsage", () => ({
+  default: function MockCloudUsage() {
+    return <div data-testid="cloud-usage">Cloud Usage</div>;
+  },
+}));
+vi.mock("@/enterprise/components/Billing/OrbPortal", () => ({
+  default: function MockOrbPortal() {
+    return <div data-testid="orb-portal">Orb Portal</div>;
+  },
+}));
+
+describe("UsagePage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows access denied when user cannot view usage", () => {
+    // @ts-expect-error partial mock
+    vi.mocked(usePermissionsUtil).mockReturnValue({
+      canViewUsage: () => false,
+    });
+    // @ts-expect-error partial mock
+    vi.mocked(useUser).mockReturnValue({
+      subscription: {},
+    });
+
+    render(<UsagePage />);
+
+    expect(
+      screen.getByText("You do not have access to view this page."),
+    ).toBeInTheDocument();
+  });
+
+  it("shows Vercel billing info when subscription is managed by Vercel", () => {
+    // @ts-expect-error partial mock
+    vi.mocked(usePermissionsUtil).mockReturnValue({
+      canViewUsage: () => true,
+    });
+    // @ts-expect-error partial mock
+    vi.mocked(useUser).mockReturnValue({
+      subscription: {
+        isVercelIntegration: true,
+      },
+    });
+
+    render(<UsagePage />);
+
+    expect(
+      screen.getByText(/plan is managed by Vercel/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders CloudUsage for orb-billed subscriptions", () => {
+    // @ts-expect-error partial mock
+    vi.mocked(usePermissionsUtil).mockReturnValue({
+      canViewUsage: () => true,
+    });
+    // @ts-expect-error partial mock
+    vi.mocked(useUser).mockReturnValue({
+      subscription: {
+        billingPlatform: "orb",
+      },
+    });
+
+    render(<UsagePage />);
+
+    expect(screen.getByTestId("cloud-usage")).toBeInTheDocument();
+    expect(screen.queryByTestId("orb-portal")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- fix `/settings/usage` to always render the CDN usage graph component
- avoid rendering Orb customer portal on Usage, since Orb portal is already available on Billing
- add regression tests to ensure orb-billed organizations still see Cloud Usage on the Usage page

## Testing
- `corepack pnpm --filter front-end exec vitest run test/components/settings/UsagePage.test.tsx`

Closes #5634
