### PR TITLE
fix(sdk): preserve cipher options with remote evaluation

### DIFF
--- a/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
+++ b/packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx
@@ -126,11 +126,8 @@ export default function SDKConnectionForm({
   );
 
   const handleSecurityTabClick = (tab: string) => {
-    if (tab === "remote") {
-      form.setValue("encryptPayload", false);
-      form.setValue("hashSecureAttributes", false);
-      form.setValue("includeExperimentNames", true);
-    }
+    // Preserve cipher toggles when moving to remote evaluation. Remote+cipher
+    // combinations are valid advanced configurations.
     setSelectedSecurityTab(tab);
   };
 


### PR DESCRIPTION
## Summary
- fix SDK Connection form behavior that cleared cipher settings when switching to the `Remote Evaluated` security tab
- preserve `encryptPayload`, `hashSecureAttributes`, and experiment-name visibility when selecting remote evaluation
- keep remote+cipher combinations available as an advanced configuration (as indicated by existing UI guidance)

## Testing
- `corepack pnpm --filter front-end type-check`

Closes #5423
