### PR TITLE
Split experiment snapshot results into per-metric documents

### DIFF
--- a/packages/back-end/src/app.ts
+++ b/packages/back-end/src/app.ts
@@ -625,6 +625,10 @@ app.get(
 app.get("/experiment/:id", experimentsController.getExperiment);
 app.get("/experiment/:id/reports", reportsController.getReportsOnExperiment);
 app.get("/snapshot/:id", experimentsController.getSnapshotById);
+app.get(
+  "/snapshot/:id/metric-results",
+  experimentsController.getSnapshotMetricResults,
+);
 app.post("/snapshot/:id/cancel", experimentsController.cancelSnapshot);
 app.post("/snapshot/:id/analysis", experimentsController.postSnapshotAnalysis);
 app.get("/experiment/:id/snapshot/:phase", experimentsController.getSnapshot);

--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -87,6 +87,7 @@ import {
   updateSnapshot,
   updateSnapshotsOnPhaseDelete,
 } from "back-end/src/models/ExperimentSnapshotModel";
+import { queryExperimentSnapshotMetricResults } from "back-end/src/models/ExperimentSnapshotMetricResultModel";
 import { getIntegrationFromDatasourceId } from "back-end/src/services/datasource";
 import { addTagsDiff } from "back-end/src/models/TagModel";
 import {
@@ -986,6 +987,80 @@ export async function getSnapshotById(
   res.status(200).json({
     status: 200,
     snapshot,
+  });
+}
+
+/**
+ * Fetch a subset of per-metric snapshot analysis rows (for lazy-loading UI).
+ * Query: analysisIndex (required), metricIds (comma-separated), dimensionNames (comma-separated), parentMetricId (optional).
+ */
+export async function getSnapshotMetricResults(
+  req: AuthRequest<
+    null,
+    { id: string },
+    {
+      analysisIndex?: string;
+      metricIds?: string;
+      dimensionNames?: string;
+      parentMetricId?: string;
+    }
+  >,
+  res: Response,
+) {
+  const context = getContextFromReq(req);
+  const { id } = req.params;
+  const analysisIndex = parseInt(req.query.analysisIndex || "", 10);
+  if (Number.isNaN(analysisIndex)) {
+    return res.status(400).json({
+      status: 400,
+      message: "Query parameter analysisIndex is required and must be a number",
+    });
+  }
+
+  const snapshot = await findSnapshotById(context.org.id, id);
+  if (!snapshot) {
+    return res.status(400).json({
+      status: 400,
+      message: "No snapshot found with that id",
+    });
+  }
+
+  const experiment = await getExperimentById(context, snapshot.experiment);
+  if (!experiment) {
+    return res.status(400).json({
+      status: 400,
+      message: "No snapshot found with that id",
+    });
+  }
+
+  const metricIds = req.query.metricIds
+    ?.split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const dimensionNames = req.query.dimensionNames
+    ?.split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  const parentMetricId =
+    typeof req.query.parentMetricId === "string"
+      ? req.query.parentMetricId
+      : undefined;
+
+  const snapshotIdForResults = snapshot.sourceSnapshotId || id;
+
+  const metricResults = await queryExperimentSnapshotMetricResults({
+    organization: context.org.id,
+    snapshotId: snapshotIdForResults,
+    analysisIndex,
+    metricIds: metricIds?.length ? metricIds : undefined,
+    dimensionNames: dimensionNames?.length ? dimensionNames : undefined,
+    parentMetricId,
+  });
+
+  res.status(200).json({
+    status: 200,
+    metricResults,
   });
 }
 

--- a/packages/back-end/src/controllers/reports.ts
+++ b/packages/back-end/src/controllers/reports.ts
@@ -61,6 +61,8 @@ export async function postReportFromSnapshot(
   if (!snapshot) {
     throw new Error("Invalid snapshot id");
   }
+  // Capture the source before overwriting the id for the clone
+  const sourceSnapshotId = snapshot.sourceSnapshotId || snapshot.id;
   // Prepare a new report-specific snapshot
   snapshot.id = uniqid("snp_");
   snapshot.type = "report";
@@ -149,9 +151,26 @@ export async function postReportFromSnapshot(
     experimentAnalysisSettings: _experimentAnalysisSettings,
   });
 
-  // Save the snapshot
+  // Clone the snapshot.  Per-metric analyses reference the source's metric
+  // rows via `sourceSnapshotId` (no duplication).  Legacy analyses with
+  // inline results are copied forward as-is (they're under 16 MB by
+  // definition since they fit in the source document).
   snapshot.report = doc.id;
-  await createExperimentSnapshotModel({ data: snapshot });
+
+  const hasPerMetricAnalysis = snapshot.analyses.some(
+    (a) => a.resultsStoredPerMetric,
+  );
+
+  const { analyses, ...rest } = snapshot;
+  await createExperimentSnapshotModel({
+    data: {
+      ...rest,
+      ...(hasPerMetricAnalysis ? { sourceSnapshotId } : {}),
+      analyses: analyses.map((a) =>
+        a.resultsStoredPerMetric ? { ...a, results: undefined } : a,
+      ),
+    },
+  });
 
   await req.audit({
     event: "experiment.analysis",

--- a/packages/back-end/src/models/ExperimentSnapshotMetricResultModel.ts
+++ b/packages/back-end/src/models/ExperimentSnapshotMetricResultModel.ts
@@ -1,7 +1,7 @@
 import { FilterQuery } from "mongoose";
+import uniqid from "uniqid";
 import type { ExperimentSnapshotMetricResultInterface } from "shared/types/experiment-snapshot";
 import { experimentSnapshotMetricResultValidator } from "shared/validators";
-import { promiseAllChunks } from "back-end/src/util/promise";
 import { Context, MakeModelClass } from "./BaseModel";
 
 const BaseClass = MakeModelClass({
@@ -63,34 +63,36 @@ export class ExperimentSnapshotMetricResultModel extends BaseClass {
     });
   }
 
-  // TODO: Replace per-row this.create() with a bulk insertMany for better
-  // write throughput.  Large snapshots can produce hundreds of metric rows,
-  // and individual round-trips become a bottleneck.
   public async insertRows(
-    rows: Omit<ExperimentSnapshotMetricResultInterface, "id">[],
+    rows: Omit<
+      ExperimentSnapshotMetricResultInterface,
+      "id" | "organization" | "dateCreated" | "dateUpdated"
+    >[],
   ): Promise<void> {
     if (!rows.length) return;
-    await promiseAllChunks(
-      rows.map((row) => async () => {
-        await this.create(row);
-      }),
-      10,
-    );
+    const now = new Date();
+    const docs = rows.map((row) => ({
+      ...row,
+      id: uniqid("esmr_"),
+      organization: this.context.org.id,
+      dateCreated: now,
+      dateUpdated: now,
+    }));
+    await this._dangerousGetCollection().insertMany(docs);
   }
 
   public async findForAnalysis(
     snapshotId: string,
     analysisIndex: number,
   ): Promise<ExperimentSnapshotMetricResultInterface[]> {
-    return (await this._find(
-      {
+    return (await this._dangerousGetCollection()
+      .find({
+        organization: this.context.org.id,
         snapshotId,
         analysisIndex,
-      },
-      {
-        sort: { dimensionValue: 1, metricId: 1 },
-      },
-    )) as ExperimentSnapshotMetricResultInterface[];
+      })
+      .sort({ dimensionValue: 1, metricId: 1 })
+      .toArray()) as unknown as ExperimentSnapshotMetricResultInterface[];
   }
 
   public async queryRows({
@@ -106,10 +108,8 @@ export class ExperimentSnapshotMetricResultModel extends BaseClass {
     dimensionNames?: string[];
     parentMetricId?: string;
   }): Promise<ExperimentSnapshotMetricResultInterface[]> {
-    const filter: FilterQuery<ExperimentSnapshotMetricResultInterface> & {
-      metricId?: { $in: string[] };
-      dimensionName?: { $in: string[] };
-    } = {
+    const filter: FilterQuery<ExperimentSnapshotMetricResultInterface> = {
+      organization: this.context.org.id,
       snapshotId,
       analysisIndex,
     };
@@ -117,9 +117,10 @@ export class ExperimentSnapshotMetricResultModel extends BaseClass {
     if (metricIds?.length) filter.metricId = { $in: metricIds };
     if (dimensionNames?.length) filter.dimensionName = { $in: dimensionNames };
 
-    return (await this._find(filter, {
-      sort: { dimensionValue: 1, metricId: 1 },
-    })) as ExperimentSnapshotMetricResultInterface[];
+    return (await this._dangerousGetCollection()
+      .find(filter)
+      .sort({ dimensionValue: 1, metricId: 1 })
+      .toArray()) as unknown as ExperimentSnapshotMetricResultInterface[];
   }
 }
 
@@ -147,10 +148,14 @@ export async function deleteExperimentSnapshotMetricResultsForAnalysis(
 }
 
 export async function insertExperimentSnapshotMetricResults(
-  rows: Omit<ExperimentSnapshotMetricResultInterface, "id">[],
+  organization: string,
+  rows: Omit<
+    ExperimentSnapshotMetricResultInterface,
+    "id" | "organization" | "dateCreated" | "dateUpdated"
+  >[],
 ): Promise<void> {
   if (!rows.length) return;
-  await scopedModel(rows[0].organization).insertRows(rows);
+  await scopedModel(organization).insertRows(rows);
 }
 
 export async function findExperimentSnapshotMetricResultsForAnalysis({

--- a/packages/back-end/src/models/ExperimentSnapshotMetricResultModel.ts
+++ b/packages/back-end/src/models/ExperimentSnapshotMetricResultModel.ts
@@ -1,0 +1,190 @@
+import { FilterQuery } from "mongoose";
+import type { ExperimentSnapshotMetricResultInterface } from "shared/types/experiment-snapshot";
+import { experimentSnapshotMetricResultValidator } from "shared/validators";
+import { promiseAllChunks } from "back-end/src/util/promise";
+import { Context, MakeModelClass } from "./BaseModel";
+
+const BaseClass = MakeModelClass({
+  schema: experimentSnapshotMetricResultValidator,
+  collectionName: "experimentsnapshotmetricresults",
+  idPrefix: "esmr_",
+  globallyUniquePrimaryKeys: true,
+  additionalIndexes: [
+    {
+      fields: {
+        organization: 1,
+        snapshotId: 1,
+        analysisIndex: 1,
+        metricId: 1,
+        dimensionName: 1,
+      },
+      unique: true,
+    },
+    {
+      fields: {
+        organization: 1,
+        parentMetricId: 1,
+        snapshotId: 1,
+        analysisIndex: 1,
+      },
+    },
+  ],
+});
+
+export class ExperimentSnapshotMetricResultModel extends BaseClass {
+  protected canRead() {
+    return true;
+  }
+  protected canCreate() {
+    return true;
+  }
+  protected canUpdate() {
+    return true;
+  }
+  protected canDelete() {
+    return true;
+  }
+
+  public async deleteForSnapshot(snapshotId: string): Promise<void> {
+    await this._dangerousGetCollection().deleteMany({
+      organization: this.context.org.id,
+      snapshotId,
+    });
+  }
+
+  public async deleteForAnalysis(
+    snapshotId: string,
+    analysisIndex: number,
+  ): Promise<void> {
+    await this._dangerousGetCollection().deleteMany({
+      organization: this.context.org.id,
+      snapshotId,
+      analysisIndex,
+    });
+  }
+
+  // TODO: Replace per-row this.create() with a bulk insertMany for better
+  // write throughput.  Large snapshots can produce hundreds of metric rows,
+  // and individual round-trips become a bottleneck.
+  public async insertRows(
+    rows: Omit<ExperimentSnapshotMetricResultInterface, "id">[],
+  ): Promise<void> {
+    if (!rows.length) return;
+    await promiseAllChunks(
+      rows.map((row) => async () => {
+        await this.create(row);
+      }),
+      10,
+    );
+  }
+
+  public async findForAnalysis(
+    snapshotId: string,
+    analysisIndex: number,
+  ): Promise<ExperimentSnapshotMetricResultInterface[]> {
+    return (await this._find(
+      {
+        snapshotId,
+        analysisIndex,
+      },
+      {
+        sort: { dimensionValue: 1, metricId: 1 },
+      },
+    )) as ExperimentSnapshotMetricResultInterface[];
+  }
+
+  public async queryRows({
+    snapshotId,
+    analysisIndex,
+    metricIds,
+    dimensionNames,
+    parentMetricId,
+  }: {
+    snapshotId: string;
+    analysisIndex: number;
+    metricIds?: string[];
+    dimensionNames?: string[];
+    parentMetricId?: string;
+  }): Promise<ExperimentSnapshotMetricResultInterface[]> {
+    const filter: FilterQuery<ExperimentSnapshotMetricResultInterface> & {
+      metricId?: { $in: string[] };
+      dimensionName?: { $in: string[] };
+    } = {
+      snapshotId,
+      analysisIndex,
+    };
+    if (parentMetricId) filter.parentMetricId = parentMetricId;
+    if (metricIds?.length) filter.metricId = { $in: metricIds };
+    if (dimensionNames?.length) filter.dimensionName = { $in: dimensionNames };
+
+    return (await this._find(filter, {
+      sort: { dimensionValue: 1, metricId: 1 },
+    })) as ExperimentSnapshotMetricResultInterface[];
+  }
+}
+
+function scopedModel(
+  organization: string,
+): ExperimentSnapshotMetricResultModel {
+  return new ExperimentSnapshotMetricResultModel({
+    org: { id: organization },
+  } as unknown as Context);
+}
+
+export async function deleteExperimentSnapshotMetricResultsForSnapshot(
+  organization: string,
+  snapshotId: string,
+): Promise<void> {
+  await scopedModel(organization).deleteForSnapshot(snapshotId);
+}
+
+export async function deleteExperimentSnapshotMetricResultsForAnalysis(
+  organization: string,
+  snapshotId: string,
+  analysisIndex: number,
+): Promise<void> {
+  await scopedModel(organization).deleteForAnalysis(snapshotId, analysisIndex);
+}
+
+export async function insertExperimentSnapshotMetricResults(
+  rows: Omit<ExperimentSnapshotMetricResultInterface, "id">[],
+): Promise<void> {
+  if (!rows.length) return;
+  await scopedModel(rows[0].organization).insertRows(rows);
+}
+
+export async function findExperimentSnapshotMetricResultsForAnalysis({
+  organization,
+  snapshotId,
+  analysisIndex,
+}: {
+  organization: string;
+  snapshotId: string;
+  analysisIndex: number;
+}): Promise<ExperimentSnapshotMetricResultInterface[]> {
+  return scopedModel(organization).findForAnalysis(snapshotId, analysisIndex);
+}
+
+export async function queryExperimentSnapshotMetricResults({
+  organization,
+  snapshotId,
+  analysisIndex,
+  metricIds,
+  dimensionNames,
+  parentMetricId,
+}: {
+  organization: string;
+  snapshotId: string;
+  analysisIndex: number;
+  metricIds?: string[];
+  dimensionNames?: string[];
+  parentMetricId?: string;
+}): Promise<ExperimentSnapshotMetricResultInterface[]> {
+  return scopedModel(organization).queryRows({
+    snapshotId,
+    analysisIndex,
+    metricIds,
+    dimensionNames,
+    parentMetricId,
+  });
+}

--- a/packages/back-end/src/models/ExperimentSnapshotModel.ts
+++ b/packages/back-end/src/models/ExperimentSnapshotModel.ts
@@ -1,5 +1,6 @@
 import mongoose, { FilterQuery, PipelineStage } from "mongoose";
 import omit from "lodash/omit";
+import isEqual from "lodash/isEqual";
 import {
   snapshotSatisfiesBlock,
   blockHasFieldOfType,
@@ -12,6 +13,16 @@ import {
   ExperimentSnapshotInterface,
   LegacyExperimentSnapshotInterface,
 } from "shared/types/experiment-snapshot";
+import {
+  deleteExperimentSnapshotMetricResultsForAnalysis,
+  deleteExperimentSnapshotMetricResultsForSnapshot,
+  findExperimentSnapshotMetricResultsForAnalysis,
+  insertExperimentSnapshotMetricResults,
+} from "back-end/src/models/ExperimentSnapshotMetricResultModel";
+import {
+  mergeMetricResultRowsToAnalysisResults,
+  splitAnalysisResultsToMetricResultRows,
+} from "back-end/src/services/experimentSnapshotMetricResults";
 import { logger } from "back-end/src/util/logger";
 import { migrateSnapshot } from "back-end/src/util/migrations";
 import { notifyExperimentChange } from "back-end/src/services/experimentNotifications";
@@ -70,6 +81,7 @@ const experimentSnapshotSchema = new mongoose.Schema({
   queryLanguage: String,
   error: String,
   queries: queriesSchema,
+  sourceSnapshotId: String,
   dimension: String,
   unknownVariations: [String],
   multipleExposures: Number,
@@ -189,18 +201,61 @@ const ExperimentSnapshotModel =
     experimentSnapshotSchema,
   );
 
-const toInterface = (
-  doc: ExperimentSnapshotDocument,
-): ExperimentSnapshotInterface =>
-  migrateSnapshot(
-    omit(doc.toJSON<ExperimentSnapshotDocument>(), ["__v", "_id"]),
-  );
+// INVARIANT: `analysisIndex` stored on metric-result rows must match the
+// position of the corresponding analysis in `snapshot.analyses[]`.  The
+// analyses array is only ever appended to ($push) or updated in-place
+// (positional $set); it must NEVER be reordered or spliced.  If that
+// invariant is violated, metric rows will hydrate into the wrong analysis.
+async function hydrateExperimentSnapshotMetricResults(
+  snapshot: ExperimentSnapshotInterface,
+): Promise<void> {
+  if (!snapshot.analyses?.length) return;
+
+  const snapshotIdForResults = snapshot.sourceSnapshotId || snapshot.id;
+
+  for (let i = 0; i < snapshot.analyses.length; i++) {
+    const analysis = snapshot.analyses[i];
+    if (!analysis.resultsStoredPerMetric) continue;
+
+    const rows = await findExperimentSnapshotMetricResultsForAnalysis({
+      organization: snapshot.organization,
+      snapshotId: snapshotIdForResults,
+      analysisIndex: i,
+    });
+    analysis.results = mergeMetricResultRowsToAnalysisResults(rows);
+  }
+}
+
+const documentToInterface = async (
+  doc: ExperimentSnapshotDocument | Record<string, unknown>,
+): Promise<ExperimentSnapshotInterface> => {
+  const raw = omit(
+    doc instanceof mongoose.Document
+      ? (doc as ExperimentSnapshotDocument).toJSON()
+      : doc,
+    ["__v", "_id"],
+  ) as LegacyExperimentSnapshotInterface;
+  const snapshot = migrateSnapshot(raw);
+  await hydrateExperimentSnapshotMetricResults(snapshot);
+  return snapshot;
+};
 
 export async function updateSnapshotsOnPhaseDelete(
   organization: string,
   experiment: string,
   phase: number,
 ) {
+  const snapshots = await ExperimentSnapshotModel.find({
+    organization,
+    experiment,
+    phase,
+  })
+    .select("id")
+    .lean();
+  for (const s of snapshots) {
+    await deleteExperimentSnapshotMetricResultsForSnapshot(organization, s.id);
+  }
+
   // Delete all snapshots for the phase
   await ExperimentSnapshotModel.deleteMany({
     organization,
@@ -268,16 +323,19 @@ export async function updateSnapshot({
       : false;
 
     if (currentExperimentModel && isLatestPhase) {
+      const hydratedSnapshot = await documentToInterface(
+        experimentSnapshotModel,
+      );
       const updatedExperimentModel = await updateExperimentAnalysisSummary({
         context,
         experiment: currentExperimentModel,
-        experimentSnapshot: experimentSnapshotModel,
+        experimentSnapshot: hydratedSnapshot,
       });
 
       const notificationsTriggered = await notifyExperimentChange({
         context,
         experiment: updatedExperimentModel,
-        snapshot: experimentSnapshotModel,
+        snapshot: hydratedSnapshot,
         previousAnalysisSummary: currentExperimentModel.analysisSummary,
       });
 
@@ -286,7 +344,7 @@ export async function updateSnapshot({
           context,
           experiment: updatedExperimentModel,
           previousAnalysisSummary: currentExperimentModel.analysisSummary,
-          experimentSnapshot: experimentSnapshotModel,
+          experimentSnapshot: hydratedSnapshot,
           notificationsTriggered,
         });
       } catch (error) {
@@ -377,6 +435,39 @@ export async function updateSnapshotAnalysis({
   id: string;
   analysis: ExperimentSnapshotAnalysis;
 }) {
+  const current = await ExperimentSnapshotModel.findOne({ organization, id });
+  if (!current) throw "Internal error";
+
+  const analyses =
+    (current.analyses as ExperimentSnapshotAnalysis[] | undefined) ?? [];
+  const analysisIndex = analyses.findIndex((a) =>
+    isEqual(a.settings, analysis.settings),
+  );
+  if (analysisIndex < 0) throw "Internal error";
+
+  await deleteExperimentSnapshotMetricResultsForAnalysis(
+    organization,
+    id,
+    analysisIndex,
+  );
+
+  let stored: ExperimentSnapshotAnalysis = { ...analysis };
+  if (analysis.status === "success" && analysis.results?.length) {
+    const rows = splitAnalysisResultsToMetricResultRows(analysis.results, {
+      organization,
+      snapshotId: id,
+      analysisIndex,
+    });
+    await insertExperimentSnapshotMetricResults(rows);
+    stored = {
+      ...analysis,
+      results: [],
+      resultsStoredPerMetric: true,
+    };
+  } else {
+    delete stored.resultsStoredPerMetric;
+  }
+
   await ExperimentSnapshotModel.updateOne(
     {
       organization,
@@ -384,7 +475,7 @@ export async function updateSnapshotAnalysis({
       "analyses.settings": analysis.settings,
     },
     {
-      $set: { "analyses.$": analysis },
+      $set: { "analyses.$": stored },
     },
   );
 
@@ -403,6 +494,7 @@ export async function updateSnapshotAnalysis({
 }
 
 export async function deleteSnapshotById(organization: string, id: string) {
+  await deleteExperimentSnapshotMetricResultsForSnapshot(organization, id);
   await ExperimentSnapshotModel.deleteOne({ organization, id });
 }
 
@@ -411,7 +503,7 @@ export async function findSnapshotById(
   id: string,
 ): Promise<ExperimentSnapshotInterface | null> {
   const doc = await ExperimentSnapshotModel.findOne({ organization, id });
-  return doc ? toInterface(doc) : null;
+  return doc ? await documentToInterface(doc) : null;
 }
 
 export async function findSnapshotsByIds(
@@ -422,7 +514,7 @@ export async function findSnapshotsByIds(
     organization: context.org.id,
     id: { $in: ids },
   });
-  return docs.map(toInterface);
+  return Promise.all(docs.map((d) => documentToInterface(d)));
 }
 
 export async function findRunningSnapshotsByQueryId(ids: string[]) {
@@ -437,7 +529,7 @@ export async function findRunningSnapshotsByQueryId(ids: string[]) {
     queries: { $elemMatch: { query: { $in: ids }, status: "running" } },
   });
 
-  return docs.map((doc) => toInterface(doc));
+  return Promise.all(docs.map((doc) => documentToInterface(doc)));
 }
 
 export async function errorSnapshotIfStillRunning(
@@ -465,7 +557,7 @@ export async function findStalledRunningSnapshots(
     dateCreated: { $gt: earliestDate, $lt: stalledBefore },
   }).limit(limit);
 
-  return docs.map((doc) => toInterface(doc));
+  return Promise.all(docs.map((doc) => documentToInterface(doc)));
 }
 
 export async function findLatestRunningSnapshotByReportId(
@@ -485,7 +577,7 @@ export async function findLatestRunningSnapshotByReportId(
     queries: { $elemMatch: { status: "running" } },
   });
 
-  return doc ? toInterface(doc) : null;
+  return doc ? await documentToInterface(doc) : null;
 }
 
 export async function getLatestSnapshot({
@@ -499,7 +591,7 @@ export async function getLatestSnapshot({
   experiment: string;
   phase: number;
   dimension?: string;
-  beforeSnapshot?: ExperimentSnapshotDocument;
+  beforeSnapshot?: ExperimentSnapshotDocument | ExperimentSnapshotInterface;
   withResults?: boolean;
   type?: SnapshotType;
 }): Promise<ExperimentSnapshotInterface | null> {
@@ -569,11 +661,11 @@ export async function getLatestSnapshot({
       ).exec();
 
       if (runningSnapshot) {
-        return toInterface(runningSnapshot);
+        return await documentToInterface(runningSnapshot);
       }
     }
 
-    return toInterface(mostRecentSnapshot);
+    return await documentToInterface(mostRecentSnapshot);
   }
 
   // Otherwise, try getting old snapshot records
@@ -586,7 +678,7 @@ export async function getLatestSnapshot({
     limit: 1,
   }).exec();
 
-  return all[0] ? toInterface(all[0]) : null;
+  return all[0] ? await documentToInterface(all[0]) : null;
 }
 
 // Gets latest snapshots per experiment-phase pair
@@ -635,30 +727,64 @@ export async function getLatestSnapshotMultipleExperiments(
 
   const snapshots: ExperimentSnapshotInterface[] = [];
   if (all[0]) {
-    // get interfaces matching the right phase
-    all.forEach((doc) => {
-      // aggregate returns document directly, no need for toJSON
-      const snapshot = migrateSnapshot(omit(doc, ["__v", "_id"]));
+    const hydrated = await Promise.all(
+      all.map((doc) =>
+        documentToInterface(
+          omit(doc, ["__v", "_id"]) as Record<string, unknown>,
+        ),
+      ),
+    );
+    for (const snapshot of hydrated) {
       const desiredPhase = experimentPhaseMap.get(snapshot.experiment);
       if (desiredPhase !== undefined && snapshot.phase === desiredPhase) {
         snapshots.push(snapshot);
         experimentPhasesToGet.delete(snapshot.experiment);
       }
-    });
+    }
   }
 
   return snapshots;
 }
 
+/**
+ * Input type for creating snapshots.  `results` defaults to `[]` when omitted.
+ *
+ * Fresh snapshots should omit `results` — they are populated later via
+ * `updateSnapshotAnalysis`, which splits metric data into the side collection.
+ *
+ * Snapshot clones (e.g. reports) may pass `resultsStoredPerMetric: true`
+ * on analyses whose metric rows live on a source snapshot (referenced via
+ * `sourceSnapshotId`), or pass inline `results` for legacy analyses that
+ * are small enough to fit in the document.
+ */
+export type CreateExperimentSnapshotInput = Omit<
+  ExperimentSnapshotInterface,
+  "analyses"
+> & {
+  analyses: (Omit<ExperimentSnapshotAnalysis, "results"> & {
+    results?: ExperimentSnapshotAnalysis["results"];
+  })[];
+};
+
 export async function createExperimentSnapshotModel({
   data,
 }: {
-  data: ExperimentSnapshotInterface;
+  data: CreateExperimentSnapshotInput;
 }): Promise<ExperimentSnapshotInterface> {
-  const created = await ExperimentSnapshotModel.create(data);
-  return toInterface(created);
+  const withDefaults = {
+    ...data,
+    analyses: data.analyses.map((a) => ({
+      ...a,
+      results: a.results ?? [],
+    })),
+  };
+  const created = await ExperimentSnapshotModel.create(withDefaults);
+  return await documentToInterface(created);
 }
 
-export const getDefaultAnalysisResults = (
+export async function getDefaultAnalysisResults(
   snapshot: ExperimentSnapshotDocument,
-) => snapshot.analyses?.[0]?.results?.[0];
+) {
+  const s = await documentToInterface(snapshot);
+  return s.analyses?.[0]?.results?.[0];
+}

--- a/packages/back-end/src/models/ExperimentSnapshotModel.ts
+++ b/packages/back-end/src/models/ExperimentSnapshotModel.ts
@@ -454,11 +454,10 @@ export async function updateSnapshotAnalysis({
   let stored: ExperimentSnapshotAnalysis = { ...analysis };
   if (analysis.status === "success" && analysis.results?.length) {
     const rows = splitAnalysisResultsToMetricResultRows(analysis.results, {
-      organization,
       snapshotId: id,
       analysisIndex,
     });
-    await insertExperimentSnapshotMetricResults(rows);
+    await insertExperimentSnapshotMetricResults(organization, rows);
     stored = {
       ...analysis,
       results: [],

--- a/packages/back-end/src/services/context.ts
+++ b/packages/back-end/src/services/context.ts
@@ -61,6 +61,7 @@ import { AiPromptModel } from "back-end/src/enterprise/models/AIPromptModel";
 import { VectorsModel } from "back-end/src/enterprise/models/VectorsModel";
 import { AgreementModel } from "back-end/src/models/AgreementModel";
 import { SqlResultChunkModel } from "back-end/src/models/SqlResultChunkModel";
+import { ExperimentSnapshotMetricResultModel } from "back-end/src/models/ExperimentSnapshotMetricResultModel";
 import { CustomHookModel } from "back-end/src/models/CustomHookModel";
 import { RampScheduleModel } from "back-end/src/models/RampScheduleModel";
 import { RampScheduleTemplateModel } from "back-end/src/models/RampScheduleTemplateModel";
@@ -104,6 +105,7 @@ export type ModelName =
   | "customHooks"
   | "incrementalRefresh"
   | "sqlResultChunks"
+  | "experimentSnapshotMetricResults"
   | "sdkConnectionCache"
   | "sdkWebhooks"
   | "savedGroups"
@@ -140,6 +142,7 @@ export const modelClasses = {
   customHooks: CustomHookModel,
   incrementalRefresh: IncrementalRefreshModel,
   sqlResultChunks: SqlResultChunkModel,
+  experimentSnapshotMetricResults: ExperimentSnapshotMetricResultModel,
   sdkConnectionCache: SdkConnectionCacheModel,
   sdkWebhooks: SdkWebhookModel,
   savedGroups: SavedGroupModel,
@@ -185,6 +188,9 @@ export class ReqContextClass {
       customHooks: new CustomHookModel(this),
       incrementalRefresh: new IncrementalRefreshModel(this),
       sqlResultChunks: new SqlResultChunkModel(this),
+      experimentSnapshotMetricResults: new ExperimentSnapshotMetricResultModel(
+        this,
+      ),
       sdkConnectionCache: new SdkConnectionCacheModel(this),
       sdkWebhooks: new SdkWebhookModel(this),
       savedGroups: new SavedGroupModel(this),

--- a/packages/back-end/src/services/experimentNotifications.ts
+++ b/packages/back-end/src/services/experimentNotifications.ts
@@ -19,6 +19,7 @@ import {
 } from "shared/enterprise";
 import { ExperimentAnalysisSummary } from "shared/validators";
 import { StatsEngine } from "shared/types/stats";
+import { ExperimentSnapshotInterface } from "shared/types/experiment-snapshot";
 import {
   ExperimentHealthSettings,
   ExperimentInterface,
@@ -31,10 +32,7 @@ import { Context } from "back-end/src/models/BaseModel";
 import { createEvent, CreateEventData } from "back-end/src/models/EventModel";
 import { updateExperiment } from "back-end/src/models/ExperimentModel";
 import { logger } from "back-end/src/util/logger";
-import {
-  ExperimentSnapshotDocument,
-  getLatestSnapshot,
-} from "back-end/src/models/ExperimentSnapshotModel";
+import { getLatestSnapshot } from "back-end/src/models/ExperimentSnapshotModel";
 import { getExperimentMetricById } from "back-end/src/services/experiments";
 import {
   getConfidenceLevelsForOrg,
@@ -276,7 +274,7 @@ export const computeExperimentChanges = async ({
 }: {
   context: Context;
   experiment: ExperimentInterface;
-  snapshot: ExperimentSnapshotDocument;
+  snapshot: ExperimentSnapshotInterface;
 }): Promise<ExperimentSignificanceChange[]> => {
   const currentAnalysis = getSnapshotAnalysis(currentSnapshot);
   if (!currentAnalysis?.results?.[0]?.variations) {
@@ -421,7 +419,7 @@ export const notifySignificance = async ({
 }: {
   context: Context;
   experiment: ExperimentInterface;
-  snapshot: ExperimentSnapshotDocument;
+  snapshot: ExperimentSnapshotInterface;
 }) => {
   const experimentChanges = await computeExperimentChanges({
     context,
@@ -537,7 +535,7 @@ export const notifyExperimentChange = async ({
 }: {
   context: Context;
   experiment: ExperimentInterface;
-  snapshot: ExperimentSnapshotDocument;
+  snapshot: ExperimentSnapshotInterface;
   previousAnalysisSummary?: ExperimentAnalysisSummary;
 }) => {
   const notificationsTriggered: string[] = [];

--- a/packages/back-end/src/services/experimentSnapshotMetricResults.ts
+++ b/packages/back-end/src/services/experimentSnapshotMetricResults.ts
@@ -20,15 +20,23 @@ function collectMetricIdsForDimension(
 /**
  * Splits a full `results` array into one persisted row per (metricId × dimensionName).
  */
+/**
+ * Fields managed by BaseModel (organization, id, dateCreated, dateUpdated)
+ * are excluded — they are populated automatically on insert.
+ */
+type MetricResultRow = Omit<
+  ExperimentSnapshotMetricResultInterface,
+  "id" | "organization" | "dateCreated" | "dateUpdated"
+>;
+
 export function splitAnalysisResultsToMetricResultRows(
   results: ExperimentReportResultDimension[],
   ctx: {
-    organization: string;
     snapshotId: string;
     analysisIndex: number;
   },
-): Omit<ExperimentSnapshotMetricResultInterface, "id">[] {
-  const out: Omit<ExperimentSnapshotMetricResultInterface, "id">[] = [];
+): MetricResultRow[] {
+  const out: MetricResultRow[] = [];
 
   results.forEach((dim) => {
     const metricIds = collectMetricIdsForDimension(dim);
@@ -45,7 +53,6 @@ export function splitAnalysisResultsToMetricResultRows(
       });
 
       out.push({
-        organization: ctx.organization,
         snapshotId: ctx.snapshotId,
         analysisIndex: ctx.analysisIndex,
         metricId,

--- a/packages/back-end/src/services/experimentSnapshotMetricResults.ts
+++ b/packages/back-end/src/services/experimentSnapshotMetricResults.ts
@@ -1,0 +1,120 @@
+import type { ExperimentReportResultDimension } from "shared/types/report";
+import type {
+  ExperimentSnapshotMetricResultInterface,
+  SnapshotVariation,
+} from "shared/types/experiment-snapshot";
+import { parseSliceMetricId } from "shared/experiments";
+
+function collectMetricIdsForDimension(
+  dim: ExperimentReportResultDimension,
+): string[] {
+  const ids = new Set<string>();
+  for (const v of dim.variations) {
+    for (const k of Object.keys(v.metrics || {})) {
+      ids.add(k);
+    }
+  }
+  return Array.from(ids);
+}
+
+/**
+ * Splits a full `results` array into one persisted row per (metricId × dimensionName).
+ */
+export function splitAnalysisResultsToMetricResultRows(
+  results: ExperimentReportResultDimension[],
+  ctx: {
+    organization: string;
+    snapshotId: string;
+    analysisIndex: number;
+  },
+): Omit<ExperimentSnapshotMetricResultInterface, "id">[] {
+  const out: Omit<ExperimentSnapshotMetricResultInterface, "id">[] = [];
+
+  results.forEach((dim) => {
+    const metricIds = collectMetricIdsForDimension(dim);
+    for (const metricId of metricIds) {
+      const { baseMetricId } = parseSliceMetricId(metricId);
+      const variations = dim.variations.map((v) => {
+        const m = v.metrics[metricId];
+        if (!m) {
+          throw new Error(
+            `splitAnalysisResults: missing metric ${metricId} for dimension ${dim.name}`,
+          );
+        }
+        return { users: v.users, metric: m };
+      });
+
+      out.push({
+        organization: ctx.organization,
+        snapshotId: ctx.snapshotId,
+        analysisIndex: ctx.analysisIndex,
+        metricId,
+        parentMetricId: baseMetricId,
+        dimensionName: dim.name,
+        dimensionValue: dim.name,
+        srm: dim.srm,
+        variations,
+      });
+    }
+  });
+
+  return out;
+}
+
+/**
+ * Merges metric result rows back into `ExperimentReportResultDimension[]` (full analysis shape).
+ */
+export function mergeMetricResultRowsToAnalysisResults(
+  rows: ExperimentSnapshotMetricResultInterface[],
+): ExperimentReportResultDimension[] {
+  const byKey = new Map<
+    string,
+    {
+      name: string;
+      srm: number;
+      variations: SnapshotVariation[];
+    }
+  >();
+
+  const sorted = [...rows].sort((a, b) => {
+    if (a.dimensionValue !== b.dimensionValue) {
+      return a.dimensionValue.localeCompare(b.dimensionValue);
+    }
+    return a.metricId.localeCompare(b.metricId);
+  });
+
+  for (const row of sorted) {
+    const key = row.dimensionValue;
+    let dim = byKey.get(key);
+    if (!dim) {
+      dim = {
+        name: row.dimensionValue,
+        srm: row.srm,
+        variations: row.variations.map((v) => ({
+          users: v.users,
+          metrics: {},
+        })),
+      };
+      byKey.set(key, dim);
+    }
+
+    row.variations.forEach((v, idx) => {
+      if (!dim!.variations[idx]) {
+        dim!.variations[idx] = { users: v.users, metrics: {} };
+      }
+      dim!.variations[idx].users = Math.max(
+        dim!.variations[idx].users,
+        v.users,
+      );
+      dim!.variations[idx].metrics[row.metricId] = v.metric;
+    });
+  }
+
+  return Array.from(byKey.values())
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map((d) => ({
+      name: d.name,
+      srm: d.srm,
+      variations: d.variations,
+    }));
+}

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -138,6 +138,7 @@ import { addTags } from "back-end/src/models/TagModel";
 import {
   addOrUpdateSnapshotAnalysis,
   createExperimentSnapshotModel,
+  CreateExperimentSnapshotInput,
   getLatestSnapshotMultipleExperiments,
   updateSnapshot,
   updateSnapshotAnalysis,
@@ -1251,7 +1252,7 @@ async function planSnapshotQueryRunner({
 }
 
 export type PlannedExperimentSnapshot = {
-  snapshot: ExperimentSnapshotInterface;
+  snapshot: CreateExperimentSnapshotInput;
   runnerKind: SnapshotQueryRunnerKind;
   useCache: boolean;
   fullRefresh: boolean;
@@ -1325,7 +1326,7 @@ export async function planSnapshot({
       !experiment.disableStickyBucketing,
   });
 
-  const data: ExperimentSnapshotInterface = {
+  const data: CreateExperimentSnapshotInput = {
     id: uniqid("snp_"),
     organization: experiment.organization,
     experiment: experiment.id,
@@ -1343,21 +1344,16 @@ export async function planSnapshot({
     analyses: [
       {
         dateCreated: new Date(),
-        results: [],
         settings: defaultAnalysisSettings,
         status: "running",
       },
       ...additionalAnalysisSettings
         .filter((a) => isAnalysisAllowed(snapshotSettings, a))
-        .map((a) => {
-          const analysis: ExperimentSnapshotAnalysis = {
-            dateCreated: new Date(),
-            results: [],
-            settings: a,
-            status: "running",
-          };
-          return analysis;
-        }),
+        .map((a) => ({
+          dateCreated: new Date(),
+          settings: a,
+          status: "running" as const,
+        })),
     ],
     status: "running",
   };

--- a/packages/back-end/src/services/reports.ts
+++ b/packages/back-end/src/services/reports.ts
@@ -72,6 +72,7 @@ import { getDataSourceById } from "back-end/src/models/DataSourceModel";
 import { getExperimentById } from "back-end/src/models/ExperimentModel";
 import {
   createExperimentSnapshotModel,
+  CreateExperimentSnapshotInput,
   getLatestSnapshot,
 } from "back-end/src/models/ExperimentSnapshotModel";
 import { getSourceIntegrationObject } from "back-end/src/services/datasource";
@@ -559,7 +560,7 @@ export async function createReportSnapshot({
 
   const snapshotType = "report";
   // Fill in and sanitize the model
-  snapshotData = {
+  const createInput: CreateExperimentSnapshotInput = {
     ...snapshotData,
     id: uniqid("snp_"),
     type: snapshotType,
@@ -574,27 +575,29 @@ export async function createReportSnapshot({
     queries: [],
     unknownVariations: [],
     multipleExposures: 0,
-    analyses: snapshotData.analyses.map((analysis) => ({
-      ...analysis,
-      dateCreated: new Date(),
-      results: [],
-      status: "running",
-      settings: {
-        ...analysis.settings,
-        ...analysisSettings,
-      },
-    })),
+    analyses: snapshotData.analyses.map(
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      ({ results, resultsStoredPerMetric, ...analysis }) => ({
+        ...analysis,
+        dateCreated: new Date(),
+        status: "running" as const,
+        settings: {
+          ...analysis.settings,
+          ...analysisSettings,
+        },
+      }),
+    ),
   };
   if (
-    snapshotData?.health?.traffic &&
-    !snapshotData?.health?.traffic?.dimension
+    createInput?.health?.traffic &&
+    !createInput?.health?.traffic?.dimension
   ) {
     // fix a weird corruption in the model where formerly-empty Mongoose Map comes back missing:
-    snapshotData.health.traffic.dimension = {};
+    createInput.health.traffic.dimension = {};
   }
 
   const snapshot = await createExperimentSnapshotModel({
-    data: snapshotData,
+    data: createInput,
   });
 
   const integration = getSourceIntegrationObject(context, datasource, true);

--- a/packages/back-end/test/services/experimentSnapshotMetricResults.test.ts
+++ b/packages/back-end/test/services/experimentSnapshotMetricResults.test.ts
@@ -1,0 +1,53 @@
+import type { ExperimentReportResultDimension } from "shared/types/report";
+import type { SnapshotMetric } from "shared/types/experiment-snapshot";
+import {
+  mergeMetricResultRowsToAnalysisResults,
+  splitAnalysisResultsToMetricResultRows,
+} from "back-end/src/services/experimentSnapshotMetricResults";
+
+function m(_id: string): SnapshotMetric {
+  return {
+    value: 1,
+    cr: 1,
+    users: 10,
+    stats: { users: 10, mean: 1, count: 10, stddev: 0 },
+  };
+}
+
+describe("experimentSnapshotMetricResults", () => {
+  it("splits and merges round-trip", () => {
+    const results: ExperimentReportResultDimension[] = [
+      {
+        name: "All",
+        srm: 1,
+        variations: [
+          { users: 10, metrics: { a: m("a"), b: m("b") } },
+          { users: 10, metrics: { a: m("a"), b: m("b") } },
+        ],
+      },
+      {
+        name: "slice:x",
+        srm: 1,
+        variations: [
+          { users: 5, metrics: { a: m("a") } },
+          { users: 5, metrics: { a: m("a") } },
+        ],
+      },
+    ];
+
+    const rows = splitAnalysisResultsToMetricResultRows(results, {
+      organization: "org",
+      snapshotId: "snp",
+      analysisIndex: 0,
+    });
+    expect(rows.length).toBe(3);
+
+    const withIds = rows.map((r, i) => ({
+      ...r,
+      id: `id_${i}`,
+    }));
+
+    const merged = mergeMetricResultRowsToAnalysisResults(withIds);
+    expect(merged).toEqual(results);
+  });
+});

--- a/packages/back-end/test/services/experimentSnapshotMetricResults.test.ts
+++ b/packages/back-end/test/services/experimentSnapshotMetricResults.test.ts
@@ -36,7 +36,6 @@ describe("experimentSnapshotMetricResults", () => {
     ];
 
     const rows = splitAnalysisResultsToMetricResultRows(results, {
-      organization: "org",
       snapshotId: "snp",
       analysisIndex: 0,
     });
@@ -45,6 +44,9 @@ describe("experimentSnapshotMetricResults", () => {
     const withIds = rows.map((r, i) => ({
       ...r,
       id: `id_${i}`,
+      organization: "org",
+      dateCreated: new Date(),
+      dateUpdated: new Date(),
     }));
 
     const merged = mergeMetricResultRowsToAnalysisResults(withIds);

--- a/packages/shared/src/enterprise/dashboards/utils.ts
+++ b/packages/shared/src/enterprise/dashboards/utils.ts
@@ -121,7 +121,7 @@ export function getBlockAnalysisSettings(
 }
 
 export function snapshotSatisfiesBlock(
-  snapshot: ExperimentSnapshotInterface,
+  snapshot: Pick<ExperimentSnapshotInterface, "dimension" | "settings">,
   block: DashboardBlockInterfaceOrData<DashboardBlockInterface>,
 ) {
   const blockSettings = getBlockSnapshotSettings(block);

--- a/packages/shared/src/validators/queries.ts
+++ b/packages/shared/src/validators/queries.ts
@@ -28,3 +28,27 @@ export const sqlResultChunkValidator = z
     data: z.record(z.string(), z.array(z.unknown())),
   })
   .strict();
+
+export const experimentSnapshotMetricResultValidator = z
+  .object({
+    organization: z.string(),
+    dateCreated: z.date(),
+    dateUpdated: z.date(),
+    id: z.string(),
+    snapshotId: z.string(),
+    analysisIndex: z.number(),
+    metricId: z.string(),
+    parentMetricId: z.string(),
+    dimensionName: z.string(),
+    dimensionValue: z.string(),
+    srm: z.number(),
+    variations: z.array(
+      z
+        .object({
+          users: z.number(),
+          metric: z.unknown(),
+        })
+        .strict(),
+    ),
+  })
+  .strict();

--- a/packages/shared/types/experiment-snapshot.d.ts
+++ b/packages/shared/types/experiment-snapshot.d.ts
@@ -156,6 +156,8 @@ export type SnapshotTriggeredBy =
 export interface ExperimentSnapshotMetricResultInterface {
   id: string;
   organization: string;
+  dateCreated: Date;
+  dateUpdated: Date;
   snapshotId: string;
   /** Index into `snapshot.analyses` */
   analysisIndex: number;

--- a/packages/shared/types/experiment-snapshot.d.ts
+++ b/packages/shared/types/experiment-snapshot.d.ts
@@ -148,6 +148,36 @@ export type SnapshotTriggeredBy =
   | "manual-dashboard"
   | "update-dashboards";
 
+/**
+ * One metric’s stats for a single results row (dimension / slice) on a snapshot analysis.
+ * Stored in `experimentsnapshotmetricresults` so large snapshots stay under BSON limits
+ * and the API can load metrics (and slices) incrementally.
+ */
+export interface ExperimentSnapshotMetricResultInterface {
+  id: string;
+  organization: string;
+  snapshotId: string;
+  /** Index into `snapshot.analyses` */
+  analysisIndex: number;
+  /** Metric id as keyed in `SnapshotVariation.metrics` (includes slice query string when applicable). */
+  metricId: string;
+  /**
+   * Base metric id for indexing slice rows (`parseSliceMetricId(metricId).baseMetricId`).
+   * Use this to fetch all slice documents for one logical metric.
+   */
+  parentMetricId: string;
+  /** Same as `ExperimentReportResultDimension.name` (e.g. `"All"`, slice labels). */
+  dimensionName: string;
+  /** Encodes the dimension row identity/value (e.g. `All`, slice value). */
+  dimensionValue: string;
+  srm: number;
+  /** Parallel to experiment phase variations; one entry per variation. */
+  variations: {
+    users: number;
+    metric: SnapshotMetric;
+  }[];
+}
+
 export interface ExperimentSnapshotAnalysis {
   // Determines which analysis this is
   settings: ExperimentSnapshotAnalysisSettings;
@@ -155,6 +185,11 @@ export interface ExperimentSnapshotAnalysis {
   status: "running" | "success" | "error";
   error?: string;
   results: ExperimentReportResultDimension[];
+  /**
+   * When true, `results` is empty on the snapshot document and metric rows live in
+   * `experimentsnapshotmetricresults`. Legacy snapshots omit this and keep full inline `results`.
+   */
+  resultsStoredPerMetric?: boolean;
 }
 
 export interface SnapshotSettingsVariation {
@@ -227,6 +262,13 @@ export interface ExperimentSnapshotInterface {
 
   // List of queries that were run as part of this snapshot
   queries: Queries;
+
+  /**
+   * When this snapshot was cloned from another (e.g. for a report), this
+   * points to the source snapshot whose metric-result rows we share.
+   * Analogous to `cachedQueryUsed` on QueryInterface.
+   */
+  sourceSnapshotId?: string;
 
   // Results
   unknownVariations: string[];


### PR DESCRIPTION
## Split experiment snapshot results into per-metric documents

### Problem

Experiment snapshots hit the 16MB MongoDB BSON document limit when users have many metric slices, because all metric results are stored inline in `analyses[].results` on the snapshot document.

### Solution

Store each metric's results as a separate document in a new `experimentsnapshotmetricresults` collection, keeping the snapshot document itself slim. Results are transparently hydrated back into the original shape on read, so all existing consumers (APIs, CSV export, notifications, front-end) continue to work without changes.

### Key changes

- **New model:** `ExperimentSnapshotMetricResultModel` (uses `BaseModel` / `MakeModelClass`) stores one document per metric × dimension, with indexes on `(snapshotId, analysisIndex, metricId, dimensionName)` and `(parentMetricId, snapshotId, analysisIndex)` for efficient per-metric and per-slice queries.
- **Split/merge logic:** `splitAnalysisResultsToMetricResultRows` and `mergeMetricResultRowsToAnalysisResults` symmetrically convert between inline results and per-metric rows. Round-trip correctness is unit tested.
- **Write path:** `updateSnapshotAnalysis` splits successful results into per-metric rows and sets `resultsStoredPerMetric: true` on the analysis, storing `results: []` on the parent document.
- **Read path:** `hydrateExperimentSnapshotMetricResults` transparently reassembles full results from the side collection when `resultsStoredPerMetric` is set. Legacy snapshots with inline results continue to work as-is.
- **Snapshot cloning (reports):** Cloned snapshots set `sourceSnapshotId` to reference the source's metric-result rows (analogous to `cachedQueryUsed` on `QueryInterface`), avoiding row duplication. Legacy sources with inline results are copied forward directly.
- **New endpoint:** `GET /snapshot/:id/metric-results` supports granular queries by `analysisIndex`, `metricIds`, `dimensionNames`, and `parentMetricId` for future lazy-loading UI work.
- **Type safety:** `CreateExperimentSnapshotInput` omits `results` from analyses (defaults to `[]`), preventing accidental >16MB inserts at creation time.

### QA checklist

- [ ] Run a standard experiment snapshot refresh — verify results display correctly and snapshot saves without error
- [ ] Run a snapshot for an experiment with many metric slices (>50 metrics) — verify it succeeds where it may have previously hit BSON limits
- [ ] Check that switching between analysis settings (stats engine, difference type) shows correct results
- [ ] Create a report from an existing experiment snapshot — verify the report loads with correct results
- [ ] Verify the external API `GET /api/v1/experiments/:id/results` returns the same shape and data as before
- [ ] Delete an experiment phase — verify the snapshot and its metric-result rows are cleaned up
- [ ] Verify experiment notifications (significance changes) still fire correctly after a snapshot refresh
- [ ] Check that dashboard snapshot blocks render correctly for experiments with per-metric stored results