### PR TITLE
hardcoded ai default model for cloud, UI tweak for ai analyst + fix m…

### DIFF
--- a/packages/back-end/src/enterprise/services/agent-handler.ts
+++ b/packages/back-end/src/enterprise/services/agent-handler.ts
@@ -5,7 +5,10 @@ import type { AIModel, AIPromptType } from "shared/ai";
 import type { AIChatMessage } from "shared/ai-chat";
 import type { ReqContext } from "back-end/types/request";
 import type { AuthRequest } from "back-end/src/types/AuthRequest";
-import { getContextFromReq } from "back-end/src/services/organizations";
+import {
+  getContextFromReq,
+  getAISettingsForOrg,
+} from "back-end/src/services/organizations";
 import {
   streamingChatCompletion,
   simpleCompletion,
@@ -166,16 +169,16 @@ export function createAgentHandler<TParams>(config: AgentConfig<TParams>) {
     const requestModel = body.model;
     const canOverride = context.permissions.canManageOrgSettings();
 
-    if (canOverride) {
-      buffer.setModel(requestModel);
-    }
-
     // Resolution: request (permitted) → conversation stored → org prompt override
     const overrideModel =
       (canOverride && requestModel) ||
       (buffer.getModel() as AIModel | undefined) ||
       dbOverrideModel ||
       undefined;
+
+    const { defaultAIModel } = getAISettingsForOrg(context, true);
+    const resolvedModel = overrideModel || defaultAIModel;
+    buffer.setModel(resolvedModel);
 
     const { messages: messagesForLLM, isFirstMessage } =
       prepareConversationMessages(buffer, message);

--- a/packages/back-end/src/enterprise/services/agent-handler.ts
+++ b/packages/back-end/src/enterprise/services/agent-handler.ts
@@ -176,7 +176,7 @@ export function createAgentHandler<TParams>(config: AgentConfig<TParams>) {
       dbOverrideModel ||
       undefined;
 
-    const { defaultAIModel } = getAISettingsForOrg(context, true);
+    const { defaultAIModel } = getAISettingsForOrg(context, false);
     const resolvedModel = overrideModel || defaultAIModel;
     buffer.setModel(resolvedModel);
 

--- a/packages/back-end/src/services/organizations.ts
+++ b/packages/back-end/src/services/organizations.ts
@@ -230,10 +230,11 @@ export function getAISettingsForOrg(
     xaiAPIKey: includeKey ? xaiKey : "",
     mistralAPIKey: includeKey ? mistralKey : "",
     googleAPIKey: includeKey ? googleKey : "",
-    defaultAIModel:
-      context.org.settings?.defaultAIModel ||
-      context.org.settings?.openAIDefaultModel ||
-      "gpt-5.4-mini",
+    defaultAIModel: IS_CLOUD
+      ? "gpt-5.4-mini"
+      : context.org.settings?.defaultAIModel ||
+        context.org.settings?.openAIDefaultModel ||
+        "gpt-5.4-mini",
     embeddingModel:
       context.org.settings?.embeddingModel || "text-embedding-ada-002",
   };

--- a/packages/front-end/enterprise/components/ProductAnalytics/EmptyState.tsx
+++ b/packages/front-end/enterprise/components/ProductAnalytics/EmptyState.tsx
@@ -4,7 +4,7 @@ import React, { useCallback, useRef, useState } from "react";
 import { BsStars } from "react-icons/bs";
 import {
   PiArrowRightBold,
-  PiChats,
+  PiCaretRightBold,
   PiChartBar,
   PiCode,
   PiDatabase,
@@ -218,19 +218,19 @@ export default function EmptyState() {
                       </Button>
                     </span>
                   </Tooltip>
-                  {!chatDisabledReason && (
-                    <LinkButton
-                      href="/product-analytics/explore/ai-chat"
-                      variant="outline"
-                      size="md"
-                    >
-                      <Flex align="center" gap="2">
-                        <PiChats size={14} />
-                        Past Chats
-                      </Flex>
-                    </LinkButton>
-                  )}
                 </Flex>
+                {!chatDisabledReason && (
+                  <LinkButton
+                    href="/product-analytics/explore/ai-chat"
+                    variant="ghost"
+                    size="sm"
+                  >
+                    <Flex align="center" gap="1">
+                      View Chat History
+                      <PiCaretRightBold size={12} />
+                    </Flex>
+                  </LinkButton>
+                )}
               </Flex>
 
               <Flex justify="center" direction="column" gap="5" mt="3">


### PR DESCRIPTION
## Hardcode AI default model for cloud + always record model on conversations

### Changes

**Always record the resolved model on AI conversations** (`agent-handler.ts`)

Previously, `buffer.setModel()` was only called when the user had `canManageOrgSettings()` permission. This meant conversations created by non-admin users never had the `model` field persisted to the database — making it impossible to audit which model was actually used.

Now we resolve the final model (applying the full override chain: admin request model → stored conversation model → per-prompt DB override → org default) and always persist it on the conversation document, regardless of the user's permissions.

**Use hardcoded default model on cloud deployments** (`organizations.ts`)

On cloud, `getAISettingsForOrg` now returns `"gpt-5.4-mini"` directly instead of reading `defaultAIModel` / `openAIDefaultModel` from the org's DB settings. Some orgs had stale legacy values (e.g. `openAIDefaultModel` set to an older model) that were silently overriding the intended default. Self-hosted deployments are unaffected and continue to respect org-level model settings.

**UI tweak for AI Analyst empty state** (`EmptyState.tsx`)

Changed the "Past Chats" button to a smaller ghost-styled "View Chat History" link with a caret icon, moved outside the main action row.
