### PR TITLE
Add status filter to LIST experiments endpoint

### DIFF
--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -2360,6 +2360,7 @@ paths:
         - $ref: '#/components/parameters/projectId'
         - $ref: '#/components/parameters/datasourceId'
         - $ref: '#/components/parameters/experimentId'
+        - $ref: '#/components/parameters/status'
       responses:
         '200':
           content:
@@ -16710,7 +16711,20 @@ paths:
         - $ref: '#/components/parameters/limit'
         - $ref: '#/components/parameters/offset'
         - $ref: '#/components/parameters/featureId'
-        - $ref: '#/components/parameters/status'
+        - name: status
+          in: query
+          description: Filter by schedule status
+          schema:
+            description: Filter by schedule status
+            type: string
+            enum:
+              - pending
+              - ready
+              - running
+              - paused
+              - pending-approval
+              - completed
+              - rolled-back
       responses:
         '200':
           content:
@@ -16858,6 +16872,16 @@ components:
       schema:
         description: Filter the returned list by the experiment tracking key (id)
         type: string
+    status:
+      name: status
+      in: query
+      description: ''
+      schema:
+        type: string
+        enum:
+          - draft
+          - running
+          - stopped
     phase:
       name: phase
       in: query
@@ -17031,21 +17055,6 @@ components:
       description: ''
       schema:
         type: string
-    status:
-      name: status
-      in: query
-      description: Filter by schedule status
-      schema:
-        description: Filter by schedule status
-        type: string
-        enum:
-          - pending
-          - ready
-          - running
-          - paused
-          - pending-approval
-          - completed
-          - rolled-back
   schemas:
     Feature:
       type: object

--- a/packages/back-end/src/api/experiments/listExperiments.ts
+++ b/packages/back-end/src/api/experiments/listExperiments.ts
@@ -20,6 +20,7 @@ export const listExperiments = createApiRequestHandler(
     project: req.query.projectId,
     datasourceId: req.query.datasourceId,
     trackingKey: req.query.experimentId,
+    status: req.query.status,
     sortBy: { dateCreated: 1 },
   });
 

--- a/packages/back-end/src/models/ExperimentModel.ts
+++ b/packages/back-end/src/models/ExperimentModel.ts
@@ -9,7 +9,10 @@ import {
 } from "shared/experiments";
 import { v4 as uuidv4 } from "uuid";
 import { VisualChange } from "shared/types/visual-changeset";
-import { ExperimentInterfaceExcludingHoldouts } from "shared/validators";
+import {
+  ExperimentInterfaceExcludingHoldouts,
+  ExperimentStatus,
+} from "shared/validators";
 import {
   Changeset,
   ExperimentInterface,
@@ -429,6 +432,7 @@ export async function getAllExperiments(
     type,
     datasourceId,
     trackingKey,
+    status,
     sortBy,
   }: {
     project?: string;
@@ -436,6 +440,7 @@ export async function getAllExperiments(
     type?: ExperimentType;
     datasourceId?: string;
     trackingKey?: string;
+    status?: ExperimentStatus;
     sortBy?: SortFilter;
   } = {},
 ): Promise<ExperimentInterface[]> {
@@ -457,6 +462,10 @@ export async function getAllExperiments(
 
   if (!includeArchived) {
     query.archived = { $ne: true };
+  }
+
+  if (status) {
+    query.status = status;
   }
 
   if (type === "multi-armed-bandit") {

--- a/packages/shared/src/validators/experiments.ts
+++ b/packages/shared/src/validators/experiments.ts
@@ -1277,6 +1277,7 @@ export const listExperimentsValidator = {
           "Filter the returned list by the experiment tracking key (id)",
         )
         .optional(),
+      status: z.enum(experimentStatus).optional(),
     })
     .strict(),
   paramsSchema: z.never(),


### PR DESCRIPTION
### Features and Changes

Adds an optional `status` query param to the list experiments endpoint to filter by experiment status

- Closes #5662

### Testing

Hit the new endpoint with and without the param to confirm the desired behavior

### Screenshots

<img width="832" height="270" alt="image" src="https://github.com/user-attachments/assets/bd7390d2-2441-4679-a4e4-b5358a9057ae" />

<img width="407" height="485" alt="image" src="https://github.com/user-attachments/assets/c36960e7-548b-4155-b0ac-98a11e0c1a16" />

<img width="376" height="393" alt="image" src="https://github.com/user-attachments/assets/6ec437da-9b9b-414b-af44-13d8c5d327f4" />

<img width="390" height="398" alt="image" src="https://github.com/user-attachments/assets/0f52d5c1-e14f-43bd-b3e8-e4483bac7fa7" />
