### PR TITLE
Updates listMember permission check

### DIFF
--- a/packages/back-end/src/api/members/listMembers.ts
+++ b/packages/back-end/src/api/members/listMembers.ts
@@ -9,7 +9,10 @@ import {
 export const listMembers = createApiRequestHandler(listMembersValidator)(async (
   req,
 ) => {
-  if (!req.context.permissions.canManageTeam()) {
+  const readableProjects =
+    req.context.permissions.getProjectsWithPermission("readData");
+  // readableProjects = [], that means the user has no access to any projects
+  if (readableProjects !== null && readableProjects.length === 0) {
     req.context.permissions.throwPermissionError();
   }
 
@@ -30,6 +33,11 @@ export const listMembers = createApiRequestHandler(listMembersValidator)(async (
 
   return {
     members: filtered.map((member) => {
+      // Strip project roles for projects the requester doesn't have readAccess to.
+      const filteredProjectRoles = (member.projectRoles ?? []).filter((pr) =>
+        req.context.permissions.canReadSingleProjectResource(pr.project),
+      );
+
       return {
         id: member.id,
         name: member.name,
@@ -38,7 +46,7 @@ export const listMembers = createApiRequestHandler(listMembersValidator)(async (
         teams: member.teams,
         environments: member.environments,
         limitAccessByEnvironment: member.limitAccessByEnvironment,
-        projectRoles: member.projectRoles,
+        projectRoles: filteredProjectRoles,
         lastLoginDate: member.lastLoginDate?.toISOString(),
         dateCreated: member.dateCreated?.toISOString(),
         managedbyIdp: member.managedByIdp || false,


### PR DESCRIPTION
### Features and Changes

The `GET /api/v1/members` endpoint previously required the `manageTeam` permission, restricting it to org admins. This change relaxes the access requirement so that any org member with `readData` in at least one project (or globally) can list org members — consistent with how other read endpoints work.

To prevent information leakage, each member's `projectRoles` are filtered in the response so that the requester only sees project-level roles for projects they themselves can read. A requester with a `noAccess` role on a given project will not see any other member's role assignment for that project.

- Closes **(add link to issue here)**

### Dependencies

None

### Testing

Using the `GET /api/v1/members` endpoint with an API key scoped to a user in each configuration:

- [ ] **Global collaborator, no project roles** — should return 200 with all org members and their full `projectRoles` unfiltered
- [ ] **Global collaborator + experimenter in `projectA`** — should return 200 with all org members and full `projectRoles` (global `readData` means no filtering)
- [ ] **Global collaborator + `noAccess` in `projectB`** — should return 200 with all org members, but no member's `projectRoles` should contain an entry for `projectB`
- [ ] **Global `noAccess`, no project roles** — should return 403
- [ ] **Global `noAccess` + experimenter in `projectA`** — should return 200 with all org members, but each member's `projectRoles` should only contain entries for `projectA` (all other project roles stripped)

### Screenshots

N/A (API-only change)