### PR TITLE
Fix: Handle COUNT DISTINCT aggregation correctly in Mean metrics for product analytics

### DIFF
--- a/packages/shared/src/enterprise/product-analytics/sql.ts
+++ b/packages/shared/src/enterprise/product-analytics/sql.ts
@@ -549,13 +549,26 @@ function getRollupAggregationExpr(
   metric: MinimalMetric,
   alias: string,
   helpers: SqlHelpers,
+  columnRef: ColumnRef,
+  isEventLevelAggregation: boolean,
 ): string {
   // Quantiles
   if (metric.metricType === "quantile" && metric.quantileSettings) {
     return helpers.percentileApprox(alias, metric.quantileSettings.quantile);
-  } else {
-    return `SUM(${alias})`;
   }
+
+  // For event-level aggregation, respect the original aggregation type
+  if (isEventLevelAggregation) {
+    if (columnRef.aggregation === "count distinct") {
+      return `COUNT(DISTINCT ${alias})`;
+    }
+    if (columnRef.aggregation === "max") {
+      return `MAX(${alias})`;
+    }
+  }
+
+  // For unit-level aggregation or default case, use SUM
+  return `SUM(${alias})`;
 }
 
 function getRollupCountExpr(metric: MinimalMetric, alias: string): string {
@@ -619,6 +632,9 @@ function getMetricData(
 
   const cappingSettings = getCappingSettings(metric);
 
+  // Event-level aggregation is when we don't have a unit
+  const isEventLevelAggregation = selectedUnit === null;
+
   return {
     unit: selectedUnit,
     alias,
@@ -636,7 +652,13 @@ function getMetricData(
     unitAggregationExpr: selectedUnit
       ? getUnitAggregationExpr(columnRef, alias)
       : null,
-    rollupAggregationExpr: getRollupAggregationExpr(metric, alias, helpers),
+    rollupAggregationExpr: getRollupAggregationExpr(
+      metric,
+      alias,
+      helpers,
+      columnRef,
+      isEventLevelAggregation,
+    ),
     rollupCountExpr,
   };
 }

--- a/packages/shared/test/product-analytics.test.ts
+++ b/packages/shared/test/product-analytics.test.ts
@@ -73,6 +73,19 @@ describe("productAnalytics", () => {
             isAutoSliceColumn: false,
           },
           {
+            column: "session_id",
+            datatype: "string",
+            dateCreated: new Date(),
+            dateUpdated: new Date(),
+            name: "session_id",
+            description: "",
+            numberFormat: "",
+            alwaysInlineFilter: false,
+            deleted: false,
+            autoSlices: [],
+            isAutoSliceColumn: false,
+          },
+          {
             column: "timestamp",
             datatype: "date",
             dateCreated: new Date(),
@@ -91,7 +104,7 @@ describe("productAnalytics", () => {
         id: "orders",
         name: "Purchases",
         organization: "org_1",
-        sql: "SELECT user_id, anonymous_id, timestamp, revenue FROM orders",
+        sql: "SELECT user_id, anonymous_id, session_id, timestamp, revenue FROM orders",
         userIdTypes: ["user_id", "anonymous_id"],
         dateCreated: new Date(),
         dateUpdated: new Date(),
@@ -167,7 +180,7 @@ describe("productAnalytics", () => {
         _factTable0 AS (
           SELECT * FROM (
             -- Raw fact table SQL
-            SELECT user_id, anonymous_id, timestamp, revenue FROM orders
+            SELECT user_id, anonymous_id, session_id, timestamp, revenue FROM orders
           ) t
           WHERE timestamp >= ${helpers.toTimestamp(startTimestamp)} AND timestamp <= ${helpers.toTimestamp(now)}
         ),
@@ -294,7 +307,7 @@ describe("productAnalytics", () => {
         _factTable0 AS (
           SELECT * FROM (
             -- Raw fact table SQL
-            SELECT user_id, anonymous_id, timestamp, revenue FROM orders
+            SELECT user_id, anonymous_id, session_id, timestamp, revenue FROM orders
           ) t
           WHERE timestamp >= ${helpers.toTimestamp(startTimestamp)} AND timestamp <= ${helpers.toTimestamp(now)}
         ),
@@ -427,7 +440,7 @@ describe("productAnalytics", () => {
         _factTable0 AS (
           SELECT * FROM (
             -- Raw fact table SQL
-            SELECT user_id, anonymous_id, timestamp, revenue FROM orders
+            SELECT user_id, anonymous_id, session_id, timestamp, revenue FROM orders
           ) t
           WHERE timestamp >= ${helpers.toTimestamp(startTimestamp)} AND timestamp <= ${helpers.toTimestamp(now)}
           AND ( (revenue > 100) OR (revenue > 200) )
@@ -561,7 +574,7 @@ describe("productAnalytics", () => {
         _factTable0 AS (
           SELECT * FROM (
             -- Raw fact table SQL
-            SELECT user_id, anonymous_id, timestamp, revenue FROM orders
+            SELECT user_id, anonymous_id, session_id, timestamp, revenue FROM orders
           ) t
           WHERE timestamp >= ${helpers.toTimestamp(startTimestamp)} AND timestamp <= ${helpers.toTimestamp(now)}
           AND ( revenue > 100 )
@@ -614,6 +627,267 @@ describe("productAnalytics", () => {
       FROM _combined_rollup
       GROUP BY
         dimension0
+    `,
+      helpers.formatDialect,
+    );
+
+    expect(sql).toEqual(expected);
+  });
+
+  it("generates SQL for mean metrics with COUNT DISTINCT aggregation", () => {
+    const metric: FactMetricInterface = {
+      id: "met_session_count",
+      name: "Session Count",
+      organization: "org_1",
+      owner: "",
+      datasource: "ds_1",
+      projects: [],
+      tags: [],
+      dateCreated: new Date(),
+      dateUpdated: new Date(),
+      metricType: "mean",
+      numerator: {
+        factTableId: "orders",
+        column: "session_id",
+        aggregation: "count distinct",
+        rowFilters: [],
+      },
+      denominator: null,
+      cappingSettings: {
+        type: "",
+        value: 0,
+        ignoreZeros: false,
+      },
+      windowSettings: {
+        type: "",
+        delayUnit: "days",
+        delayValue: 0,
+        windowUnit: "days",
+        windowValue: 0,
+      },
+      quantileSettings: null,
+      description: "",
+      regressionAdjustmentDays: 0,
+      regressionAdjustmentEnabled: false,
+      regressionAdjustmentReason: "",
+      inverse: false,
+      userIdColumns: {},
+      userIdTypes: [],
+    };
+
+    const metricsMap = new Map<string, FactMetricInterface>([
+      ["met_session_count", metric],
+    ]);
+
+    const config: ExplorationConfig = {
+      type: "metric",
+      datasource: "ds_1",
+      chartType: "line",
+      dateRange: {
+        predefined: "last7Days",
+        startDate: null,
+        endDate: null,
+        lookbackValue: null,
+        lookbackUnit: null,
+      },
+      dimensions: [
+        {
+          dimensionType: "date",
+          column: null,
+          dateGranularity: "day",
+        },
+      ],
+      dataset: {
+        type: "metric",
+        values: [
+          {
+            type: "metric",
+            metricId: "met_session_count",
+            unit: null,
+            denominatorUnit: null,
+            rowFilters: [],
+          },
+        ],
+      },
+    };
+
+    const { sql } = generateProductAnalyticsSQL(
+      config,
+      factTableMap,
+      metricsMap,
+      helpers,
+      datasource,
+    );
+
+    const now = new Date();
+    const startTimestamp = new Date(now);
+    startTimestamp.setUTCDate(startTimestamp.getUTCDate() - 7);
+
+    const expected = format(
+      `
+      WITH
+        _factTable0 AS (
+          SELECT * FROM (
+            -- Raw fact table SQL
+            SELECT user_id, anonymous_id, session_id, timestamp, revenue FROM orders
+          ) t
+          WHERE timestamp >= ${helpers.toTimestamp(startTimestamp)} AND timestamp <= ${helpers.toTimestamp(now)}
+        ),
+        _factTable0_rows AS (
+          SELECT
+            date_trunc('day', timestamp) AS dimension0,
+            session_id AS m0
+          FROM _factTable0
+        ),
+        _factTable0_event_rollup AS (
+          SELECT
+            dimension0,
+            CAST(COUNT(DISTINCT m0) AS FLOAT) AS m0_numerator
+          FROM _factTable0_rows
+          GROUP BY
+            dimension0
+        )
+      SELECT
+        dimension0,
+        m0_numerator AS m0_numerator
+      FROM _factTable0_event_rollup
+    `,
+      helpers.formatDialect,
+    );
+
+    expect(sql).toEqual(expected);
+  });
+
+  it("generates SQL for mean metrics with COUNT DISTINCT aggregation and unit", () => {
+    const metric: FactMetricInterface = {
+      id: "met_session_count_per_user",
+      name: "Session Count Per User",
+      organization: "org_1",
+      owner: "",
+      datasource: "ds_1",
+      projects: [],
+      tags: [],
+      dateCreated: new Date(),
+      dateUpdated: new Date(),
+      metricType: "mean",
+      numerator: {
+        factTableId: "orders",
+        column: "session_id",
+        aggregation: "count distinct",
+        rowFilters: [],
+      },
+      denominator: null,
+      cappingSettings: {
+        type: "",
+        value: 0,
+        ignoreZeros: false,
+      },
+      windowSettings: {
+        type: "",
+        delayUnit: "days",
+        delayValue: 0,
+        windowUnit: "days",
+        windowValue: 0,
+      },
+      quantileSettings: null,
+      description: "",
+      regressionAdjustmentDays: 0,
+      regressionAdjustmentEnabled: false,
+      regressionAdjustmentReason: "",
+      inverse: false,
+      userIdColumns: {},
+      userIdTypes: [],
+    };
+
+    const metricsMap = new Map<string, FactMetricInterface>([
+      ["met_session_count_per_user", metric],
+    ]);
+
+    const config: ExplorationConfig = {
+      type: "metric",
+      datasource: "ds_1",
+      chartType: "line",
+      dateRange: {
+        predefined: "last7Days",
+        startDate: null,
+        endDate: null,
+        lookbackValue: null,
+        lookbackUnit: null,
+      },
+      dimensions: [
+        {
+          dimensionType: "date",
+          column: null,
+          dateGranularity: "day",
+        },
+      ],
+      dataset: {
+        type: "metric",
+        values: [
+          {
+            type: "metric",
+            metricId: "met_session_count_per_user",
+            unit: "user_id",
+            denominatorUnit: null,
+            rowFilters: [],
+          },
+        ],
+      },
+    };
+
+    const { sql } = generateProductAnalyticsSQL(
+      config,
+      factTableMap,
+      metricsMap,
+      helpers,
+      datasource,
+    );
+
+    const now = new Date();
+    const startTimestamp = new Date(now);
+    startTimestamp.setUTCDate(startTimestamp.getUTCDate() - 7);
+
+    const expected = format(
+      `
+      WITH
+        _factTable0 AS (
+          SELECT * FROM (
+            -- Raw fact table SQL
+            SELECT user_id, anonymous_id, session_id, timestamp, revenue FROM orders
+          ) t
+          WHERE timestamp >= ${helpers.toTimestamp(startTimestamp)} AND timestamp <= ${helpers.toTimestamp(now)}
+        ),
+        _factTable0_rows AS (
+          SELECT
+            date_trunc('day', timestamp) AS dimension0,
+            user_id AS unit0,
+            session_id AS m0
+          FROM _factTable0
+        ),
+        _factTable0_unit0 AS (
+          SELECT
+            unit0,
+            dimension0,
+            COUNT(DISTINCT m0) AS m0
+          FROM _factTable0_rows
+          GROUP BY
+            unit0,
+            dimension0
+        ),
+        _factTable0_unit0_rollup AS (
+          SELECT
+            dimension0,
+            CAST(SUM(m0) AS FLOAT) AS m0_numerator,
+            CAST(COUNT(m0) AS FLOAT) AS m0_denominator
+          FROM _factTable0_unit0
+          GROUP BY
+            dimension0
+        )
+      SELECT
+        dimension0,
+        m0_numerator AS m0_numerator,
+        m0_denominator AS m0_denominator
+      FROM _factTable0_unit0_rollup
     `,
       helpers.formatDialect,
     );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Features and Changes

Fixed a bug where Mean metrics using COUNT DISTINCT aggregation in product analytics metric explorations were incorrectly generating `SUM()` on string fields instead of `COUNT(DISTINCT ...)`.

**Root Cause:**
The `getRollupAggregationExpr` function was only considering metric type and quantile settings when determining the rollup aggregation, but was not accounting for the `aggregation` field on the column reference (e.g., "count distinct", "max"). This caused all non-quantile rollups to default to `SUM()`, which is incorrect for COUNT DISTINCT aggregation on event-level metrics.

**Fix:**
- Updated `getRollupAggregationExpr` to accept the `columnRef` and `isEventLevelAggregation` parameters
- For event-level aggregation (metrics without a unit), the function now respects the original aggregation type:
  - `aggregation: "count distinct"` → generates `COUNT(DISTINCT alias)`
  - `aggregation: "max"` → generates `MAX(alias)`
  - Default → `SUM(alias)`
- For unit-level aggregation (metrics with a unit), the function continues to use `SUM()` after the unit aggregation step, which is correct because the COUNT DISTINCT/MAX has already been applied at the unit aggregation level

**Testing:**
- Added test case for Mean metrics with COUNT DISTINCT aggregation at event level (no unit)
- Added test case for Mean metrics with COUNT DISTINCT aggregation at unit level (with user_id unit)
- All existing tests continue to pass

- Closes https://github.com/growthbook/growthbook/issues/5658

### Dependencies

None

### Testing

1. Create a Mean metric with COUNT DISTINCT aggregation on a string column (e.g., session_id)
2. Use this metric in a Product Analytics metric exploration (Dashboard > Metric Explorer)
3. Verify that the generated SQL uses `COUNT(DISTINCT session_id)` instead of `SUM(session_id)`
4. Run existing tests: `pnpm --filter shared test product-analytics`

### Screenshots

N/A - This is a backend SQL generation fix with no UI changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://growthbookapp.slack.com/archives/C05QYS2UFRD/p1776241918265809?thread_ts=1776241918.265809&cid=C05QYS2UFRD)

<div><a href="https://cursor.com/agents/bc-d587034c-db59-5ec8-b64f-79dd0c28460b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d587034c-db59-5ec8-b64f-79dd0c28460b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

