### PR TITLE
Fixes metric explorer bug for count distinct mean metrics

### DIFF
--- a/packages/front-end/enterprise/components/ProductAnalytics/SideBar/MetricTabContent.tsx
+++ b/packages/front-end/enterprise/components/ProductAnalytics/SideBar/MetricTabContent.tsx
@@ -91,7 +91,9 @@ export default function MetricTabContent() {
                     metricId: val,
                     unit:
                       newMetric?.metricType === "mean" &&
-                      newMetric.numerator.aggregation !== "count distinct"
+                      !["count distinct", "max", "sum"].includes(
+                        newMetric.numerator.aggregation ?? "",
+                      )
                         ? null
                         : unit,
                     name: newMetric?.name

--- a/packages/front-end/enterprise/components/ProductAnalytics/SideBar/MetricTabContent.tsx
+++ b/packages/front-end/enterprise/components/ProductAnalytics/SideBar/MetricTabContent.tsx
@@ -89,7 +89,11 @@ export default function MetricTabContent() {
                   const updates = {
                     ...v,
                     metricId: val,
-                    unit: newMetric?.metricType === "mean" ? null : unit,
+                    unit:
+                      newMetric?.metricType === "mean" &&
+                      newMetric.numerator.aggregation !== "count distinct"
+                        ? null
+                        : unit,
                     name: newMetric?.name
                       ? generateUniqueValueName(
                           newMetric.name,

--- a/packages/front-end/enterprise/components/ProductAnalytics/SideBar/ValueCard.tsx
+++ b/packages/front-end/enterprise/components/ProductAnalytics/SideBar/ValueCard.tsx
@@ -113,7 +113,9 @@ export default function ValueCard({
       }
     } else if (
       factMetric?.metricType === "mean" &&
-      factMetric.numerator.aggregation === "count distinct"
+      ["count distinct", "max", "sum"].includes(
+        factMetric.numerator.aggregation ?? "",
+      )
     ) {
       supportsUnitSelection = true;
     }

--- a/packages/front-end/enterprise/components/ProductAnalytics/SideBar/ValueCard.tsx
+++ b/packages/front-end/enterprise/components/ProductAnalytics/SideBar/ValueCard.tsx
@@ -111,8 +111,13 @@ export default function ValueCard({
       if (factMetric.numerator.column === "$$distinctUsers") {
         supportsUnitSelection = true;
       }
-      // TODO: handle separate denominator unit selector
+    } else if (
+      factMetric?.metricType === "mean" &&
+      factMetric.numerator.aggregation === "count distinct"
+    ) {
+      supportsUnitSelection = true;
     }
+    // TODO: handle separate denominator unit selector
   }
 
   const columnSource = useMemo(() => {


### PR DESCRIPTION
### Features and Changes

When using the metric explorer or a dashboard with a **mean metric** (Sum, Max, or Count Distinct aggregation), GrowthBook was generating incorrect SQL. The metric's `unit` was always forced to `null` for mean metrics, which bypassed the per-user aggregation step and fell through to an event-level rollup that blindly applied `SUM()` to the raw column value. This caused two problems:

- **Count Distinct on a string column** — `SUM(<string>)` is invalid SQL in BigQuery and other warehouses, producing a type error
- **Sum and Max aggregations** — both generated identical `SUM()` SQL regardless of the configured aggregation, meaning Max metrics silently returned wrong results

**Root cause:** Mean metrics are intended to compute a per-user aggregate (e.g. `COUNT(DISTINCT session_id)` per user, then average across users). Without a unit, the query has no user-level grouping step, so the aggregation is never applied correctly.

**Fix:**
- `ValueCard.tsx` — exposes the unit selector dropdown for mean metrics with Sum, Max, or Count Distinct aggregation, consistent with how it is already shown for proportion, retention, and dailyParticipation metrics
- `MetricTabContent.tsx` — removes the blanket `unit = null` override for mean metrics when the aggregation is Sum, Max, or Count Distinct, allowing a unit to be auto-assigned from the fact table's user ID types

- Closes https://github.com/growthbook/growthbook/issues/5658

### Dependencies

None

### Testing

- [x] Create a mean fact metric with **Count Distinct** aggregation on a string column (e.g. `session_id`, `browser`)
- [x] Open the metric explorer, add that metric as a value, and verify the unit selector dropdown now appears
- [x] Verify the exploration runs without a `SUM(STRING)` error and returns correct results
- [x] Create a mean fact metric with **Max** aggregation on a numeric column
- [x] Verify the unit selector appears and the generated SQL uses `MAX()` per user rather than `SUM()`
- [x] Create a mean fact metric with **Sum** aggregation on a numeric column
- [x] Verify the unit selector appears and the generated SQL correctly uses per-user `SUM()` before averaging
- [x] Verify that mean metrics using other aggregation types (e.g. no aggregation) are unaffected

### Screenshots

<!-- For any UI changes, please include screenshots of the unit selector now appearing on mean metric value cards -->