### PR TITLE
Ability to disable API keys (plus track the last used date)

### DIFF
--- a/packages/back-end/src/middleware/authenticateApiRequestMiddleware.ts
+++ b/packages/back-end/src/middleware/authenticateApiRequestMiddleware.ts
@@ -61,11 +61,14 @@ export default function authenticateApiRequestMiddleware(
   // Lookup organization by secret key and store in req
   dangerousLookupOrganizationByApiKey(secretKey)
     .then(async (apiKeyDoc) => {
-      const { organization, secret, id, userId, role } = apiKeyDoc;
+      const { organization, secret, id, userId, role, disabled } = apiKeyDoc;
       if (!secret) {
         throw new Error(
           "Must use a Secret API Key for this request, SDK Endpoint key given instead.",
         );
+      }
+      if (disabled) {
+        throw new Error("This API key has been disabled");
       }
       req.apiKey = id || "";
 
@@ -178,6 +181,13 @@ export default function authenticateApiRequestMiddleware(
 
       // init license for org if it exists
       await licenseInit(org, getUserCodesForOrg, getLicenseMetaData);
+
+      // Fire-and-forget: record this key's usage timestamp
+      req.context.models.apiKeys
+        .dangerousRecordUsageByKey(secretKey)
+        .catch((err) => {
+          req.log.warn({ err, apiKeyId: id }, "Failed to record API key usage");
+        });
 
       // Continue to the actual request handler
       next();

--- a/packages/back-end/src/middleware/authenticateApiRequestMiddleware.ts
+++ b/packages/back-end/src/middleware/authenticateApiRequestMiddleware.ts
@@ -23,6 +23,7 @@ import {
 } from "back-end/src/services/licenseData";
 import { ReqContextClass } from "back-end/src/services/context";
 import { TeamModel } from "back-end/src/models/TeamModel";
+import { ApiKeyModel } from "back-end/src/models/ApiKeyModel";
 
 export default function authenticateApiRequestMiddleware(
   req: Request & ApiRequestLocals,
@@ -67,6 +68,13 @@ export default function authenticateApiRequestMiddleware(
           "Must use a Secret API Key for this request, SDK Endpoint key given instead.",
         );
       }
+      // Record usage before the disabled check so operators deleting a disabled
+      // key can see whether something out there is still trying to use it.
+      ApiKeyModel.dangerousRecordUsageByKey(secretKey, organization).catch(
+        (err) => {
+          req.log.warn({ err, apiKeyId: id }, "Failed to record API key usage");
+        },
+      );
       if (disabled) {
         throw new Error("This API key has been disabled");
       }
@@ -181,13 +189,6 @@ export default function authenticateApiRequestMiddleware(
 
       // init license for org if it exists
       await licenseInit(org, getUserCodesForOrg, getLicenseMetaData);
-
-      // Fire-and-forget: record this key's usage timestamp
-      req.context.models.apiKeys
-        .dangerousRecordUsageByKey(secretKey)
-        .catch((err) => {
-          req.log.warn({ err, apiKeyId: id }, "Failed to record API key usage");
-        });
 
       // Continue to the actual request handler
       next();

--- a/packages/back-end/src/models/ApiKeyModel.ts
+++ b/packages/back-end/src/models/ApiKeyModel.ts
@@ -226,13 +226,10 @@ export class ApiKeyModel extends BaseClass {
     await this.delete(doc);
   }
 
-  public async setDisabled(
-    id: string,
-    disabled: boolean,
-  ): Promise<ApiKeyInterface> {
+  public async setDisabled(id: string, disabled: boolean): Promise<void> {
     const doc = await this._findOne({ id }, { bypassSanitization: true });
     if (!doc) this.context.throwNotFoundError(`API key not found: ${id}`);
-    return this.update(doc, { disabled });
+    await this.update(doc, { disabled });
   }
 
   // Called from authentication middleware on every API request attempt.

--- a/packages/back-end/src/models/ApiKeyModel.ts
+++ b/packages/back-end/src/models/ApiKeyModel.ts
@@ -18,6 +18,7 @@ const BaseClass = MakeModelClass({
   globallyUniquePrimaryKeys: true,
   idPrefix: "key_",
   additionalIndexes: [{ fields: { id: 1 } }],
+  skipDateUpdatedFields: ["lastUsed"],
   defaultValues: {
     limitAccessByEnvironment: false,
     environments: [],
@@ -41,9 +42,11 @@ export class ApiKeyModel extends BaseClass {
       );
     }
   }
-  protected canUpdate(_existing: ApiKeyInterface): boolean {
-    // ApiKeys should be immutable
-    return false;
+  protected canUpdate(apiKey: ApiKeyInterface): boolean {
+    // The only user-driven updates allowed are toggling `disabled`;
+    // lastUsed is written via the dangerous bypass from auth middleware.
+    // Reuse the delete permission — anyone who could delete should be able to disable.
+    return this.canDelete(apiKey);
   }
   protected canDelete(apiKey: ApiKeyInterface): boolean {
     if (apiKey.secret) {
@@ -214,6 +217,23 @@ export class ApiKeyModel extends BaseClass {
     if (!doc) this.context.throwNotFoundError();
 
     await this.delete(doc);
+  }
+
+  public async setDisabled(
+    id: string,
+    disabled: boolean,
+  ): Promise<ApiKeyInterface> {
+    const doc = await this._findOne({ id }, { bypassSanitization: true });
+    if (!doc) this.context.throwNotFoundError();
+    return this.update(doc, { disabled });
+  }
+
+  // Called from authentication middleware on every authenticated API request.
+  // Runs without a user-scoped context, so it intentionally bypasses permission checks.
+  public async dangerousRecordUsageByKey(key: string): Promise<void> {
+    const doc = await this._findOne({ key }, { bypassSanitization: true });
+    if (!doc) return;
+    await this.dangerousUpdateBypassPermission(doc, { lastUsed: new Date() });
   }
 
   public async getVisualEditorApiKey(

--- a/packages/back-end/src/models/ApiKeyModel.ts
+++ b/packages/back-end/src/models/ApiKeyModel.ts
@@ -7,6 +7,7 @@ import {
   migrateApiKey,
 } from "back-end/src/util/api-key.util";
 import { getEnvironmentIdsFromOrg } from "back-end/src/services/organizations";
+import { getCollection } from "back-end/src/util/mongo.util";
 import { MakeModelClass } from "./BaseModel";
 
 export const COLLECTION_NAME = "apikeys";
@@ -234,12 +235,16 @@ export class ApiKeyModel extends BaseClass {
     return this.update(doc, { disabled });
   }
 
-  // Called from authentication middleware on every authenticated API request.
-  // Bypasses permissions, dateUpdated, and the full update pipeline — we only
-  // need a single indexed $set on the `key` primary key.
-  public async dangerousRecordUsageByKey(key: string): Promise<void> {
-    await this._dangerousGetCollection().updateOne(
-      { key, organization: this.context.org.id },
+  // Called from authentication middleware on every API request attempt.
+  // Fires even for disabled keys so operators can see whether a key is still
+  // being used before deleting it. Runs before the request context exists, so
+  // it's a static raw $set scoped by the (key, organization) pair.
+  public static async dangerousRecordUsageByKey(
+    key: string,
+    organization: string,
+  ): Promise<void> {
+    await getCollection<ApiKeyInterface>(COLLECTION_NAME).updateOne(
+      { key, organization },
       { $set: { lastUsed: new Date() } },
     );
   }

--- a/packages/back-end/src/models/ApiKeyModel.ts
+++ b/packages/back-end/src/models/ApiKeyModel.ts
@@ -22,6 +22,7 @@ const BaseClass = MakeModelClass({
   defaultValues: {
     limitAccessByEnvironment: false,
     environments: [],
+    lastUsed: null,
   },
 });
 
@@ -42,10 +43,15 @@ export class ApiKeyModel extends BaseClass {
       );
     }
   }
-  protected canUpdate(apiKey: ApiKeyInterface): boolean {
-    // The only user-driven updates allowed are toggling `disabled`;
-    // lastUsed is written via the dangerous bypass from auth middleware.
-    // Reuse the delete permission — anyone who could delete should be able to disable.
+  protected canUpdate(
+    apiKey: ApiKeyInterface,
+    updates: Partial<ApiKeyInterface>,
+  ): boolean {
+    // API keys are immutable except for toggling `disabled`.
+    // Anything else (key value, role, etc.) must never be edited.
+    // `lastUsed` is written by auth middleware via the dangerous bypass and never hits this path.
+    const keys = Object.keys(updates);
+    if (keys.length !== 1 || keys[0] !== "disabled") return false;
     return this.canDelete(apiKey);
   }
   protected canDelete(apiKey: ApiKeyInterface): boolean {
@@ -224,16 +230,18 @@ export class ApiKeyModel extends BaseClass {
     disabled: boolean,
   ): Promise<ApiKeyInterface> {
     const doc = await this._findOne({ id }, { bypassSanitization: true });
-    if (!doc) this.context.throwNotFoundError();
+    if (!doc) this.context.throwNotFoundError(`API key not found: ${id}`);
     return this.update(doc, { disabled });
   }
 
   // Called from authentication middleware on every authenticated API request.
-  // Runs without a user-scoped context, so it intentionally bypasses permission checks.
+  // Bypasses permissions, dateUpdated, and the full update pipeline — we only
+  // need a single indexed $set on the `key` primary key.
   public async dangerousRecordUsageByKey(key: string): Promise<void> {
-    const doc = await this._findOne({ key }, { bypassSanitization: true });
-    if (!doc) return;
-    await this.dangerousUpdateBypassPermission(doc, { lastUsed: new Date() });
+    await this._dangerousGetCollection().updateOne(
+      { key, organization: this.context.org.id },
+      { $set: { lastUsed: new Date() } },
+    );
   }
 
   public async getVisualEditorApiKey(

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -1796,12 +1796,9 @@ export async function putApiKeyDisabled(
   const { id } = req.params;
   const { disabled } = req.body;
 
-  const key = await context.models.apiKeys.setDisabled(id, disabled);
+  await context.models.apiKeys.setDisabled(id, disabled);
 
-  res.status(200).json({
-    status: 200,
-    key,
-  });
+  res.status(200).json({ status: 200 });
 }
 
 export async function postApiKeyReveal(

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -1788,6 +1788,22 @@ export async function deleteApiKey(
   });
 }
 
+export async function putApiKeyDisabled(
+  req: AuthRequest<{ disabled: boolean }, { id: string }>,
+  res: Response,
+) {
+  const context = getContextFromReq(req);
+  const { id } = req.params;
+  const { disabled } = req.body;
+
+  const key = await context.models.apiKeys.setDisabled(id, disabled);
+
+  res.status(200).json({
+    status: 200,
+    key,
+  });
+}
+
 export async function postApiKeyReveal(
   req: AuthRequest<{ id: string }>,
   res: Response,

--- a/packages/back-end/src/routers/organizations/organizations.router.ts
+++ b/packages/back-end/src/routers/organizations/organizations.router.ts
@@ -4,6 +4,7 @@ import { validateRequestMiddleware } from "back-end/src/routers/utils/validateRe
 import { IS_CLOUD } from "back-end/src/util/secrets";
 import {
   postApiKeyValidator,
+  putApiKeyDisabledValidator,
   putDefaultRoleValidator,
   putMemberProjectRoleValidator,
 } from "./organizations.validators";
@@ -95,6 +96,13 @@ router.post(
 );
 router.delete("/keys", organizationsController.deleteApiKey);
 router.post("/keys/reveal", organizationsController.postApiKeyReveal);
+router.put(
+  "/keys/:id/disabled",
+  validateRequestMiddleware({
+    body: putApiKeyDisabledValidator,
+  }),
+  organizationsController.putApiKeyDisabled,
+);
 
 // Legacy Webhooks
 router.get("/legacy-sdk-webhooks", organizationsController.getLegacyWebhooks);

--- a/packages/back-end/src/routers/organizations/organizations.validators.ts
+++ b/packages/back-end/src/routers/organizations/organizations.validators.ts
@@ -39,3 +39,7 @@ export const postApiKeyValidator = z.strictObject({
   environments: z.array(z.string()).optional(),
   projectRoles: z.array(projectMemberRoleValidator).optional(),
 });
+
+export const putApiKeyDisabledValidator = z.strictObject({
+  disabled: z.boolean(),
+});

--- a/packages/front-end/components/ApiKeysTable/ApiKeysTable.tsx
+++ b/packages/front-end/components/ApiKeysTable/ApiKeysTable.tsx
@@ -41,7 +41,6 @@ export const ApiKeysTable: FC<ApiKeysTableProps> = ({
   const [pendingToggle, setPendingToggle] = useState<ApiKeyInterface | null>(
     null,
   );
-  const pendingDisabled = pendingToggle ? !pendingToggle.disabled : false;
   return (
     <div style={{ overflowX: "auto" }}>
       <table className="table mb-3 appbox gbtable">
@@ -181,13 +180,15 @@ export const ApiKeysTable: FC<ApiKeysTableProps> = ({
       </table>
       {pendingToggle && onToggleDisabled && (
         <ConfirmDialog
-          title={pendingDisabled ? "Disable API key?" : "Enable API key?"}
-          content={
-            pendingDisabled
-              ? `Any request using "${pendingToggle.description || "this key"}" will be rejected until it is re-enabled.`
-              : `"${pendingToggle.description || "This key"}" will immediately start accepting requests again.`
+          title={
+            !pendingToggle.disabled ? "Disable API key?" : "Enable API key?"
           }
-          yesText={pendingDisabled ? "Disable" : "Enable"}
+          content={
+            !pendingToggle.disabled
+              ? `Any request using this key will be rejected until it is re-enabled.`
+              : `This key will immediately start accepting requests again.`
+          }
+          yesText={!pendingToggle.disabled ? "Disable" : "Enable"}
           onConfirm={async () => {
             const target = pendingToggle;
             setPendingToggle(null);

--- a/packages/front-end/components/ApiKeysTable/ApiKeysTable.tsx
+++ b/packages/front-end/components/ApiKeysTable/ApiKeysTable.tsx
@@ -135,7 +135,13 @@ export const ApiKeysTable: FC<ApiKeysTableProps> = ({
               })}
               <td>
                 {key.lastUsed ? (
-                  <Tooltip content={datetime(key.lastUsed)}>
+                  <Tooltip
+                    content={
+                      key.disabled
+                        ? `${datetime(key.lastUsed)}. This is the last time a request was attempted, successful or not.`
+                        : datetime(key.lastUsed)
+                    }
+                  >
                     <span>{ago(key.lastUsed)}</span>
                   </Tooltip>
                 ) : key.lastUsed === null ? (

--- a/packages/front-end/components/ApiKeysTable/ApiKeysTable.tsx
+++ b/packages/front-end/components/ApiKeysTable/ApiKeysTable.tsx
@@ -191,8 +191,8 @@ export const ApiKeysTable: FC<ApiKeysTableProps> = ({
           yesText={!pendingToggle.disabled ? "Disable" : "Enable"}
           onConfirm={async () => {
             const target = pendingToggle;
-            setPendingToggle(null);
             await onToggleDisabled(target.id, !target.disabled)();
+            setPendingToggle(null);
           }}
           onCancel={() => setPendingToggle(null)}
         />

--- a/packages/front-end/components/ApiKeysTable/ApiKeysTable.tsx
+++ b/packages/front-end/components/ApiKeysTable/ApiKeysTable.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import React, { FC, useState } from "react";
 import { FaCheck, FaFilter, FaTimes } from "react-icons/fa";
 import { ApiKeyInterface, ApiKeyWithRole } from "shared/types/apikey";
 import { getRoleDisplayName } from "shared/permissions";
@@ -13,6 +13,7 @@ import { useEnvironments } from "@/services/features";
 import { roleHasAccessToEnv } from "@/services/auth";
 import Tooltip from "@/ui/Tooltip";
 import Badge from "@/ui/Badge";
+import ConfirmDialog from "@/ui/ConfirmDialog";
 
 type ApiKeysTableProps = {
   onDelete: (keyId: string | undefined) => () => Promise<void>;
@@ -37,6 +38,10 @@ export const ApiKeysTable: FC<ApiKeysTableProps> = ({
   const { organization } = useUser();
   const { projects } = useDefinitions();
   const environments = useEnvironments();
+  const [pendingToggle, setPendingToggle] = useState<ApiKeyInterface | null>(
+    null,
+  );
+  const pendingDisabled = pendingToggle ? !pendingToggle.disabled : false;
   return (
     <div style={{ overflowX: "auto" }}>
       <table className="table mb-3 appbox gbtable">
@@ -133,8 +138,12 @@ export const ApiKeysTable: FC<ApiKeysTableProps> = ({
                   <Tooltip content={datetime(key.lastUsed)}>
                     <span>{ago(key.lastUsed)}</span>
                   </Tooltip>
-                ) : (
+                ) : key.lastUsed === null ? (
                   <span className="text-muted">Never</span>
+                ) : (
+                  <Tooltip content="This key was created before usage tracking was added, so we don't know when it was last used.">
+                    <span className="text-muted">Unknown</span>
+                  </Tooltip>
                 )}
               </td>
               {canDeleteKeys && (
@@ -143,9 +152,9 @@ export const ApiKeysTable: FC<ApiKeysTableProps> = ({
                     {onToggleDisabled && (
                       <button
                         className="dropdown-item"
-                        onClick={async (e) => {
+                        onClick={(e) => {
                           e.preventDefault();
-                          await onToggleDisabled(key.id, !key.disabled)();
+                          setPendingToggle(key);
                         }}
                       >
                         {key.disabled ? "Enable key" : "Disable key"}
@@ -164,6 +173,23 @@ export const ApiKeysTable: FC<ApiKeysTableProps> = ({
           ))}
         </tbody>
       </table>
+      {pendingToggle && onToggleDisabled && (
+        <ConfirmDialog
+          title={pendingDisabled ? "Disable API key?" : "Enable API key?"}
+          content={
+            pendingDisabled
+              ? `Any request using "${pendingToggle.description || "this key"}" will be rejected until it is re-enabled.`
+              : `"${pendingToggle.description || "This key"}" will immediately start accepting requests again.`
+          }
+          yesText={pendingDisabled ? "Disable" : "Enable"}
+          onConfirm={async () => {
+            const target = pendingToggle;
+            setPendingToggle(null);
+            await onToggleDisabled(target.id, !target.disabled)();
+          }}
+          onCancel={() => setPendingToggle(null)}
+        />
+      )}
     </div>
   );
 };

--- a/packages/front-end/components/ApiKeysTable/ApiKeysTable.tsx
+++ b/packages/front-end/components/ApiKeysTable/ApiKeysTable.tsx
@@ -2,6 +2,7 @@ import React, { FC } from "react";
 import { FaCheck, FaFilter, FaTimes } from "react-icons/fa";
 import { ApiKeyInterface, ApiKeyWithRole } from "shared/types/apikey";
 import { getRoleDisplayName } from "shared/permissions";
+import { ago, datetime } from "shared/dates";
 import ClickToReveal from "@/components/Settings/ClickToReveal";
 import MoreMenu from "@/components/Dropdown/MoreMenu";
 import DeleteButton from "@/components/DeleteButton/DeleteButton";
@@ -11,6 +12,7 @@ import ProjectBadges from "@/components/ProjectBadges";
 import { useEnvironments } from "@/services/features";
 import { roleHasAccessToEnv } from "@/services/auth";
 import Tooltip from "@/ui/Tooltip";
+import Badge from "@/ui/Badge";
 
 type ApiKeysTableProps = {
   onDelete: (keyId: string | undefined) => () => Promise<void>;
@@ -18,6 +20,10 @@ type ApiKeysTableProps = {
   canCreateKeys: boolean;
   canDeleteKeys: boolean;
   onReveal: (keyId: string | undefined) => () => Promise<string>;
+  onToggleDisabled?: (
+    keyId: string | undefined,
+    disabled: boolean,
+  ) => () => Promise<void>;
 };
 
 export const ApiKeysTable: FC<ApiKeysTableProps> = ({
@@ -26,6 +32,7 @@ export const ApiKeysTable: FC<ApiKeysTableProps> = ({
   canCreateKeys,
   canDeleteKeys,
   onReveal,
+  onToggleDisabled,
 }) => {
   const { organization } = useUser();
   const { projects } = useDefinitions();
@@ -42,14 +49,22 @@ export const ApiKeysTable: FC<ApiKeysTableProps> = ({
             {environments.map((env) => (
               <th key={env.id}>{env.id}</th>
             ))}
-
+            <th>Last Used</th>
             {canDeleteKeys && <th style={{ width: 30 }}></th>}
           </tr>
         </thead>
         <tbody>
           {keys.map((key) => (
-            <tr key={key.id}>
-              <td>{key.description}</td>
+            <tr
+              key={key.id}
+              style={key.disabled ? { opacity: 0.55 } : undefined}
+            >
+              <td>
+                {key.description}
+                {key.disabled && (
+                  <Badge ml="2" color="red" variant="soft" label="Disabled" />
+                )}
+              </td>
               <td style={{ minWidth: 270 }}>
                 {canCreateKeys ? (
                   <ClickToReveal
@@ -113,9 +128,29 @@ export const ApiKeysTable: FC<ApiKeysTableProps> = ({
                   </td>
                 );
               })}
+              <td>
+                {key.lastUsed ? (
+                  <Tooltip content={datetime(key.lastUsed)}>
+                    <span>{ago(key.lastUsed)}</span>
+                  </Tooltip>
+                ) : (
+                  <span className="text-muted">Never</span>
+                )}
+              </td>
               {canDeleteKeys && (
                 <td>
                   <MoreMenu>
+                    {onToggleDisabled && (
+                      <button
+                        className="dropdown-item"
+                        onClick={async (e) => {
+                          e.preventDefault();
+                          await onToggleDisabled(key.id, !key.disabled)();
+                        }}
+                      >
+                        {key.disabled ? "Enable key" : "Disable key"}
+                      </button>
+                    )}
                     <DeleteButton
                       onClick={onDelete(key.id)}
                       className="dropdown-item"

--- a/packages/front-end/components/PersonalAccessTokens/PersonalAccessTokens.tsx
+++ b/packages/front-end/components/PersonalAccessTokens/PersonalAccessTokens.tsx
@@ -12,6 +12,10 @@ type PersonalAccessTokensProps = {
   accessTokens: ApiKeyInterface[];
   onDelete: (keyId: string | undefined) => () => Promise<void>;
   onReveal: (keyId: string | undefined) => () => Promise<string>;
+  onToggleDisabled: (
+    keyId: string | undefined,
+    disabled: boolean,
+  ) => () => Promise<void>;
   onCreate: () => void;
 };
 
@@ -19,6 +23,7 @@ export const PersonalAccessTokens: FC<PersonalAccessTokensProps> = ({
   accessTokens,
   onDelete,
   onReveal,
+  onToggleDisabled,
   onCreate,
 }) => {
   const [open, setOpen] = useState(false);
@@ -47,6 +52,7 @@ export const PersonalAccessTokens: FC<PersonalAccessTokensProps> = ({
             canCreateKeys
             canDeleteKeys
             onReveal={onReveal}
+            onToggleDisabled={onToggleDisabled}
           />
         )}
         <button
@@ -112,12 +118,25 @@ export const PersonalAccessTokensContainer = () => {
     [mutate, apiCall],
   );
 
+  const onToggleDisabled = useCallback(
+    (keyId: string | undefined, disabled: boolean) => async () => {
+      if (!keyId) return;
+      await apiCall(`/keys/${keyId}/disabled`, {
+        method: "PUT",
+        body: JSON.stringify({ disabled }),
+      });
+      mutate();
+    },
+    [apiCall, mutate],
+  );
+
   return (
     <PersonalAccessTokens
       onDelete={onDelete}
       accessTokens={userKeys}
       onCreate={mutate}
       onReveal={onReveal}
+      onToggleDisabled={onToggleDisabled}
     />
   );
 };

--- a/packages/front-end/components/Settings/SecretApiKeys.tsx
+++ b/packages/front-end/components/Settings/SecretApiKeys.tsx
@@ -55,6 +55,18 @@ const SecretApiKeys: FC<{ keys: ApiKeyInterface[]; mutate: () => void }> = ({
     [mutate, apiCall],
   );
 
+  const onToggleDisabled = useCallback(
+    (keyId: string | undefined, disabled: boolean) => async () => {
+      if (!keyId) return;
+      await apiCall(`/keys/${keyId}/disabled`, {
+        method: "PUT",
+        body: JSON.stringify({ disabled }),
+      });
+      mutate();
+    },
+    [apiCall, mutate],
+  );
+
   return (
     <div className="mb-4">
       {open && canCreateKeys && (
@@ -78,6 +90,7 @@ const SecretApiKeys: FC<{ keys: ApiKeyInterface[]; mutate: () => void }> = ({
             canCreateKeys={canCreateKeys}
             canDeleteKeys={canDeleteKeys}
             onReveal={onReveal}
+            onToggleDisabled={canDeleteKeys ? onToggleDisabled : undefined}
           />
         )}
         {canCreateKeys && (

--- a/packages/front-end/ui/ConfirmDialog.tsx
+++ b/packages/front-end/ui/ConfirmDialog.tsx
@@ -1,6 +1,7 @@
-import { ReactNode } from "react";
+import { ReactNode, useState } from "react";
 import { AlertDialog, Box, Flex, Text } from "@radix-ui/themes";
 import Button from "@/ui/Button";
+import HelperText from "@/ui/HelperText";
 
 type Props = {
   title: string;
@@ -19,6 +20,7 @@ export default function ConfirmDialog({
   onConfirm,
   onCancel,
 }: Props) {
+  const [error, setError] = useState<string | null>(null);
   return (
     <AlertDialog.Root open={true}>
       <AlertDialog.Content maxWidth="520px">
@@ -35,13 +37,14 @@ export default function ConfirmDialog({
               </Text>
             </AlertDialog.Description>
           </Box>
+          {error && <HelperText status="error">{error}</HelperText>}
           <Flex justify="end" gap="3">
             {noText ? (
               <Button variant="outline" color="gray" onClick={onCancel}>
                 {noText}
               </Button>
             ) : null}
-            <Button color="violet" onClick={onConfirm}>
+            <Button color="violet" onClick={onConfirm} setError={setError}>
               {yesText}
             </Button>
           </Flex>

--- a/packages/shared/src/validators/apikey.ts
+++ b/packages/shared/src/validators/apikey.ts
@@ -53,8 +53,11 @@ export const apiKeySchema = createBaseSchemaWithPrimaryKey({
     ),
   lastUsed: z
     .date()
+    .nullable()
     .optional()
-    .describe("Timestamp of the most recent successful authentication"),
+    .describe(
+      "Timestamp of the most recent successful authentication. `null` means the key has never been used. `undefined` means the key predates usage tracking.",
+    ),
 });
 
 export const secretApiKey = apiKeySchema

--- a/packages/shared/src/validators/apikey.ts
+++ b/packages/shared/src/validators/apikey.ts
@@ -45,6 +45,16 @@ export const apiKeySchema = createBaseSchemaWithPrimaryKey({
     .describe(
       "Org API keys only. Project-specific role overrides, same shape as member projectRoles",
     ),
+  disabled: z
+    .boolean()
+    .optional()
+    .describe(
+      "When true, the key is rejected on authentication but not deleted",
+    ),
+  lastUsed: z
+    .date()
+    .optional()
+    .describe("Timestamp of the most recent successful authentication"),
 });
 
 export const secretApiKey = apiKeySchema


### PR DESCRIPTION
### Features and Changes

Keep track of last used date for API keys (both personal access token and org-wide secret keys).  Also, allow disabling/enabling keys.

When combined, these changes allows you to safely retire API keys. If one looks stale (hasn't been used recently), mark it as disabled.  Wait a couple weeks, and if it still hasn't been used, delete it.