### PR TITLE
fix(api): include customMetricSlices in experiment API responses

### DIFF
--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -2305,6 +2305,7 @@ export async function toExperimentApiInterface(
     hasVisualChangesets: experiment.hasVisualChangesets || false,
     hasURLRedirects: experiment.hasURLRedirects || false,
     customFields: experiment.customFields ?? {},
+    customMetricSlices: experiment.customMetricSlices ?? [],
     defaultDashboardId: experiment.defaultDashboardId,
     templateId: experiment.templateId || undefined,
   };


### PR DESCRIPTION
Bugfix: The `customMetricSlices` field was missing from the response objects in `GET /experiments`, `GET /experiments/:id`, `POST /experiments`, and `PUT /experiments/:id`.

