### PR TITLE
[fix] Snapshot already has chunked analyses - custom reports

### DIFF
--- a/packages/back-end/src/services/reports.ts
+++ b/packages/back-end/src/services/reports.ts
@@ -575,6 +575,8 @@ export async function createReportSnapshot({
     queries: [],
     unknownVariations: [],
     multipleExposures: 0,
+    hasChunkedAnalyses: false,
+    chunkedAnalysesMeta: [],
     analyses: snapshotData.analyses.map((analysis) => ({
       ...analysis,
       dateCreated: new Date(),


### PR DESCRIPTION
### Features and Changes

Refreshing results in a custom report was failing after #5651 

`createReportSnapshot` spreads the previous snapshot (which carries hasChunkedAnalyses: true and chunkedAnalysesMeta from DB), then empties the analyses' results for the new running snapshot. createExperimentSnapshotModel guards against 
  "chunked flag set but no populated results" and throws. The new snapshot has a fresh ID and no chunks of its own, so these fields should be reset.