### PR TITLE
fix(shared): Ensure import from the package and not src files

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -225,6 +225,11 @@ export default defineConfig([
               group: ["*back-end*", "**/sdk-{js,react}*"],
               message: "front-end can only import from shared or itself.",
             },
+            {
+              group: ["shared/src", "shared/src/*", "shared/src/**"],
+              message:
+                "Import from the package (e.g., 'shared/validators') instead of 'shared/src/...'",
+            },
           ],
         },
       ],
@@ -337,6 +342,11 @@ export default defineConfig([
               group: ["*front-end*", "**/sdk-{js,react}*"],
               message: "back-end can only import from shared or itself.",
             },
+            {
+              group: ["shared/src", "shared/src/*", "shared/src/**"],
+              message:
+                "Import from the package (e.g., 'shared/validators') instead of 'shared/src/...'",
+            },
           ],
         },
       ],
@@ -406,6 +416,11 @@ export default defineConfig([
             {
               group: ["*back-end*", "*front-end*"],
               message: "shared cannot import from back-end or front-end.",
+            },
+            {
+              group: ["shared/src", "shared/src/*", "shared/src/**"],
+              message:
+                "Within shared, use relative paths or import from shared without /src/",
             },
           ],
         },

--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -152,7 +152,7 @@ import {
   MetricQuantileSettings,
 } from "shared/types/fact-table";
 import type { PopulationDataQuerySettings } from "shared/types/query";
-import { ExplorationConfig } from "shared/src/validators/product-analytics";
+import { ExplorationConfig } from "shared/validators";
 import {
   AdditionalQueryMetadata,
   QueryMetadata,

--- a/packages/front-end/components/Dimensions/DimensionChooser.tsx
+++ b/packages/front-end/components/Dimensions/DimensionChooser.tsx
@@ -5,7 +5,7 @@ import {
   ExperimentSnapshotInterface,
 } from "shared/types/experiment-snapshot";
 import { Flex, Text } from "@radix-ui/themes";
-import { getSnapshotAnalysis } from "shared/src/util";
+import { getSnapshotAnalysis } from "shared/util";
 import { DataSourceInterfaceWithParams } from "shared/types/datasource";
 import { DimensionInterface } from "shared/types/dimension";
 import { IncrementalRefreshInterface } from "shared/validators";

--- a/packages/front-end/components/Features/RuleModal/RampScheduleSection.tsx
+++ b/packages/front-end/components/Features/RuleModal/RampScheduleSection.tsx
@@ -27,9 +27,9 @@ import {
   type RampStep,
   type FeatureRulePatch,
   type TemplateEndPatch,
+  type RevisionRampCreateAction,
 } from "shared/validators";
-import type { RevisionRampCreateAction } from "shared/src/validators/features";
-import { date as formatDate } from "shared/src/dates";
+import { date as formatDate } from "shared/dates";
 import { BsThreeDotsVertical } from "react-icons/bs";
 import { HiBadgeCheck } from "react-icons/hi";
 import {

--- a/packages/front-end/components/GetStarted/AdvancedFeaturesCard.tsx
+++ b/packages/front-end/components/GetStarted/AdvancedFeaturesCard.tsx
@@ -1,5 +1,5 @@
 import { AspectRatio, Box, Text } from "@radix-ui/themes";
-import { CommercialFeature } from "shared/src/enterprise/license-consts";
+import { CommercialFeature } from "shared/enterprise";
 import PaidFeatureBadge from "@/components/GetStarted/PaidFeatureBadge";
 import { DocSection, DocLink } from "@/components/DocLink";
 import Link from "@/ui/Link";

--- a/packages/front-end/components/GetStarted/index.tsx
+++ b/packages/front-end/components/GetStarted/index.tsx
@@ -9,7 +9,7 @@ import {
   Text,
 } from "@radix-ui/themes";
 import { PiArrowSquareOut, PiCaretDownFill } from "react-icons/pi";
-import { CommercialFeature } from "shared/src/enterprise/license-consts";
+import { CommercialFeature } from "shared/enterprise";
 import router from "next/router";
 import { useGrowthBook } from "@growthbook/growthbook-react";
 import UpgradeModal from "@/components/Settings/UpgradeModal";

--- a/packages/front-end/components/RampSchedule/RampScheduleDisplay.tsx
+++ b/packages/front-end/components/RampSchedule/RampScheduleDisplay.tsx
@@ -4,10 +4,7 @@
 import { Fragment, type ReactNode } from "react";
 import { Box, Flex, Separator } from "@radix-ui/themes";
 import stringify from "json-stringify-pretty-compact";
-import {
-  RampScheduleInterface,
-  RampStepAction,
-} from "shared/src/validators/ramp-schedule";
+import { RampScheduleInterface, RampStepAction } from "shared/validators";
 import Text from "@/ui/Text";
 import InlineCode from "@/components/SyntaxHighlighting/InlineCode";
 import ConditionDisplay from "@/components/Features/ConditionDisplay";

--- a/packages/front-end/components/RampSchedule/RampTimeline.tsx
+++ b/packages/front-end/components/RampSchedule/RampTimeline.tsx
@@ -2,13 +2,13 @@ import { Fragment, useState, type ReactNode } from "react";
 import { Box, Flex } from "@radix-ui/themes";
 import { PiCheckBold } from "react-icons/pi";
 import { format } from "date-fns";
-import { abbreviateAgo } from "shared/src/dates";
+import { abbreviateAgo } from "shared/dates";
 import {
   RampScheduleInterface,
   RampScheduleStatus,
   RampStepAction,
   RampTrigger,
-} from "shared/src/validators/ramp-schedule";
+} from "shared/validators";
 import stringify from "json-stringify-pretty-compact";
 import Text from "@/ui/Text";
 import Tooltip from "@/components/Tooltip/Tooltip";

--- a/packages/front-end/enterprise/components/ProductAnalytics/ExplorerContext.tsx
+++ b/packages/front-end/enterprise/components/ProductAnalytics/ExplorerContext.tsx
@@ -13,8 +13,8 @@ import {
   ExplorationConfig,
   ProductAnalyticsValue,
   DatasetType,
-} from "shared/src/validators/product-analytics";
-import { ProductAnalyticsExploration } from "shared/validators";
+  ProductAnalyticsExploration,
+} from "shared/validators";
 import { QueryInterface } from "shared/types/query";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import {

--- a/packages/front-end/enterprise/components/ProductAnalytics/SideBar/DatasourceConfigurator.tsx
+++ b/packages/front-end/enterprise/components/ProductAnalytics/SideBar/DatasourceConfigurator.tsx
@@ -9,7 +9,7 @@ import {
   DataSourceValue,
   ExplorationDataset,
   ExplorationConfig,
-} from "shared/src/validators/product-analytics";
+} from "shared/validators";
 import { PiCheck } from "react-icons/pi";
 import SelectField from "@/components/Forms/SelectField";
 import {

--- a/packages/front-end/hooks/useFeatureRevisionDiff.ts
+++ b/packages/front-end/hooks/useFeatureRevisionDiff.ts
@@ -2,7 +2,7 @@ import { useMemo, ReactNode } from "react";
 import isEqual from "lodash/isEqual";
 import { FeatureInterface } from "shared/types/feature";
 import { FeatureRevisionInterface } from "shared/types/feature-revision";
-import { RevisionMetadata } from "shared/src/validators/features";
+import { RevisionMetadata } from "shared/validators";
 import type { MergeResultChanges } from "shared/util";
 import {
   renderFeatureDefaultValue,

--- a/packages/shared/test/product-analytics.test.ts
+++ b/packages/shared/test/product-analytics.test.ts
@@ -1,7 +1,7 @@
+import { generateProductAnalyticsSQL } from "shared/enterprise";
 import { format } from "shared/sql";
 import { ExplorationConfig } from "shared/validators";
 import { SqlHelpers } from "shared/types/sql";
-import { generateProductAnalyticsSQL } from "shared/src/enterprise/product-analytics/sql";
 import {
   FactMetricInterface,
   FactTableInterface,


### PR DESCRIPTION
### Features and Changes

When importing from `shared` we want to use `shared` package that is compiled and not the `src` files.

This was also creating a bug where some files were being imported twice and could create issues in case of a Zod validator singleton.

#### Changes

- Add `eslint` rule to prevent import from `shared/src`
- Updated all usages from `shared/src` to `shared/{file}`