### PR TITLE
Fix metric drilldown modal not refreshing with dimension breakdowns

### DIFF
--- a/packages/front-end/components/MetricDrilldown/MetricDrilldownModal.tsx
+++ b/packages/front-end/components/MetricDrilldown/MetricDrilldownModal.tsx
@@ -189,10 +189,12 @@ const MetricDrilldownContent: FC<MetricDrilldownContentProps> = ({
   const { isAuthenticated } = useAuth();
   const { analysis } = useSnapshot();
 
-  // When dimensionInfo is provided (from BreakDownResults), use the passed initialResults
-  // which contains the correct dimension-specific data. Otherwise, use snapshot results.
+  // When dimensionInfo is provided (from BreakDownResults), use the dimension-specific
+  // results from the current analysis (which updates after baseline/difference changes),
+  // falling back to initialResults only when analysis isn't available yet.
+  // Without dimensionInfo, use the first result (aggregate view).
   const results = dimensionInfo
-    ? initialResults
+    ? (analysis?.results?.[dimensionInfo.index] ?? initialResults)
     : (analysis?.results?.[0] ?? initialResults);
 
   // TODO: Check what we need here


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Features and Changes

Fixes a regression where the baseline variation index and difference chooser controls in the metric drilldown modal were not properly triggering new analyses when dimension breakdowns were active.

**Root Cause:**
In `MetricDrilldownModal.tsx`, when `dimensionInfo` was provided (dimension breakdown active), the component was always using `initialResults` (captured when modal opened) instead of getting the updated results from the refreshed `analysis` after baseline/difference changes.

```tsx
// Before (bug):
const results = dimensionInfo
  ? initialResults  // Always stale!
  : (analysis?.results?.[0] ?? initialResults);

// After (fix):
const results = dimensionInfo
  ? (analysis?.results?.[dimensionInfo.index] ?? initialResults)  // Uses fresh data
  : (analysis?.results?.[0] ?? initialResults);
```

This worked correctly on the main page because `BreakDownResults` rebuilds from `analysis.results` directly, but the modal had pinned itself to the initial snapshot.

### Dependencies

None

### Testing

1. Open an experiment with dimension breakdowns enabled
2. Click on a metric row in the breakdown table to open the metric drilldown modal
3. Change the baseline variation using the dropdown in the modal
4. Verify the data in the modal updates to reflect the new baseline
5. Change the difference type (relative/absolute) and verify it updates correctly
6. Confirm that the same controls work properly without dimension breakdowns (non-regression)

### Screenshots

This is a behavior fix for data refresh - the UI elements themselves remain unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://growthbookapp.slack.com/archives/C07NK4F016Z/p1776459675227379?thread_ts=1776459675.227379&cid=C07NK4F016Z)

<div><a href="https://cursor.com/agents/bc-4aa35743-f184-52c5-bdb0-98633d217290"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4aa35743-f184-52c5-bdb0-98633d217290"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

