### PR TITLE
Move clickhouse functions over to the license server

### DIFF
--- a/packages/back-end/src/services/clickhouse.ts
+++ b/packages/back-end/src/services/clickhouse.ts
@@ -22,6 +22,7 @@ import {
   IS_CLOUD,
   CLICKHOUSE_DEV_PREFIX,
   CLICKHOUSE_OVERAGE_TABLE,
+  MANAGED_CLICKHOUSE_USE_LICENSE_SERVER,
 } from "back-end/src/util/secrets";
 import type { ReqContext } from "back-end/types/request";
 import { logger } from "back-end/src/util/logger";
@@ -33,6 +34,14 @@ import {
   lockDataSource,
   unlockDataSource,
 } from "back-end/src/models/DataSourceModel";
+import {
+  addCloudSDKMappingViaLicenseServer,
+  createClickhouseUserViaLicenseServer,
+  dangerousRecreateClickhouseTablesViaLicenseServer,
+  deleteClickhouseUserViaLicenseServer,
+  migrateOverageEventsForOrgIdViaLicenseServer,
+  updateMaterializedColumnsInClickhouseViaLicenseServer,
+} from "back-end/src/services/licenseServerManagedClickhouse";
 
 type ClickHouseDataType =
   | "DateTime"
@@ -370,6 +379,13 @@ export async function createClickhouseUser(
   context: ReqContext,
   materializedColumns: MaterializedColumn[] = [],
 ): Promise<DataSourceParams> {
+  if (MANAGED_CLICKHOUSE_USE_LICENSE_SERVER) {
+    return createClickhouseUserViaLicenseServer(
+      context.org.id,
+      materializedColumns,
+    );
+  }
+
   const client = createAdminClickhouseClient();
 
   const orgId = context.org.id;
@@ -461,34 +477,45 @@ export async function _dangerousRecreateClickhouseTables(
   context: ReqContext,
   datasource: GrowthbookClickhouseDataSource,
 ): Promise<void> {
-  const client = createAdminClickhouseClient();
-
   const orgId = context.org.id;
-  const user = clickhouseUserId(orgId);
-  const database = user;
 
   // Backfilling data can take a while, so lock the datasource for 30 minutes
   await lockDataSource(context, datasource, 1800);
 
   try {
-    // Drop the entire database and recreate it
-    logger.info(`Dropping Clickhouse database ${database}`);
-    await runCommand(client, `DROP DATABASE IF EXISTS ${database}`);
+    if (MANAGED_CLICKHOUSE_USE_LICENSE_SERVER) {
+      await dangerousRecreateClickhouseTablesViaLicenseServer(
+        orgId,
+        datasource.settings.materializedColumns || [],
+      );
+    } else {
+      const client = createAdminClickhouseClient();
+      const user = clickhouseUserId(orgId);
+      const database = user;
 
-    logger.info(`Creating Clickhouse database ${database}`);
-    await runCommand(client, `CREATE DATABASE ${database}`);
+      // Drop the entire database and recreate it
+      logger.info(`Dropping Clickhouse database ${database}`);
+      await runCommand(client, `DROP DATABASE IF EXISTS ${database}`);
 
-    await createClickhouseTables(
-      client,
-      orgId,
-      datasource.settings.materializedColumns || [],
-    );
+      logger.info(`Creating Clickhouse database ${database}`);
+      await runCommand(client, `CREATE DATABASE ${database}`);
+
+      await createClickhouseTables(
+        client,
+        orgId,
+        datasource.settings.materializedColumns || [],
+      );
+    }
   } finally {
     await unlockDataSource(context, datasource);
   }
 }
 
 export async function deleteClickhouseUser(organization: string) {
+  if (MANAGED_CLICKHOUSE_USE_LICENSE_SERVER) {
+    return deleteClickhouseUserViaLicenseServer(organization);
+  }
+
   const client = createAdminClickhouseClient();
   const user = clickhouseUserId(organization);
   const database = user;
@@ -505,12 +532,16 @@ export async function addCloudSDKMapping(connection: SDKConnectionInterface) {
 
   // This is not a fatal error, so just log instead of throwing
   try {
-    const client = createAdminClickhouseClient();
-    await client.insert({
-      table: "usage.sdk_key_mapping",
-      values: [{ key, organization }],
-      format: "JSONEachRow",
-    });
+    if (MANAGED_CLICKHOUSE_USE_LICENSE_SERVER) {
+      await addCloudSDKMappingViaLicenseServer(key, organization);
+    } else {
+      const client = createAdminClickhouseClient();
+      await client.insert({
+        table: "usage.sdk_key_mapping",
+        values: [{ key, organization }],
+        format: "JSONEachRow",
+      });
+    }
   } catch (e) {
     logger.error(
       e,
@@ -520,6 +551,10 @@ export async function addCloudSDKMapping(connection: SDKConnectionInterface) {
 }
 
 export async function migrateOverageEventsForOrgId(orgId: string) {
+  if (MANAGED_CLICKHOUSE_USE_LICENSE_SERVER) {
+    return migrateOverageEventsForOrgIdViaLicenseServer(orgId);
+  }
+
   const client = createAdminClickhouseClient();
   await runCommand(
     client,
@@ -697,83 +732,94 @@ export async function updateMaterializedColumns({
   await lockDataSource(context, datasource, 300);
 
   try {
-    const client = createAdminClickhouseClient();
-
     const orgId = datasource.organization;
 
-    const addClauses = columnsToAdd
-      .map(
-        ({ columnName, datatype }) =>
-          `ADD COLUMN IF NOT EXISTS ${columnName} ${getClickhouseDatatype(
-            datatype,
-          )}`,
-      )
-      .join(", ");
-    const dropClauses = columnsToDelete
-      .map((columnName) => `DROP COLUMN IF EXISTS ${columnName}`)
-      .join(", ");
-    const renameClauses = columnsToRename
-      .map(({ from, to }) => `RENAME COLUMN ${from} to ${to}`)
-      .join(", ");
-    const clauses = `${addClauses}${
-      columnsToAdd.length > 0 &&
-      columnsToDelete.length + columnsToRename.length > 0
-        ? ", "
-        : ""
-    }${dropClauses}${
-      columnsToDelete.length > 0 && columnsToRename.length > 0 ? ", " : ""
-    }${renameClauses}`;
+    if (MANAGED_CLICKHOUSE_USE_LICENSE_SERVER) {
+      await updateMaterializedColumnsInClickhouseViaLicenseServer({
+        orgId,
+        columnsToAdd,
+        columnsToDelete,
+        columnsToRename,
+        finalColumns,
+        originalColumns,
+      });
+    } else {
+      const client = createAdminClickhouseClient();
 
-    // Track which columns the view should be recreated with in case of an error
-    let viewColumns = originalColumns;
+      const addClauses = columnsToAdd
+        .map(
+          ({ columnName, datatype }) =>
+            `ADD COLUMN IF NOT EXISTS ${columnName} ${getClickhouseDatatype(
+              datatype,
+            )}`,
+        )
+        .join(", ");
+      const dropClauses = columnsToDelete
+        .map((columnName) => `DROP COLUMN IF EXISTS ${columnName}`)
+        .join(", ");
+      const renameClauses = columnsToRename
+        .map(({ from, to }) => `RENAME COLUMN ${from} to ${to}`)
+        .join(", ");
+      const clauses = `${addClauses}${
+        columnsToAdd.length > 0 &&
+        columnsToDelete.length + columnsToRename.length > 0
+          ? ", "
+          : ""
+      }${dropClauses}${
+        columnsToDelete.length > 0 && columnsToRename.length > 0 ? ", " : ""
+      }${renameClauses}`;
 
-    // First update the main events table
-    const { tableName: eventsTableName, viewName: eventsViewName } =
-      getEventsSQL(orgId, []);
-    logger.info(
-      `Updating materialized columns; dropping view ${eventsViewName}`,
-    );
-    await runCommand(client, `DROP VIEW IF EXISTS ${eventsViewName}`);
-    let err = undefined;
-    try {
-      logger.info(`Updating table schema for ${eventsTableName}`);
-      await runCommand(client, `ALTER TABLE ${eventsTableName} ${clauses}`);
-      viewColumns = finalColumns;
-    } catch (e) {
-      logger.error(e);
-      err = e;
-    } finally {
-      logger.info(`Recreating materialized view ${eventsViewName}`);
-      const eventsSQL = getEventsSQL(orgId, viewColumns);
-      await runCommand(client, eventsSQL.createView);
-    }
-    if (err) {
-      throw err;
-    }
+      // Track which columns the view should be recreated with in case of an error
+      let viewColumns = originalColumns;
 
-    // Now update the experiment views table
-    const { tableName: exposureTableName, viewName: exposureViewName } =
-      getExperimentViewSQL(orgId, []);
-    logger.info(
-      `Updating materialized columns; dropping view ${exposureViewName}`,
-    );
-    await runCommand(client, `DROP VIEW IF EXISTS ${exposureViewName}`);
-    err = undefined;
-    viewColumns = originalColumns;
-    try {
-      logger.info(`Updating table schema for ${exposureTableName}`);
-      await runCommand(client, `ALTER TABLE ${exposureTableName} ${clauses}`);
-      viewColumns = finalColumns;
-    } catch (e) {
-      logger.error(e);
-      err = e;
-    } finally {
-      logger.info(`Recreating materialized view ${exposureViewName}`);
-      const experimentViewSQL = getExperimentViewSQL(orgId, viewColumns);
-      await runCommand(client, experimentViewSQL.createView);
-    }
-    if (err) {
-      throw err;
+      // First update the main events table
+      const { tableName: eventsTableName, viewName: eventsViewName } =
+        getEventsSQL(orgId, []);
+      logger.info(
+        `Updating materialized columns; dropping view ${eventsViewName}`,
+      );
+      await runCommand(client, `DROP VIEW IF EXISTS ${eventsViewName}`);
+      let err = undefined;
+      try {
+        logger.info(`Updating table schema for ${eventsTableName}`);
+        await runCommand(client, `ALTER TABLE ${eventsTableName} ${clauses}`);
+        viewColumns = finalColumns;
+      } catch (e) {
+        logger.error(e);
+        err = e;
+      } finally {
+        logger.info(`Recreating materialized view ${eventsViewName}`);
+        const eventsSQL = getEventsSQL(orgId, viewColumns);
+        await runCommand(client, eventsSQL.createView);
+      }
+      if (err) {
+        throw err;
+      }
+
+      // Now update the experiment views table
+      const { tableName: exposureTableName, viewName: exposureViewName } =
+        getExperimentViewSQL(orgId, []);
+      logger.info(
+        `Updating materialized columns; dropping view ${exposureViewName}`,
+      );
+      await runCommand(client, `DROP VIEW IF EXISTS ${exposureViewName}`);
+      err = undefined;
+      viewColumns = originalColumns;
+      try {
+        logger.info(`Updating table schema for ${exposureTableName}`);
+        await runCommand(client, `ALTER TABLE ${exposureTableName} ${clauses}`);
+        viewColumns = finalColumns;
+      } catch (e) {
+        logger.error(e);
+        err = e;
+      } finally {
+        logger.info(`Recreating materialized view ${exposureViewName}`);
+        const experimentViewSQL = getExperimentViewSQL(orgId, viewColumns);
+        await runCommand(client, experimentViewSQL.createView);
+      }
+      if (err) {
+        throw err;
+      }
     }
 
     // Update the main events fact table with the new columns

--- a/packages/back-end/src/services/licenseServerManagedClickhouse.ts
+++ b/packages/back-end/src/services/licenseServerManagedClickhouse.ts
@@ -9,13 +9,13 @@ import type {
 import type { Response } from "node-fetch";
 import { LICENSE_SERVER_URL } from "back-end/src/enterprise/licenseUtil";
 import { fetch } from "back-end/src/util/http.util";
+import { CLOUD_SECRET } from "back-end/src/util/secrets";
 
 async function postManagedClickhouse(
   path: string,
   body: unknown,
 ): Promise<Response> {
-  const cloudSecret = process.env.CLOUD_SECRET;
-  if (!cloudSecret) {
+  if (!CLOUD_SECRET) {
     throw new Error(
       "CLOUD_SECRET must be set to use license server managed ClickHouse",
     );
@@ -28,7 +28,7 @@ async function postManagedClickhouse(
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      Authorization: `Bearer ${cloudSecret}`,
+      Authorization: `Bearer ${CLOUD_SECRET}`,
     },
     body: JSON.stringify(body),
   });

--- a/packages/back-end/src/services/licenseServerManagedClickhouse.ts
+++ b/packages/back-end/src/services/licenseServerManagedClickhouse.ts
@@ -1,0 +1,150 @@
+/**
+ * Delegates managed ClickHouse provisioning to central-license-server
+ * (see managed-clickhouse/* routes there).
+ */
+import type {
+  DataSourceParams,
+  MaterializedColumn,
+} from "shared/types/datasource";
+import type { Response } from "node-fetch";
+import { LICENSE_SERVER_URL } from "back-end/src/enterprise/licenseUtil";
+import { fetch } from "back-end/src/util/http.util";
+
+async function postManagedClickhouse(
+  path: string,
+  body: unknown,
+): Promise<Response> {
+  const cloudSecret = process.env.CLOUD_SECRET;
+  if (!cloudSecret) {
+    throw new Error(
+      "CLOUD_SECRET must be set to use license server managed ClickHouse",
+    );
+  }
+  const base = LICENSE_SERVER_URL.endsWith("/")
+    ? LICENSE_SERVER_URL
+    : `${LICENSE_SERVER_URL}/`;
+  const url = `${base}managed-clickhouse/${path}`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${cloudSecret}`,
+    },
+    body: JSON.stringify(body),
+  });
+  return res;
+}
+
+async function readErrorMessage(res: Response): Promise<string> {
+  const text = await res.text();
+  try {
+    const j = JSON.parse(text) as {
+      errorMessage?: string;
+      error?: string;
+      message?: string;
+    };
+    return (
+      j.errorMessage || j.error || j.message || text || `HTTP ${res.status}`
+    );
+  } catch {
+    return text || `HTTP ${res.status}`;
+  }
+}
+
+export async function createClickhouseUserViaLicenseServer(
+  orgId: string,
+  materializedColumns: MaterializedColumn[] = [],
+): Promise<DataSourceParams> {
+  const res = await postManagedClickhouse("provision", {
+    orgId,
+    materializedColumns,
+  });
+  if (!res.ok) {
+    throw new Error(
+      `createClickhouseUserViaLicenseServer: ${await readErrorMessage(res)}`,
+    );
+  }
+  return (await res.json()) as DataSourceParams;
+}
+
+export async function dangerousRecreateClickhouseTablesViaLicenseServer(
+  orgId: string,
+  materializedColumns: MaterializedColumn[] = [],
+): Promise<void> {
+  const res = await postManagedClickhouse("recreate-tables", {
+    orgId,
+    materializedColumns,
+  });
+  if (!res.ok) {
+    throw new Error(
+      `dangerousRecreateClickhouseTablesViaLicenseServer: ${await readErrorMessage(res)}`,
+    );
+  }
+}
+
+export async function deleteClickhouseUserViaLicenseServer(
+  orgId: string,
+): Promise<void> {
+  const res = await postManagedClickhouse("delete", { orgId });
+  if (!res.ok) {
+    throw new Error(
+      `deleteClickhouseUserViaLicenseServer: ${await readErrorMessage(res)}`,
+    );
+  }
+}
+
+export async function addCloudSDKMappingViaLicenseServer(
+  key: string,
+  organization: string,
+): Promise<void> {
+  const res = await postManagedClickhouse("sdk-key-mapping", {
+    key,
+    organization,
+  });
+  if (!res.ok) {
+    throw new Error(
+      `addCloudSDKMappingViaLicenseServer: ${await readErrorMessage(res)}`,
+    );
+  }
+}
+
+export async function migrateOverageEventsForOrgIdViaLicenseServer(
+  orgId: string,
+): Promise<void> {
+  const res = await postManagedClickhouse("migrate-overage", { orgId });
+  if (!res.ok) {
+    throw new Error(
+      `migrateOverageEventsForOrgIdViaLicenseServer: ${await readErrorMessage(res)}`,
+    );
+  }
+}
+
+export async function updateMaterializedColumnsInClickhouseViaLicenseServer({
+  orgId,
+  columnsToAdd,
+  columnsToDelete,
+  columnsToRename,
+  finalColumns,
+  originalColumns,
+}: {
+  orgId: string;
+  columnsToAdd: MaterializedColumn[];
+  columnsToDelete: string[];
+  columnsToRename: { from: string; to: string }[];
+  finalColumns: MaterializedColumn[];
+  originalColumns: MaterializedColumn[];
+}): Promise<void> {
+  const res = await postManagedClickhouse("update-materialized-columns", {
+    orgId,
+    columnsToAdd,
+    columnsToDelete,
+    columnsToRename,
+    finalColumns,
+    originalColumns,
+  });
+  if (!res.ok) {
+    throw new Error(
+      `updateMaterializedColumnsInClickhouseViaLicenseServer: ${await readErrorMessage(res)}`,
+    );
+  }
+}

--- a/packages/back-end/src/services/licenseServerManagedClickhouse.ts
+++ b/packages/back-end/src/services/licenseServerManagedClickhouse.ts
@@ -8,8 +8,32 @@ import type {
 } from "shared/types/datasource";
 import type { Response } from "node-fetch";
 import { LICENSE_SERVER_URL } from "back-end/src/enterprise/licenseUtil";
+import { logger } from "back-end/src/util/logger";
 import { fetch } from "back-end/src/util/http.util";
 import { CLOUD_SECRET } from "back-end/src/util/secrets";
+
+const MAX_SENTRY_RESPONSE_BODY_LENGTH = 16_000;
+
+function errorDetailForLog(text: string, status: number): string {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return `HTTP ${status}`;
+  }
+  try {
+    const j = JSON.parse(text) as {
+      errorMessage?: string;
+      error?: string;
+      message?: string;
+    };
+    const candidate = j.errorMessage ?? j.error ?? j.message;
+    if (typeof candidate === "string" && candidate.length > 0) {
+      return candidate.trim();
+    }
+  } catch {
+    // use raw body below
+  }
+  return trimmed;
+}
 
 async function postManagedClickhouse(
   path: string,
@@ -24,31 +48,63 @@ async function postManagedClickhouse(
     ? LICENSE_SERVER_URL
     : `${LICENSE_SERVER_URL}/`;
   const url = `${base}managed-clickhouse/${path}`;
-  const res = await fetch(url, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${CLOUD_SECRET}`,
-    },
-    body: JSON.stringify(body),
-  });
-  return res;
-}
 
-async function readErrorMessage(res: Response): Promise<string> {
-  const text = await res.text();
+  let res: Response;
   try {
-    const j = JSON.parse(text) as {
-      errorMessage?: string;
-      error?: string;
-      message?: string;
-    };
-    return (
-      j.errorMessage || j.error || j.message || text || `HTTP ${res.status}`
+    res = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${CLOUD_SECRET}`,
+      },
+      body: JSON.stringify(body),
+    });
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    logger.error(
+      {
+        err: error,
+        license_server_managed_clickhouse_path: path,
+        license_server_managed_clickhouse_url: url,
+      },
+      "License server managed ClickHouse request failed before HTTP response",
     );
-  } catch {
-    return text || `HTTP ${res.status}`;
+    throw new Error(
+      "We couldn't reach the managed warehouse service. Please try again in a few minutes. If the problem continues, contact support.",
+    );
   }
+
+  if (!res.ok) {
+    const rawBody = await res.text();
+    const contentType = res.headers.get("content-type") ?? "";
+    const detail = errorDetailForLog(rawBody, res.status);
+    const bodyForSentry =
+      rawBody.length > MAX_SENTRY_RESPONSE_BODY_LENGTH
+        ? `${rawBody.slice(0, MAX_SENTRY_RESPONSE_BODY_LENGTH)}\n…[truncated]`
+        : rawBody;
+
+    logger.error(
+      {
+        err: new Error(
+          `managed-clickhouse/${path}: HTTP ${res.status} ${res.statusText || ""}`.trim(),
+        ),
+        license_server_managed_clickhouse_path: path,
+        http_status: res.status,
+        http_status_text: res.statusText,
+        response_content_type: contentType,
+        response_body: bodyForSentry,
+        response_body_length: rawBody.length,
+        license_server_error_detail: detail,
+      },
+      `License server managed ClickHouse HTTP error: ${path} (${res.status})`,
+    );
+
+    throw new Error(
+      "The managed warehouse service returned an error. Please try again or contact support if this continues.",
+    );
+  }
+
+  return res;
 }
 
 export async function createClickhouseUserViaLicenseServer(
@@ -59,11 +115,6 @@ export async function createClickhouseUserViaLicenseServer(
     orgId,
     materializedColumns,
   });
-  if (!res.ok) {
-    throw new Error(
-      `createClickhouseUserViaLicenseServer: ${await readErrorMessage(res)}`,
-    );
-  }
   return (await res.json()) as DataSourceParams;
 }
 
@@ -71,52 +122,32 @@ export async function dangerousRecreateClickhouseTablesViaLicenseServer(
   orgId: string,
   materializedColumns: MaterializedColumn[] = [],
 ): Promise<void> {
-  const res = await postManagedClickhouse("recreate-tables", {
+  await postManagedClickhouse("recreate-tables", {
     orgId,
     materializedColumns,
   });
-  if (!res.ok) {
-    throw new Error(
-      `dangerousRecreateClickhouseTablesViaLicenseServer: ${await readErrorMessage(res)}`,
-    );
-  }
 }
 
 export async function deleteClickhouseUserViaLicenseServer(
   orgId: string,
 ): Promise<void> {
-  const res = await postManagedClickhouse("delete", { orgId });
-  if (!res.ok) {
-    throw new Error(
-      `deleteClickhouseUserViaLicenseServer: ${await readErrorMessage(res)}`,
-    );
-  }
+  await postManagedClickhouse("delete", { orgId });
 }
 
 export async function addCloudSDKMappingViaLicenseServer(
   key: string,
   organization: string,
 ): Promise<void> {
-  const res = await postManagedClickhouse("sdk-key-mapping", {
+  await postManagedClickhouse("sdk-key-mapping", {
     key,
     organization,
   });
-  if (!res.ok) {
-    throw new Error(
-      `addCloudSDKMappingViaLicenseServer: ${await readErrorMessage(res)}`,
-    );
-  }
 }
 
 export async function migrateOverageEventsForOrgIdViaLicenseServer(
   orgId: string,
 ): Promise<void> {
-  const res = await postManagedClickhouse("migrate-overage", { orgId });
-  if (!res.ok) {
-    throw new Error(
-      `migrateOverageEventsForOrgIdViaLicenseServer: ${await readErrorMessage(res)}`,
-    );
-  }
+  await postManagedClickhouse("migrate-overage", { orgId });
 }
 
 export async function updateMaterializedColumnsInClickhouseViaLicenseServer({
@@ -134,7 +165,7 @@ export async function updateMaterializedColumnsInClickhouseViaLicenseServer({
   finalColumns: MaterializedColumn[];
   originalColumns: MaterializedColumn[];
 }): Promise<void> {
-  const res = await postManagedClickhouse("update-materialized-columns", {
+  await postManagedClickhouse("update-materialized-columns", {
     orgId,
     columnsToAdd,
     columnsToDelete,
@@ -142,9 +173,4 @@ export async function updateMaterializedColumnsInClickhouseViaLicenseServer({
     finalColumns,
     originalColumns,
   });
-  if (!res.ok) {
-    throw new Error(
-      `updateMaterializedColumnsInClickhouseViaLicenseServer: ${await readErrorMessage(res)}`,
-    );
-  }
 }

--- a/packages/back-end/src/util/secrets.ts
+++ b/packages/back-end/src/util/secrets.ts
@@ -327,11 +327,15 @@ export const CLICKHOUSE_OVERAGE_TABLE =
 export const CLICKHOUSE_DEV_PREFIX =
   process.env.CLICKHOUSE_DEV_PREFIX || "test_";
 
-/** When true, managed warehouse ClickHouse provisioning runs on central-license-server. */
+/** When true, managed warehouse ClickHouse provisioning runs on central-license-server.
+ * TODO(james): remove this once we are sure we don't need to rollback.
+ */
 export const MANAGED_CLICKHOUSE_USE_LICENSE_SERVER = stringToBoolean(
   process.env.MANAGED_CLICKHOUSE_USE_LICENSE_SERVER,
   IS_CLOUD,
 );
+
+export const CLOUD_SECRET = process.env.CLOUD_SECRET ?? "";
 
 // Note: the Visual Editor relies on the information in this path, so disabling it will prevent some features from working correctly.
 export const DISABLE_API_ROOT_PATH = stringToBoolean(

--- a/packages/back-end/src/util/secrets.ts
+++ b/packages/back-end/src/util/secrets.ts
@@ -327,6 +327,12 @@ export const CLICKHOUSE_OVERAGE_TABLE =
 export const CLICKHOUSE_DEV_PREFIX =
   process.env.CLICKHOUSE_DEV_PREFIX || "test_";
 
+/** When true, managed warehouse ClickHouse provisioning runs on central-license-server. */
+export const MANAGED_CLICKHOUSE_USE_LICENSE_SERVER = stringToBoolean(
+  process.env.MANAGED_CLICKHOUSE_USE_LICENSE_SERVER,
+  IS_CLOUD,
+);
+
 // Note: the Visual Editor relies on the information in this path, so disabling it will prevent some features from working correctly.
 export const DISABLE_API_ROOT_PATH = stringToBoolean(
   process.env.DISABLE_API_ROOT_PATH,

--- a/packages/back-end/test/services/clickhouse.test.ts
+++ b/packages/back-end/test/services/clickhouse.test.ts
@@ -34,6 +34,7 @@ jest.mock("back-end/src/util/secrets", () => ({
   IS_CLOUD: false,
   CLICKHOUSE_DEV_PREFIX: "dev_",
   CLICKHOUSE_OVERAGE_TABLE: "overage",
+  MANAGED_CLICKHOUSE_USE_LICENSE_SERVER: false,
 }));
 
 jest.mock("back-end/src/models/FactTableModel", () => ({


### PR DESCRIPTION
### Features and Changes
This moves the Clickhouse Managed Warehouse functions over to the license server as they are cloud only functionality that self hosted don't need to use.

### Dependencies
Land the central-license-server change first.

### Testing
- [x] addCloudSDKMappingViaLicenseServer - Create a new sdk connection and see [usage.sdk_connections](https://console.clickhouse.cloud/services/fdb63ac1-65ec-48ef-b74f-df1854c7c3b6/console/database/usage/table/sdk_key_mapping) on clickhouse get a new row.
- [x] createClickhouseUserViaLicenseServer - Create the clickhouse datasource in the UI and see db get made and old events copied over.
- [X] dangerousRecreateClickhouseTablesViaLicenseServer - Manually `DROP TABLE feature_usage` in clickhouse db for the org.  Then in /admin choose the org and click drop and recreate table.  See the table appear again all filled out.
- [x] deleteClickhouseUserViaLicenseServer - Go to the datasource in the UI and click delete.  See that the user and database no longer exist in Clickhouse
- [x] migrateOverageEventsForOrgIdViaLicenseServer - manually in Mongo usage.organization_usages table lookup the organization and set the `usage.managedClickous.status` to `over`.  Send some more events.  See those events added to the [overage_events table](https://console.clickhouse.cloud/services/fdb63ac1-65ec-48ef-b74f-df1854c7c3b6/console/database/default/table/overage_events).  Sign up to pro. See the events removed from the clickhouse.overage_events table and added to the feature_usage table in the org's db.
- [x] updateMaterializedColumnsInClickhouseViaLicenseServer - on the datasource page add a keyAttribute.  See that a new column appears on the experiment_views table.  

