### PR TITLE
Allow holdout to be marked as "opt-in"

### DIFF
--- a/packages/back-end/src/models/HoldoutModel.ts
+++ b/packages/back-end/src/models/HoldoutModel.ts
@@ -19,7 +19,7 @@ const BaseClass = MakeModelClass({
   },
   globallyUniquePrimaryKeys: false,
   defaultValues: {
-    doNotSetAsDefaultHoldout: false,
+    skipAsDefaultHoldout: false,
   } as Partial<HoldoutInterface>,
   additionalIndexes: [
     {

--- a/packages/back-end/src/models/HoldoutModel.ts
+++ b/packages/back-end/src/models/HoldoutModel.ts
@@ -18,6 +18,9 @@ const BaseClass = MakeModelClass({
     deleteEvent: "holdout.delete",
   },
   globallyUniquePrimaryKeys: false,
+  defaultValues: {
+    doNotSetAsDefaultHoldout: false,
+  } as Partial<HoldoutInterface>,
   additionalIndexes: [
     {
       fields: { "nextScheduledStatusUpdate.date": 1 },

--- a/packages/back-end/src/routers/holdout/holdout.controller.ts
+++ b/packages/back-end/src/routers/holdout/holdout.controller.ts
@@ -248,6 +248,7 @@ export const createHoldout = async (
       experimentId: experiment.id,
       projects: data.projects || [],
       name: experiment.name,
+      doNotSetAsDefaultHoldout: data.doNotSetAsDefaultHoldout,
       environmentSettings: data.environmentSettings || {},
       linkedFeatures: {},
       linkedExperiments: {},

--- a/packages/back-end/src/routers/holdout/holdout.controller.ts
+++ b/packages/back-end/src/routers/holdout/holdout.controller.ts
@@ -248,7 +248,7 @@ export const createHoldout = async (
       experimentId: experiment.id,
       projects: data.projects || [],
       name: experiment.name,
-      doNotSetAsDefaultHoldout: data.doNotSetAsDefaultHoldout,
+      skipAsDefaultHoldout: data.skipAsDefaultHoldout,
       environmentSettings: data.environmentSettings || {},
       linkedFeatures: {},
       linkedExperiments: {},

--- a/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
@@ -292,6 +292,18 @@ export default function ExperimentHeader({
     setDropdownOpen(false);
   }
 
+  async function toggleHoldoutOptionality() {
+    if (!holdout) return;
+    await apiCall(`/holdout/${holdout.id}`, {
+      method: "PUT",
+      body: JSON.stringify({
+        doNotSetAsDefaultHoldout: !holdout.doNotSetAsDefaultHoldout,
+      }),
+    });
+    await mutate();
+    setDropdownOpen(false);
+  }
+
   async function startExperiment() {
     if (!experiment.phases?.length) {
       if (newPhase) {
@@ -863,6 +875,17 @@ export default function ExperimentHeader({
                     }}
                   >
                     {holdoutHasSchedule ? "Edit " : "Add "} Schedule
+                  </DropdownMenuItem>
+                )}
+                {isHoldout && canEditExperiment && (
+                  <DropdownMenuItem
+                    onClick={() => {
+                      toggleHoldoutOptionality();
+                    }}
+                  >
+                    {holdout?.doNotSetAsDefaultHoldout
+                      ? "Set as a default holdout"
+                      : "Set as an optional holdout"}
                   </DropdownMenuItem>
                 )}
                 {canEditExperiment &&

--- a/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
@@ -292,18 +292,6 @@ export default function ExperimentHeader({
     setDropdownOpen(false);
   }
 
-  async function toggleHoldoutOptionality() {
-    if (!holdout) return;
-    await apiCall(`/holdout/${holdout.id}`, {
-      method: "PUT",
-      body: JSON.stringify({
-        doNotSetAsDefaultHoldout: !holdout.doNotSetAsDefaultHoldout,
-      }),
-    });
-    await mutate();
-    setDropdownOpen(false);
-  }
-
   async function startExperiment() {
     if (!experiment.phases?.length) {
       if (newPhase) {
@@ -875,17 +863,6 @@ export default function ExperimentHeader({
                     }}
                   >
                     {holdoutHasSchedule ? "Edit " : "Add "} Schedule
-                  </DropdownMenuItem>
-                )}
-                {isHoldout && canEditExperiment && (
-                  <DropdownMenuItem
-                    onClick={() => {
-                      toggleHoldoutOptionality();
-                    }}
-                  >
-                    {holdout?.doNotSetAsDefaultHoldout
-                      ? "Set as a default holdout"
-                      : "Set as an optional holdout"}
                   </DropdownMenuItem>
                 )}
                 {canEditExperiment &&

--- a/packages/front-end/components/Experiment/TabbedPage/Implementation.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/Implementation.tsx
@@ -5,12 +5,14 @@ import {
 } from "shared/types/experiment";
 import { VisualChangesetInterface } from "shared/types/visual-changeset";
 import { URLRedirectInterface } from "shared/types/url-redirect";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { HoldoutInterfaceStringDates } from "shared/validators";
 import { FeatureInterface } from "shared/types/feature";
+import { Flex } from "@radix-ui/themes";
 import AddLinkedChanges from "@/components/Experiment/LinkedChanges/AddLinkedChanges";
 import LinkedChanges from "@/components/Experiment/LinkedChanges/LinkedChanges";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
+import { useAuth } from "@/services/auth";
 import VariationsTable from "@/components/Experiment/VariationsTable";
 import TrafficAndTargeting from "@/components/Experiment/TabbedPage/TrafficAndTargeting";
 import AnalysisSettings from "@/components/Experiment/TabbedPage/AnalysisSettings";
@@ -66,6 +68,7 @@ export default function Implementation({
   const [showEditEnvironmentsModal, setShowEditEnvironmentsModal] =
     useState(false);
   const phases = experiment.phases || [];
+  const { apiCall } = useAuth();
 
   const permissionsUtil = usePermissionsUtil();
 
@@ -99,6 +102,29 @@ export default function Implementation({
   );
 
   const isHoldout = experiment.type === "holdout";
+  const canEditHoldoutDefaultState =
+    isHoldout &&
+    !!holdout &&
+    !experiment.archived &&
+    experiment.status !== "stopped" &&
+    permissionsUtil.canUpdateHoldout(holdout, { projects: holdout.projects });
+
+  async function toggleDefaultHoldoutState() {
+    if (!holdout) return;
+    await apiCall(`/holdout/${holdout.id}`, {
+      method: "PUT",
+      body: JSON.stringify({
+        doNotSetAsDefaultHoldout: !holdout.doNotSetAsDefaultHoldout,
+      }),
+    });
+    await mutate();
+  }
+
+  const holdoutDefaultStateText = useMemo(() => {
+    return holdout?.doNotSetAsDefaultHoldout
+      ? `This holdout ${experiment.status === "draft" ? "will not be" : experiment.status === "running" ? "is not" : "was not"} selected by default for new experiments or features.`
+      : `This holdout ${experiment.status === "draft" ? "will be" : experiment.status === "running" ? "is" : "was"} a default for new experiments or features.`;
+  }, [holdout?.doNotSetAsDefaultHoldout, experiment.status]);
 
   return (
     <>
@@ -233,6 +259,25 @@ export default function Implementation({
                 )}
               </>
             )}
+            <Flex align="center" justify="between" mt="3">
+              <Text>
+                {holdoutDefaultStateText}
+                {canEditHoldoutDefaultState ? (
+                  <>
+                    {" "}
+                    <button
+                      type="button"
+                      className="btn btn-link p-0 align-baseline"
+                      onClick={toggleDefaultHoldoutState}
+                    >
+                      {holdout.doNotSetAsDefaultHoldout
+                        ? "Click to make default."
+                        : "Click to make opt-in."}
+                    </button>
+                  </>
+                ) : null}
+              </Text>
+            </Flex>
           </div>
         ) : null}
         {experiment.status !== "draft" && !hasLinkedChanges && !isHoldout ? (

--- a/packages/front-end/components/Experiment/TabbedPage/Implementation.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/Implementation.tsx
@@ -5,7 +5,7 @@ import {
 } from "shared/types/experiment";
 import { VisualChangesetInterface } from "shared/types/visual-changeset";
 import { URLRedirectInterface } from "shared/types/url-redirect";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { HoldoutInterfaceStringDates } from "shared/validators";
 import { FeatureInterface } from "shared/types/feature";
 import { Flex } from "@radix-ui/themes";
@@ -26,6 +26,7 @@ import Link from "@/ui/Link";
 import Badge from "@/ui/Badge";
 import Heading from "@/ui/Heading";
 import Text from "@/ui/Text";
+import Checkbox from "@/ui/Checkbox";
 import HoldoutEnvironments from "./HoldoutEnvironments";
 
 export interface Props {
@@ -109,22 +110,16 @@ export default function Implementation({
     experiment.status !== "stopped" &&
     permissionsUtil.canUpdateHoldout(holdout, { projects: holdout.projects });
 
-  async function toggleDefaultHoldoutState() {
+  async function setHoldoutDefaultState(isDefault: boolean) {
     if (!holdout) return;
     await apiCall(`/holdout/${holdout.id}`, {
       method: "PUT",
       body: JSON.stringify({
-        doNotSetAsDefaultHoldout: !holdout.doNotSetAsDefaultHoldout,
+        skipAsDefaultHoldout: !isDefault,
       }),
     });
     await mutate();
   }
-
-  const holdoutDefaultStateText = useMemo(() => {
-    return holdout?.doNotSetAsDefaultHoldout
-      ? `This holdout ${experiment.status === "draft" ? "will not be" : experiment.status === "running" ? "is not" : "was not"} selected by default for new experiments or features.`
-      : `This holdout ${experiment.status === "draft" ? "will be" : experiment.status === "running" ? "is" : "was"} a default for new experiments or features.`;
-  }, [holdout?.doNotSetAsDefaultHoldout, experiment.status]);
 
   return (
     <>
@@ -260,23 +255,15 @@ export default function Implementation({
               </>
             )}
             <Flex align="center" justify="between" mt="3">
-              <Text>
-                {holdoutDefaultStateText}
-                {canEditHoldoutDefaultState ? (
-                  <>
-                    {" "}
-                    <button
-                      type="button"
-                      className="btn btn-link p-0 align-baseline"
-                      onClick={toggleDefaultHoldoutState}
-                    >
-                      {holdout.doNotSetAsDefaultHoldout
-                        ? "Click to make default."
-                        : "Click to make opt-in."}
-                    </button>
-                  </>
-                ) : null}
-              </Text>
+              <Checkbox
+                value={!holdout.skipAsDefaultHoldout}
+                disabled={!canEditHoldoutDefaultState}
+                setValue={(isDefault) => {
+                  void setHoldoutDefaultState(isDefault);
+                }}
+                label="Use this holdout as a default for new experiments or features."
+                weight="regular"
+              />
             </Flex>
           </div>
         ) : null}

--- a/packages/front-end/components/Holdout/HoldoutSelect.tsx
+++ b/packages/front-end/components/Holdout/HoldoutSelect.tsx
@@ -66,13 +66,18 @@ export const HoldoutSelect = ({
     });
   }, [holdouts, experimentsMap, selectedProject, getDatasourceById]);
 
+  const requiredSelectableHoldouts = useMemo(
+    () => holdoutsWithExperiment.filter((h) => !h.doNotSetAsDefaultHoldout),
+    [holdoutsWithExperiment],
+  );
+
   useEffect(() => {
     // check to see if the holdout still exists and if not, set the holdout to the first valid holdout
     if (!holdoutsWithExperiment.some((h) => h.id === selectedHoldoutId)) {
-      setHoldout(holdoutsWithExperiment[0]?.id ?? "");
+      setHoldout(requiredSelectableHoldouts[0]?.id ?? "");
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [holdoutsWithExperiment]);
+  }, [holdoutsWithExperiment, requiredSelectableHoldouts]);
 
   if (!hasHoldouts) {
     return (
@@ -149,7 +154,7 @@ export const HoldoutSelect = ({
                 >
                   Identifier Type: <code>{userIdType}</code>
                 </span>
-              ) : value === "" ? (
+              ) : value === "" && requiredSelectableHoldouts.length > 0 ? (
                 <span className="text-muted small float-right position-relative">
                   Override Holdout requirement{" "}
                   <PiWarningFill
@@ -162,7 +167,7 @@ export const HoldoutSelect = ({
           );
         }}
       />
-      {holdoutsWithExperiment.length > 0 && selectedHoldoutId === "" && (
+      {requiredSelectableHoldouts.length > 0 && selectedHoldoutId === "" && (
         <HelperText status="warning" size="sm" mb="3">
           Exempting this {formType} from a holdout may impact your
           organization&apos;s analysis. Proceed with caution.

--- a/packages/front-end/components/Holdout/HoldoutSelect.tsx
+++ b/packages/front-end/components/Holdout/HoldoutSelect.tsx
@@ -72,16 +72,6 @@ export const HoldoutSelect = ({
   );
 
   useEffect(() => {
-    // If all selectable holdouts are optional, default to "None".
-    if (
-      requiredSelectableHoldouts.length === 0 &&
-      selectedHoldoutId &&
-      holdoutsWithExperiment.some((h) => h.id === selectedHoldoutId)
-    ) {
-      setHoldout("");
-      return;
-    }
-
     // check to see if the holdout still exists and if not, set the holdout to the first valid holdout
     if (!holdoutsWithExperiment.some((h) => h.id === selectedHoldoutId)) {
       setHoldout(requiredSelectableHoldouts[0]?.id ?? "");

--- a/packages/front-end/components/Holdout/HoldoutSelect.tsx
+++ b/packages/front-end/components/Holdout/HoldoutSelect.tsx
@@ -67,7 +67,7 @@ export const HoldoutSelect = ({
   }, [holdouts, experimentsMap, selectedProject, getDatasourceById]);
 
   const requiredSelectableHoldouts = useMemo(
-    () => holdoutsWithExperiment.filter((h) => !h.doNotSetAsDefaultHoldout),
+    () => holdoutsWithExperiment.filter((h) => !h.skipAsDefaultHoldout),
     [holdoutsWithExperiment],
   );
 

--- a/packages/front-end/components/Holdout/HoldoutSelect.tsx
+++ b/packages/front-end/components/Holdout/HoldoutSelect.tsx
@@ -72,6 +72,16 @@ export const HoldoutSelect = ({
   );
 
   useEffect(() => {
+    // If all selectable holdouts are optional, default to "None".
+    if (
+      requiredSelectableHoldouts.length === 0 &&
+      selectedHoldoutId &&
+      holdoutsWithExperiment.some((h) => h.id === selectedHoldoutId)
+    ) {
+      setHoldout("");
+      return;
+    }
+
     // check to see if the holdout still exists and if not, set the holdout to the first valid holdout
     if (!holdoutsWithExperiment.some((h) => h.id === selectedHoldoutId)) {
       setHoldout(requiredSelectableHoldouts[0]?.id ?? "");

--- a/packages/shared/src/validators/holdout.ts
+++ b/packages/shared/src/validators/holdout.ts
@@ -29,6 +29,7 @@ export const holdoutValidator = z
     dateUpdated: z.date(),
     projects: z.array(z.string()),
     name: z.string(),
+    doNotSetAsDefaultHoldout: z.boolean().optional(),
     experimentId: z.string(),
     linkedExperiments: z.record(z.string(), holdoutLinkedItemValidator),
     linkedFeatures: z.record(z.string(), holdoutLinkedItemValidator),

--- a/packages/shared/src/validators/holdout.ts
+++ b/packages/shared/src/validators/holdout.ts
@@ -29,7 +29,7 @@ export const holdoutValidator = z
     dateUpdated: z.date(),
     projects: z.array(z.string()),
     name: z.string(),
-    doNotSetAsDefaultHoldout: z.boolean().optional(),
+    skipAsDefaultHoldout: z.boolean().optional(),
     experimentId: z.string(),
     linkedExperiments: z.record(z.string(), holdoutLinkedItemValidator),
     linkedFeatures: z.record(z.string(), holdoutLinkedItemValidator),


### PR DESCRIPTION
## Summary

Adds optional holdout behavior via a new holdout flag, named `doNotSetAsDefaultHoldout`.

- Holdouts with `doNotSetAsDefaultHoldout: true` are no longer auto-selected by default for new experiments/features.
- Selecting `None` only shows a warning when at least one required/default holdout is available.
- `doNotSetAsDefaultHoldout` is added to the shared holdout schema, defaults to `false` on create, is persisted via holdout create/update APIs, and is editable from the holdout Overview Tab -> Implementation Section.


Toggle location
<img width="1356" height="164" alt="Screenshot 2026-04-20 at 10 47 04 AM" src="https://github.com/user-attachments/assets/74946105-1c93-48d3-9e8c-a810a46a474c" />

Opposite language + view with a linked experiment (just to show the UI)
<img width="1236" height="262" alt="Screenshot 2026-04-20 at 10 49 37 AM" src="https://github.com/user-attachments/assets/91b2b90d-4115-4422-9db7-77a78dc42e55" />

When at least one is not opt-in, we get warnings + default behavior
<img width="1004" height="305" alt="Screenshot 2026-04-20 at 10 47 12 AM" src="https://github.com/user-attachments/assets/b3f231a9-2b01-495f-b7e7-1ae6ca6916f9" />

If all holdouts are opt-in, then None is default, with no warnings
<img width="945" height="410" alt="Screenshot 2026-04-20 at 10 46 47 AM" src="https://github.com/user-attachments/assets/e1641cad-e5b8-4676-8424-3153f7b6d7d8" />