### PR TITLE
fix(pipeline): bootstrap incremental units table when prior state has no unitsTableFullName

### DIFF
--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -1078,6 +1078,7 @@ export function getSnapshotQueryRunnerKind({
   experiment,
   snapshotType,
   hasSnapshotDimensions,
+  hasMaterializedUnitsTable = true,
 }: {
   allowIncrementalRefresh: boolean;
   isExperimentCompatibleWithIncrementalRefresh: boolean;
@@ -1085,6 +1086,7 @@ export function getSnapshotQueryRunnerKind({
   experiment: ExperimentInterface;
   snapshotType: SnapshotType;
   hasSnapshotDimensions: boolean;
+  hasMaterializedUnitsTable?: boolean;
 }): SnapshotQueryRunnerKind {
   if (
     allowIncrementalRefresh &&
@@ -1093,7 +1095,11 @@ export function getSnapshotQueryRunnerKind({
     isExperimentCompatibleWithIncrementalRefresh
   ) {
     if (snapshotType === "exploratory" && !hasSnapshotDimensions) {
-      return "incremental";
+      // Dimension-less exploratory snapshots reuse the incremental runner in
+      // read-only mode (fullRefresh is clamped to false downstream). That only
+      // works if the warehouse units table has already been created by a prior
+      // standard snapshot — otherwise fall back to the non-pipeline runner.
+      return hasMaterializedUnitsTable ? "incremental" : "results";
     }
 
     return snapshotType === "exploratory"
@@ -1161,6 +1167,7 @@ async function planSnapshotQueryRunner({
     experiment,
     snapshotType,
     hasSnapshotDimensions: snapshotSettings.dimensions.length > 0,
+    hasMaterializedUnitsTable: !!incrementalRefreshModel?.unitsTableFullName,
   });
 }
 

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -1078,7 +1078,7 @@ export function getSnapshotQueryRunnerKind({
   experiment,
   snapshotType,
   hasSnapshotDimensions,
-  hasMaterializedUnitsTable = true,
+  hasMaterializedUnitsTable,
 }: {
   allowIncrementalRefresh: boolean;
   isExperimentCompatibleWithIncrementalRefresh: boolean;
@@ -1086,7 +1086,7 @@ export function getSnapshotQueryRunnerKind({
   experiment: ExperimentInterface;
   snapshotType: SnapshotType;
   hasSnapshotDimensions: boolean;
-  hasMaterializedUnitsTable?: boolean;
+  hasMaterializedUnitsTable: boolean;
 }): SnapshotQueryRunnerKind {
   if (
     allowIncrementalRefresh &&

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -1214,9 +1214,16 @@ export async function planSnapshot({
     ? await context.models.incrementalRefresh.getByExperimentId(experiment.id)
     : null;
 
-  // Full refresh when explicitly requested (!useCache) or when no prior
-  // incremental state exists (e.g. newly imported experiment)
-  const fullRefresh = !useCache || !incrementalRefreshModel;
+  // Full refresh when explicitly requested (!useCache), when no prior
+  // incremental state exists, or when the state doc exists but has no
+  // unitsTableFullName. The latter happens because acquireLock() upserts the
+  // doc before any warehouse table is created — unitsTableFullName is only
+  // populated after a successful CREATE, so a null value means the units
+  // table was never materialized (e.g. lock acquired but first run failed).
+  const fullRefresh =
+    !useCache ||
+    !incrementalRefreshModel ||
+    !incrementalRefreshModel.unitsTableFullName;
 
   const snapshotSettings = getSnapshotSettings({
     experiment,

--- a/packages/back-end/test/services/snapshot-planning.test.ts
+++ b/packages/back-end/test/services/snapshot-planning.test.ts
@@ -144,6 +144,7 @@ describe("snapshot planning", () => {
         experiment,
         snapshotType: "standard",
         hasSnapshotDimensions: false,
+        hasMaterializedUnitsTable: true,
       }),
     ).toBe("results");
   });
@@ -159,6 +160,7 @@ describe("snapshot planning", () => {
         experiment,
         snapshotType: "standard",
         hasSnapshotDimensions: false,
+        hasMaterializedUnitsTable: true,
       }),
     ).toBe("incremental");
   });
@@ -174,6 +176,7 @@ describe("snapshot planning", () => {
         experiment,
         snapshotType: "exploratory",
         hasSnapshotDimensions: true,
+        hasMaterializedUnitsTable: true,
       }),
     ).toBe("incremental-exploratory");
   });
@@ -189,6 +192,7 @@ describe("snapshot planning", () => {
         experiment,
         snapshotType: "exploratory",
         hasSnapshotDimensions: false,
+        hasMaterializedUnitsTable: true,
       }),
     ).toBe("incremental");
   });
@@ -206,6 +210,7 @@ describe("snapshot planning", () => {
         experiment,
         snapshotType: "standard",
         hasSnapshotDimensions: false,
+        hasMaterializedUnitsTable: true,
       }),
     ).toBe("results");
   });

--- a/packages/back-end/test/services/snapshot-query-runner-kind.test.ts
+++ b/packages/back-end/test/services/snapshot-query-runner-kind.test.ts
@@ -71,6 +71,20 @@ describe("getSnapshotQueryRunnerKind", () => {
     ).toBe("incremental");
   });
 
+  it("returns 'results' for exploratory snapshots without dimensions when the units table has not been materialized", () => {
+    expect(
+      getSnapshotQueryRunnerKind({
+        allowIncrementalRefresh: true,
+        isExperimentCompatibleWithIncrementalRefresh: true,
+        datasource: makeDatasource(),
+        experiment: makeExperiment(),
+        snapshotType: "exploratory",
+        hasSnapshotDimensions: false,
+        hasMaterializedUnitsTable: false,
+      }),
+    ).toBe("results");
+  });
+
   it("returns 'results' when allowIncrementalRefresh is false", () => {
     expect(
       getSnapshotQueryRunnerKind({

--- a/packages/back-end/test/services/snapshot-query-runner-kind.test.ts
+++ b/packages/back-end/test/services/snapshot-query-runner-kind.test.ts
@@ -41,6 +41,7 @@ describe("getSnapshotQueryRunnerKind", () => {
         experiment: makeExperiment(),
         snapshotType: "standard",
         hasSnapshotDimensions: false,
+        hasMaterializedUnitsTable: true,
       }),
     ).toBe("incremental");
   });
@@ -54,11 +55,12 @@ describe("getSnapshotQueryRunnerKind", () => {
         experiment: makeExperiment(),
         snapshotType: "exploratory",
         hasSnapshotDimensions: true,
+        hasMaterializedUnitsTable: true,
       }),
     ).toBe("incremental-exploratory");
   });
 
-  it("returns 'incremental' for exploratory snapshots without dimensions", () => {
+  it("returns 'incremental' for exploratory snapshots without dimensions when the units table has been materialized", () => {
     expect(
       getSnapshotQueryRunnerKind({
         allowIncrementalRefresh: true,
@@ -67,6 +69,7 @@ describe("getSnapshotQueryRunnerKind", () => {
         experiment: makeExperiment(),
         snapshotType: "exploratory",
         hasSnapshotDimensions: false,
+        hasMaterializedUnitsTable: true,
       }),
     ).toBe("incremental");
   });
@@ -85,6 +88,20 @@ describe("getSnapshotQueryRunnerKind", () => {
     ).toBe("results");
   });
 
+  it("returns 'incremental' for standard snapshots even when the units table has not been materialized (full refresh will create it)", () => {
+    expect(
+      getSnapshotQueryRunnerKind({
+        allowIncrementalRefresh: true,
+        isExperimentCompatibleWithIncrementalRefresh: true,
+        datasource: makeDatasource(),
+        experiment: makeExperiment(),
+        snapshotType: "standard",
+        hasSnapshotDimensions: false,
+        hasMaterializedUnitsTable: false,
+      }),
+    ).toBe("incremental");
+  });
+
   it("returns 'results' when allowIncrementalRefresh is false", () => {
     expect(
       getSnapshotQueryRunnerKind({
@@ -94,6 +111,7 @@ describe("getSnapshotQueryRunnerKind", () => {
         experiment: makeExperiment(),
         snapshotType: "standard",
         hasSnapshotDimensions: false,
+        hasMaterializedUnitsTable: true,
       }),
     ).toBe("results");
   });
@@ -107,6 +125,7 @@ describe("getSnapshotQueryRunnerKind", () => {
         experiment: makeExperiment(),
         snapshotType: "standard",
         hasSnapshotDimensions: false,
+        hasMaterializedUnitsTable: true,
       }),
     ).toBe("results");
   });
@@ -121,6 +140,7 @@ describe("getSnapshotQueryRunnerKind", () => {
         experiment: makeExperiment(),
         snapshotType: "standard",
         hasSnapshotDimensions: false,
+        hasMaterializedUnitsTable: true,
       }),
     ).toBe("results");
   });
@@ -137,6 +157,7 @@ describe("getSnapshotQueryRunnerKind", () => {
         experiment: makeExperiment(),
         snapshotType: "standard",
         hasSnapshotDimensions: false,
+        hasMaterializedUnitsTable: true,
       }),
     ).toBe("results");
   });
@@ -153,6 +174,7 @@ describe("getSnapshotQueryRunnerKind", () => {
         experiment: makeExperiment(),
         snapshotType: "standard",
         hasSnapshotDimensions: false,
+        hasMaterializedUnitsTable: true,
       }),
     ).toBe("results");
   });
@@ -169,6 +191,7 @@ describe("getSnapshotQueryRunnerKind", () => {
         experiment: makeExperiment(),
         snapshotType: "standard",
         hasSnapshotDimensions: false,
+        hasMaterializedUnitsTable: true,
       }),
     ).toBe("incremental");
   });
@@ -182,6 +205,7 @@ describe("getSnapshotQueryRunnerKind", () => {
         experiment: makeExperiment({ type: "multi-armed-bandit" }),
         snapshotType: "standard",
         hasSnapshotDimensions: false,
+        hasMaterializedUnitsTable: true,
       }),
     ).toBe("results");
   });
@@ -195,6 +219,7 @@ describe("getSnapshotQueryRunnerKind", () => {
         experiment: makeExperiment({ type: undefined }),
         snapshotType: "standard",
         hasSnapshotDimensions: false,
+        hasMaterializedUnitsTable: true,
       }),
     ).toBe("incremental");
   });


### PR DESCRIPTION
## Problem

In incremental Pipeline Mode, the per-experiment units table CREATE is gated on the absence of an `IncrementalRefresh` state document. Since #5466, `acquireLock()` upserts that document (with `unitsTableFullName: null`) *before* any warehouse query runs. This breaks the implicit "doc exists ⇒ table exists" assumption: if the first snapshot fails or is aborted after the lock is acquired, every subsequent "Update" sees the doc, sets `fullRefresh = false`, skips the CREATE, and the incremental UPDATE query fails reading a units table that was never created.

A related edge case: dimension-less exploratory snapshots are routed to the incremental runner in read-only mode (`fullRefresh` clamped to `false`). If no prior standard snapshot has materialized the units table, this path also reads a non-existent table.

## Fix

- Treat `incrementalRefreshModel.unitsTableFullName === null` as "needs bootstrap" when computing `fullRefresh` in `planSnapshot()`. `unitsTableFullName` is only populated after a successful CREATE, so it is the correct proxy for table existence.
- Add `hasMaterializedUnitsTable` to `getSnapshotQueryRunnerKind()` so dimension-less exploratory snapshots fall back to the `"results"` runner when the units table has not yet been created. The downstream `fullRefresh` clamp for exploratory snapshots is intentionally left in place — exploratory runs must not rebuild the units table.

## Testing

- `pnpm --filter back-end type-check`
- `pnpm --filter back-end test test/services/snapshot-query-runner-kind.test.ts test/services/snapshot-planning.test.ts` (18/18 pass, including new case)
