### PR TITLE
fix: restore feature-list-realtime-graphs flag gate for Recent Usage column

### DIFF
--- a/packages/front-end/pages/features/index.tsx
+++ b/packages/front-end/pages/features/index.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import React, { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/router";
+import { useFeature } from "@growthbook/growthbook-react";
 import { Box, Flex } from "@radix-ui/themes";
 import { FeatureInterface } from "shared/types/feature";
 import { date, datetime } from "shared/dates";
@@ -60,6 +61,8 @@ export default function FeaturesPage() {
   const [currentPage, setCurrentPage] = useState(1);
   const [featureToDuplicate, setFeatureToDuplicate] =
     useState<FeatureInterface | null>(null);
+
+  const showGraphs = useFeature("feature-list-realtime-graphs").on;
 
   const { project, projects } = useDefinitions();
   const environments = useEnvironments();
@@ -218,10 +221,12 @@ export default function FeaturesPage() {
                 <th>Type</th>
                 <th>Version</th>
                 <SortableTH field="dateUpdated">Last Updated</SortableTH>
-                <th>
-                  Recent Usage{" "}
-                  <Tooltip body="Client-side feature evaluations for the past 30 minutes. Blue means the feature was 'on', Gray means it was 'off'." />
-                </th>
+                {showGraphs && (
+                  <th>
+                    Recent Usage{" "}
+                    <Tooltip body="Client-side feature evaluations for the past 30 minutes. Blue means the feature was 'on', Gray means it was 'off'." />
+                  </th>
+                )}
                 <th>Stale</th>
                 <th style={{ width: 30 }}></th>
               </tr>
@@ -324,12 +329,14 @@ export default function FeaturesPage() {
                     <td title={datetime(feature.dateUpdated)}>
                       {date(feature.dateUpdated)}
                     </td>
-                    <td style={{ width: 170 }}>
-                      <RealTimeFeatureGraph
-                        data={usage?.[feature.id]?.realtime || []}
-                        yDomain={usageDomain}
-                      />
-                    </td>
+                    {showGraphs && (
+                      <td style={{ width: 170 }}>
+                        <RealTimeFeatureGraph
+                          data={usage?.[feature.id]?.realtime || []}
+                          yDomain={usageDomain}
+                        />
+                      </td>
+                    )}
                     <td>
                       <StaleFeatureIcon
                         context="list"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Features and Changes

This PR restores the `feature-list-realtime-graphs` feature flag gate for the "Recent Usage" sparkline column on the feature list page. This column was previously gated by the feature flag but was inadvertently exposed unconditionally during a recent table UI migration.

**Changes:**
- Added `useFeature` hook import from `@growthbook/growthbook-react`
- Created `showGraphs` variable that reads the `feature-list-realtime-graphs` feature flag value
- Conditionally render the "Recent Usage" column header and cells based on `showGraphs`

**Related commit:** The feature flag gate was removed in commit `2105468d72f0a18b9ed14349052454769dd009b3` (feat(app): migrate eight major list tables to new Table UI)

### Dependencies

None

### Testing

**Manual Testing:**
1. Started the development environment with back-end and front-end servers
2. Verified that with the feature flag OFF (default), the "Recent Usage" column is not visible in the feature list table
3. Confirmed the table displays correctly without the column

[Feature list without Recent Usage column](https://cursor.com/agents/bc-b167db87-cae1-5d59-93a9-cafb6e332125/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffeature_list_no_recent_usage_column.webp)

**Type Checking:**
- ✅ Front-end type checking passes

The screenshot above shows the feature list page with the "Recent Usage" column properly hidden when the `feature-list-realtime-graphs` flag is disabled.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://growthbookapp.slack.com/archives/C0A9B5W8LMN/p1776721617711839?thread_ts=1776721617.711839&cid=C0A9B5W8LMN)

<div><a href="https://cursor.com/agents/bc-b167db87-cae1-5d59-93a9-cafb6e332125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b167db87-cae1-5d59-93a9-cafb6e332125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

