### PR TITLE
Easier local testing of IS_CLOUD

### DIFF
--- a/packages/back-end/README.md
+++ b/packages/back-end/README.md
@@ -69,6 +69,22 @@ if (IS_CLOUD) {
 }
 ```
 
+### Testing GrowthBook Cloud functionality locally
+
+Minimum setup:
+
+```bash
+IS_CLOUD=true
+```
+
+Note: The above only works when APP_ORIGIN is localhost (or it's running on the real GrowthBook Cloud).
+
+Opt-in extras for testing cloud-only flows locally:
+
+- **SSO / Auth0 flow**: set `SSO_CONFIG` to a valid JSON config.
+- **Vercel integration**: set both `VERCEL_CLIENT_ID` and `VERCEL_CLIENT_SECRET`
+- **S3 uploads**: set both `UPLOAD_METHOD=s3` and `S3_BUCKET=…`
+
 ### Adding new commercial features
 
 All back-end code for commercial features should live under the `src/enterprise` directory. The front-end and shared packages have their own `enterprise` directories as well which can be used as needed.

--- a/packages/back-end/src/app.ts
+++ b/packages/back-end/src/app.ts
@@ -42,6 +42,10 @@ const authController = wrapController(authControllerRaw);
 
 import * as vercelControllerRaw from "./routers/vercel-native-integration/vercel-native-integration.controller";
 const vercelController = wrapController(vercelControllerRaw);
+import {
+  VERCEL_CLIENT_ID,
+  VERCEL_CLIENT_SECRET,
+} from "./services/vercel-native-integration.service";
 
 import * as datasourcesControllerRaw from "./controllers/datasources";
 const datasourcesController = wrapController(datasourcesControllerRaw);
@@ -385,7 +389,7 @@ if (CORS_ORIGIN_REGEX) {
   origins.push(CORS_ORIGIN_REGEX);
 }
 
-if (IS_CLOUD) {
+if (IS_CLOUD && VERCEL_CLIENT_ID && VERCEL_CLIENT_SECRET) {
   app.use(
     "/vercel",
     cors({

--- a/packages/back-end/src/controllers/auth.ts
+++ b/packages/back-end/src/controllers/auth.ts
@@ -9,7 +9,7 @@ import {
   createOrganization,
   hasOrganization,
 } from "back-end/src/models/OrganizationModel";
-import { IS_CLOUD } from "back-end/src/util/secrets";
+import { IS_CLOUD, IS_LOCALHOST } from "back-end/src/util/secrets";
 import {
   deleteAuthCookies,
   getAuthConnection,
@@ -38,7 +38,7 @@ import {
 import { AuthRefreshModel } from "back-end/src/models/AuthRefreshModel";
 
 export async function getHasOrganizations(req: Request, res: Response) {
-  const hasOrg = IS_CLOUD ? true : await hasOrganization();
+  const hasOrg = IS_CLOUD && !IS_LOCALHOST ? true : await hasOrganization();
   return res.json({
     status: 200,
     hasOrganizations: hasOrg,

--- a/packages/back-end/src/services/auth/OpenIdAuthConnection.ts
+++ b/packages/back-end/src/services/auth/OpenIdAuthConnection.ts
@@ -335,7 +335,12 @@ async function getConnectionFromRequest(req: Request, res: Response) {
   }
 
   let connection: SSOConnectionInterface;
-  if (IS_CLOUD && ssoConnectionId.startsWith("vercel:")) {
+  if (
+    IS_CLOUD &&
+    VERCEL_CLIENT_ID &&
+    VERCEL_CLIENT_SECRET &&
+    ssoConnectionId.startsWith("vercel:")
+  ) {
     connection = {
       id: ssoConnectionId,
       clientId: VERCEL_CLIENT_ID,

--- a/packages/back-end/src/services/auth/index.ts
+++ b/packages/back-end/src/services/auth/index.ts
@@ -9,7 +9,7 @@ import {
   EventUserLoggedIn,
 } from "shared/types/events/event-types";
 import { logger } from "back-end/src/util/logger";
-import { IS_CLOUD } from "back-end/src/util/secrets";
+import { IS_CLOUD, IS_LOCALHOST } from "back-end/src/util/secrets";
 import { AuthRequest } from "back-end/src/types/AuthRequest";
 import {
   hasUser,
@@ -165,7 +165,13 @@ export async function processJWT(
     // require all future logins to be verified too.
     // This stops someone from creating an unverified email/password account and gaining access to
     // an account using "Login with Google"
-    if (IS_CLOUD && !req.loginMethod?.id && user.verified && !req.verified) {
+    if (
+      IS_CLOUD &&
+      !IS_LOCALHOST &&
+      !req.loginMethod?.id &&
+      user.verified &&
+      !req.verified
+    ) {
       res.status(406).json({
         status: 406,
         message: "You must log in via SSO to use GrowthBook",
@@ -319,7 +325,7 @@ export async function isNewInstallation() {
 }
 
 export function usingOpenId() {
-  if (IS_CLOUD) return true;
+  if (IS_CLOUD && !IS_LOCALHOST) return true;
   if (SSO_CONFIG) return true;
   return false;
 }

--- a/packages/back-end/src/util/secrets.ts
+++ b/packages/back-end/src/util/secrets.ts
@@ -19,8 +19,6 @@ export const ALLOW_SELF_ORG_CREATION = stringToBoolean(
 );
 
 export const UPLOAD_METHOD = (() => {
-  if (IS_CLOUD) return "s3";
-
   const method = process.env.UPLOAD_METHOD;
   if (method && ["s3", "google-cloud"].includes(method)) {
     return method;
@@ -62,7 +60,7 @@ if (MONGODB_URI.match(/:27017(\/)?$/)) {
 export { MONGODB_URI };
 
 export const APP_ORIGIN = process.env.APP_ORIGIN || "http://localhost:3000";
-const isLocalhost = APP_ORIGIN.includes("localhost");
+export const IS_LOCALHOST = APP_ORIGIN.startsWith("http://localhost:");
 
 const corsOriginRegex = process.env.CORS_ORIGIN_REGEX;
 export const CORS_ORIGIN_REGEX = corsOriginRegex
@@ -90,7 +88,7 @@ export const GCS_DOMAIN =
   `https://storage.googleapis.com/${GCS_BUCKET_NAME}/`;
 
 export const JWT_SECRET = process.env.JWT_SECRET || "dev";
-if ((prod || !isLocalhost) && !IS_CLOUD && JWT_SECRET === "dev") {
+if ((prod || !IS_LOCALHOST) && !IS_CLOUD && JWT_SECRET === "dev") {
   throw new Error(
     "Cannot use JWT_SECRET=dev in production. Please set to a long random string.",
   );
@@ -221,7 +219,7 @@ export const API_USER_AGENT =
 // Only allowed while self-hosting and not multi org
 let secretAPIKey = IS_MULTI_ORG ? "" : process.env.SECRET_API_KEY || "";
 // Don't allow using "dev" (default value) in prod
-if ((prod || !isLocalhost) && secretAPIKey === "dev") {
+if ((prod || !IS_LOCALHOST) && secretAPIKey === "dev") {
   secretAPIKey = "";
   // eslint-disable-next-line
   console.error(

--- a/packages/shared/src/enterprise/sso.ts
+++ b/packages/shared/src/enterprise/sso.ts
@@ -29,9 +29,15 @@ function getSSOConfig() {
     );
   }
 
-  // Sanity check for GrowthBook Cloud (to avoid misconfigurations)
+  // Sanity check for GrowthBook Cloud (to avoid misconfigurations).
+  // Skipped when APP_ORIGIN is localhost so devs can exercise custom SSO
+  // configs in local IS_CLOUD=true setups.
+  const isLocalhost = (
+    process.env.APP_ORIGIN || "http://localhost:3000"
+  ).startsWith("http://localhost:");
   if (
     stringToBoolean(process.env.IS_CLOUD) &&
+    !isLocalhost &&
     config?.metadata?.issuer !== "https://growthbook.auth0.com/"
   ) {
     throw new Error("Invalid SSO configuration for GrowthBook Cloud");


### PR DESCRIPTION
### Features and Changes

Allow `IS_CLOUD=true` without also requiring the following:
1. `SSO_CONFIG` (as long as you are on localhost)
2. `UPLOAD_METHOD=s3`
3. `VERCEL_CLIENT_ID` and `VERCEL_CLIENT_SECRET`