### PR TITLE
fix: enable Review & Publish when holdout is the only change

### DIFF
--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -1283,10 +1283,7 @@ export async function applyRevisionChanges(
 
   // Handle holdout removal separately since updateFeature only does $set
   if (removeHoldout) {
-    await FeatureModel.updateOne(
-      { organization: context.org.id, id: feature.id },
-      { $unset: { holdout: "" } },
-    );
+    await removeHoldoutFromFeature(context, feature);
     // Remove holdout from the feature object so the returned feature is correct
     const { holdout: _, ...featureWithoutHoldout } = feature;
     return await updateFeature(

--- a/packages/back-end/src/models/FeatureModel.ts
+++ b/packages/back-end/src/models/FeatureModel.ts
@@ -1191,6 +1191,9 @@ export async function applyRevisionChanges(
 ) {
   let hasChanges = false;
   const changes: Partial<FeatureInterface> = {};
+  // Track whether to remove holdout field entirely (vs setting it to a value)
+  let removeHoldout = false;
+
   if (result.defaultValue !== undefined) {
     changes.defaultValue = result.defaultValue;
     hasChanges = true;
@@ -1232,7 +1235,11 @@ export async function applyRevisionChanges(
 
   if (result.holdout !== undefined) {
     // null means remove from holdout; object means set/change holdout
-    changes.holdout = result.holdout ?? undefined;
+    if (result.holdout === null) {
+      removeHoldout = true;
+    } else {
+      changes.holdout = result.holdout;
+    }
     hasChanges = true;
   }
 
@@ -1273,6 +1280,22 @@ export async function applyRevisionChanges(
   changes.version = revision.version;
 
   await updateSafeRolloutStatuses(context, feature, revision);
+
+  // Handle holdout removal separately since updateFeature only does $set
+  if (removeHoldout) {
+    await FeatureModel.updateOne(
+      { organization: context.org.id, id: feature.id },
+      { $unset: { holdout: "" } },
+    );
+    // Remove holdout from the feature object so the returned feature is correct
+    const { holdout: _, ...featureWithoutHoldout } = feature;
+    return await updateFeature(
+      context,
+      featureWithoutHoldout as FeatureInterface,
+      changes,
+    );
+  }
+
   return await updateFeature(context, feature, changes);
 }
 

--- a/packages/shared/src/util/features.ts
+++ b/packages/shared/src/util/features.ts
@@ -759,6 +759,9 @@ export function buildEffectiveDraft(
     ...(draftRevision.metadata !== undefined && {
       metadata: { ...filledLive.metadata, ...draftRevision.metadata },
     }),
+    ...("holdout" in draftRevision && {
+      holdout: draftRevision.holdout,
+    }),
   };
 }
 
@@ -810,6 +813,7 @@ export function draftDiffersFromLive(
         return true;
     }
   }
+  if (!isEqual(draft.holdout ?? null, filledLive.holdout ?? null)) return true;
   // Pending ramp actions (create/detach) are meaningful changes even if no feature content changed
   if ((draftRevision.rampActions ?? []).length > 0) return true;
   return false;

--- a/packages/shared/src/util/features.ts
+++ b/packages/shared/src/util/features.ts
@@ -680,6 +680,12 @@ const revisionFieldFillers: Partial<{
   defaultValue: (feature, current) => current ?? feature.defaultValue,
   archived: (feature, current) => current ?? feature.archived ?? false,
   prerequisites: (feature, current) => current ?? feature.prerequisites ?? [],
+  // Backfill holdout from feature so that removing a holdout is detected as a change.
+  // Without this, comparing draft.holdout (null) vs base.holdout (undefined → null)
+  // would show no change when the feature actually has a holdout.
+  // Note: we check for undefined explicitly because null is a valid value (means removal).
+  holdout: (feature, current) =>
+    current !== undefined ? current : (feature.holdout ?? null),
 };
 
 // Backfills stale/missing fields on a revision before passing to autoMerge.

--- a/packages/shared/test/util/feature-revisions.test.ts
+++ b/packages/shared/test/util/feature-revisions.test.ts
@@ -959,6 +959,74 @@ describe("draftDiffersFromLive", () => {
       ]),
     ).toBe(true);
   });
+
+  it("returns true when holdout is added to a feature without holdout", () => {
+    const draft: RevisionFields = {
+      ...liveRevision,
+      holdout: { id: "holdout-1", value: "holdout-value" },
+    };
+    expect(
+      draftDiffersFromLive(draft, liveRevision, feature, [
+        "production",
+        "staging",
+      ]),
+    ).toBe(true);
+  });
+
+  it("returns true when holdout is removed from a feature with holdout", () => {
+    const featureWithHoldout: FeatureInterface = {
+      ...feature,
+      holdout: { id: "holdout-1", value: "holdout-value" },
+    };
+    const draft: RevisionFields = {
+      ...liveRevision,
+      holdout: null,
+    };
+    expect(
+      draftDiffersFromLive(draft, liveRevision, featureWithHoldout, [
+        "production",
+        "staging",
+      ]),
+    ).toBe(true);
+  });
+
+  it("returns true when holdout is changed to a different one", () => {
+    const featureWithHoldout: FeatureInterface = {
+      ...feature,
+      holdout: { id: "holdout-1", value: "holdout-value" },
+    };
+    const draft: RevisionFields = {
+      ...liveRevision,
+      holdout: { id: "holdout-2", value: "different-value" },
+    };
+    expect(
+      draftDiffersFromLive(draft, liveRevision, featureWithHoldout, [
+        "production",
+        "staging",
+      ]),
+    ).toBe(true);
+  });
+
+  it("returns false when holdout is unchanged", () => {
+    const featureWithHoldout: FeatureInterface = {
+      ...feature,
+      holdout: { id: "holdout-1", value: "holdout-value" },
+    };
+    const liveRevisionWithHoldout: RevisionFields = {
+      ...liveRevision,
+      holdout: { id: "holdout-1", value: "holdout-value" },
+    };
+    const draft: RevisionFields = {
+      ...liveRevisionWithHoldout,
+      holdout: { id: "holdout-1", value: "holdout-value" },
+    };
+    expect(
+      draftDiffersFromLive(draft, liveRevisionWithHoldout, featureWithHoldout, [
+        "production",
+        "staging",
+      ]),
+    ).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/shared/test/util/feature-revisions.test.ts
+++ b/packages/shared/test/util/feature-revisions.test.ts
@@ -903,6 +903,64 @@ describe("fillRevisionFromFeature", () => {
     // existing field is preserved
     expect(filled.metadata?.description).toBe("hi");
   });
+
+  it("backfills holdout from feature when revision lacks it", () => {
+    const holdout = { id: "h-1", value: "holdout-value" };
+    const feature: FeatureInterface = { ...baseFeature, holdout };
+    const revision: RevisionFields = {
+      version: 4,
+      defaultValue: "false",
+      rules: {},
+      // holdout field missing from revision
+    };
+    const filled = fillRevisionFromFeature(revision, feature);
+    expect(filled.holdout).toEqual(holdout);
+  });
+
+  it("does not overwrite explicit holdout value in revision", () => {
+    const featureHoldout = { id: "h-1", value: "feature-value" };
+    const revisionHoldout = { id: "h-2", value: "revision-value" };
+    const feature: FeatureInterface = {
+      ...baseFeature,
+      holdout: featureHoldout,
+    };
+    const revision: RevisionFields = {
+      version: 4,
+      defaultValue: "false",
+      rules: {},
+      holdout: revisionHoldout,
+    };
+    const filled = fillRevisionFromFeature(revision, feature);
+    expect(filled.holdout).toEqual(revisionHoldout);
+  });
+
+  it("does not overwrite explicit null holdout in revision (removal)", () => {
+    const featureHoldout = { id: "h-1", value: "feature-value" };
+    const feature: FeatureInterface = {
+      ...baseFeature,
+      holdout: featureHoldout,
+    };
+    const revision: RevisionFields = {
+      version: 4,
+      defaultValue: "false",
+      rules: {},
+      holdout: null, // explicit removal
+    };
+    const filled = fillRevisionFromFeature(revision, feature);
+    expect(filled.holdout).toBeNull();
+  });
+
+  it("backfills holdout as null when feature has no holdout", () => {
+    const feature: FeatureInterface = { ...baseFeature }; // no holdout
+    const revision: RevisionFields = {
+      version: 4,
+      defaultValue: "false",
+      rules: {},
+      // holdout field missing from revision
+    };
+    const filled = fillRevisionFromFeature(revision, feature);
+    expect(filled.holdout).toBeNull();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -1264,6 +1322,40 @@ describe("autoMerge with holdout field", () => {
     const result = autoMerge(live, base, revision, [], {});
     expect(result.success).toBe(true);
     if (result.success) expect("holdout" in result.result).toBe(false);
+  });
+
+  it("no-divergence: detects holdout removal when base is backfilled via fillRevisionFromFeature", () => {
+    // This is the real-world bug scenario:
+    // 1. Feature has a holdout
+    // 2. Base revision was created before holdout tracking (no holdout field)
+    // 3. Draft revision has holdout: null to remove the holdout
+    // Without fillRevisionFromFeature backfilling base.holdout, autoMerge compares
+    // null vs undefined (→ null) and sees no change.
+    const featureWithHoldout: FeatureInterface = {
+      ...baseFeature,
+      holdout: holdout1,
+    };
+    const baseWithoutHoldoutField: RevisionFields = {
+      ...base,
+      // holdout field is NOT present (legacy revision)
+    };
+    const filledBase = fillRevisionFromFeature(
+      baseWithoutHoldoutField,
+      featureWithHoldout,
+    );
+    const liveWithHoldout: RevisionFields = { ...live, holdout: holdout1 };
+    const revision: RevisionFields = { ...base, version: 4, holdout: null };
+
+    // With fillRevisionFromFeature, base now has holdout from feature
+    expect(filledBase.holdout).toEqual(holdout1);
+
+    // autoMerge should detect the removal
+    const result = autoMerge(liveWithHoldout, filledBase, revision, [], {});
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect("holdout" in result.result).toBe(true);
+      expect(result.result.holdout).toBeNull();
+    }
   });
 
   it("no-divergence: omits holdout when value unchanged (same id)", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Features and Changes

Fixes a bug where the "Review & Publish" button was disabled (or the modal showed "no changes") when the only change to a feature flag draft was adding or removing a holdout, and fixes the issue where publishing a holdout removal didn't actually remove the holdout.

**Three related issues fixed:**

1. **`draftDiffersFromLive`** (used by the "Review & Publish" button) wasn't comparing the `holdout` field at all
2. **`fillRevisionFromFeature`** (used to prepare base revision for `autoMerge`) wasn't backfilling holdout from the feature, causing the modal to show "no changes"
3. **`applyRevisionChanges`** was converting `holdout: null` to `holdout: undefined`, which was ignored by MongoDB's `$set` operation, so the holdout was never actually removed

**Changes made:**

Frontend change detection (`packages/shared/src/util/features.ts`):
- `buildEffectiveDraft`: Now includes the `holdout` field when overlaying draft onto live
- `draftDiffersFromLive`: Now compares `holdout` between draft and live
- `fillRevisionFromFeature`: Now backfills `holdout` from feature (preserving explicit `null` for removal)

Backend publish logic (`packages/back-end/src/models/FeatureModel.ts`):
- `applyRevisionChanges`: Tracks holdout removal separately and uses `$unset` to remove the holdout field from MongoDB

### Dependencies

None

### Testing

1. Create a feature flag
2. Add the feature to a holdout (creates a draft)
3. Verify the "Review & Publish" button is enabled
4. Open the modal and verify it shows the holdout change (not "no changes")
5. Publish the change - verify holdout is now on the feature
6. Create a new draft that removes the holdout
7. Verify the "Review & Publish" button is enabled
8. Open the modal and verify it shows the holdout removal
9. Publish the holdout removal - verify holdout is actually removed from the feature

Unit tests added:
- `draftDiffersFromLive`: 4 tests for holdout scenarios
- `fillRevisionFromFeature`: 4 tests for holdout backfill behavior
- `autoMerge`: 1 test for holdout removal with backfilled base

### Screenshots

N/A - This is a logic fix, no UI changes. The UI was already correct; it just wasn't being enabled/showing changes when it should have been, and the backend wasn't properly applying the holdout removal.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://growthbookapp.slack.com/archives/C0A9B5W8LMN/p1776793000745409?thread_ts=1776793000.745409&cid=C0A9B5W8LMN)

<div><a href="https://cursor.com/agents/bc-32a0712e-3026-577b-a6c2-7b6de138502d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-32a0712e-3026-577b-a6c2-7b6de138502d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

