### PR TITLE
Allow removing experiment from holdout in draft with no linked implementations

### DIFF
--- a/packages/back-end/src/controllers/experiments.ts
+++ b/packages/back-end/src/controllers/experiments.ts
@@ -1497,19 +1497,34 @@ export async function postExperiment(
     validateVariationIds(data.variations);
   }
 
+  const experimentHasLinkedChanges =
+    experiment.hasURLRedirects ||
+    experiment.hasVisualChangesets ||
+    (experiment.linkedFeatures && experiment.linkedFeatures.length > 0);
   if (
+    // Holdout change
     data.holdoutId &&
     data.holdoutId !== experiment.holdoutId &&
     experiment.holdoutId
   ) {
-    if (
-      experiment.status !== "draft" ||
-      experiment.hasURLRedirects ||
-      experiment.hasVisualChangesets ||
-      (experiment.linkedFeatures && experiment.linkedFeatures.length > 0)
-    ) {
+    if (experiment.status !== "draft" || experimentHasLinkedChanges) {
       throw new Error(
         "Cannot change holdout after experiment has been run or linked changes have been added",
+      );
+    }
+    await context.models.holdout.removeExperimentFromHoldout(
+      experiment.holdoutId,
+      experiment.id,
+    );
+  } else if (
+    // Holdout removal
+    data.holdoutId == "" &&
+    data.holdoutId !== experiment.holdoutId &&
+    experiment.holdoutId
+  ) {
+    if (experiment.status !== "draft" || experimentHasLinkedChanges) {
+      throw new Error(
+        "Cannot remove experiment from holdout after experiment has been run or linked changes have been added",
       );
     }
     await context.models.holdout.removeExperimentFromHoldout(

--- a/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
+++ b/packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx
@@ -57,6 +57,7 @@ import { useHoldouts } from "@/hooks/useHoldouts";
 import PhaseSelector from "@/components/Experiment/PhaseSelector";
 import TemplateForm from "@/components/Experiment/Templates/TemplateForm";
 import AddToHoldoutModal from "@/components/Experiment/holdout/AddToHoldoutModal";
+import RemoveFromHoldoutModal from "@/components/Experiment/holdout/RemoveFromHoldoutModal";
 import ProjectTagBar from "./ProjectTagBar";
 import EditExperimentInfoModal, {
   FocusSelector,
@@ -170,6 +171,8 @@ export default function ExperimentHeader({
     useState<FocusSelector>("name");
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [showAddToHoldoutModal, setShowAddToHoldoutModal] = useState(false);
+  const [showRemoveFromHoldoutModal, setShowRemoveFromHoldoutModal] =
+    useState(false);
 
   const isWatching = watchedExperiments.includes(experiment.id);
   const [showTemplateForm, setShowTemplateForm] = useState(false);
@@ -714,6 +717,13 @@ export default function ExperimentHeader({
           mutate={mutate}
         />
       ) : null}
+      {showRemoveFromHoldoutModal ? (
+        <RemoveFromHoldoutModal
+          experiment={experiment}
+          close={() => setShowRemoveFromHoldoutModal(false)}
+          mutate={mutate}
+        />
+      ) : null}
 
       <div
         className={
@@ -879,6 +889,16 @@ export default function ExperimentHeader({
                       Add to holdout
                     </DropdownMenuItem>
                   )}
+                {canEditExperiment && !isHoldout && experiment.holdoutId && (
+                  <DropdownMenuItem
+                    onClick={() => {
+                      setShowRemoveFromHoldoutModal(true);
+                      setDropdownOpen(false);
+                    }}
+                  >
+                    Remove from holdout
+                  </DropdownMenuItem>
+                )}
               </DropdownMenuGroup>
               {isHoldout && canRunExperiment && (
                 <>

--- a/packages/front-end/components/Experiment/holdout/RemoveFromHoldoutModal.tsx
+++ b/packages/front-end/components/Experiment/holdout/RemoveFromHoldoutModal.tsx
@@ -1,0 +1,64 @@
+import { ExperimentInterfaceStringDates } from "shared/types/experiment";
+import { useAuth } from "@/services/auth";
+import Modal from "@/components/Modal";
+import Callout from "@/ui/Callout";
+import Text from "@/ui/Text";
+
+type Props = {
+  experiment: ExperimentInterfaceStringDates;
+  close: () => void;
+  mutate: () => void;
+};
+
+export default function RemoveFromHoldoutModal({
+  experiment,
+  close,
+  mutate,
+}: Props) {
+  const { apiCall } = useAuth();
+
+  const experimentIsDraft = experiment.status === "draft";
+  const experimentHasLinkedChanges =
+    experiment.hasURLRedirects ||
+    experiment.hasVisualChangesets ||
+    (experiment.linkedFeatures?.length ?? 0) > 0;
+  const canRemoveFromHoldout = experimentIsDraft && !experimentHasLinkedChanges;
+
+  const handleSubmit = async () => {
+    await apiCall(`/experiment/${experiment.id}`, {
+      method: "POST",
+      body: JSON.stringify({ holdoutId: "" }),
+    });
+    mutate();
+    close();
+  };
+
+  return (
+    <Modal
+      header="Remove from holdout"
+      close={close}
+      open={true}
+      trackingEventModalType="remove-experiment-from-holdout"
+      size="lg"
+      cta="Remove"
+      submit={handleSubmit}
+      ctaEnabled={canRemoveFromHoldout}
+    >
+      {!canRemoveFromHoldout ? (
+        <Callout status="error">
+          <Text>
+            Only draft experiments with no linked features can be removed from a
+            holdout.
+          </Text>
+        </Callout>
+      ) : (
+        <Callout status="warning">
+          <Text>
+            Removing this experiment from its holdout will stop holdout-based
+            exclusion for when the experiment is running.
+          </Text>
+        </Callout>
+      )}
+    </Modal>
+  );
+}


### PR DESCRIPTION
At least in the easy case with no linked changes and in draft state, we should allow removing an experiment from a holdout.

This does that by mirroring the existing back-end check for updating a holdout on an experiment in a front-end component in the experiment fly-away menu.

Only shows up when experiment is in the holdout
<img width="1049" height="163" alt="Screenshot 2026-04-21 at 10 55 31 AM" src="https://github.com/user-attachments/assets/68cfc9ee-2e5d-420f-af75-3c76d7d20697" />

If eligible, we show this and remove works
<img width="660" height="211" alt="Screenshot 2026-04-21 at 10 53 04 AM" src="https://github.com/user-attachments/assets/840a2ba3-3ad8-43b7-86d5-a0f104215537" />

If not eligible, we still show the fly out option, but the modal shows an error state.
<img width="670" height="210" alt="Screenshot 2026-04-21 at 10 52 55 AM" src="https://github.com/user-attachments/assets/bb8ed845-c94d-40c2-8163-371fc5d55400" />
