### PR TITLE
feat: Show Edit Identifier Types when editing existing fact tables

### DIFF
--- a/packages/front-end/components/FactTables/FactTableModal.tsx
+++ b/packages/front-end/components/FactTables/FactTableModal.tsx
@@ -270,7 +270,7 @@ export default function FactTableModal({
           </div>
         )}
 
-        {selectedDataSource && (!existing?.id || duplicate) && (
+        {selectedDataSource && (
           <>
             <a
               href="#"
@@ -295,7 +295,11 @@ export default function FactTableModal({
                       label: userIdType,
                     }),
                   )}
-                  helpText="The default values were auto-detected from your SQL query."
+                  helpText={
+                    !existing?.id || duplicate
+                      ? "The default values were auto-detected from your SQL query."
+                      : "Select which columns from your SQL should be treated as user identifier types."
+                  }
                   autoFocus={true}
                 />
               </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Features and Changes

This PR makes the "Edit Identifier Types" section visible in the FactTableModal when editing existing fact tables.

**Problem:**
Previously, the "Edit Identifier Types" section was only visible when creating or duplicating a fact table. Users who needed to add or modify identifier types on existing fact tables had to go through the Edit SQL modal and re-run SQL validation, even if their SQL didn't need any changes. This was unintuitive and created friction for users.

A common scenario: a user has a frontend fact table where a `device_id` column exists in the SQL but wasn't initially declared as an identifier type. Without this change, the only way to add `device_id` as an identifier type is to use the Edit SQL flow.

**Solution:**
The "Edit Identifier Types" section is now always visible in the edit modal. The help text is contextually updated:
- For new/duplicate fact tables: "The default values were auto-detected from your SQL query."
- For existing fact tables: "Select which columns from your SQL should be treated as user identifier types."

The existing validation ensures that any identifier type selected must exist as a column in the fact table's SQL.

- Closes N/A (customer support improvement)

### Dependencies

None

### Testing

1. Create or find an existing fact table
2. Click the three-dot menu and select "Edit Fact Table"
3. Verify the "Edit Identifier Types" link is now visible
4. Click to expand and verify the multi-select field allows adding/removing identifier types
5. Save changes and verify they persist

### Screenshots

**Edit Fact Table modal showing the "Edit Identifier Types" link:**
[Edit Fact Table modal with Edit Identifier Types link visible](https://cursor.com/agents/bc-1bd9a4d2-30a2-5c8d-b645-5c2d5ad0d3c3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fedit_fact_table_modal_with_identifier_types.webp)

**Expanded identifier types section with multi-select field:**
[Edit Identifier Types section expanded showing multi-select](https://cursor.com/agents/bc-1bd9a4d2-30a2-5c8d-b645-5c2d5ad0d3c3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fidentifier_types_expanded.webp)

**Multi-select dropdown open:**
[Identifier types dropdown open](https://cursor.com/agents/bc-1bd9a4d2-30a2-5c8d-b645-5c2d5ad0d3c3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fidentifier_types_dropdown.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://growthbookapp.slack.com/archives/C05QYS2UFRD/p1776785888656439?thread_ts=1776785888.656439&cid=C05QYS2UFRD)

<div><a href="https://cursor.com/agents/bc-1bd9a4d2-30a2-5c8d-b645-5c2d5ad0d3c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1bd9a4d2-30a2-5c8d-b645-5c2d5ad0d3c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

