### PR TITLE
Fix missing Product Analytic Dashboards policy in custom role UI

### DIFF
--- a/packages/shared/src/permissions/permissions.constants.ts
+++ b/packages/shared/src/permissions/permissions.constants.ts
@@ -223,6 +223,7 @@ export const POLICY_DISPLAY_GROUPS: { name: string; policies: Policy[] }[] = [
       "BillingFullAccess",
       "AuditLogsFullAccess",
       "DecisionCriteriaFullAccess",
+      "CustomHooksFullAccess",
     ],
   },
 ];

--- a/packages/shared/src/permissions/permissions.constants.ts
+++ b/packages/shared/src/permissions/permissions.constants.ts
@@ -191,6 +191,10 @@ export const POLICY_DISPLAY_GROUPS: { name: string; policies: Policy[] }[] = [
     policies: ["IdeasFullAccess", "PresentationsFullAccess"],
   },
   {
+    name: "Product Analytic Dashboards",
+    policies: ["GeneralDashboardsFullAccess"],
+  },
+  {
     name: "SDK Configuration",
     policies: [
       "SDKPayloadPublish",

--- a/packages/shared/test/policy-display-groups.test.ts
+++ b/packages/shared/test/policy-display-groups.test.ts
@@ -1,4 +1,8 @@
-import { POLICY_DISPLAY_GROUPS, POLICY_METADATA_MAP } from "../src/permissions";
+import {
+  POLICIES,
+  POLICY_DISPLAY_GROUPS,
+  POLICY_METADATA_MAP,
+} from "../src/permissions";
 
 describe("policy display groups", () => {
   it("includes product analytic dashboards policy group", () => {
@@ -11,5 +15,24 @@ describe("policy display groups", () => {
     expect(POLICY_METADATA_MAP.GeneralDashboardsFullAccess.displayName).toBe(
       "General Dashboards Full Access",
     );
+  });
+
+  it("includes custom hooks in a display group", () => {
+    const settingsGroup = POLICY_DISPLAY_GROUPS.find(
+      (group) => group.name === "Settings",
+    );
+
+    expect(settingsGroup).toBeDefined();
+    expect(settingsGroup?.policies).toContain("CustomHooksFullAccess");
+  });
+
+  it("includes every policy in at least one display group", () => {
+    const allGroupedPolicies = POLICY_DISPLAY_GROUPS.flatMap(
+      (group) => group.policies,
+    );
+
+    for (const policy of POLICIES) {
+      expect(allGroupedPolicies).toContain(policy);
+    }
   });
 });

--- a/packages/shared/test/policy-display-groups.test.ts
+++ b/packages/shared/test/policy-display-groups.test.ts
@@ -1,0 +1,18 @@
+import {
+  POLICY_DISPLAY_GROUPS,
+  POLICY_METADATA_MAP,
+} from "../src/permissions";
+
+describe("policy display groups", () => {
+  it("includes product analytic dashboards policy group", () => {
+    const dashboardsGroup = POLICY_DISPLAY_GROUPS.find(
+      (group) => group.name === "Product Analytic Dashboards",
+    );
+
+    expect(dashboardsGroup).toBeDefined();
+    expect(dashboardsGroup?.policies).toContain("GeneralDashboardsFullAccess");
+    expect(POLICY_METADATA_MAP.GeneralDashboardsFullAccess.displayName).toBe(
+      "General Dashboards Full Access",
+    );
+  });
+});

--- a/packages/shared/test/policy-display-groups.test.ts
+++ b/packages/shared/test/policy-display-groups.test.ts
@@ -1,7 +1,4 @@
-import {
-  POLICY_DISPLAY_GROUPS,
-  POLICY_METADATA_MAP,
-} from "../src/permissions";
+import { POLICY_DISPLAY_GROUPS, POLICY_METADATA_MAP } from "../src/permissions";
 
 describe("policy display groups", () => {
   it("includes product analytic dashboards policy group", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Features and Changes

- Added the missing `Product Analytic Dashboards` policy display group in `packages/shared/src/permissions/permissions.constants.ts`.
- Added `GeneralDashboardsFullAccess` to that group so it renders in the custom role permissions UI.
- Added `CustomHooksFullAccess` to the `Settings` policy display group so it also renders in the custom role permissions UI (addressing review feedback).
- Added/expanded regression test `packages/shared/test/policy-display-groups.test.ts` to:
  - validate the dashboards group includes `GeneralDashboardsFullAccess`
  - validate `CustomHooksFullAccess` is included in a display group
  - validate **every** policy in `POLICIES` appears in at least one `POLICY_DISPLAY_GROUPS` entry
- Follow-up CI fix: formatted `policy-display-groups.test.ts` to satisfy Prettier/lint checks.

- Closes **https://github.com/growthbook/growthbook/issues/5715**

### Dependencies

None.

### Testing

- `pnpm --filter shared exec prettier --check test/policy-display-groups.test.ts`
  - PASS
- `pnpm --filter shared test policy-display-groups.test.ts`
  - PASS (3 tests / 1 suite)
- Manual verification in local app (`http://localhost:3000`):
  - Navigated to **Settings -> Team -> Roles -> Create Custom Role**
  - Confirmed dashboards permissions group and policy render in the permissions list
  - Confirmed `Custom Hooks Full Access` renders in the `Settings` group

### Screenshots

[Custom role permissions shows dashboards group](https://cursor.com/agents/bc-ac189fb6-5bf6-53e4-a9c8-1c2f727d1a37/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_custom_role_dashboard_policy_group.webp)

[custom_role_dashboard_policy_group_visible.mp4](https://cursor.com/agents/bc-ac189fb6-5bf6-53e4-a9c8-1c2f727d1a37/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcustom_role_dashboard_policy_group_visible.mp4)

[Custom Hooks Full Access highlighted in custom role settings](https://cursor.com/agents/bc-ac189fb6-5bf6-53e4-a9c8-1c2f727d1a37/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_custom_hooks_full_access_find_highlighted.webp)

[custom_hooks_full_access_find_in_page_proof.mp4](https://cursor.com/agents/bc-ac189fb6-5bf6-53e4-a9c8-1c2f727d1a37/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcustom_hooks_full_access_find_in_page_proof.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://growthbookapp.slack.com/archives/C046L8DQD6F/p1776847220498339?thread_ts=1776847220.498339&cid=C046L8DQD6F)

<div><a href="https://cursor.com/agents/bc-ac189fb6-5bf6-53e4-a9c8-1c2f727d1a37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac189fb6-5bf6-53e4-a9c8-1c2f727d1a37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

