### PR TITLE
fix: align identity CTE between outer metric query and units subquery

### DIFF
--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -2166,19 +2166,32 @@ export default abstract class SqlIntegration
       undefined,
     );
 
-    // Get any required identity join queries
-    const { baseIdType, idJoinMap, idJoinSQL } = this.getIdentitiesCTE({
-      objects: [
-        [exposureQuery.userIdType],
-        activationMetric ? getUserIdTypes(activationMetric, factTableMap) : [],
-        ...unitDimensions.map((d) => [d.dimension.userIdType || "user_id"]),
-        segment ? [segment.userIdType || "user_id"] : [],
-      ],
-      from: settings.startDate,
-      to: settings.endDate,
-      forcedBaseIdType: exposureQuery.userIdType,
-      experimentId: settings.experimentId,
-    });
+    // Get any required identity join queries. When the caller provides
+    // inherited values (e.g. the outer metric query), use them so the activation
+    // metric JOIN below references a CTE the caller will actually emit.
+    let baseIdType: string;
+    let idJoinMap: Record<string, string>;
+    let idJoinSQL: string;
+    if (params.forcedBaseIdType && params.forcedIdJoinMap) {
+      baseIdType = params.forcedBaseIdType;
+      idJoinMap = params.forcedIdJoinMap;
+      idJoinSQL = "";
+    } else {
+      ({ baseIdType, idJoinMap, idJoinSQL } = this.getIdentitiesCTE({
+        objects: [
+          [exposureQuery.userIdType],
+          activationMetric
+            ? getUserIdTypes(activationMetric, factTableMap)
+            : [],
+          ...unitDimensions.map((d) => [d.dimension.userIdType || "user_id"]),
+          segment ? [segment.userIdType || "user_id"] : [],
+        ],
+        from: settings.startDate,
+        to: settings.endDate,
+        forcedBaseIdType: exposureQuery.userIdType,
+        experimentId: settings.experimentId,
+      }));
+    }
 
     // Get date range for experiment
     const startDate: Date = settings.startDate;
@@ -2399,7 +2412,7 @@ export default abstract class SqlIntegration
     const computeBanditSrm = !!banditDates && !!variationPeriodWeights;
 
     // Get any required identity join queries
-    const { baseIdType, idJoinSQL } = this.getIdentitiesCTE({
+    const { baseIdType, idJoinMap, idJoinSQL } = this.getIdentitiesCTE({
       // add idTypes usually handled in units query here in the case where
       // we don't have a separate table for the units query
       // then for this query we just need the activation metric for activation
@@ -2426,6 +2439,8 @@ export default abstract class SqlIntegration
           ? `${this.getExperimentUnitsQuery({
               ...params,
               includeIdJoins: false,
+              forcedBaseIdType: baseIdType,
+              forcedIdJoinMap: idJoinMap,
             })},`
           : ""
       }
@@ -3385,6 +3400,8 @@ export default abstract class SqlIntegration
           ? `${this.getExperimentUnitsQuery({
               ...params,
               includeIdJoins: false,
+              forcedBaseIdType: baseIdType,
+              forcedIdJoinMap: idJoinMap,
             })},`
           : params.unitsSource === "otherQuery"
             ? params.unitsSql
@@ -4125,6 +4142,8 @@ export default abstract class SqlIntegration
           ? `${this.getExperimentUnitsQuery({
               ...params,
               includeIdJoins: false,
+              forcedBaseIdType: baseIdType,
+              forcedIdJoinMap: idJoinMap,
             })},`
           : params.unitsSource === "otherQuery"
             ? params.unitsSql

--- a/packages/back-end/test/integrations/SqlIntegration.test.ts
+++ b/packages/back-end/test/integrations/SqlIntegration.test.ts
@@ -1,0 +1,181 @@
+import { ExperimentSnapshotSettings } from "shared/types/experiment-snapshot";
+import { ExposureQuery } from "shared/types/datasource";
+import { ExperimentFactMetricsQueryParams } from "shared/types/integrations";
+import Postgres from "back-end/src/integrations/Postgres";
+import { factTableFactory } from "../factories/FactTable.factory";
+import { factMetricFactory } from "../factories/FactMetric.factory";
+
+describe("SqlIntegration identity CTE generation", () => {
+  let integration: Postgres;
+
+  const exposureQuery: ExposureQuery = {
+    id: "exposure",
+    name: "Exposure",
+    description: "",
+    query:
+      "SELECT device_id as device_id, timestamp, exp_id as experiment_id, variant_id as variation_id FROM exposures",
+    userIdType: "device_id",
+    dimensions: [],
+  };
+
+  const settings: ExperimentSnapshotSettings = {
+    manual: false,
+    dimensions: [],
+    metricSettings: [],
+    goalMetrics: [],
+    secondaryMetrics: [],
+    guardrailMetrics: [],
+    activationMetric: "fact_activation",
+    defaultMetricPriorSettings: {
+      override: false,
+      proper: false,
+      mean: 0,
+      stddev: 0,
+    },
+    regressionAdjustmentEnabled: false,
+    attributionModel: "firstExposure",
+    experimentId: "exp_1",
+    queryFilter: "",
+    segment: "",
+    skipPartialData: false,
+    datasourceId: "ds_1",
+    exposureQueryId: "exposure",
+    startDate: new Date("2024-01-01"),
+    endDate: new Date("2024-01-31"),
+    variations: [],
+  };
+
+  beforeEach(() => {
+    // @ts-expect-error -- context/datasource not needed for this unit test
+    integration = new Postgres("", {});
+    jest
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .spyOn(integration as any, "getExposureQuery")
+      .mockReturnValue(exposureQuery);
+    jest
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .spyOn(integration as any, "getIdentitiesQuery")
+      .mockImplementation(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (_settings: any, baseIdType: string, idType: string) =>
+          `SELECT ${baseIdType}, ${idType} FROM identity_map`,
+      );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  // Repro: when a fact table gains a second identifier that matches another
+  // metric's fact table identifier, the identity CTE picked for the activation
+  // metric's JOIN can diverge from what's emitted as a CTE, producing a JOIN
+  // to a nonexistent `__identities_X` table.
+  it("emits every `__identities_X` CTE it references in a JOIN", () => {
+    // Events fact table has BOTH visitor_id and rle_nummer.
+    // Sales fact table has only rle_nummer.
+    const eventsFactTable = factTableFactory.build({
+      id: "ft_events",
+      name: "Events",
+      userIdTypes: ["visitor_id", "rle_nummer"],
+      sql: "SELECT visitor_id, rle_nummer, timestamp FROM events",
+      columns: [
+        {
+          column: "timestamp",
+          datatype: "date",
+          name: "timestamp",
+          numberFormat: "",
+          deleted: false,
+          dateCreated: new Date(),
+          dateUpdated: new Date(),
+        },
+      ],
+    });
+    const salesFactTable = factTableFactory.build({
+      id: "ft_sales",
+      name: "Sales",
+      userIdTypes: ["rle_nummer"],
+      sql: "SELECT rle_nummer, media_type, timestamp FROM sales",
+      columns: [
+        {
+          column: "timestamp",
+          datatype: "date",
+          name: "timestamp",
+          numberFormat: "",
+          deleted: false,
+          dateCreated: new Date(),
+          dateUpdated: new Date(),
+        },
+      ],
+    });
+    const factTableMap = new Map([
+      ["ft_events", eventsFactTable],
+      ["ft_sales", salesFactTable],
+    ]);
+
+    // Activation metric: proportion on events (could fire on visitor_id OR rle_nummer).
+    const activationMetric = factMetricFactory.build({
+      id: "fact_activation",
+      name: "activation",
+      metricType: "proportion",
+      numerator: {
+        factTableId: "ft_events",
+        column: "$$distinctUsers",
+        aggregation: "sum",
+        rowFilters: [],
+      },
+      windowSettings: {
+        type: "",
+        delayValue: 0,
+        delayUnit: "hours",
+        windowValue: 0,
+        windowUnit: "hours",
+      },
+    });
+
+    // Guardrail metric: proportion on sales (must join via rle_nummer).
+    const guardrailMetric = factMetricFactory.build({
+      id: "fact_guardrail",
+      name: "guardrail",
+      metricType: "proportion",
+      numerator: {
+        factTableId: "ft_sales",
+        column: "$$distinctUsers",
+        aggregation: "sum",
+        rowFilters: [],
+      },
+      windowSettings: {
+        type: "",
+        delayValue: 0,
+        delayUnit: "hours",
+        windowValue: 0,
+        windowUnit: "hours",
+      },
+    });
+
+    const params: ExperimentFactMetricsQueryParams = {
+      settings,
+      activationMetric,
+      metrics: [guardrailMetric],
+      factTableMap,
+      dimensions: [],
+      segment: null,
+      unitsSource: "exposureQuery",
+    };
+
+    const sql = integration.getExperimentFactMetricsQuery(params);
+
+    const joinRefs = new Set<string>();
+    for (const match of sql.matchAll(/JOIN\s+(__identities_\w+)/gi)) {
+      joinRefs.add(match[1]);
+    }
+    const cteDefs = new Set<string>();
+    for (const match of sql.matchAll(/(__identities_\w+)\s+as\s*\(/gi)) {
+      cteDefs.add(match[1]);
+    }
+
+    // Every `__identities_X` we JOIN to must be declared as a CTE.
+    for (const ref of joinRefs) {
+      expect(cteDefs).toContain(ref);
+    }
+  });
+});

--- a/packages/shared/types/integrations.d.ts
+++ b/packages/shared/types/integrations.d.ts
@@ -300,6 +300,12 @@ interface ExperimentBaseQueryParams {
 
 export interface ExperimentUnitsQueryParams extends ExperimentBaseQueryParams {
   includeIdJoins: boolean;
+  // When set, the units query uses these instead of recomputing its own
+  // identity CTE mapping. This keeps the activation/segment/dimension JOINs
+  // inside the units query aligned with the identity CTEs emitted by the
+  // outer metric query (which sees a wider set of metrics and id types).
+  forcedBaseIdType?: string;
+  forcedIdJoinMap?: Record<string, string>;
 }
 
 export interface CreateExperimentIncrementalUnitsQueryParams {


### PR DESCRIPTION
### Features and Changes

Fixes a SQL compilation failure ("`__IDENTITIES_VISITOR_ID does not exist`") that appeared after a customer added a second identifier to a fact table already referenced by an activation metric, when a guardrail metric on a different fact table shared one of those identifiers.

Two calls to `getIdentitiesCTE` were producing inconsistent `idJoinMap` values: the outer metric query saw all metrics' identifiers and emitted one CTE set, while the inner `getExperimentUnitsQuery` saw a narrower subset and — via the frequency + insertion-order tiebreaker in `getBaseIdTypeAndJoins` — picked a different identifier for the activation JOIN, referencing a CTE the outer never declared.

The fix threads the outer's `baseIdType`/`idJoinMap` through `ExperimentUnitsQueryParams` so the units subquery reuses them instead of recomputing, keeping the JOINs consistent with the CTEs actually emitted.

- Closes (internal Slack thread; no GH issue)

### Dependencies

None.

### Testing

- Added `packages/back-end/test/integrations/SqlIntegration.test.ts` — a property-based test that asserts every `JOIN __identities_X` in the generated SQL has a matching CTE declaration. Fails on `main`, passes with this fix.
- `pnpm --filter back-end test test/integrations/` — all 20 tests pass.
- `pnpm --filter back-end type-check` and `pnpm --filter shared type-check` — clean.

### Screenshots

N/A (backend SQL generation).