### PR TITLE
increase default stats engine timeout to 15 minutes

### DIFF
--- a/packages/back-end/src/services/python.ts
+++ b/packages/back-end/src/services/python.ts
@@ -50,11 +50,12 @@ const MIN_POOL_SIZE = parseEnvInt(
   { min: 0, max: MAX_POOL_SIZE, name: "GB_STATS_ENGINE_MIN_POOL_SIZE" },
 );
 
-// The stats engine usually finishes within 1 second
-// We use an overly conservative timeout to account for high load
+// The stats engine usually finishes within 1 second, but large experiments
+// with many metrics and dimension breakdowns can legitimately take several
+// minutes. We use a conservative timeout so those results aren't discarded.
 const STATS_ENGINE_TIMEOUT_MS = parseEnvInt(
   process.env.GB_STATS_ENGINE_TIMEOUT_MS,
-  300_000,
+  900_000,
   { min: 1, name: "GB_STATS_ENGINE_TIMEOUT_MS" },
 );
 


### PR DESCRIPTION
## Summary
Experiments with many metrics and a dimension breakdown can legitimately take several minutes in gbstats. With the previous 5-minute default, gbstats completes successfully but the Node-side timer has already fired — the result is discarded and the snapshot is marked failed with `Python stats server call timed out`.

This bumps the default `GB_STATS_ENGINE_TIMEOUT_MS` from 300_000 (5m) to 900_000 (15m). Still overridable via env var.

## Observed behavior

Log pattern when this happens (redacted):
```
level:50  "Python stats server (pid: <pid>) call timed out for id <uuid>"
level:50  "Queries succeeded, failed running analysis"  err: Python stats server call timed out @ /services/python.ts
level:40  "Python stats server (pid: <pid>) stdout has unknown id: <uuid>"   ← ~30s later — gbstats finished, result discarded
```

## Pipeline walkthrough — where it breaks

| # | Step | Where | Status | Fixed by this PR |
|---|---|---|---|---|
| 1 | `POST /experiment/:id/snapshot` | `controllers/experiments.ts` | ✅ | n/a |
| 2 | Create snapshot doc (`type: "exploratory"` when dimension set) | `ExperimentSnapshotModel` | ✅ | n/a |
| 3 | Generate SQL per metric with `GROUP BY dimension` | `ExperimentResultsQueryRunner` | ✅ | n/a |
| 4 | Run warehouse queries → aggregated rows per (dim × variation × metric) | warehouse | ✅ "Queries succeeded" | n/a |
| 5 | `runAnalysis()` → build single payload (all metrics × all dim rows × 3 analysis settings) | `stats.ts:629-670` | ✅ | n/a |
| 6 | `runStatsEngine()` → acquire Python subprocess from pool | `stats.ts:160` | ✅ | n/a |
| 7 | Write JSON to subprocess stdin, **start timer** | `python.ts` | ✅ | — |
| 8 | gbstats: `metrics × 3 analyses × ≤6 passes × ≤20 dims × variations` | `gbstats.py` | ⏳ can take >5m | — |
| 9 | **Timer fires at 5m** → reject promise, delete callback | `python.ts` | ❌ fires before step 10 | ✅ |
| 10 | gbstats writes result to stdout | `stats_server.py` | ✅ but logged as "unknown id", discarded | ✅ now accepted |
| 11 | Store results on snapshot → UI renders | `QueryRunner.ts` | ❌ error persisted instead | ✅ |

## Notes
- The dimension-value cap (`MAX_DIMENSIONS = 20`) is applied *after* `get_metric_dfs` rebuilds the dataframe `metrics × 3` times, so high-cardinality dimensions still incur full build cost before truncation. A follow-up perf improvement could chunk the gbstats call per-metric or apply the cap earlier — out of scope here.
- Pool-acquire wait time is not counted against the timer (timer starts post-acquire), so this is pure gbstats compute time.
