### PR TITLE
Allow opt-in namespace range overlap

### DIFF
--- a/packages/front-end/components/Features/NamespaceSelector.tsx
+++ b/packages/front-end/components/Features/NamespaceSelector.tsx
@@ -99,7 +99,6 @@ export default function NamespaceSelector({
   );
   const [allowOverlap, setAllowOverlap] = useState(false);
   const [selectKey, forceSelectRemount] = useIncrementer();
-  // Per-namespace range cache: restores user picks when switching the dropdown away and back.
   const namespaceRangesCache = useRef<Record<string, RangeTuple[]>>({});
   const namespacePath = `${formPrefix}namespace`;
   const namespaceRangesPath = `${namespacePath}.ranges`;
@@ -204,10 +203,8 @@ export default function NamespaceSelector({
     });
   }, [namespace, ranges, persistedGaps]);
 
-  // Reset allowOverlap when the namespace changes, seeding it from the
-  // detected overlap state (so existing overlapping configs auto-enable it).
-  // isOverlapping intentionally excluded — we only want this to fire on
-  // namespace change, not every time range values shift.
+  // Fires only on namespace change; ref avoids stale closure without making
+  // isOverlapping a dep (which would fire on every range edit).
   const isOverlappingRef = useRef(isOverlapping);
   isOverlappingRef.current = isOverlapping;
   useEffect(() => {
@@ -247,7 +244,6 @@ export default function NamespaceSelector({
 
   useEffect(() => {
     if (storedRanges.length > 0 || !legacyRange) return;
-    // Migrate legacy single-range tuple → canonical `ranges` array.
     const current =
       (form.getValues(namespacePath) as NamespaceFormState | undefined) ?? {};
     form.setValue(
@@ -279,7 +275,6 @@ export default function NamespaceSelector({
     }
   }, [namespace, ranges]);
 
-  // Clear namespace when the experiment's hash attribute changes and no longer matches.
   useEffect(() => {
     if (!experimentHashAttribute) return;
     const ns = form.getValues(namespacePath) as NamespaceFormState | undefined;
@@ -498,26 +493,30 @@ export default function NamespaceSelector({
                     setValue={(v) => {
                       setAllowOverlap(v);
                       if (!v && ranges.length > 0) {
-                        const snapped = ranges.map((range, index) => {
-                          const otherRanges = ranges.filter(
-                            (_, i) => i !== index,
-                          );
+                        const snapped: RangeTuple[] = [];
+                        for (let index = 0; index < ranges.length; index++) {
+                          const range = ranges[index];
+                          const otherRanges = [
+                            ...snapped,
+                            ...ranges.filter((_, i) => i > index),
+                          ];
                           const available = subtractSelectedRangesFromGaps(
                             persistedGaps,
                             otherRanges,
                           );
                           if (findContainingGap(available, range[0])) {
-                            return normalizeRangeAfterUpperChange(
+                            snapped[index] = normalizeRangeAfterUpperChange(
                               range,
                               range[1],
                               available,
                             );
+                          } else {
+                            const largest = getLargestGap(available);
+                            snapped[index] = largest
+                              ? ([largest.start, largest.end] as RangeTuple)
+                              : range;
                           }
-                          const largest = getLargestGap(available);
-                          return largest
-                            ? ([largest.start, largest.end] as RangeTuple)
-                            : range;
-                        });
+                        }
                         form.setValue(namespaceRangesPath, snapped, {
                           shouldDirty: true,
                           shouldTouch: true,

--- a/packages/front-end/components/Features/NamespaceSelector.tsx
+++ b/packages/front-end/components/Features/NamespaceSelector.tsx
@@ -21,6 +21,7 @@ import NamespaceUsageGraph from "./NamespaceUsageGraph";
 import {
   normalizeRangeAfterLowerChange,
   normalizeRangeAfterUpperChange,
+  findContainingGap,
   getLargestGap,
   RangeTuple,
   shiftDraftKeysAfterRangeRemoval,
@@ -96,6 +97,7 @@ export default function NamespaceSelector({
   const [focusedRangeIndex, setFocusedRangeIndex] = useState<number | null>(
     null,
   );
+  const [allowOverlap, setAllowOverlap] = useState(false);
   const [selectKey, forceSelectRemount] = useIncrementer();
   // Per-namespace range cache: restores user picks when switching the dropdown away and back.
   const namespaceRangesCache = useRef<Record<string, RangeTuple[]>>({});
@@ -154,30 +156,13 @@ export default function NamespaceSelector({
       (n) => n?.status !== "inactive",
     );
 
-    // Always keep the selected namespace regardless of room so edits still work.
-    // findGaps excludes featureId/trackingKey so the current experiment's own
-    // range doesn't count against available capacity.
-    const roomSet = new Set(
-      activeNamespaces
-        .filter((n) => {
-          if (n.name === namespace) return true;
-          const gaps = findGaps(namespaceUsage, n.name, featureId, trackingKey);
-          return gaps.some((g) => g.end - g.start > 0);
-        })
-        .map((n) => n.name),
-    );
-    const allocatable = activeNamespaces.filter((n) => roomSet.has(n.name));
-
     const filtered = isFallbackMode
-      ? allocatable.filter((n) => isLegacyNamespace(n))
-      : allocatable;
-
-    const optionSource = isFallbackMode ? filtered : activeNamespaces;
+      ? activeNamespaces.filter((n) => isLegacyNamespace(n))
+      : activeNamespaces;
 
     return {
       filteredNamespaces: filtered,
-      namespaceOptions: optionSource.map((n) => {
-        const isFull = !roomSet.has(n.name);
+      namespaceOptions: activeNamespaces.map((n) => {
         const isHashMismatch =
           !isFallbackMode &&
           !isLegacyNamespace(n) &&
@@ -185,12 +170,9 @@ export default function NamespaceSelector({
         return {
           value: n.name,
           label: n.label,
-          isDisabled: isFull || isHashMismatch,
-          ...(isFull ? { tooltip: "full" } : {}),
+          isDisabled: isHashMismatch,
         };
       }) as SingleValue[],
-      // Use the unfiltered active set so a full namespace still resolves when
-      // the current experiment is the one occupying all its space.
       selectedNamespace: activeNamespaces.find((n) => n.name === namespace),
       selectedIsDifferentHash:
         !isFallbackMode &&
@@ -201,23 +183,45 @@ export default function NamespaceSelector({
             n.hashAttribute !== effectiveHashAttribute,
         ),
     };
-  }, [
-    allNamespaces,
-    effectiveHashAttribute,
-    isFallbackMode,
-    namespace,
-    namespaceUsage,
-    featureId,
-    trackingKey,
-  ]);
+  }, [allNamespaces, effectiveHashAttribute, isFallbackMode, namespace]);
 
   const persistedGaps = useMemo(
     () => findGaps(namespaceUsage, namespace, featureId, trackingKey),
     [namespaceUsage, namespace, featureId, trackingKey],
   );
+
+  const isOverlapping = useMemo(() => {
+    if (!namespace || ranges.length === 0) return false;
+    return ranges.some(([start, end]) => {
+      let remaining = start;
+      const sorted = [...persistedGaps].sort((a, b) => a.start - b.start);
+      for (const gap of sorted) {
+        if (gap.start > remaining) return true;
+        if (gap.end >= end) return false;
+        remaining = gap.end;
+      }
+      return remaining < end;
+    });
+  }, [namespace, ranges, persistedGaps]);
+
+  // Reset allowOverlap when the namespace changes, seeding it from the
+  // detected overlap state (so existing overlapping configs auto-enable it).
+  // isOverlapping intentionally excluded — we only want this to fire on
+  // namespace change, not every time range values shift.
+  const isOverlappingRef = useRef(isOverlapping);
+  isOverlappingRef.current = isOverlapping;
+  useEffect(() => {
+    setAllowOverlap(isOverlappingRef.current);
+  }, [namespace]);
+
+  const effectiveGaps = useMemo(
+    () => (allowOverlap ? [{ start: 0, end: 1 }] : persistedGaps),
+    [allowOverlap, persistedGaps],
+  );
+
   const largestAvailableGap = useMemo(
-    () => getLargestGap(subtractSelectedRangesFromGaps(persistedGaps, ranges)),
-    [persistedGaps, ranges],
+    () => getLargestGap(subtractSelectedRangesFromGaps(effectiveGaps, ranges)),
+    [effectiveGaps, ranges],
   );
 
   const getDraftKey = (index: number, field: 0 | 1) => `${index}:${field}`;
@@ -306,7 +310,7 @@ export default function NamespaceSelector({
 
   const getAvailableGapsForRange = (index: number) => {
     return subtractSelectedRangesFromGaps(
-      persistedGaps,
+      effectiveGaps,
       ranges.filter((_, rangeIndex) => rangeIndex !== index),
     );
   };
@@ -437,17 +441,12 @@ export default function NamespaceSelector({
               const ns = allNamespaces.find((n) => n.name === option.value);
               const hashAttr =
                 ns?.format === "multiRange" ? ns.hashAttribute : null;
-              const isFull = option.tooltip === "full";
-              const isDisabled = option.isDisabled;
-              const tooltipContent = isFull
-                ? "This namespace is full"
-                : "Namespace and experiment hash attributes must match";
               const row = (
                 <Flex as="div" align="baseline">
                   <span>{option.label}</span>
-                  {(hashAttr || isFull) && (
+                  {hashAttr && (
                     <Text size="small" color="text-mid" ml="auto">
-                      {isDisabled && (
+                      {option.isDisabled && (
                         <PiWarningCircle
                           size={15}
                           style={{
@@ -457,19 +456,17 @@ export default function NamespaceSelector({
                           }}
                         />
                       )}
-                      {isFull ? (
-                        "full"
-                      ) : (
-                        <>
-                          hash attribute: <strong>{hashAttr}</strong>
-                        </>
-                      )}
+                      hash attribute: <strong>{hashAttr}</strong>
                     </Text>
                   )}
                 </Flex>
               );
-              if (!isDisabled) return row;
-              return <Tooltip content={tooltipContent}>{row}</Tooltip>;
+              if (!option.isDisabled) return row;
+              return (
+                <Tooltip content="Namespace and experiment hash attributes must match">
+                  {row}
+                </Tooltip>
+              );
             }}
           />
           {namespace && selectedNamespace && (
@@ -492,8 +489,43 @@ export default function NamespaceSelector({
               />
 
               <Box mt="4">
-                <Flex justify="between" align="center" mb="3">
+                <Flex justify="between" align="center" mb="1">
                   <label>Selected range{ranges.length > 1 ? "s" : ""}</label>
+                  <Checkbox
+                    size="sm"
+                    label="Allow overlap"
+                    value={allowOverlap}
+                    setValue={(v) => {
+                      setAllowOverlap(v);
+                      if (!v && ranges.length > 0) {
+                        const snapped = ranges.map((range, index) => {
+                          const otherRanges = ranges.filter(
+                            (_, i) => i !== index,
+                          );
+                          const available = subtractSelectedRangesFromGaps(
+                            persistedGaps,
+                            otherRanges,
+                          );
+                          if (findContainingGap(available, range[0])) {
+                            return normalizeRangeAfterUpperChange(
+                              range,
+                              range[1],
+                              available,
+                            );
+                          }
+                          const largest = getLargestGap(available);
+                          return largest
+                            ? ([largest.start, largest.end] as RangeTuple)
+                            : range;
+                        });
+                        form.setValue(namespaceRangesPath, snapped, {
+                          shouldDirty: true,
+                          shouldTouch: true,
+                        });
+                        setRangeDrafts({});
+                      }
+                    }}
+                  />
                 </Flex>
 
                 {ranges.map((range, index) => {
@@ -528,7 +560,12 @@ export default function NamespaceSelector({
                           }));
                           const parsed = Number.parseFloat(rawValue);
                           if (!Number.isNaN(parsed)) {
-                            setRangeAtIndex(index, [parsed, range[1]]);
+                            const normalized = normalizeRangeAfterLowerChange(
+                              range,
+                              parsed,
+                              getAvailableGapsForRange(index),
+                            );
+                            setRangeAtIndex(index, normalized);
                           }
                         }}
                         onFocus={(e) => {
@@ -558,7 +595,12 @@ export default function NamespaceSelector({
                           }));
                           const parsed = Number.parseFloat(rawValue);
                           if (!Number.isNaN(parsed)) {
-                            setRangeAtIndex(index, [range[0], parsed]);
+                            const normalized = normalizeRangeAfterUpperChange(
+                              range,
+                              parsed,
+                              getAvailableGapsForRange(index),
+                            );
+                            setRangeAtIndex(index, normalized);
                           }
                         }}
                         onFocus={(e) => {

--- a/packages/front-end/components/Features/NamespaceSelector.tsx
+++ b/packages/front-end/components/Features/NamespaceSelector.tsx
@@ -161,7 +161,7 @@ export default function NamespaceSelector({
 
     return {
       filteredNamespaces: filtered,
-      namespaceOptions: activeNamespaces.map((n) => {
+      namespaceOptions: filtered.map((n) => {
         const isHashMismatch =
           !isFallbackMode &&
           !isLegacyNamespace(n) &&
@@ -203,13 +203,14 @@ export default function NamespaceSelector({
     });
   }, [namespace, ranges, persistedGaps]);
 
-  // Fires only on namespace change; ref avoids stale closure without making
-  // isOverlapping a dep (which would fire on every range edit).
+  // Fires on namespace change or when API data first loads. The ref avoids
+  // making isOverlapping itself a dep (which would fire on every range edit).
   const isOverlappingRef = useRef(isOverlapping);
   isOverlappingRef.current = isOverlapping;
+  const isDataLoaded = !!data;
   useEffect(() => {
     setAllowOverlap(isOverlappingRef.current);
-  }, [namespace]);
+  }, [namespace, isDataLoaded]);
 
   const effectiveGaps = useMemo(
     () => (allowOverlap ? [{ start: 0, end: 1 }] : persistedGaps),
@@ -528,7 +529,8 @@ export default function NamespaceSelector({
                 </Flex>
 
                 {ranges.map((range, index) => {
-                  const showDivider = ranges.length > 1;
+                  const showDivider =
+                    ranges.length > 1 && index < ranges.length - 1;
                   return (
                     <Flex
                       key={index}
@@ -622,6 +624,8 @@ export default function NamespaceSelector({
                           color="red"
                           radius="full"
                           size="2"
+                          mr="2"
+                          mt="4"
                           onClick={() => removeRange(index)}
                           aria-label="Remove range"
                         >

--- a/packages/front-end/components/Features/NamespaceSelectorUtils.ts
+++ b/packages/front-end/components/Features/NamespaceSelectorUtils.ts
@@ -184,3 +184,32 @@ export function trimDraftKeysToRangeLength(
     }),
   );
 }
+
+export function computeInUseIntervals(
+  gaps: { start: number; end: number }[],
+): RangeTuple[] {
+  const sorted = [...gaps].sort((a, b) => a.start - b.start);
+  const result: RangeTuple[] = [];
+  let cursor = 0;
+  for (const g of sorted) {
+    if (cursor < g.start) result.push([cursor, g.start]);
+    cursor = Math.max(cursor, g.end);
+  }
+  if (cursor < 1) result.push([cursor, 1]);
+  return result;
+}
+
+export function computeOverlapIntervals(
+  selectedRanges: RangeTuple[],
+  inUseIntervals: RangeTuple[],
+): RangeTuple[] {
+  const result: RangeTuple[] = [];
+  for (const [rs, re] of selectedRanges) {
+    for (const [is, ie] of inUseIntervals) {
+      const start = Math.max(rs, is);
+      const end = Math.min(re, ie);
+      if (start < end) result.push([start, end]);
+    }
+  }
+  return result;
+}

--- a/packages/front-end/components/Features/NamespaceUsageGraph.module.scss
+++ b/packages/front-end/components/Features/NamespaceUsageGraph.module.scss
@@ -27,10 +27,18 @@
 }
 
 .card {
+  position: relative;
   border: 1px solid var(--gray-a5);
   border-radius: 8px;
   padding: var(--space-4) var(--space-5);
   background-color: var(--color-panel-solid);
+}
+
+.overlapWarning {
+  position: absolute;
+  bottom: var(--space-2);
+  left: var(--space-5);
+  right: var(--space-5);
 }
 
 .legend_box {
@@ -40,6 +48,11 @@
   display: inline-block;
   vertical-align: middle;
   flex-shrink: 0;
+  box-shadow: 0 0 0 1.5px var(--ns-legend-outline);
+}
+
+.legend_active {
+  background-color: var(--violet-9);
   box-shadow: 0 0 0 1.5px var(--ns-legend-outline);
 }
 
@@ -130,6 +143,38 @@
   );
 }
 
+.overlapZone {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  pointer-events: none;
+  background-image: repeating-linear-gradient(
+    45deg,
+    transparent 0 4px,
+    var(--white-a4) 4px 8px
+  );
+}
+
+.goalpostTickOverlap {
+  position: absolute;
+  top: 0;
+  font-size: 8px;
+  line-height: 1;
+  color: var(--amber-9);
+  transform: translateX(-50%);
+  pointer-events: none;
+}
+
+.goalpostValueOverlap {
+  position: absolute;
+  top: 10px;
+  font-size: var(--font-size-1);
+  line-height: var(--line-height-1);
+  color: var(--amber-11);
+  transform: translateX(-50%);
+  pointer-events: none;
+}
+
 .rangeFocusedOverlay {
   position: absolute;
   top: 0;
@@ -141,14 +186,40 @@
 
 .labels_row {
   position: relative;
-  height: 18px;
+  height: 36px;
   margin-top: 4px;
 }
 
 .segmentLabel {
   position: absolute;
-  top: 0;
+  top: -1px;
   font-size: var(--font-size-1);
   line-height: var(--line-height-1);
   color: var(--color-text-low);
+  transform: translateX(-50%);
+}
+
+.segmentLabelActive {
+  color: var(--violet-11);
+  font-weight: var(--font-weight-medium);
+}
+
+.goalpostTick {
+  position: absolute;
+  top: 0;
+  font-size: 8px;
+  line-height: 1;
+  color: var(--violet-9);
+  transform: translateX(-50%);
+  pointer-events: none;
+}
+
+.goalpostValue {
+  position: absolute;
+  top: 10px;
+  font-size: var(--font-size-1);
+  line-height: var(--line-height-1);
+  color: var(--violet-11);
+  transform: translateX(-50%);
+  pointer-events: none;
 }

--- a/packages/front-end/components/Features/NamespaceUsageGraph.module.scss
+++ b/packages/front-end/components/Features/NamespaceUsageGraph.module.scss
@@ -111,24 +111,6 @@
       var(--ns-stripe-mid) 4px 8px
     );
   box-shadow: 0px 0px 2px 1px var(--slate-a3);
-
-  &::after {
-    content: "";
-    position: absolute;
-    inset: 0;
-    background-color: var(--violet-9);
-    background-image: linear-gradient(
-      to bottom,
-      var(--ns-active-shadow-top) 0px,
-      transparent 8px
-    );
-    opacity: 0;
-    transition: opacity 150ms ease;
-  }
-}
-
-.inUseActive::after {
-  opacity: 1;
 }
 
 .rangeSelected {

--- a/packages/front-end/components/Features/NamespaceUsageGraph.tsx
+++ b/packages/front-end/components/Features/NamespaceUsageGraph.tsx
@@ -17,7 +17,6 @@ const percentFormatter = new Intl.NumberFormat(undefined, {
 const decimalFormatter = new Intl.NumberFormat(undefined, {
   maximumFractionDigits: 2,
 });
-// Formats like 0.5 → ".5", 0.14 → ".14", 1 → "1"
 const formatDecimal = (n: number) =>
   decimalFormatter.format(n).replace(/^0\./, ".");
 
@@ -35,7 +34,6 @@ export interface Props {
 
 type Interval = [number, number];
 
-// Complement of `gaps` within [0, 1] — i.e. intervals that are in-use.
 function computeInUseIntervals(
   gaps: { start: number; end: number }[],
 ): Interval[] {
@@ -50,7 +48,6 @@ function computeInUseIntervals(
   return result;
 }
 
-// Portions of selectedRanges that overlap with inUseIntervals (other experiments).
 function computeOverlapIntervals(
   selectedRanges: Interval[],
   inUseIntervals: Interval[],
@@ -118,7 +115,6 @@ export default function NamespaceUsageGraph({
   if (!namespaces?.length) return null;
 
   const totalUsed = inUseIntervals.reduce((sum, [s, e]) => sum + (e - s), 0);
-  // Edit mode: show caller's selected sum; otherwise show namespace total.
   const headerTotal = ranges
     ? ranges.reduce((sum, [s, e]) => sum + (e - s), 0)
     : totalUsed;

--- a/packages/front-end/components/Features/NamespaceUsageGraph.tsx
+++ b/packages/front-end/components/Features/NamespaceUsageGraph.tsx
@@ -1,15 +1,25 @@
+import { Fragment, useMemo } from "react";
 import clsx from "clsx";
 import { Box, Flex } from "@radix-ui/themes";
 import { NamespaceUsage } from "shared/types/organization";
 import useOrgSettings from "@/hooks/useOrgSettings";
 import { findGaps } from "@/services/features";
+import HelperText from "@/ui/HelperText";
 import Text from "@/ui/Text";
+import { mergeContiguousRanges } from "./NamespaceSelectorUtils";
 import styles from "./NamespaceUsageGraph.module.scss";
 
 const percentFormatter = new Intl.NumberFormat(undefined, {
   style: "percent",
   maximumFractionDigits: 2,
 });
+
+const decimalFormatter = new Intl.NumberFormat(undefined, {
+  maximumFractionDigits: 2,
+});
+// Formats like 0.5 → ".5", 0.14 → ".14", 1 → "1"
+const formatDecimal = (n: number) =>
+  decimalFormatter.format(n).replace(/^0\./, ".");
 
 export interface Props {
   usage: NamespaceUsage;
@@ -40,6 +50,22 @@ function computeInUseIntervals(
   return result;
 }
 
+// Portions of selectedRanges that overlap with inUseIntervals (other experiments).
+function computeOverlapIntervals(
+  selectedRanges: Interval[],
+  inUseIntervals: Interval[],
+): Interval[] {
+  const result: Interval[] = [];
+  for (const [rs, re] of selectedRanges) {
+    for (const [is, ie] of inUseIntervals) {
+      const start = Math.max(rs, is);
+      const end = Math.min(re, ie);
+      if (start < end) result.push([start, end]);
+    }
+  }
+  return result;
+}
+
 const toPercent = (n: number) => `${+(n * 100).toFixed(4)}%`;
 
 export default function NamespaceUsageGraph({
@@ -55,19 +81,50 @@ export default function NamespaceUsageGraph({
 }: Props) {
   const { namespaces } = useOrgSettings();
 
+  const gaps = useMemo(
+    () => findGaps(usage, namespace, featureId, trackingKey),
+    [usage, namespace, featureId, trackingKey],
+  );
+  const selectedRanges: Interval[] = useMemo(
+    () => ranges ?? (range ? [range] : []),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [JSON.stringify(ranges), JSON.stringify(range)],
+  );
+  const inUseIntervals = useMemo(() => computeInUseIntervals(gaps), [gaps]);
+  const overlapIntervals = useMemo(
+    () => mergeContiguousRanges(computeOverlapIntervals(selectedRanges, inUseIntervals)),
+    [selectedRanges, inUseIntervals],
+  );
+  const overlappingCount = useMemo(
+    () =>
+      ranges
+        ? new Set(
+            (usage[namespace] ?? [])
+              .filter(
+                (e) =>
+                  e.id !== featureId &&
+                  e.trackingKey !== trackingKey &&
+                  selectedRanges.some(([rs, re]) => rs < e.end && e.start < re),
+              )
+              .map((e) => e.trackingKey || e.id),
+          ).size
+        : 0,
+    [ranges, usage, namespace, featureId, trackingKey, selectedRanges],
+  );
+
   if (!namespaces?.length) return null;
 
-  const gaps = findGaps(usage, namespace, featureId, trackingKey);
-  const selectedRanges: Interval[] = ranges ?? (range ? [range] : []);
-  const inUseIntervals = computeInUseIntervals(gaps);
   const totalUsed = inUseIntervals.reduce((sum, [s, e]) => sum + (e - s), 0);
   // Edit mode: show caller's selected sum; otherwise show namespace total.
   const headerTotal = ranges
     ? ranges.reduce((sum, [s, e]) => sum + (e - s), 0)
     : totalUsed;
 
+  // Only used in overview mode (range prop, no featureId exclusion) where
+  // in-use intervals include the hovered experiment's own range.
+  // In edit mode (ranges prop) the selected ranges are rendered separately.
   const isActive = (s: number, e: number) =>
-    selectedRanges.some(([rs, re]) => s < re && rs < e);
+    !ranges && selectedRanges.some(([rs, re]) => s < re && rs < e);
 
   const labeledSegments: Interval[] = ranges ? selectedRanges : inUseIntervals;
 
@@ -82,6 +139,14 @@ export default function NamespaceUsageGraph({
             ({percentFormatter.format(headerTotal)} total)
           </Text>
         </Box>
+        {ranges && (
+          <Flex align="center" gap="2">
+            <Box className={clsx(styles.legend_box, styles.legend_active)} />
+            <Text size="small" color="text-mid">
+              Active
+            </Text>
+          </Flex>
+        )}
         <Flex align="center" gap="2">
           <Box className={clsx(styles.legend_box, styles.legend_available)} />
           <Text size="small" color="text-mid">
@@ -134,6 +199,14 @@ export default function NamespaceUsageGraph({
                   }}
                 />
               ))}
+            {ranges &&
+              overlapIntervals.map(([s, e], i) => (
+                <div
+                  key={`overlap-${i}`}
+                  className={styles.overlapZone}
+                  style={{ left: toPercent(s), width: toPercent(e - s) }}
+                />
+              ))}
           </div>
           {focusedRangeIndex !== null && selectedRanges[focusedRangeIndex] && (
             <div
@@ -152,14 +225,86 @@ export default function NamespaceUsageGraph({
           {labeledSegments.map(([s, e], i) => (
             <span
               key={`label-${i}`}
-              className={styles.segmentLabel}
-              style={{ left: toPercent(s) }}
+              className={clsx(
+                styles.segmentLabel,
+                selectedRanges.length > 0 && styles.segmentLabelActive,
+              )}
+              style={{ left: toPercent((s + e) / 2) }}
             >
               {percentFormatter.format(e - s)}
             </span>
           ))}
+          {selectedRanges.length > 0 &&
+            selectedRanges.map(([s, e], i) => (
+              <Fragment key={`gp-${i}`}>
+                <span
+                  className={styles.goalpostTick}
+                  style={{ left: toPercent(s) }}
+                >
+                  |
+                </span>
+                <span
+                  className={styles.goalpostTick}
+                  style={{ left: toPercent(e) }}
+                >
+                  |
+                </span>
+                <span
+                  className={styles.goalpostValue}
+                  style={{ left: toPercent(s) }}
+                >
+                  {formatDecimal(s)}
+                </span>
+                <span
+                  className={styles.goalpostValue}
+                  style={{ left: toPercent(e) }}
+                >
+                  {formatDecimal(e)}
+                </span>
+              </Fragment>
+            ))}
+          {ranges &&
+            (() => {
+              const activeBoundaries = new Set(
+                selectedRanges.flatMap(([s, e]) => [
+                  +s.toFixed(4),
+                  +e.toFixed(4),
+                ]),
+              );
+              return overlapIntervals.flatMap(([s, e], i) =>
+                [
+                  [s, `ol-s-${i}`] as const,
+                  [e, `ol-e-${i}`] as const,
+                ]
+                  .filter(([v]) => !activeBoundaries.has(+v.toFixed(4)))
+                  .map(([v, key]) => (
+                    <Fragment key={key}>
+                      <span
+                        className={styles.goalpostTickOverlap}
+                        style={{ left: toPercent(v) }}
+                      >
+                        |
+                      </span>
+                      <span
+                        className={styles.goalpostValueOverlap}
+                        style={{ left: toPercent(v) }}
+                      >
+                        {formatDecimal(v)}
+                      </span>
+                    </Fragment>
+                  )),
+              );
+            })()}
         </div>
       </Box>
+      {overlappingCount > 0 && (
+        <div className={styles.overlapWarning}>
+          <HelperText status="warning" size="sm">
+            Active range overlaps with {overlappingCount}{" "}
+            {overlappingCount === 1 ? "experiment" : "experiments"}.
+          </HelperText>
+        </div>
+      )}
     </Box>
   );
 }

--- a/packages/front-end/components/Features/NamespaceUsageGraph.tsx
+++ b/packages/front-end/components/Features/NamespaceUsageGraph.tsx
@@ -92,7 +92,10 @@ export default function NamespaceUsageGraph({
   );
   const inUseIntervals = useMemo(() => computeInUseIntervals(gaps), [gaps]);
   const overlapIntervals = useMemo(
-    () => mergeContiguousRanges(computeOverlapIntervals(selectedRanges, inUseIntervals)),
+    () =>
+      mergeContiguousRanges(
+        computeOverlapIntervals(selectedRanges, inUseIntervals),
+      ),
     [selectedRanges, inUseIntervals],
   );
   const overlappingCount = useMemo(
@@ -120,13 +123,8 @@ export default function NamespaceUsageGraph({
     ? ranges.reduce((sum, [s, e]) => sum + (e - s), 0)
     : totalUsed;
 
-  // Only used in overview mode (range prop, no featureId exclusion) where
-  // in-use intervals include the hovered experiment's own range.
-  // In edit mode (ranges prop) the selected ranges are rendered separately.
-  const isActive = (s: number, e: number) =>
-    !ranges && selectedRanges.some(([rs, re]) => s < re && rs < e);
-
-  const labeledSegments: Interval[] = ranges ? selectedRanges : inUseIntervals;
+  const labeledSegments: Interval[] =
+    selectedRanges.length > 0 ? selectedRanges : inUseIntervals;
 
   return (
     <Box className={styles.card}>
@@ -166,10 +164,7 @@ export default function NamespaceUsageGraph({
             {inUseIntervals.map(([s, e], i) => (
               <div
                 key={`inuse-${i}`}
-                className={clsx(
-                  styles.inUse,
-                  isActive(s, e) && styles.inUseActive,
-                )}
+                className={styles.inUse}
                 style={{ left: toPercent(s), width: toPercent(e - s) }}
               />
             ))}
@@ -188,17 +183,16 @@ export default function NamespaceUsageGraph({
                   }}
                 />
               ))}
-            {ranges &&
-              selectedRanges.map((r, i) => (
-                <div
-                  key={`range-${i}`}
-                  className={styles.rangeSelected}
-                  style={{
-                    left: toPercent(r[0]),
-                    width: toPercent(r[1] - r[0]),
-                  }}
-                />
-              ))}
+            {selectedRanges.map((r, i) => (
+              <div
+                key={`range-${i}`}
+                className={styles.rangeSelected}
+                style={{
+                  left: toPercent(r[0]),
+                  width: toPercent(r[1] - r[0]),
+                }}
+              />
+            ))}
             {ranges &&
               overlapIntervals.map(([s, e], i) => (
                 <div
@@ -272,10 +266,7 @@ export default function NamespaceUsageGraph({
                 ]),
               );
               return overlapIntervals.flatMap(([s, e], i) =>
-                [
-                  [s, `ol-s-${i}`] as const,
-                  [e, `ol-e-${i}`] as const,
-                ]
+                [[s, `ol-s-${i}`] as const, [e, `ol-e-${i}`] as const]
                   .filter(([v]) => !activeBoundaries.has(+v.toFixed(4)))
                   .map(([v, key]) => (
                     <Fragment key={key}>

--- a/packages/front-end/components/Features/NamespaceUsageGraph.tsx
+++ b/packages/front-end/components/Features/NamespaceUsageGraph.tsx
@@ -6,7 +6,12 @@ import useOrgSettings from "@/hooks/useOrgSettings";
 import { findGaps } from "@/services/features";
 import HelperText from "@/ui/HelperText";
 import Text from "@/ui/Text";
-import { mergeContiguousRanges } from "./NamespaceSelectorUtils";
+import {
+  computeInUseIntervals,
+  computeOverlapIntervals,
+  mergeContiguousRanges,
+  type RangeTuple,
+} from "./NamespaceSelectorUtils";
 import styles from "./NamespaceUsageGraph.module.scss";
 
 const percentFormatter = new Intl.NumberFormat(undefined, {
@@ -32,37 +37,6 @@ export interface Props {
   title?: string;
 }
 
-type Interval = [number, number];
-
-function computeInUseIntervals(
-  gaps: { start: number; end: number }[],
-): Interval[] {
-  const sorted = [...gaps].sort((a, b) => a.start - b.start);
-  const result: Interval[] = [];
-  let cursor = 0;
-  for (const g of sorted) {
-    if (cursor < g.start) result.push([cursor, g.start]);
-    cursor = Math.max(cursor, g.end);
-  }
-  if (cursor < 1) result.push([cursor, 1]);
-  return result;
-}
-
-function computeOverlapIntervals(
-  selectedRanges: Interval[],
-  inUseIntervals: Interval[],
-): Interval[] {
-  const result: Interval[] = [];
-  for (const [rs, re] of selectedRanges) {
-    for (const [is, ie] of inUseIntervals) {
-      const start = Math.max(rs, is);
-      const end = Math.min(re, ie);
-      if (start < end) result.push([start, end]);
-    }
-  }
-  return result;
-}
-
 const toPercent = (n: number) => `${+(n * 100).toFixed(4)}%`;
 
 export default function NamespaceUsageGraph({
@@ -82,7 +56,7 @@ export default function NamespaceUsageGraph({
     () => findGaps(usage, namespace, featureId, trackingKey),
     [usage, namespace, featureId, trackingKey],
   );
-  const selectedRanges: Interval[] = useMemo(
+  const selectedRanges: RangeTuple[] = useMemo(
     () => ranges ?? (range ? [range] : []),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [JSON.stringify(ranges), JSON.stringify(range)],
@@ -119,7 +93,7 @@ export default function NamespaceUsageGraph({
     ? ranges.reduce((sum, [s, e]) => sum + (e - s), 0)
     : totalUsed;
 
-  const labeledSegments: Interval[] =
+  const labeledSegments: RangeTuple[] =
     selectedRanges.length > 0 ? selectedRanges : inUseIntervals;
 
   return (

--- a/packages/front-end/components/Settings/NamespaceTableRow.tsx
+++ b/packages/front-end/components/Settings/NamespaceTableRow.tsx
@@ -1,5 +1,5 @@
 import { Namespaces, NamespaceUsage } from "shared/types/organization";
-import { Box, IconButton } from "@radix-ui/themes";
+import { Box, Flex, IconButton } from "@radix-ui/themes";
 import { MouseEventHandler, useMemo, useState } from "react";
 import { BsThreeDotsVertical } from "react-icons/bs";
 import { findGaps } from "@/services/features";
@@ -11,6 +11,7 @@ import {
   DropdownMenuItem,
 } from "@/ui/DropdownMenu";
 import Badge from "@/ui/Badge";
+import HelperText from "@/ui/HelperText";
 import Text from "@/ui/Text";
 import Link from "@/ui/Link";
 import Table, {
@@ -211,19 +212,35 @@ export default function NamespaceTableRow({
                 <TableHeader>
                   <TableRow>
                     <TableColumnHeader>Experiment</TableColumnHeader>
-                    <TableColumnHeader>Environment</TableColumnHeader>
                     <TableColumnHeader>Tracking Key</TableColumnHeader>
-                    <TableColumnHeader>Range</TableColumnHeader>
+                    <TableColumnHeader style={{ width: 300 }}>
+                      Range
+                    </TableColumnHeader>
                   </TableRow>
                 </TableHeader>
                 <TableBody onMouseLeave={() => setHoverRange(null)}>
-                  {[...experiments]
-                    .sort((a, b) => {
+                  {(() => {
+                    const sorted = [...experiments].sort((a, b) => {
                       const ka = `${a.link}|${a.trackingKey || a.id}`;
                       const kb = `${b.link}|${b.trackingKey || b.id}`;
                       return ka.localeCompare(kb);
-                    })
-                    .map((e, i, sorted) => {
+                    });
+                    // Mark which rows have ranges overlapping another experiment.
+                    const overlappingIndices = new Set(
+                      sorted.flatMap((e, i) =>
+                        sorted.some(
+                          (f, j) =>
+                            j !== i &&
+                            (f.trackingKey || f.id) !==
+                              (e.trackingKey || e.id) &&
+                            e.start < f.end &&
+                            f.start < e.end,
+                        )
+                          ? [i]
+                          : [],
+                      ),
+                    );
+                    return sorted.map((e, i) => {
                       const key = `${e.link}|${e.trackingKey || e.id}`;
                       const prevKey =
                         i > 0
@@ -249,16 +266,33 @@ export default function NamespaceTableRow({
                               </Link>
                             ) : null}
                           </TableCell>
-                          <TableCell>{e.environment}</TableCell>
                           <TableCell>
                             {isFirstInGroup ? e.trackingKey || e.id : null}
                           </TableCell>
                           <TableCell>
-                            {e.start} to {e.end}
+                            <Flex align="center" justify="between" gap="2">
+                              <Text>
+                                {e.start} to {e.end}
+                                {hoverRange?.[0] === e.start &&
+                                  hoverRange?.[1] === e.end && (
+                                    <Text
+                                      as="span"
+                                      color="text-mid"
+                                      ml="2"
+                                    >{`(${Math.round((e.end - e.start) * 100)}%)`}</Text>
+                                  )}
+                              </Text>
+                              {overlappingIndices.has(i) && (
+                                <HelperText status="warning" size="sm">
+                                  Ranges overlap
+                                </HelperText>
+                              )}
+                            </Flex>
                           </TableCell>
                         </TableRow>
                       );
-                    })}
+                    });
+                  })()}
                 </TableBody>
               </Table>
             ) : (

--- a/packages/front-end/components/Settings/NamespaceTableRow.tsx
+++ b/packages/front-end/components/Settings/NamespaceTableRow.tsx
@@ -46,8 +46,6 @@ export default function NamespaceTableRow({
     () => usage[namespace.name] ?? [],
     [usage, namespace.name],
   );
-  // Count each feature-rule / experiment once regardless of how many ranges
-  // it reserves inside the namespace.
   const uniqueExperimentCount = useMemo(() => {
     const seen = new Set<string>();
     for (const e of experiments) {
@@ -55,6 +53,41 @@ export default function NamespaceTableRow({
     }
     return seen.size;
   }, [experiments]);
+
+  const availablePercent = useMemo(
+    () =>
+      findGaps(usage, namespace.name).reduce(
+        (sum, r) => sum + (r.end - r.start),
+        0,
+      ),
+    [usage, namespace.name],
+  );
+  const sortedExperiments = useMemo(
+    () =>
+      [...experiments].sort((a, b) => {
+        const ka = `${a.link}|${a.trackingKey || a.id}`;
+        const kb = `${b.link}|${b.trackingKey || b.id}`;
+        return ka.localeCompare(kb);
+      }),
+    [experiments],
+  );
+  const overlappingIndices = useMemo(
+    () =>
+      new Set(
+        sortedExperiments.flatMap((e, i) =>
+          sortedExperiments.some(
+            (f, j) =>
+              j !== i &&
+              (f.trackingKey || f.id) !== (e.trackingKey || e.id) &&
+              e.start < f.end &&
+              f.start < e.end,
+          )
+            ? [i]
+            : [],
+        ),
+      ),
+    [sortedExperiments],
+  );
 
   const permissionsUtil = usePermissionsUtil();
   const canEdit = permissionsUtil.canUpdateNamespace();
@@ -104,12 +137,7 @@ export default function NamespaceTableRow({
         <TableCell onClick={toggleExpand} justify="end">
           <Box pr="2">
             <Text color={isInactive ? "text-mid" : undefined}>
-              {percentFormatter.format(
-                findGaps(usage, namespace.name).reduce(
-                  (sum, r) => sum + (r.end - r.start),
-                  0,
-                ),
-              )}
+              {percentFormatter.format(availablePercent)}
             </Text>
           </Box>
         </TableCell>
@@ -219,80 +247,50 @@ export default function NamespaceTableRow({
                   </TableRow>
                 </TableHeader>
                 <TableBody onMouseLeave={() => setHoverRange(null)}>
-                  {(() => {
-                    const sorted = [...experiments].sort((a, b) => {
-                      const ka = `${a.link}|${a.trackingKey || a.id}`;
-                      const kb = `${b.link}|${b.trackingKey || b.id}`;
-                      return ka.localeCompare(kb);
-                    });
-                    // Mark which rows have ranges overlapping another experiment.
-                    const overlappingIndices = new Set(
-                      sorted.flatMap((e, i) =>
-                        sorted.some(
-                          (f, j) =>
-                            j !== i &&
-                            (f.trackingKey || f.id) !==
-                              (e.trackingKey || e.id) &&
-                            e.start < f.end &&
-                            f.start < e.end,
-                        )
-                          ? [i]
-                          : [],
-                      ),
-                    );
-                    return sorted.map((e, i) => {
-                      const key = `${e.link}|${e.trackingKey || e.id}`;
-                      const prevKey =
-                        i > 0
-                          ? `${sorted[i - 1].link}|${sorted[i - 1].trackingKey || sorted[i - 1].id}`
-                          : null;
-                      const nextKey =
-                        i < sorted.length - 1
-                          ? `${sorted[i + 1].link}|${sorted[i + 1].trackingKey || sorted[i + 1].id}`
-                          : null;
-                      const isFirstInGroup = key !== prevKey;
-                      const isLastInGroup = key !== nextKey;
+                  {sortedExperiments.map((e, i) => {
+                    const key = `${e.link}|${e.trackingKey || e.id}`;
+                    const prevKey =
+                      i > 0
+                        ? `${sortedExperiments[i - 1].link}|${sortedExperiments[i - 1].trackingKey || sortedExperiments[i - 1].id}`
+                        : null;
+                    const nextKey =
+                      i < sortedExperiments.length - 1
+                        ? `${sortedExperiments[i + 1].link}|${sortedExperiments[i + 1].trackingKey || sortedExperiments[i + 1].id}`
+                        : null;
+                    const isFirstInGroup = key !== prevKey;
+                    const isLastInGroup = key !== nextKey;
 
-                      return (
-                        <TableRow
-                          key={i}
-                          onMouseEnter={() => setHoverRange([e.start, e.end])}
-                          data-group-inner={!isLastInGroup ? "" : undefined}
-                        >
-                          <TableCell>
-                            {isFirstInGroup ? (
-                              <Link href={e.link} target="_blank">
-                                {e.name}
-                              </Link>
-                            ) : null}
-                          </TableCell>
-                          <TableCell>
-                            {isFirstInGroup ? e.trackingKey || e.id : null}
-                          </TableCell>
-                          <TableCell>
-                            <Flex align="center" justify="between" gap="2">
-                              <Text>
-                                {e.start} to {e.end}
-                                {hoverRange?.[0] === e.start &&
-                                  hoverRange?.[1] === e.end && (
-                                    <Text
-                                      as="span"
-                                      color="text-mid"
-                                      ml="2"
-                                    >{`(${Math.round((e.end - e.start) * 100)}%)`}</Text>
-                                  )}
-                              </Text>
-                              {overlappingIndices.has(i) && (
-                                <HelperText status="warning" size="sm">
-                                  Ranges overlap
-                                </HelperText>
-                              )}
-                            </Flex>
-                          </TableCell>
-                        </TableRow>
-                      );
-                    });
-                  })()}
+                    return (
+                      <TableRow
+                        key={i}
+                        onMouseEnter={() => setHoverRange([e.start, e.end])}
+                        data-group-inner={!isLastInGroup ? "" : undefined}
+                      >
+                        <TableCell>
+                          {isFirstInGroup ? (
+                            <Link href={e.link} target="_blank">
+                              {e.name}
+                            </Link>
+                          ) : null}
+                        </TableCell>
+                        <TableCell>
+                          {isFirstInGroup ? e.trackingKey || e.id : null}
+                        </TableCell>
+                        <TableCell>
+                          <Flex align="center" justify="between" gap="2">
+                            <Text>
+                              {e.start} to {e.end}
+                            </Text>
+                            {overlappingIndices.has(i) && (
+                              <HelperText status="warning" size="sm">
+                                Ranges overlap
+                              </HelperText>
+                            )}
+                          </Flex>
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
                 </TableBody>
               </Table>
             ) : (


### PR DESCRIPTION
Sometimes it's actually ok to let namespace ranges overlap. Adds opt-in checkbox and UI support for this use case

<img width="764" height="459" alt="image" src="https://github.com/user-attachments/assets/1ea82eb8-a4bc-4050-aa17-5980984a7631" />

<img width="1376" height="786" alt="image" src="https://github.com/user-attachments/assets/9c39ea30-842f-421a-9089-7e7eaae5951d" />
