### PR TITLE
Product Analytics - "Show As" toggle 

### DIFF
--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -13707,6 +13707,11 @@ paths:
                                     required:
                                       - predefined
                                     additionalProperties: false
+                                  showAs:
+                                    type: string
+                                    enum:
+                                      - total
+                                      - per_unit
                                   type:
                                     type: string
                                     const: metric
@@ -13988,6 +13993,11 @@ paths:
                                     required:
                                       - predefined
                                     additionalProperties: false
+                                  showAs:
+                                    type: string
+                                    enum:
+                                      - total
+                                      - per_unit
                                   type:
                                     type: string
                                     const: fact_table
@@ -14278,6 +14288,11 @@ paths:
                                     required:
                                       - predefined
                                     additionalProperties: false
+                                  showAs:
+                                    type: string
+                                    enum:
+                                      - total
+                                      - per_unit
                                   type:
                                     type: string
                                     const: data_source
@@ -16647,6 +16662,11 @@ paths:
                   required:
                     - predefined
                   additionalProperties: false
+                showAs:
+                  type: string
+                  enum:
+                    - total
+                    - per_unit
                 type:
                   type: string
                   const: metric
@@ -16979,6 +16999,11 @@ paths:
                                 required:
                                   - predefined
                                 additionalProperties: false
+                              showAs:
+                                type: string
+                                enum:
+                                  - total
+                                  - per_unit
                               type:
                                 type: string
                                 const: metric
@@ -17280,6 +17305,11 @@ paths:
                   required:
                     - predefined
                   additionalProperties: false
+                showAs:
+                  type: string
+                  enum:
+                    - total
+                    - per_unit
                 type:
                   type: string
                   const: fact_table
@@ -17621,6 +17651,11 @@ paths:
                                 required:
                                   - predefined
                                 additionalProperties: false
+                              showAs:
+                                type: string
+                                enum:
+                                  - total
+                                  - per_unit
                               type:
                                 type: string
                                 const: fact_table
@@ -17931,6 +17966,11 @@ paths:
                   required:
                     - predefined
                   additionalProperties: false
+                showAs:
+                  type: string
+                  enum:
+                    - total
+                    - per_unit
                 type:
                   type: string
                   const: data_source
@@ -18289,6 +18329,11 @@ paths:
                                 required:
                                   - predefined
                                 additionalProperties: false
+                              showAs:
+                                type: string
+                                enum:
+                                  - total
+                                  - per_unit
                               type:
                                 type: string
                                 const: data_source
@@ -24640,6 +24685,11 @@ components:
                         required:
                           - predefined
                         additionalProperties: false
+                      showAs:
+                        type: string
+                        enum:
+                          - total
+                          - per_unit
                       type:
                         type: string
                         const: metric
@@ -24921,6 +24971,11 @@ components:
                         required:
                           - predefined
                         additionalProperties: false
+                      showAs:
+                        type: string
+                        enum:
+                          - total
+                          - per_unit
                       type:
                         type: string
                         const: fact_table
@@ -25211,6 +25266,11 @@ components:
                         required:
                           - predefined
                         additionalProperties: false
+                      showAs:
+                        type: string
+                        enum:
+                          - total
+                          - per_unit
                       type:
                         type: string
                         const: data_source
@@ -26345,6 +26405,11 @@ components:
                   required:
                     - predefined
                   additionalProperties: false
+                showAs:
+                  type: string
+                  enum:
+                    - total
+                    - per_unit
                 type:
                   type: string
                   const: metric
@@ -26596,6 +26661,11 @@ components:
                   required:
                     - predefined
                   additionalProperties: false
+                showAs:
+                  type: string
+                  enum:
+                    - total
+                    - per_unit
                 type:
                   type: string
                   const: fact_table
@@ -26856,6 +26926,11 @@ components:
                   required:
                     - predefined
                   additionalProperties: false
+                showAs:
+                  type: string
+                  enum:
+                    - total
+                    - per_unit
                 type:
                   type: string
                   const: data_source

--- a/packages/back-end/src/enterprise/services/product-analytics-agent.ts
+++ b/packages/back-end/src/enterprise/services/product-analytics-agent.ts
@@ -14,6 +14,13 @@ import {
   FactMetricInterface,
   FactTableInterface,
 } from "shared/types/fact-table";
+import {
+  clearInapplicableShowAs,
+  getEffectiveShowAs,
+  getIsRatioByIndex,
+  buildExplorationColumns,
+  getExplorationCellValue,
+} from "shared/enterprise";
 import type { ReqContext } from "back-end/types/request";
 import { runProductAnalyticsExploration } from "back-end/src/enterprise/services/product-analytics";
 import { aiTool } from "back-end/src/enterprise/services/ai";
@@ -76,9 +83,27 @@ For cumulative charts, include 0 dimensions by default — just show the total.
 Always follow the unitNote returned by getAvailableColumns:
 - fact_table valueType "unit_count": set unit to userIdTypes[0] (e.g. "user_id") unless user specifies otherwise.
 - fact_table valueType "count" or "sum": unit must be null.
-- metric: set unit for proportion, retention, dailyParticipation, and ratio-distinct metrics using userIdTypes[0]; null for all others.
+- metric: always set unit to userIdTypes[0] for standard metric types (mean, proportion, retention, dailyParticipation). The backend requires a unit to emit the denominator needed for per-unit rendering. For ratio and quantile metrics, leave unit null (they handle units internally).
 - denominatorUnit: always null.
+
+If you omit unit on a standard metric, the backend will fill in userIdTypes[0] automatically and return a configNormalized warning. Prefer setting it explicitly.
 </unit_rules>
+
+<show_as_rules>
+showAs is an optional top-level field that toggles how numeric values are rendered: "total" shows the raw numerator, "per_unit" divides by the unit count (e.g. avg per user).
+
+DEFAULT: Omit showAs in almost all cases. The UI infers a sensible default from the selected metrics — totals for most datasets, per-unit only for mean metrics whose aggregation makes totals incoherent (max, count distinct).
+
+SET showAs explicitly ONLY when the user's request clearly asks for one view:
+- "per user", "per device", "average per X", "rate" → "per_unit"
+- "total X", "sum of X", "how much X did we have" → "total"
+
+showAs has no effect on these dataset types — do not set it:
+- fact_table / data_source datasets (always renders as the raw value)
+- metric datasets where every value is a proportion, retention, dailyParticipation, ratio, or quantile metric (the toggle is hidden in the UI because per-unit is either degenerate or self-contained)
+
+Set showAs only when at least one value is a mean metric.
+</show_as_rules>
 
 <value_column_rules>
 For fact_table values:
@@ -115,6 +140,11 @@ CRITICAL search strategy:
 <tool_notes>
 runExploration returns resultCsv, config, snapshotId, and rowCount. Use resultCsv for analysis and insights. The chart is displayed automatically — do not embed config JSON in your text.
 getSnapshot retrieves config and CSV for older/compacted snapshots by snapshotId. Prefer the runExploration return value for the current run.
+
+resultCsv column conventions (so you describe the same numbers the user sees on the chart):
+- Standard metric columns: one value column per metric. The header tells you the mode — "<name>" means raw totals, "<name> per <unit>" means per-unit averages (the value is numerator/denominator). Report the numbers in the header's mode.
+- Ratio metric columns: three columns — "<name> Numerator", "<name> Denominator", "<name> Value" (= N/D). Ratio metrics always render as N/D.
+- The column headers reflect the effective showAs (explicit if you set it, otherwise the UI-inferred default). Never assume a different mode than what the header says.
 </tool_notes>
 
 <response_style>
@@ -185,7 +215,7 @@ export function findSnapshot(
 function buildConfigSchemaSummary(): string {
   return [
     "<config_schema>",
-    "Top-level: { type, datasource, chartType, dateRange, dimensions, dataset }",
+    "Top-level: { type, datasource, chartType, dateRange, dimensions, dataset, showAs? }",
     'type: "metric" | "fact_table"',
     'chartType: "line" | "area" | "timeseries-table" | "table" | "bar" | "stackedBar" | "horizontalBar" | "stackedHorizontalBar" | "bigNumber"',
     "dateRange: { predefined, lookbackValue?, lookbackUnit?, startDate?, endDate? }",
@@ -196,6 +226,7 @@ function buildConfigSchemaSummary(): string {
     'dataset for type="metric": { type: "metric", values: [{ type: "metric", name, metricId, unit, denominatorUnit, rowFilters }] }',
     'dataset for type="fact_table": { type: "fact_table", factTableId, values: [{ type: "fact_table", name, valueType: "unit_count"|"count"|"sum", valueColumn, unit, rowFilters }] }',
     'rowFilters: [{ operator: "="|"!="|"in"|"not_in"|"contains"|"not_contains"|"starts_with"|"ends_with"|"is_null"|"not_null", column: string, values: string[] }]',
+    'showAs (optional): "total" | "per_unit" — chart-level toggle between raw totals and per-unit averages for mean metrics. Omit to use the smart default (see show_as_rules).',
     "Always pass a complete config object to runExploration.",
     "</config_schema>",
   ].join("\n");
@@ -214,6 +245,9 @@ function buildSnapshotSummary(
     const valueNames = curr.dataset?.values?.map((v) => v.name).filter(Boolean);
     if (valueNames?.length) {
       parts.push(`values: ${valueNames.join(", ")}`);
+    }
+    if (curr.showAs) {
+      parts.push(`showAs: ${curr.showAs}`);
     }
     return parts.join(", ");
   }
@@ -244,82 +278,81 @@ function buildSnapshotSummary(
     parts.push("datasource changed");
   }
 
+  if ((prev.showAs ?? null) !== (curr.showAs ?? null)) {
+    parts.push(
+      `showAs: ${prev.showAs ?? "inferred"} → ${curr.showAs ?? "inferred"}`,
+    );
+  }
+
   return parts.length ? parts.join(", ") : "minor config update";
 }
 
+/**
+ * Serialize exploration result rows into a CSV for the agent. Column schema
+ * and per-cell value selection are produced by the shared helpers that also
+ * drive the Explorer result table, so the agent always sees the same columns
+ * and the same numbers the user sees on screen.
+ *
+ * Display-layer concerns (number precision, date formatting, the "Total"
+ * dimension fallback) are handled here — each surface is free to format how
+ * it prefers, but the underlying column set and cell values are identical.
+ */
 function buildResultCsv(
   rows: ProductAnalyticsResultRow[],
   config: ExplorationConfig | null,
+  getFactMetricById: (id: string) => FactMetricInterface | null,
 ): string | null {
   if (!rows.length || !config) return null;
 
-  const dimHeaders: string[] = (config.dimensions ?? []).map((d) => {
-    if (d.dimensionType === "date") return "Date";
-    if (d.dimensionType === "dynamic") return d.column ?? "Dimension";
-    if (d.dimensionType === "static") return d.column;
-    if (d.dimensionType === "slice") return "Slice";
-    return "Dimension";
-  });
-  if (!dimHeaders.length) dimHeaders.push("Total");
+  const columns = buildExplorationColumns(config, getFactMetricById);
+  if (columns.length === 0) return null;
 
-  const valueNames = config.dataset?.values?.map((v) => v.name) ?? [];
-  const hasDenom = valueNames.map((_, i) =>
-    rows.some((r) => r.values[i]?.denominator != null),
-  );
+  const renderOpts = {
+    showAs: getEffectiveShowAs(config, getFactMetricById),
+    isRatioByIndex: getIsRatioByIndex(config, getFactMetricById),
+  };
 
-  const metricHeaders: string[] = [];
-  for (let i = 0; i < valueNames.length; i++) {
-    if (hasDenom[i]) {
-      metricHeaders.push(
-        `${valueNames[i]} Numerator`,
-        `${valueNames[i]} Denominator`,
-        `${valueNames[i]} Value`,
-      );
-    } else {
-      metricHeaders.push(valueNames[i]);
+  const hasNoDimensions = !config.dimensions || config.dimensions.length === 0;
+
+  const escape = (c: string): string =>
+    c.includes('"') || c.includes(",") || c.includes("\n")
+      ? `"${c.replace(/"/g, '""')}"`
+      : c;
+
+  const formatCell = (
+    raw: string | number | null,
+    col: (typeof columns)[number],
+  ): string => {
+    if (col.kind === "dimension") {
+      if (raw == null || raw === "") return hasNoDimensions ? "Total" : "";
+      return typeof raw === "number" ? String(raw) : raw;
     }
-  }
+    if (raw == null) return "";
+    if (col.sub === "numerator" || col.sub === "denominator") {
+      return typeof raw === "number" ? String(raw) : String(raw);
+    }
+    // value (ratio) and single: 4dp for ratios/per-unit, integer for totals.
+    if (typeof raw === "number") {
+      const isRatioOrPerUnit =
+        col.sub === "value" ||
+        (col.sub === "single" && renderOpts.isRatioByIndex[col.metricIndex]) ||
+        (col.sub === "single" && renderOpts.showAs === "per_unit");
+      return isRatioOrPerUnit ? raw.toFixed(4) : String(raw);
+    }
+    return String(raw);
+  };
 
-  const header = [...dimHeaders, ...metricHeaders].join(",");
+  const header = columns.map((c) => escape(c.label)).join(",");
 
   const truncated = rows.slice(0, MAX_RESULT_ROWS);
-  const dataLines = truncated.map((row) => {
-    const dimCells =
-      dimHeaders.length === 1 && dimHeaders[0] === "Total"
-        ? ["Total"]
-        : row.dimensions.map((d) => d ?? "");
-
-    const metricCells: string[] = [];
-    for (let i = 0; i < valueNames.length; i++) {
-      const v = row.values[i];
-      if (hasDenom[i]) {
-        metricCells.push(
-          v?.numerator != null ? String(v.numerator) : "",
-          v?.denominator != null ? String(v.denominator) : "",
-          v?.numerator != null && v?.denominator != null
-            ? (v.numerator / v.denominator).toFixed(4)
-            : "",
-        );
-      } else {
-        const val =
-          v?.numerator != null
-            ? v.denominator
-              ? (v.numerator / v.denominator).toFixed(4)
-              : String(v.numerator)
-            : "";
-        metricCells.push(val);
-      }
-    }
-
-    return [...dimCells, ...metricCells]
-      .map((c) => {
-        if (c.includes('"') || c.includes(",") || c.includes("\n")) {
-          return `"${c.replace(/"/g, '""')}"`;
-        }
-        return c;
+  const dataLines = truncated.map((row) =>
+    columns
+      .map((col) => {
+        const raw = getExplorationCellValue(row, col, renderOpts);
+        return escape(formatCell(raw, col));
       })
-      .join(",");
-  });
+      .join(","),
+  );
 
   let csv = [header, ...dataLines].join("\n");
   if (rows.length > MAX_RESULT_ROWS) {
@@ -528,11 +561,18 @@ const TIMESERIES_CHART_TYPES = new Set(["line", "area", "timeseries-table"]);
 interface NormalizeResult {
   config: ExplorationConfig;
   warnings: string[];
+  /**
+   * Metric resolver derived from the metrics already fetched during
+   * normalization. Reused by the CSV writer so we don't reload metrics.
+   * Returns null for metric IDs not referenced by this config.
+   */
+  getFactMetricById: (id: string) => FactMetricInterface | null;
 }
 
-function normalizeConfigForExplorer(
+async function normalizeConfigForExplorer(
+  ctx: ReqContext,
   config: ExplorationConfig,
-): NormalizeResult {
+): Promise<NormalizeResult> {
   const warnings: string[] = [];
   let dims = config.dimensions;
   let dataset = config.dataset;
@@ -614,9 +654,93 @@ function normalizeConfigForExplorer(
     );
   }
 
+  // Load every referenced fact metric once. This map serves both the unit
+  // backfill below and the CSV writer downstream — no second round-trip.
+  const referencedMetricIds =
+    dataset.type === "metric"
+      ? Array.from(
+          new Set(
+            dataset.values
+              .map((v) => v.metricId)
+              .filter((id): id is string => !!id),
+          ),
+        )
+      : [];
+  const referencedMetrics = referencedMetricIds.length
+    ? await ctx.models.factMetrics.getByIds(referencedMetricIds)
+    : [];
+  const metricById = new Map(referencedMetrics.map((m) => [m.id, m]));
+  const getFactMetricByIdResolver = (id: string) => metricById.get(id) ?? null;
+
+  // Backfill missing units for metric values so the SQL layer emits a
+  // denominator and per_unit rendering works. The agent often omits `unit`
+  // even when it should be set; default to the numerator fact table's primary
+  // userIdType. Only applies to metric datasets — fact_table/data_source
+  // datasets have user-driven unit semantics.
+  if (dataset.type === "metric") {
+    const needsUnit = dataset.values.some(
+      (v) => !v.unit && v.metricId && metricById.has(v.metricId),
+    );
+
+    if (needsUnit) {
+      const factTableIds = Array.from(
+        new Set(
+          dataset.values
+            .filter((v) => !v.unit && v.metricId)
+            .map((v) => metricById.get(v.metricId!)?.numerator.factTableId)
+            .filter((id): id is string => !!id),
+        ),
+      );
+      const factTables = await Promise.all(
+        factTableIds.map((id) => getFactTable(ctx, id)),
+      );
+      const factTableById = new Map(
+        factTables
+          .filter((ft): ft is FactTableInterface => !!ft)
+          .map((ft) => [ft.id, ft]),
+      );
+
+      let filledCount = 0;
+      const newValues = dataset.values.map((v) => {
+        if (v.unit || !v.metricId) return v;
+        const metric = metricById.get(v.metricId);
+        if (!metric) return v;
+        const factTable = factTableById.get(metric.numerator.factTableId);
+        const defaultUnit = factTable?.userIdTypes?.[0];
+        if (!defaultUnit) return v;
+        filledCount++;
+        return { ...v, unit: defaultUnit };
+      });
+
+      if (filledCount > 0) {
+        dataset = { ...dataset, values: newValues } as typeof dataset;
+        warnings.push(
+          `Filled in default unit (userIdTypes[0] from the metric's fact table) for ${filledCount} metric value(s) where unit was missing. Set unit explicitly for standard metrics (mean, proportion, retention, dailyParticipation) to avoid this.`,
+        );
+      }
+    }
+  }
+
+  let normalized = {
+    ...config,
+    dimensions: dims,
+    dataset,
+  } as ExplorationConfig;
+
+  // Strip `showAs` when the current dataset doesn't support it, so we never
+  // persist a value that disagrees with what the chart will actually render.
+  const beforeShowAs = normalized.showAs;
+  normalized = clearInapplicableShowAs(normalized, getFactMetricByIdResolver);
+  if (beforeShowAs !== undefined && normalized.showAs === undefined) {
+    warnings.push(
+      `Dropped showAs="${beforeShowAs}" — it doesn't apply to this dataset (only meaningful for mean metrics). The chart will render totals.`,
+    );
+  }
+
   return {
-    config: { ...config, dimensions: dims, dataset } as ExplorationConfig,
+    config: normalized,
     warnings,
+    getFactMetricById: getFactMetricByIdResolver,
   };
 }
 
@@ -626,7 +750,8 @@ async function executeRunExploration(
   rawConfig: ExplorationConfig,
 ): Promise<RunExplorationToolResult> {
   try {
-    const { config, warnings } = normalizeConfigForExplorer(rawConfig);
+    const { config, warnings, getFactMetricById } =
+      await normalizeConfigForExplorer(ctx, rawConfig);
     const exploration = await runProductAnalyticsExploration(ctx, config, {
       cache: "preferred",
     });
@@ -642,7 +767,11 @@ async function executeRunExploration(
       buffer.getLatestToolResult("runExploration"),
     );
     const summary = buildSnapshotSummary(prevConfig, config);
-    const resultCsv = buildResultCsv(exploration?.result?.rows ?? [], config);
+    const resultCsv = buildResultCsv(
+      exploration?.result?.rows ?? [],
+      config,
+      getFactMetricById,
+    );
 
     const snapshotId = nextSnapshotId(buffer);
     const rowCount = exploration?.result?.rows?.length ?? 0;

--- a/packages/front-end/components/Settings/DisplayTestQueryResults.tsx
+++ b/packages/front-end/components/Settings/DisplayTestQueryResults.tsx
@@ -29,6 +29,12 @@ export type Props = {
   showDuration?: boolean;
   headerStructure?: HeaderStructure;
   orderedColumnKeys?: string[];
+  /**
+   * Display labels aligned with `orderedColumnKeys`. When omitted, the keys
+   * themselves are used as labels (back-compat for existing callers that
+   * pass human-readable keys).
+   */
+  columnLabels?: string[];
   paddingTop?: number;
   showNoRowsWarning?: boolean;
 };
@@ -46,11 +52,13 @@ export default function DisplayTestQueryResults({
   showDuration = true,
   headerStructure,
   orderedColumnKeys,
+  columnLabels,
   paddingTop = 0,
   showNoRowsWarning = true,
 }: Props) {
   const [downloadError, setDownloadError] = useState<string | null>(null);
   const cols = orderedColumnKeys ?? Object.keys(results?.[0] || {});
+  const labels = columnLabels ?? cols;
   const useTwoRowHeader = headerStructure != null && orderedColumnKeys != null;
 
   const forceShowSql = error || !results.length;
@@ -70,7 +78,21 @@ export default function DisplayTestQueryResults({
     : undefined;
 
   function handleDownload(results: Record<string, unknown>[]) {
-    const csv = convertToCSV(results);
+    // When the caller passes stable keys + separate labels, rewrite each row
+    // so the CSV column headers (derived from Object.keys) are the display
+    // labels. Otherwise fall through unchanged — the key *is* the label.
+    const rowsForCsv =
+      columnLabels && orderedColumnKeys
+        ? results.map((row) =>
+            Object.fromEntries(
+              orderedColumnKeys.map((key, i) => [
+                columnLabels[i] ?? key,
+                row[key],
+              ]),
+            ),
+          )
+        : results;
+    const csv = convertToCSV(rowsForCsv);
     if (!csv) {
       throw new Error(
         "Error downloading results. Reason: Unable to convert results to CSV.",
@@ -246,8 +268,8 @@ export default function DisplayTestQueryResults({
                     </>
                   ) : (
                     <tr>
-                      {cols.map((col) => (
-                        <th key={col}>{col}</th>
+                      {cols.map((col, i) => (
+                        <th key={col}>{labels[i] ?? col}</th>
                       ))}
                     </tr>
                   )}

--- a/packages/front-end/enterprise/components/ProductAnalytics/AIChat/ChatMessageList.tsx
+++ b/packages/front-end/enterprise/components/ProductAnalytics/AIChat/ChatMessageList.tsx
@@ -157,22 +157,32 @@ export default function ChatMessageList({
   );
 
   // Preserve the user's expanded/collapsed toggle across the active→persisted
-  // transition so it doesn't snap shut when the turn ends.
+  // transition so it doesn't snap shut when the turn ends. The active
+  // CollapsedSteps writes to this ref via onToggle, and the persisted
+  // CollapsedSteps reads from it on mount via defaultExpanded.
+  //
+  // We can't rely on a single-render "just finished turn" signal because
+  // setMessages (from syncMessagesFromServer) and setActive([]) don't always
+  // render in the same frame — the persisted CollapsedSteps can mount while
+  // activeTurnItems is still non-empty, picking up the wrong defaultExpanded.
+  // Instead, we keep the ref hot and reset it only when a fresh user turn
+  // begins, so it's stable across whichever render order React picks.
   const stepsExpandedRef = React.useRef(false);
-  const prevCollapsedCountRef = React.useRef(0);
 
-  // Detect the single render where collapsed active items transition to
-  // persisted messages (turn just ended). Only on that render do we carry the
-  // user's expanded state to the persisted CollapsedSteps.
-  const justFinishedTurn =
-    prevCollapsedCountRef.current > 0 && collapsedItems.length === 0;
-  prevCollapsedCountRef.current = collapsedItems.length;
-
-  // Reset the ref on all other renders where there are no collapsed items,
-  // so it doesn't leak to other conversations on navigation.
-  if (!justFinishedTurn && collapsedItems.length === 0) {
-    stepsExpandedRef.current = false;
-  }
+  // Reset the preserved expansion state when a new user-initiated turn starts
+  // (a new user message appears). This keeps the toggle from leaking into
+  // subsequent turns.
+  const prevUserMsgCountRef = React.useRef(0);
+  const userMsgCount = React.useMemo(
+    () => messages.filter((m) => m.role === "user").length,
+    [messages],
+  );
+  React.useEffect(() => {
+    if (userMsgCount > prevUserMsgCountRef.current) {
+      stepsExpandedRef.current = false;
+    }
+    prevUserMsgCountRef.current = userMsgCount;
+  }, [userMsgCount]);
 
   const activeItemsToSteps = (items: ActiveTurnItem[]): CollapsedStepItem[] =>
     items.flatMap((item): CollapsedStepItem[] => {
@@ -473,9 +483,7 @@ export default function ChatMessageList({
                     count={preWorkSteps.length}
                     items={preWorkSteps}
                     defaultExpanded={
-                      isLastBlock && justFinishedTurn
-                        ? stepsExpandedRef.current
-                        : false
+                      isLastBlock ? stepsExpandedRef.current : false
                     }
                   />,
                 ]

--- a/packages/front-end/enterprise/components/ProductAnalytics/ExplorerContext.tsx
+++ b/packages/front-end/enterprise/components/ProductAnalytics/ExplorerContext.tsx
@@ -19,9 +19,11 @@ import { QueryInterface } from "shared/types/query";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import {
   cleanConfigForSubmission,
+  clearInapplicableShowAs,
   compareConfig,
   createEmptyDataset,
   createEmptyValue,
+  fillMissingUnits,
   generateUniqueValueName,
   getCommonColumns,
   isSubmittableConfig,
@@ -109,12 +111,23 @@ export function ExplorerProvider({
     exploration: ProductAnalyticsExploration | null;
     error: string | null;
     query: QueryInterface | null;
-  }>({
-    draftState: initialConfig,
-    submittedState: hasExistingResults ? initialConfig : null,
-    exploration: null,
-    error: null,
-    query: null,
+  }>(() => {
+    const withUnits = fillMissingUnits(
+      initialConfig,
+      getFactTableById,
+      getFactMetricById,
+    );
+    const normalizedInitial = clearInapplicableShowAs(
+      withUnits,
+      getFactMetricById,
+    );
+    return {
+      draftState: normalizedInitial,
+      submittedState: hasExistingResults ? normalizedInitial : null,
+      exploration: null,
+      error: null,
+      query: null,
+    };
   });
   const [isStale, setIsStale] = useState(false);
   const hasEverFetchedRef = useRef(false);
@@ -132,9 +145,22 @@ export function ExplorerProvider({
             ? newStateOrUpdater(currentDraft)
             : newStateOrUpdater;
 
-        // Validate dimensions against commonColumns
-        const validatedState = validateDimensions(
+        // Backfill missing units from the fact table's primary userIdType
+        // so configs loaded from URLs, saved explorations, or AI-generated
+        // payloads always have a unit set when one is applicable.
+        const unitFilledState = fillMissingUnits(
           newState,
+          getFactTableById,
+          getFactMetricById,
+        );
+        // Strip `showAs` when the current dataset doesn't support it, so the
+        // stored value never disagrees with what the chart actually renders.
+        const showAsNormalized = clearInapplicableShowAs(
+          unitFilledState,
+          getFactMetricById,
+        );
+        const validatedState = validateDimensions(
+          showAsNormalized,
           getFactTableById,
           getFactMetricById,
         );
@@ -147,6 +173,25 @@ export function ExplorerProvider({
     },
     [getFactTableById, getFactMetricById],
   );
+
+  // Re-normalize the draft state whenever the definitions resolver functions
+  // change identity — this handles the case where an initialConfig loaded from
+  // a URL or saved exploration needed metric/fact-table lookups that weren't
+  // resolved yet at first render. Both fillMissingUnits and
+  // clearInapplicableShowAs return the same reference when nothing changes,
+  // so the setExplorerState is a no-op in the steady state.
+  useEffect(() => {
+    setExplorerState((prev) => {
+      const filled = fillMissingUnits(
+        prev.draftState,
+        getFactTableById,
+        getFactMetricById,
+      );
+      const normalized = clearInapplicableShowAs(filled, getFactMetricById);
+      if (normalized === prev.draftState) return prev;
+      return { ...prev, draftState: normalized };
+    });
+  }, [getFactTableById, getFactMetricById]);
 
   const isManagedWarehouse = useMemo(() => {
     if (!draftExploreState.datasource) return false;

--- a/packages/front-end/enterprise/components/ProductAnalytics/MainSection/ExplorerChart.tsx
+++ b/packages/front-end/enterprise/components/ProductAnalytics/MainSection/ExplorerChart.tsx
@@ -10,6 +10,9 @@ import {
   getEffectiveMetricValue,
   computeDimensionTotals,
   getIsRatioByIndex,
+  getEffectiveShowAs,
+  getSharedUnit,
+  showAsAppliesTo,
   type RenderOpts,
 } from "@/enterprise/components/ProductAnalytics/util";
 import { useAppearanceUITheme } from "@/services/AppearanceUIThemeProvider";
@@ -76,11 +79,24 @@ export default function ExplorerChart({
 
   const renderOpts: RenderOpts = useMemo(
     () => ({
-      showAs: submittedExploreState?.showAs ?? "total",
-      isRatioByIndex: getIsRatioByIndex(submittedExploreState, getFactMetricById),
+      showAs: getEffectiveShowAs(submittedExploreState, getFactMetricById),
+      isRatioByIndex: getIsRatioByIndex(
+        submittedExploreState,
+        getFactMetricById,
+      ),
     }),
     [submittedExploreState, getFactMetricById],
   );
+
+  // Y-axis label: reflects whether we're rendering raw totals or per-unit
+  // averages. Only populated when showAs applies (otherwise the toggle is
+  // hidden and the number's meaning is carried by the metric/series name).
+  const valueAxisName = useMemo(() => {
+    if (!showAsAppliesTo(submittedExploreState, getFactMetricById)) return "";
+    if (renderOpts.showAs === "total") return "Total";
+    const sharedUnit = getSharedUnit(submittedExploreState);
+    return sharedUnit ? `Per ${sharedUnit}` : "Per unit";
+  }, [submittedExploreState, getFactMetricById, renderOpts.showAs]);
 
   // Transform ProductAnalyticsResult + exploreState to ECharts format
   const chartConfig = useMemo(() => {
@@ -272,7 +288,9 @@ export default function ExplorerChart({
     const valueAxis = {
       type: "value" as const,
       scale: false,
+      name: valueAxisName,
       nameLocation: "middle" as const,
+      nameGap: 50,
       nameTextStyle: {
         fontSize: 14,
         fontWeight: "bold",
@@ -324,6 +342,7 @@ export default function ExplorerChart({
     gridLineColor,
     tooltipBackgroundColor,
     animate,
+    valueAxisName,
   ]);
 
   const hasEmptyData = useMemo(() => {

--- a/packages/front-end/enterprise/components/ProductAnalytics/MainSection/ExplorerChart.tsx
+++ b/packages/front-end/enterprise/components/ProductAnalytics/MainSection/ExplorerChart.tsx
@@ -9,8 +9,11 @@ import {
   shouldChartSectionShow,
   getEffectiveMetricValue,
   computeDimensionTotals,
+  getIsRatioByIndex,
+  type RenderOpts,
 } from "@/enterprise/components/ProductAnalytics/util";
 import { useAppearanceUITheme } from "@/services/AppearanceUIThemeProvider";
+import { useDefinitions } from "@/services/DefinitionsContext";
 import { useDashboardCharts } from "@/enterprise/components/Dashboards/DashboardChartsContext";
 import BigValueChart from "@/components/SqlExplorer/BigValueChart";
 import HelperText from "@/ui/HelperText";
@@ -69,6 +72,15 @@ export default function ExplorerChart({
   const gridLineColor =
     theme === "dark" ? "rgba(255, 255, 255, 0.08)" : "rgba(0, 0, 0, 0.06)";
   const chartsContext = useDashboardCharts();
+  const { getFactMetricById } = useDefinitions();
+
+  const renderOpts: RenderOpts = useMemo(
+    () => ({
+      showAs: submittedExploreState?.showAs ?? "total",
+      isRatioByIndex: getIsRatioByIndex(submittedExploreState, getFactMetricById),
+    }),
+    [submittedExploreState, getFactMetricById],
+  );
 
   // Transform ProductAnalyticsResult + exploreState to ECharts format
   const chartConfig = useMemo(() => {
@@ -86,10 +98,13 @@ export default function ExplorerChart({
       chartType === "stackedBar" || chartType === "stackedHorizontalBar";
 
     if (chartType === "bigNumber") {
-      let value = rows[0]?.values[0]?.numerator ?? 0;
-      if (rows[0]?.values[0]?.denominator) {
-        value /= rows[0]?.values[0]?.denominator;
-      }
+      const firstValue = rows[0]?.values[0];
+      const value = firstValue
+        ? getEffectiveMetricValue(firstValue, {
+            showAs: renderOpts.showAs,
+            isRatio: renderOpts.isRatioByIndex[0] ?? false,
+          })
+        : 0;
       return { type: "bigNumber" as const, value };
     }
 
@@ -142,7 +157,10 @@ export default function ExplorerChart({
           };
         }
 
-        dataMap[seriesKey][xValue] = getEffectiveMetricValue(v);
+        dataMap[seriesKey][xValue] = getEffectiveMetricValue(v, {
+          showAs: renderOpts.showAs,
+          isRatio: renderOpts.isRatioByIndex[valueIndex] ?? false,
+        });
       });
     });
 
@@ -168,7 +186,7 @@ export default function ExplorerChart({
     // Bar charts: sort categories by total value; timeseries: chronological
     let sortedXValues: string[];
     if (isBarType) {
-      const xValueTotals = computeDimensionTotals(rows, 0);
+      const xValueTotals = computeDimensionTotals(rows, 0, renderOpts);
       // Horizontal bars render bottom-to-top, so sort ascending for largest on top
       sortedXValues = Array.from(uniqueXValues).sort((a, b) =>
         isHorizontalBar
@@ -301,6 +319,7 @@ export default function ExplorerChart({
   }, [
     exploration?.result?.rows,
     submittedExploreState,
+    renderOpts,
     textColor,
     gridLineColor,
     tooltipBackgroundColor,

--- a/packages/front-end/enterprise/components/ProductAnalytics/MainSection/ExplorerDataTable.tsx
+++ b/packages/front-end/enterprise/components/ProductAnalytics/MainSection/ExplorerDataTable.tsx
@@ -26,6 +26,7 @@ export default function ExplorerDataTable({
   const {
     rowData,
     orderedColumnKeys,
+    columnLabels,
     headerStructure,
     explorationReturnedNoData,
   } = useExplorationTableData(exploration, submittedExploreState);
@@ -42,6 +43,7 @@ export default function ExplorerDataTable({
       showDuration={!!query?.statistics}
       headerStructure={headerStructure ?? undefined}
       orderedColumnKeys={orderedColumnKeys}
+      columnLabels={columnLabels}
       paddingTop={(isStale || loading) && !hasChart ? 35 : 0}
     />
   );

--- a/packages/front-end/enterprise/components/ProductAnalytics/MainSection/SimpleExplorationTable.tsx
+++ b/packages/front-end/enterprise/components/ProductAnalytics/MainSection/SimpleExplorationTable.tsx
@@ -16,6 +16,7 @@ export default function SimpleExplorationTable({
   const {
     rowData,
     orderedColumnKeys,
+    columnLabels,
     headerStructure,
     explorationReturnedNoData,
   } = useExplorationTableData(exploration, config);
@@ -85,8 +86,8 @@ export default function SimpleExplorationTable({
             </>
           ) : (
             <tr>
-              {orderedColumnKeys.map((col) => (
-                <th key={col}>{col}</th>
+              {orderedColumnKeys.map((key, i) => (
+                <th key={key}>{columnLabels[i] ?? key}</th>
               ))}
             </tr>
           )}

--- a/packages/front-end/enterprise/components/ProductAnalytics/MainSection/useExplorationTableData.ts
+++ b/packages/front-end/enterprise/components/ProductAnalytics/MainSection/useExplorationTableData.ts
@@ -119,23 +119,25 @@ export default function useExplorationTableData(
         row1.push({ label: col.label, rowSpan: 2 });
         continue;
       }
+      // Non-ratio metrics in a mixed (ratio + non-ratio) table span both
+      // header rows so their column doesn't render a blank second-row cell
+      // next to the ratio metric's Numerator / Denominator / Value trio.
+      if (col.sub === "single") {
+        row1.push({ label: col.label, rowSpan: 2 });
+        continue;
+      }
       const metricName =
         submittedExploreState?.dataset?.values?.[col.metricIndex]?.name ??
         col.label;
-      if (col.sub === "numerator" || col.sub === "single") {
-        row1.push({
-          label: col.sub === "single" ? col.label : metricName,
-          colSpan: col.sub === "single" ? 1 : 3,
-        });
+      if (col.sub === "numerator") {
+        row1.push({ label: metricName, colSpan: 3 });
       }
       row2Labels.push(
         col.sub === "numerator"
           ? "Numerator"
           : col.sub === "denominator"
             ? "Denominator"
-            : col.sub === "value"
-              ? "Value"
-              : "",
+            : "Value",
       );
     }
     return { row1, row2Labels };

--- a/packages/front-end/enterprise/components/ProductAnalytics/MainSection/useExplorationTableData.ts
+++ b/packages/front-end/enterprise/components/ProductAnalytics/MainSection/useExplorationTableData.ts
@@ -2,26 +2,18 @@ import { useMemo } from "react";
 import type {
   ExplorationConfig,
   ProductAnalyticsExploration,
-  ShowAs,
 } from "shared/validators";
 import type { HeaderStructure } from "@/components/Settings/DisplayTestQueryResults";
 import {
   sortExplorationRows,
   getIsRatioByIndex,
-  getEffectiveMetricValue,
   getEffectiveShowAs,
+  buildExplorationColumns,
+  getExplorationCellValue,
+  type ExplorationColumn,
   type RenderOpts,
 } from "@/enterprise/components/ProductAnalytics/util";
 import { useDefinitions } from "@/services/DefinitionsContext";
-
-type ColumnSlot =
-  | { type: "dimension"; key: string; dimIndex: number }
-  | {
-      type: "metric";
-      key: string;
-      metricIndex: number;
-      sub: "numerator" | "denominator" | "value" | "single";
-    };
 
 function shouldShowTime(
   submittedExploreState: {
@@ -36,103 +28,54 @@ function shouldShowTime(
   return dateDimension.dateGranularity === "hour";
 }
 
-function getDimensionCellValue(
-  row: { dimensions: (string | null)[] },
-  dimIndex: number,
+/**
+ * Format a raw cell value (from the shared column schema) for display in the
+ * result table. The shared schema returns unformatted primitives; this adds
+ * the UI-only concerns (date localization, rounding, Total fallback).
+ */
+function formatCellForTable(
+  raw: string | number | null,
+  col: ExplorationColumn,
   context: {
-    dimensionColumnHeaders: string[];
     submittedExploreState: {
       dimensions?: { dimensionType?: string; dateGranularity?: string }[];
     } | null;
+    hasNoDimensions: boolean;
   },
 ): unknown {
-  const dimension = row.dimensions[dimIndex];
-  const { dimensionColumnHeaders, submittedExploreState } = context;
-  if (dimension) {
-    const currentDimension = submittedExploreState?.dimensions?.[dimIndex];
-    if (currentDimension?.dimensionType === "date") {
-      const d = new Date(dimension);
-      let dateString = `${d.toLocaleDateString(undefined, {
+  if (col.kind === "dimension") {
+    if (raw == null || raw === "") {
+      return context.hasNoDimensions ? "Total" : "";
+    }
+    const d = context.submittedExploreState?.dimensions?.[col.dimIndex];
+    if (d?.dimensionType === "date" && typeof raw === "string") {
+      const date = new Date(raw);
+      let dateString = date.toLocaleDateString(undefined, {
         year: "numeric",
         month: "long",
         day: "numeric",
-      })}`;
-      if (shouldShowTime(submittedExploreState)) {
-        dateString += ` ${d.toLocaleTimeString(undefined, {
+      });
+      if (shouldShowTime(context.submittedExploreState)) {
+        dateString += ` ${date.toLocaleTimeString(undefined, {
           hour: "2-digit",
           minute: "2-digit",
         })}`;
       }
       return dateString;
     }
-    return dimension;
+    return raw;
   }
-  if (dimensionColumnHeaders[0] === "Total") return "Total";
-  return "";
-}
-
-function getMetricCellValue(
-  row: {
-    values: {
-      numerator?: number | null;
-      denominator?: number | null;
-      metricId?: string;
-    }[];
-  },
-  metricIndex: number,
-  sub: "numerator" | "denominator" | "value" | "single",
-  opts: { showAs: ShowAs; isRatio: boolean },
-): unknown {
-  const value = row.values[metricIndex];
-  if (sub === "numerator") {
-    return value?.numerator != null ? value.numerator : "";
-  }
-  if (sub === "denominator") {
-    return value?.denominator != null ? value.denominator : "";
-  }
-  if (sub === "value") {
-    // 3-column split's Value cell: always show numerator/denominator.
-    // Only ratio metrics reach this branch.
-    if (value?.numerator != null && value?.denominator != null) {
-      return (value.numerator / value.denominator).toFixed(2);
-    }
-    return "";
-  }
-  if (sub === "single") {
-    if (value?.numerator == null) return "";
-    const v = getEffectiveMetricValue(
-      { numerator: value.numerator, denominator: value.denominator ?? null },
-      opts,
-    );
-    return v.toFixed(2);
-  }
-  return "";
-}
-
-function getSlotValue(
-  row: {
-    dimensions: (string | null)[];
-    values: { numerator?: number | null; denominator?: number | null }[];
-  },
-  slot: ColumnSlot,
-  context: {
-    dimensionColumnHeaders: string[];
-    submittedExploreState: { dimensions?: { dimensionType?: string }[] } | null;
-    renderOpts: RenderOpts;
-  },
-): unknown {
-  if (slot.type === "dimension") {
-    return getDimensionCellValue(row, slot.dimIndex, context);
-  }
-  return getMetricCellValue(row, slot.metricIndex, slot.sub, {
-    showAs: context.renderOpts.showAs,
-    isRatio: context.renderOpts.isRatioByIndex[slot.metricIndex] ?? false,
-  });
+  if (raw == null) return "";
+  if (col.sub === "numerator" || col.sub === "denominator") return raw;
+  return typeof raw === "number" ? raw.toFixed(2) : raw;
 }
 
 export interface ExplorationTableData {
   rowData: Record<string, unknown>[];
+  /** Stable machine keys used to index into each row object. */
   orderedColumnKeys: string[];
+  /** Display labels, 1:1 aligned with orderedColumnKeys. */
+  columnLabels: string[];
   headerStructure: HeaderStructure | null;
   explorationReturnedNoData: boolean;
 }
@@ -154,137 +97,75 @@ export default function useExplorationTableData(
     [submittedExploreState, getFactMetricById],
   );
 
-  const dimensionColumnHeaders = useMemo(() => {
-    const headers: string[] = [];
-    for (const dimension of submittedExploreState?.dimensions || []) {
-      if (dimension.dimensionType === "date") {
-        headers.push("Date");
-      } else if (dimension.dimensionType === "dynamic") {
-        headers.push(dimension.column || "");
-      } else {
-        // Unknown dimension type — skip
-      }
-    }
-    if (headers.length === 0) {
-      headers.push("Total");
-    }
-    return headers;
-  }, [submittedExploreState?.dimensions]);
+  const columns = useMemo(
+    () => buildExplorationColumns(submittedExploreState, getFactMetricById),
+    [submittedExploreState, getFactMetricById],
+  );
 
-  const valueColumnHeaders = useMemo(() => {
-    return submittedExploreState?.dataset?.values.map((v) => v.name) || [];
-  }, [submittedExploreState?.dataset?.values]);
+  const orderedColumnKeys = useMemo(() => columns.map((c) => c.key), [columns]);
+  const columnLabels = useMemo(() => columns.map((c) => c.label), [columns]);
 
-  // Only ratio metrics get the 3-column Numerator/Denominator/Value split.
-  // Non-ratio metrics render as a single column whose value respects `showAs`.
-  const useSplitColumnsAt = useMemo(() => {
-    return valueColumnHeaders.map(
-      (_, i) => renderOpts.isRatioByIndex[i] ?? false,
-    );
-  }, [valueColumnHeaders, renderOpts.isRatioByIndex]);
-
-  const hasAnyRatio = useSplitColumnsAt.some(Boolean);
-
-  const columnSchema = useMemo((): ColumnSlot[] => {
-    const schema: ColumnSlot[] = [];
-    dimensionColumnHeaders.forEach((label, i) => {
-      schema.push({ type: "dimension", key: label, dimIndex: i });
-    });
-    valueColumnHeaders.forEach((name, i) => {
-      if (useSplitColumnsAt[i]) {
-        schema.push({
-          type: "metric",
-          key: `${name}_Numerator`,
-          metricIndex: i,
-          sub: "numerator",
-        });
-        schema.push({
-          type: "metric",
-          key: `${name}_Denominator`,
-          metricIndex: i,
-          sub: "denominator",
-        });
-        schema.push({
-          type: "metric",
-          key: `${name}_Value`,
-          metricIndex: i,
-          sub: "value",
-        });
-      } else {
-        schema.push({
-          type: "metric",
-          key: name,
-          metricIndex: i,
-          sub: "single",
-        });
-      }
-    });
-    return schema;
-  }, [dimensionColumnHeaders, valueColumnHeaders, useSplitColumnsAt]);
-
-  const orderedColumnKeys = useMemo(
-    () => columnSchema.map((s) => s.key),
-    [columnSchema],
+  const hasAnyRatio = useMemo(
+    () => columns.some((c) => c.kind === "metric" && c.sub !== "single"),
+    [columns],
   );
 
   const headerStructure = useMemo((): HeaderStructure | null => {
     if (!hasAnyRatio) return null;
     const row1: { label: string; colSpan?: number; rowSpan?: number }[] = [];
     const row2Labels: string[] = [];
-    for (const slot of columnSchema) {
-      if (slot.type === "dimension") {
-        row1.push({ label: slot.key, rowSpan: 2 });
-      } else {
-        if (slot.sub === "numerator" || slot.sub === "single") {
-          row1.push({
-            label: valueColumnHeaders[slot.metricIndex],
-            colSpan: slot.sub === "single" ? 1 : 3,
-          });
-        }
-        row2Labels.push(
-          slot.sub === "numerator"
-            ? "Numerator"
-            : slot.sub === "denominator"
-              ? "Denominator"
-              : "Value",
-        );
+    for (const col of columns) {
+      if (col.kind === "dimension") {
+        row1.push({ label: col.label, rowSpan: 2 });
+        continue;
       }
+      const metricName =
+        submittedExploreState?.dataset?.values?.[col.metricIndex]?.name ??
+        col.label;
+      if (col.sub === "numerator" || col.sub === "single") {
+        row1.push({
+          label: col.sub === "single" ? col.label : metricName,
+          colSpan: col.sub === "single" ? 1 : 3,
+        });
+      }
+      row2Labels.push(
+        col.sub === "numerator"
+          ? "Numerator"
+          : col.sub === "denominator"
+            ? "Denominator"
+            : col.sub === "value"
+              ? "Value"
+              : "",
+      );
     }
     return { row1, row2Labels };
-  }, [hasAnyRatio, columnSchema, valueColumnHeaders]);
+  }, [hasAnyRatio, columns, submittedExploreState]);
 
   const rowData = useMemo(() => {
-    const rawRows = exploration?.result?.rows || [];
+    const rawRows = exploration?.result?.rows ?? [];
     const isTimeseries =
       submittedExploreState?.dimensions?.[0]?.dimensionType === "date";
 
-    const rowsToProcess = sortExplorationRows(
-      rawRows,
-      isTimeseries,
-      renderOpts,
-    );
+    const sortedRows = sortExplorationRows(rawRows, isTimeseries, renderOpts);
 
-    const context = {
-      dimensionColumnHeaders,
-      submittedExploreState,
-      renderOpts,
-    };
+    const hasNoDimensions =
+      !submittedExploreState?.dimensions ||
+      submittedExploreState.dimensions.length === 0;
 
-    return rowsToProcess.map((row) => {
-      const values = columnSchema.map((slot) =>
-        getSlotValue(row, slot, context),
-      );
-      return Object.fromEntries(
-        columnSchema.map((slot, i) => [slot.key, values[i]]),
-      ) as Record<string, unknown>;
+    return sortedRows.map((row) => {
+      const entries = columns.map((col) => {
+        const raw = getExplorationCellValue(row, col, renderOpts);
+        return [
+          col.key,
+          formatCellForTable(raw, col, {
+            submittedExploreState,
+            hasNoDimensions,
+          }),
+        ] as const;
+      });
+      return Object.fromEntries(entries) as Record<string, unknown>;
     });
-  }, [
-    exploration?.result?.rows,
-    dimensionColumnHeaders,
-    columnSchema,
-    submittedExploreState,
-    renderOpts,
-  ]);
+  }, [exploration?.result?.rows, columns, renderOpts, submittedExploreState]);
 
   const explorationReturnedNoData = useMemo(() => {
     if (!exploration?.result?.rows?.length) return true;
@@ -294,6 +175,7 @@ export default function useExplorationTableData(
   return {
     rowData,
     orderedColumnKeys,
+    columnLabels,
     headerStructure,
     explorationReturnedNoData,
   };

--- a/packages/front-end/enterprise/components/ProductAnalytics/MainSection/useExplorationTableData.ts
+++ b/packages/front-end/enterprise/components/ProductAnalytics/MainSection/useExplorationTableData.ts
@@ -9,6 +9,7 @@ import {
   sortExplorationRows,
   getIsRatioByIndex,
   getEffectiveMetricValue,
+  getEffectiveShowAs,
   type RenderOpts,
 } from "@/enterprise/components/ProductAnalytics/util";
 import { useDefinitions } from "@/services/DefinitionsContext";
@@ -144,8 +145,11 @@ export default function useExplorationTableData(
 
   const renderOpts: RenderOpts = useMemo(
     () => ({
-      showAs: submittedExploreState?.showAs ?? "total",
-      isRatioByIndex: getIsRatioByIndex(submittedExploreState, getFactMetricById),
+      showAs: getEffectiveShowAs(submittedExploreState, getFactMetricById),
+      isRatioByIndex: getIsRatioByIndex(
+        submittedExploreState,
+        getFactMetricById,
+      ),
     }),
     [submittedExploreState, getFactMetricById],
   );

--- a/packages/front-end/enterprise/components/ProductAnalytics/MainSection/useExplorationTableData.ts
+++ b/packages/front-end/enterprise/components/ProductAnalytics/MainSection/useExplorationTableData.ts
@@ -2,9 +2,16 @@ import { useMemo } from "react";
 import type {
   ExplorationConfig,
   ProductAnalyticsExploration,
+  ShowAs,
 } from "shared/validators";
 import type { HeaderStructure } from "@/components/Settings/DisplayTestQueryResults";
-import { sortExplorationRows } from "@/enterprise/components/ProductAnalytics/util";
+import {
+  sortExplorationRows,
+  getIsRatioByIndex,
+  getEffectiveMetricValue,
+  type RenderOpts,
+} from "@/enterprise/components/ProductAnalytics/util";
+import { useDefinitions } from "@/services/DefinitionsContext";
 
 type ColumnSlot =
   | { type: "dimension"; key: string; dimIndex: number }
@@ -65,10 +72,15 @@ function getDimensionCellValue(
 
 function getMetricCellValue(
   row: {
-    values: { numerator?: number | null; denominator?: number | null }[];
+    values: {
+      numerator?: number | null;
+      denominator?: number | null;
+      metricId?: string;
+    }[];
   },
   metricIndex: number,
   sub: "numerator" | "denominator" | "value" | "single",
+  opts: { showAs: ShowAs; isRatio: boolean },
 ): unknown {
   const value = row.values[metricIndex];
   if (sub === "numerator") {
@@ -77,17 +89,21 @@ function getMetricCellValue(
   if (sub === "denominator") {
     return value?.denominator != null ? value.denominator : "";
   }
-  if (sub === "value" || sub === "single") {
+  if (sub === "value") {
+    // 3-column split's Value cell: always show numerator/denominator.
+    // Only ratio metrics reach this branch.
     if (value?.numerator != null && value?.denominator != null) {
       return (value.numerator / value.denominator).toFixed(2);
     }
-    if (value?.numerator != null && sub === "single") {
-      const val = value.denominator
-        ? value.numerator / value.denominator
-        : value.numerator;
-      return val.toFixed(2);
-    }
     return "";
+  }
+  if (sub === "single") {
+    if (value?.numerator == null) return "";
+    const v = getEffectiveMetricValue(
+      { numerator: value.numerator, denominator: value.denominator ?? null },
+      opts,
+    );
+    return v.toFixed(2);
   }
   return "";
 }
@@ -101,12 +117,16 @@ function getSlotValue(
   context: {
     dimensionColumnHeaders: string[];
     submittedExploreState: { dimensions?: { dimensionType?: string }[] } | null;
+    renderOpts: RenderOpts;
   },
 ): unknown {
   if (slot.type === "dimension") {
     return getDimensionCellValue(row, slot.dimIndex, context);
   }
-  return getMetricCellValue(row, slot.metricIndex, slot.sub);
+  return getMetricCellValue(row, slot.metricIndex, slot.sub, {
+    showAs: context.renderOpts.showAs,
+    isRatio: context.renderOpts.isRatioByIndex[slot.metricIndex] ?? false,
+  });
 }
 
 export interface ExplorationTableData {
@@ -120,6 +140,16 @@ export default function useExplorationTableData(
   exploration: ProductAnalyticsExploration | null,
   submittedExploreState: ExplorationConfig | null,
 ): ExplorationTableData {
+  const { getFactMetricById } = useDefinitions();
+
+  const renderOpts: RenderOpts = useMemo(
+    () => ({
+      showAs: submittedExploreState?.showAs ?? "total",
+      isRatioByIndex: getIsRatioByIndex(submittedExploreState, getFactMetricById),
+    }),
+    [submittedExploreState, getFactMetricById],
+  );
+
   const dimensionColumnHeaders = useMemo(() => {
     const headers: string[] = [];
     for (const dimension of submittedExploreState?.dimensions || []) {
@@ -141,17 +171,15 @@ export default function useExplorationTableData(
     return submittedExploreState?.dataset?.values.map((v) => v.name) || [];
   }, [submittedExploreState?.dataset?.values]);
 
-  const hasDenominatorAt = useMemo(() => {
-    const rawRows = exploration?.result?.rows || [];
-    const numValues = valueColumnHeaders.length;
-    const out: boolean[] = [];
-    for (let i = 0; i < numValues; i++) {
-      out[i] = rawRows.some((row) => row.values[i]?.denominator != null);
-    }
-    return out;
-  }, [exploration?.result?.rows, valueColumnHeaders.length]);
+  // Only ratio metrics get the 3-column Numerator/Denominator/Value split.
+  // Non-ratio metrics render as a single column whose value respects `showAs`.
+  const useSplitColumnsAt = useMemo(() => {
+    return valueColumnHeaders.map(
+      (_, i) => renderOpts.isRatioByIndex[i] ?? false,
+    );
+  }, [valueColumnHeaders, renderOpts.isRatioByIndex]);
 
-  const hasAnyDenominator = hasDenominatorAt.some(Boolean);
+  const hasAnyRatio = useSplitColumnsAt.some(Boolean);
 
   const columnSchema = useMemo((): ColumnSlot[] => {
     const schema: ColumnSlot[] = [];
@@ -159,7 +187,7 @@ export default function useExplorationTableData(
       schema.push({ type: "dimension", key: label, dimIndex: i });
     });
     valueColumnHeaders.forEach((name, i) => {
-      if (hasDenominatorAt[i]) {
+      if (useSplitColumnsAt[i]) {
         schema.push({
           type: "metric",
           key: `${name}_Numerator`,
@@ -188,7 +216,7 @@ export default function useExplorationTableData(
       }
     });
     return schema;
-  }, [dimensionColumnHeaders, valueColumnHeaders, hasDenominatorAt]);
+  }, [dimensionColumnHeaders, valueColumnHeaders, useSplitColumnsAt]);
 
   const orderedColumnKeys = useMemo(
     () => columnSchema.map((s) => s.key),
@@ -196,7 +224,7 @@ export default function useExplorationTableData(
   );
 
   const headerStructure = useMemo((): HeaderStructure | null => {
-    if (!hasAnyDenominator) return null;
+    if (!hasAnyRatio) return null;
     const row1: { label: string; colSpan?: number; rowSpan?: number }[] = [];
     const row2Labels: string[] = [];
     for (const slot of columnSchema) {
@@ -219,18 +247,23 @@ export default function useExplorationTableData(
       }
     }
     return { row1, row2Labels };
-  }, [hasAnyDenominator, columnSchema, valueColumnHeaders]);
+  }, [hasAnyRatio, columnSchema, valueColumnHeaders]);
 
   const rowData = useMemo(() => {
     const rawRows = exploration?.result?.rows || [];
     const isTimeseries =
       submittedExploreState?.dimensions?.[0]?.dimensionType === "date";
 
-    const rowsToProcess = sortExplorationRows(rawRows, isTimeseries);
+    const rowsToProcess = sortExplorationRows(
+      rawRows,
+      isTimeseries,
+      renderOpts,
+    );
 
     const context = {
       dimensionColumnHeaders,
       submittedExploreState,
+      renderOpts,
     };
 
     return rowsToProcess.map((row) => {
@@ -246,6 +279,7 @@ export default function useExplorationTableData(
     dimensionColumnHeaders,
     columnSchema,
     submittedExploreState,
+    renderOpts,
   ]);
 
   const explorationReturnedNoData = useMemo(() => {

--- a/packages/front-end/enterprise/components/ProductAnalytics/SideBar/ExplorerSideBar.tsx
+++ b/packages/front-end/enterprise/components/ProductAnalytics/SideBar/ExplorerSideBar.tsx
@@ -26,6 +26,7 @@ import MetricTabContent from "./MetricTabContent";
 import FactTableTabContent from "./FactTableTabContent";
 import DatasourceTabContent from "./DatasourceTabContent";
 import GroupBySection from "./GroupBySection";
+import ShowAsSection from "./ShowAsSection";
 import DatasourceConfigurator from "./DatasourceConfigurator";
 
 interface Props {
@@ -271,6 +272,7 @@ export default function ExplorerSideBar({
         {activeType === "data_source" && <DatasourceTabContent />}
       </Box>
 
+      {dataset?.values?.length > 0 && <ShowAsSection />}
       {dataset?.values?.length > 0 && <GroupBySection />}
     </Flex>
   );

--- a/packages/front-end/enterprise/components/ProductAnalytics/SideBar/ExplorerSideBar.tsx
+++ b/packages/front-end/enterprise/components/ProductAnalytics/SideBar/ExplorerSideBar.tsx
@@ -19,7 +19,10 @@ import GranularitySelector from "@/enterprise/components/ProductAnalytics/MainSe
 import Tooltip from "@/components/Tooltip/Tooltip";
 import Callout from "@/ui/Callout";
 import DataSourceDropdown from "@/enterprise/components/ProductAnalytics/MainSection/Toolbar/DataSourceDropdown";
-import { createEmptyValue } from "@/enterprise/components/ProductAnalytics/util";
+import {
+  createEmptyValue,
+  showAsAppliesTo,
+} from "@/enterprise/components/ProductAnalytics/util";
 import SaveToDashboardModal from "@/enterprise/components/ProductAnalytics/SaveToDashboardModal";
 import UpgradeModal from "@/components/Settings/UpgradeModal";
 import MetricTabContent from "./MetricTabContent";
@@ -49,7 +52,7 @@ export default function ExplorerSideBar({
     isStale,
     error,
   } = useExplorerContext();
-  const { factTables, project } = useDefinitions();
+  const { factTables, getFactMetricById, project } = useDefinitions();
   const { hasCommercialFeature, permissionsUtil } = useUser();
   // Check if the user can create dashboards for the current project or globally
   const canCreateDashboards =
@@ -272,7 +275,9 @@ export default function ExplorerSideBar({
         {activeType === "data_source" && <DatasourceTabContent />}
       </Box>
 
-      {dataset?.values?.length > 0 && <ShowAsSection />}
+      {showAsAppliesTo(draftExploreState, getFactMetricById) && (
+        <ShowAsSection />
+      )}
       {dataset?.values?.length > 0 && <GroupBySection />}
     </Flex>
   );

--- a/packages/front-end/enterprise/components/ProductAnalytics/SideBar/MetricTabContent.tsx
+++ b/packages/front-end/enterprise/components/ProductAnalytics/SideBar/MetricTabContent.tsx
@@ -9,9 +9,15 @@ import SelectField, {
 import MetricName from "@/components/Metrics/MetricName";
 import Button from "@/ui/Button";
 import { useDefinitions } from "@/services/DefinitionsContext";
-import { generateUniqueValueName } from "@/enterprise/components/ProductAnalytics/util";
+import {
+  generateUniqueValueName,
+  getLockedMixClass,
+  getMetricMixClass,
+  MetricMixClass,
+} from "@/enterprise/components/ProductAnalytics/util";
 import { useExplorerContext } from "@/enterprise/components/ProductAnalytics/ExplorerContext";
 import Text from "@/ui/Text";
+import Tooltip from "@/components/Tooltip/Tooltip";
 import { useUser } from "@/services/UserContext";
 import ValueCard from "./ValueCard";
 import styles from "./ValueCard.module.scss";
@@ -19,7 +25,8 @@ import styles from "./ValueCard.module.scss";
 export default function MetricTabContent() {
   const { draftExploreState, addValueToDataset, updateValueInDataset } =
     useExplorerContext();
-  const { factMetrics, getFactTableById, project } = useDefinitions();
+  const { factMetrics, getFactTableById, getFactMetricById, project } =
+    useDefinitions();
   const { permissionsUtil } = useUser();
 
   const values: MetricValue[] =
@@ -27,8 +34,11 @@ export default function MetricTabContent() {
       ? draftExploreState.dataset.values
       : [];
 
-  const metricOptions = useMemo(() => {
-    const groupedOptions: GroupedValue[] = [];
+  // Build the base grouped options list for this datasource. All metrics are
+  // always shown; compat is enforced per-slot via isOptionDisabled so users
+  // get a visual hint + tooltip instead of a silently shorter list.
+  const groupedOptions = useMemo(() => {
+    const grouped: GroupedValue[] = [];
     const managedMetrics: SingleValue[] = [];
     const unManagedMetrics: SingleValue[] = [];
     factMetrics.forEach((m) => {
@@ -40,20 +50,35 @@ export default function MetricTabContent() {
       }
     });
     if (managedMetrics.length > 0) {
-      groupedOptions.push({
-        label: "Official Metrics",
-        options: managedMetrics,
-      });
+      grouped.push({ label: "Official Metrics", options: managedMetrics });
     }
     if (unManagedMetrics.length > 0) {
-      groupedOptions.push({ label: "", options: unManagedMetrics });
+      grouped.push({ label: "", options: unManagedMetrics });
     }
-    return groupedOptions.length > 1
-      ? groupedOptions
-      : groupedOptions.length === 1
-        ? groupedOptions[0].options
+    return grouped.length > 1
+      ? grouped
+      : grouped.length === 1
+        ? grouped[0].options
         : [];
   }, [factMetrics, draftExploreState.datasource]);
+
+  /** The class any metric in `slotIdx` must match to be compatible with the
+   *  rest of the chart (or null if no restriction applies). */
+  const getLockedClassForSlot = (
+    slotIdx: number,
+  ): Exclude<MetricMixClass, "unknown"> | null => {
+    const otherTypes = values
+      .filter((_, i) => i !== slotIdx)
+      .map((v) => getFactMetricById(v.metricId ?? "")?.metricType);
+    return getLockedMixClass(otherTypes);
+  };
+
+  const mixTooltip = (locked: Exclude<MetricMixClass, "unknown">) =>
+    locked === "ratio"
+      ? "Ratio metrics can't be combined with other metric types."
+      : locked === "quantile"
+        ? "Quantile metrics can't be combined with other metric types."
+        : "Only the same metric type can be combined in one chart.";
 
   return (
     <Flex direction="column" gap="4">
@@ -64,6 +89,8 @@ export default function MetricTabContent() {
       )}
 
       {values.map((v, idx) => {
+        const lockedClass = getLockedClassForSlot(idx);
+        const disabledTooltip = lockedClass ? mixTooltip(lockedClass) : "";
         return (
           <ValueCard key={idx} index={idx}>
             <Flex direction="column">
@@ -100,10 +127,32 @@ export default function MetricTabContent() {
 
                   updateValueInDataset(idx, updates as MetricValue);
                 }}
-                options={metricOptions}
-                formatOptionLabel={({ value }) => {
+                options={groupedOptions}
+                isOptionDisabled={(option) => {
+                  if (!lockedClass || !("value" in option)) return false;
+                  const metric = factMetrics.find((m) => m.id === option.value);
+                  if (!metric) return false;
+                  return getMetricMixClass(metric.metricType) !== lockedClass;
+                }}
+                formatOptionLabel={({ value }, meta) => {
                   const metric = factMetrics.find((m) => m.id === value);
-                  return metric ? <MetricName metric={metric} /> : value;
+                  const label = metric ? <MetricName metric={metric} /> : value;
+                  // Only attach the mix-restriction tooltip inside the open
+                  // menu (not in the selected-value display) so it doesn't
+                  // fire on every hover over the selected option.
+                  const isDisabledInMenu =
+                    meta.context === "menu" &&
+                    !!lockedClass &&
+                    !!metric &&
+                    getMetricMixClass(metric.metricType) !== lockedClass;
+                  if (isDisabledInMenu) {
+                    return (
+                      <Tooltip body={disabledTooltip}>
+                        <span>{label}</span>
+                      </Tooltip>
+                    );
+                  }
+                  return label;
                 }}
                 formatGroupLabel={({ label }) => {
                   return label;

--- a/packages/front-end/enterprise/components/ProductAnalytics/SideBar/MetricTabContent.tsx
+++ b/packages/front-end/enterprise/components/ProductAnalytics/SideBar/MetricTabContent.tsx
@@ -147,7 +147,7 @@ export default function MetricTabContent() {
                     getMetricMixClass(metric.metricType) !== lockedClass;
                   if (isDisabledInMenu) {
                     return (
-                      <Tooltip body={disabledTooltip}>
+                      <Tooltip body={disabledTooltip} usePortal>
                         <span>{label}</span>
                       </Tooltip>
                     );

--- a/packages/front-end/enterprise/components/ProductAnalytics/SideBar/MetricTabContent.tsx
+++ b/packages/front-end/enterprise/components/ProductAnalytics/SideBar/MetricTabContent.tsx
@@ -89,7 +89,7 @@ export default function MetricTabContent() {
                   const updates = {
                     ...v,
                     metricId: val,
-                    unit: newMetric?.metricType === "mean" ? null : unit,
+                    unit,
                     name: newMetric?.name
                       ? generateUniqueValueName(
                           newMetric.name,

--- a/packages/front-end/enterprise/components/ProductAnalytics/SideBar/ShowAsSection.tsx
+++ b/packages/front-end/enterprise/components/ProductAnalytics/SideBar/ShowAsSection.tsx
@@ -1,12 +1,24 @@
 import { Flex } from "@radix-ui/themes";
 import { ShowAs } from "shared/validators";
 import { useExplorerContext } from "@/enterprise/components/ProductAnalytics/ExplorerContext";
+import {
+  getEffectiveShowAs,
+  getSharedUnit,
+} from "@/enterprise/components/ProductAnalytics/util";
+import { useDefinitions } from "@/services/DefinitionsContext";
 import Text from "@/ui/Text";
 import RadioGroup from "@/ui/RadioGroup";
 
 export default function ShowAsSection() {
   const { draftExploreState, setDraftExploreState } = useExplorerContext();
-  const value: ShowAs = draftExploreState.showAs ?? "total";
+  const { getFactMetricById } = useDefinitions();
+
+  const value: ShowAs = getEffectiveShowAs(
+    draftExploreState,
+    getFactMetricById,
+  );
+  const sharedUnit = getSharedUnit(draftExploreState);
+  const perUnitLabel = sharedUnit ? `Per ${sharedUnit}` : "Per Unit";
 
   return (
     <Flex
@@ -23,7 +35,7 @@ export default function ShowAsSection() {
       <RadioGroup
         options={[
           { label: "Event Totals", value: "total" },
-          { label: "Per Unit", value: "per_unit" },
+          { label: perUnitLabel, value: "per_unit" },
         ]}
         value={value}
         setValue={(v) =>

--- a/packages/front-end/enterprise/components/ProductAnalytics/SideBar/ShowAsSection.tsx
+++ b/packages/front-end/enterprise/components/ProductAnalytics/SideBar/ShowAsSection.tsx
@@ -1,0 +1,38 @@
+import { Flex } from "@radix-ui/themes";
+import { ShowAs } from "shared/validators";
+import { useExplorerContext } from "@/enterprise/components/ProductAnalytics/ExplorerContext";
+import Text from "@/ui/Text";
+import RadioGroup from "@/ui/RadioGroup";
+
+export default function ShowAsSection() {
+  const { draftExploreState, setDraftExploreState } = useExplorerContext();
+  const value: ShowAs = draftExploreState.showAs ?? "total";
+
+  return (
+    <Flex
+      direction="column"
+      gap="2"
+      p="3"
+      style={{
+        border: "1px solid var(--gray-a3)",
+        borderRadius: "var(--radius-4)",
+        backgroundColor: "var(--color-panel-translucent)",
+      }}
+    >
+      <Text weight="medium">Show As</Text>
+      <RadioGroup
+        options={[
+          { label: "Event Totals", value: "total" },
+          { label: "Per Unit", value: "per_unit" },
+        ]}
+        value={value}
+        setValue={(v) =>
+          setDraftExploreState((prev) => ({
+            ...prev,
+            showAs: v as ShowAs,
+          }))
+        }
+      />
+    </Flex>
+  );
+}

--- a/packages/front-end/enterprise/components/ProductAnalytics/SideBar/ValueCard.tsx
+++ b/packages/front-end/enterprise/components/ProductAnalytics/SideBar/ValueCard.tsx
@@ -101,11 +101,12 @@ export default function ValueCard({
     const factMetric = getFactMetricById(
       draftExploreState.dataset.values[index].metricId ?? "",
     );
-    if (factMetric?.metricType === "proportion") {
-      supportsUnitSelection = true;
-    } else if (factMetric?.metricType === "retention") {
-      supportsUnitSelection = true;
-    } else if (factMetric?.metricType === "dailyParticipation") {
+    if (
+      factMetric?.metricType === "mean" ||
+      factMetric?.metricType === "proportion" ||
+      factMetric?.metricType === "retention" ||
+      factMetric?.metricType === "dailyParticipation"
+    ) {
       supportsUnitSelection = true;
     } else if (factMetric?.metricType === "ratio") {
       if (factMetric.numerator.column === "$$distinctUsers") {

--- a/packages/front-end/enterprise/components/ProductAnalytics/util.ts
+++ b/packages/front-end/enterprise/components/ProductAnalytics/util.ts
@@ -13,6 +13,7 @@ import type {
   ExplorationDataset,
   ExplorationConfig,
   ProductAnalyticsResultRow,
+  ShowAs,
 } from "shared/validators";
 import { isEqual } from "lodash";
 import { createParser } from "nuqs";
@@ -367,8 +368,10 @@ function getChartCategory(chartType: ExplorationConfig["chartType"]): string {
 
 /** Strips fields that only affect rendering, not data fetching. */
 function toFetchKey(config: ExplorationConfig): unknown {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { showAs, ...rest } = config;
   return {
-    ...config,
+    ...rest,
     chartType: getChartCategory(config.chartType),
     dataset: {
       ...config.dataset,
@@ -464,27 +467,68 @@ export function shouldChartSectionShow(params: {
 
 // --- Shared sorting helpers for chart & table ---
 
-export function getEffectiveMetricValue(v: {
-  numerator: number | null;
-  denominator: number | null;
-}): number {
-  const num = v.numerator ?? 0;
-  return v.denominator ? num / v.denominator : num;
+/**
+ * Build an array of `isRatio` flags indexed by dataset value position.
+ * Only metric datasets can contain ratio values; fact_table and data_source
+ * datasets never do.
+ */
+export function getIsRatioByIndex(
+  config: ExplorationConfig | null,
+  getFactMetricById: (id: string) => FactMetricInterface | null,
+): boolean[] {
+  if (!config?.dataset || config.dataset.type !== "metric") return [];
+  return config.dataset.values.map((v) => {
+    const m = getFactMetricById(v.metricId ?? "");
+    return m?.metricType === "ratio";
+  });
 }
 
-function getRowTotal(row: ProductAnalyticsResultRow): number {
-  return row.values.reduce((sum, v) => sum + getEffectiveMetricValue(v), 0);
+export interface RenderOpts {
+  showAs: ShowAs;
+  // Indexed by the metric value's position in the dataset.values array.
+  // Ratio metrics always render as numerator/denominator regardless of showAs.
+  isRatioByIndex: boolean[];
+}
+
+export function getEffectiveMetricValue(
+  v: { numerator: number | null; denominator: number | null },
+  opts: { showAs: ShowAs; isRatio: boolean },
+): number {
+  const num = v.numerator ?? 0;
+  if (opts.isRatio) {
+    return v.denominator ? num / v.denominator : num;
+  }
+  if (opts.showAs === "per_unit") {
+    return v.denominator ? num / v.denominator : num;
+  }
+  return num;
+}
+
+function getRowTotal(
+  row: ProductAnalyticsResultRow,
+  opts: RenderOpts,
+): number {
+  return row.values.reduce(
+    (sum, v, i) =>
+      sum +
+      getEffectiveMetricValue(v, {
+        showAs: opts.showAs,
+        isRatio: opts.isRatioByIndex[i] ?? false,
+      }),
+    0,
+  );
 }
 
 /** Compute the sum of all metric values grouped by a specific dimension index. */
 export function computeDimensionTotals(
   rows: ProductAnalyticsResultRow[],
   dimIndex: number,
+  opts: RenderOpts,
 ): Record<string, number> {
   const totals: Record<string, number> = {};
   for (const row of rows) {
     const key = row.dimensions[dimIndex] ?? "";
-    totals[key] = (totals[key] ?? 0) + getRowTotal(row);
+    totals[key] = (totals[key] ?? 0) + getRowTotal(row, opts);
   }
   return totals;
 }
@@ -492,11 +536,12 @@ export function computeDimensionTotals(
 /** Compute the sum of all metric values grouped by the "group key" (all dimensions after the first). */
 export function computeGroupTotals(
   rows: ProductAnalyticsResultRow[],
+  opts: RenderOpts,
 ): Record<string, number> {
   const totals: Record<string, number> = {};
   for (const row of rows) {
     const key = row.dimensions.slice(1).join(" - ");
-    totals[key] = (totals[key] ?? 0) + getRowTotal(row);
+    totals[key] = (totals[key] ?? 0) + getRowTotal(row, opts);
   }
   return totals;
 }
@@ -534,11 +579,12 @@ export const explorationConfigParser = createParser<ExplorationConfig>({
 export function sortExplorationRows(
   rows: ProductAnalyticsResultRow[],
   isTimeseries: boolean,
+  opts: RenderOpts,
 ): ProductAnalyticsResultRow[] {
   if (rows.length === 0) return rows;
 
-  const dim0Totals = computeDimensionTotals(rows, 0);
-  const groupTotals = computeGroupTotals(rows);
+  const dim0Totals = computeDimensionTotals(rows, 0, opts);
+  const groupTotals = computeGroupTotals(rows, opts);
 
   return [...rows].sort((a, b) => {
     const dim0A = a.dimensions[0] ?? "";

--- a/packages/front-end/enterprise/components/ProductAnalytics/util.ts
+++ b/packages/front-end/enterprise/components/ProductAnalytics/util.ts
@@ -483,6 +483,71 @@ export function getIsRatioByIndex(
   });
 }
 
+// Classifies a metric for chart-mixing rules.
+// - "ratio"    -> always renders as N/D, can't be mixed with other classes
+// - "quantile" -> percentile value, can't be mixed with other classes
+// - "standard" -> mean/proportion/retention/dailyParticipation, mix freely
+// - "unknown"  -> unselected metric or metric id we couldn't resolve
+export type MetricMixClass = "ratio" | "quantile" | "standard" | "unknown";
+
+export function getMetricMixClass(
+  metricType: string | null | undefined,
+): MetricMixClass {
+  if (metricType === "ratio") return "ratio";
+  if (metricType === "quantile") return "quantile";
+  if (
+    metricType === "mean" ||
+    metricType === "proportion" ||
+    metricType === "retention" ||
+    metricType === "dailyParticipation"
+  ) {
+    return "standard";
+  }
+  return "unknown";
+}
+
+/**
+ * Given the other already-selected metrics in the dataset (excluding the slot
+ * being edited), return the class any newly selected metric must match — or
+ * null if any class is allowed.
+ *
+ * Unknown/unselected slots are ignored.
+ */
+export function getLockedMixClass(
+  otherMetricTypes: (string | null | undefined)[],
+): Exclude<MetricMixClass, "unknown"> | null {
+  for (const t of otherMetricTypes) {
+    const c = getMetricMixClass(t);
+    if (c !== "unknown") return c;
+  }
+  return null;
+}
+
+/**
+ * True when the chart-level `showAs` toggle is meaningful for this dataset.
+ *
+ * - Metric datasets: applies when at least one value is a "standard" metric
+ *   (mean/proportion/retention/dailyParticipation). Ratio and quantile metrics
+ *   ignore showAs, so a chart of only those types should hide the control.
+ * - fact_table / data_source datasets: never applies. Their value types are
+ *   count, sum, and unit_count. count/sum don't expose a unit selector, so no
+ *   denominator is emitted; unit_count's per-unit value is always 1.
+ */
+export function showAsAppliesTo(
+  config: ExplorationConfig | null,
+  getFactMetricById: (id: string) => FactMetricInterface | null,
+): boolean {
+  if (!config?.dataset) return false;
+  if (config.dataset.type !== "metric") return false;
+  if (config.dataset.values.length === 0) return false;
+  return config.dataset.values.some((v) => {
+    const c = getMetricMixClass(
+      getFactMetricById(v.metricId ?? "")?.metricType,
+    );
+    return c === "standard" || c === "unknown";
+  });
+}
+
 export interface RenderOpts {
   showAs: ShowAs;
   // Indexed by the metric value's position in the dataset.values array.
@@ -504,10 +569,7 @@ export function getEffectiveMetricValue(
   return num;
 }
 
-function getRowTotal(
-  row: ProductAnalyticsResultRow,
-  opts: RenderOpts,
-): number {
+function getRowTotal(row: ProductAnalyticsResultRow, opts: RenderOpts): number {
   return row.values.reduce(
     (sum, v, i) =>
       sum +

--- a/packages/front-end/enterprise/components/ProductAnalytics/util.ts
+++ b/packages/front-end/enterprise/components/ProductAnalytics/util.ts
@@ -524,11 +524,34 @@ export function getLockedMixClass(
 }
 
 /**
+ * True when the per-unit branch of `showAs` produces a meaningful value for
+ * this metric type (i.e. the emitted denominator isn't a trivial function of
+ * the numerator).
+ *
+ * - mean: yes. Numerator sums the column across units; denominator counts units
+ *   with activity; per_unit = real average per unit.
+ * - proportion / retention / dailyParticipation: no. These metrics emit one row
+ *   per qualifying unit, so denominator (COUNT of numerator rows) == numerator
+ *   and per_unit degenerates to ~1. Only totals make sense for these in PA.
+ * - ratio / quantile: N/A, handled separately (ratios self-contain N/D, quantiles
+ *   have no denominator emitted).
+ * - unknown: assume yes so we don't hide the control while a metric is loading.
+ */
+function metricHasMeaningfulPerUnit(
+  metricType: string | null | undefined,
+): boolean {
+  if (!metricType) return true;
+  if (metricType === "mean") return true;
+  return false;
+}
+
+/**
  * True when the chart-level `showAs` toggle is meaningful for this dataset.
  *
- * - Metric datasets: applies when at least one value is a "standard" metric
- *   (mean/proportion/retention/dailyParticipation). Ratio and quantile metrics
- *   ignore showAs, so a chart of only those types should hide the control.
+ * - Metric datasets: applies when at least one value is a standard metric for
+ *   which per-unit rendering is non-degenerate. Ratio/quantile metrics ignore
+ *   showAs, and proportion/retention/dailyParticipation collapse per_unit to ~1
+ *   in the product-analytics layer (no exposure set → denominator == numerator).
  * - fact_table / data_source datasets: never applies. Their value types are
  *   count, sum, and unit_count. count/sum don't expose a unit selector, so no
  *   denominator is emitted; unit_count's per-unit value is always 1.
@@ -541,11 +564,66 @@ export function showAsAppliesTo(
   if (config.dataset.type !== "metric") return false;
   if (config.dataset.values.length === 0) return false;
   return config.dataset.values.some((v) => {
-    const c = getMetricMixClass(
-      getFactMetricById(v.metricId ?? "")?.metricType,
-    );
-    return c === "standard" || c === "unknown";
+    const type = getFactMetricById(v.metricId ?? "")?.metricType;
+    const c = getMetricMixClass(type);
+    if (c !== "standard" && c !== "unknown") return false;
+    return metricHasMeaningfulPerUnit(type);
   });
+}
+
+/**
+ * Infer a smart default for `showAs` when the user hasn't explicitly chosen one.
+ *
+ * Rule: default to `per_unit` only when the `total` rendering would be
+ * mathematically incoherent — specifically, `mean` metrics whose numerator
+ * aggregation is `max` (sum-of-per-unit-maxes has no interpretation) or
+ * `count distinct` (sum-of-per-unit-distinct-counts double-counts values
+ * shared across units). Everything else defaults to `total`: it's always a
+ * coherent number, and for ambiguous cases (e.g. `mean` with `sum` aggregation,
+ * which can be named either "total revenue" or "avg user spend" with identical
+ * definitions) we don't try to guess intent.
+ */
+export function inferShowAs(
+  config: ExplorationConfig | null,
+  getFactMetricById: (id: string) => FactMetricInterface | null,
+): ShowAs {
+  if (!showAsAppliesTo(config, getFactMetricById)) return "total";
+  if (!config || config.dataset.type !== "metric") return "total";
+
+  const allTotalIncoherent = config.dataset.values.every((v) => {
+    const m = getFactMetricById(v.metricId ?? "");
+    if (m?.metricType !== "mean") return false;
+    const agg = m.numerator?.aggregation ?? "sum";
+    return agg === "max" || agg === "count distinct";
+  });
+  return allTotalIncoherent ? "per_unit" : "total";
+}
+
+/**
+ * Resolves the effective showAs for a config: the user's explicit choice when
+ * set, otherwise the inferred default. Use this at read sites (chart/table/
+ * sidebar) instead of `config.showAs ?? "total"` so the default matches the
+ * semantics of the selected metrics.
+ */
+export function getEffectiveShowAs(
+  config: ExplorationConfig | null,
+  getFactMetricById: (id: string) => FactMetricInterface | null,
+): ShowAs {
+  return config?.showAs ?? inferShowAs(config, getFactMetricById);
+}
+
+/**
+ * Returns the shared unit name when all values in a metric dataset agree on a
+ * single unit, otherwise null. Used to label "Per <unit>" in UI controls.
+ */
+export function getSharedUnit(config: ExplorationConfig | null): string | null {
+  if (!config?.dataset || config.dataset.type !== "metric") return null;
+  const units = config.dataset.values
+    .map((v) => v.unit)
+    .filter((u): u is string => !!u);
+  if (units.length === 0) return null;
+  const first = units[0];
+  return units.every((u) => u === first) ? first : null;
 }
 
 export interface RenderOpts {

--- a/packages/front-end/enterprise/components/ProductAnalytics/util.ts
+++ b/packages/front-end/enterprise/components/ProductAnalytics/util.ts
@@ -22,7 +22,22 @@ import {
   calculateProductAnalyticsDateRange,
   getDateGranularity,
   mapDatabaseTypeToEnum,
+  getMetricMixClass,
+  getEffectiveMetricValue,
 } from "shared/enterprise";
+export {
+  getMetricMixClass,
+  inferShowAs,
+  getEffectiveShowAs,
+  clearInapplicableShowAs,
+  getEffectiveMetricValue,
+  getSharedUnit,
+  showAsAppliesTo,
+  getIsRatioByIndex,
+  buildExplorationColumns,
+  getExplorationCellValue,
+} from "shared/enterprise";
+export type { MetricMixClass, ExplorationColumn } from "shared/enterprise";
 import { dateGranularity, explorationConfigValidator } from "shared/validators";
 
 export { mapDatabaseTypeToEnum };
@@ -266,6 +281,47 @@ export function validateDimensions(
     : config;
 }
 
+/**
+ * Fills in a default `unit` for metric values that have a resolved metric but
+ * no unit selected. Defaults to the numerator fact table's first userIdType.
+ *
+ * Without a unit, the SQL layer doesn't emit a denominator column, which breaks
+ * the per_unit branch of the showAs toggle and silently degrades ratio-like
+ * metrics. Applied when loading a config from any source (URL, AI agent, saved
+ * exploration) so users don't end up in that state.
+ *
+ * Skips:
+ * - fact_table / data_source datasets (their unit semantics are user-driven).
+ * - Metric values whose unit is already set.
+ * - Metric values whose metricId is empty or can't be resolved.
+ * - Metrics whose fact table has no userIdTypes (nothing to default to).
+ */
+export function fillMissingUnits(
+  config: ExplorationConfig,
+  getFactTableById: (id: string) => FactTableInterface | null,
+  getFactMetricById: (id: string) => FactMetricInterface | null,
+): ExplorationConfig {
+  if (!config.dataset || config.dataset.type !== "metric") return config;
+
+  let changed = false;
+  const newValues = config.dataset.values.map((v) => {
+    if (v.unit || !v.metricId) return v;
+    const metric = getFactMetricById(v.metricId);
+    if (!metric) return v;
+    const factTable = getFactTableById(metric.numerator.factTableId);
+    const defaultUnit = factTable?.userIdTypes?.[0];
+    if (!defaultUnit) return v;
+    changed = true;
+    return { ...v, unit: defaultUnit };
+  });
+
+  if (!changed) return config;
+  return {
+    ...config,
+    dataset: { ...config.dataset, values: newValues },
+  } as ExplorationConfig;
+}
+
 function hasNonEmptyValues(values: string[] | undefined): boolean {
   return (values ?? []).some((v) => v !== "");
 }
@@ -465,47 +521,6 @@ export function shouldChartSectionShow(params: {
   return true;
 }
 
-// --- Shared sorting helpers for chart & table ---
-
-/**
- * Build an array of `isRatio` flags indexed by dataset value position.
- * Only metric datasets can contain ratio values; fact_table and data_source
- * datasets never do.
- */
-export function getIsRatioByIndex(
-  config: ExplorationConfig | null,
-  getFactMetricById: (id: string) => FactMetricInterface | null,
-): boolean[] {
-  if (!config?.dataset || config.dataset.type !== "metric") return [];
-  return config.dataset.values.map((v) => {
-    const m = getFactMetricById(v.metricId ?? "");
-    return m?.metricType === "ratio";
-  });
-}
-
-// Classifies a metric for chart-mixing rules.
-// - "ratio"    -> always renders as N/D, can't be mixed with other classes
-// - "quantile" -> percentile value, can't be mixed with other classes
-// - "standard" -> mean/proportion/retention/dailyParticipation, mix freely
-// - "unknown"  -> unselected metric or metric id we couldn't resolve
-export type MetricMixClass = "ratio" | "quantile" | "standard" | "unknown";
-
-export function getMetricMixClass(
-  metricType: string | null | undefined,
-): MetricMixClass {
-  if (metricType === "ratio") return "ratio";
-  if (metricType === "quantile") return "quantile";
-  if (
-    metricType === "mean" ||
-    metricType === "proportion" ||
-    metricType === "retention" ||
-    metricType === "dailyParticipation"
-  ) {
-    return "standard";
-  }
-  return "unknown";
-}
-
 /**
  * Given the other already-selected metrics in the dataset (excluding the slot
  * being edited), return the class any newly selected metric must match — or
@@ -515,7 +530,7 @@ export function getMetricMixClass(
  */
 export function getLockedMixClass(
   otherMetricTypes: (string | null | undefined)[],
-): Exclude<MetricMixClass, "unknown"> | null {
+): "ratio" | "quantile" | "standard" | null {
   for (const t of otherMetricTypes) {
     const c = getMetricMixClass(t);
     if (c !== "unknown") return c;
@@ -523,128 +538,11 @@ export function getLockedMixClass(
   return null;
 }
 
-/**
- * True when the per-unit branch of `showAs` produces a meaningful value for
- * this metric type (i.e. the emitted denominator isn't a trivial function of
- * the numerator).
- *
- * - mean: yes. Numerator sums the column across units; denominator counts units
- *   with activity; per_unit = real average per unit.
- * - proportion / retention / dailyParticipation: no. These metrics emit one row
- *   per qualifying unit, so denominator (COUNT of numerator rows) == numerator
- *   and per_unit degenerates to ~1. Only totals make sense for these in PA.
- * - ratio / quantile: N/A, handled separately (ratios self-contain N/D, quantiles
- *   have no denominator emitted).
- * - unknown: assume yes so we don't hide the control while a metric is loading.
- */
-function metricHasMeaningfulPerUnit(
-  metricType: string | null | undefined,
-): boolean {
-  if (!metricType) return true;
-  if (metricType === "mean") return true;
-  return false;
-}
-
-/**
- * True when the chart-level `showAs` toggle is meaningful for this dataset.
- *
- * - Metric datasets: applies when at least one value is a standard metric for
- *   which per-unit rendering is non-degenerate. Ratio/quantile metrics ignore
- *   showAs, and proportion/retention/dailyParticipation collapse per_unit to ~1
- *   in the product-analytics layer (no exposure set → denominator == numerator).
- * - fact_table / data_source datasets: never applies. Their value types are
- *   count, sum, and unit_count. count/sum don't expose a unit selector, so no
- *   denominator is emitted; unit_count's per-unit value is always 1.
- */
-export function showAsAppliesTo(
-  config: ExplorationConfig | null,
-  getFactMetricById: (id: string) => FactMetricInterface | null,
-): boolean {
-  if (!config?.dataset) return false;
-  if (config.dataset.type !== "metric") return false;
-  if (config.dataset.values.length === 0) return false;
-  return config.dataset.values.some((v) => {
-    const type = getFactMetricById(v.metricId ?? "")?.metricType;
-    const c = getMetricMixClass(type);
-    if (c !== "standard" && c !== "unknown") return false;
-    return metricHasMeaningfulPerUnit(type);
-  });
-}
-
-/**
- * Infer a smart default for `showAs` when the user hasn't explicitly chosen one.
- *
- * Rule: default to `per_unit` only when the `total` rendering would be
- * mathematically incoherent — specifically, `mean` metrics whose numerator
- * aggregation is `max` (sum-of-per-unit-maxes has no interpretation) or
- * `count distinct` (sum-of-per-unit-distinct-counts double-counts values
- * shared across units). Everything else defaults to `total`: it's always a
- * coherent number, and for ambiguous cases (e.g. `mean` with `sum` aggregation,
- * which can be named either "total revenue" or "avg user spend" with identical
- * definitions) we don't try to guess intent.
- */
-export function inferShowAs(
-  config: ExplorationConfig | null,
-  getFactMetricById: (id: string) => FactMetricInterface | null,
-): ShowAs {
-  if (!showAsAppliesTo(config, getFactMetricById)) return "total";
-  if (!config || config.dataset.type !== "metric") return "total";
-
-  const allTotalIncoherent = config.dataset.values.every((v) => {
-    const m = getFactMetricById(v.metricId ?? "");
-    if (m?.metricType !== "mean") return false;
-    const agg = m.numerator?.aggregation ?? "sum";
-    return agg === "max" || agg === "count distinct";
-  });
-  return allTotalIncoherent ? "per_unit" : "total";
-}
-
-/**
- * Resolves the effective showAs for a config: the user's explicit choice when
- * set, otherwise the inferred default. Use this at read sites (chart/table/
- * sidebar) instead of `config.showAs ?? "total"` so the default matches the
- * semantics of the selected metrics.
- */
-export function getEffectiveShowAs(
-  config: ExplorationConfig | null,
-  getFactMetricById: (id: string) => FactMetricInterface | null,
-): ShowAs {
-  return config?.showAs ?? inferShowAs(config, getFactMetricById);
-}
-
-/**
- * Returns the shared unit name when all values in a metric dataset agree on a
- * single unit, otherwise null. Used to label "Per <unit>" in UI controls.
- */
-export function getSharedUnit(config: ExplorationConfig | null): string | null {
-  if (!config?.dataset || config.dataset.type !== "metric") return null;
-  const units = config.dataset.values
-    .map((v) => v.unit)
-    .filter((u): u is string => !!u);
-  if (units.length === 0) return null;
-  const first = units[0];
-  return units.every((u) => u === first) ? first : null;
-}
-
 export interface RenderOpts {
   showAs: ShowAs;
   // Indexed by the metric value's position in the dataset.values array.
   // Ratio metrics always render as numerator/denominator regardless of showAs.
   isRatioByIndex: boolean[];
-}
-
-export function getEffectiveMetricValue(
-  v: { numerator: number | null; denominator: number | null },
-  opts: { showAs: ShowAs; isRatio: boolean },
-): number {
-  const num = v.numerator ?? 0;
-  if (opts.isRatio) {
-    return v.denominator ? num / v.denominator : num;
-  }
-  if (opts.showAs === "per_unit") {
-    return v.denominator ? num / v.denominator : num;
-  }
-  return num;
 }
 
 function getRowTotal(row: ProductAnalyticsResultRow, opts: RenderOpts): number {

--- a/packages/front-end/enterprise/hooks/useAIChat/processSSEEvent.ts
+++ b/packages/front-end/enterprise/hooks/useAIChat/processSSEEvent.ts
@@ -27,6 +27,11 @@ function extractExplorationResultData(
   const data: Record<string, unknown> = {};
   if (typeof o.snapshotId === "string") data.snapshotId = o.snapshotId;
   if (o.exploration !== undefined) data.exploration = o.exploration;
+  // Include the top-level normalized config so the active-turn chart renders
+  // with the same config as the final persisted message. The exploration's
+  // embedded config can be stale (e.g. a cached exploration keeps its
+  // original showAs) — the top-level config reflects the current request.
+  if (o.config !== undefined) data.config = o.config;
   return data;
 }
 

--- a/packages/shared/src/enterprise/product-analytics/sql.ts
+++ b/packages/shared/src/enterprise/product-analytics/sql.ts
@@ -611,9 +611,16 @@ function getMetricData(
     }
   }
 
-  // For mean metrics, we need to count the units to calculate the average
+  // Always expose a denominator (unit count) for unit-aggregated non-ratio,
+  // non-quantile metrics so the frontend can render either the raw numerator
+  // (totals) or numerator/denominator (per-unit averages) based on the
+  // chart-level `showAs` setting.
   let rollupCountExpr: string | null = null;
-  if (metric.metricType === "mean" && selectedUnit) {
+  if (
+    selectedUnit &&
+    metric.metricType !== "ratio" &&
+    metric.metricType !== "quantile"
+  ) {
     rollupCountExpr = getRollupCountExpr(metric, alias);
   }
 

--- a/packages/shared/src/enterprise/product-analytics/sql.ts
+++ b/packages/shared/src/enterprise/product-analytics/sql.ts
@@ -890,6 +890,7 @@ function generateUnitAggregationRollupCTE(
   unitIndex: number,
   includedMetrics: MetricData[],
   allMetrics: string[],
+  aliasesWithDenominator: Set<string>,
   helpers: SqlHelpers,
 ): CTE {
   const selects: string[] = [];
@@ -909,14 +910,14 @@ function generateUnitAggregationRollupCTE(
       selects.push(
         `${helpers.castToFloat(metricData.rollupAggregationExpr || "NULL")} AS ${alias}_numerator`,
       );
-      if (metricData.rollupCountExpr) {
+      if (aliasesWithDenominator.has(alias)) {
         selects.push(
-          `${helpers.castToFloat(metricData.rollupCountExpr)} AS ${alias}_denominator`,
+          `${helpers.castToFloat(metricData.rollupCountExpr ?? "NULL")} AS ${alias}_denominator`,
         );
       }
     } else {
       selects.push(`${helpers.castToFloat("NULL")} AS ${alias}_numerator`);
-      if (metricData?.rollupCountExpr) {
+      if (aliasesWithDenominator.has(alias)) {
         selects.push(`${helpers.castToFloat("NULL")} AS ${alias}_denominator`);
       }
     }
@@ -939,6 +940,7 @@ function generateEventRollupCTE(
   dimensions: DimensionData[],
   includedMetrics: MetricData[],
   allMetrics: string[],
+  aliasesWithDenominator: Set<string>,
   helpers: SqlHelpers,
 ): CTE {
   const selects: string[] = [];
@@ -957,14 +959,14 @@ function generateEventRollupCTE(
       selects.push(
         `${helpers.castToFloat(metricData.rollupAggregationExpr || "NULL")} AS ${metricData.alias}_numerator`,
       );
-      if (metricData.rollupCountExpr) {
+      if (aliasesWithDenominator.has(alias)) {
         selects.push(
-          `${helpers.castToFloat(metricData.rollupCountExpr)} AS ${alias}_denominator`,
+          `${helpers.castToFloat(metricData.rollupCountExpr ?? "NULL")} AS ${alias}_denominator`,
         );
       }
     } else {
       selects.push(`${helpers.castToFloat("NULL")} AS ${alias}_numerator`);
-      if (metricData?.rollupCountExpr) {
+      if (aliasesWithDenominator.has(alias)) {
         selects.push(`${helpers.castToFloat("NULL")} AS ${alias}_denominator`);
       }
     }
@@ -1058,6 +1060,9 @@ export function generateProductAnalyticsSQL(
   });
 
   const allMetricsAliases: string[] = allMetrics.map((m) => m.alias);
+  const aliasesWithDenominator: Set<string> = new Set(
+    allMetrics.filter((m) => m.rollupCountExpr).map((m) => m.alias),
+  );
 
   // Get all dimensions
   const allDimensions: DimensionData[] = [];
@@ -1159,6 +1164,7 @@ export function generateProductAnalyticsSQL(
         unitIndex,
         metrics,
         allMetricsAliases,
+        aliasesWithDenominator,
         sqlHelpers,
       );
       ctes.push(unitRollupCTE);
@@ -1173,6 +1179,7 @@ export function generateProductAnalyticsSQL(
         allDimensions,
         eventMetrics,
         allMetricsAliases,
+        aliasesWithDenominator,
         sqlHelpers,
       );
       ctes.push(eventRollupCTE);

--- a/packages/shared/src/enterprise/product-analytics/sql.ts
+++ b/packages/shared/src/enterprise/product-analytics/sql.ts
@@ -615,6 +615,14 @@ function getMetricData(
   // non-quantile metrics so the frontend can render either the raw numerator
   // (totals) or numerator/denominator (per-unit averages) based on the
   // chart-level `showAs` setting.
+  //
+  // Intentionally symmetric across dataset types: fact_table/data_source
+  // datasets (where `showAsAppliesTo` returns false and the denominator is
+  // never surfaced) still emit this column. The extra `COUNT(...)` is cheap
+  // relative to the rest of the rollup and keeps the SQL shape / result
+  // column set identical regardless of dataset type, which simplifies the
+  // downstream parser and test fixtures. If this ever becomes a measurable
+  // cost, narrow the guard to metric datasets where per-unit is meaningful.
   let rollupCountExpr: string | null = null;
   if (
     selectedUnit &&

--- a/packages/shared/src/enterprise/product-analytics/utils/index.ts
+++ b/packages/shared/src/enterprise/product-analytics/utils/index.ts
@@ -1,4 +1,8 @@
-import type { ExplorationConfig } from "../../../validators/product-analytics";
+import type { FactMetricInterface } from "shared/types/fact-table";
+import type {
+  ExplorationConfig,
+  ShowAs,
+} from "../../../validators/product-analytics";
 
 export function mapDatabaseTypeToEnum(
   dbType: string,
@@ -108,4 +112,355 @@ export function getInitialConfigByBlockType(
 
 export function encodeExplorationConfig(config: ExplorationConfig): string {
   return btoa(encodeURIComponent(JSON.stringify(config)));
+}
+
+// ---- showAs inference & applicability ---------------------------------------
+//
+// These helpers are shared between the frontend Explorer UI and the backend
+// product analytics AI agent so that both surfaces resolve `showAs` and the
+// effective per-metric value identically. Keeping them in one place prevents
+// drift between what the chart renders and what the agent sees in its CSV.
+
+// Classifies a metric for chart-mixing rules.
+// - "ratio"    -> always renders as N/D, can't be mixed with other classes
+// - "quantile" -> percentile value, can't be mixed with other classes
+// - "standard" -> mean/proportion/retention/dailyParticipation, mix freely
+// - "unknown"  -> unselected metric or metric id we couldn't resolve
+export type MetricMixClass = "ratio" | "quantile" | "standard" | "unknown";
+
+export function getMetricMixClass(
+  metricType: string | null | undefined,
+): MetricMixClass {
+  if (metricType === "ratio") return "ratio";
+  if (metricType === "quantile") return "quantile";
+  if (
+    metricType === "mean" ||
+    metricType === "proportion" ||
+    metricType === "retention" ||
+    metricType === "dailyParticipation"
+  ) {
+    return "standard";
+  }
+  return "unknown";
+}
+
+/**
+ * True when the per-unit branch of `showAs` produces a meaningful value for
+ * this metric type (i.e. the emitted denominator isn't a trivial function of
+ * the numerator).
+ *
+ * - mean: yes. Numerator sums the column across units; denominator counts units
+ *   with activity; per_unit = real average per unit.
+ * - proportion / retention / dailyParticipation: no. These metrics emit one row
+ *   per qualifying unit, so denominator (COUNT of numerator rows) == numerator
+ *   and per_unit degenerates to ~1. Only totals make sense for these in PA.
+ * - ratio / quantile: N/A, handled separately (ratios self-contain N/D, quantiles
+ *   have no denominator emitted).
+ * - unknown: assume yes so we don't hide the control while a metric is loading.
+ */
+export function metricHasMeaningfulPerUnit(
+  metricType: string | null | undefined,
+): boolean {
+  if (!metricType) return true;
+  if (metricType === "mean") return true;
+  return false;
+}
+
+/**
+ * True when the chart-level `showAs` toggle is meaningful for this dataset.
+ *
+ * - Metric datasets: applies when at least one value is a standard metric for
+ *   which per-unit rendering is non-degenerate. Ratio/quantile metrics ignore
+ *   showAs, and proportion/retention/dailyParticipation collapse per_unit to ~1
+ *   in the product-analytics layer (no exposure set → denominator == numerator).
+ * - fact_table / data_source datasets: never applies.
+ */
+export function showAsAppliesTo(
+  config: ExplorationConfig | null,
+  getFactMetricById: (id: string) => FactMetricInterface | null,
+): boolean {
+  if (!config?.dataset) return false;
+  if (config.dataset.type !== "metric") return false;
+  if (config.dataset.values.length === 0) return false;
+  const selectedValues = config.dataset.values.filter((v) => !!v.metricId);
+  if (selectedValues.length === 0) return false;
+  return selectedValues.some((v) => {
+    const type = getFactMetricById(v.metricId ?? "")?.metricType;
+    const c = getMetricMixClass(type);
+    if (c !== "standard" && c !== "unknown") return false;
+    return metricHasMeaningfulPerUnit(type);
+  });
+}
+
+/**
+ * Infer a smart default for `showAs` when the user hasn't explicitly chosen one.
+ *
+ * Rule: default to `per_unit` only when the `total` rendering would be
+ * mathematically incoherent — specifically, `mean` metrics whose numerator
+ * aggregation is `max` (sum-of-per-unit-maxes has no interpretation) or
+ * `count distinct` (sum-of-per-unit-distinct-counts double-counts values
+ * shared across units). Everything else defaults to `total`.
+ */
+export function inferShowAs(
+  config: ExplorationConfig | null,
+  getFactMetricById: (id: string) => FactMetricInterface | null,
+): ShowAs {
+  if (!showAsAppliesTo(config, getFactMetricById)) return "total";
+  if (!config || config.dataset.type !== "metric") return "total";
+
+  // Only consider values that refer to a selected metric — empty/unresolved
+  // slots would otherwise short-circuit .every() to false and force "total".
+  // This matches the filter `showAsAppliesTo` uses to decide applicability.
+  const selectedValues = config.dataset.values.filter((v) => !!v.metricId);
+  if (selectedValues.length === 0) return "total";
+  const allTotalIncoherent = selectedValues.every((v) => {
+    const m = getFactMetricById(v.metricId ?? "");
+    if (m?.metricType !== "mean") return false;
+    const agg = m.numerator?.aggregation ?? "sum";
+    return agg === "max" || agg === "count distinct";
+  });
+  return allTotalIncoherent ? "per_unit" : "total";
+}
+
+/**
+ * Resolves the effective showAs for a config: the user's explicit choice when
+ * set, otherwise the inferred default. Use at read sites (chart/table/sidebar/
+ * agent CSV) instead of `config.showAs ?? "total"` so the default matches the
+ * semantics of the selected metrics.
+ *
+ * Invariant: callers are expected to clear `showAs` at write time (via
+ * `clearInapplicableShowAs`) when it doesn't apply to the current dataset, so
+ * we can trust `config.showAs` here without a read-side override.
+ */
+export function getEffectiveShowAs(
+  config: ExplorationConfig | null,
+  getFactMetricById: (id: string) => FactMetricInterface | null,
+): ShowAs {
+  return config?.showAs ?? inferShowAs(config, getFactMetricById);
+}
+
+/**
+ * Strips `showAs` from a config when the current dataset doesn't support it,
+ * so the stored value never lies about what will actually render. Call this
+ * alongside other write-time normalizers (validateDimensions, fillMissingUnits)
+ * whenever a config is created, loaded, or mutated.
+ *
+ * Returns the same reference when nothing changed so callers can use identity
+ * comparisons to avoid unnecessary re-renders.
+ */
+export function clearInapplicableShowAs<T extends ExplorationConfig>(
+  config: T,
+  getFactMetricById: (id: string) => FactMetricInterface | null,
+): T {
+  if (config.showAs === undefined) return config;
+  if (showAsAppliesTo(config, getFactMetricById)) return config;
+  const { showAs: _showAs, ...rest } = config;
+  return rest as T;
+}
+
+/**
+ * Returns the shared unit name when all values in a metric dataset agree on a
+ * single unit, otherwise null. Used to label "Per <unit>" in UI controls and
+ * the agent's CSV output.
+ */
+export function getSharedUnit(config: ExplorationConfig | null): string | null {
+  if (!config?.dataset || config.dataset.type !== "metric") return null;
+  const units = config.dataset.values
+    .map((v) => v.unit)
+    .filter((u): u is string => !!u);
+  if (units.length === 0) return null;
+  const first = units[0];
+  return units.every((u) => u === first) ? first : null;
+}
+
+/**
+ * Computes the effective numeric value for a single metric result cell, given
+ * the effective showAs and whether the underlying metric is a ratio. Ratios
+ * always render as N/D regardless of showAs.
+ */
+export function getEffectiveMetricValue(
+  v: { numerator: number | null; denominator: number | null },
+  opts: { showAs: ShowAs; isRatio: boolean },
+): number {
+  const num = v.numerator ?? 0;
+  if (opts.isRatio) {
+    return v.denominator ? num / v.denominator : num;
+  }
+  if (opts.showAs === "per_unit") {
+    return v.denominator ? num / v.denominator : num;
+  }
+  return num;
+}
+
+/**
+ * Build an array of `isRatio` flags indexed by dataset value position.
+ * Only metric datasets can contain ratio values; fact_table and data_source
+ * datasets never do.
+ */
+export function getIsRatioByIndex(
+  config: ExplorationConfig | null,
+  getFactMetricById: (id: string) => FactMetricInterface | null,
+): boolean[] {
+  if (!config?.dataset || config.dataset.type !== "metric") return [];
+  return config.dataset.values.map((v) => {
+    const m = getFactMetricById(v.metricId ?? "");
+    return m?.metricType === "ratio";
+  });
+}
+
+// ---- Exploration table column schema ----------------------------------------
+//
+// These helpers produce a canonical column layout + header labels for an
+// exploration result, shared between the Explorer result table (React) and
+// the AI agent's CSV serializer. Keeping the schema in one place guarantees
+// both surfaces show the same set of columns, in the same order, with the
+// same meaning — no more drift between "what the chart/table shows" and
+// "what the agent sees in its CSV".
+
+export type ExplorationColumn =
+  | {
+      kind: "dimension";
+      key: string;
+      label: string;
+      dimIndex: number;
+    }
+  | {
+      kind: "metric";
+      key: string;
+      label: string;
+      metricIndex: number;
+      /**
+       * - "numerator" / "denominator" / "value": the three columns emitted for
+       *   ratio metrics (Value = N/D).
+       * - "single": one column whose value respects the effective showAs.
+       */
+      sub: "numerator" | "denominator" | "value" | "single";
+    };
+
+/**
+ * Compute the human-readable labels used for dimension columns. Date and
+ * "Total"-fallback handling matches both the Explorer table and the agent CSV.
+ */
+function getDimensionLabels(config: ExplorationConfig | null): string[] {
+  const labels: string[] = [];
+  for (const d of config?.dimensions ?? []) {
+    if (d.dimensionType === "date") labels.push("Date");
+    else if (d.dimensionType === "dynamic")
+      labels.push(d.column ?? "Dimension");
+    else if (d.dimensionType === "static") labels.push(d.column);
+    else if (d.dimensionType === "slice") labels.push("Slice");
+    else labels.push("Dimension");
+  }
+  if (labels.length === 0) labels.push("Total");
+  return labels;
+}
+
+/**
+ * Build the full column schema for an exploration result: dimension columns
+ * followed by metric columns. Ratio metrics expand into three sub-columns
+ * (Numerator / Denominator / Value); everything else renders as a single
+ * column whose header encodes the effective showAs (e.g. "revenue per
+ * user_id" vs "revenue"), so a reader of just the table or CSV can tell at a
+ * glance which mode the numbers are in.
+ */
+export function buildExplorationColumns(
+  config: ExplorationConfig | null,
+  getFactMetricById: (id: string) => FactMetricInterface | null,
+): ExplorationColumn[] {
+  const cols: ExplorationColumn[] = [];
+
+  // Keys are stable, machine-oriented identifiers that stay unique even when
+  // two metrics resolve to the same display label (e.g. "revenue" and
+  // "revenue per user_id" in per_unit mode). Labels carry the display string.
+  const dimLabels = getDimensionLabels(config);
+  dimLabels.forEach((label, i) => {
+    cols.push({ kind: "dimension", key: `__dim_${i}__`, label, dimIndex: i });
+  });
+
+  const values = config?.dataset?.values ?? [];
+  if (values.length === 0) return cols;
+
+  const isRatio = getIsRatioByIndex(config, getFactMetricById);
+  const effectiveShowAs = getEffectiveShowAs(config, getFactMetricById);
+  const sharedUnit = getSharedUnit(config);
+
+  values.forEach((v, metricIndex) => {
+    const name = v.name;
+    if (isRatio[metricIndex]) {
+      cols.push({
+        kind: "metric",
+        key: `__metric_${metricIndex}_numerator__`,
+        label: `${name} Numerator`,
+        metricIndex,
+        sub: "numerator",
+      });
+      cols.push({
+        kind: "metric",
+        key: `__metric_${metricIndex}_denominator__`,
+        label: `${name} Denominator`,
+        metricIndex,
+        sub: "denominator",
+      });
+      cols.push({
+        kind: "metric",
+        key: `__metric_${metricIndex}_value__`,
+        label: `${name} Value`,
+        metricIndex,
+        sub: "value",
+      });
+      return;
+    }
+
+    let singleLabel = name;
+    if (effectiveShowAs === "per_unit") {
+      const unit =
+        ("unit" in v && typeof v.unit === "string" ? v.unit : null) ||
+        sharedUnit ||
+        "unit";
+      singleLabel = `${name} per ${unit}`;
+    }
+    cols.push({
+      kind: "metric",
+      key: `__metric_${metricIndex}__`,
+      label: singleLabel,
+      metricIndex,
+      sub: "single",
+    });
+  });
+
+  return cols;
+}
+
+/**
+ * Extract the raw cell value for a given column slot from a result row, using
+ * the effective showAs / ratio flags to decide how "single" cells are
+ * computed. Returns `null` for missing data, a `number` for metric cells, and
+ * a `string | null` for dimension cells. Formatting (decimal places, date
+ * strings) is left to each surface to apply.
+ */
+export function getExplorationCellValue(
+  row: {
+    dimensions: (string | null)[];
+    values: { numerator: number | null; denominator: number | null }[];
+  },
+  col: ExplorationColumn,
+  renderOpts: { showAs: ShowAs; isRatioByIndex: boolean[] },
+): string | number | null {
+  if (col.kind === "dimension") {
+    return row.dimensions[col.dimIndex] ?? null;
+  }
+  const v = row.values[col.metricIndex];
+  if (!v) return null;
+  if (col.sub === "numerator") return v.numerator;
+  if (col.sub === "denominator") return v.denominator;
+  if (col.sub === "value") {
+    if (v.numerator != null && v.denominator)
+      return v.numerator / v.denominator;
+    return null;
+  }
+  if (v.numerator == null) return null;
+  return getEffectiveMetricValue(v, {
+    showAs: renderOpts.showAs,
+    isRatio: renderOpts.isRatioByIndex[col.metricIndex] ?? false,
+  });
 }

--- a/packages/shared/src/enterprise/product-analytics/utils/index.ts
+++ b/packages/shared/src/enterprise/product-analytics/utils/index.ts
@@ -58,6 +58,7 @@ export const DEFAULT_EXPLORE_STATE: ExplorationConfig = {
     startDate: null,
     endDate: null,
   },
+  showAs: "total",
 };
 
 export type ProductAnalyticsExplorationBlockType =

--- a/packages/shared/src/enterprise/product-analytics/utils/index.ts
+++ b/packages/shared/src/enterprise/product-analytics/utils/index.ts
@@ -195,11 +195,14 @@ export function showAsAppliesTo(
 /**
  * Infer a smart default for `showAs` when the user hasn't explicitly chosen one.
  *
- * Rule: default to `per_unit` only when the `total` rendering would be
- * mathematically incoherent — specifically, `mean` metrics whose numerator
- * aggregation is `max` (sum-of-per-unit-maxes has no interpretation) or
- * `count distinct` (sum-of-per-unit-distinct-counts double-counts values
- * shared across units). Everything else defaults to `total`.
+ * Rule: default to `per_unit` when any `mean` metric in the dataset would
+ * render an incoherent total — specifically, numerator aggregation `max`
+ * (sum-of-per-unit-maxes has no interpretation) or `count distinct`
+ * (sum-of-per-unit-distinct-counts double-counts values shared across
+ * units). In a mixed dataset (e.g. mean+max alongside a proportion), the
+ * mean portion would otherwise silently show a mathematically wrong total
+ * until the user toggles. Non-mean metrics do not block the default, and
+ * everything else falls through to `total`.
  */
 export function inferShowAs(
   config: ExplorationConfig | null,
@@ -208,18 +211,15 @@ export function inferShowAs(
   if (!showAsAppliesTo(config, getFactMetricById)) return "total";
   if (!config || config.dataset.type !== "metric") return "total";
 
-  // Only consider values that refer to a selected metric — empty/unresolved
-  // slots would otherwise short-circuit .every() to false and force "total".
-  // This matches the filter `showAsAppliesTo` uses to decide applicability.
   const selectedValues = config.dataset.values.filter((v) => !!v.metricId);
   if (selectedValues.length === 0) return "total";
-  const allTotalIncoherent = selectedValues.every((v) => {
+  const anyMeanIsIncoherentAsTotal = selectedValues.some((v) => {
     const m = getFactMetricById(v.metricId ?? "");
     if (m?.metricType !== "mean") return false;
     const agg = m.numerator?.aggregation ?? "sum";
     return agg === "max" || agg === "count distinct";
   });
-  return allTotalIncoherent ? "per_unit" : "total";
+  return anyMeanIsIncoherentAsTotal ? "per_unit" : "total";
 }
 
 /**
@@ -254,7 +254,8 @@ export function clearInapplicableShowAs<T extends ExplorationConfig>(
 ): T {
   if (config.showAs === undefined) return config;
   if (showAsAppliesTo(config, getFactMetricById)) return config;
-  const { showAs: _showAs, ...rest } = config;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { showAs, ...rest } = config;
   return rest as T;
 }
 

--- a/packages/shared/src/validators/product-analytics.ts
+++ b/packages/shared/src/validators/product-analytics.ts
@@ -150,6 +150,9 @@ export const dateRangePredefined = [
 
 export const lookbackUnit = ["hour", "day", "week", "month"] as const;
 
+export const showAsValidator = z.enum(["total", "per_unit"]);
+export type ShowAs = z.infer<typeof showAsValidator>;
+
 export const baseExplorationConfigValidator = z.object({
   datasource: z.string().describe("ID of the datasource to query"),
   dimensions: z.array(dimensionValidator),
@@ -161,6 +164,13 @@ export const baseExplorationConfigValidator = z.object({
     startDate: z.string().nullish(),
     endDate: z.string().nullish(),
   }),
+  // Controls how values with a denominator are rendered at the chart level.
+  // "total"    -> render the raw numerator (e.g. total events)
+  // "per_unit" -> divide numerator by denominator (e.g. events per unit)
+  // Ratio metrics are self-contained and always render as numerator/denominator
+  // regardless of this setting.
+  // Optional for backward compatibility; read sites default to "total".
+  showAs: showAsValidator.optional(),
 });
 
 export const metricExplorationConfigValidator =

--- a/packages/shared/test/product-analytics.test.ts
+++ b/packages/shared/test/product-analytics.test.ts
@@ -111,6 +111,7 @@ describe("productAnalytics", () => {
       type: "fact_table",
       datasource: "ds_1",
       chartType: "line",
+      showAs: "total",
       dateRange: {
         predefined: "last7Days",
         startDate: null,
@@ -231,6 +232,7 @@ describe("productAnalytics", () => {
       type: "fact_table",
       datasource: "ds_1",
       chartType: "line",
+      showAs: "total",
       dateRange: {
         predefined: "last7Days",
         startDate: null,
@@ -358,6 +360,7 @@ describe("productAnalytics", () => {
       type: "fact_table",
       datasource: "ds_1",
       chartType: "line",
+      showAs: "total",
       dateRange: {
         predefined: "last7Days",
         startDate: null,
@@ -492,6 +495,7 @@ describe("productAnalytics", () => {
       type: "fact_table",
       datasource: "ds_1",
       chartType: "line",
+      showAs: "total",
       dateRange: {
         predefined: "last7Days",
         startDate: null,

--- a/packages/shared/test/product-analytics.test.ts
+++ b/packages/shared/test/product-analytics.test.ts
@@ -194,6 +194,7 @@ describe("productAnalytics", () => {
           SELECT
             dimension0,
             CAST(SUM(m0) AS FLOAT) AS m0_numerator,
+            CAST(COUNT(m0) AS FLOAT) AS m0_denominator,
             CAST(NULL AS FLOAT) AS m1_numerator
           FROM _factTable0_unit0
           GROUP BY
@@ -203,6 +204,7 @@ describe("productAnalytics", () => {
           SELECT
             dimension0,
             CAST(NULL AS FLOAT) AS m0_numerator,
+            CAST(NULL AS FLOAT) AS m0_denominator,
             CAST(SUM(m1) AS FLOAT) AS m1_numerator
           FROM _factTable0_rows
           GROUP BY
@@ -216,6 +218,7 @@ describe("productAnalytics", () => {
       SELECT
         dimension0,
         MAX(m0_numerator) AS m0_numerator,
+        MAX(m0_denominator) AS m0_denominator,
         MAX(m1_numerator) AS m1_numerator
       FROM _combined_rollup
       GROUP BY
@@ -322,6 +325,7 @@ describe("productAnalytics", () => {
           SELECT
             dimension0,
             CAST(SUM(m0) AS FLOAT) AS m0_numerator,
+            CAST(COUNT(m0) AS FLOAT) AS m0_denominator,
             CAST(NULL AS FLOAT) AS m1_numerator
           FROM _factTable0_unit0
           GROUP BY
@@ -331,6 +335,7 @@ describe("productAnalytics", () => {
           SELECT
             dimension0,
             CAST(NULL AS FLOAT) AS m0_numerator,
+            CAST(NULL AS FLOAT) AS m0_denominator,
             CAST(SUM(m1) AS FLOAT) AS m1_numerator
           FROM _factTable0_rows
           GROUP BY
@@ -344,6 +349,7 @@ describe("productAnalytics", () => {
       SELECT
         dimension0,
         MAX(m0_numerator) AS m0_numerator,
+        MAX(m0_denominator) AS m0_denominator,
         MAX(m1_numerator) AS m1_numerator
       FROM _combined_rollup
       GROUP BY
@@ -457,6 +463,7 @@ describe("productAnalytics", () => {
           SELECT
             dimension0,
             CAST(SUM(m0) AS FLOAT) AS m0_numerator,
+            CAST(COUNT(m0) AS FLOAT) AS m0_denominator,
             CAST(NULL AS FLOAT) AS m1_numerator
           FROM _factTable0_unit0
           GROUP BY
@@ -466,6 +473,7 @@ describe("productAnalytics", () => {
           SELECT
             dimension0,
             CAST(NULL AS FLOAT) AS m0_numerator,
+            CAST(NULL AS FLOAT) AS m0_denominator,
             CAST(SUM(m1) AS FLOAT) AS m1_numerator
           FROM _factTable0_rows
           GROUP BY
@@ -479,6 +487,7 @@ describe("productAnalytics", () => {
       SELECT
         dimension0,
         MAX(m0_numerator) AS m0_numerator,
+        MAX(m0_denominator) AS m0_denominator,
         MAX(m1_numerator) AS m1_numerator
       FROM _combined_rollup
       GROUP BY
@@ -592,6 +601,7 @@ describe("productAnalytics", () => {
           SELECT
             dimension0,
             CAST(SUM(m0) AS FLOAT) AS m0_numerator,
+            CAST(COUNT(m0) AS FLOAT) AS m0_denominator,
             CAST(NULL AS FLOAT) AS m1_numerator
           FROM _factTable0_unit0
           GROUP BY
@@ -601,6 +611,7 @@ describe("productAnalytics", () => {
           SELECT
             dimension0,
             CAST(NULL AS FLOAT) AS m0_numerator,
+            CAST(NULL AS FLOAT) AS m0_denominator,
             CAST(SUM(m1) AS FLOAT) AS m1_numerator
           FROM _factTable0_rows
           GROUP BY
@@ -614,6 +625,7 @@ describe("productAnalytics", () => {
       SELECT
         dimension0,
         MAX(m0_numerator) AS m0_numerator,
+        MAX(m0_denominator) AS m0_denominator,
         MAX(m1_numerator) AS m1_numerator
       FROM _combined_rollup
       GROUP BY


### PR DESCRIPTION
# Product Analytics: "Show As" toggle + unit handling fixes

## Summary

Adds a chart-level **Show As** control (`total` vs `per_unit`) to Product Analytics explorations so the same underlying metrics can be rendered as raw totals (e.g. "total events") or per-unit averages (e.g. "events per user") without editing the metric. This also fixes a bug where mean metrics without a `unit` were silently losing their denominator in SQL, which broke any per-unit rendering downstream (chart, table, and agent CSV).

## What changed

**Schema / validators** (`packages/shared`)

- New optional `showAs: "total" | "per_unit"` on `baseExplorationConfigValidator` (back-compat; read sites default to the inferred value).
- SQL layer (`sql.ts`) now always emits a denominator/unit-count column for any unit-aggregated non-ratio, non-quantile metric, so the frontend can switch between totals and per-unit on the fly.
- Regenerated `spec.yaml` to expose `showAs` on all PA endpoints.

**Shared helpers** (`packages/shared/src/enterprise/product-analytics/utils`)

- New `showAs` helpers: `inferShowAs`, `getEffectiveShowAs`, `clearInapplicableShowAs`, `showAsAppliesTo`, `getSharedUnit`.
- `getEffectiveMetricValue` now takes `{ showAs, isRatio }` — ratios always render as N/D; standard metrics respect `showAs`.
- New `buildExplorationColumns` + `getExplorationCellValue`: single source of truth for the exploration column schema (dimension columns, ratio expansion into Numerator/Denominator/Value, per-unit header labels). Used by both the Explorer result table and the agent's CSV.
- New `getMetricMixClass` + `getLockedMixClass` for mixing rules (ratio / quantile / standard).

**Explorer UI** (`packages/front-end/enterprise/components/ProductAnalytics`)

- New `ShowAsSection` sidebar control, conditionally rendered via `showAsAppliesTo` (hidden for fact_table/data_source datasets and for metric datasets where per-unit is degenerate).
- `ExplorerChart` respects the effective `showAs`, adds a Y-axis name ("Total" / "Per \<unit\>") and routes all cell/total computations through the shared helpers.
- `useExplorationTableData` reuses the shared column builder + cell extractor; display-only concerns (date formatting, rounding, "Total" fallback) stay in the hook.
- `MetricTabContent`: metric options now always show the full list and disable incompatible metrics with a tooltip (e.g. "Ratio metrics can't be combined with other metric types.") instead of silently hiding them.
- `ValueCard`: mean metrics now support unit selection.
- `ExplorerContext` normalizes configs on load and on every draft update via `fillMissingUnits` (backfills `userIdTypes[0]`) and `clearInapplicableShowAs` (strips `showAs` when it doesn't apply), so URL-loaded, AI-generated, and saved configs never disagree with what the chart renders.
- `toFetchKey` excludes `showAs` so toggling it doesn't trigger a refetch.

**AI agent** (`packages/back-end/src/enterprise/services/product-analytics-agent.ts`)

- Prompt updated with `<show_as_rules>` and tightened `<unit_rules>` (always set `unit` for standard metric types).
- `buildResultCsv` switched to the shared column schema + cell extractor, so the CSV the agent reads matches the column set, ordering, and effective `showAs` of the on-screen table/chart. Column headers now encode the mode (`"<name>"` vs `"<name> per <unit>"`).
- Snapshot summary now surfaces `showAs` transitions for follow-up turns.
- `processSSEEvent.ts`: forwards the top-level normalized config during active turns so the streaming chart matches the final persisted one.

**Misc**

- `DisplayTestQueryResults` grows an optional `columnLabels` prop so callers can pass stable keys + separate display labels (used by the exploration table to render per-unit headers without losing column identity).
- `ChatMessageList`: fix a bug where the agent's collapsed-steps expansion state could snap shut mid-turn; expansion now resets only when a new user turn begins.
- Tests updated for the default `showAs: "total"` in `DEFAULT_EXPLORE_STATE`.

## Behavior by metric type

| Metric type(s) | Unit selector | Show As toggle | Renders | Inferred default |
|---|---|---|---|---|
| `mean` | shown | **shown** | `total` → raw numerator; `per_unit` → numerator / unit count | `per_unit` when numerator aggregation is `max` or `count distinct` (totals are incoherent); otherwise `total` |
| `proportion`, `retention`, `dailyParticipation` | shown | hidden | raw numerator (per-unit would collapse to ~1 since denominator == numerator) | — |
| `ratio` | shown only when numerator is `$$distinctUsers` | hidden | always N/D (self-contained) | — |
| `quantile` | hidden | hidden | percentile value (no denominator emitted) | — |

Rules of thumb:

- **Show As toggle visibility**: requires at least one `mean` metric in the dataset. Datasets made entirely of the other types hide the toggle because per-unit is either degenerate or self-contained.
- **Mixing**: `ratio` and `quantile` can't be combined with other classes; `mean` / `proportion` / `retention` / `dailyParticipation` can mix freely with each other. Incompatible options appear disabled in the dropdown with a tooltip.
- **fact_table / data_source datasets**: Show As never applies — values render as the raw emitted number.

## Backwards compatibility

- `showAs` is optional everywhere; read sites fall back to `inferShowAs`, which only picks `per_unit` when totals would be mathematically incoherent (mean + `max` / `count distinct` aggregations). All existing saved configs render as `"total"` by default, unchanged.
- Existing configs without a `unit` on mean metrics are auto-filled at load time, restoring correct denominators without requiring a re-save.

## Testing

- Pick a `mean` metric (e.g. revenue). Show As toggle appears in the sidebar. Flip between **Event Totals** and **Per \<unit\>** — chart values, Y-axis label, and result table header (`"<name>"` vs `"<name> per <unit>"`) all update together. Toggling doesn't trigger a refetch.
- Switch to a `proportion` / `retention` / `dailyParticipation` / `ratio` / `quantile` metric — toggle is hidden.
- Add a `ratio` metric, then try to add a `mean` alongside it — incompatible options are disabled in the dropdown with a tooltip.
- Open an older mean-metric exploration that was saved without a `unit` — chart renders correctly (denominator is backfilled from `userIdTypes[0]`).
- Ask the PA AI agent "revenue per user last 7 days" then "total revenue last 7 days" — the chart flips modes and the agent's response describes the numbers matching the Y-axis label.

