### PR TITLE
feat(snapshot-chunks): Add stable key and use it for updates

### DIFF
--- a/packages/back-end/src/controllers/reports.ts
+++ b/packages/back-end/src/controllers/reports.ts
@@ -95,6 +95,9 @@ export async function postReportFromSnapshot(
     throw new Error("Missing analysis settings");
   }
 
+  // Enforce a single analysis per snapshot for reports
+  snapshot.analyses = [analysis];
+
   const phaseIndex = snapshot.phase ?? (experiment.phases?.length || 1) - 1;
   const _experimentAnalysisSettings: ExperimentReportAnalysisSettings = {
     ...pick(experiment, Object.keys(experimentAnalysisSettings.shape)),

--- a/packages/back-end/src/models/ExperimentSnapshotAnalysisChunkModel.ts
+++ b/packages/back-end/src/models/ExperimentSnapshotAnalysisChunkModel.ts
@@ -2,7 +2,8 @@ import {
   encodeSnapshotAnalysisChunks,
   decodeSnapshotAnalysisChunks,
   buildMetricOrdering,
-  getChunkedAnalysesMetaFromSnapshot,
+  migrateLegacySnapshotAnalysisChunkData,
+  remapChunkDataPositionKeysToAnalysisKeys,
   AnalysisMetaEntry,
 } from "shared/snapshot-analysis-chunks";
 import {
@@ -16,11 +17,6 @@ import {
   ExperimentSnapshotSettings,
 } from "shared/types/experiment-snapshot";
 import { MakeModelClass, waitForIndexes } from "./BaseModel";
-
-type ChunkWriteResult = {
-  chunkedAnalysesMeta: AnalysisMetaEntry[];
-  metricIds: string[];
-};
 
 const BaseClass = MakeModelClass({
   schema: experimentSnapshotAnalysisChunkValidator,
@@ -61,33 +57,93 @@ export class ExperimentSnapshotAnalysisChunkModel extends BaseClass {
     return true;
   }
 
+  // Phase 1 of the legacy chunk migration: rewrite the flat
+  // `{numRows, data:{a,d,v,...}}` shape into per-position records
+  // (`{ "0": {...}, "1": {...} }`). Keying by position keeps this
+  // migration self-contained — the position→`analysisKey` rename
+  // requires the parent snapshot and runs in `populateChunkedAnalyses`
+  // (phase 2). Idempotent on already-normalized docs.
+  protected migrate(
+    legacyDoc: unknown,
+  ): ExperimentSnapshotAnalysisChunkInterface {
+    const doc = { ...(legacyDoc as Record<string, unknown>) };
+    const { data } = migrateLegacySnapshotAnalysisChunkData(
+      doc as { data?: unknown; numRows?: unknown },
+    );
+    doc.data = data;
+    // Top-level `numRows` is a legacy-only field; the strict validator
+    // doesn't include it. Strip so reads don't carry stale state.
+    delete doc.numRows;
+    return doc as unknown as ExperimentSnapshotAnalysisChunkInterface;
+  }
+
   protected async customValidation(
     doc: ExperimentSnapshotAnalysisChunkInterface,
   ) {
-    validateExperimentSnapshotAnalysisChunkColumnLengths(doc);
+    this.validateWriteData(doc.data);
+  }
+
+  // Single choke point for write-path validation. BaseModel wires
+  // `customValidation` into create/update, but `writeAnalyses` issues
+  // `bulkWrite` directly and bypasses that hook — so every write path
+  // must delegate here. Keeping the helper on the model class makes it
+  // obvious where to plug new writers in.
+  private validateWriteData(
+    data: Record<string, { numRows: number } & Record<string, unknown>>,
+  ) {
+    validateExperimentSnapshotAnalysisChunkColumnLengths({ data });
   }
 
   /**
-   * Encode snapshot analyses and write one document per metric.
-   * Returns chunkedAnalysesMeta for storage on the main snapshot document.
+   * Write a set of analyses' sub-paths onto the snapshot's metric chunk
+   * docs. Encoding is always per-analysis (`data.<analysisKey>`); the
+   * `scope` parameter controls how authoritative the passed set is over
+   * what's already on disk.
+   *
+   * - `scope: "all"` — the passed `analyses` are the complete set for the
+   *   snapshot. For each metric chunk: any key in the passed set with no
+   *   rows for that metric has its sub-path unset; chunks for metrics no
+   *   longer in the set are deleted. Use when rebuilding a snapshot
+   *   wholesale (creation, `updateSnapshot({ analyses })`).
+   *
+   * - `scope: "keys"` — only the passed analyses' sub-paths are
+   *   authoritative; other analyses on the snapshot are untouched. For
+   *   each passed key, sub-paths on metrics that dropped out of its new
+   *   result set are unset (scoped to that key's field). Race-safe
+   *   against concurrent writes to other analyses because every write
+   *   targets only `data.<passedKey>`. Use for single-analysis
+   *   add-or-update via {@link upsertAnalysis}.
+   *
+   * Ordering is always upsert-then-prune so readers never observe a key
+   * in `chunkedAnalysesMeta` whose chunk sub-paths have been wiped (the
+   * inverse would create a visibility window of ghost-empty results).
    */
-  public async createFromAnalyses({
+  public async writeAnalyses({
     snapshotId,
     experimentId,
     analyses,
     settings,
+    scope,
   }: {
     snapshotId: string;
     experimentId: string;
     analyses: ExperimentSnapshotAnalysis[];
     settings: ExperimentSnapshotSettings;
-  }): Promise<ChunkWriteResult> {
+    scope: "all" | "keys";
+  }): Promise<{
+    chunkedAnalysesMeta: Record<string, AnalysisMetaEntry>;
+    metricIds: string[];
+  }> {
+    // For "all", no analyses or no results means nothing to persist and
+    // nothing to clean up (snapshot creation path). For "keys", an empty
+    // or empty-results analysis still needs its sub-path cleared on disk,
+    // so only short-circuit on a truly empty input list.
     if (
       analyses.length === 0 ||
-      analyses.every((analysis) => analysis.results.length === 0)
+      (scope === "all" &&
+        analyses.every((analysis) => analysis.results.length === 0))
     ) {
-      // Analyses without result rows have no chunk data or metadata to persist.
-      return { chunkedAnalysesMeta: [], metricIds: [] };
+      return { chunkedAnalysesMeta: {}, metricIds: [] };
     }
 
     const metricOrdering = getMetricOrdering(settings);
@@ -95,48 +151,176 @@ export class ExperimentSnapshotAnalysisChunkModel extends BaseClass {
       analyses,
       metricOrdering,
     );
+    const analysisKeys = analyses.map((a) => a.analysisKey);
     const entries = Array.from(metricChunks.entries());
     const metricIds = entries.map(([metricId]) => metricId);
+
+    // Per-key "keep" metric set. Used by the scope:"keys" prune below to
+    // unset a key's sub-path on chunks where it used to contribute rows
+    // but no longer does.
+    const metricIdsByKey = new Map<string, string[]>(
+      analysisKeys.map((key) => [key, []]),
+    );
+    for (const [metricId, perMetricData] of entries) {
+      for (const key of analysisKeys) {
+        if (perMetricData[key]) metricIdsByKey.get(key)!.push(metricId);
+      }
+    }
+
     await waitForIndexes();
 
+    // 1. Upsert. For scope:"all" we inline-unset keys in the passed set
+    //    that are absent from a given metric chunk. For scope:"keys" the
+    //    stale-unset is a separate post-pass (step 2 below) because we
+    //    don't know up-front which chunks previously carried the key.
+    // Track whether step 1 issued any `$unset` — only those can leave a
+    // chunk's `data` empty, and only then does step 3's sweep have work.
+    let hadInlineUnsets = false;
     if (entries.length) {
       const now = new Date();
       await this.bulkWrite(
-        entries.map(([metricId, chunk]) => {
-          validateExperimentSnapshotAnalysisChunkColumnLengths(chunk);
+        entries.map(([metricId, perMetricData]) => {
+          this.validateWriteData(perMetricData);
+
+          const setOps: Record<string, unknown> = {
+            experimentId,
+            dateUpdated: now,
+          };
+          const unsetOps: Record<string, ""> = {};
+          for (const key of analysisKeys) {
+            const perAnalysis = perMetricData[key];
+            if (perAnalysis) {
+              setOps[`data.${key}`] = perAnalysis;
+            } else if (scope === "all") {
+              unsetOps[`data.${key}`] = "";
+            }
+          }
+
+          const hasUnsets = Object.keys(unsetOps).length > 0;
+          if (hasUnsets) hadInlineUnsets = true;
+
+          const update: Record<string, unknown> = {
+            $set: setOps,
+            $setOnInsert: {
+              id: this._generateId(),
+              dateCreated: now,
+            },
+            ...(hasUnsets ? { $unset: unsetOps } : {}),
+          };
 
           return {
             updateOne: {
-              filter: {
-                snapshotId,
-                metricId,
-              },
-              update: {
-                $set: {
-                  experimentId,
-                  numRows: chunk.numRows,
-                  data: chunk.data,
-                  dateUpdated: now,
-                },
-                $setOnInsert: {
-                  id: this._generateId(),
-                  dateCreated: now,
-                },
-              },
+              filter: { snapshotId, metricId },
+              update,
               upsert: true,
             },
           };
         }),
       );
+    }
 
-      await this._dangerousGetCollection().deleteMany({
-        organization: this.context.org.id,
+    // 2. Prune stale state per scope.
+    const coll = this._dangerousGetCollection();
+    const organization = this.context.org.id;
+
+    let anyPruneUnsetModified = false;
+    if (scope === "all") {
+      // Chunks for metrics that dropped out of the snapshot entirely.
+      // This deletes whole chunks (never leaves `data: {}` behind), so
+      // it doesn't contribute to the step-3 sweep decision.
+      await coll.deleteMany({
+        organization,
         snapshotId,
         metricId: { $nin: metricIds },
+      });
+    } else {
+      // For each passed key, drop `data.<key>` from chunks where it
+      // previously contributed rows but doesn't now. `$nin: []` matches
+      // every chunk, which correctly covers the empty-results case
+      // (clear the key everywhere). Each unset targets a disjoint
+      // sub-path per key, so parallel dispatch is safe.
+      const pruneResults = await Promise.all(
+        analysisKeys.map((key) =>
+          coll.updateMany(
+            {
+              organization,
+              snapshotId,
+              metricId: { $nin: metricIdsByKey.get(key) ?? [] },
+              [`data.${key}`]: { $exists: true },
+            },
+            { $unset: { [`data.${key}`]: "" } },
+          ),
+        ),
+      );
+      anyPruneUnsetModified = pruneResults.some((r) => r.modifiedCount > 0);
+    }
+
+    // 3. Shared sweep: drop chunk docs whose `data` became empty as a
+    //    result of unsets in steps 1 or 2. Skip when no unset could
+    //    possibly have emptied a chunk — at steady state every
+    //    `upsertAnalysis` call hits this path, so the saved round-trip
+    //    is meaningful under fan-out.
+    if (hadInlineUnsets || anyPruneUnsetModified) {
+      await coll.deleteMany({
+        organization,
+        snapshotId,
+        $or: [{ data: {} }, { data: { $exists: false } }],
       });
     }
 
     return { chunkedAnalysesMeta, metricIds };
+  }
+
+  /**
+   * Convenience wrapper for single-analysis writes. Delegates to
+   * {@link writeAnalyses} with `scope: "keys"` and returns the meta entry
+   * for the passed analysis (the shape callers have always consumed).
+   */
+  public async upsertAnalysis({
+    snapshotId,
+    experimentId,
+    analysis,
+    settings,
+  }: {
+    snapshotId: string;
+    experimentId: string;
+    analysis: ExperimentSnapshotAnalysis;
+    settings: ExperimentSnapshotSettings;
+  }): Promise<{ metaEntry: AnalysisMetaEntry; metricIds: string[] }> {
+    const { chunkedAnalysesMeta, metricIds } = await this.writeAnalyses({
+      snapshotId,
+      experimentId,
+      analyses: [analysis],
+      settings,
+      scope: "keys",
+    });
+    const metaEntry = chunkedAnalysesMeta[analysis.analysisKey] ?? {
+      dimensions: [],
+    };
+    return { metaEntry, metricIds };
+  }
+
+  /**
+   * Remove a single analysis's sub-path from every chunk for the snapshot.
+   * Used when a write path needs to roll back its own minted key — e.g.,
+   * when `addOrUpdateSnapshotAnalysis` loses a same-settings race and has
+   * to clean up the speculative `data.<mintedKey>` it wrote before
+   * delegating to the update path.
+   */
+  public async removeAnalysisChunks(snapshotId: string, analysisKey: string) {
+    await this._dangerousGetCollection().updateMany(
+      {
+        organization: this.context.org.id,
+        snapshotId,
+        [`data.${analysisKey}`]: { $exists: true },
+      },
+      { $unset: { [`data.${analysisKey}`]: "" } },
+    );
+    await this._dangerousGetCollection().deleteMany({
+      organization: this.context.org.id,
+      snapshotId,
+      $or: [{ data: {} }, { data: { $exists: false } }],
+    });
   }
 
   /**
@@ -155,7 +339,19 @@ export class ExperimentSnapshotAnalysisChunkModel extends BaseClass {
     snapshots: ExperimentSnapshotInterface[],
     metricIds?: string[],
   ) {
-    const chunkedSnapshots = snapshots.filter((s) => s.hasChunkedAnalyses);
+    // A snapshot "has chunks" if EITHER the stored `hasChunkedAnalyses`
+    // flag or its `chunkedAnalysesMeta` record says so. The flag alone is
+    // unreliable: a single-analysis writer can flip it to `false` based on
+    // a stale read taken before a concurrent writer populated another
+    // analysis. The meta unset in that write is scoped per-key so
+    // surviving meta entries remain on disk — checking them here ensures
+    // populated data is never hidden by a stale flag.
+    const chunkedSnapshots = snapshots.filter(
+      (s) =>
+        s.hasChunkedAnalyses ||
+        (!!s.chunkedAnalysesMeta &&
+          Object.keys(s.chunkedAnalysesMeta).length > 0),
+    );
     if (!chunkedSnapshots.length) return;
 
     const query: Record<string, unknown> = {
@@ -167,7 +363,6 @@ export class ExperimentSnapshotAnalysisChunkModel extends BaseClass {
 
     const allChunks = await this._find(query);
 
-    // Group chunks by snapshot ID
     const chunksBySnapshotId = new Map<
       string,
       ExperimentSnapshotAnalysisChunkInterface[]
@@ -179,23 +374,47 @@ export class ExperimentSnapshotAnalysisChunkModel extends BaseClass {
       chunksBySnapshotId.get(chunk.snapshotId)!.push(chunk);
     }
 
-    // Decode and populate each snapshot
     const filterMetricIds = metricIds ? new Set(metricIds) : undefined;
     for (const snapshot of chunkedSnapshots) {
       const chunks = chunksBySnapshotId.get(snapshot.id) ?? [];
-      if (!chunks.length && !snapshot.chunkedAnalysesMeta?.length) continue;
+      const metaHasEntries =
+        !!snapshot.chunkedAnalysesMeta &&
+        Object.keys(snapshot.chunkedAnalysesMeta).length > 0;
+      if (!chunks.length && !metaHasEntries) continue;
 
-      const { chunkedAnalysesMeta, analysisMetadata } =
-        getChunkedAnalysesMetaFromSnapshot(snapshot);
+      // Phase 2 of the chunk migration: chunks come out of `_find` with
+      // shape already normalized by `migrate()` above (phase 1), so
+      // either keyed by `analysisKey` (post-refactor docs) or by
+      // numeric position (legacy docs). Rename positions to
+      // `analysisKey`s using the snapshot's own ordering — this is the
+      // only place we have both pieces of context. Idempotent on
+      // already-renamed data.
+      const analysisKeysByPosition = snapshot.analyses.map(
+        (a) => a.analysisKey,
+      );
+      const decodableChunks = chunks.map((chunk) => ({
+        metricId: chunk.metricId,
+        data: remapChunkDataPositionKeysToAnalysisKeys(
+          chunk.data,
+          analysisKeysByPosition,
+        ),
+      }));
 
       const decoded = decodeSnapshotAnalysisChunks(
-        chunks,
-        chunkedAnalysesMeta,
-        analysisMetadata,
+        decodableChunks,
+        snapshot.chunkedAnalysesMeta ?? {},
+        snapshot.analyses.map((a) => ({
+          analysisKey: a.analysisKey,
+          settings: a.settings,
+          dateCreated: a.dateCreated,
+          status: a.status,
+          ...(a.error ? { error: a.error } : {}),
+        })),
         filterMetricIds,
       );
 
-      // Merge decoded results into snapshot analyses
+      // `decoded` mirrors the order of `snapshot.analyses` (we built
+      // `analysisMetadata` from it above). Positional mapping back is safe.
       for (let i = 0; i < decoded.length; i++) {
         if (snapshot.analyses[i]) {
           snapshot.analyses[i].results = decoded[i].results;

--- a/packages/back-end/src/models/ExperimentSnapshotAnalysisChunkModel.ts
+++ b/packages/back-end/src/models/ExperimentSnapshotAnalysisChunkModel.ts
@@ -413,10 +413,26 @@ export class ExperimentSnapshotAnalysisChunkModel extends BaseClass {
         filterMetricIds,
       );
 
+      const chunkedAnalysesMeta = snapshot.chunkedAnalysesMeta ?? {};
+      const chunkDataKeys = new Set<string>();
+      for (const chunk of decodableChunks) {
+        for (const key of Object.keys(chunk.data)) {
+          chunkDataKeys.add(key);
+        }
+      }
+
       // `decoded` mirrors the order of `snapshot.analyses` (we built
       // `analysisMetadata` from it above). Positional mapping back is safe.
+      // Preserve inline results on legacy snapshots that were partially
+      // transitioned to chunked storage: only analyses that actually have
+      // chunk/meta state should be overwritten from decoded chunk data.
       for (let i = 0; i < decoded.length; i++) {
-        if (snapshot.analyses[i]) {
+        const analysis = snapshot.analyses[i];
+        if (
+          analysis &&
+          (chunkedAnalysesMeta[analysis.analysisKey] ||
+            chunkDataKeys.has(analysis.analysisKey))
+        ) {
           snapshot.analyses[i].results = decoded[i].results;
         }
       }

--- a/packages/back-end/src/models/ExperimentSnapshotModel.ts
+++ b/packages/back-end/src/models/ExperimentSnapshotModel.ts
@@ -1169,7 +1169,10 @@ async function persistLegacyAnalysisMigration({
 }) {
   const setOps: Record<string, unknown> = {};
 
-  if (legacyChunkedAnalysesMeta !== undefined) {
+  if (
+    legacyChunkedAnalysesMeta !== undefined ||
+    keylessAnalysisPositions.length > 0
+  ) {
     setOps.chunkedAnalysesMeta = snapshot.chunkedAnalysesMeta ?? {};
   }
 

--- a/packages/back-end/src/models/ExperimentSnapshotModel.ts
+++ b/packages/back-end/src/models/ExperimentSnapshotModel.ts
@@ -14,7 +14,11 @@ import {
   LegacyExperimentSnapshotInterface,
   ExperimentSnapshotSettings,
 } from "shared/types/experiment-snapshot";
-import { AnalysisMetaEntry } from "shared/snapshot-analysis-chunks";
+import {
+  AnalysisKeyType,
+  AnalysisMetaEntry,
+  buildAnalysisKey,
+} from "shared/snapshot-analysis-chunks";
 import { logger } from "back-end/src/util/logger";
 import { migrateSnapshot } from "back-end/src/util/migrations";
 import { notifyExperimentChange } from "back-end/src/services/experimentNotifications";
@@ -81,8 +85,9 @@ const experimentSnapshotSchema = new mongoose.Schema({
   settings: {},
   analyses: {},
   hasChunkedAnalyses: Boolean,
-  chunkedAnalysesMeta: [
-    {
+  chunkedAnalysesMeta: {
+    type: Map,
+    of: {
       _id: false,
       dimensions: [
         {
@@ -93,7 +98,7 @@ const experimentSnapshotSchema = new mongoose.Schema({
         },
       ],
     },
-  ],
+  },
   results: [
     {
       _id: false,
@@ -286,18 +291,19 @@ async function chunkAndStripAnalyses({
 }): Promise<{
   strippedAnalyses: ExperimentSnapshotAnalysis[];
   hasChunkedAnalyses: true;
-  chunkedAnalysesMeta: AnalysisMetaEntry[];
+  chunkedAnalysesMeta: Record<AnalysisKeyType, AnalysisMetaEntry>;
   metricIds: string[];
 } | null> {
   const hasResults = analyses.some((a) => a.results?.length > 0);
   if (!hasResults) return null;
 
   const chunkWrite =
-    await context.models.experimentSnapshotAnalysisChunks.createFromAnalyses({
+    await context.models.experimentSnapshotAnalysisChunks.writeAnalyses({
       snapshotId,
       experimentId,
       analyses,
       settings,
+      scope: "all",
     });
 
   return {
@@ -315,12 +321,15 @@ export async function updateSnapshotsOnPhaseDelete(
 ) {
   const organization = context.org.id;
 
-  // Delete associated chunks for snapshots being deleted
+  // Delete associated chunks for snapshots being deleted. We avoid filtering
+  // by `hasChunkedAnalyses` because single-analysis writers can race and leave
+  // the on-disk flag stale-false while chunks still exist (see
+  // `buildMetaOpsForAnalysisWrite`). `deleteBySnapshotIds` is a no-op for
+  // snapshots without chunks, so enumerating all phase snapshots is safe.
   const snapshotsToDelete = await ExperimentSnapshotModel.find({
     organization,
     experiment,
     phase,
-    hasChunkedAnalyses: true,
   }).select({ id: 1 });
   if (snapshotsToDelete.length) {
     await context.models.experimentSnapshotAnalysisChunks.deleteBySnapshotIds(
@@ -371,29 +380,45 @@ export async function updateSnapshot({
     throw "Cannot update snapshot that does not exist.";
   }
 
-  const updatesForDb = { ...updates };
+  const existingInterface = toInterface(existingSnapshotModel);
+  const updatesForDb: Partial<ExperimentSnapshotInterface> = { ...updates };
   let deleteExistingChunksAfterUpdate = false;
   let chunkResult: Awaited<ReturnType<typeof chunkAndStripAnalyses>> = null;
   let experimentSnapshot: ExperimentSnapshotInterface = {
-    ...toInterface(existingSnapshotModel),
+    ...existingInterface,
     ...updates,
   };
 
   const analysisUpdates = updates.analyses;
   const hasAnalysisUpdates = analysisUpdates !== undefined;
 
+  // Normalize analysis keys up front: preserve keys by settings-match against
+  // the existing on-disk analyses so in-place updates stay on the same
+  // sub-path, mint fresh ones for analyses that don't match.
+  const normalizedAnalyses = hasAnalysisUpdates
+    ? analysisUpdates.map((analysis) => {
+        const resolvedKey = resolveAnalysisKey(
+          existingInterface.analyses,
+          analysis,
+        );
+        return analysis.analysisKey === resolvedKey
+          ? analysis
+          : { ...analysis, analysisKey: resolvedKey };
+      })
+    : undefined;
+
   // If analyses have results, chunk them into separate documents
-  if (hasAnalysisUpdates) {
+  if (normalizedAnalyses) {
     chunkResult = await chunkAndStripAnalyses({
       context,
       snapshotId: id,
       experimentId: experimentSnapshot.experiment,
-      analyses: analysisUpdates,
+      analyses: normalizedAnalyses,
       settings: experimentSnapshot.settings,
     });
   }
 
-  if (chunkResult) {
+  if (chunkResult && normalizedAnalyses) {
     deleteExistingChunksAfterUpdate = chunkResult.metricIds.length === 0;
     // Clear results from the main document while keeping the logical snapshot
     // populated for post-success side effects below.
@@ -402,18 +427,20 @@ export async function updateSnapshot({
     updatesForDb.chunkedAnalysesMeta = chunkResult.chunkedAnalysesMeta;
     experimentSnapshot = {
       ...experimentSnapshot,
-      analyses: analysisUpdates ?? experimentSnapshot.analyses,
+      analyses: normalizedAnalyses,
       hasChunkedAnalyses: chunkResult.hasChunkedAnalyses,
       chunkedAnalysesMeta: chunkResult.chunkedAnalysesMeta,
     };
-  } else if (hasAnalysisUpdates) {
+  } else if (normalizedAnalyses) {
     deleteExistingChunksAfterUpdate = true;
+    updatesForDb.analyses = normalizedAnalyses;
     updatesForDb.hasChunkedAnalyses = false;
-    updatesForDb.chunkedAnalysesMeta = [];
+    updatesForDb.chunkedAnalysesMeta = {};
     experimentSnapshot = {
       ...experimentSnapshot,
+      analyses: normalizedAnalyses,
       hasChunkedAnalyses: false,
-      chunkedAnalysesMeta: [],
+      chunkedAnalysesMeta: {},
     };
   }
 
@@ -536,78 +563,113 @@ export async function addOrUpdateSnapshotAnalysis(
   const { context, id, analysis } = params;
   const organization = context.org.id;
 
-  // For chunked snapshots, handle results separately
-  const snapshot = await ExperimentSnapshotModel.findOne({
-    organization,
-    id,
-  });
+  // Read the existing snapshot so we can resolve analysisKey deterministically:
+  // match by settings to keep in-place updates on the same sub-path, otherwise
+  // use the caller's key (or mint one if missing) for the push.
+  const existing = await ExperimentSnapshotModel.findOne({ organization, id });
+  if (!existing) {
+    throw "Cannot update snapshot analysis that does not exist.";
+  }
+  const existingInterface = toInterface(existing);
 
-  if (snapshot?.hasChunkedAnalyses) {
-    const snapshotInterface = toInterface(snapshot);
-    await populateSnapshotAnalyses(context, snapshotInterface);
+  const existingIndex = getAnalysisIndexBySettings(
+    existingInterface.analyses,
+    analysis.settings,
+  );
+  const analysisKey =
+    existingIndex !== -1
+      ? existingInterface.analyses[existingIndex].analysisKey
+      : analysis.analysisKey || buildAnalysisKey();
+  const keyedAnalysis: ExperimentSnapshotAnalysis = {
+    ...analysis,
+    analysisKey,
+  };
 
-    const existingAnalysisIndex = getAnalysisIndexBySettings(
-      snapshotInterface.analyses,
-      analysis.settings,
-    );
-    const analyses =
-      existingAnalysisIndex === -1
-        ? [...snapshotInterface.analyses, analysis]
-        : snapshotInterface.analyses.map((existingAnalysis, i) =>
-            i === existingAnalysisIndex ? analysis : existingAnalysis,
-          );
-
-    const chunkResult = await chunkAndStripAnalyses({
-      context,
+  // Write the analysis's chunk sub-path atomically. Scoped to
+  // `data.<analysisKey>` so concurrent writers for other analyses never
+  // contend on the same MongoDB field.
+  const hasResults = keyedAnalysis.results.length > 0;
+  const { metaEntry } =
+    await context.models.experimentSnapshotAnalysisChunks.upsertAnalysis({
       snapshotId: id,
-      experimentId: snapshotInterface.experiment,
-      analyses,
-      settings: snapshotInterface.settings,
+      experimentId: existingInterface.experiment,
+      analysis: keyedAnalysis,
+      settings: existingInterface.settings,
     });
-    const updatesForDb: Partial<ExperimentSnapshotInterface> = chunkResult
-      ? {
-          analyses: chunkResult.strippedAnalyses,
-          hasChunkedAnalyses: chunkResult.hasChunkedAnalyses,
-          chunkedAnalysesMeta: chunkResult.chunkedAnalysesMeta,
-        }
-      : {
-          analyses,
-          hasChunkedAnalyses: false,
-          chunkedAnalysesMeta: [],
-        };
 
-    await ExperimentSnapshotModel.updateOne(
-      { organization, id },
+  // Stripped copy of the analysis (results live in chunk docs once written).
+  const strippedAnalysis: ExperimentSnapshotAnalysis = hasResults
+    ? { ...keyedAnalysis, results: [] }
+    : keyedAnalysis;
+
+  // Decide whether resetting this analysis to empty should also flip the
+  // top-level `hasChunkedAnalyses` flag off. Safe when no other analysis has
+  // chunks on disk (per `existingInterface`). Benign race: a concurrent
+  // populating writer re-sets the flag to true on their write. The meta wipe
+  // is always scoped to `analysisKey` so concurrent writers for other keys
+  // never lose their meta entry.
+  const clearAllMeta =
+    !hasResults && isLastPopulatedAnalysis(existingInterface, analysisKey);
+
+  if (existingIndex === -1) {
+    // New analysis: atomic $push guarded by $ne on settings (existing idiom)
+    // to prevent double-inserts when two writers race on the same settings.
+    const { setOps, unsetOps } = buildMetaOpsForAnalysisWrite({
+      analysisKey,
+      metaEntry,
+      hasResults,
+      clearAllMeta,
+    });
+    const updateDoc: Record<string, unknown> = {
+      $push: { analyses: strippedAnalysis },
+      $set: setOps,
+    };
+    if (Object.keys(unsetOps).length) updateDoc.$unset = unsetOps;
+    const pushRes = await ExperimentSnapshotModel.updateOne(
       {
-        $set: updatesForDb,
-      },
-    );
-
-    if (!chunkResult || chunkResult.metricIds.length === 0) {
-      await context.models.experimentSnapshotAnalysisChunks.deleteBySnapshotId(
+        organization,
         id,
+        "analyses.settings": { $ne: keyedAnalysis.settings },
+      },
+      updateDoc,
+    );
+    if (pushRes.matchedCount === 0) {
+      // A concurrent writer inserted the same-settings analysis first and
+      // won the $push. `upsertAnalysis` already wrote our minted
+      // `data.<analysisKey>` sub-path into every metric chunk, and those
+      // would orphan forever (the winning writer owns a different key that
+      // no one ever migrates to ours). Clean them up before delegating.
+      await context.models.experimentSnapshotAnalysisChunks.removeAnalysisChunks(
+        id,
+        analysisKey,
       );
+      // Delegate to the update path — it re-reads the snapshot and resolves
+      // the winning key by settings match.
+      await updateSnapshotAnalysis({ context, id, analysis });
     }
     return;
   }
 
-  // Non-chunked path (legacy or first-time)
-  // looks for snapshots with this ID but WITHOUT these analysis settings
-  const experimentSnapshotModel = await ExperimentSnapshotModel.updateOne(
+  // Existing analysis: positional $set on the matched settings (existing
+  // idiom) keeps the analysis doc aligned with its pre-existing position.
+  const { setOps, unsetOps } = buildMetaOpsForAnalysisWrite({
+    analysisKey,
+    metaEntry,
+    hasResults,
+    clearAllMeta,
+  });
+  const updateDoc: Record<string, unknown> = {
+    $set: { "analyses.$": strippedAnalysis, ...setOps },
+  };
+  if (Object.keys(unsetOps).length) updateDoc.$unset = unsetOps;
+  await ExperimentSnapshotModel.updateOne(
     {
       organization,
       id,
-      "analyses.settings": { $ne: analysis.settings },
+      "analyses.settings": keyedAnalysis.settings,
     },
-    {
-      $push: { analyses: analysis },
-    },
+    updateDoc,
   );
-  // if analysis already exist, no documents will be returned by above query
-  // so instead find and update existing analysis in DB
-  if (experimentSnapshotModel.matchedCount === 0) {
-    await updateSnapshotAnalysis({ context, id, analysis });
-  }
 }
 
 export async function updateSnapshotAnalysis({
@@ -621,70 +683,55 @@ export async function updateSnapshotAnalysis({
 }) {
   const organization = context.org.id;
 
-  // For chunked snapshots, update the analysis doc and rebuild chunks
-  const snapshot = await ExperimentSnapshotModel.findOne({
-    organization,
-    id,
-  });
+  const existing = await ExperimentSnapshotModel.findOne({ organization, id });
+  if (!existing) return;
+  const existingInterface = toInterface(existing);
 
-  if (snapshot?.hasChunkedAnalyses) {
-    const snapshotInterface = toInterface(snapshot);
-    const existingAnalysisIndex = getAnalysisIndexBySettings(
-      snapshotInterface.analyses,
-      analysis.settings,
-    );
-    if (existingAnalysisIndex === -1) {
-      return;
-    }
+  const existingIndex = getAnalysisIndexBySettings(
+    existingInterface.analyses,
+    analysis.settings,
+  );
+  if (existingIndex === -1) return;
 
-    await populateSnapshotAnalyses(context, snapshotInterface);
-    const analyses = snapshotInterface.analyses.map((existingAnalysis, i) =>
-      i === existingAnalysisIndex ? analysis : existingAnalysis,
-    );
-    const chunkResult = await chunkAndStripAnalyses({
-      context,
+  const analysisKey = existingInterface.analyses[existingIndex].analysisKey;
+  const keyedAnalysis: ExperimentSnapshotAnalysis = {
+    ...analysis,
+    analysisKey,
+  };
+
+  const hasResults = keyedAnalysis.results.length > 0;
+  const { metaEntry } =
+    await context.models.experimentSnapshotAnalysisChunks.upsertAnalysis({
       snapshotId: id,
-      experimentId: snapshotInterface.experiment,
-      analyses,
-      settings: snapshotInterface.settings,
+      experimentId: existingInterface.experiment,
+      analysis: keyedAnalysis,
+      settings: existingInterface.settings,
     });
-    const updatesForDb: Partial<ExperimentSnapshotInterface> = chunkResult
-      ? {
-          analyses: chunkResult.strippedAnalyses,
-          hasChunkedAnalyses: chunkResult.hasChunkedAnalyses,
-          chunkedAnalysesMeta: chunkResult.chunkedAnalysesMeta,
-        }
-      : {
-          analyses,
-          hasChunkedAnalyses: false,
-          chunkedAnalysesMeta: [],
-        };
 
-    await ExperimentSnapshotModel.updateOne(
-      { organization, id },
-      {
-        $set: updatesForDb,
-      },
-    );
+  const strippedAnalysis: ExperimentSnapshotAnalysis = hasResults
+    ? { ...keyedAnalysis, results: [] }
+    : keyedAnalysis;
 
-    if (!chunkResult || chunkResult.metricIds.length === 0) {
-      await context.models.experimentSnapshotAnalysisChunks.deleteBySnapshotId(
-        id,
-      );
-    }
-    return;
-  }
+  const clearAllMeta =
+    !hasResults && isLastPopulatedAnalysis(existingInterface, analysisKey);
+  const { setOps, unsetOps } = buildMetaOpsForAnalysisWrite({
+    analysisKey,
+    metaEntry,
+    hasResults,
+    clearAllMeta,
+  });
+  const updateDoc: Record<string, unknown> = {
+    $set: { "analyses.$": strippedAnalysis, ...setOps },
+  };
+  if (Object.keys(unsetOps).length) updateDoc.$unset = unsetOps;
 
-  // Non-chunked path
   await ExperimentSnapshotModel.updateOne(
     {
       organization,
       id,
-      "analyses.settings": analysis.settings,
+      "analyses.settings": keyedAnalysis.settings,
     },
-    {
-      $set: { "analyses.$": analysis },
-    },
+    updateDoc,
   );
 
   // Not notifying on new analysis because new analyses in an existing snapshot
@@ -1008,3 +1055,68 @@ export async function createExperimentSnapshotModel({
 export const getDefaultAnalysisResults = (
   snapshot: ExperimentSnapshotDocument,
 ) => snapshot.analyses?.[0]?.results?.[0];
+
+// Resolve the analysisKey to use when writing `analysis` into `existing`.
+// A match by settings reuses the existing key so in-place updates stay on the
+// same sub-path; otherwise we mint a fresh key (or reuse the caller-supplied
+// one if present).
+function resolveAnalysisKey(
+  existing: ExperimentSnapshotAnalysis[],
+  analysis: ExperimentSnapshotAnalysis,
+): string {
+  const existingIndex = getAnalysisIndexBySettings(existing, analysis.settings);
+  if (existingIndex !== -1) return existing[existingIndex].analysisKey;
+  return analysis.analysisKey || buildAnalysisKey();
+}
+
+// Returns true if every analysis key other than `ignoreKey` has no dimensions
+// in meta. Used to decide whether clearing a single analysis leaves nothing
+// chunked (so we can clear `hasChunkedAnalyses`/meta). Benign race: if a
+// concurrent writer is populating another key, they set the flag back to true
+// on their write, so the worst case is a transient stale `hasChunkedAnalyses`.
+function isLastPopulatedAnalysis(
+  snapshot: ExperimentSnapshotInterface,
+  ignoreKey: string,
+): boolean {
+  const meta = snapshot.chunkedAnalysesMeta ?? {};
+  for (const [key, entry] of Object.entries(meta)) {
+    if (key === ignoreKey) continue;
+    if (entry?.dimensions?.length) return false;
+  }
+  return true;
+}
+
+// Build the meta mutation operators for a single-analysis write. The meta
+// sub-path (`chunkedAnalysesMeta.<analysisKey>`) is always keyed off
+// `analysisKey` — writers for other keys never contend on the same field, so
+// a concurrent writer's meta survives our clear. The `hasChunkedAnalyses`
+// flag is still written best-effort (benign race; see `migrateSnapshot` for
+// read-time derivation safety).
+function buildMetaOpsForAnalysisWrite({
+  analysisKey,
+  metaEntry,
+  hasResults,
+  clearAllMeta,
+}: {
+  analysisKey: string;
+  metaEntry: AnalysisMetaEntry;
+  hasResults: boolean;
+  clearAllMeta: boolean;
+}): {
+  setOps: Record<string, unknown>;
+  unsetOps: Record<string, unknown>;
+} {
+  if (clearAllMeta) {
+    return {
+      setOps: { hasChunkedAnalyses: false },
+      unsetOps: { [`chunkedAnalysesMeta.${analysisKey}`]: "" },
+    };
+  }
+  return {
+    setOps: {
+      [`chunkedAnalysesMeta.${analysisKey}`]: metaEntry,
+      ...(hasResults ? { hasChunkedAnalyses: true } : {}),
+    },
+    unsetOps: {},
+  };
+}

--- a/packages/back-end/src/models/ExperimentSnapshotModel.ts
+++ b/packages/back-end/src/models/ExperimentSnapshotModel.ts
@@ -585,6 +585,12 @@ export async function addOrUpdateSnapshotAnalysis(
     analysisKey,
   };
 
+  await normalizeLegacyChunkedAnalysesMeta({
+    organization,
+    id,
+    migratedMeta: existingInterface.chunkedAnalysesMeta ?? {},
+  });
+
   // Write the analysis's chunk sub-path atomically. Scoped to
   // `data.<analysisKey>` so concurrent writers for other analyses never
   // contend on the same MongoDB field.
@@ -698,6 +704,12 @@ export async function updateSnapshotAnalysis({
     ...analysis,
     analysisKey,
   };
+
+  await normalizeLegacyChunkedAnalysesMeta({
+    organization,
+    id,
+    migratedMeta: existingInterface.chunkedAnalysesMeta ?? {},
+  });
 
   const hasResults = keyedAnalysis.results.length > 0;
   const { metaEntry } =
@@ -1084,6 +1096,27 @@ function isLastPopulatedAnalysis(
     if (entry?.dimensions?.length) return false;
   }
   return true;
+}
+
+async function normalizeLegacyChunkedAnalysesMeta({
+  organization,
+  id,
+  migratedMeta,
+}: {
+  organization: string;
+  id: string;
+  migratedMeta: Record<AnalysisKeyType, AnalysisMetaEntry>;
+}) {
+  await ExperimentSnapshotModel.collection.updateOne(
+    {
+      organization,
+      id,
+      chunkedAnalysesMeta: { $type: "array" },
+    },
+    {
+      $set: { chunkedAnalysesMeta: migratedMeta },
+    },
+  );
 }
 
 // Build the meta mutation operators for a single-analysis write. The meta

--- a/packages/back-end/src/models/ExperimentSnapshotModel.ts
+++ b/packages/back-end/src/models/ExperimentSnapshotModel.ts
@@ -1068,14 +1068,17 @@ export const getDefaultAnalysisResults = (
   snapshot: ExperimentSnapshotDocument,
 ) => snapshot.analyses?.[0]?.results?.[0];
 
-// Resolve the analysisKey to use when writing `analysis` into `existing`.
-// A match by settings reuses the existing key so in-place updates stay on the
-// same sub-path; otherwise we mint a fresh key (or reuse the caller-supplied
-// one if present).
 function resolveAnalysisKey(
   existing: ExperimentSnapshotAnalysis[],
   analysis: ExperimentSnapshotAnalysis,
 ): string {
+  if (
+    analysis.analysisKey &&
+    existing.some((a) => a.analysisKey === analysis.analysisKey)
+  ) {
+    return analysis.analysisKey;
+  }
+
   const existingIndex = getAnalysisIndexBySettings(existing, analysis.settings);
   if (existingIndex !== -1) return existing[existingIndex].analysisKey;
   return analysis.analysisKey || buildAnalysisKey();

--- a/packages/back-end/src/models/ExperimentSnapshotModel.ts
+++ b/packages/back-end/src/models/ExperimentSnapshotModel.ts
@@ -245,6 +245,40 @@ const toInterface = (
     omit(doc.toJSON<ExperimentSnapshotDocument>(), ["__v", "_id"]),
   );
 
+async function prepareSnapshotForAnalysisWrite({
+  organization,
+  id,
+  doc,
+}: {
+  organization: string;
+  id: string;
+  doc: ExperimentSnapshotDocument;
+}): Promise<ExperimentSnapshotInterface> {
+  const legacySnapshot = omit(doc.toJSON<ExperimentSnapshotDocument>(), [
+    "__v",
+    "_id",
+  ]) as LegacyExperimentSnapshotInterface;
+  // `migrateSnapshot` adds missing analysisKeys by mutating the analysis
+  // objects, so capture the raw on-disk legacy state before calling it.
+  const keylessAnalysisPositions = getKeylessAnalysisPositions(
+    legacySnapshot.analyses,
+  );
+  const legacyChunkedAnalysesMeta = getLegacyChunkedAnalysesMeta(
+    legacySnapshot.chunkedAnalysesMeta,
+  );
+  const snapshot = migrateSnapshot(legacySnapshot);
+
+  await persistLegacyAnalysisMigration({
+    organization,
+    id,
+    snapshot,
+    legacyChunkedAnalysesMeta,
+    keylessAnalysisPositions,
+  });
+
+  return snapshot;
+}
+
 function getAnalysisIndexBySettings(
   analyses: ExperimentSnapshotAnalysis[],
   settings: ExperimentSnapshotAnalysis["settings"],
@@ -570,7 +604,11 @@ export async function addOrUpdateSnapshotAnalysis(
   if (!existing) {
     throw "Cannot update snapshot analysis that does not exist.";
   }
-  const existingInterface = toInterface(existing);
+  const existingInterface = await prepareSnapshotForAnalysisWrite({
+    organization,
+    id,
+    doc: existing,
+  });
 
   const existingIndex = getAnalysisIndexBySettings(
     existingInterface.analyses,
@@ -584,12 +622,6 @@ export async function addOrUpdateSnapshotAnalysis(
     ...analysis,
     analysisKey,
   };
-
-  await normalizeLegacyChunkedAnalysesMeta({
-    organization,
-    id,
-    migratedMeta: existingInterface.chunkedAnalysesMeta ?? {},
-  });
 
   // Write the analysis's chunk sub-path atomically. Scoped to
   // `data.<analysisKey>` so concurrent writers for other analyses never
@@ -649,8 +681,6 @@ export async function addOrUpdateSnapshotAnalysis(
         id,
         analysisKey,
       );
-      // Delegate to the update path — it re-reads the snapshot and resolves
-      // the winning key by settings match.
       await updateSnapshotAnalysis({ context, id, analysis });
     }
     return;
@@ -691,7 +721,11 @@ export async function updateSnapshotAnalysis({
 
   const existing = await ExperimentSnapshotModel.findOne({ organization, id });
   if (!existing) return;
-  const existingInterface = toInterface(existing);
+  const existingInterface = await prepareSnapshotForAnalysisWrite({
+    organization,
+    id,
+    doc: existing,
+  });
 
   const existingIndex = getAnalysisIndexBySettings(
     existingInterface.analyses,
@@ -704,12 +738,6 @@ export async function updateSnapshotAnalysis({
     ...analysis,
     analysisKey,
   };
-
-  await normalizeLegacyChunkedAnalysesMeta({
-    organization,
-    id,
-    migratedMeta: existingInterface.chunkedAnalysesMeta ?? {},
-  });
 
   const hasResults = keyedAnalysis.results.length > 0;
   const { metaEntry } =
@@ -1101,25 +1129,73 @@ function isLastPopulatedAnalysis(
   return true;
 }
 
-async function normalizeLegacyChunkedAnalysesMeta({
+function getLegacyChunkedAnalysesMeta(
+  chunkedAnalysesMeta: unknown,
+): unknown[] | Record<string, unknown> | undefined {
+  const NUMBER_REGEX = /^\d+$/;
+  if (Array.isArray(chunkedAnalysesMeta)) return chunkedAnalysesMeta;
+  if (
+    chunkedAnalysesMeta != undefined &&
+    typeof chunkedAnalysesMeta === "object" &&
+    Object.keys(chunkedAnalysesMeta).length > 0 &&
+    Object.keys(chunkedAnalysesMeta).every((k) => NUMBER_REGEX.test(k))
+  ) {
+    return chunkedAnalysesMeta as Record<string, unknown>;
+  }
+}
+
+function getKeylessAnalysisPositions(analyses: unknown): number[] {
+  if (!Array.isArray(analyses)) return [];
+
+  return analyses.flatMap((analysis, position) => {
+    if (!analysis || typeof analysis !== "object") return [position];
+    const analysisKey = (analysis as { analysisKey?: unknown }).analysisKey;
+    return typeof analysisKey === "string" && analysisKey ? [] : [position];
+  });
+}
+
+async function persistLegacyAnalysisMigration({
   organization,
   id,
-  migratedMeta,
+  snapshot,
+  legacyChunkedAnalysesMeta,
+  keylessAnalysisPositions,
 }: {
   organization: string;
   id: string;
-  migratedMeta: Record<AnalysisKeyType, AnalysisMetaEntry>;
+  snapshot: ExperimentSnapshotInterface;
+  legacyChunkedAnalysesMeta?: unknown[] | Record<string, unknown>;
+  keylessAnalysisPositions: number[];
 }) {
-  await ExperimentSnapshotModel.collection.updateOne(
-    {
-      organization,
-      id,
-      chunkedAnalysesMeta: { $type: "array" },
-    },
-    {
-      $set: { chunkedAnalysesMeta: migratedMeta },
-    },
-  );
+  const setOps: Record<string, unknown> = {};
+
+  if (legacyChunkedAnalysesMeta !== undefined) {
+    setOps.chunkedAnalysesMeta = snapshot.chunkedAnalysesMeta ?? {};
+  }
+
+  for (const position of keylessAnalysisPositions) {
+    const analysis = snapshot.analyses[position];
+    if (analysis?.analysisKey) {
+      setOps[`analyses.${position}.analysisKey`] = analysis.analysisKey;
+    }
+  }
+
+  if (!Object.keys(setOps).length) return;
+
+  const filter: Record<string, unknown> = {
+    organization,
+    id,
+  };
+  if (legacyChunkedAnalysesMeta !== undefined) {
+    filter.$or = [
+      { chunkedAnalysesMeta: { $type: "array" } },
+      { chunkedAnalysesMeta: legacyChunkedAnalysesMeta },
+    ];
+  }
+
+  await ExperimentSnapshotModel.collection.updateOne(filter, {
+    $set: setOps,
+  });
 }
 
 // Build the meta mutation operators for a single-analysis write. The meta

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -53,6 +53,7 @@ import {
   getLatestPhaseVariations,
 } from "shared/experiments";
 import { hoursBetween } from "shared/dates";
+import { buildAnalysisKey } from "shared/snapshot-analysis-chunks";
 import { v4 as uuidv4 } from "uuid";
 import { differenceInMinutes } from "date-fns";
 import { VisualChangesetInterface } from "shared/types/visual-changeset";
@@ -1374,6 +1375,7 @@ export async function planSnapshot({
     multipleExposures: 0,
     analyses: [
       {
+        analysisKey: buildAnalysisKey(),
         dateCreated: new Date(),
         results: [],
         settings: defaultAnalysisSettings,
@@ -1383,6 +1385,7 @@ export async function planSnapshot({
         .filter((a) => isAnalysisAllowed(snapshotSettings, a))
         .map((a) => {
           const analysis: ExperimentSnapshotAnalysis = {
+            analysisKey: buildAnalysisKey(),
             dateCreated: new Date(),
             results: [],
             settings: a,
@@ -1974,6 +1977,7 @@ async function getSnapshotAnalyses(
       return;
     }
     const analysis: ExperimentSnapshotAnalysis = {
+      analysisKey: buildAnalysisKey(),
       results: [],
       status: "running",
       settings: analysisSettings,
@@ -2072,6 +2076,7 @@ export async function createSnapshotAnalysis(
     throw new Error("Snapshot queries not available for analysis");
   }
   const analysis: ExperimentSnapshotAnalysis = {
+    analysisKey: buildAnalysisKey(),
     results: [],
     status: "running",
     settings: analysisSettings,

--- a/packages/back-end/src/services/reports.ts
+++ b/packages/back-end/src/services/reports.ts
@@ -578,7 +578,7 @@ export async function createReportSnapshot({
     unknownVariations: [],
     multipleExposures: 0,
     hasChunkedAnalyses: false,
-    chunkedAnalysesMeta: [],
+    chunkedAnalysesMeta: {},
     analyses: snapshotData.analyses.map((analysis) => ({
       ...analysis,
       dateCreated: new Date(),

--- a/packages/back-end/src/services/reports.ts
+++ b/packages/back-end/src/services/reports.ts
@@ -60,6 +60,7 @@ import { MetricGroupInterface } from "shared/types/metric-groups";
 import { DataSourceInterface } from "shared/types/datasource";
 import { ProjectInterface } from "shared/types/project";
 import { accountFeatures, CommercialFeature } from "shared/enterprise";
+import { buildAnalysisKey } from "shared/snapshot-analysis-chunks";
 import { getMetricsByIds } from "back-end/src/models/MetricModel";
 import { ReqContext } from "back-end/types/request";
 import { ApiReqContext } from "back-end/types/api";
@@ -580,16 +581,15 @@ export async function createReportSnapshot({
     multipleExposures: 0,
     hasChunkedAnalyses: false,
     chunkedAnalysesMeta: {},
-    analyses: snapshotData.analyses.map((analysis) => ({
-      ...analysis,
-      dateCreated: new Date(),
-      results: [],
-      status: "running",
-      settings: {
-        ...analysis.settings,
-        ...analysisSettings,
+    analyses: [
+      {
+        analysisKey: buildAnalysisKey(),
+        dateCreated: new Date(),
+        results: [],
+        status: "running",
+        settings: analysisSettings,
       },
-    })),
+    ],
   };
   if (
     snapshotData?.health?.traffic &&

--- a/packages/back-end/src/util/migrations.ts
+++ b/packages/back-end/src/util/migrations.ts
@@ -35,11 +35,17 @@ import {
   ExperimentSnapshotInterface,
   MetricForSnapshot,
 } from "shared/types/experiment-snapshot";
+import {
+  AnalysisKeyType,
+  AnalysisMetaEntry,
+  buildAnalysisKey,
+} from "shared/snapshot-analysis-chunks";
 import { getEnvironments } from "back-end/src/services/organizations";
 import { getConfigOrganizationSettings } from "back-end/src/init/config";
 import { decryptDataSourceParams } from "back-end/src/services/datasource";
 import { SdkWebHookLogDocument } from "back-end/src/models/SdkWebhookLogModel";
 import { getAccountPlan } from "back-end/src/enterprise";
+import { logger } from "back-end/src/util/logger";
 import { DEFAULT_CONVERSION_WINDOW_HOURS } from "./secrets";
 
 function roundVariationWeight(num: number): number {
@@ -796,6 +802,7 @@ export function migrateSnapshot(
 
       snapshot.analyses = [
         {
+          analysisKey: buildAnalysisKey(),
           dateCreated: snapshot.dateCreated,
           status: snapshot.error ? "error" : "success",
           settings: {
@@ -955,6 +962,65 @@ export function migrateSnapshot(
   }
   if (!snapshot.runStarted) {
     snapshot.runStarted = null;
+  }
+
+  // Ensure all analyses have a unique analysisKey
+  snapshot.analyses.forEach((analysis) => {
+    if (!analysis.analysisKey) {
+      analysis.analysisKey = buildAnalysisKey();
+    }
+  });
+
+  // Legacy meta was stored as `AnalysisMetaEntry[]`, where positions
+  // matched the same index of `snapshot.analyses`.
+  // The updated shape makes Mongoose produce a Map keyed by number
+  // instead of an array. So we need to check they key values as well
+  // to determine if we need to migrate the data.
+  const chunkedAnalysesMeta = snapshot.chunkedAnalysesMeta as unknown;
+  const NUMBER_REGEX = /^\d+$/;
+  const isChunkedAnalysesInLegacyFormat =
+    Array.isArray(chunkedAnalysesMeta) ||
+    (chunkedAnalysesMeta != undefined &&
+      typeof chunkedAnalysesMeta === "object" &&
+      Object.keys(chunkedAnalysesMeta).length > 0 &&
+      Object.keys(chunkedAnalysesMeta).every((k) => NUMBER_REGEX.test(k)));
+
+  if (isChunkedAnalysesInLegacyFormat) {
+    const newChunkedAnalysesMeta: Record<AnalysisKeyType, AnalysisMetaEntry> =
+      {};
+
+    const legacyEntries = Array.isArray(chunkedAnalysesMeta)
+      ? chunkedAnalysesMeta
+      : Object.values(chunkedAnalysesMeta);
+
+    legacyEntries.forEach((entry, position) => {
+      const key = snapshot.analyses[position]?.analysisKey;
+      if (!key) {
+        // legacy meta had more entries than the current analyses
+        // array. It is unexpected, so we drop it rather than crash
+        logger.error(
+          { snapshotId: snapshot.id, position },
+          "migrateSnapshot: dropping orphan legacy chunkedAnalysesMeta entry",
+        );
+        return;
+      }
+      newChunkedAnalysesMeta[key] = entry;
+    });
+
+    snapshot.chunkedAnalysesMeta = newChunkedAnalysesMeta;
+  }
+
+  // Derive `hasChunkedAnalyses` from meta at read time for snapshots that
+  // ever touched chunked storage: single-analysis writes can race and leave
+  // the on-disk flag stale-false while meta still has entries (see
+  // `buildMetaOpsForAnalysisWrite` in ExperimentSnapshotModel). Downstream
+  // readers gate chunk loading on this flag, so re-deriving keeps populated
+  // snapshots from being silently skipped. Leave pre-chunked-storage
+  // snapshots (no flag, no meta) untouched.
+  const meta = snapshot.chunkedAnalysesMeta ?? {};
+  const metaHasEntries = Object.keys(meta).length > 0;
+  if (metaHasEntries || snapshot.hasChunkedAnalyses) {
+    snapshot.hasChunkedAnalyses = metaHasEntries;
   }
 
   return snapshot;

--- a/packages/back-end/test/migrations.test.ts
+++ b/packages/back-end/test/migrations.test.ts
@@ -2015,6 +2015,7 @@ describe("Snapshot Migration", () => {
       multipleExposures: 5,
       analyses: [
         {
+          analysisKey: expect.any(String),
           dateCreated: now,
           results: results,
           status: "success",
@@ -2236,6 +2237,7 @@ describe("Snapshot Migration", () => {
       multipleExposures: 0,
       analyses: [
         {
+          analysisKey: expect.any(String),
           dateCreated: now,
           results,
           settings: {
@@ -2307,6 +2309,216 @@ describe("Snapshot Migration", () => {
     expect(
       migrateSnapshot(initial as LegacyExperimentSnapshotInterface),
     ).toEqual(result);
+  });
+
+  describe("chunkedAnalysesMeta migration", () => {
+    const now = new Date();
+    const entryA = {
+      dimensions: [{ name: "", srm: 0.95, variationUsers: [100, 100] }],
+    };
+    const entryB = {
+      dimensions: [{ name: "foo", srm: 1, variationUsers: [50, 50] }],
+    };
+
+    function buildSnapshot(
+      chunkedAnalysesMeta: unknown,
+      analyses: unknown[],
+    ): LegacyExperimentSnapshotInterface {
+      return {
+        id: "snp_meta_1",
+        organization: "org_1",
+        experiment: "exp_1",
+        phase: 0,
+        dateCreated: now,
+        runStarted: now,
+        queries: [],
+        dimension: "",
+        unknownVariations: [],
+        multipleExposures: 0,
+        hasChunkedAnalyses: true,
+        chunkedAnalysesMeta,
+        analyses,
+        settings: {
+          queryFilter: "",
+          activationMetric: null,
+          attributionModel: "firstExposure",
+          datasourceId: "",
+          dimensions: [],
+          endDate: now,
+          experimentId: "",
+          exposureQueryId: "",
+          goalMetrics: [],
+          secondaryMetrics: [],
+          guardrailMetrics: [],
+          manual: false,
+          metricSettings: [],
+          regressionAdjustmentEnabled: false,
+          segment: "",
+          skipPartialData: false,
+          startDate: now,
+          variations: [],
+          defaultMetricPriorSettings: {
+            override: false,
+            proper: false,
+            mean: 0,
+            stddev: DEFAULT_PROPER_PRIOR_STDDEV,
+          },
+        },
+        status: "success",
+      } as unknown as LegacyExperimentSnapshotInterface;
+    }
+
+    it("converts array-shaped meta to a record keyed by each analysis's analysisKey", () => {
+      const initial = buildSnapshot(
+        [entryA, entryB],
+        [
+          { dateCreated: now, status: "success", settings: {}, results: [] },
+          { dateCreated: now, status: "success", settings: {}, results: [] },
+        ],
+      );
+
+      const migrated = migrateSnapshot(initial);
+
+      const keys = migrated.analyses.map((a) => a.analysisKey);
+      expect(keys).toHaveLength(2);
+      expect(keys[0]).toEqual(expect.any(String));
+      expect(keys[1]).toEqual(expect.any(String));
+      expect(keys[0]).not.toEqual(keys[1]);
+      expect(migrated.chunkedAnalysesMeta).toEqual({
+        [keys[0]]: entryA,
+        [keys[1]]: entryB,
+      });
+    });
+
+    it("preserves pre-existing analysisKey values when converting", () => {
+      const initial = buildSnapshot(
+        [entryA, entryB],
+        [
+          {
+            analysisKey: "an_preset_a",
+            dateCreated: now,
+            status: "success",
+            settings: {},
+            results: [],
+          },
+          {
+            analysisKey: "an_preset_b",
+            dateCreated: now,
+            status: "success",
+            settings: {},
+            results: [],
+          },
+        ],
+      );
+
+      const migrated = migrateSnapshot(initial);
+
+      expect(migrated.analyses.map((a) => a.analysisKey)).toEqual([
+        "an_preset_a",
+        "an_preset_b",
+      ]);
+      expect(migrated.chunkedAnalysesMeta).toEqual({
+        an_preset_a: entryA,
+        an_preset_b: entryB,
+      });
+    });
+
+    it("leaves record-shaped meta untouched (idempotent)", () => {
+      const record = { an_a: entryA, an_b: entryB };
+      const initial = buildSnapshot(record, [
+        {
+          analysisKey: "an_a",
+          dateCreated: now,
+          status: "success",
+          settings: {},
+          results: [],
+        },
+        {
+          analysisKey: "an_b",
+          dateCreated: now,
+          status: "success",
+          settings: {},
+          results: [],
+        },
+      ]);
+
+      const migrated = migrateSnapshot(initial);
+
+      expect(migrated.chunkedAnalysesMeta).toEqual(record);
+    });
+
+    it("converts an empty array to an empty record", () => {
+      const initial = buildSnapshot(
+        [],
+        [
+          {
+            analysisKey: "an_a",
+            dateCreated: now,
+            status: "success",
+            settings: {},
+            results: [],
+          },
+        ],
+      );
+
+      const migrated = migrateSnapshot(initial);
+
+      expect(migrated.chunkedAnalysesMeta).toEqual({});
+    });
+
+    it("converts numeric-string-keyed meta (Mongoose Map-of-array shape) to a record keyed by analysisKey", () => {
+      // When Mongoose reads a BSON array into a Map-typed schema field,
+      // toJSON() produces a POJO with stringified numeric keys rather
+      // than an Array. The migration must still recognize this as legacy.
+      const initial = buildSnapshot({ "0": entryA, "1": entryB }, [
+        { dateCreated: now, status: "success", settings: {}, results: [] },
+        { dateCreated: now, status: "success", settings: {}, results: [] },
+      ]);
+
+      const migrated = migrateSnapshot(initial);
+
+      const keys = migrated.analyses.map((a) => a.analysisKey);
+      expect(keys).toHaveLength(2);
+      expect(keys[0]).not.toEqual(keys[1]);
+      expect(migrated.chunkedAnalysesMeta).toEqual({
+        [keys[0]]: entryA,
+        [keys[1]]: entryB,
+      });
+    });
+
+    it("sorts numeric-string keys numerically before position mapping", () => {
+      // Integer-indexed property keys always enumerate in ascending numeric
+      // order per ECMA-262 §7.3.22 (OrdinaryOwnPropertyKeys) — not insertion
+      // order — so `Object.values` on a record with keys "0".."11" returns
+      // values positioned for index 0..11. Pin this invariant across a
+      // multi-digit range to catch any future code that relies on insertion
+      // order instead.
+      const entries: Record<string, typeof entryA> = {};
+      for (let i = 0; i < 12; i++) {
+        entries[String(i)] = {
+          dimensions: [
+            { name: `dim${i}`, srm: 0.9, variationUsers: [100, 100] },
+          ],
+        };
+      }
+      const analyses = Array.from({ length: 12 }, () => ({
+        dateCreated: now,
+        status: "success",
+        settings: {},
+        results: [],
+      }));
+      const initial = buildSnapshot(entries, analyses);
+
+      const migrated = migrateSnapshot(initial);
+
+      const keys = migrated.analyses.map((a) => a.analysisKey);
+      expect(migrated.chunkedAnalysesMeta[keys[10]]?.dimensions[0].name).toBe(
+        "dim10",
+      );
+      expect(migrated.chunkedAnalysesMeta[keys[11]]?.dimensions[0].name).toBe(
+        "dim11",
+      );
+    });
   });
 });
 

--- a/packages/back-end/test/models/ExperimentSnapshotModel.test.ts
+++ b/packages/back-end/test/models/ExperimentSnapshotModel.test.ts
@@ -189,6 +189,65 @@ function makeSnapshotWithMetric(id: string) {
   return snapshot;
 }
 
+function makeLegacyInlineSnapshotSettings(experimentId: string) {
+  return {
+    manual: false,
+    dimensions: [],
+    metricSettings: [],
+    goalMetrics: ["met_1"],
+    secondaryMetrics: [],
+    guardrailMetrics: [],
+    activationMetric: null,
+    defaultMetricPriorSettings: {
+      override: false,
+      proper: false,
+      mean: 0,
+      stddev: 1,
+    },
+    regressionAdjustmentEnabled: false,
+    attributionModel: "firstExposure",
+    experimentId,
+    queryFilter: "",
+    segment: "",
+    skipPartialData: false,
+    datasourceId: "ds_1",
+    exposureQueryId: "eq_1",
+    startDate: new Date(),
+    endDate: new Date(),
+    variations: [
+      { id: "0", weight: 0.5 },
+      { id: "1", weight: 0.5 },
+    ],
+  };
+}
+
+async function insertLegacyInlineSnapshot({
+  id,
+  experimentId,
+  analyses,
+}: {
+  id: string;
+  experimentId: string;
+  analyses: Partial<ExperimentSnapshotAnalysis>[];
+}) {
+  await mongoose.connection.db!.collection("experimentsnapshots").insertOne({
+    id,
+    organization: "org_1",
+    experiment: experimentId,
+    phase: 0,
+    dimension: null,
+    dateCreated: new Date(),
+    runStarted: null,
+    status: "success",
+    queries: [],
+    unknownVariations: [],
+    multipleExposures: 0,
+    hasChunkedAnalyses: false,
+    analyses,
+    settings: makeLegacyInlineSnapshotSettings(experimentId),
+  });
+}
+
 describe("ExperimentSnapshotModel", () => {
   let mongod: MongoMemoryServer;
 
@@ -1131,6 +1190,58 @@ describe("ExperimentSnapshotModel", () => {
   });
 
   describe("concurrent analysis writes", () => {
+    it("preserves the legacy inline analysis when two addOrUpdateSnapshotAnalysis calls race on different settings", async () => {
+      const context = getSnapshotUpdateContext();
+      const legacySnapshotId = "snp_legacy_inline_race_different_settings";
+      const experimentId = "exp_legacy_inline_race_different_settings";
+
+      const { analysisKey: legacyKey, ...legacyAnalysis } = makeAnalysis({
+        settings: makeAnalysisSettings({ statsEngine: "bayesian" }),
+        value: 11,
+      });
+      void legacyKey;
+
+      await insertLegacyInlineSnapshot({
+        id: legacySnapshotId,
+        experimentId,
+        analyses: [legacyAnalysis],
+      });
+
+      await Promise.all([
+        addOrUpdateSnapshotAnalysis({
+          context,
+          id: legacySnapshotId,
+          analysis: makeAnalysis({
+            settings: makeAnalysisSettings({
+              statsEngine: "frequentist",
+              differenceType: "relative",
+            }),
+            value: 22,
+          }),
+        }),
+        addOrUpdateSnapshotAnalysis({
+          context,
+          id: legacySnapshotId,
+          analysis: makeAnalysis({
+            settings: makeAnalysisSettings({
+              statsEngine: "bayesian",
+              differenceType: "absolute",
+            }),
+            value: 33,
+          }),
+        }),
+      ]);
+
+      const result = await findSnapshotById(context, legacySnapshotId);
+      expect(result?.analyses).toHaveLength(3);
+
+      const values =
+        result?.analyses.map(
+          (a) => a.results[0]?.variations[0]?.metrics.met_1?.value ?? -1,
+        ) ?? [];
+      expect(values.sort((a, b) => a - b)).toEqual([11, 22, 33]);
+    });
+
     it("persists both analyses when two writers race on different settings", async () => {
       const context = getSnapshotUpdateContext();
       const snapshot = makeSnapshotWithMetric("snp_race_different_settings");
@@ -1664,7 +1775,7 @@ describe("ExperimentSnapshotModel", () => {
     });
   });
 
-  describe("legacy write-path migration", () => {
+  describe("legacy snapshot compatibility", () => {
     it("preserves new-shape sub-records appended to a legacy chunk doc", async () => {
       // Simulates the on-disk state after a writer appends a
       // `data.<analysisKey>` sub-record (via bulkWrite) to a doc that
@@ -1970,7 +2081,7 @@ describe("ExperimentSnapshotModel", () => {
     it("preserves legacy data when addOrUpdateSnapshotAnalysis appends a new analysis", async () => {
       // End-to-end regression: a legacy snapshot + chunk on disk, then the
       // production write path (`addOrUpdateSnapshotAnalysis`) appends a new
-      // analysis. Without the chunk-migration fix the re-read silently
+      // analysis. Without the read-path fix the re-read silently
       // drops the pre-existing legacy data; with the fix both analyses
       // decode correctly.
       const context = getSnapshotUpdateContext();
@@ -2096,6 +2207,251 @@ describe("ExperimentSnapshotModel", () => {
       expect(
         appendedAnalysis!.results[0].variations[1].metrics.met_1.value,
       ).toBe(104);
+    });
+
+    it("preserves legacy inline analyses when updateSnapshotAnalysis writes to a snapshot from main", async () => {
+      const context = getSnapshotUpdateContext();
+      const legacySnapshotId = "snp_inline_migration_update";
+      const experimentId = "exp_inline_migration_update";
+
+      const { analysisKey: bayesianKey, ...legacyBayesian } = makeAnalysis({
+        settings: makeAnalysisSettings({ statsEngine: "bayesian" }),
+        value: 10,
+      });
+      const { analysisKey: frequentistKey, ...legacyFrequentist } =
+        makeAnalysis({
+          settings: makeAnalysisSettings({ statsEngine: "frequentist" }),
+          value: 20,
+        });
+      void bayesianKey;
+      void frequentistKey;
+
+      await insertLegacyInlineSnapshot({
+        id: legacySnapshotId,
+        experimentId,
+        analyses: [legacyBayesian, legacyFrequentist],
+      });
+
+      await updateSnapshotAnalysis({
+        context,
+        id: legacySnapshotId,
+        analysis: {
+          dateCreated: new Date(),
+          status: "success",
+          settings: makeAnalysisSettings({ statsEngine: "bayesian" }),
+          results: [
+            {
+              name: "",
+              srm: 0.95,
+              variations: [
+                {
+                  users: 100,
+                  metrics: { met_1: { value: 42, cr: 0.42, users: 100 } },
+                },
+                {
+                  users: 120,
+                  metrics: { met_1: { value: 47, cr: 0.392, users: 120 } },
+                },
+              ],
+            },
+          ],
+        },
+      });
+
+      const result = await findSnapshotById(context, legacySnapshotId);
+      expect(result?.analyses).toHaveLength(2);
+
+      const bayesian = result!.analyses.find(
+        (a) => a.settings.statsEngine === "bayesian",
+      );
+      const frequentist = result!.analyses.find(
+        (a) => a.settings.statsEngine === "frequentist",
+      );
+
+      // Target analysis reflects the new value.
+      expect(bayesian!.results[0].variations[0].metrics.met_1.value).toBe(42);
+      expect(bayesian!.results[0].variations[1].metrics.met_1.value).toBe(47);
+
+      // Non-target analysis's pre-existing inline results must still be
+      // visible after the snapshot enters the mixed inline/chunked state.
+      expect(frequentist!.results[0].variations[0].metrics.met_1.value).toBe(
+        20,
+      );
+      expect(frequentist!.results[0].variations[1].metrics.met_1.value).toBe(
+        25,
+      );
+
+      const snapshotsCollection = mongoose.connection.db!.collection(
+        "experimentsnapshots",
+      );
+      const stored = (await snapshotsCollection.findOne({
+        id: legacySnapshotId,
+      })) as {
+        hasChunkedAnalyses?: boolean;
+        analyses?: { results?: unknown[] }[];
+      } | null;
+      expect(stored?.hasChunkedAnalyses).toBe(true);
+      expect(
+        stored?.analyses
+          ?.map((storedAnalysis) => storedAnalysis.results?.length ?? 0)
+          .sort((a, b) => a - b),
+      ).toEqual([0, 1]);
+    });
+
+    it("preserves legacy inline analyses when addOrUpdateSnapshotAnalysis appends onto a snapshot from main", async () => {
+      const context = getSnapshotUpdateContext();
+      const legacySnapshotId = "snp_inline_migration_append";
+      const experimentId = "exp_inline_migration_append";
+
+      const { analysisKey: bayesianKey, ...legacyBayesian } = makeAnalysis({
+        settings: makeAnalysisSettings({ statsEngine: "bayesian" }),
+        value: 77,
+      });
+      void bayesianKey;
+
+      await insertLegacyInlineSnapshot({
+        id: legacySnapshotId,
+        experimentId,
+        analyses: [legacyBayesian],
+      });
+
+      await addOrUpdateSnapshotAnalysis({
+        context,
+        id: legacySnapshotId,
+        analysis: makeAnalysis({
+          settings: makeAnalysisSettings({ statsEngine: "frequentist" }),
+          value: 33,
+        }),
+      });
+
+      const result = await findSnapshotById(context, legacySnapshotId);
+      expect(result?.analyses).toHaveLength(2);
+
+      const bayesian = result!.analyses.find(
+        (a) => a.settings.statsEngine === "bayesian",
+      );
+      const frequentist = result!.analyses.find(
+        (a) => a.settings.statsEngine === "frequentist",
+      );
+
+      // Pre-existing inline analysis must still be visible after the write
+      // path creates a mixed inline/chunked snapshot on disk.
+      expect(bayesian!.results[0].variations[0].metrics.met_1.value).toBe(77);
+      expect(bayesian!.results[0].variations[1].metrics.met_1.value).toBe(82);
+
+      // Appended analysis data must also be visible.
+      expect(frequentist!.results[0].variations[0].metrics.met_1.value).toBe(
+        33,
+      );
+      expect(frequentist!.results[0].variations[1].metrics.met_1.value).toBe(
+        38,
+      );
+
+      const snapshotsCollection = mongoose.connection.db!.collection(
+        "experimentsnapshots",
+      );
+      const stored = (await snapshotsCollection.findOne({
+        id: legacySnapshotId,
+      })) as {
+        hasChunkedAnalyses?: boolean;
+        analyses?: { results?: unknown[] }[];
+      } | null;
+      expect(stored?.hasChunkedAnalyses).toBe(true);
+      expect(
+        stored?.analyses
+          ?.map((storedAnalysis) => storedAnalysis.results?.length ?? 0)
+          .sort((a, b) => a - b),
+      ).toEqual([0, 1]);
+    });
+
+    it("preserves legacy inline baseline analyses when changing difference type on the PR branch", async () => {
+      // Reproduces the bug report:
+      // 1. On `main`, create a non-chunked snapshot.
+      // 2. On `main`, switch baselines, which appends a second inline analysis.
+      // 3. On this PR, change only the difference type while staying on that
+      //    switched-baseline analysis.
+      //
+      // The fix should preserve the two prior inline analyses even though the
+      // write path only chunks the newly-added analysis and flips the snapshot
+      // into a mixed inline/chunked state on disk.
+      const context = getSnapshotUpdateContext();
+      const legacySnapshotId = "snp_legacy_inline_baseline_switch";
+      const experimentId = "exp_legacy_inline_baseline_switch";
+
+      const { analysisKey: baselineZeroKey, ...baselineZeroInline } =
+        makeAnalysis({
+          settings: makeAnalysisSettings({
+            baselineVariationIndex: 0,
+            differenceType: "relative",
+          }),
+          value: 10,
+        });
+      const { analysisKey: baselineOneKey, ...baselineOneInline } =
+        makeAnalysis({
+          settings: makeAnalysisSettings({
+            baselineVariationIndex: 1,
+            differenceType: "relative",
+          }),
+          value: 20,
+        });
+      void baselineZeroKey;
+      void baselineOneKey;
+
+      await insertLegacyInlineSnapshot({
+        id: legacySnapshotId,
+        experimentId,
+        analyses: [baselineZeroInline, baselineOneInline],
+      });
+
+      await addOrUpdateSnapshotAnalysis({
+        context,
+        id: legacySnapshotId,
+        analysis: makeAnalysis({
+          settings: makeAnalysisSettings({
+            baselineVariationIndex: 1,
+            differenceType: "absolute",
+          }),
+          value: 33,
+        }),
+      });
+
+      const result = await findSnapshotById(context, legacySnapshotId);
+      expect(result?.analyses).toHaveLength(3);
+
+      const baselineZeroRelative = result!.analyses.find(
+        (analysis) =>
+          analysis.settings.baselineVariationIndex === 0 &&
+          analysis.settings.differenceType === "relative",
+      );
+      const baselineOneRelative = result!.analyses.find(
+        (analysis) =>
+          analysis.settings.baselineVariationIndex === 1 &&
+          analysis.settings.differenceType === "relative",
+      );
+      const baselineOneAbsolute = result!.analyses.find(
+        (analysis) =>
+          analysis.settings.baselineVariationIndex === 1 &&
+          analysis.settings.differenceType === "absolute",
+      );
+
+      expect(
+        baselineZeroRelative!.results[0].variations[0].metrics.met_1.value,
+      ).toBe(10);
+      expect(
+        baselineZeroRelative!.results[0].variations[1].metrics.met_1.value,
+      ).toBe(15);
+      expect(
+        baselineOneRelative!.results[0].variations[0].metrics.met_1.value,
+      ).toBe(20);
+      expect(
+        baselineOneRelative!.results[0].variations[1].metrics.met_1.value,
+      ).toBe(25);
+      expect(
+        baselineOneAbsolute!.results[0].variations[0].metrics.met_1.value,
+      ).toBe(33);
+      expect(
+        baselineOneAbsolute!.results[0].variations[1].metrics.met_1.value,
+      ).toBe(38);
     });
   });
 });

--- a/packages/back-end/test/models/ExperimentSnapshotModel.test.ts
+++ b/packages/back-end/test/models/ExperimentSnapshotModel.test.ts
@@ -2312,6 +2312,7 @@ describe("ExperimentSnapshotModel", () => {
         context,
         id: legacySnapshotId,
         analysis: {
+          analysisKey: buildAnalysisKey(),
           dateCreated: new Date(),
           status: "success",
           settings: makeAnalysisSettings({ statsEngine: "bayesian" }),

--- a/packages/back-end/test/models/ExperimentSnapshotModel.test.ts
+++ b/packages/back-end/test/models/ExperimentSnapshotModel.test.ts
@@ -2453,5 +2453,201 @@ describe("ExperimentSnapshotModel", () => {
         baselineOneAbsolute!.results[0].variations[1].metrics.met_1.value,
       ).toBe(38);
     });
+
+    it("appends a new analysis when chunkedAnalysesMeta is stored as an array on disk", async () => {
+      // Reproduces the production error:
+      //   MongoServerError: Cannot create field 'an_xxx' in element
+      //   {chunkedAnalysesMeta: [...]}
+      // when addOrUpdateSnapshotAnalysis appends an analysis to a snapshot
+      // whose chunkedAnalysesMeta was persisted in the legacy array shape.
+      const context = getSnapshotUpdateContext();
+      const legacySnapshotId = "snp_array_meta_append";
+      const experimentId = "exp_array_meta_append";
+      const bayesianSettings = makeAnalysisSettings({
+        statsEngine: "bayesian",
+      });
+      const frequentistSettings = makeAnalysisSettings({
+        statsEngine: "frequentist",
+      });
+
+      const legacyChunkCollection = mongoose.connection.db!.collection(
+        "experimentsnapshotanalysischunks",
+      );
+      await legacyChunkCollection.insertOne({
+        id: "snpac_array_meta_append",
+        organization: "org_1",
+        snapshotId: legacySnapshotId,
+        experimentId,
+        metricId: "met_1",
+        dateCreated: new Date(),
+        dateUpdated: new Date(),
+        numRows: 4,
+        data: {
+          a: [0, 0, 1, 1],
+          d: ["", "", "", ""],
+          v: [0, 1, 0, 1],
+          value: [10, 15, 20, 25],
+          cr: [0.1, 0.125, 0.2, 0.208],
+          users: [100, 120, 100, 120],
+        },
+      });
+
+      const snapshotsCollection = mongoose.connection.db!.collection(
+        "experimentsnapshots",
+      );
+      await snapshotsCollection.insertOne({
+        id: legacySnapshotId,
+        organization: "org_1",
+        experiment: experimentId,
+        phase: 0,
+        dimension: null,
+        dateCreated: new Date(),
+        runStarted: null,
+        status: "success",
+        queries: [],
+        unknownVariations: [],
+        multipleExposures: 0,
+        hasChunkedAnalyses: true,
+        // Array form on disk — the bug-trigger condition.
+        chunkedAnalysesMeta: [
+          {
+            dimensions: [{ name: "", srm: 0.95, variationUsers: [100, 120] }],
+          },
+          {
+            dimensions: [{ name: "", srm: 0.9, variationUsers: [100, 120] }],
+          },
+        ],
+        analyses: [
+          {
+            dateCreated: new Date(),
+            status: "success",
+            settings: bayesianSettings,
+            results: [],
+          },
+          {
+            dateCreated: new Date(),
+            status: "success",
+            settings: frequentistSettings,
+            results: [],
+          },
+        ],
+        settings: makeLegacyInlineSnapshotSettings(experimentId),
+      });
+
+      // The new analysis must succeed without MongoDB rejecting the
+      // string-keyed sub-path write against the array meta field.
+      await addOrUpdateSnapshotAnalysis({
+        context,
+        id: legacySnapshotId,
+        analysis: makeAnalysis({
+          settings: makeAnalysisSettings({
+            statsEngine: "frequentist",
+            differenceType: "absolute",
+          }),
+          value: 33,
+        }),
+      });
+
+      const result = await findSnapshotById(context, legacySnapshotId);
+      expect(result?.analyses).toHaveLength(3);
+
+      const appended = result!.analyses.find(
+        (analysis) => analysis.settings.differenceType === "absolute",
+      );
+      expect(appended?.results[0].variations[0].metrics.met_1.value).toBe(33);
+      expect(appended?.results[0].variations[1].metrics.met_1.value).toBe(38);
+
+      // The previously-array meta must have been normalized to a Record
+      // form on disk so subsequent partial $sets on string keys work.
+      const stored = (await snapshotsCollection.findOne({
+        id: legacySnapshotId,
+      })) as { chunkedAnalysesMeta?: unknown } | null;
+      expect(Array.isArray(stored?.chunkedAnalysesMeta)).toBe(false);
+      expect(typeof stored?.chunkedAnalysesMeta).toBe("object");
+    });
+
+    it("updates an existing analysis when chunkedAnalysesMeta is stored as an array on disk", async () => {
+      const context = getSnapshotUpdateContext();
+      const legacySnapshotId = "snp_array_meta_update";
+      const experimentId = "exp_array_meta_update";
+      const bayesianSettings = makeAnalysisSettings({
+        statsEngine: "bayesian",
+      });
+
+      const legacyChunkCollection = mongoose.connection.db!.collection(
+        "experimentsnapshotanalysischunks",
+      );
+      await legacyChunkCollection.insertOne({
+        id: "snpac_array_meta_update",
+        organization: "org_1",
+        snapshotId: legacySnapshotId,
+        experimentId,
+        metricId: "met_1",
+        dateCreated: new Date(),
+        dateUpdated: new Date(),
+        numRows: 2,
+        data: {
+          a: [0, 0],
+          d: ["", ""],
+          v: [0, 1],
+          value: [10, 15],
+          cr: [0.1, 0.125],
+          users: [100, 120],
+        },
+      });
+
+      const snapshotsCollection = mongoose.connection.db!.collection(
+        "experimentsnapshots",
+      );
+      await snapshotsCollection.insertOne({
+        id: legacySnapshotId,
+        organization: "org_1",
+        experiment: experimentId,
+        phase: 0,
+        dimension: null,
+        dateCreated: new Date(),
+        runStarted: null,
+        status: "success",
+        queries: [],
+        unknownVariations: [],
+        multipleExposures: 0,
+        hasChunkedAnalyses: true,
+        chunkedAnalysesMeta: [
+          {
+            dimensions: [{ name: "", srm: 0.95, variationUsers: [100, 120] }],
+          },
+        ],
+        analyses: [
+          {
+            dateCreated: new Date(),
+            status: "success",
+            settings: bayesianSettings,
+            results: [],
+          },
+        ],
+        settings: makeLegacyInlineSnapshotSettings(experimentId),
+      });
+
+      await updateSnapshotAnalysis({
+        context,
+        id: legacySnapshotId,
+        analysis: makeAnalysis({
+          settings: bayesianSettings,
+          value: 99,
+        }),
+      });
+
+      const result = await findSnapshotById(context, legacySnapshotId);
+      expect(result?.analyses).toHaveLength(1);
+      expect(
+        result?.analyses[0].results[0].variations[0].metrics.met_1.value,
+      ).toBe(99);
+
+      const stored = (await snapshotsCollection.findOne({
+        id: legacySnapshotId,
+      })) as { chunkedAnalysesMeta?: unknown } | null;
+      expect(Array.isArray(stored?.chunkedAnalysesMeta)).toBe(false);
+      expect(typeof stored?.chunkedAnalysesMeta).toBe("object");
+    });
   });
 });

--- a/packages/back-end/test/models/ExperimentSnapshotModel.test.ts
+++ b/packages/back-end/test/models/ExperimentSnapshotModel.test.ts
@@ -4,6 +4,7 @@ import {
   ExperimentSnapshotAnalysis,
   ExperimentSnapshotInterface,
 } from "shared/types/experiment-snapshot";
+import { buildAnalysisKey } from "shared/snapshot-analysis-chunks";
 import {
   getLatestSnapshot,
   createExperimentSnapshotModel,
@@ -87,6 +88,7 @@ function makeAnalysis({
   status?: ExperimentSnapshotAnalysis["status"];
 }): ExperimentSnapshotAnalysis {
   return {
+    analysisKey: buildAnalysisKey(),
     dateCreated: new Date("2025-01-01T00:00:00Z"),
     status,
     settings,
@@ -129,6 +131,7 @@ function makeAnalysisWithoutMetrics({
   status?: ExperimentSnapshotAnalysis["status"];
 }): ExperimentSnapshotAnalysis {
   return {
+    analysisKey: buildAnalysisKey(),
     dateCreated: new Date("2025-01-01T00:00:00Z"),
     status,
     settings,
@@ -159,6 +162,7 @@ function makeEmptyAnalysis({
   status?: ExperimentSnapshotAnalysis["status"];
 }): ExperimentSnapshotAnalysis {
   return {
+    analysisKey: buildAnalysisKey(),
     dateCreated: new Date("2025-01-02T00:00:00Z"),
     status,
     settings,
@@ -249,7 +253,8 @@ describe("ExperimentSnapshotModel", () => {
         expect(chunks).toHaveLength(1);
         expect(chunks[0].snapshotId).toBe(snapshot.id);
         expect(chunks[0].metricId).toBe("met_1");
-        expect(chunks[0].numRows).toBe(2);
+        const [perAnalysis] = Object.values(chunks[0].data);
+        expect(perAnalysis?.numRows).toBe(2);
       },
     );
 
@@ -259,21 +264,20 @@ describe("ExperimentSnapshotModel", () => {
       const settings = makeAnalysisSettings();
 
       const result =
-        await context.models.experimentSnapshotAnalysisChunks.createFromAnalyses(
-          {
-            snapshotId: "snp_no_results",
-            experimentId: "exp_no_results",
-            analyses: [makeEmptyAnalysis({ settings })],
-            settings: snapshot.settings,
-          },
-        );
+        await context.models.experimentSnapshotAnalysisChunks.writeAnalyses({
+          snapshotId: "snp_no_results",
+          experimentId: "exp_no_results",
+          analyses: [makeEmptyAnalysis({ settings })],
+          settings: snapshot.settings,
+          scope: "all",
+        });
 
       const chunks =
         await context.models.experimentSnapshotAnalysisChunks.getAllChunksForSnapshot(
           "snp_no_results",
         );
 
-      expect(result).toEqual({ chunkedAnalysesMeta: [], metricIds: [] });
+      expect(result).toEqual({ chunkedAnalysesMeta: {}, metricIds: [] });
       expect(chunks).toHaveLength(0);
     });
 
@@ -283,7 +287,7 @@ describe("ExperimentSnapshotModel", () => {
       const settings = makeAnalysisSettings();
 
       snapshot.analyses = [makeEmptyAnalysis({ settings })];
-      snapshot.chunkedAnalysesMeta = [];
+      snapshot.chunkedAnalysesMeta = {};
 
       const created = await createExperimentSnapshotModel({
         data: snapshot,
@@ -291,7 +295,7 @@ describe("ExperimentSnapshotModel", () => {
       });
 
       expect(created.hasChunkedAnalyses).toBeFalsy();
-      expect(created.chunkedAnalysesMeta).toEqual([]);
+      expect(created.chunkedAnalysesMeta ?? {}).toEqual({});
     });
 
     it("creates fresh chunks from a populated chunked snapshot interface", async () => {
@@ -303,7 +307,7 @@ describe("ExperimentSnapshotModel", () => {
       snapshot.status = "success";
       snapshot.analyses = [analysis];
       snapshot.hasChunkedAnalyses = true;
-      snapshot.chunkedAnalysesMeta = [{ dimensions: [] }];
+      snapshot.chunkedAnalysesMeta = {};
 
       const created = await createExperimentSnapshotModel({
         data: snapshot,
@@ -334,8 +338,8 @@ describe("ExperimentSnapshotModel", () => {
         snapshot.status = "running";
         snapshot.analyses = [makeEmptyAnalysis({ settings })];
         snapshot.hasChunkedAnalyses = true;
-        snapshot.chunkedAnalysesMeta = [
-          {
+        snapshot.chunkedAnalysesMeta = {
+          an_preexisting: {
             dimensions: [
               {
                 name: "",
@@ -344,7 +348,7 @@ describe("ExperimentSnapshotModel", () => {
               },
             ],
           },
-        ];
+        };
         if (type === "report") {
           snapshot.report = "rep_1";
         }
@@ -703,6 +707,7 @@ describe("ExperimentSnapshotModel", () => {
       await createExperimentSnapshotModel({ data: snapshot, context });
 
       const analysis: ExperimentSnapshotAnalysis = {
+        analysisKey: buildAnalysisKey(),
         dateCreated: new Date("2025-01-01T00:00:00Z"),
         status: "success",
         settings: {
@@ -966,7 +971,7 @@ describe("ExperimentSnapshotModel", () => {
 
       const result = await findSnapshotById(context, snapshot.id);
       expect(result?.hasChunkedAnalyses).toBe(false);
-      expect(result?.chunkedAnalysesMeta).toEqual([]);
+      expect(result?.chunkedAnalysesMeta ?? {}).toEqual({});
       expect(result?.analyses[0].status).toBe("running");
       expect(result?.analyses[0].results).toEqual([]);
 
@@ -1020,8 +1025,10 @@ describe("ExperimentSnapshotModel", () => {
 
       const result = await findSnapshotById(context, snapshot.id);
       expect(result?.hasChunkedAnalyses).toBe(true);
-      expect(result?.chunkedAnalysesMeta).toEqual([
-        {
+      const analysisKey = result?.analyses[0].analysisKey;
+      expect(analysisKey).toBeTruthy();
+      expect(result?.chunkedAnalysesMeta).toEqual({
+        [analysisKey as string]: {
           dimensions: [
             {
               name: "",
@@ -1030,7 +1037,7 @@ describe("ExperimentSnapshotModel", () => {
             },
           ],
         },
-      ]);
+      });
       expect(result?.analyses[0].results).toEqual(metricLessAnalysis.results);
     });
 
@@ -1067,7 +1074,7 @@ describe("ExperimentSnapshotModel", () => {
 
       const result = await findSnapshotById(context, snapshot.id);
       expect(result?.hasChunkedAnalyses).toBe(false);
-      expect(result?.chunkedAnalysesMeta).toEqual([]);
+      expect(result?.chunkedAnalysesMeta ?? {}).toEqual({});
       expect(result?.analyses[0].status).toBe("running");
       expect(result?.analyses[0].results).toEqual([]);
 
@@ -1111,7 +1118,7 @@ describe("ExperimentSnapshotModel", () => {
 
       const result = await findSnapshotById(context, snapshot.id);
       expect(result?.hasChunkedAnalyses).toBe(false);
-      expect(result?.chunkedAnalysesMeta).toEqual([]);
+      expect(result?.chunkedAnalysesMeta ?? {}).toEqual({});
       expect(result?.analyses[0].status).toBe("running");
       expect(result?.analyses[0].results).toEqual([]);
 
@@ -1120,6 +1127,975 @@ describe("ExperimentSnapshotModel", () => {
           snapshot.id,
         );
       expect(chunks).toHaveLength(0);
+    });
+  });
+
+  describe("concurrent analysis writes", () => {
+    it("persists both analyses when two writers race on different settings", async () => {
+      const context = getSnapshotUpdateContext();
+      const snapshot = makeSnapshotWithMetric("snp_race_different_settings");
+      await createExperimentSnapshotModel({ data: snapshot, context });
+
+      const relativeSettings = makeAnalysisSettings({
+        differenceType: "relative",
+      });
+      const absoluteSettings = makeAnalysisSettings({
+        differenceType: "absolute",
+      });
+
+      // Two analyses with distinct settings racing on the same snapshot. The
+      // $ne-on-settings $push filter means both should succeed — one pushes
+      // the relative slot, the other pushes the absolute slot, neither stomps.
+      await Promise.all([
+        addOrUpdateSnapshotAnalysis({
+          context,
+          id: snapshot.id,
+          analysis: makeAnalysis({ settings: relativeSettings, value: 10 }),
+        }),
+        addOrUpdateSnapshotAnalysis({
+          context,
+          id: snapshot.id,
+          analysis: makeAnalysis({ settings: absoluteSettings, value: 20 }),
+        }),
+      ]);
+
+      const result = await findSnapshotById(context, snapshot.id);
+      expect(result?.analyses).toHaveLength(2);
+
+      const values = result?.analyses.map(
+        (a) => a.results[0]?.variations[0]?.metrics.met_1?.value,
+      );
+      expect(values?.sort()).toEqual([10, 20]);
+
+      const keys = result?.analyses.map((a) => a.analysisKey) ?? [];
+      expect(new Set(keys).size).toBe(keys.length);
+      expect(Object.keys(result?.chunkedAnalysesMeta ?? {}).sort()).toEqual(
+        [...keys].sort(),
+      );
+
+      const chunks =
+        await context.models.experimentSnapshotAnalysisChunks.getAllChunksForSnapshot(
+          snapshot.id,
+        );
+      expect(chunks).toHaveLength(1);
+      const subPaths = Object.keys(chunks[0].data).sort();
+      expect(subPaths).toEqual([...keys].sort());
+    });
+
+    it("deduplicates to one analysis when two writers race on the same settings", async () => {
+      // Two writers with identical settings should converge — the $ne filter
+      // prevents a duplicate $push; the loser falls through to update the
+      // existing slot. Final snapshot has exactly one analysis and one meta
+      // entry pointing at the surviving analysisKey. The loser's initial
+      // chunk sub-path (written under a freshly minted key before the push
+      // lost the race) may linger as an orphan — harmless because the
+      // decoder only materializes sub-paths that are present in meta.
+      const context = getSnapshotUpdateContext();
+      const snapshot = makeSnapshotWithMetric("snp_race_same_settings");
+      await createExperimentSnapshotModel({ data: snapshot, context });
+
+      const settings = makeAnalysisSettings();
+
+      await Promise.all([
+        addOrUpdateSnapshotAnalysis({
+          context,
+          id: snapshot.id,
+          analysis: makeAnalysis({ settings, value: 10 }),
+        }),
+        addOrUpdateSnapshotAnalysis({
+          context,
+          id: snapshot.id,
+          analysis: makeAnalysis({ settings, value: 20 }),
+        }),
+      ]);
+
+      const result = await findSnapshotById(context, snapshot.id);
+      expect(result?.analyses).toHaveLength(1);
+
+      const survivingKey = result?.analyses[0].analysisKey as string;
+      expect(Object.keys(result?.chunkedAnalysesMeta ?? {})).toEqual([
+        survivingKey,
+      ]);
+
+      // Last writer wins. The surviving value is one of the two racers,
+      // never a mix of the two (atomic positional $set).
+      const value =
+        result?.analyses[0].results[0].variations[0].metrics.met_1.value;
+      expect([10, 20]).toContain(value);
+
+      const chunks =
+        await context.models.experimentSnapshotAnalysisChunks.getAllChunksForSnapshot(
+          snapshot.id,
+        );
+      expect(chunks).toHaveLength(1);
+      // Every sub-path that matters (i.e., has matching meta) decodes
+      // correctly; orphan sub-paths with no meta entry are ignored.
+      expect(chunks[0].data[survivingKey]?.numRows).toBe(2);
+    });
+
+    it("last writer wins cleanly when two writers race on updateSnapshotAnalysis for the same analysis", async () => {
+      const context = getSnapshotUpdateContext();
+      const snapshot = makeSnapshotWithMetric("snp_race_same_analysis_update");
+      const settings = makeAnalysisSettings();
+
+      await createExperimentSnapshotModel({ data: snapshot, context });
+      await updateSnapshot({
+        context,
+        id: snapshot.id,
+        updates: {
+          status: "success",
+          analyses: [makeAnalysis({ settings, value: 10 })],
+        },
+      });
+
+      await Promise.all([
+        updateSnapshotAnalysis({
+          context,
+          id: snapshot.id,
+          analysis: makeAnalysis({ settings, value: 30 }),
+        }),
+        updateSnapshotAnalysis({
+          context,
+          id: snapshot.id,
+          analysis: makeAnalysis({ settings, value: 50 }),
+        }),
+      ]);
+
+      const result = await findSnapshotById(context, snapshot.id);
+      expect(result?.analyses).toHaveLength(1);
+
+      const value =
+        result?.analyses[0].results[0].variations[0].metrics.met_1.value;
+      // MongoDB serializes per-document updates so there is no torn row: the
+      // survivor is exactly one of the racers, never a mix.
+      expect([30, 50]).toContain(value);
+
+      const chunks =
+        await context.models.experimentSnapshotAnalysisChunks.getAllChunksForSnapshot(
+          snapshot.id,
+        );
+      expect(chunks).toHaveLength(1);
+      const analysisKey = result?.analyses[0].analysisKey as string;
+      expect(Object.keys(chunks[0].data)).toEqual([analysisKey]);
+      expect(chunks[0].data[analysisKey]?.numRows).toBe(2);
+    });
+
+    it("isolates sub-paths when writers race across different analyses", async () => {
+      // The load-bearing invariant: two writers on different analyses of the
+      // same snapshot must touch disjoint MongoDB sub-paths. One writer's
+      // rewrite of its own analysis cannot stomp the other's rows.
+      const context = getSnapshotUpdateContext();
+      const snapshot = makeSnapshotWithMetric("snp_race_cross_analysis");
+      const relativeSettings = makeAnalysisSettings({
+        differenceType: "relative",
+      });
+      const absoluteSettings = makeAnalysisSettings({
+        differenceType: "absolute",
+      });
+
+      await createExperimentSnapshotModel({ data: snapshot, context });
+      await updateSnapshot({
+        context,
+        id: snapshot.id,
+        updates: {
+          status: "success",
+          analyses: [
+            makeAnalysis({ settings: relativeSettings, value: 10 }),
+            makeAnalysis({ settings: absoluteSettings, value: 20 }),
+          ],
+        },
+      });
+
+      await Promise.all([
+        updateSnapshotAnalysis({
+          context,
+          id: snapshot.id,
+          analysis: makeAnalysis({ settings: relativeSettings, value: 99 }),
+        }),
+        updateSnapshotAnalysis({
+          context,
+          id: snapshot.id,
+          analysis: makeAnalysis({ settings: absoluteSettings, value: 77 }),
+        }),
+      ]);
+
+      const result = await findSnapshotById(context, snapshot.id);
+      const byDifferenceType = new Map(
+        result?.analyses.map((a) => [
+          a.settings.differenceType,
+          a.results[0]?.variations[0]?.metrics.met_1?.value,
+        ]) ?? [],
+      );
+      expect(byDifferenceType.get("relative")).toBe(99);
+      expect(byDifferenceType.get("absolute")).toBe(77);
+    });
+
+    it("hydrates chunked results even when hasChunkedAnalyses flag is stale-false", async () => {
+      // Reproduces the P1-4 race: a single-analysis writer resetting its
+      // own analysis can flip `hasChunkedAnalyses: false` based on a read
+      // taken before a concurrent writer populated another analysis. The
+      // scoped meta unset already preserves the surviving analysis's
+      // meta entry — the read path must also not treat the stale flag
+      // as authoritative, or the populated data becomes invisible.
+      const context = getSnapshotUpdateContext();
+      const snapshot = makeSnapshotWithMetric("snp_stale_flag");
+      const settings = makeAnalysisSettings();
+
+      await createExperimentSnapshotModel({ data: snapshot, context });
+      await updateSnapshot({
+        context,
+        id: snapshot.id,
+        updates: {
+          status: "success",
+          analyses: [makeAnalysis({ settings, value: 42 })],
+        },
+      });
+
+      // Simulate the losing race: `hasChunkedAnalyses` flipped to false
+      // on disk while the surviving analysis's meta + chunks remain.
+      const snapshotsCollection = mongoose.connection.db!.collection(
+        "experimentsnapshots",
+      );
+      await snapshotsCollection.updateOne(
+        { id: snapshot.id },
+        { $set: { hasChunkedAnalyses: false } },
+      );
+
+      const result = await findSnapshotById(context, snapshot.id);
+      expect(result?.analyses).toHaveLength(1);
+      expect(
+        result?.analyses[0].results[0].variations[0].metrics.met_1.value,
+      ).toBe(42);
+    });
+  });
+
+  describe("legacy read-path migration", () => {
+    it("decodes a legacy-shape chunk + snapshot identically to a native new-shape equivalent", async () => {
+      // Insert a legacy-shape chunk doc directly into MongoDB (pre-refactor
+      // shape: top-level numRows, data.a column, flat d/v/value columns).
+      // `migrateSnapshot` mints a fresh analysisKey on the parent, and
+      // `populateChunkedAnalyses` co-migrates the legacy chunk in memory
+      // using that key — producing decoded analyses identical to a natively
+      // new-shape snapshot.
+      const context = getSnapshotUpdateContext();
+      const legacySnapshotId = "snp_legacy_roundtrip";
+      const experimentId = "exp_legacy_roundtrip";
+
+      const legacyChunkCollection = mongoose.connection.db!.collection(
+        "experimentsnapshotanalysischunks",
+      );
+      await legacyChunkCollection.insertOne({
+        id: "snpac_legacy_1",
+        organization: "org_1",
+        snapshotId: legacySnapshotId,
+        experimentId,
+        metricId: "met_1",
+        dateCreated: new Date(),
+        dateUpdated: new Date(),
+        numRows: 2,
+        data: {
+          a: [0, 0],
+          d: ["", ""],
+          v: [0, 1],
+          value: [10, 15],
+          cr: [0.1, 0.125],
+          users: [100, 120],
+        },
+      });
+
+      // Insert a legacy-shape parent snapshot (no analysisKey; array-shaped
+      // chunkedAnalysesMeta) via the raw mongoose collection. The model's
+      // read path should rewrite it in memory.
+      const snapshotsCollection = mongoose.connection.db!.collection(
+        "experimentsnapshots",
+      );
+      await snapshotsCollection.insertOne({
+        id: legacySnapshotId,
+        organization: "org_1",
+        experiment: experimentId,
+        phase: 0,
+        dimension: null,
+        dateCreated: new Date(),
+        runStarted: null,
+        status: "success",
+        queries: [],
+        unknownVariations: [],
+        multipleExposures: 0,
+        hasChunkedAnalyses: true,
+        chunkedAnalysesMeta: [
+          {
+            dimensions: [{ name: "", srm: 0.95, variationUsers: [100, 120] }],
+          },
+        ],
+        analyses: [
+          {
+            // no analysisKey — this is what exercises migrateSnapshot
+            dateCreated: new Date(),
+            status: "success",
+            settings: {
+              dimensions: [],
+              statsEngine: "bayesian",
+              regressionAdjusted: false,
+              sequentialTesting: false,
+              differenceType: "relative",
+              pValueCorrection: null,
+              baselineVariationIndex: 0,
+              numGoalMetrics: 1,
+            },
+            results: [],
+          },
+        ],
+        settings: {
+          manual: false,
+          dimensions: [],
+          metricSettings: [],
+          goalMetrics: ["met_1"],
+          secondaryMetrics: [],
+          guardrailMetrics: [],
+          activationMetric: null,
+          defaultMetricPriorSettings: {
+            override: false,
+            proper: false,
+            mean: 0,
+            stddev: 1,
+          },
+          regressionAdjustmentEnabled: false,
+          attributionModel: "firstExposure",
+          experimentId,
+          queryFilter: "",
+          segment: "",
+          skipPartialData: false,
+          datasourceId: "ds_1",
+          exposureQueryId: "eq_1",
+          startDate: new Date(),
+          endDate: new Date(),
+          variations: [
+            { id: "0", weight: 0.5 },
+            { id: "1", weight: 0.5 },
+          ],
+        },
+      });
+
+      const migrated = await findSnapshotById(context, legacySnapshotId);
+      expect(migrated).toBeTruthy();
+      expect(migrated?.analyses).toHaveLength(1);
+
+      const mintedKey = migrated?.analyses[0].analysisKey as string;
+      expect(mintedKey).toBeTruthy();
+
+      // Snapshot migration rewrote the array-shaped chunkedAnalysesMeta
+      // into a record keyed by the same key it minted for analyses[0].
+      expect(Object.keys(migrated?.chunkedAnalysesMeta ?? {})).toEqual([
+        mintedKey,
+      ]);
+
+      // Decoded results should match what the legacy shape encoded.
+      expect(
+        migrated?.analyses[0].results[0].variations[0].metrics.met_1.value,
+      ).toBe(10);
+      expect(
+        migrated?.analyses[0].results[0].variations[1].metrics.met_1.value,
+      ).toBe(15);
+    });
+
+    it("splits a legacy chunk with multiple analyses into per-analysis sub-records with independent numRows", async () => {
+      // Legacy chunk with rows interleaved across two analyses via the `a`
+      // column:
+      //   Analysis 0 (one dim "", two variations) -> 2 rows.
+      //   Analysis 1 (two dims "US"/"UK", but UK v0 has no metric row) -> 3 rows.
+      // Total legacy numRows = 5, split asymmetrically by migration.
+      const context = getSnapshotUpdateContext();
+      const legacySnapshotId = "snp_legacy_multi_analysis";
+      const experimentId = "exp_legacy_multi_analysis";
+
+      const legacyChunkCollection = mongoose.connection.db!.collection(
+        "experimentsnapshotanalysischunks",
+      );
+      await legacyChunkCollection.insertOne({
+        id: "snpac_legacy_multi",
+        organization: "org_1",
+        snapshotId: legacySnapshotId,
+        experimentId,
+        metricId: "met_1",
+        dateCreated: new Date(),
+        dateUpdated: new Date(),
+        numRows: 5,
+        data: {
+          a: [0, 0, 1, 1, 1],
+          d: ["", "", "US", "US", "UK"],
+          v: [0, 1, 0, 1, 1],
+          value: [10, 15, 20, 25, 30],
+          cr: [0.1, 0.15, 0.2, 0.25, 0.3],
+          users: [100, 120, 50, 55, 60],
+        },
+      });
+
+      const snapshotsCollection = mongoose.connection.db!.collection(
+        "experimentsnapshots",
+      );
+      await snapshotsCollection.insertOne({
+        id: legacySnapshotId,
+        organization: "org_1",
+        experiment: experimentId,
+        phase: 0,
+        dimension: null,
+        dateCreated: new Date(),
+        runStarted: null,
+        status: "success",
+        queries: [],
+        unknownVariations: [],
+        multipleExposures: 0,
+        hasChunkedAnalyses: true,
+        chunkedAnalysesMeta: [
+          {
+            dimensions: [{ name: "", srm: 0.95, variationUsers: [100, 120] }],
+          },
+          {
+            dimensions: [
+              { name: "US", srm: 0.9, variationUsers: [50, 55] },
+              { name: "UK", srm: 0.88, variationUsers: [45, 60] },
+            ],
+          },
+        ],
+        analyses: [
+          {
+            dateCreated: new Date(),
+            status: "success",
+            settings: makeAnalysisSettings({ statsEngine: "bayesian" }),
+            results: [],
+          },
+          {
+            dateCreated: new Date(),
+            status: "success",
+            settings: makeAnalysisSettings({
+              statsEngine: "frequentist",
+              dimensions: ["country"],
+            }),
+            results: [],
+          },
+        ],
+        settings: {
+          manual: false,
+          dimensions: [],
+          metricSettings: [],
+          goalMetrics: ["met_1"],
+          secondaryMetrics: [],
+          guardrailMetrics: [],
+          activationMetric: null,
+          defaultMetricPriorSettings: {
+            override: false,
+            proper: false,
+            mean: 0,
+            stddev: 1,
+          },
+          regressionAdjustmentEnabled: false,
+          attributionModel: "firstExposure",
+          experimentId,
+          queryFilter: "",
+          segment: "",
+          skipPartialData: false,
+          datasourceId: "ds_1",
+          exposureQueryId: "eq_1",
+          startDate: new Date(),
+          endDate: new Date(),
+          variations: [
+            { id: "0", weight: 0.5 },
+            { id: "1", weight: 0.5 },
+          ],
+        },
+      });
+
+      const migrated = await findSnapshotById(context, legacySnapshotId);
+      expect(migrated).toBeTruthy();
+      expect(migrated?.analyses).toHaveLength(2);
+
+      const [analysisA, analysisB] = migrated!.analyses;
+      const keyA = analysisA.analysisKey;
+      const keyB = analysisB.analysisKey;
+      expect(keyA).toBeTruthy();
+      expect(keyB).toBeTruthy();
+      expect(keyA).not.toEqual(keyB);
+
+      // Snapshot migration rewrote the array-shaped chunkedAnalysesMeta
+      // into a record keyed by the same keys minted on analyses[].
+      expect(Object.keys(migrated?.chunkedAnalysesMeta ?? {}).sort()).toEqual(
+        [keyA, keyB].sort(),
+      );
+
+      // Chunk migration split the 5-row legacy block 2/3 across the two
+      // analyses — each analysis's decoded `results` reflects its own
+      // effective numRows, not the combined total.
+      expect(analysisA.settings.statsEngine).toBe("bayesian");
+      expect(analysisA.results).toHaveLength(1);
+      const aAll = analysisA.results[0];
+      expect(aAll.name).toBe("");
+      expect(aAll.variations[0].metrics.met_1.value).toBe(10);
+      expect(aAll.variations[0].metrics.met_1.users).toBe(100);
+      expect(aAll.variations[1].metrics.met_1.value).toBe(15);
+
+      expect(analysisB.settings.statsEngine).toBe("frequentist");
+      expect(analysisB.results).toHaveLength(2);
+      const bUs = analysisB.results.find((r) => r.name === "US")!;
+      const bUk = analysisB.results.find((r) => r.name === "UK")!;
+      expect(bUs.variations[0].metrics.met_1.value).toBe(20);
+      expect(bUs.variations[1].metrics.met_1.value).toBe(25);
+      // UK v0 had no legacy row -> decoder hydrates users from meta but
+      // exposes no metric entry for the missing cell.
+      expect(bUk.variations[0].users).toBe(45);
+      expect(bUk.variations[0].metrics.met_1).toBeUndefined();
+      expect(bUk.variations[1].metrics.met_1.value).toBe(30);
+
+      // Re-reading the legacy doc mints fresh analysisKeys (migrateSnapshot
+      // allocates new random keys on each read since the migration is not
+      // persisted), but the decoded numeric results must match — confirming
+      // that the chunk migration correctly follows whichever keys the
+      // snapshot migration mints for the same positions.
+      const again = await findSnapshotById(context, legacySnapshotId);
+      expect(again?.analyses).toHaveLength(2);
+      expect(
+        again?.analyses[0].results[0].variations[0].metrics.met_1.value,
+      ).toBe(10);
+      expect(
+        again?.analyses[0].results[0].variations[1].metrics.met_1.value,
+      ).toBe(15);
+      const againBUs = again?.analyses[1].results.find((r) => r.name === "US");
+      expect(againBUs?.variations[0].metrics.met_1.value).toBe(20);
+      expect(againBUs?.variations[1].metrics.met_1.value).toBe(25);
+    });
+  });
+
+  describe("legacy write-path migration", () => {
+    it("preserves new-shape sub-records appended to a legacy chunk doc", async () => {
+      // Simulates the on-disk state after a writer appends a
+      // `data.<analysisKey>` sub-record (via bulkWrite) to a doc that
+      // still carries legacy top-level `numRows` and flat columns. The
+      // migration must rebuild the position-keyed legacy data AND keep
+      // the pre-existing new-shape sub-record intact so both analyses
+      // decode correctly.
+      const context = getSnapshotUpdateContext();
+      const legacySnapshotId = "snp_mixed_shape";
+      const experimentId = "exp_mixed_shape";
+      const newAnalysisKey = "an_appended_new";
+
+      const legacyChunkCollection = mongoose.connection.db!.collection(
+        "experimentsnapshotanalysischunks",
+      );
+      await legacyChunkCollection.insertOne({
+        id: "snpac_mixed",
+        organization: "org_1",
+        snapshotId: legacySnapshotId,
+        experimentId,
+        metricId: "met_1",
+        dateCreated: new Date(),
+        dateUpdated: new Date(),
+        numRows: 2,
+        data: {
+          a: [0, 0],
+          d: ["", ""],
+          v: [0, 1],
+          value: [10, 15],
+          cr: [0.1, 0.125],
+          users: [100, 120],
+          [newAnalysisKey]: {
+            numRows: 2,
+            d: ["", ""],
+            v: [0, 1],
+            value: [42, 43],
+            cr: [0.42, 0.43],
+            users: [200, 200],
+          },
+        },
+      });
+
+      // Parent snapshot: two analyses. analyses[0] has no analysisKey
+      // (legacy) — migration mints one at read time. analyses[1] already
+      // has the appended key. chunkedAnalysesMeta uses the new
+      // (post-refactor) record shape with meta for the appended key; the
+      // legacy analysis's dimensions get hydrated in a later step of
+      // decode based on the array entries seen — but for this test we
+      // only assert both analyses decode their chunk data correctly.
+      const snapshotsCollection = mongoose.connection.db!.collection(
+        "experimentsnapshots",
+      );
+      await snapshotsCollection.insertOne({
+        id: legacySnapshotId,
+        organization: "org_1",
+        experiment: experimentId,
+        phase: 0,
+        dimension: null,
+        dateCreated: new Date(),
+        runStarted: null,
+        status: "success",
+        queries: [],
+        unknownVariations: [],
+        multipleExposures: 0,
+        hasChunkedAnalyses: true,
+        chunkedAnalysesMeta: {
+          [newAnalysisKey]: {
+            dimensions: [{ name: "", srm: 0.92, variationUsers: [200, 200] }],
+          },
+        },
+        analyses: [
+          {
+            // legacy analysis, no analysisKey — migration will mint one
+            dateCreated: new Date(),
+            status: "success",
+            settings: makeAnalysisSettings({ statsEngine: "bayesian" }),
+            results: [],
+          },
+          {
+            analysisKey: newAnalysisKey,
+            dateCreated: new Date(),
+            status: "success",
+            settings: makeAnalysisSettings({ statsEngine: "frequentist" }),
+            results: [],
+          },
+        ],
+        settings: {
+          manual: false,
+          dimensions: [],
+          metricSettings: [],
+          goalMetrics: ["met_1"],
+          secondaryMetrics: [],
+          guardrailMetrics: [],
+          activationMetric: null,
+          defaultMetricPriorSettings: {
+            override: false,
+            proper: false,
+            mean: 0,
+            stddev: 1,
+          },
+          regressionAdjustmentEnabled: false,
+          attributionModel: "firstExposure",
+          experimentId,
+          queryFilter: "",
+          segment: "",
+          skipPartialData: false,
+          datasourceId: "ds_1",
+          exposureQueryId: "eq_1",
+          startDate: new Date(),
+          endDate: new Date(),
+          variations: [
+            { id: "0", weight: 0.5 },
+            { id: "1", weight: 0.5 },
+          ],
+        },
+      });
+
+      const migrated = await findSnapshotById(context, legacySnapshotId);
+      expect(migrated).toBeTruthy();
+      expect(migrated?.analyses).toHaveLength(2);
+
+      // Legacy analysis: decodes from the position-keyed data rebuilt by
+      // phase-1 migration from the flat columns.
+      const legacyAnalysis = migrated!.analyses[0];
+      expect(legacyAnalysis.analysisKey).toBeTruthy();
+      expect(legacyAnalysis.settings.statsEngine).toBe("bayesian");
+      expect(legacyAnalysis.results[0].variations[0].metrics.met_1.value).toBe(
+        10,
+      );
+      expect(legacyAnalysis.results[0].variations[1].metrics.met_1.value).toBe(
+        15,
+      );
+
+      // Appended analysis: decodes from the new-shape sub-record that my
+      // fix preserves through migration. Without the fix this would be
+      // silently dropped and the test would see undefined results.
+      const appendedAnalysis = migrated!.analyses[1];
+      expect(appendedAnalysis.analysisKey).toBe(newAnalysisKey);
+      expect(appendedAnalysis.settings.statsEngine).toBe("frequentist");
+      expect(
+        appendedAnalysis.results[0].variations[0].metrics.met_1.value,
+      ).toBe(42);
+      expect(
+        appendedAnalysis.results[0].variations[1].metrics.met_1.value,
+      ).toBe(43);
+    });
+
+    it("preserves multiple sequentially-appended new-shape sub-records", async () => {
+      // Two writers each appended their own analysisKey sub-record to a
+      // legacy chunk. Both must survive migration.
+      const context = getSnapshotUpdateContext();
+      const legacySnapshotId = "snp_mixed_sequential";
+      const experimentId = "exp_mixed_sequential";
+      const keyFirst = "an_first_write";
+      const keySecond = "an_second_write";
+
+      const legacyChunkCollection = mongoose.connection.db!.collection(
+        "experimentsnapshotanalysischunks",
+      );
+      await legacyChunkCollection.insertOne({
+        id: "snpac_mixed_seq",
+        organization: "org_1",
+        snapshotId: legacySnapshotId,
+        experimentId,
+        metricId: "met_1",
+        dateCreated: new Date(),
+        dateUpdated: new Date(),
+        numRows: 2,
+        data: {
+          a: [0, 0],
+          d: ["", ""],
+          v: [0, 1],
+          value: [1, 2],
+          cr: [0.01, 0.02],
+          users: [100, 100],
+          [keyFirst]: {
+            numRows: 2,
+            d: ["", ""],
+            v: [0, 1],
+            value: [10, 11],
+            cr: [0.1, 0.11],
+            users: [100, 100],
+          },
+          [keySecond]: {
+            numRows: 2,
+            d: ["", ""],
+            v: [0, 1],
+            value: [20, 21],
+            cr: [0.2, 0.21],
+            users: [100, 100],
+          },
+        },
+      });
+
+      const snapshotsCollection = mongoose.connection.db!.collection(
+        "experimentsnapshots",
+      );
+      await snapshotsCollection.insertOne({
+        id: legacySnapshotId,
+        organization: "org_1",
+        experiment: experimentId,
+        phase: 0,
+        dimension: null,
+        dateCreated: new Date(),
+        runStarted: null,
+        status: "success",
+        queries: [],
+        unknownVariations: [],
+        multipleExposures: 0,
+        hasChunkedAnalyses: true,
+        chunkedAnalysesMeta: {
+          [keyFirst]: {
+            dimensions: [{ name: "", srm: 0.9, variationUsers: [100, 100] }],
+          },
+          [keySecond]: {
+            dimensions: [{ name: "", srm: 0.9, variationUsers: [100, 100] }],
+          },
+        },
+        analyses: [
+          {
+            dateCreated: new Date(),
+            status: "success",
+            settings: makeAnalysisSettings({ statsEngine: "bayesian" }),
+            results: [],
+          },
+          {
+            analysisKey: keyFirst,
+            dateCreated: new Date(),
+            status: "success",
+            settings: makeAnalysisSettings({ statsEngine: "frequentist" }),
+            results: [],
+          },
+          {
+            analysisKey: keySecond,
+            dateCreated: new Date(),
+            status: "success",
+            settings: makeAnalysisSettings({
+              statsEngine: "frequentist",
+              differenceType: "absolute",
+            }),
+            results: [],
+          },
+        ],
+        settings: {
+          manual: false,
+          dimensions: [],
+          metricSettings: [],
+          goalMetrics: ["met_1"],
+          secondaryMetrics: [],
+          guardrailMetrics: [],
+          activationMetric: null,
+          defaultMetricPriorSettings: {
+            override: false,
+            proper: false,
+            mean: 0,
+            stddev: 1,
+          },
+          regressionAdjustmentEnabled: false,
+          attributionModel: "firstExposure",
+          experimentId,
+          queryFilter: "",
+          segment: "",
+          skipPartialData: false,
+          datasourceId: "ds_1",
+          exposureQueryId: "eq_1",
+          startDate: new Date(),
+          endDate: new Date(),
+          variations: [
+            { id: "0", weight: 0.5 },
+            { id: "1", weight: 0.5 },
+          ],
+        },
+      });
+
+      const migrated = await findSnapshotById(context, legacySnapshotId);
+      expect(migrated?.analyses).toHaveLength(3);
+
+      // Legacy position-keyed data.
+      expect(
+        migrated!.analyses[0].results[0].variations[0].metrics.met_1.value,
+      ).toBe(1);
+      expect(
+        migrated!.analyses[0].results[0].variations[1].metrics.met_1.value,
+      ).toBe(2);
+
+      // First appended analysisKey.
+      expect(
+        migrated!.analyses[1].results[0].variations[0].metrics.met_1.value,
+      ).toBe(10);
+      expect(
+        migrated!.analyses[1].results[0].variations[1].metrics.met_1.value,
+      ).toBe(11);
+
+      // Second appended analysisKey.
+      expect(
+        migrated!.analyses[2].results[0].variations[0].metrics.met_1.value,
+      ).toBe(20);
+      expect(
+        migrated!.analyses[2].results[0].variations[1].metrics.met_1.value,
+      ).toBe(21);
+    });
+
+    it("preserves legacy data when addOrUpdateSnapshotAnalysis appends a new analysis", async () => {
+      // End-to-end regression: a legacy snapshot + chunk on disk, then the
+      // production write path (`addOrUpdateSnapshotAnalysis`) appends a new
+      // analysis. Without the chunk-migration fix the re-read silently
+      // drops the pre-existing legacy data; with the fix both analyses
+      // decode correctly.
+      const context = getSnapshotUpdateContext();
+      const legacySnapshotId = "snp_write_to_legacy";
+      const experimentId = "exp_write_to_legacy";
+
+      const legacyChunkCollection = mongoose.connection.db!.collection(
+        "experimentsnapshotanalysischunks",
+      );
+      await legacyChunkCollection.insertOne({
+        id: "snpac_write_to_legacy",
+        organization: "org_1",
+        snapshotId: legacySnapshotId,
+        experimentId,
+        metricId: "met_1",
+        dateCreated: new Date(),
+        dateUpdated: new Date(),
+        numRows: 2,
+        data: {
+          a: [0, 0],
+          d: ["", ""],
+          v: [0, 1],
+          value: [10, 15],
+          cr: [0.1, 0.125],
+          users: [100, 120],
+        },
+      });
+
+      const snapshotsCollection = mongoose.connection.db!.collection(
+        "experimentsnapshots",
+      );
+      await snapshotsCollection.insertOne({
+        id: legacySnapshotId,
+        organization: "org_1",
+        experiment: experimentId,
+        phase: 0,
+        dimension: null,
+        dateCreated: new Date(),
+        runStarted: null,
+        status: "success",
+        queries: [],
+        unknownVariations: [],
+        multipleExposures: 0,
+        hasChunkedAnalyses: true,
+        chunkedAnalysesMeta: {
+          "0": {
+            dimensions: [{ name: "", srm: 0.95, variationUsers: [100, 120] }],
+          },
+        },
+        analyses: [
+          {
+            dateCreated: new Date(),
+            status: "success",
+            settings: makeAnalysisSettings({ statsEngine: "bayesian" }),
+            results: [],
+          },
+        ],
+        settings: {
+          manual: false,
+          dimensions: [],
+          metricSettings: [],
+          goalMetrics: ["met_1"],
+          secondaryMetrics: [],
+          guardrailMetrics: [],
+          activationMetric: null,
+          defaultMetricPriorSettings: {
+            override: false,
+            proper: false,
+            mean: 0,
+            stddev: 1,
+          },
+          regressionAdjustmentEnabled: false,
+          attributionModel: "firstExposure",
+          experimentId,
+          queryFilter: "",
+          segment: "",
+          skipPartialData: false,
+          datasourceId: "ds_1",
+          exposureQueryId: "eq_1",
+          startDate: new Date(),
+          endDate: new Date(),
+          variations: [
+            { id: "0", weight: 0.5 },
+            { id: "1", weight: 0.5 },
+          ],
+        },
+      });
+
+      // Append a new frequentist analysis via the production write path.
+      // This exercises the bulkWrite that adds `data.<newKey>` alongside
+      // the legacy flat columns on the chunk doc.
+      const freqSettings = makeAnalysisSettings({ statsEngine: "frequentist" });
+      await addOrUpdateSnapshotAnalysis({
+        context,
+        id: legacySnapshotId,
+        analysis: makeAnalysis({ settings: freqSettings, value: 99 }),
+      });
+
+      const result = await findSnapshotById(context, legacySnapshotId);
+      expect(result?.analyses).toHaveLength(2);
+
+      const legacyAnalysis = result!.analyses.find(
+        (a) => a.settings.statsEngine === "bayesian",
+      );
+      const appendedAnalysis = result!.analyses.find(
+        (a) => a.settings.statsEngine === "frequentist",
+      );
+      expect(legacyAnalysis).toBeTruthy();
+      expect(appendedAnalysis).toBeTruthy();
+
+      // Pre-existing legacy data must still be visible.
+      expect(legacyAnalysis!.results[0].variations[0].metrics.met_1.value).toBe(
+        10,
+      );
+      expect(legacyAnalysis!.results[0].variations[1].metrics.met_1.value).toBe(
+        15,
+      );
+
+      // Appended analysis data must also be visible.
+      expect(
+        appendedAnalysis!.results[0].variations[0].metrics.met_1.value,
+      ).toBe(99);
+      expect(
+        appendedAnalysis!.results[0].variations[1].metrics.met_1.value,
+      ).toBe(104);
     });
   });
 });

--- a/packages/back-end/test/models/ExperimentSnapshotModel.test.ts
+++ b/packages/back-end/test/models/ExperimentSnapshotModel.test.ts
@@ -2670,6 +2670,61 @@ describe("ExperimentSnapshotModel", () => {
       );
     });
 
+    it("appends a new analysis when chunkedAnalysesMeta is stored as an empty array on disk", async () => {
+      const context = getSnapshotUpdateContext();
+      const legacySnapshotId = "snp_empty_array_meta_append";
+      const experimentId = "exp_empty_array_meta_append";
+
+      const snapshotsCollection = mongoose.connection.db!.collection(
+        "experimentsnapshots",
+      );
+      await snapshotsCollection.insertOne({
+        id: legacySnapshotId,
+        organization: "org_1",
+        experiment: experimentId,
+        phase: 0,
+        dimension: null,
+        dateCreated: new Date(),
+        runStarted: null,
+        status: "success",
+        queries: [],
+        unknownVariations: [],
+        multipleExposures: 0,
+        hasChunkedAnalyses: false,
+        chunkedAnalysesMeta: [],
+        analyses: [
+          {
+            dateCreated: new Date(),
+            status: "success",
+            settings: makeAnalysisSettings({ statsEngine: "bayesian" }),
+            results: [],
+          },
+        ],
+        settings: makeLegacyInlineSnapshotSettings(experimentId),
+      });
+
+      await addOrUpdateSnapshotAnalysis({
+        context,
+        id: legacySnapshotId,
+        analysis: makeAnalysis({
+          settings: makeAnalysisSettings({ statsEngine: "frequentist" }),
+          value: 33,
+        }),
+      });
+
+      const result = await findSnapshotById(context, legacySnapshotId);
+      expect(result?.analyses).toHaveLength(2);
+      expect(
+        result?.analyses[1].results[0].variations[0].metrics.met_1.value,
+      ).toBe(33);
+
+      const stored = (await snapshotsCollection.findOne({
+        id: legacySnapshotId,
+      })) as { chunkedAnalysesMeta?: unknown } | null;
+      expect(Array.isArray(stored?.chunkedAnalysesMeta)).toBe(false);
+      expect(typeof stored?.chunkedAnalysesMeta).toBe("object");
+    });
+
     it("updates an existing analysis when chunkedAnalysesMeta is stored as an array on disk", async () => {
       const context = getSnapshotUpdateContext();
       const legacySnapshotId = "snp_array_meta_update";

--- a/packages/back-end/test/models/ExperimentSnapshotModel.test.ts
+++ b/packages/back-end/test/models/ExperimentSnapshotModel.test.ts
@@ -2250,6 +2250,10 @@ describe("ExperimentSnapshotModel", () => {
       expect(appendedAnalysis).toBeTruthy();
 
       // Pre-existing legacy data must still be visible.
+      expect(legacyAnalysis!.results[0].srm).toBe(0.95);
+      expect(legacyAnalysis!.results[0].variations.map((v) => v.users)).toEqual(
+        [100, 120],
+      );
       expect(legacyAnalysis!.results[0].variations[0].metrics.met_1.value).toBe(
         10,
       );
@@ -2264,6 +2268,21 @@ describe("ExperimentSnapshotModel", () => {
       expect(
         appendedAnalysis!.results[0].variations[1].metrics.met_1.value,
       ).toBe(104);
+
+      const stored = (await snapshotsCollection.findOne({
+        id: legacySnapshotId,
+      })) as {
+        analyses?: { analysisKey?: string }[];
+        chunkedAnalysesMeta?: Record<string, unknown>;
+      } | null;
+      const storedKeys =
+        stored?.analyses?.map((analysis) => analysis.analysisKey) ?? [];
+      expect(storedKeys.every((key) => typeof key === "string" && !!key)).toBe(
+        true,
+      );
+      expect(Object.keys(stored?.chunkedAnalysesMeta ?? {}).sort()).toEqual(
+        [...storedKeys].sort(),
+      );
     });
 
     it("preserves legacy inline analyses when updateSnapshotAnalysis writes to a snapshot from main", async () => {
@@ -2608,9 +2627,25 @@ describe("ExperimentSnapshotModel", () => {
       const result = await findSnapshotById(context, legacySnapshotId);
       expect(result?.analyses).toHaveLength(3);
 
+      const bayesian = result!.analyses.find(
+        (analysis) => analysis.settings.statsEngine === "bayesian",
+      );
+      const frequentist = result!.analyses.find(
+        (analysis) =>
+          analysis.settings.statsEngine === "frequentist" &&
+          analysis.settings.differenceType === "relative",
+      );
       const appended = result!.analyses.find(
         (analysis) => analysis.settings.differenceType === "absolute",
       );
+      expect(bayesian?.results[0].srm).toBe(0.95);
+      expect(bayesian?.results[0].variations.map((v) => v.users)).toEqual([
+        100, 120,
+      ]);
+      expect(frequentist?.results[0].srm).toBe(0.9);
+      expect(frequentist?.results[0].variations.map((v) => v.users)).toEqual([
+        100, 120,
+      ]);
       expect(appended?.results[0].variations[0].metrics.met_1.value).toBe(33);
       expect(appended?.results[0].variations[1].metrics.met_1.value).toBe(38);
 
@@ -2618,9 +2653,20 @@ describe("ExperimentSnapshotModel", () => {
       // form on disk so subsequent partial $sets on string keys work.
       const stored = (await snapshotsCollection.findOne({
         id: legacySnapshotId,
-      })) as { chunkedAnalysesMeta?: unknown } | null;
+      })) as {
+        analyses?: { analysisKey?: string }[];
+        chunkedAnalysesMeta?: Record<string, unknown>;
+      } | null;
       expect(Array.isArray(stored?.chunkedAnalysesMeta)).toBe(false);
       expect(typeof stored?.chunkedAnalysesMeta).toBe("object");
+      const storedKeys =
+        stored?.analyses?.map((analysis) => analysis.analysisKey) ?? [];
+      expect(storedKeys.every((key) => typeof key === "string" && !!key)).toBe(
+        true,
+      );
+      expect(Object.keys(stored?.chunkedAnalysesMeta ?? {}).sort()).toEqual(
+        [...storedKeys].sort(),
+      );
     });
 
     it("updates an existing analysis when chunkedAnalysesMeta is stored as an array on disk", async () => {

--- a/packages/back-end/test/models/ExperimentSnapshotModel.test.ts
+++ b/packages/back-end/test/models/ExperimentSnapshotModel.test.ts
@@ -829,6 +829,63 @@ describe("ExperimentSnapshotModel", () => {
       ).toBe(15);
       expect(populateChunkedAnalysesSpy).not.toHaveBeenCalled();
     });
+
+    it("preserves distinct analysisKeys when multiple analyses share identical settings", async () => {
+      const context = getSnapshotUpdateContext();
+      const snapshot = makeSnapshotWithMetric("snp_shared_settings");
+      const sharedSettings = makeAnalysisSettings({ statsEngine: "bayesian" });
+      const firstKey = buildAnalysisKey();
+      const secondKey = buildAnalysisKey();
+      snapshot.analyses = [
+        {
+          analysisKey: firstKey,
+          dateCreated: new Date("2025-01-01T00:00:00Z"),
+          status: "running",
+          settings: sharedSettings,
+          results: [],
+        },
+        {
+          analysisKey: secondKey,
+          dateCreated: new Date("2025-01-01T00:00:00Z"),
+          status: "running",
+          settings: sharedSettings,
+          results: [],
+        },
+      ];
+
+      await createExperimentSnapshotModel({ data: snapshot, context });
+
+      const firstAnalysis = makeAnalysis({
+        settings: sharedSettings,
+        value: 10,
+      });
+      firstAnalysis.analysisKey = firstKey;
+      const secondAnalysis = makeAnalysis({
+        settings: sharedSettings,
+        value: 20,
+      });
+      secondAnalysis.analysisKey = secondKey;
+
+      await updateSnapshot({
+        context,
+        id: snapshot.id,
+        updates: {
+          status: "success",
+          analyses: [firstAnalysis, secondAnalysis],
+        },
+      });
+
+      const stored = await findSnapshotById(context, snapshot.id);
+      expect(stored?.analyses).toHaveLength(2);
+      expect(stored?.analyses[0].analysisKey).toBe(firstKey);
+      expect(stored?.analyses[1].analysisKey).toBe(secondKey);
+      expect(
+        stored?.analyses[0].results[0].variations[0].metrics.met_1.value,
+      ).toBe(10);
+      expect(
+        stored?.analyses[1].results[0].variations[0].metrics.met_1.value,
+      ).toBe(20);
+    });
   });
 
   describe("chunked snapshot analysis updates", () => {

--- a/packages/back-end/test/services/snapshot-lifecycle.test.ts
+++ b/packages/back-end/test/services/snapshot-lifecycle.test.ts
@@ -6,6 +6,7 @@ import {
   ExperimentSnapshotInterface,
   ExperimentSnapshotSettings,
 } from "shared/types/experiment-snapshot";
+import { buildAnalysisKey } from "shared/snapshot-analysis-chunks";
 import { MetricSnapshotSettings } from "shared/types/report";
 import { ApiReqContext } from "back-end/types/api";
 import {
@@ -196,6 +197,7 @@ function makePlan(
       multipleExposures: 0,
       analyses: [
         {
+          analysisKey: buildAnalysisKey(),
           dateCreated: new Date("2025-02-01T00:00:00.000Z"),
           results: [],
           settings: defaultAnalysisSettings,

--- a/packages/shared/src/snapshot-analysis-chunks.ts
+++ b/packages/shared/src/snapshot-analysis-chunks.ts
@@ -1,22 +1,39 @@
+import uniqid from "uniqid";
 import {
   ExperimentSnapshotAnalysis,
   ExperimentSnapshotAnalysisSettings,
-  ExperimentSnapshotInterface,
   SnapshotMetric,
   SnapshotVariation,
 } from "shared/types/experiment-snapshot";
 import { ExperimentReportResultDimension } from "shared/types/report";
 
-// Index columns identify which (analysis, dimension, variation) a row belongs to.
-// The metricId is a document-level field, not a column.
-const INDEX_COLUMNS = new Set(["a", "d", "v"]);
+export type AnalysisKeyType = string;
+
+// Index columns identify which (dimension, variation) a row belongs to inside
+// a per-analysis sub-path. The metricId is a document-level field, not a column.
+const INDEX_COLUMNS = new Set(["d", "v"]);
+
+/** Generate a fresh `analysisKey` for a newly created analysis. */
+export function buildAnalysisKey(): string {
+  return uniqid("an_");
+}
 
 // -- Types --
 
-export type MetricChunkData = {
+/**
+ * Per-analysis columnar sub-record stored under `chunk.data.<analysisKey>`.
+ * Every column array (d, v, and any value columns) has exactly `numRows`
+ * entries. Value columns use an `unknown` index so declared fields retain
+ * their narrow types; callers must narrow with `Array.isArray` before use.
+ */
+export type AnalysisChunkData = {
   numRows: number;
-  data: Record<string, unknown[]>;
+  d: string[];
+  v: number[];
+  [col: string]: unknown;
 };
+
+export type MetricChunkData = Record<string, AnalysisChunkData>;
 
 export type AnalysisMetaEntry = {
   dimensions: Array<{
@@ -28,28 +45,50 @@ export type AnalysisMetaEntry = {
 
 export interface EncodeResult {
   metricChunks: Map<string, MetricChunkData>;
-  chunkedAnalysesMeta: AnalysisMetaEntry[];
+  chunkedAnalysesMeta: Record<string, AnalysisMetaEntry>;
 }
 
 // -- Encode --
 
 /**
- * Encode snapshot analyses into per-metric columnar documents.
- * Each metric gets its own chunk. Meta data (srm, variation users) is
- * extracted once and returned separately for storage on the snapshot doc.
+ * Encode snapshot analyses into per-metric, per-analysis columnar data.
+ *
+ * Each analysis must already have an immutable `analysisKey`. The encoder
+ * emits one chunk payload per metric, with every analysis stored under its
+ * own `data.<analysisKey>` sub-record so concurrent writers updating
+ * different analyses never touch the same MongoDB field.
+ *
+ * Meta data (srm, variation users) is extracted once per analysis and
+ * returned as a keyed record for storage on the snapshot doc.
  */
 export function encodeSnapshotAnalysisChunks(
   analyses: ExperimentSnapshotAnalysis[],
   metricOrdering: string[],
 ): EncodeResult {
-  // Extract chunkedAnalysesMeta (shared across all metrics)
-  const chunkedAnalysesMeta: AnalysisMetaEntry[] = analyses.map((analysis) => ({
-    dimensions: analysis.results.map((dim) => ({
-      name: dim.name,
-      srm: dim.srm,
-      variationUsers: dim.variations.map((v) => v.users),
-    })),
-  }));
+  // Duplicate analysisKeys would collapse onto the same MongoDB sub-path
+  // and silently lose data. TypeScript can enforce that each analysis has a
+  // key, but not uniqueness across the array — so we check it here.
+  const seenKeys = new Set<string>();
+  for (const analysis of analyses) {
+    if (seenKeys.has(analysis.analysisKey)) {
+      throw new Error(
+        `encodeSnapshotAnalysisChunks: duplicate analysisKey "${analysis.analysisKey}"`,
+      );
+    }
+    seenKeys.add(analysis.analysisKey);
+  }
+
+  // Extract chunkedAnalysesMeta (one entry per analysis, keyed by analysisKey)
+  const chunkedAnalysesMeta: Record<string, AnalysisMetaEntry> = {};
+  for (const analysis of analyses) {
+    chunkedAnalysesMeta[analysis.analysisKey] = {
+      dimensions: analysis.results.map((dim) => ({
+        name: dim.name,
+        srm: dim.srm,
+        variationUsers: dim.variations.map((v) => v.users),
+      })),
+    };
+  }
 
   // Collect all metric IDs seen across all analyses
   const allMetricIds = new Set<string>();
@@ -77,80 +116,123 @@ export function encodeSnapshotAnalysisChunks(
   const metricChunks = new Map<string, MetricChunkData>();
 
   for (const metricId of orderedMetrics) {
-    const data: Record<string, unknown[]> = { a: [], d: [], v: [] };
-    const valueColumns = new Set<string>();
-    let numRows = 0;
+    const perMetricData: MetricChunkData = {};
+    let metricHasRows = false;
 
-    for (let ai = 0; ai < analyses.length; ai++) {
-      const analysis = analyses[ai];
-      for (const dim of analysis.results) {
-        for (let vi = 0; vi < dim.variations.length; vi++) {
-          const metric = dim.variations[vi].metrics[metricId];
-          if (!metric) continue;
-
-          data.a.push(ai);
-          data.d.push(dim.name);
-          data.v.push(vi);
-
-          for (const col of Object.keys(metric)) {
-            if (!valueColumns.has(col)) {
-              valueColumns.add(col);
-              // Backfill nulls for previous rows
-              data[col] = new Array(numRows).fill(null);
-            }
-            data[col].push(metric[col as keyof SnapshotMetric] ?? null);
-          }
-          // For any known value columns not in this flat object, push null
-          for (const col of valueColumns) {
-            if (!(col in metric)) {
-              data[col].push(null);
-            }
-          }
-
-          numRows++;
-        }
+    for (const analysis of analyses) {
+      const perAnalysis = encodePerAnalysis(analysis, metricId);
+      if (perAnalysis.numRows > 0) {
+        perMetricData[analysis.analysisKey] = perAnalysis;
+        metricHasRows = true;
       }
     }
 
-    if (numRows > 0) {
-      metricChunks.set(metricId, { numRows, data });
+    if (metricHasRows) {
+      metricChunks.set(metricId, perMetricData);
     }
   }
 
   return { metricChunks, chunkedAnalysesMeta };
 }
 
+/**
+ * Encode a single (analysis, metric) pair into columnar form. Rows where
+ * the metric is absent are skipped, so `numRows` reflects only rows where
+ * this metric contributed data.
+ */
+function encodePerAnalysis(
+  analysis: ExperimentSnapshotAnalysis,
+  metricId: string,
+): AnalysisChunkData {
+  const d: string[] = [];
+  const v: number[] = [];
+  const valueColumns = new Map<string, unknown[]>();
+  let numRows = 0;
+
+  for (const dim of analysis.results) {
+    for (let vi = 0; vi < dim.variations.length; vi++) {
+      const metric = dim.variations[vi].metrics[metricId];
+      if (!metric) continue;
+
+      d.push(dim.name);
+      v.push(vi);
+
+      for (const col of Object.keys(metric)) {
+        if (!valueColumns.has(col)) {
+          // New value column — backfill nulls for prior rows of this analysis.
+          valueColumns.set(col, new Array(numRows).fill(null));
+        }
+        valueColumns
+          .get(col)!
+          .push(metric[col as keyof SnapshotMetric] ?? null);
+      }
+      // Value columns seen before but not in this flat object pad with null.
+      for (const [col, values] of valueColumns) {
+        if (!(col in metric)) values.push(null);
+      }
+
+      numRows++;
+    }
+  }
+
+  const perAnalysis: AnalysisChunkData = { numRows, d, v };
+  for (const [col, values] of valueColumns) {
+    perAnalysis[col] = values;
+  }
+  return perAnalysis;
+}
+
 // -- Decode --
 
-interface AnalysisMetadata {
+export interface AnalysisMetadata {
+  analysisKey: string;
   settings: ExperimentSnapshotAnalysisSettings;
   dateCreated: Date;
   status: "running" | "success" | "error";
   error?: string;
 }
 
+// Loose shape accepted by the decoder. Matches the zod validator's stored
+// shape (columns typed as `unknown[]`) so callers can pass chunk documents
+// straight from MongoDB without an upfront cast. The encoder guarantees
+// `d` holds strings and `v` holds numbers at write time — we narrow them
+// positionally inside the decoder.
+type PerAnalysisChunkDataInput = {
+  numRows: number;
+  d: unknown[];
+  v: unknown[];
+  [col: string]: unknown;
+};
+
 interface MetricChunkInput {
   metricId: string;
-  numRows: number;
-  data: Record<string, unknown[]>;
+  data: Record<string, PerAnalysisChunkDataInput>;
 }
 
 /**
- * Decode per-metric columnar chunks back into ExperimentSnapshotAnalysis[].
+ * Decode per-metric, per-analysis columnar chunks back into
+ * `ExperimentSnapshotAnalysis[]`.
  *
- * @param chunks - Per-metric chunk documents
- * @param chunkedAnalysesMeta - Shared dimension/variation metadata (from snapshot doc)
- * @param analysisMetadata - Per-analysis settings/status (from snapshot doc)
- * @param filterMetricIds - Optional set of metric IDs to include
+ * Each chunk stores its rows under `data.<analysisKey>`, so the decoder
+ * looks each key up in `chunkedAnalysesMeta` to hydrate dimension /
+ * variation structure. Analyses whose meta is missing are skipped cleanly
+ * (this is the "stale meta, fresh chunk" safety property from the
+ * race-fix plan).
+ *
+ * @param chunks - Per-metric chunk documents (new shape).
+ * @param chunkedAnalysesMeta - Shared dimension/variation metadata keyed
+ *   by analysisKey (from the snapshot doc).
+ * @param analysisMetadata - Per-analysis settings/status (from snapshot),
+ *   each including its analysisKey. Output order mirrors this input.
+ * @param filterMetricIds - Optional set of metric IDs to include.
  */
 export function decodeSnapshotAnalysisChunks(
   chunks: MetricChunkInput[],
-  chunkedAnalysesMeta: AnalysisMetaEntry[],
+  chunkedAnalysesMeta: Record<string, AnalysisMetaEntry>,
   analysisMetadata: AnalysisMetadata[],
   filterMetricIds?: Set<string>,
 ): ExperimentSnapshotAnalysis[] {
-  // Build the nested structure
-  // analysisIndex -> dimensionName -> { srm, variations: [{ users, metrics }] }
+  // analysisKey -> dimensionName -> { srm, variations: [{ users, metrics }] }
   type DimData = {
     srm: number;
     variations: Map<
@@ -158,12 +240,11 @@ export function decodeSnapshotAnalysisChunks(
       { users: number; metrics: Record<string, SnapshotMetric> }
     >;
   };
-  const analysisMap = new Map<number, Map<string, DimData>>();
+  const analysisMap = new Map<string, Map<string, DimData>>();
 
-  // Initialize structure from chunkedAnalysesMeta
-  for (let ai = 0; ai < chunkedAnalysesMeta.length; ai++) {
-    const meta = chunkedAnalysesMeta[ai];
-    if (!meta) continue;
+  // Seed structure from chunkedAnalysesMeta so dimensions without metric
+  // rows still appear (matches legacy decoder behaviour).
+  for (const [analysisKey, meta] of Object.entries(chunkedAnalysesMeta)) {
     const dims = new Map<string, DimData>();
     for (const dim of meta.dimensions) {
       const variations = new Map<
@@ -175,56 +256,60 @@ export function decodeSnapshotAnalysisChunks(
       }
       dims.set(dim.name, { srm: dim.srm, variations });
     }
-    analysisMap.set(ai, dims);
+    analysisMap.set(analysisKey, dims);
   }
 
   // Process data rows from each chunk
   for (const chunk of chunks) {
-    const { metricId, data, numRows } = chunk;
-    if (!numRows) continue;
+    const { metricId, data } = chunk;
 
     // Skip if filtering and this metric isn't requested
     if (filterMetricIds && !filterMetricIds.has(metricId)) continue;
 
-    const dataA = data.a as number[];
-    const dataD = data.d as string[];
-    const dataV = data.v as number[];
-    const valueColumns = Object.keys(data).filter(
-      (col) => !INDEX_COLUMNS.has(col),
-    );
+    for (const [analysisKey, perAnalysis] of Object.entries(data)) {
+      const { numRows, d, v } = perAnalysis;
+      if (!numRows) continue;
 
-    for (let i = 0; i < numRows; i++) {
-      const ai = dataA[i];
-      const dimName = dataD[i];
-      const vi = dataV[i];
-
-      // Read flat metric values, omitting nulls so absent optional fields
-      // stay undefined (matching the original inline representation).
-      const metric: Record<string, unknown> = {};
-      for (const col of valueColumns) {
-        const val = data[col]?.[i] ?? null;
-        if (val !== null) {
-          metric[col] = val;
-        }
-      }
+      const valueColumns = Object.keys(perAnalysis).filter(
+        (col) => col !== "numRows" && !INDEX_COLUMNS.has(col),
+      );
 
       // Ensure structure exists (in case chunkedAnalysesMeta is incomplete)
-      if (!analysisMap.has(ai)) analysisMap.set(ai, new Map());
-      const dims = analysisMap.get(ai)!;
-      if (!dims.has(dimName))
-        dims.set(dimName, { srm: 0, variations: new Map() });
-      const dim = dims.get(dimName)!;
-      if (!dim.variations.has(vi))
-        dim.variations.set(vi, { users: 0, metrics: {} });
+      if (!analysisMap.has(analysisKey))
+        analysisMap.set(analysisKey, new Map());
+      const dims = analysisMap.get(analysisKey)!;
 
-      dim.variations.get(vi)!.metrics[metricId] =
-        metric as unknown as SnapshotMetric;
+      for (let i = 0; i < numRows; i++) {
+        const dimName = d[i] as string;
+        const vi = v[i] as number;
+
+        // Read flat metric values, omitting nulls so absent optional fields
+        // stay undefined (matching the original inline representation).
+        const metric: Record<string, unknown> = {};
+        for (const col of valueColumns) {
+          const colValues = perAnalysis[col];
+          if (!Array.isArray(colValues)) continue;
+          const val = colValues[i] ?? null;
+          if (val !== null) {
+            metric[col] = val;
+          }
+        }
+
+        if (!dims.has(dimName))
+          dims.set(dimName, { srm: 0, variations: new Map() });
+        const dim = dims.get(dimName)!;
+        if (!dim.variations.has(vi))
+          dim.variations.set(vi, { users: 0, metrics: {} });
+
+        dim.variations.get(vi)!.metrics[metricId] =
+          metric as unknown as SnapshotMetric;
+      }
     }
   }
 
-  // Reconstruct ExperimentSnapshotAnalysis[]
-  return analysisMetadata.map((meta, ai): ExperimentSnapshotAnalysis => {
-    const dims = analysisMap.get(ai);
+  // Reconstruct ExperimentSnapshotAnalysis[] in the order of analysisMetadata.
+  return analysisMetadata.map((meta): ExperimentSnapshotAnalysis => {
+    const dims = analysisMap.get(meta.analysisKey);
     const results: ExperimentReportResultDimension[] = [];
 
     if (dims) {
@@ -243,6 +328,7 @@ export function decodeSnapshotAnalysisChunks(
     }
 
     return {
+      analysisKey: meta.analysisKey,
       settings: meta.settings,
       dateCreated: meta.dateCreated,
       status: meta.status,
@@ -250,6 +336,161 @@ export function decodeSnapshotAnalysisChunks(
       results,
     };
   });
+}
+
+// -- Legacy chunk migration --
+//
+// Two-phase to keep phase 1 free of snapshot context, so it can run
+// inside `BaseModel.migrate()` (which only sees the chunk doc) instead
+// of relying on call-site discipline.
+//
+//   phase 1: `migrateLegacySnapshotAnalysisChunkData` — flat legacy
+//     shape -> position-keyed records (`{ "0": {...}, "1": {...} }`).
+//
+//   phase 2: `remapChunkDataPositionKeysToAnalysisKeys` — rename the
+//     numeric position keys to `analysisKey`s using the parent
+//     snapshot's ordering.
+
+export type MigrateLegacySnapshotAnalysisChunkInput = {
+  data?: unknown;
+  numRows?: unknown;
+};
+
+export type MigrateLegacySnapshotAnalysisChunkResult = {
+  data: Record<string, AnalysisChunkData>;
+  // Non-null when a legacy-shape chunk was translated. Null for
+  // already-new-shape docs so callers can log conditionally.
+  migrated: { legacyNumRows: number; analysisCount: number } | null;
+};
+
+/**
+ * Phase 1: normalize a chunk document's `data` field away from the
+ * legacy flat shape. Output is keyed by stringified position (`"0"`,
+ * `"1"`, ...) — phase 2 (`remapChunkDataPositionKeysToAnalysisKeys`)
+ * renames those positions to `analysisKey`s once snapshot context is
+ * available.
+ *
+ * Idempotent: docs without a top-level `numRows` and without flat
+ * columns at the data root pass through unchanged with `migrated: null`,
+ * regardless of whether their existing keys are positions or
+ * `analysisKey`s.
+ */
+export function migrateLegacySnapshotAnalysisChunkData(
+  chunk: MigrateLegacySnapshotAnalysisChunkInput,
+): MigrateLegacySnapshotAnalysisChunkResult {
+  const data = (chunk.data as Record<string, unknown>) ?? {};
+  const topLevelNumRows =
+    typeof chunk.numRows === "number" ? chunk.numRows : undefined;
+  const dataHasFlatColumns = Array.isArray(data.d);
+
+  if (topLevelNumRows === undefined && !dataHasFlatColumns) {
+    return {
+      data: data as Record<string, AnalysisChunkData>,
+      migrated: null,
+    };
+  }
+
+  const numRows = topLevelNumRows ?? 0;
+  const aColumn = Array.isArray(data.a) ? (data.a as number[]) : undefined;
+
+  const columnEntries: Array<[string, unknown[]]> = [];
+  for (const [key, value] of Object.entries(data)) {
+    if (key === "a") continue;
+    if (Array.isArray(value)) columnEntries.push([key, value]);
+  }
+
+  const rowsByPosition = new Map<number, number[]>();
+  for (let i = 0; i < numRows; i++) {
+    const position = aColumn?.[i] ?? 0;
+    if (!rowsByPosition.has(position)) rowsByPosition.set(position, []);
+    rowsByPosition.get(position)!.push(i);
+  }
+
+  const newData: Record<string, AnalysisChunkData> = {};
+  for (const [position, rowIndices] of rowsByPosition) {
+    const perAnalysis: AnalysisChunkData = {
+      numRows: rowIndices.length,
+      d: [],
+      v: [],
+    };
+    for (const [col] of columnEntries) {
+      if (col !== "d" && col !== "v") {
+        (perAnalysis as Record<string, unknown[] | number>)[col] = [];
+      }
+    }
+    const columnTargets: Array<[unknown[], unknown[]]> = columnEntries.map(
+      ([col, values]) => [
+        (perAnalysis as Record<string, unknown[] | number>)[col] as unknown[],
+        values,
+      ],
+    );
+    for (const rowIdx of rowIndices) {
+      for (const [target, values] of columnTargets) {
+        target.push(values[rowIdx] ?? null);
+      }
+    }
+    newData[String(position)] = perAnalysis;
+  }
+
+  // Preserve new-shape sub-records that coexist with legacy flat
+  // columns. This happens when a writer (bulkWrite path) appends a
+  // `data.<analysisKey>` sub-record to a doc that still carries legacy
+  // top-level `numRows` and flat `d`/`v`/value columns. Without this
+  // step those sub-records would be silently dropped on the next read.
+  // Legacy columns are always arrays and never collide here — we only
+  // copy non-null object values. New-shape keys never collide with
+  // position keys (`^\d+$`) because they begin with `an_`.
+  for (const [key, value] of Object.entries(data)) {
+    if (Array.isArray(value)) continue;
+    if (typeof value !== "object" || value === null) continue;
+    newData[key] = value as AnalysisChunkData;
+  }
+
+  return {
+    data: newData,
+    migrated: {
+      legacyNumRows: numRows,
+      analysisCount: rowsByPosition.size,
+    },
+  };
+}
+
+// Phase 1 produces stringified non-negative integer positions, while a
+// real `analysisKey` from `buildAnalysisKey()` always starts with
+// `an_`. The validator additionally requires `analysisKeySchema` keys
+// to be ≥5 chars, so a pure-digit key can never be a legitimate
+// `analysisKey` — making this regex sufficient to distinguish.
+const POSITION_KEY_PATTERN = /^\d+$/;
+
+/**
+ * Phase 2: rename position-keyed sub-records (output of phase 1) to
+ * `analysisKey`-keyed sub-records using the parent snapshot's analyses
+ * ordering. Positions with no matching `analysisKey` are dropped — this
+ * covers legacy snapshots whose analyses array shrank before migration
+ * (orphan rows in the chunks).
+ *
+ * Idempotent on data already keyed by `analysisKey`: keys that don't
+ * match the position pattern pass through untouched, so re-running the
+ * remap on already-renamed data is a no-op.
+ *
+ * Generic over the value type so callers can pass either the strict
+ * `AnalysisChunkData` (post-encode) or the looser validator-inferred
+ * shape (post-read), since this helper only inspects keys.
+ */
+export function remapChunkDataPositionKeysToAnalysisKeys<T>(
+  data: Record<string, T>,
+  analysisKeysByPosition: string[],
+): Record<string, T> {
+  const out: Record<string, T> = {};
+  for (const [key, perAnalysis] of Object.entries(data)) {
+    if (POSITION_KEY_PATTERN.test(key)) {
+      const analysisKey = analysisKeysByPosition[Number(key)];
+      if (analysisKey) out[analysisKey] = perAnalysis;
+    } else {
+      out[key] = perAnalysis;
+    }
+  }
+  return out;
 }
 
 /**
@@ -278,25 +519,4 @@ export function buildMetricOrdering(
   }
 
   return [...nonSlice, ...slice];
-}
-
-/**
- * Helper to extract chunkedAnalysesMeta and analysisMetadata from a snapshot,
- * used by populateChunkedAnalyses in the chunk model.
- */
-export function getChunkedAnalysesMetaFromSnapshot(
-  snapshot: ExperimentSnapshotInterface,
-): {
-  chunkedAnalysesMeta: AnalysisMetaEntry[];
-  analysisMetadata: AnalysisMetadata[];
-} {
-  return {
-    chunkedAnalysesMeta: snapshot.chunkedAnalysesMeta ?? [],
-    analysisMetadata: snapshot.analyses.map((a) => ({
-      settings: a.settings,
-      dateCreated: a.dateCreated,
-      status: a.status,
-      ...(a.error ? { error: a.error } : {}),
-    })),
-  };
 }

--- a/packages/shared/src/validators/snapshot-analysis-chunks.ts
+++ b/packages/shared/src/validators/snapshot-analysis-chunks.ts
@@ -1,33 +1,58 @@
 import { z } from "zod";
 
+const ANALYSIS_KEY_PATTERN = /^[A-Za-z0-9_-]+$/;
+
+export const analysisKeySchema = z
+  .string()
+  .min(5, "analysisKey must be at least 5 characters long")
+  .regex(
+    ANALYSIS_KEY_PATTERN,
+    "analysisKey must contain only alphanumerics, dashes, or underscores",
+  );
+
 type ExperimentSnapshotAnalysisChunkColumnLengthMismatch = {
+  analysisKey: string;
   column: string;
   actualLength: number;
   expectedLength: number;
 };
 
 type ExperimentSnapshotAnalysisChunkNumRowsMismatch = {
+  analysisKey: string;
   actualLength: number;
   expectedLength: number;
 };
 
-function getExperimentSnapshotAnalysisChunkLengthMismatches({
-  data,
-  numRows,
-}: {
-  data: Record<string, unknown[]>;
-  numRows: number;
-}): {
+function getPerAnalysisChunkLengthMismatches(
+  analysisKey: string,
+  perAnalysis: { numRows: number } & Record<string, unknown>,
+): {
   columnMismatches: ExperimentSnapshotAnalysisChunkColumnLengthMismatch[];
   numRowsMismatch?: ExperimentSnapshotAnalysisChunkNumRowsMismatch;
 } {
+  const columnEntries: Array<[string, unknown[]]> = [];
+  for (const [key, value] of Object.entries(perAnalysis)) {
+    if (key === "numRows") continue;
+    if (Array.isArray(value)) {
+      columnEntries.push([key, value]);
+    }
+  }
+
+  // If every column agrees on a single length, that length is authoritative
+  // and `numRows` is validated against it. Otherwise fall back to `numRows`
+  // as the expected length for per-column error messages.
+  const firstLength = columnEntries[0]?.[1]?.length ?? 0;
+  const columnsAgree = columnEntries.every(
+    ([, values]) => values.length === firstLength,
+  );
+  const expectedLength = columnsAgree ? firstLength : perAnalysis.numRows;
+
   const columnMismatches: ExperimentSnapshotAnalysisChunkColumnLengthMismatch[] =
     [];
-  const expectedLength = Object.values(data)[0]?.length ?? 0;
-
-  for (const [column, values] of Object.entries(data)) {
+  for (const [column, values] of columnEntries) {
     if (values.length !== expectedLength) {
       columnMismatches.push({
+        analysisKey,
         column,
         actualLength: values.length,
         expectedLength,
@@ -38,44 +63,69 @@ function getExperimentSnapshotAnalysisChunkLengthMismatches({
   return {
     columnMismatches,
     numRowsMismatch:
-      numRows === expectedLength
+      perAnalysis.numRows === expectedLength
         ? undefined
         : {
-            actualLength: numRows,
+            analysisKey,
+            actualLength: perAnalysis.numRows,
             expectedLength,
           },
   };
 }
 
+/**
+ * Runtime assertion used by the encoder to catch column-length mismatches
+ * before persistence. Throws with a combined message covering every
+ * analysis sub-path in the chunk.
+ */
 export function validateExperimentSnapshotAnalysisChunkColumnLengths({
   data,
-  numRows,
 }: {
-  data: Record<string, unknown[]>;
-  numRows: number;
+  data: Record<string, { numRows: number } & Record<string, unknown>>;
 }) {
-  const { columnMismatches, numRowsMismatch } =
-    getExperimentSnapshotAnalysisChunkLengthMismatches({
-      data,
-      numRows,
-    });
-  if (!columnMismatches.length && !numRowsMismatch) return;
+  const messages: string[] = [];
 
-  const messages = columnMismatches.map(
-    ({ column, actualLength, expectedLength }) =>
-      `${column} has ${actualLength}, expected ${expectedLength}`,
-  );
-  if (numRowsMismatch) {
-    messages.push(
-      `numRows has ${numRowsMismatch.actualLength}, expected ${numRowsMismatch.expectedLength}`,
-    );
+  for (const [analysisKey, perAnalysis] of Object.entries(data)) {
+    const { columnMismatches, numRowsMismatch } =
+      getPerAnalysisChunkLengthMismatches(analysisKey, perAnalysis);
+
+    for (const mismatch of columnMismatches) {
+      messages.push(
+        `data.${analysisKey}.${mismatch.column} has ${mismatch.actualLength}, expected ${mismatch.expectedLength}`,
+      );
+    }
+    if (numRowsMismatch) {
+      messages.push(
+        `data.${analysisKey}.numRows has ${numRowsMismatch.actualLength}, expected ${numRowsMismatch.expectedLength}`,
+      );
+    }
   }
+
+  if (!messages.length) return;
 
   throw new Error(
     "Snapshot analysis chunk columns must have the same length and match numRows: " +
       messages.join("; "),
   );
 }
+
+// One analysis's rows, stored as parallel columnar arrays under
+// `data[<analysisKey>]` inside a chunk document. `d` (dimension name) and
+// `v` (variation index) are required index columns. Any additional keys
+// are value columns sourced from `SnapshotMetric`.
+//
+// `catchall(z.unknown())` instead of `z.array(z.unknown())` so the inferred
+// TypeScript type doesn't intersect `numRows: number` with `unknown[]` (=
+// `never`). The superRefine below filters via `Array.isArray`, and the
+// write-path `validateExperimentSnapshotAnalysisChunkColumnLengths` helper
+// enforces column-array shape before persistence.
+const perAnalysisChunkSchema = z
+  .object({
+    numRows: z.number().int().nonnegative(),
+    d: z.array(z.unknown()),
+    v: z.array(z.unknown()),
+  })
+  .catchall(z.unknown());
 
 export const experimentSnapshotAnalysisChunkValidator = z
   .object({
@@ -86,28 +136,29 @@ export const experimentSnapshotAnalysisChunkValidator = z
     snapshotId: z.string(),
     experimentId: z.string(),
     metricId: z.string(),
-    numRows: z.number(),
-    data: z.record(z.string(), z.array(z.unknown())),
+    data: z.record(analysisKeySchema, perAnalysisChunkSchema),
   })
   .strict()
   .superRefine((chunk, ctx) => {
-    const { columnMismatches, numRowsMismatch } =
-      getExperimentSnapshotAnalysisChunkLengthMismatches(chunk);
+    for (const [analysisKey, perAnalysis] of Object.entries(chunk.data)) {
+      const { columnMismatches, numRowsMismatch } =
+        getPerAnalysisChunkLengthMismatches(analysisKey, perAnalysis);
 
-    for (const mismatch of columnMismatches) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: `Column "${mismatch.column}" has ${mismatch.actualLength} rows, expected ${mismatch.expectedLength}`,
-        path: ["data", mismatch.column],
-      });
-    }
+      for (const mismatch of columnMismatches) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Column "${mismatch.column}" in analysis "${analysisKey}" has ${mismatch.actualLength} rows, expected ${mismatch.expectedLength}`,
+          path: ["data", analysisKey, mismatch.column],
+        });
+      }
 
-    if (numRowsMismatch) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: `numRows has ${numRowsMismatch.actualLength} rows, expected ${numRowsMismatch.expectedLength}`,
-        path: ["numRows"],
-      });
+      if (numRowsMismatch) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `numRows for analysis "${analysisKey}" has ${numRowsMismatch.actualLength} rows, expected ${numRowsMismatch.expectedLength}`,
+          path: ["data", analysisKey, "numRows"],
+        });
+      }
     }
   });
 

--- a/packages/shared/test/snapshot-analysis-chunks.test.ts
+++ b/packages/shared/test/snapshot-analysis-chunks.test.ts
@@ -8,8 +8,12 @@ import {
   encodeSnapshotAnalysisChunks,
   decodeSnapshotAnalysisChunks,
   buildMetricOrdering,
-  getChunkedAnalysesMetaFromSnapshot,
+  buildAnalysisKey,
+  migrateLegacySnapshotAnalysisChunkData,
+  remapChunkDataPositionKeysToAnalysisKeys,
   AnalysisMetaEntry,
+  MetricChunkData,
+  AnalysisChunkData,
 } from "../src/snapshot-analysis-chunks";
 import {
   experimentSnapshotAnalysisChunkValidator,
@@ -44,8 +48,10 @@ function makeAnalysisSettings(
 function makeAnalysis(
   results: ExperimentSnapshotAnalysis["results"],
   settingsOverrides: Partial<ExperimentSnapshotAnalysisSettings> = {},
+  analysisKey: string = buildAnalysisKey(),
 ): ExperimentSnapshotAnalysis {
   return {
+    analysisKey,
     settings: makeAnalysisSettings(settingsOverrides),
     dateCreated: new Date("2025-01-01"),
     status: "success",
@@ -61,10 +67,12 @@ function decodeHelper(
     analyses,
     [],
   );
-  const chunks = Array.from(metricChunks.entries()).map(
-    ([metricId, chunk]) => ({ metricId, ...chunk }),
-  );
+  const chunks = Array.from(metricChunks.entries()).map(([metricId, data]) => ({
+    metricId,
+    data,
+  }));
   const analysisMetadata = analyses.map((a) => ({
+    analysisKey: a.analysisKey,
     settings: a.settings,
     dateCreated: a.dateCreated,
     status: a.status as "success" | "running" | "error",
@@ -78,7 +86,9 @@ function decodeHelper(
   );
 }
 
-function makeExperimentSnapshotAnalysisChunk(data: Record<string, unknown[]>) {
+function makeExperimentSnapshotAnalysisChunk(
+  data: Record<string, AnalysisChunkData>,
+) {
   return {
     organization: "org_1",
     dateCreated: new Date("2025-01-01"),
@@ -87,32 +97,56 @@ function makeExperimentSnapshotAnalysisChunk(data: Record<string, unknown[]>) {
     snapshotId: "snp_1",
     experimentId: "exp_1",
     metricId: "met_1",
-    numRows: 2,
     data,
   };
 }
 
 describe("experimentSnapshotAnalysisChunkValidator", () => {
-  it("accepts column data when all arrays match numRows", () => {
+  it("accepts per-analysis data when all column arrays match numRows", () => {
     const result = experimentSnapshotAnalysisChunkValidator.safeParse(
       makeExperimentSnapshotAnalysisChunk({
-        a: [0, 0],
-        d: ["All", "All"],
-        v: [0, 1],
-        value: [0.1, 0.2],
+        analysisOne: {
+          numRows: 2,
+          d: ["All", "All"],
+          v: [0, 1],
+          value: [0.1, 0.2],
+        },
       }),
     );
 
     expect(result.success).toBe(true);
   });
 
-  it("rejects column data when any array length differs from the other columns", () => {
+  it("accepts multiple analysis sub-paths in a single chunk", () => {
     const result = experimentSnapshotAnalysisChunkValidator.safeParse(
       makeExperimentSnapshotAnalysisChunk({
-        a: [0, 0],
-        d: ["All"],
-        v: [0, 1],
-        value: [0.1, 0.2, 0.3],
+        analysisOne: {
+          numRows: 2,
+          d: ["All", "All"],
+          v: [0, 1],
+          value: [0.1, 0.2],
+        },
+        analysisTwo: {
+          numRows: 1,
+          d: ["All"],
+          v: [0],
+          value: [0.3],
+        },
+      }),
+    );
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects per-analysis column arrays with mismatched lengths", () => {
+    const result = experimentSnapshotAnalysisChunkValidator.safeParse(
+      makeExperimentSnapshotAnalysisChunk({
+        analysisOne: {
+          numRows: 2,
+          d: ["All"],
+          v: [0, 1],
+          value: [0.1, 0.2, 0.3],
+        },
       }),
     );
 
@@ -121,49 +155,63 @@ describe("experimentSnapshotAnalysisChunkValidator", () => {
       expect(result.error.issues).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            message: 'Column "d" has 1 rows, expected 2',
-            path: ["data", "d"],
+            message:
+              'Column "d" in analysis "analysisOne" has 1 rows, expected 2',
+            path: ["data", "analysisOne", "d"],
           }),
           expect.objectContaining({
-            message: 'Column "value" has 3 rows, expected 2',
-            path: ["data", "value"],
+            message:
+              'Column "value" in analysis "analysisOne" has 3 rows, expected 2',
+            path: ["data", "analysisOne", "value"],
           }),
         ]),
       );
     }
   });
 
-  it("rejects column data when numRows does not match the common array length", () => {
-    const result = experimentSnapshotAnalysisChunkValidator.safeParse({
-      ...makeExperimentSnapshotAnalysisChunk({
-        a: [0, 0],
-        d: ["All", "All"],
-        v: [0, 1],
+  it("rejects per-analysis numRows that disagrees with the column length", () => {
+    const result = experimentSnapshotAnalysisChunkValidator.safeParse(
+      makeExperimentSnapshotAnalysisChunk({
+        analysisOne: {
+          numRows: 3,
+          d: ["All", "All"],
+          v: [0, 1],
+        },
       }),
-      numRows: 3,
-    });
+    );
 
     expect(result.success).toBe(false);
     if (!result.success) {
       expect(result.error.issues).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            message: "numRows has 3 rows, expected 2",
-            path: ["numRows"],
+            message:
+              'numRows for analysis "analysisOne" has 3 rows, expected 2',
+            path: ["data", "analysisOne", "numRows"],
           }),
         ]),
       );
     }
   });
 
+  it("rejects analysisKey sub-paths that contain MongoDB-reserved characters", () => {
+    const result = experimentSnapshotAnalysisChunkValidator.safeParse(
+      makeExperimentSnapshotAnalysisChunk({
+        "bad.key": { numRows: 0, d: [], v: [] },
+      }),
+    );
+    expect(result.success).toBe(false);
+  });
+
   it("throws from the model-layer helper when column lengths are invalid", () => {
     expect(() =>
       validateExperimentSnapshotAnalysisChunkColumnLengths({
-        numRows: 2,
         data: {
-          a: [0, 0],
-          d: ["All"],
-          v: [0, 1],
+          analysisOne: {
+            numRows: 2,
+            d: ["All"],
+            v: [0, 1],
+          },
         },
       }),
     ).toThrow(
@@ -204,31 +252,51 @@ describe("buildMetricOrdering", () => {
   });
 });
 
+describe("analysisKey helpers", () => {
+  it("buildAnalysisKey produces unique strings", () => {
+    const keys = new Set<string>();
+    for (let i = 0; i < 100; i++) keys.add(buildAnalysisKey());
+    expect(keys.size).toBe(100);
+  });
+
+  it("buildAnalysisKey produces MongoDB-sub-path-safe keys", () => {
+    const key = buildAnalysisKey();
+    expect(key).not.toContain(".");
+    expect(key).not.toContain("$");
+    expect(key.length).toBeGreaterThan(0);
+  });
+});
+
 describe("encodeSnapshotAnalysisChunks", () => {
   it("produces one chunk per metric", () => {
+    const keyA = buildAnalysisKey();
     const analyses = [
-      makeAnalysis([
-        {
-          name: "All",
-          srm: 0.5,
-          variations: [
-            {
-              users: 500,
-              metrics: {
-                met_a: makeMetric({ value: 1 }),
-                met_b: makeMetric({ value: 2 }),
+      makeAnalysis(
+        [
+          {
+            name: "All",
+            srm: 0.5,
+            variations: [
+              {
+                users: 500,
+                metrics: {
+                  met_a: makeMetric({ value: 1 }),
+                  met_b: makeMetric({ value: 2 }),
+                },
               },
-            },
-            {
-              users: 500,
-              metrics: {
-                met_a: makeMetric({ value: 3 }),
-                met_b: makeMetric({ value: 4 }),
+              {
+                users: 500,
+                metrics: {
+                  met_a: makeMetric({ value: 3 }),
+                  met_b: makeMetric({ value: 4 }),
+                },
               },
-            },
-          ],
-        },
-      ]),
+            ],
+          },
+        ],
+        {},
+        keyA,
+      ),
     ];
 
     const { metricChunks } = encodeSnapshotAnalysisChunks(analyses, [
@@ -240,52 +308,112 @@ describe("encodeSnapshotAnalysisChunks", () => {
     expect(metricChunks.has("met_a")).toBe(true);
     expect(metricChunks.has("met_b")).toBe(true);
 
-    // Each metric has 2 rows (2 variations)
-    expect(metricChunks.get("met_a")!.numRows).toBe(2);
-    expect(metricChunks.get("met_b")!.numRows).toBe(2);
-
-    // No "m" column in data (metricId is document-level)
-    expect(metricChunks.get("met_a")!.data.m).toBeUndefined();
+    // Each metric has the analysis sub-path with 2 rows (2 variations)
+    const perMetA = metricChunks.get("met_a")!;
+    expect(Object.keys(perMetA)).toEqual([keyA]);
+    expect(perMetA[keyA].numRows).toBe(2);
+    expect(perMetA[keyA].d).toEqual(["All", "All"]);
+    expect(perMetA[keyA].v).toEqual([0, 1]);
+    // No positional "a" column — that was removed with the race fix.
+    expect((perMetA[keyA] as Record<string, unknown>).a).toBeUndefined();
   });
 
-  it("extracts chunkedAnalysesMeta correctly", () => {
+  it("keys chunkedAnalysesMeta by analysisKey", () => {
+    const keyA = buildAnalysisKey();
     const analyses = [
-      makeAnalysis([
-        {
-          name: "All",
-          srm: 0.5,
-          variations: [
-            { users: 500, metrics: { met_1: makeMetric() } },
-            { users: 600, metrics: { met_1: makeMetric() } },
-          ],
-        },
-        {
-          name: "country:US",
-          srm: 0.48,
-          variations: [
-            { users: 200, metrics: { met_1: makeMetric() } },
-            { users: 300, metrics: { met_1: makeMetric() } },
-          ],
-        },
-      ]),
+      makeAnalysis(
+        [
+          {
+            name: "All",
+            srm: 0.5,
+            variations: [
+              { users: 500, metrics: { met_1: makeMetric() } },
+              { users: 600, metrics: { met_1: makeMetric() } },
+            ],
+          },
+          {
+            name: "country:US",
+            srm: 0.48,
+            variations: [
+              { users: 200, metrics: { met_1: makeMetric() } },
+              { users: 300, metrics: { met_1: makeMetric() } },
+            ],
+          },
+        ],
+        {},
+        keyA,
+      ),
     ];
 
     const { chunkedAnalysesMeta } = encodeSnapshotAnalysisChunks(analyses, [
       "met_1",
     ]);
 
-    expect(chunkedAnalysesMeta).toHaveLength(1);
-    expect(chunkedAnalysesMeta[0].dimensions).toHaveLength(2);
-    expect(chunkedAnalysesMeta[0].dimensions[0]).toEqual({
+    expect(Object.keys(chunkedAnalysesMeta)).toEqual([keyA]);
+    expect(chunkedAnalysesMeta[keyA].dimensions).toHaveLength(2);
+    expect(chunkedAnalysesMeta[keyA].dimensions[0]).toEqual({
       name: "All",
       srm: 0.5,
       variationUsers: [500, 600],
     });
-    expect(chunkedAnalysesMeta[0].dimensions[1]).toEqual({
+    expect(chunkedAnalysesMeta[keyA].dimensions[1]).toEqual({
       name: "country:US",
       srm: 0.48,
       variationUsers: [200, 300],
     });
+  });
+
+  it("stores analyses under disjoint sub-paths in the same chunk", () => {
+    const keyA = buildAnalysisKey();
+    const keyB = buildAnalysisKey();
+    const analyses = [
+      makeAnalysis(
+        [
+          {
+            name: "All",
+            srm: 0.5,
+            variations: [
+              { users: 100, metrics: { met_1: makeMetric({ value: 1 }) } },
+            ],
+          },
+        ],
+        {},
+        keyA,
+      ),
+      makeAnalysis(
+        [
+          {
+            name: "All",
+            srm: 0.51,
+            variations: [
+              { users: 200, metrics: { met_1: makeMetric({ value: 2 }) } },
+            ],
+          },
+        ],
+        { statsEngine: "frequentist" },
+        keyB,
+      ),
+    ];
+
+    const { metricChunks } = encodeSnapshotAnalysisChunks(analyses, ["met_1"]);
+    const perMet1 = metricChunks.get("met_1")!;
+
+    expect(Object.keys(perMet1).sort()).toEqual([keyA, keyB].sort());
+    expect(perMet1[keyA].numRows).toBe(1);
+    expect(perMet1[keyB].numRows).toBe(1);
+    expect(perMet1[keyA].value).toEqual([1]);
+    expect(perMet1[keyB].value).toEqual([2]);
+  });
+
+  it("throws when two analyses share an analysisKey", () => {
+    const shared = buildAnalysisKey();
+    const analyses = [
+      makeAnalysis([], {}, shared),
+      makeAnalysis([], { statsEngine: "frequentist" }, shared),
+    ];
+    expect(() => encodeSnapshotAnalysisChunks(analyses, [])).toThrow(
+      /duplicate analysisKey/,
+    );
   });
 
   it("handles empty results", () => {
@@ -295,8 +423,10 @@ describe("encodeSnapshotAnalysisChunks", () => {
       [],
     );
     expect(metricChunks.size).toBe(0);
-    expect(chunkedAnalysesMeta).toHaveLength(1);
-    expect(chunkedAnalysesMeta[0].dimensions).toHaveLength(0);
+    expect(Object.keys(chunkedAnalysesMeta)).toHaveLength(1);
+    expect(
+      chunkedAnalysesMeta[analyses[0].analysisKey].dimensions,
+    ).toHaveLength(0);
   });
 });
 
@@ -327,6 +457,7 @@ describe("decodeSnapshotAnalysisChunks", () => {
 
     const decoded = decodeHelper(analyses);
     expect(decoded).toHaveLength(1);
+    expect(decoded[0].analysisKey).toBe(analyses[0].analysisKey);
     expect(decoded[0].results).toHaveLength(1);
     expect(decoded[0].results[0].name).toBe("All");
     expect(decoded[0].results[0].srm).toBe(0.5);
@@ -557,15 +688,17 @@ describe("decodeSnapshotAnalysisChunks", () => {
   });
 
   it("treats top-level CI nulls as absent and preserves unbounded CIs", () => {
+    const analysisKey = buildAnalysisKey();
     const analysisMetadata = [
       {
+        analysisKey,
         settings: makeAnalysisSettings(),
         dateCreated: new Date("2025-01-01"),
         status: "success" as const,
       },
     ];
-    const chunkedAnalysesMeta: AnalysisMetaEntry[] = [
-      {
+    const chunkedAnalysesMeta: Record<string, AnalysisMetaEntry> = {
+      [analysisKey]: {
         dimensions: [
           {
             name: "All",
@@ -574,33 +707,34 @@ describe("decodeSnapshotAnalysisChunks", () => {
           },
         ],
       },
-    ];
+    };
     const decoded = decodeSnapshotAnalysisChunks(
       [
         {
           metricId: "met_1",
-          numRows: 5,
           data: {
-            a: [0, 0, 0, 0, 0],
-            d: ["All", "All", "All", "All", "All"],
-            v: [0, 1, 2, 3, 4],
-            value: [1, 2, 3, 4, 5],
-            cr: [0.1, 0.2, 0.3, 0.4, 0.5],
-            users: [100, 100, 100, 100, 100],
-            ci: [
-              null,
-              undefined,
-              [-Infinity, 0.2],
-              [0.1, Infinity],
-              [-Infinity, Infinity],
-            ],
-            ciAdjusted: [
-              null,
-              undefined,
-              [-Infinity, 0.3],
-              [0.2, Infinity],
-              [-Infinity, Infinity],
-            ],
+            [analysisKey]: {
+              numRows: 5,
+              d: ["All", "All", "All", "All", "All"],
+              v: [0, 1, 2, 3, 4],
+              value: [1, 2, 3, 4, 5],
+              cr: [0.1, 0.2, 0.3, 0.4, 0.5],
+              users: [100, 100, 100, 100, 100],
+              ci: [
+                null,
+                undefined,
+                [-Infinity, 0.2],
+                [0.1, Infinity],
+                [-Infinity, Infinity],
+              ],
+              ciAdjusted: [
+                null,
+                undefined,
+                [-Infinity, 0.3],
+                [0.2, Infinity],
+                [-Infinity, Infinity],
+              ],
+            },
           },
         },
       ],
@@ -659,15 +793,19 @@ describe("decodeSnapshotAnalysisChunks", () => {
   });
 
   it("preserves analysis error field", () => {
+    const analysisKey = buildAnalysisKey();
     const analysisMetadata = [
       {
+        analysisKey,
         settings: makeAnalysisSettings(),
         dateCreated: new Date("2025-01-01"),
         status: "error" as const,
         error: "Something went wrong",
       },
     ];
-    const chunkedAnalysesMeta: AnalysisMetaEntry[] = [{ dimensions: [] }];
+    const chunkedAnalysesMeta: Record<string, AnalysisMetaEntry> = {
+      [analysisKey]: { dimensions: [] },
+    };
 
     const decoded = decodeSnapshotAnalysisChunks(
       [],
@@ -676,6 +814,55 @@ describe("decodeSnapshotAnalysisChunks", () => {
     );
     expect(decoded[0].status).toBe("error");
     expect(decoded[0].error).toBe("Something went wrong");
+  });
+
+  it("skips chunk sub-paths whose analysisKey is missing from meta", () => {
+    // Simulates the race-safety property: a chunk wrote a sub-path but the
+    // parent snapshot was rolled back / is stale. Decoder must not mis-route
+    // those rows; it must drop them silently.
+    const keyAlive = buildAnalysisKey();
+    const keyOrphan = buildAnalysisKey();
+
+    const chunks: { metricId: string; data: MetricChunkData }[] = [
+      {
+        metricId: "met_1",
+        data: {
+          [keyAlive]: {
+            numRows: 1,
+            d: ["All"],
+            v: [0],
+            value: [1],
+          },
+          [keyOrphan]: {
+            numRows: 1,
+            d: ["All"],
+            v: [0],
+            value: [999],
+          },
+        },
+      },
+    ];
+
+    const decoded = decodeSnapshotAnalysisChunks(
+      chunks,
+      {
+        [keyAlive]: {
+          dimensions: [{ name: "All", srm: 1, variationUsers: [100] }],
+        },
+      },
+      [
+        {
+          analysisKey: keyAlive,
+          settings: makeAnalysisSettings(),
+          dateCreated: new Date("2025-01-01"),
+          status: "success",
+        },
+      ],
+    );
+
+    expect(decoded).toHaveLength(1);
+    expect(decoded[0].analysisKey).toBe(keyAlive);
+    expect(decoded[0].results[0].variations[0].metrics.met_1.value).toBe(1);
   });
 
   it("chunked path produces the same result as the original inline path", () => {
@@ -861,7 +1048,6 @@ describe("decodeSnapshotAnalysisChunks", () => {
     const originalPathResult = analyses;
 
     // --- Chunked path: simulate what the production code does ---
-    // 1. Build a snapshot object as it would exist in the DB
     const snapshot = {
       id: "snp_test123",
       organization: "org_test",
@@ -903,12 +1089,10 @@ describe("decodeSnapshotAnalysisChunks", () => {
       queries: [],
       unknownVariations: [],
       multipleExposures: 0,
-      // Analyses stored with results for getChunkedAnalysesMetaFromSnapshot
       analyses,
       hasChunkedAnalyses: true,
     } satisfies ExperimentSnapshotInterface;
 
-    // 2. Encode: what createFromAnalyses does
     const metricOrdering = buildMetricOrdering(
       snapshot.settings.goalMetrics,
       snapshot.settings.secondaryMetrics,
@@ -919,27 +1103,28 @@ describe("decodeSnapshotAnalysisChunks", () => {
       metricOrdering,
     );
 
-    // 3. Simulate the snapshot as stored in DB (analyses have empty results,
-    //    chunkedAnalysesMeta is saved alongside)
     const storedSnapshot: ExperimentSnapshotInterface = {
       ...snapshot,
       analyses: analyses.map((a) => ({ ...a, results: [] })),
       chunkedAnalysesMeta,
     };
 
-    // 4. Decode: what populateChunkedAnalyses does via getChunkedAnalysesMetaFromSnapshot
-    const { chunkedAnalysesMeta: decodeMeta, analysisMetadata } =
-      getChunkedAnalysesMetaFromSnapshot(storedSnapshot);
+    const analysisMetadata = storedSnapshot.analyses.map((a) => ({
+      analysisKey: a.analysisKey,
+      settings: a.settings,
+      dateCreated: a.dateCreated,
+      status: a.status,
+      ...(a.error ? { error: a.error } : {}),
+    }));
     const chunks = Array.from(metricChunks.entries()).map(
-      ([metricId, chunk]) => ({ metricId, ...chunk }),
+      ([metricId, data]) => ({ metricId, data }),
     );
     const chunkedPathResult = decodeSnapshotAnalysisChunks(
       chunks,
-      decodeMeta,
+      storedSnapshot.chunkedAnalysesMeta ?? {},
       analysisMetadata,
     );
 
-    // --- The two paths must produce identical analyses ---
     expect(chunkedPathResult).toEqual(originalPathResult);
   });
 
@@ -973,5 +1158,313 @@ describe("decodeSnapshotAnalysisChunks", () => {
     expect(decoded[0].results[0].variations[0].metrics.met_unknown.value).toBe(
       2,
     );
+  });
+});
+
+describe("migrateLegacySnapshotAnalysisChunkData", () => {
+  it("returns already-normalized docs unchanged with migrated=null (idempotence)", () => {
+    const key = "an_preset";
+    const newShape = {
+      data: {
+        [key]: {
+          numRows: 2,
+          d: ["All", "All"],
+          v: [0, 1],
+          value: [10, 15],
+        },
+      },
+    };
+
+    const result = migrateLegacySnapshotAnalysisChunkData(newShape);
+
+    expect(result.migrated).toBeNull();
+    expect(result.data).toBe(newShape.data);
+    expect(result.data[key].numRows).toBe(2);
+  });
+
+  it("returns position-keyed docs unchanged with migrated=null (phase-2 input)", () => {
+    // Phase 1 output is also valid input for phase 1 — so re-running it
+    // (e.g. if `BaseModel.migrate` is invoked twice) is a no-op.
+    const positionKeyed = {
+      data: {
+        "0": { numRows: 1, d: ["All"], v: [0], value: [1] },
+        "1": { numRows: 1, d: ["All"], v: [0], value: [2] },
+      },
+    };
+
+    const result = migrateLegacySnapshotAnalysisChunkData(positionKeyed);
+
+    expect(result.migrated).toBeNull();
+    expect(result.data).toBe(positionKeyed.data);
+  });
+
+  it("splits a legacy chunk into position-keyed records, one per legacy `a` value", () => {
+    const legacyChunk = {
+      numRows: 5,
+      data: {
+        a: [0, 0, 1, 1, 1],
+        d: ["", "", "US", "US", "UK"],
+        v: [0, 1, 0, 1, 1],
+        value: [10, 15, 20, 25, 30],
+        cr: [0.1, 0.15, 0.2, 0.25, 0.3],
+        users: [100, 120, 50, 55, 60],
+      },
+    };
+
+    const result = migrateLegacySnapshotAnalysisChunkData(legacyChunk);
+
+    expect(result.migrated).toEqual({ legacyNumRows: 5, analysisCount: 2 });
+    expect(Object.keys(result.data).sort()).toEqual(["0", "1"]);
+
+    const aData = result.data["0"];
+    expect(aData.numRows).toBe(2);
+    expect(aData.d).toEqual(["", ""]);
+    expect(aData.v).toEqual([0, 1]);
+    expect(aData.value).toEqual([10, 15]);
+    expect(aData.cr).toEqual([0.1, 0.15]);
+    expect(aData.users).toEqual([100, 120]);
+
+    const bData = result.data["1"];
+    expect(bData.numRows).toBe(3);
+    expect(bData.d).toEqual(["US", "US", "UK"]);
+    expect(bData.v).toEqual([0, 1, 1]);
+    expect(bData.value).toEqual([20, 25, 30]);
+    expect(bData.cr).toEqual([0.2, 0.25, 0.3]);
+    expect(bData.users).toEqual([50, 55, 60]);
+  });
+
+  it("treats missing `a` column as all-position-0 and keeps value columns intact", () => {
+    const legacyChunk = {
+      numRows: 2,
+      data: {
+        d: ["All", "All"],
+        v: [0, 1],
+        value: [7, 9],
+      },
+    };
+
+    const result = migrateLegacySnapshotAnalysisChunkData(legacyChunk);
+
+    expect(result.migrated).toEqual({ legacyNumRows: 2, analysisCount: 1 });
+    expect(Object.keys(result.data)).toEqual(["0"]);
+    expect(result.data["0"].numRows).toBe(2);
+    expect(result.data["0"].d).toEqual(["All", "All"]);
+    expect(result.data["0"].v).toEqual([0, 1]);
+    expect(result.data["0"].value).toEqual([7, 9]);
+  });
+
+  it("handles empty legacy chunks (numRows=0) without producing sub-records", () => {
+    const legacyChunk = { numRows: 0, data: {} };
+
+    const result = migrateLegacySnapshotAnalysisChunkData(legacyChunk);
+
+    expect(result.migrated).toEqual({ legacyNumRows: 0, analysisCount: 0 });
+    expect(result.data).toEqual({});
+  });
+
+  it("round-trips through remap + decode with asymmetric numRows", () => {
+    const keyA = "an_a";
+    const keyB = "an_b";
+    const legacyChunk = {
+      numRows: 5,
+      data: {
+        a: [0, 0, 1, 1, 1],
+        d: ["", "", "US", "US", "UK"],
+        v: [0, 1, 0, 1, 1],
+        value: [10, 15, 20, 25, 30],
+        cr: [0.1, 0.15, 0.2, 0.25, 0.3],
+        users: [100, 120, 50, 55, 60],
+      },
+    };
+
+    const { data: positionKeyed } =
+      migrateLegacySnapshotAnalysisChunkData(legacyChunk);
+    const data = remapChunkDataPositionKeysToAnalysisKeys(positionKeyed, [
+      keyA,
+      keyB,
+    ]);
+
+    const chunkedAnalysesMeta: Record<string, AnalysisMetaEntry> = {
+      [keyA]: {
+        dimensions: [{ name: "", srm: 0.95, variationUsers: [100, 120] }],
+      },
+      [keyB]: {
+        dimensions: [
+          { name: "US", srm: 0.9, variationUsers: [50, 55] },
+          { name: "UK", srm: 0.88, variationUsers: [45, 60] },
+        ],
+      },
+    };
+    const analysisMetadata = [
+      {
+        analysisKey: keyA,
+        settings: makeAnalysisSettings({ statsEngine: "bayesian" }),
+        dateCreated: new Date("2025-01-01"),
+        status: "success" as const,
+      },
+      {
+        analysisKey: keyB,
+        settings: makeAnalysisSettings({ statsEngine: "frequentist" }),
+        dateCreated: new Date("2025-01-02"),
+        status: "success" as const,
+      },
+    ];
+
+    const decoded = decodeSnapshotAnalysisChunks(
+      [{ metricId: "met_1", data }],
+      chunkedAnalysesMeta,
+      analysisMetadata,
+    );
+
+    expect(decoded).toHaveLength(2);
+
+    // Analysis A: single dim, two variations, both populated.
+    const aAll = decoded[0].results[0];
+    expect(aAll.name).toBe("");
+    expect(aAll.variations[0].metrics.met_1.value).toBe(10);
+    expect(aAll.variations[0].metrics.met_1.users).toBe(100);
+    expect(aAll.variations[1].metrics.met_1.value).toBe(15);
+
+    // Analysis B: US has both variations; UK v0 had no legacy row -> no
+    // metric entry (users hydrated from meta), UK v1 = 30.
+    expect(decoded[1].results).toHaveLength(2);
+    const bUs = decoded[1].results.find((r) => r.name === "US")!;
+    const bUk = decoded[1].results.find((r) => r.name === "UK")!;
+    expect(bUs.variations[0].metrics.met_1.value).toBe(20);
+    expect(bUs.variations[1].metrics.met_1.value).toBe(25);
+    expect(bUk.variations[0].users).toBe(45);
+    expect(bUk.variations[0].metrics.met_1).toBeUndefined();
+    expect(bUk.variations[1].metrics.met_1.value).toBe(30);
+  });
+
+  it("is deterministic across repeated calls (same input -> same output)", () => {
+    const legacyChunk = {
+      numRows: 5,
+      data: {
+        a: [0, 0, 1, 1, 1],
+        d: ["", "", "US", "US", "UK"],
+        v: [0, 1, 0, 1, 1],
+        value: [10, 15, 20, 25, 30],
+      },
+    };
+
+    const first = migrateLegacySnapshotAnalysisChunkData(legacyChunk);
+    const second = migrateLegacySnapshotAnalysisChunkData(legacyChunk);
+
+    expect(second.data).toEqual(first.data);
+    expect(second.migrated).toEqual(first.migrated);
+  });
+
+  it("preserves new-shape sub-records coexisting with legacy flat columns", () => {
+    // A legacy chunk that had a new-shape sub-record appended via
+    // bulkWrite (writer path) before the migration ran. The migration
+    // must rebuild the position-keyed legacy data AND keep the
+    // pre-existing new-shape sub-record intact.
+    const mixedShape = {
+      numRows: 2,
+      data: {
+        a: [0, 0],
+        d: ["All", "All"],
+        v: [0, 1],
+        value: [10, 15],
+        an_newwrite: {
+          numRows: 1,
+          d: ["All"],
+          v: [0],
+          value: [42],
+        },
+      },
+    };
+
+    const result = migrateLegacySnapshotAnalysisChunkData(mixedShape);
+
+    expect(result.migrated).toEqual({ legacyNumRows: 2, analysisCount: 1 });
+    expect(Object.keys(result.data).sort()).toEqual(["0", "an_newwrite"]);
+
+    // Position-keyed legacy data rebuilt correctly.
+    expect(result.data["0"].numRows).toBe(2);
+    expect(result.data["0"].value).toEqual([10, 15]);
+
+    // New-shape sub-record preserved verbatim.
+    expect(result.data["an_newwrite"].numRows).toBe(1);
+    expect(result.data["an_newwrite"].value).toEqual([42]);
+  });
+
+  it("preserves multiple new-shape sub-records sequentially appended to a legacy chunk", () => {
+    // Simulates two sequential writes to a still-legacy chunk doc: the
+    // on-disk state accumulates two new-shape sub-records alongside
+    // the untouched legacy columns. Migration must preserve both.
+    const mixedShape = {
+      numRows: 1,
+      data: {
+        a: [0],
+        d: ["All"],
+        v: [0],
+        value: [1],
+        an_first: { numRows: 1, d: ["All"], v: [0], value: [2] },
+        an_second: { numRows: 1, d: ["All"], v: [0], value: [3] },
+      },
+    };
+
+    const result = migrateLegacySnapshotAnalysisChunkData(mixedShape);
+
+    expect(Object.keys(result.data).sort()).toEqual([
+      "0",
+      "an_first",
+      "an_second",
+    ]);
+    expect(result.data["an_first"].value).toEqual([2]);
+    expect(result.data["an_second"].value).toEqual([3]);
+  });
+});
+
+describe("remapChunkDataPositionKeysToAnalysisKeys", () => {
+  it("renames numeric position keys to the matching analysisKeys", () => {
+    const positionKeyed: Record<string, AnalysisChunkData> = {
+      "0": { numRows: 1, d: ["All"], v: [0], value: [10] },
+      "1": { numRows: 1, d: ["All"], v: [0], value: [20] },
+    };
+
+    const remapped = remapChunkDataPositionKeysToAnalysisKeys(positionKeyed, [
+      "an_first",
+      "an_second",
+    ]);
+
+    expect(Object.keys(remapped).sort()).toEqual(["an_first", "an_second"]);
+    expect(remapped["an_first"].value).toEqual([10]);
+    expect(remapped["an_second"].value).toEqual([20]);
+  });
+
+  it("drops position keys that have no matching analysisKey (orphans)", () => {
+    // Position 1's analysis was removed from the parent snapshot before
+    // migration — its rows have no home.
+    const positionKeyed: Record<string, AnalysisChunkData> = {
+      "0": { numRows: 1, d: ["All"], v: [0], value: [10] },
+      "1": { numRows: 1, d: ["All"], v: [0], value: [99] },
+    };
+
+    const remapped = remapChunkDataPositionKeysToAnalysisKeys(positionKeyed, [
+      "an_only",
+    ]);
+
+    expect(Object.keys(remapped)).toEqual(["an_only"]);
+    expect(remapped["an_only"].value).toEqual([10]);
+  });
+
+  it("passes already-renamed analysisKey-keyed data through unchanged (idempotence)", () => {
+    const analysisKeyed: Record<string, AnalysisChunkData> = {
+      an_first: { numRows: 1, d: ["All"], v: [0], value: [10] },
+      an_second: { numRows: 1, d: ["All"], v: [0], value: [20] },
+    };
+
+    // Even with a non-empty analysisKeysByPosition, the renamer must
+    // recognize that these are not numeric positions and leave them be.
+    const remapped = remapChunkDataPositionKeysToAnalysisKeys(analysisKeyed, [
+      "an_other",
+    ]);
+
+    expect(Object.keys(remapped).sort()).toEqual(["an_first", "an_second"]);
+    expect(remapped["an_first"]).toBe(analysisKeyed["an_first"]);
+    expect(remapped["an_second"]).toBe(analysisKeyed["an_second"]);
   });
 });

--- a/packages/shared/types/experiment-snapshot.d.ts
+++ b/packages/shared/types/experiment-snapshot.d.ts
@@ -1,7 +1,10 @@
 import { MidExperimentPowerCalculationResult } from "shared/enterprise";
 import { BanditResult } from "shared/validators";
 import { CovariateImbalanceResult } from "shared/health";
-import { AnalysisMetaEntry } from "shared/snapshot-analysis-chunks";
+import {
+  AnalysisKeyType,
+  AnalysisMetaEntry,
+} from "shared/snapshot-analysis-chunks";
 import { PhaseSQLVar } from "shared/types/sql";
 import {
   MetricSettingsForStatsEngine,
@@ -153,6 +156,8 @@ export type SnapshotTriggeredBy =
   | "update-dashboards";
 
 export interface ExperimentSnapshotAnalysis {
+  // Stable per snapshot-analysis key used to identify the chunked row data
+  analysisKey: string;
   // Determines which analysis this is
   settings: ExperimentSnapshotAnalysisSettings;
   dateCreated: Date;
@@ -237,7 +242,8 @@ export interface ExperimentSnapshotInterface {
   multipleExposures: number;
   analyses: ExperimentSnapshotAnalysis[];
   hasChunkedAnalyses?: boolean;
-  chunkedAnalysesMeta?: AnalysisMetaEntry[];
+  // Keyed by `ExperimentSnapshotAnalysis.analysisKey`
+  chunkedAnalysesMeta?: Record<AnalysisKeyType, AnalysisMetaEntry>;
   banditResult?: BanditResult;
 
   health?: ExperimentSnapshotHealth;


### PR DESCRIPTION
### Features and Changes

On #5651 we started splitting results into multiple documents, per-metric. Meaning a doc can contain multiple analysis for each given metric/snapshot pair.

This created a race condition because our updates are positionally based, so 2 parallel analysis can create conflicting/misleading data, meaning we cannot rely just on the index anymore.

So we now have a stable `analysisKey` inside the `snapshot.analysis` array, and the underlying `chunkedMeta` and `SnapshotChunkedResultModel` store the data using `Record<AnalysisKey, chunkData>`.

This fixes the problem because in the past we would say `update data on position 2 to be X` and that could conflict, but now we say `update data where analysisKey is Y to be X`.


### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

- Added unit tests
- Loading snapshots with no chunked results work
- Loading snapshots with chunked results in the old format also works
- Loading snapshots with the new format works
- Creating new snapshots still works (by clicking Update in the Results tab of a Experiment)