### PR TITLE
Adds copy link to explorations

### DIFF
--- a/packages/front-end/enterprise/components/ProductAnalytics/SideBar/ExplorerSideBar.tsx
+++ b/packages/front-end/enterprise/components/ProductAnalytics/SideBar/ExplorerSideBar.tsx
@@ -5,7 +5,8 @@ import {
   FactTableValue,
   ExplorationConfig,
 } from "shared/validators";
-import { PiArrowsClockwise } from "react-icons/pi";
+import { PiArrowsClockwise, PiLink } from "react-icons/pi";
+import ShareUrlPopover from "@/ui/ShareUrlPopover";
 import PaidFeatureBadge from "@/components/GetStarted/PaidFeatureBadge";
 import Text from "@/ui/Text";
 import SelectField from "@/components/Forms/SelectField";
@@ -103,33 +104,48 @@ export default function ExplorerSideBar({
       {error && renderingInDashboardSidebar ? (
         <Callout status="error">{error}</Callout>
       ) : null}
-      <Flex justify="end" height="32px" py="2">
+      <Flex justify="end" align="center" height="32px" py="2" gap="2">
         {!renderingInDashboardSidebar ? (
-          <Tooltip
-            body={saveToDashboardDisabledReason || ""}
-            shouldDisplay={!!saveToDashboardDisabledReason}
-          >
-            <Button
-              size="sm"
-              ml="auto"
-              disabled={!!saveToDashboardDisabledReason}
-              onClick={() => {
-                if (!hasDashboardsFeature) {
-                  setShowUpgradeModal(true);
-                } else {
-                  setShowSaveToDashboardModal(true);
-                }
-              }}
+          <>
+            <Tooltip
+              body={saveToDashboardDisabledReason || ""}
+              shouldDisplay={!!saveToDashboardDisabledReason}
             >
-              <Flex align="center" justify="center" gap="2">
-                <PaidFeatureBadge
-                  commercialFeature="product-analytics-dashboards"
-                  useTip={false}
-                />
-                Save to Dashboard
-              </Flex>
-            </Button>
-          </Tooltip>
+              <Button
+                size="sm"
+                disabled={!!saveToDashboardDisabledReason}
+                onClick={() => {
+                  if (!hasDashboardsFeature) {
+                    setShowUpgradeModal(true);
+                  } else {
+                    setShowSaveToDashboardModal(true);
+                  }
+                }}
+              >
+                <Flex align="center" justify="center" gap="2">
+                  <PaidFeatureBadge
+                    commercialFeature="product-analytics-dashboards"
+                    useTip={false}
+                  />
+                  Save to Dashboard
+                </Flex>
+              </Button>
+            </Tooltip>
+            <ShareUrlPopover
+              trigger={
+                <Button
+                  size="sm"
+                  variant="solid"
+                  color="violet"
+                  aria-label="Share exploration link"
+                >
+                  <PiLink />
+                </Button>
+              }
+              side="bottom"
+              align="end"
+            />
+          </>
         ) : (
           <Flex direction="row" align="center" justify="between" width="100%">
             <DataSourceDropdown />

--- a/packages/front-end/enterprise/components/ProductAnalytics/SideBar/ExplorerSideBar.tsx
+++ b/packages/front-end/enterprise/components/ProductAnalytics/SideBar/ExplorerSideBar.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Flex, Box } from "@radix-ui/themes";
+import { Flex, Box, IconButton } from "@radix-ui/themes";
 import {
   DatasetType,
   FactTableValue,
@@ -132,15 +132,18 @@ export default function ExplorerSideBar({
               </Button>
             </Tooltip>
             <ShareUrlPopover
+              title="Share this exploration"
+              description="Anyone in your organization with read access to the Data Source this exploration uses, can open this exploration."
               trigger={
-                <Button
-                  size="sm"
+                <IconButton
+                  size="2"
                   variant="solid"
                   color="violet"
                   aria-label="Share exploration link"
+                  style={{ height: 32, width: 32 }}
                 >
-                  <PiLink />
-                </Button>
+                  <PiLink size={20} />
+                </IconButton>
               }
               side="bottom"
               align="end"

--- a/packages/front-end/ui/ShareUrlPopover.module.scss
+++ b/packages/front-end/ui/ShareUrlPopover.module.scss
@@ -1,0 +1,22 @@
+.popoverContent {
+  width: 680px;
+  max-width: min(680px, 90vw);
+}
+
+.inner {
+  padding: 33px 40px 36px;
+}
+
+.urlField {
+  flex: 1;
+  min-width: 0;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  padding: 0 12px;
+  border: 1px solid rgba(0, 6, 46, 0.2);
+  border-radius: 6px;
+  background: var(--color-surface);
+  overflow: hidden;
+  white-space: nowrap;
+}

--- a/packages/front-end/ui/ShareUrlPopover.tsx
+++ b/packages/front-end/ui/ShareUrlPopover.tsx
@@ -1,15 +1,17 @@
 import React from "react";
-import { Box, Flex, Text } from "@radix-ui/themes";
+import { Box, Flex } from "@radix-ui/themes";
 import { PiCheck, PiCopy } from "react-icons/pi";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import Button from "@/ui/Button";
+import Heading from "@/ui/Heading";
+import Text from "@/ui/Text";
 import { Popover } from "@/ui/Popover";
 import styles from "./ShareUrlPopover.module.scss";
 
 interface ShareUrlPopoverProps {
   trigger: React.ReactNode;
   url?: string;
-  title?: string;
+  title: string;
   description?: string;
   side?: "top" | "right" | "bottom" | "left";
   align?: "start" | "center" | "end";
@@ -18,8 +20,8 @@ interface ShareUrlPopoverProps {
 export default function ShareUrlPopover({
   trigger,
   url,
-  title = "Share this exploration",
-  description = "Anyone in your organization with this link can open this exploration with the exact configuration applied.",
+  title,
+  description,
   side = "bottom",
   align = "center",
 }: ShareUrlPopoverProps) {
@@ -39,20 +41,18 @@ export default function ShareUrlPopover({
       content={
         <Box className={styles.inner}>
           <Flex direction="column" gap="1" mb="5">
-            <Text
-              size="5"
-              weight="bold"
-              style={{ color: "var(--color-text-high)" }}
-            >
+            <Heading as="h3" size="medium" color="text-high">
               {title}
-            </Text>
-            <Text size="3" style={{ color: "var(--color-text-mid)" }}>
-              {description}
-            </Text>
+            </Heading>
+            {description && (
+              <Text size="medium" color="text-mid">
+                {description}
+              </Text>
+            )}
           </Flex>
           <Flex gap="2" align="center">
             <Box className={styles.urlField} title={shareUrl}>
-              <Text size="3" style={{ color: "var(--color-text-high)" }}>
+              <Text size="medium" color="text-high">
                 {shareUrl}
               </Text>
             </Box>

--- a/packages/front-end/ui/ShareUrlPopover.tsx
+++ b/packages/front-end/ui/ShareUrlPopover.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import { Box, Flex, Text } from "@radix-ui/themes";
+import { PiCheck, PiCopy } from "react-icons/pi";
+import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
+import Button from "@/ui/Button";
+import { Popover } from "@/ui/Popover";
+import styles from "./ShareUrlPopover.module.scss";
+
+interface ShareUrlPopoverProps {
+  trigger: React.ReactNode;
+  url?: string;
+  title?: string;
+  description?: string;
+  side?: "top" | "right" | "bottom" | "left";
+  align?: "start" | "center" | "end";
+}
+
+export default function ShareUrlPopover({
+  trigger,
+  url,
+  title = "Share this exploration",
+  description = "Anyone in your organization with this link can open this exploration with the exact configuration applied.",
+  side = "bottom",
+  align = "center",
+}: ShareUrlPopoverProps) {
+  const shareUrl =
+    url ?? (typeof window !== "undefined" ? window.location.href : "");
+  const { copySuccess, performCopy } = useCopyToClipboard({ timeout: 2000 });
+
+  return (
+    <Popover
+      trigger={trigger}
+      side={side}
+      align={align}
+      showCloseButton
+      showArrow={false}
+      contentStyle={{ padding: 0 }}
+      contentClassName={styles.popoverContent}
+      content={
+        <Box className={styles.inner}>
+          <Flex direction="column" gap="1" mb="5">
+            <Text
+              size="5"
+              weight="bold"
+              style={{ color: "var(--color-text-high)" }}
+            >
+              {title}
+            </Text>
+            <Text size="3" style={{ color: "var(--color-text-mid)" }}>
+              {description}
+            </Text>
+          </Flex>
+          <Flex gap="2" align="center">
+            <Box className={styles.urlField} title={shareUrl}>
+              <Text size="3" style={{ color: "var(--color-text-high)" }}>
+                {shareUrl}
+              </Text>
+            </Box>
+            <Button
+              variant="outline"
+              color="violet"
+              size="md"
+              icon={copySuccess ? <PiCheck /> : <PiCopy />}
+              onClick={() => performCopy(shareUrl)}
+            >
+              {copySuccess ? "Copied!" : "Copy link"}
+            </Button>
+          </Flex>
+        </Box>
+      }
+    />
+  );
+}


### PR DESCRIPTION
### Features and Changes

This change set adds functionality to allow users to copy the link of the current exploration view to share with others in the same org.

### Dependencies

None

### Testing

Manual 

### Screenshots

<img width="1757" height="410" alt="Screenshot 2026-04-24 at 11 29 33 AM" src="https://github.com/user-attachments/assets/50e6ed76-a972-4170-b604-9ad711b36353" />





<img width="781" height="316" alt="Screenshot 2026-04-24 at 11 29 40 AM" src="https://github.com/user-attachments/assets/438e9b95-d2aa-4e71-b02e-254b86ef9e76" />

