### PR TITLE
Add snowflake event forwarder

### DIFF
--- a/packages/back-end/src/controllers/datasources.ts
+++ b/packages/back-end/src/controllers/datasources.ts
@@ -29,6 +29,7 @@ import {
 } from "shared/types/datasource";
 import { GoogleAnalyticsParams } from "shared/types/integrations/googleanalytics";
 import { BigQueryConnectionParams } from "shared/types/integrations/bigquery";
+import { SnowflakeConnectionParams } from "shared/types/integrations/snowflake";
 import { FactTableColumnType } from "shared/types/fact-table";
 import { SQLExecutionError } from "back-end/src/util/errors";
 import { AuthRequest } from "back-end/src/types/AuthRequest";
@@ -86,6 +87,25 @@ import {
 } from "back-end/src/services/clickhouse";
 import { UNITS_TABLE_PREFIX } from "back-end/src/queryRunners/ExperimentResultsQueryRunner";
 import { getExperimentsByTrackingKeys } from "back-end/src/models/ExperimentModel";
+
+type EventForwarderDatasourceParams =
+  | BigQueryConnectionParams
+  | SnowflakeConnectionParams
+  | undefined;
+
+function getEventForwarderDatasourceParams(
+  datasourceType: DataSourceType,
+  params: DataSourceParams | undefined,
+): EventForwarderDatasourceParams {
+  switch (datasourceType) {
+    case "bigquery":
+      return params as BigQueryConnectionParams;
+    case "snowflake":
+      return params as SnowflakeConnectionParams;
+    default:
+      return undefined;
+  }
+}
 
 export async function deleteDataSource(
   req: AuthRequest<null, { id: string }>,
@@ -262,23 +282,22 @@ export async function postDataSources(
       description,
       projects,
     );
+    const eventForwarderDatasourceParams = getEventForwarderDatasourceParams(
+      datasource.type,
+      params,
+    );
 
     const syncedEventForwarderConfig =
       await syncEventForwarderConfigFromDatasource({
         context,
         datasource,
         draft: eventForwarderConfig,
-        datasourceParams:
-          datasource.type === "bigquery"
-            ? (params as BigQueryConnectionParams)
-            : undefined,
+        datasourceParams: eventForwarderDatasourceParams,
       });
     await provisionEventForwarderThroughLicenseServer(
       context,
       syncedEventForwarderConfig,
-      datasource.type === "bigquery"
-        ? (params as BigQueryConnectionParams)
-        : undefined,
+      eventForwarderDatasourceParams,
     );
     const integration = getSourceIntegrationObject(context, datasource);
 
@@ -546,22 +565,21 @@ export async function putDataSource(
       ...updates,
     };
     const integration = getSourceIntegrationObject(context, updatedDatasource);
+    const eventForwarderDatasourceParams = getEventForwarderDatasourceParams(
+      updatedDatasource.type,
+      integration.params,
+    );
     const syncedEventForwarderConfig =
       await syncEventForwarderConfigFromDatasource({
         context,
         datasource: updatedDatasource,
         draft: eventForwarderConfig,
-        datasourceParams:
-          updatedDatasource.type === "bigquery"
-            ? (integration.params as BigQueryConnectionParams)
-            : undefined,
+        datasourceParams: eventForwarderDatasourceParams,
       });
     await provisionEventForwarderThroughLicenseServer(
       context,
       syncedEventForwarderConfig,
-      updatedDatasource.type === "bigquery"
-        ? (integration.params as BigQueryConnectionParams)
-        : undefined,
+      eventForwarderDatasourceParams,
     );
 
     res.status(200).json({

--- a/packages/back-end/src/enterprise/licenseUtil.ts
+++ b/packages/back-end/src/enterprise/licenseUtil.ts
@@ -1012,19 +1012,38 @@ function shouldLimitAccessDueToExpiredLicense(
 }
 
 /** Payload for central-license-server `POST .../event-forwarder/provision`. */
-export type EventForwarderLicenseProvisionParams = {
+type EventForwarderLicenseProvisionBaseParams = {
   organizationId: string;
   datasourceId: string;
   topic: string;
-  sinkType: "bigquery" | "snowflake" | "databricks";
-  bigqueryProjectId: string;
-  resolvedTableName: string;
-  bigqueryDataset: string;
-  serviceAccountKeyJson: string;
   attributeSchema: SDKAttributeSchema;
   connectorName?: string;
   connectorId?: string;
 };
+
+export type EventForwarderLicenseProvisionParams =
+  | (EventForwarderLicenseProvisionBaseParams & {
+      sinkType: "bigquery";
+      bigqueryProjectId: string;
+      resolvedTableName: string;
+      bigqueryDataset: string;
+      serviceAccountKeyJson: string;
+    })
+  | (EventForwarderLicenseProvisionBaseParams & {
+      sinkType: "snowflake";
+      snowflake: {
+        tableName: string;
+        account: string;
+        accessUrl?: string;
+        username: string;
+        database: string;
+        schema: string;
+        privateKey: string;
+        privateKeyPassword?: string;
+        role?: string;
+        warehouse?: string;
+      };
+    });
 
 export async function postProvisionEventForwarderToLicenseServer(
   params: EventForwarderLicenseProvisionParams,

--- a/packages/back-end/src/services/eventForwarderBqTableResolution.ts
+++ b/packages/back-end/src/services/eventForwarderBqTableResolution.ts
@@ -1,25 +1,10 @@
-import * as bq from "@google-cloud/bigquery";
 import {
   isValidBigQueryTableName,
   normalizeBigQueryTableNameForEventForwarder,
-  stripLeadingUtf8ByteOrderMark,
 } from "shared/util";
 import { BigQueryEventForwarderStoredConfig } from "shared/types/event-forwarder";
 import { EventForwarderConfigInterface } from "shared/validators";
 import { decryptEventForwarderConfigModel } from "back-end/src/services/eventForwarderConfig";
-
-function sanitizeBigQueryIdentifier(value: string): string {
-  const sanitized = value.replace(/[^a-zA-Z0-9_]+/g, "_");
-  return /^[A-Za-z_]/.test(sanitized) ? sanitized : `_${sanitized}`;
-}
-
-function getFallbackTableName(
-  baseTableName: string,
-  connectorName: string,
-): string {
-  const suffix = sanitizeBigQueryIdentifier(connectorName).slice(-16);
-  return `${baseTableName}_${suffix}`;
-}
 
 function validateBigQueryTableName(tableName: string): void {
   if (!tableName) {
@@ -33,25 +18,11 @@ function validateBigQueryTableName(tableName: string): void {
   }
 }
 
-function normalizeKeyfileJsonString(keyfile: string): string {
-  const trimmed = stripLeadingUtf8ByteOrderMark(keyfile).trim();
-  if (!trimmed) return "";
-  try {
-    return JSON.stringify(JSON.parse(trimmed));
-  } catch {
-    throw new Error(
-      "Event forwarder service account key is not valid JSON. Re-upload the GCP service account key file from the BigQuery datasource settings.",
-    );
-  }
-}
-
 /**
- * Resolves the BigQuery table name for the Confluent sink (base name or fallback
- * when the table already exists). GrowthBook runs this before calling the license server.
+ * Resolves the BigQuery table name for the Confluent sink. Existing tables are reused.
  */
 export async function resolveBigQueryEventForwarderTableName(
   eventForwarderConfig: EventForwarderConfigInterface,
-  projectId: string,
 ): Promise<string> {
   const storedConfig =
     decryptEventForwarderConfigModel<BigQueryEventForwarderStoredConfig>(
@@ -65,39 +36,12 @@ export async function resolveBigQueryEventForwarderTableName(
 
   const baseTableName = normalizeBigQueryTableNameForEventForwarder(trimmed);
 
-  if (!storedConfig.dataset || !projectId) {
+  if (!storedConfig.dataset) {
     throw new Error(
-      "Missing BigQuery project or dataset needed for connector provisioning",
+      "Missing BigQuery dataset needed for connector provisioning",
     );
   }
 
   validateBigQueryTableName(baseTableName);
-
-  const rawKey = storedConfig.serviceAccountKey?.trim() || "";
-  const keyfile = JSON.parse(
-    rawKey ? normalizeKeyfileJsonString(rawKey) : "{}",
-  ) as {
-    client_email?: string;
-    private_key?: string;
-  };
-  const client = new bq.BigQuery({
-    projectId,
-    credentials: {
-      client_email: keyfile.client_email || "",
-      private_key: keyfile.private_key || "",
-    },
-  });
-  const [tableExists] = await client
-    .dataset(storedConfig.dataset, { projectId })
-    .table(baseTableName)
-    .exists();
-
-  const connectorName =
-    eventForwarderConfig.connectorName?.trim() ||
-    eventForwarderConfig.connectorId?.trim() ||
-    eventForwarderConfig.datasourceId;
-
-  return tableExists
-    ? getFallbackTableName(baseTableName, connectorName)
-    : baseTableName;
+  return baseTableName;
 }

--- a/packages/back-end/src/services/eventForwarderConfig.ts
+++ b/packages/back-end/src/services/eventForwarderConfig.ts
@@ -161,6 +161,8 @@ function buildSnowflakeStoredConfigFromDraft(
     draft.tableName?.trim() ||
     existingStored?.tableName?.trim() ||
     DEFAULT_EVENT_FORWARDER_SNOWFLAKE_TABLE_NAME;
+  const accessUrl =
+    draft.accessUrl?.trim() || existingStored?.accessUrl?.trim() || "";
 
   const authMethod = datasourceParams?.authMethod ?? "password";
   if (authMethod !== "key-pair") {
@@ -175,10 +177,7 @@ function buildSnowflakeStoredConfigFromDraft(
       datasourceParams?.account?.trim() ||
       existingStored?.account?.trim() ||
       "",
-    accessUrl:
-      datasourceParams?.accessUrl?.trim() ||
-      existingStored?.accessUrl?.trim() ||
-      undefined,
+    accessUrl: accessUrl || undefined,
     username:
       datasourceParams?.username?.trim() ||
       existingStored?.username?.trim() ||
@@ -261,6 +260,7 @@ export function toEventForwarderConfigDraft(
       config: {
         tableName:
           decrypted.tableName || DEFAULT_EVENT_FORWARDER_SNOWFLAKE_TABLE_NAME,
+        accessUrl: decrypted.accessUrl || "",
       },
     };
   }
@@ -355,10 +355,11 @@ export async function syncEventForwarderConfigFromDatasource({
       !snowflake.database ||
       !snowflake.schema ||
       !snowflake.tableName ||
+      !snowflake.accessUrl ||
       !snowflake.privateKey
     ) {
       throw new Error(
-        "Snowflake event forwarder requires account, username, database, schema, table name, and private key credentials",
+        "Snowflake event forwarder requires account, username, database, schema, table name, event forwarder access URL, and private key credentials",
       );
     }
   }

--- a/packages/back-end/src/services/eventForwarderConfig.ts
+++ b/packages/back-end/src/services/eventForwarderConfig.ts
@@ -1,21 +1,34 @@
 import { AES, enc } from "crypto-js";
 import { DataSourceInterface } from "shared/types/datasource";
 import { BigQueryConnectionParams } from "shared/types/integrations/bigquery";
+import { SnowflakeConnectionParams } from "shared/types/integrations/snowflake";
 import {
   BigQueryEventForwarderConfigDraft,
   BigQueryEventForwarderStoredConfig,
   EventForwarderConfigDraft,
   EventForwarderSinkType,
+  SnowflakeEventForwarderConfigDraft,
+  SnowflakeEventForwarderStoredConfig,
 } from "shared/types/event-forwarder";
 import { EventForwarderConfigInterface } from "shared/validators";
 import {
   DEFAULT_EVENT_FORWARDER_BIGQUERY_TABLE_NAME,
+  DEFAULT_EVENT_FORWARDER_SNOWFLAKE_TABLE_NAME,
   normalizeBigQueryTableNameForEventForwarder,
+  normalizeSnowflakeTableNameForEventForwarder,
 } from "shared/util";
 import { ReqContext } from "back-end/types/request";
 import { ENCRYPTION_KEY } from "back-end/src/util/secrets";
 
-type SinkConfig = BigQueryEventForwarderStoredConfig | Record<string, string>;
+type SinkConfig =
+  | BigQueryEventForwarderStoredConfig
+  | SnowflakeEventForwarderStoredConfig
+  | Record<string, string>;
+
+type EventForwarderDatasourceParams =
+  | BigQueryConnectionParams
+  | SnowflakeConnectionParams
+  | undefined;
 
 function sanitizeKafkaName(value: string): string {
   return value
@@ -132,15 +145,86 @@ function buildBigQueryStoredConfigFromDraft(
   };
 }
 
+function buildSnowflakeStoredConfigFromDraft(
+  draft: SnowflakeEventForwarderConfigDraft,
+  datasourceParams: SnowflakeConnectionParams | undefined,
+  existingModel: EventForwarderConfigInterface | null,
+): SnowflakeEventForwarderStoredConfig {
+  const existingStored =
+    existingModel?.sinkType === "snowflake"
+      ? decryptSinkConfig<SnowflakeEventForwarderStoredConfig>(
+          existingModel.config,
+        )
+      : null;
+
+  const rawTableName =
+    draft.tableName?.trim() ||
+    existingStored?.tableName?.trim() ||
+    DEFAULT_EVENT_FORWARDER_SNOWFLAKE_TABLE_NAME;
+
+  const authMethod = datasourceParams?.authMethod ?? "password";
+  if (authMethod !== "key-pair") {
+    throw new Error(
+      "Snowflake event forwarder requires key-pair authentication. Password authentication is supported for Snowflake queries, but Confluent Snowflake Sink provisioning requires a private key.",
+    );
+  }
+
+  return {
+    tableName: normalizeSnowflakeTableNameForEventForwarder(rawTableName),
+    account:
+      datasourceParams?.account?.trim() ||
+      existingStored?.account?.trim() ||
+      "",
+    accessUrl:
+      datasourceParams?.accessUrl?.trim() ||
+      existingStored?.accessUrl?.trim() ||
+      undefined,
+    username:
+      datasourceParams?.username?.trim() ||
+      existingStored?.username?.trim() ||
+      "",
+    database:
+      datasourceParams?.database?.trim() ||
+      existingStored?.database?.trim() ||
+      "",
+    schema:
+      datasourceParams?.schema?.trim() || existingStored?.schema?.trim() || "",
+    privateKey:
+      datasourceParams?.privateKey?.trim() ||
+      existingStored?.privateKey?.trim() ||
+      "",
+    privateKeyPassword:
+      datasourceParams?.privateKeyPassword?.trim() ||
+      existingStored?.privateKeyPassword?.trim() ||
+      undefined,
+    role:
+      datasourceParams?.role?.trim() ||
+      existingStored?.role?.trim() ||
+      undefined,
+    warehouse:
+      datasourceParams?.warehouse?.trim() ||
+      existingStored?.warehouse?.trim() ||
+      undefined,
+  };
+}
+
 function buildNormalizedSinkPayload(
   draft: EventForwarderConfigDraft,
-  datasourceParams: BigQueryConnectionParams | undefined,
+  datasourceParams: EventForwarderDatasourceParams,
   existingModel: EventForwarderConfigInterface | null,
 ): SinkConfig {
   if (draft.sinkType === "bigquery") {
     return buildBigQueryStoredConfigFromDraft(
       draft.config,
-      datasourceParams,
+      datasourceParams as BigQueryConnectionParams | undefined,
+      existingModel,
+    );
+  }
+
+  if (draft.sinkType === "snowflake") {
+    return buildSnowflakeStoredConfigFromDraft(
+      draft.config,
+      datasourceParams as SnowflakeConnectionParams | undefined,
       existingModel,
     );
   }
@@ -164,6 +248,19 @@ export function toEventForwarderConfigDraft(
         tableName:
           rest.tableName || DEFAULT_EVENT_FORWARDER_BIGQUERY_TABLE_NAME,
         serviceAccountKey: "",
+      },
+    };
+  }
+
+  if (config.sinkType === "snowflake") {
+    const decrypted = decryptSinkConfig<SnowflakeEventForwarderStoredConfig>(
+      config.config,
+    );
+    return {
+      sinkType: "snowflake",
+      config: {
+        tableName:
+          decrypted.tableName || DEFAULT_EVENT_FORWARDER_SNOWFLAKE_TABLE_NAME,
       },
     };
   }
@@ -200,7 +297,7 @@ export async function syncEventForwarderConfigFromDatasource({
     "id" | "organization" | "projects" | "type"
   >;
   draft?: EventForwarderConfigDraft | null;
-  datasourceParams?: BigQueryConnectionParams;
+  datasourceParams?: EventForwarderDatasourceParams;
 }): Promise<EventForwarderConfigInterface | null> {
   const sinkType = getEventForwarderSinkTypeForDatasource(datasource);
 
@@ -229,11 +326,14 @@ export async function syncEventForwarderConfigFromDatasource({
   );
 
   if (draft.sinkType === "bigquery") {
+    const bigQueryParams = datasourceParams as
+      | BigQueryConnectionParams
+      | undefined;
     const bqProject =
-      datasourceParams?.defaultProject?.trim() ||
-      datasourceParams?.projectId?.trim() ||
+      bigQueryParams?.defaultProject?.trim() ||
+      bigQueryParams?.projectId?.trim() ||
       "";
-    const defaultDataset = datasourceParams?.defaultDataset?.trim() || "";
+    const defaultDataset = bigQueryParams?.defaultDataset?.trim() || "";
     const bq = normalizedPayload as BigQueryEventForwarderStoredConfig;
     if (
       !bqProject ||
@@ -243,6 +343,22 @@ export async function syncEventForwarderConfigFromDatasource({
     ) {
       throw new Error(
         "BigQuery event forwarder requires connector project (BigQuery Project ID), default dataset, table name, and service account credentials",
+      );
+    }
+  }
+
+  if (draft.sinkType === "snowflake") {
+    const snowflake = normalizedPayload as SnowflakeEventForwarderStoredConfig;
+    if (
+      !snowflake.account ||
+      !snowflake.username ||
+      !snowflake.database ||
+      !snowflake.schema ||
+      !snowflake.tableName ||
+      !snowflake.privateKey
+    ) {
+      throw new Error(
+        "Snowflake event forwarder requires account, username, database, schema, table name, and private key credentials",
       );
     }
   }

--- a/packages/back-end/src/services/eventForwarderDatasourceLifecycle.ts
+++ b/packages/back-end/src/services/eventForwarderDatasourceLifecycle.ts
@@ -8,7 +8,7 @@ import { ReqContext } from "back-end/types/request";
 
 /**
  * After removing a datasource: if a per-datasource event forwarder row exists for this id,
- * delete the Mongo row first, then tear down BigQuery Confluent resources via the license server.
+ * delete the Mongo row first, then tear down Confluent resources via the license server.
  */
 export async function syncEventForwarderAfterDatasourceDeleted(
   context: ReqContext | ApiReqContext,
@@ -87,18 +87,19 @@ export async function syncEventForwarderAfterDatasourceDeleted(
     existing,
   );
 
-  if (sinkType === "bigquery") {
+  if (sinkType === "bigquery" || sinkType === "snowflake") {
     logger.info(
       {
         organizationId: context.org.id,
         eventForwarderConfigId: snapshot.eventForwarderConfigId,
       },
-      "Event forwarder sync: invoking BigQuery Confluent teardown via license server",
+      "Event forwarder sync: invoking Confluent teardown via license server",
     );
     try {
       await teardownBigQueryEventForwarderInfrastructureRemote({
         organizationId: snapshot.organizationId,
         datasourceId: snapshot.datasourceId,
+        sinkType: snapshot.sinkType,
         topic: snapshot.topic,
         connectorName: snapshot.connectorName,
         connectorId: snapshot.connectorId,
@@ -157,7 +158,7 @@ export async function syncEventForwarderAfterDatasourceDeleted(
         sinkType,
         eventForwarderConfigId: snapshot.eventForwarderConfigId,
       },
-      "Event forwarder sync: skipping Confluent teardown (sink is not bigquery)",
+      "Event forwarder sync: skipping Confluent teardown for sink type",
     );
   }
 }

--- a/packages/back-end/src/services/eventForwarderProvisioning.ts
+++ b/packages/back-end/src/services/eventForwarderProvisioning.ts
@@ -1,6 +1,10 @@
 import { BigQueryConnectionParams } from "shared/types/integrations/bigquery";
-import { BigQueryEventForwarderStoredConfig } from "shared/types/event-forwarder";
 import { SDKAttributeSchema } from "shared/types/organization";
+import { SnowflakeConnectionParams } from "shared/types/integrations/snowflake";
+import {
+  BigQueryEventForwarderStoredConfig,
+  SnowflakeEventForwarderStoredConfig,
+} from "shared/types/event-forwarder";
 import { EventForwarderConfigInterface } from "shared/validators";
 import {
   postProvisionEventForwarderToLicenseServer,
@@ -19,55 +23,77 @@ import { ReqContext } from "back-end/types/request";
 export async function provisionEventForwarderThroughLicenseServer(
   context: ReqContext,
   eventForwarderConfig: EventForwarderConfigInterface | null,
-  bigqueryConnectionParams?: BigQueryConnectionParams,
+  datasourceParams?: BigQueryConnectionParams | SnowflakeConnectionParams,
 ): Promise<void> {
   if (!eventForwarderConfig) {
     return;
   }
 
-  if (eventForwarderConfig.sinkType !== "bigquery") {
+  if (eventForwarderConfig.sinkType === "databricks") {
     return;
   }
 
-  const projectId =
-    bigqueryConnectionParams?.defaultProject?.trim() ||
-    bigqueryConnectionParams?.projectId?.trim() ||
-    "";
-
-  if (!projectId) {
-    const message =
-      "Missing BigQuery connector project id for event forwarder provisioning";
-    await context.models.eventForwarderConfigs.update(eventForwarderConfig, {
-      status: "error",
-      lastProvisioningError: message,
-    });
-    throw new Error(message);
-  }
-
   try {
-    const resolvedTableName = await resolveBigQueryEventForwarderTableName(
-      eventForwarderConfig,
-      projectId,
-    );
+    const attributeSchema = context.org.settings?.attributeSchema ?? [];
+    let result: {
+      schemaId: number;
+      connectorName: string;
+      connectorId: string;
+    };
 
-    const decrypted =
-      decryptEventForwarderConfigModel<BigQueryEventForwarderStoredConfig>(
-        eventForwarderConfig,
-      );
+    if (eventForwarderConfig.sinkType === "bigquery") {
+      const bigqueryConnectionParams = datasourceParams as
+        | BigQueryConnectionParams
+        | undefined;
+      const projectId =
+        bigqueryConnectionParams?.defaultProject?.trim() ||
+        bigqueryConnectionParams?.projectId?.trim() ||
+        "";
 
-    const result = await postProvisionEventForwarderToLicenseServer({
-      organizationId: context.org.id,
-      datasourceId: eventForwarderConfig.datasourceId,
-      topic: eventForwarderConfig.topic,
-      sinkType: "bigquery",
-      bigqueryProjectId: projectId,
-      resolvedTableName,
-      bigqueryDataset: decrypted.dataset.trim(),
-      serviceAccountKeyJson: (decrypted.serviceAccountKey ?? "").trim(),
-      attributeSchema: context.org.settings?.attributeSchema ?? [],
-      connectorName: eventForwarderConfig.connectorName?.trim() || undefined,
-      connectorId: eventForwarderConfig.connectorId?.trim() || undefined,
-    });
+      if (!projectId) {
+        throw new Error(
+          "Missing BigQuery connector project id for event forwarder provisioning",
+        );
+      }
+
+      const resolvedTableName =
+        await resolveBigQueryEventForwarderTableName(eventForwarderConfig);
+
+      const decrypted =
+        decryptEventForwarderConfigModel<BigQueryEventForwarderStoredConfig>(
+          eventForwarderConfig,
+        );
+
+      result = await postProvisionEventForwarderToLicenseServer({
+        organizationId: context.org.id,
+        datasourceId: eventForwarderConfig.datasourceId,
+        topic: eventForwarderConfig.topic,
+        sinkType: "bigquery",
+        bigqueryProjectId: projectId,
+        resolvedTableName,
+        bigqueryDataset: decrypted.dataset.trim(),
+        serviceAccountKeyJson: (decrypted.serviceAccountKey ?? "").trim(),
+        attributeSchema,
+        connectorName: eventForwarderConfig.connectorName?.trim() || undefined,
+        connectorId: eventForwarderConfig.connectorId?.trim() || undefined,
+      });
+    } else {
+      const decrypted =
+        decryptEventForwarderConfigModel<SnowflakeEventForwarderStoredConfig>(
+          eventForwarderConfig,
+        );
+
+      result = await postProvisionEventForwarderToLicenseServer({
+        organizationId: context.org.id,
+        datasourceId: eventForwarderConfig.datasourceId,
+        topic: eventForwarderConfig.topic,
+        sinkType: "snowflake",
+        snowflake: decrypted,
+        attributeSchema,
+        connectorName: eventForwarderConfig.connectorName?.trim() || undefined,
+        connectorId: eventForwarderConfig.connectorId?.trim() || undefined,
+      });
+    }
 
     await context.models.eventForwarderConfigs.update(eventForwarderConfig, {
       schemaId: result.schemaId,
@@ -157,6 +183,7 @@ export async function updateEventForwarderSchemaThroughLicenseServer(
 export async function teardownBigQueryEventForwarderInfrastructureRemote(snapshot: {
   organizationId: string;
   datasourceId: string;
+  sinkType?: "bigquery" | "snowflake" | "databricks";
   topic?: string;
   connectorName?: string;
   connectorId?: string;
@@ -164,7 +191,7 @@ export async function teardownBigQueryEventForwarderInfrastructureRemote(snapsho
   await postTeardownEventForwarderToLicenseServer({
     organizationId: snapshot.organizationId,
     datasourceId: snapshot.datasourceId,
-    sinkType: "bigquery",
+    sinkType: snapshot.sinkType ?? "bigquery",
     topic: snapshot.topic,
     connectorName: snapshot.connectorName,
     connectorId: snapshot.connectorId,

--- a/packages/back-end/src/services/eventForwarderProvisioning.ts
+++ b/packages/back-end/src/services/eventForwarderProvisioning.ts
@@ -77,7 +77,7 @@ export async function provisionEventForwarderThroughLicenseServer(
         connectorName: eventForwarderConfig.connectorName?.trim() || undefined,
         connectorId: eventForwarderConfig.connectorId?.trim() || undefined,
       });
-    } else {
+    } else if (eventForwarderConfig.sinkType === "snowflake") {
       const decrypted =
         decryptEventForwarderConfigModel<SnowflakeEventForwarderStoredConfig>(
           eventForwarderConfig,
@@ -93,6 +93,10 @@ export async function provisionEventForwarderThroughLicenseServer(
         connectorName: eventForwarderConfig.connectorName?.trim() || undefined,
         connectorId: eventForwarderConfig.connectorId?.trim() || undefined,
       });
+    } else {
+      throw new Error(
+        `Unsupported event forwarder sink type for provisioning: ${eventForwarderConfig.sinkType}`,
+      );
     }
 
     await context.models.eventForwarderConfigs.update(eventForwarderConfig, {

--- a/packages/back-end/test/services/eventForwarderDatasourceLifecycle.test.ts
+++ b/packages/back-end/test/services/eventForwarderDatasourceLifecycle.test.ts
@@ -80,6 +80,7 @@ describe("syncEventForwarderAfterDatasourceDeleted", () => {
     expect(mockedTeardownRemote).toHaveBeenCalledWith({
       organizationId: "org1",
       datasourceId: "ds_a",
+      sinkType: "bigquery",
       topic: "topic-a",
       connectorName: undefined,
       connectorId: undefined,
@@ -112,7 +113,7 @@ describe("syncEventForwarderAfterDatasourceDeleted", () => {
     expect(deleteForDatasourceCascade).not.toHaveBeenCalled();
   });
 
-  it("deletes the row without Confluent teardown for non-BigQuery sinks", async () => {
+  it("cascade-deletes the row before license-server Snowflake teardown", async () => {
     const existing: EventForwarderConfigInterface = {
       id: "efc_s",
       organization: "org1",
@@ -153,8 +154,15 @@ describe("syncEventForwarderAfterDatasourceDeleted", () => {
       snowflakeDs,
     );
 
-    expect(mockedTeardownRemote).not.toHaveBeenCalled();
     expect(deleteForDatasourceCascade).toHaveBeenCalledWith(existing);
+    expect(mockedTeardownRemote).toHaveBeenCalledWith({
+      organizationId: "org1",
+      datasourceId: "ds_s",
+      sinkType: "snowflake",
+      topic: "topic-s",
+      connectorName: undefined,
+      connectorId: undefined,
+    });
   });
 
   it("invokes teardown only for the forwarder tied to the deleted datasource id", async () => {
@@ -206,6 +214,7 @@ describe("syncEventForwarderAfterDatasourceDeleted", () => {
     expect(mockedTeardownRemote).toHaveBeenCalledWith({
       organizationId: "org1",
       datasourceId: "ds_a",
+      sinkType: "bigquery",
       topic: "topic-a",
       connectorName: undefined,
       connectorId: undefined,
@@ -224,6 +233,7 @@ describe("syncEventForwarderAfterDatasourceDeleted", () => {
     expect(mockedTeardownRemote).toHaveBeenCalledWith({
       organizationId: "org1",
       datasourceId: "ds_b",
+      sinkType: "bigquery",
       topic: "topic-b",
       connectorName: undefined,
       connectorId: undefined,

--- a/packages/front-end/components/Settings/BigQueryForm.tsx
+++ b/packages/front-end/components/Settings/BigQueryForm.tsx
@@ -10,6 +10,7 @@ import Tooltip from "@/components/Tooltip/Tooltip";
 import SelectField from "@/components/Forms/SelectField";
 import Button from "@/components/Button";
 import Checkbox from "@/ui/Checkbox";
+import EventForwarderTableNameField from "./EventForwarderTableNameField";
 
 const BigQueryForm: FC<{
   params: Partial<BigQueryConnectionParams>;
@@ -245,32 +246,21 @@ const BigQueryForm: FC<{
                 gap="3"
                 className="form-group col-md-12 mt-3 px-0"
               >
-                <Flex direction="column" gap="1">
-                  <label className="mb-0">
-                    <Flex align="center" gap="1">
-                      <span>Event Forwarder Table Name</span>
-                      <Tooltip body="Defaults to gb_events. If that table already exists, GrowthBook will provision a connector using a suffixed fallback table name instead." />
-                    </Flex>
-                  </label>
-                  <Field
-                    type="text"
-                    className="form-control"
-                    name="eventForwarderTableName"
-                    value={eventForwarderConfig.config.tableName}
-                    onChange={(e) =>
-                      setEventForwarderConfig({
-                        sinkType: "bigquery",
-                        config: {
-                          ...eventForwarderConfig.config,
-                          tableName: e.target.value,
-                        },
-                      })
-                    }
-                    placeholder="gb_events"
-                    helpText="Letters, numbers, and underscores (Unicode allowed). Hyphens and spaces are normalized to underscores when saving."
-                    required
-                  />
-                </Flex>
+                <EventForwarderTableNameField
+                  value={eventForwarderConfig.config.tableName}
+                  onChange={(tableName) =>
+                    setEventForwarderConfig({
+                      sinkType: "bigquery",
+                      config: {
+                        ...eventForwarderConfig.config,
+                        tableName,
+                      },
+                    })
+                  }
+                  placeholder="gb_events"
+                  tooltip="Defaults to gb_events. If that table already exists, GrowthBook will reuse it for the event forwarder."
+                  helpText="Letters, numbers, and underscores (Unicode allowed). Hyphens and spaces are normalized to underscores when saving."
+                />
               </Flex>
             )}
           </div>

--- a/packages/front-end/components/Settings/ConnectionSettings.tsx
+++ b/packages/front-end/components/Settings/ConnectionSettings.tsx
@@ -178,6 +178,8 @@ export default function ConnectionSettings({
           onParamChange={onParamChange}
           onManualParamChange={onManualParamChange}
           params={datasource?.params || {}}
+          eventForwarderConfig={datasource.eventForwarderConfig || null}
+          setEventForwarderConfig={setEventForwarderConfig}
         />
       );
       break;

--- a/packages/front-end/components/Settings/EventForwarderTableNameField.tsx
+++ b/packages/front-end/components/Settings/EventForwarderTableNameField.tsx
@@ -1,0 +1,40 @@
+import { Flex } from "@radix-ui/themes";
+import Field from "@/components/Forms/Field";
+import Tooltip from "@/components/Tooltip/Tooltip";
+
+export default function EventForwarderTableNameField({
+  label = "Event Forwarder Table Name",
+  value,
+  onChange,
+  placeholder,
+  tooltip,
+  helpText,
+}: {
+  label?: string;
+  value: string;
+  onChange: (value: string) => void;
+  placeholder: string;
+  tooltip: string;
+  helpText: string;
+}) {
+  return (
+    <Flex direction="column" gap="1">
+      <label className="mb-0">
+        <Flex align="center" gap="1">
+          <span>{label}</span>
+          <Tooltip body={tooltip} />
+        </Flex>
+      </label>
+      <Field
+        type="text"
+        className="form-control"
+        name="eventForwarderTableName"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        helpText={helpText}
+        required
+      />
+    </Flex>
+  );
+}

--- a/packages/front-end/components/Settings/SnowflakeForm.tsx
+++ b/packages/front-end/components/Settings/SnowflakeForm.tsx
@@ -31,6 +31,10 @@ const SnowflakeForm: FC<{
   // Convenience variable for the auth method to handle undefined
   const authMethod = params.authMethod ?? "password";
   const canEnableEventForwarder = authMethod === "key-pair";
+  const snowflakeEventForwarderConfig =
+    eventForwarderConfig?.sinkType === "snowflake"
+      ? eventForwarderConfig
+      : null;
 
   return (
     <div className="row">
@@ -147,7 +151,7 @@ const SnowflakeForm: FC<{
             <Checkbox
               id="enableSnowflakeEventForwarder"
               label="Enable Event Forwarder"
-              value={!!eventForwarderConfig}
+              value={!!snowflakeEventForwarderConfig}
               disabled={!canEnableEventForwarder}
               disabledMessage="Snowflake event forwarding uses Confluent Snowflake Sink, which requires key-pair authentication."
               setValue={(value) => {
@@ -172,16 +176,16 @@ const SnowflakeForm: FC<{
               </span>
             </div>
           </div>
-          {eventForwarderConfig && (
+          {snowflakeEventForwarderConfig && (
             <>
               <div className="form-group col-md-12">
                 <EventForwarderTableNameField
-                  value={eventForwarderConfig.config.tableName}
+                  value={snowflakeEventForwarderConfig.config.tableName}
                   onChange={(tableName) =>
                     setEventForwarderConfig({
                       sinkType: "snowflake",
                       config: {
-                        ...eventForwarderConfig.config,
+                        ...snowflakeEventForwarderConfig.config,
                         tableName,
                       },
                     })
@@ -202,12 +206,12 @@ const SnowflakeForm: FC<{
                   name="eventForwarderAccessUrl"
                   required
                   placeholder="https://abcd12345.us-east-1.snowflakecomputing.com:443"
-                  value={eventForwarderConfig.config.accessUrl || ""}
+                  value={snowflakeEventForwarderConfig.config.accessUrl || ""}
                   onChange={(e) =>
                     setEventForwarderConfig({
                       sinkType: "snowflake",
                       config: {
-                        ...eventForwarderConfig.config,
+                        ...snowflakeEventForwarderConfig.config,
                         accessUrl: e.target.value,
                       },
                     })

--- a/packages/front-end/components/Settings/SnowflakeForm.tsx
+++ b/packages/front-end/components/Settings/SnowflakeForm.tsx
@@ -97,7 +97,7 @@ const SnowflakeForm: FC<{
         </div>
       ) : null}
 
-      {authMethod === "key-pair" ? (
+      {authMethod === "key-pair" && (
         <>
           <div className="form-group col-md-12">
             <label>Private Key File</label>
@@ -143,8 +143,81 @@ const SnowflakeForm: FC<{
               }
             />
           </div>
+          <div className="form-group col-md-12">
+            <Checkbox
+              id="enableSnowflakeEventForwarder"
+              label="Enable Event Forwarder"
+              value={!!eventForwarderConfig}
+              disabled={!canEnableEventForwarder}
+              disabledMessage="Snowflake event forwarding uses Confluent Snowflake Sink, which requires key-pair authentication."
+              setValue={(value) => {
+                if (!value) {
+                  setEventForwarderConfig(null);
+                  return;
+                }
+
+                setEventForwarderConfig({
+                  sinkType: "snowflake",
+                  config: {
+                    tableName: DEFAULT_EVENT_FORWARDER_SNOWFLAKE_TABLE_NAME,
+                    accessUrl: "",
+                  },
+                });
+              }}
+            />
+            <div>
+              <span className="text-muted small">
+                Enriched events are written to the configured Snowflake database
+                and schema on this page.
+              </span>
+            </div>
+          </div>
+          {eventForwarderConfig && (
+            <>
+              <div className="form-group col-md-12">
+                <EventForwarderTableNameField
+                  value={eventForwarderConfig.config.tableName}
+                  onChange={(tableName) =>
+                    setEventForwarderConfig({
+                      sinkType: "snowflake",
+                      config: {
+                        ...eventForwarderConfig.config,
+                        tableName,
+                      },
+                    })
+                  }
+                  placeholder={DEFAULT_EVENT_FORWARDER_SNOWFLAKE_TABLE_NAME}
+                  tooltip="Defaults to GB_EVENTS. GrowthBook maps the Kafka topic to this Snowflake table."
+                  helpText="Letters, numbers, underscores, and dollar signs. Hyphens and spaces are normalized to underscores when saving."
+                />
+              </div>
+              <div className="form-group col-md-12">
+                <label>
+                  Event Forwarder Access URL{" "}
+                  <Tooltip body="Full Snowflake URL for Confluent Snowflake Sink, including the region, for example https://abcd12345.us-east-1.snowflakecomputing.com:443" />
+                </label>
+                <input
+                  type="text"
+                  className="form-control"
+                  name="eventForwarderAccessUrl"
+                  required
+                  placeholder="https://abcd12345.us-east-1.snowflakecomputing.com:443"
+                  value={eventForwarderConfig.config.accessUrl || ""}
+                  onChange={(e) =>
+                    setEventForwarderConfig({
+                      sinkType: "snowflake",
+                      config: {
+                        ...eventForwarderConfig.config,
+                        accessUrl: e.target.value,
+                      },
+                    })
+                  }
+                />
+              </div>
+            </>
+          )}
         </>
-      ) : null}
+      )}
 
       <div className="form-group col-md-12">
         <label>Database</label>
@@ -207,7 +280,7 @@ const SnowflakeForm: FC<{
           />
         </div>
       </div>
-      {useAccessUrl ? (
+      {useAccessUrl && (
         <div className="form-group col-md-12">
           <label>
             Access URL{" "}
@@ -220,53 +293,6 @@ const SnowflakeForm: FC<{
             required
             value={params.accessUrl || ""}
             onChange={onParamChange}
-          />
-        </div>
-      ) : null}
-      <div className="form-group col-md-12">
-        <Checkbox
-          id="enableSnowflakeEventForwarder"
-          label="Enable Event Forwarder"
-          value={!!eventForwarderConfig}
-          disabled={!canEnableEventForwarder}
-          disabledMessage="Snowflake event forwarding uses Confluent Snowflake Sink, which requires key-pair authentication."
-          setValue={(value) => {
-            if (!value) {
-              setEventForwarderConfig(null);
-              return;
-            }
-
-            setEventForwarderConfig({
-              sinkType: "snowflake",
-              config: {
-                tableName: DEFAULT_EVENT_FORWARDER_SNOWFLAKE_TABLE_NAME,
-              },
-            });
-          }}
-        />
-        <div>
-          <span className="text-muted small">
-            Enriched events are written to the configured Snowflake database and
-            schema on this page.
-          </span>
-        </div>
-      </div>
-      {eventForwarderConfig?.sinkType === "snowflake" && (
-        <div className="form-group col-md-12">
-          <EventForwarderTableNameField
-            value={eventForwarderConfig.config.tableName}
-            onChange={(tableName) =>
-              setEventForwarderConfig({
-                sinkType: "snowflake",
-                config: {
-                  ...eventForwarderConfig.config,
-                  tableName,
-                },
-              })
-            }
-            placeholder={DEFAULT_EVENT_FORWARDER_SNOWFLAKE_TABLE_NAME}
-            tooltip="Defaults to GB_EVENTS. GrowthBook maps the Kafka topic to this Snowflake table."
-            helpText="Letters, numbers, underscores, and dollar signs. Hyphens and spaces are normalized to underscores when saving."
           />
         </div>
       )}

--- a/packages/front-end/components/Settings/SnowflakeForm.tsx
+++ b/packages/front-end/components/Settings/SnowflakeForm.tsx
@@ -1,20 +1,36 @@
 import { FC, ChangeEventHandler, useState } from "react";
+import { DEFAULT_EVENT_FORWARDER_SNOWFLAKE_TABLE_NAME } from "shared/util";
+import { EventForwarderConfigDraft } from "shared/types/event-forwarder";
 import { SnowflakeConnectionParams } from "shared/types/integrations/snowflake";
 import Tooltip from "@/components/Tooltip/Tooltip";
 import Switch from "@/ui/Switch";
+import Checkbox from "@/ui/Checkbox";
 import { GBInfo } from "@/components/Icons";
 import FileInput from "@/components/FileInput";
+import EventForwarderTableNameField from "./EventForwarderTableNameField";
 
 const SnowflakeForm: FC<{
   params: Partial<SnowflakeConnectionParams>;
+  eventForwarderConfig: EventForwarderConfigDraft | null;
   existing: boolean;
+  setEventForwarderConfig: (
+    eventForwarderConfig: EventForwarderConfigDraft | null,
+  ) => void;
   onParamChange: ChangeEventHandler<HTMLInputElement>;
   onManualParamChange: (name: string, value: string) => void;
-}> = ({ params, existing, onParamChange, onManualParamChange }) => {
+}> = ({
+  params,
+  eventForwarderConfig,
+  setEventForwarderConfig,
+  existing,
+  onParamChange,
+  onManualParamChange,
+}) => {
   const [useAccessUrl, setUseAccessUrl] = useState(!!params.accessUrl);
   const [originalAuthMethod] = useState(params.authMethod);
   // Convenience variable for the auth method to handle undefined
   const authMethod = params.authMethod ?? "password";
+  const canEnableEventForwarder = authMethod === "key-pair";
 
   return (
     <div className="row">
@@ -49,7 +65,12 @@ const SnowflakeForm: FC<{
           autoComplete="off"
           name="authMethod"
           value={params.authMethod ?? "password"}
-          onChange={(e) => onManualParamChange("authMethod", e.target.value)}
+          onChange={(e) => {
+            onManualParamChange("authMethod", e.target.value);
+            if (e.target.value !== "key-pair" && eventForwarderConfig) {
+              setEventForwarderConfig(null);
+            }
+          }}
         >
           <option value="password">Password</option>
           <option value="key-pair">Key Pair</option>
@@ -202,6 +223,53 @@ const SnowflakeForm: FC<{
           />
         </div>
       ) : null}
+      <div className="form-group col-md-12">
+        <Checkbox
+          id="enableSnowflakeEventForwarder"
+          label="Enable Event Forwarder"
+          value={!!eventForwarderConfig}
+          disabled={!canEnableEventForwarder}
+          disabledMessage="Snowflake event forwarding uses Confluent Snowflake Sink, which requires key-pair authentication."
+          setValue={(value) => {
+            if (!value) {
+              setEventForwarderConfig(null);
+              return;
+            }
+
+            setEventForwarderConfig({
+              sinkType: "snowflake",
+              config: {
+                tableName: DEFAULT_EVENT_FORWARDER_SNOWFLAKE_TABLE_NAME,
+              },
+            });
+          }}
+        />
+        <div>
+          <span className="text-muted small">
+            Enriched events are written to the configured Snowflake database and
+            schema on this page.
+          </span>
+        </div>
+      </div>
+      {eventForwarderConfig?.sinkType === "snowflake" && (
+        <div className="form-group col-md-12">
+          <EventForwarderTableNameField
+            value={eventForwarderConfig.config.tableName}
+            onChange={(tableName) =>
+              setEventForwarderConfig({
+                sinkType: "snowflake",
+                config: {
+                  ...eventForwarderConfig.config,
+                  tableName,
+                },
+              })
+            }
+            placeholder={DEFAULT_EVENT_FORWARDER_SNOWFLAKE_TABLE_NAME}
+            tooltip="Defaults to GB_EVENTS. GrowthBook maps the Kafka topic to this Snowflake table."
+            helpText="Letters, numbers, underscores, and dollar signs. Hyphens and spaces are normalized to underscores when saving."
+          />
+        </div>
+      )}
     </div>
   );
 };

--- a/packages/shared/src/util/index.ts
+++ b/packages/shared/src/util/index.ts
@@ -27,6 +27,7 @@ import { featureHasEnvironment } from "./features";
 
 export * from "./strings";
 export * from "./bigquery-table-name";
+export * from "./snowflake-table-name";
 export * from "./features";
 export * from "./saved-groups";
 export * from "./metric-time-series";

--- a/packages/shared/src/util/snowflake-table-name.ts
+++ b/packages/shared/src/util/snowflake-table-name.ts
@@ -1,0 +1,40 @@
+/** Snowflake unquoted identifiers are max 255 chars and start with a letter or underscore. */
+
+const SNOWFLAKE_IDENTIFIER_MAX_LENGTH = 255;
+
+export const DEFAULT_EVENT_FORWARDER_SNOWFLAKE_TABLE_NAME = "GB_EVENTS";
+
+export function normalizeSnowflakeTableNameForEventForwarder(
+  raw: string,
+  defaultWhenEmpty = DEFAULT_EVENT_FORWARDER_SNOWFLAKE_TABLE_NAME,
+): string {
+  let s = raw.normalize("NFKC").trim();
+  if (!s) return defaultWhenEmpty;
+
+  const afterSanitize = s
+    .replace(/[^A-Za-z0-9_$]+/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^_|_$/g, "");
+
+  if (!afterSanitize) {
+    throw new Error(
+      "Event forwarder table name must contain at least one letter or number.",
+    );
+  }
+
+  s = afterSanitize;
+
+  if (!/^[A-Za-z_]/.test(s)) {
+    s = `_${s}`;
+  }
+
+  return s.slice(0, SNOWFLAKE_IDENTIFIER_MAX_LENGTH).toUpperCase();
+}
+
+export function isValidSnowflakeTableName(name: string): boolean {
+  return (
+    name.length > 0 &&
+    name.length <= SNOWFLAKE_IDENTIFIER_MAX_LENGTH &&
+    /^[A-Z_][A-Z0-9_$]*$/.test(name)
+  );
+}

--- a/packages/shared/test/util/snowflake-table-name.test.ts
+++ b/packages/shared/test/util/snowflake-table-name.test.ts
@@ -1,0 +1,59 @@
+import {
+  DEFAULT_EVENT_FORWARDER_SNOWFLAKE_TABLE_NAME,
+  isValidSnowflakeTableName,
+  normalizeSnowflakeTableNameForEventForwarder,
+} from "../../src/util/snowflake-table-name";
+
+describe("normalizeSnowflakeTableNameForEventForwarder", () => {
+  it("returns default when raw is empty", () => {
+    expect(normalizeSnowflakeTableNameForEventForwarder("")).toBe(
+      DEFAULT_EVENT_FORWARDER_SNOWFLAKE_TABLE_NAME,
+    );
+    expect(normalizeSnowflakeTableNameForEventForwarder("   ")).toBe(
+      DEFAULT_EVENT_FORWARDER_SNOWFLAKE_TABLE_NAME,
+    );
+  });
+
+  it("maps hyphens and spaces to underscores and uppercases", () => {
+    expect(normalizeSnowflakeTableNameForEventForwarder("gb-events")).toBe(
+      "GB_EVENTS",
+    );
+    expect(normalizeSnowflakeTableNameForEventForwarder("gb events")).toBe(
+      "GB_EVENTS",
+    );
+  });
+
+  it("prefixes when the first character would be a digit", () => {
+    expect(normalizeSnowflakeTableNameForEventForwarder("42foo")).toBe(
+      "_42FOO",
+    );
+  });
+
+  it("allows dollar signs", () => {
+    expect(normalizeSnowflakeTableNameForEventForwarder("gb$events")).toBe(
+      "GB$EVENTS",
+    );
+  });
+
+  it("throws when there are no letters or digits", () => {
+    expect(() => normalizeSnowflakeTableNameForEventForwarder("___")).toThrow(
+      /letter or number/,
+    );
+    expect(() => normalizeSnowflakeTableNameForEventForwarder("---")).toThrow(
+      /letter or number/,
+    );
+  });
+});
+
+describe("isValidSnowflakeTableName", () => {
+  it("accepts normalized Snowflake identifiers", () => {
+    expect(isValidSnowflakeTableName("GB_EVENTS")).toBe(true);
+    expect(isValidSnowflakeTableName("_42")).toBe(true);
+    expect(isValidSnowflakeTableName("GB$EVENTS")).toBe(true);
+  });
+
+  it("rejects lowercase and hyphens", () => {
+    expect(isValidSnowflakeTableName("gb_events")).toBe(false);
+    expect(isValidSnowflakeTableName("GB-EVENTS")).toBe(false);
+  });
+});

--- a/packages/shared/types/event-forwarder.d.ts
+++ b/packages/shared/types/event-forwarder.d.ts
@@ -17,6 +17,7 @@ export interface BigQueryEventForwarderStoredConfig {
 
 export interface SnowflakeEventForwarderConfigDraft {
   tableName: string;
+  accessUrl?: string;
 }
 
 /** Encrypted payload saved for provisioning; credentials are copied from datasource params at sync time. */

--- a/packages/shared/types/event-forwarder.d.ts
+++ b/packages/shared/types/event-forwarder.d.ts
@@ -15,6 +15,24 @@ export interface BigQueryEventForwarderStoredConfig {
   serviceAccountKey?: string;
 }
 
+export interface SnowflakeEventForwarderConfigDraft {
+  tableName: string;
+}
+
+/** Encrypted payload saved for provisioning; credentials are copied from datasource params at sync time. */
+export interface SnowflakeEventForwarderStoredConfig {
+  tableName: string;
+  account: string;
+  accessUrl?: string;
+  username: string;
+  database: string;
+  schema: string;
+  privateKey: string;
+  privateKeyPassword?: string;
+  role?: string;
+  warehouse?: string;
+}
+
 export type EventForwarderConfigDraft =
   | {
       sinkType: "bigquery";
@@ -22,7 +40,7 @@ export type EventForwarderConfigDraft =
     }
   | {
       sinkType: "snowflake";
-      config: Record<string, string>;
+      config: SnowflakeEventForwarderConfigDraft;
     }
   | {
       sinkType: "databricks";


### PR DESCRIPTION
### Features and Changes
- Refactor Bigquery part to support Snowflake as well
- Add connector and UI part to enable event forwarder for Snowflake

- Closes **[Add Snowflake](https://www.notion.so/growthbook/Event-Forwarder-345a857e74a080a888c8de6d150a518d?source=copy_link#34fa857e74a080ab92b8cac778654bf5)**

### Testing

- Set up Snowflake data source with Event forwarder. Check in Confluent
- Delete and make sure Kafka and connector are deleted on Confluent