### PR TITLE
Updates experiment endpoints to flush subnormal values to 0

### DIFF
--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -2356,7 +2356,7 @@ export async function toExperimentApiInterface(
 // that break many real-world JSON parsers.
 function safeFloat(n: number | undefined, fallback = 0): number {
   if (n == null || !isFinite(n)) return fallback;
-  return parseFloat(n.toFixed(10));
+  return parseFloat(n.toFixed(20));
 }
 
 export function toSnapshotApiInterface(

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -2352,6 +2352,15 @@ export async function toExperimentApiInterface(
   return apiExperiment;
 }
 
+// The smallest positive normal IEEE 754 double. Values below this magnitude
+// are subnormal and can break many real-world JSON parsers, so we flush them to 0.
+const SMALLEST_NORMAL_FLOAT = 2.2250738585072014e-308;
+
+function safeFloat(n: number | undefined, fallback = 0): number {
+  if (n == null || !isFinite(n)) return fallback;
+  return Math.abs(n) < SMALLEST_NORMAL_FLOAT ? fallback : n;
+}
+
 export function toSnapshotApiInterface(
   experiment: ExperimentInterface,
   snapshot: ExperimentSnapshotInterface,
@@ -2448,16 +2457,16 @@ export function toSnapshotApiInterface(
                 {
                   engine:
                     analysis?.settings?.statsEngine || DEFAULT_STATS_ENGINE,
-                  numerator: data?.value || 0,
-                  denominator: data?.denominator || data?.users || 0,
-                  mean: data?.stats?.mean || 0,
-                  stddev: data?.stats?.stddev || 0,
-                  percentChange: data?.expected || 0,
-                  ciLow: data?.ci?.[0] ?? 0,
-                  ciHigh: data?.ci?.[1] ?? 0,
-                  pValue: data?.pValue || 0,
-                  risk: data?.risk?.[1] || 0,
-                  chanceToBeatControl: data?.chanceToWin || 0,
+                  numerator: safeFloat(data?.value),
+                  denominator: safeFloat(data?.denominator ?? data?.users),
+                  mean: safeFloat(data?.stats?.mean),
+                  stddev: safeFloat(data?.stats?.stddev),
+                  percentChange: safeFloat(data?.expected),
+                  ciLow: safeFloat(data?.ci?.[0]),
+                  ciHigh: safeFloat(data?.ci?.[1]),
+                  pValue: safeFloat(data?.pValue),
+                  risk: safeFloat(data?.risk?.[1]),
+                  chanceToBeatControl: safeFloat(data?.chanceToWin),
                 },
               ],
             };

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -2352,7 +2352,7 @@ export async function toExperimentApiInterface(
   return apiExperiment;
 }
 
-// Round to 10 decimal places to avoid returning subnormal floats (e.g. 2.7e-313)
+// Round to 20 decimal places to avoid returning subnormal floats (e.g. 2.7e-313)
 // that break many real-world JSON parsers.
 function safeFloat(n: number | undefined, fallback = 0): number {
   if (n == null || !isFinite(n)) return fallback;

--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -2352,13 +2352,11 @@ export async function toExperimentApiInterface(
   return apiExperiment;
 }
 
-// The smallest positive normal IEEE 754 double. Values below this magnitude
-// are subnormal and can break many real-world JSON parsers, so we flush them to 0.
-const SMALLEST_NORMAL_FLOAT = 2.2250738585072014e-308;
-
+// Round to 10 decimal places to avoid returning subnormal floats (e.g. 2.7e-313)
+// that break many real-world JSON parsers.
 function safeFloat(n: number | undefined, fallback = 0): number {
   if (n == null || !isFinite(n)) return fallback;
-  return Math.abs(n) < SMALLEST_NORMAL_FLOAT ? fallback : n;
+  return parseFloat(n.toFixed(10));
 }
 
 export function toSnapshotApiInterface(


### PR DESCRIPTION
### Features and Changes

The `GET /api/v1/experiments/:id/results` endpoint can return subnormal (denormalized) IEEE 754 floating-point values from the stats engine — for example, `"risk": 2.7569490816e-313`. These values are technically valid per the JSON spec but break many real-world JSON parsers used by API consumers.

This change introduces a `safeFloat` helper that sanitizes all numeric fields in the experiment results API response by rounding to 20 decimal places (`toFixed(20)`), which flushes subnormal values to `0` while preserving all practically meaningful precision. It also handles `null`, `undefined`, `NaN`, and `Infinity` defensively. The affected fields are: `numerator`, `denominator`, `mean`, `stddev`, `percentChange`, `ciLow`, `ciHigh`, `pValue`, `risk`, and `chanceToBeatControl`.

As a small correctness fix, the `denominator` fallback was changed from `||` (which would skip a valid `0` denominator) to `??` (nullish coalescing).

- Closes **(add link to issue here)**

### Dependencies

None

### Testing

- [x] Run the following to verify `safeFloat` behavior:
  ```bash
  node << 'EOF'
  const safeFloat = (n, fallback = 0) => {
    if (n == null || !isFinite(n)) return fallback;
    return parseFloat(n.toFixed(20));
  };
  console.log(safeFloat(2.7569490816e-313)); // 0  (subnormal flushed)
  console.log(safeFloat(0.5));               // 0.5
  console.log(safeFloat(1e-10));             // 1e-10 (preserved)
  console.log(safeFloat(1e-21));             // 0  (beyond 20 decimal places, flushed)
  console.log(safeFloat(NaN));               // 0
  console.log(safeFloat(Infinity));          // 0
  console.log(safeFloat(undefined));         // 0
  EOF
  ```
- [x] Call `GET /api/v1/experiments/:id/results` for an experiment with results and verify the numeric fields parse correctly
- [x] If possible, seed a local snapshot with a subnormal `risk` value (e.g. `2.7569490816e-313`) in MongoDB and confirm the API returns `0` for that field

### Screenshots

N/A — backend-only change, no UI impact