### PR TITLE
REST: clarify trackingKey param for listExperiments

### DIFF
--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -4875,6 +4875,7 @@ paths:
         - $ref: '#/components/parameters/offset'
         - $ref: '#/components/parameters/projectId'
         - $ref: '#/components/parameters/datasourceId'
+        - $ref: '#/components/parameters/trackingKey'
         - $ref: '#/components/parameters/experimentId'
         - name: status
           in: query
@@ -19786,12 +19787,28 @@ components:
       schema:
         description: Filter by Data Source
         type: string
+    trackingKey:
+      name: trackingKey
+      in: query
+      description: Filter by experiment tracking key
+      schema:
+        description: Filter by experiment tracking key
+        type: string
     experimentId:
       name: experimentId
       in: query
-      description: Filter the returned list by the experiment tracking key (id)
+      description: >-
+        Filter the returned list by the experiment tracking key (not the
+        internal experiment ID). Note, this was deprecated to help reduce
+        confusion, consider using `trackingKey` instead, which is functionally
+        identical. You cannot use both params at the same time.
       schema:
-        description: Filter the returned list by the experiment tracking key (id)
+        deprecated: true
+        description: >-
+          Filter the returned list by the experiment tracking key (not the
+          internal experiment ID). Note, this was deprecated to help reduce
+          confusion, consider using `trackingKey` instead, which is functionally
+          identical. You cannot use both params at the same time.
         type: string
     phase:
       name: phase

--- a/packages/back-end/src/api/experiments/listExperiments.ts
+++ b/packages/back-end/src/api/experiments/listExperiments.ts
@@ -14,13 +14,19 @@ import {
 export const listExperiments = createApiRequestHandler(
   listExperimentsValidator,
 )(async (req) => {
+  if (req.query.trackingKey && req.query.experimentId) {
+    throw new Error(
+      "Cannot use both trackingKey and experimentId query parameters. Use trackingKey instead.",
+    );
+  }
+
   // Filter and sort at the database level for better performance
   // Note: type is not specified, which defaults to excluding holdouts
   const experiments = await getAllExperiments(req.context, {
     includeArchived: true,
     project: req.query.projectId,
     datasourceId: req.query.datasourceId,
-    trackingKey: req.query.experimentId,
+    trackingKey: req.query.trackingKey ?? req.query.experimentId,
     status: req.query.status,
     sortBy: { dateCreated: 1 },
   });

--- a/packages/shared/src/validators/experiments.ts
+++ b/packages/shared/src/validators/experiments.ts
@@ -1282,12 +1282,18 @@ export const listExperimentsValidator = {
       ...paginationQueryFields,
       projectId: z.string().describe("Filter by project id").optional(),
       datasourceId: z.string().describe("Filter by Data Source").optional(),
+      trackingKey: z
+        .string()
+        .describe("Filter by experiment tracking key")
+        .optional(),
       experimentId: z
         .string()
         .describe(
-          "Filter the returned list by the experiment tracking key (id)",
+          "Filter the returned list by the experiment tracking key (not the internal experiment ID). Note, this was deprecated to help reduce confusion, consider using `trackingKey` instead, which is functionally identical. You cannot use both params at the same time.",
         )
-        .optional(),
+        .optional()
+        .meta({ deprecated: true }),
+
       status: z.enum(experimentStatus).optional(),
     })
     .strict(),


### PR DESCRIPTION
Deprecates `experimentId` and replaces it with the better named `trackingKey` param for `listExperiments` REST API endpoint.