### PR TITLE
Cleaner AI model defaulting for agents, product analytics normalization for dimension order

### DIFF
--- a/packages/back-end/src/enterprise/services/agent-handler.ts
+++ b/packages/back-end/src/enterprise/services/agent-handler.ts
@@ -167,27 +167,23 @@ export function createAgentHandler<TParams>(config: AgentConfig<TParams>) {
       config.agentType,
     );
 
-    const requestModel = body.model;
-    const canOverride = context.permissions.canManageOrgSettings();
     const storedModel = buffer.getModel() as AIModel | undefined;
 
-    // Pick the model override (if any). Anything that ends up `undefined`
-    // falls through to the org's `defaultAIModel` below — which on Cloud is
-    // the hardcoded model.
-    let overrideModel: AIModel | undefined;
-    if (IS_CLOUD) {
-      // Cloud: existing conversations keep their stored model; new ones
-      // (storedModel === undefined) fall through to the hardcoded default.
-      // `requestModel` and `dbOverrideModel` are deliberately ignored.
-      overrideModel = storedModel;
-    } else if (canOverride && requestModel) {
-      // Self-hosted: an admin's per-request choice wins over everything else.
-      overrideModel = requestModel;
-    } else {
-      // Self-hosted: stored model on the conversation, else org-level prompt
-      // default.
-      overrideModel = storedModel || dbOverrideModel;
-    }
+    // Resolve the model override. `undefined` falls through to the org's
+    // `defaultAIModel` below — which on Cloud is always the hardcoded model.
+    //
+    // Cloud: continued conversations keep their stored model; new ones fall
+    // through to the hardcoded default. `body.model` and `dbOverrideModel`
+    // are deliberately ignored — Cloud users cannot pick a model.
+    //
+    // Self-hosted: continued conversations keep their stored model; on the
+    // first turn we honor the user's per-request choice, else the org-level
+    // prompt override, else the org default. The model selector is disabled
+    // in the UI after the first turn, so `body.model` won't be set on
+    // follow-ups in normal usage.
+    const overrideModel: AIModel | undefined = IS_CLOUD
+      ? storedModel
+      : storedModel || body.model || dbOverrideModel;
 
     const { defaultAIModel } = getAISettingsForOrg(context, false);
     const resolvedModel = overrideModel || defaultAIModel;

--- a/packages/back-end/src/enterprise/services/agent-handler.ts
+++ b/packages/back-end/src/enterprise/services/agent-handler.ts
@@ -13,6 +13,7 @@ import {
   streamingChatCompletion,
   simpleCompletion,
 } from "back-end/src/enterprise/services/ai";
+import { IS_CLOUD } from "back-end/src/util/secrets";
 import {
   type ConversationBuffer,
   loadOrInitConversation,
@@ -168,13 +169,25 @@ export function createAgentHandler<TParams>(config: AgentConfig<TParams>) {
 
     const requestModel = body.model;
     const canOverride = context.permissions.canManageOrgSettings();
+    const storedModel = buffer.getModel() as AIModel | undefined;
 
-    // Resolution: request (permitted) → conversation stored → org prompt override
-    const overrideModel =
-      (canOverride && requestModel) ||
-      (buffer.getModel() as AIModel | undefined) ||
-      dbOverrideModel ||
-      undefined;
+    // Pick the model override (if any). Anything that ends up `undefined`
+    // falls through to the org's `defaultAIModel` below — which on Cloud is
+    // the hardcoded model.
+    let overrideModel: AIModel | undefined;
+    if (IS_CLOUD) {
+      // Cloud: existing conversations keep their stored model; new ones
+      // (storedModel === undefined) fall through to the hardcoded default.
+      // `requestModel` and `dbOverrideModel` are deliberately ignored.
+      overrideModel = storedModel;
+    } else if (canOverride && requestModel) {
+      // Self-hosted: an admin's per-request choice wins over everything else.
+      overrideModel = requestModel;
+    } else {
+      // Self-hosted: stored model on the conversation, else org-level prompt
+      // default.
+      overrideModel = storedModel || dbOverrideModel;
+    }
 
     const { defaultAIModel } = getAISettingsForOrg(context, false);
     const resolvedModel = overrideModel || defaultAIModel;

--- a/packages/back-end/src/enterprise/services/product-analytics-agent.ts
+++ b/packages/back-end/src/enterprise/services/product-analytics-agent.ts
@@ -651,6 +651,15 @@ function normalizeConfigForExplorer(
     }
   }
 
+  const dateIdx = dims.findIndex((d) => d.dimensionType === "date");
+  if (dateIdx > 0) {
+    const dateDim = dims[dateIdx];
+    dims = [dateDim, ...dims.filter((_, i) => i !== dateIdx)];
+    warnings.push(
+      "Moved date dimension to the first position. Date dimensions must come before breakdown dimensions.",
+    );
+  }
+
   // bigNumber: no dimensions, single value
   if (config.chartType === "bigNumber") {
     if (dims.length > 0) {


### PR DESCRIPTION
### Features and Changes

- Changed how models are resolved for cloud vs self hosted:
  - Cloud: always uses hardcoded default unless existing conversation has a model
  - Self hosted: existing conversation model > per-conversation override > org default > hard coded default 

- Dimension normalization for product analytics agent
  - If there is a date dimension it should always be first 



