### PR TITLE
Updates canSubscribe logic

### DIFF
--- a/packages/front-end/services/UserContext.tsx
+++ b/packages/front-end/services/UserContext.tsx
@@ -479,33 +479,33 @@ export function UserContextProvider({ children }: { children: ReactNode }) {
   const license = currentOrg?.license;
 
   const canSubscribe = useMemo(() => {
-    const disableSelfServeBilling =
-      organization?.disableSelfServeBilling || false;
+    const effectiveAccountPlan = currentOrg?.effectiveAccountPlan;
+    const subscriptionStatus =
+      license?.stripeSubscription?.status ||
+      license?.orbSubscription?.status ||
+      "";
 
-    const hasValidEnterprisePlan =
-      currentOrg?.effectiveAccountPlan === "enterprise";
-
-    if (hasValidEnterprisePlan) {
-      if (disableSelfServeBilling) return false;
+    if (effectiveAccountPlan === "enterprise") {
+      // There are some edge cases where enterprise plans don't have a subscription/status
+      // so we return false to be safe
       return false;
     }
 
-    // if already on pro, they must have a subscription - some self-hosted pro have an annual contract not directly through stripe.
-    if (
-      ["pro", "pro_sso"].includes(currentOrg?.effectiveAccountPlan || "") &&
-      !subscription?.externalId
-    )
-      return false;
-
-    if (["active", "trialing", "past_due"].includes(subscription?.status || ""))
-      return false;
+    if (["pro", "pro_sso"].includes(effectiveAccountPlan || "")) {
+      if (
+        ["active", "trialing", "past_due", "paused", "unpaid"].includes(
+          subscriptionStatus,
+        )
+      ) {
+        return false;
+      }
+    }
 
     return true;
   }, [
-    organization?.disableSelfServeBilling,
     currentOrg?.effectiveAccountPlan,
-    subscription?.externalId,
-    subscription?.status,
+    license?.orbSubscription?.status,
+    license?.stripeSubscription?.status,
   ]);
 
   return (

--- a/packages/front-end/services/UserContext.tsx
+++ b/packages/front-end/services/UserContext.tsx
@@ -482,16 +482,17 @@ export function UserContextProvider({ children }: { children: ReactNode }) {
     const disableSelfServeBilling =
       organization?.disableSelfServeBilling || false;
 
-    if (disableSelfServeBilling) return false;
+    const hasValidEnterprisePlan =
+      currentOrg?.effectiveAccountPlan === "enterprise";
 
-    if (organization?.enterprise) return false; //TODO: Remove this once we have moved the license off the organization
-
-    if (license?.plan === "enterprise") return false;
+    if (hasValidEnterprisePlan) {
+      if (disableSelfServeBilling) return false;
+      return false;
+    }
 
     // if already on pro, they must have a subscription - some self-hosted pro have an annual contract not directly through stripe.
     if (
-      license &&
-      ["pro", "pro_sso"].includes(license.plan || "") &&
+      ["pro", "pro_sso"].includes(currentOrg?.effectiveAccountPlan || "") &&
       !subscription?.externalId
     )
       return false;
@@ -500,7 +501,12 @@ export function UserContextProvider({ children }: { children: ReactNode }) {
       return false;
 
     return true;
-  }, [organization, license, subscription]);
+  }, [
+    organization?.disableSelfServeBilling,
+    currentOrg?.effectiveAccountPlan,
+    subscription?.externalId,
+    subscription?.status,
+  ]);
 
   return (
     <UserContext.Provider

--- a/packages/front-end/services/UserContext.tsx
+++ b/packages/front-end/services/UserContext.tsx
@@ -492,13 +492,7 @@ export function UserContextProvider({ children }: { children: ReactNode }) {
     }
 
     if (["pro", "pro_sso"].includes(effectiveAccountPlan || "")) {
-      if (
-        ["active", "trialing", "past_due", "paused", "unpaid"].includes(
-          subscriptionStatus,
-        )
-      ) {
-        return false;
-      }
+      if (subscriptionStatus !== "canceled") return false;
     }
 
     return true;

--- a/packages/front-end/services/UserContext.tsx
+++ b/packages/front-end/services/UserContext.tsx
@@ -483,6 +483,7 @@ export function UserContextProvider({ children }: { children: ReactNode }) {
     const subscriptionStatus =
       license?.stripeSubscription?.status ||
       license?.orbSubscription?.status ||
+      subscription?.status ||
       "";
 
     if (effectiveAccountPlan === "enterprise") {
@@ -500,6 +501,7 @@ export function UserContextProvider({ children }: { children: ReactNode }) {
     currentOrg?.effectiveAccountPlan,
     license?.orbSubscription?.status,
     license?.stripeSubscription?.status,
+    subscription?.status,
   ]);
 
   return (


### PR DESCRIPTION
### Features and Changes

This PR simplifies the logic for the `canSubscribe` variable to reflect the changes we've made to how licenses/subscriptions are managed.

Now, we get the org's effective account plan, and we block an org's ability to upgrade if their plan is `enterprise`, or if they have a `pro` or `pro_sso` plan and their status isn't `cancelled`.

Previously, we were using some older objects to identify this - now, we're getting it entirely from the license.
