### PR TITLE
Adding tracking for product analytics explorer

### DIFF
--- a/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardEditorSidebar/ProductAnalyticsExplorerSettings.tsx
+++ b/packages/front-end/enterprise/components/Dashboards/DashboardEditor/DashboardEditorSidebar/ProductAnalyticsExplorerSettings.tsx
@@ -62,6 +62,7 @@ export default function ProductAnalyticsExplorerSettings({
     <ExplorerProvider
       initialConfig={initialConfig}
       hasExistingResults={!!block.explorerAnalysisId}
+      trackingSource="dashboard-editor"
       onRunComplete={(exploration) => {
         setBlock({
           ...block,

--- a/packages/front-end/enterprise/components/ProductAnalytics/Explorer.tsx
+++ b/packages/front-end/enterprise/components/ProductAnalytics/Explorer.tsx
@@ -183,7 +183,11 @@ function ExplorerInner({ type }: { type: DatasetType }) {
           </AlertDialog.Content>
         </AlertDialog.Root>
       )}
-      <ExplorerProvider key={type} initialConfig={initialConfig}>
+      <ExplorerProvider
+        key={type}
+        initialConfig={initialConfig}
+        trackingSource="manual-explorer"
+      >
         <ExplorerUrlSync setUrlConfig={setUrlConfig} />
         <ExplorerContent />
       </ExplorerProvider>

--- a/packages/front-end/enterprise/components/ProductAnalytics/ExplorerContext.tsx
+++ b/packages/front-end/enterprise/components/ProductAnalytics/ExplorerContext.tsx
@@ -30,7 +30,10 @@ import {
   validateDimensions,
 } from "@/enterprise/components/ProductAnalytics/util";
 import { useLocalStorage } from "@/hooks/useLocalStorage";
+import track from "@/services/track";
 import { useExploreData, CacheOption } from "./useExploreData";
+
+const MAX_TRACKED_ERROR_LENGTH = 500;
 
 type SetDraftStateAction =
   | ExplorationConfig
@@ -49,6 +52,7 @@ export interface ExplorerContextValue {
   needsFetch: boolean;
   needsUpdate: boolean;
   isSubmittable: boolean;
+  trackingSource: string | undefined;
 
   // ─── Modifiers ─────────────────────────────────────────────────────────
   setDraftExploreState: (action: SetDraftStateAction) => void;
@@ -89,6 +93,7 @@ interface ExplorerProviderProps {
   initialConfig: ExplorationConfig;
   hasExistingResults?: boolean;
   onRunComplete?: (exploration: ProductAnalyticsExploration) => void;
+  trackingSource?: string;
 }
 
 export function ExplorerProvider({
@@ -96,6 +101,7 @@ export function ExplorerProvider({
   initialConfig,
   hasExistingResults = false,
   onRunComplete,
+  trackingSource,
 }: ExplorerProviderProps) {
   const { loading, fetchData } = useExploreData();
   const { getFactTableById, getFactMetricById, datasources } = useDefinitions();
@@ -255,12 +261,14 @@ export function ExplorerProvider({
       hasEverFetchedRef.current = true;
       const requestId = ++submitRequestIdRef.current;
 
+      const startTime = Date.now();
       // Do the fetch (we keep previous exploration/submitted state visible until result arrives)
       const {
         data: fetchResult,
         query,
         error: fetchError,
       } = await fetchData(configToSubmit, { cache });
+      const durationMs = Date.now() - startTime;
 
       // Ignore out-of-order responses from older in-flight requests.
       if (requestId !== submitRequestIdRef.current) return;
@@ -290,6 +298,34 @@ export function ExplorerProvider({
         error: fetchError || fetchResult?.error || null,
       }));
       if (fetchResult) onRunComplete?.(fetchResult);
+
+      if (trackingSource) {
+        const datasourceType =
+          datasources.find((d) => d.id === configToSubmit.datasource)?.type ??
+          null;
+        const errorMessage = fetchError || fetchResult?.error || null;
+        const baseProps = {
+          source: trackingSource,
+          type: configToSubmit.type,
+          chart_type: configToSubmit.chartType,
+          datasource_type: datasourceType,
+          duration_ms: durationMs,
+          cache,
+          num_values: configToSubmit.dataset?.values?.length ?? 0,
+          num_dimensions: configToSubmit.dimensions?.length ?? 0,
+        };
+        if (errorMessage) {
+          track("Product Analytics Explorer: Refresh Failure", {
+            ...baseProps,
+            error_message: errorMessage.slice(0, MAX_TRACKED_ERROR_LENGTH),
+          });
+        } else if (fetchResult) {
+          track("Product Analytics Explorer: Refresh Success", {
+            ...baseProps,
+            row_count: fetchResult.result?.rows?.length ?? 0,
+          });
+        }
+      }
     },
     [
       draftExploreState,
@@ -297,6 +333,8 @@ export function ExplorerProvider({
       fetchData,
       onRunComplete,
       isManagedWarehouse,
+      trackingSource,
+      datasources,
     ],
   );
 
@@ -438,6 +476,14 @@ export function ExplorerProvider({
 
   const changeChartType = useCallback(
     (chartType: ExplorationConfig["chartType"]) => {
+      if (trackingSource && draftExploreState.chartType !== chartType) {
+        track("Product Analytics Explorer: Chart Type Changed", {
+          source: trackingSource,
+          type: draftExploreState.type,
+          from_chart_type: draftExploreState.chartType,
+          to_chart_type: chartType,
+        });
+      }
       setDraftExploreState((prev) => {
         let dimensions = prev.dimensions;
         let dataset = prev.dataset;
@@ -475,7 +521,12 @@ export function ExplorerProvider({
         return { ...prev, chartType, dimensions, dataset } as ExplorationConfig;
       });
     },
-    [setDraftExploreState],
+    [
+      setDraftExploreState,
+      trackingSource,
+      draftExploreState.chartType,
+      draftExploreState.type,
+    ],
   );
 
   const clearAllDatasets = useCallback(
@@ -484,6 +535,23 @@ export function ExplorerProvider({
       setIsStale(false);
       if (datasourceId) {
         setDefaultDataSourceId(datasourceId);
+      }
+
+      if (
+        trackingSource &&
+        newDatasourceId &&
+        newDatasourceId !== draftExploreState.datasource
+      ) {
+        const fromDs = datasources.find(
+          (d) => d.id === draftExploreState.datasource,
+        );
+        const toDs = datasources.find((d) => d.id === newDatasourceId);
+        track("Product Analytics Explorer: Datasource Changed", {
+          source: trackingSource,
+          type: draftExploreState.type,
+          from_datasource_type: fromDs?.type ?? null,
+          to_datasource_type: toDs?.type ?? null,
+        });
       }
 
       setExplorerState((prev) => {
@@ -504,7 +572,15 @@ export function ExplorerProvider({
         };
       });
     },
-    [createDefaultValue, datasources, initialConfig, setDefaultDataSourceId],
+    [
+      createDefaultValue,
+      datasources,
+      initialConfig,
+      setDefaultDataSourceId,
+      trackingSource,
+      draftExploreState.datasource,
+      draftExploreState.type,
+    ],
   );
 
   const value = useMemo<ExplorerContextValue>(
@@ -528,6 +604,7 @@ export function ExplorerProvider({
       isSubmittable,
       clearAllDatasets,
       query,
+      trackingSource,
     }),
     [
       draftExploreState,
@@ -549,6 +626,7 @@ export function ExplorerProvider({
       isSubmittable,
       clearAllDatasets,
       query,
+      trackingSource,
     ],
   );
 

--- a/packages/front-end/enterprise/components/ProductAnalytics/ExplorerContext.tsx
+++ b/packages/front-end/enterprise/components/ProductAnalytics/ExplorerContext.tsx
@@ -104,7 +104,12 @@ export function ExplorerProvider({
   trackingSource,
 }: ExplorerProviderProps) {
   const { loading, fetchData } = useExploreData();
-  const { getFactTableById, getFactMetricById, datasources } = useDefinitions();
+  const {
+    getFactTableById,
+    getFactMetricById,
+    datasources,
+    getDatasourceById,
+  } = useDefinitions();
 
   const [, setDefaultDataSourceId] = useLocalStorage<string>(
     LOCALSTORAGE_EXPLORER_DATASOURCE_KEY,
@@ -201,11 +206,9 @@ export function ExplorerProvider({
 
   const isManagedWarehouse = useMemo(() => {
     if (!draftExploreState.datasource) return false;
-    const datasource = datasources.find(
-      (d) => d.id === draftExploreState.datasource,
-    );
+    const datasource = getDatasourceById(draftExploreState.datasource);
     return datasource?.type === "growthbook_clickhouse";
-  }, [datasources, draftExploreState.datasource]);
+  }, [getDatasourceById, draftExploreState.datasource]);
 
   const setSubmittedExploreState = useCallback((state: ExplorationConfig) => {
     setExplorerState((prev) => ({
@@ -301,8 +304,7 @@ export function ExplorerProvider({
 
       if (trackingSource) {
         const datasourceType =
-          datasources.find((d) => d.id === configToSubmit.datasource)?.type ??
-          null;
+          getDatasourceById(configToSubmit.datasource)?.type ?? null;
         const errorMessage = fetchError || fetchResult?.error || null;
         const baseProps = {
           source: trackingSource,
@@ -334,7 +336,7 @@ export function ExplorerProvider({
       onRunComplete,
       isManagedWarehouse,
       trackingSource,
-      datasources,
+      getDatasourceById,
     ],
   );
 
@@ -542,10 +544,8 @@ export function ExplorerProvider({
         newDatasourceId &&
         newDatasourceId !== draftExploreState.datasource
       ) {
-        const fromDs = datasources.find(
-          (d) => d.id === draftExploreState.datasource,
-        );
-        const toDs = datasources.find((d) => d.id === newDatasourceId);
+        const fromDs = getDatasourceById(draftExploreState.datasource);
+        const toDs = getDatasourceById(newDatasourceId);
         track("Product Analytics Explorer: Datasource Changed", {
           source: trackingSource,
           type: draftExploreState.type,
@@ -575,6 +575,7 @@ export function ExplorerProvider({
     [
       createDefaultValue,
       datasources,
+      getDatasourceById,
       initialConfig,
       setDefaultDataSourceId,
       trackingSource,

--- a/packages/front-end/enterprise/components/ProductAnalytics/SaveToDashboardModal.tsx
+++ b/packages/front-end/enterprise/components/ProductAnalytics/SaveToDashboardModal.tsx
@@ -34,6 +34,7 @@ import {
 } from "@/enterprise/components/Dashboards/DashboardModal";
 import { useCronValidation } from "@/enterprise/components/Dashboards/useCronValidation";
 import DashboardUpdateScheduleSelector from "@/enterprise/components/Dashboards/DashboardUpdateScheduleSelector";
+import track from "@/services/track";
 
 function datasetTypeToBlockType(
   type: "metric" | "fact_table" | "data_source",
@@ -52,12 +53,14 @@ interface Props {
   close: () => void;
   config: ExplorationConfig;
   exploration: ProductAnalyticsExploration | null;
+  trackingSource?: string;
 }
 
 export default function SaveToDashboardModal({
   close,
   config,
   exploration,
+  trackingSource,
 }: Props) {
   const router = useRouter();
   const { dashboards, dashboardsMap, mutateDashboards } = useDashboards(false);
@@ -154,6 +157,16 @@ export default function SaveToDashboardModal({
     }
 
     mutateDashboards();
+
+    if (trackingSource) {
+      track("Product Analytics Explorer: Saved To Dashboard", {
+        source: trackingSource,
+        type: config.type,
+        chart_type: config.chartType,
+        target: createOrAdd === "new" ? "new-dashboard" : "existing-dashboard",
+      });
+    }
+
     router.push(`/product-analytics/dashboards/${dashboardId}`);
   };
 

--- a/packages/front-end/enterprise/components/ProductAnalytics/SideBar/ExplorerSideBar.tsx
+++ b/packages/front-end/enterprise/components/ProductAnalytics/SideBar/ExplorerSideBar.tsx
@@ -26,6 +26,7 @@ import {
 } from "@/enterprise/components/ProductAnalytics/util";
 import SaveToDashboardModal from "@/enterprise/components/ProductAnalytics/SaveToDashboardModal";
 import UpgradeModal from "@/components/Settings/UpgradeModal";
+import track from "@/services/track";
 import MetricTabContent from "./MetricTabContent";
 import FactTableTabContent from "./FactTableTabContent";
 import DatasourceTabContent from "./DatasourceTabContent";
@@ -52,6 +53,7 @@ export default function ExplorerSideBar({
     isSubmittable,
     isStale,
     error,
+    trackingSource,
   } = useExplorerContext();
   const { factTables, getFactMetricById, project } = useDefinitions();
   const { hasCommercialFeature, permissionsUtil } = useUser();
@@ -96,6 +98,7 @@ export default function ExplorerSideBar({
           close={() => setShowSaveToDashboardModal(false)}
           config={draftExploreState}
           exploration={exploration}
+          trackingSource={trackingSource}
         />
       )}
       {showUpgradeModal && (
@@ -151,6 +154,17 @@ export default function ExplorerSideBar({
               }
               side="bottom"
               align="end"
+              onCopy={
+                trackingSource
+                  ? () => {
+                      track("Product Analytics Explorer: Copy Link Clicked", {
+                        source: trackingSource,
+                        type: draftExploreState.type,
+                        chart_type: draftExploreState.chartType,
+                      });
+                    }
+                  : undefined
+              }
             />
           </>
         ) : (

--- a/packages/front-end/ui/ShareUrlPopover.tsx
+++ b/packages/front-end/ui/ShareUrlPopover.tsx
@@ -15,6 +15,7 @@ interface ShareUrlPopoverProps {
   description?: string;
   side?: "top" | "right" | "bottom" | "left";
   align?: "start" | "center" | "end";
+  onCopy?: (url: string) => void;
 }
 
 export default function ShareUrlPopover({
@@ -24,6 +25,7 @@ export default function ShareUrlPopover({
   description,
   side = "bottom",
   align = "center",
+  onCopy,
 }: ShareUrlPopoverProps) {
   const shareUrl =
     url ?? (typeof window !== "undefined" ? window.location.href : "");
@@ -61,7 +63,10 @@ export default function ShareUrlPopover({
               color="violet"
               size="md"
               icon={copySuccess ? <PiCheck /> : <PiCopy />}
-              onClick={() => performCopy(shareUrl)}
+              onClick={() => {
+                performCopy(shareUrl);
+                onCopy?.(shareUrl);
+              }}
             >
               {copySuccess ? "Copied!" : "Copy link"}
             </Button>


### PR DESCRIPTION
### Features and Changes

Adds anonymous usage tracking to the Product Analytics Explorer (both the standalone Manual Explorer and the Dashboard Editor block) so we can analyze how the feature is used.

- Added a `trackingSource` prop to the explorer context to track where the event is coming from:
- `manual-explorer` — `/product-analytics/explore/*` pages
- `dashboard-editor` — editing a Product Analytics block inside a dashboard

NOTE: AI Analyst has different tracking since it does querying on the backend. We can instrument it more separately. 


All events are prefixed `Product Analytics Explorer:` and include `source` + explorer `type`:

- `Refresh Success` — `row_count`, `duration_ms`, `chart_type`, `datasource_type`, `cache`
- `Refresh Failure` — `error_message`, `duration_ms`, `chart_type`, `datasource_type`, `cache`
- `Chart Type Changed` — `from_chart_type`, `to_chart_type`
- `Datasource Changed` — `from_datasource_type`, `to_datasource_type`
- `Saved To Dashboard` — `chart_type`, `target` (manual-explorer only)
- `Copy Link Clicked` — `chart_type` (manual-explorer only)

