### PR TITLE
fix(ids): use uuidv7 for BaseModel and QueryModel id generation

### DIFF
--- a/packages/back-end/jest.config.js
+++ b/packages/back-end/jest.config.js
@@ -1,8 +1,10 @@
 module.exports = {
   moduleFileExtensions: ["ts", "js", "node", "json"],
   transform: {
-    "^.+\\.(ts|tsx)$": "@swc/jest",
+    "^.+\\.(ts|tsx|js|mjs)$": "@swc/jest",
   },
+  // uuid@14+ ships ESM-only. Let swc transpile it for the Jest CJS runtime.
+  transformIgnorePatterns: ["node_modules/(?!\\.pnpm/uuid@|uuid/)"],
   testMatch: ["**/test/**/*.test.(ts|js)"],
   moduleNameMapper: {
     "^axios$": "axios/dist/axios.js",

--- a/packages/back-end/package.json
+++ b/packages/back-end/package.json
@@ -169,7 +169,6 @@
     "@types/sql-formatter": "^2.3.0",
     "@types/thrift": "^0.10.11",
     "@types/uniqid": "^5.2.0",
-    "@types/uuid": "^9.0.2",
     "chokidar": "^3.5.3",
     "cross-env": "^7.0.3",
     "delay-cli": "^2.0.0",

--- a/packages/back-end/package.json
+++ b/packages/back-end/package.json
@@ -130,7 +130,7 @@
     "stripe": "^17.4.0",
     "tiktoken": "1.0.21",
     "uniqid": "^5.3.0",
-    "uuid": "^9.0.0",
+    "uuid": "^14.0.0",
     "zod": "^4.1.12"
   },
   "devDependencies": {

--- a/packages/back-end/src/models/BaseModel.ts
+++ b/packages/back-end/src/models/BaseModel.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 import { v4 as uuidv4 } from "uuid";
-import uniqid from "uniqid";
 import mongoose, { FilterQuery } from "mongoose";
 import { AnyBulkWriteOperation, Collection } from "mongodb";
 import omit from "lodash/omit";
@@ -32,6 +31,7 @@ import {
 } from "back-end/src/api/ApiModel";
 import { CrudAction } from "back-end/src/api/apiModelHandlers";
 import { dbSafeBulkWrite } from "back-end/src/util/mongo.util";
+import { generateId } from "back-end/src/util/uuid";
 import {
   resolveOwnerEmail,
   resolveOwnerEmails,
@@ -616,7 +616,7 @@ export abstract class BaseModel<
    * Internal methods that can be used by subclasses
    ***************/
   protected _generateId() {
-    return uniqid(this.config.idPrefix);
+    return generateId(this.config.idPrefix);
   }
   protected _generateUid() {
     return uuidv4().replace(/-/g, "");

--- a/packages/back-end/src/models/QueryModel.ts
+++ b/packages/back-end/src/models/QueryModel.ts
@@ -1,10 +1,10 @@
 import mongoose from "mongoose";
 import { omit } from "lodash";
-import uniqid from "uniqid";
 import { QueryInterface, QueryType } from "shared/types/query";
 import { QueryLanguage } from "shared/types/datasource";
 import { ApiQuery } from "shared/validators";
 import { QUERY_CACHE_TTL_MINS } from "back-end/src/util/secrets";
+import { generateId } from "back-end/src/util/uuid";
 import type { ReqContext } from "back-end/types/request";
 import type { ApiReqContext } from "back-end/types/api";
 
@@ -297,7 +297,7 @@ export async function createNewQuery({
     createdAt: new Date(),
     datasource,
     heartbeat: new Date(),
-    id: uniqid("qry_"),
+    id: generateId("qry_"),
     language,
     organization,
     query,
@@ -325,7 +325,7 @@ export async function createNewQueryFromCached({
     createdAt: new Date(),
     datasource: existing.datasource,
     heartbeat: new Date(),
-    id: uniqid("qry_"),
+    id: generateId("qry_"),
     displayTitle: existing.displayTitle,
     language: existing.language,
     organization: existing.organization,

--- a/packages/back-end/src/util/uuid.ts
+++ b/packages/back-end/src/util/uuid.ts
@@ -1,36 +1,20 @@
 import { parse as uuidParse, v7 as uuidv7 } from "uuid";
+import bs58 from "bs58";
 
-const BASE58_ALPHABET =
-  "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
-// 16 bytes (UUIDv7) base58-encode to at most ⌈log₅₈(2¹²⁸)⌉ = 22 chars.
-// Pad shorter encodings with the base58 zero-digit so width is stable.
 const BASE58_WIDTH = 22;
 
 /**
- * Generate an opaque, sortable resource id. Drop-in replacement for
- * `uniqid(prefix)`.
+ * Generate a sortable, opaque, resource id.
+ *
+ * Replaces uniqid(prefix), with lower chances of collision
+ *
+ * uuid is prefixed by '2' to differentiate from uniqid(prefix)
+ * and is base58 to reduce the length of the id
  *
  * Format: `prefix + "2" + base58(uuidv7)` — e.g. `qry_21CaYDxMweieUAr1YaiBC2d`.
- *
- * - **uuidv7** keeps the unix-ms timestamp at the front, so lexicographic
- *   id sort tracks creation time.
- * - **base58** packs all 128 bits into 22 chars without losing entropy
- *   (vs. truncated hex which sacrifices random bits for length).
- * - **The literal `"2"` prefix** keeps new ids sorting after legacy
- *   `uniqid`-generated ids, which all start with `"1"` (uniqid encodes
- *   address+pid+time in base36, and the leading address byte was always
- *   in the `1xx` range). Sort order across the migration stays intact.
  */
 export function generateId(prefix = ""): string {
-  const bytes = uuidParse(uuidv7());
-  let n = 0n;
-  for (const b of bytes) {
-    n = (n << 8n) | BigInt(b);
-  }
-  let suffix = "";
-  while (n > 0n) {
-    suffix = BASE58_ALPHABET[Number(n % 58n)] + suffix;
-    n = n / 58n;
-  }
-  return prefix + "2" + suffix.padStart(BASE58_WIDTH, BASE58_ALPHABET[0]);
+  return (
+    prefix + "2" + bs58.encode(uuidParse(uuidv7())).padStart(BASE58_WIDTH, "1")
+  );
 }

--- a/packages/back-end/src/util/uuid.ts
+++ b/packages/back-end/src/util/uuid.ts
@@ -1,0 +1,36 @@
+import { parse as uuidParse, v7 as uuidv7 } from "uuid";
+
+const BASE58_ALPHABET =
+  "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+// 16 bytes (UUIDv7) base58-encode to at most ⌈log₅₈(2¹²⁸)⌉ = 22 chars.
+// Pad shorter encodings with the base58 zero-digit so width is stable.
+const BASE58_WIDTH = 22;
+
+/**
+ * Generate an opaque, sortable resource id. Drop-in replacement for
+ * `uniqid(prefix)`.
+ *
+ * Format: `prefix + "2" + base58(uuidv7)` — e.g. `qry_21CaYDxMweieUAr1YaiBC2d`.
+ *
+ * - **uuidv7** keeps the unix-ms timestamp at the front, so lexicographic
+ *   id sort tracks creation time.
+ * - **base58** packs all 128 bits into 22 chars without losing entropy
+ *   (vs. truncated hex which sacrifices random bits for length).
+ * - **The literal `"2"` prefix** keeps new ids sorting after legacy
+ *   `uniqid`-generated ids, which all start with `"1"` (uniqid encodes
+ *   address+pid+time in base36, and the leading address byte was always
+ *   in the `1xx` range). Sort order across the migration stays intact.
+ */
+export function generateId(prefix = ""): string {
+  const bytes = uuidParse(uuidv7());
+  let n = 0n;
+  for (const b of bytes) {
+    n = (n << 8n) | BigInt(b);
+  }
+  let suffix = "";
+  while (n > 0n) {
+    suffix = BASE58_ALPHABET[Number(n % 58n)] + suffix;
+    n = n / 58n;
+  }
+  return prefix + "2" + suffix.padStart(BASE58_WIDTH, BASE58_ALPHABET[0]);
+}

--- a/packages/back-end/src/util/uuid.ts
+++ b/packages/back-end/src/util/uuid.ts
@@ -1,8 +1,6 @@
 import { parse as uuidParse, v7 as uuidv7 } from "uuid";
 import bs58 from "bs58";
 
-const BASE58_WIDTH = 22;
-
 /**
  * Generate a sortable, opaque, resource id.
  *
@@ -11,10 +9,8 @@ const BASE58_WIDTH = 22;
  * uuid is prefixed by '2' to differentiate from uniqid(prefix)
  * and is base58 to reduce the length of the id
  *
- * Format: `prefix + "2" + base58(uuidv7)` — e.g. `qry_21CaYDxMweieUAr1YaiBC2d`.
+ * Format: `prefix + "2" + base58(uuidv7)` — e.g. `qry_2CaYDxMweieUAr1YaiBC2d`.
  */
 export function generateId(prefix = ""): string {
-  return (
-    prefix + "2" + bs58.encode(uuidParse(uuidv7())).padStart(BASE58_WIDTH, "1")
-  );
+  return prefix + "2" + bs58.encode(uuidParse(uuidv7()));
 }

--- a/packages/back-end/test/jest.setup.ts
+++ b/packages/back-end/test/jest.setup.ts
@@ -1,6 +1,12 @@
 // Polyfill web streams for Node.js test environment
 import { TransformStream } from "node:stream/web";
+import { webcrypto } from "node:crypto";
 global.TransformStream = TransformStream as typeof globalThis.TransformStream;
+// uuid@14 expects `crypto` to be a global; Jest's VM context doesn't
+// expose Node 20+'s built-in `globalThis.crypto` by default.
+if (!globalThis.crypto) {
+  globalThis.crypto = webcrypto as unknown as Crypto;
+}
 
 // Mock snowflake-sdk to prevent open handles from CustomGC
 jest.mock("snowflake-sdk", () => ({

--- a/packages/back-end/test/jest.setup.ts
+++ b/packages/back-end/test/jest.setup.ts
@@ -1,7 +1,9 @@
 // Polyfill web streams for Node.js test environment
 import { TransformStream } from "node:stream/web";
 import { webcrypto } from "node:crypto";
+
 global.TransformStream = TransformStream as typeof globalThis.TransformStream;
+
 // uuid@14 expects `crypto` to be a global; Jest's VM context doesn't
 // expose Node 20+'s built-in `globalThis.crypto` by default.
 if (!globalThis.crypto) {

--- a/packages/back-end/test/util/uuid.test.ts
+++ b/packages/back-end/test/util/uuid.test.ts
@@ -1,18 +1,17 @@
 import { generateId } from "back-end/src/util/uuid";
 
 describe("generateId", () => {
-  it("returns prefix + literal '2' + 22-char base58 suffix", () => {
+  it("returns prefix + literal '2' + base58 suffix", () => {
     const id = generateId("foo_");
     expect(id).toMatch(
-      /^foo_2[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{22}$/,
+      /^foo_2[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{21}$/,
     );
-    expect(id.length).toBe("foo_".length + 1 + 22);
   });
 
   it("works with no prefix", () => {
     const id = generateId();
     expect(id).toMatch(
-      /^2[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{22}$/,
+      /^2[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{21}$/,
     );
   });
 

--- a/packages/back-end/test/util/uuid.test.ts
+++ b/packages/back-end/test/util/uuid.test.ts
@@ -1,0 +1,39 @@
+import { generateId } from "back-end/src/util/uuid";
+
+describe("generateId", () => {
+  it("returns prefix + literal '2' + 22-char base58 suffix", () => {
+    const id = generateId("foo_");
+    expect(id).toMatch(
+      /^foo_2[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{22}$/,
+    );
+    expect(id.length).toBe("foo_".length + 1 + 22);
+  });
+
+  it("works with no prefix", () => {
+    const id = generateId();
+    expect(id).toMatch(
+      /^2[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{22}$/,
+    );
+  });
+
+  it("produces unique ids across rapid successive calls", () => {
+    const ids = new Set<string>();
+    for (let i = 0; i < 1000; i++) ids.add(generateId("x_"));
+    expect(ids.size).toBe(1000);
+  });
+
+  it("sorts after legacy uniqid-style ids that start with '1'", () => {
+    // uniqid encodes address+pid+time in base36 with a leading '1...' suffix.
+    const legacy = "qry_19g6nmoipsmha";
+    const fresh = generateId("qry_");
+    expect([legacy, fresh].sort()).toEqual([legacy, fresh]);
+  });
+
+  it("is lexicographically time-ordered between successive calls", async () => {
+    const first = generateId("x_");
+    // Sleep just over 1ms to bump uuidv7's timestamp portion.
+    await new Promise((r) => setTimeout(r, 2));
+    const second = generateId("x_");
+    expect(first < second).toBe(true);
+  });
+});

--- a/packages/front-end/package.json
+++ b/packages/front-end/package.json
@@ -109,7 +109,7 @@
     "styled-jsx": "5.1.6",
     "swr": "^2.2.5",
     "uniqid": "^5.3.0",
-    "uuid": "^14.0.0",
+    "uuid": "^9.0.0",
     "zod": "^4.1.12"
   },
   "devDependencies": {

--- a/packages/front-end/package.json
+++ b/packages/front-end/package.json
@@ -109,7 +109,7 @@
     "styled-jsx": "5.1.6",
     "swr": "^2.2.5",
     "uniqid": "^5.3.0",
-    "uuid": "^9.0.0",
+    "uuid": "^14.0.0",
     "zod": "^4.1.12"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -557,9 +557,6 @@ importers:
       '@types/uniqid':
         specifier: ^5.2.0
         version: 5.3.0
-      '@types/uuid':
-        specifier: ^9.0.2
-        version: 9.0.2
       '@typescript/native-preview':
         specifier: 7.0.0-dev.20260309.1
         version: 7.0.0-dev.20260309.1
@@ -6358,9 +6355,6 @@ packages:
 
   '@types/unist@3.0.0':
     resolution: {integrity: sha512-MFETx3tbTjE7Uk6vvnWINA/1iJ7LuMdO4fcq8UfF0pRbj01aGLduVvQcRyswuACJdpnHgg8E3rQLhaRdNEJS0w==}
-
-  '@types/uuid@9.0.2':
-    resolution: {integrity: sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ==}
 
   '@types/webidl-conversions@6.1.1':
     resolution: {integrity: sha512-XAahCdThVuCFDQLT7R7Pk/vqeObFNL3YqRyFZg+AqAP/W1/w3xHaIxuW7WszQqTbIBOPRcItYJIou3i/mppu3Q==}
@@ -20408,8 +20402,6 @@ snapshots:
   '@types/uniqid@5.3.0': {}
 
   '@types/unist@3.0.0': {}
-
-  '@types/uuid@9.0.2': {}
 
   '@types/webidl-conversions@6.1.1': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -901,8 +901,8 @@ importers:
         specifier: ^5.3.0
         version: 5.4.0
       uuid:
-        specifier: ^14.0.0
-        version: 14.0.0
+        specifier: ^9.0.0
+        version: 9.0.1
       zod:
         specifier: ^4.1.12
         version: 4.1.12

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -449,8 +449,8 @@ importers:
         specifier: ^5.3.0
         version: 5.4.0
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^14.0.0
+        version: 14.0.0
       zod:
         specifier: ^4.1.12
         version: 4.1.12
@@ -901,8 +901,8 @@ importers:
         specifier: ^5.3.0
         version: 5.4.0
       uuid:
-        specifier: ^9.0.0
-        version: 9.0.1
+        specifier: ^14.0.0
+        version: 14.0.0
       zod:
         specifier: ^4.1.12
         version: 4.1.12
@@ -13046,6 +13046,10 @@ packages:
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
+
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
+    hasBin: true
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
@@ -28674,6 +28678,8 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   utils-merge@1.0.1: {}
+
+  uuid@14.0.0: {}
 
   uuid@8.3.2: {}
 


### PR DESCRIPTION
### Features and Changes

In certain collections we are using `uniqid` to generate pseudo-random ids but we are hitting conflicts more often than what we would like.

So we are switching to use `uuidv7` (with a prefix of `2` to differentiate from `uniqid`), to reduce the chance of those collisions.

- Bump uuid package version to 14
- Create new util for generating ids (drop-in replacement for `uniqid`)
- Update BaseModel to make use of it

### Testing

New unit tests added + suite passes + manual testing