### PR TITLE
Disable attributes edit and show event forwarder

### DIFF
--- a/packages/back-end/src/api/attributes/putAttribute.ts
+++ b/packages/back-end/src/api/attributes/putAttribute.ts
@@ -4,6 +4,7 @@ import { createApiRequestHandler } from "back-end/src/util/handler";
 import { updateOrganization } from "back-end/src/models/OrganizationModel";
 import { auditDetailsUpdate } from "back-end/src/services/audit";
 import { addTagsDiff } from "back-end/src/models/TagModel";
+import { hasReadyEventForwarderConfig } from "back-end/src/services/eventForwarderConfig";
 import { validatePayload } from "./validations";
 
 export const putAttribute = createApiRequestHandler(putAttributeValidator)(
@@ -24,8 +25,15 @@ export const putAttribute = createApiRequestHandler(putAttributeValidator)(
       ...(await validatePayload(req.context, rawUpdatedAttribute)),
     };
 
+    const hasReadyEventForwarder = await hasReadyEventForwarderConfig(
+      req.context,
+    );
     if (
-      !req.context.permissions.canUpdateAttribute(attribute, updatedAttribute)
+      !req.context.permissions.canUpdateAttribute(
+        attribute,
+        updatedAttribute,
+        hasReadyEventForwarder,
+      )
     )
       req.context.permissions.throwPermissionError();
 

--- a/packages/back-end/src/app.ts
+++ b/packages/back-end/src/app.ts
@@ -907,9 +907,17 @@ app.get("/revision/feature", featuresController.getDraftandReviewRevisions);
 // Data Sources
 app.get("/datasources", datasourcesController.getDataSources);
 app.get("/datasource/:id", datasourcesController.getDataSource);
+app.get(
+  "/event-forwarder/has-ready",
+  datasourcesController.getHasReadyEventForwarder,
+);
 app.post("/datasources", datasourcesController.postDataSources);
 app.put("/datasource/:id", datasourcesController.putDataSource);
 app.delete("/datasource/:id", datasourcesController.deleteDataSource);
+app.post(
+  "/datasource/:id/event-forwarder/pause",
+  datasourcesController.postPauseEventForwarder,
+);
 app.get("/datasource/:id/metrics", datasourcesController.getDataSourceMetrics);
 app.get("/datasource/:id/queries", datasourcesController.getDataSourceQueries);
 app.post(

--- a/packages/back-end/src/app.ts
+++ b/packages/back-end/src/app.ts
@@ -918,6 +918,10 @@ app.post(
   "/datasource/:id/event-forwarder/pause",
   datasourcesController.postPauseEventForwarder,
 );
+app.post(
+  "/datasource/:id/event-forwarder/resume",
+  datasourcesController.postResumeEventForwarder,
+);
 app.get("/datasource/:id/metrics", datasourcesController.getDataSourceMetrics);
 app.get("/datasource/:id/queries", datasourcesController.getDataSourceQueries);
 app.post(

--- a/packages/back-end/src/controllers/datasources.ts
+++ b/packages/back-end/src/controllers/datasources.ts
@@ -47,7 +47,7 @@ import {
 } from "back-end/src/services/datasource";
 import {
   getEventForwarderConfigForDatasource,
-  getEventForwarderConfigDraftForDatasource,
+  getEventForwarderConfigWithMetadataForDatasource,
   hasReadyEventForwarderConfig,
   refreshEventForwarderConfigCredentials,
   syncEventForwarderConfigFromDatasource,
@@ -55,6 +55,7 @@ import {
 import {
   pauseEventForwarderThroughLicenseServer,
   provisionEventForwarderThroughLicenseServer,
+  resumeEventForwarderThroughLicenseServer,
   updateEventForwarderCredentialsThroughLicenseServer,
 } from "back-end/src/services/eventForwarderProvisioning";
 import { getOauth2Client } from "back-end/src/integrations/GoogleAnalytics";
@@ -232,10 +233,11 @@ async function getDataSourceWithParams(
     ...otherFields,
     params: getNonSensitiveParams(integration),
     decryptionError: integration.decryptionError,
-    eventForwarderConfig: await getEventForwarderConfigDraftForDatasource(
-      context,
-      datasource,
-    ),
+    eventForwarderConfig:
+      await getEventForwarderConfigWithMetadataForDatasource(
+        context,
+        datasource,
+      ),
   };
 }
 
@@ -672,6 +674,66 @@ export async function postPauseEventForwarder(
     res.status(200).json({ status: 200 });
   } catch (e) {
     req.log.error(e, "Failed to pause event forwarder");
+    res.status(400).json({
+      status: 400,
+      message: e.message || "An error occurred",
+    });
+  }
+}
+
+export async function postResumeEventForwarder(
+  req: AuthRequest<null, { id: string }>,
+  res: Response<
+    | { status: 200 }
+    | {
+        status: 400 | 403 | 404;
+        message: string;
+      }
+  >,
+) {
+  const context = getContextFromReq(req);
+  const { id } = req.params;
+  const datasource = await getDataSourceById(context, id);
+  if (!datasource) {
+    res.status(404).json({
+      status: 404,
+      message: "Cannot find data source",
+    });
+    return;
+  }
+
+  if (!context.permissions.canUpdateDataSourceSettings(datasource)) {
+    context.permissions.throwPermissionError();
+  }
+
+  const eventForwarderConfig = await getEventForwarderConfigForDatasource(
+    context,
+    datasource.id,
+  );
+  if (!eventForwarderConfig) {
+    res.status(404).json({
+      status: 404,
+      message: "Cannot find event forwarder config",
+    });
+    return;
+  }
+
+  if (eventForwarderConfig.status !== "paused") {
+    res.status(400).json({
+      status: 400,
+      message: "Only paused event forwarders can be resumed",
+    });
+    return;
+  }
+
+  try {
+    await resumeEventForwarderThroughLicenseServer(
+      context,
+      eventForwarderConfig,
+    );
+    res.status(200).json({ status: 200 });
+  } catch (e) {
+    req.log.error(e, "Failed to resume event forwarder");
     res.status(400).json({
       status: 400,
       message: e.message || "An error occurred",

--- a/packages/back-end/src/controllers/datasources.ts
+++ b/packages/back-end/src/controllers/datasources.ts
@@ -46,11 +46,14 @@ import {
   runUserExposureQuery,
 } from "back-end/src/services/datasource";
 import {
+  getEventForwarderConfigForDatasource,
   getEventForwarderConfigDraftForDatasource,
+  hasReadyEventForwarderConfig,
   refreshEventForwarderConfigCredentials,
   syncEventForwarderConfigFromDatasource,
 } from "back-end/src/services/eventForwarderConfig";
 import {
+  pauseEventForwarderThroughLicenseServer,
   provisionEventForwarderThroughLicenseServer,
   updateEventForwarderCredentialsThroughLicenseServer,
 } from "back-end/src/services/eventForwarderProvisioning";
@@ -614,6 +617,78 @@ export async function putDataSource(
       message: e.message || "An error occurred",
     });
   }
+}
+
+export async function postPauseEventForwarder(
+  req: AuthRequest<null, { id: string }>,
+  res: Response<
+    | { status: 200 }
+    | {
+        status: 400 | 403 | 404;
+        message: string;
+      }
+  >,
+) {
+  const context = getContextFromReq(req);
+  const { id } = req.params;
+  const datasource = await getDataSourceById(context, id);
+  if (!datasource) {
+    res.status(404).json({
+      status: 404,
+      message: "Cannot find data source",
+    });
+    return;
+  }
+
+  if (!context.permissions.canUpdateDataSourceSettings(datasource)) {
+    context.permissions.throwPermissionError();
+  }
+
+  const eventForwarderConfig = await getEventForwarderConfigForDatasource(
+    context,
+    datasource.id,
+  );
+  if (!eventForwarderConfig) {
+    res.status(404).json({
+      status: 404,
+      message: "Cannot find event forwarder config",
+    });
+    return;
+  }
+
+  if (eventForwarderConfig.status !== "ready") {
+    res.status(400).json({
+      status: 400,
+      message: "Only ready event forwarders can be paused",
+    });
+    return;
+  }
+
+  try {
+    await pauseEventForwarderThroughLicenseServer(
+      context,
+      eventForwarderConfig,
+    );
+    res.status(200).json({ status: 200 });
+  } catch (e) {
+    req.log.error(e, "Failed to pause event forwarder");
+    res.status(400).json({
+      status: 400,
+      message: e.message || "An error occurred",
+    });
+  }
+}
+
+export async function getHasReadyEventForwarder(
+  req: AuthRequest,
+  res: Response<{ status: 200; hasReadyEventForwarder: boolean }>,
+) {
+  const context = getContextFromReq(req);
+
+  res.status(200).json({
+    status: 200,
+    hasReadyEventForwarder: await hasReadyEventForwarderConfig(context),
+  });
 }
 
 /**

--- a/packages/back-end/src/enterprise/licenseUtil.ts
+++ b/packages/back-end/src/enterprise/licenseUtil.ts
@@ -1076,6 +1076,21 @@ export async function postTeardownEventForwarderToLicenseServer(params: {
   });
 }
 
+export async function postPauseEventForwarderToLicenseServer(params: {
+  organizationId: string;
+  datasourceId: string;
+  connectorName: string;
+}): Promise<{ ok: true }> {
+  const url = `${LICENSE_SERVER_URL}event-forwarder/pause`;
+  return callLicenseServer({
+    url,
+    body: JSON.stringify({
+      ...params,
+      cloudSecret: process.env.CLOUD_SECRET,
+    }),
+  });
+}
+
 export type EventForwarderSchemaUpdateParams = {
   organizationId: string;
   datasourceId: string;

--- a/packages/back-end/src/enterprise/licenseUtil.ts
+++ b/packages/back-end/src/enterprise/licenseUtil.ts
@@ -1091,6 +1091,21 @@ export async function postPauseEventForwarderToLicenseServer(params: {
   });
 }
 
+export async function postResumeEventForwarderToLicenseServer(params: {
+  organizationId: string;
+  datasourceId: string;
+  connectorName: string;
+}): Promise<{ ok: true }> {
+  const url = `${LICENSE_SERVER_URL}event-forwarder/resume`;
+  return callLicenseServer({
+    url,
+    body: JSON.stringify({
+      ...params,
+      cloudSecret: process.env.CLOUD_SECRET,
+    }),
+  });
+}
+
 export type EventForwarderSchemaUpdateParams = {
   organizationId: string;
   datasourceId: string;

--- a/packages/back-end/src/routers/attributes/attributes.controller.ts
+++ b/packages/back-end/src/routers/attributes/attributes.controller.ts
@@ -9,6 +9,7 @@ import { addTags, addTagsDiff } from "back-end/src/models/TagModel";
 import { getAllFeatures } from "back-end/src/models/FeatureModel";
 import { getAllExperiments } from "back-end/src/models/ExperimentModel";
 import { updateEventForwarderSchemaThroughLicenseServer } from "back-end/src/services/eventForwarderProvisioning";
+import { hasReadyEventForwarderConfig } from "back-end/src/services/eventForwarderConfig";
 
 export const postAttribute = async (
   req: AuthRequest<SDKAttribute>,
@@ -128,7 +129,14 @@ export const putAttribute = async (
   }
 
   const existing = attributeSchema[index];
-  if (!context.permissions.canUpdateAttribute(existing, { projects })) {
+  const hasReadyEventForwarder = await hasReadyEventForwarderConfig(context);
+  if (
+    !context.permissions.canUpdateAttribute(
+      existing,
+      { projects },
+      hasReadyEventForwarder,
+    )
+  ) {
     context.permissions.throwPermissionError();
   }
 

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -56,6 +56,10 @@ import {
   getNonSensitiveParams,
   getSourceIntegrationObject,
 } from "back-end/src/services/datasource";
+import {
+  getEventForwarderSinkTypeForDatasource,
+  toEventForwarderConfigDraft,
+} from "back-end/src/services/eventForwarderConfig";
 import { updatePassword } from "back-end/src/services/users";
 import { getAllTags } from "back-end/src/models/TagModel";
 import {
@@ -168,6 +172,7 @@ export async function getDefinitions(req: AuthRequest, res: Response) {
     factMetrics,
     decisionCriteria,
     webhookSecrets,
+    eventForwarderConfigs,
   ] = await Promise.all([
     getMetricsByOrganization(context),
     getDataSourcesByOrganization(context),
@@ -182,13 +187,24 @@ export async function getDefinitions(req: AuthRequest, res: Response) {
     context.models.factMetrics.getAll(),
     context.models.decisionCriteria.getAll(),
     context.models.webhookSecrets.getAllForFrontEnd(),
+    context.models.eventForwarderConfigs.getAll(),
   ]);
+
+  const eventForwarderConfigByDatasourceId = new Map(
+    eventForwarderConfigs.map((config) => [config.datasourceId, config]),
+  );
 
   return res.status(200).json({
     status: 200,
     metrics,
     datasources: datasources.map((d) => {
       const integration = getSourceIntegrationObject(context, d);
+      const eventForwarderConfig = getEventForwarderSinkTypeForDatasource(d)
+        ? eventForwarderConfigByDatasourceId.get(d.id)
+        : null;
+      const eventForwarderConfigDraft = toEventForwarderConfigDraft(
+        eventForwarderConfig ?? null,
+      );
       return {
         id: d.id,
         name: d.name,
@@ -199,6 +215,17 @@ export async function getDefinitions(req: AuthRequest, res: Response) {
         projects: d.projects || [],
         properties: integration.getSourceProperties(),
         decryptionError: integration.decryptionError || false,
+        eventForwarderConfig:
+          eventForwarderConfig && eventForwarderConfigDraft
+            ? {
+                ...eventForwarderConfigDraft,
+                status: eventForwarderConfig.status,
+                connectorName: eventForwarderConfig.connectorName,
+                connectorId: eventForwarderConfig.connectorId,
+                lastProvisioningError:
+                  eventForwarderConfig.lastProvisioningError,
+              }
+            : null,
         dateCreated: d.dateCreated,
         dateUpdated: d.dateUpdated,
       };

--- a/packages/back-end/src/services/eventForwarderConfig.ts
+++ b/packages/back-end/src/services/eventForwarderConfig.ts
@@ -6,6 +6,7 @@ import {
   BigQueryEventForwarderConfigDraft,
   BigQueryEventForwarderStoredConfig,
   EventForwarderConfigDraft,
+  EventForwarderConfigWithMetadata,
   EventForwarderSinkType,
   SnowflakeEventForwarderConfigDraft,
   SnowflakeEventForwarderStoredConfig,
@@ -290,6 +291,29 @@ export async function getEventForwarderConfigDraftForDatasource(
     datasource.id,
   );
   return toEventForwarderConfigDraft(existing);
+}
+
+export async function getEventForwarderConfigWithMetadataForDatasource(
+  context: ReqContext,
+  datasource: Pick<DataSourceInterface, "type" | "id">,
+): Promise<EventForwarderConfigWithMetadata | null> {
+  const sinkType = getEventForwarderSinkTypeForDatasource(datasource);
+  if (!sinkType) return null;
+
+  const existing = await getEventForwarderConfigForDatasource(
+    context,
+    datasource.id,
+  );
+  const draft = toEventForwarderConfigDraft(existing);
+  if (!existing || !draft) return null;
+
+  return {
+    ...draft,
+    status: existing.status,
+    connectorName: existing.connectorName,
+    connectorId: existing.connectorId,
+    lastProvisioningError: existing.lastProvisioningError,
+  };
 }
 
 export async function syncEventForwarderConfigFromDatasource({

--- a/packages/back-end/src/services/eventForwarderConfig.ts
+++ b/packages/back-end/src/services/eventForwarderConfig.ts
@@ -76,6 +76,13 @@ export async function getEventForwarderConfigForDatasource(
   return configs.find((config) => config.datasourceId === datasourceId) ?? null;
 }
 
+export async function hasReadyEventForwarderConfig(
+  context: ReqContext,
+): Promise<boolean> {
+  const configs = await context.models.eventForwarderConfigs.getAll();
+  return configs.some((config) => config.status === "ready");
+}
+
 /**
  * Builds the same JSON shape as a GCP-downloaded service account key (see
  * `keyfile` in Confluent’s BigQuery Storage Sink docs). This is not Confluent’s

--- a/packages/back-end/src/services/eventForwarderProvisioning.ts
+++ b/packages/back-end/src/services/eventForwarderProvisioning.ts
@@ -7,6 +7,7 @@ import {
 } from "shared/types/event-forwarder";
 import { EventForwarderConfigInterface } from "shared/validators";
 import {
+  postPauseEventForwarderToLicenseServer,
   postProvisionEventForwarderToLicenseServer,
   postTeardownEventForwarderToLicenseServer,
   postUpdateEventForwarderCredentialsToLicenseServer,
@@ -230,6 +231,59 @@ export async function updateEventForwarderCredentialsThroughLicenseServer(
 
     await context.models.eventForwarderConfigs.update(eventForwarderConfig, {
       status: "error",
+      lastProvisioningError: message,
+    });
+
+    throw new Error(message);
+  }
+}
+
+/**
+ * Pauses a provisioned event forwarder connector through the central license server.
+ * Only ready configs can be paused; failed or pending configs do not have a
+ * reliably running Confluent connector to pause.
+ */
+export async function pauseEventForwarderThroughLicenseServer(
+  context: ReqContext,
+  eventForwarderConfig: EventForwarderConfigInterface,
+): Promise<void> {
+  if (eventForwarderConfig.status !== "ready") {
+    throw new Error("Only ready event forwarders can be paused");
+  }
+
+  if (eventForwarderConfig.sinkType === "databricks") {
+    throw new Error("Databricks event forwarders cannot be paused");
+  }
+
+  const connectorName = eventForwarderConfig.connectorName?.trim();
+  if (!connectorName) {
+    throw new Error("Cannot pause event forwarder without a connector name");
+  }
+
+  try {
+    await postPauseEventForwarderToLicenseServer({
+      organizationId: context.org.id,
+      datasourceId: eventForwarderConfig.datasourceId,
+      connectorName,
+    });
+
+    await context.models.eventForwarderConfigs.update(eventForwarderConfig, {
+      status: "paused",
+      lastProvisioningError: "",
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Unknown pause error";
+    logger.error(
+      {
+        eventForwarderConfigId: eventForwarderConfig.id,
+        organizationId: context.org.id,
+        error: message,
+      },
+      "Failed to pause event forwarder connector via license server",
+    );
+
+    await context.models.eventForwarderConfigs.update(eventForwarderConfig, {
       lastProvisioningError: message,
     });
 

--- a/packages/back-end/src/services/eventForwarderProvisioning.ts
+++ b/packages/back-end/src/services/eventForwarderProvisioning.ts
@@ -9,6 +9,7 @@ import { EventForwarderConfigInterface } from "shared/validators";
 import {
   postPauseEventForwarderToLicenseServer,
   postProvisionEventForwarderToLicenseServer,
+  postResumeEventForwarderToLicenseServer,
   postTeardownEventForwarderToLicenseServer,
   postUpdateEventForwarderCredentialsToLicenseServer,
   postUpdateEventForwarderSchemaToLicenseServer,
@@ -281,6 +282,57 @@ export async function pauseEventForwarderThroughLicenseServer(
         error: message,
       },
       "Failed to pause event forwarder connector via license server",
+    );
+
+    await context.models.eventForwarderConfigs.update(eventForwarderConfig, {
+      lastProvisioningError: message,
+    });
+
+    throw new Error(message);
+  }
+}
+
+/**
+ * Resumes a paused event forwarder connector through the central license server.
+ */
+export async function resumeEventForwarderThroughLicenseServer(
+  context: ReqContext,
+  eventForwarderConfig: EventForwarderConfigInterface,
+): Promise<void> {
+  if (eventForwarderConfig.status !== "paused") {
+    throw new Error("Only paused event forwarders can be resumed");
+  }
+
+  if (eventForwarderConfig.sinkType === "databricks") {
+    throw new Error("Databricks event forwarders cannot be resumed");
+  }
+
+  const connectorName = eventForwarderConfig.connectorName?.trim();
+  if (!connectorName) {
+    throw new Error("Cannot resume event forwarder without a connector name");
+  }
+
+  try {
+    await postResumeEventForwarderToLicenseServer({
+      organizationId: context.org.id,
+      datasourceId: eventForwarderConfig.datasourceId,
+      connectorName,
+    });
+
+    await context.models.eventForwarderConfigs.update(eventForwarderConfig, {
+      status: "ready",
+      lastProvisioningError: "",
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Unknown resume error";
+    logger.error(
+      {
+        eventForwarderConfigId: eventForwarderConfig.id,
+        organizationId: context.org.id,
+        error: message,
+      },
+      "Failed to resume event forwarder connector via license server",
     );
 
     await context.models.eventForwarderConfigs.update(eventForwarderConfig, {

--- a/packages/back-end/test/api/attributes.test.ts
+++ b/packages/back-end/test/api/attributes.test.ts
@@ -177,6 +177,9 @@ describe("attributes API", () => {
         projects: {
           getAll: () => [{ id: "proj1" }, { id: "proj2" }, { id: "proj3" }],
         },
+        eventForwarderConfigs: {
+          getAll: () => [],
+        },
       },
       org: {
         id: "org1",
@@ -328,6 +331,9 @@ describe("attributes API", () => {
         projects: {
           getAll: () => [{ id: "bla" }],
         },
+        eventForwarderConfigs: {
+          getAll: () => [],
+        },
       },
       org: {
         id: "org1",
@@ -347,6 +353,52 @@ describe("attributes API", () => {
       },
       permissions: {
         canUpdateAttribute: () => false,
+        throwPermissionError: () => {
+          throw new Error("permission error");
+        },
+      },
+    });
+
+    const response = await request(app)
+      .put("/api/v1/attributes/attr1")
+      .send({
+        description: "bla",
+      })
+      .set("Authorization", "Bearer foo");
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({
+      message: "permission error",
+    });
+    expect(updateOrganization).not.toHaveBeenCalledWith();
+    expect(auditMock).not.toHaveBeenCalledWith();
+  });
+
+  it("refuses to update attributes when a ready event forwarder exists", async () => {
+    setReqContext({
+      models: {
+        projects: {
+          getAll: () => [{ id: "bla" }],
+        },
+        eventForwarderConfigs: {
+          getAll: () => [{ status: "ready" }],
+        },
+      },
+      org: {
+        id: "org1",
+        settings: {
+          attributeSchema: [
+            {
+              property: "attr1",
+              datatype: "string[]",
+              projects: ["bla"],
+            },
+          ],
+        },
+      },
+      permissions: {
+        canUpdateAttribute: (_existing, _updates, hasReadyEventForwarder) =>
+          !hasReadyEventForwarder,
         throwPermissionError: () => {
           throw new Error("permission error");
         },

--- a/packages/back-end/test/permissions.test.ts
+++ b/packages/back-end/test/permissions.test.ts
@@ -1887,6 +1887,25 @@ describe("PermissionsUtilClass.canUpdateAttribute check", () => {
     ).toEqual(true);
   });
 
+  it("User with attribute update permission cannot update when a ready event forwarder exists", async () => {
+    const permissions = new Permissions({
+      global: {
+        permissions: roleToPermissionMap("engineer", testOrg),
+        limitAccessByEnvironment: false,
+        environments: [],
+      },
+      projects: {},
+    });
+
+    expect(
+      permissions.canUpdateAttribute(
+        { projects: ["ABC123"] },
+        { projects: [] },
+        true,
+      ),
+    ).toEqual(false);
+  });
+
   it("User with global readonly role can update an attribute from being in project ABC123 to being in ABC123 and DEF456", async () => {
     const permissions = new Permissions({
       global: {

--- a/packages/front-end/components/Features/AttributeModal.tsx
+++ b/packages/front-end/components/Features/AttributeModal.tsx
@@ -18,6 +18,7 @@ import { useUser } from "@/services/UserContext";
 import Tooltip from "@/components/Tooltip/Tooltip";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
 import useProjectOptions from "@/hooks/useProjectOptions";
+import useApi from "@/hooks/useApi";
 import Callout from "@/ui/Callout";
 import Checkbox from "@/ui/Checkbox";
 import MarkdownInput from "@/components/Markdown/MarkdownInput";
@@ -48,6 +49,15 @@ export default function AttributeModal({ close, attribute }: Props) {
 
   const schema = useAttributeSchema(true);
   const current = schema.find((s) => s.property === attribute);
+  const { data: eventForwarderData } = useApi<{
+    status: 200;
+    hasReadyEventForwarder: boolean;
+  }>("/event-forwarder/has-ready", {
+    shouldRun: () => !!attribute,
+  });
+  const hasReadyEventForwarder =
+    eventForwarderData?.hasReadyEventForwarder || false;
+  const isEventForwarderStatusLoading = !!attribute && !eventForwarderData;
 
   const form = useForm<SDKAttribute>({
     defaultValues: {
@@ -77,7 +87,11 @@ export default function AttributeModal({ close, attribute }: Props) {
 
   const permissionRequired = (project: string) => {
     return attribute
-      ? permissionsUtil.canUpdateAttribute({ projects: [project] }, {})
+      ? permissionsUtil.canUpdateAttribute(
+          { projects: [project] },
+          {},
+          hasReadyEventForwarder,
+        )
       : permissionsUtil.canCreateAttribute({ projects: [project] });
   };
 
@@ -87,23 +101,39 @@ export default function AttributeModal({ close, attribute }: Props) {
   );
 
   const selectedProjects = form.watch("projects") || [];
-  const canCreateWithoutProject = attribute
-    ? permissionsUtil.canUpdateAttribute(
-        { projects: current?.projects || [] },
-        { projects: [] },
-      )
-    : permissionsUtil.canCreateAttribute({ projects: [] });
-  const hasProjectPermission = attribute
-    ? permissionsUtil.canUpdateAttribute(
-        { projects: current?.projects || [] },
-        { projects: selectedProjects },
-      )
-    : permissionsUtil.canCreateAttribute({ projects: selectedProjects });
-  const ctaDisabledMessage = !hasProjectPermission
-    ? !selectedProjects.length && projectOptions.length > 0
-      ? "Select a project to continue."
-      : `You don't have permission to ${attribute ? "update" : "create"} attributes.`
-    : undefined;
+  const canCreateWithoutProject =
+    !isEventForwarderStatusLoading &&
+    (attribute
+      ? permissionsUtil.canUpdateAttribute(
+          { projects: current?.projects || [] },
+          { projects: [] },
+          hasReadyEventForwarder,
+        )
+      : permissionsUtil.canCreateAttribute({ projects: [] }));
+  const hasProjectPermission =
+    !isEventForwarderStatusLoading &&
+    (attribute
+      ? permissionsUtil.canUpdateAttribute(
+          { projects: current?.projects || [] },
+          { projects: selectedProjects },
+          hasReadyEventForwarder,
+        )
+      : permissionsUtil.canCreateAttribute({ projects: selectedProjects }));
+  let ctaDisabledMessage: string | undefined;
+  if (!hasProjectPermission) {
+    if (isEventForwarderStatusLoading) {
+      ctaDisabledMessage = "Checking Event Forwarder status.";
+    } else if (hasReadyEventForwarder) {
+      ctaDisabledMessage =
+        "Attributes can't be updated while an Event Forwarder is active.";
+    } else if (!selectedProjects.length && projectOptions.length > 0) {
+      ctaDisabledMessage = "Select a project to continue.";
+    } else {
+      ctaDisabledMessage = `You don't have permission to ${
+        attribute ? "update" : "create"
+      } attributes.`;
+    }
+  }
 
   return (
     <Modal

--- a/packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentifierTypes/DataSourceInlineEditIdentifierTypes.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentifierTypes/DataSourceInlineEditIdentifierTypes.tsx
@@ -99,8 +99,15 @@ export const DataSourceInlineEditIdentifierTypes: FC<
         </Flex>
         {canEdit && (
           <Box>
-            <Button variant="solid" onClick={handleAdd}>
-              <FaPlus className="mr-1" /> Add
+            <Button
+              variant="solid"
+              onClick={handleAdd}
+              style={{
+                alignItems: "center",
+              }}
+            >
+              <FaPlus className="mr-1" />
+              &nbsp;<span>Add</span>
             </Button>
           </Box>
         )}

--- a/packages/front-end/components/Settings/EditDataSource/EventForwarder/EventForwarder.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/EventForwarder/EventForwarder.tsx
@@ -98,7 +98,7 @@ export default function EventForwarder({
 
       <Card>
         <Flex direction="column" gap="3" p="2">
-          <Flex direction="row" gap="4" align="center" wrap="wrap">
+          <Flex direction="column" gap="4">
             <Box>
               <Text weight="medium">Table Name: </Text>
               {tableName ? (
@@ -106,10 +106,6 @@ export default function EventForwarder({
               ) : (
                 <Text color="text-low">None</Text>
               )}
-            </Box>
-            <Box>
-              <Text weight="medium">Connector Status: </Text>
-              <Text>{statusLabels[eventForwarderConfig.status]}</Text>
             </Box>
           </Flex>
 

--- a/packages/front-end/components/Settings/EditDataSource/EventForwarder/EventForwarder.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/EventForwarder/EventForwarder.tsx
@@ -1,0 +1,130 @@
+import { useState } from "react";
+import { EventForwarderStatus } from "shared/types/event-forwarder";
+import { DataSourceInterfaceWithParams } from "shared/types/datasource";
+import { Box, Card, Flex } from "@radix-ui/themes";
+import { useAuth } from "@/services/auth";
+import Badge from "@/ui/Badge";
+import Button from "@/ui/Button";
+import Callout from "@/ui/Callout";
+import Heading from "@/ui/Heading";
+import Text from "@/ui/Text";
+
+type Props = {
+  dataSource: DataSourceInterfaceWithParams;
+  canEdit?: boolean;
+  onRefresh: () => Promise<void>;
+};
+
+const statusLabels: Record<EventForwarderStatus, string> = {
+  pending: "Pending",
+  ready: "Ready",
+  paused: "Paused",
+  error: "Error",
+  schema_update_error: "Schema Update Error",
+};
+
+const statusColors: Record<
+  EventForwarderStatus,
+  "gray" | "green" | "amber" | "red"
+> = {
+  pending: "gray",
+  ready: "green",
+  paused: "amber",
+  error: "red",
+  schema_update_error: "red",
+};
+
+export default function EventForwarder({
+  dataSource,
+  canEdit = true,
+  onRefresh,
+}: Props) {
+  const [error, setError] = useState<string | null>(null);
+  const { apiCall } = useAuth();
+  const eventForwarderConfig = dataSource.eventForwarderConfig;
+
+  if (!eventForwarderConfig) return null;
+
+  const tableName =
+    "tableName" in eventForwarderConfig.config
+      ? eventForwarderConfig.config.tableName
+      : "";
+  const isReady = eventForwarderConfig.status === "ready";
+  const isPaused = eventForwarderConfig.status === "paused";
+  const canToggle = canEdit && (isReady || isPaused);
+  const action = isReady ? "pause" : "resume";
+
+  return (
+    <Box>
+      <Flex align="center" justify="between" gap="3" mb="2">
+        <Flex align="center" gap="2">
+          <Heading as="h3" size="medium" mb="0">
+            Event Forwarder
+          </Heading>
+          <Badge
+            label={statusLabels[eventForwarderConfig.status]}
+            color={statusColors[eventForwarderConfig.status]}
+            variant="soft"
+          />
+        </Flex>
+
+        {canToggle && (
+          <Button
+            variant="outline"
+            color={isReady ? "red" : "gray"}
+            setError={setError}
+            style={{
+              alignItems: "center",
+            }}
+            onClick={async () => {
+              await apiCall(
+                `/datasource/${dataSource.id}/event-forwarder/${action}`,
+                {
+                  method: "POST",
+                },
+              );
+              await onRefresh();
+            }}
+          >
+            {isReady ? "Pause" : "Resume"}
+          </Button>
+        )}
+      </Flex>
+
+      <p>
+        Forward SDK event data from GrowthBook to this datasource for downstream
+        analysis and diagnostics.
+      </p>
+
+      <Card>
+        <Flex direction="column" gap="3" p="2">
+          <Flex direction="row" gap="4" align="center" wrap="wrap">
+            <Box>
+              <Text weight="medium">Table Name: </Text>
+              {tableName ? (
+                <code>{tableName}</code>
+              ) : (
+                <Text color="text-low">None</Text>
+              )}
+            </Box>
+            <Box>
+              <Text weight="medium">Connector Status: </Text>
+              <Text>{statusLabels[eventForwarderConfig.status]}</Text>
+            </Box>
+          </Flex>
+
+          {eventForwarderConfig.lastProvisioningError ? (
+            <Callout status="error" mb="0">
+              {eventForwarderConfig.lastProvisioningError}
+            </Callout>
+          ) : null}
+          {error ? (
+            <Callout status="error" mb="0">
+              {error}
+            </Callout>
+          ) : null}
+        </Flex>
+      </Card>
+    </Box>
+  );
+}

--- a/packages/front-end/pages/attributes.tsx
+++ b/packages/front-end/pages/attributes.tsx
@@ -24,6 +24,7 @@ import SortedTags from "@/components/Tags/SortedTags";
 import Markdown from "@/components/Markdown/Markdown";
 import Link from "@/ui/Link";
 import { useAttributeReferences } from "@/hooks/useAttributeReferences";
+import useApi from "@/hooks/useApi";
 
 const HEADER_HEIGHT_PX = 55;
 
@@ -46,6 +47,12 @@ const FeatureAttributesPage = (): React.ReactElement => {
     [attributeSchema],
   );
   const { references } = useAttributeReferences(attributeKeys);
+  const { data: eventForwarderData } = useApi<{
+    status: 200;
+    hasReadyEventForwarder: boolean;
+  }>("/event-forwarder/has-ready");
+  const activeEventForwarder =
+    eventForwarderData?.hasReadyEventForwarder || false;
 
   const attributesWithComputedFields = useAddComputedFields(
     attributeSchema,
@@ -259,7 +266,15 @@ const FeatureAttributesPage = (): React.ReactElement => {
                       This action cannot be undone.
                     </>
                   }
-                  className="dropdown-item text-danger"
+                  className={`dropdown-item text-danger${
+                    activeEventForwarder ? " disabled" : ""
+                  }`}
+                  disabled={activeEventForwarder}
+                  title={
+                    activeEventForwarder
+                      ? "Attributes can't be deleted while an Event Forwarder is active."
+                      : ""
+                  }
                   onClick={async () => {
                     await apiCall<{
                       status: number;

--- a/packages/front-end/pages/attributes/[property].tsx
+++ b/packages/front-end/pages/attributes/[property].tsx
@@ -33,6 +33,7 @@ import {
 } from "@/ui/DropdownMenu";
 import AttributeReferencesList from "@/components/Features/AttributeReferencesList";
 import Tooltip from "@/components/Tooltip/Tooltip";
+import useApi from "@/hooks/useApi";
 
 export default function AttributeDetailPage() {
   const router = useRouter();
@@ -49,6 +50,12 @@ export default function AttributeDetailPage() {
   const { apiCall } = useAuth();
   const { refreshOrganization } = useUser();
   const permissionsUtil = usePermissionsUtil();
+  const { data: eventForwarderData } = useApi<{
+    status: 200;
+    hasReadyEventForwarder: boolean;
+  }>("/event-forwarder/has-ready");
+  const activeEventForwarder =
+    eventForwarderData?.hasReadyEventForwarder || false;
 
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [showReferencesModal, setShowReferencesModal] = useState(false);
@@ -210,8 +217,11 @@ export default function AttributeDetailPage() {
           close={() => setShowDeleteModal(false)}
           cta="Delete"
           submitColor="danger"
+          ctaEnabled={!activeEventForwarder}
+          disabledMessage="Attributes can't be deleted while an Event Forwarder is active."
           trackingEventModalType=""
           submit={async () => {
+            if (activeEventForwarder) return;
             await apiCall<{ status: number }>("/attribute/", {
               method: "DELETE",
               body: JSON.stringify({ id: attribute.property }),
@@ -272,6 +282,7 @@ export default function AttributeDetailPage() {
               <DropdownMenuGroup>
                 <DropdownMenuItem
                   color="red"
+                  disabled={activeEventForwarder}
                   onClick={() => {
                     setShowDeleteModal(true);
                     setDropdownOpen(false);

--- a/packages/front-end/pages/datasources/[did].tsx
+++ b/packages/front-end/pages/datasources/[did].tsx
@@ -35,6 +35,7 @@ import { useCombinedMetrics } from "@/components/Metrics/MetricsList";
 import { FeatureEvaluationQueries } from "@/components/Settings/EditDataSource/FeatureEvaluationQueries/FeatureEvaluationQueries";
 import Heading from "@/ui/Heading";
 import Text from "@/ui/Text";
+import EventForwarder from "@/components/Settings/EditDataSource/EventForwarder/EventForwarder";
 
 function quotePropertyName(name: string) {
   if (name.match(/^[a-zA-Z_][a-zA-Z0-9_]*$/)) {
@@ -428,6 +429,18 @@ mixpanel.init('YOUR PROJECT TOKEN', {
                     canEdit={canUpdateDataSourceSettings}
                   />
                 </Frame>
+
+                {d.eventForwarderConfig ? (
+                  <Frame>
+                    <EventForwarder
+                      dataSource={d}
+                      canEdit={canUpdateDataSourceSettings}
+                      onRefresh={async () => {
+                        await mutateDefinitions({});
+                      }}
+                    />
+                  </Frame>
+                ) : null}
 
                 {d.settings.notebookRunQuery && (
                   <Frame>

--- a/packages/shared/src/permissions/permissionsClass.ts
+++ b/packages/shared/src/permissions/permissionsClass.ts
@@ -290,7 +290,10 @@ export class Permissions {
   public canUpdateAttribute = (
     existing: Pick<SDKAttribute, "projects">,
     updates: Pick<SDKAttribute, "projects">,
+    hasReadyEventForwarder = false,
   ): boolean => {
+    if (hasReadyEventForwarder) return false;
+
     return this.checkProjectFilterUpdatePermission(
       existing,
       updates,

--- a/packages/shared/src/validators/event-forwarder-config.ts
+++ b/packages/shared/src/validators/event-forwarder-config.ts
@@ -9,6 +9,7 @@ const eventForwarderSinkTypeValidator = z.enum([
 const eventForwarderStatusValidator = z.enum([
   "pending",
   "ready",
+  "paused",
   "error",
   "schema_update_error",
 ]);

--- a/packages/shared/types/datasource.d.ts
+++ b/packages/shared/types/datasource.d.ts
@@ -11,7 +11,7 @@ import { DatabricksConnectionParams } from "./integrations/databricks";
 import { MetricType } from "./metric";
 import { MssqlConnectionParams } from "./integrations/mssql";
 import { FactTableColumnType } from "./fact-table";
-import { EventForwarderConfigDraft } from "./event-forwarder";
+import { EventForwarderConfigWithMetadata } from "./event-forwarder";
 
 export type DataSourceType =
   | "growthbook_clickhouse"
@@ -149,7 +149,7 @@ type WithParams<B, P> = Omit<B, "params"> & {
   params: P;
   properties?: DataSourceProperties;
   decryptionError: boolean;
-  eventForwarderConfig?: EventForwarderConfigDraft | null;
+  eventForwarderConfig?: EventForwarderConfigWithMetadata | null;
 };
 
 export type IdentityJoinQuery = {

--- a/packages/shared/types/event-forwarder.d.ts
+++ b/packages/shared/types/event-forwarder.d.ts
@@ -1,6 +1,11 @@
 export type EventForwarderSinkType = "bigquery" | "snowflake" | "databricks";
 
-export type EventForwarderStatus = "pending" | "ready" | "error";
+export type EventForwarderStatus =
+  | "pending"
+  | "ready"
+  | "paused"
+  | "error"
+  | "schema_update_error";
 
 /** BigQuery sink settings edited with the datasource form (dataset is the datasource Default Dataset). */
 export interface BigQueryEventForwarderConfigDraft {
@@ -47,3 +52,10 @@ export type EventForwarderConfigDraft =
       sinkType: "databricks";
       config: Record<string, string>;
     };
+
+export type EventForwarderConfigWithMetadata = EventForwarderConfigDraft & {
+  status: EventForwarderStatus;
+  connectorName?: string;
+  connectorId?: string;
+  lastProvisioningError?: string;
+};


### PR DESCRIPTION
### Features and Changes
- When Event Forwarder is Ready:
- Disable Edit attributes
- Disable hard/soft delete attributes

- Closes **[Allow add and archive attributes](https://www.notion.so/growthbook/Event-Forwarder-345a857e74a080a888c8de6d150a518d?source=copy_link#349a857e74a080d7b96fd2f0e1feb6e1)**

### Dependencies

https://github.com/growthbook/central-license-server/pull/112

### Testing
- Setup event forwarder
- Verify attributes can't be modified
- Verify attributes can't be deleted but can be archived
- Verify users can add more attributes

### Screenshots
<img width="906" height="419" alt="Screenshot 2026-04-28 at 2 08 54 PM" src="https://github.com/user-attachments/assets/9b74a492-a611-4f05-ba8c-81475a4d140c" />

<img width="1679" height="273" alt="Screenshot 2026-04-28 at 11 21 34 PM" src="https://github.com/user-attachments/assets/62e401ef-6fb8-4b8d-bb6b-b72e8bab3a4b" />

