### PR TITLE
docs(self-host): Fix SQL typo in query table name from 'identifies' to 'identifiers'

### DIFF
--- a/docs/docs/self-host/config.mdx
+++ b/docs/docs/self-host/config.mdx
@@ -50,7 +50,7 @@ datasources:
               - country
         identityJoins:
           - ids: ["user_id", "anonymous_id"]
-            query: SELECT user_id, anonymous_id FROM identifies
+            query: SELECT user_id, anonymous_id FROM identifiers
 ```
 
 ### Data Source Connection Params
@@ -213,7 +213,7 @@ settings:
     # These optional queries map between different types of identifiers
     identityJoins:
       - ids: ["user_id", "anonymous_id"]
-        query: SELECT user_id, anonymous_id FROM identifies
+        query: SELECT user_id, anonymous_id FROM identifiers
   # Used when exporting experiment results to a Jupyter notebook
   # Define a `runQuery(sql)` function that returns a pandas data frame
   notebookRunQuery: >


### PR DESCRIPTION
### Features and Changes

This fixes a type in the `config.yml` section of the self-hosting docs

### Dependencies

None

### Testing


### Screenshots


<img width="1857" height="10429" alt="Screenshot 2026-04-28 at 20-23-15 Config yml GrowthBook Docs" src="https://github.com/user-attachments/assets/a35f1e10-0540-4922-8e06-08112a2716e4" />
