### PR TITLE
Add rate limiter on scim endpoints

### DIFF
--- a/packages/back-end/src/api/api.router.ts
+++ b/packages/back-end/src/api/api.router.ts
@@ -1,11 +1,10 @@
 import { existsSync, readFileSync } from "fs";
 import path from "path";
 import { Router, Request, RequestHandler } from "express";
-import rateLimit from "express-rate-limit";
 import bodyParser from "body-parser";
 import * as Sentry from "@sentry/node";
-import { parseEnvInt } from "shared/util";
 import authenticateApiRequestMiddleware from "back-end/src/middleware/authenticateApiRequestMiddleware";
+import { apiStyleRateLimiter } from "back-end/src/middleware/apiStyleRateLimiter";
 import { DashboardModel } from "back-end/src/enterprise/models/DashboardModel";
 import { CustomFieldModel } from "back-end/src/models/CustomFieldModel";
 import { MetricGroupModel } from "back-end/src/models/MetricGroupModel";
@@ -17,7 +16,7 @@ import { RampScheduleModel } from "back-end/src/models/RampScheduleModel";
 import { ModelClass } from "back-end/src/services/context";
 import { getBuild } from "back-end/src/util/build";
 import { ApiRequestLocals } from "back-end/types/api";
-import { IS_CLOUD, SENTRY_DSN } from "back-end/src/util/secrets";
+import { SENTRY_DSN } from "back-end/src/util/secrets";
 import { featureRoutes } from "./features/features.router";
 import { experimentsRoutes } from "./experiments/experiments.router";
 import { snapshotsRoutes } from "./snapshots/snapshots.router";
@@ -101,23 +100,9 @@ if (SENTRY_DSN) {
   }) as RequestHandler);
 }
 
-const API_RATE_LIMIT_MAX = parseEnvInt(process.env.API_RATE_LIMIT_MAX, 60, {
-  min: 1,
-  name: "API_RATE_LIMIT_MAX",
-});
-const overallRateLimit = IS_CLOUD ? 60 : API_RATE_LIMIT_MAX;
-// Rate limit API keys to 60 requests per minute
+// Rate limit API keys to 60 requests per minute (configurable via API_RATE_LIMIT_MAX)
 router.use(
-  rateLimit({
-    windowMs: 60 * 1000,
-    max: API_RATE_LIMIT_MAX,
-    standardHeaders: true,
-    legacyHeaders: false,
-    keyGenerator: (req) => (req as Request & ApiRequestLocals).apiKey,
-    message: {
-      message: `Too many requests, limit to ${overallRateLimit} per minute`,
-    },
-  }),
+  apiStyleRateLimiter((req) => (req as Request & ApiRequestLocals).apiKey),
 );
 
 // Index health check route

--- a/packages/back-end/src/middleware/apiStyleRateLimiter.ts
+++ b/packages/back-end/src/middleware/apiStyleRateLimiter.ts
@@ -8,11 +8,12 @@ const API_RATE_LIMIT_MAX = parseEnvInt(process.env.API_RATE_LIMIT_MAX, 60, {
   name: "API_RATE_LIMIT_MAX",
 });
 
-const overallRateLimit = IS_CLOUD ? 60 : API_RATE_LIMIT_MAX;
+const messageRateLimit = IS_CLOUD ? 60 : API_RATE_LIMIT_MAX;
 
 /**
- * Same window and cap as `/api/v1` (see `API_RATE_LIMIT_MAX`). Use after auth
- * with a keyGenerator that identifies the caller (e.g. secret API key id).
+ * Since API_RATE_LIMIT_MAX is per server, the error message is not quite accurate.
+ * For cloud we hardcode the approximate limit. As many self hosted users have a single server,
+ * the actual limit is probably API_RATE_LIMIT_MAX.
  */
 export function apiStyleRateLimiter(
   keyGenerator: (req: Request) => string,
@@ -24,7 +25,7 @@ export function apiStyleRateLimiter(
     legacyHeaders: false,
     keyGenerator,
     message: {
-      message: `Too many requests, limit to ${overallRateLimit} per minute`,
+      message: `Too many requests, limit to ${messageRateLimit} per minute`,
     },
   });
 }

--- a/packages/back-end/src/middleware/apiStyleRateLimiter.ts
+++ b/packages/back-end/src/middleware/apiStyleRateLimiter.ts
@@ -1,0 +1,30 @@
+import { Request } from "express";
+import rateLimit from "express-rate-limit";
+import { parseEnvInt } from "shared/util";
+import { IS_CLOUD } from "back-end/src/util/secrets";
+
+const API_RATE_LIMIT_MAX = parseEnvInt(process.env.API_RATE_LIMIT_MAX, 60, {
+  min: 1,
+  name: "API_RATE_LIMIT_MAX",
+});
+
+const overallRateLimit = IS_CLOUD ? 60 : API_RATE_LIMIT_MAX;
+
+/**
+ * Same window and cap as `/api/v1` (see `API_RATE_LIMIT_MAX`). Use after auth
+ * with a keyGenerator that identifies the caller (e.g. secret API key id).
+ */
+export function apiStyleRateLimiter(
+  keyGenerator: (req: Request) => string,
+): ReturnType<typeof rateLimit> {
+  return rateLimit({
+    windowMs: 60 * 1000,
+    max: API_RATE_LIMIT_MAX,
+    standardHeaders: true,
+    legacyHeaders: false,
+    keyGenerator,
+    message: {
+      message: `Too many requests, limit to ${overallRateLimit} per minute`,
+    },
+  });
+}

--- a/packages/back-end/src/scim/scim.router.ts
+++ b/packages/back-end/src/scim/scim.router.ts
@@ -1,5 +1,7 @@
-import { Router, RequestHandler } from "express";
+import { Router, Request, RequestHandler } from "express";
 import authenticateApiRequestMiddleware from "back-end/src/middleware/authenticateApiRequestMiddleware";
+import { apiStyleRateLimiter } from "back-end/src/middleware/apiStyleRateLimiter";
+import { ApiRequestLocals } from "back-end/types/api";
 import usersRouter from "./users/users.router";
 import groupsRouter from "./groups/groups.router";
 import scimMiddleware from "./middleware/scimMiddleware";
@@ -7,6 +9,9 @@ import scimMiddleware from "./middleware/scimMiddleware";
 const router = Router();
 
 router.use(authenticateApiRequestMiddleware as RequestHandler);
+router.use(
+  apiStyleRateLimiter((req) => (req as Request & ApiRequestLocals).apiKey),
+);
 router.use(scimMiddleware as RequestHandler);
 
 // API endpoints


### PR DESCRIPTION
### Features and Changes
Add a rate limiter on scim endpoints like we have on api endpoints.

Fixes: https://www.notion.so/growthbook/2fda857e74a08191baabfcd3c4cb9541?v=2fda857e74a0812aba39000cc86b39ed&p=350a857e74a08095b43ae5d2d61519b3&pm=s

### Testing
```
BASE="http://localhost:3100"
KEY="secret_..."   # your secret API key
for i in $(seq 1 65); do
  code=$(curl -s -o /dev/null -w "%{http_code}" \
    -H "Authorization: Bearer $KEY" \
    -H "Accept: application/scim+json" \
    "$BASE/scim/v2/users?count=1")
  echo "$i $code"
done
```
See 403 (since scim isn't set up locally for the first 59 requests, then 429s.
