### PR TITLE
feat: Update fact table page with Radix fly-out menu and audit log

### DIFF
--- a/packages/front-end/components/HistoryTable.tsx
+++ b/packages/front-end/components/HistoryTable.tsx
@@ -156,7 +156,7 @@ export function HistoryTableRow({
 }
 
 const HistoryTable: FC<{
-  type: "experiment" | "metric" | "feature" | "savedGroup";
+  type: "experiment" | "metric" | "feature" | "savedGroup" | "factTable";
   showName?: boolean;
   showType?: boolean;
   id?: string;

--- a/packages/front-end/pages/fact-tables/[ftid].tsx
+++ b/packages/front-end/pages/fact-tables/[ftid].tsx
@@ -1,6 +1,7 @@
 import { useRouter } from "next/router";
 import { useState } from "react";
-import { Box, Flex, Text } from "@radix-ui/themes";
+import { Box, Flex, IconButton, Text } from "@radix-ui/themes";
+import { BsThreeDotsVertical } from "react-icons/bs";
 import {
   FactTableInterface,
   FactMetricInterface,
@@ -11,8 +12,6 @@ import EditOwnerModal from "@/components/Owner/EditOwnerModal";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import LoadingOverlay from "@/components/LoadingOverlay";
 import { GBEdit } from "@/components/Icons";
-import MoreMenu from "@/components/Dropdown/MoreMenu";
-import DeleteButton from "@/components/DeleteButton/DeleteButton";
 import { useAuth } from "@/services/auth";
 import FactTableModal from "@/components/FactTables/FactTableModal";
 import Code from "@/components/SyntaxHighlighting/Code";
@@ -36,6 +35,13 @@ import Frame from "@/ui/Frame";
 import { useUser } from "@/services/UserContext";
 import { DeleteDemoDatasourceButton } from "@/components/DemoDataSourcePage/DemoDataSourcePage";
 import Callout from "@/ui/Callout";
+import {
+  DropdownMenu,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+} from "@/ui/DropdownMenu";
+import Modal from "@/components/Modal";
+import HistoryTable from "@/components/HistoryTable";
 
 export function getMetricsForFactTable(
   factMetrics: FactMetricInterface[],
@@ -60,6 +66,9 @@ export default function FactTablePage() {
 
   const [editProjectsOpen, setEditProjectsOpen] = useState(false);
   const [editTagsModal, setEditTagsModal] = useState(false);
+  const [auditModal, setAuditModal] = useState(false);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [openDropdown, setOpenDropdown] = useState(false);
 
   const [duplicateFactTable, setDuplicateFactTable] = useState<
     FactTableInterface | undefined
@@ -208,6 +217,43 @@ export default function FactTablePage() {
           source="fact-table-page"
         />
       )}
+      {auditModal && (
+        <Modal
+          trackingEventModalType=""
+          open={true}
+          header="Audit Log"
+          close={() => setAuditModal(false)}
+          size="lg"
+          closeCta="Close"
+        >
+          <HistoryTable type="factTable" id={factTable.id} />
+        </Modal>
+      )}
+      {showDeleteModal && (
+        <Modal
+          trackingEventModalType=""
+          header="Delete Fact Table"
+          close={() => setShowDeleteModal(false)}
+          open={true}
+          cta="Delete"
+          submitColor="danger"
+          submit={async () => {
+            await apiCall(`/fact-tables/${factTable.id}`, {
+              method: "DELETE",
+            });
+            mutateDefinitions();
+            setShowDeleteModal(false);
+            router.push("/fact-tables");
+          }}
+          ctaEnabled={canDelete}
+          increasedElevation={true}
+        >
+          <p>
+            Are you sure you want to delete this fact table? This action cannot
+            be undone.
+          </p>
+        </Modal>
+      )}
       <PageHead
         breadcrumb={[
           { display: "Fact Tables", href: "/fact-tables" },
@@ -248,38 +294,50 @@ export default function FactTablePage() {
             <OfficialBadge type="Fact Table" managedBy={factTable.managedBy} />
           </h1>
         </div>
-        <div className="ml-auto">
-          <MoreMenu>
+        <div className="ml-auto mr-2">
+          <DropdownMenu
+            trigger={
+              <IconButton
+                variant="ghost"
+                color="gray"
+                radius="full"
+                size="3"
+                highContrast
+              >
+                <BsThreeDotsVertical size={18} />
+              </IconButton>
+            }
+            menuPlacement="end"
+            open={openDropdown}
+            onOpenChange={setOpenDropdown}
+          >
             {canEdit && (
-              <button
-                className="dropdown-item"
-                onClick={(e) => {
-                  e.preventDefault();
+              <DropdownMenuItem
+                onClick={() => {
+                  setOpenDropdown(false);
                   setEditOpen(true);
                 }}
               >
-                Edit Fact Table
-              </button>
+                Edit
+              </DropdownMenuItem>
             )}
-            {!factTable.managedBy &&
-            canEdit &&
+            {canEdit &&
+            !factTable.managedBy &&
             permissionsUtil.canCreateOfficialResources(factTable) &&
             hasCommercialFeature("manage-official-resources") ? (
-              <button
-                className="dropdown-item"
-                onClick={(e) => {
-                  e.preventDefault();
+              <DropdownMenuItem
+                onClick={() => {
+                  setOpenDropdown(false);
                   setShowConvertToOfficialModal(true);
                 }}
               >
-                Convert to Official Fact Table
-              </button>
+                Convert to Official
+              </DropdownMenuItem>
             ) : null}
             {canDuplicate && (
-              <button
-                className="dropdown-item"
-                onClick={(e) => {
-                  e.preventDefault();
+              <DropdownMenuItem
+                onClick={() => {
+                  setOpenDropdown(false);
                   setDuplicateFactTable({
                     ...factTable,
                     name: `${factTable.name} (Copy)`,
@@ -291,13 +349,22 @@ export default function FactTablePage() {
                   });
                 }}
               >
-                Duplicate Fact Table
-              </button>
+                Duplicate
+              </DropdownMenuItem>
             )}
+            <DropdownMenuItem
+              onClick={() => {
+                setOpenDropdown(false);
+                setAuditModal(true);
+              }}
+            >
+              Audit log
+            </DropdownMenuItem>
+            {canEdit || canDelete ? <DropdownMenuSeparator /> : null}
             {canEdit && (
-              <button
-                className="dropdown-item"
+              <DropdownMenuItem
                 onClick={async () => {
+                  setOpenDropdown(false);
                   await apiCall(
                     `/fact-tables/${factTable.id}/${
                       factTable.archived ? "unarchive" : "archive"
@@ -309,25 +376,21 @@ export default function FactTablePage() {
                   mutateDefinitions();
                 }}
               >
-                {factTable.archived ? "Unarchive" : "Archive"} Fact Table
-              </button>
+                {factTable.archived ? "Unarchive" : "Archive"}
+              </DropdownMenuItem>
             )}
             {canDelete && (
-              <DeleteButton
-                className="dropdown-item"
-                displayName="Fact Table"
-                useIcon={false}
-                text="Delete Fact Table"
-                onClick={async () => {
-                  await apiCall(`/fact-tables/${factTable.id}`, {
-                    method: "DELETE",
-                  });
-                  mutateDefinitions();
-                  router.push("/fact-tables");
+              <DropdownMenuItem
+                color="red"
+                onClick={() => {
+                  setOpenDropdown(false);
+                  setShowDeleteModal(true);
                 }}
-              />
+              >
+                Delete
+              </DropdownMenuItem>
             )}
-          </MoreMenu>
+          </DropdownMenu>
         </div>
       </div>
       <div className="row mb-3">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Features and Changes

Updates the fact table page ([ftid]) to have a Radix styled fly-out menu matching the fact metric page ([fmid]) implementation, with the following changes:

- **Replaced MoreMenu with Radix DropdownMenu**: The fact table page now uses the same Radix `DropdownMenu` component as the fact metric page, providing a consistent and modern UI.

- **Removed "Fact Table" from menu option labels**: Simplified menu labels by removing the redundant "Fact Table" prefix:
  - "Edit Fact Table" → "Edit"
  - "Convert to Official Fact Table" → "Convert to Official"
  - "Duplicate Fact Table" → "Duplicate"
  - "Archive Fact Table" / "Unarchive Fact Table" → "Archive" / "Unarchive"
  - "Delete Fact Table" → "Delete"

- **Added Audit Log access**: Added an "Audit log" menu option that opens a modal displaying the fact table's audit history, similar to how it works on the fact metric page.

- **Updated HistoryTable component**: Extended the `HistoryTable` component to accept `"factTable"` as a valid type, enabling audit log display for fact tables.

- **Delete confirmation modal**: Replaced the inline `DeleteButton` component with a proper confirmation modal for the delete action, matching the fact metric page pattern.

### Dependencies

None

### Testing

1. Navigate to a fact table page
2. Click the three-dots menu icon in the top right
3. Verify the menu opens with options: Edit, Convert to Official (if applicable), Duplicate, Audit log, Archive/Unarchive, Delete
4. Verify none of the options include "Fact Table" in their labels
5. Click "Audit log" and verify the modal opens showing audit history
6. Close the modal and verify other menu options work correctly

### Screenshots

**Fact Table Page with Three-Dots Menu:**
[Fact table detail page](https://cursor.com/agents/bc-7bf306e5-ccbb-5efe-860d-460de094a711/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffact_table_page.webp)

**Dropdown Menu showing options:**
[Dropdown menu showing all options without Fact Table in labels](https://cursor.com/agents/bc-7bf306e5-ccbb-5efe-860d-460de094a711/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdropdown_menu.webp)

**Audit Log Modal:**
[Audit log modal displaying fact table history](https://cursor.com/agents/bc-7bf306e5-ccbb-5efe-860d-460de094a711/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Faudit_log_modal.webp)

### Demo Video

[fact_table_menu_and_audit_log_demo.mp4](https://cursor.com/agents/bc-7bf306e5-ccbb-5efe-860d-460de094a711/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffact_table_menu_and_audit_log_demo.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://growthbookapp.slack.com/archives/C046L8DQD6F/p1777485624190209?thread_ts=1777485624.190209&cid=C046L8DQD6F)

<div><a href="https://cursor.com/agents/bc-7bf306e5-ccbb-5efe-860d-460de094a711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7bf306e5-ccbb-5efe-860d-460de094a711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

