### PR TITLE
Add disableSelfServeBilling toggle and org messages to admin UI

### DIFF
--- a/packages/back-end/src/controllers/admin.ts
+++ b/packages/back-end/src/controllers/admin.ts
@@ -1,6 +1,9 @@
 import { Response } from "express";
 import { parseIntWithDefault } from "shared/util";
-import { OrganizationInterface } from "shared/types/organization";
+import {
+  OrganizationInterface,
+  OrganizationMessage,
+} from "shared/types/organization";
 import { UserInterface } from "shared/types/user";
 import { SSOConnectionInterface } from "shared/types/sso-connection";
 import {
@@ -85,6 +88,8 @@ export async function _dangerousAdminPutOrganization(
     autoApproveMembers?: boolean;
     enterprise?: boolean;
     freeSeats?: number;
+    disableSelfServeBilling?: boolean;
+    messages?: OrganizationMessage[];
   }>,
   res: Response,
 ) {
@@ -105,6 +110,8 @@ export async function _dangerousAdminPutOrganization(
     autoApproveMembers,
     enterprise,
     freeSeats,
+    disableSelfServeBilling,
+    messages,
   } = req.body;
   const updates: Partial<OrganizationInterface> = {};
   const orig: Partial<OrganizationInterface> = {};
@@ -149,6 +156,31 @@ export async function _dangerousAdminPutOrganization(
   if (freeSeats !== org.freeSeats) {
     updates.freeSeats = freeSeats;
     orig.freeSeats = org.freeSeats;
+  }
+  if (
+    disableSelfServeBilling !== undefined &&
+    disableSelfServeBilling !== org.disableSelfServeBilling
+  ) {
+    updates.disableSelfServeBilling = disableSelfServeBilling;
+    orig.disableSelfServeBilling = org.disableSelfServeBilling;
+  }
+  if (messages !== undefined) {
+    const VALID_LEVELS = new Set(["info", "warning", "danger"]);
+    if (
+      !Array.isArray(messages) ||
+      messages.length > 10 ||
+      messages.some(
+        (m) => typeof m.message !== "string" || !VALID_LEVELS.has(m.level),
+      )
+    ) {
+      return res.status(400).json({
+        status: 400,
+        message:
+          "Invalid messages: each entry must have a string message and a level of 'info', 'warning', or 'danger', with a maximum of 10 messages.",
+      });
+    }
+    updates.messages = messages;
+    orig.messages = org.messages;
   }
 
   await updateOrganization(org.id, updates);

--- a/packages/back-end/src/controllers/admin.ts
+++ b/packages/back-end/src/controllers/admin.ts
@@ -168,19 +168,23 @@ export async function _dangerousAdminPutOrganization(
     const VALID_LEVELS = new Set(["info", "warning", "danger"]);
     if (
       !Array.isArray(messages) ||
-      messages.length > 10 ||
       messages.some(
-        (m) => typeof m.message !== "string" || !VALID_LEVELS.has(m.level),
+        (m) =>
+          typeof m.message !== "string" ||
+          m.message.trim() === "" ||
+          !VALID_LEVELS.has(m.level),
       )
     ) {
       return res.status(400).json({
         status: 400,
         message:
-          "Invalid messages: each entry must have a string message and a level of 'info', 'warning', or 'danger', with a maximum of 10 messages.",
+          "Invalid messages: each entry must have a non-empty string message and a level of 'info', 'warning', or 'danger'.",
       });
     }
-    updates.messages = messages;
-    orig.messages = org.messages;
+    if (JSON.stringify(messages) !== JSON.stringify(org.messages ?? [])) {
+      updates.messages = messages;
+      orig.messages = org.messages;
+    }
   }
 
   await updateOrganization(org.id, updates);

--- a/packages/front-end/components/Admin/EditOrganization.tsx
+++ b/packages/front-end/components/Admin/EditOrganization.tsx
@@ -3,12 +3,12 @@ import {
   OrganizationInterface,
   OrganizationMessage,
 } from "shared/types/organization";
-
-type MessageWithId = OrganizationMessage & { id: string };
 import { useAuth } from "@/services/auth";
 import Modal from "@/components/Modal";
 import { isCloud } from "@/services/env";
 import Checkbox from "@/ui/Checkbox";
+
+type MessageWithId = OrganizationMessage & { id: string };
 
 const EditOrganization: FC<{
   onEdit: () => void;

--- a/packages/front-end/components/Admin/EditOrganization.tsx
+++ b/packages/front-end/components/Admin/EditOrganization.tsx
@@ -1,5 +1,8 @@
 import { useState, FC } from "react";
-import { OrganizationInterface } from "shared/types/organization";
+import {
+  OrganizationInterface,
+  OrganizationMessage,
+} from "shared/types/organization";
 import { useAuth } from "@/services/auth";
 import Modal from "@/components/Modal";
 import { isCloud } from "@/services/env";
@@ -26,6 +29,12 @@ const EditOrganization: FC<{
   const [autoApproveMembers, setAutoApproveMembers] = useState(
     currentOrg.autoApproveMembers || false,
   );
+  const [disableSelfServeBilling, setDisableSelfServeBilling] = useState(
+    currentOrg.disableSelfServeBilling || false,
+  );
+  const [messages, setMessages] = useState<OrganizationMessage[]>(
+    currentOrg.messages || [],
+  );
 
   const { apiCall } = useAuth();
 
@@ -45,9 +54,30 @@ const EditOrganization: FC<{
         autoApproveMembers,
         enterprise: legacyEnterprise,
         freeSeats,
+        disableSelfServeBilling,
+        messages,
       }),
     });
     onEdit();
+  };
+
+  const addMessage = () => {
+    setMessages([...messages, { message: "", level: "info" }]);
+  };
+
+  const updateMessage = (
+    index: number,
+    field: keyof OrganizationMessage,
+    value: string,
+  ) => {
+    const updated = messages.map((m, i) =>
+      i === index ? { ...m, [field]: value } : m,
+    );
+    setMessages(updated);
+  };
+
+  const removeMessage = (index: number) => {
+    setMessages(messages.filter((_, i) => i !== index));
   };
 
   return (
@@ -198,6 +228,20 @@ const EditOrganization: FC<{
                 </span>
               </div>
             </div>
+            <div className="mt-3">
+              <Checkbox
+                id="disableSelfServeBilling"
+                label="Disable self-serve billing"
+                value={disableSelfServeBilling}
+                setValue={setDisableSelfServeBilling}
+              />
+              <div>
+                <span className="text-muted small">
+                  Prevents users in this org from managing their own
+                  subscription.
+                </span>
+              </div>
+            </div>
             <div className="p-2 border mt-3">
               <div>
                 <b>Deprecated:</b>
@@ -222,6 +266,62 @@ const EditOrganization: FC<{
                   </span>
                 </div>
               </div>
+            </div>
+            <div className="mt-3">
+              <div className="d-flex justify-content-between align-items-center mb-1">
+                <label className="mb-0 font-weight-bold">
+                  Organization Messages
+                </label>
+                <button
+                  type="button"
+                  className="btn btn-sm btn-outline-primary"
+                  onClick={addMessage}
+                >
+                  + Add Message
+                </button>
+              </div>
+              <div className="text-muted small mb-2">
+                Banners displayed to all users in this org. Supports Markdown.
+                Useful for maintenance notices or account alerts. Each message
+                will appear on every page, so be mindful of not adding too many.
+              </div>
+              {messages.map((msg, i) => (
+                <div key={i} className="d-flex gap-2 mb-2 align-items-center">
+                  <input
+                    type="text"
+                    className="form-control form-control-sm flex-grow-1"
+                    placeholder="Message text (Markdown supported)"
+                    value={msg.message}
+                    onChange={(e) =>
+                      updateMessage(i, "message", e.target.value)
+                    }
+                  />
+                  <select
+                    className="form-control form-control-sm"
+                    style={{ width: 110, flexShrink: 0 }}
+                    value={msg.level}
+                    onChange={(e) =>
+                      updateMessage(
+                        i,
+                        "level",
+                        e.target.value as OrganizationMessage["level"],
+                      )
+                    }
+                  >
+                    <option value="info">Info</option>
+                    <option value="warning">Warning</option>
+                    <option value="danger">Danger</option>
+                  </select>
+                  <button
+                    type="button"
+                    className="btn btn-sm btn-outline-danger"
+                    style={{ flexShrink: 0 }}
+                    onClick={() => removeMessage(i)}
+                  >
+                    &times;
+                  </button>
+                </div>
+              ))}
             </div>
           </>
         ) : null}

--- a/packages/front-end/components/Admin/EditOrganization.tsx
+++ b/packages/front-end/components/Admin/EditOrganization.tsx
@@ -3,6 +3,8 @@ import {
   OrganizationInterface,
   OrganizationMessage,
 } from "shared/types/organization";
+
+type MessageWithId = OrganizationMessage & { id: string };
 import { useAuth } from "@/services/auth";
 import Modal from "@/components/Modal";
 import { isCloud } from "@/services/env";
@@ -32,8 +34,11 @@ const EditOrganization: FC<{
   const [disableSelfServeBilling, setDisableSelfServeBilling] = useState(
     currentOrg.disableSelfServeBilling || false,
   );
-  const [messages, setMessages] = useState<OrganizationMessage[]>(
-    currentOrg.messages || [],
+  const [messages, setMessages] = useState<MessageWithId[]>(
+    (currentOrg.messages || []).map((m) => ({
+      ...m,
+      id: crypto.randomUUID(),
+    })),
   );
 
   const { apiCall } = useAuth();
@@ -55,29 +60,31 @@ const EditOrganization: FC<{
         enterprise: legacyEnterprise,
         freeSeats,
         disableSelfServeBilling,
-        messages,
+        messages: messages.map(({ id: _id, ...m }) => m),
       }),
     });
     onEdit();
   };
 
   const addMessage = () => {
-    setMessages([...messages, { message: "", level: "info" }]);
+    setMessages([
+      ...messages,
+      { id: crypto.randomUUID(), message: "", level: "info" },
+    ]);
   };
 
   const updateMessage = (
-    index: number,
+    id: string,
     field: keyof OrganizationMessage,
     value: string,
   ) => {
-    const updated = messages.map((m, i) =>
-      i === index ? { ...m, [field]: value } : m,
+    setMessages(
+      messages.map((m) => (m.id === id ? { ...m, [field]: value } : m)),
     );
-    setMessages(updated);
   };
 
-  const removeMessage = (index: number) => {
-    setMessages(messages.filter((_, i) => i !== index));
+  const removeMessage = (id: string) => {
+    setMessages(messages.filter((m) => m.id !== id));
   };
 
   return (
@@ -283,17 +290,20 @@ const EditOrganization: FC<{
               <div className="text-muted small mb-2">
                 Banners displayed to all users in this org. Supports Markdown.
                 Useful for maintenance notices or account alerts. Each message
-                will appear on every page, so be mindful of not adding too many.
+                will appear on every page.
               </div>
-              {messages.map((msg, i) => (
-                <div key={i} className="d-flex gap-2 mb-2 align-items-center">
+              {messages.map((msg) => (
+                <div
+                  key={msg.id}
+                  className="d-flex gap-2 mb-2 align-items-center"
+                >
                   <input
                     type="text"
                     className="form-control form-control-sm flex-grow-1"
                     placeholder="Message text (Markdown supported)"
                     value={msg.message}
                     onChange={(e) =>
-                      updateMessage(i, "message", e.target.value)
+                      updateMessage(msg.id, "message", e.target.value)
                     }
                   />
                   <select
@@ -302,7 +312,7 @@ const EditOrganization: FC<{
                     value={msg.level}
                     onChange={(e) =>
                       updateMessage(
-                        i,
+                        msg.id,
                         "level",
                         e.target.value as OrganizationMessage["level"],
                       )
@@ -316,7 +326,7 @@ const EditOrganization: FC<{
                     type="button"
                     className="btn btn-sm btn-outline-danger"
                     style={{ flexShrink: 0 }}
-                    onClick={() => removeMessage(i)}
+                    onClick={() => removeMessage(msg.id)}
                   >
                     &times;
                   </button>


### PR DESCRIPTION
### Features and Changes

Adds two new superadmin controls to the Edit Organization modal (Cloud only):

- **Disable self-serve billing** — a checkbox that sets `disableSelfServeBilling` on an org, preventing users in that org from managing their own subscription through the GrowthBook UI.
- **Organization Messages** — a list editor for per-org banner messages (info / warning / danger severity). These banners are already rendered for all users via `OrganizationMessages`; this change gives superadmins the ability to author and manage them without needing a direct DB edit. Supports Markdown.

Both fields are persisted through the existing `PUT /admin/organization` endpoint and audited via the standard `organization.update` audit event.

- Closes **(add link to issue here)**

### Dependencies

None

### Testing

- [x] Log in as a superadmin and open the Admin page
- [x] Open the Edit modal for any Cloud org
- [x] Toggle **Disable self-serve billing** on/off and confirm it saves and reflects correctly on re-open
- [x] Add an **Organization Message** with each severity level (info, warning, danger) and confirm the banners appear for a user in that org
- [x] Edit and remove messages and confirm changes persist
- [x] Confirm the `organization.update` audit log entry is created for both field types

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->