### PR TITLE
feat: support archived flag in bulk-import facts endpoint

### DIFF
--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -11304,6 +11304,12 @@ paths:
                               - ''
                               - api
                               - admin
+                          archived:
+                            description: >-
+                              Set to true to archive the metric. Archived
+                              metrics are hidden by default in the UI and
+                              excluded from new experiments.
+                            type: boolean
                           metricAutoSlices:
                             description: >-
                               Array of slice column names that will be

--- a/packages/shared/src/validators/bulk-import.ts
+++ b/packages/shared/src/validators/bulk-import.ts
@@ -419,6 +419,12 @@ const postBulkImportFactsBody = z
                 'Set this to "api" to disable editing in the GrowthBook UI',
               )
               .optional(),
+            archived: z
+              .boolean()
+              .describe(
+                "Set to true to archive the metric. Archived metrics are hidden by default in the UI and excluded from new experiments.",
+              )
+              .optional(),
             metricAutoSlices: z
               .array(z.string())
               .describe(


### PR DESCRIPTION
## Summary

- Adds an optional `archived` field to the fact metric payload accepted by `POST /api/v1/bulk-import/facts`.
- Customers syncing fact metrics from version control can now archive metrics through the same bulk endpoint they use for create/update, instead of having to call the standalone update endpoint separately.

The runtime handlers (`getCreateMetricPropsFromBody` and `getUpdateFactMetricPropsFromBody`) already pass `archived` through to the model layer via spread, so this change only required exposing the field in the bulk-import Zod schema and regenerating the OpenAPI spec.

- closes #5763

## Test plan

- [x] Send a bulk-import payload with `factMetrics[].data.archived: true` for a new metric and confirm it is created in the archived state
- [x] Send a bulk-import payload with `archived: true` / `archived: false` for an existing metric and confirm the archived state is updated
- [x] Confirm `pnpm --filter back-end type-check` passes (verified locally)
- [x] Confirm `pnpm --filter back-end generate-openapi` produces the committed spec (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)