### PR TITLE
Remove unused code now that most Clickhouse functions are on the license server

### DIFF
--- a/packages/back-end/src/controllers/datasources.ts
+++ b/packages/back-end/src/controllers/datasources.ts
@@ -1510,10 +1510,7 @@ export async function postRecreateManagedWarehouse(
     );
   }
 
-  await dangerousRecreateClickhouseTables(
-    context.org.id,
-    datasource.settings.materializedColumns || [],
-  );
+  await dangerousRecreateClickhouseTables(context.org.id);
 
   res.status(200).json({
     status: 200,

--- a/packages/back-end/src/controllers/datasources.ts
+++ b/packages/back-end/src/controllers/datasources.ts
@@ -73,10 +73,10 @@ import { SourceIntegrationInterface } from "back-end/src/types/Integration";
 import { logger } from "back-end/src/util/logger";
 import { IS_CLOUD } from "back-end/src/util/secrets";
 import {
-  _dangerousRecreateClickhouseTables,
   getReservedColumnNames,
   updateMaterializedColumns,
 } from "back-end/src/services/clickhouse";
+import { dangerousRecreateClickhouseTables } from "back-end/src/services/licenseServerManagedClickhouse";
 import { UNITS_TABLE_PREFIX } from "back-end/src/queryRunners/ExperimentResultsQueryRunner";
 import { getExperimentsByTrackingKeys } from "back-end/src/models/ExperimentModel";
 
@@ -1510,7 +1510,10 @@ export async function postRecreateManagedWarehouse(
     );
   }
 
-  await _dangerousRecreateClickhouseTables(context, datasource);
+  await dangerousRecreateClickhouseTables(
+    context.org.id,
+    datasource.settings.materializedColumns || [],
+  );
 
   res.status(200).json({
     status: 200,

--- a/packages/back-end/src/controllers/subscription.ts
+++ b/packages/back-end/src/controllers/subscription.ts
@@ -34,10 +34,8 @@ import {
   getLicenseMetaData,
   getUserCodesForOrg,
 } from "back-end/src/services/licenseData";
-import {
-  getDailyUsageForOrg,
-  migrateOverageEventsForOrgId,
-} from "back-end/src/services/clickhouse";
+import { getDailyUsageForOrg } from "back-end/src/services/clickhouse";
+import { migrateOverageEventsForOrgId } from "back-end/src/services/licenseServerManagedClickhouse";
 import {
   createSetupIntent,
   deletePaymentMethodById,

--- a/packages/back-end/src/models/DataSourceModel.ts
+++ b/packages/back-end/src/models/DataSourceModel.ts
@@ -28,7 +28,7 @@ import { IS_CLOUD } from "back-end/src/util/secrets";
 import { ReqContext } from "back-end/types/request";
 import { ApiReqContext } from "back-end/types/api";
 import { logger } from "back-end/src/util/logger";
-import { deleteClickhouseUser } from "back-end/src/services/clickhouse";
+import { deleteClickhouseUser } from "back-end/src/services/licenseServerManagedClickhouse";
 import { createModelAuditLogger } from "back-end/src/services/audit";
 import { deleteFactTable, getFactTable } from "./FactTableModel";
 
@@ -57,7 +57,6 @@ const dataSourceSchema = new mongoose.Schema<DataSourceDocument>({
     index: true,
   },
   settings: {},
-  lockUntil: Date,
 });
 dataSourceSchema.index({ id: 1, organization: 1 }, { unique: true });
 type DataSourceDocument = mongoose.Document & DataSourceInterface;
@@ -407,63 +406,6 @@ export async function updateDataSource(
   );
 
   await audit.logUpdate(context, datasource, { ...datasource, ...updates });
-}
-
-function isLocked(datasource: DataSourceInterface): boolean {
-  if (usingFileConfig() || !datasource.lockUntil) return false;
-  return datasource.lockUntil > new Date();
-}
-
-export async function lockDataSource(
-  context: ReqContext | ApiReqContext,
-  datasource: DataSourceInterface,
-  seconds: number,
-) {
-  if (usingFileConfig()) {
-    throw new Error("Cannot lock. Data sources managed by config.yml");
-  }
-  if (datasource.organization !== context.org.id) {
-    throw new Error("Cannot lock data source from another organization");
-  }
-
-  // Already locked, throw error
-  if (isLocked(datasource)) {
-    throw new Error(
-      "Data source is currently being modified. Please try again later.",
-    );
-  }
-
-  await DataSourceModel.updateOne(
-    {
-      id: datasource.id,
-      organization: context.org.id,
-    },
-    {
-      $set: { lockUntil: new Date(Date.now() + seconds * 1000) },
-    },
-  );
-}
-
-export async function unlockDataSource(
-  context: ReqContext | ApiReqContext,
-  datasource: DataSourceInterface,
-) {
-  if (usingFileConfig()) {
-    throw new Error("Cannot unlock. Data sources managed by config.yml");
-  }
-  if (datasource.organization !== context.org.id) {
-    throw new Error("Cannot unlock data source from another organization");
-  }
-
-  await DataSourceModel.updateOne(
-    {
-      id: datasource.id,
-      organization: context.org.id,
-    },
-    {
-      $set: { lockUntil: null },
-    },
-  );
 }
 
 // WARNING: This does not restrict by organization

--- a/packages/back-end/src/models/SdkConnectionModel.ts
+++ b/packages/back-end/src/models/SdkConnectionModel.ts
@@ -26,7 +26,8 @@ import {
 import { errorStringFromZodResult } from "back-end/src/util/validation";
 import { ApiReqContext } from "back-end/types/api";
 import { ReqContext } from "back-end/types/request";
-import { addCloudSDKMapping } from "back-end/src/services/clickhouse";
+import { addCloudSDKMapping } from "back-end/src/services/licenseServerManagedClickhouse";
+import { logger } from "back-end/src/util/logger";
 import { queueSDKPayloadRefresh } from "back-end/src/services/features";
 import { createModelAuditLogger } from "back-end/src/services/audit";
 import {
@@ -266,7 +267,15 @@ export async function createSDKConnection(
   const doc = await SDKConnectionModel.create(connection);
 
   if (IS_CLOUD) {
-    await addCloudSDKMapping(connection);
+    const { key, organization } = connection;
+    try {
+      await addCloudSDKMapping(key, organization);
+    } catch (e) {
+      logger.error(
+        e,
+        `Error inserting sdk key mapping (${key} -> ${organization})`,
+      );
+    }
   }
 
   queueSDKPayloadRefresh({

--- a/packages/back-end/src/services/clickhouse.ts
+++ b/packages/back-end/src/services/clickhouse.ts
@@ -1,20 +1,15 @@
-import * as crypto from "crypto";
 import { createClient as createClickhouseClient } from "@clickhouse/client";
-import generator from "generate-password";
 import { AIPromptType } from "shared/ai";
 import { MANAGED_WAREHOUSE_EVENTS_FACT_TABLE_ID } from "shared/constants";
 import {
   isManagedWarehouseAwaitingProvisioning,
   parseIntWithDefault,
 } from "shared/util";
-import { SDKConnectionInterface } from "shared/types/sdk-connection";
 import {
   GrowthbookClickhouseDataSource,
-  DataSourceParams,
   MaterializedColumn,
 } from "shared/types/datasource";
 import { DailyUsage } from "shared/types/organization";
-import { FactTableColumnType } from "shared/types/fact-table";
 import {
   CLICKHOUSE_HOST,
   CLICKHOUSE_ADMIN_USER,
@@ -23,9 +18,7 @@ import {
   CLICKHOUSE_MAIN_TABLE,
   ENVIRONMENT,
   IS_CLOUD,
-  CLICKHOUSE_DEV_PREFIX,
   CLICKHOUSE_OVERAGE_TABLE,
-  MANAGED_CLICKHOUSE_USE_LICENSE_SERVER,
 } from "back-end/src/util/secrets";
 import type { ReqContext } from "back-end/types/request";
 import { logger } from "back-end/src/util/logger";
@@ -33,18 +26,7 @@ import {
   getFactTablesForDatasource,
   updateFactTableColumns,
 } from "back-end/src/models/FactTableModel";
-import {
-  lockDataSource,
-  unlockDataSource,
-} from "back-end/src/models/DataSourceModel";
-import {
-  addCloudSDKMappingViaLicenseServer,
-  createClickhouseUserViaLicenseServer,
-  dangerousRecreateClickhouseTablesViaLicenseServer,
-  deleteClickhouseUserViaLicenseServer,
-  migrateOverageEventsForOrgIdViaLicenseServer,
-  updateMaterializedColumnsInClickhouseViaLicenseServer,
-} from "back-end/src/services/licenseServerManagedClickhouse";
+import { updateMaterializedColumnsInClickhouse } from "back-end/src/services/licenseServerManagedClickhouse";
 
 type ClickHouseDataType =
   | "DateTime"
@@ -53,33 +35,6 @@ type ClickHouseDataType =
   | "String"
   | "LowCardinality(String)";
 
-// These will eventually move to be inside of attributes
-const tempTopLevelFields: Record<string, ClickHouseDataType> = {
-  user_id: "String",
-  url: "String",
-  url_path: "String",
-  url_host: "String",
-  url_query: "String",
-  url_fragment: "String",
-  device_id: "String",
-  page_id: "String",
-  session_id: "String",
-  page_title: "String",
-  utm_source: "String",
-  utm_medium: "String",
-  utm_campaign: "String",
-  utm_term: "String",
-  utm_content: "String",
-  geo_country: "String",
-  geo_city: "String",
-  geo_lat: "Float64",
-  geo_lon: "Float64",
-  ua: "String",
-  ua_browser: "String",
-  ua_os: "String",
-  ua_device_type: "String",
-};
-
 const REMAINING_COLUMNS_SCHEMA: Record<string, ClickHouseDataType> = {
   environment: "LowCardinality(String)",
   sdk_language: "LowCardinality(String)",
@@ -87,17 +42,6 @@ const REMAINING_COLUMNS_SCHEMA: Record<string, ClickHouseDataType> = {
   event_uuid: "String",
   ip: "String",
 };
-
-function clickhouseUserId(orgId: string) {
-  // Sanity check. An orgId of `default` or another reserved word would seriously mess things up
-  if (!orgId.startsWith("org_")) {
-    throw new Error("Invalid organization id");
-  }
-
-  return ENVIRONMENT === "production"
-    ? `${orgId}`
-    : `${CLICKHOUSE_DEV_PREFIX}${orgId}`;
-}
 
 function ensureClickhouseEnvVars() {
   if (
@@ -128,49 +72,6 @@ function createAdminClickhouseClient() {
   });
 }
 
-function getClickhouseDatatype(
-  columnType: FactTableColumnType,
-): ClickHouseDataType {
-  switch (columnType) {
-    case "date":
-      return "DateTime";
-    case "number":
-      return "Float64";
-    case "boolean":
-      return "Boolean";
-    default:
-      return "String";
-  }
-}
-
-function getClickhouseExtractClause(
-  sourceField: string,
-  columnType: FactTableColumnType,
-) {
-  // Some fields will eventually be inside attributes instead of top-level
-  // This is a temp workaround until then
-  if (tempTopLevelFields[sourceField]) {
-    const desiredDataType = getClickhouseDatatype(columnType);
-
-    // If the desired data type is different from the actual type, need to cast it
-    if (desiredDataType !== tempTopLevelFields[sourceField]) {
-      return `CAST(${sourceField} AS ${desiredDataType})`;
-    }
-
-    // Otherwise, just return the column name
-    return sourceField;
-  }
-
-  switch (columnType) {
-    case "number":
-      return `JSONExtractFloat(context_json, '${sourceField}')`;
-    case "boolean":
-      return `JSONExtractBool(context_json, '${sourceField}')`;
-    default:
-      return `JSONExtractString(context_json, '${sourceField}')`;
-  }
-}
-
 export function getReservedColumnNames(): Set<string> {
   return new Set(
     [
@@ -183,388 +84,6 @@ export function getReservedColumnNames(): Set<string> {
       "variation_id",
       ...Object.keys(REMAINING_COLUMNS_SCHEMA),
     ].map((col) => col.toLowerCase()),
-  );
-}
-
-type ColumnDef = {
-  source: string;
-  alias?: string;
-  datatype: ClickHouseDataType;
-};
-
-function getCreateTableColumnList(columns: ColumnDef[]): string[] {
-  return columns.map(
-    ({ source, alias, datatype }) => `${alias || source} ${datatype}`,
-  );
-}
-function getSelectColumnList(columns: ColumnDef[]): string[] {
-  return columns.map(
-    ({ source, alias }) =>
-      `${source}${alias && alias !== source ? ` as ${alias}` : ""}`,
-  );
-}
-
-function getRemainingColumnDefs(): ColumnDef[] {
-  return Object.entries(REMAINING_COLUMNS_SCHEMA).map(([colName, colType]) => ({
-    source: colName,
-    datatype: colType as ClickHouseDataType,
-  }));
-}
-
-function getMaterializedColumnDefs(
-  materializedColumns: MaterializedColumn[],
-): ColumnDef[] {
-  return materializedColumns.map(({ columnName, datatype, sourceField }) => ({
-    source: getClickhouseExtractClause(sourceField, datatype),
-    alias: columnName,
-    datatype: getClickhouseDatatype(datatype),
-  }));
-}
-
-function getMaterializedViewSQL({
-  orgId,
-  colDefs,
-  orderBy,
-  filter,
-  baseTableName,
-}: {
-  orgId: string;
-  colDefs: ColumnDef[];
-  orderBy: string;
-  filter: string;
-  baseTableName: string;
-}): {
-  createTable: string;
-  createView: string;
-  populateTable: string;
-  select: string;
-  tableName: string;
-  viewName: string;
-} {
-  const tableName = getTableName(orgId, baseTableName);
-  const viewName = getTableName(orgId, `${baseTableName}_mv`);
-
-  const createTable = `CREATE TABLE ${tableName} (
-  ${getCreateTableColumnList(colDefs).join(",\n  ")}
-) ENGINE = MergeTree()
-PARTITION BY toYYYYMM(timestamp) 
-ORDER BY ${orderBy}`;
-
-  const select = `SELECT ${getSelectColumnList(colDefs).join(", ")}
-    FROM ${CLICKHOUSE_MAIN_TABLE} 
-    WHERE (organization = '${orgId}') AND (${filter})`;
-
-  const populateTable = `INSERT INTO ${tableName} ${select}`;
-  const createView = `CREATE MATERIALIZED VIEW ${viewName} TO ${tableName} 
-DEFINER=CURRENT_USER SQL SECURITY DEFINER
-AS ${select}`;
-
-  return {
-    createTable,
-    select,
-    populateTable,
-    createView,
-    tableName,
-    viewName,
-  };
-}
-
-function getEventsSQL(
-  orgId: string,
-  materializedColumns: MaterializedColumn[],
-) {
-  return getMaterializedViewSQL({
-    orgId,
-    baseTableName: "events",
-    filter: "event_name NOT IN ('Experiment Viewed', 'Feature Evaluated')",
-    orderBy: "(event_name, timestamp)",
-    colDefs: [
-      { source: "timestamp", datatype: "DateTime" },
-      { source: "client_key", datatype: "String" },
-      { source: "event_name", datatype: "String" },
-      { source: "properties_json", alias: "properties", datatype: "String" },
-      { source: "context_json", alias: "attributes", datatype: "String" },
-      ...getRemainingColumnDefs(),
-      ...getMaterializedColumnDefs(materializedColumns),
-    ],
-  });
-}
-
-function getExperimentViewSQL(
-  orgId: string,
-  materializedColumns: MaterializedColumn[],
-) {
-  return getMaterializedViewSQL({
-    orgId,
-    baseTableName: "experiment_views",
-    filter: "event_name = 'Experiment Viewed'",
-    orderBy: "(experiment_id, timestamp)",
-    colDefs: [
-      { source: "timestamp", datatype: "DateTime" },
-      { source: "client_key", datatype: "String" },
-      {
-        source: "JSONExtractString(properties_json, 'experimentId')",
-        alias: "experiment_id",
-        datatype: "String",
-      },
-      {
-        source: "JSONExtractString(properties_json, 'variationId')",
-        alias: "variation_id",
-        datatype: "String",
-      },
-      { source: "properties_json", alias: "properties", datatype: "String" },
-      { source: "context_json", alias: "attributes", datatype: "String" },
-      ...getRemainingColumnDefs(),
-      ...getMaterializedColumnDefs(materializedColumns),
-    ],
-  });
-}
-
-function getFeatureusageSQL(orgId: string) {
-  return getMaterializedViewSQL({
-    orgId,
-    baseTableName: "feature_usage",
-    filter: "event_name = 'Feature Evaluated'",
-    orderBy: "(feature, timestamp)",
-    colDefs: [
-      { source: "timestamp", datatype: "DateTime" },
-      { source: "client_key", datatype: "String" },
-      {
-        source: "JSONExtractString(properties_json, 'feature')",
-        alias: "feature",
-        datatype: "String",
-      },
-      {
-        source: "JSONExtractString(properties_json, 'revision')",
-        alias: "revision",
-        datatype: "String",
-      },
-      {
-        source: "JSONExtractString(properties_json, 'source')",
-        alias: "source",
-        datatype: "String",
-      },
-      {
-        source: "JSONExtractString(properties_json, 'value')",
-        alias: "value",
-        datatype: "String",
-      },
-      {
-        source: "JSONExtractString(properties_json, 'ruleId')",
-        alias: "ruleId",
-        datatype: "String",
-      },
-      {
-        source: "JSONExtractString(properties_json, 'variationId')",
-        alias: "variationId",
-        datatype: "String",
-      },
-      { source: "context_json", alias: "attributes", datatype: "String" },
-      ...getRemainingColumnDefs(),
-    ],
-  });
-}
-
-async function runCommand(
-  client: ReturnType<typeof createClickhouseClient>,
-  query: string,
-): Promise<void> {
-  await client.command({ query });
-}
-
-function getTableName(orgId: string, name: string) {
-  const user = clickhouseUserId(orgId);
-  const database = user;
-  return `${database}.${name}`;
-}
-
-export async function createClickhouseUser(
-  context: ReqContext,
-  materializedColumns: MaterializedColumn[] = [],
-): Promise<DataSourceParams> {
-  if (MANAGED_CLICKHOUSE_USE_LICENSE_SERVER) {
-    return createClickhouseUserViaLicenseServer(
-      context.org.id,
-      materializedColumns,
-    );
-  }
-
-  const client = createAdminClickhouseClient();
-
-  const orgId = context.org.id;
-  const user = clickhouseUserId(orgId);
-  const password = generator.generate({
-    length: 30,
-    numbers: true,
-  });
-  const hashedPassword = crypto
-    .createHash("sha256")
-    .update(password)
-    .digest("hex");
-
-  const database = user;
-  logger.info(`creating Clickhouse database ${database}`);
-  // It's important this does not have "IF NOT EXISTS" to protect against race conditions
-  await runCommand(client, `CREATE DATABASE ${database}`);
-
-  logger.info(`Creating Clickhouse user ${user}`);
-  await runCommand(
-    client,
-    `CREATE USER ${user} IDENTIFIED WITH sha256_hash BY '${hashedPassword}' DEFAULT DATABASE ${database}`,
-  );
-
-  await createClickhouseTables(client, orgId, materializedColumns);
-
-  logger.info(
-    `Granting select permissions on information_schema.columns to ${user}`,
-  );
-  // For schema browser.  They can only see info on tables that they have select permissions on.
-  await runCommand(
-    client,
-    `GRANT SELECT(data_type, table_name, table_catalog, table_schema, column_name) ON information_schema.columns TO ${user}`,
-  );
-
-  const url = new URL(CLICKHOUSE_HOST);
-
-  const params = {
-    port: parseIntWithDefault(url.port, 9000),
-    url: url.toString(),
-    user: user,
-    password: password,
-    database: database,
-  };
-
-  return params;
-}
-
-export async function createClickhouseTables(
-  client: ReturnType<typeof createAdminClickhouseClient>,
-  orgId: string,
-  materializedColumns: MaterializedColumn[] = [],
-): Promise<void> {
-  const user = clickhouseUserId(orgId);
-  const database = user;
-
-  // Events table
-  const eventsSQL = getEventsSQL(orgId, materializedColumns);
-  logger.info(`Creating table ${eventsSQL.tableName}`);
-  await runCommand(client, eventsSQL.createTable);
-  logger.info(`Populating table ${eventsSQL.tableName}`);
-  await runCommand(client, eventsSQL.populateTable);
-  logger.info(`Creating materialized view ${eventsSQL.viewName}`);
-  await runCommand(client, eventsSQL.createView);
-
-  // Experiment views table
-  const experimentViewSQL = getExperimentViewSQL(orgId, materializedColumns);
-  logger.info(`Creating table ${experimentViewSQL.tableName}`);
-  await runCommand(client, experimentViewSQL.createTable);
-  logger.info(`Populating table ${experimentViewSQL.tableName}`);
-  await runCommand(client, experimentViewSQL.populateTable);
-  logger.info(`Creating materialized view ${experimentViewSQL.viewName}`);
-  await runCommand(client, experimentViewSQL.createView);
-
-  // Feature usage table
-  const featureUsageSQL = getFeatureusageSQL(orgId);
-  logger.info(`Creating table ${featureUsageSQL.tableName}`);
-  await runCommand(client, featureUsageSQL.createTable);
-  logger.info(`Populating table ${featureUsageSQL.tableName}`);
-  await runCommand(client, featureUsageSQL.populateTable);
-  logger.info(`Creating materialized view ${featureUsageSQL.viewName}`);
-  await runCommand(client, featureUsageSQL.createView);
-
-  logger.info(`Granting select permissions on ${database}.* to ${user}`);
-  await runCommand(client, `GRANT SELECT ON ${database}.* TO ${user}`);
-}
-
-export async function _dangerousRecreateClickhouseTables(
-  context: ReqContext,
-  datasource: GrowthbookClickhouseDataSource,
-): Promise<void> {
-  const orgId = context.org.id;
-
-  try {
-    if (MANAGED_CLICKHOUSE_USE_LICENSE_SERVER) {
-      await dangerousRecreateClickhouseTablesViaLicenseServer(
-        orgId,
-        datasource.settings.materializedColumns || [],
-      );
-    } else {
-      // Backfilling data can take a while, so lock the datasource for 30 minutes
-      await lockDataSource(context, datasource, 1800);
-
-      const client = createAdminClickhouseClient();
-      const user = clickhouseUserId(orgId);
-      const database = user;
-
-      // Drop the entire database and recreate it
-      logger.info(`Dropping Clickhouse database ${database}`);
-      await runCommand(client, `DROP DATABASE IF EXISTS ${database}`);
-
-      logger.info(`Creating Clickhouse database ${database}`);
-      await runCommand(client, `CREATE DATABASE ${database}`);
-      await createClickhouseTables(
-        client,
-        orgId,
-        datasource.settings.materializedColumns || [],
-      );
-    }
-  } finally {
-    await unlockDataSource(context, datasource);
-  }
-}
-
-export async function deleteClickhouseUser(organization: string) {
-  if (MANAGED_CLICKHOUSE_USE_LICENSE_SERVER) {
-    return deleteClickhouseUserViaLicenseServer(organization);
-  }
-
-  const client = createAdminClickhouseClient();
-  const user = clickhouseUserId(organization);
-  const database = user;
-
-  logger.info(`Deleting Clickhouse user ${user}`);
-  await runCommand(client, `DROP USER IF EXISTS ${user}`);
-
-  logger.info(`Deleting Clickhouse database ${database}`);
-  await runCommand(client, `DROP DATABASE IF EXISTS ${database}`);
-}
-
-export async function addCloudSDKMapping(connection: SDKConnectionInterface) {
-  const { key, organization } = connection;
-
-  // This is not a fatal error, so just log instead of throwing
-  try {
-    if (MANAGED_CLICKHOUSE_USE_LICENSE_SERVER) {
-      await addCloudSDKMappingViaLicenseServer(key, organization);
-    } else {
-      const client = createAdminClickhouseClient();
-      await client.insert({
-        table: "usage.sdk_key_mapping",
-        values: [{ key, organization }],
-        format: "JSONEachRow",
-      });
-    }
-  } catch (e) {
-    logger.error(
-      e,
-      `Error inserting sdk key mapping (${key} -> ${organization})`,
-    );
-  }
-}
-
-export async function migrateOverageEventsForOrgId(orgId: string) {
-  if (MANAGED_CLICKHOUSE_USE_LICENSE_SERVER) {
-    return migrateOverageEventsForOrgIdViaLicenseServer(orgId);
-  }
-
-  const client = createAdminClickhouseClient();
-  await runCommand(
-    client,
-    `INSERT INTO ${CLICKHOUSE_MAIN_TABLE} SELECT * FROM ${CLICKHOUSE_OVERAGE_TABLE} WHERE organization = '${orgId}'`,
-  );
-  await runCommand(
-    client,
-    `ALTER TABLE ${CLICKHOUSE_OVERAGE_TABLE} DELETE WHERE organization = '${orgId}'`,
   );
 }
 
@@ -734,101 +253,14 @@ export async function updateMaterializedColumns({
   }
   const orgId = datasource.organization;
 
-  try {
-    if (MANAGED_CLICKHOUSE_USE_LICENSE_SERVER) {
-      await updateMaterializedColumnsInClickhouseViaLicenseServer({
-        orgId,
-        columnsToAdd,
-        columnsToDelete,
-        columnsToRename,
-        finalColumns,
-        originalColumns,
-      });
-    } else {
-      // We can only process one materialized column update at a time.
-      // This should be quick, but lock it 5 minutes just in case.
-      await lockDataSource(context, datasource, 300);
-
-      const client = createAdminClickhouseClient();
-
-      const addClauses = columnsToAdd
-        .map(
-          ({ columnName, datatype }) =>
-            `ADD COLUMN IF NOT EXISTS ${columnName} ${getClickhouseDatatype(
-              datatype,
-            )}`,
-        )
-        .join(", ");
-      const dropClauses = columnsToDelete
-        .map((columnName) => `DROP COLUMN IF EXISTS ${columnName}`)
-        .join(", ");
-      const renameClauses = columnsToRename
-        .map(({ from, to }) => `RENAME COLUMN ${from} to ${to}`)
-        .join(", ");
-      const clauses = `${addClauses}${
-        columnsToAdd.length > 0 &&
-        columnsToDelete.length + columnsToRename.length > 0
-          ? ", "
-          : ""
-      }${dropClauses}${
-        columnsToDelete.length > 0 && columnsToRename.length > 0 ? ", " : ""
-      }${renameClauses}`;
-
-      // Track which columns the view should be recreated with in case of an error
-      let viewColumns = originalColumns;
-
-      // First update the main events table
-      const { tableName: eventsTableName, viewName: eventsViewName } =
-        getEventsSQL(orgId, []);
-      logger.info(
-        `Updating materialized columns; dropping view ${eventsViewName}`,
-      );
-      await runCommand(client, `DROP VIEW IF EXISTS ${eventsViewName}`);
-      let err = undefined;
-      try {
-        logger.info(`Updating table schema for ${eventsTableName}`);
-        await runCommand(client, `ALTER TABLE ${eventsTableName} ${clauses}`);
-        viewColumns = finalColumns;
-      } catch (e) {
-        logger.error(e);
-        err = e;
-      } finally {
-        logger.info(`Recreating materialized view ${eventsViewName}`);
-        const eventsSQL = getEventsSQL(orgId, viewColumns);
-        await runCommand(client, eventsSQL.createView);
-      }
-      if (err) {
-        throw err;
-      }
-
-      // Now update the experiment views table
-      const { tableName: exposureTableName, viewName: exposureViewName } =
-        getExperimentViewSQL(orgId, []);
-      logger.info(
-        `Updating materialized columns; dropping view ${exposureViewName}`,
-      );
-      await runCommand(client, `DROP VIEW IF EXISTS ${exposureViewName}`);
-      err = undefined;
-      viewColumns = originalColumns;
-      try {
-        logger.info(`Updating table schema for ${exposureTableName}`);
-        await runCommand(client, `ALTER TABLE ${exposureTableName} ${clauses}`);
-        viewColumns = finalColumns;
-      } catch (e) {
-        logger.error(e);
-        err = e;
-      } finally {
-        logger.info(`Recreating materialized view ${exposureViewName}`);
-        const experimentViewSQL = getExperimentViewSQL(orgId, viewColumns);
-        await runCommand(client, experimentViewSQL.createView);
-      }
-      if (err) {
-        throw err;
-      }
-    }
-  } finally {
-    await unlockDataSource(context, datasource);
-  }
+  await updateMaterializedColumnsInClickhouse({
+    orgId,
+    columnsToAdd,
+    columnsToDelete,
+    columnsToRename,
+    finalColumns,
+    originalColumns,
+  });
 
   // Update the main events fact table with the new columns
   const factTables = await getFactTablesForDatasource(context, datasource.id);

--- a/packages/back-end/src/services/licenseServerManagedClickhouse.ts
+++ b/packages/back-end/src/services/licenseServerManagedClickhouse.ts
@@ -123,7 +123,7 @@ async function postManagedClickhouse(
   return res;
 }
 
-export async function createClickhouseUserViaLicenseServer(
+export async function createClickhouseUser(
   orgId: string,
   materializedColumns: MaterializedColumn[] = [],
 ): Promise<DataSourceParams> {
@@ -134,7 +134,7 @@ export async function createClickhouseUserViaLicenseServer(
   return (await res.json()) as DataSourceParams;
 }
 
-export async function dangerousRecreateClickhouseTablesViaLicenseServer(
+export async function dangerousRecreateClickhouseTables(
   orgId: string,
   materializedColumns: MaterializedColumn[] = [],
 ): Promise<void> {
@@ -144,13 +144,11 @@ export async function dangerousRecreateClickhouseTablesViaLicenseServer(
   });
 }
 
-export async function deleteClickhouseUserViaLicenseServer(
-  orgId: string,
-): Promise<void> {
+export async function deleteClickhouseUser(orgId: string): Promise<void> {
   await postManagedClickhouse("delete", { orgId });
 }
 
-export async function addCloudSDKMappingViaLicenseServer(
+export async function addCloudSDKMapping(
   key: string,
   organization: string,
 ): Promise<void> {
@@ -160,13 +158,13 @@ export async function addCloudSDKMappingViaLicenseServer(
   });
 }
 
-export async function migrateOverageEventsForOrgIdViaLicenseServer(
+export async function migrateOverageEventsForOrgId(
   orgId: string,
 ): Promise<void> {
   await postManagedClickhouse("migrate-overage", { orgId });
 }
 
-export async function updateMaterializedColumnsInClickhouseViaLicenseServer({
+export async function updateMaterializedColumnsInClickhouse({
   orgId,
   columnsToAdd,
   columnsToDelete,

--- a/packages/back-end/src/services/licenseServerManagedClickhouse.ts
+++ b/packages/back-end/src/services/licenseServerManagedClickhouse.ts
@@ -2,10 +2,7 @@
  * Delegates managed ClickHouse provisioning to central-license-server
  * (see managed-clickhouse/* routes there).
  */
-import type {
-  DataSourceParams,
-  MaterializedColumn,
-} from "shared/types/datasource";
+import type { MaterializedColumn } from "shared/types/datasource";
 import type { RequestInit, Response } from "node-fetch";
 import { LICENSE_SERVER_URL } from "back-end/src/enterprise/licenseUtil";
 import { logger } from "back-end/src/util/logger";
@@ -123,25 +120,10 @@ async function postManagedClickhouse(
   return res;
 }
 
-export async function createClickhouseUser(
-  orgId: string,
-  materializedColumns: MaterializedColumn[] = [],
-): Promise<DataSourceParams> {
-  const res = await postManagedClickhouse("provision", {
-    orgId,
-    materializedColumns,
-  });
-  return (await res.json()) as DataSourceParams;
-}
-
 export async function dangerousRecreateClickhouseTables(
   orgId: string,
-  materializedColumns: MaterializedColumn[] = [],
 ): Promise<void> {
-  await postManagedClickhouse("recreate-tables", {
-    orgId,
-    materializedColumns,
-  });
+  await postManagedClickhouse("recreate-tables", { orgId });
 }
 
 export async function deleteClickhouseUser(orgId: string): Promise<void> {

--- a/packages/back-end/src/util/secrets.ts
+++ b/packages/back-end/src/util/secrets.ts
@@ -322,8 +322,6 @@ export const CLICKHOUSE_DATABASE = process.env.CLICKHOUSE_DATABASE || "";
 export const CLICKHOUSE_MAIN_TABLE = process.env.CLICKHOUSE_MAIN_TABLE || "";
 export const CLICKHOUSE_OVERAGE_TABLE =
   process.env.CLICKHOUSE_OVERAGE_TABLE || "overage_events";
-export const CLICKHOUSE_DEV_PREFIX =
-  process.env.CLICKHOUSE_DEV_PREFIX || "test_";
 
 export const CLOUD_SECRET = process.env.CLOUD_SECRET ?? "";
 

--- a/packages/back-end/src/util/secrets.ts
+++ b/packages/back-end/src/util/secrets.ts
@@ -325,14 +325,6 @@ export const CLICKHOUSE_OVERAGE_TABLE =
 export const CLICKHOUSE_DEV_PREFIX =
   process.env.CLICKHOUSE_DEV_PREFIX || "test_";
 
-/** When true, managed warehouse ClickHouse provisioning runs on central-license-server.
- * TODO(james): remove this once we are sure we don't need to rollback.
- */
-export const MANAGED_CLICKHOUSE_USE_LICENSE_SERVER = stringToBoolean(
-  process.env.MANAGED_CLICKHOUSE_USE_LICENSE_SERVER,
-  IS_CLOUD,
-);
-
 export const CLOUD_SECRET = process.env.CLOUD_SECRET ?? "";
 
 // Note: the Visual Editor relies on the information in this path, so disabling it will prevent some features from working correctly.

--- a/packages/back-end/test/services/clickhouse.test.ts
+++ b/packages/back-end/test/services/clickhouse.test.ts
@@ -12,15 +12,6 @@ import {
   updateFactTableColumns,
 } from "back-end/src/models/FactTableModel";
 
-const mockCommand = jest.fn();
-const mockClickhouseClient = {
-  command: mockCommand,
-};
-
-jest.mock("@clickhouse/client", () => ({
-  createClient: jest.fn(() => mockClickhouseClient),
-}));
-
 jest.mock("back-end/src/util/secrets", () => ({
   CLICKHOUSE_HOST: "http://localhost:8123",
   CLICKHOUSE_ADMIN_USER: "admin",
@@ -29,7 +20,6 @@ jest.mock("back-end/src/util/secrets", () => ({
   CLICKHOUSE_MAIN_TABLE: "events",
   ENVIRONMENT: "development",
   IS_CLOUD: false,
-  CLICKHOUSE_DEV_PREFIX: "dev_",
   CLICKHOUSE_OVERAGE_TABLE: "overage",
 }));
 
@@ -87,7 +77,6 @@ describe("updateMaterializedColumns", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockCommand.mockResolvedValue(undefined);
     mockUpdateFactTableColumns.mockResolvedValue(undefined as never);
   });
 
@@ -146,7 +135,6 @@ describe("updateMaterializedColumns", () => {
       originalColumns: [],
     });
 
-    expect(mockCommand).not.toHaveBeenCalled();
     expect(mockUpdateMaterializedColumnsLicense).not.toHaveBeenCalled();
   });
 

--- a/packages/back-end/test/services/clickhouse.test.ts
+++ b/packages/back-end/test/services/clickhouse.test.ts
@@ -6,14 +6,11 @@ import {
 import { MANAGED_WAREHOUSE_EVENTS_FACT_TABLE_ID } from "shared/constants";
 import type { ReqContext } from "back-end/types/request";
 import { updateMaterializedColumns } from "back-end/src/services/clickhouse";
+import { updateMaterializedColumnsInClickhouse } from "back-end/src/services/licenseServerManagedClickhouse";
 import {
   getFactTablesForDatasource,
   updateFactTableColumns,
 } from "back-end/src/models/FactTableModel";
-import {
-  lockDataSource,
-  unlockDataSource,
-} from "back-end/src/models/DataSourceModel";
 
 const mockCommand = jest.fn();
 const mockClickhouseClient = {
@@ -34,7 +31,10 @@ jest.mock("back-end/src/util/secrets", () => ({
   IS_CLOUD: false,
   CLICKHOUSE_DEV_PREFIX: "dev_",
   CLICKHOUSE_OVERAGE_TABLE: "overage",
-  MANAGED_CLICKHOUSE_USE_LICENSE_SERVER: false,
+}));
+
+jest.mock("back-end/src/services/licenseServerManagedClickhouse", () => ({
+  updateMaterializedColumnsInClickhouse: jest.fn().mockResolvedValue(undefined),
 }));
 
 jest.mock("back-end/src/models/FactTableModel", () => ({
@@ -42,15 +42,11 @@ jest.mock("back-end/src/models/FactTableModel", () => ({
   updateFactTableColumns: jest.fn(),
 }));
 
-jest.mock("back-end/src/models/DataSourceModel", () => ({
-  lockDataSource: jest.fn(),
-  unlockDataSource: jest.fn(),
-}));
-
 const mockGetFactTablesForDatasource = jest.mocked(getFactTablesForDatasource);
 const mockUpdateFactTableColumns = jest.mocked(updateFactTableColumns);
-const mockLockDataSource = jest.mocked(lockDataSource);
-const mockUnlockDataSource = jest.mocked(unlockDataSource);
+const mockUpdateMaterializedColumnsLicense = jest.mocked(
+  updateMaterializedColumnsInClickhouse,
+);
 
 function makeFactTableColumn(
   column: string,
@@ -92,8 +88,6 @@ describe("updateMaterializedColumns", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockCommand.mockResolvedValue(undefined);
-    mockLockDataSource.mockResolvedValue(undefined as never);
-    mockUnlockDataSource.mockResolvedValue(undefined as never);
     mockUpdateFactTableColumns.mockResolvedValue(undefined as never);
   });
 
@@ -124,6 +118,7 @@ describe("updateMaterializedColumns", () => {
       originalColumns: [],
     });
 
+    expect(mockUpdateMaterializedColumnsLicense).toHaveBeenCalledTimes(1);
     expect(mockUpdateFactTableColumns).toHaveBeenCalledTimes(1);
     const changes = mockUpdateFactTableColumns.mock.calls[0][1] as {
       columns: ColumnInterface[];
@@ -135,7 +130,7 @@ describe("updateMaterializedColumns", () => {
     );
   });
 
-  it("does not call ClickHouse when managed warehouse has not been provisioned yet", async () => {
+  it("does not call the managed warehouse service when provisioning is not complete", async () => {
     const unprovisionedDs = {
       ...datasource,
       settings: { hasBeenProvisioned: false },
@@ -151,8 +146,8 @@ describe("updateMaterializedColumns", () => {
       originalColumns: [],
     });
 
-    expect(mockLockDataSource).not.toHaveBeenCalled();
     expect(mockCommand).not.toHaveBeenCalled();
+    expect(mockUpdateMaterializedColumnsLicense).not.toHaveBeenCalled();
   });
 
   it("restores deleted rename destination and tombstones source when destination name already exists", async () => {
@@ -183,6 +178,7 @@ describe("updateMaterializedColumns", () => {
       originalColumns: [],
     });
 
+    expect(mockUpdateMaterializedColumnsLicense).toHaveBeenCalledTimes(1);
     expect(mockUpdateFactTableColumns).toHaveBeenCalledTimes(1);
     const changes = mockUpdateFactTableColumns.mock.calls[0][1] as {
       columns: ColumnInterface[];

--- a/packages/shared/types/datasource.d.ts
+++ b/packages/shared/types/datasource.d.ts
@@ -309,7 +309,6 @@ interface DataSourceBase {
   params: string;
   projects?: string[];
   settings: DataSourceSettings;
-  lockUntil?: Date | null;
   type: DataSourceType;
 }
 


### PR DESCRIPTION
### Features and Changes
Removes dead code that now exists on the license server.
Also removes passing materialized_columns to the recreate function as that is no longer needed and is looked up based upon the org on the license server.

### Testing
ci tests
