### PR TITLE
audit: add some datasource details; add to [did]; clean up [ftid]

### DIFF
--- a/packages/back-end/src/models/DataSourceModel.ts
+++ b/packages/back-end/src/models/DataSourceModel.ts
@@ -31,13 +31,25 @@ import { deleteClickhouseUser } from "back-end/src/services/clickhouse";
 import { createModelAuditLogger } from "back-end/src/services/audit";
 import { deleteFactTable, getFactTable } from "./FactTableModel";
 
-const audit = createModelAuditLogger({
+const dataSourceAuditConfig = {
   entity: "datasource",
   createEvent: "datasource.create",
   updateEvent: "datasource.update",
   deleteEvent: "datasource.delete",
-  omitDetails: true,
-});
+  detailsAllowlist: [
+    "id",
+    "name",
+    "description",
+    "organization",
+    "dateCreated",
+    "dateUpdated",
+    "type",
+    "projects",
+    "settings",
+  ],
+} as const;
+
+const audit = createModelAuditLogger(dataSourceAuditConfig);
 
 const dataSourceSchema = new mongoose.Schema<DataSourceDocument>({
   id: String,

--- a/packages/back-end/src/services/audit.ts
+++ b/packages/back-end/src/services/audit.ts
@@ -112,8 +112,27 @@ export type AuditLogConfig<Entity extends EntityType> = {
   updateEvent: EventTypes<Entity>;
   deleteEvent: EventTypes<Entity>;
   autocreateEvent?: EventTypes<Entity>;
+  detailsAllowlist?: readonly string[];
   omitDetails?: boolean;
 };
+
+function getAuditDetailsDoc(
+  doc: object,
+  detailsAllowlist?: readonly string[],
+): object {
+  if (!detailsAllowlist) return doc;
+
+  const source = doc as Record<string, unknown>;
+  const filtered: Record<string, unknown> = {};
+
+  detailsAllowlist.forEach((key) => {
+    if (key in source) {
+      filtered[key] = source[key];
+    }
+  });
+
+  return filtered;
+}
 
 export function createModelAuditLogger<E extends EntityType>(
   config: AuditLogConfig<E>,
@@ -131,7 +150,11 @@ export function createModelAuditLogger<E extends EntityType>(
               ("name" in doc && typeof doc.name === "string" && doc.name) || "",
           },
           event: config.createEvent,
-          details: config.omitDetails ? "" : auditDetailsCreate(doc),
+          details: config.omitDetails
+            ? ""
+            : auditDetailsCreate(
+                getAuditDetailsDoc(doc, config.detailsAllowlist),
+              ),
         } as AuditInterfaceTemplate<E>);
       } catch (e) {
         context.logger.error(
@@ -160,7 +183,12 @@ export function createModelAuditLogger<E extends EntityType>(
               "",
           },
           event,
-          details: config.omitDetails ? "" : auditDetailsUpdate(doc, newDoc),
+          details: config.omitDetails
+            ? ""
+            : auditDetailsUpdate(
+                getAuditDetailsDoc(doc, config.detailsAllowlist),
+                getAuditDetailsDoc(newDoc, config.detailsAllowlist),
+              ),
         } as AuditInterfaceTemplate<E>);
       } catch (e) {
         context.logger.error(e, `Error creating audit log for ${event}`);
@@ -177,7 +205,11 @@ export function createModelAuditLogger<E extends EntityType>(
               ("name" in doc && typeof doc.name === "string" && doc.name) || "",
           },
           event: config.deleteEvent,
-          details: config.omitDetails ? "" : auditDetailsDelete(doc),
+          details: config.omitDetails
+            ? ""
+            : auditDetailsDelete(
+                getAuditDetailsDoc(doc, config.detailsAllowlist),
+              ),
         } as AuditInterfaceTemplate<E>);
       } catch (e) {
         context.logger.error(
@@ -198,7 +230,11 @@ export function createModelAuditLogger<E extends EntityType>(
               ("name" in doc && typeof doc.name === "string" && doc.name) || "",
           },
           event: config.autocreateEvent,
-          details: config.omitDetails ? "" : auditDetailsCreate(doc),
+          details: config.omitDetails
+            ? ""
+            : auditDetailsCreate(
+                getAuditDetailsDoc(doc, config.detailsAllowlist),
+              ),
         } as AuditInterfaceTemplate<E>);
       } catch (e) {
         context.logger.error(

--- a/packages/front-end/components/HistoryTable.tsx
+++ b/packages/front-end/components/HistoryTable.tsx
@@ -156,7 +156,13 @@ export function HistoryTableRow({
 }
 
 const HistoryTable: FC<{
-  type: "experiment" | "metric" | "feature" | "savedGroup" | "factTable";
+  type:
+    | "experiment"
+    | "metric"
+    | "feature"
+    | "savedGroup"
+    | "factTable"
+    | "datasource";
   showName?: boolean;
   showType?: boolean;
   id?: string;

--- a/packages/front-end/pages/datasources/[did].tsx
+++ b/packages/front-end/pages/datasources/[did].tsx
@@ -38,6 +38,8 @@ import { useCombinedMetrics } from "@/components/Metrics/MetricsList";
 import { FeatureEvaluationQueries } from "@/components/Settings/EditDataSource/FeatureEvaluationQueries/FeatureEvaluationQueries";
 import Heading from "@/ui/Heading";
 import Text from "@/ui/Text";
+import Modal from "@/components/Modal";
+import HistoryTable from "@/components/HistoryTable";
 
 function quotePropertyName(name: string) {
   if (name.match(/^[a-zA-Z_][a-zA-Z0-9_]*$/)) {
@@ -53,6 +55,7 @@ const DataSourcePage: FC = () => {
   const [editConn, setEditConn] = useState(false);
   const [viewSqlExplorer, setViewSqlExplorer] = useState(false);
   const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [auditModal, setAuditModal] = useState(false);
   const router = useRouter();
 
   const {
@@ -217,6 +220,14 @@ const DataSourcePage: FC = () => {
                   Edit Connection Info
                 </DropdownMenuItem>
               )}
+              <DropdownMenuItem
+                onClick={() => {
+                  setAuditModal(true);
+                  setDropdownOpen(false);
+                }}
+              >
+                Audit log
+              </DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuItem
                 onClick={() => {
@@ -514,6 +525,18 @@ mixpanel.init('YOUR PROJECT TOKEN', {
           lockDatasource={true}
           trackingEventModalSource="datasource-id-page"
         />
+      )}
+      {auditModal && (
+        <Modal
+          trackingEventModalType=""
+          open={true}
+          header="Audit Log"
+          close={() => setAuditModal(false)}
+          size="lg"
+          closeCta="Close"
+        >
+          <HistoryTable type={"datasource"} id={d.id} />
+        </Modal>
       )}
     </div>
   );

--- a/packages/front-end/pages/fact-tables/[ftid].tsx
+++ b/packages/front-end/pages/fact-tables/[ftid].tsx
@@ -328,25 +328,27 @@ export default function FactTablePage() {
             {canEdit || canDelete || canDuplicate ? (
               <>
                 <DropdownMenuSeparator />
-                {canDuplicate && (
-                  <DropdownMenuItem
-                    onClick={() => {
-                      setDuplicateFactTable({
-                        ...factTable,
-                        name: `${factTable.name} (Copy)`,
-                        managedBy:
-                          factTable.managedBy === "admin" &&
-                          permissionsUtil.canCreateOfficialResources(factTable)
-                            ? "admin"
-                            : "",
-                      });
-                      setDropdownOpen(false);
-                    }}
-                  >
-                    Duplicate
-                  </DropdownMenuItem>
-                )}
                 <DropdownMenuGroup>
+                  {canDuplicate && (
+                    <DropdownMenuItem
+                      onClick={() => {
+                        setDuplicateFactTable({
+                          ...factTable,
+                          name: `${factTable.name} (Copy)`,
+                          managedBy:
+                            factTable.managedBy === "admin" &&
+                            permissionsUtil.canCreateOfficialResources(
+                              factTable,
+                            )
+                              ? "admin"
+                              : "",
+                        });
+                        setDropdownOpen(false);
+                      }}
+                    >
+                      Duplicate
+                    </DropdownMenuItem>
+                  )}
                   {canEdit && (
                     <DropdownMenuItem
                       onClick={async () => {

--- a/packages/front-end/pages/fact-tables/[ftid].tsx
+++ b/packages/front-end/pages/fact-tables/[ftid].tsx
@@ -300,7 +300,7 @@ export default function FactTablePage() {
                     setDropdownOpen(false);
                   }}
                 >
-                  Edit Fact Table
+                  Edit
                 </DropdownMenuItem>
               )}
               {!factTable.managedBy &&
@@ -316,24 +316,6 @@ export default function FactTablePage() {
                     Convert to Official Fact Table
                   </DropdownMenuItem>
                 )}
-              {canDuplicate && (
-                <DropdownMenuItem
-                  onClick={() => {
-                    setDuplicateFactTable({
-                      ...factTable,
-                      name: `${factTable.name} (Copy)`,
-                      managedBy:
-                        factTable.managedBy === "admin" &&
-                        permissionsUtil.canCreateOfficialResources(factTable)
-                          ? "admin"
-                          : "",
-                    });
-                    setDropdownOpen(false);
-                  }}
-                >
-                  Duplicate Fact Table
-                </DropdownMenuItem>
-              )}
               <DropdownMenuItem
                 onClick={() => {
                   setAuditModal(true);
@@ -342,49 +324,69 @@ export default function FactTablePage() {
               >
                 Audit log
               </DropdownMenuItem>
-              {canEdit && (
-                <DropdownMenuItem
-                  onClick={async () => {
-                    await apiCall(
-                      `/fact-tables/${factTable.id}/${
-                        factTable.archived ? "unarchive" : "archive"
-                      }`,
-                      {
-                        method: "POST",
-                      },
-                    );
-                    mutateDefinitions();
-                    setDropdownOpen(false);
-                  }}
-                >
-                  {factTable.archived ? "Unarchive" : "Archive"} Fact Table
-                </DropdownMenuItem>
-              )}
             </DropdownMenuGroup>
-            {canDelete && (
+            {canEdit || canDelete || canDuplicate ? (
               <>
                 <DropdownMenuSeparator />
-                <DropdownMenuGroup>
+                {canDuplicate && (
                   <DropdownMenuItem
-                    color="red"
-                    confirmation={{
-                      confirmationTitle: "Delete Fact Table",
-                      cta: "Delete",
-                      submit: async () => {
-                        await apiCall(`/fact-tables/${factTable.id}`, {
-                          method: "DELETE",
-                        });
-                        mutateDefinitions();
-                        router.push("/fact-tables");
-                      },
-                      closeDropdown: () => setDropdownOpen(false),
+                    onClick={() => {
+                      setDuplicateFactTable({
+                        ...factTable,
+                        name: `${factTable.name} (Copy)`,
+                        managedBy:
+                          factTable.managedBy === "admin" &&
+                          permissionsUtil.canCreateOfficialResources(factTable)
+                            ? "admin"
+                            : "",
+                      });
+                      setDropdownOpen(false);
                     }}
                   >
-                    Delete Fact Table
+                    Duplicate
                   </DropdownMenuItem>
+                )}
+                <DropdownMenuGroup>
+                  {canEdit && (
+                    <DropdownMenuItem
+                      onClick={async () => {
+                        await apiCall(
+                          `/fact-tables/${factTable.id}/${
+                            factTable.archived ? "unarchive" : "archive"
+                          }`,
+                          {
+                            method: "POST",
+                          },
+                        );
+                        mutateDefinitions();
+                        setDropdownOpen(false);
+                      }}
+                    >
+                      {factTable.archived ? "Unarchive" : "Archive"}
+                    </DropdownMenuItem>
+                  )}
+                  {canDelete && (
+                    <DropdownMenuItem
+                      color="red"
+                      confirmation={{
+                        confirmationTitle: "Delete Fact Table",
+                        cta: "Delete",
+                        submit: async () => {
+                          await apiCall(`/fact-tables/${factTable.id}`, {
+                            method: "DELETE",
+                          });
+                          mutateDefinitions();
+                          router.push("/fact-tables");
+                        },
+                        closeDropdown: () => setDropdownOpen(false),
+                      }}
+                    >
+                      Delete
+                    </DropdownMenuItem>
+                  )}
                 </DropdownMenuGroup>
               </>
-            )}
+            ) : null}
           </DropdownMenu>
         </Flex>
       </Flex>


### PR DESCRIPTION
### Features and Changes

Adds `detailsAllowlist` to allow certain fields to be included in datasource audit log events; adds audit log to datasource page; and standardizes fact table fly out menu to look like our other entities.

### Testing

https://www.loom.com/share/479bcbfc302b40c984f2732a3c483ffa
