### PR TITLE
Add test connections

### DIFF
--- a/packages/back-end/src/app.ts
+++ b/packages/back-end/src/app.ts
@@ -916,8 +916,16 @@ app.get(
   datasourcesController.getHasReadyEventForwarder,
 );
 app.post("/datasources", datasourcesController.postDataSources);
+app.post(
+  "/datasources/event-forwarder/test-access",
+  datasourcesController.postTestEventForwarderAccessForCreate,
+);
 app.put("/datasource/:id", datasourcesController.putDataSource);
 app.delete("/datasource/:id", datasourcesController.deleteDataSource);
+app.post(
+  "/datasource/:id/event-forwarder/test-access",
+  datasourcesController.postTestEventForwarderAccessForDatasource,
+);
 app.post(
   "/datasource/:id/event-forwarder/pause",
   datasourcesController.postPauseEventForwarder,

--- a/packages/back-end/src/controllers/datasources.ts
+++ b/packages/back-end/src/controllers/datasources.ts
@@ -10,10 +10,18 @@ import {
   type PipelineValidationResults,
 } from "shared/enterprise";
 import { TemplateVariables } from "shared/types/sql";
-import { factTableColumnTypes } from "shared/validators";
+import {
+  eventForwarderAccessTestCreateBodySchema,
+  eventForwarderAccessTestEditBodySchema,
+  factTableColumnTypes,
+} from "shared/validators";
 import { AutoMetricToCreate } from "shared/types/integrations";
 import { AuditUserLoggedIn } from "shared/types/audit";
-import { EventForwarderConfigDraft } from "shared/types/event-forwarder";
+import {
+  BigQueryEventForwarderStoredConfig,
+  EventForwarderConfigDraft,
+  SnowflakeEventForwarderStoredConfig,
+} from "shared/types/event-forwarder";
 import {
   DataSourceParams,
   DataSourceType,
@@ -31,6 +39,7 @@ import { GoogleAnalyticsParams } from "shared/types/integrations/googleanalytics
 import { BigQueryConnectionParams } from "shared/types/integrations/bigquery";
 import { SnowflakeConnectionParams } from "shared/types/integrations/snowflake";
 import type { ClickHouseConnectionParams } from "shared/types/integrations/clickhouse";
+import { DatabricksConnectionParams } from "shared/types/integrations/databricks";
 import { FactTableColumnType } from "shared/types/fact-table";
 import { SQLExecutionError } from "back-end/src/util/errors";
 import { AuthRequest } from "back-end/src/types/AuthRequest";
@@ -47,12 +56,15 @@ import {
   runUserExposureQuery,
 } from "back-end/src/services/datasource";
 import {
+  buildNormalizedEventForwarderSinkPayloadForTest,
   getEventForwarderConfigForDatasource,
   getEventForwarderConfigWithMetadataForDatasource,
   hasReadyEventForwarderConfig,
   refreshEventForwarderConfigCredentials,
   syncEventForwarderConfigFromDatasource,
+  toEventForwarderConfigDraft,
 } from "back-end/src/services/eventForwarderConfig";
+import { testEventForwarderWriteAccess } from "back-end/src/services/eventForwarderWriteAccessValidation";
 import {
   pauseEventForwarderThroughLicenseServer,
   provisionEventForwarderThroughLicenseServer,
@@ -113,6 +125,31 @@ function getEventForwarderDatasourceParams(
     default:
       return undefined;
   }
+}
+
+function getCandidateDatasource({
+  context,
+  type,
+  params,
+  projects,
+}: {
+  context: ReturnType<typeof getContextFromReq>;
+  type: "bigquery" | "snowflake" | "databricks";
+  params: DataSourceParams;
+  projects?: string[];
+}): DataSourceInterface {
+  return {
+    id: "event-forwarder-access-test",
+    name: "Event Forwarder Access Test",
+    description: "",
+    organization: context.org.id,
+    dateCreated: null,
+    dateUpdated: null,
+    params: encryptParams(params),
+    projects,
+    settings: {},
+    type,
+  } as DataSourceInterface;
 }
 
 export async function deleteDataSource(
@@ -624,6 +661,164 @@ export async function putDataSource(
       message: e.message || "An error occurred",
     });
   }
+}
+
+export async function postTestEventForwarderAccessForCreate(
+  req: AuthRequest,
+  res: Response,
+) {
+  const parsed = eventForwarderAccessTestCreateBodySchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({
+      status: 400,
+      message: parsed.error.issues.map((i) => i.message).join("; "),
+    });
+  }
+
+  const context = getContextFromReq(req);
+  const { type, eventForwarderConfig, projects } = parsed.data;
+  const params = parsed.data.params as unknown as DataSourceParams;
+  const eventForwarderProjects = projects ?? [];
+
+  if (!context.permissions.canCreateDataSource({ projects, type })) {
+    context.permissions.throwPermissionError();
+  }
+  if (
+    !context.permissions.canCreateEventForwarderConfig({
+      projects: eventForwarderProjects,
+    })
+  ) {
+    context.permissions.throwPermissionError();
+  }
+
+  const datasource = getCandidateDatasource({
+    context,
+    type,
+    params,
+    projects,
+  });
+  const datasourceParams = getEventForwarderDatasourceParams(type, params);
+  const databricksParams = params as DatabricksConnectionParams;
+  const normalized = buildNormalizedEventForwarderSinkPayloadForTest(
+    eventForwarderConfig as EventForwarderConfigDraft,
+    datasourceParams,
+    null,
+  );
+
+  const result =
+    eventForwarderConfig.sinkType === "bigquery"
+      ? await testEventForwarderWriteAccess(context, {
+          sinkType: "bigquery",
+          datasource,
+          params: datasourceParams as BigQueryConnectionParams,
+          config: normalized as BigQueryEventForwarderStoredConfig,
+        })
+      : eventForwarderConfig.sinkType === "snowflake"
+        ? await testEventForwarderWriteAccess(context, {
+            sinkType: "snowflake",
+            datasource,
+            params: datasourceParams as SnowflakeConnectionParams,
+            config: normalized as SnowflakeEventForwarderStoredConfig,
+          })
+        : await testEventForwarderWriteAccess(context, {
+            sinkType: "databricks",
+            datasource,
+            params: databricksParams,
+            config: normalized as Record<string, string>,
+          });
+
+  res.status(200).json(result);
+}
+
+export async function postTestEventForwarderAccessForDatasource(
+  req: AuthRequest<unknown, { id: string }>,
+  res: Response,
+) {
+  const parsed = eventForwarderAccessTestEditBodySchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({
+      status: 400,
+      message: parsed.error.issues.map((i) => i.message).join("; "),
+    });
+  }
+
+  const context = getContextFromReq(req);
+  const datasource = await getDataSourceById(context, req.params.id);
+  if (!datasource) {
+    return res
+      .status(404)
+      .json({ status: 404, message: "Cannot find data source" });
+  }
+
+  if (
+    !context.permissions.canUpdateDataSourceSettings(datasource) ||
+    !context.permissions.canRunPipelineValidationQueries(datasource)
+  ) {
+    context.permissions.throwPermissionError();
+  }
+  if (
+    parsed.data.params &&
+    !context.permissions.canUpdateDataSourceParams(datasource)
+  ) {
+    context.permissions.throwPermissionError();
+  }
+
+  const integration = getSourceIntegrationObject(context, datasource);
+  if (parsed.data.params) {
+    mergeParams(integration, parsed.data.params as Partial<DataSourceParams>);
+  }
+
+  const existingEventForwarderConfig =
+    await getEventForwarderConfigForDatasource(context, datasource.id);
+  const draft =
+    (parsed.data.eventForwarderConfig as
+      | EventForwarderConfigDraft
+      | undefined) ?? toEventForwarderConfigDraft(existingEventForwarderConfig);
+  if (!draft) {
+    return res.status(400).json({
+      status: 400,
+      message: "Event Forwarder is not configured for this data source.",
+    });
+  }
+
+  const candidateDatasource = {
+    ...datasource,
+    params: encryptParams(integration.params as DataSourceParams),
+  } as DataSourceInterface;
+  const datasourceParams = getEventForwarderDatasourceParams(
+    datasource.type,
+    integration.params as DataSourceParams,
+  );
+  const databricksParams = integration.params as DatabricksConnectionParams;
+  const normalized = buildNormalizedEventForwarderSinkPayloadForTest(
+    draft,
+    datasourceParams,
+    existingEventForwarderConfig,
+  );
+
+  const result =
+    draft.sinkType === "bigquery"
+      ? await testEventForwarderWriteAccess(context, {
+          sinkType: "bigquery",
+          datasource: candidateDatasource,
+          params: datasourceParams as BigQueryConnectionParams,
+          config: normalized as BigQueryEventForwarderStoredConfig,
+        })
+      : draft.sinkType === "snowflake"
+        ? await testEventForwarderWriteAccess(context, {
+            sinkType: "snowflake",
+            datasource: candidateDatasource,
+            params: datasourceParams as SnowflakeConnectionParams,
+            config: normalized as SnowflakeEventForwarderStoredConfig,
+          })
+        : await testEventForwarderWriteAccess(context, {
+            sinkType: "databricks",
+            datasource: candidateDatasource,
+            params: databricksParams,
+            config: normalized as Record<string, string>,
+          });
+
+  res.status(200).json(result);
 }
 
 export async function postPauseEventForwarder(

--- a/packages/back-end/src/controllers/datasources.ts
+++ b/packages/back-end/src/controllers/datasources.ts
@@ -64,7 +64,10 @@ import {
   syncEventForwarderConfigFromDatasource,
   toEventForwarderConfigDraft,
 } from "back-end/src/services/eventForwarderConfig";
-import { testEventForwarderWriteAccess } from "back-end/src/services/eventForwarderWriteAccessValidation";
+import {
+  getEventForwarderWriteAccessFailedResponse,
+  testEventForwarderWriteAccess,
+} from "back-end/src/services/eventForwarderWriteAccessValidation";
 import {
   pauseEventForwarderThroughLicenseServer,
   provisionEventForwarderThroughLicenseServer,
@@ -150,6 +153,12 @@ function getCandidateDatasource({
     settings: {},
     type,
   } as DataSourceInterface;
+}
+
+function getEventForwarderAccessTestErrorResponse(error: unknown) {
+  return getEventForwarderWriteAccessFailedResponse(
+    error instanceof Error ? error.message : String(error),
+  );
 }
 
 export async function deleteDataSource(
@@ -699,35 +708,39 @@ export async function postTestEventForwarderAccessForCreate(
   });
   const datasourceParams = getEventForwarderDatasourceParams(type, params);
   const databricksParams = params as DatabricksConnectionParams;
-  const normalized = buildNormalizedEventForwarderSinkPayloadForTest(
-    eventForwarderConfig as EventForwarderConfigDraft,
-    datasourceParams,
-    null,
-  );
+  try {
+    const normalized = buildNormalizedEventForwarderSinkPayloadForTest(
+      eventForwarderConfig as EventForwarderConfigDraft,
+      datasourceParams,
+      null,
+    );
 
-  const result =
-    eventForwarderConfig.sinkType === "bigquery"
-      ? await testEventForwarderWriteAccess(context, {
-          sinkType: "bigquery",
-          datasource,
-          params: datasourceParams as BigQueryConnectionParams,
-          config: normalized as BigQueryEventForwarderStoredConfig,
-        })
-      : eventForwarderConfig.sinkType === "snowflake"
+    const result =
+      eventForwarderConfig.sinkType === "bigquery"
         ? await testEventForwarderWriteAccess(context, {
-            sinkType: "snowflake",
+            sinkType: "bigquery",
             datasource,
-            params: datasourceParams as SnowflakeConnectionParams,
-            config: normalized as SnowflakeEventForwarderStoredConfig,
+            params: datasourceParams as BigQueryConnectionParams,
+            config: normalized as BigQueryEventForwarderStoredConfig,
           })
-        : await testEventForwarderWriteAccess(context, {
-            sinkType: "databricks",
-            datasource,
-            params: databricksParams,
-            config: normalized as Record<string, string>,
-          });
+        : eventForwarderConfig.sinkType === "snowflake"
+          ? await testEventForwarderWriteAccess(context, {
+              sinkType: "snowflake",
+              datasource,
+              params: datasourceParams as SnowflakeConnectionParams,
+              config: normalized as SnowflakeEventForwarderStoredConfig,
+            })
+          : await testEventForwarderWriteAccess(context, {
+              sinkType: "databricks",
+              datasource,
+              params: databricksParams,
+              config: normalized as Record<string, string>,
+            });
 
-  res.status(200).json(result);
+    res.status(200).json(result);
+  } catch (error) {
+    res.status(200).json(getEventForwarderAccessTestErrorResponse(error));
+  }
 }
 
 export async function postTestEventForwarderAccessForDatasource(
@@ -790,35 +803,39 @@ export async function postTestEventForwarderAccessForDatasource(
     integration.params as DataSourceParams,
   );
   const databricksParams = integration.params as DatabricksConnectionParams;
-  const normalized = buildNormalizedEventForwarderSinkPayloadForTest(
-    draft,
-    datasourceParams,
-    existingEventForwarderConfig,
-  );
+  try {
+    const normalized = buildNormalizedEventForwarderSinkPayloadForTest(
+      draft,
+      datasourceParams,
+      existingEventForwarderConfig,
+    );
 
-  const result =
-    draft.sinkType === "bigquery"
-      ? await testEventForwarderWriteAccess(context, {
-          sinkType: "bigquery",
-          datasource: candidateDatasource,
-          params: datasourceParams as BigQueryConnectionParams,
-          config: normalized as BigQueryEventForwarderStoredConfig,
-        })
-      : draft.sinkType === "snowflake"
+    const result =
+      draft.sinkType === "bigquery"
         ? await testEventForwarderWriteAccess(context, {
-            sinkType: "snowflake",
+            sinkType: "bigquery",
             datasource: candidateDatasource,
-            params: datasourceParams as SnowflakeConnectionParams,
-            config: normalized as SnowflakeEventForwarderStoredConfig,
+            params: datasourceParams as BigQueryConnectionParams,
+            config: normalized as BigQueryEventForwarderStoredConfig,
           })
-        : await testEventForwarderWriteAccess(context, {
-            sinkType: "databricks",
-            datasource: candidateDatasource,
-            params: databricksParams,
-            config: normalized as Record<string, string>,
-          });
+        : draft.sinkType === "snowflake"
+          ? await testEventForwarderWriteAccess(context, {
+              sinkType: "snowflake",
+              datasource: candidateDatasource,
+              params: datasourceParams as SnowflakeConnectionParams,
+              config: normalized as SnowflakeEventForwarderStoredConfig,
+            })
+          : await testEventForwarderWriteAccess(context, {
+              sinkType: "databricks",
+              datasource: candidateDatasource,
+              params: databricksParams,
+              config: normalized as Record<string, string>,
+            });
 
-  res.status(200).json(result);
+    res.status(200).json(result);
+  } catch (error) {
+    res.status(200).json(getEventForwarderAccessTestErrorResponse(error));
+  }
 }
 
 export async function postPauseEventForwarder(

--- a/packages/back-end/src/services/eventForwarderConfig.ts
+++ b/packages/back-end/src/services/eventForwarderConfig.ts
@@ -239,6 +239,59 @@ function buildNormalizedSinkPayload(
   return draft.config as Record<string, string>;
 }
 
+export function buildNormalizedEventForwarderSinkPayloadForTest(
+  draft: EventForwarderConfigDraft,
+  datasourceParams: EventForwarderDatasourceParams,
+  existingModel: EventForwarderConfigInterface | null,
+): SinkConfig {
+  const normalizedPayload = buildNormalizedSinkPayload(
+    draft,
+    datasourceParams,
+    existingModel,
+  );
+
+  if (draft.sinkType === "bigquery") {
+    const bigQueryParams = datasourceParams as
+      | BigQueryConnectionParams
+      | undefined;
+    const bqProject =
+      bigQueryParams?.defaultProject?.trim() ||
+      bigQueryParams?.projectId?.trim() ||
+      "";
+    const defaultDataset = bigQueryParams?.defaultDataset?.trim() || "";
+    const bq = normalizedPayload as BigQueryEventForwarderStoredConfig;
+    if (
+      !bqProject ||
+      !defaultDataset ||
+      !bq.tableName?.trim() ||
+      !bq.serviceAccountKey
+    ) {
+      throw new Error(
+        "BigQuery event forwarder requires connector project (BigQuery Project ID), default dataset, table name, and service account credentials",
+      );
+    }
+  }
+
+  if (draft.sinkType === "snowflake") {
+    const snowflake = normalizedPayload as SnowflakeEventForwarderStoredConfig;
+    if (
+      !snowflake.account ||
+      !snowflake.username ||
+      !snowflake.database ||
+      !snowflake.schema ||
+      !snowflake.tableName ||
+      !snowflake.accessUrl ||
+      !snowflake.privateKey
+    ) {
+      throw new Error(
+        "Snowflake event forwarder requires account, username, database, schema, table name, event forwarder access URL, and private key credentials",
+      );
+    }
+  }
+
+  return normalizedPayload;
+}
+
 export function toEventForwarderConfigDraft(
   config: EventForwarderConfigInterface | null,
 ): EventForwarderConfigDraft | null {

--- a/packages/back-end/src/services/eventForwarderProvisioning.ts
+++ b/packages/back-end/src/services/eventForwarderProvisioning.ts
@@ -6,6 +6,7 @@ import {
   SnowflakeEventForwarderStoredConfig,
 } from "shared/types/event-forwarder";
 import { EventForwarderConfigInterface } from "shared/validators";
+import { getDataSourceById } from "back-end/src/models/DataSourceModel";
 import {
   postPauseEventForwarderToLicenseServer,
   postProvisionEventForwarderToLicenseServer,
@@ -16,8 +17,21 @@ import {
 } from "back-end/src/enterprise/licenseUtil";
 import { decryptEventForwarderConfigModel } from "back-end/src/services/eventForwarderConfig";
 import { resolveBigQueryEventForwarderTableName } from "back-end/src/services/eventForwarderBqTableResolution";
+import { testEventForwarderWriteAccess } from "back-end/src/services/eventForwarderWriteAccessValidation";
 import { logger } from "back-end/src/util/logger";
 import { ReqContext } from "back-end/types/request";
+
+function assertEventForwarderWriteAccessResult(
+  result: Awaited<ReturnType<typeof testEventForwarderWriteAccess>>,
+): void {
+  const sinkWrite = result.results.sinkWrite;
+  if (sinkWrite.result !== "success") {
+    throw new Error(
+      sinkWrite.resultMessage ||
+        "Event Forwarder write access validation failed",
+    );
+  }
+}
 
 /**
  * Provisions Confluent resources for a BigQuery event forwarder via the central license server.
@@ -38,6 +52,13 @@ export async function provisionEventForwarderThroughLicenseServer(
 
   try {
     const attributeSchema = context.org.settings?.attributeSchema ?? [];
+    const datasource = await getDataSourceById(
+      context,
+      eventForwarderConfig.datasourceId,
+    );
+    if (!datasource) {
+      throw new Error("Cannot find data source for event forwarder");
+    }
     let result: {
       schemaId: number;
       connectorName: string;
@@ -67,6 +88,15 @@ export async function provisionEventForwarderThroughLicenseServer(
           eventForwarderConfig,
         );
 
+      assertEventForwarderWriteAccessResult(
+        await testEventForwarderWriteAccess(context, {
+          sinkType: "bigquery",
+          datasource,
+          params: bigqueryConnectionParams as BigQueryConnectionParams,
+          config: decrypted,
+        }),
+      );
+
       result = await postProvisionEventForwarderToLicenseServer({
         organizationId: context.org.id,
         datasourceId: eventForwarderConfig.datasourceId,
@@ -85,6 +115,15 @@ export async function provisionEventForwarderThroughLicenseServer(
         decryptEventForwarderConfigModel<SnowflakeEventForwarderStoredConfig>(
           eventForwarderConfig,
         );
+
+      assertEventForwarderWriteAccessResult(
+        await testEventForwarderWriteAccess(context, {
+          sinkType: "snowflake",
+          datasource,
+          params: datasourceParams as SnowflakeConnectionParams,
+          config: decrypted,
+        }),
+      );
 
       result = await postProvisionEventForwarderToLicenseServer({
         organizationId: context.org.id,

--- a/packages/back-end/src/services/eventForwarderWriteAccessValidation.ts
+++ b/packages/back-end/src/services/eventForwarderWriteAccessValidation.ts
@@ -22,6 +22,7 @@ import {
   getSourceIntegrationObject,
 } from "back-end/src/services/datasource";
 import SqlIntegration from "back-end/src/integrations/SqlIntegration";
+import { logger } from "back-end/src/util/logger";
 
 type EventForwarderWriteAccessInput =
   | {
@@ -49,7 +50,9 @@ type ServiceAccountKey = {
   private_key?: string;
 };
 
-function failed(message: string): EventForwarderAccessTestResponse {
+export function getEventForwarderWriteAccessFailedResponse(
+  message: string,
+): EventForwarderAccessTestResponse {
   return {
     status: 200,
     results: {
@@ -80,7 +83,12 @@ function parseBigQueryServiceAccountKey(raw: string): ServiceAccountKey | null {
   const trimmed = raw.trim();
   if (!trimmed) return null;
 
-  const parsed = JSON.parse(trimmed) as unknown;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    throw new Error("Event Forwarder service account key is not valid JSON.");
+  }
   if (!parsed || typeof parsed !== "object") {
     throw new Error("Event Forwarder service account key is not valid JSON.");
   }
@@ -195,7 +203,7 @@ async function runProbe({
     );
     created = true;
   } catch (error) {
-    return failed(getErrorMessage(error));
+    return getEventForwarderWriteAccessFailedResponse(getErrorMessage(error));
   } finally {
     if (created) {
       try {
@@ -209,14 +217,21 @@ async function runProbe({
         );
       } catch (error) {
         const dropError = getErrorMessage(error);
-        failure = failure
-          ? `${failure}; cleanup failed: ${dropError}`
-          : `Cleanup failed: ${dropError}`;
+        if (failure) {
+          failure = `${failure}; cleanup failed: ${dropError}`;
+        } else {
+          logger.warn(
+            error,
+            `Event Forwarder write access cleanup failed for ${fullTestTablePath}`,
+          );
+        }
       }
     }
   }
 
-  return failure ? failed(failure) : success();
+  return failure
+    ? getEventForwarderWriteAccessFailedResponse(failure)
+    : success();
 }
 
 export async function testEventForwarderWriteAccess(
@@ -234,7 +249,9 @@ export async function testEventForwarderWriteAccess(
 
   const integration = getSourceIntegrationObject(context, datasource, true);
   if (!(integration instanceof SqlIntegration)) {
-    return failed("This data source does not support Event Forwarder testing.");
+    return getEventForwarderWriteAccessFailedResponse(
+      "This data source does not support Event Forwarder testing.",
+    );
   }
 
   const randomSuffix = Math.random().toString(36).substring(2, 7);

--- a/packages/back-end/src/services/eventForwarderWriteAccessValidation.ts
+++ b/packages/back-end/src/services/eventForwarderWriteAccessValidation.ts
@@ -1,7 +1,6 @@
 import {
   getPipelineValidationCreateTableQuery,
   getPipelineValidationDropTableQuery,
-  getPipelineValidationInsertQuery,
 } from "shared/enterprise";
 import { EventForwarderAccessTestResponse } from "shared/validators";
 import {
@@ -197,19 +196,6 @@ async function runProbe({
     created = true;
   } catch (error) {
     return failed(getErrorMessage(error));
-  }
-
-  try {
-    await integration.runTestQuery(
-      getPipelineValidationInsertQuery({
-        tableFullName: fullTestTablePath,
-        integration,
-      }),
-      undefined,
-      "pipelineValidation",
-    );
-  } catch (error) {
-    failure = getErrorMessage(error);
   } finally {
     if (created) {
       try {

--- a/packages/back-end/src/services/eventForwarderWriteAccessValidation.ts
+++ b/packages/back-end/src/services/eventForwarderWriteAccessValidation.ts
@@ -1,0 +1,266 @@
+import {
+  getPipelineValidationCreateTableQuery,
+  getPipelineValidationDropTableQuery,
+  getPipelineValidationInsertQuery,
+} from "shared/enterprise";
+import { EventForwarderAccessTestResponse } from "shared/validators";
+import {
+  DataSourceInterface,
+  DataSourceParams,
+  DataSourcePipelineSettings,
+} from "shared/types/datasource";
+import { BigQueryConnectionParams } from "shared/types/integrations/bigquery";
+import { SnowflakeConnectionParams } from "shared/types/integrations/snowflake";
+import { DatabricksConnectionParams } from "shared/types/integrations/databricks";
+import {
+  BigQueryEventForwarderStoredConfig,
+  SnowflakeEventForwarderStoredConfig,
+} from "shared/types/event-forwarder";
+import { UNITS_TABLE_PREFIX } from "back-end/src/queryRunners/ExperimentResultsQueryRunner";
+import { ReqContext } from "back-end/types/request";
+import {
+  encryptParams,
+  getSourceIntegrationObject,
+} from "back-end/src/services/datasource";
+import SqlIntegration from "back-end/src/integrations/SqlIntegration";
+
+type EventForwarderWriteAccessInput =
+  | {
+      sinkType: "bigquery";
+      datasource: DataSourceInterface;
+      params: BigQueryConnectionParams;
+      config: BigQueryEventForwarderStoredConfig;
+    }
+  | {
+      sinkType: "snowflake";
+      datasource: DataSourceInterface;
+      params: SnowflakeConnectionParams;
+      config: SnowflakeEventForwarderStoredConfig;
+    }
+  | {
+      sinkType: "databricks";
+      datasource: DataSourceInterface;
+      params: DatabricksConnectionParams;
+      config: Record<string, string>;
+    };
+
+type ServiceAccountKey = {
+  project_id?: string;
+  client_email?: string;
+  private_key?: string;
+};
+
+function failed(message: string): EventForwarderAccessTestResponse {
+  return {
+    status: 200,
+    results: {
+      sinkWrite: {
+        result: "failed",
+        resultMessage: message,
+      },
+    },
+  };
+}
+
+function success(): EventForwarderAccessTestResponse {
+  return {
+    status: 200,
+    results: {
+      sinkWrite: {
+        result: "success",
+      },
+    },
+  };
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function parseBigQueryServiceAccountKey(raw: string): ServiceAccountKey | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+
+  const parsed = JSON.parse(trimmed) as unknown;
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error("Event Forwarder service account key is not valid JSON.");
+  }
+
+  return parsed as ServiceAccountKey;
+}
+
+function getBigQueryProbeParams(
+  params: BigQueryConnectionParams,
+  serviceAccountKeyJson: string | undefined,
+): BigQueryConnectionParams {
+  const serviceAccountKey = parseBigQueryServiceAccountKey(
+    serviceAccountKeyJson || "",
+  );
+  if (!serviceAccountKey) return params;
+
+  return {
+    ...params,
+    authType: "json",
+    projectId: serviceAccountKey.project_id || params.projectId,
+    defaultProject:
+      params.defaultProject ||
+      serviceAccountKey.project_id ||
+      params.projectId ||
+      "",
+    clientEmail: serviceAccountKey.client_email || params.clientEmail,
+    privateKey: serviceAccountKey.private_key || params.privateKey,
+    serviceAccountJson: serviceAccountKeyJson,
+  };
+}
+
+function getProbeDatasource({
+  datasource,
+  params,
+}: {
+  datasource: DataSourceInterface;
+  params: DataSourceParams;
+}): DataSourceInterface {
+  const pipelineSettings: DataSourcePipelineSettings = {
+    allowWriting: true,
+    mode: "ephemeral",
+    writeDataset: "",
+    unitsTableRetentionHours: 1,
+    unitsTableDeletion: true,
+  };
+
+  return {
+    ...datasource,
+    params: encryptParams(params),
+    settings: {
+      ...datasource.settings,
+      pipelineSettings,
+    },
+  };
+}
+
+function getProbeTablePath({
+  integration,
+  tableName,
+  input,
+}: {
+  integration: SqlIntegration;
+  tableName: string;
+  input: EventForwarderWriteAccessInput;
+}): string {
+  if (input.sinkType === "bigquery") {
+    const projectId =
+      input.params.defaultProject?.trim() || input.params.projectId?.trim();
+    return integration.generateTablePath(
+      tableName,
+      input.config.dataset.trim(),
+      projectId,
+      true,
+    );
+  }
+
+  if (input.sinkType === "snowflake") {
+    return integration.generateTablePath(
+      tableName,
+      input.config.schema.trim(),
+      input.config.database.trim(),
+      true,
+    );
+  }
+
+  return integration.generateTablePath(
+    tableName,
+    undefined,
+    input.params.catalog,
+    false,
+  );
+}
+
+async function runProbe({
+  integration,
+  fullTestTablePath,
+}: {
+  integration: SqlIntegration;
+  fullTestTablePath: string;
+}): Promise<EventForwarderAccessTestResponse> {
+  let created = false;
+  let failure: string | null = null;
+
+  try {
+    await integration.runTestQuery(
+      getPipelineValidationCreateTableQuery({
+        tableFullName: fullTestTablePath,
+        integration,
+      }),
+      undefined,
+      "pipelineValidation",
+    );
+    created = true;
+  } catch (error) {
+    return failed(getErrorMessage(error));
+  }
+
+  try {
+    await integration.runTestQuery(
+      getPipelineValidationInsertQuery({
+        tableFullName: fullTestTablePath,
+        integration,
+      }),
+      undefined,
+      "pipelineValidation",
+    );
+  } catch (error) {
+    failure = getErrorMessage(error);
+  } finally {
+    if (created) {
+      try {
+        await integration.runTestQuery(
+          getPipelineValidationDropTableQuery({
+            tableFullName: fullTestTablePath,
+            integration,
+          }),
+          undefined,
+          "pipelineValidation",
+        );
+      } catch (error) {
+        const dropError = getErrorMessage(error);
+        failure = failure
+          ? `${failure}; cleanup failed: ${dropError}`
+          : `Cleanup failed: ${dropError}`;
+      }
+    }
+  }
+
+  return failure ? failed(failure) : success();
+}
+
+export async function testEventForwarderWriteAccess(
+  context: ReqContext,
+  input: EventForwarderWriteAccessInput,
+): Promise<EventForwarderAccessTestResponse> {
+  const params =
+    input.sinkType === "bigquery"
+      ? getBigQueryProbeParams(input.params, input.config.serviceAccountKey)
+      : input.params;
+  const datasource = getProbeDatasource({
+    datasource: input.datasource,
+    params,
+  });
+
+  const integration = getSourceIntegrationObject(context, datasource, true);
+  if (!(integration instanceof SqlIntegration)) {
+    return failed("This data source does not support Event Forwarder testing.");
+  }
+
+  const randomSuffix = Math.random().toString(36).substring(2, 7);
+  const testTableName = `${UNITS_TABLE_PREFIX}_event_forwarder_validation_${randomSuffix}`;
+  const fullTestTablePath = getProbeTablePath({
+    integration,
+    tableName: testTableName,
+    input,
+  });
+
+  return runProbe({
+    integration,
+    fullTestTablePath,
+  });
+}

--- a/packages/front-end/components/Settings/BigQueryForm.tsx
+++ b/packages/front-end/components/Settings/BigQueryForm.tsx
@@ -49,6 +49,10 @@ const BigQueryForm: FC<{
     message: string;
   } | null>(null);
   const { apiCall } = useAuth();
+  const canTestEventForwarderAccess =
+    eventForwarderConfig?.sinkType === "bigquery" &&
+    !!params.defaultDataset?.trim() &&
+    !!eventForwarderConfig.config.tableName.trim();
 
   async function testConnection() {
     try {
@@ -122,13 +126,15 @@ const BigQueryForm: FC<{
       setValidatedEventForwarderSignature?.(eventForwarderAccessSignature);
       setEventForwarderTestResult({
         status: "success",
-        message: "Event Forwarder write access verified.",
+        message:
+          "Event Forwarder table creation access verified. GrowthBook created and deleted a temporary validation table.",
       });
     } else {
       setEventForwarderTestResult({
         status: "error",
         message:
-          sinkWrite.resultMessage || "Event Forwarder write access failed.",
+          sinkWrite.resultMessage ||
+          "Event Forwarder table creation access failed.",
       });
     }
   }
@@ -320,10 +326,11 @@ const BigQueryForm: FC<{
                 <div>
                   <Button
                     color="primary"
-                    disabled={!params.defaultDataset}
+                    disabled={!canTestEventForwarderAccess}
+                    loadingCta="Testing access"
                     onClick={testEventForwarderAccess}
                   >
-                    Test Event Forwarder Access
+                    Test Table Creation Access
                   </Button>
                 </div>
                 {eventForwarderTestResult ? (

--- a/packages/front-end/components/Settings/BigQueryForm.tsx
+++ b/packages/front-end/components/Settings/BigQueryForm.tsx
@@ -330,7 +330,7 @@ const BigQueryForm: FC<{
                     loadingCta="Testing access"
                     onClick={testEventForwarderAccess}
                   >
-                    Test Table Creation Access
+                    Test Write Access
                   </Button>
                 </div>
                 {eventForwarderTestResult ? (

--- a/packages/front-end/components/Settings/BigQueryForm.tsx
+++ b/packages/front-end/components/Settings/BigQueryForm.tsx
@@ -3,6 +3,7 @@ import { Flex } from "@radix-ui/themes";
 import { stripLeadingUtf8ByteOrderMark } from "shared/util";
 import { BigQueryConnectionParams } from "shared/types/integrations/bigquery";
 import { EventForwarderConfigDraft } from "shared/types/event-forwarder";
+import { EventForwarderAccessTestResponse } from "shared/validators";
 import { isCloud } from "@/services/env";
 import { useAuth } from "@/services/auth";
 import Field from "@/components/Forms/Field";
@@ -10,6 +11,7 @@ import Tooltip from "@/components/Tooltip/Tooltip";
 import SelectField from "@/components/Forms/SelectField";
 import Button from "@/components/Button";
 import Checkbox from "@/ui/Checkbox";
+import Callout from "@/ui/Callout";
 import EventForwarderTableNameField from "./EventForwarderTableNameField";
 
 const BigQueryForm: FC<{
@@ -21,6 +23,10 @@ const BigQueryForm: FC<{
     eventForwarderConfig: EventForwarderConfigDraft | null,
   ) => void;
   onParamChange: ChangeEventHandler<HTMLInputElement | HTMLSelectElement>;
+  datasourceId?: string;
+  projects?: string[];
+  eventForwarderAccessSignature: string;
+  setValidatedEventForwarderSignature?: (signature: string | null) => void;
 }> = ({
   params,
   eventForwarderConfig,
@@ -28,11 +34,19 @@ const BigQueryForm: FC<{
   setEventForwarderConfig,
   existing,
   onParamChange,
+  datasourceId,
+  projects,
+  eventForwarderAccessSignature,
+  setValidatedEventForwarderSignature,
 }) => {
   const [testConnectionResults, setTestConnectionResults] = useState<{
     status: "success" | "danger" | "warning";
     message: string;
     datasetOptions: string[];
+  } | null>(null);
+  const [eventForwarderTestResult, setEventForwarderTestResult] = useState<{
+    status: "success" | "error";
+    message: string;
   } | null>(null);
   const { apiCall } = useAuth();
 
@@ -73,6 +87,48 @@ const BigQueryForm: FC<{
         status: "danger",
         message: e.message,
         datasetOptions: [],
+      });
+    }
+  }
+
+  async function testEventForwarderAccess() {
+    if (eventForwarderConfig?.sinkType !== "bigquery") return;
+
+    setEventForwarderTestResult(null);
+    setValidatedEventForwarderSignature?.(null);
+    const endpoint =
+      existing && datasourceId
+        ? `/datasource/${datasourceId}/event-forwarder/test-access`
+        : "/datasources/event-forwarder/test-access";
+    const body =
+      existing && datasourceId
+        ? {
+            params,
+            eventForwarderConfig,
+          }
+        : {
+            type: "bigquery",
+            params,
+            projects,
+            eventForwarderConfig,
+          };
+
+    const response = await apiCall<EventForwarderAccessTestResponse>(endpoint, {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
+    const sinkWrite = response.results.sinkWrite;
+    if (sinkWrite.result === "success") {
+      setValidatedEventForwarderSignature?.(eventForwarderAccessSignature);
+      setEventForwarderTestResult({
+        status: "success",
+        message: "Event Forwarder write access verified.",
+      });
+    } else {
+      setEventForwarderTestResult({
+        status: "error",
+        message:
+          sinkWrite.resultMessage || "Event Forwarder write access failed.",
       });
     }
   }
@@ -261,6 +317,24 @@ const BigQueryForm: FC<{
                   tooltip="Defaults to gb_events. If that table already exists, GrowthBook will reuse it for the event forwarder."
                   helpText="Letters, numbers, and underscores (Unicode allowed). Hyphens and spaces are normalized to underscores when saving."
                 />
+                <div>
+                  <Button
+                    color="primary"
+                    disabled={!params.defaultDataset}
+                    onClick={testEventForwarderAccess}
+                  >
+                    Test Event Forwarder Access
+                  </Button>
+                </div>
+                {eventForwarderTestResult ? (
+                  <Callout
+                    status={eventForwarderTestResult.status}
+                    mt="0"
+                    mb="0"
+                  >
+                    {eventForwarderTestResult.message}
+                  </Callout>
+                ) : null}
               </Flex>
             )}
           </div>

--- a/packages/front-end/components/Settings/ConnectionSettings.tsx
+++ b/packages/front-end/components/Settings/ConnectionSettings.tsx
@@ -20,6 +20,8 @@ export interface Props {
   hasError: boolean;
   setDirty?: (dirty: boolean) => void;
   setDatasource: (newVal: Partial<DataSourceInterfaceWithParams>) => void;
+  eventForwarderAccessSignature?: string;
+  setValidatedEventForwarderSignature?: (signature: string | null) => void;
 }
 
 export default function ConnectionSettings({
@@ -28,6 +30,8 @@ export default function ConnectionSettings({
   setDatasource,
   setDirty,
   hasError,
+  eventForwarderAccessSignature = "",
+  setValidatedEventForwarderSignature,
 }: Props) {
   // Set the new params (specific per-datasource) and optionally settings (shared between datasources)
   const setParams = (
@@ -180,6 +184,12 @@ export default function ConnectionSettings({
           params={datasource?.params || {}}
           eventForwarderConfig={datasource.eventForwarderConfig || null}
           setEventForwarderConfig={setEventForwarderConfig}
+          datasourceId={datasource.id}
+          projects={datasource.projects}
+          eventForwarderAccessSignature={eventForwarderAccessSignature}
+          setValidatedEventForwarderSignature={
+            setValidatedEventForwarderSignature
+          }
         />
       );
       break;
@@ -202,6 +212,12 @@ export default function ConnectionSettings({
           eventForwarderConfig={datasource.eventForwarderConfig || null}
           setEventForwarderConfig={setEventForwarderConfig}
           onParamChange={onParamChange}
+          datasourceId={datasource.id}
+          projects={datasource.projects}
+          eventForwarderAccessSignature={eventForwarderAccessSignature}
+          setValidatedEventForwarderSignature={
+            setValidatedEventForwarderSignature
+          }
         />
       );
       break;

--- a/packages/front-end/components/Settings/DataSourceForm.tsx
+++ b/packages/front-end/components/Settings/DataSourceForm.tsx
@@ -7,6 +7,7 @@ import {
 } from "react";
 import { DataSourceInterfaceWithParams } from "shared/types/datasource";
 import { getDemoDatasourceProjectIdForOrganization } from "shared/demo-datasource";
+import { computeEventForwarderAccessSignature } from "shared/util";
 import { dataSourceConnections } from "@/services/eventSchema";
 import Button from "@/components/Button";
 import SelectField from "@/components/Forms/SelectField";
@@ -54,6 +55,10 @@ const DataSourceForm: FC<{
   const [datasource, setDatasource] = useState<
     Partial<DataSourceInterfaceWithParams> | undefined
   >();
+  const [
+    validatedEventForwarderSignature,
+    setValidatedEventForwarderSignature,
+  ] = useState<string | null>(null);
   const [hasError, setHasError] = useState(false);
   const permissionsUtil = usePermissionsUtil();
 
@@ -95,6 +100,22 @@ const DataSourceForm: FC<{
     }
   }, [data, dirty]);
 
+  const eventForwarderAccessSignature = computeEventForwarderAccessSignature(
+    datasource || {},
+  );
+  const eventForwarderSaveBlocked =
+    !!datasource?.eventForwarderConfig &&
+    validatedEventForwarderSignature !== eventForwarderAccessSignature;
+
+  useEffect(() => {
+    if (
+      validatedEventForwarderSignature &&
+      validatedEventForwarderSignature !== eventForwarderAccessSignature
+    ) {
+      setValidatedEventForwarderSignature(null);
+    }
+  }, [eventForwarderAccessSignature, validatedEventForwarderSignature]);
+
   if (!datasource) {
     return null;
   }
@@ -106,6 +127,11 @@ const DataSourceForm: FC<{
     try {
       if (!datasource.type) {
         throw new Error("Please select a data source type");
+      }
+      if (eventForwarderSaveBlocked) {
+        throw new Error(
+          "Test Event Forwarder access before saving this datasource.",
+        );
       }
 
       let id = data.id;
@@ -186,11 +212,13 @@ const DataSourceForm: FC<{
       cta={cta}
       size="lg"
       secondaryCTA={secondaryCTA}
-      ctaEnabled={!isSampleData}
+      ctaEnabled={!isSampleData && !eventForwarderSaveBlocked}
       disabledMessage={
         isSampleData
           ? "You cannot edit the sample data source connection."
-          : undefined
+          : eventForwarderSaveBlocked
+            ? "Test Event Forwarder access before saving this datasource."
+            : undefined
       }
     >
       {importSampleData && !datasource.type && (
@@ -302,6 +330,10 @@ const DataSourceForm: FC<{
         hasError={hasError}
         setDatasource={setDatasource}
         setDirty={setDirty}
+        eventForwarderAccessSignature={eventForwarderAccessSignature}
+        setValidatedEventForwarderSignature={
+          setValidatedEventForwarderSignature
+        }
       />
       <EditSchemaOptions
         datasource={datasource}

--- a/packages/front-end/components/Settings/NewDataSourceForm.tsx
+++ b/packages/front-end/components/Settings/NewDataSourceForm.tsx
@@ -10,6 +10,7 @@ import {
   DataSourceInterfaceWithParams,
   SchemaFormat,
 } from "shared/types/datasource";
+import { computeEventForwarderAccessSignature } from "shared/util";
 import { useForm } from "react-hook-form";
 import { isDemoDatasourceProject } from "shared/demo-datasource";
 import { FaExternalLinkAlt } from "react-icons/fa";
@@ -105,6 +106,10 @@ const NewDataSourceForm: FC<{
     projects: project ? [project] : [],
     ...initial,
   });
+  const [
+    validatedEventForwarderSignature,
+    setValidatedEventForwarderSignature,
+  ] = useState<string | null>(null);
 
   // Cloud, no managed warehouse yet, and is either free OR on a usage-based paid plan
   const showManagedWarehouse =
@@ -134,6 +139,21 @@ const NewDataSourceForm: FC<{
     .map((s) => s.value);
 
   const [lastError, setLastError] = useState("");
+  const eventForwarderAccessSignature =
+    computeEventForwarderAccessSignature(connectionInfo);
+  const eventForwarderSaveBlocked =
+    step === "connection" &&
+    !!connectionInfo.eventForwarderConfig &&
+    validatedEventForwarderSignature !== eventForwarderAccessSignature;
+
+  useEffect(() => {
+    if (
+      validatedEventForwarderSignature &&
+      validatedEventForwarderSignature !== eventForwarderAccessSignature
+    ) {
+      setValidatedEventForwarderSignature(null);
+    }
+  }, [eventForwarderAccessSignature, validatedEventForwarderSignature]);
 
   const setSchemaSettings = useCallback(
     (s: eventSchema) => {
@@ -215,6 +235,11 @@ const NewDataSourceForm: FC<{
       try {
         if (!connectionInfo.type || !connectionInfo.params) {
           throw new Error("Please select a data source type");
+        }
+        if (eventForwarderSaveBlocked) {
+          throw new Error(
+            "Test Event Forwarder access before saving this datasource.",
+          );
         }
 
         if (connectionInfo.settings && eventTracker) {
@@ -632,6 +657,10 @@ const NewDataSourceForm: FC<{
           existing={false}
           hasError={!!lastError}
           setDatasource={setConnectionInfo}
+          eventForwarderAccessSignature={eventForwarderAccessSignature}
+          setValidatedEventForwarderSignature={
+            setValidatedEventForwarderSignature
+          }
         />
       </div>
     );
@@ -729,6 +758,12 @@ const NewDataSourceForm: FC<{
     !connectionInfo.params?.defaultDataset
   ) {
     ctaEnabled = false;
+  }
+
+  if (eventForwarderSaveBlocked) {
+    ctaEnabled = false;
+    disabledMessage =
+      "Test Event Forwarder access before saving this datasource.";
   }
 
   if (step === "initial" && !connectionInfo.type) {

--- a/packages/front-end/components/Settings/SnowflakeForm.tsx
+++ b/packages/front-end/components/Settings/SnowflakeForm.tsx
@@ -2,11 +2,15 @@ import { FC, ChangeEventHandler, useState } from "react";
 import { DEFAULT_EVENT_FORWARDER_SNOWFLAKE_TABLE_NAME } from "shared/util";
 import { EventForwarderConfigDraft } from "shared/types/event-forwarder";
 import { SnowflakeConnectionParams } from "shared/types/integrations/snowflake";
+import { EventForwarderAccessTestResponse } from "shared/validators";
+import { useAuth } from "@/services/auth";
 import Tooltip from "@/components/Tooltip/Tooltip";
 import Switch from "@/ui/Switch";
 import Checkbox from "@/ui/Checkbox";
 import { GBInfo } from "@/components/Icons";
 import FileInput from "@/components/FileInput";
+import Button from "@/components/Button";
+import Callout from "@/ui/Callout";
 import EventForwarderTableNameField from "./EventForwarderTableNameField";
 
 const SnowflakeForm: FC<{
@@ -18,6 +22,10 @@ const SnowflakeForm: FC<{
   ) => void;
   onParamChange: ChangeEventHandler<HTMLInputElement>;
   onManualParamChange: (name: string, value: string) => void;
+  datasourceId?: string;
+  projects?: string[];
+  eventForwarderAccessSignature: string;
+  setValidatedEventForwarderSignature?: (signature: string | null) => void;
 }> = ({
   params,
   eventForwarderConfig,
@@ -25,9 +33,18 @@ const SnowflakeForm: FC<{
   existing,
   onParamChange,
   onManualParamChange,
+  datasourceId,
+  projects,
+  eventForwarderAccessSignature,
+  setValidatedEventForwarderSignature,
 }) => {
+  const { apiCall } = useAuth();
   const [useAccessUrl, setUseAccessUrl] = useState(!!params.accessUrl);
   const [originalAuthMethod] = useState(params.authMethod);
+  const [eventForwarderTestResult, setEventForwarderTestResult] = useState<{
+    status: "success" | "error";
+    message: string;
+  } | null>(null);
   // Convenience variable for the auth method to handle undefined
   const authMethod = params.authMethod ?? "password";
   const canEnableEventForwarder = authMethod === "key-pair";
@@ -35,6 +52,48 @@ const SnowflakeForm: FC<{
     eventForwarderConfig?.sinkType === "snowflake"
       ? eventForwarderConfig
       : null;
+
+  async function testEventForwarderAccess() {
+    if (!snowflakeEventForwarderConfig) return;
+
+    setEventForwarderTestResult(null);
+    setValidatedEventForwarderSignature?.(null);
+    const endpoint =
+      existing && datasourceId
+        ? `/datasource/${datasourceId}/event-forwarder/test-access`
+        : "/datasources/event-forwarder/test-access";
+    const body =
+      existing && datasourceId
+        ? {
+            params,
+            eventForwarderConfig: snowflakeEventForwarderConfig,
+          }
+        : {
+            type: "snowflake",
+            params,
+            projects,
+            eventForwarderConfig: snowflakeEventForwarderConfig,
+          };
+
+    const response = await apiCall<EventForwarderAccessTestResponse>(endpoint, {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
+    const sinkWrite = response.results.sinkWrite;
+    if (sinkWrite.result === "success") {
+      setValidatedEventForwarderSignature?.(eventForwarderAccessSignature);
+      setEventForwarderTestResult({
+        status: "success",
+        message: "Event Forwarder write access verified.",
+      });
+    } else {
+      setEventForwarderTestResult({
+        status: "error",
+        message:
+          sinkWrite.resultMessage || "Event Forwarder write access failed.",
+      });
+    }
+  }
 
   return (
     <div className="row">
@@ -218,6 +277,22 @@ const SnowflakeForm: FC<{
                   }
                 />
               </div>
+              <div className="form-group col-md-12">
+                <Button color="primary" onClick={testEventForwarderAccess}>
+                  Test Event Forwarder Access
+                </Button>
+              </div>
+              {eventForwarderTestResult ? (
+                <div className="form-group col-md-12">
+                  <Callout
+                    status={eventForwarderTestResult.status}
+                    mt="0"
+                    mb="0"
+                  >
+                    {eventForwarderTestResult.message}
+                  </Callout>
+                </div>
+              ) : null}
             </>
           )}
         </>

--- a/packages/front-end/components/Settings/SnowflakeForm.tsx
+++ b/packages/front-end/components/Settings/SnowflakeForm.tsx
@@ -52,6 +52,19 @@ const SnowflakeForm: FC<{
     eventForwarderConfig?.sinkType === "snowflake"
       ? eventForwarderConfig
       : null;
+  const hasSnowflakePrivateKey =
+    !!params.privateKey?.trim() ||
+    (existing && authMethod === originalAuthMethod);
+  const canTestEventForwarderAccess = snowflakeEventForwarderConfig
+    ? !!snowflakeEventForwarderConfig.config.tableName.trim() &&
+      !!snowflakeEventForwarderConfig.config.accessUrl?.trim() &&
+      !!params.account?.trim() &&
+      !!params.username?.trim() &&
+      !!params.database?.trim() &&
+      !!params.schema?.trim() &&
+      authMethod === "key-pair" &&
+      hasSnowflakePrivateKey
+    : false;
 
   async function testEventForwarderAccess() {
     if (!snowflakeEventForwarderConfig) return;
@@ -84,13 +97,15 @@ const SnowflakeForm: FC<{
       setValidatedEventForwarderSignature?.(eventForwarderAccessSignature);
       setEventForwarderTestResult({
         status: "success",
-        message: "Event Forwarder write access verified.",
+        message:
+          "Event Forwarder table creation access verified. GrowthBook created and deleted a temporary validation table.",
       });
     } else {
       setEventForwarderTestResult({
         status: "error",
         message:
-          sinkWrite.resultMessage || "Event Forwarder write access failed.",
+          sinkWrite.resultMessage ||
+          "Event Forwarder table creation access failed.",
       });
     }
   }
@@ -278,8 +293,13 @@ const SnowflakeForm: FC<{
                 />
               </div>
               <div className="form-group col-md-12">
-                <Button color="primary" onClick={testEventForwarderAccess}>
-                  Test Event Forwarder Access
+                <Button
+                  color="primary"
+                  disabled={!canTestEventForwarderAccess}
+                  loadingCta="Testing access"
+                  onClick={testEventForwarderAccess}
+                >
+                  Test Table Creation Access
                 </Button>
               </div>
               {eventForwarderTestResult ? (

--- a/packages/front-end/components/Settings/SnowflakeForm.tsx
+++ b/packages/front-end/components/Settings/SnowflakeForm.tsx
@@ -299,7 +299,7 @@ const SnowflakeForm: FC<{
                   loadingCta="Testing access"
                   onClick={testEventForwarderAccess}
                 >
-                  Test Table Creation Access
+                  Test Write Access
                 </Button>
               </div>
               {eventForwarderTestResult ? (

--- a/packages/shared/src/util/event-forwarder-access-signature.ts
+++ b/packages/shared/src/util/event-forwarder-access-signature.ts
@@ -1,0 +1,90 @@
+import { DataSourceInterfaceWithParams } from "shared/types/datasource";
+
+type StableJson =
+  | null
+  | string
+  | number
+  | boolean
+  | StableJson[]
+  | { [key: string]: StableJson };
+
+function stableValue(value: unknown): StableJson {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "string") return value;
+  if (typeof value === "number") return value;
+  if (typeof value === "boolean") return value;
+  if (Array.isArray(value)) return value.map(stableValue);
+  if (typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([key, inner]) => [key, stableValue(inner)]),
+    );
+  }
+  return String(value);
+}
+
+function pickFields(
+  source: Record<string, unknown> | undefined,
+  fields: string[],
+): Record<string, unknown> {
+  if (!source) return {};
+  return Object.fromEntries(fields.map((field) => [field, source[field]]));
+}
+
+export function computeEventForwarderAccessSignature(
+  datasource: Partial<DataSourceInterfaceWithParams>,
+): string {
+  const config = datasource.eventForwarderConfig;
+  if (!config) return "";
+
+  const params = datasource.params as Record<string, unknown> | undefined;
+  const base = {
+    type: datasource.type,
+    eventForwarderConfig: config,
+  };
+
+  if (config.sinkType === "bigquery") {
+    return JSON.stringify(
+      stableValue({
+        ...base,
+        params: pickFields(params, [
+          "authType",
+          "projectId",
+          "defaultProject",
+          "defaultDataset",
+          "clientEmail",
+          "privateKey",
+          "serviceAccountJson",
+        ]),
+      }),
+    );
+  }
+
+  if (config.sinkType === "snowflake") {
+    return JSON.stringify(
+      stableValue({
+        ...base,
+        params: pickFields(params, [
+          "account",
+          "username",
+          "authMethod",
+          "database",
+          "schema",
+          "role",
+          "warehouse",
+          "accessUrl",
+          "privateKey",
+          "privateKeyPassword",
+        ]),
+      }),
+    );
+  }
+
+  return JSON.stringify(
+    stableValue({
+      ...base,
+      params: pickFields(params, ["host", "port", "path", "token", "catalog"]),
+    }),
+  );
+}

--- a/packages/shared/src/util/index.ts
+++ b/packages/shared/src/util/index.ts
@@ -28,6 +28,7 @@ import { featureHasEnvironment } from "./features";
 export * from "./strings";
 export * from "./bigquery-table-name";
 export * from "./snowflake-table-name";
+export * from "./event-forwarder-access-signature";
 export * from "./features";
 export * from "./managedWarehouse";
 export * from "./saved-groups";

--- a/packages/shared/src/validators/event-forwarder-access-test.ts
+++ b/packages/shared/src/validators/event-forwarder-access-test.ts
@@ -1,0 +1,70 @@
+import { z } from "zod";
+
+const datasourceParamsSchema = z.record(z.string(), z.unknown());
+
+const bigQueryEventForwarderConfigSchema = z.object({
+  sinkType: z.literal("bigquery"),
+  config: z.object({
+    tableName: z.string(),
+    serviceAccountKey: z.string().optional(),
+  }),
+});
+
+const snowflakeEventForwarderConfigSchema = z.object({
+  sinkType: z.literal("snowflake"),
+  config: z.object({
+    tableName: z.string(),
+    accessUrl: z.string().optional(),
+  }),
+});
+
+const databricksEventForwarderConfigSchema = z.object({
+  sinkType: z.literal("databricks"),
+  config: z.record(z.string(), z.string()),
+});
+
+export const eventForwarderAccessTestConfigSchema = z.discriminatedUnion(
+  "sinkType",
+  [
+    bigQueryEventForwarderConfigSchema,
+    snowflakeEventForwarderConfigSchema,
+    databricksEventForwarderConfigSchema,
+  ],
+);
+
+export const eventForwarderAccessTestCreateBodySchema = z.object({
+  type: z.enum(["bigquery", "snowflake", "databricks"]),
+  params: datasourceParamsSchema,
+  projects: z.array(z.string()).optional(),
+  eventForwarderConfig: eventForwarderAccessTestConfigSchema,
+});
+
+export const eventForwarderAccessTestEditBodySchema = z.object({
+  params: datasourceParamsSchema.optional(),
+  eventForwarderConfig: eventForwarderAccessTestConfigSchema.optional(),
+});
+
+export const eventForwarderAccessTestResultSchema = z.object({
+  result: z.enum(["success", "failed", "skipped"]),
+  resultMessage: z.string().optional(),
+});
+
+export const eventForwarderAccessTestResponseSchema = z.object({
+  status: z.literal(200),
+  results: z.object({
+    sinkWrite: eventForwarderAccessTestResultSchema,
+  }),
+});
+
+export type EventForwarderAccessTestCreateBody = z.infer<
+  typeof eventForwarderAccessTestCreateBodySchema
+>;
+export type EventForwarderAccessTestEditBody = z.infer<
+  typeof eventForwarderAccessTestEditBodySchema
+>;
+export type EventForwarderAccessTestResponse = z.infer<
+  typeof eventForwarderAccessTestResponseSchema
+>;
+export type EventForwarderAccessTestResult = z.infer<
+  typeof eventForwarderAccessTestResultSchema
+>;

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -29,6 +29,7 @@ export * from "./snapshot-analysis-chunks";
 export * from "./webhook-secrets";
 export * from "./webhooks";
 export * from "./event-forwarder-config";
+export * from "./event-forwarder-access-test";
 export * from "./event-webhook";
 export * from "./feature-webhook-schemas";
 // Load watch before events - events imports base-types which imports validators, creating a cycle.

--- a/packages/shared/test/event-forwarder-avro.test.ts
+++ b/packages/shared/test/event-forwarder-avro.test.ts
@@ -78,7 +78,7 @@ describe("eventForwarderAvro", () => {
     expect(summary.recordName).toBe(EVENT_FORWARDER_AVRO_RECORD_NAME);
     expect(summary.namespace).toBe(EVENT_FORWARDER_AVRO_NAMESPACE);
     expect(summary.fieldNames).toContain("event_name");
-    expect(summary.fieldNames).toContain("attributes");
+    expect(summary.fieldNames).toContain("additional_attributes");
     expect(summary.fieldNames.length).toBe(
       EVENT_FORWARDER_AVRO_DEFAULT_FIELDS.length,
     );


### PR DESCRIPTION
### Features and Changes

- Add Test Connection to Event Forwarder
- This attempt to test Write access in DW by create and then delete a temporary table
- Closes **[Test EF connection](https://www.notion.so/growthbook/Event-Forwarder-345a857e74a080a888c8de6d150a518d?source=copy_link#34ca857e74a080f3b0aeffee82043afa)**

### Testing

- Create a new data source
- Enable an Event Forwarder
- Test to see if there's a write access

### Screenshots
<img width="882" height="244" alt="Screenshot 2026-05-01 at 11 17 03 AM" src="https://github.com/user-attachments/assets/71c45506-25fe-4ee3-bff1-65c74f2c4ceb" />

