### PR TITLE
Fix React console warnings

### DIFF
--- a/packages/front-end/pages/_document.tsx
+++ b/packages/front-end/pages/_document.tsx
@@ -7,7 +7,7 @@ export default function Document() {
     // so we suppress hydration warnings so React does not attempt to patch
     // our changes.
     // This applies only to the <html> element, not affecting any of the children.
-    <Html suppressHydrationWarning>
+    <Html suppressHydrationWarning data-scroll-behavior="smooth">
       <Head>
         <script
           dangerouslySetInnerHTML={{

--- a/packages/front-end/ui/Popover.tsx
+++ b/packages/front-end/ui/Popover.tsx
@@ -4,6 +4,7 @@ import { IconButton } from "@radix-ui/themes";
 import type { MarginProps } from "@radix-ui/themes/dist/esm/props/margin.props.js";
 import { PiX } from "react-icons/pi";
 import { RadixTheme } from "@/services/RadixTheme";
+import Button from "./Button";
 import styles from "./Popover.module.scss";
 
 type AllowedChildren = string | React.ReactNode;
@@ -53,13 +54,16 @@ export function Popover({
     ...contentStyle,
   };
 
-  // In case using our own button component, ensure preventDefault is false
-  const clonedTrigger = React.isValidElement(trigger)
-    ? React.cloneElement(trigger, { preventDefault: false } as Record<
-        string,
-        unknown
-      >)
-    : trigger;
+  // Override the @/ui/Button default of preventDefault=true so it doesn't
+  // interfere with Radix Popover's open/close handling. Only applies to that
+  // component — passing the prop to a DOM element triggers a React warning.
+  const clonedTrigger =
+    React.isValidElement(trigger) && trigger.type === Button
+      ? React.cloneElement(trigger, { preventDefault: false } as Record<
+          string,
+          unknown
+        >)
+      : trigger;
 
   return (
     <RadixPopover.Root {...props}>

--- a/packages/front-end/ui/PremiumCallout.tsx
+++ b/packages/front-end/ui/PremiumCallout.tsx
@@ -1,5 +1,10 @@
 import { CommercialFeature } from "shared/enterprise";
-import { Flex, IconButton, Callout as RadixCallout } from "@radix-ui/themes";
+import {
+  Flex,
+  IconButton,
+  Callout as RadixCallout,
+  Text,
+} from "@radix-ui/themes";
 import { MarginProps } from "@radix-ui/themes/dist/esm/props/margin.props.js";
 import { useState } from "react";
 import { PiArrowSquareOut, PiLightbulb, PiX } from "react-icons/pi";
@@ -109,12 +114,15 @@ export default function PremiumCallout({
         }}
       >
         <RadixCallout.Icon>{icon}</RadixCallout.Icon>
-        <RadixCallout.Text size="2">
+        {/* Render as a div instead of RadixCallout.Text (which forces <p>)
+            so block-level children and the inner Flex don't produce invalid
+            <div>-inside-<p> nesting. */}
+        <Text as="div" size="2">
           <Flex align="start" gap="1" pr="3">
             <div>{children}</div>
             <div style={{ flex: 1 }}>{link}</div>
           </Flex>
-        </RadixCallout.Text>
+        </Text>
         {dismissable ? (
           <IconButton
             variant="ghost"


### PR DESCRIPTION
### Features and Changes

Fixes 3 React warnings that were clogging up console logs on dev:

1. Invalid prop `preventDefault` on HTML elements
2. `<div>` inside of `<p>`
3. Smooth scroll behavior during navigation (https://nextjs.org/docs/messages/missing-data-scroll-behavior)