### PR TITLE
chore(design-system): Add rule to prevent usages of alert

### DIFF
--- a/eslint-rules/no-alert-classname.mjs
+++ b/eslint-rules/no-alert-classname.mjs
@@ -83,14 +83,20 @@ function inspectClassnamesObjectKey(node, report) {
 
 function inspectClassnamesArgument(node, report) {
   const arg =
-    node && node.type === "SpreadElement" ? node.argument : unwrapExpression(node);
+    node && node.type === "SpreadElement"
+      ? node.argument
+      : unwrapExpression(node);
 
   if (!arg) return;
 
   if (arg.type === "ObjectExpression") {
     for (const property of arg.properties) {
       if (property.type === "Property") {
-        inspectClassnamesObjectKey(property.key, report);
+        if (property.computed) {
+          inspectClassValue(property.key, report);
+        } else {
+          inspectClassnamesObjectKey(property.key, report);
+        }
       } else if (property.type === "SpreadElement") {
         inspectClassValue(property.argument, report);
       }
@@ -99,6 +105,24 @@ function inspectClassnamesArgument(node, report) {
   }
 
   inspectClassValue(arg, report);
+}
+
+function inspectJoinReceiver(node, report) {
+  const value = unwrapExpression(node);
+
+  if (!value) return;
+
+  // Support array helper chains before `.join()` without inspecting unrelated
+  // member-expression calls as className values.
+  if (
+    value.type === "CallExpression" &&
+    value.callee.type === "MemberExpression"
+  ) {
+    inspectJoinReceiver(value.callee.object, report);
+    return;
+  }
+
+  inspectClassValue(value, report);
 }
 
 function inspectClassValue(node, report) {
@@ -150,12 +174,8 @@ function inspectClassValue(node, report) {
         return;
       }
 
-      if (value.callee.type === "MemberExpression") {
-        inspectClassValue(value.callee.object, report);
-
-        if (isJoinCall(value)) {
-          return;
-        }
+      if (isJoinCall(value)) {
+        inspectJoinReceiver(value.callee.object, report);
       }
       return;
     default:
@@ -178,7 +198,10 @@ export default {
   create(context) {
     return {
       JSXAttribute(node) {
-        if (node.name.type !== "JSXIdentifier" || node.name.name !== "className") {
+        if (
+          node.name.type !== "JSXIdentifier" ||
+          node.name.name !== "className"
+        ) {
           return;
         }
 

--- a/eslint-rules/no-alert-classname.mjs
+++ b/eslint-rules/no-alert-classname.mjs
@@ -1,0 +1,209 @@
+const ALERT_CLASS_REGEX = /(^|\s)alert(\s|$)/;
+
+function hasAlertClass(value) {
+  return typeof value === "string" && ALERT_CLASS_REGEX.test(value);
+}
+
+function unwrapExpression(node) {
+  let current = node;
+
+  while (current) {
+    switch (current.type) {
+      case "ChainExpression":
+        current = current.expression;
+        break;
+      case "ParenthesizedExpression":
+      case "TSAsExpression":
+      case "TSSatisfiesExpression":
+      case "TSNonNullExpression":
+      case "TSTypeAssertion":
+        current = current.expression;
+        break;
+      default:
+        return current;
+    }
+  }
+
+  return current;
+}
+
+function isClassnamesHelperCall(node) {
+  return (
+    node.type === "CallExpression" &&
+    node.callee.type === "Identifier" &&
+    (node.callee.name === "clsx" || node.callee.name === "classnames")
+  );
+}
+
+function isJoinCall(node) {
+  return (
+    node.type === "CallExpression" &&
+    node.callee.type === "MemberExpression" &&
+    !node.callee.computed &&
+    node.callee.property.type === "Identifier" &&
+    node.callee.property.name === "join"
+  );
+}
+
+function reportIfAlertString(node, rawValue, report) {
+  if (hasAlertClass(rawValue)) {
+    report(node);
+  }
+}
+
+function inspectTemplateLiteral(node, report) {
+  for (const quasi of node.quasis) {
+    reportIfAlertString(quasi, quasi.value.cooked ?? quasi.value.raw, report);
+  }
+
+  for (const expression of node.expressions) {
+    inspectClassValue(expression, report);
+  }
+}
+
+function inspectClassnamesObjectKey(node, report) {
+  const key = unwrapExpression(node);
+
+  if (!key) return;
+
+  switch (key.type) {
+    case "Identifier":
+      reportIfAlertString(key, key.name, report);
+      return;
+    case "Literal":
+      reportIfAlertString(key, key.value, report);
+      return;
+    case "TemplateLiteral":
+      inspectTemplateLiteral(key, report);
+      return;
+    default:
+      inspectClassValue(key, report);
+  }
+}
+
+function inspectClassnamesArgument(node, report) {
+  const arg =
+    node && node.type === "SpreadElement" ? node.argument : unwrapExpression(node);
+
+  if (!arg) return;
+
+  if (arg.type === "ObjectExpression") {
+    for (const property of arg.properties) {
+      if (property.type === "Property") {
+        inspectClassnamesObjectKey(property.key, report);
+      } else if (property.type === "SpreadElement") {
+        inspectClassValue(property.argument, report);
+      }
+    }
+    return;
+  }
+
+  inspectClassValue(arg, report);
+}
+
+function inspectClassValue(node, report) {
+  const value = unwrapExpression(node);
+
+  if (!value) return;
+
+  switch (value.type) {
+    case "Literal":
+      reportIfAlertString(value, value.value, report);
+      return;
+    case "TemplateLiteral":
+      inspectTemplateLiteral(value, report);
+      return;
+    case "ArrayExpression":
+      for (const element of value.elements) {
+        if (!element) continue;
+        if (element.type === "SpreadElement") {
+          inspectClassValue(element.argument, report);
+        } else {
+          inspectClassValue(element, report);
+        }
+      }
+      return;
+    case "BinaryExpression":
+      if (value.operator === "+") {
+        inspectClassValue(value.left, report);
+        inspectClassValue(value.right, report);
+      }
+      return;
+    case "ConditionalExpression":
+      inspectClassValue(value.consequent, report);
+      inspectClassValue(value.alternate, report);
+      return;
+    case "LogicalExpression":
+      inspectClassValue(value.left, report);
+      inspectClassValue(value.right, report);
+      return;
+    case "SequenceExpression":
+      for (const expression of value.expressions) {
+        inspectClassValue(expression, report);
+      }
+      return;
+    case "CallExpression":
+      if (isClassnamesHelperCall(value)) {
+        for (const arg of value.arguments) {
+          inspectClassnamesArgument(arg, report);
+        }
+        return;
+      }
+
+      if (value.callee.type === "MemberExpression") {
+        inspectClassValue(value.callee.object, report);
+
+        if (isJoinCall(value)) {
+          return;
+        }
+      }
+      return;
+    default:
+      return;
+  }
+}
+
+export default {
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Disallow the alert class token in className values.",
+    },
+    schema: [],
+    messages: {
+      noAlertClassname:
+        "Do not use Bootstrap `alert` classes. Use the `Callout` component from `@/ui/Callout` instead.",
+    },
+  },
+  create(context) {
+    return {
+      JSXAttribute(node) {
+        if (node.name.type !== "JSXIdentifier" || node.name.name !== "className") {
+          return;
+        }
+
+        if (!node.value) return;
+
+        const reportedNodes = new Set();
+        const report = (target) => {
+          if (reportedNodes.has(target)) return;
+          reportedNodes.add(target);
+
+          context.report({
+            node: target,
+            messageId: "noAlertClassname",
+          });
+        };
+
+        if (node.value.type === "Literal") {
+          reportIfAlertString(node.value, node.value.value, report);
+          return;
+        }
+
+        if (node.value.type === "JSXExpressionContainer") {
+          inspectClassValue(node.value.expression, report);
+        }
+      },
+    };
+  },
+};

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1,9 +1,4 @@
 {
-  "eslint-rules/no-alert-classname.mjs": {
-    "prettier/prettier": {
-      "count": 2
-    }
-  },
   "packages/front-end/components/ActivityList.tsx": {
     "local/no-alert-classname": {
       "count": 1

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1,7 +1,42 @@
 {
+  "eslint-rules/no-alert-classname.mjs": {
+    "prettier/prettier": {
+      "count": 2
+    }
+  },
+  "packages/front-end/components/ActivityList.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/Archetype/ArchetypeList.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
   "packages/front-end/components/Archetype/AssignmentTester.tsx": {
     "no-restricted-imports": {
       "count": 2
+    }
+  },
+  "packages/front-end/components/Auth/CreateOrJoinOrganization.tsx": {
+    "local/no-alert-classname": {
+      "count": 3
+    }
+  },
+  "packages/front-end/components/Auth/SelectInitialPlan.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/Auth/Welcome.tsx": {
+    "local/no-alert-classname": {
+      "count": 2
+    }
+  },
+  "packages/front-end/components/AutoGenerateMetricsModal.tsx": {
+    "local/no-alert-classname": {
+      "count": 5
     }
   },
   "packages/front-end/components/CustomFields/CustomFieldDisplay.tsx": {
@@ -59,14 +94,44 @@
       "count": 1
     }
   },
+  "packages/front-end/components/DemoDataSourcePage/DemoDataSourcePage.tsx": {
+    "local/no-alert-classname": {
+      "count": 2
+    }
+  },
   "packages/front-end/components/Dimensions/DimensionChooser.tsx": {
     "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/DiscussionThread.tsx": {
+    "local/no-alert-classname": {
       "count": 1
     }
   },
   "packages/front-end/components/EmptyState.tsx": {
     "no-restricted-imports": {
       "count": 1
+    }
+  },
+  "packages/front-end/components/EventWebHooks/EventWebHookList/EventWebHookList.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/EventWebHooks/EventWebHookLogs/EventWebHookLogs.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/Events/EventDetail/EventDetail.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/Events/EventsPage/EventsPage.tsx": {
+    "local/no-alert-classname": {
+      "count": 3
     }
   },
   "packages/front-end/components/ExecReports/ExecExperimentsGraph.tsx": {
@@ -86,6 +151,11 @@
   },
   "packages/front-end/components/Experiment/BaselineChooserColumnLabel.tsx": {
     "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/Experiment/BreakDownResults.tsx": {
+    "local/no-alert-classname": {
       "count": 1
     }
   },
@@ -114,9 +184,19 @@
       "count": 1
     }
   },
+  "packages/front-end/components/Experiment/EditDOMMutationsModal.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
   "packages/front-end/components/Experiment/EditHypothesisModal.tsx": {
     "no-restricted-imports": {
       "count": 2
+    }
+  },
+  "packages/front-end/components/Experiment/EditPhaseModal.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
     }
   },
   "packages/front-end/components/Experiment/EditTargetingModal.tsx": {
@@ -126,6 +206,11 @@
   },
   "packages/front-end/components/Experiment/ExperimentCarouselModal.tsx": {
     "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/Experiment/ExperimentGraph.tsx": {
+    "local/no-alert-classname": {
       "count": 1
     }
   },
@@ -144,13 +229,36 @@
       "count": 1
     }
   },
+  "packages/front-end/components/Experiment/ImportExperimentList.tsx": {
+    "local/no-alert-classname": {
+      "count": 2
+    }
+  },
   "packages/front-end/components/Experiment/NewExperimentForm.tsx": {
+    "local/no-alert-classname": {
+      "count": 2
+    },
     "no-restricted-imports": {
       "count": 2
     }
   },
+  "packages/front-end/components/Experiment/NewPhaseForm.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
   "packages/front-end/components/Experiment/RefreshSnapshotButton.tsx": {
     "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/Experiment/ReleaseChangesForm.tsx": {
+    "local/no-alert-classname": {
+      "count": 4
+    }
+  },
+  "packages/front-end/components/Experiment/Results.tsx": {
+    "local/no-alert-classname": {
       "count": 1
     }
   },
@@ -169,13 +277,33 @@
       "count": 1
     }
   },
+  "packages/front-end/components/Experiment/StatusBanner.tsx": {
+    "local/no-alert-classname": {
+      "count": 3
+    }
+  },
   "packages/front-end/components/Experiment/TabbedPage/AnalysisSettingsSummary.tsx": {
     "no-restricted-imports": {
       "count": 1
     }
   },
+  "packages/front-end/components/Experiment/TabbedPage/BanditUpdateStatus.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
   "packages/front-end/components/Experiment/TabbedPage/ExperimentDecisionExplanation.tsx": {
     "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/Experiment/TabbedPage/ExperimentHeader.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/Experiment/TabbedPage/HealthTabOnboardingModal.tsx": {
+    "local/no-alert-classname": {
       "count": 1
     }
   },
@@ -189,19 +317,62 @@
       "count": 1
     }
   },
+  "packages/front-end/components/Experiment/TabbedPage/StartExperimentModal.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/Experiment/TabbedPage/StoppedExperimentBanner.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
   "packages/front-end/components/Experiment/TabbedPage/TargetMDEModal.tsx": {
     "no-restricted-imports": {
       "count": 1
     }
   },
+  "packages/front-end/components/Experiment/TabbedPage/TrafficAndTargeting.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
   "packages/front-end/components/Experiment/TabbedPage/index.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    },
     "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/Experiment/Templates/TemplateForm.tsx": {
+    "local/no-alert-classname": {
+      "count": 2
+    }
+  },
+  "packages/front-end/components/Experiment/Templates/TemplatesPage.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/Experiment/UrlRedirectModal.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/Experiment/UsersTable.tsx": {
+    "local/no-alert-classname": {
       "count": 1
     }
   },
   "packages/front-end/components/Experiment/VariationChooserColumnLabel.tsx": {
     "no-restricted-imports": {
       "count": 1
+    }
+  },
+  "packages/front-end/components/Experiment/VariationIdWarning.tsx": {
+    "local/no-alert-classname": {
+      "count": 3
     }
   },
   "packages/front-end/components/Experiment/VariationsTable.tsx": {
@@ -214,8 +385,21 @@
       "count": 2
     }
   },
+  "packages/front-end/components/FactTables/ColumnList.tsx": {
+    "local/no-alert-classname": {
+      "count": 3
+    }
+  },
   "packages/front-end/components/FactTables/ColumnModal.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    },
     "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/FactTables/FactFilterModal.tsx": {
+    "local/no-alert-classname": {
       "count": 1
     }
   },
@@ -234,7 +418,22 @@
       "count": 1
     }
   },
+  "packages/front-end/components/FactTables/FactTableModal.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
   "packages/front-end/components/Features/AddToHoldoutModal.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/Features/CodeSnippetModal.tsx": {
+    "local/no-alert-classname": {
+      "count": 3
+    }
+  },
+  "packages/front-end/components/Features/CompareEnvironmentsModal.tsx": {
     "no-restricted-imports": {
       "count": 1
     }
@@ -259,9 +458,29 @@
       "count": 1
     }
   },
+  "packages/front-end/components/Features/FeatureModal/FeatureFromExperimentModal.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
   "packages/front-end/components/Features/FeatureReferencesList.tsx": {
     "no-restricted-imports": {
       "count": 1
+    }
+  },
+  "packages/front-end/components/Features/FeatureRules.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/Features/FeaturesHeader.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/Features/FeaturesOverview.tsx": {
+    "local/no-alert-classname": {
+      "count": 2
     }
   },
   "packages/front-end/components/Features/HoldoutRule.tsx": {
@@ -284,18 +503,61 @@
       "count": 1
     }
   },
+  "packages/front-end/components/Features/RevisionLog.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
   "packages/front-end/components/Features/RolloutSummary.tsx": {
     "no-restricted-imports": {
       "count": 1
     }
   },
+  "packages/front-end/components/Features/RuleModal/BanditRefNewFields.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
   "packages/front-end/components/Features/RuleModal/SafeRolloutFields.tsx": {
+    "local/no-alert-classname": {
+      "count": 2
+    },
     "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/Features/RuleModal/StandardRuleFields.tsx": {
+    "local/no-alert-classname": {
       "count": 1
     }
   },
   "packages/front-end/components/Features/RuleModal/index.tsx": {
     "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/Features/SDKConnections/ConnectionStatus.tsx": {
+    "local/no-alert-classname": {
+      "count": 2
+    }
+  },
+  "packages/front-end/components/Features/SDKConnections/InitialSDKConnectionForm.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/Features/SDKConnections/ProxyTestButton.tsx": {
+    "local/no-alert-classname": {
+      "count": 2
+    }
+  },
+  "packages/front-end/components/Features/SDKConnections/SDKConnectionForm.tsx": {
+    "local/no-alert-classname": {
+      "count": 2
+    }
+  },
+  "packages/front-end/components/Features/SDKConnections/SDKConnectionsList.tsx": {
+    "local/no-alert-classname": {
       "count": 1
     }
   },
@@ -319,7 +581,15 @@
       "count": 1
     }
   },
+  "packages/front-end/components/Forms/InlineForm.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
   "packages/front-end/components/GeneralSettings/AISettings.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    },
     "no-restricted-imports": {
       "count": 2
     }
@@ -351,6 +621,11 @@
   },
   "packages/front-end/components/GeneralSettings/FeatureSettings.tsx": {
     "no-restricted-imports": {
+      "count": 2
+    }
+  },
+  "packages/front-end/components/GeneralSettings/ImportSettings.tsx": {
+    "local/no-alert-classname": {
       "count": 2
     }
   },
@@ -409,8 +684,33 @@
       "count": 1
     }
   },
+  "packages/front-end/components/GuidedGetStarted/CheckSDKConnectionResults.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/HealthTab/BanditSRMCard.tsx": {
+    "local/no-alert-classname": {
+      "count": 2
+    }
+  },
+  "packages/front-end/components/HealthTab/DimensionIssues.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
   "packages/front-end/components/HealthTab/PowerCard.tsx": {
     "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/HealthTab/SRMCard.tsx": {
+    "local/no-alert-classname": {
+      "count": 2
+    }
+  },
+  "packages/front-end/components/HistoryTable.tsx": {
+    "local/no-alert-classname": {
       "count": 1
     }
   },
@@ -440,13 +740,56 @@
     }
   },
   "packages/front-end/components/Holdout/NewHoldoutForm.tsx": {
+    "local/no-alert-classname": {
+      "count": 2
+    },
     "no-restricted-imports": {
       "count": 1
+    }
+  },
+  "packages/front-end/components/HomePage/DiscussionFeed.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/HomePage/ExperimentImpact/ExperimentImpactTab.tsx": {
+    "local/no-alert-classname": {
+      "count": 2
+    }
+  },
+  "packages/front-end/components/HomePage/ExperimentImpact/index.tsx": {
+    "local/no-alert-classname": {
+      "count": 2
+    }
+  },
+  "packages/front-end/components/HomePage/ExperimentsGetStarted.tsx": {
+    "local/no-alert-classname": {
+      "count": 2
+    }
+  },
+  "packages/front-end/components/HomePage/GetStartedStep.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/HomePage/IdeasFeed.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/HomePage/NorthStarMetricDisplay.tsx": {
+    "local/no-alert-classname": {
+      "count": 3
     }
   },
   "packages/front-end/components/InitialSetup/ManagedWarehouseModal.tsx": {
     "no-restricted-imports": {
       "count": 1
+    }
+  },
+  "packages/front-end/components/InitialSetup/VerifyConnectionPage.tsx": {
+    "local/no-alert-classname": {
+      "count": 4
     }
   },
   "packages/front-end/components/Layout/TopNav.tsx": {
@@ -470,12 +813,20 @@
     }
   },
   "packages/front-end/components/Markdown/MarkdownInput.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    },
     "no-restricted-imports": {
       "count": 1
     }
   },
   "packages/front-end/components/Marketing/PremiumTooltip.tsx": {
     "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/Marketing/UpgradeMessage.tsx": {
+    "local/no-alert-classname": {
       "count": 1
     }
   },
@@ -509,8 +860,21 @@
       "count": 1
     }
   },
+  "packages/front-end/components/Metrics/MetricGroupsList.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
   "packages/front-end/components/Modal.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    },
     "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/OAuthError.tsx": {
+    "local/no-alert-classname": {
       "count": 1
     }
   },
@@ -519,8 +883,38 @@
       "count": 1
     }
   },
+  "packages/front-end/components/OrganizationMessages/OrganizationMessages.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
   "packages/front-end/components/OutdatedBadge.tsx": {
     "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/PersonalAccessTokens/PersonalAccessTokens.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/PowerCalculation/PowerCalculationContent.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/ProtectedPage.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/Queries/AsyncQueriesModal.tsx": {
+    "local/no-alert-classname": {
+      "count": 7
+    }
+  },
+  "packages/front-end/components/Queries/ExpandableQuery.tsx": {
+    "local/no-alert-classname": {
       "count": 1
     }
   },
@@ -534,8 +928,23 @@
       "count": 1
     }
   },
+  "packages/front-end/components/Report/LegacyReportPage.tsx": {
+    "local/no-alert-classname": {
+      "count": 5
+    }
+  },
   "packages/front-end/components/Report/ReportAnalysisSettingsBar.tsx": {
     "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/SafeRollout/AnalysisSettingsSummary.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/SafeRollout/Results/ResultsTable.tsx": {
+    "local/no-alert-classname": {
       "count": 1
     }
   },
@@ -559,14 +968,89 @@
       "count": 1
     }
   },
+  "packages/front-end/components/SavedQueries/ExpandableSavedQuery.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/SchemaBrowser/BuildInformationSchemaCard.tsx": {
+    "local/no-alert-classname": {
+      "count": 2
+    }
+  },
+  "packages/front-end/components/SchemaBrowser/DatasourceTableData.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
   "packages/front-end/components/SchemaBrowser/EditSqlModal.tsx": {
     "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/SchemaBrowser/PendingInformationSchemaCard.tsx": {
+    "local/no-alert-classname": {
+      "count": 2
+    }
+  },
+  "packages/front-end/components/SchemaBrowser/RetryInformationSchemaCard.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/SchemaBrowser/SaveQueryModal.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/SchemaBrowser/SchemaBrowser.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/SchemaBrowser/SchemaBrowserWrapper.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/Segments/SegmentForm.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/Settings/ApiKeys.tsx": {
+    "local/no-alert-classname": {
+      "count": 2
+    }
+  },
+  "packages/front-end/components/Settings/BigQueryForm.tsx": {
+    "local/no-alert-classname": {
+      "count": 2
+    }
+  },
+  "packages/front-end/components/Settings/DataSourceForm.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/Settings/DataSourceSchemaChooser.tsx": {
+    "local/no-alert-classname": {
       "count": 1
     }
   },
   "packages/front-end/components/Settings/DataSourceTypeSelector.tsx": {
     "no-restricted-imports": {
       "count": 1
+    }
+  },
+  "packages/front-end/components/Settings/DataSources.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/Settings/DisplayTestQueryResults.tsx": {
+    "local/no-alert-classname": {
+      "count": 2
     }
   },
   "packages/front-end/components/Settings/EditDataSource/ClickhouseMaterializedColumns/AddEditMaterializedColumnsModal.tsx": {
@@ -576,6 +1060,11 @@
   },
   "packages/front-end/components/Settings/EditDataSource/ClickhouseMaterializedColumns/index.tsx": {
     "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/Settings/EditDataSource/DataSourceInlineEditIdentifierTypes/DataSourceInlineEditIdentifierTypes.tsx": {
+    "local/no-alert-classname": {
       "count": 1
     }
   },
@@ -590,6 +1079,9 @@
     }
   },
   "packages/front-end/components/Settings/EditDataSource/DataSourceMetrics.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    },
     "no-restricted-imports": {
       "count": 1
     }
@@ -605,7 +1097,15 @@
     }
   },
   "packages/front-end/components/Settings/EditDataSource/DimensionMetadata/DimensionSlicesRunner.tsx": {
+    "local/no-alert-classname": {
+      "count": 2
+    },
     "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/Settings/EditDataSource/ExperimentAssignmentQueries/AddEditExperimentAssignmentQueryModal.tsx": {
+    "local/no-alert-classname": {
       "count": 1
     }
   },
@@ -619,9 +1119,39 @@
       "count": 1
     }
   },
+  "packages/front-end/components/Settings/EditDataSource/FeatureEvaluationQueries/FeatureEvaluationQueryModal.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/Settings/EditLicenseModal.tsx": {
+    "local/no-alert-classname": {
+      "count": 2
+    }
+  },
+  "packages/front-end/components/Settings/EnvironmentModal.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
   "packages/front-end/components/Settings/ExperimentCheckListModal.tsx": {
     "no-restricted-imports": {
       "count": 2
+    }
+  },
+  "packages/front-end/components/Settings/GoogleAnalyticsForm.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/Settings/HostWarning.tsx": {
+    "local/no-alert-classname": {
+      "count": 3
+    }
+  },
+  "packages/front-end/components/Settings/MixpanelForm.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
     }
   },
   "packages/front-end/components/Settings/NewDataSourceForm.tsx": {
@@ -629,8 +1159,41 @@
       "count": 1
     }
   },
+  "packages/front-end/components/Settings/SSOSettings.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
   "packages/front-end/components/Settings/SubscriptionInfo.tsx": {
+    "local/no-alert-classname": {
+      "count": 4
+    },
     "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/Settings/Team/AutoApproveMembersToggle.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/Settings/Team/InviteList.tsx": {
+    "local/no-alert-classname": {
+      "count": 3
+    }
+  },
+  "packages/front-end/components/Settings/Team/InviteModal.tsx": {
+    "local/no-alert-classname": {
+      "count": 4
+    }
+  },
+  "packages/front-end/components/Settings/Team/MembersTabView.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/Settings/Team/OrphanedUsersList.tsx": {
+    "local/no-alert-classname": {
       "count": 1
     }
   },
@@ -639,14 +1202,50 @@
       "count": 1
     }
   },
+  "packages/front-end/components/Settings/UpgradeModal/VerifyingEmailModal.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
   "packages/front-end/components/Settings/UpgradeModal/index.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    },
     "no-restricted-imports": {
       "count": 1
     }
   },
+  "packages/front-end/components/Settings/Webhooks.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/Settings/WebhooksModal.tsx": {
+    "local/no-alert-classname": {
+      "count": 4
+    }
+  },
+  "packages/front-end/components/Share/Presentation.tsx": {
+    "local/no-alert-classname": {
+      "count": 2
+    }
+  },
+  "packages/front-end/components/Share/Preview.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
   "packages/front-end/components/Share/ShareModal.tsx": {
+    "local/no-alert-classname": {
+      "count": 2
+    },
     "no-restricted-imports": {
       "count": 1
+    }
+  },
+  "packages/front-end/components/SlackIntegrations/SlackIntegrationsListView/SlackIntegrationsListView.tsx": {
+    "local/no-alert-classname": {
+      "count": 2
     }
   },
   "packages/front-end/components/SqlExplorer/BigValueChart.tsx": {
@@ -661,6 +1260,31 @@
   },
   "packages/front-end/components/Tags/TagsModal.tsx": {
     "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/Teams/Roles/RoleForm.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/Teams/Roles/RoleFormWrapper.tsx": {
+    "local/no-alert-classname": {
+      "count": 2
+    }
+  },
+  "packages/front-end/components/TempMessage.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/importing/ImportFromLaunchDarkly/ImportFromLaunchDarkly.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/components/importing/ImportFromStatsig/ImportFromStatsig.tsx": {
+    "local/no-alert-classname": {
       "count": 1
     }
   },
@@ -745,6 +1369,9 @@
     }
   },
   "packages/front-end/enterprise/components/ExecReports/ExecExperimentImpact.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    },
     "no-restricted-imports": {
       "count": 2
     }
@@ -764,14 +1391,74 @@
       "count": 1
     }
   },
+  "packages/front-end/enterprise/components/ProductAnalytics/SideBar/DatasourceConfigurator.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
   "packages/front-end/enterprise/components/feature-promos/ExperimentTemplatePromoCard.tsx": {
     "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "packages/front-end/pages/_app.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/pages/activity.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/pages/admin.tsx": {
+    "local/no-alert-classname": {
+      "count": 4
+    }
+  },
+  "packages/front-end/pages/bandit/[bid].tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/pages/bandits/index.tsx": {
+    "local/no-alert-classname": {
       "count": 1
     }
   },
   "packages/front-end/pages/correlations.tsx": {
     "no-restricted-imports": {
       "count": 2
+    }
+  },
+  "packages/front-end/pages/dashboard.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/pages/datasources/[did].tsx": {
+    "local/no-alert-classname": {
+      "count": 4
+    }
+  },
+  "packages/front-end/pages/datasources/queries/[did].tsx": {
+    "local/no-alert-classname": {
+      "count": 3
+    }
+  },
+  "packages/front-end/pages/dimensions/index.tsx": {
+    "local/no-alert-classname": {
+      "count": 4
+    }
+  },
+  "packages/front-end/pages/experiments/index.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/pages/experiments/lookup.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
     }
   },
   "packages/front-end/pages/experiments/template/[tid].tsx": {
@@ -784,12 +1471,91 @@
       "count": 1
     }
   },
+  "packages/front-end/pages/fact-metrics/[fmid].tsx": {
+    "local/no-alert-classname": {
+      "count": 2
+    },
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "packages/front-end/pages/fact-tables/[ftid].tsx": {
+    "local/no-alert-classname": {
+      "count": 2
+    },
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "packages/front-end/pages/features/index.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/pages/getstarted/data-source-guide.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/pages/getstarted/experiment-guide.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/pages/getstarted/feature-flag-guide.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/pages/getstarted/imported-experiment-guide.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/pages/holdouts/index.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/pages/idea/[iid].tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/pages/ideas.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/pages/index.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/pages/integrations/github/index.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/pages/integrations/slack/index.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
   "packages/front-end/pages/interactions.tsx": {
     "no-restricted-imports": {
       "count": 1
     }
   },
+  "packages/front-end/pages/invitation.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
   "packages/front-end/pages/learnings/index.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    },
     "no-restricted-imports": {
       "count": 1
     }
@@ -799,9 +1565,67 @@
       "count": 2
     }
   },
+  "packages/front-end/pages/metric/[mid].tsx": {
+    "local/no-alert-classname": {
+      "count": 7
+    }
+  },
+  "packages/front-end/pages/namespaces.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/pages/oauth/google.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/pages/oauth/lookup.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/pages/present/[pid].tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/pages/presentations.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/pages/product-analytics/dashboards/[did].tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
   "packages/front-end/pages/product-analytics/dashboards/index.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    },
     "no-restricted-imports": {
       "count": 1
+    }
+  },
+  "packages/front-end/pages/project/[pid].tsx": {
+    "local/no-alert-classname": {
+      "count": 3
+    }
+  },
+  "packages/front-end/pages/report/[rid].tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/pages/reports.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/pages/reset-password.tsx": {
+    "local/no-alert-classname": {
+      "count": 3
     }
   },
   "packages/front-end/pages/saved-groups/[sgid].tsx": {
@@ -814,8 +1638,33 @@
       "count": 2
     }
   },
+  "packages/front-end/pages/sdks/[sdkid].tsx": {
+    "local/no-alert-classname": {
+      "count": 2
+    }
+  },
+  "packages/front-end/pages/sdks/index.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/pages/segments/index.tsx": {
+    "local/no-alert-classname": {
+      "count": 6
+    }
+  },
+  "packages/front-end/pages/settings/billing.tsx": {
+    "local/no-alert-classname": {
+      "count": 4
+    }
+  },
   "packages/front-end/pages/settings/custom-hooks.tsx": {
     "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "packages/front-end/pages/settings/custom-markdown.tsx": {
+    "local/no-alert-classname": {
       "count": 1
     }
   },
@@ -824,13 +1673,71 @@
       "count": 1
     }
   },
+  "packages/front-end/pages/settings/keys.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/pages/settings/organizations.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/pages/settings/tags.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/pages/settings/team.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/pages/settings/team/[tid].tsx": {
+    "local/no-alert-classname": {
+      "count": 2
+    }
+  },
+  "packages/front-end/pages/settings/usage.tsx": {
+    "local/no-alert-classname": {
+      "count": 2
+    }
+  },
+  "packages/front-end/pages/settings/webhooks/event/[eventwebhookid].tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/pages/settings/webhooks/index.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
+  "packages/front-end/pages/setup/index.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
   "packages/front-end/pages/sql-explorer/[id].tsx": {
     "no-restricted-imports": {
       "count": 1
     }
   },
+  "packages/front-end/pages/sql-explorer/index.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    }
+  },
   "packages/front-end/pages/timeline.tsx": {
+    "local/no-alert-classname": {
+      "count": 1
+    },
     "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "packages/front-end/services/auth.tsx": {
+    "local/no-alert-classname": {
       "count": 1
     }
   },

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -104,11 +104,6 @@
       "count": 1
     }
   },
-  "packages/front-end/components/DiscussionThread.tsx": {
-    "local/no-alert-classname": {
-      "count": 1
-    }
-  },
   "packages/front-end/components/EmptyState.tsx": {
     "no-restricted-imports": {
       "count": 1
@@ -317,11 +312,6 @@
       "count": 1
     }
   },
-  "packages/front-end/components/Experiment/TabbedPage/StartExperimentModal.tsx": {
-    "local/no-alert-classname": {
-      "count": 1
-    }
-  },
   "packages/front-end/components/Experiment/TabbedPage/StoppedExperimentBanner.tsx": {
     "local/no-alert-classname": {
       "count": 1
@@ -385,11 +375,6 @@
       "count": 2
     }
   },
-  "packages/front-end/components/FactTables/ColumnList.tsx": {
-    "local/no-alert-classname": {
-      "count": 3
-    }
-  },
   "packages/front-end/components/FactTables/ColumnModal.tsx": {
     "local/no-alert-classname": {
       "count": 1
@@ -418,11 +403,6 @@
       "count": 1
     }
   },
-  "packages/front-end/components/FactTables/FactTableModal.tsx": {
-    "local/no-alert-classname": {
-      "count": 1
-    }
-  },
   "packages/front-end/components/Features/AddToHoldoutModal.tsx": {
     "no-restricted-imports": {
       "count": 1
@@ -431,11 +411,6 @@
   "packages/front-end/components/Features/CodeSnippetModal.tsx": {
     "local/no-alert-classname": {
       "count": 3
-    }
-  },
-  "packages/front-end/components/Features/CompareEnvironmentsModal.tsx": {
-    "no-restricted-imports": {
-      "count": 1
     }
   },
   "packages/front-end/components/Features/ExperimentRefSummary.tsx": {
@@ -458,17 +433,7 @@
       "count": 1
     }
   },
-  "packages/front-end/components/Features/FeatureModal/FeatureFromExperimentModal.tsx": {
-    "local/no-alert-classname": {
-      "count": 1
-    }
-  },
   "packages/front-end/components/Features/FeatureReferencesList.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "packages/front-end/components/Features/FeatureRules.tsx": {
     "no-restricted-imports": {
       "count": 1
     }
@@ -813,9 +778,6 @@
     }
   },
   "packages/front-end/components/Markdown/MarkdownInput.tsx": {
-    "local/no-alert-classname": {
-      "count": 1
-    },
     "no-restricted-imports": {
       "count": 1
     }
@@ -1401,27 +1363,7 @@
       "count": 1
     }
   },
-  "packages/front-end/pages/_app.tsx": {
-    "local/no-alert-classname": {
-      "count": 1
-    }
-  },
-  "packages/front-end/pages/activity.tsx": {
-    "local/no-alert-classname": {
-      "count": 1
-    }
-  },
-  "packages/front-end/pages/admin.tsx": {
-    "local/no-alert-classname": {
-      "count": 4
-    }
-  },
   "packages/front-end/pages/bandit/[bid].tsx": {
-    "local/no-alert-classname": {
-      "count": 1
-    }
-  },
-  "packages/front-end/pages/bandits/index.tsx": {
     "local/no-alert-classname": {
       "count": 1
     }
@@ -1429,11 +1371,6 @@
   "packages/front-end/pages/correlations.tsx": {
     "no-restricted-imports": {
       "count": 2
-    }
-  },
-  "packages/front-end/pages/dashboard.tsx": {
-    "local/no-alert-classname": {
-      "count": 1
     }
   },
   "packages/front-end/pages/datasources/[did].tsx": {
@@ -1444,11 +1381,6 @@
   "packages/front-end/pages/datasources/queries/[did].tsx": {
     "local/no-alert-classname": {
       "count": 3
-    }
-  },
-  "packages/front-end/pages/dimensions/index.tsx": {
-    "local/no-alert-classname": {
-      "count": 4
     }
   },
   "packages/front-end/pages/experiments/index.tsx": {
@@ -1474,40 +1406,14 @@
   "packages/front-end/pages/fact-metrics/[fmid].tsx": {
     "local/no-alert-classname": {
       "count": 2
-    },
-    "no-restricted-imports": {
-      "count": 1
     }
   },
   "packages/front-end/pages/fact-tables/[ftid].tsx": {
     "local/no-alert-classname": {
       "count": 2
-    },
-    "no-restricted-imports": {
-      "count": 1
     }
   },
   "packages/front-end/pages/features/index.tsx": {
-    "local/no-alert-classname": {
-      "count": 1
-    }
-  },
-  "packages/front-end/pages/getstarted/data-source-guide.tsx": {
-    "local/no-alert-classname": {
-      "count": 1
-    }
-  },
-  "packages/front-end/pages/getstarted/experiment-guide.tsx": {
-    "local/no-alert-classname": {
-      "count": 1
-    }
-  },
-  "packages/front-end/pages/getstarted/feature-flag-guide.tsx": {
-    "local/no-alert-classname": {
-      "count": 1
-    }
-  },
-  "packages/front-end/pages/getstarted/imported-experiment-guide.tsx": {
     "local/no-alert-classname": {
       "count": 1
     }
@@ -1517,45 +1423,12 @@
       "count": 1
     }
   },
-  "packages/front-end/pages/idea/[iid].tsx": {
-    "local/no-alert-classname": {
-      "count": 1
-    }
-  },
-  "packages/front-end/pages/ideas.tsx": {
-    "local/no-alert-classname": {
-      "count": 1
-    }
-  },
-  "packages/front-end/pages/index.tsx": {
-    "local/no-alert-classname": {
-      "count": 1
-    }
-  },
-  "packages/front-end/pages/integrations/github/index.tsx": {
-    "local/no-alert-classname": {
-      "count": 1
-    }
-  },
-  "packages/front-end/pages/integrations/slack/index.tsx": {
-    "local/no-alert-classname": {
-      "count": 1
-    }
-  },
   "packages/front-end/pages/interactions.tsx": {
     "no-restricted-imports": {
       "count": 1
     }
   },
-  "packages/front-end/pages/invitation.tsx": {
-    "local/no-alert-classname": {
-      "count": 1
-    }
-  },
   "packages/front-end/pages/learnings/index.tsx": {
-    "local/no-alert-classname": {
-      "count": 1
-    },
     "no-restricted-imports": {
       "count": 1
     }
@@ -1568,31 +1441,6 @@
   "packages/front-end/pages/metric/[mid].tsx": {
     "local/no-alert-classname": {
       "count": 7
-    }
-  },
-  "packages/front-end/pages/namespaces.tsx": {
-    "local/no-alert-classname": {
-      "count": 1
-    }
-  },
-  "packages/front-end/pages/oauth/google.tsx": {
-    "local/no-alert-classname": {
-      "count": 1
-    }
-  },
-  "packages/front-end/pages/oauth/lookup.tsx": {
-    "local/no-alert-classname": {
-      "count": 1
-    }
-  },
-  "packages/front-end/pages/present/[pid].tsx": {
-    "local/no-alert-classname": {
-      "count": 1
-    }
-  },
-  "packages/front-end/pages/presentations.tsx": {
-    "local/no-alert-classname": {
-      "count": 1
     }
   },
   "packages/front-end/pages/product-analytics/dashboards/[did].tsx": {
@@ -1618,16 +1466,6 @@
       "count": 1
     }
   },
-  "packages/front-end/pages/reports.tsx": {
-    "local/no-alert-classname": {
-      "count": 1
-    }
-  },
-  "packages/front-end/pages/reset-password.tsx": {
-    "local/no-alert-classname": {
-      "count": 3
-    }
-  },
   "packages/front-end/pages/saved-groups/[sgid].tsx": {
     "no-restricted-imports": {
       "count": 2
@@ -1638,24 +1476,9 @@
       "count": 2
     }
   },
-  "packages/front-end/pages/sdks/[sdkid].tsx": {
-    "local/no-alert-classname": {
-      "count": 2
-    }
-  },
   "packages/front-end/pages/sdks/index.tsx": {
     "local/no-alert-classname": {
       "count": 1
-    }
-  },
-  "packages/front-end/pages/segments/index.tsx": {
-    "local/no-alert-classname": {
-      "count": 6
-    }
-  },
-  "packages/front-end/pages/settings/billing.tsx": {
-    "local/no-alert-classname": {
-      "count": 4
     }
   },
   "packages/front-end/pages/settings/custom-hooks.tsx": {
@@ -1663,58 +1486,8 @@
       "count": 1
     }
   },
-  "packages/front-end/pages/settings/custom-markdown.tsx": {
-    "local/no-alert-classname": {
-      "count": 1
-    }
-  },
   "packages/front-end/pages/settings/index.tsx": {
     "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "packages/front-end/pages/settings/keys.tsx": {
-    "local/no-alert-classname": {
-      "count": 1
-    }
-  },
-  "packages/front-end/pages/settings/organizations.tsx": {
-    "local/no-alert-classname": {
-      "count": 1
-    }
-  },
-  "packages/front-end/pages/settings/tags.tsx": {
-    "local/no-alert-classname": {
-      "count": 1
-    }
-  },
-  "packages/front-end/pages/settings/team.tsx": {
-    "local/no-alert-classname": {
-      "count": 1
-    }
-  },
-  "packages/front-end/pages/settings/team/[tid].tsx": {
-    "local/no-alert-classname": {
-      "count": 2
-    }
-  },
-  "packages/front-end/pages/settings/usage.tsx": {
-    "local/no-alert-classname": {
-      "count": 2
-    }
-  },
-  "packages/front-end/pages/settings/webhooks/event/[eventwebhookid].tsx": {
-    "local/no-alert-classname": {
-      "count": 1
-    }
-  },
-  "packages/front-end/pages/settings/webhooks/index.tsx": {
-    "local/no-alert-classname": {
-      "count": 1
-    }
-  },
-  "packages/front-end/pages/setup/index.tsx": {
-    "local/no-alert-classname": {
       "count": 1
     }
   },
@@ -1729,9 +1502,6 @@
     }
   },
   "packages/front-end/pages/timeline.tsx": {
-    "local/no-alert-classname": {
-      "count": 1
-    },
     "no-restricted-imports": {
       "count": 1
     }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,7 @@ import globals from "globals";
 import * as tsParser from "@typescript-eslint/parser";
 import js from "@eslint/js";
 import { FlatCompat } from "@eslint/eslintrc";
+import noAlertClassname from "./eslint-rules/no-alert-classname.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -239,6 +240,14 @@ export default defineConfig([
   {
     files: ["./packages/front-end/**/*.ts*"],
 
+    plugins: {
+      local: {
+        rules: {
+          "no-alert-classname": noAlertClassname,
+        },
+      },
+    },
+
     rules: {
       "no-restricted-syntax": [
         "error",
@@ -255,6 +264,7 @@ export default defineConfig([
             "Don't use window.history.replaceState directly. Use router.replace(url, undefined, { shallow: true }) from next/router instead.",
         },
       ],
+      "local/no-alert-classname": "error",
     },
   },
   {


### PR DESCRIPTION
### Features and Changes

New rule to prevent new additions of `alert` in classNames which is the Bootstrap Callout.
We should use `ui/Callout` instead.

<img width="847" height="231" alt="Screenshot 2026-05-01 at 11 19 27 AM" src="https://github.com/user-attachments/assets/174142e1-da56-4efb-a98a-41a1ddce50f2" />
