### PR TITLE
Add separate event forwarder setup

### DIFF
--- a/packages/back-end/src/app.ts
+++ b/packages/back-end/src/app.ts
@@ -922,6 +922,14 @@ app.post(
 );
 app.put("/datasource/:id", datasourcesController.putDataSource);
 app.delete("/datasource/:id", datasourcesController.deleteDataSource);
+app.put(
+  "/datasource/:id/event-forwarder",
+  datasourcesController.putEventForwarderForDataSource,
+);
+app.delete(
+  "/datasource/:id/event-forwarder",
+  datasourcesController.deleteEventForwarderForDataSource,
+);
 app.post(
   "/datasource/:id/event-forwarder/test-access",
   datasourcesController.postTestEventForwarderAccessForDatasource,

--- a/packages/back-end/src/controllers/datasources.ts
+++ b/packages/back-end/src/controllers/datasources.ts
@@ -74,6 +74,7 @@ import {
   resumeEventForwarderThroughLicenseServer,
   updateEventForwarderCredentialsThroughLicenseServer,
 } from "back-end/src/services/eventForwarderProvisioning";
+import { deleteEventForwarderConfigForDatasource } from "back-end/src/services/eventForwarderDatasourceLifecycle";
 import { getOauth2Client } from "back-end/src/integrations/GoogleAnalytics";
 import SqlIntegration from "back-end/src/integrations/SqlIntegration";
 import {
@@ -665,6 +666,167 @@ export async function putDataSource(
     });
   } catch (e) {
     req.log.error(e, "Failed to update data source");
+    res.status(400).json({
+      status: 400,
+      message: e.message || "An error occurred",
+    });
+  }
+}
+
+export async function putEventForwarderForDataSource(
+  req: AuthRequest<unknown, { id: string }>,
+  res: Response,
+) {
+  const parsed = eventForwarderAccessTestEditBodySchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({
+      status: 400,
+      message: parsed.error.issues.map((i) => i.message).join("; "),
+    });
+  }
+  if (!parsed.data.eventForwarderConfig) {
+    return res.status(400).json({
+      status: 400,
+      message: "Event Forwarder config is required.",
+    });
+  }
+
+  const context = getContextFromReq(req);
+  const datasource = await getDataSourceById(context, req.params.id);
+  if (!datasource) {
+    return res.status(404).json({
+      status: 404,
+      message: "Cannot find data source",
+    });
+  }
+
+  if (!context.permissions.canUpdateDataSourceSettings(datasource)) {
+    context.permissions.throwPermissionError();
+  }
+  if (
+    parsed.data.params &&
+    !context.permissions.canUpdateDataSourceParams(datasource)
+  ) {
+    context.permissions.throwPermissionError();
+  }
+
+  const existingEventForwarderConfig =
+    await getEventForwarderConfigForDatasource(context, datasource.id);
+  const projects = datasource.projects ?? [];
+  if (existingEventForwarderConfig) {
+    if (
+      !context.permissions.canUpdateEventForwarderConfig(
+        existingEventForwarderConfig,
+        {
+          ...existingEventForwarderConfig,
+          projects,
+        },
+      )
+    ) {
+      context.permissions.throwPermissionError();
+    }
+  } else if (!context.permissions.canCreateEventForwarderConfig({ projects })) {
+    context.permissions.throwPermissionError();
+  }
+
+  try {
+    const integration = getSourceIntegrationObject(context, datasource);
+    const updates: Partial<DataSourceInterface> = { dateUpdated: new Date() };
+
+    if (parsed.data.params) {
+      mergeParams(integration, parsed.data.params as Partial<DataSourceParams>);
+      await integration.testConnection();
+      updates.params = encryptParams(integration.params as DataSourceParams);
+    }
+
+    await updateDataSource(context, datasource, updates);
+
+    const updatedDatasource = {
+      ...datasource,
+      ...updates,
+    };
+    const eventForwarderDatasourceParams = getEventForwarderDatasourceParams(
+      updatedDatasource.type,
+      integration.params as DataSourceParams,
+    );
+    const syncedEventForwarderConfig =
+      await syncEventForwarderConfigFromDatasource({
+        context,
+        datasource: updatedDatasource,
+        draft: parsed.data.eventForwarderConfig as EventForwarderConfigDraft,
+        datasourceParams: eventForwarderDatasourceParams,
+      });
+    await provisionEventForwarderThroughLicenseServer(
+      context,
+      syncedEventForwarderConfig,
+      eventForwarderDatasourceParams,
+    );
+
+    res.status(200).json({
+      status: 200,
+      datasource: await getDataSourceWithParams(
+        context,
+        getSourceIntegrationObject(context, updatedDatasource),
+      ),
+    });
+  } catch (e) {
+    req.log.error(e, "Failed to update event forwarder");
+    res.status(400).json({
+      status: 400,
+      message: e.message || "An error occurred",
+    });
+  }
+}
+
+export async function deleteEventForwarderForDataSource(
+  req: AuthRequest<null, { id: string }>,
+  res: Response,
+) {
+  const context = getContextFromReq(req);
+  const datasource = await getDataSourceById(context, req.params.id);
+  if (!datasource) {
+    return res.status(404).json({
+      status: 404,
+      message: "Cannot find data source",
+    });
+  }
+
+  if (!context.permissions.canUpdateDataSourceSettings(datasource)) {
+    context.permissions.throwPermissionError();
+  }
+
+  const eventForwarderConfig = await getEventForwarderConfigForDatasource(
+    context,
+    datasource.id,
+  );
+  if (!eventForwarderConfig) {
+    return res.status(404).json({
+      status: 404,
+      message: "Cannot find event forwarder config",
+    });
+  }
+  if (
+    !context.permissions.canDeleteEventForwarderConfig(eventForwarderConfig)
+  ) {
+    context.permissions.throwPermissionError();
+  }
+
+  try {
+    await deleteEventForwarderConfigForDatasource(
+      context,
+      datasource,
+      eventForwarderConfig,
+    );
+
+    res.status(200).json({
+      status: 200,
+      datasource: await getDataSourceWithParams(
+        context,
+        getSourceIntegrationObject(context, datasource),
+      ),
+    });
+  } catch (e) {
+    req.log.error(e, "Failed to delete event forwarder");
     res.status(400).json({
       status: 400,
       message: e.message || "An error occurred",

--- a/packages/back-end/src/services/eventForwarderDatasourceLifecycle.ts
+++ b/packages/back-end/src/services/eventForwarderDatasourceLifecycle.ts
@@ -1,4 +1,5 @@
 import { DataSourceInterface } from "shared/types/datasource";
+import { EventForwarderConfigInterface } from "shared/validators";
 import { usingFileConfig } from "back-end/src/init/config";
 import { getEventForwarderSinkTypeForDatasource } from "back-end/src/services/eventForwarderConfig";
 import { teardownBigQueryEventForwarderInfrastructureRemote } from "back-end/src/services/eventForwarderProvisioning";
@@ -6,60 +7,19 @@ import { logger } from "back-end/src/util/logger";
 import { ApiReqContext } from "back-end/types/api";
 import { ReqContext } from "back-end/types/request";
 
-/**
- * After removing a datasource: if a per-datasource event forwarder row exists for this id,
- * delete the Mongo row first, then tear down Confluent resources via the license server.
- */
-export async function syncEventForwarderAfterDatasourceDeleted(
-  context: ReqContext | ApiReqContext,
-  datasource: DataSourceInterface,
-): Promise<void> {
-  logger.info(
-    {
-      organizationId: context.org.id,
-      datasourceId: datasource.id,
-      datasourceType: datasource.type,
-    },
-    "Event forwarder sync after datasource delete: starting",
-  );
-
-  if (usingFileConfig()) {
-    logger.info(
-      {
-        organizationId: context.org.id,
-        datasourceId: datasource.id,
-      },
-      "Event forwarder sync after datasource delete: skipped (config.yml / file config mode)",
-    );
-    return;
-  }
-
+async function deleteEventForwarderAndTeardown({
+  context,
+  datasource,
+  existing,
+  deleteExisting,
+}: {
+  context: ReqContext | ApiReqContext;
+  datasource: DataSourceInterface;
+  existing: EventForwarderConfigInterface;
+  deleteExisting: () => Promise<void>;
+}): Promise<void> {
   const sinkType = getEventForwarderSinkTypeForDatasource(datasource);
   if (!sinkType) {
-    logger.info(
-      {
-        organizationId: context.org.id,
-        datasourceId: datasource.id,
-        datasourceType: datasource.type,
-      },
-      "Event forwarder sync after datasource delete: datasource type has no event-forwarder sink (no Confluent row to reconcile)",
-    );
-    return;
-  }
-
-  const existing =
-    await context.models.eventForwarderConfigs.dangerousGetByDatasourceIdBypassPermission(
-      datasource.id,
-    );
-  if (!existing) {
-    logger.info(
-      {
-        organizationId: context.org.id,
-        datasourceId: datasource.id,
-        sinkType,
-      },
-      "Event forwarder sync after datasource delete: no event forwarder config for this datasource — skipping teardown and cascade delete",
-    );
     return;
   }
 
@@ -73,19 +33,7 @@ export async function syncEventForwarderAfterDatasourceDeleted(
     eventForwarderConfigId: existing.id,
   };
 
-  logger.info(
-    {
-      organizationId: context.org.id,
-      datasourceId: datasource.id,
-      sinkType,
-      eventForwarderConfigId: existing.id,
-    },
-    "Event forwarder sync after datasource delete: removing event forwarder row before license-server teardown",
-  );
-
-  await context.models.eventForwarderConfigs.deleteForDatasourceCascade(
-    existing,
-  );
+  await deleteExisting();
 
   if (sinkType === "bigquery" || sinkType === "snowflake") {
     logger.info(
@@ -161,4 +109,98 @@ export async function syncEventForwarderAfterDatasourceDeleted(
       "Event forwarder sync: skipping Confluent teardown for sink type",
     );
   }
+}
+
+export async function deleteEventForwarderConfigForDatasource(
+  context: ReqContext,
+  datasource: DataSourceInterface,
+  existing: EventForwarderConfigInterface,
+): Promise<void> {
+  await deleteEventForwarderAndTeardown({
+    context,
+    datasource,
+    existing,
+    deleteExisting: async () => {
+      await context.models.eventForwarderConfigs.delete(existing);
+    },
+  });
+}
+
+/**
+ * After removing a datasource: if a per-datasource event forwarder row exists for this id,
+ * delete the Mongo row first, then tear down Confluent resources via the license server.
+ */
+export async function syncEventForwarderAfterDatasourceDeleted(
+  context: ReqContext | ApiReqContext,
+  datasource: DataSourceInterface,
+): Promise<void> {
+  logger.info(
+    {
+      organizationId: context.org.id,
+      datasourceId: datasource.id,
+      datasourceType: datasource.type,
+    },
+    "Event forwarder sync after datasource delete: starting",
+  );
+
+  if (usingFileConfig()) {
+    logger.info(
+      {
+        organizationId: context.org.id,
+        datasourceId: datasource.id,
+      },
+      "Event forwarder sync after datasource delete: skipped (config.yml / file config mode)",
+    );
+    return;
+  }
+
+  const sinkType = getEventForwarderSinkTypeForDatasource(datasource);
+  if (!sinkType) {
+    logger.info(
+      {
+        organizationId: context.org.id,
+        datasourceId: datasource.id,
+        datasourceType: datasource.type,
+      },
+      "Event forwarder sync after datasource delete: datasource type has no event-forwarder sink (no Confluent row to reconcile)",
+    );
+    return;
+  }
+
+  const existing =
+    await context.models.eventForwarderConfigs.dangerousGetByDatasourceIdBypassPermission(
+      datasource.id,
+    );
+  if (!existing) {
+    logger.info(
+      {
+        organizationId: context.org.id,
+        datasourceId: datasource.id,
+        sinkType,
+      },
+      "Event forwarder sync after datasource delete: no event forwarder config for this datasource — skipping teardown and cascade delete",
+    );
+    return;
+  }
+
+  logger.info(
+    {
+      organizationId: context.org.id,
+      datasourceId: datasource.id,
+      sinkType,
+      eventForwarderConfigId: existing.id,
+    },
+    "Event forwarder sync after datasource delete: removing event forwarder row before license-server teardown",
+  );
+
+  await deleteEventForwarderAndTeardown({
+    context,
+    datasource,
+    existing,
+    deleteExisting: async () => {
+      await context.models.eventForwarderConfigs.deleteForDatasourceCascade(
+        existing,
+      );
+    },
+  });
 }

--- a/packages/back-end/src/services/eventForwarderDatasourceLifecycle.ts
+++ b/packages/back-end/src/services/eventForwarderDatasourceLifecycle.ts
@@ -18,9 +18,19 @@ async function deleteEventForwarderAndTeardown({
   existing: EventForwarderConfigInterface;
   deleteExisting: () => Promise<void>;
 }): Promise<void> {
-  const sinkType = getEventForwarderSinkTypeForDatasource(datasource);
-  if (!sinkType) {
-    return;
+  const datasourceSinkType = getEventForwarderSinkTypeForDatasource(datasource);
+  const sinkType = datasourceSinkType ?? existing.sinkType;
+  if (!datasourceSinkType) {
+    logger.warn(
+      {
+        organizationId: context.org.id,
+        datasourceId: datasource.id,
+        datasourceType: datasource.type,
+        sinkType,
+        eventForwarderConfigId: existing.id,
+      },
+      "Event forwarder sync: datasource type has no event-forwarder sink; falling back to config sink type before deletion",
+    );
   }
 
   const snapshot = {

--- a/packages/back-end/test/services/eventForwarderDatasourceLifecycle.test.ts
+++ b/packages/back-end/test/services/eventForwarderDatasourceLifecycle.test.ts
@@ -1,6 +1,9 @@
 import type { EventForwarderConfigInterface } from "shared/validators";
 import type { DataSourceInterface } from "shared/types/datasource";
-import { syncEventForwarderAfterDatasourceDeleted } from "back-end/src/services/eventForwarderDatasourceLifecycle";
+import {
+  deleteEventForwarderConfigForDatasource,
+  syncEventForwarderAfterDatasourceDeleted,
+} from "back-end/src/services/eventForwarderDatasourceLifecycle";
 import * as configInit from "back-end/src/init/config";
 import * as provisioning from "back-end/src/services/eventForwarderProvisioning";
 
@@ -292,5 +295,57 @@ describe("syncEventForwarderAfterDatasourceDeleted", () => {
         }),
       }),
     );
+  });
+});
+
+describe("deleteEventForwarderConfigForDatasource", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedTeardownRemote.mockResolvedValue(undefined);
+  });
+
+  it("permission-deletes the row before license-server teardown", async () => {
+    const existing: EventForwarderConfigInterface = {
+      id: "efc_delete",
+      organization: "org1",
+      datasourceId: "ds_delete",
+      projects: ["p1"],
+      topic: "topic-delete",
+      schemaId: 1,
+      sinkType: "bigquery",
+      config: "{}",
+      status: "ready",
+      connectorName: "connector-delete",
+      connectorId: "lcc-delete",
+      dateCreated: new Date(),
+      dateUpdated: new Date(),
+    };
+
+    const deleteConfig = jest.fn().mockResolvedValue(undefined);
+    const context = {
+      org: { id: "org1" },
+      auditLog: jest.fn().mockResolvedValue(undefined),
+      models: {
+        eventForwarderConfigs: {
+          delete: deleteConfig,
+        },
+      },
+    };
+
+    await deleteEventForwarderConfigForDatasource(
+      context as never,
+      bqDatasource("ds_delete"),
+      existing,
+    );
+
+    expect(deleteConfig).toHaveBeenCalledWith(existing);
+    expect(mockedTeardownRemote).toHaveBeenCalledWith({
+      organizationId: "org1",
+      datasourceId: "ds_delete",
+      sinkType: "bigquery",
+      topic: "topic-delete",
+      connectorName: "connector-delete",
+      connectorId: "lcc-delete",
+    });
   });
 });

--- a/packages/back-end/test/services/eventForwarderDatasourceLifecycle.test.ts
+++ b/packages/back-end/test/services/eventForwarderDatasourceLifecycle.test.ts
@@ -348,4 +348,50 @@ describe("deleteEventForwarderConfigForDatasource", () => {
       connectorId: "lcc-delete",
     });
   });
+
+  it("still deletes and tears down when datasource type no longer maps to a sink", async () => {
+    const existing: EventForwarderConfigInterface = {
+      id: "efc_orphan",
+      organization: "org1",
+      datasourceId: "ds_orphan",
+      projects: ["p1"],
+      topic: "topic-orphan",
+      schemaId: 1,
+      sinkType: "bigquery",
+      config: "{}",
+      status: "ready",
+      dateCreated: new Date(),
+      dateUpdated: new Date(),
+    };
+
+    const deleteConfig = jest.fn().mockResolvedValue(undefined);
+    const context = {
+      org: { id: "org1" },
+      auditLog: jest.fn().mockResolvedValue(undefined),
+      models: {
+        eventForwarderConfigs: {
+          delete: deleteConfig,
+        },
+      },
+    };
+
+    await deleteEventForwarderConfigForDatasource(
+      context as never,
+      {
+        ...bqDatasource("ds_orphan"),
+        type: "postgres",
+      },
+      existing,
+    );
+
+    expect(deleteConfig).toHaveBeenCalledWith(existing);
+    expect(mockedTeardownRemote).toHaveBeenCalledWith({
+      organizationId: "org1",
+      datasourceId: "ds_orphan",
+      sinkType: "bigquery",
+      topic: "topic-orphan",
+      connectorName: undefined,
+      connectorId: undefined,
+    });
+  });
 });

--- a/packages/front-end/components/Settings/BigQueryEventForwarderForm.tsx
+++ b/packages/front-end/components/Settings/BigQueryEventForwarderForm.tsx
@@ -1,0 +1,119 @@
+import { ChangeEventHandler, FC } from "react";
+import { Flex } from "@radix-ui/themes";
+import { DEFAULT_EVENT_FORWARDER_BIGQUERY_TABLE_NAME } from "shared/util";
+import { DataSourceParams } from "shared/types/datasource";
+import { BigQueryConnectionParams } from "shared/types/integrations/bigquery";
+import { EventForwarderConfigDraft } from "shared/types/event-forwarder";
+import Field from "@/components/Forms/Field";
+import Button from "@/components/Button";
+import Callout from "@/ui/Callout";
+import EventForwarderTableNameField from "./EventForwarderTableNameField";
+import { useEventForwarderAccessTest } from "./useEventForwarderAccessTest";
+
+const BigQueryEventForwarderForm: FC<{
+  params: Partial<BigQueryConnectionParams>;
+  accessTestParams?: Partial<DataSourceParams>;
+  eventForwarderConfig: EventForwarderConfigDraft;
+  existing: boolean;
+  setParams?: (params: { [key: string]: string | boolean }) => void;
+  setEventForwarderConfig: (
+    eventForwarderConfig: EventForwarderConfigDraft | null,
+  ) => void;
+  onParamChange?: ChangeEventHandler<HTMLInputElement>;
+  datasourceId?: string;
+  projects?: string[];
+  eventForwarderAccessSignature: string;
+  setValidatedEventForwarderSignature?: (signature: string | null) => void;
+  showDefaultDatasetField?: boolean;
+  className?: string;
+}> = ({
+  params,
+  accessTestParams,
+  eventForwarderConfig,
+  existing,
+  setParams,
+  setEventForwarderConfig,
+  onParamChange,
+  datasourceId,
+  projects,
+  eventForwarderAccessSignature,
+  setValidatedEventForwarderSignature,
+  showDefaultDatasetField = false,
+  className = "form-group col-md-12 mt-3 px-0",
+}) => {
+  const bigQueryEventForwarderConfig =
+    eventForwarderConfig.sinkType === "bigquery" ? eventForwarderConfig : null;
+  const { eventForwarderTestResult, testEventForwarderAccess } =
+    useEventForwarderAccessTest({
+      existing,
+      datasourceId,
+      type: "bigquery",
+      params: accessTestParams ?? params,
+      projects,
+      eventForwarderConfig: bigQueryEventForwarderConfig,
+      eventForwarderAccessSignature,
+      setValidatedEventForwarderSignature,
+    });
+
+  if (!bigQueryEventForwarderConfig) return null;
+
+  const canTestEventForwarderAccess =
+    !!params.defaultDataset?.trim() &&
+    !!bigQueryEventForwarderConfig.config.tableName.trim();
+
+  return (
+    <Flex direction="column" gap="3" className={className}>
+      {showDefaultDatasetField ? (
+        <Field
+          label="Default Dataset"
+          type="text"
+          className="form-control"
+          name="defaultDataset"
+          value={params.defaultDataset || ""}
+          onChange={(e) => {
+            if (setParams) {
+              setParams({ defaultDataset: e.target.value });
+            } else {
+              onParamChange?.(e);
+            }
+          }}
+          placeholder=""
+          required
+          helpText="Enriched events are written to this BigQuery dataset."
+        />
+      ) : null}
+      <EventForwarderTableNameField
+        value={bigQueryEventForwarderConfig.config.tableName}
+        onChange={(tableName) =>
+          setEventForwarderConfig({
+            sinkType: "bigquery",
+            config: {
+              ...bigQueryEventForwarderConfig.config,
+              tableName,
+            },
+          })
+        }
+        placeholder={DEFAULT_EVENT_FORWARDER_BIGQUERY_TABLE_NAME}
+        tooltip="Defaults to gb_events. If that table already exists, GrowthBook will reuse it for the event forwarder."
+        helpText="Letters, numbers, and underscores (Unicode allowed). Hyphens and spaces are normalized to underscores when saving."
+      />
+      <div>
+        <Button
+          color="primary"
+          disabled={!canTestEventForwarderAccess}
+          loadingCta="Testing access"
+          onClick={testEventForwarderAccess}
+        >
+          Test Write Access
+        </Button>
+      </div>
+      {eventForwarderTestResult ? (
+        <Callout status={eventForwarderTestResult.status} mt="0" mb="0">
+          {eventForwarderTestResult.message}
+        </Callout>
+      ) : null}
+    </Flex>
+  );
+};
+
+export default BigQueryEventForwarderForm;

--- a/packages/front-end/components/Settings/BigQueryForm.tsx
+++ b/packages/front-end/components/Settings/BigQueryForm.tsx
@@ -1,9 +1,7 @@
 import { ChangeEventHandler, FC, useState } from "react";
-import { Flex } from "@radix-ui/themes";
 import { stripLeadingUtf8ByteOrderMark } from "shared/util";
 import { BigQueryConnectionParams } from "shared/types/integrations/bigquery";
 import { EventForwarderConfigDraft } from "shared/types/event-forwarder";
-import { EventForwarderAccessTestResponse } from "shared/validators";
 import { isCloud } from "@/services/env";
 import { useAuth } from "@/services/auth";
 import Field from "@/components/Forms/Field";
@@ -11,8 +9,7 @@ import Tooltip from "@/components/Tooltip/Tooltip";
 import SelectField from "@/components/Forms/SelectField";
 import Button from "@/components/Button";
 import Checkbox from "@/ui/Checkbox";
-import Callout from "@/ui/Callout";
-import EventForwarderTableNameField from "./EventForwarderTableNameField";
+import BigQueryEventForwarderForm from "./BigQueryEventForwarderForm";
 
 const BigQueryForm: FC<{
   params: Partial<BigQueryConnectionParams>;
@@ -44,15 +41,7 @@ const BigQueryForm: FC<{
     message: string;
     datasetOptions: string[];
   } | null>(null);
-  const [eventForwarderTestResult, setEventForwarderTestResult] = useState<{
-    status: "success" | "error";
-    message: string;
-  } | null>(null);
   const { apiCall } = useAuth();
-  const canTestEventForwarderAccess =
-    eventForwarderConfig?.sinkType === "bigquery" &&
-    !!params.defaultDataset?.trim() &&
-    !!eventForwarderConfig.config.tableName.trim();
 
   async function testConnection() {
     try {
@@ -91,50 +80,6 @@ const BigQueryForm: FC<{
         status: "danger",
         message: e.message,
         datasetOptions: [],
-      });
-    }
-  }
-
-  async function testEventForwarderAccess() {
-    if (eventForwarderConfig?.sinkType !== "bigquery") return;
-
-    setEventForwarderTestResult(null);
-    setValidatedEventForwarderSignature?.(null);
-    const endpoint =
-      existing && datasourceId
-        ? `/datasource/${datasourceId}/event-forwarder/test-access`
-        : "/datasources/event-forwarder/test-access";
-    const body =
-      existing && datasourceId
-        ? {
-            params,
-            eventForwarderConfig,
-          }
-        : {
-            type: "bigquery",
-            params,
-            projects,
-            eventForwarderConfig,
-          };
-
-    const response = await apiCall<EventForwarderAccessTestResponse>(endpoint, {
-      method: "POST",
-      body: JSON.stringify(body),
-    });
-    const sinkWrite = response.results.sinkWrite;
-    if (sinkWrite.result === "success") {
-      setValidatedEventForwarderSignature?.(eventForwarderAccessSignature);
-      setEventForwarderTestResult({
-        status: "success",
-        message:
-          "Event Forwarder table creation access verified. GrowthBook created and deleted a temporary validation table.",
-      });
-    } else {
-      setEventForwarderTestResult({
-        status: "error",
-        message:
-          sinkWrite.resultMessage ||
-          "Event Forwarder table creation access failed.",
       });
     }
   }
@@ -303,46 +248,20 @@ const BigQueryForm: FC<{
               </div>
             </div>
             {eventForwarderConfig?.sinkType === "bigquery" && (
-              <Flex
-                direction="column"
-                gap="3"
-                className="form-group col-md-12 mt-3 px-0"
-              >
-                <EventForwarderTableNameField
-                  value={eventForwarderConfig.config.tableName}
-                  onChange={(tableName) =>
-                    setEventForwarderConfig({
-                      sinkType: "bigquery",
-                      config: {
-                        ...eventForwarderConfig.config,
-                        tableName,
-                      },
-                    })
-                  }
-                  placeholder="gb_events"
-                  tooltip="Defaults to gb_events. If that table already exists, GrowthBook will reuse it for the event forwarder."
-                  helpText="Letters, numbers, and underscores (Unicode allowed). Hyphens and spaces are normalized to underscores when saving."
-                />
-                <div>
-                  <Button
-                    color="primary"
-                    disabled={!canTestEventForwarderAccess}
-                    loadingCta="Testing access"
-                    onClick={testEventForwarderAccess}
-                  >
-                    Test Write Access
-                  </Button>
-                </div>
-                {eventForwarderTestResult ? (
-                  <Callout
-                    status={eventForwarderTestResult.status}
-                    mt="0"
-                    mb="0"
-                  >
-                    {eventForwarderTestResult.message}
-                  </Callout>
-                ) : null}
-              </Flex>
+              <BigQueryEventForwarderForm
+                params={params}
+                eventForwarderConfig={eventForwarderConfig}
+                existing={existing}
+                setParams={setParams}
+                setEventForwarderConfig={setEventForwarderConfig}
+                onParamChange={onParamChange}
+                datasourceId={datasourceId}
+                projects={projects}
+                eventForwarderAccessSignature={eventForwarderAccessSignature}
+                setValidatedEventForwarderSignature={
+                  setValidatedEventForwarderSignature
+                }
+              />
             )}
           </div>
         </>

--- a/packages/front-end/components/Settings/EditDataSource/EventForwarder/EventForwarder.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/EventForwarder/EventForwarder.tsx
@@ -113,10 +113,16 @@ function getEventForwarderDraft(
 }
 
 function getEventForwarderParamsForSubmit(
-  dataSource: EventForwarderDatasourceDraft,
+  dataSource: DataSourceInterfaceWithParams,
+  draft: EventForwarderDatasourceDraft,
 ): Partial<DataSourceParams> | undefined {
-  if (dataSource.type !== "bigquery") return undefined;
-  const params = dataSource.params as Partial<BigQueryConnectionParams>;
+  if (draft.type !== "bigquery") return undefined;
+  const originalParams = dataSource.params as Partial<BigQueryConnectionParams>;
+  const params = draft.params as Partial<BigQueryConnectionParams>;
+  if ((params.defaultDataset || "") === (originalParams.defaultDataset || "")) {
+    return undefined;
+  }
+
   return {
     defaultDataset: params.defaultDataset || "",
   } as Partial<DataSourceParams>;
@@ -185,6 +191,10 @@ function EventForwarderModal({
     ? "Edit Event Forwarder"
     : "Set Up Event Forwarder";
   const params = datasourceDraft.params || {};
+  const eventForwarderParamsForSubmit = getEventForwarderParamsForSubmit(
+    dataSource,
+    datasourceDraft,
+  );
 
   return (
     <Modal
@@ -196,8 +206,8 @@ function EventForwarderModal({
           method: "PUT",
           body: JSON.stringify({
             eventForwarderConfig,
-            ...(getEventForwarderParamsForSubmit(datasourceDraft)
-              ? { params: getEventForwarderParamsForSubmit(datasourceDraft) }
+            ...(eventForwarderParamsForSubmit
+              ? { params: eventForwarderParamsForSubmit }
               : {}),
           }),
         });
@@ -221,7 +231,7 @@ function EventForwarderModal({
       {eventForwarderConfig?.sinkType === "bigquery" ? (
         <BigQueryEventForwarderForm
           params={params as Partial<BigQueryConnectionParams>}
-          accessTestParams={getEventForwarderParamsForSubmit(datasourceDraft)}
+          accessTestParams={eventForwarderParamsForSubmit}
           eventForwarderConfig={eventForwarderConfig}
           existing={true}
           setParams={setParams}
@@ -374,31 +384,33 @@ export default function EventForwarder({
         </Callout>
       ) : null}
 
-      <Card>
-        <Flex direction="column" gap="3" p="2">
-          <Flex direction="column" gap="4">
-            <Box>
-              <Text weight="medium">Table Name: </Text>
-              {tableName ? (
-                <code>{tableName}</code>
-              ) : (
-                <Text color="text-low">None</Text>
-              )}
-            </Box>
-          </Flex>
+      {eventForwarderConfig ? (
+        <Card>
+          <Flex direction="column" gap="3" p="2">
+            <Flex direction="column" gap="4">
+              <Box>
+                <Text weight="medium">Table Name: </Text>
+                {tableName ? (
+                  <code>{tableName}</code>
+                ) : (
+                  <Text color="text-low">None</Text>
+                )}
+              </Box>
+            </Flex>
 
-          {eventForwarderConfig?.lastProvisioningError ? (
-            <Callout status="error" mb="0">
-              {eventForwarderConfig.lastProvisioningError}
-            </Callout>
-          ) : null}
-          {error ? (
-            <Callout status="error" mb="0">
-              {error}
-            </Callout>
-          ) : null}
-        </Flex>
-      </Card>
+            {eventForwarderConfig.lastProvisioningError ? (
+              <Callout status="error" mb="0">
+                {eventForwarderConfig.lastProvisioningError}
+              </Callout>
+            ) : null}
+            {error ? (
+              <Callout status="error" mb="0">
+                {error}
+              </Callout>
+            ) : null}
+          </Flex>
+        </Card>
+      ) : null}
       {showEditModal ? (
         <EventForwarderModal
           dataSource={dataSource}

--- a/packages/front-end/components/Settings/EditDataSource/EventForwarder/EventForwarder.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/EventForwarder/EventForwarder.tsx
@@ -1,8 +1,27 @@
-import { useState } from "react";
-import { EventForwarderStatus } from "shared/types/event-forwarder";
-import { DataSourceInterfaceWithParams } from "shared/types/datasource";
+import { useEffect, useState } from "react";
+import {
+  DEFAULT_EVENT_FORWARDER_BIGQUERY_TABLE_NAME,
+  DEFAULT_EVENT_FORWARDER_SNOWFLAKE_TABLE_NAME,
+  computeEventForwarderAccessSignature,
+  stripLeadingUtf8ByteOrderMark,
+} from "shared/util";
+import {
+  EventForwarderConfigDraft,
+  EventForwarderStatus,
+} from "shared/types/event-forwarder";
+import {
+  DataSourceInterfaceWithParams,
+  DataSourceParams,
+} from "shared/types/datasource";
+import { BigQueryConnectionParams } from "shared/types/integrations/bigquery";
+import { SnowflakeConnectionParams } from "shared/types/integrations/snowflake";
 import { Box, Card, Flex } from "@radix-ui/themes";
 import { useAuth } from "@/services/auth";
+import DeleteButton from "@/components/DeleteButton/DeleteButton";
+import Modal from "@/components/Modal";
+import MoreMenu from "@/components/Dropdown/MoreMenu";
+import BigQueryEventForwarderForm from "@/components/Settings/BigQueryEventForwarderForm";
+import SnowflakeEventForwarderForm from "@/components/Settings/SnowflakeEventForwarderForm";
 import Badge from "@/ui/Badge";
 import Button from "@/ui/Button";
 import Callout from "@/ui/Callout";
@@ -13,6 +32,15 @@ type Props = {
   dataSource: DataSourceInterfaceWithParams;
   canEdit?: boolean;
   onRefresh: () => Promise<void>;
+};
+
+type EventForwarderDatasourceDraft = {
+  type: "bigquery" | "snowflake";
+  params:
+    | Partial<BigQueryConnectionParams>
+    | Partial<SnowflakeConnectionParams>;
+  projects?: string[];
+  eventForwarderConfig: EventForwarderConfigDraft | null;
 };
 
 const statusLabels: Record<EventForwarderStatus, string> = {
@@ -34,23 +62,224 @@ const statusColors: Record<
   schema_update_error: "red",
 };
 
+function getEventForwarderDraft(
+  dataSource: DataSourceInterfaceWithParams,
+): EventForwarderConfigDraft | null {
+  const existing = dataSource.eventForwarderConfig;
+  if (existing?.sinkType === "bigquery") {
+    return {
+      sinkType: "bigquery",
+      config: {
+        tableName: existing.config.tableName,
+        serviceAccountKey: existing.config.serviceAccountKey,
+      },
+    };
+  }
+  if (existing?.sinkType === "snowflake") {
+    return {
+      sinkType: "snowflake",
+      config: {
+        tableName: existing.config.tableName,
+        accessUrl: existing.config.accessUrl,
+      },
+    };
+  }
+
+  if (dataSource.type === "bigquery") {
+    const params = dataSource.params as BigQueryConnectionParams;
+    const serviceAccountKey =
+      stripLeadingUtf8ByteOrderMark(params.serviceAccountJson ?? "").trim() ||
+      "";
+
+    return {
+      sinkType: "bigquery",
+      config: {
+        tableName: DEFAULT_EVENT_FORWARDER_BIGQUERY_TABLE_NAME,
+        ...(serviceAccountKey ? { serviceAccountKey } : {}),
+      },
+    };
+  }
+  if (dataSource.type === "snowflake") {
+    return {
+      sinkType: "snowflake",
+      config: {
+        tableName: DEFAULT_EVENT_FORWARDER_SNOWFLAKE_TABLE_NAME,
+        accessUrl: "",
+      },
+    };
+  }
+
+  return null;
+}
+
+function getEventForwarderParamsForSubmit(
+  dataSource: EventForwarderDatasourceDraft,
+): Partial<DataSourceParams> | undefined {
+  if (dataSource.type !== "bigquery") return undefined;
+  const params = dataSource.params as Partial<BigQueryConnectionParams>;
+  return {
+    defaultDataset: params.defaultDataset || "",
+  } as Partial<DataSourceParams>;
+}
+
+function EventForwarderModal({
+  dataSource,
+  onCancel,
+  onRefresh,
+}: {
+  dataSource: DataSourceInterfaceWithParams;
+  onCancel: () => void;
+  onRefresh: () => Promise<void>;
+}) {
+  const { apiCall } = useAuth();
+  const [datasourceDraft, setDatasourceDraft] =
+    useState<EventForwarderDatasourceDraft>(() => ({
+      type: dataSource.type as "bigquery" | "snowflake",
+      params: { ...dataSource.params } as
+        | Partial<BigQueryConnectionParams>
+        | Partial<SnowflakeConnectionParams>,
+      projects: dataSource.projects,
+      eventForwarderConfig: getEventForwarderDraft(dataSource),
+    }));
+  const [
+    validatedEventForwarderSignature,
+    setValidatedEventForwarderSignature,
+  ] = useState<string | null>(null);
+
+  const eventForwarderAccessSignature = computeEventForwarderAccessSignature(
+    datasourceDraft as Partial<DataSourceInterfaceWithParams>,
+  );
+  const eventForwarderSaveBlocked =
+    !!datasourceDraft.eventForwarderConfig &&
+    validatedEventForwarderSignature !== eventForwarderAccessSignature;
+
+  useEffect(() => {
+    if (
+      validatedEventForwarderSignature &&
+      validatedEventForwarderSignature !== eventForwarderAccessSignature
+    ) {
+      setValidatedEventForwarderSignature(null);
+    }
+  }, [eventForwarderAccessSignature, validatedEventForwarderSignature]);
+
+  const setParams = (params: { [key: string]: string | boolean }) => {
+    setDatasourceDraft((current) => ({
+      ...current,
+      params: {
+        ...current.params,
+        ...params,
+      },
+    }));
+  };
+  const setEventForwarderConfig = (
+    eventForwarderConfig: EventForwarderConfigDraft | null,
+  ) => {
+    setDatasourceDraft((current) => ({
+      ...current,
+      eventForwarderConfig,
+    }));
+  };
+
+  const eventForwarderConfig = datasourceDraft.eventForwarderConfig;
+  const modalTitle = dataSource.eventForwarderConfig
+    ? "Edit Event Forwarder"
+    : "Set Up Event Forwarder";
+  const params = datasourceDraft.params || {};
+
+  return (
+    <Modal
+      trackingEventModalType=""
+      open={true}
+      submit={async () => {
+        if (!eventForwarderConfig) return;
+        await apiCall(`/datasource/${dataSource.id}/event-forwarder`, {
+          method: "PUT",
+          body: JSON.stringify({
+            eventForwarderConfig,
+            ...(getEventForwarderParamsForSubmit(datasourceDraft)
+              ? { params: getEventForwarderParamsForSubmit(datasourceDraft) }
+              : {}),
+          }),
+        });
+        await onRefresh();
+      }}
+      close={onCancel}
+      header={modalTitle}
+      cta="Confirm"
+      size="lg"
+      ctaEnabled={!eventForwarderSaveBlocked}
+      disabledMessage={
+        eventForwarderSaveBlocked
+          ? "Test Event Forwarder access before confirming."
+          : undefined
+      }
+    >
+      <p>
+        Confirming will create or update the Kafka topic and connector for this
+        datasource.
+      </p>
+      {eventForwarderConfig?.sinkType === "bigquery" ? (
+        <BigQueryEventForwarderForm
+          params={params as Partial<BigQueryConnectionParams>}
+          accessTestParams={getEventForwarderParamsForSubmit(datasourceDraft)}
+          eventForwarderConfig={eventForwarderConfig}
+          existing={true}
+          setParams={setParams}
+          setEventForwarderConfig={setEventForwarderConfig}
+          datasourceId={dataSource.id}
+          projects={dataSource.projects}
+          eventForwarderAccessSignature={eventForwarderAccessSignature}
+          setValidatedEventForwarderSignature={
+            setValidatedEventForwarderSignature
+          }
+          showDefaultDatasetField
+          className="form-group col-md-12 px-0"
+        />
+      ) : null}
+      {eventForwarderConfig?.sinkType === "snowflake" ? (
+        <SnowflakeEventForwarderForm
+          params={params as Partial<SnowflakeConnectionParams>}
+          eventForwarderConfig={eventForwarderConfig}
+          existing={true}
+          setEventForwarderConfig={setEventForwarderConfig}
+          datasourceId={dataSource.id}
+          projects={dataSource.projects}
+          eventForwarderAccessSignature={eventForwarderAccessSignature}
+          setValidatedEventForwarderSignature={
+            setValidatedEventForwarderSignature
+          }
+          accessTestParams={undefined}
+          hasSnowflakePrivateKey={
+            (params as Partial<SnowflakeConnectionParams>).authMethod ===
+              "key-pair" ||
+            !!(params as Partial<SnowflakeConnectionParams>).privateKey?.trim()
+          }
+        />
+      ) : null}
+    </Modal>
+  );
+}
+
 export default function EventForwarder({
   dataSource,
   canEdit = true,
   onRefresh,
 }: Props) {
   const [error, setError] = useState<string | null>(null);
+  const [showEditModal, setShowEditModal] = useState(false);
   const { apiCall } = useAuth();
   const eventForwarderConfig = dataSource.eventForwarderConfig;
 
-  if (!eventForwarderConfig) return null;
+  if (dataSource.type !== "bigquery" && dataSource.type !== "snowflake") {
+    return null;
+  }
 
   const tableName =
-    "tableName" in eventForwarderConfig.config
+    eventForwarderConfig && "tableName" in eventForwarderConfig.config
       ? eventForwarderConfig.config.tableName
       : "";
-  const isReady = eventForwarderConfig.status === "ready";
-  const isPaused = eventForwarderConfig.status === "paused";
+  const isReady = eventForwarderConfig?.status === "ready";
+  const isPaused = eventForwarderConfig?.status === "paused";
   const canToggle = canEdit && (isReady || isPaused);
   const action = isReady ? "pause" : "resume";
 
@@ -61,40 +290,89 @@ export default function EventForwarder({
           <Heading as="h3" size="medium" mb="0">
             Event Forwarder
           </Heading>
-          <Badge
-            label={statusLabels[eventForwarderConfig.status]}
-            color={statusColors[eventForwarderConfig.status]}
-            variant="soft"
-          />
+          {eventForwarderConfig ? (
+            <Badge
+              label={statusLabels[eventForwarderConfig.status]}
+              color={statusColors[eventForwarderConfig.status]}
+              variant="soft"
+            />
+          ) : null}
         </Flex>
 
-        {canToggle && (
-          <Button
-            variant="outline"
-            color={isReady ? "red" : "gray"}
-            setError={setError}
-            style={{
-              alignItems: "center",
-            }}
-            onClick={async () => {
-              await apiCall(
-                `/datasource/${dataSource.id}/event-forwarder/${action}`,
-                {
-                  method: "POST",
-                },
-              );
-              await onRefresh();
-            }}
-          >
-            {isReady ? "Pause" : "Resume"}
-          </Button>
-        )}
+        <Flex align="center" gap="4">
+          {canEdit && eventForwarderConfig && (
+            <MoreMenu useRadix size={16}>
+              <button
+                className="dropdown-item py-2"
+                onClick={() => setShowEditModal(true)}
+              >
+                Edit Event Forwarder
+              </button>
+
+              <hr className="dropdown-divider" />
+              <DeleteButton
+                onClick={async () => {
+                  await apiCall(
+                    `/datasource/${dataSource.id}/event-forwarder`,
+                    {
+                      method: "DELETE",
+                    },
+                  );
+                  await onRefresh();
+                }}
+                className="dropdown-item text-danger py-2"
+                iconClassName="mr-2"
+                style={{ borderRadius: 0 }}
+                useIcon={false}
+                displayName="Event Forwarder"
+                deleteMessage="Are you sure you want to delete this event forwarder? This removes the GrowthBook Kafka topic and connector for this datasource."
+                title="Delete"
+                text="Delete Event Forwarder"
+                outline={false}
+              />
+            </MoreMenu>
+          )}
+          {eventForwarderConfig && canToggle && (
+            <Button
+              variant="outline"
+              color={isReady ? "red" : "gray"}
+              setError={setError}
+              style={{
+                alignItems: "center",
+              }}
+              onClick={async () => {
+                await apiCall(
+                  `/datasource/${dataSource.id}/event-forwarder/${action}`,
+                  {
+                    method: "POST",
+                  },
+                );
+                await onRefresh();
+              }}
+            >
+              {isReady ? "Pause" : "Resume"}
+            </Button>
+          )}
+        </Flex>
       </Flex>
 
       <p>
         Forward SDK event data from GrowthBook to this datasource for downstream
         analysis and diagnostics.
       </p>
+
+      {!eventForwarderConfig ? (
+        <Callout status="info">
+          Event Forwarder is not configured for this datasource.
+          {canEdit ? (
+            <Box mt="3">
+              <Button onClick={() => setShowEditModal(true)}>
+                Set Up Event Forwarder
+              </Button>
+            </Box>
+          ) : null}
+        </Callout>
+      ) : null}
 
       <Card>
         <Flex direction="column" gap="3" p="2">
@@ -109,7 +387,7 @@ export default function EventForwarder({
             </Box>
           </Flex>
 
-          {eventForwarderConfig.lastProvisioningError ? (
+          {eventForwarderConfig?.lastProvisioningError ? (
             <Callout status="error" mb="0">
               {eventForwarderConfig.lastProvisioningError}
             </Callout>
@@ -121,6 +399,16 @@ export default function EventForwarder({
           ) : null}
         </Flex>
       </Card>
+      {showEditModal ? (
+        <EventForwarderModal
+          dataSource={dataSource}
+          onCancel={() => setShowEditModal(false)}
+          onRefresh={async () => {
+            setShowEditModal(false);
+            await onRefresh();
+          }}
+        />
+      ) : null}
     </Box>
   );
 }

--- a/packages/front-end/components/Settings/SnowflakeEventForwarderForm.tsx
+++ b/packages/front-end/components/Settings/SnowflakeEventForwarderForm.tsx
@@ -1,0 +1,127 @@
+import { FC } from "react";
+import { DEFAULT_EVENT_FORWARDER_SNOWFLAKE_TABLE_NAME } from "shared/util";
+import { DataSourceParams } from "shared/types/datasource";
+import { SnowflakeConnectionParams } from "shared/types/integrations/snowflake";
+import { EventForwarderConfigDraft } from "shared/types/event-forwarder";
+import Tooltip from "@/components/Tooltip/Tooltip";
+import Button from "@/components/Button";
+import Callout from "@/ui/Callout";
+import EventForwarderTableNameField from "./EventForwarderTableNameField";
+import { useEventForwarderAccessTest } from "./useEventForwarderAccessTest";
+
+const SnowflakeEventForwarderForm: FC<{
+  params: Partial<SnowflakeConnectionParams>;
+  accessTestParams?: Partial<DataSourceParams>;
+  eventForwarderConfig: EventForwarderConfigDraft;
+  existing: boolean;
+  setEventForwarderConfig: (
+    eventForwarderConfig: EventForwarderConfigDraft | null,
+  ) => void;
+  datasourceId?: string;
+  projects?: string[];
+  eventForwarderAccessSignature: string;
+  setValidatedEventForwarderSignature?: (signature: string | null) => void;
+  hasSnowflakePrivateKey: boolean;
+}> = ({
+  params,
+  accessTestParams,
+  eventForwarderConfig,
+  existing,
+  setEventForwarderConfig,
+  datasourceId,
+  projects,
+  eventForwarderAccessSignature,
+  setValidatedEventForwarderSignature,
+  hasSnowflakePrivateKey,
+}) => {
+  const snowflakeEventForwarderConfig =
+    eventForwarderConfig.sinkType === "snowflake" ? eventForwarderConfig : null;
+  const { eventForwarderTestResult, testEventForwarderAccess } =
+    useEventForwarderAccessTest({
+      existing,
+      datasourceId,
+      type: "snowflake",
+      params: accessTestParams ?? params,
+      projects,
+      eventForwarderConfig: snowflakeEventForwarderConfig,
+      eventForwarderAccessSignature,
+      setValidatedEventForwarderSignature,
+    });
+
+  if (!snowflakeEventForwarderConfig) return null;
+
+  const authMethod = params.authMethod ?? "password";
+  const canTestEventForwarderAccess =
+    !!snowflakeEventForwarderConfig.config.tableName.trim() &&
+    !!snowflakeEventForwarderConfig.config.accessUrl?.trim() &&
+    !!params.account?.trim() &&
+    !!params.username?.trim() &&
+    !!params.database?.trim() &&
+    !!params.schema?.trim() &&
+    authMethod === "key-pair" &&
+    hasSnowflakePrivateKey;
+
+  return (
+    <>
+      <div className="form-group col-md-12">
+        <EventForwarderTableNameField
+          value={snowflakeEventForwarderConfig.config.tableName}
+          onChange={(tableName) =>
+            setEventForwarderConfig({
+              sinkType: "snowflake",
+              config: {
+                ...snowflakeEventForwarderConfig.config,
+                tableName,
+              },
+            })
+          }
+          placeholder={DEFAULT_EVENT_FORWARDER_SNOWFLAKE_TABLE_NAME}
+          tooltip="Defaults to GB_EVENTS. GrowthBook maps the Kafka topic to this Snowflake table."
+          helpText="Letters, numbers, underscores, and dollar signs. Hyphens and spaces are normalized to underscores when saving."
+        />
+      </div>
+      <div className="form-group col-md-12">
+        <label>
+          Event Forwarder Access URL{" "}
+          <Tooltip body="Full Snowflake URL for Confluent Snowflake Sink, including the region, for example https://abcd12345.us-east-1.snowflakecomputing.com:443" />
+        </label>
+        <input
+          type="text"
+          className="form-control"
+          name="eventForwarderAccessUrl"
+          required
+          placeholder="https://abcd12345.us-east-1.snowflakecomputing.com:443"
+          value={snowflakeEventForwarderConfig.config.accessUrl || ""}
+          onChange={(e) =>
+            setEventForwarderConfig({
+              sinkType: "snowflake",
+              config: {
+                ...snowflakeEventForwarderConfig.config,
+                accessUrl: e.target.value,
+              },
+            })
+          }
+        />
+      </div>
+      <div className="form-group col-md-12">
+        <Button
+          color="primary"
+          disabled={!canTestEventForwarderAccess}
+          loadingCta="Testing access"
+          onClick={testEventForwarderAccess}
+        >
+          Test Write Access
+        </Button>
+      </div>
+      {eventForwarderTestResult ? (
+        <div className="form-group col-md-12">
+          <Callout status={eventForwarderTestResult.status} mt="0" mb="0">
+            {eventForwarderTestResult.message}
+          </Callout>
+        </div>
+      ) : null}
+    </>
+  );
+};
+
+export default SnowflakeEventForwarderForm;

--- a/packages/front-end/components/Settings/SnowflakeForm.tsx
+++ b/packages/front-end/components/Settings/SnowflakeForm.tsx
@@ -2,16 +2,12 @@ import { FC, ChangeEventHandler, useState } from "react";
 import { DEFAULT_EVENT_FORWARDER_SNOWFLAKE_TABLE_NAME } from "shared/util";
 import { EventForwarderConfigDraft } from "shared/types/event-forwarder";
 import { SnowflakeConnectionParams } from "shared/types/integrations/snowflake";
-import { EventForwarderAccessTestResponse } from "shared/validators";
-import { useAuth } from "@/services/auth";
 import Tooltip from "@/components/Tooltip/Tooltip";
 import Switch from "@/ui/Switch";
 import Checkbox from "@/ui/Checkbox";
 import { GBInfo } from "@/components/Icons";
 import FileInput from "@/components/FileInput";
-import Button from "@/components/Button";
-import Callout from "@/ui/Callout";
-import EventForwarderTableNameField from "./EventForwarderTableNameField";
+import SnowflakeEventForwarderForm from "./SnowflakeEventForwarderForm";
 
 const SnowflakeForm: FC<{
   params: Partial<SnowflakeConnectionParams>;
@@ -38,13 +34,8 @@ const SnowflakeForm: FC<{
   eventForwarderAccessSignature,
   setValidatedEventForwarderSignature,
 }) => {
-  const { apiCall } = useAuth();
   const [useAccessUrl, setUseAccessUrl] = useState(!!params.accessUrl);
   const [originalAuthMethod] = useState(params.authMethod);
-  const [eventForwarderTestResult, setEventForwarderTestResult] = useState<{
-    status: "success" | "error";
-    message: string;
-  } | null>(null);
   // Convenience variable for the auth method to handle undefined
   const authMethod = params.authMethod ?? "password";
   const canEnableEventForwarder = authMethod === "key-pair";
@@ -55,60 +46,6 @@ const SnowflakeForm: FC<{
   const hasSnowflakePrivateKey =
     !!params.privateKey?.trim() ||
     (existing && authMethod === originalAuthMethod);
-  const canTestEventForwarderAccess = snowflakeEventForwarderConfig
-    ? !!snowflakeEventForwarderConfig.config.tableName.trim() &&
-      !!snowflakeEventForwarderConfig.config.accessUrl?.trim() &&
-      !!params.account?.trim() &&
-      !!params.username?.trim() &&
-      !!params.database?.trim() &&
-      !!params.schema?.trim() &&
-      authMethod === "key-pair" &&
-      hasSnowflakePrivateKey
-    : false;
-
-  async function testEventForwarderAccess() {
-    if (!snowflakeEventForwarderConfig) return;
-
-    setEventForwarderTestResult(null);
-    setValidatedEventForwarderSignature?.(null);
-    const endpoint =
-      existing && datasourceId
-        ? `/datasource/${datasourceId}/event-forwarder/test-access`
-        : "/datasources/event-forwarder/test-access";
-    const body =
-      existing && datasourceId
-        ? {
-            params,
-            eventForwarderConfig: snowflakeEventForwarderConfig,
-          }
-        : {
-            type: "snowflake",
-            params,
-            projects,
-            eventForwarderConfig: snowflakeEventForwarderConfig,
-          };
-
-    const response = await apiCall<EventForwarderAccessTestResponse>(endpoint, {
-      method: "POST",
-      body: JSON.stringify(body),
-    });
-    const sinkWrite = response.results.sinkWrite;
-    if (sinkWrite.result === "success") {
-      setValidatedEventForwarderSignature?.(eventForwarderAccessSignature);
-      setEventForwarderTestResult({
-        status: "success",
-        message:
-          "Event Forwarder table creation access verified. GrowthBook created and deleted a temporary validation table.",
-      });
-    } else {
-      setEventForwarderTestResult({
-        status: "error",
-        message:
-          sinkWrite.resultMessage ||
-          "Event Forwarder table creation access failed.",
-      });
-    }
-  }
 
   return (
     <div className="row">
@@ -251,69 +188,19 @@ const SnowflakeForm: FC<{
             </div>
           </div>
           {snowflakeEventForwarderConfig && (
-            <>
-              <div className="form-group col-md-12">
-                <EventForwarderTableNameField
-                  value={snowflakeEventForwarderConfig.config.tableName}
-                  onChange={(tableName) =>
-                    setEventForwarderConfig({
-                      sinkType: "snowflake",
-                      config: {
-                        ...snowflakeEventForwarderConfig.config,
-                        tableName,
-                      },
-                    })
-                  }
-                  placeholder={DEFAULT_EVENT_FORWARDER_SNOWFLAKE_TABLE_NAME}
-                  tooltip="Defaults to GB_EVENTS. GrowthBook maps the Kafka topic to this Snowflake table."
-                  helpText="Letters, numbers, underscores, and dollar signs. Hyphens and spaces are normalized to underscores when saving."
-                />
-              </div>
-              <div className="form-group col-md-12">
-                <label>
-                  Event Forwarder Access URL{" "}
-                  <Tooltip body="Full Snowflake URL for Confluent Snowflake Sink, including the region, for example https://abcd12345.us-east-1.snowflakecomputing.com:443" />
-                </label>
-                <input
-                  type="text"
-                  className="form-control"
-                  name="eventForwarderAccessUrl"
-                  required
-                  placeholder="https://abcd12345.us-east-1.snowflakecomputing.com:443"
-                  value={snowflakeEventForwarderConfig.config.accessUrl || ""}
-                  onChange={(e) =>
-                    setEventForwarderConfig({
-                      sinkType: "snowflake",
-                      config: {
-                        ...snowflakeEventForwarderConfig.config,
-                        accessUrl: e.target.value,
-                      },
-                    })
-                  }
-                />
-              </div>
-              <div className="form-group col-md-12">
-                <Button
-                  color="primary"
-                  disabled={!canTestEventForwarderAccess}
-                  loadingCta="Testing access"
-                  onClick={testEventForwarderAccess}
-                >
-                  Test Write Access
-                </Button>
-              </div>
-              {eventForwarderTestResult ? (
-                <div className="form-group col-md-12">
-                  <Callout
-                    status={eventForwarderTestResult.status}
-                    mt="0"
-                    mb="0"
-                  >
-                    {eventForwarderTestResult.message}
-                  </Callout>
-                </div>
-              ) : null}
-            </>
+            <SnowflakeEventForwarderForm
+              params={params}
+              eventForwarderConfig={snowflakeEventForwarderConfig}
+              existing={existing}
+              setEventForwarderConfig={setEventForwarderConfig}
+              datasourceId={datasourceId}
+              projects={projects}
+              eventForwarderAccessSignature={eventForwarderAccessSignature}
+              setValidatedEventForwarderSignature={
+                setValidatedEventForwarderSignature
+              }
+              hasSnowflakePrivateKey={hasSnowflakePrivateKey}
+            />
           )}
         </>
       )}

--- a/packages/front-end/components/Settings/useEventForwarderAccessTest.ts
+++ b/packages/front-end/components/Settings/useEventForwarderAccessTest.ts
@@ -1,0 +1,83 @@
+import { useState } from "react";
+import { DataSourceParams, DataSourceType } from "shared/types/datasource";
+import { EventForwarderConfigDraft } from "shared/types/event-forwarder";
+import { EventForwarderAccessTestResponse } from "shared/validators";
+import { useAuth } from "@/services/auth";
+
+export type EventForwarderAccessTestResult = {
+  status: "success" | "error";
+  message: string;
+};
+
+export function useEventForwarderAccessTest({
+  existing,
+  datasourceId,
+  type,
+  params,
+  projects,
+  eventForwarderConfig,
+  eventForwarderAccessSignature,
+  setValidatedEventForwarderSignature,
+}: {
+  existing: boolean;
+  datasourceId?: string;
+  type: DataSourceType;
+  params?: Partial<DataSourceParams>;
+  projects?: string[];
+  eventForwarderConfig: EventForwarderConfigDraft | null;
+  eventForwarderAccessSignature: string;
+  setValidatedEventForwarderSignature?: (signature: string | null) => void;
+}) {
+  const { apiCall } = useAuth();
+  const [eventForwarderTestResult, setEventForwarderTestResult] =
+    useState<EventForwarderAccessTestResult | null>(null);
+
+  async function testEventForwarderAccess() {
+    if (!eventForwarderConfig) return;
+
+    setEventForwarderTestResult(null);
+    setValidatedEventForwarderSignature?.(null);
+    const endpoint =
+      existing && datasourceId
+        ? `/datasource/${datasourceId}/event-forwarder/test-access`
+        : "/datasources/event-forwarder/test-access";
+    const body =
+      existing && datasourceId
+        ? {
+            ...(params ? { params } : {}),
+            eventForwarderConfig,
+          }
+        : {
+            type,
+            params: params || {},
+            projects,
+            eventForwarderConfig,
+          };
+
+    const response = await apiCall<EventForwarderAccessTestResponse>(endpoint, {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
+    const sinkWrite = response.results.sinkWrite;
+    if (sinkWrite.result === "success") {
+      setValidatedEventForwarderSignature?.(eventForwarderAccessSignature);
+      setEventForwarderTestResult({
+        status: "success",
+        message:
+          "Event Forwarder table creation access verified. GrowthBook created and deleted a temporary validation table.",
+      });
+    } else {
+      setEventForwarderTestResult({
+        status: "error",
+        message:
+          sinkWrite.resultMessage ||
+          "Event Forwarder table creation access failed.",
+      });
+    }
+  }
+
+  return {
+    eventForwarderTestResult,
+    testEventForwarderAccess,
+  };
+}

--- a/packages/front-end/pages/datasources/[did].tsx
+++ b/packages/front-end/pages/datasources/[did].tsx
@@ -141,6 +141,8 @@ const DataSourcePage: FC = () => {
 
   const supportsSQL = d.properties?.queryLanguage === "sql";
   const supportsEvents = d.properties?.events || false;
+  const supportsEventForwarder =
+    d.type === "bigquery" || d.type === "snowflake";
 
   return (
     <div className="container pagecontents">
@@ -424,6 +426,18 @@ mixpanel.init('YOUR PROJECT TOKEN', {
               )
             ) : (
               <>
+                {supportsEventForwarder && (
+                  <Frame>
+                    <EventForwarder
+                      dataSource={d}
+                      canEdit={canUpdateDataSourceSettings}
+                      onRefresh={async () => {
+                        await mutateDefinitions({});
+                      }}
+                    />
+                  </Frame>
+                )}
+
                 {d.dateUpdated === d.dateCreated &&
                   d?.settings?.schemaFormat !== "custom" && (
                     <Callout status="info" mt="4" mb="4">
@@ -470,18 +484,6 @@ mixpanel.init('YOUR PROJECT TOKEN', {
                     canEdit={canUpdateDataSourceSettings}
                   />
                 </Frame>
-
-                {d.eventForwarderConfig ? (
-                  <Frame>
-                    <EventForwarder
-                      dataSource={d}
-                      canEdit={canUpdateDataSourceSettings}
-                      onRefresh={async () => {
-                        await mutateDefinitions({});
-                      }}
-                    />
-                  </Frame>
-                ) : null}
 
                 {d.settings.notebookRunQuery && (
                   <Frame>


### PR DESCRIPTION
### Features and Changes

- Allow independently connect to Event forwarder with an existing data source

- Closes **[Setup up event forwarder](https://www.notion.so/growthbook/Event-Forwarder-345a857e74a080a888c8de6d150a518d?source=copy_link#350a857e74a08093bc0ce7e72e3a243a)**

### Testing

Create a data source WITHOUT event forwarder (or use an existing Big Query/Snowflake)
Create a new event forwarder
Verify on Confluent

### Screenshots

<img width="1485" height="330" alt="Screenshot 2026-05-01 at 3 15 54 PM" src="https://github.com/user-attachments/assets/a721806f-278a-4dff-8047-c450692e70d8" />
<img width="1587" height="400" alt="Screenshot 2026-05-01 at 3 16 17 PM" src="https://github.com/user-attachments/assets/6a0df007-7778-4232-8483-3be1e6bae551" />
<img width="1103" height="573" alt="Screenshot 2026-05-01 at 3 16 20 PM" src="https://github.com/user-attachments/assets/8f0b37e3-b144-4a7a-8fb8-0b132b163e82" />
