### PR TITLE
feat: support {{experimentId}} in fact-table SQL for incremental refresh + docs

### DIFF
--- a/docs/docs/experimentation-analysis/sql-templates.mdx
+++ b/docs/docs/experimentation-analysis/sql-templates.mdx
@@ -67,6 +67,26 @@ The inserted values do not have surrounding quotes, so you must add those yourse
 
 :::
 
+## Experiment Id Filter
+
+When a Fact Table or Metric query is run as part of an experiment analysis, the `{{ experimentId }}` variable is replaced with the experiment's tracking key. This is useful when a single Fact Table contains rows for many experiments and you need to scope it to the one being analyzed:
+
+```sql
+SELECT
+  user_id,
+  timestamp,
+  score
+FROM classifier_scores
+WHERE
+  sample_type = CONCAT('experiment:', '{{ experimentId }}')
+```
+
+When the same SQL is run outside of an experiment context (for example, when previewing a Fact Table or running a standalone Metric Analysis), `{{ experimentId }}` is replaced with `%`. If you need the query to return rows in both contexts, write the filter as a `LIKE` so that `%` matches everything:
+
+```sql
+WHERE sample_type LIKE CONCAT('experiment:', '{{ experimentId }}')
+```
+
 ## Phase Filters
 
 Experiments can have multiple phases. By default, we use date ranges to restrict data to the current phase, but this may be imprecise if your experiment configs are cached in your app or data is delayed.

--- a/docs/docs/experimentation-analysis/sql-templates.mdx
+++ b/docs/docs/experimentation-analysis/sql-templates.mdx
@@ -78,13 +78,22 @@ SELECT
   score
 FROM classifier_scores
 WHERE
-  sample_type = CONCAT('experiment:', '{{ experimentId }}')
+  sample_type = '{{ experimentId }}'
 ```
 
-When the same SQL is run outside of an experiment context (for example, when previewing a Fact Table or running a standalone Metric Analysis), `{{ experimentId }}` is replaced with `%`. If you need the query to return rows in both contexts, write the filter as a `LIKE` so that `%` matches everything:
+When the same SQL is run outside of an experiment context (for example, when previewing a Fact Table or running a standalone Metric Analysis), `{{ experimentId }}` is replaced with `%`. If you need the query to return rows in both contexts, write the filter as a `LIKE` pattern so `%` can act as a wildcard:
 
 ```sql
-WHERE sample_type LIKE CONCAT('experiment:', '{{ experimentId }}')
+WHERE sample_type LIKE '{{ experimentId }}'
+```
+
+If you prefer an exact match in experiment context and no filter outside experiment context, you can conditionally add the clause with `{{#if ...}}`. Since `%` is always non-empty, this example uses `replace` to strip `%` first:
+
+```sql
+WHERE 1=1
+  {{#if (replace experimentId "%" "")}}
+    AND sample_type = '{{ experimentId }}'
+  {{/if}}
 ```
 
 ## Phase Filters

--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -1941,6 +1941,7 @@ export default abstract class SqlIntegration
           factTable: factTableWithMetricData.factTable,
           startDate: factTableWithMetricData.minCovariateStartDate,
           endDate: factTableWithMetricData.maxCovariateEndDate,
+          experimentId: params.settings.experimentId,
           metricsWithIndices: metricData.map((m, i) => ({
             metric: m.metric,
             index: i,
@@ -2235,6 +2236,7 @@ export default abstract class SqlIntegration
           factTable: factTableWithMetricData.factTable,
           startDate: factTableWithMetricData.metricStart,
           endDate: factTableWithMetricData.metricEnd,
+          experimentId: params.settings.experimentId,
           castIdToString: true,
           addFiltersToWhere: true,
           // if last max timestamp is later than metric start and thus the start

--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -1640,6 +1640,8 @@ export default abstract class SqlIntegration
                   startDate: settings.startDate,
                   endDate: settings.endDate,
                   experimentId: settings.experimentId,
+                  phase: settings.phase,
+                  customFields: settings.customFields,
                 },
               )})`
             : ""
@@ -1651,6 +1653,8 @@ export default abstract class SqlIntegration
               startDate: settings.startDate,
               endDate: settings.endDate,
               experimentId: settings.experimentId,
+              phase: settings.phase,
+              customFields: settings.customFields,
               // TODO(incremental-refresh): add incremental start data as template variable
             },
             this.getSqlDialect(),
@@ -1942,6 +1946,8 @@ export default abstract class SqlIntegration
           startDate: factTableWithMetricData.minCovariateStartDate,
           endDate: factTableWithMetricData.maxCovariateEndDate,
           experimentId: params.settings.experimentId,
+          phase: params.settings.phase,
+          customFields: params.settings.customFields,
           metricsWithIndices: metricData.map((m, i) => ({
             metric: m.metric,
             index: i,
@@ -2237,6 +2243,8 @@ export default abstract class SqlIntegration
           startDate: factTableWithMetricData.metricStart,
           endDate: factTableWithMetricData.metricEnd,
           experimentId: params.settings.experimentId,
+          phase: params.settings.phase,
+          customFields: params.settings.customFields,
           castIdToString: true,
           addFiltersToWhere: true,
           // if last max timestamp is later than metric start and thus the start

--- a/packages/back-end/test/sqlintegration.test.ts
+++ b/packages/back-end/test/sqlintegration.test.ts
@@ -317,6 +317,52 @@ describe("bigquery integration", () => {
     );
   });
 
+  it("substitutes {{experimentId}} in fact table SQL when experimentId is provided", () => {
+    const factTable = factTableFactory.build({
+      sql: "SELECT user_id, timestamp, value FROM events WHERE sample_type = CONCAT('experiment:', '{{experimentId}}')",
+    });
+    const factMetric = factMetricFactory.build({
+      metricType: "mean",
+      numerator: {
+        factTableId: factTable.id,
+        column: "value",
+        aggregation: "sum",
+      },
+    });
+
+    const startDate = new Date("2023-01-01");
+    const endDate = new Date("2023-01-31");
+
+    const result = getFactMetricCTE(bigQueryDialect, {
+      metricsWithIndices: [{ metric: factMetric, index: 0 }],
+      factTable,
+      baseIdType: "user_id",
+      idJoinMap: {},
+      startDate,
+      endDate,
+      experimentId: "my-experiment",
+    });
+
+    expect(result).toContain(
+      "WHERE sample_type = CONCAT('experiment:', 'my-experiment')",
+    );
+
+    // Outside experiment context, falls back to '%' so the variable is still
+    // valid (e.g. for `LIKE '{{experimentId}}'` patterns or column introspection).
+    const resultNoExperiment = getFactMetricCTE(bigQueryDialect, {
+      metricsWithIndices: [{ metric: factMetric, index: 0 }],
+      factTable,
+      baseIdType: "user_id",
+      idJoinMap: {},
+      startDate,
+      endDate,
+    });
+
+    expect(resultNoExperiment).toContain(
+      "WHERE sample_type = CONCAT('experiment:', '%')",
+    );
+  });
+
   it("generates CTE with metric filters in where clause if all metrics have filters", () => {
     const factTableWithFilters = factTableFactory.build({
       filters: [

--- a/packages/back-end/test/sqlintegration.test.ts
+++ b/packages/back-end/test/sqlintegration.test.ts
@@ -363,6 +363,64 @@ describe("bigquery integration", () => {
     );
   });
 
+  it("substitutes {{phase.index}} in fact table SQL when phase is provided", () => {
+    const factTable = factTableFactory.build({
+      sql: "SELECT user_id, timestamp, value FROM events WHERE phase_index = '{{phase.index}}'",
+    });
+    const factMetric = factMetricFactory.build({
+      metricType: "mean",
+      numerator: {
+        factTableId: factTable.id,
+        column: "value",
+        aggregation: "sum",
+      },
+    });
+
+    const startDate = new Date("2023-01-01");
+    const endDate = new Date("2023-01-31");
+
+    const result = getFactMetricCTE(bigQueryDialect, {
+      metricsWithIndices: [{ metric: factMetric, index: 0 }],
+      factTable,
+      baseIdType: "user_id",
+      idJoinMap: {},
+      startDate,
+      endDate,
+      phase: { index: "2" },
+    });
+
+    expect(result).toContain("WHERE phase_index = '2'");
+  });
+
+  it("substitutes {{customFields.*}} in fact table SQL when custom fields are provided", () => {
+    const factTable = factTableFactory.build({
+      sql: "SELECT user_id, timestamp, value FROM events WHERE region = {{sqlstring customFields.region}}",
+    });
+    const factMetric = factMetricFactory.build({
+      metricType: "mean",
+      numerator: {
+        factTableId: factTable.id,
+        column: "value",
+        aggregation: "sum",
+      },
+    });
+
+    const startDate = new Date("2023-01-01");
+    const endDate = new Date("2023-01-31");
+
+    const result = getFactMetricCTE(bigQueryDialect, {
+      metricsWithIndices: [{ metric: factMetric, index: 0 }],
+      factTable,
+      baseIdType: "user_id",
+      idJoinMap: {},
+      startDate,
+      endDate,
+      customFields: { region: "north-america" },
+    });
+
+    expect(result).toContain("WHERE region = 'north-america'");
+  });
+
   it("generates CTE with metric filters in where clause if all metrics have filters", () => {
     const factTableWithFilters = factTableFactory.build({
       filters: [


### PR DESCRIPTION
## Use case

We have a shared Fact Table that emits classifier-score rows for **many** experiments simultaneously, keyed by a column like `sample_type = 'experiment:<trackingKey>'`. When GrowthBook joins exposures ⋈ fact-table on the bare identifier, a user enrolled in N experiments gets N× the rows in every experiment's metric — so we need the fact-table SQL itself to filter to the experiment being analyzed:

```sql
WHERE sample_type = CONCAT('experiment:', '{{ experimentId }}')
```

## What this PR does

`{{ experimentId }}` already exists in `compileSqlTemplate` and is already threaded into `getFactMetricCTE` for the **standard** experiment-analysis path (`experiment-fact-metrics-query.ts`, `experiment-metric-query.ts`). This PR closes two small gaps:

1. **Incremental pipeline mode** — `getInsertMetricSourceCovariateDataQuery` and `getInsertMetricSourceDataQuery` were calling `getFactMetricCTE` without `experimentId`, even though `params.settings.experimentId` is in scope. Fact tables that reference `{{ experimentId }}` would silently render as `%` under incremental refresh, returning rows for all experiments. Now passes `params.settings.experimentId`.
2. **Docs** — adds an *Experiment Id Filter* section to the SQL Templates guide. The variable was previously only documented for assignment queries / dimensions, not fact tables.
3. **Test** — adds a unit test on `getFactMetricCTE` asserting both substitution of the tracking key and the `%` fallback.

## Behavior outside experiment context

Unchanged: when there is no experiment in scope (fact-table preview, standalone Metric Analysis, column introspection, product analytics), `{{ experimentId }}` resolves to `%` per the existing fallback in `compileSqlTemplate`. The docs recommend writing the filter as a `LIKE` if the query needs to return rows in both contexts.

## Testing

- `packages/back-end`: `jest test/sqlintegration.test.ts` — 2257 passed (incl. all 2244 snapshots)
- `packages/back-end`: `tsgo --noEmit` — clean
- `eslint` on changed files — clean