### PR TITLE
Fix 404 from Auth0-initiated login on Cloud

### DIFF
--- a/packages/front-end/pages/login.tsx
+++ b/packages/front-end/pages/login.tsx
@@ -1,0 +1,15 @@
+import { useRouter } from "next/router";
+import { useEffect } from "react";
+import LoadingOverlay from "@/components/LoadingOverlay";
+
+// Auth0's "Initiate Login URI" sends IdP-initiated logins to /login?iss=<issuer>.
+// Redirect to "/" so AuthProvider runs the normal auth flow.
+export default function Login() {
+  const router = useRouter();
+  useEffect(() => {
+    router.replace("/");
+  }, [router]);
+  return <LoadingOverlay />;
+}
+
+Login.preAuth = true;


### PR DESCRIPTION
### Features and Changes

Auth0 sometimes initiates GrowthBook sessions on GrowthBook Cloud by taking users to `/login` which doesn't exist in our app, so the user sees the static 404 page and bypasses our auth process.  This PR adds a small stub `/login` page that simply redirects to the homepage.  This will force these requests to go through our normal login flow.