### PR TITLE
feat(fact-metrics): add "hll merge" / "kll merge" column aggregations for pre-built sketch columns

### DIFF
--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -13961,6 +13961,14 @@ paths:
                       minimum: 0.001
                       maximum: 0.999
                       multipleOf: 0.001
+                    quantileEventCountColumn:
+                      description: >-
+                        Optional override for the source-column name used to
+                        recover per-row event counts when numerator.aggregation
+                        is 'kll merge'. Defaults to
+                        '<numerator.column>_n_events'. Only valid for
+                        event-quantile metrics with a 'kll merge' numerator.
+                      type: string
                   required:
                     - type
                     - ignoreZeros
@@ -14481,6 +14489,14 @@ paths:
                       minimum: 0.001
                       maximum: 0.999
                       multipleOf: 0.001
+                    quantileEventCountColumn:
+                      description: >-
+                        Optional override for the source-column name used to
+                        recover per-row event counts when numerator.aggregation
+                        is 'kll merge'. Defaults to
+                        '<numerator.column>_n_events'. Only valid for
+                        event-quantile metrics with a 'kll merge' numerator.
+                      type: string
                   required:
                     - type
                     - ignoreZeros
@@ -27824,6 +27840,13 @@ components:
               minimum: 0.001
               maximum: 0.999
               multipleOf: 0.001
+            quantileEventCountColumn:
+              description: >-
+                Optional override for the source-column name used to recover
+                per-row event counts when numerator.aggregation is 'kll merge'.
+                Defaults to '<numerator.column>_n_events'. Only valid for
+                event-quantile metrics with a 'kll merge' numerator.
+              type: string
           required:
             - type
             - ignoreZeros

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -15231,6 +15231,15 @@ paths:
                                 minimum: 0.001
                                 maximum: 0.999
                                 multipleOf: 0.001
+                              quantileEventCountColumn:
+                                description: >-
+                                  Optional override for the source-column name
+                                  used to recover per-row event counts when
+                                  numerator.aggregation is 'kll merge'. Defaults
+                                  to '<numerator.column>_n_events'. Only valid
+                                  for event-quantile metrics with a 'kll merge'
+                                  numerator.
+                                type: string
                             required:
                               - type
                               - ignoreZeros

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -27474,6 +27474,7 @@ components:
             - date
             - boolean
             - json
+            - binary
             - other
             - ''
         numberFormat:
@@ -27500,6 +27501,7 @@ components:
                   - date
                   - boolean
                   - json
+                  - binary
                   - other
                   - ''
             additionalProperties: false

--- a/packages/back-end/generated/spec.yaml
+++ b/packages/back-end/generated/spec.yaml
@@ -13737,15 +13737,19 @@ paths:
                       description: >-
                         User aggregation of selected column. Either sum or max
                         for numeric columns; count distinct for string columns;
-                        ignored for special columns. Default: sum. If you
-                        specify a string column you must explicitly specify
-                        count distinct. Not used for proportion or event
-                        quantile metrics.
+                        hll merge / kll merge for pre-built sketch columns
+                        (requires data-source support); ignored for special
+                        columns. Default: sum. If you specify a string column
+                        you must explicitly specify count distinct. Not used for
+                        proportion metrics; for event quantile metrics only kll
+                        merge is applicable.
                       type: string
                       enum:
                         - sum
                         - max
                         - count distinct
+                        - hll merge
+                        - kll merge
                     filters:
                       deprecated: true
                       description: >-
@@ -13845,15 +13849,19 @@ paths:
                       description: >-
                         User aggregation of selected column. Either sum or max
                         for numeric columns; count distinct for string columns;
-                        ignored for special columns. Default: sum. If you
-                        specify a string column you must explicitly specify
-                        count distinct. Not used for proportion or event
-                        quantile metrics.
+                        hll merge / kll merge for pre-built sketch columns
+                        (requires data-source support); ignored for special
+                        columns. Default: sum. If you specify a string column
+                        you must explicitly specify count distinct. Not used for
+                        proportion metrics; for event quantile metrics only kll
+                        merge is applicable.
                       type: string
                       enum:
                         - sum
                         - max
                         - count distinct
+                        - hll merge
+                        - kll merge
                     filters:
                       deprecated: true
                       description: >-
@@ -14249,15 +14257,19 @@ paths:
                       description: >-
                         User aggregation of selected column. Either sum or max
                         for numeric columns; count distinct for string columns;
-                        ignored for special columns. Default: sum. If you
-                        specify a string column you must explicitly specify
-                        count distinct. Not used for proportion or event
-                        quantile metrics.
+                        hll merge / kll merge for pre-built sketch columns
+                        (requires data-source support); ignored for special
+                        columns. Default: sum. If you specify a string column
+                        you must explicitly specify count distinct. Not used for
+                        proportion metrics; for event quantile metrics only kll
+                        merge is applicable.
                       type: string
                       enum:
                         - sum
                         - max
                         - count distinct
+                        - hll merge
+                        - kll merge
                     filters:
                       deprecated: true
                       description: >-
@@ -14357,15 +14369,19 @@ paths:
                       description: >-
                         User aggregation of selected column. Either sum or max
                         for numeric columns; count distinct for string columns;
-                        ignored for special columns. Default: sum. If you
-                        specify a string column you must explicitly specify
-                        count distinct. Not used for proportion or event
-                        quantile metrics.
+                        hll merge / kll merge for pre-built sketch columns
+                        (requires data-source support); ignored for special
+                        columns. Default: sum. If you specify a string column
+                        you must explicitly specify count distinct. Not used for
+                        proportion metrics; for event quantile metrics only kll
+                        merge is applicable.
                       type: string
                       enum:
                         - sum
                         - max
                         - count distinct
+                        - hll merge
+                        - kll merge
                     filters:
                       deprecated: true
                       description: >-
@@ -14969,16 +14985,20 @@ paths:
                                 description: >-
                                   User aggregation of selected column. Either
                                   sum or max for numeric columns; count distinct
-                                  for string columns; ignored for special
-                                  columns. Default: sum. If you specify a string
-                                  column you must explicitly specify count
-                                  distinct. Not used for proportion or event
-                                  quantile metrics.
+                                  for string columns; hll merge / kll merge for
+                                  pre-built sketch columns (requires data-source
+                                  support); ignored for special columns.
+                                  Default: sum. If you specify a string column
+                                  you must explicitly specify count distinct.
+                                  Not used for proportion metrics; for event
+                                  quantile metrics only kll merge is applicable.
                                 type: string
                                 enum:
                                   - sum
                                   - max
                                   - count distinct
+                                  - hll merge
+                                  - kll merge
                               filters:
                                 deprecated: true
                                 description: >-
@@ -15081,16 +15101,20 @@ paths:
                                 description: >-
                                   User aggregation of selected column. Either
                                   sum or max for numeric columns; count distinct
-                                  for string columns; ignored for special
-                                  columns. Default: sum. If you specify a string
-                                  column you must explicitly specify count
-                                  distinct. Not used for proportion or event
-                                  quantile metrics.
+                                  for string columns; hll merge / kll merge for
+                                  pre-built sketch columns (requires data-source
+                                  support); ignored for special columns.
+                                  Default: sum. If you specify a string column
+                                  you must explicitly specify count distinct.
+                                  Not used for proportion metrics; for event
+                                  quantile metrics only kll merge is applicable.
                                 type: string
                                 enum:
                                   - sum
                                   - max
                                   - count distinct
+                                  - hll merge
+                                  - kll merge
                               filters:
                                 deprecated: true
                                 description: >-
@@ -27609,6 +27633,8 @@ components:
                 - sum
                 - max
                 - count distinct
+                - hll merge
+                - kll merge
             filters:
               deprecated: true
               description: >-

--- a/packages/back-end/src/api/fact-metrics/postFactMetric.ts
+++ b/packages/back-end/src/api/fact-metrics/postFactMetric.ts
@@ -8,12 +8,9 @@ import {
   DEFAULT_PROPER_PRIOR_STDDEV,
   DEFAULT_WIN_RISK_THRESHOLD,
 } from "shared/constants";
-import { getSelectedColumnDatatype } from "shared/experiments";
 import { postFactMetricValidator } from "shared/validators";
 import {
-  ColumnRef,
   CreateFactMetricProps,
-  FactMetricType,
   FactTableInterface,
 } from "shared/types/fact-table";
 import { OrganizationInterface } from "shared/types/organization";
@@ -21,120 +18,6 @@ import { getFactTable } from "back-end/src/models/FactTableModel";
 import { resolveOwnerEmail } from "back-end/src/services/owner";
 import { createApiRequestHandler } from "back-end/src/util/handler";
 import { FactMetricModel } from "back-end/src/models/FactMetricModel";
-
-export function validateAggregationSpecification({
-  column,
-  factTable,
-  metricType,
-  quantileType,
-  quantileIgnoreZeros,
-  quantileEventCountColumn,
-  errorPrefix,
-}: {
-  column: ColumnRef;
-  factTable: FactTableInterface;
-  metricType?: FactMetricType;
-  quantileType?: "unit" | "event";
-  quantileIgnoreZeros?: boolean;
-  quantileEventCountColumn?: string;
-  errorPrefix?: string;
-}) {
-  const datatype = getSelectedColumnDatatype({
-    factTable,
-    column: column.column,
-  });
-  if (column.aggregation === "count distinct" && datatype !== "string") {
-    throw new Error(
-      `${errorPrefix}Cannot use 'count distinct' aggregation with the special or numeric column '${column.column}'.`,
-    );
-  }
-  if (
-    (column.aggregation === "hll merge" ||
-      column.aggregation === "kll merge") &&
-    datatype !== "binary"
-  ) {
-    throw new Error(
-      `${errorPrefix}Cannot use '${column.aggregation}' aggregation with the ${datatype || "unknown"} column '${column.column}'. The column must have a binary datatype (e.g. BigQuery BYTES).`,
-    );
-  }
-  if (datatype === "string" && column.aggregation !== "count distinct") {
-    throw new Error(
-      `${errorPrefix}Must use 'count distinct' aggregation with string column '${column.column}'.`,
-    );
-  }
-  if (
-    datatype === "binary" &&
-    column.aggregation !== "hll merge" &&
-    column.aggregation !== "kll merge"
-  ) {
-    throw new Error(
-      `${errorPrefix}Must use 'hll merge' or 'kll merge' aggregation with binary column '${column.column}'.`,
-    );
-  }
-  // 'kll merge' is only meaningful in event-quantile metrics — the
-  // back-end aggregation pipeline silently falls through to a SUM in
-  // any other context (which would produce broken SQL on a binary
-  // sketch column). Block it at the API boundary when we have enough
-  // context to tell.
-  if (
-    column.aggregation === "kll merge" &&
-    metricType !== undefined &&
-    (metricType !== "quantile" || quantileType !== "event")
-  ) {
-    throw new Error(
-      `${errorPrefix}'kll merge' aggregation is only valid for event-quantile metrics (metricType=quantile, quantileSettings.type=event).`,
-    );
-  }
-  // `ignoreZeros` cannot be applied when re-aggregating pre-built KLL
-  // sketches: the zero-filtering must happen in the upstream pipeline
-  // that built the sketch (we can no longer see individual event
-  // values). Reject explicit attempts to combine the two.
-  if (column.aggregation === "kll merge" && quantileIgnoreZeros) {
-    throw new Error(
-      `${errorPrefix}'ignoreZeros' is not supported with 'kll merge' aggregation. Filter zero-valued events before building the KLL sketch in your source pipeline.`,
-    );
-  }
-  // KLL sketches do not expose an internal "items inserted" count via any
-  // current SQL engine. To recover per-user event counts (needed for the
-  // cluster-aware variance estimator and the two-pass rank recovery in
-  // kllRankApprox) we require the user to materialize a paired count column
-  // of numeric datatype alongside the sketch column on the same fact table.
-  // Default name: `<sketch>_n_events`. The metric author can override that
-  // default via quantileSettings.quantileEventCountColumn — useful when their
-  // upstream pipeline already emits a count under a different name.
-  if (column.aggregation === "kll merge") {
-    const expectedNEventsColumn =
-      quantileEventCountColumn?.trim() || `${column.column}_n_events`;
-    const overrideUsed =
-      !!quantileEventCountColumn && quantileEventCountColumn.trim().length > 0;
-    const pairedColumn = factTable.columns.find(
-      (c) => c.column === expectedNEventsColumn && !c.deleted,
-    );
-    if (!pairedColumn) {
-      throw new Error(
-        overrideUsed
-          ? `${errorPrefix}quantileSettings.quantileEventCountColumn references '${expectedNEventsColumn}', which does not exist on the fact table. Add it as a numeric column or remove the override.`
-          : `${errorPrefix}'kll merge' on column '${column.column}' requires a paired event-count column named '${expectedNEventsColumn}' on the same fact table. Add it as a numeric column, or set quantileSettings.quantileEventCountColumn to point at an existing one.`,
-      );
-    }
-    if (pairedColumn.datatype !== "number") {
-      throw new Error(
-        `${errorPrefix}Paired event-count column '${expectedNEventsColumn}' must have a numeric datatype (got '${pairedColumn.datatype || "unknown"}').`,
-      );
-    }
-  } else if (
-    quantileEventCountColumn !== undefined &&
-    quantileEventCountColumn !== ""
-  ) {
-    // The override is only meaningful for 'kll merge'. Any other context (raw
-    // event quantiles, unit quantiles, non-quantile metrics) computes
-    // n_events from the row stream itself, so a custom source column has no
-    // semantics. Reject explicit attempts to combine the two.
-    throw new Error(
-      `${errorPrefix}quantileSettings.quantileEventCountColumn is only valid when numerator.aggregation === 'kll merge'.`,
-    );
-  }
-}
 
 export async function getCreateMetricPropsFromBody(
   body: z.infer<typeof postFactMetricValidator.bodySchema>,
@@ -173,16 +56,6 @@ export async function getCreateMetricPropsFromBody(
       body.metricType === "proportion" || body.metricType === "retention"
         ? "$$distinctUsers"
         : body.numerator.column || "$$distinctUsers",
-  });
-
-  validateAggregationSpecification({
-    errorPrefix: "Numerator misspecified. ",
-    column: cleanedNumerator,
-    factTable: factTable,
-    metricType: body.metricType,
-    quantileType: quantileSettings?.type,
-    quantileIgnoreZeros: quantileSettings?.ignoreZeros,
-    quantileEventCountColumn: quantileSettings?.quantileEventCountColumn,
   });
 
   const data: CreateFactMetricProps = {
@@ -257,17 +130,6 @@ export async function getCreateMetricPropsFromBody(
     if (!denominatorFactTable) {
       throw new Error("Could not find denominator fact table");
     }
-    validateAggregationSpecification({
-      errorPrefix: "Denominator misspecified. ",
-      column: data.denominator,
-      factTable: denominatorFactTable,
-      metricType: body.metricType,
-      quantileType: quantileSettings?.type,
-      quantileIgnoreZeros: quantileSettings?.ignoreZeros,
-      // The override only applies to numerators (denominators don't support
-      // 'kll merge'). Pass undefined so the validator never sees it here.
-      quantileEventCountColumn: undefined,
-    });
   }
 
   if (cappingSettings?.type && cappingSettings?.type !== "none") {

--- a/packages/back-end/src/api/fact-metrics/postFactMetric.ts
+++ b/packages/back-end/src/api/fact-metrics/postFactMetric.ts
@@ -13,6 +13,7 @@ import { postFactMetricValidator } from "shared/validators";
 import {
   ColumnRef,
   CreateFactMetricProps,
+  FactMetricType,
   FactTableInterface,
 } from "shared/types/fact-table";
 import { OrganizationInterface } from "shared/types/organization";
@@ -24,10 +25,16 @@ import { FactMetricModel } from "back-end/src/models/FactMetricModel";
 export function validateAggregationSpecification({
   column,
   factTable,
+  metricType,
+  quantileType,
+  quantileIgnoreZeros,
   errorPrefix,
 }: {
   column: ColumnRef;
   factTable: FactTableInterface;
+  metricType?: FactMetricType;
+  quantileType?: "unit" | "event";
+  quantileIgnoreZeros?: boolean;
   errorPrefix?: string;
 }) {
   const datatype = getSelectedColumnDatatype({
@@ -42,16 +49,70 @@ export function validateAggregationSpecification({
   if (
     (column.aggregation === "hll merge" ||
       column.aggregation === "kll merge") &&
-    (datatype === "string" || datatype === "number")
+    datatype !== "binary"
   ) {
     throw new Error(
-      `${errorPrefix}Cannot use '${column.aggregation}' aggregation with the ${datatype} column '${column.column}'. The column must be a pre-built sketch (e.g. BigQuery BYTES).`,
+      `${errorPrefix}Cannot use '${column.aggregation}' aggregation with the ${datatype || "unknown"} column '${column.column}'. The column must have a binary datatype (e.g. BigQuery BYTES).`,
     );
   }
   if (datatype === "string" && column.aggregation !== "count distinct") {
     throw new Error(
       `${errorPrefix}Must use 'count distinct' aggregation with string column '${column.column}'.`,
     );
+  }
+  if (
+    datatype === "binary" &&
+    column.aggregation !== "hll merge" &&
+    column.aggregation !== "kll merge"
+  ) {
+    throw new Error(
+      `${errorPrefix}Must use 'hll merge' or 'kll merge' aggregation with binary column '${column.column}'.`,
+    );
+  }
+  // 'kll merge' is only meaningful in event-quantile metrics — the
+  // back-end aggregation pipeline silently falls through to a SUM in
+  // any other context (which would produce broken SQL on a binary
+  // sketch column). Block it at the API boundary when we have enough
+  // context to tell.
+  if (
+    column.aggregation === "kll merge" &&
+    metricType !== undefined &&
+    (metricType !== "quantile" || quantileType !== "event")
+  ) {
+    throw new Error(
+      `${errorPrefix}'kll merge' aggregation is only valid for event-quantile metrics (metricType=quantile, quantileSettings.type=event).`,
+    );
+  }
+  // `ignoreZeros` cannot be applied when re-aggregating pre-built KLL
+  // sketches: the zero-filtering must happen in the upstream pipeline
+  // that built the sketch (we can no longer see individual event
+  // values). Reject explicit attempts to combine the two.
+  if (column.aggregation === "kll merge" && quantileIgnoreZeros) {
+    throw new Error(
+      `${errorPrefix}'ignoreZeros' is not supported with 'kll merge' aggregation. Filter zero-valued events before building the KLL sketch in your source pipeline.`,
+    );
+  }
+  // KLL sketches do not expose an internal "items inserted" count via
+  // any current SQL engine. To recover per-user event counts (needed
+  // for the cluster-aware variance estimator and the two-pass rank
+  // recovery in kllRankApprox), we require the user to materialize a
+  // paired count column named `<sketch>_n_events` of numeric datatype
+  // alongside the sketch column on the same fact table.
+  if (column.aggregation === "kll merge") {
+    const expectedNEventsColumn = `${column.column}_n_events`;
+    const pairedColumn = factTable.columns.find(
+      (c) => c.column === expectedNEventsColumn && !c.deleted,
+    );
+    if (!pairedColumn) {
+      throw new Error(
+        `${errorPrefix}'kll merge' on column '${column.column}' requires a paired event-count column named '${expectedNEventsColumn}' on the same fact table. Add it as a numeric column.`,
+      );
+    }
+    if (pairedColumn.datatype !== "number") {
+      throw new Error(
+        `${errorPrefix}Paired event-count column '${expectedNEventsColumn}' must have a numeric datatype (got '${pairedColumn.datatype || "unknown"}').`,
+      );
+    }
   }
 }
 
@@ -98,6 +159,9 @@ export async function getCreateMetricPropsFromBody(
     errorPrefix: "Numerator misspecified. ",
     column: cleanedNumerator,
     factTable: factTable,
+    metricType: body.metricType,
+    quantileType: quantileSettings?.type,
+    quantileIgnoreZeros: quantileSettings?.ignoreZeros,
   });
 
   const data: CreateFactMetricProps = {
@@ -176,6 +240,9 @@ export async function getCreateMetricPropsFromBody(
       errorPrefix: "Denominator misspecified. ",
       column: data.denominator,
       factTable: denominatorFactTable,
+      metricType: body.metricType,
+      quantileType: quantileSettings?.type,
+      quantileIgnoreZeros: quantileSettings?.ignoreZeros,
     });
   }
 

--- a/packages/back-end/src/api/fact-metrics/postFactMetric.ts
+++ b/packages/back-end/src/api/fact-metrics/postFactMetric.ts
@@ -39,6 +39,15 @@ export function validateAggregationSpecification({
       `${errorPrefix}Cannot use 'count distinct' aggregation with the special or numeric column '${column.column}'.`,
     );
   }
+  if (
+    (column.aggregation === "hll merge" ||
+      column.aggregation === "kll merge") &&
+    (datatype === "string" || datatype === "number")
+  ) {
+    throw new Error(
+      `${errorPrefix}Cannot use '${column.aggregation}' aggregation with the ${datatype} column '${column.column}'. The column must be a pre-built sketch (e.g. BigQuery BYTES).`,
+    );
+  }
   if (datatype === "string" && column.aggregation !== "count distinct") {
     throw new Error(
       `${errorPrefix}Must use 'count distinct' aggregation with string column '${column.column}'.`,

--- a/packages/back-end/src/api/fact-metrics/postFactMetric.ts
+++ b/packages/back-end/src/api/fact-metrics/postFactMetric.ts
@@ -28,6 +28,7 @@ export function validateAggregationSpecification({
   metricType,
   quantileType,
   quantileIgnoreZeros,
+  quantileEventCountColumn,
   errorPrefix,
 }: {
   column: ColumnRef;
@@ -35,6 +36,7 @@ export function validateAggregationSpecification({
   metricType?: FactMetricType;
   quantileType?: "unit" | "event";
   quantileIgnoreZeros?: boolean;
+  quantileEventCountColumn?: string;
   errorPrefix?: string;
 }) {
   const datatype = getSelectedColumnDatatype({
@@ -92,20 +94,27 @@ export function validateAggregationSpecification({
       `${errorPrefix}'ignoreZeros' is not supported with 'kll merge' aggregation. Filter zero-valued events before building the KLL sketch in your source pipeline.`,
     );
   }
-  // KLL sketches do not expose an internal "items inserted" count via
-  // any current SQL engine. To recover per-user event counts (needed
-  // for the cluster-aware variance estimator and the two-pass rank
-  // recovery in kllRankApprox), we require the user to materialize a
-  // paired count column named `<sketch>_n_events` of numeric datatype
-  // alongside the sketch column on the same fact table.
+  // KLL sketches do not expose an internal "items inserted" count via any
+  // current SQL engine. To recover per-user event counts (needed for the
+  // cluster-aware variance estimator and the two-pass rank recovery in
+  // kllRankApprox) we require the user to materialize a paired count column
+  // of numeric datatype alongside the sketch column on the same fact table.
+  // Default name: `<sketch>_n_events`. The metric author can override that
+  // default via quantileSettings.quantileEventCountColumn — useful when their
+  // upstream pipeline already emits a count under a different name.
   if (column.aggregation === "kll merge") {
-    const expectedNEventsColumn = `${column.column}_n_events`;
+    const expectedNEventsColumn =
+      quantileEventCountColumn?.trim() || `${column.column}_n_events`;
+    const overrideUsed =
+      !!quantileEventCountColumn && quantileEventCountColumn.trim().length > 0;
     const pairedColumn = factTable.columns.find(
       (c) => c.column === expectedNEventsColumn && !c.deleted,
     );
     if (!pairedColumn) {
       throw new Error(
-        `${errorPrefix}'kll merge' on column '${column.column}' requires a paired event-count column named '${expectedNEventsColumn}' on the same fact table. Add it as a numeric column.`,
+        overrideUsed
+          ? `${errorPrefix}quantileSettings.quantileEventCountColumn references '${expectedNEventsColumn}', which does not exist on the fact table. Add it as a numeric column or remove the override.`
+          : `${errorPrefix}'kll merge' on column '${column.column}' requires a paired event-count column named '${expectedNEventsColumn}' on the same fact table. Add it as a numeric column, or set quantileSettings.quantileEventCountColumn to point at an existing one.`,
       );
     }
     if (pairedColumn.datatype !== "number") {
@@ -113,6 +122,17 @@ export function validateAggregationSpecification({
         `${errorPrefix}Paired event-count column '${expectedNEventsColumn}' must have a numeric datatype (got '${pairedColumn.datatype || "unknown"}').`,
       );
     }
+  } else if (
+    quantileEventCountColumn !== undefined &&
+    quantileEventCountColumn !== ""
+  ) {
+    // The override is only meaningful for 'kll merge'. Any other context (raw
+    // event quantiles, unit quantiles, non-quantile metrics) computes
+    // n_events from the row stream itself, so a custom source column has no
+    // semantics. Reject explicit attempts to combine the two.
+    throw new Error(
+      `${errorPrefix}quantileSettings.quantileEventCountColumn is only valid when numerator.aggregation === 'kll merge'.`,
+    );
   }
 }
 
@@ -162,6 +182,7 @@ export async function getCreateMetricPropsFromBody(
     metricType: body.metricType,
     quantileType: quantileSettings?.type,
     quantileIgnoreZeros: quantileSettings?.ignoreZeros,
+    quantileEventCountColumn: quantileSettings?.quantileEventCountColumn,
   });
 
   const data: CreateFactMetricProps = {
@@ -243,6 +264,9 @@ export async function getCreateMetricPropsFromBody(
       metricType: body.metricType,
       quantileType: quantileSettings?.type,
       quantileIgnoreZeros: quantileSettings?.ignoreZeros,
+      // The override only applies to numerators (denominators don't support
+      // 'kll merge'). Pass undefined so the validator never sees it here.
+      quantileEventCountColumn: undefined,
     });
   }
 

--- a/packages/back-end/src/api/fact-metrics/updateFactMetric.ts
+++ b/packages/back-end/src/api/fact-metrics/updateFactMetric.ts
@@ -55,6 +55,9 @@ export async function getUpdateFactMetricPropsFromBody(
   const effectiveQuantileIgnoreZeros =
     updates.quantileSettings?.ignoreZeros ??
     factMetric.quantileSettings?.ignoreZeros;
+  const effectiveQuantileEventCountColumn =
+    updates.quantileSettings?.quantileEventCountColumn ??
+    factMetric.quantileSettings?.quantileEventCountColumn;
 
   const metricType = updates.metricType;
   if (numerator) {
@@ -76,6 +79,7 @@ export async function getUpdateFactMetricPropsFromBody(
       metricType: effectiveMetricType,
       quantileType: effectiveQuantileType,
       quantileIgnoreZeros: effectiveQuantileIgnoreZeros,
+      quantileEventCountColumn: effectiveQuantileEventCountColumn,
     });
   }
   // remove denominator for non-ratio metrics where existing
@@ -103,6 +107,8 @@ export async function getUpdateFactMetricPropsFromBody(
       metricType: effectiveMetricType,
       quantileType: effectiveQuantileType,
       quantileIgnoreZeros: effectiveQuantileIgnoreZeros,
+      // Override is numerator-only; never relevant for denominators.
+      quantileEventCountColumn: undefined,
     });
   }
   if (cappingSettings) {

--- a/packages/back-end/src/api/fact-metrics/updateFactMetric.ts
+++ b/packages/back-end/src/api/fact-metrics/updateFactMetric.ts
@@ -9,7 +9,6 @@ import {
 import { getFactTable } from "back-end/src/models/FactTableModel";
 import { resolveOwnerEmail } from "back-end/src/services/owner";
 import { createApiRequestHandler } from "back-end/src/util/handler";
-import { validateAggregationSpecification } from "back-end/src/api/fact-metrics/postFactMetric";
 import { FactMetricModel } from "back-end/src/models/FactMetricModel";
 
 function expectsDenominator(metricType: FactMetricType) {
@@ -46,19 +45,6 @@ export async function getUpdateFactMetricPropsFromBody(
     loseRisk: riskThresholdDanger,
   };
 
-  // Effective metric type / quantile type for validation: prefer the
-  // values being written by this PATCH; fall back to whatever is already
-  // persisted on the metric.
-  const effectiveMetricType = updates.metricType ?? factMetric.metricType;
-  const effectiveQuantileType =
-    updates.quantileSettings?.type ?? factMetric.quantileSettings?.type;
-  const effectiveQuantileIgnoreZeros =
-    updates.quantileSettings?.ignoreZeros ??
-    factMetric.quantileSettings?.ignoreZeros;
-  const effectiveQuantileEventCountColumn =
-    updates.quantileSettings?.quantileEventCountColumn ??
-    factMetric.quantileSettings?.quantileEventCountColumn;
-
   const metricType = updates.metricType;
   if (numerator) {
     updates.numerator = FactMetricModel.migrateColumnRef({
@@ -72,15 +58,6 @@ export async function getUpdateFactMetricPropsFromBody(
     if (!factTable) {
       throw new Error("Could not find numerator fact table");
     }
-    validateAggregationSpecification({
-      errorPrefix: "Numerator misspecified. ",
-      column: updates.numerator,
-      factTable: factTable,
-      metricType: effectiveMetricType,
-      quantileType: effectiveQuantileType,
-      quantileIgnoreZeros: effectiveQuantileIgnoreZeros,
-      quantileEventCountColumn: effectiveQuantileEventCountColumn,
-    });
   }
   // remove denominator for non-ratio metrics where existing
   // metric is a ratio metric
@@ -100,16 +77,6 @@ export async function getUpdateFactMetricPropsFromBody(
     if (!factTable) {
       throw new Error("Could not find denominator fact table");
     }
-    validateAggregationSpecification({
-      errorPrefix: "Denominator misspecified. ",
-      column: updates.denominator,
-      factTable: factTable,
-      metricType: effectiveMetricType,
-      quantileType: effectiveQuantileType,
-      quantileIgnoreZeros: effectiveQuantileIgnoreZeros,
-      // Override is numerator-only; never relevant for denominators.
-      quantileEventCountColumn: undefined,
-    });
   }
   if (cappingSettings) {
     updates.cappingSettings = {

--- a/packages/back-end/src/api/fact-metrics/updateFactMetric.ts
+++ b/packages/back-end/src/api/fact-metrics/updateFactMetric.ts
@@ -46,6 +46,16 @@ export async function getUpdateFactMetricPropsFromBody(
     loseRisk: riskThresholdDanger,
   };
 
+  // Effective metric type / quantile type for validation: prefer the
+  // values being written by this PATCH; fall back to whatever is already
+  // persisted on the metric.
+  const effectiveMetricType = updates.metricType ?? factMetric.metricType;
+  const effectiveQuantileType =
+    updates.quantileSettings?.type ?? factMetric.quantileSettings?.type;
+  const effectiveQuantileIgnoreZeros =
+    updates.quantileSettings?.ignoreZeros ??
+    factMetric.quantileSettings?.ignoreZeros;
+
   const metricType = updates.metricType;
   if (numerator) {
     updates.numerator = FactMetricModel.migrateColumnRef({
@@ -63,6 +73,9 @@ export async function getUpdateFactMetricPropsFromBody(
       errorPrefix: "Numerator misspecified. ",
       column: updates.numerator,
       factTable: factTable,
+      metricType: effectiveMetricType,
+      quantileType: effectiveQuantileType,
+      quantileIgnoreZeros: effectiveQuantileIgnoreZeros,
     });
   }
   // remove denominator for non-ratio metrics where existing
@@ -87,6 +100,9 @@ export async function getUpdateFactMetricPropsFromBody(
       errorPrefix: "Denominator misspecified. ",
       column: updates.denominator,
       factTable: factTable,
+      metricType: effectiveMetricType,
+      quantileType: effectiveQuantileType,
+      quantileIgnoreZeros: effectiveQuantileIgnoreZeros,
     });
   }
   if (cappingSettings) {

--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -2290,7 +2290,10 @@ export default abstract class SqlIntegration
                         endDate: params.settings.endDate,
                         // Skip ignoreZeros for n_events (it would emit a
                         // numeric != 0 filter that's irrelevant here)
-                        metricQuantileSettings: undefined,
+                        metricQuantileSettings: {
+                          ...data.metricQuantileSettings,
+                          ignoreZeros: false,
+                        },
                         metricTimestampColExpr: castToTimestamp("m.timestamp"),
                         exposureTimestampColExpr: "d.first_exposure_timestamp",
                       })} AS ${data.alias}_n_events`

--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -2280,6 +2280,22 @@ export default abstract class SqlIntegration
                       })} AS ${data.alias}_denominator`
                     : ""
                 }
+                ${
+                  data.metric.numerator.aggregation === "kll merge"
+                    ? `, ${addCaseWhenTimeFilter(this.getSqlDialect(), {
+                        col: `m.${data.alias}_n_events`,
+                        metric: data.metric,
+                        overrideConversionWindows:
+                          data.overrideConversionWindows,
+                        endDate: params.settings.endDate,
+                        // Skip ignoreZeros for n_events (it would emit a
+                        // numeric != 0 filter that's irrelevant here)
+                        metricQuantileSettings: undefined,
+                        metricTimestampColExpr: castToTimestamp("m.timestamp"),
+                        exposureTimestampColExpr: "d.first_exposure_timestamp",
+                      })} AS ${data.alias}_n_events`
+                    : ""
+                }
                 `,
               )
               .join("\n")}
@@ -2308,7 +2324,13 @@ export default abstract class SqlIntegration
                 }
                 ${
                   m.quantileMetric === "event"
-                    ? `, COUNT(${m.alias}_value) AS ${encodeMetricIdForColumnName(m.id)}_n_events`
+                    ? // For 'kll merge' metrics, each row in __newMetricRows
+                      // is a pre-aggregated sketch covering many events, so
+                      // COUNT(rows) does NOT equal events. SUM the paired
+                      // count column instead.
+                      m.metric.numerator.aggregation === "kll merge"
+                      ? `, SUM(COALESCE(${m.alias}_n_events, 0)) AS ${encodeMetricIdForColumnName(m.id)}_n_events`
+                      : `, COUNT(${m.alias}_value) AS ${encodeMetricIdForColumnName(m.id)}_n_events`
                     : ""
                 }
               `;
@@ -2521,13 +2543,14 @@ export default abstract class SqlIntegration
           ${baseIdType}
       )
       ${
+        // __eventQuantileSketch: pass 1 of two-pass KLL rank recovery — merge
+        // per-user sketches by variation+dimension. __eventQuantileMetric
+        // below extracts the quantile grid (including q_hat) from these
+        // merged sketches; __joinedData then uses q_hat as the threshold for
+        // per-user rank recovery (pass 2).
         eventQuantileData.length > 0
           ? `
       , __eventQuantileSketch AS (
-        -- Pass 1 of two-pass KLL rank recovery: merge per-user sketches by
-        -- variation+dimension. __eventQuantileMetric extracts the quantile grid
-        -- (including q_hat) from these merged sketches; __joinedData then uses
-        -- q_hat as the threshold for per-user rank recovery (pass 2).
         SELECT
           u.variation AS variation
           ${allDimensionCols.map((c) => `, u.${c.alias} AS ${c.alias}`).join("")}

--- a/packages/back-end/src/integrations/sql/columns/fact-metric-quantile-data.ts
+++ b/packages/back-end/src/integrations/sql/columns/fact-metric-quantile-data.ts
@@ -17,6 +17,7 @@ export function getFactMetricQuantileData(
         valueCol: `${m.alias}_value`,
         outputCol: `${m.alias}_value_quantile`,
         metricQuantileSettings: m.metricQuantileSettings,
+        isKllMerge: m.metric.numerator.aggregation === "kll merge",
       });
     });
   return quantileData;

--- a/packages/back-end/src/integrations/sql/ctes/fact-metric-cte.ts
+++ b/packages/back-end/src/integrations/sql/ctes/fact-metric-cte.ts
@@ -125,6 +125,21 @@ export function getFactMetricCTE(
       metricCols.push(`-- ${m.name}
         ${column} as m${index}_value`);
 
+      // For 'kll merge' metrics, also project the paired event-count
+      // column (`<sketch>_n_events`). KLL sketches do not retain an
+      // accessible item count, so the user must materialize this
+      // alongside the sketch. The validator at metric-create time
+      // requires it to exist as a numeric column on the same fact table.
+      if (m.numerator.aggregation === "kll merge") {
+        const nEventsSourceCol = `${m.numerator.column}_n_events`;
+        const nEventsCol =
+          filters.length > 0
+            ? `CASE WHEN (${filters.join("\n AND ")}) THEN m.${nEventsSourceCol} ELSE NULL END`
+            : `m.${nEventsSourceCol}`;
+        metricCols.push(`-- ${m.name} (paired n_events for kll merge)
+        ${nEventsCol} as m${index}_n_events`);
+      }
+
       allMetricFilters.push(filters);
     }
 

--- a/packages/back-end/src/integrations/sql/ctes/fact-metric-cte.ts
+++ b/packages/back-end/src/integrations/sql/ctes/fact-metric-cte.ts
@@ -126,12 +126,16 @@ export function getFactMetricCTE(
         ${column} as m${index}_value`);
 
       // For 'kll merge' metrics, also project the paired event-count
-      // column (`<sketch>_n_events`). KLL sketches do not retain an
-      // accessible item count, so the user must materialize this
-      // alongside the sketch. The validator at metric-create time
-      // requires it to exist as a numeric column on the same fact table.
+      // column. KLL sketches do not retain an accessible item count, so
+      // the user must materialize this alongside the sketch. Source-column
+      // resolution: the metric author may override the default convention
+      // (`<sketch>_n_events`) via quantileSettings.quantileEventCountColumn;
+      // the create-time validator guarantees the resolved column exists
+      // and has a numeric datatype on the same fact table.
       if (m.numerator.aggregation === "kll merge") {
-        const nEventsSourceCol = `${m.numerator.column}_n_events`;
+        const nEventsSourceCol =
+          m.quantileSettings?.quantileEventCountColumn?.trim() ||
+          `${m.numerator.column}_n_events`;
         const nEventsCol =
           filters.length > 0
             ? `CASE WHEN (${filters.join("\n AND ")}) THEN m.${nEventsSourceCol} ELSE NULL END`

--- a/packages/back-end/src/integrations/sql/ctes/fact-metric-cte.ts
+++ b/packages/back-end/src/integrations/sql/ctes/fact-metric-cte.ts
@@ -14,6 +14,7 @@ import { compileSqlTemplate } from "back-end/src/util/sql";
 
 import { getFactMetricColumn } from "back-end/src/integrations/sql/columns/fact-metric-column";
 import { toTimestampWithMs } from "back-end/src/integrations/sql/primitives/to-timestamp-with-ms";
+import { getKllEventCountSourceColumn } from "back-end/src/services/factMetrics";
 
 /** Fact Table CTE for multiple fact metrics that share the same fact table */
 export function getFactMetricCTE(
@@ -133,9 +134,11 @@ export function getFactMetricCTE(
       // the create-time validator guarantees the resolved column exists
       // and has a numeric datatype on the same fact table.
       if (m.numerator.aggregation === "kll merge") {
-        const nEventsSourceCol =
-          m.quantileSettings?.quantileEventCountColumn?.trim() ||
-          `${m.numerator.column}_n_events`;
+        const nEventsSourceCol = getKllEventCountSourceColumn({
+          column: m.numerator,
+          quantileEventCountColumn:
+            m.quantileSettings?.quantileEventCountColumn,
+        });
         const nEventsCol =
           filters.length > 0
             ? `CASE WHEN (${filters.join("\n AND ")}) THEN m.${nEventsSourceCol} ELSE NULL END`

--- a/packages/back-end/src/integrations/sql/fact-metrics/aggregation-metadata.ts
+++ b/packages/back-end/src/integrations/sql/fact-metrics/aggregation-metadata.ts
@@ -157,49 +157,54 @@ export function getAggregationMetadata(
     };
   }
 
-  // "kll merge": the column is a pre-built KLL sketch (BYTES). Only valid for
-  // event-quantile metrics. Identical to the event-quantile branch below except
-  // the first aggregation step merges existing sketches (kllMergePartial)
-  // rather than building one from raw numeric values (kllInit). The
-  // fullAggregationFunction is unused for "kll merge" because the non-
-  // incremental per-user path never sees raw event values — only sketches.
-  if (
-    !columnRef?.column.startsWith("$$") &&
-    columnRef?.aggregation === "kll merge" &&
-    metric.metricType === "quantile" &&
-    metric.quantileSettings?.type === "event"
-  ) {
-    return {
-      intermediateDataType: "kll",
-      partialAggregationFunction: (column: string) =>
-        dialect.kllMergePartial(column),
-      reAggregationFunction: (column: string) =>
-        dialect.kllMergePartial(column),
-      finalDataType: "integer",
-      fullAggregationFunction: (column: string, quantileColumn?: string) =>
-        `SUM(${dialect.ifElse(`${column} <= ${quantileColumn ?? ""}`, "1", "0")})`,
-    };
-  }
+  if (metric.metricType === "quantile") {
+    if (!metric.quantileSettings) {
+      throw new Error(
+        `Quantile metric '${metric.id}' is missing quantileSettings.`,
+      );
+    }
 
-  if (
-    metric.metricType === "quantile" &&
-    metric.quantileSettings?.type === "event"
-  ) {
-    // For incremental refresh, event quantile metrics store a KLL sketch of
-    // event values per user-date. Sketches are merged (per user, then per
-    // variation) at stats-query time and the quantile grid is extracted via
-    // kllExtractPoint. The per-user "count below threshold" (main_sum) is
-    // recovered via two-pass rank recovery (kllRankApprox) — see
-    // getIncrementalRefreshStatisticsQuery.
-    return {
-      intermediateDataType: "kll",
-      partialAggregationFunction: (column: string) => dialect.kllInit(column),
-      reAggregationFunction: (column: string) =>
-        dialect.kllMergePartial(column),
-      finalDataType: "integer",
-      fullAggregationFunction: (column: string, quantileColumn?: string) =>
-        `SUM(${dialect.ifElse(`${column} <= ${quantileColumn ?? ""}`, "1", "0")})`,
-    };
+    if (metric.quantileSettings.type === "event") {
+      // "kll merge": the column is a pre-built KLL sketch (BYTES). Only valid for
+      // event-quantile metrics. Identical to the event-quantile branch below except
+      // the first aggregation step merges existing sketches (kllMergePartial)
+      // rather than building one from raw numeric values (kllInit). The
+      // fullAggregationFunction is unused for "kll merge" because the non-
+      // incremental per-user path never sees raw event values — only sketches.
+      if (
+        !columnRef?.column.startsWith("$$") &&
+        columnRef?.aggregation === "kll merge"
+      ) {
+        return {
+          intermediateDataType: "kll",
+          partialAggregationFunction: (column: string) =>
+            dialect.kllMergePartial(column),
+          reAggregationFunction: (column: string) =>
+            dialect.kllMergePartial(column),
+          finalDataType: "integer",
+          fullAggregationFunction: (column: string, quantileColumn?: string) =>
+            `SUM(${dialect.ifElse(`${column} <= ${quantileColumn ?? ""}`, "1", "0")})`,
+        };
+      }
+      // For incremental refresh, event quantile metrics store a KLL sketch of
+      // event values per user-date. Sketches are merged (per user, then per
+      // variation) at stats-query time and the quantile grid is extracted via
+      // kllExtractPoint. The per-user "count below threshold" (main_sum) is
+      // recovered via two-pass rank recovery (kllRankApprox) — see
+      // getIncrementalRefreshStatisticsQuery.
+      return {
+        intermediateDataType: "kll",
+        partialAggregationFunction: (column: string) => dialect.kllInit(column),
+        reAggregationFunction: (column: string) =>
+          dialect.kllMergePartial(column),
+        finalDataType: "integer",
+        fullAggregationFunction: (column: string, quantileColumn?: string) =>
+          `SUM(${dialect.ifElse(`${column} <= ${quantileColumn ?? ""}`, "1", "0")})`,
+      };
+    }
+
+    // Unit quantiles are handled however the unit aggregation is specified and the quantile
+    // is applied AFTER the `fullAggregationFunction` in the stats step.
   }
 
   const reAggregationFunction = nullIfZero

--- a/packages/back-end/src/integrations/sql/fact-metrics/aggregation-metadata.ts
+++ b/packages/back-end/src/integrations/sql/fact-metrics/aggregation-metadata.ts
@@ -134,6 +134,53 @@ export function getAggregationMetadata(
     };
   }
 
+  // "hll merge": the column is a pre-built HLL sketch (BYTES). Identical to
+  // "count distinct" except the first aggregation step merges existing sketches
+  // (hllReaggregate) rather than building one from raw values (hllAggregate).
+  if (
+    !columnRef?.column.startsWith("$$") &&
+    columnRef?.aggregation === "hll merge"
+  ) {
+    const reAggregationFunction = nullIfZero
+      ? (column: string) =>
+          `NULLIF(${dialect.hllCardinality(dialect.hllReaggregate(column))}, 0)`
+      : (column: string) =>
+          dialect.hllCardinality(dialect.hllReaggregate(column));
+    return {
+      intermediateDataType: "hll",
+      partialAggregationFunction: (column: string) =>
+        castToHllDataType(dialect, dialect.hllReaggregate(column)),
+      finalDataType: "integer",
+      reAggregationFunction,
+      // Full aggregation also starts from sketches, so reuse the re-agg path.
+      fullAggregationFunction: reAggregationFunction,
+    };
+  }
+
+  // "kll merge": the column is a pre-built KLL sketch (BYTES). Only valid for
+  // event-quantile metrics. Identical to the event-quantile branch below except
+  // the first aggregation step merges existing sketches (kllMergePartial)
+  // rather than building one from raw numeric values (kllInit). The
+  // fullAggregationFunction is unused for "kll merge" because the non-
+  // incremental per-user path never sees raw event values — only sketches.
+  if (
+    !columnRef?.column.startsWith("$$") &&
+    columnRef?.aggregation === "kll merge" &&
+    metric.metricType === "quantile" &&
+    metric.quantileSettings?.type === "event"
+  ) {
+    return {
+      intermediateDataType: "kll",
+      partialAggregationFunction: (column: string) =>
+        dialect.kllMergePartial(column),
+      reAggregationFunction: (column: string) =>
+        dialect.kllMergePartial(column),
+      finalDataType: "integer",
+      fullAggregationFunction: (column: string, quantileColumn?: string) =>
+        `SUM(${dialect.ifElse(`${column} <= ${quantileColumn ?? ""}`, "1", "0")})`,
+    };
+  }
+
   if (
     metric.metricType === "quantile" &&
     metric.quantileSettings?.type === "event"

--- a/packages/back-end/src/integrations/sql/queries/experiment-fact-metrics-query.ts
+++ b/packages/back-end/src/integrations/sql/queries/experiment-fact-metrics-query.ts
@@ -329,7 +329,10 @@ export function getExperimentFactMetricsQuery(
                           data.overrideConversionWindows,
                         endDate: settings.endDate,
                         // Skip ignoreZeros for n_events
-                        metricQuantileSettings: undefined,
+                        metricQuantileSettings: {
+                          ...data.metricQuantileSettings,
+                          ignoreZeros: false,
+                        },
                         metricTimestampColExpr: "m.timestamp",
                         exposureTimestampColExpr: "d.timestamp",
                       })} as ${data.alias}_n_events`
@@ -414,7 +417,7 @@ export function getExperimentFactMetricsQuery(
     , __userMetricAgg${f.index === 0 ? "" : f.index} as (${(() => {
       // Per-table 'kll merge' resolution wrapper:
       // For 'kll merge' event-quantile metrics, the inner SELECT below merges
-      // per-event sketches into a per-user sketch via kllMergePartial (an
+      // per-row sketches into a per-user sketch via kllMergePartial (an
       // aggregate over the per-user GROUP BY) and emits it as
       // ${alias}_user_sketch. The OUTER SELECT then joins that per-user sketch
       // with __eventQuantileMetric (per variation+dim) and applies

--- a/packages/back-end/src/integrations/sql/queries/experiment-fact-metrics-query.ts
+++ b/packages/back-end/src/integrations/sql/queries/experiment-fact-metrics-query.ts
@@ -27,6 +27,7 @@ import { getMetricData } from "back-end/src/integrations/sql/fact-metrics/metric
 import { processActivationMetric } from "back-end/src/integrations/sql/processing/process-activation-metric";
 import { processDimensions } from "back-end/src/integrations/sql/processing/process-dimensions";
 import { getQuantileGridColumns } from "back-end/src/integrations/sql/columns/quantile-grid-columns";
+import { getKllQuantileGridColumns } from "back-end/src/integrations/sql/columns/kll-quantile-grid-columns";
 
 export function getExperimentFactMetricsQuery(
   dialect: SqlDialect,
@@ -318,6 +319,22 @@ export function getExperimentFactMetricsQuery(
                       })} as ${data.alias}_denominator`
                     : ""
                 }
+                ${
+                  data.metric.numerator.aggregation === "kll merge" &&
+                  data.numeratorSourceIndex === f.index
+                    ? `, ${addCaseWhenTimeFilter(dialect, {
+                        col: `m.${data.alias}_n_events`,
+                        metric: data.metric,
+                        overrideConversionWindows:
+                          data.overrideConversionWindows,
+                        endDate: settings.endDate,
+                        // Skip ignoreZeros for n_events
+                        metricQuantileSettings: undefined,
+                        metricTimestampColExpr: "m.timestamp",
+                        exposureTimestampColExpr: "d.timestamp",
+                      })} as ${data.alias}_n_events`
+                    : ""
+                }
                 `,
             )
             .join("\n")}
@@ -358,6 +375,12 @@ export function getExperimentFactMetricsQuery(
         )
       )
     ${
+      // __eventQuantileMetric: per (variation, dimension) quantile grid for
+      // event-quantile metrics. Raw event-quantile metrics use APPROX_PERCENTILE
+      // over the per-event numeric values in __userMetricJoin. 'kll merge'
+      // metrics merge per-event sketches via KLL_QUANTILES.MERGE_PARTIAL and
+      // then read off quantile + bound points via KLL_QUANTILES.EXTRACT_POINT
+      // — same shape as the incremental-refresh path in SqlIntegration.ts.
       eventQuantileData.length
         ? `
       , __eventQuantileMetric${f.index === 0 ? "" : f.index} AS (
@@ -366,11 +389,18 @@ export function getExperimentFactMetricsQuery(
         ${dimensionCols.map((c) => `, m.${c.alias} AS ${c.alias}`).join("")}
         ${eventQuantileData
           .map((data) =>
-            getQuantileGridColumns(
-              dialect,
-              data.metricQuantileSettings,
-              `${data.alias}_`,
-            ),
+            data.isKllMerge
+              ? getKllQuantileGridColumns(
+                  dialect,
+                  data.metricQuantileSettings,
+                  dialect.kllMergePartial(`m.${data.alias}_value`),
+                  `${data.alias}_`,
+                )
+              : getQuantileGridColumns(
+                  dialect,
+                  data.metricQuantileSettings,
+                  `${data.alias}_`,
+                ),
           )
           .join("\n")}
       FROM
@@ -381,7 +411,41 @@ export function getExperimentFactMetricsQuery(
       )`
         : ""
     }
-    , __userMetricAgg${f.index === 0 ? "" : f.index} as (
+    , __userMetricAgg${f.index === 0 ? "" : f.index} as (${(() => {
+      // Per-table 'kll merge' resolution wrapper:
+      // For 'kll merge' event-quantile metrics, the inner SELECT below merges
+      // per-event sketches into a per-user sketch via kllMergePartial (an
+      // aggregate over the per-user GROUP BY) and emits it as
+      // ${alias}_user_sketch. The OUTER SELECT then joins that per-user sketch
+      // with __eventQuantileMetric (per variation+dim) and applies
+      // kllRankApprox — without GROUP BY — to recover the per-user "count
+      // below threshold". This mirrors the two-pass rank recovery used by the
+      // incremental-refresh path in SqlIntegration.ts and avoids putting
+      // scalar subqueries with outer-aggregate references inside the per-user
+      // GROUP BY (which BigQuery/Snowflake/etc. handle inconsistently).
+      const factTableKllMergeMetrics = metricData.filter(
+        (d) =>
+          d.metric.numerator.aggregation === "kll merge" &&
+          d.numeratorSourceIndex === f.index,
+      );
+      const hasKllMerge = factTableKllMergeMetrics.length > 0;
+      const kllMergeResolutionCols = factTableKllMergeMetrics
+        .map(
+          (data) =>
+            `, ${dialect.kllRankApprox(
+              `base.${data.alias}_user_sketch`,
+              `qm.${data.alias}_quantile`,
+              `base.${data.alias}_n_events`,
+              100,
+            )} AS ${data.alias}_value`,
+        )
+        .join("\n");
+      return `${
+        hasKllMerge
+          ? `SELECT base.* ${kllMergeResolutionCols}
+      FROM (`
+          : ""
+      }
       -- Add in the aggregate metric value for each user
       SELECT
         umj.variation
@@ -390,8 +454,20 @@ export function getExperimentFactMetricsQuery(
         , umj.${baseIdType}
         ${metricData
           .map((data) => {
-            return `${
-              data.numeratorSourceIndex === f.index
+            // For 'kll merge' event-quantile metrics, ${alias}_value is
+            // computed in the OUTER wrapper SELECT above; here we only emit
+            // the per-user merged sketch so kllRankApprox can resolve it
+            // post-GROUP-BY.
+            const isKllMergeNumerator =
+              data.metric.numerator.aggregation === "kll merge" &&
+              data.numeratorSourceIndex === f.index;
+
+            const kllMergeColumns = isKllMergeNumerator
+              ? `, ${dialect.kllMergePartial(`umj.${data.alias}_value`)} AS ${data.alias}_user_sketch`
+              : "";
+
+            const numeratorValueColumn =
+              data.numeratorSourceIndex === f.index && !isKllMergeNumerator
                 ? `, ${data.aggregatedValueTransformation({
                     column: data.numeratorAggFns.fullAggregationFunction(
                       `umj.${data.alias}_value`,
@@ -400,8 +476,9 @@ export function getExperimentFactMetricsQuery(
                     initialTimestampColumn: "MIN(umj.timestamp)",
                     analysisEndDate: params.settings.endDate,
                   })} AS ${data.alias}_value`
-                : ""
-            }
+                : "";
+
+            return `${numeratorValueColumn}${kllMergeColumns}
               ${
                 data.ratioMetric && data.denominatorSourceIndex === f.index
                   ? `, ${data.aggregatedValueTransformation({
@@ -417,9 +494,13 @@ export function getExperimentFactMetricsQuery(
           })
           .join("\n")}
         ${eventQuantileData
-          .map(
-            (data) =>
-              `, COUNT(umj.${data.alias}_value) AS ${data.alias}_n_events`,
+          .map((data) =>
+            // For 'kll merge' metrics, each row is a pre-aggregated sketch
+            // covering many events, so COUNT(rows) does NOT equal events.
+            // SUM the paired count column instead.
+            data.isKllMerge
+              ? `, SUM(COALESCE(umj.${data.alias}_n_events, 0)) AS ${data.alias}_n_events`
+              : `, COUNT(umj.${data.alias}_value) AS ${data.alias}_n_events`,
           )
           .join("\n")}
         ${
@@ -461,7 +542,17 @@ export function getExperimentFactMetricsQuery(
         ${dimensionCols.map((c) => `, umj.${c.alias}`).join("")}
         ${banditDates?.length ? `, umj.bandit_period` : ""}
         , umj.${baseIdType}
-    )
+      ${
+        hasKllMerge
+          ? `
+      ) base
+      LEFT JOIN __eventQuantileMetric${f.index === 0 ? "" : f.index} qm
+      ON (qm.variation = base.variation ${dimensionCols
+        .map((c) => `AND qm.${c.alias} = base.${c.alias}`)
+        .join("\n")})`
+          : ""
+      }`;
+    })()})
     ${
       percentileTableIndices.has(f.index)
         ? `

--- a/packages/back-end/src/integrations/sql/queries/experiment-fact-metrics-query.ts
+++ b/packages/back-end/src/integrations/sql/queries/experiment-fact-metrics-query.ts
@@ -264,9 +264,247 @@ export function getExperimentFactMetricsQuery(
       }
     )
     ${factTablesWithIndices
-      .map(
-        (f) =>
-          `, __factTable${f.index === 0 ? "" : f.index} as (
+      .map((f) => {
+        const suffix = f.index === 0 ? "" : f.index;
+        const userMetricJoinTable = `__userMetricJoin${suffix}`;
+        const userMetricAggBaseTable = `__userMetricAggBase${suffix}`;
+        const userMetricAggTable = `__userMetricAgg${suffix}`;
+        const eventQuantileMetricTable = `__eventQuantileMetric${suffix}`;
+
+        const factTableKllMergeMetrics = metricData.filter(
+          (d) =>
+            d.metric.numerator.aggregation === "kll merge" &&
+            d.numeratorSourceIndex === f.index,
+        );
+        const hasKllMerge = factTableKllMergeMetrics.length > 0;
+        const hasEventQuantile = eventQuantileData.length > 0;
+        const hasNonKllEventQuantile = eventQuantileData.some(
+          (d) => !d.isKllMerge,
+        );
+        // KLL is mergeable: merge(per-event sketches) ≡ merge(per-user merged
+        // sketches). When every event-quantile metric is 'kll merge', read
+        // the variation-level merge from the per-user sketches in
+        // __userMetricAggBase instead of re-scanning per-event values in
+        // __userMetricJoin — same shape as __eventQuantileSketch +
+        // __eventQuantileMetric in the incremental-refresh path in
+        // SqlIntegration.ts. Mixed cases still read per-event from
+        // __userMetricJoin because non-KLL APPROX_PERCENTILE needs per-event
+        // values and we only emit a single __eventQuantileMetric CTE.
+        const eqmReadsFromBase =
+          hasKllMerge && !hasNonKllEventQuantile && hasEventQuantile;
+
+        // Per-user aggregation body — shared between __userMetricAggBase
+        // (when emitted) and __userMetricAgg (when no KLL merge wrapper is
+        // needed).
+        //
+        // Notes on what this SELECT emits per metric:
+        //   - 'kll merge' numerator: a per-user sketch column
+        //     <alias>_user_sketch via kllMergePartial. The scalar
+        //     <alias>_value is computed post-GROUP-BY in __userMetricAgg
+        //     because kllRankApprox needs the per-user sketch AND the
+        //     variation-level quantile (BigQuery/Snowflake handle scalar
+        //     subqueries with outer-aggregate references inside a GROUP BY
+        //     inconsistently, so the rank recovery is done after the join).
+        //   - non-KLL numerator: a per-user <alias>_value via
+        //     aggregatedValueTransformation; non-KLL event-quantile metrics
+        //     reference qm.<alias>_quantile per-event so they require the
+        //     LEFT JOIN to __eventQuantileMetric below.
+        //   - <alias>_n_events: SUM of the paired count column for kll
+        //     merge (since each row is a pre-aggregated sketch covering many
+        //     events) and COUNT(rows) otherwise.
+        const perUserAggSelect = `
+          -- Add in the aggregate metric value for each user
+          SELECT
+            umj.variation
+            ${dimensionCols
+              .map((c) => `, umj.${c.alias} AS ${c.alias}`)
+              .join("")}
+            ${banditDates?.length ? `, umj.bandit_period` : ""}
+            , umj.${baseIdType}
+            ${metricData
+              .map((data) => {
+                const isKllMergeNumerator =
+                  data.metric.numerator.aggregation === "kll merge" &&
+                  data.numeratorSourceIndex === f.index;
+
+                const kllMergeColumns = isKllMergeNumerator
+                  ? `, ${dialect.kllMergePartial(`umj.${data.alias}_value`)} AS ${data.alias}_user_sketch`
+                  : "";
+
+                const numeratorValueColumn =
+                  data.numeratorSourceIndex === f.index && !isKllMergeNumerator
+                    ? `, ${data.aggregatedValueTransformation({
+                        column: data.numeratorAggFns.fullAggregationFunction(
+                          `umj.${data.alias}_value`,
+                          `qm.${data.alias}_quantile`,
+                        ),
+                        initialTimestampColumn: "MIN(umj.timestamp)",
+                        analysisEndDate: params.settings.endDate,
+                      })} AS ${data.alias}_value`
+                    : "";
+
+                return `${numeratorValueColumn}${kllMergeColumns}
+              ${
+                data.ratioMetric && data.denominatorSourceIndex === f.index
+                  ? `, ${data.aggregatedValueTransformation({
+                      column: data.denominatorAggFns.fullAggregationFunction(
+                        `umj.${data.alias}_denominator`,
+                        `qm.${data.alias}_quantile`,
+                      ),
+                      initialTimestampColumn: "MIN(umj.timestamp)",
+                      analysisEndDate: params.settings.endDate,
+                    })} AS ${data.alias}_denominator`
+                  : ""
+              }`;
+              })
+              .join("\n")}
+            ${eventQuantileData
+              .map((data) =>
+                data.isKllMerge
+                  ? `, SUM(COALESCE(umj.${data.alias}_n_events, 0)) AS ${data.alias}_n_events`
+                  : `, COUNT(umj.${data.alias}_value) AS ${data.alias}_n_events`,
+              )
+              .join("\n")}
+            ${
+              regressionAdjustedTableIndices.has(f.index)
+                ? regressionAdjustedMetrics
+                    .map(
+                      (metric) =>
+                        `${
+                          metric.numeratorSourceIndex === f.index
+                            ? `, ${metric.covariateNumeratorAggFns.fullAggregationFunction(
+                                `umj.${metric.alias}_covariate_value`,
+                              )} AS ${metric.alias}_covariate_value`
+                            : ""
+                        }${
+                          metric.ratioMetric &&
+                          metric.denominatorSourceIndex === f.index
+                            ? `, ${metric.covariateDenominatorAggFns.fullAggregationFunction(
+                                `umj.${metric.alias}_covariate_denominator`,
+                              )} AS ${metric.alias}_covariate_denominator`
+                            : ""
+                        }`,
+                    )
+                    .join("\n")
+                : ""
+            }
+          FROM
+            ${userMetricJoinTable} umj
+          ${
+            // Non-KLL event-quantile metrics need the variation-level
+            // quantile joined per-event so aggregatedValueTransformation can
+            // reference qm.<alias>_quantile during the per-user GROUP BY.
+            // KLL-only paths avoid this join — the per-user sketch carries
+            // enough information and resolution happens in __userMetricAgg.
+            hasNonKllEventQuantile
+              ? `
+          LEFT JOIN ${eventQuantileMetricTable} qm
+          ON (qm.variation = umj.variation ${dimensionCols
+            .map((c) => `AND qm.${c.alias} = umj.${c.alias}`)
+            .join("\n")})`
+              : ""
+          }
+          GROUP BY
+            umj.variation
+            ${dimensionCols.map((c) => `, umj.${c.alias}`).join("")}
+            ${banditDates?.length ? `, umj.bandit_period` : ""}
+            , umj.${baseIdType}
+        `;
+
+        // __eventQuantileMetric: per (variation, dimension) quantile grid for
+        // event-quantile metrics. Raw event-quantile metrics use
+        // APPROX_PERCENTILE over per-event numeric values in
+        // __userMetricJoin. 'kll merge' metrics merge sketches via
+        // KLL_QUANTILES.MERGE_PARTIAL and read off quantile + bound points
+        // via KLL_QUANTILES.EXTRACT_POINT. When eqmReadsFromBase, the merge
+        // operand is the per-user sketch from __userMetricAggBase (so
+        // __userMetricJoin is scanned exactly once); otherwise it's the
+        // per-event sketch from __userMetricJoin.
+        const eventQuantileMetricCte = hasEventQuantile
+          ? `
+      , ${eventQuantileMetricTable} AS (
+        SELECT
+        m.variation AS variation
+        ${dimensionCols.map((c) => `, m.${c.alias} AS ${c.alias}`).join("")}
+        ${eventQuantileData
+          .map((data) =>
+            data.isKllMerge
+              ? getKllQuantileGridColumns(
+                  dialect,
+                  data.metricQuantileSettings,
+                  dialect.kllMergePartial(
+                    eqmReadsFromBase
+                      ? `m.${data.alias}_user_sketch`
+                      : `m.${data.alias}_value`,
+                  ),
+                  `${data.alias}_`,
+                )
+              : getQuantileGridColumns(
+                  dialect,
+                  data.metricQuantileSettings,
+                  `${data.alias}_`,
+                ),
+          )
+          .join("\n")}
+      FROM
+        ${eqmReadsFromBase ? userMetricAggBaseTable : userMetricJoinTable} m
+      GROUP BY
+        m.variation
+        ${dimensionCols.map((c) => `, m.${c.alias}`).join("")}
+      )`
+          : "";
+
+        // __userMetricAggBase: per-user aggregation. Only emitted when
+        // there are KLL merge metrics — its only consumer is __userMetricAgg
+        // (and __eventQuantileMetric when eqmReadsFromBase). Without KLL
+        // merge metrics the per-user aggregation goes directly into
+        // __userMetricAgg.
+        const userMetricAggBaseCte = hasKllMerge
+          ? `
+      , ${userMetricAggBaseTable} as (${perUserAggSelect})`
+          : "";
+
+        // __userMetricAgg: final per-user values consumed by downstream
+        // statistics CTEs.
+        //   - With KLL merge: thin wrapper that joins __userMetricAggBase
+        //     against __eventQuantileMetric to apply kllRankApprox
+        //     post-GROUP-BY (recovers the per-user "count below threshold"
+        //     using the per-user sketch and the variation-level quantile).
+        //   - Without KLL merge: just the per-user aggregation directly.
+        const kllMergeResolutionCols = factTableKllMergeMetrics
+          .map(
+            (data) =>
+              `, ${dialect.kllRankApprox(
+                `base.${data.alias}_user_sketch`,
+                `qm.${data.alias}_quantile`,
+                `base.${data.alias}_n_events`,
+                100,
+              )} AS ${data.alias}_value`,
+          )
+          .join("\n");
+        const userMetricAggCte = hasKllMerge
+          ? `
+      , ${userMetricAggTable} as (
+        SELECT base.* ${kllMergeResolutionCols}
+        FROM ${userMetricAggBaseTable} base
+        LEFT JOIN ${eventQuantileMetricTable} qm
+        ON (qm.variation = base.variation ${dimensionCols
+          .map((c) => `AND qm.${c.alias} = base.${c.alias}`)
+          .join("\n")})
+      )`
+          : `
+      , ${userMetricAggTable} as (${perUserAggSelect})`;
+
+        // CTE order depends on the dependency graph:
+        //   - eqmReadsFromBase (KLL only): join → base → eqm → agg
+        //   - mixed KLL + non-KLL event quantile: join → eqm → base → agg
+        //   - non-KLL event quantile only: join → eqm → agg (no base)
+        //   - no event quantile: join → agg (no base, no eqm)
+        const downstreamCtes = eqmReadsFromBase
+          ? `${userMetricAggBaseCte}${eventQuantileMetricCte}${userMetricAggCte}`
+          : `${eventQuantileMetricCte}${userMetricAggBaseCte}${userMetricAggCte}`;
+
+        return `, __factTable${suffix} as (
         ${getFactMetricCTE(dialect, {
           baseIdType,
           idJoinMap,
@@ -280,7 +518,7 @@ export function getExperimentFactMetricsQuery(
           customFields: settings.customFields,
         })}
       )
-      , __userMetricJoin${f.index === 0 ? "" : f.index} as (
+      , ${userMetricJoinTable} as (
         SELECT
           d.variation AS variation
           , d.timestamp AS timestamp
@@ -373,203 +611,24 @@ export function getExperimentFactMetricsQuery(
           }
         FROM
           __distinctUsers d
-        LEFT JOIN __factTable${f.index === 0 ? "" : f.index} m ON (
+        LEFT JOIN __factTable${suffix} m ON (
           m.${baseIdType} = d.${baseIdType}
         )
-      )
-    ${
-      // __eventQuantileMetric: per (variation, dimension) quantile grid for
-      // event-quantile metrics. Raw event-quantile metrics use APPROX_PERCENTILE
-      // over the per-event numeric values in __userMetricJoin. 'kll merge'
-      // metrics merge per-event sketches via KLL_QUANTILES.MERGE_PARTIAL and
-      // then read off quantile + bound points via KLL_QUANTILES.EXTRACT_POINT
-      // — same shape as the incremental-refresh path in SqlIntegration.ts.
-      eventQuantileData.length
-        ? `
-      , __eventQuantileMetric${f.index === 0 ? "" : f.index} AS (
-        SELECT
-        m.variation AS variation
-        ${dimensionCols.map((c) => `, m.${c.alias} AS ${c.alias}`).join("")}
-        ${eventQuantileData
-          .map((data) =>
-            data.isKllMerge
-              ? getKllQuantileGridColumns(
-                  dialect,
-                  data.metricQuantileSettings,
-                  dialect.kllMergePartial(`m.${data.alias}_value`),
-                  `${data.alias}_`,
-                )
-              : getQuantileGridColumns(
-                  dialect,
-                  data.metricQuantileSettings,
-                  `${data.alias}_`,
-                ),
-          )
-          .join("\n")}
-      FROM
-        __userMetricJoin${f.index === 0 ? "" : f.index} m
-      GROUP BY
-        m.variation
-        ${dimensionCols.map((c) => `, m.${c.alias}`).join("")}
-      )`
-        : ""
-    }
-    , __userMetricAgg${f.index === 0 ? "" : f.index} as (${(() => {
-      // Per-table 'kll merge' resolution wrapper:
-      // For 'kll merge' event-quantile metrics, the inner SELECT below merges
-      // per-row sketches into a per-user sketch via kllMergePartial (an
-      // aggregate over the per-user GROUP BY) and emits it as
-      // ${alias}_user_sketch. The OUTER SELECT then joins that per-user sketch
-      // with __eventQuantileMetric (per variation+dim) and applies
-      // kllRankApprox — without GROUP BY — to recover the per-user "count
-      // below threshold". This mirrors the two-pass rank recovery used by the
-      // incremental-refresh path in SqlIntegration.ts and avoids putting
-      // scalar subqueries with outer-aggregate references inside the per-user
-      // GROUP BY (which BigQuery/Snowflake/etc. handle inconsistently).
-      const factTableKllMergeMetrics = metricData.filter(
-        (d) =>
-          d.metric.numerator.aggregation === "kll merge" &&
-          d.numeratorSourceIndex === f.index,
-      );
-      const hasKllMerge = factTableKllMergeMetrics.length > 0;
-      const kllMergeResolutionCols = factTableKllMergeMetrics
-        .map(
-          (data) =>
-            `, ${dialect.kllRankApprox(
-              `base.${data.alias}_user_sketch`,
-              `qm.${data.alias}_quantile`,
-              `base.${data.alias}_n_events`,
-              100,
-            )} AS ${data.alias}_value`,
-        )
-        .join("\n");
-      return `${
-        hasKllMerge
-          ? `SELECT base.* ${kllMergeResolutionCols}
-      FROM (`
-          : ""
-      }
-      -- Add in the aggregate metric value for each user
-      SELECT
-        umj.variation
-        ${dimensionCols.map((c) => `, umj.${c.alias} AS ${c.alias}`).join("")}
-        ${banditDates?.length ? `, umj.bandit_period` : ""}
-        , umj.${baseIdType}
-        ${metricData
-          .map((data) => {
-            // For 'kll merge' event-quantile metrics, ${alias}_value is
-            // computed in the OUTER wrapper SELECT above; here we only emit
-            // the per-user merged sketch so kllRankApprox can resolve it
-            // post-GROUP-BY.
-            const isKllMergeNumerator =
-              data.metric.numerator.aggregation === "kll merge" &&
-              data.numeratorSourceIndex === f.index;
-
-            const kllMergeColumns = isKllMergeNumerator
-              ? `, ${dialect.kllMergePartial(`umj.${data.alias}_value`)} AS ${data.alias}_user_sketch`
-              : "";
-
-            const numeratorValueColumn =
-              data.numeratorSourceIndex === f.index && !isKllMergeNumerator
-                ? `, ${data.aggregatedValueTransformation({
-                    column: data.numeratorAggFns.fullAggregationFunction(
-                      `umj.${data.alias}_value`,
-                      `qm.${data.alias}_quantile`,
-                    ),
-                    initialTimestampColumn: "MIN(umj.timestamp)",
-                    analysisEndDate: params.settings.endDate,
-                  })} AS ${data.alias}_value`
-                : "";
-
-            return `${numeratorValueColumn}${kllMergeColumns}
-              ${
-                data.ratioMetric && data.denominatorSourceIndex === f.index
-                  ? `, ${data.aggregatedValueTransformation({
-                      column: data.denominatorAggFns.fullAggregationFunction(
-                        `umj.${data.alias}_denominator`,
-                        `qm.${data.alias}_quantile`,
-                      ),
-                      initialTimestampColumn: "MIN(umj.timestamp)",
-                      analysisEndDate: params.settings.endDate,
-                    })} AS ${data.alias}_denominator`
-                  : ""
-              }`;
-          })
-          .join("\n")}
-        ${eventQuantileData
-          .map((data) =>
-            // For 'kll merge' metrics, each row is a pre-aggregated sketch
-            // covering many events, so COUNT(rows) does NOT equal events.
-            // SUM the paired count column instead.
-            data.isKllMerge
-              ? `, SUM(COALESCE(umj.${data.alias}_n_events, 0)) AS ${data.alias}_n_events`
-              : `, COUNT(umj.${data.alias}_value) AS ${data.alias}_n_events`,
-          )
-          .join("\n")}
-        ${
-          regressionAdjustedTableIndices.has(f.index)
-            ? regressionAdjustedMetrics
-                .map(
-                  (metric) =>
-                    `${
-                      metric.numeratorSourceIndex === f.index
-                        ? `, ${metric.covariateNumeratorAggFns.fullAggregationFunction(
-                            `umj.${metric.alias}_covariate_value`,
-                          )} AS ${metric.alias}_covariate_value`
-                        : ""
-                    }${
-                      metric.ratioMetric &&
-                      metric.denominatorSourceIndex === f.index
-                        ? `, ${metric.covariateDenominatorAggFns.fullAggregationFunction(
-                            `umj.${metric.alias}_covariate_denominator`,
-                          )} AS ${metric.alias}_covariate_denominator`
-                        : ""
-                    }`,
-                )
-                .join("\n")
-            : ""
-        }
-      FROM
-        __userMetricJoin${f.index === 0 ? "" : f.index} umj
-      ${
-        eventQuantileData.length
-          ? `
-      LEFT JOIN __eventQuantileMetric${f.index === 0 ? "" : f.index} qm
-      ON (qm.variation = umj.variation ${dimensionCols
-        .map((c) => `AND qm.${c.alias} = umj.${c.alias}`)
-        .join("\n")})`
-          : ""
-      }
-      GROUP BY
-        umj.variation
-        ${dimensionCols.map((c) => `, umj.${c.alias}`).join("")}
-        ${banditDates?.length ? `, umj.bandit_period` : ""}
-        , umj.${baseIdType}
-      ${
-        hasKllMerge
-          ? `
-      ) base
-      LEFT JOIN __eventQuantileMetric${f.index === 0 ? "" : f.index} qm
-      ON (qm.variation = base.variation ${dimensionCols
-        .map((c) => `AND qm.${c.alias} = base.${c.alias}`)
-        .join("\n")})`
-          : ""
-      }`;
-    })()})
+      )${downstreamCtes}
     ${
       percentileTableIndices.has(f.index)
         ? `
-      , __capValue${f.index === 0 ? "" : f.index} AS (
+      , __capValue${suffix} AS (
           ${dialect.percentileCapSelectClause(
             percentileData.filter((p) => p.sourceIndex === f.index),
-            `__userMetricAgg${f.index === 0 ? "" : f.index}`,
+            userMetricAggTable,
           )}
       )
       `
         : ""
     }
-    `,
-      )
+    `;
+      })
       .join("\n")}    
     ${
       banditDates?.length

--- a/packages/back-end/src/jobs/refreshFactTableColumns.ts
+++ b/packages/back-end/src/jobs/refreshFactTableColumns.ts
@@ -172,6 +172,7 @@ export async function runRefreshColumnsQuery(
     [timestampColumn],
     "factTableValidation",
   );
+  console.log("result", result);
 
   const typeMap = new Map<string, FactTableColumnType>();
   const jsonMap = new Map<string, JSONColumnFields>();

--- a/packages/back-end/src/jobs/refreshFactTableColumns.ts
+++ b/packages/back-end/src/jobs/refreshFactTableColumns.ts
@@ -172,7 +172,6 @@ export async function runRefreshColumnsQuery(
     [timestampColumn],
     "factTableValidation",
   );
-  console.log("result", result);
 
   const typeMap = new Map<string, FactTableColumnType>();
   const jsonMap = new Map<string, JSONColumnFields>();

--- a/packages/back-end/src/models/FactMetricModel.ts
+++ b/packages/back-end/src/models/FactMetricModel.ts
@@ -26,7 +26,7 @@ import {
   validateFactMetricRowFilterSql,
 } from "back-end/src/services/factMetricRowFilterValidation";
 import { projectFilterQuery } from "back-end/src/util/mongo.util";
-import { validateAggregationSpecification } from "back-end/src/api/fact-metrics/postFactMetric";
+import { validateAggregationSpecification } from "back-end/src/services/factMetricAggregationValidation";
 import { MakeModelClass } from "./BaseModel";
 import { getDataSourceById } from "./DataSourceModel";
 import { getFactTableMap } from "./FactTableModel";

--- a/packages/back-end/src/models/FactMetricModel.ts
+++ b/packages/back-end/src/models/FactMetricModel.ts
@@ -355,6 +355,7 @@ export class FactMetricModel extends BaseClass {
       metricType: data.metricType,
       quantileType: data.quantileSettings?.type,
       quantileIgnoreZeros: data.quantileSettings?.ignoreZeros,
+      quantileEventCountColumn: data.quantileSettings?.quantileEventCountColumn,
     });
 
     // validate column
@@ -416,6 +417,8 @@ export class FactMetricModel extends BaseClass {
         metricType: data.metricType,
         quantileType: data.quantileSettings?.type,
         quantileIgnoreZeros: data.quantileSettings?.ignoreZeros,
+        // Override is numerator-only; never relevant for denominators.
+        quantileEventCountColumn: undefined,
       });
     } else if (data.denominator?.factTableId) {
       throw new Error("Denominator not allowed for non-ratio metric");

--- a/packages/back-end/src/models/FactMetricModel.ts
+++ b/packages/back-end/src/models/FactMetricModel.ts
@@ -26,6 +26,7 @@ import {
   validateFactMetricRowFilterSql,
 } from "back-end/src/services/factMetricRowFilterValidation";
 import { projectFilterQuery } from "back-end/src/util/mongo.util";
+import { validateAggregationSpecification } from "back-end/src/api/fact-metrics/postFactMetric";
 import { MakeModelClass } from "./BaseModel";
 import { getDataSourceById } from "./DataSourceModel";
 import { getFactTableMap } from "./FactTableModel";
@@ -344,6 +345,18 @@ export class FactMetricModel extends BaseClass {
       filterType: "numerator",
     });
 
+    // Validate aggregation/datatype constraints (runs for every code path
+    // that hits BaseModel — internal UI controllers, external API,
+    // bulk import, etc.)
+    validateAggregationSpecification({
+      errorPrefix: "Numerator misspecified. ",
+      column: data.numerator,
+      factTable: numeratorFactTable,
+      metricType: data.metricType,
+      quantileType: data.quantileSettings?.type,
+      quantileIgnoreZeros: data.quantileSettings?.ignoreZeros,
+    });
+
     // validate column
     const metricSupportsDistinctDates =
       data.metricType === "mean" ||
@@ -394,6 +407,15 @@ export class FactMetricModel extends BaseClass {
         columnRef: data.denominator,
         factTable: denominatorFactTable,
         filterType: "denominator",
+      });
+
+      validateAggregationSpecification({
+        errorPrefix: "Denominator misspecified. ",
+        column: data.denominator,
+        factTable: denominatorFactTable,
+        metricType: data.metricType,
+        quantileType: data.quantileSettings?.type,
+        quantileIgnoreZeros: data.quantileSettings?.ignoreZeros,
       });
     } else if (data.denominator?.factTableId) {
       throw new Error("Denominator not allowed for non-ratio metric");

--- a/packages/back-end/src/services/bigquery.ts
+++ b/packages/back-end/src/services/bigquery.ts
@@ -54,8 +54,10 @@ export function getFactTableTypeFromBigQueryType(
 
     case "RANGE":
     case "GEOGRAPHY":
-    case "BYTES":
       return "other";
+
+    case "BYTES":
+      return "binary";
 
     default: {
       const _: never = dataType;

--- a/packages/back-end/src/services/factMetricAggregationValidation.ts
+++ b/packages/back-end/src/services/factMetricAggregationValidation.ts
@@ -1,0 +1,123 @@
+import { getSelectedColumnDatatype } from "shared/experiments";
+import {
+  ColumnRef,
+  FactMetricType,
+  FactTableInterface,
+} from "shared/types/fact-table";
+import { getKllEventCountSourceColumn } from "back-end/src/services/factMetrics";
+
+export function validateAggregationSpecification({
+  column,
+  factTable,
+  metricType,
+  quantileType,
+  quantileIgnoreZeros,
+  quantileEventCountColumn,
+  errorPrefix,
+}: {
+  column: ColumnRef;
+  factTable: FactTableInterface;
+  metricType: FactMetricType;
+  quantileType: "unit" | "event" | undefined;
+  quantileIgnoreZeros: boolean | undefined;
+  quantileEventCountColumn: string | undefined;
+  errorPrefix: string;
+}) {
+  const datatype = getSelectedColumnDatatype({
+    factTable,
+    column: column.column,
+  });
+  if (column.aggregation === "count distinct" && datatype !== "string") {
+    throw new Error(
+      `${errorPrefix}Cannot use 'count distinct' aggregation with the special or numeric column '${column.column}'.`,
+    );
+  }
+  if (
+    (column.aggregation === "hll merge" ||
+      column.aggregation === "kll merge") &&
+    datatype !== "binary"
+  ) {
+    throw new Error(
+      `${errorPrefix}Cannot use '${column.aggregation}' aggregation with the ${datatype || "unknown"} column '${column.column}'. The column must have a binary datatype (e.g. BigQuery BYTES).`,
+    );
+  }
+  if (datatype === "string" && column.aggregation !== "count distinct") {
+    throw new Error(
+      `${errorPrefix}Must use 'count distinct' aggregation with string column '${column.column}'.`,
+    );
+  }
+  if (
+    datatype === "binary" &&
+    column.aggregation !== "hll merge" &&
+    column.aggregation !== "kll merge"
+  ) {
+    throw new Error(
+      `${errorPrefix}Must use 'hll merge' or 'kll merge' aggregation with binary column '${column.column}'.`,
+    );
+  }
+  // 'kll merge' is only meaningful in event-quantile metrics — the
+  // back-end aggregation pipeline silently falls through to a SUM in
+  // any other context (which would produce broken SQL on a binary
+  // sketch column). Block it at the API boundary when we have enough
+  // context to tell.
+  if (
+    column.aggregation === "kll merge" &&
+    metricType !== undefined &&
+    (metricType !== "quantile" || quantileType !== "event")
+  ) {
+    throw new Error(
+      `${errorPrefix}'kll merge' aggregation is only valid for event-quantile metrics (metricType=quantile, quantileSettings.type=event).`,
+    );
+  }
+  // `ignoreZeros` cannot be applied when re-aggregating pre-built KLL
+  // sketches: the zero-filtering must happen in the upstream pipeline
+  // that built the sketch (we can no longer see individual event
+  // values). Reject explicit attempts to combine the two.
+  if (column.aggregation === "kll merge" && quantileIgnoreZeros) {
+    throw new Error(
+      `${errorPrefix}'ignoreZeros' is not supported with 'kll merge' aggregation. Filter zero-valued events before building the KLL sketch in your source pipeline.`,
+    );
+  }
+  // KLL sketches do not expose an internal "items inserted" count via any
+  // current SQL engine. To recover per-user event counts (needed for the
+  // cluster-aware variance estimator and the two-pass rank recovery in
+  // kllRankApprox) we require the user to materialize a paired count column
+  // of numeric datatype alongside the sketch column on the same fact table.
+  // Default name: `<sketch>_n_events`. The metric author can override that
+  // default via quantileSettings.quantileEventCountColumn — useful when their
+  // upstream pipeline already emits a count under a different name.
+  if (column.aggregation === "kll merge") {
+    const expectedNEventsColumn = getKllEventCountSourceColumn({
+      column,
+      quantileEventCountColumn,
+    });
+    const overrideUsed =
+      !!quantileEventCountColumn && quantileEventCountColumn.trim().length > 0;
+    const pairedColumn = factTable.columns.find(
+      (c) => c.column === expectedNEventsColumn && !c.deleted,
+    );
+    if (!pairedColumn) {
+      throw new Error(
+        overrideUsed
+          ? `${errorPrefix}quantileSettings.quantileEventCountColumn references '${expectedNEventsColumn}', which does not exist on the fact table. Add it as a numeric column or remove the override.`
+          : `${errorPrefix}'kll merge' on column '${column.column}' requires a paired event-count column named '${expectedNEventsColumn}' on the same fact table. Add it as a numeric column, or set quantileSettings.quantileEventCountColumn to point at an existing one.`,
+      );
+    }
+    if (pairedColumn.datatype !== "number") {
+      throw new Error(
+        `${errorPrefix}Paired event-count column '${expectedNEventsColumn}' must have a numeric datatype (got '${pairedColumn.datatype || "unknown"}').`,
+      );
+    }
+  } else if (
+    quantileEventCountColumn !== undefined &&
+    quantileEventCountColumn !== ""
+  ) {
+    // The override is only meaningful for 'kll merge'. Any other context (raw
+    // event quantiles, unit quantiles, non-quantile metrics) computes
+    // n_events from the row stream itself, so a custom source column has no
+    // semantics. Reject explicit attempts to combine the two.
+    throw new Error(
+      `${errorPrefix}quantileSettings.quantileEventCountColumn is only valid when numerator.aggregation === 'kll merge'.`,
+    );
+  }
+}

--- a/packages/back-end/src/services/factMetricAggregationValidation.ts
+++ b/packages/back-end/src/services/factMetricAggregationValidation.ts
@@ -69,6 +69,22 @@ export function validateAggregationSpecification({
       `${errorPrefix}'kll merge' aggregation is only valid for event-quantile metrics (metricType=quantile, quantileSettings.type=event).`,
     );
   }
+  // Inverse of the guard above: an event-quantile metric on a binary
+  // (sketch) column MUST use 'kll merge'. Other binary aggregations
+  // (currently just 'hll merge') don't produce a quantile and would
+  // otherwise fall through to APPROX_PERCENTILE over raw BYTES in
+  // __eventQuantileMetric — the warehouse rejects this at runtime with
+  // an opaque type error rather than a clear API-level message.
+  if (
+    metricType === "quantile" &&
+    quantileType === "event" &&
+    datatype === "binary" &&
+    column.aggregation !== "kll merge"
+  ) {
+    throw new Error(
+      `${errorPrefix}Event-quantile metrics on the binary column '${column.column}' must use 'kll merge' aggregation (got '${column.aggregation}').`,
+    );
+  }
   // `ignoreZeros` cannot be applied when re-aggregating pre-built KLL
   // sketches: the zero-filtering must happen in the upstream pipeline
   // that built the sketch (we can no longer see individual event

--- a/packages/back-end/src/services/factMetrics.ts
+++ b/packages/back-end/src/services/factMetrics.ts
@@ -1,0 +1,11 @@
+import type { ColumnRef } from "shared/types/fact-table";
+
+export function getKllEventCountSourceColumn({
+  column,
+  quantileEventCountColumn,
+}: {
+  column: ColumnRef;
+  quantileEventCountColumn?: string | null;
+}): string {
+  return quantileEventCountColumn?.trim() || `${column.column}_n_events`;
+}

--- a/packages/back-end/test/integrations/BigQuery.test.ts
+++ b/packages/back-end/test/integrations/BigQuery.test.ts
@@ -172,6 +172,24 @@ describe("BigQuery KLL quantile sketch methods", () => {
       "KLL_QUANTILES.MERGE_PARTIAL(col)",
     );
   });
+
+  it("throws for quantile metrics without quantileSettings", () => {
+    const metric = factMetricFactory.build({
+      id: "fact_missing_quantile_settings",
+      metricType: "quantile",
+      quantileSettings: null,
+      numerator: { factTableId: "ft1", column: "amount" },
+    });
+
+    expect(() =>
+      getAggregationMetadata(integration.getSqlDialect(), {
+        metric,
+        useDenominator: false,
+      }),
+    ).toThrow(
+      "Quantile metric 'fact_missing_quantile_settings' is missing quantileSettings.",
+    );
+  });
 });
 
 describe("BigQuery pre-built sketch column aggregations (hll merge / kll merge)", () => {

--- a/packages/back-end/test/integrations/BigQuery.test.ts
+++ b/packages/back-end/test/integrations/BigQuery.test.ts
@@ -167,6 +167,87 @@ describe("BigQuery KLL quantile sketch methods", () => {
   });
 });
 
+describe("BigQuery pre-built sketch column aggregations (hll merge / kll merge)", () => {
+  let integration: BigQuery;
+
+  beforeEach(() => {
+    // @ts-expect-error -- context/datasource not needed for this unit test
+    integration = new BigQuery("", {});
+  });
+
+  it("merges pre-built HLL sketch columns (not INIT) for 'hll merge'", () => {
+    const metric = factMetricFactory.build({
+      metricType: "mean",
+      numerator: {
+        factTableId: "ft1",
+        column: "session_id_hll",
+        aggregation: "hll merge",
+      },
+    });
+    const metadata = getAggregationMetadata(integration.getSqlDialect(), {
+      metric,
+      useDenominator: false,
+    });
+    expect(metadata.intermediateDataType).toBe("hll");
+    expect(metadata.finalDataType).toBe("integer");
+    // Partial step must MERGE the existing sketch, never INIT a new one.
+    const partial = metadata.partialAggregationFunction("col");
+    expect(partial).toContain("HLL_COUNT.MERGE_PARTIAL(col)");
+    expect(partial).not.toContain("HLL_COUNT.INIT");
+    // Re-agg and full-agg both extract cardinality from a merged sketch.
+    expect(metadata.reAggregationFunction("col")).toBe(
+      "HLL_COUNT.EXTRACT(HLL_COUNT.MERGE_PARTIAL(col))",
+    );
+    expect(metadata.fullAggregationFunction("col")).toBe(
+      "HLL_COUNT.EXTRACT(HLL_COUNT.MERGE_PARTIAL(col))",
+    );
+  });
+
+  it("merges pre-built KLL sketch columns (not INIT) for event-quantile 'kll merge'", () => {
+    const metric = factMetricFactory.build({
+      metricType: "quantile",
+      quantileSettings: { type: "event", quantile: 0.9, ignoreZeros: false },
+      numerator: {
+        factTableId: "ft1",
+        column: "latency_ms_kll",
+        aggregation: "kll merge",
+      },
+    });
+    const metadata = getAggregationMetadata(integration.getSqlDialect(), {
+      metric,
+      useDenominator: false,
+    });
+    expect(metadata.intermediateDataType).toBe("kll");
+    // Partial step must MERGE_PARTIAL the existing sketch, never INIT.
+    expect(metadata.partialAggregationFunction("col")).toBe(
+      "KLL_QUANTILES.MERGE_PARTIAL(col)",
+    );
+    expect(metadata.partialAggregationFunction("col")).not.toContain(
+      "INIT_FLOAT64",
+    );
+    expect(metadata.reAggregationFunction("col")).toBe(
+      "KLL_QUANTILES.MERGE_PARTIAL(col)",
+    );
+  });
+
+  it("ignores 'kll merge' for non-event-quantile metrics (falls through to sum)", () => {
+    // Guard: kll merge only applies when metricType=quantile && type=event.
+    const metric = factMetricFactory.build({
+      metricType: "mean",
+      numerator: {
+        factTableId: "ft1",
+        column: "latency_ms_kll",
+        aggregation: "kll merge",
+      },
+    });
+    const metadata = getAggregationMetadata(integration.getSqlDialect(), {
+      metric,
+      useDenominator: false,
+    });
+    expect(metadata.intermediateDataType).toBe("float");
+  });
+});
+
 describe("BigQuery KLL incremental refresh SQL generation (E2E)", () => {
   let integration: BigQuery;
 
@@ -266,6 +347,31 @@ describe("BigQuery KLL incremental refresh SQL generation (E2E)", () => {
     expect(sql).toContain("KLL_QUANTILES.INIT_FLOAT64");
     // Companion count emitted alongside the sketch
     expect(sql).toMatch(/COUNT\([^)]+\)\s+AS\s+\w+_n_events/);
+  });
+
+  it("getInsertMetricSourceDataQuery emits KLL MERGE_PARTIAL (not INIT) for 'kll merge' columns", () => {
+    const prebuiltSketchMetric = factMetricFactory.build({
+      id: "fact_eq_sketch",
+      metricType: "quantile",
+      quantileSettings: { type: "event", quantile: 0.9, ignoreZeros: false },
+      numerator: {
+        factTableId: "ft_events",
+        column: "latency_ms_kll",
+        aggregation: "kll merge",
+      },
+    });
+    const sql = integration.getInsertMetricSourceDataQuery({
+      settings,
+      activationMetric: null,
+      factTableMap,
+      metricSourceTableFullName: "proj.ds.metric_source",
+      unitsSourceTableFullName: "proj.ds.units",
+      metrics: [prebuiltSketchMetric],
+      lastMaxTimestamp: null,
+    });
+    // Partial aggregation merges the pre-built sketch; must not INIT.
+    expect(sql).toContain("KLL_QUANTILES.MERGE_PARTIAL");
+    expect(sql).not.toContain("KLL_QUANTILES.INIT_FLOAT64");
   });
 
   it("getIncrementalRefreshStatisticsQuery emits two-pass KLL rank recovery CTEs", () => {

--- a/packages/back-end/test/integrations/BigQuery.test.ts
+++ b/packages/back-end/test/integrations/BigQuery.test.ts
@@ -3,6 +3,7 @@ import { ExposureQuery } from "shared/types/datasource";
 import BigQuery from "back-end/src/integrations/BigQuery";
 import { getAggregationMetadata } from "back-end/src/integrations/sql/fact-metrics/aggregation-metadata";
 import { N_STAR_VALUES } from "back-end/src/services/experimentQueries/constants";
+import { getFactTableTypeFromBigQueryType } from "back-end/src/services/bigquery";
 import { factTableFactory } from "../factories/FactTable.factory";
 import { factMetricFactory } from "../factories/FactMetric.factory";
 
@@ -69,6 +70,12 @@ describe("BigQuery reservation job config", () => {
       useLegacySql: false,
     });
     expect(queryJobConfig).not.toHaveProperty("reservation");
+  });
+});
+
+describe("BigQuery type mapping", () => {
+  it("maps BYTES to binary fact table datatype", () => {
+    expect(getFactTableTypeFromBigQueryType("BYTES")).toBe("binary");
   });
 });
 
@@ -374,6 +381,34 @@ describe("BigQuery KLL incremental refresh SQL generation (E2E)", () => {
     expect(sql).not.toContain("KLL_QUANTILES.INIT_FLOAT64");
   });
 
+  it("getInsertMetricSourceDataQuery sources n_events from paired '<col>_n_events' (not COUNT) for 'kll merge'", () => {
+    const prebuiltSketchMetric = factMetricFactory.build({
+      id: "fact_eq_sketch_paired",
+      metricType: "quantile",
+      quantileSettings: { type: "event", quantile: 0.9, ignoreZeros: false },
+      numerator: {
+        factTableId: "ft_events",
+        column: "latency_ms_kll",
+        aggregation: "kll merge",
+      },
+    });
+    const sql = integration.getInsertMetricSourceDataQuery({
+      settings,
+      activationMetric: null,
+      factTableMap,
+      metricSourceTableFullName: "proj.ds.metric_source",
+      unitsSourceTableFullName: "proj.ds.units",
+      metrics: [prebuiltSketchMetric],
+      lastMaxTimestamp: null,
+    });
+    // The paired count column must be projected from the source fact table
+    // and SUM-aggregated for n_events. COUNT(<col>_value) would be wrong:
+    // each row is a pre-aggregated sketch covering many events.
+    expect(sql).toContain("latency_ms_kll_n_events");
+    expect(sql).toMatch(/SUM\(COALESCE\([^)]+_n_events,\s*0\)\)\s+AS\s+\w+_n_events/);
+    expect(sql).not.toMatch(/COUNT\([^)]+\)\s+AS\s+\w+_n_events/);
+  });
+
   it("getIncrementalRefreshStatisticsQuery emits two-pass KLL rank recovery CTEs", () => {
     const sql = integration.getIncrementalRefreshStatisticsQuery({
       settings,
@@ -411,5 +446,69 @@ describe("BigQuery KLL incremental refresh SQL generation (E2E)", () => {
     expect(sketchPos).toBeGreaterThan(0);
     expect(gridPos).toBeGreaterThan(sketchPos);
     expect(joinedPos).toBeGreaterThan(gridPos);
+  });
+
+  it("getExperimentFactMetricsQuery uses kll grid extraction and post-aggregation rank recovery for 'kll merge' event quantiles", () => {
+    const prebuiltSketchMetric = factMetricFactory.build({
+      id: "fact_eq_sketch_xp",
+      metricType: "quantile",
+      quantileSettings: { type: "event", quantile: 0.9, ignoreZeros: false },
+      numerator: {
+        factTableId: "ft_events",
+        column: "latency_ms_kll",
+        aggregation: "kll merge",
+      },
+    });
+    const sql = integration.getExperimentFactMetricsQuery({
+      settings,
+      activationMetric: null,
+      dimensions: [],
+      segment: null,
+      factTableMap,
+      metrics: [prebuiltSketchMetric],
+      unitsSource: "exposureQuery",
+    });
+
+    // __eventQuantileMetric must extract the quantile grid from a merged
+    // KLL sketch, not from raw values via APPROX_PERCENTILE.
+    expect(sql).toContain("__eventQuantileMetric");
+    // After format/indent, EXTRACT_POINT_FLOAT64(KLL_QUANTILES.MERGE_PARTIAL(...))
+    // can split across lines AND the formatter inserts spaces between the
+    // function name and its opening paren. Collapse whitespace and allow
+    // optional spaces around parens before matching.
+    const flat = sql.replace(/\s+/g, " ");
+    expect(flat).toMatch(
+      /KLL_QUANTILES\.EXTRACT_POINT_FLOAT64\s*\(\s*KLL_QUANTILES\.MERGE_PARTIAL/,
+    );
+    // __userMetricAgg must wrap its per-user GROUP BY in a base subquery
+    // and recover per-user "count below threshold" via kllRankApprox.
+    // EXTRACT_FLOAT64 (the cdfArray construction) is the tell-tale sign.
+    expect(sql).toContain("KLL_QUANTILES.EXTRACT_FLOAT64");
+    expect(flat).toMatch(/\)\s+base\s+LEFT\s+JOIN\s+__eventQuantileMetric/i);
+    // n_events must come from the paired count column, not COUNT(rows).
+    expect(flat).toMatch(
+      /SUM\(COALESCE\([^)]+_n_events,\s*0\)\)\s+AS\s+\w+_n_events/,
+    );
+  });
+
+  it("getExperimentFactMetricsQuery falls back to APPROX_QUANTILES (no kll wrapper) for raw event quantiles", () => {
+    const sql = integration.getExperimentFactMetricsQuery({
+      settings,
+      activationMetric: null,
+      dimensions: [],
+      segment: null,
+      factTableMap,
+      metrics: [eventQuantileMetric],
+      unitsSource: "exposureQuery",
+    });
+
+    // Raw event quantile uses APPROX_QUANTILES on the per-event values, no
+    // KLL extraction or rank-recovery wrapper.
+    expect(sql).toContain("APPROX_QUANTILES");
+    expect(sql).not.toContain("KLL_QUANTILES.EXTRACT_FLOAT64");
+    const flat = sql.replace(/\s+/g, " ");
+    expect(flat).not.toMatch(
+      /\)\s+base\s+LEFT\s+JOIN\s+__eventQuantileMetric/i,
+    );
   });
 });

--- a/packages/back-end/test/integrations/BigQuery.test.ts
+++ b/packages/back-end/test/integrations/BigQuery.test.ts
@@ -537,15 +537,27 @@ describe("BigQuery KLL incremental refresh SQL generation (E2E)", () => {
     expect(flat).toMatch(
       /KLL_QUANTILES\.EXTRACT_POINT_FLOAT64\s*\(\s*KLL_QUANTILES\.MERGE_PARTIAL/,
     );
-    // __userMetricAgg must wrap its per-user GROUP BY in a base subquery
-    // and recover per-user "count below threshold" via kllRankApprox.
-    // EXTRACT_FLOAT64 (the cdfArray construction) is the tell-tale sign.
+    // The per-user aggregation lives in __userMetricAggBase; __userMetricAgg
+    // is a thin wrapper that joins __userMetricAggBase against
+    // __eventQuantileMetric to recover per-user "count below threshold" via
+    // kllRankApprox. EXTRACT_FLOAT64 (the cdfArray construction) is the
+    // tell-tale sign of kllRankApprox.
+    expect(sql).toContain("__userMetricAggBase");
     expect(sql).toContain("KLL_QUANTILES.EXTRACT_FLOAT64");
-    expect(flat).toMatch(/\)\s+base\s+LEFT\s+JOIN\s+__eventQuantileMetric/i);
+    expect(flat).toMatch(
+      /FROM\s+__userMetricAggBase\s+base\s+LEFT\s+JOIN\s+__eventQuantileMetric/i,
+    );
     // n_events must come from the paired count column, not COUNT(rows).
     expect(flat).toMatch(
       /SUM\(COALESCE\([^)]+_n_events,\s*0\)\)\s+AS\s+\w+_n_events/,
     );
+    // KLL is mergeable, so __userMetricJoin should be scanned exactly once:
+    // __eventQuantileMetric reads merged per-user sketches from
+    // __userMetricAggBase rather than re-scanning per-event sketches.
+    const userMetricJoinFromCount = (
+      flat.match(/FROM\s+__userMetricJoin\b/gi) || []
+    ).length;
+    expect(userMetricJoinFromCount).toBe(1);
   });
 
   it("getExperimentFactMetricsQuery falls back to APPROX_QUANTILES (no kll wrapper) for raw event quantiles", () => {
@@ -563,9 +575,8 @@ describe("BigQuery KLL incremental refresh SQL generation (E2E)", () => {
     // KLL extraction or rank-recovery wrapper.
     expect(sql).toContain("APPROX_QUANTILES");
     expect(sql).not.toContain("KLL_QUANTILES.EXTRACT_FLOAT64");
-    const flat = sql.replace(/\s+/g, " ");
-    expect(flat).not.toMatch(
-      /\)\s+base\s+LEFT\s+JOIN\s+__eventQuantileMetric/i,
-    );
+    // No KLL merge metrics → the per-user aggregation goes directly into
+    // __userMetricAgg without the __userMetricAggBase wrapper.
+    expect(sql).not.toContain("__userMetricAggBase");
   });
 });

--- a/packages/back-end/test/integrations/BigQuery.test.ts
+++ b/packages/back-end/test/integrations/BigQuery.test.ts
@@ -405,8 +405,47 @@ describe("BigQuery KLL incremental refresh SQL generation (E2E)", () => {
     // and SUM-aggregated for n_events. COUNT(<col>_value) would be wrong:
     // each row is a pre-aggregated sketch covering many events.
     expect(sql).toContain("latency_ms_kll_n_events");
-    expect(sql).toMatch(/SUM\(COALESCE\([^)]+_n_events,\s*0\)\)\s+AS\s+\w+_n_events/);
+    expect(sql).toMatch(
+      /SUM\(COALESCE\([^)]+_n_events,\s*0\)\)\s+AS\s+\w+_n_events/,
+    );
     expect(sql).not.toMatch(/COUNT\([^)]+\)\s+AS\s+\w+_n_events/);
+  });
+
+  it("getInsertMetricSourceDataQuery honors quantileSettings.quantileEventCountColumn override", () => {
+    // The override lets users name the paired count column anything (not
+    // just `<sketch>_n_events`). SQL generation should source from the
+    // override column verbatim.
+    const overrideMetric = factMetricFactory.build({
+      id: "fact_eq_sketch_override",
+      metricType: "quantile",
+      quantileSettings: {
+        type: "event",
+        quantile: 0.9,
+        ignoreZeros: false,
+        quantileEventCountColumn: "rollup_event_count",
+      },
+      numerator: {
+        factTableId: "ft_events",
+        column: "latency_ms_kll",
+        aggregation: "kll merge",
+      },
+    });
+    const sql = integration.getInsertMetricSourceDataQuery({
+      settings,
+      activationMetric: null,
+      factTableMap,
+      metricSourceTableFullName: "proj.ds.metric_source",
+      unitsSourceTableFullName: "proj.ds.units",
+      metrics: [overrideMetric],
+      lastMaxTimestamp: null,
+    });
+    // Override column is projected as the n_events source.
+    expect(sql).toContain("rollup_event_count");
+    // The default convention name must NOT appear when override is set.
+    expect(sql).not.toContain("latency_ms_kll_n_events");
+    expect(sql).toMatch(
+      /SUM\(COALESCE\([^)]+_n_events,\s*0\)\)\s+AS\s+\w+_n_events/,
+    );
   });
 
   it("getIncrementalRefreshStatisticsQuery emits two-pass KLL rank recovery CTEs", () => {

--- a/packages/front-end/components/FactTables/ColumnModal.tsx
+++ b/packages/front-end/components/FactTables/ColumnModal.tsx
@@ -354,6 +354,10 @@ export default function ColumnModal({ existing, factTable, close }: Props) {
             value: "json",
           },
           {
+            label: "Binary",
+            value: "binary",
+          },
+          {
             label: "Other",
             value: "other",
           },
@@ -480,6 +484,10 @@ export default function ColumnModal({ existing, factTable, close }: Props) {
                                 {
                                   label: "Boolean",
                                   value: "boolean",
+                                },
+                                {
+                                  label: "Binary",
+                                  value: "binary",
                                 },
                                 {
                                   label: "Other",

--- a/packages/front-end/components/FactTables/FactMetricList.tsx
+++ b/packages/front-end/components/FactTables/FactMetricList.tsx
@@ -11,7 +11,7 @@ import { tagLinkProps, useSearch } from "@/services/search";
 import { useDefinitions } from "@/services/DefinitionsContext";
 import { useUser } from "@/services/UserContext";
 import Field from "@/components/Forms/Field";
-import Tooltip from "@/components/Tooltip/Tooltip";
+import Tooltip from "@/ui/Tooltip";
 import SortedTags from "@/components/Tags/SortedTags";
 import MetricName from "@/components/Metrics/MetricName";
 import FactMetricTypeDisplayName from "@/components/Metrics/FactMetricTypeDisplayName";
@@ -85,36 +85,31 @@ function FactMetricRowMenu({
       menuPlacement="end"
     >
       <DropdownMenuGroup>
-        {canEditMenu && (
+        {(canEditMenu || canShowDisabledEdit) && (
           <DropdownMenuItem
             onClick={() => {
               onEdit();
               setOpen(false);
             }}
+            disabled={canShowDisabledEdit}
           >
-            Edit
-          </DropdownMenuItem>
-        )}
-        {canShowDisabledEdit && (
-          <DropdownMenuItem disabled>
-            <Tooltip body={editDisabledReason}>
+            <Tooltip content={editDisabledReason} enabled={canShowDisabledEdit}>
               <span>Edit</span>
             </Tooltip>
           </DropdownMenuItem>
         )}
-        {canDuplicateMenu && (
+        {(canDuplicateMenu || canShowDisabledDuplicate) && (
           <DropdownMenuItem
             onClick={() => {
               onDuplicate();
               setOpen(false);
             }}
+            disabled={canShowDisabledDuplicate}
           >
-            Duplicate
-          </DropdownMenuItem>
-        )}
-        {canShowDisabledDuplicate && (
-          <DropdownMenuItem disabled>
-            <Tooltip body={editDisabledReason}>
+            <Tooltip
+              content={editDisabledReason}
+              enabled={canShowDisabledDuplicate}
+            >
               <span>Duplicate</span>
             </Tooltip>
           </DropdownMenuItem>
@@ -322,11 +317,8 @@ export default function FactMetricList({
         )}
         <div className="col-auto ml-auto">
           <Tooltip
-            body={
-              canCreateMetrics
-                ? ""
-                : `You don't have permission to add metrics to this fact table`
-            }
+            content={`You don't have permission to add metrics to this fact table`}
+            enabled={!canCreateMetrics}
           >
             <Button
               onClick={() => {
@@ -409,7 +401,7 @@ export default function FactMetricList({
                                 style={{ whiteSpace: "nowrap" }}
                               >
                                 <Tooltip
-                                  body={
+                                  content={
                                     hasNoLevels
                                       ? "No slice levels configured"
                                       : levels?.join(", ") || "No levels"
@@ -454,9 +446,6 @@ export default function FactMetricList({
                     {metric.dateUpdated ? date(metric.dateUpdated) : null}
                   </td>
                   <td>
-                    {/*
-                      KLL/HLL merge metrics must be edited via REST API.
-                    */}
                     <FactMetricRowMenu
                       metric={metric}
                       canEdit={canEdit(metric)}

--- a/packages/front-end/components/FactTables/FactMetricList.tsx
+++ b/packages/front-end/components/FactTables/FactMetricList.tsx
@@ -30,20 +30,11 @@ import {
   DropdownMenuItem,
   DropdownMenuSeparator,
 } from "@/ui/DropdownMenu";
+import {
+  isMergeAggregationMetric,
+  REST_API_ONLY_EDIT_MESSAGE,
+} from "@/services/factMetrics";
 import FactMetricModal from "./FactMetricModal";
-
-const REST_API_ONLY_EDIT_MESSAGE =
-  "This is a metric that can only be managed via the REST API";
-
-function isMergeAggregationMetric(metric: FactMetricInterface): boolean {
-  const aggregations = [
-    metric.numerator.aggregation,
-    metric.denominator?.aggregation,
-  ];
-  return aggregations.some((aggregation) =>
-    ["kll merge", "hll merge"].includes(aggregation || ""),
-  );
-}
 
 function FactMetricRowMenu({
   metric,

--- a/packages/front-end/components/FactTables/FactMetricList.tsx
+++ b/packages/front-end/components/FactTables/FactMetricList.tsx
@@ -69,6 +69,12 @@ function FactMetricRowMenu({
     canEdit && !metric.archived && !editDisabledReason && !!onEdit;
   const canShowDisabledEdit =
     canEdit && !metric.archived && !!editDisabledReason;
+  // Duplicate uses the same FactMetricModal as Edit, so anything that locks
+  // editing to the REST API also has to lock Duplicate — otherwise a user
+  // could open a half-broken modal pre-filled with values the picker can no
+  // longer represent.
+  const canDuplicateMenu = canDuplicate && !editDisabledReason;
+  const canShowDisabledDuplicate = canDuplicate && !!editDisabledReason;
 
   return (
     <DropdownMenu
@@ -105,7 +111,7 @@ function FactMetricRowMenu({
             </Tooltip>
           </DropdownMenuItem>
         )}
-        {canDuplicate && (
+        {canDuplicateMenu && (
           <DropdownMenuItem
             onClick={() => {
               onDuplicate();
@@ -113,6 +119,13 @@ function FactMetricRowMenu({
             }}
           >
             Duplicate
+          </DropdownMenuItem>
+        )}
+        {canShowDisabledDuplicate && (
+          <DropdownMenuItem disabled>
+            <Tooltip body={editDisabledReason}>
+              <span>Duplicate</span>
+            </Tooltip>
           </DropdownMenuItem>
         )}
         {canEdit && (

--- a/packages/front-end/components/FactTables/FactMetricList.tsx
+++ b/packages/front-end/components/FactTables/FactMetricList.tsx
@@ -32,6 +32,19 @@ import {
 } from "@/ui/DropdownMenu";
 import FactMetricModal from "./FactMetricModal";
 
+const REST_API_ONLY_EDIT_MESSAGE =
+  "This is a metric that can only be managed via the REST API";
+
+function isMergeAggregationMetric(metric: FactMetricInterface): boolean {
+  const aggregations = [
+    metric.numerator.aggregation,
+    metric.denominator?.aggregation,
+  ];
+  return aggregations.some((aggregation) =>
+    ["kll merge", "hll merge"].includes(aggregation || ""),
+  );
+}
+
 function FactMetricRowMenu({
   metric,
   canEdit,
@@ -39,6 +52,7 @@ function FactMetricRowMenu({
   canDuplicate,
   onEdit,
   onDuplicate,
+  editDisabledReason,
 }: {
   metric: FactMetricInterface;
   canEdit: boolean;
@@ -46,10 +60,15 @@ function FactMetricRowMenu({
   canDuplicate: boolean;
   onEdit: () => void;
   onDuplicate: () => void;
+  editDisabledReason?: string;
 }) {
   const [open, setOpen] = useState(false);
   const { apiCall } = useAuth();
   const { mutateDefinitions } = useDefinitions();
+  const canEditMenu =
+    canEdit && !metric.archived && !editDisabledReason && !!onEdit;
+  const canShowDisabledEdit =
+    canEdit && !metric.archived && !!editDisabledReason;
 
   return (
     <DropdownMenu
@@ -69,7 +88,7 @@ function FactMetricRowMenu({
       menuPlacement="end"
     >
       <DropdownMenuGroup>
-        {canEdit && (
+        {canEditMenu && (
           <DropdownMenuItem
             onClick={() => {
               onEdit();
@@ -77,6 +96,13 @@ function FactMetricRowMenu({
             }}
           >
             Edit
+          </DropdownMenuItem>
+        )}
+        {canShowDisabledEdit && (
+          <DropdownMenuItem disabled>
+            <Tooltip body={editDisabledReason}>
+              <span>Edit</span>
+            </Tooltip>
           </DropdownMenuItem>
         )}
         {canDuplicate && (
@@ -424,12 +450,20 @@ export default function FactMetricList({
                     {metric.dateUpdated ? date(metric.dateUpdated) : null}
                   </td>
                   <td>
+                    {/*
+                      KLL/HLL merge metrics must be edited via REST API.
+                    */}
                     <FactMetricRowMenu
                       metric={metric}
                       canEdit={canEdit(metric)}
                       canDelete={canDelete(metric)}
                       canDuplicate={canCreateMetrics}
                       onEdit={() => setEditMetric(metric)}
+                      editDisabledReason={
+                        isMergeAggregationMetric(metric)
+                          ? REST_API_ONLY_EDIT_MESSAGE
+                          : undefined
+                      }
                       onDuplicate={() =>
                         setDuplicateMetric({
                           ...metric,

--- a/packages/front-end/components/FactTables/FactMetricModal.tsx
+++ b/packages/front-end/components/FactTables/FactMetricModal.tsx
@@ -493,8 +493,7 @@ function ColumnRefSelector({
       (aggregationType === "unit" &&
         metricType !== "quantile" &&
         !!datasource.properties?.hasCountDistinctHLL) ||
-      (aggregationType === "event" &&
-        !!datasource.properties?.hasQuantileKLL),
+      (aggregationType === "event" && !!datasource.properties?.hasQuantileKLL),
     includeJSONFields: true,
   });
 
@@ -1618,7 +1617,23 @@ export default function FactMetricModal({
               ignoreZeros: false,
             };
             values.numerator.aggregation = "kll merge";
+          } else if (values.quantileSettings?.quantileEventCountColumn) {
+            // Strip the kll-merge override if the metric is no longer using
+            // a binary numerator. The back-end validator rejects this
+            // combination, so clearing it here keeps form submissions valid
+            // when a user toggles the numerator off a sketch column.
+            values.quantileSettings = {
+              ...values.quantileSettings,
+              quantileEventCountColumn: undefined,
+            };
           }
+        } else if (values.quantileSettings?.quantileEventCountColumn) {
+          // Same defense for non-quantile metric types (e.g. user switched
+          // metricType after configuring the override).
+          values.quantileSettings = {
+            ...values.quantileSettings,
+            quantileEventCountColumn: undefined,
+          };
         }
 
         // reset aggregate filter for certain metrics

--- a/packages/front-end/components/FactTables/FactMetricModal.tsx
+++ b/packages/front-end/components/FactTables/FactMetricModal.tsx
@@ -166,15 +166,6 @@ function getNumericColumns(
   );
 }
 
-function getBinaryColumns(
-  factTable: FactTableInterface | null,
-): ColumnInterface[] {
-  if (!factTable) return [];
-  return factTable.columns.filter(
-    (col) => col.datatype === "binary" && !col.deleted,
-  );
-}
-
 function getColumnOptions({
   factTable,
   datasource,
@@ -185,7 +176,6 @@ function getColumnOptions({
   includeStringColumns = false,
   includeJSONFields = false,
   includeBooleanColumns = false,
-  includeBinaryColumns = false,
   showColumnsAsSums = false,
   excludeColumns,
   groupPrefix = "",
@@ -199,7 +189,6 @@ function getColumnOptions({
   includeStringColumns?: boolean;
   includeBooleanColumns?: boolean;
   includeJSONFields?: boolean;
-  includeBinaryColumns?: boolean;
   showColumnsAsSums?: boolean;
   excludeColumns?: Set<string>;
   groupPrefix?: string;
@@ -256,13 +245,6 @@ function getColumnOptions({
       })),
     );
   }
-
-  const binaryColumnOptions: SingleValue[] = getBinaryColumns(factTable).map(
-    (col) => ({
-      label: col.name,
-      value: col.column,
-    }),
-  );
 
   // Add JSON fields
   if (includeJSONFields && factTable?.columns) {
@@ -329,12 +311,6 @@ function getColumnOptions({
       ),
     });
   }
-  if (includeBinaryColumns && binaryColumnOptions.length > 0) {
-    ret.push({
-      label: `${groupPrefix}Pre-Aggregated (Binary) Columns`,
-      options: binaryColumnOptions.filter((v) => !excludeColumns?.has(v.value)),
-    });
-  }
   return ret;
 }
 
@@ -349,20 +325,6 @@ function getAggregationOptions(
       {
         label: "Count Distinct",
         value: "count distinct",
-      },
-    ];
-  }
-
-  if (selectedColumnDatatype === "binary") {
-    // Binary columns are pre-aggregated sketches; the merge function is
-    // implied by the column's datatype (HLL for unit-level Count Distinct,
-    // KLL for event-quantile metrics — see ColumnRefSelector). Surface a
-    // single, plain-language option so users don't have to know the
-    // underlying merge primitive.
-    return [
-      {
-        label: "Count Distinct",
-        value: "hll merge",
       },
     ];
   }
@@ -441,7 +403,6 @@ function ColumnRefSelector({
   includeCountDistinct,
   includeDistinctDates,
   aggregationType = "unit",
-  metricType,
   includeColumn,
   datasource,
   disableFactTableSelector,
@@ -456,12 +417,6 @@ function ColumnRefSelector({
   includeDistinctDates?: boolean;
   includeColumn?: boolean;
   aggregationType?: "unit" | "event";
-  // Used to disambiguate binary-column semantics. Pre-aggregated KLL
-  // sketches only make sense in event-quantile metrics; pre-aggregated
-  // HLL sketches only make sense for non-quantile unit aggregations
-  // (mean / ratio). For unit-quantile pickers we therefore omit binary
-  // columns entirely — see getColumnOptions usage below.
-  metricType?: FactMetricType;
   datasource: DataSourceInterfaceWithParams;
   disableFactTableSelector?: boolean;
   extraField?: ReactElement;
@@ -482,18 +437,6 @@ function ColumnRefSelector({
     includeNumericColumns: true,
     includeStringColumns:
       datasource.properties?.hasCountDistinctHLL && aggregationType === "unit",
-    includeBinaryColumns:
-      // Pre-aggregated HLL sketches: shown alongside Count Distinct on
-      // non-quantile unit-aggregation pickers (mean / ratio). They are
-      // intentionally hidden from unit-quantile pickers because a binary
-      // column may hold either HLL or KLL bytes — there is no clean way
-      // to compute a per-user scalar from a KLL sketch that feeds a
-      // cross-user quantile.
-      // Pre-aggregated KLL sketches: shown for event-quantile pickers.
-      (aggregationType === "unit" &&
-        metricType !== "quantile" &&
-        !!datasource.properties?.hasCountDistinctHLL) ||
-      (aggregationType === "event" && !!datasource.properties?.hasQuantileKLL),
     includeJSONFields: true,
   });
 
@@ -593,18 +536,7 @@ function ColumnRefSelector({
 
                 if (newDatatype === "string") {
                   aggregation = "count distinct";
-                } else if (newDatatype === "binary") {
-                  // Pre-aggregated sketch column: pick the merge primitive
-                  // implied by the metric context. Event-quantile pickers
-                  // use KLL; everything else (mean / ratio Count Distinct)
-                  // uses HLL.
-                  aggregation =
-                    aggregationType === "event" ? "kll merge" : "hll merge";
-                } else if (
-                  aggregation === "count distinct" ||
-                  aggregation === "hll merge" ||
-                  aggregation === "kll merge"
-                ) {
+                } else if (aggregation === "count distinct") {
                   aggregation = "sum";
                 }
 
@@ -805,8 +737,7 @@ function getWHERE({
   if (
     type === "quantile" &&
     quantileSettings.type === "event" &&
-    quantileSettings.ignoreZeros &&
-    columnRef?.aggregation !== "kll merge"
+    quantileSettings.ignoreZeros
   ) {
     whereParts.push(`-- Ignore zeros in percentile\nvalue > 0`);
   }
@@ -854,13 +785,9 @@ function getPreviewSQL({
           ? "1"
           : numerator.aggregation === "count distinct"
             ? `COUNT(DISTINCT ${numerator.column})`
-            : numerator.aggregation === "hll merge"
-              ? `-- Pre-aggregated HLL sketch column\n  HLL_COUNT.MERGE(${numerator.column})`
-              : numerator.aggregation === "kll merge"
-                ? `-- Pre-aggregated KLL sketch column\n  KLL_QUANTILES.MERGE_PARTIAL(${numerator.column})`
-                : `${(numerator.aggregation ?? "sum").toUpperCase()}(${
-                    numerator.column
-                  })`;
+            : `${(numerator.aggregation ?? "sum").toUpperCase()}(${
+                numerator.column
+              })`;
   const numeratorAdjustment =
     type === "dailyParticipation" ? "\n\t/ CEIL(days_since_exposure)" : "";
 
@@ -871,13 +798,11 @@ function getPreviewSQL({
         ? "1"
         : denominator?.column === "$$distinctDates"
           ? `COUNT(DISTINCT DATE(timestamp))`
-          : denominator?.aggregation === "hll merge"
-            ? `-- Pre-aggregated HLL sketch column\n  HLL_COUNT.MERGE(${denominator?.column})`
-            : denominator?.aggregation === "count distinct"
-              ? `-- HyperLogLog estimation used instead of COUNT DISTINCT\n  COUNT(DISTINCT ${denominator?.column})`
-              : `${(denominator?.aggregation ?? "sum").toUpperCase()}(${
-                  denominator?.column
-                })`;
+          : denominator?.aggregation === "count distinct"
+            ? `-- HyperLogLog estimation used instead of COUNT DISTINCT\n  COUNT(DISTINCT ${denominator?.column})`
+            : `${(denominator?.aggregation ?? "sum").toUpperCase()}(${
+                denominator?.column
+              })`;
 
   const WHERE = getWHERE({
     factTable: numeratorFactTable,
@@ -946,15 +871,11 @@ SELECT
   }${
     type === "quantile"
       ? `-- Final result\n  PERCENTILE(${
-          numerator.aggregation === "kll merge"
-            ? `\n    -- Merge pre-aggregated KLL sketches across events\n    KLL_QUANTILES.MERGE_PARTIAL(m.value),\n  `
-            : quantileSettings.ignoreZeros
-              ? `m.value,`
-              : `\n    -- COALESCE to include NULL in the calculation\n    COALESCE(m.value, 0),\n  `
+          quantileSettings.ignoreZeros
+            ? `m.value,`
+            : `\n    -- COALESCE to include NULL in the calculation\n    COALESCE(m.value, 0),\n  `
         }  ${quantileSettings.quantile}${
-          numerator.aggregation === "kll merge" || !quantileSettings.ignoreZeros
-            ? "\n  "
-            : ""
+          !quantileSettings.ignoreZeros ? "\n  " : ""
         })`
       : `-- Final result\n  numerator / denominator`
   } AS value
@@ -1483,23 +1404,9 @@ export default function FactMetricModal({
   const denominator = form.watch("denominator");
   const windowSettings = form.watch("windowSettings");
 
-  // Must have at least one numeric column to use event-level quantile metrics.
-  // Pre-aggregated KLL sketch (binary) columns also unlock event quantiles,
-  // but only on data sources that natively support KLL merging.
-  // For user-level quantiles, there is the option to count rows so it's always available.
-  const canUseEventQuantile =
-    getNumericColumns(numeratorFactTable).length > 0 ||
-    (!!selectedDataSource?.properties?.hasQuantileKLL &&
-      getBinaryColumns(numeratorFactTable).length > 0);
-
-  // A binary numerator column locks the metric to event-quantile mode: the
-  // only valid merge primitive on a binary sketch in a quantile metric is
-  // KLL, which requires event-level aggregation.
-  const numeratorDatatype = getSelectedColumnDatatype({
-    factTable: numeratorFactTable,
-    column: numerator?.column || "",
-  });
-  const numeratorIsBinary = numeratorDatatype === "binary";
+  // Must have at least one numeric column to use event-level quantile metrics
+  // For user-level quantiles, there is the option to count rows so it's always available
+  const canUseEventQuantile = getNumericColumns(numeratorFactTable).length > 0;
 
   const quantileMetricType = type !== "quantile" ? "" : quantileSettings.type;
 
@@ -1595,45 +1502,6 @@ export default function FactMetricModal({
         if (values.metricType === "dailyParticipation") {
           values.numerator.column = "$$distinctDates";
           values.numerator.aggregation = undefined;
-        }
-
-        // Quantile metrics with a binary (pre-aggregated sketch) column
-        // are only valid in event-quantile mode with the `kll merge`
-        // aggregation. Normalize here to defend against stale form state
-        // (e.g. metrics created before this constraint existed).
-        if (values.metricType === "quantile") {
-          const numeratorDatatype = getSelectedColumnDatatype({
-            factTable: numeratorFactTable,
-            column: values.numerator.column,
-          });
-          if (numeratorDatatype === "binary") {
-            values.quantileSettings = {
-              ...quantileSettings,
-              ...values.quantileSettings,
-              type: "event",
-              // ignoreZeros has no meaning when re-aggregating pre-built
-              // KLL sketches — that filtering must happen in the source
-              // pipeline that built the sketch. Force off.
-              ignoreZeros: false,
-            };
-            values.numerator.aggregation = "kll merge";
-          } else if (values.quantileSettings?.quantileEventCountColumn) {
-            // Strip the kll-merge override if the metric is no longer using
-            // a binary numerator. The back-end validator rejects this
-            // combination, so clearing it here keeps form submissions valid
-            // when a user toggles the numerator off a sketch column.
-            values.quantileSettings = {
-              ...values.quantileSettings,
-              quantileEventCountColumn: undefined,
-            };
-          }
-        } else if (values.quantileSettings?.quantileEventCountColumn) {
-          // Same defense for non-quantile metric types (e.g. user switched
-          // metricType after configuring the override).
-          values.quantileSettings = {
-            ...values.quantileSettings,
-            quantileEventCountColumn: undefined,
-          };
         }
 
         // reset aggregate filter for certain metrics
@@ -2096,57 +1964,31 @@ export default function FactMetricModal({
               ) : type === "quantile" ? (
                 <div>
                   <div className="form-group">
-                    <Tooltip
-                      shouldDisplay={numeratorIsBinary}
-                      body="Pre-aggregated sketch (binary) columns can only be used for event-level quantiles — there is no meaningful per-user reduction of a KLL sketch that feeds into a cross-user quantile."
-                    >
-                      <Switch
-                        id="quantileTypeSelector"
-                        label="Aggregate by User First"
-                        description="Aggregate by Experiment User before taking quantile?"
-                        value={
-                          !numeratorIsBinary &&
-                          (!canUseEventQuantile ||
-                            quantileSettings.type !== "event")
-                        }
-                        onChange={(unit) => {
-                          // Event-level quantiles must select a numeric or
-                          // pre-aggregated binary column — special values
-                          // ($$count etc.) are not valid event values.
-                          if (!unit && numerator?.column?.startsWith("$$")) {
-                            const column =
-                              getNumericColumns(numeratorFactTable)[0] ??
-                              getBinaryColumns(numeratorFactTable)[0];
-                            form.setValue("numerator", {
-                              ...numerator,
-                              column: column?.column || "",
-                              aggregation:
-                                column?.datatype === "binary"
-                                  ? "kll merge"
-                                  : numerator?.aggregation,
-                            });
-                          } else if (unit && numeratorIsBinary) {
-                            // Switching to unit-quantile while a binary
-                            // column is selected: binary is invalid in
-                            // unit mode (see ColumnRefSelector gating).
-                            // Fall back to the first numeric column and
-                            // clear the merge aggregation.
-                            const column =
-                              getNumericColumns(numeratorFactTable)[0];
-                            form.setValue("numerator", {
-                              ...numerator,
-                              column: column?.column || "$$count",
-                              aggregation: undefined,
-                            });
-                          }
-                          form.setValue("quantileSettings", {
-                            ...quantileSettings,
-                            type: unit ? "unit" : "event",
+                    <Switch
+                      id="quantileTypeSelector"
+                      label="Aggregate by User First"
+                      description="Aggregate by Experiment User before taking quantile?"
+                      value={
+                        !canUseEventQuantile ||
+                        quantileSettings.type !== "event"
+                      }
+                      onChange={(unit) => {
+                        // Event-level quantiles must select a numeric column
+                        if (!unit && numerator?.column?.startsWith("$$")) {
+                          const column =
+                            getNumericColumns(numeratorFactTable)[0];
+                          form.setValue("numerator", {
+                            ...numerator,
+                            column: column?.column || "",
                           });
-                        }}
-                        disabled={!canUseEventQuantile || numeratorIsBinary}
-                      />
-                    </Tooltip>
+                        }
+                        form.setValue("quantileSettings", {
+                          ...quantileSettings,
+                          type: unit ? "unit" : "event",
+                        });
+                      }}
+                      disabled={!canUseEventQuantile}
+                    />
                   </div>
                   <label>
                     {quantileSettings.type === "unit"
@@ -2160,7 +2002,6 @@ export default function FactMetricModal({
                     }
                     includeColumn={true}
                     aggregationType={quantileSettings.type}
-                    metricType={type}
                     includeDistinctDates={true}
                     setDatasource={setDatasource}
                     datasource={selectedDataSource}
@@ -2171,8 +2012,9 @@ export default function FactMetricModal({
                       <>
                         {form
                           .watch("numerator")
-                          ?.column?.startsWith("$$distinctUsers") ||
-                        numeratorIsBinary ? undefined : (
+                          ?.column?.startsWith(
+                            "$$distinctUsers",
+                          ) ? undefined : (
                           <div className="col-auto">
                             <div className="form-group">
                               <label htmlFor="quantileIgnoreZeros">
@@ -2219,10 +2061,7 @@ export default function FactMetricModal({
                     {quantileSettings.type === "unit"
                       ? " of all aggregated experiment user values"
                       : " of all rows that are matched to experiment users"}
-                    {!numeratorIsBinary && quantileSettings.ignoreZeros
-                      ? ", ignoring zeros"
-                      : ""}
-                    .
+                    {quantileSettings.ignoreZeros ? ", ignoring zeros" : ""}.
                   </HelperText>
                 </div>
               ) : type === "ratio" ? (

--- a/packages/front-end/components/FactTables/FactMetricModal.tsx
+++ b/packages/front-end/components/FactTables/FactMetricModal.tsx
@@ -166,6 +166,15 @@ function getNumericColumns(
   );
 }
 
+function getBinaryColumns(
+  factTable: FactTableInterface | null,
+): ColumnInterface[] {
+  if (!factTable) return [];
+  return factTable.columns.filter(
+    (col) => col.datatype === "binary" && !col.deleted,
+  );
+}
+
 function getColumnOptions({
   factTable,
   datasource,
@@ -176,6 +185,7 @@ function getColumnOptions({
   includeStringColumns = false,
   includeJSONFields = false,
   includeBooleanColumns = false,
+  includeBinaryColumns = false,
   showColumnsAsSums = false,
   excludeColumns,
   groupPrefix = "",
@@ -189,6 +199,7 @@ function getColumnOptions({
   includeStringColumns?: boolean;
   includeBooleanColumns?: boolean;
   includeJSONFields?: boolean;
+  includeBinaryColumns?: boolean;
   showColumnsAsSums?: boolean;
   excludeColumns?: Set<string>;
   groupPrefix?: string;
@@ -245,6 +256,13 @@ function getColumnOptions({
       })),
     );
   }
+
+  const binaryColumnOptions: SingleValue[] = getBinaryColumns(factTable).map(
+    (col) => ({
+      label: col.name,
+      value: col.column,
+    }),
+  );
 
   // Add JSON fields
   if (includeJSONFields && factTable?.columns) {
@@ -311,6 +329,12 @@ function getColumnOptions({
       ),
     });
   }
+  if (includeBinaryColumns && binaryColumnOptions.length > 0) {
+    ret.push({
+      label: `${groupPrefix}Pre-Aggregated (Binary) Columns`,
+      options: binaryColumnOptions.filter((v) => !excludeColumns?.has(v.value)),
+    });
+  }
   return ret;
 }
 
@@ -325,6 +349,20 @@ function getAggregationOptions(
       {
         label: "Count Distinct",
         value: "count distinct",
+      },
+    ];
+  }
+
+  if (selectedColumnDatatype === "binary") {
+    // Binary columns are pre-aggregated sketches; the merge function is
+    // implied by the column's datatype (HLL for unit-level Count Distinct,
+    // KLL for event-quantile metrics — see ColumnRefSelector). Surface a
+    // single, plain-language option so users don't have to know the
+    // underlying merge primitive.
+    return [
+      {
+        label: "Count Distinct",
+        value: "hll merge",
       },
     ];
   }
@@ -403,6 +441,7 @@ function ColumnRefSelector({
   includeCountDistinct,
   includeDistinctDates,
   aggregationType = "unit",
+  metricType,
   includeColumn,
   datasource,
   disableFactTableSelector,
@@ -417,6 +456,12 @@ function ColumnRefSelector({
   includeDistinctDates?: boolean;
   includeColumn?: boolean;
   aggregationType?: "unit" | "event";
+  // Used to disambiguate binary-column semantics. Pre-aggregated KLL
+  // sketches only make sense in event-quantile metrics; pre-aggregated
+  // HLL sketches only make sense for non-quantile unit aggregations
+  // (mean / ratio). For unit-quantile pickers we therefore omit binary
+  // columns entirely — see getColumnOptions usage below.
+  metricType?: FactMetricType;
   datasource: DataSourceInterfaceWithParams;
   disableFactTableSelector?: boolean;
   extraField?: ReactElement;
@@ -437,6 +482,19 @@ function ColumnRefSelector({
     includeNumericColumns: true,
     includeStringColumns:
       datasource.properties?.hasCountDistinctHLL && aggregationType === "unit",
+    includeBinaryColumns:
+      // Pre-aggregated HLL sketches: shown alongside Count Distinct on
+      // non-quantile unit-aggregation pickers (mean / ratio). They are
+      // intentionally hidden from unit-quantile pickers because a binary
+      // column may hold either HLL or KLL bytes — there is no clean way
+      // to compute a per-user scalar from a KLL sketch that feeds a
+      // cross-user quantile.
+      // Pre-aggregated KLL sketches: shown for event-quantile pickers.
+      (aggregationType === "unit" &&
+        metricType !== "quantile" &&
+        !!datasource.properties?.hasCountDistinctHLL) ||
+      (aggregationType === "event" &&
+        !!datasource.properties?.hasQuantileKLL),
     includeJSONFields: true,
   });
 
@@ -536,7 +594,18 @@ function ColumnRefSelector({
 
                 if (newDatatype === "string") {
                   aggregation = "count distinct";
-                } else if (aggregation === "count distinct") {
+                } else if (newDatatype === "binary") {
+                  // Pre-aggregated sketch column: pick the merge primitive
+                  // implied by the metric context. Event-quantile pickers
+                  // use KLL; everything else (mean / ratio Count Distinct)
+                  // uses HLL.
+                  aggregation =
+                    aggregationType === "event" ? "kll merge" : "hll merge";
+                } else if (
+                  aggregation === "count distinct" ||
+                  aggregation === "hll merge" ||
+                  aggregation === "kll merge"
+                ) {
                   aggregation = "sum";
                 }
 
@@ -737,7 +806,8 @@ function getWHERE({
   if (
     type === "quantile" &&
     quantileSettings.type === "event" &&
-    quantileSettings.ignoreZeros
+    quantileSettings.ignoreZeros &&
+    columnRef?.aggregation !== "kll merge"
   ) {
     whereParts.push(`-- Ignore zeros in percentile\nvalue > 0`);
   }
@@ -785,9 +855,13 @@ function getPreviewSQL({
           ? "1"
           : numerator.aggregation === "count distinct"
             ? `COUNT(DISTINCT ${numerator.column})`
-            : `${(numerator.aggregation ?? "sum").toUpperCase()}(${
-                numerator.column
-              })`;
+            : numerator.aggregation === "hll merge"
+              ? `-- Pre-aggregated HLL sketch column\n  HLL_COUNT.MERGE(${numerator.column})`
+              : numerator.aggregation === "kll merge"
+                ? `-- Pre-aggregated KLL sketch column\n  KLL_QUANTILES.MERGE_PARTIAL(${numerator.column})`
+                : `${(numerator.aggregation ?? "sum").toUpperCase()}(${
+                    numerator.column
+                  })`;
   const numeratorAdjustment =
     type === "dailyParticipation" ? "\n\t/ CEIL(days_since_exposure)" : "";
 
@@ -798,11 +872,13 @@ function getPreviewSQL({
         ? "1"
         : denominator?.column === "$$distinctDates"
           ? `COUNT(DISTINCT DATE(timestamp))`
-          : denominator?.aggregation === "count distinct"
-            ? `-- HyperLogLog estimation used instead of COUNT DISTINCT\n  COUNT(DISTINCT ${denominator?.column})`
-            : `${(denominator?.aggregation ?? "sum").toUpperCase()}(${
-                denominator?.column
-              })`;
+          : denominator?.aggregation === "hll merge"
+            ? `-- Pre-aggregated HLL sketch column\n  HLL_COUNT.MERGE(${denominator?.column})`
+            : denominator?.aggregation === "count distinct"
+              ? `-- HyperLogLog estimation used instead of COUNT DISTINCT\n  COUNT(DISTINCT ${denominator?.column})`
+              : `${(denominator?.aggregation ?? "sum").toUpperCase()}(${
+                  denominator?.column
+                })`;
 
   const WHERE = getWHERE({
     factTable: numeratorFactTable,
@@ -871,11 +947,15 @@ SELECT
   }${
     type === "quantile"
       ? `-- Final result\n  PERCENTILE(${
-          quantileSettings.ignoreZeros
-            ? `m.value,`
-            : `\n    -- COALESCE to include NULL in the calculation\n    COALESCE(m.value, 0),\n  `
+          numerator.aggregation === "kll merge"
+            ? `\n    -- Merge pre-aggregated KLL sketches across events\n    KLL_QUANTILES.MERGE_PARTIAL(m.value),\n  `
+            : quantileSettings.ignoreZeros
+              ? `m.value,`
+              : `\n    -- COALESCE to include NULL in the calculation\n    COALESCE(m.value, 0),\n  `
         }  ${quantileSettings.quantile}${
-          !quantileSettings.ignoreZeros ? "\n  " : ""
+          numerator.aggregation === "kll merge" || !quantileSettings.ignoreZeros
+            ? "\n  "
+            : ""
         })`
       : `-- Final result\n  numerator / denominator`
   } AS value
@@ -1404,9 +1484,23 @@ export default function FactMetricModal({
   const denominator = form.watch("denominator");
   const windowSettings = form.watch("windowSettings");
 
-  // Must have at least one numeric column to use event-level quantile metrics
-  // For user-level quantiles, there is the option to count rows so it's always available
-  const canUseEventQuantile = getNumericColumns(numeratorFactTable).length > 0;
+  // Must have at least one numeric column to use event-level quantile metrics.
+  // Pre-aggregated KLL sketch (binary) columns also unlock event quantiles,
+  // but only on data sources that natively support KLL merging.
+  // For user-level quantiles, there is the option to count rows so it's always available.
+  const canUseEventQuantile =
+    getNumericColumns(numeratorFactTable).length > 0 ||
+    (!!selectedDataSource?.properties?.hasQuantileKLL &&
+      getBinaryColumns(numeratorFactTable).length > 0);
+
+  // A binary numerator column locks the metric to event-quantile mode: the
+  // only valid merge primitive on a binary sketch in a quantile metric is
+  // KLL, which requires event-level aggregation.
+  const numeratorDatatype = getSelectedColumnDatatype({
+    factTable: numeratorFactTable,
+    column: numerator?.column || "",
+  });
+  const numeratorIsBinary = numeratorDatatype === "binary";
 
   const quantileMetricType = type !== "quantile" ? "" : quantileSettings.type;
 
@@ -1502,6 +1596,29 @@ export default function FactMetricModal({
         if (values.metricType === "dailyParticipation") {
           values.numerator.column = "$$distinctDates";
           values.numerator.aggregation = undefined;
+        }
+
+        // Quantile metrics with a binary (pre-aggregated sketch) column
+        // are only valid in event-quantile mode with the `kll merge`
+        // aggregation. Normalize here to defend against stale form state
+        // (e.g. metrics created before this constraint existed).
+        if (values.metricType === "quantile") {
+          const numeratorDatatype = getSelectedColumnDatatype({
+            factTable: numeratorFactTable,
+            column: values.numerator.column,
+          });
+          if (numeratorDatatype === "binary") {
+            values.quantileSettings = {
+              ...quantileSettings,
+              ...values.quantileSettings,
+              type: "event",
+              // ignoreZeros has no meaning when re-aggregating pre-built
+              // KLL sketches — that filtering must happen in the source
+              // pipeline that built the sketch. Force off.
+              ignoreZeros: false,
+            };
+            values.numerator.aggregation = "kll merge";
+          }
         }
 
         // reset aggregate filter for certain metrics
@@ -1964,31 +2081,57 @@ export default function FactMetricModal({
               ) : type === "quantile" ? (
                 <div>
                   <div className="form-group">
-                    <Switch
-                      id="quantileTypeSelector"
-                      label="Aggregate by User First"
-                      description="Aggregate by Experiment User before taking quantile?"
-                      value={
-                        !canUseEventQuantile ||
-                        quantileSettings.type !== "event"
-                      }
-                      onChange={(unit) => {
-                        // Event-level quantiles must select a numeric column
-                        if (!unit && numerator?.column?.startsWith("$$")) {
-                          const column =
-                            getNumericColumns(numeratorFactTable)[0];
-                          form.setValue("numerator", {
-                            ...numerator,
-                            column: column?.column || "",
-                          });
+                    <Tooltip
+                      shouldDisplay={numeratorIsBinary}
+                      body="Pre-aggregated sketch (binary) columns can only be used for event-level quantiles — there is no meaningful per-user reduction of a KLL sketch that feeds into a cross-user quantile."
+                    >
+                      <Switch
+                        id="quantileTypeSelector"
+                        label="Aggregate by User First"
+                        description="Aggregate by Experiment User before taking quantile?"
+                        value={
+                          !numeratorIsBinary &&
+                          (!canUseEventQuantile ||
+                            quantileSettings.type !== "event")
                         }
-                        form.setValue("quantileSettings", {
-                          ...quantileSettings,
-                          type: unit ? "unit" : "event",
-                        });
-                      }}
-                      disabled={!canUseEventQuantile}
-                    />
+                        onChange={(unit) => {
+                          // Event-level quantiles must select a numeric or
+                          // pre-aggregated binary column — special values
+                          // ($$count etc.) are not valid event values.
+                          if (!unit && numerator?.column?.startsWith("$$")) {
+                            const column =
+                              getNumericColumns(numeratorFactTable)[0] ??
+                              getBinaryColumns(numeratorFactTable)[0];
+                            form.setValue("numerator", {
+                              ...numerator,
+                              column: column?.column || "",
+                              aggregation:
+                                column?.datatype === "binary"
+                                  ? "kll merge"
+                                  : numerator?.aggregation,
+                            });
+                          } else if (unit && numeratorIsBinary) {
+                            // Switching to unit-quantile while a binary
+                            // column is selected: binary is invalid in
+                            // unit mode (see ColumnRefSelector gating).
+                            // Fall back to the first numeric column and
+                            // clear the merge aggregation.
+                            const column =
+                              getNumericColumns(numeratorFactTable)[0];
+                            form.setValue("numerator", {
+                              ...numerator,
+                              column: column?.column || "$$count",
+                              aggregation: undefined,
+                            });
+                          }
+                          form.setValue("quantileSettings", {
+                            ...quantileSettings,
+                            type: unit ? "unit" : "event",
+                          });
+                        }}
+                        disabled={!canUseEventQuantile || numeratorIsBinary}
+                      />
+                    </Tooltip>
                   </div>
                   <label>
                     {quantileSettings.type === "unit"
@@ -2002,6 +2145,7 @@ export default function FactMetricModal({
                     }
                     includeColumn={true}
                     aggregationType={quantileSettings.type}
+                    metricType={type}
                     includeDistinctDates={true}
                     setDatasource={setDatasource}
                     datasource={selectedDataSource}
@@ -2012,9 +2156,8 @@ export default function FactMetricModal({
                       <>
                         {form
                           .watch("numerator")
-                          ?.column?.startsWith(
-                            "$$distinctUsers",
-                          ) ? undefined : (
+                          ?.column?.startsWith("$$distinctUsers") ||
+                        numeratorIsBinary ? undefined : (
                           <div className="col-auto">
                             <div className="form-group">
                               <label htmlFor="quantileIgnoreZeros">
@@ -2061,7 +2204,10 @@ export default function FactMetricModal({
                     {quantileSettings.type === "unit"
                       ? " of all aggregated experiment user values"
                       : " of all rows that are matched to experiment users"}
-                    {quantileSettings.ignoreZeros ? ", ignoring zeros" : ""}.
+                    {!numeratorIsBinary && quantileSettings.ignoreZeros
+                      ? ", ignoring zeros"
+                      : ""}
+                    .
                   </HelperText>
                 </div>
               ) : type === "ratio" ? (

--- a/packages/front-end/components/Metrics/MetricsList.tsx
+++ b/packages/front-end/components/Metrics/MetricsList.tsx
@@ -43,7 +43,7 @@ import PremiumCallout from "@/ui/PremiumCallout";
 import { useDemoDataSourceProject } from "@/hooks/useDemoDataSourceProject";
 import LinkButton from "@/ui/LinkButton";
 import useOrgSettings from "@/hooks/useOrgSettings";
-import Tooltip from "@/components/Tooltip/Tooltip";
+import Tooltip from "@/ui/Tooltip";
 import {
   isMergeAggregationMetric,
   REST_API_ONLY_EDIT_MESSAGE,
@@ -92,19 +92,18 @@ function MetricRowMenu({ metric }: { metric: MetricTableItem }) {
       menuPlacement="end"
     >
       <DropdownMenuGroup>
-        {canEditMenu && (
+        {(canEditMenu || canShowDisabledEdit) && (
           <DropdownMenuItem
             onClick={() => {
               setOpen(false);
               metric.onEdit?.();
             }}
+            disabled={!!metric.editDisabledReason}
           >
-            Edit
-          </DropdownMenuItem>
-        )}
-        {canShowDisabledEdit && (
-          <DropdownMenuItem disabled>
-            <Tooltip body={metric.editDisabledReason}>
+            <Tooltip
+              content={metric.editDisabledReason}
+              enabled={!!metric.editDisabledReason}
+            >
               <span>Edit</span>
             </Tooltip>
           </DropdownMenuItem>
@@ -115,8 +114,14 @@ function MetricRowMenu({ metric }: { metric: MetricTableItem }) {
               setOpen(false);
               metric.onDuplicate?.();
             }}
+            disabled={!!metric.editDisabledReason}
           >
-            Duplicate
+            <Tooltip
+              content={metric.editDisabledReason}
+              enabled={!!metric.editDisabledReason}
+            >
+              <span>Duplicate</span>
+            </Tooltip>
           </DropdownMenuItem>
         )}
         {canArchive && (

--- a/packages/front-end/components/Metrics/MetricsList.tsx
+++ b/packages/front-end/components/Metrics/MetricsList.tsx
@@ -43,17 +43,33 @@ import PremiumCallout from "@/ui/PremiumCallout";
 import { useDemoDataSourceProject } from "@/hooks/useDemoDataSourceProject";
 import LinkButton from "@/ui/LinkButton";
 import useOrgSettings from "@/hooks/useOrgSettings";
+import Tooltip from "@/components/Tooltip/Tooltip";
+
+const REST_API_ONLY_EDIT_MESSAGE =
+  "This is a metric that can only be managed via the REST API";
 
 function MetricRowMenu({ metric }: { metric: MetricTableItem }) {
   const [open, setOpen] = useState(false);
 
   const canDuplicate =
     !!metric.onDuplicate && envAllowsCreatingMetrics() && metric.canDuplicate;
-  const canEditMenu = metric.canEdit && !metric.archived && !!metric.onEdit;
+  const canEditMenu =
+    metric.canEdit &&
+    !metric.archived &&
+    !metric.editDisabledReason &&
+    !!metric.onEdit;
+  const canShowDisabledEdit =
+    metric.canEdit && !metric.archived && !!metric.editDisabledReason;
   const canArchive = metric.canEdit && !!metric.onArchive;
   const canDelete = metric.canDelete && !!metric.onDelete;
 
-  if (!canDuplicate && !canEditMenu && !canArchive && !canDelete) {
+  if (
+    !canDuplicate &&
+    !canEditMenu &&
+    !canShowDisabledEdit &&
+    !canArchive &&
+    !canDelete
+  ) {
     return null;
   }
 
@@ -83,6 +99,13 @@ function MetricRowMenu({ metric }: { metric: MetricTableItem }) {
             }}
           >
             Edit
+          </DropdownMenuItem>
+        )}
+        {canShowDisabledEdit && (
+          <DropdownMenuItem disabled>
+            <Tooltip body={metric.editDisabledReason}>
+              <span>Edit</span>
+            </Tooltip>
           </DropdownMenuItem>
         )}
         {canDuplicate && (
@@ -147,6 +170,7 @@ export interface MetricTableItem {
   canEdit: boolean;
   canDuplicate: boolean;
   canDelete: boolean;
+  editDisabledReason?: string;
   onArchive?: (desiredState: boolean) => Promise<void>;
   onDuplicate?: () => void;
   onEdit?: () => void;
@@ -284,6 +308,13 @@ export function useCombinedMetrics({
         canDuplicate,
         canEdit,
         canDelete,
+        editDisabledReason:
+          m.numerator.aggregation === "kll merge" ||
+          m.numerator.aggregation === "hll merge" ||
+          m.denominator?.aggregation === "kll merge" ||
+          m.denominator?.aggregation === "hll merge"
+            ? REST_API_ONLY_EDIT_MESSAGE
+            : undefined,
         onArchive: canEdit
           ? async (archivedState) => {
               await apiCall(`/fact-metrics/${m.id}`, {

--- a/packages/front-end/components/Metrics/MetricsList.tsx
+++ b/packages/front-end/components/Metrics/MetricsList.tsx
@@ -44,9 +44,10 @@ import { useDemoDataSourceProject } from "@/hooks/useDemoDataSourceProject";
 import LinkButton from "@/ui/LinkButton";
 import useOrgSettings from "@/hooks/useOrgSettings";
 import Tooltip from "@/components/Tooltip/Tooltip";
-
-const REST_API_ONLY_EDIT_MESSAGE =
-  "This is a metric that can only be managed via the REST API";
+import {
+  isMergeAggregationMetric,
+  REST_API_ONLY_EDIT_MESSAGE,
+} from "@/services/factMetrics";
 
 function MetricRowMenu({ metric }: { metric: MetricTableItem }) {
   const [open, setOpen] = useState(false);
@@ -308,13 +309,9 @@ export function useCombinedMetrics({
         canDuplicate,
         canEdit,
         canDelete,
-        editDisabledReason:
-          m.numerator.aggregation === "kll merge" ||
-          m.numerator.aggregation === "hll merge" ||
-          m.denominator?.aggregation === "kll merge" ||
-          m.denominator?.aggregation === "hll merge"
-            ? REST_API_ONLY_EDIT_MESSAGE
-            : undefined,
+        editDisabledReason: isMergeAggregationMetric(m)
+          ? REST_API_ONLY_EDIT_MESSAGE
+          : undefined,
         onArchive: canEdit
           ? async (archivedState) => {
               await apiCall(`/fact-metrics/${m.id}`, {

--- a/packages/front-end/pages/fact-metrics/[fmid].tsx
+++ b/packages/front-end/pages/fact-metrics/[fmid].tsx
@@ -573,13 +573,12 @@ export default function FactMetricPage() {
                 }}
                 disabled={editViaApiOnly}
               >
-                {editViaApiOnly ? (
-                  <Tooltip content={REST_API_ONLY_EDIT_MESSAGE}>
-                    <span>Edit Metric</span>
-                  </Tooltip>
-                ) : (
+                <Tooltip
+                  content={REST_API_ONLY_EDIT_MESSAGE}
+                  enabled={editViaApiOnly}
+                >
                   <span>Edit Metric</span>
-                )}
+                </Tooltip>
               </DropdownMenuItem>
             )}
             {canEdit &&

--- a/packages/front-end/pages/fact-metrics/[fmid].tsx
+++ b/packages/front-end/pages/fact-metrics/[fmid].tsx
@@ -44,7 +44,7 @@ import {
   getPercentileLabel,
 } from "@/services/metrics";
 import MarkdownInlineEdit from "@/components/Markdown/MarkdownInlineEdit";
-import Tooltip from "@/components/Tooltip/Tooltip";
+import Tooltip from "@/ui/Tooltip";
 import { capitalizeFirstLetter } from "@/services/utils";
 import MetricName from "@/components/Metrics/MetricName";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
@@ -467,7 +467,7 @@ export default function FactMetricPage() {
             <>
               Projects{" "}
               <Tooltip
-                body={
+                content={
                   "The dropdown below has been filtered to only include projects where you have permission to update Metrics"
                 }
               />
@@ -585,7 +585,7 @@ export default function FactMetricPage() {
             )}
             {canEdit && editViaApiOnly && (
               <DropdownMenuItem disabled>
-                <Tooltip body={REST_API_ONLY_EDIT_MESSAGE}>
+                <Tooltip content={REST_API_ONLY_EDIT_MESSAGE}>
                   <span>Edit Metric</span>
                 </Tooltip>
               </DropdownMenuItem>
@@ -896,11 +896,7 @@ export default function FactMetricPage() {
         </div>
         <div className="col-12 col-md-4">
           <div className="appbox p-3">
-            <RightRailSection
-              title="Advanced Settings"
-              open={() => setEditOpen("openWithAdvanced")}
-              canOpen={canEdit}
-            >
+            <RightRailSection title="Advanced Settings">
               {factMetric.windowSettings.delayValue ? (
                 <RightRailSectionGroup type="custom" empty="" className="mt-3">
                   <ul className="right-rail-subsection list-unstyled mb-4">

--- a/packages/front-end/pages/fact-metrics/[fmid].tsx
+++ b/packages/front-end/pages/fact-metrics/[fmid].tsx
@@ -896,7 +896,11 @@ export default function FactMetricPage() {
         </div>
         <div className="col-12 col-md-4">
           <div className="appbox p-3">
-            <RightRailSection title="Advanced Settings">
+            <RightRailSection
+              title="Advanced Settings"
+              open={() => setEditOpen("openWithAdvanced")}
+              canOpen={canEdit && !editViaApiOnly}
+            >
               {factMetric.windowSettings.delayValue ? (
                 <RightRailSectionGroup type="custom" empty="" className="mt-3">
                   <ul className="right-rail-subsection list-unstyled mb-4">

--- a/packages/front-end/pages/fact-metrics/[fmid].tsx
+++ b/packages/front-end/pages/fact-metrics/[fmid].tsx
@@ -73,6 +73,18 @@ import Callout from "@/ui/Callout";
 import { DeleteDemoDatasourceButton } from "@/components/DemoDataSourcePage/DemoDataSourcePage";
 import Code from "@/components/SyntaxHighlighting/Code";
 
+const REST_API_ONLY_EDIT_MESSAGE =
+  "This is a metric that can only be managed via the REST API";
+
+function isMergeAggregationMetric(metric: {
+  numerator: { aggregation?: string };
+  denominator?: { aggregation?: string } | null;
+}): boolean {
+  return [metric.numerator.aggregation, metric.denominator?.aggregation].some(
+    (aggregation) => aggregation === "kll merge" || aggregation === "hll merge",
+  );
+}
+
 function FactTableLink({ id }: { id?: string }) {
   const { getFactTableById } = useDefinitions();
   const factTable = getFactTableById(id || "");
@@ -242,6 +254,7 @@ export default function FactMetricPage() {
 
   let canEdit = permissionsUtil.canUpdateFactMetric(factMetric, {});
   let canDelete = permissionsUtil.canDeleteFactMetric(factMetric);
+  const editViaApiOnly = isMergeAggregationMetric(factMetric);
 
   if (
     factMetric.managedBy &&
@@ -560,7 +573,7 @@ export default function FactMetricPage() {
             open={openDropdown}
             onOpenChange={setOpenDropdown}
           >
-            {canEdit && (
+            {canEdit && !editViaApiOnly && (
               <DropdownMenuItem
                 onClick={() => {
                   setOpenDropdown(false);
@@ -568,6 +581,13 @@ export default function FactMetricPage() {
                 }}
               >
                 Edit Metric
+              </DropdownMenuItem>
+            )}
+            {canEdit && editViaApiOnly && (
+              <DropdownMenuItem disabled>
+                <Tooltip body={REST_API_ONLY_EDIT_MESSAGE}>
+                  <span>Edit Metric</span>
+                </Tooltip>
               </DropdownMenuItem>
             )}
             {canEdit &&

--- a/packages/front-end/pages/fact-metrics/[fmid].tsx
+++ b/packages/front-end/pages/fact-metrics/[fmid].tsx
@@ -72,18 +72,10 @@ import { DocLink } from "@/components/DocLink";
 import Callout from "@/ui/Callout";
 import { DeleteDemoDatasourceButton } from "@/components/DemoDataSourcePage/DemoDataSourcePage";
 import Code from "@/components/SyntaxHighlighting/Code";
-
-const REST_API_ONLY_EDIT_MESSAGE =
-  "This is a metric that can only be managed via the REST API";
-
-function isMergeAggregationMetric(metric: {
-  numerator: { aggregation?: string };
-  denominator?: { aggregation?: string } | null;
-}): boolean {
-  return [metric.numerator.aggregation, metric.denominator?.aggregation].some(
-    (aggregation) => aggregation === "kll merge" || aggregation === "hll merge",
-  );
-}
+import {
+  isMergeAggregationMetric,
+  REST_API_ONLY_EDIT_MESSAGE,
+} from "@/services/factMetrics";
 
 function FactTableLink({ id }: { id?: string }) {
   const { getFactTableById } = useDefinitions();
@@ -573,21 +565,21 @@ export default function FactMetricPage() {
             open={openDropdown}
             onOpenChange={setOpenDropdown}
           >
-            {canEdit && !editViaApiOnly && (
+            {canEdit && (
               <DropdownMenuItem
                 onClick={() => {
                   setOpenDropdown(false);
                   setEditOpen("open");
                 }}
+                disabled={editViaApiOnly}
               >
-                Edit Metric
-              </DropdownMenuItem>
-            )}
-            {canEdit && editViaApiOnly && (
-              <DropdownMenuItem disabled>
-                <Tooltip content={REST_API_ONLY_EDIT_MESSAGE}>
+                {editViaApiOnly ? (
+                  <Tooltip content={REST_API_ONLY_EDIT_MESSAGE}>
+                    <span>Edit Metric</span>
+                  </Tooltip>
+                ) : (
                   <span>Edit Metric</span>
-                </Tooltip>
+                )}
               </DropdownMenuItem>
             )}
             {canEdit &&

--- a/packages/front-end/services/factMetrics.ts
+++ b/packages/front-end/services/factMetrics.ts
@@ -1,0 +1,16 @@
+/**
+ * Fact metrics whose numerator/denominator uses pre-aggregated sketch merge
+ * (`kll merge` / `hll merge`) are created and updated via the REST API only;
+ * the UI cannot represent these configurations.
+ */
+export const REST_API_ONLY_EDIT_MESSAGE =
+  "This is a metric that can only be managed via the REST API";
+
+export function isMergeAggregationMetric(metric: {
+  numerator: { aggregation?: string };
+  denominator?: { aggregation?: string } | null;
+}): boolean {
+  return [metric.numerator.aggregation, metric.denominator?.aggregation].some(
+    (aggregation) => aggregation === "kll merge" || aggregation === "hll merge",
+  );
+}

--- a/packages/shared/src/enterprise/product-analytics/sql.ts
+++ b/packages/shared/src/enterprise/product-analytics/sql.ts
@@ -11,7 +11,6 @@ import {
   MetricCappingSettings,
   NumberFormat,
   ColumnRef,
-  ColumnAggregation,
 } from "shared/types/fact-table";
 import { DataSourceSettings } from "shared/types/datasource";
 import {
@@ -549,13 +548,7 @@ function getUnitAggregationExpr(
     return `SUM(${alias})`;
   }
 
-  if (!columnRef.aggregation) {
-    throw new Error(
-      `Missing aggregation for fact metric column '${columnRef.column}'.`,
-    );
-  }
-
-  const aggregation: ColumnAggregation = columnRef.aggregation;
+  const aggregation = columnRef.aggregation;
   switch (aggregation) {
     case "sum":
       return `SUM(${alias})`;
@@ -567,6 +560,8 @@ function getUnitAggregationExpr(
       return helpers.hllCardinality(helpers.hllReaggregate(alias));
     case "kll merge":
       return helpers.kllMergePartial(alias);
+    case undefined:
+      return `SUM(${alias})`;
   }
 
   return assertNever(aggregation);

--- a/packages/shared/src/enterprise/product-analytics/sql.ts
+++ b/packages/shared/src/enterprise/product-analytics/sql.ts
@@ -11,6 +11,7 @@ import {
   MetricCappingSettings,
   NumberFormat,
   ColumnRef,
+  ColumnAggregation,
 } from "shared/types/fact-table";
 import { DataSourceSettings } from "shared/types/datasource";
 import {
@@ -79,6 +80,10 @@ interface CTE {
 interface DateRange {
   startDate: Date;
   endDate: Date;
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unexpected value: ${value}`);
 }
 
 function getMetricAliases(index: number) {
@@ -519,10 +524,15 @@ function getEventValueExpr(
   return `CASE WHEN (${filters.join(" AND ")}) THEN ${rawValue} ELSE NULL END`;
 }
 
-function getUnitAggregationExpr(columnRef: ColumnRef, alias: string): string {
-  if (columnRef.column === "$$distintDates") {
+function getUnitAggregationExpr(
+  columnRef: ColumnRef,
+  alias: string,
+  helpers: SqlDialect,
+): string {
+  if (columnRef.column === "$$distinctDates") {
     return `COUNT(DISTINCT ${alias})`;
-  } else if (columnRef.column === "$$distinctUsers") {
+  }
+  if (columnRef.column === "$$distinctUsers") {
     if (columnRef.aggregateFilter && columnRef.aggregateFilterColumn) {
       const filters = getAggregateFilters({
         columnRef: columnRef,
@@ -534,24 +544,55 @@ function getUnitAggregationExpr(columnRef: ColumnRef, alias: string): string {
       }
     }
     return `MAX(${alias})`;
-  } else if (columnRef.column === "$$count") {
-    return `SUM(${alias})`;
-  } else if (columnRef.aggregation === "count distinct") {
-    return `COUNT(DISTINCT ${alias})`;
-  } else if (columnRef.aggregation === "max") {
-    return `MAX(${alias})`;
-  } else {
+  }
+  if (columnRef.column === "$$count") {
     return `SUM(${alias})`;
   }
+
+  if (!columnRef.aggregation) {
+    throw new Error(
+      `Missing aggregation for fact metric column '${columnRef.column}'.`,
+    );
+  }
+
+  const aggregation: ColumnAggregation = columnRef.aggregation;
+  switch (aggregation) {
+    case "sum":
+      return `SUM(${alias})`;
+    case "max":
+      return `MAX(${alias})`;
+    case "count distinct":
+      return `COUNT(DISTINCT ${alias})`;
+    case "hll merge":
+      return helpers.hllCardinality(helpers.hllReaggregate(alias));
+    case "kll merge":
+      return helpers.kllMergePartial(alias);
+  }
+
+  return assertNever(aggregation);
 }
 
 function getRollupAggregationExpr(
   metric: MinimalMetric,
+  columnRef: ColumnRef,
   alias: string,
   helpers: SqlDialect,
+  fromUnitAggregation: boolean,
 ): string {
+  if (columnRef.aggregation === "hll merge") {
+    return fromUnitAggregation
+      ? `SUM(${alias})`
+      : helpers.hllCardinality(helpers.hllReaggregate(alias));
+  }
+
   // Quantiles
   if (metric.metricType === "quantile" && metric.quantileSettings) {
+    if (columnRef.aggregation === "kll merge") {
+      return helpers.kllExtractPoint(
+        helpers.kllMergePartial(alias),
+        metric.quantileSettings.quantile,
+      );
+    }
     return helpers.percentileApprox(alias, metric.quantileSettings.quantile);
   } else {
     return `SUM(${alias})`;
@@ -649,9 +690,15 @@ function getMetricData(
       cappingSettings,
     ),
     unitAggregationExpr: selectedUnit
-      ? getUnitAggregationExpr(columnRef, alias)
+      ? getUnitAggregationExpr(columnRef, alias, helpers)
       : null,
-    rollupAggregationExpr: getRollupAggregationExpr(metric, alias, helpers),
+    rollupAggregationExpr: getRollupAggregationExpr(
+      metric,
+      columnRef,
+      alias,
+      helpers,
+      !!selectedUnit,
+    ),
     rollupCountExpr,
   };
 }

--- a/packages/shared/src/validators/bulk-import.ts
+++ b/packages/shared/src/validators/bulk-import.ts
@@ -97,9 +97,15 @@ const postBulkImportFactsBody = z
                 )
                 .optional(),
               aggregation: z
-                .enum(["sum", "max", "count distinct"])
+                .enum([
+                  "sum",
+                  "max",
+                  "count distinct",
+                  "hll merge",
+                  "kll merge",
+                ])
                 .describe(
-                  "User aggregation of selected column. Either sum or max for numeric columns; count distinct for string columns; ignored for special columns. Default: sum. If you specify a string column you must explicitly specify count distinct. Not used for proportion or event quantile metrics.",
+                  "User aggregation of selected column. Either sum or max for numeric columns; count distinct for string columns; hll merge / kll merge for pre-built sketch columns (requires data-source support); ignored for special columns. Default: sum. If you specify a string column you must explicitly specify count distinct. Not used for proportion metrics; for event quantile metrics only kll merge is applicable.",
                 )
                 .optional(),
               filters: z
@@ -179,9 +185,15 @@ const postBulkImportFactsBody = z
                     "The column name or one of the special values: '$$distinctUsers' or '$$count' (or '$$distinctDates' if metricType is 'mean' or 'ratio' or 'quantile' and quantileSettings.type is 'unit')",
                   ),
                 aggregation: z
-                  .enum(["sum", "max", "count distinct"])
+                  .enum([
+                    "sum",
+                    "max",
+                    "count distinct",
+                    "hll merge",
+                    "kll merge",
+                  ])
                   .describe(
-                    "User aggregation of selected column. Either sum or max for numeric columns; count distinct for string columns; ignored for special columns. Default: sum. If you specify a string column you must explicitly specify count distinct. Not used for proportion or event quantile metrics.",
+                    "User aggregation of selected column. Either sum or max for numeric columns; count distinct for string columns; hll merge / kll merge for pre-built sketch columns (requires data-source support); ignored for special columns. Default: sum. If you specify a string column you must explicitly specify count distinct. Not used for proportion metrics; for event quantile metrics only kll merge is applicable.",
                   )
                   .optional(),
                 filters: z

--- a/packages/shared/src/validators/bulk-import.ts
+++ b/packages/shared/src/validators/bulk-import.ts
@@ -1,7 +1,6 @@
 import { z } from "zod";
 import { ownerInputField } from "./owner-field";
 
-// Corresponds to payload-schemas/BulkImportFactsPayload.yaml
 // The body references PostFactTablePayload, PostFactTableFilterPayload, and PostFactMetricPayload
 const postBulkImportFactsBody = z
   .object({
@@ -278,6 +277,12 @@ const postBulkImportFactsBody = z
                   .gte(0.001)
                   .lte(0.999)
                   .describe("The quantile value (from 0.001 to 0.999)"),
+                quantileEventCountColumn: z
+                  .string()
+                  .describe(
+                    "Optional override for the source-column name used to recover per-row event counts when numerator.aggregation is 'kll merge'. Defaults to '<numerator.column>_n_events'. Only valid for event-quantile metrics with a 'kll merge' numerator.",
+                  )
+                  .optional(),
               })
               .describe(
                 'Controls the settings for quantile metrics (mandatory if metricType is "quantile")',

--- a/packages/shared/src/validators/fact-metrics.ts
+++ b/packages/shared/src/validators/fact-metrics.ts
@@ -42,7 +42,9 @@ const apiRowFilterValidator = z.object({
 const apiNumeratorRef = z.object({
   factTableId: z.string(),
   column: z.string(),
-  aggregation: z.enum(["sum", "max", "count distinct"]).optional(),
+  aggregation: z
+    .enum(["sum", "max", "count distinct", "hll merge", "kll merge"])
+    .optional(),
   filters: z
     .array(z.string())
     .describe(
@@ -299,9 +301,9 @@ const postNumeratorRef = z.object({
     )
     .optional(),
   aggregation: z
-    .enum(["sum", "max", "count distinct"])
+    .enum(["sum", "max", "count distinct", "hll merge", "kll merge"])
     .describe(
-      "User aggregation of selected column. Either sum or max for numeric columns; count distinct for string columns; ignored for special columns. Default: sum. If you specify a string column you must explicitly specify count distinct. Not used for proportion or event quantile metrics.",
+      "User aggregation of selected column. Either sum or max for numeric columns; count distinct for string columns; hll merge / kll merge for pre-built sketch columns (requires data-source support); ignored for special columns. Default: sum. If you specify a string column you must explicitly specify count distinct. Not used for proportion metrics; for event quantile metrics only kll merge is applicable.",
     )
     .optional(),
   filters: z
@@ -347,9 +349,9 @@ const postDenominatorRef = z
         "The column name or one of the special values: '$$distinctUsers' or '$$count' (or '$$distinctDates' if metricType is 'mean' or 'ratio' or 'quantile' and quantileSettings.type is 'unit')",
       ),
     aggregation: z
-      .enum(["sum", "max", "count distinct"])
+      .enum(["sum", "max", "count distinct", "hll merge", "kll merge"])
       .describe(
-        "User aggregation of selected column. Either sum or max for numeric columns; count distinct for string columns; ignored for special columns. Default: sum. If you specify a string column you must explicitly specify count distinct. Not used for proportion or event quantile metrics.",
+        "User aggregation of selected column. Either sum or max for numeric columns; count distinct for string columns; hll merge / kll merge for pre-built sketch columns (requires data-source support); ignored for special columns. Default: sum. If you specify a string column you must explicitly specify count distinct. Not used for proportion metrics; for event quantile metrics only kll merge is applicable.",
       )
       .optional(),
     filters: z

--- a/packages/shared/src/validators/fact-metrics.ts
+++ b/packages/shared/src/validators/fact-metrics.ts
@@ -122,6 +122,12 @@ const apiQuantileSettings = z
       .gte(0.001)
       .lte(0.999)
       .describe("The quantile value (from 0.001 to 0.999)"),
+    quantileEventCountColumn: z
+      .string()
+      .describe(
+        "Optional override for the source-column name used to recover per-row event counts when numerator.aggregation is 'kll merge'. Defaults to '<numerator.column>_n_events'. Only valid for event-quantile metrics with a 'kll merge' numerator.",
+      )
+      .optional(),
   })
   .describe(
     'Controls the settings for quantile metrics (mandatory if metricType is "quantile")',
@@ -395,6 +401,12 @@ const postQuantileSettings = z
       .gte(0.001)
       .lte(0.999)
       .describe("The quantile value (from 0.001 to 0.999)"),
+    quantileEventCountColumn: z
+      .string()
+      .describe(
+        "Optional override for the source-column name used to recover per-row event counts when numerator.aggregation is 'kll merge'. Defaults to '<numerator.column>_n_events'. Only valid for event-quantile metrics with a 'kll merge' numerator.",
+      )
+      .optional(),
   })
   .describe(
     'Controls the settings for quantile metrics (mandatory if metricType is "quantile")',

--- a/packages/shared/src/validators/fact-table.ts
+++ b/packages/shared/src/validators/fact-table.ts
@@ -206,6 +206,12 @@ export const quantileSettingsValidator = z.object({
   quantile: z.number(),
   type: z.enum(["unit", "event"]),
   ignoreZeros: z.boolean(),
+  // Override the source-column name used to recover per-row event counts for
+  // 'kll merge' event-quantile metrics. When unset, the SQL pipeline falls
+  // back to the convention `<sketch>_n_events` on the same fact table. Only
+  // valid when numerator.aggregation === "kll merge"; the validator rejects
+  // any other usage.
+  quantileEventCountColumn: z.string().optional(),
 });
 
 export const priorSettingsValidator = z.object({

--- a/packages/shared/src/validators/fact-table.ts
+++ b/packages/shared/src/validators/fact-table.ts
@@ -118,6 +118,14 @@ export const columnAggregationValidator = z.enum([
   "sum",
   "max",
   "count distinct",
+  // The column is a pre-built HLL sketch (e.g. BigQuery BYTES from
+  // HLL_COUNT.INIT). Per-user aggregation merges sketches and extracts the
+  // cardinality; downstream stats treat it as a numeric value per user.
+  "hll merge",
+  // The column is a pre-built KLL sketch (e.g. BigQuery BYTES from
+  // KLL_QUANTILES.INIT_*). Only valid for event-quantile metrics. Per-user
+  // aggregation merges sketches; variation stats reuse the two-pass KLL path.
+  "kll merge",
 ]);
 
 export const rowFilterOperators = [

--- a/packages/shared/src/validators/fact-table.ts
+++ b/packages/shared/src/validators/fact-table.ts
@@ -11,6 +11,7 @@ export const factTableColumnTypes = [
   "date",
   "boolean",
   "json",
+  "binary",
   "other",
   "",
 ];
@@ -21,6 +22,7 @@ export const factTableColumnTypeValidator = z.enum([
   "date",
   "boolean",
   "json",
+  "binary",
   "other",
   "",
 ]);
@@ -306,6 +308,7 @@ export const apiFactTableColumnValidator = namedSchema(
         "date",
         "boolean",
         "json",
+        "binary",
         "other",
         "",
       ]),
@@ -329,6 +332,7 @@ export const apiFactTableColumnValidator = namedSchema(
                 "date",
                 "boolean",
                 "json",
+                "binary",
                 "other",
                 "",
               ])

--- a/packages/shared/test/product-analytics.test.ts
+++ b/packages/shared/test/product-analytics.test.ts
@@ -13,7 +13,7 @@ describe("productAnalytics", () => {
     settings: {},
   };
 
-  const helpers = {
+  const helpers: SqlDialect = {
     escapeStringLiteral: (value) => value,
     jsonExtract: (jsonCol, path, isNumeric) =>
       `${jsonCol}:'${path}'::${isNumeric ? "float" : "text"}`,
@@ -30,7 +30,7 @@ describe("productAnalytics", () => {
       `'${d.toISOString().substring(0, 10)} 00:00:00'`,
     formatDialect: "bigquery",
     castToFloat: (col) => `CAST(${col} AS FLOAT)`,
-  } as Partial<SqlDialect> as SqlDialect;
+  };
 
   const factTableMap = new Map<string, FactTableInterface>([
     [
@@ -784,7 +784,9 @@ describe("productAnalytics", () => {
       datasource,
     );
 
-    expect(sql).toMatch(/HLL_COUNT\s*\(\s*HLL_MERGE\s*\(\s*m0\s*\)\s*\)\s+AS\s+m0/);
+    expect(sql).toMatch(
+      /HLL_COUNT\s*\(\s*HLL_MERGE\s*\(\s*m0\s*\)\s*\)\s+AS\s+m0/,
+    );
     expect(sql).toContain("CAST(SUM(m0) AS FLOAT) AS m0_numerator");
   });
 

--- a/packages/shared/test/product-analytics.test.ts
+++ b/packages/shared/test/product-analytics.test.ts
@@ -13,7 +13,7 @@ describe("productAnalytics", () => {
     settings: {},
   };
 
-  const helpers: SqlDialect = {
+  const helpers = {
     escapeStringLiteral: (value) => value,
     jsonExtract: (jsonCol, path, isNumeric) =>
       `${jsonCol}:'${path}'::${isNumeric ? "float" : "text"}`,
@@ -21,12 +21,16 @@ describe("productAnalytics", () => {
     dateTrunc: (col, granularity) => `date_trunc('${granularity}', ${col})`,
     percentileApprox: (col, quantile) =>
       `APPROX_PERCENTILE(${col}, ${quantile})`,
+    hllReaggregate: (col) => `HLL_MERGE(${col})`,
+    hllCardinality: (col) => `HLL_COUNT(${col})`,
+    kllMergePartial: (col) => `KLL_MERGE(${col})`,
+    kllExtractPoint: (col, quantile) => `KLL_POINT(${col}, ${quantile})`,
     toTimestamp: (d: Date) =>
       // Do not include the timestamp component to make the test deterministic
       `'${d.toISOString().substring(0, 10)} 00:00:00'`,
     formatDialect: "bigquery",
     castToFloat: (col) => `CAST(${col} AS FLOAT)`,
-  };
+  } as Partial<SqlDialect> as SqlDialect;
 
   const factTableMap = new Map<string, FactTableInterface>([
     [
@@ -105,6 +109,106 @@ describe("productAnalytics", () => {
   ]);
 
   const metricMap = new Map<string, FactMetricInterface>();
+
+  const sketchFactTableMap = new Map<string, FactTableInterface>([
+    [
+      "sketches",
+      {
+        ...factTableMap.get("orders")!,
+        id: "sketches",
+        name: "Sketches",
+        sql: "SELECT user_id, timestamp, users_hll, latency_kll FROM sketches",
+        columns: [
+          ...factTableMap.get("orders")!.columns,
+          {
+            column: "users_hll",
+            datatype: "binary",
+            dateCreated: new Date(),
+            dateUpdated: new Date(),
+            name: "users_hll",
+            description: "",
+            numberFormat: "",
+            alwaysInlineFilter: false,
+            deleted: false,
+            autoSlices: [],
+            isAutoSliceColumn: false,
+          },
+          {
+            column: "latency_kll",
+            datatype: "binary",
+            dateCreated: new Date(),
+            dateUpdated: new Date(),
+            name: "latency_kll",
+            description: "",
+            numberFormat: "",
+            alwaysInlineFilter: false,
+            deleted: false,
+            autoSlices: [],
+            isAutoSliceColumn: false,
+          },
+        ],
+      },
+    ],
+  ]);
+
+  const sketchMetricMap = new Map<string, FactMetricInterface>([
+    [
+      "hll_metric",
+      {
+        id: "hll_metric",
+        name: "Users HLL",
+        metricType: "mean",
+        numerator: {
+          factTableId: "sketches",
+          column: "users_hll",
+          aggregation: "hll merge",
+        },
+        denominator: null,
+        cappingSettings: {
+          type: "",
+          value: 0,
+        },
+        windowSettings: {
+          type: "",
+          delayValue: 0,
+          delayUnit: "days",
+          windowValue: 0,
+          windowUnit: "days",
+        },
+        quantileSettings: null,
+      } as FactMetricInterface,
+    ],
+    [
+      "kll_metric",
+      {
+        id: "kll_metric",
+        name: "Latency KLL",
+        metricType: "quantile",
+        numerator: {
+          factTableId: "sketches",
+          column: "latency_kll",
+          aggregation: "kll merge",
+        },
+        denominator: null,
+        cappingSettings: {
+          type: "",
+          value: 0,
+        },
+        windowSettings: {
+          type: "",
+          delayValue: 0,
+          delayUnit: "days",
+          windowValue: 0,
+          windowUnit: "days",
+        },
+        quantileSettings: {
+          type: "event",
+          quantile: 0.9,
+          ignoreZeros: false,
+        },
+      } as FactMetricInterface,
+    ],
+  ]);
 
   it("generates SQL for fact tables", () => {
     const config: ExplorationConfig = {
@@ -635,5 +739,101 @@ describe("productAnalytics", () => {
     );
 
     expect(sql).toEqual(expected);
+  });
+
+  it("generates SQL for HLL merge metric unit aggregation", () => {
+    const config: ExplorationConfig = {
+      type: "metric",
+      datasource: "ds_1",
+      chartType: "line",
+      showAs: "total",
+      dateRange: {
+        predefined: "last7Days",
+        startDate: null,
+        endDate: null,
+        lookbackValue: null,
+        lookbackUnit: null,
+      },
+      dimensions: [
+        {
+          dimensionType: "date",
+          column: null,
+          dateGranularity: "day",
+        },
+      ],
+      dataset: {
+        type: "metric",
+        values: [
+          {
+            name: "Users HLL",
+            type: "metric",
+            metricId: "hll_metric",
+            rowFilters: [],
+            unit: "user_id",
+            denominatorUnit: null,
+          },
+        ],
+      },
+    };
+
+    const { sql } = generateProductAnalyticsSQL(
+      config,
+      sketchFactTableMap,
+      sketchMetricMap,
+      helpers,
+      datasource,
+    );
+
+    expect(sql).toMatch(/HLL_COUNT\s*\(\s*HLL_MERGE\s*\(\s*m0\s*\)\s*\)\s+AS\s+m0/);
+    expect(sql).toContain("CAST(SUM(m0) AS FLOAT) AS m0_numerator");
+  });
+
+  it("generates SQL for KLL merge quantile rollup", () => {
+    const config: ExplorationConfig = {
+      type: "metric",
+      datasource: "ds_1",
+      chartType: "line",
+      showAs: "total",
+      dateRange: {
+        predefined: "last7Days",
+        startDate: null,
+        endDate: null,
+        lookbackValue: null,
+        lookbackUnit: null,
+      },
+      dimensions: [
+        {
+          dimensionType: "date",
+          column: null,
+          dateGranularity: "day",
+        },
+      ],
+      dataset: {
+        type: "metric",
+        values: [
+          {
+            name: "Latency KLL",
+            type: "metric",
+            metricId: "kll_metric",
+            rowFilters: [],
+            unit: null,
+            denominatorUnit: null,
+          },
+        ],
+      },
+    };
+
+    const { sql } = generateProductAnalyticsSQL(
+      config,
+      sketchFactTableMap,
+      sketchMetricMap,
+      helpers,
+      datasource,
+    );
+
+    expect(sql).toMatch(
+      /CAST\s*\(\s*KLL_POINT\s*\(\s*KLL_MERGE\s*\(\s*m0\s*\),\s*0\.9\s*\)\s+AS\s+FLOAT\s*\)\s+AS\s+m0_numerator/,
+    );
+    expect(sql).not.toContain("APPROX_PERCENTILE(m0, 0.9)");
   });
 });

--- a/packages/shared/types/integrations.d.ts
+++ b/packages/shared/types/integrations.d.ts
@@ -172,7 +172,7 @@ export type FactMetricQuantileData = {
   // KLL sketch column). In that case n_events must be aggregated by
   // SUM-ing the paired '<sketch>_n_events' column rather than COUNT-ing
   // sketch rows.
-  isKllMerge?: boolean;
+  isKllMerge: boolean;
 };
 
 export type FactMetricPercentileData = {

--- a/packages/shared/types/integrations.d.ts
+++ b/packages/shared/types/integrations.d.ts
@@ -168,6 +168,11 @@ export type FactMetricQuantileData = {
   valueCol: string;
   outputCol: string;
   metricQuantileSettings: MetricQuantileSettings;
+  // True when the metric's numerator uses 'kll merge' (pre-aggregated
+  // KLL sketch column). In that case n_events must be aggregated by
+  // SUM-ing the paired '<sketch>_n_events' column rather than COUNT-ing
+  // sketch rows.
+  isKllMerge?: boolean;
 };
 
 export type FactMetricPercentileData = {


### PR DESCRIPTION
# feat(fact-metrics): "hll merge" / "kll merge" column aggregations for pre-built sketch columns

## Motivation

We run GrowthBook against pre-aggregated fact tables where the heavy lifting happens upstream: an hourly job rolls raw events up to one row per user-hour, and for distinct-count and percentile inputs it stores **BigQuery sketch columns** (`HLL_COUNT.INIT(...)` / `KLL_QUANTILES.INIT_FLOAT64(...)` → `BYTES`) rather than raw values.

Today `columnAggregation` only supports `sum | max | count distinct`, so there's no way to tell a fact metric "this column is already a sketch — merge it, don't re-init it." That forces us either back onto the raw event table (billions of rows per experiment query) or onto a separate non-GrowthBook stats path.

#5532 added every dialect primitive this needs (`hllReaggregate`, `hllCardinality`, `kllMergePartial`, `kllExtractPoint`, `kllRankApprox`) for the incremental-refresh pipeline. This PR is the small follow-up that wires those same primitives to a `columnAggregation` value so a fact metric can consume a pre-built sketch column directly.

## Changes

- **`columnAggregation` enum** — add `"hll merge"` and `"kll merge"` in `shared/validators/fact-table.ts` and the duplicated API / bulk-import validators; update `.describe()` strings; regenerate `back-end/generated/spec.yaml`.
- **`getAggregationMetadata`** (`back-end/src/integrations/sql/fact-metrics/aggregation-metadata.ts`) — two new branches:
  - `"hll merge"`: identical to `"count distinct"` but `partialAggregationFunction` / `fullAggregationFunction` call `dialect.hllReaggregate` (BigQuery `HLL_COUNT.MERGE_PARTIAL`) instead of `dialect.hllAggregate` (`HLL_COUNT.INIT`). Result is an integer per user, so mean/ratio statistics work unchanged.
  - `"kll merge"`: identical to the existing event-quantile branch but `partialAggregationFunction` calls `dialect.kllMergePartial` (`KLL_QUANTILES.MERGE_PARTIAL`) instead of `dialect.kllInit`. Guarded to `metricType: "quantile"` + `quantileSettings.type: "event"`. The two-pass KLL rank-recovery path from #5532 is reused as-is.
- **`validateAggregationSpecification`** (`back-end/src/api/fact-metrics/postFactMetric.ts`) — reject `hll merge` / `kll merge` on `string` / `number` columns with a clear error.
- **Tests** (`back-end/test/integrations/BigQuery.test.ts`) — 4 new cases:
  - `"hll merge"` emits `HLL_COUNT.MERGE_PARTIAL` + `HLL_COUNT.EXTRACT`, never `HLL_COUNT.INIT`.
  - `"kll merge"` emits `KLL_QUANTILES.MERGE_PARTIAL`, never `INIT_FLOAT64`.
  - `"kll merge"` on a non-event-quantile metric falls through (guard holds).
  - E2E `getInsertMetricSourceDataQuery` with a `"kll merge"` metric emits `MERGE_PARTIAL` and not `INIT`.

**No new dialect primitives, no new capability flags.** The base dialect already throws on `hllReaggregate` / `kllMergePartial`, so data sources without HLL/KLL support fail with the existing message. The front-end metric modal is untouched — these aggregations are API-first for programmatically managed metrics; happy to add UI in a follow-up if wanted.

## Example

```yaml
# p90 latency from a pre-built KLL sketch column
- id: fact__latency_p90
  metricType: quantile
  quantileSettings: { quantile: 0.9, type: event }
  numerator:
    factTableId: ftb__hourly_events
    column: latency_ms_kll       # BYTES, KLL_QUANTILES.INIT_FLOAT64 upstream
    aggregation: "kll merge"

# distinct sessions per user from a pre-built HLL sketch column
- id: fact__sessions_per_user
  metricType: mean
  numerator:
    factTableId: ftb__hourly_events
    column: session_id_hll       # BYTES, HLL_COUNT.INIT upstream
    aggregation: "hll merge"
```

Generated per-user SQL (BigQuery):

```sql
-- kll merge
KLL_QUANTILES.MERGE_PARTIAL(m0_value) AS m0_value           -- BYTES per user

-- hll merge
HLL_COUNT.EXTRACT(HLL_COUNT.MERGE_PARTIAL(m1_value)) AS ... -- INT64 per user
```

## Impact

Lets experiment queries for distinct-count and event-percentile metrics run against pre-aggregated roll-ups instead of raw event tables — in our case that moves a class of metrics from billions of rows scanned per query to the hourly grain.

## Testing

- `pnpm --filter shared run type-check` — clean
- `pnpm --filter back-end run type-check` — clean
- `pnpm --filter shared run test` — 620 passed
- `pnpm --filter back-end run test -- test/integrations/` — 23 passed (4 new)
- `eslint` on changed files — clean
