### PR TITLE
Improves getSubscriptionFromLicense lookup

### DIFF
--- a/packages/back-end/src/enterprise/licenseUtil.ts
+++ b/packages/back-end/src/enterprise/licenseUtil.ts
@@ -63,7 +63,7 @@ export function getSubscriptionFromLicense(
   if (!sub) return null;
 
   return {
-    billingPlatform: license.orbSubscription ? "orb" : "stripe",
+    billingPlatform: orbSub ? "orb" : "stripe",
     externalId: sub.id,
     trialEnd: sub.trialEnd,
     status: getStripeSubscriptionStatus(sub.status),

--- a/packages/back-end/src/enterprise/licenseUtil.ts
+++ b/packages/back-end/src/enterprise/licenseUtil.ts
@@ -54,7 +54,11 @@ function getStripeSubscriptionStatus(
 export function getSubscriptionFromLicense(
   license: Partial<LicenseInterface>,
 ): SubscriptionInfo | null {
-  const sub = license.orbSubscription || license.stripeSubscription;
+  const orbSub = license.orbSubscription?.id ? license.orbSubscription : null;
+  const stripeSub = license.stripeSubscription?.id
+    ? license.stripeSubscription
+    : null;
+  const sub = orbSub || stripeSub;
 
   if (!sub) return null;
 


### PR DESCRIPTION
### Features and Changes

Fixes a 404 from Orb when an org with a placeholder subscription record visits the Usage or Billing pages.

A customer org had `orbSubscription: { id: "" }` persisted on its license (the field was set manually via our license admin tool without a real Orb subscription being created). `getSubscriptionFromLicense` only checked for the existence of the `orbSubscription`/`stripeSubscription` object, not for a real `id`, so it returned a `SubscriptionInfo` with `billingPlatform: "orb"` and an empty `externalId`. The front-end then mounted `OrbPortal`, which called `/subscription/portal-url` → license server → Orb, producing:

> `404 Could not find a resource of type Customer with external_customer_id: org_...`

This change requires a non-empty `id` on the subscription stub before treating it as a real subscription. With no valid id, `getSubscriptionFromLicense` returns `null`, and all downstream consumers (`usage.tsx`, `billing.tsx`, `SubscriptionInfo.tsx`, `shouldLimitAccessDueToExpiredLicense`, `UserContext`) fall through to their non-subscription branches as intended.

- Closes **(add link to issue here)**

### Dependencies

None.

### Testing

- [x] Org with a real Orb subscription: Usage page still renders `OrbPortal` and Billing page still shows Orb-specific UI.
- [x] Org with a real Stripe subscription: Usage page renders `CloudUsage` and Billing page shows Stripe-specific UI as before.
- [x] Org with a placeholder `orbSubscription: { id: "" }` (repro of the reported bug): Usage page now renders `CloudUsage` instead of `OrbPortal`, and no Orb portal-url request is made. No 404.
- [x] Org with no subscription at all: behavior unchanged.

### Screenshots