### PR TITLE
Fix several auth bugs

### DIFF
--- a/packages/back-end/src/app.ts
+++ b/packages/back-end/src/app.ts
@@ -103,6 +103,7 @@ import { isEmailEnabled } from "./services/email";
 import { init } from "./init";
 import { aiRouter } from "./routers/ai/ai.router";
 import { getCustomLogProps, httpLogger, logger } from "./util/logger";
+import { shouldSkipErrorLog } from "./util/errors";
 import { usersRouter } from "./routers/users/users.router";
 import { organizationsRouter } from "./routers/organizations/organizations.router";
 import { uploadRouter } from "./routers/upload/upload.router";
@@ -1122,7 +1123,9 @@ app.use(function (req, res) {
 });
 
 if (SENTRY_DSN) {
-  Sentry.setupExpressErrorHandler(app);
+  Sentry.setupExpressErrorHandler(app, {
+    shouldHandleError: (err) => !shouldSkipErrorLog(err),
+  });
 }
 
 const errorHandler: ErrorRequestHandler = (
@@ -1133,11 +1136,12 @@ const errorHandler: ErrorRequestHandler = (
   next,
 ) => {
   const status = err.status || 400;
+  const level = shouldSkipErrorLog(err) ? "debug" : "error";
 
   if (req.log) {
-    req.log.error(err.message);
+    req.log[level](err.message);
   } else {
-    httpLogger.logger.error(getCustomLogProps(req), err.message);
+    httpLogger.logger[level](getCustomLogProps(req), err.message);
   }
 
   res.status(status).json({

--- a/packages/back-end/src/controllers/auth.ts
+++ b/packages/back-end/src/controllers/auth.ts
@@ -69,7 +69,7 @@ export async function postRefresh(req: Request, res: Response) {
       expiresIn,
     } = await auth.refresh(req, res, refreshToken);
 
-    IdTokenCookie.setValue(idToken, req, res, expiresIn);
+    IdTokenCookie.setValue(idToken, req, res, expiresIn * 1000);
     if (newRefreshToken) {
       RefreshTokenCookie.setValue(newRefreshToken, req, res);
     }
@@ -101,7 +101,7 @@ export async function postOAuthCallback(req: Request, res: Response) {
     }
 
     RefreshTokenCookie.setValue(refreshToken, req, res);
-    IdTokenCookie.setValue(idToken, req, res, expiresIn);
+    IdTokenCookie.setValue(idToken, req, res, expiresIn * 1000);
 
     return res.status(200).json({
       status: 200,
@@ -137,7 +137,7 @@ export async function setResponseCookies(
     idToken,
     req,
     res,
-    Math.max(10 * 60 * 1000, expiresIn),
+    Math.max(10 * 60 * 1000, expiresIn * 1000),
   );
   RefreshTokenCookie.setValue(refreshToken, req, res);
 

--- a/packages/back-end/src/models/UserModel.ts
+++ b/packages/back-end/src/models/UserModel.ts
@@ -1,7 +1,6 @@
 import mongoose from "mongoose";
 import uniqid from "uniqid";
 import escapeRegExp from "lodash/escapeRegExp";
-import { Document } from "mongodb";
 import { UserInterface } from "shared/types/user";
 import {
   usingOpenId,
@@ -166,32 +165,6 @@ export async function createUser({
       agreedToTerms,
     }),
   );
-}
-
-export async function findVerifiedEmails(
-  emails: string[] | undefined,
-): Promise<string[]> {
-  let users: Document[] = [];
-  if (emails) {
-    // Match either the input casing or its lowercased form so callers don't
-    // miss accounts that were stored in lowercase by `createUser`.
-    const variants = Array.from(
-      new Set([...emails, ...emails.map((e) => e.toLowerCase())]),
-    );
-    users = await getCollection(COLLECTION)
-      .find({
-        email: { $in: variants },
-        verified: true,
-      })
-      .toArray();
-  } else {
-    users = await getCollection(COLLECTION)
-      .find({
-        verified: true,
-      })
-      .toArray();
-  }
-  return users.map((u) => u.email);
 }
 
 export async function resetMinTokenDate(userId: string) {

--- a/packages/back-end/src/models/UserModel.ts
+++ b/packages/back-end/src/models/UserModel.ts
@@ -24,6 +24,15 @@ const userSchema = new mongoose.Schema({
     type: String,
     unique: true,
   },
+  // Lowercased copy of `email`, used as the canonical lookup key for
+  // case-insensitive matches. Not unique — a small number of legacy
+  // duplicate accounts (e.g. `User@x.com` + `user@x.com`) may share an
+  // emailLower, and the case-sensitive `email` lookup is what
+  // disambiguates them.
+  emailLower: {
+    type: String,
+    index: true,
+  },
   passwordHash: String,
   superAdmin: Boolean,
   verified: Boolean,
@@ -36,8 +45,11 @@ const UserModel = mongoose.model<UserInterface>("User", userSchema);
 const COLLECTION = "users";
 
 const toInterface: ToInterface<UserInterface> = (doc) => {
-  const obj = removeMongooseFields(doc);
+  const obj = removeMongooseFields(doc) as UserInterface & {
+    emailLower?: string;
+  };
   if (!obj.dateCreated) obj.dateCreated = doc._id?.getTimestamp();
+  delete obj.emailLower;
   return obj;
 };
 
@@ -105,17 +117,34 @@ export async function getUserById(id: string): Promise<UserInterface | null> {
 export async function getUserByEmail(
   email: string,
 ): Promise<UserInterface | null> {
-  // Exact case-sensitive match wins so existing duplicate accounts (e.g.
-  // `User@x.com` and `user@x.com`) keep resolving to their own row.
-  const exact = await getCollection(COLLECTION).findOne({ email });
+  const collection = getCollection(COLLECTION);
+
+  // 1. Exact case-sensitive match wins so existing duplicate accounts (e.g.
+  //    `User@x.com` and `user@x.com`) keep resolving to their own row.
+  const exact = await collection.findOne({ email });
   if (exact) return toInterface(exact);
 
-  // Fall back to case-insensitive match so we don't create a new duplicate
-  // when a SSO provider sends a different casing than what's already stored.
-  const ci = await getCollection(COLLECTION).findOne({
+  // 2. Indexed lookup on the canonical lowercase form. Catches the case
+  //    where the input casing differs from the stored casing.
+  const lower = email.toLowerCase();
+  const lowerHit = await collection.findOne({ emailLower: lower });
+  if (lowerHit) return toInterface(lowerHit);
+
+  // 3. Last-resort full collection scan, only for legacy rows written
+  //    before `emailLower` was populated. On hit, backfill `emailLower`
+  //    so subsequent lookups for this user go through path 2.
+  const ci = await collection.findOne({
     email: { $regex: `^${escapeRegExp(email)}$`, $options: "i" },
   });
-  return ci ? toInterface(ci) : null;
+  if (ci) {
+    await collection.updateOne(
+      { _id: ci._id },
+      { $set: { emailLower: (ci.email || "").toLowerCase() } },
+    );
+    return toInterface(ci);
+  }
+
+  return null;
 }
 
 export async function getUsersByIds(ids: string[]): Promise<UserInterface[]> {
@@ -156,7 +185,8 @@ export async function createUser({
   return toInterface(
     await UserModel.create({
       name,
-      email: email.toLowerCase(),
+      email,
+      emailLower: email.toLowerCase(),
       passwordHash,
       id: uniqid("u_"),
       verified,

--- a/packages/back-end/src/models/UserModel.ts
+++ b/packages/back-end/src/models/UserModel.ts
@@ -1,5 +1,6 @@
 import mongoose from "mongoose";
 import uniqid from "uniqid";
+import escapeRegExp from "lodash/escapeRegExp";
 import { Document } from "mongodb";
 import { UserInterface } from "shared/types/user";
 import {
@@ -105,8 +106,17 @@ export async function getUserById(id: string): Promise<UserInterface | null> {
 export async function getUserByEmail(
   email: string,
 ): Promise<UserInterface | null> {
-  const user = await getCollection(COLLECTION).findOne({ email });
-  return user ? toInterface(user) : null;
+  // Exact case-sensitive match wins so existing duplicate accounts (e.g.
+  // `User@x.com` and `user@x.com`) keep resolving to their own row.
+  const exact = await getCollection(COLLECTION).findOne({ email });
+  if (exact) return toInterface(exact);
+
+  // Fall back to case-insensitive match so we don't create a new duplicate
+  // when a SSO provider sends a different casing than what's already stored.
+  const ci = await getCollection(COLLECTION).findOne({
+    email: { $regex: `^${escapeRegExp(email)}$`, $options: "i" },
+  });
+  return ci ? toInterface(ci) : null;
 }
 
 export async function getUsersByIds(ids: string[]): Promise<UserInterface[]> {
@@ -147,7 +157,7 @@ export async function createUser({
   return toInterface(
     await UserModel.create({
       name,
-      email,
+      email: email.toLowerCase(),
       passwordHash,
       id: uniqid("u_"),
       verified,
@@ -163,9 +173,14 @@ export async function findVerifiedEmails(
 ): Promise<string[]> {
   let users: Document[] = [];
   if (emails) {
+    // Match either the input casing or its lowercased form so callers don't
+    // miss accounts that were stored in lowercase by `createUser`.
+    const variants = Array.from(
+      new Set([...emails, ...emails.map((e) => e.toLowerCase())]),
+    );
     users = await getCollection(COLLECTION)
       .find({
-        email: { $in: emails },
+        email: { $in: variants },
         verified: true,
       })
       .toArray();

--- a/packages/back-end/src/models/UserModel.ts
+++ b/packages/back-end/src/models/UserModel.ts
@@ -1,6 +1,5 @@
 import mongoose from "mongoose";
 import uniqid from "uniqid";
-import escapeRegExp from "lodash/escapeRegExp";
 import { UserInterface } from "shared/types/user";
 import {
   usingOpenId,
@@ -24,15 +23,6 @@ const userSchema = new mongoose.Schema({
     type: String,
     unique: true,
   },
-  // Lowercased copy of `email`, used as the canonical lookup key for
-  // case-insensitive matches. Not unique — a small number of legacy
-  // duplicate accounts (e.g. `User@x.com` + `user@x.com`) may share an
-  // emailLower, and the case-sensitive `email` lookup is what
-  // disambiguates them.
-  emailLower: {
-    type: String,
-    index: true,
-  },
   passwordHash: String,
   superAdmin: Boolean,
   verified: Boolean,
@@ -45,11 +35,8 @@ const UserModel = mongoose.model<UserInterface>("User", userSchema);
 const COLLECTION = "users";
 
 const toInterface: ToInterface<UserInterface> = (doc) => {
-  const obj = removeMongooseFields(doc) as UserInterface & {
-    emailLower?: string;
-  };
+  const obj = removeMongooseFields(doc);
   if (!obj.dateCreated) obj.dateCreated = doc._id?.getTimestamp();
-  delete obj.emailLower;
   return obj;
 };
 
@@ -119,29 +106,19 @@ export async function getUserByEmail(
 ): Promise<UserInterface | null> {
   const collection = getCollection(COLLECTION);
 
-  // 1. Exact case-sensitive match wins so existing duplicate accounts (e.g.
-  //    `User@x.com` and `user@x.com`) keep resolving to their own row.
+  // Exact case-sensitive match. Existing duplicate accounts (e.g.
+  // `User@x.com` and `user@x.com`) keep resolving to their own row.
   const exact = await collection.findOne({ email });
   if (exact) return toInterface(exact);
 
-  // 2. Indexed lookup on the canonical lowercase form. Catches the case
-  //    where the input casing differs from the stored casing.
+  // If the input had any uppercase, retry with the lowercased form.
+  // `createUser` lowercases on insert, so for any account created
+  // after this fix landed this second lookup hits the unique `email`
+  // index — no scan.
   const lower = email.toLowerCase();
-  const lowerHit = await collection.findOne({ emailLower: lower });
-  if (lowerHit) return toInterface(lowerHit);
-
-  // 3. Last-resort full collection scan, only for legacy rows written
-  //    before `emailLower` was populated. On hit, backfill `emailLower`
-  //    so subsequent lookups for this user go through path 2.
-  const ci = await collection.findOne({
-    email: { $regex: `^${escapeRegExp(email)}$`, $options: "i" },
-  });
-  if (ci) {
-    await collection.updateOne(
-      { _id: ci._id },
-      { $set: { emailLower: (ci.email || "").toLowerCase() } },
-    );
-    return toInterface(ci);
+  if (lower !== email) {
+    const lowerHit = await collection.findOne({ email: lower });
+    if (lowerHit) return toInterface(lowerHit);
   }
 
   return null;
@@ -185,8 +162,7 @@ export async function createUser({
   return toInterface(
     await UserModel.create({
       name,
-      email,
-      emailLower: email.toLowerCase(),
+      email: email.toLowerCase(),
       passwordHash,
       id: uniqid("u_"),
       verified,

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -623,8 +623,9 @@ export async function putMember(
   }
 
   try {
+    const reqEmailLower = (req.email || "").toLowerCase();
     const invite: Invite | undefined = organization.invites.find(
-      (inv) => inv.email === req.email,
+      (inv) => inv.email.toLowerCase() === reqEmailLower,
     );
     if (invite) {
       // if user already invited, accept invite

--- a/packages/back-end/src/routers/organizations/organizations.controller.ts
+++ b/packages/back-end/src/routers/organizations/organizations.controller.ts
@@ -623,7 +623,7 @@ export async function putMember(
   }
 
   try {
-    const reqEmailLower = (req.email || "").toLowerCase();
+    const reqEmailLower = req.email.toLowerCase();
     const invite: Invite | undefined = organization.invites.find(
       (inv) => inv.email.toLowerCase() === reqEmailLower,
     );

--- a/packages/back-end/src/scim/users/createUser.ts
+++ b/packages/back-end/src/scim/users/createUser.ts
@@ -33,8 +33,9 @@ export async function createUser(
   }
 
   const expandedMembers = await expandOrgMembers(org.members);
+  const userNameLower = (userName || "").toLowerCase();
   const existingOrgMember = expandedMembers.find(
-    (member) => member.email === userName,
+    (member) => member.email.toLowerCase() === userNameLower,
   );
 
   const responseObj = cloneDeep(req.body);

--- a/packages/back-end/src/services/organizations.ts
+++ b/packages/back-end/src/services/organizations.ts
@@ -714,15 +714,17 @@ export async function inviteUser({
 } & MemberRoleWithProjects) {
   organization.invites = organization.invites || [];
 
-  // User is already invited
-  if (
-    organization.invites.filter((invite) => invite.email === email).length > 0
-  ) {
+  email = email.toLowerCase();
+
+  // User is already invited (legacy invites may have been stored with
+  // mixed case, so compare case-insensitively).
+  const existingInvite = organization.invites.find(
+    (invite) => invite.email.toLowerCase() === email,
+  );
+  if (existingInvite) {
     return {
       emailSent: true,
-      inviteUrl: getInviteUrl(
-        organization.invites.filter((invite) => invite.email === email)[0].key,
-      ),
+      inviteUrl: getInviteUrl(existingInvite.key),
     };
   }
 

--- a/packages/back-end/src/util/errors.ts
+++ b/packages/back-end/src/util/errors.ts
@@ -96,3 +96,17 @@ export class ConcurrentIncrementalRefreshError extends Error {
     this.name = "ConcurrentIncrementalRefreshError";
   }
 }
+
+// Some errors are part of normal operation and shouldn't pollute
+// error-level logs or Sentry. Add cases here as we identify them.
+export function shouldSkipErrorLog(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+
+  // express-jwt wraps the underlying jsonwebtoken error under `inner`.
+  // A TokenExpiredError fires every time a logged-in tab makes a request
+  // after its JWT lifespan; the front-end silently refreshes and retries.
+  const inner = (err as { inner?: { name?: string } }).inner;
+  if (inner?.name === "TokenExpiredError") return true;
+
+  return false;
+}

--- a/packages/back-end/test/models/UserModel.test.ts
+++ b/packages/back-end/test/models/UserModel.test.ts
@@ -6,80 +6,102 @@ jest.mock("back-end/src/util/mongo.util", () => ({
   removeMongooseFields: jest.fn((doc) => doc),
 }));
 
+type MockColl = {
+  findOne: jest.Mock;
+  updateOne: jest.Mock;
+};
+
+function mockCollection(findOneResults: unknown[]): MockColl {
+  const findOne = jest.fn();
+  findOneResults.forEach((r) => findOne.mockResolvedValueOnce(r));
+  const updateOne = jest.fn().mockResolvedValue({ acknowledged: true });
+  const coll: MockColl = { findOne, updateOne };
+  (getCollection as jest.Mock).mockReturnValue(coll);
+  return coll;
+}
+
 describe("getUserByEmail", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   it("returns the exact-case match without falling back", async () => {
-    const exactDoc = { id: "u_1", email: "User@Example.com", name: "Mixed" };
-    const findOne = jest
-      .fn()
-      .mockResolvedValueOnce(exactDoc)
-      .mockResolvedValueOnce(null);
-
-    (getCollection as jest.Mock).mockReturnValue({ findOne });
+    const exactDoc = {
+      id: "u_1",
+      email: "User@Example.com",
+      emailLower: "user@example.com",
+    };
+    const coll = mockCollection([exactDoc]);
 
     const result = await getUserByEmail("User@Example.com");
 
     expect(result?.email).toBe("User@Example.com");
-    expect(findOne).toHaveBeenCalledTimes(1);
-    expect(findOne).toHaveBeenCalledWith({ email: "User@Example.com" });
+    expect(coll.findOne).toHaveBeenCalledTimes(1);
+    expect(coll.findOne).toHaveBeenCalledWith({ email: "User@Example.com" });
+    expect(coll.updateOne).not.toHaveBeenCalled();
   });
 
-  it("falls back to a case-insensitive match when the exact lookup misses", async () => {
-    const ciDoc = { id: "u_2", email: "user@example.com", name: "Lower" };
-    const findOne = jest
-      .fn()
-      .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce(ciDoc);
-
-    (getCollection as jest.Mock).mockReturnValue({ findOne });
-
-    const result = await getUserByEmail("User@Example.com");
-
-    expect(result?.email).toBe("user@example.com");
-    expect(findOne).toHaveBeenCalledTimes(2);
-    expect(findOne).toHaveBeenNthCalledWith(2, {
-      email: { $regex: "^User@Example\\.com$", $options: "i" },
-    });
-  });
-
-  it("falls back even when the input email is already lowercase", async () => {
-    // Catches the gap where a pre-existing mixed-case account would otherwise
-    // get a new lowercase duplicate created.
-    const ciDoc = { id: "u_3", email: "User@Example.com", name: "Mixed" };
-    const findOne = jest
-      .fn()
-      .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce(ciDoc);
-
-    (getCollection as jest.Mock).mockReturnValue({ findOne });
+  it("falls back to the indexed emailLower lookup when exact misses", async () => {
+    const lowerDoc = {
+      id: "u_2",
+      email: "User@Example.com",
+      emailLower: "user@example.com",
+    };
+    const coll = mockCollection([null, lowerDoc]);
 
     const result = await getUserByEmail("user@example.com");
 
     expect(result?.email).toBe("User@Example.com");
-    expect(findOne).toHaveBeenCalledTimes(2);
+    expect(coll.findOne).toHaveBeenCalledTimes(2);
+    expect(coll.findOne).toHaveBeenNthCalledWith(2, {
+      emailLower: "user@example.com",
+    });
+    // emailLower already present, no backfill needed
+    expect(coll.updateOne).not.toHaveBeenCalled();
   });
 
-  it("escapes regex metacharacters in the fallback query", async () => {
-    const findOne = jest.fn().mockResolvedValue(null);
-    (getCollection as jest.Mock).mockReturnValue({ findOne });
+  it("falls back to regex scan only when both indexed lookups miss, and backfills emailLower", async () => {
+    const legacyDoc = {
+      _id: "mongoid_3",
+      id: "u_3",
+      email: "User@Example.com",
+      dateCreated: new Date(),
+      // No emailLower — this is a pre-fix legacy row
+    };
+    const coll = mockCollection([null, null, legacyDoc]);
+
+    const result = await getUserByEmail("user@example.com");
+
+    expect(result?.email).toBe("User@Example.com");
+    expect(coll.findOne).toHaveBeenCalledTimes(3);
+    expect(coll.findOne).toHaveBeenNthCalledWith(3, {
+      email: { $regex: "^user@example\\.com$", $options: "i" },
+    });
+    // Backfill so the next lookup goes through path 2 (indexed)
+    expect(coll.updateOne).toHaveBeenCalledTimes(1);
+    expect(coll.updateOne).toHaveBeenCalledWith(
+      { _id: "mongoid_3" },
+      { $set: { emailLower: "user@example.com" } },
+    );
+  });
+
+  it("escapes regex metacharacters in the legacy fallback", async () => {
+    const coll = mockCollection([null, null, null]);
 
     await getUserByEmail("a.b+c@x.com");
 
-    expect(findOne).toHaveBeenNthCalledWith(2, {
+    expect(coll.findOne).toHaveBeenNthCalledWith(3, {
       email: { $regex: "^a\\.b\\+c@x\\.com$", $options: "i" },
     });
   });
 
-  it("returns null when neither lookup matches", async () => {
-    const findOne = jest.fn().mockResolvedValue(null);
-    (getCollection as jest.Mock).mockReturnValue({ findOne });
+  it("returns null when none of the three lookups match", async () => {
+    const coll = mockCollection([null, null, null]);
 
     const result = await getUserByEmail("nobody@example.com");
 
     expect(result).toBeNull();
-    expect(findOne).toHaveBeenCalledTimes(2);
+    expect(coll.findOne).toHaveBeenCalledTimes(3);
+    expect(coll.updateOne).not.toHaveBeenCalled();
   });
 });

--- a/packages/back-end/test/models/UserModel.test.ts
+++ b/packages/back-end/test/models/UserModel.test.ts
@@ -6,18 +6,11 @@ jest.mock("back-end/src/util/mongo.util", () => ({
   removeMongooseFields: jest.fn((doc) => doc),
 }));
 
-type MockColl = {
-  findOne: jest.Mock;
-  updateOne: jest.Mock;
-};
-
-function mockCollection(findOneResults: unknown[]): MockColl {
+function mockFindOne(results: unknown[]): jest.Mock {
   const findOne = jest.fn();
-  findOneResults.forEach((r) => findOne.mockResolvedValueOnce(r));
-  const updateOne = jest.fn().mockResolvedValue({ acknowledged: true });
-  const coll: MockColl = { findOne, updateOne };
-  (getCollection as jest.Mock).mockReturnValue(coll);
-  return coll;
+  results.forEach((r) => findOne.mockResolvedValueOnce(r));
+  (getCollection as jest.Mock).mockReturnValue({ findOne });
+  return findOne;
 }
 
 describe("getUserByEmail", () => {
@@ -26,82 +19,42 @@ describe("getUserByEmail", () => {
   });
 
   it("returns the exact-case match without falling back", async () => {
-    const exactDoc = {
-      id: "u_1",
-      email: "User@Example.com",
-      emailLower: "user@example.com",
-    };
-    const coll = mockCollection([exactDoc]);
+    const exactDoc = { id: "u_1", email: "User@Example.com" };
+    const findOne = mockFindOne([exactDoc]);
 
     const result = await getUserByEmail("User@Example.com");
 
     expect(result?.email).toBe("User@Example.com");
-    expect(coll.findOne).toHaveBeenCalledTimes(1);
-    expect(coll.findOne).toHaveBeenCalledWith({ email: "User@Example.com" });
-    expect(coll.updateOne).not.toHaveBeenCalled();
+    expect(findOne).toHaveBeenCalledTimes(1);
+    expect(findOne).toHaveBeenCalledWith({ email: "User@Example.com" });
   });
 
-  it("falls back to the indexed emailLower lookup when exact misses", async () => {
-    const lowerDoc = {
-      id: "u_2",
-      email: "User@Example.com",
-      emailLower: "user@example.com",
-    };
-    const coll = mockCollection([null, lowerDoc]);
+  it("retries with the lowercased email when the input had uppercase and exact missed", async () => {
+    const lowerDoc = { id: "u_2", email: "user@example.com" };
+    const findOne = mockFindOne([null, lowerDoc]);
+
+    const result = await getUserByEmail("User@Example.com");
+
+    expect(result?.email).toBe("user@example.com");
+    expect(findOne).toHaveBeenCalledTimes(2);
+    expect(findOne).toHaveBeenNthCalledWith(2, { email: "user@example.com" });
+  });
+
+  it("does not retry when the input is already lowercase", async () => {
+    const findOne = mockFindOne([null]);
 
     const result = await getUserByEmail("user@example.com");
-
-    expect(result?.email).toBe("User@Example.com");
-    expect(coll.findOne).toHaveBeenCalledTimes(2);
-    expect(coll.findOne).toHaveBeenNthCalledWith(2, {
-      emailLower: "user@example.com",
-    });
-    // emailLower already present, no backfill needed
-    expect(coll.updateOne).not.toHaveBeenCalled();
-  });
-
-  it("falls back to regex scan only when both indexed lookups miss, and backfills emailLower", async () => {
-    const legacyDoc = {
-      _id: "mongoid_3",
-      id: "u_3",
-      email: "User@Example.com",
-      dateCreated: new Date(),
-      // No emailLower — this is a pre-fix legacy row
-    };
-    const coll = mockCollection([null, null, legacyDoc]);
-
-    const result = await getUserByEmail("user@example.com");
-
-    expect(result?.email).toBe("User@Example.com");
-    expect(coll.findOne).toHaveBeenCalledTimes(3);
-    expect(coll.findOne).toHaveBeenNthCalledWith(3, {
-      email: { $regex: "^user@example\\.com$", $options: "i" },
-    });
-    // Backfill so the next lookup goes through path 2 (indexed)
-    expect(coll.updateOne).toHaveBeenCalledTimes(1);
-    expect(coll.updateOne).toHaveBeenCalledWith(
-      { _id: "mongoid_3" },
-      { $set: { emailLower: "user@example.com" } },
-    );
-  });
-
-  it("escapes regex metacharacters in the legacy fallback", async () => {
-    const coll = mockCollection([null, null, null]);
-
-    await getUserByEmail("a.b+c@x.com");
-
-    expect(coll.findOne).toHaveBeenNthCalledWith(3, {
-      email: { $regex: "^a\\.b\\+c@x\\.com$", $options: "i" },
-    });
-  });
-
-  it("returns null when none of the three lookups match", async () => {
-    const coll = mockCollection([null, null, null]);
-
-    const result = await getUserByEmail("nobody@example.com");
 
     expect(result).toBeNull();
-    expect(coll.findOne).toHaveBeenCalledTimes(3);
-    expect(coll.updateOne).not.toHaveBeenCalled();
+    expect(findOne).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns null when neither lookup matches", async () => {
+    const findOne = mockFindOne([null, null]);
+
+    const result = await getUserByEmail("Nobody@Example.com");
+
+    expect(result).toBeNull();
+    expect(findOne).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/back-end/test/models/UserModel.test.ts
+++ b/packages/back-end/test/models/UserModel.test.ts
@@ -1,0 +1,85 @@
+import { getUserByEmail } from "back-end/src/models/UserModel";
+import { getCollection } from "back-end/src/util/mongo.util";
+
+jest.mock("back-end/src/util/mongo.util", () => ({
+  getCollection: jest.fn(),
+  removeMongooseFields: jest.fn((doc) => doc),
+}));
+
+describe("getUserByEmail", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns the exact-case match without falling back", async () => {
+    const exactDoc = { id: "u_1", email: "User@Example.com", name: "Mixed" };
+    const findOne = jest
+      .fn()
+      .mockResolvedValueOnce(exactDoc)
+      .mockResolvedValueOnce(null);
+
+    (getCollection as jest.Mock).mockReturnValue({ findOne });
+
+    const result = await getUserByEmail("User@Example.com");
+
+    expect(result?.email).toBe("User@Example.com");
+    expect(findOne).toHaveBeenCalledTimes(1);
+    expect(findOne).toHaveBeenCalledWith({ email: "User@Example.com" });
+  });
+
+  it("falls back to a case-insensitive match when the exact lookup misses", async () => {
+    const ciDoc = { id: "u_2", email: "user@example.com", name: "Lower" };
+    const findOne = jest
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(ciDoc);
+
+    (getCollection as jest.Mock).mockReturnValue({ findOne });
+
+    const result = await getUserByEmail("User@Example.com");
+
+    expect(result?.email).toBe("user@example.com");
+    expect(findOne).toHaveBeenCalledTimes(2);
+    expect(findOne).toHaveBeenNthCalledWith(2, {
+      email: { $regex: "^User@Example\\.com$", $options: "i" },
+    });
+  });
+
+  it("falls back even when the input email is already lowercase", async () => {
+    // Catches the gap where a pre-existing mixed-case account would otherwise
+    // get a new lowercase duplicate created.
+    const ciDoc = { id: "u_3", email: "User@Example.com", name: "Mixed" };
+    const findOne = jest
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(ciDoc);
+
+    (getCollection as jest.Mock).mockReturnValue({ findOne });
+
+    const result = await getUserByEmail("user@example.com");
+
+    expect(result?.email).toBe("User@Example.com");
+    expect(findOne).toHaveBeenCalledTimes(2);
+  });
+
+  it("escapes regex metacharacters in the fallback query", async () => {
+    const findOne = jest.fn().mockResolvedValue(null);
+    (getCollection as jest.Mock).mockReturnValue({ findOne });
+
+    await getUserByEmail("a.b+c@x.com");
+
+    expect(findOne).toHaveBeenNthCalledWith(2, {
+      email: { $regex: "^a\\.b\\+c@x\\.com$", $options: "i" },
+    });
+  });
+
+  it("returns null when neither lookup matches", async () => {
+    const findOne = jest.fn().mockResolvedValue(null);
+    (getCollection as jest.Mock).mockReturnValue({ findOne });
+
+    const result = await getUserByEmail("nobody@example.com");
+
+    expect(result).toBeNull();
+    expect(findOne).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary

Three independent auth fixes plus one bit of dead-code cleanup:

### 1. Stop creating duplicate user accounts on email case mismatch

Auth0 lowercases emails before issuing tokens, but federated Google logins and Enterprise SSO providers (Okta, etc.) often preserve the user's original case. We were doing case-sensitive lookups everywhere, so the same human could end up with two accounts depending on how they last logged in.

- `createUser` lowercases the email before insert, so all new accounts are stored canonically.
- `getUserByEmail` does an exact case-sensitive match first (so existing duplicates keep resolving to their own row), then if the input had any uppercase retries with the lowercased form. Both lookups hit the existing unique `email` index — no full collection scan.
- Invite emails are lowercased on creation, and the auto-accept comparison in the org controller is case-insensitive — so an invite for `Alice@example.com` now matches a login as `alice@example.com`.
- SCIM existing-member lookup is case-insensitive.

No DB migration here. Existing duplicates are left alone (will be cleaned up by a separate one-time migration). One edge case is also left for that migration: a legacy mixed-case row queried with already-lowercase input won't auto-resolve and could create a new duplicate. Rare in practice.

### 2. Fix cookie expiration off by 1000×

`expiresIn` from the auth provider is in seconds, but `IdTokenCookie.setValue` expects milliseconds. The cookie was expiring almost immediately after issue, forcing a refresh on every request. Multiply by 1000 in `postRefresh`, `postOAuthCallback`, and `setResponseCookies`.

### 3. Stop logging expected `TokenExpiredError` at error level

A logged-in tab making a request after its JWT lifespan throws `TokenExpiredError`; the front-end silently refreshes and retries. This is normal operation, but it was being logged at error level and reported to Sentry, drowning out real issues. New `shouldSkipErrorLog` helper drops these from Sentry's `shouldHandleError` and downgrades the express logger to `debug`.

### 4. Drop unused `findVerifiedEmails` helper

No callers remain in the repo. Removed it (and its now-unused `mongodb.Document` import) instead of keeping it in sync with the new email-normalization rules.

## Test plan

- [x] Back-end unit tests pass (`pnpm --filter back-end test`)
- [x] Unit tests for `getUserByEmail` cover: exact match wins, lowercased retry on miss, no retry when input is already lowercase, null on no match
- [x] Type-check + lint clean
- [x] Manual: with both `Alice@example.com` and `alice@example.com` in the DB, log in as each — each should resolve to its exact-case row
- [x] Manual: invite `Carol@example.com`, sign up via SSO as `carol@example.com` — invite should auto-accept
- [x] Manual (Cloud): log in via Auth0 mock with `email_verified=false` against a pre-existing verified account — must still 406 (existing protection still fires post-fallback)
- [x] Manual: confirm idle browser tabs no longer flood Sentry with `TokenExpiredError`
- [x] Manual: confirm session cookie now lives the full token lifetime