### PR TITLE
Fix nulls when archiving attributes

### DIFF
--- a/packages/back-end/src/routers/attributes/attributes.controller.ts
+++ b/packages/back-end/src/routers/attributes/attributes.controller.ts
@@ -84,10 +84,16 @@ export const putAttribute = async (
   }
 
   const existing = attributeSchema[index];
+  // Only pass `projects` when the client actually sent it — passing
+  // `{ projects: undefined }` would be interpreted as a request to scope the
+  // attribute globally and incorrectly deny project-scoped users.
   if (
-    !context.permissions.canUpdateAttribute(existing, {
-      projects: attributeFields.projects,
-    })
+    !context.permissions.canUpdateAttribute(
+      existing,
+      "projects" in attributeFields
+        ? { projects: attributeFields.projects }
+        : {},
+    )
   ) {
     context.permissions.throwPermissionError();
   }

--- a/packages/back-end/src/routers/attributes/attributes.controller.ts
+++ b/packages/back-end/src/routers/attributes/attributes.controller.ts
@@ -13,17 +13,7 @@ export const postAttribute = async (
   req: AuthRequest<SDKAttribute>,
   res: Response<{ status: number }>,
 ) => {
-  const {
-    property,
-    description,
-    datatype,
-    projects,
-    format,
-    enum: enumValue,
-    hashAttribute,
-    disableEqualityConditions,
-    tags = [],
-  } = req.body;
+  const { tags = [], ...attributeFields } = req.body;
   const context = getContextFromReq(req);
 
   if (!context.permissions.canCreateAttribute({ ...req.body })) {
@@ -33,7 +23,7 @@ export const postAttribute = async (
 
   const attributeSchema = org.settings?.attributeSchema || [];
 
-  if (attributeSchema.some((a) => a.property === property)) {
+  if (attributeSchema.some((a) => a.property === attributeFields.property)) {
     context.throwBadRequestError("An attribute with that name already exists");
   }
 
@@ -42,15 +32,8 @@ export const postAttribute = async (
   }
 
   const newAttribute: SDKAttribute = {
-    property,
-    description,
-    datatype,
-    projects,
-    format,
-    enum: enumValue,
-    hashAttribute,
-    disableEqualityConditions,
-    tags: tags.length > 0 ? tags : undefined,
+    ...attributeFields,
+    ...(tags.length > 0 && { tags }),
   };
 
   await updateOrganization(org.id, {
@@ -84,19 +67,7 @@ export const putAttribute = async (
   req: AuthRequest<SDKAttribute & { previousName?: string }>,
   res: Response<{ status: number }>,
 ) => {
-  const {
-    property,
-    description,
-    datatype,
-    projects,
-    format,
-    enum: enumValue,
-    hashAttribute,
-    archived,
-    disableEqualityConditions,
-    previousName,
-    tags,
-  } = req.body;
+  const { previousName, tags, ...attributeFields } = req.body;
   const context = getContextFromReq(req);
   const { org } = context;
 
@@ -104,7 +75,8 @@ export const putAttribute = async (
 
   // If the name is being changed, we need to access the attribute via its previous name
   const index = attributeSchema.findIndex(
-    (a) => a.property === (previousName ? previousName : property),
+    (a) =>
+      a.property === (previousName ? previousName : attributeFields.property),
   );
 
   if (index === -1) {
@@ -112,14 +84,18 @@ export const putAttribute = async (
   }
 
   const existing = attributeSchema[index];
-  if (!context.permissions.canUpdateAttribute(existing, { projects })) {
+  if (
+    !context.permissions.canUpdateAttribute(existing, {
+      projects: attributeFields.projects,
+    })
+  ) {
     context.permissions.throwPermissionError();
   }
 
   if (
     previousName &&
-    property !== previousName &&
-    attributeSchema.some((a) => a.property === property)
+    attributeFields.property !== previousName &&
+    attributeSchema.some((a) => a.property === attributeFields.property)
   ) {
     // If the name is being changed, check if the new name already exists
     context.throwBadRequestError("An attribute with that name already exists");
@@ -129,18 +105,11 @@ export const putAttribute = async (
     await addTagsDiff(org.id, existing.tags || [], tags);
   }
 
-  // Update the attribute
+  // Only merge fields the client actually sent — absent keys preserve the
+  // existing value, avoiding the BSON `undefined → null` round trip.
   attributeSchema[index] = {
     ...attributeSchema[index],
-    property,
-    description,
-    datatype,
-    projects,
-    format,
-    enum: enumValue,
-    hashAttribute,
-    archived,
-    disableEqualityConditions,
+    ...attributeFields,
     ...(tags !== undefined && { tags: tags.length > 0 ? tags : undefined }),
   };
 

--- a/packages/back-end/src/routers/attributes/attributes.router.ts
+++ b/packages/back-end/src/routers/attributes/attributes.router.ts
@@ -20,7 +20,7 @@ router.get(
 router.post(
   "/",
   validateRequestMiddleware({
-    body: z.object({
+    body: z.strictObject({
       property: z.string(),
       description: z.string().optional(),
       datatype: z.enum(attributeDataTypes),
@@ -28,6 +28,7 @@ router.post(
       format: z.string().optional(),
       enum: z.string().optional(),
       hashAttribute: z.boolean().optional(),
+      disableEqualityConditions: z.boolean().optional(),
       tags: z.array(z.string()).optional(),
     }),
   }),
@@ -37,7 +38,7 @@ router.post(
 router.put(
   "/",
   validateRequestMiddleware({
-    body: z.object({
+    body: z.strictObject({
       property: z.string(),
       description: z.string().optional(),
       datatype: z.enum(attributeDataTypes),
@@ -46,6 +47,7 @@ router.put(
       enum: z.string().optional(),
       hashAttribute: z.boolean().optional(),
       archived: z.boolean().optional(),
+      disableEqualityConditions: z.boolean().optional(),
       previousName: z.string().optional(),
       tags: z.array(z.string()).optional(),
     }),

--- a/packages/front-end/pages/attributes.tsx
+++ b/packages/front-end/pages/attributes.tsx
@@ -227,14 +227,7 @@ const FeatureAttributesPage = (): React.ReactElement => {
                     const updatedAttribute: SDKAttribute = {
                       property: v.property,
                       datatype: v.datatype,
-                      projects: v.projects,
-                      format: v.format,
-                      enum: v.enum,
-                      hashAttribute: v.hashAttribute,
                       archived: !v.archived,
-                      tags: v.tags,
-                      description: v.description,
-                      disableEqualityConditions: v.disableEqualityConditions,
                     };
                     await apiCall<{
                       res: number;

--- a/packages/front-end/pages/attributes/[property].tsx
+++ b/packages/front-end/pages/attributes/[property].tsx
@@ -362,6 +362,8 @@ export default function AttributeDetailPage() {
                   if (payload.projects === null) delete payload.projects;
                   if (payload.format === null) delete payload.format;
                   if (payload.enum === null) delete payload.enum;
+                  if (payload.disableEqualityConditions === null)
+                    delete payload.disableEqualityConditions;
                   await apiCall("/attribute", {
                     method: "PUT",
                     body: JSON.stringify(payload),


### PR DESCRIPTION
### Features and Changes

Since #5251 we've been sending optional fields explicitly as part of the PUT /attributes endpoint, but when not present on the attribute they're stored as `null` in mongo (as it's assumed to be an `$unset`). Then on the next round trip, those null fields hit the zod validator which has `.optional()` but not `.nullish()`, failing validation.

The fix is to only pass the relevant fields in the frontend, and to store only the fields that were part of the request body in the backend. This way an attribute not being changed won't lead to it being nulled, and even if it's already been nulled by this bug, the frontend won't pass it unless it's changing (and will correctly be revalidated).


### Testing

1. On `main`, archive an attribute (works) and then attempt to unarchive it (errors)
2. Use the network tab to inspect the `/organization` response and see that `attributeSchema` now has `null` for most fields on the archived attribute
3. Swap to this branch and unarchive the attribute (now works)
4. Archive a fresh attribute and inspect `/organization` again to verify that it didn't add the nulls to this one
