### PR TITLE
fix: avoid prompt validation errors in general settings

### DIFF
--- a/packages/front-end/components/GeneralSettings/AISettings.tsx
+++ b/packages/front-end/components/GeneralSettings/AISettings.tsx
@@ -248,13 +248,13 @@ export default function AISettings({
   useEffect(() => {
     if (data) {
       const prompts = getPrompts(data);
-      prompts.forEach((prompt) => {
-        promptForm.setValue(prompt.promptType, prompt.promptValue);
-        promptForm.setValue(
-          `${prompt.promptType}-model`,
-          prompt.overrideModel || "",
-        );
-      });
+      promptForm.reset(
+        prompts.reduce<Record<string, string>>((acc, prompt) => {
+          acc[prompt.promptType] = prompt.promptValue;
+          acc[`${prompt.promptType}-model`] = prompt.overrideModel || "";
+          return acc;
+        }, {}),
+      );
     }
   }, [data, promptForm]);
 

--- a/packages/front-end/pages/settings/index.tsx
+++ b/packages/front-end/pages/settings/index.tsx
@@ -331,11 +331,21 @@ const GeneralSettingsPage = (): React.ReactElement => {
     hasChanges(value, originalValue) || promptForm.formState.isDirty;
 
   const savePrompts = promptForm.handleSubmit(async (promptValues) => {
-    const formattedPrompts = CUSTOMIZABLE_PROMPT_TYPES.map((type) => ({
-      type,
-      prompt: promptValues[type],
-      overrideModel: promptValues[`${type}-model`] || undefined,
-    }));
+    const formattedPrompts = CUSTOMIZABLE_PROMPT_TYPES.flatMap((type) => {
+      const prompt = promptValues[type];
+      if (typeof prompt !== "string") return [];
+
+      return [
+        {
+          type,
+          prompt,
+          overrideModel: promptValues[`${type}-model`] || undefined,
+        },
+      ];
+    });
+
+    if (!formattedPrompts.length) return;
+
     await apiCall(`/ai/prompts`, {
       method: "POST",
       body: JSON.stringify({ prompts: formattedPrompts }),


### PR DESCRIPTION
## Summary
- stop the AI prompt subform from becoming dirty during initial settings load
- skip undefined prompt values when building the \/ai/prompts\ save payload

## Why
Saving non-AI general settings could still trigger the AI prompt save path with undefined prompt values, which caused validation errors like:

\[prompts.0.prompt] Invalid input: expected string, received undefined\

The settings change still persisted, but the UI showed an error during save.

Fixes #5053