### PR TITLE
Add callout to contact us to delete

### DIFF
--- a/packages/front-end/components/Settings/EditDataSource/EventForwarder/EventForwarder.tsx
+++ b/packages/front-end/components/Settings/EditDataSource/EventForwarder/EventForwarder.tsx
@@ -17,9 +17,7 @@ import { BigQueryConnectionParams } from "shared/types/integrations/bigquery";
 import { SnowflakeConnectionParams } from "shared/types/integrations/snowflake";
 import { Box, Card, Flex } from "@radix-ui/themes";
 import { useAuth } from "@/services/auth";
-import DeleteButton from "@/components/DeleteButton/DeleteButton";
 import Modal from "@/components/Modal";
-import MoreMenu from "@/components/Dropdown/MoreMenu";
 import BigQueryEventForwarderForm from "@/components/Settings/BigQueryEventForwarderForm";
 import SnowflakeEventForwarderForm from "@/components/Settings/SnowflakeEventForwarderForm";
 import Badge from "@/ui/Badge";
@@ -310,38 +308,11 @@ export default function EventForwarder({
         </Flex>
 
         <Flex align="center" gap="4">
-          {canEdit && eventForwarderConfig && (
-            <MoreMenu useRadix size={16}>
-              <button
-                className="dropdown-item py-2"
-                onClick={() => setShowEditModal(true)}
-              >
-                Edit Event Forwarder
-              </button>
-
-              <hr className="dropdown-divider" />
-              <DeleteButton
-                onClick={async () => {
-                  await apiCall(
-                    `/datasource/${dataSource.id}/event-forwarder`,
-                    {
-                      method: "DELETE",
-                    },
-                  );
-                  await onRefresh();
-                }}
-                className="dropdown-item text-danger py-2"
-                iconClassName="mr-2"
-                style={{ borderRadius: 0 }}
-                useIcon={false}
-                displayName="Event Forwarder"
-                deleteMessage="Are you sure you want to delete this event forwarder? This removes the GrowthBook Kafka topic and connector for this datasource."
-                title="Delete"
-                text="Delete Event Forwarder"
-                outline={false}
-              />
-            </MoreMenu>
-          )}
+          {canEdit && eventForwarderConfig ? (
+            <Button variant="outline" onClick={() => setShowEditModal(true)}>
+              Edit Event Forwarder
+            </Button>
+          ) : null}
           {eventForwarderConfig && canToggle && (
             <Button
               variant="outline"
@@ -382,7 +353,19 @@ export default function EventForwarder({
             </Box>
           ) : null}
         </Callout>
-      ) : null}
+      ) : (
+        <Callout status="info" mb="3">
+          To remove the Event Forwarder,{" "}
+          <a
+            href="https://www.growthbook.io/contact"
+            target="_blank"
+            rel="noreferrer"
+          >
+            contact us
+          </a>
+          .
+        </Callout>
+      )}
 
       {eventForwarderConfig ? (
         <Card>

--- a/packages/front-end/pages/datasources/[did].tsx
+++ b/packages/front-end/pages/datasources/[did].tsx
@@ -94,6 +94,8 @@ const DataSourcePage: FC = () => {
   const canDelete =
     (d && permissionsUtil.canDeleteDataSource(d) && !hasFileConfig()) || false;
 
+  const deleteBlockedByEventForwarder = Boolean(d?.eventForwarderConfig);
+
   const canUpdateConnectionParams =
     (d &&
       !isManagedWarehouse &&
@@ -279,7 +281,29 @@ const DataSourcePage: FC = () => {
                     confirmation={{
                       confirmationTitle: `Delete "${d.name}" Datasource`,
                       cta: "Delete",
+                      ctaEnabled: !deleteBlockedByEventForwarder,
+                      getConfirmationContent: async () => {
+                        if (deleteBlockedByEventForwarder) {
+                          return (
+                            <>
+                              {"Please "}
+                              <a
+                                href="https://www.growthbook.io/contact"
+                                target="_blank"
+                                rel="noreferrer"
+                              >
+                                contact us
+                              </a>
+                              {
+                                " to remove the Event Forwarder first; after that, you can delete this data source here."
+                              }
+                            </>
+                          );
+                        }
+                        return "Are you sure? This action cannot be undone.";
+                      },
                       submit: async () => {
+                        if (deleteBlockedByEventForwarder) return;
                         await apiCall(`/datasource/${d.id}`, {
                           method: "DELETE",
                         });

--- a/packages/front-end/pages/datasources/[did].tsx
+++ b/packages/front-end/pages/datasources/[did].tsx
@@ -60,6 +60,10 @@ const DataSourcePage: FC = () => {
   const [viewSqlExplorer, setViewSqlExplorer] = useState(false);
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [auditModal, setAuditModal] = useState(false);
+  const [
+    deleteBlockedByEventForwarderModalOpen,
+    setDeleteBlockedByEventForwarderModalOpen,
+  ] = useState(false);
   const router = useRouter();
 
   const {
@@ -276,45 +280,35 @@ const DataSourcePage: FC = () => {
               {canDelete && (
                 <>
                   <DropdownMenuSeparator />
-                  <DropdownMenuItem
-                    color="red"
-                    confirmation={{
-                      confirmationTitle: `Delete "${d.name}" Datasource`,
-                      cta: "Delete",
-                      ctaEnabled: !deleteBlockedByEventForwarder,
-                      getConfirmationContent: async () => {
-                        if (deleteBlockedByEventForwarder) {
-                          return (
-                            <>
-                              {"Please "}
-                              <a
-                                href="https://www.growthbook.io/contact"
-                                target="_blank"
-                                rel="noreferrer"
-                              >
-                                contact us
-                              </a>
-                              {
-                                " to remove the Event Forwarder first; after that, you can delete this data source here."
-                              }
-                            </>
-                          );
-                        }
-                        return "Are you sure? This action cannot be undone.";
-                      },
-                      submit: async () => {
-                        if (deleteBlockedByEventForwarder) return;
-                        await apiCall(`/datasource/${d.id}`, {
-                          method: "DELETE",
-                        });
-                        mutateDefinitions({});
-                        router.push("/datasources");
-                      },
-                      closeDropdown: () => setDropdownOpen(false),
-                    }}
-                  >
-                    Delete
-                  </DropdownMenuItem>
+                  {deleteBlockedByEventForwarder ? (
+                    <DropdownMenuItem
+                      color="red"
+                      onClick={() => {
+                        setDeleteBlockedByEventForwarderModalOpen(true);
+                        setDropdownOpen(false);
+                      }}
+                    >
+                      Delete
+                    </DropdownMenuItem>
+                  ) : (
+                    <DropdownMenuItem
+                      color="red"
+                      confirmation={{
+                        confirmationTitle: `Delete "${d.name}" Datasource`,
+                        cta: "Delete",
+                        submit: async () => {
+                          await apiCall(`/datasource/${d.id}`, {
+                            method: "DELETE",
+                          });
+                          mutateDefinitions({});
+                          router.push("/datasources");
+                        },
+                        closeDropdown: () => setDropdownOpen(false),
+                      }}
+                    >
+                      Delete
+                    </DropdownMenuItem>
+                  )}
                 </>
               )}
             </DropdownMenu>
@@ -586,6 +580,28 @@ mixpanel.init('YOUR PROJECT TOKEN', {
           size="lg"
         >
           <HistoryTable type={"datasource"} id={d.id} />
+        </ModalStandard>
+      )}
+      {deleteBlockedByEventForwarderModalOpen && (
+        <ModalStandard
+          trackingEventModalType=""
+          open={true}
+          header={`Cannot delete "${d.name}"`}
+          close={() => setDeleteBlockedByEventForwarderModalOpen(false)}
+        >
+          <>
+            {"Please "}
+            <a
+              href="https://www.growthbook.io/contact"
+              target="_blank"
+              rel="noreferrer"
+            >
+              contact us
+            </a>
+            {
+              " to remove the Event Forwarder first; after that, you can delete this data source here."
+            }
+          </>
         </ModalStandard>
       )}
     </div>

--- a/packages/front-end/ui/DropdownMenu.tsx
+++ b/packages/front-end/ui/DropdownMenu.tsx
@@ -204,6 +204,8 @@ type DropdownItemProps = {
     confirmationTitle: string;
     cta: string;
     ctaColor?: "red" | "violet";
+    /** When false, the confirm CTA is disabled (e.g. explain-only modal). */
+    ctaEnabled?: boolean;
     hideDropdown?: () => void;
     showDropdown?: () => void;
     closeDropdown?: () => void;
@@ -265,6 +267,7 @@ export function DropdownMenuItem({
           open={true}
           cta={confirmation.cta}
           ctaColor={confirmation.ctaColor ?? "red"}
+          ctaEnabled={confirmation.ctaEnabled ?? true}
           submit={confirmation.submit}
         >
           {confirmationContent ?? "Are you sure? This action cannot be undone."}

--- a/packages/front-end/ui/DropdownMenu.tsx
+++ b/packages/front-end/ui/DropdownMenu.tsx
@@ -204,8 +204,6 @@ type DropdownItemProps = {
     confirmationTitle: string;
     cta: string;
     ctaColor?: "red" | "violet";
-    /** When false, the confirm CTA is disabled (e.g. explain-only modal). */
-    ctaEnabled?: boolean;
     hideDropdown?: () => void;
     showDropdown?: () => void;
     closeDropdown?: () => void;
@@ -267,7 +265,6 @@ export function DropdownMenuItem({
           open={true}
           cta={confirmation.cta}
           ctaColor={confirmation.ctaColor ?? "red"}
-          ctaEnabled={confirmation.ctaEnabled ?? true}
           submit={confirmation.submit}
         >
           {confirmationContent ?? "Are you sure? This action cannot be undone."}


### PR DESCRIPTION
### Features and Changes

- Add callout to contact us to delete event forwarder
- Block datasource from being deleted when event forwarder is attached

- Closes https://www.notion.so/growthbook/Event-Forwarder-345a857e74a080a888c8de6d150a518d?source=copy_link#359a857e74a0800a8e1ffa6a467d5aa4

### Testing

- Setup event forwarder in an existing data source
- Check that it's not allowed to be deleted anymore
- Check delete data source to see a message if event forwarder is still attached

### Screenshots

<img width="1526" height="369" alt="Screenshot 2026-05-07 at 10 26 30 AM" src="https://github.com/user-attachments/assets/42c72013-5ec9-4252-8b0f-0b5370fa13ce" />

<img width="975" height="356" alt="Screenshot 2026-05-07 at 10 37 21 AM" src="https://github.com/user-attachments/assets/d204f64a-2232-4983-a8eb-84aa533bc3a6" />

