### PR TITLE
docs: improve agentic consumption of docs via llms.txt cleanup

### DIFF
--- a/docs/docs/account/audit-logs.mdx
+++ b/docs/docs/account/audit-logs.mdx
@@ -6,9 +6,9 @@ slug: audit-logs
 ---
 
 import MaxWidthImage from "@site/src/components/MaxWidthImage";
-import CommercialFeature from '@site/src/components/CommercialFeature';
 
-<CommercialFeature feature="audit-logging" />
+:::enterprise-feature[Audit Logging]
+:::
 
 GrowthBook keeps an audit log of all actions taken on the platform. You can access this page from the Settings → Log in the left navigation.
 

--- a/docs/docs/account/user-permissions.mdx
+++ b/docs/docs/account/user-permissions.mdx
@@ -6,7 +6,6 @@ slug: user-permissions
 ---
 
 import MaxWidthImage from "@site/src/components/MaxWidthImage";
-import CommercialFeature from '@site/src/components/CommercialFeature';
 
 In the context of GrowthBook, a user, or member, is an individual who has access to your organization's GrowthBook account. Each user is assigned a role that determines the level of access they have within the application. GrowthBook offers a range of roles, from `No Access` to `Admin` and even custom roles, each with a specific set of permissions (see below).
 GrowthBook's user permissions system allows organizations to define the level of access each user has within the application. This granular control ensures that users can only access the resources they need to perform their job, enhancing security and privacy.
@@ -100,7 +99,8 @@ The table below lists the roles available in GrowthBook and their associated per
 
 ### How does the No Access role work?
 
-<CommercialFeature feature="no-access-role" />
+:::enterprise-feature[No Access Role]
+:::
 
 In some cases, an organization might want to hide certain projects from a user entirely. This is possible with the `No Access` role. The `No Access` role can either be applied as the user's global role, or it can be a project-specific role.
 
@@ -112,7 +112,8 @@ If you need to apply these rules to many users as once, you can create a Team wi
 
 ### How does the Project Admin role work?
 
-<CommercialFeature feature="project-admin-role" />
+:::enterprise-feature[Project Admin Role]
+:::
 
 The Project Admin role provides full access to all features and experiments within a project, similar to the `Experimenter` role. Additionally, Project Admin allows you to manage project settings and change project roles for other members within that project. This makes it ideal for delegating project-level administration without granting full `Admin` permissions.
 

--- a/docs/docs/bandits/overview.mdx
+++ b/docs/docs/bandits/overview.mdx
@@ -4,9 +4,9 @@ slug: /bandits/overview
 ---
 
 import Pill from '@site/src/components/Pill';
-import CommercialFeature from '@site/src/components/CommercialFeature';
 
-<CommercialFeature feature="multi-armed-bandits" />
+:::pro-feature[Multi Armed Bandits]
+:::
 
 ### What are Bandits?
 

--- a/docs/docs/experimentation-analysis/data-pipeline.mdx
+++ b/docs/docs/experimentation-analysis/data-pipeline.mdx
@@ -5,11 +5,11 @@ sidebar_label: Data Pipeline
 slug: /app/data-pipeline
 ---
 
-import CommercialFeature from '@site/src/components/CommercialFeature';
-
 # Data Pipeline Mode
 
-<CommercialFeature feature="pipeline-mode" description="Availability differs by warehouse and pipeline strategy." />
+:::enterprise-feature[Pipeline Mode]
+Availability differs by warehouse and pipeline strategy.
+:::
 
 Pipeline mode will provide substantial savings for experimenters with lots of data and/or long-running experiments. With **Pipeline Mode**, GrowthBook writes intermediate tables back to your warehouse and re-uses those across metric analyses in an experiment.
 

--- a/docs/docs/experimentation-analysis/decision-framework.mdx
+++ b/docs/docs/experimentation-analysis/decision-framework.mdx
@@ -4,11 +4,11 @@ slug: /app/experiment-decisions
 ---
 
 import MaxWidthImage from "@site/src/components/MaxWidthImage";
-import CommercialFeature from '@site/src/components/CommercialFeature';
 
 # Experiment Decision Framework
 
-<CommercialFeature feature="decision-framework" />
+:::pro-feature[Decision Framework]
+:::
 
 The Experiment Decision Framework (EDF) is a set of tools and customizable settings to help streamline and improve experiment decision making. The EDF can help answer questions like, "Should I keep running my experiment?" and "Do my results meet my success criteria?"
 

--- a/docs/docs/experimentation-analysis/experiment-dashboards.mdx
+++ b/docs/docs/experimentation-analysis/experiment-dashboards.mdx
@@ -5,11 +5,11 @@ slug: /app/experiment-dashboards
 ---
 
 import MaxWidthImage from "@site/src/components/MaxWidthImage";
-import CommercialFeature from '@site/src/components/CommercialFeature';
 
 # Experiment Dashboards
 
-<CommercialFeature feature="dashboards" />
+:::enterprise-feature[Dashboards]
+:::
 
 Use experiment dashboards to create tailored views of your experiment. Highlight key insights, add context, and share a clear story with your team.
 

--- a/docs/docs/experimentation-analysis/query-optimization.mdx
+++ b/docs/docs/experimentation-analysis/query-optimization.mdx
@@ -5,8 +5,6 @@ sidebar_label: Query Optimization
 slug: /app/query-optimization
 ---
 
-import CommercialFeature from '@site/src/components/CommercialFeature';
-
 # Query Optimization
 
 GrowthBook is designed to run efficient database queries out-of-the-box, but for large datasets or complex metrics, there are a few settings and techniques you can use to optimize your queries.
@@ -39,7 +37,8 @@ Read more about [Fact Tables](/app/metrics) and how to [convert legacy metrics t
 
 ## Fact Table Query Optimization
 
-<CommercialFeature feature="multi-metric-queries" />
+:::enterprise-feature[Multi Metric Queries]
+:::
 
 Fact Table Query Optimization enables faster, more efficient queries.
 
@@ -55,7 +54,8 @@ In all other cases, this optimization is enabled by default. It can be disabled 
 
 ## Data Pipeline Mode
 
-<CommercialFeature feature="pipeline-mode" />
+:::enterprise-feature[Pipeline Mode]
+:::
 
 Data Pipeline Mode reduces the amount of duplicate data your warehouse needs to scan.
 

--- a/docs/docs/experimentation-analysis/sql-templates.mdx
+++ b/docs/docs/experimentation-analysis/sql-templates.mdx
@@ -5,8 +5,6 @@ sidebar_label: SQL Templates
 slug: /app/sql-templates
 ---
 
-import CommercialFeature from '@site/src/components/CommercialFeature';
-
 # SQL Templates
 
 SQL in GrowthBook is first run through a templating engine (Handlebars) to allow for dynamic SQL generation. This allows for several advanced use cases, outlined below.
@@ -124,7 +122,8 @@ The filter will still be added above even when the phase index is `0`, despite t
 
 ## Custom Field Filters
 
-<CommercialFeature feature="custom-metadata" />
+:::enterprise-feature[Custom Metadata]
+:::
 
 Custom Fields for experiments can be used in SQL templates to add additional filtering logic. For example, if you have a Custom Field called `region`, you can use that in your Fact Table definition to filter data based on the region for a specific experiment.
 

--- a/docs/docs/features/basics.mdx
+++ b/docs/docs/features/basics.mdx
@@ -6,7 +6,6 @@ slug: /features/basics
 ---
 
 import MaxWidthImage from "@site/src/components/MaxWidthImage";
-import CommercialFeature from '@site/src/components/CommercialFeature';
 
 This page covers the core concepts you'll need to create and configure feature flags in GrowthBook.
 
@@ -49,7 +48,8 @@ Features can be a simple ON/OFF flag or a more complex data type (string, number
 
 **JSON** flags also support JSON Schema validation, which lets you enforce the structure of the value before it reaches your application.
 
-<CommercialFeature feature="json-validation" />
+:::enterprise-feature[JSON Validation]
+:::
 
 ## Default Values
 

--- a/docs/docs/features/environments.mdx
+++ b/docs/docs/features/environments.mdx
@@ -6,7 +6,6 @@ slug: /features/environments
 ---
 
 import MaxWidthImage from "@site/src/components/MaxWidthImage";
-import CommercialFeature from '@site/src/components/CommercialFeature';
 
 # Environments
 
@@ -53,7 +52,8 @@ Learn more about [how to use projects](/using/growthbook-best-practices#projects
 
 ## Environment Inheritance
 
-<CommercialFeature feature="environment-inheritance" />
+:::enterprise-feature[Environment Inheritance]
+:::
 
 When you create an environment you can specify a parent environment to inherit from.
 The new environment initially copies all feature rules from its parent. After creation, the environments

--- a/docs/docs/features/json-schema-validation.mdx
+++ b/docs/docs/features/json-schema-validation.mdx
@@ -5,12 +5,12 @@ sidebar_label: JSON Schema Validation
 slug: /features/json-schema-validation
 ---
 
-import CommercialFeature from "@site/src/components/CommercialFeature";
 import MaxWidthImage from "@site/src/components/MaxWidthImage";
 
 # JSON Schema Validation
 
-<CommercialFeature feature="json-validation" />
+:::enterprise-feature[JSON Validation]
+:::
 
 JSON feature flags are powerful, especially for remote configuration, letting you ship structured data like pricing rules, layout settings, or experiment parameters without a code deploy. That flexibility comes with a risk: a single typo or missing field in a JSON blob can break production. GrowthBook Enterprise lets you attach a JSON Schema to a JSON flag so every value is validated against the structure you define.
 

--- a/docs/docs/features/prerequisites.mdx
+++ b/docs/docs/features/prerequisites.mdx
@@ -6,9 +6,9 @@ slug: /features/prerequisites
 ---
 
 import MaxWidthImage from "@site/src/components/MaxWidthImage";
-import CommercialFeature from '@site/src/components/CommercialFeature';
 
-<CommercialFeature feature="prerequisites" />
+:::pro-feature[Prerequisites]
+:::
 
 <iframe width="560" height="315" style={{aspectRatio: "16/9", width: "100%", height: "auto"}} src="https://www.youtube-nocookie.com/embed/5W7JfvHVI3E?si=CGkhcxHMDUwU-ENM" title="YouTube video player" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerPolicy="strict-origin-when-cross-origin" allowFullScreen></iframe>
 
@@ -74,7 +74,8 @@ Inline prerequisite targeting provides finer-grained control than top-level prer
 2. Inline prerequisites can be applied to individual experiments which may not be linked to a specific feature (such as visual experiments).
 3. Inline prerequisite targeting is not limited to boolean features. You can specify any evaluation condition you'd like (ex: prerequisite value is: greater than 3, in a list of allowed values, or matches a regex pattern). You can even do advanced targeting with JSON.
 
-<CommercialFeature feature="prerequisite-targeting" />
+:::enterprise-feature[Prerequisite Targeting]
+:::
 
 To create an inline prerequisite within a feature, add prerequisite targeting to an existing rule or create a new rule with prerequisite targeting. You can specify one or more prerequisite features within the same project and give each a custom evaluation condition. A similar flow exists while editing the targeting rules of an experiment.
 

--- a/docs/docs/features/publishing-and-approval-flows.mdx
+++ b/docs/docs/features/publishing-and-approval-flows.mdx
@@ -6,7 +6,6 @@ slug: /features/publishing-and-approval-flows
 ---
 
 import MaxWidthImage from "@site/src/components/MaxWidthImage";
-import CommercialFeature from '@site/src/components/CommercialFeature';
 
 # Publishing & Approval Flows
 
@@ -44,7 +43,8 @@ In the example below, the Default Value was set to `foo` when you first created 
 
 ## Approval Flows
 
-<CommercialFeature feature="require-approvals" />
+:::enterprise-feature[Require Approvals]
+:::
 
 With Approval flows, you can require approval before publishing any change to an existing feature flag. Approval flows help reduce errors by making sure changes to features have been viewed and approved by someone else in your organization.
 

--- a/docs/docs/features/rules.mdx
+++ b/docs/docs/features/rules.mdx
@@ -6,7 +6,6 @@ slug: /features/rules
 ---
 
 import MaxWidthImage from "@site/src/components/MaxWidthImage";
-import CommercialFeature from '@site/src/components/CommercialFeature';
 
 # Rules
 
@@ -118,7 +117,8 @@ When a user is placed into an experiment, the SDK fires the `trackingCallback` t
 
 ## Safe Rollout
 
-<CommercialFeature feature="safe-rollout" />
+:::pro-feature[Safe Rollout]
+:::
 
 Safe Rollout rules combine a gradual percentage rollout with automatic guardrail monitoring. GrowthBook monitors key metrics for regressions and can auto-rollback if something goes wrong.
 
@@ -148,7 +148,8 @@ Any rule can include targeting conditions to limit which users it applies to. Co
 
 ## Scheduling Rules
 
-<CommercialFeature feature="schedule-feature-flag" />
+:::pro-feature[Schedule Feature Flag]
+:::
 
 <MaxWidthImage maxWidth={600}>
     ![Feature Scheduling](/images/features/feature-scheduling-2.png)
@@ -168,7 +169,8 @@ Test your rules directly in GrowthBook on the **Simulation** page. Adjust user a
 
 ### Archetypes
 
-<CommercialFeature feature="archetypes" />
+:::pro-feature[Archetypes]
+:::
 
 Archetypes let you save preset user attribute profiles so you can quickly test how rules apply to specific types of users. If you frequently target features to certain groups (e.g., beta testers, enterprise accounts), archetypes let you check the result in one click. They appear at the top of the **Simulation** page. Hover over any value to see debug information.
 

--- a/docs/docs/features/safe-rollouts.mdx
+++ b/docs/docs/features/safe-rollouts.mdx
@@ -6,9 +6,9 @@ slug: /features/safe-rollouts
 ---
 
 import MaxWidthImage from "@site/src/components/MaxWidthImage";
-import CommercialFeature from "@site/src/components/CommercialFeature";
 
-<CommercialFeature feature="safe-rollout" />
+:::pro-feature[Safe Rollout]
+:::
 
 Releasing a new feature always carries risk. Even small changes can introduce regressions. Safe Rollouts reduce this risk by releasing to a subset of users while monitoring key metrics for issues.
 

--- a/docs/docs/integrations/ai.mdx
+++ b/docs/docs/integrations/ai.mdx
@@ -4,7 +4,6 @@ description: Learn about AI integrations with GrowthBook.
 ---
 
 import MaxWidthImage from '@site/src/components/MaxWidthImage';
-import CommercialFeature from '@site/src/components/CommercialFeature';
 
 # AI Integrations
 
@@ -126,6 +125,8 @@ From the settings page you can also select the AI model you want to use. The def
   ![AI Settings Self-hosting](/images/integrations/ai/ai-settings-self-hosting.png)
 </MaxWidthImage>
 
-<CommercialFeature feature="ai-suggestions" description="AI features for self-hosted GrowthBook instances are available on Enterprise plans." />
+:::enterprise-feature[AI Suggestions]
+AI features for self-hosted GrowthBook instances are available on Enterprise plans.
+:::
 
 You can learn more from the [OpenAI Documentation](https://platform.openai.com/docs/).

--- a/docs/docs/integrations/scim.mdx
+++ b/docs/docs/integrations/scim.mdx
@@ -5,11 +5,11 @@ id: scim
 slug: scim
 ---
 
-import CommercialFeature from '@site/src/components/CommercialFeature';
-
 # SCIM Integration for Enterprise Organizations
 
-<CommercialFeature feature="scim" description="SCIM requires Single Sign-On (SSO) to be enabled. Currently, GrowthBook only supports Okta and Azure AD/Microsoft Entra ID as identity providers." />
+:::enterprise-feature[SCIM]
+SCIM requires Single Sign-On (SSO) to be enabled. Currently, GrowthBook only supports Okta and Azure AD/Microsoft Entra ID as identity providers.
+:::
 
 SCIM, or [System for Cross-domain Identity Management](https://scim.cloud/), is the standard for managing users and groups across multiple applications. With SCIM, you can automate the provisioning and deprovisioning of users in your GrowthBook account through your identity provider.
 

--- a/docs/docs/integrations/shopify.mdx
+++ b/docs/docs/integrations/shopify.mdx
@@ -1,10 +1,9 @@
-import CommercialFeature from '@site/src/components/CommercialFeature';
-
 # Shopify Integration
 
 Unleash the power of experimentation with GrowthBook to supercharge your Shopify store—no coding skills required!
 
-<CommercialFeature feature="visual-editor" />
+:::pro-feature[Visual Editor]
+:::
 
 ## Let's Get Started
 

--- a/docs/docs/metrics/metrics.mdx
+++ b/docs/docs/metrics/metrics.mdx
@@ -5,7 +5,6 @@ slug: /app/metrics
 ---
 
 import MaxWidthImage from "@site/src/components/MaxWidthImage";
-import CommercialFeature from '@site/src/components/CommercialFeature';
 
 # Metrics and Fact Tables
 
@@ -309,7 +308,8 @@ You can read more about Bayesian priors on [our statistical details page](/stati
 
 ## Metric Slices
 
-<CommercialFeature feature="metric-slices" />
+:::enterprise-feature[Metric Slices]
+:::
 
 Many metrics are easily decomposed, and you may want to learn about the different elements.
 For example, you may want to see revenue across different product types (e.g. "apparel", "equipment").
@@ -411,7 +411,8 @@ For more advanced analysis, use our [Product Analytics](/app/product-analytics) 
 
 ## Metric Groups
 
-<CommercialFeature feature="metric-groups" />
+:::enterprise-feature[Metric Groups]
+:::
 
 There are often groups of metrics you want to add together to an experiment. For example, 5 key revenue metrics that you add to anything touching the checkout flow.
 

--- a/docs/docs/official-resources.mdx
+++ b/docs/docs/official-resources.mdx
@@ -6,9 +6,9 @@ slug: /official-resources
 ---
 
 import MaxWidthImage from '@site/src/components/MaxWidthImage';
-import CommercialFeature from '@site/src/components/CommercialFeature';
 
-<CommercialFeature feature="manage-official-resources" />
+:::enterprise-feature[Manage Official Resources]
+:::
 
 Official Resources are protected resources that **can only be modified by users with appropriate permissions**. These resources have a checkmark badge in the app to indicate their protected status. This feature is useful for resources that are externally managed or need to remain consistent across teams.
 

--- a/docs/docs/product-analytics.mdx
+++ b/docs/docs/product-analytics.mdx
@@ -5,11 +5,12 @@ slug: /app/product-analytics
 ---
 
 import MaxWidthImage from "@site/src/components/MaxWidthImage";
-import CommercialFeature from '@site/src/components/CommercialFeature';
 
 # Product Analytics
 
-<CommercialFeature feature="product-analytics-dashboards" description="Pro organizations can create unlimited private dashboards, while Enterprise organizations gain access to the full suite of sharing and collaboration options." />
+:::pro-feature[Product Analytics Dashboards]
+Pro organizations can create unlimited private dashboards, while Enterprise organizations gain access to the full suite of sharing and collaboration options.
+:::
 
 Build **general-purpose dashboards** to better understand your product's performance, user behavior, and key business metrics.
 

--- a/docs/docs/running-experiments/experiment-templates.mdx
+++ b/docs/docs/running-experiments/experiment-templates.mdx
@@ -4,11 +4,10 @@ description: Experiment Templates provide standardized configurations for experi
 slug: experiment-templates
 ---
 
-import CommercialFeature from '@site/src/components/CommercialFeature';
-
 # Experiment Templates
 
-<CommercialFeature feature="templates" />
+:::enterprise-feature[Templates]
+:::
 
 Experiment Templates provide standardized configurations for experiment creation across your team. By reducing setup overhead and eliminating common boilerplate, templates enable faster experiment initialization and consistency in experimental design.
 

--- a/docs/docs/running-experiments/pre-launch-checklist.mdx
+++ b/docs/docs/running-experiments/pre-launch-checklist.mdx
@@ -4,11 +4,10 @@ description: Use GrowthBook's customizable pre-launch checklists to ensure all r
 slug: /app/pre-launch-checklist
 ---
 
-import CommercialFeature from '@site/src/components/CommercialFeature';
-
 # Customizable Pre-Launch Checklist
 
-<CommercialFeature feature="custom-launch-checklist" />
+:::enterprise-feature[Custom Launch Checklist]
+:::
 
 Use GrowthBook's customizable pre-launch checklists to ensure all requirements are met before running an experiment. This guide explains how to create and manage these checklists.
 

--- a/docs/docs/running-experiments/running-holdouts.mdx
+++ b/docs/docs/running-experiments/running-holdouts.mdx
@@ -4,9 +4,8 @@ description: Run holdout experiments to measure the long-term impact of features
 slug: /app/holdouts
 ---
 
-import CommercialFeature from '@site/src/components/CommercialFeature';
-
-<CommercialFeature feature="holdouts" />
+:::enterprise-feature[Holdouts]
+:::
 
 Holdout experiments (or simply "holdouts") measure the long-term impact of features by maintaining a control group that doesn't receive new functionality. While most users experience your latest features and improvements, a small percentage remains on the original version, providing a baseline to measure cumulative effects over time.
 

--- a/docs/docs/running-experiments/url-redirects.mdx
+++ b/docs/docs/running-experiments/url-redirects.mdx
@@ -6,11 +6,11 @@ slug: /app/url-redirects
 ---
 
 import Pill from '@site/src/components/Pill';
-import CommercialFeature from '@site/src/components/CommercialFeature';
 
 # URL Redirect Testing
 
-<CommercialFeature feature="redirects" />
+:::pro-feature[Redirects]
+:::
 
 URL Redirect tests are an alternative to using the Visual Editor and are ideal for testing big changes or complete page redesigns.
 

--- a/docs/docs/sso.mdx
+++ b/docs/docs/sso.mdx
@@ -6,11 +6,11 @@ slug: sso
 ---
 
 import MaxWidthImage from '@site/src/components/MaxWidthImage';
-import CommercialFeature from '@site/src/components/CommercialFeature';
 
 # Enterprise SSO
 
-<CommercialFeature feature="sso" />
+:::enterprise-feature[SSO]
+:::
 
 SSO is available on GrowthBook Cloud or Self-hosted via OpenID Connect. If you are using the Cloud, your account
 representative will help you get this setup, though the steps are mostly the same. To enable SSO on your self hosted GrowthBook

--- a/docs/docs/statistics/cuped.mdx
+++ b/docs/docs/statistics/cuped.mdx
@@ -6,12 +6,14 @@ slug: cuped
 ---
 
 import MaxWidthImage from "@site/src/components/MaxWidthImage";
-import CommercialFeature from '@site/src/components/CommercialFeature';
 
 # CUPED + post-stratification
 
-<CommercialFeature feature="regression-adjustment" />
-<CommercialFeature feature="post-stratification" />
+:::pro-feature[CUPED]
+:::
+
+:::enterprise-feature[Post Stratification]
+:::
 
 CUPEDps (Controlled-experiment Using Pre-Experiment Data + post-stratification) increases the velocity of experimentation by reducing the uncertainty in estimates of experiment uplift. It uses both pre-experiment metric data as well as user attributes to improve the accuracy of experiment results.
 

--- a/docs/docs/statistics/quantile.mdx
+++ b/docs/docs/statistics/quantile.mdx
@@ -5,11 +5,10 @@ sidebar_label: Quantile Testing
 slug: quantile
 ---
 
-import CommercialFeature from '@site/src/components/CommercialFeature';
-
 # Quantile Testing
 
-<CommercialFeature feature="quantile-metrics" />
+:::pro-feature[Quantile Metrics]
+:::
 
 :::note
 Quantile Testing is incompatible with Mixpanel or MySQL integrations.

--- a/docs/docs/statistics/sequential.mdx
+++ b/docs/docs/statistics/sequential.mdx
@@ -6,11 +6,11 @@ slug: sequential
 ---
 
 import MaxWidthImage from "@site/src/components/MaxWidthImage";
-import CommercialFeature from '@site/src/components/CommercialFeature';
 
 # Sequential Testing
 
-<CommercialFeature feature="sequential-testing" />
+:::pro-feature[Sequential Testing]
+:::
 
 :::info Sequential Testing is only implemented for the Frequentist statistics engine.
 :::

--- a/docs/docs/sticky-bucketing.mdx
+++ b/docs/docs/sticky-bucketing.mdx
@@ -5,9 +5,8 @@ sidebar_label: Sticky Bucketing
 slug: /app/sticky-bucketing
 ---
 
-import CommercialFeature from '@site/src/components/CommercialFeature';
-
-<CommercialFeature feature="sticky-bucketing" />
+:::pro-feature[Sticky Bucketing]
+:::
 
 This article serves two purposes:
 

--- a/docs/docs/visual-editor.mdx
+++ b/docs/docs/visual-editor.mdx
@@ -7,9 +7,9 @@ slug: /app/visual
 ---
 
 import MaxWidthImage from '@site/src/components/MaxWidthImage';
-import CommercialFeature from '@site/src/components/CommercialFeature';
 
-<CommercialFeature feature="visual-editor" />
+:::pro-feature[Visual Editor]
+:::
 
 With the Visual Editor, users can design A/B tests on their site directly in their browser, run them in production, and analyze results, all without writing a single line of code. To use the Visual Editor, a software developer will need to integrate GrowthBook's [Script Tag](/lib/script-tag), [JavaScript](/lib/js), or [ReactJS](/lib/react) SDKs with your application. Alternatively, use one of our [Edge SDKs](/lib/edge/cloudflare) to render visual experiments on a CDN.
 

--- a/docs/docs/warehouses/bigquery.mdx
+++ b/docs/docs/warehouses/bigquery.mdx
@@ -6,7 +6,6 @@ slug: /guide/bigquery
 ---
 
 import MaxWidthImage from "@site/src/components/MaxWidthImage";
-import CommercialFeature from '@site/src/components/CommercialFeature';
 
 This document outlines the steps needed to add your BigQuery database to GrowthBook.
 
@@ -96,7 +95,8 @@ When you click save, GrowthBook will test the connection to make sure the creden
 
 ## Enabling Data Pipeline Mode
 
-<CommercialFeature feature="pipeline-mode" />
+:::enterprise-feature[Pipeline Mode]
+:::
 
 Pipeline mode can reduce query costs if you grant the GrowthBook service account write permissions in your data warehouse.
 

--- a/docs/docs/warehouses/snowflake.mdx
+++ b/docs/docs/warehouses/snowflake.mdx
@@ -5,8 +5,6 @@ sidebar_label: Snowflake
 slug: snowflake
 ---
 
-import CommercialFeature from '@site/src/components/CommercialFeature';
-
 We support multiple [account identifier](https://docs.snowflake.com/en/user-guide/admin-account-identifier.html) formats when connecting to Snowflake. An example account identifier is `xy12345.us-east-2.aws`.
 
 ## Self-Hosting
@@ -21,6 +19,8 @@ SNOWFLAKE_PROXY=http://username:password@proxyserver.company.com:80
 
 ## Enabling Data Pipeline Mode
 
-<CommercialFeature feature="pipeline-mode" description="Pipeline mode can reduce query costs if you grant the GrowthBook service account write permissions in your data warehouse." />
+:::enterprise-feature[Pipeline Mode]
+Pipeline mode can reduce query costs if you grant the GrowthBook service account write permissions in your data warehouse.
+:::
 
 [More details can be found here.](/app/data-pipeline)

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -78,6 +78,10 @@ const config = {
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl: "https://github.com/growthbook/growthbook/edit/main/docs/",
+          admonitions: {
+            keywords: ["pro-feature", "enterprise-feature"],
+            extendDefaults: true,
+          },
         },
         blog: false,
         theme: {
@@ -89,8 +93,8 @@ const config = {
         gtag:
           process.env.NODE_ENV === "production"
             ? {
-                trackingID: "G-3W683MDLMQ",
-              }
+              trackingID: "G-3W683MDLMQ",
+            }
             : undefined,
       }),
     ],
@@ -109,175 +113,177 @@ const config = {
   ],
 
   themeConfig:
-    /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
-    {
-      // announcementBar: {
-      //   id: "announcement-bar",
-      //   content: `<p style="margin: 0;">Webinar: Ronny Kohavi on Designing Experiments for Long-Term Growth. <a href="https://us06web.zoom.us/webinar/register/5017695505972/WN_1jSNg4gBS8i8XfyflDbe5w" target="_blank">Register Now →</a></p>`,
-      //   backgroundColor: "var(--violet-a3)",
-      //   textColor: "var(--violet-a11)",
-      //   isCloseable: true,
-      // },
-      navbar: {
-        //hideOnScroll: true,
-        //title: 'GrowthBook Docs',
-        logo: {
-          alt: "GrowthBook Docs",
-          src: "img/growthbook-docslogo-light.png",
-          srcDark: "img/growthbook-docslogo-dark.png",
-        },
-        items: [
-          {
-            to: "/",
-            label: "Docs",
-            position: "left",
-            activeBaseRegex: "^/(?!(lib|api)(/|$))",
-          },
-          {
-            to: "/lib",
-            label: "SDKs",
-            position: "left",
-          },
-          {
-            to: "/api",
-            label: "API",
-            position: "left",
-          },
-          {
-            href: "https://growthbook.io",
-            label: "Home",
-            position: "right",
-          },
-          {
-            href: "https://app.growthbook.io",
-            label: "Log in",
-            position: "right",
-          },
-          {
-            href: "https://github.com/growthbook/growthbook",
-            label: "GitHub",
-            position: "right",
-          },
-          {
-            label: "Support",
-            position: "right",
-            items: [
-              {
-                href: "https://slack.growthbook.io",
-                label: "Join our Slack",
-                target: "_blank",
-                rel: null,
-              },
-              {
-                href: "https://github.com/growthbook/growthbook/issues/new/choose",
-                label: "Open an issue",
-                target: "_blank",
-                rel: null,
-              },
-            ],
-            className: "navbar__link--support",
-          },
-        ],
+  /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
+  {
+    // announcementBar: {
+    //   id: "announcement-bar",
+    //   content: `<p style="margin: 0;">Webinar: Ronny Kohavi on Designing Experiments for Long-Term Growth. <a href="https://us06web.zoom.us/webinar/register/5017695505972/WN_1jSNg4gBS8i8XfyflDbe5w" target="_blank">Register Now →</a></p>`,
+    //   backgroundColor: "var(--violet-a3)",
+    //   textColor: "var(--violet-a11)",
+    //   isCloseable: true,
+    // },
+    navbar: {
+      //hideOnScroll: true,
+      //title: 'GrowthBook Docs',
+      logo: {
+        alt: "GrowthBook Docs",
+        src: "img/growthbook-docslogo-light.png",
+        srcDark: "img/growthbook-docslogo-dark.png",
       },
-      metadata: [
+      items: [
         {
-          name: "og:image",
-          content: "https://cdn.growthbook.io/growthbook-github-card.png",
+          to: "/",
+          label: "Docs",
+          position: "left",
+          activeBaseRegex: "^/(?!(lib|api)(/|$))",
         },
         {
-          name: "twitter:image",
-          content: "https://cdn.growthbook.io/growthbook-github-card.png",
+          to: "/lib",
+          label: "SDKs",
+          position: "left",
         },
         {
-          name: "twitter:card",
-          content: "summary_large_image",
+          to: "/api",
+          label: "API",
+          position: "left",
         },
         {
-          name: "twitter:domain",
-          content: "growthbook.io",
+          href: "https://growthbook.io",
+          label: "Home",
+          position: "right",
         },
         {
-          name: "twitter:site",
-          content: "@growth_book",
+          href: "https://app.growthbook.io",
+          label: "Log in",
+          position: "right",
         },
         {
-          name: "twitter:creator",
-          content: "growthbook",
+          href: "https://github.com/growthbook/growthbook",
+          label: "GitHub",
+          position: "right",
         },
         {
-          name: "og:type",
-          content: "website",
-        },
-        {
-          name: "og:site_name",
-          content: "GrowthBook Docs",
+          label: "Support",
+          position: "right",
+          items: [
+            {
+              href: "https://slack.growthbook.io",
+              label: "Join our Slack",
+              target: "_blank",
+              rel: null,
+            },
+            {
+              href: "https://github.com/growthbook/growthbook/issues/new/choose",
+              label: "Open an issue",
+              target: "_blank",
+              rel: null,
+            },
+          ],
+          className: "navbar__link--support",
         },
       ],
-      prism: {
-        theme: themes.github,
-        darkTheme: themes.dracula,
-        additionalLanguages: [
-          "csharp",
-          "ruby",
-          "php",
-          "java",
-          "kotlin",
-          "swift",
-          "dart",
-          "groovy",
-          "scala",
-          "json",
-          "bash",
-        ],
+    },
+    metadata: [
+      {
+        name: "og:image",
+        content: "https://cdn.growthbook.io/growthbook-github-card.png",
       },
-      colorMode: {
-        defaultMode: "light",
-        disableSwitch: false,
-        respectPrefersColorScheme: true,
+      {
+        name: "twitter:image",
+        content: "https://cdn.growthbook.io/growthbook-github-card.png",
       },
-      algolia: {
-        // The application ID provided by Algolia
-        appId: "MN7ZMY63CG",
-
-        // Public API key: it is safe to commit it
-        apiKey: "43a7bc1b7a1494649e79a9fa7c3376be",
-
-        indexName: "growthbook",
-
-        // Optional: see doc section below
-        contextualSearch: true,
-
-        // Optional: Specify domains where the navigation should occur through window.location instead on history.push. Useful when our Algolia config crawls multiple documentation sites and we want to navigate with window.location.href to them.
-        //externalUrlRegex: "external\\.com|domain\\.com",
-
-        // Optional: Algolia search parameters
-        searchParameters: {
-          optionalFilters: [],
-        },
-
-        // Optional: path for search page that enabled by default (`false` to disable it)
-        searchPagePath: "search",
-
-        //... other Algolia params
+      {
+        name: "twitter:card",
+        content: "summary_large_image",
       },
-      zoom: {
-        selector: ".markdown img:not(.no-zoom)",
-        background: {
-          light: "hsl(0 0% 100% / 0.75)",
-          dark: "hsl(0 0% 0% / 0.75)",
-        },
+      {
+        name: "twitter:domain",
+        content: "growthbook.io",
+      },
+      {
+        name: "twitter:site",
+        content: "@growth_book",
+      },
+      {
+        name: "twitter:creator",
+        content: "growthbook",
+      },
+      {
+        name: "og:type",
+        content: "website",
+      },
+      {
+        name: "og:site_name",
+        content: "GrowthBook Docs",
+      },
+    ],
+    prism: {
+      theme: themes.github,
+      darkTheme: themes.dracula,
+      additionalLanguages: [
+        "csharp",
+        "ruby",
+        "php",
+        "java",
+        "kotlin",
+        "swift",
+        "dart",
+        "groovy",
+        "scala",
+        "json",
+        "bash",
+      ],
+    },
+    colorMode: {
+      defaultMode: "light",
+      disableSwitch: false,
+      respectPrefersColorScheme: true,
+    },
+    algolia: {
+      // The application ID provided by Algolia
+      appId: "MN7ZMY63CG",
+
+      // Public API key: it is safe to commit it
+      apiKey: "43a7bc1b7a1494649e79a9fa7c3376be",
+
+      indexName: "growthbook",
+
+      // Optional: see doc section below
+      contextualSearch: true,
+
+      // Optional: Specify domains where the navigation should occur through window.location instead on history.push. Useful when our Algolia config crawls multiple documentation sites and we want to navigate with window.location.href to them.
+      //externalUrlRegex: "external\\.com|domain\\.com",
+
+      // Optional: Algolia search parameters
+      searchParameters: {
+        optionalFilters: [],
+      },
+
+      // Optional: path for search page that enabled by default (`false` to disable it)
+      searchPagePath: "search",
+
+      //... other Algolia params
+    },
+    zoom: {
+      selector: ".markdown img:not(.no-zoom)",
+      background: {
+        light: "hsl(0 0% 100% / 0.75)",
+        dark: "hsl(0 0% 0% / 0.75)",
       },
     },
+  },
   plugins: [
     "docusaurus-plugin-sass",
     [
       "docusaurus-plugin-llms",
       {
-        excludeImports: true,
-        pathTransformation: {
-          ignorePaths: ["docs"],
-        },
+        generateMarkdownFiles: true,  // Enable individual markdown file generation
+        generateLLMsTxt: true,        // Generate index file linking to markdown files
+        excludeImports: true,         // Clean up import statements  
+        removeDuplicateHeadings: true, // Remove redundant content        pathTransformation: {
+        ignorePaths: ["docs"],
       },
+
     ],
     "docusaurus-plugin-image-zoom",
   ],

--- a/docs/package.json
+++ b/docs/package.json
@@ -46,7 +46,7 @@
     "@docusaurus/types": "^3.9.2",
     "@types/node": "^22.15.19",
     "@types/react": "^19.1.4",
-    "docusaurus-plugin-llms": "^0.1.4",
+    "docusaurus-plugin-llms": "^0.4.0",
     "docusaurus-plugin-module-alias": "^0.0.2",
     "typescript": "^5.7.3"
   },

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -10,22 +10,22 @@ importers:
     dependencies:
       '@docusaurus/core':
         specifier: ^3.9.2
-        version: 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+        version: 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
       '@docusaurus/faster':
         specifier: ^3.9.2
-        version: 3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))
+        version: 3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))
       '@docusaurus/plugin-client-redirects':
         specifier: ^3.9.2
-        version: 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+        version: 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
       '@docusaurus/preset-classic':
         specifier: ^3.9.2
-        version: 3.9.2(@algolia/client-search@5.40.0)(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(@types/react@19.1.4)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(search-insights@2.17.3)(typescript@5.9.3)
+        version: 3.9.2(@algolia/client-search@5.40.0)(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(@types/react@19.1.4)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(search-insights@2.17.3)(typescript@5.9.3)
       '@docusaurus/remark-plugin-npm2yarn':
         specifier: ^3.9.2
         version: 3.9.2
       '@docusaurus/theme-live-codeblock':
         specifier: ^3.9.2
-        version: 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+        version: 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
       '@docusaurus/tsconfig':
         specifier: ^3.9.2
         version: 3.9.2
@@ -37,10 +37,10 @@ importers:
         version: 2.1.1
       docusaurus-plugin-image-zoom:
         specifier: ^3.0.1
-        version: 3.0.1(@docusaurus/theme-classic@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@rspack/core@1.5.8)(@swc/core@1.11.24)(@types/react@19.1.4)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3))
+        version: 3.0.1(@docusaurus/theme-classic@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@rspack/core@1.5.8)(@swc/core@1.11.24)(@types/react@19.1.4)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3))
       docusaurus-plugin-sass:
         specifier: ^0.2.2
-        version: 0.2.6(@docusaurus/core@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3))(@rspack/core@1.5.8)(sass@1.89.0)(webpack@5.99.9(@swc/core@1.11.24))
+        version: 0.2.6(@docusaurus/core@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3))(@rspack/core@1.5.8)(sass@1.89.0)(webpack@5.99.9(@swc/core@1.11.24))
       hast-util-is-element:
         specifier: 3.0.0
         version: 3.0.0
@@ -58,7 +58,7 @@ importers:
         version: 19.1.4(react@19.1.4)
       redocusaurus:
         specifier: 2.2.3
-        version: 2.2.3(@docusaurus/theme-common@3.9.2(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3))(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@docusaurus/utils@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(core-js@3.42.0)(mobx@6.13.7)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(styled-components@6.1.18(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(webpack@5.99.9(@swc/core@1.11.24))
+        version: 2.2.3(@docusaurus/theme-common@3.9.2(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3))(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@docusaurus/utils@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(core-js@3.42.0)(mobx@6.13.7)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(styled-components@6.1.18(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(webpack@5.99.9(@swc/core@1.11.24))
       rehype-katex:
         specifier: ^7.0.1
         version: 7.0.1
@@ -74,10 +74,10 @@ importers:
     devDependencies:
       '@docusaurus/module-type-aliases':
         specifier: ^3.9.2
-        version: 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+        version: 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       '@docusaurus/types':
         specifier: ^3.9.2
-        version: 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+        version: 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       '@types/node':
         specifier: ^22.15.19
         version: 22.15.19
@@ -85,8 +85,8 @@ importers:
         specifier: ^19.1.4
         version: 19.1.4
       docusaurus-plugin-llms:
-        specifier: ^0.1.4
-        version: 0.1.4(@docusaurus/core@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3))
+        specifier: ^0.4.0
+        version: 0.4.0(@docusaurus/core@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3))
       docusaurus-plugin-module-alias:
         specifier: ^0.0.2
         version: 0.0.2
@@ -743,8 +743,8 @@ packages:
     resolution: {integrity: sha512-909rVuj3phpjW6y0MCXAZ5iNeORePa6ldJvp2baWGcTjwqbBDDz6xoS5JHJ7lS88NlwLYj07ImL/8IUMtDZzTA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/runtime@7.27.1':
-    resolution: {integrity: sha512-1x3D2xEk2fRo3PAhwQwu5UubzgiVWSXTBfWpVd2Mx2AzRqJuDJCsgaDVZ7HB5iGzDW1Hl1sWN2mFyKjmR9uAog==}
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
     engines: {node: '>=6.9.0'}
 
   '@babel/template@7.27.2':
@@ -1431,42 +1431,36 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.1':
     resolution: {integrity: sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.1':
     resolution: {integrity: sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.1':
     resolution: {integrity: sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.1':
     resolution: {integrity: sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.1':
     resolution: {integrity: sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.1':
     resolution: {integrity: sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==}
@@ -1544,25 +1538,21 @@ packages:
     resolution: {integrity: sha512-UAWCsOnpkvy8eAVRo0uipbHXDhnoDq5zmqWTMhpga0/a3yzCp2e+fnjZb/qnFNYb5MeL0O1mwMOYgn1M3oHILQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rspack/binding-linux-arm64-musl@1.5.8':
     resolution: {integrity: sha512-GnSvGT4GjokPSD45cTtE+g7LgghuxSP1MRmvd+Vp/I8pnxTVSTsebRod4TAqyiv+l11nuS8yqNveK9qiOkBLWw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rspack/binding-linux-x64-gnu@1.5.8':
     resolution: {integrity: sha512-XLxh5n/pzUfxsugz/8rVBv+Tx2nqEM+9rharK69kfooDsQNKyz7PANllBQ/v4svJ+W0BRHnDL4qXSGdteZeEjA==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rspack/binding-linux-x64-musl@1.5.8':
     resolution: {integrity: sha512-gE0+MZmwF+01p9/svpEESkzkLpBkVUG2o03YMpwXYC/maeRRhWvF8BJ7R3i/Ls/jFGSE87dKX5NbRLVzqksq/w==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rspack/binding-wasm32-wasi@1.5.8':
     resolution: {integrity: sha512-cfg3niNHeJuxuml1Vy9VvaJrI/5TakzoaZvKX2g5S24wfzR50Eyy4JAsZ+L2voWQQp1yMJbmPYPmnTCTxdJQBQ==}
@@ -1732,28 +1722,24 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.11.24':
     resolution: {integrity: sha512-ypXLIdszRo0re7PNNaXN0+2lD454G8l9LPK/rbfRXnhLWDBPURxzKlLlU/YGd2zP98wPcVooMmegRSNOKfvErw==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.11.24':
     resolution: {integrity: sha512-IM7d+STVZD48zxcgo69L0yYptfhaaE9cMZ+9OoMxirNafhKKXwoZuufol1+alEFKc+Wbwp+aUPe/DeWC/Lh3dg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.11.24':
     resolution: {integrity: sha512-DZByJaMVzSfjQKKQn3cqSeqwy6lpMaQDQQ4HPlch9FWtDx/dLcpdIhxssqZXcR2rhaQVIaRQsCqwV6orSDGAGw==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.11.24':
     resolution: {integrity: sha512-Q64Ytn23y9aVDKN5iryFi8mRgyHw3/kyjTjT4qFCa8AEb5sGUuSj//AUZ6c0J7hQKMHlg9do5Etvoe61V98/JQ==}
@@ -1808,28 +1794,24 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/html-linux-arm64-musl@1.13.20':
     resolution: {integrity: sha512-HrqXdFuBeCe3nfSn4NSizPrtth4lsLJPF1LwwqYHgsE1bAuUkIOEgWmtcLlG1hZ7AhonLX+CIT0JNiSN0ALE7w==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@swc/html-linux-x64-gnu@1.13.20':
     resolution: {integrity: sha512-4F7MY4p7YQ/WjyPCwuAtWICyZSief1uoE6stMCIC4yVm5ybwbWKJqLPrd0lbC9W0jllk4TYHoUYI6WAc7jCJKA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/html-linux-x64-musl@1.13.20':
     resolution: {integrity: sha512-aL6BNlq2vIC2nS+Y0OEHZcOit9BFig0bzb78fSfK8eCz8+/ZIQujgLRxnKw2smAPtMBwS00mqaQPeRJt0J60bQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@swc/html-win32-arm64-msvc@1.13.20':
     resolution: {integrity: sha512-x2APd7wcxaer8cjKL6V9J+Y8dCUbxyrLC2GyB7xopL4TLfzqcY6V6jRWKB8eT41pF4ZqF3GqFv73jPZk1HNyOw==}
@@ -2843,8 +2825,8 @@ packages:
     peerDependencies:
       '@docusaurus/theme-classic': '>=3.0.0'
 
-  docusaurus-plugin-llms@0.1.4:
-    resolution: {integrity: sha512-51JukBpl4SNBtubyk1JU/YWGm/Ewithp3QkedXcj8bs/Dd81HcizpmVdyvV9zQ1T2/nEpbrg8g7oZ1OjHdlWPQ==}
+  docusaurus-plugin-llms@0.4.0:
+    resolution: {integrity: sha512-jYlj2HJ5+gu7oJZuJ83Hk8KlB65YlZZ/7UpHXiL7Qr+qpNBkVocmt2Molc6F3HNr5RqcfhWD/98CvgyNztg/ow==}
     engines: {node: '>=18.0'}
     peerDependencies:
       '@docusaurus/core': ^3.0.0
@@ -3799,28 +3781,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.1:
     resolution: {integrity: sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.1:
     resolution: {integrity: sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.1:
     resolution: {integrity: sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.1:
     resolution: {integrity: sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==}
@@ -6046,6 +6024,11 @@ packages:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
     engines: {node: '>= 6'}
 
+  yaml@2.8.4:
+    resolution: {integrity: sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
@@ -6918,7 +6901,7 @@ snapshots:
     dependencies:
       core-js-pure: 3.42.0
 
-  '@babel/runtime@7.27.1': {}
+  '@babel/runtime@7.29.2': {}
 
   '@babel/template@7.27.2':
     dependencies:
@@ -7255,7 +7238,7 @@ snapshots:
     transitivePeerDependencies:
       - '@algolia/client-search'
 
-  '@docusaurus/babel@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)':
+  '@docusaurus/babel@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)':
     dependencies:
       '@babel/core': 7.27.1
       '@babel/generator': 7.27.1
@@ -7264,11 +7247,11 @@ snapshots:
       '@babel/preset-env': 7.27.2(@babel/core@7.27.1)
       '@babel/preset-react': 7.27.1(@babel/core@7.27.1)
       '@babel/preset-typescript': 7.27.1(@babel/core@7.27.1)
-      '@babel/runtime': 7.27.1
+      '@babel/runtime': 7.29.2
       '@babel/runtime-corejs3': 7.27.1
       '@babel/traverse': 7.27.1
       '@docusaurus/logger': 3.9.2
-      '@docusaurus/utils': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/utils': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       babel-plugin-dynamic-import-node: 2.3.3
       fs-extra: 11.3.0
       tslib: 2.8.1
@@ -7282,14 +7265,14 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/bundler@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)':
+  '@docusaurus/bundler@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)':
     dependencies:
       '@babel/core': 7.27.1
-      '@docusaurus/babel': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/babel': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       '@docusaurus/cssnano-preset': 3.9.2
       '@docusaurus/logger': 3.9.2
-      '@docusaurus/types': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      '@docusaurus/utils': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/types': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/utils': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       babel-loader: 9.2.1(@babel/core@7.27.1)(webpack@5.99.9(@swc/core@1.11.24))
       clean-css: 5.3.3
       copy-webpack-plugin: 11.0.0(webpack@5.99.9(@swc/core@1.11.24))
@@ -7309,7 +7292,7 @@ snapshots:
       webpack: 5.99.9(@swc/core@1.11.24)
       webpackbar: 6.0.1(webpack@5.99.9(@swc/core@1.11.24))
     optionalDependencies:
-      '@docusaurus/faster': 3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))
+      '@docusaurus/faster': 3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))
     transitivePeerDependencies:
       - '@parcel/css'
       - '@rspack/core'
@@ -7326,15 +7309,15 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/core@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)':
+  '@docusaurus/core@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/babel': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      '@docusaurus/bundler': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      '@docusaurus/babel': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/bundler': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
       '@docusaurus/logger': 3.9.2
-      '@docusaurus/mdx-loader': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      '@docusaurus/utils': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      '@docusaurus/utils-common': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      '@docusaurus/utils-validation': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/mdx-loader': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/utils': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/utils-common': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/utils-validation': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       '@mdx-js/react': 3.1.0(@types/react@19.1.4)(react@19.1.4)
       boxen: 6.2.1
       chalk: 4.1.2
@@ -7398,9 +7381,9 @@ snapshots:
       postcss-sort-media-queries: 5.2.0(postcss@8.5.6)
       tslib: 2.8.1
 
-  '@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))':
+  '@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))':
     dependencies:
-      '@docusaurus/types': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/types': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       '@rspack/core': 1.5.8
       '@swc/core': 1.11.24
       '@swc/html': 1.13.20
@@ -7420,12 +7403,12 @@ snapshots:
       chalk: 4.1.2
       tslib: 2.8.1
 
-  '@docusaurus/mdx-loader@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)':
+  '@docusaurus/mdx-loader@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)':
     dependencies:
       '@docusaurus/logger': 3.9.2
-      '@docusaurus/utils': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      '@docusaurus/utils-validation': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      '@mdx-js/mdx': 3.1.0(acorn@8.14.1)
+      '@docusaurus/utils': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/utils-validation': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@mdx-js/mdx': 3.1.0(acorn@6.4.2)
       '@slorber/remark-comment': 1.0.0
       escape-html: 1.0.3
       estree-util-value-to-estree: 3.4.0
@@ -7456,9 +7439,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/module-type-aliases@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)':
+  '@docusaurus/module-type-aliases@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)':
     dependencies:
-      '@docusaurus/types': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/types': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       '@types/history': 4.7.11
       '@types/react': 19.1.4
       '@types/react-router-config': 5.0.11
@@ -7475,13 +7458,13 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/plugin-client-redirects@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)':
+  '@docusaurus/plugin-client-redirects@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
       '@docusaurus/logger': 3.9.2
-      '@docusaurus/utils': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      '@docusaurus/utils-common': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      '@docusaurus/utils-validation': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/utils': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/utils-common': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/utils-validation': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       eta: 2.2.0
       fs-extra: 11.3.0
       lodash: 4.17.21
@@ -7507,17 +7490,17 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-content-blog@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)':
+  '@docusaurus/plugin-content-blog@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
       '@docusaurus/logger': 3.9.2
-      '@docusaurus/mdx-loader': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      '@docusaurus/plugin-content-docs': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
-      '@docusaurus/theme-common': 3.9.2(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3))(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      '@docusaurus/types': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      '@docusaurus/utils': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      '@docusaurus/utils-common': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      '@docusaurus/utils-validation': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/mdx-loader': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/plugin-content-docs': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      '@docusaurus/theme-common': 3.9.2(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3))(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/types': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/utils': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/utils-common': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/utils-validation': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       cheerio: 1.0.0-rc.12
       feed: 4.2.2
       fs-extra: 11.3.0
@@ -7549,17 +7532,17 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)':
+  '@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
       '@docusaurus/logger': 3.9.2
-      '@docusaurus/mdx-loader': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      '@docusaurus/module-type-aliases': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      '@docusaurus/theme-common': 3.9.2(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3))(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      '@docusaurus/types': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      '@docusaurus/utils': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      '@docusaurus/utils-common': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      '@docusaurus/utils-validation': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/mdx-loader': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/module-type-aliases': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/theme-common': 3.9.2(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3))(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/types': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/utils': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/utils-common': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/utils-validation': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       '@types/react-router-config': 5.0.11
       combine-promises: 1.2.0
       fs-extra: 11.3.0
@@ -7590,13 +7573,13 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-content-pages@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)':
+  '@docusaurus/plugin-content-pages@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
-      '@docusaurus/mdx-loader': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      '@docusaurus/types': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      '@docusaurus/utils': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      '@docusaurus/utils-validation': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      '@docusaurus/mdx-loader': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/types': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/utils': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/utils-validation': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       fs-extra: 11.3.0
       react: 19.1.4
       react-dom: 19.1.4(react@19.1.4)
@@ -7621,12 +7604,12 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-css-cascade-layers@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)':
+  '@docusaurus/plugin-css-cascade-layers@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
-      '@docusaurus/types': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      '@docusaurus/utils': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      '@docusaurus/utils-validation': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      '@docusaurus/types': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/utils': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/utils-validation': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@docusaurus/faster'
@@ -7649,11 +7632,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-debug@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)':
+  '@docusaurus/plugin-debug@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
-      '@docusaurus/types': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      '@docusaurus/utils': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      '@docusaurus/types': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/utils': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       fs-extra: 11.3.0
       react: 19.1.4
       react-dom: 19.1.4(react@19.1.4)
@@ -7678,11 +7661,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-google-analytics@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)':
+  '@docusaurus/plugin-google-analytics@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
-      '@docusaurus/types': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      '@docusaurus/utils-validation': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      '@docusaurus/types': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/utils-validation': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       react: 19.1.4
       react-dom: 19.1.4(react@19.1.4)
       tslib: 2.8.1
@@ -7705,11 +7688,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-google-gtag@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)':
+  '@docusaurus/plugin-google-gtag@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
-      '@docusaurus/types': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      '@docusaurus/utils-validation': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      '@docusaurus/types': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/utils-validation': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       '@types/gtag.js': 0.0.12
       react: 19.1.4
       react-dom: 19.1.4(react@19.1.4)
@@ -7733,11 +7716,11 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-google-tag-manager@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)':
+  '@docusaurus/plugin-google-tag-manager@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
-      '@docusaurus/types': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      '@docusaurus/utils-validation': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      '@docusaurus/types': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/utils-validation': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       react: 19.1.4
       react-dom: 19.1.4(react@19.1.4)
       tslib: 2.8.1
@@ -7760,14 +7743,14 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-sitemap@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)':
+  '@docusaurus/plugin-sitemap@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
       '@docusaurus/logger': 3.9.2
-      '@docusaurus/types': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      '@docusaurus/utils': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      '@docusaurus/utils-common': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      '@docusaurus/utils-validation': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/types': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/utils': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/utils-common': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/utils-validation': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       fs-extra: 11.3.0
       react: 19.1.4
       react-dom: 19.1.4(react@19.1.4)
@@ -7792,12 +7775,12 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/plugin-svgr@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)':
+  '@docusaurus/plugin-svgr@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
-      '@docusaurus/types': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      '@docusaurus/utils': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      '@docusaurus/utils-validation': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      '@docusaurus/types': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/utils': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/utils-validation': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       '@svgr/core': 8.1.0(typescript@5.9.3)
       '@svgr/webpack': 8.1.0(typescript@5.9.3)
       react: 19.1.4
@@ -7823,23 +7806,23 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/preset-classic@3.9.2(@algolia/client-search@5.40.0)(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(@types/react@19.1.4)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(search-insights@2.17.3)(typescript@5.9.3)':
+  '@docusaurus/preset-classic@3.9.2(@algolia/client-search@5.40.0)(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(@types/react@19.1.4)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(search-insights@2.17.3)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
-      '@docusaurus/plugin-content-blog': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
-      '@docusaurus/plugin-content-docs': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
-      '@docusaurus/plugin-content-pages': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
-      '@docusaurus/plugin-css-cascade-layers': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
-      '@docusaurus/plugin-debug': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
-      '@docusaurus/plugin-google-analytics': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
-      '@docusaurus/plugin-google-gtag': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
-      '@docusaurus/plugin-google-tag-manager': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
-      '@docusaurus/plugin-sitemap': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
-      '@docusaurus/plugin-svgr': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
-      '@docusaurus/theme-classic': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@rspack/core@1.5.8)(@swc/core@1.11.24)(@types/react@19.1.4)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
-      '@docusaurus/theme-common': 3.9.2(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3))(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      '@docusaurus/theme-search-algolia': 3.9.2(@algolia/client-search@5.40.0)(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(@types/react@19.1.4)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(search-insights@2.17.3)(typescript@5.9.3)
-      '@docusaurus/types': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      '@docusaurus/plugin-content-blog': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      '@docusaurus/plugin-content-docs': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      '@docusaurus/plugin-content-pages': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      '@docusaurus/plugin-css-cascade-layers': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      '@docusaurus/plugin-debug': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      '@docusaurus/plugin-google-analytics': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      '@docusaurus/plugin-google-gtag': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      '@docusaurus/plugin-google-tag-manager': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      '@docusaurus/plugin-sitemap': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      '@docusaurus/plugin-svgr': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      '@docusaurus/theme-classic': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@rspack/core@1.5.8)(@swc/core@1.11.24)(@types/react@19.1.4)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      '@docusaurus/theme-common': 3.9.2(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3))(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/theme-search-algolia': 3.9.2(@algolia/client-search@5.40.0)(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(@types/react@19.1.4)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(search-insights@2.17.3)(typescript@5.9.3)
+      '@docusaurus/types': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       react: 19.1.4
       react-dom: 19.1.4(react@19.1.4)
     transitivePeerDependencies:
@@ -7879,21 +7862,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@docusaurus/theme-classic@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@rspack/core@1.5.8)(@swc/core@1.11.24)(@types/react@19.1.4)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)':
+  '@docusaurus/theme-classic@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@rspack/core@1.5.8)(@swc/core@1.11.24)(@types/react@19.1.4)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
       '@docusaurus/logger': 3.9.2
-      '@docusaurus/mdx-loader': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      '@docusaurus/module-type-aliases': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      '@docusaurus/plugin-content-blog': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
-      '@docusaurus/plugin-content-docs': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
-      '@docusaurus/plugin-content-pages': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
-      '@docusaurus/theme-common': 3.9.2(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3))(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/mdx-loader': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/module-type-aliases': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/plugin-content-blog': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      '@docusaurus/plugin-content-docs': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      '@docusaurus/plugin-content-pages': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      '@docusaurus/theme-common': 3.9.2(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3))(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       '@docusaurus/theme-translations': 3.9.2
-      '@docusaurus/types': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      '@docusaurus/utils': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      '@docusaurus/utils-common': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      '@docusaurus/utils-validation': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/types': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/utils': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/utils-common': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/utils-validation': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       '@mdx-js/react': 3.1.0(@types/react@19.1.4)(react@19.1.4)
       clsx: 2.1.1
       infima: 0.2.0-alpha.45
@@ -7927,13 +7910,13 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/theme-common@3.9.2(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3))(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)':
+  '@docusaurus/theme-common@3.9.2(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3))(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)':
     dependencies:
-      '@docusaurus/mdx-loader': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      '@docusaurus/module-type-aliases': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      '@docusaurus/plugin-content-docs': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
-      '@docusaurus/utils': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      '@docusaurus/utils-common': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/mdx-loader': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/module-type-aliases': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/plugin-content-docs': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      '@docusaurus/utils': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/utils-common': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       '@types/history': 4.7.11
       '@types/react': 19.1.4
       '@types/react-router-config': 5.0.11
@@ -7952,12 +7935,12 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/theme-live-codeblock@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)':
+  '@docusaurus/theme-live-codeblock@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)':
     dependencies:
-      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
-      '@docusaurus/theme-common': 3.9.2(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3))(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      '@docusaurus/theme-common': 3.9.2(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3))(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       '@docusaurus/theme-translations': 3.9.2
-      '@docusaurus/utils-validation': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/utils-validation': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       '@philpl/buble': 0.19.7
       clsx: 2.1.1
       fs-extra: 11.3.0
@@ -7985,16 +7968,16 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@docusaurus/theme-search-algolia@3.9.2(@algolia/client-search@5.40.0)(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(@types/react@19.1.4)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(search-insights@2.17.3)(typescript@5.9.3)':
+  '@docusaurus/theme-search-algolia@3.9.2(@algolia/client-search@5.40.0)(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(@types/react@19.1.4)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(search-insights@2.17.3)(typescript@5.9.3)':
     dependencies:
       '@docsearch/react': 4.2.0(@algolia/client-search@5.40.0)(@types/react@19.1.4)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(search-insights@2.17.3)
-      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
       '@docusaurus/logger': 3.9.2
-      '@docusaurus/plugin-content-docs': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
-      '@docusaurus/theme-common': 3.9.2(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3))(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/plugin-content-docs': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      '@docusaurus/theme-common': 3.9.2(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3))(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       '@docusaurus/theme-translations': 3.9.2
-      '@docusaurus/utils': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      '@docusaurus/utils-validation': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/utils': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/utils-validation': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       algoliasearch: 5.40.0
       algoliasearch-helper: 3.26.0(algoliasearch@5.40.0)
       clsx: 2.1.1
@@ -8034,9 +8017,9 @@ snapshots:
 
   '@docusaurus/tsconfig@3.9.2': {}
 
-  '@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)':
+  '@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)':
     dependencies:
-      '@mdx-js/mdx': 3.1.0(acorn@8.14.1)
+      '@mdx-js/mdx': 3.1.0(acorn@6.4.2)
       '@types/history': 4.7.11
       '@types/mdast': 4.0.4
       '@types/react': 19.1.4
@@ -8056,9 +8039,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils-common@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)':
+  '@docusaurus/utils-common@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)':
     dependencies:
-      '@docusaurus/types': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/types': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@swc/core'
@@ -8070,11 +8053,11 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils-validation@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)':
+  '@docusaurus/utils-validation@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)':
     dependencies:
       '@docusaurus/logger': 3.9.2
-      '@docusaurus/utils': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      '@docusaurus/utils-common': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/utils': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/utils-common': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       fs-extra: 11.3.0
       joi: 17.13.3
       js-yaml: 4.1.0
@@ -8090,11 +8073,11 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)':
+  '@docusaurus/utils@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)':
     dependencies:
       '@docusaurus/logger': 3.9.2
-      '@docusaurus/types': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      '@docusaurus/utils-common': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/types': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/utils-common': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       escape-string-regexp: 4.0.0
       execa: 5.1.1
       file-loader: 6.2.0(webpack@5.99.9(@swc/core@1.11.24))
@@ -8236,7 +8219,7 @@ snapshots:
 
   '@leichtgewicht/ip-codec@2.0.5': {}
 
-  '@mdx-js/mdx@3.1.0(acorn@8.14.1)':
+  '@mdx-js/mdx@3.1.0(acorn@6.4.2)':
     dependencies:
       '@types/estree': 1.0.7
       '@types/estree-jsx': 1.0.5
@@ -8250,7 +8233,7 @@ snapshots:
       hast-util-to-jsx-runtime: 2.3.6
       markdown-extensions: 2.0.0
       recma-build-jsx: 1.0.0
-      recma-jsx: 1.0.0(acorn@8.14.1)
+      recma-jsx: 1.0.0(acorn@6.4.2)
       recma-stringify: 1.0.0
       rehype-recma: 1.0.0
       remark-mdx: 3.1.0
@@ -8519,7 +8502,7 @@ snapshots:
 
   '@slorber/react-helmet-async@1.3.0(react-dom@19.1.4(react@19.1.4))(react@19.1.4)':
     dependencies:
-      '@babel/runtime': 7.27.1
+      '@babel/runtime': 7.29.2
       invariant: 2.2.4
       prop-types: 15.8.1
       react: 19.1.4
@@ -9787,25 +9770,26 @@ snapshots:
     dependencies:
       '@leichtgewicht/ip-codec': 2.0.5
 
-  docusaurus-plugin-image-zoom@3.0.1(@docusaurus/theme-classic@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@rspack/core@1.5.8)(@swc/core@1.11.24)(@types/react@19.1.4)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)):
+  docusaurus-plugin-image-zoom@3.0.1(@docusaurus/theme-classic@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@rspack/core@1.5.8)(@swc/core@1.11.24)(@types/react@19.1.4)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)):
     dependencies:
-      '@docusaurus/theme-classic': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@rspack/core@1.5.8)(@swc/core@1.11.24)(@types/react@19.1.4)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      '@docusaurus/theme-classic': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@rspack/core@1.5.8)(@swc/core@1.11.24)(@types/react@19.1.4)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
       medium-zoom: 1.1.0
       validate-peer-dependencies: 2.2.0
 
-  docusaurus-plugin-llms@0.1.4(@docusaurus/core@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)):
+  docusaurus-plugin-llms@0.4.0(@docusaurus/core@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)):
     dependencies:
-      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
       gray-matter: 4.0.3
       minimatch: 9.0.5
+      yaml: 2.8.4
 
   docusaurus-plugin-module-alias@0.0.2:
     dependencies:
       joi: 17.13.3
 
-  docusaurus-plugin-redoc@2.2.3(@docusaurus/utils@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(core-js@3.42.0)(mobx@6.13.7)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(styled-components@6.1.18(react-dom@19.1.4(react@19.1.4))(react@19.1.4)):
+  docusaurus-plugin-redoc@2.2.3(@docusaurus/utils@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(core-js@3.42.0)(mobx@6.13.7)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(styled-components@6.1.18(react-dom@19.1.4(react@19.1.4))(react@19.1.4)):
     dependencies:
-      '@docusaurus/utils': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/utils': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       '@redocly/openapi-core': 1.16.0
       redoc: 2.4.0(core-js@3.42.0)(mobx@6.13.7)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(styled-components@6.1.18(react-dom@19.1.4(react@19.1.4))(react@19.1.4))
     transitivePeerDependencies:
@@ -9818,9 +9802,9 @@ snapshots:
       - styled-components
       - supports-color
 
-  docusaurus-plugin-sass@0.2.6(@docusaurus/core@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3))(@rspack/core@1.5.8)(sass@1.89.0)(webpack@5.99.9(@swc/core@1.11.24)):
+  docusaurus-plugin-sass@0.2.6(@docusaurus/core@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3))(@rspack/core@1.5.8)(sass@1.89.0)(webpack@5.99.9(@swc/core@1.11.24)):
     dependencies:
-      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
+      '@docusaurus/core': 3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3)
       sass: 1.89.0
       sass-loader: 16.0.5(@rspack/core@1.5.8)(sass@1.89.0)(webpack@5.99.9(@swc/core@1.11.24))
     transitivePeerDependencies:
@@ -9829,9 +9813,9 @@ snapshots:
       - sass-embedded
       - webpack
 
-  docusaurus-theme-redoc@2.2.3(@docusaurus/theme-common@3.9.2(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3))(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(core-js@3.42.0)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(webpack@5.99.9(@swc/core@1.11.24)):
+  docusaurus-theme-redoc@2.2.3(@docusaurus/theme-common@3.9.2(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3))(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(core-js@3.42.0)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(webpack@5.99.9(@swc/core@1.11.24)):
     dependencies:
-      '@docusaurus/theme-common': 3.9.2(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3))(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/theme-common': 3.9.2(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3))(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
       '@redocly/openapi-core': 1.16.0
       clsx: 1.2.1
       lodash: 4.17.21
@@ -10464,7 +10448,7 @@ snapshots:
 
   history@4.10.1:
     dependencies:
-      '@babel/runtime': 7.27.1
+      '@babel/runtime': 7.29.2
       loose-envify: 1.4.0
       resolve-pathname: 3.0.0
       tiny-invariant: 1.3.3
@@ -11839,7 +11823,7 @@ snapshots:
 
   polished@4.3.1:
     dependencies:
-      '@babel/runtime': 7.27.1
+      '@babel/runtime': 7.29.2
 
   postcss-attribute-case-insensitive@7.0.1(postcss@8.5.6):
     dependencies:
@@ -12386,19 +12370,19 @@ snapshots:
 
   react-loadable-ssr-addon-v5-slorber@1.0.1(@docusaurus/react-loadable@6.0.0(react@19.1.4))(webpack@5.99.9(@swc/core@1.11.24)):
     dependencies:
-      '@babel/runtime': 7.27.1
+      '@babel/runtime': 7.29.2
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@19.1.4)'
       webpack: 5.99.9(@swc/core@1.11.24)
 
   react-router-config@5.1.1(react-router@5.3.4(react@19.1.4))(react@19.1.4):
     dependencies:
-      '@babel/runtime': 7.27.1
+      '@babel/runtime': 7.29.2
       react: 19.1.4
       react-router: 5.3.4(react@19.1.4)
 
   react-router-dom@5.3.4(react@19.1.4):
     dependencies:
-      '@babel/runtime': 7.27.1
+      '@babel/runtime': 7.29.2
       history: 4.10.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
@@ -12409,7 +12393,7 @@ snapshots:
 
   react-router@5.3.4(react@19.1.4):
     dependencies:
-      '@babel/runtime': 7.27.1
+      '@babel/runtime': 7.29.2
       history: 4.10.1
       hoist-non-react-statics: 3.3.2
       loose-envify: 1.4.0
@@ -12456,9 +12440,9 @@ snapshots:
       estree-util-build-jsx: 3.0.1
       vfile: 6.0.3
 
-  recma-jsx@1.0.0(acorn@8.14.1):
+  recma-jsx@1.0.0(acorn@6.4.2):
     dependencies:
-      acorn-jsx: 5.3.2(acorn@8.14.1)
+      acorn-jsx: 5.3.2(acorn@6.4.2)
       estree-util-to-js: 2.0.0
       recma-parse: 1.0.0
       recma-stringify: 1.0.0
@@ -12513,12 +12497,12 @@ snapshots:
       - react-native
       - supports-color
 
-  redocusaurus@2.2.3(@docusaurus/theme-common@3.9.2(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3))(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@docusaurus/utils@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(core-js@3.42.0)(mobx@6.13.7)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(styled-components@6.1.18(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(webpack@5.99.9(@swc/core@1.11.24)):
+  redocusaurus@2.2.3(@docusaurus/theme-common@3.9.2(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3))(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(@docusaurus/utils@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(core-js@3.42.0)(mobx@6.13.7)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(styled-components@6.1.18(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(webpack@5.99.9(@swc/core@1.11.24)):
     dependencies:
-      '@docusaurus/theme-common': 3.9.2(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3))(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      '@docusaurus/utils': 3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
-      docusaurus-plugin-redoc: 2.2.3(@docusaurus/utils@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(core-js@3.42.0)(mobx@6.13.7)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(styled-components@6.1.18(react-dom@19.1.4(react@19.1.4))(react@19.1.4))
-      docusaurus-theme-redoc: 2.2.3(@docusaurus/theme-common@3.9.2(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3))(@swc/core@1.11.24)(acorn@8.14.1)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(core-js@3.42.0)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(webpack@5.99.9(@swc/core@1.11.24))
+      '@docusaurus/theme-common': 3.9.2(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3))(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      '@docusaurus/utils': 3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)
+      docusaurus-plugin-redoc: 2.2.3(@docusaurus/utils@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(core-js@3.42.0)(mobx@6.13.7)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(styled-components@6.1.18(react-dom@19.1.4(react@19.1.4))(react@19.1.4))
+      docusaurus-theme-redoc: 2.2.3(@docusaurus/theme-common@3.9.2(@docusaurus/plugin-content-docs@3.9.2(@docusaurus/faster@3.9.2(@docusaurus/types@3.9.2(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)))(@mdx-js/react@3.1.0(@types/react@19.1.4)(react@19.1.4))(@rspack/core@1.5.8)(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(typescript@5.9.3))(@swc/core@1.11.24)(acorn@6.4.2)(react-dom@19.1.4(react@19.1.4))(react@19.1.4))(core-js@3.42.0)(react-dom@19.1.4(react@19.1.4))(react@19.1.4)(webpack@5.99.9(@swc/core@1.11.24))
     transitivePeerDependencies:
       - core-js
       - encoding
@@ -13602,6 +13586,8 @@ snapshots:
   yaml-ast-parser@0.0.43: {}
 
   yaml@1.10.2: {}
+
+  yaml@2.8.4: {}
 
   yargs-parser@21.1.1: {}
 

--- a/docs/src/theme/Admonition/Types.tsx
+++ b/docs/src/theme/Admonition/Types.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+// eslint-disable-next-line import/no-unresolved
+import DefaultAdmonitionTypes from "@theme-original/Admonition/Types";
+
+type AdmonitionProps = {
+  title?: string;
+  children?: React.ReactNode;
+};
+
+function extractText(node: React.ReactNode): string {
+  if (!node) return "";
+  if (typeof node === "string") return node;
+  if (typeof node === "number") return String(node);
+  if (React.isValidElement(node)) {
+    return extractText((node.props as { children?: React.ReactNode }).children);
+  }
+  if (Array.isArray(node)) {
+    return node.map(extractText).join("");
+  }
+  return "";
+}
+
+function ProFeatureAdmonition({ title, children }: AdmonitionProps) {
+  const description = extractText(children).trim() || undefined;
+  return (
+    <p className="commercial-feature commercial-feature--pro" role="note">
+      <span className="commercial-feature-badge commercial-feature-badge--pro">
+        Pro
+      </span>
+      <span className="commercial-feature-text">
+        <strong>{title}</strong> is available on Pro and Enterprise plans.
+        {description ? ` ${description}` : ""}
+      </span>
+    </p>
+  );
+}
+
+function EnterpriseFeatureAdmonition({ title, children }: AdmonitionProps) {
+  const description = extractText(children).trim() || undefined;
+  return (
+    <p
+      className="commercial-feature commercial-feature--enterprise"
+      role="note"
+    >
+      <span className="commercial-feature-badge commercial-feature-badge--enterprise">
+        Enterprise
+      </span>
+      <span className="commercial-feature-text">
+        <strong>{title}</strong> is available on Enterprise plans.
+        {description ? ` ${description}` : ""}
+      </span>
+    </p>
+  );
+}
+
+const AdmonitionTypes = {
+  ...DefaultAdmonitionTypes,
+  "pro-feature": ProFeatureAdmonition,
+  "enterprise-feature": EnterpriseFeatureAdmonition,
+};
+
+export default AdmonitionTypes;


### PR DESCRIPTION
Update docusaurus-plugin-llms to 0.4.0 and configure it to generate
per-page markdown files and a clean llms.txt index. Replace CommercialFeature
JSX components with custom :::pro-feature and :::enterprise-feature admonition
types so commercial feature notices continue to render correctly in the browser
while producing clean, JSX-free output in the generated LLM files.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

### Features and Changes

<!--
  Include a description of your changes.
  If there are any new tools, API's, etc. that devs can leverage, it may be helpful to include usage info.
-->

<!--
  Indicate which issue this will close, if applicable
  For multiple issues, add a new `- Closes` or `- Fixes` line
-->

- Closes **(add link to issue here)**

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

### Testing

<!--
  Please describe how to test these changes.
 -->

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
