### PR TITLE
Add input field to color picker

### DIFF
--- a/packages/front-end/components/Share/ShareModal.tsx
+++ b/packages/front-end/components/Share/ShareModal.tsx
@@ -18,7 +18,7 @@ import {
 import { GrDrag } from "react-icons/gr";
 import { FaCheck, FaRegTrashAlt } from "react-icons/fa";
 import { FiAlertTriangle } from "react-icons/fi";
-import { HexColorPicker } from "react-colorful";
+import { HexColorInput, HexColorPicker } from "react-colorful";
 import { getValidDate, ago, datetime, date } from "shared/dates";
 import { getLatestPhaseVariations } from "shared/experiments";
 import { PiArrowLeft, PiCaretRight, PiX } from "react-icons/pi";
@@ -1148,7 +1148,9 @@ const ShareModal = ({
                                 >
                                   Background color
                                 </label>
+
                                 <HexColorPicker
+                                  data-testid="background-color-picker"
                                   onChange={(c) => {
                                     form.setValue(
                                       "customTheme.backgroundColor",
@@ -1159,7 +1161,20 @@ const ShareModal = ({
                                   color={
                                     value.customTheme?.backgroundColor || ""
                                   }
+                                />
+
+                                <HexColorInput
+                                  className="form-control"
+                                  color={
+                                    value.customTheme?.backgroundColor || ""
+                                  }
                                   id="custombackground"
+                                  onChange={(c) => {
+                                    form.setValue(
+                                      "customTheme.backgroundColor",
+                                      c,
+                                    );
+                                  }}
                                 />
                               </Flex>
                               <Flex direction="column" align="center" gap="2">
@@ -1169,13 +1184,23 @@ const ShareModal = ({
                                 >
                                   Text color
                                 </label>
+
                                 <HexColorPicker
+                                  data-testid="text-color-picker"
                                   onChange={(c) => {
                                     form.setValue("customTheme.textColor", c);
                                   }}
                                   style={{ margin: "0 auto" }}
                                   color={value.customTheme?.textColor || ""}
+                                />
+
+                                <HexColorInput
+                                  className="form-control"
+                                  color={value.customTheme?.textColor || ""}
                                   id="customtextcolor"
+                                  onChange={(c) => {
+                                    form.setValue("customTheme.textColor", c);
+                                  }}
                                 />
                               </Flex>
                             </Grid>

--- a/packages/front-end/package.json
+++ b/packages/front-end/package.json
@@ -118,6 +118,7 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/crypto-js": "^4.2.2",
     "@types/diff": "^5.0.1",
     "@types/lodash": "^4.14.155",

--- a/packages/front-end/package.json
+++ b/packages/front-end/package.json
@@ -85,7 +85,7 @@
     "react-ace": "^10.1.0",
     "react-beautiful-dnd": "^13.1.0",
     "react-collapsible": "^2.10.0",
-    "react-colorful": "^5.3.0",
+    "react-colorful": "^5.7.0",
     "react-day-picker": "^9.3.1",
     "react-diff-viewer": "^3.1.1",
     "react-dom": "^18.2.0",

--- a/packages/front-end/test/components/Share/ShareModal/HexColorInput.test.tsx
+++ b/packages/front-end/test/components/Share/ShareModal/HexColorInput.test.tsx
@@ -1,0 +1,248 @@
+import { act, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { ExperimentInterface } from "shared/validators";
+import ShareModal from "@/components/Share/ShareModal";
+
+vi.mock("next/router", () => ({
+  useRouter: vi.fn(() => ({ query: { q: "" } })),
+}));
+
+vi.mock("@/services/UserContext", () => ({
+  useUser: vi.fn(() => ({
+    getOwnerDisplay: () => "Bar",
+    hasCommercialFeature: () => true,
+    settings: {},
+  })),
+}));
+
+vi.mock("@/hooks/useExperiments", () => ({
+  useExperiments: vi.fn(() => ({
+    experiments: [
+      {
+        id: "exp_171wm84x7movsgrzl",
+        uid: "81d028f007054667b7859168bcf4906c",
+        trackingKey: "TestExperiment",
+        organization: "org_171wm84x7movs5ul9",
+        project: "prj_2CaodVYaxSmGzXmNJgV98Y",
+        owner: "u_171wm84x7movs5ukh",
+        datasource: "",
+        userIdType: "anonymous",
+        exposureQueryId: "",
+        hashAttribute: "id",
+        fallbackAttribute: "",
+        hashVersion: 2,
+        disableStickyBucketing: false,
+        name: "TestExperiment",
+        dateCreated: new Date(),
+        dateUpdated: new Date(),
+        tags: [],
+        description: "",
+        hypothesis: "",
+        pastNotifications: [],
+        metricOverrides: [],
+        decisionFrameworkSettings: {
+          decisionFrameworkMetricOverrides: [],
+        },
+        goalMetrics: [],
+        secondaryMetrics: [],
+        guardrailMetrics: [],
+        activationMetric: "",
+        segment: "",
+        queryFilter: "",
+        skipPartialData: false,
+        attributionModel: "firstExposure",
+        archived: false,
+        status: "running",
+        analysis: "",
+        releasedVariationId: "",
+        excludeFromPayload: true,
+        autoAssign: false,
+        implementation: "code",
+        previewURL: "",
+        targetURLRegex: "",
+        variations: [
+          {
+            id: "var_movsgjxz",
+            name: "Control",
+            description: "",
+            key: "0",
+            screenshots: [],
+          },
+          {
+            id: "var_movsgjy0",
+            name: "Variation 1",
+            description: "",
+            key: "1",
+            screenshots: [],
+          },
+        ],
+        phases: [
+          {
+            dateStarted: new Date(),
+            name: "Main",
+            reason: "",
+            coverage: 1,
+            condition: "{}",
+            savedGroups: [],
+            prerequisites: [],
+            namespace: {
+              enabled: false,
+              name: "",
+              range: [0, 1],
+            },
+            seed: "77c889ff-9eaf-4b78-a11f-18d87593f771",
+            variationWeights: [0.5, 0.5],
+            variations: [
+              {
+                id: "var_movsgjxz",
+                status: "active",
+              },
+              {
+                id: "var_movsgjy0",
+                status: "active",
+              },
+            ],
+            banditEvents: [],
+          },
+        ],
+        lastSnapshotAttempt: new Date(),
+        nextSnapshotAttempt: new Date(),
+        autoSnapshots: true,
+        ideaSource: "",
+        regressionAdjustmentEnabled: false,
+        linkedFeatures: [],
+        sequentialTestingEnabled: false,
+        sequentialTestingTuningParameter: 5000,
+        type: "standard",
+        banditScheduleValue: 1,
+        banditScheduleUnit: "days",
+        banditBurnInValue: 1,
+        banditBurnInUnit: "days",
+        banditConversionWindowUnit: "hours",
+        shareLevel: "organization",
+        analysisSummary: {
+          resultsStatus: {
+            variations: [],
+            settings: {
+              sequentialTesting: true,
+            },
+          },
+          precomputedDimensions: [],
+          snapshotId: "",
+        },
+        dismissedWarnings: [],
+        customMetricSlices: [],
+        pendingFeatureDrafts: [],
+        manualLaunchChecklist: [],
+      },
+    ] satisfies ExperimentInterface[],
+  })),
+}));
+
+const getColorPickerValue = (pickerTestId: string) => {
+  const picker = screen.getByTestId(pickerTestId);
+
+  const satBrightSlider = within(picker).getByRole("slider", { name: "Color" });
+  const hueSlider = within(picker).getByRole("slider", { name: "Hue" });
+
+  const saturationBrightnessText =
+    satBrightSlider.getAttribute("aria-valuetext");
+
+  const match = saturationBrightnessText?.match(
+    /Saturation (\d+)%, Brightness (\d+)%/,
+  );
+
+  if (match) {
+    const saturation = Number(match[1]);
+    const brightness = Number(match[2]);
+
+    const hue = Number(hueSlider.getAttribute("aria-valuenow"));
+
+    return {
+      h: hue,
+      s: saturation,
+      b: brightness,
+    };
+  }
+
+  throw new Error(
+    `Unable to parse color of color picker with testid ${pickerTestId}.`,
+  );
+};
+
+describe("ShareModal", () => {
+  it("Color pickers should be synced with text inputs", async () => {
+    const Harness = () => {
+      const [modalIsOpen, setModalIsOpen] = useState(true);
+
+      return (
+        <ShareModal
+          title="New Presentation"
+          modalState={modalIsOpen}
+          setModalState={setModalIsOpen}
+          refreshList={vi.fn()}
+        />
+      );
+    };
+
+    render(<Harness />);
+
+    const user = userEvent.setup();
+
+    const result = await screen.findByRole("button", { name: /Next/ });
+
+    await user.click(result);
+
+    await user.click(screen.getByRole("combobox"));
+
+    await user.click(await screen.findByText("Custom"));
+
+    const backgroundColorInput = screen.getByLabelText("Background color");
+
+    expect(backgroundColorInput.getAttribute("value")).toBe("3400a3");
+
+    const textColorInput = screen.getByLabelText("Text color");
+
+    expect(textColorInput.getAttribute("value")).toBe("ffffff");
+
+    const backgroundColorPickerTestId = "background-color-picker";
+    const textColorPickerTestId = "text-color-picker";
+
+    expect(getColorPickerValue(backgroundColorPickerTestId)).toEqual({
+      h: 259,
+      s: 100,
+      b: 64,
+    });
+
+    expect(getColorPickerValue(textColorPickerTestId)).toEqual({
+      h: 0,
+      s: 0,
+      b: 100,
+    });
+
+    await act(async () => {
+      await user.clear(backgroundColorInput);
+
+      await user.type(backgroundColorInput, "dd169e");
+    });
+
+    expect(getColorPickerValue(backgroundColorPickerTestId)).toEqual({
+      h: 319,
+      s: 90,
+      b: 87,
+    });
+
+    await act(async () => {
+      await user.clear(textColorInput);
+
+      await user.type(textColorInput, "8ee4dc");
+    });
+
+    expect(getColorPickerValue(textColorPickerTestId)).toEqual({
+      h: 174,
+      s: 38,
+      b: 89,
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -922,6 +922,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.0
         version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.0.6)(@types/react@18.0.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/crypto-js':
         specifier: ^4.2.2
         version: 4.2.2
@@ -5962,6 +5965,12 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
 
   '@tootallnate/once@1.1.2':
     resolution: {integrity: sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==}
@@ -19974,6 +19983,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.0.15
       '@types/react-dom': 18.0.6
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
 
   '@tootallnate/once@1.1.2': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -829,8 +829,8 @@ importers:
         specifier: ^2.10.0
         version: 2.10.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react-colorful:
-        specifier: ^5.3.0
-        version: 5.5.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: ^5.7.0
+        version: 5.7.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react-day-picker:
         specifier: ^9.3.1
         version: 9.3.1(react@18.2.0)
@@ -11541,8 +11541,8 @@ packages:
       react: ~15 || ~16 || ~17 || ~18
       react-dom: ~15 || ~16 || ~17 || ~18
 
-  react-colorful@5.5.1:
-    resolution: {integrity: sha512-M1TJH2X3RXEt12sWkpa6hLc/bbYS0H6F4rIqjQZ+RxNBstpY67d9TrFXtqdZwhpmBXcCwEi7stKqFue3ZRkiOg==}
+  react-colorful@5.7.0:
+    resolution: {integrity: sha512-fuesYIemttah97XmsIHmz4OORDHiSFzyc9HMAIrCHJou2jaRQmL8cFJ76K4zQhhj8jzwOBlOi4BaGTjjOZCfTg==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
@@ -26859,7 +26859,7 @@ snapshots:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  react-colorful@5.5.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  react-colorful@5.7.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)


### PR DESCRIPTION
### Features and Changes

Hey there,

I added synced text inputs underneath the color pickers in the share modal for presentations. In order to do this, I bumped the `react-colorful` dependency to latest as it has a built-in text input made just for this purpose. Additionally, I brought in `@testing-library/user-event` which describes itself as follows:

> [user-event](https://github.com/testing-library/user-event) is a companion library for Testing Library that simulates user interactions by dispatching the events that would happen if the interaction took place in a browser.

<!--
  Indicate which issue this will close, if applicable
  For multiple issues, add a new `- Closes` or `- Fixes` line
-->

- Closes #5685 

### Testing

- Added a test to verify changes to the new inputs sync to the color pickers.
- Manually tested the change.

### Screenshots

https://github.com/user-attachments/assets/470860b0-6d3a-49a8-b11f-7ea93b43b24c