### PR TITLE
fix(incremental-refresh): warn when exploratory analysis skips unmaterialized metrics

### DIFF
--- a/packages/back-end/src/models/ExperimentSnapshotModel.ts
+++ b/packages/back-end/src/models/ExperimentSnapshotModel.ts
@@ -77,6 +77,7 @@ const experimentSnapshotSchema = new mongoose.Schema({
   query: String,
   queryLanguage: String,
   error: String,
+  warnings: [String],
   queries: queriesSchema,
   dimension: String,
   unknownVariations: [String],

--- a/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshExploratoryQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshExploratoryQueryRunner.ts
@@ -61,7 +61,7 @@ export const startExperimentIncrementalRefreshExploratoryQueries = async (
   startQuery: (
     params: StartQueryParams<RowsType, ProcessedRowsType>,
   ) => Promise<QueryPointer>,
-): Promise<Queries> => {
+): Promise<{ queries: Queries; skippedMetricIds: string[] }> => {
   const snapshotSettings = params.snapshotSettings;
   const experimentId = params.experimentId;
   const metricMap = params.metricMap;
@@ -129,12 +129,19 @@ export const startExperimentIncrementalRefreshExploratoryQueries = async (
     snapshotSettings,
   });
 
+  // Metrics whose source tables have not yet been materialized by the standard
+  // (non-exploratory) runner. We still skip them so the rest of the dimension
+  // breakdown succeeds, but we surface a warning on the snapshot so users know
+  // why these metrics are missing instead of seeing them silently disappear.
+  const skippedMetricIds: string[] = [];
+
   for (const group of metricSourceGroups) {
     const existingSource = existingSources?.find(
       (s) => s.groupId === group.groupId,
     );
     if (!existingSource) {
       // skip in case the group just has new metrics
+      skippedMetricIds.push(...group.metrics.map((m) => m.id));
       continue;
     }
 
@@ -196,7 +203,7 @@ export const startExperimentIncrementalRefreshExploratoryQueries = async (
     });
     queries.push(statisticsQuery);
   }
-  return queries;
+  return { queries, skippedMetricIds };
 };
 
 export class ExperimentIncrementalRefreshExploratoryQueryRunner extends QueryRunner<
@@ -206,6 +213,7 @@ export class ExperimentIncrementalRefreshExploratoryQueryRunner extends QueryRun
 > {
   private variationNames: string[] = [];
   private metricMap: Map<string, ExperimentMetricInterface> = new Map();
+  private skippedMetricIds: string[] = [];
 
   checkPermissions(): boolean {
     return this.context.permissions.canRunExperimentQueries(
@@ -248,12 +256,15 @@ export class ExperimentIncrementalRefreshExploratoryQueryRunner extends QueryRun
       analysisType: "exploratory",
     });
 
-    return startExperimentIncrementalRefreshExploratoryQueries(
-      this.context,
-      params,
-      this.integration,
-      this.startQuery.bind(this),
-    );
+    const { queries, skippedMetricIds } =
+      await startExperimentIncrementalRefreshExploratoryQueries(
+        this.context,
+        params,
+        this.integration,
+        this.startQuery.bind(this),
+      );
+    this.skippedMetricIds = skippedMetricIds;
+    return queries;
   }
 
   // largely copied from ExperimentResultsQueryRunner
@@ -286,6 +297,20 @@ export class ExperimentIncrementalRefreshExploratoryQueryRunner extends QueryRun
       result.unknownVariations = results.unknownVariations || [];
       result.multipleExposures = results.multipleExposures ?? 0;
     });
+
+    if (this.skippedMetricIds.length) {
+      const names = this.skippedMetricIds.map(
+        (id) => this.metricMap.get(id)?.name ?? id,
+      );
+      result.warnings = [
+        ...(result.warnings ?? []),
+        `${names.length} metric${
+          names.length === 1 ? " has" : "s have"
+        } not been materialized for dimension breakdown yet. ` +
+          `Run "Update" on the main Results tab first, then re-run this analysis. ` +
+          `Skipped: ${names.join(", ")}.`,
+      ];
+    }
     return result;
   }
 

--- a/packages/back-end/src/queryRunners/ExperimentResultsQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentResultsQueryRunner.ts
@@ -68,6 +68,7 @@ export type SnapshotResult = {
   analyses: ExperimentSnapshotAnalysis[];
   banditResult?: BanditResult;
   health?: ExperimentSnapshotHealth;
+  warnings?: string[];
 };
 
 export type ExperimentResultsQueryParams = {

--- a/packages/shared/types/experiment-snapshot.d.ts
+++ b/packages/shared/types/experiment-snapshot.d.ts
@@ -226,6 +226,9 @@ export interface ExperimentSnapshotInterface {
 
   // Status and meta info about the snapshot run
   error?: string;
+  // Non-fatal warnings surfaced to the user (e.g., metrics skipped during an
+  // exploratory analysis because their sources have not been materialized yet).
+  warnings?: string[];
   dateCreated: Date;
   runStarted: Date | null;
   status: "running" | "success" | "error";


### PR DESCRIPTION
When an exploratory (dimension) analysis runs against the incremental-refresh pipeline, metric groups whose source tables haven't yet been materialized by the standard runner are silently skipped (`ExperimentIncrementalRefreshExploratoryQueryRunner.ts` `if (!existingSource) continue`). The user just sees those metrics missing from the dimension breakdown with no explanation.

This keeps the skip so the rest of the breakdown still succeeds, but collects the skipped metric ids and surfaces a non-fatal warning on the snapshot pointing the user to run **Update** on the main Results tab first.

Adds an optional `warnings: string[]` to `ExperimentSnapshotInterface` / mongoose schema / `SnapshotResult` to carry this (and future) non-fatal messages. Front-end rendering of `snapshot.warnings` can land separately; this PR is the back-end half.