### PR TITLE
fix(incremental-refresh): force standard runner on full refresh even with dimension selected

### DIFF
--- a/packages/back-end/src/services/experiments.ts
+++ b/packages/back-end/src/services/experiments.ts
@@ -1697,13 +1697,20 @@ function getSnapshotType({
   experiment,
   dimension,
   phaseIndex,
+  useCache,
 }: {
   experiment: ExperimentInterface;
   dimension: string | undefined;
   phaseIndex: number;
+  useCache: boolean;
 }): SnapshotType {
   // dimension analyses are ad-hoc
-  if (dimension) {
+  // Exception: a forced full refresh (useCache === false) must always run the
+  // standard runner so the incremental-refresh source tables are actually
+  // rebuilt. If we routed to "exploratory" here, the exploratory runner would
+  // read from existing materialized sources and never rebuild them, so the
+  // user's "Full Refresh" click would silently be a no-op for the pipeline.
+  if (dimension && useCache) {
     return "exploratory";
   }
 
@@ -1823,6 +1830,7 @@ export async function planExperimentSnapshot({
       experiment,
       dimension,
       phaseIndex: phase,
+      useCache,
     });
 
   let project = null;


### PR DESCRIPTION
If the user clicks **Full Refresh** while a dimension is selected, `postSnapshot` sends `?force=true` (→ `useCache=false`) **and** `dimension` in the body. `getSnapshotType` sees the dimension and returns `"exploratory"`, which routes to the exploratory runner — that runner only *reads* existing materialized sources and never rebuilds them, so the force flag is silently discarded and the pipeline isn't actually refreshed.

Gate the `dimension → exploratory` branch on `useCache`. A forced full refresh now always hits the standard runner that rebuilds the incremental source tables.