### PR TITLE
fix(pipeline): drop prior-generation metric-source tables on full refresh

### DIFF
--- a/packages/back-end/src/integrations/GoogleAnalytics.ts
+++ b/packages/back-end/src/integrations/GoogleAnalytics.ts
@@ -34,6 +34,7 @@ import {
   ExperimentFactMetricsQueryResponse,
   UserExperimentExposuresQueryResponse,
   DropMetricSourceCovariateTableQueryParams,
+  DropMetricSourceTableQueryParams,
   InsertMetricSourceCovariateDataQueryParams,
   CreateMetricSourceCovariateTableQueryParams,
 } from "shared/types/integrations";
@@ -228,6 +229,11 @@ export default class GoogleAnalytics implements SourceIntegrationInterface {
     _setExternalId: ExternalIdCallback,
     _queryMetadata?: QueryMetadata,
   ): Promise<IncrementalWithNoOutputQueryResponse> {
+    throw new Error("Method not implemented.");
+  }
+  getDropMetricSourceTableQuery(
+    _params: DropMetricSourceTableQueryParams,
+  ): string {
     throw new Error("Method not implemented.");
   }
   getDropMetricSourceCovariateTableQuery(

--- a/packages/back-end/src/integrations/Mixpanel.ts
+++ b/packages/back-end/src/integrations/Mixpanel.ts
@@ -34,6 +34,7 @@ import {
   ExperimentFactMetricsQueryResponse,
   UserExperimentExposuresQueryResponse,
   DropMetricSourceCovariateTableQueryParams,
+  DropMetricSourceTableQueryParams,
   CreateMetricSourceCovariateTableQueryParams,
   InsertMetricSourceCovariateDataQueryParams,
 } from "shared/types/integrations";
@@ -181,6 +182,11 @@ export default class Mixpanel implements SourceIntegrationInterface {
   }
   getInsertMetricSourceDataQuery(
     _params: InsertMetricSourceDataQueryParams,
+  ): string {
+    throw new Error("Method not implemented.");
+  }
+  getDropMetricSourceTableQuery(
+    _params: DropMetricSourceTableQueryParams,
   ): string {
     throw new Error("Method not implemented.");
   }

--- a/packages/back-end/src/integrations/SqlIntegration.ts
+++ b/packages/back-end/src/integrations/SqlIntegration.ts
@@ -77,6 +77,7 @@ import {
   InsertMetricSourceDataQueryParams,
   DimensionColumnData,
   DropMetricSourceCovariateTableQueryParams,
+  DropMetricSourceTableQueryParams,
   MaxTimestampQueryResponse,
   ExperimentFactMetricsQueryResponseRows,
   IncrementalRefreshStatisticsQueryParams,
@@ -133,6 +134,7 @@ import { getDimensionInStatement } from "back-end/src/integrations/sql/fact-metr
 import { getDimensionSlicesQuery as getDimensionSlicesQueryFromSql } from "back-end/src/integrations/sql/queries/dimension-slices-query";
 import { getDimensionValuePerUnit } from "back-end/src/integrations/sql/fact-metrics/dimension-value-per-unit";
 import { getDropMetricSourceCovariateTableQuery } from "back-end/src/integrations/sql/queries/drop-metric-source-covariate-table-query";
+import { getDropMetricSourceTableQuery } from "back-end/src/integrations/sql/queries/drop-metric-source-table-query";
 import { getDropOldIncrementalUnitsQuery } from "back-end/src/integrations/sql/queries/drop-old-incremental-units-query";
 import { getDropUnitsTableQuery } from "back-end/src/integrations/sql/queries/drop-units-table-query";
 import { encodeMetricIdForColumnName } from "back-end/src/integrations/sql/fact-metrics/encode-metric-id-for-column-name";
@@ -1823,6 +1825,12 @@ export default abstract class SqlIntegration
       `,
       this.getSqlDialect().formatDialect,
     );
+  }
+
+  getDropMetricSourceTableQuery(
+    params: DropMetricSourceTableQueryParams,
+  ): string {
+    return getDropMetricSourceTableQuery(this.getSqlDialect(), params);
   }
 
   getDropMetricSourceCovariateTableQuery(

--- a/packages/back-end/src/integrations/sql/queries/drop-metric-source-table-query.ts
+++ b/packages/back-end/src/integrations/sql/queries/drop-metric-source-table-query.ts
@@ -1,0 +1,23 @@
+import { format } from "shared/sql";
+import { DropMetricSourceTableQueryParams } from "shared/types/integrations";
+import { SqlDialect } from "shared/types/sql";
+import { INCREMENTAL_METRICS_TABLE_PREFIX } from "back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner";
+
+export function getDropMetricSourceTableQuery(
+  dialect: SqlDialect,
+  params: DropMetricSourceTableQueryParams,
+): string {
+  if (
+    !params.metricSourceTableFullName.includes(INCREMENTAL_METRICS_TABLE_PREFIX)
+  ) {
+    throw new Error(
+      "Unable to drop table that is not an incremental refresh metric source table.",
+    );
+  }
+  return format(
+    `
+      DROP TABLE IF EXISTS ${params.metricSourceTableFullName}
+      `,
+    dialect.formatDialect,
+  );
+}

--- a/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner.ts
+++ b/packages/back-end/src/queryRunners/ExperimentIncrementalRefreshQueryRunner.ts
@@ -262,9 +262,25 @@ const startExperimentIncrementalRefreshQueries = async (
     );
   }
 
+  // Always load prior state so a full refresh can clean up the previous
+  // generation of metric source / covariate tables instead of orphaning them.
+  const priorIncrementalRefreshModel =
+    await context.models.incrementalRefresh.getByExperimentId(experimentId);
+
   const incrementalRefreshModel = params.fullRefresh
     ? null
-    : await context.models.incrementalRefresh.getByExperimentId(experimentId);
+    : priorIncrementalRefreshModel;
+
+  const priorMetricSourceTables = params.fullRefresh
+    ? (priorIncrementalRefreshModel?.metricSources ?? []).map(
+        (s) => s.tableFullName,
+      )
+    : [];
+  const priorMetricCovariateSourceTables = params.fullRefresh
+    ? (priorIncrementalRefreshModel?.metricCovariateSources ?? []).map(
+        (s) => s.tableFullName,
+      )
+    : [];
 
   const executionId = params.queryParentId;
 
@@ -514,6 +530,10 @@ const startExperimentIncrementalRefreshQueries = async (
   let runningSourceData = existingSources ?? [];
   let runningCovariateSourceData = existingCovariateSources ?? [];
 
+  // Track when each new metric source has been created and persisted so we
+  // only drop prior-generation tables after the replacements exist.
+  const newMetricSourceReadyDependencies: string[] = [];
+
   for (const group of metricSourceGroups) {
     const existingSource = existingSources?.find(
       (s) => s.groupId === group.groupId,
@@ -725,6 +745,9 @@ const startExperimentIncrementalRefreshQueries = async (
         queryType: "experimentIncrementalRefreshInsertMetricsCovariateData",
       });
       queries.push(insertMetricCovariateDataQuery);
+      newMetricSourceReadyDependencies.push(
+        insertMetricCovariateDataQuery.query,
+      );
     }
 
     const maxTimestampMetricsSourceQuery = await startQuery({
@@ -805,6 +828,7 @@ const startExperimentIncrementalRefreshQueries = async (
       queryType: "experimentIncrementalRefreshMaxTimestampMetricsSource",
     });
     queries.push(maxTimestampMetricsSourceQuery);
+    newMetricSourceReadyDependencies.push(maxTimestampMetricsSourceQuery.query);
 
     // Match standard query runner behavior: quantiles only run overall stats
     // (no pre-computed dimensions), regardless of requested dimensions.
@@ -839,6 +863,40 @@ const startExperimentIncrementalRefreshQueries = async (
     });
     queries.push(statisticsQuery);
   }
+
+  // Drop the prior generation of metric source / covariate tables now that the
+  // new sources have been created and persisted. Runs only on full refresh and
+  // only after every new source's max-timestamp query succeeds, so a failed
+  // refresh leaves the previous tables in place.
+  for (const [i, tableFullName] of priorMetricSourceTables.entries()) {
+    const dropPriorMetricsSourceQuery = await startQuery({
+      name: `drop_prior_metrics_source_${queryParentId}_${i}`,
+      displayTitle: "Drop Prior Metrics Source",
+      query: integration.getDropMetricSourceTableQuery({
+        metricSourceTableFullName: tableFullName,
+      }),
+      dependencies: newMetricSourceReadyDependencies,
+      run: (query, setExternalId, queryMetadata) =>
+        integration.runDropTableQuery(query, setExternalId, queryMetadata),
+      queryType: "experimentIncrementalRefreshDropMetricsSourceTable",
+    });
+    queries.push(dropPriorMetricsSourceQuery);
+  }
+  for (const [i, tableFullName] of priorMetricCovariateSourceTables.entries()) {
+    const dropPriorMetricsCovariateQuery = await startQuery({
+      name: `drop_prior_metrics_covariate_${queryParentId}_${i}`,
+      displayTitle: "Drop Prior Metric Covariate Table",
+      query: integration.getDropMetricSourceCovariateTableQuery({
+        metricSourceCovariateTableFullName: tableFullName,
+      }),
+      dependencies: newMetricSourceReadyDependencies,
+      run: (query, setExternalId, queryMetadata) =>
+        integration.runDropTableQuery(query, setExternalId, queryMetadata),
+      queryType: "experimentIncrementalRefreshDropMetricsCovariateTable",
+    });
+    queries.push(dropPriorMetricsCovariateQuery);
+  }
+
   const runTrafficQuery = shouldRunHealthTrafficQuery({
     snapshotType: params.snapshotType,
     snapshotDimensions: snapshotSettings.dimensions,

--- a/packages/back-end/src/types/Integration.ts
+++ b/packages/back-end/src/types/Integration.ts
@@ -11,6 +11,7 @@ import {
   DimensionSlicesQueryParams,
   DimensionSlicesQueryResponse,
   DropMetricSourceCovariateTableQueryParams,
+  DropMetricSourceTableQueryParams,
   DropOldIncrementalUnitsQueryParams,
   DropTableQueryParams,
   DropTableQueryResponse,
@@ -166,6 +167,9 @@ export interface SourceIntegrationInterface {
   ): string;
   getInsertMetricSourceDataQuery(
     params: InsertMetricSourceDataQueryParams,
+  ): string;
+  getDropMetricSourceTableQuery(
+    params: DropMetricSourceTableQueryParams,
   ): string;
   getDropMetricSourceCovariateTableQuery(
     params: DropMetricSourceCovariateTableQueryParams,

--- a/packages/shared/types/integrations.d.ts
+++ b/packages/shared/types/integrations.d.ts
@@ -360,6 +360,10 @@ export interface InsertMetricSourceDataQueryParams {
   lastMaxTimestamp: Date | null;
 }
 
+export interface DropMetricSourceTableQueryParams {
+  metricSourceTableFullName: string;
+}
+
 export interface DropMetricSourceCovariateTableQueryParams {
   metricSourceCovariateTableFullName: string;
 }

--- a/packages/shared/types/query.d.ts
+++ b/packages/shared/types/query.d.ts
@@ -65,6 +65,7 @@ export type QueryType =
   | "experimentIncrementalRefreshAlterUnitsTable"
   | "experimentIncrementalRefreshMaxTimestampUnitsTable"
   | "experimentIncrementalRefreshCreateMetricsSourceTable"
+  | "experimentIncrementalRefreshDropMetricsSourceTable"
   | "experimentIncrementalRefreshInsertMetricsSourceData"
   | "experimentIncrementalRefreshMaxTimestampMetricsSource"
   | "experimentIncrementalRefreshDropMetricsCovariateTable"


### PR DESCRIPTION
## Problem

In incremental pipeline mode, every Full Refresh creates new metric-source
(and CUPED covariate) tables with freshly randomized group-id suffixes and
persists them to `incrementalRefreshModel.metricSources` /
`metricCovariateSources`. The previous generation's tables are never dropped,
so each Full Refresh orphans the prior `gb_metrics_*` tables in the
configured destination schema. Over time this accumulates storage with no
way to reclaim it from within GrowthBook.

## Fix

`ExperimentIncrementalRefreshQueryRunner` now always loads the prior
incremental-refresh model at the start of a run. When `fullRefresh` is true
it captures the prior `metricSources[].tableFullName` and
`metricCovariateSources[].tableFullName` lists, then after the per-group
loop enqueues a `DROP TABLE IF EXISTS` for each one.

The drops are gated on every new source's max-timestamp query (the step
whose `onSuccess` persists the replacement source to the model), so a
failed refresh leaves the previous tables in place — we only clean up once
the new generation is fully created and recorded.

Adds `getDropMetricSourceTableQuery` to `SourceIntegrationInterface`
(mirroring the existing `getDropMetricSourceCovariateTableQuery`) and wires
it through `SqlIntegration` plus the GA/Mixpanel stubs. Prior covariate
tables reuse the existing covariate drop helper.

## Testing

`tsgo --noEmit` and `eslint` clean. There is no existing test harness for
`startExperimentIncrementalRefreshQueries` (it is fully mocked in
`snapshot-lifecycle.test.ts`) and the sibling drop-query helpers are also
untested, so no new test is included — happy to add one if there's a
preferred fixture pattern for this runner.


## Known limitation

This only drops tables that were recorded in `incrementalRefreshModel.metricSources` / `metricCovariateSources`. Tables created by a run that failed before its `onSuccess` persisted them (or the generation-before-last when a full refresh partially succeeded) remain orphaned. This PR strictly narrows the orphan window — from "every full refresh" to "only partially-failed full refreshes" — but does not eliminate it. A complete fix would require either persisting the table name at create-time rather than at max-timestamp time, or a schema-level sweep of `gb_metrics_<experimentId>_*` tables not referenced by the current model — both larger changes left for follow-up.
